### PR TITLE
Implement prefs in editor scripts

### DIFF
--- a/editor/resources/templates/template.editor_script
+++ b/editor/resources/templates/template.editor_script
@@ -1,10 +1,23 @@
 local M = {}
 
 function M.get_language_servers()
+    -- Define new language servers here
+    -- Learn more: https://defold.com/manuals/editor-scripts/#language-servers
+    -- Remove this function if not needed
     return {}
 end
 
 function M.get_commands()
+    -- Add editor commands
+    -- Learn more: https://defold.com/manuals/editor-scripts/#commands
+    -- Remove this function if not needed
+    return {}
+end
+
+function M.get_prefs_schema()
+    -- Define preferences that may be used by the editor script
+    -- Learn more: https://defold.com/manuals/editor-scripts/#prefs
+    -- Remove this function if not needed
     return {}
 end
 

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -2663,6 +2663,7 @@ If you do not specifically require different script states, consider changing th
 (defn reload-extensions! [app-view project kind workspace changes-view build-errors-view prefs]
   (extensions/reload!
     project kind
+    :prefs prefs
     :reload-resources! (fn reload-resources! []
                          (let [f (future/make)]
                            (disk/async-reload! (make-render-task-progress :resource-sync)

--- a/editor/src/clj/editor/bundle_dialog.clj
+++ b/editor/src/clj/editor/bundle_dialog.clj
@@ -183,7 +183,7 @@
 
 (defn- set-string-pref!
   [prefs key ^String string]
-  (prefs/set! prefs key (not-empty string)))
+  (prefs/set! prefs key string))
 
 (defn- get-file-pref
   ^File [prefs key]
@@ -191,7 +191,7 @@
 
 (defn- set-file-pref!
   [prefs key ^File file]
-  (set-string-pref! prefs key (when file (.getPath file))))
+  (set-string-pref! prefs key (if file (.getPath file) "")))
 
 ;; -----------------------------------------------------------------------------
 ;; Generic

--- a/editor/src/clj/editor/bundle_dialog.clj
+++ b/editor/src/clj/editor/bundle_dialog.clj
@@ -183,7 +183,7 @@
 
 (defn- set-string-pref!
   [prefs key ^String string]
-  (prefs/set! prefs key string))
+  (prefs/set! prefs key (not-empty string)))
 
 (defn- get-file-pref
   ^File [prefs key]
@@ -191,7 +191,7 @@
 
 (defn- set-file-pref!
   [prefs key ^File file]
-  (set-string-pref! prefs key (if file (.getPath file) "")))
+  (set-string-pref! prefs key (when file (.getPath file))))
 
 ;; -----------------------------------------------------------------------------
 ;; Generic

--- a/editor/src/clj/editor/debug_view.clj
+++ b/editor/src/clj/editor/debug_view.clj
@@ -642,7 +642,7 @@
   (enabled? [prefs] (prefs/get prefs [:run :simulated-resolution]))
   (run [project prefs]
        (prefs/set! prefs [:run :simulated-resolution] nil)
-       (prefs/set! prefs [:run :simulate-rotated-device] nil)
+       (prefs/set! prefs [:run :simulate-rotated-device] false)
        (let [project-settings-data (project-settings-screen-data project)]
          (change-resolution! prefs (:width project-settings-data) (:height project-settings-data)))))
 

--- a/editor/src/clj/editor/editor_extensions.clj
+++ b/editor/src/clj/editor/editor_extensions.clj
@@ -27,6 +27,7 @@
             [editor.editor-extensions.commands :as commands]
             [editor.editor-extensions.error-handling :as error-handling]
             [editor.editor-extensions.graph :as graph]
+            [editor.editor-extensions.prefs-functions :as prefs-functions]
             [editor.editor-extensions.runtime :as rt]
             [editor.editor-extensions.ui-components :as ui-components]
             [editor.fs :as fs]
@@ -36,10 +37,12 @@
             [editor.lsp :as lsp]
             [editor.lsp.async :as lsp.async]
             [editor.os :as os]
+            [editor.prefs :as prefs]
             [editor.process :as process]
             [editor.resource :as resource]
             [editor.system :as system]
-            [editor.workspace :as workspace])
+            [editor.workspace :as workspace]
+            [util.eduction :as e])
   (:import [com.dynamo.bob Platform]
            [java.nio.file FileAlreadyExistsException Files NotDirectoryException Path]
            [org.luaj.vm2 LuaError Prototype]))
@@ -434,6 +437,36 @@
                     (rt/->clj rt commands-coercer lua-ret)))))
             (execute-all-top-level-functions state :get_commands {} evaluation-context)))))
 
+(defn- reload-prefs! [project-path state evaluation-context]
+  (let [{:keys [display-output! rt]} state
+        report-omitted-schema! (fn report-omitted-schema! [path reason]
+                                 (display-output! :err (str "Omitting prefs schema definition for path '" (string/join "." (map name path)) "': " reason)))
+        omit-on-conflict (fn omit-on-conflict [a b path]
+                           (if (= a b)
+                             a
+                             (do (report-omitted-schema! path "conflicts with another editor script schema")
+                                 nil)))
+        schema (->> (execute-all-top-level-functions state :get_prefs_schema nil evaluation-context)
+                    (e/keep
+                      (fn [[proj-path lua-ret]]
+                        (error-handling/try-with-extension-exceptions
+                          :display-output! display-output!
+                          :label (str "Reloading prefs schema in " proj-path)
+                          :catch nil
+                          (prefs/difference-schemas
+                            (fn [_ _ path]
+                              (report-omitted-schema! path (str "'" proj-path "' defines a schema that conflicts with the editor schema")))
+                            (prefs-functions/lua-schema-definition->schema rt lua-ret)
+                            prefs/default-schema))))
+                    (reduce
+                      (fn [a b]
+                        (if a
+                          (prefs/merge-schemas omit-on-conflict a b)
+                          b))
+                      nil))]
+    (when schema
+      (prefs/register-project-schema! project-path schema))))
+
 (defn- add-all-entry [m path module]
   (reduce-kv
     (fn [acc k v]
@@ -446,6 +479,7 @@
 (def module-coercer
   (coerce/hash-map :opt {:get_commands coerce/function
                          :get_language_servers coerce/function
+                         :get_prefs_schema coerce/function
                          :on_build_started coerce/function
                          :on_build_finished coerce/function
                          :on_bundle_started coerce/function
@@ -516,6 +550,7 @@
     kind       which scripts to reload, either :all, :library or :project
 
   Required kv-args:
+    :prefs                editor prefs
     :reload-resources!    0-arg function that asynchronously reloads the editor
                           resources, returns a CompletableFuture (that might
                           complete exceptionally if reload fails)
@@ -541,8 +576,8 @@
                                                   strings
                             evaluation-context    evaluation context of the
                                                   invocation"
-  [project kind & {:keys [reload-resources! display-output! save! open-resource! invoke-bob!] :as opts}]
-  {:pre [reload-resources! display-output! save! open-resource! invoke-bob!]}
+  [project kind & {:keys [prefs reload-resources! display-output! save! open-resource! invoke-bob!] :as opts}]
+  {:pre [prefs reload-resources! display-output! save! open-resource! invoke-bob!]}
   (g/with-auto-evaluation-context evaluation-context
     (let [extensions (g/node-value project :editor-extensions evaluation-context)
           old-state (ext-state project evaluation-context)
@@ -565,6 +600,7 @@
                                "execute" (make-ext-execute-fn project-path display-output! reload-resources!)
                                "bob" (make-ext-bob-fn invoke-bob!)
                                "platform" (.getPair (Platform/getHostPlatform))
+                               "prefs" (prefs-functions/env prefs)
                                "save" (make-ext-save-fn save!)
                                "transact" ext-transact
                                "tx" {"set" (make-ext-tx-set-fn project)}
@@ -593,6 +629,7 @@
                                               (:project-prototypes old-state [])))
                       evaluation-context)]
       (g/user-data-swap! extensions :state (constantly new-state))
+      (reload-prefs! project-path new-state evaluation-context)
       (reload-language-servers! project new-state evaluation-context)
       (reload-commands! project new-state evaluation-context)
       nil)))

--- a/editor/src/clj/editor/editor_extensions.clj
+++ b/editor/src/clj/editor/editor_extensions.clj
@@ -453,7 +453,7 @@
                           :display-output! display-output!
                           :label (str "Reloading prefs schema in " proj-path)
                           :catch nil
-                          (prefs/difference-schemas
+                          (prefs/subtract-schemas
                             (fn [_ _ path]
                               (report-omitted-schema! path (str "'" proj-path "' defines a schema that conflicts with the editor schema")))
                             (prefs-functions/lua-schema-definition->schema rt lua-ret)

--- a/editor/src/clj/editor/editor_extensions/coerce.clj
+++ b/editor/src/clj/editor/editor_extensions/coerce.clj
@@ -19,6 +19,7 @@
             [editor.editor-extensions.vm :as vm]
             [editor.util :as util]
             [util.coll :as coll]
+            [util.eduction :as e]
             [util.fn :as fn])
   (:import [org.luaj.vm2 LuaDouble LuaError LuaInteger LuaString LuaValue Varargs]))
 
@@ -99,6 +100,16 @@
                                          (mapv #(vm/lua-value->string vm %))
                                          (util/join-words ", " " or "))))
           v)))))
