### PR TITLE
Activate tabs on right click

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -95,7 +95,7 @@
            [javafx.collections ListChangeListener ObservableList]
            [javafx.event Event]
            [javafx.geometry HPos Orientation Pos]
-           [javafx.scene Parent Scene Node]
+           [javafx.scene Parent Scene]
            [javafx.scene.control Label MenuBar SplitPane Tab TabPane TabPane$TabClosingPolicy TabPane$TabDragPolicy Tooltip]
            [javafx.scene.image Image ImageView]
            [javafx.scene.input Clipboard ClipboardContent MouseEvent MouseButton]

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -1876,10 +1876,9 @@ If you do not specifically require different script states, consider changing th
   (defn- handle-tab-pane-mouse-pressed! 
     [^TabPane tab-pane ^MouseEvent event]
     (when (= MouseButton/SECONDARY (.getButton event))
-      (->> (.invoke getTab
-                    (ui/closest-node-where #(instance? TabHeaderSkin %) (.getTarget event))
-                    (into-array Object []))
-           (.select (.getSelectionModel tab-pane))))))
+      (when-let [node (ui/closest-node-where #(instance? TabHeaderSkin %) (.getTarget event))]
+        (->> (.invoke getTab node (into-array Object []))
+             (.select (.getSelectionModel tab-pane)))))))
 
 (defn- configure-editor-tab-pane! [^TabPane tab-pane ^Scene app-scene app-view]
   (.setTabClosingPolicy tab-pane TabPane$TabClosingPolicy/ALL_TABS)

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -1870,19 +1870,21 @@ If you do not specifically require different script states, consider changing th
 (defn- tab->view-type [^Tab tab]
   (some-> tab (ui/user-data ::view-type) :id))
 
+(defn- get-target-tab
+  [^MouseEvent event]
+  (let [TabHeaderSkin (Class/forName "javafx.scene.control.skin.TabPaneSkin$TabHeaderSkin")
+        getTab (.getDeclaredMethod TabHeaderSkin "getTab" (into-array Class []))]
+    (.setAccessible getTab true)
+    (.invoke getTab
+             (ui/closest-node-where #(instance? TabHeaderSkin %) (.getTarget event))
+             (into-array Object []))))
+
 (defn- handle-tab-pane-mouse-pressed!
-  "Selects the tab on right-click."
+  "Activates the tab on right-click."
   [^TabPane tab-pane ^MouseEvent event]
   (when (= MouseButton/SECONDARY (.getButton event))
-    ;; Hackish way to get the tab index under the mouse cursor.
-    (when-let [target-tab (->> (.lookupAll tab-pane ".tab")
-                               (keep-indexed
-                                (fn [i ^Node node]
-                                  (when (.contains (.getBoundsInParent node)
-                                                   (.getX event) (.getY event))
-                                    i)))
-                               first)]
-      (.select (.getSelectionModel tab-pane) (int target-tab)))))
+    (->> (get-target-tab event)
+         (.select (.getSelectionModel tab-pane)))))
 
 (defn- configure-editor-tab-pane! [^TabPane tab-pane ^Scene app-scene app-view]
   (.setTabClosingPolicy tab-pane TabPane$TabClosingPolicy/ALL_TABS)

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -1870,21 +1870,16 @@ If you do not specifically require different script states, consider changing th
 (defn- tab->view-type [^Tab tab]
   (some-> tab (ui/user-data ::view-type) :id))
 
-(defn- get-target-tab
-  [^MouseEvent event]
-  (let [TabHeaderSkin (Class/forName "javafx.scene.control.skin.TabPaneSkin$TabHeaderSkin")
-        getTab (.getDeclaredMethod TabHeaderSkin "getTab" (into-array Class []))]
-    (.setAccessible getTab true)
-    (.invoke getTab
-             (ui/closest-node-where #(instance? TabHeaderSkin %) (.getTarget event))
-             (into-array Object []))))
-
-(defn- handle-tab-pane-mouse-pressed!
-  "Activates the tab on right-click."
-  [^TabPane tab-pane ^MouseEvent event]
-  (when (= MouseButton/SECONDARY (.getButton event))
-    (->> (get-target-tab event)
-         (.select (.getSelectionModel tab-pane)))))
+(let [TabHeaderSkin (Class/forName "javafx.scene.control.skin.TabPaneSkin$TabHeaderSkin")
+      getTab (.getDeclaredMethod TabHeaderSkin "getTab" (into-array Class []))]
+  (.setAccessible getTab true)
+  (defn- handle-tab-pane-mouse-pressed! 
+    [^TabPane tab-pane ^MouseEvent event]
+    (when (= MouseButton/SECONDARY (.getButton event))
+      (->> (.invoke getTab
+                    (ui/closest-node-where #(instance? TabHeaderSkin %) (.getTarget event))
+                    (into-array Object []))
+           (.select (.getSelectionModel tab-pane))))))
 
 (defn- configure-editor-tab-pane! [^TabPane tab-pane ^Scene app-scene app-view]
   (.setTabClosingPolicy tab-pane TabPane$TabClosingPolicy/ALL_TABS)

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -95,7 +95,7 @@
            [javafx.collections ListChangeListener ObservableList]
            [javafx.event Event]
            [javafx.geometry HPos Orientation Pos]
-           [javafx.scene Parent Scene]
+           [javafx.scene Parent Scene Node]
            [javafx.scene.control Label MenuBar SplitPane Tab TabPane TabPane$TabClosingPolicy TabPane$TabDragPolicy Tooltip]
            [javafx.scene.image Image ImageView]
            [javafx.scene.input Clipboard ClipboardContent MouseEvent MouseButton]
@@ -1874,11 +1874,11 @@ If you do not specifically require different script states, consider changing th
   "Selects the tab on right-click."
   [^TabPane tab-pane ^MouseEvent event]
   (when (= MouseButton/SECONDARY (.getButton event))
-    ;; Hackish way to get the tab index under the mouse cursor
+    ;; Hackish way to get the tab index under the mouse cursor.
     (when-let [target-tab (->> (.lookupAll tab-pane ".tab")
                                (keep-indexed
-                                (fn [i tab]
-                                  (when (.contains (.getBoundsInParent tab)
+                                (fn [i ^Node node]
+                                  (when (.contains (.getBoundsInParent node)
                                                    (.getX event) (.getY event))
                                     i)))
                                first)]


### PR DESCRIPTION
Activate tabs on right click, to fix the context of the displayed menu.

Fixes #9071

### Technical changes
Tabs are not JavaFX Nodes, so we can't add event handlers to them (mouse-clicks/context-menu-requests). We have to find a way to select the tab through the parent `TabPane`. Using `tab.setContextMenu` could work, but we would have to change the way we register menus, to be able to pass the correct view context.