### PR TITLE
Fixed the GUI properties iterator

### DIFF
--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -2966,7 +2966,6 @@ namespace dmGameSystem
 
 
         const dmGui::Property properties_all[] = {
-            // keep order as in `gui.h`->`num Property`
             dmGui::PROPERTY_POSITION,
             dmGui::PROPERTY_ROTATION,
             dmGui::PROPERTY_SCALE,
@@ -2978,7 +2977,6 @@ namespace dmGameSystem
             dmGui::PROPERTY_PIE_PARAMS,
             dmGui::PROPERTY_TEXT_PARAMS,
             dmGui::PROPERTY_EULER,
-            //dmGui::PROPERTY_PREV_EULER
         };
         properties = properties_all;
         num_properties = DM_ARRAY_SIZE(properties_all);

--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -2950,6 +2950,7 @@ namespace dmGameSystem
         const char* property_names[] = {
             "position",
             "rotation",
+            "euler",
             "scale",
             "color",
             "size",
@@ -2958,7 +2959,6 @@ namespace dmGameSystem
             "slice9",
             "pie_params",
             "text_params",
-            "euler",
         };
 
         const dmGui::Property* properties = 0;
@@ -2968,6 +2968,7 @@ namespace dmGameSystem
         const dmGui::Property properties_all[] = {
             dmGui::PROPERTY_POSITION,
             dmGui::PROPERTY_ROTATION,
+            dmGui::PROPERTY_EULER,
             dmGui::PROPERTY_SCALE,
             dmGui::PROPERTY_COLOR,
             dmGui::PROPERTY_SIZE,
@@ -2976,7 +2977,6 @@ namespace dmGameSystem
             dmGui::PROPERTY_SLICE9,
             dmGui::PROPERTY_PIE_PARAMS,
             dmGui::PROPERTY_TEXT_PARAMS,
-            dmGui::PROPERTY_EULER,
         };
         properties = properties_all;
         num_properties = DM_ARRAY_SIZE(properties_all);

--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -2966,6 +2966,7 @@ namespace dmGameSystem
 
 
         const dmGui::Property properties_all[] = {
+            // keep order as in `gui.h`->`num Property`
             dmGui::PROPERTY_POSITION,
             dmGui::PROPERTY_ROTATION,
             dmGui::PROPERTY_SCALE,
@@ -2977,6 +2978,7 @@ namespace dmGameSystem
             dmGui::PROPERTY_PIE_PARAMS,
             dmGui::PROPERTY_TEXT_PARAMS,
             dmGui::PROPERTY_EULER,
+            //dmGui::PROPERTY_PREV_EULER
         };
         properties = properties_all;
         num_properties = DM_ARRAY_SIZE(properties_all);

--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -2986,7 +2986,7 @@ namespace dmGameSystem
             dmGui::Property property = properties[index];
             Vector4 value = dmGui::GetNodeProperty(component->m_Scene, node, property);
 
-            pit->m_Property.m_NameHash = dmHashString64(property_names[property]);
+            pit->m_Property.m_NameHash = dmHashString64(property_names[index]);
             pit->m_Property.m_Value.m_V4[0] = value.getX();
             pit->m_Property.m_Value.m_V4[1] = value.getY();
             pit->m_Property.m_Value.m_V4[2] = value.getZ();

--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -2950,7 +2950,6 @@ namespace dmGameSystem
         const char* property_names[] = {
             "position",
             "rotation",
-            "euler",
             "scale",
             "color",
             "size",
@@ -2959,6 +2958,7 @@ namespace dmGameSystem
             "slice9",
             "pie_params",
             "text_params",
+            "euler",
         };
 
         const dmGui::Property* properties = 0;
@@ -2968,7 +2968,6 @@ namespace dmGameSystem
         const dmGui::Property properties_all[] = {
             dmGui::PROPERTY_POSITION,
             dmGui::PROPERTY_ROTATION,
-            dmGui::PROPERTY_EULER,
             dmGui::PROPERTY_SCALE,
             dmGui::PROPERTY_COLOR,
             dmGui::PROPERTY_SIZE,
@@ -2977,6 +2976,7 @@ namespace dmGameSystem
             dmGui::PROPERTY_SLICE9,
             dmGui::PROPERTY_PIE_PARAMS,
             dmGui::PROPERTY_TEXT_PARAMS,
+            dmGui::PROPERTY_EULER,
         };
         properties = properties_all;
         num_properties = DM_ARRAY_SIZE(properties_all);


### PR DESCRIPTION
Fixed a bug with the GUI properties iterator (used in the Poco extension) where properties were mixed up.

Fix https://github.com/defold/defold/issues/9852