### PR TITLE
Fix pivot point related issues

### DIFF
--- a/editor/src/clj/editor/sprite.clj
+++ b/editor/src/clj/editor/sprite.clj
@@ -592,13 +592,24 @@
 
   (input copied-nodes g/Any :array :cascade-delete)
 
-  (output aabb AABB (g/fnk [size]
+  (output aabb AABB (g/fnk [size ^:try scene-infos]
                       (let [[^double width ^double height ^double depth] size
+                            first-animation (when-not (g/error-value? scene-infos)
+                                              (:animation (first scene-infos)))
+                            anim-pivot (when first-animation
+                                         (get-in first-animation [:frames 0 :pivot]))
+                            [pivot-x pivot-y] (if anim-pivot
+                                                anim-pivot
+                                                [0.0 0.0])
                             half-width (* 0.5 width)
                             half-height (* 0.5 height)
-                            half-depth (* 0.5 depth)]
-                        (geom/make-aabb (Point3d. (- half-width) (- half-height) (- half-depth))
-                                        (Point3d. half-width half-height half-depth)))))
+                            half-depth (* 0.5 depth)
+
+                            ; Adjusted calculations for min-x and min-y
+                            min-x (- (* (- width) pivot-x) half-width)
+                            min-y (- (* (- height) pivot-y) half-height)]
+                        (geom/make-aabb (Point3d. min-x min-y (- half-depth))
+                                        (Point3d. (+ min-x width) (+ min-y height) half-depth)))))
   (output save-value g/Any produce-save-value)
   (output scene g/Any :cached produce-scene)
   (output build-targets g/Any :cached produce-build-targets)

--- a/editor/src/clj/editor/texture_set.clj
+++ b/editor/src/clj/editor/texture_set.clj
@@ -250,12 +250,15 @@
 
         ; Pivot point comes from the SpriteGeometry, where (0,0) is center of the image and +Y is up.
         [^double image-pivot-x ^double image-pivot-y] (or (:pivot animation-frame) [0.0 0.0])
-        image-pivot-x (* (or (:width animation-frame) 0.0) image-pivot-x)
-        image-pivot-y (* (or (:height animation-frame) 0.0) image-pivot-y)
+        [width height] (if (and (= :size-mode-manual size-mode)) size [(:width animation-frame) (:height animation-frame)])
+        image-pivot-x (* width image-pivot-x)
+        image-pivot-y (* height image-pivot-y)
 
         position-data (:position-data out)
-        offset-positions (offset-vertices image-pivot-x image-pivot-y position-data)]
-    (assoc out :position-data offset-positions)))
+        line-data (:line-data out)
+        offset-positions (offset-vertices image-pivot-x image-pivot-y position-data)
+        offset-lines (offset-vertices image-pivot-x image-pivot-y line-data)]
+    (assoc out :position-data offset-positions :line-data offset-lines)))
 
 
 ;; animation

--- a/editor/src/clj/editor/texture_set.clj
+++ b/editor/src/clj/editor/texture_set.clj
@@ -250,7 +250,7 @@
 
         ; Pivot point comes from the SpriteGeometry, where (0,0) is center of the image and +Y is up.
         [^double image-pivot-x ^double image-pivot-y] (or (:pivot animation-frame) [0.0 0.0])
-        [width height] (if (and (= :size-mode-manual size-mode)) size [(:width animation-frame) (:height animation-frame)])
+        [width height] (if (or (and (= :size-mode-manual size-mode)) (nil? animation-frame)) size [(:width animation-frame) (:height animation-frame)])
         image-pivot-x (* width image-pivot-x)
         image-pivot-y (* height image-pivot-y)
 


### PR DESCRIPTION
Fixed issues related to pivot points:
	•	AABB for sprites with non-default pivots.
	•	Sprite position in the editor when using manual size and a custom pivot point.
	•	Fixed bounding boxes for sprites with custom pivot points.

Fix https://github.com/defold/defold/issues/9699

## PR checklist

* [x] Code
	* [ ] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
