### PR TITLE
Throw a Lua error if `nil` passed into `go.exists()` function

### DIFF
--- a/engine/gameobject/src/gameobject/gameobject_script.cpp
+++ b/engine/gameobject/src/gameobject/gameobject_script.cpp
@@ -2084,6 +2084,11 @@ namespace dmGameObject
     int Script_Exists(lua_State* L)
     {
         DM_LUA_STACK_CHECK(L, 1);
+        int top = lua_gettop(L);
+        if (top == 1 && lua_isnil(L, 1))
+        {
+            return luaL_error(L, "The url shouldn't be `nil`");
+        }
         ScriptInstance* i = ScriptInstance_Check(L);
         Instance* instance = i->m_Instance;
         dmMessage::URL sender;

--- a/engine/gameobject/src/gameobject/test/script/exists.script
+++ b/engine/gameobject/src/gameobject/test/script/exists.script
@@ -20,4 +20,8 @@ function init(self)
     assert(go.exists(msg.url(nil, "a", nil)), "Expected go msg.url(nil, 'a', nil) to exist")
     assert(go.exists(msg.url(nil, "b", nil)), "Expected go msg.url(nil, 'b', nil) to exist")
     assert(not go.exists("unknown"), "Expected go 'unknown' to not exist")
+    if pcall(go.exists, nil) then
+        assert(false, "Error expected if call go.exists with nil")
+    end
+    assert(go.exists(), "Object itself always exists")
 end


### PR DESCRIPTION
⚠️ Passing `nil` to `go.exists()` results in a Lua error, as this aligns with expected behavior and helps catch logical issues in the code.

Fixes https://github.com/defold/defold/issues/9998