### PR TITLE
Ensure build resource paths for embedded resources always reflect their contents

### DIFF
--- a/editor/src/clj/editor/build_target.clj
+++ b/editor/src/clj/editor/build_target.clj
@@ -52,15 +52,10 @@
   ([build-target]
    (with-content-hash build-target nil))
   ([build-target opts]
-   (assoc build-target :content-hash (content-hash build-target opts))))
-
-(defn make-content-hash-build-resource [memory-resource-build-target]
-  (let [build-resource (:resource memory-resource-build-target)
-        source-resource (:resource build-resource)
-        content-hash (:content-hash memory-resource-build-target)]
-    (assert (resource/memory-resource? source-resource))
-    (assert (string? content-hash))
-    (workspace/make-build-resource (assoc source-resource :data content-hash))))
+   (let [content-hash (content-hash build-target opts)]
+     (cond-> (assoc build-target :content-hash content-hash)
+             (resource/memory-resource? (:resource (:resource build-target)))
+             (assoc-in [:resource :resource :data] content-hash)))))
 
 (defn make-proj-path->build-target [build-targets]
   ;; Create a map that can be used to locate the build target that was produced

--- a/editor/src/clj/editor/code/shader.clj
+++ b/editor/src/clj/editor/code/shader.clj
@@ -154,15 +154,13 @@
          (integer? max-page-count)]}
   (let [shader-resource (:resource shader-source-info)
         workspace (resource/workspace shader-resource)
-        shader-resource-type (resource/resource-type shader-resource)
         user-data {:compile-spirv compile-spirv
                    :shader-source (:shader-source shader-source-info)
                    :max-page-count max-page-count
-                   :resource-ext (resource/type-ext shader-resource)}
-        memory-resource (resource/make-memory-resource workspace shader-resource-type user-data)]
+                   :resource-ext (resource/type-ext shader-resource)}]
     (bt/with-content-hash
       {:node-id (:node-id shader-source-info)
-       :resource (workspace/make-build-resource memory-resource)
+       :resource (workspace/make-placeholder-build-resource workspace (resource/type-ext shader-resource))
        :build-fn build-shader
        :user-data user-data})))
 

--- a/editor/src/clj/editor/collection.clj
+++ b/editor/src/clj/editor/collection.clj
@@ -177,25 +177,48 @@
    :icon ""
    :label ""})
 
