### PR TITLE
Consider successors from implicit connections inherited by override nodes

### DIFF
--- a/editor/.idea/codeStyles/Project.xml
+++ b/editor/.idea/codeStyles/Project.xml
@@ -16,6 +16,7 @@
           <entry key="clojure.test/are" value="-1" />
           <entry key="dev/run-with-progress" value="-1" />
           <entry key="dynamo.graph/make-nodes" value="-1" />
+          <entry key="dynamo.graph/override" value="-1" />
           <entry key="dynamo.graph/precluding-errors" value="-1" />
           <entry key="dynamo.graph/set-property" value="-1" />
           <entry key="dynamo.graph/transact" value="-1" />

--- a/editor/src/clj/internal/transaction.clj
+++ b/editor/src/clj/internal/transaction.clj
@@ -21,6 +21,7 @@
             [internal.system :as is]
             [internal.util :as util]
             [schema.core :as s]
+            [util.array :as array]
             [util.coll :refer [pair]]
             [util.debug-util :as du]
             [util.eduction :as e])
@@ -744,9 +745,10 @@
             ;; nodes of the source node, since these will inherit an implicit
             ;; connection between them and the corresponding override nodes of
             ;; the target node.
-            (flag-successors-changed (cons (pair source-id source-label)
-                                           (e/map #(pair % source-label)
-                                                  (ig/get-overrides basis source-id))))
+            (flag-successors-changed (e/concat
+                                       (array/of (pair source-id source-label))
+                                       (e/map #(pair % source-label)
+                                              (ig/get-overrides basis source-id))))
             (flag-override-nodes-affected target target-label)))
       ctx)
     ctx))
@@ -785,9 +787,10 @@
       ;; When updating the successors, we must also consider any override nodes
       ;; of the source node, since these will inherit an implicit connection
       ;; between them and the corresponding override nodes of the target node.
-      (flag-successors-changed (cons (pair source-id source-label)
-                                     (e/map #(pair % source-label)
-                                            (ig/get-overrides (:basis ctx) source-id))))
+      (flag-successors-changed (e/concat
+                                 (array/of (pair source-id source-label))
+                                 (e/map #(pair % source-label)
+                                        (ig/get-overrides (:basis ctx) source-id))))
       (ctx-remove-overrides source-id source-label target-id target-label)))
 
 (defmethod perform :disconnect

--- a/editor/src/clj/internal/transaction.clj
+++ b/editor/src/clj/internal/transaction.clj
@@ -22,7 +22,8 @@
             [internal.util :as util]
             [schema.core :as s]
             [util.coll :refer [pair]]
-            [util.debug-util :as du])
+            [util.debug-util :as du]
+            [util.eduction :as e])
   (:import [internal.graph.types Arc]))
 
 (set! *warn-on-reflection* true)
