### PR TITLE
Fixed warning pointer truncation from HINSTANCE to int in sys_posix OpenURL

### DIFF
--- a/engine/dlib/src/dlib/sys_posix.cpp
+++ b/engine/dlib/src/dlib/sys_posix.cpp
@@ -274,7 +274,7 @@ namespace dmSys
 
     Result OpenURL(const char* url, const char* target)
     {
-        int ret = (int) ShellExecuteA(NULL, "open", url, NULL, NULL, SW_SHOWNORMAL);
+        intptr_t ret = (intptr_t) ShellExecuteA(NULL, "open", url, NULL, NULL, SW_SHOWNORMAL);
         if (ret == 32)
         {
             return RESULT_OK;


### PR DESCRIPTION
skip release notes

On Windows, the following warning is generated:

```
sys_posix.cpp(277): warning C4311: 'type cast': pointer truncation from 'HINSTANCE' to 'int'
```

`HINSTANCE` is a void*, and [according to the docs](https://learn.microsoft.com/en-us/windows/win32/api/shellapi/nf-shellapi-shellexecutea#return-value), when returned from `ShellExecuteA` it should only ever be cast to an `INT_PTR`.

No associated issue.

### Technical changes

* Cast `ShellExecuteA` return value to the properly sized integer type.