### PR TITLE
Add context menu to scene view

### DIFF
--- a/editor/src/clj/editor/input.clj
+++ b/editor/src/clj/editor/input.clj
@@ -83,4 +83,6 @@
                :shift (.isShiftDown mouse-event)
                :meta (.isMetaDown mouse-event)
                :control (.isControlDown mouse-event)
-               :click-count (.getClickCount mouse-event))))))
+               :click-count (.getClickCount mouse-event)
+               :screen-x (.getScreenX mouse-event)
+               :screen-y (.getScreenY mouse-event))))))

--- a/editor/src/clj/editor/input.clj
+++ b/editor/src/clj/editor/input.clj
@@ -84,5 +84,6 @@
                :meta (.isMetaDown mouse-event)
                :control (.isControlDown mouse-event)
                :click-count (.getClickCount mouse-event)
+               :target (.getTarget mouse-event)
                :screen-x (.getScreenX mouse-event)
                :screen-y (.getScreenY mouse-event))))))

--- a/editor/src/clj/editor/input.clj
+++ b/editor/src/clj/editor/input.clj
@@ -13,27 +13,9 @@
 ;; specific language governing permissions and limitations under the License.
 
 (ns editor.input
-  (:require [dynamo.graph :as g]
-            [schema.core :as s])
-  (:import [com.defold.editor Start UIUtil]
-           [com.jogamp.opengl.util.awt TextRenderer]
-           [editor.types Camera AABB Region]
-           [java.awt Font]
-           [java.awt.image BufferedImage]
-           [javafx.application Platform]
-           [javafx.collections FXCollections ObservableList]
-           [javafx.embed.swing SwingFXUtils]
-           [javafx.event ActionEvent EventHandler EventType]
-           [javafx.fxml FXMLLoader]
-           [javafx.scene Scene Node Parent]
-           [javafx.scene.control Button TitledPane TextArea TreeItem Menu MenuItem MenuBar Tab ProgressBar]
-           [javafx.scene.image Image ImageView WritableImage PixelWriter]
-           [javafx.scene.input InputEvent MouseEvent MouseButton ScrollEvent]
-           [javafx.scene.layout AnchorPane StackPane HBox Priority]
-           [javafx.stage Stage FileChooser]
-           [java.io File]
-           [java.lang Runnable System]
-           [javax.vecmath Point3d Matrix4d Vector4d Matrix3d Vector3d]))
+  (:require [schema.core :as s])
+  (:import [javafx.event EventType]
+           [javafx.scene.input InputEvent MouseEvent MouseButton ScrollEvent]))
 
 (set! *warn-on-reflection* true)
 

