### PR TITLE
Fixed mistake in which value is written as the "size" from crashtool on module load failure

### DIFF
--- a/engine/crash/src/tool/crashtool.cpp
+++ b/engine/crash/src/tool/crashtool.cpp
@@ -189,7 +189,7 @@ uintptr_t GetProcessBaseAddress(PlatformInfo& pinfo, DWORD processID)
             MODULEINFO info;
             if (GetModuleInformation(process, mods[i], &info, sizeof(info)))
             {
-            fprintf(stderr, "  size: 0x%08x\n", (uintptr_t)info.lpBaseOfDll);
+            fprintf(stderr, "  size: 0x%08x\n", info.SizeOfImage);
             }
         }
     }


### PR DESCRIPTION
skip release notes

On Windows, the following warning is generated:

```
crashtool.cpp(192): warning C4477: 'fprintf' : format string '%08x' requires
    an argument of type 'unsigned int', but variadic argument 1 has type 'uintptr_t'
```

It seems like the [`MODULEINFO`](https://learn.microsoft.com/en-us/windows/win32/api/psapi/ns-psapi-moduleinfo) member `lpBaseOfDll` was printed instead of `SizeOfImage` as the "size", by simple mistake. Alternatively, the text label is incorrect as well as the address format (which only fits 32b pointers).

No associated issue.

### Technical changes

* Print the module size instead of the module's address as the "size".