### PR TITLE
Avoid rare build crashes in TimeProfiler

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/TimeProfiler.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/TimeProfiler.java
@@ -263,6 +263,9 @@ public class TimeProfiler {
     }
 
     public static void addScopeToCurrentThread(ProfilingScope scope) {
+        if (scope == null) {
+            return;
+        }
         ProfilingScope currentScope = getCurrentScope();
         if (currentScope != null) {
             if (currentScope.children == null) {


### PR DESCRIPTION
I can't reproduce this crash and also failed to follow the reason, but we need stable build.

A couple of examples:
```
Generating report...2025-01-08 13:56:54 SEVERE  java.lang.NullPointerException: Cannot read field "startTime" because "scope" is null 
2025-01-08 13:56:54 SEVERE  Cause:0: java.lang.NullPointerException: Cannot read field "startTime" because "scope" is null 
2025-01-08 13:56:54 SEVERE  com.dynamo.bob.util.TimeProfiler.generateJsonRecursively(TimeProfiler.java:97) 
2025-01-08 13:56:54 SEVERE  com.dynamo.bob.util.TimeProfiler.generateJsonRecursively(TimeProfiler.java:110) 
2025-01-08 13:56:54 SEVERE  com.dynamo.bob.util.TimeProfiler.generateJsonRecursively(TimeProfiler.java:110) 
2025-01-08 13:56:54 SEVERE  com.dynamo.bob.util.TimeProfiler.generateJsonRecursively(TimeProfiler.java:110) 
2025-01-08 13:56:54 SEVERE  com.dynamo.bob.util.TimeProfiler.generateJSON(TimeProfiler.java:126) 
2025-01-08 13:56:54 SEVERE  com.dynamo.bob.util.TimeProfiler.createReport(TimeProfiler.java:205) 
2025-01-08 13:56:54 SEVERE  com.dynamo.bob.Bob.invoke(Bob.java:1026) 
2025-01-08 13:56:54 SEVERE  com.dynamo.bob.Bob.main(Bob.java:1054) 
2025-01-08 13:56:54 SEVERE  java.lang.NullPointerException: Cannot read field "startTime" because "scope" is null 
```

```
 java.lang.NullPointerException: Cannot assign field "parent" because "scope" is null
    	at com.dynamo.bob.util.TimeProfiler.addScopeToCurrentThread(TimeProfiler.java:273)
    	at com.dynamo.bob.TaskBuilder.build(TaskBuilder.java:314)
    	at com.dynamo.bob.Project.runTasks(Project.java:1872)
    	at com.dynamo.bob.Project.createAndRunTasks(Project.java:1644)
    	at com.dynamo.bob.Project.doBuild(Project.java:1788)
    	at com.dynamo.bob.Project.build(Project.java:708)
    	at com.dynamo.bob.bundle.test.BundlerTest.build(BundlerTest.java:360)
    	at com.dynamo.bob.bundle.test.BundlerTest.testBundleResourcesDirs(BundlerTest.java:757)
    	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
    	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
    	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
    	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
    	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
    	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
    	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
    	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
    	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
    	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
    	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
    	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
    	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
    	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
    	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
    	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
    	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
    	at org.junit.runners.Suite.runChild(Suite.java:128)
    	at org.junit.runners.Suite.runChild(Suite.java:27)
    	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
    	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
    	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
    	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
    	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
    	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
    	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.runTestClass(JUnitTestClassExecutor.java:112)
    	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.execute(JUnitTestClassExecutor.java:58)
    	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.execute(JUnitTestClassExecutor.java:40)
    	at org.gradle.api.internal.tasks.testing.junit.AbstractJUnitTestClassProcessor.processTestClass(AbstractJUnitTestClassProcessor.java:60)
    	at org.gradle.api.internal.tasks.testing.SuiteTestClassProcessor.processTestClass(SuiteTestClassProcessor.java:52)
    	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
    	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
    	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:36)
    	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
    	at org.gradle.internal.dispatch.ContextClassLoaderDispatch.dispatch(ContextClassLoaderDispatch.java:33)
    	at org.gradle.internal.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:94)
    	at jdk.proxy1/jdk.proxy1.$Proxy2.processTestClass(Unknown Source)
    	at org.gradle.api.internal.tasks.testing.worker.TestWorker$2.run(TestWorker.java:176)
    	at org.gradle.api.internal.tasks.testing.worker.TestWorker.executeAndMaintainThreadName(TestWorker.java:129)
    	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:100)
    	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:60)
    	at org.gradle.process.internal.worker.child.ActionExecutionWorker.execute(ActionExecutionWorker.java:56)
    	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:113)
    	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:65)
    	at worker.org.gradle.process.internal.worker.GradleWorkerMain.run(GradleWorkerMain.java:69)
    	at worker.org.gradle.process.internal.worker.GradleWorkerMain.main(GradleWorkerMain.java:74)
    2025-01-10 11:39:24 INFO    Build tasks took 0.005000 s
    ```
https://github.com/defold/defold/actions/runs/12708363230/job/35426277543