### PR TITLE
Fix single separator issue on toolbar

### DIFF
--- a/editor/src/clj/editor/ui.clj
+++ b/editor/src/clj/editor/ui.clj
@@ -1828,9 +1828,9 @@
                             (user-data! child ::command command))
                           (user-data! child ::menu-user-data user-data)
                           child)))
-           children (if (instance? Separator (last children))
-                      (butlast children)
-                      children)]
+           children (cond-> children
+                      (instance? Separator (last children)) butlast
+                      (instance? Separator (first children)) rest)]
        (doseq [child children]
          (.add (.getChildren control) child))))))
 


### PR DESCRIPTION
I did not expect #10150 to break something, but a single separator is visible when we focus on the asset tree. We need to also remove separators when they are the first element of a toolbar. I hadn't noticed that we clear the toolbar when we focus on the asset tree until now.