### PR TITLE
Added support for no-evict sound resource chunks

### DIFF
--- a/engine/gamesys/src/gamesys/resources/res_sound_data.cpp
+++ b/engine/gamesys/src/gamesys/resources/res_sound_data.cpp
@@ -125,6 +125,9 @@ namespace dmGameSystem
 
     static void AddChunk(HResourceChunkCache cache, dmhash_t path_hash, uint8_t* data, uint32_t size, uint32_t offset)
     {
+        // Offset==0 means the initial chunk of a file (the part that contains the header of a file)
+        // We have no way for the decoders to ask for it themselves, so we need to keep it in the cache or
+        // the decoder will fail when start playing the sound
         int flags = offset == 0 ? RESOURCE_CHUNK_CACHE_NO_EVICT : RESOURCE_CHUNK_CACHE_DEFAULT;
         if (!ResourceChunkCacheCanFit(cache, size))
         {

--- a/engine/resource/src/resource_chunk_cache.cpp
+++ b/engine/resource/src/resource_chunk_cache.cpp
@@ -41,8 +41,9 @@ struct ResourceInternalDataChunk
 
     dmhash_t m_PathHash;
     uint8_t* m_Data;
-    uint32_t m_Size;    // Size of data
-    uint32_t m_Offset;  // Offset into the file
+    uint32_t m_Size;        // Size of data
+    uint32_t m_Offset:31;   // Offset into the file
+    uint32_t m_NoEvict:1;   // Set if the chunk mustn't be evicted
 };
 
 #if __cplusplus >= 201103L
@@ -54,9 +55,10 @@ struct ResourceChunkCache
     // The array is sorted on (path_hash, offset)
     dmArray<ResourceInternalDataChunk*> m_Chunks;
 
-    uint32_t m_CacheSize;    // The cache size for all streaming sounds
-    uint32_t m_CacheSizeUsed;// The amount of cache currently used
-    DLList   m_LRU; // head is MRU, tail is LRU
+    uint32_t m_CacheSize;       // The cache size for all streaming sounds
+    uint32_t m_CacheSizeUsed;   // The amount of cache currently used
+    DLList   m_LRU;             // head is MRU, tail is LRU
+    DLList   m_LRUNoEvict;      // head is MRU, tail is LRU
 };
 
 // **********************************************************************************
@@ -97,12 +99,13 @@ static DLListNode* ListGetLast(DLList* list)
 
 // **********************************************************************************
 