-(g/defnk produce-go-build-targets [_node-id build-error build-resource ddf-message resource-property-build-targets source-build-targets pose]
-  ;; Create a build-target for the referenced or embedded game object. Also tag
-  ;; on :game-object-instance-data with the overrides for this instance. This
-  ;; will later be extracted and compiled into the Collection - the overrides do
-  ;; not end up in the resulting game object binary.
+(defn- path-error [node-id resource]
+  (or (validation/prop-error :fatal node-id :path validation/prop-nil? resource "Path")
+      (validation/prop-error :fatal node-id :path validation/prop-resource-not-exists? resource "Path")))
+
+(defn- component-property-error [node-id ddf-message]
+  (when-some [errors (not-empty (sequence (comp (mapcat :properties) ; Extract GameObject$PropertyDescs from GameObject$ComponentPropertyDescs.
+                                                (keep :error))
+                                          (:component-properties ddf-message)))]
+    (g/error-aggregate errors :_node-id node-id :_label :build-targets)))
+
+(g/defnk produce-referenced-go-build-targets [_node-id ddf-message resource-property-build-targets source-build-targets pose source-resource]
+  ;; Create a build-target for the referenced game object. Also tag on
+  ;; :game-object-instance-data with the overrides for this instance. This will
+  ;; later be extracted and compiled into the Collection - the overrides do not
+  ;; end up in the resulting game object binary.
   ;; Please refer to `/engine/gameobject/proto/gameobject/gameobject_ddf.proto`
   ;; when reading this. It describes how the ddf-message map is structured.
   ;; You might also want to familiarize yourself with how this process works in
   ;; `game_object.clj`, since it is similar but less complicated there.
-  (if-some [errors
-            (not-empty
-              (sequence (comp (mapcat :properties) ; Extract GameObject$PropertyDescs from GameObject$ComponentPropertyDescs.
-                              (keep :error))
-                        (:component-properties ddf-message)))]
-    (g/error-aggregate errors :_node-id _node-id :_label :build-targets)
-    (let [game-object-build-target (first source-build-targets)
-          proj-path->resource-property-build-target (bt/make-proj-path->build-target resource-property-build-targets)
-          instance-desc-with-go-props (dissoc ddf-message :data)] ; GameObject$InstanceDesc or GameObject$EmbeddedInstanceDesc in map format. We don't need the :data from GameObject$EmbeddedInstanceDesc.
-      [(collection-common/game-object-instance-build-target build-resource instance-desc-with-go-props pose game-object-build-target proj-path->resource-property-build-target)])))
+  (or (path-error _node-id source-resource)
+      (component-property-error _node-id ddf-message)
+      (let [game-object-build-target (first source-build-targets)
+            build-resource (:resource game-object-build-target)
+            proj-path->resource-property-build-target (bt/make-proj-path->build-target resource-property-build-targets)]
+        [(collection-common/game-object-instance-build-target build-resource ddf-message pose game-object-build-target proj-path->resource-property-build-target)])))
+
+(g/defnk produce-embedded-go-build-targets [_node-id ddf-message resource-property-build-targets source-build-targets pose]
+  ;; Create a build-target for the embedded game object. Also tag on
+  ;; :game-object-instance-data with the overrides for this instance. This will
+  ;; later be extracted and compiled into the Collection - the overrides do not
+  ;; end up in the resulting game object binary.
+  ;; Please refer to `/engine/gameobject/proto/gameobject/gameobject_ddf.proto`
+  ;; when reading this. It describes how the ddf-message map is structured.
+  ;; You might also want to familiarize yourself with how this process works in
+  ;; `game_object.clj`, since it is similar but less complicated there.
+  (or (component-property-error _node-id ddf-message)
+      (let [game-object-build-target (first source-build-targets)
+            build-resource (bt/make-content-hash-build-resource game-object-build-target)
+            build-target (assoc game-object-build-target :resource build-resource)
+            proj-path->resource-property-build-target (bt/make-proj-path->build-target resource-property-build-targets)
+            instance-desc-with-go-props (dissoc ddf-message :data)] ; GameObject$EmbeddedInstanceDesc in map format. We don't need the :data field.
+        [(collection-common/game-object-instance-build-target build-resource instance-desc-with-go-props pose build-target proj-path->resource-property-build-target)])))
 
 (g/defnode GameObjectInstanceNode
   (inherits scene/SceneNode)
@@ -216,9 +239,7 @@
   (output node-outline outline/OutlineData :cached produce-go-outline)
   (output ddf-message g/Any :abstract)
   (output node-outline-extras g/Any (g/constantly {}))
-  (output build-resource resource/Resource :abstract)
-  (output build-targets g/Any produce-go-build-targets)
-  (output build-error g/Err (g/constantly nil))
+  (output build-targets g/Any :abstract)
 
   (output scene g/Any :cached (g/fnk [_node-id id transform scene child-scenes]
                                 (-> (collection-common/any-instance-scene _node-id id transform scene)
@@ -234,8 +255,7 @@
   (input proto-msg g/Any)
   (output node-outline-extras g/Any (g/fnk [source-outline]
                                            {:alt-outline source-outline}))
-  (output build-resource resource/Resource (g/fnk [source-build-targets]
-                                             (some-> source-build-targets first bt/make-content-hash-build-resource)))
+  (output build-targets g/Any produce-embedded-go-build-targets)
   (output ddf-message g/Any (g/fnk [id child-ids position rotation scale proto-msg]
                               (gen-embed-ddf id child-ids position rotation scale proto-msg))))
 
@@ -286,15 +306,6 @@
 
             script/ScriptPropertyNode
             true))))))
