### PR TITLE
Add `pprint` to editor scripts

### DIFF
--- a/editor/src/clj/editor/editor_extensions/docs.clj
+++ b/editor/src/clj/editor/editor_extensions/docs.clj
@@ -267,7 +267,8 @@
           :type :function
           :description "Pretty-print a Lua value"
           :parameters [{:name "value"
-                        :types ["any"]}]}]
+                        :types ["any"]
+                        :doc "any lua value to pretty-print"}]}]
         (when-not (System/getProperty "defold.version")
           ;; Dev-only docs
           [{:name "editor.bundle.abort_message"

--- a/editor/src/clj/editor/editor_extensions/docs.clj
+++ b/editor/src/clj/editor/editor_extensions/docs.clj
@@ -262,7 +262,12 @@
           :description "Encode Lua value to JSON string"
           :parameters [{:name "value"
                         :types ["any"]
-                        :doc "any lua value that may be represented as JSON"}]}]
+                        :doc "any lua value that may be represented as JSON"}]}
+         {:name "pprint"
+          :type :function
+          :description "Pretty-print a Lua value"
+          :parameters [{:name "value"
+                        :types ["any"]}]}]
         (when-not (System/getProperty "defold.version")
           ;; Dev-only docs
           [{:name "editor.bundle.abort_message"

--- a/editor/test/integration/editor_extensions_test.clj
+++ b/editor/test/integration/editor_extensions_test.clj
@@ -819,9 +819,7 @@ nesting:
                      (str out)
                      #"0x[0-9a-f]+"
                      (fn [s]
-                       (if-let [id (@hash->stable-id s)]
-                         id
-                         (let [id ((vswap! hash->stable-id #(assoc % s (str "0x" (count %)))) s)]
-                           id))))]
+                       (or (@hash->stable-id s)
+                           ((vswap! hash->stable-id #(assoc % s (str "0x" (count %)))) s))))]
         (is (= actual expected-pprint-output)
             (string/join "\n" (diff/make-diff-output-lines actual expected-pprint-output 3)))))))

--- a/editor/test/integration/editor_extensions_test.clj
+++ b/editor/test/integration/editor_extensions_test.clj
@@ -32,7 +32,8 @@
             [editor.ui :as ui]
             [editor.workspace :as workspace]
             [integration.test-util :as test-util]
-            [support.test-support :as test-support])
+            [support.test-support :as test-support]
+            [util.diff :as diff])
   (:import [org.luaj.vm2 LuaError]))
 
 (set! *warn-on-reflection* true)
@@ -753,3 +754,74 @@
               [:out "json.decode('fals') => error"]
               [:out "json.decode('true {', {all = true}) => error"]]
              @output)))))
+
+(def expected-pprint-output
+  "scalars:
+1
+true
+<function: print>
+\"string\"
+empty:
+{} --[[0x0]]
+array only:
+{ --[[0x1]]
+  1,
+  2,
+  3,
+  \"a\"
+}
+hash only:
+{ --[[0x2]]
+  a = 1,
+  b = 2
+}
+array and hash:
+{ --[[0x3]]
+  1,
+  2,
+  a = 3,
+  b = 4
+}
+non-identifier keys:
+{ --[[0x4]]
+  [\"foo-bar\"] = 1
+}
+circular refs:
+{ --[[0x5]]
+  1,
+  2,
+  circular_ref = <table: 0x5>
+}
+nesting:
+{ --[[0x6]]
+  1,
+  false,
+  { --[[0x7]]
+    a = 1
+  },
+  { --[[0x8]]
+    [{ --[[0x9]]
+      \"table\",
+      \"key\"
+    }] = 1
+  },
+  \"a\"
+}
+")
+
+(deftest pprint-test
+  (test-util/with-loaded-project "test/resources/editor_extensions/pprint-test"
+    (let [out (StringBuilder.)]
+      (reload-editor-scripts! project :display-output! #(doto out (.append %2) (.append \newline)))
+      (run-edit-menu-test-command!)
+      (let [hash->stable-id (volatile! {})
+            actual (string/replace
+                     (str out)
+                     #"0x[0-9a-f]+"
+                     (fn [s]
+                       (if-let [id (@hash->stable-id s)]
+                         id
+                         (let [id ((vswap! hash->stable-id #(assoc % s (str "0x" (count %)))) s)]
+                           id))))]
+        (is (= actual expected-pprint-output)
+            (string/join "\n" (diff/make-diff-output-lines actual expected-pprint-output 3)))))))

--- a/editor/test/resources/editor_extensions/pprint-test/.gitignore
+++ b/editor/test/resources/editor_extensions/pprint-test/.gitignore
@@ -1,0 +1,11 @@
+/.editor_settings
+/.internal
+/build
+.externalToolBuilders
+.DS_Store
+Thumbs.db
+.lock-wscript
+*.pyc
+.project
+.cproject
+builtins

--- a/editor/test/resources/editor_extensions/pprint-test/game.project
+++ b/editor/test/resources/editor_extensions/pprint-test/game.project
@@ -1,0 +1,20 @@
+[bootstrap]
+main_collection = /main/main.collectionc
+
+[script]
+shared_state = 1
+
+[display]
+width = 960
+height = 640
+high_dpi = 1
+
+[android]
+input_method = HiddenInputField
+
+[html5]
+scale_mode = stretch
+
+[project]
+title = pprint-test
+

--- a/editor/test/resources/editor_extensions/pprint-test/test.editor_script
+++ b/editor/test/resources/editor_extensions/pprint-test/test.editor_script
@@ -1,0 +1,43 @@
+local M = {}
+
+function M.get_commands()
+    return {{
+        label = "Test",
+        locations = {"Edit"},
+        run = function()
+            print("scalars:")
+            pprint(1, true, print, "string")
+            
+            print("empty:")
+            pprint({})
+            
+            print("array only:")
+            pprint({1, 2, 3, "a"})
+
+            print("hash only:")
+            pprint({a = 1, b = 2})
+
+            print("array and hash:")
+            pprint({1, 2, a = 3, b = 4})
+
+            print("non-identifier keys:")
+            pprint({["foo-bar"] = 1})
+
+            print("circular refs:")
+            local t = {1, 2}
+            t.circular_ref = t
+            pprint(t)
+
+            print("nesting:")
+            pprint({
+                1,
+                false,
+                {a = 1},
+                {[{"table", "key"}] = 1},
+                "a"
+            })
+        end
+    }}
+end
+
+return M


### PR DESCRIPTION
This changeset adds `pprint` editor script function:
```lua
local t = {1, 2, a = 3, b = 4}
t.self = t
pprint(t)

-- Output:
-- { -- [[0x7f8b1b0]]
--   1,
--   2,
--   a = 3,
--   b = 4,
--   self = <table: 0x7f8b1b0>
-- }
```

Fixes #10140
