### PR TITLE
Make prefs more resilient to unexpected values

### DIFF
--- a/editor/src/clj/editor/prefs.clj
+++ b/editor/src/clj/editor/prefs.clj
@@ -349,11 +349,17 @@
                 :else (.write w (pr-str x))))]
       (write! config 0))))
 
-(defn- safe-assoc-in [m p v]
-  (cond
-    (coll/empty? p) v
-    (identical? ::not-found m) (assoc-in {} p v)
-    :else (assoc-in m p v)))
+(defn safe-assoc-in
+  "Like assoc-in, but allows empty paths and replaces non-map vals with maps"
+  [m p v]
+  (if (coll/empty? p)
+    v
+    (let [is-map (map? m)
+          k (p 0)]
+      (assoc
+        (if is-map m {})
+        k
+        (safe-assoc-in (if is-map (m k) {}) (subvec p 1) v)))))
 
 (defn- incorporate-updated-storage [{:keys [events storage] :as current-state} updated-storage]
   (let [merged-storage (conj storage updated-storage)]

--- a/editor/test/editor/prefs_test.clj
+++ b/editor/test/editor/prefs_test.clj
@@ -508,4 +508,12 @@
       (is (= {[:present-in-both :conflict] [{:type :integer} {:type :string}]}
              @conflicts)))))
 
+(deftest safe-assoc-in-test
+  (is (= "val" (prefs/safe-assoc-in {} [] "val")))
+  (is (= {:a "val"} (prefs/safe-assoc-in {} [:a] "val")))
+  (is (= {:a "val"} (prefs/safe-assoc-in 42 [:a] "val")))
+  (is (= {:a {:b "val"}} (prefs/safe-assoc-in {:a 1} [:a :b] "val")))
+  (is (= {:a {:b "val"}} (prefs/safe-assoc-in ::prefs/not-found [:a :b] "val")))
+  (is (= {:a {:b "val" :other true}} (prefs/safe-assoc-in {:a {:other true}} [:a :b] "val")))
+  (is (= {:a {:other true} :x "val"} (prefs/safe-assoc-in {:a {:other true}} [:x] "val"))))
 


### PR DESCRIPTION
Technical notes:
`safe-assoc-in` wasn't safe enough, it still assumed intermediate `assoc-in` structures would be maps, i.e. `(safe-assoc-in {:a 1} [:a :b] true)` would try to `assoc` into `1`.

Fixes #9760