### PR TITLE
Use more precise method to calculate `dt`

### DIFF
--- a/engine/dlib/src/dlib/connection_pool.cpp
+++ b/engine/dlib/src/dlib/connection_pool.cpp
@@ -304,7 +304,7 @@ namespace dmConnectionPool
     static Result Connect(HPool pool, const char* host, dmSocket::Address address, uint16_t port, bool ssl, int timeout,
                                     dmSocket::Socket* socket, dmSSLSocket::Socket* sslsocket, dmSocket::Result* sr)
     {
-        uint64_t connectstart = dmTime::GetTime();
+        uint64_t connectstart = dmTime::GetMonotonicTime();
 
         Result r = ConnectSocket(pool, address, port, timeout, socket, sr);
         if( r != RESULT_OK )
@@ -313,7 +313,7 @@ namespace dmConnectionPool
             return r;
         }
 
-        uint64_t handshakestart = dmTime::GetTime();
+        uint64_t handshakestart = dmTime::GetMonotonicTime();
         if( timeout > 0 && (handshakestart - connectstart) > (uint64_t)timeout )
         {
             dmSocket::Delete(*socket);
@@ -350,11 +350,11 @@ namespace dmConnectionPool
         // that the caller can try to connect first to ipv4 and then to ipv6 if ipv4 failed.
         dmSocket::Address address;
 
-        uint64_t dial_started = dmTime::GetTime();
+        uint64_t dial_started = dmTime::GetMonotonicTime();
         bool gethost_did_succeed = dmSocket::GetHostByNameT(host, &address, timeout, cancelflag, ipv4, ipv6) == dmSocket::RESULT_OK;
         if (timeout > 0)
         {
-            timeout = timeout - (int)(dmTime::GetTime() - dial_started);
+            timeout = timeout - (int)(dmTime::GetMonotonicTime() - dial_started);
             if (timeout <= 0)
             {
                 return RESULT_SOCKET_ERROR;
@@ -415,7 +415,7 @@ namespace dmConnectionPool
     Result Dial(HPool pool, const char* host, uint16_t port, bool ssl, int timeout, int* cancelflag, HConnection* connection, dmSocket::Result* sock_res)
     {
         // try connecting to the host using ipv4 first
-        uint64_t dial_started = dmTime::GetTime();
+        uint64_t dial_started = dmTime::GetMonotonicTime();
         Result r = DoDial(pool, host, port, ssl, timeout, cancelflag, connection, sock_res, 1, 0);
         // Only if handshake failed NOT because of timeout
         if (r == RESULT_OK || r == RESULT_SHUT_DOWN || r == RESULT_OUT_OF_RESOURCES ||
@@ -426,7 +426,7 @@ namespace dmConnectionPool
         // ipv4 connection failed - reduce timeout (if needed) and try using ipv6 instead
         if (timeout > 0)
         {
-            timeout = timeout - (int)(dmTime::GetTime() - dial_started);
+            timeout = timeout - (int)(dmTime::GetMonotonicTime() - dial_started);
             if (timeout <= 0)
             {
                 return RESULT_SOCKET_ERROR;

--- a/engine/dlib/src/dlib/connection_pool.cpp
+++ b/engine/dlib/src/dlib/connection_pool.cpp
@@ -227,7 +227,7 @@ namespace dmConnectionPool
     static void PurgeExpired(HPool pool) {
         uint32_t n = pool->m_Connections.Size();
 
-        uint64_t now = dmTime::GetTime();
+        uint64_t now = dmTime::GetMonotonicTime();
         for (uint32_t i = 0; i < n; ++i) {
             Connection* c = &pool->m_Connections[i];
             if (c->m_State == STATE_CONNECTED && now >= c->m_Expires) {
@@ -399,7 +399,7 @@ namespace dmConnectionPool
                 c->m_ID = conn_id;
                 c->m_ReuseCount = 0;
                 c->m_State = STATE_INUSE;
-                c->m_Expires = pool->m_MaxKeepAlive * 1000000U + dmTime::GetTime();
+                c->m_Expires = pool->m_MaxKeepAlive * 1000000U + dmTime::GetMonotonicTime();
                 c->m_Address = address;
                 c->m_Port = port;
                 c->m_WasShutdown = 0;

--- a/engine/dlib/src/dlib/darwin/time_darwin.cpp
+++ b/engine/dlib/src/dlib/darwin/time_darwin.cpp
@@ -31,7 +31,7 @@ namespace dmTime
         return ((uint64_t) tv.tv_sec) * 1000000U + tv.tv_usec;
     }
 
-    uint64_t GetMonotomicTime()
+    uint64_t GetMonotonicTime()
     {
         uint64_t nanoseconds = clock_gettime_nsec_np(CLOCK_UPTIME_RAW);
         return nanoseconds / 1000U;

--- a/engine/dlib/src/dlib/darwin/time_darwin.cpp
+++ b/engine/dlib/src/dlib/darwin/time_darwin.cpp
@@ -33,8 +33,7 @@ namespace dmTime
 
     uint64_t GetMonotomicTime()
     {
-        struct timespec ts;
-        clock_gettime(CLOCK_MONOTONIC, &ts);
-        return (uint64_t) ts.tv_sec * 1000000U + ts.tv_nsec / 1000U;
+        uint64_t nanoseconds = clock_gettime_nsec_np(CLOCK_UPTIME_RAW);
+        return nanoseconds / 1000U;
     }
 }

--- a/engine/dlib/src/dlib/http_client.cpp
+++ b/engine/dlib/src/dlib/http_client.cpp
@@ -321,7 +321,7 @@ namespace dmHttpClient
             return true;
         if( client->m_RequestTimeout == 0 )
             return false;
-        uint64_t currenttime = dmTime::GetTime();
+        uint64_t currenttime = dmTime::GetMonotonicTime();
         return int(currenttime - client->m_RequestStart) >= client->m_RequestTimeout;
     }
 
@@ -1101,7 +1101,7 @@ bail:
     Result Get(HClient client, const char* path)
     {
         dmSnPrintf(client->m_URI, sizeof(client->m_URI), "%s://%s:%d/%s", client->m_Secure ? "https" : "http", client->m_Hostname, (int) client->m_Port, path);
-        client->m_RequestStart = dmTime::GetTime();
+        client->m_RequestStart = dmTime::GetMonotonicTime();
 
         Result r;
 
@@ -1139,7 +1139,7 @@ bail:
                 // Try again
                 if (i < client->m_MaxGetRetries - 1) {
                     client->m_Statistics.m_Reconnections++;
-                    client->m_RequestStart = dmTime::GetTime();
+                    client->m_RequestStart = dmTime::GetMonotonicTime();
                     dmLogInfo("HTTPCLIENT: Connection lost, reconnecting. (%d/%d)", i + 1, client->m_MaxGetRetries - 1);
                 }
             }
@@ -1162,7 +1162,7 @@ bail:
             return Get(client, path);
         } else {
             dmSnPrintf(client->m_URI, sizeof(client->m_URI), "%s://%s:%d/%s", client->m_Secure ? "https" : "http", client->m_Hostname, (int) client->m_Port, path);
-            client->m_RequestStart = dmTime::GetTime();
+            client->m_RequestStart = dmTime::GetMonotonicTime();
             Result r = DoRequest(client, path, method);
             return r;
         }

--- a/engine/dlib/src/dlib/http_server.cpp
+++ b/engine/dlib/src/dlib/http_server.cpp
@@ -619,7 +619,7 @@ bail:
                     Connection connection;
                     memset(&connection, 0, sizeof(connection));
                     connection.m_Socket = client_socket;
-                    connection.m_ConnectionTimeStart = dmTime::GetTime();
+                    connection.m_ConnectionTimeStart = dmTime::GetMonotonicTime();
                     server->m_Connections.Push(connection);
                 }
             }
@@ -631,7 +631,7 @@ bail:
 
         dmSocket::SelectorZero(&selector);
 
-        uint64_t current_time = dmTime::GetTime();
+        uint64_t current_time = dmTime::GetMonotonicTime();
 
         // Iterate over persistent connections, timeout phase
         for (uint32_t i = 0; i < server->m_Connections.Size(); ++i)

--- a/engine/dlib/src/dlib/socket.cpp
+++ b/engine/dlib/src/dlib/socket.cpp
@@ -129,8 +129,8 @@ namespace dmSocket
         ctx->m_Finished = 0;
 
         dmThread::Thread t = dmThread::New(&GetHostByNameThreadWorker, THREAD_STACK_SIZE, ctx, "GetHostByName");
-        uint64_t tend = timeout ? dmTime::GetTime() + timeout : 0xFFFFFFFFFFFFFFFF;
-        while (tend > dmTime::GetTime())
+        uint64_t tend = timeout ? dmTime::GetMonotonicTime() + timeout : 0xFFFFFFFFFFFFFFFF;
+        while (tend > dmTime::GetMonotonicTime())
         {
             if (dmAtomicAdd32(&ctx->m_Finished, 0) == 1) // the thread has finished
             {

--- a/engine/dlib/src/dlib/sslsocket.cpp
+++ b/engine/dlib/src/dlib/sslsocket.cpp
@@ -263,7 +263,7 @@ static int RecvTimeout( void* _ctx, unsigned char *buf, size_t len, uint32_t tim
 
 Result New(dmSocket::Socket socket, const char* host, uint64_t timeout, SSLSocket** sslsocket)
 {
-    uint64_t handshakestart = dmTime::GetTime();
+    uint64_t handshakestart = dmTime::GetMonotonicTime();
 
     SSLSocket* c = (SSLSocket*)malloc(sizeof(SSLSocket));
     memset(c, 0, sizeof(SSLSocket));
@@ -359,7 +359,7 @@ Result New(dmSocket::Socket socket, const char* host, uint64_t timeout, SSLSocke
     } while (ret == MBEDTLS_ERR_SSL_WANT_READ ||
              ret == MBEDTLS_ERR_SSL_WANT_WRITE);
 
-    uint64_t currenttime = dmTime::GetTime();
+    uint64_t currenttime = dmTime::GetMonotonicTime();
     if( timeout > 0 && int(currenttime - handshakestart) > timeout )
     {
         ret = MBEDTLS_ERR_SSL_TIMEOUT;

--- a/engine/dlib/src/dlib/sslsocket.cpp
+++ b/engine/dlib/src/dlib/sslsocket.cpp
@@ -198,7 +198,7 @@ Result SetSslPublicKeys(const uint8_t* key, uint32_t keylen)
 static void TimingSetDelay(void* data, uint32_t int_ms, uint32_t fin_ms)
 {
     SSLSocket* socket = (SSLSocket*)data;
-    socket->m_TimeStart = dmTime::GetTime();
+    socket->m_TimeStart = dmTime::GetMonotonicTime();
     socket->m_TimeLimit1 = int_ms; // intermediate limit
     socket->m_TimeLimit2 = fin_ms; // final limit
 }
@@ -209,7 +209,7 @@ static int TimingGetDelay(void* data)
     if( socket->m_TimeLimit2 == 0 )
         return -1;
 
-    uint64_t t = dmTime::GetTime();
+    uint64_t t = dmTime::GetMonotonicTime();
     uint64_t elapsed_ms = (t - socket->m_TimeStart) / 1000;
 
     if( elapsed_ms >= socket->m_TimeLimit2 )

--- a/engine/dlib/src/dlib/time.h
+++ b/engine/dlib/src/dlib/time.h
@@ -21,8 +21,8 @@
 namespace dmTime
 {
     inline void BusyWait(uint32_t useconds) {
-        uint64_t end = dmTime::GetMonotomicTime() + (uint64_t)useconds;
-        while (dmTime::GetMonotomicTime() < end);
+        uint64_t end = dmTime::GetMonotonicTime() + (uint64_t)useconds;
+        while (dmTime::GetMonotonicTime() < end);
     }
 }
 

--- a/engine/dlib/src/dlib/time.h
+++ b/engine/dlib/src/dlib/time.h
@@ -20,14 +20,9 @@
 
 namespace dmTime
 {
-    /**
-     * Busy wait thread with high precision (~10 microseconds).
-     * NOTE This function currently has low precision, see DEF-2013
-     * @param useconds Time to wait in microseconds
-     */
     inline void BusyWait(uint32_t useconds) {
-        uint64_t end = dmTime::GetTime() + (uint64_t)useconds;
-        while (dmTime::GetTime() < end);
+        uint64_t end = dmTime::GetMonotomicTime() + (uint64_t)useconds;
+        while (dmTime::GetMonotomicTime() < end);
     }
 }
 

--- a/engine/dlib/src/dlib/time_posix.cpp
+++ b/engine/dlib/src/dlib/time_posix.cpp
@@ -14,7 +14,7 @@
 
 #include "time.h"
 
-#include <sys/time.h>
+#include <time.h>
 #include <unistd.h>
 
 namespace dmTime
@@ -26,9 +26,9 @@ namespace dmTime
 
     uint64_t GetTime()
     {
-        timeval tv;
-        gettimeofday(&tv, 0);
-        return ((uint64_t) tv.tv_sec) * 1000000U + tv.tv_usec;
+        struct timespec ts;
+        clock_gettime(CLOCK_REALTIME, &ts);
+        return (uint64_t)ts.tv_sec * 1000000U + ts.tv_nsec / 1000U;
     }
 
     uint64_t GetMonotomicTime()

--- a/engine/dlib/src/dlib/time_posix.cpp
+++ b/engine/dlib/src/dlib/time_posix.cpp
@@ -31,7 +31,7 @@ namespace dmTime
         return (uint64_t)ts.tv_sec * 1000000U + ts.tv_nsec / 1000U;
     }
 
-    uint64_t GetMonotomicTime()
+    uint64_t GetMonotonicTime()
     {
         struct timespec ts;
         clock_gettime(CLOCK_MONOTONIC, &ts);

--- a/engine/dlib/src/dlib/win32/time_win32.cpp
+++ b/engine/dlib/src/dlib/win32/time_win32.cpp
@@ -44,4 +44,18 @@ namespace dmTime
         t -= DELTA_EPOCH_IN_MICROSECS;
         return t;
     }
+
+    static uint64_t frequency = 0;
+
+    uint64_t GetMonotonicTime()
+    {
+        if (frequency == 0) {
+            LARGE_INTEGER freq;
+            QueryPerformanceFrequency(&freq);
+            frequency = freq.QuadPart;
+        }
+        LARGE_INTEGER counter;
+        QueryPerformanceCounter(&counter);
+        return (uint64_t)counter.QuadPart * 1000000ULL / frequency;
+    }
 }

--- a/engine/dlib/src/dmsdk/dlib/time.h
+++ b/engine/dlib/src/dmsdk/dlib/time.h
@@ -43,6 +43,16 @@ namespace dmTime
      * @name dmTime::GetMonotomicTime
      * @return result [type:uint64_t] Monotomic time in microseconds
      */
+    
+    /*
+        +------------------+------------------+----------------------------------+------------------------------------+
+        | Platform         | Precision        | Resolution                       | Behavior                           |
+        +------------------+------------------+----------------------------------+------------------------------------+
+        | Windows          | Sub-microsecond  | ~100 nanoseconds or better       | Monotonic (QueryPerformanceCounter)|
+        | POSIX (Linux)    | Nanoseconds      | ~10 nanoseconds to 1 microsecond | Monotonic (CLOCK_MONOTONIC)        |
+        | macOS            | Nanoseconds      | ~10 nanoseconds to 1 microsecond | Monotonic (CLOCK_UPTIME_RAW)       |
+        +------------------+------------------+----------------------------------+------------------------------------+
+    */
     uint64_t GetMonotomicTime();
 
     /*# sleep thread with low precision (~10 milliseconds).

--- a/engine/dlib/src/dmsdk/dlib/time.h
+++ b/engine/dlib/src/dmsdk/dlib/time.h
@@ -37,11 +37,11 @@ namespace dmTime
      */
     uint64_t GetTime();
 
-    /*# get monotomic time in microseconds
+    /*# get monotonic time in microseconds
      *
-     * Get monotomic time in microseconds since some unspecified starting point.
-     * @name dmTime::GetMonotomicTime
-     * @return result [type:uint64_t] Monotomic time in microseconds
+     * Get monotonic time in microseconds since some unspecified starting point.
+     * @name dmTime::GetMonotonicTime
+     * @return result [type:uint64_t] Monotonic time in microseconds
      */
     
     /*
@@ -53,7 +53,7 @@ namespace dmTime
         | macOS            | Nanoseconds      | ~10 nanoseconds to 1 microsecond | Monotonic (CLOCK_UPTIME_RAW)       |
         +------------------+------------------+----------------------------------+------------------------------------+
     */
-    uint64_t GetMonotomicTime();
+    uint64_t GetMonotonicTime();
 
     /*# sleep thread with low precision (~10 milliseconds).
      *

--- a/engine/dlib/src/dmsdk/dlib/time.h
+++ b/engine/dlib/src/dmsdk/dlib/time.h
@@ -37,6 +37,14 @@ namespace dmTime
      */
     uint64_t GetTime();
 
+    /*# get monotomic time in microseconds
+     *
+     * Get monotomic time in microseconds since some unspecified starting point.
+     * @name dmTime::GetMonotomicTime
+     * @return result [type:uint64_t] Monotomic time in microseconds
+     */
+    uint64_t GetMonotomicTime();
+
     /*# sleep thread with low precision (~10 milliseconds).
      *
      * Sleep thread with low precision (~10 milliseconds).

--- a/engine/dlib/src/test/test_httpclient.cpp
+++ b/engine/dlib/src/test/test_httpclient.cpp
@@ -993,9 +993,9 @@ TEST_P(dmHttpClientTestSSL, FailedSSLHandshake)
         uint64_t timeout = 130 * 1000;
         dmHttpClient::SetOptionInt(m_Client, dmHttpClient::OPTION_REQUEST_TIMEOUT, timeout); // microseconds
 
-        uint64_t timestart = dmTime::GetTime();
+        uint64_t timestart = dmTime::GetMonotonicTime();
         dmHttpClient::Result r = dmHttpClient::Get(m_Client, "/sleep/5000"); // milliseconds
-        uint64_t timeend = dmTime::GetTime();
+        uint64_t timeend = dmTime::GetMonotonicTime();
 
         ASSERT_NE(dmHttpClient::RESULT_OK, r);
         ASSERT_NE(dmHttpClient::RESULT_NOT_200_OK, r);

--- a/engine/dlib/src/test/test_job_thread.cpp
+++ b/engine/dlib/src/test/test_job_thread.cpp
@@ -62,9 +62,9 @@ TEST(dmJobThread, PushJobsMultipleThreads)
         dmJobThread::PushJob(ctx, process, callback, (void*) &contexts[i], (void*) &datas[i]);
     }
 
-    uint64_t stop_time = dmTime::GetTime() + 1*1e6; // 1 second
+    uint64_t stop_time = dmTime::GetMonotonicTime() + 1*1e6; // 1 second
     bool tests_done = false;
-    while (dmTime::GetTime() < stop_time && !tests_done)
+    while (dmTime::GetMonotonicTime() < stop_time && !tests_done)
     {
         dmJobThread::Update(ctx);
 

--- a/engine/dlib/src/test/test_message.cpp
+++ b/engine/dlib/src/test/test_message.cpp
@@ -150,13 +150,13 @@ TEST(dmMessage, Bench)
     ASSERT_LT(0u, dmMessage::Dispatch(receiver.m_Socket, HandleMessage, 0));
 
     // Benchmark
-    uint64_t start = dmTime::GetTime();
+    uint64_t start = dmTime::GetMonotonicTime();
     for (uint32_t iter = 0; iter < iter_count; ++iter)
     {
         ASSERT_EQ(dmMessage::RESULT_OK, dmMessage::Post(0x0, &receiver, m_HashMessage1, 0, 0x0, &message_data1, sizeof(CustomMessageData1), 0));
     }
     ASSERT_LT(0u, dmMessage::Dispatch(receiver.m_Socket, HandleMessage, 0));
-    uint64_t end = dmTime::GetTime();
+    uint64_t end = dmTime::GetMonotonicTime();
     printf("Bench elapsed: %f ms (%f us per call)\n", (end-start) / 1000.0f, (end-start) / float(iter_count));
 
     ASSERT_EQ(0u, dmMessage::Dispatch(receiver.m_Socket, HandleMessage, 0));

--- a/engine/dlib/src/test/test_profile.cpp
+++ b/engine/dlib/src/test/test_profile.cpp
@@ -72,7 +72,6 @@ struct PropertyCtx
 
 // *******************************************************************************
 // Samples
-/*
 static void ProcessSample(SampleCtx* ctx, dmProfile::HSample sample)
 {
     TestSample out;
@@ -112,7 +111,6 @@ static void SampleTreeCallback(void* _ctx, const char* thread_name, dmProfile::H
     printf("Thread: %s\n", thread_name);
     TraverseSampleTree(ctx, 1, root);
 }
-*/
 
 // *******************************************************************************
 // Properties
@@ -168,15 +166,6 @@ TEST(dmProfile, SmallTest)
     dmProfile::Finalize();
 }
 
-#if 0
-// This test is currently disabled until we can figure out a good way to test it.
-// It is currentlyu very tricky to do due to its threadeded mechanic.
-
-// TODO
-// 100 msec, which is in fact much higher than the expected time of the profiler
-// On OSX, the time is usually a few microseconds, but once in a while the time spikes to ~0.5 ms
-// On Linux CI, the time can be as high as 16 msec
-// The timings (dmTime::BusyWait) is based around dmTime::GetTime, this issue is a revisit to improve the expected granularity: DEF-2013
 #define TOL 0.1
 
 TEST(dmProfile, Profile)
@@ -262,8 +251,6 @@ TEST(dmProfile, Profile)
 
     dmMutex::Delete(ctx.m_Mutex);
 }
-
-#endif // Disable
 
 
 DM_PROPERTY_GROUP(prop_TestGroup1, "");

--- a/engine/dlib/src/test/test_socket.cpp
+++ b/engine/dlib/src/test/test_socket.cpp
@@ -867,15 +867,15 @@ TEST(Socket, Timeout)
     memset(buf, 0, sizeof(buf));
 
     for (int i = 0; i < 10; ++i) {
-        uint64_t start = dmTime::GetTime();
+        uint64_t start = dmTime::GetMonotonicTime();
         r = dmSocket::Receive(client_socket, buf, sizeof(buf), &received);
-        uint64_t end = dmTime::GetTime();
+        uint64_t end = dmTime::GetMonotonicTime();
         ASSERT_EQ(dmSocket::RESULT_WOULDBLOCK, r);
         ASSERT_GE(end - start, timeout - 2500); // NOTE: Margin of 2500. Required on Linux
     }
 
     for (int i = 0; i < 10; ++i) {
-        uint64_t start = dmTime::GetTime();
+        uint64_t start = dmTime::GetMonotonicTime();
         for (int j = 0; j < 10000; ++j) {
             // Loop to ensure that we fill send buffers
             r = dmSocket::Send(client_socket, buf, sizeof(buf), &received);
@@ -883,7 +883,7 @@ TEST(Socket, Timeout)
                 break;
             }
         }
-        uint64_t end = dmTime::GetTime();
+        uint64_t end = dmTime::GetMonotonicTime();
         ASSERT_EQ(dmSocket::RESULT_WOULDBLOCK, r);
         ASSERT_GE(end - start, timeout - 2500); // NOTE: Margin of 2500. Required on Linux
     }

--- a/engine/dlib/src/test/test_time.cpp
+++ b/engine/dlib/src/test/test_time.cpp
@@ -22,15 +22,13 @@ TEST(dmTime, Sleep)
     dmTime::Sleep(1);
 }
 
-#if !defined(GITHUB_CI)
-TEST(dmTime, GetTime)
+TEST(dmTime, GetMonotonicTime)
 {
-    uint64_t start = dmTime::GetTime();
+    uint64_t start = dmTime::GetMonotonicTime();
     dmTime::Sleep(200000);
-    uint64_t end = dmTime::GetTime();
+    uint64_t end = dmTime::GetMonotonicTime();
     ASSERT_NEAR((double) 200000, (double) (end-start), (double) 40000);
 }
-#endif
 
 int main(int argc, char **argv)
 {

--- a/engine/dlib/src/test/test_time.cpp
+++ b/engine/dlib/src/test/test_time.cpp
@@ -22,13 +22,15 @@ TEST(dmTime, Sleep)
     dmTime::Sleep(1);
 }
 
-TEST(dmTime, GetMonotonicTime)
+#if !defined(GITHUB_CI)
+TEST(dmTime, GetTime)
 {
-    uint64_t start = dmTime::GetMonotonicTime();
+    uint64_t start = dmTime::GetTime();
     dmTime::Sleep(200000);
-    uint64_t end = dmTime::GetMonotonicTime();
+    uint64_t end = dmTime::GetTime();
     ASSERT_NEAR((double) 200000, (double) (end-start), (double) 40000);
 }
+#endif
 
 int main(int argc, char **argv)
 {

--- a/engine/dlib/src/wscript
+++ b/engine/dlib/src/wscript
@@ -100,6 +100,9 @@ def build(bld):
         source_files = remove_files(source_files, ['thread_win32.cpp'])
         source_files = remove_files(source_files, ['mutex_win32.cpp'])
 
+    if build_util.get_target_os() in ['macos', 'ios']:
+        source_files = remove_files(source_files, ['time_posix.cpp'])
+
     dlib = bld.stlib(features = 'c cxx',
                      source   = source_files + platform_source_files,
                      includes = ['.', './mbedtls/include', './mbedtls/crypto/include'],

--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -183,7 +183,7 @@ namespace dmEngine
 
         // We reset the time on both events because
         // on some platforms both events will arrive when regaining focus
-        engine->m_PreviousFrameTime = dmTime::GetTime(); // we might have stalled for a long time
+        engine->m_PreviousFrameTime = dmTime::GetMonotomicTime(); // we might have stalled for a long time
 
         dmExtension::Params params;
         params.m_ConfigFile = engine->m_Config;
@@ -265,7 +265,7 @@ namespace dmEngine
         m_ModelContext.m_RenderContext = 0x0;
         m_ModelContext.m_MaxModelCount = 0;
         m_AccumFrameTime = 0;
-        m_PreviousFrameTime = dmTime::GetTime();
+        m_PreviousFrameTime = dmTime::GetMonotomicTime();
     }
 
     HEngine New(dmEngineService::HEngineService engine_service)
@@ -1479,7 +1479,7 @@ namespace dmEngine
             dmExtension::DispatchEvent( &params, &event );
         }
 
-        engine->m_PreviousFrameTime = dmTime::GetTime();
+        engine->m_PreviousFrameTime = dmTime::GetMonotomicTime();
 
         return true;
 
@@ -1584,7 +1584,7 @@ bail:
 
     static void StepFrame(HEngine engine, float dt)
     {
-        uint64_t frame_start = dmTime::GetTime();
+        uint64_t frame_start = dmTime::GetMonotomicTime();
 
         dmProfiler::SetUpdateFrequency((uint32_t)(1.0f / dt));
 
@@ -1830,7 +1830,7 @@ bail:
                 if (engine->m_UseSwVSync && engine->m_UpdateFrequency > 0)
                 {
                     DM_PROFILE("SoftwareVsync");
-                    uint64_t current = dmTime::GetTime();
+                    uint64_t current = dmTime::GetMonotomicTime();
 
                     float target_time = dt; // already pre calculated by CalcTimeStep
                     uint64_t elapsed = current - frame_start;
@@ -1838,9 +1838,9 @@ bail:
 
                     while (remainder > 500) // dont bother with less than 0.5ms
                     {
-                        uint64_t t1 = dmTime::GetTime();
+                        uint64_t t1 = dmTime::GetMonotomicTime();
                         dmTime::Sleep(100); // sleep in chunks of 0.1ms
-                        uint64_t t2 = dmTime::GetTime();
+                        uint64_t t2 = dmTime::GetMonotomicTime();
                         uint64_t slept = t2 - t1;
                         if (slept >= remainder)
                             break;
@@ -1879,7 +1879,7 @@ bail:
 
     static void CalcTimeStep(HEngine engine, float& step_dt, uint32_t& num_steps)
     {
-        uint64_t time = dmTime::GetTime();
+        uint64_t time = dmTime::GetMonotomicTime();
         uint64_t frame_time = time - engine->m_PreviousFrameTime; // The actual time between two engine frames
         engine->m_PreviousFrameTime = time;
 

--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -183,7 +183,7 @@ namespace dmEngine
 
         // We reset the time on both events because
         // on some platforms both events will arrive when regaining focus
-        engine->m_PreviousFrameTime = dmTime::GetMonotomicTime(); // we might have stalled for a long time
+        engine->m_PreviousFrameTime = dmTime::GetMonotonicTime(); // we might have stalled for a long time
 
         dmExtension::Params params;
         params.m_ConfigFile = engine->m_Config;
@@ -265,7 +265,7 @@ namespace dmEngine
         m_ModelContext.m_RenderContext = 0x0;
         m_ModelContext.m_MaxModelCount = 0;
         m_AccumFrameTime = 0;
-        m_PreviousFrameTime = dmTime::GetMonotomicTime();
+        m_PreviousFrameTime = dmTime::GetMonotonicTime();
     }
 
     HEngine New(dmEngineService::HEngineService engine_service)
@@ -1479,7 +1479,7 @@ namespace dmEngine
             dmExtension::DispatchEvent( &params, &event );
         }
 
-        engine->m_PreviousFrameTime = dmTime::GetMonotomicTime();
+        engine->m_PreviousFrameTime = dmTime::GetMonotonicTime();
 
         return true;
 
@@ -1584,7 +1584,7 @@ bail:
 
     static void StepFrame(HEngine engine, float dt)
     {
-        uint64_t frame_start = dmTime::GetMonotomicTime();
+        uint64_t frame_start = dmTime::GetMonotonicTime();
 
         dmProfiler::SetUpdateFrequency((uint32_t)(1.0f / dt));
 
@@ -1830,7 +1830,7 @@ bail:
                 if (engine->m_UseSwVSync && engine->m_UpdateFrequency > 0)
                 {
                     DM_PROFILE("SoftwareVsync");
-                    uint64_t current = dmTime::GetMonotomicTime();
+                    uint64_t current = dmTime::GetMonotonicTime();
 
                     float target_time = dt; // already pre calculated by CalcTimeStep
                     uint64_t elapsed = current - frame_start;
@@ -1838,9 +1838,9 @@ bail:
 
                     while (remainder > 500) // dont bother with less than 0.5ms
                     {
-                        uint64_t t1 = dmTime::GetMonotomicTime();
+                        uint64_t t1 = dmTime::GetMonotonicTime();
                         dmTime::Sleep(100); // sleep in chunks of 0.1ms
-                        uint64_t t2 = dmTime::GetMonotomicTime();
+                        uint64_t t2 = dmTime::GetMonotonicTime();
                         uint64_t slept = t2 - t1;
                         if (slept >= remainder)
                             break;
@@ -1879,7 +1879,7 @@ bail:
 
     static void CalcTimeStep(HEngine engine, float& step_dt, uint32_t& num_steps)
     {
-        uint64_t time = dmTime::GetMonotomicTime();
+        uint64_t time = dmTime::GetMonotonicTime();
         uint64_t frame_time = time - engine->m_PreviousFrameTime; // The actual time between two engine frames
         engine->m_PreviousFrameTime = time;
 

--- a/engine/gameobject/src/gameobject/test/anim/test_gameobject_anim.cpp
+++ b/engine/gameobject/src/gameobject/test/anim/test_gameobject_anim.cpp
@@ -490,15 +490,15 @@ TEST_F(AnimTest, LoadTest)
         ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, result);
     }
 
-    uint64_t time = dmTime::GetTime();
+    uint64_t time = dmTime::GetMonotonicTime();
     dmGameObject::Update(m_Collection, &m_UpdateContext);
-    uint64_t delta = dmTime::GetTime() - time;
+    uint64_t delta = dmTime::GetMonotonicTime() - time;
 
     printf("%d animations started in %.3f ms\n", count*4, delta * 0.001);
 
-    time = dmTime::GetTime();
+    time = dmTime::GetMonotonicTime();
     dmGameObject::Update(m_Collection, &m_UpdateContext);
-    delta = dmTime::GetTime() - time;
+    delta = dmTime::GetMonotonicTime() - time;
 
     printf("%d animations simulated in %.3f ms\n", count*3, delta * 0.001);
 

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -155,8 +155,8 @@ TEST_P(ResourceTest, TestPreload)
     dmResource::HPreloader pr = dmResource::NewPreloader(m_Factory, resource_name);
     dmResource::Result r;
 
-    uint64_t stop_time = dmTime::GetTime() + 30*10e6;
-    while (dmTime::GetTime() < stop_time)
+    uint64_t stop_time = dmTime::GetMonotonicTime() + 30*10e6;
+    while (dmTime::GetMonotonicTime() < stop_time)
     {
         // Simulate running at 30fps
         r = dmResource::UpdatePreloader(pr, 0, 0, 33*1000);
@@ -258,11 +258,11 @@ static bool UpdateAndWaitUntilDone(
     uint32_t                           timeout_seconds = 1)
 {
     uint64_t timeout = timeout_seconds * 1000000; // microseconds
-    uint64_t stop_time = dmTime::GetTime() + timeout;
+    uint64_t stop_time = dmTime::GetMonotonicTime() + timeout;
     bool tests_done = false;
     while (!tests_done)
     {
-        if (dmTime::GetTime() >= stop_time)
+        if (dmTime::GetMonotonicTime() >= stop_time)
         {
             dmLogError("Test timed out after %f seconds", timeout / 1000000.0f);
             break;
@@ -1807,8 +1807,8 @@ TEST_P(FactoryTest, Test)
     {
         go_pr = dmResource::NewPreloader(m_Factory, param.m_GOPath);
         dmResource::Result r;
-        uint64_t stop_time = dmTime::GetTime() + 30*10e6;
-        while (dmTime::GetTime() < stop_time)
+        uint64_t stop_time = dmTime::GetMonotonicTime() + 30*10e6;
+        while (dmTime::GetMonotonicTime() < stop_time)
         {
             r = dmResource::UpdatePreloader(go_pr, 0, 0, 16*1000);
             if (r != dmResource::RESULT_PENDING)
@@ -2003,8 +2003,8 @@ TEST_P(CollectionFactoryTest, Test)
     {
         go_pr = dmResource::NewPreloader(m_Factory, param.m_GOPath);
         dmResource::Result r;
-        uint64_t stop_time = dmTime::GetTime() + 30*10e6;
-        while (dmTime::GetTime() < stop_time)
+        uint64_t stop_time = dmTime::GetMonotonicTime() + 30*10e6;
+        while (dmTime::GetMonotonicTime() < stop_time)
         {
             r = dmResource::UpdatePreloader(go_pr, 0, 0, 16*1000);
             if (r != dmResource::RESULT_PENDING)

--- a/engine/gamesys/src/gamesys/test/test_gamesys_http.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys_http.cpp
@@ -54,9 +54,9 @@ TEST_F(ComponentTest, HTTPRequest)
     dmGameObject::HInstance go = ::Spawn(m_Factory, m_Collection, "/http/http_request.goc", dmHashString64("/http_request"), 0, Point3(0, 0, 0), Quat(0, 0, 0, 1), Vector3(1, 1, 1));
     ASSERT_NE((void*)0, go);
 
-    uint64_t stop_time = dmTime::GetTime() + 1*1e6; // 1 second
+    uint64_t stop_time = dmTime::GetMonotonicTime() + 1*1e6; // 1 second
     bool tests_done = false;
-    while (dmTime::GetTime() < stop_time && !tests_done)
+    while (dmTime::GetMonotonicTime() < stop_time && !tests_done)
     {
     	ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
 

--- a/engine/gamesys/src/gamesys/test/test_script_http.cpp
+++ b/engine/gamesys/src/gamesys/test/test_script_http.cpp
@@ -215,7 +215,7 @@ TEST_F(ScriptHttpTest, TestGetPost)
     }
     lua_pop(L, 1);
 
-    uint64_t start = dmTime::GetTime();
+    uint64_t start = dmTime::GetMonotonicTime();
 
     while (1) {
         dmSys::PumpMessageQueue();
@@ -239,7 +239,7 @@ TEST_F(ScriptHttpTest, TestGetPost)
 
         dmTime::Sleep(10 * 1000);
 
-        uint64_t now = dmTime::GetTime();
+        uint64_t now = dmTime::GetMonotonicTime();
         uint64_t elapsed = now - start;
 
         if (elapsed / 1000000 > 8) {

--- a/engine/gamesys/src/gamesys/test/test_script_http.cpp
+++ b/engine/gamesys/src/gamesys/test/test_script_http.cpp
@@ -287,7 +287,7 @@ TEST_F(ScriptHttpTest, TestTimeout)
     }
     lua_pop(L, 1);
 
-    uint64_t start = dmTime::GetTime();
+    uint64_t start = dmTime::GetMonotonicTime();
     while (1) {
         dmSys::PumpMessageQueue();
         dmMessage::Dispatch(m_DefaultURL.m_Socket, DispatchCallbackDDF, this);
@@ -307,7 +307,7 @@ TEST_F(ScriptHttpTest, TestTimeout)
 
         dmTime::Sleep(10 * 1000);
 
-        uint64_t now = dmTime::GetTime();
+        uint64_t now = dmTime::GetMonotonicTime();
         uint64_t elapsed = now - start;
         if (elapsed / 1000000 > 4) {
             dmLogError("The test timed out\n");

--- a/engine/graphics/src/test/test_app_graphics.cpp
+++ b/engine/graphics/src/test/test_app_graphics.cpp
@@ -554,7 +554,7 @@ static void* EngineCreate(int argc, char** argv)
     engine->m_Test->Initialize(engine);
 
     engine->m_WasCreated++;
-    engine->m_TimeStart = dmTime::GetTime();
+    engine->m_TimeStart = dmTime::GetMonotonicTime();
     return &g_EngineCtx;
 }
 
@@ -571,7 +571,7 @@ static UpdateResult EngineUpdate(void* _engine)
 {
     EngineCtx* engine = (EngineCtx*)_engine;
     engine->m_WasRun++;
-    uint64_t t = dmTime::GetTime();
+    uint64_t t = dmTime::GetMonotonicTime();
     float elapsed = (t - engine->m_TimeStart) / 1000000.0f;
     /*
     if (elapsed > 3.0f)
@@ -634,7 +634,7 @@ TEST(App, Run)
     ASSERT_EQ(0, ret);
 
 
-    uint64_t t = dmTime::GetTime();
+    uint64_t t = dmTime::GetMonotonicTime();
     float elapsed = (t - g_EngineCtx.m_TimeStart) / 1000000.0f;
     (void)elapsed;
 

--- a/engine/graphics/src/test/test_graphics.cpp
+++ b/engine/graphics/src/test/test_graphics.cpp
@@ -1386,8 +1386,8 @@ TEST_F(dmGraphicsTest, TestTextureAsync)
         dmGraphics::SetTextureAsync(textures[i], params, TestTextureAsyncCallback, (void*) (values + i));
     }
 
-    uint64_t stop_time = dmTime::GetTime() + 1*1e6; // 1 second
-    while(!all_complete && dmTime::GetTime() < stop_time)
+    uint64_t stop_time = dmTime::GetMonotonicTime() + 1*1e6; // 1 second
+    while(!all_complete && dmTime::GetMonotonicTime() < stop_time)
     {
         dmJobThread::Update(m_JobThread);
         all_complete = true;
@@ -1416,8 +1416,8 @@ TEST_F(dmGraphicsTest, TestTextureAsync)
     }
 
     all_complete = false;
-    stop_time = dmTime::GetTime() + 1*1e6; // 1 second
-    while(!all_complete && dmTime::GetTime() < stop_time)
+    stop_time = dmTime::GetMonotonicTime() + 1*1e6; // 1 second
+    while(!all_complete && dmTime::GetMonotonicTime() < stop_time)
     {
         dmJobThread::Update(m_JobThread);
         all_complete = true;
@@ -1447,8 +1447,8 @@ enum SyncronizedWaitCondition
 static bool WaitUntilSyncronizedTextures(dmGraphics::HContext graphics_context, dmJobThread::HContext job_thread, dmGraphics::HTexture* textures, uint32_t texture_count, SyncronizedWaitCondition cond)
 {
     bool all_complete = false;
-    uint64_t stop_time = dmTime::GetTime() + 1*1e6; // 1 second
-    while(!all_complete && dmTime::GetTime() < stop_time)
+    uint64_t stop_time = dmTime::GetMonotonicTime() + 1*1e6; // 1 second
+    while(!all_complete && dmTime::GetMonotonicTime() < stop_time)
     {
         dmJobThread::Update(job_thread);
         all_complete = true;

--- a/engine/liveupdate/src/test/test_liveupdate_job.cpp
+++ b/engine/liveupdate/src/test/test_liveupdate_job.cpp
@@ -93,10 +93,10 @@ TEST_F(AsyncTestSingleThread, TestJobs)
         PushJob(m_JobThread, &hash_state, &contexts[i]);
     }
 
-    uint64_t time_start = dmTime::GetTime();
+    uint64_t time_start = dmTime::GetMonotonicTime();
     while (true)
     {
-        if ((dmTime::GetTime() - time_start) >= 5 * 10000000)
+        if ((dmTime::GetMonotonicTime() - time_start) >= 5 * 10000000)
         {
             dmLogError("Test timed out!");
             break;

--- a/engine/modelc/src/test/test_model.cpp
+++ b/engine/modelc/src/test/test_model.cpp
@@ -293,7 +293,7 @@ TEST(ModelSkinnedTopNodes, MultipleModels)
 
 static int TestStandalone(const char* path)
 {
-    uint64_t tstart = dmTime::GetTime();
+    uint64_t tstart = dmTime::GetMonotonicTime();
 
     dmModelImporter::Options options;
     dmModelImporter::Scene* scene = LoadScene(path, options);
@@ -301,7 +301,7 @@ static int TestStandalone(const char* path)
     if (!scene)
         return 1;
 
-    uint64_t tend = dmTime::GetTime();
+    uint64_t tend = dmTime::GetMonotonicTime();
     printf("Model %s loaded in %.3f seconds.\n", path, float(tend-tstart)/1000000.0f);
 
     dmModelImporter::DebugScene(scene);

--- a/engine/platform/src/test/test_platform_app.cpp
+++ b/engine/platform/src/test/test_platform_app.cpp
@@ -137,7 +137,7 @@ static void* EngineCreate(int argc, char** argv)
     EngineCtx* engine = &g_EngineCtx;
 
     engine->m_WasCreated++;
-    engine->m_TimeStart = dmTime::GetTime();
+    engine->m_TimeStart = dmTime::GetMonotonicTime();
 
     dmPlatform::WindowParams params = {};
     params.m_Width                  = 512;
@@ -194,7 +194,7 @@ TEST(App, Run)
     ASSERT_EQ(0, ret);
 
 
-    uint64_t t = dmTime::GetTime();
+    uint64_t t = dmTime::GetMonotonicTime();
     float elapsed = (t - g_EngineCtx.m_TimeStart) / 1000000.0f;
     (void)elapsed;
 

--- a/engine/profiler/src/profiler.cpp
+++ b/engine/profiler/src/profiler.cpp
@@ -597,7 +597,7 @@ static void SampleTreeCallback(void* _ctx, const char* thread_name, dmProfile::H
     DM_MUTEX_SCOPED_LOCK(g_ProfilerMutex);
 
     dmProfileRender::ProfilerFrame* frame = (dmProfileRender::ProfilerFrame*)_ctx;
-    frame->m_Time = dmTime::GetMonotomicTime();
+    frame->m_Time = dmTime::GetMonotonicTime();
 
     // Prune old profiler threads
     dmProfileRender::PruneProfilerThreads(frame, frame->m_Time - 150000);

--- a/engine/profiler/src/profiler.cpp
+++ b/engine/profiler/src/profiler.cpp
@@ -597,7 +597,7 @@ static void SampleTreeCallback(void* _ctx, const char* thread_name, dmProfile::H
     DM_MUTEX_SCOPED_LOCK(g_ProfilerMutex);
 
     dmProfileRender::ProfilerFrame* frame = (dmProfileRender::ProfilerFrame*)_ctx;
-    frame->m_Time = dmTime::GetTime();
+    frame->m_Time = dmTime::GetMonotomicTime();
 
     // Prune old profiler threads
     dmProfileRender::PruneProfilerThreads(frame, frame->m_Time - 150000);

--- a/engine/profiler/src/profiler_proc_utils.cpp
+++ b/engine/profiler/src/profiler_proc_utils.cpp
@@ -135,7 +135,7 @@ void dmProfilerExt::SampleProcCpuUsage(bool use_virtual_metric)
         return;
     }
 
-    uint64_t time = dmTime::GetMonotomicTime();
+    uint64_t time = dmTime::GetMonotonicTime();
     if (_sample_cpu_last_t == 0) {
         _sample_cpu_last_t = time;
         return;

--- a/engine/profiler/src/profiler_proc_utils.cpp
+++ b/engine/profiler/src/profiler_proc_utils.cpp
@@ -135,7 +135,7 @@ void dmProfilerExt::SampleProcCpuUsage(bool use_virtual_metric)
         return;
     }
 
-    uint64_t time = dmTime::GetTime();
+    uint64_t time = dmTime::GetMonotomicTime();
     if (_sample_cpu_last_t == 0) {
         _sample_cpu_last_t = time;
         return;

--- a/engine/profiler/src/profiler_win32.cpp
+++ b/engine/profiler/src/profiler_win32.cpp
@@ -42,7 +42,7 @@ static ULONGLONG SubtractTimes(const FILETIME& ftA, const FILETIME& ftB)
 }
 
 void dmProfilerExt::SampleCpuUsage() {
-    uint64_t time = dmTime::GetTime();
+    uint64_t time = dmTime::GetMonotonicTime();
     if (_sample_cpu_last_t == 0 || (time - _sample_cpu_last_t) * 0.000001 > SAMPLE_CPU_INTERVAL) {
         FILETIME ftSysIdle, ftSysKernel, ftSysUser;
         FILETIME ftProcCreation, ftProcExit, ftProcKernel, ftProcUser;

--- a/engine/resource/src/resource_preloader.cpp
+++ b/engine/resource/src/resource_preloader.cpp
@@ -927,7 +927,7 @@ namespace dmResource
     {
         DM_PROFILE("UpdatePreloader");
 
-        uint64_t start           = dmTime::GetTime();
+        uint64_t start           = dmTime::GetMonotomicTime();
         uint32_t empty_runs      = 0;
         bool close_to_time_limit = soft_time_limit < 1000;
 
@@ -1003,7 +1003,7 @@ namespace dmResource
             }
             else
             {
-                close_to_time_limit = (dmTime::GetTime() + 1000 - start) > soft_time_limit;
+                close_to_time_limit = (dmTime::GetMonotomicTime() + 1000 - start) > soft_time_limit;
                 if (close_to_time_limit)
                 {
                     // Sleep a very short time, on windows it this small number just means "give up time slice"
@@ -1016,7 +1016,7 @@ namespace dmResource
                 // more of our time waiting for files to complete loading.
                 dmTime::Sleep(1000);
             }
-        } while (dmTime::GetTime() - start <= soft_time_limit);
+        } while (dmTime::GetMonotomicTime() - start <= soft_time_limit);
 
         return RESULT_PENDING;
     }

--- a/engine/resource/src/resource_preloader.cpp
+++ b/engine/resource/src/resource_preloader.cpp
@@ -927,7 +927,7 @@ namespace dmResource
     {
         DM_PROFILE("UpdatePreloader");
 
-        uint64_t start           = dmTime::GetMonotomicTime();
+        uint64_t start           = dmTime::GetMonotonicTime();
         uint32_t empty_runs      = 0;
         bool close_to_time_limit = soft_time_limit < 1000;
 
@@ -1003,7 +1003,7 @@ namespace dmResource
             }
             else
             {
-                close_to_time_limit = (dmTime::GetMonotomicTime() + 1000 - start) > soft_time_limit;
+                close_to_time_limit = (dmTime::GetMonotonicTime() + 1000 - start) > soft_time_limit;
                 if (close_to_time_limit)
                 {
                     // Sleep a very short time, on windows it this small number just means "give up time slice"
@@ -1016,7 +1016,7 @@ namespace dmResource
                 // more of our time waiting for files to complete loading.
                 dmTime::Sleep(1000);
             }
-        } while (dmTime::GetMonotomicTime() - start <= soft_time_limit);
+        } while (dmTime::GetMonotonicTime() - start <= soft_time_limit);
 
         return RESULT_PENDING;
     }

--- a/engine/resource/src/test/test_resource.cpp
+++ b/engine/resource/src/test/test_resource.cpp
@@ -1165,13 +1165,13 @@ TEST(RecreateTest, RecreateTestHttp)
 
     dmThread::Thread send_thread = dmThread::New(&SendReloadThread, 0x8000, 0, "reload");
 
-    uint64_t t_start = dmTime::GetTime();
+    uint64_t t_start = dmTime::GetMonotonicTime();
     do
     {
         dmTime::Sleep(1000 * 10);
         dmResource::UpdateFactory(factory);
 
-        uint64_t t = dmTime::GetTime();
+        uint64_t t = dmTime::GetMonotonicTime();
         if ((t - t_start) >= 2 * 1000000)
         {
             ASSERT_TRUE(false && "Test timed out");

--- a/engine/script/src/http_service.cpp
+++ b/engine/script/src/http_service.cpp
@@ -372,16 +372,16 @@ namespace dmHttpService
         Worker* worker = (Worker*) arg;
 
         uint64_t flush_period = 5 * 1000000U;
-        uint64_t next_flush = dmTime::GetTime() + flush_period;
+        uint64_t next_flush = dmTime::GetMonotonicTime() + flush_period;
         while (worker->m_Run)
         {
             dmMessage::DispatchBlocking(worker->m_Socket, &Dispatch, worker);
             if (!worker->m_Run)
                 break;
 
-            if (worker->m_CacheFlusher && dmTime::GetTime() > next_flush) {
+            if (worker->m_CacheFlusher && dmTime::GetMonotonicTime() > next_flush) {
                 dmHttpCache::Flush(worker->m_Service->m_HttpCache);
-                next_flush = dmTime::GetTime() + flush_period;
+                next_flush = dmTime::GetMonotonicTime() + flush_period;
             }
         }
     }

--- a/engine/script/src/test/test_script_msg.cpp
+++ b/engine/script/src/test/test_script_msg.cpp
@@ -750,7 +750,7 @@ TEST_F(ScriptMsgTest, TestURLCreateBeforeSocket)
 
 TEST_F(ScriptMsgTest, TestPerf)
 {
-    uint64_t time = dmTime::GetTime();
+    uint64_t time = dmTime::GetMonotonicTime();
     uint32_t count = 10000;
     char program[256];
     dmSnPrintf(program, 256,
@@ -760,7 +760,7 @@ TEST_F(ScriptMsgTest, TestPerf)
         "end\n",
         count);
     ASSERT_TRUE(dmScriptTest::RunString(L, program));
-    time = dmTime::GetTime() - time;
+    time = dmTime::GetMonotonicTime() - time;
     printf("Time per post: %.4f\n", time / (double)count);
 }
 

--- a/engine/sound/src/test/test_sound.cpp
+++ b/engine/sound/src/test/test_sound.cpp
@@ -1345,14 +1345,14 @@ TEST_P(dmSoundVerifyWavTest, Mix)
 
     dmSound::NewSoundData(params.m_Sound, params.m_SoundSize, params.m_Type, &sd, 1234);
 
-    uint64_t tstart = dmTime::GetTime();
+    uint64_t tstart = dmTime::GetMonotonicTime();
 
     dmSound::HSoundInstance instance = 0;
     r = dmSound::NewSoundInstance(sd, &instance);
     ASSERT_EQ(dmSound::RESULT_OK, r);
     ASSERT_NE((dmSound::HSoundInstance) 0, instance);
 
-    uint64_t tend = dmTime::GetTime();
+    uint64_t tend = dmTime::GetMonotonicTime();
     ASSERT_GT(250u, tend-tstart);
 
     r = dmSound::Play(instance);

--- a/engine/sound/src/test/test_sound_perf.cpp
+++ b/engine/sound/src/test/test_sound_perf.cpp
@@ -66,9 +66,9 @@ public:
         char tmp[4096];
         dmSoundCodec::HDecodeStream stream;
 
-        const uint64_t time_beg = dmTime::GetTime();
+        const uint64_t time_beg = dmTime::GetMonotonicTime();
         ASSERT_EQ(decoder->m_OpenStream(buf, size, &stream), dmSoundCodec::RESULT_OK);
-        const uint64_t time_open = dmTime::GetTime();
+        const uint64_t time_open = dmTime::GetMonotonicTime();
 
         uint64_t max_chunk_time = 0;
         uint64_t iterations = 0;
@@ -80,7 +80,7 @@ public:
 
             uint32_t decoded;
 
-            const uint64_t chunk_begin = dmTime::GetTime();
+            const uint64_t chunk_begin = dmTime::GetMonotonicTime();
 
             if (skip)
                 decoder->m_SkipInStream(stream, sizeof(tmp), &decoded);
@@ -92,14 +92,14 @@ public:
             if (decoded != sizeof(tmp))
                 break;
 
-            const uint64_t chunk_time = dmTime::GetTime() - chunk_begin;
+            const uint64_t chunk_time = dmTime::GetMonotonicTime() - chunk_begin;
             if (chunk_time > max_chunk_time)
                 max_chunk_time = chunk_time;
         }
 
         const float t2s = 0.000001f;
         const float t2ms = 0.001f;
-        const uint64_t time_done = dmTime::GetTime();
+        const uint64_t time_done = dmTime::GetMonotonicTime();
 
         dmSoundCodec::Info streamInfo;
         decoder->m_GetStreamInfo(stream, &streamInfo);


### PR DESCRIPTION
Fixes an issue where `dt` occasionally becomes 0.5s, causing jitters in the game.
Also, a new function has been introduced in `dmsdk`: `dmTime::GetMonotonicTime()`. This is the recommended way to measure time intervals (i.e., the time elapsed between events).

Fix https://github.com/defold/defold/issues/3450
Fix https://github.com/defold/defold/issues/8948
Fix https://github.com/defold/defold/issues/9812