### PR TITLE
ParticleFx vertex buffer batch update

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
@@ -656,8 +656,11 @@ max_emitter_count.type = integer
 max_emitter_count.help = max number of particle fx emitters, 64 by default
 max_emitter_count.default = 64
 max_particle_count.type = integer
-max_particle_count.help = max total number of living particles, 1024 by default
+max_particle_count.help = max total number of living particles. limits the GPU vertex buffer size. 1024 by default
 max_particle_count.default = 1024
+max_particle_count.type = integer
+max_particle_count.help = max number of particles per upload to the GPU. limits the CPU memory usage. 1024 by default.
+max_particle_buffer_count = 1024
 
 [network]
 help = Network related settings

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
@@ -658,8 +658,8 @@ max_emitter_count.default = 64
 max_particle_count.type = integer
 max_particle_count.help = max total number of living particles. limits the GPU vertex buffer size. 1024 by default
 max_particle_count.default = 1024
-max_particle_count.type = integer
-max_particle_count.help = max number of particles per upload to the GPU. limits the CPU memory usage. 1024 by default.
+max_particle_buffer_count.type = integer
+max_particle_buffer_count.help = max number of particles per upload to the GPU. limits the CPU memory usage. 1024 by default.
 max_particle_buffer_count = 1024
 
 [network]

