### PR TITLE
Async loaded texture resource now deregisters correct number of bytes from the load queue

### DIFF
--- a/engine/engine/src/test/issue-10119/issue-10119-proxy.collection
+++ b/engine/engine/src/test/issue-10119/issue-10119-proxy.collection
@@ -1,0 +1,10 @@
+name: "img"
+scale_along_z: 0
+embedded_instances {
+  id: "go"
+  data: "components {\n"
+  "  id: \"img\"\n"
+  "  component: \"/issue-10119/issue-10119.gui\"\n"
+  "}\n"
+  ""
+}

--- a/engine/engine/src/test/issue-10119/issue-10119.atlas
+++ b/engine/engine/src/test/issue-10119/issue-10119.atlas
@@ -1,0 +1,10 @@
+images {
+  image: "/builtins/assets/images/logo/logo_256.png"
+}
+images {
+  image: "/builtins/assets/images/logo/logo_blue_256.png"
+}
+images {
+  image: "/builtins/assets/images/logo/logo_blue_512.png"
+}
+extrude_borders: 2

--- a/engine/engine/src/test/issue-10119/issue-10119.collection
+++ b/engine/engine/src/test/issue-10119/issue-10119.collection
@@ -1,0 +1,16 @@
+name: "main"
+scale_along_z: 0
+embedded_instances {
+  id: "go"
+  data: "components {\n"
+  "  id: \"m\"\n"
+  "  component: \"/issue-10119/issue-10119.script\"\n"
+  "}\n"
+  "embedded_components {\n"
+  "  id: \"collectionproxy\"\n"
+  "  type: \"collectionproxy\"\n"
+  "  data: \"collection: \\\"/issue-10119/issue-10119-proxy.collection\\\"\\n"
+  "\"\n"
+  "}\n"
+  ""
+}

--- a/engine/engine/src/test/issue-10119/issue-10119.gui
+++ b/engine/engine/src/test/issue-10119/issue-10119.gui
@@ -1,0 +1,22 @@
+textures {
+  name: "mega"
+  texture: "/issue-10119/issue-10119.atlas"
+}
+nodes {
+  position {
+    x: 529.0
+    y: 336.0
+  }
+  scale {
+    x: 0.5
+    y: 0.5
+    z: 0.5
+  }
+  type: TYPE_BOX
+  texture: "mega/logo_blue_512"
+  id: "box"
+  inherit_alpha: true
+  size_mode: SIZE_MODE_AUTO
+}
+material: "/builtins/materials/gui.material"
+adjust_reference: ADJUST_REFERENCE_PARENT

--- a/engine/engine/src/test/issue-10119/issue-10119.script
+++ b/engine/engine/src/test/issue-10119/issue-10119.script
@@ -1,0 +1,24 @@
+function init(self)
+	self.count = 0
+	msg.post("#collectionproxy", "async_load")
+end
+
+function update(self, dt)
+	self.count = self.count + 1
+
+	if self.count > 100 then
+		print("Waited too long to load!")
+		sys.exit(1)
+	end
+end
+
+function on_message(self, message_id, message, sender)
+	if message_id == hash("proxy_loaded") then
+		msg.post(sender, "init")
+		msg.post(sender, "enable")
+
+		-- The issue was that the loading became messed up, and we'd wait forever
+		print("Loaded!")
+		sys.exit(0)
+	end
+end

--- a/engine/engine/src/test/main.collection
+++ b/engine/engine/src/test/main.collection
@@ -136,5 +136,11 @@ embedded_instances {
   "  data: \"collection: \\\"/issue-8672/issue-8672.collection\\\"\\n"
   "\"\n"
   "}\n"
+  "embedded_components {\n"
+  "  id: \"collectionproxy30\"\n"
+  "  type: \"collectionproxy\"\n"
+  "  data: \"collection: \\\"/issue-10119/issue-10119.collection\\\"\\n"
+  "\"\n"
+  "}\n"
   ""
 }

--- a/engine/engine/src/test/test_engine.cpp
+++ b/engine/engine/src/test/test_engine.cpp
@@ -49,8 +49,13 @@ static void TestEngienFinalize(void* _ctx)
     dmEngineFinalize();
 }
 
+static bool g_ExitRequested = false;
+static int  g_ExitCode = 0;
+
 static dmEngine::HEngine TestEngineCreate(int argc, char** argv)
 {
+    g_ExitRequested = false;
+
     dmEngine::HEngine engine = dmEngineCreate(argc, argv);
 
     if (g_PreRun)
@@ -70,12 +75,19 @@ static void TestEngineDestroy(dmEngine::HEngine engine)
 
 static dmEngine::UpdateResult TestEngineUpdate(dmEngine::HEngine engine)
 {
+    if (g_ExitRequested)
+    {
+        return dmEngine::RESULT_EXIT;
+    }
     return dmEngineUpdate(engine);
 }
 
 static void TestEngineGetResult(dmEngine::HEngine engine, int* run_action, int* exit_code, int* argc, char*** argv)
 {
     dmEngineGetResult(engine, run_action, exit_code, argc, argv);
+
+    g_ExitRequested = true;
+    g_ExitCode = *exit_code;
 }
 
 static int Launch(int argc, char *argv[], PreRun pre_run, PostRun post_run, void* context)
@@ -425,6 +437,13 @@ TEST_F(EngineTest, ISSUE_8672_timer)
 {
     char project_path[256];
     const char* argv[] = {"test_engine", "--config=bootstrap.main_collection=/issue-8672/issue-8672.collectionc", "--config=dmengine.unload_builtins=0", MAKE_PATH(project_path, "/game.projectc")};
+    ASSERT_EQ(0, Launch(DM_ARRAY_SIZE(argv), (char**)argv, 0, 0, 0));
+}
+
+TEST_F(EngineTest, ISSUE_10119)
+{
+    char project_path[256];
+    const char* argv[] = {"test_engine", "--config=bootstrap.main_collection=/issue-10119/issue-10119.collectionc", "--config=script.shared_state=1", MAKE_PATH(project_path, "/game.projectc")};
     ASSERT_EQ(0, Launch(DM_ARRAY_SIZE(argv), (char**)argv, 0, 0, 0));
 }
 

--- a/engine/resource/src/async/load_queue.cpp
+++ b/engine/resource/src/async/load_queue.cpp
@@ -54,6 +54,7 @@ dmResource::Result DoLoadResource(dmResource::HFactory factory, HRequest request
             params.m_FileSize               = request->m_ResourceSize;
             params.m_IsBufferPartial        = request->m_BufferSize != request->m_ResourceSize;
             params.m_IsBufferTransferrable  = 1;
+            params.m_Filename               = request->m_CanonicalPath;
             params.m_HintInfo               = &request->m_PreloadInfo.m_HintInfo;
 
             // out


### PR DESCRIPTION
Fixes https://github.com/defold/defold/issues/10119

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
