### PR TITLE
Fix issues related to async texture creation

### DIFF
--- a/engine/gamesys/src/gamesys/scripts/script_resource.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_resource.cpp
@@ -259,7 +259,6 @@ struct SetTextureAsyncRequest
     dmBuffer::HBuffer          m_Buffer;
     int32_t                    m_BufferRef;
     HOpaqueHandle              m_Handle;
-    bool                       m_UseRawData;
 };
 
 struct ResourceModule
@@ -701,7 +700,7 @@ static void HandleRequestCompleted(dmGraphics::HTexture texture, void* user_data
         dmScript::DestroyCallback(request->m_CallbackInfo);
     }
 
-    if (request->m_UseRawData)
+    if (request->m_RawData)
     {
         delete request->m_RawData;
     }
@@ -1047,9 +1046,8 @@ static int CreateTextureAsync(lua_State* L)
     CheckCreateTextureResourceParams(L, &create_params);
 
     // We need to create an empty upload buffer if no explicit buffer is passed
-    bool is_transcoded              = create_params.m_CompressionType != dmGraphics::TextureImage::COMPRESSION_TYPE_DEFAULT && dmGraphics::IsFormatTranscoded(create_params.m_CompressionType);
-    bool use_raw_data               = create_params.m_Buffer == 0 || is_transcoded;
-    uint8_t* raw_data               = 0;
+    bool is_transcoded = dmGraphics::IsFormatTranscoded(create_params.m_CompressionType);
+    uint8_t* raw_data  = 0;
 
     if (create_params.m_Buffer == 0)
     {
@@ -1109,7 +1107,6 @@ static int CreateTextureAsync(lua_State* L)
     request->m_Buffer            = create_params.m_Buffer;
     request->m_PathHash          = create_params.m_PathHash;
     request->m_RawData           = raw_data;
-    request->m_UseRawData        = use_raw_data;
 
     dmGraphics::TextureParams texture_params;
     texture_params.m_Width  = create_params.m_Width;
@@ -1152,8 +1149,7 @@ static int CreateTextureAsync(lua_State* L)
         texture_params.m_Data     = decompressed_data;
         texture_params.m_DataSize = decompressed_data_size;
 
-        request->m_RawData    = decompressed_data;
-        request->m_UseRawData = true;
+        request->m_RawData = decompressed_data;
     }
 
     // Execute the upload, the upload buffer should now be locked by this request

--- a/engine/gamesys/src/gamesys/scripts/script_resource.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_resource.cpp
@@ -255,10 +255,11 @@ struct SetTextureAsyncRequest
     lua_State*                 m_LuaState;
     dmScript::LuaCallbackInfo* m_CallbackInfo;
     TextureResource*           m_TextureResource;
+    uint8_t*                   m_RawData;
     dmBuffer::HBuffer          m_Buffer;
     int32_t                    m_BufferRef;
     HOpaqueHandle              m_Handle;
-    bool                       m_UseUploadBuffer;
+    bool                       m_UseRawData;
 };
 
 struct ResourceModule
@@ -700,12 +701,11 @@ static void HandleRequestCompleted(dmGraphics::HTexture texture, void* user_data
         dmScript::DestroyCallback(request->m_CallbackInfo);
     }
 
-    // If we used a temporary upload buffer, we need to delete it.
-    if (request->m_UseUploadBuffer)
+    if (request->m_UseRawData)
     {
-        dmBuffer::Destroy(request->m_Buffer);
+        delete request->m_RawData;
     }
-    else
+    if (request->m_Buffer)
     {
         dmScript::Unref(request->m_LuaState, LUA_REGISTRYINDEX, request->m_BufferRef);
     }
@@ -1046,17 +1046,14 @@ static int CreateTextureAsync(lua_State* L)
     CreateTextureResourceParams create_params = {};
     CheckCreateTextureResourceParams(L, &create_params);
 
