### PR TITLE
Texture resource now owns the loaded memory until it's finished loading

### DIFF
--- a/engine/gamesys/src/gamesys/resources/res_texture.cpp
+++ b/engine/gamesys/src/gamesys/resources/res_texture.cpp
@@ -33,6 +33,7 @@ namespace dmGameSystem
 
     struct ImageDesc
     {
+        uint8_t*                  m_Memory; // the memory from the resource system
         dmGraphics::TextureImage* m_DDFImage;
         uint8_t*                  m_DDFImageBytes;
         uint8_t*                  m_DecompressedData[MAX_MIPMAP_COUNT];
@@ -329,10 +330,11 @@ namespace dmGameSystem
         return result;
     }
 
-    static ImageDesc* CreateImage(dmGraphics::HContext context, dmGraphics::TextureImage* texture_image, uint8_t* image_bytes)
+    static ImageDesc* CreateImage(dmGraphics::HContext context, dmGraphics::TextureImage* texture_image, uint8_t* memory, uint8_t* image_bytes)
     {
         ImageDesc* image_desc = new ImageDesc;
         memset(image_desc, 0x0, sizeof(ImageDesc));
+        image_desc->m_Memory = memory;
         image_desc->m_DDFImage = texture_image;
         image_desc->m_DDFImageBytes = image_bytes;
         return image_desc;
@@ -348,6 +350,7 @@ namespace dmGameSystem
             }
         }
 
+        delete[] image_desc->m_Memory;
         delete image_desc;
     }
 
@@ -376,8 +379,9 @@ namespace dmGameSystem
             image_payload = message_bytes + header_size + sizeof(int32_t);
         }
 
-        ImageDesc* image_desc = CreateImage((dmGraphics::HContext) params->m_Context, texture_image, image_payload);
+        ImageDesc* image_desc = CreateImage((dmGraphics::HContext) params->m_Context, texture_image, (uint8_t*) params->m_Buffer, image_payload);
         *params->m_PreloadData = image_desc;
+        *params->m_BufferOwnershipTransferred = true;
         return dmResource::RESULT_OK;
     }
 
@@ -485,7 +489,7 @@ namespace dmGameSystem
 
         // Create the image from the DDF data.
         // Note that the image desc for performance reasons keeps references to the DDF image, meaning they're invalid after the DDF message has been free'd!
-        ImageDesc* image_desc = CreateImage((dmGraphics::HContext) params->m_Context, texture_image, (uint8_t*) texture_image->m_ImageDataAddress);
+        ImageDesc* image_desc = CreateImage((dmGraphics::HContext) params->m_Context, texture_image, 0, (uint8_t*) texture_image->m_ImageDataAddress);
 
         ResTextureUploadParams upload_params = {};
 

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -175,6 +175,33 @@ TEST_P(ResourceTest, TestPreload)
     dmResource::Release(m_Factory, resource);
 }
 
