### PR TITLE
Improved `Debug->Simulate Resolution` functionality

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -784,7 +784,7 @@
           launched-targets (for [instance-index instance-index-range]
                              (let [last-instance? (or (= count 1) (= instance-index count))
                                    instance-debug? (and debug? last-instance?)
-                                   launched-target (->> (engine/launch! engine project-directory prefs instance-debug? instance-index)
+                                   launched-target (->> (engine/launch! engine project-directory prefs workspace instance-debug? instance-index)
                                                         (decorate-target engine-descriptor)
                                                         (targets/add-launched-target! instance-index))]
                                (when (not last-instance?)

--- a/editor/src/clj/editor/debug_view.clj
+++ b/editor/src/clj/editor/debug_view.clj
@@ -632,6 +632,15 @@
   (state [app-view user-data prefs workspace]
          (= user-data (prefs/get-prefs prefs (prefs/make-project-specific-key "simulated-resolution" workspace) nil))))
 
+(handler/defhandler :reset-custom-resolution :global
+  (enabled? [] true)
+  (run [project prefs workspace]
+       (prefs/set-prefs prefs (prefs/make-project-specific-key "simulated-resolution" workspace) nil)
+       (let [project-settings (project/settings project)
+             width (get project-settings ["display" "width"])
+             height (get project-settings ["display" "height"])]
+         (change-resolution! prefs width height workspace))))
+
 (handler/defhandler :set-custom-resolution :global
   (enabled? [] true)
   (run [project app-view prefs build-errors-view selection user-data workspace]
@@ -683,7 +692,10 @@
                 :command :engine-resource-profile-show}
                {:label :separator}
                {:label "Simulate Resolution"
-                :children [{:label "Custom Resolution..."
+                :children [{:label "Reset Simulated Resolution"
+                            :command :reset-custom-resolution}
+                           {:label :separator}
+                           {:label "Custom Resolution..."
                             :command :set-custom-resolution
                             :check true}
                            {:label "Apple"

--- a/editor/src/clj/editor/debug_view.clj
+++ b/editor/src/clj/editor/debug_view.clj
@@ -612,17 +612,17 @@
             (current-session debug-view evaluation-context))
   (run [debug-view] (mobdebug/exit! (current-session debug-view))))
 
-(defn- should-rotate-device? [prefs workspace]
-  (prefs/get-prefs prefs (prefs/make-project-specific-key "should-rotate-device" workspace) false))
+(defn- simulate-rotated-device? [prefs workspace]
+  (prefs/get-prefs prefs (prefs/make-project-specific-key "simulate-rotated-device" workspace) false))
 
 (defn- change-resolution! [prefs width height workspace]
   (let [target (targets/selected-target prefs)
-        should-rotate-device? (should-rotate-device? prefs workspace)]
+        simulate-rotated-device? (simulate-rotated-device? prefs workspace)]
     (when target
       (if (targets/all-launched-targets? target)
         (doseq [launched-target (targets/all-launched-targets)]
-          (engine/change-resolution! launched-target width height should-rotate-device?))
-        (engine/change-resolution! target width height should-rotate-device?)))))
+          (engine/change-resolution! launched-target width height simulate-rotated-device?))
+        (engine/change-resolution! target width height simulate-rotated-device?)))))
 
 (defn- project-settings-screen-data [project]
   (let [project-settings (project/settings project)
@@ -642,6 +642,7 @@
   (enabled? [prefs workspace] (prefs/get-prefs prefs (prefs/make-project-specific-key "simulated-resolution" workspace) nil))
   (run [project prefs workspace]
        (prefs/set-prefs prefs (prefs/make-project-specific-key "simulated-resolution" workspace) nil)
+       (prefs/set-prefs prefs (prefs/make-project-specific-key "simulate-rotated-device" workspace) nil)
        (let [project-settings-data (project-settings-screen-data project)]
          (change-resolution! prefs (:width project-settings-data) (:height project-settings-data) workspace))))
 
@@ -660,11 +661,11 @@
 (handler/defhandler :set-rotate-device :global
   (enabled? [] true)
   (run [project app-view prefs build-errors-view selection user-data workspace]
-       (prefs/set-prefs prefs (prefs/make-project-specific-key "should-rotate-device" workspace) (not (should-rotate-device? prefs workspace)))
+       (prefs/set-prefs prefs (prefs/make-project-specific-key "simulate-rotated-device" workspace) (not (simulate-rotated-device? prefs workspace)))
        (let [data (prefs/get-prefs prefs (prefs/make-project-specific-key "simulated-resolution" workspace) nil)]
          (when data
            (change-resolution! prefs (:width data) (:height data) workspace))))
-  (state [app-view user-data prefs workspace] (should-rotate-device? prefs workspace)))
+  (state [app-view user-data prefs workspace] (simulate-rotated-device? prefs workspace)))
 
 (handler/defhandler :disabled-menu-label :global
   (enabled? [] false))

--- a/editor/src/clj/editor/debug_view.clj
+++ b/editor/src/clj/editor/debug_view.clj
@@ -736,6 +736,16 @@
                                                     :check true
                                                     :user-data {:width 414
                                                                 :height 896}}
+                                                   {:label "iPhone 12 Pro Max/13 Pro Max/14 Plus (428x926)"
+                                                    :command :set-resolution
+                                                    :check true
+                                                    :user-data {:width 428
+                                                                :height 926}}
+                                                   {:label "iPhone 14 Pro Max/15 Plus/15 Pro Max (430x932)"
+                                                    :command :set-resolution
+                                                    :check true
+                                                    :user-data {:width 430
+                                                                :height 932}}
                                                    {:label :separator}
                                                    {:label "Native Resolutions"
                                                     :command :disabled-menu-label}
@@ -759,12 +769,12 @@
                                                     :check true
                                                     :user-data {:width 1242
                                                                 :height 2208}}
