### PR TITLE
Added the ability to specify custom templates for the project.

### DIFF
--- a/editor/src/clj/editor/game_object_common.clj
+++ b/editor/src/clj/editor/game_object_common.clj
@@ -38,13 +38,11 @@
 
 (def component-transform-property-keys (set (keys scene/identity-transform-properties)))
 
-(defn- template-pb-map-raw [workspace resource-type]
+(defn template-pb-map [workspace resource-type]
   (let [template (workspace/template workspace resource-type)
         read-fn (:read-fn resource-type)]
     (with-open [reader (StringReader. template)]
       (read-fn reader))))
-
-(def template-pb-map (fn/memoize template-pb-map-raw))
 
 (defn strip-default-scale-from-component-desc [component-desc]
   ;; GameObject$ComponentDesc or GameObject$EmbeddedComponentDesc in map format.

--- a/editor/src/clj/editor/workspace.clj
+++ b/editor/src/clj/editor/workspace.clj
@@ -467,15 +467,16 @@ ordinary paths."
 (def ^:private java-resource-path "templates/template.")
 
 (defn- get-template-resource [workspace resource-type]
-  (let [resource-path (:template resource-type)
-        ext (:ext resource-type)]
-    (or
-      ;; default user resource
-      (when ext (find-resource workspace (str default-user-resource-path ext)))
-      ;; editor resource provided from extensions
-      (when resource-path (find-resource workspace resource-path))
-      ;; java resource
-      (when ext (io/resource (str java-resource-path ext))))))
+  (when resource-type
+    (let [resource-path (:template resource-type)
+          ext (:ext resource-type)]
+      (or
+        ;; default user resource
+        (find-resource workspace (str default-user-resource-path ext))
+        ;; editor resource provided from extensions
+        (when resource-path (find-resource workspace resource-path))
+        ;; java resource
+        (io/resource (str java-resource-path ext))))))
 
 (defn has-template? [workspace resource-type]
   (let [resource (get-template-resource workspace resource-type)]

--- a/editor/src/clj/editor/workspace.clj
+++ b/editor/src/clj/editor/workspace.clj
@@ -463,18 +463,18 @@ ordinary paths."
                                                                         path))))]
       (resolve-workspace-resource workspace path))))
 
-(defn- template-path [resource-type]
-  (or (:template resource-type)
-      (some->> resource-type :ext (str "templates/template."))))
-
-(def ^:private user-resource-path "/templates/template.")
+(def ^:private default-user-resource-path "/templates/default.")
+(def ^:private java-resource-path "templates/template.")
 
 (defn- get-template-resource [workspace resource-type]
-  (let [path (template-path resource-type)
-        java-resource (when path (io/resource path))
-        user-resource (find-resource workspace (some->> resource-type :ext (str user-resource-path)))
-        editor-resource (when path (find-resource workspace path))]
-    (or user-resource java-resource editor-resource)))
+  (let [resource-path (:template resource-type)]
+    (or
+      ;; default user resource
+      (find-resource workspace (some->> resource-type :ext (str default-user-resource-path)))
+      ;; editor resource provided from extensions
+      (when resource-path (find-resource workspace resource-path))
+      ;; java resource
+      (io/resource (some->> resource-type :ext (str java-resource-path))))))
 
 (defn has-template? [workspace resource-type]
   (let [resource (get-template-resource workspace resource-type)]

--- a/editor/src/clj/editor/workspace.clj
+++ b/editor/src/clj/editor/workspace.clj
@@ -467,14 +467,15 @@ ordinary paths."
 (def ^:private java-resource-path "templates/template.")
 
 (defn- get-template-resource [workspace resource-type]
-  (let [resource-path (:template resource-type)]
+  (let [resource-path (:template resource-type)
+        ext (:ext resource-type)]
     (or
       ;; default user resource
-      (find-resource workspace (some->> resource-type :ext (str default-user-resource-path)))
+      (when ext (find-resource workspace (str default-user-resource-path ext)))
       ;; editor resource provided from extensions
       (when resource-path (find-resource workspace resource-path))
       ;; java resource
-      (io/resource (some->> resource-type :ext (str java-resource-path))))))
+      (when ext (io/resource (str java-resource-path ext))))))
 
 (defn has-template? [workspace resource-type]
   (let [resource (get-template-resource workspace resource-type)]


### PR DESCRIPTION
It is now possible to specify custom templates for each project. To do so, create a new folder named templates in the project’s root directory, and add new files named `default.*` with the desired extensions, such as `/templates/default.gui` or `/templates/default.script`. Additionally, if the `{{NAME}}` token is used in these files, it will be replaced with the filename specified in the file creation window.

Fix https://github.com/defold/defold/issues/6694