### PR TITLE
Zoom at pointer position on mouse wheel

### DIFF
--- a/editor/src/clj/editor/camera.clj
+++ b/editor/src/clj/editor/camera.clj
@@ -388,9 +388,9 @@
   [^Camera camera ^Camera prev-camera ^Region viewport [^double x ^double y]]
   (let [focus ^Vector4d (:focus-point camera)
         point (camera-project camera viewport (Point3d. (.x focus) (.y focus) (.z focus)))
-        screen-z (.z point)
-        world (camera-unproject camera viewport x y screen-z)
-        delta (camera-unproject prev-camera viewport x y screen-z)]
+        prev-point (camera-project prev-camera viewport (Point3d. (.x focus) (.y focus) (.z focus)))
+        world (camera-unproject camera viewport x y (.z point))
+        delta (camera-unproject prev-camera viewport x y (.z prev-point))]
     (.sub delta world)
     (assoc (camera-move camera (.x delta) (.y delta) (.z delta))
            :focus-point (doto focus (.add delta)))))

--- a/editor/src/clj/editor/camera.clj
+++ b/editor/src/clj/editor/camera.clj
@@ -385,6 +385,7 @@
       :focus-point (doto focus (.add delta)))))
 
 (defn pan-at-pointer-position
+  "Pans the camera so that the focus point is at the same position as it was before `dolly`."
   [^Camera camera ^Camera prev-camera ^Region viewport [^double x ^double y]]
   (let [focus ^Vector4d (:focus-point camera)
         point (camera-project camera viewport (Point3d. (.x focus) (.y focus) (.z focus)))

--- a/editor/src/clj/editor/camera.clj
+++ b/editor/src/clj/editor/camera.clj
@@ -388,8 +388,9 @@
   "Pans the camera so that the focus point is at the same position as it was before `dolly`."
   [^Camera camera ^Camera prev-camera ^Region viewport [^double x ^double y]]
   (let [focus ^Vector4d (:focus-point camera)
-        point (camera-project camera viewport (Point3d. (.x focus) (.y focus) (.z focus)))
-        prev-point (camera-project prev-camera viewport (Point3d. (.x focus) (.y focus) (.z focus)))
+        focus-point-3d (Point3d. (.x focus) (.y focus) (.z focus))
+        point (camera-project camera viewport focus-point-3d)
+        prev-point (camera-project prev-camera viewport focus-point-3d)
         world (camera-unproject camera viewport x y (.z point))
         delta (camera-unproject prev-camera viewport x y (.z prev-point))]
     (.sub delta world)
@@ -638,7 +639,7 @@
                    (:movement ui-state))
         camera (g/node-value self :camera)
         is-mode-2d (mode-2d? camera)
-        filter-fn (or (:filter-fn camera) identity)
+        filter-fn (:filter-fn camera)
         camera (cond-> camera
                  (and (= type :scroll)
                       (contains? movements-enabled :dolly))
@@ -659,7 +660,7 @@
                    (= :tumble movement)
                    (tumble last-x last-y x y))
 
-                 :always
+                 filter-fn
                  filter-fn)]
     (g/set-property! self :local-camera camera)
     (case type


### PR DESCRIPTION
When 2d-mode is enabled, zooming will now take the pointer position into account, so that the focus point remains the same on scroll. We can use the mouse position to target the point that we want to zoom into, and avoid panning as a separate navigation step. Holding `ALT` will activate the previous behavior. On 3d-mode the opposite is applied. We maintain a fixed camera target on mouse wheel (as we used to), and pan to the pointed position on `ALT` down.

![zoom-at-pointer-position](https://github.com/user-attachments/assets/e68e3dfb-4587-4b88-b69e-d18b683d18e5)