-    // Create an empty upload buffer
-    dmBuffer::HBuffer upload_buffer = create_params.m_Buffer;
-    bool use_upload_buffer = create_params.m_Buffer == 0;
-    if (use_upload_buffer)
+    // We need to create an empty upload buffer if no explicit buffer is passed
+    bool is_transcoded              = create_params.m_CompressionType != dmGraphics::TextureImage::COMPRESSION_TYPE_DEFAULT && dmGraphics::IsFormatTranscoded(create_params.m_CompressionType);
+    bool use_raw_data               = create_params.m_Buffer == 0 || is_transcoded;
+    uint8_t* raw_data               = 0;
+
+    if (create_params.m_Buffer == 0)
     {
-        const dmBuffer::StreamDeclaration streams_decl = {dmHashString64("data"), dmBuffer::VALUE_TYPE_UINT8, 1};
-        dmBuffer::Result r = dmBuffer::Create(create_params.m_Width * create_params.m_Height * create_params.m_TextureBpp, &streams_decl, 1, &upload_buffer);
-        if (r != dmBuffer::RESULT_OK)
-        {
-            return DM_LUA_ERROR("Unable to create an empty upload buffer: %s (%d)", dmBuffer::GetResultString(r), r);
-        }
+        raw_data = new uint8_t[create_params.m_Width * create_params.m_Height * create_params.m_TextureBpp];
     }
 
     // The callback is optional, we don't have to do anything with the result if we don't need to.
@@ -1070,6 +1067,9 @@ static int CreateTextureAsync(lua_State* L)
     create_texture_resource_params.m_Height     = 1;
     create_texture_resource_params.m_MaxMipMaps = 1;
     create_texture_resource_params.m_Buffer     = 0;
+
+    // We can't support a compression type here because the texture doesn't exist yet, so set it to a default.
+    create_texture_resource_params.m_CompressionType = dmGraphics::TextureImage::COMPRESSION_TYPE_DEFAULT;
 
     dmGraphics::TextureImage texture_image = {};
     MakeTextureImage(create_texture_resource_params, &texture_image);
@@ -1095,6 +1095,8 @@ static int CreateTextureAsync(lua_State* L)
 
     dmGraphics::TextureCreationParams texture_create_params;
     texture_create_params.m_Type = create_params.m_Type;
+    texture_create_params.m_Width = create_params.m_Width;
+    texture_create_params.m_Height = create_params.m_Height;
 
     dmGraphics::HTexture texture_dst = dmGraphics::NewTexture(g_ResourceModule.m_GraphicsContext, texture_create_params);
 
@@ -1104,23 +1106,54 @@ static int CreateTextureAsync(lua_State* L)
     request->m_TextureResource   = (TextureResource*) resource;
     request->m_Handle            = request_handle;
     request->m_CallbackInfo      = callback_info;
-    request->m_Buffer            = upload_buffer;
-    request->m_UseUploadBuffer   = use_upload_buffer;
+    request->m_Buffer            = create_params.m_Buffer;
     request->m_PathHash          = create_params.m_PathHash;
+    request->m_RawData           = raw_data;
+    request->m_UseRawData        = use_raw_data;
 
     dmGraphics::TextureParams texture_params;
     texture_params.m_Width  = create_params.m_Width;
     texture_params.m_Height = create_params.m_Height;
     texture_params.m_Format = create_params.m_Format;
 
-    dmBuffer::GetBytes(request->m_Buffer, (void**)&texture_params.m_Data, &texture_params.m_DataSize);
-
     // If we are not using a specifically created upload buffer, we push the Lua object and increase its ref count,
     // this is so that we can make sure that the buffer to live during the upload.
