### PR TITLE
Allow editing markdown files

### DIFF
--- a/editor/src/clj/editor/html_view.clj
+++ b/editor/src/clj/editor/html_view.clj
@@ -236,12 +236,6 @@
          (resource/proj-path resource))))
 
 (g/defnk load-resource! [^WebView web-view resource-node _node-id html]
-  "Loads the url corresponding to the current resource.
-
-  This will open the resource at the new location if we've moved it.
-
-  If we somehow manage to browse away from the project to an external
-  page, this will somewhat annoyingly bring us back."
   (when resource-node
     (let [web-engine (.getEngine web-view)
           resource   (g/node-value resource-node :resource)

--- a/editor/src/clj/editor/html_view.clj
+++ b/editor/src/clj/editor/html_view.clj
@@ -273,7 +273,9 @@
         web-view      (make-web-view project)
         web-engine    (.getEngine web-view)
         view-id       (g/make-node! graph WebViewNode :web-view web-view)
-        repainter     (ui/->timer 30 "update-web-view!" (fn [_ _ _] (g/node-value view-id :load-resource)))]
+        repainter     (ui/->timer 30 "update-web-view!" (fn [_ _ _] 
+                                                          (when (.isSelected (:tab opts))
+                                                            (g/node-value view-id :load-resource))))]
 
     (.addListener (.locationProperty web-engine)
                   (ui/change-listener _ _ new-location (handle-location-change! project view-id new-location)))

--- a/editor/src/clj/editor/html_view.clj
+++ b/editor/src/clj/editor/html_view.clj
@@ -268,7 +268,7 @@
         web-engine (.getEngine web-view)
         view-id (g/make-node! graph WebViewNode :web-view web-view)
         repainter (ui/->timer 30 "update-web-view!" (fn [_ _ _]
-                                                      (when (.isSelected (:tab opts))
+                                                      (when (.isSelected ^Tab (:tab opts))
                                                         (g/node-value view-id :update-web-view))))]
 
     (.addListener (.locationProperty web-engine)

--- a/editor/src/clj/editor/markdown.clj
+++ b/editor/src/clj/editor/markdown.clj
@@ -446,5 +446,5 @@
     :ext "md"
     :label "Markdown"
     :node-type MarkdownNode
-    :view-types [:html :text]
+    :view-types [:html :code]
     :view-opts nil))

--- a/editor/src/clj/editor/markdown.clj
+++ b/editor/src/clj/editor/markdown.clj
@@ -29,15 +29,14 @@
             [cljfx.prop :as fx.prop]
             [clojure.string :as string]
             [dynamo.graph :as g]
+            [editor.code.data :as data]
+            [editor.code.resource :as r]
             [editor.defold-project :as project]
             [editor.fxui :as fxui]
             [editor.html-view :as html-view]
-            [editor.resource-io :as resource-io]
-            [editor.resource-node :as resource-node]
             [editor.ui :as ui]
             [editor.workspace :as workspace]
-            [util.fn :as fn]
-            [util.text-util :as text-util])
+            [util.fn :as fn])
   (:import [java.net URI]
            [javafx.scene.control ScrollPane]
            [org.commonmark.ext.autolink AutolinkExtension]
@@ -432,34 +431,20 @@
     (.render renderer doc)))
 
 (g/defnode MarkdownNode
-  (inherits resource-node/ResourceNode)
+  (inherits r/CodeEditorResourceNode)
 
-  (output markdown g/Str :cached (g/fnk [_node-id resource]
-                                   (resource-io/with-error-translation resource _node-id :markdown
-                                     (slurp resource :encoding "UTF-8"))))
-
-  (output html g/Str :cached (g/fnk [markdown]
-                               (str "<!DOCTYPE html>"
-                                    "<html><head></head><body>"
-                                    (markdown->html markdown)
-                                    "</body></html>"))))
-
-(defn- search-value-fn [node-id _resource evaluation-context]
-  (g/node-value node-id :markdown evaluation-context))
-
-(defn search-fn
-  ([search-string]
-   (text-util/search-string->re-pattern search-string :case-insensitive))
-  ([markdown re-pattern]
-   (text-util/text->text-matches markdown re-pattern)))
+  (output html g/Str :cached (g/fnk [save-value]
+                                    (str "<!DOCTYPE html>"
+                                         "<html><head></head><body>"
+                                         (-> save-value
+                                             data/lines->string
+                                             markdown->html)
+                                         "</body></html>"))))
 
 (defn register-resource-types [workspace]
-  (workspace/register-resource-type workspace
+  (r/register-code-resource-type workspace
     :ext "md"
     :label "Markdown"
-    :textual? true
-    :search-fn search-fn
-    :search-value-fn search-value-fn
     :node-type MarkdownNode
     :view-types [:html :text]
     :view-opts nil))

--- a/editor/src/clj/editor/markdown.clj
+++ b/editor/src/clj/editor/markdown.clj
@@ -433,13 +433,13 @@
 (g/defnode MarkdownNode
   (inherits r/CodeEditorResourceNode)
 
-  (output html g/Str :cached (g/fnk [save-value]
-                                    (str "<!DOCTYPE html>"
-                                         "<html><head></head><body>"
-                                         (-> save-value
-                                             data/lines->string
-                                             markdown->html)
-                                         "</body></html>"))))
+  (output html g/Str :cached (g/fnk [arg-list] [save-value]
+                               (str "<!DOCTYPE html>"
+                                    "<html><head></head><body>"
+                                    (-> save-value
+                                        data/lines->string
+                                        markdown->html)
+                                    "</body></html>"))))
 
 (defn register-resource-types [workspace]
   (r/register-code-resource-type workspace

--- a/editor/src/clj/editor/markdown.clj
+++ b/editor/src/clj/editor/markdown.clj
@@ -433,7 +433,7 @@
 (g/defnode MarkdownNode
   (inherits r/CodeEditorResourceNode)
 
-  (output html g/Str :cached (g/fnk [arg-list] [save-value]
+  (output html g/Str :cached (g/fnk [save-value]
                                (str "<!DOCTYPE html>"
                                     "<html><head></head><body>"
                                     (-> save-value

--- a/editor/src/clj/editor/resource.clj
+++ b/editor/src/clj/editor/resource.clj
@@ -83,7 +83,7 @@
 
 (defn openable-in-view-type?
   [value view-type]
-  (contains? (into #{} (map :id (:view-types (resource-type value)))) view-type))
+  (coll/some #(= view-type %) (:view-types (resource-type value))))
 
 (defn- ->unix-seps ^String [^String path]
   (FilenameUtils/separatorsToUnix path))

--- a/editor/src/clj/editor/resource.clj
+++ b/editor/src/clj/editor/resource.clj
@@ -81,9 +81,10 @@
   (and (openable-resource? value)
        (true? (:editor-openable (resource-type value)))))
 
-(defn openable-in-view-type?
-  [value view-type]
-  (coll/some #(= view-type %) (:view-types (resource-type value))))
+(defn has-view-type? [resource view-type]
+  {:pre [(keyword? view-type)]}
+  (boolean (some #(= view-type (:id %))
+                 (:view-types (resource-type resource)))))
 
 (defn- ->unix-seps ^String [^String path]
   (FilenameUtils/separatorsToUnix path))

--- a/editor/src/clj/editor/resource.clj
+++ b/editor/src/clj/editor/resource.clj
@@ -81,6 +81,10 @@
   (and (openable-resource? value)
        (true? (:editor-openable (resource-type value)))))
 
+(defn openable-in-view-type?
+  [value view-type]
+  (contains? (into #{} (map :id (:view-types (resource-type value)))) view-type))
+
 (defn- ->unix-seps ^String [^String path]
   (FilenameUtils/separatorsToUnix path))
 

--- a/editor/test/integration/save_test.clj
+++ b/editor/test/integration/save_test.clj
@@ -237,25 +237,26 @@
                                         (is (= #{:save-data :save-value} (cached-save-data-outputs "/game_object/test.go")))
                                         (is (= #{:save-data} (cached-save-data-outputs "/json/test.json"))) ; The save-value output is not :cached. Lazy loaded.
                                         (is (= #{:save-data} (cached-save-data-outputs "/script/test_module.lua"))) ; The save-value output is not :cached.
-                                        (is (= #{} (cached-save-data-outputs "/markdown/test.md"))) ; Stateless, so no save-data.
+                                        (is (= #{:save-data} (cached-save-data-outputs "/markdown/test.md")))
 
                                         (is (= #{:save-data :save-value} (cached-save-data-outputs "/added_externally.go")))
                                         (is (= #{:save-data} (cached-save-data-outputs "/added_externally.json"))) ; The save-value output is not :cached. Lazy loaded.
                                         (is (= #{:save-data} (cached-save-data-outputs "/added_externally.lua"))) ; The save-value output is not :cached.
-                                        (is (= #{} (cached-save-data-outputs "/added_externally.md"))))) ; Stateless, so no save-data.
+                                        (is (= #{:save-data} (cached-save-data-outputs "/added_externally.md")))))
 
                                     (testing "Expectations for reloaded resources."
                                       (let [external-game-object-pb-map (protobuf/read-map-without-defaults GameObject$PrototypeDesc (workspace/find-resource workspace "/game_object/test.go"))
-                                            external-lua-lines (code.util/split-lines external-lua-text)]
+                                            external-lua-lines (code.util/split-lines external-lua-text)
+                                            external-markdown-lines (code.util/split-lines external-markdown-text)]
                                         (is (check-eager-loaded-save-data! project "/game_object/test.go" external-game-object-text external-game-object-pb-map))
                                         (is (check-lazy-loaded-save-data! project "/json/test.json" external-json-text))
                                         (is (check-eager-loaded-save-data! project "/script/test_module.lua" external-lua-text external-lua-lines))
-                                        (is (check-lazy-loaded-save-data! project "/markdown/test.md" external-markdown-text))
+                                        (is (check-eager-loaded-save-data! project "/markdown/test.md" external-markdown-text external-markdown-lines))
 
                                         (is (check-eager-loaded-save-data! project "/added_externally.go" external-game-object-text external-game-object-pb-map))
                                         (is (check-lazy-loaded-save-data! project "/added_externally.json" external-json-text))
                                         (is (check-eager-loaded-save-data! project "/added_externally.lua" external-lua-text external-lua-lines))
-                                        (is (check-lazy-loaded-save-data! project "/added_externally.md" external-markdown-text))))
+                                        (is (check-eager-loaded-save-data! project "/added_externally.md" external-markdown-text external-markdown-lines))))
 
                                     (testing "Save data unaffected."
                                       (is (= dirty-save-data-before (project/dirty-save-data project))))
@@ -264,7 +265,7 @@
                                       (is (= {"script" 1} (g/node-value (project/get-resource-node project "/game_object/test.go") :id-counts)))
                                       (is (= (code.util/split-lines external-json-text) (g/node-value (project/get-resource-node project "/json/test.json") :lines)))
                                       (is (= (code.util/split-lines external-lua-text) (g/node-value (project/get-resource-node project "/script/test_module.lua") :lines)))
-                                      (is (= external-markdown-text (g/node-value (project/get-resource-node project "/markdown/test.md") :markdown))))
+                                      (is (= (code.util/split-lines external-markdown-text) (g/node-value (project/get-resource-node project "/markdown/test.md") :lines))))
 
                                     (testing "Externally added files are seen by the editor."
                                       (is (some? (workspace/find-resource workspace "/added_externally.go")))
@@ -278,7 +279,7 @@
                                       (is (= {"script" 1} (g/node-value (project/get-resource-node project "/added_externally.go") :id-counts)))
                                       (is (= (code.util/split-lines external-json-text) (g/node-value (project/get-resource-node project "/added_externally.json") :lines)))
                                       (is (= (code.util/split-lines external-lua-text) (g/node-value (project/get-resource-node project "/added_externally.lua") :lines)))
-                                      (is (= external-markdown-text (g/node-value (project/get-resource-node project "/added_externally.md") :markdown))))
+                                      (is (= (code.util/split-lines external-markdown-text) (g/node-value (project/get-resource-node project "/added_externally.md") :lines))))
 
                                     (testing "Can delete externally added files from within the editor."
                                       (delete-file! workspace "/added_externally.go")

--- a/editor/test/resources/save_data_project/checked.md
+++ b/editor/test/resources/save_data_project/checked.md
@@ -1,0 +1,16 @@
+# Title
+Title paragraph text.
+
+## Heading
+Heading paragraph text.
+
+### Sub-heading
+Sub-heading paragraph text.
+
+* Unordered
+* List
+
+---
+
+1. Ordered
+2. List


### PR DESCRIPTION
Allow editing markdown files on text view. The web view should be updated accordingly.

Fixes #5301

### Technical changes
* Clicking on external and internal anchors should work as intended.
* We should avoid unneeded re-rendering.