### PR TITLE
Added response.url to http requests and progress callbacks

### DIFF
--- a/engine/gamesys/src/gamesys/scripts/script_http.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_http.cpp
@@ -309,6 +309,7 @@ namespace dmGameSystem
 
             g_Service = dmHttpService::New(&params);
             dmScript::RegisterDDFDecoder(dmHttpDDF::HttpResponse::m_DDFDescriptor, &HttpResponseDecoder);
+            dmScript::RegisterDDFDecoder(dmHttpDDF::HttpRequestProgress::m_DDFDescriptor, &HttpRequestProgressDecoder);
         }
 
         if (config_file)

--- a/engine/gamesys/src/gamesys/scripts/script_http_js.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_http_js.cpp
@@ -54,6 +54,7 @@ namespace dmGameSystem
         dmMessage::URL  m_Requester;
         void*           m_RequestData;
         const char*     m_Path;
+        const char*     m_Url;  // The request url
         int             m_Callback;
     };
 
@@ -87,10 +88,8 @@ namespace dmGameSystem
         dmHttpDDF::HttpResponse* response = (dmHttpDDF::HttpResponse*)message->m_Data;
         free((void*) response->m_Headers);
         free((void*) response->m_Response);
-        if (response->m_Path)
-        {
-            free((void*) response->m_Path);
-        }
+        free((void*) response->m_Path);
+        free((void*) response->m_Url);
     }
 
     static void SendResponse(const RequestContext* ctx, int status,
@@ -104,6 +103,7 @@ namespace dmGameSystem
         resp.m_Response = (uint64_t) response;
         resp.m_ResponseLength = response_length;
         resp.m_Path = ctx->m_Path;
+        resp.m_Url = ctx->m_Url;
 
         resp.m_Headers = (uint64_t) malloc(headers_length);
         memcpy((void*) resp.m_Headers, headers, headers_length);
@@ -114,10 +114,8 @@ namespace dmGameSystem
         {
             free((void*) resp.m_Headers);
             free((void*) resp.m_Response);
-            if (resp.m_Path)
-            {
-                free((void*) resp.m_Path);
-            }
+            free((void*) resp.m_Path);
+            free((void*) resp.m_Url);
             dmLogWarning("Failed to return http-response. Requester deleted?");
         }
     }
@@ -229,15 +227,8 @@ namespace dmGameSystem
             ctx->m_Callback = callback;
             ctx->m_Requester = sender;
             ctx->m_RequestData = request_params.m_SendData;
-            ctx->m_Path = 0;
-            if (path)
-            {
-                size_t length = strlen(path) + 1;
-                char *path_val = (char *)malloc(length);
-                memcpy(path_val, path, length);
-                path_val[length] = '\0';
-                ctx->m_Path = path_val;
-            }
+            ctx->m_Path = path ? strdup(path) : 0;
+            ctx->m_Url = request_params.m_Url ? strdup(request_params.m_Url) : 0;
 
             request_params.m_Args = ctx;
 

--- a/engine/gamesys/src/gamesys/scripts/script_http_util.h
+++ b/engine/gamesys/src/gamesys/scripts/script_http_util.h
@@ -78,6 +78,12 @@ namespace dmGameSystem
             lua_setfield(L, -2, "response");
         }
 
+        if (resp->m_Url)
+        {
+            lua_pushstring(L, resp->m_Url);
+            lua_setfield(L, -2, "url");
+        }
+
         lua_pushliteral(L, "headers");
         lua_newtable(L);
         if (resp->m_HeadersLength > 0) {
@@ -111,6 +117,12 @@ namespace dmGameSystem
         }
         lua_rawset(L, -3);
 
+        return dmScript::RESULT_OK;
+    }
+
+    dmScript::Result HttpRequestProgressDecoder(lua_State* L, const dmDDF::Descriptor* desc, const char* data)
+    {
+        dmScript::PushDDFNoDecoder(L, desc, (const char*)data, false);
         return dmScript::RESULT_OK;
     }
 }

--- a/engine/script/src/dmsdk/script/script.h
+++ b/engine/script/src/dmsdk/script/script.h
@@ -462,7 +462,7 @@ namespace dmScript
      * @param L [type: lua_State*] the Lua state
      * @param descriptor [type: const dmDDF::Descriptor*] field descriptor
      * @param data [type: const char*] the message data (i.e. the message struct)
-     * @param pointers_are_offets [type: bool] True if pointers are offsets
+     * @param pointers_are_offsets [type: bool] True if pointers are offsets
      */
     void PushDDF(lua_State*L, const dmDDF::Descriptor* descriptor, const char* data, bool pointers_are_offsets);
 

--- a/engine/script/src/dmsdk/script/script.h
+++ b/engine/script/src/dmsdk/script/script.h
@@ -461,8 +461,8 @@ namespace dmScript
      * Push DDF message to Lua stack
      * @param L [type: lua_State*] the Lua state
      * @param descriptor [type: const dmDDF::Descriptor*] field descriptor
