### PR TITLE
Make sure that the api generator outputs the command for disoverability

### DIFF
--- a/build_tools/waf_dynamo.py
+++ b/build_tools/waf_dynamo.py
@@ -1538,6 +1538,9 @@ def detect(conf):
     if platform in ('x86_64-linux', 'x86_64-win32', 'x86_64-macos', 'arm64-macos'):
         conf.env['IS_TARGET_DESKTOP'] = 'true'
 
+    if host_platform in ('x86_64-linux', 'x86_64-win32', 'x86_64-macos', 'arm64-macos'):
+        conf.env['IS_HOST_DESKTOP'] = 'true'
+
     if platform in ('js-web', 'wasm-web') and not conf.env['NODEJS']:
         conf.find_program('node', var='NODEJS', mandatory = False)
 
@@ -1720,6 +1723,15 @@ def detect(conf):
     remove_flag(conf.env['shlib_CFLAGS'], '-current_version', 1)
     remove_flag(conf.env['shlib_CXXFLAGS'], '-compatibility_version', 1)
     remove_flag(conf.env['shlib_CXXFLAGS'], '-current_version', 1)
+
+    # Needed for api generation
+    if conf.env.IS_HOST_DESKTOP:
+        if not 'CLANG' in conf.env:
+            conf.find_program('clang',   var='CLANG', mandatory = True)
+            os.environ['CLANG'] = conf.env.CLANG[0]
+        if not 'CLANGPP' in conf.env:
+            conf.find_program('clang++', var='CLANGPP', mandatory = True)
+            os.environ['CLANGPP'] = conf.env.CLANGPP[0]
 
     # NOTE: We override after check_tool. Otherwise waf gets confused and CXX_NAME etc are missing..
     if platform in ('js-web', 'wasm-web'):

--- a/engine/jni/scripts/external/gen_ir.py
+++ b/engine/jni/scripts/external/gen_ir.py
@@ -209,13 +209,15 @@ def parse_inner_cpp(main_prefix, dep_prefixes, namespace, inp, outp):
 
 
 def clang(csrc_path, includes=[]):
-    cmd = ['clang', '-Xclang', '-ast-dump=json', '-c']
+    clang = os.environ.get('CLANG', 'clang')
+    cmd = [clang, '-Xclang', '-ast-dump=json', '-c']
     cmd.extend([ '-I%s' % include for include in includes])
     cmd.append(csrc_path)
     return run.command(cmd)
 
 def clang_cpp(csrc_path, includes=[]):
-    cmd = ['clang++', '-Xclang', '-ast-dump=json', '-c']
+    clangpp = os.environ.get('CLANGPP', 'clang++')
+    cmd = [clangpp, '-Xclang', '-ast-dump=json', '-c']
     cmd.extend([ '-I%s' % include for include in includes])
     cmd.append(csrc_path)
     return run.command(cmd)

--- a/engine/jni/scripts/external/gen_ir.py
+++ b/engine/jni/scripts/external/gen_ir.py
@@ -2,6 +2,7 @@
 #   Generate an intermediate representation of a clang AST dump.
 #-------------------------------------------------------------------------------
 import os, sys, json, subprocess
+import run
 
 def is_api_decl(decl, prefix):
     if 'type' in decl and decl['type']['qualType'].startswith(prefix):
@@ -211,13 +212,13 @@ def clang(csrc_path, includes=[]):
     cmd = ['clang', '-Xclang', '-ast-dump=json', '-c']
     cmd.extend([ '-I%s' % include for include in includes])
     cmd.append(csrc_path)
-    return subprocess.check_output(cmd)
+    return run.command(cmd)
 
 def clang_cpp(csrc_path, includes=[]):
     cmd = ['clang++', '-Xclang', '-ast-dump=json', '-c']
     cmd.extend([ '-I%s' % include for include in includes])
     cmd.append(csrc_path)
-    return subprocess.check_output(cmd)
+    return run.command(cmd)
 
 def gen(source_path, includes, module, main_prefix, dep_prefixes):
     ast = clang_cpp(source_path, includes)


### PR DESCRIPTION
## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
