### PR TITLE
Fix visibility toolbar not working

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -455,13 +455,17 @@
 (handler/defhandler :show-visibility-settings :workbench
   (run [app-view scene-visibility]
     (when-let [btn (some-> ^TabPane (g/node-value app-view :active-tab-pane)
-                           (ui/selected-tab)
-                           (.. getContent (lookup "#show-visibility-settings")))]
+                           ui/selected-tab
+                           .getContent
+                           (.lookup "#visibility-settings-graphic")
+                           .getParent)]
       (scene-visibility/show-visibility-settings! app-view btn scene-visibility)))
   (state [app-view scene-visibility]
     (when-let [btn (some-> ^TabPane (g/node-value app-view :active-tab-pane)
-                           (ui/selected-tab)
-                           (.. getContent (lookup "#show-visibility-settings")))]
+                           ui/selected-tab
+                           .getContent
+                           (.lookup "#visibility-settings-graphic")
+                           .getParent)]
       ;; TODO: We have no mechanism for updating the style nor icon on
       ;; on the toolbar button. For now we piggyback on the state
       ;; update polling to set a style when the filters are active.
@@ -483,6 +487,7 @@
 
 (defn- make-visibility-settings-graphic []
   (doto (StackPane.)
+    (.setId "visibility-settings-graphic")
     (ui/children! [(doto (make-svg-icon-graphic eye-icon-svg-path)
                      (.setId "eye-icon"))
                    (doto (Ellipse. 3.0 3.0)

--- a/editor/styling/stylesheets/modules/_toolbar.scss
+++ b/editor/styling/stylesheets/modules/_toolbar.scss
@@ -45,12 +45,12 @@
         }
     }
 
-    #show-visibility-settings {
-        #eye-icon {
+    #visibility-settings-graphic {
+        & > #eye-icon {
             -fx-translate-y: 1px;
         }
 
-        #active-indicator {
+        & > #active-indicator {
             visibility: hidden;
             -fx-fill: -df-defold-orange;
             -fx-stroke: -df-component-darker;
@@ -58,12 +58,13 @@
             -fx-translate-x: 3.5px;
             -fx-translate-y: -5px;
         }
-
-        &:selected #active-indicator {
+    }
+    .toggle-button {
+        &:selected > #visibility-settings-graphic > #active-indicator {
             -fx-stroke: -df-background-light;
         }
 
-        &.filters-active #active-indicator {
+        &.filters-active > #visibility-settings-graphic > #active-indicator {
             visibility: visible;
         }
     }


### PR DESCRIPTION
While refactoring the handlers, I stopped assigning command names as ids to javafx menu items. This caused the visibility toolbar to not work, since it was looking up a node by the command name. This commit fixes that.

Fixes #10064
