### PR TITLE
Fix exception when pasting named resources inside Gui scenes

### DIFF
--- a/editor/project.clj
+++ b/editor/project.clj
@@ -281,7 +281,7 @@
                                 :jvm-opts          ["-Ddefold.extension.lua-preprocessor.url=https://github.com/defold/extension-lua-preprocessor/archive/main.zip"
                                                     "-Ddefold.extension.rive.url=https://github.com/defold/extension-rive/archive/refs/tags/2.4.0.zip"
                                                     "-Ddefold.extension.simpledata.url=https://github.com/defold/extension-simpledata/archive/refs/tags/v1.1.0.zip"
-                                                    "-Ddefold.extension.spine.url=https://github.com/defold/extension-spine/archive/refs/tags/3.6.4.zip"
+                                                    "-Ddefold.extension.spine.url=https://github.com/defold/extension-spine/archive/refs/tags/3.6.5.zip"
                                                     "-Ddefold.extension.teal.url=https://github.com/defold/extension-teal/archive/main.zip"
                                                     "-Ddefold.extension.texturepacker.url=https://github.com/defold/extension-texturepacker/archive/refs/tags/2.1.zip"
                                                     "-Ddefold.unpack.path=tmp/unpack"

--- a/editor/test/integration/test_util.clj
+++ b/editor/test/integration/test_util.clj
@@ -32,6 +32,7 @@
             [editor.handler :as handler]
             [editor.material :as material]
             [editor.math :as math]
+            [editor.outline :as outline]
             [editor.particlefx :as particlefx]
             [editor.prefs :as prefs]
             [editor.progress :as progress]
@@ -674,6 +675,56 @@
 
 (defn outline [root path]
   (get-in (g/node-value root :node-outline) (interleave (repeat :children) path)))
+
+(defrecord OutlineItemIterator [root path]
+  outline/ItemIterator
+  (value [_this]
+    (outline root path))
+  (parent [_this]
+    (when (not (empty? path))
+      (->OutlineItemIterator root (butlast path)))))
+
+(defn- make-outline-item-iterator [root-node-id outline-path]
+  {:pre [(g/node-id? root-node-id)
+         (vector? outline-path)
+         (every? nat-int? outline-path)]}
+  (->OutlineItemIterator root-node-id outline-path))
+
+(defn outline-copy
+  "Return a serialized a data representation of the specified parts of the
+  edited scene. The returned value could be placed on the clipboard and later
+  pasted into an edited scene."
+  [project root-node-id & outline-paths]
+  (let [item-iterators (mapv #(make-outline-item-iterator root-node-id %) outline-paths)]
+    (outline/copy project item-iterators)))
+
+(defn outline-cut!
+  "Cut the specified parts of the edited scene and return a data representation
+  of the cut nodes that can be placed on the clipboard."
+  [project root-node-id outline-path & mode-outline-paths]
+  (let [item-iterators (into [(make-outline-item-iterator root-node-id outline-path)]
+                             (map #(make-outline-item-iterator root-node-id %))
+                             mode-outline-paths)]
+    (outline/cut! project item-iterators)))
+
+(defn outline-paste!
+  "Paste the copied-data into the edited scene, similar to how the user would
+  perform this operation in the editor."
+  ([project root-node-id outline-path copied-data]
+   (outline-paste! project root-node-id outline-path copied-data nil))
+  ([project root-node-id outline-path copied-data select-fn]
+   (let [item-iterator (make-outline-item-iterator root-node-id outline-path)]
+     (assert (outline/paste? project item-iterator copied-data))
+     (outline/paste! project item-iterator copied-data select-fn))))
+
+(defn outline-duplicate!
+  "Simulate a copy-paste operation of the specified node in-place, typically how
+  a user might duplicate an element in the edited scene."
+  ([project root-node-id outline-path]
+   (outline-duplicate! project root-node-id outline-path nil))
+  ([project root-node-id outline-path select-fn]
+   (let [copied-data (outline-copy project root-node-id outline-path)]
+     (outline-paste! project root-node-id outline-path copied-data select-fn))))
 
 (defn- outline->str
   ([outline]


### PR DESCRIPTION
Fixed an issue where pasting a named resource inside a Gui scene would throw an exception.

Fixes #10145.

### Technical changes
* Added functions for Outline-related clipboard actions to the `test-util` module.
* Added tests for pasting all resource types. This uncovered that we do not support copy-pasting of Spine Scene resources in GUI. The tests added here depend on merging https://github.com/defold/extension-spine/pull/198.