### PR TITLE
Merge custom and default editor keybindnings instead of replacing them

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -1892,7 +1892,7 @@ If you do not specifically require different script states, consider changing th
 (defn open-custom-keymap
   [path]
   (try (and (not= path "")
-            (some-> path
+            (some-> (str (System/getProperty "user.home") "/" path)
                     slurp
                     edn/read-string))
        (catch Exception e
@@ -1906,14 +1906,19 @@ If you do not specifically require different script states, consider changing th
          (log/error :exception e)
          nil)))
 
+(defn- merge-keymaps [prefs]
+  (let [custom-keymap (or (open-custom-keymap (prefs/get-prefs prefs "custom-keymap-path" "")) [])
+        default-keymap keymap/default-host-key-bindings
+        merged-keymap (concat custom-keymap default-keymap)]
+      merged-keymap))
+
 (defn make-app-view [view-graph project ^Stage stage ^MenuBar menu-bar ^SplitPane editor-tabs-split ^TabPane tool-tab-pane prefs]
   (let [app-scene (.getScene stage)]
     (ui/disable-menu-alt-key-mnemonic! menu-bar)
     (.setUseSystemMenuBar menu-bar true)
     (.setTitle stage (make-title))
     (let [editor-tab-pane (TabPane.)
-          keymap (or (open-custom-keymap (prefs/get-prefs prefs "custom-keymap-path" ""))
-                     keymap/default-host-key-bindings)
+          keymap (merge-keymaps prefs)
           app-view (first (g/tx-nodes-added (g/transact (g/make-node view-graph AppView
                                                                      :stage stage
                                                                      :scene app-scene

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -1908,9 +1908,11 @@ If you do not specifically require different script states, consider changing th
 
 (defn- merge-keymaps [prefs]
   (let [custom-keymap (or (open-custom-keymap (prefs/get-prefs prefs "custom-keymap-path" "")) [])
-        default-keymap keymap/default-host-key-bindings
-        merged-keymap (concat custom-keymap default-keymap)]
-      merged-keymap))
+        default-keymap keymap/default-host-key-bindings]
+    (into []
+      (mapcat val)
+      (conj (group-by first default-keymap)
+            (group-by first custom-keymap)))))
 
 (defn make-app-view [view-graph project ^Stage stage ^MenuBar menu-bar ^SplitPane editor-tabs-split ^TabPane tool-tab-pane prefs]
   (let [app-scene (.getScene stage)]

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -1892,7 +1892,7 @@ If you do not specifically require different script states, consider changing th
 (defn open-custom-keymap
   [path]
   (try (and (not= path "")
-            (some-> (str (System/getProperty "user.home") "/" path)
+            (some-> path
                     slurp
                     edn/read-string))
        (catch Exception e


### PR DESCRIPTION
Custom keybindings will now be merged with/added to the defaults instead of completely replacing the defaults.

Fixes #9433 

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
