### PR TITLE
The default render script was not using an option table when drawing the gui

### DIFF
--- a/engine/engine/content/builtins/render/default.render_script
+++ b/engine/engine/content/builtins/render/default.render_script
@@ -241,8 +241,8 @@ function update(self)
     render.set_projection(camera_gui.proj)
 
     render.enable_state(graphics.STATE_STENCIL_TEST)
-    render.draw(predicates.gui, camera_gui.frustum)
-    render.draw(predicates.debug_text, camera_gui.frustum)
+    render.draw(predicates.gui, camera_gui.options)
+    render.draw(predicates.debug_text, camera_gui.options)
     render.disable_state(graphics.STATE_STENCIL_TEST)
     render.disable_state(graphics.STATE_BLEND)
 end


### PR DESCRIPTION
The default render script was now passing an options table when drawing the gui and text in the last step of the `update()` function.

Fixes #10221 