### PR TITLE
Disable change tracking for initial project load transactions

### DIFF
--- a/editor/src/clj/dynamo/graph.clj
+++ b/editor/src/clj/dynamo/graph.clj
@@ -200,7 +200,8 @@
          override-id-generator (is/override-id-generator system)
          tx-data-context-map (or (:tx-data-context-map opts) {})
          metrics-collector (:metrics opts)
-         transaction-context (it/new-transaction-context basis id-generators override-id-generator tx-data-context-map metrics-collector)
+         track-changes (:track-changes opts true)
+         transaction-context (it/new-transaction-context basis id-generators override-id-generator tx-data-context-map metrics-collector track-changes)
          tx-result (it/transact* transaction-context txs)]
      (when (and (not (:dry-run opts))
                 (= :ok (:status tx-result)))
@@ -226,16 +227,6 @@
  "Returns a list of the node-ids added given a result from a transaction, (tx-result)."
   [tx-result]
   (:nodes-added tx-result))
-
-(defn is-added?
-  "Returns a boolean if a node was added as a result of a transaction given a tx-result and node."
-  [tx-result node-id]
-  (contains? (:nodes-added tx-result) node-id))
-
-(defn is-deleted?
-  "Returns a boolean if a node was delete as a result of a transaction given a tx-result and node."
-  [tx-result node-id]
-  (contains? (:nodes-deleted tx-result) node-id))
 
 (defn transaction-basis
   "Returns the final basis from the result of a transaction given a tx-result"

--- a/editor/src/clj/editor/defold_project.clj
+++ b/editor/src/clj/editor/defold_project.clj
@@ -377,10 +377,9 @@
     (g/cache-output-values! endpoint+cached-value-pairs)
     (log-cache-info! (g/cache) "Cached loaded save data in system cache.")))
 
