### PR TITLE
Upgraded Ubuntu to 22.04 in all GitHub runners

### DIFF
--- a/.github/workflows/build-luajit.yml
+++ b/.github/workflows/build-luajit.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         arch: [x86_64-linux]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout repo
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         arch: [arm64-linux]
-    runs-on: ubuntu-20.04-arm
+    runs-on: ubuntu-24.04-arm
     steps:
       
     - name: Add ARM64 architecture and install dependencies
@@ -140,7 +140,7 @@ jobs:
     strategy:
       matrix:
         platform: [armv7-android, arm64-android]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout repo
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683

--- a/.github/workflows/build-luajit.yml
+++ b/.github/workflows/build-luajit.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         arch: [x86_64-linux]
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout repo
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         arch: [arm64-linux]
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-22.04-arm
     steps:
       
     - name: Add ARM64 architecture and install dependencies
@@ -140,7 +140,7 @@ jobs:
     strategy:
       matrix:
         platform: [armv7-android, arm64-android]
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout repo
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683

--- a/.github/workflows/editor-only.yml
+++ b/.github/workflows/editor-only.yml
@@ -24,7 +24,7 @@ env:
 
 jobs:
   build-editor:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps: [
       {
         name: 'Checkout',
@@ -76,7 +76,7 @@ jobs:
 
   sign-editor-windows:
     needs: [build-editor]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         platform: [x86_64-win32]
@@ -114,7 +114,7 @@ jobs:
 
   release:
     needs: [sign-editor-macos, sign-editor-windows]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps: [
       {
         name: 'Checkout',

--- a/.github/workflows/editor-only.yml
+++ b/.github/workflows/editor-only.yml
@@ -24,7 +24,7 @@ env:
 
 jobs:
   build-editor:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps: [
       {
         name: 'Checkout',
@@ -76,7 +76,7 @@ jobs:
 
   sign-editor-windows:
     needs: [build-editor]
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         platform: [x86_64-win32]
@@ -114,7 +114,7 @@ jobs:
 
   release:
     needs: [sign-editor-macos, sign-editor-windows]
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps: [
       {
         name: 'Checkout',

--- a/.github/workflows/engine-nightly.yml
+++ b/.github/workflows/engine-nightly.yml
@@ -44,7 +44,7 @@ jobs:
       }]
 
   bld-eng-linux-x64:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps: [
       { name: 'Checkout', uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 },
       { name: 'Install Python', uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c, with: { python-version: 3.12} },
@@ -76,7 +76,7 @@ jobs:
       }]
 
   bld-eng-linux-arm64:
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-22.04-arm
     steps: [
       { name: 'Checkout', uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 },
       { name: 'Install Python', uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c, with: { python-version: 3.12} },
@@ -111,7 +111,7 @@ jobs:
     strategy:
       matrix:
         platform: [js-web, wasm-web]
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps: [
       { name: 'Checkout', uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11, with: { ref: '${{env.BUILD_BRANCH}}' } },
       { name: 'Install Python', uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c, with: { python-version: 3.12} },

--- a/.github/workflows/engine-nightly.yml
+++ b/.github/workflows/engine-nightly.yml
@@ -44,7 +44,7 @@ jobs:
       }]
 
   bld-eng-linux-x64:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps: [
       { name: 'Checkout', uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 },
       { name: 'Install Python', uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c, with: { python-version: 3.12} },
@@ -76,7 +76,7 @@ jobs:
       }]
 
   bld-eng-linux-arm64:
-    runs-on: ubuntu-20.04-arm
+    runs-on: ubuntu-24.04-arm
     steps: [
       { name: 'Checkout', uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 },
       { name: 'Install Python', uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c, with: { python-version: 3.12} },
@@ -111,7 +111,7 @@ jobs:
     strategy:
       matrix:
         platform: [js-web, wasm-web]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps: [
       { name: 'Checkout', uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11, with: { ref: '${{env.BUILD_BRANCH}}' } },
       { name: 'Install Python', uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c, with: { python-version: 3.12} },

--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -82,7 +82,7 @@ jobs:
     strategy:
       matrix:
         platform: [js-web, wasm-web]
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps: [
       { name: 'Checkout', uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11, with: { ref: '${{env.BUILD_BRANCH}}' } },
       { name: 'Install Python', uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c, with: { python-version: 3.13} },
@@ -111,7 +111,7 @@ jobs:
     strategy:
       matrix:
         platform: [armv7-android, arm64-android]
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps: [
       { name: 'Checkout', uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11, with: { ref: '${{env.BUILD_BRANCH}}' } },
       { name: 'Install Python', uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c, with: { python-version: 3.13} },
@@ -135,7 +135,7 @@ jobs:
     strategy:
       matrix:
         platform: [x86_64-linux]
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps: [
       { name: 'Checkout', uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11, with: { ref: '${{env.BUILD_BRANCH}}' } },
       { name: 'Install Python', uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c, with: { python-version: 3.13} },
@@ -159,7 +159,7 @@ jobs:
     strategy:
       matrix:
         platform: [arm64-linux]
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-22.04-arm
     steps: [
       { name: 'Checkout', uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11, with: { ref: '${{env.BUILD_BRANCH}}' } },
       { name: 'Install Python', uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c, with: { python-version: 3.13} },
@@ -233,7 +233,7 @@ jobs:
 
   build-bob:
     needs: [bld-eng-darwin, bld-eng-windows, bld-eng-linux-x64, bld-eng-linux-arm64, bld-eng-android, bld-eng-web, bld-eng-switch, bld-eng-ps]
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps: [
       { name: 'Checkout', uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11, with: { ref: '${{env.BUILD_BRANCH}}' } },
       { name: 'Install Python', uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c, with: { python-version: 3.13} },
@@ -263,7 +263,7 @@ jobs:
 
   build-sdk:
     needs: [bld-eng-darwin, bld-eng-windows, bld-eng-linux-x64, bld-eng-linux-arm64, bld-eng-android, bld-eng-web, bld-eng-switch, bld-eng-ps]
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps: [
       { name: 'Checkout', uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11, with: { ref: '${{env.BUILD_BRANCH}}' } },
       { name: 'Install Python', uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c, with: { python-version: 3.13} },
@@ -284,7 +284,7 @@ jobs:
 
   build-editor:
     needs: [build-bob]
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps: [
       {
         name: 'Checkout',
@@ -362,7 +362,7 @@ jobs:
 
   sign-editor-windows:
     needs: [build-editor]
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         platform: [x86_64-win32]
@@ -412,7 +412,7 @@ jobs:
 
   release:
     needs: [sign-editor-darwin, sign-editor-windows]
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps: [
       {
         name: 'Checkout',

--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -82,7 +82,7 @@ jobs:
     strategy:
       matrix:
         platform: [js-web, wasm-web]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps: [
       { name: 'Checkout', uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11, with: { ref: '${{env.BUILD_BRANCH}}' } },
       { name: 'Install Python', uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c, with: { python-version: 3.13} },
@@ -111,7 +111,7 @@ jobs:
     strategy:
       matrix:
         platform: [armv7-android, arm64-android]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps: [
       { name: 'Checkout', uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11, with: { ref: '${{env.BUILD_BRANCH}}' } },
       { name: 'Install Python', uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c, with: { python-version: 3.13} },
@@ -135,7 +135,7 @@ jobs:
     strategy:
       matrix:
         platform: [x86_64-linux]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps: [
       { name: 'Checkout', uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11, with: { ref: '${{env.BUILD_BRANCH}}' } },
       { name: 'Install Python', uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c, with: { python-version: 3.13} },
@@ -159,7 +159,7 @@ jobs:
     strategy:
       matrix:
         platform: [arm64-linux]
-    runs-on: ubuntu-20.04-arm
+    runs-on: ubuntu-24.04-arm
     steps: [
       { name: 'Checkout', uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11, with: { ref: '${{env.BUILD_BRANCH}}' } },
       { name: 'Install Python', uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c, with: { python-version: 3.13} },
@@ -233,7 +233,7 @@ jobs:
 
   build-bob:
     needs: [bld-eng-darwin, bld-eng-windows, bld-eng-linux-x64, bld-eng-linux-arm64, bld-eng-android, bld-eng-web, bld-eng-switch, bld-eng-ps]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps: [
       { name: 'Checkout', uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11, with: { ref: '${{env.BUILD_BRANCH}}' } },
       { name: 'Install Python', uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c, with: { python-version: 3.13} },
@@ -263,7 +263,7 @@ jobs:
 
   build-sdk:
     needs: [bld-eng-darwin, bld-eng-windows, bld-eng-linux-x64, bld-eng-linux-arm64, bld-eng-android, bld-eng-web, bld-eng-switch, bld-eng-ps]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps: [
       { name: 'Checkout', uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11, with: { ref: '${{env.BUILD_BRANCH}}' } },
       { name: 'Install Python', uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c, with: { python-version: 3.13} },
@@ -284,7 +284,7 @@ jobs:
 
   build-editor:
     needs: [build-bob]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps: [
       {
         name: 'Checkout',
@@ -362,7 +362,7 @@ jobs:
 
   sign-editor-windows:
     needs: [build-editor]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         platform: [x86_64-win32]
@@ -412,7 +412,7 @@ jobs:
 
   release:
     needs: [sign-editor-darwin, sign-editor-windows]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps: [
       {
         name: 'Checkout',

--- a/ci/ci.py
+++ b/ci/ci.py
@@ -151,6 +151,9 @@ def install(args):
         call("update-alternatives --display clang")
         call("update-alternatives --display clang++")
 
+        call("wget http://security.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb")
+        call("apt install ./libtinfo5_6.3-2ubuntu0.1_amd64.deb")
+
         clang_priority = 200 # GA runner has clang at prio 100, so let's add a higher prio
         clang_version = 16
         clang_path = "/usr/bin"

--- a/ci/ci.py
+++ b/ci/ci.py
@@ -152,7 +152,7 @@ def install(args):
         call("update-alternatives --display clang++")
 
         call("wget http://security.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb")
-        call("apt install ./libtinfo5_6.3-2ubuntu0.1_amd64.deb")
+        call("sudo apt install ./libtinfo5_6.3-2ubuntu0.1_amd64.deb")
 
         clang_priority = 200 # GA runner has clang at prio 100, so let's add a higher prio
         clang_version = 16

--- a/ci/ci.py
+++ b/ci/ci.py
@@ -132,107 +132,120 @@ def setup_steam_config(args):
     b64decode_to_file(args.steam_config_b64, steam_config_file)
     print("Wrote config to", steam_config_file)
 
+def install_linux(args):
+    host_platform = platform_from_host()
+
+    # # we use apt-fast to speed up apt-get downloads
+    # # https://github.com/ilikenwf/apt-fast
+    # call("sudo add-apt-repository ppa:apt-fast/stable")
+    call("sudo apt-get update", failonerror=False)
+    # call("echo debconf apt-fast/maxdownloads string 16 | sudo debconf-set-selections")
+    # call("echo debconf apt-fast/dlflag boolean true | sudo debconf-set-selections")
+    # call("echo debconf apt-fast/aptmanager string apt-get | sudo debconf-set-selections")
+    # call("sudo apt-get install -y apt-fast aria2")
+
+    call("sudo apt-get install -y software-properties-common")
+
+    call("update-alternatives --display clang")
+    call("update-alternatives --display clang++")
+
+    # libtinfo needed when building wasm-web
+    if host_platform == "arm64-linux":
+        call("wget http://ports.ubuntu.com/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_arm64.deb")
+        call("sudo apt install ./libtinfo5_6.3-2ubuntu0.1_arm64.deb")
+    else:
+        call("wget http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb")
+        call("sudo apt install ./libtinfo5_6.3-2ubuntu0.1_amd64.deb")
+
+    clang_priority = 200 # GA runner has clang at prio 100, so let's add a higher prio
+    clang_version = 16
+    clang_path = "/usr/bin"
+    clang_exe = f"/usr/bin/clang-{clang_version}" # installed on the recent GA runners
+
+    # On older ubuntu 20 clang-16 isn't available
+    # Also note that this is before the install_sdk step
+    # if we had to install it ourselves, let's use the correct path
+    if not os.path.exists(clang_exe):
+        print(f"{clang_exe} not found. Installing LLVM + CLANG {clang_version} ...")
+
+        call(f"wget https://apt.llvm.org/llvm.sh")
+        call(f"chmod +x ./llvm.sh")
+        call(f"sudo ./llvm.sh {clang_version}")
+        call(f"rm ./llvm.sh")
+
+        clang_path = f"/usr/lib/llvm-{clang_version}/bin"
+
+        # Add and select the correct version
+        call(f"sudo update-alternatives --install /usr/bin/clang clang {clang_path}/clang-{clang_version} {clang_priority}")
+        call(f"sudo update-alternatives --install /usr/bin/clang++ clang++ {clang_path}/clang++ {clang_priority}")
+        call(f"sudo update-alternatives --install /usr/bin/clang-cpp clang-cpp {clang_path}/clang-cpp {clang_priority}")
+        call(f"sudo update-alternatives --install /usr/bin/llvm-ar llvm-ar {clang_path}/llvm-ar {clang_priority}")
+
+    else:
+        print(f"{clang_exe} found. Selecting LLVM + CLANG {clang_version} ...")
+        # Add and select the correct version
+        call(f"sudo update-alternatives --install /usr/bin/clang clang {clang_path}/clang-{clang_version} {clang_priority}")
+        call(f"sudo update-alternatives --install /usr/bin/clang++ clang++ {clang_path}/clang++-{clang_version} {clang_priority}")
+        call(f"sudo update-alternatives --install /usr/bin/clang-cpp clang-cpp {clang_path}/clang-cpp-{clang_version} {clang_priority}")
+        call(f"sudo update-alternatives --install /usr/bin/llvm-ar llvm-ar {clang_path}/llvm-ar-{clang_version} {clang_priority}")
+
+    call("update-alternatives --display clang")
+    call("update-alternatives --display clang++")
+    call("update-alternatives --display clang-cpp")
+    call("update-alternatives --display llvm-ar")
+
+    packages = [
+        "autoconf",
+        "automake",
+        "build-essential",
+        "freeglut3-dev",
+        "libssl-dev",
+        "libtool",
+        "libxi-dev",
+        "libx11-xcb-dev",
+        "libxrandr-dev",
+        "libopenal-dev",
+        "libgl1-mesa-dev",
+        "libglw1-mesa-dev",
+        "openssl",
+        "tofrodos",
+        "tree",
+        "valgrind",
+        "uuid-dev",
+        "xvfb"
+    ]
+    aptget(" ".join(packages))
+
+    if args.steam_config_b64:
+        # for steamcmd
+        # https://github.com/steamcmd/docker/blob/master/dockerfiles/ubuntu-22/Dockerfile#L15C5-L16C62
+        # https://github.com/game-ci/steam-deploy
+        call("sudo dpkg --add-architecture i386")
+        call("sudo apt-get update", failonerror=False)
+        # accept license agreement
+        call("echo steam steam/question select 'I AGREE' | sudo debconf-set-selections")
+        call("echo steam steam/license note '' | sudo debconf-set-selections")
+        packages = [
+            "lib32z1",
+            "steamcmd",
+            "lib32gcc1",
+            "hfsprogs"   # for mounting DMG files
+        ]
+        aptget(" ".join(packages))
+        setup_steam_config(args)
+def install_macos(args):
+    if args.keychain_cert:
+        setup_keychain(args)
+
 def install(args):
-    # installed tools: https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-Readme.md
+    # installed tools: https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2404-Readme.md
     system = platform.system()
     print("Installing dependencies for system '%s' " % (system))
     if system == "Linux":
-        # # we use apt-fast to speed up apt-get downloads
-        # # https://github.com/ilikenwf/apt-fast
-        # call("sudo add-apt-repository ppa:apt-fast/stable")
-        call("sudo apt-get update", failonerror=False)
-        # call("echo debconf apt-fast/maxdownloads string 16 | sudo debconf-set-selections")
-        # call("echo debconf apt-fast/dlflag boolean true | sudo debconf-set-selections")
-        # call("echo debconf apt-fast/aptmanager string apt-get | sudo debconf-set-selections")
-        # call("sudo apt-get install -y apt-fast aria2")
-
-        call("sudo apt-get install -y software-properties-common")
-
-        call("update-alternatives --display clang")
-        call("update-alternatives --display clang++")
-
-        call("wget http://security.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb")
-        call("sudo apt install ./libtinfo5_6.3-2ubuntu0.1_amd64.deb")
-
-        clang_priority = 200 # GA runner has clang at prio 100, so let's add a higher prio
-        clang_version = 16
-        clang_path = "/usr/bin"
-        clang_exe = f"/usr/bin/clang-{clang_version}" # installed on the recent GA runners
-
-        # On older ubuntu 20 clang-16 isn't available
-        # Also note that this is before the install_sdk step
-        # if we had to install it ourselves, let's use the correct path
-        if not os.path.exists(clang_exe):
-            print(f"{clang_exe} not found. Installing LLVM + CLANG {clang_version} ...")
-
-            call(f"wget https://apt.llvm.org/llvm.sh")
-            call(f"chmod +x ./llvm.sh")
-            call(f"sudo ./llvm.sh {clang_version}")
-            call(f"rm ./llvm.sh")
-
-            clang_path = f"/usr/lib/llvm-{clang_version}/bin"
-
-            # Add and select the correct version
-            call(f"sudo update-alternatives --install /usr/bin/clang clang {clang_path}/clang-{clang_version} {clang_priority}")
-            call(f"sudo update-alternatives --install /usr/bin/clang++ clang++ {clang_path}/clang++ {clang_priority}")
-            call(f"sudo update-alternatives --install /usr/bin/clang-cpp clang-cpp {clang_path}/clang-cpp {clang_priority}")
-            call(f"sudo update-alternatives --install /usr/bin/llvm-ar llvm-ar {clang_path}/llvm-ar {clang_priority}")
-
-        else:
-            # Add and select the correct version
-            call(f"sudo update-alternatives --install /usr/bin/clang clang {clang_path}/clang-{clang_version} {clang_priority}")
-            call(f"sudo update-alternatives --install /usr/bin/clang++ clang++ {clang_path}/clang++-{clang_version} {clang_priority}")
-            call(f"sudo update-alternatives --install /usr/bin/clang-cpp clang-cpp {clang_path}/clang-cpp-{clang_version} {clang_priority}")
-            call(f"sudo update-alternatives --install /usr/bin/llvm-ar llvm-ar {clang_path}/llvm-ar-{clang_version} {clang_priority}")
-
-        call("update-alternatives --display clang")
-        call("update-alternatives --display clang++")
-        call("update-alternatives --display clang-cpp")
-        call("update-alternatives --display llvm-ar")
-
-        packages = [
-            "autoconf",
-            "automake",
-            "build-essential",
-            "freeglut3-dev",
-            "libssl-dev",
-            "libtool",
-            "libxi-dev",
-            "libx11-xcb-dev",
-            "libxrandr-dev",
-            "libopenal-dev",
-            "libgl1-mesa-dev",
-            "libglw1-mesa-dev",
-            "openssl",
-            "tofrodos",
-            "tree",
-            "valgrind",
-            "uuid-dev",
-            "xvfb"
-        ]
-        aptget(" ".join(packages))
-
-        if args.steam_config_b64:
-            # for steamcmd
-            # https://github.com/steamcmd/docker/blob/master/dockerfiles/ubuntu-22/Dockerfile#L15C5-L16C62
-            # https://github.com/game-ci/steam-deploy
-            call("sudo dpkg --add-architecture i386")
-            call("sudo apt-get update", failonerror=False)
-            # accept license agreement
-            call("echo steam steam/question select 'I AGREE' | sudo debconf-set-selections")
-            call("echo steam steam/license note '' | sudo debconf-set-selections")
-            packages = [
-                "lib32z1",
-                "steamcmd",
-                "lib32gcc1",
-                "hfsprogs"   # for mounting DMG files
-            ]
-            aptget(" ".join(packages))
-            setup_steam_config(args)
+        install_linux(args)
 
     elif system == "Darwin":
-        if args.keychain_cert:
-            setup_keychain(args)
+        install_macos(args)
 
 def build_engine(platform, channel, with_valgrind = False, with_asan = False, with_ubsan = False, with_tsan = False,
                 with_vanilla_lua = False, skip_tests = False, skip_build_tests = False, skip_codesign = True,


### PR DESCRIPTION
Ubuntu 20.04 LTS reaches end of life in April 2025. Ubuntu 20.04 LTS will no longer be supported on GitHub Actions. This PR updates the GitHub Actions workflows to Ubuntu 22.04 LTS and installs additional required dependency.