### PR TITLE
Add a wrapper api for our profiler properties

### DIFF
--- a/engine/dlib/src/dlib/message.cpp
+++ b/engine/dlib/src/dlib/message.cpp
@@ -27,7 +27,7 @@
 #include <dlib/profile/profile.h>
 
 DM_PROPERTY_GROUP(rmtp_Message, "dmMessage", 0);
-DM_PROPERTY_U32(rmtp_Messages, 0, PPF_FRAME_RESET, "# messages/frame", &rmtp_Message);
+DM_PROPERTY_U32(rmtp_Messages, 0, PROFILE_PROPERTY_FRAME_RESET, "# messages/frame", &rmtp_Message);
 
 namespace dmMessage
 {

--- a/engine/dlib/src/dlib/message.cpp
+++ b/engine/dlib/src/dlib/message.cpp
@@ -26,8 +26,8 @@
 #include <dlib/spinlock.h>
 #include <dlib/profile/profile.h>
 
-DM_PROPERTY_GROUP(rmtp_Message, "dmMessage");
-DM_PROPERTY_U32(rmtp_Messages, 0, FrameReset, "# messages/frame", &rmtp_Message);
+DM_PROPERTY_GROUP(rmtp_Message, "dmMessage", 0);
+DM_PROPERTY_U32(rmtp_Messages, 0, PPF_FRAME_RESET, "# messages/frame", &rmtp_Message);
 
 namespace dmMessage
 {

--- a/engine/dlib/src/dlib/profile/profile_null.cpp
+++ b/engine/dlib/src/dlib/profile/profile_null.cpp
@@ -193,3 +193,127 @@ namespace dmProfile
 
 } // namespace dmProfile
 
+
+dmProfilePropertyIdx dmProfileCreatePropertyGroup(const char* name, const char* desc, dmProfilePropertyIdx* parentidx)
+{
+    return DM_PROFILE_PROPERTY_INVALID_IDX;
+}
+
+dmProfilePropertyIdx dmProfileCreatePropertyBool(const char* name, const char* desc, int value, uint32_t flags, dmProfilePropertyIdx* parentidx)
+{
+    return DM_PROFILE_PROPERTY_INVALID_IDX;
+}
+
+dmProfilePropertyIdx dmProfileCreatePropertyS32(const char* name, const char* desc, int32_t value, uint32_t flags, dmProfilePropertyIdx* parentidx)
+{
+    return DM_PROFILE_PROPERTY_INVALID_IDX;
+}
+
+dmProfilePropertyIdx dmProfileCreatePropertyU32(const char* name, const char* desc, uint32_t value, uint32_t flags, dmProfilePropertyIdx* parentidx)
+{
+    return DM_PROFILE_PROPERTY_INVALID_IDX;
+}
+
+dmProfilePropertyIdx dmProfileCreatePropertyF32(const char* name, const char* desc, float value, uint32_t flags, dmProfilePropertyIdx* parentidx)
+{
+    return DM_PROFILE_PROPERTY_INVALID_IDX;
+}
+
+dmProfilePropertyIdx dmProfileCreatePropertyS64(const char* name, const char* desc, int64_t value, uint32_t flags, dmProfilePropertyIdx* parentidx)
+{
+    return DM_PROFILE_PROPERTY_INVALID_IDX;
+}
+
+dmProfilePropertyIdx dmProfileCreatePropertyU64(const char* name, const char* desc, uint64_t value, uint32_t flags, dmProfilePropertyIdx* parentidx)
+{
+    return DM_PROFILE_PROPERTY_INVALID_IDX;
+}
+
+dmProfilePropertyIdx dmProfileCreatePropertyF64(const char* name, const char* desc, double value, uint32_t flags, dmProfilePropertyIdx* parentidx)
+{
+    return DM_PROFILE_PROPERTY_INVALID_IDX;
+}
+
+void dmProfilePropertySetBool(dmProfilePropertyIdx idx, int v)
+{
+    (void)idx;
+    (void)v;
+}
+
+void dmProfilePropertySetS32(dmProfilePropertyIdx idx, int32_t v)
+{
+    (void)idx;
+    (void)v;
+}
+
+void dmProfilePropertySetU32(dmProfilePropertyIdx idx, uint32_t v)
+{
+    (void)idx;
+    (void)v;
+}
+
+void dmProfilePropertySetF32(dmProfilePropertyIdx idx, float v)
+{
+    (void)idx;
+    (void)v;
+}
+
+void dmProfilePropertySetS64(dmProfilePropertyIdx idx, int64_t v)
+{
+    (void)idx;
+    (void)v;
+}
+
+void dmProfilePropertySetU64(dmProfilePropertyIdx idx, uint64_t v)
+{
+    (void)idx;
+    (void)v;
+}
+
+void dmProfilePropertySetF64(dmProfilePropertyIdx idx, double v)
+{
+    (void)idx;
+    (void)v;
+}
+
+void dmProfilePropertyAddS32(dmProfilePropertyIdx idx, int32_t v)
+{
+    (void)idx;
+    (void)v;
+}
+
+void dmProfilePropertyAddU32(dmProfilePropertyIdx idx, uint32_t v)
+{
+    (void)idx;
+    (void)v;
+}
+
+void dmProfilePropertyAddF32(dmProfilePropertyIdx idx, float v)
+{
+    (void)idx;
+    (void)v;
+}
+
+void dmProfilePropertyAddS64(dmProfilePropertyIdx idx, int64_t v)
+{
+    (void)idx;
+    (void)v;
+}
+
+void dmProfilePropertyAddU64(dmProfilePropertyIdx idx, uint64_t v)
+{
+    (void)idx;
+    (void)v;
+}
+
+void dmProfilePropertyAddF64(dmProfilePropertyIdx idx, double v)
+{
+    (void)idx;
+    (void)v;
+}
+
+void dmProfilePropertyReset(dmProfilePropertyIdx idx)
+{
+    (void)idx;
+}
+

--- a/engine/dlib/src/dlib/profile/profile_remotery.cpp
+++ b/engine/dlib/src/dlib/profile/profile_remotery.cpp
@@ -484,7 +484,7 @@ static void SetupProperty(rmtProperty* prop, const char* name, const char* desc,
 {
     memset(prop, 0, sizeof(rmtProperty));
     prop->initialised    = RMT_FALSE;
-    prop->flags          = (flags == PPF_FRAME_RESET) ? RMT_PropertyFlags_FrameReset : RMT_PropertyFlags_NoFlags;
+    prop->flags          = (flags == PROFILE_PROPERTY_FRAME_RESET) ? RMT_PropertyFlags_FrameReset : RMT_PropertyFlags_NoFlags;
     prop->name           = name;
     prop->description    = desc;
     prop->parent         = parentidx ? GetPropertyFromIdx(*parentidx) : 0;

--- a/engine/dlib/src/dlib/profile/profile_remotery.cpp
+++ b/engine/dlib/src/dlib/profile/profile_remotery.cpp
@@ -21,14 +21,10 @@
 #include "dlib/log.h"
 #include "dlib/atomic.h"
 #include "dlib/spinlock.h"
-#include "dlib/static_assert.h"
 
 #include "dlib/hash.h"
 
 #include "dmsdk/external/remotery/Remotery.h"
-#include "dmsdk/external/remotery/Remotery.h"
-
-// DM_STATIC_ASSERT(sizeof(rmtProperty) <= DM_PROFILE_PROPERTY_MEM_SIZE, "Struct is too small!");
 
 namespace dmProfile
 {

--- a/engine/dlib/src/dlib/profile/profile_remotery.cpp
+++ b/engine/dlib/src/dlib/profile/profile_remotery.cpp
@@ -21,10 +21,14 @@
 #include "dlib/log.h"
 #include "dlib/atomic.h"
 #include "dlib/spinlock.h"
+#include "dlib/static_assert.h"
 
 #include "dlib/hash.h"
 
 #include "dmsdk/external/remotery/Remotery.h"
+#include "dmsdk/external/remotery/Remotery.h"
+
+// DM_STATIC_ASSERT(sizeof(rmtProperty) <= DM_PROFILE_PROPERTY_MEM_SIZE, "Struct is too small!");
 
 namespace dmProfile
 {
@@ -125,17 +129,6 @@ namespace dmProfile
         dmAtomicStore32(&g_ProfilerInitialized, 1);
 
         dmLogInfo("Initialized Remotery (ws://127.0.0.1:%d/rmt)", settings->port);
-    }
-
-    static inline void WaitForFlag(int32_atomic_t* lock)
-    {
-        while (dmAtomicGet32(lock) == 0) {
-        }
-    }
-
-    static inline void AtomicUnlock(int32_atomic_t* lock)
-    {
-        dmAtomicStore32(lock, 0);
     }
 
     void Finalize()
@@ -460,3 +453,235 @@ namespace dmProfile
 
 
 } // namespace dmProfile
+
+static const uint32_t g_MaxPropertyCount = 256;
+static uint32_t g_PropertyCount = 0;
+static rmtProperty g_Properties[g_MaxPropertyCount];
+
+static rmtProperty* AllocateProperty(dmProfilePropertyIdx* idx)
+{
+    if (g_PropertyCount >= g_MaxPropertyCount)
+        return 0;
+    *idx = g_PropertyCount++;
+    return &g_Properties[*idx];
+}
+
+#define ALLOC_PROP_AND_CHECK() \
+    dmProfilePropertyIdx idx; \
+    rmtProperty* prop = AllocateProperty(&idx); \
+    if (!prop) \
+        return DM_PROFILE_PROPERTY_INVALID_IDX;
+
+static rmtProperty* GetPropertyFromIdx(dmProfilePropertyIdx idx)
+{
+    if (idx < g_PropertyCount || idx == DM_PROFILE_PROPERTY_INVALID_IDX)
+        return 0;
+    return &g_Properties[idx];
+}
+
+#define GET_PROP_AND_CHECK(IDX) \
+    rmtProperty* prop = &g_Properties[IDX]; \
+    if (!prop) \
+        return;
+
+static void SetupProperty(rmtProperty* prop, const char* name, const char* desc, uint32_t flags, dmProfilePropertyIdx* parentidx)
+{
+    memset(prop, 0, sizeof(rmtProperty));
+    prop->initialised    = RMT_FALSE;
+    prop->flags          = (flags == PPF_FRAME_RESET) ? RMT_PropertyFlags_FrameReset : RMT_PropertyFlags_NoFlags;
+    prop->name           = name;
+    prop->description    = desc;
+    prop->parent         = parentidx ? GetPropertyFromIdx(*parentidx) : 0;
+}
+
+dmProfilePropertyIdx dmProfileCreatePropertyGroup(const char* name, const char* desc, dmProfilePropertyIdx* parentidx)
+{
+    ALLOC_PROP_AND_CHECK();
+    SetupProperty(prop, name, desc, RMT_PropertyFlags_NoFlags, parentidx);
+    prop->type = RMT_PropertyType_rmtGroup;
+    return idx;
+}
+
+dmProfilePropertyIdx dmProfileCreatePropertyBool(const char* name, const char* desc, int value, uint32_t flags, dmProfilePropertyIdx* parentidx)
+{
+    ALLOC_PROP_AND_CHECK();
+    SetupProperty(prop, name, desc, flags, parentidx);
+    prop->type           = RMT_PropertyType_rmtBool;
+    prop->value          = rmtPropertyValue::MakeBool((rmtBool)value);
+    prop->lastFrameValue = prop->value;
+    prop->defaultValue   = prop->value;
+    return idx;
+}
+
+dmProfilePropertyIdx dmProfileCreatePropertyS32(const char* name, const char* desc, int32_t value, uint32_t flags, dmProfilePropertyIdx* parentidx)
+{
+    ALLOC_PROP_AND_CHECK();
+    SetupProperty(prop, name, desc, flags, parentidx);
+    prop->type           = RMT_PropertyType_rmtS32;
+    prop->value          = rmtPropertyValue::MakeS32(value);
+    prop->lastFrameValue = prop->value;
+    prop->defaultValue   = prop->value;
+    return idx;
+}
+
+dmProfilePropertyIdx dmProfileCreatePropertyU32(const char* name, const char* desc, uint32_t value, uint32_t flags, dmProfilePropertyIdx* parentidx)
+{
+    ALLOC_PROP_AND_CHECK();
+    SetupProperty(prop, name, desc, flags, parentidx);
+    prop->type           = RMT_PropertyType_rmtU32;
+    prop->value          = rmtPropertyValue::MakeU32(value);
+    prop->lastFrameValue = prop->value;
+    prop->defaultValue   = prop->value;
+    return idx;
+}
+
+dmProfilePropertyIdx dmProfileCreatePropertyF32(const char* name, const char* desc, float value, uint32_t flags, dmProfilePropertyIdx* parentidx)
+{
+    ALLOC_PROP_AND_CHECK();
+    SetupProperty(prop, name, desc, flags, parentidx);
+    prop->type           = RMT_PropertyType_rmtF32;
+    prop->value          = rmtPropertyValue::MakeF32(value);
+    prop->lastFrameValue = prop->value;
+    prop->defaultValue   = prop->value;
+    return idx;
+}
+
+dmProfilePropertyIdx dmProfileCreatePropertyS64(const char* name, const char* desc, int64_t value, uint32_t flags, dmProfilePropertyIdx* parentidx)
+{
+    ALLOC_PROP_AND_CHECK();
+    SetupProperty(prop, name, desc, flags, parentidx);
+    prop->type           = RMT_PropertyType_rmtS64;
+    prop->value          = rmtPropertyValue::MakeS64(value);
+    prop->lastFrameValue = prop->value;
+    prop->defaultValue   = prop->value;
+    return idx;
+}
+
+dmProfilePropertyIdx dmProfileCreatePropertyU64(const char* name, const char* desc, uint64_t value, uint32_t flags, dmProfilePropertyIdx* parentidx)
+{
+    ALLOC_PROP_AND_CHECK();
+    SetupProperty(prop, name, desc, flags, parentidx);
+    prop->type           = RMT_PropertyType_rmtU64;
+    prop->value          = rmtPropertyValue::MakeU64(value);
+    prop->lastFrameValue = prop->value;
+    prop->defaultValue   = prop->value;
+    return idx;
+}
+
+dmProfilePropertyIdx dmProfileCreatePropertyF64(const char* name, const char* desc, double value, uint32_t flags, dmProfilePropertyIdx* parentidx)
+{
+    ALLOC_PROP_AND_CHECK();
+    SetupProperty(prop, name, desc, flags, parentidx);
+    prop->type           = RMT_PropertyType_rmtF64;
+    prop->value          = rmtPropertyValue::MakeF64(value);
+    prop->lastFrameValue = prop->value;
+    prop->defaultValue   = prop->value;
+    return idx;
+}
+
+// See _rmt_PropertySet
+void dmProfilePropertySetBool(dmProfilePropertyIdx idx, int v)
+{
+    GET_PROP_AND_CHECK(idx);
+    prop->value.Bool = (rmtBool)v;
+    _rmt_PropertySetValue(prop);
+}
+
+void dmProfilePropertySetS32(dmProfilePropertyIdx idx, int32_t v)
+{
+    GET_PROP_AND_CHECK(idx);
+    prop->value.S32 = v;
+    _rmt_PropertySetValue(prop);
+}
+
+void dmProfilePropertySetU32(dmProfilePropertyIdx idx, uint32_t v)
+{
+    GET_PROP_AND_CHECK(idx);
+    prop->value.U32 = v;
+    _rmt_PropertySetValue(prop);
+}
+
+void dmProfilePropertySetF32(dmProfilePropertyIdx idx, float v)
+{
+    GET_PROP_AND_CHECK(idx);
+    prop->value.F32 = v;
+    _rmt_PropertySetValue(prop);
+}
+
+void dmProfilePropertySetS64(dmProfilePropertyIdx idx, int64_t v)
+{
+    GET_PROP_AND_CHECK(idx);
+    prop->value.S64 = v;
+    _rmt_PropertySetValue(prop);
+}
+
+void dmProfilePropertySetU64(dmProfilePropertyIdx idx, uint64_t v)
+{
+    GET_PROP_AND_CHECK(idx);
+    prop->value.U64 = v;
+    _rmt_PropertySetValue(prop);
+}
+void dmProfilePropertySetF64(dmProfilePropertyIdx idx, double v)
+{
+    GET_PROP_AND_CHECK(idx);
+    prop->value.F64 = v;
+    _rmt_PropertySetValue(prop);
+}
+
+// See _rmt_PropertyAdd
+void dmProfilePropertyAddS32(dmProfilePropertyIdx idx, int32_t v)
+{
+    GET_PROP_AND_CHECK(idx);
+    prop->value.S32 += v;
+    rmtPropertyValue delta_value = rmtPropertyValue::MakeS32(v);
+    _rmt_PropertyAddValue(prop, delta_value);
+}
+
+void dmProfilePropertyAddU32(dmProfilePropertyIdx idx, uint32_t v)
+{
+    GET_PROP_AND_CHECK(idx);
+    prop->value.U32 += v;
+    rmtPropertyValue delta_value = rmtPropertyValue::MakeU32(v);
+    _rmt_PropertyAddValue(prop, delta_value);
+}
+
+void dmProfilePropertyAddF32(dmProfilePropertyIdx idx, float v)
+{
+    GET_PROP_AND_CHECK(idx);
+    prop->value.F32 += v;
+    rmtPropertyValue delta_value = rmtPropertyValue::MakeF32(v);
+    _rmt_PropertyAddValue(prop, delta_value);
+}
+
+void dmProfilePropertyAddS64(dmProfilePropertyIdx idx, int64_t v)
+{
+    GET_PROP_AND_CHECK(idx);
+    prop->value.S64 += v;
+    rmtPropertyValue delta_value = rmtPropertyValue::MakeS64(v);
+    _rmt_PropertyAddValue(prop, delta_value);
+}
+
+void dmProfilePropertyAddU64(dmProfilePropertyIdx idx, uint64_t v)
+{
+    GET_PROP_AND_CHECK(idx);
+    prop->value.U64 += v;
+    rmtPropertyValue delta_value = rmtPropertyValue::MakeU64(v);
+    _rmt_PropertyAddValue(prop, delta_value);
+}
+
+void dmProfilePropertyAddF64(dmProfilePropertyIdx idx, double v)
+{
+    GET_PROP_AND_CHECK(idx);
+    prop->value.F64 += v;
+    rmtPropertyValue delta_value = rmtPropertyValue::MakeF64(v);
+    _rmt_PropertyAddValue(prop, delta_value);
+}
+
+// See rmt_PropertyReset
+void dmProfilePropertyReset(dmProfilePropertyIdx idx)
+{
+    GET_PROP_AND_CHECK(idx);
+    prop->value = prop->defaultValue;
+    _rmt_PropertySetValue(prop);
+}
+

--- a/engine/dlib/src/dmsdk/dlib/profile.h
+++ b/engine/dlib/src/dmsdk/dlib/profile.h
@@ -108,7 +108,7 @@
  *
  * ```cpp
  * DM_PROPERTY_EXTERN(rmtp_GameObject);
- * DM_PROPERTY_U32(rmtp_ComponentsAnim, 0, PPF_FRAME_RESET, "#", &rmtp_GameObject);
+ * DM_PROPERTY_U32(rmtp_ComponentsAnim, 0, PROFILE_PROPERTY_FRAME_RESET, "#", &rmtp_GameObject);
  * ```
  */
 #define DM_PROPERTY_EXTERN(name)
@@ -139,14 +139,14 @@
  * @name DM_PROPERTY_BOOL
  * @param name [type:symbol] The property symbol/name
  * @param default [type:bool] The default value
- * @param flags [type:uint32_t] The flags. Either `PPF_FRAME_NONE` or `PPF_FRAME_RESET`. `PPF_FRAME_RESET` makes the value reset each frame.
+ * @param flags [type:uint32_t] The flags. Either `PROFILE_PROPERTY_NONE` or `PROFILE_PROPERTY_FRAME_RESET`. `PROFILE_PROPERTY_FRAME_RESET` makes the value reset each frame.
  * @param desc [type:const char*] The description
  * @param group [type: dmProfilePropertyIdx*] The parent group. May be 0.
  *
  * @examples
  *
  * ```cpp
- * DM_PROPERTY_BOOL(rmtp_MyBool, 0, PPF_FRAME_RESET, "true or false", &rmtp_MyGroup);
+ * DM_PROPERTY_BOOL(rmtp_MyBool, 0, PROFILE_PROPERTY_FRAME_RESET, "true or false", &rmtp_MyGroup);
  * ```
  */
 #define DM_PROPERTY_BOOL(name, default_value, flag, desc, parent)
@@ -159,14 +159,14 @@
  * @name DM_PROPERTY_S32
  * @param name [type:symbol] The property symbol/name
  * @param default [type:int32_t] The default value
- * @param flags [type:uint32_t] The flags. Either `PPF_FRAME_NONE` or `PPF_FRAME_RESET`. `PPF_FRAME_RESET` makes the value reset each frame.
+ * @param flags [type:uint32_t] The flags. Either `PROFILE_PROPERTY_NONE` or `PROFILE_PROPERTY_FRAME_RESET`. `PROFILE_PROPERTY_FRAME_RESET` makes the value reset each frame.
  * @param desc [type:const char*] The description
  * @param group [type: dmProfilePropertyIdx*] The parent group. May be 0.
  *
  * @examples
  *
  * ```cpp
- * DM_PROPERTY_S32(rmtp_MyValue, 0, PPF_FRAME_RESET, "a value", &rmtp_MyGroup);
+ * DM_PROPERTY_S32(rmtp_MyValue, 0, PROFILE_PROPERTY_FRAME_RESET, "a value", &rmtp_MyGroup);
  * ```
  */
 #define DM_PROPERTY_S32(name, default_value, flag, desc, parent)
@@ -179,14 +179,14 @@
  * @name DM_PROPERTY_U32
  * @param name [type:symbol] The property symbol/name
  * @param default [type:uint32_t] The default value
- * @param flags [type:uint32_t] The flags. Either `PPF_FRAME_NONE` or `PPF_FRAME_RESET`. `PPF_FRAME_RESET` makes the value reset each frame.
+ * @param flags [type:uint32_t] The flags. Either `PROFILE_PROPERTY_NONE` or `PROFILE_PROPERTY_FRAME_RESET`. `PROFILE_PROPERTY_FRAME_RESET` makes the value reset each frame.
  * @param desc [type:const char*] The description
  * @param group [type: dmProfilePropertyIdx*] The parent group. May be 0.
  *
  * @examples
  *
  * ```cpp
- * DM_PROPERTY_U32(rmtp_MyValue, 0, PPF_FRAME_RESET, "a value", &rmtp_MyGroup);
+ * DM_PROPERTY_U32(rmtp_MyValue, 0, PROFILE_PROPERTY_FRAME_RESET, "a value", &rmtp_MyGroup);
  * ```
  */
 #define DM_PROPERTY_U32(name, default_value, flag, desc, parent)
@@ -199,14 +199,14 @@
  * @name DM_PROPERTY_F32
  * @param name [type:symbol] The property symbol/name
  * @param default [type:float] The default value
- * @param flags [type:uint32_t] The flags. Either `PPF_FRAME_NONE` or `PPF_FRAME_RESET`. `PPF_FRAME_RESET` makes the value reset each frame.
+ * @param flags [type:uint32_t] The flags. Either `PROFILE_PROPERTY_NONE` or `PROFILE_PROPERTY_FRAME_RESET`. `PROFILE_PROPERTY_FRAME_RESET` makes the value reset each frame.
  * @param desc [type:const char*] The description
  * @param group [type: dmProfilePropertyIdx*] The parent group. May be 0.
  *
  * @examples
  *
  * ```cpp
- * DM_PROPERTY_F32(rmtp_MyValue, 0, PPF_FRAME_RESET, "a value", &rmtp_MyGroup);
+ * DM_PROPERTY_F32(rmtp_MyValue, 0, PROFILE_PROPERTY_FRAME_RESET, "a value", &rmtp_MyGroup);
  * ```
  */
 #define DM_PROPERTY_F32(name, default_value, flag, desc, parent)
@@ -219,14 +219,14 @@
  * @name DM_PROPERTY_S64
  * @param name [type:symbol] The property symbol/name
  * @param default [type:int64_t] The default value
- * @param flags [type:uint32_t] The flags. Either `PPF_FRAME_NONE` or `PPF_FRAME_RESET`. `PPF_FRAME_RESET` makes the value reset each frame.
+ * @param flags [type:uint32_t] The flags. Either `PROFILE_PROPERTY_NONE` or `PROFILE_PROPERTY_FRAME_RESET`. `PROFILE_PROPERTY_FRAME_RESET` makes the value reset each frame.
  * @param desc [type:const char*] The description
  * @param group [type: dmProfilePropertyIdx*] The parent group. May be 0.
  *
  * @examples
  *
  * ```cpp
- * DM_PROPERTY_S64(rmtp_MyValue, 0, PPF_FRAME_RESET, "a value", &rmtp_MyGroup);
+ * DM_PROPERTY_S64(rmtp_MyValue, 0, PROFILE_PROPERTY_FRAME_RESET, "a value", &rmtp_MyGroup);
  * ```
  */
 #define DM_PROPERTY_S64(name, default_value, flag, desc, parent)
@@ -240,14 +240,14 @@
  * @name DM_PROPERTY_U64
  * @param name [type:symbol] The property symbol/name
  * @param default [type:uint64_t] The default value
- * @param flags [type:uint32_t] The flags. Either `PPF_FRAME_NONE` or `PPF_FRAME_RESET`. `PPF_FRAME_RESET` makes the value reset each frame.
+ * @param flags [type:uint32_t] The flags. Either `PROFILE_PROPERTY_NONE` or `PROFILE_PROPERTY_FRAME_RESET`. `PROFILE_PROPERTY_FRAME_RESET` makes the value reset each frame.
  * @param desc [type:const char*] The description
  * @param group [type: dmProfilePropertyIdx*] The parent group. May be 0.
  *
  * @examples
  *
  * ```cpp
- * DM_PROPERTY_U64(rmtp_MyValue, 0, PPF_FRAME_RESET, "a value", &rmtp_MyGroup);
+ * DM_PROPERTY_U64(rmtp_MyValue, 0, PROFILE_PROPERTY_FRAME_RESET, "a value", &rmtp_MyGroup);
  * ```
  */
 #define DM_PROPERTY_U64(name, default_value, flag, desc, parent)
@@ -260,14 +260,14 @@
  * @name DM_PROPERTY_F64
  * @param name [type:symbol] The property symbol/name
  * @param default [type:double] The default value
- * @param flags [type:uint32_t] The flags. Either `PPF_FRAME_NONE` or `PPF_FRAME_RESET`. `PPF_FRAME_RESET` makes the value reset each frame.
+ * @param flags [type:uint32_t] The flags. Either `PROFILE_PROPERTY_NONE` or `PROFILE_PROPERTY_FRAME_RESET`. `PROFILE_PROPERTY_FRAME_RESET` makes the value reset each frame.
  * @param desc [type:const char*] The description
  * @param group [type: dmProfilePropertyIdx*] The parent group. May be 0.
  *
  * @examples
  *
  * ```cpp
- * DM_PROPERTY_F64(rmtp_MyValue, 0, PPF_FRAME_RESET, "a value", &rmtp_MyGroup);
+ * DM_PROPERTY_F64(rmtp_MyValue, 0, PROFILE_PROPERTY_FRAME_RESET, "a value", &rmtp_MyGroup);
  * ```
  */
 #define DM_PROPERTY_F64(name, default_value, flag, desc, parent)
@@ -533,8 +533,8 @@ void dmProfilePropertyReset(dmProfilePropertyIdx idx);
 
 enum ProfilePropertyFlags
 {
-    PPF_NONE = 0,
-    PPF_FRAME_RESET = 1  // reset the property each frame
+    PROFILE_PROPERTY_NONE = 0,
+    PROFILE_PROPERTY_FRAME_RESET = 1  // reset the property each frame
 };
 
 #if defined(NDEBUG) || defined(DM_PROFILE_NULL)

--- a/engine/dlib/src/dmsdk/dlib/profile.h
+++ b/engine/dlib/src/dmsdk/dlib/profile.h
@@ -26,8 +26,6 @@
 
 #include <stdint.h>
 
-#include <dmsdk/external/remotery/Remotery.h> // Private, don't use this api directly!
-
 /*# add profile scope
  *
  * Adds a profiling scope. Excluded by default in release builds.
@@ -110,7 +108,7 @@
  *
  * ```cpp
  * DM_PROPERTY_EXTERN(rmtp_GameObject);
- * DM_PROPERTY_U32(rmtp_ComponentsAnim, 0, FrameReset, "#", &rmtp_GameObject);
+ * DM_PROPERTY_U32(rmtp_ComponentsAnim, 0, PPF_FRAME_RESET, "#", &rmtp_GameObject);
  * ```
  */
 #define DM_PROPERTY_EXTERN(name)
@@ -123,11 +121,12 @@
  * @name DM_PROPERTY_GROUP
  * @param name [type:symbol] The group name
  * @param desc [type:const char*] The description
+ * @param parent [type: dmProfilePropertyIdx*] pointer to parent property
  *
  * @examples
  *
  * ```cpp
- * DM_PROPERTY_GROUP(rmtp_GameObject, "My Group");
+ * DM_PROPERTY_GROUP(rmtp_GameObject, "My Group", 0);
  * ```
  */
 #define DM_PROPERTY_GROUP(name, desc)
@@ -140,17 +139,17 @@
  * @name DM_PROPERTY_BOOL
  * @param name [type:symbol] The property symbol/name
  * @param default [type:bool] The default value
- * @param flags [type:uint32_t] The flags. Either `NoFlags` or `FrameReset`. `FrameReset` makes the value reset each frame.
+ * @param flags [type:uint32_t] The flags. Either `PPF_FRAME_NONE` or `PPF_FRAME_RESET`. `PPF_FRAME_RESET` makes the value reset each frame.
  * @param desc [type:const char*] The description
- * @param group [type:property*] [optional] The parent group
+ * @param group [type: dmProfilePropertyIdx*] The parent group. May be 0.
  *
  * @examples
  *
  * ```cpp
- * DM_PROPERTY_BOOL(rmtp_MyBool, 0, FrameReset, "true or false", &rmtp_MyGroup);
+ * DM_PROPERTY_BOOL(rmtp_MyBool, 0, PPF_FRAME_RESET, "true or false", &rmtp_MyGroup);
  * ```
  */
-#define DM_PROPERTY_BOOL(name, default_value, flag, desc, ...)
+#define DM_PROPERTY_BOOL(name, default_value, flag, desc, parent)
 #undef DM_PROPERTY_BOOL
 
 /*# int32_t property
@@ -160,17 +159,17 @@
  * @name DM_PROPERTY_S32
  * @param name [type:symbol] The property symbol/name
  * @param default [type:int32_t] The default value
- * @param flags [type:uint32_t] The flags. Either `NoFlags` or `FrameReset`. `FrameReset` makes the value reset each frame.
+ * @param flags [type:uint32_t] The flags. Either `PPF_FRAME_NONE` or `PPF_FRAME_RESET`. `PPF_FRAME_RESET` makes the value reset each frame.
  * @param desc [type:const char*] The description
- * @param group [type:property*] [optional] The parent group
+ * @param group [type: dmProfilePropertyIdx*] The parent group. May be 0.
  *
  * @examples
  *
  * ```cpp
- * DM_PROPERTY_S32(rmtp_MyValue, 0, FrameReset, "a value", &rmtp_MyGroup);
+ * DM_PROPERTY_S32(rmtp_MyValue, 0, PPF_FRAME_RESET, "a value", &rmtp_MyGroup);
  * ```
  */
-#define DM_PROPERTY_S32(name, default_value, flag, desc, ...)
+#define DM_PROPERTY_S32(name, default_value, flag, desc, parent)
 #undef DM_PROPERTY_S32
 
 /*# uint32_t property
@@ -180,17 +179,17 @@
  * @name DM_PROPERTY_U32
  * @param name [type:symbol] The property symbol/name
  * @param default [type:uint32_t] The default value
- * @param flags [type:uint32_t] The flags. Either `NoFlags` or `FrameReset`. `FrameReset` makes the value reset each frame.
+ * @param flags [type:uint32_t] The flags. Either `PPF_FRAME_NONE` or `PPF_FRAME_RESET`. `PPF_FRAME_RESET` makes the value reset each frame.
  * @param desc [type:const char*] The description
- * @param group [type:property*] [optional] The parent group
+ * @param group [type: dmProfilePropertyIdx*] The parent group. May be 0.
  *
  * @examples
  *
  * ```cpp
- * DM_PROPERTY_U32(rmtp_MyValue, 0, FrameReset, "a value", &rmtp_MyGroup);
+ * DM_PROPERTY_U32(rmtp_MyValue, 0, PPF_FRAME_RESET, "a value", &rmtp_MyGroup);
  * ```
  */
-#define DM_PROPERTY_U32(name, default_value, flag, desc, ...)
+#define DM_PROPERTY_U32(name, default_value, flag, desc, parent)
 #undef DM_PROPERTY_U32
 
 /*# float property
@@ -200,17 +199,17 @@
  * @name DM_PROPERTY_F32
  * @param name [type:symbol] The property symbol/name
  * @param default [type:float] The default value
- * @param flags [type:uint32_t] The flags. Either `NoFlags` or `FrameReset`. `FrameReset` makes the value reset each frame.
+ * @param flags [type:uint32_t] The flags. Either `PPF_FRAME_NONE` or `PPF_FRAME_RESET`. `PPF_FRAME_RESET` makes the value reset each frame.
  * @param desc [type:const char*] The description
- * @param group [type:property*] [optional] The parent group
+ * @param group [type: dmProfilePropertyIdx*] The parent group. May be 0.
  *
  * @examples
  *
  * ```cpp
- * DM_PROPERTY_F32(rmtp_MyValue, 0, FrameReset, "a value", &rmtp_MyGroup);
+ * DM_PROPERTY_F32(rmtp_MyValue, 0, PPF_FRAME_RESET, "a value", &rmtp_MyGroup);
  * ```
  */
-#define DM_PROPERTY_F32(name, default_value, flag, desc, ...)
+#define DM_PROPERTY_F32(name, default_value, flag, desc, parent)
 #undef DM_PROPERTY_F32
 
 /*# int64_t property
@@ -220,17 +219,17 @@
  * @name DM_PROPERTY_S64
  * @param name [type:symbol] The property symbol/name
  * @param default [type:int64_t] The default value
- * @param flags [type:uint32_t] The flags. Either `NoFlags` or `FrameReset`. `FrameReset` makes the value reset each frame.
+ * @param flags [type:uint32_t] The flags. Either `PPF_FRAME_NONE` or `PPF_FRAME_RESET`. `PPF_FRAME_RESET` makes the value reset each frame.
  * @param desc [type:const char*] The description
- * @param group [type:property*] [optional] The parent group
+ * @param group [type: dmProfilePropertyIdx*] The parent group. May be 0.
  *
  * @examples
  *
  * ```cpp
- * DM_PROPERTY_S64(rmtp_MyValue, 0, FrameReset, "a value", &rmtp_MyGroup);
+ * DM_PROPERTY_S64(rmtp_MyValue, 0, PPF_FRAME_RESET, "a value", &rmtp_MyGroup);
  * ```
  */
-#define DM_PROPERTY_S64(name, default_value, flag, desc, ...)
+#define DM_PROPERTY_S64(name, default_value, flag, desc, parent)
 #undef DM_PROPERTY_S64
 
 
@@ -241,17 +240,17 @@
  * @name DM_PROPERTY_U64
  * @param name [type:symbol] The property symbol/name
  * @param default [type:uint64_t] The default value
- * @param flags [type:uint32_t] The flags. Either `NoFlags` or `FrameReset`. `FrameReset` makes the value reset each frame.
+ * @param flags [type:uint32_t] The flags. Either `PPF_FRAME_NONE` or `PPF_FRAME_RESET`. `PPF_FRAME_RESET` makes the value reset each frame.
  * @param desc [type:const char*] The description
- * @param group [type:property*] [optional] The parent group
+ * @param group [type: dmProfilePropertyIdx*] The parent group. May be 0.
  *
  * @examples
  *
  * ```cpp
- * DM_PROPERTY_U64(rmtp_MyValue, 0, FrameReset, "a value", &rmtp_MyGroup);
+ * DM_PROPERTY_U64(rmtp_MyValue, 0, PPF_FRAME_RESET, "a value", &rmtp_MyGroup);
  * ```
  */
-#define DM_PROPERTY_U64(name, default_value, flag, desc, ...)
+#define DM_PROPERTY_U64(name, default_value, flag, desc, parent)
 #undef DM_PROPERTY_U64
 
 /*# double property
@@ -261,17 +260,17 @@
  * @name DM_PROPERTY_F64
  * @param name [type:symbol] The property symbol/name
  * @param default [type:double] The default value
- * @param flags [type:uint32_t] The flags. Either `NoFlags` or `FrameReset`. `FrameReset` makes the value reset each frame.
+ * @param flags [type:uint32_t] The flags. Either `PPF_FRAME_NONE` or `PPF_FRAME_RESET`. `PPF_FRAME_RESET` makes the value reset each frame.
  * @param desc [type:const char*] The description
- * @param group [type:property*] [optional] The parent group
+ * @param group [type: dmProfilePropertyIdx*] The parent group. May be 0.
  *
  * @examples
  *
  * ```cpp
- * DM_PROPERTY_F64(rmtp_MyValue, 0, FrameReset, "a value", &rmtp_MyGroup);
+ * DM_PROPERTY_F64(rmtp_MyValue, 0, PPF_FRAME_RESET, "a value", &rmtp_MyGroup);
  * ```
  */
-#define DM_PROPERTY_F64(name, default_value, flag, desc, ...)
+#define DM_PROPERTY_F64(name, default_value, flag, desc, parent)
 #undef DM_PROPERTY_F64
 
 
@@ -498,6 +497,52 @@
 #define DM_PROPERTY_RESET(name)
 #undef DM_PROPERTY_RESET
 
+//  Used to allocate correct memory size without dynamic allocations
+// #define DM_PROFILE_PROPERTY_MEM_SIZE 128
+// struct dmProfileProperty
+// {
+//     uint8_t mem[DM_PROFILE_PROPERTY_MEM_SIZE];
+// };
+
+typedef uint32_t dmProfilePropertyIdx;
+
+// Private
+#define DM_PROFILE_PROPERTY_INVALID_IDX 0xFFFFFFFF
+
+dmProfilePropertyIdx dmProfileCreatePropertyGroup(const char* name, const char* desc, dmProfilePropertyIdx* parent);
+dmProfilePropertyIdx dmProfileCreatePropertyBool(const char* name, const char* desc, int value, uint32_t flags, dmProfilePropertyIdx* parent);
+dmProfilePropertyIdx dmProfileCreatePropertyS32(const char* name, const char* desc, int32_t value, uint32_t flags, dmProfilePropertyIdx* parent);
+dmProfilePropertyIdx dmProfileCreatePropertyU32(const char* name, const char* desc, uint32_t value, uint32_t flags, dmProfilePropertyIdx* parent);
+dmProfilePropertyIdx dmProfileCreatePropertyF32(const char* name, const char* desc, float value, uint32_t flags, dmProfilePropertyIdx* parent);
+dmProfilePropertyIdx dmProfileCreatePropertyS64(const char* name, const char* desc, int64_t value, uint32_t flags, dmProfilePropertyIdx* parent);
+dmProfilePropertyIdx dmProfileCreatePropertyU64(const char* name, const char* desc, uint64_t value, uint32_t flags, dmProfilePropertyIdx* parent);
+dmProfilePropertyIdx dmProfileCreatePropertyF64(const char* name, const char* desc, double value, uint32_t flags, dmProfilePropertyIdx* parent);
+
+void dmProfilePropertySetBool(dmProfilePropertyIdx idx, int v);
+void dmProfilePropertySetS32(dmProfilePropertyIdx idx, int32_t v);
+void dmProfilePropertySetU32(dmProfilePropertyIdx idx, uint32_t v);
+void dmProfilePropertySetF32(dmProfilePropertyIdx idx, float v);
+void dmProfilePropertySetS64(dmProfilePropertyIdx idx, int64_t v);
+void dmProfilePropertySetU64(dmProfilePropertyIdx idx, uint64_t v);
+void dmProfilePropertySetF64(dmProfilePropertyIdx idx, double v);
+
+void dmProfilePropertyAddS32(dmProfilePropertyIdx idx, int32_t v);
+void dmProfilePropertyAddU32(dmProfilePropertyIdx idx, uint32_t v);
+void dmProfilePropertyAddF32(dmProfilePropertyIdx idx, float v);
+void dmProfilePropertyAddS64(dmProfilePropertyIdx idx, int64_t v);
+void dmProfilePropertyAddU64(dmProfilePropertyIdx idx, uint64_t v);
+void dmProfilePropertyAddF64(dmProfilePropertyIdx idx, double v);
+
+void dmProfilePropertyReset(dmProfilePropertyIdx idx);
+
+// Public
+#define DM_PROPERTY_EXTERN(name) extern dmProfilePropertyIdx name;
+
+enum ProfilePropertyFlags
+{
+    PPF_NONE = 0,
+    PPF_FRAME_RESET = 1  // reset the property each frame
+};
 
 #if defined(NDEBUG) || defined(DM_PROFILE_NULL)
     #define DM_PROFILE_TEXT_LENGTH 1024
@@ -505,7 +550,6 @@
     #define DM_PROFILE(name)
     #define DM_PROFILE_DYN(name, name_hash)
 
-    #define DM_PROPERTY_EXTERN(name)                extern rmtProperty name;
     #define DM_PROPERTY_GROUP(name, desc, ...)
     #define DM_PROPERTY_BOOL(name, default_value, flag, desc, ...)
     #define DM_PROPERTY_S32(name, default_value, flag, desc, ...)
@@ -546,37 +590,68 @@
     #define DM_PROFILE_TEXT_LENGTH 1024
     #define DM_PROFILE_TEXT(format, ...)              dmProfile::LogText(format, __VA_ARGS__)
 
+    // // The profiler property api
+    // #define DM_PROPERTY_EXTERN(name)                                rmt_PropertyExtern(name)
+    // #define DM_PROPERTY_GROUP(name, desc, ...)                      rmt_PropertyDefine_Group(name, desc, __VA_ARGS__)
+    // #define DM_PROPERTY_BOOL(name, default_value, flag, desc, ...)  rmt_PropertyDefine_Bool(name, default_value, flag, desc, __VA_ARGS__)
+    // #define DM_PROPERTY_S32(name, default_value, flag, desc, ...)   rmt_PropertyDefine_S32(name, default_value, flag, desc, __VA_ARGS__)
+    // #define DM_PROPERTY_U32(name, default_value, flag, desc, ...)   rmt_PropertyDefine_U32(name, default_value, flag, desc, __VA_ARGS__)
+    // #define DM_PROPERTY_F32(name, default_value, flag, desc, ...)   rmt_PropertyDefine_F32(name, default_value, flag, desc, __VA_ARGS__)
+    // #define DM_PROPERTY_S64(name, default_value, flag, desc, ...)   rmt_PropertyDefine_S64(name, default_value, flag, desc, __VA_ARGS__)
+    // #define DM_PROPERTY_U64(name, default_value, flag, desc, ...)   rmt_PropertyDefine_U64(name, default_value, flag, desc, __VA_ARGS__)
+    // #define DM_PROPERTY_F64(name, default_value, flag, desc, ...)   rmt_PropertyDefine_F64(name, default_value, flag, desc, __VA_ARGS__)
+
+    // // Set properties to the given value
+    // #define DM_PROPERTY_SET_BOOL(name, set_value)   rmt_PropertySet_Bool(name, set_value)
+    // #define DM_PROPERTY_SET_S32(name, set_value)    rmt_PropertySet_S32(name, set_value)
+    // #define DM_PROPERTY_SET_U32(name, set_value)    rmt_PropertySet_U32(name, set_value)
+    // #define DM_PROPERTY_SET_F32(name, set_value)    rmt_PropertySet_F32(name, set_value)
+    // #define DM_PROPERTY_SET_S64(name, set_value)    rmt_PropertySet_S64(name, set_value)
+    // #define DM_PROPERTY_SET_U64(name, set_value)    rmt_PropertySet_U64(name, set_value)
+    // #define DM_PROPERTY_SET_F64(name, set_value)    rmt_PropertySet_F64(name, set_value)
+
+    // // Add the given value to properties
+    // #define DM_PROPERTY_ADD_S32(name, add_value)    rmt_PropertyAdd_S32(name, add_value)
+    // #define DM_PROPERTY_ADD_U32(name, add_value)    rmt_PropertyAdd_U32(name, add_value)
+    // #define DM_PROPERTY_ADD_F32(name, add_value)    rmt_PropertyAdd_F32(name, add_value)
+    // #define DM_PROPERTY_ADD_S64(name, add_value)    rmt_PropertyAdd_S64(name, add_value)
+    // #define DM_PROPERTY_ADD_U64(name, add_value)    rmt_PropertyAdd_U64(name, add_value)
+    // #define DM_PROPERTY_ADD_F64(name, add_value)    rmt_PropertyAdd_F64(name, add_value)
+
+    // #define DM_PROPERTY_RESET(name)                 rmt_PropertyReset(name)
+
     // The profiler property api
-    #define DM_PROPERTY_EXTERN(name)                                rmt_PropertyExtern(name)
-    #define DM_PROPERTY_GROUP(name, desc, ...)                      rmt_PropertyDefine_Group(name, desc, __VA_ARGS__)
-    #define DM_PROPERTY_BOOL(name, default_value, flag, desc, ...)  rmt_PropertyDefine_Bool(name, default_value, flag, desc, __VA_ARGS__)
-    #define DM_PROPERTY_S32(name, default_value, flag, desc, ...)   rmt_PropertyDefine_S32(name, default_value, flag, desc, __VA_ARGS__)
-    #define DM_PROPERTY_U32(name, default_value, flag, desc, ...)   rmt_PropertyDefine_U32(name, default_value, flag, desc, __VA_ARGS__)
-    #define DM_PROPERTY_F32(name, default_value, flag, desc, ...)   rmt_PropertyDefine_F32(name, default_value, flag, desc, __VA_ARGS__)
-    #define DM_PROPERTY_S64(name, default_value, flag, desc, ...)   rmt_PropertyDefine_S64(name, default_value, flag, desc, __VA_ARGS__)
-    #define DM_PROPERTY_U64(name, default_value, flag, desc, ...)   rmt_PropertyDefine_U64(name, default_value, flag, desc, __VA_ARGS__)
-    #define DM_PROPERTY_F64(name, default_value, flag, desc, ...)   rmt_PropertyDefine_F64(name, default_value, flag, desc, __VA_ARGS__)
+    #define DM_PROPERTY_GROUP(name, desc, parent)                       dmProfilePropertyIdx name = dmProfileCreatePropertyGroup(#name, desc, parent)
+    #define DM_PROPERTY_BOOL(name, default_value, flags, desc, parent)  dmProfilePropertyIdx name = dmProfileCreatePropertyBool(#name, desc, default_value, flags, parent)
+    #define DM_PROPERTY_S32(name, default_value, flags, desc, parent)   dmProfilePropertyIdx name = dmProfileCreatePropertyS32(#name, desc, default_value, flags, parent)
+    #define DM_PROPERTY_U32(name, default_value, flags, desc, parent)   dmProfilePropertyIdx name = dmProfileCreatePropertyU32(#name, desc, default_value, flags, parent)
+    #define DM_PROPERTY_F32(name, default_value, flags, desc, parent)   dmProfilePropertyIdx name = dmProfileCreatePropertyF32(#name, desc, default_value, flags, parent)
+    #define DM_PROPERTY_S64(name, default_value, flags, desc, parent)   dmProfilePropertyIdx name = dmProfileCreatePropertyS64(#name, desc, default_value, flags, parent)
+    #define DM_PROPERTY_U64(name, default_value, flags, desc, parent)   dmProfilePropertyIdx name = dmProfileCreatePropertyU64(#name, desc, default_value, flags, parent)
+    #define DM_PROPERTY_F64(name, default_value, flags, desc, parent)   dmProfilePropertyIdx name = dmProfileCreatePropertyF64(#name, desc, default_value, flags, parent)
 
     // Set properties to the given value
-    #define DM_PROPERTY_SET_BOOL(name, set_value)   rmt_PropertySet_Bool(name, set_value)
-    #define DM_PROPERTY_SET_S32(name, set_value)    rmt_PropertySet_S32(name, set_value)
-    #define DM_PROPERTY_SET_U32(name, set_value)    rmt_PropertySet_U32(name, set_value)
-    #define DM_PROPERTY_SET_F32(name, set_value)    rmt_PropertySet_F32(name, set_value)
-    #define DM_PROPERTY_SET_S64(name, set_value)    rmt_PropertySet_S64(name, set_value)
-    #define DM_PROPERTY_SET_U64(name, set_value)    rmt_PropertySet_U64(name, set_value)
-    #define DM_PROPERTY_SET_F64(name, set_value)    rmt_PropertySet_F64(name, set_value)
+    #define DM_PROPERTY_SET_BOOL(name, set_value)   dmProfilePropertySetBool(name, set_value)
+    #define DM_PROPERTY_SET_S32(name, set_value)    dmProfilePropertySetS32(name, set_value)
+    #define DM_PROPERTY_SET_U32(name, set_value)    dmProfilePropertySetU32(name, set_value)
+    #define DM_PROPERTY_SET_F32(name, set_value)    dmProfilePropertySetF32(name, set_value)
+    #define DM_PROPERTY_SET_S64(name, set_value)    dmProfilePropertySetS64(name, set_value)
+    #define DM_PROPERTY_SET_U64(name, set_value)    dmProfilePropertySetU64(name, set_value)
+    #define DM_PROPERTY_SET_F64(name, set_value)    dmProfilePropertySetF64(name, set_value)
 
     // Add the given value to properties
-    #define DM_PROPERTY_ADD_S32(name, add_value)    rmt_PropertyAdd_S32(name, add_value)
-    #define DM_PROPERTY_ADD_U32(name, add_value)    rmt_PropertyAdd_U32(name, add_value)
-    #define DM_PROPERTY_ADD_F32(name, add_value)    rmt_PropertyAdd_F32(name, add_value)
-    #define DM_PROPERTY_ADD_S64(name, add_value)    rmt_PropertyAdd_S64(name, add_value)
-    #define DM_PROPERTY_ADD_U64(name, add_value)    rmt_PropertyAdd_U64(name, add_value)
-    #define DM_PROPERTY_ADD_F64(name, add_value)    rmt_PropertyAdd_F64(name, add_value)
+    #define DM_PROPERTY_ADD_S32(name, add_value)    dmProfilePropertyAddS32(name, add_value)
+    #define DM_PROPERTY_ADD_U32(name, add_value)    dmProfilePropertyAddU32(name, add_value)
+    #define DM_PROPERTY_ADD_F32(name, add_value)    dmProfilePropertyAddF32(name, add_value)
+    #define DM_PROPERTY_ADD_S64(name, add_value)    dmProfilePropertyAddS64(name, add_value)
+    #define DM_PROPERTY_ADD_U64(name, add_value)    dmProfilePropertyAddU64(name, add_value)
+    #define DM_PROPERTY_ADD_F64(name, add_value)    dmProfilePropertyAddF64(name, add_value)
 
-    #define DM_PROPERTY_RESET(name)                 rmt_PropertyReset(name)
+    #define DM_PROPERTY_RESET(name)                 dmProfilePropertyReset(name)
 
 #endif
+
+
 
 namespace dmProfile
 {

--- a/engine/dlib/src/dmsdk/dlib/profile.h
+++ b/engine/dlib/src/dmsdk/dlib/profile.h
@@ -497,13 +497,6 @@
 #define DM_PROPERTY_RESET(name)
 #undef DM_PROPERTY_RESET
 
-//  Used to allocate correct memory size without dynamic allocations
-// #define DM_PROFILE_PROPERTY_MEM_SIZE 128
-// struct dmProfileProperty
-// {
-//     uint8_t mem[DM_PROFILE_PROPERTY_MEM_SIZE];
-// };
-
 typedef uint32_t dmProfilePropertyIdx;
 
 // Private
@@ -589,36 +582,6 @@ enum ProfilePropertyFlags
 
     #define DM_PROFILE_TEXT_LENGTH 1024
     #define DM_PROFILE_TEXT(format, ...)              dmProfile::LogText(format, __VA_ARGS__)
-
-    // // The profiler property api
-    // #define DM_PROPERTY_EXTERN(name)                                rmt_PropertyExtern(name)
-    // #define DM_PROPERTY_GROUP(name, desc, ...)                      rmt_PropertyDefine_Group(name, desc, __VA_ARGS__)
-    // #define DM_PROPERTY_BOOL(name, default_value, flag, desc, ...)  rmt_PropertyDefine_Bool(name, default_value, flag, desc, __VA_ARGS__)
-    // #define DM_PROPERTY_S32(name, default_value, flag, desc, ...)   rmt_PropertyDefine_S32(name, default_value, flag, desc, __VA_ARGS__)
-    // #define DM_PROPERTY_U32(name, default_value, flag, desc, ...)   rmt_PropertyDefine_U32(name, default_value, flag, desc, __VA_ARGS__)
-    // #define DM_PROPERTY_F32(name, default_value, flag, desc, ...)   rmt_PropertyDefine_F32(name, default_value, flag, desc, __VA_ARGS__)
-    // #define DM_PROPERTY_S64(name, default_value, flag, desc, ...)   rmt_PropertyDefine_S64(name, default_value, flag, desc, __VA_ARGS__)
-    // #define DM_PROPERTY_U64(name, default_value, flag, desc, ...)   rmt_PropertyDefine_U64(name, default_value, flag, desc, __VA_ARGS__)
-    // #define DM_PROPERTY_F64(name, default_value, flag, desc, ...)   rmt_PropertyDefine_F64(name, default_value, flag, desc, __VA_ARGS__)
-
-    // // Set properties to the given value
-    // #define DM_PROPERTY_SET_BOOL(name, set_value)   rmt_PropertySet_Bool(name, set_value)
-    // #define DM_PROPERTY_SET_S32(name, set_value)    rmt_PropertySet_S32(name, set_value)
-    // #define DM_PROPERTY_SET_U32(name, set_value)    rmt_PropertySet_U32(name, set_value)
-    // #define DM_PROPERTY_SET_F32(name, set_value)    rmt_PropertySet_F32(name, set_value)
-    // #define DM_PROPERTY_SET_S64(name, set_value)    rmt_PropertySet_S64(name, set_value)
-    // #define DM_PROPERTY_SET_U64(name, set_value)    rmt_PropertySet_U64(name, set_value)
-    // #define DM_PROPERTY_SET_F64(name, set_value)    rmt_PropertySet_F64(name, set_value)
-
-    // // Add the given value to properties
-    // #define DM_PROPERTY_ADD_S32(name, add_value)    rmt_PropertyAdd_S32(name, add_value)
-    // #define DM_PROPERTY_ADD_U32(name, add_value)    rmt_PropertyAdd_U32(name, add_value)
-    // #define DM_PROPERTY_ADD_F32(name, add_value)    rmt_PropertyAdd_F32(name, add_value)
-    // #define DM_PROPERTY_ADD_S64(name, add_value)    rmt_PropertyAdd_S64(name, add_value)
-    // #define DM_PROPERTY_ADD_U64(name, add_value)    rmt_PropertyAdd_U64(name, add_value)
-    // #define DM_PROPERTY_ADD_F64(name, add_value)    rmt_PropertyAdd_F64(name, add_value)
-
-    // #define DM_PROPERTY_RESET(name)                 rmt_PropertyReset(name)
 
     // The profiler property api
     #define DM_PROPERTY_GROUP(name, desc, parent)                       dmProfilePropertyIdx name = dmProfileCreatePropertyGroup(#name, desc, parent)

--- a/engine/dlib/src/test/test_profile.cpp
+++ b/engine/dlib/src/test/test_profile.cpp
@@ -254,16 +254,16 @@ TEST(dmProfile, Profile)
 
 
 DM_PROPERTY_GROUP(prop_TestGroup1, "", 0);
-DM_PROPERTY_BOOL(prop_TestBOOL, 0, PPF_FRAME_RESET, "", &prop_TestGroup1);
-DM_PROPERTY_S32(propt_TestS32, 0, PPF_FRAME_RESET, "", &prop_TestGroup1);
-DM_PROPERTY_U32(propt_TestU32, 0, PPF_FRAME_RESET, "", &prop_TestGroup1);
-DM_PROPERTY_F32(propt_TestF32, 0, PPF_FRAME_RESET, "", &prop_TestGroup1);
-DM_PROPERTY_S64(propt_TestS64, 0, PPF_FRAME_RESET, "", &prop_TestGroup1);
-DM_PROPERTY_U64(propt_TestU64, 0, PPF_FRAME_RESET, "", &prop_TestGroup1);
-DM_PROPERTY_F64(propt_TestF64, 0, PPF_FRAME_RESET, "", &prop_TestGroup1);
+DM_PROPERTY_BOOL(prop_TestBOOL, 0, PROFILE_PROPERTY_FRAME_RESET, "", &prop_TestGroup1);
+DM_PROPERTY_S32(propt_TestS32, 0, PROFILE_PROPERTY_FRAME_RESET, "", &prop_TestGroup1);
+DM_PROPERTY_U32(propt_TestU32, 0, PROFILE_PROPERTY_FRAME_RESET, "", &prop_TestGroup1);
+DM_PROPERTY_F32(propt_TestF32, 0, PROFILE_PROPERTY_FRAME_RESET, "", &prop_TestGroup1);
+DM_PROPERTY_S64(propt_TestS64, 0, PROFILE_PROPERTY_FRAME_RESET, "", &prop_TestGroup1);
+DM_PROPERTY_U64(propt_TestU64, 0, PROFILE_PROPERTY_FRAME_RESET, "", &prop_TestGroup1);
+DM_PROPERTY_F64(propt_TestF64, 0, PROFILE_PROPERTY_FRAME_RESET, "", &prop_TestGroup1);
 
 DM_PROPERTY_GROUP(prop_TestGroup2, "", &prop_TestGroup1);
-DM_PROPERTY_U32(prop_FrameCounter, 0, PPF_NONE, "", &prop_TestGroup2);
+DM_PROPERTY_U32(prop_FrameCounter, 0, PROFILE_PROPERTY_NONE, "", &prop_TestGroup2);
 
 static TestProperty* GetProperty(PropertyCtx* ctx, const char* name)
 {

--- a/engine/dlib/src/test/test_profile.cpp
+++ b/engine/dlib/src/test/test_profile.cpp
@@ -253,17 +253,17 @@ TEST(dmProfile, Profile)
 }
 
 
-DM_PROPERTY_GROUP(prop_TestGroup1, "");
-DM_PROPERTY_BOOL(prop_TestBOOL, 0, FrameReset, "", &prop_TestGroup1);
-DM_PROPERTY_S32(propt_TestS32, 0, FrameReset, "", &prop_TestGroup1);
-DM_PROPERTY_U32(propt_TestU32, 0, FrameReset, "", &prop_TestGroup1);
-DM_PROPERTY_F32(propt_TestF32, 0, FrameReset, "", &prop_TestGroup1);
-DM_PROPERTY_S64(propt_TestS64, 0, FrameReset, "", &prop_TestGroup1);
-DM_PROPERTY_U64(propt_TestU64, 0, FrameReset, "", &prop_TestGroup1);
-DM_PROPERTY_F64(propt_TestF64, 0, FrameReset, "", &prop_TestGroup1);
+DM_PROPERTY_GROUP(prop_TestGroup1, "", 0);
+DM_PROPERTY_BOOL(prop_TestBOOL, 0, PPF_FRAME_RESET, "", &prop_TestGroup1);
+DM_PROPERTY_S32(propt_TestS32, 0, PPF_FRAME_RESET, "", &prop_TestGroup1);
+DM_PROPERTY_U32(propt_TestU32, 0, PPF_FRAME_RESET, "", &prop_TestGroup1);
+DM_PROPERTY_F32(propt_TestF32, 0, PPF_FRAME_RESET, "", &prop_TestGroup1);
+DM_PROPERTY_S64(propt_TestS64, 0, PPF_FRAME_RESET, "", &prop_TestGroup1);
+DM_PROPERTY_U64(propt_TestU64, 0, PPF_FRAME_RESET, "", &prop_TestGroup1);
+DM_PROPERTY_F64(propt_TestF64, 0, PPF_FRAME_RESET, "", &prop_TestGroup1);
 
 DM_PROPERTY_GROUP(prop_TestGroup2, "", &prop_TestGroup1);
-DM_PROPERTY_U32(prop_FrameCounter, 0, NoFlags, "", &prop_TestGroup2);
+DM_PROPERTY_U32(prop_FrameCounter, 0, PPF_NONE, "", &prop_TestGroup2);
 
 static TestProperty* GetProperty(PropertyCtx* ctx, const char* name)
 {

--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -96,8 +96,8 @@ extern "C" {
 #endif
 
 DM_PROPERTY_EXTERN(rmtp_Script);
-DM_PROPERTY_U32(rmtp_LuaMem, 0, PPF_FRAME_RESET, "kb", &rmtp_Script); // kilo bytes
-DM_PROPERTY_U32(rmtp_LuaRefs, 0, PPF_FRAME_RESET, "# Lua references", &rmtp_Script);
+DM_PROPERTY_U32(rmtp_LuaMem, 0, PROFILE_PROPERTY_FRAME_RESET, "kb", &rmtp_Script); // kilo bytes
+DM_PROPERTY_U32(rmtp_LuaRefs, 0, PROFILE_PROPERTY_FRAME_RESET, "# Lua references", &rmtp_Script);
 
 namespace dmEngine
 {

--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -96,8 +96,8 @@ extern "C" {
 #endif
 
 DM_PROPERTY_EXTERN(rmtp_Script);
-DM_PROPERTY_U32(rmtp_LuaMem, 0, FrameReset, "kb", &rmtp_Script); // kilo bytes
-DM_PROPERTY_U32(rmtp_LuaRefs, 0, FrameReset, "# Lua references", &rmtp_Script);
+DM_PROPERTY_U32(rmtp_LuaMem, 0, PPF_FRAME_RESET, "kb", &rmtp_Script); // kilo bytes
+DM_PROPERTY_U32(rmtp_LuaRefs, 0, PPF_FRAME_RESET, "# Lua references", &rmtp_Script);
 
 namespace dmEngine
 {

--- a/engine/gameobject/src/gameobject/comp_anim.cpp
+++ b/engine/gameobject/src/gameobject/comp_anim.cpp
@@ -31,7 +31,7 @@ extern "C"
 }
 
 DM_PROPERTY_EXTERN(rmtp_GameObject);
-DM_PROPERTY_U32(rmtp_ComponentsAnim, 0, PPF_FRAME_RESET, "#", &rmtp_GameObject);
+DM_PROPERTY_U32(rmtp_ComponentsAnim, 0, PROFILE_PROPERTY_FRAME_RESET, "#", &rmtp_GameObject);
 
 namespace dmGameObject
 {

--- a/engine/gameobject/src/gameobject/comp_anim.cpp
+++ b/engine/gameobject/src/gameobject/comp_anim.cpp
@@ -31,7 +31,7 @@ extern "C"
 }
 
 DM_PROPERTY_EXTERN(rmtp_GameObject);
-DM_PROPERTY_U32(rmtp_ComponentsAnim, 0, FrameReset, "#", &rmtp_GameObject);
+DM_PROPERTY_U32(rmtp_ComponentsAnim, 0, PPF_FRAME_RESET, "#", &rmtp_GameObject);
 
 namespace dmGameObject
 {

--- a/engine/gameobject/src/gameobject/comp_script.cpp
+++ b/engine/gameobject/src/gameobject/comp_script.cpp
@@ -33,7 +33,7 @@ extern "C"
 }
 
 DM_PROPERTY_EXTERN(rmtp_GameObject);
-DM_PROPERTY_U32(rmtp_ScriptCount, 0, PPF_FRAME_RESET, "# components", &rmtp_GameObject);
+DM_PROPERTY_U32(rmtp_ScriptCount, 0, PROFILE_PROPERTY_FRAME_RESET, "# components", &rmtp_GameObject);
 
 namespace dmGameObject
 {

--- a/engine/gameobject/src/gameobject/comp_script.cpp
+++ b/engine/gameobject/src/gameobject/comp_script.cpp
@@ -33,7 +33,7 @@ extern "C"
 }
 
 DM_PROPERTY_EXTERN(rmtp_GameObject);
-DM_PROPERTY_U32(rmtp_ScriptCount, 0, FrameReset, "# components", &rmtp_GameObject);
+DM_PROPERTY_U32(rmtp_ScriptCount, 0, PPF_FRAME_RESET, "# components", &rmtp_GameObject);
 
 namespace dmGameObject
 {

--- a/engine/gameobject/src/gameobject/gameobject.cpp
+++ b/engine/gameobject/src/gameobject/gameobject.cpp
@@ -44,8 +44,8 @@
 
 DM_PROPERTY_GROUP(rmtp_GameObject, "Gameobjects", 0);
 
-DM_PROPERTY_U32(rmtp_GOInstances, 0, PPF_FRAME_RESET, "# alive go instances / frame", &rmtp_GameObject);
-DM_PROPERTY_U32(rmtp_GODeleted, 0, PPF_FRAME_RESET, "# deleted instances / frame", &rmtp_GameObject);
+DM_PROPERTY_U32(rmtp_GOInstances, 0, PROFILE_PROPERTY_FRAME_RESET, "# alive go instances / frame", &rmtp_GameObject);
+DM_PROPERTY_U32(rmtp_GODeleted, 0, PROFILE_PROPERTY_FRAME_RESET, "# deleted instances / frame", &rmtp_GameObject);
 
 namespace dmGameObject
 {

--- a/engine/gameobject/src/gameobject/gameobject.cpp
+++ b/engine/gameobject/src/gameobject/gameobject.cpp
@@ -42,10 +42,10 @@
 #include <dmsdk/dlib/vmath.h>
 #include <dmsdk/resource/resource.hpp>
 
-DM_PROPERTY_GROUP(rmtp_GameObject, "Gameobjects");
+DM_PROPERTY_GROUP(rmtp_GameObject, "Gameobjects", 0);
 
-DM_PROPERTY_U32(rmtp_GOInstances, 0, FrameReset, "# alive go instances / frame", &rmtp_GameObject);
-DM_PROPERTY_U32(rmtp_GODeleted, 0, FrameReset, "# deleted instances / frame", &rmtp_GameObject);
+DM_PROPERTY_U32(rmtp_GOInstances, 0, PPF_FRAME_RESET, "# alive go instances / frame", &rmtp_GameObject);
+DM_PROPERTY_U32(rmtp_GODeleted, 0, PPF_FRAME_RESET, "# deleted instances / frame", &rmtp_GameObject);
 
 namespace dmGameObject
 {

--- a/engine/gamesys/src/gamesys/components/box2d/comp_collision_object_box2d.cpp
+++ b/engine/gamesys/src/gamesys/components/box2d/comp_collision_object_box2d.cpp
@@ -43,7 +43,7 @@
 #include <gamesys/gamesys_ddf.h>
 
 DM_PROPERTY_EXTERN(rmtp_Components);
-DM_PROPERTY_U32(rmtp_CollisionObjectBox2D, 0, PPF_FRAME_RESET, "# components", &rmtp_Components);
+DM_PROPERTY_U32(rmtp_CollisionObjectBox2D, 0, PROFILE_PROPERTY_FRAME_RESET, "# components", &rmtp_Components);
 
 namespace dmGameSystem
 {

--- a/engine/gamesys/src/gamesys/components/box2d/comp_collision_object_box2d.cpp
+++ b/engine/gamesys/src/gamesys/components/box2d/comp_collision_object_box2d.cpp
@@ -43,7 +43,7 @@
 #include <gamesys/gamesys_ddf.h>
 
 DM_PROPERTY_EXTERN(rmtp_Components);
-DM_PROPERTY_U32(rmtp_CollisionObjectBox2D, 0, FrameReset, "# components", &rmtp_Components);
+DM_PROPERTY_U32(rmtp_CollisionObjectBox2D, 0, PPF_FRAME_RESET, "# components", &rmtp_Components);
 
 namespace dmGameSystem
 {

--- a/engine/gamesys/src/gamesys/components/bullet3d/comp_collision_object_bullet3d.cpp
+++ b/engine/gamesys/src/gamesys/components/bullet3d/comp_collision_object_bullet3d.cpp
@@ -35,7 +35,7 @@
 #include "gamesys_private.h" // ShowFullBufferError
 
 DM_PROPERTY_EXTERN(rmtp_Components);
-DM_PROPERTY_U32(rmtp_CollisionObjectBullet3D, 0, PPF_FRAME_RESET, "# components", &rmtp_Components);
+DM_PROPERTY_U32(rmtp_CollisionObjectBullet3D, 0, PROFILE_PROPERTY_FRAME_RESET, "# components", &rmtp_Components);
 
 namespace dmGameSystem
 {

--- a/engine/gamesys/src/gamesys/components/bullet3d/comp_collision_object_bullet3d.cpp
+++ b/engine/gamesys/src/gamesys/components/bullet3d/comp_collision_object_bullet3d.cpp
@@ -35,7 +35,7 @@
 #include "gamesys_private.h" // ShowFullBufferError
 
 DM_PROPERTY_EXTERN(rmtp_Components);
-DM_PROPERTY_U32(rmtp_CollisionObjectBullet3D, 0, FrameReset, "# components", &rmtp_Components);
+DM_PROPERTY_U32(rmtp_CollisionObjectBullet3D, 0, PPF_FRAME_RESET, "# components", &rmtp_Components);
 
 namespace dmGameSystem
 {

--- a/engine/gamesys/src/gamesys/components/comp_camera.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_camera.cpp
@@ -31,7 +31,7 @@
 #include "comp_private.h"
 
 DM_PROPERTY_EXTERN(rmtp_Components);
-DM_PROPERTY_U32(rmtp_Camera, 0, PPF_FRAME_RESET, "# components", &rmtp_Components);
+DM_PROPERTY_U32(rmtp_Camera, 0, PROFILE_PROPERTY_FRAME_RESET, "# components", &rmtp_Components);
 
 namespace dmGameSystem
 {

--- a/engine/gamesys/src/gamesys/components/comp_camera.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_camera.cpp
@@ -31,7 +31,7 @@
 #include "comp_private.h"
 
 DM_PROPERTY_EXTERN(rmtp_Components);
-DM_PROPERTY_U32(rmtp_Camera, 0, FrameReset, "# components", &rmtp_Components);
+DM_PROPERTY_U32(rmtp_Camera, 0, PPF_FRAME_RESET, "# components", &rmtp_Components);
 
 namespace dmGameSystem
 {

--- a/engine/gamesys/src/gamesys/components/comp_collection_factory.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_collection_factory.cpp
@@ -31,7 +31,7 @@
 #include "../gamesys_private.h"
 
 DM_PROPERTY_EXTERN(rmtp_Components);
-DM_PROPERTY_U32(rmtp_CollectionFactory, 0, PPF_FRAME_RESET, "# components", &rmtp_Components);
+DM_PROPERTY_U32(rmtp_CollectionFactory, 0, PROFILE_PROPERTY_FRAME_RESET, "# components", &rmtp_Components);
 
 namespace dmGameSystem
 {

--- a/engine/gamesys/src/gamesys/components/comp_collection_factory.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_collection_factory.cpp
@@ -31,7 +31,7 @@
 #include "../gamesys_private.h"
 
 DM_PROPERTY_EXTERN(rmtp_Components);
-DM_PROPERTY_U32(rmtp_CollectionFactory, 0, FrameReset, "# components", &rmtp_Components);
+DM_PROPERTY_U32(rmtp_CollectionFactory, 0, PPF_FRAME_RESET, "# components", &rmtp_Components);
 
 namespace dmGameSystem
 {

--- a/engine/gamesys/src/gamesys/components/comp_collection_proxy.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_collection_proxy.cpp
@@ -35,9 +35,9 @@
 #include <gamesys/gamesys_ddf.h>
 
 DM_PROPERTY_EXTERN(rmtp_Components);
-DM_PROPERTY_U32(rmtp_CollectionProxy, 0, PPF_FRAME_RESET, "# components", &rmtp_Components);
-DM_PROPERTY_U32(rmtp_CollectionProxyLoaded, 0, PPF_FRAME_RESET, "# loaded collection proxies", &rmtp_CollectionProxy);
-DM_PROPERTY_U32(rmtp_CollectionProxyEnabled, 0, PPF_FRAME_RESET, "# enabled collection proxies", &rmtp_CollectionProxy);
+DM_PROPERTY_U32(rmtp_CollectionProxy, 0, PROFILE_PROPERTY_FRAME_RESET, "# components", &rmtp_Components);
+DM_PROPERTY_U32(rmtp_CollectionProxyLoaded, 0, PROFILE_PROPERTY_FRAME_RESET, "# loaded collection proxies", &rmtp_CollectionProxy);
+DM_PROPERTY_U32(rmtp_CollectionProxyEnabled, 0, PROFILE_PROPERTY_FRAME_RESET, "# enabled collection proxies", &rmtp_CollectionProxy);
 
 namespace dmGameSystem
 {

--- a/engine/gamesys/src/gamesys/components/comp_collection_proxy.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_collection_proxy.cpp
@@ -35,9 +35,9 @@
 #include <gamesys/gamesys_ddf.h>
 
 DM_PROPERTY_EXTERN(rmtp_Components);
-DM_PROPERTY_U32(rmtp_CollectionProxy, 0, FrameReset, "# components", &rmtp_Components);
-DM_PROPERTY_U32(rmtp_CollectionProxyLoaded, 0, FrameReset, "# loaded collection proxies", &rmtp_CollectionProxy);
-DM_PROPERTY_U32(rmtp_CollectionProxyEnabled, 0, FrameReset, "# enabled collection proxies", &rmtp_CollectionProxy);
+DM_PROPERTY_U32(rmtp_CollectionProxy, 0, PPF_FRAME_RESET, "# components", &rmtp_Components);
+DM_PROPERTY_U32(rmtp_CollectionProxyLoaded, 0, PPF_FRAME_RESET, "# loaded collection proxies", &rmtp_CollectionProxy);
+DM_PROPERTY_U32(rmtp_CollectionProxyEnabled, 0, PPF_FRAME_RESET, "# enabled collection proxies", &rmtp_CollectionProxy);
 
 namespace dmGameSystem
 {

--- a/engine/gamesys/src/gamesys/components/comp_factory.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_factory.cpp
@@ -31,7 +31,7 @@
 #include "../gamesys_private.h"
 
 DM_PROPERTY_EXTERN(rmtp_Components);
-DM_PROPERTY_U32(rmtp_Factory, 0, PPF_FRAME_RESET, "# components", &rmtp_Components);
+DM_PROPERTY_U32(rmtp_Factory, 0, PROFILE_PROPERTY_FRAME_RESET, "# components", &rmtp_Components);
 
 namespace dmGameSystem
 {

--- a/engine/gamesys/src/gamesys/components/comp_factory.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_factory.cpp
@@ -31,7 +31,7 @@
 #include "../gamesys_private.h"
 
 DM_PROPERTY_EXTERN(rmtp_Components);
-DM_PROPERTY_U32(rmtp_Factory, 0, FrameReset, "# components", &rmtp_Components);
+DM_PROPERTY_U32(rmtp_Factory, 0, PPF_FRAME_RESET, "# components", &rmtp_Components);
 
 namespace dmGameSystem
 {

--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -54,7 +54,7 @@
 #include <dmsdk/resource/resource.h>
 
 DM_PROPERTY_EXTERN(rmtp_Gui);
-DM_PROPERTY_U32(rmtp_GuiVertexCount, 0, PPF_FRAME_RESET, "#", &rmtp_Gui);
+DM_PROPERTY_U32(rmtp_GuiVertexCount, 0, PROFILE_PROPERTY_FRAME_RESET, "#", &rmtp_Gui);
 
 namespace dmGameSystem
 {

--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -54,7 +54,7 @@
 #include <dmsdk/resource/resource.h>
 
 DM_PROPERTY_EXTERN(rmtp_Gui);
-DM_PROPERTY_U32(rmtp_GuiVertexCount, 0, FrameReset, "#", &rmtp_Gui);
+DM_PROPERTY_U32(rmtp_GuiVertexCount, 0, PPF_FRAME_RESET, "#", &rmtp_Gui);
 
 namespace dmGameSystem
 {

--- a/engine/gamesys/src/gamesys/components/comp_label.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_label.cpp
@@ -47,7 +47,7 @@
 #include <dmsdk/gamesys/resources/res_font.h>
 
 DM_PROPERTY_EXTERN(rmtp_Components);
-DM_PROPERTY_U32(rmtp_Label, 0, PPF_FRAME_RESET, "# components", &rmtp_Components);
+DM_PROPERTY_U32(rmtp_Label, 0, PROFILE_PROPERTY_FRAME_RESET, "# components", &rmtp_Components);
 
 namespace dmGameSystem
 {

--- a/engine/gamesys/src/gamesys/components/comp_label.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_label.cpp
@@ -47,7 +47,7 @@
 #include <dmsdk/gamesys/resources/res_font.h>
 
 DM_PROPERTY_EXTERN(rmtp_Components);
-DM_PROPERTY_U32(rmtp_Label, 0, FrameReset, "# components", &rmtp_Components);
+DM_PROPERTY_U32(rmtp_Label, 0, PPF_FRAME_RESET, "# components", &rmtp_Components);
 
 namespace dmGameSystem
 {

--- a/engine/gamesys/src/gamesys/components/comp_mesh.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_mesh.cpp
@@ -45,9 +45,9 @@
 #include "../resources/res_mesh.h"
 
 DM_PROPERTY_EXTERN(rmtp_Components);
-DM_PROPERTY_U32(rmtp_Mesh, 0, PPF_FRAME_RESET, "# components", &rmtp_Components);
-DM_PROPERTY_U32(rmtp_MeshVertexCount, 0, PPF_FRAME_RESET, "# vertices", &rmtp_Mesh);
-DM_PROPERTY_U32(rmtp_MeshVertexSize, 0, PPF_FRAME_RESET, "size of vertices in bytes", &rmtp_Mesh);
+DM_PROPERTY_U32(rmtp_Mesh, 0, PROFILE_PROPERTY_FRAME_RESET, "# components", &rmtp_Components);
+DM_PROPERTY_U32(rmtp_MeshVertexCount, 0, PROFILE_PROPERTY_FRAME_RESET, "# vertices", &rmtp_Mesh);
+DM_PROPERTY_U32(rmtp_MeshVertexSize, 0, PROFILE_PROPERTY_FRAME_RESET, "size of vertices in bytes", &rmtp_Mesh);
 
 namespace dmGameSystem
 {

--- a/engine/gamesys/src/gamesys/components/comp_mesh.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_mesh.cpp
@@ -45,9 +45,9 @@
 #include "../resources/res_mesh.h"
 
 DM_PROPERTY_EXTERN(rmtp_Components);
-DM_PROPERTY_U32(rmtp_Mesh, 0, FrameReset, "# components", &rmtp_Components);
-DM_PROPERTY_U32(rmtp_MeshVertexCount, 0, FrameReset, "# vertices", &rmtp_Mesh);
-DM_PROPERTY_U32(rmtp_MeshVertexSize, 0, FrameReset, "size of vertices in bytes", &rmtp_Mesh);
+DM_PROPERTY_U32(rmtp_Mesh, 0, PPF_FRAME_RESET, "# components", &rmtp_Components);
+DM_PROPERTY_U32(rmtp_MeshVertexCount, 0, PPF_FRAME_RESET, "# vertices", &rmtp_Mesh);
+DM_PROPERTY_U32(rmtp_MeshVertexSize, 0, PPF_FRAME_RESET, "size of vertices in bytes", &rmtp_Mesh);
 
 namespace dmGameSystem
 {

--- a/engine/gamesys/src/gamesys/components/comp_model.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_model.cpp
@@ -49,10 +49,10 @@
 #include <dmsdk/resource/resource.h>
 
 DM_PROPERTY_EXTERN(rmtp_Components);
-DM_PROPERTY_U32(rmtp_Model, 0, PPF_FRAME_RESET, "# components", &rmtp_Components);
-DM_PROPERTY_U32(rmtp_ModelIndexCount, 0, PPF_FRAME_RESET, "# indices", &rmtp_Model);
-DM_PROPERTY_U32(rmtp_ModelVertexCount, 0, PPF_FRAME_RESET, "# vertices", &rmtp_Model);
-DM_PROPERTY_U32(rmtp_ModelVertexSize, 0, PPF_FRAME_RESET, "size of vertices in bytes", &rmtp_Model);
+DM_PROPERTY_U32(rmtp_Model, 0, PROFILE_PROPERTY_FRAME_RESET, "# components", &rmtp_Components);
+DM_PROPERTY_U32(rmtp_ModelIndexCount, 0, PROFILE_PROPERTY_FRAME_RESET, "# indices", &rmtp_Model);
+DM_PROPERTY_U32(rmtp_ModelVertexCount, 0, PROFILE_PROPERTY_FRAME_RESET, "# vertices", &rmtp_Model);
+DM_PROPERTY_U32(rmtp_ModelVertexSize, 0, PROFILE_PROPERTY_FRAME_RESET, "size of vertices in bytes", &rmtp_Model);
 
 namespace dmGameSystem
 {

--- a/engine/gamesys/src/gamesys/components/comp_model.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_model.cpp
@@ -49,10 +49,10 @@
 #include <dmsdk/resource/resource.h>
 
 DM_PROPERTY_EXTERN(rmtp_Components);
-DM_PROPERTY_U32(rmtp_Model, 0, FrameReset, "# components", &rmtp_Components);
-DM_PROPERTY_U32(rmtp_ModelIndexCount, 0, FrameReset, "# indices", &rmtp_Model);
-DM_PROPERTY_U32(rmtp_ModelVertexCount, 0, FrameReset, "# vertices", &rmtp_Model);
-DM_PROPERTY_U32(rmtp_ModelVertexSize, 0, FrameReset, "size of vertices in bytes", &rmtp_Model);
+DM_PROPERTY_U32(rmtp_Model, 0, PPF_FRAME_RESET, "# components", &rmtp_Components);
+DM_PROPERTY_U32(rmtp_ModelIndexCount, 0, PPF_FRAME_RESET, "# indices", &rmtp_Model);
+DM_PROPERTY_U32(rmtp_ModelVertexCount, 0, PPF_FRAME_RESET, "# vertices", &rmtp_Model);
+DM_PROPERTY_U32(rmtp_ModelVertexSize, 0, PPF_FRAME_RESET, "size of vertices in bytes", &rmtp_Model);
 
 namespace dmGameSystem
 {

--- a/engine/gamesys/src/gamesys/components/comp_particlefx.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_particlefx.cpp
@@ -37,10 +37,10 @@
 #include "resources/res_material.h"
 
 DM_PROPERTY_EXTERN(rmtp_Components);
-DM_PROPERTY_U32(rmtp_ParticleFx, 0, PPF_FRAME_RESET, "# components", &rmtp_Components);
-DM_PROPERTY_U32(rmtp_ParticleVertexCount, 0, PPF_FRAME_RESET, "# vertices", &rmtp_ParticleFx);
-DM_PROPERTY_U32(rmtp_ParticleVertexSize, 0, PPF_FRAME_RESET, "size of CPU vertex buffer (in bytes)", &rmtp_ParticleFx);
-DM_PROPERTY_U32(rmtp_ParticleVertexSizeGPU, 0, PPF_FRAME_RESET, "size of GPU vertex buffer (in bytes)", &rmtp_ParticleFx);
+DM_PROPERTY_U32(rmtp_ParticleFx, 0, PROFILE_PROPERTY_FRAME_RESET, "# components", &rmtp_Components);
+DM_PROPERTY_U32(rmtp_ParticleVertexCount, 0, PROFILE_PROPERTY_FRAME_RESET, "# vertices", &rmtp_ParticleFx);
+DM_PROPERTY_U32(rmtp_ParticleVertexSize, 0, PROFILE_PROPERTY_FRAME_RESET, "size of CPU vertex buffer (in bytes)", &rmtp_ParticleFx);
+DM_PROPERTY_U32(rmtp_ParticleVertexSizeGPU, 0, PROFILE_PROPERTY_FRAME_RESET, "size of GPU vertex buffer (in bytes)", &rmtp_ParticleFx);
 
 namespace dmGameSystem
 {

--- a/engine/gamesys/src/gamesys/components/comp_particlefx.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_particlefx.cpp
@@ -37,10 +37,10 @@
 #include "resources/res_material.h"
 
 DM_PROPERTY_EXTERN(rmtp_Components);
-DM_PROPERTY_U32(rmtp_ParticleFx, 0, FrameReset, "# components", &rmtp_Components);
-DM_PROPERTY_U32(rmtp_ParticleVertexCount, 0, FrameReset, "# vertices", &rmtp_ParticleFx);
-DM_PROPERTY_U32(rmtp_ParticleVertexSize, 0, FrameReset, "size of CPU vertex buffer (in bytes)", &rmtp_ParticleFx);
-DM_PROPERTY_U32(rmtp_ParticleVertexSizeGPU, 0, FrameReset, "size of GPU vertex buffer (in bytes)", &rmtp_ParticleFx);
+DM_PROPERTY_U32(rmtp_ParticleFx, 0, PPF_FRAME_RESET, "# components", &rmtp_Components);
+DM_PROPERTY_U32(rmtp_ParticleVertexCount, 0, PPF_FRAME_RESET, "# vertices", &rmtp_ParticleFx);
+DM_PROPERTY_U32(rmtp_ParticleVertexSize, 0, PPF_FRAME_RESET, "size of CPU vertex buffer (in bytes)", &rmtp_ParticleFx);
+DM_PROPERTY_U32(rmtp_ParticleVertexSizeGPU, 0, PPF_FRAME_RESET, "size of GPU vertex buffer (in bytes)", &rmtp_ParticleFx);
 
 namespace dmGameSystem
 {

--- a/engine/gamesys/src/gamesys/components/comp_sound.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sound.cpp
@@ -32,8 +32,8 @@
 #include "comp_private.h"
 
 DM_PROPERTY_EXTERN(rmtp_Components);
-DM_PROPERTY_U32(rmtp_Sound, 0, PPF_FRAME_RESET, "# components", &rmtp_Components);
-DM_PROPERTY_U32(rmtp_SoundPlaying, 0, PPF_FRAME_RESET, "# sounds playing", &rmtp_Sound);
+DM_PROPERTY_U32(rmtp_Sound, 0, PROFILE_PROPERTY_FRAME_RESET, "# components", &rmtp_Components);
+DM_PROPERTY_U32(rmtp_SoundPlaying, 0, PROFILE_PROPERTY_FRAME_RESET, "# sounds playing", &rmtp_Sound);
 
 namespace dmGameSystem
 {

--- a/engine/gamesys/src/gamesys/components/comp_sound.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sound.cpp
@@ -32,8 +32,8 @@
 #include "comp_private.h"
 
 DM_PROPERTY_EXTERN(rmtp_Components);
-DM_PROPERTY_U32(rmtp_Sound, 0, FrameReset, "# components", &rmtp_Components);
-DM_PROPERTY_U32(rmtp_SoundPlaying, 0, FrameReset, "# sounds playing", &rmtp_Sound);
+DM_PROPERTY_U32(rmtp_Sound, 0, PPF_FRAME_RESET, "# components", &rmtp_Components);
+DM_PROPERTY_U32(rmtp_SoundPlaying, 0, PPF_FRAME_RESET, "# sounds playing", &rmtp_Sound);
 
 namespace dmGameSystem
 {

--- a/engine/gamesys/src/gamesys/components/comp_sprite.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sprite.cpp
@@ -47,10 +47,10 @@
 #include <dmsdk/gamesys/resources/res_textureset.h>
 
 DM_PROPERTY_EXTERN(rmtp_Components);
-DM_PROPERTY_U32(rmtp_Sprite, 0, PPF_FRAME_RESET, "# components", &rmtp_Components);
-DM_PROPERTY_U32(rmtp_SpriteVertexCount, 0, PPF_FRAME_RESET, "# vertices", &rmtp_Sprite);
-DM_PROPERTY_U32(rmtp_SpriteVertexSize, 0, PPF_FRAME_RESET, "size of vertices in bytes", &rmtp_Sprite);
-DM_PROPERTY_U32(rmtp_SpriteIndexSize, 0, PPF_FRAME_RESET, "size of indices in bytes", &rmtp_Sprite);
+DM_PROPERTY_U32(rmtp_Sprite, 0, PROFILE_PROPERTY_FRAME_RESET, "# components", &rmtp_Components);
+DM_PROPERTY_U32(rmtp_SpriteVertexCount, 0, PROFILE_PROPERTY_FRAME_RESET, "# vertices", &rmtp_Sprite);
+DM_PROPERTY_U32(rmtp_SpriteVertexSize, 0, PROFILE_PROPERTY_FRAME_RESET, "size of vertices in bytes", &rmtp_Sprite);
+DM_PROPERTY_U32(rmtp_SpriteIndexSize, 0, PROFILE_PROPERTY_FRAME_RESET, "size of indices in bytes", &rmtp_Sprite);
 
 namespace dmGameSystem
 {

--- a/engine/gamesys/src/gamesys/components/comp_sprite.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sprite.cpp
@@ -47,10 +47,10 @@
 #include <dmsdk/gamesys/resources/res_textureset.h>
 
 DM_PROPERTY_EXTERN(rmtp_Components);
-DM_PROPERTY_U32(rmtp_Sprite, 0, FrameReset, "# components", &rmtp_Components);
-DM_PROPERTY_U32(rmtp_SpriteVertexCount, 0, FrameReset, "# vertices", &rmtp_Sprite);
-DM_PROPERTY_U32(rmtp_SpriteVertexSize, 0, FrameReset, "size of vertices in bytes", &rmtp_Sprite);
-DM_PROPERTY_U32(rmtp_SpriteIndexSize, 0, FrameReset, "size of indices in bytes", &rmtp_Sprite);
+DM_PROPERTY_U32(rmtp_Sprite, 0, PPF_FRAME_RESET, "# components", &rmtp_Components);
+DM_PROPERTY_U32(rmtp_SpriteVertexCount, 0, PPF_FRAME_RESET, "# vertices", &rmtp_Sprite);
+DM_PROPERTY_U32(rmtp_SpriteVertexSize, 0, PPF_FRAME_RESET, "size of vertices in bytes", &rmtp_Sprite);
+DM_PROPERTY_U32(rmtp_SpriteIndexSize, 0, PPF_FRAME_RESET, "size of indices in bytes", &rmtp_Sprite);
 
 namespace dmGameSystem
 {

--- a/engine/gamesys/src/gamesys/components/comp_tilegrid.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_tilegrid.cpp
@@ -41,10 +41,10 @@
 #include <dmsdk/gamesys/render_constants.h>
 
 DM_PROPERTY_EXTERN(rmtp_Components);
-DM_PROPERTY_U32(rmtp_Tilemap, 0, PPF_FRAME_RESET, "# components", &rmtp_Components);
-DM_PROPERTY_U32(rmtp_TilemapTileCount, 0, PPF_FRAME_RESET, "# vertices", &rmtp_Tilemap);
-DM_PROPERTY_U32(rmtp_TilemapVertexCount, 0, PPF_FRAME_RESET, "# vertices", &rmtp_Tilemap);
-DM_PROPERTY_U32(rmtp_TilemapVertexSize, 0, PPF_FRAME_RESET, "size of vertices in bytes", &rmtp_Tilemap);
+DM_PROPERTY_U32(rmtp_Tilemap, 0, PROFILE_PROPERTY_FRAME_RESET, "# components", &rmtp_Components);
+DM_PROPERTY_U32(rmtp_TilemapTileCount, 0, PROFILE_PROPERTY_FRAME_RESET, "# vertices", &rmtp_Tilemap);
+DM_PROPERTY_U32(rmtp_TilemapVertexCount, 0, PROFILE_PROPERTY_FRAME_RESET, "# vertices", &rmtp_Tilemap);
+DM_PROPERTY_U32(rmtp_TilemapVertexSize, 0, PROFILE_PROPERTY_FRAME_RESET, "size of vertices in bytes", &rmtp_Tilemap);
 
 namespace dmGameSystem
 {

--- a/engine/gamesys/src/gamesys/components/comp_tilegrid.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_tilegrid.cpp
@@ -41,10 +41,10 @@
 #include <dmsdk/gamesys/render_constants.h>
 
 DM_PROPERTY_EXTERN(rmtp_Components);
-DM_PROPERTY_U32(rmtp_Tilemap, 0, FrameReset, "# components", &rmtp_Components);
-DM_PROPERTY_U32(rmtp_TilemapTileCount, 0, FrameReset, "# vertices", &rmtp_Tilemap);
-DM_PROPERTY_U32(rmtp_TilemapVertexCount, 0, FrameReset, "# vertices", &rmtp_Tilemap);
-DM_PROPERTY_U32(rmtp_TilemapVertexSize, 0, FrameReset, "size of vertices in bytes", &rmtp_Tilemap);
+DM_PROPERTY_U32(rmtp_Tilemap, 0, PPF_FRAME_RESET, "# components", &rmtp_Components);
+DM_PROPERTY_U32(rmtp_TilemapTileCount, 0, PPF_FRAME_RESET, "# vertices", &rmtp_Tilemap);
+DM_PROPERTY_U32(rmtp_TilemapVertexCount, 0, PPF_FRAME_RESET, "# vertices", &rmtp_Tilemap);
+DM_PROPERTY_U32(rmtp_TilemapVertexSize, 0, PPF_FRAME_RESET, "size of vertices in bytes", &rmtp_Tilemap);
 
 namespace dmGameSystem
 {

--- a/engine/gamesys/src/gamesys/gamesys.cpp
+++ b/engine/gamesys/src/gamesys/gamesys.cpp
@@ -73,7 +73,7 @@
 #include "components/comp_tilegrid.h"
 #include "components/comp_label.h"
 
-DM_PROPERTY_GROUP(rmtp_Components, "Gameobject Components");
+DM_PROPERTY_GROUP(rmtp_Components, "Gameobject Components", 0);
 
 namespace dmGameSystem
 {

--- a/engine/graphics/src/graphics.cpp
+++ b/engine/graphics/src/graphics.cpp
@@ -25,8 +25,8 @@
 #include <dlib/math.h>
 
 DM_PROPERTY_GROUP(rmtp_Graphics, "Graphics", 0);
-DM_PROPERTY_U32(rmtp_DrawCalls, 0, PPF_FRAME_RESET, "# vertices", &rmtp_Graphics);
-DM_PROPERTY_U32(rmtp_DispatchCalls, 0, PPF_FRAME_RESET, "# dispatches", &rmtp_Graphics);
+DM_PROPERTY_U32(rmtp_DrawCalls, 0, PROFILE_PROPERTY_FRAME_RESET, "# vertices", &rmtp_Graphics);
+DM_PROPERTY_U32(rmtp_DispatchCalls, 0, PROFILE_PROPERTY_FRAME_RESET, "# dispatches", &rmtp_Graphics);
 
 #include <dlib/log.h>
 #include <dlib/dstrings.h>

--- a/engine/graphics/src/graphics.cpp
+++ b/engine/graphics/src/graphics.cpp
@@ -24,9 +24,9 @@
 #include <dlib/profile.h>
 #include <dlib/math.h>
 
-DM_PROPERTY_GROUP(rmtp_Graphics, "Graphics");
-DM_PROPERTY_U32(rmtp_DrawCalls, 0, FrameReset, "# vertices", &rmtp_Graphics);
-DM_PROPERTY_U32(rmtp_DispatchCalls, 0, FrameReset, "# dispatches", &rmtp_Graphics);
+DM_PROPERTY_GROUP(rmtp_Graphics, "Graphics", 0);
+DM_PROPERTY_U32(rmtp_DrawCalls, 0, PPF_FRAME_RESET, "# vertices", &rmtp_Graphics);
+DM_PROPERTY_U32(rmtp_DispatchCalls, 0, PPF_FRAME_RESET, "# dispatches", &rmtp_Graphics);
 
 #include <dlib/log.h>
 #include <dlib/dstrings.h>

--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -40,16 +40,16 @@
 #include "gui_private.h"
 #include "gui_script.h"
 
-DM_PROPERTY_U32(rmtp_Gui, 0, PPF_FRAME_RESET, "", 0);
-DM_PROPERTY_U32(rmtp_GuiAnimations, 0, PPF_FRAME_RESET, "", &rmtp_Gui);
-DM_PROPERTY_U32(rmtp_GuiActiveAnimations, 0, PPF_FRAME_RESET, "", &rmtp_Gui);
-DM_PROPERTY_U32(rmtp_GuiNodes, 0, PPF_FRAME_RESET, "", &rmtp_Gui);
-DM_PROPERTY_U32(rmtp_GuiActiveNodes, 0, PPF_FRAME_RESET, "", &rmtp_Gui);
-DM_PROPERTY_U32(rmtp_GuiStaticTextures, 0, PPF_FRAME_RESET, "", &rmtp_Gui);
-DM_PROPERTY_U32(rmtp_GuiDynamicTextures, 0, PPF_FRAME_RESET, "", &rmtp_Gui);
-DM_PROPERTY_U32(rmtp_GuiTextures, 0, PPF_FRAME_RESET, "", &rmtp_Gui);
-DM_PROPERTY_U32(rmtp_GuiParticlefx, 0, PPF_FRAME_RESET, "", &rmtp_Gui);
-DM_PROPERTY_F32(rmtp_GuiDynamicTexturesSizeMb, 0, PPF_NONE, "size of dynamic tex in Mb", &rmtp_Gui);
+DM_PROPERTY_U32(rmtp_Gui, 0, PROFILE_PROPERTY_FRAME_RESET, "", 0);
+DM_PROPERTY_U32(rmtp_GuiAnimations, 0, PROFILE_PROPERTY_FRAME_RESET, "", &rmtp_Gui);
+DM_PROPERTY_U32(rmtp_GuiActiveAnimations, 0, PROFILE_PROPERTY_FRAME_RESET, "", &rmtp_Gui);
+DM_PROPERTY_U32(rmtp_GuiNodes, 0, PROFILE_PROPERTY_FRAME_RESET, "", &rmtp_Gui);
+DM_PROPERTY_U32(rmtp_GuiActiveNodes, 0, PROFILE_PROPERTY_FRAME_RESET, "", &rmtp_Gui);
+DM_PROPERTY_U32(rmtp_GuiStaticTextures, 0, PROFILE_PROPERTY_FRAME_RESET, "", &rmtp_Gui);
+DM_PROPERTY_U32(rmtp_GuiDynamicTextures, 0, PROFILE_PROPERTY_FRAME_RESET, "", &rmtp_Gui);
+DM_PROPERTY_U32(rmtp_GuiTextures, 0, PROFILE_PROPERTY_FRAME_RESET, "", &rmtp_Gui);
+DM_PROPERTY_U32(rmtp_GuiParticlefx, 0, PROFILE_PROPERTY_FRAME_RESET, "", &rmtp_Gui);
+DM_PROPERTY_F32(rmtp_GuiDynamicTexturesSizeMb, 0, PROFILE_PROPERTY_NONE, "size of dynamic tex in Mb", &rmtp_Gui);
 
 namespace dmGui
 {

--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -40,16 +40,16 @@
 #include "gui_private.h"
 #include "gui_script.h"
 
-DM_PROPERTY_U32(rmtp_Gui, 0, FrameReset, "");
-DM_PROPERTY_U32(rmtp_GuiAnimations, 0, FrameReset, "", &rmtp_Gui);
-DM_PROPERTY_U32(rmtp_GuiActiveAnimations, 0, FrameReset, "", &rmtp_Gui);
-DM_PROPERTY_U32(rmtp_GuiNodes, 0, FrameReset, "", &rmtp_Gui);
-DM_PROPERTY_U32(rmtp_GuiActiveNodes, 0, FrameReset, "", &rmtp_Gui);
-DM_PROPERTY_U32(rmtp_GuiStaticTextures, 0, FrameReset, "", &rmtp_Gui);
-DM_PROPERTY_U32(rmtp_GuiDynamicTextures, 0, FrameReset, "", &rmtp_Gui);
-DM_PROPERTY_U32(rmtp_GuiTextures, 0, FrameReset, "", &rmtp_Gui);
-DM_PROPERTY_U32(rmtp_GuiParticlefx, 0, FrameReset, "", &rmtp_Gui);
-DM_PROPERTY_F32(rmtp_GuiDynamicTexturesSizeMb, 0, NoFlags, "size of dynamic tex in Mb", &rmtp_Gui);
+DM_PROPERTY_U32(rmtp_Gui, 0, PPF_FRAME_RESET, "", 0);
+DM_PROPERTY_U32(rmtp_GuiAnimations, 0, PPF_FRAME_RESET, "", &rmtp_Gui);
+DM_PROPERTY_U32(rmtp_GuiActiveAnimations, 0, PPF_FRAME_RESET, "", &rmtp_Gui);
+DM_PROPERTY_U32(rmtp_GuiNodes, 0, PPF_FRAME_RESET, "", &rmtp_Gui);
+DM_PROPERTY_U32(rmtp_GuiActiveNodes, 0, PPF_FRAME_RESET, "", &rmtp_Gui);
+DM_PROPERTY_U32(rmtp_GuiStaticTextures, 0, PPF_FRAME_RESET, "", &rmtp_Gui);
+DM_PROPERTY_U32(rmtp_GuiDynamicTextures, 0, PPF_FRAME_RESET, "", &rmtp_Gui);
+DM_PROPERTY_U32(rmtp_GuiTextures, 0, PPF_FRAME_RESET, "", &rmtp_Gui);
+DM_PROPERTY_U32(rmtp_GuiParticlefx, 0, PPF_FRAME_RESET, "", &rmtp_Gui);
+DM_PROPERTY_F32(rmtp_GuiDynamicTexturesSizeMb, 0, PPF_NONE, "size of dynamic tex in Mb", &rmtp_Gui);
 
 namespace dmGui
 {

--- a/engine/particle/src/particle.cpp
+++ b/engine/particle/src/particle.cpp
@@ -29,7 +29,7 @@
 #include "particle_private.h"
 
 DM_PROPERTY_GROUP(rmtp_Particles, "Particles", 0);
-DM_PROPERTY_U32(rmtp_ParticlesAlive, 0, PPF_FRAME_RESET, "# particles alive", &rmtp_Particles);
+DM_PROPERTY_U32(rmtp_ParticlesAlive, 0, PROFILE_PROPERTY_FRAME_RESET, "# particles alive", &rmtp_Particles);
 
 namespace dmParticle
 {

--- a/engine/particle/src/particle.cpp
+++ b/engine/particle/src/particle.cpp
@@ -28,8 +28,8 @@
 #include "particle.h"
 #include "particle_private.h"
 
-DM_PROPERTY_GROUP(rmtp_Particles, "Particles");
-DM_PROPERTY_U32(rmtp_ParticlesAlive, 0, FrameReset, "# particles alive", &rmtp_Particles);
+DM_PROPERTY_GROUP(rmtp_Particles, "Particles", 0);
+DM_PROPERTY_U32(rmtp_ParticlesAlive, 0, PPF_FRAME_RESET, "# particles alive", &rmtp_Particles);
 
 namespace dmParticle
 {

--- a/engine/profiler/src/profiler.cpp
+++ b/engine/profiler/src/profiler.cpp
@@ -32,8 +32,8 @@
 #include <dmsdk/extension/extension.h>
 
 DM_PROPERTY_GROUP(rmtp_Profiler, "Profiler", 0);
-DM_PROPERTY_U32(rmtp_CpuUsage, 0, PPF_FRAME_RESET, "%% Cpu Usage", &rmtp_Profiler);
-DM_PROPERTY_U32(rmtp_Memory, 0, PPF_FRAME_RESET, "Memory usage in kb", &rmtp_Profiler);
+DM_PROPERTY_U32(rmtp_CpuUsage, 0, PROFILE_PROPERTY_FRAME_RESET, "%% Cpu Usage", &rmtp_Profiler);
+DM_PROPERTY_U32(rmtp_Memory, 0, PROFILE_PROPERTY_FRAME_RESET, "Memory usage in kb", &rmtp_Profiler);
 
 namespace dmProfiler
 {

--- a/engine/profiler/src/profiler.cpp
+++ b/engine/profiler/src/profiler.cpp
@@ -31,9 +31,9 @@
 #include <dmsdk/dlib/vmath.h>
 #include <dmsdk/extension/extension.h>
 
-DM_PROPERTY_GROUP(rmtp_Profiler, "Profiler");
-DM_PROPERTY_U32(rmtp_CpuUsage, 0, FrameReset, "%% Cpu Usage", &rmtp_Profiler);
-DM_PROPERTY_U32(rmtp_Memory, 0, FrameReset, "Memory usage in kb", &rmtp_Profiler);
+DM_PROPERTY_GROUP(rmtp_Profiler, "Profiler", 0);
+DM_PROPERTY_U32(rmtp_CpuUsage, 0, PPF_FRAME_RESET, "%% Cpu Usage", &rmtp_Profiler);
+DM_PROPERTY_U32(rmtp_Memory, 0, PPF_FRAME_RESET, "Memory usage in kb", &rmtp_Profiler);
 
 namespace dmProfiler
 {

--- a/engine/profiler/src/profiler_android.cpp
+++ b/engine/profiler/src/profiler_android.cpp
@@ -19,7 +19,7 @@
 #include "profiler_proc_utils.h"
 
 DM_PROPERTY_EXTERN(rmtp_Profiler);
-DM_PROPERTY_BOOL(rmtp_AttachedToJVM, false, PPF_FRAME_RESET, "Thread attached to JVM", &rmtp_Profiler);
+DM_PROPERTY_BOOL(rmtp_AttachedToJVM, false, PROFILE_PROPERTY_FRAME_RESET, "Thread attached to JVM", &rmtp_Profiler);
 
 extern struct android_app* __attribute__((weak)) g_AndroidApp;
 

--- a/engine/profiler/src/profiler_android.cpp
+++ b/engine/profiler/src/profiler_android.cpp
@@ -19,7 +19,7 @@
 #include "profiler_proc_utils.h"
 
 DM_PROPERTY_EXTERN(rmtp_Profiler);
-DM_PROPERTY_BOOL(rmtp_AttachedToJVM, false, FrameReset, "Thread attached to JVM", &rmtp_Profiler);
+DM_PROPERTY_BOOL(rmtp_AttachedToJVM, false, PPF_FRAME_RESET, "Thread attached to JVM", &rmtp_Profiler);
 
 extern struct android_app* __attribute__((weak)) g_AndroidApp;
 

--- a/engine/render/src/render/font_renderer.cpp
+++ b/engine/render/src/render/font_renderer.cpp
@@ -33,8 +33,8 @@
 #include "font_renderer_api.h"   // for the font renderer backend api
 
 DM_PROPERTY_EXTERN(rmtp_Render);
-DM_PROPERTY_U32(rmtp_FontCharacterCount, 0, PPF_FRAME_RESET, "# glyphs", &rmtp_Render);
-DM_PROPERTY_U32(rmtp_FontVertexSize, 0, PPF_FRAME_RESET, "size of vertices in bytes", &rmtp_Render);
+DM_PROPERTY_U32(rmtp_FontCharacterCount, 0, PROFILE_PROPERTY_FRAME_RESET, "# glyphs", &rmtp_Render);
+DM_PROPERTY_U32(rmtp_FontVertexSize, 0, PROFILE_PROPERTY_FRAME_RESET, "size of vertices in bytes", &rmtp_Render);
 
 namespace dmRender
 {

--- a/engine/render/src/render/font_renderer.cpp
+++ b/engine/render/src/render/font_renderer.cpp
@@ -33,8 +33,8 @@
 #include "font_renderer_api.h"   // for the font renderer backend api
 
 DM_PROPERTY_EXTERN(rmtp_Render);
-DM_PROPERTY_U32(rmtp_FontCharacterCount, 0, FrameReset, "# glyphs", &rmtp_Render);
-DM_PROPERTY_U32(rmtp_FontVertexSize, 0, FrameReset, "size of vertices in bytes", &rmtp_Render);
+DM_PROPERTY_U32(rmtp_FontCharacterCount, 0, PPF_FRAME_RESET, "# glyphs", &rmtp_Render);
+DM_PROPERTY_U32(rmtp_FontVertexSize, 0, PPF_FRAME_RESET, "size of vertices in bytes", &rmtp_Render);
 
 namespace dmRender
 {

--- a/engine/render/src/render/render.cpp
+++ b/engine/render/src/render/render.cpp
@@ -31,7 +31,7 @@
 #include "debug_renderer.h"
 #include "font_renderer.h"
 
-DM_PROPERTY_GROUP(rmtp_Render, "Renderer");
+DM_PROPERTY_GROUP(rmtp_Render, "Renderer", 0);
 
 namespace dmRender
 {

--- a/engine/resource/src/resource.cpp
+++ b/engine/resource/src/resource.cpp
@@ -64,7 +64,7 @@
  *  - Handle out of resources. Eg Hashtables full.
  */
 
-DM_PROPERTY_U32(rmtp_Resource, 0, PPF_FRAME_RESET, "# resources", 0);
+DM_PROPERTY_U32(rmtp_Resource, 0, PROFILE_PROPERTY_FRAME_RESET, "# resources", 0);
 
 
 struct ResourceReloadedCallbackPair

--- a/engine/resource/src/resource.cpp
+++ b/engine/resource/src/resource.cpp
@@ -64,7 +64,7 @@
  *  - Handle out of resources. Eg Hashtables full.
  */
 
-DM_PROPERTY_U32(rmtp_Resource, 0, FrameReset, "# resources");
+DM_PROPERTY_U32(rmtp_Resource, 0, PPF_FRAME_RESET, "# resources", 0);
 
 
 struct ResourceReloadedCallbackPair

--- a/engine/script/src/script.cpp
+++ b/engine/script/src/script.cpp
@@ -39,7 +39,7 @@ extern "C"
 #include <lua/lualib.h>
 }
 
-DM_PROPERTY_GROUP(rmtp_Script, "");
+DM_PROPERTY_GROUP(rmtp_Script, "", 0);
 
 namespace dmScript
 {

--- a/engine/script/src/script_timer.cpp
+++ b/engine/script/src/script_timer.cpp
@@ -24,7 +24,7 @@
 #include "script_private.h"
 
 DM_PROPERTY_EXTERN(rmtp_Script);
-DM_PROPERTY_U32(rmtp_TimerCount, 0, PPF_FRAME_RESET, "# timers", &rmtp_Script);
+DM_PROPERTY_U32(rmtp_TimerCount, 0, PROFILE_PROPERTY_FRAME_RESET, "# timers", &rmtp_Script);
 
 namespace dmScript
 {

--- a/engine/script/src/script_timer.cpp
+++ b/engine/script/src/script_timer.cpp
@@ -24,7 +24,7 @@
 #include "script_private.h"
 
 DM_PROPERTY_EXTERN(rmtp_Script);
-DM_PROPERTY_U32(rmtp_TimerCount, 0, FrameReset, "# timers", &rmtp_Script);
+DM_PROPERTY_U32(rmtp_TimerCount, 0, PPF_FRAME_RESET, "# timers", &rmtp_Script);
 
 namespace dmScript
 {


### PR DESCRIPTION
If you are a native extension developer and are using the `DM_PROFILE()` macros, there has been an api change.

The changes needed to update should be minimal.

Previous:
```c++
DM_PROPERTY_PROPERTY_GROUP(rmtp_TestGroup1);
DM_PROPERTY_BOOL(rmtp_TestBOOL, 0, FrameReset, "", &rmtp_TestGroup1);
```

Now, we've added the parent as an explicit argument, and we've converted the enum into a Defold specific enum:
```c++
DM_PROPERTY_GROUP(prop_TestGroup1, "", 0); // excplicit parent pointer, 0 in this case
DM_PROPERTY_BOOL(prop_TestBOOL, 0, PROFILE_PROPERTY_FRAME_RESET, "", &prop_TestGroup1);
```

### Technical changes

The properties are now represented by an opaque index.
Each implementation interacts with this index.
We now also don't expose Remotery.h in our dmsdk header.

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
