### PR TITLE
Fixing up timing or EOS status return for streamed sound resources and tremolo specific reinit on loop. Fixes #9968

### DIFF
--- a/engine/gamesys/src/gamesys/resources/res_sound_data.cpp
+++ b/engine/gamesys/src/gamesys/resources/res_sound_data.cpp
@@ -217,9 +217,9 @@ namespace dmGameSystem
         }
 
         dmSound::Result result = dmSound::RESULT_PARTIAL_DATA;
-        if (offset >= resource->m_FileSize)
+        if (offset >= resource->m_FileSize && nread == 0)
         {
-            // we just read the last chunk
+            // we cannot return any data as we reached the end of the resource
             result = dmSound::RESULT_END_OF_STREAM;
         }
 


### PR DESCRIPTION
EOS return code could have been returned on last (partial) read and not on first read at the end of the resource. This in turn confused the logic in the decoder code, resulting in samples at the end of the resource not being decoded properly at at times.

This also affects non-looped playback.

This bug was not present for playback of in-memory resources.