-static ResourceInternalDataChunk* AllocChunk(ResourceChunkCache* cache, dmhash_t path_hash, uint8_t* data, uint32_t data_size, uint32_t offset)
+static ResourceInternalDataChunk* AllocChunk(ResourceChunkCache* cache, dmhash_t path_hash, uint8_t* data, uint32_t data_size, uint32_t offset, int flags)
 {
     ResourceInternalDataChunk* chunk = new ResourceInternalDataChunk;
     chunk->m_PathHash = path_hash;
     chunk->m_Offset = offset;
     chunk->m_Size = data_size;
+    chunk->m_NoEvict = flags & RESOURCE_CHUNK_CACHE_NO_EVICT?1:0;
     chunk->m_Data = new uint8_t[data_size];
     memcpy(chunk->m_Data, data, data_size);
 
@@ -153,21 +156,13 @@ static bool ChunkComparePathFn(const ResourceInternalDataChunk* chunk, dmhash_t 
 
 static void PrintChunk(ResourceChunkCache* cache, ResourceInternalDataChunk* chunk)
 {
-    printf("  chunk: '%s'  offset: %8u  size: %8u  data: %p\n", dmHashReverseSafe64(chunk->m_PathHash), chunk->m_Offset, chunk->m_Size, chunk->m_Data);
+    printf("  chunk: '%s'  offset: %8u  size: %8u  data: %p  noevict: %s\n", dmHashReverseSafe64(chunk->m_PathHash), chunk->m_Offset, chunk->m_Size, chunk->m_Data, chunk->m_NoEvict?"true":"false");
 }
 
-void ResourceChunkCacheDebugChunks(ResourceChunkCache* cache)
+static void PrintList(ResourceChunkCache* cache, DLList* list)
 {
-    uint32_t num_chunks = cache->m_Chunks.Size();
-    printf("NUM CHUNKS: %u\n", num_chunks);
-    for (uint32_t i = 0; i < num_chunks; ++i)
-    {
-        ResourceInternalDataChunk* chunk = cache->m_Chunks[i];
-        PrintChunk(cache, chunk);
-    }
-    printf("LRU:\n");
-    DLListNode* item = cache->m_LRU.m_Head.m_Next;
-    DLListNode* end = &cache->m_LRU.m_Tail;
+    DLListNode* item = list->m_Head.m_Next;
+    DLListNode* end = &list->m_Tail;
     while (item != end)
     {
         ResourceInternalDataChunk* chunk = (ResourceInternalDataChunk*)item;
@@ -175,6 +170,22 @@ void ResourceChunkCacheDebugChunks(ResourceChunkCache* cache)
 
         item = item->m_Next;
     }
+}
+
+void ResourceChunkCacheDebugChunks(ResourceChunkCache* cache)
+{
+    uint32_t num_chunks = cache->m_Chunks.Size();
+    printf("CACHE: size: %u  used: %u\n", cache->m_CacheSize, cache->m_CacheSizeUsed);
+    printf("NUM CHUNKS: %u\n", num_chunks);
+    for (uint32_t i = 0; i < num_chunks; ++i)
+    {
+        ResourceInternalDataChunk* chunk = cache->m_Chunks[i];
+        PrintChunk(cache, chunk);
+    }
+    printf("LRU:\n");
+    PrintList(cache, &cache->m_LRU);
+    printf("LRU (no evict):\n");
+    PrintList(cache, &cache->m_LRUNoEvict);
 }
 
 // **********************************************************************************
@@ -186,6 +197,7 @@ HResourceChunkCache ResourceChunkCacheCreate(uint32_t max_memory)
     cache->m_CacheSizeUsed = 0;
 
     ListInit(&cache->m_LRU);
+    ListInit(&cache->m_LRUNoEvict);
     return cache;
 }
 
@@ -280,8 +292,12 @@ bool ResourceChunkCacheGet(HResourceChunkCache cache, dmhash_t path_hash, uint32
             out->m_Size = chunk_size;
 
             // Update the LRU by placing the item first in the queue
-            ListRemove(&cache->m_LRU, (DLListNode*)chunk);
-            ListAdd(&cache->m_LRU, (DLListNode*)chunk);
+            DLList* list = &cache->m_LRU;
+            if (chunk->m_NoEvict)
+                list = &cache->m_LRUNoEvict;
+
+            ListRemove(list, (DLListNode*)chunk);
+            ListAdd(list, (DLListNode*)chunk);
             return true;
         }
     }
@@ -289,7 +305,7 @@ bool ResourceChunkCacheGet(HResourceChunkCache cache, dmhash_t path_hash, uint32
 }
 
 // Stores a new resoruce chunk
-bool ResourceChunkCachePut(HResourceChunkCache cache, uint64_t path_hash, ResourceCacheChunk* _chunk)
+bool ResourceChunkCachePut(HResourceChunkCache cache, uint64_t path_hash, int flags, ResourceCacheChunk* _chunk)
 {
 //printf("put '%s': '%s' sz: %u  off: %u\n", dmHashReverseSafe64(path_hash), (const char*)_chunk->m_Data, _chunk->m_Size, _chunk->m_Offset);
     if (!ResourceChunkCacheCanFit(cache, _chunk->m_Size))
@@ -310,10 +326,14 @@ bool ResourceChunkCachePut(HResourceChunkCache cache, uint64_t path_hash, Resour
         cache->m_Chunks.OffsetCapacity(16);
     }
 
-    ResourceInternalDataChunk* chunk = AllocChunk(cache, path_hash, _chunk->m_Data, _chunk->m_Size, _chunk->m_Offset);
+    ResourceInternalDataChunk* chunk = AllocChunk(cache, path_hash, _chunk->m_Data, _chunk->m_Size, _chunk->m_Offset, flags);
     cache->m_Chunks.Push(chunk);
     SortChunksOnPathAndOffset(cache);
-    ListAdd(&cache->m_LRU, (DLListNode*)chunk); // add it first in the LRU
+
+    DLList* list = &cache->m_LRU;
+    if (flags & RESOURCE_CHUNK_CACHE_NO_EVICT)
+        list = &cache->m_LRUNoEvict;
+    ListAdd(list, (DLListNode*)chunk); // add it first in the LRU
     return true;
 }
 
