### PR TITLE
Visibility fixes and enhancements

### DIFF
--- a/editor/src/clj/editor/outline_view.clj
+++ b/editor/src/clj/editor/outline_view.clj
@@ -134,6 +134,7 @@
                 :child-error? (boolean (some :child-error? data))
                 :child-overridden? (boolean (some :child-overridden? data))
                 :hideable? (contains? outline-name-paths (rest node-outline-key-path))
+                :hidden-parent? (scene-visibility/hidden-outline-key-path? hidden-node-outline-key-paths node-outline-key-path)
                 :scene-visibility (if (contains? hidden-node-outline-key-paths node-outline-key-path)
                                     :hidden
                                     :visible))]
@@ -489,7 +490,8 @@
                             (ui/add-style! "visibility-toggle")
                             (.addEventFilter MouseEvent/MOUSE_PRESSED ui/ignore-event-filter)
                             (AnchorPane/setRightAnchor 0.0))
-        text-label (Label.)
+        text-label (doto (Label.)
+                     (ui/bind-double-click! :open))
         h-box (doto (HBox. 5 (ui/node-array [image-view-icon text-label]))
                 (ui/add-style! "h-box")
                 (AnchorPane/setRightAnchor 0.0)
@@ -508,7 +510,7 @@
                        (proxy-super setGraphic nil)
                        (proxy-super setContextMenu nil)
                        (proxy-super setStyle nil))
-                     (let [{:keys [label icon link color outline-error? outline-overridden? outline-reference? outline-show-link? parent-reference? child-error? child-overridden? scene-visibility hideable? node-outline-key-path]} item
+                     (let [{:keys [label icon link color outline-error? outline-overridden? outline-reference? outline-show-link? parent-reference? child-error? child-overridden? scene-visibility hideable? node-outline-key-path hidden-parent?]} item
                            icon (if outline-error? "icons/32/Icons_E_02_error.png" icon)
                            show-link? (and (some? link)
                                            (or outline-reference? outline-show-link?))
@@ -544,6 +546,9 @@
                        (if hideable?
                          (ui/add-style! this "hideable")
                          (ui/remove-style! this "hideable"))
+                       (if hidden-parent?
+                         (ui/add-style! this "hidden-parent")
+                         (ui/remove-style! this "hidden-parent"))
                        (if hidden?
                          (ui/add-style! this "scene-visibility-hidden")
                          (ui/remove-style! this "scene-visibility-hidden")))))))]
@@ -578,7 +583,6 @@
       (.setOnDragDropped (ui/event-handler e (error-reporting/catch-all! (drag-dropped project app-view outline-view e))))
       (.setCellFactory (reify Callback (call ^TreeCell [this view] (make-tree-cell view drag-entered-handler drag-exited-handler))))
       (ui/observe-selection #(propagate-selection %2 app-view))
-      (ui/bind-double-click! :open)
       (ui/register-context-menu ::outline-menu)
       (ui/context! :outline {} (SelectionProvider. outline-view) {} {java.lang.Long :node-id
                                                                      resource/Resource :link}))))

--- a/editor/src/clj/editor/scene.clj
+++ b/editor/src/clj/editor/scene.clj
@@ -40,6 +40,7 @@
             [editor.scene-shapes :as scene-shapes]
             [editor.scene-text :as scene-text]
             [editor.scene-tools :as scene-tools]
+            [editor.scene-visibility :as scene-visibility]
             [editor.system :as system]
             [editor.types :as types]
             [editor.ui :as ui]
