### PR TITLE
New vmath functions

### DIFF
--- a/engine/gameobject/src/gameobject/test/hierarchy/transform.script
+++ b/engine/gameobject/src/gameobject/test/hierarchy/transform.script
@@ -17,7 +17,7 @@ local EPSILON = 0.001
 function make_transform(p,r,s)
 	local trans = vmath.matrix4()
 	local scale = vmath.matrix4()
-	local rot   = vmath.matrix4_from_quat(r)
+	local rot   = vmath.matrix4_quat(r)
 
 	scale.m00 = s.x
 	scale.m11 = s.y

--- a/engine/script/src/script.h
+++ b/engine/script/src/script.h
@@ -283,6 +283,15 @@ namespace dmScript
      */
     bool IsVector(lua_State *L, int index);
 
+    /*# get the value at index as a dmVMath::FloatVector*
+     * Get the value at index as a dmVMath::FloatVector*
+     * @name dmScript::ToVector
+     * @param L [type:lua_State*] Lua state
+     * @param index [type:int] Index of the value
+     * @return v [type:dmVMath::FloatVector*] The pointer to the value, or 0 if not correct type
+     */
+    dmVMath::FloatVector* ToVector(lua_State *L, int index);
+
     /**
      * Push a FloatVector value onto the supplied lua state, will increase the stack by 1.
      * @param L Lua state

--- a/engine/script/src/script_vmath.cpp
+++ b/engine/script/src/script_vmath.cpp
@@ -2481,12 +2481,63 @@ namespace dmScript
      * print(result) --> vmath.matrix4(1, 0, 0, 0, 0, 0.5, 0, 0, 0, 0, 0.5, 0, 0, 0, 0, 1)
      * ```
      */
