### PR TITLE
Improve compile_commands.json creation

### DIFF
--- a/scripts/build.py
+++ b/scripts/build.py
@@ -991,39 +991,23 @@ class Configuration(object):
         # Put the output json in the defold root since its where EasyClangComplete would look for it
         output_path = os.path.join(self.defold_root, 'compile_commands.json')
 
-        need_trailing_comma = False
+        result_config = []
+        # We loop over engine/<subdirs> and look for engine/<subdir>/build/compile_commands.json
+        engine_path = os.path.join(self.defold_root, 'engine')
+        for engine_subpath in os.listdir(engine_path):
+            potential_json_path = os.path.join(engine_path, engine_subpath, "build", "compile_commands.json")
+
+            if os.path.exists(potential_json_path):
+                self._log("Adding %s" % potential_json_path)
+
+                with open(potential_json_path, 'r') as input_file:
+                    sub_config = json.load(input_file)
+                    for elem in sub_config:
+                        result_config.append(elem)
+                    input_file.close()
         with open(output_path, 'w') as output_file:
-            # Open array json token
-            output_file.write("[\n")
-
-            # We loop over engine/<subdirs> and look for engine/<subdir>/build/compile_commands.json
-            engine_path = os.path.join(self.defold_root, 'engine')
-            for engine_subpath in os.listdir(engine_path):
-                potential_json_path = os.path.join(engine_path, engine_subpath, "build", "compile_commands.json")
-
-                if os.path.exists(potential_json_path):
-                    self._log("Adding %s" % potential_json_path)
-
-                    with open(potential_json_path, 'r') as input_file:
-                        # Take content but skip first and last lines (they would only include square brackets)
-                        input_lines = input_file.readlines()[1:-1]
-
-                        # Prettify output a bit by skipping last newline, this makes any appended comma
-                        # to appear on the same line
-                        if input_lines[-1][-1] == '\n':
-                            input_lines[-1] = input_lines[-1][:-1]
-
-                        # Append comma when adding more than one
-                        if need_trailing_comma:
-                            output_file.write(",\n")
-
-                        # Copy over contents to output file
-                        output_file.write(''.join(input_lines))
-
-                        need_trailing_comma = True
-
-            # Close array
-            output_file.write("\n]\n")
+            json.dump(result_config, output_file)
+            output_file.close()
 
     def build_builtins(self):
         with open(join(self.dynamo_home, 'share', 'builtins.zip'), 'wb') as f:


### PR DESCRIPTION
Rework compile_command.json generation. Instead of string manipulation parse input file to map, accumulate all command in one array and dump it to result json.
## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
