### PR TITLE
Add vertex + index memory size to model profiling

### DIFF
--- a/engine/gamesys/src/dmsdk/gamesys/resources/res_model.h
+++ b/engine/gamesys/src/dmsdk/gamesys/resources/res_model.h
@@ -48,6 +48,7 @@ namespace dmGameSystem
         uint32_t                    m_VertexCount;
         uint32_t                    m_IndexCount;
         dmGraphics::Type            m_IndexBufferElementType;
+        uint16_t                    m_LastUsedFrame; // Used for statistics
     };
 
     struct MeshInfo

--- a/engine/gamesys/src/dmsdk/gamesys/resources/res_model.h
+++ b/engine/gamesys/src/dmsdk/gamesys/resources/res_model.h
@@ -48,7 +48,7 @@ namespace dmGameSystem
         uint32_t                    m_VertexCount;
         uint32_t                    m_IndexCount;
         dmGraphics::Type            m_IndexBufferElementType;
-        uint16_t                    m_LastUsedFrame; // Used for statistics
+        uint8_t                     m_LastUsedFrame; // Used for statistics
     };
 
     struct MeshInfo

--- a/engine/gamesys/src/gamesys/components/comp_model.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_model.cpp
@@ -136,7 +136,7 @@ namespace dmGameSystem
         // For profiling data:
         uint32_t                         m_StatisticsVertexCount;
         uint32_t                         m_StatisticsVertexDataSize;
-        uint16_t                         m_CurrentFrameTick;
+        uint8_t                          m_CurrentFrameTick;
     };
 
     static const uint32_t VERTEX_BUFFER_MAX_BATCHES = 16;     // Max dmRender::RenderListEntry.m_MinorOrder (4 bits)
@@ -1618,8 +1618,8 @@ namespace dmGameSystem
 
         world->m_MaxBatchIndex = 0;
         world->m_CurrentFrameTick++;
-        // Skip over frame 0xFFFF so we can use it as a special flag for recently enabled render items
-        world->m_CurrentFrameTick = world->m_CurrentFrameTick == 0xFFFF ? 0 : world->m_CurrentFrameTick;
+        // Skip over frame 0xFF so we can use it as a special flag for recently enabled render items
+        world->m_CurrentFrameTick = world->m_CurrentFrameTick == 0xFF ? 0 : world->m_CurrentFrameTick;
 
         update_result.m_TransformsUpdated = rig_res == dmRig::RESULT_UPDATED_POSE;
         return dmGameObject::UPDATE_RESULT_OK;
@@ -2098,7 +2098,7 @@ namespace dmGameSystem
             if (item.m_Model->m_Id == mesh_id)
             {
                 item.m_Enabled = enabled?1:0;
-                item.m_Buffers->m_LastUsedFrame = 0xFFFF;
+                item.m_Buffers->m_LastUsedFrame = 0xFF;
                 found = true;
             }
         }

--- a/engine/gamesys/src/gamesys/components/comp_model.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_model.cpp
@@ -87,10 +87,10 @@ namespace dmGameSystem
         uint32_t                    m_InstanceRenderHash;
         uint32_t                    m_BoneIndex;
         uint32_t                    m_MaterialIndex;
-        uint32_t                    m_Enabled : 1;
-        uint32_t                    m_AttributeRenderDataIndex : 16;
+        uint32_t                    m_Enabled                     : 1;
+        uint32_t                    m_AttributeRenderDataIndex    : 16;
         uint32_t                    m_PerInstanceCustomAttributes : 1;
-        uint32_t                    : 14;
+        uint32_t                    m_UpdateCounter               : 14;
     };
 
     struct ModelComponent
@@ -128,13 +128,16 @@ namespace dmGameSystem
         dmRender::HBufferedRenderBuffer  m_InstanceBufferLocalSpace;
         dmRender::HBufferedRenderBuffer* m_VertexBuffers;
         dmArray<uint8_t>*                m_VertexBufferData;
-        uint32_t*                        m_VertexBufferVertexCounts;
         uint32_t*                        m_VertexBufferDispatchCounts;
         // Temporary scratch array for instances, only used during the creation phase of components
         dmArray<dmGameObject::HInstance> m_ScratchInstances;
         dmRig::HRigContext               m_RigContext;
         uint32_t                         m_MaxElementsVertices;
         uint32_t                         m_MaxBatchIndex;
