### PR TITLE
Allow passing CFLAGS/LFLAGS from build.py to emscripten

### DIFF
--- a/build_tools/waf_dynamo.py
+++ b/build_tools/waf_dynamo.py
@@ -508,7 +508,12 @@ def default_flags(self):
         emflags_link =[j for i in emflags_link for j in i]
 
         flags = []
+        if os.environ.get('EMCFLAGS', None) is not None:
+            flags += os.environ.get("EMCFLAGS", "").split(' ')
         linkflags = []
+        if os.environ.get('EMLINKFLAGS', None) is not None:
+            linkflags += os.environ.get("EMLINKFLAGS", "").split(' ')
+
         if int(opt_level) < 2:
             flags = ['-gseparate-dwarf', '-gsource-map']
             linkflags = ['-gseparate-dwarf', '-gsource-map']


### PR DESCRIPTION
It is already possible to pass CFLAGS/LINKFLAGS into waf for running the c compiler, but I'd like to pass options specifically into emscripten as well at compile/link time.