### PR TITLE
Vertex attribute fixes for instancing support in the editor

### DIFF
--- a/editor/.idea/codeStyles/Project.xml
+++ b/editor/.idea/codeStyles/Project.xml
@@ -12,6 +12,7 @@
           <entry key="clojure.core.cache/defcache" value="-1" />
           <entry key="clojure.core/defmulti" value="-1" />
           <entry key="clojure.core/defonce" value="-1" />
+          <entry key="clojure.core/vector-of" value="-1" />
           <entry key="clojure.test/are" value="-1" />
           <entry key="dynamo.graph/make-nodes" value="-1" />
           <entry key="dynamo.graph/precluding-errors" value="-1" />

--- a/editor/src/clj/editor/buffers.clj
+++ b/editor/src/clj/editor/buffers.clj
@@ -15,12 +15,13 @@
 (ns editor.buffers
   (:require [util.num :as num])
   (:import [com.google.protobuf ByteString]
-           [java.nio Buffer ByteBuffer ByteOrder DoubleBuffer FloatBuffer IntBuffer LongBuffer ShortBuffer]))
+           [java.nio Buffer ByteBuffer ByteOrder DoubleBuffer FloatBuffer IntBuffer LongBuffer ShortBuffer]
+           [java.nio.charset StandardCharsets]))
 
 (set! *warn-on-reflection* true)
 
 (defn slurp-bytes
-  [^ByteBuffer buff]
+  ^bytes [^ByteBuffer buff]
   (let [buff (.duplicate buff)
         n (.remaining buff)
         bytes (byte-array n)]
@@ -29,12 +30,16 @@
 
 (defn alias-buf-bytes
   "Avoids copy if possible."
-  [^ByteBuffer buff]
+  ^bytes [^ByteBuffer buff]
   (if (and (.hasArray buff) (= (.remaining buff) (alength (.array buff))))
     (.array buff)
     (slurp-bytes buff)))
 
-(defn bbuf->string [^ByteBuffer bb] (String. ^bytes (alias-buf-bytes bb) "UTF-8"))
+(defn bbuf->string
+  (^String [^ByteBuffer bb]
+   (String. (alias-buf-bytes bb) StandardCharsets/UTF_8))
+  (^String [^ByteBuffer bb ^long offset ^long length]
+   (String. (alias-buf-bytes bb) offset length StandardCharsets/UTF_8)))
 
 (defprotocol ByteStringCoding
   (byte-pack [source] "Return a Protocol Buffer compatible ByteString from the given source."))

--- a/editor/src/clj/editor/form.clj
+++ b/editor/src/clj/editor/form.clj
@@ -37,7 +37,12 @@
    :boolean false
    :integer 0
    :number 0.0
-   :vec4 [0.0 0.0 0.0 0.0]
+   :vec4 (vector-of :double 0.0 0.0 0.0 0.0)
+   :mat4 (vector-of :double
+           1.0 0.0 0.0 0.0
+           0.0 1.0 0.0 0.0
+           0.0 0.0 1.0 0.0
+           0.0 0.0 0.0 1.0)
    :2panel [],
    :list []})
 
@@ -76,9 +81,11 @@
               {}
               sections-defaults))))
 
-(defn two-panel-defaults [panel-field-info]
-  (let [panel-key-defaults (field-defaults [(:panel-key panel-field-info)])
-        panel-form-defaults (form-defaults (:panel-form panel-field-info))]
+(defn two-panel-defaults [{:keys [panel-key panel-form panel-form-fn] :as _panel-field-info}]
+  (let [panel-key-defaults (field-defaults [panel-key])
+        panel-form-defaults (form-defaults (if panel-form-fn
+                                             (panel-form-fn nil)
+                                             panel-form))]
     (when (and panel-key-defaults panel-form-defaults)
       (merge panel-key-defaults panel-form-defaults))))
 

--- a/editor/src/clj/editor/geom.clj
+++ b/editor/src/clj/editor/geom.clj
@@ -525,9 +525,10 @@
     (let [q (math/euler->quat euler)
           tmp-v (Vector3d.)]
       (let [res (mapv (fn [[^double x ^double y ^double z]]
-                    (.set tmp-v x y z)
-                    (let [v (math/rotate q tmp-v)]
-                      [(.x v) (.y v) (.z v)])) ps)]
+                        (.set tmp-v x y z)
+                        (let [v (math/rotate q tmp-v)]
+                          (vector-of :double (.x v) (.y v) (.z v))))
+                      ps)]
         res))))
 
 (defn transf-p
@@ -536,7 +537,8 @@
     (let [res (mapv (fn [[^double x ^double y ^double z]]
                       (.set p x y z)
                       (.transform m4d p)
-                      [(.x p) (.y p) (.z p)]) ps)]
+                      (vector-of :double (.x p) (.y p) (.z p)))
+                    ps)]
       res)))
 
 (defn transf-p4
@@ -545,7 +547,7 @@
     (let [res (mapv (fn [[^double x ^double y ^double z]]
                       (.set p x y z)
                       (.transform m4d p)
-                      [(.x p) (.y p) (.z p) 1.0])
+                      (vector-of :double (.x p) (.y p) (.z p) 1.0))
                     ps)]
       res)))
 
@@ -556,7 +558,7 @@
             (.set n x y z)
             (.transform m4d n)
             (.normalize n) ; Need to normalize since the matrix may be scaled.
-            [(.x n) (.y n) (.z n)])
+            (vector-of :double (.x n) (.y n) (.z n)))
           normals)))
 
 (defn transf-n4
@@ -566,17 +568,17 @@
             (.set n x y z)
             (.transform m4d n)
             (.normalize n) ; Need to normalize since the matrix may be scaled.
-            [(.x n) (.y n) (.z n) 0.0])
+            (vector-of :double (.x n) (.y n) (.z n) 0.0))
           normals)))
 
 (defn transf-tangents
   [^Matrix4d m4d tangents]
   (let [n (Vector3d.)]
-    (mapv (fn [[^double x ^double y ^double z ^double w]]
+    (mapv (fn [[^double x ^double y ^double z w]]
             (.set n x y z)
             (.transform m4d n)
             (.normalize n) ; Need to normalize since the matrix may be scaled.
-            [(.x n) (.y n) (.z n) w])
+            (vector-of :double (.x n) (.y n) (.z n) (or w 1.0)))
           tangents)))
 
 (defn chain [n f ps]

--- a/editor/src/clj/editor/graphics.clj
+++ b/editor/src/clj/editor/graphics.clj
@@ -18,7 +18,6 @@
             [editor.geom :as geom]
             [editor.gl.shader :as shader]
             [editor.gl.vertex2 :as vtx]
-            [editor.math :as math]
             [editor.properties :as properties]
             [editor.protobuf :as protobuf]
             [editor.types :as types]
@@ -79,6 +78,8 @@
 (def default-attribute-semantic-type (protobuf/default Graphics$VertexAttribute :semantic-type))
 
 (def default-attribute-vector-type (protobuf/default Graphics$VertexAttribute :vector-type))
+
+(def default-attribute-step-function (protobuf/default Graphics$VertexAttribute :step-function))
 
 (def ^:private attribute-data-type-infos
   [{:data-type :type-byte

--- a/editor/src/clj/editor/graphics.clj
+++ b/editor/src/clj/editor/graphics.clj
@@ -829,9 +829,9 @@
       :vector-type-vec2 types/Vec2
       :vector-type-vec3 types/Vec3
       :vector-type-vec4 types/Vec4
-      :vector-type-mat2 types/Vec4
-      :vector-type-mat3 types/Vec4
-      :vector-type-mat4 types/Vec4)))
+      :vector-type-mat2 types/Mat2
+      :vector-type-mat3 types/Mat3
+      :vector-type-mat4 types/Mat4)))
 
 (defn- attribute-update-property [current-property-value attribute-info new-value]
   (let [name-key (:name-key attribute-info)

--- a/editor/src/clj/editor/graphics.clj
+++ b/editor/src/clj/editor/graphics.clj
@@ -30,7 +30,8 @@
             [util.fn :as fn]
             [util.murmur :as murmur]
             [util.num :as num])
-  (:import [com.dynamo.graphics.proto Graphics$CoordinateSpace Graphics$VertexAttribute Graphics$VertexAttribute$SemanticType Graphics$VertexAttribute$VectorType]
+  (:import [com.dynamo.bob.pipeline GraphicsUtil]
+           [com.dynamo.graphics.proto Graphics$CoordinateSpace Graphics$VertexAttribute Graphics$VertexAttribute$SemanticType Graphics$VertexAttribute$VectorType]
            [com.google.protobuf ByteString]
            [com.jogamp.opengl GL2]
            [editor.gl.vertex2 VertexBuffer]
@@ -38,8 +39,40 @@
            [javax.vecmath Matrix4d]))
 
 (set! *warn-on-reflection* true)
+(set! *unchecked-math* :warn-on-boxed)
 
 (namespaces/import-vars [editor.gl.vertex2 attribute-name->key])
+
+(def ^:private scalar-zero (vector-of :double 0.0))
+(def ^:private scalar-one (vector-of :double 1.0))
+
+(def ^:private vec2-zero (vector-of :double 0.0 0.0))
+(def ^:private vec2-one (vector-of :double 1.0 1.0))
+
+(def ^:private vec3-zero (vector-of :double 0.0 0.0 0.0))
+(def ^:private vec3-one (vector-of :double 1.0 1.0 1.0))
+
+(def ^:private vec4-zero (vector-of :double 0.0 0.0 0.0 0.0))
+(def ^:private vec4-one (vector-of :double 1.0 1.0 1.0 1.0))
+(def ^:private vec4-xyz-zero-w-one (vector-of :double 0.0 0.0 0.0 1.0))
+
+(def ^:private mat2-identity
+  (vector-of :double
+    1.0 0.0
+    0.0 1.0))
+
+(def ^:private mat3-identity
+  (vector-of :double
+    1.0 0.0 0.0
+    0.0 1.0 0.0
+    0.0 0.0 1.0))
+
+(def ^:private mat4-identity
+  (vector-of :double
+    1.0 0.0 0.0 0.0
+    0.0 1.0 0.0 0.0
+    0.0 0.0 1.0 0.0
+    0.0 0.0 0.0 1.0))
 
 (def default-attribute-data-type (protobuf/default Graphics$VertexAttribute :data-type))
 
@@ -80,6 +113,28 @@
 (def semantic-type? (protobuf/valid-enum-values Graphics$VertexAttribute$SemanticType))
 
 (def vector-type? (protobuf/valid-enum-values Graphics$VertexAttribute$VectorType))
+
+(defn- disambiguating-vector-type? [vector-type]
+  ;; Can this vector-type disambiguate between two vector-types guessed sorely
+  ;; from the number of values? Currently only relevant to the case when we have
+  ;; exactly four values. In that case, we could have a :vector-type-vec4 or a
+  ;; :vector-type-mat2. If we have the more uncommon :vector-type-mat2, we
+  ;; explicitly write it to the file for override attribute values.
+  (case vector-type
+    :vector-type-mat2 true
+    false))
+
+(def engine-provided-semantic-types
+  (into #{}
+        (keep (fn [^Graphics$VertexAttribute$SemanticType pb-semantic-type]
+                (when (GraphicsUtil/isEngineProvidedAttributeSemanticType pb-semantic-type)
+                  (protobuf/pb-enum->val pb-semantic-type))))
+        (protobuf/protocol-message-enums Graphics$VertexAttribute$SemanticType)))
+
+(defn engine-provided-attribute? [attribute]
+  {:pre [(map? attribute)] ; Graphics$VertexAttribute in map format.
+   :post [(boolean? %)]}
+  (contains? engine-provided-semantic-types (:semantic-type attribute default-attribute-semantic-type)))
 
 (def ^:private attribute-data-type->attribute-value-keyword
   (fn/make-case-fn (map (juxt :data-type :value-keyword)
@@ -139,13 +194,55 @@
         stored-values (doubles->stored-values double-values attribute-value-keyword)]
     (pair attribute-value-keyword stored-values)))
 
+(defn- guess-old-vector-type [^long element-count new-vector-type]
+  ;; With most element counts we can know for certain, but if we have exactly
+  ;; four elements, we could have either a vec4 or a mat2.
+  (case element-count
+    1 :vector-type-scalar
+    2 :vector-type-vec2
+    3 :vector-type-vec3
+    4 (case new-vector-type
+        ;; If we know we're targeting a scalar or vector type, we assume we have
+        ;; a vector type. It makes no difference, really.
+        :vector-type-scalar :vector-type-vec4
+        :vector-type-vec2 :vector-type-vec4
+        :vector-type-vec3 :vector-type-vec4
+        :vector-type-vec4 :vector-type-vec4
+
+        ;; Similarly, if we're targeting a matrix type, assume we have a matrix
+        ;; as well. It makes a difference if we're targeting a mat3 or a mat4,
+        ;; since our four values will be written to the top-left of the matrix.
+        :vector-type-mat2 :vector-type-mat2
+        :vector-type-mat3 :vector-type-mat2
+        :vector-type-mat4 :vector-type-mat2
+
+        ;; If we don't even know what we're targeting, assume we have a vector.
+        ;; In the case where we had a :vector-type-mat2 override, it would
+        ;; specify the :vector-type because the disambiguating-vector-type?
+        ;; function returns true for :vector-type-mat2, so we wouldn't even be
+        ;; in this function to begin with.
+        nil :vector-type-mat4)
+    9 :vector-type-mat3
+    16 :vector-type-mat4))
+
 (defn override-attributes->vertex-attribute-overrides [attributes]
   (into {}
         (map (fn [vertex-attribute]
-               [(attribute-name->key (:name vertex-attribute))
-                {:name (:name vertex-attribute)
-                 :values (attribute->any-doubles vertex-attribute)
-                 :value-keyword (attribute->value-keyword vertex-attribute)}]))
+               (let [attribute-name (:name vertex-attribute)
+                     attribute-key (attribute-name->key attribute-name)
+                     values (attribute->any-doubles vertex-attribute)
+                     value-keyword (attribute->value-keyword vertex-attribute)
+
+                     ;; Only written if it can't be guessed from the element
+                     ;; count. I.e. either :vector-type-mat2 or nil. See the
+                     ;; disambiguating-vector-type? function for details.
+                     vector-type (or (:vector-type vertex-attribute)
+                                     (guess-old-vector-type (count values) nil))]
+                 (pair attribute-key
+                       {:name attribute-name
+                        :values values
+                        :value-keyword value-keyword
+                        :vector-type vector-type}))))
         attributes))
 
 (defn doubles-outside-attribute-range-error-message [double-values attribute]
@@ -173,44 +270,8 @@
 (defn validate-doubles [double-values attribute node-id prop-kw]
   (validation/prop-error :fatal node-id prop-kw doubles-outside-attribute-range-error-message double-values attribute))
 
-;; For positions, we want to have a 1.0 in the W coordinate so that they can be
-;; transformed correctly by a 4D matrix. For colors, we default to opaque white.
-(def ^:private default-attribute-element-values (vector-of :double 0.0 0.0 0.0 0.0))
-(def ^:private default-attribute-element-values-mat4 (vector-of :double
-                                                                0.0 0.0 0.0 0.0
-                                                                0.0 0.0 0.0 0.0
-                                                                0.0 0.0 0.0 0.0
-                                                                0.0 0.0 0.0 0.0))
-;; Transform values (i.e identity world, normal matrices)
-(def ^:private default-attribute-transform-values-mat4 (vector-of :double
-                                                                  1.0 0.0 0.0 0.0
-                                                                  0.0 1.0 0.0 0.0
-                                                                  0.0 0.0 1.0 0.0
-                                                                  0.0 0.0 0.0 1.0))
-
-;; Position semantic values
-(def ^:private default-position-element-values (vector-of :double 0.0 0.0 0.0 1.0))
-(def ^:private default-position-element-values-mat4 (vector-of :double
-                                                               0.0 0.0 0.0 1.0
-                                                               0.0 0.0 0.0 1.0
-                                                               0.0 0.0 0.0 1.0
-                                                               0.0 0.0 0.0 1.0))
-;; Color semantic values
-(def ^:private default-color-element-values (vector-of :double 1.0 1.0 1.0 1.0))
-(def ^:private default-color-element-values-mat4 (vector-of :double
-                                                            1.0 1.0 1.0 1.0
-                                                            1.0 1.0 1.0 1.0
-                                                            1.0 1.0 1.0 1.0
-                                                            1.0 1.0 1.0 1.0))
-
-(defn- vector-type-is-matrix? [attribute-vector-type]
-  (case attribute-vector-type
-    :vector-type-mat2 true
-    :vector-type-mat3 true
-    :vector-type-mat4 true
-    false))
-
-(defn vector-type->component-count [attribute-vector-type]
+(defn vector-type->component-count
+  ^long [attribute-vector-type]
   (case attribute-vector-type
     :vector-type-scalar 1
     :vector-type-vec2 2
@@ -230,42 +291,208 @@
     :float-mat3 :vector-type-mat3
     :float-mat4 :vector-type-mat4))
 
-(defn resize-doubles [double-values semantic-type new-vector-type]
-  {:pre [(vector? double-values)
-         (semantic-type? semantic-type)
-         (vector-type? new-vector-type)]}
-  (let [old-element-count (count double-values)
-        new-element-count (vector-type->component-count new-vector-type)]
-    (cond
-      (< new-element-count old-element-count)
-      (subvec double-values 0 new-element-count)
+(defn default-attribute-doubles [semantic-type vector-type]
+  (case vector-type
+    :vector-type-scalar (case semantic-type
+                          :semantic-type-color scalar-one
+                          scalar-zero)
+    :vector-type-vec2 (case semantic-type
+                        :semantic-type-color vec2-one
+                        vec2-zero)
+    :vector-type-vec3 (case semantic-type
+                        :semantic-type-color vec3-one
+                        vec3-zero)
+    :vector-type-vec4 (case semantic-type
+                        :semantic-type-position vec4-xyz-zero-w-one
+                        :semantic-type-color vec4-one
+                        :semantic-type-tangent vec4-xyz-zero-w-one
+                        vec4-zero)
+    :vector-type-mat2 mat2-identity
+    :vector-type-mat3 mat3-identity
+    :vector-type-mat4 mat4-identity))
 
-      (> new-element-count old-element-count)
-      (let [default-element-values
-            (if (vector-type-is-matrix? new-vector-type)
-              (case semantic-type
-                :semantic-type-position default-position-element-values-mat4
-                :semantic-type-color default-color-element-values-mat4
-                :semantic-type-world-matrix default-attribute-transform-values-mat4
-                :semantic-type-normal-matrix default-attribute-transform-values-mat4
-                default-attribute-element-values-mat4)
+(defn- semantic-type->w [semantic-type]
+  (nth (default-attribute-doubles semantic-type :vector-type-vec4) 3))
 
-              (case semantic-type
-                :semantic-type-position default-position-element-values
-                :semantic-type-color default-color-element-values
-                default-attribute-element-values))]
-        (into double-values
-              (subvec default-element-values old-element-count new-element-count)))
-
-      :else
-      double-values)))
-
-(defn- default-attribute-doubles-raw [semantic-type vector-type]
+(defn convert-double-values [double-values semantic-type old-vector-type new-vector-type]
   {:pre [(semantic-type? semantic-type)
-         (vector-type? vector-type)]}
-  (resize-doubles (vector-of :double) semantic-type vector-type))
+         (or (nil? old-vector-type) (vector-type? old-vector-type))
+         (vector-type? new-vector-type)]}
+  (if (coll/empty? double-values)
+    (default-attribute-doubles semantic-type new-vector-type)
+    (case (or old-vector-type
+              (guess-old-vector-type (count double-values) new-vector-type))
 
-(def default-attribute-doubles (fn/memoize default-attribute-doubles-raw))
+      :vector-type-scalar
+      (case new-vector-type
+        :vector-type-scalar double-values
+        :vector-type-vec2 (let [[a] double-values]
+                            (vector-of :double a a))
+        :vector-type-vec3 (let [[a] double-values]
+                            (vector-of :double a a a))
+        :vector-type-vec4 (let [[a] double-values]
+                            (vector-of :double a a a a))
+        :vector-type-mat2 (let [[a] double-values]
+                            (vector-of :double
+                              a 0
+                              0 a))
+        :vector-type-mat3 (let [[a] double-values]
+                            (vector-of :double
+                              a 0 0
+                              0 a 0
+                              0 0 a))
+        :vector-type-mat4 (let [[a] double-values]
+                            (vector-of :double
+                              a 0 0 0
+                              0 a 0 0
+                              0 0 a 0
+                              0 0 0 a)))
+
+      :vector-type-vec2
+      (case new-vector-type
+        :vector-type-scalar (let [[a b] double-values]
+                              (vector-of :double a))
+        :vector-type-vec2 double-values
+        :vector-type-vec3 (let [[a b] double-values]
+                            (vector-of :double a b 0))
+        :vector-type-vec4 (let [[a b] double-values
+                                w (semantic-type->w semantic-type)]
+                            (vector-of :double a b 0 w))
+        :vector-type-mat2 (let [[a b] double-values]
+                            (vector-of :double
+                              a b
+                              0 0))
+        :vector-type-mat3 (let [[a b] double-values]
+                            (vector-of :double
+                              a b 0
+                              0 0 0
+                              0 0 0))
+        :vector-type-mat4 (let [[a b] double-values]
+                            (vector-of :double
+                              a b 0 0
+                              0 0 0 0
+                              0 0 0 0
+                              0 0 0 0)))
+
+      :vector-type-vec3
+      (case new-vector-type
+        :vector-type-scalar (let [[a b c] double-values]
+                              (vector-of :double a))
+        :vector-type-vec2 (let [[a b c] double-values]
+                            (vector-of :double a b))
+        :vector-type-vec3 double-values
+        :vector-type-vec4 (let [[a b c] double-values
+                                w (semantic-type->w semantic-type)]
+                            (vector-of :double a b c w))
+        :vector-type-mat2 (let [[a b c] double-values]
+                            (vector-of :double
+                              a b
+                              c 0))
+        :vector-type-mat3 (let [[a b c] double-values]
+                            (vector-of :double
+                              a b c
+                              0 0 0
+                              0 0 0))
+        :vector-type-mat4 (let [[a b c] double-values]
+                            (vector-of :double
+                              a b c 0
+                              0 0 0 0
+                              0 0 0 0
+                              0 0 0 0)))
+
+      :vector-type-vec4
+      (case new-vector-type
+        :vector-type-scalar (let [[a b c d] double-values]
+                              (vector-of :double a))
+        :vector-type-vec2 (let [[a b c d] double-values]
+                            (vector-of :double a b))
+        :vector-type-vec3 (let [[a b c d] double-values]
+                            (vector-of :double a b c))
+        :vector-type-vec4 double-values
+        :vector-type-mat2 double-values
+        :vector-type-mat3 (let [[a b c d] double-values]
+                            (vector-of :double
+                              a b c
+                              d 0 0
+                              0 0 0))
+        :vector-type-mat4 (let [[a b c d] double-values]
+                            (vector-of :double
+                              a b c d
+                              0 0 0 0
+                              0 0 0 0
+                              0 0 0 0)))
+
+      :vector-type-mat2
+      (case new-vector-type
+        :vector-type-scalar (subvec double-values 0 1)
+        :vector-type-vec2 (subvec double-values 0 2)
+        :vector-type-vec3 (subvec double-values 0 3)
+        :vector-type-vec4 double-values
+        :vector-type-mat2 double-values
+        :vector-type-mat3 (let [[a b
+                                 c d]
+                                double-values]
+                            (vector-of :double
+                              a b 0
+                              c d 0
+                              0 0 1))
+        :vector-type-mat4 (let [[a b
+                                 c d]
+                                double-values]
+                            (vector-of :double
+                              a b 0 0
+                              c d 0 0
+                              0 0 1 0
+                              0 0 0 1)))
+
+      :vector-type-mat3
+      (case new-vector-type
+        :vector-type-scalar (subvec double-values 0 1)
+        :vector-type-vec2 (subvec double-values 0 2)
+        :vector-type-vec3 (subvec double-values 0 3)
+        :vector-type-vec4 (subvec double-values 0 4)
+        :vector-type-mat2 (let [[a b c
+                                 d e f
+                                 g h i]
+                                double-values]
+                            (vector-of :double
+                              a b
+                              d e))
+        :vector-type-mat3 double-values
+        :vector-type-mat4 (let [[a b c
+                                 d e f
+                                 g h i]
+                                double-values]
+                            (vector-of :double
+                              a b c 0
+                              d e f 0
+                              g h i 0
+                              0 0 0 1)))
+
+      :vector-type-mat4
+      (case new-vector-type
+        :vector-type-scalar (subvec double-values 0 1)
+        :vector-type-vec2 (subvec double-values 0 2)
+        :vector-type-vec3 (subvec double-values 0 3)
+        :vector-type-vec4 (subvec double-values 0 4)
+        :vector-type-mat2 (let [[a b c d
+                                 e f g h
+                                 i j k l
+                                 m n o p]
+                                double-values]
+                            (vector-of :double
+                              a b
+                              e f))
+        :vector-type-mat3 (let [[a b c d
+                                 e f g h
+                                 i j k l
+                                 m n o p]
+                                double-values]
+                            (vector-of :double
+                              a b c
+                              e f g
+                              i j k))
+        :vector-type-mat4 double-values))))
 
 (defn attribute-data-type->buffer-data-type [attribute-data-type]
   (case attribute-data-type
@@ -278,7 +505,7 @@
     :type-float :float))
 
 (defn attribute-values+data-type->byte-size [attribute-values attribute-data-type]
-  (* (count attribute-values) (attribute-data-type->byte-size attribute-data-type)))
+  (* (count attribute-values) (int (attribute-data-type->byte-size attribute-data-type))))
 
 (defn- make-attribute-bytes
   ^bytes [attribute-data-type normalize attribute-values]
@@ -329,7 +556,7 @@
   {:pre [(map? attribute-info)
          (coordinate-space? coordinate-space)
          (attribute-data-type? data-type)
-         (keyword? vector-type)
+         (vector-type? vector-type)
          (string? name)
          (keyword? name-key)
          (or (nil? normalize) (boolean? normalize))
@@ -369,17 +596,20 @@
          #(:coordinate-space % :coordinate-space-local)
          :semantic-type)))
 