-(defn- load-nodes-into-graph! [node-load-infos project progress-loading! resource-metrics transaction-metrics]
+(defn- load-nodes-into-graph! [node-load-infos project progress-loading! resource-metrics transact-opts]
   (let [tx-data (load-tx-data node-load-infos project progress-loading! resource-metrics)
-        tx-opts (du/when-metrics {:metrics transaction-metrics})
-        tx-result (g/transact tx-opts tx-data)
+        tx-result (g/transact transact-opts tx-data)
         basis (:basis tx-result)]
     ;; Return the set of migrated resource node ids, if any.
     (into #{}
@@ -408,7 +407,7 @@
 
 (declare workspace)
 
-(defn- load-nodes! [project node-ids render-progress! old-resource-node-dependencies resource-metrics transaction-metrics]
+(defn- load-nodes! [project node-ids render-progress! old-resource-node-dependencies resource-metrics transact-opts]
   (let [workspace (workspace project)
         old-resource-node-ids-by-proj-path (g/node-value project :nodes-by-resource-path)
 
@@ -426,26 +425,26 @@
 
     (store-loaded-disk-sha256-hashes! node-load-infos workspace)
     (store-loaded-source-values! node-load-infos)
-    (let [migrated-resource-node-ids (load-nodes-into-graph! node-load-infos project progress-loading! resource-metrics transaction-metrics)
+    (let [migrated-resource-node-ids (load-nodes-into-graph! node-load-infos project progress-loading! resource-metrics transact-opts)
           basis (g/now)
           migrated-proj-paths (into (sorted-set)
                                     (map #(resource/proj-path (resource-node/resource basis %)))
                                     migrated-resource-node-ids)]
-      (cache-loaded-save-data! node-load-infos project migrated-resource-node-ids)
-      (render-progress! progress/done)
 
       ;; Log any migrated proj-paths.
       ;; Disabled during tests to minimize log spam.
       (when (and (pos? (count migrated-proj-paths))
                  (not (Boolean/getBoolean "defold.tests")))
-        (log/info :message "Some files were migrated and will be saved in an updated format." :migrated-proj-paths migrated-proj-paths)))
-    node-load-infos))
+        (log/info :message "Some files were migrated and will be saved in an updated format." :migrated-proj-paths migrated-proj-paths))
 
-(defn- make-nodes! [project resources]
+      {:migrated-resource-node-ids migrated-resource-node-ids
+       :node-load-infos node-load-infos})))
+
+(defn- make-nodes! [project resources transact-opts]
   (let [project-graph (graph project)
         file-resources (filter #(= :file (resource/source-type %)) resources)]
     (g/tx-nodes-added
-      (g/transact
+      (g/transact transact-opts
         (for [[resource-type resources] (group-by resource/resource-type file-resources)
               :let [node-type (resource-type->node-type resource-type)]
               resource resources]
@@ -498,20 +497,38 @@
    (let [process-metrics (du/make-metrics-collector)
          resource-metrics (du/make-metrics-collector)
          transaction-metrics (du/make-metrics-collector)
+
+         ;; We can disable change tracking on the initial load since we have
+         ;; nothing in the cache and will reset the undo history afterward.
+         change-tracked-transact false
+
+         transact-opts {:metrics transaction-metrics
+                        :track-changes change-tracked-transact}
+
          nodes (du/measuring process-metrics :make-new-nodes
-                 (make-nodes! project resources))]
+                 (make-nodes! project resources transact-opts))]
+
+     ;; When we're not tracking changes, we will not evict stale values from the
+     ;; system cache. This means subsequent graph queries won't see the changes
+     ;; from the transaction if a value was previously cached. To be on the safe
+     ;; side, we clear the cache after each transaction we perform with change
+     ;; tracking disabled.
+     (when-not change-tracked-transact
+       (g/clear-system-cache!))
 
      ;; Make sure the game.project node is property connected before loading
      ;; the resource nodes, since establishing these connections will
      ;; invalidate any dependent outputs in the cache.
      (when-let [game-project (get-resource-node project "/game.project")]
        (let [script-intel (script-intelligence project)]
-         (g/transact
+         (g/transact transact-opts
            (concat
              (g/connect script-intel :build-errors game-project :build-errors)
              (g/connect game-project :display-profiles-data project :display-profiles)
              (g/connect game-project :texture-profiles-data project :texture-profiles)
-             (g/connect game-project :settings-map project :settings)))))
+             (g/connect game-project :settings-map project :settings)))
+         (when-not change-tracked-transact
+           (g/clear-system-cache!))))
 
      ;; Load the resource nodes. Referenced nodes will be loaded prior to
      ;; nodes that refer to them, provided the :dependencies-fn reports the
@@ -521,8 +538,13 @@
      ;; texture profiles and image resources. We probably want to ensure the
      ;; texture profiles are loaded before anything that makes implicit use of
      ;; them to avoid potentially costly cache invalidation.
-     (du/measuring process-metrics :load-new-nodes
-       (load-nodes! project nodes render-progress! {} resource-metrics transaction-metrics))
+     (let [{:keys [migrated-resource-node-ids node-load-infos]}
+           (du/measuring process-metrics :load-new-nodes
+             (load-nodes! project nodes render-progress! {} resource-metrics transact-opts))]
+       (when-not change-tracked-transact
+         (g/clear-system-cache!))
+       (cache-loaded-save-data! node-load-infos project migrated-resource-node-ids)
+       (render-progress! progress/done))
      (du/when-metrics
        (reset! load-metrics-atom
                {:new-nodes-by-path (g/node-value project :nodes-by-resource-path)
@@ -743,7 +765,7 @@
                                                      (dependencies-fn save-value))))))))
         resource->old-node (comp old-nodes-by-path resource/proj-path)
         new-nodes (du/measuring process-metrics :make-new-nodes
-                    (make-nodes! project (:new plan)))
+                    (make-nodes! project (:new plan) transact-opts))
         resource-path->new-node (g/with-auto-evaluation-context evaluation-context
                                   (into {}
                                         (map (fn [resource-node]
@@ -781,11 +803,15 @@
         (for [node (:delete plan)]
           (g/delete-node node))))
 
-    (du/measuring process-metrics :load-new-nodes
-      (load-nodes! project new-nodes render-progress! old-resource-node-dependencies resource-metrics transaction-metrics))
-
-    (du/measuring process-metrics :update-cache
-      (g/update-cache-from-evaluation-context! rn-dependencies-evaluation-context))
+    (let [{:keys [migrated-resource-node-ids node-load-infos]}
+          (du/measuring process-metrics :load-new-nodes
+            (load-nodes! project new-nodes render-progress! old-resource-node-dependencies resource-metrics transact-opts))]
+      (du/measuring process-metrics :update-cache-with-dependencies
+        ;; TODO: Investigate if we should even be doing this. Evaluates save-value output, but aren't they stale?
+        (g/update-cache-from-evaluation-context! rn-dependencies-evaluation-context))
+      (du/measuring process-metrics :update-cache-with-save-data
+        (cache-loaded-save-data! node-load-infos project migrated-resource-node-ids))
+      (render-progress! progress/done))
 
     (du/measuring process-metrics :transfer-outgoing-arcs
       (g/transact transact-opts
@@ -1101,6 +1127,7 @@
 (defn make-project [graph workspace-id extensions]
   (let [plugin-graph (g/make-graph! :history false :volatility 2)
         code-preprocessors (workspace/code-preprocessors workspace-id)
+
         transpilers-id
         (first
           (g/tx-nodes-added

--- a/editor/src/clj/editor/lsp/async.clj
+++ b/editor/src/clj/editor/lsp/async.clj
@@ -13,8 +13,8 @@
 ;; specific language governing permissions and limitations under the License.
 
 (ns editor.lsp.async
-  (:require [clojure.core.async :as a :refer [<! >!]]
-            [editor.ui :as ui])
+  (:require [cljfx.api :as fx]
+            [clojure.core.async :as a :refer [<! >!]])
   (:import [clojure.core.async.impl.channels ManyToManyChannel]))
 
 (set! *warn-on-reflection* true)
@@ -105,5 +105,5 @@
   [ec & body]
   `(let [~ec (g/make-evaluation-context)
          ret# (do ~@body)]
-     (ui/run-later (g/update-cache-from-evaluation-context! ~ec))
+     (fx/on-fx-thread (g/update-cache-from-evaluation-context! ~ec))
      ret#))

--- a/editor/src/clj/internal/system.clj
+++ b/editor/src/clj/internal/system.clj
@@ -351,6 +351,7 @@
 
 (defn update-cache-from-evaluation-context
   [system evaluation-context]
+  {:pre [(some? system)]}
   ;; We assume here that the evaluation context was created from
   ;; the system but they may have diverged, making some cache
   ;; hits/misses invalid.

--- a/editor/src/clj/internal/transaction.clj
+++ b/editor/src/clj/internal/transaction.clj
@@ -190,49 +190,57 @@
 (defn- mark-input-activated
   [ctx node-id input-label]
   ;; This gets called a lot, so we're trying to keep allocations to a minimum.
-  (let [basis (:basis ctx)
-        dirty-deps (-> (gt/node-by-id-at basis node-id)
-                       gt/node-type
-                       in/input-dependencies
-                       (get input-label))
-        nodes-affected (:nodes-affected ctx)]
-    (assoc ctx
-      :nodes-affected
-      (into nodes-affected
-            (map #(gt/endpoint node-id %))
-            dirty-deps))))
+  (if-not (:track-changes ctx)
+    ctx
+    (let [basis (:basis ctx)
+          dirty-deps (-> (gt/node-by-id-at basis node-id)
+                         gt/node-type
+                         in/input-dependencies
+                         (get input-label))
+          nodes-affected (:nodes-affected ctx)]
+      (assoc ctx
+        :nodes-affected
+        (into nodes-affected
+              (map #(gt/endpoint node-id %))
+              dirty-deps)))))
 
 (defn- mark-output-activated
   [ctx node-id output-label]
   ;; This gets called a lot, so we're trying to keep allocations to a minimum.
-  (let [nodes-affected (:nodes-affected ctx)]
-    (assoc ctx
-      :nodes-affected
-      (conj nodes-affected (gt/endpoint node-id output-label)))))
+  (if-not (:track-changes ctx)
+    ctx
+    (let [nodes-affected (:nodes-affected ctx)]
+      (assoc ctx
+        :nodes-affected
+        (conj nodes-affected (gt/endpoint node-id output-label))))))
 
 (defn- mark-outputs-activated
   [ctx node-id output-labels]
   ;; This gets called a lot, so we're trying to keep allocations to a minimum.
-  (let [nodes-affected (:nodes-affected ctx)]
-    (assoc ctx
-      :nodes-affected
-      (into nodes-affected
-            (map #(gt/endpoint node-id %))
-            output-labels))))
+  (if-not (:track-changes ctx)
+    ctx
+    (let [nodes-affected (:nodes-affected ctx)]
+      (assoc ctx
+        :nodes-affected
+        (into nodes-affected
+              (map #(gt/endpoint node-id %))
+              output-labels)))))
 
 (defn- mark-all-outputs-activated
   [ctx node-id]
   ;; This gets called a lot, so we're trying to keep allocations to a minimum.
-  (let [basis (:basis ctx)
-        output-labels (-> (gt/node-by-id-at basis node-id)
-                          gt/node-type
-                          in/output-labels)
-        nodes-affected (:nodes-affected ctx)]
-    (assoc ctx
-      :nodes-affected
-      (into nodes-affected
-            (map #(gt/endpoint node-id %))
-            output-labels))))
+  (if-not (:track-changes ctx)
+    ctx
+    (let [basis (:basis ctx)
+          output-labels (-> (gt/node-by-id-at basis node-id)
+                            gt/node-type
+                            in/output-labels)
+          nodes-affected (:nodes-affected ctx)]
+      (assoc ctx
+        :nodes-affected
+        (into nodes-affected
+              (map #(gt/endpoint node-id %))
+              output-labels)))))
 
 (defn- next-node-id [ctx graph-id]
   (is/next-node-id* (:node-id-generators ctx) graph-id))
@@ -821,9 +829,8 @@
 
 (defmethod perform :update-graph-value
   [ctx {:keys [graph-id fn args]}]
-  (-> ctx
-      (update-in [:basis :graphs graph-id :graph-values] #(apply fn % args))
-      (update :graphs-modified conj graph-id)))
+  (cond-> (update-in ctx [:basis :graphs graph-id :graph-values] #(apply fn % args))
+          (:track-changes ctx) (update :graphs-modified conj graph-id)))
 
 (defmethod metrics-key :update-graph-value
   [{:keys [graph-id]}]
@@ -910,11 +917,11 @@
   [{:keys [nodes-modified graphs-modified tx-data-context] :as ctx}]
   (-> (select-keys ctx tx-report-keys)
       (assoc :status (if (zero? (:completed-action-count ctx)) :empty :ok)
-             :graphs-modified (into graphs-modified (map gt/node-id->graph-id nodes-modified))
+             :graphs-modified (into graphs-modified (map gt/node-id->graph-id) nodes-modified)
              :tx-data-context-map (deref tx-data-context))))
 
 (defn new-transaction-context
-  [basis node-id-generators override-id-generator tx-data-context-map metrics-collector]
+  [basis node-id-generators override-id-generator tx-data-context-map metrics-collector track-changes]
   {:pre [(map? tx-data-context-map)]}
   {:basis basis
    :nodes-affected #{}
@@ -931,8 +938,8 @@
    :completed-action-count 0
    :txid (new-txid)
    :tx-data-context (atom tx-data-context-map)
-   :deferred-setters []
-   :metrics metrics-collector})
+   :metrics metrics-collector
+   :track-changes track-changes})
 
 (defn- update-overrides
   [{:keys [override-nodes-affected-ordered] :as ctx}]

--- a/editor/src/clj/util/debug_util.clj
+++ b/editor/src/clj/util/debug_util.clj
@@ -157,11 +157,11 @@
   ([]
    `(allocated-bytes (Runtime/getRuntime)))
   ([runtime-expr]
-   `(let [^Runtime runtime# ~runtime-expr]
-      (System/gc)
-      (System/runFinalization)
-      (- (.totalMemory runtime#)
-         (.freeMemory runtime#)))))
+   `(long (let [^Runtime runtime# ~runtime-expr]
+            (System/gc)
+            (System/runFinalization)
+            (- (.totalMemory runtime#)
+               (.freeMemory runtime#))))))
 
 (defmacro log-time-and-memory
   "Evaluates expr. Then logs the supplied label along with the time it took and

--- a/editor/test/editor/protobuf_types_test.clj
+++ b/editor/test/editor/protobuf_types_test.clj
@@ -160,7 +160,7 @@
           project (project/make-project proj-graph workspace extensions)]
       (let [node-load-infos
             (-> project
-                (#'project/make-nodes! (g/node-value project :resources))
+                (#'project/make-nodes! (g/node-value project :resources) nil)
                 (#'project/read-node-load-infos (constantly nil) nil)
                 (#'project/sort-node-load-infos-for-loading {} {}))
 

--- a/editor/test/integration/editor_extensions_test.clj
+++ b/editor/test/integration/editor_extensions_test.clj
@@ -309,7 +309,7 @@
         (is (= 2.5 (test-util/prop sprite-outline :playback-rate)))))))
 
 (deftest refresh-context-after-write-test
-  (test-util/with-loaded-project "test/resources/editor_extensions/refresh_context_project"
+  (test-util/with-scratch-project "test/resources/editor_extensions/refresh_context_project"
     (let [output (atom [])
           _ (reload-editor-scripts! project :display-output! #(swap! output conj [%1 %2]))
           handler+context (handler/active
@@ -396,7 +396,7 @@
       (test-initial-state!))))
 
 (deftest save-test
-  (test-util/with-loaded-project "test/resources/editor_extensions/save_test"
+  (test-util/with-scratch-project "test/resources/editor_extensions/save_test"
     (let [output (atom [])
           _ (reload-editor-scripts! project :display-output! #(swap! output conj [%1 %2]))
           handler+context (handler/active

--- a/editor/test/integration/scope_test.clj
+++ b/editor/test/integration/scope_test.clj
@@ -45,8 +45,9 @@
           old-count (node-count (g/graph graph-id))
           old-node-ids (set (ig/node-ids (g/graph graph-id)))
           old-basis (g/now)
-          mem-resource (project/make-embedded-resource project :editable resource-type-name inline-resource)]
-      (#'project/load-nodes! project (#'project/make-nodes! project [mem-resource]) (constantly nil) {} nil nil)
+          mem-resource (project/make-embedded-resource project :editable resource-type-name inline-resource)
+          resource-node-ids (#'project/make-nodes! project [mem-resource] nil)]
+      (test-util/load-project-nodes! project resource-node-ids)
       (let [new-resource-node (project/get-resource-node project mem-resource)
             new-count (node-count (g/graph graph-id))]
         (is (> new-count old-count))

--- a/editor/test/integration/test_util.clj
+++ b/editor/test/integration/test_util.clj
@@ -312,6 +312,11 @@
      (g/reset-undo! proj-graph)
      project)))
 
+(defn load-project-nodes! [project resource-node-ids]
+  (let [{:keys [migrated-resource-node-ids node-load-infos]}
+        (#'project/load-nodes! project resource-node-ids (constantly nil) {} nil nil)]
+    (#'project/cache-loaded-save-data! node-load-infos project migrated-resource-node-ids)))
+
 (defn project-node-resources [project]
   (g/with-auto-evaluation-context evaluation-context
     (sort-by resource/proj-path
@@ -561,7 +566,7 @@
 (defmacro with-ui-run-later-rebound
   [& forms]
   `(let [laters# (atom [])]
-     (with-redefs [ui/do-run-later (fn [f#] (swap! laters# conj f#))]
+     (with-redefs [ui/do-run-later (fn ~'fake-run-later [f#] (swap! laters# conj f#))]
        (let [result# (do ~@forms)]
          (doseq [f# @laters#] (f#))
          result#))))


### PR DESCRIPTION
Improved project load time and peak memory usage when loading large projects in the editor.

### Technical changes
You can now supply `{:track-changes false}` in `opts` to `g/transact` to disable change tracking inside the transaction. Change tracking is used to figure out the set of node outputs that were affected by the changes and need to be evicted from the cache as a result. This is also stored in the undo step so we can evict any affected entries from the cache when we move through the undo history.

Tracking the changes and figuring out the set of dependent outputs is a memory-intensive and lengthy process, so we save quite a bit of peak memory usage and time spent loading the project if we skip it.

When we load the project initially, we will clear the undo history once we're done, so we don't really need to track changes as long as we're careful to manage the system cache manually during the loading process.