### PR TITLE
Use sizeof instead of strlen for immutable char arrays

### DIFF
--- a/engine/dlib/src/basis/encoder/basisu_comp.cpp
+++ b/engine/dlib/src/basis/encoder/basisu_comp.cpp
@@ -1984,18 +1984,20 @@ namespace basisu
 		basist::ktx2_transcoder::key_value_vec key_values(m_params.m_ktx2_key_values);
 		key_values.enlarge(1);
 		
-		const char* pKTXwriter = "KTXwriter";
-		key_values.back().m_key.resize(strlen(pKTXwriter) + 1);
-		memcpy(key_values.back().m_key.data(), pKTXwriter, strlen(pKTXwriter) + 1);
+		const char pKTXwriter[] = "KTXwriter";
+		key_values.back().m_key.resize(sizeof(pKTXwriter));
+		memcpy(key_values.back().m_key.data(), pKTXwriter, sizeof(pKTXwriter));
 
 		char writer_id[128];
+		int writer_id_length =
 #ifdef _MSC_VER
-		sprintf_s(writer_id, sizeof(writer_id), "Basis Universal %s", BASISU_LIB_VERSION_STRING);
+			sprintf_s(writer_id, sizeof(writer_id), "Basis Universal %s", BASISU_LIB_VERSION_STRING);
 #else
-		snprintf(writer_id, sizeof(writer_id), "Basis Universal %s", BASISU_LIB_VERSION_STRING);
+			snprintf(writer_id, sizeof(writer_id), "Basis Universal %s", BASISU_LIB_VERSION_STRING);
 #endif
-		key_values.back().m_value.resize(strlen(writer_id) + 1);
-		memcpy(key_values.back().m_value.data(), writer_id, strlen(writer_id) + 1);
+		assert(writer_id_length >= 0 && writer_id_length < sizeof(writer_id));
+		key_values.back().m_value.resize(writer_id_length + 1);
+		memcpy(key_values.back().m_value.data(), writer_id, writer_id_length + 1);
 
 		key_values.sort();
 

--- a/engine/dlib/src/dlib/http_cache_verify.cpp
+++ b/engine/dlib/src/dlib/http_cache_verify.cpp
@@ -62,11 +62,13 @@ namespace dmHttpCacheVerify
             // Young enough
 
             // #path + space + #etag + \n
