### PR TITLE
Use a global vao when enabling a vertex declaration

### DIFF
--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -1429,11 +1429,7 @@ static void LogFrameBufferError(GLenum status)
         }
 
 #if !defined(GL_ES_VERSION_2_0)
-        {
-            GLuint vao;
-            glGenVertexArrays(1, &vao);
-            glBindVertexArray(vao);
-        }
+        glGenVertexArrays(1, &context->m_GlobalVAO);
 #endif
 
         SetSwapInterval(_context, params.m_SwapInterval);
@@ -1857,6 +1853,10 @@ static void LogFrameBufferError(GLenum status)
         assert(vertex_declaration);
 
         OpenGLContext* context = (OpenGLContext*) _context;
+
+    #if !defined(GL_ES_VERSION_2_0)
+        glBindVertexArray(context->m_GlobalVAO);
+    #endif
 
         if (!(context->m_ModificationVersion == vertex_declaration->m_ModificationVersion && vertex_declaration->m_BoundForProgram == ((OpenGLProgram*) program)->m_Id))
         {

--- a/engine/graphics/src/opengl/graphics_opengl_private.h
+++ b/engine/graphics/src/opengl/graphics_opengl_private.h
@@ -148,6 +148,9 @@ namespace dmGraphics
         dmOpaqueHandleContainer<uintptr_t> m_AssetHandleContainer;
 
         PipelineState           m_PipelineState;
+
+        GLuint                  m_GlobalVAO;
+
         uint32_t                m_Width;
         uint32_t                m_Height;
         uint32_t                m_MaxTextureSize;


### PR DESCRIPTION
In some extensions (e.g Rive) that use vertex array objects, the OpenGL render state can get mixed up because of our single global vertex array object that is only bound once during initialization.