-;; This function can return nil if element-count and vector-type is nil,
-;; which happens for default values. This is only used for sanitation,
-;; so we shouldn't return the default value here.
-(defn- attribute-info->vector-type [{:keys [element-count semantic-type vector-type] :as attribute-info}]
-  (let [is-valid-vector-type (some? vector-type)
-        is-valid-element-count (pos-int? element-count)]
-    (cond
-      is-valid-vector-type vector-type
-      is-valid-element-count (vtx/element-count+semantic-type->vector-type element-count semantic-type))))
+(defn- attribute-info->vector-type [{:keys [element-count vector-type] :as _attribute-info}]
+  ;; This function can return nil if element-count and vector-type is nil,
+  ;; which happens for default values. This is only used for sanitation,
+  ;; so we shouldn't return the default value here. In legacy file formats, only
+  ;; scalar, vec2, vec3, vec4 attributes were supported.
+  (or vector-type
+      (when (pos-int? element-count)
+        (case (long element-count)
+          1 :vector-type-scalar
+          2 :vector-type-vec2
+          3 :vector-type-vec3
+          4 :vector-type-vec4))))
 
-(defn- editable-semantic-type? [semantic-type]
+(defn- overridable-semantic-type? [semantic-type]
   (case semantic-type
     :semantic-type-none true
     :semantic-type-position false
@@ -391,8 +621,8 @@
     :semantic-type-world-matrix false
     :semantic-type-normal-matrix false))
 
-(defn editable-attribute-info? [attribute-info]
-  (editable-semantic-type? (:semantic-type attribute-info default-attribute-semantic-type)))
+(defn overridable-attribute-info? [attribute-info]
+  (overridable-semantic-type? (:semantic-type attribute-info default-attribute-semantic-type)))
 
 ;; TODO(save-value-cleanup): We only really need to sanitize the attributes if a resource type has :read-defaults true.
 (defn sanitize-attribute-value-v [attribute-value]
@@ -417,13 +647,13 @@
                  (not= attribute-vector-type default-attribute-vector-type))
             (assoc :vector-type attribute-vector-type)
 
-            (editable-attribute-info? attribute)
+            (not (engine-provided-attribute? attribute))
             (assoc attribute-value-keyword {:v attribute-values}))))
 
 (defn sanitize-attribute-override [attribute]
   ;; Graphics$VertexAttribute in map format.
   (-> attribute
-      (dissoc :binary-values :coordinate-space :data-type :element-count :name-hash :normalize :semantic-type :vector-type)
+      (dissoc :binary-values :coordinate-space :data-type :element-count :name-hash :normalize :semantic-type)
       (sanitize-attribute-value-field :double-values)
       (sanitize-attribute-value-field :long-values)))
 
@@ -488,7 +718,6 @@
             :step-function :vertex-step-function-instance
             :vector-type :vector-type-mat4}])))
 
-
 (defn- compatible-vector-type [vector-type-value vector-type-container]
   (let [vector-type-value-comp-count (vector-type->component-count vector-type-value)
         vector-type-container-comp-count (vector-type->component-count vector-type-container)]
@@ -525,34 +754,56 @@
 
 (defn vertex-attribute-overrides->save-values [vertex-attribute-overrides material-attribute-infos]
   (let [declared-material-attribute-key? (into #{} (map :name-key) material-attribute-infos)
+
         material-attribute-save-values
-        (into []
-              (keep (fn [{:keys [data-type name name-key normalize semantic-type vector-type]}]
-                      (when-some [override-values (some-> vertex-attribute-overrides (get name-key) :values coll/not-empty)]
-                        ;; Ensure our saved values have the expected element-count.
-                        ;; If the material has been edited, this might have changed,
-                        ;; but specialized widgets like the one we use to edit color
-                        ;; properties may also produce a different element count from
-                        ;; what the material dictates.
-                        (let [resized-values (resize-doubles override-values semantic-type vector-type)
-                              [attribute-value-keyword stored-values] (doubles->storage resized-values data-type normalize)]
-                          (protobuf/make-map-without-defaults Graphics$VertexAttribute
-                            :name name
-                            attribute-value-keyword {:v stored-values})))))
-              material-attribute-infos)
+        (keep
+          (fn [material-attribute-info]
+            (let [attribute-key (:name-key material-attribute-info)
+                  override-info (vertex-attribute-overrides attribute-key)]
+              (when-some [override-values (coll/not-empty (:values override-info))]
+                ;; Ensure our saved values have the expected element-count.
+                ;; If the material has been edited, this might have changed,
+                ;; but edits made using specialized widgets like the one we use
+                ;; to edit color properties may also alter the vector-type from
+                ;; what the material dictates.
+                (let [{:keys [data-type name normalize semantic-type]} material-attribute-info
+                      material-attribute-vector-type (:vector-type material-attribute-info)
+                      override-attribute-vector-type (:vector-type override-info)
+                      _ (assert (vector-type? override-attribute-vector-type))
+                      converted-values (convert-double-values override-values semantic-type override-attribute-vector-type material-attribute-vector-type)
+                      [attribute-value-keyword stored-values] (doubles->storage converted-values data-type normalize)
+                      explicit-vector-type (when (disambiguating-vector-type? material-attribute-vector-type)
+                                             material-attribute-vector-type)]
+                  (protobuf/make-map-without-defaults Graphics$VertexAttribute
+                    :name name
+                    :vector-type explicit-vector-type
+                    attribute-value-keyword {:v stored-values})))))
+          material-attribute-infos)
+
         orphaned-attribute-save-values
-        (into []
-              (keep (fn [[name-key attribute-info]]
-                      (when-not (contains? declared-material-attribute-key? name-key)
-                        (let [attribute-name (:name attribute-info)
-                              attribute-value-keyword (:value-keyword attribute-info)
-                              attribute-values (:values attribute-info)]
-                          (protobuf/make-map-without-defaults Graphics$VertexAttribute
-                            :name attribute-name
-                            attribute-value-keyword (when (coll/not-empty attribute-values)
-                                                      {:v attribute-values})))))
-                    vertex-attribute-overrides))]
-    (concat material-attribute-save-values orphaned-attribute-save-values)))
+        (keep
+          (fn [[attribute-key override-info]]
+            (when-some [override-values (coll/not-empty (:values override-info))]
+              (when-not (declared-material-attribute-key? attribute-key)
+                (let [attribute-name (:name override-info)
+                      attribute-value-keyword (:value-keyword override-info)
+                      override-attribute-vector-type (:vector-type override-info)
+                      _ (assert (vector-type? override-attribute-vector-type))
+                      explicit-vector-type (when (disambiguating-vector-type? override-attribute-vector-type)
+                                             override-attribute-vector-type)]
+                  (protobuf/make-map-without-defaults Graphics$VertexAttribute
+                    :name attribute-name
+                    :vector-type explicit-vector-type
+                    attribute-value-keyword (when (coll/not-empty override-values)
+                                              {:v override-values}))))))
+          vertex-attribute-overrides)]
+
+    ;; Merge attributes from both collections and sort by name to ensure we get
+    ;; a consistent attribute order in the files.
+    (->> [material-attribute-save-values
+          orphaned-attribute-save-values]
+         (into [] cat)
+         (sort-by :name))))
 
 (defn vertex-attribute-overrides->build-target [vertex-attribute-overrides vertex-attribute-bytes material-attribute-infos]
   (into []
@@ -582,20 +833,16 @@
       :vector-type-mat3 types/Vec4
       :vector-type-mat4 types/Vec4)))
 
