### PR TITLE
Removed Windows-specific direct includes of malloc.h to get access to alloca outside of dalloca.h

### DIFF
--- a/engine/dlib/src/dlib/buffer.cpp
+++ b/engine/dlib/src/dlib/buffer.cpp
@@ -16,6 +16,7 @@
 #include <dlib/hash.h>
 #include <dmsdk/dlib/buffer.h>
 
+#include <dlib/dalloca.h>
 #include <dlib/log.h>
 #include <dlib/memory.h>
 #include <dlib/math.h>
@@ -27,10 +28,6 @@
 #include <string.h>
 #include <assert.h>
 #include <new>
-
-#if defined(_WIN32)
-#include <malloc.h>
-#endif
 
 #include <stdio.h>
 

--- a/engine/gamesys/src/gamesys/scripts/script_buffer.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_buffer.cpp
@@ -16,6 +16,7 @@
 #include <stdint.h>
 #include <string.h>
 
+#include <dlib/dalloca.h>
 #include <dlib/buffer.h>
 #include <dlib/dstrings.h>
 #include <dlib/log.h>
@@ -26,11 +27,6 @@
 
 #include <dmsdk/script/script.h>
 #include <dmsdk/gamesys/script.h>
-
-#if defined(_WIN32)
-#include <malloc.h>
-#define alloca(_SIZE) _alloca(_SIZE)
-#endif
 
 extern "C"
 {

--- a/engine/liveupdate/src/liveupdate.cpp
+++ b/engine/liveupdate/src/liveupdate.cpp
@@ -41,11 +41,6 @@
 #include <resource/resource_util.h>     // BytesToHexString for debug printing
 #include <resource/providers/provider.h>
 
-#if defined(_WIN32)
-#include <malloc.h>
-#define alloca(_SIZE) _alloca(_SIZE)
-#endif
-
 namespace dmLiveUpdate
 {
     const char* LIVEUPDATE_LEGACY_MOUNT_NAME        = "liveupdate"; // By not prefixing it with '_', the user may then remove it


### PR DESCRIPTION
skip release notes

#9798 describes and fixes the following warning that is generated on Windows:

```
dalloca.h:33:13: warning: 'alloca' macro redefined [-Wmacro-redefined]
```

However, in several other locations malloc.h is directly included and `alloca` potentially redefined. To avoid this, these includes are removed and replaced with dalloca.h which centralizes the include and `alloca` definition.

No associated issue.

### Technical changes

* Replaced Windows-specific includes of malloc.h with includes of dalloca.h