### PR TITLE
Detect DMFS (meant to operate like IDBFS or NODEFS) as a replacement …

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/resources/jsweb/dmloader.js
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/resources/jsweb/dmloader.js
@@ -429,7 +429,9 @@ var GameArchiveLoader = {
         this.addListener(this._onFileLoadedListeners, callback);
     },
     notifyFileLoaded: function(file) {
-        this.notifyListeners(this._onFileLoadedListeners, { name: file.name, data: file.data });
+        if (file.data) {
+            this.notifyListeners(this._onFileLoadedListeners, { name: file.name, data: file.data });
+        }
     },
 
     addArchiveLoadedListener: function(callback) {
@@ -470,7 +472,11 @@ var GameArchiveLoader = {
             EngineLoader.loadAsmJsAsync(exeName);
             totalSize += EngineLoader.asmjs_size;
         }
-        this.downloadContent();
+        if (!Module['isDMFSSupported']) {
+            // we can download in parallel here because we will not rely on FS, otherwise
+            // we have to wait until after the [w]asm is loaded.
+            this.downloadContent();
+        }
         ProgressUpdater.resetCurrent();
         if (isWASMSupported) {
             EngineLoader.updateWasmInstantiateProgress(totalSize);
@@ -480,16 +486,27 @@ var GameArchiveLoader = {
 
     downloadContent: function() {
         var file = this._files[this._fileIndex];
-        // if the file consists of more than one piece we prepare an array to store the pieces in
-        if (file.pieces.length > 1) {
-            file.data = new Uint8Array(file.size);
+
+        if (Module['isDMFSSupported']) {
+            const path = `${DMSYS.GetUserPersistentDataRoot()}/${file.name}`;
+            try { // see if already and stored
+                const stat = FS.stat(path);
+                if(stat) {
+                    if (file.size == stat.size) { // should we verify hash too?
+                        this.onFileLoaded(file);
+                        return;
+                    }
+                }
+            } catch(_e) { }
+            file.stream = FS.open(path, "w");
         }
+
         // how many pieces to download at a time
         var limit = file.pieces.length;
         if (typeof this.MAX_CONCURRENT_XHR !== 'undefined') {
             limit = Math.min(limit, this.MAX_CONCURRENT_XHR);
         }
-        // download pieces
+
         for (var i=0; i<limit; ++i) {
             this.downloadPiece(file, i);
         }
@@ -532,9 +549,14 @@ var GameArchiveLoader = {
     },
 
     addPieceToFile: function(file, piece) {
-        if (1 == file.pieces.length) {
+        if (file.stream !== undefined) {
+            FS.write(file.stream, piece.data, 0, piece.data.length, piece.offset);
+        } else if (1 == file.pieces.length) {
             file.data = piece.data;
         } else {
+            if(!file.data) {
+               file.data = new Uint8Array(file.size);
+            }
             var start = piece.offset;
             var end = start + piece.data.length;
             if (0 > start) {
@@ -553,6 +575,11 @@ var GameArchiveLoader = {
         ++file.totalLoadedPieces;
         // is all pieces of the file loaded?
         if (file.totalLoadedPieces == file.pieces.length) {
+            if (file.stream !== undefined) {
+                FS.close(file.stream);
+                file.stream = undefined;
+            }
+            this.verifyFile(file);
             this.onFileLoaded(file);
         }
         // continue loading more pieces of the file
@@ -600,7 +627,6 @@ var GameArchiveLoader = {
     },
 
     onFileLoaded: function(file) {
-        this.verifyFile(file);
         this.notifyFileLoaded(file);
         ++this._fileIndex;
         if (this._fileIndex == this._files.length) {
@@ -752,6 +778,13 @@ var Module = {
     printErr: function(text) { console.error(text); },
 
     setStatus: function(text) { console.log(text); },
+
+    isDMFSSupported: (function() {
+        // DMFS is meant as a mount for FS to provide another way to acess resources, by default we just use IDBFS
+        if(typeof DMFS === "undefined")
+            return false;
+        return true;
+    })(),
 
     isWASMSupported: (function() {
         try {
@@ -950,18 +983,25 @@ var Module = {
             return;
         }
 
-        // If IndexedDB is supported we mount the persistent data root as IDBFS,
-        // then try to do a IDB->MEM sync before we start the engine to get
-        // previously saved data before boot.
         try {
-            FS.mount(IDBFS, {}, dir);
+            if (Module['isDMFSSupported']) {
+                // In DMFS mode we will use that as our mountpoint and make sure that all
+                // relative paths point into there.
+                FS.mount(new DMFS(CUSTOM_PARAMETERS['exe_name']), {}, dir);
+                FS.chdir(dir);
+            } else {
+                // If IndexedDB is supported we mount the persistent data root as IDBFS,
+                // then try to do a IDB->MEM sync before we start the engine to get
+                // previously saved data before boot.
+                FS.mount(IDBFS, {}, dir);
+            }
             // Patch FS.close so it will try to sync MEM->IDB
             var _close = FS.close;
             FS.close = function(stream) {
                 var r = _close(stream);
                 Module.persistentSync();
                 return r;
-            }
+            };
         }
         catch (error) {
             Module.persistentStorage = false;
@@ -985,6 +1025,9 @@ var Module = {
     postRun: [function() {
         if(Module._archiveLoaded) {
             ProgressView.removeProgress();
+        } else if (Module['isDMFSSupported']) {
+            // kick off the content download now that we have FS access
+            GameArchiveLoader.downloadContent();
         }
     }],
 


### PR DESCRIPTION
For my custom engine I'd like to avoid having all resources in memory, I've made it so that dmloader can detect a DMFS which will act as a replacement for in memory file access. This will have no impact on browser where we cannot implement such a thing.