+
+(defn const
+  "Coercer that deserializes a LuaValue into a predefined expected constant"
+  [value]
+  (let [expected-lua-value (enum-lua-value-cache value)]
+    ^{:schema {:type :enum :values [value]}}
+    (fn coerce-const [vm ^LuaValue x]
+      (if (vm/with-lock vm (.eq_b x expected-lua-value))
+        value
+        (failure x (str "is not " (vm/lua-value->string vm expected-lua-value)))))))
 
 (def string
   "Coercer that deserializes a Lua string into a string"
@@ -270,45 +281,38 @@
   "Coerces Lua table to a Clojure map with required and optional keys
 
   Optional kv-args:
-    :req    a map from required key to a coercer for a value at that key
-    :opt    a map from optional key to a coercer for a value at that key"
-  [& {:keys [req opt]}]
-  (let [reqs (mapv (fn [[k v]]
-                     [(vm/->lua k) k v])
-                   req)
-        opts (mapv (fn [[k v]]
-                     [(vm/->lua k) k v])
-                   opt)]
+    :req           a map from required key to a coercer for a value at that key
+    :opt           a map from optional key to a coercer for a value at that key
+    :extra-keys    boolean, whether to allow unspecified keys (default true)"
+  [& {:keys [req opt extra-keys]
+      :or {extra-keys true}}]
+  (let [required-keys (mapv key req)
+        lua-key->clj-key+coerce-val (coll/pair-map-by (comp enum-lua-value-cache key) (e/concat req opt))]
     ^{:schema {:type :table}}
     (fn coerce-hash-map [vm ^LuaValue x]
       (if (.istable x)
-        (let [acc (transient {})
-              acc (vm/with-lock vm
-                    (reduce
-                      (fn acc-req [acc [^LuaValue lua-key clj-key coerce-val]]
-                        (let [lua-val (.rawget x lua-key)]
-                          (if (.isnil lua-val)
-                            (reduced (failure x (str "needs " (vm/lua-value->string vm lua-key) " key")))
-                            (let [coerced-val (coerce-val vm lua-val)]
-                              (if (failure? coerced-val)
-                                (reduced coerced-val)
-                                (assoc! acc clj-key coerced-val))))))
-                      acc
-                      reqs))]
+        (let [acc (reduce
+                    (fn [acc ^Varargs varargs]
+                      (let [lua-key (.arg1 varargs)]
+                        (if-let [[clj-key coerce-val] (lua-key->clj-key+coerce-val lua-key)]
+                          (let [coerced-val (coerce-val vm (.arg varargs 2))]
+                            (if (failure? coerced-val)
+                              (reduced coerced-val)
+                              (assoc! acc clj-key coerced-val)))
+                          (if extra-keys
+                            acc
+                            (reduced (failure x (str "cannot have the " (vm/lua-value->string vm lua-key) " key")))))))
+                    (transient {})
+                    (vm/lua-table-reducer vm x))]
           (if (failure? acc)
             acc
-            (let [acc (vm/with-lock vm
-                        (reduce
-                          (fn acc-opt [acc [^LuaValue lua-key clj-key coerce-val]]
-                            (let [lua-val (.rawget x lua-key)]
-                              (if (.isnil lua-val)
-                                acc
-                                (let [coerced-val (coerce-val vm lua-val)]
-                                  (if (failure? coerced-val)
-                                    (reduced coerced-val)
-                                    (assoc! acc clj-key coerced-val))))))
-                          acc
-                          opts))]
+            (let [acc (reduce
+                        (fn [acc k]
+                          (if (contains? acc k)
+                            acc
+                            (reduced (failure x (str "must have the " (vm/lua-value->string vm (enum-lua-value-cache k)) " key")))))
+                        acc
+                        required-keys)]
               (if (failure? acc)
                 acc
                 (persistent! acc)))))

--- a/editor/src/clj/editor/editor_extensions/docs.clj
+++ b/editor/src/clj/editor/editor_extensions/docs.clj
@@ -16,10 +16,11 @@
   (:require [clojure.string :as string]
             [editor.editor-extensions.prefs-docs :as prefs-docs]
             [editor.editor-extensions.ui-docs :as ui-docs]
-            [editor.lua-completion :as lua-completion]))
+            [editor.lua-completion :as lua-completion]
+            [util.eduction :as e]))
 
 (defn editor-script-docs
-  "Returns reducible with script doc maps covering the editor API"
+  "Returns a vector with script doc maps covering the editor API"
   []
   (let [node-param {:name "node"
                     :types ["string" "userdata"]
@@ -27,74 +28,74 @@
         property-param {:name "property"
                         :types ["string"]
                         :doc "Either <code>\"path\"</code>, <code>\"text\"</code>, or a property from the Outline view (hover the label to see its editor script name)"}]
-    (eduction
-      cat
-      [[{:name "editor"
-         :type :module
-         :description "The editor module, only available when the Lua code is run as [editor script](https://defold.com/manuals/editor-scripts/)."}
-        {:name "editor.get"
-         :type :function
-         :parameters [node-param property-param]
-         :returnvalues [{:name "value"
-                         :types ["any"]
-                         :doc "property value"}]
-         :description "Get a value of a node property inside the editor.\n\nSome properties might be read-only, and some might be unavailable in different contexts, so you should use `editor.can_get()` before reading them and `editor.can_set()` before making the editor set them."}
-        {:name "editor.can_get"
-         :type :function
-         :parameters [node-param property-param]
-         :returnvalues [{:name "value"
-                         :types ["boolean"]
-                         :doc ""}]
-         :description "Check if you can get this property so `editor.get()` won't throw an error"}
-        {:name "editor.can_set"
-         :type :function
-         :parameters [node-param property-param]
-         :returnvalues [{:name "value"
-                         :types ["boolean"]
-                         :doc ""}]
-         :description "Check if `\"set\"` action with this property won't throw an error"}
-        {:name "editor.resource_attributes"
-         :type :function
-         :description "Query information about a project resource"
-         :parameters [{:name "resource_path"
-                       :types ["string"]
-                       :doc "Resource path (starting with <code>/</code>) of a resource to look up"}]
-         :returnvalues [{:name "value"
-                         :types ["table"]
-                         :doc (str "A table with the following keys:"
-                                   (lua-completion/args-doc-html
-                                     [{:name "exists"
-                                       :types ["boolean"]
-                                       :doc "whether a resource identified by the path exists in the project"}
-                                      {:name "is_file"
-                                       :types ["boolean"]
-                                       :doc "whether the resource represents a file with some content"}
-                                      {:name "is_directory"
-                                       :types ["boolean"]
-                                       :doc "whether the resource represents a directory"}]))}]}
-        {:name "editor.create_directory"
-         :type :function
-         :parameters [{:name "resource_path"
-                       :types ["string"]
-                       :doc "Resource path (starting with <code>/</code>) of a directory to create"}]
-         :description "Create a directory if it does not exist, and all non-existent parent directories.\n\nThrows an error if the directory can't be created."
-         :examples "```\neditor.create_directory(\"/assets/gen\")\n```"}
-        {:name "editor.delete_directory"
-         :type :function
-         :parameters [{:name "resource_path"
-                       :types ["string"]
-                       :doc "Resource path (starting with <code>/</code>) of a directory to delete"}]
-         :description "Delete a directory if it exists, and all existent child directories and files.\n\nThrows an error if the directory can't be deleted."
-         :examples "```\neditor.delete_directory(\"/assets/gen\")\n```"}
-        {:name "editor.external_file_attributes"
-         :type :function
-         :description "Query information about file system path"
-         :parameters [{:name "path"
-                       :types ["string"]
-                       :doc "External file path, resolved against project root if relative"}]
-         :returnvalues [{:name "attributes"
-                         :types ["table"]
-                         :doc "A table with the following keys:<dl>
+    (vec
+      (e/concat
+        [{:name "editor"
+          :type :module
+          :description "The editor module, only available when the Lua code is run as [editor script](https://defold.com/manuals/editor-scripts/)."}
+         {:name "editor.get"
+          :type :function
+          :parameters [node-param property-param]
+          :returnvalues [{:name "value"
+                          :types ["any"]
+                          :doc "property value"}]
+          :description "Get a value of a node property inside the editor.\n\nSome properties might be read-only, and some might be unavailable in different contexts, so you should use `editor.can_get()` before reading them and `editor.can_set()` before making the editor set them."}
+         {:name "editor.can_get"
+          :type :function
+          :parameters [node-param property-param]
+          :returnvalues [{:name "value"
+                          :types ["boolean"]
+                          :doc ""}]
+          :description "Check if you can get this property so `editor.get()` won't throw an error"}
+         {:name "editor.can_set"
+          :type :function
+          :parameters [node-param property-param]
+          :returnvalues [{:name "value"
+                          :types ["boolean"]
+                          :doc ""}]
+          :description "Check if `\"set\"` action with this property won't throw an error"}
+         {:name "editor.resource_attributes"
+          :type :function
+          :description "Query information about a project resource"
+          :parameters [{:name "resource_path"
+                        :types ["string"]
+                        :doc "Resource path (starting with <code>/</code>) of a resource to look up"}]
+          :returnvalues [{:name "value"
+                          :types ["table"]
+                          :doc (str "A table with the following keys:"
+                                    (lua-completion/args-doc-html
+                                      [{:name "exists"
+                                        :types ["boolean"]
+                                        :doc "whether a resource identified by the path exists in the project"}
+                                       {:name "is_file"
+                                        :types ["boolean"]
+                                        :doc "whether the resource represents a file with some content"}
+                                       {:name "is_directory"
+                                        :types ["boolean"]
+                                        :doc "whether the resource represents a directory"}]))}]}
+         {:name "editor.create_directory"
+          :type :function
+          :parameters [{:name "resource_path"
+                        :types ["string"]
+                        :doc "Resource path (starting with <code>/</code>) of a directory to create"}]
+          :description "Create a directory if it does not exist, and all non-existent parent directories.\n\nThrows an error if the directory can't be created."
+          :examples "```\neditor.create_directory(\"/assets/gen\")\n```"}
+         {:name "editor.delete_directory"
+          :type :function
+          :parameters [{:name "resource_path"
+                        :types ["string"]
+                        :doc "Resource path (starting with <code>/</code>) of a directory to delete"}]
+          :description "Delete a directory if it exists, and all existent child directories and files.\n\nThrows an error if the directory can't be deleted."
+          :examples "```\neditor.delete_directory(\"/assets/gen\")\n```"}
+         {:name "editor.external_file_attributes"
+          :type :function
+          :description "Query information about file system path"
+          :parameters [{:name "path"
+                        :types ["string"]
+                        :doc "External file path, resolved against project root if relative"}]
+          :returnvalues [{:name "attributes"
+                          :types ["table"]
+                          :doc "A table with the following keys:<dl>
                                                  <dt><code>path <small>string</small></code></dt>
                                                  <dd>resolved file path</dd>
                                                  <dt><code>exists <small>boolean</small></code></dt>
@@ -104,17 +105,17 @@
                                                  <dt><code>is_directory <small>boolean</small></code></dt>
                                                  <dd>whether the path corresponds to a directory</dd>
                                                </dl>"}]}
-        {:name "editor.execute"
-         :type :function
-         :parameters [{:name "command"
-                       :types ["string"]
-                       :doc "Shell command name to execute"}
-                      {:name "[...]"
-                       :types ["string"]
-                       :doc "Optional shell command arguments"}
-                      {:name "[options]"
-                       :types ["table"]
-                       :doc "Optional options table. Supported entries:
+         {:name "editor.execute"
+          :type :function
+          :parameters [{:name "command"
+                        :types ["string"]
+                        :doc "Shell command name to execute"}
+                       {:name "[...]"
+                        :types ["string"]
+                        :doc "Optional shell command arguments"}
+                       {:name "[options]"
+                        :types ["table"]
+                        :doc "Optional options table. Supported entries:
                                            <ul>
                                              <li>
                                                <span class=\"type\">boolean</span> <code>reload_resources</code>: make the editor reload the resources from disk after the command is executed, default <code>true</code>
@@ -148,84 +149,83 @@
                                                </ul>
                                              </li>
                                            </ul>"}]
-         :returnvalues [{:name "result"
-                         :types ["nil" "string"]
-                         :doc "If <code>out</code> option is set to <code>\"capture\"</code>, returns the output as string with trimmed trailing newlines. Otherwise, returns <code>nil</code>."}]
-         :description "Execute a shell command.\n\nAny shell command arguments should be provided as separate argument strings to this function. If the exit code of the process is not zero, this function throws error. By default, the function returns `nil`, but it can be configured to capture the output of the shell command as string and return it — set `out` option to `\"capture\"` to do it.<br>By default, after this shell command is executed, the editor will reload resources from disk."
-         :examples "Make a directory with spaces in it:\n```\neditor.execute(\"mkdir\", \"new dir\")\n```\nRead the git status:\n```\nlocal status = editor.execute(\"git\", \"status\", \"--porcelain\", {\n  reload_resources = false,\n  out = \"capture\"\n})\n```"}
-        {:name "editor.bob"
-         :type :function
-         :parameters [{:name "[options]"
-                       :types ["table"]
-                       :doc "table of command line options for bob, without the leading dashes (<code>--</code>). You can use snake_case instead of kebab-case for option keys. Only long option names are supported (i.e. <code>output</code>, not <code>o</code>). Supported value types are strings, integers and booleans. If an option takes no arguments, use a boolean (i.e. <code>true</code>). If an option may be repeated, you can use an array of values."}
-                      {:name "[...commands]"
-                       :types ["string"]
-                       :doc "bob commands, e.g. <code>\"resolve\"</code> or <code>\"build\"</code>"}]
-         :returnvalues []
-         :description "Run bob the builder program\n\nFor the full documentation of the available commands and options, see [the bob manual](https://defold.com/manuals/bob/)."
-         :examples "Print help in the console:\n```\neditor.bob({help = true})\n```\n\nBundle the game for the host platform:\n```\nlocal opts = {\n    archive = true,\n    platform = editor.platform\n}\neditor.bob(opts, \"distclean\", \"resolve\", \"build\", \"bundle\")\n```\nUsing snake_cased and repeated options:\n```\nlocal opts = {\n    archive = true,\n    platform = editor.platform,\n    build_server = \"https://build.my-company.com\",\n    settings = {\"test.ini\", \"headless.ini\"}\n}\neditor.bob(opts, \"distclean\", \"resolve\", \"build\")\n```\n"}
-        {:name "editor.platform"
-         :type :variable
-         :description "Editor platform id.\n\nA `string`, either:\n- `\"x86_64-win32\"`\n- `\"x86_64-macos\"`\n- `\"arm64-macos\"`\n- `\"x86_64-linux\"`"}
-        {:name "editor.save"
-         :type :function
-         :parameters []
-         :description "Persist any unsaved changes to disk"}
-        {:name "editor.transact"
-         :type :function
-         :parameters [{:name "txs"
-                       :types ["transaction_step[]"]
-                       :doc "An array of transaction steps created using <code>editor.tx.*</code> functions"}]
-         :description "Change the editor state in a single, undoable transaction"}
-        {:name "editor.tx"
-         :type :module
-         :description "The editor module that defines function for creating transaction steps for `editor.transact()` function."}
-        {:name "editor.tx.set"
-         :type :function
-         :parameters [node-param
-                      property-param
-                      {:name "value"
-                       :types ["any"]
-                       :doc "A new value for the property"}]
-         :returnvalues [{:name "result"
-                         :types ["transaction_step"]
-                         :doc "A transaction step"}]
-         :description "Create a set transaction step.\n\nWhen the step is transacted using `editor.transact()`, it will set the node's property to a supplied value"}
-        {:name "editor.version"
-         :type :variable
-         :description "A string, version name of Defold"}
-        {:name "editor.engine_sha1"
-         :type :variable
-         :description "A string, SHA1 of Defold engine"}
-        {:name "editor.editor_sha1"
-         :type :variable
-         :description "A string, SHA1 of Defold editor"}
-        {:name "editor.ui"
-         :type :module
-         :description "Module with functions for creating UI elements in the editor"}
-        {:name "editor.ui.open_resource"
-         :type :function
-         :description "Open a resource, either in the editor or in a third-party app"
-         :parameters [{:name "resource_path"
-                       :types ["string"]
-                       :doc "Resource path (starting with <code>/</code>) of a resource to open"}]}]
-       (eduction
-         (mapcat
-           (fn [[enum-id enum-values]]
-             (let [id (ui-docs/->screaming-snake-case enum-id)]
-               (eduction
-                 cat
-                 [[{:name (str "editor.ui." id)
-                    :type :module
-                    :description (str "Constants for "
-                                      (string/replace (name enum-id) \- \space)
-                                      " enums")}]
-                  (eduction
-                    (map (fn [enum-value]
-                           {:name (str "editor.ui." id "." (ui-docs/->screaming-snake-case enum-value))
-                            :type :constant
-                            :description (format "`\"%s\"`" (name enum-value))}))
-                    enum-values)]))))
-         ui-docs/enums)
-       (ui-docs/script-docs)
-       (prefs-docs/script-docs)])))
+          :returnvalues [{:name "result"
+                          :types ["nil" "string"]
+                          :doc "If <code>out</code> option is set to <code>\"capture\"</code>, returns the output as string with trimmed trailing newlines. Otherwise, returns <code>nil</code>."}]
+          :description "Execute a shell command.\n\nAny shell command arguments should be provided as separate argument strings to this function. If the exit code of the process is not zero, this function throws error. By default, the function returns `nil`, but it can be configured to capture the output of the shell command as string and return it — set `out` option to `\"capture\"` to do it.<br>By default, after this shell command is executed, the editor will reload resources from disk."
+          :examples "Make a directory with spaces in it:\n```\neditor.execute(\"mkdir\", \"new dir\")\n```\nRead the git status:\n```\nlocal status = editor.execute(\"git\", \"status\", \"--porcelain\", {\n  reload_resources = false,\n  out = \"capture\"\n})\n```"}
+         {:name "editor.bob"
+          :type :function
+          :parameters [{:name "[options]"
+                        :types ["table"]
+                        :doc "table of command line options for bob, without the leading dashes (<code>--</code>). You can use snake_case instead of kebab-case for option keys. Only long option names are supported (i.e. <code>output</code>, not <code>o</code>). Supported value types are strings, integers and booleans. If an option takes no arguments, use a boolean (i.e. <code>true</code>). If an option may be repeated, you can use an array of values."}
+                       {:name "[...commands]"
+                        :types ["string"]
+                        :doc "bob commands, e.g. <code>\"resolve\"</code> or <code>\"build\"</code>"}]
+          :returnvalues []
+          :description "Run bob the builder program\n\nFor the full documentation of the available commands and options, see [the bob manual](https://defold.com/manuals/bob/)."
+          :examples "Print help in the console:\n```\neditor.bob({help = true})\n```\n\nBundle the game for the host platform:\n```\nlocal opts = {\n    archive = true,\n    platform = editor.platform\n}\neditor.bob(opts, \"distclean\", \"resolve\", \"build\", \"bundle\")\n```\nUsing snake_cased and repeated options:\n```\nlocal opts = {\n    archive = true,\n    platform = editor.platform,\n    build_server = \"https://build.my-company.com\",\n    settings = {\"test.ini\", \"headless.ini\"}\n}\neditor.bob(opts, \"distclean\", \"resolve\", \"build\")\n```\n"}
+         {:name "editor.platform"
+          :type :variable
+          :description "Editor platform id.\n\nA `string`, either:\n- `\"x86_64-win32\"`\n- `\"x86_64-macos\"`\n- `\"arm64-macos\"`\n- `\"x86_64-linux\"`"}
+         {:name "editor.save"
+          :type :function
+          :parameters []
+          :description "Persist any unsaved changes to disk"}
+         {:name "editor.transact"
+          :type :function
+          :parameters [{:name "txs"
+                        :types ["transaction_step[]"]
+                        :doc "An array of transaction steps created using <code>editor.tx.*</code> functions"}]
+          :description "Change the editor state in a single, undoable transaction"}
+         {:name "editor.tx"
+          :type :module
+          :description "The editor module that defines function for creating transaction steps for `editor.transact()` function."}
+         {:name "editor.tx.set"
+          :type :function
+          :parameters [node-param
+                       property-param
+                       {:name "value"
+                        :types ["any"]
+                        :doc "A new value for the property"}]
+          :returnvalues [{:name "result"
+                          :types ["transaction_step"]
+                          :doc "A transaction step"}]
+          :description "Create a set transaction step.\n\nWhen the step is transacted using `editor.transact()`, it will set the node's property to a supplied value"}
+         {:name "editor.version"
+          :type :variable
+          :description "A string, version name of Defold"}
+         {:name "editor.engine_sha1"
+          :type :variable
+          :description "A string, SHA1 of Defold engine"}
+         {:name "editor.editor_sha1"
+          :type :variable
+          :description "A string, SHA1 of Defold editor"}
+         {:name "editor.ui"
+          :type :module
+          :description "Module with functions for creating UI elements in the editor"}
+         {:name "editor.ui.open_resource"
+          :type :function
+          :description "Open a resource, either in the editor or in a third-party app"
+          :parameters [{:name "resource_path"
+                        :types ["string"]
+                        :doc "Resource path (starting with <code>/</code>) of a resource to open"}]}]
+        (e/mapcat
+          (fn [[enum-id enum-values]]
+            (let [id (ui-docs/->screaming-snake-case enum-id)]
+              (eduction
+                cat
+                [[{:name (str "editor.ui." id)
+                   :type :module
+                   :description (str "Constants for "
+                                     (string/replace (name enum-id) \- \space)
+                                     " enums")}]
+                 (eduction
+                   (map (fn [enum-value]
+                          {:name (str "editor.ui." id "." (ui-docs/->screaming-snake-case enum-value))
+                           :type :constant
+                           :description (format "`\"%s\"`" (name enum-value))}))
+                   enum-values)])))
+          ui-docs/enums)
+        (ui-docs/script-docs)
+        (prefs-docs/script-docs)))))

--- a/editor/src/clj/editor/editor_extensions/docs.clj
+++ b/editor/src/clj/editor/editor_extensions/docs.clj
@@ -167,7 +167,6 @@
         {:name "editor.platform"
          :type :variable
          :description "Editor platform id.\n\nA `string`, either:\n- `\"x86_64-win32\"`\n- `\"x86_64-macos\"`\n- `\"arm64-macos\"`\n- `\"x86_64-linux\"`"}
-
         {:name "editor.save"
          :type :function
          :parameters []

--- a/editor/src/clj/editor/editor_extensions/docs.clj
+++ b/editor/src/clj/editor/editor_extensions/docs.clj
@@ -14,6 +14,7 @@
 
 (ns editor.editor-extensions.docs
   (:require [clojure.string :as string]
+            [editor.editor-extensions.prefs-docs :as prefs-docs]
             [editor.editor-extensions.ui-docs :as ui-docs]
             [editor.lua-completion :as lua-completion]))
 
@@ -166,6 +167,7 @@
         {:name "editor.platform"
          :type :variable
          :description "Editor platform id.\n\nA `string`, either:\n- `\"x86_64-win32\"`\n- `\"x86_64-macos\"`\n- `\"arm64-macos\"`\n- `\"x86_64-linux\"`"}
+
         {:name "editor.save"
          :type :function
          :parameters []
@@ -226,4 +228,5 @@
                             :description (format "`\"%s\"`" (name enum-value))}))
                     enum-values)]))))
          ui-docs/enums)
-       (ui-docs/script-docs)])))
+       (ui-docs/script-docs)
+       (prefs-docs/script-docs)])))