@@ -341,8 +342,14 @@
         all-originals (ig/override-originals basis original-node-id)]
     (-> ctx
         (assoc :basis (gt/override-node basis original-node-id override-node-id))
+
+        ;; Any property, input or output on any original nodes must now take the
+        ;; new override node into account.
         (flag-all-successors-changed all-originals)
-        (flag-successors-changed (mapcat #(gt/sources basis %) all-originals)))))
+
+        ;; Similarly, so must the source outputs of any arcs that target any of
+        ;; the original nodes.
+        (flag-successors-changed (e/mapcat #(gt/sources basis %) all-originals)))))
 
 (defmethod perform :override-node
   [ctx {:keys [original-node-id override-node-id]}]
@@ -723,9 +730,9 @@
                     (in/type-name input-nodetype) target-label))
     (assert-schema-type-compatible source-id source-label output-nodetype output-valtype target-id target-label input-nodetype input-valtype)))
 
-(defn- ctx-connect [ctx source-id source-label target-id target-label]
-  (if-let [source (gt/node-by-id-at (:basis ctx) source-id)] ; nil if source node was deleted in this transaction
-    (if-let [target (gt/node-by-id-at (:basis ctx) target-id)] ; nil if target node was deleted in this transaction
+(defn- ctx-connect [{:keys [basis] :as ctx} source-id source-label target-id target-label]
+  (if-let [source (gt/node-by-id-at basis source-id)] ; nil if source node was deleted in this transaction
+    (if-let [target (gt/node-by-id-at basis target-id)] ; nil if target node was deleted in this transaction
       (do
         (assert-type-compatible source-id source source-label target-id target target-label)
         (-> ctx
@@ -733,7 +740,13 @@
             (ctx-disconnect-single target target-id target-label)
             (mark-input-activated target-id target-label)
             (update :basis gt/connect source-id source-label target-id target-label)
-            (flag-successors-changed [[source-id source-label]])
+            ;; When updating the successors, we must also consider any override
+            ;; nodes of the source node, since these will inherit an implicit
+            ;; connection between them and the corresponding override nodes of
+            ;; the target node.
+            (flag-successors-changed (cons (pair source-id source-label)
+                                           (e/map #(pair % source-label)
+                                                  (ig/get-overrides basis source-id))))
             (flag-override-nodes-affected target target-label)))
       ctx)
     ctx))
@@ -769,7 +782,12 @@
   (-> ctx
       (mark-input-activated target-id target-label)
       (update :basis gt/disconnect source-id source-label target-id target-label)
-      (flag-successors-changed [[source-id source-label]])
+      ;; When updating the successors, we must also consider any override nodes
+      ;; of the source node, since these will inherit an implicit connection
+      ;; between them and the corresponding override nodes of the target node.
+      (flag-successors-changed (cons (pair source-id source-label)
+                                     (e/map #(pair % source-label)
+                                            (ig/get-overrides (:basis ctx) source-id))))
       (ctx-remove-overrides source-id source-label target-id target-label)))
 
 (defmethod perform :disconnect

--- a/editor/src/clj/util/array.clj
+++ b/editor/src/clj/util/array.clj
@@ -1,0 +1,94 @@
+;; Copyright 2020-2024 The Defold Foundation
+;; Copyright 2014-2020 King
+;; Copyright 2009-2014 Ragnar Svensson, Christian Murray
+;; Licensed under the Defold License version 1.0 (the "License"); you may not use
+;; this file except in compliance with the License.
+;;
+;; You may obtain a copy of the License, together with FAQs at
+;; https://www.defold.com/license
+;;
+;; Unless required by applicable law or agreed to in writing, software distributed
+;; under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+;; CONDITIONS OF ANY KIND, either express or implied. See the License for the
+;; specific language governing permissions and limitations under the License.
+
+(ns util.array
+  (:import [java.lang.reflect Array]))
+
+(set! *warn-on-reflection* true)
+(set! *unchecked-math* :warn-on-boxed)
+
+(def ^"[Ljava.lang.Object;" empty-object-array (Array/newInstance Object 0))
+
+(defn of
+  (^"[Ljava.lang.Object;" [] empty-object-array)
+  (^"[Ljava.lang.Object;" [a]
+   (doto (Array/newInstance Object 1)
+     (Array/set 0 a)))
+  (^"[Ljava.lang.Object;" [a b]
+   (doto (Array/newInstance Object 2)
+     (Array/set 0 a)
+     (Array/set 1 b)))
+  (^"[Ljava.lang.Object;" [a b c]
+   (doto (Array/newInstance Object 3)
+     (Array/set 0 a)
+     (Array/set 1 b)
+     (Array/set 2 c)))
+  (^"[Ljava.lang.Object;" [a b c d]
+   (doto (Array/newInstance Object 4)
+     (Array/set 0 a)
+     (Array/set 1 b)
+     (Array/set 2 c)
+     (Array/set 3 d)))
+  (^"[Ljava.lang.Object;" [a b c d e]
+   (doto (Array/newInstance Object 5)
+     (Array/set 0 a)
+     (Array/set 1 b)
+     (Array/set 2 c)
+     (Array/set 3 d)
+     (Array/set 4 e)))
+  (^"[Ljava.lang.Object;" [a b c d e f]
+   (doto (Array/newInstance Object 6)
+     (Array/set 0 a)
+     (Array/set 1 b)
+     (Array/set 2 c)
+     (Array/set 3 d)
+     (Array/set 4 e)
+     (Array/set 5 f)))
+  (^"[Ljava.lang.Object;" [a b c d e f g]
+   (doto (Array/newInstance Object 7)
+     (Array/set 0 a)
+     (Array/set 1 b)
+     (Array/set 2 c)
+     (Array/set 3 d)
+     (Array/set 4 e)
+     (Array/set 5 f)
+     (Array/set 6 g)))
+  (^"[Ljava.lang.Object;" [a b c d e f g h]
+   (doto (Array/newInstance Object 8)
+     (Array/set 0 a)
+     (Array/set 1 b)
+     (Array/set 2 c)
+     (Array/set 3 d)
+     (Array/set 4 e)
+     (Array/set 5 f)
+     (Array/set 6 g)
+     (Array/set 7 h)))
+  (^"[Ljava.lang.Object;" [a b c d e f g h & more]
+   (let [more-count (count more)
+         length (+ 8 more-count)
+         array (doto (Array/newInstance Object (int length))
+                 (Array/set 0 a)
+                 (Array/set 1 b)
+                 (Array/set 2 c)
+                 (Array/set 3 d)
+                 (Array/set 4 e)
+                 (Array/set 5 f)
+                 (Array/set 6 g)
+                 (Array/set 7 h))]
+     (reduce (fn [^long index item]
+               (Array/set array index item)
+               (inc index))
+             (- length more-count)
+             more)
+     array)))

--- a/editor/src/clj/util/eduction.clj
+++ b/editor/src/clj/util/eduction.clj
@@ -13,115 +13,130 @@
 ;; specific language governing permissions and limitations under the License.
 
 (ns util.eduction
-  (:refer-clojure :exclude [cat concat dedupe distinct drop drop-while filter interpose keep keep-indexed map map-indexed mapcat partition-all partition-by random-sample remove replace take take-nth take-while]))
+  (:refer-clojure :exclude [cat concat dedupe distinct drop drop-while filter interpose keep keep-indexed map map-indexed mapcat partition-all partition-by random-sample remove replace take take-nth take-while])
+  (:require [util.array :as array]))
 
 (set! *warn-on-reflection* true)
+(set! *unchecked-math* :warn-on-boxed)
 
 (defonce empty-eduction (eduction))
 
 (definline cat [coll]
-  `(eduction
+  `(->Eduction
      clojure.core/cat
      ~coll))
 
 (defn concat
   ([] empty-eduction)
-  ([x] x)
-  ([x y] (eduction clojure.core/cat [x y]))
-  ([x y & zs]
-   (eduction clojure.core/cat (into [x y] zs))))
+  ([a] a)
+  ([a b]
+   (->Eduction
+     clojure.core/cat
+     (array/of a b)))
+  ([a b c]
+   (->Eduction
+     clojure.core/cat
+     (array/of a b c)))
+  ([a b c d]
+   (->Eduction
+     clojure.core/cat
+     (array/of a b c d)))
+  ([a b c d & more]
+   (->Eduction
+     clojure.core/cat
+     (apply array/of a b c d more))))
 
 (definline dedupe [coll]
-  `(eduction
+  `(->Eduction
      (clojure.core/dedupe)
      ~coll))
 
 (definline distinct [coll]
-  `(eduction
+  `(->Eduction
      (clojure.core/distinct)
      ~coll))
 
 (definline drop [n coll]
-  `(eduction
+  `(->Eduction
      (clojure.core/drop ~n)
      ~coll))
 
 (definline drop-while [pred coll]
-  `(eduction
+  `(->Eduction
      (clojure.core/drop-while ~pred)
      ~coll))
 
 (definline filter [pred coll]
-  `(eduction
+  `(->Eduction
      (clojure.core/filter ~pred)
      ~coll))
 
 (definline interpose [sep coll]
-  `(eduction
+  `(->Eduction
      (clojure.core/interpose ~sep)
      ~coll))
 
 (definline keep [f coll]
-  `(eduction
+  `(->Eduction
      (clojure.core/keep ~f)
      ~coll))
 
 (definline keep-indexed [f coll]
-  `(eduction
+  `(->Eduction
      (clojure.core/keep-indexed ~f)
      ~coll))
 
 (definline map [f coll]
-  `(eduction
+  `(->Eduction
      (clojure.core/map ~f)
      ~coll))
 
 (definline map-indexed [f coll]
-  `(eduction
+  `(->Eduction
      (clojure.core/map-indexed ~f)
      ~coll))
 
 (definline mapcat [f coll]
-  `(eduction
+  `(->Eduction
      (clojure.core/mapcat ~f)
      ~coll))
 
 (definline partition-all [n coll]
-  `(eduction
+  `(->Eduction
      (clojure.core/partition-all ~n)
      ~coll))
 
 (definline partition-by [f coll]
-  `(eduction
+  `(->Eduction
      (clojure.core/partition-by ~f)
      ~coll))
 
 (definline random-sample [prob coll]
-  `(eduction
+  `(->Eduction
      (clojure.core/random-sample ~prob)
      ~coll))
 
 (definline remove [pred coll]
-  `(eduction
+  `(->Eduction
      (clojure.core/remove ~pred)
      ~coll))
 
 (definline replace [smap coll]
-  `(eduction
+  `(->Eduction
      (clojure.core/replace ~smap)
      ~coll))
 
 (definline take [n coll]
-  `(eduction
+  `(->Eduction
      (clojure.core/take ~n)
      ~coll))
 
 (definline take-nth [n coll]
-  `(eduction
+  `(->Eduction
      (clojure.core/take-nth ~n)
      ~coll))
 
 (definline take-while [pred coll]
-  `(eduction
+  `(->Eduction
      (clojure.core/take-while ~pred)
      ~coll))

--- a/editor/test/internal/node_test.clj
+++ b/editor/test/internal/node_test.clj
@@ -13,24 +13,19 @@
 ;; specific language governing permissions and limitations under the License.
 
 (ns internal.node-test
-  (:require [clojure.string :as str]
+  (:require [clojure.set :as set]
+            [clojure.string :as string]
             [clojure.test :refer :all]
             [dynamo.graph :as g]
+            [internal.graph.types :as gt]
             [internal.node :as in]
-            [internal.system :as is]
-            [internal.util :as util]
-            [schema.core :as s]
-            [support.test-support :refer [tx-nodes with-clean-system]]
-            [internal.graph.types :as gt])
+            [support.test-support :refer [tx-nodes with-clean-system]])
   (:import clojure.lang.ExceptionInfo))
 
 (def ^:dynamic *calls*)
 
 (defn tally [node fn-symbol]
   (swap! *calls* update-in [(:_node-id node) fn-symbol] (fnil inc 0)))
-
-(defn get-tally [node fn-symbol]
-  (get-in @*calls* [(:_node-id node) fn-symbol] 0))
 
 (g/defnk string-value [] "uff-da")
 
@@ -175,7 +170,7 @@
                    (fn [node-id] (g/set-property    node-id :foo "two")))
   (expect-modified SimpleTestNode
                    #{:_declared-properties :_properties :foo}
-                   (fn [node-id] (g/update-property node-id :foo str/reverse)))
+                   (fn [node-id] (g/update-property node-id :foo string/reverse)))
   (expect-modified SimpleTestNode #{} (fn [node-id] (g/set-property    node-id :foo "one")))
   (expect-modified SimpleTestNode #{} (fn [node-id] (g/update-property node-id :foo identity))))
 
@@ -611,30 +606,551 @@
         (is (= @production-count 1))))))
 
 (g/defnode CachedDependencyTestNode
+  (property property g/Any)
   (input regular-input g/Any)
   (input array-input g/Any :array)
-  (output internal-output g/Any :cached (g/fnk [_node-id] _node-id))
-  (output evaluated-output g/Any :cached (g/fnk [regular-input array-input internal-output] [regular-input array-input internal-output])))
+
+  ;; Dependent on property.
+  (output uncached-output<=property g/Any (g/fnk [property] property))
+  (output cached-output<=property g/Any :cached (g/fnk [property] property))
+  (output uncached-secondary-output<=uncached-output<=property g/Any (g/fnk [uncached-output<=property] uncached-output<=property))
+  (output cached-secondary-output<=uncached-output<=property g/Any :cached (g/fnk [uncached-output<=property] uncached-output<=property))
+  (output uncached-secondary-output<=cached-output<=property g/Any (g/fnk [cached-output<=property] cached-output<=property))
+  (output cached-secondary-output<=cached-output<=property g/Any :cached (g/fnk [cached-output<=property] cached-output<=property))
+
+  ;; Dependent on regular-input.
+  (output uncached-output<=regular-input g/Any (g/fnk [regular-input] regular-input))
+  (output cached-output<=regular-input g/Any :cached (g/fnk [regular-input] regular-input))
+  (output uncached-secondary-output<=uncached-output<=regular-input g/Any (g/fnk [uncached-output<=regular-input] uncached-output<=regular-input))
+  (output cached-secondary-output<=uncached-output<=regular-input g/Any :cached (g/fnk [uncached-output<=regular-input] uncached-output<=regular-input))
+  (output uncached-secondary-output<=cached-output<=regular-input g/Any (g/fnk [cached-output<=regular-input] cached-output<=regular-input))
+  (output cached-secondary-output<=cached-output<=regular-input g/Any :cached (g/fnk [cached-output<=regular-input] cached-output<=regular-input))
+
+  ;; Dependent on array-input.
+  (output uncached-output<=array-input g/Any (g/fnk [array-input] array-input))
+  (output cached-output<=array-input g/Any :cached (g/fnk [array-input] array-input))
+  (output uncached-secondary-output<=uncached-output<=array-input g/Any (g/fnk [uncached-output<=array-input] uncached-output<=array-input))
+  (output cached-secondary-output<=uncached-output<=array-input g/Any :cached (g/fnk [uncached-output<=array-input] uncached-output<=array-input))
+  (output uncached-secondary-output<=cached-output<=array-input g/Any (g/fnk [cached-output<=array-input] cached-output<=array-input))
+  (output cached-secondary-output<=cached-output<=array-input g/Any :cached (g/fnk [cached-output<=array-input] cached-output<=array-input)))
 
 (deftest dependency-caching
+  (letfn [(cacheable-property-dependent-endpoints [node-id]
+            #{(gt/endpoint node-id :cached-output<=property)
+              (gt/endpoint node-id :cached-secondary-output<=uncached-output<=property)
+              (gt/endpoint node-id :cached-secondary-output<=cached-output<=property)})
+
+          (evaluate-and-check-property-dependents! [node-id expected-value]
+            (is (= expected-value (g/node-value node-id :property)))
+            (is (= expected-value (g/node-value node-id :uncached-output<=property)))
+            (is (= expected-value (g/node-value node-id :cached-output<=property)))
+            (is (= expected-value (g/node-value node-id :uncached-secondary-output<=uncached-output<=property)))
+            (is (= expected-value (g/node-value node-id :cached-secondary-output<=uncached-output<=property)))
+            (is (= expected-value (g/node-value node-id :uncached-secondary-output<=cached-output<=property)))
+            (is (= expected-value (g/node-value node-id :cached-secondary-output<=cached-output<=property))))
+
+          (cacheable-regular-input-dependent-endpoints [node-id]
+            #{(gt/endpoint node-id :cached-output<=regular-input)
+              (gt/endpoint node-id :cached-secondary-output<=uncached-output<=regular-input)
+              (gt/endpoint node-id :cached-secondary-output<=cached-output<=regular-input)})
+
+          (evaluate-and-check-regular-input-dependents! [node-id expected-value]
+            (is (= expected-value (g/node-value node-id :regular-input)))
+            (is (= expected-value (g/node-value node-id :uncached-output<=regular-input)))
+            (is (= expected-value (g/node-value node-id :cached-output<=regular-input)))
+            (is (= expected-value (g/node-value node-id :uncached-secondary-output<=uncached-output<=regular-input)))
+            (is (= expected-value (g/node-value node-id :cached-secondary-output<=uncached-output<=regular-input)))
+            (is (= expected-value (g/node-value node-id :uncached-secondary-output<=cached-output<=regular-input)))
+            (is (= expected-value (g/node-value node-id :cached-secondary-output<=cached-output<=regular-input))))
+
+          (cacheable-array-input-dependent-endpoints [node-id]
+            #{(gt/endpoint node-id :cached-output<=array-input)
+              (gt/endpoint node-id :cached-secondary-output<=uncached-output<=array-input)
+              (gt/endpoint node-id :cached-secondary-output<=cached-output<=array-input)})
+
+          (evaluate-and-check-array-input-dependents! [node-id expected-value]
+            (is (= expected-value (g/node-value node-id :array-input)))
+            (is (= expected-value (g/node-value node-id :uncached-output<=array-input)))
+            (is (= expected-value (g/node-value node-id :cached-output<=array-input)))
+            (is (= expected-value (g/node-value node-id :uncached-secondary-output<=uncached-output<=array-input)))
+            (is (= expected-value (g/node-value node-id :cached-secondary-output<=uncached-output<=array-input)))
+            (is (= expected-value (g/node-value node-id :uncached-secondary-output<=cached-output<=array-input)))
+            (is (= expected-value (g/node-value node-id :cached-secondary-output<=cached-output<=array-input))))]
+
+    (with-clean-system
+      (let [[consumer
+             regular-input-producer
+             array-input-producer-one
+             array-input-producer-two]
+            (tx-nodes (g/make-node world CachedDependencyTestNode)
+                      (g/make-node world CachedDependencyTestNode)
+                      (g/make-node world CachedDependencyTestNode)
+                      (g/make-node world CachedDependencyTestNode))
+
+            [ov-consumer]
+            (tx-nodes (g/override consumer))]
+
+        (is (= #{} (set (keys (g/cache)))))
+
+        (testing "No connections between nodes, property on consumer not set."
+          (evaluate-and-check-property-dependents! consumer nil)
+          (evaluate-and-check-property-dependents! ov-consumer nil)
+          (is (= (set/union
+                   (cacheable-property-dependent-endpoints consumer)
+                   (cacheable-property-dependent-endpoints ov-consumer))
+                 (set (keys (g/cache)))))
+
+          (evaluate-and-check-regular-input-dependents! consumer nil)
+          (evaluate-and-check-regular-input-dependents! ov-consumer nil)
+          (is (= (set/union
+                   (cacheable-property-dependent-endpoints consumer)
+                   (cacheable-property-dependent-endpoints ov-consumer)
+                   (cacheable-regular-input-dependent-endpoints consumer)
+                   (cacheable-regular-input-dependent-endpoints ov-consumer))
+                 (set (keys (g/cache)))))
+
+          (evaluate-and-check-array-input-dependents! consumer [])
+          (evaluate-and-check-array-input-dependents! ov-consumer [])
+          (is (= (set/union
+                   (cacheable-property-dependent-endpoints consumer)
+                   (cacheable-property-dependent-endpoints ov-consumer)
+                   (cacheable-regular-input-dependent-endpoints consumer)
+                   (cacheable-regular-input-dependent-endpoints ov-consumer)
+                   (cacheable-array-input-dependent-endpoints consumer)
+                   (cacheable-array-input-dependent-endpoints ov-consumer))
+                 (set (keys (g/cache))))))
+
+        ;; Set property on consumer.
+        (g/transact
+          (g/set-property consumer :property "first change to consumer"))
+
+        (testing "Setting consumer property invalidates cached dependents."
+          (is (= (set/union
+                   (cacheable-regular-input-dependent-endpoints consumer)
+                   (cacheable-regular-input-dependent-endpoints ov-consumer)
+                   (cacheable-array-input-dependent-endpoints consumer)
+                   (cacheable-array-input-dependent-endpoints ov-consumer))
+                 (set (keys (g/cache))))))
+
+        (testing "Outputs dependent on consumer property reflect new state."
+          (evaluate-and-check-property-dependents! consumer "first change to consumer")
+          (evaluate-and-check-property-dependents! ov-consumer "first change to consumer"))
+
+        (testing "Outputs dependent on consumer property enter the cache after evaluation."
+          (is (= (set/union
+                   (cacheable-property-dependent-endpoints consumer)
+                   (cacheable-property-dependent-endpoints ov-consumer)
+                   (cacheable-regular-input-dependent-endpoints consumer)
+                   (cacheable-regular-input-dependent-endpoints ov-consumer)
+                   (cacheable-array-input-dependent-endpoints consumer)
+                   (cacheable-array-input-dependent-endpoints ov-consumer))
+                 (set (keys (g/cache))))))
+
+        ;; Set property on consumer a second time.
+        (g/transact
+          (g/set-property consumer :property "second change to consumer"))
+
+        (testing "Outputs dependent on consumer property reflect new state."
+          (evaluate-and-check-property-dependents! consumer "second change to consumer")
+          (evaluate-and-check-property-dependents! ov-consumer "second change to consumer"))
+
+        ;; Connect regular-input-producer to regular-input on consumer.
+        (g/transact
+          (g/connect regular-input-producer :uncached-output<=property consumer :regular-input))
+
+        (testing "Connecting to regular-input on consumer invalidates cached dependents."
+          (is (= (set/union
+                   (cacheable-property-dependent-endpoints consumer)
+                   (cacheable-property-dependent-endpoints ov-consumer)
+                   (cacheable-array-input-dependent-endpoints consumer)
+                   (cacheable-array-input-dependent-endpoints ov-consumer))
+                 (set (keys (g/cache))))))
+
+        (testing "Connected to regular-input, property on regular-input-producer not set."
+          (evaluate-and-check-regular-input-dependents! consumer nil)
+          (evaluate-and-check-regular-input-dependents! ov-consumer nil)
+          (is (= (set/union
+                   (cacheable-property-dependent-endpoints consumer)
+                   (cacheable-property-dependent-endpoints ov-consumer)
+                   (cacheable-regular-input-dependent-endpoints consumer)
+                   (cacheable-regular-input-dependent-endpoints ov-consumer)
+                   (cacheable-array-input-dependent-endpoints consumer)
+                   (cacheable-array-input-dependent-endpoints ov-consumer))
+                 (set (keys (g/cache))))))
+
+        ;; Set property on regular-input-producer.
+        (g/transact
+          (g/set-property regular-input-producer :property "first change to regular-input-producer"))
+
+        (testing "Setting regular-input-producer property invalidates cached dependents."
+          (is (= (set/union
+                   (cacheable-property-dependent-endpoints consumer)
+                   (cacheable-property-dependent-endpoints ov-consumer)
+                   (cacheable-array-input-dependent-endpoints consumer)
+                   (cacheable-array-input-dependent-endpoints ov-consumer))
+                 (set (keys (g/cache))))))
+
+        (testing "Outputs dependent on regular-input-producer property reflect new state."
+          (evaluate-and-check-regular-input-dependents! consumer "first change to regular-input-producer")
+          (evaluate-and-check-regular-input-dependents! ov-consumer "first change to regular-input-producer"))
+
+        (testing "Outputs dependent on regular-input-producer property enter the cache after evaluation."
+          (is (= (set/union
+                   (cacheable-property-dependent-endpoints consumer)
+                   (cacheable-property-dependent-endpoints ov-consumer)
+                   (cacheable-regular-input-dependent-endpoints consumer)
+                   (cacheable-regular-input-dependent-endpoints ov-consumer)
+                   (cacheable-array-input-dependent-endpoints consumer)
+                   (cacheable-array-input-dependent-endpoints ov-consumer))
+                 (set (keys (g/cache))))))
+
+        ;; Set property on regular-input-producer a second time.
+        (g/transact
+          (g/set-property regular-input-producer :property "second change to regular-input-producer"))
+
+        (testing "Outputs dependent on consumer property reflect new state."
+          (evaluate-and-check-regular-input-dependents! consumer "second change to regular-input-producer")
+          (evaluate-and-check-regular-input-dependents! ov-consumer "second change to regular-input-producer"))
+
+        ;; Connect array-input-producer-one to array-input on consumer.
+        (g/transact
+          (g/connect array-input-producer-one :uncached-output<=property consumer :array-input))
+
+        (testing "Connecting to array-input on consumer invalidates cached dependents."
+          (is (= (set/union
+                   (cacheable-property-dependent-endpoints consumer)
+                   (cacheable-property-dependent-endpoints ov-consumer)
+                   (cacheable-regular-input-dependent-endpoints consumer)
+                   (cacheable-regular-input-dependent-endpoints ov-consumer))
+                 (set (keys (g/cache))))))
+
+        (testing "Connected to array-input, property on array-input-producer-one not set."
+          (evaluate-and-check-array-input-dependents! consumer [nil])
+          (evaluate-and-check-array-input-dependents! ov-consumer [nil])
+          (is (= (set/union
+                   (cacheable-property-dependent-endpoints consumer)
+                   (cacheable-property-dependent-endpoints ov-consumer)
+                   (cacheable-regular-input-dependent-endpoints consumer)
+                   (cacheable-regular-input-dependent-endpoints ov-consumer)
+                   (cacheable-array-input-dependent-endpoints consumer)
+                   (cacheable-array-input-dependent-endpoints ov-consumer))
+                 (set (keys (g/cache))))))
+
+        ;; Set property on array-input-producer-one.
+        (g/transact
+          (g/set-property array-input-producer-one :property "first change to array-input-producer-one"))
+
+        (testing "Setting array-input-producer-one property invalidates cached dependents."
+          (is (= (set/union
+                   (cacheable-property-dependent-endpoints consumer)
+                   (cacheable-property-dependent-endpoints ov-consumer)
+                   (cacheable-regular-input-dependent-endpoints consumer)
+                   (cacheable-regular-input-dependent-endpoints ov-consumer))
+                 (set (keys (g/cache))))))
+
+        (testing "Outputs dependent on array-input-producer-one property reflect new state."
+          (evaluate-and-check-array-input-dependents! consumer ["first change to array-input-producer-one"])
+          (evaluate-and-check-array-input-dependents! ov-consumer ["first change to array-input-producer-one"]))
+
+        (testing "Outputs dependent on array-input-producer-one property enter the cache after evaluation."
+          (is (= (set/union
+                   (cacheable-property-dependent-endpoints consumer)
+                   (cacheable-property-dependent-endpoints ov-consumer)
+                   (cacheable-regular-input-dependent-endpoints consumer)
+                   (cacheable-regular-input-dependent-endpoints ov-consumer)
+                   (cacheable-array-input-dependent-endpoints consumer)
+                   (cacheable-array-input-dependent-endpoints ov-consumer))
+                 (set (keys (g/cache))))))
+
+        ;; Set property on array-input-producer-one a second time.
+        (g/transact
+          (g/set-property array-input-producer-one :property "second change to array-input-producer-one"))
+
+        (testing "Outputs dependent on consumer property reflect new state."
+          (evaluate-and-check-array-input-dependents! consumer ["second change to array-input-producer-one"])
+          (evaluate-and-check-array-input-dependents! ov-consumer ["second change to array-input-producer-one"]))
+
+        ;; Connect array-input-producer-two to array-input on consumer.
+        (g/transact
+          (g/connect array-input-producer-two :uncached-output<=property consumer :array-input))
+
+        (testing "Connecting to array-input on consumer invalidates cached dependents."
+          (is (= (set/union
+                   (cacheable-property-dependent-endpoints consumer)
+                   (cacheable-property-dependent-endpoints ov-consumer)
+                   (cacheable-regular-input-dependent-endpoints consumer)
+                   (cacheable-regular-input-dependent-endpoints ov-consumer))
+                 (set (keys (g/cache))))))
+
+        (testing "Connected to array-input, property on array-input-producer-two not set."
+          (evaluate-and-check-array-input-dependents! consumer ["second change to array-input-producer-one" nil])
+          (evaluate-and-check-array-input-dependents! ov-consumer ["second change to array-input-producer-one" nil])
+          (is (= (set/union
+                   (cacheable-property-dependent-endpoints consumer)
+                   (cacheable-property-dependent-endpoints ov-consumer)
+                   (cacheable-regular-input-dependent-endpoints consumer)
+                   (cacheable-regular-input-dependent-endpoints ov-consumer)
+                   (cacheable-array-input-dependent-endpoints consumer)
+                   (cacheable-array-input-dependent-endpoints ov-consumer))
+                 (set (keys (g/cache))))))
+
+        ;; Set property on array-input-producer-two.
+        (g/transact
+          (g/set-property array-input-producer-two :property "first change to array-input-producer-two"))
+
+        (testing "Setting array-input-producer-two property invalidates cached dependents."
+          (is (= (set/union
+                   (cacheable-property-dependent-endpoints consumer)
+                   (cacheable-property-dependent-endpoints ov-consumer)
+                   (cacheable-regular-input-dependent-endpoints consumer)
+                   (cacheable-regular-input-dependent-endpoints ov-consumer))
+                 (set (keys (g/cache))))))
+
+        (testing "Outputs dependent on array-input-producer-two property reflect new state."
+          (evaluate-and-check-array-input-dependents! consumer ["second change to array-input-producer-one" "first change to array-input-producer-two"])
+          (evaluate-and-check-array-input-dependents! ov-consumer ["second change to array-input-producer-one" "first change to array-input-producer-two"]))
+
+        (testing "Outputs dependent on array-input-producer-two property enter the cache after evaluation."
+          (is (= (set/union
+                   (cacheable-property-dependent-endpoints consumer)
+                   (cacheable-property-dependent-endpoints ov-consumer)
+                   (cacheable-regular-input-dependent-endpoints consumer)
+                   (cacheable-regular-input-dependent-endpoints ov-consumer)
+                   (cacheable-array-input-dependent-endpoints consumer)
+                   (cacheable-array-input-dependent-endpoints ov-consumer))
+                 (set (keys (g/cache))))))
+
+        ;; Set property on array-input-producer-two a second time.
+        (g/transact
+          (g/set-property array-input-producer-two :property "second change to array-input-producer-two"))
+
+        (testing "Outputs dependent on consumer property reflect new state."
+          (evaluate-and-check-array-input-dependents! consumer ["second change to array-input-producer-one" "second change to array-input-producer-two"])
+          (evaluate-and-check-array-input-dependents! ov-consumer ["second change to array-input-producer-one" "second change to array-input-producer-two"]))
+
+        ;; Disconnect array-input-producer-one from array-input on consumer.
+        (g/transact
+          (g/disconnect array-input-producer-one :uncached-output<=property consumer :array-input))
+
+        (testing "Disconnecting from array-input on consumer invalidates cached dependents."
+          (is (= (set/union
+                   (cacheable-property-dependent-endpoints consumer)
+                   (cacheable-property-dependent-endpoints ov-consumer)
+                   (cacheable-regular-input-dependent-endpoints consumer)
+                   (cacheable-regular-input-dependent-endpoints ov-consumer))
+                 (set (keys (g/cache))))))
+
+        (testing "Only array-input-producer-two connected to array-input."
+          (evaluate-and-check-array-input-dependents! consumer ["second change to array-input-producer-two"])
+          (evaluate-and-check-array-input-dependents! ov-consumer ["second change to array-input-producer-two"])
+          (is (= (set/union
+                   (cacheable-property-dependent-endpoints consumer)
+                   (cacheable-property-dependent-endpoints ov-consumer)
+                   (cacheable-regular-input-dependent-endpoints consumer)
+                   (cacheable-regular-input-dependent-endpoints ov-consumer)
+                   (cacheable-array-input-dependent-endpoints consumer)
+                   (cacheable-array-input-dependent-endpoints ov-consumer))
+                 (set (keys (g/cache))))))))))
+
+(g/defnode OverrideSuccessorsTestNode
+  (property property g/Any)
+  (input owning-input g/Any :cascade-delete :array)
+  (input external-input g/Any)
+
+  ;; Dependent on property.
+  (output output<=property g/Any (g/fnk [property] property))
+  (output secondary-output<=output<=property g/Any (g/fnk [output<=property] output<=property))
+
+  ;; Dependent on external-input.
+  (output output<=external-input g/Any (g/fnk [external-input] external-input))
+  (output secondary-output<=output<=external-input g/Any (g/fnk [output<=external-input] output<=external-input)))
+
+(defn- successor-output-endpoints
+  ([node-id output-label]
+   (successor-output-endpoints (g/now) node-id output-label))
+  ([basis node-id output-label]
+   (assert (g/has-output? (g/node-type* basis node-id) output-label) "Only outputs have successors.")
+   (let [graph-id (g/node-id->graph-id node-id)]
+     (into (sorted-set)
+           (get-in basis [:graphs graph-id :successors node-id output-label])))))
+
+(defn- dependent-internal-output-endpoints
+  ([node-id label]
+   (dependent-internal-output-endpoints (g/now) node-id label))
+  ([basis node-id label]
+   (let [node-type (g/node-type* basis node-id)
+         label->dependent-internal-output-labels (in/input-dependencies node-type)]
+     (into (sorted-set)
+           (map #(g/endpoint node-id %))
+           (label->dependent-internal-output-labels label)))))
+
+(defn- dependent-immediate-override-output-endpoints
+  ([node-id label]
+   (dependent-immediate-override-output-endpoints (g/now) node-id label))
+  ([basis node-id label]
+   (into (sorted-set)
+         (map #(gt/endpoint % label))
+         (g/overrides basis node-id))))
+
+(deftest override-successors
+  ;; This test recreates a scenario discovered when working on the gui system.
+  ;; We discovered an issue where the successors stored in the graph would not
+  ;; correct after adding a gui node to a scene imported as a template from
+  ;; another scene.
   (with-clean-system
-    (let [[regular-input-producer array-input-producer-one array-input-producer-two consumer]
-          (tx-nodes (g/make-node world CachedDependencyTestNode)
-                    (g/make-node world CachedDependencyTestNode)
-                    (g/make-node world CachedDependencyTestNode)
-                    (g/make-node world CachedDependencyTestNode))]
+    (let [[referenced-scene
+           referenced-scene-node-tree
+           referenced-scene-text
+           referenced-scene-added-text
+           referencing-scene
+           referencing-scene-node-tree
+           referencing-scene-button
+           referencing-scene-referenced-scene
+           referencing-scene-referenced-scene-node-tree
+           referencing-scene-referenced-scene-text]
+          (g/tx-nodes-added
+            (g/transact
+              (g/make-nodes
+                world [referenced-scene [OverrideSuccessorsTestNode :property "referenced-scene"]
+                       referenced-scene-node-tree [OverrideSuccessorsTestNode :property "referenced-scene-node-tree"]
+                       referenced-scene-text [OverrideSuccessorsTestNode :property "referenced-scene-text"]
+                       referenced-scene-added-text [OverrideSuccessorsTestNode :property "referenced-scene-added-text"]
+                       referencing-scene [OverrideSuccessorsTestNode :property "referencing-scene"]
+                       referencing-scene-node-tree [OverrideSuccessorsTestNode :property "referencing-scene-node-tree"]
+                       referencing-scene-button [OverrideSuccessorsTestNode :property "referencing-scene-button"]]
+                (g/connect referenced-scene-text :_node-id referenced-scene-node-tree :owning-input)
+                (g/connect referenced-scene-node-tree :_node-id referenced-scene :owning-input)
+                (g/connect referenced-scene :output<=property referenced-scene-node-tree :external-input)
+                (g/connect referenced-scene-node-tree :output<=external-input referenced-scene-text :external-input)
+                (g/connect referencing-scene-button :_node-id referencing-scene-node-tree :owning-input)
+                (g/connect referencing-scene-node-tree :_node-id referencing-scene :owning-input)
+                (g/connect referencing-scene :output<=property referencing-scene-node-tree :external-input)
+                (g/connect referencing-scene-node-tree :output<=external-input referencing-scene-button :external-input)
+                (g/override referenced-scene {}
+                  (fn [_evaluation-context id-mapping]
+                    (let [referencing-scene-referenced-scene (get id-mapping referenced-scene)
+                          referencing-scene-referenced-scene-node-tree (get id-mapping referenced-scene-node-tree)
+                          referencing-scene-referenced-scene-text (get id-mapping referenced-scene-text)]
+                      (concat
+                        (g/set-property referencing-scene-referenced-scene :property "referencing-scene-referenced-scene")
+                        (g/set-property referencing-scene-referenced-scene-node-tree :property "referencing-scene-referenced-scene-node-tree")
+                        (g/set-property referencing-scene-referenced-scene-text :property "referencing-scene-referenced-scene-text")
+                        (g/connect referencing-scene-referenced-scene :_node-id referencing-scene-button :owning-input)
+                        (g/connect referencing-scene-button :output<=external-input referencing-scene-referenced-scene :external-input))))))))]
+
+      ;; Connect referenced-scene-added-text to referenced-scene-node-tree after the override has been established.
       (g/transact
         (concat
-          (g/connect regular-input-producer :evaluated-output consumer :regular-input)
-          (g/connect array-input-producer-one :evaluated-output consumer :array-input)
-          (g/connect array-input-producer-two :evaluated-output consumer :array-input)))
-      (g/node-value consumer :evaluated-output)
-      (is (= #{(gt/endpoint consumer :evaluated-output)
-               (gt/endpoint consumer :internal-output)
-               (gt/endpoint regular-input-producer :evaluated-output)
-               (gt/endpoint regular-input-producer :internal-output)
-               (gt/endpoint array-input-producer-one :evaluated-output)
-               (gt/endpoint array-input-producer-one :internal-output)
-               (gt/endpoint array-input-producer-two :evaluated-output)
-               (gt/endpoint array-input-producer-two :internal-output)}
-             (set (keys (g/cache))))))))
+          (g/connect referenced-scene-added-text :_node-id referenced-scene-node-tree :owning-input)
+          (g/connect referenced-scene-node-tree :output<=external-input referenced-scene-added-text :external-input)))
+
+      (let [referencing-scene-referenced-scene-added-text (first (g/overrides referenced-scene-added-text))
+
+            node-id->symbol
+            {referenced-scene 'referenced-scene
+             referenced-scene-node-tree 'referenced-scene-node-tree
+             referenced-scene-text 'referenced-scene-text
+             referenced-scene-added-text 'referenced-scene-added-text
+             referencing-scene 'referencing-scene
+             referencing-scene-node-tree 'referencing-scene-node-tree
+             referencing-scene-button 'referencing-scene-button
+             referencing-scene-referenced-scene 'referencing-scene-referenced-scene
+             referencing-scene-referenced-scene-node-tree 'referencing-scene-referenced-scene-node-tree
+             referencing-scene-referenced-scene-text 'referencing-scene-referenced-scene-text
+             referencing-scene-referenced-scene-added-text 'referencing-scene-referenced-scene-added-text}
+
+            endpoint->symbol+label
+            (fn endpoint->symbol+label [endpoint]
+              (let [node-id (g/endpoint-node-id endpoint)
+                    label (g/endpoint-label endpoint)
+                    symbol (node-id->symbol node-id)]
+                (assert (symbol? symbol) "Supplied node-id not found in node-id->symbol map.")
+                [symbol label]))
+
+            endpoints->symbol+labels
+            (fn endpoints->symbol+labels [endpoints]
+              (into (sorted-set)
+                    (map endpoint->symbol+label)
+                    endpoints))
+
+            dependent-immediate-override-outputs (comp endpoints->symbol+labels dependent-immediate-override-output-endpoints)
+            dependent-internal-outputs (comp endpoints->symbol+labels dependent-internal-output-endpoints)
+            successor-outputs (comp endpoints->symbol+labels successor-output-endpoints)]
+
+        (testing "Created nodes are returned in expected order."
+          (is (= "referenced-scene" (g/node-value referenced-scene :property)))
+          (is (= "referenced-scene-node-tree" (g/node-value referenced-scene-node-tree :property)))
+          (is (= "referenced-scene-text" (g/node-value referenced-scene-text :property)))
+          (is (= "referenced-scene-added-text" (g/node-value referenced-scene-added-text :property)))
+          (is (= "referencing-scene" (g/node-value referencing-scene :property)))
+          (is (= "referencing-scene-node-tree" (g/node-value referencing-scene-node-tree :property)))
+          (is (= "referencing-scene-button" (g/node-value referencing-scene-button :property)))
+          (is (= "referencing-scene-referenced-scene" (g/node-value referencing-scene-referenced-scene :property)))
+          (is (= "referencing-scene-referenced-scene-node-tree" (g/node-value referencing-scene-referenced-scene-node-tree :property)))
+          (is (= "referencing-scene-referenced-scene-text" (g/node-value referencing-scene-referenced-scene-text :property))))
+
+        (testing "Successors in referenced scene."
+          (is (= (set/union
+                   (dependent-immediate-override-outputs referenced-scene :property)
+                   (dependent-internal-outputs referenced-scene :property))
+                 (successor-outputs referenced-scene :property)))
+
+          (is (= (set/union
+                   (dependent-immediate-override-outputs referenced-scene :output<=property)
+                   (dependent-internal-outputs referenced-scene :output<=property)
+                   (dependent-internal-outputs referenced-scene-node-tree :external-input))
+                 (successor-outputs referenced-scene :output<=property)))
+
+          (is (= (set/union
+                   (dependent-immediate-override-outputs referenced-scene-node-tree :output<=external-input)
+                   (dependent-internal-outputs referenced-scene-node-tree :output<=external-input)
+                   (dependent-internal-outputs referenced-scene-text :external-input)
+                   (dependent-internal-outputs referenced-scene-added-text :external-input))
+                 (successor-outputs referenced-scene-node-tree :output<=external-input)))
+
+          (is (= (set/union
+                   (dependent-immediate-override-outputs referenced-scene-text :output<=external-input)
+                   (dependent-internal-outputs referenced-scene-text :output<=external-input))
+                 (successor-outputs referenced-scene-text :output<=external-input)))
+
+          (is (= (set/union
+                   (dependent-immediate-override-outputs referenced-scene-added-text :output<=external-input)
+                   (dependent-internal-outputs referenced-scene-added-text :output<=external-input))
+                 (successor-outputs referenced-scene-added-text :output<=external-input))))
+
+        (testing "Successors in referencing scene."
+          (is (= (dependent-internal-outputs referencing-scene :property)
+                 (successor-outputs referencing-scene :property)))
+
+          (is (= (dependent-internal-outputs referencing-scene :output<=external-input)
+                 (successor-outputs referencing-scene :output<=external-input)))
+
+          (is (= (dependent-internal-outputs referencing-scene :output<=external-input)
+                 (successor-outputs referencing-scene :output<=external-input)))
+
+          (is (= (set/union
+                   (dependent-internal-outputs referencing-scene-node-tree :output<=external-input)
+                   (dependent-internal-outputs referencing-scene-button :external-input))
+                 (successor-outputs referencing-scene-node-tree :output<=external-input)))
+
+          (is (= (set/union
+                   (dependent-internal-outputs referencing-scene-button :output<=external-input)
+                   (dependent-internal-outputs referencing-scene-referenced-scene :external-input))
+                 (successor-outputs referencing-scene-button :output<=external-input)))
+
+          (is (= (set/union
+                   (dependent-internal-outputs referencing-scene-referenced-scene :output<=property)
+                   (dependent-internal-outputs referencing-scene-referenced-scene-node-tree :external-input))
+                 (successor-outputs referencing-scene-referenced-scene :output<=property)))
+
+          (is (= (set/union
+                   (dependent-internal-outputs referencing-scene-referenced-scene-node-tree :output<=external-input)
+                   (dependent-internal-outputs referencing-scene-referenced-scene-text :external-input)
+                   (dependent-internal-outputs referencing-scene-referenced-scene-added-text :external-input))
+                 (successor-outputs referencing-scene-referenced-scene-node-tree :output<=external-input)))
+
+          (is (= (dependent-internal-outputs referencing-scene-referenced-scene-text :output<=external-input)
+                 (successor-outputs referencing-scene-referenced-scene-text :output<=external-input)))
+
+          (is (= (dependent-internal-outputs referencing-scene-referenced-scene-added-text :output<=external-input)
+                 (successor-outputs referencing-scene-referenced-scene-added-text :output<=external-input))))))))