+        // For profiling data:
+        uint32_t                         m_StatisticsVertexCount;
+        uint32_t                         m_StatisticsVertexDataSize;
+        uint32_t                         m_CurrentUpdateCounter : 14;
     };
 
     static const uint32_t VERTEX_BUFFER_MAX_BATCHES = 16;     // Max dmRender::RenderListEntry.m_MinorOrder (4 bits)
@@ -192,7 +195,6 @@ namespace dmGameSystem
 
         world->m_VertexBuffers = new dmRender::HBufferedRenderBuffer[VERTEX_BUFFER_MAX_BATCHES];
         world->m_VertexBufferData = new dmArray<uint8_t>[VERTEX_BUFFER_MAX_BATCHES];
-        world->m_VertexBufferVertexCounts = new uint32_t[VERTEX_BUFFER_MAX_BATCHES];
         world->m_VertexBufferDispatchCounts = new uint32_t[VERTEX_BUFFER_MAX_BATCHES];
 
         for(uint32_t i = 0; i < VERTEX_BUFFER_MAX_BATCHES; ++i)
@@ -200,6 +202,10 @@ namespace dmGameSystem
             world->m_VertexBuffers[i] = dmRender::NewBufferedRenderBuffer(context->m_RenderContext, dmRender::RENDER_BUFFER_TYPE_VERTEX_BUFFER);
             world->m_VertexBufferDispatchCounts[i] = 0;
         }
+
+        world->m_StatisticsVertexCount    = 0;
+        world->m_StatisticsVertexDataSize = 0;
+        world->m_CurrentUpdateCounter      = 0;
 
         dmGraphics::DeleteVertexStreamDeclaration(stream_declaration_vertex);
         dmGraphics::DeleteVertexStreamDeclaration(stream_declaration_instance);
@@ -226,7 +232,6 @@ namespace dmGameSystem
         dmRig::DeleteContext(world->m_RigContext);
 
         delete [] world->m_VertexBufferData;
-        delete [] world->m_VertexBufferVertexCounts;
         delete [] world->m_VertexBufferDispatchCounts;
         delete [] world->m_VertexBuffers;
 
@@ -1192,6 +1197,17 @@ namespace dmGameSystem
                 dmGameSystem::EnableRenderObjectConstants(&ro, component->m_RenderConstants);
             }
             dmRender::AddToRender(render_context, &ro);
+
+            // Update statistics
+            if (render_item->m_UpdateCounter != world->m_CurrentUpdateCounter)
+            {
+                world->m_StatisticsVertexDataSize +=
+                    dmGraphics::GetIndexBufferSize(ro.m_IndexBuffer) +
+                    dmGraphics::GetVertexBufferSize(ro.m_VertexBuffers[0]) +
+                    dmGraphics::GetVertexBufferSize(ro.m_VertexBuffers[1]);
+                render_item->m_UpdateCounter = world->m_CurrentUpdateCounter;
+            }
+            world->m_StatisticsVertexCount += buffers->m_IndexCount;
         }
     }
 
@@ -1357,7 +1373,6 @@ namespace dmGameSystem
 
         // Since we currently don't support index buffer, we need to produce the indexed vertices
         uint32_t required_vertex_count = dmMath::Max(vertex_count, index_count);
-        world->m_VertexBufferVertexCounts[batch_index] = required_vertex_count;
 
         // Prepare vertex buffer
         uint32_t vertex_stride;
@@ -1429,6 +1444,10 @@ namespace dmGameSystem
         }
 
         dmRender::AddToRender(render_context, &ro);
+
+        // Update statistics
+        world->m_StatisticsVertexCount    += vx_count;
+        world->m_StatisticsVertexDataSize += vx_count * vertex_stride;
     }
 
     static inline dmRenderDDF::MaterialDesc::VertexSpace GetRenderMaterialVertexSpace(dmRender::HMaterial material)
@@ -1591,6 +1610,7 @@ namespace dmGameSystem
         dmRender::RewindBuffer(context->m_RenderContext, world->m_InstanceBufferLocalSpace);
 
         world->m_MaxBatchIndex = 0;
+        world->m_CurrentUpdateCounter++;
 
         update_result.m_TransformsUpdated = rig_res == dmRig::RESULT_UPDATED_POSE;
         return dmGameObject::UPDATE_RESULT_OK;