@@ -346,40 +366,21 @@ static void RemoveChunks(HResourceChunkCache cache, uint32_t index, uint32_t cou
     cache->m_Chunks.SetSize(num_chunks - count);
 }
 
-// Evicts the least recently used item from the cache
-void ResourceChunkCacheEvictOne(HResourceChunkCache cache)
-{
-    DLListNode* last = ListGetLast(&cache->m_LRU);
-    if (!last)
-        return;
-
-    ListRemove(&cache->m_LRU, last);
-    ResourceInternalDataChunk* chunk = (ResourceInternalDataChunk*)last;
-
-    uint32_t index = ResourceChunkCacheFindIndex(cache, chunk);
-    RemoveChunks(cache, index, 1);
-    FreeChunk(cache, chunk);
-}
-
 bool ResourceChunkCacheEvictMemory(HResourceChunkCache cache, uint32_t size)
 {
-    uint32_t cache_size = cache->m_CacheSize;
-    uint32_t cache_size_used = cache->m_CacheSizeUsed;
-
+    DLList* list = &cache->m_LRU;
     while (!ResourceChunkCacheCanFit(cache, size))
     {
-        DLListNode* last = ListGetLast(&cache->m_LRU);
+        DLListNode* last = ListGetLast(list);
         if (!last)
             break;
 
-        ListRemove(&cache->m_LRU, last);
-        ResourceInternalDataChunk* chunk = (ResourceInternalDataChunk*)last;
+        ListRemove(list, last);
 
+        ResourceInternalDataChunk* chunk = (ResourceInternalDataChunk*)last;
         uint32_t index = ResourceChunkCacheFindIndex(cache, chunk);
         RemoveChunks(cache, index, 1);
         FreeChunk(cache, chunk);
-
-        cache_size_used = cache->m_CacheSizeUsed;
     }
 
     return ResourceChunkCacheCanFit(cache, size);
@@ -405,7 +406,12 @@ void ResourceChunkCacheEvictPathHash(HResourceChunkCache cache, uint64_t path_ha
             break;
 
         ++count;
-        ListRemove(&cache->m_LRU, (DLListNode*)chunk);
+
+        DLList* list = &cache->m_LRU;
+        if (chunk->m_NoEvict)
+            list = &cache->m_LRUNoEvict;
+
+        ListRemove(list, (DLListNode*)chunk);
         FreeChunk(cache, chunk);
     }
 

--- a/engine/resource/src/resource_chunk_cache.h
+++ b/engine/resource/src/resource_chunk_cache.h
@@ -25,6 +25,12 @@ struct ResourceCacheChunk
     uint32_t m_Size;
 };
 
+enum ResourceChunkCacheFlags
+{
+    RESOURCE_CHUNK_CACHE_DEFAULT     = 0,
+    RESOURCE_CHUNK_CACHE_NO_EVICT    = 1,
+};
+
 typedef struct ResourceChunkCache* HResourceChunkCache;
 
 HResourceChunkCache ResourceChunkCacheCreate(uint32_t max_memory);
@@ -35,12 +41,14 @@ void                ResourceChunkCacheDestroy(HResourceChunkCache cache);
 bool ResourceChunkCacheGet(HResourceChunkCache cache, dmhash_t path_hash, uint32_t offset, ResourceCacheChunk* out);
 
 // Stores a new resoruce chunk. Returns true if successful, false if the operation failed
-bool ResourceChunkCachePut(HResourceChunkCache cache, dmhash_t path_hash, ResourceCacheChunk* chunk);
+// Flags are a set of ResourceChunkCacheFlags
+bool ResourceChunkCachePut(HResourceChunkCache cache, dmhash_t path_hash, int flags, ResourceCacheChunk* chunk);
 
 // Returns true if the cache is full
 bool ResourceChunkCacheCanFit(HResourceChunkCache cache, uint32_t size);
 
 // Evicts the chunks until the requested size will fit
+// It will not evict chunks added with the no-evict flag
 bool ResourceChunkCacheEvictMemory(HResourceChunkCache cache, uint32_t size);
 
 // Evicts the chunks associated with path_hash