--- a/editor/resources/meta.edn
+++ b/editor/resources/meta.edn
@@ -462,10 +462,13 @@
    :default 64,
    :path ["gui" "max_count"]},
   {:type :integer,
-   :help
-   "max number of particlefx nodes per collection",
-   :default 64,
-   :path ["gui" "max_particlefx_count"]}
+   :help "max total number of living particles. limits the GPU vertex buffer size. 1024 by default",
+   :default 1024,
+   :path ["particle_fx" "max_particle_count"]}
+  {:type :integer,
+   :help "max number of particles per upload to the GPU. limits the CPU memory usage. 1024 by default.",
+   :default 1024,
+   :path ["particle_fx" "max_particle_buffer_count"]}
   {:type :integer,
    :help
    "max total number of active animations in gui, 1024 by default",

--- a/editor/test/resources/save_data_project/game.project
+++ b/editor/test/resources/save_data_project/game.project
@@ -160,6 +160,7 @@ split_meshes = 1
 max_count = 128
 max_emitter_count = 128
 max_particle_count = 2048
+max_particle_buffer_count = 512
 
 [sound]
 use_thread = 0

--- a/engine/gamesys/src/gamesys/components/comp_particlefx.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_particlefx.cpp
@@ -39,7 +39,8 @@
 DM_PROPERTY_EXTERN(rmtp_Components);
 DM_PROPERTY_U32(rmtp_ParticleFx, 0, FrameReset, "# components", &rmtp_Components);
 DM_PROPERTY_U32(rmtp_ParticleVertexCount, 0, FrameReset, "# vertices", &rmtp_ParticleFx);
-DM_PROPERTY_U32(rmtp_ParticleVertexSize, 0, FrameReset, "size of vertices in bytes", &rmtp_ParticleFx);
+DM_PROPERTY_U32(rmtp_ParticleVertexSize, 0, FrameReset, "size of CPU vertex buffer (in bytes)", &rmtp_ParticleFx);
+DM_PROPERTY_U32(rmtp_ParticleVertexSizeGPU, 0, FrameReset, "size of GPU vertex buffer (in bytes)", &rmtp_ParticleFx);
 
 namespace dmGameSystem
 {
@@ -460,7 +461,7 @@ namespace dmGameSystem
                     dmGraphics::HVertexDeclaration vx_decl = dmRender::GetVertexDeclaration(mat);
                     uint32_t stride = dmGraphics::GetVertexDeclarationStride(vx_decl);
 
-                    uint32_t pcount = GetEmitterVertexCount(pfx_world->m_ParticleContext, render_data->m_Instance, render_data->m_EmitterIndex) / 6;
+                    uint32_t pcount = dmParticle::GetParticleCount(pfx_world->m_ParticleContext, render_data->m_Instance, render_data->m_EmitterIndex);
 
                     bool is_full = false;
                     if ((pcount + particle_count) > pfx_context->m_MaxParticleCount)
@@ -527,6 +528,7 @@ namespace dmGameSystem
                 {
                     DM_PROPERTY_ADD_U32(rmtp_ParticleVertexCount, pfx_world->m_VerticesWritten);
                     DM_PROPERTY_ADD_U32(rmtp_ParticleVertexSize, pfx_world->m_VertexBufferData.Capacity());
+                    DM_PROPERTY_ADD_U32(rmtp_ParticleVertexSizeGPU, pfx_world->m_VertexBufferSize);
                     pfx_world->m_DispatchCount++;
                 }
                 break;

--- a/engine/gamesys/src/gamesys/components/comp_particlefx.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_particlefx.cpp
@@ -365,7 +365,7 @@ namespace dmGameSystem
 
                 if (flush) // Upload the written data (if there was any)
                 {
-                    const uint32_t vb_upload_size = dmMath::Min(max_gpu_size, vb_size);
+                    uint32_t vb_upload_size = dmMath::Min(max_gpu_size, vb_size);
                     dmRender::SetBufferSubData(render_context, pfx_world->m_VertexBuffer, gpu_vb_offset, vb_upload_size, vertex_buffer.Begin());
                     gpu_vb_offset += vb_upload_size;
                     vb_size = 0;
@@ -373,10 +373,9 @@ namespace dmGameSystem
             }
         }
 
-
         if (vb_size != 0) // Do we have any lingering data?
         {
-            const uint32_t vb_upload_size = dmMath::Min(max_gpu_size, vb_size);
+            uint32_t vb_upload_size = dmMath::Min(max_gpu_size, vb_size);
             dmRender::SetBufferSubData(render_context, pfx_world->m_VertexBuffer, gpu_vb_offset, vb_upload_size, vertex_buffer.Begin());
             gpu_vb_offset += vb_upload_size;
         }
@@ -443,12 +442,6 @@ namespace dmGameSystem
 
                     uint32_t pcount = GetEmitterVertexCount(pfx_world->m_ParticleContext, render_data->m_Instance, render_data->m_EmitterIndex) / 6;
 
-                    // Align to the next boundary for the material
-                    if (buffer_size % stride != 0)
-                    {
-                        buffer_size += stride - buffer_size % stride;
-                    }
-
                     bool is_full = false;
                     if ((pcount + particle_count) > pfx_context->m_MaxParticleCount)
                     {
@@ -463,6 +456,10 @@ namespace dmGameSystem
                     }
 
                     particle_count += pcount;
+
+                    // To accomodate for aligning the buffer to the different strides
+                    // we add one extra particle to give us some extra room
+                    ++pcount;
 
                     buffer_size += stride * pcount * 6;
 

--- a/engine/gamesys/src/gamesys/components/comp_particlefx.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_particlefx.cpp
@@ -469,6 +469,7 @@ namespace dmGameSystem
             case dmRender::RENDER_LIST_OPERATION_END:
                 if (pfx_world->m_GPUVertexBufferOffset)
                 {
+                    dmRender::SetBufferData(params.m_Context, pfx_world->m_VertexBuffer, pfx_world->m_VertexBufferData.Size(), pfx_world->m_VertexBufferData.Begin(), dmGraphics::BUFFER_USAGE_STREAM_DRAW);
                     DM_PROPERTY_ADD_U32(rmtp_ParticleVertexCount, pfx_world->m_VerticesWritten);
                     DM_PROPERTY_ADD_U32(rmtp_ParticleVertexSize, pfx_world->m_VertexBufferData.Capacity());
                     pfx_world->m_DispatchCount++;

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -3074,7 +3074,7 @@ TEST_F(ComponentTest, DispatchBuffersTest)
 
         const uint32_t vertex_count   = 6;
         const uint32_t vertex_padding = vertex_stride_b - (vertex_stride_a * vertex_count) % vertex_stride_b;
-        const uint32_t buffer_size    = (vertex_stride_a + vertex_stride_b) * vertex_count + vertex_padding;
+        const uint32_t buffer_size    = vertex_stride_a * (vertex_count + 6) + vertex_stride_b * (vertex_count + 6); // we allocate for an extra particle
         uint8_t buffer[buffer_size];
 
         vs_format_a* pfx_a = (vs_format_a*) &buffer[0];

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -2994,10 +2994,10 @@ TEST_F(ComponentTest, DispatchBuffersTest)
             vs_format_a* written_sprite_a = (vs_format_a*) &gfx_vx_buffer->m_Buffer[0];
             vs_format_b* written_sprite_b = (vs_format_b*) &gfx_vx_buffer->m_Buffer[vertex_stride_a * vertex_count + vertex_padding];
 
-            for (int i = 0; i < vertex_count; ++i)
+            for (int j = 0; j < vertex_count; ++j)
             {
-                ASSERT_VTX_A_EQ(sprite_a[i], written_sprite_a[i]);
-                ASSERT_VTX_B_EQ(sprite_b[i], written_sprite_b[i]);
+                ASSERT_VTX_A_EQ(sprite_a[j], written_sprite_a[j]);
+                ASSERT_VTX_B_EQ(sprite_b[j], written_sprite_b[j]);
             }
         }
     }
