### PR TITLE
Fix rare case of double initialization in web build

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/resources/jsweb/dmloader.js
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/resources/jsweb/dmloader.js
@@ -796,6 +796,7 @@ var Module = {
     _archiveLoaded: false,
     _preLoadDone: false,
     _isEngineLoaded: false,
+    _isMainCalled: false,
 
     // Persistent storage
     persistentStorage: true,
@@ -1092,11 +1093,16 @@ var Module = {
     },
 
     _callMain: function(_, _) {
-        ProgressView.removeProgress();
-        if (Module.callMain === undefined) {
-            Module.noInitialRun = false;
+        if (!Module._isMainCalled) {
+            Module._isMainCalled = true;
+            ProgressView.removeProgress();
+            if (Module.callMain === undefined) {
+                Module.noInitialRun = false;
+            } else {
+                Module.callMain(Module.arguments);
+            }
         } else {
-            Module.callMain(Module.arguments);
+            console.warn("Main was called several times!");
         }
     },
     // Wrap IDBFS syncfs call with logic to avoid multiple syncs
@@ -1134,6 +1140,10 @@ Module['persistentStorage'] = (typeof window !== 'undefined') && !!(window.index
 Module['INITIAL_MEMORY'] = CUSTOM_PARAMETERS.custom_heap_size;
 
 Module['onRuntimeInitialized'] = function() {
+    window.addEventListener("error", (errorEvent) => {
+        var errorObject = Module.prepareErrorObject(errorEvent.message, errorEvent.filename, errorEvent.lineno, errorEvent.colno, errorEvent.error);
+        Module.ccall('JSWriteDump', 'null', ['string'], [JSON.stringify(errorObject.stack)]);
+    });
     Module.runApp("canvas");
 };
 
@@ -1151,13 +1161,9 @@ Module["locateFile"] = function(path, scriptDirectory)
 Module["isWASMSupported"] = false; 
 {{/DEFOLD_HAS_WASM_ENGINE}}
 
-window.onerror = function(err, url, line, column, errObj) {
-    if (typeof Module.ccall !== 'undefined') {
-        var errorObject = Module.prepareErrorObject(err, url, line, column, errObj);
-        Module.ccall('JSWriteDump', 'null', ['string'], [JSON.stringify(errorObject.stack)]);
-    }
+window.addEventListener("error", (errorEvent) => {
     Module.setStatus('Exception thrown, see JavaScript console');
     Module.setStatus = function(text) {
         if (text) Module.printErr('[post-exception status] ' + text);
     };
-};
+});

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/resources/jsweb/dmloader.js
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/resources/jsweb/dmloader.js
@@ -897,6 +897,10 @@ var Module = {
     * Module.runApp - Starts the application given a canvas element id
     **/
     runApp: function(appCanvasId, _) {
+        window.addEventListener("error", (errorEvent) => {
+            var errorObject = Module.prepareErrorObject(errorEvent.message, errorEvent.filename, errorEvent.lineno, errorEvent.colno, errorEvent.error);
+            Module.ccall('JSWriteDump', 'null', ['string'], [JSON.stringify(errorObject.stack)]);
+        });
         Module._isEngineLoaded = true;
         Module.setupCanvas(appCanvasId);
 
@@ -1140,10 +1144,6 @@ Module['persistentStorage'] = (typeof window !== 'undefined') && !!(window.index
 Module['INITIAL_MEMORY'] = CUSTOM_PARAMETERS.custom_heap_size;
 
 Module['onRuntimeInitialized'] = function() {
-    window.addEventListener("error", (errorEvent) => {
-        var errorObject = Module.prepareErrorObject(errorEvent.message, errorEvent.filename, errorEvent.lineno, errorEvent.colno, errorEvent.error);
-        Module.ccall('JSWriteDump', 'null', ['string'], [JSON.stringify(errorObject.stack)]);
-    });
     Module.runApp("canvas");
 };
 


### PR DESCRIPTION
Fix rare case of double initialization in web build.

Fixes #9481
Related https://github.com/defold/extension-poki-sdk/pull/17

### Technical changes
Initial problem was the following:
When game loaded from Poki in Telegram iOS WebView Telegram code has error `ReferenceError: Cant' find variable: disableWebkitEnterFullscreen`. Error happened several times during startup. In `dmloader.js` we have global error handler which consist of two parts:
1. Simple printing in console log like "error ....."
2. Call native function via `ccall`. Before call we have check if `ccall` is defined.
So error in Telegram code triggers our handler which tries execute `ccall` before wasm is fully loaded and ready to use.
In js code which generated by Emscripten lot of function calls with caching like these 
```
var _emscripten_stack_get_current2 = function _emscripten_stack_get_current() {
    return (_emscripten_stack_get_current2 = wasmExports["xi"])()
};
```
So when first time `_emscripten_stack_get_current2` was called and wasm wasn't loaded - it cached `undefined` value for function.

When wasm is loaded `onRuntimeInitialized` hook is called. In case of Poki extenstion it triggers `PokiSDK.init()`. `init` returns Promise object and in extension Poki we want handle promise's result and promise's exception.
```
Module['onRuntimeInitialized'] = function() {
	PokiSDK.init().then(()=>{
		Module.runApp("canvas");
	}).catch(()=>{
		Module.runApp("canvas");
	});
};
```
Final part. If during `runApp` any exception happened - `catch` block executes which led to double call of `runApp`. In our case that exception is undefined function `_emscripten_stack_get_current2`.

What is changed:
* Divide error handler into two parts. Part that contains native call moved to `onRuntimeInitialized` to be sure that WASM was loaded. It prevents of caching of `undefined` as function.
* Introduce flag to prevent double initialization in case of several `runApp` external calls. In common case we can't control how many times `runApp` can be called outside of our code. So new flag was introduced and print warning if double initialization is happened.

## PR checklist

* [x] Code
	* [x] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [x] Add comments where needed
* [x] Documentation
	* [x] Make sure that API documentation is updated in code comments
	* [x] Make sure that manuals are updated (in github.com/defold/doc)
* [x] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [x] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [x] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   4. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