--- a/engine/resource/src/test/test_resource_chunk_cache.cpp
+++ b/engine/resource/src/test/test_resource_chunk_cache.cpp
@@ -43,7 +43,7 @@ TEST(ResourceChunkCache, Small)
     ASSERT_TRUE(ResourceChunkCacheVerify(cache));
 
     // First chunk
-    ASSERT_TRUE(ResourceChunkCachePut(cache, path_hash1, &chunk1));
+    ASSERT_TRUE(ResourceChunkCachePut(cache, path_hash1, RESOURCE_CHUNK_CACHE_DEFAULT, &chunk1));
     ASSERT_EQ(1u, ResourceChunkCacheGetNumChunks(cache));
     ASSERT_FALSE(ResourceChunkCacheCanFit(cache, chunk_size*3));
     ASSERT_TRUE(ResourceChunkCacheCanFit(cache, chunk_size*2));
@@ -65,7 +65,7 @@ TEST(ResourceChunkCache, Small)
     ASSERT_FALSE(ResourceChunkCacheGet(cache, path_hash1, 16, &getter));
 
     // Second chunk
-    ASSERT_TRUE(ResourceChunkCachePut(cache, path_hash1, &chunk2));
+    ASSERT_TRUE(ResourceChunkCachePut(cache, path_hash1, RESOURCE_CHUNK_CACHE_DEFAULT, &chunk2));
     ASSERT_EQ(2u, ResourceChunkCacheGetNumChunks(cache));
     ASSERT_FALSE(ResourceChunkCacheCanFit(cache, chunk_size*2));
     ASSERT_TRUE(ResourceChunkCacheCanFit(cache, chunk_size*1));
@@ -80,7 +80,7 @@ TEST(ResourceChunkCache, Small)
     ASSERT_FALSE(ResourceChunkCacheGet(cache, path_hash1, 16, &getter));
 
     // Third chunk
-    ASSERT_TRUE(ResourceChunkCachePut(cache, path_hash1, &chunk3));
+    ASSERT_TRUE(ResourceChunkCachePut(cache, path_hash1, RESOURCE_CHUNK_CACHE_DEFAULT, &chunk3));
     ASSERT_EQ(3u, ResourceChunkCacheGetNumChunks(cache));
     ASSERT_FALSE(ResourceChunkCacheCanFit(cache, chunk_size*1));
     ASSERT_TRUE(ResourceChunkCacheVerify(cache));
@@ -93,7 +93,7 @@ TEST(ResourceChunkCache, Small)
 
     // Same chunk
     dmLogWarning("EXPECTED ERROR -->");
-    ASSERT_FALSE(ResourceChunkCachePut(cache, path_hash1, &chunk3));
+    ASSERT_FALSE(ResourceChunkCachePut(cache, path_hash1, RESOURCE_CHUNK_CACHE_DEFAULT, &chunk3));
     dmLogWarning("<-- EXPECTED ERROR END");
     ASSERT_EQ(3u, ResourceChunkCacheGetNumChunks(cache));
     ASSERT_FALSE(ResourceChunkCacheCanFit(cache, chunk_size*1));
@@ -162,9 +162,9 @@ TEST(ResourceChunkCache, Multiple)
     ResourceCacheChunk f3ch3 = {(uint8_t*)data3 +chunk_size*2, chunk_size*2, chunk_size};
     uint64_t path_hash3 = dmHashString64("file3");
 