-(defn- attribute-expected-vector-type [{:keys [semantic-type vector-type] :as _attribute}]
-  {:pre [(keyword? vector-type)]}
-  (case semantic-type
-    :semantic-type-color :vector-type-vec4
-    vector-type))
-
-(defn- attribute-update-property [current-property-value attribute new-value]
-  (let [name-key (:name-key attribute)
+(defn- attribute-update-property [current-property-value attribute-info new-value]
+  (let [name-key (:name-key attribute-info)
         override-info (name-key current-property-value)
-        attribute-value-keyword (attribute-value-keyword (:data-type attribute) (:normalize attribute))
+        attribute-value-keyword (attribute-value-keyword (:data-type attribute-info) (:normalize attribute-info))
         override-value-keyword (or attribute-value-keyword (:value-keyword override-info))
-        override-name (or (:name attribute) (:name override-info))]
+        override-name (or (:name attribute-info) (:name override-info))
+        vector-type (:vector-type attribute-info)]
     (assoc current-property-value name-key {:values new-value
                                             :value-keyword override-value-keyword
+                                            :vector-type vector-type
                                             :name override-name})))
 
 (defn- attribute-clear-property [current-property-value {:keys [name-key] :as _attribute}]
@@ -607,16 +854,16 @@
 
 (def attribute-key->property-key (memoize attribute-key->property-key-raw))
 
-(defn- attribute-edit-type [{:keys [semantic-type vector-type] :as attribute} property-type]
+(defn- attribute-override-property-edit-type [{:keys [semantic-type vector-type] :as attribute-info} property-type]
   {:pre [(keyword? vector-type)
          (semantic-type? semantic-type)]}
-  (let [attribute-update-fn (fn [_evaluation-context self _old-value new-value]
+  (let [attribute-update-fn (fn attribute-update-fn [_evaluation-context self _old-value new-value]
                               (let [values (if (= g/Num property-type)
                                              (vector-of :double new-value)
                                              new-value)]
-                                (g/update-property self :vertex-attribute-overrides attribute-update-property attribute values)))
-        attribute-clear-fn (fn [self _property-label]
-                             (g/update-property self :vertex-attribute-overrides attribute-clear-property attribute))]
+                                (g/update-property self :vertex-attribute-overrides attribute-update-property attribute-info values)))
+        attribute-clear-fn (fn attribute-clear-fn [self _property-label]
+                             (g/update-property self :vertex-attribute-overrides attribute-clear-property attribute-info))]
     (cond-> {:type property-type
              :set-fn attribute-update-fn
              :clear-fn attribute-clear-fn}
@@ -624,58 +871,67 @@
             (= semantic-type :semantic-type-color)
             (assoc :ignore-alpha? (not= :vector-type-vec4 vector-type)))))
 
-(defn- attribute-value [attribute-values property-type semantic-type vector-type]
-  {:pre [(semantic-type? semantic-type)
-         (vector-type? vector-type)]}
+(defn- attribute-property-value [attribute-values property-type semantic-type source-vector-type target-vector-type]
   (if (= g/Num property-type)
     (first attribute-values) ; The widget expects a number, not a vector.
-    (resize-doubles attribute-values semantic-type vector-type)))
+    (convert-double-values attribute-values semantic-type source-vector-type target-vector-type)))
 
-(defn attribute-properties-by-property-key [_node-id material-attribute-infos vertex-attribute-overrides]
-  (let [name-keys (into #{} (map :name-key) material-attribute-infos)]
+(defn attribute-property-entries [_node-id material-attribute-infos vertex-attribute-overrides]
+  (let [declared-material-attribute-key? (into #{} (map :name-key) material-attribute-infos)]
     (concat
-      (keep (fn [attribute-info]
-              (when (editable-attribute-info? attribute-info)
-                (let [attribute-key (:name-key attribute-info)
-                      semantic-type (:semantic-type attribute-info)
-                      material-values (:values attribute-info)
-                      override-values (:values (vertex-attribute-overrides attribute-key))
+      ;; Original and overridden vertex attributes with a match in the material.
+      (keep (fn [material-attribute-info]
+              (when (overridable-attribute-info? material-attribute-info)
+                (let [attribute-key (:name-key material-attribute-info)
+                      semantic-type (:semantic-type material-attribute-info)
+                      override-attribute-info (vertex-attribute-overrides attribute-key)
+                      override-values (:values override-attribute-info)
+                      material-values (:values material-attribute-info)
                       attribute-values (or override-values material-values)
-                      property-type (attribute-property-type attribute-info)
-                      expected-vector-type (attribute-expected-vector-type attribute-info)
-                      edit-type (attribute-edit-type attribute-info property-type)
+                      attribute-values-vector-type (:vector-type (or override-attribute-info material-attribute-info))
+                      _ (assert (vector-type? attribute-values-vector-type))
+                      property-type (attribute-property-type material-attribute-info)
+                      property-vector-type (case semantic-type
+                                             :semantic-type-color :vector-type-vec4
+                                             (:vector-type material-attribute-info))
+                      edit-type (attribute-override-property-edit-type material-attribute-info property-type)
                       property-key (attribute-key->property-key attribute-key)
                       label (properties/keyword->name attribute-key)
-                      value (attribute-value attribute-values property-type semantic-type expected-vector-type)
+                      value (attribute-property-value attribute-values property-type semantic-type attribute-values-vector-type property-vector-type)
                       error (when (some? override-values)
-                              (validate-doubles override-values attribute-info _node-id property-key))
-                      prop {:node-id _node-id
-                            :type property-type
-                            :edit-type edit-type
-                            :label label
-                            :value value
-                            :error error}]
-                  ;; Insert the original material values as original-value if there is a vertex override.
-                  (if (some? override-values)
-                    [property-key (assoc prop :original-value material-values)]
-                    [property-key prop]))))
+                              (validate-doubles override-values material-attribute-info _node-id property-key))
+                      prop (cond-> {:node-id _node-id
+                                    :type property-type
+                                    :edit-type edit-type
+                                    :label label
+                                    :value value
+                                    :error error}
+
+                                   ;; Insert the original material values as original-value if there is a vertex override.
+                                   (some? override-values)
+                                   (assoc :original-value material-values))]
+                  (pair property-key prop))))
             material-attribute-infos)
+
+      ;; Rogue vertex attributes without a match in the material.
       (for [[name-key vertex-override-info] vertex-attribute-overrides
-            :when (not (name-keys name-key))
-            :let [values (:values vertex-override-info)
-                  vector-type (if (number? values)
-                                :vector-type-scalar
-                                (vtx/element-count+semantic-type->vector-type (count values) :semantic-type-none))
-                  assumed-attribute-info {:vector-type vector-type
+            :when (not (declared-material-attribute-key? name-key))
+            :let [name (:name vertex-override-info)
+                  values (:values vertex-override-info)
+                  semantic-type :semantic-type-none
+                  vector-type (:vector-type vertex-override-info)
+                  _ (assert (vector-type? vector-type))
+                  assumed-attribute-info {:name name
                                           :name-key name-key
-                                          :semantic-type :semantic-type-none}
+                                          :semantic-type semantic-type
+                                          :vector-type vector-type}
                   property-type (attribute-property-type assumed-attribute-info)]]
         [(attribute-key->property-key name-key)
          {:node-id _node-id
-          :value (attribute-value values property-type :semantic-type-none vector-type)
-          :label (properties/keyword->name name-key)
+          :value (attribute-property-value values property-type semantic-type vector-type vector-type)
+          :label name
           :type property-type
-          :edit-type (attribute-edit-type assumed-attribute-info property-type)
+          :edit-type (attribute-override-property-edit-type assumed-attribute-info property-type)
           :original-value []}]))))
 
 (defn attribute-bytes-by-attribute-key [_node-id material-attribute-infos vertex-attribute-overrides]
@@ -686,16 +942,18 @@
                      (let [override-info (get vertex-attribute-overrides name-key)
                            override-values (:values override-info)
                            [bytes error] (if (nil? override-values)
-                                           [(:bytes attribute-info) (:error attribute-info)]
+                                           (pair (:bytes attribute-info) (:error attribute-info))
                                            (let [{:keys [semantic-type vector-type]} attribute-info
-                                                 resized-values (resize-doubles override-values semantic-type vector-type)
-                                                 [bytes error-message :as bytes+error-message] (attribute->bytes+error-message attribute-info resized-values)]
+                                                 override-vector-type (:vector-type override-info)
+                                                 _ (assert (vector-type? override-vector-type))
+                                                 converted-values (convert-double-values override-values semantic-type override-vector-type vector-type)
+                                                 [bytes error-message :as bytes+error-message] (attribute->bytes+error-message attribute-info converted-values)]
                                              (if (nil? error-message)
                                                bytes+error-message
                                                (let [property-key (attribute-key->property-key name-key)
                                                      error (g/->error _node-id property-key :fatal override-values error-message)]
-                                                 [bytes error]))))]
-                       [name-key (or error bytes)])))
+                                                 (pair bytes error)))))]
+                       (pair name-key (or error bytes)))))
               material-attribute-infos)]
     (g/precluding-errors (vals vertex-attribute-bytes)
       vertex-attribute-bytes)))
@@ -708,47 +966,29 @@
                (assoc :vertex-elements (count vertex)))
            exception))
 
-(defn- renderable-data->world-position-v3 [renderable-data]
+(defn- renderable-data->world-positions-v3 [renderable-data]
   (let [local-positions (:position-data renderable-data)
         world-transform (:world-transform renderable-data)]
     (geom/transf-p world-transform local-positions)))
 
-(defn- renderable-data->world-position-v4 [renderable-data]
-  (let [local-positions (:position-data renderable-data)
-        world-transform (:world-transform renderable-data)]
-    (geom/transf-p4 world-transform local-positions)))
-
-(defn- renderable-data->world-direction-v3 [renderable-data->local-directions renderable-data]
-  (let [local-directions (renderable-data->local-directions renderable-data)
+(defn- renderable-data->world-normals-v3 [renderable-data]
+  (let [local-directions (:normal-data renderable-data)
         normal-transform (:normal-transform renderable-data)]
     (geom/transf-n normal-transform local-directions)))
 
-(defn- renderable-data->world-direction-v4 [renderable-data->local-directions renderable-data]
-  (let [local-directions (renderable-data->local-directions renderable-data)
-        normal-transform (:normal-transform renderable-data)]
-    (geom/transf-n4 normal-transform local-directions)))
-
-(defn- renderable-data->world-tangent-v4 [renderable-data]
+(defn- renderable-data->world-tangents-v4 [renderable-data]
   (let [tangents (:tangent-data renderable-data)
         normal-transform (:normal-transform renderable-data)]
     (geom/transf-tangents normal-transform tangents)))
 
-(def ^:private renderable-data->world-normal-v3 (partial renderable-data->world-direction-v3 :normal-data))
-(def ^:private renderable-data->world-normal-v4 (partial renderable-data->world-direction-v4 :normal-data))
-(def ^:private renderable-data->world-tangent-v3 (partial renderable-data->world-direction-v3 :tangent-data))
-
-(defn- matrix4+attribute->flat-array [^Matrix4d matrix attribute]
-  (let [vector-component-count (vector-type->component-count (:vector-type attribute))
-        matrix-flat-array (math/vecmath->clj (doto (Matrix4d. matrix) (.transpose)))
-        matrix-row-column-count (vtx/vertex-attribute->row-column-count attribute)]
-    (vec (flatten (if matrix-row-column-count
-                    (map #(take matrix-row-column-count %)
-                         (take matrix-row-column-count (partition 4 matrix-flat-array)))
-                    (take vector-component-count matrix-flat-array))))))
+(defn- mat4-double-values [^Matrix4d matrix vector-type]
+  (-> matrix
+      (geom/as-array)
+      (convert-double-values :semantic-type-none :vector-type-mat4 vector-type))) ; Semantic type does not matter for this.
 
 (defn put-attributes! [^VertexBuffer vbuf renderable-datas]
   (let [vertex-description (.vertex-description vbuf)
-        vertex-byte-stride (:size vertex-description)
+        ^long vertex-byte-stride (:size vertex-description)
         ^ByteBuffer buf (.buf vbuf)
 
         put-bytes!
@@ -764,7 +1004,7 @@
         (fn put-doubles!
           [vertex-byte-offset semantic-type buffer-data-type vector-type normalize vertices]
           (reduce (fn [^long vertex-byte-offset attribute-doubles]
-                    (let [attribute-doubles (resize-doubles attribute-doubles semantic-type vector-type)]
+                    (let [attribute-doubles (convert-double-values attribute-doubles semantic-type nil vector-type)]
                       (vtx/buf-put! buf vertex-byte-offset buffer-data-type normalize attribute-doubles))
                     (+ vertex-byte-offset vertex-byte-stride))
                   (long vertex-byte-offset)
@@ -772,7 +1012,7 @@
 
         put-renderables!
         (fn put-renderables!
-          ^long [^long attribute-byte-offset renderable-data->vertices put-vertices!]
+          ^long [^long attribute-byte-offset put-vertices! renderable-data->vertices]
           (reduce (fn [^long vertex-byte-offset renderable-data]
                     (let [vertices (renderable-data->vertices renderable-data)]
                       (put-vertices! vertex-byte-offset vertices)))
@@ -783,7 +1023,7 @@
         (let [renderable-data (first renderable-datas)
               texcoord-datas (:texcoord-datas renderable-data)]
           (if (nil? renderable-data)
-            (constantly false)
+            fn/constantly-false
             (fn mesh-data-exists? [semantic-type ^long channel]
               (case semantic-type
                 :semantic-type-position
@@ -821,7 +1061,7 @@
                     vector-type (:vector-type attribute)
                     normalize (:normalize attribute)
                     name-key (:name-key attribute)
-                    ^long attribute-byte-offset (:attribute-byte-offset reduce-info)
+                    attribute-byte-offset (long (:attribute-byte-offset reduce-info))
                     channel (get reduce-info semantic-type)
 
                     put-attribute-bytes!
@@ -849,67 +1089,52 @@
                     :semantic-type-position
                     (case (:coordinate-space attribute)
                       :coordinate-space-world
-                      (let [renderable-data->world-position
-                            (case element-count
-                              3 renderable-data->world-position-v3
-                              4 renderable-data->world-position-v4)]
-                        (put-renderables! attribute-byte-offset renderable-data->world-position put-attribute-doubles!))
-                      (put-renderables! attribute-byte-offset :position-data put-attribute-doubles!))
+                      (put-renderables! attribute-byte-offset put-attribute-doubles! renderable-data->world-positions-v3)
+                      (put-renderables! attribute-byte-offset put-attribute-doubles! :position-data))
 
                     :semantic-type-texcoord
-                    (put-renderables! attribute-byte-offset #(get-in % [:texcoord-datas channel :uv-data]) put-attribute-doubles!)
+                    (put-renderables! attribute-byte-offset put-attribute-doubles! #(get-in % [:texcoord-datas channel :uv-data]))
 
                     :semantic-type-page-index
-                    (put-renderables! attribute-byte-offset
-                                      (fn [renderable-data]
+                    (put-renderables! attribute-byte-offset put-attribute-doubles!
+                                      (fn renderable-data->page-indices [renderable-data]
                                         (let [vertex-count (count (:position-data renderable-data))
                                               page-index (get-in renderable-data [:texcoord-datas channel :page-index])]
-                                          (repeat vertex-count [(double page-index)])))
-                                      put-attribute-doubles!)
+                                          (repeat vertex-count [(double page-index)]))))
 
                     :semantic-type-color
-                    (put-renderables! attribute-byte-offset :color-data put-attribute-doubles!)
+                    (put-renderables! attribute-byte-offset put-attribute-doubles! :color-data)
 
                     :semantic-type-normal
                     (case (:coordinate-space attribute)
                       :coordinate-space-world
-                      (let [renderable-data->world-normal
-                            (case element-count
-                              3 renderable-data->world-normal-v3
-                              4 renderable-data->world-normal-v4)]
-                        (put-renderables! attribute-byte-offset renderable-data->world-normal put-attribute-doubles!))
-                      (put-renderables! attribute-byte-offset :normal-data put-attribute-doubles!))
+                      (put-renderables! attribute-byte-offset put-attribute-doubles! renderable-data->world-normals-v3)
+                      (put-renderables! attribute-byte-offset put-attribute-doubles! :normal-data))
 
                     :semantic-type-tangent
                     (case (:coordinate-space attribute)
                       :coordinate-space-world
-                      (let [renderable-data->world-tangent
-                            (case element-count
-                              3 renderable-data->world-tangent-v3
-                              4 renderable-data->world-tangent-v4)]
-                        (put-renderables! attribute-byte-offset renderable-data->world-tangent put-attribute-doubles!))
-                      (put-renderables! attribute-byte-offset :tangent-data put-attribute-doubles!))
+                      (put-renderables! attribute-byte-offset put-attribute-doubles! renderable-data->world-tangents-v4)
+                      (put-renderables! attribute-byte-offset put-attribute-doubles! :tangent-data))
 
                     :semantic-type-world-matrix
-                    (put-renderables! attribute-byte-offset
-                                      (fn [renderable-data]
+                    (put-renderables! attribute-byte-offset put-attribute-doubles!
+                                      (fn renderable-data->world-matrices [renderable-data]
                                         (let [vertex-count (count (:position-data renderable-data))
-                                              matrix-values (matrix4+attribute->flat-array (:world-transform renderable-data) attribute)]
-                                          (repeat vertex-count matrix-values)))
-                                      put-attribute-doubles!)
+                                              matrix-values (mat4-double-values (:world-transform renderable-data) vector-type)]
+                                          (repeat vertex-count matrix-values))))
 
                     :semantic-type-normal-matrix
-                    (put-renderables! attribute-byte-offset
-                                      (fn [renderable-data]
+                    (put-renderables! attribute-byte-offset put-attribute-doubles!
+                                      (fn renderable-data->normal-matrices [renderable-data]
                                         (let [vertex-count (count (:position-data renderable-data))
-                                              matrix-values (matrix4+attribute->flat-array (:normal-transform renderable-data) attribute)]
-                                          (repeat vertex-count matrix-values)))
-                                      put-attribute-doubles!))
+                                              matrix-values (mat4-double-values (:normal-transform renderable-data) vector-type)]
+                                          (repeat vertex-count matrix-values)))))
 
                   ;; Mesh data doesn't exist. Use the attribute data from the
                   ;; material or overrides.
-                  (put-renderables! attribute-byte-offset
-                                    (fn [renderable-data]
+                  (put-renderables! attribute-byte-offset put-attribute-bytes!
+                                    (fn renderable-data->attribute-bytes [renderable-data]
                                       (let [vertex-count (count (:position-data renderable-data))
                                             attribute-bytes (get (:vertex-attribute-bytes renderable-data) name-key)
                                             attribute-byte-count-max (* element-count (buffers/type-size buffer-data-type))]
@@ -918,8 +1143,7 @@
                                           (let [attribute-bytes-clamped (byte-array attribute-byte-count-max)]
                                             (System/arraycopy attribute-bytes 0 attribute-bytes-clamped 0 attribute-byte-count-max)
                                             (repeat vertex-count attribute-bytes-clamped))
-                                          (repeat vertex-count attribute-bytes))))
-                                    put-attribute-bytes!))
+                                          (repeat vertex-count attribute-bytes))))))
                 (-> reduce-info
                     (update semantic-type inc)
                     (assoc :attribute-byte-offset (+ attribute-byte-offset

--- a/editor/src/clj/editor/graphics.clj
+++ b/editor/src/clj/editor/graphics.clj
@@ -125,7 +125,7 @@
     :vector-type-mat2 true
     false))
 
-(def engine-provided-semantic-types
+(def ^:private engine-provided-semantic-types
   (into #{}
         (keep (fn [^Graphics$VertexAttribute$SemanticType pb-semantic-type]
                 (when (GraphicsUtil/isEngineProvidedAttributeSemanticType pb-semantic-type)

--- a/editor/src/clj/editor/graphics.clj
+++ b/editor/src/clj/editor/graphics.clj
@@ -653,7 +653,9 @@
 
 (defn sanitize-attribute-override [attribute]
   ;; Graphics$VertexAttribute in map format.
-  (-> attribute
+  (-> (if (disambiguating-vector-type? (:vector-type attribute default-attribute-vector-type))
+        attribute
+        (dissoc attribute :vector-type))
       (dissoc :binary-values :coordinate-space :data-type :element-count :name-hash :normalize :semantic-type)
       (sanitize-attribute-value-field :double-values)
       (sanitize-attribute-value-field :long-values)))

--- a/editor/src/clj/editor/material.clj
+++ b/editor/src/clj/editor/material.clj
@@ -275,20 +275,27 @@
                    :type :string
                    :default "new_attribute"}
        :panel-form-fn
-       (fn panel-form-fn [{:keys [semantic-type vector-type]
-                           :or {semantic-type graphics/default-attribute-semantic-type
-                                vector-type graphics/default-attribute-vector-type}
-                           :as _selected-attribute}]
+       (fn panel-form-fn [selected-attribute]
          {:sections
           [{:fields
-            (assoc vertex-attribute-fields
-              value-vertex-attribute-field-index
-              (let [type (vector-type->form-field-type vector-type)
-                    default (graphics/default-attribute-doubles semantic-type vector-type)]
-                {:path [:values]
-                 :label "Value"
-                 :type type
-                 :default default}))}]})}
+            (cond
+              (nil? selected-attribute)
+              vertex-attribute-fields
+
+              (graphics/engine-provided-attribute? selected-attribute)
+              (coll/remove-index vertex-attribute-fields value-vertex-attribute-field-index)
+
+              :else
+              (assoc vertex-attribute-fields
+                value-vertex-attribute-field-index
+                (let [semantic-type (:semantic-type selected-attribute graphics/default-attribute-semantic-type)
+                      vector-type (:vector-type selected-attribute graphics/default-attribute-vector-type)
+                      type (vector-type->form-field-type vector-type)
+                      default (graphics/default-attribute-doubles semantic-type vector-type)]
+                  {:path [:values]
+                   :label "Value"
+                   :type type
+                   :default default})))}]})}
       (render-program-utils/gen-form-data-constants "Vertex Constants" :vertex-constants)
       (render-program-utils/gen-form-data-constants "Fragment Constants" :fragment-constants)
       (render-program-utils/gen-form-data-samplers "Samplers" :samplers)

--- a/editor/src/clj/editor/material.clj
+++ b/editor/src/clj/editor/material.clj
@@ -66,7 +66,7 @@
       (-> editable-attribute
           (dissoc :values)
           (protobuf/assign attribute-value-keyword
-                           (when (and (graphics/editable-attribute-info? editable-attribute)
+                           (when (and (not (graphics/engine-provided-attribute? editable-attribute))
                                       (coll/not-empty stored-values))
                              {:v stored-values}))))))
 
@@ -292,6 +292,8 @@
         old-normalize (:normalize old-attribute)
         new-vector-type (:vector-type new-attribute)
         new-normalize (:normalize new-attribute)]
+    (assert (graphics/vector-type? old-vector-type))
+    (assert (graphics/vector-type? new-vector-type))
     (cond
       ;; If an attribute changes from a non-normalized value to a normalized one
       ;; or vice versa, attempt to remap the value range. Note that we cannot do
@@ -326,7 +328,7 @@
       ;; project to be saved with the updated vector type.
       (not= old-vector-type new-vector-type)
       (let [semantic-type (:semantic-type new-attribute)]
-        (update new-attribute :values #(graphics/resize-doubles % semantic-type new-vector-type)))
+        (update new-attribute :values #(graphics/convert-double-values % semantic-type old-vector-type new-vector-type)))
 
       ;; If something else changed, do not attempt value coercion.
       :else

--- a/editor/src/clj/editor/model.clj
+++ b/editor/src/clj/editor/model.clj
@@ -329,7 +329,7 @@
                                                         (set (keys sampler-name-index))
                                                         (set (keys texture-binding-name-index)))
                               should-be-deleted (not (mesh-material-names name))
-                              material-attribute-properties (graphics/attribute-properties-by-property-key _node-id material-attribute-infos vertex-attribute-overrides)
+                              material-attribute-properties (graphics/attribute-property-entries _node-id material-attribute-infos vertex-attribute-overrides)
                               material-binding-node-id _node-id
                               material-property [material-prop-key
                                                  (cond-> {:node-id material-binding-node-id

--- a/editor/src/clj/editor/particlefx.clj
+++ b/editor/src/clj/editor/particlefx.clj
@@ -765,7 +765,7 @@
 (g/defnk produce-properties [_node-id _declared-properties material-attribute-infos vertex-attribute-overrides]
   (let [attribute-properties
         (when-not (g/error-value? material-attribute-infos)
-          (graphics/attribute-properties-by-property-key _node-id material-attribute-infos vertex-attribute-overrides))]
+          (graphics/attribute-property-entries _node-id material-attribute-infos vertex-attribute-overrides))]
     (-> _declared-properties
         (update :properties into attribute-properties)
         (update :display-order into (map first) attribute-properties))))

--- a/editor/src/clj/editor/particlefx.clj
+++ b/editor/src/clj/editor/particlefx.clj
@@ -763,7 +763,9 @@
         (validation/prop-error :fatal _node-id :material shader/page-count-mismatch-error-message is-paged-material texture-page-count material-max-page-count "Image"))))
 
 (g/defnk produce-properties [_node-id _declared-properties material-attribute-infos vertex-attribute-overrides]
-  (let [attribute-properties (graphics/attribute-properties-by-property-key _node-id material-attribute-infos vertex-attribute-overrides)]
+  (let [attribute-properties
+        (when-not (g/error-value? material-attribute-infos)
+          (graphics/attribute-properties-by-property-key _node-id material-attribute-infos vertex-attribute-overrides))]
     (-> _declared-properties
         (update :properties into attribute-properties)
         (update :display-order into (map first) attribute-properties))))

--- a/editor/src/clj/editor/protobuf_forms.clj
+++ b/editor/src/clj/editor/protobuf_forms.clj
@@ -18,7 +18,7 @@
             [editor.protobuf :as protobuf]
             [editor.util :as util]
             [util.fn :as fn])
-  (:import [com.dynamo.graphics.proto Graphics$PlatformProfile$OS Graphics$TextureFormatAlternative$CompressionLevel Graphics$TextureImage$CompressionType Graphics$TextureImage$TextureFormat Graphics$TextureProfiles]
+  (:import [com.dynamo.graphics.proto Graphics$PlatformProfile Graphics$PlatformProfile$OS Graphics$TextureFormatAlternative$CompressionLevel Graphics$TextureImage$CompressionType Graphics$TextureImage$TextureFormat Graphics$TextureProfiles]
            [com.dynamo.input.proto Input$Gamepad Input$GamepadMaps Input$GamepadType Input$InputBinding Input$Key Input$Mouse Input$Text Input$Touch]))
 
 (set! *warn-on-reflection* true)
@@ -302,12 +302,12 @@
                                           {:path [:max-texture-size]
                                            :type :integer
                                            :label "Max texture size"
-                                           :default 0
+                                           :default (protobuf/default Graphics$PlatformProfile :max-texture-size)
                                            :optional true}
                                           {:path [:premultiply-alpha]
                                            :type :boolean
                                            :label "Premultiply alpha"
-                                           :default true
+                                           :default (protobuf/default Graphics$PlatformProfile :premultiply-alpha)
                                            :optional true}]}]}}]}]}}]}]}))
 
 (defn produce-form-data

--- a/editor/src/clj/editor/protobuf_forms.clj
+++ b/editor/src/clj/editor/protobuf_forms.clj
@@ -16,7 +16,8 @@
   (:require [clojure.string :as str]
             [dynamo.graph :as g]
             [editor.protobuf :as protobuf]
-            [editor.util :as util])
+            [editor.util :as util]
+            [util.fn :as fn])
   (:import [com.dynamo.graphics.proto Graphics$PlatformProfile$OS Graphics$TextureFormatAlternative$CompressionLevel Graphics$TextureImage$CompressionType Graphics$TextureImage$TextureFormat Graphics$TextureProfiles]
            [com.dynamo.input.proto Input$Gamepad Input$GamepadMaps Input$GamepadType Input$InputBinding Input$Key Input$Mouse Input$Text Input$Touch]))
 
