### PR TITLE
Improve FS synchronization

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/resources/jsweb/dmloader.js
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/resources/jsweb/dmloader.js
@@ -960,14 +960,17 @@ var Module = {
         FS.syncfs(true, function(err) {
             if (err) {
                 Module._syncTries += 1;
-                console.warn("Unable to synchronize mounted file systems: " + err);
+                console.info(`Unable to synchronize mounted file systems (attempt ${Module._syncTries} of ${Module._syncMaxTries}): `, err);
                 if (Module._syncMaxTries > Module._syncTries) {
                     Module.preSync(done);
                 } else {
+                    console.warn("Mounted system wasn't synchronized. Retry count was exceeded.");
+                    Module._syncTries = 0;
                     Module._syncInitial = true;
                     done();
                 }
             } else {
+                Module._syncTries = 0;
                 Module._syncInitial = true;
                 if (done !== undefined) {
                     done();
@@ -1099,8 +1102,10 @@ var Module = {
                 Module._syncInProgress = false;
 
                 if (err) {
-                    console.warn("Unable to synchronize mounted file systems: " + err);
+                    console.info(`Unable to synchronize mounted file systems (attempt ${Module._syncTries} of ${Module._syncMaxTries}): `, err);
                     Module._syncTries += 1;
+                } else {
+                    Module._syncTries = 0;
                 }
 
                 if (Module._syncNeeded) {
@@ -1109,6 +1114,9 @@ var Module = {
                 }
 
             });
+        } else {
+            console.warn("Mounted system wasn't synchronized. Retry count was exceeded.");
+            Module._syncTries = 0;
         }
     },
 };

--- a/engine/dlib/src/dlib/sys_posix.cpp
+++ b/engine/dlib/src/dlib/sys_posix.cpp
@@ -129,7 +129,6 @@ namespace dmSys
 #endif
 
 
-#if !defined(__EMSCRIPTEN__)
     Result Rename(const char* dst_filename, const char* src_filename)
     {
 #if defined(_WIN32)
@@ -143,52 +142,6 @@ namespace dmSys
         }
         return RESULT_UNKNOWN;
     }
-#else // EMSCRIPTEN
-    Result Rename(const char* dst_filename, const char* src_filename)
-    {
-        FILE* src_file = fopen(src_filename, "rb");
-        if (!src_file)
-        {
-            return RESULT_IO;
-        }
-
-        fseek(src_file, 0, SEEK_END);
-        size_t buf_len = ftell(src_file);
-        fseek(src_file, 0, SEEK_SET);
-        char* buf = (char*)malloc(buf_len);
-        if (fread(buf, 1, buf_len, src_file) != buf_len)
-        {
-            fclose(src_file);
-            free(buf);
-            return RESULT_IO;
-        }
-
-        FILE* dst_file = fopen(dst_filename, "wb");
-        if (!dst_file)
-        {
-            fclose(src_file);
-            free(buf);
-            return RESULT_IO;
-        }
-
-        if(fwrite(buf, 1, buf_len, dst_file) != buf_len)
-        {
-            fclose(src_file);
-            fclose(dst_file);
-            free(buf);
-            return RESULT_IO;
-        }
-
-        fclose(src_file);
-        fclose(dst_file);
-        free(buf);
-
-        dmSys::Unlink(src_filename);
-
-        return RESULT_OK;
-    }
-
-#endif
 
     Result GetHostFileName(char* buffer, size_t buffer_size, const char* path)
     {

--- a/engine/gamesys/src/gamesys/scripts/script_http_util.h
+++ b/engine/gamesys/src/gamesys/scripts/script_http_util.h
@@ -32,7 +32,6 @@ namespace dmGameSystem
             return false;
         }
         size_t nwritten = fwrite(data, 1, data_len, f);
-        fflush(f);
         fclose(f);
         if (nwritten != data_len)
         {


### PR DESCRIPTION
[HTML5 only] Fixed issue when several `http.request` with option `path` led to stop syncing MemoryDB->PersistentDB and as a result - losing saved data after page reload

Fixes #9745

### Technical changes
Simplified repro steps are following:
1. Download any file via `http.request` and use path option to store result.
2. Observe warning about syncfs error.
3. Repeat more than 3 times
4. Reload page. Only part of data stored in IndexedDB

What is happened
When we use path option engine tries to write response body to `xxxxxxx.httptmp` file, close it and rename to file without `.httptmp`. On every `fclose` we call `FS.syncfs` which start syncing data between in-memory db and IndexedDB. As I understood that process is not synchronous. As a result when we call `fclose` we submit to sync file list which contains `xxxxxxx.httptmp` . After submitting we call `dmSys::Rename` and file `xxxxxxx.httptmp` is not exists any more. So when submitted task executes, it tries call `FS.stat` for `xxxxxxx.httptmp` and catch ENOENT (file doesn't exist).
When error occurred - we try sync DBs one more time and it completes successfully.

The fix is to reset retry count which used when we call `FS.synfs`. In general it helps prevent any error related to syncfs that unrelated to our code.
Vanilla `fclose` from Emscripten doesn't have any `syncfs` logic. It's our own addition in dmloader.js.

## PR checklist

* [x] Code
	* [x] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [x] Add comments where needed
* [x] Documentation
	* [x] Make sure that API documentation is updated in code comments
	* [x] Make sure that manuals are updated (in github.com/defold/doc)
* [x] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [x] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [x] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
