### PR TITLE
Improved reverse hash implementation performance

### DIFF
--- a/engine/dlib/src/dlib/hash.cpp
+++ b/engine/dlib/src/dlib/hash.cpp
@@ -32,11 +32,16 @@ struct ReverseHashEntry
     uint16_t m_Length;
 };
 
+template<typename TABLE>
+static void IncreaseTableCapacity(TABLE* table, uint32_t increment)
+{
+    uint32_t capacity = table->Capacity() + increment;
+    table->SetCapacity((capacity*5)/7, capacity);
+}
+
 struct ReverseHashContainer
 {
-    static const size_t m_HashTableSize = 1024;
-    static const size_t m_HashTableCapacity = 512;
-    static const size_t m_HashTableCapacityIncrement = 256;
+    static const size_t m_HashTableCapacityIncrement = 16 * 1024;
     static const size_t m_HashStatesCapacity = 512;
     static const size_t m_HashStatesCapacityIncrement = 256;
 
@@ -81,12 +86,10 @@ struct ReverseHashContainer
 
         if(enable)
         {
-
-            if(m_HashTable32Entries.Capacity() < m_HashTableCapacity)
-                m_HashTable32Entries.SetCapacity(m_HashTableSize, m_HashTableCapacity);
-            m_HashTable32Entries.Clear();
-            if(m_HashTable64Entries.Capacity() < m_HashTableCapacity)
-                m_HashTable64Entries.SetCapacity(m_HashTableSize, m_HashTableCapacity);
+            if (m_HashTable32Entries.Full())
+                IncreaseTableCapacity(&m_HashTable32Entries, m_HashTableCapacityIncrement);
+            if (m_HashTable64Entries.Full())
+                IncreaseTableCapacity(&m_HashTable64Entries, m_HashTableCapacityIncrement);
             m_HashTable64Entries.Clear();
             m_HashStates.SetCapacity(m_HashStatesCapacity);
             m_HashStates.SetSize(m_HashStatesCapacity);
@@ -234,7 +237,7 @@ uint32_t dmHashBuffer32(const void * key, uint32_t len)
         {
             if (hash_table->Full())
             {
-                hash_table->SetCapacity(dmHashContainer().m_HashTableSize, hash_table->Capacity() + dmHashContainer().m_HashTableCapacityIncrement);
+                IncreaseTableCapacity(hash_table, dmHashContainer().m_HashTableCapacityIncrement);
             }
             char* copy = (char*) malloc(len + 1);
             memcpy(copy, key, len);
@@ -311,7 +314,7 @@ uint64_t dmHashBuffer64(const void * key, uint32_t len)
         {
             if (hash_table->Full())
             {
-                hash_table->SetCapacity(dmHashContainer().m_HashTableSize, hash_table->Capacity() + dmHashContainer().m_HashTableCapacityIncrement);
+                IncreaseTableCapacity(hash_table, dmHashContainer().m_HashTableCapacityIncrement);
             }
             char* copy = (char*) malloc(len + 1);
             memcpy(copy, key, len);
@@ -438,7 +441,7 @@ uint32_t dmHashFinal32(HashState32* hash_state)
         {
             if (hash_table->Full())
             {
-                hash_table->SetCapacity(dmHashContainer().m_HashTableSize, hash_table->Capacity() + dmHashContainer().m_HashTableCapacityIncrement);
+                IncreaseTableCapacity(hash_table, dmHashContainer().m_HashTableCapacityIncrement);
             }
             hash_table->Put(hash_state->m_Hash, dmHashContainer().m_HashStates[hash_state->m_ReverseHashEntryIndex]);
         }
@@ -574,7 +577,7 @@ uint64_t dmHashFinal64(HashState64* hash_state)
         {
             if (hash_table->Full())
             {
-                hash_table->SetCapacity(dmHashContainer().m_HashTableSize, hash_table->Capacity() + dmHashContainer().m_HashTableCapacityIncrement);
+                IncreaseTableCapacity(hash_table, dmHashContainer().m_HashTableCapacityIncrement);
             }
             hash_table->Put(hash_state->m_Hash, dmHashContainer().m_HashStates[hash_state->m_ReverseHashEntryIndex]);
         }

--- a/engine/dlib/src/test/test_dlib.cpp
+++ b/engine/dlib/src/test/test_dlib.cpp
@@ -20,6 +20,7 @@
 #include <jc_test/jc_test.h>
 #include "../dlib/hash.h"
 #include "../dlib/log.h"
+#include "../dlib/time.h"
 
 class dlib : public jc_test_base_class
 {
@@ -493,6 +494,52 @@ TEST_F(dlib, HashMaxReverse)
 
     free((void*) buffer);
 }
+
+TEST_F(dlib, HashReverseStress)
+{
+    // Make sure creating many reverse hashes doesn't take too much time
+    uint32_t count_small = 1000;
+    uint32_t count_large = 100000;
+
+    uint64_t tsmall_start = dmTime::GetMonotonicTime();
+    for(uint32_t i = 0; i < count_small; ++i)
+    {
+        uint64_t h = dmHashBuffer64(&i, sizeof(i));
+
+        uint32_t* rh = (uint32_t*)dmHashReverse64(h, 0);
+
+        ASSERT_NE((uint32_t*)0, rh);
+        ASSERT_EQ(i, *rh);
+    }
+    uint64_t tsmall_end = dmTime::GetMonotonicTime();
+    float time_small = (tsmall_end - tsmall_start)/1000000.0f;
+
+    printf("Hash + reverse lookup of %u items took %f s\n", count_small, time_small);
+    // The complexity goes up
+    float multiplier = 3.0f;
+    float expected_time = multiplier * (time_small * (count_large / count_small));
+    printf("Hash + reverse lookup of %u items x %f %%: ca %f s\n", count_large, multiplier*100.0f, expected_time);
+
+    uint64_t tlarge_start = dmTime::GetMonotonicTime();
+    for(uint32_t i = 0; i < count_large; ++i)
+    {
+        uint64_t h = dmHashBuffer64(&i, sizeof(i));
+
+        uint32_t* rh = (uint32_t*)dmHashReverse64(h, 0);
+
+        ASSERT_NE((uint32_t*)0, rh);
+        ASSERT_EQ(i, *rh);
+    }
+    uint64_t tlarge_end = dmTime::GetMonotonicTime();
+
+    float time_large = (tlarge_end - tlarge_start)/1000000.0f;
+
+    printf("Hash + reverse lookup of %u items took %f s\n", count_large, time_large);
+
+    ASSERT_GE(expected_time, time_large);
+
+}
+
 
 TEST_F(dlib, HashIncrementalReverse)
 {

--- a/engine/dlib/src/test/test_dlib.cpp
+++ b/engine/dlib/src/test/test_dlib.cpp
@@ -516,7 +516,7 @@ TEST_F(dlib, HashReverseStress)
 
     printf("Hash + reverse lookup of %u items took %f s\n", count_small, time_small);
     // The complexity goes up
-    float multiplier = 3.0f;
+    float multiplier = 4.0f;
     float expected_time = multiplier * (time_small * (count_large / count_small));
     printf("Hash + reverse lookup of %u items x %f %%: ca %f s\n", count_large, multiplier*100.0f, expected_time);
 


### PR DESCRIPTION
### Technical changes

Previously, the internal table storage was increased in an unbalanced manner.
Now the table/capacity ratio suits the table implementation better.
Also, the performance was also hindered by many small allocations, so we now do larger allocations each time, further improving performance.

Comparisons (hashing a uint32 and doing the reverse lookup)
```
now:   Hash + reverse lookup of 100000 items took 0.032221 s
prev:  Hash + reverse lookup of 100000 items took 4.7  s
```
Which is roughly 145x speed boost.


## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