-     * @param pointers_are_offets [type: bool] True if pointers are offsets
      * @param data [type: const char*] the message data (i.e. the message struct)
+     * @param pointers_are_offets [type: bool] True if pointers are offsets
      */
     void PushDDF(lua_State*L, const dmDDF::Descriptor* descriptor, const char* data, bool pointers_are_offsets);
 

--- a/engine/script/src/http_service.cpp
+++ b/engine/script/src/http_service.cpp
@@ -101,6 +101,7 @@ namespace dmHttpService
         h.Push('\n');
     }
 
+    // Called from the http thread(s)
     void HttpContent(dmHttpClient::HResponse response, void* user_data, int status_code, const void* content_data, uint32_t content_data_size, int32_t content_length, const char* method)
     {
         Worker* worker = (Worker*) user_data;
@@ -135,6 +136,7 @@ namespace dmHttpService
             dmHttpDDF::HttpRequestProgress progress = {};
             progress.m_BytesReceived                = bytes_received;
             progress.m_BytesTotal                   = content_length;
+            progress.m_Url                          = worker->m_Request->m_Url;
             worker->m_Service->m_ReportProgressCallback(&progress, &worker->m_CurrentRequesterURL, worker->m_ResponseUserData2);
         }
     }
@@ -207,6 +209,7 @@ namespace dmHttpService
     static void SendResponse(const dmMessage::URL* requester, uintptr_t userdata1, uintptr_t userdata2, int status,
                              const char* headers, uint32_t headers_length,
                              const char* response, uint32_t response_length,
+                             const char* url,
                              const char* filepath)
     {
         dmHttpDDF::HttpResponse resp;
@@ -219,6 +222,7 @@ namespace dmHttpService
         resp.m_Response = (uint64_t) malloc(response_length);
         memcpy((void*) resp.m_Response, response, response_length);
         resp.m_Path = filepath;
+        resp.m_Url = url;
 
         if (dmMessage::RESULT_OK != dmMessage::Post(0, requester, dmHttpDDF::HttpResponse::m_DDFHash, userdata1, userdata2, (uintptr_t) dmHttpDDF::HttpResponse::m_DDFDescriptor, &resp, sizeof(resp), MessageDestroyCallback) )
         {
@@ -236,7 +240,7 @@ namespace dmHttpService
         dmURI::Result ur =  dmURI::Parse(request->m_Url, &url);
         if (ur != dmURI::RESULT_OK)
         {
-            SendResponse(requester, 0, 0, 0, 0, 0, 0, 0, 0);
+            SendResponse(requester, 0, 0, 0, 0, 0, 0, 0, worker->m_Request->m_Url, 0);
             return;
         }
         if (url.m_Path[0] == '\0') {
@@ -290,15 +294,15 @@ namespace dmHttpService
             dmHttpClient::Result r = dmHttpClient::Request(worker->m_Client, request->m_Method, url.m_Path);
 
             if (r == dmHttpClient::RESULT_OK || r == dmHttpClient::RESULT_NOT_200_OK) {
-                SendResponse(requester, userdata1, userdata2, worker->m_Status, worker->m_Headers.Begin(), worker->m_Headers.Size(), worker->m_Response.Begin(), worker->m_Response.Size(), worker->m_Filepath);
+                SendResponse(requester, userdata1, userdata2, worker->m_Status, worker->m_Headers.Begin(), worker->m_Headers.Size(), worker->m_Response.Begin(), worker->m_Response.Size(), worker->m_Request->m_Url, worker->m_Filepath);
             } else {
                 // TODO: Error codes to lua?
                 dmLogError("HTTP request to '%s' failed (http result: %d  socket result: %d)", request->m_Url, r, GetLastSocketResult(worker->m_Client));
-                SendResponse(requester, userdata1, userdata2, 0, worker->m_Headers.Begin(), worker->m_Headers.Size(), worker->m_Response.Begin(), worker->m_Response.Size(), worker->m_Filepath);
+                SendResponse(requester, userdata1, userdata2, 0, worker->m_Headers.Begin(), worker->m_Headers.Size(), worker->m_Response.Begin(), worker->m_Response.Size(), worker->m_Request->m_Url, worker->m_Filepath);
             }
         } else {
             // TODO: Error codes to lua?
-            SendResponse(requester, userdata1, userdata2, 0, worker->m_Headers.Begin(), worker->m_Headers.Size(), worker->m_Response.Begin(), worker->m_Response.Size(), worker->m_Filepath);
+            SendResponse(requester, userdata1, userdata2, 0, worker->m_Headers.Begin(), worker->m_Headers.Size(), worker->m_Response.Begin(), worker->m_Response.Size(), worker->m_Request->m_Url, worker->m_Filepath);
             dmLogError("Unable to create HTTP connection to '%s'. No route to host?", request->m_Url);
         }
     }

--- a/engine/script/src/script.h
+++ b/engine/script/src/script.h
@@ -115,7 +115,7 @@ namespace dmScript
      * @param L lua state
      * @param name_hash the hash of the name returned by SetGlobal
      */
-    void GetGlobal(lua_State*L, uint32_t name_hash);
+    void GetGlobal(lua_State* L, uint32_t name_hash);
 
     /**
      * Use a ScriptExtension to hook into various callbacks of the script lifetime
@@ -263,8 +263,18 @@ namespace dmScript
      * @param L Lua state
      * @param descriptor Field descriptor
      * @param data DDF data
+     * @param pointers_are_offets True if pointers are offsets
      */
-    void PushDDF(lua_State*L, const dmDDF::Descriptor* descriptor, const char* data);
+    void PushDDFNoDecoder(lua_State* L, const dmDDF::Descriptor* descriptor, const char* data, bool pointers_are_offsets);
+
+    /**
+     * Push DDF message to Lua stack. Invokes any registered decoder
+     * @note the pointers_are_offsets is set as false
+     * @param L Lua state
+     * @param descriptor Field descriptor
+     * @param data DDF data
+     */
+    void PushDDF(lua_State* L, const dmDDF::Descriptor* descriptor, const char* data);
 
     void RegisterDDFDecoder(void* descriptor, MessageDecoder decoder);
 

--- a/engine/script/src/script/http_ddf.proto
+++ b/engine/script/src/script/http_ddf.proto
@@ -44,6 +44,7 @@ message HttpRequestProgress
     required uint32 bytes_sent     = 1;
     required uint32 bytes_received = 2;
     required uint32 bytes_total    = 3;
+    optional string url            = 4;
 }
 
 message HttpResponse
