### PR TITLE
Make the atlas output `*.a.texturesetc` more deterministic

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/AbstractProtoBuilderTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/AbstractProtoBuilderTest.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -175,6 +176,16 @@ public abstract class AbstractProtoBuilderTest {
         return messages;
     }
 
+    protected void clean() throws Exception {
+        Collection<String> result = new ArrayList<>();
+        fileSystem.walk("build", new FileSystemWalker() {
+            public void handleFile(String path, Collection<String> results) {
+                fileSystem.addFile(path, null);
+            }
+        }, result);
+        project.build(new NullProgress(), "clean");
+    }
+
     protected <T extends Message> T getMessage(List<Message> messages, Class<T> type) {
         for (int i = messages.size() - 1; i >= 0; i--) {
             Message message = messages.get(i);
@@ -245,5 +256,4 @@ public abstract class AbstractProtoBuilderTest {
         baos.flush();
         addFile(path, baos.toByteArray());
     }
-
 }

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/AtlasBuilderTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/AtlasBuilderTest.java
@@ -21,10 +21,14 @@ import static org.junit.Assert.assertTrue;
 import static org.hamcrest.CoreMatchers.is;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.HashSet;
 
+import com.dynamo.bob.archive.ArchiveEntry;
+import com.dynamo.bob.archive.ManifestBuilder;
+import com.dynamo.liveupdate.proto.Manifest;
 import org.junit.Test;
 
 import com.dynamo.graphics.proto.Graphics.TextureImage;
@@ -306,4 +310,45 @@ public class AtlasBuilderTest extends AbstractProtoBuilderTest {
         assertEquals(imageNameHashes, textureSet.getImageNameHashesList());
     }
 
+    @Test
+    public void testHexDigestForAtlas() throws Exception {
+        List<String> names = new ArrayList<>();
+        for (int i = 1; i <= 10; i++) {
+            StringBuilder line = new StringBuilder();
+            int min = 1;
+            int max = 16;
+            String name = "/" + i + ".png";
+            addImage(name, (int)(Math.random() * (max - min + 1) + min), (int)(Math.random() * (max - min + 1) + min));
+            line.append("images {\n  image: \"");
+            line.append(name);
+            line.append("\"\n}\n");
+            names.add(line.toString());
+        }
+
+        Collections.shuffle(names);
+        StringBuilder src = new StringBuilder();
+        for (String l: names) {
+            src.append(l);
+        }
+        List<Message> outputs1 = build("testHex.atlas", src.toString());
+        TextureSet textureSet1 = getMessage(outputs1, TextureSet.class);
+
+        byte[] hash1 = ManifestBuilder.CryptographicOperations.hash(textureSet1.toByteArray(), Manifest.HashAlgorithm.HASH_SHA1);
+        String hexDigest1 = ManifestBuilder.CryptographicOperations.hexdigest(hash1);
+
+        clean();
+
+        Collections.shuffle(names);
+        StringBuilder src1 = new StringBuilder();
+        for (String l: names) {
+            src1.append(l);
+        }
+        List<Message> outputs2 = build("testHex.atlas", src1.toString());
+        TextureSet textureSet2 = getMessage(outputs2, TextureSet.class);
+
+        byte[] hash2 = ManifestBuilder.CryptographicOperations.hash(textureSet2.toByteArray(), Manifest.HashAlgorithm.HASH_SHA1);
+        String hexDigest2 = ManifestBuilder.CryptographicOperations.hexdigest(hash2);
+
+        assertEquals(hexDigest1, hexDigest2);
+    }
 }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/AtlasUtil.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/AtlasUtil.java
@@ -136,6 +136,19 @@ public class AtlasUtil {
         }
     }
 
+    private static void sortImages(List<AtlasImage> images) {
+        images.sort(new Comparator<AtlasImage>() {
+            @Override
+            public int compare(AtlasImage img1, AtlasImage img2) {
+                int nameComparison = img1.getImage().compareTo(img2.getImage());
+                if (nameComparison == 0) {
+                    return Integer.compare(img1.getSpriteTrimMode().getNumber(), img2.getSpriteTrimMode().getNumber());
+                }
+                return nameComparison;
+            }
+        });
+    }
+
     public static List<AtlasImage> collectImages(IResource atlasResource, Atlas atlas, PathTransformer transformer) throws CompileExceptionError {
         Map<AtlasImageSortKey, AtlasImage> uniqueImages = new HashMap<>();
         HashSet<String> uniqueNames = new HashSet<>();
@@ -169,18 +182,7 @@ public class AtlasUtil {
                 }
             }
         }
-
-        images.sort(new Comparator<AtlasImage>() {
-            @Override
-            public int compare(AtlasImage img1, AtlasImage img2) {
-                int nameComparison = img1.getImage().compareTo(img2.getImage());
-                if (nameComparison == 0) {
-                    return Integer.compare(img1.getSpriteTrimMode().getNumber(), img2.getSpriteTrimMode().getNumber());
-                }
-                return nameComparison;
-            }
-        });
-
+        sortImages(images);
         return images;
     }
 
@@ -269,7 +271,7 @@ public class AtlasUtil {
     }
 
     // These are for the Atlas animation
