### PR TITLE
Set clearcolor alpha to one by default

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
@@ -106,7 +106,7 @@ clear_color_blue.default = 0
 
 clear_color_alpha.type = number
 clear_color_alpha.help = Default clear color - alpha channel
-clear_color_alpha.default = 0
+clear_color_alpha.default = 1
 
 [physics]
 help = Physics settings

--- a/editor/resources/meta.edn
+++ b/editor/resources/meta.edn
@@ -168,7 +168,7 @@
   {:type :number,
    :help "Render clear color - alpha channel",
    :label "Clear Color Alpha"
-   :default 0,
+   :default 1.0,
    :minimum 0.0,
    :maximum 1.0,
    :path ["render" "clear_color_alpha"]}


### PR DESCRIPTION
The default clearcolor alpha value is now 1.0 in game.project.