@@ -1620,6 +1640,9 @@ namespace dmGameSystem
         {
             case dmRender::RENDER_LIST_OPERATION_BEGIN:
             {
+                world->m_StatisticsVertexCount    = 0;
+                world->m_StatisticsVertexDataSize = 0;
+
                 world->m_InstanceBufferDataLocalSpace.SetSize(0);
                 world->m_RenderObjects.SetSize(0);
 
@@ -1641,7 +1664,6 @@ namespace dmGameSystem
                     dmRender::SetBufferData(params.m_Context, world->m_InstanceBufferLocalSpace, world->m_InstanceBufferDataLocalSpace.Size(), world->m_InstanceBufferDataLocalSpace.Begin(), dmGraphics::BUFFER_USAGE_DYNAMIC_DRAW);
                 }
 
-                uint32_t total_count = 0;
                 for (uint32_t batch_index = 0; batch_index < VERTEX_BUFFER_MAX_BATCHES; ++batch_index)
                 {
                     dmArray<uint8_t>& vertex_buffer_data = world->m_VertexBufferData[batch_index];
@@ -1654,11 +1676,10 @@ namespace dmGameSystem
                     dmRender::HBufferedRenderBuffer& gfx_vertex_buffer = world->m_VertexBuffers[batch_index];
                     dmRender::SetBufferData(params.m_Context, gfx_vertex_buffer, vb_size, vertex_buffer_data.Begin(), dmGraphics::BUFFER_USAGE_DYNAMIC_DRAW);
                     world->m_VertexBufferDispatchCounts[batch_index]++;
-                    total_count += world->m_VertexBufferVertexCounts[batch_index];
                 }
 
-                DM_PROPERTY_ADD_U32(rmtp_ModelVertexCount, total_count);
-                DM_PROPERTY_ADD_U32(rmtp_ModelVertexSize, total_count * sizeof(dmRig::RigModelVertex));
+                DM_PROPERTY_ADD_U32(rmtp_ModelVertexCount, world->m_StatisticsVertexCount);
+                DM_PROPERTY_ADD_U32(rmtp_ModelVertexSize, world->m_StatisticsVertexDataSize);
                 break;
             }
             default:

--- a/engine/gamesys/src/gamesys/components/comp_model.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_model.cpp
@@ -1618,6 +1618,8 @@ namespace dmGameSystem
 
         world->m_MaxBatchIndex = 0;
         world->m_CurrentFrameTick++;
+        // Skip over frame 0xFFFF so we can use it as a special flag for recently enabled render items
+        world->m_CurrentFrameTick = world->m_CurrentFrameTick == 0xFFFF ? 0 : world->m_CurrentFrameTick;
 
         update_result.m_TransformsUpdated = rig_res == dmRig::RESULT_UPDATED_POSE;
         return dmGameObject::UPDATE_RESULT_OK;
@@ -2096,6 +2098,7 @@ namespace dmGameSystem
             if (item.m_Model->m_Id == mesh_id)
             {
                 item.m_Enabled = enabled?1:0;
+                item.m_Buffers->m_LastUsedFrame = 0xFFFF;
                 found = true;
             }
         }

--- a/engine/graphics/src/graphics.cpp
+++ b/engine/graphics/src/graphics.cpp
@@ -1218,6 +1218,10 @@ namespace dmGraphics
     {
         g_functions.m_SetVertexBufferSubData(buffer, offset, size, data);
     }