@@ -3055,10 +3055,10 @@ TEST_F(ComponentTest, DispatchBuffersTest)
             vs_format_a* written_model_a = (vs_format_a*) &gfx_vx_buffer->m_Buffer[0];
             vs_format_b* written_model_b = (vs_format_b*) &gfx_vx_buffer->m_Buffer[vertex_stride_a * vertex_count + vertex_padding];
 
-            for (int i = 0; i < vertex_count; ++i)
+            for (int j = 0; j < vertex_count; ++j)
             {
-                ASSERT_VTX_A_EQ(model_a[i], written_model_a[i]);
-                ASSERT_VTX_B_EQ(model_b[i], written_model_b[i]);
+                ASSERT_VTX_A_EQ(model_a[j], written_model_a[j]);
+                ASSERT_VTX_B_EQ(model_b[j], written_model_b[j]);
             }
         }
     }
@@ -3101,18 +3101,25 @@ TEST_F(ComponentTest, DispatchBuffersTest)
         SET_VTX_B(pfx_b[4], p2[0], p2[1], 0.0f, 4.0f, 3.0f, 2.0f, 1.0f);
         SET_VTX_B(pfx_b[5], p0[0], p0[1], 0.0f, 4.0f, 3.0f, 2.0f, 1.0f);
 
+        uint32_t buffer_sizes[] = { vertex_stride_a * vertex_count,
+                                    vertex_stride_b * vertex_count,
+                                    vertex_stride_a * vertex_count,
+                                    vertex_stride_b * vertex_count};
         for (int i = 0; i < num_draws; ++i)
         {
             dmGraphics::VertexBuffer* gfx_vx_buffer = (dmGraphics::VertexBuffer*) vx_buffer->m_Buffers[i];
-            ASSERT_EQ(buffer_size, gfx_vx_buffer->m_Size);
+            ASSERT_EQ(buffer_sizes[i], gfx_vx_buffer->m_Size);
 
             vs_format_a* written_pfx_a = (vs_format_a*) &gfx_vx_buffer->m_Buffer[0];
             vs_format_b* written_pfx_b = (vs_format_b*) &gfx_vx_buffer->m_Buffer[vertex_stride_a * vertex_count + vertex_padding];
 
-            for (int i = 0; i < vertex_count; ++i)
+            for (int j = 0; j < vertex_count; ++j)
             {
-                ASSERT_VTX_A_EQ(pfx_a[i], written_pfx_a[i]);
-                ASSERT_VTX_B_EQ(pfx_b[i], written_pfx_b[i]);
+                ASSERT_VTX_A_EQ(pfx_a[j], written_pfx_a[j]);
+                if (i > 0)
+                {
+                    ASSERT_VTX_B_EQ(pfx_b[j], written_pfx_b[j]);
+                }
             }
         }
     }

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -3101,14 +3101,10 @@ TEST_F(ComponentTest, DispatchBuffersTest)
         SET_VTX_B(pfx_b[4], p2[0], p2[1], 0.0f, 4.0f, 3.0f, 2.0f, 1.0f);
         SET_VTX_B(pfx_b[5], p0[0], p0[1], 0.0f, 4.0f, 3.0f, 2.0f, 1.0f);
 
