### PR TITLE
Fix the issue where the hash script property can't be reversed

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/LuaScannerTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/LuaScannerTest.java
@@ -507,4 +507,32 @@ public class LuaScannerTest {
         expected = "  ";
         assertEquals(expected, scanner.getParsedLua());
     }
+
+    @Test
+    public void testGoPropertyHash() throws Exception {
+        String luaCode = "go.property(\"semi1\", hash(\"value\"))";
+        LuaScanner scanner = new LuaScanner();
+        scanner.parse(luaCode);
+        String expected = " ";
+        assertEquals(expected, scanner.getParsedLua());
+
+        scanner = new LuaScanner();
+        scanner.setDebug();
+        scanner.parse(luaCode);
+        expected = " hash(\"value\")";
+        assertEquals(expected, scanner.getParsedLua());
+
+        luaCode = "go.property(\"semi1\", hash \"value\")";
+        scanner = new LuaScanner();
+        scanner.parse(luaCode);
+        expected = "  ";
+        assertEquals(expected, scanner.getParsedLua());
+
+        luaCode = "go.property(\"semi1\", hash \"value\")";
+        scanner = new LuaScanner();
+        scanner.setDebug();
+        scanner.parse(luaCode);
+        expected = " hash \"value\"";
+        assertEquals(expected, scanner.getParsedLua());
+    }
 }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/LuaBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/LuaBuilder.java
@@ -108,6 +108,10 @@ public abstract class LuaBuilder extends Builder {
             }
 
             scanner = new LuaScanner();
+            if (variant == Bob.VARIANT_DEBUG)
+            {
+                scanner.setDebug();
+            }
             scanner.parse(script);
             luaScanners.put(path, scanner);
         }

--- a/editor/src/clj/editor/code/script_compilation.clj
+++ b/editor/src/clj/editor/code/script_compilation.clj
@@ -160,40 +160,34 @@
                   (assert (not (neg? paren-count)))
                   (if (pos? paren-count)
                     (recur cursor-ranges (next tokens) paren-count consumed skipped)
-                    (if (nil? skipped)
-                      (let [next-tokens (next tokens)
-                           [next-text :as next-token] (first next-tokens)
-                           [_ start-row start-col] (first consumed)
-                           [end-text end-row end-col] (if (= ";" next-text) next-token token)
-                           end-col (+ ^long end-col (count end-text))
-                           start-cursor (data/->Cursor start-row start-col)
-                           end-cursor (data/->Cursor end-row end-col)
-                           cursor-range (data/->CursorRange start-cursor end-cursor)]
-                       (recur (conj! cursor-ranges cursor-range)
-                              next-tokens
-                              0
-                              []
-                              nil))
-                      (let [next-tokens (next tokens)
-                            [next-text :as next-token] (first next-tokens)
-                            [_ start-row start-col] (first consumed)
-                            [_ end-row end-col] skipped
-                            end-col (- ^long end-col 1)
-                            start-cursor (data/->Cursor start-row start-col)
-                            end-cursor (data/->Cursor end-row end-col)
-                            cursor-range (data/->CursorRange start-cursor end-cursor)
-                            new-cursor-ranges (conj! cursor-ranges cursor-range)
-                            [_ start-row start-col] token
-                            [end-text end-row end-col] (if (= ";" next-text) next-token token)
-                            end-col (+ ^long end-col (count end-text))
-                            start-cursor (data/->Cursor start-row start-col)
-                            end-cursor (data/->Cursor end-row end-col)
-                            cursor-range (data/->CursorRange start-cursor end-cursor)]
-                        (recur (conj! new-cursor-ranges cursor-range)
-                               next-tokens
-                               0
-                               []
-                               nil)))))
+                    (let [next-tokens (next tokens)
+                          [next-text :as next-token] (first next-tokens)
+                          [_ start-row start-col] (first consumed)
+                          [end-text end-row end-col] (if (= ";" next-text) next-token token)
+                          end-col (+ ^long end-col (count end-text))
+                          end-cursor (data/->Cursor end-row end-col)
+                          start-cursor (data/->Cursor start-row start-col)]
+                      (if (nil? skipped)
+                        (let [cursor-range (data/->CursorRange start-cursor end-cursor)]
+                          (recur (conj! cursor-ranges cursor-range)
+                                 next-tokens
+                                 0
+                                 []
+                                 nil))
+                        (let [
+                              [_ end-row-skipped end-col-skipped] skipped
+                              end-col-skipped (- ^long end-col-skipped 1)
+                              end-cursor-before-skipped (data/->Cursor end-row-skipped end-col-skipped)
+                              cursor-range-before-skipped (data/->CursorRange start-cursor end-cursor-before-skipped)
+                              new-cursor-ranges (conj! cursor-ranges cursor-range-before-skipped)
+                              [_ start-row-after-skipped start-col-after-skipped] token
+                              start-cursor-after-skipped (data/->Cursor start-row-after-skipped start-col-after-skipped)
+                              cursor-range (data/->CursorRange start-cursor-after-skipped end-cursor)]
+                          (recur (conj! new-cursor-ranges cursor-range)
+                                 next-tokens
+                                 0
+                                 []
+                                 nil))))))
             "hash" (recur cursor-ranges (next tokens) paren-count consumed token)
             (recur cursor-ranges (next tokens) paren-count consumed skipped)))
       (persistent! cursor-ranges))))

