### PR TITLE
Remove WebGPU detection from `dmloader.js`

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/resources/jsweb/dmloader.js
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/resources/jsweb/dmloader.js
@@ -801,22 +801,6 @@ var Module = {
         return { stack:stack, message:message };
     },
 
-    hasWebGPUSupport: function() {
-        var webgpu_support = false;
-        try {
-            var canvas = document.createElement("canvas");
-            var webgpu = canvas.getContext("webgpu");
-            if (webgpu && webgpu instanceof WebGPURenderingContext) {
-                webgpu_support = true;
-            }
-        } catch (error) {
-            console.log("An error occurred while detecting WebGPU support: " + error);
-            webgpu_support = false;
-        }
-
-        return webgpu_support;
-    },
-
     hasWebGLSupport: function() {
         var webgl_support = false;
         try {
@@ -857,7 +841,7 @@ var Module = {
         }
         Module.fullScreenContainer = fullScreenContainer || Module.canvas;
 
-        if (Module.hasWebGPUSupport() || Module.hasWebGLSupport()) {
+        if (Module.hasWebGLSupport()) {
             Module.canvas.focus();
 
             // Add context menu hide-handler if requested


### PR DESCRIPTION
In the helper script `dmloader.js` there was added a detection of the WebGPU availability, but it worked incorrectly, because it was comparing with the wrong class and every user got an annoying error that there is no WebGPU (actually there is).

This PR removes the WebGPU detection and leaves only the WebGL detection. It is enough to detect the availability of WebGL as a minimum requirement to run the game, and whether the game will run WebGL or WebGPU will be decided by the engine itself.

Fixes [#9580](https://github.com/defold/defold/issues/9580)