-        uint32_t buffer_sizes[] = { vertex_stride_a * vertex_count,
-                                    vertex_stride_b * vertex_count,
-                                    vertex_stride_a * vertex_count,
-                                    vertex_stride_b * vertex_count};
         for (int i = 0; i < num_draws; ++i)
         {
             dmGraphics::VertexBuffer* gfx_vx_buffer = (dmGraphics::VertexBuffer*) vx_buffer->m_Buffers[i];
-            ASSERT_EQ(buffer_sizes[i], gfx_vx_buffer->m_Size);
+            ASSERT_EQ(buffer_size, gfx_vx_buffer->m_Size);
 
             vs_format_a* written_pfx_a = (vs_format_a*) &gfx_vx_buffer->m_Buffer[0];
             vs_format_b* written_pfx_b = (vs_format_b*) &gfx_vx_buffer->m_Buffer[vertex_stride_a * vertex_count + vertex_padding];
@@ -3116,10 +3112,7 @@ TEST_F(ComponentTest, DispatchBuffersTest)
             for (int j = 0; j < vertex_count; ++j)
             {
                 ASSERT_VTX_A_EQ(pfx_a[j], written_pfx_a[j]);
-                if (i > 0)
-                {
-                    ASSERT_VTX_B_EQ(pfx_b[j], written_pfx_b[j]);
-                }
+                ASSERT_VTX_B_EQ(pfx_b[j], written_pfx_b[j]);
             }
         }
     }

--- a/engine/gamesys/src/gamesys/test/test_gamesys.h
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.h
@@ -573,6 +573,7 @@ void GamesysTest<T>::SetUp()
     m_ParticleFXContext.m_RenderContext = m_RenderContext;
     m_ParticleFXContext.m_MaxParticleFXCount = 64;
     m_ParticleFXContext.m_MaxParticleCount = 256;
+    m_ParticleFXContext.m_MaxParticleBufferCount = 256;
     m_ParticleFXContext.m_MaxEmitterCount = 8;
 
     m_SpriteContext.m_RenderContext = m_RenderContext;

--- a/engine/particle/src/particle.cpp
+++ b/engine/particle/src/particle.cpp
@@ -601,7 +601,9 @@ namespace dmParticle
     static void UpdateEmitterState(Instance* instance, Emitter* emitter, EmitterPrototype* emitter_prototype, dmParticleDDF::Emitter* emitter_ddf, float dt);
     static void EvaluateEmitterProperties(Emitter* emitter, Property* emitter_properties, float duration, float properties[EMITTER_KEY_COUNT]);
     static void EvaluateParticleProperties(Emitter* emitter, Property* particle_properties, dmParticleDDF::Emitter* emitter_ddf, float dt);
