### PR TITLE
Make miniz functions private

### DIFF
--- a/engine/dlib/src/test/test_zip.cpp
+++ b/engine/dlib/src/test/test_zip.cpp
@@ -25,6 +25,12 @@
 extern unsigned char FOO_ZIP[];
 extern uint32_t FOO_ZIP_SIZE;
 
+// If you get a duplicate here, then we've missed to put the "miniz.h" header within a namespace
+extern "C" void mz_free(void *p)
+{
+    free(p);
+}
+
 
 #define PATH_FORMAT "src/test/data/%s"
 

--- a/engine/dlib/src/zip/README.md
+++ b/engine/dlib/src/zip/README.md
@@ -1,3 +1,5 @@
 To update this folder:
 * go to https://github.com/kuba--/zip
 * Download miniz.h, zip.h and zip.c
+* Rename zip.c to zip.cpp
+* In miniz.h, remove the `extern "C"`, so that the functions will be private within zip.cpp

--- a/engine/dlib/src/zip/miniz.h
+++ b/engine/dlib/src/zip/miniz.h
@@ -267,7 +267,7 @@
 #endif
 
 #ifdef __cplusplus
-extern "C" {
+//extern "C" {
 #endif
 
 /* ------------------- zlib-style API Definitions. */
@@ -621,7 +621,7 @@ typedef void *const voidpc;
 #endif /* MINIZ_NO_ZLIB_APIS */
 
 #ifdef __cplusplus
-}
+//}
 #endif
 
 #pragma once
