### PR TITLE
Add instanced model material to builtins

### DIFF
--- a/engine/engine/content/builtins/materials/model_instanced.material
+++ b/engine/engine/content/builtins/materials/model_instanced.material
@@ -1,0 +1,40 @@
+name: "model_instanced"
+tags: "model"
+vertex_program: "/builtins/materials/model_instanced.vp"
+fragment_program: "/builtins/materials/model.fp"
+vertex_space: VERTEX_SPACE_LOCAL
+vertex_constants {
+  name: "mtx_view"
+  type: CONSTANT_TYPE_VIEW
+}
+vertex_constants {
+  name: "mtx_proj"
+  type: CONSTANT_TYPE_PROJECTION
+}
+vertex_constants {
+  name: "light"
+  type: CONSTANT_TYPE_USER
+  value {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+}
+fragment_constants {
+  name: "tint"
+  type: CONSTANT_TYPE_USER
+  value {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+}
+samplers {
+  name: "tex0"
+  wrap_u: WRAP_MODE_CLAMP_TO_EDGE
+  wrap_v: WRAP_MODE_CLAMP_TO_EDGE
+  filter_min: FILTER_MODE_MIN_LINEAR
+  filter_mag: FILTER_MODE_MAG_LINEAR
+}

--- a/engine/engine/content/builtins/materials/model_instanced.vp
+++ b/engine/engine/content/builtins/materials/model_instanced.vp
@@ -1,0 +1,35 @@
+
+// Positions can be world or local space, since world and normal
+// matrices are identity for world vertex space materials.
+// If world vertex space is selected, you can remove the
+// normal matrix multiplication for optimal performance.
+
+attribute highp vec4 position;
+attribute mediump vec2 texcoord0;
+attribute mediump vec3 normal;
+
+// When 'mtx_world' and 'mtx_normal' is specified as attributes,
+// instanced rendering is automatically triggered.
+// To read more about instancing in Defold, navigate to
+// https://defold.com/manuals/material/#instancing
+attribute mediump mat4 mtx_world;
+attribute mediump mat4 mtx_normal;
+
+uniform mediump mat4 mtx_view;
+uniform mediump mat4 mtx_proj;
+uniform mediump vec4 light;
+
+varying highp vec4 var_position;
+varying mediump vec3 var_normal;
+varying mediump vec2 var_texcoord0;
+varying mediump vec4 var_light;
+
+void main()
+{
+    vec4 p = mtx_view * mtx_world * vec4(position.xyz, 1.0);
+    var_light = mtx_view * vec4(light.xyz, 1.0);
+    var_position = p;
+    var_texcoord0 = texcoord0;
+    var_normal = normalize((mtx_normal * vec4(normal, 0.0)).xyz);
+    gl_Position = mtx_proj * p;
+}


### PR DESCRIPTION
A new `instanced` model material has been added to builtins that can be used on model components to achieve [instanced rendering](https://defold.com/manuals/material/#instancing).