--- a/editor/test/util/array_test.clj
+++ b/editor/test/util/array_test.clj
@@ -24,10 +24,9 @@
   (Arrays/equals a b))
 
 (deftest of-test
-  (let [items [:a :b :c :d :e :f :g :h :i :j :k :l :m :n :o :p]]
-    (doseq [^long length (range 4)]
+  (let [items (mapv #(str "item" %) (range 20))]
+    (dotimes [length (count items)]
       (let [expected-items (take length items)]
-        (is (apply array/of expected-items))
         (is (object-arrays-equal?
               (object-array expected-items)
               (apply array/of expected-items)))))))

--- a/editor/test/util/array_test.clj
+++ b/editor/test/util/array_test.clj
@@ -1,0 +1,33 @@
+;; Copyright 2020-2024 The Defold Foundation
+;; Copyright 2014-2020 King
+;; Copyright 2009-2014 Ragnar Svensson, Christian Murray
+;; Licensed under the Defold License version 1.0 (the "License"); you may not use
+;; this file except in compliance with the License.
+;;
+;; You may obtain a copy of the License, together with FAQs at
+;; https://www.defold.com/license
+;;
+;; Unless required by applicable law or agreed to in writing, software distributed
+;; under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+;; CONDITIONS OF ANY KIND, either express or implied. See the License for the
+;; specific language governing permissions and limitations under the License.
+
+(ns util.array-test
+  (:require [clojure.test :refer :all]
+            [util.array :as array])
+  (:import [java.util Arrays]))
+
+(set! *warn-on-reflection* true)
+(set! *unchecked-math* :warn-on-boxed)
+
+(defn- object-arrays-equal? [^"[Ljava.lang.Object;" a ^"[Ljava.lang.Object;" b]
+  (Arrays/equals a b))
+
+(deftest of-test
+  (let [items [:a :b :c :d :e :f :g :h :i :j :k :l :m :n :o :p]]
+    (doseq [^long length (range 4)]
+      (let [expected-items (take length items)]
+        (is (apply array/of expected-items))
+        (is (object-arrays-equal?
+              (object-array expected-items)
+              (apply array/of expected-items)))))))

--- a/editor/test/util/eduction_test.clj
+++ b/editor/test/util/eduction_test.clj
@@ -31,15 +31,16 @@
   (is (= (concat)
          (e/concat)))
   (is (eduction? (e/concat)))
-  (let [single-coll (range 0 3)]
-    (is (identical? single-coll
-                    (e/concat single-coll))))
-  (is (= (concat (range 0 3) (range 3 5))
-         (e/concat (range 0 3) (range 3 5))))
-  (is (eduction? (e/concat (range 0 3) (range 3 5))))
-  (is (= (concat (range 0 3) (range 3 5) (range 5 8))
-         (e/concat (range 0 3) (range 3 5) (range 5 8))))
-  (is (eduction? (e/concat (range 0 3) (range 3 5) (range 5 8)))))
+  (let [single-arg (range 0 3)]
+    (is (identical? single-arg
+                    (e/concat single-arg))))
+  (let [ranges (partition-all 4 (range))]
+    (doseq [arg-count (range 2 20)]
+      (let [args (take arg-count ranges)
+            expected (apply concat args)
+            actual (apply e/concat args)]
+        (is (= expected actual))
+        (is (eduction? actual))))))
 
 (deftest dedupe-test
   (is (= (dedupe [1 2 1 1 2])


### PR DESCRIPTION
Fixed an issue where stale values would be retained in the editor system cache in certain scenarios involving overrides.

### Technical changes
* We now correctly consider successors from implicit connections inherited by override nodes when altering the topology of the editor graph.