--- a/editor/src/clj/editor/editor_extensions/error_handling.clj
+++ b/editor/src/clj/editor/editor_extensions/error_handling.clj
@@ -30,7 +30,7 @@
   to the console
 
   Leading kv-args:
-    :display-output!    require, 2-arg fn to display error output
+    :display-output!    required, 2-arg fn to display error output
     :label              optional, string error prefix, defaults to \"Extension\"
     :catch              optional, result value in case of exceptions (otherwise
                         the Exception is re-thrown)"

--- a/editor/src/clj/editor/editor_extensions/prefs_docs.clj
+++ b/editor/src/clj/editor/editor_extensions/prefs_docs.clj
@@ -155,16 +155,6 @@
                                   :types ["schema[]"]
                                   :doc "schemas for the items")
                (make-default-prop "any[]")
-               scope-prop])
-     (ui-docs/component
-       "one_of"
-       :description "compositional one-of schema\n\nRequires at least one of the alternative schemas to satisfy the data (checked in order)"
-       :props [(ui-docs/make-prop :schemas
-                                  :required true
-                                  :coerce (coerce/vector-of schema-coercer :min-count 2)
-                                  :types ["schema[]"]
-                                  :doc "alternative schemas for the value")
-               (make-default-prop "any")
                scope-prop])]))
 
 (defn- schema-component->script-doc [{:keys [name props description]}]

--- a/editor/src/clj/editor/editor_extensions/prefs_docs.clj
+++ b/editor/src/clj/editor/editor_extensions/prefs_docs.clj
@@ -1,0 +1,232 @@
+;; Copyright 2020-2024 The Defold Foundation
+;; Copyright 2014-2020 King
+;; Copyright 2009-2014 Ragnar Svensson, Christian Murray
+;; Licensed under the Defold License version 1.0 (the "License"); you may not use
+;; this file except in compliance with the License.
+;;
+;; You may obtain a copy of the License, together with FAQs at
+;; https://www.defold.com/license
+;;
+;; Unless required by applicable law or agreed to in writing, software distributed
+;; under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+;; CONDITIONS OF ANY KIND, either express or implied. See the License for the
+;; specific language governing permissions and limitations under the License.
+
+(ns editor.editor-extensions.prefs-docs
+  (:require [clojure.string :as string]
+            [editor.editor-extensions.coerce :as coerce]
+            [editor.editor-extensions.ui-docs :as ui-docs]
+            [util.coll :as coll]
+            [util.eduction :as e]))
+
+(set! *warn-on-reflection* true)
+
+(defn- make-default-prop [type-string]
+  (ui-docs/make-prop :default
+                     ;; instead of coercing here, we produce the schema, and then
+                     ;; coerce the default according to that schema
+                     :coerce coerce/untouched
+                     :types [type-string]
+                     :doc "default value"))
+
+(defn editor-script-defined-schema? [x]
+  (= :schema (:type (meta x))))
+
+(def schema-coercer
+  (coerce/wrap-with-pred coerce/userdata editor-script-defined-schema? "is not a schema"))
+
+(definline allowed-keyword-character? [ch]
+  `(or (Character/isLetterOrDigit (char ~ch)) (= \- ~ch) (= \_ ~ch)))
+
+(defn- edn-serializable-string? [^String s]
+  (let [n (.length s)]
+    (and (pos? n)
+         (loop [i 0]
+           (cond
+             (= i n) true
+             (allowed-keyword-character? (.charAt s i)) (recur (inc i))
+             :else false)))))
+
+(def serializable-keyword-coercer
+  (-> coerce/string
+      (coerce/wrap-with-pred edn-serializable-string? "is not a valid keyword")
+      (coerce/wrap-transform keyword)))
+
+(def schema-components
+  (let [scope-prop (ui-docs/make-prop :scope
+                                      :coerce (coerce/enum :global :project)
+                                      :types ["string"]
+                                      :doc (ui-docs/doc-with-ul-options "preference scope"
+                                                                        ["<code>editor.prefs.SCOPE.GLOBAL</code>: same preference value is used in every project on this computer"
+                                                                         "<code>editor.prefs.SCOPE.PROJECT</code>: a separate preference value per project"]))]
+    [(ui-docs/component
+       "boolean"
+       :description "boolean schema"
+       :props [(make-default-prop "boolean")
+               scope-prop])
+     (ui-docs/component
+       "string"
+       :description "string schema"
+       :props [(make-default-prop "string")
+               scope-prop])
+     (ui-docs/component
+       "keyword"
+       :description "keyword schema\n\nA keyword is a short string that is interned within the editor runtime, useful e.g. for identifiers"
+       :props [(make-default-prop "string")
+               scope-prop])
+     (ui-docs/component
+       "integer"
+       :description "integer schema"
+       :props [(make-default-prop "integer")
+               scope-prop])
+     (ui-docs/component
+       "number"
+       :description "floating point number schema"
+       :props [(make-default-prop "number")
+               scope-prop])
+     (ui-docs/component
+       "array"
+       :description "array schema"
+       :props [(ui-docs/make-prop :item
+                                  :required true
+                                  :coerce schema-coercer
+                                  :types ["schema"]
+                                  :doc "array item schema")
+               (make-default-prop "item[]")
+               scope-prop])
+     (ui-docs/component
+       "set"
+       :description "set schema\n\nSet is represented as a lua table with <code>true</code> values"
+       :props [(ui-docs/make-prop :item
+                                  :required true
+                                  :coerce schema-coercer
+                                  :types ["schema"]
+                                  :doc "set item schema")
+               (make-default-prop "table&lt;item, true&gt;") ;; todo whacky html parsing
+               scope-prop])
+     (ui-docs/component
+       "object"
+       :description "heterogeneous object schema"
+       :props [(ui-docs/make-prop :properties
+                                  :required true
+                                  :coerce (coerce/map-of serializable-keyword-coercer schema-coercer)
+                                  :types ["table&lt;string, schema&gt;"] ;; todo whacky html parsing
+                                  :doc "a table from property key (string) to value schema")
+               (make-default-prop "table")
+               scope-prop])
+     (ui-docs/component
+       "object_of"
+       :description "homogeneous object schema"
+       :props [(ui-docs/make-prop :key
+                                  :required true
+                                  :coerce schema-coercer
+                                  :types ["schema"]
+                                  :doc "table key schema")
+               (ui-docs/make-prop :val
+                                  :required true
+                                  :coerce schema-coercer
+                                  :types ["schema"]
+                                  :doc "table value schema")
+               (make-default-prop "table")
+               scope-prop])
+     (ui-docs/component
+       "enum"
+       :description "enum value schema"
+       :props [(ui-docs/make-prop :values
+                                  :required true
+                                  :coerce (coerce/vector-of
+                                            (coerce/one-of
+                                              coerce/null
+                                              coerce/boolean
+                                              coerce/number
+                                              coerce/string)
+                                            :min-count 1
+                                            :distinct true)
+                                  :types ["any[]"]
+                                  :doc "allowed values, must be scalar (nil, boolean, number or string)")
+               (make-default-prop "any")
+               scope-prop])
+     (ui-docs/component
+       "tuple"
+       :description "tuple schema\n\nA tuple is a fixed-length array where each item has its own defined type"
+       :props [(ui-docs/make-prop :items
+                                  :required true
+                                  :coerce (coerce/vector-of schema-coercer :min-count 1)
+                                  :types ["schema[]"]
+                                  :doc "schemas for the items")
+               (make-default-prop "any[]")
+               scope-prop])
+     (ui-docs/component
+       "one_of"
+       :description "compositional one-of schema\n\nRequires at least one of the alternative schemas to satisfy the data (checked in order)"
+       :props [(ui-docs/make-prop :schemas
+                                  :required true
+                                  :coerce (coerce/vector-of schema-coercer :min-count 2)
+                                  :types ["schema[]"]
+                                  :doc "alternative schemas for the value")
+               (make-default-prop "any")
+               scope-prop])]))
+
+(defn- schema-component->script-doc [{:keys [name props description]}]
+  (let [[req opt] (coll/separate-by :required props)
+        optional (coll/empty? req)]
+    {:name (str "editor.prefs.schema." name)
+     :type :function
+     :description description
+     :parameters [{:name (if optional "[opts]" "opts")
+                   :types ["table"]
+                   :doc (str (when-not optional
+                               (str "Required opts:\n"
+                                    (ui-docs/props-doc-html req)
+                                    "\n\n"))
+                             "Optional opts:\n"
+                             (ui-docs/props-doc-html opt))}]
+     :returnvalues [{:name "value"
+                     :types ["schema"]
+                     :doc "Prefs schema"}]}))
+
+(def enums
+  {:scope [:global :project]})
+
+(defn script-docs []
+  (e/concat
+    [{:name "editor.prefs"
+      :type :module
+      :description "Reading and writing editor preferences"}
+     {:name "editor.prefs.get"
+      :type :function
+      :parameters [{:name "key"
+                    :types ["string"]
+                    :doc "dot-separated preference key path"}]
+      :returnvalues [{:name "value"
+                      :types ["any"]
+                      :doc "current pref value or default if a schema for the key path exists, nil otherwise"}]
+      :description "Get preference value\n\nThe schema for the preference value should be defined beforehand."}
+     {:name "editor.prefs.set"
+      :type :function
+      :parameters [{:name "key"
+                    :types ["string"]
+                    :doc "dot-separated preference key path"}
+                   {:name "value"
+                    :types ["any"]
+                    :doc "new pref value to set"}]
+      :description "Set preference value\n\nThe schema for the preference value should be defined beforehand."}
+     {:name "editor.prefs.schema"
+      :type :module
+      :description "Schema for defining preferences"}]
+    (e/map schema-component->script-doc schema-components)
+    (e/mapcat (fn [[id-kw vs]]
+                (let [id (str "editor.prefs." (ui-docs/->screaming-snake-case id-kw))]
+                  (e/concat
+                    [{:name id
+                      :type :module
+                      :description (str "Constants for "
+                                        (string/replace (name id-kw) \- \space)
+                                        " enums")}]
+                    (e/map
+                      (fn [v-kw]
+                        {:name (str id "." (ui-docs/->screaming-snake-case v-kw))
+                         :type :constant
+                         :description (format "`\"%s\"`" (name v-kw))})
+                      vs))))
+              enums)))

--- a/editor/src/clj/editor/editor_extensions/prefs_docs.clj
+++ b/editor/src/clj/editor/editor_extensions/prefs_docs.clj
@@ -102,7 +102,7 @@
                                   :coerce schema-coercer
                                   :types ["schema"]
                                   :doc "set item schema")
-               (make-default-prop "table&lt;item, true&gt;") ;; todo whacky html parsing
+               (make-default-prop "table&lt;item, true&gt;")
                scope-prop])
      (ui-docs/component
        "object"
@@ -110,7 +110,7 @@
        :props [(ui-docs/make-prop :properties
                                   :required true
                                   :coerce (coerce/map-of serializable-keyword-coercer schema-coercer)
-                                  :types ["table&lt;string, schema&gt;"] ;; todo whacky html parsing
+                                  :types ["table&lt;string, schema&gt;"]
                                   :doc "a table from property key (string) to value schema")
                (make-default-prop "table")
                scope-prop])

--- a/editor/src/clj/editor/editor_extensions/prefs_functions.clj
+++ b/editor/src/clj/editor/editor_extensions/prefs_functions.clj
@@ -65,7 +65,7 @@
             {req true opt false} (iutil/group-into {} {} :required (coll/pair-fn :name :coerce) props)
             coercer (coerce/hash-map :req req :opt opt)
             make-schema-lua-value
