### PR TITLE
WebGPU issues 

### DIFF
--- a/engine/graphics/src/webgpu/graphics_webgpu.cpp
+++ b/engine/graphics/src/webgpu/graphics_webgpu.cpp
@@ -1008,6 +1008,7 @@ static HContext WebGPUNewContext(const ContextParams& params)
     if (!g_WebGPUContext)
     {
         g_WebGPUContext = (WebGPUContext*)malloc(sizeof(WebGPUContext));
+        memset(g_WebGPUContext, 0, sizeof(*g_WebGPUContext));
         if (InitializeWebGPUContext(g_WebGPUContext, params))
             return g_WebGPUContext;
         DeleteContext(g_WebGPUContext);

--- a/engine/graphics/src/webgpu/graphics_webgpu.cpp
+++ b/engine/graphics/src/webgpu/graphics_webgpu.cpp
@@ -1801,20 +1801,20 @@ static void WebGPUSetupRenderPipeline(WebGPUContext* context, WebGPUBuffer* inde
     }
 
     // Set the indexbuffer
-    if (indexBuffer && indexBuffer != context->m_CurrentRenderPass.m_IndexBuffer)
+    if (indexBuffer && indexBuffer->m_Buffer != context->m_CurrentRenderPass.m_IndexBuffer)
     {
         assert(indexBufferType == TYPE_UNSIGNED_SHORT || indexBufferType == TYPE_UNSIGNED_INT);
-        wgpuRenderPassEncoderSetIndexBuffer(context->m_CurrentRenderPass.m_Encoder, indexBuffer->m_Buffer, indexBufferType == TYPE_UNSIGNED_INT ? WGPUIndexFormat_Uint32 : WGPUIndexFormat_Uint16, 0, indexBuffer->m_Used);
-        context->m_CurrentRenderPass.m_IndexBuffer = indexBuffer;
+        wgpuRenderPassEncoderSetIndexBuffer(context->m_CurrentRenderPass.m_Encoder, indexBuffer->m_Buffer, indexBufferType == TYPE_UNSIGNED_INT ? WGPUIndexFormat_Uint32 : WGPUIndexFormat_Uint16, 0, WGPU_WHOLE_SIZE);
+        context->m_CurrentRenderPass.m_IndexBuffer = indexBuffer->m_Buffer;
     }
 
     // Set the vertexbuffer(s)
     for (int slot = 0; slot < MAX_VERTEX_BUFFERS; ++slot)
     {
-        if (context->m_CurrentVertexBuffers[slot] && context->m_CurrentVertexBuffers[slot] != context->m_CurrentRenderPass.m_VertexBuffers[slot])
+        if (context->m_CurrentVertexBuffers[slot] && context->m_CurrentVertexBuffers[slot]->m_Buffer != context->m_CurrentRenderPass.m_VertexBuffers[slot])
         {
             wgpuRenderPassEncoderSetVertexBuffer(context->m_CurrentRenderPass.m_Encoder, slot, context->m_CurrentVertexBuffers[slot]->m_Buffer, 0, context->m_CurrentVertexBuffers[slot]->m_Used);
-            context->m_CurrentRenderPass.m_VertexBuffers[slot] = context->m_CurrentVertexBuffers[slot];
+            context->m_CurrentRenderPass.m_VertexBuffers[slot] = context->m_CurrentVertexBuffers[slot]->m_Buffer;
         }
     }
 

--- a/engine/graphics/src/webgpu/graphics_webgpu.cpp
+++ b/engine/graphics/src/webgpu/graphics_webgpu.cpp
@@ -1123,6 +1123,14 @@ static void WebGPUGetDefaultTextureFilters(HContext _context, TextureFilter& out
     out_mag_filter         = context->m_DefaultTextureMagFilter;
 }
 
+static void WebGPUCreateCommandEncoder(WebGPUContext* context)
+{
+    if(!context->m_CommandEncoder)
+    {
+        context->m_CommandEncoder = wgpuDeviceCreateCommandEncoder(context->m_Device, NULL);
+    }
+}
+
 static void WebGPUEndRenderPass(WebGPUContext* context);
 
 static void WebGPUEndComputePass(WebGPUContext* context)
@@ -1136,12 +1144,30 @@ static void WebGPUEndComputePass(WebGPUContext* context)
     }
 }
 