@@ -380,7 +381,7 @@
                           (some selection-set node-id-path) :parent-selected) ; Child nodes appear dimly selected if their parent is selected.
         visible? (and parent-shows-children
                       (:visible-self? renderable true)
-                      (not (contains? hidden-node-outline-key-paths node-outline-key-path))
+                      (not (scene-visibility/hidden-outline-key-path? hidden-node-outline-key-paths node-outline-key-path))
                       (not-any? (partial contains? hidden-renderable-tags) (:tags renderable)))
         aabb ^AABB (if visible? (:aabb scene geom/null-aabb) geom/null-aabb)
         flat-renderable (-> scene

--- a/editor/src/clj/editor/scene_visibility.clj
+++ b/editor/src/clj/editor/scene_visibility.clj
@@ -154,20 +154,12 @@
 
   (output outline-name-paths OutlineNamePaths :cached (g/fnk [active-scene] (set (scene-outline-name-paths active-scene))))
 
-  (output outline-name-paths-by-selection-state OutlineNamePathsByBool :cached (g/fnk [outline-name-paths outline-selection]
-                                                                                 (let [selected-outline-name-paths (into [] (keep outline-selection-entry->outline-name-path) outline-selection)
-                                                                                       outline-name-path-below-selection? (fn [outline-name-path]
-                                                                                                                            (boolean (some #(iutil/seq-starts-with? outline-name-path %)
-                                                                                                                                           selected-outline-name-paths)))]
-                                                                                   (iutil/group-into {} #{}
-                                                                                                     outline-name-path-below-selection?
-                                                                                                     outline-name-paths))))
+  (output selected-outline-name-paths OutlineNamePaths (g/fnk [outline-selection]
+                                                         (set (into [] (keep outline-selection-entry->outline-name-path) outline-selection))))
 
-  (output selected-outline-name-paths OutlineNamePaths (g/fnk [outline-name-paths-by-selection-state]
-                                                         (outline-name-paths-by-selection-state true)))
-
-  (output unselected-outline-name-paths OutlineNamePaths (g/fnk [outline-name-paths-by-selection-state]
-                                                           (outline-name-paths-by-selection-state false)))
+  (output unselected-outline-name-paths OutlineNamePaths (g/fnk [selected-outline-name-paths outline-name-paths]
+                                                           (set/difference outline-name-paths selected-outline-name-paths)))
+  
   (output unselected-hideable-outline-name-paths OutlineNamePaths :cached (g/fnk [hidden-outline-name-paths unselected-outline-name-paths]
                                                                             (not-empty (set/difference unselected-outline-name-paths hidden-outline-name-paths))))
 
@@ -260,9 +252,7 @@
            (g/node-value scene-visibility :active-scene-resource-node evaluation-context))
   (run [scene-visibility user-data]
        (let [{:keys [node-outline-key-path]} user-data
-             outline-name-paths (g/node-value scene-visibility :outline-name-paths)
-             name-path-child? #(iutil/seq-starts-with? % (rest node-outline-key-path))
-             name-paths-to-toggle (set (filter name-path-child? outline-name-paths))]
+             name-paths-to-toggle #{(vec (rest node-outline-key-path))}]
          (if (contains? (g/node-value scene-visibility :hidden-node-outline-key-paths) node-outline-key-path)
            (show-outline-name-paths! scene-visibility name-paths-to-toggle)
            (hide-outline-name-paths! scene-visibility name-paths-to-toggle)))))
@@ -418,3 +408,8 @@
   (active? [scene-visibility evaluation-context]
            (g/node-value scene-visibility :active-scene-resource-node evaluation-context))
   (run [scene-visibility] (toggle-tag-visibility! scene-visibility :grid)))
+
+(defn hidden-outline-key-path?
+  [hidden-node-outline-key-paths node-outline-key-path]
+  (boolean (some #(iutil/seq-starts-with? node-outline-key-path %)
+                 hidden-node-outline-key-paths)))

--- a/editor/src/clj/editor/scene_visibility.clj
+++ b/editor/src/clj/editor/scene_visibility.clj
@@ -154,11 +154,11 @@
 
   (output outline-name-paths OutlineNamePaths :cached (g/fnk [active-scene] (set (scene-outline-name-paths active-scene))))
 
-  (output selected-outline-name-paths OutlineNamePaths (g/fnk [outline-selection]
-                                                         (set (into [] (keep outline-selection-entry->outline-name-path) outline-selection))))
+  (output selected-outline-name-paths OutlineNamePaths :cached (g/fnk [outline-selection]
+                                                                 (set (into [] (keep outline-selection-entry->outline-name-path) outline-selection))))
 
-  (output unselected-outline-name-paths OutlineNamePaths (g/fnk [selected-outline-name-paths outline-name-paths]
-                                                           (set/difference outline-name-paths selected-outline-name-paths)))
+  (output unselected-outline-name-paths OutlineNamePaths :cached (g/fnk [selected-outline-name-paths outline-name-paths]
+                                                                   (set/difference outline-name-paths selected-outline-name-paths)))
   
   (output unselected-hideable-outline-name-paths OutlineNamePaths :cached (g/fnk [hidden-outline-name-paths unselected-outline-name-paths]
                                                                             (not-empty (set/difference unselected-outline-name-paths hidden-outline-name-paths))))
@@ -252,7 +252,7 @@
            (g/node-value scene-visibility :active-scene-resource-node evaluation-context))
   (run [scene-visibility user-data]
        (let [{:keys [node-outline-key-path]} user-data
-             name-paths-to-toggle #{(vec (rest node-outline-key-path))}]
+             name-paths-to-toggle #{(subvec node-outline-key-path 1)}]
          (if (contains? (g/node-value scene-visibility :hidden-node-outline-key-paths) node-outline-key-path)
            (show-outline-name-paths! scene-visibility name-paths-to-toggle)
            (hide-outline-name-paths! scene-visibility name-paths-to-toggle)))))

--- a/editor/styling/stylesheets/modules/_outline.scss
+++ b/editor/styling/stylesheets/modules/_outline.scss
@@ -109,7 +109,7 @@
       }
     }
 
-    &.scene-visibility-hidden {
+    &.hidden-parent {
       .tree-disclosure-node {
         .arrow {
           -fx-opacity: 40%;
@@ -121,6 +121,9 @@
       .text {
         -fx-opacity: 40%;
       }
+    }
+
+    &.scene-visibility-hidden {
       .visibility-toggle {
         visibility: visible;
       }


### PR DESCRIPTION
Hide children of invisible nodes without toggling their visibility state, fix hiding models and double clicking on the visibility toggle.

Fixes #9818