### PR TITLE
Camera components should have precedence in the default render script

### DIFF
--- a/engine/engine/content/builtins/render/default.render_script
+++ b/engine/engine/content/builtins/render/default.render_script
@@ -3,10 +3,10 @@
 -- Copyright 2009-2014 Ragnar Svensson, Christian Murray
 -- Licensed under the Defold License version 1.0 (the "License"); you may not use
 -- this file except in compliance with the License.
--- 
+--
 -- You may obtain a copy of the License, together with FAQs at
 -- https://www.defold.com/license
--- 
+--
 -- Unless required by applicable law or agreed to in writing, software distributed
 -- under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 -- CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -67,8 +67,10 @@ local function update_clear_color(state, color)
 end
 
 local function update_camera(camera, state)
-    camera.proj = camera.projection_fn(camera, state)
-    camera.frustum.frustum = camera.proj * camera.view
+    if camera.projection_fn then
+        camera.proj = camera.projection_fn(camera, state)
+        camera.options.frustum = camera.proj * camera.view
+    end
 end
 
 local function update_state(state)
@@ -111,7 +113,7 @@ end
 
 local function create_camera(state, name, is_main_camera)
     local camera = {}
-    camera.frustum = {}
+    camera.options = {}
     state.cameras[name] = camera
     if is_main_camera then
         state.main_camera = camera
@@ -135,6 +137,38 @@ local function create_state()
     return state
 end
 
+local function set_camera_world(state)
+    local camera_components = camera.get_cameras()
+
+    -- This will set the last enabled camera from the stack of camera components
+    if #camera_components > 0 then
+        for i = #camera_components, 1, -1 do
+            if camera.get_enabled(camera_components[i]) then
+                local camera_component = state.cameras.camera_component
+                camera_component.camera = camera_components[i]
+                render.set_camera(camera_component.camera, { use_frustum = true })
+                -- The frustum will be overridden by the render.set_camera call,
+                -- so we don't need to return anything here other than an empty table.
+                return camera_component.options
+            end
+        end
+    end
+
+    -- If no active camera was found, we use the default main "camera world" camera
+    local camera_world = state.cameras.camera_world
+    render.set_view(camera_world.view)
+    render.set_projection(camera_world.proj)
+    return camera_world.options
+end
+
+local function reset_camera_world(state)
+    -- unbind the camera if a camera component is used
+    if state.cameras.camera_component.camera then
+        state.cameras.camera_component.camera = nil
+        render.set_camera()
+    end
+end
+
 function init(self)
     self.predicates = create_predicates("tile", "gui", "particle", "model", "debug_text")
 
@@ -146,10 +180,14 @@ function init(self)
 
     local state = create_state()
     self.state = state
+
     local camera_world = create_camera(state, "camera_world", true)
     init_camera(camera_world, get_stretch_projection)
     local camera_gui = create_camera(state, "camera_gui")
     init_camera(camera_gui, get_gui_projection)
+    -- Create a special camera that wraps camera components (if they exist)
+    -- It will take precedence over any other camera, and not change from messages
+    local camera_component = create_camera(state, "camera_component")
     update_state(state)
 end
 
@@ -171,10 +209,8 @@ function update(self)
 
     -- setup camera view and projection
     --
-    local camera_world = state.cameras.camera_world
+    local draw_options_world = set_camera_world(state)
     render.set_viewport(0, 0, state.window_width, state.window_height)
-    render.set_view(camera_world.view)
-    render.set_projection(camera_world.proj)
 
     -- set states used for all the world predicates
     render.set_blend_func(graphics.BLEND_FACTOR_SRC_ALPHA, graphics.BLEND_FACTOR_ONE_MINUS_SRC_ALPHA)
@@ -183,18 +219,20 @@ function update(self)
     -- render `model` predicate for default 3D material
     --
     render.enable_state(graphics.STATE_CULL_FACE)
-    render.draw(predicates.model, camera_world.frustum)
+    render.draw(predicates.model, draw_options_world)
     render.set_depth_mask(false)
     render.disable_state(graphics.STATE_CULL_FACE)
 
     -- render the other components: sprites, tilemaps, particles etc
     --
     render.enable_state(graphics.STATE_BLEND)
-    render.draw(predicates.tile, camera_world.frustum)
-    render.draw(predicates.particle, camera_world.frustum)
+    render.draw(predicates.tile, draw_options_world)
+    render.draw(predicates.particle, draw_options_world)
     render.disable_state(graphics.STATE_DEPTH_TEST)
 
     render.draw_debug3d()
+
+    reset_camera_world(state)
 
     -- render GUI
     --
@@ -212,6 +250,7 @@ end
 function on_message(self, message_id, message)
     local state = self.state
     local camera = state.main_camera
+
     if message_id == MSG_CLEAR_COLOR then
         update_clear_color(state, message.color)
     elseif message_id == MSG_WINDOW_RESIZED then

