### PR TITLE
Ensure that Bob stops building immediately if any of the build steps fail

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/ConsoleProgress.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/ConsoleProgress.java
@@ -23,6 +23,7 @@ public class ConsoleProgress implements IProgress {
     private float ticks;
     private float scale = 1;
     private Boolean isATTY = false;
+    private boolean canceled = false;
 
     public ConsoleProgress() {
         reportTo = this;
@@ -96,7 +97,14 @@ public class ConsoleProgress implements IProgress {
 
     @Override
     public boolean isCanceled() {
-        return false;
+        if (reportTo != null) {
+            return reportTo.canceled || canceled;
+        }
+        return canceled;
     }
 
+    @Override
+    public void setCanceled(boolean canceled) {
+        this.canceled = canceled;
+    }
 }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/NullProgress.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/NullProgress.java
@@ -38,4 +38,8 @@ public class NullProgress implements IProgress {
         return false;
     }
 
+    @Override
+    public void setCanceled(boolean canceled) {
+    }
+
 }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
@@ -1361,7 +1361,16 @@ public class Project {
 
                 long tstart = System.currentTimeMillis();
 
-                buildEngine(monitor, architectures, appmanifestOptions);
+                try {
+                    buildEngine(monitor, architectures, appmanifestOptions);
+                }
+                catch (Exception e) {
+                    if ((e instanceof MultipleCompileException) ||
+                        (e instanceof CompileExceptionError)) {
+                        monitor.setCanceled(true);
+                    }
+                    throw  e;
+                }
 
                 long tend = System.currentTimeMillis();
                 logger.info("Engine build took %f s", (tend-tstart)/1000.0);
@@ -1773,32 +1782,40 @@ public class Project {
                         }
                     }
                     TimeProfiler.stop();
-
-                    if (shouldBuildProject) {
-                        result = createAndRunTasks(monitor);
-                    }
-
-                    if (remoteBuildFuture != null) {
-                        // get the result from the remote build and catch
-                        // if an exception was thrown in buildRemoteEngine() the
-                        // original exception is included in the ExecutionException
-                        try {
-                            remoteBuildFuture.get();
-                        }
-                        catch (ExecutionException|InterruptedException e) {
-                            Throwable cause = e.getCause();
-                            if ((cause instanceof MultipleCompileException) ||
-                                (cause instanceof CompileExceptionError)) {
-                                throw cause;
-                            }
-                            else {
-                                throw new CompileExceptionError(cause);
-                            }
+                    boolean resourceBuildingFailed = false;
+                    try {
+                        if (shouldBuildProject) {
+                            result = createAndRunTasks(monitor);
                         }
                     }
-
-                    if (anyFailing(result)) {
-                        break loop;
+                    catch(Exception e) {
+                        if (!monitor.isCanceled()) {
+                            resourceBuildingFailed = true;
+                            throw e;
+                        }
+                    }
+                    finally {
+                        if (remoteBuildFuture != null && !resourceBuildingFailed) {
+                            // get the result from the remote build and catch
+                            // if an exception was thrown in buildRemoteEngine() the
+                            // original exception is included in the ExecutionException
+                            try {
+                                remoteBuildFuture.get();
+                            }
+                            catch (ExecutionException|InterruptedException e) {
+                                Throwable cause = e.getCause();
+                                if ((cause instanceof MultipleCompileException) ||
+                                    (cause instanceof CompileExceptionError)) {
+                                    throw cause;
+                                }
+                                else {
+                                    throw new CompileExceptionError(cause);
+                                }
+                            }
+                        }
+                        if (anyFailing(result)) {
+                            break loop;
+                        }
                     }
                     break;
                 }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/TaskBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/TaskBuilder.java
@@ -340,8 +340,10 @@ public class TaskBuilder {
                 }
             }
             catch (Exception e) {
-                logger.severe("Exception");
-                e.printStackTrace(new java.io.PrintStream(System.out));
+                if (!monitor.isCanceled()) {
+                    logger.severe("Exception");
+                    e.printStackTrace(new java.io.PrintStream(System.out));
+                }
                 abort = true;
             }
         }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/ICanceled.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/ICanceled.java
@@ -16,4 +16,5 @@ package com.dynamo.bob.bundle;
 
 public interface ICanceled {
     boolean isCanceled();
+    void setCanceled(boolean canceled);
 }

--- a/editor/src/clj/editor/pipeline/bob.clj
+++ b/editor/src/clj/editor/pipeline/bob.clj
@@ -96,6 +96,7 @@
    (reify IProgress
      (isCanceled [_this]
        (task-cancelled?))
+     (setCanceled [_this canceled])
      (subProgress [_this _work-claimed-from-this]
        (->progress render-progress! task-cancelled? msg-stack-atom))
      (beginTask [_this name _steps]


### PR DESCRIPTION
Ensure that if the engine build fails, Bob stops building resources and displays the error.

Fix https://github.com/defold/defold/issues/9695