-
-(defn- path-error [node-id resource]
-  (or (validation/prop-error :fatal node-id :path validation/prop-nil? resource "Path")
-      (validation/prop-error :fatal node-id :path validation/prop-resource-not-exists? resource "Path")))
-
-(defn- substitute-error [val-or-error substitute]
-  (if-not (g/error? val-or-error)
-    val-or-error
-    substitute))
 
 (g/defnode ReferencedGOInstanceNode
   (inherits GameObjectInstanceNode)
@@ -367,10 +378,7 @@
 
   (output ddf-message g/Any (g/fnk [id child-ids source-resource position rotation scale ddf-component-properties]
                                    (gen-ref-ddf id child-ids position rotation scale source-resource ddf-component-properties)))
-  (output build-error g/Err (g/fnk [_node-id source-resource]
-                                   (path-error _node-id source-resource)))
-  (output build-resource resource/Resource (g/fnk [source-build-targets]
-                                             (:resource (first source-build-targets)))))
+  (output build-targets g/Any produce-referenced-go-build-targets))
 
 (g/defnk produce-proto-msg [name scale-along-z ref-inst-ddf embed-inst-ddf ref-coll-ddf]
   (protobuf/make-map-without-defaults GameObject$CollectionDesc

--- a/editor/src/clj/editor/collection.clj
+++ b/editor/src/clj/editor/collection.clj
@@ -199,9 +199,8 @@
   (or (path-error _node-id source-resource)
       (component-property-error _node-id ddf-message)
       (let [game-object-build-target (first source-build-targets)
-            build-resource (:resource game-object-build-target)
             proj-path->resource-property-build-target (bt/make-proj-path->build-target resource-property-build-targets)]
-        [(collection-common/game-object-instance-build-target build-resource ddf-message pose game-object-build-target proj-path->resource-property-build-target)])))
+        [(collection-common/game-object-instance-build-target game-object-build-target ddf-message pose proj-path->resource-property-build-target)])))
 
 (g/defnk produce-embedded-go-build-targets [_node-id ddf-message resource-property-build-targets source-build-targets pose]
   ;; Create a build-target for the embedded game object. Also tag on
@@ -214,11 +213,9 @@
   ;; `game_object.clj`, since it is similar but less complicated there.
   (or (component-property-error _node-id ddf-message)
       (let [game-object-build-target (first source-build-targets)
-            build-resource (bt/make-content-hash-build-resource game-object-build-target)
-            build-target (assoc game-object-build-target :resource build-resource)
             proj-path->resource-property-build-target (bt/make-proj-path->build-target resource-property-build-targets)
             instance-desc-with-go-props (dissoc ddf-message :data)] ; GameObject$EmbeddedInstanceDesc in map format. We don't need the :data field.
-        [(collection-common/game-object-instance-build-target build-resource instance-desc-with-go-props pose build-target proj-path->resource-property-build-target)])))
+        [(collection-common/game-object-instance-build-target game-object-build-target instance-desc-with-go-props pose proj-path->resource-property-build-target)])))
 
 (g/defnode GameObjectInstanceNode
   (inherits scene/SceneNode)

--- a/editor/src/clj/editor/defold_project.clj
+++ b/editor/src/clj/editor/defold_project.clj
@@ -540,7 +540,7 @@
 
 (defn make-embedded-resource [project editability ext data]
   (let [workspace (g/node-value project :workspace)]
-    (workspace/make-embedded-resource workspace editability ext data)))
+    (workspace/make-memory-resource workspace editability ext data)))
 
 (defn all-save-data
   ([project]

--- a/editor/src/clj/editor/font.clj
+++ b/editor/src/clj/editor/font.clj
@@ -553,10 +553,10 @@
         {:resource resource
          :content (protobuf/map->bytes Font$GlyphBank compressed-font-map)}))))
 