--- a/editor/src/clj/editor/scene.clj
+++ b/editor/src/clj/editor/scene.clj
@@ -1295,7 +1295,6 @@
                             (try
                               (profiler/profile "input-event" -1
                                 (let [action (augment-action view-id (i/action-from-jfx e))
-                                      action (assoc action :parent parent)
                                       x (:x action)
                                       y (:y action)
                                       pos [x y 0.0]

--- a/editor/src/clj/editor/scene.clj
+++ b/editor/src/clj/editor/scene.clj
@@ -1295,6 +1295,7 @@
                             (try
                               (profiler/profile "input-event" -1
                                 (let [action (augment-action view-id (i/action-from-jfx e))
+                                      action (assoc action :parent parent)
                                       x (:x action)
                                       y (:y action)
                                       pos [x y 0.0]

--- a/editor/src/clj/editor/scene_selection.clj
+++ b/editor/src/clj/editor/scene_selection.clj
@@ -144,7 +144,7 @@
                          (let [node ^Node (:target action)
                                scene ^Scene (.getScene node)
                                context-menu (ui/init-context-menu! ::scene-selection-menu scene)]
-                           (.show context-menu node ^double (:screen-x action) ^double  (:screen-y action))))
+                           (.show context-menu node ^double (:screen-x action) ^double (:screen-y action))))
                        nil)
       :mouse-released (do
                         (g/transact

--- a/editor/src/clj/editor/scene_selection.clj
+++ b/editor/src/clj/editor/scene_selection.clj
@@ -140,8 +140,8 @@
                            (g/set-property self :prev-selection (g/node-value self :selection))))
                        (select self op-seq mode toggle?)
                        (when contextual?
-                         (-> (ui/init-context-menu! ::scene-selection-menu (.getScene (:parent action)))
-                             (.show (:parent action) (:screen-x action) (:screen-y action))))
+                         (-> (ui/init-context-menu! ::scene-selection-menu (.getScene (:target action)))
+                             (.show (:target action) (:screen-x action) (:screen-y action))))
                        nil)
       :mouse-released (do
                         (g/transact

--- a/editor/src/clj/editor/scene_selection.clj
+++ b/editor/src/clj/editor/scene_selection.clj
@@ -13,50 +13,42 @@
 ;; specific language governing permissions and limitations under the License.
 
 (ns editor.scene-selection
-  (:require [clojure.set :as set]
-            [dynamo.graph :as g]
+  (:require [dynamo.graph :as g]
             [editor.system :as system]
-            [editor.background :as background]
-            [editor.colors :as colors]
-            [editor.camera :as c]
-            [editor.core :as core]
             [editor.geom :as geom]
-            [editor.gl :as gl]
-            [editor.grid :as grid]
-            [editor.input :as i]
-            [editor.math :as math]
+            [editor.handler :as handler]
             [editor.types :as types]
-            [editor.workspace :as workspace]
+            [editor.ui :as ui]
             [editor.gl.pass :as pass]
-            [schema.core :as s]
-            [service.log :as log])
-  (:import [com.defold.editor Start UIUtil]
-           [com.jogamp.opengl.util GLPixelStorageModes]
-           [com.jogamp.opengl.util.awt TextRenderer]
-           [editor.types Camera AABB Region Rect]
-           [java.awt Font]
-           [java.awt.image BufferedImage DataBufferByte]
-           [javafx.animation AnimationTimer]
-           [javafx.application Platform]
-           [javafx.beans.value ChangeListener]
-           [javafx.collections FXCollections ObservableList]
-           [javafx.embed.swing SwingFXUtils]
-           [javafx.event ActionEvent EventHandler]
-           [javafx.geometry BoundingBox]
-           [javafx.scene Scene Node Parent]
-           [javafx.scene.control Tab]
-           [javafx.scene.image Image ImageView WritableImage PixelWriter]
-           [javafx.scene.input MouseEvent]
-           [javafx.scene.layout AnchorPane Pane]
+            [schema.core :as s])
+  (:import [editor.types Rect]
            [java.lang Runnable Math]
-           [java.nio IntBuffer ByteBuffer ByteOrder]
-           [com.jogamp.opengl GL GL2 GL2GL3 GLContext GLProfile GLAutoDrawable GLOffscreenAutoDrawable GLDrawableFactory GLCapabilities]
-           [com.jogamp.opengl.glu GLU]
-           [javax.vecmath Point2i Point3d Quat4d Matrix4d Vector4d Matrix3d Vector3d]))
+           [com.jogamp.opengl GL2]
+           [javax.vecmath Point2i Point3d Matrix4d]))
 
 (set! *warn-on-reflection* true)
 
-(defn render-selection-box [^GL2 gl render-args renderables count]
+(handler/register-menu! ::scene-selection-menu
+                        [{:label "Cut"
+                          :command :cut}
+                         {:label "Copy"
+                          :command :copy}
+                         {:label "Paste"
+                          :command :paste}
+                         {:label "Delete"
+                          :icon "icons/32/Icons_M_06_trash.png"
+                          :command :delete}
+                         {:label :separator}
+                         {:label "Show/Hide Objects"
+                          :command :hide-toggle-selected}
+                         {:label "Hide Unselected Objects"
+                          :command :hide-unselected}
+                         {:label "Show All Hidden Objects"
+                          :command :show-all-hidden}
+                         {:label :separator
+                          :id ::context-menu-end}])
+
+(defn render-selection-box [^GL2 gl _render-args renderables _count]
   (let [user-data (:user-data (first renderables))
         start (:start user-data)
         current (:current user-data)]
@@ -90,15 +82,26 @@
 (defn- select [controller op-seq mode toggle?]
   (let [select-fn (g/node-value controller :select-fn)
         selection (g/node-value controller :picking-selection)
+        contextual? (g/node-value controller :contextual?)
         mode-filter-fn (case mode
                         :single (fn [selection] (if-let [sel (first selection)] [sel] []))
-                        :multi  identity)
-        toggle-filter-fn (if toggle?
+                        :multi identity)
+        toggle-filter-fn (cond
+                           toggle?
                            (fn [selection]
                              (let [selection-set (set selection)
                                    prev-selection (g/node-value controller :prev-selection)
                                    prev-selection-set (set prev-selection)]
                                (into [] (concat (filter (complement selection-set) prev-selection) (filter (complement prev-selection-set) selection)))))
+
+                           contextual?
+                           (fn [selection]
+                             (let [prev-selection (g/node-value controller :prev-selection)]
+                               (if (some #(= (first selection) %) prev-selection)
+                                 prev-selection
+                                 selection)))
+                           
+                           :else
                            identity)
         sel-filter-fn (comp toggle-filter-fn mode-filter-fn)
         selection (or (not-empty (sel-filter-fn selection))
@@ -115,13 +118,13 @@
   [[x0 y0 z0] [x1 y1 z1]]
   (.distance (Point3d. x0 y0 z0) (Point3d. x1 y1 z1)))
 
-(defn handle-selection-input [self action user-data]
-  (let [start      (g/node-value self :start)
-        current    (g/node-value self :current)
-        op-seq     (g/node-value self :op-seq)
-        mode       (g/node-value self :mode)
-        toggle?    (g/node-value self :toggle?)
-        cursor-pos [(:x action) (:y action) 0]]
+(defn handle-selection-input [self action _user-data]
+  (let [start (g/node-value self :start)
+        op-seq (g/node-value self :op-seq)
+        mode (g/node-value self :mode)
+        toggle? (g/node-value self :toggle?)
+        cursor-pos [(:x action) (:y action) 0]
+        contextual? (= (:button action) :secondary)]
     (case (:type action)
       :mouse-pressed (let [op-seq (gensym)
                            toggle? (true? (some true? (map #(% action) toggle-modifiers)))
@@ -133,8 +136,12 @@
                            (g/set-property self :current cursor-pos)
                            (g/set-property self :mode mode)
                            (g/set-property self :toggle? toggle?)
+                           (g/set-property self :contextual? contextual?)
                            (g/set-property self :prev-selection (g/node-value self :selection))))
                        (select self op-seq mode toggle?)
+                       (when contextual?
+                         (-> (ui/init-context-menu! ::scene-selection-menu (.getScene (:parent action)))
+                             (.show (:parent action) (:screen-x action) (:screen-y action))))
                        nil)
       :mouse-released (do
                         (g/transact
@@ -144,9 +151,10 @@
                             (g/set-property self :op-seq nil)
                             (g/set-property self :mode nil)
                             (g/set-property self :toggle? nil)
+                            (g/set-property self :contextual? nil)
                             (g/set-property self :prev-selection nil)))
                         nil)
-      :mouse-moved (if start
+      :mouse-moved (if (and start (not (g/node-value self :contextual?)))
                      (let [new-mode (if (and (= :single mode) (< min-pick-size (distance start cursor-pos)))
                                       :multi
                                       mode)]
@@ -183,6 +191,7 @@
   (property op-seq g/Any)
   (property mode SelectionMode)
   (property toggle? g/Bool)
+  (property contextual? g/Bool)
   (property prev-selection g/Any)
 
   (input selection g/Any)

--- a/editor/src/clj/editor/scene_selection.clj
+++ b/editor/src/clj/editor/scene_selection.clj
@@ -24,6 +24,7 @@
   (:import [editor.types Rect]
            [java.lang Runnable Math]
            [com.jogamp.opengl GL2]
+           [javafx.scene Node]
            [javax.vecmath Point2i Point3d Matrix4d]))
 
 (set! *warn-on-reflection* true)
@@ -140,8 +141,10 @@
                            (g/set-property self :prev-selection (g/node-value self :selection))))
                        (select self op-seq mode toggle?)
                        (when contextual?
-                         (-> (ui/init-context-menu! ::scene-selection-menu (.getScene (:target action)))
-                             (.show (:target action) (:screen-x action) (:screen-y action))))
+                         (let [node ^Node (:target action)
+                               scene ^Scene (.getScene node)
+                               context-menu (ui/init-context-menu! ::scene-selection-menu scene)]
+                           (.show context-menu node ^double (:screen-x action) ^double  (:screen-y action))))
                        nil)
       :mouse-released (do
                         (g/transact

--- a/editor/src/clj/editor/scene_selection.clj
+++ b/editor/src/clj/editor/scene_selection.clj
@@ -24,7 +24,7 @@
   (:import [editor.types Rect]
            [java.lang Runnable Math]
            [com.jogamp.opengl GL2]
-           [javafx.scene Node]
+           [javafx.scene Node Scene]
            [javax.vecmath Point2i Point3d Matrix4d]))
 
 (set! *warn-on-reflection* true)

--- a/editor/src/clj/editor/ui.clj
+++ b/editor/src/clj/editor/ui.clj
@@ -1424,15 +1424,15 @@
   (defn set-show-relative-to-window! [context-menu x]
     (.invoke method context-menu (into-array Object [(boolean x)]))))
 
-(defn init-context-menu! [menu-location ^Scene scene]
+(defn init-context-menu! ^ContextMenu [menu-location ^Scene scene]
   (let [menu-items (g/with-auto-or-fake-evaluation-context evaluation-context
                      (make-menu-items scene (handler/realize-menu menu-location) (contexts scene false) (or (user-data scene :command->shortcut) {}) evaluation-context))
         cm (make-context-menu menu-items)]
     (doto (.getItems cm)
       (refresh-separator-visibility)
       (refresh-menu-item-styles))
-      ;; Required for autohide to work when the event originates from the anchor/source node
-      ;; See RT-15160 and Control.java
+    ;; Required for autohide to work when the event originates from the anchor/source node
+    ;; See RT-15160 and Control.java
     (set-show-relative-to-window! cm true)
     cm))
 
@@ -1440,9 +1440,9 @@
   (when-not (.isConsumed event)
     (.consume event)
     (let [node ^Node (.getTarget event)
-          scene ^Scene (.getScene node)]
-      (-> (init-context-menu! menu-location scene)
-          (.show node (.getScreenX event) (.getScreenY event))))))
+          scene ^Scene (.getScene node)
+          context-menu (init-context-menu! menu-location scene)]
+      (.show context-menu node (.getScreenX event) (.getScreenY event)))))
 
 (defn register-context-menu
   "Register a context menu listener on a control for the menu location


### PR DESCRIPTION
Introduce a context menu to scene view.

![context-menu](https://github.com/user-attachments/assets/1ef87331-3f9e-400c-a860-7c51a2d002dd)

### Technical changes
Simply registering a context menu wouldn't work properly in this case. We need to explicitly show it on certain conditions, and make it play nice with element selection.