### PR TITLE
Fixed warning alloca macro redefined on Windows

### DIFF
--- a/engine/dlib/src/dmsdk/dlib/dalloca.h
+++ b/engine/dlib/src/dmsdk/dlib/dalloca.h
@@ -30,7 +30,9 @@
     #include "alloca_vendor.h"
 #elif defined(_WIN32)
     #include <malloc.h>
-    #define alloca(_SIZE) _alloca(_SIZE)
+    #if !defined(alloca)
+        #define alloca(_SIZE) _alloca(_SIZE) // done in malloc.h if _CRT_INTERNAL_NONSTDC_NAMES is non-zero
+    #endif
 #else
     #include <alloca.h>
 #endif


### PR DESCRIPTION
skip release notes

On Windows, the following warning is generated many, many times:

```
dalloca.h:33:13: warning: 'alloca' macro redefined [-Wmacro-redefined]
   33 |     #define alloca(_SIZE) _alloca(_SIZE)
      |             ^
/opt/platformsdk/Win32/WindowsKits/10/Include/10.0.20348.0/ucrt/malloc.h:176:13: note: previous definition is here
  176 |     #define alloca _alloca
      |             ^
```

malloc.h:

```cpp
#if defined(_CRT_INTERNAL_NONSTDC_NAMES) && _CRT_INTERNAL_NONSTDC_NAMES
    #define alloca _alloca
#endif
```

I'm guessing that the above define was added with the Universal CRT, causing Defold's define to start triggering the warning.

No associated issue.

### Technical changes

* Added a preprocessor guard to avoid the warning in case `alloca` is already defined.