### PR TITLE
Mouse lock regression

### DIFF
--- a/engine/platform/src/platform_window_glfw3.cpp
+++ b/engine/platform/src/platform_window_glfw3.cpp
@@ -540,7 +540,15 @@ namespace dmPlatform
     {
         if (state == DEVICE_STATE_CURSOR)
         {
-            glfwSetInputMode(window->m_Window, GLFW_CURSOR, op1 ? GLFW_CURSOR_NORMAL : GLFW_CURSOR_HIDDEN);
+            if (op1)
+            {
+                glfwSetInputMode(window->m_Window, GLFW_CURSOR, GLFW_CURSOR_NORMAL);
+            }
+            else
+            {
+                glfwSetInputMode(window->m_Window, GLFW_CURSOR, GLFW_CURSOR_HIDDEN);
+                glfwSetInputMode(window->m_Window, GLFW_CURSOR, GLFW_CURSOR_DISABLED);
+            }
         }
     }
 


### PR DESCRIPTION
Fixed a regression issue where `window.set_mouse_lock(true)` didn't lock the mouse to the window.

Fixes #9323 

