### PR TITLE
Copy shader tools once to avoid issues in threaded builds

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/shader/ShaderCompilePipeline.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/shader/ShaderCompilePipeline.java
@@ -53,8 +53,17 @@ public class ShaderCompilePipeline {
     protected ArrayList<ShaderModule> shaderModules = new ArrayList<>();
     protected Options options                       = null;
 
-    public ShaderCompilePipeline(String pipelineName) {
+    private static String tintExe = null;
+    private static String glslangExe = null;
+    private static String spirvOptExe = null;
+    private static String spirvCrossExe = null;
+
+    public ShaderCompilePipeline(String pipelineName) throws IOException {
         this.pipelineName = pipelineName;
+        if (this.tintExe == null) this.tintExe = Bob.getExe(Platform.getHostPlatform(), "tint");
+        if (this.glslangExe == null) this.glslangExe = Bob.getExe(Platform.getHostPlatform(), "glslang");
+        if (this.spirvOptExe == null) this.spirvOptExe = Bob.getExe(Platform.getHostPlatform(), "spirv-opt");
+        if (this.spirvCrossExe == null) this.spirvCrossExe = Bob.getExe(Platform.getHostPlatform(), "spirv-cross");
     }
 
     protected void reset() {
@@ -131,7 +140,7 @@ public class ShaderCompilePipeline {
     }
 
     protected static void generateWGSL(String pathFileInSpv, String pathFileOutWGSL) throws IOException, CompileExceptionError {
-        Result result = Exec.execResult(Bob.getExe(Platform.getHostPlatform(), "tint"),
+        Result result = Exec.execResult(tintExe,
             "--format", "wgsl",
             "-o", pathFileOutWGSL,
             pathFileInSpv);
@@ -139,7 +148,7 @@ public class ShaderCompilePipeline {
     }
 
     private void generateSPIRv(ShaderDesc.ShaderType shaderType, String pathFileInGLSL, String pathFileOutSpv) throws IOException, CompileExceptionError {
-        Result result = Exec.execResult(Bob.getExe(Platform.getHostPlatform(), "glslang"),
+        Result result = Exec.execResult(glslangExe,
             "-w",
             "--entry-point", "main",
             "--auto-map-bindings",
@@ -155,7 +164,7 @@ public class ShaderCompilePipeline {
 
     private void generateSPIRvOptimized(String pathFileInSpv, String pathFileOutSpvOpt) throws IOException, CompileExceptionError{
         // Run optimization pass on the result
-        Result result = Exec.execResult(Bob.getExe(Platform.getHostPlatform(), "spirv-opt"),
+        Result result = Exec.execResult(spirvOptExe,
             "-O",
             pathFileInSpv,
             "-o", pathFileOutSpvOpt);
@@ -163,7 +172,7 @@ public class ShaderCompilePipeline {
     }
 
     private void generateSPIRvReflection(String pathFileInSpv, String pathFileOutSpvReflection) throws IOException, CompileExceptionError{
-        Result result = Exec.execResult(Bob.getExe(Platform.getHostPlatform(), "spirv-cross"),
+        Result result = Exec.execResult(spirvCrossExe,
             pathFileInSpv,
             "--entry", "main",
             "--output", pathFileOutSpvReflection,
@@ -178,7 +187,7 @@ public class ShaderCompilePipeline {
         }
 
         ArrayList<String> args = new ArrayList<>();
-        args.add(Bob.getExe(Platform.getHostPlatform(), "spirv-cross"));
+        args.add(spirvCrossExe);
         args.add(pathFileInSpv);
         args.add("--version");
         args.add(String.valueOf(versionOut));


### PR DESCRIPTION
## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
