### PR TITLE
Add the `engine-setup` script tag to the HTML5 template

### DIFF
--- a/engine/engine/content/builtins/manifests/web/engine_template.html
+++ b/engine/engine/content/builtins/manifests/web/engine_template.html
@@ -94,7 +94,10 @@
 	</div>
 	<!-- -->
 	<script id='engine-loader' type='text/javascript' src="dmloader.js"></script>
-
+	<script id='engine-setup' type='text/javascript'>
+		// From here you can configure game startup parameters via the CUSTOM_PARAMETERS object,
+		// override ProgressView to create your own loader. See dmloader.js for more details.
+	</script>
 	<script id='engine-start' type='text/javascript'>
 		var runningFromFileWarning = document.getElementById("running-from-file-warning");
 		if (window.location.href.startsWith("file://")) {


### PR DESCRIPTION
This change brings back the `engine-setup` section to the HTML5 template. Developers can use it and native extensions can inject code here to add game startup parameters via the `CUSTOM_PARAMETERS` object, setup loading progress listeners, override the `dmloader.js` functions.

Closes https://github.com/defold/defold/issues/9645
