### PR TITLE
Remove argument to --tc

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/util/TimeProfilerTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/util/TimeProfilerTest.java
@@ -29,7 +29,7 @@ public class TimeProfilerTest {
                 "--root", cwd + "/test/time_profiler_project",
                 "--build-report-json", jsonReport.toString(),
                 "--build-report-html", htmlReport.toString(),
-                "--texture-compression", "true",
+                "--texture-compression",
                 "--strip-executable",
                 "--verbose",
                 "--variant", "release",

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Bob.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Bob.java
@@ -613,7 +613,7 @@ public class Bob {
     private static String[] migrateInvalidArguments(String[] args) {
         ArrayList<String> migratedArguments = new ArrayList<>();
         for (String arg : args) {
-            // Migrate texture compression argument
+            // Migrate texture compression argument. Deprecated in 1.9.7 (https://github.com/defold/defold/pull/10000)
             boolean argIsTextureCompression = arg.startsWith("--tc") || arg.startsWith("--texture-compression");
             if (argIsTextureCompression && arg.contains("=false")) {
                 System.out.println("Warning: --texture-compression and --tc no longer accepts an argument. To disable texture compression, remove the argument.");

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Bob.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Bob.java
@@ -560,7 +560,7 @@ public class Bob {
                 opt(null, "with-symbols", ZERO, "Generate the symbol file (if applicable)", false),
 
                 opt("tp", "texture-profiles", ONE, "DEPRECATED! Use --texture-compression instead", true),
-                opt("tc", "texture-compression", ONE, "Use texture compression as specified in texture profiles", true),
+                opt("tc", "texture-compression", ZERO, "Use texture compression as specified in texture profiles", true),
 
                 opt(null, "exclude-build-folder", ONE, "DEPRECATED! Use '.defignore' file instead", true),
 

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Bob.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Bob.java
@@ -608,8 +608,20 @@ public class Bob {
                 opt(null, "debug-output-spirv", ONE, "Force build SPIR-V shaders", false),
                 opt(null, "debug-output-wgsl", ONE, "Force build WGSL shaders", false)
         );
+    }
 
-
+    private static String[] migrateInvalidArguments(String[] args) {
+        ArrayList<String> migratedArguments = new ArrayList<>();
+        for (String arg : args) {
+            // Migrate texture compression argument
+            boolean argIsTextureCompression = arg.startsWith("--tc") || arg.startsWith("--texture-compression");
+            if (argIsTextureCompression && arg.contains("=false")) {
+                System.out.println("Warning: --texture-compression and --tc no longer accepts an argument. To disable texture compression, remove the argument.");
+            } else {
+                migratedArguments.add(arg);
+            }
+        }
+        return migratedArguments.toArray(new String[0]);
     }
 
     private static CommandLine parse(String[] args) throws OptionValidationException {
@@ -618,6 +630,9 @@ public class Bob {
 
         CommandLineParser parser = new PosixParser();
         CommandLine cmd;
+
+        args = migrateInvalidArguments(args);
+
         try {
             cmd = parser.parse(options, args);
         } catch (ParseException e) {
@@ -941,7 +956,7 @@ public class Bob {
                 System.out.println("WARNING option 'texture-profiles' is deprecated, use option 'texture-compression' instead.");
                 String texCompression = cmd.getOptionValue("texture-profiles");
                 if (cmd.hasOption("texture-compression")) {
-                    texCompression = cmd.getOptionValue("texture-compression");
+                    texCompression = "true";
                 }
                 project.setOption("texture-compression", texCompression);
             }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
@@ -1725,9 +1725,6 @@ public class Project {
         }
 
         boolean texture_compress = this.option("texture-compression", "false").equals("true");
-
-        System.out.println("Has texture compression? " + texture_compress);
-
         if (texture_compress)
         {
             registerTextureCompressors();

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
@@ -1725,6 +1725,9 @@ public class Project {
         }
 
         boolean texture_compress = this.option("texture-compression", "false").equals("true");
+
+        System.out.println("Has texture compression? " + texture_compress);
+
         if (texture_compress)
         {
             registerTextureCompressors();

--- a/editor/src/clj/editor/pipeline/bob.clj
+++ b/editor/src/clj/editor/pipeline/bob.clj
@@ -285,21 +285,21 @@
               (.isDirectory output-directory)))
   (assert (string? (not-empty platform)))
   (let [build-server-url (native-extensions/get-build-server-url prefs project)
-        editor-texture-compression (if (prefs/get prefs [:build :texture-compression]) "true" "false")
+        editor-texture-compression? (prefs/get prefs [:build :texture-compression])
         build-report-path (.getAbsolutePath (io/file output-directory "report.html"))
         bundle-output-path (.getAbsolutePath output-directory)
         defold-sdk-sha1 (or (system/defold-engine-sha1) "")
-        strip-executable? (= "release" variant)]
+        strip-executable? (= "release" variant)
+        texture-compression? (case texture-compression
+                               "enabled" true
+                               "disabled" false
+                               "editor" editor-texture-compression?)]
     (cond-> {"platform" platform
              "variant" variant
 
              ;; From AbstractBundleHandler
              (if bundle-contentless? "exclude-archive" "archive") true
              "bundle-output" bundle-output-path
-             "texture-compression" (case texture-compression
-                                     "enabled" "true"
-                                     "disabled" "false"
-                                     "editor" editor-texture-compression)
 
              ;; From BundleGenericHandler
              "build-server" build-server-url
@@ -313,6 +313,7 @@
              "auth" ""}
 
             strip-executable? (assoc "strip-executable" true)
+            texture-compression? (assoc "texture-compression" true)
 
             ;; From BundleGenericHandler
             generate-debug-symbols? (assoc "with-symbols" true)


### PR DESCRIPTION
The `--texture-compression` argument in bob no longer requires a secondary flag to indicate wether or not texture compression should be applied according to the projects texture profile settings.

Before:
```
java -jar bob.jar --texture-compression=true # texture compression enabled
java -jar bob.jar --texture-compression=false # texture compression disabled
```

After:
```
java -jar bob.jar --texture-compression # texture compression enabled
java -jar bob.jar # texture compression disabled (argument omitted)
```

NOTE: bob is backwards compatible, meaning --texture-compression=false will work for the time being, but will likely be removed at a later time. A warning will be raised about the argument, but the feature will still work.