### PR TITLE
Add TextureProfilesBuilder instead of building it in GameProjectBuilder

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/TextureCompressorTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/TextureCompressorTest.java
@@ -16,6 +16,7 @@ package com.dynamo.bob.pipeline;
 
 import com.defold.extension.pipeline.texture.*;
 import com.defold.extension.pipeline.texture.TestTextureCompressor;
+import com.dynamo.bob.fs.IResource;
 import com.dynamo.graphics.proto.Graphics;
 import org.junit.Before;
 import org.junit.Test;
@@ -99,8 +100,10 @@ public class TextureCompressorTest extends AbstractProtoBuilderTest {
         texProfilesBuilder.addProfiles(textureProfile.build()).addPathSettings(genericPath);
 
         this.getProject().setOption("texture-compression", "true");
-        this.getProject().setTextureProfiles(texProfilesBuilder.build());
 
+        this.getProject().getProjectProperties().putStringValue("graphics", "texture_profiles", "my.texture_profile");
+        IResource res = this.getProject().getResource("my.texture_profilesc");
+        res.output().setContent(texProfilesBuilder.build().toByteArray());
         TextureCompression.registerCompressor(testCompressor);
         ensureBuildProject();
 

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
@@ -2252,12 +2252,4 @@ public class Project {
         return Collections.unmodifiableList(new ArrayList(this.tasks.values()));
     }
 
-    public TextureProfiles getTextureProfiles() {
-        return textureProfiles;
-    }
-
-    public void setTextureProfiles(TextureProfiles textureProfiles) {
-        this.textureProfiles = textureProfiles;
-    }
-
 }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Task.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Task.java
@@ -127,6 +127,8 @@ public class Task {
         return inputs.get(0);
     }
 
+    public IResource lastInput() { return inputs.get(inputs.size() - 1); }
+
     public List<IResource> getOutputs() {
         return Collections.unmodifiableList(outputs);
     }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/AtlasBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/AtlasBuilder.java
@@ -86,12 +86,7 @@ public class AtlasBuilder extends ProtoBuilder<Atlas.Builder> {
             taskBuilder.addInput(input.getResource(image.getImage()));
         }
 
-        // If there is a texture profiles file, we need to make sure
-        // it has been read before building this tile set, add it as an input.
-        String textureProfilesPath = this.project.getProjectProperties().getStringValue("graphics", "texture_profiles");
-        if (textureProfilesPath != null) {
-            taskBuilder.addInput(this.project.getResource(textureProfilesPath));
-        }
+        TextureUtil.addTextureProfileInput(taskBuilder, project);
 
         return taskBuilder.build();
     }