-            (fn [rt m]
+            (fn make-schema-lua-value [rt m]
               (let [schema (assoc m :type schema-type)
                     schema (if-let [default-lua-value (:default schema)]
                              (assoc schema :default (rt/->clj rt (schema->coercer schema) default-lua-value))
@@ -169,7 +169,7 @@
         m))))
 
 (defn env [prefs]
-  (conj
+  (merge
     {"get" (make-get-fn prefs)
      "set" (make-set-fn prefs)
      "schema" schema-lua-env}

--- a/editor/src/clj/editor/editor_extensions/prefs_functions.clj
+++ b/editor/src/clj/editor/editor_extensions/prefs_functions.clj
@@ -1,0 +1,176 @@
+;; Copyright 2020-2024 The Defold Foundation
+;; Copyright 2014-2020 King
+;; Copyright 2009-2014 Ragnar Svensson, Christian Murray
+;; Licensed under the Defold License version 1.0 (the "License"); you may not use
+;; this file except in compliance with the License.
+;;
+;; You may obtain a copy of the License, together with FAQs at
+;; https://www.defold.com/license
+;;
+;; Unless required by applicable law or agreed to in writing, software distributed
+;; under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+;; CONDITIONS OF ANY KIND, either express or implied. See the License for the
+;; specific language governing permissions and limitations under the License.
+
+(ns editor.editor-extensions.prefs-functions
+  (:require [clojure.spec.alpha :as s]
+            [clojure.string :as string]
+            [editor.editor-extensions.coerce :as coerce]
+            [editor.editor-extensions.prefs-docs :as prefs-docs]
+            [editor.editor-extensions.runtime :as rt]
+            [editor.editor-extensions.ui-docs :as ui-docs]
+            [editor.prefs :as prefs]
+            [internal.util :as iutil]
+            [util.coll :as coll])
+  (:import [org.luaj.vm2 LuaError]))
+
+(set! *warn-on-reflection* true)
+
+(defn- map-keys->set [m]
+  (persistent!
+    (reduce-kv
+      (fn [acc k _]
+        (conj! acc k))
+      (transient #{})
+      m)))
+
+(def ^:private number->double-coercer
+  (coerce/wrap-transform coerce/number double))
+
+(defn- schema->coercer [schema]
+  (case (:type schema)
+    :any coerce/any
+    :boolean coerce/boolean
+    :string coerce/string
+    :keyword prefs-docs/serializable-keyword-coercer
+    :integer coerce/integer
+    :number number->double-coercer
+    :array (coerce/vector-of (schema->coercer (:item schema)))
+    :set (coerce/wrap-transform
+           (coerce/map-of (schema->coercer (:item schema)) (coerce/const true))
+           map-keys->set)
+    :object-of (coerce/map-of (schema->coercer (:key schema)) (schema->coercer (:val schema)))
+    :object (coerce/hash-map :opt (coll/pair-map-by key (comp schema->coercer val) (:properties schema))
+                             :extra-keys false)
+    :enum (apply coerce/enum (:values schema))
+    :tuple (apply coerce/tuple (mapv schema->coercer (:items schema)))
+    :one-of (apply coerce/one-of (mapv schema->coercer (:schemas schema)))))
+
+(def ^:private schema-lua-env
+  (coll/pair-map-by
+    :name
+    (fn [{:keys [name props]}]
+      (let [schema-type (keyword (string/replace name \_ \-))
+            string-representation (str "editor.prefs.schema." name "(...)")
+            {req true opt false} (iutil/group-into {} {} :required (coll/pair-fn :name :coerce) props)
+            coercer (coerce/hash-map :req req :opt opt)
+            make-schema-lua-value
+            (fn [rt m]
+              (let [schema (assoc m :type schema-type)
+                    schema (if-let [default-lua-value (:default schema)]
+                             (assoc schema :default (rt/->clj rt (schema->coercer schema) default-lua-value))
+                             schema)]
+                (s/assert ::prefs/schema schema)
+                (rt/wrap-userdata (vary-meta schema assoc :type :schema) string-representation)))]
+        (if req
+          (rt/lua-fn schema-factory [{:keys [rt]} lua-arg]
+            (make-schema-lua-value rt (rt/->clj rt coercer lua-arg)))
+          ;; all keys are optional
+          (rt/lua-fn schema-factory
+            ([{:keys [rt]}]
+             (make-schema-lua-value rt {}))
+            ([{:keys [rt]} lua-arg]
+             (make-schema-lua-value rt (rt/->clj rt coercer lua-arg)))))))
+    prefs-docs/schema-components))
+
+(defn parse-dot-separated-path [^String s]
+  (let [n (.length s)
+        non-empty! (fn [^String s]
+                     (if (.isEmpty s)
+                       (throw (LuaError. "Key path element cannot be empty"))
+                       s))]
+    (loop [acc (transient [])
+           from 0
+           to 0]
+      (if (= n to)
+        (persistent! (conj! acc (keyword (non-empty! (.substring s from to)))))
+        (let [ch (.charAt s to)]
+          (cond
+            (= ch \.)
+            (recur (conj! acc (keyword (non-empty! (.substring s from to)))) (inc to) (inc to))
+
+            (prefs-docs/allowed-keyword-character? ch)
+            (recur acc from (inc to))
+
+            :else
+            (throw (LuaError. (str "Invalid identifier character: '" ch "'")))))))))
+
+(defn- make-get-fn [prefs]
+  (rt/lua-fn ext-get
+    [{:keys [rt]} lua-path]
+    (let [path-str (rt/->clj rt coerce/string lua-path)
+          path (parse-dot-separated-path path-str)]
+      (try
+        (prefs/get prefs path)
+        (catch Exception e
+          (case (::prefs/error (ex-data e))
+            :path (throw (LuaError. (str "No schema defined for prefs path '" path-str "'")))
+            (throw e)))))))
+
+(defn- make-set-fn [prefs]
+  (rt/lua-fn ext-set [{:keys [rt]} lua-path lua-value]
+    (let [path-str (rt/->clj rt coerce/string lua-path)
+          path (parse-dot-separated-path path-str)]
+      (try
+        (let [schema (prefs/schema prefs path)
+              coercer (schema->coercer schema)
+              value (rt/->clj rt coercer lua-value)]
+          (prefs/set! prefs path value))
+        (catch Exception e
+          (let [data (ex-data e)]
+            (case (::prefs/error data)
+              ;; we don't catch :value errors here because coercer already
+              ;; verifies the right data shape and presents Lua-specific error
+              ;; messages to the user
+              :path (throw (LuaError. (str "No schema defined for prefs path '" path-str "'")))
+              (throw e))))))))
+
+(def ^:private enum-env
+  (into {}
+        (map (fn [[id values]]
+               [(ui-docs/->screaming-snake-case id)
+                (coll/pair-map-by ui-docs/->screaming-snake-case coerce/enum-lua-value-cache values)]))
+        prefs-docs/enums))
+
+(def schema-definition-coercer
+  (coerce/one-of
+    ;; simple
+    prefs-docs/schema-coercer
+    ;; easy: strings are dot-separated paths
+    (coerce/map-of coerce/string prefs-docs/schema-coercer)))
+
+(defn- fail-on-conflict [_ _ path]
+  (throw (LuaError. (str "Conflicting schemas defined at path '" (string/join "." (map name path)) "'"))))
+
+(defn lua-schema-definition->schema [rt lua-schema-definition]
+  (let [m (rt/->clj rt schema-definition-coercer lua-schema-definition)]
+    (if (prefs-docs/editor-script-defined-schema? m)
+      m
+      (reduce-kv
+        (fn [acc path-str schema]
+          (let [path (parse-dot-separated-path path-str)
+                schema (loop [i (dec (count path))
+                              acc schema]
+                         (if (neg? i)
+                           acc
+                           (recur (dec i) {:type :object :properties {(path i) acc}})))]
+            (prefs/merge-schemas fail-on-conflict acc schema)))
+        {:type :object :properties {}}
+        m))))
+
+(defn env [prefs]
+  (conj
+    {"get" (make-get-fn prefs)
+     "set" (make-set-fn prefs)
+     "schema" schema-lua-env}
+    enum-env))

--- a/editor/src/clj/editor/editor_extensions/prefs_functions.clj
+++ b/editor/src/clj/editor/editor_extensions/prefs_functions.clj
@@ -53,8 +53,7 @@
     :object (coerce/hash-map :opt (coll/pair-map-by key (comp schema->coercer val) (:properties schema))
                              :extra-keys false)
     :enum (apply coerce/enum (:values schema))
-    :tuple (apply coerce/tuple (mapv schema->coercer (:items schema)))
-    :one-of (apply coerce/one-of (mapv schema->coercer (:schemas schema)))))
+    :tuple (apply coerce/tuple (mapv schema->coercer (:items schema)))))
 
 (def ^:private schema-lua-env
   (coll/pair-map-by

--- a/editor/src/clj/editor/editor_extensions/ui_docs.clj
+++ b/editor/src/clj/editor/editor_extensions/ui_docs.clj
@@ -47,13 +47,14 @@
     :string ["string"]
     :function ["function"]
     :integer ["integer"]
+    :number ["number"]
     :table ["table"]
     :any ["any"]
     :array (when-let [item-types (infer-doc-types-from-coercer-schema (:item schema))]
              [(str (group-doc-types item-types) "[]")])
     nil))
 
-(defn- ^{:arglists '([name & {:keys [coerce required types doc]}])} make-prop
+(defn ^{:arglists '([name & {:keys [coerce required types doc]}])} make-prop
   "Construct a prop definition map
 
   Args:
@@ -388,7 +389,7 @@
 
 ;; region component definitions
 
-(defn- props-doc-html [props]
+(defn props-doc-html [props]
   (lua-completion/args-doc-html
     (map #(update % :name name) props)))
 

--- a/editor/src/clj/editor/editor_extensions/ui_docs.clj
+++ b/editor/src/clj/editor/editor_extensions/ui_docs.clj
@@ -19,6 +19,7 @@
             [editor.lua-completion :as lua-completion]
             [editor.util :as util]
             [util.coll :as coll]
+            [util.eduction :as e]
             [util.fn :as fn]))
 
 ;; region make-prop
@@ -718,43 +719,42 @@ end)</code></pre>"})
                   input-with-issue-props)}))
 
 (defn script-docs
-  "Returns reducible with all ui-related script doc maps"
+  "Returns a vector with all ui-related script doc maps"
   []
   (let [add-ns-prefix #(str "editor.ui." %)]
-    (eduction
-      cat
-      (map #(update % :name add-ns-prefix))
-      [(eduction
-         (map component->script-doc)
-         [horizontal-component
-          vertical-component
-          grid-component
-          separator-component
-          scroll-component
-          label-component
-          paragraph-component
-          heading-component
-          icon-component
-          button-component
-          check-box-component
-          select-box-component
-          ;; We don't need these components for the initial release, but we
-          ;; might want to add them later on:
-          #_text-field-component
-          #_value-field-component
-          string-field-component
-          integer-field-component
-          number-field-component
-          dialog-button-component
-          dialog-component])
-       [show-dialog-doc
-        function-component-doc
-        external-file-field-doc
-        resource-field-doc
-        show-external-file-dialog-doc
-        show-external-directory-dialog-doc
-        show-resource-dialog-doc
-        use-state-doc
-        use-memo-doc]])))
-
+    (->> (e/concat
+           (e/map
+             component->script-doc
+             [horizontal-component
+              vertical-component
+              grid-component
+              separator-component
+              scroll-component
+              label-component
+              paragraph-component
+              heading-component
+              icon-component
+              button-component
+              check-box-component
+              select-box-component
+              ;; We don't need these components for the initial release, but we
+              ;; might want to add them later on:
+              #_text-field-component
+              #_value-field-component
+              string-field-component
+              integer-field-component
+              number-field-component
+              dialog-button-component
+              dialog-component])
+           [show-dialog-doc
+            function-component-doc
+            external-file-field-doc
+            resource-field-doc
+            show-external-file-dialog-doc
+            show-external-directory-dialog-doc
+            show-resource-dialog-doc
+            use-state-doc
+            use-memo-doc])
+         (e/map #(update % :name add-ns-prefix))
+         vec)))
 ;; endregion

--- a/editor/src/clj/editor/editor_extensions/vm.clj
+++ b/editor/src/clj/editor/editor_extensions/vm.clj
@@ -32,7 +32,7 @@
   (:require [clojure.java.io :as io])
   (:import [clojure.lang IReduceInit Named]
            [java.nio.charset StandardCharsets]
-           [java.util List Map]
+           [java.util List Map Set]
            [java.util.concurrent.locks ReentrantLock]
            [org.apache.commons.io.input CharSequenceInputStream]
            [org.luaj.vm2 Globals LuaBoolean LuaClosure LuaDouble LuaFunction LuaInteger LuaNil LuaString LuaTable LuaUserdata LuaValue Prototype Varargs]
@@ -160,6 +160,12 @@
                    (.rawset ret (int (inc i)) ^LuaValue (->lua v))))
                (recur (inc i))))
            ret))
+  Set (->lua [x]
+        (reduce
+          (fn [^LuaTable acc x]
+            (cond-> acc (some? x) (doto (.hashset (->lua x) LuaValue/TRUE))))
+          (LuaTable. 0 (count x))
+          x))
   Map (->lua [x]
         (reduce-kv
           (fn [^LuaTable acc k v]

--- a/editor/src/clj/editor/lua.clj
+++ b/editor/src/clj/editor/lua.clj
@@ -23,7 +23,8 @@
             [editor.lua-completion :as lua-completion]
             [editor.protobuf :as protobuf]
             [internal.util :as util]
-            [util.coll :refer [pair]])
+            [util.coll :refer [pair]]
+            [util.eduction :as e])
   (:import [com.dynamo.scriptdoc.proto ScriptDoc$Document]
            [java.net URI]
            [org.apache.commons.io FilenameUtils]))
@@ -231,9 +232,9 @@
               (make-ast-completions local-completion-info required-completion-infos)))
 
 (def editor-completions
-  (make-completion-map
-    (eduction
-      (map (fn [doc]
-             (let [name-parts (string/split (:name doc) #"\.")]
-               [(pop name-parts) (lua-completion/make (assoc doc :name (peek name-parts)))])))
-      (ext-docs/editor-script-docs))))
+  (->> (ext-docs/editor-script-docs)
+       (e/map
+         (fn [doc]
+           (let [name-parts (string/split (:name doc) #"\.")]
+             [(pop name-parts) (lua-completion/make (assoc doc :name (peek name-parts)))])))
+       (make-completion-map)))

--- a/editor/src/clj/editor/prefs.clj
+++ b/editor/src/clj/editor/prefs.clj
@@ -436,7 +436,7 @@
                    ;; we put default schema into state to use the same schema
                    ;; access pattern, but it is not modifiable (register-schema!
                    ;; disallows using :default key)
-                   :registry {:default (s/assert ::schema (resolve-schema default-schema))}})]
+                   :registry {:default (resolve-schema (s/assert ::schema default-schema))}})]
     (add-watch ret global-state-watcher global-state-watcher)
     (.addShutdownHook (Runtime/getRuntime) (Thread. #(sync-state! global-state)))
     ret))

--- a/editor/src/clj/editor/prefs.clj
+++ b/editor/src/clj/editor/prefs.clj
@@ -304,7 +304,7 @@
 (s/def ::key ::schema)
 (s/def ::val ::schema)
 (defmethod type-spec :object-of [_] (s/keys :req-un [::key ::val]))
-(s/def ::items (s/coll-of ::schema :kind vector?))
+(s/def ::items (s/coll-of ::schema :kind vector? :min-count 2))
 (defmethod type-spec :tuple [_] (s/keys :req-un [::items]))
 (s/def ::values (s/coll-of any? :min-count 1 :kind vector?))
 (defmethod type-spec :enum [_] (s/keys :req-un [::values]))

--- a/editor/src/clj/editor/prefs.clj
+++ b/editor/src/clj/editor/prefs.clj
@@ -73,172 +73,155 @@
 (defn- nilable [schema]
   {:type :one-of :schemas [{:type :enum :values [nil]} schema]})
 
