### PR TITLE
Fixed an issue where the LiveUpdate archive path could become invalid after an app update

### DIFF
--- a/engine/dlib/src/dlib/sys.h
+++ b/engine/dlib/src/dlib/sys.h
@@ -237,6 +237,19 @@ namespace dmSys
      */
     Result GetLogPath(char* path, uint32_t path_len);
 
+    /**
+     * Get path to home directory.
+     * Platform notes:
+     * <ul>
+     * <li>iOS: In iOS, the home directory is the application’s sandbox directory
+     * <li>MacOs: In macOS, it’s the application’s sandbox directory, or the current user’s home directory if the application isn’t in a sandbox
+     * </ul>
+     * @param path
+     * @param path_len
+     * @return
+     */
+    Result GetHomePath(char* path, uint32_t path_len);
+
 
     /**
      * Get system information

--- a/engine/dlib/src/dlib/sys_cocoa.mm
+++ b/engine/dlib/src/dlib/sys_cocoa.mm
@@ -93,6 +93,17 @@ namespace dmSys
         }
     }
 
+    Result GetHomePath(char* path, uint32_t path_len)
+    {
+        NSString* p = NSHomeDirectory();
+        const char* s = [p UTF8String];
+
+        if (dmStrlCpy(path, s, path_len) >= path_len)
+            return RESULT_INVAL;
+
+        return RESULT_OK;
+    }
+
 #if defined(DM_PLATFORM_IOS)
 
     static NetworkConnectivity g_NetworkConnectivity = NETWORK_DISCONNECTED;

--- a/engine/dlib/src/dlib/sys_posix.cpp
+++ b/engine/dlib/src/dlib/sys_posix.cpp
@@ -595,7 +595,11 @@ namespace dmSys
 
         return RESULT_OK;
     }
+#endif
 
+
+// NOTE: iOS/Mac implementation in sys_cocoa.mm
+#if !defined(__MACH__) && !defined(DM_PLATFORM_IOS)
     Result GetHomePath(char* path, uint32_t path_len)
     {
         const char* home = NULL;
@@ -632,8 +636,6 @@ namespace dmSys
         return RESULT_OK;
     }
 #endif
-
-
 
     void FillTimeZone(struct SystemInfo* info)
     {

--- a/engine/dlib/src/dlib/sys_posix.cpp
+++ b/engine/dlib/src/dlib/sys_posix.cpp
@@ -598,42 +598,10 @@ namespace dmSys
 #endif
 
 
-// NOTE: iOS/Mac implementation in sys_cocoa.mm
-#if !defined(__MACH__) && !defined(DM_PLATFORM_IOS) && !defined(__ANDROID__)
+#if defined(__EMSCRIPTEN__)
     Result GetHomePath(char* path, uint32_t path_len)
     {
-        const char* home = NULL;
-
-    #ifdef _WIN32
-        char home_path[MAX_PATH];
-        if (SUCCEEDED(SHGetFolderPathA(NULL, CSIDL_PROFILE, NULL, 0, home_path)))
-        {
-            home = home_path;
-        }
-        else
-        {
-            return RESULT_INVAL;
-        }
-    #else
-        home = getenv("HOME");
-        if (!home)
-        {
-            struct passwd *pw = getpwuid(getuid());
-            if (pw)
-            {
-                home = pw->pw_dir;
-            }
-            else
-            {
-                return RESULT_INVAL;
-            }
-        }
-    #endif
-
-        if (dmStrlCpy(path, home, path_len) >= path_len)
-            return RESULT_INVAL;
-
-        return RESULT_OK;
+        return GetApplicationSupportPath("", path, path_len);
     }
 #elif defined(__ANDROID__)
     Result GetHomePath(char* path, uint32_t path_len)
@@ -688,6 +656,43 @@ namespace dmSys
         }
 
         return res;
+    }
+// NOTE: iOS/Mac implementation in sys_cocoa.mm
+#elif !defined(__MACH__) && !defined(DM_PLATFORM_IOS)
+    Result GetHomePath(char* path, uint32_t path_len)
+    {
+        const char* home = NULL;
+
+    #ifdef _WIN32
+        char home_path[MAX_PATH];
+        if (SUCCEEDED(SHGetFolderPathA(NULL, CSIDL_PROFILE, NULL, 0, home_path)))
+        {
+            home = home_path;
+        }
+        else
+        {
+            return RESULT_INVAL;
+        }
+    #else
+        home = getenv("HOME");
+        if (!home)
+        {
+            struct passwd *pw = getpwuid(getuid());
+            if (pw)
+            {
+                home = pw->pw_dir;
+            }
+            else
+            {
+                return RESULT_INVAL;
+            }
+        }
+    #endif
+
+        if (dmStrlCpy(path, home, path_len) >= path_len)
+            return RESULT_INVAL;
+
+        return RESULT_OK;
     }
 #endif
 

--- a/engine/resource/src/resource.cpp
+++ b/engine/resource/src/resource.cpp
@@ -311,7 +311,9 @@ HFactory NewFactory(NewFactoryParams* params, const char* uri)
         dmMessage::DeleteSocket(socket);
         return 0;
     }
-
+    char app_home_path[1024];
+    dmSys::GetHomePath(app_home_path, sizeof(app_home_path));
+    dmLogInfo("GetHomePath `%s`", app_home_path);
     if (factory->m_BaseArchiveMount)
     {
         if (params->m_Flags & RESOURCE_FACTORY_FLAGS_LIVE_UPDATE_MOUNTS_ON_START)

--- a/engine/resource/src/resource.cpp
+++ b/engine/resource/src/resource.cpp
@@ -311,9 +311,7 @@ HFactory NewFactory(NewFactoryParams* params, const char* uri)
         dmMessage::DeleteSocket(socket);
         return 0;
     }
-    char app_home_path[1024];
-    dmSys::GetHomePath(app_home_path, sizeof(app_home_path));
-    dmLogInfo("GetHomePath `%s`", app_home_path);
+
     if (factory->m_BaseArchiveMount)
     {
         if (params->m_Flags & RESOURCE_FACTORY_FLAGS_LIVE_UPDATE_MOUNTS_ON_START)

--- a/engine/resource/src/resource_mounts.cpp
+++ b/engine/resource/src/resource_mounts.cpp
@@ -283,7 +283,7 @@ dmResource::Result LoadMounts(HContext ctx, const char* app_support_path)
     }
 
     char app_home_path[1024];
-    dmSys::GetHomePath(app_home_path, sizeof(app_home_path));
+    dmSys::Result app_path_result = dmSys::GetHomePath(app_home_path, sizeof(app_home_path));
 
     uint32_t size = entries.Size();
     for (uint32_t i = 0; i < size; ++i)
@@ -291,13 +291,16 @@ dmResource::Result LoadMounts(HContext ctx, const char* app_support_path)
         MountFileEntry& entry = entries[i];
 
         char uri[1024];
-        dmTemplate::Result tr = dmTemplate::Format((void*)app_home_path, uri, sizeof(uri), entry.m_Uri, UriTeplateReplacer);
-        if (tr != dmTemplate::RESULT_OK)
+        if (app_path_result == dmSys::RESULT_OK)
         {
-            dmLogError("Error formating liveupdate mount Uri `%s` response (%d)", entry.m_Uri, tr);
-            return dmResource::RESULT_INVALID_DATA;
+            dmTemplate::Result tr = dmTemplate::Format((void*)app_home_path, uri, sizeof(uri), entry.m_Uri, UriTeplateReplacer);
+            if (tr != dmTemplate::RESULT_OK)
+            {
+                dmLogError("Error formating liveupdate mount Uri `%s` response (%d)", entry.m_Uri, tr);
+                return dmResource::RESULT_INVALID_DATA;
+            }
         }
-
+        
         DM_RESOURCE_DBG_LOG(2, "  mounting: '%s' %d '%s'\n", entry.m_Name, entry.m_Priority, uri);
         LoadMount(ctx, entry.m_Priority, entry.m_Name, uri, true);
     }

--- a/engine/resource/src/resource_mounts.cpp
+++ b/engine/resource/src/resource_mounts.cpp
@@ -290,7 +290,6 @@ dmResource::Result LoadMounts(HContext ctx, const char* app_support_path)
     {
         MountFileEntry& entry = entries[i];
 
-        dmLogError("Load Before '%s'", entry.m_Uri);
         char uri[1024];
         dmTemplate::Result tr = dmTemplate::Format((void*)app_home_path, uri, sizeof(uri), entry.m_Uri, UriTeplateReplacer);
         if (tr != dmTemplate::RESULT_OK)
@@ -298,7 +297,6 @@ dmResource::Result LoadMounts(HContext ctx, const char* app_support_path)
             dmLogError("Error formating liveupdate mount Uri `%s` response (%d)", entry.m_Uri, tr);
             return dmResource::RESULT_INVALID_DATA;
         }
-        dmLogError("Load After '%s'", uri);
 
         DM_RESOURCE_DBG_LOG(2, "  mounting: '%s' %d '%s'\n", entry.m_Name, entry.m_Priority, uri);
         LoadMount(ctx, entry.m_Priority, entry.m_Name, uri, true);
@@ -344,8 +342,6 @@ dmResource::Result SaveMounts(HContext ctx, const char* app_support_path)
         MountFileEntry entry;
         entry.m_Name = strdup(mount.m_Name);
 
-        dmLogError("Save Before '%s'", uri_str);
-
         if (app_path_result == dmSys::RESULT_OK)
         {
             char* save_path = strstr(uri_str, app_home_path);
@@ -362,8 +358,6 @@ dmResource::Result SaveMounts(HContext ctx, const char* app_support_path)
                 memcpy(uri_str, uricopy, sizeof(uri_str));
             }
         }
-
-        dmLogError("Save After '%s'", uri_str);
 
         entry.m_Uri = strdup(uri_str);
         entry.m_Priority = mount.m_Priority;

--- a/engine/resource/src/resource_mounts.cpp
+++ b/engine/resource/src/resource_mounts.cpp
@@ -249,7 +249,7 @@ static dmResource::Result LoadMount(HContext ctx, int priority, const char* name
     return dmResource::RESULT_OK;
 }
 
-const char* UriTeplateReplacer(void* user_data, const char* key)
+const char* UriTemplateReplacer(void* user_data, const char* key)
 {
     if (strcmp(key, "HOME_PATH") == 0)
     {
@@ -282,7 +282,7 @@ dmResource::Result LoadMounts(HContext ctx, const char* app_support_path)
         return result;
     }
 
-    char app_home_path[1024];
+    char app_home_path[DMPATH_MAX_PATH];
     dmSys::Result app_path_result = dmSys::GetHomePath(app_home_path, sizeof(app_home_path));
 
     uint32_t size = entries.Size();
@@ -290,10 +290,10 @@ dmResource::Result LoadMounts(HContext ctx, const char* app_support_path)
     {
         MountFileEntry& entry = entries[i];
 
-        char uri[1024];
+        char uri[DMPATH_MAX_PATH];
         if (app_path_result == dmSys::RESULT_OK)
         {
-            dmTemplate::Result tr = dmTemplate::Format((void*)app_home_path, uri, sizeof(uri), entry.m_Uri, UriTeplateReplacer);
+            dmTemplate::Result tr = dmTemplate::Format((void*)app_home_path, uri, sizeof(uri), entry.m_Uri, UriTemplateReplacer);
             if (tr != dmTemplate::RESULT_OK)
             {
                 dmLogError("Error formating liveupdate mount Uri `%s` response (%d)", entry.m_Uri, tr);
@@ -320,7 +320,7 @@ dmResource::Result SaveMounts(HContext ctx, const char* app_support_path)
 
     dmArray<MountFileEntry> entries;
 
-    char app_home_path[1024];
+    char app_home_path[DMPATH_MAX_PATH];
     dmSys::Result app_path_result = dmSys::GetHomePath(app_home_path, sizeof(app_home_path));
 
     uint32_t size = ctx->m_Mounts.Size();
@@ -336,7 +336,7 @@ dmResource::Result SaveMounts(HContext ctx, const char* app_support_path)
         dmURI::Parts uri;
         dmResourceProvider::GetUri(mount.m_Archive, &uri);
 
-        char uri_str[1024];
+        char uri_str[DMPATH_MAX_PATH];
         if (uri.m_Location[0] == '\0')
             dmSnPrintf(uri_str, sizeof(uri_str), "%s:%s", uri.m_Scheme, uri.m_Path);
         else
@@ -351,11 +351,11 @@ dmResource::Result SaveMounts(HContext ctx, const char* app_support_path)
             if (save_path)
             {
                 size_t before_len = save_path - uri_str + 1;
-                char before[1024];
+                char before[DMPATH_MAX_PATH];
                 dmStrlCpy(before, uri_str, before_len);
                 before[before_len] = '\0';
 
-                char uricopy[1024];
+                char uricopy[DMPATH_MAX_PATH];
                 const char* rest = save_path + strlen(app_home_path);
                 dmSnPrintf(uricopy, sizeof(uricopy), "%s${HOME_PATH}%s", before, rest);
                 memcpy(uri_str, uricopy, sizeof(uri_str));

--- a/engine/resource/src/test/wscript
+++ b/engine/resource/src/test/wscript
@@ -201,6 +201,7 @@ def build(bld):
     bld.program(features     = 'cxx test',
                 includes     = '.. ../../proto',
                 use          = 'TESTMAIN DDF DLIB PROFILE_NULL SOCKET THREAD LUA resource',
+                web_libs     = ['library_sys.js'],
                 exported_symbols = ['ResourceProviderFile', 'ResourceProviderZip', 'ResourceProviderArchive'],
                 target       = 'test_resource_mounts',
                 source       = 'test_resource_mounts.cpp',


### PR DESCRIPTION
Use a dynamic path for the `HOME` part of the LiveUpdate mount path to prevent iOS from breaking it when the app `UUID` changes after an update. 

Fix https://github.com/defold/defold/issues/9664