-            verify_context->m_BytesWritten += strlen(entry_info->m_URI) + 1 + strlen(entry_info->m_ETag) + 1;
+            size_t uri_length = strlen(entry_info->m_URI);
+            size_t etag_length = strlen(entry_info->m_ETag);
+            verify_context->m_BytesWritten += uri_length + 1 + etag_length + 1;
             if (!verify_context->m_DryRun)
             {
                 dmHttpClient::Result r;
-                r = Write(verify_context->m_Response, entry_info->m_URI, strlen(entry_info->m_URI));
+                r = Write(verify_context->m_Response, entry_info->m_URI, uri_length);
                 if (r != dmHttpClient::RESULT_OK)
                 {
                     verify_context->m_Result = r;
@@ -80,7 +82,7 @@ namespace dmHttpCacheVerify
                     return;
                 }
 
-                r = Write(verify_context->m_Response, entry_info->m_ETag, strlen(entry_info->m_ETag));
+                r = Write(verify_context->m_Response, entry_info->m_ETag, etag_length);
                 if (r != dmHttpClient::RESULT_OK)
                 {
                     verify_context->m_Result = r;

--- a/engine/dlib/src/dlib/log.cpp
+++ b/engine/dlib/src/dlib/log.cpp
@@ -45,7 +45,7 @@
 namespace dmLog
 {
 
-const char* LOG_OUTPUT_TRUNCATED_MESSAGE = "...\n[Output truncated]\n";
+const char LOG_OUTPUT_TRUNCATED_MESSAGE[] = "...\n[Output truncated]\n";
 const int MAX_LOG_FILE_SIZE = 1024 * 1024 * 32;
 
 struct dmLogConnection
@@ -237,15 +237,15 @@ static void dmLogUpdateNetwork()
                 if (connections_full)
                 {
                     dmLogError("Too many log connections opened");
-                    const char* resp = "1 Too many log connections opened\n";
-                    SendAll(client_socket, resp, strlen(resp));
+                    const char resp[] = "1 Too many log connections opened\n";
+                    SendAll(client_socket, resp, sizeof(resp) - 1);
                     dmSocket::Shutdown(client_socket, dmSocket::SHUTDOWNTYPE_READWRITE);
                     dmSocket::Delete(client_socket);
                 }
                 else
                 {
-                    const char* resp = "0 OK\n";
-                    SendAll(client_socket, resp, strlen(resp));
+                    const char resp[] = "0 OK\n";
+                    SendAll(client_socket, resp, sizeof(resp) - 1);
                     dmSocket::SetNoDelay(client_socket, true);
                     dmLogConnection connection;
                     memset(&connection, 0, sizeof(connection));
@@ -672,7 +672,7 @@ void LogInternal(LogSeverity severity, const char* domain, const char* format, .
 
     if (n >= dmLog::MAX_STRING_SIZE)
     {
-        strcpy(&str_buf[dmLog::MAX_STRING_SIZE - (strlen(dmLog::LOG_OUTPUT_TRUNCATED_MESSAGE) + 1)], dmLog::LOG_OUTPUT_TRUNCATED_MESSAGE);
+        strcpy(&str_buf[dmLog::MAX_STRING_SIZE - sizeof(dmLog::LOG_OUTPUT_TRUNCATED_MESSAGE)], dmLog::LOG_OUTPUT_TRUNCATED_MESSAGE);
     }
 
     str_buf[dmLog::MAX_STRING_SIZE-1] = '\0';

--- a/engine/dlib/src/dlib/ssdp.cpp
+++ b/engine/dlib/src/dlib/ssdp.cpp
@@ -37,9 +37,9 @@
 namespace dmSSDP
 {
 
-    static const char * SSDP_MCAST_ADDR_IPV4               = "239.255.255.250";
+    static const char SSDP_MCAST_ADDR_IPV4[] = "239.255.255.250";
 
-    static const char* SSDP_ALIVE_TMPL =
+    static const char SSDP_ALIVE_TMPL[] =
         "NOTIFY * HTTP/1.1\r\n"
         "SERVER: Defold SSDP 1.0\r\n"
         "CACHE-CONTROL: max-age=${MAX_AGE}\r\n"
@@ -49,7 +49,7 @@ namespace dmSSDP
         "NT: ${NT}\r\n"
         "USN: ${UDN}::${DEVICE_TYPE}\r\n\r\n";
 
-    static const char* SSDP_BYEBYE_TMPL =
+    static const char SSDP_BYEBYE_TMPL[] =
         "NOTIFY * HTTP/1.1\r\n"
         "SERVER: Defold SSDP 1.0\r\n"
         "HOST: 239.255.255.250:1900\r\n"
@@ -57,7 +57,7 @@ namespace dmSSDP
         "NT: ${NT}\r\n"
         "USN: ${UDN}::${DEVICE_TYPE}\r\n\r\n";
 
-    static const char* SEARCH_RESULT_FMT =
+    static const char SEARCH_RESULT_FMT[] =
         "HTTP/1.1 200 OK\r\n"
         "SERVER: Defold SSDP 1.0\r\n"
         "CACHE-CONTROL: max-age=${MAX_AGE}\r\n"
@@ -67,7 +67,7 @@ namespace dmSSDP
         "USN: ${UDN}::${DEVICE_TYPE}\r\n"
         "Content-Length: 0\r\n\r\n";
 
-    static const char* M_SEARCH_FMT =
+    static const char M_SEARCH_FMT[] =
         "M-SEARCH * HTTP/1.1\r\n"
         "SERVER: Defold SSDP 1.0\r\n"
         "HOST: 239.255.255.250:1900\r\n"
@@ -317,8 +317,8 @@ bail:
         if (!last_slash)
         {
             dmHttpServer::SetStatusCode(request, 400);
-            const char* s = "Bad URL";
-            dmHttpServer::Send(request, s, strlen(s));
+            const char s[] = "Bad URL";
+            dmHttpServer::Send(request, s, sizeof(s) - 1);
             return;
         }
         const char* id = last_slash + 1;
@@ -328,8 +328,8 @@ bail:
         if (!device)
         {
             dmHttpServer::SetStatusCode(request, 404);
-            const char* s = "Device not found";
-            dmHttpServer::Send(request, s, strlen(s));
+            const char s[] = "Device not found";
+            dmHttpServer::Send(request, s, sizeof(s) - 1);
             return;
         }
 
@@ -339,8 +339,8 @@ bail:
         if (tr != dmTemplate::RESULT_OK)
         {
             dmLogError("Error formating http response (%d)", tr);
-            const char *s = "Internal error";
-            dmHttpServer::Send(request, s, strlen(s));
+            const char s[] = "Internal error";
+            dmHttpServer::Send(request, s, sizeof(s) - 1);
             return;
         }
 
@@ -1022,7 +1022,7 @@ bail:
 
                 int sent_bytes;
                 dmSocket::Result sr;
-                sr = dmSocket::SendTo(ssdp->m_LocalAddrSocket[i], M_SEARCH_FMT, strlen(M_SEARCH_FMT), &sent_bytes,
+                sr = dmSocket::SendTo(ssdp->m_LocalAddrSocket[i], M_SEARCH_FMT, sizeof(M_SEARCH_FMT) - 1, &sent_bytes,
                     dmSocket::AddressFromIPString(SSDP_MCAST_ADDR_IPV4), SSDP_MCAST_PORT);
 
                 dmLogDebug("SSDP M-SEARCH");

--- a/engine/dlib/src/dlib/sslsocket.cpp
+++ b/engine/dlib/src/dlib/sslsocket.cpp
@@ -288,10 +288,10 @@ Result New(dmSocket::Socket socket, const char* host, uint64_t timeout, SSLSocke
 #endif
     int ret = 0;
 
-    const char* pers = "defold_ssl_client";
+    const char pers[] = "defold_ssl_client";
     if( ( ret = mbedtls_ctr_drbg_seed( c->m_MbedCtrDrbg, mbedtls_entropy_func, c->m_MbedEntropy,
                                (const unsigned char *) pers,
-                               strlen( pers ) ) ) != 0 )
+                               sizeof( pers ) - 1 ) ) != 0 )
     {
         SSL_LOGE("mbedtls_ctr_drbg_seed failed", ret);
         return RESULT_SSL_INIT_FAILED;

--- a/engine/engine/src/engine_service.cpp
+++ b/engine/engine/src/engine_service.cpp
@@ -185,7 +185,7 @@ namespace dmEngineService
             }
 
             dmWebServer::SetStatusCode(request, 200);
-            dmWebServer::Send(request, "OK", strlen("OK"));
+            dmWebServer::Send(request, "OK", sizeof("OK") - 1);
             return;
 
     bail:
@@ -198,7 +198,7 @@ namespace dmEngineService
         static void PingHandler(void* user_data, dmWebServer::Request* request)
         {
             dmWebServer::SetStatusCode(request, 200);
-            dmWebServer::Send(request, "PONG\n", strlen("PONG\n"));
+            dmWebServer::Send(request, "PONG\n", sizeof("PONG\n") - 1);
         }
 
         static void InfoHandler(void* user_data, dmWebServer::Request* request)

--- a/engine/gameobject/src/gameobject/gameobject.cpp
+++ b/engine/gameobject/src/gameobject/gameobject.cpp
@@ -54,6 +54,7 @@ namespace dmGameObject
     const dmhash_t UNNAMED_IDENTIFIER = dmHashBuffer64("__unnamed__", strlen("__unnamed__"));
     const dmhash_t GAME_OBJECT_EXT = dmHashString64("goc");
     const char* ID_SEPARATOR = "/";
+    const uint32_t ID_SEPARATOR_LENGTH = 1;
     const uint32_t MAX_DISPATCH_ITERATION_COUNT = 10;
 
     static Prototype EMPTY_PROTOTYPE;
@@ -1190,7 +1191,7 @@ namespace dmGameObject
         collection->m_WorldTransforms[instance->m_Index] = dmTransform::ToMatrix4(instance->m_Transform);
 
         dmHashInit64(&instance->m_CollectionPathHashState, true);
-        dmHashUpdateBuffer64(&instance->m_CollectionPathHashState, ID_SEPARATOR, strlen(ID_SEPARATOR));
+        dmHashUpdateBuffer64(&instance->m_CollectionPathHashState, ID_SEPARATOR, ID_SEPARATOR_LENGTH);
 
         Result result = SetIdentifier(collection, instance, id);
         if (result == RESULT_IDENTIFIER_IN_USE)
@@ -1390,9 +1391,10 @@ namespace dmGameObject
             // to with the root_path added)
             HashState64 new_id_hs;
             dmHashClone64(&new_id_hs, &prefixHashState, true);
-            dmHashUpdateBuffer64(&new_id_hs, instance_desc.m_Id, strlen(instance_desc.m_Id));
+            size_t id_length = strlen(instance_desc.m_Id);
+            dmHashUpdateBuffer64(&new_id_hs, instance_desc.m_Id, id_length);
             dmhash_t new_id = dmHashFinal64(&new_id_hs);
-            dmhash_t id = dmHashBuffer64(instance_desc.m_Id, strlen(instance_desc.m_Id));
+            dmhash_t id = dmHashBuffer64(instance_desc.m_Id, id_length);
             id_mapping->Put(id, new_id);
             new_instances.Push(instance);
 

--- a/engine/gamesys/src/gamesys/scripts/script_http.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_http.cpp
@@ -162,17 +162,19 @@ namespace dmGameSystem
                 lua_pushvalue(L, 4);
                 lua_pushnil(L);
                 while (lua_next(L, -2)) {
-                    const char* attr = lua_tostring(L, -2);
-                    const char* val = lua_tostring(L, -1);
+                    size_t attr_len;
+                    const char* attr = lua_tolstring(L, -2, &attr_len);
+                    size_t val_len;
+                    const char* val = lua_tolstring(L, -1, &val_len);
                     if (attr && val) {
                         uint32_t left = h.Capacity() - h.Size();
-                        uint32_t required = strlen(attr) + strlen(val) + 2;
+                        uint32_t required = attr_len + val_len + 2;
                         if (left < required) {
                             h.OffsetCapacity(dmMath::Max(required, 1024U));
                         }
-                        h.PushArray(attr, strlen(attr));
+                        h.PushArray(attr, attr_len);
                         h.Push(':');
-                        h.PushArray(val, strlen(val));
+                        h.PushArray(val, val_len);
                         h.Push('\n');
                     } else {
                         // luaL_error would be nice but that would evade call to 'h' destructor

--- a/engine/gamesys/src/gamesys/scripts/script_http_js.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_http_js.cpp
@@ -174,16 +174,18 @@ namespace dmGameSystem
                 lua_pushvalue(L, 4);
                 lua_pushnil(L);
                 while (lua_next(L, -2)) {
-                    const char* attr = lua_tostring(L, -2);
-                    const char* val = lua_tostring(L, -1);
+                    size_t attr_len;
+                    const char* attr = lua_tolstring(L, -2, &attr_len);
+                    size_t val_len;
+                    const char* val = lua_tolstring(L, -1, &val_len);
                     uint32_t left = h.Capacity() - h.Size();
-                    uint32_t required = strlen(attr) + strlen(val) + 2;
+                    uint32_t required = attr_len + val_len + 2;
                     if (left < required) {
                         h.OffsetCapacity(dmMath::Max(required, 1024U));
                     }
-                    h.PushArray(attr, strlen(attr));
+                    h.PushArray(attr, attr_len);
                     h.Push(':');
-                    h.PushArray(val, strlen(val));
+                    h.PushArray(val, val_len);
                     h.Push('\n');
                     lua_pop(L, 1);
                 }

--- a/engine/graphics/src/null/graphics_null.cpp
+++ b/engine/graphics/src/null/graphics_null.cpp
@@ -1123,10 +1123,10 @@ namespace dmGraphics
         assert(index < program->m_Uniforms.Size());
         ShaderBinding& uniform = program->m_Uniforms[index];
         *buffer = '\0';
-        dmStrlCat(buffer, uniform.m_Name, buffer_size);
+        size_t length = dmStrlCat(buffer, uniform.m_Name, buffer_size);
         *type = uniform.m_Type;
         *size = uniform.m_Size;
-        return (uint32_t)strlen(buffer);
+        return dmMath::Min((uint32_t)length, buffer_size - 1);
     }
 
     static HUniformLocation NullGetUniformLocation(HProgram prog, const char* name)

--- a/engine/resource/src/resource_util.cpp
+++ b/engine/resource/src/resource_util.cpp
@@ -23,7 +23,7 @@ namespace dmResource
 {
 
 static Result DecryptWithXtea(void* buffer, uint32_t buffer_len);
-const char* KEY = "aQj8CScgNP4VsfXK";
+const char KEY[] = "aQj8CScgNP4VsfXK";
 
 FDecryptResource g_ResourceDecryption = DecryptWithXtea; // Currently global since we didn't use the resource factory as the context!
 
@@ -36,7 +36,7 @@ void RegisterResourceDecryptionFunction(FDecryptResource decrypt_resource)
 
 static dmResource::Result DecryptWithXtea(void* buffer, uint32_t buffer_len)
 {
-    dmCrypt::Result cr = dmCrypt::Decrypt(dmCrypt::ALGORITHM_XTEA, (uint8_t*) buffer, buffer_len, (const uint8_t*) KEY, strlen(KEY));
+    dmCrypt::Result cr = dmCrypt::Decrypt(dmCrypt::ALGORITHM_XTEA, (uint8_t*) buffer, buffer_len, (const uint8_t*) KEY, sizeof(KEY) - 1);
     if (cr != dmCrypt::RESULT_OK)
     {
         return dmResource::RESULT_UNKNOWN_ERROR;


### PR DESCRIPTION
skip release notes

Resolves #9738

### Technical changes

* No changes to behavior — simply uses `sizeof` instead of `strlen` where possible.