### PR TITLE
Use right message class for atlas

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/AtlasBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/AtlasBuilder.java
@@ -44,7 +44,7 @@ import com.dynamo.gamesys.proto.AtlasProto.AtlasImage;
 
 import com.google.protobuf.TextFormat;
 
-@ProtoParams(srcClass = Atlas.class, messageClass = Atlas.class)
+@ProtoParams(srcClass = Atlas.class, messageClass = TextureSet.class)
 @BuilderParams(name = "Atlas", inExts = {".atlas"}, outExt = ".a.texturesetc")
 public class AtlasBuilder extends ProtoBuilder<Atlas.Builder> {
 


### PR DESCRIPTION
`messageClass` is output message format, in this case Atlas is input format which transforms into TextureSet - the output format. 

It's important to specify it right, so the output format will be used to calculate the build artifact signature (if output format changes, the resurce should be changed as well)