### PR TITLE
Auto set install prefix for defold/external library folder

### DIFF
--- a/external/bullet3d/wscript
+++ b/external/bullet3d/wscript
@@ -17,6 +17,11 @@ def options(opt):
     opt.load('waf_dynamo')
 
 def configure(conf):
+    if os.environ['DYNAMO_HOME'] != conf.env.PREFIX:
+        if 'PREFIX' not in os.environ:
+            conf.env.PREFIX = os.environ['DYNAMO_HOME']
+            print("Setting PREFIX=$DYNAMO_HOME")
+
     conf.load('waf_dynamo')
     conf.env.append_unique('DEFINES', 'NDEBUG')
 

--- a/external/glfw/README.md
+++ b/external/glfw/README.md
@@ -4,11 +4,10 @@ Build steps:
 
 * configure
 * build
-* package
+* install
 
 Example:
 
     $ waf configure --platform=x86_64-win32
     $ waf install
 
-It will install to `<defold>\packages\bullet-2.77-x86_64-win32.tar.gz`

--- a/external/glfw/wscript
+++ b/external/glfw/wscript
@@ -24,6 +24,11 @@ def options(opt):
     opt.load('waf_dynamo')
 
 def configure(conf):
+    if os.environ['DYNAMO_HOME'] != conf.env.PREFIX:
+        if 'PREFIX' not in os.environ:
+            conf.env.PREFIX = os.environ['DYNAMO_HOME']
+            print("Setting PREFIX=$DYNAMO_HOME")
+
     if not platform_supports_feature(conf.env.PLATFORM, "opengl", None):
         print("GLFW isn't supported on this platform", conf.env.PLATFORM)
         return

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -1669,6 +1669,16 @@ class Configuration(object):
             self._log(str(output, encoding='utf-8'))
             sys.exit(process.returncode)
 
+    def fatal(self, msg):
+        self._log(msg)
+        sys.exit(1)
+
+    def verify_env(self):
+        for env_var in ['DYNAMO_HOME', 'PYTHONPATH', 'JAVA_HOME']:
+            if not env_var in os.environ:
+                msg = f"{env_var} was not found in environment.\nDid you use './scripts/build.py shell'?"
+                self.fatal(msg)
+
 # ------------------------------------------------------------
 # BEGIN: RELEASE
 #
@@ -2532,6 +2542,10 @@ To pass on arbitrary options to waf: build.py OPTIONS COMMANDS -- WAF_OPTIONS
                       gcloud_certfile = options.gcloud_certfile,
                       gcloud_keyfile = options.gcloud_keyfile,
                       verbose = options.verbose)
+
+    verify_shell = 'shell' not in args
+    if verify_shell:
+        c.verify_env()
 
     for cmd in args:
         f = getattr(c, cmd, None)

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -1673,12 +1673,6 @@ class Configuration(object):
         self._log(msg)
         sys.exit(1)
 
-    def verify_env(self):
-        for env_var in ['DYNAMO_HOME', 'PYTHONPATH', 'JAVA_HOME']:
-            if not env_var in os.environ:
-                msg = f"{env_var} was not found in environment.\nDid you use './scripts/build.py shell'?"
-                self.fatal(msg)
-
 # ------------------------------------------------------------
 # BEGIN: RELEASE
 #
@@ -2545,7 +2539,11 @@ To pass on arbitrary options to waf: build.py OPTIONS COMMANDS -- WAF_OPTIONS
 
     verify_shell = 'shell' not in args
     if verify_shell:
-        c.verify_env()
+        for env_var in ['DYNAMO_HOME', 'PYTHONPATH', 'JAVA_HOME']:
+            if not env_var in os.environ:
+                c._log("CMD: " + ' '.join(sys.argv))
+                msg = f"{env_var} was not found in environment.\nDid you use './scripts/build.py shell'?"
+                c.fatal(msg)
 
     for cmd in args:
         f = getattr(c, cmd, None)

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -2537,8 +2537,12 @@ To pass on arbitrary options to waf: build.py OPTIONS COMMANDS -- WAF_OPTIONS
                       gcloud_keyfile = options.gcloud_keyfile,
                       verbose = options.verbose)
 
-    verify_shell = 'shell' not in args
-    if verify_shell:
+    needs_dynamo_home = True
+    for cmd in args:
+        if cmd in ['shell', 'save_env']:
+            needs_dynamo_home = False
+            break
+    if needs_dynamo_home:
         for env_var in ['DYNAMO_HOME', 'PYTHONPATH', 'JAVA_HOME']:
             if not env_var in os.environ:
                 c._log("CMD: " + ' '.join(sys.argv))


### PR DESCRIPTION
We made it easier to build the external libraries in defold/externals, if you forgot to set the install prefix.
We now we it automatically to be DYNAMO_HOME

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
