### PR TITLE
Don't generate content more than once

### DIFF
--- a/engine/gamesys/src/gamesys/test/wscript
+++ b/engine/gamesys/src/gamesys/test/wscript
@@ -6,9 +6,6 @@ import waflib.Task, waflib.TaskGen, waflib.Options
 from waflib.TaskGen import extension
 from waf_dynamo import platform_supports_feature
 
-sys.path.insert(0, "src")
-import waf_gamesys
-
 def configure(conf):
     if platform_supports_feature(conf.env.PLATFORM, 'compute', None):
         conf.env.append_unique('DEFINES', 'DM_HAVE_PLATFORM_COMPUTE_SUPPORT')
@@ -81,7 +78,6 @@ def build(bld):
                                use = 'TESTMAIN DMGLFW GAMEOBJECT DDF RESOURCE PHYSICS RENDER GRAPHICS_GAMESYS_TEST SOCKET APP PROFILE_NULL SCRIPT LUA EXTENSION INPUT PLATFORM_NULL HID_NULL PARTICLE RIG GUI SOUND_NULL LIVEUPDATE DLIB gamesys gamesys_rig gamesys_model',
                                exported_symbols = exported_symbols + ['ScriptModelExt'],
                                web_libs = ['library_sys.js', 'library_script.js', 'library_render.js'],
-                               proto_gen_py = True,
                                content_root='../test',
                                source = bld.path.ant_glob('test_gamesys.cpp') + bld.path.ant_glob(dirs, excl=excl_pattern),
                                target = 'test_gamesys')
@@ -91,8 +87,6 @@ def build(bld):
                                         includes = '../../../src ../../../proto',
                                         use = 'TESTMAIN DMGLFW GAMEOBJECT DDF RESOURCE PHYSICS RENDER GRAPHICS_GAMESYS_TEST SOCKET APP PROFILE_NULL SCRIPT TEST_SCRIPT LUA EXTENSION INPUT PLATFORM_NULL HID_NULL PARTICLE RIG GUI SOUND_NULL LIVEUPDATE DLIB gamesys gamesys_rig_null gamesys_model_null',
                                         exported_symbols = exported_symbols,
-                                        proto_gen_py = True,
-                                        content_root='../test',
                                         source = bld.path.ant_glob('test_gamesys_http.cpp') + bld.path.ant_glob('http/*'),
                                         target = 'test_gamesys_http')
 
@@ -101,7 +95,6 @@ def build(bld):
             bld.program(features = 'cxx test',
                         includes = '..',
                         use = 'TESTMAIN DMGLFW GAMEOBJECT DDF RESOURCE PHYSICS RENDER GRAPHICS_GAMESYS_TEST SOCKET APP PROFILE_NULL SCRIPT LUA EXTENSION INPUT PLATFORM_NULL HID_NULL PARTICLE RIG GUI SOUND_NULL LIVEUPDATE DLIB TEST_SCRIPT gamesys gamesys_rig_null gamesys_model_null',
-                        proto_gen_py = True,
                         source = 'test_script_http.cpp http/test_http.lua.raw http/test_http_timeout.lua.raw'.split(),
                         target = 'test_script_http')
 

--- a/engine/gamesys/src/gamesys/wscript
+++ b/engine/gamesys/src/gamesys/wscript
@@ -1,10 +1,14 @@
 #! /usr/bin/env python
-import os
-import re
+import os, sys, re
 from waf_dynamo import apidoc_extract_task
+import waflib.Options
+
+sys.path.insert(0, "src")
+import waf_gamesys
 
 def configure(conf):
-    conf.recurse('test')
+    if not waflib.Options.options.skip_build_tests:
+        conf.recurse('test')
 
 def has_ext(itm, ext):
     if type("") == type(itm):
@@ -46,28 +50,24 @@ def build(bld):
 
     bld.stlib(features = 'cxx ddf',
         includes = '. .. ../../src ../../proto',
-        proto_gen_py = True,
         protoc_includes = '../../proto',
         source = 'resources/res_model.cpp components/comp_model.cpp scripts/script_model.cpp ../../proto/gamesys/model_ddf.proto',
         target = 'gamesys_model')
 
     bld.stlib(features = 'cxx',
         includes = '. .. ../../src ../../proto',
-        proto_gen_py = True,
         protoc_includes = '../../proto',
         source = 'resources/res_model_null.cpp components/comp_model_null.cpp',
         target = 'gamesys_model_null')
 
     bld.stlib(features = 'cxx ddf',
         includes = '. .. ../../src ../../proto',
-        proto_gen_py = True,
         protoc_includes = '../../proto',
         source = 'resources/res_rig_scene.cpp',
         target = 'gamesys_rig')
 
     bld.stlib(features = 'cxx',
         includes = '. .. ../../src ../../proto',
-        proto_gen_py = True,
         protoc_includes = '../../proto',
         source = 'resources/res_rig_scene_null.cpp',
         target = 'gamesys_rig_null')
@@ -108,8 +108,9 @@ def build(bld):
         'components/comp_sound.cpp',
         'components/comp_collection_proxy.cpp'] + proto_files)
 
-    bld.add_group()
-    bld.recurse('test')
+    if not waflib.Options.options.skip_build_tests:
+        bld.add_group()
+        bld.recurse('test')
 
     bld.install_files('${PREFIX}/include/gamesys', 'gamesys.h')
     bld.install_files('${PREFIX}/include/gamesys/components', 'components/comp_gui.h')

--- a/engine/gamesys/src/gamesys/wscript
+++ b/engine/gamesys/src/gamesys/wscript
@@ -51,6 +51,7 @@ def build(bld):
     bld.stlib(features = 'cxx ddf',
         includes = '. .. ../../src ../../proto',
         protoc_includes = '../../proto',
+        proto_gen_py = True,
         source = 'resources/res_model.cpp components/comp_model.cpp scripts/script_model.cpp ../../proto/gamesys/model_ddf.proto',
         target = 'gamesys_model')
 


### PR DESCRIPTION
## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