@@ -65,5 +66,6 @@ message HttpResponse
     required uint64 response        = 4;
     required uint32 response_length = 5;
 
-    required string path            = 6;
+    required string path            = 6; // Path on disc where the response is written to
+    required string url             = 7;
 }

--- a/engine/script/src/script_ddf.cpp
+++ b/engine/script/src/script_ddf.cpp
@@ -576,34 +576,40 @@ namespace dmScript
         }
     }
 
-    void PushDDF(lua_State*L, const dmDDF::Descriptor* d, const char* data)
+    void PushDDFNoDecoder(lua_State* L, const dmDDF::Descriptor* d, const char* data, bool pointers_are_offsets)
     {
+        uintptr_t pointers_offset = 0;
+        if (pointers_are_offsets)
+            pointers_offset = (uintptr_t) data;
+
+        lua_newtable(L);
+        for (uint32_t i = 0; i < d->m_FieldCount; ++i)
+        {
+            const dmDDF::FieldDescriptor* f = &d->m_Fields[i];
+
+            lua_pushstring(L, f->m_Name);
+            DDFToLuaValue(L, &d->m_Fields[i], data, pointers_offset);
+            lua_rawset(L, -3);
+        }
+
+    }
+
+    void PushDDF(lua_State* L, const dmDDF::Descriptor* d, const char* data)
+    {
+        // TODO: Can/should we use the decoders here too?
         PushDDF(L, d, data, false);
     }
 
-    void PushDDF(lua_State*L, const dmDDF::Descriptor* d, const char* data, bool pointers_are_offsets)
+    void PushDDF(lua_State* L, const dmDDF::Descriptor* d, const char* data, bool pointers_are_offsets)
     {
         MessageDecoder* decoder = g_Decoders.Get((uintptr_t) d);
         if (decoder) {
-            Result r = (*decoder)(L, d, data);
+            Result r = (*decoder)(L, d, data); // May call PushDDFNoDecoder with different value on pointers_are_offsets
             if (r != RESULT_OK) {
                 luaL_error(L, "Failed to decode %s message (%d)", d->m_Name, r);
             }
         } else {
-            uintptr_t pointers_offset = 0;
-
-            if (pointers_are_offsets)
-                pointers_offset = (uintptr_t) data;
-
-            lua_newtable(L);
-            for (uint32_t i = 0; i < d->m_FieldCount; ++i)
-            {
-                const dmDDF::FieldDescriptor* f = &d->m_Fields[i];
-
-                lua_pushstring(L, f->m_Name);
-                DDFToLuaValue(L, &d->m_Fields[i], data, pointers_offset);
-                lua_rawset(L, -3);
-            }
+            PushDDFNoDecoder(L, d, data, pointers_are_offsets);
         }
     }
 


### PR DESCRIPTION
This allows the developer to get the url back in the callback, using the `response.url` variable.

Fixes https://github.com/defold/defold/issues/9959

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