-
-    // Let's only fit 3 chunks at the same time
-    HResourceChunkCache cache = ResourceChunkCacheCreate(num_files*chunk_size);
+    // The initial chunks are "no evict", and then add some extra space to add another chunk
+    int max_num_chunks_in_cache = num_files + 1;
+    HResourceChunkCache cache = ResourceChunkCacheCreate(max_num_chunks_in_cache*chunk_size);
     ASSERT_NE((HResourceChunkCache)0, cache);
 
     ResourceCacheChunk* expected_chunks[num_files][num_chunks_per_file] = {
@@ -177,20 +177,42 @@ TEST(ResourceChunkCache, Multiple)
 
     // We basically want to add chunks in a looping
     // fashion, and check that the collected data is the correct one
+    uint32_t prev_count = 0;
     for (uint32_t i = 0; i < 30; ++i)
     {
         uint32_t file_index = i % num_files;
         uint32_t chunk_index = (i / num_files) % num_chunks_per_file;
+
+        ResourceCacheChunk* expected_chunk = expected_chunks[file_index][chunk_index];
+        bool is_no_evict = expected_chunk->m_Offset == 0;
+        bool add_no_evict = i < num_files;
+        bool will_evict = prev_count == max_num_chunks_in_cache;
+        bool will_add = !is_no_evict ? 1 : add_no_evict;
+
+        uint32_t expected_num_chunks_before = prev_count;
+        uint32_t expected_num_chunks_after  = expected_num_chunks_before;
+        if (will_evict)
+            expected_num_chunks_after--;
+        if (will_add)
+            expected_num_chunks_after++;
 
         dmhash_t path_hash = path_hashes[file_index];
 
         printf("********************************************\n");
         printf("LOOP: %u  file: %s  chunk: %u\n", i, dmHashReverseSafe64(path_hash), chunk_index);
 
-        if (i < num_files)
+        // printf("  prev_count: %u\n", prev_count);
+        // printf("  is_no_evict: %s\n", is_no_evict?"true":"false");
+        // printf("  add_no_evict: %s\n", add_no_evict?"true":"false");
+        // printf("  will_evict: %s\n", will_evict?"true":"false");
+        // printf("  will_add: %s\n", will_add?"true":"false");
+        // printf("  before: %u  after: %u\n", expected_num_chunks_before, expected_num_chunks_after);
+
+        ASSERT_EQ(chunk_size*expected_num_chunks_before, ResourceChunkCacheGetUsedMemory(cache));
+
+        if (expected_num_chunks_before < max_num_chunks_in_cache)
         {
-            ASSERT_EQ(chunk_size*i, ResourceChunkCacheGetUsedMemory(cache));
-            ASSERT_TRUE(ResourceChunkCacheCanFit(cache, chunk_size*(num_files-i)));
+            ASSERT_TRUE(ResourceChunkCacheCanFit(cache, chunk_size*(max_num_chunks_in_cache-expected_num_chunks_before)));
         }
         else
         {
@@ -201,15 +223,23 @@ TEST(ResourceChunkCache, Multiple)
             ASSERT_TRUE(ResourceChunkCacheCanFit(cache, chunk_size));
         }
 
-        ResourceCacheChunk* expected_chunk = expected_chunks[file_index][chunk_index];
-        ASSERT_TRUE(ResourceChunkCachePut(cache, path_hash, expected_chunk));
+        int flags = RESOURCE_CHUNK_CACHE_DEFAULT;
+        if (is_no_evict)
+            flags = RESOURCE_CHUNK_CACHE_NO_EVICT;
+
+        bool expected_add_result = true;
+        if (is_no_evict && !add_no_evict)
+            expected_add_result = false;
+
+        bool added = ResourceChunkCachePut(cache, path_hash, flags, expected_chunk);
+        ASSERT_EQ(expected_add_result, added);
 
         ResourceChunkCacheDebugChunks(cache);
 
-        uint32_t expected_num_chunks = i < num_files ? i+1 : num_files;
-        ASSERT_EQ(expected_num_chunks, ResourceChunkCacheGetNumChunks(cache));
+        ASSERT_EQ(expected_num_chunks_after, ResourceChunkCacheGetNumChunks(cache));
+        prev_count = expected_num_chunks_after;
 
-        if (expected_num_chunks == 3)
+        if (expected_num_chunks_after == max_num_chunks_in_cache)
         {
             ASSERT_FALSE(ResourceChunkCacheCanFit(cache, chunk_size));
         }

--- a/engine/sound/src/sound.cpp
+++ b/engine/sound/src/sound.cpp
@@ -655,7 +655,7 @@ namespace dmSound
 
             dmSoundCodec::Result r = dmSoundCodec::NewDecoder(ss->m_CodecContext, codec_format, sound_data, &decoder);
             if (r != dmSoundCodec::RESULT_OK) {
-                dmLogError("Failed to decode sound (%d)", r);
+                dmLogError("Failed to decode sound %s: (%d)", dmHashReverseSafe64(sound_data->m_NameHash), r);
                 return RESULT_INVALID_STREAM_DATA;
             }
 


### PR DESCRIPTION
This fixes the case where the first part of a sound file gets evicted, which in turn will cause the sound decoders to not initialize correctly.

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
