### PR TITLE
Moved sound component to separate extension

### DIFF
--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -1253,9 +1253,6 @@ namespace dmEngine
         engine->m_TilemapContext.m_MaxTilemapCount  = dmConfigFile::GetInt(engine->m_Config, "tilemap.max_count", 16);
         engine->m_TilemapContext.m_MaxTileCount     = dmConfigFile::GetInt(engine->m_Config, "tilemap.max_tile_count", 2048);
 
-        engine->m_SoundContext.m_MaxComponentCount  = dmConfigFile::GetInt(engine->m_Config, "sound.max_component_count", 32);
-        engine->m_SoundContext.m_MaxSoundInstances  = dmConfigFile::GetInt(engine->m_Config, "sound.max_sound_instances", 256);
-
         engine->m_CollectionProxyContext.m_Factory = engine->m_Factory;
         engine->m_CollectionProxyContext.m_MaxCollectionProxyCount = dmConfigFile::GetInt(engine->m_Config, dmGameSystem::COLLECTION_PROXY_MAX_COUNT_KEY, 8);
 
@@ -1303,8 +1300,7 @@ namespace dmEngine
 
         go_result = dmGameSystem::RegisterComponentTypes(engine->m_Factory, engine->m_Register, engine->m_RenderContext, &engine->m_PhysicsContext, &engine->m_ParticleFXContext, &engine->m_SpriteContext,
                                                                                                 &engine->m_CollectionProxyContext, &engine->m_FactoryContext, &engine->m_CollectionFactoryContext,
-                                                                                                &engine->m_ModelContext, &engine->m_LabelContext, &engine->m_TilemapContext,
-                                                                                                &engine->m_SoundContext);
+                                                                                                &engine->m_ModelContext, &engine->m_LabelContext, &engine->m_TilemapContext);
         if (go_result != dmGameObject::RESULT_OK)
             goto bail;
 

--- a/engine/engine/src/engine_private.h
+++ b/engine/engine/src/engine_private.h
@@ -141,7 +141,6 @@ namespace dmEngine
         dmGameSystem::ModelContext                  m_ModelContext;
         dmGameSystem::LabelContext                  m_LabelContext;
         dmGameSystem::TilemapContext                m_TilemapContext;
-        dmGameSystem::SoundContext                  m_SoundContext;
         dmGameObject::ModuleContext                 m_ModuleContext;
 
         dmGameSystem::FontResource*                 m_SystemFont;

--- a/engine/engine/src/test/wscript
+++ b/engine/engine/src/test/wscript
@@ -64,7 +64,7 @@ def build(bld):
                              'ResourceTypeAnim', 'ResourceTypeAnimationSet', 'ResourceTypeGui', 'ResourceTypeGuiScript',
                              'ResourceProviderFile', 'ResourceProviderArchive', 'ResourceProviderArchiveMutable',
                              'ResourceTypeOgg','ResourceTypeWav']
-    component_type_symbols = ['ComponentTypeAnim', 'ComponentTypeScript', 'ComponentTypeGui', 'ComponentTypeMesh']
+    component_type_symbols = ['ComponentTypeAnim', 'ComponentTypeScript', 'ComponentTypeGui', 'ComponentTypeMesh', 'ComponentTypeSound']
     exported_symbols = ['ProfilerExt', 'GraphicsAdapterNull', 'ScriptModelExt']
 
     bld.add_group()

--- a/engine/engine/src/wscript
+++ b/engine/engine/src/wscript
@@ -61,7 +61,7 @@ def build(bld):
                              'ResourceTypeAnim', 'ResourceTypeAnimationSet', 'ResourceTypeGui', 'ResourceTypeGuiScript',
                              'ResourceTypeOgg', 'ResourceTypeWav',
                              'ResourceProviderFile', 'ResourceProviderArchive', 'ResourceProviderArchiveMutable', 'ResourceProviderZip']
-    component_type_symbols = ['ComponentTypeAnim', 'ComponentTypeScript', 'ComponentTypeGui', 'ComponentTypeMesh']
+    component_type_symbols = ['ComponentTypeAnim', 'ComponentTypeScript', 'ComponentTypeGui', 'ComponentTypeMesh', 'ComponentTypeSound']
 
     exported_symbols = ['DefaultSoundDevice', 'AudioDecoderWav', 'CrashExt', 'ProfilerExt', 'LiveUpdateExt', 'ScriptBox2DExt', 'ScriptImageExt', 'ScriptModelExt', 'ScriptTypesExt']
 

--- a/engine/gamesys/src/gamesys/components/comp_sound.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sound.cpp
@@ -140,7 +140,7 @@ namespace dmGameSystem
         return dmGameObject::CREATE_RESULT_OK;
     }
 
-    void* CompSoundGetComponent(const dmGameObject::ComponentGetParams& params)
+    static void* CompSoundGetComponent(const dmGameObject::ComponentGetParams& params)
     {
         SoundWorld* world = (SoundWorld*)params.m_World;
         return &world->m_Components.Get(params.m_UserData);

--- a/engine/gamesys/src/gamesys/components/comp_sound.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sound.cpp
@@ -613,6 +613,13 @@ namespace dmGameSystem
 
         return dmGameObject::RESULT_OK;
     }