-(defn- resolve-schema
-  "Convert schema to a fully-specified one
-
-  In a fully resolved schema, every schema element up to leaves has a defined
-  scope. All nested object schemas are considered branches, and all non-object
-  schemas are leaves."
-  ([schema]
-   (resolve-schema schema :global))
-  ([schema default-scope]
-   (let [scope (:scope schema default-scope)
-         schema (assoc schema :scope scope)]
-     (case (:type schema)
-       :object (update schema :properties (fn [m]
-                                            (coll/pair-map-by key #(resolve-schema (val %) scope) m)))
-       schema))))
-
 (def default-schema
-  (resolve-schema
-    {:type :object
-     :properties
-     {:asset-browser {:type :object
-                      :properties
-                      {:track-active-tab {:type :boolean :label "Track Active Tab in Asset Browser"}}}
-      :input {:type :object
-              :properties
-              {:keymap-path {:type :string :label "Path to Custom Keymap"}}}
-      :code {:type :object
-             :properties
-             {:custom-editor {:type :string}
-              :open-file {:type :string :default "{file}"}
-              :open-file-at-line {:type :string :default "{file}:{line}" :label "Open File at Line"}
-              :font {:type :object
-                     :properties
-                     {:name {:type :string :default "Dejavu Sans Mono"}
-                      :size {:type :number :default 12.0}}}
-              :find {:type :object
-                     :scope :project
-                     :properties
-                     {:term {:type :string}
-                      :replacement {:type :string}
-                      :whole-word {:type :boolean}
-                      :case-sensitive {:type :boolean}
-                      :wrap {:type :boolean :default true}}}
-              :visibility {:type :object
-                           :properties
-                           {:indentation-guides {:type :boolean :default true}
-                            :minimap {:type :boolean :default true}
-                            :whitespace {:type :boolean :default true}}}}}
-      :tools {:type :object
-              :properties
-              {:adb-path {:type :string
-                          :label "ADB path"
-                          :description "Path to ADB command that might be used to install and launch the Android app when it's bundled"}
-               :ios-deploy-path {:type :string
-                                 :label "ios-deploy path"
-                                 :description "Path to ios-deploy command that might be used to install and launch iOS app when it's bundled"}}}
-      :extensions {:type :object
-                   :properties
-                   {:build-server {:type :string}
-                    :build-server-headers {:type :string}}}
-      :search-in-files {:type :object
-                        :scope :project
-                        :properties
-                        {:term {:type :string}
-                         :exts {:type :string}
-                         :include-libraries {:type :boolean :default true}}}
-      :open-assets {:type :object
-                    :scope :project
+  {:type :object
+   :properties
+   {:asset-browser {:type :object
                     :properties
-                    {:term {:type :string}}}
-      :build {:type :object
-              :scope :project
-              :properties
-              {:lint-code {:type :boolean :default true :label "Lint Code on Build"}
-               :texture-compression {:type :boolean}}}
-      :bundle {:type :object
-               :scope :project
-               :properties
-               {:variant {:type :enum :values ["debug" "release" "headless"]}
-                :texture-compression {:type :enum :values ["enabled" "disabled" "editor"]}
-                :debug-symbols {:type :boolean :default true}
-                :build-report {:type :boolean}
-                :liveupdate {:type :boolean}
-                :contentless {:type :boolean}
-                :output-directory (nilable {:type :string})
-                :open-output-directory {:type :boolean :default true}
-                :android {:type :object
-                          :properties
-                          {:keystore (nilable {:type :string})
-                           :keystore-pass (nilable {:type :string})
-                           :key-pass (nilable {:type :string})
-                           :architecture {:type :object
-                                          :properties
-                                          {:armv7-android {:type :boolean :default true}
-                                           :arm64-android {:type :boolean}}}
-                           :format (nilable {:type :enum :values ["apk" "aab" "apk,aab"]})
-                           :install {:type :boolean}
-                           :launch {:type :boolean}}}
-                :macos {:type :object
-                        :properties
-                        {:architecture {:type :object
-                                        :properties
-                                        {:x86_64-macos {:type :boolean :default true}
-                                         :arm64-macos {:type :boolean :default true}}}}}
-                :ios {:type :object
-                      :properties
-                      {:sign {:type :boolean :default true}
-                       :code-signing-identity (nilable {:type :string})
-                       :provisioning-profile (nilable {:type :string})
-                       :architecture {:type :object
-                                      :properties
-                                      {:arm64-ios {:type :boolean :default true}
-                                       :x86_64-ios {:type :boolean}}}
-                       :install {:type :boolean}
-                       :launch {:type :boolean}}}
-                :html5 {:type :object
-                        :properties
-                        {:architecture {:type :object
-                                        :properties
-                                        {:js-web {:type :boolean}
-                                         :wasm-web {:type :boolean :default true}}}}}
-                :windows {:type :object
-                          :properties
-                          {:platform {:type :enum
-                                      ;; derive from bob?
-                                      :values ["x86_64-win32" "x86-win32"]}}}}}
-      :window {:type :object
-               :properties
-               {:dimensions {:type :any}
-                :split-positions {:type :any}
-                :hidden-panes {:type :set :item {:type :keyword}}}}
-      :workflow {:type :object
+                    {:track-active-tab {:type :boolean :label "Track Active Tab in Asset Browser"}}}
+    :input {:type :object
+            :properties
+            {:keymap-path {:type :string :label "Path to Custom Keymap"}}}
+    :code {:type :object
+           :properties
+           {:custom-editor {:type :string}
+            :open-file {:type :string :default "{file}"}
+            :open-file-at-line {:type :string :default "{file}:{line}" :label "Open File at Line"}
+            :font {:type :object
+                   :properties
+                   {:name {:type :string :default "Dejavu Sans Mono"}
+                    :size {:type :number :default 12.0}}}
+            :find {:type :object
+                   :scope :project
+                   :properties
+                   {:term {:type :string}
+                    :replacement {:type :string}
+                    :whole-word {:type :boolean}
+                    :case-sensitive {:type :boolean}
+                    :wrap {:type :boolean :default true}}}
+            :visibility {:type :object
+                         :properties
+                         {:indentation-guides {:type :boolean :default true}
+                          :minimap {:type :boolean :default true}
+                          :whitespace {:type :boolean :default true}}}}}
+    :tools {:type :object
+            :properties
+            {:adb-path {:type :string
+                        :label "ADB path"
+                        :description "Path to ADB command that might be used to install and launch the Android app when it's bundled"}
+             :ios-deploy-path {:type :string
+                               :label "ios-deploy path"
+                               :description "Path to ios-deploy command that might be used to install and launch iOS app when it's bundled"}}}
+    :extensions {:type :object
                  :properties
-                 {:load-external-changes-on-app-focus {:type :boolean
-                                                       :default true
-                                                       :label "Load External Changes on App Focus"}
-                  :recent-files {:type :array
-                                 :item {:type :tuple :items [{:type :string} {:type :keyword}]}
-                                 :scope :project}}}
-      :console {:type :object
-                :properties
-                {:filters {:type :array
-                           :item {:type :tuple :items [{:type :string} {:type :boolean}]}}}}
-      :run {:type :object
+                 {:build-server {:type :string}
+                  :build-server-headers {:type :string}}}
+    :search-in-files {:type :object
+                      :scope :project
+                      :properties
+                      {:term {:type :string}
+                       :exts {:type :string}
+                       :include-libraries {:type :boolean :default true}}}
+    :open-assets {:type :object
+                  :scope :project
+                  :properties
+                  {:term {:type :string}}}
+    :build {:type :object
+            :scope :project
             :properties
-            {:instance-count {:type :integer :default 1 :scope :project}
-             :selected-target-id {:type :any}
-             :manual-target-ip+port {:type :string}
-             :quit-on-escape {:type :boolean :label "Escape Quits Game"}
-             :simulate-rotated-device (nilable {:type :boolean :scope :project})
-             :simulated-resolution {:type :any :scope :project}}}
-      :scene {:type :object
+            {:lint-code {:type :boolean :default true :label "Lint Code on Build"}
+             :texture-compression {:type :boolean}}}
+    :bundle {:type :object
+             :scope :project
+             :properties
+             {:variant {:type :enum :values ["debug" "release" "headless"]}
+              :texture-compression {:type :enum :values ["enabled" "disabled" "editor"]}
+              :debug-symbols {:type :boolean :default true}
+              :build-report {:type :boolean}
+              :liveupdate {:type :boolean}
+              :contentless {:type :boolean}
+              :output-directory (nilable {:type :string})
+              :open-output-directory {:type :boolean :default true}
+              :android {:type :object
+                        :properties
+                        {:keystore (nilable {:type :string})
+                         :keystore-pass (nilable {:type :string})
+                         :key-pass (nilable {:type :string})
+                         :architecture {:type :object
+                                        :properties
+                                        {:armv7-android {:type :boolean :default true}
+                                         :arm64-android {:type :boolean}}}
+                         :format (nilable {:type :enum :values ["apk" "aab" "apk,aab"]})
+                         :install {:type :boolean}
+                         :launch {:type :boolean}}}
+              :macos {:type :object
+                      :properties
+                      {:architecture {:type :object
+                                      :properties
+                                      {:x86_64-macos {:type :boolean :default true}
+                                       :arm64-macos {:type :boolean :default true}}}}}
+              :ios {:type :object
+                    :properties
+                    {:sign {:type :boolean :default true}
+                     :code-signing-identity (nilable {:type :string})
+                     :provisioning-profile (nilable {:type :string})
+                     :architecture {:type :object
+                                    :properties
+                                    {:arm64-ios {:type :boolean :default true}
+                                     :x86_64-ios {:type :boolean}}}
+                     :install {:type :boolean}
+                     :launch {:type :boolean}}}
+              :html5 {:type :object
+                      :properties
+                      {:architecture {:type :object
+                                      :properties
+                                      {:js-web {:type :boolean}
+                                       :wasm-web {:type :boolean :default true}}}}}
+              :windows {:type :object
+                        :properties
+                        {:platform {:type :enum
+                                    ;; derive from bob?
+                                    :values ["x86_64-win32" "x86-win32"]}}}}}
+    :window {:type :object
+             :properties
+             {:dimensions {:type :any}
+              :split-positions {:type :any}
+              :hidden-panes {:type :set :item {:type :keyword}}}}
+    :workflow {:type :object
+               :properties
+               {:load-external-changes-on-app-focus {:type :boolean
+                                                     :default true
+                                                     :label "Load External Changes on App Focus"}
+                :recent-files {:type :array
+                               :item {:type :tuple :items [{:type :string} {:type :keyword}]}
+                               :scope :project}}}
+    :console {:type :object
               :properties
-              {:move-whole-pixels {:type :boolean :default true}}}
-      :dev {:type :object
+              {:filters {:type :array
+                         :item {:type :tuple :items [{:type :string} {:type :boolean}]}}}}
+    :run {:type :object
+          :properties
+          {:instance-count {:type :integer :default 1 :scope :project}
+           :selected-target-id {:type :any}
+           :manual-target-ip+port {:type :string}
+           :quit-on-escape {:type :boolean :label "Escape Quits Game"}
+           :simulate-rotated-device (nilable {:type :boolean :scope :project})
+           :simulated-resolution {:type :any :scope :project}}}
+    :scene {:type :object
             :properties
-            {:custom-engine {:type :any}}}
-      :git {:type :object
-            :properties
-            {:credentials {:type :any :scope :project}}}
-      :welcome {:type :object
-                :properties
-                {:last-opened-project-directory {:type :any}
-                 :recent-projects {:type :object-of
-                                   :key {:type :string}
-                                   :val {:type :string}}}}}}))
+            {:move-whole-pixels {:type :boolean :default true}}}
+    :dev {:type :object
+          :properties
+          {:custom-engine {:type :any}}}
+    :git {:type :object
+          :properties
+          {:credentials {:type :any :scope :project}}}
+    :welcome {:type :object
+              :properties
+              {:last-opened-project-directory {:type :any}
+               :recent-projects {:type :object-of
+                                 :key {:type :string}
+                                 :val {:type :string}}}}}})
 
 ;; region schema validation
 
@@ -333,8 +316,6 @@
 (s/def ::preferences (s/keys :req-un [:editor.prefs.preferences/scopes
                                       :editor.prefs.preferences/schemas]))
 
-(s/assert ::schema default-schema)
-
 ;; endregion
 
 ;; region internal global state
@@ -427,6 +408,22 @@
              (:events new-state))
     (.schedule sync-executor ^Runnable #(sync-state! global-state) 30 TimeUnit/SECONDS)))
 
+(defn- resolve-schema
+  "Convert schema to a fully-specified one
+
+  In a fully resolved schema, every schema element up to leaves has a defined
+  scope. All nested object schemas are considered branches, and all non-object
+  schemas are leaves."
+  ([schema]
+   (resolve-schema schema :global))
+  ([schema default-scope]
+   (let [scope (:scope schema default-scope)
+         schema (assoc schema :scope scope)]
+     (case (:type schema)
+       :object (update schema :properties (fn [m]
+                                            (coll/pair-map-by key #(resolve-schema (val %) scope) m)))
+       schema))))
+
 (def global-state
   ;; global state value is a map with the following keys:
   ;;   :storage     a map from absolute file Path to its prefs map
@@ -439,7 +436,7 @@
                    ;; we put default schema into state to use the same schema
                    ;; access pattern, but it is not modifiable (register-schema!
                    ;; disallows using :default key)
-                   :registry {:default default-schema}})]
+                   :registry {:default (s/assert ::schema (resolve-schema default-schema))}})]
     (add-watch ret global-state-watcher global-state-watcher)
     (.addShutdownHook (Runtime/getRuntime) (Thread. #(sync-state! global-state)))
     ret))

--- a/editor/src/clj/editor/welcome.clj
+++ b/editor/src/clj/editor/welcome.clj
@@ -190,11 +190,9 @@
   exist will be filtered out. The projects are returned in descending order with
   the most recently opened project first."
   [prefs]
-  (sort-by :last-opened
-           coll/descending-order
-           (if-some [timestamps-by-path (prefs/get prefs recent-projects-prefs-key)]
-             (into [] xform-timestamps-by-path->recent-projects timestamps-by-path)
-             [])))
+  (->> (prefs/get prefs recent-projects-prefs-key)
+       (into [] xform-timestamps-by-path->recent-projects)
+       (sort-by :last-opened coll/descending-order)))
 
 (defn add-recent-project!
   "Updates the recent projects list in the preferences to include a new entry

--- a/editor/test/editor/prefs_test.clj
+++ b/editor/test/editor/prefs_test.clj
@@ -18,6 +18,16 @@
             [editor.fs :as fs]
             [editor.prefs :as prefs]))
 