-    static GenerateVertexDataResult UpdateRenderData(HParticleContext context, Instance* instance, Emitter* emitter, dmParticleDDF::Emitter* ddf, const dmGraphics::VertexAttributeInfos& attribute_infos, const Vector4& color, uint32_t vertex_index, uint8_t* vertex_buffer, uint32_t vertex_buffer_size, uint32_t* bytes_written, float dt);
+    static GenerateVertexDataResult UpdateRenderData(HParticleContext context, Instance* instance, Emitter* emitter, dmParticleDDF::Emitter* ddf,
+                                                    uint32_t particle_start, uint32_t particle_count,
+                                                    const dmGraphics::VertexAttributeInfos& attribute_infos, const Vector4& color, uint32_t vertex_index, uint8_t* vertex_buffer, uint32_t vertex_buffer_size, uint32_t* bytes_written, float dt);
     static void GenerateKeys(Emitter* emitter, float max_particle_life_time);
     static void SortParticles(Emitter* emitter);
     static void Simulate(Instance* instance, Emitter* emitter, EmitterPrototype* prototype, dmParticleDDF::Emitter* ddf, float dt);
@@ -642,7 +644,34 @@ namespace dmParticle
         emitter->m_LastPosition = world_position;
     }
 
-    GenerateVertexDataResult GenerateVertexData(HParticleContext context, float dt, HInstance instance, uint32_t emitter_index,  const dmGraphics::VertexAttributeInfos& attribute_infos, const Vector4& color, void* vertex_buffer, uint32_t vertex_buffer_size, uint32_t* out_vertex_buffer_size)
+    uint32_t GetParticleCount(HParticleContext context, HInstance instance, uint32_t emitter_index)
+    {
+        DM_PROFILE(__FUNCTION__);
+        if (instance == INVALID_INSTANCE)
+        {
+            return 0;
+        }
+
+        Instance* inst = GetInstance(context, instance);
+        if (IsSleeping(inst))
+        {
+            return 0;
+        }
+
+        Emitter* emitter = &inst->m_Emitters[emitter_index];
+        return emitter->m_Particles.Size();
+    }
+
+    static GenerateVertexDataResult GenerateVertexDataInternal(HParticleContext context,
+                                                                float dt,
+                                                                HInstance instance,
+                                                                uint32_t emitter_index,
+                                                                uint32_t particle_start,
+                                                                uint32_t particle_count,
+                                                                const dmGraphics::VertexAttributeInfos& attribute_infos,
+                                                                const Vector4& color,
+                                                                void* vertex_buffer,
+                                                                uint32_t vertex_buffer_size, uint32_t* out_vertex_buffer_size)
     {
         assert(attribute_infos.m_StructSize == sizeof(dmGraphics::VertexAttributeInfos));
         assert(attribute_infos.m_VertexStride != 0);
@@ -679,13 +708,25 @@ namespace dmParticle
         GenerateVertexDataResult res = GENERATE_VERTEX_DATA_OK;
         if (vertex_buffer != 0x0 && vertex_buffer_size > 0)
         {
-            res = UpdateRenderData(context, inst, emitter, emitter_ddf, attribute_infos, color, vertex_index, vertex_buffer_write, vertex_buffer_size, &bytes_written, dt);
+            uint32_t count = dmMath::Min(emitter->m_Particles.Size(), particle_count);
+            res = UpdateRenderData(context, inst, emitter, emitter_ddf, particle_start, count,
+                                    attribute_infos, color, vertex_index, vertex_buffer_write, vertex_buffer_size, &bytes_written, dt);
             *out_vertex_buffer_size += bytes_written;
         }
 
         context->m_Stats.m_Particles = bytes_written / vertex_size / 6; // Debug data for editor playback
 
         return res;
+    }
+
+    GenerateVertexDataResult GenerateVertexData(HParticleContext context, float dt, HInstance instance, uint32_t emitter_index, const dmGraphics::VertexAttributeInfos& attribute_infos, const Vector4& color, void* vertex_buffer, uint32_t vertex_buffer_size, uint32_t* out_vertex_buffer_size)
+    {
+        return GenerateVertexDataInternal(context, dt, instance, emitter_index, 0, 0xFFFFFFFF, attribute_infos, color, vertex_buffer, vertex_buffer_size, out_vertex_buffer_size);
+    }
+
+    GenerateVertexDataResult GenerateVertexDataPartial(HParticleContext context, float dt, HInstance instance, uint32_t emitter_index, uint32_t particle_start, uint32_t particle_count, const dmGraphics::VertexAttributeInfos& attribute_infos, const Vector4& color, void* vertex_buffer, uint32_t vertex_buffer_size, uint32_t* out_vertex_buffer_size)
+    {
+        return GenerateVertexDataInternal(context, dt, instance, emitter_index, particle_start, particle_count, attribute_infos, color, vertex_buffer, vertex_buffer_size, out_vertex_buffer_size);
     }
 
     void Update(HParticleContext context, float dt, FetchAnimationCallback fetch_animation_callback)