-(defn- make-glyph-bank-build-target [node-id glyph-bank-build-resource user-data]
+(defn- make-glyph-bank-build-target [workspace node-id user-data]
   (bt/with-content-hash
     {:node-id node-id
-     :resource glyph-bank-build-resource
+     :resource (workspace/make-placeholder-build-resource workspace "glyph_bank")
      :build-fn build-glyph-bank
      :user-data user-data}))
 
@@ -569,14 +569,11 @@
       (let [workspace (resource/workspace resource)
             glyph-bank-pb-fields (protobuf/field-key-set Font$GlyphBank)
             glyph-bank-user-data {:font-map (select-keys font-map glyph-bank-pb-fields)}
-            glyph-bank-resource-type (workspace/get-resource-type workspace "glyph_bank")
-            glyph-bank-resource (resource/make-memory-resource workspace glyph-bank-resource-type glyph-bank-user-data)
-            glyph-bank-build-resource (workspace/make-build-resource glyph-bank-resource)
-            glyph-bank-build-target (make-glyph-bank-build-target _node-id glyph-bank-build-resource glyph-bank-user-data)
+            glyph-bank-build-target (make-glyph-bank-build-target workspace _node-id glyph-bank-user-data)
             dep-build-targets+glyph-bank (conj dep-build-targets glyph-bank-build-target)
             pb-map (protobuf/make-map-without-defaults Font$FontMap
                      :material material
-                     :glyph-bank glyph-bank-resource
+                     :glyph-bank (:resource glyph-bank-build-target)
                      :shadow-x (:shadow-x font-map)
                      :shadow-y (:shadow-y font-map)
                      :alpha (:alpha font-map)

--- a/editor/src/clj/editor/game_object_common.clj
+++ b/editor/src/clj/editor/game_object_common.clj
@@ -224,8 +224,8 @@
     {:resource build-resource
      :content (protobuf/map->bytes GameObject$PrototypeDesc prototype-desc)}))
 
-(defn game-object-build-target [build-resource host-resource-node-id component-instance-datas component-build-targets]
-  {:pre [(or (nil? build-resource) (workspace/build-resource? build-resource))
+(defn game-object-build-target [source-resource host-resource-node-id component-instance-datas component-build-targets]
+  {:pre [(workspace/source-resource? source-resource)
          (g/node-id? host-resource-node-id)
          (vector? component-instance-datas)
          (vector? component-build-targets)]}
@@ -235,7 +235,7 @@
   ;; script property overrides.
   (bt/with-content-hash
     {:node-id host-resource-node-id
-     :resource build-resource
+     :resource (workspace/make-build-resource source-resource)
      :build-fn build-game-object
      :user-data {:component-instance-datas (mapv #(dissoc % :property-deps)
                                                  component-instance-datas)}

--- a/editor/src/clj/editor/game_object_non_editable.clj
+++ b/editor/src/clj/editor/game_object_non_editable.clj
@@ -54,12 +54,6 @@
       (project/load-embedded-resource-node project embedded-resource-node-id embedded-resource embedded-resource-pb-map)
       (gu/connect-existing-outputs embedded-resource-node-type embedded-resource-node-id host-node-id embedded-component-connections))))
 
-(g/defnk produce-embedded-component-build-targets [embedded-component-build-targets]
-  (into []
-        (map (comp #(assoc % :resource (bt/make-content-hash-build-resource %))
-                   util/only-or-throw))
-        embedded-component-build-targets))
-
 (g/defnk produce-embedded-component-resource-data->scene-index [embedded-component-resource-data->index resource]
   (let [workspace (resource/workspace resource)
         ext->resource-type (workspace/get-resource-type-map workspace :non-editable)]
@@ -143,7 +137,7 @@
   (input own-resource-property-build-targets g/Any :array)
   (input other-resource-property-build-targets g/Any :array)
 
-  (output embedded-component-build-targets g/Any :cached produce-embedded-component-build-targets)
+  (output embedded-component-build-targets g/Any :cached (g/fnk [embedded-component-build-targets] (mapv util/only-or-throw embedded-component-build-targets)))
   (output embedded-component-resource-data->scene-index g/Any :cached produce-embedded-component-resource-data->scene-index)
   (output embedded-component-scenes g/Any :cached (gu/passthrough embedded-component-scenes))
   (output referenced-component-build-targets g/Any :cached (g/fnk [referenced-component-build-targets] (mapv util/only-or-throw referenced-component-build-targets)))
@@ -315,10 +309,9 @@
 
             component-build-targets
             (into referenced-component-build-targets
-                  embedded-component-build-targets)
+                  embedded-component-build-targets)]
 
-            build-resource (workspace/make-build-resource resource)]
-        [(game-object-common/game-object-build-target build-resource _node-id component-instance-datas component-build-targets)])))
+        [(game-object-common/game-object-build-target resource _node-id component-instance-datas component-build-targets)])))
 
 (g/defnk produce-ddf-component-properties [prototype-desc]
   (prototype-desc->component-property-descs prototype-desc))

