### PR TITLE
Set OpenGL version from editor cosmetic addendum

### DIFF
--- a/editor/resources/meta.edn
+++ b/editor/resources/meta.edn
@@ -310,20 +310,20 @@
    "verify the return value after each graphics call",
    :default true,
    :path ["graphics" "verify_graphics_calls"]}
-  {:type :integer,
+  {:type :string,
    :help
    "OpenGL context version hint. If a specific version is selected, this will used as the minimum version required (does not apply to OpenGL ES). Defaults to OpenGL 3.3",
-   :default 33,
+   :default "33",
    :path ["graphics" "opengl_version_hint"]
-   :options [[33 "OpenGL 3.3"]
-             [40 "OpenGL 4.0"]
-             [41 "OpenGL 4.1"]
-             [42 "OpenGL 4.2"]
-             [43 "OpenGL 4.3"]
-             [44 "OpenGL 4.4"]
-             [45 "OpenGL 4.5"]
-             [46 "OpenGL 4.6"]
-             [0 "Highest version available"]]}
+   :options [["33" "OpenGL 3.3"]
+             ["40" "OpenGL 4.0"]
+             ["41" "OpenGL 4.1"]
+             ["42" "OpenGL 4.2"]
+             ["43" "OpenGL 4.3"]
+             ["44" "OpenGL 4.4"]
+             ["45" "OpenGL 4.5"]
+             ["46" "OpenGL 4.6"]
+             ["0" "Highest version available"]]}
   {:type :boolean,
    :help "Set the 'core' OpenGL profile hint when creating the context. The core profile removes all deprecated features from OpenGL, such as immediate mode rendering. Does not apply to OpenGL ES.",
    :default true,


### PR DESCRIPTION
The editor doesn't support having an :option with integers as keys instead of strings.