### PR TITLE
The physics contact_point_event now returns the correct contact point

### DIFF
--- a/engine/gamesys/proto/gamesys/physics_ddf.proto
+++ b/engine/gamesys/proto/gamesys/physics_ddf.proto
@@ -347,12 +347,13 @@ message EnableGridShapeLayer
 message ContactPoint
 {
     required dmMath.Point3  position                 = 1; // World position of contact point
-    required dmMath.Point3  instance_position        = 2; // World position of instance point
-    required dmMath.Vector3 normal                   = 3;
-    required dmMath.Vector3 relative_velocity        = 4;
-    required float          mass                     = 5;
-    required uint64         id                       = 6;
-    required uint64         group                    = 7;
+    required dmMath.Point3  instance_position        = 2; // World position of instance a
+    required dmMath.Point3  other_position           = 3; // World position of instance b
+    required dmMath.Vector3 normal                   = 4;
+    required dmMath.Vector3 relative_velocity        = 5;
+    required float          mass                     = 6;
+    required uint64         id                       = 7;
+    required uint64         group                    = 8;
 }
 
 /*# reports a contact point between two collision objects in cases where a listener is specified.

--- a/engine/gamesys/proto/gamesys/physics_ddf.proto
+++ b/engine/gamesys/proto/gamesys/physics_ddf.proto
@@ -346,12 +346,13 @@ message EnableGridShapeLayer
 
 message ContactPoint
 {
-    required dmMath.Point3  position                 = 1;
-    required dmMath.Vector3 normal                   = 2;
-    required dmMath.Vector3 relative_velocity        = 3;
-    required float          mass                     = 4;
-    required uint64         id                       = 5;
-    required uint64         group                    = 6;
+    required dmMath.Point3  position                 = 1; // World position of contact point
+    required dmMath.Point3  instance_position        = 2; // World position of instance point
+    required dmMath.Vector3 normal                   = 3;
+    required dmMath.Vector3 relative_velocity        = 4;
+    required float          mass                     = 5;
+    required uint64         id                       = 6;
+    required uint64         group                    = 7;
 }
 
 /*# reports a contact point between two collision objects in cases where a listener is specified.

--- a/engine/gamesys/proto/gamesys/physics_ddf.proto
+++ b/engine/gamesys/proto/gamesys/physics_ddf.proto
@@ -347,13 +347,12 @@ message EnableGridShapeLayer
 message ContactPoint
 {
     required dmMath.Point3  position                 = 1; // World position of contact point
-    required dmMath.Point3  instance_position        = 2; // World position of instance a
-    required dmMath.Point3  other_position           = 3; // World position of instance b
-    required dmMath.Vector3 normal                   = 4;
-    required dmMath.Vector3 relative_velocity        = 5;
-    required float          mass                     = 6;
-    required uint64         id                       = 7;
-    required uint64         group                    = 8;
+    required dmMath.Point3  instance_position        = 2; // World position of instance point
+    required dmMath.Vector3 normal                   = 3;
+    required dmMath.Vector3 relative_velocity        = 4;
+    required float          mass                     = 5;
+    required uint64         id                       = 6;
+    required uint64         group                    = 7;
 }
 
 /*# reports a contact point between two collision objects in cases where a listener is specified.

--- a/engine/gamesys/src/gamesys/components/comp_collision_object.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_collision_object.cpp
@@ -689,6 +689,7 @@ namespace dmGameSystem
                 a.m_Group               = group_hash_a;
                 a.m_Id                  = instance_a_id;
                 a.m_Position            = contact_point.m_PositionA;
+                a.m_InstancePosition    = dmGameObject::GetWorldPosition(instance_a);
                 a.m_Mass                = mass_a;
                 a.m_RelativeVelocity    = -contact_point.m_RelativeVelocity;
                 a.m_Normal              = -contact_point.m_Normal;
@@ -697,6 +698,7 @@ namespace dmGameSystem
                 b.m_Group               = group_hash_b;
                 b.m_Id                  = instance_b_id;
                 b.m_Position            = contact_point.m_PositionB;
+                a.m_InstancePosition    = dmGameObject::GetWorldPosition(instance_b);
                 b.m_Mass                = mass_b;
                 b.m_RelativeVelocity    = contact_point.m_RelativeVelocity;
                 b.m_Normal              = contact_point.m_Normal;

--- a/engine/gamesys/src/gamesys/components/comp_collision_object.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_collision_object.cpp
@@ -688,7 +688,7 @@ namespace dmGameSystem
                 dmPhysicsDDF::ContactPoint& a = ddf.m_A;
                 a.m_Group               = group_hash_a;
                 a.m_Id                  = instance_a_id;
-                a.m_Position            = dmGameObject::GetWorldPosition(instance_a);
+                a.m_Position            = contact_point.m_PositionA;
                 a.m_Mass                = mass_a;
                 a.m_RelativeVelocity    = -contact_point.m_RelativeVelocity;
                 a.m_Normal              = -contact_point.m_Normal;
@@ -696,7 +696,7 @@ namespace dmGameSystem
                 dmPhysicsDDF::ContactPoint& b = ddf.m_B;
                 b.m_Group               = group_hash_b;
                 b.m_Id                  = instance_b_id;
-                b.m_Position            = dmGameObject::GetWorldPosition(instance_b);
+                b.m_Position            = contact_point.m_PositionB;
                 b.m_Mass                = mass_b;
                 b.m_RelativeVelocity    = contact_point.m_RelativeVelocity;
                 b.m_Normal              = contact_point.m_Normal;

--- a/engine/gamesys/src/gamesys/components/comp_collision_object.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_collision_object.cpp
@@ -698,7 +698,7 @@ namespace dmGameSystem
                 b.m_Group               = group_hash_b;
                 b.m_Id                  = instance_b_id;
                 b.m_Position            = contact_point.m_PositionB;
-                a.m_InstancePosition    = dmGameObject::GetWorldPosition(instance_b);
+                b.m_InstancePosition    = dmGameObject::GetWorldPosition(instance_b);
                 b.m_Mass                = mass_b;
                 b.m_RelativeVelocity    = contact_point.m_RelativeVelocity;
                 b.m_Normal              = contact_point.m_Normal;

--- a/engine/gamesys/src/gamesys/components/comp_collision_object.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_collision_object.cpp
@@ -690,7 +690,6 @@ namespace dmGameSystem
                 a.m_Id                  = instance_a_id;
                 a.m_Position            = contact_point.m_PositionA;
                 a.m_InstancePosition    = dmGameObject::GetWorldPosition(instance_a);
-                a.m_OtherPosition       = dmGameObject::GetWorldPosition(instance_b);
                 a.m_Mass                = mass_a;
                 a.m_RelativeVelocity    = -contact_point.m_RelativeVelocity;
                 a.m_Normal              = -contact_point.m_Normal;
@@ -699,8 +698,7 @@ namespace dmGameSystem
                 b.m_Group               = group_hash_b;
                 b.m_Id                  = instance_b_id;
                 b.m_Position            = contact_point.m_PositionB;
-                b.m_InstancePosition    = dmGameObject::GetWorldPosition(instance_b);
-                b.m_OtherPosition       = dmGameObject::GetWorldPosition(instance_a);
+                a.m_InstancePosition    = dmGameObject::GetWorldPosition(instance_b);
                 b.m_Mass                = mass_b;
                 b.m_RelativeVelocity    = contact_point.m_RelativeVelocity;
                 b.m_Normal              = contact_point.m_Normal;

--- a/engine/gamesys/src/gamesys/components/comp_collision_object.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_collision_object.cpp
@@ -690,6 +690,7 @@ namespace dmGameSystem
                 a.m_Id                  = instance_a_id;
                 a.m_Position            = contact_point.m_PositionA;
                 a.m_InstancePosition    = dmGameObject::GetWorldPosition(instance_a);
+                a.m_OtherPosition       = dmGameObject::GetWorldPosition(instance_b);
                 a.m_Mass                = mass_a;
                 a.m_RelativeVelocity    = -contact_point.m_RelativeVelocity;
                 a.m_Normal              = -contact_point.m_Normal;
@@ -698,7 +699,8 @@ namespace dmGameSystem
                 b.m_Group               = group_hash_b;
                 b.m_Id                  = instance_b_id;
                 b.m_Position            = contact_point.m_PositionB;
-                a.m_InstancePosition    = dmGameObject::GetWorldPosition(instance_b);
+                b.m_InstancePosition    = dmGameObject::GetWorldPosition(instance_b);
+                b.m_OtherPosition       = dmGameObject::GetWorldPosition(instance_a);
                 b.m_Mass                = mass_b;
                 b.m_RelativeVelocity    = contact_point.m_RelativeVelocity;
                 b.m_Normal              = contact_point.m_Normal;

--- a/engine/gamesys/src/gamesys/scripts/script_physics.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_physics.cpp
@@ -1561,24 +1561,26 @@ namespace dmGameSystem
      *   if event == hash("contact_point_event") then
      *     pprint(data)
      *     -- {
-     *     --  distance = 0.0714111328125,
-     *     --  applied_impulse = 310.00769042969,
-     *     --  a = {
-     *     --      position = vmath.vector3(446, 371, 0),
-     *     --      relative_velocity = vmath.vector3(1.1722083854693e-06, -20.667181015015, -0),
-     *     --      mass = 0,
-     *     --      group = hash: [default],
-     *     --      id = hash: [/flat],
-     *     --      normal = vmath.vector3(-0, -1, -0)
+     *     --  distance = 2.1490633487701,
+     *     --  applied_impulse = 0
+     *     --  a = { --[[0x113f7c6c0]]
+     *     --    group = hash: [box],
+     *     --    id = hash: [/box]
+     *     --    mass = 0,
+     *     --    normal = vmath.vector3(0.379, 0.925, -0),
+     *     --    position = vmath.vector3(517.337, 235.068, 0),
+     *     --    instance_position = vmath.vector3(480, 144, 0),
+     *     --    relative_velocity = vmath.vector3(-0, -0, -0),
      *     --  },
-     *     --  b = {
-     *     --      position = vmath.vector3(185, 657.92858886719, 0),
-     *     --      relative_velocity = vmath.vector3(-1.1722083854693e-06, 20.667181015015, 0),
-     *     --      mass = 10,
-     *     --      group = hash: [default],
-     *     --      id = hash: [/go2],
-     *     --      normal = vmath.vector3(0, 1, 0)
-     *     --  }
+     *     --  b = { --[[0x113f7c840]]
+     *     --    group = hash: [circle],
+     *     --    id = hash: [/circle]
+     *     --    mass = 0,
+     *     --    normal = vmath.vector3(-0.379, -0.925, 0),
+     *     --    position = vmath.vector3(517.337, 235.068, 0),
+     *     --    instance_position = vmath.vector3(-0.0021, 0, -0.0022),
+     *     --    relative_velocity = vmath.vector3(0, 0, 0),
+     *     --  },
      *     -- }
      *   elseif event == hash("collision_event") then
      *     pprint(data)


### PR DESCRIPTION
This is a bug fix for the `contact_point_event`, where the `position` is now the contact point itself.
This makes it similar to the `contact_point_response` event, which was the intention.

If you need the old position (the world position of the object itself), you can use either `message.a.instance_position`/`message.b.instance_position`.

Fixes https://github.com/defold/defold/issues/9454

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
