### PR TITLE
Fix for gui where we didn't use the font resource correctly

### DIFF
--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -1126,7 +1126,7 @@ namespace dmEngine
         gui_params.m_GetURLCallback = dmGameSystem::GuiGetURLCallback;
         gui_params.m_GetUserDataCallback = dmGameSystem::GuiGetUserDataCallback;
         gui_params.m_ResolvePathCallback = dmGameSystem::GuiResolvePathCallback;
-        gui_params.m_GetTextMetricsCallback = dmGameSystem::GuiGetTextMetricsCallback;
+        gui_params.m_GetTextMetricsCallback = (void (*)(const void *, const char *, float, bool, float, float, dmGui::TextMetrics *))dmGameSystem::GuiGetTextMetricsCallback;
 
         // If an extension changes window size at extensions initialization phase, engine should read that.
         physical_width = dmGraphics::GetWindowWidth(engine->m_GraphicsContext);

--- a/engine/gamesys/src/dmsdk/gamesys/resources/res_gui.h
+++ b/engine/gamesys/src/dmsdk/gamesys/resources/res_gui.h
@@ -17,7 +17,6 @@
 
 #include <dmsdk/dlib/array.h>
 #include <dmsdk/dlib/hashtable.h>
-#include <dmsdk/render/render.h>
 #include <dmsdk/gui/gui.h>
 
 #include <gamesys/gui_ddf.h>
@@ -45,7 +44,6 @@ namespace dmGameSystem
         dmGuiDDF::SceneDesc*                m_SceneDesc;
         dmGui::HScript                      m_Script;
         dmArray<FontResource*>              m_Fonts;
-        dmArray<dmRender::HFontMap>         m_FontMaps;
         dmArray<dmhash_t>                   m_FontMapPaths;
         dmArray<GuiSceneTextureSetResource> m_GuiTextureSets;
         dmArray<dmParticle::HPrototype>     m_ParticlePrototypes;

--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -170,7 +170,7 @@ namespace dmGameSystem
         return node_material_res ? GetNodeMaterial(node_material_res) : gui_context->m_Material;
     }
 
