### PR TITLE
Fix windows app icon

### DIFF
--- a/engine/platform/src/platform_window_glfw3.cpp
+++ b/engine/platform/src/platform_window_glfw3.cpp
@@ -293,7 +293,7 @@ namespace dmPlatform
         if (res == PLATFORM_RESULT_OK)
         {
             FocusWindowNative(window);
-            SetWindowsIconNative(HWindow window);
+            SetWindowsIconNative(window);
 
         #ifdef __MACH__
             // Set size from settings

--- a/engine/platform/src/platform_window_glfw3.cpp
+++ b/engine/platform/src/platform_window_glfw3.cpp
@@ -293,6 +293,7 @@ namespace dmPlatform
         if (res == PLATFORM_RESULT_OK)
         {
             FocusWindowNative(window);
+            SetWindowsIconNative(HWindow window);
 
         #ifdef __MACH__
             // Set size from settings

--- a/engine/platform/src/platform_window_glfw3_linux.cpp
+++ b/engine/platform/src/platform_window_glfw3_linux.cpp
@@ -43,4 +43,9 @@ namespace dmPlatform
     {
         // NOP
     }
+
+    void SetWindowsIconNative(HWindow window)
+    {
+        // NOP
+    }
 }

--- a/engine/platform/src/platform_window_glfw3_osx.cpp
+++ b/engine/platform/src/platform_window_glfw3_osx.cpp
@@ -49,5 +49,10 @@ namespace dmPlatform
     {
         // NOP
     }
+
+    void SetWindowsIconNative(HWindow window)
+    {
+        // NOP
+    }
 }
 

--- a/engine/platform/src/platform_window_glfw3_private.h
+++ b/engine/platform/src/platform_window_glfw3_private.h
@@ -56,6 +56,7 @@ namespace dmPlatform
 
     void FocusWindowNative(HWindow window);
     void CenterWindowNative(HWindow wnd, GLFWmonitor* monitor);
+    void SetWindowsIconNative(HWindow window);
 }
 
 #endif // DM_PLATFORM_WINDOW_GLFW3_PRIVATE_H

--- a/engine/platform/src/platform_window_glfw3_win32.cpp
+++ b/engine/platform/src/platform_window_glfw3_win32.cpp
@@ -13,6 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #include <dlib/time.h>
+#include <dlib/log.h>
 
 #include <glfw/glfw3.h>
 
@@ -22,6 +23,8 @@
 
 #include "platform_window_glfw3_private.h"
 #include "platform_window_win32.h"
