### PR TITLE
Add handling of -1 return value from dmSnPrintf when the result was truncated

### DIFF
--- a/engine/dlib/src/dlib/http_client.cpp
+++ b/engine/dlib/src/dlib/http_client.cpp
@@ -522,7 +522,7 @@ namespace dmHttpClient
         // DEF-2889 most webservers have a header length limit of 8096 bytes
         char buf[8096];
         const int bufsize = sizeof(buf);
-        if(dmSnPrintf(buf, bufsize, "%s: %s\r\n", name, value) > bufsize) {
+        if(dmSnPrintf(buf, bufsize, "%s: %s\r\n", name, value) == -1) {
             dmLogWarning("Truncated HTTP request header %s since it was larger than %d", name, bufsize);
         }
 

--- a/engine/dlib/src/dlib/log.cpp
+++ b/engine/dlib/src/dlib/log.cpp
@@ -671,7 +671,8 @@ void LogInternal(LogSeverity severity, const char* domain, const char* format, .
 
     if (n < dmLog::MAX_STRING_SIZE)
     {
-        n += dmSnPrintf(str_buf + n, dmLog::MAX_STRING_SIZE - n, "\n");
+        dmSnPrintf(str_buf + n, dmLog::MAX_STRING_SIZE - n, "\n");
+        ++n; // Since dmSnPrintf returns -1 on truncation, don't add the return value to n, and instead increment n separately
     }
 
     if (n >= dmLog::MAX_STRING_SIZE)

--- a/engine/dlib/src/dlib/testutil.cpp
+++ b/engine/dlib/src/dlib/testutil.cpp
@@ -53,8 +53,8 @@ const char* GetIpFromConfig(dmConfigFile::HConfig config, char* ip, uint32_t ipl
         return 0;
     }
 
-    uint32_t nwritten = dmSnPrintf(ip, iplen, "%s", _ip);
-    if (nwritten >= iplen)
+    int nwritten = dmSnPrintf(ip, iplen, "%s", _ip);
+    if (nwritten == -1)
         return 0;
     return ip;
 }

--- a/engine/dlib/src/dmsdk/dlib/dstrings.h
+++ b/engine/dlib/src/dmsdk/dlib/dstrings.h
@@ -29,7 +29,8 @@
 
 /*# Size-bounded string formating.
  *
- * Size-bounded string formating. Resulting string is guaranteed to be 0-terminated.
+ * Size-bounded string formating. Resulting string is guaranteed to be 0-terminated. Unlike snprintf, which
+ * always returns the untruncated string length, this function returns -1 if the string was truncated.
  *
  * @name dmSnPrintf
  * @param buffer Buffer to write to

--- a/engine/dlib/src/test/test_log.cpp
+++ b/engine/dlib/src/test/test_log.cpp
@@ -14,6 +14,7 @@
 
 #include <stdint.h>
 #include <stdlib.h>
+#include <string.h>
 #include <testmain/testmain.h>
 #include "../dlib/array.h"
 #include "../dlib/atomic.h"
@@ -241,6 +242,7 @@ static void TestLogCaptureCallback(LogSeverity severity, const char* domain, con
 
 TEST(dmLog, TestCapture)
 {
+    g_LogListenerOutput.SetSize(0);
     dmLog::LogParams params;
     dmLog::LogInitialize(&params);
     dmLogRegisterListener(TestLogCaptureCallback);
@@ -266,6 +268,62 @@ TEST(dmLog, TestCapture)
     ASSERT_STREQ(ExpectedOutput, g_LogListenerOutput.Begin());
 }
 
+TEST(dmLog, TestMaxUntruncatedMessageLength)
+{
+    g_LogListenerOutput.SetSize(0);
+    dmLog::LogParams params;
+    dmLog::LogInitialize(&params);
+    dmLogRegisterListener(TestLogCaptureCallback);
+
+    const size_t expected_size = dmLog::MAX_STRING_SIZE;
+    char* expected = (char*)malloc(expected_size);
+    const char prefix[] = "INFO:DLIB: ";
+    const size_t prefix_length = sizeof(prefix) - 1;
+    memcpy(expected, prefix, prefix_length);
+    memset(expected + prefix_length, 'x', expected_size - prefix_length - 2);
+    strcpy(expected + expected_size - 2, "\n");
+
+    expected[expected_size - 2] = '\0'; // let input length be one short of the output length to leave space for dmLog to append a newline
+    dmLogInfo(expected + prefix_length);
+    expected[expected_size - 2] = '\n'; // add the expected newline at the end
+
+    dmLog::LogFinalize();
+    g_LogListenerOutput.SetCapacity(g_LogListenerOutput.Size() + 1);
+    g_LogListenerOutput.Push('\0');
+
+    ASSERT_STREQ(expected, g_LogListenerOutput.Begin());
+
+    free(expected);
+}
+
+TEST(dmLog, TestMessageTruncationThreshold)
+{
+    g_LogListenerOutput.SetSize(0);
+    dmLog::LogParams params;
+    dmLog::LogInitialize(&params);
+    dmLogRegisterListener(TestLogCaptureCallback);
+
+    const size_t expected_size = dmLog::MAX_STRING_SIZE;
+    char* expected = (char*)malloc(expected_size);
+    const char prefix[] = "INFO:DLIB: ";
+    const size_t prefix_length = sizeof(prefix) - 1;
+    memcpy(expected, prefix, prefix_length);
+    memset(expected + prefix_length, 'x', expected_size - prefix_length - 2);
+    strcpy(expected + expected_size - 2, "\n");
+
+    expected[expected_size - 2] = '!'; // let input length be one too long, i.e. leave no space for dmLog to append a newline
+    dmLogInfo(expected + prefix_length);
+    const char truncation_msg[] = "...\n[Output truncated]\n"; // copied from log.cpp
+    strcpy(expected + expected_size - sizeof(truncation_msg), truncation_msg);
+
+    dmLog::LogFinalize();
+    g_LogListenerOutput.SetCapacity(g_LogListenerOutput.Size() + 1);
+    g_LogListenerOutput.Push('\0');
+
+    ASSERT_STREQ(expected, g_LogListenerOutput.Begin());
+
+    free(expected);
+}
 
 static void LogThreadWithLogCalls(void* arg)
 {

--- a/engine/gamesys/src/gamesys/gamesys_private.cpp
+++ b/engine/gamesys/src/gamesys/gamesys_private.cpp
@@ -46,13 +46,21 @@ namespace dmGameSystem
             const char* path_name_receiver = dmHashReverseSafe64(receiver->m_Path);
             const char* fragment_name_receiver = dmHashReverseSafe64(receiver->m_Fragment);
 
-            n+= dmSnPrintf(buf + n, sizeof(buf) - n, " Message '%s' sent from %s:%s#%s to %s:%s#%s.",
+            int length = dmSnPrintf(buf + n, sizeof(buf) - n, " Message '%s' sent from %s:%s#%s to %s:%s#%s.",
                             id_str,
                             socket_name_sender, path_name_sender, fragment_name_sender,
                             socket_name_receiver, path_name_receiver, fragment_name_receiver);
+            if (length == -1)
+            {
+                n = sizeof(buf);
+            }
+            else
+            {
+                n += length;
+            }
         }
 
-        if (n >= (int) sizeof(buf) - 1) {
+        if (n > (int) sizeof(buf) - 1) {
             dmLogError("Buffer underflow when formatting message-error (LogMessageError)");
         }
 


### PR DESCRIPTION
skip release notes

Resolves #9749

### Technical changes

* Added handling of -1 return value from `dmSnPrintf`, which is returned when the resulting string was truncated.
* Fixed a couple of erroneous return value and bound checks.