+(defmethod assert-expr 'thrown-with-data? [msg [_ expected-data-pred & body :as form]]
+  `(try
+     (do ~@body)
+     (do-report {:type :fail :message ~msg :expected '~form :actual nil})
+     (catch Throwable e#
+       (let [actual-data# (ex-data e#)
+             result# (if (~expected-data-pred actual-data#) :pass :fail)]
+         (do-report {:type result# :message ~msg :expected '~form :actual e#})
+         e#))))
+
 (defmacro with-schemas [id->schema & body]
   `(try
      ~@(map (fn [[id schema]]
@@ -28,6 +38,16 @@
        ~@(map (fn [id]
                 `(prefs/unregister-schema! ~id))
               (keys id->schema)))))
+
+(defn- value-error-data? [path]
+  (fn [x]
+    (and (= :value (::prefs/error x))
+         (= path (:path x)))))
+
+(defn- path-error-data? [path]
+  (fn [x]
+    (and (= :path (::prefs/error x))
+         (= path (:path x)))))
 
 (deftest prefs-types-test
   (with-schemas {::types {:type :object
@@ -41,7 +61,11 @@
                                                             :array {:type :array :item {:type :string}}
                                                             :set {:type :set :item {:type :string}}
                                                             :enum {:type :enum :values [:foo :bar]}
-                                                            :tuple {:type :tuple :items [{:type :string} {:type :keyword :default :code-view}]}}}}}}
+                                                            :tuple {:type :tuple :items [{:type :string} {:type :keyword :default :code-view}]}
+                                                            :object-of {:type :object-of :key {:type :string} :val {:type :string}}
+                                                            :one-of {:type :one-of
+                                                                     :schemas [{:type :enum :values [nil]}
+                                                                               {:type :string}]}}}}}}
     (let [p (prefs/make :scopes {:global (fs/create-temp-file! "global" "test.editor_settings")}
                         :schemas [::types])]
       ;; ensure defaults are properly typed
@@ -54,7 +78,9 @@
                       :array []
                       :set #{}
                       :enum :foo
-                      :tuple ["" :code-view]}}
+                      :tuple ["" :code-view]
+                      :object-of {}
+                      :one-of nil}}
              (prefs/get p [])))
       ;; change values
       (prefs/set! p [] {:types {:any 'foo/bar
@@ -66,7 +92,9 @@
                                 :array ["heh"]
                                 :set #{"heh"}
                                 :enum :bar
-                                :tuple ["/game.project" :form-view]}})
+                                :tuple ["/game.project" :form-view]
+                                :object-of {"foo" "bar"}
+                                :one-of "foo"}})
       ;; ensure updated values are as expected
       (is (= {:types {:any 'foo/bar
                       :boolean false
@@ -77,29 +105,40 @@
                       :array ["heh"]
                       :set #{"heh"}
                       :enum :bar
-                      :tuple ["/game.project" :form-view]}}
+                      :tuple ["/game.project" :form-view]
+                      :object-of {"foo" "bar"}
+                      :one-of "foo"}}
              (prefs/get p [])))
-      ;; set to invalid values (expect a single correct field — :string)
-      (prefs/set! p [] {:types {:boolean "not-a-boolean"
-                                :string "STILL A STRING"
-                                :keyword "not-a-keyword"
-                                :integer "not-an-int"
-                                :number "NaN"
-                                :array true
-                                :set false
-                                :enum 12
-                                :tuple nil}})
-      ;; only a valid preference is applied
+      ;; set to invalid values
+      (is (thrown-with-data? (value-error-data? [:types :boolean])
+                             (prefs/set! p [] {:types {:boolean "not-a-boolean"}})))
+      (is (thrown-with-data? (value-error-data? [:types :boolean])
+                             (prefs/set! p [:types] {:boolean "not-a-boolean"})))
+      (are [path value] (thrown-with-data? (value-error-data? path) (prefs/set! p path value))
+        [:types :boolean] "not-a-boolean"
+        [:types :string] 12
+        [:types :keyword] "not-a-keyword"
+        [:types :integer] "not-an-int"
+        [:types :number] "NaN"
+        [:types :array] true
+        [:types :set] false
+        [:types :enum] 12
+        [:types :tuple] nil
+        [:types :object-of] {:foo :bar}
+        [:types :one-of] true)
+      ;; No invalid changes are recorded
       (is (= {:types {:any 'foo/bar
                       :boolean false
-                      :string "STILL A STRING"
+                      :string "str"
                       :keyword :something
                       :integer 42
                       :number 42
                       :array ["heh"]
                       :set #{"heh"}
                       :enum :bar
-                      :tuple ["/game.project" :form-view]}}
+                      :tuple ["/game.project" :form-view]
+                      :object-of {"foo" "bar"}
+                      :one-of "foo"}}
              (prefs/get p []))))))
 
 (deftest get-unregistered-key-test
@@ -107,7 +146,7 @@
     (let [p (prefs/make :scopes {:global (fs/create-temp-file! "global" "test.editor_settings")}
                         :schemas [::unregistered-key])]
       (is (= {:name ""} (prefs/get p [])))
-      (is (nil? (prefs/get p [:undefined]))))))
+      (is (thrown-with-data? (path-error-data? [:undefined]) (prefs/get p [:undefined]))))))
 
 (deftest utf8-handling-test
   (with-schemas {::utf8 {:type :string}}
@@ -250,3 +289,133 @@
         (prefs/set! p-num [:timeout] 10.0)
         (is (= 10.0 (prefs/get p-num [:timeout])))
         (is (= "" (prefs/get p-str [:timeout])))))))
+
+(deftest schema-merge-test
+  (testing "no conflicts"
+    (let [conflicts (atom {})]
+      (is (= {:type :object
+              :properties {:only-in-a {:type :string}
+                           :only-in-b {:type :string}}}
+             (prefs/merge-schemas
+               (fn [a b path]
+                 (swap! conflicts assoc path [a b])
+                 a)
+               {:type :object
+                :properties {:only-in-a {:type :string}}}
+               {:type :object
+                :properties {:only-in-b {:type :string}}})))
+      (is (= {} @conflicts))))
+  (testing "a conflict: prefer left"
+    ;; left -> integer, right -> string
+    (let [conflicts (atom {})]
+      (is (= {:type :object
+              :properties {:only-in-a {:type :string}
+                           :only-in-b {:type :string}
+                           :present-in-both {:type :integer}}}
+             (prefs/merge-schemas
+               (fn [a b path]
+                 (swap! conflicts assoc path [a b])
+                 a)
+               {:type :object
+                :properties {:only-in-a {:type :string}
+                             :present-in-both {:type :integer}}}
+               {:type :object
+                :properties {:present-in-both {:type :string}
+                             :only-in-b {:type :string}}})))
+      (is (= {[:present-in-both] [{:type :integer} {:type :string}]} @conflicts))))
+  (testing "a conflict: prefer right"
+    ;; left -> integer, right -> string
+    (let [conflicts (atom {})]
+      (is (= {:type :object
+              :properties {:only-in-a {:type :string}
+                           :only-in-b {:type :string}
+                           :present-in-both {:type :string}}}
+             (prefs/merge-schemas
+               (fn [a b path]
+                 (swap! conflicts assoc path [a b])
+                 b)
+               {:type :object
+                :properties {:only-in-a {:type :string}
+                             :present-in-both {:type :integer}}}
+               {:type :object
+                :properties {:present-in-both {:type :string}
+                             :only-in-b {:type :string}}})))
+      (is (= {[:present-in-both] [{:type :integer} {:type :string}]} @conflicts))))
+  (testing "a conflict: exclude"
+    ;; left -> integer, right -> string
+    (let [conflicts (atom {})]
+      (is (= {:type :object
+              :properties {:only-in-a {:type :string}
+                           :only-in-b {:type :string}}}
+             (prefs/merge-schemas
+               (fn [a b path]
+                 (swap! conflicts assoc path [a b])
+                 nil)
+               {:type :object
+                :properties {:only-in-a {:type :string}
+                             :present-in-both {:type :integer}}}
+               {:type :object
+                :properties {:present-in-both {:type :string}
+                             :only-in-b {:type :string}}})))
+      (is (= {[:present-in-both] [{:type :integer} {:type :string}]} @conflicts)))))
+
+(deftest schema-difference-test
+  (testing "no conflict"
+    (let [conflicts (atom {})]
+      (is (= {:type :object
+              :properties {:only-in-a {:type :string}}}
+             (prefs/difference-schemas
+               (fn [a b path]
+                 (swap! conflicts assoc path [a b]))
+               {:type :object
+                :properties {:only-in-a {:type :string}}}
+               {:type :object
+                :properties {:only-in-b {:type :string}}})))
+      (is (= {} @conflicts))))
+  (testing "top-level conflict"
+    (let [conflicts (atom {})]
+      (is (nil?
+            (prefs/difference-schemas
+              (fn [a b path]
+                (swap! conflicts assoc path [a b]))
+              {:type :integer}
+              {:type :string})))
+      (is (= {[] [{:type :integer} {:type :string}]}
+             @conflicts))))
+  (testing "depth-1 conflict"
+    (let [conflicts (atom {})]
+      (is (= {:type :object
+              :properties {:only-in-a {:type :string}}}
+             (prefs/difference-schemas
+               (fn [a b path]
+                 (swap! conflicts assoc path [a b]))
+               {:type :object
+                :properties {:only-in-a {:type :string}
+                             :present-in-both {:type :integer}}}
+               {:type :object
+                :properties {:only-in-b {:type :string}
+                             :present-in-both {:type :string}}})))
+      (is (= {[:present-in-both] [{:type :integer} {:type :string}]}
+             @conflicts))))
+  (testing "depth-2 conflict"
+    (let [conflicts (atom {})]
+      (is (= {:type :object
+              :properties {:only-in-a {:type :string}
+                           :present-in-both {:type :object
+                                             :properties {:only-in-a {:type :boolean}}}}}
+             (prefs/difference-schemas
+               (fn [a b path]
+                 (swap! conflicts assoc path [a b]))
+               {:type :object
+                :properties {:only-in-a {:type :string}
+                             :present-in-both {:type :object
+                                               :properties {:only-in-a {:type :boolean}
+                                                            :conflict {:type :integer}}}}}
+               {:type :object
+                :properties {:only-in-b {:type :string}
+                             :present-in-both {:type :object
+                                               :properties {:conflict {:type :string}}}}})))
+      (is (= {[:present-in-both :conflict] [{:type :integer} {:type :string}]}
+             @conflicts)))))
+
+

--- a/editor/test/editor/prefs_test.clj
+++ b/editor/test/editor/prefs_test.clj
@@ -62,10 +62,7 @@
                                                             :set {:type :set :item {:type :string}}
                                                             :enum {:type :enum :values [:foo :bar]}
                                                             :tuple {:type :tuple :items [{:type :string} {:type :keyword :default :code-view}]}
-                                                            :object-of {:type :object-of :key {:type :string} :val {:type :string}}
-                                                            :one-of {:type :one-of
-                                                                     :schemas [{:type :enum :values [nil]}
-                                                                               {:type :string}]}}}}}}
+                                                            :object-of {:type :object-of :key {:type :string} :val {:type :string}}}}}}}
     (let [p (prefs/make :scopes {:global (fs/create-temp-file! "global" "test.editor_settings")}
                         :schemas [::types])]
       ;; ensure defaults are properly typed
@@ -79,8 +76,7 @@
                       :set #{}
                       :enum :foo
                       :tuple ["" :code-view]
-                      :object-of {}
-                      :one-of nil}}
+                      :object-of {}}}
              (prefs/get p [])))
       ;; change values
       (prefs/set! p [] {:types {:any 'foo/bar
@@ -93,8 +89,7 @@
                                 :set #{"heh"}
                                 :enum :bar
                                 :tuple ["/game.project" :form-view]
-                                :object-of {"foo" "bar"}
-                                :one-of "foo"}})
+                                :object-of {"foo" "bar"}}})
       ;; ensure updated values are as expected
       (is (= {:types {:any 'foo/bar
                       :boolean false
@@ -106,8 +101,7 @@
                       :set #{"heh"}
                       :enum :bar
                       :tuple ["/game.project" :form-view]
-                      :object-of {"foo" "bar"}
-                      :one-of "foo"}}
+                      :object-of {"foo" "bar"}}}
              (prefs/get p [])))
       ;; set to invalid values
       (is (thrown-with-data? (value-error-data? [:types :boolean])
@@ -124,8 +118,7 @@
         [:types :set] false
         [:types :enum] 12
         [:types :tuple] nil
-        [:types :object-of] {:foo :bar}
-        [:types :one-of] true)
+        [:types :object-of] {:foo :bar})
       ;; No invalid changes are recorded
       (is (= {:types {:any 'foo/bar
                       :boolean false
@@ -137,8 +130,7 @@
                       :set #{"heh"}
                       :enum :bar
                       :tuple ["/game.project" :form-view]
-                      :object-of {"foo" "bar"}
-                      :one-of "foo"}}
+                      :object-of {"foo" "bar"}}}
              (prefs/get p []))))))
 
 (deftest get-unregistered-key-test
@@ -364,7 +356,7 @@
     (let [conflicts (atom {})]
       (is (= {:type :object
               :properties {:only-in-a {:type :string}}}
-             (prefs/difference-schemas
+             (prefs/subtract-schemas
                (fn [a b path]
                  (swap! conflicts assoc path [a b]))
                {:type :object
@@ -375,7 +367,7 @@
   (testing "top-level conflict"
     (let [conflicts (atom {})]
       (is (nil?
-            (prefs/difference-schemas
+            (prefs/subtract-schemas
               (fn [a b path]
                 (swap! conflicts assoc path [a b]))
               {:type :integer}
@@ -386,7 +378,7 @@
     (let [conflicts (atom {})]
       (is (= {:type :object
               :properties {:only-in-a {:type :string}}}
-             (prefs/difference-schemas
+             (prefs/subtract-schemas
                (fn [a b path]
                  (swap! conflicts assoc path [a b]))
                {:type :object
@@ -403,7 +395,7 @@
               :properties {:only-in-a {:type :string}
                            :present-in-both {:type :object
                                              :properties {:only-in-a {:type :boolean}}}}}
-             (prefs/difference-schemas
+             (prefs/subtract-schemas
                (fn [a b path]
                  (swap! conflicts assoc path [a b]))
                {:type :object

--- a/editor/test/integration/editor_extensions_test.clj
+++ b/editor/test/integration/editor_extensions_test.clj
@@ -16,14 +16,17 @@
   (:require [clojure.string :as string]
             [clojure.test :refer :all]
             [dynamo.graph :as g]
+            [editor.defold-project :as project]
             [editor.editor-extensions :as extensions]
             [editor.editor-extensions.coerce :as coerce]
+            [editor.editor-extensions.prefs-functions :as prefs-functions]
             [editor.editor-extensions.runtime :as rt]
             [editor.editor-extensions.vm :as vm]
             [editor.future :as future]
             [editor.graph-util :as gu]
             [editor.handler :as handler]
             [editor.pipeline.bob :as bob]
+            [editor.prefs :as prefs]
             [editor.process :as process]
             [editor.resource :as resource]
             [editor.ui :as ui]
@@ -272,15 +275,21 @@
         (when (or (:error ret) (:exception ret))
           (throw (LuaError. "Bob invocation failed")))))))
 
+(defn- reload-editor-scripts! [project & {:keys [display-output! open-resource! prefs]
+                                          :or {display-output! println
+                                               open-resource! open-resource-noop!}}]
+  (extensions/reload! project :all
+                      :prefs (or prefs (test-util/make-test-prefs))
+                      :reload-resources! (make-reload-resources-fn (project/workspace project))
+                      :display-output! display-output!
+                      :save! (make-save-fn project)
+                      :open-resource! open-resource!
+                      :invoke-bob! (make-invoke-bob-fn project)))
+
 (deftest editor-scripts-commands-test
   (test-util/with-loaded-project "test/resources/editor_extensions/commands_project"
     (let [sprite-outline (:node-id (test-util/outline (test-util/resource-node project "/main/main.collection") [0 0]))]
-      (extensions/reload! project :all
-                          :reload-resources! (make-reload-resources-fn workspace)
-                          :display-output! println
-                          :save! (make-save-fn project)
-                          :open-resource! open-resource-noop!
-                          :invoke-bob! (make-invoke-bob-fn project))
+      (reload-editor-scripts! project)
       (let [handler+context (handler/active
                               (:command (first (handler/realize-menu :editor.outline-view/context-menu-end)))
                               (handler/eval-contexts
@@ -302,12 +311,7 @@
 (deftest refresh-context-after-write-test
   (test-util/with-loaded-project "test/resources/editor_extensions/refresh_context_project"
     (let [output (atom [])
-          _ (extensions/reload! project :all
-                                :reload-resources! (make-reload-resources-fn workspace)
-                                :display-output! #(swap! output conj [%1 %2])
-                                :save! (make-save-fn project)
-                                :open-resource! open-resource-noop!
-                                :invoke-bob! (make-invoke-bob-fn project))
+          _ (reload-editor-scripts! project :display-output! #(swap! output conj [%1 %2]))
           handler+context (handler/active
                             (:command (first (handler/realize-menu :editor.asset-browser/context-menu-end)))
                             (handler/eval-contexts
@@ -324,22 +328,21 @@
       (is (= [[:out "old = Initial content, new = Another text!, reverted = Initial content"]]
              @output)))))
 
+(defn- run-edit-menu-test-command! []
+  (let [handler+context (handler/active
+                          (:command (last (handler/realize-menu :editor.app-view/edit-end)))
+                          (handler/eval-contexts
+                            [(handler/->context :global {} (->StaticSelection []))]
+                            false)
+                          {})]
+    (assert handler+context "Test bug: undefined test command")
+    @(handler/run handler+context)))
+
 (deftest execute-test
   (test-util/with-loaded-project "test/resources/editor_extensions/execute_test"
-    (let [output (atom [])
-          _ (extensions/reload! project :all
-                                :reload-resources! (make-reload-resources-fn workspace)
-                                :display-output! #(swap! output conj [%1 %2])
-                                :save! (make-save-fn project)
-                                :open-resource! open-resource-noop!
-                                :invoke-bob! (make-invoke-bob-fn project))
-          handler+context (handler/active
-                            (:command (last (handler/realize-menu :editor.app-view/edit-end)))
-                            (handler/eval-contexts
-                              [(handler/->context :global {} (->StaticSelection []))]
-                              false)
-                            {})]
-      @(handler/run handler+context)
+    (let [output (atom [])]
+      (reload-editor-scripts! project :display-output! #(swap! output conj [%1 %2]))
+      (run-edit-menu-test-command!)
       ;; see test.editor_script:
       ;; first, it tries to execute `git bleh`, catches the error, then prints it.
       ;; second, it captures the output of `git log --oneline --max-count=10` and
@@ -354,12 +357,7 @@
 (deftest transact-test
   (test-util/with-loaded-project "test/resources/editor_extensions/transact_test"
     (let [output (atom [])
-          _ (extensions/reload! project :all
-                                :reload-resources! (make-reload-resources-fn workspace)
-                                :display-output! #(swap! output conj [%1 %2])
-                                :save! (make-save-fn project)
-                                :open-resource! open-resource-noop!
-                                :invoke-bob! (make-invoke-bob-fn project))
+          _ (reload-editor-scripts! project :display-output! #(swap! output conj [%1 %2]))
           node (:node-id (test-util/outline (test-util/resource-node project "/main/main.collection") [0 0]))
           handler+context (handler/active
                             (:command (first (handler/realize-menu :editor.outline-view/context-menu-end)))
@@ -400,12 +398,7 @@
 (deftest save-test
   (test-util/with-loaded-project "test/resources/editor_extensions/save_test"
     (let [output (atom [])
-          _ (extensions/reload! project :all
-                                :reload-resources! (make-reload-resources-fn workspace)
-                                :display-output! #(swap! output conj [%1 %2])
-                                :save! (make-save-fn project)
-                                :open-resource! open-resource-noop!
-                                :invoke-bob! (make-invoke-bob-fn project))
+          _ (reload-editor-scripts! project :display-output! #(swap! output conj [%1 %2]))
           handler+context (handler/active
                             (:command (first (handler/realize-menu :editor.asset-browser/context-menu-end)))
                             (handler/eval-contexts
@@ -420,20 +413,9 @@
 
 (deftest resource-attributes-test
   (test-util/with-loaded-project "test/resources/editor_extensions/resource_attributes_project"
-    (let [output (atom [])
-          _ (extensions/reload! project :all
-                                :reload-resources! (make-reload-resources-fn workspace)
-                                :display-output! #(swap! output conj [%1 %2])
-                                :save! (make-save-fn project)
-                                :open-resource! open-resource-noop!
-                                :invoke-bob! (make-invoke-bob-fn project))
-          handler+context (handler/active
-                            (:command (last (handler/realize-menu :editor.app-view/edit-end)))
-                            (handler/eval-contexts
-                              [(handler/->context :global {} (->StaticSelection []))]
-                              false)
-                            {})]
-      @(handler/run handler+context)
+    (let [output (atom [])]
+      (reload-editor-scripts! project :display-output! #(swap! output conj [%1 %2]))
+      (run-edit-menu-test-command!)
       ;; see test.editor script: it uses editor.resource_attributes with different resource
       ;; paths and prints results
       (is (= [[:out "test '/': exists = true, file = false, directory = true)"]
@@ -444,21 +426,11 @@
 
 (deftest open-resource-test
   (test-util/with-loaded-project "test/resources/editor_extensions/open_resource_project"
-    (let [output (atom [])
-          _ (extensions/reload! project :all
-                                :reload-resources! (make-reload-resources-fn workspace)
-                                :display-output! #(swap! output conj [%1 %2])
-                                :save! (make-save-fn project)
-                                :open-resource! (fn [resource]
-                                                  (swap! output conj [:open-resource (resource/proj-path resource)]))
-                                :invoke-bob! (make-invoke-bob-fn project))
-          handler+context (handler/active
-                            (:command (last (handler/realize-menu :editor.app-view/edit-end)))
-                            (handler/eval-contexts
-                              [(handler/->context :global {} (->StaticSelection []))]
-                              false)
-                            {})]
-      @(handler/run handler+context)
+    (let [output (atom [])]
+      (reload-editor-scripts! project
+                              :display-output! #(swap! output conj [%1 %2])
+                              :open-resource! #(swap! output conj [:open-resource (resource/proj-path %)]))
+      (run-edit-menu-test-command!)
       ;; see test.editor script: it uses editor.open_resource with different resource
       ;; paths and prints results
       (is (= [[:open-resource "/game.project"]
@@ -479,6 +451,12 @@
         (is (identical? foo-str (coerce enum "foo")))
         (is (= :bar (coerce enum "bar")))
         (is (thrown? LuaError (coerce enum "something else")))))
+
+    (testing "const"
+      (let [foo-str "foo"
+            const (coerce/const foo-str)]
+        (is (identical? foo-str (coerce const "foo")))
+        (is (thrown? LuaError (coerce const 12)))))
 
     (testing "string"
       (is (= "foo" (coerce coerce/string "foo")))
@@ -587,7 +565,11 @@
       (is (= {:a 1 :b 2} (coerce (coerce/hash-map
                                    :req {:a coerce/integer}
                                    :opt {:b coerce/integer})
-                                 {:a 1 :b 2}))))
+                                 {:a 1 :b 2})))
+      (is (thrown? LuaError (coerce (coerce/hash-map :extra-keys false) {:a 1})))
+      (is (thrown? LuaError (coerce (coerce/hash-map :opt {:b coerce/integer} :extra-keys false) {:a 1})))
+      (is (= {:a 1} (coerce (coerce/hash-map :opt {:a coerce/integer} :extra-keys false) {:a 1})))
+      (is (= {:a 1} (coerce (coerce/hash-map :req {:a coerce/integer} :extra-keys false) {:a 1}))))
 
     (testing "one-of"
       (is (= "foo" (coerce (coerce/one-of coerce/string coerce/integer) "foo")))
@@ -611,20 +593,9 @@
 
 (deftest external-file-attributes-test
   (test-util/with-loaded-project "test/resources/editor_extensions/external_file_attributes_project"
-    (let [output (atom [])
-          _ (extensions/reload! project :all
-                                :reload-resources! (make-reload-resources-fn workspace)
-                                :display-output! #(swap! output conj [%1 %2])
-                                :save! (make-save-fn project)
-                                :open-resource! open-resource-noop!
-                                :invoke-bob! (make-invoke-bob-fn project))
-          handler+context (handler/active
-                            (:command (last (handler/realize-menu :editor.app-view/edit-end)))
-                            (handler/eval-contexts
-                              [(handler/->context :global {} (->StaticSelection []))]
-                              false)
-                            {})]
-      @(handler/run handler+context)
+    (let [output (atom [])]
+      (reload-editor-scripts! project :display-output! #(swap! output conj [%1 %2]))
+      (run-edit-menu-test-command!)
       ;; see test.editor_script: it uses editor.external_file_attributes() to
       ;; get fs information about 3 paths, and then prints it
       (is (= [[:out "path = '.', exists = true, file = false, directory = true"]
@@ -634,21 +605,126 @@
 
 (deftest ui-test
   (test-util/with-loaded-project "test/resources/editor_extensions/ui_project"
-    (let [output (atom [])
-          _ (extensions/reload! project :all
-                                :reload-resources! (make-reload-resources-fn workspace)
-                                :display-output! #(swap! output conj [%1 %2])
-                                :save! (make-save-fn project)
-                                :open-resource! open-resource-noop!
-                                :invoke-bob! (make-invoke-bob-fn project))
-          handler+context (handler/active
-                            (:command (last (handler/realize-menu :editor.app-view/edit-end)))
-                            (handler/eval-contexts
-                              [(handler/->context :global {} (->StaticSelection []))]
-                              false)
-                            {})]
-      @(handler/run handler+context)
+    (let [output (atom [])]
+      (reload-editor-scripts! project :display-output! #(swap! output conj [%1 %2]))
+      (run-edit-menu-test-command!)
       ;; see test.editor_script: it creates a lot of ui components that should
       ;; form a valid UI tree. In case of any errors the output will get error
       ;; entries.
       (is (= [] @output)))))
+
+(deftest prefs-round-trip-test
+  (test-util/with-loaded-project "test/resources/editor_extensions/prefs_round_trip_project"
+    (let [output (atom [])
+          prefs (prefs/project
+                  "test/resources/editor_extensions/prefs_round_trip_project"
+                  (prefs/global test-util/shared-test-prefs-file))
+          _ (reload-editor-scripts! project
+                                    :prefs prefs
+                                    :display-output! #(swap! output conj [%1 %2]))
+          all-keys (mapv (comp name key) (:properties (prefs/schema prefs [])))
+          _ (prefs/set! prefs [:test :prefs-keys] all-keys)
+          initial-prefs (prefs/get prefs [])
+          ;; See test.editor_script: it iterates over every 'test.prefs-keys'
+          ;; preference, gets the value, and then sets the same value back.
+          ;; This get->set->get round-tripping should not cause any errors, and
+          ;; should not change any values
+          _ (run-edit-menu-test-command!)]
+      ;; no output => no runtime errors
+      (is (= [] @output))
+      ;; the prefs are unchanged
+      (is (= initial-prefs (prefs/get prefs []))))))
+
+(deftest prefs-set-test
+  (test-util/with-loaded-project "test/resources/editor_extensions/prefs_get_set_test"
+    (let [output (atom [])
+          prefs (prefs/project
+                  "test/resources/editor_extensions/prefs_get_set_test"
+                  (prefs/global test-util/shared-test-prefs-file))]
+      (reload-editor-scripts! project
+                              :prefs prefs
+                              :display-output! #(swap! output conj [%1 %2]))
+      (run-edit-menu-test-command!)
+      ;; See test.editor_script: it defines prefs for every available schema,
+      ;; then, for every pref it sets a value, gets it and prints it (possibly
+      ;; with some metadata), then sets it to another value, and then gets and
+      ;; prints it again
+      (is (= [[:out "array: table 0"]
+              [:out "array: table 2 foo bar"]
+              [:out "boolean: boolean false"]
+              [:out "boolean: boolean true"]
+              [:out "enum: number 1"]
+              [:out "enum: string foo"]
+              [:out "integer: 42"]
+              [:out "integer: 43"]
+              [:out "keyword: string foo-bar"]
+              [:out "keyword: string code-view"]
+              [:out "number: 12.3"]
+              [:out "number: 0.1"]
+              [:out "object: table foo"]
+              [:out "object: table bar"]
+              [:out "object: table baz"]
+              [:out "object of: table foo = true, bar = false"]
+              [:out "object of: table foo = false, bar = true"]
+              [:out "one_of: number 1"]
+              [:out "one_of: string foo"]
+              [:out "set: table foo = true, bar = true"]
+              [:out "set: table foo = true, bar = nil"]
+              [:out "string: a string"]
+              [:out "string: another_string"]
+              [:out "tuple: a string 12"]
+              [:out "tuple: another string 42"]]
+             @output)))))
+
+(deftest prefs-schema-test
+  (test-util/with-loaded-project "test/resources/editor_extensions/prefs_schema_errors"
+    (let [output (atom [])
+          prefs (prefs/project
+                  "test/resources/editor_extensions/prefs_schema_errors"
+                  (prefs/global test-util/shared-test-prefs-file))]
+      (reload-editor-scripts! project
+                              :prefs prefs
+                              :display-output! #(swap! output conj [%1 %2]))
+      (run-edit-menu-test-command!)
+      ;; See the test project:
+      ;; - /not_an_object_schema.editor_script defines a schema that is not
+      ;;   an object
+      ;; - /conflict_a.editor_script and /conflict_b.editor_script define
+      ;;   conflicting schemas
+      ;; - /builtin_conflict.editor_script defines a schema that conflicts with
+      ;;   a built-in editor schema (sets 'bundle' to boolean)
+      ;; - /test.editor_script accesses prefs defined by other editor scripts
+      (is (= #{[:err "Omitting prefs schema definition for path '': '/not_an_object_schema.editor_script' defines a schema that conflicts with the editor schema"]
+               [:err "Omitting prefs schema definition for path 'bundle': '/builtin_conflict.editor_script' defines a schema that conflicts with the editor schema"]
+               [:err "Omitting prefs schema definition for path 'test.conflict': conflicts with another editor script schema"]
+               [:out "pcall(editor.prefs.get, 'test.only-in-a') => true, a"]
+               [:out "pcall(editor.prefs.get, 'test.only-in-b') => true, b"]
+               [:out "pcall(editor.prefs.get, 'test.conflict') => false, No schema defined for prefs path 'test.conflict'"]
+               [:out "pcall(editor.prefs.get, 'bundle.variant') => true, debug"]}
+             (set @output))))))
+
+(deftest prefs-test
+  (testing "dot-separated paths parsing"
+    (are [s path] (= path (prefs-functions/parse-dot-separated-path s))
+      "foo.bar.baz" [:foo :bar :baz]
+      "foo-bar.baz" [:foo-bar :baz]
+      "foo-bar_baz" [:foo-bar_baz]
+      "3d" [:3d])
+    (are [s re] (thrown-with-msg? LuaError (re-pattern re) (prefs-functions/parse-dot-separated-path s))
+      "" "Key path element cannot be empty"
+      "." "Key path element cannot be empty"
+      "foo." "Key path element cannot be empty"
+      ".foo" "Key path element cannot be empty"
+      "foo..bar" "Key path element cannot be empty"
+      "foo.bar..." "Key path element cannot be empty"
+
+      "with space" "Invalid identifier character"
+      "brace{" "Invalid identifier character"
+      "brace[" "Invalid identifier character"
+      ":colon" "Invalid identifier character"
+      "hash#" "Invalid identifier character"
+      "hash#" "Invalid identifier character"
+      "\\backslash" "Invalid identifier character"
+      "/slash" "Invalid identifier character"
+      "^hat" "Invalid identifier character"
+      "%percent" "Invalid identifier character")))

--- a/editor/test/integration/editor_extensions_test.clj
+++ b/editor/test/integration/editor_extensions_test.clj
@@ -666,8 +666,6 @@
               [:out "object: table baz"]
               [:out "object of: table foo = true, bar = false"]
               [:out "object of: table foo = false, bar = true"]
-              [:out "one_of: number 1"]
-              [:out "one_of: string foo"]
               [:out "set: table foo = true, bar = true"]
               [:out "set: table foo = true, bar = nil"]
               [:out "string: a string"]

--- a/editor/test/integration/test_util.clj
+++ b/editor/test/integration/test_util.clj
@@ -183,7 +183,7 @@
 (defn make-build-stage-test-prefs []
   (prefs/global "test/resources/test.editor_settings"))
 
-(defonce ^:private shared-test-prefs-file (fs/create-temp-file! "unit-test" "prefs.editor_settings"))
+(defonce shared-test-prefs-file (fs/create-temp-file! "unit-test" "prefs.editor_settings"))
 (defn make-test-prefs []
   (prefs/make :scopes {:global shared-test-prefs-file :project shared-test-prefs-file}
               :schemas [:default]))

--- a/editor/test/integration/test_util.clj
+++ b/editor/test/integration/test_util.clj
@@ -15,7 +15,7 @@
 (ns integration.test-util
   (:require [clojure.java.io :as io]
             [clojure.string :as string]
-            [clojure.test :refer [is testing]]
+            [clojure.test :as test :refer [is testing]]
             [dynamo.graph :as g]
             [editor.app-view :as app-view]
             [editor.atlas :as atlas]
@@ -1641,3 +1641,16 @@
             save-text (resource-node/save-data-content save-data)]
         ;; Compare text.
         (check-text-equivalence! disk-text save-text message)))))
+
+(defmethod test/assert-expr 'thrown-with-data? [msg [_ expected-data-pred & body :as form]]
+  `(try
+     (do ~@body)
+     (test/do-report {:type :fail :message ~msg :expected '~form :actual nil})
+     (catch Throwable e#
+       (let [actual-data# (ex-data e#)
+             result# (if (~expected-data-pred actual-data#) :pass :fail)]
+         (test/do-report {:type result# :message ~msg :expected '~form :actual e#})
+         e#))))
+
+(defmacro check-thrown-with-data! [expected-data-pred & body]
+  `(is (~'thrown-with-data? ~expected-data-pred ~@body)))

--- a/editor/test/resources/editor_extensions/prefs_get_set_test/.gitignore
+++ b/editor/test/resources/editor_extensions/prefs_get_set_test/.gitignore
@@ -1,0 +1,11 @@
+/.editor_settings
+/.internal
+/build
+.externalToolBuilders
+.DS_Store
+Thumbs.db
+.lock-wscript
+*.pyc
+.project
+.cproject
+builtins

--- a/editor/test/resources/editor_extensions/prefs_get_set_test/game.project
+++ b/editor/test/resources/editor_extensions/prefs_get_set_test/game.project
@@ -1,0 +1,20 @@
+[bootstrap]
+main_collection = /main/main.collectionc
+
+[script]
+shared_state = 1
+
+[display]
+width = 960
+height = 640
+high_dpi = 1
+
+[android]
+input_method = HiddenInputField
+
+[html5]
+scale_mode = stretch
+
+[project]
+title = prefs_get_set_test
+

--- a/editor/test/resources/editor_extensions/prefs_get_set_test/test.editor_script
+++ b/editor/test/resources/editor_extensions/prefs_get_set_test/test.editor_script
@@ -15,10 +15,6 @@ function M.get_prefs_schema()
             key = editor.prefs.schema.keyword(),
             val = editor.prefs.schema.boolean()
         }),
-        ["test.one_of"] = editor.prefs.schema.one_of({schemas = {
-            editor.prefs.schema.integer(),
-            editor.prefs.schema.string()
-        }}),
         ["test.set"] = editor.prefs.schema.set({item = editor.prefs.schema.string()}),
         ["test.string"] = editor.prefs.schema.string(),
         ["test.tuple"] = editor.prefs.schema.tuple({items = {
@@ -90,13 +86,6 @@ function M.get_commands()
             editor.prefs.set("test.object_of", {foo = false, bar = true})
             object_of = editor.prefs.get("test.object_of")
             print(("object of: %s foo = %s, bar = %s"):format(type(object_of), tostring(object_of.foo), tostring(object_of.bar)))
-
-            editor.prefs.set("test.one_of", 1)
-            local one_of = editor.prefs.get("test.one_of")
-            print(("one_of: %s %s"):format(type(one_of), one_of))
-            editor.prefs.set("test.one_of", "foo")
-            one_of = editor.prefs.get("test.one_of")
-            print(("one_of: %s %s"):format(type(one_of), one_of))
 
             editor.prefs.set("test.set", {foo = true, bar = true})
             local set = editor.prefs.get("test.set")

--- a/editor/test/resources/editor_extensions/prefs_get_set_test/test.editor_script
+++ b/editor/test/resources/editor_extensions/prefs_get_set_test/test.editor_script
@@ -1,0 +1,125 @@
+local M = {}
+
+function M.get_prefs_schema()
+    return {
+        ["test.array"] = editor.prefs.schema.array({item = editor.prefs.schema.string()}),
+        ["test.boolean"] = editor.prefs.schema.boolean(),
+        ["test.enum"] = editor.prefs.schema.enum({values = {1, 2, "foo"}}),
+        ["test.integer"] = editor.prefs.schema.integer(),
+        ["test.keyword"] = editor.prefs.schema.keyword(),
+        ["test.number"] = editor.prefs.schema.number(),
+        ["test.object"] = editor.prefs.schema.object({properties = {
+            string = editor.prefs.schema.string()
+        }}),
+        ["test.object_of"] = editor.prefs.schema.object_of({
+            key = editor.prefs.schema.keyword(),
+            val = editor.prefs.schema.boolean()
+        }),
+        ["test.one_of"] = editor.prefs.schema.one_of({schemas = {
+            editor.prefs.schema.integer(),
+            editor.prefs.schema.string()
+        }}),
+        ["test.set"] = editor.prefs.schema.set({item = editor.prefs.schema.string()}),
+        ["test.string"] = editor.prefs.schema.string(),
+        ["test.tuple"] = editor.prefs.schema.tuple({items = {
+            editor.prefs.schema.string(),
+            editor.prefs.schema.integer(),
+        }}),
+    }
+end
+
+function M.get_commands()
+    return {{
+        label = "Test",
+        locations = {"Edit"},
+        run = function()
+            editor.prefs.set("test.array", {})
+            local array = editor.prefs.get("test.array")
+            print(("array: %s %s"):format(type(array), #array))
+            editor.prefs.set("test.array", {"foo", "bar"})
+            array = editor.prefs.get("test.array")
+            print(("array: %s %s %s %s"):format(type(array), #array, array[1], array[2]))
+
+            editor.prefs.set("test.boolean", false)
+            local boolean = editor.prefs.get("test.boolean")
+            print(("boolean: %s %s"):format(type(boolean), tostring(boolean)))
+            editor.prefs.set("test.boolean", true)
+            boolean = editor.prefs.get("test.boolean")
+            print(("boolean: %s %s"):format(type(boolean), tostring(boolean)))
+
+            editor.prefs.set("test.enum", 1)
+            local enum = editor.prefs.get("test.enum")
+            print(("enum: %s %s"):format(type(enum), tostring(enum)))
+            editor.prefs.set("test.enum", "foo")
+            enum = editor.prefs.get("test.enum")
+            print(("enum: %s %s"):format(type(enum), tostring(enum)))
+
+            editor.prefs.set("test.integer", 42)
+            local integer = editor.prefs.get("test.integer")
+            print(("integer: %s"):format(integer))
+            editor.prefs.set("test.integer", 43)
+            print(("integer: %s"):format(editor.prefs.get("test.integer")))
+
+            editor.prefs.set("test.keyword", "foo-bar")
+            local keyword = editor.prefs.get("test.keyword")
+            print(("keyword: %s %s"):format(type(keyword), keyword))
+            editor.prefs.set("test.keyword", "code-view")
+            keyword = editor.prefs.get("test.keyword")
+            print(("keyword: %s %s"):format(type(keyword), keyword))
+
+            editor.prefs.set("test.number", 12.3)
+            local number = editor.prefs.get("test.number")
+            print(("number: %s"):format(number))
+            editor.prefs.set("test.number", 0.1)
+            number = editor.prefs.get("test.number")
+            print(("number: %s"):format(number))
+
+            editor.prefs.set("test.object", {string = "foo"})
+            local object = editor.prefs.get("test.object")
+            print(("object: %s %s"):format(type(object), object.string))
+            editor.prefs.set("test.object", {string = "bar"})
+            object = editor.prefs.get("test.object")
+            print(("object: %s %s"):format(type(object), object.string))
+            editor.prefs.set("test.object.string", "baz")
+            object = editor.prefs.get("test.object")
+            print(("object: %s %s"):format(type(object), object.string))
+
+            editor.prefs.set("test.object_of", {foo = true, bar = false})
+            local object_of = editor.prefs.get("test.object_of")
+            print(("object of: %s foo = %s, bar = %s"):format(type(object_of), tostring(object_of.foo), tostring(object_of.bar)))
+            editor.prefs.set("test.object_of", {foo = false, bar = true})
+            object_of = editor.prefs.get("test.object_of")
+            print(("object of: %s foo = %s, bar = %s"):format(type(object_of), tostring(object_of.foo), tostring(object_of.bar)))
+
+            editor.prefs.set("test.one_of", 1)
+            local one_of = editor.prefs.get("test.one_of")
+            print(("one_of: %s %s"):format(type(one_of), one_of))
+            editor.prefs.set("test.one_of", "foo")
+            one_of = editor.prefs.get("test.one_of")
+            print(("one_of: %s %s"):format(type(one_of), one_of))
+
+            editor.prefs.set("test.set", {foo = true, bar = true})
+            local set = editor.prefs.get("test.set")
+            print(("set: %s foo = %s, bar = %s"):format(type(set), tostring(set.foo), tostring(set.bar)))
+            editor.prefs.set("test.set", {foo = true})
+            set = editor.prefs.get("test.set")
+            print(("set: %s foo = %s, bar = %s"):format(type(set), tostring(set.foo), tostring(set.bar)))
+            
+            editor.prefs.set("test.string", "a string")
+            local string = editor.prefs.get("test.string")
+            print(("string: %s"):format(string))
+            editor.prefs.set("test.string", "another_string")
+            string = editor.prefs.get("test.string")
+            print(("string: %s"):format(string))
+            
+            editor.prefs.set("test.tuple", {"a string", 12})
+            local tuple = editor.prefs.get("test.tuple")
+            print(("tuple: %s %s"):format(tuple[1], tuple[2]))
+            editor.prefs.set("test.tuple", {"another string", 42})
+            tuple = editor.prefs.get("test.tuple")
+            print(("tuple: %s %s"):format(tuple[1], tuple[2]))
+        end
+    }}
+end
+
+return M

--- a/editor/test/resources/editor_extensions/prefs_round_trip_project/.gitignore
+++ b/editor/test/resources/editor_extensions/prefs_round_trip_project/.gitignore
@@ -1,0 +1,11 @@
+/.editor_settings
+/.internal
+/build
+.externalToolBuilders
+.DS_Store
+Thumbs.db
+.lock-wscript
+*.pyc
+.project
+.cproject
+builtins

--- a/editor/test/resources/editor_extensions/prefs_round_trip_project/game.project
+++ b/editor/test/resources/editor_extensions/prefs_round_trip_project/game.project
@@ -1,0 +1,20 @@
+[bootstrap]
+main_collection = /main/main.collectionc
+
+[script]
+shared_state = 1
+
+[display]
+width = 960
+height = 640
+high_dpi = 1
+
+[android]
+input_method = HiddenInputField
+
+[html5]
+scale_mode = stretch
+
+[project]
+title = prefs_get_set_project
+

--- a/editor/test/resources/editor_extensions/prefs_round_trip_project/test.editor_script
+++ b/editor/test/resources/editor_extensions/prefs_round_trip_project/test.editor_script
@@ -1,0 +1,21 @@
+local M = {}
+
+function M.get_commands()
+    return {{
+        label = "Test",
+        locations = {"Edit"},
+        run = function()
+            local keys = editor.prefs.get("test.prefs-keys")
+            for i = 1, #keys do
+                local key = keys[i]
+                editor.prefs.set(key, editor.prefs.get(key))
+            end
+        end
+    }}
+end
+
+function M.get_prefs_schema() 
+    return {["test.prefs-keys"] = editor.prefs.schema.array({item = editor.prefs.schema.string()})}
+end
+
+return M

--- a/editor/test/resources/editor_extensions/prefs_schema_errors/.gitignore
+++ b/editor/test/resources/editor_extensions/prefs_schema_errors/.gitignore
@@ -1,0 +1,11 @@
+/.editor_settings
+/.internal
+/build
+.externalToolBuilders
+.DS_Store
+Thumbs.db
+.lock-wscript
+*.pyc
+.project
+.cproject
+builtins

--- a/editor/test/resources/editor_extensions/prefs_schema_errors/builtin_conflict.editor_script
+++ b/editor/test/resources/editor_extensions/prefs_schema_errors/builtin_conflict.editor_script
@@ -1,0 +1,7 @@
+local M = {}
+
+function M.get_prefs_schema()
+    return {["bundle"] = editor.prefs.schema.boolean()}
+end
+
+return M

--- a/editor/test/resources/editor_extensions/prefs_schema_errors/conflict_a.editor_script
+++ b/editor/test/resources/editor_extensions/prefs_schema_errors/conflict_a.editor_script
@@ -1,0 +1,13 @@
+local M = {}
+
+function M.get_prefs_schema()
+    -- Define preferences that may be used by the editor script
+    -- Learn more: https://defold.com/manuals/editor-scripts/#prefs
+    -- Remove this function if not needed
+    return {
+        ["test.only-in-a"] = editor.prefs.schema.string({default = "a"}),
+        ["test.conflict"] = editor.prefs.schema.string()
+    }
+end
+
+return M

--- a/editor/test/resources/editor_extensions/prefs_schema_errors/conflict_b.editor_script
+++ b/editor/test/resources/editor_extensions/prefs_schema_errors/conflict_b.editor_script
@@ -1,0 +1,10 @@
+local M = {}
+
+function M.get_prefs_schema()
+    return {
+        ["test.only-in-b"] = editor.prefs.schema.string({default = "b"}),
+        ["test.conflict"] = editor.prefs.schema.boolean()
+    }
+end
+
+return M

--- a/editor/test/resources/editor_extensions/prefs_schema_errors/game.project
+++ b/editor/test/resources/editor_extensions/prefs_schema_errors/game.project
@@ -1,0 +1,20 @@
+[bootstrap]
+main_collection = /main/main.collectionc
+
+[script]
+shared_state = 1
+
+[display]
+width = 960
+height = 640
+high_dpi = 1
+
+[android]
+input_method = HiddenInputField
+
+[html5]
+scale_mode = stretch
+
+[project]
+title = prefs_schema_errors
+

--- a/editor/test/resources/editor_extensions/prefs_schema_errors/not_an_object_schema.editor_script
+++ b/editor/test/resources/editor_extensions/prefs_schema_errors/not_an_object_schema.editor_script
@@ -1,0 +1,7 @@
+local M = {}
+
+function M.get_prefs_schema()
+    return editor.prefs.schema.string()
+end
+
+return M

--- a/editor/test/resources/editor_extensions/prefs_schema_errors/test.editor_script
+++ b/editor/test/resources/editor_extensions/prefs_schema_errors/test.editor_script
@@ -1,0 +1,21 @@
+local M = {}
+
+local function print_pref_value(k)
+    local success, error_or_value = pcall(editor.prefs.get, k)
+    print(("pcall(editor.prefs.get, '%s') => %s, %s"):format(k, tostring(success), tostring(error_or_value)))
+end
+
+function M.get_commands()
+    return {{
+        label = "Test",
+        locations = {"Edit"},
+        run = function()
+            print_pref_value("test.only-in-a")
+            print_pref_value("test.only-in-b")
+            print_pref_value("test.conflict")
+            print_pref_value("bundle.variant")
+        end
+    }}
+end
+
+return M


### PR DESCRIPTION
Now editor scripts can define and use preferences — persistent, uncommitted pieces of data stored on the user's computer.

Technical notes:

Now that we expose prefs to editor scripts, I tightened the prefs semantics: `get` on unregistered schema keys throw instead of returning `nil`, invalid `set!` throws instead of silent omission.

Docs PR: https://github.com/defold/doc/pull/493

Related to #8062