### PR TITLE
Fix a copy error when importing the glTF file - it should copy the bone from `skin->m_Bones` to `sorted_bones` in the `SortSkinBones`.

### DIFF
--- a/engine/modelc/src/modelimporter_gltf.cpp
+++ b/engine/modelc/src/modelimporter_gltf.cpp
@@ -1088,7 +1088,7 @@ static void SortSkinBones(Skin* skin)
         for (uint32_t i = 0; i < bones_count; ++i)
         {
             uint32_t new_index = skin->m_BoneRemap[i];
-            CopyBone(&sorted_bones[new_index], &skin->m_Bones[i]);
+            CopyBone(&skin->m_Bones[i], &sorted_bones[new_index]);
         }
 
         skin->m_Bones.Swap(sorted_bones);


### PR DESCRIPTION
Fix a copy error when importing the glTF file - it should copy the bone from `skin->m_Bones` to `sorted_bones` in the `SortSkinBones`.

The editor failed to import the [RiggedFigure](https://github.com/KhronosGroup/glTF-Sample-Models/tree/main/2.0/RiggedFigure), 
Then I debugged it and found somebody with the same problem in the forum.