-    if (!use_upload_buffer)
+    if (create_params.m_Buffer)
     {
         lua_pushvalue(L, 3);
         request->m_BufferRef = dmScript::Ref(L, LUA_REGISTRYINDEX);
+    }
+
+    dmBuffer::GetBytes(request->m_Buffer, (void**) &texture_params.m_Data, &texture_params.m_DataSize);
+
+    // If the data is transcoded, we need an extra pass here to unpack the data before uploading it
+    if (is_transcoded)
+    {
+        assert(create_params.m_Buffer != 0);
+
+        uint32_t num_mips = 1;
+        texture_params.m_Format = dmGraphics::GetSupportedCompressionFormat(g_ResourceModule.m_GraphicsContext, texture_params.m_Format, texture_params.m_Width, texture_params.m_Height);
+
+        uint8_t* decompressed_data;
+        uint32_t decompressed_data_size;
+        uint32_t compressed_mipmap_size = texture_params.m_DataSize;
+
+        // TODO: Perhaps we should change the transcode function to not take an image? We only use these fields:
+        dmGraphics::TextureImage::Image compressed_image;
+        compressed_image.m_MipMapSize.m_Count           = 1;
+        compressed_image.m_MipMapSizeCompressed.m_Data  = &compressed_mipmap_size;
+        compressed_image.m_MipMapSizeCompressed.m_Count = 1;
+
+        if (!dmGraphics::Transcode(create_params.m_Path, &compressed_image, 1, (uint8_t*) texture_params.m_Data, texture_params.m_Format, &decompressed_data, &decompressed_data_size, &num_mips))
+        {
+            return DM_LUA_ERROR("Unable to transcode texture data");
+        }
+
+        texture_params.m_Data     = decompressed_data;
+        texture_params.m_DataSize = decompressed_data_size;
+
+        request->m_RawData    = decompressed_data;
+        request->m_UseRawData = true;
     }
 
     // Execute the upload, the upload buffer should now be locked by this request

--- a/engine/gamesys/src/gamesys/test/resource/create_texture.script
+++ b/engine/gamesys/src/gamesys/test/resource/create_texture.script
@@ -127,7 +127,7 @@ end
 
 function test_async_simple(self)
     self.requests = {}
-    
+
     -- Request with buffer + callback
     local tex_buffer = buffer.create(tparams.width * tparams.height, {{name = hash("data"), type = buffer.VALUE_TYPE_UINT8, count = 4 }})
     self.requests[1] = {}
@@ -185,6 +185,56 @@ function test_async_simple(self)
     collectgarbage("collect")
 end
 
+async_basis_test_done = false
+async_basis_tests_complete = 0
+
+function async_basis_test_completed(self)
+    async_basis_tests_complete = async_basis_tests_complete + 1
+    async_basis_test_done = async_basis_tests_complete == #self.requests_basis
+end
+
+function test_async_basis(self)
+    local host_path = sys.get_host_path("src/gamesys/test/resource/blank.basis")
+    local f     = io.open(host_path, "rb")
+    local c     = f:read("*all")
+    local fsize = f:seek("end")
+    f:close()
+
+    local tex_buffer = buffer.create(fsize, {{name = hash("data"), type = buffer.VALUE_TYPE_UINT8, count = 1 }})
+    local stream     = buffer.get_stream(tex_buffer, hash("data"))
+
+    for i=1, fsize do
+        stream[i] = c:byte(i)
+    end
+
+    local tparams = {
+        type             = graphics.TEXTURE_TYPE_2D,
+        width            = 32,
+        height           = 32,
+        format           = graphics.TEXTURE_FORMAT_RGB_ETC1,
+        compression_type = graphics.COMPRESSION_TYPE_BASIS_UASTC,
+    }
+
+    self.requests_basis = {}
+
+    -- Request with buffer + callback
+    self.requests_basis[1] = {}
+    self.requests_basis[1].path, self.requests_basis[1].id = resource.create_texture_async("/test_async_basis.texturec", tparams, tex_buffer,
+        function(self, request_id, result)
+            assert(request_id  == self.requests_basis[1].id)
+            assert(result.path == self.requests_basis[1].path)
+
+            local t_info = resource.get_texture_info(result.path)
+            assert(t_info.width == tparams.width)
+            assert(t_info.height == tparams.height)
+            async_basis_test_completed(self)
+        end)
+
+    local t_info = resource.get_texture_info(self.requests_basis[1].path)
+    assert(t_info.width  == 1)
+    assert(t_info.height == 1)
+end
+
 function test_get_texture_info()
     local t_id   = resource.create_texture("/test_get_texture_info.texturec", tparams)
     local t_info = resource.get_texture_info(t_id)
