### PR TITLE
Deprecate the `--input` (`-i`) option in `bob.jar`

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/JarTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/JarTest.java
@@ -41,7 +41,7 @@ public class JarTest {
 
     private int bob(String command) throws IOException, InterruptedException, CompileExceptionError, URISyntaxException {
         String jarPath = "../com.dynamo.cr.bob/dist/bob.jar";
-        Process p = Runtime.getRuntime().exec(new String[] { "java", "-jar", jarPath, "-v", "-r", "test/proj", "-i", ".", command });
+        Process p = Runtime.getRuntime().exec(new String[] { "java", "-jar", jarPath, "-v", "-r", "test/proj", command });
         BufferedReader in = new BufferedReader(new InputStreamReader(p.getInputStream()));
         BufferedReader ein = new BufferedReader(new InputStreamReader(p.getErrorStream()));
         String line;
@@ -56,7 +56,7 @@ public class JarTest {
 
     private int bob(String[] commands, String outputMatch) throws IOException, InterruptedException, CompileExceptionError, URISyntaxException {
         String jarPath = "../com.dynamo.cr.bob/dist/bob.jar";
-        String[] bobArgs = new String[] { "java", "-jar", jarPath, "-v", "-r", "test/proj", "-i", "."};
+        String[] bobArgs = new String[] { "java", "-jar", jarPath, "-v", "-r", "test/proj"};
         String[] allArgs = new String[bobArgs.length + commands.length];
         System.arraycopy(bobArgs, 0, allArgs, 0, bobArgs.length);
         System.arraycopy(commands, 0, allArgs, bobArgs.length, commands.length);

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Bob.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Bob.java
@@ -490,7 +490,7 @@ public class Bob {
         Options options = new Options();
         addOption(options, "r", "root", true, "Build root directory. Default is current directory", true);
         addOption(options, "o", "output", true, "Output directory. Default is \"build/default\"", false);
-        addOption(options, "i", "input", true, "Source directory. Default is current directory", true);
+        addOption(options, "i", "input", true, "DEPRECATED! Use --root instead", true);
         addOption(options, "v", "verbose", false, "Verbose output", false);
         addOption(options, "h", "help", false, "This help message", false);
         addOption(options, "a", "archive", false, "Build archive", false);
@@ -743,6 +743,11 @@ public class Bob {
         if (cmd.hasOption("exclude-build-folder")) {
             // Deprecated in 1.5.1. Just a message for now.
             System.out.println("--exclude-build-folder option is deprecated. Use '.defignore' file instead");
+        }
+
+        if (cmd.hasOption("input")) {
+            System.out.println("-i (--input) option is deprecated. Use --root instead.");
+            throw new OptionValidationException(1);
         }
 
         String[] commands = cmd.getArgs();


### PR DESCRIPTION
The `--input` (`-i`) option for `bob.jar` is deprecated and can no longer be used. If you want to specify a project folder to be built, use the `--root` option instead.

Fix https://github.com/defold/defold/issues/9495