--- a/engine/gamesys/src/gamesys/components/comp_camera.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_camera.cpp
@@ -175,6 +175,7 @@ namespace dmGameSystem
         *params.m_UserData = (uintptr_t) new_camera;
 
         CameraStackPush(w, new_camera);
+        dmRender::SetRenderCameraEnabled(render_context, camera.m_RenderCamera, true);
 
         return dmGameObject::CREATE_RESULT_OK;
     }
@@ -289,11 +290,13 @@ namespace dmGameSystem
             (dmDDF::Descriptor*)params.m_Message->m_Descriptor == dmGamesysDDF::AcquireCameraFocus::m_DDFDescriptor)
         {
             CameraStackPush(camera->m_World, camera);
+            dmRender::SetRenderCameraEnabled((dmRender::RenderContext*)params.m_Context, camera->m_RenderCamera, true);
         }
         else if (params.m_Message->m_Id == dmGameObjectDDF::Disable::m_DDFDescriptor->m_NameHash ||
             (dmDDF::Descriptor*)params.m_Message->m_Descriptor == dmGamesysDDF::ReleaseCameraFocus::m_DDFDescriptor)
         {
             CameraStackRemove(camera->m_World, camera);
+            dmRender::SetRenderCameraEnabled((dmRender::RenderContext*)params.m_Context, camera->m_RenderCamera, false);
         }
 
         return dmGameObject::UPDATE_RESULT_OK;

--- a/engine/render/src/render/camera.cpp
+++ b/engine/render/src/render/camera.cpp
@@ -137,6 +137,15 @@ namespace dmRender
         }
     }
 
+    void SetRenderCameraEnabled(HRenderContext render_context, HRenderCamera camera, bool value)
+    {
+        RenderCamera* c = render_context->m_RenderCameras.Get(camera);
+        if (c)
+        {
+            c->m_Enabled = value;
+        }
+    }
+
     // render_private.h
     RenderCamera* GetRenderCameraByUrl(HRenderContext render_context, const dmMessage::URL& camera_url)
     {

--- a/engine/render/src/render/render.h
+++ b/engine/render/src/render/render.h
@@ -382,6 +382,7 @@ namespace dmRender
     void                            GetRenderCameraProjection(HRenderContext render_context, HRenderCamera camera, dmVMath::Matrix4* mtx);
     void                            SetRenderCameraData(HRenderContext render_context, HRenderCamera camera, const RenderCameraData* data);
     void                            GetRenderCameraData(HRenderContext render_context, HRenderCamera camera, RenderCameraData* data);
+    void                            SetRenderCameraEnabled(HRenderContext render_context, HRenderCamera camera, bool value);
     void                            UpdateRenderCamera(HRenderContext render_context, HRenderCamera camera, const dmVMath::Point3* position, const dmVMath::Quat* rotation);
 
     static inline dmGraphics::TextureWrap WrapFromDDF(dmRenderDDF::MaterialDesc::WrapMode wrap_mode)

--- a/engine/render/src/render/render_private.h
+++ b/engine/render/src/render/render_private.h
@@ -263,7 +263,8 @@ namespace dmRender
 
         RenderCameraData m_Data;
         uint8_t          m_UseFrustum : 1;
-        uint8_t          m_Dirty : 1;
+        uint8_t          m_Dirty      : 1;
+        uint8_t          m_Enabled    : 1;
     };
 
     struct RenderContext

--- a/engine/render/src/render/render_script_camera.cpp
+++ b/engine/render/src/render/render_script_camera.cpp
@@ -109,6 +109,20 @@ namespace dmRender
         return 1;
     }
 
+    /*# get enabled
+    *
+    * @name camera.get_enabled
+    * @param camera [type:url|handle|nil] camera id
+    * @return flag [type:bool] true if the camera is enabled
+    */
+    static int RenderScriptCamera_GetEnabled(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        RenderCamera* camera = CheckRenderCamera(L, 1, g_RenderScriptCameraModule.m_RenderContext);
+        lua_pushboolean(L, camera->m_Enabled);
+        return 1;
+    }
+
     /*# get projection matrix
     *
     * @name camera.get_projection
@@ -246,6 +260,7 @@ namespace dmRender
         // READ-ONLY
         {"get_projection",          RenderScriptCamera_GetProjection},
         {"get_view",                RenderScriptCamera_GetView},
+        {"get_enabled",             RenderScriptCamera_GetEnabled},
 
         // READ-WRITE
         {"get_aspect_ratio",        RenderScriptCamera_GetAspectRatio},


### PR DESCRIPTION
The default render script has been updated to take camera components into account - if there are camera components in the scene, they will be used in favor of the various "projection modes" specified in the render script. For a camera component to be used in rendering, a need function has also been added to the camera API:

`camera.get_enabled(url)`

This function can be used to check wether or not a camera is enabled or not. If there exists multiple camera components in the scene, the last enabled camera will be used for rendering. This is usually the camera component created last, but enabling and disabling camera components can change this order in the engine as well.

Fixes #9842 