+    uint32_t GetVertexBufferSize(HVertexBuffer buffer)
+    {
+        return g_functions.m_GetVertexBufferSize(buffer);
+    }
     uint32_t GetMaxElementsVertices(HContext context)
     {
         return g_functions.m_GetMaxElementsVertices(context);
@@ -1237,6 +1241,10 @@ namespace dmGraphics
     void SetIndexBufferSubData(HIndexBuffer buffer, uint32_t offset, uint32_t size, const void* data)
     {
         g_functions.m_SetIndexBufferSubData(buffer, offset, size, data);
+    }
+    uint32_t GetIndexBufferSize(HIndexBuffer buffer)
+    {
+        return g_functions.m_GetIndexBufferSize(buffer);
     }
     bool IsIndexBufferFormatSupported(HContext context, IndexBufferFormat format)
     {

--- a/engine/graphics/src/graphics.h
+++ b/engine/graphics/src/graphics.h
@@ -596,6 +596,8 @@ namespace dmGraphics
 
     void     EnableVertexBuffer(HContext context, HVertexBuffer vertex_buffer, uint32_t binding_index);
     void     DisableVertexBuffer(HContext context, HVertexBuffer vertex_buffer);
+    uint32_t GetVertexBufferSize(HVertexBuffer vertex_buffer);
+    uint32_t GetIndexBufferSize(HIndexBuffer buffer);
 
     void     DrawElements(HContext context, PrimitiveType prim_type, uint32_t first, uint32_t count, Type type, HIndexBuffer index_buffer, uint32_t instance_count);
     void     Draw(HContext context, PrimitiveType prim_type, uint32_t first, uint32_t count, uint32_t instance_count);

--- a/engine/graphics/src/graphics_adapter.h
+++ b/engine/graphics/src/graphics_adapter.h
@@ -66,11 +66,13 @@ namespace dmGraphics
     typedef void (*DeleteVertexBufferFn)(HVertexBuffer buffer);
     typedef void (*SetVertexBufferDataFn)(HVertexBuffer buffer, uint32_t size, const void* data, BufferUsage buffer_usage);
     typedef void (*SetVertexBufferSubDataFn)(HVertexBuffer buffer, uint32_t offset, uint32_t size, const void* data);
+    typedef uint32_t (*GetVertexBufferSizeFn)(HVertexBuffer buffer);
     typedef uint32_t (*GetMaxElementsVerticesFn)(HContext context);
     typedef HIndexBuffer (*NewIndexBufferFn)(HContext context, uint32_t size, const void* data, BufferUsage buffer_usage);
     typedef void (*DeleteIndexBufferFn)(HIndexBuffer buffer);
     typedef void (*SetIndexBufferDataFn)(HIndexBuffer buffer, uint32_t size, const void* data, BufferUsage buffer_usage);
     typedef void (*SetIndexBufferSubDataFn)(HIndexBuffer buffer, uint32_t offset, uint32_t size, const void* data);
+    typedef uint32_t (*GetIndexBufferSizeFn)(HIndexBuffer buffer);
     typedef bool (*IsIndexBufferFormatSupportedFn)(HContext context, IndexBufferFormat format);
     typedef uint32_t (*GetMaxElementsIndicesFn)(HContext context);
     typedef HVertexDeclaration (*NewVertexDeclarationFn)(HContext context, HVertexStreamDeclaration stream_declaration);
@@ -180,11 +182,13 @@ namespace dmGraphics
         DeleteVertexBufferFn m_DeleteVertexBuffer;
         SetVertexBufferDataFn m_SetVertexBufferData;
         SetVertexBufferSubDataFn m_SetVertexBufferSubData;
+        GetVertexBufferSizeFn m_GetVertexBufferSize;
         GetMaxElementsVerticesFn m_GetMaxElementsVertices;
         NewIndexBufferFn m_NewIndexBuffer;
         DeleteIndexBufferFn m_DeleteIndexBuffer;
         SetIndexBufferDataFn m_SetIndexBufferData;
         SetIndexBufferSubDataFn m_SetIndexBufferSubData;
+        GetIndexBufferSizeFn m_GetIndexBufferSize;
         IsIndexBufferFormatSupportedFn m_IsIndexBufferFormatSupported;
         GetMaxElementsIndicesFn m_GetMaxElementsIndices;
         NewVertexDeclarationFn m_NewVertexDeclaration;
@@ -298,11 +302,13 @@ namespace dmGraphics
         DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, DeleteVertexBuffer); \
         DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, SetVertexBufferData); \
         DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, SetVertexBufferSubData); \
+        DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, GetVertexBufferSize); \
         DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, GetMaxElementsVertices); \
         DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, NewIndexBuffer); \
         DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, DeleteIndexBuffer); \
         DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, SetIndexBufferData); \
         DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, SetIndexBufferSubData); \
+        DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, GetIndexBufferSize); \
         DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, IsIndexBufferFormatSupported); \
         DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, NewVertexDeclaration); \
         DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, NewVertexDeclarationStride); \

--- a/engine/graphics/src/null/graphics_null.cpp
+++ b/engine/graphics/src/null/graphics_null.cpp
@@ -442,6 +442,10 @@ namespace dmGraphics
 
     static uint32_t NullGetVertexBufferSize(HVertexBuffer buffer)
     {
+        if (!buffer)
+        {
+            return 0;
+        }
         VertexBuffer* buffer_ptr = (VertexBuffer*) buffer;
         return buffer_ptr->m_Size;
     }