-    static inline dmRender::HMaterial GetTextNodeMaterial(RenderGuiContext* gui_context, dmGui::HScene scene, dmGui::HNode node, dmRender::HFontMap font_map)
+    static inline dmRender::HMaterial GetTextNodeMaterial(RenderGuiContext* gui_context, dmGui::HScene scene, dmGui::HNode node, dmRender::HFont font_map)
     {
         void* node_material_res = dmGui::GetNodeMaterial(scene, node);
         if (node_material_res)
@@ -1154,7 +1154,7 @@ namespace dmGameSystem
             dmGui::NodeType node_type = dmGui::GetNodeType(scene, node);
             assert(node_type == dmGui::NODE_TYPE_TEXT);
 
-            dmRender::HFontMap font_map  = (dmRender::HFontMap) dmGui::GetNodeFont(scene, node);
+            dmRender::HFont font_map = (dmRender::HFont)dmGui::GetNodeFont(scene, node);
             if (!font_map)
                 continue;
             dmRender::HMaterial material = GetTextNodeMaterial(gui_context, scene, node, font_map);
@@ -2095,7 +2095,7 @@ namespace dmGameSystem
         uint32_t prev_custom_type                       = dmGui::GetNodeCustomType(scene, first_node);
         uint64_t prev_combined_type                     = GetCombinedNodeType(prev_node_type, prev_custom_type);
         dmGraphics::HTexture prev_texture               = GetNodeTexture(scene, first_node);
-        void* prev_font                                 = dmGui::GetNodeFont(scene, first_node);
+        dmRender::HFont prev_font                       = (dmRender::HFont)dmGui::GetNodeFont(scene, first_node);
         HComponentRenderConstants prev_render_constants = (HComponentRenderConstants) dmGui::GetNodeRenderConstants(scene, first_node);
         const dmGui::StencilScope* prev_stencil_scope   = stencil_scopes[0];
         uint32_t prev_emitter_batch_key                 = 0;
@@ -2110,7 +2110,7 @@ namespace dmGameSystem
 
         if (prev_node_type == dmGui::NODE_TYPE_TEXT)
         {
-            prev_material = GetTextNodeMaterial(gui_context, scene, first_node, (dmRender::HFontMap) prev_font);
+            prev_material = GetTextNodeMaterial(gui_context, scene, first_node, prev_font);
         }
         else
         {
@@ -2128,7 +2128,7 @@ namespace dmGameSystem
             uint32_t custom_type                       = dmGui::GetNodeCustomType(scene, node);
             uint64_t combined_type                     = GetCombinedNodeType(node_type, custom_type);
             dmGraphics::HTexture texture               = GetNodeTexture(scene, node);
-            void* font                                 = dmGui::GetNodeFont(scene, node);
+            dmRender::HFont font                       = (dmRender::HFont)dmGui::GetNodeFont(scene, node);
             const dmGui::StencilScope* stencil_scope   = stencil_scopes[i];
             uint32_t emitter_batch_key                 = 0;
             dmRender::HMaterial material               = 0;
@@ -2143,7 +2143,7 @@ namespace dmGameSystem
 
             if (node_type == dmGui::NODE_TYPE_TEXT)
             {
-                material = GetTextNodeMaterial(gui_context, scene, node, (dmRender::HFontMap) font);
+                material = GetTextNodeMaterial(gui_context, scene, node, font);
             }
             else
             {
@@ -2756,21 +2756,23 @@ namespace dmGameSystem
                 return dmGameObject::PROPERTY_RESULT_INVALID_KEY;
             }
             dmResource::HFactory factory = dmGameObject::GetFactory(params.m_Instance);
-            dmGameSystem::FontResource* font = 0;
-            dmGameObject::PropertyResult res = SetResourceProperty(factory, params.m_Value, FONT_EXT_HASH, (void**)&font);
+            dmGameSystem::FontResource* font_resource = 0;
+            dmGameObject::PropertyResult res = SetResourceProperty(factory, params.m_Value, FONT_EXT_HASH, (void**)&font_resource);
             if (res == dmGameObject::PROPERTY_RESULT_OK)
             {
+                dmRender::HFont font = dmGameSystem::ResFontGetHandle(font_resource);
+
                 dmGui::Result r = dmGui::AddFont(gui_component->m_Scene, params.m_Options.m_Key, (void*)font, params.m_Value.m_Hash);
                 if (r != dmGui::RESULT_OK)
                 {
                     dmLogError("Unable to set font `%s` property in component `%s`", dmHashReverseSafe64(params.m_Options.m_Key), gui_component->m_Resource->m_Path);
-                    dmResource::Release(factory, font);
+                    dmResource::Release(factory, font_resource);
                     return dmGameObject::PROPERTY_RESULT_BUFFER_OVERFLOW;
                 }
                 if(gui_component->m_ResourcePropertyPointers.Full()) {
                     gui_component->m_ResourcePropertyPointers.OffsetCapacity(1);
                 }
-                gui_component->m_ResourcePropertyPointers.Push(font);
+                gui_component->m_ResourcePropertyPointers.Push(font_resource);
             }
             return res;
         }

--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -699,10 +699,11 @@ namespace dmGameSystem
 
         dmGui::SetSceneAdjustReference(scene, (dmGui::AdjustReference)scene_desc->m_AdjustReference);
 
-        for (uint32_t i = 0; i < scene_resource->m_FontMaps.Size(); ++i)
+        for (uint32_t i = 0; i < scene_resource->m_Fonts.Size(); ++i)
         {
             const char* name = scene_desc->m_Fonts[i].m_Name;
-            dmGui::Result r = dmGui::AddFont(scene, dmHashString64(name), (void*) scene_resource->m_FontMaps[i], scene_resource->m_FontMapPaths[i]);
+            dmGameSystem::FontResource* font = scene_resource->m_Fonts[i];
+            dmGui::Result r = dmGui::AddFont(scene, dmHashString64(name), (void*)font, scene_resource->m_FontMapPaths[i]);
             if (r != dmGui::RESULT_OK) {
                 dmLogError("Unable to add font '%s' to scene (%d)", name,  r);
                 return false;
@@ -1154,7 +1155,8 @@ namespace dmGameSystem
             dmGui::NodeType node_type = dmGui::GetNodeType(scene, node);
             assert(node_type == dmGui::NODE_TYPE_TEXT);
 
-            dmRender::HFont font_map = (dmRender::HFont)dmGui::GetNodeFont(scene, node);
+            dmGameSystem::FontResource* font_resource = (dmGameSystem::FontResource*)dmGui::GetNodeFont(scene, node);
+            dmRender::HFont font_map = font_resource != 0 ? dmGameSystem::ResFontGetHandle(font_resource) : 0;
             if (!font_map)
                 continue;
             dmRender::HMaterial material = GetTextNodeMaterial(gui_context, scene, node, font_map);
@@ -2095,7 +2097,8 @@ namespace dmGameSystem
         uint32_t prev_custom_type                       = dmGui::GetNodeCustomType(scene, first_node);
         uint64_t prev_combined_type                     = GetCombinedNodeType(prev_node_type, prev_custom_type);
         dmGraphics::HTexture prev_texture               = GetNodeTexture(scene, first_node);
-        dmRender::HFont prev_font                       = (dmRender::HFont)dmGui::GetNodeFont(scene, first_node);
+        dmGameSystem::FontResource* prev_font_resource  = (dmGameSystem::FontResource*)dmGui::GetNodeFont(scene, first_node);
+        dmRender::HFont             prev_font           = prev_font_resource ? dmGameSystem::ResFontGetHandle(prev_font_resource) : 0;
         HComponentRenderConstants prev_render_constants = (HComponentRenderConstants) dmGui::GetNodeRenderConstants(scene, first_node);
         const dmGui::StencilScope* prev_stencil_scope   = stencil_scopes[0];
         uint32_t prev_emitter_batch_key                 = 0;
@@ -2128,7 +2131,8 @@ namespace dmGameSystem
             uint32_t custom_type                       = dmGui::GetNodeCustomType(scene, node);
             uint64_t combined_type                     = GetCombinedNodeType(node_type, custom_type);
             dmGraphics::HTexture texture               = GetNodeTexture(scene, node);
-            dmRender::HFont font                       = (dmRender::HFont)dmGui::GetNodeFont(scene, node);
+            dmGameSystem::FontResource* font_resource  = (dmGameSystem::FontResource*)dmGui::GetNodeFont(scene, node);
+            dmRender::HFont             font           = font_resource ? dmGameSystem::ResFontGetHandle(font_resource) : 0;
             const dmGui::StencilScope* stencil_scope   = stencil_scopes[i];
             uint32_t emitter_batch_key                 = 0;
             dmRender::HMaterial material               = 0;
@@ -2694,10 +2698,11 @@ namespace dmGameSystem
     }
 
     // Public function used by engine (as callback from gui system)
-    void GuiGetTextMetricsCallback(const void* font, const char* text, float width, bool line_break, float leading, float tracking, dmGui::TextMetrics* out_metrics)
+    void GuiGetTextMetricsCallback(dmGameSystem::FontResource* font_resource, const char* text, float width, bool line_break, float leading, float tracking, dmGui::TextMetrics* out_metrics)
     {
+        dmRender::HFont font = dmGameSystem::ResFontGetHandle(font_resource);
         dmRender::TextMetrics metrics;
-        dmRender::GetTextMetrics((dmRender::HFontMap)font, text, width, line_break, leading, tracking, &metrics);
+        dmRender::GetTextMetrics(font, text, width, line_break, leading, tracking, &metrics);
         out_metrics->m_Width = metrics.m_Width;
         out_metrics->m_Height = metrics.m_Height;
         out_metrics->m_MaxAscent = metrics.m_MaxAscent;
@@ -2760,9 +2765,7 @@ namespace dmGameSystem
             dmGameObject::PropertyResult res = SetResourceProperty(factory, params.m_Value, FONT_EXT_HASH, (void**)&font_resource);
             if (res == dmGameObject::PROPERTY_RESULT_OK)
             {
-                dmRender::HFont font = dmGameSystem::ResFontGetHandle(font_resource);
-
-                dmGui::Result r = dmGui::AddFont(gui_component->m_Scene, params.m_Options.m_Key, (void*)font, params.m_Value.m_Hash);
+                dmGui::Result r = dmGui::AddFont(gui_component->m_Scene, params.m_Options.m_Key, (void*)font_resource, params.m_Value.m_Hash);
                 if (r != dmGui::RESULT_OK)
                 {
                     dmLogError("Unable to set font `%s` property in component `%s`", dmHashReverseSafe64(params.m_Options.m_Key), gui_component->m_Resource->m_Path);

--- a/engine/gamesys/src/gamesys/components/comp_gui.h
+++ b/engine/gamesys/src/gamesys/components/comp_gui.h
@@ -26,11 +26,13 @@ namespace dmMessage
 
 namespace dmGameSystem
 {
+    struct FontResource;
+
     // Used by the engine to setup the dmGui::HContext
     void GuiGetURLCallback(dmGui::HScene scene, dmMessage::URL* url);
     uintptr_t GuiGetUserDataCallback(dmGui::HScene scene);
     dmhash_t GuiResolvePathCallback(dmGui::HScene scene, const char* path, uint32_t path_size);
-    void GuiGetTextMetricsCallback(const void* font, const char* text, float width, bool line_break, float leading, float tracking, dmGui::TextMetrics* out_metrics);
+    void GuiGetTextMetricsCallback(dmGameSystem::FontResource* font_resource, const char* text, float width, bool line_break, float leading, float tracking, dmGui::TextMetrics* out_metrics);
 
     // Used only in engine_service.cpp for resource profiling
     typedef bool (*FDynamicTextturesIterator)(dmhash_t gui_res_id, dmhash_t name_hash, uint32_t size, void* user_ctx);

--- a/engine/gamesys/src/gamesys/resources/res_gui.cpp
+++ b/engine/gamesys/src/gamesys/resources/res_gui.cpp
@@ -82,9 +82,7 @@ namespace dmGameSystem
 
         resource->m_Fonts.SetCapacity(resource->m_SceneDesc->m_Fonts.m_Count);
         resource->m_Fonts.SetSize(0);
-        resource->m_FontMaps.SetCapacity(resource->m_SceneDesc->m_Fonts.m_Count);
-        resource->m_FontMaps.SetSize(0);
-        resource->m_FontMapPaths.SetCapacity(resource->m_FontMaps.Capacity());
+        resource->m_FontMapPaths.SetCapacity(resource->m_Fonts.Capacity());
         resource->m_FontMapPaths.SetSize(0);
         for (uint32_t i = 0; i < resource->m_SceneDesc->m_Fonts.m_Count; ++i)
         {
@@ -93,9 +91,6 @@ namespace dmGameSystem
             if (r != dmResource::RESULT_OK)
                 return r;
             resource->m_Fonts.Push(font);
-
-            dmRender::HFontMap font_map = ResFontGetHandle(font);
-            resource->m_FontMaps.Push(font_map);
 
             dmhash_t path_hash = 0;
             dmResource::GetPath(factory, font, &path_hash);
@@ -159,7 +154,6 @@ namespace dmGameSystem
         uint32_t size = sizeof(GuiSceneResource);
         size += ddf_size;
         size += res->m_Fonts.Capacity()*sizeof(FontResource*);
-        size += res->m_FontMaps.Capacity()*sizeof(dmRender::HFontMap);
         size += res->m_GuiTextureSets.Capacity()*sizeof(GuiSceneTextureSetResource);
         //size += res->m_Resources.Capacity()* ? // We should probably collect the sizes when we get them from the resource factory
         size += res->m_ParticlePrototypes.Capacity()*sizeof(dmParticle::HPrototype);
@@ -320,7 +314,6 @@ namespace dmGameSystem
             ReleaseResources(params->m_Factory, scene_resource);
             scene_resource->m_SceneDesc = tmp_scene_resource.m_SceneDesc;
             scene_resource->m_Script = tmp_scene_resource.m_Script;
-            scene_resource->m_FontMaps.Swap(tmp_scene_resource.m_FontMaps);
             scene_resource->m_GuiTextureSets.Swap(tmp_scene_resource.m_GuiTextureSets);
             scene_resource->m_Path = tmp_scene_resource.m_Path;
             scene_resource->m_GuiContext = tmp_scene_resource.m_GuiContext;

--- a/engine/gamesys/src/gamesys/test/gui/goscript.go
+++ b/engine/gamesys/src/gamesys/test/gui/goscript.go
@@ -1,0 +1,8 @@
+components {
+  id: "gui"
+  component: "/gui/goscript.gui"
+}
+components {
+  id: "script"
+  component: "/gui/goscript.script"
+}

--- a/engine/gamesys/src/gamesys/test/gui/goscript.gui
+++ b/engine/gamesys/src/gamesys/test/gui/goscript.gui
@@ -1,0 +1,51 @@
+script: "/gui/goscript.gui_script"
+fonts {
+  name: "test_font"
+  font: "/font/valid_font.font"
+}
+fonts {
+  name: "test_font2"
+  font: "/font/glyph_bank_test_1.font"
+}
+textures {
+  name: "test_texture"
+  texture: "/texture/valid_png.png"
+}
+nodes {
+  position {
+    x: 1.0
+    y: 0.0
+    z: 0.0
+    w: 0.0
+  }
+  rotation {
+    x: 1.0
+    y: 0.0
+    z: 0.0
+    w: 0.0
+  }
+  scale {
+    x: 1.0
+    y: 0.0
+    z: 0.0
+    w: 0.0
+  }
+  size {
+    x: 1.0
+    y: 0.0
+    z: 0.0
+    w: 0.0
+  }
+  color {
+    x: 1.0
+    y: 0.0
+    z: 0.0
+    w: 0.0
+  }
+  type: TYPE_TEXT
+  blend_mode: BLEND_MODE_ALPHA
+  id: "text"
+  font: "test_font"
+  text: "HELLO"
+}
+material: "/gui/gui.material"

--- a/engine/gamesys/src/gamesys/test/gui/goscript.gui_script
+++ b/engine/gamesys/src/gamesys/test/gui/goscript.gui_script
@@ -1,0 +1,21 @@
+-- Copyright 2020-2024 The Defold Foundation
+-- Copyright 2014-2020 King
+-- Copyright 2009-2014 Ragnar Svensson, Christian Murray
+-- Licensed under the Defold License version 1.0 (the "License"); you may not use
+-- this file except in compliance with the License.
+-- 
+-- You may obtain a copy of the License, together with FAQs at
+-- https://www.defold.com/license
+-- 
+-- Unless required by applicable law or agreed to in writing, software distributed
+-- under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+-- CONDITIONS OF ANY KIND, either express or implied. See the License for the
+-- specific language governing permissions and limitations under the License.
+
+require "gui.gui_module"
+
+function init(self)
+end
+
+function update(self, dt)
+end

--- a/engine/gamesys/src/gamesys/test/gui/goscript.script
+++ b/engine/gamesys/src/gamesys/test/gui/goscript.script
@@ -1,0 +1,5 @@
+function init(self)
+    timer.delay(.001, false, function()
+        go.set("/go#gui", "fonts", hash("/font/glyph_bank_test_1.fontc"), { key = "test_font" })
+    end)
+end

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -1511,6 +1511,37 @@ TEST_F(GuiTest, MaxDynamictextures)
     ASSERT_TRUE(dmGameObject::Final(m_Collection));
 }
 
+// Test setting gui font
+TEST_F(ResourceTest, ScriptSetFonts)
+{
+    dmGameObject::HInstance go = Spawn(m_Factory, m_Collection, "/gui/goscript.goc", dmHashString64("/go"), 0, Point3(0, 0, 0), Quat(0, 0, 0, 1), Vector3(1, 1, 1));
+    ASSERT_NE((void*)0x0, go);
+
+    void* font1 = 0;
+    ASSERT_EQ(dmResource::RESULT_OK, dmResource::Get(m_Factory, "/font/valid_font.fontc", (void**) &font1));
+    ASSERT_TRUE(font1 != 0x0);
+
+    void* font2 = 0;
+    ASSERT_EQ(dmResource::RESULT_OK, dmResource::Get(m_Factory, "/font/glyph_bank_test_1.fontc", (void**) &font2));
+    ASSERT_TRUE(font2 != 0x0);
+
+    for (int i = 0; i < 3; ++i)
+    {
+        ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+        // Trigger a render to finalize deletion of the textures
+        dmRender::RenderListBegin(m_RenderContext);
+        dmGameObject::Render(m_Collection);
+
+        dmRender::RenderListEnd(m_RenderContext);
+        dmRender::DrawRenderList(m_RenderContext, 0x0, 0x0, 0x0);
+    }
+
+    dmResource::Release(m_Factory, font1);
+    dmResource::Release(m_Factory, font2);
+
+    ASSERT_TRUE(dmGameObject::Final(m_Collection));
+}
+
 TEST_F(FontTest, GlyphBankTest)
 {
     const char path_font_1[] = "/font/glyph_bank_test_1.fontc";


### PR DESCRIPTION
Fixes https://github.com/defold/defold/issues/9653

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
