### PR TITLE
Migrate builtin shaders to the new shader pipeline

### DIFF
--- a/engine/engine/content/builtins/fonts/font-df-ms-singlelayer.fp
+++ b/engine/engine/content/builtins/fonts/font-df-ms-singlelayer.fp
@@ -1,35 +1,43 @@
-varying lowp vec2 var_texcoord0;
-varying lowp vec4 var_face_color;
-varying lowp vec4 var_outline_color;
-varying lowp vec4 var_sdf_params;
+#version 140
+
+in mediump vec2 var_texcoord0;
+in mediump vec4 var_face_color;
+in mediump vec4 var_outline_color;
+in mediump vec4 var_sdf_params;
 
 uniform mediump sampler2D texture_sampler;
-uniform lowp vec4 texture_size_recip;
+
+uniform fs_uniforms
+{
+    mediump vec4 texture_size_recip;
+};
+
+out vec4 out_fragColor;
 
 float sample_df(vec2 where)
 {
-    return texture2D(texture_sampler, where).x;
+    return texture(texture_sampler, where).x;
 }
 
 void main()
 {
-    lowp float sdf_edge = var_sdf_params.x;
-    lowp float sdf_outline = var_sdf_params.y;
-    lowp float sdf_smoothing = var_sdf_params.z;
+    mediump float sdf_edge = var_sdf_params.x;
+    mediump float sdf_outline = var_sdf_params.y;
+    mediump float sdf_smoothing = var_sdf_params.z;
 
     // sample 4 points around var_texcoord0
-    lowp vec2 dtex = vec2(0.5 * texture_size_recip.xy);
-    lowp vec4 dt = vec4(vec2(var_texcoord0 - dtex), vec2(var_texcoord0 + dtex));
-    lowp float distance = 2.0 * (sample_df(var_texcoord0))
+    mediump vec2 dtex = vec2(0.5 * texture_size_recip.xy);
+    mediump vec4 dt = vec4(vec2(var_texcoord0 - dtex), vec2(var_texcoord0 + dtex));
+    mediump float distance = 2.0 * (sample_df(var_texcoord0))
                    + sample_df(dt.xy) // upper left
                    + sample_df(dt.xw) // bottom left
                    + sample_df(dt.zy) // upper right
                    + sample_df(dt.zw); // bottom right
     distance = (1.0 / 6.0) * distance;
 
-    lowp float alpha = smoothstep(sdf_edge - sdf_smoothing, sdf_edge + sdf_smoothing, distance);
-    lowp float outline_alpha = smoothstep(sdf_outline - sdf_smoothing, sdf_outline + sdf_smoothing, distance);
-    lowp vec4 color = mix(var_outline_color, var_face_color, alpha);
+    mediump float alpha = smoothstep(sdf_edge - sdf_smoothing, sdf_edge + sdf_smoothing, distance);
+    mediump float outline_alpha = smoothstep(sdf_outline - sdf_smoothing, sdf_outline + sdf_smoothing, distance);
+    mediump vec4 color = mix(var_outline_color, var_face_color, alpha);
 
-    gl_FragColor = color * outline_alpha;
+    out_fragColor = color * outline_alpha;
 }

--- a/engine/engine/content/builtins/fonts/font-df-ms.fp
+++ b/engine/engine/content/builtins/fonts/font-df-ms.fp
@@ -1,28 +1,35 @@
-varying lowp vec2 var_texcoord0;
-varying lowp vec4 var_face_color;
-varying lowp vec4 var_outline_color;
-varying lowp vec4 var_shadow_color;
-varying lowp vec4 var_sdf_params;
-varying lowp vec4 var_layer_mask;
+#version 140
+
+in mediump vec2 var_texcoord0;
+in mediump vec4 var_face_color;
+in mediump vec4 var_outline_color;
+in mediump vec4 var_shadow_color;
+in mediump vec4 var_sdf_params;
+in mediump vec4 var_layer_mask;
+
+out vec4 out_fragColor;
 
 uniform mediump sampler2D texture_sampler;