@@ -491,6 +495,10 @@ namespace dmGraphics
 
     static uint32_t NullGetIndexBufferSize(HIndexBuffer buffer)
     {
+        if (!buffer)
+        {
+            return 0;
+        }
         IndexBuffer* buffer_ptr = (IndexBuffer*) buffer;
         return buffer_ptr->m_Size;
     }

--- a/engine/graphics/src/null/graphics_null.cpp
+++ b/engine/graphics/src/null/graphics_null.cpp
@@ -440,6 +440,12 @@ namespace dmGraphics
             memcpy(&(vb->m_Buffer)[offset], data, size);
     }
 
+    static uint32_t NullGetVertexBufferSize(HVertexBuffer buffer)
+    {
+        VertexBuffer* buffer_ptr = (VertexBuffer*) buffer;
+        return buffer_ptr->m_Size;
+    }
+
     static uint32_t NullGetMaxElementsVertices(HContext context)
     {
         return 65536;
@@ -481,6 +487,12 @@ namespace dmGraphics
         IndexBuffer* ib = (IndexBuffer*)buffer;
         if (offset + size <= ib->m_Size && data != 0x0)
             memcpy(&(ib->m_Buffer)[offset], data, size);
+    }
+
+    static uint32_t NullGetIndexBufferSize(HIndexBuffer buffer)
+    {
+        IndexBuffer* buffer_ptr = (IndexBuffer*) buffer;
+        return buffer_ptr->m_Size;
     }
 
     static bool NullIsIndexBufferFormatSupported(HContext context, IndexBufferFormat format)

