### PR TITLE
API doc fix on lua example of timer.trigger

### DIFF
--- a/engine/script/src/script_timer.cpp
+++ b/engine/script/src/script_timer.cpp
@@ -689,7 +689,7 @@ namespace dmScript
      * if not result then
      *    print("the timer is already cancelled or complete")
      * end
-     * ``
+     * ```
      */
     static int TimerTrigger(lua_State* L)
     {


### PR DESCRIPTION
Fix the formatting problem of `timer.trigger` example in API docs.

The reason is that there's one backtick lacking on `timer.trigger` documentation code.

Closes #10067