-uniform lowp vec4 texture_size_recip;
+uniform fs_uniforms
+{
+    mediump vec4 texture_size_recip;
+};
 
 vec3 sample_df(vec2 where)
 {
-    return texture2D(texture_sampler, where).xyz;
+    return texture(texture_sampler, where).xyz;
 }
 
 void main()
 {
-    lowp float sdf_edge      = var_sdf_params.x;
-    lowp float sdf_outline   = var_sdf_params.y;
-    lowp float sdf_smoothing = var_sdf_params.z;
-    lowp float sdf_shadow    = var_sdf_params.w;
+    mediump float sdf_edge      = var_sdf_params.x;
+    mediump float sdf_outline   = var_sdf_params.y;
+    mediump float sdf_smoothing = var_sdf_params.z;
+    mediump float sdf_shadow    = var_sdf_params.w;
 
     // sample 4 points around var_texcoord0
-    lowp vec2 dtex = vec2(0.5 * texture_size_recip.xy);
-    lowp vec4 dt = vec4(vec2(var_texcoord0 - dtex), vec2(var_texcoord0 + dtex));
+    mediump vec2 dtex = vec2(0.5 * texture_size_recip.xy);
+    mediump vec4 dt = vec4(vec2(var_texcoord0 - dtex), vec2(var_texcoord0 + dtex));
     mediump vec3 df_sample = 2.0 * (sample_df(var_texcoord0))
                    + sample_df(dt.xy) // upper left
                    + sample_df(dt.xw) // bottom left
@@ -34,17 +41,17 @@ void main()
     mediump float distance_shadow = df_sample.z;
 
     // If there is no blur, the shadow should behave in the same way as the outline.
-    lowp float sdf_shadow_as_outline = floor(sdf_shadow);
+    mediump float sdf_shadow_as_outline = floor(sdf_shadow);
     // If this is a single layer font, we must make sure to not mix alpha between layers.
-    lowp float sdf_is_single_layer   = var_layer_mask.a;
+    mediump float sdf_is_single_layer   = var_layer_mask.a;
 
-    lowp float face_alpha      = smoothstep(sdf_edge - sdf_smoothing, sdf_edge + sdf_smoothing, distance);
-    lowp float outline_alpha   = smoothstep(sdf_outline - sdf_smoothing, sdf_outline + sdf_smoothing, distance);
-    lowp float shadow_alpha    = smoothstep(sdf_shadow - sdf_smoothing, sdf_edge + sdf_smoothing, distance_shadow);
+    mediump float face_alpha      = smoothstep(sdf_edge - sdf_smoothing, sdf_edge + sdf_smoothing, distance);
+    mediump float outline_alpha   = smoothstep(sdf_outline - sdf_smoothing, sdf_outline + sdf_smoothing, distance);
+    mediump float shadow_alpha    = smoothstep(sdf_shadow - sdf_smoothing, sdf_edge + sdf_smoothing, distance_shadow);
 
     shadow_alpha = mix(shadow_alpha,outline_alpha,sdf_shadow_as_outline);
 
-    gl_FragColor = face_alpha * var_face_color * var_layer_mask.x +
+    out_fragColor = face_alpha * var_face_color * var_layer_mask.x +
       outline_alpha * var_outline_color * var_layer_mask.y * (1.0 - face_alpha * sdf_is_single_layer) +
       shadow_alpha * var_shadow_color * var_layer_mask.z * (1.0 - min(1.0,outline_alpha + face_alpha) * sdf_is_single_layer);
 }

--- a/engine/engine/content/builtins/fonts/font-df-singlelayer.fp
+++ b/engine/engine/content/builtins/fonts/font-df-singlelayer.fp
@@ -1,21 +1,25 @@
-varying lowp vec2 var_texcoord0;
-varying lowp vec4 var_face_color;
-varying lowp vec4 var_outline_color;
-varying lowp vec4 var_sdf_params;
+#version 140
+
+in mediump vec2 var_texcoord0;
+in mediump vec4 var_face_color;
+in mediump vec4 var_outline_color;
+in mediump vec4 var_sdf_params;
+
+out vec4 out_fragColor;
 
 uniform mediump sampler2D texture_sampler;
 
 void main()
 {
-    lowp float distance = texture2D(texture_sampler, var_texcoord0).x;
+    mediump float distance = texture(texture_sampler, var_texcoord0).x;
 
-    lowp float sdf_edge = var_sdf_params.x;
-    lowp float sdf_outline = var_sdf_params.y;
-    lowp float sdf_smoothing = var_sdf_params.z;
+    mediump float sdf_edge = var_sdf_params.x;
+    mediump float sdf_outline = var_sdf_params.y;
+    mediump float sdf_smoothing = var_sdf_params.z;
 
-    lowp float alpha = smoothstep(sdf_edge - sdf_smoothing, sdf_edge + sdf_smoothing, distance);
-    lowp float outline_alpha = smoothstep(sdf_outline - sdf_smoothing, sdf_outline + sdf_smoothing, distance);
-    lowp vec4 color = mix(var_outline_color, var_face_color, alpha);
+    mediump float alpha = smoothstep(sdf_edge - sdf_smoothing, sdf_edge + sdf_smoothing, distance);
+    mediump float outline_alpha = smoothstep(sdf_outline - sdf_smoothing, sdf_outline + sdf_smoothing, distance);
+    mediump vec4 color = mix(var_outline_color, var_face_color, alpha);
 
-    gl_FragColor = color * outline_alpha;
+    out_fragColor = color * outline_alpha;
 }

