### PR TITLE
Improve messages when constants and attributes are missing from the materials and compute programs

### DIFF
--- a/editor/resources/templates/template.cp
+++ b/editor/resources/templates/template.cp
@@ -4,7 +4,10 @@ layout (local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 
 layout(rgba32f) uniform image2D texture_out;
 
-uniform vec4 color;
+uniform uniforms
+{
+    vec4 color;
+};
 
 void main()
 {

--- a/engine/gamesys/src/gamesys/components/comp_sprite.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sprite.cpp
@@ -2163,11 +2163,14 @@ namespace dmGameSystem
         }
 
         dmRender::HMaterial material = GetComponentMaterial(component);
-        if (SetMaterialConstant(material, params.m_PropertyId, params.m_Value, params.m_Options.m_Index, CompSpriteSetConstantCallback, component) == dmGameObject::PROPERTY_RESULT_OK)
+        dmGameObject::PropertyResult res = SetMaterialConstant(material, params.m_PropertyId, params.m_Value, params.m_Options.m_Index, CompSpriteSetConstantCallback, component);
+
+        // Only check attributes if the constant property was not found
+        if (res == dmGameObject::PROPERTY_RESULT_NOT_FOUND)
         {
-            return dmGameObject::PROPERTY_RESULT_OK;
+            return SetMaterialAttribute(sprite_world->m_DynamicVertexAttributePool, &component->m_DynamicVertexAttributeIndex, material, set_property, params.m_Value, CompSpriteGetMaterialAttributeCallback, component);
         }
-        return SetMaterialAttribute(sprite_world->m_DynamicVertexAttributePool, &component->m_DynamicVertexAttributeIndex, material, set_property, params.m_Value, CompSpriteGetMaterialAttributeCallback, component);
+        return res;
     }
 
     static bool CompSpriteIterPropertiesGetNext(dmGameObject::SceneNodePropertyIterator* pit)

--- a/engine/render/src/render/material.cpp
+++ b/engine/render/src/render/material.cpp
@@ -253,7 +253,7 @@ namespace dmRender
         return material->m_FragmentProgram;
     }
 
-    static int32_t FindMaterialAttributeIndex(HMaterial material, dmhash_t name_hash)
+    uint8_t GetMaterialAttributeIndex(HMaterial material, dmhash_t name_hash)
     {
         dmArray<dmGraphics::VertexAttribute>& attributes = material->m_VertexAttributes;
         for (int i = 0; i < attributes.Size(); ++i)
@@ -263,7 +263,7 @@ namespace dmRender
                 return i;
             }
         }
-        return -1;
+        return INVALID_MATERIAL_ATTRIBUTE_INDEX;
     }
 
     void SetMaterialProgramConstantType(HMaterial material, dmhash_t name_hash, dmRenderDDF::MaterialDesc::ConstantType type)
