### PR TITLE
Pan camera on ctrl down while scrolling

### DIFF
--- a/editor/src/clj/editor/prefs.clj
+++ b/editor/src/clj/editor/prefs.clj
@@ -160,7 +160,9 @@
            :engine-arguments {:type :string :scope :project}}}
     :scene {:type :object
             :properties
-            {:move-whole-pixels {:type :boolean :default true}}}
+            {:move-whole-pixels {:type :boolean :default true}
+             :pan-on-mouse-wheel {:type :boolean
+                                   :label "Pan on mouse wheel when 2d view is active"}}}
     :dev {:type :object
           :properties
           {:custom-engine {:type :any}}}

--- a/editor/src/clj/editor/prefs_dialog.clj
+++ b/editor/src/clj/editor/prefs_dialog.clj
@@ -108,6 +108,8 @@
                     {:label "Engine Arguments" :type :string :key [:run :engine-arguments]  :multi-line true
                      :prompt-value "One argument per line"
                      :tooltip "Arguments that will be passed to the dmengine executables when the editor builds and runs.\n Use one argument per line. For example:\n--config=bootstrap.main_collection=/my dir/1.collectionc\n--verbose\n--graphics-adapter=vulkan"}]}
+           {:name "Scene"
+            :prefs [{:label "Pan on mouse wheel when 2d view is active" :type :boolean :key [:scene :pan-on-mouse-wheel]}]}
            {:name "Code"
             :prefs [{:label "Custom Editor" :type :string :key [:code :custom-editor]}
                     {:label "Open File" :type :string :key [:code :open-file]}

--- a/editor/src/clj/editor/rulers.clj
+++ b/editor/src/clj/editor/rulers.clj
@@ -23,12 +23,11 @@
             [editor.gl.vertex2 :as vtx]
             [editor.gl.pass :as pass]
             [editor.image-util :as image-util]
-            [editor.math :as math]
             [editor.types :as types])
   (:import  [com.jogamp.opengl GL GL2]
             [java.awt.image BufferedImage]
             [java.nio BufferOverflowException]
-            [javax.vecmath Matrix4d Point3d]
+            [javax.vecmath Point3d]
             [editor.types Camera]))
 
 (set! *warn-on-reflection* true)
