### PR TITLE
Add `http` module to editor scripts

### DIFF
--- a/editor/src/clj/editor/editor_extensions/docs.clj
+++ b/editor/src/clj/editor/editor_extensions/docs.clj
@@ -241,7 +241,45 @@
           ui-docs/enums)
         (ui-docs/script-docs)
         (prefs-docs/script-docs)
-        [{:name "json"
+        [{:name "http"
+          :type :module
+          :description "Functions for performing HTTP requests"}
+         {:name "http.request"
+          :type :function
+          :description "Perform an HTTP request"
+          :parameters [{:name "url"
+                        :types ["string"]
+                        :doc "request URL"}
+                       {:name "[opts]"
+                        :types ["table"]
+                        :doc (str "Additional request options, a table with the following keys:"
+                                  (lua-completion/args-doc-html
+                                    [{:name "method"
+                                      :types ["string"]
+                                      :doc "request method, defaults to <code>\"GET\"</code>"}
+                                     {:name "headers"
+                                      :types ["table"]
+                                      :doc "request headers, a table with string keys and values"}
+                                     {:name "body"
+                                      :types ["string"]
+                                      :doc "request body"}
+                                     {:name "as"
+                                      :types ["string"]
+                                      :doc "Response body converter, either <code>\"string\"</code> or <code>\"json\"</code>"}]))}]
+          :returnvalues [{:name "response"
+                          :types ["table"]
+                          :doc (str "HTTP response, a table with the following keys:"
+                                    (lua-completion/args-doc-html
+                                      [{:name "status"
+                                        :types ["integer"]
+                                        :doc "response code"}
+                                       {:name "headers"
+                                        :types ["table"]
+                                        :doc "response headers, a table where each key is a lower-cased string, and each value is either a string or an array of strings if the header was repeated"}
+                                       {:name "body"
+                                        :types ["string" "any" "nil"]
+                                        :doc "response body, present only when <code>as</code> option was provided, either a string or a parsed json value"}]))}]}
+         {:name "json"
           :type :module
           :description "Module for encoding or decoding values in JSON format"}
          {:name "json.decode"

--- a/editor/src/clj/editor/sentry.clj
+++ b/editor/src/clj/editor/sentry.clj
@@ -14,14 +14,14 @@
 
 (ns editor.sentry
   (:require
-   [clojure.data.json :as json]
-   [clojure.java.io :as io]
-   [clojure.string :as string]
-   [editor.gl :as gl]
-   [editor.system :as system]
-   [schema.utils :as su]
-   [service.log :as log]
-   [util.http-client :as http])
+    [clojure.data.json :as json]
+    [clojure.java.io :as io]
+    [clojure.string :as string]
+    [editor.gl :as gl]
+    [editor.system :as system]
+    [schema.utils :as su]
+    [service.log :as log]
+    [util.http-client :as http])
   (:import
    (java.util.concurrent LinkedBlockingQueue TimeUnit)
    (java.time LocalDateTime ZoneOffset)))
@@ -139,33 +139,31 @@
   (-write [object out options] (json/-write (str object) out options)))
 
 (defn make-request-data
-  [{:keys [project-id key secret]} event]
-  {:request-method :post
-   :scheme         "https"
-   :server-name    "sentry.io"
-   :uri            (format "/api/%s/store/" project-id)
-   :content-type   "application/json"
-   :headers        {"X-Sentry-Auth" (x-sentry-auth (:timestamp event) key secret)
-                    "User-Agent"    user-agent
-                    "Accept"        "application/json"}
-   :body           (try
-                     (json/write-str event)
-                     (catch Exception e
-                       ;; The :extra field in the event data returned by make-event can potentially
-                       ;; contain anything, since it includes ex-data from the exception.
-                       ;; We attempt to convert unrepresentable values into an appropriate json value
-                       ;; using the to-safe-json-value function above, but new types might appear.
-                       ;; In case conversion fails, we replace the :extra data with safe data that
-                       ;; will convert successfully, and include info about the conversion failure
-                       ;; so we can add conversions to the to-safe-json-value function as needed.
-                       (json/write-str (assoc event :extra {:java-home (system/java-home)
-                                                            :conversion-failure (exception-data e (Thread/currentThread))}))))})
+  [{:keys [key secret]} event]
+  {:method "POST"
+   :headers {"X-Sentry-Auth" (x-sentry-auth (:timestamp event) key secret)
+             "Content-Type" "application/json"
+             "User-Agent" user-agent
+             "Accept" "application/json"}
+   :body (try
+           (json/write-str event)
+           (catch Exception e
+             ;; The :extra field in the event data returned by make-event can potentially
+             ;; contain anything, since it includes ex-data from the exception.
+             ;; We attempt to convert unrepresentable values into an appropriate json value
+             ;; using the to-safe-json-value function above, but new types might appear.
+             ;; In case conversion fails, we replace the :extra data with safe data that
+             ;; will convert successfully, and include info about the conversion failure
+             ;; so we can add conversions to the to-safe-json-value function as needed.
+             (json/write-str (assoc event :extra {:java-home (system/java-home)
+                                                  :conversion-failure (exception-data e (Thread/currentThread))}))))
+   :as :input-stream})
 
 (defn report-exception
-  [options exception thread]
+  [{:keys [project-id] :as options} exception thread]
   (let [event (make-event exception thread)
         request (make-request-data options event)
-        response (http/request request)]
+        response @(http/request (format "https://sentry.io/api/%s/store/" project-id) request)]
     (when (= 200 (:status response))
       (with-open [reader (io/reader (:body response))]
         (-> reader (json/read :key-fn keyword) :id)))))

