### PR TITLE
Added range information to http.request callback

### DIFF
--- a/engine/dlib/src/dlib/configfile.cpp
+++ b/engine/dlib/src/dlib/configfile.cpp
@@ -516,7 +516,9 @@ namespace dmConfigFile
         (void) value;
     }
 
-    static void HttpContent(dmHttpClient::HResponse response, void* user_data, int status_code, const void* content_data, uint32_t content_data_size, int32_t content_length, const char* method)
+    static void HttpContent(dmHttpClient::HResponse response, void* user_data, int status_code, const void* content_data, uint32_t content_data_size, int32_t content_length,
+                            uint32_t range_start, uint32_t range_end, uint32_t document_size,
+                            const char* method)
     {
         (void) method; // unused
         HttpContext* context = (HttpContext*) user_data;

--- a/engine/dlib/src/dlib/http_cache.cpp
+++ b/engine/dlib/src/dlib/http_cache.cpp
@@ -412,7 +412,6 @@ namespace dmHttpCache
         return RESULT_OK;
     }
 
-    //Result Begin(HCache cache, const char* uri, const char* etag, uint32_t max_age, HCacheCreator* cache_creator)
     Result Begin(HCache cache, const char* uri, const char* etag, uint32_t max_age,
                 uint32_t range_start, uint32_t range_end, uint32_t document_size, HCacheCreator* cache_creator)
     {

--- a/engine/dlib/src/dlib/http_cache.cpp
+++ b/engine/dlib/src/dlib/http_cache.cpp
@@ -35,7 +35,7 @@ namespace dmHttpCache
     // Magic file header for index file
     const uint32_t MAGIC = 0xCAAAAAAC;
     // Current index file version
-    const uint32_t VERSION = 7;
+    const uint32_t VERSION = 8;
 
     // Maximum number of cache entry creations in flight
     const uint32_t MAX_CACHE_CREATORS = 16;
@@ -73,18 +73,16 @@ namespace dmHttpCache
     struct FileEntry
     {
         uint64_t m_UriHash;
-        // ETag string
-        char     m_ETag[MAX_TAG_LEN];
-        // Path string
-        char     m_URI[MAX_URI_LEN];
+        char     m_ETag[MAX_TAG_LEN];   // ETag string
+        char     m_URI[MAX_URI_LEN];    // cache key (e.g. url + range)
         // The content hash is the hash of URI and ETag.
         uint64_t m_IdentifierHash;
-        // Last accessed time
-        uint64_t m_LastAccessed;
-        // Expires
+        uint64_t m_LastAccessed;    // Last accessed time
         uint64_t m_Expires;
-        // Checksum
         uint64_t m_Checksum;
+        uint32_t m_RangeStart;      // The bytes range start
+        uint32_t m_RangeEnd;        // The bytes range end (inclusive)
+        uint32_t m_DocumentSize;    // The actual document size
     };
 
     /*
@@ -260,6 +258,9 @@ namespace dmHttpCache
                             e.m_Info.m_LastAccessed = entries[i].m_LastAccessed;
                             e.m_Info.m_Expires = entries[i].m_Expires;
                             e.m_Info.m_Checksum = entries[i].m_Checksum;
+                            e.m_Info.m_RangeStart = entries[i].m_RangeStart;
+                            e.m_Info.m_RangeEnd = entries[i].m_RangeEnd;
+                            e.m_Info.m_DocumentSize = entries[i].m_DocumentSize;
                             c->m_CacheTable.Put(entries[i].m_UriHash, e);
                         }
                         else
@@ -312,6 +313,9 @@ namespace dmHttpCache
         file_entry.m_LastAccessed = entry->m_Info.m_LastAccessed;
         file_entry.m_Expires = entry->m_Info.m_Expires;
         file_entry.m_Checksum = entry->m_Info.m_Checksum;
+        file_entry.m_RangeStart = entry->m_Info.m_RangeStart;
+        file_entry.m_RangeEnd = entry->m_Info.m_RangeEnd;
+        file_entry.m_DocumentSize = entry->m_Info.m_DocumentSize;
 
         dmHashUpdateBuffer64(&context->m_HashState, &file_entry, sizeof(file_entry));
         size_t n_written = fwrite(&file_entry, 1, sizeof(file_entry), context->m_File);
@@ -408,7 +412,9 @@ namespace dmHttpCache
         return RESULT_OK;
     }
 
-    Result Begin(HCache cache, const char* uri, const char* etag, uint32_t max_age, HCacheCreator* cache_creator)
+    //Result Begin(HCache cache, const char* uri, const char* etag, uint32_t max_age, HCacheCreator* cache_creator)
+    Result Begin(HCache cache, const char* uri, const char* etag, uint32_t max_age,
+                uint32_t range_start, uint32_t range_end, uint32_t document_size, HCacheCreator* cache_creator)
     {
         dmMutex::ScopedLock lock(cache->m_Mutex);
         *cache_creator = 0;
@@ -465,6 +471,9 @@ namespace dmHttpCache
         entry->m_Info.m_URI = dmPoolAllocator::Duplicate(cache->m_StringAllocator, uri);
         entry->m_Info.m_IdentifierHash = identifier_hash;
         entry->m_Info.m_LastAccessed = dmTime::GetTime();
+        entry->m_Info.m_RangeStart = range_start;
+        entry->m_Info.m_RangeEnd = range_end;
+        entry->m_Info.m_DocumentSize = document_size;
         if (max_age > 0) {
             entry->m_Info.m_Expires = dmTime::GetTime() + max_age * 1000000U;
         } else {
@@ -666,7 +675,8 @@ namespace dmHttpCache
         }
     }
 
-    Result Get(HCache cache, const char* uri, const char* etag, FILE** file, uint32_t* file_size, uint64_t* checksum)
+    Result Get(HCache cache, const char* uri, const char* etag, FILE** file, uint32_t* file_size, uint64_t* checksum,
+                uint32_t* range_start, uint32_t* range_end, uint32_t* document_size)
     {
         dmMutex::ScopedLock lock(cache->m_Mutex);
 
@@ -703,6 +713,11 @@ namespace dmHttpCache
                 *file = f;
                 entry->m_ReadLockCount++;
                 *checksum = entry->m_Info.m_Checksum;
+
+                *range_start = entry->m_Info.m_RangeStart;
+                *range_end = entry->m_Info.m_RangeEnd;
+                *document_size = entry->m_Info.m_DocumentSize;
+
                 return RESULT_OK;
             }
             else

--- a/engine/dlib/src/dlib/http_cache.h
+++ b/engine/dlib/src/dlib/http_cache.h
@@ -75,6 +75,10 @@ namespace dmHttpCache
         uint64_t m_Expires;
         /// Checksum
         uint64_t m_Checksum;
+        uint32_t m_RangeStart;
+        uint32_t m_RangeEnd;
+        uint32_t m_DocumentSize;
+
         /// True if the entry is verified, ie the cached version is valid, during the session
         uint8_t  m_Verified : 1;
         /// Valid in terms of Cache-Control expires
@@ -130,10 +134,13 @@ namespace dmHttpCache
      * @param uri uri
      * @param etag etag
      * @param max_age max-age from http-header "Cache-Control"
+     * @param range_start   The partial request start byte
+     * @param range_end     The partial request end byte (inclusive)
+     * @param document_size The full document size (!= from content length)
      * @param cache_creator cache creator handle (out)
      * @return RESULT_OK on success
      */
-    Result Begin(HCache cache, const char* uri, const char* etag, uint32_t max_age, HCacheCreator* cache_creator);
+    Result Begin(HCache cache, const char* uri, const char* etag, uint32_t max_age, uint32_t range_start, uint32_t range_end, uint32_t document_size, HCacheCreator* cache_creator);
 
     /**
      * Add data to cache entry
@@ -174,14 +181,19 @@ namespace dmHttpCache
 
     /**
      * Get file for cache entry
-     * @param cache cache
-     * @param uri uri
-     * @param etag etag
-     * @param file file representing the cached content
-     * @param checksum content checksum (dmHashString64)
+     * @param cache         cache
+     * @param uri           uri
+     * @param etag          etag
+     * @param file          file representing the cached content
+     * @param file_size     size of the cached content
+     * @param checksum      content checksum (dmHashString64)
+     * @param range_start   start offset into original file
+     * @param range_end     end offset into original file (inclusive)
+     * @param document_size size of the original file
      * @return RESULT_OK on success.
      */
-    Result Get(HCache cache, const char* uri, const char* etag, FILE** file, uint32_t* file_size, uint64_t* checksum);
+    Result Get(HCache cache, const char* uri, const char* etag, FILE** file, uint32_t* file_size, uint64_t* checksum,
+                    uint32_t* range_start, uint32_t* range_end, uint32_t* document_size);
 
     /**
      * Set cache entry to verifed

--- a/engine/dlib/src/dlib/http_cache_verify.cpp
+++ b/engine/dlib/src/dlib/http_cache_verify.cpp
@@ -119,7 +119,9 @@ namespace dmHttpCacheVerify
         return verify_context->m_Result;
     }
 
-    static void HttpContent(dmHttpClient::HResponse, void* user_data, int status_code, const void* content_data, uint32_t content_data_size, int32_t content_length, const char* method)
+    static void HttpContent(dmHttpClient::HResponse, void* user_data, int status_code, const void* content_data, uint32_t content_data_size, int32_t content_length,
+                            uint32_t range_start, uint32_t range_end, uint32_t document_size,
+                            const char* method)
     {
         (void) method; // Unused
 

--- a/engine/dlib/src/dlib/http_client.cpp
+++ b/engine/dlib/src/dlib/http_client.cpp
@@ -112,10 +112,10 @@ namespace dmHttpClient
         int m_TotalReceived;
 
         // Headers
-        int      m_ContentLength;
+        int      m_ContentLength;       // Size of the payload sent over the http
         int      m_RangeStart;
         int      m_RangeEnd;
-        int      m_DocumentSize;
+        int      m_DocumentSize;        // The actual size of the file itself (!= content length)
         char     m_ETag[dmHttpCache::MAX_TAG_LEN];
         uint32_t m_Chunked : 1;
         uint32_t m_CloseConnection : 1;
@@ -139,6 +139,7 @@ namespace dmHttpClient
             m_ContentLength = -1;
             m_RangeStart = -1;
             m_RangeEnd = -1;
+            m_DocumentSize = -1;
             m_ETag[0] = '\0';
             m_ContentOffset = -1;
             m_TotalReceived = 0;
@@ -227,7 +228,9 @@ namespace dmHttpClient
     }
 
     static void DefaultHttpContentData(HResponse response, void* user_data, int status_code,
-        const void* content_data, uint32_t content_data_size, int32_t content_length, const char* method)
+        const void* content_data, uint32_t content_data_size, int32_t content_length,
+        uint32_t range_start, uint32_t range_end, uint32_t document_size,
+        const char* method)
     {
         (void) response;
         (void) user_data;
@@ -670,7 +673,9 @@ bail:
             } else {
                 n = dmMath::Min(to_transfer - total_transferred, response->m_TotalReceived - response->m_ContentOffset);
             }
-            http_content(response, client->m_Userdata, response->m_Status, client->m_Buffer + response->m_ContentOffset, n, response->m_ContentLength, method);
+            http_content(response, client->m_Userdata, response->m_Status, client->m_Buffer + response->m_ContentOffset, n, response->m_ContentLength,
+                        response->m_RangeStart, response->m_RangeEnd, response->m_DocumentSize,
+                        method);
 
             if (response->m_CacheCreator && add_to_cache)
             {
@@ -743,7 +748,8 @@ bail:
         }
     }
 
-    static void HttpContentConsume(HResponse response, void* user_data, int status_code, const void* content_data, uint32_t content_data_size, int32_t content_length, const char* method)
+    static void HttpContentConsume(HResponse response, void* user_data, int status_code, const void* content_data, uint32_t content_data_size, int32_t content_length,
+                                    uint32_t range_start, uint32_t range_end, uint32_t document_size, const char* method)
     {
         (void) response;
         (void) user_data;
@@ -751,6 +757,9 @@ bail:
         (void) content_data;
         (void) content_data_size;
         (void) content_length;
+        (void) range_start;
+        (void) range_end;
+        (void) document_size;
         (void) method;
     }
 
@@ -798,14 +807,20 @@ bail:
         FILE* file = 0;
         uint32_t file_size = 0;
         uint64_t checksum;
-        cache_result = dmHttpCache::Get(client->m_HttpCache, client->m_CacheKey, cache_etag, &file, &file_size, &checksum);
+        uint32_t range_start;
+        uint32_t range_end;
+        uint32_t document_size;
+        cache_result = dmHttpCache::Get(client->m_HttpCache, client->m_CacheKey, cache_etag, &file, &file_size, &checksum,
+                                        &range_start, &range_end, &document_size);
         if (cache_result == dmHttpCache::RESULT_OK)
         {
             // If the request is a "HEAD" request, and the URI is cached (i.e the file exists),
             // then we should return the meta-data about the file (including triggering the progress callback).
             if (method_is_head)
             {
-                client->m_HttpContent(response, client->m_Userdata, response->m_Status, 0, 0, file_size, "HEAD");
+                client->m_HttpContent(response, client->m_Userdata, response->m_Status, 0, 0, file_size,
+                                        range_start, range_end, document_size,
+                                        "HEAD");
             }
             else
             {
@@ -815,7 +830,9 @@ bail:
                 {
                     nread = fread(client->m_Buffer, 1, BUFFER_SIZE, file);
                     client->m_Buffer[nread] = '\0';
-                    client->m_HttpContent(response, client->m_Userdata, response->m_Status, client->m_Buffer, nread, file_size, 0);
+                    client->m_HttpContent(response, client->m_Userdata, response->m_Status, client->m_Buffer, nread, file_size,
+                                        range_start, range_end, document_size,
+                                        0);
                 }
                 while (nread > 0);
             }
@@ -835,7 +852,7 @@ bail:
     {
         Result r = RESULT_OK;
 
-        client->m_HttpContent(response, client->m_Userdata, response->m_Status, 0, 0, 0, 0);
+        client->m_HttpContent(response, client->m_Userdata, response->m_Status, 0, 0, 0, 0, 0, 0, 0);
 
         if (strcmp(method, "HEAD") == 0) {
             // A response from a HEAD request should not attempt to read any body despite
@@ -990,7 +1007,12 @@ bail:
             bool is_ok = response.m_Status == 200 || response.m_Status == 206;
             if (!client->m_IgnoreCache && client->m_HttpCache && !method_is_head && is_ok)
             {
-                dmHttpCache::Begin(client->m_HttpCache, client->m_CacheKey, response.m_ETag, response.m_MaxAge, &response.m_CacheCreator);
+                uint32_t document_size = dmMath::Max(response.m_ContentLength, response.m_DocumentSize);
+                uint32_t range_start = response.m_RangeStart != -1 ? response.m_RangeStart : 0;
+                uint32_t range_end = response.m_RangeEnd != -1 ? response.m_RangeEnd : document_size-1;
+
+                dmHttpCache::Begin(client->m_HttpCache, client->m_CacheKey, response.m_ETag, response.m_MaxAge,
+                                    range_start, range_end, document_size, &response.m_CacheCreator);
             }
 
             r = HandleResponse(client, path, method, &response);
@@ -1091,8 +1113,12 @@ bail:
         FILE* file = 0;
         uint32_t file_size = 0;
         uint64_t checksum;
+        uint32_t range_start;
+        uint32_t range_end;
+        uint32_t document_size;
 
-        dmHttpCache::Result cache_result = dmHttpCache::Get(client->m_HttpCache, client->m_CacheKey, info->m_ETag, &file, &file_size, &checksum);
+        dmHttpCache::Result cache_result = dmHttpCache::Get(client->m_HttpCache, client->m_CacheKey, info->m_ETag, &file, &file_size, &checksum,
+                                                            &range_start, &range_end, &document_size);
         if (cache_result == dmHttpCache::RESULT_OK)
         {
             // NOTE: We have an extra byte for null-termination so no buffer overrun here.
@@ -1101,7 +1127,9 @@ bail:
             {
                 nread = fread(client->m_Buffer, 1, BUFFER_SIZE, file);
                 client->m_Buffer[nread] = '\0';
-                client->m_HttpContent(&response, client->m_Userdata, 304, client->m_Buffer, nread, file_size, "GET");
+                client->m_HttpContent(&response, client->m_Userdata, 304, client->m_Buffer, nread, file_size,
+                                      range_start, range_end, document_size,
+                                      "GET");
             }
             while (nread > 0);
             dmHttpCache::Release(client->m_HttpCache, client->m_CacheKey, info->m_ETag, file);

--- a/engine/dlib/src/dlib/http_client.cpp
+++ b/engine/dlib/src/dlib/http_client.cpp
@@ -1003,6 +1003,14 @@ bail:
         }
         else
         {
+            // Let's make the range values valid, even if it might not be a ranged request
+            if (response.m_DocumentSize == 0xFFFFFFFF)
+            {
+                response.m_DocumentSize = response.m_ContentLength;
+                response.m_RangeStart = 0;
+                response.m_RangeEnd = response.m_DocumentSize-1;
+            }
+
             // Non-cached response
             bool is_ok = response.m_Status == 200 || response.m_Status == 206;
             if (!client->m_IgnoreCache && client->m_HttpCache && !method_is_head && is_ok)

--- a/engine/dlib/src/dlib/http_client.h
+++ b/engine/dlib/src/dlib/http_client.h
@@ -67,9 +67,16 @@ namespace dmHttpClient
      * @param status_code Status code, eg 200
      * @param content_data Content data
      * @param content_data_size Content data size
+     * @param content_length The content length to receive (possibly in multiple callbacks)
+     * @param range_start The start byte offset into the original file
+     * @param range_end The end byte offset into the original file (inclusive)
+     * @param document_size The full size of the document
      * @param method The method of the request.
      */
-    typedef void (*HttpContent)(HResponse response, void* user_data, int status_code, const void* content_data, uint32_t content_data_size, int32_t content_size, const char* method);
+    typedef void (*HttpContent)(HResponse response, void* user_data, int status_code,
+                                const void* content_data, uint32_t content_data_size, int32_t content_length,
+                                uint32_t range_start, uint32_t range_end, uint32_t document_size,
+                                const char* method);
 
     /**
      * HTTP content-length callback. Invoked for POST-request prior to HttpWrite-callback to determine content-length

--- a/engine/dlib/src/test/test_httpserver.cpp
+++ b/engine/dlib/src/test/test_httpserver.cpp
@@ -131,7 +131,9 @@ public:
         }
     }
 
-    static void ClientHttpContent(dmHttpClient::HResponse response, void* user_data, int status_code, const void* content_data, uint32_t content_data_size, int32_t content_length, const char* method)
+    static void ClientHttpContent(dmHttpClient::HResponse response, void* user_data, int status_code, const void* content_data, uint32_t content_data_size, int32_t content_length,
+                                    uint32_t range_start, uint32_t range_end, uint32_t document_size,
+                                    const char* method)
     {
         dmHttpServerTest* self = (dmHttpServerTest*) user_data;
         self->m_ClientData.append((const char*) content_data, content_data_size);

--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -1095,14 +1095,11 @@ namespace dmEngine
         dmResource::NewFactoryParams params;
         params.m_MaxResources = max_resources;
         params.m_Flags = 0;
+        params.m_HttpCache = engine->m_HttpCache;
 
         if (dLib::IsDebugMode())
         {
             params.m_Flags = RESOURCE_FACTORY_FLAGS_RELOAD_SUPPORT;
-
-            int32_t http_cache = dmConfigFile::GetInt(engine->m_Config, "resource.http_cache", 1);
-            if (http_cache)
-                params.m_Flags |= RESOURCE_FACTORY_FLAGS_HTTP_CACHE;
         }
 
         int32_t liveupdate_enable = dmConfigFile::GetInt(engine->m_Config, "liveupdate.enabled", 1);

--- a/engine/gamesys/src/gamesys/scripts/script_http.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_http.cpp
@@ -87,11 +87,14 @@ namespace dmGameSystem
      *
      * - [type:number] `status`: the status of the response
      * - [type:string] `response`: the response data (if not saved on disc)
-     * - [type:table] `headers`: all the returned headers
+     * - [type:table] `headers`: all the returned headers (if status is 200 or 206)
      * - [type:string] `path`: the stored path (if saved to disc)
      * - [type:string] `error`: if any unforeseen errors occurred (e.g. file I/O)
      * - [type:number] `bytes_received`: the amount of bytes received/sent for a request, only if option `report_progress` is true
      * - [type:number] `bytes_total`: the total amount of bytes for a request, only if option `report_progress` is true
+     * - [type:number] `range_start`: the start offset into the requested file
+     * - [type:number] `range_end`: the end offset into the requested file (inclusive)
+     * - [type:number] `document_size`: the full size of the requested file
      *
      * @param [headers] [type:table] optional table with custom headers
      * @param [post_data] [type:string] optional data to send

--- a/engine/gamesys/src/gamesys/scripts/script_http_util.h
+++ b/engine/gamesys/src/gamesys/scripts/script_http_util.h
@@ -84,6 +84,13 @@ namespace dmGameSystem
             lua_setfield(L, -2, "url");
         }
 
+        lua_pushinteger(L, resp->m_RangeStart);
+        lua_setfield(L, -2, "range_start");
+        lua_pushinteger(L, resp->m_RangeEnd);
+        lua_setfield(L, -2, "range_end");
+        lua_pushinteger(L, resp->m_DocumentSize);
+        lua_setfield(L, -2, "document_size");
+
         lua_pushliteral(L, "headers");
         lua_newtable(L);
         if (resp->m_HeadersLength > 0) {

--- a/engine/resource/src/providers/provider.h
+++ b/engine/resource/src/providers/provider.h
@@ -17,7 +17,10 @@
 
 #include <stdint.h>
 #include <dlib/hash.h>
+#include <dlib/http_cache.h>
 #include <dlib/uri.h>
+
+#include <resource/resource.h>
 
 namespace dmResource
 {
@@ -77,13 +80,28 @@ namespace dmResourceProvider
 
 
     // Plugin API
+    struct ArchiveLoaderParams
+    {
+        dmResource::HFactory    m_Factory;
+        dmHttpCache::HCache     m_HttpCache;
+    };
+
+    typedef void (*FRegisterLoader)(ArchiveLoader*);
+    typedef Result (*FInitializeLoader)(ArchiveLoaderParams*, ArchiveLoader*);
+    typedef Result (*FFinalizeLoader)(ArchiveLoaderParams*, ArchiveLoader*);
 
     // Internal
-    void Register(ArchiveLoader* loader, uint32_t size, const char* name, void (*setup_fn)(ArchiveLoader*));
+    void Register(ArchiveLoader* loader, uint32_t size, const char* name,
+                    FRegisterLoader register_fn,
+                    FInitializeLoader initialize_fn,
+                    FFinalizeLoader finalize_fn);
+
+    Result InitializeLoaders(ArchiveLoaderParams*);
+    Result FinalizeLoaders(ArchiveLoaderParams*);
 
     // Extension declaration helper. Internal
-    #define DM_REGISTER_ARCHIVE_LOADER(symbol, desc, desc_size, name, setup_fn) extern "C" void symbol () { \
-        dmResourceProvider::Register((struct dmResourceProvider::ArchiveLoader*) &desc, desc_size, name, setup_fn); \
+    #define DM_REGISTER_ARCHIVE_LOADER(symbol, desc, desc_size, name, register_fn, initialize_fn, finalize_fn) extern "C" void symbol () { \
+        dmResourceProvider::Register((struct dmResourceProvider::ArchiveLoader*) &desc, desc_size, name, register_fn, initialize_fn, finalize_fn); \
     }
 
     // Archive loader desc bytesize declaration
@@ -92,9 +110,9 @@ namespace dmResourceProvider
     #define DM_RESOURCE_PROVIDER_PASTE_SYMREG2(x, y) DM_RESOURCE_PROVIDER_PASTE_SYMREG(x, y)
 
     // public
-    #define DM_DECLARE_ARCHIVE_LOADER(symbol, name, setup_fn) \
+    #define DM_DECLARE_ARCHIVE_LOADER(symbol, name, register_fn, initialize_fn, finalize_fn) \
         uint8_t DM_ALIGNED(16) DM_RESOURCE_PROVIDER_PASTE_SYMREG2(symbol, __LINE__)[dmResourceProvider::g_ExtensionDescBufferSize]; \
-        DM_REGISTER_ARCHIVE_LOADER(symbol, DM_RESOURCE_PROVIDER_PASTE_SYMREG2(symbol, __LINE__), sizeof(DM_RESOURCE_PROVIDER_PASTE_SYMREG2(symbol, __LINE__)), name, setup_fn);
+        DM_REGISTER_ARCHIVE_LOADER(symbol, DM_RESOURCE_PROVIDER_PASTE_SYMREG2(symbol, __LINE__), sizeof(DM_RESOURCE_PROVIDER_PASTE_SYMREG2(symbol, __LINE__)), name, register_fn, initialize_fn, finalize_fn);
 }
 
 #endif // DM_RESOURCE_PROVIDER_H

--- a/engine/resource/src/providers/provider.h
+++ b/engine/resource/src/providers/provider.h
@@ -20,7 +20,7 @@
 #include <dlib/http_cache.h>
 #include <dlib/uri.h>
 
-#include <resource/resource.h>
+#include "../resource.h"
 
 namespace dmResource
 {

--- a/engine/resource/src/providers/provider_archive.cpp
+++ b/engine/resource/src/providers/provider_archive.cpp
@@ -269,5 +269,5 @@ namespace dmResourceProviderArchive
         loader->m_ReadFilePartial   = ReadFilePartial;
     }
 
-    DM_DECLARE_ARCHIVE_LOADER(ResourceProviderArchive, "archive", SetupArchiveLoader);
+    DM_DECLARE_ARCHIVE_LOADER(ResourceProviderArchive, "archive", SetupArchiveLoader, 0, 0);
 }

--- a/engine/resource/src/providers/provider_archive_mutable.cpp
+++ b/engine/resource/src/providers/provider_archive_mutable.cpp
@@ -586,6 +586,6 @@ namespace dmResourceProviderArchiveMutable
         loader->m_WriteFile         = WriteFile;
     }
 
-    DM_DECLARE_ARCHIVE_LOADER(ResourceProviderArchiveMutable, "mutable", SetupArchiveLoader);
+    DM_DECLARE_ARCHIVE_LOADER(ResourceProviderArchiveMutable, "mutable", SetupArchiveLoader, 0, 0);
 }
 

--- a/engine/resource/src/providers/provider_file.cpp
+++ b/engine/resource/src/providers/provider_file.cpp
@@ -137,5 +137,5 @@ namespace dmResourceProviderFile
         loader->m_ReadFilePartial   = ReadFilePartial;
     }
 
-    DM_DECLARE_ARCHIVE_LOADER(ResourceProviderFile, "file", SetupArchiveLoader);
+    DM_DECLARE_ARCHIVE_LOADER(ResourceProviderFile, "file", SetupArchiveLoader, 0, 0);
 }

--- a/engine/resource/src/providers/provider_http.cpp
+++ b/engine/resource/src/providers/provider_http.cpp
@@ -326,5 +326,5 @@ static void SetupArchiveLoaderHttp(dmResourceProvider::ArchiveLoader* loader)
     loader->m_ReadFilePartial   = ReadFilePartial;
 }
 
-DM_DECLARE_ARCHIVE_LOADER(ResourceProviderHttp, "http", SetupArchiveLoaderHttp);
+DM_DECLARE_ARCHIVE_LOADER(ResourceProviderHttp, "http", SetupArchiveLoaderHttp, 0, 0);
 }

--- a/engine/resource/src/providers/provider_http.cpp
+++ b/engine/resource/src/providers/provider_http.cpp
@@ -214,6 +214,8 @@ static dmResourceProvider::Result GetRequestFromUri(HttpProviderContext* archive
         archive->m_ChunkedRequest   = 1;
     }
 
+    bool get_file_size = strcmp(method, "HEAD") == 0;
+
     // // Always verify cache for reloaded resources
     // if (factory->m_HttpCache)
     //     dmHttpCache::SetConsistencyPolicy(factory->m_HttpCache, dmHttpCache::CONSISTENCY_POLICY_VERIFY);
@@ -225,7 +227,7 @@ static dmResourceProvider::Result GetRequestFromUri(HttpProviderContext* archive
     dmHttpClient::GetURI(archive->m_HttpClient, path, cache_key, sizeof(cache_key));
 
     // Make the cache key the same (see http_service.cpp)
-    if (INVALID_CHUNK_VALUE != offset && INVALID_CHUNK_VALUE != size)
+    if (!get_file_size && INVALID_CHUNK_VALUE != offset && INVALID_CHUNK_VALUE != size)
     {
         char range[256];
         dmSnPrintf(range, sizeof(range), "=bytes=%u-%u", offset, offset+size-1);
@@ -264,8 +266,6 @@ static dmResourceProvider::Result GetRequestFromUri(HttpProviderContext* archive
     }
 
     printf("HTTP RESULT: %d - %s - %s\n", archive->m_HttpStatus, method, cache_key);
-
-    bool get_file_size = strcmp(method, "HEAD") == 0;
 
     if (get_file_size)
     {

--- a/engine/resource/src/providers/provider_http.cpp
+++ b/engine/resource/src/providers/provider_http.cpp
@@ -267,8 +267,6 @@ static dmResourceProvider::Result GetRequestFromUri(HttpProviderContext* archive
         }
     }
 
-    printf("HTTP RESULT: %d - %s - %s\n", archive->m_HttpStatus, method, cache_key);
-
     if (get_file_size)
     {
         *buffer_length = archive->m_HttpContentLength;
@@ -325,7 +323,6 @@ static dmResourceProvider::Result ReadFilePartial(dmResourceProvider::HArchiveIn
 {
     HttpProviderContext* archive = (HttpProviderContext*)_archive;
     (void)path_hash;
-printf("%s: %s: %s - %u - %u\n", __FILE__, __FUNCTION__, path, offset, size);
     dmResourceProvider::Result result = GetRequestFromUri((HttpProviderContext*)archive, "GET", path, offset, size, nread, buffer);
     if (result != dmResourceProvider::RESULT_OK)
     {
@@ -337,8 +334,6 @@ printf("%s: %s: %s - %u - %u\n", __FILE__, __FUNCTION__, path, offset, size);
 static dmResourceProvider::Result InitializeArchiveLoaderHttp(dmResourceProvider::ArchiveLoaderParams* params, dmResourceProvider::ArchiveLoader* loader)
 {
     g_HttpCache = params->m_HttpCache;
-printf("%s: %s: HTTP CACHE: %p\n", __FILE__, __FUNCTION__, g_HttpCache);
-
     return dmResourceProvider::RESULT_OK;
 }
 

--- a/engine/resource/src/providers/provider_http.cpp
+++ b/engine/resource/src/providers/provider_http.cpp
@@ -90,7 +90,9 @@ static void HttpHeader(dmHttpClient::HResponse response, void* user_data, int st
     }
 }
 
-static void HttpContent(dmHttpClient::HResponse, void* user_data, int status_code, const void* content_data, uint32_t content_data_size, int32_t content_length, const char* method)
+static void HttpContent(dmHttpClient::HResponse, void* user_data, int status_code, const void* content_data, uint32_t content_data_size, int32_t content_length,
+                        uint32_t range_start, uint32_t range_end, uint32_t document_size,
+                        const char* method)
 {
     HttpProviderContext* archive = (HttpProviderContext*)user_data;
     (void) status_code;

--- a/engine/resource/src/providers/provider_private.h
+++ b/engine/resource/src/providers/provider_private.h
@@ -30,6 +30,9 @@ namespace dmResourceProvider
     struct ArchiveLoader
     {
         dmhash_t                m_NameHash;         // E.g. "http", "archive", "mutable", "file", "zip"
+        FInitializeLoader       m_Initialize;
+        FFinalizeLoader         m_Finalize;
+
         FCanMount               m_CanMount;
         FMount                  m_Mount;
         FUnmount                m_Unmount;

--- a/engine/resource/src/providers/provider_zip.cpp
+++ b/engine/resource/src/providers/provider_zip.cpp
@@ -362,5 +362,5 @@ static void SetupArchiveLoaderHttpZip(dmResourceProvider::ArchiveLoader* loader)
     loader->m_ReadFilePartial   = ReadFilePartial;
 }
 
-DM_DECLARE_ARCHIVE_LOADER(ResourceProviderZip, "zip", SetupArchiveLoaderHttpZip);
+DM_DECLARE_ARCHIVE_LOADER(ResourceProviderZip, "zip", SetupArchiveLoaderHttpZip, 0, 0);
 }

--- a/engine/resource/src/resource.h
+++ b/engine/resource/src/resource.h
@@ -19,6 +19,7 @@
 #include <dlib/array.h>
 #include <dlib/hash.h>
 #include <dlib/hashtable.h>
+#include <dlib/http_cache.h>
 #include <dlib/mutex.h>
 
 struct ResourceDescriptor;
@@ -68,11 +69,6 @@ namespace dmResource
      * Enable resource reloading support. Both over files and http.
      */
     #define RESOURCE_FACTORY_FLAGS_RELOAD_SUPPORT (1 << 0)
-
-    /**
-     * Enable HTTP cache
-     */
-    #define RESOURCE_FACTORY_FLAGS_HTTP_CACHE     (1 << 2)
 
     /**
      * Enable Live update
@@ -138,6 +134,8 @@ namespace dmResource
         EmbeddedResource m_ArchiveIndex;
         EmbeddedResource m_ArchiveData;
         EmbeddedResource m_ArchiveManifest;
+
+        dmHttpCache::HCache m_HttpCache;
 
         uint32_t m_Reserved[5];
 

--- a/engine/script/src/http_service.cpp
+++ b/engine/script/src/http_service.cpp
@@ -55,6 +55,9 @@ namespace dmHttpService
         dmHttpDDF::HttpRequest*   m_Request;
         const char*           m_Filepath;
         int                   m_Status;
+        uint32_t              m_RangeStart;
+        uint32_t              m_RangeEnd;
+        uint32_t              m_DocumentSize;
         uintptr_t             m_ResponseUserData1;
         uintptr_t             m_ResponseUserData2;
         dmArray<char>         m_Response;
@@ -102,10 +105,16 @@ namespace dmHttpService
     }
 
     // Called from the http thread(s)
-    void HttpContent(dmHttpClient::HResponse response, void* user_data, int status_code, const void* content_data, uint32_t content_data_size, int32_t content_length, const char* method)
+    void HttpContent(dmHttpClient::HResponse response, void* user_data, int status_code,
+                    const void* content_data, uint32_t content_data_size, int32_t content_length,
+                    uint32_t range_start, uint32_t range_end, uint32_t document_size,
+                    const char* method)
     {
         Worker* worker = (Worker*) user_data;
         worker->m_Status = status_code;
+        worker->m_RangeStart = range_start;
+        worker->m_RangeEnd = range_end;
+        worker->m_DocumentSize = document_size;
         dmArray<char>& r = worker->m_Response;
         bool method_is_head = method && strcmp(method, "HEAD") == 0;
 
@@ -209,12 +218,18 @@ namespace dmHttpService
                              const char* headers, uint32_t headers_length,
                              const char* response, uint32_t response_length,
                              const char* url,
-                             const char* filepath)
+                             const char* filepath,
+                             uint32_t range_start,
+                             uint32_t range_end,
+                             uint32_t document_size)
     {
         dmHttpDDF::HttpResponse resp;
         resp.m_Status = status;
         resp.m_HeadersLength = headers_length;
         resp.m_ResponseLength = response_length;
+        resp.m_RangeStart = range_start;
+        resp.m_RangeEnd = range_end;
+        resp.m_DocumentSize = document_size;
 
         resp.m_Headers = (uint64_t) malloc(headers_length);
         memcpy((void*) resp.m_Headers, headers, headers_length);
@@ -262,7 +277,7 @@ namespace dmHttpService
         dmURI::Result ur =  dmURI::Parse(request->m_Url, &url);
         if (ur != dmURI::RESULT_OK)
         {
-            SendResponse(requester, 0, 0, 0, 0, 0, 0, 0, worker->m_Request->m_Url, 0);
+            SendResponse(requester, 0, 0, 0, 0, 0, 0, 0, worker->m_Request->m_Url, 0, 0, 0, 0);
             return;
         }
         if (url.m_Path[0] == '\0') {
@@ -298,6 +313,9 @@ namespace dmHttpService
         worker->m_Headers.SetSize(0);
         worker->m_Headers.SetCapacity(DEFAULT_HEADER_BUFFER_SIZE);
         worker->m_Filepath = request->m_Path;
+        worker->m_RangeStart = 0;
+        worker->m_RangeEnd = 0;
+        worker->m_DocumentSize = 0;
 
         if (request->m_ReportProgress)
         {
@@ -332,15 +350,18 @@ namespace dmHttpService
             dmHttpClient::Result r = dmHttpClient::Request(worker->m_Client, request->m_Method, url.m_Path);
 
             if (r == dmHttpClient::RESULT_OK || r == dmHttpClient::RESULT_NOT_200_OK) {
-                SendResponse(requester, userdata1, userdata2, worker->m_Status, worker->m_Headers.Begin(), worker->m_Headers.Size(), worker->m_Response.Begin(), worker->m_Response.Size(), request->m_Url, worker->m_Filepath);
+                SendResponse(requester, userdata1, userdata2, worker->m_Status, worker->m_Headers.Begin(), worker->m_Headers.Size(), worker->m_Response.Begin(), worker->m_Response.Size(), request->m_Url, worker->m_Filepath,
+                                    worker->m_RangeStart, worker->m_RangeEnd, worker->m_DocumentSize);
             } else {
                 // TODO: Error codes to lua?
                 dmLogError("HTTP request to '%s' failed (http result: %d  socket result: %d)", request->m_Url, r, GetLastSocketResult(worker->m_Client));
-                SendResponse(requester, userdata1, userdata2, 0, worker->m_Headers.Begin(), worker->m_Headers.Size(), worker->m_Response.Begin(), worker->m_Response.Size(), request->m_Url, worker->m_Filepath);
+                SendResponse(requester, userdata1, userdata2, 0, worker->m_Headers.Begin(), worker->m_Headers.Size(), worker->m_Response.Begin(), worker->m_Response.Size(), request->m_Url, worker->m_Filepath,
+                                worker->m_RangeStart, worker->m_RangeEnd, worker->m_DocumentSize);
             }
         } else {
             // TODO: Error codes to lua?
-            SendResponse(requester, userdata1, userdata2, 0, worker->m_Headers.Begin(), worker->m_Headers.Size(), worker->m_Response.Begin(), worker->m_Response.Size(), request->m_Url, worker->m_Filepath);
+            SendResponse(requester, userdata1, userdata2, 0, worker->m_Headers.Begin(), worker->m_Headers.Size(), worker->m_Response.Begin(), worker->m_Response.Size(), request->m_Url, worker->m_Filepath,
+                            worker->m_RangeStart, worker->m_RangeEnd, worker->m_DocumentSize);
             dmLogError("Unable to create HTTP connection to '%s'. No route to host?", request->m_Url);
         }
     }

--- a/engine/script/src/http_service.cpp
+++ b/engine/script/src/http_service.cpp
@@ -245,7 +245,7 @@ namespace dmHttpService
                 if (length < buffer_length)
                 {
                     memcpy(buffer, current, length);
-                    buffer[length-1] = 0;
+                    buffer[length] = 0;
                     return buffer;
                 }
             }
@@ -320,7 +320,7 @@ namespace dmHttpService
             const char* range_header = FindHeader(worker, "Range:", header_buffer, sizeof(header_buffer));
             if (range_header)
             {
-                // If we find a range header, let's use it to append to the
+                // If we find a range header, let's use it to append to the cache key
                 range_header += strlen("Range:");
                 while(*range_header == ' ')
                     ++range_header;

--- a/engine/script/src/script/http_ddf.proto
+++ b/engine/script/src/script/http_ddf.proto
@@ -68,4 +68,8 @@ message HttpResponse
 
     required string path            = 6; // Path on disc where the response is written to
     required string url             = 7;
+
+    optional uint32 range_start     = 8;
+    optional uint32 range_end       = 9;
+    optional uint32 document_size   = 10;
 }

--- a/engine/sound/src/sound.cpp
+++ b/engine/sound/src/sound.cpp
@@ -866,6 +866,8 @@ namespace dmSound
             sum_sq_left += g->m_SumSquaredMemory[2 * ss_index + 0];
             sum_sq_right += g->m_SumSquaredMemory[2 * ss_index + 1];
             uint16_t frame_count = g->m_FrameCounts[ss_index];
+            if (frame_count == 0)
+                break;
 
             left -= frame_count;
             total_frame_count += frame_count;
@@ -905,6 +907,8 @@ namespace dmSound
             max_peak_left_sq = dmMath::Max(max_peak_left_sq, g->m_PeakMemorySq[2 * ss_index + 0]);
             max_peak_right_sq = dmMath::Max(max_peak_right_sq, g->m_PeakMemorySq[2 * ss_index + 1]);
             uint16_t frame_count = g->m_FrameCounts[ss_index];
+            if (frame_count == 0)
+                break;
 
             left -= frame_count;
             ss_index = (ss_index - 1) % GROUP_MEMORY_BUFFER_COUNT;


### PR DESCRIPTION
We added the following variables for a http request callback:
* `range_start` -  Start byte offset into the file
* `range_end` -  End byte offset into the file (invlusive)
* `document_size` -  The full size of the document (in bytes)

These are always available unless it's a progress type callback.

```lua
local function http_result(self, _id, response)
	if response.status == 200 or response.status == 206 or response.status == 304 then
		print("start", response.range_start)
                print("end", response.range_end)
                print("file size", response.document_size)
		...
```


Fixes https://github.com/defold/defold/issues/10010

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