@@ -48,7 +49,12 @@
 
 (defn make-options [enum-values]
   (let [prefix-size (longest-prefix-size enum-values)]
-    (map (juxt first #(display-name-or-default % prefix-size)) enum-values)))
+    (mapv (juxt first #(display-name-or-default % prefix-size)) enum-values)))
+
+(defn- make-enum-options-raw [^Class pb-enum-class]
+  (make-options (protobuf/enum-values pb-enum-class)))
+
+(def make-enum-options (fn/memoize make-enum-options-raw))
 
 (defn- default-form-ops [node-id]
   {:form-ops {:user-data {:node-id node-id}

--- a/editor/src/clj/editor/render_program_utils.clj
+++ b/editor/src/clj/editor/render_program_utils.clj
@@ -82,15 +82,40 @@
   [downgraded-constant-value]
   [downgraded-constant-value])
 
-(defn- hack-downgrade-constant [constant]
-  (protobuf/sanitize constant :value hack-downgrade-constant-value))
+(defn editable-constant-type? [constant-type]
+  (case constant-type
+    :constant-type-user true
+    :constant-type-viewproj false
+    :constant-type-world false
+    :constant-type-texture false
+    :constant-type-view false
+    :constant-type-projection false
+    :constant-type-normal false
+    :constant-type-worldview false
+    :constant-type-worldviewproj false
+    :constant-type-user-matrix4 true))
 
-(defn- hack-upgrade-constant [constant]
-  (protobuf/sanitize constant :value hack-upgrade-constant-value))
+(defn sanitize-constant [constant]
+  {:pre [(map? constant)]} ; Material$MaterialDesc$Constant in map format.
+  (cond-> constant
+          (not (editable-constant-type? (:type constant)))
+          (dissoc :value)))
 
-(def hack-downgrade-constants (partial mapv hack-downgrade-constant))
+(defn- constant->editable-constant [constant]
+  {:pre [(map? constant)]} ; Material$MaterialDesc$Constant in map format.
+  (if (editable-constant-type? (:type constant))
+    (protobuf/sanitize constant :value hack-downgrade-constant-value)
+    (assoc constant :value protobuf/vector4-zero)))
 
-(def hack-upgrade-constants (partial mapv hack-upgrade-constant))
+(defn- editable-constant->constant [constant]
+  {:pre [(map? constant)]} ; Material$MaterialDesc$Constant in map format.
+  (if (editable-constant-type? (:type constant))
+    (protobuf/sanitize constant :value hack-upgrade-constant-value)
+    (dissoc constant :value)))
+
+(def constants->editable-constants (partial mapv constant->editable-constant))
+
+(def editable-constants->constants (partial mapv editable-constant->constant))
 
 (def ^:private editable-sampler-optional-field-defaults
   (-> Material$MaterialDesc$Sampler

--- a/editor/src/clj/editor/render_target.clj
+++ b/editor/src/clj/editor/render_target.clj
@@ -49,7 +49,7 @@
                          {:path [:format]
                           :label "format"
                           :type :choicebox
-                          :options (protobuf-forms/make-options (protobuf/enum-values Graphics$TextureImage$TextureFormat))
+                          :options (protobuf-forms/make-enum-options Graphics$TextureImage$TextureFormat)
                           :default :texture-format-rgba}]}
               {:path [:depth-stencil-attachment-width]
                :label "Depth/Stencil Width"

--- a/editor/src/clj/editor/sprite.clj
+++ b/editor/src/clj/editor/sprite.clj
@@ -436,7 +436,7 @@
 
         attribute-properties
         (when-not (g/error-value? material-attribute-infos)
-          (graphics/attribute-properties-by-property-key _node-id material-attribute-infos vertex-attribute-overrides))]
+          (graphics/attribute-property-entries _node-id material-attribute-infos vertex-attribute-overrides))]
 
     (-> _declared-properties
         (update :properties (fn [props]

--- a/editor/src/clj/editor/sprite.clj
+++ b/editor/src/clj/editor/sprite.clj
@@ -385,6 +385,7 @@
         combined-name+indices (-> #{}
                                   (into (map key) texture-binding-index)
                                   (into (map key) material-sampler-index))
+
         texture-binding-properties
         (->> combined-name+indices
              sort
@@ -432,7 +433,11 @@
                        :edit-type {:type resource/Resource
                                    :ext extension
                                    :set-fn (fn/partial set-texture-binding-id sampler-name)}}])))))
-        attribute-properties (graphics/attribute-properties-by-property-key _node-id material-attribute-infos vertex-attribute-overrides)]
+
+        attribute-properties
+        (when-not (g/error-value? material-attribute-infos)
+          (graphics/attribute-properties-by-property-key _node-id material-attribute-infos vertex-attribute-overrides))]
+
     (-> _declared-properties
         (update :properties (fn [props]
                               (-> props

--- a/editor/src/clj/editor/types.clj
+++ b/editor/src/clj/editor/types.clj
@@ -85,6 +85,18 @@
                     (s/one s/Num "z")
                     (s/one s/Num "w")])
 
+(g/deftype Mat2 [(s/one s/Num "m00") (s/one s/Num "m01")
+                 (s/one s/Num "m10") (s/one s/Num "m11")])
+
+(g/deftype Mat3 [(s/one s/Num "m00") (s/one s/Num "m01") (s/one s/Num "m02")
+                 (s/one s/Num "m10") (s/one s/Num "m11") (s/one s/Num "m12")
+                 (s/one s/Num "m20") (s/one s/Num "m21") (s/one s/Num "m22")])
+
+(g/deftype Mat4 [(s/one s/Num "m00") (s/one s/Num "m01") (s/one s/Num "m02") (s/one s/Num "m03")
+                 (s/one s/Num "m10") (s/one s/Num "m11") (s/one s/Num "m12") (s/one s/Num "m13")
+                 (s/one s/Num "m20") (s/one s/Num "m21") (s/one s/Num "m22") (s/one s/Num "m23")
+                 (s/one s/Num "m30") (s/one s/Num "m31") (s/one s/Num "m32") (s/one s/Num "m33")])
+
 (g/deftype Lines [s/Str])
 
 (defn Point3d->Vec3 [^Point3d p]

--- a/editor/src/clj/util/coll.clj
+++ b/editor/src/clj/util/coll.clj
@@ -208,6 +208,13 @@
        (let [finished (apply vector-of primitive-type (take partition-length in-progress))]
          (cons finished (partition-all-primitives primitive-type partition-length step (nthrest in-progress step))))))))
 
+(defn remove-index
+  "Removes an item at the specified position in a vector"
+  [coll ^long index]
+  (-> (into (subvec coll 0 index)
+            (subvec coll (inc index)))
+      (with-meta (meta coll))))
+
 (defn separate-by
   "Separates items in the supplied collection into two based on a predicate.
   Returns a pair of [true-items, false-items]. The resulting collections will

--- a/editor/src/clj/util/coll.clj
+++ b/editor/src/clj/util/coll.clj
@@ -135,7 +135,8 @@
     (nil? coll)
     true
 
-    (counted? coll)
+    (or (counted? coll)
+        (.isArray (class coll)))
     (zero? (count coll))
 
     (instance? CharSequence coll)

--- a/editor/styling/stylesheets/components/_cljfx-form.scss
+++ b/editor/styling/stylesheets/components/_cljfx-form.scss
@@ -19,7 +19,6 @@
 .cljfx-form-fields {
   -fx-padding: 16px;
   -fx-hgap: 3px;
-  -fx-vgap: 12px;
 }
 
 .cljfx-form-icon-button {

--- a/editor/styling/stylesheets/components/_property.scss
+++ b/editor/styling/stylesheets/components/_property.scss
@@ -19,3 +19,24 @@
         -fx-alignment: center-right;
     }
 }
+
+.property-component-matrix {
+    -fx-spacing: 0;
+    -fx-padding: 0;
+    -fx-hgap: 0;
+    -fx-vgap: 7;
+
+    .label {
+        -fx-padding: 0 4px 0 8px;
+        -fx-text-fill: -df-text-dark;
+        -fx-alignment: center;
+
+        &.leftmost {
+            -fx-padding: 0 4px 0 4px;
+        }
+    }
+
+    .text-field {
+        -fx-alignment: center-right;
+    }
+}

