### PR TITLE
Ship off batches of particles to minimize RAM overhead

### DIFF
--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -1096,7 +1096,8 @@ namespace dmEngine
         engine->m_ParticleFXContext.m_RenderContext = engine->m_RenderContext;
         engine->m_ParticleFXContext.m_MaxParticleFXCount = dmConfigFile::GetInt(engine->m_Config, dmParticle::MAX_INSTANCE_COUNT_KEY, 64);
         engine->m_ParticleFXContext.m_MaxEmitterCount = dmConfigFile::GetInt(engine->m_Config, dmParticle::MAX_EMITTER_COUNT_KEY, 64);
-        engine->m_ParticleFXContext.m_MaxParticleCount = dmConfigFile::GetInt(engine->m_Config, dmParticle::MAX_PARTICLE_COUNT_KEY, 1024);
+        engine->m_ParticleFXContext.m_MaxParticleCount = dmConfigFile::GetInt(engine->m_Config, dmParticle::MAX_PARTICLE_GPU_COUNT_KEY, 1024);
+        engine->m_ParticleFXContext.m_MaxParticleBufferCount = dmConfigFile::GetInt(engine->m_Config, dmParticle::MAX_PARTICLE_CPU_COUNT_KEY, 1024);
         engine->m_ParticleFXContext.m_Debug = false;
 
         dmInput::NewContextParams input_params;

--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -124,6 +124,7 @@ namespace dmGameSystem
         uint32_t                    m_MaxGuiComponents;
         uint32_t                    m_MaxParticleFXCount;
         uint32_t                    m_MaxParticleCount;
+        uint32_t                    m_MaxParticleBufferCount;
         uint32_t                    m_MaxAnimationCount;
     };
 
@@ -378,6 +379,7 @@ namespace dmGameSystem
 
         gui_world->m_MaxParticleFXCount = gui_context->m_MaxParticleFXCount;
         gui_world->m_MaxParticleCount = gui_context->m_MaxParticleCount;
+        gui_world->m_MaxParticleBufferCount = gui_context->m_MaxParticleBufferCount;
         gui_world->m_ParticleContext = dmParticle::CreateContext(gui_world->m_MaxParticleFXCount, gui_world->m_MaxParticleCount);
         gui_world->m_MaxAnimationCount = gui_context->m_MaxAnimationCount;
 
@@ -3095,6 +3097,7 @@ namespace dmGameSystem
         gui_context->m_MaxParticleFXCount = dmConfigFile::GetInt(ctx->m_Config, "gui.max_particlefx_count", 64);
         gui_context->m_MaxParticleCount = dmConfigFile::GetInt(ctx->m_Config, "gui.max_particle_count", 1024);
         gui_context->m_MaxAnimationCount = dmConfigFile::GetInt(ctx->m_Config, "gui.max_animation_count", 1024);
+        gui_context->m_MaxParticleBufferCount = dmConfigFile::GetInt(ctx->m_Config, "gui.max_particle_buffer_count", 1024);
 
         int32_t max_gui_count = dmConfigFile::GetInt(ctx->m_Config, "gui.max_instance_count", 128);
         gui_context->m_Worlds.SetCapacity(max_gui_count);

--- a/engine/gamesys/src/gamesys/components/comp_gui_private.h
+++ b/engine/gamesys/src/gamesys/components/comp_gui_private.h
@@ -144,6 +144,7 @@ namespace dmGameSystem
         dmGraphics::VertexAttributeInfos         m_ParticleAttributeInfos;
         uint32_t                                 m_MaxParticleFXCount;
         uint32_t                                 m_MaxParticleCount;
+        uint32_t                                 m_MaxParticleBufferCount;
         uint32_t                                 m_RenderedParticlesSize;
         uint32_t                                 m_MaxAnimationCount;
         float                                    m_DT;

--- a/engine/gamesys/src/gamesys/gamesys.h
+++ b/engine/gamesys/src/gamesys/gamesys.h
@@ -100,6 +100,7 @@ namespace dmGameSystem
         dmResource::HFactory m_Factory;
         dmRender::HRenderContext m_RenderContext;
         uint32_t m_MaxParticleFXCount;
+        uint32_t m_MaxParticleBufferCount;
         uint32_t m_MaxParticleCount;
         uint32_t m_MaxEmitterCount;
         bool m_Debug;

