### PR TITLE
Fix missing animation preview overlay in atlas views

### DIFF
--- a/editor/src/clj/editor/texture_set.clj
+++ b/editor/src/clj/editor/texture_set.clj
@@ -265,9 +265,9 @@
 
 (defn- animation-frame->vertex-pos-uv
   [animation-frame world-transform]
-  (let [^double width (:width animation-frame)
-        ^double height (:height animation-frame)
-        frame-vertex-data (frame-vertex-data animation-frame width height)
+  (let [size [(:width animation-frame)
+              (:height animation-frame)]
+        frame-vertex-data (frame-vertex-data animation-frame size :pivot-center)
         page-index (:page-index animation-frame 0)]
     (mapv (fn [positions uvs]
             (let [x (get positions 0)


### PR DESCRIPTION
The animation preview overlay is now visible again in atlas views.

Fixes #9304.
