### PR TITLE
Add gamepad mapping for Core (Plus) Wired Controller

### DIFF
--- a/engine/engine/content/builtins/input/default.gamepads
+++ b/engine/engine/content/builtins/input/default.gamepads
@@ -5885,3 +5885,35 @@ driver
     map { input: GAMEPAD_GUIDE type: GAMEPAD_TYPE_BUTTON index: 16 }
     map { input: GAMEPAD_RAW type: GAMEPAD_TYPE_BUTTON index: 11 }
 }
+
+driver {
+  device: "Core (Plus) Wired Controller" # 3rd Party (PowerA) Nintendo Switch Pro Controller
+  platform: "osx"
+  dead_zone: 0.05
+  map { input: GAMEPAD_LSTICK_LEFT type: GAMEPAD_TYPE_AXIS index: 0 mod { mod: GAMEPAD_MODIFIER_NEGATE } mod { mod: GAMEPAD_MODIFIER_CLAMP } }
+  map { input: GAMEPAD_LSTICK_RIGHT type: GAMEPAD_TYPE_AXIS index: 0 mod { mod: GAMEPAD_MODIFIER_CLAMP } }
+  map { input: GAMEPAD_LSTICK_UP type: GAMEPAD_TYPE_AXIS index: 1 mod { mod: GAMEPAD_MODIFIER_NEGATE } mod { mod: GAMEPAD_MODIFIER_CLAMP } }
+  map { input: GAMEPAD_LSTICK_DOWN type: GAMEPAD_TYPE_AXIS index: 1 mod { mod: GAMEPAD_MODIFIER_CLAMP } }
+  map { input: GAMEPAD_RSTICK_LEFT type: GAMEPAD_TYPE_AXIS index: 2 mod { mod: GAMEPAD_MODIFIER_NEGATE } mod { mod: GAMEPAD_MODIFIER_CLAMP } }
+  map { input: GAMEPAD_RSTICK_RIGHT type: GAMEPAD_TYPE_AXIS index: 2 mod { mod: GAMEPAD_MODIFIER_CLAMP } }
+  map { input: GAMEPAD_RSTICK_UP type: GAMEPAD_TYPE_AXIS index: 5 mod { mod: GAMEPAD_MODIFIER_NEGATE } mod { mod: GAMEPAD_MODIFIER_CLAMP } }
+  map { input: GAMEPAD_RSTICK_DOWN type: GAMEPAD_TYPE_AXIS index: 5 mod { mod: GAMEPAD_MODIFIER_CLAMP } }
+  map { input: GAMEPAD_LPAD_UP type: GAMEPAD_TYPE_HAT index: 0 hat_mask: 1 }
+  map { input: GAMEPAD_LPAD_RIGHT type: GAMEPAD_TYPE_HAT index: 0 hat_mask: 2 }
+  map { input: GAMEPAD_LPAD_DOWN type: GAMEPAD_TYPE_HAT index: 0 hat_mask: 4 }
+  map { input: GAMEPAD_LPAD_LEFT type: GAMEPAD_TYPE_HAT index: 0 hat_mask: 8 }
+  map { input: GAMEPAD_RPAD_LEFT type: GAMEPAD_TYPE_BUTTON index: 0 }
+  map { input: GAMEPAD_RPAD_DOWN type: GAMEPAD_TYPE_BUTTON index: 1 }
+  map { input: GAMEPAD_RPAD_RIGHT type: GAMEPAD_TYPE_BUTTON index: 2 }
+  map { input: GAMEPAD_RPAD_UP type: GAMEPAD_TYPE_HAT index: 3 }
+  map { input: GAMEPAD_LSHOULDER type: GAMEPAD_TYPE_BUTTON index: 4 }
+  map { input: GAMEPAD_RSHOULDER type: GAMEPAD_TYPE_BUTTON index: 5 }
+  map { input: GAMEPAD_LTRIGGER type: GAMEPAD_TYPE_BUTTON index: 6 }
+  map { input: GAMEPAD_RTRIGGER type: GAMEPAD_TYPE_BUTTON index: 7 }
+  map { input: GAMEPAD_BACK type: GAMEPAD_TYPE_BUTTON index: 8 }
+  map { input: GAMEPAD_START type: GAMEPAD_TYPE_BUTTON index: 9 }
+  map { input: GAMEPAD_LSTICK_CLICK type: GAMEPAD_TYPE_BUTTON index: 10 }
+  map { input: GAMEPAD_RSTICK_CLICK type: GAMEPAD_TYPE_BUTTON index: 11 }
+  map { input: GAMEPAD_GUIDE type: GAMEPAD_TYPE_BUTTON index: 12 }
+  map { input: GAMEPAD_RAW type: GAMEPAD_TYPE_AXIS index: 0 }
+}


### PR DESCRIPTION
Add a mapping for the Core (Plus) Wired Controller to `builtins/input/default.gamepads`

Fixes #9888 

## PR checklist

* [x] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.