+static void WebGPUSubmitCommandEncoder(WebGPUContext* context)
+{
+    TRACE_CALL;
+    if (context->m_CommandEncoder)
+    {
+        WebGPUEndComputePass(context);
+        WebGPUEndRenderPass(context);
+
+        const WGPUCommandBuffer buffer = wgpuCommandEncoderFinish(context->m_CommandEncoder, NULL);
+        wgpuQueueSubmit(context->m_Queue, 1, &buffer);
+        wgpuCommandBufferRelease(buffer);
+        wgpuCommandEncoderRelease(context->m_CommandEncoder);
+        context->m_CommandEncoder = NULL;
+        context->m_LastSubmittedRenderPass = context->m_RenderPasses;
+    }
+}
+
 static void WebGPUBeginComputePass(WebGPUContext* context)
 {
     TRACE_CALL;
     if (!context->m_CurrentComputePass.m_Encoder)
     {
         WebGPUEndRenderPass(context);
+        WebGPUCreateCommandEncoder(context);
         WGPUComputePassDescriptor desc          = {};
         context->m_CurrentComputePass.m_Encoder = wgpuCommandEncoderBeginComputePass(context->m_CommandEncoder, &desc);
     }
@@ -1166,6 +1192,8 @@ static void WebGPUBeginRenderPass(WebGPUContext* context, const float* clearColo
     if (context->m_CurrentRenderPass.m_Target != context->m_CurrentRenderTarget)
     {
         WebGPUEndRenderPass(context);
+        WebGPUCreateCommandEncoder(context);
+        ++context->m_RenderPasses;
         context->m_CurrentRenderPass.m_Target = context->m_CurrentRenderTarget;
         {
             WGPURenderPassDescriptor desc = {};
@@ -1289,7 +1317,6 @@ static void WebGPUBeginFrame(HContext _context)
         texture->m_Texture     = wgpuSwapChainGetCurrentTexture(context->m_SwapChain);
         texture->m_TextureView = wgpuSwapChainGetCurrentTextureView(context->m_SwapChain);
     }
-    context->m_CommandEncoder      = wgpuDeviceCreateCommandEncoder(context->m_Device, NULL);
     context->m_CurrentRenderTarget = context->m_MainRenderTarget;
 }
 
@@ -1297,17 +1324,8 @@ static void WebGPUFlip(HContext _context)
 {
     TRACE_CALL;
     WebGPUContext* context = (WebGPUContext*)_context;
-    WebGPUEndComputePass(context);
-    WebGPUEndRenderPass(context);
+    WebGPUSubmitCommandEncoder(context);
     context->m_CurrentRenderTarget = NULL;
-    if (context->m_CommandEncoder)
-    {
-        const WGPUCommandBuffer buffer = wgpuCommandEncoderFinish(context->m_CommandEncoder, NULL);
-        wgpuQueueSubmit(context->m_Queue, 1, &buffer);
-        wgpuCommandBufferRelease(buffer);
-        wgpuCommandEncoderRelease(context->m_CommandEncoder);
-        context->m_CommandEncoder = NULL;
-    }
     {
 #if !defined(__EMSCRIPTEN__)
         wgpuSwapChainPresent(context->m_SwapChain);
@@ -1345,13 +1363,18 @@ static void WebGPUWriteBuffer(WebGPUContext* context, WebGPUBuffer* buffer, size
 {
     TRACE_CALL;
     assert(size);
-    if (!buffer->m_Buffer)
+    if (!buffer->m_Buffer) // create it
     {
         WGPUBufferDescriptor desc = {};
         desc.usage                = buffer->m_Usage;
         desc.size                 = size;
         buffer->m_Buffer          = wgpuDeviceCreateBuffer(context->m_Device, &desc);
         buffer->m_Used = buffer->m_Size = desc.size;
+    }
+    else if (buffer->m_LastRenderPass && buffer->m_LastRenderPass > context->m_LastSubmittedRenderPass) // flush pipeline
+    {
+        //dmLogWarning("Deoptimization: Forcing pipeline flush due to buffer write");
+        WebGPUSubmitCommandEncoder(context);
     }
     wgpuQueueWriteBuffer(context->m_Queue, buffer->m_Buffer, offset, data, size);
 }
@@ -1395,6 +1418,7 @@ static void WebGPUSetVertexBufferData(HVertexBuffer buffer, uint32_t size, const
         wgpuBufferRelease(gpu_buffer->m_Buffer);
         gpu_buffer->m_Buffer = NULL;
         gpu_buffer->m_Used = gpu_buffer->m_Size = 0;
+        gpu_buffer->m_LastRenderPass = 0;
     }
     else
     {
@@ -1462,6 +1486,7 @@ static void WebGPUSetIndexBufferData(HIndexBuffer _buffer, uint32_t size, const 
         wgpuBufferRelease(buffer->m_Buffer);
         buffer->m_Buffer = NULL;
         buffer->m_Used = buffer->m_Size = 0;
+        buffer->m_LastRenderPass = 0;
     }
     else
     {
@@ -1806,6 +1831,7 @@ static void WebGPUSetupRenderPipeline(WebGPUContext* context, WebGPUBuffer* inde
         assert(indexBufferType == TYPE_UNSIGNED_SHORT || indexBufferType == TYPE_UNSIGNED_INT);
         wgpuRenderPassEncoderSetIndexBuffer(context->m_CurrentRenderPass.m_Encoder, indexBuffer->m_Buffer, indexBufferType == TYPE_UNSIGNED_INT ? WGPUIndexFormat_Uint32 : WGPUIndexFormat_Uint16, 0, WGPU_WHOLE_SIZE);
         context->m_CurrentRenderPass.m_IndexBuffer = indexBuffer->m_Buffer;
+        indexBuffer->m_LastRenderPass = context->m_RenderPasses;
     }
 
     // Set the vertexbuffer(s)
@@ -1815,6 +1841,7 @@ static void WebGPUSetupRenderPipeline(WebGPUContext* context, WebGPUBuffer* inde
         {
             wgpuRenderPassEncoderSetVertexBuffer(context->m_CurrentRenderPass.m_Encoder, slot, context->m_CurrentVertexBuffers[slot]->m_Buffer, 0, context->m_CurrentVertexBuffers[slot]->m_Used);
             context->m_CurrentRenderPass.m_VertexBuffers[slot] = context->m_CurrentVertexBuffers[slot]->m_Buffer;
+            context->m_CurrentVertexBuffers[slot]->m_LastRenderPass = context->m_RenderPasses;
         }
     }
 

--- a/engine/graphics/src/webgpu/graphics_webgpu_private.h
+++ b/engine/graphics/src/webgpu/graphics_webgpu_private.h
@@ -43,6 +43,7 @@ namespace dmGraphics
 
         size_t                     m_Size = 0;
         size_t                     m_Used = 0;
+        size_t                     m_LastRenderPass = 0;
     };
 
     struct WebGPUUniformBuffer
@@ -214,6 +215,8 @@ namespace dmGraphics
         WGPUTextureFormat                  m_Format;
         WGPUSwapChain                      m_SwapChain;
         WGPUCommandEncoder                 m_CommandEncoder;
+        uint32_t                           m_RenderPasses;
+        uint32_t                           m_LastSubmittedRenderPass;
 
         // Current state
         PipelineState       m_CurrentPipelineState;

--- a/engine/graphics/src/webgpu/graphics_webgpu_private.h
+++ b/engine/graphics/src/webgpu/graphics_webgpu_private.h
@@ -158,11 +158,11 @@ namespace dmGraphics
     struct WebGPURenderPass
     {
         WGPUBindGroup         m_BindGroups[MAX_SET_COUNT];
-        WebGPUBuffer*         m_VertexBuffers[MAX_VERTEX_BUFFERS];
+        WGPUBuffer            m_VertexBuffers[MAX_VERTEX_BUFFERS];
         WebGPURenderTarget*   m_Target;
         WGPURenderPassEncoder m_Encoder;
         WGPURenderPipeline    m_Pipeline;
-        WebGPUBuffer*         m_IndexBuffer;
+        WGPUBuffer            m_IndexBuffer;
     };
 
     struct WebGPUTextureSampler

--- a/engine/render/src/render/render.cpp
+++ b/engine/render/src/render/render.cpp
@@ -136,6 +136,7 @@ namespace dmRender
 
         dmGraphics::AdapterFamily installed_adapter_family = dmGraphics::GetInstalledAdapterFamily();
         if (installed_adapter_family == dmGraphics::ADAPTER_FAMILY_VULKAN ||
+            installed_adapter_family == dmGraphics::ADAPTER_FAMILY_WEBGPU ||
             installed_adapter_family == dmGraphics::ADAPTER_FAMILY_VENDOR)
         {
             context->m_MultiBufferingRequired = 1;

--- a/share/extender/build_input.yml
+++ b/share/extender/build_input.yml
@@ -403,6 +403,7 @@ platforms:
         EMSCRIPTEN_BIN:         "{{env.EMSCRIPTEN_BIN_3_1_65}}"
         MANIFEST_MERGE_TOOL:    "{{env.MANIFEST_MERGE_TOOL}}"
     context:
+        optLevel: 3
         stackSize: 5242880
         minFirefoxVersion: 34
         minChromeVersion: 32
@@ -413,7 +414,7 @@ platforms:
         engineLibs: ["engine", "engine_service", "mbedtls", "zip", "profile_null", "remotery_null", "profilerext_null", "record_null", "gameobject", "ddf", "resource", "gamesys", "gamesys_model", "gamesys_rig", "script_box2d", "graphics", "graphics_transcoder_basisu", "basis_transcoder", "physics", "BulletDynamics", "BulletCollision", "platform", "LinearMath", "Box2D", "render", "script", "lua", "extension", "hid", "input", "particle", "rig", "dlib", "image", "dmglfw", "gui", "crashext", "liveupdate", "sound"]
         defines:    ["DM_PLATFORM_HTML5", "GL_ES_VERSION_2_0"]
         flags:      ["-fno-exceptions", "-fno-rtti", "-fPIC"]
-        linkFlags:  ["--emit-symbol-map", "-lidbfs.js"]
+        linkFlags:  ["--emit-symbol-map", "-O{{optLevel}}", "-lidbfs.js"]
         emscriptenFlags: ["DISABLE_EXCEPTION_CATCHING=1"]
         emscriptenLinkFlags: ["INITIAL_MEMORY={{initialMemory}}", "DISABLE_EXCEPTION_CATCHING=1", "IMPORTED_MEMORY=1", "EXPORTED_FUNCTIONS=_JSWriteDump,_main,_dmExportedSymbols,_malloc,_free", "EXPORTED_RUNTIME_METHODS=[\"stackTrace\",\"ccall\",\"callMain\",\"UTF8ToString\",\"HEAPU8\",\"stringToNewUTF8\"]", "ERROR_ON_UNDEFINED_SYMBOLS=1", "MAX_WEBGL_VERSION=2", "STACK_SIZE={{stackSize}}", "MIN_FIREFOX_VERSION={{minFirefoxVersion}}", "MIN_SAFARI_VERSION={{minSafariVersion}}", "MIN_CHROME_VERSION={{minChromeVersion}}"]
         libs:       []
@@ -427,7 +428,7 @@ platforms:
     symbolsPattern:  'dmengine.js.symbols'
     allowedLibs:    ["(\\w[\\w\\.+-]+)"]
     allowedFlags:   ["-Wa,{{comma_separated_arg}}","-W{{warning}}","-Wno-{{warning}}","-ansi","--ansi","-std-default={{arg}}","-stdlib=(libstdc\\+\\+|libc\\+\\+)","-w","-std=(c89|c99|c\\+\\+98|c\\+\\+0x|c\\+\\+11|c\\+\\+14|c\\+\\+17|c\\+\\+20)","-Wp,{{comma_separated_arg}}","--extra-warnings","--warn-{{warning}}","--warn-={{warning}}","-ferror-limit={{number}}","-O([0-4]?|fast|s|z)","-f\\w[\\w-=]+","-x","c","-l\\w+.js"]
-    compileCmd:     '{{env.EMSCRIPTEN_BIN}}/em++ -c -O3 -g {{#defines}}-D{{{.}}} {{/defines}} {{#flags}}{{{.}}} {{/flags}} {{#emscriptenFlags}}-s {{{.}}} {{/emscriptenFlags}} {{#ext.includes}}-I{{{.}}} {{/ext.includes}} {{#includes}}-I{{{.}}} {{/includes}} {{src}} -o {{tgt}}'
+    compileCmd:     '{{env.EMSCRIPTEN_BIN}}/em++ -c -O{{optLevel}} -g {{#defines}}-D{{{.}}} {{/defines}} {{#flags}}{{{.}}} {{/flags}} {{#emscriptenFlags}}-s {{{.}}} {{/emscriptenFlags}} {{#ext.includes}}-I{{{.}}} {{/ext.includes}} {{#includes}}-I{{{.}}} {{/includes}} {{src}} -o {{tgt}}'
     libCmd:         '{{env.EMSCRIPTEN_BIN}}/emar rcs {{tgt}} {{#objs}}{{{.}}} {{/objs}}'
     manifestName:     'engine_template.html'
     manifestMergeCmd: 'java -jar {{env.MANIFEST_MERGE_TOOL}} --platform {{platform}} --main {{mainManifest}} {{#libraries}} --lib {{.}} {{/libraries}} --out {{target}}'
@@ -438,7 +439,7 @@ platforms:
         emscriptenLinkFlags: ["WASM=0", "LEGACY_VM_SUPPORT=1"]
 
     zipContentPattern: 'dmengine.js'
-    linkCmd:        '{{env.EMSCRIPTEN_BIN}}/em++ {{#src}}{{{.}}} {{/src}} -o {{tgt}} -O3 {{#linkFlags}}{{{.}}} {{/linkFlags}} {{#emscriptenLinkFlags}}-s {{{.}}} {{/emscriptenLinkFlags}} {{#ext.libPaths}}-L{{{.}}} {{/ext.libPaths}} {{#libPaths}}-L{{{.}}} {{/libPaths}} -Wl,--start-group {{#libs}}-l{{{.}}} {{/libs}} {{#ext.libs}}-l{{{.}}} {{/ext.libs}} {{#engineLibs}}-l{{{.}}} {{/engineLibs}} -Wl,--end-group {{#ext.jsLibs}}--js-library {{{.}}} {{/ext.jsLibs}} {{#engineJsLibs}}--js-library {{dynamo_home}}/lib/js-web/js/library_{{{.}}}.js {{/engineJsLibs}} {{#externalJsLibs}}--js-library {{dynamo_home}}/ext/lib/js-web/js/library_{{{.}}}.js {{/externalJsLibs}}'
+    linkCmd:        '{{env.EMSCRIPTEN_BIN}}/em++ {{#src}}{{{.}}} {{/src}} -o {{tgt}} {{#linkFlags}}{{{.}}} {{/linkFlags}} {{#emscriptenLinkFlags}}-s {{{.}}} {{/emscriptenLinkFlags}} {{#ext.libPaths}}-L{{{.}}} {{/ext.libPaths}} {{#libPaths}}-L{{{.}}} {{/libPaths}} -Wl,--start-group {{#libs}}-l{{{.}}} {{/libs}} {{#ext.libs}}-l{{{.}}} {{/ext.libs}} {{#engineLibs}}-l{{{.}}} {{/engineLibs}} -Wl,--end-group {{#ext.jsLibs}}--js-library {{{.}}} {{/ext.jsLibs}} {{#engineJsLibs}}--js-library {{dynamo_home}}/lib/js-web/js/library_{{{.}}}.js {{/engineJsLibs}} {{#externalJsLibs}}--js-library {{dynamo_home}}/ext/lib/js-web/js/library_{{{.}}}.js {{/externalJsLibs}}'
 
 
   wasm-web:
@@ -447,7 +448,7 @@ platforms:
         emscriptenLinkFlags: ["ALLOW_MEMORY_GROWTH=1", "WASM=1"]
 
     zipContentPattern: 'dmengine.(wasm|js)'
-    linkCmd:        '{{env.EMSCRIPTEN_BIN}}/em++ {{#src}}{{{.}}} {{/src}} -o {{tgt}} -O3 {{#linkFlags}}{{{.}}} {{/linkFlags}} {{#emscriptenLinkFlags}}-s {{{.}}} {{/emscriptenLinkFlags}} {{#ext.libPaths}}-L{{{.}}} {{/ext.libPaths}} {{#libPaths}}-L{{{.}}} {{/libPaths}} -Wl,--start-group {{#libs}}-l{{{.}}} {{/libs}} {{#ext.libs}}-l{{{.}}} {{/ext.libs}} {{#engineLibs}}-l{{{.}}} {{/engineLibs}} -Wl,--end-group {{#ext.jsLibs}}--js-library {{{.}}} {{/ext.jsLibs}} {{#engineJsLibs}}--js-library {{dynamo_home}}/lib/wasm-web/js/library_{{{.}}}.js {{/engineJsLibs}} {{#externalJsLibs}}--js-library {{dynamo_home}}/ext/lib/js-web/js/library_{{{.}}}.js {{/externalJsLibs}}'
+    linkCmd:        '{{env.EMSCRIPTEN_BIN}}/em++ {{#src}}{{{.}}} {{/src}} -o {{tgt}} {{#linkFlags}}{{{.}}} {{/linkFlags}} {{#emscriptenLinkFlags}}-s {{{.}}} {{/emscriptenLinkFlags}} {{#ext.libPaths}}-L{{{.}}} {{/ext.libPaths}} {{#libPaths}}-L{{{.}}} {{/libPaths}} -Wl,--start-group {{#libs}}-l{{{.}}} {{/libs}} {{#ext.libs}}-l{{{.}}} {{/ext.libs}} {{#engineLibs}}-l{{{.}}} {{/engineLibs}} -Wl,--end-group {{#ext.jsLibs}}--js-library {{{.}}} {{/ext.jsLibs}} {{#engineJsLibs}}--js-library {{dynamo_home}}/lib/wasm-web/js/library_{{{.}}}.js {{/engineJsLibs}} {{#externalJsLibs}}--js-library {{dynamo_home}}/ext/lib/js-web/js/library_{{{.}}}.js {{/externalJsLibs}}'
 
   win32:
     # It's here to whitelist this as a platform, currently used for general settings


### PR DESCRIPTION
Found a couple webgpu issues:

Make sure the context is all set to null as there lives non pod data in it that does not have constructor called now that it is malloc.

Alow interleaving buffer writes and draw calls works. In principal it should not happen as it causes a pipeline flush, but make sure the adapter handles it safely as it can be reordered in the work queue.

Make sure to account for WGPUBuffer that is current and its known size rather than relying on whole buffer in webgpu.h