### PR TITLE
Make the building artifacts independent for the `Build HTML5` and `Build` options

### DIFF
--- a/editor/src/clj/editor/pipeline/bob.clj
+++ b/editor/src/clj/editor/pipeline/bob.clj
@@ -236,7 +236,8 @@
           {:error {:causes (engine-build-errors/unsupported-platform-error-causes project evaluation-context)}}
           (let [ws (project/workspace project evaluation-context)
                 proj-path (str (workspace/project-path ws evaluation-context))
-                bob-project (Project. java/class-loader (DefaultFileSystem.) proj-path "build/default")]
+                output-path (or (get bob-args "output") "build/default")
+                bob-project (Project. java/class-loader (DefaultFileSystem.) proj-path output-path)]
             (doseq [[key val] bob-args]
               (.setOption bob-project key val))
             (when-not (string/blank? build-server-headers)
@@ -381,12 +382,13 @@
 ;; Build HTML5
 ;; -----------------------------------------------------------------------------
 
-(defn- build-html5-output-path [project]
+(defn- build-html5-output-path
+  ([project]
   (let [ws (project/workspace project)
-        build-path (workspace/build-path ws)]
-    (io/file build-path "__htmlLaunchDir")))
+        build-path (workspace/build-html5-path ws)]
+    (io/file build-path "__htmlLaunchDir"))))
 
-(def build-html5-bob-commands ["distclean" "build" "bundle"])
+(def build-html5-bob-commands ["build" "bundle"])
 
 (defn build-html5-bob-args [project prefs]
   (let [output-path (build-html5-output-path project)
@@ -398,6 +400,7 @@
              "architectures" "wasm-web"
              "variant" "debug"
              "archive" "true"
+             "output" (subs workspace/build-html5-dir 1)
              "bundle-output" (str output-path)
              "build-server" build-server-url
              "defoldsdk" defold-sdk-sha1

--- a/editor/src/clj/editor/workspace.clj
+++ b/editor/src/clj/editor/workspace.clj
@@ -52,6 +52,7 @@ ordinary paths."
 (set! *warn-on-reflection* true)
 
 (def build-dir "/build/default/")
+(def build-html5-dir "/build/default_html5/")
 (def plugins-dir "/build/plugins/")
 
 ;; SDK api
@@ -86,6 +87,10 @@ ordinary paths."
    (io/file (project-path workspace) (skip-first-char build-dir)))
   (^File [workspace build-resource-path]
    (io/file (build-path workspace) (skip-first-char build-resource-path))))
+
+(defn build-html5-path
+  (^File [workspace]
+   (io/file (project-path workspace) (skip-first-char build-html5-dir))))
 
 (defn plugin-path
   (^File [workspace]


### PR DESCRIPTION
From now on, the `Build HTML5` and `Build` options produce separate build artifact folders in the `build` directory. This means alternating between these options will no longer require rebuilding the project from scratch each time, speeding up the workflow for HTML5 testing.