--- a/editor/src/clj/util/http_client.clj
+++ b/editor/src/clj/util/http_client.clj
@@ -19,6 +19,8 @@
            [java.net.http HttpClient HttpClient$Redirect HttpRequest HttpRequest$BodyPublishers HttpRequest$Builder HttpResponse HttpResponse$BodyHandlers]
            [java.util List]))
 
+(set! *warn-on-reflection* true)
+
 (def ^:private ^HttpClient client
   (-> (HttpClient/newBuilder)
       (.followRedirects HttpClient$Redirect/NORMAL)
@@ -44,7 +46,7 @@
   (-> client
       (.sendAsync
         (-> (HttpRequest/newBuilder (URI. url))
-            (as-> $ (reduce-kv HttpRequest$Builder/.header $ headers))
+            (as-> $ ^HttpRequest$Builder (reduce-kv HttpRequest$Builder/.header $ headers))
             (.method method (cond
                               (nil? body) (HttpRequest$BodyPublishers/noBody)
                               (string? body) (HttpRequest$BodyPublishers/ofString body)

--- a/editor/src/clj/util/http_client.clj
+++ b/editor/src/clj/util/http_client.clj
@@ -13,103 +13,56 @@
 ;; specific language governing permissions and limitations under the License.
 
 (ns util.http-client
-  (:require
-   [clojure.data.json :as json]
-   [clojure.java.io :as io]
-   [clojure.string :as string])
-  (:import
-   (java.io ByteArrayOutputStream InputStream IOException)
-   (java.net URI URL HttpURLConnection)))
+  "Clojure HTTP client implementation using modern java.net.http stack"
+  (:import [java.io InputStream]
+           [java.net URI]
+           [java.net.http HttpClient HttpClient$Redirect HttpRequest HttpRequest$BodyPublishers HttpRequest$Builder HttpResponse HttpResponse$BodyHandlers]
+           [java.util List]))
 
-(set! *warn-on-reflection* true)
-
-;; http client using HttpURLConnection, extracted from clj-http-lite
-
-(defn parse-headers
-  "Takes a URLConnection and returns a map of names to values.
-   If a name appears more than once (like `set-cookie`) then the value
-   will be a vector containing the values in the order they appeared
-   in the headers."
-  [conn]
-  (loop [i 1 headers {}]
-    (let [k (.getHeaderFieldKey ^HttpURLConnection conn i)
-          v (.getHeaderField ^HttpURLConnection conn i)]
-      (if k
-        (recur (inc i) (update-in headers [k] conj v))
-        (zipmap (for [k (keys headers)]
-                  (.toLowerCase ^String k))
-                (for [v (vals headers)]
-                  (if (= 1 (count v))
-                    (first v)
-                    (vec v))))))))
-
-(defn- coerce-body-entity
-  "Coerce the http-entity from an HttpResponse to either a byte-array, or a
-  stream that closes itself and the connection manager when closed."
-  [{:keys [as]} conn]
-  (let [ins (try
-              (.getInputStream ^HttpURLConnection conn)
-              (catch Exception e
-                (.getErrorStream ^HttpURLConnection conn)))]
-    (if (or (= :stream as) (nil? ins))
-      ins
-      (with-open [ins ^InputStream ins
-                  baos (ByteArrayOutputStream.)]
-        (io/copy ins baos)
-        (.flush baos)
-        (.toByteArray baos)))))
-
-(defn split-url
-  [url]
-  (let [u (URL. url)
-        port (.getPort u)]
-    (cond-> {:protocol (.getProtocol u)
-             :host     (.getHost u)
-             :path     (.getPath u)
-             :query    (.getQuery u)}
-      (not (neg? port)) (assoc :port port))))
+(def ^:private ^HttpClient client
+  (-> (HttpClient/newBuilder)
+      (.followRedirects HttpClient$Redirect/NORMAL)
+      (.build)))
 
 (defn request
-  "Executes the HTTP request corresponding to the given Ring request map and
-   returns the Ring response map corresponding to the resulting HTTP response.
-   Note that where Ring uses InputStreams for the request and response bodies,
-   the clj-http uses ByteArrays for the bodies."
-  [{:keys [request-method scheme server-name server-port uri query-string
-           headers content-type character-encoding body socket-timeout
-           conn-timeout multipart debug insecure? save-request? follow-redirects
-           chunk-size] :as req}]
-  (let [http-url (str (name scheme) "://" server-name
-                      (when server-port (str ":" server-port))
-                      uri
-                      (when query-string (str "?" query-string)))
-        ^HttpURLConnection conn (.openConnection ^URL (URL. http-url))]
-    (when (and content-type character-encoding)
-      (.setRequestProperty conn "Content-Type" (str content-type
-                                                    "; charset="
-                                                    character-encoding)))
-    (when (and content-type (not character-encoding))
-      (.setRequestProperty conn "Content-Type" content-type))
-    (doseq [[h v] headers]
-      (.setRequestProperty conn h v))
-    (when (false? follow-redirects)
-      (.setInstanceFollowRedirects ^HttpURLConnection conn false))
-    (.setRequestMethod ^HttpURLConnection conn (.toUpperCase (name request-method)))
-    (when body
-      (.setDoOutput conn true))
-    (when socket-timeout
-      (.setReadTimeout conn socket-timeout))
-    (when conn-timeout
-      (.setConnectTimeout conn conn-timeout))
-    (when chunk-size
-      (.setChunkedStreamingMode conn chunk-size))
-    (.connect conn)
-    (when body
-      (with-open [out (.getOutputStream conn)]
-        (io/copy body out)))
-    (merge {:headers (parse-headers conn)
-            :status (.getResponseCode ^HttpURLConnection conn)
-            :body (when-not (= request-method :head)
-                    (coerce-body-entity req conn))}
-           (when save-request?
-             {:request (assoc (dissoc req :save-request?)
-                              :http-url http-url)}))))
+  "Send HTTP request
+
+  Optional kv-args:
+    :method     request method string, defaults to GET
+    :headers    request headers map, string->string
+    :body       request body, either string, InputStream or a byte array
+    :as         response body, either :string, :input-stream or :byte-array
+
+  Returns a CompletableFuture that will receive a map with the following keys:
+    :status     HTTP status code, e.g. 200
+    :headers    response headers map, string->(string|string[])
+    :body       the key is present only if :as was provided; either string,
+                InputStream or byte array"
+  [url & {:keys [method body headers as]
+          :or {method "GET"}}]
+  {:pre [(string? url)]}
+  (-> client
+      (.sendAsync
+        (-> (HttpRequest/newBuilder (URI. url))
+            (as-> $ (reduce-kv HttpRequest$Builder/.header $ headers))
+            (.method method (cond
+                              (nil? body) (HttpRequest$BodyPublishers/noBody)
+                              (string? body) (HttpRequest$BodyPublishers/ofString body)
+                              (instance? InputStream body) (HttpRequest$BodyPublishers/ofInputStream (fn [] body))
+                              (instance? byte/1 body) (HttpRequest$BodyPublishers/ofByteArray body)
+                              :else (throw (IllegalArgumentException. "body should either be nil, string, InputStream or byte array"))))
+            (.build))
+        (case as
+          nil (HttpResponse$BodyHandlers/discarding)
+          :string (HttpResponse$BodyHandlers/ofString)
+          :input-stream (HttpResponse$BodyHandlers/ofInputStream)
+          :byte-array (HttpResponse$BodyHandlers/ofByteArray)))
+      (.thenApply
+        (fn [^HttpResponse response]
+          (cond-> {:status (.statusCode response)
+                   :headers (into {}
+                                  (map (fn [[k v]]
+                                         [k (if (< 1 (count v)) (vec v) (.get ^List v 0))]))
+                                  (.map (.headers response)))}
+                  (.body response)
+                  (assoc :body (.body response)))))))

--- a/editor/test/integration/editor_extensions_test.clj
+++ b/editor/test/integration/editor_extensions_test.clj
@@ -32,6 +32,8 @@
             [editor.ui :as ui]
             [editor.workspace :as workspace]
             [integration.test-util :as test-util]
+            [ring.adapter.jetty :as jetty]
+            [ring.util.response :as response]
             [support.test-support :as test-support]
             [util.diff :as diff])
   (:import [org.luaj.vm2 LuaError]))
@@ -823,3 +825,55 @@ nesting:
                            ((vswap! hash->stable-id #(assoc % s (str "0x" (count %)))) s))))]
         (is (= actual expected-pprint-output)
             (string/join "\n" (diff/make-diff-output-lines actual expected-pprint-output 3)))))))
+
+(def expected-http-test-output
+  "GET http://localhost:23000 => error (ConnectException)
+GET not-an-url => error (URI with undefined scheme)
+HEAD http://localhost:23456 => 200
+GET http://localhost:23456 => 200
+GET http://localhost:23456/redirect/foo as string => 200
+\"successfully redirected\"
+GET http://localhost:23456/json as json => 200
+{ --[[0x0]]
+  a = 1,
+  b = { --[[0x1]]
+    true
+  }
+}
+POST http://localhost:23456/echo {\"y\":\"foo\",\"x\":4} as json => 200
+{ --[[0x2]]
+  y = \"foo\",
+  x = 4
+}
+POST http://localhost:23456/echo hello world! as string => 200
+\"hello world!\"
+")
+
+(deftest http-test
+  (test-util/with-loaded-project "test/resources/editor_extensions/http_project"
+    (let [server (jetty/run-jetty
+                   (fn [request]
+                     (case (:uri request)
+                       "/redirect/foo" (response/redirect "/foo")
+                       "/foo" (response/response "successfully redirected")
+                       "/" (response/response "")
+                       "/json" (response/response "{\"a\": 1, \"b\": [true]}")
+                       "/echo" (response/response (slurp (:body request)))
+                       (response/not-found "404")))
+                   {:port 23456 :join? false})
+          out (StringBuilder.)]
+      (try
+        (reload-editor-scripts! project :display-output! #(doto out (.append %2) (.append \newline)))
+        ;; See test.editor_script: the test invokes http.request with various options and prints results
+        (run-edit-menu-test-command!)
+        (let [hash->stable-id (volatile! {})
+              actual (string/replace
+                       (str out)
+                       #"0x[0-9a-f]+"
+                       (fn [s]
+                         (or (@hash->stable-id s)
+                             ((vswap! hash->stable-id #(assoc % s (str "0x" (count %)))) s))))]
+          (is (= actual expected-http-test-output)
+              (string/join "\n" (diff/make-diff-output-lines actual expected-http-test-output 3))))
+        (finally
+          (.stop server))))))

--- a/editor/test/resources/editor_extensions/http_project/.gitignore
+++ b/editor/test/resources/editor_extensions/http_project/.gitignore
@@ -1,0 +1,11 @@
+/.editor_settings
+/.internal
+/build
+.externalToolBuilders
+.DS_Store
+Thumbs.db
+.lock-wscript
+*.pyc
+.project
+.cproject
+builtins

--- a/editor/test/resources/editor_extensions/http_project/game.project
+++ b/editor/test/resources/editor_extensions/http_project/game.project
@@ -1,0 +1,20 @@
+[bootstrap]
+main_collection = /main/main.collectionc
+
+[script]
+shared_state = 1
+
+[display]
+width = 960
+height = 640
+high_dpi = 1
+
+[android]
+input_method = HiddenInputField
+
+[html5]
+scale_mode = stretch
+
+[project]
+title = http_project
+

--- a/editor/test/resources/editor_extensions/http_project/test.editor_script
+++ b/editor/test/resources/editor_extensions/http_project/test.editor_script
@@ -1,0 +1,36 @@
+local M = {}
+
+local function test(url, opts)
+    local success, result = pcall(http.request, url, opts)
+    local method = (opts and opts.method) or "GET"
+    local as = (opts and opts.as and (" as " .. opts.as)) or ""
+    local body = (opts and opts.body and (" " .. opts.body)) or ""
+    local prefix = ("%s %s%s%s"):format(method, url, body, as)
+    if success then
+        print(("%s => %s"):format(prefix, result.status))
+        if result.body then
+            pprint(result.body)
+        end
+    else
+        print(("%s => error (%s)"):format(prefix, result))
+    end
+end
+
+function M.get_commands()
+    return {{
+        label = "Test",
+        locations = {"Edit"},
+        run = function()
+            test("http://localhost:23000")
+            test("not-an-url")
+            test("http://localhost:23456", {method = "HEAD"})
+            test("http://localhost:23456")
+            test("http://localhost:23456/redirect/foo", {as = "string"})
+            test("http://localhost:23456/json", {as = "json"})
+            test("http://localhost:23456/echo", {as = "json", method = "POST", body = json.encode({x = 4, y = "foo"})})
+            test("http://localhost:23456/echo", {as = "string", method = "POST", body = "hello world!"})
+        end
+    }}
+end
+
+return M


### PR DESCRIPTION
Editor scripts can now make HTTP requests using the `http` module, e.g.:
```lua
pprint(http.request("https://api.nasa.gov/planetary/apod?api_key=DEMO_KEY", {as = "json"}))
-- Output:
-- { --[[0x4de6c2e]]
--   status = 200,
--   headers = { --[[0xa1982c5]]
--     ["content-length"] = "1102",
--     age = "0",
--     vary = { --[[0xe26075e]]
--       "Accept-Encoding",
--       "Accept-Encoding"
--     },
--     ...
--   },
--   body = { --[[0x4b2488fe]]
--     media_type = "image",
--     title = "SpaceX Rocket Launch Plume over California",
--     copyright = "\nMartin LaMontagne\n",
--     date = "2025-02-17",
--     url = "https://apod.nasa.gov/apod/image/2502/FishPlume_LaMontagne_960.jpg",
--     hdurl = "https://apod.nasa.gov/apod/image/2502/FishPlume_LaMontagne_2272.jpg",
--     service_version = "v1",
--     explanation = "What's happened to the sky? Last Monday, the photogenic launch plume from a SpaceX rocket launch created quite a spectacle over parts of southern California and Arizona.  Looking at times like a giant space fish, the impressive rocket launch from Vandenberg Air Force Base near Lompoc, California, was so bright because it was backlit by the setting Sun. The Falcon 9 rocket successfully delivered to low Earth orbit 23 Starlink communications satellites.  The plume from the first stage is seen on the right, while the soaring upper stage rocket is seen at the apex of the plume toward the left. Venus appears at the top of the frame, while a bright streetlight shines on the far right.  The featured image was captured toward the west after sunset from near Phoenix, Arizona."
--   }
-- }
```

Fixes #8654