### PR TITLE
Fixed an issue where texture compression checkbox was not taken into account when using `Build HTML5` from the editor

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/PlatformTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/PlatformTest.java
@@ -72,7 +72,12 @@ public class PlatformTest {
     @Test
     public void testPlatformMatching() {
 
-        // assertTrue(Platform.matchPlatformAgainstOS("",               PlatformProfile.OS.OS_ID_GENERIC));
+        assertTrue(Platform.X86Win32.matchesOS(PlatformProfile.OS.OS_ID_GENERIC));
+        assertTrue(Platform.X86_64MacOS.matchesOS(PlatformProfile.OS.OS_ID_GENERIC));
+        assertTrue(Platform.X86_64Ios.matchesOS(PlatformProfile.OS.OS_ID_GENERIC));
+        assertTrue(Platform.X86_64Linux.matchesOS(PlatformProfile.OS.OS_ID_GENERIC));
+        assertTrue(Platform.Arm64Android.matchesOS(PlatformProfile.OS.OS_ID_GENERIC));
+        assertTrue(Platform.WasmWeb.matchesOS(PlatformProfile.OS.OS_ID_GENERIC));
 
         assertTrue(Platform.X86Win32.matchesOS(PlatformProfile.OS.OS_ID_WINDOWS));
         assertTrue(Platform.X86_64Win32.matchesOS(PlatformProfile.OS.OS_ID_WINDOWS));

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Platform.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Platform.java
@@ -224,6 +224,9 @@ public class Platform {
     }
 
     public boolean matchesOS(PlatformProfile.OS os) {
+        if (os.equals(OS.OS_ID_GENERIC)) {
+            return true;
+        }
         return this.osID.equals(os);
     }
 

--- a/editor/src/clj/editor/pipeline/bob.clj
+++ b/editor/src/clj/editor/pipeline/bob.clj
@@ -302,6 +302,7 @@
      "build-server" build-server-url
      "build-server-header" (native-extensions/get-build-server-headers prefs)
      "defoldsdk" defold-sdk-sha1
+     "texture-compression" (prefs/get prefs [:build :texture-compression])
      ;; internal option: can't set using command line, but it is needed to run
      ;; the HTML5 build locally.
      :local-launch true


### PR DESCRIPTION
Fixes https://github.com/defold/defold/issues/10206