### PR TITLE
Fix the detection of `require` in a tail function call by the editor.

### DIFF
--- a/editor/src/clj/editor/lua_parser.clj
+++ b/editor/src/clj/editor/lua_parser.clj
@@ -192,15 +192,41 @@
                 (when-some [function-name (matching-pred string? (nth var-suffix-node 2))]
                   [module-name function-name arg-exps])))))))))
 
+(defn- deep-search-node [node target-node-type]
+  "Recursively searches for the first occurrence of a specific target node type in the given node tree."
+  (when (seq? node)
+    (or
+      ;; If we find the target node type, return it
+      (when (= target-node-type (first node)) node)
+      ;; Otherwise, recursively search its children
+      (some #(deep-search-node % target-node-type) (rest node)))))
+
+(defn- match-and-extract-args
+  "Checks if the function name matches and extracts argument expressions (:explist) if found."
+  [function-name node check-fn]
+  (when (check-fn)
+    (let [name-and-args-node (deep-search-node node :nameAndArgs)]
+      (when (some? name-and-args-node)
+        (parse-arg-exps name-and-args-node)))))
+
 (defn- matching-functioncall
+  "Searches the node tree recursively for a function call matching the given module-name and function-name.
+   Returns parsed argument expressions (:explist) if found."
   ([function-name node]
    (matching-functioncall nil function-name node))
   ([module-name function-name node]
-   (when-some [[parsed-module-name parsed-function-name parsed-arg-exps] (parse-functioncall node)]
-     (println "node: " node "\nreturns: " parsed-module-name parsed-function-name parsed-arg-exps "\nexpected:\n\n")
-     (when (and (= module-name parsed-module-name)
-                (= function-name parsed-function-name))
-       parsed-arg-exps))))
+   (when (= :functioncall (first node))
+     (when-some [var-node (deep-search-node node :var)]
+       (if module-name
+         ;; If module-name is specified, ensure the :var matches the module-name
+         (when (= module-name (second var-node))
+           (when-some [varsuffix-node (deep-search-node var-node :varSuffix)]
+             (match-and-extract-args function-name node
+                                     #(= function-name (nth varsuffix-node 2)))))
+         ;; If module-name is not specified, compare the :var directly with function-name
+         (match-and-extract-args function-name node
+                                 #(= function-name (second var-node))))))))
+
 
 (defn- matching-args [parse-fns arg-exps]
   (when (= (count parse-fns) (count arg-exps))

--- a/editor/src/clj/editor/lua_parser.clj
+++ b/editor/src/clj/editor/lua_parser.clj
@@ -215,8 +215,8 @@
   ([function-name node]
    (matching-functioncall nil function-name node))
   ([module-name function-name node]
-   (when (= :functioncall (first node))
-     (when-some [var-node (deep-search-node node :var)]
+   (when-some [var-or-exp-node (matching-type :varOrExp (second node))]
+     (when-some [var-node (deep-search-node var-or-exp-node :var)]
        (if module-name
          ;; If module-name is specified, ensure the :var matches the module-name
          (when (= module-name (second var-node))
@@ -226,7 +226,6 @@
          ;; If module-name is not specified, compare the :var directly with function-name
          (match-and-extract-args function-name node
                                  #(= function-name (second var-node))))))))
-
 
 (defn- matching-args [parse-fns arg-exps]
   (when (= (count parse-fns) (count arg-exps))

--- a/editor/src/clj/editor/lua_parser.clj
+++ b/editor/src/clj/editor/lua_parser.clj
@@ -197,6 +197,7 @@
    (matching-functioncall nil function-name node))
   ([module-name function-name node]
    (when-some [[parsed-module-name parsed-function-name parsed-arg-exps] (parse-functioncall node)]
+     (println "node: " node "\nreturns: " parsed-module-name parsed-function-name parsed-arg-exps "\nexpected:\n\n")
      (when (and (= module-name parsed-module-name)
                 (= function-name parsed-function-name))
        parsed-arg-exps))))

--- a/editor/test/editor/lua_parser_test.clj
+++ b/editor/test/editor/lua_parser_test.clj
@@ -84,6 +84,11 @@
           result (select-keys (lua-info code) [:vars :requires])]
       (is (= {:vars #{}
               :requires [[nil "mymath"]]} result))))
+  (testing "require function call with tail function call"
+    (let [code "require(\"deep_thought\").get_question(\"42\")"
+          result (select-keys (lua-info code) [:vars :requires])]
+      (is (= {:vars #{}
+              :requires [[nil "deep_thought"]]} result))))
   (testing "require call as part of complex expression"
     (let [code (string/join "\n" ["state_rules[hash(\"main\")] = hash_rules("
                                   "    require \"main/state_rules\""


### PR DESCRIPTION
Fixed an issue where using a tail call with `require` was impossible in the editor:
```lua
local result = require("my_module").call(42)
```

Fix https://github.com/defold/defold/issues/7963

## PR checklist

* [ ] Code
	* [x] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [x] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
