### PR TITLE
Engine Arguments field in preferences

### DIFF
--- a/editor/src/clj/editor/engine.clj
+++ b/editor/src/clj/editor/engine.clj
@@ -14,7 +14,6 @@
 
 (ns editor.engine
   (:require [clojure.java.io :as io]
-            [clojure.string :as string]
             [clojure.string :as str]
             [editor.code.util :refer [split-lines]]
             [editor.engine.native-extensions :as native-extensions]
@@ -282,8 +281,8 @@
                      (> instance-index 0)
                      (into [(format "--config=project.instance_index=%d" instance-index)])
 
-                     (not (string/blank? engine-arguments))
-                     (into (remove string/blank?) (split-lines engine-arguments)))
+                     (not (str/blank? engine-arguments))
+                     (into (remove str/blank?) (split-lines engine-arguments)))
         env {"DM_SERVICE_PORT" "dynamic"
              "DM_QUIT_ON_ESC" (if (prefs/get prefs [:run :quit-on-escape])
                                 "1" "0")

--- a/editor/src/clj/editor/engine.clj
+++ b/editor/src/clj/editor/engine.clj
@@ -15,6 +15,7 @@
 (ns editor.engine
   (:require [clojure.java.io :as io]
             [clojure.string :as str]
+            [editor.code.util :refer [split-lines]]
             [editor.engine.native-extensions :as native-extensions]
             [editor.fs :as fs]
             [editor.prefs :as prefs]
@@ -268,7 +269,7 @@
                                (File.)
                                (.getAbsolutePath))
         command (.getAbsolutePath engine)
-        engine-argument (prefs/get prefs [:run :engine-arguments])
+        engine-arguments (prefs/get prefs [:run :engine-arguments])
         args (cond-> []
                      defold-log-dir
                      (into ["--config=project.write_log=1"
@@ -280,8 +281,8 @@
                      (> instance-index 0)
                      (into [(format "--config=project.instance_index=%d" instance-index)])
 
-                     (not-empty engine-argument)
-                     (into [engine-argument]))
+                     (not-empty engine-arguments)
+                     (into (split-lines engine-arguments)))
         env {"DM_SERVICE_PORT" "dynamic"
              "DM_QUIT_ON_ESC" (if (prefs/get prefs [:run :quit-on-escape])
                                 "1" "0")

--- a/editor/src/clj/editor/engine.clj
+++ b/editor/src/clj/editor/engine.clj
@@ -14,6 +14,7 @@
 
 (ns editor.engine
   (:require [clojure.java.io :as io]
+            [clojure.string :as string]
             [clojure.string :as str]
             [editor.code.util :refer [split-lines]]
             [editor.engine.native-extensions :as native-extensions]
@@ -281,8 +282,8 @@
                      (> instance-index 0)
                      (into [(format "--config=project.instance_index=%d" instance-index)])
 
-                     (not-empty engine-arguments)
-                     (into (split-lines engine-arguments)))
+                     (not (string/blank? engine-arguments))
+                     (into (remove string/blank?) (split-lines engine-arguments)))
         env {"DM_SERVICE_PORT" "dynamic"
              "DM_QUIT_ON_ESC" (if (prefs/get prefs [:run :quit-on-escape])
                                 "1" "0")

--- a/editor/src/clj/editor/engine.clj
+++ b/editor/src/clj/editor/engine.clj
@@ -268,6 +268,7 @@
                                (File.)
                                (.getAbsolutePath))
         command (.getAbsolutePath engine)
+        engine-argument (prefs/get prefs [:run :engine-arguments])
         args (cond-> []
                      defold-log-dir
                      (into ["--config=project.write_log=1"
@@ -277,7 +278,10 @@
                      (into ["--config=bootstrap.debug_init_script=/_defold/debugger/start.luac"])
 
                      (> instance-index 0)
-                     (into [(format "--config=project.instance_index=%d" instance-index)]))
+                     (into [(format "--config=project.instance_index=%d" instance-index)])
+
+                     (not-empty engine-argument)
+                     (into [engine-argument]))
         env {"DM_SERVICE_PORT" "dynamic"
              "DM_QUIT_ON_ESC" (if (prefs/get prefs [:run :quit-on-escape])
                                 "1" "0")

--- a/editor/src/clj/editor/prefs.clj
+++ b/editor/src/clj/editor/prefs.clj
@@ -200,7 +200,8 @@
            :manual-target-ip+port {:type :string}
            :quit-on-escape {:type :boolean :label "Escape Quits Game"}
            :simulate-rotated-device {:type :boolean :scope :project}
-           :simulated-resolution {:type :any :scope :project}}}
+           :simulated-resolution {:type :any :scope :project}
+           :engine-arguments {:type :string :scope :project}}}
     :scene {:type :object
             :properties
             {:move-whole-pixels {:type :boolean :default true}}}

--- a/editor/src/clj/editor/prefs_dialog.clj
+++ b/editor/src/clj/editor/prefs_dialog.clj
@@ -21,7 +21,7 @@
   (:import [com.defold.control DefoldStringConverter LongField]
            [javafx.geometry VPos]
            [javafx.scene Parent Scene]
-           [javafx.scene.control CheckBox ChoiceBox ColorPicker Label Tab TabPane TextArea TextField]
+           [javafx.scene.control CheckBox ChoiceBox ColorPicker Label Tab TabPane TextArea TextField TextInputControl]
            [javafx.scene.input KeyCode KeyEvent]
            [javafx.scene.layout ColumnConstraints GridPane Priority]))
 
@@ -46,9 +46,11 @@
   (create-generic ColorPicker prefs grid desc))
 
 (defmethod create-control! :string [prefs grid desc]
-  (if (:multi-line desc)
-    (create-generic TextArea prefs grid desc)
-    (create-generic TextField prefs grid desc)))
+  (let [control (if (:multi-line desc)
+                  (create-generic TextArea prefs grid desc)
+                  (create-generic TextField prefs grid desc))]
+    (when (:prompt-value desc) (.setPromptText ^TextInputControl control (:prompt-value desc)))
+    control))
 
 (defmethod create-control! :long [prefs grid desc]
   (create-generic LongField prefs grid desc))