--- a/engine/engine/content/builtins/fonts/font-df.fp
+++ b/engine/engine/content/builtins/fonts/font-df.fp
@@ -1,36 +1,40 @@
-varying lowp vec2 var_texcoord0;
-varying lowp vec4 var_face_color;
-varying lowp vec4 var_outline_color;
-varying lowp vec4 var_shadow_color;
-varying lowp vec4 var_sdf_params;
-varying lowp vec4 var_layer_mask;
+#version 140
+
+in mediump vec2 var_texcoord0;
+in mediump vec4 var_face_color;
+in mediump vec4 var_outline_color;
+in mediump vec4 var_shadow_color;
+in mediump vec4 var_sdf_params;
+in mediump vec4 var_layer_mask;
+
+out vec4 out_fragColor;
 
 uniform mediump sampler2D texture_sampler;
 
 void main()
 {
-    mediump vec4 df_sample = texture2D(texture_sampler, var_texcoord0);
+    mediump vec4 df_sample = texture(texture_sampler, var_texcoord0);
 
     mediump float distance        = df_sample.x;
     mediump float distance_shadow = df_sample.z;
 
-    lowp float sdf_edge      = var_sdf_params.x;
-    lowp float sdf_outline   = var_sdf_params.y;
-    lowp float sdf_smoothing = var_sdf_params.z;
-    lowp float sdf_shadow    = var_sdf_params.w;
+    mediump float sdf_edge      = var_sdf_params.x;
+    mediump float sdf_outline   = var_sdf_params.y;
+    mediump float sdf_smoothing = var_sdf_params.z;
+    mediump float sdf_shadow    = var_sdf_params.w;
 
     // If there is no blur, the shadow should behave in the same way as the outline.
-    lowp float sdf_shadow_as_outline = floor(sdf_shadow);
+    mediump float sdf_shadow_as_outline = floor(sdf_shadow);
     // If this is a single layer font, we must make sure to not mix alpha between layers.
-    lowp float sdf_is_single_layer   = var_layer_mask.a;
+    mediump float sdf_is_single_layer   = var_layer_mask.a;
 
-    lowp float face_alpha      = smoothstep(sdf_edge - sdf_smoothing, sdf_edge + sdf_smoothing, distance);
-    lowp float outline_alpha   = smoothstep(sdf_outline - sdf_smoothing, sdf_outline + sdf_smoothing, distance);
-    lowp float shadow_alpha    = smoothstep(sdf_shadow - sdf_smoothing, sdf_edge + sdf_smoothing, distance_shadow);
+    mediump float face_alpha      = smoothstep(sdf_edge - sdf_smoothing, sdf_edge + sdf_smoothing, distance);
+    mediump float outline_alpha   = smoothstep(sdf_outline - sdf_smoothing, sdf_outline + sdf_smoothing, distance);
+    mediump float shadow_alpha    = smoothstep(sdf_shadow - sdf_smoothing, sdf_edge + sdf_smoothing, distance_shadow);
 
     shadow_alpha = mix(shadow_alpha,outline_alpha,sdf_shadow_as_outline);
 
-    gl_FragColor = face_alpha * var_face_color * var_layer_mask.x +
+    out_fragColor = face_alpha * var_face_color * var_layer_mask.x +
         outline_alpha * var_outline_color * var_layer_mask.y * (1.0 - face_alpha * sdf_is_single_layer) +
         shadow_alpha * var_shadow_color * var_layer_mask.z * (1.0 - min(1.0,outline_alpha + face_alpha) * sdf_is_single_layer);
 }

--- a/engine/engine/content/builtins/fonts/font-df.vp
+++ b/engine/engine/content/builtins/fonts/font-df.vp
@@ -1,20 +1,25 @@
-uniform highp mat4 view_proj;
-
-varying mediump vec2 var_texcoord0;
-varying lowp vec4 var_face_color;
-varying lowp vec4 var_outline_color;
-varying lowp vec4 var_shadow_color;
-varying lowp vec4 var_sdf_params;
-varying lowp vec4 var_layer_mask;
+#version 140
 
 // positions are in world space
