### PR TITLE
Added Switch Pro Controller for Windows

### DIFF
--- a/engine/engine/content/builtins/input/default.gamepads
+++ b/engine/engine/content/builtins/input/default.gamepads
@@ -5855,7 +5855,7 @@ driver
 
 driver
 {
-    device: "Wireless Gamepad"
+    device: "Wireless Gamepad" # Nintendo Switch Pro Controller
     platform: "windows"
     dead_zone: 0.200
     map { input: GAMEPAD_LSTICK_LEFT type: GAMEPAD_TYPE_AXIS index: 0 mod { mod: GAMEPAD_MODIFIER_NEGATE } mod { mod: GAMEPAD_MODIFIER_CLAMP } }

--- a/engine/engine/content/builtins/input/default.gamepads
+++ b/engine/engine/content/builtins/input/default.gamepads
@@ -5852,3 +5852,36 @@ driver
     map { input: GAMEPAD_START type: GAMEPAD_TYPE_BUTTON index: 15 hat_mask: 0 }
     map { input: GAMEPAD_BACK type: GAMEPAD_TYPE_BUTTON index: 17 hat_mask: 0 }
 }
+
+driver
+{
+    device: "Wireless Gamepad"
+    platform: "windows"
+    dead_zone: 0.200
+    map { input: GAMEPAD_LSTICK_LEFT type: GAMEPAD_TYPE_AXIS index: 0 mod { mod: GAMEPAD_MODIFIER_NEGATE } mod { mod: GAMEPAD_MODIFIER_CLAMP } }
+    map { input: GAMEPAD_LSTICK_RIGHT type: GAMEPAD_TYPE_AXIS index: 0 mod { mod: GAMEPAD_MODIFIER_CLAMP } }
+    map { input: GAMEPAD_LSTICK_DOWN type: GAMEPAD_TYPE_AXIS index: 1 mod { mod: GAMEPAD_MODIFIER_CLAMP } }
+    map { input: GAMEPAD_LSTICK_UP type: GAMEPAD_TYPE_AXIS index: 1 mod { mod: GAMEPAD_MODIFIER_NEGATE } mod { mod: GAMEPAD_MODIFIER_CLAMP } }
+    map { input: GAMEPAD_LSTICK_CLICK type: GAMEPAD_TYPE_BUTTON index: 14 }
+    map { input: GAMEPAD_LTRIGGER type: GAMEPAD_TYPE_BUTTON index: 10 }
+    map { input: GAMEPAD_LSHOULDER type: GAMEPAD_TYPE_BUTTON index: 8 }
+    map { input: GAMEPAD_LPAD_LEFT type: GAMEPAD_TYPE_BUTTON index: 2 }
+    map { input: GAMEPAD_LPAD_RIGHT type: GAMEPAD_TYPE_BUTTON index: 3 }
+    map { input: GAMEPAD_LPAD_DOWN type: GAMEPAD_TYPE_BUTTON index: 1 }
+    map { input: GAMEPAD_LPAD_UP type: GAMEPAD_TYPE_BUTTON index: 0 }
+    map { input: GAMEPAD_RSTICK_LEFT type: GAMEPAD_TYPE_AXIS index: 2 mod { mod: GAMEPAD_MODIFIER_NEGATE } mod { mod: GAMEPAD_MODIFIER_CLAMP } }
+    map { input: GAMEPAD_RSTICK_RIGHT type: GAMEPAD_TYPE_AXIS index: 2 mod { mod: GAMEPAD_MODIFIER_CLAMP } }
+    map { input: GAMEPAD_RSTICK_DOWN type: GAMEPAD_TYPE_AXIS index: 3 mod { mod: GAMEPAD_MODIFIER_CLAMP } }
+    map { input: GAMEPAD_RSTICK_UP type: GAMEPAD_TYPE_AXIS index: 3 mod { mod: GAMEPAD_MODIFIER_NEGATE } mod { mod: GAMEPAD_MODIFIER_CLAMP } }
+    map { input: GAMEPAD_RSTICK_CLICK type: GAMEPAD_TYPE_BUTTON index: 15 }
+    map { input: GAMEPAD_RTRIGGER type: GAMEPAD_TYPE_BUTTON index: 11 }
+    map { input: GAMEPAD_RSHOULDER type: GAMEPAD_TYPE_BUTTON index: 9 }
+    map { input: GAMEPAD_RPAD_LEFT type: GAMEPAD_TYPE_BUTTON index: 6 }
+    map { input: GAMEPAD_RPAD_RIGHT type: GAMEPAD_TYPE_BUTTON index: 5 }
+    map { input: GAMEPAD_RPAD_DOWN type: GAMEPAD_TYPE_BUTTON index: 4 }
+    map { input: GAMEPAD_RPAD_UP type: GAMEPAD_TYPE_BUTTON index: 7 }
+    map { input: GAMEPAD_START type: GAMEPAD_TYPE_BUTTON index: 13 }
+    map { input: GAMEPAD_BACK type: GAMEPAD_TYPE_BUTTON index: 12 }
+    map { input: GAMEPAD_GUIDE type: GAMEPAD_TYPE_BUTTON index: 16 }
+    map { input: GAMEPAD_RAW type: GAMEPAD_TYPE_BUTTON index: 11 }
+}


### PR DESCRIPTION
Added Switch Pro Controller for Windows.

Technical notes
Created the mapping file with gdc 1.9.3.

Gdc reports the name of the gamepad as "Wireless Gamepad", and the defold gamepad tester example project stops recognizing input if you change the name to anything else. Windows settings menu reports it as "Pro Controller".