-                                                   {:label "iPhone X/XS (1125x2436)"
+                                                   {:label "iPhone X/XS/11 Pro (1125x2436)"
                                                     :command :set-resolution
                                                     :check true
                                                     :user-data {:width 1125
                                                                 :height 2436}}
-                                                   {:label "iPhone XS Max (1242x2688)"
+                                                   {:label "iPhone XS Max/11 Pro Max (1242x2688)"
                                                     :command :set-resolution
                                                     :check true
                                                     :user-data {:width 1242
@@ -773,7 +783,17 @@
                                                     :command :set-resolution
                                                     :check true
                                                     :user-data {:width 828
-                                                                :height 1792}}]}
+                                                                :height 1792}}
+                                                   {:label "iPhone 12 Pro Max/13 Pro Max/14 Plus (1284x2778)"
+                                                    :command :set-resolution
+                                                    :check true
+                                                    :user-data {:width 1284
+                                                                :height 2778}}
+                                                   {:label "iPhone 14 Pro Max/15 Plus/15 Pro Max (1290x2796)"
+                                                    :command :set-resolution
+                                                    :check true
+                                                    :user-data {:width 1290
+                                                                :height 2796}}]}
                                        {:label "iPad"
                                         :children [{:label "Viewport Resolutions"
                                                     :command :disabled-menu-label}
@@ -866,6 +886,24 @@
                                         :check true
                                         :user-data {:width 1440
                                                     :height 2960}}]}
+                           {:label "Handheld"
+                            :children [{:label "Native Resolutions"
+                                        :command :disabled-menu-label}
+                                       {:label "1080p (1920x1080)"
+                                        :command :set-resolution
+                                        :check true
+                                        :user-data {:width 1920
+                                                    :height 1080}}
+                                       {:label "720p (1280x720)"
+                                        :command :set-resolution
+                                        :check true
+                                        :user-data {:width 1280
+                                                    :height 720}}
+                                       {:label "Steam Deck (1280x800)"
+                                        :command :set-resolution
+                                        :check true
+                                        :user-data {:width 1280
+                                                    :height 800}}]}
                            {:label "Rotated Device"
                             :command :set-rotate-device
                             :check true}]}]}])

--- a/editor/src/clj/editor/dialogs.clj
+++ b/editor/src/clj/editor/dialogs.clj
@@ -263,10 +263,10 @@
                           :text "Set Resolution"
                           :on-action {:event-type :confirm}}]}}))
 
-(defn make-resolution-dialog []
+(defn make-resolution-dialog [data]
   (fxui/show-dialog-and-await-result!
-    :initial-state {:width-text "320"
-                    :height-text "420"}
+    :initial-state {:width-text (str (or (:width data) "320"))
+                    :height-text (str (or (:height data) "420"))}
     :event-handler (fn [state {:keys [fx/event event-type]}]
                      (case event-type
                        :set-width (assoc state :width-text event)

--- a/editor/src/clj/editor/engine.clj
+++ b/editor/src/clj/editor/engine.clj
@@ -282,7 +282,7 @@
 
                      simulated-resolution
                      (into [(format "--config=display.width=%d" (:width simulated-resolution))
-                            (format "--config=display.height=%d"(:height simulated-resolution))]))
+                            (format "--config=display.height=%d" (:height simulated-resolution))]))
         env {"DM_SERVICE_PORT" "dynamic"
              "DM_QUIT_ON_ESC" (if (prefs/get-prefs prefs "general-quit-on-esc" false)
                                 "1" "0")

--- a/editor/src/clj/editor/engine.clj
+++ b/editor/src/clj/editor/engine.clj
@@ -84,6 +84,13 @@
       (finally
         (.disconnect conn)))))
 