@@ -189,80 +188,77 @@
     "%.0f"))
 
 (g/defnk produce-renderables [camera viewport cursor-pos vertex-buffer]
-  (let [z (some-> camera
-            c/camera-view-matrix
-            (.getElement 2 2))]
-    (if (and (not (types/empty-space? viewport)) z (= z 1.0))
-      (let [[min-x min-y] (unproject camera viewport 0 (:bottom viewport))
-            [max-x max-y] (unproject camera viewport (:right viewport) 0)
-            tmp-p (Point3d.)
-            [cursor-x cursor-y] cursor-pos
-            xs (label-points min-x max-x (Math/ceil (/ (:right viewport) horizontal-label-spacing))
-                 #(-> (c/camera-project camera viewport (doto tmp-p (.setX %)))
-                    (.x))
-                 #(> % width))
-           ys (label-points min-y max-y (Math/ceil (/ (:bottom viewport) vertical-label-spacing))
-                #(-> (c/camera-project camera viewport (doto tmp-p (.setY %)))
-                   (.y))
-                #(> (- (:bottom viewport) height) %))
-           user-data (do
-                       (vtx/clear! vertex-buffer)
-                       (try
-                         ;; backgrounds
-                         (let [[r g b a] colors/scene-background]
-                           (quad! vertex-buffer 0 0 width (:bottom viewport) r g b a)
-                           (quad! vertex-buffer 0 (- (:bottom viewport) height) (:right viewport) (:bottom viewport) r g b a))
-                         ;; x-labels
-                         (let [y (- (:bottom viewport) (/ (- height (second img-dims)) 2))
-                               ws (mapv first xs)
-                               nf (num-format ws)]
-                           (doseq [[x-w x-s] xs
-                                   :let [text (String/format nil nf (to-array [x-w]))]]
-                             (label! vertex-buffer (+ 2 x-s) y text true)))
-                         ;; y-labels
-                         (let [x width
-                               ws (mapv first ys)
-                               nf (num-format ws)]
-                           (doseq [[y-w y-s] ys
-                                   :let [text (String/format nil nf (to-array [y-w]))]]
-                             (label! vertex-buffer (- x 2) (- y-s 1) text false)))
-                         ;; This is unfortunate but should not have any severe consequence
-                         (catch BufferOverflowException _))
-                       ;; end of triangles; start of lines
-                       (let [tri-count (count vertex-buffer)]
-                         (try
-                           (let [[r g b a] marker-color]
-                             (let [x0 width
-                                   y0 0
-                                   x1 (:right viewport)
-                                   y1 (- (:bottom viewport) height)]
-                               ;; borders
-                               (line! vertex-buffer x0 y0 x0 y1 r g b a)
-                               (line! vertex-buffer x0 y1 x1 y1 r g b a)
-                               ;; x tick markers
-                               (doseq [[_ x-s] xs
-                                       :let [y0 (:bottom viewport)]]
-                                 (line! vertex-buffer x-s y0 x-s y1 r g b a))
-                               ;; y tick markers
-                               (doseq [[_ y-s] ys
-                                       :let [y-s (inc y-s)]]
-                                 (line! vertex-buffer 0 y-s width y-s r g b a))
-                               ;; mouse markers
-                               (when (and cursor-x (> cursor-x width))
-                                 (let [y0 (:bottom viewport)]
-                                   (apply line! vertex-buffer cursor-x y0 cursor-x y1 colors/scene-grid-x-axis)))
-                               (when (and cursor-y (< cursor-y y1))
-                                 (apply line! vertex-buffer 0 cursor-y width cursor-y colors/scene-grid-y-axis))))
-                           ;; This is unfortunate but should not have any severe consequence
-                           (catch BufferOverflowException _))
-                         (vtx/flip! vertex-buffer)
-                         {:vb vertex-buffer
-                          :tri-count tri-count
-                          :line-count (- (count vertex-buffer) tri-count)}))]
-        {pass/overlay [{:render-fn render-rulers
-                        :batch-key nil
-                        :user-data user-data}]})
-      {})))
+  (if (and (not (types/empty-space? viewport)) (c/camera-2d? camera))
+    (let [[min-x min-y] (unproject camera viewport 0 (:bottom viewport))
+          [max-x max-y] (unproject camera viewport (:right viewport) 0)
+          tmp-p (Point3d.)
+          [cursor-x cursor-y] cursor-pos
+          xs (label-points min-x max-x (Math/ceil (/ (:right viewport) horizontal-label-spacing))
+                           #(-> (c/camera-project camera viewport (doto tmp-p (.setX %)))
+                                (.x))
+                           #(> % width))
+          ys (label-points min-y max-y (Math/ceil (/ (:bottom viewport) vertical-label-spacing))
+                           #(-> (c/camera-project camera viewport (doto tmp-p (.setY %)))
+                                (.y))
+                           #(> (- (:bottom viewport) height) %))
+          user-data (do
+                      (vtx/clear! vertex-buffer)
+                      (try
+                        ;; backgrounds
+                        (let [[r g b a] colors/scene-background]
+                          (quad! vertex-buffer 0 0 width (:bottom viewport) r g b a)
+                          (quad! vertex-buffer 0 (- (:bottom viewport) height) (:right viewport) (:bottom viewport) r g b a))
+                        ;; x-labels
+                        (let [y (- (:bottom viewport) (/ (- height (second img-dims)) 2))
+                              ws (mapv first xs)
+                              nf (num-format ws)]
+                          (doseq [[x-w x-s] xs
+                                  :let [text (String/format nil nf (to-array [x-w]))]]
+                            (label! vertex-buffer (+ 2 x-s) y text true)))
+                        ;; y-labels
+                        (let [x width
+                              ws (mapv first ys)
+                              nf (num-format ws)]
+                          (doseq [[y-w y-s] ys
+                                  :let [text (String/format nil nf (to-array [y-w]))]]
+                            (label! vertex-buffer (- x 2) (- y-s 1) text false)))
+                        ;; This is unfortunate but should not have any severe consequence
+                        (catch BufferOverflowException _))
+                         ;; end of triangles; start of lines
+                      (let [tri-count (count vertex-buffer)]
+                        (try
+                          (let [[r g b a] marker-color
+                                x0 width
+                                y0 0
+                                x1 (:right viewport)
+                                y1 (- (:bottom viewport) height)]
+                            ;; borders
+                            (line! vertex-buffer x0 y0 x0 y1 r g b a)
+                            (line! vertex-buffer x0 y1 x1 y1 r g b a)
+                            ;; x tick markers
+                            (doseq [[_ x-s] xs
+                                    :let [y0 (:bottom viewport)]]
+                              (line! vertex-buffer x-s y0 x-s y1 r g b a))
+                            ;; y tick markers
+                            (doseq [[_ y-s] ys
+                                    :let [y-s (inc y-s)]]
+                              (line! vertex-buffer 0 y-s width y-s r g b a))
+                             ;; mouse markers
+                            (when (and cursor-x (> cursor-x width))
+                              (let [y0 (:bottom viewport)]
+                                (apply line! vertex-buffer cursor-x y0 cursor-x y1 colors/scene-grid-x-axis)))
+                            (when (and cursor-y (< cursor-y y1))
+                              (apply line! vertex-buffer 0 cursor-y width cursor-y colors/scene-grid-y-axis)))
+                          ;; This is unfortunate but should not have any severe consequence
+                          (catch BufferOverflowException _))
+                        (vtx/flip! vertex-buffer)
+                        {:vb vertex-buffer
+                         :tri-count tri-count
+                         :line-count (- (count vertex-buffer) tri-count)}))]
+      {pass/overlay [{:render-fn render-rulers
+                      :batch-key nil
+                      :user-data user-data}]})
+    {}))
 
 (g/defnode Rulers
   (input camera Camera)

--- a/editor/src/clj/editor/scene.clj
+++ b/editor/src/clj/editor/scene.clj
@@ -28,6 +28,7 @@
             [editor.input :as i]
             [editor.math :as math]
             [editor.pose :as pose]
+            [editor.prefs]
             [editor.properties :as properties]
             [editor.protobuf :as protobuf]
             [editor.render :as render]
@@ -1476,7 +1477,7 @@
                                                                                    (g/operation-sequence op-seq)
                                                                                    (g/operation-label "Select")
                                                                                    (select-fn selection))))]
-                   camera          [c/CameraController :local-camera (or (:camera opts) (c/make-camera :orthographic identity {:fov-x 1000 :fov-y 1000}))]
+                   camera          [c/CameraController :local-camera (or (:camera opts) (c/make-camera :orthographic identity {:fov-x 1000 :fov-y 1000})) :pan-on-mouse-wheel (editor.prefs/get prefs [:scene :pan-on-mouse-wheel])]
                    grid            grid-type
                    tool-controller [tool-controller-type :prefs prefs]
                    rulers          [rulers/Rulers]]


### PR DESCRIPTION
On a 2d view context, scrolling and holding `CTRL` will now pan the camera, instead of zooming in/out. Panning should work on both directions.

Resolves #6425