### PR TITLE
Remove platform specific handling of snprintf on Windows since it's not needed with Universal CRT

### DIFF
--- a/engine/dlib/src/dlib/dstrings.cpp
+++ b/engine/dlib/src/dlib/dstrings.cpp
@@ -25,18 +25,14 @@
 
 int dmSnPrintf(char *buffer, size_t count, const char *format, ...)
 {
-    // MS-compliance
+    // mimics ms pre-ucrt vsnprintf_s behavior
     if (buffer == 0x0 || count == 0 || format == 0x0)
         return -1;
     va_list argp;
     va_start(argp, format);
-#if defined(_WIN32)
-    int result = _vsnprintf_s(buffer, count, _TRUNCATE, format, argp);
-#else
     int result = vsnprintf(buffer, count, format, argp);
-#endif
     va_end(argp);
-    // MS-compliance
+    // mimics ms pre-ucrt vsnprintf_s behavior
     if (count == 0 || (count > 0 && result >= (int)count))
         return -1;
     return result;

--- a/engine/dlib/src/dlib/dstrings.cpp
+++ b/engine/dlib/src/dlib/dstrings.cpp
@@ -33,7 +33,7 @@ int dmSnPrintf(char *buffer, size_t count, const char *format, ...)
     int result = vsnprintf(buffer, count, format, argp);
     va_end(argp);
     // mimics ms pre-ucrt vsnprintf_s behavior
-    if (count == 0 || (count > 0 && result >= (int)count))
+    if (result >= (int)count)
         return -1;
     return result;
 }

--- a/engine/dlib/src/dlib/pprint.cpp
+++ b/engine/dlib/src/dlib/pprint.cpp
@@ -48,11 +48,7 @@ namespace dmPPrint
         }
 
         int c = m_BufferSize - m_Cursor;
-    #if defined(_WIN32)
-        _vsnprintf_s(m_Buffer + m_Cursor, c, _TRUNCATE, format, argp);
-    #else
         vsnprintf(m_Buffer + m_Cursor, c, format, argp);
-    #endif
 
         m_Buffer[m_BufferSize-1] = '\0';
         m_Cursor = strlen(m_Buffer);

--- a/engine/dlib/src/dlib/testutil.cpp
+++ b/engine/dlib/src/dlib/testutil.cpp
@@ -103,13 +103,7 @@ const char* MakeHostPathf(char* dst, uint32_t dst_len, const char* path_format, 
 
     va_list argp;
     va_start(argp, path_format);
-
-#if defined(_WIN32)
-    int result = _vsnprintf_s(dst+len, dst_len-len, _TRUNCATE, path_format, argp);
-#else
-    int result = vsnprintf(dst+len, dst_len-len, path_format, argp);
-#endif
-    (void)result;
+    vsnprintf(dst+len, dst_len-len, path_format, argp);
     va_end(argp);
 
     dmPath::Normalize(dst, dst, dst_len);

--- a/engine/script/src/script_table.cpp
+++ b/engine/script/src/script_table.cpp
@@ -820,11 +820,7 @@ namespace dmScript
         size_t count = sizeof(buffer);
         va_list argp;
         va_start(argp, format);
-#if defined(_WIN32)
-        _vsnprintf_s(buffer, count, _TRUNCATE, format, argp);
-#else
         vsnprintf(buffer, count, format, argp);
-#endif
         va_end(argp);
         PushTableLogString(logger, buffer);
     }


### PR DESCRIPTION
skip release notes

Resolves #9747

### Technical changes

* Replaced use of `_vsnprintf_s` with `vsnprintf` on `_WIN32`. With the Universal CRT in Visual Studio 2015 and Windows 10, the `snprintf` family of functions now comply with C99, and as a result, there's no need to have platform specific code. Since no platform besides Windows use the `_s` function variant, I'm assuming that a decision has been made to not use it, so neither should Windows now with this update.
* No changes to actual behavior.