+
+    dmGameObject::Result CompSoundcExit(const dmGameObject::ComponentTypeCreateCtx* ctx, dmGameObject::HComponentType type)
+    {
+        SoundContext* context = (SoundContext*)ComponentTypeGetContext(type);
+        delete context;
+        return dmGameObject::RESULT_OK;
+    }
 }
 
-DM_DECLARE_COMPONENT_TYPE(ComponentTypeSound, "soundc", dmGameSystem::CompSoundcInit, 0);
+DM_DECLARE_COMPONENT_TYPE(ComponentTypeSound, "soundc", dmGameSystem::CompSoundcInit, dmGameSystem::CompSoundcExit);

--- a/engine/gamesys/src/gamesys/components/comp_sound.h
+++ b/engine/gamesys/src/gamesys/components/comp_sound.h
@@ -19,7 +19,6 @@
 
 namespace dmGameSystem
 {
-    void* CompSoundGetComponent(const dmGameObject::ComponentGetParams& params);
 }
 
 #endif

--- a/engine/gamesys/src/gamesys/components/comp_sound.h
+++ b/engine/gamesys/src/gamesys/components/comp_sound.h
@@ -19,25 +19,7 @@
 
 namespace dmGameSystem
 {
-    dmGameObject::CreateResult CompSoundNewWorld(const dmGameObject::ComponentNewWorldParams& params);
-
-    dmGameObject::CreateResult CompSoundDeleteWorld(const dmGameObject::ComponentDeleteWorldParams& params);
-
-    dmGameObject::CreateResult CompSoundCreate(const dmGameObject::ComponentCreateParams& params);
-
-    dmGameObject::CreateResult CompSoundDestroy(const dmGameObject::ComponentDestroyParams& params);
-
-    dmGameObject::CreateResult CompSoundAddToUpdate(const dmGameObject::ComponentAddToUpdateParams& params);
-
-    dmGameObject::UpdateResult CompSoundUpdate(const dmGameObject::ComponentsUpdateParams& params, dmGameObject::ComponentsUpdateResult& update_result);
-
-    dmGameObject::UpdateResult CompSoundOnMessage(const dmGameObject::ComponentOnMessageParams& params);
-
-    dmGameObject::PropertyResult CompSoundGetProperty(const dmGameObject::ComponentGetPropertyParams& params, dmGameObject::PropertyDesc& out_value);
-
-    dmGameObject::PropertyResult CompSoundSetProperty(const dmGameObject::ComponentSetPropertyParams& params);
-
-    void*                       CompSoundGetComponent(const dmGameObject::ComponentGetParams& params);
+    void* CompSoundGetComponent(const dmGameObject::ComponentGetParams& params);
 }
 
 #endif

--- a/engine/gamesys/src/gamesys/gamesys.cpp
+++ b/engine/gamesys/src/gamesys/gamesys.cpp
@@ -67,7 +67,6 @@
 #include "components/comp_model.h"
 #include "components/comp_mesh.h"
 #include "components/comp_gui.h"
-#include "components/comp_sound.h"
 #include "components/comp_camera.h"
 #include "components/comp_factory.h"
 #include "components/comp_collection_factory.h"
@@ -146,8 +145,7 @@ namespace dmGameSystem
                                                 CollectionFactoryContext *collectionfactory_context,
                                                 ModelContext* model_context,
                                                 LabelContext* label_context,
-                                                TilemapContext* tilemap_context,
-                                                SoundContext* sound_context)
+                                                TilemapContext* tilemap_context)
     {
         HResourceType type;
         dmGameObject::ComponentType component_type;
@@ -230,14 +228,6 @@ namespace dmGameSystem
                 &CompCameraOnReload, CompCameraGetProperty, CompCameraSetProperty,
                 0, 0,
                 1);
-
-        REGISTER_COMPONENT_TYPE("soundc", 600, sound_context,
-                CompSoundNewWorld, CompSoundDeleteWorld,
-                CompSoundCreate, CompSoundDestroy, 0, 0, CompSoundAddToUpdate, CompSoundGetComponent,
-                CompSoundUpdate, 0, 0, 0, CompSoundOnMessage, 0,
-                0, CompSoundGetProperty, CompSoundSetProperty,
-                0, 0,
-                0);
 
         REGISTER_COMPONENT_TYPE("modelc", 700, model_context,
                 CompModelNewWorld, CompModelDeleteWorld,

--- a/engine/gamesys/src/gamesys/gamesys.h
+++ b/engine/gamesys/src/gamesys/gamesys.h
@@ -136,16 +136,6 @@ namespace dmGameSystem
         uint32_t                    m_MaxModelCount;
     };
 