@@ -708,7 +749,6 @@ namespace dmParticle
                 for (uint32_t emitter_i = 0; emitter_i < emitter_count; ++emitter_i)
                 {
                     Emitter* emitter = &instance->m_Emitters[emitter_i];
-                    emitter->m_ParticlesConsumed = 0;
                     emitter->m_VertexCount = 0;
                     dmParticleDDF::Emitter* emitter_ddf = &instance->m_Prototype->m_DDF->m_Emitters[emitter_i];
                     UpdateEmitterVelocity(instance, emitter, emitter_ddf, dt);
@@ -725,7 +765,6 @@ namespace dmParticle
                 EmitterPrototype* emitter_prototype = &prototype->m_Emitters[emitter_i];
                 dmParticleDDF::Emitter* emitter_ddf = &prototype->m_DDF->m_Emitters[emitter_i];
 
-                emitter->m_ParticlesConsumed = 0;
                 UpdateEmitterVelocity(instance, emitter, emitter_ddf, dt);
                 UpdateEmitter(prototype, instance, emitter_prototype, emitter, emitter_ddf, dt);
                 TotalAliveParticles += (uint32_t)emitter->m_Particles.Size();
@@ -1043,7 +1082,19 @@ namespace dmParticle
         1.0f, 1.0f,
     };
 