@@ -714,7 +714,7 @@ typedef struct mz_dummy_time_t_tag {
 #endif
 
 #ifdef __cplusplus
-extern "C" {
+//extern "C" {
 #endif
 
 extern MINIZ_EXPORT void *miniz_def_alloc_func(void *opaque, size_t items,
@@ -727,14 +727,14 @@ extern MINIZ_EXPORT void *miniz_def_realloc_func(void *opaque, void *address,
 #define MZ_UINT32_MAX (0xFFFFFFFFU)
 
 #ifdef __cplusplus
-}
+//}
 #endif
 #pragma once
 
 #ifndef MINIZ_NO_DEFLATE_APIS
 
 #ifdef __cplusplus
-extern "C" {
+//extern "C" {
 #endif
 /* ------------------- Low-level Compression API Definitions */
 
@@ -978,7 +978,7 @@ MINIZ_EXPORT void tdefl_compressor_free(tdefl_compressor *pComp);
 #endif
 
 #ifdef __cplusplus
-}
+//}
 #endif
 
 #endif /*#ifndef MINIZ_NO_DEFLATE_APIS*/
@@ -989,7 +989,7 @@ MINIZ_EXPORT void tdefl_compressor_free(tdefl_compressor *pComp);
 #ifndef MINIZ_NO_INFLATE_APIS
 
 #ifdef __cplusplus
-extern "C" {
+//extern "C" {
 #endif
 /* Decompression flags used by tinfl_decompress(). */
 /* TINFL_FLAG_PARSE_ZLIB_HEADER: If set, the input has a valid zlib header and
@@ -1180,7 +1180,7 @@ struct tinfl_decompressor_tag {
 };
 
 #ifdef __cplusplus
-}
+//}
 #endif
 
 #endif /*#ifndef MINIZ_NO_INFLATE_APIS*/
@@ -1192,7 +1192,7 @@ struct tinfl_decompressor_tag {
 #ifndef MINIZ_NO_ARCHIVE_APIS
 
 #ifdef __cplusplus
-extern "C" {
+//extern "C" {
 #endif
 
 enum {
@@ -1823,7 +1823,7 @@ MINIZ_EXPORT void *mz_zip_extract_archive_file_to_heap_v2(
 #endif /* #ifndef MINIZ_NO_ARCHIVE_WRITING_APIS */
 
 #ifdef __cplusplus
-}
+//}
 #endif
 
 #endif /* MINIZ_NO_ARCHIVE_APIS */
@@ -1860,7 +1860,7 @@ typedef unsigned char mz_validate_uint32[sizeof(mz_uint32) == 4 ? 1 : -1];
 typedef unsigned char mz_validate_uint64[sizeof(mz_uint64) == 8 ? 1 : -1];
 
 #ifdef __cplusplus
-extern "C" {
+//extern "C" {
 #endif
 
 /* ------------------- zlib-style API's */
@@ -2455,7 +2455,7 @@ const char *mz_error(int err) {
 #endif /*MINIZ_NO_ZLIB_APIS */
 
 #ifdef __cplusplus
-}
+//}
 #endif
 
 /*
@@ -2513,7 +2513,7 @@ const char *mz_error(int err) {
 #ifndef MINIZ_NO_DEFLATE_APIS
 
 #ifdef __cplusplus
-extern "C" {
+//extern "C" {
 #endif
 
 /* ------------------- Low-level Compression (independent from all decompression
@@ -4132,7 +4132,7 @@ void tdefl_compressor_free(tdefl_compressor *pComp) { MZ_FREE(pComp); }
 #endif
 
 #ifdef __cplusplus
-}
+//}
 #endif
 
 #endif /*#ifndef MINIZ_NO_DEFLATE_APIS*/
@@ -4165,7 +4165,7 @@ void tdefl_compressor_free(tdefl_compressor *pComp) { MZ_FREE(pComp); }
 #ifndef MINIZ_NO_INFLATE_APIS
 
 #ifdef __cplusplus
-extern "C" {
+//extern "C" {
 #endif
 
 /* ------------------- Low-level Decompression (completely independent from all
@@ -4902,7 +4902,7 @@ void tinfl_decompressor_free(tinfl_decompressor *pDecomp) { MZ_FREE(pDecomp); }
 #endif
 
 #ifdef __cplusplus
-}
+//}
 #endif
 
 #endif /*#ifndef MINIZ_NO_INFLATE_APIS*/
@@ -4936,7 +4936,7 @@ void tinfl_decompressor_free(tinfl_decompressor *pDecomp) { MZ_FREE(pDecomp); }
 #ifndef MINIZ_NO_ARCHIVE_APIS
 
 #ifdef __cplusplus
-extern "C" {
+//extern "C" {
 #endif
 
 /* ------------------- .ZIP archive reading */
@@ -10196,7 +10196,7 @@ mz_bool mz_zip_end(mz_zip_archive *pZip) {
 }
 
 #ifdef __cplusplus
-}
+//}
 #endif
 
 #endif /*#ifndef MINIZ_NO_ARCHIVE_APIS*/

--- a/engine/dlib/src/zip/zip.cpp
+++ b/engine/dlib/src/zip/zip.cpp
@@ -165,6 +165,7 @@ const char *zip_strerror(int errnum) {
   return zip_errlist[errnum];
 }
 
+#if defined(ZIP_USE_DEFLATE) // defold
 static const char *zip_basename(const char *name) {
   char const *p;
   char const *base = name += FILESYSTEM_PREFIX_LEN(name);
@@ -218,6 +219,7 @@ static int zip_mkpath(char *path) {
 
   return 0;
 }
+#endif
 
 static char *zip_strclone(const char *str, size_t n) {
   char c;
@@ -235,6 +237,7 @@ static char *zip_strclone(const char *str, size_t n) {
   return begin;
 }
 
+#if defined(ZIP_USE_DISC_IO) // defold
 static char *zip_strrpl(const char *str, size_t n, char oldchar, char newchar) {
   char c;
   size_t i;
@@ -301,7 +304,6 @@ static char *zip_name_normalize(char *name, char *const nname, size_t len) {
   return nname;
 }
 
-#if defined(ZIP_USE_DEFLATE) // defold
 static int zip_archive_truncate(mz_zip_archive *pzip) {
   mz_zip_internal_state *pState = pzip->m_pState;
   mz_uint64 file_size = pzip->m_archive_size;
@@ -455,6 +457,7 @@ static inline void zip_archive_finalize(mz_zip_archive *pzip) {
 #endif
 }
 
+#if defined(ZIP_USE_DEFLATE) // defold
 static ssize_t zip_entry_mark(struct zip_t *zip,
                               struct zip_entry_mark_t *entry_mark,
                               const size_t n, char *const entries[],
@@ -568,6 +571,7 @@ static ssize_t zip_entry_markbyindex(struct zip_t *zip,
   }
   return err;
 }
+
 static ssize_t zip_index_next(mz_uint64 *local_header_ofs_array,
                               ssize_t cur_index) {
   ssize_t new_index = 0, i;
@@ -872,7 +876,6 @@ static int zip_central_dir_delete(mz_zip_internal_state *pState,
   return 0;
 }
 
-#if defined(ZIP_USE_DEFLATE) // defold
 static ssize_t zip_entries_delete_mark(struct zip_t *zip,
                                        struct zip_entry_mark_t *entry_mark,
                                        int entry_num) {
@@ -1093,21 +1096,19 @@ static int _zip_entry_open(struct zip_t *zip, const char *entryname,
                            int case_sensitive) {
   size_t entrylen = 0;
   mz_zip_archive *pzip = NULL;
-  mz_uint num_alignment_padding_bytes, level;
   mz_zip_archive_file_stat stats;
   int err = 0;
-  mz_uint16 dos_time = 0, dos_date = 0;
-  mz_uint32 extra_size = 0;
 #if defined(ZIP_USE_DEFLATE) // defold
+  mz_uint32 extra_size = 0;
+  mz_uint num_alignment_padding_bytes, level;
+  mz_uint16 dos_time = 0, dos_date = 0;
   mz_uint8 extra_data[MZ_ZIP64_MAX_CENTRAL_EXTRA_FIELD_SIZE];
-#endif
   mz_uint64 local_dir_header_ofs = 0;
+#endif
 
   if (!zip) {
     return ZIP_ENOINIT;
   }
-
-  local_dir_header_ofs = zip->archive.m_archive_size;
 
   if (!entryname) {
     return ZIP_EINVENTNAME;
@@ -1160,6 +1161,8 @@ static int _zip_entry_open(struct zip_t *zip, const char *entryname,
 #if !defined(ZIP_USE_DEFLATE) // defold
   return ZIP_ENOFILE;
 #else
+
+  local_dir_header_ofs = zip->archive.m_archive_size;
 
   /*
     .ZIP File Format Specification Version: 6.3.3
@@ -1373,21 +1376,18 @@ int zip_entry_openbyindex(struct zip_t *zip, size_t index) {
 
 int zip_entry_close(struct zip_t *zip) {
   mz_zip_archive *pzip = NULL;
-  mz_uint level;
+  int err = 0;
 #if defined(ZIP_USE_DEFLATE) // defold
+  mz_uint level;
   tdefl_status done;
-#endif
   mz_uint16 entrylen;
   mz_uint16 dos_time = 0, dos_date = 0;
-  int err = 0;
   mz_uint8 *pExtra_data = NULL;
   mz_uint32 extra_size = 0;
-
-#if defined(ZIP_USE_DEFLATE) // defold
   mz_uint8 extra_data[MZ_ZIP64_MAX_CENTRAL_EXTRA_FIELD_SIZE];
-#endif
   mz_uint8 local_dir_footer[MZ_ZIP_DATA_DESCRIPTER_SIZE64];
   mz_uint32 local_dir_footer_size = MZ_ZIP_DATA_DESCRIPTER_SIZE64;
+#endif
 
   if (!zip) {
     // zip_t handler is not initialized


### PR DESCRIPTION
## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
