### PR TITLE
Add a new preference to prevent the browser from opening after `Build HTML5`

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -1348,7 +1348,7 @@ If you do not specifically require different script states, consider changing th
                                (let [url (format "http://localhost:%d%s/index.html" (http-server/port web-server) bob/html5-url-prefix)]
                                  (if (prefs/get prefs [:build :open-html5-build])
                                    (ui/open-url url)
-                                   (console/append-console-entry! nil (format "INFO:The game is available at %s" url))))
+                                   (console/append-console-entry! nil (format "INFO: The game is available at %s" url))))
                                (.close out))))))
 
 (handler/defhandler :rebuild-html5 :global

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -1345,8 +1345,11 @@ If you do not specifically require different script states, consider changing th
                            render-build-error! bob-commands bob-args project changes-view
                            (fn [successful?]
                              (when successful?
-                               (ui/open-url (format "http://localhost:%d%s/index.html" (http-server/port web-server) bob/html5-url-prefix)))
-                             (.close out)))))
+                               (let [url (format "http://localhost:%d%s/index.html" (http-server/port web-server) bob/html5-url-prefix)]
+                                 (if (prefs/get prefs [:build :open-html5-build])
+                                   (ui/open-url url)
+                                   (console/append-console-entry! nil (format "INFO:The game is available at %s" url))))
+                               (.close out))))))
 
 (handler/defhandler :rebuild-html5 :global
   (run [project prefs web-server build-errors-view changes-view main-stage tool-tab-pane]

--- a/editor/src/clj/editor/prefs.clj
+++ b/editor/src/clj/editor/prefs.clj
@@ -126,7 +126,7 @@
             :properties
             {:lint-code {:type :boolean :default true :label "Lint Code on Build"}
              :texture-compression {:type :boolean}
-             :open-html5-build {:type :boolean :default true :label "Open browser after `Build HTML5`"}}}
+             :open-html5-build {:type :boolean :default true :label "Open Browser After `Build HTML5`"}}}
     :bundle {:type :object
              :scope :project
              :properties

--- a/editor/src/clj/editor/prefs.clj
+++ b/editor/src/clj/editor/prefs.clj
@@ -125,7 +125,8 @@
             :scope :project
             :properties
             {:lint-code {:type :boolean :default true :label "Lint Code on Build"}
-             :texture-compression {:type :boolean}}}
+             :texture-compression {:type :boolean}
+             :open-html5-build {:type :boolean :default true :label "Open browser after `Build HTML5`"}}}
     :bundle {:type :object
              :scope :project
              :properties

--- a/editor/src/clj/editor/prefs_dialog.clj
+++ b/editor/src/clj/editor/prefs_dialog.clj
@@ -100,7 +100,7 @@
   (cond-> [{:name  "General"
             :prefs [{:label "Load External Changes on App Focus" :type :boolean :key [:workflow :load-external-changes-on-app-focus]}
                     {:label "Open Bundle Target Folder" :type :boolean :key [:bundle :open-output-directory]}
-                    {:label "Open browser after `Build HTML5`" :type :boolean :key [:build :open-html5-build]}
+                    {:label "Open Browser After `Build HTML5`" :type :boolean :key [:build :open-html5-build]}
                     {:label "Enable Texture Compression" :type :boolean :key [:build :texture-compression]}
                     {:label "Escape Quits Game" :type :boolean :key [:run :quit-on-escape]}
                     {:label "Track Active Tab in Asset Browser" :type :boolean :key [:asset-browser :track-active-tab]}

--- a/editor/src/clj/editor/prefs_dialog.clj
+++ b/editor/src/clj/editor/prefs_dialog.clj
@@ -100,6 +100,7 @@
   (cond-> [{:name  "General"
             :prefs [{:label "Load External Changes on App Focus" :type :boolean :key [:workflow :load-external-changes-on-app-focus]}
                     {:label "Open Bundle Target Folder" :type :boolean :key [:bundle :open-output-directory]}
+                    {:label "Open browser after `Build HTML5`" :type :boolean :key [:build :open-html5-build]}
                     {:label "Enable Texture Compression" :type :boolean :key [:build :texture-compression]}
                     {:label "Escape Quits Game" :type :boolean :key [:run :quit-on-escape]}
                     {:label "Track Active Tab in Asset Browser" :type :boolean :key [:asset-browser :track-active-tab]}


### PR DESCRIPTION
Some browsers always create a new tab when opening the same URL.  
In such cases, it may be useful to rebuild the HTML5 build without reopening the browser and instead manually update the page.  
This is now possible with a new checkbox in **Preferences**.  

Fixes https://github.com/defold/defold/issues/10181