--- a/editor/src/clj/editor/image.clj
+++ b/editor/src/clj/editor/image.clj
@@ -44,19 +44,13 @@
 (defn make-texture-build-target
   [workspace node-id image-generator texture-profile compress?]
   (assert (contains? image-generator :sha1))
-  (let [texture-type (workspace/get-resource-type workspace "texture")
-        texture-hash (digestable/sha1-hash
-                       {:compress? compress?
-                        :image-sha1 (:sha1 image-generator)
-                        :texture-profile texture-profile})
-        texture-resource (resource/make-memory-resource workspace texture-type texture-hash)]
-    (bt/with-content-hash
-      {:node-id node-id
-       :resource (workspace/make-build-resource texture-resource)
-       :build-fn build-texture
-       :user-data {:content-generator image-generator
-                   :compress? compress?
-                   :texture-profile texture-profile}})))
+  (bt/with-content-hash
+    {:node-id node-id
+     :resource (workspace/make-placeholder-build-resource workspace "texture")
+     :build-fn build-texture
+     :user-data {:content-generator image-generator
+                 :compress? compress?
+                 :texture-profile texture-profile}}))
 
 (defn- build-array-texture [resource _dep-resources user-data]
   (let [{:keys [content-generator texture-profile texture-page-count compress?]} user-data
@@ -71,21 +65,14 @@
 (defn make-array-texture-build-target
   [workspace node-id array-images-generator texture-profile texture-page-count compress?]
   (assert (contains? array-images-generator :sha1))
-  (let [texture-type (workspace/get-resource-type workspace "texture")
-        texture-hash (digestable/sha1-hash
-                       {:compress? compress?
-                        :image-sha1 (:sha1 array-images-generator)
-                        :texture-page-count texture-page-count
-                        :texture-profile texture-profile})
-        texture-resource (resource/make-memory-resource workspace texture-type texture-hash)]
-    (bt/with-content-hash
-      {:node-id node-id
-       :resource (workspace/make-build-resource texture-resource)
-       :build-fn build-array-texture
-       :user-data {:content-generator array-images-generator
-                   :compress? compress?
-                   :texture-page-count texture-page-count
-                   :texture-profile texture-profile}})))
+  (bt/with-content-hash
+    {:node-id node-id
+     :resource (workspace/make-placeholder-build-resource workspace "texture")
+     :build-fn build-array-texture
+     :user-data {:content-generator array-images-generator
+                 :compress? compress?
+                 :texture-page-count texture-page-count
+                 :texture-profile texture-profile}}))
 
 (g/defnk produce-build-targets [_node-id resource content-generator texture-profile build-settings]
   [(bt/with-content-hash

--- a/editor/src/clj/editor/model.clj
+++ b/editor/src/clj/editor/model.clj
@@ -130,19 +130,16 @@
                g/error-aggregate)
       (let [workspace (resource/workspace resource)
             animation-set-build-target (if (nil? animation-set-build-target-single) animation-set-build-target animation-set-build-target-single)
-            rig-scene-type (workspace/get-resource-type workspace "rigscene")
-            rig-scene-pseudo-data (digest/string->sha1-hex (str/join (map #(-> % :resource :resource :data) [animation-set-build-target mesh-set-build-target skeleton-build-target])))
-            rig-scene-resource (resource/make-memory-resource workspace rig-scene-type rig-scene-pseudo-data)
             rig-scene-dep-build-targets {:animation-set animation-set-build-target
                                          :mesh-set mesh-set-build-target
                                          :skeleton skeleton-build-target}
             rig-scene-pb-msg {}
-            rig-scene-build-targets (rig/make-rig-scene-build-targets _node-id rig-scene-resource rig-scene-pb-msg dep-build-targets rig-scene-dep-build-targets)
-            rt-pb-msg (-> {:rig-scene rig-scene-resource
+            rig-scene-build-target (rig/make-rig-scene-build-target workspace _node-id rig-scene-pb-msg dep-build-targets rig-scene-dep-build-targets)
+            rt-pb-msg (-> {:rig-scene (:resource rig-scene-build-target)
                            :default-animation (:default-animation pb-msg)
                            :materials (:materials pb-msg)}
                           (update-build-target-vertex-attributes material-binding-infos))
-            dep-build-targets (into rig-scene-build-targets (flatten dep-build-targets))]
+            dep-build-targets (into [rig-scene-build-target] (flatten dep-build-targets))]
         [(pipeline/make-protobuf-build-target _node-id resource ModelProto$Model rt-pb-msg dep-build-targets)])))
 
 (g/defnk produce-gpu-textures [_node-id samplers texture-binding-infos :as m]

--- a/editor/src/clj/editor/sound.clj
+++ b/editor/src/clj/editor/sound.clj
@@ -149,16 +149,6 @@
   {:pre [(map? sound-desc)]} ; Sound$SoundDesc in map format.
   (pipeline/make-protobuf-build-target owner-resource-node-id sound-desc-resource Sound$SoundDesc sound-desc dep-build-targets))
 
-(defn make-sound-desc-memory-resource [workspace sound-desc dep-build-targets]
-  ;; We need the content-hash from the resulting build-target for the data
-  ;; field when constructing our MemoryResource. We can safely supply a dummy
-  ;; MemoryResource as the source-resource for the throwaway build-target since
-  ;; it will not affect the content-hash.
-  (let [dummy-memory-resource (workspace/make-embedded-resource workspace :editable "sound" nil)
-        build-target (make-sound-desc-build-target workspace dummy-memory-resource sound-desc dep-build-targets)
-        content-hash (:content-hash build-target)]
-    (workspace/make-embedded-resource workspace :editable "sound" content-hash)))
-
 (g/defnk produce-build-targets
   [_node-id resource sound dep-build-targets save-value]
   (or (validation/prop-error :fatal _node-id :sound validation/prop-nil? sound "Sound")

--- a/editor/src/clj/editor/sound.clj
+++ b/editor/src/clj/editor/sound.clj
@@ -149,6 +149,16 @@
   {:pre [(map? sound-desc)]} ; Sound$SoundDesc in map format.
   (pipeline/make-protobuf-build-target owner-resource-node-id sound-desc-resource Sound$SoundDesc sound-desc dep-build-targets))
 
+(defn make-sound-desc-memory-resource [workspace sound-desc dep-build-targets]
+  ;; We need the content-hash from the resulting build-target for the data
+  ;; field when constructing our MemoryResource. We can safely supply a dummy
+  ;; MemoryResource as the source-resource for the throwaway build-target since
+  ;; it will not affect the content-hash.
+  (let [dummy-memory-resource (workspace/make-embedded-resource workspace :editable "sound" nil)
+        build-target (make-sound-desc-build-target workspace dummy-memory-resource sound-desc dep-build-targets)
+        content-hash (:content-hash build-target)]
+    (workspace/make-embedded-resource workspace :editable "sound" content-hash)))
+
 (g/defnk produce-build-targets
   [_node-id resource sound dep-build-targets save-value]
   (or (validation/prop-error :fatal _node-id :sound validation/prop-nil? sound "Sound")

--- a/editor/src/clj/editor/workspace.clj
+++ b/editor/src/clj/editor/workspace.clj
@@ -160,8 +160,7 @@ ordinary paths."
   ([source-resource]
    (make-build-resource source-resource nil))
   ([source-resource prefix]
-   {:pre [(resource/resource? source-resource)
-          (not (build-resource? source-resource))]}
+   {:pre [(source-resource? source-resource)]}
    (BuildResource. source-resource prefix)))
 
 (defn counterpart-build-resource
@@ -377,7 +376,7 @@ ordinary paths."
   ([workspace editability ext]
    (get (get-resource-type-map workspace editability) ext)))
 
-(defn make-embedded-resource [workspace editability ext data]
+(defn make-memory-resource [workspace editability ext data]
   (let [resource-type-map (get-resource-type-map workspace editability)]
     (if-some [resource-type (resource-type-map ext)]
       (resource/make-memory-resource workspace resource-type data)
@@ -386,6 +385,18 @@ ordinary paths."
                       {:type ext
                        :registered-types (into (sorted-set)
                                                (keys resource-type-map))})))))
+
+(defn make-placeholder-resource
+  ([workspace ext]
+   (make-memory-resource workspace :editable ext nil))
+  ([workspace editability ext]
+   (make-memory-resource workspace editability ext nil)))
+
+(defn make-placeholder-build-resource
+  ([workspace ext]
+   (make-build-resource (make-placeholder-resource workspace :editable ext)))
+  ([workspace editability ext]
+   (make-build-resource (make-placeholder-resource workspace editability ext))))
 
 (defn resource-icon [resource]
   (when resource

--- a/editor/test/editor/build_target_test.clj
+++ b/editor/test/editor/build_target_test.clj
@@ -42,11 +42,6 @@
      (.flush writer)
      (.toString writer))))
 
-(defn- make-lua-memory-resource [workspace source]
-  (assert (string? source))
-  (let [resource-type (workspace/get-resource-type workspace "lua")]
-    (resource/make-memory-resource workspace resource-type source)))
-
 (defn- make-fake-file-resource [workspace path text]
   (let [root-dir (workspace/project-path workspace)]
     (test-util/make-fake-file-resource workspace
@@ -67,7 +62,7 @@
           file-resource-node (project/get-resource-node project file-resource)
           zip-resource (workspace/find-resource workspace  "/builtins/graphics/particle_blob.png")
           zip-resource-node (project/get-resource-node project zip-resource)
-          memory-resource (make-lua-memory-resource workspace "return {key = 123}")
+          memory-resource (workspace/make-memory-resource workspace :editable "lua" "return {key = 123}")
           build-resource (workspace/make-build-resource memory-resource)
           fake-file-resource (make-fake-file-resource workspace "docs/readme.txt" "Defold")
           custom-resource (game-project/->CustomResource fake-file-resource)]


### PR DESCRIPTION
Referencing a `.wav` or `.ogg` file directly as a component from a game object embedded in a collection no longer throws an exception when building the project.

### Technical changes
* We now have separate production functions to produce the build targets from referenced and embedded components. Some common outputs that did not make sense for both cases have been removed.
* It is no longer the responsibility of the consumer of an embedded resource build target to make sure its `:resource` field reflects its contents. Instead, `bt/with-content-hash` will now update the `:data` field of source `MemoryResources` with the calculated `content-hash`.
* All code paths that previously calculated a `:data` prior to producing the `build-target` have been updated to instead use the `:resource` of the resulting `build-target` to reference the resulting binary.
