### PR TITLE
remove auto uncompress when unpack_arc

### DIFF
--- a/scripts/unpack_arc.py
+++ b/scripts/unpack_arc.py
@@ -24,6 +24,7 @@ except:
 
 import struct
 import hashlib
+import optparse
 import lz4.block
 import resource.liveupdate_ddf_pb2
 
@@ -56,8 +57,18 @@ def xtea_decryptCTR(key, data, n=32):
     return data
 
 if __name__ == "__main__":
-    resources = sys.argv[1]
-    output = sys.argv[2]
+    usage = '''usage: %prog [options] input
+'''
+    parser = optparse.OptionParser(usage)
+
+    parser.add_option('--uncompress', dest='uncompress',
+                      default = False,
+                      help = 'Whether to automatically uncompress files')
+
+    options, args = parser.parse_args()
+
+    resources = args[0]
+    output = args[1]
     os.makedirs(output, 0o777, True)
 
     if os.path.isdir(resources):
@@ -129,8 +140,11 @@ if __name__ == "__main__":
                         #print("encrypted")
                         xtea_decryptCTR(bytearray(b'aQj8CScgNP4VsfXK'), data)
                     if compressed_size != -1:
-                        #print("compressed %d" % uncompressed_size)
-                        data = lz4.block.decompress(data, uncompressed_size)
+                        if options.uncompress:
+                            data = lz4.block.decompress(data, uncompressed_size)
+                        else:
+                            url += ".lz4";
+
                 except Exception as e:
                     print("Failed: ", e)
                     print(traceback.format_exc())

--- a/scripts/unpack_ddf.py
+++ b/scripts/unpack_ddf.py
@@ -33,6 +33,7 @@ except:
 from google.protobuf import text_format
 import google.protobuf.message
 
+import lz4.block
 import binascii
 
 import gameobject.gameobject_ddf_pb2
@@ -275,7 +276,16 @@ if __name__ == "__main__":
 
     with open(path, 'rb') as f:
         content = f.read()
-        _, ext = os.path.splitext(path)
+        base, ext = os.path.splitext(path)
+        if ext == ".lz4":
+            base, ext = os.path.splitext(base)
+            decompressed_size = len(content) * 2
+            while True:
+                try:
+                    content = lz4.block.decompress(content, uncompressed_size=decompressed_size, return_bytearray=True)
+                    break
+                except lz4.block.LZ4BlockError:
+                    decompressed_size *= 2
         builder = BUILDERS.get(ext, None)
         if builder is None:
             print("No builder registered for filetype %s" %ext)


### PR DESCRIPTION
Allow unpacked archives to retain their compression on disk and have unpack_ddf do the unarchive on the fly.