### PR TITLE
Vendor fixes for miniz and zip.c

### DIFF
--- a/engine/dlib/src/wscript
+++ b/engine/dlib/src/wscript
@@ -41,6 +41,8 @@ def build(bld):
         platform_source_dirs.append('dlib/ps4/**/*.cpp')
 
     extra_defines = ['ZLIB_CONST']
+    extra_defines +=['MINIZ_NO_TIME', 'MINIZ_NO_DEFLATE_APIS']
+    extra_defines +=['MINIZ_USE_ANSI', 'ZIP_NO_DEFLATE', 'ZIP_NO_DISC_IO']   # defold defines
 
     if 'win32' not in bld.env.PLATFORM:
         extra_defines.append('Z_HAVE_UNISTD_H')

--- a/engine/dlib/src/zip/miniz.h
+++ b/engine/dlib/src/zip/miniz.h
@@ -5032,6 +5032,12 @@ static int mz_mkdir(const char *pDirname) {
 #define MZ_FCLOSE fclose
 #define MZ_FREAD fread
 #define MZ_FWRITE fwrite
+#if defined(MINIZ_USE_ANSI) // defold
+#define MZ_FTELL64 ftell
+#define MZ_FSEEK64 fseek
+#define MZ_FILE_STAT_STRUCT _stat
+#define MZ_FILE_STAT mz_stat
+#else
 #define MZ_FTELL64 _ftelli64
 #define MZ_FSEEK64 _fseeki64
 #if defined(__MINGW32__)
@@ -5041,6 +5047,7 @@ static int mz_mkdir(const char *pDirname) {
 #define MZ_FILE_STAT_STRUCT _stat64
 #define MZ_FILE_STAT mz_stat64
 #endif
+#endif // MINIZ_USE_ANSI
 #define MZ_FFLUSH fflush
 #define MZ_FREOPEN mz_freopen
 #define MZ_DELETE_FILE remove
@@ -5054,8 +5061,13 @@ static int mz_mkdir(const char *pDirname) {
 #define MZ_FCLOSE fclose
 #define MZ_FREAD fread
 #define MZ_FWRITE fwrite
+#if defined(MINIZ_USE_ANSI) // defold
+#define MZ_FTELL64 ftell
+#define MZ_FSEEK64 fseek
+#else
 #define MZ_FTELL64 _ftelli64
 #define MZ_FSEEK64 _fseeki64
+#endif
 #define MZ_FILE_STAT_STRUCT stat
 #define MZ_FILE_STAT stat
 #define MZ_FFLUSH fflush
@@ -5092,10 +5104,17 @@ static int mz_mkdir(const char *pDirname) {
 #define MZ_FCLOSE fclose
 #define MZ_FREAD fread
 #define MZ_FWRITE fwrite
+#if defined(MINIZ_USE_ANSI) // defold
+#define MZ_FTELL64 ftell
+#define MZ_FSEEK64 fseek
+#define MZ_FILE_STAT_STRUCT stat
+#define MZ_FILE_STAT stat
+#else
 #define MZ_FTELL64 ftello64
 #define MZ_FSEEK64 fseeko64
 #define MZ_FILE_STAT_STRUCT stat64
 #define MZ_FILE_STAT stat64
+#endif
 #define MZ_FFLUSH fflush
 #define MZ_FREOPEN(p, m, s) freopen64(p, m, s)
 #define MZ_DELETE_FILE remove
@@ -5110,8 +5129,13 @@ static int mz_mkdir(const char *pDirname) {
 #define MZ_FCLOSE fclose
 #define MZ_FREAD fread
 #define MZ_FWRITE fwrite
+#if defined(MINIZ_USE_ANSI) // defold
+#define MZ_FTELL64 ftell
+#define MZ_FSEEK64 fseek
+#else
 #define MZ_FTELL64 ftello
 #define MZ_FSEEK64 fseeko
+#endif
 #define MZ_FILE_STAT_STRUCT stat
 #define MZ_FILE_STAT stat
 #define MZ_FFLUSH fflush
@@ -5129,7 +5153,7 @@ static int mz_mkdir(const char *pDirname) {
 #define MZ_FCLOSE fclose
 #define MZ_FREAD fread
 #define MZ_FWRITE fwrite
-#ifdef __STRICT_ANSI__
+#if defined(__STRICT_ANSI__) || defined(MINIZ_USE_ANSI)
 #define MZ_FTELL64 ftell
 #define MZ_FSEEK64 fseek
 #else

--- a/engine/dlib/src/zip/zip.h
+++ b/engine/dlib/src/zip/zip.h
@@ -67,6 +67,20 @@ typedef long ssize_t; /* byte count or error */
 #define ZIP_DEFAULT_ITER_BUF_SIZE 32*1024
 
 /**
+ * If defined, supports deflate functionality
+ */
+#if !defined(ZIP_NO_DEFLATE)
+#define ZIP_USE_DEFLATE
+#endif
+
+/**
+ * If defined, supports using file operations
+ */
+#if !defined(ZIP_NO_DISC_IO)
+#define ZIP_USE_DISC_IO
+#endif
+
+/**
  * Error codes
  */
 #define ZIP_ENOINIT -1      // not initialized
@@ -474,10 +488,12 @@ extern ZIP_EXPORT ssize_t zip_entries_deletebyindex(struct zip_t *zip,
  *
  * @return the return code - 0 on success, negative number (< 0) on error.
  */
+#if defined(ZIP_USE_DISC_IO)
 extern ZIP_EXPORT int
 zip_stream_extract(const char *stream, size_t size, const char *dir,
                    int (*on_extract)(const char *filename, void *arg),
                    void *arg);
+#endif
 
 /**
  * Opens zip archive stream into memory.
@@ -588,8 +604,10 @@ extern ZIP_EXPORT void zip_cstream_close(struct zip_t *zip);
  *
  * @return the return code - 0 on success, negative number (< 0) on error.
  */
+#if defined(ZIP_USE_DEFLATE)
 extern ZIP_EXPORT int zip_create(const char *zipname, const char *filenames[],
                                  size_t len);
+#endif
 
 /**
  * Extracts a zip archive file into directory.


### PR DESCRIPTION
## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
