### PR TITLE
Add physics event checkbox to collison component

### DIFF
--- a/editor/src/clj/editor/collision_object.clj
+++ b/editor/src/clj/editor/collision_object.clj
@@ -394,7 +394,10 @@
         linear-damping :linear-damping
         angular-damping :angular-damping
         locked-rotation :locked-rotation
-        bullet :bullet)
+        bullet :bullet
+        event-collision :event-collision
+        event-contact :event-contact
+        event-trigger :event-trigger)
       (g/connect self :collision-group-node project :collision-group-nodes)
       (g/connect project :collision-groups-data self :collision-groups-data)
       (g/connect project :settings self :project-settings)
@@ -439,7 +442,7 @@
 
 (g/defnk produce-save-value
   [collision-shape-resource type mass friction restitution
-   group mask angular-damping linear-damping locked-rotation bullet
+   group mask angular-damping linear-damping locked-rotation bullet event-collision event-contact event-trigger
    shapes]
   (let [embedded-collision-shape (make-embedded-collision-shape shapes)
         mask (cond-> []
@@ -459,6 +462,9 @@
           :angular-damping angular-damping
           :locked-rotation locked-rotation
           :bullet bullet
+          :event-collision event-collision
+          :event-contact event-contact
+          :event-trigger event-trigger
           :embedded-collision-shape embedded-collision-shape)
         (strip-empty-embedded-collision-shape))))
 
@@ -583,6 +589,18 @@
             (default (protobuf/default Physics$CollisionObjectDesc :locked-rotation)))
   (property bullet g/Bool
             (default (protobuf/default Physics$CollisionObjectDesc :bullet)))
+  (property event-collision g/Bool
+            (dynamic label (g/constantly "Generate Collision Events"))
+            (dynamic tooltip (g/constantly "If disabled, filters out any collision events involving this collision object"))
+            (default (protobuf/default Physics$CollisionObjectDesc :event-collision)))
+  (property event-contact g/Bool
+            (dynamic label (g/constantly "Generate Contact Events"))
+            (dynamic tooltip (g/constantly "If disabled, filters out any contact events involving this collision object"))
+            (default (protobuf/default Physics$CollisionObjectDesc :event-contact)))
+  (property event-trigger g/Bool
+            (dynamic label (g/constantly "Generate Trigger Events"))
+            (dynamic tooltip (g/constantly "If disabled, filters out any trigger events involving this collision object"))
+            (default (protobuf/default Physics$CollisionObjectDesc :event-trigger)))
 
   (property group g/Str) ; Required protobuf field.
   (property mask g/Str) ; Nil is valid default.

--- a/editor/test/resources/save_data_project/checked01.collisionobject
+++ b/editor/test/resources/save_data_project/checked01.collisionobject
@@ -68,3 +68,6 @@ linear_damping: 0.1
 angular_damping: 0.1
 locked_rotation: true
 bullet: true
+event_collision: false
+event_contact: false
+event_trigger: false

--- a/editor/test/resources/save_data_project/checked02.collisionobject
+++ b/editor/test/resources/save_data_project/checked02.collisionobject
@@ -65,3 +65,6 @@ linear_damping: 0.1
 angular_damping: 0.1
 locked_rotation: true
 bullet: true
+event_collision: false
+event_contact: false
+event_trigger: false

--- a/engine/gamesys/proto/gamesys/physics_ddf.proto
+++ b/engine/gamesys/proto/gamesys/physics_ddf.proto
@@ -99,6 +99,10 @@ message CollisionObjectDesc
     optional float                  angular_damping = 10 [default=0];
     optional bool                   locked_rotation = 11 [default=false];
     optional bool                   bullet          = 12 [default=false];
