### PR TITLE
Wait for the reload to finish before building

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -1047,8 +1047,8 @@
           (result-fn project-build-results)
           nil)
 
-        phase-6-await-lint!
-        (fn phase-6-await-lint! [project-build-results]
+        phase-7-await-lint!
+        (fn phase-7-await-lint! [project-build-results]
           (if lint
             (do
               (render-progress! (progress/make-indeterminate "Linting code..."))
@@ -1087,12 +1087,12 @@
                     (finish-with-result! project-build-results)))))
             (finish-with-result! project-build-results)))
 
-        phase-5-await-engine-build!
-        (fn phase-5-await-engine-build! [project-build-results]
+        phase-6-await-engine-build!
+        (fn phase-6-await-engine-build! [project-build-results]
           (assert (nil? (:error project-build-results)))
           (let [engine-build-future @engine-build-future-atom]
             (if (nil? engine-build-future)
-              (phase-6-await-lint! project-build-results)
+              (phase-7-await-lint! project-build-results)
               (do
                 (render-progress! (progress/make-indeterminate "Fetching engine..."))
                 (run-on-background-thread!
@@ -1100,15 +1100,15 @@
                     (deref engine-build-future))
                   (fn process-engine-build-results-on-ui-thread! [engine-or-exception]
                     (if (instance? Throwable engine-or-exception)
-                      (phase-6-await-lint!
+                      (phase-7-await-lint!
                         (assoc project-build-results
                           :error (g/with-auto-evaluation-context evaluation-context
                                    (engine-build-errors/exception->error-value engine-or-exception project evaluation-context))))
-                      (phase-6-await-lint!
+                      (phase-7-await-lint!
                         (assoc project-build-results :engine engine-or-exception)))))))))
 
-        phase-4-run-post-build-hook!
-        (fn phase-4-run-post-build-hook! [project-build-results]
+        phase-5-run-post-build-hook!
+        (fn phase-5-run-post-build-hook! [project-build-results]
           (render-progress! (progress/make-indeterminate "Executing post-build hooks..."))
           (let [platform (engine/current-platform)
                 project-build-successful (nil? (:error project-build-results))]
@@ -1120,11 +1120,11 @@
                                            :exception-policy :ignore))
               (fn process-post-build-hook-results-on-ui-thread! [_]
                 (if project-build-successful
-                  (phase-5-await-engine-build! (assoc project-build-results :project-build-successful true))
+                  (phase-6-await-engine-build! (assoc project-build-results :project-build-successful true))
                   (finish-with-result! project-build-results))))))
 
-        phase-3-build-project!
-        (fn phase-3-build-project! []
+        phase-4-build-project!
+        (fn phase-4-build-project! []
           ;; We're about to create an evaluation-context. Make sure it is
           ;; created from the main thread, so it makes sense to update the cache
           ;; from it after the project build concludes. Note that we selectively
@@ -1145,18 +1145,18 @@
                 (project/update-system-cache-build-targets! evaluation-context)
                 (project/log-cache-info! (g/cache) "Cached compiled build targets in system cache.")
                 (cond
-                  run-build-hooks (phase-4-run-post-build-hook! project-build-results)
-                  (nil? (:error project-build-results)) (phase-5-await-engine-build! project-build-results)
+                  run-build-hooks (phase-5-run-post-build-hook! project-build-results)
+                  (nil? (:error project-build-results)) (phase-6-await-engine-build! project-build-results)
                   :else (finish-with-result! project-build-results))))))
 
-        phase-2-start-all-build-processes!
-        (fn phase-2-start-all-build-processes! []
+        phase-3-start-all-build-processes!
+        (fn phase-3-start-all-build-processes! []
           (start-engine-build!)
           (start-lint!)
-          (phase-3-build-project!))
+          (phase-4-build-project!))
 
-        phase-1-run-pre-build-hook!
-        (fn phase-1-run-pre-build-hook! []
+        phase-2-run-pre-build-hook!
+        (fn phase-2-run-pre-build-hook! []
           (render-progress! (progress/make-indeterminate "Executing pre-build hooks..."))
           (let [platform (engine/current-platform)]
             (run-on-background-thread!
@@ -1178,7 +1178,17 @@
               (fn process-pre-build-hook-results-on-ui-thread! [extension-error]
                 (if (some? extension-error)
                   (finish-with-result! {:error extension-error})
-                  (phase-2-start-all-build-processes!))))))]
+                  (phase-3-start-all-build-processes!))))))
+
+        phase-1-await-current-reload!
+        (fn phase-1-await-current-reload! []
+          (run-on-background-thread!
+            disk/await-current-reload
+            (fn start-the-build-process-on-ui-thread! [_]
+              (if run-build-hooks
+                (phase-2-run-pre-build-hook!)
+                (phase-3-start-all-build-processes!)))))]
+
     ;; Trigger phase 1. Subsequent phases will be triggered as prior phases
     ;; finish without errors. Each phase will do some work on a background
     ;; thread, then process the results on the ui thread, and potentially
@@ -1186,9 +1196,7 @@
     ;; soon as they can.
     (assert (not @build-in-progress-atom))
     (reset! build-in-progress-atom true)
-    (if run-build-hooks
-      (phase-1-run-pre-build-hook!)
-      (phase-2-start-all-build-processes!))))
+    (phase-1-await-current-reload!)))
 
 (defn- handle-build-results! [workspace render-build-error! build-results]
   (let [{:keys [error warning artifact-map etags project-build-successful]} build-results

--- a/editor/src/clj/editor/disk.clj
+++ b/editor/src/clj/editor/disk.clj
@@ -117,6 +117,11 @@
 
 (def ^:private blocking-reload! (partial blocking-job! reload-job-atom start-reload-job!))
 
+(defn await-current-reload
+  "If a reload is in progress, blocks until done; otherwise returns immediately"
+  []
+  (some-> @reload-job-atom deref))
+
 ;; -----------------------------------------------------------------------------
 ;; Save
 ;; -----------------------------------------------------------------------------

--- a/editor/test/editor/analytics_test.clj
+++ b/editor/test/editor/analytics_test.clj
@@ -73,14 +73,15 @@
   (let [validation-messages (let [validation-messages-atom (atom [])]
                               (with-redefs [analytics/get-response-code! (partial get-response-code-and-append-validation-messages! validation-messages-atom)
                                             sys/defold-version (constantly "0.1.234")]
-                                (with-config! {:cid mock-cid}
-                                  (analytics/start! validation-server-url send-interval)
-                                  (analytics/track-event! "test-category" "test-action")
-                                  (analytics/track-event! "test-category" "test-action" "test-label")
-                                  (analytics/track-exception! (NullPointerException.))
-                                  (analytics/track-screen! "test-screen-name")
-                                  (analytics/shutdown! shutdown-timeout)
-                                  @validation-messages-atom)))]
+                                (log/without-logging
+                                  (with-config! {:cid mock-cid}
+                                    (analytics/start! validation-server-url send-interval)
+                                    (analytics/track-event! "test-category" "test-action")
+                                    (analytics/track-event! "test-category" "test-action" "test-label")
+                                    (analytics/track-exception! (NullPointerException.))
+                                    (analytics/track-screen! "test-screen-name")
+                                    (analytics/shutdown! shutdown-timeout)
+                                    @validation-messages-atom))))]
     (is (= 0 (count validation-messages)))))
 
 (deftest send-error-test


### PR DESCRIPTION
When the user focuses on the editor, it performs a resource reload. On large projects this may take a while, and if the user starts a build, the build will use outdated resources. This change fixes the issue by waiting for the reload to finish before starting the build.

Fixes #6681