+
+(defn apply-simulated-resolution! [prefs workspace target]
+  (let [data (prefs/get-prefs prefs (prefs/make-project-specific-key "simulated-resolution" workspace) nil)]
+    (when data
+      (change-resolution! target (:width data) (:height data)
+                          (prefs/get-prefs prefs (prefs/make-project-specific-key "should-rotate-device" workspace) false)))))
+
 (defn reboot! [target local-url debug?]
   (let [uri (URI. (format "%s/post/@system/reboot" (:url target)))
         conn ^HttpURLConnection (get-connection uri)
@@ -256,19 +263,11 @@
       (copy-dmengine-dependencies! engine-dir extender-platform)
       engine-file)))
 
-(defn simulated-resolution [prefs workspace]
-  (let [data (prefs/get-prefs prefs (prefs/make-project-specific-key "simulated-resolution" workspace) nil)]
-    (when data
-      (if (prefs/get-prefs prefs (prefs/make-project-specific-key "should-rotate-device" workspace) false)
-        {:width (:height data) :height (:width data)}
-        {:width (:width data) :height (:height data)}))))
-
 (defn launch! [^File engine project-directory prefs workspace debug? instance-index]
   (let [defold-log-dir (some-> (System/getProperty "defold.log.dir")
                                (File.)
                                (.getAbsolutePath))
         command (.getAbsolutePath engine)
-        simulated-resolution (simulated-resolution prefs workspace)
         args (cond-> []
                      defold-log-dir
                      (into ["--config=project.write_log=1"
@@ -278,11 +277,7 @@
                      (into ["--config=bootstrap.debug_init_script=/_defold/debugger/start.luac"])
 
                      (> instance-index 0)
-                     (into [(format "--config=project.instance_index=%d" instance-index)])
-
-                     simulated-resolution
-                     (into [(format "--config=display.width=%d" (:width simulated-resolution))
-                            (format "--config=display.height=%d" (:height simulated-resolution))]))
+                     (into [(format "--config=project.instance_index=%d" instance-index)]))
         env {"DM_SERVICE_PORT" "dynamic"
              "DM_QUIT_ON_ESC" (if (prefs/get-prefs prefs "general-quit-on-esc" false)
                                 "1" "0")

--- a/editor/src/clj/editor/engine.clj
+++ b/editor/src/clj/editor/engine.clj
@@ -89,7 +89,7 @@
   (let [data (prefs/get-prefs prefs (prefs/make-project-specific-key "simulated-resolution" workspace) nil)]
     (when data
       (change-resolution! target (:width data) (:height data)
-                          (prefs/get-prefs prefs (prefs/make-project-specific-key "should-rotate-device" workspace) false)))))
+                          (prefs/get-prefs prefs (prefs/make-project-specific-key "simulate-rotated-device" workspace) false)))))
 
 (defn reboot! [target local-url debug?]
   (let [uri (URI. (format "%s/post/@system/reboot" (:url target)))

--- a/editor/src/clj/editor/targets.clj
+++ b/editor/src/clj/editor/targets.clj
@@ -120,11 +120,10 @@
     (reset! launched-targets
             (map (fn [launched-target]
                    (if (= (:id launched-target) (:id target))
-                     (do
-                       (let [result-target (merge launched-target target-info)]
-                         (when (and (:url target-info) (not (:url launched-target)))
-                           (on-service-url-found result-target))
-                       result-target))
+                     (let [result-target (merge launched-target target-info)]
+                       (when (and (:url target-info) (not (:url launched-target)))
+                         (on-service-url-found result-target))
+                       result-target)
                      launched-target))
                  old))
     (when (not= old @launched-targets)

--- a/editor/src/clj/editor/targets.clj
+++ b/editor/src/clj/editor/targets.clj
@@ -115,12 +115,16 @@
       (callback url)
       (add-watch launched-targets [::url id callback] (url-watcher id callback)))))
 
-(defn update-launched-target! [target target-info]
+(defn update-launched-target! [target target-info on-service-url-found]
   (let [old @launched-targets]
     (reset! launched-targets
             (map (fn [launched-target]
                    (if (= (:id launched-target) (:id target))
-                     (merge launched-target target-info)
+                     (do
+                       (let [result-target (merge launched-target target-info)]
+                         (when (and (:url target-info) (not (:url launched-target)))
+                           (on-service-url-found result-target))
+                       result-target))
                      launched-target))
                  old))
     (when (not= old @launched-targets)


### PR DESCRIPTION
A few improvements were made to the `Debug->Simulate Resolution` functionality in the editor:
* The selected resolution is now saved for a project, including custom resolutions.
* The selected resolution is applied every time the engine starts.
* A few new iPhone devices and a new "Handheld" section were added.
* Resolution simulation now works for all launched instances.

Fix https://github.com/defold/defold/issues/8130

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
