### PR TITLE
Added fix for asynchronous raycast messages

### DIFF
--- a/engine/dlib/src/dlib/message.cpp
+++ b/engine/dlib/src/dlib/message.cpp
@@ -360,6 +360,21 @@ namespace dmMessage
         }
     }
 
+    dmhash_t GetSocketNameHash(HSocket socket)
+    {
+        DM_SPINLOCK_SCOPED_LOCK(g_MessageSpinlock);
+
+        MessageSocket* message_socket = g_MessageContext->m_Sockets.Get(socket);
+        if (message_socket != 0x0)
+        {
+            return message_socket->m_NameHash;
+        }
+        else
+        {
+            return 0x0;
+        }
+    }
+
     bool IsSocketValid(HSocket socket)
     {
         if (socket != 0)

--- a/engine/dlib/src/dmsdk/dlib/message.h
+++ b/engine/dlib/src/dmsdk/dlib/message.h
@@ -151,6 +151,14 @@ namespace dmMessage
     const char* GetSocketName(HSocket socket);
 
     /*#
+     * Get socket name hash
+     * @name GetSocketNameHash
+     * @param socket [type: dmMessage::HSocket] Socket
+     * @return name_hash [type: dmhash_t] socket name hash. 0 if it was not found
+     */
+    dmhash_t GetSocketNameHash(HSocket socket);
+
+    /*#
      * Get the message path
      * @name GetPath
      * @param url [type: dmMessage::URL] url

--- a/engine/dlib/src/test/test_httpclient.cpp
+++ b/engine/dlib/src/test/test_httpclient.cpp
@@ -951,13 +951,19 @@ TEST_P(dmHttpClientTestExternal, PostExternal)
     m_Content = "";
     m_StatusCode = -1;
 
-    r = dmHttpClient::Post(m_Client, m_URI.m_Path);
     printf("POST'ing to %s://%s%s\n", m_URI.m_Scheme, m_URI.m_Location, m_URI.m_Path);
+    r = dmHttpClient::Post(m_Client, m_URI.m_Path);
+
+    printf("STATUS: %d\n", m_StatusCode);
+    if (503 == m_StatusCode)
+    {
+        // It's an external page, which may be down from time to time
+        return;
+    }
 
     ASSERT_EQ(dmHttpClient::RESULT_OK, r);
     ASSERT_EQ(200, m_StatusCode);
 
-    printf("STATUS: %d\n", m_StatusCode);
     printf("CONTENT:\n%s\n", m_Content.c_str());
 }
 

--- a/engine/engine/loop.sh
+++ b/engine/engine/loop.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+COUNT=$1
+shift
+ARGS=$*
+
+function usage {
+    echo "USAGE: iterate.sh <count> <cmd> [<args>]"
+    exit 1
+}
+
+if [ "" == "${COUNT}" ]; then
+    usage
+fi
+
+if [ "" == "${ARGS}" ]; then
+    usage
+fi
+
+set -e
+
+for (( i=0 ; i < ${COUNT} ; i++ )) ; do
+    echo "**************************************************************************************************************"
+    echo "Loop: ${i}: ${ARGS} "
+    ${ARGS}
+done

--- a/engine/engine/src/test/main.script
+++ b/engine/engine/src/test/main.script
@@ -59,7 +59,8 @@ local function deactivate_proxy(self, index)
     msg.post(proxy, "unload")
 end
 
-function on_message(self, message_id, message)
+ --TODO: Rearrange this mess: Make sure each state is only started after the previous is unloaded!
+function on_message(self, message_id, message, sender)
     if message_id == hash("proxy_loaded") then
         msg.post(self.loading_proxy, "init")
         msg.post(self.loading_proxy, "enable")

--- a/engine/gameobject/src/gameobject/gameobject.cpp
+++ b/engine/gameobject/src/gameobject/gameobject.cpp
@@ -328,6 +328,18 @@ namespace dmGameObject
         regist->m_Collections.SetSize(0);
     }
 
+    HCollection GetCollectionByHash(HRegister regist, dmhash_t socket_name)
+    {
+        uint32_t collection_count = regist->m_Collections.Size();
+        for (uint32_t i = 0; i < collection_count; ++i)
+        {
+            Collection* collection = regist->m_Collections[i];
+            if (collection->m_NameHash == socket_name)
+                return collection->m_HCollection;
+        }
+        return 0;
+    }
+
     void DeleteRegister(HRegister regist)
     {
         DeleteCollections(regist);
@@ -491,7 +503,7 @@ namespace dmGameObject
             return 0;
         }
 
-        collection->m_NameHash = dmHashString64(name);
+        collection->m_NameHash = dmHashString64(name); // Same as the socket name
 
         HCollection hcollection = (HCollection)new CollectionHandle;
         Result result = AttachCollection(collection, name, factory, regist, hcollection);

--- a/engine/gameobject/src/gameobject/gameobject.cpp
+++ b/engine/gameobject/src/gameobject/gameobject.cpp
@@ -2235,23 +2235,7 @@ namespace dmGameObject
         DispatchMessagesContext* context = (DispatchMessagesContext*) user_ptr;
         Collection* collection = context->m_Collection;
 
-        Instance* instance = 0x0;
-        // Start by looking for the instance in the user-data,
-        // which is the case when an instance sends to itself.
-        if (message->m_UserData1 != 0
-                && message->m_Sender.m_Socket == message->m_Receiver.m_Socket
-                && message->m_Sender.m_Path == message->m_Receiver.m_Path)
-        {
-            Instance* user_data_instance = (Instance*)message->m_UserData1;
-            if (message->m_Receiver.m_Path == user_data_instance->m_Identifier)
-            {
-                instance = user_data_instance;
-            }
-        }
-        if (instance == 0x0)
-        {
-            instance = GetInstanceFromIdentifier(context->m_Collection, message->m_Receiver.m_Path);
-        }
+        Instance* instance = GetInstanceFromIdentifier(collection, message->m_Receiver.m_Path);
         if (instance == 0x0)
         {
             DM_HASH_REVERSE_MEM(hash_ctx, 512);

--- a/engine/gameobject/src/gameobject/gameobject.h
+++ b/engine/gameobject/src/gameobject/gameobject.h
@@ -267,6 +267,15 @@ namespace dmGameObject
     HRegister GetRegister(HCollection collection);
 
     /**
+     * Retrieve a collection from the socket name hash
+     * @param regist The register bound to the specified collection
+     * @param socket_name The name of the socket
+     * @return The game object collection if successful. 0 otherwise.
+     */
+    // Used by comp_collision_object.cpp to do cold lookups of urls
+    HCollection GetCollectionByHash(HRegister regist, dmhash_t socket_name);
+
+    /**
      * Retrieve the frame message socket for the specified collection.
      * @param collection Collection handle
      * @return The frame message socket of the specified collection

--- a/engine/gameobject/src/gameobject/gameobject_private.h
+++ b/engine/gameobject/src/gameobject/gameobject_private.h
@@ -304,7 +304,8 @@ namespace dmGameObject
 
     // Used by res_collection.cpp
     HInstance NewInstance(Collection* collection, Prototype* proto, const char* prototype_name);
-    HInstance GetInstanceFromIdentifier(Collection* collection, dmhash_t identifier);
+    HInstance GetInstanceFromIdentifier(Collection* collection, dmhash_t identifier); // TODO: Mostly duplicate: replace with HCollection version
+
     void ReleaseInstanceIndex(uint32_t index, HCollection collection);
     Result SetIdentifier(Collection* collection, HInstance instance, const char* identifier);
     void ReleaseIdentifier(Collection* collection, HInstance instance);

--- a/engine/gamesys/proto/gamesys/physics_ddf.proto
+++ b/engine/gamesys/proto/gamesys/physics_ddf.proto
@@ -268,12 +268,13 @@ message TriggerResponse
     required uint64 own_group               = 5;
 }
 
+// Runtime only (not public)
 message RequestRayCast
 {
-    required dmMath.Point3  from = 1;
-    required dmMath.Point3  to = 2;
-    required uint32         mask = 3;
-    required uint32         request_id = 4;
+    required dmMath.Point3  from            = 1;
+    required dmMath.Point3  to              = 2;
+    required uint32         mask            = 3;
+    required uint32         request_id      = 4;
 }
 
 /*# reports a ray cast hit

--- a/engine/gamesys/src/gamesys/scripts/script_camera.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_camera.cpp
@@ -52,15 +52,14 @@ namespace dmGameSystem
     static int Camera_AcquireFocus(lua_State* L)
     {
         DM_LUA_STACK_CHECK(L, 0);
-        dmGameObject::HInstance instance = CheckGoInstance(L);
+        (void)CheckGoInstance(L); // left to check that it's not called from incorrect context.
 
         dmMessage::URL receiver;
         dmMessage::URL sender;
         dmScript::ResolveURL(L, 1, &receiver, &sender);
 
         dmGamesysDDF::AcquireCameraFocus msg;
-        dmMessage::Post(&sender, &receiver, dmGamesysDDF::AcquireCameraFocus::m_DDFDescriptor->m_NameHash, (uintptr_t)instance,
-            0, (uintptr_t)dmGamesysDDF::AcquireCameraFocus::m_DDFDescriptor, &msg, sizeof(msg), 0);
+        dmMessage::Post(&sender, &receiver, dmGamesysDDF::AcquireCameraFocus::m_DDFDescriptor->m_NameHash, 0, 0, (uintptr_t)dmGamesysDDF::AcquireCameraFocus::m_DDFDescriptor, &msg, sizeof(msg), 0);
         return 0;
     }
 
@@ -76,15 +75,14 @@ namespace dmGameSystem
     static int Camera_ReleaseFocus(lua_State* L)
     {
         DM_LUA_STACK_CHECK(L, 0);
-        dmGameObject::HInstance instance = CheckGoInstance(L);
+        (void)CheckGoInstance(L); // left to check that it's not called from incorrect context.
 
         dmMessage::URL receiver;
         dmMessage::URL sender;
         dmScript::ResolveURL(L, 1, &receiver, &sender);
 
         dmGamesysDDF::ReleaseCameraFocus msg;
-        dmMessage::Post(&sender, &receiver, dmGamesysDDF::ReleaseCameraFocus::m_DDFDescriptor->m_NameHash, (uintptr_t)instance,
-            0, (uintptr_t)dmGamesysDDF::ReleaseCameraFocus::m_DDFDescriptor, &msg, sizeof(msg), 0);
+        dmMessage::Post(&sender, &receiver, dmGamesysDDF::ReleaseCameraFocus::m_DDFDescriptor->m_NameHash, 0, 0, (uintptr_t)dmGamesysDDF::ReleaseCameraFocus::m_DDFDescriptor, &msg, sizeof(msg), 0);
         return 0;
     }
 

--- a/engine/gamesys/src/gamesys/scripts/script_collection_factory.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_collection_factory.cpp
@@ -314,10 +314,6 @@ namespace dmGameSystem
             rotation = dmGameObject::GetWorldRotation(sender_instance);
         }
 
-        const uint32_t buffer_size = 4096;
-        uint8_t DM_ALIGNED(16) buffer[buffer_size];
-        uint32_t buffer_pos = 0;
-
         dmGameObject::InstancePropertyBuffers prop_bufs;
         prop_bufs.SetCapacity(8, 32);
 
@@ -332,8 +328,6 @@ namespace dmGameSystem
                 while (lua_next(L, -2))
                 {
                     dmhash_t instance_id = dmScript::CheckHash(L, -2);
-                    uint32_t left = buffer_size - buffer_pos;
-
                     dmGameObject::HPropertyContainer properties = dmGameObject::PropertyContainerCreateFromLua(L, -1);
 
                     prop_bufs.Put(instance_id, properties);

--- a/engine/gamesys/src/gamesys/scripts/script_collectionproxy.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_collectionproxy.cpp
@@ -124,7 +124,6 @@ namespace dmGameSystem
 
 
         const char* path = 0;
-        dmhash_t path_hash = 0;
         if (!lua_isnil(L, 2))
         {
             path = luaL_checkstring(L, 2);

--- a/engine/gamesys/src/gamesys/scripts/script_factory.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_factory.cpp
@@ -237,7 +237,7 @@ namespace dmGameSystem
      * end
      * ```
      */
-    static int FactoryComp_CreateWithMessage(lua_State* L, dmGameObject::HCollection collection, dmGameObject::HInstance sender_instance, dmMessage::URL* receiver,
+    static int FactoryComp_CreateWithMessage(lua_State* L, dmGameObject::HCollection collection, dmMessage::URL* receiver,
                                             uint32_t index, dmhash_t id, dmGameObject::HPropertyContainer properties,
                                             const dmVMath::Point3& position, const dmVMath::Quat& rotation, const dmVMath::Vector3& scale)
     {
@@ -268,7 +268,7 @@ namespace dmGameSystem
             return luaL_error(L, "factory.create can not be called from this script type");
         }
 
-        dmMessage::Post(&sender, receiver, dmGameSystemDDF::Create::m_DDFDescriptor->m_NameHash, (uintptr_t)sender_instance,
+        dmMessage::Post(&sender, receiver, dmGameSystemDDF::Create::m_DDFDescriptor->m_NameHash, 0,
                         (uintptr_t)dmGameSystemDDF::Create::m_DDFDescriptor, buffer, sizeof(dmGameSystemDDF::Create) + properties_size, 0);
 
         return 0;
@@ -345,7 +345,7 @@ namespace dmGameSystem
             bool msg_passing = dmGameObject::GetInstanceFromLua(L) == 0x0;
             if (msg_passing)
             {
-                FactoryComp_CreateWithMessage(L, collection, sender_instance, &receiver, index, id, properties, position, rotation, scale);
+                FactoryComp_CreateWithMessage(L, collection, &receiver, index, id, properties, position, rotation, scale);
                 // We currently don't know if the creation succeeds
                 dmScript::PushHash(L, id);
             }

--- a/engine/gamesys/src/gamesys/scripts/script_label.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_label.cpp
@@ -277,7 +277,7 @@ static int SetText(lua_State* L)
 {
     DM_LUA_STACK_CHECK(L, 0);
 
-    dmGameObject::HInstance instance = CheckGoInstance(L);
+    (void)CheckGoInstance(L); // left to check that it's not called from incorrect context.
 
     size_t text_len = 0;
     const char* text = luaL_checklstring(L, 2, &text_len);
@@ -302,7 +302,7 @@ static int SetText(lua_State* L)
     dmScript::GetURL(L, &sender);
     dmScript::ResolveURL(L, 1, &receiver, &sender);
 
-    if (dmMessage::RESULT_OK != dmMessage::Post(&sender, &receiver, dmGameSystemDDF::SetText::m_DDFDescriptor->m_NameHash, (uintptr_t)instance, (uintptr_t)dmGameSystemDDF::SetText::m_DDFDescriptor, data, data_size, 0) )
+    if (dmMessage::RESULT_OK != dmMessage::Post(&sender, &receiver, dmGameSystemDDF::SetText::m_DDFDescriptor->m_NameHash, 0, (uintptr_t)dmGameSystemDDF::SetText::m_DDFDescriptor, data, data_size, 0) )
     {
         return DM_LUA_ERROR("Failed to send label string as message!");
     }

--- a/engine/gamesys/src/gamesys/scripts/script_model.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_model.cpp
@@ -173,7 +173,7 @@ namespace dmGameSystem
         float offset = 0.0f;
         float playback_rate = 1.0f;
 
-        dmGameObject::HInstance instance = CheckGoInstance(L);
+        (void)CheckGoInstance(L); // left to check that it's not called from incorrect context.
 
         dmhash_t anim_id = dmScript::CheckHashOrString(L, 2);
         lua_Integer playback = luaL_checkinteger(L, 3);
@@ -200,7 +200,7 @@ namespace dmGameSystem
         msg.m_Offset = offset;
         msg.m_PlaybackRate = playback_rate;
 
-        dmMessage::Post(&sender, &receiver, dmModelDDF::ModelPlayAnimation::m_DDFDescriptor->m_NameHash, (uintptr_t)instance, (uintptr_t)functionref, (uintptr_t)dmModelDDF::ModelPlayAnimation::m_DDFDescriptor, &msg, sizeof(msg), 0);
+        dmMessage::Post(&sender, &receiver, dmModelDDF::ModelPlayAnimation::m_DDFDescriptor->m_NameHash, 0, (uintptr_t)functionref, (uintptr_t)dmModelDDF::ModelPlayAnimation::m_DDFDescriptor, &msg, sizeof(msg), 0);
         assert(top == lua_gettop(L));
         return 0;
     }
@@ -293,7 +293,7 @@ namespace dmGameSystem
         DM_LUA_STACK_CHECK(L, 0);
         int top = lua_gettop(L);
 
-        dmGameObject::HInstance instance = CheckGoInstance(L);
+        (void)CheckGoInstance(L); // left to check that it's not called from incorrect context.
 
         dmhash_t anim_id = dmScript::CheckHashOrString(L, 2);
         lua_Integer playback = luaL_checkinteger(L, 3);
@@ -341,7 +341,7 @@ namespace dmGameSystem
         msg.m_Offset = offset;
         msg.m_PlaybackRate = playback_rate;
 
-        dmMessage::Post(&sender, &receiver, dmModelDDF::ModelPlayAnimation::m_DDFDescriptor->m_NameHash, (uintptr_t)instance, (uintptr_t)functionref, (uintptr_t)dmModelDDF::ModelPlayAnimation::m_DDFDescriptor, &msg, sizeof(msg), 0);
+        dmMessage::Post(&sender, &receiver, dmModelDDF::ModelPlayAnimation::m_DDFDescriptor->m_NameHash, 0, (uintptr_t)functionref, (uintptr_t)dmModelDDF::ModelPlayAnimation::m_DDFDescriptor, &msg, sizeof(msg), 0);
         return 0;
     }
 
@@ -355,7 +355,7 @@ namespace dmGameSystem
     {
         int top = lua_gettop(L);
 
-        dmGameObject::HInstance instance = CheckGoInstance(L);
+        (void)CheckGoInstance(L); // left to check that it's not called from incorrect context.
 
         dmMessage::URL receiver;
         dmMessage::URL sender;
@@ -363,7 +363,7 @@ namespace dmGameSystem
 
         dmModelDDF::ModelCancelAnimation msg;
 
-        dmMessage::Post(&sender, &receiver, dmModelDDF::ModelCancelAnimation::m_DDFDescriptor->m_NameHash, (uintptr_t)instance, (uintptr_t)dmModelDDF::ModelCancelAnimation::m_DDFDescriptor, &msg, sizeof(msg), 0);
+        dmMessage::Post(&sender, &receiver, dmModelDDF::ModelCancelAnimation::m_DDFDescriptor->m_NameHash, 0, (uintptr_t)dmModelDDF::ModelCancelAnimation::m_DDFDescriptor, &msg, sizeof(msg), 0);
         assert(top == lua_gettop(L));
         return 0;
     }
@@ -464,7 +464,7 @@ namespace dmGameSystem
     {
         int top = lua_gettop(L);
 
-        dmGameObject::HInstance instance = CheckGoInstance(L);
+        (void)CheckGoInstance(L); // left to check that it's not called from incorrect context.
 
         dmhash_t name_hash = dmScript::CheckHashOrString(L, 2);
         dmVMath::Vector4* value = dmScript::CheckVector4(L, 3);
@@ -478,7 +478,7 @@ namespace dmGameSystem
         dmMessage::URL sender;
         dmScript::ResolveURL(L, 1, &receiver, &sender);
 
-        dmMessage::Post(&sender, &receiver, dmGameSystemDDF::SetConstant::m_DDFDescriptor->m_NameHash, (uintptr_t)instance, (uintptr_t)dmGameSystemDDF::SetConstant::m_DDFDescriptor, &msg, sizeof(msg), 0);
+        dmMessage::Post(&sender, &receiver, dmGameSystemDDF::SetConstant::m_DDFDescriptor->m_NameHash, 0, (uintptr_t)dmGameSystemDDF::SetConstant::m_DDFDescriptor, &msg, sizeof(msg), 0);
         assert(top == lua_gettop(L));
         return 0;
     }
@@ -509,7 +509,7 @@ namespace dmGameSystem
     {
         int top = lua_gettop(L);
 
-        dmGameObject::HInstance instance = CheckGoInstance(L);
+        (void)CheckGoInstance(L); // left to check that it's not called from incorrect context.
         dmhash_t name_hash = dmScript::CheckHashOrString(L, 2);
 
         dmGameSystemDDF::ResetConstant msg;
@@ -519,7 +519,7 @@ namespace dmGameSystem
         dmMessage::URL sender;
         dmScript::ResolveURL(L, 1, &receiver, &sender);
 
-        dmMessage::Post(&sender, &receiver, dmGameSystemDDF::ResetConstant::m_DDFDescriptor->m_NameHash, (uintptr_t)instance, (uintptr_t)dmGameSystemDDF::ResetConstant::m_DDFDescriptor, &msg, sizeof(msg), 0);
+        dmMessage::Post(&sender, &receiver, dmGameSystemDDF::ResetConstant::m_DDFDescriptor->m_NameHash, 0, (uintptr_t)dmGameSystemDDF::ResetConstant::m_DDFDescriptor, &msg, sizeof(msg), 0);
         assert(top == lua_gettop(L));
         return 0;
     }

--- a/engine/gamesys/src/gamesys/scripts/script_particlefx.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_particlefx.cpp
@@ -163,7 +163,7 @@ namespace dmGameSystem
      */
     int ParticleFX_Play(lua_State* L)
     {
-        dmGameObject::HInstance instance = CheckGoInstance(L);
+        (void)CheckGoInstance(L); // left to check that it's not called from incorrect context.
 
         int top = lua_gettop(L);
 
@@ -213,7 +213,7 @@ namespace dmGameSystem
             &sender,
             &receiver,
             dmGameSystemDDF::PlayParticleFX::m_DDFDescriptor->m_NameHash,
-            (uintptr_t)instance,
+            0,
             (uintptr_t)dmGameSystemDDF::PlayParticleFX::m_DDFDescriptor,
             (void*)msg_buf,
             msg_size,
@@ -248,7 +248,7 @@ namespace dmGameSystem
     {
         DM_LUA_STACK_CHECK(L, 0);
 
-        dmGameObject::HInstance instance = CheckGoInstance(L);
+        (void)CheckGoInstance(L); // left to check that it's not called from incorrect context.
 
         dmGameSystemDDF::StopParticleFX msg;
         uint32_t msg_size = sizeof(dmGameSystemDDF::StopParticleFX);
@@ -279,7 +279,7 @@ namespace dmGameSystem
 
         msg.m_ClearParticles = clear_particles;
 
-        dmMessage::Post(&sender, &receiver, dmGameSystemDDF::StopParticleFX::m_DDFDescriptor->m_NameHash, (uintptr_t)instance, (uintptr_t)dmGameSystemDDF::StopParticleFX::m_DDFDescriptor, (void*)&msg, msg_size, 0);
+        dmMessage::Post(&sender, &receiver, dmGameSystemDDF::StopParticleFX::m_DDFDescriptor->m_NameHash, 0, (uintptr_t)dmGameSystemDDF::StopParticleFX::m_DDFDescriptor, (void*)&msg, msg_size, 0);
         return 0;
     }
 
@@ -313,7 +313,7 @@ namespace dmGameSystem
     {
         int top = lua_gettop(L);
 
-        dmGameObject::HInstance instance = CheckGoInstance(L);
+        (void)CheckGoInstance(L); // left to check that it's not called from incorrect context.
 
         dmhash_t emitter_id = dmScript::CheckHashOrString(L, 2);
         dmhash_t name_hash = dmScript::CheckHashOrString(L, 3);
@@ -340,7 +340,7 @@ namespace dmGameSystem
         dmMessage::URL sender;
         dmScript::ResolveURL(L, 1, &receiver, &sender);
 
-        dmMessage::Post(&sender, &receiver, dmGameSystemDDF::SetConstantParticleFX::m_DDFDescriptor->m_NameHash, (uintptr_t)instance, (uintptr_t)dmGameSystemDDF::SetConstantParticleFX::m_DDFDescriptor, &msg, sizeof(msg), 0);
+        dmMessage::Post(&sender, &receiver, dmGameSystemDDF::SetConstantParticleFX::m_DDFDescriptor->m_NameHash, 0, (uintptr_t)dmGameSystemDDF::SetConstantParticleFX::m_DDFDescriptor, &msg, sizeof(msg), 0);
         assert(top == lua_gettop(L));
         return 0;
     }
@@ -373,7 +373,7 @@ namespace dmGameSystem
     {
         int top = lua_gettop(L);
 
-        dmGameObject::HInstance instance = CheckGoInstance(L);
+        (void)CheckGoInstance(L); // left to check that it's not called from incorrect context.
         dmhash_t emitter_id = dmScript::CheckHashOrString(L, 2);
         dmhash_t name_hash = dmScript::CheckHashOrString(L, 3);
 
@@ -385,7 +385,7 @@ namespace dmGameSystem
         dmMessage::URL sender;
         dmScript::ResolveURL(L, 1, &receiver, &sender);
 
-        dmMessage::Post(&sender, &receiver, dmGameSystemDDF::ResetConstantParticleFX::m_DDFDescriptor->m_NameHash, (uintptr_t)instance, (uintptr_t)dmGameSystemDDF::ResetConstantParticleFX::m_DDFDescriptor, &msg, sizeof(msg), 0);
+        dmMessage::Post(&sender, &receiver, dmGameSystemDDF::ResetConstantParticleFX::m_DDFDescriptor->m_NameHash, 0, (uintptr_t)dmGameSystemDDF::ResetConstantParticleFX::m_DDFDescriptor, &msg, sizeof(msg), 0);
         assert(top == lua_gettop(L));
         return 0;
     }

--- a/engine/gamesys/src/gamesys/scripts/script_physics.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_physics.cpp
@@ -358,7 +358,7 @@ namespace dmGameSystem
         dmMessage::URL receiver;
         dmMessage::ResetURL(&receiver);
         receiver.m_Socket = context->m_Socket;
-        dmMessage::Post(&sender, &receiver, dmPhysicsDDF::RequestRayCast::m_DDFDescriptor->m_NameHash, (uintptr_t)sender_instance, (uintptr_t)dmPhysicsDDF::RequestRayCast::m_DDFDescriptor, &request, sizeof(dmPhysicsDDF::RequestRayCast), 0);
+        dmMessage::Post(&sender, &receiver, dmPhysicsDDF::RequestRayCast::m_DDFDescriptor->m_NameHash, 0, (uintptr_t)dmPhysicsDDF::RequestRayCast::m_DDFDescriptor, &request, sizeof(dmPhysicsDDF::RequestRayCast), 0);
         return 0;
     }
 

--- a/engine/gamesys/src/gamesys/scripts/script_sound.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_sound.cpp
@@ -503,7 +503,7 @@ namespace dmGameSystem
         DM_LUA_STACK_CHECK(L, 1);
         int top = lua_gettop(L);
 
-        dmGameObject::HInstance instance = CheckGoInstance(L);
+        (void)CheckGoInstance(L); // left to check that it's not called from incorrect context.
 
         dmMessage::URL receiver;
         dmMessage::URL sender;
@@ -556,7 +556,7 @@ namespace dmGameSystem
         msg.m_Speed = speed;
         msg.m_PlayId = play_id;
 
-        dmMessage::Post(&sender, &receiver, dmGameSystemDDF::PlaySound::m_DDFDescriptor->m_NameHash, (uintptr_t)instance, functionref, (uintptr_t)dmGameSystemDDF::PlaySound::m_DDFDescriptor, &msg, sizeof(msg), 0);
+        dmMessage::Post(&sender, &receiver, dmGameSystemDDF::PlaySound::m_DDFDescriptor->m_NameHash, 0, functionref, (uintptr_t)dmGameSystemDDF::PlaySound::m_DDFDescriptor, &msg, sizeof(msg), 0);
 
         lua_pushnumber(L, (double) msg.m_PlayId);
 
@@ -586,7 +586,7 @@ namespace dmGameSystem
     {
         DM_LUA_STACK_CHECK(L, 0);
         int top = lua_gettop(L);
-        dmGameObject::HInstance instance = CheckGoInstance(L);
+        (void)CheckGoInstance(L); // left to check that it's not called from incorrect context.
 
         dmMessage::URL receiver;
         dmMessage::URL sender;
@@ -612,7 +612,7 @@ namespace dmGameSystem
         dmGameSystemDDF::StopSound msg;
         msg.m_PlayId = play_id;
 
-        dmMessage::Post(&sender, &receiver, dmGameSystemDDF::StopSound::m_DDFDescriptor->m_NameHash, (uintptr_t)instance, (uintptr_t)dmGameSystemDDF::StopSound::m_DDFDescriptor, &msg, sizeof(msg), 0);
+        dmMessage::Post(&sender, &receiver, dmGameSystemDDF::StopSound::m_DDFDescriptor->m_NameHash, 0, (uintptr_t)dmGameSystemDDF::StopSound::m_DDFDescriptor, &msg, sizeof(msg), 0);
         return 0;
     }
 
@@ -634,7 +634,7 @@ namespace dmGameSystem
     static int Sound_Pause(lua_State* L)
     {
         DM_LUA_STACK_CHECK(L, 0);
-        dmGameObject::HInstance instance = CheckGoInstance(L);
+        (void)CheckGoInstance(L); // left to check that it's not called from incorrect context.
 
         dmMessage::URL receiver;
         dmMessage::URL sender;
@@ -643,7 +643,7 @@ namespace dmGameSystem
         dmGameSystemDDF::PauseSound msg;
         msg.m_Pause = dmScript::CheckBoolean(L, 2);
 
-        dmMessage::Post(&sender, &receiver, dmGameSystemDDF::PauseSound::m_DDFDescriptor->m_NameHash, (uintptr_t)instance, (uintptr_t)dmGameSystemDDF::PauseSound::m_DDFDescriptor, &msg, sizeof(msg), 0);
+        dmMessage::Post(&sender, &receiver, dmGameSystemDDF::PauseSound::m_DDFDescriptor->m_NameHash, 0, (uintptr_t)dmGameSystemDDF::PauseSound::m_DDFDescriptor, &msg, sizeof(msg), 0);
         return 0;
     }
 
@@ -670,7 +670,7 @@ namespace dmGameSystem
     {
         DM_LUA_STACK_CHECK(L, 0);
 
-        dmGameObject::HInstance instance = CheckGoInstance(L);
+        (void)CheckGoInstance(L); // left to check that it's not called from incorrect context.
 
         dmMessage::URL receiver;
         dmMessage::URL sender;
@@ -681,7 +681,7 @@ namespace dmGameSystem
         dmGameSystemDDF::SetGain msg;
         msg.m_Gain = gain;
 
-        dmMessage::Post(&sender, &receiver, dmGameSystemDDF::SetGain::m_DDFDescriptor->m_NameHash, (uintptr_t)instance, (uintptr_t)dmGameSystemDDF::SetGain::m_DDFDescriptor, &msg, sizeof(msg), 0);
+        dmMessage::Post(&sender, &receiver, dmGameSystemDDF::SetGain::m_DDFDescriptor->m_NameHash, 0, (uintptr_t)dmGameSystemDDF::SetGain::m_DDFDescriptor, &msg, sizeof(msg), 0);
         return 0;
     }
 
@@ -708,7 +708,7 @@ namespace dmGameSystem
     {
         DM_LUA_STACK_CHECK(L, 0);
 
-        dmGameObject::HInstance instance = CheckGoInstance(L);
+        (void)CheckGoInstance(L); // left to check that it's not called from incorrect context.
 
         dmMessage::URL receiver;
         dmMessage::URL sender;
@@ -719,7 +719,7 @@ namespace dmGameSystem
         dmGameSystemDDF::SetPan msg;
         msg.m_Pan = pan;
 
-        dmMessage::Post(&sender, &receiver, dmGameSystemDDF::SetPan::m_DDFDescriptor->m_NameHash, (uintptr_t)instance, (uintptr_t)dmGameSystemDDF::SetPan::m_DDFDescriptor, &msg, sizeof(msg), 0);
+        dmMessage::Post(&sender, &receiver, dmGameSystemDDF::SetPan::m_DDFDescriptor->m_NameHash, 0, (uintptr_t)dmGameSystemDDF::SetPan::m_DDFDescriptor, &msg, sizeof(msg), 0);
         return 0;
     }
 

--- a/engine/gamesys/src/gamesys/scripts/script_sprite.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_sprite.cpp
@@ -276,7 +276,7 @@ namespace dmGameSystem
     {
         int top = lua_gettop(L);
 
-        dmGameObject::HInstance instance = CheckGoInstance(L);
+        (void)CheckGoInstance(L); // left to check that it's not called from incorrect context.
 
         dmGameSystemDDF::SetFlipHorizontal msg;
         msg.m_Flip = (uint32_t)lua_toboolean(L, 2);
@@ -285,7 +285,7 @@ namespace dmGameSystem
         dmMessage::URL sender;
         dmScript::ResolveURL(L, 1, &receiver, &sender);
 
-        dmMessage::Post(&sender, &receiver, dmGameSystemDDF::SetFlipHorizontal::m_DDFDescriptor->m_NameHash, (uintptr_t)instance, (uintptr_t)dmGameSystemDDF::SetFlipHorizontal::m_DDFDescriptor, &msg, sizeof(msg), 0);
+        dmMessage::Post(&sender, &receiver, dmGameSystemDDF::SetFlipHorizontal::m_DDFDescriptor->m_NameHash, 0, (uintptr_t)dmGameSystemDDF::SetFlipHorizontal::m_DDFDescriptor, &msg, sizeof(msg), 0);
         assert(top == lua_gettop(L));
         return 0;
     }
@@ -315,7 +315,7 @@ namespace dmGameSystem
     {
         int top = lua_gettop(L);
 
-        dmGameObject::HInstance instance = CheckGoInstance(L);
+        (void)CheckGoInstance(L); // left to check that it's not called from incorrect context.
 
         dmGameSystemDDF::SetFlipVertical msg;
         msg.m_Flip = (uint32_t)lua_toboolean(L, 2);
@@ -324,7 +324,7 @@ namespace dmGameSystem
         dmMessage::URL sender;
         dmScript::ResolveURL(L, 1, &receiver, &sender);
 
-        dmMessage::Post(&sender, &receiver, dmGameSystemDDF::SetFlipVertical::m_DDFDescriptor->m_NameHash, (uintptr_t)instance, (uintptr_t)dmGameSystemDDF::SetFlipVertical::m_DDFDescriptor, &msg, sizeof(msg), 0);
+        dmMessage::Post(&sender, &receiver, dmGameSystemDDF::SetFlipVertical::m_DDFDescriptor->m_NameHash, 0, (uintptr_t)dmGameSystemDDF::SetFlipVertical::m_DDFDescriptor, &msg, sizeof(msg), 0);
         assert(top == lua_gettop(L));
         return 0;
     }
@@ -357,7 +357,7 @@ namespace dmGameSystem
     {
         int top = lua_gettop(L);
 
-        dmGameObject::HInstance instance = CheckGoInstance(L);
+        (void)CheckGoInstance(L); // left to check that it's not called from incorrect context.
         dmhash_t name_hash = dmScript::CheckHashOrString(L, 2);
         dmVMath::Vector4* value = dmScript::CheckVector4(L, 3);
 
@@ -370,7 +370,7 @@ namespace dmGameSystem
         dmMessage::URL sender;
         dmScript::ResolveURL(L, 1, &receiver, &sender);
 
-        dmMessage::Post(&sender, &receiver, dmGameSystemDDF::SetConstant::m_DDFDescriptor->m_NameHash, (uintptr_t)instance, (uintptr_t)dmGameSystemDDF::SetConstant::m_DDFDescriptor, &msg, sizeof(msg), 0);
+        dmMessage::Post(&sender, &receiver, dmGameSystemDDF::SetConstant::m_DDFDescriptor->m_NameHash, 0, (uintptr_t)dmGameSystemDDF::SetConstant::m_DDFDescriptor, &msg, sizeof(msg), 0);
         assert(top == lua_gettop(L));
         return 0;
     }
@@ -401,7 +401,7 @@ namespace dmGameSystem
     {
         int top = lua_gettop(L);
 
-        dmGameObject::HInstance instance = CheckGoInstance(L);
+        (void)CheckGoInstance(L); // left to check that it's not called from incorrect context.
         dmhash_t name_hash = dmScript::CheckHashOrString(L, 2);
 
         dmGameSystemDDF::ResetConstant msg;
@@ -411,7 +411,7 @@ namespace dmGameSystem
         dmMessage::URL sender;
         dmScript::ResolveURL(L, 1, &receiver, &sender);
 
-        dmMessage::Post(&sender, &receiver, dmGameSystemDDF::ResetConstant::m_DDFDescriptor->m_NameHash, (uintptr_t)instance, (uintptr_t)dmGameSystemDDF::ResetConstant::m_DDFDescriptor, &msg, sizeof(msg), 0);
+        dmMessage::Post(&sender, &receiver, dmGameSystemDDF::ResetConstant::m_DDFDescriptor->m_NameHash, 0, (uintptr_t)dmGameSystemDDF::ResetConstant::m_DDFDescriptor, &msg, sizeof(msg), 0);
         assert(top == lua_gettop(L));
         return 0;
     }
@@ -421,7 +421,7 @@ namespace dmGameSystem
     {
         int top = lua_gettop(L);
 
-        dmGameObject::HInstance instance = CheckGoInstance(L);
+        (void)CheckGoInstance(L); // left to check that it's not called from incorrect context.
 
         dmVMath::Vector3* scale = dmScript::CheckVector3(L, 2);
 
@@ -432,7 +432,7 @@ namespace dmGameSystem
         dmMessage::URL sender;
         dmScript::ResolveURL(L, 1, &receiver, &sender);
 
-        dmMessage::Post(&sender, &receiver, dmGameSystemDDF::SetScale::m_DDFDescriptor->m_NameHash, (uintptr_t)instance, (uintptr_t)dmGameSystemDDF::SetScale::m_DDFDescriptor, &msg, sizeof(msg), 0);
+        dmMessage::Post(&sender, &receiver, dmGameSystemDDF::SetScale::m_DDFDescriptor->m_NameHash, 0, (uintptr_t)dmGameSystemDDF::SetScale::m_DDFDescriptor, &msg, sizeof(msg), 0);
         assert(top == lua_gettop(L));
         return 0;
     }
@@ -501,7 +501,7 @@ namespace dmGameSystem
         DM_LUA_STACK_CHECK(L, 0);
         int top = lua_gettop(L);
 
-        dmGameObject::HInstance instance = CheckGoInstance(L);
+        (void)CheckGoInstance(L); // left to check that it's not called from incorrect context.
         dmhash_t id_hash = dmScript::CheckHashOrString(L, 2);
 
         dmMessage::URL receiver;
@@ -543,7 +543,7 @@ namespace dmGameSystem
         msg.m_Offset = offset;
         msg.m_PlaybackRate = playback_rate;
 
-        dmMessage::Post(&sender, &receiver, dmGameSystemDDF::PlayAnimation::m_DDFDescriptor->m_NameHash, (uintptr_t)instance, (uintptr_t)functionref, (uintptr_t)dmGameSystemDDF::PlayAnimation::m_DDFDescriptor, &msg, sizeof(msg), 0);
+        dmMessage::Post(&sender, &receiver, dmGameSystemDDF::PlayAnimation::m_DDFDescriptor->m_NameHash, 0, (uintptr_t)functionref, (uintptr_t)dmGameSystemDDF::PlayAnimation::m_DDFDescriptor, &msg, sizeof(msg), 0);
         return 0;
     }
 

--- a/engine/gamesys/src/gamesys/scripts/script_tilemap.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_tilemap.cpp
@@ -111,7 +111,7 @@ namespace dmGameSystem
     {
         int top = lua_gettop(L);
 
-        dmGameObject::HInstance instance = CheckGoInstance(L);
+        (void)CheckGoInstance(L); // left to check that it's not called from incorrect context.
 
         dmhash_t name_hash = dmScript::CheckHashOrString(L, 2);
         dmVMath::Vector4* value = dmScript::CheckVector4(L, 3);
@@ -124,7 +124,7 @@ namespace dmGameSystem
         dmMessage::URL sender;
         dmScript::ResolveURL(L, 1, &receiver, &sender);
 
-        dmMessage::Post(&sender, &receiver, dmGameSystemDDF::SetConstantTileMap::m_DDFDescriptor->m_NameHash, (uintptr_t)instance, (uintptr_t)dmGameSystemDDF::SetConstantTileMap::m_DDFDescriptor, &msg, sizeof(msg), 0);
+        dmMessage::Post(&sender, &receiver, dmGameSystemDDF::SetConstantTileMap::m_DDFDescriptor->m_NameHash, 0, (uintptr_t)dmGameSystemDDF::SetConstantTileMap::m_DDFDescriptor, &msg, sizeof(msg), 0);
         assert(top == lua_gettop(L));
         return 0;
     }
@@ -155,7 +155,7 @@ namespace dmGameSystem
     {
         int top = lua_gettop(L);
 
-        dmGameObject::HInstance instance = CheckGoInstance(L);
+        (void)CheckGoInstance(L); // left to check that it's not called from incorrect context.
         dmhash_t name_hash = dmScript::CheckHashOrString(L, 2);
 
         dmGameSystemDDF::ResetConstantTileMap msg;
@@ -165,7 +165,7 @@ namespace dmGameSystem
         dmMessage::URL sender;
         dmScript::ResolveURL(L, 1, &receiver, &sender);
 
-        dmMessage::Post(&sender, &receiver, dmGameSystemDDF::ResetConstantTileMap::m_DDFDescriptor->m_NameHash, (uintptr_t)instance, (uintptr_t)dmGameSystemDDF::ResetConstantTileMap::m_DDFDescriptor, &msg, sizeof(msg), 0);
+        dmMessage::Post(&sender, &receiver, dmGameSystemDDF::ResetConstantTileMap::m_DDFDescriptor->m_NameHash, 0, (uintptr_t)dmGameSystemDDF::ResetConstantTileMap::m_DDFDescriptor, &msg, sizeof(msg), 0);
         assert(top == lua_gettop(L));
         return 0;
     }


### PR DESCRIPTION
This fixes a rare crash where lingering raycast messages were handled the exact frame when the collection was freed.

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