@@ -104,14 +106,16 @@
                     {:label "Track Active Tab in Asset Browser" :type :boolean :key [:asset-browser :track-active-tab]}
                     {:label "Lint Code on Build" :type :boolean :key [:build :lint-code]}
                     {:label "Path to Custom Keymap" :type :string :key [:input :keymap-path]}
-                    {:label "Engine Arguments" :type :string :key [:run :engine-arguments]}]}
+                    {:label "Engine Arguments" :type :string :key [:run :engine-arguments]  :multi-line true
+                     :prompt-value "One argument per line"
+                     :tooltip "Arguments that will be passed to the dmengine executables when the editor builds and runs.\n Use one argument per line. For example:\n--config=bootstrap.main_collection=/my dir/1.collectionc\n--verbose\n--graphics-adapter=vulkan"}]}
            {:name "Code"
             :prefs [{:label "Custom Editor" :type :string :key [:code :custom-editor]}
                     {:label "Open File" :type :string :key [:code :open-file]}
                     {:label "Open File at Line" :type :string :key [:code :open-file-at-line]}
                     {:label "Code Editor Font (Requires Restart)" :type :string :key [:code :font :name]}]}
            {:name  "Extensions"
-            :prefs [{:label "Build Server" :type :string :key [:extensions :build-server] :replace {"" native-extensions/defold-build-server-url}}
+            :prefs [{:label "Build Server" :type :string :key [:extensions :build-server] :replace {"" native-extensions/defold-build-server-url} :prompt-value "https://build.defold.com"}
                     {:label "Build Server Headers" :type :string :key [:extensions :build-server-headers] :multi-line true}]}
            {:name "Tools"
             :prefs [{:label "ADB path" :type :string :key [:tools :adb-path] :tooltip "Path to ADB command that might be used to install and launch the Android app when it's bundled"}

--- a/editor/src/clj/editor/prefs_dialog.clj
+++ b/editor/src/clj/editor/prefs_dialog.clj
@@ -103,7 +103,8 @@
                     {:label "Escape Quits Game" :type :boolean :key [:run :quit-on-escape]}
                     {:label "Track Active Tab in Asset Browser" :type :boolean :key [:asset-browser :track-active-tab]}
                     {:label "Lint Code on Build" :type :boolean :key [:build :lint-code]}
-                    {:label "Path to Custom Keymap" :type :string :key [:input :keymap-path]}]}
+                    {:label "Path to Custom Keymap" :type :string :key [:input :keymap-path]}
+                    {:label "Engine Arguments" :type :string :key [:run :engine-arguments]}]}
            {:name "Code"
             :prefs [{:label "Custom Editor" :type :string :key [:code :custom-editor]}
                     {:label "Open File" :type :string :key [:code :open-file]}

--- a/editor/styling/stylesheets/components/_text-area.scss
+++ b/editor/styling/stylesheets/components/_text-area.scss
@@ -6,6 +6,8 @@
     -fx-background-color: none;
     -fx-background-insets: 0;
     -fx-background-radius: 0;
+    -fx-text-fill: -df-text-light;
+    -fx-prompt-text-fill: -df-text-dark;
 
     .content {
         -fx-background-color: none;

--- a/editor/styling/stylesheets/components/_text-field.scss
+++ b/editor/styling/stylesheets/components/_text-field.scss
@@ -7,7 +7,7 @@
     -fx-border-width: 1px 1px 1px 1px;
     -fx-border-color: -df-component-dark;
     -fx-text-fill: -df-text-light;
-    -fx-prompt-text-fill: -df-text;
+    -fx-prompt-text-fill: -df-text-dark;
     -fx-min-height: 26px;
     &:hover {
         -fx-border-color: -df-component-light;


### PR DESCRIPTION
It is now possible to add engine arguments in the editor’s preferences. The value is saved on a per-project basis.

Fix https://github.com/defold/defold/issues/9668