### PR TITLE
Add string hash function dmHashLiteral to avoid strlen call, like lua_pushliteral

### DIFF
--- a/engine/dlib/src/dlib/ssdp.cpp
+++ b/engine/dlib/src/dlib/ssdp.cpp
@@ -631,7 +631,7 @@ bail:
 
     void HandleAnnounce(RequestParseState* state, const char* usn)
     {
-        static const dmhash_t location_hash = dmHashString64("LOCATION");
+        static const dmhash_t location_hash = dmHashLiteral64("LOCATION");
 
         dmhash_t id = dmHashString64(usn);
         SSDP* ssdp = state->m_SSDP;
@@ -732,7 +732,7 @@ bail:
 
     void HandleSearch(RequestParseState* state, dmSocket::Address from_address, uint16_t from_port)
     {
-        static const dmhash_t st_hash = dmHashString64("ST");
+        static const dmhash_t st_hash = dmHashLiteral64("ST");
         const char** st = state->m_Headers.Get(st_hash);
         if (!st)
         {
@@ -753,9 +753,9 @@ bail:
      */
     bool DispatchSocket(SSDP* ssdp, dmSocket::Socket socket, bool response)
     {
-        static const dmhash_t usn_hash = dmHashString64("USN");
-        static const dmhash_t ssdp_alive_hash = dmHashString64("ssdp:alive");
-        static const dmhash_t ssdp_byebye_hash = dmHashString64("ssdp:byebye");
+        static const dmhash_t usn_hash = dmHashLiteral64("USN");
+        static const dmhash_t ssdp_alive_hash = dmHashLiteral64("ssdp:alive");
+        static const dmhash_t ssdp_byebye_hash = dmHashLiteral64("ssdp:byebye");
 
         dmSocket::Result sr;
         int recv_bytes;

--- a/engine/dlib/src/dmsdk/dlib/hash.h
+++ b/engine/dlib/src/dmsdk/dlib/hash.h
@@ -84,6 +84,7 @@ DM_DLLEXPORT uint64_t dmHashBuffer64(const void* buffer, uint32_t buffer_len);
  * @return hash [type:uint32_t] hash value
  */
 DM_DLLEXPORT uint32_t dmHashString32(const char* string);
+#define dmHashLiteral32(string) dmHashBuffer32((string), sizeof((string)) - 1)
 
 
 /*# calculate 64-bit hash value from string
@@ -93,6 +94,7 @@ DM_DLLEXPORT uint32_t dmHashString32(const char* string);
  * @return hash [type:uint64_t] hash value
  */
 DM_DLLEXPORT uint64_t dmHashString64(const char* string);
+#define dmHashLiteral64(string) dmHashBuffer64((string), sizeof((string)) - 1)
 
 
 /*# get string value from hash

--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -203,12 +203,12 @@ namespace dmEngine
         component_create_ctx.m_Register = engine->m_Register;
         component_create_ctx.m_Factory = engine->m_Factory;
         component_create_ctx.m_Contexts.SetCapacity(3, 8);
-        component_create_ctx.m_Contexts.Put(dmHashString64("graphics"), engine->m_GraphicsContext);
-        component_create_ctx.m_Contexts.Put(dmHashString64("render"), engine->m_RenderContext);
+        component_create_ctx.m_Contexts.Put(dmHashLiteral64("graphics"), engine->m_GraphicsContext);
+        component_create_ctx.m_Contexts.Put(dmHashLiteral64("render"), engine->m_RenderContext);
         if (engine->m_GuiContext)
         {
-            component_create_ctx.m_Contexts.Put(dmHashString64("gui_scriptc"), engine->m_GuiScriptContext);
-            component_create_ctx.m_Contexts.Put(dmHashString64("guic"), engine->m_GuiContext);
+            component_create_ctx.m_Contexts.Put(dmHashLiteral64("gui_scriptc"), engine->m_GuiScriptContext);
+            component_create_ctx.m_Contexts.Put(dmHashLiteral64("guic"), engine->m_GuiContext);
         }
     }
 
@@ -1257,14 +1257,14 @@ namespace dmEngine
         // Variables need to be declared up here due to the goto's
         bool has_host_mount = dmSys::GetEnv("DM_HOSTFS") != 0;
 
-        engine->m_ResourceTypeContexts.Put(dmHashString64("goc"), engine->m_Register);
-        engine->m_ResourceTypeContexts.Put(dmHashString64("collectionc"), engine->m_Register);
-        engine->m_ResourceTypeContexts.Put(dmHashString64("luac"), &engine->m_ModuleContext);
-        engine->m_ResourceTypeContexts.Put(dmHashString64("scriptc"), engine->m_GOScriptContext);
+        engine->m_ResourceTypeContexts.Put(dmHashLiteral64("goc"), engine->m_Register);
+        engine->m_ResourceTypeContexts.Put(dmHashLiteral64("collectionc"), engine->m_Register);
+        engine->m_ResourceTypeContexts.Put(dmHashLiteral64("luac"), &engine->m_ModuleContext);
+        engine->m_ResourceTypeContexts.Put(dmHashLiteral64("scriptc"), engine->m_GOScriptContext);
         if (engine->m_GuiContext)
         {
-            engine->m_ResourceTypeContexts.Put(dmHashString64("gui_scriptc"), engine->m_GuiScriptContext);
-            engine->m_ResourceTypeContexts.Put(dmHashString64("guic"), engine->m_GuiContext);
+            engine->m_ResourceTypeContexts.Put(dmHashLiteral64("gui_scriptc"), engine->m_GuiScriptContext);
+            engine->m_ResourceTypeContexts.Put(dmHashLiteral64("guic"), engine->m_GuiContext);
         }
 
         fact_result = dmResource::RegisterTypes(engine->m_Factory, &engine->m_ResourceTypeContexts);

--- a/engine/engine/src/engine_service.cpp
+++ b/engine/engine/src/engine_service.cpp
@@ -648,9 +648,9 @@ namespace dmEngineService
 
     static void OutputGuiDynamicTextures(dmGameObject::SceneNode* node, dmWebServer::Request* request)
     {
-        static const dmhash_t s_GuiResource = dmHashString64("guic");
-        static const dmhash_t s_PropertyResource = dmHashString64("resource");
-        static const dmhash_t s_PropertyType = dmHashString64("type");
+        static const dmhash_t s_GuiResource = dmHashLiteral64("guic");
+        static const dmhash_t s_PropertyResource = dmHashLiteral64("resource");
+        static const dmhash_t s_PropertyType = dmHashLiteral64("type");
 
         if (node->m_Type == dmGameObject::SCENE_NODE_TYPE_SUBCOMPONENT)
             return;
@@ -719,9 +719,9 @@ namespace dmEngineService
 
     static void OutputResourceSceneGraph(dmGameObject::SceneNode* node, uint32_t parent, uint32_t* counter, dmWebServer::Request* request)
     {
-        static const dmhash_t s_PropertyId = dmHashString64("id");
-        static const dmhash_t s_PropertyResource = dmHashString64("resource");
-        static const dmhash_t s_PropertyType = dmHashString64("type");
+        static const dmhash_t s_PropertyId = dmHashLiteral64("id");
+        static const dmhash_t s_PropertyResource = dmHashLiteral64("resource");
+        static const dmhash_t s_PropertyType = dmHashLiteral64("type");
 
         if (node->m_Type == dmGameObject::SCENE_NODE_TYPE_SUBCOMPONENT)
             return;

--- a/engine/gameobject/src/gameobject/gameobject.cpp
+++ b/engine/gameobject/src/gameobject/gameobject.cpp
@@ -51,8 +51,8 @@ namespace dmGameObject
 {
     const char* COLLECTION_MAX_INSTANCES_KEY = "collection.max_instances";
     const char* COLLECTION_MAX_INPUT_STACK_ENTRIES_KEY = "collection.max_input_stack_entries";
-    const dmhash_t UNNAMED_IDENTIFIER = dmHashBuffer64("__unnamed__", strlen("__unnamed__"));
-    const dmhash_t GAME_OBJECT_EXT = dmHashString64("goc");
+    const dmhash_t UNNAMED_IDENTIFIER = dmHashLiteral64("__unnamed__");
+    const dmhash_t GAME_OBJECT_EXT = dmHashLiteral64("goc");
     const char* ID_SEPARATOR = "/";
     const uint32_t MAX_DISPATCH_ITERATION_COUNT = 10;
 
@@ -61,20 +61,20 @@ namespace dmGameObject
     static void Unlink(Collection* collection, Instance* instance);
 
 #define PROP_FLOAT(var_name, prop_name)\
-    const dmhash_t PROP_##var_name = dmHashString64(#prop_name);\
+    const dmhash_t PROP_##var_name = dmHashLiteral64(#prop_name);\
 
 #define PROP_VECTOR3(var_name, prop_name)\
-    const dmhash_t PROP_##var_name = dmHashString64(#prop_name);\
-    const dmhash_t PROP_##var_name##_X = dmHashString64(#prop_name ".x");\
-    const dmhash_t PROP_##var_name##_Y = dmHashString64(#prop_name ".y");\
-    const dmhash_t PROP_##var_name##_Z = dmHashString64(#prop_name ".z");
+    const dmhash_t PROP_##var_name = dmHashLiteral64(#prop_name);\
+    const dmhash_t PROP_##var_name##_X = dmHashLiteral64(#prop_name ".x");\
+    const dmhash_t PROP_##var_name##_Y = dmHashLiteral64(#prop_name ".y");\
+    const dmhash_t PROP_##var_name##_Z = dmHashLiteral64(#prop_name ".z");
 
 #define PROP_QUAT(var_name, prop_name)\
-    const dmhash_t PROP_##var_name = dmHashString64(#prop_name);\
-    const dmhash_t PROP_##var_name##_X = dmHashString64(#prop_name ".x");\
-    const dmhash_t PROP_##var_name##_Y = dmHashString64(#prop_name ".y");\
-    const dmhash_t PROP_##var_name##_Z = dmHashString64(#prop_name ".z");\
-    const dmhash_t PROP_##var_name##_W = dmHashString64(#prop_name ".w");
+    const dmhash_t PROP_##var_name = dmHashLiteral64(#prop_name);\
+    const dmhash_t PROP_##var_name##_X = dmHashLiteral64(#prop_name ".x");\
+    const dmhash_t PROP_##var_name##_Y = dmHashLiteral64(#prop_name ".y");\
+    const dmhash_t PROP_##var_name##_Z = dmHashLiteral64(#prop_name ".z");\
+    const dmhash_t PROP_##var_name##_W = dmHashLiteral64(#prop_name ".w");
 
     PROP_VECTOR3(POSITION, position);
     PROP_QUAT(ROTATION, rotation);

--- a/engine/gameobject/src/gameobject/gameobject_profile.cpp
+++ b/engine/gameobject/src/gameobject/gameobject_profile.cpp
@@ -253,15 +253,15 @@ static dmhash_t g_SceneNodePropertyName_world_scale = 0;
 // In order to do reverse hashes on these, we need to hash them after the engine has started
 static void InitSceneNodePropertyNames()
 {
-    g_SceneNodePropertyName_id             = dmHashString64("id");
-    g_SceneNodePropertyName_type           = dmHashString64("type");
-    g_SceneNodePropertyName_resource       = dmHashString64("resource");
-    g_SceneNodePropertyName_position       = dmHashString64("position");
-    g_SceneNodePropertyName_rotation       = dmHashString64("rotation");
-    g_SceneNodePropertyName_scale          = dmHashString64("scale");
-    g_SceneNodePropertyName_world_position = dmHashString64("world_position");
-    g_SceneNodePropertyName_world_rotation = dmHashString64("world_rotation");
-    g_SceneNodePropertyName_world_scale    = dmHashString64("world_scale");
+    g_SceneNodePropertyName_id             = dmHashLiteral64("id");
+    g_SceneNodePropertyName_type           = dmHashLiteral64("type");
+    g_SceneNodePropertyName_resource       = dmHashLiteral64("resource");
+    g_SceneNodePropertyName_position       = dmHashLiteral64("position");
+    g_SceneNodePropertyName_rotation       = dmHashLiteral64("rotation");
+    g_SceneNodePropertyName_scale          = dmHashLiteral64("scale");
+    g_SceneNodePropertyName_world_position = dmHashLiteral64("world_position");
+    g_SceneNodePropertyName_world_rotation = dmHashLiteral64("world_rotation");
+    g_SceneNodePropertyName_world_scale    = dmHashLiteral64("world_scale");
 }
 
 // ********************************************************************************************
@@ -293,7 +293,7 @@ static bool IterateCollectionPropertiesGetNext(SceneNodePropertyIterator* pit)
     else if (pit->m_Property.m_NameHash == g_SceneNodePropertyName_type)
     {
         pit->m_Property.m_Type = SCENE_NODE_PROPERTY_TYPE_HASH;
-        pit->m_Property.m_Value.m_Hash = dmHashString64("collectionc");
+        pit->m_Property.m_Value.m_Hash = dmHashLiteral64("collectionc");
     }
     else if (pit->m_Property.m_NameHash == g_SceneNodePropertyName_resource)
     {
@@ -354,7 +354,7 @@ static bool IterateGameObjectPropertiesGetNext(SceneNodePropertyIterator* pit)
         else if (property_names[index] == g_SceneNodePropertyName_type)
         {
             pit->m_Property.m_Type = SCENE_NODE_PROPERTY_TYPE_HASH;
-            pit->m_Property.m_Value.m_Hash = dmHashString64("goc");
+            pit->m_Property.m_Value.m_Hash = dmHashLiteral64("goc");
         }
         else if (property_names[index] == g_SceneNodePropertyName_resource)
         {

--- a/engine/gamesys/src/dmsdk/gamesys/property.h
+++ b/engine/gamesys/src/dmsdk/gamesys/property.h
@@ -112,18 +112,18 @@ namespace dmGameSystem
     dmGameObject::PropertyResult SetResourceProperty(dmResource::HFactory factory, const dmGameObject::PropertyVar& value, dmhash_t* exts, uint32_t ext_count, void** out_resource);
 
 #define DM_GAMESYS_PROP_VECTOR3(var_name, prop_name, readOnly)\
-    static const dmGameSystem::PropVector3 var_name(dmHashString64(#prop_name),\
-            dmHashString64(#prop_name ".x"),\
-            dmHashString64(#prop_name ".y"),\
-            dmHashString64(#prop_name ".z"),\
+    static const dmGameSystem::PropVector3 var_name(dmHashLiteral64(#prop_name),\
+            dmHashLiteral64(#prop_name ".x"),\
+            dmHashLiteral64(#prop_name ".y"),\
+            dmHashLiteral64(#prop_name ".z"),\
             readOnly);
 
 #define DM_GAMESYS_PROP_VECTOR4(var_name, prop_name, readOnly)\
-    static const dmGameSystem::PropVector4 var_name(dmHashString64(#prop_name),\
-            dmHashString64(#prop_name ".x"),\
-            dmHashString64(#prop_name ".y"),\
-            dmHashString64(#prop_name ".z"),\
-            dmHashString64(#prop_name ".w"),\
+    static const dmGameSystem::PropVector4 var_name(dmHashLiteral64(#prop_name),\
+            dmHashLiteral64(#prop_name ".x"),\
+            dmHashLiteral64(#prop_name ".y"),\
+            dmHashLiteral64(#prop_name ".z"),\
+            dmHashLiteral64(#prop_name ".w"),\
             readOnly);
 
 

--- a/engine/gamesys/src/gamesys/components/comp_camera.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_camera.cpp
@@ -58,13 +58,13 @@ namespace dmGameSystem
         dmArray<CameraComponent*> m_CameraStack;
     };
 
-    static const dmhash_t CAMERA_PROP_FOV               = dmHashString64("fov");
-    static const dmhash_t CAMERA_PROP_NEAR_Z            = dmHashString64("near_z");
-    static const dmhash_t CAMERA_PROP_FAR_Z             = dmHashString64("far_z");
-    static const dmhash_t CAMERA_PROP_ORTHOGRAPHIC_ZOOM = dmHashString64("orthographic_zoom");
-    static const dmhash_t CAMERA_PROP_PROJECTION        = dmHashString64("projection");
-    static const dmhash_t CAMERA_PROP_VIEW              = dmHashString64("view");
-    static const dmhash_t CAMERA_PROP_ASPECT_RATIO      = dmHashString64("aspect_ratio");
+    static const dmhash_t CAMERA_PROP_FOV               = dmHashLiteral64("fov");
+    static const dmhash_t CAMERA_PROP_NEAR_Z            = dmHashLiteral64("near_z");
+    static const dmhash_t CAMERA_PROP_FAR_Z             = dmHashLiteral64("far_z");
+    static const dmhash_t CAMERA_PROP_ORTHOGRAPHIC_ZOOM = dmHashLiteral64("orthographic_zoom");
+    static const dmhash_t CAMERA_PROP_PROJECTION        = dmHashLiteral64("projection");
+    static const dmhash_t CAMERA_PROP_VIEW              = dmHashLiteral64("view");
+    static const dmhash_t CAMERA_PROP_ASPECT_RATIO      = dmHashLiteral64("aspect_ratio");
 
 
     static void CompCameraUpdateViewProjection(CameraComponent* camera, dmRender::RenderContext* render_context)

--- a/engine/gamesys/src/gamesys/components/comp_collection_factory.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_collection_factory.cpp
@@ -37,7 +37,7 @@ namespace dmGameSystem
 {
     const char* COLLECTION_FACTORY_MAX_COUNT_KEY = "collectionfactory.max_count";
 
-    static const dmhash_t COLLECTION_FACTORY_PROP_PROTOTYPE = dmHashString64("prototype");
+    static const dmhash_t COLLECTION_FACTORY_PROP_PROTOTYPE = dmHashLiteral64("prototype");
 
     static void CleanupAsyncLoading(lua_State*, CollectionFactoryComponent*);
     static bool PreloadCompleteCallback(const dmResource::PreloaderCompleteCallbackParams*);

--- a/engine/gamesys/src/gamesys/components/comp_collection_proxy.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_collection_proxy.cpp
@@ -55,13 +55,13 @@ namespace dmGameSystem
 
     const char* COLLECTION_PROXY_MAX_COUNT_KEY = "collection_proxy.max_count";
 
-    static const dmhash_t COLLECTION_PROXY_LOAD_HASH = dmHashString64("load");
-    static const dmhash_t COLLECTION_PROXY_ASYNC_LOAD_HASH = dmHashString64("async_load");
-    static const dmhash_t COLLECTION_PROXY_UNLOAD_HASH = dmHashString64("unload");
-    static const dmhash_t COLLECTION_PROXY_INIT_HASH = dmHashString64("init");
-    static const dmhash_t COLLECTION_PROXY_FINAL_HASH = dmHashString64("final");
-    static const dmhash_t COLLECTION_PROXY_LOADED_HASH = dmHashString64("proxy_loaded");
-    static const dmhash_t COLLECTION_PROXY_UNLOADED_HASH = dmHashString64("proxy_unloaded");
+    static const dmhash_t COLLECTION_PROXY_LOAD_HASH = dmHashLiteral64("load");
+    static const dmhash_t COLLECTION_PROXY_ASYNC_LOAD_HASH = dmHashLiteral64("async_load");
+    static const dmhash_t COLLECTION_PROXY_UNLOAD_HASH = dmHashLiteral64("unload");
+    static const dmhash_t COLLECTION_PROXY_INIT_HASH = dmHashLiteral64("init");
+    static const dmhash_t COLLECTION_PROXY_FINAL_HASH = dmHashLiteral64("final");
+    static const dmhash_t COLLECTION_PROXY_LOADED_HASH = dmHashLiteral64("proxy_loaded");
+    static const dmhash_t COLLECTION_PROXY_UNLOADED_HASH = dmHashLiteral64("proxy_unloaded");
 
     struct CollectionProxyComponent
     {
@@ -747,7 +747,7 @@ namespace dmGameSystem
             dmGameObject::Result r = CompCollectionProxySetTimeStep(0, proxy, ddf->m_Factor, (int)ddf->m_Mode);
             return dmGameObject::RESULT_OK == r ? dmGameObject::UPDATE_RESULT_OK : dmGameObject::UPDATE_RESULT_UNKNOWN_ERROR;
         }
-        else if (params.m_Message->m_Id == dmHashString64("reset_time_step")) // DEPRECATED!
+        else if (params.m_Message->m_Id == dmHashLiteral64("reset_time_step")) // DEPRECATED!
         {
             proxy->m_TimeStepFactor = 1.0f;
             proxy->m_TimeStepMode = dmGameSystemDDF::TIME_STEP_MODE_CONTINUOUS;

--- a/engine/gamesys/src/gamesys/components/comp_collision_object.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_collision_object.cpp
@@ -57,12 +57,12 @@ namespace dmGameSystem
     /// Config key for using max updates during a single step
     const char* PHYSICS_MAX_FIXED_TIMESTEPS         = "physics.max_fixed_timesteps";
 
-    static const dmhash_t PROP_LINEAR_DAMPING = dmHashString64("linear_damping");
-    static const dmhash_t PROP_ANGULAR_DAMPING = dmHashString64("angular_damping");
-    static const dmhash_t PROP_LINEAR_VELOCITY = dmHashString64("linear_velocity");
-    static const dmhash_t PROP_ANGULAR_VELOCITY = dmHashString64("angular_velocity");
-    static const dmhash_t PROP_MASS = dmHashString64("mass");
-    static const dmhash_t PROP_BULLET = dmHashString64("bullet");
+    static const dmhash_t PROP_LINEAR_DAMPING = dmHashLiteral64("linear_damping");
+    static const dmhash_t PROP_ANGULAR_DAMPING = dmHashLiteral64("angular_damping");
+    static const dmhash_t PROP_LINEAR_VELOCITY = dmHashLiteral64("linear_velocity");
+    static const dmhash_t PROP_ANGULAR_VELOCITY = dmHashLiteral64("angular_velocity");
+    static const dmhash_t PROP_MASS = dmHashLiteral64("mass");
+    static const dmhash_t PROP_BULLET = dmHashLiteral64("bullet");
 
     struct CollisionComponent;
     struct JointEndPoint;
@@ -2128,7 +2128,7 @@ namespace dmGameSystem
                 {
                     pit->m_Property.m_Value.m_Bool = dmPhysics::IsEnabled2D(component->m_Object2D);
                 }
-                pit->m_Property.m_NameHash = dmHashString64("enabled");
+                pit->m_Property.m_NameHash = dmHashLiteral64("enabled");
             }
             return true;
         }

--- a/engine/gamesys/src/gamesys/components/comp_factory.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_factory.cpp
@@ -39,7 +39,7 @@ namespace dmGameSystem
 
     const char* FACTORY_MAX_COUNT_KEY = "factory.max_count";
 
-    static const dmhash_t FACTORY_PROP_PROTOTYPE = dmHashString64("prototype");
+    static const dmhash_t FACTORY_PROP_PROTOTYPE = dmHashLiteral64("prototype");
 
     static void CleanupAsyncLoading(lua_State*, FactoryComponent*);
     static bool PreloadCompleteCallback(const dmResource::PreloaderCompleteCallbackParams*);

--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -654,7 +654,7 @@ namespace dmGameSystem
             memset(message, 0, sizeof(dmMessage::Message));
             message->m_Sender = dmMessage::URL();
             message->m_Receiver = dmMessage::URL();
-            message->m_Id = dmHashString64("layout_changed");
+            message->m_Id = dmHashLiteral64("layout_changed");
             message->m_Descriptor = (uintptr_t)dmGuiDDF::LayoutChanged::m_DDFDescriptor;
             message->m_DataSize = sizeof(dmGuiDDF::LayoutChanged);
             dmGuiDDF::LayoutChanged* message_data = (dmGuiDDF::LayoutChanged*)message->m_Data;
@@ -2872,8 +2872,7 @@ namespace dmGameSystem
     static dmhash_t PivotToHash(dmGui::HScene scene, dmGui::HNode node)
     {
         dmGui::Pivot pivot = dmGui::GetNodePivot(scene, node);
-        const char* pivot_name = "";
-#define CASE_PIVOT(_NAME) case dmGui:: _NAME: pivot_name = # _NAME; break
+#define CASE_PIVOT(_NAME) case dmGui::_NAME: return dmHashLiteral64(#_NAME)
 
         switch (pivot)
         {
@@ -2890,7 +2889,7 @@ namespace dmGameSystem
 
 #undef CASE_PIVOT
 
-        return dmHashString64(pivot_name);
+        return dmHashLiteral64("");
     }
 
     static bool CompGuiIterPropertiesGetNext(dmGameObject::SceneNodePropertyIterator* pit)
@@ -3037,7 +3036,7 @@ namespace dmGameSystem
             {
                 pit->m_Property.m_Type = dmGameObject::SCENE_NODE_PROPERTY_TYPE_BOOLEAN;
                 pit->m_Property.m_Value.m_Bool = dmGui::IsNodeEnabled(component->m_Scene, node, false);
-                pit->m_Property.m_NameHash = dmHashString64("enabled");
+                pit->m_Property.m_NameHash = dmHashLiteral64("enabled");
             }
             return true;
         }
@@ -3053,7 +3052,7 @@ namespace dmGameSystem
                 {
                     pit->m_Property.m_Type = dmGameObject::SCENE_NODE_PROPERTY_TYPE_TEXT;
                     pit->m_Property.m_Value.m_Text = dmGui::GetNodeText(component->m_Scene, node);
-                    pit->m_Property.m_NameHash = dmHashString64("text");
+                    pit->m_Property.m_NameHash = dmHashLiteral64("text");
                 }
                 return true;
             }
@@ -3087,9 +3086,9 @@ namespace dmGameSystem
     {
         CompGuiContext* gui_context = new CompGuiContext;
         gui_context->m_Factory = ctx->m_Factory;
-        gui_context->m_RenderContext = *(dmRender::HRenderContext*)ctx->m_Contexts.Get(dmHashString64("render"));
-        gui_context->m_GuiContext = *(dmGui::HContext*)ctx->m_Contexts.Get(dmHashString64("guic"));
-        gui_context->m_ScriptContext = *(dmScript::HContext*)ctx->m_Contexts.Get(dmHashString64("gui_scriptc"));
+        gui_context->m_RenderContext = *(dmRender::HRenderContext*)ctx->m_Contexts.Get(dmHashLiteral64("render"));
+        gui_context->m_GuiContext = *(dmGui::HContext*)ctx->m_Contexts.Get(dmHashLiteral64("guic"));
+        gui_context->m_ScriptContext = *(dmScript::HContext*)ctx->m_Contexts.Get(dmHashLiteral64("gui_scriptc"));
 
         gui_context->m_MaxGuiComponents = dmConfigFile::GetInt(ctx->m_Config, "gui.max_count", 64);
         gui_context->m_MaxParticleFXCount = dmConfigFile::GetInt(ctx->m_Config, "gui.max_particlefx_count", 64);

--- a/engine/gamesys/src/gamesys/components/comp_label.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_label.cpp
@@ -99,9 +99,9 @@ namespace dmGameSystem
     DM_GAMESYS_PROP_VECTOR4(LABEL_PROP_COLOR, color, false);
     DM_GAMESYS_PROP_VECTOR4(LABEL_PROP_OUTLINE, outline, false);
     DM_GAMESYS_PROP_VECTOR4(LABEL_PROP_SHADOW, shadow, false);
-    static const dmhash_t LABEL_PROP_LEADING = dmHashString64("leading");
-    static const dmhash_t LABEL_PROP_TRACKING = dmHashString64("tracking");
-    static const dmhash_t LABEL_PROP_LINE_BREAK = dmHashString64("line_break");
+    static const dmhash_t LABEL_PROP_LEADING = dmHashLiteral64("leading");
+    static const dmhash_t LABEL_PROP_TRACKING = dmHashLiteral64("tracking");
+    static const dmhash_t LABEL_PROP_LINE_BREAK = dmHashLiteral64("line_break");
 
     dmGameObject::CreateResult CompLabelNewWorld(const dmGameObject::ComponentNewWorldParams& params)
     {
@@ -801,7 +801,7 @@ namespace dmGameSystem
             {
                 pit->m_Property.m_Type = dmGameObject::SCENE_NODE_PROPERTY_TYPE_BOOLEAN;
                 pit->m_Property.m_Value.m_Bool = component->m_Enabled;
-                pit->m_Property.m_NameHash = dmHashString64("enabled");
+                pit->m_Property.m_NameHash = dmHashLiteral64("enabled");
             }
             return true;
         }

--- a/engine/gamesys/src/gamesys/components/comp_mesh.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_mesh.cpp
@@ -213,9 +213,9 @@ namespace dmGameSystem
 
     static const uint32_t MAX_TEXTURE_COUNT = dmRender::RenderObject::MAX_TEXTURE_COUNT;
 
-    static const dmhash_t PROP_VERTICES = dmHashString64("vertices");
+    static const dmhash_t PROP_VERTICES = dmHashLiteral64("vertices");
 
-    static const uint64_t AABB_HASH = dmHashString64("AABB");
+    static const uint64_t AABB_HASH = dmHashLiteral64("AABB");
 
     static void ResourceReloadedCallback(const dmResource::ResourceReloadedParams* params);
 
@@ -1133,7 +1133,7 @@ namespace dmGameSystem
             {
                 pit->m_Property.m_Type = dmGameObject::SCENE_NODE_PROPERTY_TYPE_BOOLEAN;
                 pit->m_Property.m_Value.m_Bool = component->m_Enabled;
-                pit->m_Property.m_NameHash = dmHashString64("enabled");
+                pit->m_Property.m_NameHash = dmHashLiteral64("enabled");
             }
             return true;
         }
@@ -1155,7 +1155,7 @@ namespace dmGameSystem
     {
         MeshContext* mesh_context = new MeshContext;
         mesh_context->m_Factory = ctx->m_Factory;
-        mesh_context->m_RenderContext = *(dmRender::HRenderContext*)ctx->m_Contexts.Get(dmHashString64("render"));
+        mesh_context->m_RenderContext = *(dmRender::HRenderContext*)ctx->m_Contexts.Get(dmHashLiteral64("render"));
         mesh_context->m_MaxMeshCount = dmConfigFile::GetInt(ctx->m_Config, "mesh.max_count", 128);
 
         ComponentTypeSetPrio(type, 725);

--- a/engine/gamesys/src/gamesys/components/comp_model.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_model.cpp
@@ -144,10 +144,10 @@ namespace dmGameSystem
     static const uint8_t VX_DECL_INSTANCE_BUFFER    = 1;
     static const uint8_t VX_DECL_CUSTOM_BUFFER      = 2;
 
-    static const dmhash_t PROP_SKIN          = dmHashString64("skin");
-    static const dmhash_t PROP_ANIMATION     = dmHashString64("animation");
-    static const dmhash_t PROP_CURSOR        = dmHashString64("cursor");
-    static const dmhash_t PROP_PLAYBACK_RATE = dmHashString64("playback_rate");
+    static const dmhash_t PROP_SKIN          = dmHashLiteral64("skin");
+    static const dmhash_t PROP_ANIMATION     = dmHashLiteral64("animation");
+    static const dmhash_t PROP_CURSOR        = dmHashLiteral64("cursor");
+    static const dmhash_t PROP_PLAYBACK_RATE = dmHashLiteral64("playback_rate");
 
     static void ResourceReloadedCallback(const dmResource::ResourceReloadedParams* params);
     static void DestroyComponent(ModelWorld* world, uint32_t index);
@@ -2135,7 +2135,7 @@ namespace dmGameSystem
             {
                 pit->m_Property.m_Type = dmGameObject::SCENE_NODE_PROPERTY_TYPE_BOOLEAN;
                 pit->m_Property.m_Value.m_Bool = component->m_Enabled;
-                pit->m_Property.m_NameHash = dmHashString64("enabled");
+                pit->m_Property.m_NameHash = dmHashLiteral64("enabled");
             }
             return true;
         }

--- a/engine/gamesys/src/gamesys/components/comp_sound.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sound.cpp
@@ -71,10 +71,10 @@ namespace dmGameSystem
         dmIndexPool32                   m_EntryIndices;
     };
 
-    static const dmhash_t SOUND_PROP_GAIN   = dmHashString64("gain");
-    static const dmhash_t SOUND_PROP_PAN    = dmHashString64("pan");
-    static const dmhash_t SOUND_PROP_SPEED  = dmHashString64("speed");
-    static const dmhash_t SOUND_PROP_SOUND  = dmHashString64("sound");
+    static const dmhash_t SOUND_PROP_GAIN   = dmHashLiteral64("gain");
+    static const dmhash_t SOUND_PROP_PAN    = dmHashLiteral64("pan");
+    static const dmhash_t SOUND_PROP_SPEED  = dmHashLiteral64("speed");
+    static const dmhash_t SOUND_PROP_SOUND  = dmHashLiteral64("sound");
 
     dmGameObject::CreateResult CompSoundNewWorld(const dmGameObject::ComponentNewWorldParams& params)
     {
@@ -182,8 +182,8 @@ namespace dmGameSystem
     {
         // For reverse hashing to work for easier debugging we hash these ids here
         // The hash container is enabled in engine init so it's too early in compilation unit scope
-        static const dmhash_t SOUND_EVENT_DONE    = dmHashString64("sound_done");
-        static const dmhash_t SOUND_EVENT_STOPPED = dmHashString64("sound_stopped");
+        static const dmhash_t SOUND_EVENT_DONE    = dmHashLiteral64("sound_done");
+        static const dmhash_t SOUND_EVENT_STOPPED = dmHashLiteral64("sound_stopped");
 
         dmSound::Result r = dmSound::DeleteSoundInstance(entry.m_SoundInstance);
         entry.m_SoundInstance = 0;

--- a/engine/gamesys/src/gamesys/components/comp_sprite.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sprite.cpp
@@ -157,10 +157,10 @@ namespace dmGameSystem
     DM_GAMESYS_PROP_VECTOR3(SPRITE_PROP_SIZE, size, false);
     DM_GAMESYS_PROP_VECTOR4(SPRITE_PROP_SLICE, slice, false);
 
-    static const dmhash_t SPRITE_PROP_CURSOR        = dmHashString64("cursor");
-    static const dmhash_t SPRITE_PROP_PLAYBACK_RATE = dmHashString64("playback_rate");
-    static const dmhash_t SPRITE_PROP_ANIMATION     = dmHashString64("animation");
-    static const dmhash_t SPRITE_PROP_FRAME_COUNT   = dmHashString64("frame_count");
+    static const dmhash_t SPRITE_PROP_CURSOR        = dmHashLiteral64("cursor");
+    static const dmhash_t SPRITE_PROP_PLAYBACK_RATE = dmHashLiteral64("playback_rate");
+    static const dmhash_t SPRITE_PROP_ANIMATION     = dmHashLiteral64("animation");
+    static const dmhash_t SPRITE_PROP_FRAME_COUNT   = dmHashLiteral64("frame_count");
 
     // The 9 slice function produces 16 vertices (4 rows 4 columns)
     // and since there's 2 triangles per quad and 9 quads in total,
@@ -2414,7 +2414,7 @@ namespace dmGameSystem
             {
                 pit->m_Property.m_Type = dmGameObject::SCENE_NODE_PROPERTY_TYPE_BOOLEAN;
                 pit->m_Property.m_Value.m_Bool = component->m_Enabled;
-                pit->m_Property.m_NameHash = dmHashString64("enabled");
+                pit->m_Property.m_NameHash = dmHashLiteral64("enabled");
             }
             return true;
         }

--- a/engine/gamesys/src/gamesys/components/comp_tilegrid.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_tilegrid.cpp
@@ -1006,7 +1006,7 @@ namespace dmGameSystem
             {
                 pit->m_Property.m_Type = dmGameObject::SCENE_NODE_PROPERTY_TYPE_BOOLEAN;
                 pit->m_Property.m_Value.m_Bool = component->m_Enabled;
-                pit->m_Property.m_NameHash = dmHashString64("enabled");
+                pit->m_Property.m_NameHash = dmHashLiteral64("enabled");
             }
             return true;
         }

--- a/engine/gamesys/src/gamesys/gamesys_private.h
+++ b/engine/gamesys/src/gamesys/gamesys_private.h
@@ -32,7 +32,7 @@ namespace dmGameSystem
 {
 #define EXT_CONSTANTS(prefix, ext)\
     static const char* prefix##_EXT = ext;\
-    static const dmhash_t prefix##_EXT_HASH = dmHashString64(ext);\
+    static const dmhash_t prefix##_EXT_HASH = dmHashLiteral64(ext);\
 
     EXT_CONSTANTS(COLLECTION_FACTORY, "collectionfactoryc")
     EXT_CONSTANTS(COLLISION_OBJECT, "collisionobjectc")
@@ -49,23 +49,23 @@ namespace dmGameSystem
 
 #undef EXT_CONSTANTS
 
-    static const dmhash_t PROP_FONT = dmHashString64("font");
-    static const dmhash_t PROP_FONTS = dmHashString64("fonts");
-    static const dmhash_t PROP_IMAGE = dmHashString64("image");
-    static const dmhash_t PROP_MATERIAL = dmHashString64("material");
-    static const dmhash_t PROP_MATERIALS = dmHashString64("materials");
+    static const dmhash_t PROP_FONT = dmHashLiteral64("font");
+    static const dmhash_t PROP_FONTS = dmHashLiteral64("fonts");
+    static const dmhash_t PROP_IMAGE = dmHashLiteral64("image");
+    static const dmhash_t PROP_MATERIAL = dmHashLiteral64("material");
+    static const dmhash_t PROP_MATERIALS = dmHashLiteral64("materials");
     static const dmhash_t PROP_TEXTURE[dmRender::RenderObject::MAX_TEXTURE_COUNT] = {
-        dmHashString64("texture0"),
-        dmHashString64("texture1"),
-        dmHashString64("texture2"),
-        dmHashString64("texture3"),
-        dmHashString64("texture4"),
-        dmHashString64("texture5"),
-        dmHashString64("texture6"),
-        dmHashString64("texture7")
+        dmHashLiteral64("texture0"),
+        dmHashLiteral64("texture1"),
+        dmHashLiteral64("texture2"),
+        dmHashLiteral64("texture3"),
+        dmHashLiteral64("texture4"),
+        dmHashLiteral64("texture5"),
+        dmHashLiteral64("texture6"),
+        dmHashLiteral64("texture7")
     };
-    static const dmhash_t PROP_TEXTURES = dmHashString64("textures");
-    static const dmhash_t PROP_TILE_SOURCE = dmHashString64("tile_source");
+    static const dmhash_t PROP_TEXTURES = dmHashLiteral64("textures");
+    static const dmhash_t PROP_TILE_SOURCE = dmHashLiteral64("tile_source");
 
     struct EmitterStateChangedScriptData
     {

--- a/engine/gamesys/src/gamesys/resources/res_gui_script.cpp
+++ b/engine/gamesys/src/gamesys/resources/res_gui_script.cpp
@@ -119,14 +119,14 @@ namespace dmGameSystem
 
     static ResourceResult ResourceTypeGuiScript_Register(HResourceTypeContext ctx, HResourceType type)
     {
-        dmScript::HContext gui_scriptc_ctx = (dmScript::HContext)ResourceTypeContextGetContextByHash(ctx, dmHashString64("gui_scriptc"));
+        dmScript::HContext gui_scriptc_ctx = (dmScript::HContext)ResourceTypeContextGetContextByHash(ctx, dmHashLiteral64("gui_scriptc"));
         if (gui_scriptc_ctx == 0)
         {
             dmLogError("Missing resource context 'gui_scriptc' when registering resource type 'gui_scriptc'");
             return RESOURCE_RESULT_INVAL;
         }
 
-        dmGui::HContext gui_ctx = (dmGui::HContext)ResourceTypeContextGetContextByHash(ctx, dmHashString64("guic"));
+        dmGui::HContext gui_ctx = (dmGui::HContext)ResourceTypeContextGetContextByHash(ctx, dmHashLiteral64("guic"));
         if (gui_ctx == 0)
         {
             dmLogError("Missing resource context 'guic' when registering resource type 'gui_scriptc'");

--- a/engine/gamesys/src/gamesys/scripts/script_image.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_image.cpp
@@ -301,7 +301,7 @@ namespace dmGameSystem
             lua_pushliteral(L, "buffer");
 
             dmBuffer::StreamDeclaration streams_decl[] = {
-                { dmHashString64("data"), dmBuffer::VALUE_TYPE_UINT8, bytes_per_pixel }
+                { dmHashLiteral64("data"), dmBuffer::VALUE_TYPE_UINT8, bytes_per_pixel }
             };
 
             dmBuffer::HBuffer buffer = 0;

--- a/engine/gamesys/src/gamesys/scripts/script_resource.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_resource.cpp
@@ -411,7 +411,7 @@ static int Load(lua_State* L)
     }
 
     dmBuffer::StreamDeclaration streams_decl[] = {
-        {dmHashString64("data"), dmBuffer::VALUE_TYPE_UINT8, 1}
+        {dmHashLiteral64("data"), dmBuffer::VALUE_TYPE_UINT8, 1}
     };
 
     dmBuffer::HBuffer buffer = 0;
@@ -1027,7 +1027,7 @@ static int CreateTextureAsync(lua_State* L)
     bool use_upload_buffer = create_params.m_Buffer == 0;
     if (use_upload_buffer)
     {
-        const dmBuffer::StreamDeclaration streams_decl = {dmHashString64("data"), dmBuffer::VALUE_TYPE_UINT8, 1};
+        const dmBuffer::StreamDeclaration streams_decl = {dmHashLiteral64("data"), dmBuffer::VALUE_TYPE_UINT8, 1};
         dmBuffer::Result r = dmBuffer::Create(create_params.m_Width * create_params.m_Height * create_params.m_TextureBpp, &streams_decl, 1, &upload_buffer);
         if (r != dmBuffer::RESULT_OK)
         {

--- a/engine/gamesys/src/gamesys/scripts/script_sys_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_sys_gamesys.cpp
@@ -172,7 +172,7 @@ namespace dmGameSystem
             HOpaqueHandle request_handle = (HOpaqueHandle) (uintptr_t) context;
             LuaRequest* request          = g_SysModule.m_LoadRequests.Get(request_handle);
             request->m_Status            = REQUEST_STATUS_FINISHED;
-            dmBuffer::StreamDeclaration streams_decl[] = {{ dmHashString64("data"), dmBuffer::VALUE_TYPE_UINT8, 1 }};
+            dmBuffer::StreamDeclaration streams_decl[] = {{ dmHashLiteral64("data"), dmBuffer::VALUE_TYPE_UINT8, 1 }};
             dmBuffer::Create(request->m_LoadBuffer.Size(), streams_decl, 1, &request->m_Payload);
 
             uint8_t* buffer_data     = 0;
@@ -239,7 +239,7 @@ namespace dmGameSystem
             return luaL_error(L, "sys.load_buffer failed to load the resource (code=%d)", (int) res);
         }
 
-        dmBuffer::StreamDeclaration streams_decl[] = {{ dmHashString64("data"), dmBuffer::VALUE_TYPE_UINT8, 1 }};
+        dmBuffer::StreamDeclaration streams_decl[] = {{ dmHashLiteral64("data"), dmBuffer::VALUE_TYPE_UINT8, 1 }};
 
         dmBuffer::HBuffer buffer = 0;
         dmBuffer::Create(load_buffer_data.Size(), streams_decl, 1, &buffer);

--- a/engine/gamesys/src/gamesys/test/test_gamesys.h
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.h
@@ -471,10 +471,10 @@ void GamesysTest<T>::SetupComponentCreateContext(dmGameObject::ComponentTypeCrea
     component_create_ctx.m_Factory = m_Factory;
     component_create_ctx.m_Config = m_Config;
     component_create_ctx.m_Contexts.SetCapacity(3, 8);
-    component_create_ctx.m_Contexts.Put(dmHashString64("graphics"), m_GraphicsContext);
-    component_create_ctx.m_Contexts.Put(dmHashString64("render"), m_RenderContext);
-    component_create_ctx.m_Contexts.Put(dmHashString64("guic"), m_GuiContext);
-    component_create_ctx.m_Contexts.Put(dmHashString64("gui_scriptc"), m_ScriptContext);
+    component_create_ctx.m_Contexts.Put(dmHashLiteral64("graphics"), m_GraphicsContext);
+    component_create_ctx.m_Contexts.Put(dmHashLiteral64("render"), m_RenderContext);
+    component_create_ctx.m_Contexts.Put(dmHashLiteral64("guic"), m_GuiContext);
+    component_create_ctx.m_Contexts.Put(dmHashLiteral64("gui_scriptc"), m_ScriptContext);
 }
 
 template<typename T>
@@ -531,12 +531,12 @@ void GamesysTest<T>::SetUp()
     dmGameObject::Initialize(m_Register, m_ScriptContext);
 
     m_Contexts.SetCapacity(7,16);
-    m_Contexts.Put(dmHashString64("goc"), m_Register);
-    m_Contexts.Put(dmHashString64("collectionc"), m_Register);
-    m_Contexts.Put(dmHashString64("scriptc"), m_ScriptContext);
-    m_Contexts.Put(dmHashString64("luac"), &m_ModuleContext);
-    m_Contexts.Put(dmHashString64("guic"), m_GuiContext);
-    m_Contexts.Put(dmHashString64("gui_scriptc"), m_ScriptContext);
+    m_Contexts.Put(dmHashLiteral64("goc"), m_Register);
+    m_Contexts.Put(dmHashLiteral64("collectionc"), m_Register);
+    m_Contexts.Put(dmHashLiteral64("scriptc"), m_ScriptContext);
+    m_Contexts.Put(dmHashLiteral64("luac"), &m_ModuleContext);
+    m_Contexts.Put(dmHashLiteral64("guic"), m_GuiContext);
+    m_Contexts.Put(dmHashLiteral64("gui_scriptc"), m_ScriptContext);
 
     dmResource::RegisterTypes(m_Factory, &m_Contexts);
 
@@ -758,8 +758,8 @@ protected:
         L = dmScript::GetLuaState(m_Context);
 
         const dmBuffer::StreamDeclaration streams_decl[] = {
-            {dmHashString64("rgb"), dmBuffer::VALUE_TYPE_UINT16, 3},
-            {dmHashString64("a"), dmBuffer::VALUE_TYPE_FLOAT32, 1},
+            {dmHashLiteral64("rgb"), dmBuffer::VALUE_TYPE_UINT16, 3},
+            {dmHashLiteral64("a"), dmBuffer::VALUE_TYPE_FLOAT32, 1},
         };
 
         m_Count = 256;
@@ -814,8 +814,8 @@ protected:
 
 
         const dmBuffer::StreamDeclaration streams_decl[] = {
-            {dmHashString64("rgb"), dmBuffer::VALUE_TYPE_UINT16, 3},
-            {dmHashString64("a"), dmBuffer::VALUE_TYPE_FLOAT32, 1},
+            {dmHashLiteral64("rgb"), dmBuffer::VALUE_TYPE_UINT16, 3},
+            {dmHashLiteral64("a"), dmBuffer::VALUE_TYPE_FLOAT32, 1},
         };
 
         const CopyBufferTestParams& p = GetParam();

--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -58,9 +58,9 @@ namespace dmGui
     /**
      * Default layer id
      */
-    const dmhash_t DEFAULT_LAYER = dmHashString64("");
+    const dmhash_t DEFAULT_LAYER = dmHashLiteral64("");
 
-    const dmhash_t DEFAULT_LAYOUT = dmHashString64("");
+    const dmhash_t DEFAULT_LAYOUT = dmHashLiteral64("");
 
     const uint16_t INVALID_INDEX = 0xffff;
 
@@ -93,11 +93,11 @@ namespace dmGui
     };
 
 #define PROP(name, prop)\
-    { dmHashString64(#name), prop, 0xff }, \
-    { dmHashString64(#name ".x"), prop, 0 }, \
-    { dmHashString64(#name ".y"), prop, 1 }, \
-    { dmHashString64(#name ".z"), prop, 2 }, \
-    { dmHashString64(#name ".w"), prop, 3 },
+    { dmHashLiteral64(#name), prop, 0xff }, \
+    { dmHashLiteral64(#name ".x"), prop, 0 }, \
+    { dmHashLiteral64(#name ".y"), prop, 1 }, \
+    { dmHashLiteral64(#name ".z"), prop, 2 }, \
+    { dmHashLiteral64(#name ".w"), prop, 3 },
 
     PropDesc g_Properties[] = {
             PROP(position, PROPERTY_POSITION )
@@ -109,23 +109,23 @@ namespace dmGui
             PROP(shadow, PROPERTY_SHADOW )
             PROP(slice9, PROPERTY_SLICE9 )
             PROP(euler, PROPERTY_EULER )
-            { dmHashString64("inner_radius"), PROPERTY_PIE_PARAMS, 0 },
-            { dmHashString64("fill_angle"), PROPERTY_PIE_PARAMS, 1 },
-            { dmHashString64("leading"), PROPERTY_TEXT_PARAMS, 0 },
-            { dmHashString64("tracking"), PROPERTY_TEXT_PARAMS, 1 },
+            { dmHashLiteral64("inner_radius"), PROPERTY_PIE_PARAMS, 0 },
+            { dmHashLiteral64("fill_angle"), PROPERTY_PIE_PARAMS, 1 },
+            { dmHashLiteral64("leading"), PROPERTY_TEXT_PARAMS, 0 },
+            { dmHashLiteral64("tracking"), PROPERTY_TEXT_PARAMS, 1 },
     };
 #undef PROP
 
     PropDesc g_PropTable[] = {
-            { dmHashString64("position"), PROPERTY_POSITION, 0xff },
-            { dmHashString64("rotation"), PROPERTY_ROTATION, 0xff },
-            { dmHashString64("scale"), PROPERTY_SCALE, 0xff },
-            { dmHashString64("color"), PROPERTY_COLOR, 0xff },
-            { dmHashString64("size"), PROPERTY_SIZE, 0xff },
-            { dmHashString64("outline"), PROPERTY_OUTLINE, 0xff },
-            { dmHashString64("shadow"), PROPERTY_SHADOW, 0xff },
-            { dmHashString64("slice"), PROPERTY_SLICE9, 0xff },
-            { dmHashString64("euler"), PROPERTY_EULER, 0xff },
+            { dmHashLiteral64("position"), PROPERTY_POSITION, 0xff },
+            { dmHashLiteral64("rotation"), PROPERTY_ROTATION, 0xff },
+            { dmHashLiteral64("scale"), PROPERTY_SCALE, 0xff },
+            { dmHashLiteral64("color"), PROPERTY_COLOR, 0xff },
+            { dmHashLiteral64("size"), PROPERTY_SIZE, 0xff },
+            { dmHashLiteral64("outline"), PROPERTY_OUTLINE, 0xff },
+            { dmHashLiteral64("shadow"), PROPERTY_SHADOW, 0xff },
+            { dmHashLiteral64("slice"), PROPERTY_SLICE9, 0xff },
+            { dmHashLiteral64("euler"), PROPERTY_EULER, 0xff },
     };
 
     PropDesc* GetPropertyDesc(dmhash_t property_hash)

--- a/engine/gui/src/gui_null.cpp
+++ b/engine/gui/src/gui_null.cpp
@@ -43,7 +43,7 @@ namespace dmGui
 
 
     // gui_null.cpp
-    const dmhash_t DEFAULT_LAYER = dmHashString64("");
+    const dmhash_t DEFAULT_LAYER = dmHashLiteral64("");
     const dmhash_t DEFAULT_LAYOUT = DEFAULT_LAYER;
     const uint16_t INVALID_INDEX = 0xffff;
 

--- a/engine/input/src/input.cpp
+++ b/engine/input/src/input.cpp
@@ -27,7 +27,7 @@
 
 namespace dmInput
 {
-    const uint32_t UNKNOWN_GAMEPAD_CONFIG_ID = dmHashString32("UNKNOWN_GAMEPAD_CONFIG_ID");
+    const uint32_t UNKNOWN_GAMEPAD_CONFIG_ID = dmHashLiteral32("UNKNOWN_GAMEPAD_CONFIG_ID");
     static const uint16_t INVALID_INDEX = 0xFFFF;
 
 

--- a/engine/liveupdate/src/liveupdate.cpp
+++ b/engine/liveupdate/src/liveupdate.cpp
@@ -656,7 +656,7 @@ namespace dmLiveUpdate
         dmURI::Parts uri;
         dmURI::Parse(archive_uri, &uri);
 
-        dmResourceProvider::HArchiveLoader loader = dmResourceProvider::FindLoaderByName(dmHashString64("zip"));
+        dmResourceProvider::HArchiveLoader loader = dmResourceProvider::FindLoaderByName(dmHashLiteral64("zip"));
         if (!loader)
         {
             dmLogError("Failed to find 'mutable' loader");

--- a/engine/profiler/src/profiler.cpp
+++ b/engine/profiler/src/profiler.cpp
@@ -760,9 +760,9 @@ static dmExtension::Result AppInitializeProfiler(dmExtension::AppParams* params)
     }
 
     g_ProfilerThreadSortOrder.SetCapacity(7, 8);
-    g_ProfilerThreadSortOrder.Put(dmHashString64("Main"), 0);
-    g_ProfilerThreadSortOrder.Put(dmHashString64("sound"), 1);
-    g_ProfilerThreadSortOrder.Put(dmHashString64("liveupdate"), 2);
+    g_ProfilerThreadSortOrder.Put(dmHashLiteral64("Main"), 0);
+    g_ProfilerThreadSortOrder.Put(dmHashLiteral64("sound"), 1);
+    g_ProfilerThreadSortOrder.Put(dmHashLiteral64("liveupdate"), 2);
 
     return dmExtension::RESULT_OK;
 }

--- a/engine/render/src/render/debug_renderer.cpp
+++ b/engine/render/src/render/debug_renderer.cpp
@@ -86,12 +86,12 @@ namespace dmRender
         }
 
         HMaterial material3d = NewMaterial(render_context, vertex_program, fragment_program);
-        SetMaterialProgramConstantType(material3d, dmHashString64("view_proj"), dmRenderDDF::MaterialDesc::CONSTANT_TYPE_VIEWPROJ);
+        SetMaterialProgramConstantType(material3d, dmHashLiteral64("view_proj"), dmRenderDDF::MaterialDesc::CONSTANT_TYPE_VIEWPROJ);
         dmhash_t debug_tag_3d = dmHashString64(DEBUG_3D_NAME);
         SetMaterialTags(material3d, 1, &debug_tag_3d);
 
         HMaterial material2d = NewMaterial(render_context, vertex_program, fragment_program);
-        SetMaterialProgramConstantType(material2d, dmHashString64("view_proj"), dmRenderDDF::MaterialDesc::CONSTANT_TYPE_VIEWPROJ);
+        SetMaterialProgramConstantType(material2d, dmHashLiteral64("view_proj"), dmRenderDDF::MaterialDesc::CONSTANT_TYPE_VIEWPROJ);
         dmhash_t debug_tag_2d = dmHashString64(DEBUG_2D_NAME);
         SetMaterialTags(material2d, 1, &debug_tag_2d);
 

--- a/engine/render/src/render/font_renderer.cpp
+++ b/engine/render/src/render/font_renderer.cpp
@@ -528,7 +528,7 @@ namespace dmRender
         }
     };
 
-    static dmhash_t g_TextureSizeRecipHash = dmHashString64("texture_size_recip");
+    static dmhash_t g_TextureSizeRecipHash = dmHashLiteral64("texture_size_recip");
 
     static dmVMath::Point3 CalcCenterPoint(HFontMap font_map, const TextEntry& te, const TextMetrics& metrics) {
         float x_offset = OffsetX(te.m_Align, te.m_Width);

--- a/engine/render/src/render/render.h
+++ b/engine/render/src/render/render.h
@@ -32,15 +32,15 @@ namespace dmRender
 
     static const uint32_t MAX_MATERIAL_TAG_COUNT = 32; // Max tag count per material
 
-    static const dmhash_t VERTEX_STREAM_POSITION      = dmHashString64("position");
-    static const dmhash_t VERTEX_STREAM_NORMAL        = dmHashString64("normal");
-    static const dmhash_t VERTEX_STREAM_TANGENT       = dmHashString64("tangent");
-    static const dmhash_t VERTEX_STREAM_COLOR         = dmHashString64("color");
-    static const dmhash_t VERTEX_STREAM_TEXCOORD0     = dmHashString64("texcoord0");
-    static const dmhash_t VERTEX_STREAM_TEXCOORD1     = dmHashString64("texcoord1");
-    static const dmhash_t VERTEX_STREAM_PAGE_INDEX    = dmHashString64("page_index");
-    static const dmhash_t VERTEX_STREAM_WORLD_MATRIX  = dmHashString64("mtx_world");
-    static const dmhash_t VERTEX_STREAM_NORMAL_MATRIX = dmHashString64("mtx_normal");
+    static const dmhash_t VERTEX_STREAM_POSITION      = dmHashLiteral64("position");
+    static const dmhash_t VERTEX_STREAM_NORMAL        = dmHashLiteral64("normal");
+    static const dmhash_t VERTEX_STREAM_TANGENT       = dmHashLiteral64("tangent");
+    static const dmhash_t VERTEX_STREAM_COLOR         = dmHashLiteral64("color");
+    static const dmhash_t VERTEX_STREAM_TEXCOORD0     = dmHashLiteral64("texcoord0");
+    static const dmhash_t VERTEX_STREAM_TEXCOORD1     = dmHashLiteral64("texcoord1");
+    static const dmhash_t VERTEX_STREAM_PAGE_INDEX    = dmHashLiteral64("page_index");
+    static const dmhash_t VERTEX_STREAM_WORLD_MATRIX  = dmHashLiteral64("mtx_world");
+    static const dmhash_t VERTEX_STREAM_NORMAL_MATRIX = dmHashLiteral64("mtx_normal");
 
     typedef struct RenderTargetSetup*       HRenderTargetSetup;
     typedef uint64_t                        HRenderType;

--- a/engine/resource/src/resource.cpp
+++ b/engine/resource/src/resource.cpp
@@ -184,7 +184,7 @@ static Result AddBuiltinMount(HFactory factory, NewFactoryParams* params)
         return RESULT_INVAL;
     }
 
-    dmResourceProvider::HArchiveLoader loader = dmResourceProvider::FindLoaderByName(dmHashString64("archive"));
+    dmResourceProvider::HArchiveLoader loader = dmResourceProvider::FindLoaderByName(dmHashLiteral64("archive"));
     result = dmResourceProvider::CreateMount(loader, internal, &factory->m_BuiltinMount);
 
     if (dmResourceProvider::RESULT_OK != result)

--- a/engine/rig/src/rig.cpp
+++ b/engine/rig/src/rig.cpp
@@ -29,7 +29,7 @@ namespace dmRig
 {
     using namespace dmVMath;
 
-    static const dmhash_t NULL_ANIMATION = dmHashString64("");
+    static const dmhash_t NULL_ANIMATION = dmHashLiteral64("");
     static const float CURSOR_EPSILON = 0.0001f;
 
     static void DoAnimate(HRigContext context, RigInstance* instance, float dt);

--- a/engine/sound/src/sound.cpp
+++ b/engine/sound/src/sound.cpp
@@ -49,7 +49,7 @@ namespace dmSound
     // TODO: How many bits?
     const uint32_t RESAMPLE_FRACTION_BITS = 31;
 
-    const dmhash_t MASTER_GROUP_HASH = dmHashString64("master");
+    const dmhash_t MASTER_GROUP_HASH = dmHashLiteral64("master");
     const uint32_t GROUP_MEMORY_BUFFER_COUNT = 64;
 
     static void SoundThread(void* ctx);


### PR DESCRIPTION
skip release notes

Resolves #9740

### Technical changes

* Added macros `dmHashLiteral32` and `dmHashLiteral64` in hash.h.
* No changes to behavior — simply uses the new macro where possible.