### PR TITLE
Remove unused world constant from tile_map in builtins

### DIFF
--- a/engine/engine/content/builtins/materials/tile_map.material
+++ b/engine/engine/content/builtins/materials/tile_map.material
@@ -7,10 +7,6 @@ vertex_constants {
   name: "view_proj"
   type: CONSTANT_TYPE_VIEWPROJ
 }
-vertex_constants {
-  name: "world"
-  type: CONSTANT_TYPE_WORLD
-}
 fragment_constants {
   name: "tint"
   type: CONSTANT_TYPE_USER


### PR DESCRIPTION
The unused `world` constant has been removed from the `tile_map` material from builtins.

Fixes #9634