--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -1634,6 +1634,10 @@ static void LogFrameBufferError(GLenum status)
     static void OpenGLSetVertexBufferSubData(HVertexBuffer buffer, uint32_t offset, uint32_t size, const void* data)
     {
         DM_PROFILE(__FUNCTION__);
+        if (!buffer)
+        {
+            return;
+        }
         OpenGLBuffer* vertex_buffer = (OpenGLBuffer*) buffer;
         glBindBufferARB(GL_ARRAY_BUFFER_ARB, vertex_buffer->m_Id);
         CHECK_GL_ERROR;
@@ -1662,7 +1666,7 @@ static void LogFrameBufferError(GLenum status)
     {
         DM_PROFILE(__FUNCTION__);
         // NOTE: WebGl doesn't seem to like zero-sized vertex buffers (very poor performance)
-        if (size == 0)
+        if (size == 0 || !buffer)
         {
             return;
         }
@@ -1703,6 +1707,10 @@ static void LogFrameBufferError(GLenum status)
 
     static void OpenGLSetIndexBufferSubData(HIndexBuffer buffer, uint32_t offset, uint32_t size, const void* data)
     {
+        if (!buffer)
+        {
+            return;
+        }
         DM_PROFILE(__FUNCTION__);
         OpenGLBuffer* index_buffer = (OpenGLBuffer*) buffer;
         glBindBufferARB(GL_ELEMENT_ARRAY_BUFFER_ARB, index_buffer->m_Id);

--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -1593,30 +1593,37 @@ static void LogFrameBufferError(GLenum status)
 
     static HVertexBuffer OpenGLNewVertexBuffer(HContext context, uint32_t size, const void* data, BufferUsage buffer_usage)
     {
-        uint32_t buffer = 0;
-        glGenBuffersARB(1, &buffer);
+        OpenGLBuffer* vertex_buffer = new OpenGLBuffer();
+        vertex_buffer->m_MemorySize = size;
+        glGenBuffersARB(1, &vertex_buffer->m_Id);
         CHECK_GL_ERROR;
-        SetVertexBufferData(buffer, size, data, buffer_usage);
-        return buffer;
+        SetVertexBufferData((HVertexBuffer) vertex_buffer, size, data, buffer_usage);
+        return (HVertexBuffer) vertex_buffer;
     }
 
     static void OpenGLDeleteVertexBuffer(HVertexBuffer buffer)
     {
         if (!buffer)
+        {
             return;
-        GLuint b = (GLuint) buffer;
-        glDeleteBuffersARB(1, &b);
+        }
+        OpenGLBuffer* vertex_buffer = (OpenGLBuffer*) buffer;
+        glDeleteBuffersARB(1, &vertex_buffer->m_Id);
         CHECK_GL_ERROR;
+        delete vertex_buffer;
     }
 
     static void OpenGLSetVertexBufferData(HVertexBuffer buffer, uint32_t size, const void* data, BufferUsage buffer_usage)
     {
         DM_PROFILE(__FUNCTION__);
         // NOTE: Android doesn't seem to like zero-sized vertex buffers
-        if (size == 0) {
+        if (size == 0)
+        {
             return;
         }
-        glBindBufferARB(GL_ARRAY_BUFFER_ARB, buffer);
+        OpenGLBuffer* vertex_buffer = (OpenGLBuffer*) buffer;
+        vertex_buffer->m_MemorySize = size;
+        glBindBufferARB(GL_ARRAY_BUFFER_ARB, vertex_buffer->m_Id);
         CHECK_GL_ERROR
         glBufferDataARB(GL_ARRAY_BUFFER_ARB, size, data, GetOpenGLBufferUsage(buffer_usage));
         CHECK_GL_ERROR
@@ -1627,12 +1634,23 @@ static void LogFrameBufferError(GLenum status)
     static void OpenGLSetVertexBufferSubData(HVertexBuffer buffer, uint32_t offset, uint32_t size, const void* data)
     {
         DM_PROFILE(__FUNCTION__);
-        glBindBufferARB(GL_ARRAY_BUFFER_ARB, buffer);
+        OpenGLBuffer* vertex_buffer = (OpenGLBuffer*) buffer;
+        glBindBufferARB(GL_ARRAY_BUFFER_ARB, vertex_buffer->m_Id);
         CHECK_GL_ERROR;
         glBufferSubDataARB(GL_ARRAY_BUFFER_ARB, offset, size, data);
         CHECK_GL_ERROR;
         glBindBufferARB(GL_ARRAY_BUFFER_ARB, 0);
         CHECK_GL_ERROR;
+    }
+
+    static uint32_t OpenGLGetVertexBufferSize(HVertexBuffer buffer)
+    {
+        if (!buffer)
+        {
+            return 0;
+        }
+        OpenGLBuffer* vertex_buffer = (OpenGLBuffer*) buffer;
+        return vertex_buffer->m_MemorySize;
     }
 
     static uint32_t OpenGLGetMaxElementsVertices(HContext context)
@@ -1644,10 +1662,15 @@ static void LogFrameBufferError(GLenum status)
     {
         DM_PROFILE(__FUNCTION__);
         // NOTE: WebGl doesn't seem to like zero-sized vertex buffers (very poor performance)
-        if (size == 0) {
+        if (size == 0)
+        {
             return;
         }
-        glBindBufferARB(GL_ELEMENT_ARRAY_BUFFER_ARB, buffer);
+
+        OpenGLBuffer* index_buffer = (OpenGLBuffer*) buffer;
+        index_buffer->m_MemorySize = size;
+
+        glBindBufferARB(GL_ELEMENT_ARRAY_BUFFER_ARB, index_buffer->m_Id);
         CHECK_GL_ERROR
         glBufferDataARB(GL_ELEMENT_ARRAY_BUFFER_ARB, size, data, GetOpenGLBufferUsage(buffer_usage));
         CHECK_GL_ERROR
@@ -1657,31 +1680,47 @@ static void LogFrameBufferError(GLenum status)
 
     static HIndexBuffer OpenGLNewIndexBuffer(HContext context, uint32_t size, const void* data, BufferUsage buffer_usage)
     {
-        uint32_t buffer = 0;
-        glGenBuffersARB(1, &buffer);
+        OpenGLBuffer* index_buffer = new OpenGLBuffer; 
+        glGenBuffersARB(1, &index_buffer->m_Id);
         CHECK_GL_ERROR
-        OpenGLSetIndexBufferData(buffer, size, data, buffer_usage);
-        return buffer;
+        OpenGLSetIndexBufferData((HIndexBuffer) index_buffer, size, data, buffer_usage);
+        index_buffer->m_MemorySize = size;
+        return (HIndexBuffer) index_buffer;
     }
 
     static void OpenGLDeleteIndexBuffer(HIndexBuffer buffer)
     {
         if (!buffer)
+        {
             return;
-        GLuint b = (GLuint) buffer;
-        glDeleteBuffersARB(1, &b);
+        }
+
+        OpenGLBuffer* index_buffer = (OpenGLBuffer*) buffer;
+        glDeleteBuffersARB(1, &index_buffer->m_Id);
         CHECK_GL_ERROR;
+        delete index_buffer;
     }
 
     static void OpenGLSetIndexBufferSubData(HIndexBuffer buffer, uint32_t offset, uint32_t size, const void* data)
     {
         DM_PROFILE(__FUNCTION__);
-        glBindBufferARB(GL_ELEMENT_ARRAY_BUFFER_ARB, buffer);
+        OpenGLBuffer* index_buffer = (OpenGLBuffer*) buffer;
+        glBindBufferARB(GL_ELEMENT_ARRAY_BUFFER_ARB, index_buffer->m_Id);
         CHECK_GL_ERROR;
         glBufferSubDataARB(GL_ELEMENT_ARRAY_BUFFER_ARB, offset, size, data);
         CHECK_GL_ERROR;
         glBindBufferARB(GL_ELEMENT_ARRAY_BUFFER_ARB, 0);
         CHECK_GL_ERROR;
+    }
+
+    static uint32_t OpenGLGetIndexBufferSize(HIndexBuffer buffer)
+    {
+        if (!buffer)
+        {
+            return 0;
+        }
+        OpenGLBuffer* index_buffer = (OpenGLBuffer*) buffer;
+        return index_buffer->m_MemorySize;
     }
 
     static bool OpenGLIsIndexBufferFormatSupported(HContext context, IndexBufferFormat format)
@@ -1758,9 +1797,10 @@ static void LogFrameBufferError(GLenum status)
         vertex_declaration->m_ModificationVersion = ((OpenGLContext*) context)->m_ModificationVersion;
     }
 
-    static void OpenGLEnableVertexBuffer(HContext context, HVertexBuffer vertex_buffer, uint32_t binding_index)
+    static void OpenGLEnableVertexBuffer(HContext context, HVertexBuffer buffer, uint32_t binding_index)
     {
-        glBindBufferARB(GL_ARRAY_BUFFER, vertex_buffer);
+        OpenGLBuffer* vertex_buffer = (OpenGLBuffer*) buffer;
+        glBindBufferARB(GL_ARRAY_BUFFER, vertex_buffer->m_Id);
         CHECK_GL_ERROR;
     }
 
@@ -1895,16 +1935,18 @@ static void LogFrameBufferError(GLenum status)
         }
     }
 
-    static void OpenGLDrawElements(HContext context, PrimitiveType prim_type, uint32_t first, uint32_t count, Type type, HIndexBuffer index_buffer, uint32_t instance_count)
+    static void OpenGLDrawElements(HContext context, PrimitiveType prim_type, uint32_t first, uint32_t count, Type type, HIndexBuffer buffer, uint32_t instance_count)
     {
         DM_PROFILE(__FUNCTION__);
         DM_PROPERTY_ADD_U32(rmtp_DrawCalls, 1);
         assert(context);
-        assert(index_buffer);
+        assert(buffer);
 
         DrawSetup((OpenGLContext*) context);
 
-        glBindBufferARB(GL_ELEMENT_ARRAY_BUFFER, index_buffer);
+        OpenGLBuffer* index_buffer = (OpenGLBuffer*) buffer;
+
+        glBindBufferARB(GL_ELEMENT_ARRAY_BUFFER, index_buffer->m_Id);
         CHECK_GL_ERROR;
 
         OpenGLContext* context_ptr = (OpenGLContext*) context;

--- a/engine/graphics/src/opengl/graphics_opengl_private.h
+++ b/engine/graphics/src/opengl/graphics_opengl_private.h
@@ -31,6 +31,12 @@ namespace dmGraphics
         ATTACHMENT_TYPE_TEXTURE = 2,
     };
 
+    enum DeviceBufferType
+    {
+        DEVICE_BUFFER_TYPE_INDEX   = 0,
+        DEVICE_BUFFER_TYPE_VERTEX  = 1,
+    };
+
     struct OpenGLTexture
     {
         TextureParams     m_Params;
@@ -75,6 +81,13 @@ namespace dmGraphics
         GLuint               m_Id;
         ShaderMeta           m_ShaderMeta;
         ShaderDesc::Language m_Language;
+    };
+
+    struct OpenGLBuffer
+    {
+        GLuint           m_Id;
+        DeviceBufferType m_Type;
+        uint32_t         m_MemorySize;
     };
 
     struct OpenGLVertexAttribute

--- a/engine/graphics/src/vulkan/graphics_vulkan.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan.cpp
@@ -1686,6 +1686,10 @@ bail:
 
     static uint32_t VulkanGetVertexBufferSize(HVertexBuffer buffer)
     {
+        if (!buffer)
+        {
+            return 0;
+        }
         DeviceBuffer* buffer_ptr = (DeviceBuffer*) buffer;
         return buffer_ptr->m_MemorySize;
     }
@@ -1749,6 +1753,10 @@ bail:
 
     static uint32_t VulkanGetIndexBufferSize(HIndexBuffer buffer)
     {
+        if (!buffer)
+        {
+            return 0;
+        }
         DeviceBuffer* buffer_ptr = (DeviceBuffer*) buffer;
         return buffer_ptr->m_MemorySize;
     }

--- a/engine/graphics/src/vulkan/graphics_vulkan.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan.cpp
@@ -1684,6 +1684,12 @@ bail:
         DeviceBufferUploadHelper(g_VulkanContext, data, size, offset, buffer_ptr);
     }
 
+    static uint32_t VulkanGetVertexBufferSize(HVertexBuffer buffer)
+    {
+        DeviceBuffer* buffer_ptr = (DeviceBuffer*) buffer;
+        return buffer_ptr->m_MemorySize;
+    }
+
     static uint32_t VulkanGetMaxElementsVertices(HContext context)
     {
         return ((VulkanContext*) context)->m_PhysicalDevice.m_Properties.limits.maxDrawIndexedIndexValue;
@@ -1739,6 +1745,12 @@ bail:
         DeviceBuffer* buffer_ptr = (DeviceBuffer*) buffer;
         assert(offset + size < buffer_ptr->m_MemorySize);
         DeviceBufferUploadHelper(g_VulkanContext, data, size, 0, buffer_ptr);
+    }
+
+    static uint32_t VulkanGetIndexBufferSize(HIndexBuffer buffer)
+    {
+        DeviceBuffer* buffer_ptr = (DeviceBuffer*) buffer;
+        return buffer_ptr->m_MemorySize;
     }
 
     static bool VulkanIsIndexBufferFormatSupported(HContext context, IndexBufferFormat format)

--- a/engine/graphics/src/webgpu/graphics_webgpu.cpp
+++ b/engine/graphics/src/webgpu/graphics_webgpu.cpp
@@ -1365,6 +1365,10 @@ static void WebGPUSetVertexBufferSubData(HVertexBuffer buffer, uint32_t offset, 
 
 static uint32_t WebGPUGetVertexBufferSize(HVertexBuffer buffer)
 {
+    if (!buffer)
+    {
+        return 0;
+    }
     WebGPUBuffer* buffer_ptr = (WebGPUBuffer*) buffer;
     return buffer_ptr->m_Size;
 }
@@ -1424,6 +1428,16 @@ static void WebGPUSetIndexBufferSubData(HIndexBuffer _buffer, uint32_t offset, u
     WebGPUBuffer* buffer = (WebGPUBuffer*)_buffer;
     assert(buffer->m_Used >= offset + size);
     WebGPUWriteBuffer(g_WebGPUContext, buffer, offset, data, size);
+}
+
+static uint32_t WebGPUGetIndexBufferSize(HIndexBuffer buffer)
+{
+    if (!buffer)
+    {
+        return 0;
+    }
+    WebGPUBuffer* buffer_ptr = (WebGPUBuffer*) buffer;
+    return buffer_ptr->m_Size;
 }
 
 static bool WebGPUIsIndexBufferFormatSupported(HContext context, IndexBufferFormat format)

--- a/engine/graphics/src/webgpu/graphics_webgpu.cpp
+++ b/engine/graphics/src/webgpu/graphics_webgpu.cpp
@@ -1363,6 +1363,12 @@ static void WebGPUSetVertexBufferSubData(HVertexBuffer buffer, uint32_t offset, 
     WebGPUWriteBuffer(g_WebGPUContext, gpu_buffer, offset, data, size);
 }
 
+static uint32_t WebGPUGetVertexBufferSize(HVertexBuffer buffer)
+{
+    WebGPUBuffer* buffer_ptr = (WebGPUBuffer*) buffer;
+    return buffer_ptr->m_Size;
+}
+
 static uint32_t WebGPUGetMaxElementsVertices(HContext context)
 {
     TRACE_CALL;


### PR DESCRIPTION
The profiler can now show vertex count and vertex buffer + index buffer memory for local and instanced local models.

Fixes #9534