### PR TITLE
Add optional SHA1 validation for wasm, wasmjs, and asmjs files

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/HTML5Bundler.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/HTML5Bundler.java
@@ -55,10 +55,14 @@ public class HTML5Bundler implements IBundler {
     private static final String SplitFileDir = "archive";
     private static final String SplitFileJson = "archive_files.json";
     private static int SplitFileSegmentSize = 2 * 1024 * 1024;
+    private static String SplitFileSHA1 = "";
 
     // previously it was hardcoded in dmloader.js
+    private String WasmSHA1 = "";
     private long WasmSize = 2000000;
+    private String WasmjsSHA1 = "";
     private long WasmjsSize = 250000;
+    private String AsmjsSHA1 = "";
     private long AsmjsSize = 4000000;
     public static final String MANIFEST_NAME = "engine_template.html";
 
@@ -96,8 +100,12 @@ public class HTML5Bundler implements IBundler {
             }
         }
         properties.put("DEFOLD_HEAP_SIZE", customHeapSize);
+        properties.put("DEFOLD_ARCHIVE_SHA1", SplitFileSHA1);
+        properties.put("DEFOLD_WASM_SHA1", WasmSHA1);
         properties.put("DEFOLD_WASM_SIZE", WasmSize);
+        properties.put("DEFOLD_WASMJS_SHA1", WasmjsSHA1);
         properties.put("DEFOLD_WASMJS_SIZE", WasmjsSize);
+        properties.put("ASMJS_SHA1", AsmjsSHA1);
         properties.put("ASMJS_SIZE", AsmjsSize);
 
         String splashImage = projectProperties.getStringValue("html5", "splash_image", null);
@@ -267,6 +275,29 @@ public class HTML5Bundler implements IBundler {
         }
     }
 
+    private static String calculateSHA1(File file) throws IOException {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-1");
+            BufferedInputStream is = new BufferedInputStream(new FileInputStream(file));
+            byte[] buffer = new byte[1024];
+            int n = is.read(buffer);
+            while (n != -1) {
+                md.update(buffer, 0, n);
+                n = is.read(buffer);
+            }
+            is.close();
+            String sha1 = new BigInteger(1, md.digest()).toString(16);
+            while (sha1.length() < 40) {
+                sha1 = "0" + sha1;
+            }
+            return sha1;
+        } catch (IOException e) {
+            return null;
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     URL getResource(String name) {
         return getClass().getResource(String.format("resources/jsweb/%s", name));
     }
@@ -348,6 +379,9 @@ public class HTML5Bundler implements IBundler {
                     if (binExtension.equals("js")) {
                         FileUtils.copyFile(bin, new File(appDir, enginePrefix + "_asmjs.js"));
                         AsmjsSize = bin.length();
+                        if (project.hasOption("with-sha1")) {
+                            AsmjsSHA1 = HTML5Bundler.calculateSHA1(bin);
+                        }
                     } else {
                         throw new RuntimeException("Unknown extension '" + binExtension + "' of engine binary.");
                     }
@@ -376,9 +410,15 @@ public class HTML5Bundler implements IBundler {
                     if (binExtension.equals("js")) {
                         FileUtils.copyFile(bin, new File(appDir, enginePrefix + "_wasm.js"));
                         WasmjsSize = bin.length();
+                        if (project.hasOption("with-sha1")) {
+                            WasmjsSHA1 = HTML5Bundler.calculateSHA1(bin);
+                        }
                     } else if (binExtension.equals("wasm")) {
                         FileUtils.copyFile(bin, new File(appDir, enginePrefix + ".wasm"));
                         WasmSize = bin.length();
+                        if (project.hasOption("with-sha1")) {
+                            WasmSHA1 = HTML5Bundler.calculateSHA1(bin);
+                        }
                     } else {
                         throw new RuntimeException("Unknown extension '" + binExtension + "' of engine binary.");
                     }
@@ -411,15 +451,15 @@ public class HTML5Bundler implements IBundler {
             toSplit.performSplit(targetDir);
             splitFiles.add(toSplit);
         }
-        createSplitFilesJson(splitFiles, targetDir);
+        createSplitFilesJson(splitFiles, targetDir, project.hasOption("with-sha1"));
     }
 
-    private void createSplitFilesJson(ArrayList<SplitFile> splitFiles, File targetDir) throws IOException {
+    private void createSplitFilesJson(ArrayList<SplitFile> splitFiles, File targetDir, boolean sha1) throws IOException {
+        File descFile = new File(targetDir, SplitFileJson);
         BufferedWriter writer = null;
         JsonGenerator generator = null;
         long totalSize = 0;
         try {
-            File descFile = new File(targetDir, SplitFileJson);
             writer = new BufferedWriter(new FileWriter(descFile));
             generator = (new JsonFactory()).createJsonGenerator(writer);
 
@@ -440,6 +480,9 @@ public class HTML5Bundler implements IBundler {
                 generator.close();
             }
             IOUtils.closeQuietly(writer);
+            if (sha1) {
+                SplitFileSHA1 = HTML5Bundler.calculateSHA1(descFile);
+            }
         }
     }
 }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/resources/jsweb/dmloader.js
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/resources/jsweb/dmloader.js
@@ -132,7 +132,7 @@ var CUSTOM_PARAMETERS = {
         game_canvas.width = Math.floor(width * dpi);
         game_canvas.height = Math.floor(height * dpi);
     }
-}
+};
 
 // file downloader
 // wraps XMLHttpRequest and adds retry support and progress updates when the
