### PR TITLE
Enable instanced arrays on WebGL 1.0

### DIFF
--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -1246,6 +1246,12 @@ static void LogFrameBufferError(GLenum status)
                 context->m_TextureFormatSupport |= 1 << TEXTURE_FORMAT_RGB32F;
                 context->m_TextureFormatSupport |= 1 << TEXTURE_FORMAT_RGBA32F;
             }
+
+            // https://registry.khronos.org/webgl/extensions/ANGLE_instanced_arrays/
+            if (OpenGLIsExtensionSupported(context, "ANGLE_instanced_arrays"))
+            {
+                context->m_InstancingSupport = 1;
+            }
         }
 
         // GL_NUM_COMPRESSED_TEXTURE_FORMATS is deprecated in newer OpenGL Versions


### PR DESCRIPTION
WebGL 1.0 now also supports instanced arrays if the appropriate `ANGLE_instanced_arrays` extension is available on the user's device.

Fixes https://github.com/defold/defold/issues/9729