@@ -237,6 +287,7 @@ function update(self)
         test_get_texture_info,
         test_invalid,
         test_async_simple,
+        test_async_basis,
     }
 
     if tests[self.update_counter] ~= nil then

--- a/engine/gamesys/src/gamesys/test/resource/set_texture.script
+++ b/engine/gamesys/src/gamesys/test/resource/set_texture.script
@@ -13,110 +13,110 @@
 -- specific language governing permissions and limitations under the License.
 
 function init(self)
-	self.update_counter = 0
+    self.update_counter = 0
 end
 
 -- oridinal dimensions of the sprite is 84 x 67, but it gets downsized to 64 x 64
 local function test_success_simple(self)
-	local x             = 16
-	local y             = 16
-	local height        = 32
-	local width         = 32
-	local buf           = buffer.create(width * height, { {name=hash("rgb"), type=buffer.VALUE_TYPE_UINT8, count=3} } )
-	local resource_path = go.get("#sprite", "texture0")
-	local header = {
-		width        = width,
-		height       = height,
-		type         = graphics.TEXTURE_TYPE_2D,
-		format       = graphics.TEXTURE_FORMAT_RGB,
-		x            = x,
-		y            = y,
-	}
-	resource.set_texture(resource_path, header, buf)
+    local x             = 16
+    local y             = 16
+    local height        = 32
+    local width         = 32
+    local buf           = buffer.create(width * height, { {name=hash("rgb"), type=buffer.VALUE_TYPE_UINT8, count=3} } )
+    local resource_path = go.get("#sprite", "texture0")
+    local header = {
+        width        = width,
+        height       = height,
+        type         = graphics.TEXTURE_TYPE_2D,
+        format       = graphics.TEXTURE_FORMAT_RGB,
+        x            = x,
+        y            = y,
+    }
+    resource.set_texture(resource_path, header, buf)
 end
 
 local function test_success_resize(self)
-	local height        = 256
-	local width         = 256
-	local buf           = buffer.create(width * height, { {name=hash("rgb"), type=buffer.VALUE_TYPE_UINT8, count=3} } )
-	local resource_path = go.get("#sprite", "texture0")
-	local header = {
-		width        = width,
-		height       = height,
-		type         = graphics.TEXTURE_TYPE_2D,
-		format       = graphics.TEXTURE_FORMAT_RGB,
-	}
-	resource.set_texture(resource_path, header, buf)
+    local height        = 256
+    local width         = 256
+    local buf           = buffer.create(width * height, { {name=hash("rgb"), type=buffer.VALUE_TYPE_UINT8, count=3} } )
+    local resource_path = go.get("#sprite", "texture0")
+    local header = {
+        width        = width,
+        height       = height,
+        type         = graphics.TEXTURE_TYPE_2D,
+        format       = graphics.TEXTURE_FORMAT_RGB,
+    }
+    resource.set_texture(resource_path, header, buf)
 end
 
 local function test_fail_out_of_bounds(self)
-	local x             = 256
-	local y             = 256
-	local height        = 32
-	local width         = 32
-	local buf           = buffer.create(width * height, { {name=hash("rgb"), type=buffer.VALUE_TYPE_UINT8, count=3} } )
-	local resource_path = go.get("#sprite", "texture0")
-	local header = {
-		width        = width,
-		height       = height,
-		type         = graphics.TEXTURE_TYPE_2D,
-		format       = graphics.TEXTURE_FORMAT_RGB,
-		x            = x,
-		y            = y,
-	}
-	resource.set_texture(resource_path, header, buf)
+    local x             = 256
+    local y             = 256
+    local height        = 32
+    local width         = 32
+    local buf           = buffer.create(width * height, { {name=hash("rgb"), type=buffer.VALUE_TYPE_UINT8, count=3} } )
+    local resource_path = go.get("#sprite", "texture0")
+    local header = {
+        width        = width,
+        height       = height,
+        type         = graphics.TEXTURE_TYPE_2D,
+        format       = graphics.TEXTURE_FORMAT_RGB,
+        x            = x,
+        y            = y,
+    }
+    resource.set_texture(resource_path, header, buf)
 end
 
 local function test_fail_wrong_mipmap(self)
