### PR TITLE
Cleanup state of the builders when build is done.

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Builder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Builder.java
@@ -133,4 +133,7 @@ public abstract class Builder {
     public boolean isGameProjectBuilder() {
         return false;
     }
+
+    public void clearState() {
+    }
 }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
@@ -1790,9 +1790,6 @@ run:
 
                 // compare all task signature. current task signature between previous
                 // signature from state on disk
-                TimeProfiler.start("compare signatures");
-                TimeProfiler.addData("color", "#FFC0CB");
-                TimeProfiler.addData("main input", String.valueOf(task.input(0)));
                 byte[] taskSignature = task.calculateSignature();
                 boolean allSigsEquals = true;
                 for (IResource r : outputResources) {
@@ -1802,7 +1799,7 @@ run:
                         break;
                     }
                 }
-                TimeProfiler.stop();
+
                 // game.project is always the last task
                 boolean isLastTask = completedTasks.size() + 1 == buildTasks.size();
                 boolean shouldRun = !completedTasks.contains(task);

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
@@ -1881,6 +1881,7 @@ run:
                             state.putSignature(r.getAbsPath(), taskSignature);
                         }
                     }
+                    builder.clearState();
                     monitor.worked(1);
                     buildContainsChanges = true;
 

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/ProtoBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/ProtoBuilder.java
@@ -156,4 +156,10 @@ public abstract class ProtoBuilder<B extends GeneratedMessageV3.Builder<B>> exte
         task.output(0).setContent(out.toByteArray());
     }
 
+    @Override
+    public void clearState() {
+        super.clearState();
+        protoParams = null;
+        srcBuilders = null;
+    }
 }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/CollectionBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/CollectionBuilder.java
@@ -461,4 +461,9 @@ public class CollectionBuilder extends ProtoBuilder<CollectionDesc.Builder> {
         return messageBuilder;
     }
 
+    @Override
+    public void clearState() {
+        super.clearState();
+        compCounterInputsCount = null;
+    }
 }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/LuaBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/LuaBuilder.java
@@ -72,7 +72,7 @@ public abstract class LuaBuilder extends Builder {
     private static List<ILuaPreprocessor> luaPreprocessors = null;
     private static List<ILuaObfuscator> luaObfuscators = null;
 
-    private Map<String, LuaScanner> luaScanners = new HashMap();
+    private LuaScanner luaScanner;
 
     /**
      * Get a LuaScanner instance for a resource
@@ -84,8 +84,7 @@ public abstract class LuaBuilder extends Builder {
     private LuaScanner getLuaScanner(IResource resource) throws IOException, CompileExceptionError {
         final String path = resource.getAbsPath();
         final String variant = project.option("variant", Bob.VARIANT_RELEASE);
-        LuaScanner scanner = luaScanners.get(path);
-        if (scanner == null) {
+        if (luaScanner == null) {
             final byte[] scriptBytes = resource.getContent();
             String script = new String(scriptBytes, "UTF-8");
 
@@ -107,15 +106,14 @@ public abstract class LuaBuilder extends Builder {
                 }
             }
 
-            scanner = new LuaScanner();
+            luaScanner = new LuaScanner();
             if (variant == Bob.VARIANT_DEBUG)
             {
-                scanner.setDebug();
+                luaScanner.setDebug();
             }
-            scanner.parse(script);
-            luaScanners.put(path, scanner);
+            luaScanner.parse(script);
         }
-        return scanner;
+        return luaScanner;
     }
 
     @Override
@@ -622,5 +620,11 @@ public abstract class LuaBuilder extends Builder {
             }
         }
         return builder.build();
+    }
+
+    @Override
+    public void clearState() {
+        super.clearState();
+        luaScanner = null;
     }
 }


### PR DESCRIPTION
Currently, some builders save intermediate states to reduce work between different "create" and "build" stages. This may cause additional memory pressure on large projects, so it's better to release memory and allow the garbage collector to free it.