### PR TITLE
Automatically calculate the maximum number of game objects required for a runtime collection

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/CollectionBuilderTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/CollectionBuilderTest.java
@@ -555,8 +555,15 @@ public class CollectionBuilderTest extends AbstractProtoBuilderTest {
 
         CollectionDesc collection = getMessage(messages, CollectionDesc.class);
         List<ComponenTypeDesc> types = collection.getComponentTypesList();
-        Assert.assertEquals(1, types.size());
-        Assert.assertEquals(2, types.get(0).getMaxCount());
+        Assert.assertEquals(2, types.size());
+        for (ComponenTypeDesc type: types) {
+            if (type.getNameHash() == MurmurHash.hash64("spritec")) {
+                Assert.assertEquals(2, type.getMaxCount());
+            }
+            else if (type.getNameHash() == MurmurHash.hash64("goc")) {
+                Assert.assertEquals(1, type.getMaxCount());
+            }
+        }
     }
 
     /**
@@ -617,11 +624,15 @@ public class CollectionBuilderTest extends AbstractProtoBuilderTest {
 
         CollectionDesc collection = getMessage(mainColmsg, CollectionDesc.class);
         List<ComponenTypeDesc> types = collection.getComponentTypesList();
-        Assert.assertEquals(2, types.size());
+        Assert.assertEquals(3, types.size());
         for (ComponenTypeDesc type: types) {
             if (type.getNameHash() == MurmurHash.hash64("collectionfactoryc")) {
                 Assert.assertEquals(1, type.getMaxCount());
-            } else {
+            }
+            else if (type.getNameHash() == MurmurHash.hash64("spritec")) {
+                Assert.assertEquals((int)ComponentsCounter.DYNAMIC_VALUE, type.getMaxCount());
+            }
+            else if (type.getNameHash() == MurmurHash.hash64("goc")) {
                 Assert.assertEquals((int)ComponentsCounter.DYNAMIC_VALUE, type.getMaxCount());
             }
         }
@@ -677,11 +688,15 @@ public class CollectionBuilderTest extends AbstractProtoBuilderTest {
 
         CollectionDesc collection = getMessage(mainColmsg, CollectionDesc.class);
         List<ComponenTypeDesc> types = collection.getComponentTypesList();
-        Assert.assertEquals(2, types.size());
+        Assert.assertEquals(3, types.size());
         for (ComponenTypeDesc type: types) {
             if (type.getNameHash() == MurmurHash.hash64("factoryc")) {
                 Assert.assertEquals(1, type.getMaxCount());
-            } else {
+            }
+            else if (type.getNameHash() == MurmurHash.hash64("spritec")) {
+                Assert.assertEquals((int)ComponentsCounter.DYNAMIC_VALUE, type.getMaxCount());
+            }
+            else if (type.getNameHash() == MurmurHash.hash64("goc")) {
                 Assert.assertEquals((int)ComponentsCounter.DYNAMIC_VALUE, type.getMaxCount());
             }
         }
@@ -750,11 +765,15 @@ public class CollectionBuilderTest extends AbstractProtoBuilderTest {
 
         CollectionDesc collection = getMessage(mainColmsg, CollectionDesc.class);
         List<ComponenTypeDesc> types = collection.getComponentTypesList();
-        Assert.assertEquals(2, types.size());
+        Assert.assertEquals(3, types.size());
         for (ComponenTypeDesc type: types) {
             if (type.getNameHash() == MurmurHash.hash64("factoryc")) {
                 Assert.assertEquals(2, type.getMaxCount());
-            } else {
+            }
+            else if (type.getNameHash() == MurmurHash.hash64("spritec")) {
+                Assert.assertEquals((int)ComponentsCounter.DYNAMIC_VALUE, type.getMaxCount());
+            }
+            else if (type.getNameHash() == MurmurHash.hash64("goc")) {
                 Assert.assertEquals((int)ComponentsCounter.DYNAMIC_VALUE, type.getMaxCount());
             }
         }
@@ -884,11 +903,15 @@ public class CollectionBuilderTest extends AbstractProtoBuilderTest {
 
         CollectionDesc collection = getMessage(mainColmsg, CollectionDesc.class);
         List<ComponenTypeDesc> types = collection.getComponentTypesList();
-        Assert.assertEquals(2, types.size());
+        Assert.assertEquals(3, types.size());
         for (ComponenTypeDesc type: types) {
             if (type.getNameHash() == MurmurHash.hash64("collectionfactoryc")) {
                 Assert.assertEquals(1, type.getMaxCount());
-            } else {
+            }
+            else if (type.getNameHash() == MurmurHash.hash64("spritec")) {
+                Assert.assertEquals((int)ComponentsCounter.DYNAMIC_VALUE, type.getMaxCount());
+            }
+            else if (type.getNameHash() == MurmurHash.hash64("goc")) {
                 Assert.assertEquals((int)ComponentsCounter.DYNAMIC_VALUE, type.getMaxCount());
             }
         }
@@ -958,9 +981,12 @@ public class CollectionBuilderTest extends AbstractProtoBuilderTest {
         assertTrue(instances.containsKey("/subCol2/go"));
 
         List<ComponenTypeDesc> types = collection.getComponentTypesList();
-        Assert.assertEquals(1, types.size());
+        Assert.assertEquals(2, types.size());
         for (ComponenTypeDesc type: types) {
             if (type.getNameHash() == MurmurHash.hash64("spritec")) {
+                Assert.assertEquals(2, type.getMaxCount());
+            }
+            else if (type.getNameHash() == MurmurHash.hash64("goc")) {
                 Assert.assertEquals(2, type.getMaxCount());
             }
         }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/CollectionBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/CollectionBuilder.java
@@ -372,6 +372,7 @@ public class CollectionBuilder extends ProtoBuilder<CollectionDesc.Builder> {
     @Override
     protected CollectionDesc.Builder transform(Task task, IResource resource, CollectionDesc.Builder messageBuilder) throws CompileExceptionError, IOException {
         Integer countOfRealEmbededObjects = messageBuilder.getEmbeddedInstancesCount();
+        int goCount = messageBuilder.getInstancesCount();
         mergeSubCollections(resource, messageBuilder);
         ComponentsCounter.Storage compStorage = ComponentsCounter.createStorage();
         int embedIndex = 0;
@@ -388,6 +389,7 @@ public class CollectionBuilder extends ProtoBuilder<CollectionDesc.Builder> {
             // mergeSubCollections() embeds instances, but we want to count only "real" embeded instances
             if (embedIndex < countOfRealEmbededObjects) {
                 ComponentsCounter.countComponentsInEmbededObjects(project, genResource, compStorage);
+                goCount++;
             }
 
             int buildDirLen = project.getBuildDirectory().length();
@@ -454,6 +456,7 @@ public class CollectionBuilder extends ProtoBuilder<CollectionDesc.Builder> {
         }
         messageBuilder.addAllPropertyResources(propertyResources);
 
+        compStorage.add("goc", goCount);
         ComponentsCounter.sumInputs(compStorage, task.getInputs(), compCounterInputsCount);
         ComponentsCounter.copyDataToBuilder(compStorage, project, messageBuilder);
         task.output(1).setContent(compStorage.toByteArray());

--- a/engine/gameobject/src/gameobject/gameobject.cpp
+++ b/engine/gameobject/src/gameobject/gameobject.cpp
@@ -52,6 +52,7 @@ namespace dmGameObject
     const char* COLLECTION_MAX_INSTANCES_KEY = "collection.max_instances";
     const char* COLLECTION_MAX_INPUT_STACK_ENTRIES_KEY = "collection.max_input_stack_entries";
     const dmhash_t UNNAMED_IDENTIFIER = dmHashBuffer64("__unnamed__", strlen("__unnamed__"));
+    const dmhash_t GAME_OBJECT_EXT = dmHashString64("goc");
     const char* ID_SEPARATOR = "/";
     const uint32_t MAX_DISPATCH_ITERATION_COUNT = 10;
 
@@ -365,7 +366,16 @@ namespace dmGameObject
 
     Collection* AllocCollection(const char* name, HRegister regist, uint32_t max_instances, dmGameObjectDDF::CollectionDesc* collection_desc)
     {
-        Collection* collection = new Collection(0, 0, max_instances, GetInputStackDefaultCapacity(regist));
+        uint32_t instances_in_collection = GetMaxComponentInstances(GAME_OBJECT_EXT, collection_desc);
+        if (instances_in_collection == 0)
+        {
+            instances_in_collection = max_instances;
+        }
+        else
+        {
+            instances_in_collection = dmMath::Min(max_instances, instances_in_collection);
+        }
+        Collection* collection = new Collection(0, 0, instances_in_collection, GetInputStackDefaultCapacity(regist));
         collection->m_Mutex = dmMutex::New();
 
         for (uint32_t i = 0; i < regist->m_ComponentTypeCount; ++i)
@@ -376,7 +386,7 @@ namespace dmGameObject
                 params.m_Context = regist->m_ComponentTypes[i].m_Context;
                 params.m_ComponentIndex = i;
                 params.m_MaxComponentInstances = GetMaxComponentInstances(regist->m_ComponentTypes[i].m_NameHash, collection_desc);
-                params.m_MaxInstances = max_instances;
+                params.m_MaxInstances = instances_in_collection;
                 params.m_World = &collection->m_ComponentWorlds[i];
                 regist->m_ComponentTypes[i].m_NewWorldFunction(params);
             }
@@ -493,7 +503,7 @@ namespace dmGameObject
     {
         if (max_instances > INVALID_INSTANCE_INDEX)
         {
-            dmLogError("max_instances must be less or equal to %d", INVALID_INSTANCE_INDEX);
+            dmLogError("max_instances must be less or equal to %d", INVALID_INSTANCE_INDEX - 1);
             return 0;
         }
 

--- a/engine/gameobject/src/gameobject/res_collection.cpp
+++ b/engine/gameobject/src/gameobject/res_collection.cpp
@@ -32,9 +32,9 @@ namespace dmGameObject
         dmResource::Result res = dmResource::RESULT_OK;
 
         uint32_t created_instances = 0;
-        uint32_t collection_capacity = dmGameObject::GetCollectionDefaultCapacity(regist);
+        uint32_t default_capacity = dmGameObject::GetCollectionDefaultCapacity(regist);
 
-        HCollection hcollection = NewCollection(collection_desc->m_Name, factory, regist, collection_capacity, collection_desc);
+        HCollection hcollection = NewCollection(collection_desc->m_Name, factory, regist, default_capacity, collection_desc);
         if (hcollection == 0)
         {
             dmLogError("AcquireResources NewCollection RESULT_OUT_OF_RESOURCES");


### PR DESCRIPTION
Bob calculates how many game objects are used by each collection. If the collection has no `factory` or `collectionfactory` component, this value is used to allocate the exact number of GameObjects for the world (collection proxy). Otherwise, `collection.max_instances` is used.

This helps save memory, especially in cases where the game has a world that requires a large `max_instances` value for the main game scene, but smaller and static extra scenes (such as popups, menus, etc.).

Fix https://github.com/defold/defold/issues/9556
## PR checklist

* [ ] Code
	* [x] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