--- a/engine/particle/src/particle.h
+++ b/engine/particle/src/particle.h
@@ -62,8 +62,10 @@ namespace dmParticle
     extern const char* MAX_INSTANCE_COUNT_KEY;
     /// Config key to use for tweaking maximum number of emitters in a context.
     extern const char* MAX_EMITTER_COUNT_KEY;
-    /// Config key to use for tweaking the total maximum number of particles in a context.
-    extern const char* MAX_PARTICLE_COUNT_KEY;
+    /// Config key to use for tweaking the total maximum number of particles in a context in GPU buffer.
+    extern const char* MAX_PARTICLE_GPU_COUNT_KEY;
+    /// Config key to use for tweaking the total maximum number of particles in a context in CPU buffer.
+    extern const char* MAX_PARTICLE_CPU_COUNT_KEY;
 
     /**
      * Render constants supplied to the render callback.

--- a/engine/particle/src/particle_private.h
+++ b/engine/particle/src/particle_private.h
@@ -120,6 +120,8 @@ namespace dmParticle
         dmVMath::Point3         m_LastPosition;
         dmhash_t                m_Id;
         EmitterRenderData       m_RenderData;
+        /// Number of particles that have been consumed by the renderer
+        uint32_t                m_ParticlesConsumed;
         /// Vertex index of the render data for the particles spawned by this emitter.
         uint32_t                m_VertexIndex;
         /// Number of vertices of the render data for the particles spawned by this emitter.
@@ -139,8 +141,6 @@ namespace dmParticle
         float                   m_StartDelay;
         /// Particle spawn rate spread, randomized on emitter creation and used for the duration of the emitter.
         float                   m_SpawnRateSpread;
-        /// If the user has been warned that all particles cannot be rendered.
-        uint16_t                m_RenderWarning : 1;
         /// If the user has been warned that the emitters animation could not be fetched
         uint16_t                m_FetchAnimWarning : 1;
         uint16_t                m_LastPositionSet : 1;

--- a/engine/render/src/render/buffer.cpp
+++ b/engine/render/src/render/buffer.cpp
@@ -113,6 +113,24 @@ namespace dmRender
         }
     }
 
+    void SetBufferSubData(HRenderContext render_context, HBufferedRenderBuffer buffer, uint32_t offset, uint32_t size, void* data)
+    {
+        switch(buffer->m_Type)
+        {
+        case RENDER_BUFFER_TYPE_VERTEX_BUFFER:
+        {
+            dmGraphics::HVertexBuffer vbuf = (dmGraphics::HVertexBuffer) buffer->m_Buffers[buffer->m_BufferIndex];
+            dmGraphics::SetVertexBufferSubData(vbuf, offset, size, data);
+        } break;
+        case RENDER_BUFFER_TYPE_INDEX_BUFFER:
+        {
+            dmGraphics::HIndexBuffer ibuf = (dmGraphics::HIndexBuffer) buffer->m_Buffers[buffer->m_BufferIndex];
+            dmGraphics::SetIndexBufferSubData(ibuf, offset, size, data);
+        } break;
+        default:break;
+        }
+    }
+
     void TrimBuffer(HRenderContext render_context, HBufferedRenderBuffer buffer)
     {
         if (!buffer)

--- a/engine/render/src/render/render.h
+++ b/engine/render/src/render/render.h
@@ -356,6 +356,7 @@ namespace dmRender
     HRenderBuffer                   GetBuffer(HRenderContext render_context, HBufferedRenderBuffer buffer);
     int32_t                         GetBufferIndex(HRenderContext render_context, HBufferedRenderBuffer buffer);
     void                            SetBufferData(HRenderContext render_context, HBufferedRenderBuffer buffer, uint32_t size, void* data, dmGraphics::BufferUsage buffer_usage);
+    void                            SetBufferSubData(HRenderContext render_context, HBufferedRenderBuffer buffer, uint32_t offset, uint32_t size, void* data);
     void                            TrimBuffer(HRenderContext render_context, HBufferedRenderBuffer buffer);
     void                            RewindBuffer(HRenderContext render_context, HBufferedRenderBuffer buffer);
 


### PR DESCRIPTION
Introduced a CPU limit and upload in batches to the GPU up to the limit. I think we could create the buffer as it grows up to the max rather than reallocating, but at least with this a smaller number can be chosen than enough for worst case.