### PR TITLE
Added new property in `game.project` to specify minimum log level `project.minimum_log_level`

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
@@ -13,6 +13,10 @@ write_log.type = bool
 write_log.help = Write log file to disk
 write_log.default = 0
 
+minimum_log_level.type = string
+minimum_log_level.help = only the minimum log level and higher levels will be shown
+minimum_log_level.default = 2
+
 compress_archive.type = bool
 compress_archive.help = Compress archive (not for Android)
 compress_archive.default = 1

--- a/editor/resources/meta.edn
+++ b/editor/resources/meta.edn
@@ -19,6 +19,11 @@
    :help "Write log file to disk",
    :default false,
    :path ["project" "write_log"]}
+  {:type :string,
+   :help "only the minimum log level and higher levels will be shown",
+   :default "2",
+   :path ["project" "minimum_log_level"]
+   :options [["0" "DEBUG = 0"] ["1" "USER DEBUG = 1"] ["2" "INFO = 2"] ["3" "WARNING = 3"] ["4" "ERROR = 4"] ["5" "FATAL = 5"]]}
   {:type :boolean,
    :help "compress archive (not for Android)",
    :default true,

--- a/editor/test/resources/save_data_project/game.project
+++ b/editor/test/resources/save_data_project/game.project
@@ -62,6 +62,7 @@ version = 1.1
 publisher = Defold Foundation
 developer = Defold Foundation
 write_log = 1
+minimum_log_level = 1
 compress_archive = 1
 custom_resources = /referenced/custom
 bundle_resources = /referenced/bundle

--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -692,6 +692,10 @@ namespace dmEngine
 #endif
         }
 
+        // Set minimul log level
+        int32_t minimum_log_level = dmConfigFile::GetInt(engine->m_Config, "project.minimum_log_level", LOG_SEVERITY_INFO);
+        dmLogSetLevel((LogSeverity)minimum_log_level);
+
         // Try loading SSL keys
         char engine_ssl_keys_path[DMPATH_MAX_PATH];
         dmPath::Concat(resources_path, "/ssl_keys.pem", engine_ssl_keys_path, sizeof(engine_ssl_keys_path));

--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -692,7 +692,7 @@ namespace dmEngine
 #endif
         }
 
-        // Set minimul log level
+        // Set minimum log level
         int32_t minimum_log_level = dmConfigFile::GetInt(engine->m_Config, "project.minimum_log_level", LOG_SEVERITY_INFO);
         dmLogSetLevel((LogSeverity)minimum_log_level);
 


### PR DESCRIPTION
Using the new `game.project` property `project.minimum_log_level`, it is possible to specify the minimum log level for the logging system. Only logs at the minimum level or higher will be shown.

Fix https://github.com/defold/defold/issues/8828