@@ -383,8 +383,8 @@ namespace dmRender
         for (int i = 0; i < attributes_count; ++i)
         {
             const dmGraphics::VertexAttribute& graphics_attribute_in = attributes[i];
-            int32_t index = FindMaterialAttributeIndex(material, graphics_attribute_in.m_NameHash);
-            if (index < 0)
+            uint8_t index = GetMaterialAttributeIndex(material, graphics_attribute_in.m_NameHash);
+            if (index == INVALID_MATERIAL_ATTRIBUTE_INDEX)
             {
                 continue;
             }
@@ -426,8 +426,8 @@ namespace dmRender
         for (int i = 0; i < attributes_count; ++i)
         {
             const dmGraphics::VertexAttribute& graphics_attribute_in = attributes[i];
-            int32_t index = FindMaterialAttributeIndex(material, graphics_attribute_in.m_NameHash);
-            if (index < 0)
+            uint8_t index = GetMaterialAttributeIndex(material, graphics_attribute_in.m_NameHash);
+            if (index == INVALID_MATERIAL_ATTRIBUTE_INDEX)
             {
                 continue;
             }

--- a/engine/render/src/render/render.h
+++ b/engine/render/src/render/render.h
@@ -51,9 +51,10 @@ namespace dmRender
     typedef struct BufferedRenderBuffer*    HBufferedRenderBuffer;
     typedef HOpaqueHandle                   HRenderCamera;
 
-    static const uint8_t RENDERLIST_INVALID_DISPATCH    = 0xff;
-    static const HRenderType INVALID_RENDER_TYPE_HANDLE = ~0ULL;
-    static const uint32_t INVALID_SAMPLER_UNIT          = 0xffffffff;
+    static const uint8_t RENDERLIST_INVALID_DISPATCH       = 0xff;
+    static const HRenderType INVALID_RENDER_TYPE_HANDLE    = ~0ULL;
+    static const uint32_t INVALID_SAMPLER_UNIT             = 0xffffffff;
+    static const uint8_t  INVALID_MATERIAL_ATTRIBUTE_INDEX = 0xff;
 
     /**
      * Display profiles handle
@@ -151,6 +152,15 @@ namespace dmRender
         float            m_OrthographicZoom;
         uint8_t          m_AutoAspectRatio        : 1;
         uint8_t          m_OrthographicProjection : 1;
+    };
+
+    struct MaterialProgramAttributeInfo
+    {
+        dmhash_t                           m_AttributeNameHash;
+        const dmGraphics::VertexAttribute* m_Attribute;
+        const uint8_t*                     m_ValuePtr;
+        dmhash_t                           m_ElementIds[4];
+        uint32_t                           m_ElementIndex;
     };
 
     HRenderContext NewRenderContext(dmGraphics::HContext graphics_context, const RenderContextParams& params);
@@ -255,20 +265,12 @@ namespace dmRender
     void                            SetMaterialProgramConstantType(HMaterial material, dmhash_t name_hash, dmRenderDDF::MaterialDesc::ConstantType type);
     bool                            GetMaterialProgramConstant(HMaterial, dmhash_t name_hash, HConstant& out_value);
 
-    struct MaterialProgramAttributeInfo
-    {
-        dmhash_t                           m_AttributeNameHash;
-        const dmGraphics::VertexAttribute* m_Attribute;
-        const uint8_t*                     m_ValuePtr;
-        dmhash_t                           m_ElementIds[4];
-        uint32_t                           m_ElementIndex;
-    };
-
     dmGraphics::HVertexDeclaration  GetVertexDeclaration(HMaterial material);
     bool                            GetMaterialProgramAttributeInfo(HMaterial material, dmhash_t name_hash, MaterialProgramAttributeInfo& info);
     void                            GetMaterialProgramAttributes(HMaterial material, const dmGraphics::VertexAttribute** attributes, uint32_t* attribute_count);
     void                            GetMaterialProgramAttributeValues(HMaterial material, uint32_t index, const uint8_t** value_ptr, uint32_t* num_values);
     void                            SetMaterialProgramAttributes(HMaterial material, const dmGraphics::VertexAttribute* attributes, uint32_t attributes_count);
+    uint8_t                         GetMaterialAttributeIndex(HMaterial material, dmhash_t name_hash);
 
     // Compute
     HComputeProgram                 NewComputeProgram(HRenderContext render_context, dmGraphics::HComputeProgram shader);
@@ -283,6 +285,7 @@ namespace dmRender
     void                            SetComputeProgramConstantType(HComputeProgram compute_program, dmhash_t name_hash, dmRenderDDF::MaterialDesc::ConstantType type);
     bool                            SetComputeProgramSampler(HComputeProgram compute_program, dmhash_t name_hash, uint32_t unit, dmGraphics::TextureWrap u_wrap, dmGraphics::TextureWrap v_wrap, dmGraphics::TextureFilter min_filter, dmGraphics::TextureFilter mag_filter, float max_anisotropy);
     uint32_t                        GetComputeProgramSamplerUnit(HComputeProgram compute_program, dmhash_t name_hash);
+    bool                            GetComputeProgramConstant(HComputeProgram compute_program, dmhash_t name_hash, HConstant& out_value);
 
     /** Retrieve info about a hash related to a program constant
      * The function checks if the hash matches a constant or any element of it.

--- a/engine/render/src/render/render_private.h
+++ b/engine/render/src/render/render_private.h
@@ -343,7 +343,6 @@ namespace dmRender
     void    DispatchCompute(HRenderContext render_context, uint32_t group_count_x, uint32_t group_count_y, uint32_t group_count_z, HNamedConstantBuffer constant_buffer);
     void    ApplyComputeProgramConstants(HRenderContext render_context, HComputeProgram compute_program);
     int32_t GetComputeProgramSamplerIndex(HComputeProgram program, dmhash_t name_hash);
-    bool    GetComputeProgramConstant(HComputeProgram compute_program, dmhash_t name_hash, HConstant& out_value);
 
     // Render camera
     RenderCamera* GetRenderCameraByUrl(HRenderContext render_context, const dmMessage::URL& camera_url);


### PR DESCRIPTION
When a material or compute program has specified constants, attributes and samplers in the material editor but are either missing, not used or optimized away from the shaders we now show a warning. 

Fixes #9463 
Fixes #9241
Fixes #6503