+
+#define IDI_APPICON 100
 
 namespace dmPlatform
 {
@@ -38,6 +41,136 @@ namespace dmPlatform
     static inline bool IsWindowForeground(HWindow window)
     {
         return GetWindowsHWND(window) == GetForegroundWindow();
+    }
+
+    static void RepackColors(uint32_t num_pixels, uint32_t bit_depth, uint8_t* pixels_in, uint8_t* pixels_out)
+    {
+        for(uint32_t px=0; px < num_pixels; px++)
+        {
+            if (bit_depth == 24)
+            {
+                pixels_out[0] = pixels_in[2];
+                pixels_out[1] = pixels_in[1];
+                pixels_out[2] = pixels_in[0];
+                pixels_out[3] = 255;
+                pixels_out+=4;
+                pixels_in+=3;
+            }
+            else if (bit_depth == 32)
+            {
+                pixels_out[0] = pixels_in[2];
+                pixels_out[1] = pixels_in[1];
+                pixels_out[2] = pixels_in[0];
+                pixels_out[3] = pixels_in[3];
+                pixels_out+=4;
+                pixels_in+=4;
+            }
+        }
+    }
+
+    static const char* HICONToGLFWImage(HICON hIcon, GLFWimage* image)
+    {
+        // HDC hdc;
+        // uint8_t* pixels;
+        // uint8_t* convertedPixels;
+        // int rowSize, convertedRowSize;
+
+        // Get icon information
+        ICONINFO icon_info;
+        if (!GetIconInfo(hIcon, &icon_info))
+        {
+            return "Unable to get icon information";
+        }
+
+        // Get bitmap information
+        BITMAP bm;
+        if (!GetObject(icon_info.hbmColor, sizeof(BITMAP), &bm))
+        {
+            DeleteObject(icon_info.hbmColor);
+            DeleteObject(icon_info.hbmMask);
+            return "Unable to get bitmap information";
+        }
+
+        if (!(bm.bmBitsPixel == 24 || bm.bmBitsPixel == 32))
+        {
+            DeleteObject(icon_info.hbmColor);
+            DeleteObject(icon_info.hbmMask);
+            return "Invalid bitmap depth. Only a bit depth of 24 or 32 is currently supported.";
+        }
+
+        BITMAPINFO bmi              = {};
+        bmi.bmiHeader.biSize        = sizeof(BITMAPINFOHEADER);
+        bmi.bmiHeader.biWidth       = bm.bmWidth;
+        bmi.bmiHeader.biHeight      = -bm.bmHeight; // Negative height for top-down bitmap
+        bmi.bmiHeader.biPlanes      = 1;
+        bmi.bmiHeader.biBitCount    = (WORD) bm.bmBitsPixel; // Use the actual color depth
+        bmi.bmiHeader.biCompression = BI_RGB;
+
+        uint32_t row_size = ((bm.bmBitsPixel * bm.bmWidth + 31) / 32) * 4; // Row size in bytes
+        uint8_t* pixels   = (uint8_t*) malloc(row_size * bm.bmHeight);
+
+        HDC hdc = GetDC(NULL);
+        if (!hdc)
+        {
+            free(pixels);
+            DeleteObject(icon_info.hbmColor);
+            DeleteObject(icon_info.hbmMask);
+            return "Unable to get a device context";
+        }
+
+        // Get the original pixel data
+        if (!GetDIBits(hdc, icon_info.hbmColor, 0, bm.bmHeight, pixels, &bmi, DIB_RGB_COLORS))
+        {
+            free(pixels);
+            ReleaseDC(NULL, hdc);
+            DeleteObject(icon_info.hbmColor);
+            DeleteObject(icon_info.hbmMask);
+            return "Unable to get the pixel data from the bitmap";
+        }
+
+        ReleaseDC(NULL, hdc);
+
+        image->width = bm.bmWidth;
+        image->height = bm.bmHeight;
+
+        // Repack to RGBA. The bitmap is stored in BGR format, so we need this conversion regardless.
+        // From the GLFW docs:
+        // "The image data is 32-bit, little-endian, non-premultiplied RGBA, i.e. eight bits per channel with the red channel first.
+        // The pixels are arranged canonically as sequential rows, starting from the top-left corner."
+        uint8_t* pixels_rgba = (uint8_t*) malloc(bm.bmWidth * bm.bmHeight * 4);
+        RepackColors(bm.bmWidth * bm.bmHeight, bm.bmBitsPixel, pixels, pixels_rgba);
+        free(pixels);
+        image->pixels = pixels_rgba;
+
+        return NULL;
+    }
+
+    void SetWindowsIconNative(HWindow window)
+    {
+        HWND hwnd = GetWindowsHWND(window);
+
+        HINSTANCE hInstance = (HINSTANCE) GetWindowLongPtr(hwnd, GWLP_HINSTANCE);
+
+        HICON hIcon = (HICON) LoadImageW(hInstance, MAKEINTRESOURCE(IDI_APPICON), IMAGE_ICON, 0, 0, LR_DEFAULTSIZE | LR_SHARED);
+
+        if (!hIcon)
+        {
+            dmLogWarning("No icon found!");
+            return;
+        }
+
+        GLFWimage image = {};
+        const char* err_msg_or_null = HICONToGLFWImage(hIcon, &image);
+
+        if (err_msg_or_null)
+        {
+            dmLogWarning("Unable to convert HICON to GLFWIcon: %s", err_msg_or_null);
+            return;
+        }
+
+        glfwSetWindowIcon(window->m_Window, 1, &image);
+
+        free(image.pixels);
     }
 
     void FocusWindowNative(HWindow window)


### PR DESCRIPTION
Fixed an issue where the application icon on windows wasn't showing due to a regression after updating to GLFW3.

Fixes #9312 
Fixes #9325 