### PR TITLE
Fixed warning "not all control paths return a value" in socket.cpp

### DIFF
--- a/engine/dlib/src/dlib/socket_posix.cpp
+++ b/engine/dlib/src/dlib/socket_posix.cpp
@@ -173,6 +173,7 @@ namespace dmSocket
             case TYPE_STREAM:  return SOCK_STREAM;
             case TYPE_DGRAM:   return SOCK_DGRAM;
         }
+        return 0;
     }
     static int ProtocolToNative(Protocol protocol)
     {
@@ -181,6 +182,7 @@ namespace dmSocket
             case PROTOCOL_TCP:  return IPPROTO_TCP;
             case PROTOCOL_UDP:  return IPPROTO_UDP;
         }
+        return 0;
     }
     static int DomainToNative(Domain domain)
     {
@@ -191,6 +193,7 @@ namespace dmSocket
             case DOMAIN_IPV6:     return AF_INET6;
             case DOMAIN_UNKNOWN:  return 0xff;
         }
+        return 0;
     }
 
     Result New(Domain domain, Type type, Protocol protocol, Socket* socket)
@@ -433,6 +436,7 @@ namespace dmSocket
             case SHUTDOWNTYPE_READWRITE:    return SHUT_RDWR;
 #endif
         }
+        return 0;
     }
 
     Result Shutdown(Socket socket, ShutdownType how)


### PR DESCRIPTION
skip release notes

On Windows, the following warnings are generated:

```
socket_posix.cpp(176) : warning C4715: 'dmSocket::TypeToNative': not all control paths return a value
socket_posix.cpp(184) : warning C4715: 'dmSocket::ProtocolToNative': not all control paths return a value
socket_posix.cpp(194) : warning C4715: 'dmSocket::DomainToNative': not all control paths return a value
socket_posix.cpp(436) : warning C4715: 'dmSocket::ShutdownTypeToNative': not all control paths return a value
```

No associated issue.

### Technical changes

* Add a return statement at the end of these switch-statement functions to resolve the warning.