### PR TITLE
Strip clrf line endings from shader source

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/ShaderProgramBuilderTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/ShaderProgramBuilderTest.java
@@ -755,6 +755,20 @@ public class ShaderProgramBuilderTest extends AbstractProtoBuilderTest {
     }
 
     @Test
+    public void testCarriageReturn() throws Exception {
+        String src =
+            "#version 140 \r\n" +
+            "\r\n" +
+            "void main(){\r\n" +
+            "   gl_FragColor = vec4(1.0); \r\n" +
+            "}\r\n";
+
+        List<Message> outputs = build("/test_shader_cr.fp", src);
+        ShaderDesc shaderDesc = (ShaderDesc) outputs.get(0);
+        assertTrue(shaderDesc.getShadersCount() > 0);
+    }
+
+    @Test
     public void testShaderCompilePipelines() throws Exception {
         String shaderNewPipeline =
             """

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderProgramBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderProgramBuilder.java
@@ -72,6 +72,10 @@ public abstract class ShaderProgramBuilder extends Builder {
 
         // Parse source for includes and add the include nodes as inputs/dependancies to the shader
         String source = new String(input.getContent(), StandardCharsets.UTF_8);
+
+        // SPIR-v tools cannot handle carriage return
+        source = source.replace("\r", "");
+
         shaderPreprocessor = new ShaderPreprocessor(this.project, input.getPath(), source);
         String[] includes = shaderPreprocessor.getIncludes();
 
@@ -326,7 +330,11 @@ public abstract class ShaderProgramBuilder extends Builder {
             byte[] inBytes = new byte[is.available()];
             is.read(inBytes);
 
-            String source                         = new String(inBytes, StandardCharsets.UTF_8);
+            String source = new String(inBytes, StandardCharsets.UTF_8);
+
+            // SPIR-v tools cannot handle carriage return
+            source = source.replace("\r", "");
+
             ShaderPreprocessor shaderPreprocessor = new ShaderPreprocessor(this.project, args[0], source);
             String finalShaderSource              = shaderPreprocessor.getCompiledSource();
 


### PR DESCRIPTION
Carriage return line endings are now stripped from shader code.

Fixes #9681 