### PR TITLE
Fix arrow key movement of GUI elements on non default layouts

### DIFF
--- a/editor/src/clj/editor/scene.clj
+++ b/editor/src/clj/editor/scene.clj
@@ -1237,17 +1237,10 @@
           (.setImage image-view new-image))))))
 
 (defn- nudge! [scene-node-ids ^double dx ^double dy ^double dz]
-  (g/transact
-   (for [node-id scene-node-ids
-         :let [[^double x ^double y ^double z] (g/node-value node-id :position)
-               current-layout (g/maybe-node-value node-id :current-layout)
-               new-position [(+ x dx) (+ y dy) (+ z dz)]]]
-     (if (str/blank? current-layout)
-       (g/set-property node-id :position new-position)
-       (g/update-property
-        node-id :layout->prop->override
-        update current-layout
-        assoc :position new-position)))))
+  (g/with-auto-evaluation-context evaluation-context
+    (g/transact
+      (for [node-id scene-node-ids]
+        (scene-tools/manip-move evaluation-context node-id (Vector3d. dx dy dz))))))
 
 (declare selection->movable)
 

--- a/editor/src/clj/editor/scene.clj
+++ b/editor/src/clj/editor/scene.clj
@@ -14,7 +14,6 @@
 
 (ns editor.scene
   (:require [clojure.set :as set]
-            [clojure.string :as str]
             [dynamo.graph :as g]
             [editor.background :as background]
             [editor.camera :as c]

--- a/editor/src/clj/editor/scene.clj
+++ b/editor/src/clj/editor/scene.clj
@@ -1236,8 +1236,8 @@
           (.setImage image-view new-image))))))
 
 (defn- nudge! [scene-node-ids ^double dx ^double dy ^double dz]
-  (g/with-auto-evaluation-context evaluation-context
-    (g/transact
+  (g/transact
+    (g/with-auto-evaluation-context evaluation-context
       (for [node-id scene-node-ids]
         (scene-tools/manip-move evaluation-context node-id (Vector3d. dx dy dz))))))
 


### PR DESCRIPTION
Moving gui elements using arrow keys on non default layouts now works as intended.

Fixes #10077
