### PR TITLE
Added `android:appCategory="game"` into `AndroidManifest.xml`

### DIFF
--- a/engine/engine/content/builtins/manifests/android/AndroidManifest.xml
+++ b/engine/engine/content/builtins/manifests/android/AndroidManifest.xml
@@ -5,6 +5,7 @@
         package="{{android.package}}"
         android:versionCode="{{android.version_code}}"
         android:versionName="{{project.version}}"
+        android:appCategory="game"
         android:installLocation="auto">
 
     <uses-feature android:required="true" android:glEsVersion="0x00020000" />


### PR DESCRIPTION
Google Play requires the `android:appCategory` attribute in the `AndroidManifest.xml`. Since Defold is a game engine, we have added `android:appCategory="game"` into the default `AndroidManifest.xml`.

If you need a different category for your app, create a custom manifest and choose the appropriate category: https://developer.android.com/reference/android/R.attr.html#appCategory.

> [!WARNING]
> If you already have a custom `AndroidManifest.xml`, please take note of these changes. 