### PR TITLE
Fix paths to Clang for Linux CI

### DIFF
--- a/build_tools/sdk.py
+++ b/build_tools/sdk.py
@@ -117,10 +117,10 @@ defold_info['win10sdk']['version'] = VERSION_WINDOWS_SDK_10
 defold_info['win10sdk']['pattern'] = "Win32/%s" % PACKAGES_WIN32_SDK_10
 
 defold_info['x86_64-linux']['version'] = VERSION_LINUX_CLANG
-defold_info['x86_64-linux']['pattern'] = 'linux/clang-%s' % VERSION_LINUX_CLANG
+defold_info['x86_64-linux']['pattern'] = 'x86_64-linux/clang-%s' % VERSION_LINUX_CLANG
 
 defold_info['arm64-linux']['version'] = VERSION_LINUX_CLANG
-defold_info['arm64-linux']['pattern'] = 'linux/clang-%s' % VERSION_LINUX_CLANG
+defold_info['arm64-linux']['pattern'] = 'arm64-linux/clang-%s' % VERSION_LINUX_CLANG
 
 ## **********************************************************************************************
 


### PR DESCRIPTION
This PR fixes paths to Clang for Linux CI, i.e. Github CI scripts will use the correct version of Clang:
```
Checking for program 'ccache'            : not found 
Checking for program 'clang'             : /examplepath/tmp/dynamo_home/ext/SDKs/x86_64-linux/clang-16.0.0/bin/clang 
Checking for 'clang' (C compiler)        : /examplepath/tmp/dynamo_home/ext/SDKs/x86_64-linux/clang-16.0.0/bin/clang 
Checking for 'clang++' (C++ compiler)    : /examplepath/tmp/dynamo_home/ext/SDKs/x86_64-linux/clang-16.0.0/bin/clang++ 
```

Fixes #9994

### Technical changes
* Please assign the "skip release notes" is the PR should not be included in the generated release notes.

