### PR TITLE
Use dmHashBuffer64 instead of dmHashString64 where string length is known

### DIFF
--- a/engine/dlib/src/dlib/http_cache.cpp
+++ b/engine/dlib/src/dlib/http_cache.cpp
@@ -417,11 +417,12 @@ namespace dmHttpCache
             return RESULT_INVAL;
         }
 
-        uint64_t uri_hash = dmHashString64(uri);
+        size_t uri_length = strlen(uri);
+        uint64_t uri_hash = dmHashBuffer64(uri, uri_length);
 
         HashState64 hash_state;
         dmHashInit64(&hash_state, false);
-        dmHashUpdateBuffer64(&hash_state, uri, strlen(uri));
+        dmHashUpdateBuffer64(&hash_state, uri, uri_length);
         dmHashUpdateBuffer64(&hash_state, etag, strlen(etag));
         uint64_t identifier_hash = dmHashFinal64(&hash_state);
 
@@ -670,13 +671,14 @@ namespace dmHttpCache
     {
         dmMutex::ScopedLock lock(cache->m_Mutex);
 
+        size_t uri_length = strlen(uri);
         HashState64 hash_state;
         dmHashInit64(&hash_state, false);
-        dmHashUpdateBuffer64(&hash_state, uri, strlen(uri));
+        dmHashUpdateBuffer64(&hash_state, uri, uri_length);
         dmHashUpdateBuffer64(&hash_state, etag, strlen(etag));
         uint64_t identifier_hash = dmHashFinal64(&hash_state);
 
-        uint64_t uri_hash = dmHashString64(uri);
+        uint64_t uri_hash = dmHashBuffer64(uri, uri_length);
         Entry* entry = cache->m_CacheTable.Get(uri_hash);
         if (entry != 0 && entry->m_Info.m_IdentifierHash == identifier_hash)
         {
@@ -738,13 +740,14 @@ namespace dmHttpCache
     {
         dmMutex::ScopedLock lock(cache->m_Mutex);
 
+        size_t uri_length = strlen(uri);
         HashState64 hash_state;
         dmHashInit64(&hash_state, false);
-        dmHashUpdateBuffer64(&hash_state, uri, strlen(uri));
+        dmHashUpdateBuffer64(&hash_state, uri, uri_length);
         dmHashUpdateBuffer64(&hash_state, etag, strlen(etag));
         uint64_t identifier_hash = dmHashFinal64(&hash_state);
 
-        uint64_t uri_hash = dmHashString64(uri);
+        uint64_t uri_hash = dmHashBuffer64(uri, uri_length);
         Entry* entry = cache->m_CacheTable.Get(uri_hash);
         assert(entry);
         assert(entry->m_Info.m_IdentifierHash == identifier_hash);

--- a/engine/dlib/src/dlib/ssdp.cpp
+++ b/engine/dlib/src/dlib/ssdp.cpp
@@ -596,10 +596,14 @@ bail:
 
         char key[64];
         key[sizeof(key)-1] = '\0'; // Ensure NULL termination
+        uint32_t key_length = 0;
         for (uint32_t i = 0; i < sizeof(key); ++i) {
             key[i] = toupper(orig_key[i]);
             if (key[i] == '\0')
+            {
+                key_length = i;
                 break;
+            }
         }
 
         if (strcmp(key, "CACHE-CONTROL") == 0)
@@ -619,7 +623,7 @@ bail:
             state->m_NTSHash = dmHashString64(value);
         }
 
-        dmhash_t key_hash = dmHashString64(key);
+        dmhash_t key_hash = dmHashBuffer64(key, key_length);
         state->m_Headers.Put(key_hash, strdup(value));
     }
 

--- a/engine/gameobject/src/gameobject/gameobject.cpp
+++ b/engine/gameobject/src/gameobject/gameobject.cpp
@@ -969,8 +969,8 @@ namespace dmGameObject
     dmhash_t ConstructInstanceId(uint32_t index)
     {
         char buffer[16] = { 0 };
-        dmSnPrintf(buffer, sizeof(buffer), "%sinstance%d", ID_SEPARATOR, index);
-        return dmHashString64(buffer);
+        int length = dmSnPrintf(buffer, sizeof(buffer), "%sinstance%d", ID_SEPARATOR, index);
+        return dmHashBuffer64(buffer, length);
     }
 
     uint32_t AcquireInstanceIndex(HCollection hcollection)

--- a/engine/gameobject/src/gameobject/gameobject_props_lua.cpp
+++ b/engine/gameobject/src/gameobject/gameobject_props_lua.cpp
@@ -223,7 +223,9 @@ namespace dmGameObject
             if (lua_isstring(L, -2))
             {
                 void* userdata = 0;
-                dmhash_t id = dmHashString64(lua_tostring(L, -2));
+                size_t length;
+                const char* string = lua_tolstring(L, -2, &length);
+                dmhash_t id = dmHashBuffer64(string, length);
                 switch(GetPropertyType(L, -1, &userdata))
                 {
                     case PROPERTY_TYPE_NUMBER:

--- a/engine/gameobject/src/gameobject/gameobject_script.cpp
+++ b/engine/gameobject/src/gameobject/gameobject_script.cpp
@@ -210,8 +210,9 @@ namespace dmGameObject
 
     static int ScriptResolvePath(lua_State* L)
     {
-        const char* path = luaL_checkstring(L, 2);
-        dmScript::PushHash(L, dmHashString64(path));
+        size_t length;
+        const char* path = luaL_checklstring(L, 2, &length);
+        dmScript::PushHash(L, dmHashBuffer64(path, length));
         return 1;
     }
 
@@ -620,7 +621,9 @@ namespace dmGameObject
         dmhash_t property_id = 0;
         if (lua_isstring(L, 2))
         {
-            property_id = dmHashString64(lua_tostring(L, 2));
+            size_t id_length;
+            const char* id_string = lua_tolstring(L, 2, &id_length);
+            property_id = dmHashBuffer64(id_string, id_length);
         }
         else
         {
@@ -816,7 +819,9 @@ namespace dmGameObject
 
         if (lua_isstring(L, 2))
         {
-            property_id = dmHashString64(lua_tostring(L, 2));
+            size_t id_length;
+            const char* id_string = lua_tolstring(L, 2, &id_length);
+            property_id = dmHashBuffer64(id_string, id_length);
         }
         else
         {
@@ -1598,7 +1603,9 @@ namespace dmGameObject
         dmhash_t property_id = 0;
         if (lua_isstring(L, 2))
         {
-            property_id = dmHashString64(lua_tostring(L, 2));
+            size_t id_length;
+            const char* id_string = lua_tolstring(L, 2, &id_length);
+            property_id = dmHashBuffer64(id_string, id_length);
         }
         else
         {
@@ -1750,7 +1757,9 @@ namespace dmGameObject
         {
             if (lua_isstring(L, 2))
             {
-                property_id = dmHashString64(lua_tostring(L, 2));
+                size_t id_length;
+                const char* id_string = lua_tolstring(L, 2, &id_length);
+                property_id = dmHashBuffer64(id_string, id_length);
             }
             else
             {

--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -2259,8 +2259,8 @@ namespace dmGameSystem
 
     static inline dmhash_t ResolveDynamicTexturePath(GuiComponent* component, dmhash_t path_hash, char* buffer, uint32_t buffer_size)
     {
-        dmSnPrintf(buffer, buffer_size, "%s/%llu.texturec", component->m_Resource->m_Path, (unsigned long long) path_hash);
-        return dmHashString64(buffer);
+        int length = dmSnPrintf(buffer, buffer_size, "%s/%llu.texturec", component->m_Resource->m_Path, (unsigned long long) path_hash);
+        return dmHashBuffer64(buffer, length < 0 ? buffer_size - 1 : length);
     }
 
     static dmGui::HTextureSource NewTextureResourceCallback(dmGui::HScene scene, const dmhash_t path_hash, uint32_t width, uint32_t height, dmImage::Type type, const void* data)
@@ -2929,7 +2929,7 @@ namespace dmGameSystem
                 const char* custom_type_name = (const char*)dmHashReverse32(custom_type, &length);
                 if (custom_type_name == 0)
                     custom_type_name = "";
-                pit->m_Property.m_Value.m_Hash = dmHashString64(custom_type_name);
+                pit->m_Property.m_Value.m_Hash = dmHashBuffer64(custom_type_name, length);
             } else if (index == 2) // id
             {
                 pit->m_Property.m_Type = dmGameObject::SCENE_NODE_PROPERTY_TYPE_HASH;

--- a/engine/gamesys/src/gamesys/scripts/script_collection_factory.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_collection_factory.cpp
@@ -56,7 +56,9 @@ namespace dmGameSystem
     {
         if (lua_isstring(L, -1))
         {
-            dmScript::PushHash(L, dmHashString64(lua_tostring(L, -1)));
+            size_t length;
+            const char* string = lua_tolstring(L, -1, &length);
+            dmScript::PushHash(L, dmHashBuffer64(string, length));
             lua_rawget(L, -3);
             return 1;
         }
@@ -455,8 +457,9 @@ namespace dmGameSystem
         dmhash_t path_hash = 0;
         if (!lua_isnil(L, 2))
         {
-            path = luaL_checkstring(L, 2);
-            path_hash = dmHashString64(path);
+            size_t path_length;
+            path = luaL_checklstring(L, 2, &path_length);
+            path_hash = dmHashBuffer64(path, path_length);
 
             // check that the path is a .collectionc
             const char* ext = dmResource::GetExtFromPath(path);

--- a/engine/gamesys/src/gamesys/scripts/script_resource.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_resource.cpp
@@ -1909,7 +1909,9 @@ static void MakeTextureSetFromLua(lua_State* L, dmhash_t texture_path_hash, dmGr
             lua_getfield(L, -1, "id");
             if (lua_isstring(L, -1))
             {
-                id_hash = dmHashString64(lua_tostring(L, -1));
+                size_t id_length;
+                const char* id_string = lua_tolstring(L, -1, &id_length);
+                id_hash = dmHashBuffer64(id_string, id_length);
             }
             lua_pop(L, 1);
             texture_set_ddf->m_ImageNameHashes[i] = id_hash;

--- a/engine/gamesys/src/gamesys/scripts/script_sys_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_sys_gamesys.cpp
@@ -327,7 +327,8 @@ namespace dmGameSystem
     static int Sys_LoadBufferAsync(lua_State* L)
     {
         int top          = lua_gettop(L);
-        const char* path = luaL_checkstring(L, 1);
+        size_t path_length;
+        const char* path = luaL_checklstring(L, 1, &path_length);
         dmScript::LuaCallbackInfo* callback_info = dmScript::CreateCallback(dmScript::GetMainThread(L), 2);
 
         if (callback_info == 0x0)
@@ -335,7 +336,7 @@ namespace dmGameSystem
             return luaL_error(L, "sys.load_buffer_async failed to create callback");
         }
 
-        dmhash_t path_hash = dmHashString64(path);
+        dmhash_t path_hash = dmHashBuffer64(path, path_length);
         {
             DM_MUTEX_SCOPED_LOCK(g_SysModule.m_LoadRequestsMutex);
 

--- a/engine/gui/src/gui_script.cpp
+++ b/engine/gui/src/gui_script.cpp
@@ -155,8 +155,9 @@ namespace dmGui
 
     static int GuiScriptResolvePath(lua_State* L)
     {
-        const char* path = luaL_checkstring(L, 2);
-        dmScript::PushHash(L, dmHashString64(path));
+        size_t length;
+        const char* path = luaL_checklstring(L, 2, &length);
+        dmScript::PushHash(L, dmHashBuffer64(path, length));
         return 1;
     }
 
@@ -629,7 +630,9 @@ namespace dmGui
         dmhash_t id = 0;
         if (lua_isstring(L, 2))
         {
-            id = dmHashString64(lua_tostring(L, 2));
+            size_t length;
+            const char* string = lua_tolstring(L, 2, &length);
+            id = dmHashBuffer64(string, length);
         }
         else
         {
@@ -1445,9 +1448,11 @@ namespace dmGui
 
         dmhash_t property_hash;
         if (dmScript::IsHash(L, 2)) {
-           property_hash = dmScript::CheckHash(L, 2);
+            property_hash = dmScript::CheckHash(L, 2);
         } else {
-           property_hash = dmHashString64(luaL_checkstring(L, 2));
+            size_t length;
+            const char* string = luaL_checklstring(L, 2, &length);
+            property_hash = dmHashBuffer64(string, length);
         }
 
         if (!dmGui::HasPropertyHash(scene, hnode, property_hash)) {
@@ -1586,9 +1591,11 @@ namespace dmGui
 
         dmhash_t property_hash;
         if (dmScript::IsHash(L, 2)) {
-           property_hash = dmScript::CheckHash(L, 2);
+            property_hash = dmScript::CheckHash(L, 2);
         } else {
-           property_hash = dmHashString64(luaL_checkstring(L, 2));
+            size_t length;
+            const char* string = luaL_checklstring(L, 2, &length);
+            property_hash = dmHashBuffer64(string, length);
         }
 
         if (!dmGui::HasPropertyHash(scene, hnode, property_hash)) {
@@ -2736,8 +2743,9 @@ namespace dmGui
 
         dmhash_t font_id_hash = 0;
         if (lua_isstring(L, 1)) {
-            const char* font_id = luaL_checkstring(L, 1);
-            font_id_hash = dmHashString64(font_id);
+            size_t font_id_length;
+            const char* font_id = luaL_checklstring(L, 1, &font_id_length);
+            font_id_hash = dmHashBuffer64(font_id, font_id_length);
         } else {
             font_id_hash = dmScript::CheckHash(L, 1);
         }
@@ -3706,7 +3714,9 @@ namespace dmGui
     {
         if (lua_isstring(L, -1))
         {
-            dmScript::PushHash(L, dmHashString64(lua_tostring(L, -1)));
+            size_t length;
+            const char* string = lua_tolstring(L, -1, &length);
+            dmScript::PushHash(L, dmHashBuffer64(string, length));
             lua_rawget(L, -3);
             return 1;
         }

--- a/engine/render/src/render/program_utils.cpp
+++ b/engine/render/src/render/program_utils.cpp
@@ -87,19 +87,20 @@ namespace dmRender
 
     void FillElementIds(char* buffer, uint32_t buffer_size, dmhash_t element_ids[4])
     {
-        size_t original_size = strlen(buffer);
-        dmStrlCat(buffer, ".x", buffer_size);
-        element_ids[0] = dmHashString64(buffer);
-        buffer[original_size] = 0;
-        dmStrlCat(buffer, ".y", buffer_size);
-        element_ids[1] = dmHashString64(buffer);
-        buffer[original_size] = 0;
-        dmStrlCat(buffer, ".z", buffer_size);
-        element_ids[2] = dmHashString64(buffer);
-        buffer[original_size] = 0;
-        dmStrlCat(buffer, ".w", buffer_size);
-        element_ids[3] = dmHashString64(buffer);
-        buffer[original_size] = 0;
+        uint32_t insert_index = (uint32_t)strlen(buffer);
+        uint32_t final_length = insert_index + 2;
+        assert(final_length < buffer_size);
+        buffer[final_length] = 0;
+        buffer[insert_index] = '.';
+        buffer[insert_index + 1] = 'x';
+        element_ids[0] = dmHashBuffer64(buffer, final_length);
+        buffer[insert_index + 1] = 'y';
+        element_ids[1] = dmHashBuffer64(buffer, final_length);
+        buffer[insert_index + 1] = 'z';
+        element_ids[2] = dmHashBuffer64(buffer, final_length);
+        buffer[insert_index + 1] = 'w';
+        element_ids[3] = dmHashBuffer64(buffer, final_length);
+        buffer[insert_index] = 0;
     }
 
     int32_t GetProgramSamplerIndex(const dmArray<Sampler>& samplers, dmhash_t name_hash)

--- a/engine/render/src/render/render_script.cpp
+++ b/engine/render/src/render/render_script.cpp
@@ -150,8 +150,9 @@ namespace dmRender
         HNamedConstantBuffer cb            = cb_table->m_ConstantBuffer;
         assert(cb);
 
-        const char* name         = luaL_checkstring(L, 2);
-        dmhash_t name_hash       = dmHashString64(name);
+        size_t name_length;
+        const char* name         = luaL_checklstring(L, 2, &name_length);
+        dmhash_t name_hash       = dmHashBuffer64(name, name_length);
         dmVMath::Vector4* values = 0;
         uint32_t num_values      = 0;
 
@@ -201,8 +202,9 @@ namespace dmRender
         HNamedConstantBuffer cb = cb_table->m_ConstantBuffer;
         assert(cb);
 
-        const char* name = luaL_checkstring(L, 2);
-        dmhash_t name_hash = dmHashString64(name);
+        size_t name_length;
+        const char* name = luaL_checklstring(L, 2, &name_length);
+        dmhash_t name_hash = dmHashBuffer64(name, name_length);
 
         if (lua_istable(L, 3))
         {
@@ -437,7 +439,9 @@ namespace dmRender
 
     static int RenderScriptResolvePath(lua_State* L)
     {
-        dmScript::PushHash(L, dmHashString64(luaL_checkstring(L, 2)));
+        size_t length;
+        const char* string = luaL_checklstring(L, 2, &length);
+        dmScript::PushHash(L, dmHashBuffer64(string, length));
         return 1;
     }
 
@@ -534,7 +538,9 @@ namespace dmRender
 
     static int RenderScriptInstanceResolvePath(lua_State* L)
     {
-        dmScript::PushHash(L, dmHashString64(luaL_checkstring(L, 2)));
+        size_t length;
+        const char* string = luaL_checklstring(L, 2, &length);
+        dmScript::PushHash(L, dmHashBuffer64(string, length));
         return 1;
     }
 

--- a/engine/script/src/script_hash.cpp
+++ b/engine/script/src/script_hash.cpp
@@ -85,8 +85,9 @@ namespace dmScript
         }
         else
         {
-            const char* str = luaL_checkstring(L, 1);
-            hash = dmHashString64(str);
+            size_t length;
+            const char* str = luaL_checklstring(L, 1, &length);
+            hash = dmHashBuffer64(str, length);
         }
         PushHash(L, hash);
 

--- a/engine/script/src/script_module.cpp
+++ b/engine/script/src/script_module.cpp
@@ -91,8 +91,9 @@ namespace dmScript
 
         HContext context = dmScript::GetScriptContext(L);
 
-        const char *name = luaL_checkstring(L, 1);
-        dmhash_t name_hash = dmHashString64(name);
+        size_t length;
+        const char *name = luaL_checklstring(L, 1, &length);
+        dmhash_t name_hash = dmHashBuffer64(name, length);
         Module* module = context->m_Modules.Get(name_hash);
 
         if (module == NULL)

--- a/engine/script/src/script_msg.cpp
+++ b/engine/script/src/script_msg.cpp
@@ -198,7 +198,9 @@ namespace dmScript
         {
             if (lua_isstring(L, 3))
             {
-                url->m_Path = dmHashString64(lua_tostring(L, 3));
+                size_t length;
+                const char* string = lua_tolstring(L, 3, &length);
+                url->m_Path = dmHashBuffer64(string, length);
             }
             else if (lua_isnil(L, 3))
             {
@@ -221,7 +223,9 @@ namespace dmScript
         {
             if (lua_isstring(L, 3))
             {
-                url->m_Fragment = dmHashString64(lua_tostring(L, 3));
+                size_t length;
+                const char* string = lua_tolstring(L, 3, &length);
+                url->m_Fragment = dmHashBuffer64(string, length);
             }
             else if (lua_isnil(L, 3))
             {
@@ -404,7 +408,7 @@ namespace dmScript
                     }
                     else
                     {
-                        url.m_Path = dmHashString64(path);
+                        url.m_Path = dmHashBuffer64(path, path_length);
                     }
                 }
                 else
@@ -427,7 +431,9 @@ namespace dmScript
             {
                 if (lua_isstring(L, 3))
                 {
-                    url.m_Fragment = dmHashString64(lua_tostring(L, 3));
+                    size_t length;
+                    const char* string = lua_tolstring(L, 3, &length);
+                    url.m_Fragment = dmHashBuffer64(string, length);
                 }
                 else
                 {
@@ -502,7 +508,9 @@ namespace dmScript
         dmhash_t message_id;
         if (lua_isstring(L, 2))
         {
-            message_id = dmHashString64(lua_tostring(L, 2));
+            size_t id_length;
+            const char* id_string = lua_tolstring(L, 2, &id_length);
+            message_id = dmHashBuffer64(id_string, id_length);
         }
         else
         {

--- a/engine/script/src/script_sys.cpp
+++ b/engine/script/src/script_sys.cpp
@@ -130,7 +130,8 @@ union SaveLoadBuffer
 
     static int Sys_Save(lua_State* L)
     {
-        const char* filename = luaL_checkstring(L, 1);
+        size_t filename_length;
+        const char* filename = luaL_checklstring(L, 1, &filename_length);
 
         luaL_checktype(L, 2, LUA_TTABLE);
 
@@ -149,7 +150,7 @@ union SaveLoadBuffer
         // The counter and hash are there to make the files unique enough to avoid that the user
         // accidentally writes to it.
         static int save_counter = 0;
-        uint32_t hash = dmHashString32(filename);
+        uint32_t hash = dmHashBuffer32(filename, filename_length);
         int res = dmSnPrintf(tmp_filename, sizeof(tmp_filename), "%s.defoldtmp_%x_%d", filename, hash, save_counter++);
         if (res == -1)
         {


### PR DESCRIPTION
skip release notes

Resolves #9736

### Technical changes

* No changes to actual behavior — simply makes use of string length where it's easy enough to do.