### PR TITLE
Setting 'highest available' opengl ctx is not supported on osx

### DIFF
--- a/engine/platform/src/platform_window_opengl.h
+++ b/engine/platform/src/platform_window_opengl.h
@@ -23,7 +23,15 @@ namespace dmPlatform
     {
         uint32_t tmp_major = version / 10;
         uint32_t tmp_minor = version % 10;
-        if (version == 0 ||                                    // Highest available
+
+        bool use_highest_version_supported = true;
+
+        // Osx doesn't support using the "highest version available"
+    #ifdef __MACH__
+        use_highest_version_supported = false;
+    #endif
+
+        if (version == 0 && use_highest_version_supported ||   // Highest available
             (tmp_major == 3 && tmp_minor == 3) ||              // Only 3.3 is supported from 3.x
             (tmp_major == 4 && tmp_minor >= 0 && *minor <= 6)) // Only 4.0 - 4.6 are proper versions
         {

--- a/engine/platform/src/platform_window_opengl.h
+++ b/engine/platform/src/platform_window_opengl.h
@@ -31,7 +31,7 @@ namespace dmPlatform
         use_highest_version_supported = false;
     #endif
 
-        if (version == 0 && use_highest_version_supported ||   // Highest available
+        if ((version == 0 && use_highest_version_supported) ||   // Highest available
             (tmp_major == 3 && tmp_minor == 3) ||              // Only 3.3 is supported from 3.x
             (tmp_major == 4 && tmp_minor >= 0 && *minor <= 6)) // Only 4.0 - 4.6 are proper versions
         {

--- a/engine/tools/src/gdc/main.cpp
+++ b/engine/tools/src/gdc/main.cpp
@@ -105,6 +105,7 @@ int main(int argc, char *argv[])
     window_params.m_Height = 32;
     window_params.m_Title = "gdc";
     window_params.m_PrintDeviceInfo = false;
+    window_params.m_OpenGLVersionHint = 33;
     window_params.m_GraphicsApi = dmPlatform::PLATFORM_GRAPHICS_API_OPENGL;
 
     dmPlatform::HWindow window = dmPlatform::NewWindow();


### PR DESCRIPTION
Fixed an issue where projects using the "use highest available" opengl version hint on OSX caused runtime crashes. Using highest available version on OSX is not supported, so we fallback to the default version in that case instead.

Fixes #9716 