-    struct SoundContext
-    {
-        SoundContext()
-        {
-            memset(this, 0, sizeof(*this));
-        }
-        uint32_t                    m_MaxComponentCount;
-        uint32_t                    m_MaxSoundInstances;
-    };
-
     struct ScriptLibContext
     {
         ScriptLibContext();
@@ -213,8 +203,7 @@ namespace dmGameSystem
                                                   CollectionFactoryContext *collectionfactory_context,
                                                   ModelContext* model_context,
                                                   LabelContext* label_context,
-                                                  TilemapContext* tilemap_context,
-                                                  SoundContext* sound_context);
+                                                  TilemapContext* tilemap_context);
 
     void OnWindowFocus(bool focus);
     void OnWindowIconify(bool iconfiy);

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -725,7 +725,11 @@ TEST_F(ComponentTest, ConsumeInputInCollectionProxy)
     dmGameObject::HInstance go_consume_no = Spawn(m_Factory, m_Collection, path_consume_no, hash_go_consume_no, 0, Point3(0, 0, 0), Quat(0, 0, 0, 1), Vector3(1, 1, 1));
     ASSERT_NE((void*)0, go_consume_no);
 
-    // Iteration 1: Handle proxy enable and input acquire messages from input_consume_no.script
+    // Iteration 1: Let script send the "enable" message
+    ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+    ASSERT_TRUE(dmGameObject::PostUpdate(m_Collection));
+
+    // Iteration 2: Handle proxy enable and input acquire messages from input_consume_sink.script
     ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
     ASSERT_TRUE(dmGameObject::PostUpdate(m_Collection));
 

--- a/engine/gamesys/src/gamesys/test/test_gamesys.h
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.h
@@ -134,7 +134,6 @@ protected:
     dmGameSystem::ModelContext m_ModelContext;
     dmGameSystem::LabelContext m_LabelContext;
     dmGameSystem::TilemapContext m_TilemapContext;
-    dmGameSystem::SoundContext m_SoundContext;
     dmRig::HRigContext m_RigContext;
     dmGameObject::ModuleContext m_ModuleContext;
     dmHashTable64<void*> m_Contexts;
@@ -603,9 +602,6 @@ void GamesysTest<T>::SetUp()
 
     dmBuffer::NewContext(); // ???
 
-    m_SoundContext.m_MaxComponentCount = 32;
-    m_SoundContext.m_MaxSoundInstances = 256;
-
     m_PhysicsContext.m_MaxCollisionCount = 64;
     m_PhysicsContext.m_MaxContactPointCount = 128;
     m_PhysicsContext.m_MaxCollisionObjectCount = 512;
@@ -626,7 +622,9 @@ void GamesysTest<T>::SetUp()
 
     assert(dmGameObject::RESULT_OK == dmGameSystem::RegisterComponentTypes(m_Factory, m_Register, m_RenderContext, &m_PhysicsContext, &m_ParticleFXContext, &m_SpriteContext,
                                                                                                     &m_CollectionProxyContext, &m_FactoryContext, &m_CollectionFactoryContext,
-                                                                                                    &m_ModelContext, &m_LabelContext, &m_TilemapContext, &m_SoundContext));
+                                                                                                    &m_ModelContext, &m_LabelContext, &m_TilemapContext));
+
+    dmGameObject::SortComponentTypes(m_Register);
 
     // TODO: Investigate why the ConsumeInputInCollectionProxy test fails if the components are actually sorted (the way they're supposed to)
     //dmGameObject::SortComponentTypes(m_Register);

--- a/engine/gamesys/src/gamesys/test/wscript
+++ b/engine/gamesys/src/gamesys/test/wscript
@@ -58,19 +58,22 @@ def build(bld):
         excl_pattern.append('**/*.cp')
         excl_pattern.append('**/*.compute')
 
-    exported_symbols = ['ResourceTypeGameObject',
-                        'ResourceTypeCollection',
-                        'ResourceTypeLua',
-                        'ResourceTypeScript',
-                        'ResourceProviderFile',
-                        'ComponentTypeScript',
-                        'ResourceTypeAnim',
-                        'ComponentTypeAnim',
-                        'ResourceTypeAnimationSet',
+    exported_symbols = ['ComponentTypeAnim',
                         'ComponentTypeGui',
                         'ComponentTypeMesh',
-                        'ResourceTypeGui','ResourceTypeGuiScript',
-                        'ResourceTypeOgg','ResourceTypeWav',
+                        'ComponentTypeScript',
+                        'ComponentTypeSound',
+                        'ResourceProviderFile',
+                        'ResourceTypeAnim',
+                        'ResourceTypeAnimationSet',
+                        'ResourceTypeCollection',
+                        'ResourceTypeGameObject',
+                        'ResourceTypeLua',
+                        'ResourceTypeScript',
+                        'ResourceTypeGui',
+                        'ResourceTypeGuiScript',
+                        'ResourceTypeOgg',
+                        'ResourceTypeWav',
                         'GraphicsAdapterNull',
                         'ScriptImageExt']
 


### PR DESCRIPTION
This change allows us to more easily update the properties that the sound component/resources may need. 
It als introduces the symbol `ComponentTypeSound` into the build system, which is another step towards being able to exclude components fully from the engine.

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