-	local height        = 1
-	local width         = 1
-	local buf           = buffer.create(width * height, { {name=hash("rgb"), type=buffer.VALUE_TYPE_UINT8, count=3} } )
-	local resource_path = go.get("#sprite", "texture0")
-	local header = {
-		width        = width,
-		height       = height,
-		type         = graphics.TEXTURE_TYPE_2D,
-		format       = graphics.TEXTURE_FORMAT_RGB,
-		mipmap       = 31,
-	}
-	resource.set_texture(resource_path, header, buf)
+    local height        = 1
+    local width         = 1
+    local buf           = buffer.create(width * height, { {name=hash("rgb"), type=buffer.VALUE_TYPE_UINT8, count=3} } )
+    local resource_path = go.get("#sprite", "texture0")
+    local header = {
+        width        = width,
+        height       = height,
+        type         = graphics.TEXTURE_TYPE_2D,
+        format       = graphics.TEXTURE_FORMAT_RGB,
+        mipmap       = 31,
+    }
+    resource.set_texture(resource_path, header, buf)
 end
 
 local function test_success_compressed(self)
     local host_path = sys.get_host_path("src/gamesys/test/resource/blank.basis")
-	local f     = io.open(host_path, "rb")
+    local f     = io.open(host_path, "rb")
     local c     = f:read("*all")
     local fsize = f:seek("end")
     f:close()
 
     local tex_buffer = buffer.create(fsize, {{name = hash("data"), type = buffer.VALUE_TYPE_UINT8, count = 1 }})
-	local stream     = buffer.get_stream(tex_buffer, hash("data"))
+    local stream     = buffer.get_stream(tex_buffer, hash("data"))
 
-	for i=1, fsize do
-		stream[i] = c:byte(i)
-	end
+    for i=1, fsize do
+        stream[i] = c:byte(i)
+    end
 
-	local args = {
-		type             = graphics.TEXTURE_TYPE_2D,
-		width            = 32,
-		height           = 32,
-		format           = graphics.TEXTURE_FORMAT_RGB_ETC1,
-		compression_type = graphics.COMPRESSION_TYPE_BASIS_UASTC,
-	}
+    local args = {
+        type             = graphics.TEXTURE_TYPE_2D,
+        width            = 32,
+        height           = 32,
+        format           = graphics.TEXTURE_FORMAT_RGB_ETC1,
+        compression_type = graphics.COMPRESSION_TYPE_BASIS_UASTC,
+    }
 
     resource.set_texture(go.get("#sprite", "texture0"), args, tex_buffer)
 end
 
 function update(self, dt)
-	self.update_counter = self.update_counter + 1
+    self.update_counter = self.update_counter + 1
 
-	local tests = {
-		test_success_simple,
-		test_success_resize,
-		test_fail_out_of_bounds,
-		test_fail_wrong_mipmap,
-		test_success_compressed,
-	}
+    local tests = {
+        test_success_simple,
+        test_success_resize,
+        test_fail_out_of_bounds,
+        test_fail_wrong_mipmap,
+        test_success_compressed,
+    }
 
-	tests[self.update_counter](self)
+    tests[self.update_counter](self)
 end

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -400,7 +400,9 @@ TEST_F(ResourceTest, TestCreateTextureFromScript)
 
     ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
 
+    // Wait until all async operations are done
     ASSERT_TRUE(UpdateAndWaitUntilDone(scriptlibcontext, m_Collection, &m_UpdateContext, false, "async_test_done"));
+    ASSERT_TRUE(UpdateAndWaitUntilDone(scriptlibcontext, m_Collection, &m_UpdateContext, false, "async_basis_test_done"));
 
     // cleanup
     DeleteInstance(m_Collection, go);


### PR DESCRIPTION
Fixed an issue where `resource.create_texture_async` only updated the width and height when setting the texture data, but it should have a valid width and height when _creating_ the texture as well. This would cause GUIs that use dynamic textures to crash, because the "original texture" dimensions were never set. The function can now properly use transcoded texture data as well.

Fixes #10078 