### PR TITLE
Fixed warning about zero extending result of bitwise complement in DM_ALIGN macro

### DIFF
--- a/engine/dlib/src/dmsdk/dlib/align.h
+++ b/engine/dlib/src/dmsdk/dlib/align.h
@@ -61,7 +61,7 @@
  * int result = DM_ALIGN(24, 16);
  * ```
  */
-#define DM_ALIGN(x, a) (((uintptr_t) (x) + (a-1)) & ~(a-1))
+#define DM_ALIGN(x, a) (((uintptr_t) (x) + (a-1)) & ~(uintptr_t) (a-1))
 
 #if defined(__GNUC__)
 #define DM_ALIGNED(a) __attribute__ ((aligned (a)))


### PR DESCRIPTION
skip release notes

On Windows, the following warnings are generated when the `DM_ALIGN` macro is used:

```
buffer.cpp(177): warning C4319: '~': zero extending 'uint32_t' to 'uintptr_t' of greater size
buffer.cpp(184): warning C4319: '~': zero extending 'uint32_t' to 'uintptr_t' of greater size
graphics_vulkan.cpp(2107): warning C4319: '~': zero extending 'uint32_t' to 'uintptr_t' of greater size
graphics_vulkan.cpp(2603): warning C4319: '~': zero extending 'uint32_t' to 'uintptr_t' of greater size
```

Docs: [Compiler Warning (level 1) C4319](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4319?view=msvc-170)

This warning appears to simply be a warning about an implicit conversion that "could lead to unexpected operation results."

No associated issue.

### Technical changes

* Added an explicit cast to `uintptr_t`.