--- a/editor/test/editor/graphics_test.clj
+++ b/editor/test/editor/graphics_test.clj
@@ -1,0 +1,307 @@
+;; Copyright 2020-2024 The Defold Foundation
+;; Copyright 2014-2020 King
+;; Copyright 2009-2014 Ragnar Svensson, Christian Murray
+;; Licensed under the Defold License version 1.0 (the "License"); you may not use
+;; this file except in compliance with the License.
+;;
+;; You may obtain a copy of the License, together with FAQs at
+;; https://www.defold.com/license
+;;
+;; Unless required by applicable law or agreed to in writing, software distributed
+;; under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+;; CONDITIONS OF ANY KIND, either express or implied. See the License for the
+;; specific language governing permissions and limitations under the License.
+
+(ns editor.graphics-test
+  (:require [clojure.test :refer :all]
+            [editor.graphics :as graphics]
+            [editor.protobuf :as protobuf]
+            [util.coll :refer [pair]])
+  (:import [com.dynamo.graphics.proto Graphics$VertexAttribute$SemanticType Graphics$VertexAttribute$VectorType]))
+
+(set! *warn-on-reflection* true)
+
+(def ^:private semantic-types (protobuf/valid-enum-values Graphics$VertexAttribute$SemanticType))
+
+(def ^:private vector-types (protobuf/valid-enum-values Graphics$VertexAttribute$VectorType))
+
+(defn- semantic-type->label
+  ^String [semantic-type]
+  (subs (name semantic-type)
+        (count "semantic-type-")))
+
+(defn- vector-type->label
+  ^String [vector-type]
+  (if vector-type
+    (subs (name vector-type)
+          (count "vector-type-"))
+    "no-values"))
+
+(deftest vector-type->component-count-test
+  (is (= {:vector-type-scalar 1
+          :vector-type-vec2 2
+          :vector-type-vec3 3
+          :vector-type-vec4 4
+          :vector-type-mat2 4
+          :vector-type-mat3 9
+          :vector-type-mat4 16}
+         (into {}
+               (map (juxt identity graphics/vector-type->component-count))
+               vector-types))))
+
+(def ^:private convert-double-values-rule-declaration
+  ;; This map describes the expected behavior of the convert-double-values
+  ;; function under various semantic-types.
+  ;;
+  ;; Format: semantic-type->old-vector-type->new-vector-type->expected-result.
+  ;;
+  ;; The nil entry for the old-vector-type details the expected result when
+  ;; resizing an empty vector to a specified new-vector-type, i.e. constructing
+  ;; a vector-type instance from nothing.
+  ;;
+  ;; We will look up the old-vector-type in the new-vector-type->expected-result
+  ;; map for each semantic-type, invoke graphics/convert-double-values, and
+  ;; verify that the result matches the value for the new-vector-type in the
+  ;; new-vector-type->expected-result map. If a particular semantic-type does
+  ;; not declare a behavior for a particular new-vector-type, we will expect the
+  ;; behavior to match :semantic-type-none.
+  ;;
+  ;; Formally, the conversion rules are:
+  ;;
+  ;; * Converting from a scalar or vector to a smaller scalar or vector will
+  ;;   truncate values from the end of the source value.
+  ;; * Converting from a scalar or vector to a larger vector will zero-fill at
+  ;;   the end, unless the semantic-type is position, color or tangent, in which
+  ;;   case the W component will be one.
+  ;; * Converting from a scalar or vector to a matrix will zero-fill at the end.
+  ;; * Converting from a matrix to a smaller matrix will use the top-left
+  ;;   portion of the source matrix.
+  ;; * Converting from a matrix to a larger matrix will write into the top-left
+  ;;   portion of the destination matrix, and fill the remaining space with the
+  ;;   identity matrix.
+  ;; * Converting from a matrix to a vector will truncate values from the end of
+  ;;   the source matrix.
+  ;;
+  ;; In addition to conversions, we have a unique set of rules for the case
+  ;; where we construct a default value from no value at all:
+  ;;
+  ;; * The default for a scalar or vector is a double vector of the appropriate
+  ;;   length. The contents are typically zeroes, but there are some special
+  ;;   cases based on the semantic-type. Colors will be initialized to opaque
+  ;;   white, and positions and tangents will have a one in the W component.
+  ;; * The default for a matrix is the identity matrix.
+  {:semantic-type-none
+   {nil
+    {:vector-type-scalar [0.0]
+     :vector-type-vec2 [0.0 0.0]
+     :vector-type-vec3 [0.0 0.0 0.0]
+     :vector-type-vec4 [0.0 0.0 0.0 0.0]
+     :vector-type-mat2 [1.0 0.0
+                        0.0 1.0]
+     :vector-type-mat3 [1.0 0.0 0.0
+                        0.0 1.0 0.0
+                        0.0 0.0 1.0]
+     :vector-type-mat4 [1.0 0.0 0.0 0.0
+                        0.0 1.0 0.0 0.0
+                        0.0 0.0 1.0 0.0
+                        0.0 0.0 0.0 1.0]}
+
+    :vector-type-scalar
+    {:vector-type-scalar [1.1]
+     :vector-type-vec2 [1.1 1.1]
+     :vector-type-vec3 [1.1 1.1 1.1]
+     :vector-type-vec4 [1.1 1.1 1.1 1.1]
+     :vector-type-mat2 [1.1 0.0
+                        0.0 1.1]
+     :vector-type-mat3 [1.1 0.0 0.0
+                        0.0 1.1 0.0
+                        0.0 0.0 1.1]
+     :vector-type-mat4 [1.1 0.0 0.0 0.0
+                        0.0 1.1 0.0 0.0
+                        0.0 0.0 1.1 0.0
+                        0.0 0.0 0.0 1.1]}
+
+    :vector-type-vec2
+    {:vector-type-scalar [1.1]
+     :vector-type-vec2 [1.1 1.2]
+     :vector-type-vec3 [1.1 1.2 0.0]
+     :vector-type-vec4 [1.1 1.2 0.0 0.0]
+     :vector-type-mat2 [1.1 1.2
+                        0.0 0.0]
+     :vector-type-mat3 [1.1 1.2 0.0
+                        0.0 0.0 0.0
+                        0.0 0.0 0.0]
+     :vector-type-mat4 [1.1 1.2 0.0 0.0
+                        0.0 0.0 0.0 0.0
+                        0.0 0.0 0.0 0.0
+                        0.0 0.0 0.0 0.0]}
+
+    :vector-type-vec3
+    {:vector-type-scalar [1.1]
+     :vector-type-vec2 [1.1 1.2]
+     :vector-type-vec3 [1.1 1.2 1.3]
+     :vector-type-vec4 [1.1 1.2 1.3 0.0]
+     :vector-type-mat2 [1.1 1.2
+                        1.3 0.0]
+     :vector-type-mat3 [1.1 1.2 1.3
+                        0.0 0.0 0.0
+                        0.0 0.0 0.0]
+     :vector-type-mat4 [1.1 1.2 1.3 0.0
+                        0.0 0.0 0.0 0.0
+                        0.0 0.0 0.0 0.0
+                        0.0 0.0 0.0 0.0]}
+
+    :vector-type-vec4
+    {:vector-type-scalar [1.1]
+     :vector-type-vec2 [1.1 1.2]
+     :vector-type-vec3 [1.1 1.2 1.3]
+     :vector-type-vec4 [1.1 1.2 1.3 4.4]
+     :vector-type-mat2 [1.1 1.2
+                        1.3 4.4]
+     :vector-type-mat3 [1.1 1.2 1.3
+                        4.4 0.0 0.0
+                        0.0 0.0 0.0]
+     :vector-type-mat4 [1.1 1.2 1.3 4.4
+                        0.0 0.0 0.0 0.0
+                        0.0 0.0 0.0 0.0
+                        0.0 0.0 0.0 0.0]}
+
+    :vector-type-mat2
+    {:vector-type-scalar [1.1]
+     :vector-type-vec2 [1.1 1.2]
+     :vector-type-vec3 [1.1 1.2 1.3]
+     :vector-type-vec4 [1.1 1.2 1.3 1.4]
+     :vector-type-mat2 [1.1 1.2
+                        1.3 1.4]
+     :vector-type-mat3 [1.1 1.2 0.0
+                        1.3 1.4 0.0
+                        0.0 0.0 1.0]
+     :vector-type-mat4 [1.1 1.2 0.0 0.0
+                        1.3 1.4 0.0 0.0
+                        0.0 0.0 1.0 0.0
+                        0.0 0.0 0.0 1.0]}
+
+    :vector-type-mat3
+    {:vector-type-scalar [1.1]
+     :vector-type-vec2 [1.1 1.2]
+     :vector-type-vec3 [1.1 1.2 1.3]
+     :vector-type-vec4 [1.1 1.2 1.3 1.4]
+     :vector-type-mat2 [1.1 1.2
+                        1.4 1.5]
+     :vector-type-mat3 [1.1 1.2 1.3
+                        1.4 1.5 1.6
+                        1.7 1.8 1.9]
+     :vector-type-mat4 [1.1 1.2 1.3 0.0
+                        1.4 1.5 1.6 0.0
+                        1.7 1.8 1.9 0.0
+                        0.0 0.0 0.0 1.0]}
+
+    :vector-type-mat4
+    {:vector-type-scalar [1.1]
+     :vector-type-vec2 [1.1 1.2]
+     :vector-type-vec3 [1.1 1.2 1.3]
+     :vector-type-vec4 [1.1 1.2 1.3 1.4]
+     :vector-type-mat2 [1.1 1.2
+                        1.5 1.6]
+     :vector-type-mat3 [1.1 1.2 1.3
+                        1.5 1.6 1.7
+                        1.9 2.0 2.1]
+     :vector-type-mat4 [1.1 1.2 1.3 1.4
+                        1.5 1.6 1.7 1.8
+                        1.9 2.0 2.1 2.2
+                        2.3 2.4 2.5 2.6]}}
+
+   :semantic-type-position
+   {nil
+    {:vector-type-vec4 [0.0 0.0 0.0 1.0]}
+
+    :vector-type-vec2
+    {:vector-type-vec4 [1.1 1.2 0.0 1.0]}
+
+    :vector-type-vec3
+    {:vector-type-vec4 [1.1 1.2 1.3 1.0]}}
+
+   :semantic-type-color
+   {nil
+    {:vector-type-scalar [1.0]
+     :vector-type-vec2 [1.0 1.0]
+     :vector-type-vec3 [1.0 1.0 1.0]
+     :vector-type-vec4 [1.0 1.0 1.0 1.0]}
+
+    :vector-type-vec2
+    {:vector-type-vec4 [1.1 1.2 0.0 1.0]}
+
+    :vector-type-vec3
+    {:vector-type-vec4 [1.1 1.2 1.3 1.0]}}
+
+   :semantic-type-tangent
+   {nil
+    {:vector-type-vec4 [0.0 0.0 0.0 1.0]}
+
+    :vector-type-vec2
+    {:vector-type-vec4 [1.1 1.2 0.0 1.0]}
+
+    :vector-type-vec3
+    {:vector-type-vec4 [1.1 1.2 1.3 1.0]}}})
+
+(deftest convert-double-values-rule-declaration-test
+  (is (= (conj vector-types nil)
+         (set (keys (convert-double-values-rule-declaration :semantic-type-none)))))
+  (is (every? #(is (= vector-types (set (keys %))))
+              (vals (convert-double-values-rule-declaration :semantic-type-none)))))
+
+(def ^:private convert-double-values-rules
+  (let [default-semantic-rules (convert-double-values-rule-declaration :semantic-type-none)]
+    (into {}
+          (map (fn [semantic-type]
+                 (let [declared-semantic-rules (convert-double-values-rule-declaration semantic-type)
+                       semantic-rules (merge-with merge default-semantic-rules declared-semantic-rules)]
+                   (pair semantic-type semantic-rules))))
+          semantic-types)))
+
+(deftest convert-double-values-rules-test
+  ;; Sanity checks to verify the rules were merged as expected.
+  (is (= {:vector-type-scalar [1.1]
+          :vector-type-vec2 [1.1 1.2]
+          :vector-type-vec3 [1.1 1.2 1.3]
+          :vector-type-vec4 [1.1 1.2 1.3 1.0]
+          :vector-type-mat2 [1.1 1.2
+                             1.3 0.0]
+          :vector-type-mat3 [1.1 1.2 1.3
+                             0.0 0.0 0.0
+                             0.0 0.0 0.0]
+          :vector-type-mat4 [1.1 1.2 1.3 0.0
+                             0.0 0.0 0.0 0.0
+                             0.0 0.0 0.0 0.0
+                             0.0 0.0 0.0 0.0]}
+         (get-in convert-double-values-rules
+                 [:semantic-type-position :vector-type-vec3])))
+  (is (= {:vector-type-scalar [1.0]
+          :vector-type-vec2 [1.0 1.0]
+          :vector-type-vec3 [1.0 1.0 1.0]
+          :vector-type-vec4 [1.0 1.0 1.0 1.0]
+          :vector-type-mat2 [1.0 0.0
+                             0.0 1.0]
+          :vector-type-mat3 [1.0 0.0 0.0
+                             0.0 1.0 0.0
+                             0.0 0.0 1.0]
+          :vector-type-mat4 [1.0 0.0 0.0 0.0
+                             0.0 1.0 0.0 0.0
+                             0.0 0.0 1.0 0.0
+                             0.0 0.0 0.0 1.0]}
+         (get-in convert-double-values-rules
+                 [:semantic-type-color nil]))))
+
+(deftest convert-double-values-test
+  (doseq [[semantic-type semantic-rules] convert-double-values-rules
+          [old-vector-type new-vector-type->expected-result] semantic-rules
+          :let [original-doubles (if old-vector-type
+                                   (new-vector-type->expected-result old-vector-type)
+                                   [])]
+          [new-vector-type expected-doubles] new-vector-type->expected-result]
+    (is (= expected-doubles
+           (graphics/convert-double-values original-doubles semantic-type old-vector-type new-vector-type))
+        (format "%s, %s -> %s"
+                (semantic-type->label semantic-type)
+                (vector-type->label old-vector-type)
+                (vector-type->label new-vector-type)))))

--- a/editor/test/integration/model_test.clj
+++ b/editor/test/integration/model_test.clj
@@ -89,14 +89,15 @@
         (is (nil? (test-util/prop-error node-id :mesh)))
         (doseq [v [nil (workspace/resolve-workspace-resource workspace "/not_found.dae")]]
           (test-util/with-prop [node-id :mesh v]
-            (is (g/error? (test-util/prop-error node-id :mesh))))))
+            (is (g/error? (test-util/prop-error node-id :mesh)))
+            (is (g/error-value? (g/node-value node-id :build-targets))))))
 
-      (testing "at least 1 material is required"
+      (testing "material must be assigned and exist"
         (is (not (g/error-value? (g/node-value node-id :build-targets))))
-        (let [material-binding-id (get-in (g/node-value node-id :material-binding-infos) [0 :_node-id])]
-          (doseq [v [nil (workspace/resolve-workspace-resource workspace "/not_found.material")]]
-            (test-util/with-prop [material-binding-id :material v]
-              (is (g/error-value? (g/node-value node-id :build-targets)))))))
+        (doseq [v [nil (workspace/resolve-workspace-resource workspace "/not_found.material")]]
+          (test-util/with-prop [node-id :__material__0 v]
+            (is (g/error? (test-util/prop-error node-id :__material__0)))
+            (is (g/error-value? (g/node-value node-id :build-targets))))))
 
       (testing "default-animation should be empty string or a valid animation"
         (is (nil? (test-util/prop-error node-id :animations)))
@@ -107,4 +108,5 @@
           (test-util/with-prop [node-id :default-animation "treasure_chest"]
             (is (not (g/error? (test-util/prop-error node-id :default-animation)))))
           (test-util/with-prop [node-id :default-animation "gurka"]
-            (is (g/error? (test-util/prop-error node-id :default-animation)))))))))
+            (is (g/error? (test-util/prop-error node-id :default-animation)))
+            (is (g/error-value? (g/node-value node-id :build-targets)))))))))