+TEST_P(ResourceTest, TestPreloadAsync)
+{
+    const char* resource_name = GetParam();
+    void* resource;
+    dmResource::HPreloader pr = dmResource::NewPreloader(m_Factory, resource_name);
+    dmResource::Result r;
+
+    dmGraphics::NullContext* null_context = (dmGraphics::NullContext*) m_GraphicsContext;
+    null_context->m_UseAsyncTextureLoad   = 1;
+
+    uint64_t stop_time = dmTime::GetMonotonicTime() + 30*10e6;
+    while (dmTime::GetMonotonicTime() < stop_time)
+    {
+        // Simulate running at 30fps
+        r = dmResource::UpdatePreloader(pr, 0, 0, 33*1000);
+        if (r != dmResource::RESULT_PENDING)
+            break;
+        dmTime::Sleep(33*1000);
+    }
+
+    ASSERT_EQ(dmResource::RESULT_OK, r);
+    ASSERT_EQ(dmResource::RESULT_OK, dmResource::Get(m_Factory, resource_name, &resource));
+
+    dmResource::DeletePreloader(pr);
+    dmResource::Release(m_Factory, resource);
+}
+
 TEST_F(ResourceTest, TestReloadTextureSet)
 {
     const char* texture_set_path_a   = "/textureset/valid_a.t.texturesetc";

--- a/engine/resource/src/async/load_queue.cpp
+++ b/engine/resource/src/async/load_queue.cpp
@@ -30,6 +30,7 @@ dmResource::Result DoLoadResource(dmResource::HFactory factory, HRequest request
     result->m_LoadResult = dmResource::LoadResourceToBuffer(factory, request->m_CanonicalPath, request->m_Name, preload_size, &request->m_ResourceSize, &request->m_BufferSize, buffer);
     result->m_PreloadResult = dmResource::RESULT_PENDING;
     result->m_PreloadData   = 0;
+    result->m_BufferOwnershipTransferred = false;
 
     if (result->m_LoadResult == dmResource::RESULT_OK)
     {
@@ -53,7 +54,11 @@ dmResource::Result DoLoadResource(dmResource::HFactory factory, HRequest request
             params.m_FileSize       = request->m_ResourceSize;
             params.m_IsBufferPartial= request->m_BufferSize != request->m_ResourceSize;
             params.m_HintInfo       = &request->m_PreloadInfo.m_HintInfo;
-            params.m_PreloadData    = &result->m_PreloadData;
+
+            // out
+            params.m_PreloadData = &result->m_PreloadData;
+            params.m_BufferOwnershipTransferred = &result->m_BufferOwnershipTransferred;
+
             result->m_PreloadResult = (dmResource::Result)request->m_PreloadInfo.m_CompleteFunction(&params);
         }
         else

--- a/engine/resource/src/async/load_queue.cpp
+++ b/engine/resource/src/async/load_queue.cpp
@@ -30,7 +30,7 @@ dmResource::Result DoLoadResource(dmResource::HFactory factory, HRequest request
     result->m_LoadResult = dmResource::LoadResourceToBuffer(factory, request->m_CanonicalPath, request->m_Name, preload_size, &request->m_ResourceSize, &request->m_BufferSize, buffer);
     result->m_PreloadResult = dmResource::RESULT_PENDING;
     result->m_PreloadData   = 0;
-    result->m_BufferOwnershipTransferred = false;
+    result->m_IsBufferOwnershipTransferred = false;
 
     if (result->m_LoadResult == dmResource::RESULT_OK)
     {
@@ -47,17 +47,18 @@ dmResource::Result DoLoadResource(dmResource::HFactory factory, HRequest request
         if (request->m_PreloadInfo.m_CompleteFunction)
         {
             ResourcePreloadParams params;
-            params.m_Factory        = factory;
-            params.m_Context        = request->m_PreloadInfo.m_Context;
-            params.m_Buffer         = buffer->Begin();
-            params.m_BufferSize     = request->m_BufferSize;
-            params.m_FileSize       = request->m_ResourceSize;
-            params.m_IsBufferPartial= request->m_BufferSize != request->m_ResourceSize;
-            params.m_HintInfo       = &request->m_PreloadInfo.m_HintInfo;
+            params.m_Factory                = factory;
+            params.m_Context                = request->m_PreloadInfo.m_Context;
+            params.m_Buffer                 = buffer->Begin();
+            params.m_BufferSize             = request->m_BufferSize;
+            params.m_FileSize               = request->m_ResourceSize;
+            params.m_IsBufferPartial        = request->m_BufferSize != request->m_ResourceSize;
+            params.m_IsBufferTransferrable  = 1;
+            params.m_HintInfo               = &request->m_PreloadInfo.m_HintInfo;
 
             // out
             params.m_PreloadData = &result->m_PreloadData;
-            params.m_BufferOwnershipTransferred = &result->m_BufferOwnershipTransferred;
+            params.m_IsBufferOwnershipTransferred = &result->m_IsBufferOwnershipTransferred;
 
             result->m_PreloadResult = (dmResource::Result)request->m_PreloadInfo.m_CompleteFunction(&params);
         }

--- a/engine/resource/src/async/load_queue.h
+++ b/engine/resource/src/async/load_queue.h
@@ -47,7 +47,7 @@ namespace dmLoadQueue
         dmResource::Result m_LoadResult;
         dmResource::Result m_PreloadResult;
         void* m_PreloadData;
-        bool m_BufferOwnershipTransferred; // If true, the resource preloader has taken ownership of the data
+        bool m_IsBufferOwnershipTransferred; // If true, the resource preloader has taken ownership of the data
     };
 
     HQueue CreateQueue(dmResource::HFactory factory);

--- a/engine/resource/src/async/load_queue.h
+++ b/engine/resource/src/async/load_queue.h
@@ -47,6 +47,7 @@ namespace dmLoadQueue
         dmResource::Result m_LoadResult;
         dmResource::Result m_PreloadResult;
         void* m_PreloadData;
+        bool m_BufferOwnershipTransferred; // If true, the resource preloader has taken ownership of the data
     };
 
     HQueue CreateQueue(dmResource::HFactory factory);

--- a/engine/resource/src/async/load_queue_sync.cpp
+++ b/engine/resource/src/async/load_queue_sync.cpp
@@ -73,7 +73,7 @@ namespace dmLoadQueue
         *resource_size = request->m_ResourceSize;
         *buf = buffer->Begin();
 
-        if (load_result->m_BufferOwnershipTransferred)
+        if (load_result->m_IsBufferOwnershipTransferred)
         {
             // we reset the dmArray (size = 0, capacity = 0)
             memset((void*)buffer, 0, sizeof(*buffer));

--- a/engine/resource/src/async/load_queue_sync.cpp
+++ b/engine/resource/src/async/load_queue_sync.cpp
@@ -72,6 +72,12 @@ namespace dmLoadQueue
         *buffer_size = request->m_BufferSize;
         *resource_size = request->m_ResourceSize;
         *buf = buffer->Begin();
+
+        if (load_result->m_BufferOwnershipTransferred)
+        {
+            // we reset the dmArray (size = 0, capacity = 0)
+            memset((void*)buffer, 0, sizeof(*buffer));
+        }
         return RESULT_OK;
     }
 

--- a/engine/resource/src/async/load_queue_threaded.cpp
+++ b/engine/resource/src/async/load_queue_threaded.cpp
@@ -199,7 +199,7 @@ namespace dmLoadQueue
         *resource_size  = request->m_ResourceSize;
         *load_result    = request->m_Result;
 
-        if (load_result->m_BufferOwnershipTransferred)
+        if (load_result->m_IsBufferOwnershipTransferred)
         {
             // we reset the dmArray (size = 0, capacity = 0)
             memset((void*)&request->m_Buffer, 0, sizeof(request->m_Buffer));

--- a/engine/resource/src/async/load_queue_threaded.cpp
+++ b/engine/resource/src/async/load_queue_threaded.cpp
@@ -199,6 +199,11 @@ namespace dmLoadQueue
         *resource_size  = request->m_ResourceSize;
         *load_result    = request->m_Result;
 
+        if (load_result->m_BufferOwnershipTransferred)
+        {
+            // we reset the dmArray (size = 0, capacity = 0)
+            memset((void*)&request->m_Buffer, 0, sizeof(request->m_Buffer));
+        }
         return RESULT_OK;
     }
 

--- a/engine/resource/src/dmsdk/resource/resource.h
+++ b/engine/resource/src/dmsdk/resource/resource.h
@@ -354,13 +354,14 @@ struct ResourcePreloadParams
     const char*              m_Filename;
     const void*              m_Buffer;
     uint32_t                 m_BufferSize;
-    uint32_t                 m_FileSize:31;
+    uint32_t                 m_FileSize:30;
     uint32_t                 m_IsBufferPartial:1;
+    uint32_t                 m_IsBufferTransferrable:1; // Can the callback take ownership?
     HResourcePreloadHintInfo m_HintInfo;
     HResourceType            m_Type;
     // Out
     void**                   m_PreloadData;
-    bool*                    m_BufferOwnershipTransferred; // If set, the resource type has taken ownership of the data
+    bool*                    m_IsBufferOwnershipTransferred; // If set, the resource type has taken ownership of the data
 };
 
 /*#

--- a/engine/resource/src/dmsdk/resource/resource.h
+++ b/engine/resource/src/dmsdk/resource/resource.h
@@ -357,8 +357,10 @@ struct ResourcePreloadParams
     uint32_t                 m_FileSize:31;
     uint32_t                 m_IsBufferPartial:1;
     HResourcePreloadHintInfo m_HintInfo;
-    void**                   m_PreloadData;
     HResourceType            m_Type;
+    // Out
+    void**                   m_PreloadData;
+    bool*                    m_BufferOwnershipTransferred; // If set, the resource type has taken ownership of the data
 };
 
 /*#

--- a/engine/resource/src/resource.cpp
+++ b/engine/resource/src/resource.cpp
@@ -747,7 +747,6 @@ static Result DoCreateResource(HFactory factory, ResourceType* resource_type, co
     tmp_resource.m_ResourceType   = resource_type;
 
     void* preload_data = 0;
-    bool ownership_transferred = false;
     Result create_error = RESULT_OK;
 
     bool is_partial = buffer_size != resource_size;
@@ -755,19 +754,20 @@ static Result DoCreateResource(HFactory factory, ResourceType* resource_type, co
     if (resource_type->m_PreloadFunction)
     {
         ResourcePreloadParams params;
-        params.m_Factory        = factory;
-        params.m_Type           = resource_type;
-        params.m_Context        = resource_type->m_Context;
-        params.m_Buffer         = buffer;
-        params.m_BufferSize     = buffer_size;
-        params.m_FileSize       = resource_size;
-        params.m_IsBufferPartial= is_partial;
-        params.m_Filename       = name;
-        params.m_HintInfo       = 0; // No hinting now
+        params.m_Factory                = factory;
+        params.m_Type                   = resource_type;
+        params.m_Context                = resource_type->m_Context;
+        params.m_Buffer                 = buffer;
+        params.m_BufferSize             = buffer_size;
+        params.m_FileSize               = resource_size;
+        params.m_IsBufferPartial        = is_partial;
+        params.m_IsBufferTransferrable  = 0;
+        params.m_Filename               = name;
+        params.m_HintInfo               = 0; // No hinting now
         // out
-        params.m_PreloadData    = &preload_data;
-        params.m_BufferOwnershipTransferred = &ownership_transferred;
-        create_error            = (Result)resource_type->m_PreloadFunction(&params);
+        params.m_PreloadData            = &preload_data;
+        params.m_IsBufferOwnershipTransferred = 0;
+        create_error                    = (Result)resource_type->m_PreloadFunction(&params);
     }
 
     if (create_error == RESULT_OK)
@@ -804,11 +804,6 @@ static Result DoCreateResource(HFactory factory, ResourceType* resource_type, co
                 break;
             dmTime::Sleep(1000);
         }
-    }
-
-    if (ownership_transferred)
-    {
-        memset((void*)&factory->m_Buffer, 0, sizeof(factory->m_Buffer));
     }
 
     // Restore to default buffer size


### PR DESCRIPTION

Fixes https://github.com/defold/defold/issues/10074

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