+
+    /*# creates a new matrix4 from uniform scale
+     *
+     * creates a new matrix4 from uniform scale
+     *
+     * @name vmath.matrix4_scale
+     * @param scale [type:number] scale
+     * @return matrix [type:matrix4] new matrix4
+     * @examples
+     *
+     * ```lua
+     * local result = vmath.matrix4_scale(0.5)
+     * print(result) --> vmath.matrix4(0.5, 0, 0, 0, 0, 0.5, 0, 0, 0, 0, 0.5, 0, 0, 0, 0, 1)
+     * ```
+     */
+
+    /*# creates a new matrix4 from three scale components
+     *
+     * Creates a new matrix4 from three scale components
+     *
+     * @name vmath.matrix4_scale
+     * @param scale_x [type:number] scale along X axis
+     * @param scale_y [type:number] sclae along Y axis
+     * @param scale_z [type:number] scale along Z asis
+     * @return matrix [type:matrix4] new matrix4
+     * @examples
+     *
+     * ```lua
+     * local result = vmath.matrix4_scale(1, 0.5, 0.5)
+     * print(result) --> vmath.matrix4(1, 0, 0, 0, 0, 0.5, 0, 0, 0, 0, 0.5, 0, 0, 0, 0, 1)
+     * ```
+     */
     static int Matrix4_Scale(lua_State* L)
     {
-        Vector3* scale = CheckVector3(L, 1);
-        Matrix4 result = Matrix4::scale(*scale);
-        PushMatrix4(L, result);
-        return 1;
+        if (lua_isnumber(L, 1))
+        {
+            float x, y, z;
+            x = (float) luaL_checknumber(L, 1);
+            if (lua_isnumber(L, 2) && lua_isnumber(L, 3))
+            {
+                y = (float) luaL_checknumber(L, 2);
+                z = (float) luaL_checknumber(L, 3);
+            }
+            else
+            {
+                y = x; z = x;
+            }
+            PushMatrix4(L, Matrix4::scale(Vector3(x, y, z)));
+        }
+        else
+        {
+            Vector3* scale = CheckVector3(L, 1);
+            Matrix4 result = Matrix4::scale(*scale);
+            PushMatrix4(L, result);
+            return 1;
+        }
+        return luaL_error(L, "First argument should be number or vector3");
     }
 
     /*# clamp input value in range [min, max] and return clamped value

--- a/engine/script/src/script_vmath.cpp
+++ b/engine/script/src/script_vmath.cpp
@@ -2519,7 +2519,7 @@ namespace dmScript
         {
             float x, y, z;
             x = (float) luaL_checknumber(L, 1);
-            if (lua_isnumber(L, 2) && lua_isnumber(L, 3))
+            if (lua_gettop(L) == 3)
             {
                 y = (float) luaL_checknumber(L, 2);
                 z = (float) luaL_checknumber(L, 3);
@@ -2542,26 +2542,24 @@ namespace dmScript
 
     /*# clamp input value in range [min, max] and return clamped value
      *
-     * Clamp input value to be in range of [min, max]. In case if input value has vector|vector3|vector4 type
-     * return new vector|vector3|vector4 with clamped value at every vector's element.
-     * Min/max arguments can be vector|vector3|vector4. In that case clamp excuted per every vector's element
+     * Clamp input value to be in range of [min, max]. In case if input value has vector3|vector4 type
+     * return new vector3|vector4 with clamped value at every vector's element.
+     * Min/max arguments can be vector3|vector4. In that case clamp excuted per every vector's element
      *
      * @name vmath.clamp
-     * @param value [type:number|vector3|vector4|vector] Input value or vector of values
-     * @param min [type:number|vector3|vector4|vector] Min value(s) border
-     * @param max [type:number|vector3|vector4|vector] Max value(s) border
-     * @return clamped_value [type:number|vector3|vector4|vector] Clamped value or vector
+     * @param value [type:number|vector3|vector4] Input value or vector of values
+     * @param min [type:number|vector3|vector4] Min value(s) border
+     * @param max [type:number|vector3|vector4] Max value(s) border
+     * @return clamped_value [type:number|vector3|vector4] Clamped value or vector
      * @example
      * 
      * ```lua
      * local value1 = 56
-	 * print(vmath.clamp(value1, 89, 134)) -> 89
-	 * local v1 = vmath.vector({ -45, 34, 13, 10, 55 })
-	 * print(vmath.clamp(v1, 0, 15)) -> vmath.vector (size: 5)
-	 * local v2 = vmath.vector3(190, 190, -10)
-	 * print(vmath.clamp(v2, -50, 150)) -> vmath.vector3(150, 150, -10)
-	 * local v3 = vmath.vector4(30, -30, 45, 1)
-	 * print(vmath.clamp(v3, 0, 20)) -> vmath.vector4(20, 0, 20, 1)
+     * print(vmath.clamp(value1, 89, 134)) -> 89
+     * local v2 = vmath.vector3(190, 190, -10)
+     * print(vmath.clamp(v2, -50, 150)) -> vmath.vector3(150, 150, -10)
+     * local v3 = vmath.vector4(30, -30, 45, 1)
+     * print(vmath.clamp(v3, 0, 20)) -> vmath.vector4(20, 0, 20, 1)
      * 
      * local min_v = vmath.vector4(0, -10, -10, 1)
      * print(vmath.clamp(v3, min_v, 20)) -> vmath.vector4(20, -10, 20, 1)
@@ -2640,50 +2638,10 @@ namespace dmScript
                 dmMath::Clamp(value->getW(), min_v.getW(), max_v.getW())
             ));
         }
-        else if  (argument_type == SCRIPT_TYPE_VECTOR)
-        {
-            FloatVector* value = (FloatVector*)argument;
-            FloatVector* result = new FloatVector(value->size);
-
-            float min_float, max_float;
-            FloatVector *min_v, *max_v;
-            if (argument2_type == LUA_TNUMBER)
-            {
-                min_float = (float) luaL_checknumber(L, 2);
-            }
-            else
-            {
-                min_v = CheckVector(L, 2);
-                if (min_v->size != value->size)
-                {
-                    return luaL_error(L, "argument #2 vector size must be equal to argument #1 vector size");
-                }
-            }
-            if (argument3_type == LUA_TNUMBER)
-            {
-                max_float = (float) luaL_checknumber(L, 3);
-            }
-            else
-            {
-                max_v = CheckVector(L, 3);
-                if (max_v->size != value->size)
-                {
-                    return luaL_error(L, "argument #3 vector size must be equal to argument #1 vector size");
-                }
-            }
-
-            for (size_t idx = 0; idx < result->size; ++idx)
-            {
-                float min = argument2_type == LUA_TNUMBER ? min_float : min_v->values[idx];
-                float max = argument3_type == LUA_TNUMBER ? max_float : max_v->values[idx];
-                result->values[idx] = dmMath::Clamp(result->values[idx], min, max);
-            }
-            PushVector(L, result);
-        }
         else
         {
-            return luaL_error(L, "%s.%s accepts (%s|%s|%s|%s) as argument.", SCRIPT_LIB_NAME, "clamp",
-                            "number", SCRIPT_TYPE_NAME_VECTOR3, SCRIPT_TYPE_NAME_VECTOR4, SCRIPT_TYPE_NAME_VECTOR);
+            return luaL_error(L, "%s.%s accepts (%s|%s|%s) as argument.", SCRIPT_LIB_NAME, "clamp",
+                            "number", SCRIPT_TYPE_NAME_VECTOR3, SCRIPT_TYPE_NAME_VECTOR4);
         }
         return 1;
     }

--- a/engine/script/src/script_vmath.cpp
+++ b/engine/script/src/script_vmath.cpp
@@ -145,7 +145,7 @@ namespace dmScript
         }
         if ((*userdata = (void*)dmScript::ToVector3(L, index)))
         {
-            Vector3* v = (Vector3*)userdata;
+            Vector3* v = (Vector3*)*userdata;
             if (!CheckVector3Components(v))
             {
                 luaL_error(L, "argument #%d contains one or more values which are not numbers: vmath.vector3(%f, %f, %f)", index, v->getX(), v->getY(), v->getZ());
@@ -155,7 +155,7 @@ namespace dmScript
         }
         else if ((*userdata = (void*)dmScript::ToVector4(L, index)))
         {
-            Vector4* v = (Vector4*)userdata;
+            Vector4* v = (Vector4*)*userdata;
             if (!CheckVector4Components(v))
             {
                 luaL_error(L, "argument #%d contains one or more values which are not numbers: vmath.vector4(%f, %f, %f, %f)", index, v->getX(), v->getY(), v->getZ(), v->getW());
@@ -169,7 +169,7 @@ namespace dmScript
         }
         else if ((*userdata = (void*)dmScript::ToQuat(L, index)))
         {
-            Quat* q = (Quat*)userdata;
+            Quat* q = (Quat*)*userdata;
             if (!CheckQuatComponents(q))
             {
                 luaL_error(L, "argument #%d contains one or more values which are not numbers: vmath.quat(%f, %f, %f, %f)", index, q->getX(), q->getY(), q->getZ(), q->getW());
@@ -179,7 +179,7 @@ namespace dmScript
         }
         else if ((*userdata = (void*)dmScript::ToMatrix4(L, index)))
         {
-            Matrix4* m = (Matrix4*)userdata;
+            Matrix4* m = (Matrix4*)*userdata;
             if (!CheckMatrix4Components(m))
             {
                 luaL_error(L, "argument #%d contains one or more values which are not numbers: vmath.matrix4(%f, %f, %f, %f, %f, %f, %f, %f, %f, %f, %f, %f, %f, %f, %f, %f)", index,

--- a/engine/script/src/test/test_script_vmath.cpp
+++ b/engine/script/src/test/test_script_vmath.cpp
@@ -368,6 +368,11 @@ TEST_F(ScriptVmathTest, TestToValueFn)
     ASSERT_EQ(top, lua_gettop(L));
 }
 
+TEST_F(ScriptVmathTest, TestVMathClamp)
+{
+    ASSERT_TRUE(RunFile(L, "test_script_vmath.luac"));
+}
+
 extern "C" void dmExportedSymbols();
 
 int main(int argc, char **argv)

--- a/engine/script/src/test/test_script_vmath.cpp
+++ b/engine/script/src/test/test_script_vmath.cpp
@@ -206,6 +206,8 @@ TEST_F(ScriptVmathTest, TestQuatFail)
     ASSERT_FALSE(RunString(L, "local q = vmath.lerp(1, vmath.quat(0, 0, 0, 1), vmath.vector3(0, 0, 0))"));
     // Slerp
     ASSERT_FALSE(RunString(L, "local q = vmath.slerp(1, vmath.quat(0, 0, 0, 1), vmath.vector3(0, 0, 0))"));
+    // From matrix4
+    ASSERT_FALSE(RunString(L, "local q = vmath.quat_matrix4()"));
 }
 
 TEST_F(ScriptVmathTest, TestTransform)
@@ -292,6 +294,10 @@ TEST_F(ScriptVmathTest, TestMatrix4Fail)
     ASSERT_FALSE(RunString(L, "local m = vmath.matrix4() * true"));
     // translation
     ASSERT_FALSE(RunString(L, "local m = vmath.matrix4_translation()"));
+    // scale
+    ASSERT_FALSE(RunString(L, "local m = vmath.matrix4_scale()"));
+    // compose
+    ASSERT_FALSE(RunString(L, "local m = vmath.matrix4_compose()"));
 }
 
 

--- a/engine/script/src/test/test_script_vmath.lua
+++ b/engine/script/src/test/test_script_vmath.lua
@@ -1,0 +1,54 @@
+-- Copyright 2020-2024 The Defold Foundation
+-- Copyright 2014-2020 King
+-- Copyright 2009-2014 Ragnar Svensson, Christian Murray
+-- Licensed under the Defold License version 1.0 (the "License"); you may not use
+-- this file except in compliance with the License.
+-- 
+-- You may obtain a copy of the License, together with FAQs at
+-- https://www.defold.com/license
+-- 
+-- Unless required by applicable law or agreed to in writing, software distributed
+-- under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+-- CONDITIONS OF ANY KIND, either express or implied. See the License for the
+-- specific language governing permissions and limitations under the License.
+
+--- clamp function
+
+local num1 = 34
+local num2 = -17.8
+local num3 = 87.9
+assert(vmath.clamp(num1, 0, 50) == 34)
+assert(vmath.clamp(num2, 0, 50) == 0)
+assert(vmath.clamp(num3, 0, 50) == 50)
+
+local vec3_1 = vmath.vector3(-345, 55.6, -0.5)
+local vec3_2 = vmath.vector3(167, 23, 1.3)
+local vec3_3 = vmath.vector3(189.3, 333, 1)
+local vec3_min = vmath.vector3(-12, -22, 0)
+local vec3_max = vmath.vector3(125, 65, 1)
+
+
+assert(vmath.clamp(vec3_1, vec3_min, vec3_max) == vmath.vector3(-12, 55.6, 0))
+assert(vmath.clamp(vec3_2, vec3_min, vec3_max) == vmath.vector3(125, 23, 1))
+
+print(vmath.clamp(vec3_3, vec3_min, vec3_max))
+assert(vmath.clamp(vec3_3, vec3_min, vec3_max) == vmath.vector3(125, 65, 1))
+assert(vmath.clamp(vec3_3, 0, 1) == vmath.vector3(1, 1, 1))
+
+local vec4_1 = vmath.vector4(1, 2, 3, 4)
+local vec4_2 = vmath.vector4(-0.5, -0.3, -0.1, 0)
+local vec4_3 = vmath.vector4(34.3, 22.1, 90.4, 1)
+local vec4_min = vmath.vector4(0, 0, 0, 1)
+local vec4_max = vmath.vector4(5, 5, 5, 1)
+
+print(vmath.clamp(vec4_1, vec4_min, vec4_max))
+assert(vmath.clamp(vec4_1, vec4_min, vec4_max) == vmath.vector4(1, 2, 3, 1))
+
+print(vmath.clamp(vec4_2, vec4_min, vec4_max))
+assert(vmath.clamp(vec4_2, vec4_min, vec4_max) == vmath.vector4(0, 0, 0, 1))
+
+print(vmath.clamp(vec4_3, vec4_min, vec4_max))
+assert(vmath.clamp(vec4_3, vec4_min, vec4_max) == vmath.vector4(5, 5, 5, 1))
+
+print(vmath.clamp(vec4_1, 86.2, 200.1))
+assert(vmath.clamp(vec4_1, 86.2, 200.1) == vmath.vector4(86.2, 86.2, 86.2, 86.2))

--- a/engine/script/src/test/wscript
+++ b/engine/script/src/test/wscript
@@ -58,7 +58,7 @@ def build(bld):
                                      exported_symbols = exported_symbols,
                                      proto_gen_py = True,
                                      target = 'test_script_vmath',
-                                     source = 'test_script_vmath.cpp test_number.lua test_vector.lua test_vector3.lua test_vector4.lua test_quat.lua test_matrix4.lua'.split())
+                                     source = 'test_script_vmath.cpp test_number.lua test_vector.lua test_vector3.lua test_vector4.lua test_quat.lua test_matrix4.lua test_script_vmath.lua'.split())
 
     script_table_features = flist + ' embed';
     test_script_table = bld.program(features = script_table_features,


### PR DESCRIPTION
Added new `vmath` functions:
* `vmath.quat_matrix4` - get quaternion from matrix4
* `vmath.matrix4_compose` - create matrix4 from translation (vector3|vector4), rotation (quaternion) and scale (vector3)
* `vmath.matrix4_scale` - create matrix4 from scale (vector3) or from number (uniform scale) or 3 number (x, y, z)
* `vmath.clamp` - clamp input value in range [min, max]. Input value can be number, vector, vector3, vector4. In case of vector type clamp applies per vector component. `min`, `max` also can be number, vector, vector3, vector4.

Fixes #5118 

## PR checklist

* [x] Code
	* [x] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [x] Add comments where needed
* [x] Documentation
	* [x] Make sure that API documentation is updated in code comments
	* [x] Make sure that manuals are updated (in github.com/defold/doc)
* [x] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [x] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [x] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
