### PR TITLE
Fix the `render_script` to draw debug text and debug lines using world projection.

### DIFF
--- a/engine/engine/content/builtins/render/default.render_script
+++ b/engine/engine/content/builtins/render/default.render_script
@@ -136,6 +136,7 @@ local function create_state()
 end
 
 function init(self)
+    self.is_debug = sys.get_engine_info().is_debug
     self.predicates = create_predicates("tile", "gui", "particle", "model", "debug_text")
 
     -- default is stretch projection. copy from builtins and change for different projection
@@ -194,8 +195,6 @@ function update(self)
     render.draw(predicates.particle, camera_world.frustum)
     render.disable_state(graphics.STATE_DEPTH_TEST)
 
-    render.draw_debug3d()
-
     -- render GUI
     --
     local camera_gui = state.cameras.camera_gui
@@ -204,9 +203,19 @@ function update(self)
 
     render.enable_state(graphics.STATE_STENCIL_TEST)
     render.draw(predicates.gui, camera_gui.frustum)
-    render.draw(predicates.debug_text, camera_gui.frustum)
     render.disable_state(graphics.STATE_STENCIL_TEST)
     render.disable_state(graphics.STATE_BLEND)
+
+    -- render debug lines and text only in debug
+    --
+    if self.is_debug then
+        render.set_view(camera_world.view)
+        render.set_projection(camera_world.proj)
+        render.enable_state(graphics.STATE_BLEND)
+        render.draw_debug3d() -- debug lines
+        render.draw(predicates.debug_text, camera_gui.frustum) -- debug text
+        render.disable_state(graphics.STATE_BLEND)
+    end
 end
 
 function on_message(self, message_id, message)


### PR DESCRIPTION
The issue where debug text and debug lines were drawn using different view and projection settings, causing inconsistency in coordinates between these two debug APIs, has been resolved. The default `render_script` has been updated to fix this inconsistency.

Fix https://github.com/defold/defold/issues/9406