### PR TITLE
Refresh Bundle menu on editor script reload

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -2639,7 +2639,8 @@ If you do not specifically require different script states, consider changing th
                                                     (future/complete! f nil)
                                                     (future/fail! f (LuaError. "Bob invocation failed")))
                                                   (.close out)))))
-                     f))))
+                     f)))
+  (ui/invalidate-menubar-item! ::project/bundle))
 
 (defn- fetch-libraries [app-view workspace project changes-view build-errors-view prefs]
   (let [library-uris (project/project-dependencies project)

--- a/editor/src/clj/editor/defold_project.clj
+++ b/editor/src/clj/editor/defold_project.clj
@@ -645,6 +645,7 @@
                {:label "Rebuild HTML5"
                 :command :rebuild-html5}
                {:label "Bundle"
+                :id ::bundle
                 :command :bundle}
                {:label "Rebundle"
                 :command :rebundle}

--- a/editor/src/clj/editor/editor_extensions.clj
+++ b/editor/src/clj/editor/editor_extensions.clj
@@ -563,9 +563,9 @@
 (defn- re-create-ext-state [initial-state evaluation-context]
   (let [{:keys [rt display-output!]} initial-state]
     (->> (e/concat
+           [bundle-editor-script-prototype]
            (:library-prototypes initial-state)
-           (:project-prototypes initial-state)
-           [bundle-editor-script-prototype])
+           (:project-prototypes initial-state))
          (reduce
            (fn [acc x]
              (cond


### PR DESCRIPTION
This changeset fixes an editor UI glitch where refreshing the Bundle menu after editor script reload needed an extra click to see the new bundle commands.

Fixes #10060