--- a/editor/src/clj/editor/code/script_compilation.clj
+++ b/editor/src/clj/editor/code/script_compilation.clj
@@ -174,8 +174,7 @@
                                  0
                                  []
                                  nil))
-                        (let [
-                              [_ end-row-skipped end-col-skipped] skipped
+                        (let [[_ end-row-skipped end-col-skipped] skipped
                               end-col-skipped (- ^long end-col-skipped 1)
                               end-cursor-before-skipped (data/->Cursor end-row-skipped end-col-skipped)
                               cursor-range-before-skipped (data/->CursorRange start-cursor end-cursor-before-skipped)

--- a/editor/src/clj/editor/code/script_compilation.clj
+++ b/editor/src/clj/editor/code/script_compilation.clj
@@ -147,31 +147,55 @@
   (loop [cursor-ranges (transient [])
          tokens (lua-parser/tokens (data/lines-reader lines))
          paren-count 0
-         consumed []]
+         consumed []
+         skipped nil]
     (if-some [[text :as token] (first tokens)]
       (case (count consumed)
-        0 (recur cursor-ranges (next tokens) 0 (case text "go" (conj consumed token) []))
-        1 (recur cursor-ranges (next tokens) 0 (case text "." (conj consumed token) []))
-        2 (recur cursor-ranges (next tokens) 0 (case text "property" (conj consumed token) []))
+        0 (recur cursor-ranges (next tokens) 0 (case text "go" (conj consumed token) []) skipped)
+        1 (recur cursor-ranges (next tokens) 0 (case text "." (conj consumed token) []) skipped)
+        2 (recur cursor-ranges (next tokens) 0 (case text "property" (conj consumed token) []) skipped)
         3 (case text
-            "(" (recur cursor-ranges (next tokens) (inc paren-count) consumed)
+            "(" (recur cursor-ranges (next tokens) (inc paren-count) consumed skipped)
             ")" (let [paren-count (dec paren-count)]
                   (assert (not (neg? paren-count)))
                   (if (pos? paren-count)
-                    (recur cursor-ranges (next tokens) paren-count consumed)
-                    (let [next-tokens (next tokens)
-                          [next-text :as next-token] (first next-tokens)
-                          [_ start-row start-col] (first consumed)
-                          [end-text end-row end-col] (if (= ";" next-text) next-token token)
-                          end-col (+ ^long end-col (count end-text))
-                          start-cursor (data/->Cursor start-row start-col)
-                          end-cursor (data/->Cursor end-row end-col)
-                          cursor-range (data/->CursorRange start-cursor end-cursor)]
-                      (recur (conj! cursor-ranges cursor-range)
-                             next-tokens
-                             0
-                             []))))
-            (recur cursor-ranges (next tokens) paren-count consumed)))
+                    (recur cursor-ranges (next tokens) paren-count consumed skipped)
+                    (if (nil? skipped)
+                      (let [next-tokens (next tokens)
+                           [next-text :as next-token] (first next-tokens)
+                           [_ start-row start-col] (first consumed)
+                           [end-text end-row end-col] (if (= ";" next-text) next-token token)
+                           end-col (+ ^long end-col (count end-text))
+                           start-cursor (data/->Cursor start-row start-col)
+                           end-cursor (data/->Cursor end-row end-col)
+                           cursor-range (data/->CursorRange start-cursor end-cursor)]
+                       (recur (conj! cursor-ranges cursor-range)
+                              next-tokens
+                              0
+                              []
+                              nil))
+                      (let [next-tokens (next tokens)
+                            [next-text :as next-token] (first next-tokens)
+                            [_ start-row start-col] (first consumed)
+                            [_ end-row end-col] skipped
+                            end-col (- ^long end-col 1)
+                            start-cursor (data/->Cursor start-row start-col)
+                            end-cursor (data/->Cursor end-row end-col)
+                            cursor-range (data/->CursorRange start-cursor end-cursor)
+                            new-cursor-ranges (conj! cursor-ranges cursor-range)
+                            [_ start-row start-col] token
+                            [end-text end-row end-col] (if (= ";" next-text) next-token token)
+                            end-col (+ ^long end-col (count end-text))
+                            start-cursor (data/->Cursor start-row start-col)
+                            end-cursor (data/->Cursor end-row end-col)
+                            cursor-range (data/->CursorRange start-cursor end-cursor)]
+                        (recur (conj! new-cursor-ranges cursor-range)
+                               next-tokens
+                               0
+                               []
+                               nil)))))
+            "hash" (recur cursor-ranges (next tokens) paren-count consumed token)
+            (recur cursor-ranges (next tokens) paren-count consumed skipped)))
       (persistent! cursor-ranges))))
 
 (defn- cursor-range->whitespace-lines [lines cursor-range]

--- a/editor/test/editor/code/script_test.clj
+++ b/editor/test/editor/code/script_test.clj
@@ -245,7 +245,7 @@
     ["             "]
 
     ["go.property('name', hash())"]
-    ["                           "]
+    ["                    hash() "]
 
     ["go.property('name', resource.texture('/image.png'))"]
     ["                                                   "]


### PR DESCRIPTION
Hash values can be reversed to their string equivalents in Debug builds, simplifying the development process. This fix makes hashes added in `go.property()` reversible as well.

Fix https://github.com/defold/defold/issues/7422
## PR checklist

* [x] Code
	* [x] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [x] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [x] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