-attribute mediump vec4 position;
-attribute mediump vec2 texcoord0;
-attribute mediump vec4 sdf_params;
-attribute lowp vec4 face_color;
-attribute lowp vec4 outline_color;
-attribute lowp vec4 shadow_color;
-attribute lowp vec3 layer_mask;
+in mediump vec4 position;
+in mediump vec2 texcoord0;
+in mediump vec4 sdf_params;
+in mediump vec4 face_color;
+in mediump vec4 outline_color;
+in mediump vec4 shadow_color;
+in mediump vec3 layer_mask;
+
+out mediump vec2 var_texcoord0;
+out mediump vec4 var_face_color;
+out mediump vec4 var_outline_color;
+out mediump vec4 var_shadow_color;
+out mediump vec4 var_sdf_params;
+out mediump vec4 var_layer_mask;
+
+uniform vs_uniforms
+{
+    highp mat4 view_proj;
+};
 
 void main()
 {

--- a/engine/engine/content/builtins/fonts/font-fnt.fp
+++ b/engine/engine/content/builtins/fonts/font-fnt.fp
@@ -1,9 +1,13 @@
-varying mediump vec2 var_texcoord0;
-varying lowp vec4 var_face_color;
+#version 140
 
-uniform lowp sampler2D texture_sampler;
+in mediump vec2 var_texcoord0;
+in mediump vec4 var_face_color;
+
+out vec4 out_fragColor;
+
+uniform mediump sampler2D texture_sampler;
 
 void main()
 {
-    gl_FragColor = texture2D(texture_sampler, var_texcoord0.xy) * var_face_color * var_face_color.a;
+    out_fragColor = texture(texture_sampler, var_texcoord0.xy) * var_face_color * var_face_color.a;
 }

--- a/engine/engine/content/builtins/fonts/font-fnt.vp
+++ b/engine/engine/content/builtins/fonts/font-fnt.vp
@@ -1,15 +1,20 @@
-uniform highp mat4 view_proj;
+#version 140
 
-varying mediump vec2 var_texcoord0;
-varying lowp vec4 var_face_color;
-varying lowp vec4 var_outline_color;
+out mediump vec2 var_texcoord0;
+out mediump vec4 var_face_color;
+out mediump vec4 var_outline_color;
 
 // positions are in world space
-attribute mediump vec4 position;
-attribute mediump vec2 texcoord0;
-attribute lowp vec4 face_color;
-attribute lowp vec4 outline_color;
-attribute lowp vec4 shadow_color;
+in mediump vec4 position;
+in mediump vec2 texcoord0;
+in mediump vec4 face_color;
+in mediump vec4 outline_color;
+in mediump vec4 shadow_color;
+
+uniform vs_uniforms
+{
+    mat4 view_proj;
+};
 
 void main()
 {

--- a/engine/engine/content/builtins/fonts/font-singlelayer.fp
+++ b/engine/engine/content/builtins/fonts/font-singlelayer.fp
@@ -1,11 +1,15 @@
-varying mediump vec2 var_texcoord0;
-varying lowp vec4 var_face_color;
-varying lowp vec4 var_outline_color;
+#version 140
 
-uniform lowp sampler2D texture_sampler;
+in mediump vec2 var_texcoord0;
+in mediump vec4 var_face_color;
+in mediump vec4 var_outline_color;
+
+out vec4 out_fragColor;
+
+uniform mediump sampler2D texture_sampler;
 
 void main()
 {
-    lowp vec2 t  = texture2D(texture_sampler, var_texcoord0.xy).xy;
-    gl_FragColor = vec4(var_face_color.xyz, 1.0) * t.x * var_face_color.w + vec4(var_outline_color.xyz * t.y * var_outline_color.w, t.y * var_outline_color.w) * (1.0 - t.x);
+    mediump vec2 t = texture(texture_sampler, var_texcoord0.xy).xy;
+    out_fragColor  = vec4(var_face_color.xyz, 1.0) * t.x * var_face_color.w + vec4(var_outline_color.xyz * t.y * var_outline_color.w, t.y * var_outline_color.w) * (1.0 - t.x);
 }

--- a/engine/engine/content/builtins/fonts/font.fp
+++ b/engine/engine/content/builtins/fonts/font.fp
@@ -1,16 +1,20 @@
-varying mediump vec2 var_texcoord0;
-varying lowp vec4 var_face_color;
-varying lowp vec4 var_outline_color;
-varying lowp vec4 var_shadow_color;
-varying lowp vec4 var_layer_mask;
+#version 140
 
-uniform lowp sampler2D texture_sampler;
+in mediump vec2 var_texcoord0;
+in mediump vec4 var_face_color;
+in mediump vec4 var_outline_color;
+in mediump vec4 var_shadow_color;
+in mediump vec4 var_layer_mask;
+
+out vec4 out_fragColor;
+
+uniform mediump sampler2D texture_sampler;
 
 void main()
 {
-    lowp float is_single_layer = var_layer_mask.a;
-    lowp vec3 t                = texture2D(texture_sampler, var_texcoord0.xy).xyz;
-    float face_alpha           = var_face_color.w * t.x;
+    mediump float is_single_layer = var_layer_mask.a;
+    mediump vec3 t                = texture(texture_sampler, var_texcoord0.xy).xyz;
+    float face_alpha              = var_face_color.w * t.x;
 
     float raw_outline_alpha    = var_outline_color.w * t.y;
     float max_outline_alpha    = (1.0 - face_alpha * is_single_layer);
@@ -20,9 +24,9 @@ void main()
     float max_shadow_alpha     = (1.0 - (face_alpha + outline_alpha) * is_single_layer);
     float shadow_alpha         = min(raw_shadow_alpha, max_shadow_alpha);
 
-    lowp vec4 face_color       = var_layer_mask.x * vec4(var_face_color.xyz, 1.0)    * face_alpha;
-    lowp vec4 outline_color    = var_layer_mask.y * vec4(var_outline_color.xyz, 1.0) * outline_alpha;
-    lowp vec4 shadow_color     = var_layer_mask.z * vec4(var_shadow_color.xyz, 1.0)  * shadow_alpha;
+    mediump vec4 face_color    = var_layer_mask.x * vec4(var_face_color.xyz, 1.0)    * face_alpha;
+    mediump vec4 outline_color = var_layer_mask.y * vec4(var_outline_color.xyz, 1.0) * outline_alpha;
+    mediump vec4 shadow_color  = var_layer_mask.z * vec4(var_shadow_color.xyz, 1.0)  * shadow_alpha;
 
-    gl_FragColor = face_color + outline_color + shadow_color;
+    out_fragColor = face_color + outline_color + shadow_color;
 }

--- a/engine/engine/content/builtins/fonts/font.vp
+++ b/engine/engine/content/builtins/fonts/font.vp
@@ -1,19 +1,24 @@
-uniform highp mat4 view_proj;
-
-varying mediump vec2 var_texcoord0;
-varying lowp vec4 var_face_color;
-varying lowp vec4 var_outline_color;
-varying lowp vec4 var_shadow_color;
-varying lowp vec4 var_layer_mask;
-varying lowp float var_is_single_layer;
+#version 140
 
 // positions are in world space
-attribute mediump vec4 position;
-attribute mediump vec2 texcoord0;
-attribute lowp vec4 face_color;
-attribute lowp vec4 outline_color;
-attribute lowp vec4 shadow_color;
-attribute lowp vec3 layer_mask;
+in mediump vec4 position;
+in mediump vec2 texcoord0;
+in mediump vec4 face_color;
+in mediump vec4 outline_color;
+in mediump vec4 shadow_color;
+in mediump vec3 layer_mask;
+
+out mediump vec2 var_texcoord0;
+out mediump vec4 var_face_color;
+out mediump vec4 var_outline_color;
+out mediump vec4 var_shadow_color;
+out mediump vec4 var_layer_mask;
+out mediump float var_is_single_layer;
+
+uniform vs_uniforms
+{
+    uniform mat4 view_proj;
+};
 
 void main()
 {

--- a/engine/engine/content/builtins/materials/gui.fp
+++ b/engine/engine/content/builtins/materials/gui.fp
@@ -1,10 +1,13 @@
-varying mediump vec2 var_texcoord0;
-varying lowp vec4 var_color;
+#version 140
 
-uniform lowp sampler2D texture_sampler;
+in mediump vec2 var_texcoord0;
+in mediump vec4 var_color;
+
+out vec4 out_fragColor;
+
+uniform mediump sampler2D texture_sampler;
 
 void main()
 {
-    lowp vec4 tex = texture2D(texture_sampler, var_texcoord0.xy);
-    gl_FragColor = tex * var_color;
+    out_fragColor = texture(texture_sampler, var_texcoord0.xy) * var_color;
 }

--- a/engine/engine/content/builtins/materials/gui.vp
+++ b/engine/engine/content/builtins/materials/gui.vp
@@ -1,12 +1,16 @@
-uniform highp mat4 view_proj;
+#version 140
 
-// positions are in world space
-attribute mediump vec3 position;
-attribute mediump vec2 texcoord0;
-attribute lowp vec4 color;
+in mediump vec3 position;
+in mediump vec2 texcoord0;
+in mediump vec4 color;
 
-varying mediump vec2 var_texcoord0;
-varying lowp vec4 var_color;
+out mediump vec2 var_texcoord0;
+out mediump vec4 var_color;
+
+uniform vs_uniforms
+{
+    mediump mat4 view_proj;
+};
 
 void main()
 {

--- a/engine/engine/content/builtins/materials/gui_paged_atlas.fp
+++ b/engine/engine/content/builtins/materials/gui_paged_atlas.fp
@@ -1,11 +1,14 @@
-varying mediump vec2 var_texcoord0;
-varying lowp vec4 var_color;
-varying lowp float var_page_index;
+#version 140
 
-uniform lowp sampler2DArray texture_sampler;
+in mediump vec2 var_texcoord0;
+in mediump vec4 var_color;
+in mediump float var_page_index;
+
+out vec4 out_fragColor;
+
+uniform mediump sampler2DArray texture_sampler;
 
 void main()
 {
-    lowp vec4 tex = texture2DArray(texture_sampler, vec3(var_texcoord0.xy, var_page_index));
-    gl_FragColor = tex * var_color;
+    out_fragColor = texture(texture_sampler, vec3(var_texcoord0.xy, var_page_index)) * var_color;
 }

--- a/engine/engine/content/builtins/materials/gui_paged_atlas.vp
+++ b/engine/engine/content/builtins/materials/gui_paged_atlas.vp
@@ -1,14 +1,18 @@
-uniform highp mat4 view_proj;
+#version 140
 
-// positions are in world space
-attribute mediump vec3 position;
-attribute mediump vec2 texcoord0;
-attribute lowp vec4 color;
-attribute lowp float page_index;
+in mediump vec3 position;
+in mediump vec2 texcoord0;
+in mediump vec4 color;
+in mediump float page_index;
 
-varying mediump vec2 var_texcoord0;
-varying lowp vec4 var_color;
-varying lowp float var_page_index;
+out mediump vec2 var_texcoord0;
+out mediump vec4 var_color;
+out mediump float var_page_index;
+
+uniform vs_uniforms
+{
+    mat4 view_proj;
+};
 
 void main()
 {

--- a/engine/engine/content/builtins/materials/model.fp
+++ b/engine/engine/content/builtins/materials/model.fp
@@ -1,16 +1,22 @@
-varying highp vec4 var_position;
-varying mediump vec3 var_normal;
-varying mediump vec2 var_texcoord0;
-varying mediump vec4 var_light;
+in highp vec4 var_position;
+in mediump vec3 var_normal;
+in mediump vec2 var_texcoord0;
+in mediump vec4 var_light;
 
-uniform lowp sampler2D tex0;
-uniform lowp vec4 tint;
+out vec4 out_fragColor;
+
+uniform mediump sampler2D tex0;
+
+uniform fs_uniforms
+{
+    mediump vec4 tint;
+};
 
 void main()
 {
     // Pre-multiply alpha since all runtime textures already are
     vec4 tint_pm = vec4(tint.xyz * tint.w, tint.w);
-    vec4 color = texture2D(tex0, var_texcoord0.xy) * tint_pm;
+    vec4 color = texture(tex0, var_texcoord0.xy) * tint_pm;
 
     // Diffuse light calculations
     vec3 ambient_light = vec3(0.2);
@@ -18,6 +24,6 @@ void main()
     diff_light = max(dot(var_normal,diff_light), 0.0) + ambient_light;
     diff_light = clamp(diff_light, 0.0, 1.0);
 
-    gl_FragColor = vec4(color.rgb*diff_light,1.0);
+    out_fragColor = vec4(color.rgb*diff_light,1.0);
 }
 

--- a/engine/engine/content/builtins/materials/model.vp
+++ b/engine/engine/content/builtins/materials/model.vp
@@ -1,23 +1,27 @@
+#version 140
 
 // Positions can be world or local space, since world and normal
 // matrices are identity for world vertex space materials.
 // If world vertex space is selected, you can remove the
 // normal matrix multiplication for optimal performance.
 
-attribute highp vec4 position;
-attribute mediump vec2 texcoord0;
-attribute mediump vec3 normal;
+in highp vec4 position;
+in mediump vec2 texcoord0;
+in mediump vec3 normal;
 
-uniform mediump mat4 mtx_worldview;
-uniform mediump mat4 mtx_view;
-uniform mediump mat4 mtx_proj;
-uniform mediump mat4 mtx_normal;
-uniform mediump vec4 light;
+out highp vec4 var_position;
+out mediump vec3 var_normal;
+out mediump vec2 var_texcoord0;
+out mediump vec4 var_light;
 
-varying highp vec4 var_position;
-varying mediump vec3 var_normal;
-varying mediump vec2 var_texcoord0;
-varying mediump vec4 var_light;
+uniform vs_uniforms
+{
+    uniform mediump mat4 mtx_worldview;
+    uniform mediump mat4 mtx_view;
+    uniform mediump mat4 mtx_proj;
+    uniform mediump mat4 mtx_normal;
+    uniform mediump vec4 light;
+};
 
 void main()
 {

--- a/engine/engine/content/builtins/materials/model_instanced.vp
+++ b/engine/engine/content/builtins/materials/model_instanced.vp
@@ -1,28 +1,32 @@
+#version 140
 
 // Positions can be world or local space, since world and normal
 // matrices are identity for world vertex space materials.
 // If world vertex space is selected, you can remove the
 // normal matrix multiplication for optimal performance.
 
-attribute highp vec4 position;
-attribute mediump vec2 texcoord0;
-attribute mediump vec3 normal;
+in highp vec4 position;
+in mediump vec2 texcoord0;
+in mediump vec3 normal;
 
 // When 'mtx_world' and 'mtx_normal' is specified as attributes,
 // instanced rendering is automatically triggered.
 // To read more about instancing in Defold, navigate to
 // https://defold.com/manuals/material/#instancing
-attribute mediump mat4 mtx_world;
-attribute mediump mat4 mtx_normal;
+in mediump mat4 mtx_world;
+in mediump mat4 mtx_normal;
 
-uniform mediump mat4 mtx_view;
-uniform mediump mat4 mtx_proj;
-uniform mediump vec4 light;
+out highp vec4 var_position;
+out mediump vec3 var_normal;
+out mediump vec2 var_texcoord0;
+out mediump vec4 var_light;
 
-varying highp vec4 var_position;
-varying mediump vec3 var_normal;
-varying mediump vec2 var_texcoord0;
-varying mediump vec4 var_light;
+uniform vs_uniforms
+{
+    mediump mat4 mtx_view;
+    mediump mat4 mtx_proj;
+    mediump vec4 light;
+};
 
 void main()
 {

--- a/engine/engine/content/builtins/materials/particlefx.fp
+++ b/engine/engine/content/builtins/materials/particlefx.fp
@@ -1,13 +1,21 @@
-varying mediump vec2 var_texcoord0;
-varying lowp vec4 var_color;
+#version 140
 
-uniform lowp sampler2D texture_sampler;
-uniform lowp vec4 tint;
+in mediump vec2 var_texcoord0;
+in mediump vec4 var_color;
+
+out vec4 out_fragColor;
+
+uniform mediump sampler2D texture_sampler;
+
+uniform fs_uniforms
+{
+    mediump vec4 tint;
+};
 
 void main()
 {
     // Pre-multiply alpha since all runtime textures already are
-    lowp vec4 tint_pm = vec4(tint.xyz * tint.w, tint.w);
+    mediump vec4 tint_pm = vec4(tint.xyz * tint.w, tint.w);
     // var_color is vertex color from the particle system, pre-multiplied in vertex program
-    gl_FragColor = texture2D(texture_sampler, var_texcoord0.xy) * var_color * tint_pm;
+    out_fragColor = texture(texture_sampler, var_texcoord0.xy) * var_color * tint_pm;
 }

--- a/engine/engine/content/builtins/materials/particlefx.vp
+++ b/engine/engine/content/builtins/materials/particlefx.vp
@@ -1,12 +1,17 @@
-uniform highp mat4 view_proj;
+#version 140
 
 // positions are in world space
-attribute highp vec4 position;
-attribute mediump vec2 texcoord0;
-attribute lowp vec4 color;
+in highp vec4 position;
+in mediump vec2 texcoord0;
+in mediump vec4 color;
 
-varying mediump vec2 var_texcoord0;
-varying lowp vec4 var_color;
+out mediump vec2 var_texcoord0;
+out mediump vec4 var_color;
+
+uniform vs_uniforms
+{
+    highp mat4 view_proj;
+};
 
 void main()
 {

--- a/engine/engine/content/builtins/materials/particlefx_paged_atlas.fp
+++ b/engine/engine/content/builtins/materials/particlefx_paged_atlas.fp
@@ -1,14 +1,22 @@
-varying mediump vec2 var_texcoord0;
-varying lowp vec4    var_color;
-varying lowp float   var_page_index;
+#version 140
 
-uniform lowp sampler2DArray texture_sampler;
-uniform lowp vec4           tint;
+in mediump vec2 var_texcoord0;
+in mediump vec4 var_color;
+in mediump float var_page_index;
+
+out vec4 out_fragColor;
+
+uniform mediump sampler2DArray texture_sampler;
+
+uniform fs_uniforms
+{
+    mediump vec4 tint;
+};
 
 void main()
 {
     // Pre-multiply alpha since all runtime textures already are
-    lowp vec4 tint_pm = vec4(tint.xyz * tint.w, tint.w);
+    mediump vec4 tint_pm = vec4(tint.xyz * tint.w, tint.w);
     // var_color is vertex color from the particle system, pre-multiplied in vertex program
-    gl_FragColor = texture2DArray(texture_sampler, vec3(var_texcoord0.xy, var_page_index)) * var_color * tint_pm;
+    out_fragColor = texture2DArray(texture_sampler, vec3(var_texcoord0.xy, var_page_index)) * var_color * tint_pm;
 }

--- a/engine/engine/content/builtins/materials/particlefx_paged_atlas.fp
+++ b/engine/engine/content/builtins/materials/particlefx_paged_atlas.fp
@@ -18,5 +18,5 @@ void main()
     // Pre-multiply alpha since all runtime textures already are
     mediump vec4 tint_pm = vec4(tint.xyz * tint.w, tint.w);
     // var_color is vertex color from the particle system, pre-multiplied in vertex program
-    out_fragColor = texture2DArray(texture_sampler, vec3(var_texcoord0.xy, var_page_index)) * var_color * tint_pm;
+    out_fragColor = texture(texture_sampler, vec3(var_texcoord0.xy, var_page_index)) * var_color * tint_pm;
 }

--- a/engine/engine/content/builtins/materials/particlefx_paged_atlas.vp
+++ b/engine/engine/content/builtins/materials/particlefx_paged_atlas.vp
@@ -1,14 +1,19 @@
-uniform highp mat4 view_proj;
+#version 140
 
 // positions are in world space
-attribute highp vec4   position;
-attribute mediump vec2 texcoord0;
-attribute lowp vec4    color;
-attribute lowp float   page_index;
+in highp vec4 position;
+in mediump vec2 texcoord0;
+in mediump vec4 color;
+in mediump float page_index;
 
-varying mediump vec2 var_texcoord0;
-varying lowp vec4    var_color;
-varying lowp float   var_page_index;
+out mediump vec2 var_texcoord0;
+out mediump vec4 var_color;
+out mediump float var_page_index;
+
+uniform vs_uniforms
+{
+    highp mat4 view_proj;
+};
 
 void main()
 {

--- a/engine/engine/content/builtins/materials/sprite.fp
+++ b/engine/engine/content/builtins/materials/sprite.fp
@@ -1,11 +1,18 @@
-varying mediump vec2 var_texcoord0;
+#version 140
 
-uniform lowp sampler2D texture_sampler;
-uniform lowp vec4 tint;
+in mediump vec2 var_texcoord0;
+
+out vec4 out_fragColor;
+
+uniform mediump sampler2D texture_sampler;
+uniform fs_uniforms
+{
+    mediump vec4 tint;
+};
 
 void main()
 {
     // Pre-multiply alpha since all runtime textures already are
-    lowp vec4 tint_pm = vec4(tint.xyz * tint.w, tint.w);
-    gl_FragColor = texture2D(texture_sampler, var_texcoord0.xy) * tint_pm;
+    mediump vec4 tint_pm = vec4(tint.xyz * tint.w, tint.w);
+    out_fragColor = texture(texture_sampler, var_texcoord0.xy) * tint_pm;
 }

--- a/engine/engine/content/builtins/materials/sprite.vp
+++ b/engine/engine/content/builtins/materials/sprite.vp
@@ -1,10 +1,15 @@
-uniform highp mat4 view_proj;
+#version 140
 
 // positions are in world space
-attribute highp vec4 position;
-attribute mediump vec2 texcoord0;
+in highp vec4 position;
+in mediump vec2 texcoord0;
 
-varying mediump vec2 var_texcoord0;
+out mediump vec2 var_texcoord0;
+
+uniform vs_uniforms
+{
+    highp mat4 view_proj;
+};
 
 void main()
 {

--- a/engine/engine/content/builtins/materials/sprite_paged_atlas.fp
+++ b/engine/engine/content/builtins/materials/sprite_paged_atlas.fp
@@ -3,7 +3,7 @@
 in mediump vec2 var_texcoord0;
 in mediump float var_page_index;
 
-out vec4 out_FragColor;
+out vec4 out_fragColor;
 
 uniform mediump sampler2DArray texture_sampler;
 
@@ -16,5 +16,5 @@ void main()
 {
     // Pre-multiply alpha since all runtime textures already are
     mediump vec4 tint_pm = vec4(tint.xyz * tint.w, tint.w);
-    out_fragColor      = texture2DArray(texture_sampler, vec3(var_texcoord0.xy, var_page_index)) * tint_pm;
+    out_fragColor = texture(texture_sampler, vec3(var_texcoord0.xy, var_page_index)) * tint_pm;
 }

--- a/engine/engine/content/builtins/materials/sprite_paged_atlas.fp
+++ b/engine/engine/content/builtins/materials/sprite_paged_atlas.fp
@@ -1,12 +1,20 @@
-varying mediump vec2 var_texcoord0;
-varying lowp float   var_page_index;
+#version 140
 
-uniform lowp sampler2DArray texture_sampler;
-uniform lowp vec4           tint;
+in mediump vec2 var_texcoord0;
+in mediump float var_page_index;
+
+out vec4 out_FragColor;
+
+uniform mediump sampler2DArray texture_sampler;
+
+uniform fs_uniforms
+{
+    mediump vec4 tint;
+};
 
 void main()
 {
     // Pre-multiply alpha since all runtime textures already are
-    lowp vec4 tint_pm = vec4(tint.xyz * tint.w, tint.w);
-    gl_FragColor      = texture2DArray(texture_sampler, vec3(var_texcoord0.xy, var_page_index)) * tint_pm;
+    mediump vec4 tint_pm = vec4(tint.xyz * tint.w, tint.w);
+    out_fragColor      = texture2DArray(texture_sampler, vec3(var_texcoord0.xy, var_page_index)) * tint_pm;
 }

--- a/engine/engine/content/builtins/materials/sprite_paged_atlas.vp
+++ b/engine/engine/content/builtins/materials/sprite_paged_atlas.vp
@@ -1,12 +1,17 @@
-uniform highp mat4 view_proj;
+#version 140
 
 // positions are in world space
-attribute highp vec4   position;
-attribute mediump vec2 texcoord0;
-attribute lowp float   page_index;
+in highp vec4 position;
+in mediump vec2 texcoord0;
+in mediump float page_index;
 
-varying mediump vec2 var_texcoord0;
-varying lowp float   var_page_index;
+out mediump vec2 var_texcoord0;
+out mediump float var_page_index;
+
+uniform vs_uniforms
+{
+    highp mat4 view_proj;
+};
 
 void main()
 {

--- a/engine/engine/content/builtins/materials/tile_map.fp
+++ b/engine/engine/content/builtins/materials/tile_map.fp
@@ -1,11 +1,19 @@
-varying mediump vec2 var_texcoord0;
+#version 140
 
-uniform lowp sampler2D texture_sampler;
-uniform lowp vec4 tint;
+in mediump vec2 var_texcoord0;
+
+out vec4 out_fragColor;
+
+uniform mediump sampler2D texture_sampler;
+
+uniform fs_uniforms
+{
+    mediump vec4 tint;
+};
 
 void main()
 {
     // Pre-multiply alpha since all runtime textures already are
-    lowp vec4 tint_pm = vec4(tint.xyz * tint.w, tint.w);
-    gl_FragColor = texture2D(texture_sampler, var_texcoord0.xy) * tint_pm;
+    mediump vec4 tint_pm = vec4(tint.xyz * tint.w, tint.w);
+    out_fragColor = texture(texture_sampler, var_texcoord0.xy) * tint_pm;
 }

--- a/engine/engine/content/builtins/materials/tile_map.vp
+++ b/engine/engine/content/builtins/materials/tile_map.vp
@@ -1,10 +1,15 @@
-uniform highp mat4 view_proj;
+#version 140
 
 // positions are in world space
-attribute highp vec4 position;
-attribute mediump vec2 texcoord0;
+in highp vec4 position;
+in mediump vec2 texcoord0;
 
-varying mediump vec2 var_texcoord0;
+out mediump vec2 var_texcoord0;
+
+uniform vs_uniforms
+{
+    highp mat4 view_proj;
+};
 
 void main()
 {

--- a/engine/engine/content/materials/debug.fp
+++ b/engine/engine/content/materials/debug.fp
@@ -1,6 +1,10 @@
-varying lowp vec4 var_color;
+#version 140
+
+in mediump vec4 var_color;
+
+out vec4 out_fragColor;
 
 void main()
 {
-    gl_FragColor = var_color;
+    out_fragColor = var_color;
 }

--- a/engine/engine/content/materials/debug.vp
+++ b/engine/engine/content/materials/debug.vp
@@ -1,9 +1,15 @@
-uniform mediump mat4 view_proj;
+#version 140
 
-varying lowp vec4 var_color;
+in mediump vec4 position;
+in mediump vec4 color;
 
-attribute mediump vec4 position;
-attribute lowp vec4 color;
+uniform vs_uniforms
+{
+    mediump mat4 view_proj;
+};
+
+
+out mediump vec4 var_color;
 
 void main()
 {

--- a/engine/shaderc/src/shaderc_spvc.cpp
+++ b/engine/shaderc/src/shaderc_spvc.cpp
@@ -440,6 +440,11 @@ namespace dmShaderc
             spvc_compiler_options_set_uint(spv_options, SPVC_COMPILER_OPTION_GLSL_VERSION,                  options.m_Version);
             spvc_compiler_options_set_bool(spv_options, SPVC_COMPILER_OPTION_GLSL_ES,                       options.m_GlslEs);
             spvc_compiler_options_set_bool(spv_options, SPVC_COMPILER_OPTION_GLSL_ENABLE_420PACK_EXTENSION, !options.m_No420PackExtension);
+
+            // TODO:
+            // SPVC_COMPILER_OPTION_GLSL_ES_DEFAULT_FLOAT_PRECISION_HIGHP
+            // SPVC_COMPILER_OPTION_GLSL_ES_DEFAULT_INT_PRECISION_HIGHP
+
         }
         else if (compiler->m_BaseCompiler.m_Language == SHADER_LANGUAGE_HLSL)
         {

--- a/engine/shaderc/src/test/test_shaderc.cpp
+++ b/engine/shaderc/src/test/test_shaderc.cpp
@@ -453,7 +453,7 @@ TEST(Shaderc, Structs)
     dmShaderc::DeleteShaderContext(shader_ctx);
 }
 
-static int TestStandalone(const char* filename)
+static int TestStandalone(const char* filename, const char* compileTo = 0)
 {
     uint32_t data_size;
     void* data = ReadFile(filename, &data_size);
@@ -462,6 +462,26 @@ static int TestStandalone(const char* filename)
     const dmShaderc::ShaderReflection* reflection = dmShaderc::GetReflection(shader_ctx);
 
     dmShaderc::DebugPrintReflection(reflection);
+
+    if (compileTo)
+    {
+        if (strcmp(compileTo, "es100") == 0)
+        {
+            dmShaderc::HShaderCompiler compiler = dmShaderc::NewShaderCompiler(shader_ctx, dmShaderc::SHADER_LANGUAGE_GLSL);
+            dmShaderc::ShaderCompilerOptions options;
+            options.m_Stage                      = dmShaderc::SHADER_STAGE_VERTEX;
+            options.m_Version                    = 100;
+            options.m_No420PackExtension         = 1;
+            options.m_GlslEmitUboAsPlainUniforms = 1;
+            options.m_GlslEs                     = 1;
+            options.m_EntryPoint                 = "main";
+
+            dmShaderc::ShaderCompileResult* dst = dmShaderc::Compile(shader_ctx, compiler, options);
+            dmLogInfo("%s", (const char*) dst->m_Data.Begin());
+
+            dmShaderc::DeleteShaderCompiler(compiler);
+        }
+    }
 
     dmShaderc::DeleteShaderContext(shader_ctx);
 
@@ -472,6 +492,11 @@ int main(int argc, char **argv)
 {
     if (argc > 1 && (strstr(argv[1], ".spv") != 0))
     {
+        if (argc > 2)
+        {
+            return TestStandalone(argv[1], argv[2]);
+        }
+
         return TestStandalone(argv[1]);
     }
 


### PR DESCRIPTION
The builtin shaders are now written in `#version 140` glsl, which means that they will now be compiled to the target shader language with the new shader compile pipeline. To read more about the new pipeline and how to migrate existing shaders, head over to https://defold.com/manuals/shader/#writing-modern-glsl-shaders

Fixes #10107 