### PR TITLE
Fix mouse over state of toolbar buttons

### DIFF
--- a/editor/styling/stylesheets/modules/_toolbar.scss
+++ b/editor/styling/stylesheets/modules/_toolbar.scss
@@ -30,7 +30,11 @@
 
         &:hover {
             & > .image-view {
-                -fx-effect: innershadow(gaussian, -df-text, 20, 0.3, 0, 0) !important;
+                -fx-effect: innershadow(gaussian, -df-text-selected, 20, 0.3, 0, 0) !important;
+            }
+
+            SVGPath {
+                -fx-fill: -df-text-selected;
             }
         }
         &:selected {

--- a/editor/styling/stylesheets/modules/_toolbar.scss
+++ b/editor/styling/stylesheets/modules/_toolbar.scss
@@ -102,9 +102,6 @@
 
     SVGPath {
         -fx-fill: -df-text;
-        &:hover, &:pressed, &:focused {
-            -fx-fill: -df-text;
-        }
     }
 
     .separator {


### PR DESCRIPTION
The fix [here](https://github.com/defold/defold/commit/1a074c21277d3355b68c3fe12538a3b32fc86eac#diff-5b2c365ea12152c04181092a182be946f1197a57a290c1d82dd4c5d302f44759R32-R35) disabled the mouse over state. Changing the color of svg paths would maintain that, and also fix the related #8941.