-    private static List<MappedAnimDesc> createAnimDescs(Atlas atlas, PathTransformer transformer, List<AtlasImage> atlasImages) throws CompileExceptionError {
+    private static List<MappedAnimDesc> createAnimDescs(Atlas atlas, PathTransformer transformer) throws CompileExceptionError {
         List<MappedAnimDesc> animDescs = new ArrayList<MappedAnimDesc>(atlas.getAnimationsCount() + atlas.getImagesCount());
         for (AtlasAnimation anim : atlas.getAnimationsList()) {
             List<String> framePaths = new ArrayList<String>();
@@ -286,7 +288,9 @@ public class AtlasUtil {
 
             animDescs.add(new MappedAnimDesc(anim.getId(), framePaths, frameIds, anim.getPlayback(), anim.getFps(), anim.getFlipHorizontal() != 0, anim.getFlipVertical() != 0));
         }
-        for (AtlasImage image : atlasImages) {
+        List<AtlasImage> images = new ArrayList<>(atlas.getImagesList());
+        sortImages(images);
+        for (AtlasImage image : images) {
             String id = transformer.transform(image.getImage());
             animDescs.add(new MappedAnimDesc(id, Collections.singletonList(image.getImage()), Collections.singletonList(id)));
         }
@@ -343,7 +347,7 @@ public class AtlasUtil {
             imageNames.add(imageName);
         }
 
-        List<MappedAnimDesc> animDescs = createAnimDescs(atlas, transformer, atlasImages);
+        List<MappedAnimDesc> animDescs = createAnimDescs(atlas, transformer);
         MappedAnimIterator iterator = new MappedAnimIterator(animDescs, imageResourcePaths);
         try {
             TextureSetResult result = TextureSetGenerator.generate(images, imageTrimModes, imageNames, iterator,
@@ -414,7 +418,7 @@ public class AtlasUtil {
 
         List<BufferedImage> imageDatas = loadImagesFromPaths(imageAbsolutePaths);
 
-        List<MappedAnimDesc> animDescs = createAnimDescs(atlas, nameTransformer, atlasImages);
+        List<MappedAnimDesc> animDescs = createAnimDescs(atlas, nameTransformer);
         MappedAnimIterator iterator = new MappedAnimIterator(animDescs, imagePaths);
         try {
             TextureSetResult result = TextureSetGenerator.generate(imageDatas, imageTrimModes, imageNames, iterator,

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/AtlasUtil.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/AtlasUtil.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.io.FileInputStream;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.HashMap;
@@ -168,6 +169,18 @@ public class AtlasUtil {
                 }
             }
         }
+
+        images.sort(new Comparator<AtlasImage>() {
+            @Override
+            public int compare(AtlasImage img1, AtlasImage img2) {
+                int nameComparison = img1.getImage().compareTo(img2.getImage());
+                if (nameComparison == 0) {
+                    return Integer.compare(img1.getSpriteTrimMode().getNumber(), img2.getSpriteTrimMode().getNumber());
+                }
+                return nameComparison;
+            }
+        });
+
         return images;
     }
 
@@ -256,7 +269,7 @@ public class AtlasUtil {
     }
 
     // These are for the Atlas animation
-    private static List<MappedAnimDesc> createAnimDescs(Atlas atlas, PathTransformer transformer) throws CompileExceptionError {
+    private static List<MappedAnimDesc> createAnimDescs(Atlas atlas, PathTransformer transformer, List<AtlasImage> atlasImages) throws CompileExceptionError {
         List<MappedAnimDesc> animDescs = new ArrayList<MappedAnimDesc>(atlas.getAnimationsCount() + atlas.getImagesCount());
         for (AtlasAnimation anim : atlas.getAnimationsList()) {
             List<String> framePaths = new ArrayList<String>();
@@ -273,7 +286,7 @@ public class AtlasUtil {
 
             animDescs.add(new MappedAnimDesc(anim.getId(), framePaths, frameIds, anim.getPlayback(), anim.getFps(), anim.getFlipHorizontal() != 0, anim.getFlipVertical() != 0));
         }
-        for (AtlasImage image : atlas.getImagesList()) {
+        for (AtlasImage image : atlasImages) {
             String id = transformer.transform(image.getImage());
             animDescs.add(new MappedAnimDesc(id, Collections.singletonList(image.getImage()), Collections.singletonList(id)));
         }
@@ -330,7 +343,7 @@ public class AtlasUtil {
             imageNames.add(imageName);
         }
 
-        List<MappedAnimDesc> animDescs = createAnimDescs(atlas, transformer);
+        List<MappedAnimDesc> animDescs = createAnimDescs(atlas, transformer, atlasImages);
         MappedAnimIterator iterator = new MappedAnimIterator(animDescs, imageResourcePaths);
         try {
             TextureSetResult result = TextureSetGenerator.generate(images, imageTrimModes, imageNames, iterator,
@@ -401,7 +414,7 @@ public class AtlasUtil {
 
         List<BufferedImage> imageDatas = loadImagesFromPaths(imageAbsolutePaths);
 
-        List<MappedAnimDesc> animDescs = createAnimDescs(atlas, nameTransformer);
+        List<MappedAnimDesc> animDescs = createAnimDescs(atlas, nameTransformer, atlasImages);
         MappedAnimIterator iterator = new MappedAnimIterator(animDescs, imagePaths);
         try {
             TextureSetResult result = TextureSetGenerator.generate(imageDatas, imageTrimModes, imageNames, iterator,


### PR DESCRIPTION
Fixes the issue where changing the order of images in an atlas without altering any content results in a different `*.a.texturesetc` file.

Fix https://github.com/defold/defold/issues/9370

## PR checklist

* [x] Code
	* [x] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [x] Add comments where needed
* [x] Documentation
	* [x] Make sure that API documentation is updated in code comments
	* [x] Make sure that manuals are updated (in github.com/defold/doc)
* [x] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [x] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
