### PR TITLE
Default to `$XDG_STATE_HOME/Defold` instead of `$HOME/.Defold` for Linux logs

### DIFF
--- a/editor/src/java/com/defold/util/SupportPath.java
+++ b/editor/src/java/com/defold/util/SupportPath.java
@@ -92,26 +92,27 @@ public class SupportPath {
         if (userHome == null) {
             return null;
         }
+        final Path home = Paths.get(userHome);
 
         // 1. $HOME/.Defold
-        final Path homeDefold = Paths.get(userHome, "." + applicationName);
-        if (Files.isDirectory(homeDefold)) {
-            return userHome.resolve("." + applicationName);
+        final Path homeDefoldDir = home.resolve("." + applicationName);
+        if (Files.isDirectory(homeDefoldDir)) {
+            return homeDefoldDir;
         }
 
         // 2. $XDG_STATE_HOME
-        final String localStateEnv = System.getenv("XDG_STATE_HOME");
-        if (localStateEnv != null) {
-            Path localState = Paths.get(localStateEnv);
-            if (Files.isDirectory(localState)) {
-                return localState.resolve(applicationName);
+        final String xdgStateEnv = System.getenv("XDG_STATE_HOME");
+        if (xdgStateEnv != null) {
+            Path xdgStateHome = Paths.get(xdgStateEnv);
+            if (Files.isDirectory(xdgStateHome)) {
+                return xdgStateHome.resolve(applicationName);
             }
         }
 
         // 3. $HOME/.local/state
-        final Path home = Paths.get(userHome);
         if (Files.isDirectory(home)) {
-            return home.resolve(".local", "state", applicationName);
+            Path homeLocalState = Paths.get(userHome, ".local", "state");
+            return homeLocalState.resolve(applicationName);
         }
 
         return null;

--- a/editor/src/java/com/defold/util/SupportPath.java
+++ b/editor/src/java/com/defold/util/SupportPath.java
@@ -94,13 +94,7 @@ public class SupportPath {
         }
         final Path home = Paths.get(userHome);
 
-        // 1. $HOME/.Defold
-        final Path homeDefoldDir = home.resolve("." + applicationName);
-        if (Files.isDirectory(homeDefoldDir)) {
-            return homeDefoldDir;
-        }
-
-        // 2. $XDG_STATE_HOME
+        // 1. $XDG_STATE_HOME
         final String xdgStateEnv = System.getenv("XDG_STATE_HOME");
         if (xdgStateEnv != null) {
             Path xdgStateHome = Paths.get(xdgStateEnv);
@@ -109,7 +103,7 @@ public class SupportPath {
             }
         }
 
-        // 3. $HOME/.local/state
+        // 2. $HOME/.local/state
         if (Files.isDirectory(home)) {
             Path homeLocalState = Paths.get(userHome, ".local", "state");
             return homeLocalState.resolve(applicationName);

--- a/editor/src/java/com/defold/util/SupportPath.java
+++ b/editor/src/java/com/defold/util/SupportPath.java
@@ -87,29 +87,14 @@ public class SupportPath {
     // linux
 
     private static Path getLinuxSupportPath(String applicationName) {
-        // Ensure we have a user.home set
-        final String userHome = System.getProperty("user.home");
-        if (userHome == null) {
-            return null;
+        final String xdgStateHome = System.getenv("XDG_STATE_HOME");
+        if (xdgStateHome != null) {
+            // 1. $XDG_STATE_HOME
+            return Path.of(xdgStateHome, applicationName);
+        } else {
+            // 2. ~/.local/state
+            return Path.of(System.getProperty("user.home"), ".local", "state", applicationName);
         }
-        final Path home = Paths.get(userHome);
-
-        // 1. $XDG_STATE_HOME
-        final String xdgStateEnv = System.getenv("XDG_STATE_HOME");
-        if (xdgStateEnv != null) {
-            Path xdgStateHome = Paths.get(xdgStateEnv);
-            if (Files.isDirectory(xdgStateHome)) {
-                return xdgStateHome.resolve(applicationName);
-            }
-        }
-
-        // 2. $HOME/.local/state
-        if (Files.isDirectory(home)) {
-            Path homeLocalState = Paths.get(userHome, ".local", "state");
-            return homeLocalState.resolve(applicationName);
-        }
-
-        return null;
     }
 
     public static void main(String[] args) {

--- a/editor/src/java/com/defold/util/SupportPath.java
+++ b/editor/src/java/com/defold/util/SupportPath.java
@@ -87,13 +87,31 @@ public class SupportPath {
     // linux
 
     private static Path getLinuxSupportPath(String applicationName) {
+        // Ensure we have a user.home set
         final String userHome = System.getProperty("user.home");
         if (userHome == null) {
             return null;
         }
+
+        // 1. $HOME/.Defold
+        final Path homeDefold = Paths.get(userHome, "." + applicationName);
+        if (Files.isDirectory(homeDefold)) {
+            return userHome.resolve("." + applicationName);
+        }
+
+        // 2. $XDG_STATE_HOME
+        final String localStateEnv = System.getenv("XDG_STATE_HOME");
+        if (localStateEnv != null) {
+            Path localState = Paths.get(localStateEnv);
+            if (Files.isDirectory(localState)) {
+                return localState.resolve(applicationName);
+            }
+        }
+
+        // 3. $HOME/.local/state
         final Path home = Paths.get(userHome);
         if (Files.isDirectory(home)) {
-            return home.resolve("." + applicationName);
+            return home.resolve(".local", "state", applicationName);
         }
 
         return null;

--- a/editor/src/java/com/defold/util/SupportPath.java
+++ b/editor/src/java/com/defold/util/SupportPath.java
@@ -91,10 +91,10 @@ public class SupportPath {
         if (xdgStateHome != null) {
             // 1. $XDG_STATE_HOME
             return Path.of(xdgStateHome, applicationName);
-        } else {
-            // 2. ~/.local/state
-            return Path.of(System.getProperty("user.home"), ".local", "state", applicationName);
         }
+
+        // 2. ~/.local/state
+        return Path.of(System.getProperty("user.home"), ".local", "state", applicationName);
     }
 
     public static void main(String[] args) {


### PR DESCRIPTION
On Linux, the `.Defold` folder was hardcoded to the `$HOME` folder. It now follows the XDG spec and uses `$XDG_STATE_HOME` or `$HOME/.local/state/Defold`.

Fixes #10102

### Technical changes
* It would be better to search for the $XDG_STATE_HOME env first, but that would force current users who also have the env set to do an unpack and split their logs (which I would consider a breaking change)
* Please note line 97 and 99 `Paths.get(userHome, "." + applicationName)` might match if applicationName = "" because `.` refers to the folder itself (i.e. `$HOME/.` can return `$HOME`). 
This shouldn't be an issue, it is only called through `getSupportPath()` which calls with applicationName = "Defold", and it's been present since the file was created, but it is worth noting.
* I haven't had the ability to build Defold yet