--- a/editor/test/integration/particlefx_test.clj
+++ b/editor/test/integration/particlefx_test.clj
@@ -76,7 +76,7 @@
 
 (deftest particlefx-validation
   (test-util/with-loaded-project
-    (let [node-id   (test-util/resource-node project "/particlefx/default.particlefx")
+    (let [node-id (test-util/resource-node project "/particlefx/default.particlefx")
           emitter (:node-id (test-util/outline node-id [0]))]
       (is (nil? (test-util/prop-error emitter :tile-source)))
       (doseq [v [nil (workspace/resolve-workspace-resource workspace "/not_found.atlas")]]
@@ -85,7 +85,8 @@
       (is (nil? (test-util/prop-error emitter :material)))
       (doseq [v [nil (workspace/resolve-workspace-resource workspace "/not_found.material")]]
         (test-util/with-prop [emitter :material v]
-          (is (g/error? (test-util/prop-error emitter :material)))))
+          (is (g/error? (test-util/prop-error emitter :material)))
+          (is (g/error-value? (g/node-value node-id :build-targets)))))
       (is (nil? (test-util/prop-error emitter :animation)))
       (doseq [v ["" "not_found"]]
         (test-util/with-prop [emitter :animation v]
@@ -94,7 +95,7 @@
 (deftest particle-scene
   (test-util/with-loaded-project
     (let [node-id (project/get-resource-node project "/particlefx/default.particlefx")
-          material-node (project/get-resource-node project "/materials/test_samplers.material")          
+          material-node (project/get-resource-node project "/materials/test_samplers.material")
           [emitter-a emitter-b] (g/node-value node-id :nodes)]
       (testing "uses shader and texture params from assigned material"
         (test-util/with-prop [emitter-a :material (workspace/resolve-workspace-resource workspace "/materials/test_samplers.material")]

--- a/editor/test/integration/save_data_test.clj
+++ b/editor/test/integration/save_data_test.clj
@@ -205,7 +205,7 @@
 
    'dmGraphics.VertexAttribute
    {:default
-    {"element_count" :deprecated}
+    {"element_count" :deprecated} ; Migration tested in integration.save-data-test/silent-migrations-test.
 
     [["particlefx" "emitters" "[*]" "attributes"]
      ["sprite" "attributes"]
@@ -493,7 +493,7 @@
 
    'dmRenderDDF.RenderPrototypeDesc
    {:default
-    {"materials" :deprecated}}
+    {"materials" :deprecated}} ; Migration tested in integration.save-data-test/silent-migrations-test.
 
    'dmRenderDDF.RenderTargetDesc.DepthStencilAttachment
    {:default
@@ -678,14 +678,18 @@
       (let [legacy-element-count-material (project/get-resource-node project "/silently_migrated/legacy_vertex_attribute_element_count.material")
             legacy-attributes (g/node-value legacy-element-count-material :attributes)
             vector-types-by-attribute-name (into (sorted-map)
-                                                 (map (juxt :name :vector-type))
+                                                 (map (fn [attribute]
+                                                        (pair (:name attribute)
+                                                              (select-keys attribute [:vector-type :values]))))
                                                  legacy-attributes)]
-        (is (= {"legacy_count_1" :vector-type-scalar
-                "legacy_count_2" :vector-type-vec2
-                "legacy_count_3" :vector-type-vec3
-                "legacy_count_4" :vector-type-vec4
-                "legacy_count_9" :vector-type-mat3
-                "legacy_count_16" :vector-type-mat4}
+        (is (= {"legacy_count_1" {:vector-type :vector-type-scalar
+                                  :values [1.1]}
+                "legacy_count_2" {:vector-type :vector-type-vec2
+                                  :values [1.1 1.2]}
+                "legacy_count_3" {:vector-type :vector-type-vec3
+                                  :values [1.1 1.2 1.3]}
+                "legacy_count_4" {:vector-type :vector-type-vec4
+                                  :values [1.1 1.2 1.3 1.4]}}
                vector-types-by-attribute-name))))
 
     (testing "render"

--- a/editor/test/integration/save_data_test.clj
+++ b/editor/test/integration/save_data_test.clj
@@ -214,8 +214,7 @@
      "data_type" :unused
      "normalize" :unused
      "semantic_type" :unused
-     "step_function" :unused
-     "vector_type" :unused}}
+     "step_function" :unused}}
 
    ['dmGraphics.VertexAttribute "[TYPE_FLOAT]"]
    {:default

--- a/editor/test/integration/sparse_protobuf_test.clj
+++ b/editor/test/integration/sparse_protobuf_test.clj
@@ -278,7 +278,8 @@
                   :attributes vertex-attribute}}
 
      "particlefx"
-     {:emitters {:modifiers {:properties (required {:points {:y 0.0}})}}
+     {:emitters {:modifiers {:properties (required {:points {:y 0.0}})}
+                 :attributes vertex-attribute}
       :modifiers {:properties (required {:points (required {:y 0.0})})}}
 
      "sprite"

--- a/editor/test/integration/test_util.clj
+++ b/editor/test/integration/test_util.clj
@@ -783,8 +783,10 @@
   (let [[node-id# property# value#] binding]
     `(let [old-value# (prop ~node-id# ~property#)]
        (prop! ~node-id# ~property# ~value#)
-       ~@forms
-       (prop! ~node-id# ~property# old-value#))))
+       (try
+         ~@forms
+         (finally
+           (prop! ~node-id# ~property# old-value#))))))
 
 (defn make-call-logger
   "Returns a function that keeps track of its invocations. Every

--- a/editor/test/resources/save_data_project/checked.compute
+++ b/editor/test/resources/save_data_project/checked.compute
@@ -12,8 +12,6 @@ constants {
 constants {
   name: "constant_2"
   type: CONSTANT_TYPE_VIEWPROJ
-  value {
-  }
 }
 samplers {
   name: "texture0"

--- a/editor/test/resources/save_data_project/checked.material
+++ b/editor/test/resources/save_data_project/checked.material
@@ -16,8 +16,6 @@ vertex_constants {
 vertex_constants {
   name: "viewproj"
   type: CONSTANT_TYPE_VIEWPROJ
-  value {
-  }
 }
 fragment_constants {
   name: "screensize"
@@ -32,8 +30,6 @@ fragment_constants {
 fragment_constants {
   name: "proj"
   type: CONSTANT_TYPE_PROJECTION
-  value {
-  }
 }
 samplers {
   name: "texture0"
@@ -56,11 +52,6 @@ attributes {
   name: "position"
   semantic_type: SEMANTIC_TYPE_POSITION
   coordinate_space: COORDINATE_SPACE_WORLD
-  double_values {
-    v: 0.0
-    v: 0.0
-    v: 0.0
-  }
   vector_type: VECTOR_TYPE_VEC3
 }
 attributes {
@@ -68,8 +59,8 @@ attributes {
   semantic_type: SEMANTIC_TYPE_TEXCOORD
   normalize: true
   double_values {
-    v: 0.0
-    v: 0.0
+    v: 0.1
+    v: 0.2
   }
   vector_type: VECTOR_TYPE_VEC2
 }
@@ -78,7 +69,7 @@ attributes {
   semantic_type: SEMANTIC_TYPE_PAGE_INDEX
   data_type: TYPE_UNSIGNED_INT
   long_values {
-    v: 0
+    v: 1
   }
   vector_type: VECTOR_TYPE_SCALAR
 }
@@ -89,9 +80,9 @@ attributes {
   data_type: TYPE_BYTE
   coordinate_space: COORDINATE_SPACE_WORLD
   double_values {
-    v: 1.0
-    v: 1.0
-    v: 1.0
+    v: 0.1
+    v: 0.2
+    v: 0.3
   }
   vector_type: VECTOR_TYPE_VEC3
 }
@@ -102,9 +93,9 @@ attributes {
   data_type: TYPE_UNSIGNED_BYTE
   coordinate_space: COORDINATE_SPACE_WORLD
   double_values {
-    v: 1.0
-    v: 1.0
-    v: 1.0
+    v: 0.1
+    v: 0.2
+    v: 0.3
   }
   vector_type: VECTOR_TYPE_VEC3
 }
@@ -115,9 +106,9 @@ attributes {
   data_type: TYPE_SHORT
   coordinate_space: COORDINATE_SPACE_WORLD
   double_values {
-    v: 1.0
-    v: 1.0
-    v: 1.0
+    v: 0.1
+    v: 0.2
+    v: 0.3
   }
   vector_type: VECTOR_TYPE_VEC3
 }
@@ -128,9 +119,9 @@ attributes {
   data_type: TYPE_UNSIGNED_SHORT
   coordinate_space: COORDINATE_SPACE_WORLD
   double_values {
-    v: 1.0
-    v: 1.0
-    v: 1.0
+    v: 0.1
+    v: 0.2
+    v: 0.3
   }
   vector_type: VECTOR_TYPE_VEC3
 }
@@ -141,9 +132,9 @@ attributes {
   data_type: TYPE_INT
   coordinate_space: COORDINATE_SPACE_WORLD
   double_values {
-    v: 1.0
-    v: 1.0
-    v: 1.0
+    v: 0.1
+    v: 0.2
+    v: 0.3
   }
   vector_type: VECTOR_TYPE_VEC3
 }
@@ -154,9 +145,9 @@ attributes {
   data_type: TYPE_UNSIGNED_INT
   coordinate_space: COORDINATE_SPACE_WORLD
   double_values {
-    v: 1.0
-    v: 1.0
-    v: 1.0
+    v: 0.1
+    v: 0.2
+    v: 0.3
   }
   vector_type: VECTOR_TYPE_VEC3
 }
@@ -166,9 +157,9 @@ attributes {
   normalize: true
   coordinate_space: COORDINATE_SPACE_WORLD
   double_values {
-    v: 1.0
-    v: 1.0
-    v: 1.0
+    v: 0.1
+    v: 0.2
+    v: 0.3
   }
   vector_type: VECTOR_TYPE_VEC3
 }
@@ -230,58 +221,29 @@ attributes {
   name: "float"
   coordinate_space: COORDINATE_SPACE_WORLD
   double_values {
-    v: 1.0
+    v: 1.1
   }
   vector_type: VECTOR_TYPE_SCALAR
 }
 attributes {
   name: "instance_world"
   semantic_type: SEMANTIC_TYPE_WORLD_MATRIX
-  double_values {
-    v: 1.0
-    v: 0.0
-    v: 0.0
-    v: 0.0
-    v: 0.0
-    v: 1.0
-    v: 0.0
-    v: 0.0
-    v: 0.0
-    v: 0.0
-    v: 1.0
-    v: 0.0
-    v: 0.0
-    v: 0.0
-    v: 0.0
-    v: 1.0
-  }
   step_function: VERTEX_STEP_FUNCTION_INSTANCE
   vector_type: VECTOR_TYPE_MAT4
 }
 attributes {
   name: "instance_normal"
   semantic_type: SEMANTIC_TYPE_NORMAL_MATRIX
-  double_values {
-    v: 1.0
-    v: 0.0
-    v: 0.0
-    v: 0.0
-    v: 0.0
-    v: 1.0
-    v: 0.0
-    v: 0.0
-    v: 0.0
-  }
   step_function: VERTEX_STEP_FUNCTION_INSTANCE
   vector_type: VECTOR_TYPE_MAT3
 }
 attributes {
   name: "instance_custom"
   double_values {
-    v: 1.0
-    v: 0.0
-    v: 0.0
-    v: 0.0
+    v: 1.1
+    v: 1.2
+    v: 1.3
+    v: 1.4
   }
   step_function: VERTEX_STEP_FUNCTION_INSTANCE
 }
@@ -290,9 +252,9 @@ attributes {
   data_type: TYPE_BYTE
   long_values {
     v: 1
-    v: 0
-    v: 0
-    v: 0
+    v: 2
+    v: 3
+    v: 4
   }
   step_function: VERTEX_STEP_FUNCTION_INSTANCE
 }
@@ -301,9 +263,9 @@ attributes {
   data_type: TYPE_INT
   long_values {
     v: 1
-    v: 0
-    v: 0
-    v: 0
+    v: 2
+    v: 3
+    v: 4
   }
   step_function: VERTEX_STEP_FUNCTION_INSTANCE
 }
@@ -311,10 +273,10 @@ attributes {
   name: "instance_custom_short"
   data_type: TYPE_SHORT
   long_values {
-    v: 0
-    v: 0
-    v: 0
-    v: 0
+    v: 1
+    v: 2
+    v: 3
+    v: 4
   }
   step_function: VERTEX_STEP_FUNCTION_INSTANCE
 }
@@ -322,10 +284,10 @@ attributes {
   name: "instance_custom_ubyte"
   data_type: TYPE_UNSIGNED_BYTE
   long_values {
-    v: 0
-    v: 0
-    v: 0
-    v: 0
+    v: 1
+    v: 2
+    v: 3
+    v: 4
   }
   step_function: VERTEX_STEP_FUNCTION_INSTANCE
 }
@@ -333,10 +295,10 @@ attributes {
   name: "instance_custom_uint"
   data_type: TYPE_UNSIGNED_INT
   long_values {
-    v: 0
-    v: 0
-    v: 0
-    v: 0
+    v: 1
+    v: 2
+    v: 3
+    v: 4
   }
   step_function: VERTEX_STEP_FUNCTION_INSTANCE
 }
@@ -344,10 +306,10 @@ attributes {
   name: "instance_custom_ushort"
   data_type: TYPE_UNSIGNED_SHORT
   long_values {
-    v: 0
-    v: 0
-    v: 0
-    v: 0
+    v: 1
+    v: 2
+    v: 3
+    v: 4
   }
   step_function: VERTEX_STEP_FUNCTION_INSTANCE
 }

--- a/editor/test/resources/save_data_project/checked.material
+++ b/editor/test/resources/save_data_project/checked.material
@@ -238,6 +238,56 @@ attributes {
   vector_type: VECTOR_TYPE_MAT3
 }
 attributes {
+  name: "instance_custom_mat2"
+  double_values {
+    v: 1.1
+    v: 0.0
+    v: 0.0
+    v: 1.1
+  }
+  step_function: VERTEX_STEP_FUNCTION_INSTANCE
+  vector_type: VECTOR_TYPE_MAT2
+}
+attributes {
+  name: "instance_custom_mat3"
+  double_values {
+    v: 1.1
+    v: 0.0
+    v: 0.0
+    v: 0.0
+    v: 1.1
+    v: 0.0
+    v: 0.0
+    v: 0.0
+    v: 1.1
+  }
+  step_function: VERTEX_STEP_FUNCTION_INSTANCE
+  vector_type: VECTOR_TYPE_MAT3
+}
+attributes {
+  name: "instance_custom_mat4"
+  double_values {
+    v: 1.1
+    v: 0.0
+    v: 0.0
+    v: 0.0
+    v: 0.0
+    v: 1.1
+    v: 0.0
+    v: 0.0
+    v: 0.0
+    v: 0.0
+    v: 1.1
+    v: 0.0
+    v: 0.0
+    v: 0.0
+    v: 0.0
+    v: 1.1
+  }
+  step_function: VERTEX_STEP_FUNCTION_INSTANCE
+  vector_type: VECTOR_TYPE_MAT4
+}
+attributes {
   name: "instance_custom"
   double_values {
     v: 1.1

--- a/editor/test/resources/save_data_project/checked.model
+++ b/editor/test/resources/save_data_project/checked.model
@@ -23,93 +23,7 @@ materials {
     texture: "/referenced/images/blue.png"
   }
   attributes {
-    name: "normalized_byte"
-    double_values {
-      v: 1.0
-      v: 1.0
-      v: 0.0
-    }
-  }
-  attributes {
-    name: "normalized_unsigned_byte"
-    double_values {
-      v: 1.0
-      v: 1.0
-      v: 0.0
-    }
-  }
-  attributes {
-    name: "normalized_short"
-    double_values {
-      v: 1.0
-      v: 1.0
-      v: 0.0
-    }
-  }
-  attributes {
-    name: "normalized_unsigned_short"
-    double_values {
-      v: 1.0
-      v: 1.0
-      v: 0.0
-    }
-  }
-  attributes {
-    name: "normalized_int"
-    double_values {
-      v: 1.0
-      v: 1.0
-      v: 0.0
-    }
-  }
-  attributes {
-    name: "normalized_unsigned_int"
-    double_values {
-      v: 1.0
-      v: 1.0
-      v: 0.0
-    }
-  }
-  attributes {
-    name: "normalized_float"
-    double_values {
-      v: 1.0
-      v: 1.0
-      v: 0.0
-    }
-  }
-  attributes {
     name: "byte"
-    long_values {
-      v: 2
-    }
-  }
-  attributes {
-    name: "unsigned_byte"
-    long_values {
-      v: 2
-    }
-  }
-  attributes {
-    name: "short"
-    long_values {
-      v: 2
-    }
-  }
-  attributes {
-    name: "unsigned_short"
-    long_values {
-      v: 2
-    }
-  }
-  attributes {
-    name: "int"
-    long_values {
-      v: 2
-    }
-  }
-  attributes {
-    name: "unsigned_int"
     long_values {
       v: 2
     }
@@ -126,6 +40,92 @@ materials {
       v: 2.0
       v: 0.0
       v: 0.0
+    }
+  }
+  attributes {
+    name: "int"
+    long_values {
+      v: 2
+    }
+  }
+  attributes {
+    name: "normalized_byte"
+    double_values {
+      v: 1.0
+      v: 1.0
+      v: 0.0
+    }
+  }
+  attributes {
+    name: "normalized_float"
+    double_values {
+      v: 1.0
+      v: 1.0
+      v: 0.0
+    }
+  }
+  attributes {
+    name: "normalized_int"
+    double_values {
+      v: 1.0
+      v: 1.0
+      v: 0.0
+    }
+  }
+  attributes {
+    name: "normalized_short"
+    double_values {
+      v: 1.0
+      v: 1.0
+      v: 0.0
+    }
+  }
+  attributes {
+    name: "normalized_unsigned_byte"
+    double_values {
+      v: 1.0
+      v: 1.0
+      v: 0.0
+    }
+  }
+  attributes {
+    name: "normalized_unsigned_int"
+    double_values {
+      v: 1.0
+      v: 1.0
+      v: 0.0
+    }
+  }
+  attributes {
+    name: "normalized_unsigned_short"
+    double_values {
+      v: 1.0
+      v: 1.0
+      v: 0.0
+    }
+  }
+  attributes {
+    name: "short"
+    long_values {
+      v: 2
+    }
+  }
+  attributes {
+    name: "unsigned_byte"
+    long_values {
+      v: 2
+    }
+  }
+  attributes {
+    name: "unsigned_int"
+    long_values {
+      v: 2
+    }
+  }
+  attributes {
+    name: "unsigned_short"
+    long_values {
+      v: 2
     }
   }
 }

--- a/editor/test/resources/save_data_project/checked.model
+++ b/editor/test/resources/save_data_project/checked.model
@@ -40,6 +40,52 @@ materials {
       v: 2.0
       v: 0.0
       v: 0.0
+      v: 0.0
+    }
+  }
+  attributes {
+    name: "instance_custom_mat2"
+    double_values {
+      v: 1.2
+      v: 0.0
+      v: 0.0
+      v: 1.2
+    }
+    vector_type: VECTOR_TYPE_MAT2
+  }
+  attributes {
+    name: "instance_custom_mat3"
+    double_values {
+      v: 1.2
+      v: 0.0
+      v: 0.0
+      v: 0.0
+      v: 1.2
+      v: 0.0
+      v: 0.0
+      v: 0.0
+      v: 1.2
+    }
+  }
+  attributes {
+    name: "instance_custom_mat4"
+    double_values {
+      v: 1.2
+      v: 0.0
+      v: 0.0
+      v: 0.0
+      v: 0.0
+      v: 1.2
+      v: 0.0
+      v: 0.0
+      v: 0.0
+      v: 0.0
+      v: 1.2
+      v: 0.0
+      v: 0.0
+      v: 0.0
+      v: 0.0
+      v: 1.2
     }
   }
   attributes {

--- a/editor/test/resources/save_data_project/checked.particlefx
+++ b/editor/test/resources/save_data_project/checked.particlefx
@@ -378,6 +378,51 @@ emitters {
     }
   }
   attributes {
+    name: "instance_custom_mat2"
+    double_values {
+      v: 1.2
+      v: 0.0
+      v: 0.0
+      v: 1.2
+    }
+    vector_type: VECTOR_TYPE_MAT2
+  }
+  attributes {
+    name: "instance_custom_mat3"
+    double_values {
+      v: 1.2
+      v: 0.0
+      v: 0.0
+      v: 0.0
+      v: 1.2
+      v: 0.0
+      v: 0.0
+      v: 0.0
+      v: 1.2
+    }
+  }
+  attributes {
+    name: "instance_custom_mat4"
+    double_values {
+      v: 1.2
+      v: 0.0
+      v: 0.0
+      v: 0.0
+      v: 0.0
+      v: 1.2
+      v: 0.0
+      v: 0.0
+      v: 0.0
+      v: 0.0
+      v: 1.2
+      v: 0.0
+      v: 0.0
+      v: 0.0
+      v: 0.0
+      v: 1.2
+    }
+  }
+  attributes {
     name: "int"
     long_values {
       v: 2
@@ -841,6 +886,51 @@ emitters {
       v: 0.0
       v: 0.0
       v: 0.0
+    }
+  }
+  attributes {
+    name: "instance_custom_mat2"
+    double_values {
+      v: 1.2
+      v: 0.0
+      v: 0.0
+      v: 1.2
+    }
+    vector_type: VECTOR_TYPE_MAT2
+  }
+  attributes {
+    name: "instance_custom_mat3"
+    double_values {
+      v: 1.2
+      v: 0.0
+      v: 0.0
+      v: 0.0
+      v: 1.2
+      v: 0.0
+      v: 0.0
+      v: 0.0
+      v: 1.2
+    }
+  }
+  attributes {
+    name: "instance_custom_mat4"
+    double_values {
+      v: 1.2
+      v: 0.0
+      v: 0.0
+      v: 0.0
+      v: 0.0
+      v: 1.2
+      v: 0.0
+      v: 0.0
+      v: 0.0
+      v: 0.0
+      v: 1.2
+      v: 0.0
+      v: 0.0
+      v: 0.0
+      v: 0.0
+      v: 1.2
     }
   }
   attributes {
@@ -1310,6 +1400,51 @@ emitters {
     }
   }
   attributes {
+    name: "instance_custom_mat2"
+    double_values {
+      v: 1.2
+      v: 0.0
+      v: 0.0
+      v: 1.2
+    }
+    vector_type: VECTOR_TYPE_MAT2
+  }
+  attributes {
+    name: "instance_custom_mat3"
+    double_values {
+      v: 1.2
+      v: 0.0
+      v: 0.0
+      v: 0.0
+      v: 1.2
+      v: 0.0
+      v: 0.0
+      v: 0.0
+      v: 1.2
+    }
+  }
+  attributes {
+    name: "instance_custom_mat4"
+    double_values {
+      v: 1.2
+      v: 0.0
+      v: 0.0
+      v: 0.0
+      v: 0.0
+      v: 1.2
+      v: 0.0
+      v: 0.0
+      v: 0.0
+      v: 0.0
+      v: 1.2
+      v: 0.0
+      v: 0.0
+      v: 0.0
+      v: 0.0
+      v: 1.2
+    }
+  }
+  attributes {
     name: "int"
     long_values {
       v: 2
@@ -1776,6 +1911,51 @@ emitters {
     }
   }
   attributes {
+    name: "instance_custom_mat2"
+    double_values {
+      v: 1.2
+      v: 0.0
+      v: 0.0
+      v: 1.2
+    }
+    vector_type: VECTOR_TYPE_MAT2
+  }
+  attributes {
+    name: "instance_custom_mat3"
+    double_values {
+      v: 1.2
+      v: 0.0
+      v: 0.0
+      v: 0.0
+      v: 1.2
+      v: 0.0
+      v: 0.0
+      v: 0.0
+      v: 1.2
+    }
+  }
+  attributes {
+    name: "instance_custom_mat4"
+    double_values {
+      v: 1.2
+      v: 0.0
+      v: 0.0
+      v: 0.0
+      v: 0.0
+      v: 1.2
+      v: 0.0
+      v: 0.0
+      v: 0.0
+      v: 0.0
+      v: 1.2
+      v: 0.0
+      v: 0.0
+      v: 0.0
+      v: 0.0
+      v: 1.2
+    }
+  }
+  attributes {
     name: "int"
     long_values {
       v: 2
@@ -2239,6 +2419,51 @@ emitters {
       v: 0.0
       v: 0.0
       v: 0.0
+    }
+  }
+  attributes {
+    name: "instance_custom_mat2"
+    double_values {
+      v: 1.2
+      v: 0.0
+      v: 0.0
+      v: 1.2
+    }
+    vector_type: VECTOR_TYPE_MAT2
+  }
+  attributes {
+    name: "instance_custom_mat3"
+    double_values {
+      v: 1.2
+      v: 0.0
+      v: 0.0
+      v: 0.0
+      v: 1.2
+      v: 0.0
+      v: 0.0
+      v: 0.0
+      v: 1.2
+    }
+  }
+  attributes {
+    name: "instance_custom_mat4"
+    double_values {
+      v: 1.2
+      v: 0.0
+      v: 0.0
+      v: 0.0
+      v: 0.0
+      v: 1.2
+      v: 0.0
+      v: 0.0
+      v: 0.0
+      v: 0.0
+      v: 1.2
+      v: 0.0
+      v: 0.0
+      v: 0.0
+      v: 0.0
+      v: 1.2
     }
   }
   attributes {

--- a/editor/test/resources/save_data_project/checked.particlefx
+++ b/editor/test/resources/save_data_project/checked.particlefx
@@ -357,93 +357,7 @@ emitters {
     z: 1.3
   }
   attributes {
-    name: "normalized_byte"
-    double_values {
-      v: 1.0
-      v: 1.0
-      v: 0.0
-    }
-  }
-  attributes {
-    name: "normalized_unsigned_byte"
-    double_values {
-      v: 1.0
-      v: 1.0
-      v: 0.0
-    }
-  }
-  attributes {
-    name: "normalized_short"
-    double_values {
-      v: 1.0
-      v: 1.0
-      v: 0.0
-    }
-  }
-  attributes {
-    name: "normalized_unsigned_short"
-    double_values {
-      v: 1.0
-      v: 1.0
-      v: 0.0
-    }
-  }
-  attributes {
-    name: "normalized_int"
-    double_values {
-      v: 1.0
-      v: 1.0
-      v: 0.0
-    }
-  }
-  attributes {
-    name: "normalized_unsigned_int"
-    double_values {
-      v: 1.0
-      v: 1.0
-      v: 0.0
-    }
-  }
-  attributes {
-    name: "normalized_float"
-    double_values {
-      v: 1.0
-      v: 1.0
-      v: 0.0
-    }
-  }
-  attributes {
     name: "byte"
-    long_values {
-      v: 2
-    }
-  }
-  attributes {
-    name: "unsigned_byte"
-    long_values {
-      v: 2
-    }
-  }
-  attributes {
-    name: "short"
-    long_values {
-      v: 2
-    }
-  }
-  attributes {
-    name: "unsigned_short"
-    long_values {
-      v: 2
-    }
-  }
-  attributes {
-    name: "int"
-    long_values {
-      v: 2
-    }
-  }
-  attributes {
-    name: "unsigned_int"
     long_values {
       v: 2
     }
@@ -461,6 +375,92 @@ emitters {
       v: 0.0
       v: 0.0
       v: 0.0
+    }
+  }
+  attributes {
+    name: "int"
+    long_values {
+      v: 2
+    }
+  }
+  attributes {
+    name: "normalized_byte"
+    double_values {
+      v: 1.0
+      v: 1.0
+      v: 0.0
+    }
+  }
+  attributes {
+    name: "normalized_float"
+    double_values {
+      v: 1.0
+      v: 1.0
+      v: 0.0
+    }
+  }
+  attributes {
+    name: "normalized_int"
+    double_values {
+      v: 1.0
+      v: 1.0
+      v: 0.0
+    }
+  }
+  attributes {
+    name: "normalized_short"
+    double_values {
+      v: 1.0
+      v: 1.0
+      v: 0.0
+    }
+  }
+  attributes {
+    name: "normalized_unsigned_byte"
+    double_values {
+      v: 1.0
+      v: 1.0
+      v: 0.0
+    }
+  }
+  attributes {
+    name: "normalized_unsigned_int"
+    double_values {
+      v: 1.0
+      v: 1.0
+      v: 0.0
+    }
+  }
+  attributes {
+    name: "normalized_unsigned_short"
+    double_values {
+      v: 1.0
+      v: 1.0
+      v: 0.0
+    }
+  }
+  attributes {
+    name: "short"
+    long_values {
+      v: 2
+    }
+  }
+  attributes {
+    name: "unsigned_byte"
+    long_values {
+      v: 2
+    }
+  }
+  attributes {
+    name: "unsigned_int"
+    long_values {
+      v: 2
+    }
+  }
+  attributes {
+    name: "unsigned_short"
+    long_values {
+      v: 2
     }
   }
 }
@@ -823,93 +823,7 @@ emitters {
     z: 1.3
   }
   attributes {
-    name: "normalized_byte"
-    double_values {
-      v: 1.0
-      v: 1.0
-      v: 0.0
-    }
-  }
-  attributes {
-    name: "normalized_unsigned_byte"
-    double_values {
-      v: 1.0
-      v: 1.0
-      v: 0.0
-    }
-  }
-  attributes {
-    name: "normalized_short"
-    double_values {
-      v: 1.0
-      v: 1.0
-      v: 0.0
-    }
-  }
-  attributes {
-    name: "normalized_unsigned_short"
-    double_values {
-      v: 1.0
-      v: 1.0
-      v: 0.0
-    }
-  }
-  attributes {
-    name: "normalized_int"
-    double_values {
-      v: 1.0
-      v: 1.0
-      v: 0.0
-    }
-  }
-  attributes {
-    name: "normalized_unsigned_int"
-    double_values {
-      v: 1.0
-      v: 1.0
-      v: 0.0
-    }
-  }
-  attributes {
-    name: "normalized_float"
-    double_values {
-      v: 1.0
-      v: 1.0
-      v: 0.0
-    }
-  }
-  attributes {
     name: "byte"
-    long_values {
-      v: 2
-    }
-  }
-  attributes {
-    name: "unsigned_byte"
-    long_values {
-      v: 2
-    }
-  }
-  attributes {
-    name: "short"
-    long_values {
-      v: 2
-    }
-  }
-  attributes {
-    name: "unsigned_short"
-    long_values {
-      v: 2
-    }
-  }
-  attributes {
-    name: "int"
-    long_values {
-      v: 2
-    }
-  }
-  attributes {
-    name: "unsigned_int"
     long_values {
       v: 2
     }
@@ -927,6 +841,92 @@ emitters {
       v: 0.0
       v: 0.0
       v: 0.0
+    }
+  }
+  attributes {
+    name: "int"
+    long_values {
+      v: 2
+    }
+  }
+  attributes {
+    name: "normalized_byte"
+    double_values {
+      v: 1.0
+      v: 1.0
+      v: 0.0
+    }
+  }
+  attributes {
+    name: "normalized_float"
+    double_values {
+      v: 1.0
+      v: 1.0
+      v: 0.0
+    }
+  }
+  attributes {
+    name: "normalized_int"
+    double_values {
+      v: 1.0
+      v: 1.0
+      v: 0.0
+    }
+  }
+  attributes {
+    name: "normalized_short"
+    double_values {
+      v: 1.0
+      v: 1.0
+      v: 0.0
+    }
+  }
+  attributes {
+    name: "normalized_unsigned_byte"
+    double_values {
+      v: 1.0
+      v: 1.0
+      v: 0.0
+    }
+  }
+  attributes {
+    name: "normalized_unsigned_int"
+    double_values {
+      v: 1.0
+      v: 1.0
+      v: 0.0
+    }
+  }
+  attributes {
+    name: "normalized_unsigned_short"
+    double_values {
+      v: 1.0
+      v: 1.0
+      v: 0.0
+    }
+  }
+  attributes {
+    name: "short"
+    long_values {
+      v: 2
+    }
+  }
+  attributes {
+    name: "unsigned_byte"
+    long_values {
+      v: 2
+    }
+  }
+  attributes {
+    name: "unsigned_int"
+    long_values {
+      v: 2
+    }
+  }
+  attributes {
+    name: "unsigned_short"
+    long_values {
+      v: 2
     }
   }
 }
@@ -1289,93 +1289,7 @@ emitters {
     z: 1.3
   }
   attributes {
-    name: "normalized_byte"
-    double_values {
-      v: 1.0
-      v: 1.0
-      v: 0.0
-    }
-  }
-  attributes {
-    name: "normalized_unsigned_byte"
-    double_values {
-      v: 1.0
-      v: 1.0
-      v: 0.0
-    }
-  }
-  attributes {
-    name: "normalized_short"
-    double_values {
-      v: 1.0
-      v: 1.0
-      v: 0.0
-    }
-  }
-  attributes {
-    name: "normalized_unsigned_short"
-    double_values {
-      v: 1.0
-      v: 1.0
-      v: 0.0
-    }
-  }
-  attributes {
-    name: "normalized_int"
-    double_values {
-      v: 1.0
-      v: 1.0
-      v: 0.0
-    }
-  }
-  attributes {
-    name: "normalized_unsigned_int"
-    double_values {
-      v: 1.0
-      v: 1.0
-      v: 0.0
-    }
-  }
-  attributes {
-    name: "normalized_float"
-    double_values {
-      v: 1.0
-      v: 1.0
-      v: 0.0
-    }
-  }
-  attributes {
     name: "byte"
-    long_values {
-      v: 2
-    }
-  }
-  attributes {
-    name: "unsigned_byte"
-    long_values {
-      v: 2
-    }
-  }
-  attributes {
-    name: "short"
-    long_values {
-      v: 2
-    }
-  }
-  attributes {
-    name: "unsigned_short"
-    long_values {
-      v: 2
-    }
-  }
-  attributes {
-    name: "int"
-    long_values {
-      v: 2
-    }
-  }
-  attributes {
-    name: "unsigned_int"
     long_values {
       v: 2
     }
@@ -1393,6 +1307,92 @@ emitters {
       v: 0.0
       v: 0.0
       v: 0.0
+    }
+  }
+  attributes {
+    name: "int"
+    long_values {
+      v: 2
+    }
+  }
+  attributes {
+    name: "normalized_byte"
+    double_values {
+      v: 1.0
+      v: 1.0
+      v: 0.0
+    }
+  }
+  attributes {
+    name: "normalized_float"
+    double_values {
+      v: 1.0
+      v: 1.0
+      v: 0.0
+    }
+  }
+  attributes {
+    name: "normalized_int"
+    double_values {
+      v: 1.0
+      v: 1.0
+      v: 0.0
+    }
+  }
+  attributes {
+    name: "normalized_short"
+    double_values {
+      v: 1.0
+      v: 1.0
+      v: 0.0
+    }
+  }
+  attributes {
+    name: "normalized_unsigned_byte"
+    double_values {
+      v: 1.0
+      v: 1.0
+      v: 0.0
+    }
+  }
+  attributes {
+    name: "normalized_unsigned_int"
+    double_values {
+      v: 1.0
+      v: 1.0
+      v: 0.0
+    }
+  }
+  attributes {
+    name: "normalized_unsigned_short"
+    double_values {
+      v: 1.0
+      v: 1.0
+      v: 0.0
+    }
+  }
+  attributes {
+    name: "short"
+    long_values {
+      v: 2
+    }
+  }
+  attributes {
+    name: "unsigned_byte"
+    long_values {
+      v: 2
+    }
+  }
+  attributes {
+    name: "unsigned_int"
+    long_values {
+      v: 2
+    }
+  }
+  attributes {
+    name: "unsigned_short"
+    long_values {
+      v: 2
     }
   }
 }
@@ -1755,93 +1755,7 @@ emitters {
     z: 1.3
   }
   attributes {
-    name: "normalized_byte"
-    double_values {
-      v: 1.0
-      v: 1.0
-      v: 0.0
-    }
-  }
-  attributes {
-    name: "normalized_unsigned_byte"
-    double_values {
-      v: 1.0
-      v: 1.0
-      v: 0.0
-    }
-  }
-  attributes {
-    name: "normalized_short"
-    double_values {
-      v: 1.0
-      v: 1.0
-      v: 0.0
-    }
-  }
-  attributes {
-    name: "normalized_unsigned_short"
-    double_values {
-      v: 1.0
-      v: 1.0
-      v: 0.0
-    }
-  }
-  attributes {
-    name: "normalized_int"
-    double_values {
-      v: 1.0
-      v: 1.0
-      v: 0.0
-    }
-  }
-  attributes {
-    name: "normalized_unsigned_int"
-    double_values {
-      v: 1.0
-      v: 1.0
-      v: 0.0
-    }
-  }
-  attributes {
-    name: "normalized_float"
-    double_values {
-      v: 1.0
-      v: 1.0
-      v: 0.0
-    }
-  }
-  attributes {
     name: "byte"
-    long_values {
-      v: 2
-    }
-  }
-  attributes {
-    name: "unsigned_byte"
-    long_values {
-      v: 2
-    }
-  }
-  attributes {
-    name: "short"
-    long_values {
-      v: 2
-    }
-  }
-  attributes {
-    name: "unsigned_short"
-    long_values {
-      v: 2
-    }
-  }
-  attributes {
-    name: "int"
-    long_values {
-      v: 2
-    }
-  }
-  attributes {
-    name: "unsigned_int"
     long_values {
       v: 2
     }
@@ -1859,6 +1773,92 @@ emitters {
       v: 0.0
       v: 0.0
       v: 0.0
+    }
+  }
+  attributes {
+    name: "int"
+    long_values {
+      v: 2
+    }
+  }
+  attributes {
+    name: "normalized_byte"
+    double_values {
+      v: 1.0
+      v: 1.0
+      v: 0.0
+    }
+  }
+  attributes {
+    name: "normalized_float"
+    double_values {
+      v: 1.0
+      v: 1.0
+      v: 0.0
+    }
+  }
+  attributes {
+    name: "normalized_int"
+    double_values {
+      v: 1.0
+      v: 1.0
+      v: 0.0
+    }
+  }
+  attributes {
+    name: "normalized_short"
+    double_values {
+      v: 1.0
+      v: 1.0
+      v: 0.0
+    }
+  }
+  attributes {
+    name: "normalized_unsigned_byte"
+    double_values {
+      v: 1.0
+      v: 1.0
+      v: 0.0
+    }
+  }
+  attributes {
+    name: "normalized_unsigned_int"
+    double_values {
+      v: 1.0
+      v: 1.0
+      v: 0.0
+    }
+  }
+  attributes {
+    name: "normalized_unsigned_short"
+    double_values {
+      v: 1.0
+      v: 1.0
+      v: 0.0
+    }
+  }
+  attributes {
+    name: "short"
+    long_values {
+      v: 2
+    }
+  }
+  attributes {
+    name: "unsigned_byte"
+    long_values {
+      v: 2
+    }
+  }
+  attributes {
+    name: "unsigned_int"
+    long_values {
+      v: 2
+    }
+  }
+  attributes {
+    name: "unsigned_short"
+    long_values {
+      v: 2
     }
   }
 }
@@ -2221,93 +2221,7 @@ emitters {
     z: 1.3
   }
   attributes {
-    name: "normalized_byte"
-    double_values {
-      v: 1.0
-      v: 1.0
-      v: 0.0
-    }
-  }
-  attributes {
-    name: "normalized_unsigned_byte"
-    double_values {
-      v: 1.0
-      v: 1.0
-      v: 0.0
-    }
-  }
-  attributes {
-    name: "normalized_short"
-    double_values {
-      v: 1.0
-      v: 1.0
-      v: 0.0
-    }
-  }
-  attributes {
-    name: "normalized_unsigned_short"
-    double_values {
-      v: 1.0
-      v: 1.0
-      v: 0.0
-    }
-  }
-  attributes {
-    name: "normalized_int"
-    double_values {
-      v: 1.0
-      v: 1.0
-      v: 0.0
-    }
-  }
-  attributes {
-    name: "normalized_unsigned_int"
-    double_values {
-      v: 1.0
-      v: 1.0
-      v: 0.0
-    }
-  }
-  attributes {
-    name: "normalized_float"
-    double_values {
-      v: 1.0
-      v: 1.0
-      v: 0.0
-    }
-  }
-  attributes {
     name: "byte"
-    long_values {
-      v: 2
-    }
-  }
-  attributes {
-    name: "unsigned_byte"
-    long_values {
-      v: 2
-    }
-  }
-  attributes {
-    name: "short"
-    long_values {
-      v: 2
-    }
-  }
-  attributes {
-    name: "unsigned_short"
-    long_values {
-      v: 2
-    }
-  }
-  attributes {
-    name: "int"
-    long_values {
-      v: 2
-    }
-  }
-  attributes {
-    name: "unsigned_int"
     long_values {
       v: 2
     }
@@ -2325,6 +2239,92 @@ emitters {
       v: 0.0
       v: 0.0
       v: 0.0
+    }
+  }
+  attributes {
+    name: "int"
+    long_values {
+      v: 2
+    }
+  }
+  attributes {
+    name: "normalized_byte"
+    double_values {
+      v: 1.0
+      v: 1.0
+      v: 0.0
+    }
+  }
+  attributes {
+    name: "normalized_float"
+    double_values {
+      v: 1.0
+      v: 1.0
+      v: 0.0
+    }
+  }
+  attributes {
+    name: "normalized_int"
+    double_values {
+      v: 1.0
+      v: 1.0
+      v: 0.0
+    }
+  }
+  attributes {
+    name: "normalized_short"
+    double_values {
+      v: 1.0
+      v: 1.0
+      v: 0.0
+    }
+  }
+  attributes {
+    name: "normalized_unsigned_byte"
+    double_values {
+      v: 1.0
+      v: 1.0
+      v: 0.0
+    }
+  }
+  attributes {
+    name: "normalized_unsigned_int"
+    double_values {
+      v: 1.0
+      v: 1.0
+      v: 0.0
+    }
+  }
+  attributes {
+    name: "normalized_unsigned_short"
+    double_values {
+      v: 1.0
+      v: 1.0
+      v: 0.0
+    }
+  }
+  attributes {
+    name: "short"
+    long_values {
+      v: 2
+    }
+  }
+  attributes {
+    name: "unsigned_byte"
+    long_values {
+      v: 2
+    }
+  }
+  attributes {
+    name: "unsigned_int"
+    long_values {
+      v: 2
+    }
+  }
+  attributes {
+    name: "unsigned_short"
+    long_values {
+      v: 2
     }
   }
 }

--- a/editor/test/resources/save_data_project/checked.sprite
+++ b/editor/test/resources/save_data_project/checked.sprite
@@ -37,6 +37,51 @@ attributes {
   }
 }
 attributes {
+  name: "instance_custom_mat2"
+  double_values {
+    v: 1.2
+    v: 0.0
+    v: 0.0
+    v: 1.2
+  }
+  vector_type: VECTOR_TYPE_MAT2
+}
+attributes {
+  name: "instance_custom_mat3"
+  double_values {
+    v: 1.2
+    v: 0.0
+    v: 0.0
+    v: 0.0
+    v: 1.2
+    v: 0.0
+    v: 0.0
+    v: 0.0
+    v: 1.2
+  }
+}
+attributes {
+  name: "instance_custom_mat4"
+  double_values {
+    v: 1.2
+    v: 0.0
+    v: 0.0
+    v: 0.0
+    v: 0.0
+    v: 1.2
+    v: 0.0
+    v: 0.0
+    v: 0.0
+    v: 0.0
+    v: 1.2
+    v: 0.0
+    v: 0.0
+    v: 0.0
+    v: 0.0
+    v: 1.2
+  }
+}
+attributes {
   name: "int"
   long_values {
     v: 2

--- a/editor/test/resources/save_data_project/checked.sprite
+++ b/editor/test/resources/save_data_project/checked.sprite
@@ -16,93 +16,7 @@ size_mode: SIZE_MODE_MANUAL
 offset: 0.1
 playback_rate: 0.5
 attributes {
-  name: "normalized_byte"
-  double_values {
-    v: 1.0
-    v: 1.0
-    v: 0.0
-  }
-}
-attributes {
-  name: "normalized_unsigned_byte"
-  double_values {
-    v: 1.0
-    v: 1.0
-    v: 0.0
-  }
-}
-attributes {
-  name: "normalized_short"
-  double_values {
-    v: 1.0
-    v: 1.0
-    v: 0.0
-  }
-}
-attributes {
-  name: "normalized_unsigned_short"
-  double_values {
-    v: 1.0
-    v: 1.0
-    v: 0.0
-  }
-}
-attributes {
-  name: "normalized_int"
-  double_values {
-    v: 1.0
-    v: 1.0
-    v: 0.0
-  }
-}
-attributes {
-  name: "normalized_unsigned_int"
-  double_values {
-    v: 1.0
-    v: 1.0
-    v: 0.0
-  }
-}
-attributes {
-  name: "normalized_float"
-  double_values {
-    v: 1.0
-    v: 1.0
-    v: 0.0
-  }
-}
-attributes {
   name: "byte"
-  long_values {
-    v: 2
-  }
-}
-attributes {
-  name: "unsigned_byte"
-  long_values {
-    v: 2
-  }
-}
-attributes {
-  name: "short"
-  long_values {
-    v: 2
-  }
-}
-attributes {
-  name: "unsigned_short"
-  long_values {
-    v: 2
-  }
-}
-attributes {
-  name: "int"
-  long_values {
-    v: 2
-  }
-}
-attributes {
-  name: "unsigned_int"
   long_values {
     v: 2
   }
@@ -120,6 +34,92 @@ attributes {
     v: 0.0
     v: 0.0
     v: 0.0
+  }
+}
+attributes {
+  name: "int"
+  long_values {
+    v: 2
+  }
+}
+attributes {
+  name: "normalized_byte"
+  double_values {
+    v: 1.0
+    v: 1.0
+    v: 0.0
+  }
+}
+attributes {
+  name: "normalized_float"
+  double_values {
+    v: 1.0
+    v: 1.0
+    v: 0.0
+  }
+}
+attributes {
+  name: "normalized_int"
+  double_values {
+    v: 1.0
+    v: 1.0
+    v: 0.0
+  }
+}
+attributes {
+  name: "normalized_short"
+  double_values {
+    v: 1.0
+    v: 1.0
+    v: 0.0
+  }
+}
+attributes {
+  name: "normalized_unsigned_byte"
+  double_values {
+    v: 1.0
+    v: 1.0
+    v: 0.0
+  }
+}
+attributes {
+  name: "normalized_unsigned_int"
+  double_values {
+    v: 1.0
+    v: 1.0
+    v: 0.0
+  }
+}
+attributes {
+  name: "normalized_unsigned_short"
+  double_values {
+    v: 1.0
+    v: 1.0
+    v: 0.0
+  }
+}
+attributes {
+  name: "short"
+  long_values {
+    v: 2
+  }
+}
+attributes {
+  name: "unsigned_byte"
+  long_values {
+    v: 2
+  }
+}
+attributes {
+  name: "unsigned_int"
+  long_values {
+    v: 2
+  }
+}
+attributes {
+  name: "unsigned_short"
+  long_values {
+    v: 2
   }
 }
 textures {

--- a/editor/test/resources/save_data_project/checked03.gui
+++ b/editor/test/resources/save_data_project/checked03.gui
@@ -1,4 +1,3 @@
-script: ""
 fonts {
   name: "first_font"
   font: "/checked.font"

--- a/editor/test/resources/save_data_project/referenced/empty.gui
+++ b/editor/test/resources/save_data_project/referenced/empty.gui
@@ -1,3 +1,2 @@
-script: ""
 material: "/builtins/materials/gui.material"
 adjust_reference: ADJUST_REFERENCE_PARENT

--- a/editor/test/resources/save_data_project/referenced/model.material
+++ b/editor/test/resources/save_data_project/referenced/model.material
@@ -6,8 +6,6 @@ vertex_space: VERTEX_SPACE_LOCAL
 vertex_constants {
   name: "viewproj"
   type: CONSTANT_TYPE_VIEWPROJ
-  value {
-  }
 }
 samplers {
   name: "texture0"
@@ -30,11 +28,6 @@ attributes {
   name: "position"
   semantic_type: SEMANTIC_TYPE_POSITION
   coordinate_space: COORDINATE_SPACE_WORLD
-  double_values {
-    v: 0.0
-    v: 0.0
-    v: 0.0
-  }
   vector_type: VECTOR_TYPE_VEC3
 }
 attributes {
@@ -230,41 +223,12 @@ attributes {
 attributes {
   name: "instance_world"
   semantic_type: SEMANTIC_TYPE_WORLD_MATRIX
-  double_values {
-    v: 1.0
-    v: 0.0
-    v: 0.0
-    v: 0.0
-    v: 0.0
-    v: 1.0
-    v: 0.0
-    v: 0.0
-    v: 0.0
-    v: 0.0
-    v: 1.0
-    v: 0.0
-    v: 0.0
-    v: 0.0
-    v: 0.0
-    v: 1.0
-  }
   step_function: VERTEX_STEP_FUNCTION_INSTANCE
   vector_type: VECTOR_TYPE_MAT4
 }
 attributes {
   name: "instance_normal"
   semantic_type: SEMANTIC_TYPE_NORMAL_MATRIX
-  double_values {
-    v: 1.0
-    v: 0.0
-    v: 0.0
-    v: 0.0
-    v: 0.0
-    v: 1.0
-    v: 0.0
-    v: 0.0
-    v: 0.0
-  }
   step_function: VERTEX_STEP_FUNCTION_INSTANCE
   vector_type: VECTOR_TYPE_MAT3
 }

--- a/editor/test/resources/save_data_project/referenced/model.material
+++ b/editor/test/resources/save_data_project/referenced/model.material
@@ -233,12 +233,128 @@ attributes {
   vector_type: VECTOR_TYPE_MAT3
 }
 attributes {
-  name: "instance_custom"
+  name: "instance_custom_mat2"
   double_values {
-    v: 1.0
+    v: 1.1
     v: 0.0
     v: 0.0
+    v: 1.1
   }
   step_function: VERTEX_STEP_FUNCTION_INSTANCE
-  vector_type: VECTOR_TYPE_VEC3
+  vector_type: VECTOR_TYPE_MAT2
+}
+attributes {
+  name: "instance_custom_mat3"
+  double_values {
+    v: 1.1
+    v: 0.0
+    v: 0.0
+    v: 0.0
+    v: 1.1
+    v: 0.0
+    v: 0.0
+    v: 0.0
+    v: 1.1
+  }
+  step_function: VERTEX_STEP_FUNCTION_INSTANCE
+  vector_type: VECTOR_TYPE_MAT3
+}
+attributes {
+  name: "instance_custom_mat4"
+  double_values {
+    v: 1.1
+    v: 0.0
+    v: 0.0
+    v: 0.0
+    v: 0.0
+    v: 1.1
+    v: 0.0
+    v: 0.0
+    v: 0.0
+    v: 0.0
+    v: 1.1
+    v: 0.0
+    v: 0.0
+    v: 0.0
+    v: 0.0
+    v: 1.1
+  }
+  step_function: VERTEX_STEP_FUNCTION_INSTANCE
+  vector_type: VECTOR_TYPE_MAT4
+}
+attributes {
+  name: "instance_custom"
+  double_values {
+    v: 1.1
+    v: 1.2
+    v: 1.3
+    v: 1.4
+  }
+  step_function: VERTEX_STEP_FUNCTION_INSTANCE
+}
+attributes {
+  name: "instance_custom_byte"
+  data_type: TYPE_BYTE
+  long_values {
+    v: 1
+    v: 2
+    v: 3
+    v: 4
+  }
+  step_function: VERTEX_STEP_FUNCTION_INSTANCE
+}
+attributes {
+  name: "instance_custom_int"
+  data_type: TYPE_INT
+  long_values {
+    v: 1
+    v: 2
+    v: 3
+    v: 4
+  }
+  step_function: VERTEX_STEP_FUNCTION_INSTANCE
+}
+attributes {
+  name: "instance_custom_short"
+  data_type: TYPE_SHORT
+  long_values {
+    v: 1
+    v: 2
+    v: 3
+    v: 4
+  }
+  step_function: VERTEX_STEP_FUNCTION_INSTANCE
+}
+attributes {
+  name: "instance_custom_ubyte"
+  data_type: TYPE_UNSIGNED_BYTE
+  long_values {
+    v: 1
+    v: 2
+    v: 3
+    v: 4
+  }
+  step_function: VERTEX_STEP_FUNCTION_INSTANCE
+}
+attributes {
+  name: "instance_custom_uint"
+  data_type: TYPE_UNSIGNED_INT
+  long_values {
+    v: 1
+    v: 2
+    v: 3
+    v: 4
+  }
+  step_function: VERTEX_STEP_FUNCTION_INSTANCE
+}
+attributes {
+  name: "instance_custom_ushort"
+  data_type: TYPE_UNSIGNED_SHORT
+  long_values {
+    v: 1
+    v: 2
+    v: 3
+    v: 4
+  }
+  step_function: VERTEX_STEP_FUNCTION_INSTANCE
 }

--- a/editor/test/resources/save_data_project/silently_migrated/legacy_vertex_attribute_element_count.material
+++ b/editor/test/resources/save_data_project/silently_migrated/legacy_vertex_attribute_element_count.material
@@ -1,59 +1,37 @@
 name: "legacy_vertex_attribute_element_count"
-vertex_program: ""
-fragment_program: ""
+vertex_program: "/builtins/materials/model.vp"
+fragment_program: "/builtins/materials/model.fp"
 attributes {
   name: "legacy_count_1"
   element_count: 1
   double_values {
-    v: 1.0
+    v: 1.1
   }
 }
 attributes {
   name: "legacy_count_2"
   element_count: 2
   double_values {
-    v: 1.0
-    v: 0.0
+    v: 1.1
+    v: 1.2
   }
 }
 attributes {
   name: "legacy_count_3"
   element_count: 3
   double_values {
-    v: 1.0
-    v: 0.0
-    v: 0.0
+    v: 1.1
+    v: 1.2
+    v: 1.3
   }
 }
 attributes {
   name: "legacy_count_4"
   element_count: 4
   double_values {
-    v: 1.0
-    v: 0.0
-    v: 0.0
-    v: 0.0
-  }
-}
-attributes {
-  name: "legacy_count_9"
-  semantic_type: SEMANTIC_TYPE_WORLD_MATRIX
-  element_count: 9
-  double_values {
-    v: 1.0
-    v: 0.0
-    v: 0.0
-    v: 0.0
-  }
-}
-attributes {
-  name: "legacy_count_16"
-  semantic_type: SEMANTIC_TYPE_WORLD_MATRIX
-  element_count: 16
-  double_values {
-    v: 1.0
-    v: 0.0
-    v: 0.0
-    v: 0.0
+    v: 1.1
+    v: 1.2
+    v: 1.3
+    v: 1.4
   }
 }

--- a/editor/test/util/coll_test.clj
+++ b/editor/test/util/coll_test.clj
@@ -184,6 +184,8 @@
   (is (true? (coll/empty? #{})))
   (is (true? (coll/empty? (sorted-map))))
   (is (true? (coll/empty? (sorted-set))))
+  (is (true? (coll/empty? (double-array 0))))
+  (is (true? (coll/empty? (object-array 0))))
   (is (true? (coll/empty? (range 0))))
   (is (true? (coll/empty? (repeatedly 0 rand))))
   (is (false? (coll/empty? "a")))
@@ -194,6 +196,8 @@
   (is (false? (coll/empty? #{1})))
   (is (false? (coll/empty? (sorted-map :a 1))))
   (is (false? (coll/empty? (sorted-set 1))))
+  (is (false? (coll/empty? (double-array 1))))
+  (is (false? (coll/empty? (object-array 1))))
   (is (false? (coll/empty? (range 1))))
   (is (false? (coll/empty? (repeatedly 1 rand)))))
 
@@ -207,6 +211,8 @@
   (is (nil? (coll/not-empty #{})))
   (is (nil? (coll/not-empty (sorted-map))))
   (is (nil? (coll/not-empty (sorted-set))))
+  (is (nil? (coll/not-empty (double-array 0))))
+  (is (nil? (coll/not-empty (object-array 0))))
   (is (nil? (coll/not-empty (range 0))))
   (is (nil? (coll/not-empty (repeatedly 0 rand))))
   (letfn [(returns-input? [input]
@@ -219,6 +225,8 @@
     (is (returns-input? #{1}))
     (is (returns-input? (sorted-map :a 1)))
     (is (returns-input? (sorted-set 1)))
+    (is (returns-input? (double-array 1)))
+    (is (returns-input? (object-array 1)))
     (is (returns-input? (range 1)))
     (is (returns-input? (repeatedly 1 rand)))))
 

--- a/editor/test/util/coll_test.clj
+++ b/editor/test/util/coll_test.clj
@@ -247,6 +247,26 @@
       (is (map? result))
       (is (= {'one :one 'two :two} result)))))
 
+(deftest remove-index-test
+  (testing "Returns a vector without the item at the specified index."
+    (is (= [:b :c] (coll/remove-index [:a :b :c] 0)))
+    (is (= [:a :c] (coll/remove-index [:a :b :c] 1)))
+    (is (= [:a :b] (coll/remove-index [:a :b :c] 2))))
+
+  (testing "Throws when index out of bounds."
+    (is (thrown? IndexOutOfBoundsException (coll/remove-index [:a :b :c] -1)))
+    (is (thrown? IndexOutOfBoundsException (coll/remove-index [:a :b :c] 3))))
+
+  (testing "Preserves metadata."
+    (let [original-meta {:meta-key "meta-value"}]
+      (doseq [checked-coll [[:a :b :c]
+                            (subvec [:a :b :c] 1)
+                            (vector-of :long 10 20 30)
+                            (vector-of :double 10.0 20.0 30.0)]]
+        (let [original-coll (with-meta checked-coll original-meta)
+              altered-coll (coll/remove-index original-coll 1)]
+          (is (identical? original-meta (meta altered-coll))))))))
+
 (deftest separate-by-test
   (testing "Separates by predicate"
     (let [[odds evens] (coll/separate-by odd? [0 1 2 3 4])]

--- a/engine/gamesys/src/gamesys/test/material/attributes.vp
+++ b/engine/gamesys/src/gamesys/test/material/attributes.vp
@@ -1,13 +1,16 @@
 attribute vec4 position;
 attribute vec3 normal;
 attribute vec2 texcoord0;
+attribute vec4 color;
 
 varying vec3 var_normal;
 varying vec2 var_texcoord0;
+varying vec4 var_color;
 
 void main()
 {
     gl_Position   = position;
     var_normal    = normal;
     var_texcoord0 = texcoord0;
+    var_color = color;
 }

--- a/engine/gamesys/src/gamesys/test/material/attributes_valid.material
+++ b/engine/gamesys/src/gamesys/test/material/attributes_valid.material
@@ -7,12 +7,6 @@ attributes {
   coordinate_space: COORDINATE_SPACE_LOCAL
   data_type: TYPE_FLOAT
   element_count: 2
-  double_values {
-    v: 1.0
-    v: 2.0
-    v: 3.0
-    v: 4.0
-  }
 }
 
 attributes {
@@ -37,3 +31,15 @@ attributes {
   }
 }
 
+attributes {
+  name: "color"
+  semantic_type: SEMANTIC_TYPE_COLOR
+  data_type: TYPE_FLOAT
+  element_count: 3
+  double_values {
+    v: 1.0
+    v: 2.0
+    v: 3.0
+    v: 4.0
+  }
+}


### PR DESCRIPTION
Various fixes and improvements to vertex attribute editing.

In summary:
* The editor will now correctly convert declared and override `values` for `VertexAttributes` when the `vector_type` is changed in the `.material`.
* When editing `VertexAttributes` of a `.material`, we now present a tailor-made detail view of the selected `VertexAttribute` for editing instead of cramming all the attributes into a table view.
* It is now possible to override matrix `VertexAttributes` in the Property Editor.
* The editor will no longer write `values` to the project files for `VertexAttributes` with `SEMANTIC_TYPE_POSITION`, `SEMANTIC_TYPE_WORLD_MATRIX`, or `SEMANTIC_TYPE_NORMAL_MATRIX`, since these are expected to always be provided by the engine.
* The editor will no longer write the `value` to the project files for `Constants` unless their `type` is either `CONSTANT_TYPE_USER` or `CONSTANT_TYPE_USER_MATRIX4`.
* If a `VertexAttribute` override is made on a `VECTOR_TYPE_MAT2` attribute, we include the `vector_type` field in the project files so we can make an appropriate conversion if the user changes the `vector_type` of the `VertexAttribute` declaration in the `.material`.
* `VertexAttribute` overrides are now sorted by name in the project files to avoid merge conflicts.