+    // Should the component generate events
+    optional bool                   event_collision = 13 [default=true];
+    optional bool                   event_contact   = 14 [default=true];
+    optional bool                   event_trigger   = 15 [default=true];
 }
 
 /*# Collision object physics API documentation

--- a/engine/gamesys/src/gamesys/components/comp_collision_object.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_collision_object.cpp
@@ -91,6 +91,13 @@ namespace dmGameSystem
         JointEntry* m_JointEntry;
     };
 
+    enum EventMask
+    {
+        EVENT_MASK_COLLISION = 1 << 0,
+        EVENT_MASK_CONTACT   = 1 << 1,
+        EVENT_MASK_TRIGGER   = 1 << 2,
+    };
+
     struct CollisionComponent
     {
         CollisionObjectResource* m_Resource;
@@ -125,6 +132,7 @@ namespace dmGameSystem
         uint8_t m_StartAsEnabled : 1;
         uint8_t m_FlippedX : 1; // set if it's been flipped
         uint8_t m_FlippedY : 1;
+        uint8_t m_EventMask : 3;
     };
 
     struct CollisionWorld
@@ -390,6 +398,11 @@ namespace dmGameSystem
         dmPhysics::CollisionObjectData data;
         SetCollisionObjectData(world, component, resource, ddf, enabled, data);
         component->m_Mask = data.m_Mask;
+
+        component->m_EventMask  = ddf->m_EventCollision?EVENT_MASK_COLLISION:0;
+        component->m_EventMask |= ddf->m_EventContact?EVENT_MASK_CONTACT:0;
+        component->m_EventMask |= ddf->m_EventTrigger?EVENT_MASK_TRIGGER:0;
+
         if (physics_context->m_3D)
         {
             if (resource->m_TileGrid)
@@ -594,21 +607,34 @@ namespace dmGameSystem
         }
     }
 
-    void RunPhysicsCallback(CollisionWorld* world, const dmDDF::Descriptor* desc, const char* data)
+    static void RunPhysicsCallback(CollisionWorld* world, const dmDDF::Descriptor* desc, const char* data)
     {
         RunCollisionWorldCallback(world->m_CallbackInfo, desc, data);
     }
 
-    bool CollisionCallback(void* user_data_a, uint16_t group_a, void* user_data_b, uint16_t group_b, void* user_data)
+    // Returns true if either of the components supports the flag(s)
+    static bool SupportsEvent(CollisionComponent* component, uint8_t event)
+    {
+        return (component->m_EventMask & event) == event;
+    }
+
+    static bool CollisionCallback(void* user_data_a, uint16_t group_a, void* user_data_b, uint16_t group_b, void* user_data)
     {
         CollisionUserData* cud = (CollisionUserData*)user_data;
         if (cud->m_Count < cud->m_Context->m_MaxCollisionCount)
         {
             CollisionWorld* world = cud->m_World;
-            cud->m_Count += 1;
 
             CollisionComponent* component_a = (CollisionComponent*)user_data_a;
             CollisionComponent* component_b = (CollisionComponent*)user_data_b;
+
+            bool event_supported_a = SupportsEvent(component_a, EVENT_MASK_COLLISION);
+            bool event_supported_b = SupportsEvent(component_b, EVENT_MASK_COLLISION);
+            if (!event_supported_a && event_supported_a == event_supported_b)
+                return false; // Neither supported this event
+
+            cud->m_Count += 1;
+
             dmGameObject::HInstance instance_a = component_a->m_Instance;
             dmGameObject::HInstance instance_b = component_b->m_Instance;
             dmhash_t instance_a_id = dmGameObject::GetIdentifier(instance_a);
@@ -634,23 +660,29 @@ namespace dmGameSystem
                 return true;
             }
 
-            dmPhysicsDDF::CollisionResponse ddf;
-
             // Broadcast to A components
-            ddf.m_OwnGroup = group_hash_a;
-            ddf.m_OtherGroup = group_hash_b;
-            ddf.m_Group = group_hash_b;
-            ddf.m_OtherId = instance_b_id;
-            ddf.m_OtherPosition = dmGameObject::GetWorldPosition(instance_b);
-            BroadCast(&ddf, instance_a, instance_a_id, component_a->m_ComponentIndex);
+            if (event_supported_a)
+            {
+                dmPhysicsDDF::CollisionResponse ddf;
+                ddf.m_OwnGroup = group_hash_a;
+                ddf.m_OtherGroup = group_hash_b;
+                ddf.m_Group = group_hash_b;
+                ddf.m_OtherId = instance_b_id;
+                ddf.m_OtherPosition = dmGameObject::GetWorldPosition(instance_b);
+                BroadCast(&ddf, instance_a, instance_a_id, component_a->m_ComponentIndex);
+            }
 
             // Broadcast to B components
-            ddf.m_OwnGroup = group_hash_b;
-            ddf.m_OtherGroup = group_hash_a;
-            ddf.m_Group = group_hash_a;
-            ddf.m_OtherId = instance_a_id;
-            ddf.m_OtherPosition = dmGameObject::GetWorldPosition(instance_a);
-            BroadCast(&ddf, instance_b, instance_b_id, component_b->m_ComponentIndex);
+            if (event_supported_b)
+            {
+                dmPhysicsDDF::CollisionResponse ddf;
+                ddf.m_OwnGroup = group_hash_b;
+                ddf.m_OtherGroup = group_hash_a;
+                ddf.m_Group = group_hash_a;
+                ddf.m_OtherId = instance_a_id;
+                ddf.m_OtherPosition = dmGameObject::GetWorldPosition(instance_a);
+                BroadCast(&ddf, instance_b, instance_b_id, component_b->m_ComponentIndex);
+            }
 
             return true;
         }
@@ -660,16 +692,23 @@ namespace dmGameSystem
         }
     }
 
-    bool ContactPointCallback(const dmPhysics::ContactPoint& contact_point, void* user_data)
+    static bool ContactPointCallback(const dmPhysics::ContactPoint& contact_point, void* user_data)
     {
         CollisionUserData* cud = (CollisionUserData*)user_data;
         if (cud->m_Count < cud->m_Context->m_MaxContactPointCount)
         {
             CollisionWorld* world = cud->m_World;
-            cud->m_Count += 1;
 
             CollisionComponent* component_a = (CollisionComponent*)contact_point.m_UserDataA;
             CollisionComponent* component_b = (CollisionComponent*)contact_point.m_UserDataB;
+
+            bool event_supported_a = SupportsEvent(component_a, EVENT_MASK_CONTACT);
+            bool event_supported_b = SupportsEvent(component_b, EVENT_MASK_CONTACT);
+            if (!event_supported_a && event_supported_a == event_supported_b)
+                return false; // Neither supported this event
+
+            cud->m_Count += 1;
+
             dmGameObject::HInstance instance_a = component_a->m_Instance;
             dmGameObject::HInstance instance_b = component_b->m_Instance;
             dmhash_t instance_a_id = dmGameObject::GetIdentifier(instance_a);
@@ -707,39 +746,45 @@ namespace dmGameSystem
                 return true;
             }
 
-            dmPhysicsDDF::ContactPointResponse ddf;
-
             // Broadcast to A components
-            ddf.m_Position = contact_point.m_PositionA;
-            ddf.m_Normal = -contact_point.m_Normal;
-            ddf.m_RelativeVelocity = -contact_point.m_RelativeVelocity;
-            ddf.m_Distance = contact_point.m_Distance;
-            ddf.m_AppliedImpulse = contact_point.m_AppliedImpulse;
-            ddf.m_Mass = mass_a;
-            ddf.m_OtherMass = mass_b;
-            ddf.m_OtherId = instance_b_id;
-            ddf.m_OtherPosition = dmGameObject::GetWorldPosition(instance_b);
-            ddf.m_Group = group_hash_b;
-            ddf.m_OwnGroup = group_hash_a;
-            ddf.m_OtherGroup = group_hash_b;
-            ddf.m_LifeTime = 0;
-            BroadCast(&ddf, instance_a, instance_a_id, component_a->m_ComponentIndex);
+            if (event_supported_a)
+            {
+                dmPhysicsDDF::ContactPointResponse ddf;
+                ddf.m_Position = contact_point.m_PositionA;
+                ddf.m_Normal = -contact_point.m_Normal;
+                ddf.m_RelativeVelocity = -contact_point.m_RelativeVelocity;
+                ddf.m_Distance = contact_point.m_Distance;
+                ddf.m_AppliedImpulse = contact_point.m_AppliedImpulse;
+                ddf.m_Mass = mass_a;
+                ddf.m_OtherMass = mass_b;
+                ddf.m_OtherId = instance_b_id;
+                ddf.m_OtherPosition = dmGameObject::GetWorldPosition(instance_b);
+                ddf.m_Group = group_hash_b;
+                ddf.m_OwnGroup = group_hash_a;
+                ddf.m_OtherGroup = group_hash_b;
+                ddf.m_LifeTime = 0;
+                BroadCast(&ddf, instance_a, instance_a_id, component_a->m_ComponentIndex);
+            }
 
             // Broadcast to B components
-            ddf.m_Position = contact_point.m_PositionB;
-            ddf.m_Normal = contact_point.m_Normal;
-            ddf.m_RelativeVelocity = contact_point.m_RelativeVelocity;
-            ddf.m_Distance = contact_point.m_Distance;
-            ddf.m_AppliedImpulse = contact_point.m_AppliedImpulse;
-            ddf.m_Mass = mass_b;
-            ddf.m_OtherMass = mass_a;
-            ddf.m_OtherId = instance_a_id;
-            ddf.m_OtherPosition = dmGameObject::GetWorldPosition(instance_a);
-            ddf.m_Group = group_hash_a;
-            ddf.m_OwnGroup = group_hash_b;
-            ddf.m_OtherGroup = group_hash_a;
-            ddf.m_LifeTime = 0;
-            BroadCast(&ddf, instance_b, instance_b_id, component_b->m_ComponentIndex);
+            if (event_supported_b)
+            {
+                dmPhysicsDDF::ContactPointResponse ddf;
+                ddf.m_Position = contact_point.m_PositionB;
+                ddf.m_Normal = contact_point.m_Normal;
+                ddf.m_RelativeVelocity = contact_point.m_RelativeVelocity;
+                ddf.m_Distance = contact_point.m_Distance;
+                ddf.m_AppliedImpulse = contact_point.m_AppliedImpulse;
+                ddf.m_Mass = mass_b;
+                ddf.m_OtherMass = mass_a;
+                ddf.m_OtherId = instance_a_id;
+                ddf.m_OtherPosition = dmGameObject::GetWorldPosition(instance_a);
+                ddf.m_Group = group_hash_a;
+                ddf.m_OwnGroup = group_hash_b;
+                ddf.m_OtherGroup = group_hash_a;
+                ddf.m_LifeTime = 0;
+                BroadCast(&ddf, instance_b, instance_b_id, component_b->m_ComponentIndex);
+            }
 
             return true;
         }
@@ -752,11 +797,17 @@ namespace dmGameSystem
     static bool g_CollisionOverflowWarning = false;
     static bool g_ContactOverflowWarning = false;
 
-    void TriggerEnteredCallback(const dmPhysics::TriggerEnter& trigger_enter, void* user_data)
+    static void TriggerEnteredCallback(const dmPhysics::TriggerEnter& trigger_enter, void* user_data)
     {
         CollisionWorld* world = (CollisionWorld*)user_data;
         CollisionComponent* component_a = (CollisionComponent*)trigger_enter.m_UserDataA;
         CollisionComponent* component_b = (CollisionComponent*)trigger_enter.m_UserDataB;
+
+        bool event_supported_a = SupportsEvent(component_a, EVENT_MASK_TRIGGER);
+        bool event_supported_b = SupportsEvent(component_b, EVENT_MASK_TRIGGER);
+        if (!event_supported_a && event_supported_a == event_supported_b)
+            return; // Neither supported this event
+
         dmGameObject::HInstance instance_a = component_a->m_Instance;
         dmGameObject::HInstance instance_b = component_b->m_Instance;
         dmhash_t instance_a_id = dmGameObject::GetIdentifier(instance_a);
@@ -767,7 +818,6 @@ namespace dmGameSystem
 
         if (world->m_CallbackInfo != 0x0)
         {
-
             dmPhysicsDDF::TriggerEvent ddf;
             ddf.m_Enter = 1;
 
@@ -787,18 +837,24 @@ namespace dmGameSystem
         ddf.m_Enter = 1;
 
         // Broadcast to A components
-        ddf.m_OtherId = instance_b_id;
-        ddf.m_Group = group_hash_b;
-        ddf.m_OwnGroup = group_hash_a;
-        ddf.m_OtherGroup = group_hash_b;
-        BroadCast(&ddf, instance_a, instance_a_id, component_a->m_ComponentIndex);
+        if (event_supported_a)
+        {
+            ddf.m_OtherId = instance_b_id;
+            ddf.m_Group = group_hash_b;
+            ddf.m_OwnGroup = group_hash_a;
+            ddf.m_OtherGroup = group_hash_b;
+            BroadCast(&ddf, instance_a, instance_a_id, component_a->m_ComponentIndex);
+        }
 
         // Broadcast to B components
-        ddf.m_OtherId = instance_a_id;
-        ddf.m_Group = group_hash_a;
-        ddf.m_OwnGroup = group_hash_b;
-        ddf.m_OtherGroup = group_hash_a;
-        BroadCast(&ddf, instance_b, instance_b_id, component_b->m_ComponentIndex);
+        if (event_supported_b)
+        {
+            ddf.m_OtherId = instance_a_id;
+            ddf.m_Group = group_hash_a;
+            ddf.m_OwnGroup = group_hash_b;
+            ddf.m_OtherGroup = group_hash_a;
+            BroadCast(&ddf, instance_b, instance_b_id, component_b->m_ComponentIndex);
+        }
     }
 
     void TriggerExitedCallback(const dmPhysics::TriggerExit& trigger_exit, void* user_data)


### PR DESCRIPTION
The collision component now has 3 checkboxes, allowing you to disable the object generating redundant events.
When two collision objects interact, we check if we should send a message to the user, given these checkboxes.
This helps to greatly reduce number of physics events passed to from the engine to the Lua scripting.

E.g. given the "Generate Contact Events" checkboxes:

When using `physics.set_listener()`:

| Component A | Component B | Send Message |
|-------------|-------------|--------------|
| ✅︎          | ✅︎          | Yes          |
| ❌          | ✅︎          | Yes          |
| ✅︎          | ❌          | Yes          |
| ❌          | ❌          | No           |

When using the default message handler:

| Component A | Component B | Send Message(s)  |
|-------------|-------------|------------------|
| ✅︎          | ✅︎          | Yes (A,B) + (B,A) |
| ❌          | ✅︎          | Yes (B,A)         |
| ✅︎          | ❌          | Yes (A,B)         |
| ❌          | ❌          | No                |


Fixes https://github.com/defold/defold/issues/10085

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