@@ -108,7 +103,7 @@ public class AtlasBuilder extends ProtoBuilder<Atlas.Builder> {
                                                 .setTexture(texturePath)
                                                 .build();
 
-        TextureProfile texProfile = TextureUtil.getTextureProfileByPath(this.project.getTextureProfiles(), task.input(0).getPath());
+        TextureProfile texProfile = TextureUtil.getTextureProfileByPath(task.lastInput(), task.input(0).getPath());
         logger.fine("Compiling %s using profile %s", task.input(0).getPath(), texProfile!=null?texProfile.getName():"<none>");
 
         boolean compress = project.option("texture-compression", "false").equals("true");

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/CubemapBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/CubemapBuilder.java
@@ -56,12 +56,7 @@ public class CubemapBuilder extends ProtoBuilder<Cubemap.Builder> {
                 // '.texturec' can't be parsed with Cubemap, we specify this output manually
                 .addOutput(input.changeExt(".texturec"));
 
-        // If there is a texture profiles file, we need to make sure
-        // it has been read before building this tile set, add it as an input.
-        String textureProfilesPath = this.project.getProjectProperties().getStringValue("graphics", "texture_profiles");
-        if (textureProfilesPath != null) {
-            taskBuilder.addInput(this.project.getResource(textureProfilesPath));
-        }
+        TextureUtil.addTextureProfileInput(taskBuilder, project);
 
         return taskBuilder.build();
     }
@@ -69,7 +64,7 @@ public class CubemapBuilder extends ProtoBuilder<Cubemap.Builder> {
     @Override
     public void build(Task task) throws CompileExceptionError, IOException {
 
-        TextureProfile texProfile = TextureUtil.getTextureProfileByPath(this.project.getTextureProfiles(), task.input(0).getPath());
+        TextureProfile texProfile = TextureUtil.getTextureProfileByPath(task.lastInput(), task.input(0).getPath());
         logger.fine("Compiling %s using profile %s", task.firstInput().getPath(), texProfile!=null?texProfile.getName():"<none>");
 
         TextureGenerator.GenerateResult[] generateResults = new TextureGenerator.GenerateResult[6];

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/GameProjectBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/GameProjectBuilder.java
@@ -17,13 +17,17 @@ package com.dynamo.bob.pipeline;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.RandomAccessFile;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.NoSuchAlgorithmException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 import com.dynamo.bob.fs.ResourceUtil;
 import org.apache.commons.io.FileUtils;
@@ -35,7 +39,6 @@ import com.dynamo.bob.Builder;
 import com.dynamo.bob.BuilderParams;
 import com.dynamo.bob.CompileExceptionError;
 import com.dynamo.bob.CopyCustomResourcesBuilder;
-import com.dynamo.bob.Platform;
 import com.dynamo.bob.Project;
 import com.dynamo.bob.ProtoBuilder;
 import com.dynamo.bob.Task;
@@ -50,12 +53,8 @@ import com.dynamo.bob.fs.IResource;
 import com.dynamo.bob.util.FileUtil;
 import com.dynamo.bob.logging.Logger;
 import com.dynamo.bob.pipeline.graph.ResourceGraph;
-import com.dynamo.bob.util.ComponentsCounter;
 import com.dynamo.bob.util.BobProjectProperties;
 import com.dynamo.bob.util.TimeProfiler;
-import com.dynamo.graphics.proto.Graphics.PlatformProfile;
-import com.dynamo.graphics.proto.Graphics.TextureProfile;
-import com.dynamo.graphics.proto.Graphics.TextureProfiles;
 import com.dynamo.liveupdate.proto.Manifest.HashAlgorithm;
 import com.dynamo.liveupdate.proto.Manifest.SignAlgorithm;
 
@@ -161,53 +160,8 @@ public class GameProjectBuilder extends Builder {
             index++;
         }
 
-        // Load texture profile message if supplied and enabled
-        String textureProfilesPath = project.getProjectProperties().getStringValue("graphics", "texture_profiles");
-        if (textureProfilesPath != null) {
-            TimeProfiler.start("Load texture profile");
-            TextureProfiles.Builder texProfilesBuilder = TextureProfiles.newBuilder();
-            IResource texProfilesInput = project.getResource(textureProfilesPath);
-            if (!texProfilesInput.exists()) {
-                throw new CompileExceptionError(input, -1, "Could not find supplied texture_profiles file: " + textureProfilesPath);
-            }
-            ProtoUtil.merge(texProfilesInput, texProfilesBuilder);
-
-            // If Bob is building for a specific platform, we need to
-            // filter out any platform entries not relevant to the target platform.
-            // (i.e. we don't want win32 specific profiles lingering in android bundles)
-            Platform targetPlatform = project.getPlatform();
-
-            List<TextureProfile> newProfiles = new LinkedList<TextureProfile>();
-            for (int i = 0; i < texProfilesBuilder.getProfilesCount(); i++) {
-
-                TextureProfile profile = texProfilesBuilder.getProfiles(i);
-                TextureProfile.Builder profileBuilder = TextureProfile.newBuilder();
-                profileBuilder.mergeFrom(profile);
-                profileBuilder.clearPlatforms();
-
-                // Take only the platforms that matches the target platform
-                for (PlatformProfile platformProfile : profile.getPlatformsList()) {
-                    if (targetPlatform.matchesOS(platformProfile.getOs())) {
-                        profileBuilder.addPlatforms(platformProfile);
-                    }
-                }
-
-                newProfiles.add(profileBuilder.build());
-            }
-
-            // Update profiles list with new filtered one
-            // Now it should only contain profiles with platform entries
-            // relevant for the target platform...
-            texProfilesBuilder.clearProfiles();
-            texProfilesBuilder.addAllProfiles(newProfiles);
-
-
-            // Add the current texture profiles to the project, since this
-            // needs to be reachedable by the TextureGenerator.
-            TextureProfiles textureProfiles = texProfilesBuilder.build();
-            project.setTextureProfiles(textureProfiles);
-            TimeProfiler.stop();
-        }
+        String textureProfilesPath = project.getProjectProperties().getStringValue("graphics", "texture_profiles", "/builtins/graphics/default.texture_profiles");
+        createSubTask(textureProfilesPath, "", builder);
 
         return builder.build();
     }
@@ -364,7 +318,7 @@ public class GameProjectBuilder extends Builder {
     }
 
     // Used to transform an input game.project properties map to a game.projectc representation.
-    // Can be used for doing build time properties conversion.
+    // Can be used for doing build time properties' conversion.
     static public void transformGameProjectFile(BobProjectProperties properties) {
         properties.removePrivateFields();
 

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/TextureBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/TextureBuilder.java
@@ -40,12 +40,7 @@ public class TextureBuilder extends Builder {
                 .addInput(input)
                 .addOutput(input.changeExt(params.outExt()));
 
-        // If there is a texture profiles file, we need to make sure
-        // it has been read before building this tile set, add it as an input.
-        String textureProfilesPath = this.project.getProjectProperties().getStringValue("graphics", "texture_profiles");
-        if (textureProfilesPath != null) {
-            taskBuilder.addInput(this.project.getResource(textureProfilesPath));
-        }
+        TextureUtil.addTextureProfileInput(taskBuilder, project);
 
         return taskBuilder.build();
     }
@@ -54,7 +49,7 @@ public class TextureBuilder extends Builder {
     public void build(Task task) throws CompileExceptionError,
             IOException {
 
-        TextureProfile texProfile = TextureUtil.getTextureProfileByPath(this.project.getTextureProfiles(), task.firstInput().getPath());
+        TextureProfile texProfile = TextureUtil.getTextureProfileByPath(task.lastInput(), task.firstInput().getPath());
         logger.fine("Compiling %s using profile %s", task.firstInput().getPath(), texProfile!=null?texProfile.getName():"<none>");
 
         ByteArrayInputStream is = new ByteArrayInputStream(task.firstInput().getContent());

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/TextureProfilesBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/TextureProfilesBuilder.java
@@ -1,0 +1,60 @@
+package com.dynamo.bob.pipeline;
+
+import com.dynamo.bob.BuilderParams;
+import com.dynamo.bob.CompileExceptionError;
+import com.dynamo.bob.Platform;
+import com.dynamo.bob.ProtoBuilder;
+import com.dynamo.bob.ProtoParams;
+import com.dynamo.bob.Task;
+import com.dynamo.bob.fs.IResource;
+import com.dynamo.graphics.proto.Graphics;
+
+import java.io.IOException;
+import java.util.LinkedList;
+import java.util.List;
+
+@ProtoParams(srcClass = Graphics.TextureProfiles.class, messageClass = Graphics.TextureProfiles.class)
+@BuilderParams(name = "TextureProfile", inExts = {".texture_profiles"}, outExt = ".texture_profilesc")
+public class TextureProfilesBuilder extends ProtoBuilder<Graphics.TextureProfiles.Builder> {
+
+    public void build(Task task) throws CompileExceptionError, IOException {
+        Graphics.TextureProfiles.Builder texProfilesBuilder = Graphics.TextureProfiles.newBuilder();
+        IResource texProfilesInput = task.firstInput();
+        ProtoUtil.merge(texProfilesInput, texProfilesBuilder);
+
+        // If Bob is building for a specific platform, we need to
+        // filter out any platform entries not relevant to the target platform.
+        // (i.e. we don't want win32 specific profiles lingering in android bundles)
+        Platform targetPlatform = project.getPlatform();
+
+        List<Graphics.TextureProfile> newProfiles = new LinkedList<Graphics.TextureProfile>();
+        for (int i = 0; i < texProfilesBuilder.getProfilesCount(); i++) {
+
+            Graphics.TextureProfile profile = texProfilesBuilder.getProfiles(i);
+            Graphics.TextureProfile.Builder profileBuilder = Graphics.TextureProfile.newBuilder();
+            profileBuilder.mergeFrom(profile);
+            profileBuilder.clearPlatforms();
+
+            // Take only the platforms that matches the target platform
+            for (Graphics.PlatformProfile platformProfile : profile.getPlatformsList()) {
+                if (targetPlatform.matchesOS(platformProfile.getOs())) {
+                    profileBuilder.addPlatforms(platformProfile);
+                }
+            }
+
+            newProfiles.add(profileBuilder.build());
+        }
+
+        // Update profiles list with new filtered one
+        // Now it should only contain profiles with platform entries
+        // relevant for the target platform...
+        texProfilesBuilder.clearProfiles();
+        texProfilesBuilder.addAllProfiles(newProfiles);
+
+        // Add the current texture profiles to the project, since this
+        // needs to be reachedable by the TextureGenerator.
+        Graphics.TextureProfiles textureProfiles = texProfilesBuilder.build();
+
+        task.output(0).setContent(textureProfiles.toByteArray());
+    }
+}

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/TileSetBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/TileSetBuilder.java
@@ -66,12 +66,7 @@ public class TileSetBuilder extends ProtoBuilder<TileSet.Builder> {
                 taskBuilder.addInput(collision);
             }
 
-            // If there is a texture profiles file, we need to make sure
-            // it has been read before building this tile set, add it as an input.
-            String textureProfilesPath = this.project.getProjectProperties().getStringValue("graphics", "texture_profiles");
-            if (textureProfilesPath != null) {
-                taskBuilder.addInput(this.project.getResource(textureProfilesPath));
-            }
+            TextureUtil.addTextureProfileInput(taskBuilder, project);
 
             return taskBuilder.build();
         } else {
@@ -91,7 +86,7 @@ public class TileSetBuilder extends ProtoBuilder<TileSet.Builder> {
     public void build(Task task) throws CompileExceptionError,
             IOException {
 
-        TextureProfile texProfile = TextureUtil.getTextureProfileByPath(this.project.getTextureProfiles(), task.firstInput().getPath());
+        TextureProfile texProfile = TextureUtil.getTextureProfileByPath(task.lastInput(), task.firstInput().getPath());
         logger.fine("Compiling %s using profile %s", task.firstInput().getPath(), texProfile!=null?texProfile.getName():"<none>");
 
         TileSet.Builder builder = getSrcBuilder(task.firstInput());


### PR DESCRIPTION
We already have a dependency graph that checks signatures, protocol file formats, output data, etc., as part of the signature, making our cache invalidation more robust.  

I also want `texture_profiles` to be part of this system to ensure that if `texture_profiles` change (as an input for textures), the textures are rebuilt accordingly.  

This step is necessary to fix [issue #10217](https://github.com/defold/defold/issues/10217).  