-    static GenerateVertexDataResult UpdateRenderData(HParticleContext context, Instance* instance, Emitter* emitter, dmParticleDDF::Emitter* ddf, const dmGraphics::VertexAttributeInfos& attribute_infos, const Vector4& color, uint32_t vertex_index, uint8_t* vertex_buffer, uint32_t vertex_buffer_size, uint32_t* bytes_written, float dt)
+    static GenerateVertexDataResult UpdateRenderData(HParticleContext context,
+                                                    Instance* instance,
+                                                    Emitter* emitter,
+                                                    dmParticleDDF::Emitter* ddf,
+                                                    uint32_t particle_start,
+                                                    uint32_t particle_count,
+                                                    const dmGraphics::VertexAttributeInfos& attribute_infos,
+                                                    const Vector4& color,
+                                                    uint32_t vertex_index,
+                                                    uint8_t* vertex_buffer,
+                                                    uint32_t vertex_buffer_size,
+                                                    uint32_t* bytes_written,
+                                                    float dt)
     {
         DM_PROFILE(__FUNCTION__);
         static int tex_coord_order[] = {
@@ -1110,7 +1161,6 @@ namespace dmParticle
         }
 
         uint32_t max_vertex_count = vertex_buffer_size / vertex_size;
-        uint32_t particle_count = emitter->m_Particles.Size();
         uint32_t j;
 
         float width_factor = 1.0f;
@@ -1183,7 +1233,7 @@ namespace dmParticle
         dmGraphics::SetWriteAttributeStreamDesc(&write_params.m_PositionsLocalSpace, position_local_channel, dmGraphics::VertexAttribute::VECTOR_TYPE_VEC4, 1, false);
         dmGraphics::SetWriteAttributeStreamDesc(&write_params.m_TexCoords, tex_coord_channel, dmGraphics::VertexAttribute::VECTOR_TYPE_VEC2, 1, false);
 
-        for (j = emitter->m_ParticlesConsumed; j < particle_count && vertex_index + 6 <= max_vertex_count; j++)
+        for (j = particle_start; j < particle_count && vertex_index + 6 <= max_vertex_count; j++)
         {
             Particle* particle = &emitter->m_Particles[j];
             // Evaluate anim frame
@@ -1316,13 +1366,13 @@ namespace dmParticle
 
         GenerateVertexDataResult res = GENERATE_VERTEX_DATA_OK;
 
-        if (j < particle_count)
+        if (j < particle_count) // If we did an early out, it means the perticles didn't fit the buffer
         {
             res = GENERATE_VERTEX_DATA_MAX_PARTICLES_EXCEEDED;
         }
-        emitter->m_ParticlesConsumed = j;
-        emitter->m_VertexCount = vertex_index - emitter->m_VertexIndex;
-        *bytes_written = emitter->m_VertexCount * attribute_infos.m_VertexStride;
+        uint32_t num_written = vertex_index - emitter->m_VertexIndex;
+        emitter->m_VertexCount += num_written; // since we check if it's == 0
+        *bytes_written = num_written * attribute_infos.m_VertexStride;
 
         return res;
     }

--- a/engine/particle/src/particle.cpp
+++ b/engine/particle/src/particle.cpp
@@ -1233,7 +1233,9 @@ namespace dmParticle
         dmGraphics::SetWriteAttributeStreamDesc(&write_params.m_PositionsLocalSpace, position_local_channel, dmGraphics::VertexAttribute::VECTOR_TYPE_VEC4, 1, false);
         dmGraphics::SetWriteAttributeStreamDesc(&write_params.m_TexCoords, tex_coord_channel, dmGraphics::VertexAttribute::VECTOR_TYPE_VEC2, 1, false);
 
-        for (j = particle_start; j < particle_count && vertex_index + 6 <= max_vertex_count; j++)
+        uint32_t particle_full_count = emitter->m_Particles.Size();
+        uint32_t particle_end = dmMath::Min(particle_start + particle_count, particle_full_count);
+        for (j = particle_start; j < particle_end && vertex_index + 6 <= max_vertex_count; j++)
         {
             Particle* particle = &emitter->m_Particles[j];
             // Evaluate anim frame
@@ -1366,7 +1368,7 @@ namespace dmParticle
 
         GenerateVertexDataResult res = GENERATE_VERTEX_DATA_OK;
 
-        if (j < particle_count) // If we did an early out, it means the perticles didn't fit the buffer
+        if (j < particle_count) // If we did an early out, it means the particles didn't fit the buffer
         {
             res = GENERATE_VERTEX_DATA_MAX_PARTICLES_EXCEEDED;
         }

--- a/engine/particle/src/particle.h
+++ b/engine/particle/src/particle.h
@@ -366,7 +366,7 @@ namespace dmParticle
     DM_PARTICLE_PROTO(GenerateVertexDataResult, GenerateVertexData, HParticleContext context, float dt, HInstance instance, uint32_t emitter_index, const dmGraphics::VertexAttributeInfos& attribute_infos, const dmVMath::Vector4& color, void* vertex_buffer, uint32_t vertex_buffer_size, uint32_t* out_vertex_buffer_size);
 
     /**
-     * Gets the
+     * Gets the particle count for an emitter
      * @param context Particle context
      * @param dt Time step.
      * @param instance Particle instance handle

--- a/engine/particle/src/particle.h
+++ b/engine/particle/src/particle.h
@@ -366,6 +366,40 @@ namespace dmParticle
     DM_PARTICLE_PROTO(GenerateVertexDataResult, GenerateVertexData, HParticleContext context, float dt, HInstance instance, uint32_t emitter_index, const dmGraphics::VertexAttributeInfos& attribute_infos, const dmVMath::Vector4& color, void* vertex_buffer, uint32_t vertex_buffer_size, uint32_t* out_vertex_buffer_size);
 
     /**
+     * Gets the
+     * @param context Particle context
+     * @param dt Time step.
+     * @param instance Particle instance handle
+     * @param emitter_index Emitter index for which to generate vertex data for
+     * @param attribute_infos Attribute information on the streams to write
+     * @param color The particle color to (potentially) write
+     * @param offset The particle index to start from
+     * @param count The number of particles to update
+     * @param vertex_buffer Vertex buffer into which to store the particle vertex data. If this is 0x0, no data will be generated.
+     * @param vertex_buffer_size Size in bytes of the supplied vertex buffer.
+     * @param out_vertex_buffer_size Size in bytes of the total data written to vertex buffer.
+     * @return Result enum value
+     */
+    DM_PARTICLE_PROTO(uint32_t, GetParticleCount, HParticleContext context, HInstance instance, uint32_t emitter_index);
+
+    /**
+     * Generates partial vertex data for an emitter
+     * @param context Particle context
+     * @param dt Time step.
+     * @param instance Particle instance handle
+     * @param emitter_index Emitter index for which to generate vertex data for
+     * @param particle_start The particle index to start from
+     * @param particle_count The number of particles to update
+     * @param attribute_infos Attribute information on the streams to write
+     * @param color The particle color to (potentially) write
+     * @param vertex_buffer Vertex buffer into which to store the particle vertex data. If this is 0x0, no data will be generated.
+     * @param vertex_buffer_size Size in bytes of the supplied vertex buffer.
+     * @param out_vertex_buffer_size Size in bytes of the total data written to vertex buffer.
+     * @return Result enum value
+     */
+    DM_PARTICLE_PROTO(GenerateVertexDataResult, GenerateVertexDataPartial, HParticleContext context, float dt, HInstance instance, uint32_t emitter_index, uint32_t particle_start, uint32_t particle_count, const dmGraphics::VertexAttributeInfos& attribute_infos, const dmVMath::Vector4& color, void* vertex_buffer, uint32_t vertex_buffer_size, uint32_t* out_vertex_buffer_size);
+
+    /**
      * Debug render the status of the instances within the specified context.
      * @param context Context of the instances to render.
      * @param RenderLine Function pointer to use to render the lines.

--- a/engine/particle/src/particle_private.h
+++ b/engine/particle/src/particle_private.h
@@ -120,8 +120,6 @@ namespace dmParticle
         dmVMath::Point3         m_LastPosition;
         dmhash_t                m_Id;
         EmitterRenderData       m_RenderData;
-        /// Number of particles that have been consumed by the renderer
-        uint32_t                m_ParticlesConsumed;
         /// Vertex index of the render data for the particles spawned by this emitter.
         uint32_t                m_VertexIndex;
         /// Number of vertices of the render data for the particles spawned by this emitter.

--- a/engine/particle/src/test/test_particle.cpp
+++ b/engine/particle/src/test/test_particle.cpp
@@ -1481,7 +1481,6 @@ TEST_F(ParticleTest, Animation)
         dmParticle::Update(m_Context, dt, FetchAnimationCallback);
         TestVertex* vb = vertex_buffer;
         uint32_t vertex_buffer_size = 0;
-        uint32_t vb_offs = 0;
         for (uint32_t type = 0; type < type_count; ++type)
         {
             dmParticle::GenerateVertexData(m_Context, dt, instance, type, m_AttributeInfos, Vector4(1,1,1,1), (void*)vertex_buffer, 6 * type_count * sizeof(TestVertex), &vertex_buffer_size);
@@ -1506,7 +1505,6 @@ TEST_F(ParticleTest, Animation)
                     VerifyVertexDims(vb, 1, 1.0f, 2, 3);
                 }
                 vb += 6;
-                vb_offs += 6;
             }
         }
         ASSERT_EQ((vb - vertex_buffer) * sizeof(TestVertex), vertex_buffer_size);


### PR DESCRIPTION
This allows for a smaller CPU memory usage when updating the GPU vertex buffer.

There is a new property `particle_fx.max_particle_buffer_count` (default 1024) that controls how many particles will fit into the CPU buffer, effectively limiting CPU memory usage.

The previous property `particle_fx.max_particle_count` (default 1024), is now the limit of the GPU vertex buffer size.

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