@@ -230,15 +230,19 @@ var FileLoader = {
         };
         request.onretry = function(xhr, event, loadedSize, currentAttempt) {
             onretry(loadedSize, currentAttempt);
-        }
+        };
         request.send();
     }
 };
 
 
 var EngineLoader = {
+    {{#DEFOLD_ARCHIVE_SHA1}}arc_sha1: "{{DEFOLD_ARCHIVE_SHA1}}",{{/DEFOLD_ARCHIVE_SHA1}}
+    {{#DEFOLD_WASM_SHA1}}wasm_sha1: "{{DEFOLD_WASM_SHA1}}",{{/DEFOLD_WASM_SHA1}}
     wasm_size: {{ DEFOLD_WASM_SIZE }},
-    wasmjs_size: {{ DEFOLD_WASMJS_SIZE}},
+    {{#DEFOLD_WASMJS_SHA1}}wasmjs_sha1: "{{DEFOLD_WASMJS_SHA1}}",{{/DEFOLD_WASMJS_SHA1}}
+    wasmjs_size: {{ DEFOLD_WASMJS_SIZE }},
+    {{#ASMJS_SHA1}}asmjs_sha1: "{{ASMJS_SHA1}}",{{/ASMJS_SHA1}}
     asmjs_size: {{ ASMJS_SIZE }},
     wasm_instantiate_progress: 0,
 
@@ -255,9 +259,16 @@ var EngineLoader = {
                 ProgressUpdater.updateCurrent(delta);
             },
             function(error) { throw error; },
-            function(wasm) {
+            async function(wasm) {
                 if (wasm.byteLength != EngineLoader.wasm_size) {
                    console.warn("Unexpected wasm size: " + wasm.byteLength + ", expected: " + EngineLoader.wasm_size);
+                }
+                if (EngineLoader.wasm_sha1) {
+                    const digest = await window.crypto.subtle.digest("SHA-1", wasm);
+                    const sha1 = Array.from(new Uint8Array(digest)).map(b => b.toString(16).padStart(2, '0')).join('');
+                    if (sha1 != EngineLoader.wasm_sha1) {
+                        console.warn("Unexpected wasm sha1: " + sha1 + ", expected: " + EngineLoader.wasm_sha1);
+                    }
                 }
                 var wasmInstantiate = WebAssembly.instantiate(new Uint8Array(wasm), imports).then(function(output) {
                     successCallback(output.instance);
@@ -316,21 +327,31 @@ var EngineLoader = {
             }
             return {}; // Compiling asynchronously, no exports.
         };
-        EngineLoader.loadAndRunScriptAsync(exeName + '_wasm.js');
+        EngineLoader.loadAndRunScriptAsync(exeName + '_wasm.js', EngineLoader.wasmjs_size, EngineLoader.wasmjs_sha1);
     },
 
     loadAsmJsAsync: function(exeName) {
-        EngineLoader.loadAndRunScriptAsync(exeName + '_asmjs.js');
+        EngineLoader.loadAndRunScriptAsync(exeName + '_asmjs.js', EngineLoader.asmjs_size, EngineLoader.asmjs_sha1);
     },
 
     // load and start engine script (asm.js or wasm.js)
-    loadAndRunScriptAsync: function(src) {
+    loadAndRunScriptAsync: function(src, expectedLength, expectedSHA1) {
         FileLoader.load(src, "text",
             function(delta) {
                 ProgressUpdater.updateCurrent(delta);
             },
             function(error) { throw error; },
-            function(response) {
+            async function(response) {
+                if (response.length != expectedLength) {
+                    console.warn("Unexpected JS size: " + response.length + ", expected: " + expectedLength);
+                }
+                if (expectedSHA1) {
+                    const digest = await window.crypto.subtle.digest("SHA-1", new TextEncoder().encode(response));
+                    const sha1 = Array.from(new Uint8Array(digest)).map(b => b.toString(16).padStart(2, '0')).join('');
+                    if (sha1 != expectedSHA1) {
+                        throw new Error("Unexpected sha1: " + sha1 + ", expected: " + expectedSHA1);
+                    }
+                }
                 var tag = document.createElement("script");
                 tag.text = response;
                 document.body.appendChild(tag);
@@ -361,14 +382,14 @@ var EngineLoader = {
         // move resize callback setup here to make possible to override callback
         // from outside of dmloader.js
         if (typeof CUSTOM_PARAMETERS["resize_window_callback"] === "function") {
-            var callback = CUSTOM_PARAMETERS["resize_window_callback"]
+            var callback = CUSTOM_PARAMETERS["resize_window_callback"];
             callback();
             window.addEventListener('resize', callback, false);
             window.addEventListener('orientationchange', callback, false);
             window.addEventListener('focus', callback, false);
         }        
     }
-}
+};
 
 
 /* ********************************************************************* */
@@ -413,7 +434,7 @@ var GameArchiveLoader = {
         list.push(callback);
     },
     notifyListeners: function(list, data) {
-        for (i=0; i<list.length; ++i) {
+        for (let i=0; i<list.length; ++i) {
             list[i](data);
         }
     },
@@ -421,8 +442,8 @@ var GameArchiveLoader = {
     addFileDownloadErrorListener: function(callback) {
         this.addListener(this._onFileDownloadErrorListeners, callback);
     },
-    notifyFileDownloadError: function(url) {
-        this.notifyListeners(this._onFileDownloadErrorListeners, url);
+    notifyFileDownloadError: function(error) {
+        this.notifyListeners(this._onFileDownloadErrorListeners, error);
     },
 
     addFileLoadedListener: function(callback) {
@@ -450,14 +471,29 @@ var GameArchiveLoader = {
     loadArchiveDescription: function(descriptionUrl) {
         FileLoader.load(
             this._archiveLocationFilter(descriptionUrl),
-            "json",
+            "text",
             function (delta) { },
             function (error) { GameArchiveLoader.notifyFileDownloadError(descriptionUrl); },
-            function (json) { GameArchiveLoader.onReceiveDescription(json); },
+            function (text) { GameArchiveLoader.onReceiveDescription(text); },
             function (loadedDelta, currentAttempt) { });
     },
 
-    onReceiveDescription: function(json) {
+    onReceiveDescription: async function(text) {
+        let json;
+        try {
+            json = JSON.parse(text);
+            if (EngineLoader.arc_sha1) {
+                const digest = await window.crypto.subtle.digest("SHA-1", text);
+                const sha1 = Array.from(new Uint8Array(digest)).map(b => b.toString(16).padStart(2, '0')).join('');
+                if (sha1 != EngineLoader.arc_sha1) {
+                    throw new Error(`Unexpected hash ${sha1} wanted ${EngineLoader.arc_sha1}`);
+                }
+            }
+        } catch (e) {
+            GameArchiveLoader.notifyFileDownloadError(e.toString());
+            return;
+        }
+
         var totalSize = json.total_size;
         var exeName = CUSTOM_PARAMETERS['exe_name'];
         this._files = json.content;
@@ -489,14 +525,14 @@ var GameArchiveLoader = {
             const path = `${DMSYS.GetUserPersistentDataRoot()}/${file.name}`;
             try { // see if already and stored
                 const stat = FS.stat(path);
-                if(stat) {
-                    let matches = (file.size == stat.size)
+                if (stat) {
+                    let matches = (file.size == stat.size);
                     if (matches && file.sha1) {
                         const stream = FS.open(path, "r");
-                        if(stream) {
+                        if (stream) {
                             try {
                                 const mmap = FS.mmap(stream, stat.size, 0, 0x01, 0x01); //PROT_READ, MAP_SHARED
-                                if(mmap) {
+                                if (mmap) {
                                     const digest = await window.crypto.subtle.digest("SHA-1", mmap);
                                     matches = Array.from(new Uint8Array(digest)).map(b => b.toString(16).padStart(2, '0')).join('') == file.sha1;
                                 }
@@ -568,7 +604,7 @@ var GameArchiveLoader = {
         } else if (1 == file.pieces.length) {
             file.data = piece.data;
         } else {
-            if(!file.data) {
+            if (!file.data) {
                file.data = new Uint8Array(file.size);
             }
             var start = piece.offset;
@@ -642,16 +678,16 @@ var GameArchiveLoader = {
                 }
             }
         }
-        if(file.sha1) {
+        if (file.sha1) {
             let data = file.data;
-            if(file.stream) {
+            if (file.stream) {
                 try {
                     data = FS.mmap(file.stream, file.size, 0, 0x01, 0x01); //PROT_READ, MAP_SHARED
                 } catch(e) { }
             }
             return window.crypto.subtle.digest("SHA-1", data).then((digest) => {
                 const sha1 = Array.from(new Uint8Array(digest)).map(b => b.toString(16).padStart(2, '0')).join('');
-                if(sha1 !== file.sha1)
+                if (sha1 !== file.sha1)
                     return Promise.reject(new Error(`Unexpected hash ${sha1} wanted ${file.sha1}`));
                 return;
             });
@@ -815,7 +851,7 @@ var Module = {
 
     isDMFSSupported: (function() {
         // DMFS is meant as a mount for FS to provide another way to acess resources, by default we just use IDBFS
-        if(typeof DMFS === "undefined")
+        if (typeof DMFS === "undefined")
             return false;
         return true;
     })(),
@@ -1067,13 +1103,13 @@ var Module = {
 
     preRun: [function() {
         /* If archive is loaded, preload all its files */
-        if(Module._archiveLoaded) {
+        if (Module._archiveLoaded) {
             Module.preloadAll();
         }
     }],
 
     postRun: [function() {
-        if(Module._archiveLoaded) {
+        if (Module._archiveLoaded) {
             ProgressView.removeProgress();
         } else if (Module['isDMFSSupported']) {
             // kick off the content download now that we have FS access
@@ -1158,7 +1194,7 @@ Module["locateFile"] = function(path, scriptDirectory)
 };
 
 {{^DEFOLD_HAS_WASM_ENGINE}}
-Module["isWASMSupported"] = false; 
+Module["isWASMSupported"] = false;
 {{/DEFOLD_HAS_WASM_ENGINE}}
 
 window.addEventListener("error", (errorEvent) => {


### PR DESCRIPTION
Second step to adding SHA1 authentication. This is lumped in `--with-sha1` and will add hash verification for .wasm, _wasm.js _asm.js and the split file .json in the dmloader.