### PR TITLE
Take Bob’s parameters into consideration to decide which resources should be rebuilt

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/cache/test/ResourceCacheKeyTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/cache/test/ResourceCacheKeyTest.java
@@ -14,15 +14,28 @@
 
 package com.dynamo.bob.cache.test;
 
+import static java.util.Map.entry;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
+import java.lang.reflect.Field;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
-import java.util.HashMap;
+import java.util.Set;
+import java.util.stream.Collectors;
 
+import com.dynamo.bob.Bob;
+import com.dynamo.bob.BuilderParams;
+import com.dynamo.bob.Project;
+import com.dynamo.bob.fs.DefaultFileSystem;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -37,6 +50,7 @@ import com.dynamo.bob.test.util.MockResource;
 
 public class ResourceCacheKeyTest {
 
+	@BuilderParams(name = "DummyBuilder", outExt = "", inExts = {}, paramsForSignature = {"important_option"})
 	private class DummyBuilder extends Builder {
 		private TaskBuilder builder;
 
@@ -75,20 +89,10 @@ public class ResourceCacheKeyTest {
 		return fs.addFile(name, content.getBytes());
 	}
 
-	private Map<String, String> createImportantOptions() {
-		Map<String, String> options = new HashMap<String, String>();
-		options.put("important_option", "yep");
-		return options;
-	}
-	private Map<String, String> createEmptyOptions() {
-		return new HashMap<String, String>();
-	}
-
 	@Before
 	public void setUp() throws Exception {
 		fs = new MockFileSystem();
 		fs.setBuildDirectory("build");
-		ResourceCacheKey.includeOption("important_option");
 	}
 
 	@After
@@ -97,103 +101,233 @@ public class ResourceCacheKeyTest {
 
 	// can we create a cache key at all?
 	@Test
-	public void testBasicKeyCreation() throws CompileExceptionError, IOException {
+	public void testBasicKeyCreation() throws CompileExceptionError, IOException, NoSuchAlgorithmException {
 		IResource input = createResource("someInput");
 		IResource output = createResource("someOutput").output();
 
 		DummyBuilder builder = new DummyBuilder();
 		Task task = builder.addInput(input).addOutput(output).create(null);
-		String key = ResourceCacheKey.calculate(task, createEmptyOptions(), output);
+		String key = ResourceCacheKey.calculate(task.calculateSignature(), output);
 		assertTrue(key != null);
 	}
 
 	// do we always get the same key with the same input?
 	@Test
-	public void testDeterministicKeyCreation() throws CompileExceptionError, IOException {
+	public void testDeterministicKeyCreation() throws CompileExceptionError, IOException, NoSuchAlgorithmException {
 		IResource input = createResource("someInput");
 		IResource output = createResource("someOutput").output();
 
 		DummyBuilder builder1 = new DummyBuilder();
 		Task task1 = builder1.addInput(input).addOutput(output).create(null);
-		String key1 = ResourceCacheKey.calculate(task1, createEmptyOptions(), output);
+		String key1 = ResourceCacheKey.calculate(task1.calculateSignature(), output);
 
 		DummyBuilder builder2 = new DummyBuilder();
 		Task task2 = builder2.addInput(input).addOutput(output).create(null);
-		String key2 = ResourceCacheKey.calculate(task2, createEmptyOptions(), output);
+		String key2 = ResourceCacheKey.calculate(task2.calculateSignature(), output);
 
 		assertEquals(key1, key2);
 	}
 
 	// is project options taken into account and produce different keys?
 	@Test
-	public void testProjectOptions() throws CompileExceptionError, IOException {
+	public void testProjectOptions() throws CompileExceptionError, IOException, NoSuchAlgorithmException {
 		IResource input = createResource("someInput");
 		IResource output = createResource("someOutput").output();
 
 		DummyBuilder builder = new DummyBuilder();
 		Task task = builder.addInput(input).addOutput(output).create(null);
-		String key1 = ResourceCacheKey.calculate(task, createImportantOptions(), output);
-		String key2 = ResourceCacheKey.calculate(task, createEmptyOptions(), output);
+		String key1 = ResourceCacheKey.calculate(task.calculateSignature(), output);
+		DummyBuilder.addParamsDigest(DummyBuilder.class, Map.ofEntries(
+				entry("important_option", "yep")
+			), DummyBuilder.class.getAnnotation(BuilderParams.class));
+		String key2 = ResourceCacheKey.calculate(task.calculateSignature(), output);
 
 		assertNotEquals(key1, key2);
 	}
 
 	// are input resources taken into account and produce different keys?
 	@Test
-	public void testInputs() throws CompileExceptionError, IOException {
+	public void testInputs() throws CompileExceptionError, IOException, NoSuchAlgorithmException {
 		IResource input = createResource("someInput");
 		IResource output = createResource("someOutput").output();
 
 		DummyBuilder builder1 = new DummyBuilder();
 		Task task1 = builder1.addInput(input).addOutput(output).create(null);
-		String key1 = ResourceCacheKey.calculate(task1, createEmptyOptions(), output);
+		String key1 = ResourceCacheKey.calculate(task1.calculateSignature(), output);
 
 		DummyBuilder builder2 = new DummyBuilder();
 		input.setContent("someOtherInput".getBytes());
 		Task task2 = builder2.addInput(input).addOutput(output).create(null);
-		String key2 = ResourceCacheKey.calculate(task2, createEmptyOptions(), output);
+		String key2 = ResourceCacheKey.calculate(task2.calculateSignature(), output);
 
 		assertNotEquals(key1, key2);
 	}
 
 	// are output resource names taken into account and produce different keys?
 	@Test
-	public void testOutputNames() throws CompileExceptionError, IOException {
+	public void testOutputNames() throws CompileExceptionError, IOException, NoSuchAlgorithmException {
 		IResource input = createResource("someInput");
 
 		DummyBuilder builder1 = new DummyBuilder();
 		IResource output1 = createResource("someOutput").output();
 		Task task1 = builder1.addInput(input).addOutput(output1).create(null);
-		String key1 = ResourceCacheKey.calculate(task1, createEmptyOptions(), output1);
+		String key1 = ResourceCacheKey.calculate(task1.calculateSignature(), output1);
 
 		DummyBuilder builder2 = new DummyBuilder();
 		IResource output2 = createResource("someOutput").output();
 		Task task2 = builder2.addInput(input).addOutput(output2).create(null);
-		String key2 = ResourceCacheKey.calculate(task2, createEmptyOptions(), output2);
+		String key2 = ResourceCacheKey.calculate(task2.calculateSignature(), output2);
 
 		assertNotEquals(key1, key2);
 	}
 
 	// some project options have no impact on key creation
 	@Test
-	public void testIgnoredOptions() throws CompileExceptionError, IOException {
+	public void testIgnoredOptions() throws CompileExceptionError, IOException, NoSuchAlgorithmException {
 		IResource input = createResource("someInput");
 		IResource output = createResource("someOutput").output();
-
-		Map<String, String> ignoredOptions1 = new HashMap<String, String>();
-		ignoredOptions1.put("email", "foo@bar.com");
-		ignoredOptions1.put("debug", "true");
+		DummyBuilder.addParamsDigest(DummyBuilder.class, Map.ofEntries(
+				entry("not_important_option", "yep")
+		), DummyBuilder.class.getAnnotation(BuilderParams.class));
 		DummyBuilder builder1 = new DummyBuilder();
 		Task task1 = builder1.addInput(input).addOutput(output).create(null);
-		String key1 = ResourceCacheKey.calculate(task1, ignoredOptions1, output);
+		String key1 = ResourceCacheKey.calculate(task1.calculateSignature(), output);
 
-		Map<String, String> ignoredOptions2 = new HashMap<String, String>();
-		ignoredOptions2.put("email", "bob@acme.com");
-		ignoredOptions2.put("debug", "false");
 		DummyBuilder builder2 = new DummyBuilder();
 		Task task2 = builder2.addInput(input).addOutput(output).create(null);
-		String key2 = ResourceCacheKey.calculate(task2, ignoredOptions2, output);
+		String key2 = ResourceCacheKey.calculate(task2.calculateSignature(), output);
 
 		assertEquals(key1, key2);
+	}
+
+	// Ensure that all parameters specified in all builders exist in Bob
+	@Test
+	public void testAllParametersExist() throws IOException, CompileExceptionError, NoSuchFieldException, IllegalAccessException {
+		// Initialize project
+		Project project = new Project(new DefaultFileSystem());
+		project.scanJavaClasses();
+
+		// Access private static field classToParamsDigest
+		Class<?> builderClass = Builder.class;
+		Field field = builderClass.getDeclaredField("classToParamsDigest");
+		field.setAccessible(true);
+		Map<Class<?>, byte[]> map = (Map<Class<?>, byte[]>) field.get(null);
+
+		// Get all available command line options
+		List<Bob.CommandLineOption> commandLineOptions = Bob.getCommandLineOptions();
+		Set<String> allOptions = new HashSet<>();
+
+		// Collect all long options
+		for (Bob.CommandLineOption option : commandLineOptions) {
+			allOptions.add(option.longOpt);
+		}
+
+		// Validate each parameter in classToParamsDigest
+		for (Class<?> klass : map.keySet()) {
+			String[] params = klass.getAnnotation(BuilderParams.class).paramsForSignature();
+
+			for (String param : params) {
+				if (!allOptions.contains(param)) {
+					if (param.equals("important_option"))
+					{
+						assertEquals(BuilderParams.class.toString(), "interface com.dynamo.bob.BuilderParams");
+					}
+					else {
+						Assert.fail("Class " + klass.getName() + " uses parameter '" + param + "' in classToParamsDigest, but it does not exist in the command line options.");
+					}
+				}
+			}
+		}
+	}
+
+	// Fails if a new Bob parameter is added.
+	// Ensure that new Bob parameters do not affect build signatures.
+	// If a parameter does affect builders, add it to @BuilderParams -> paramsForSignature,
+	// then update the list in this test.
+	@Test
+	public void testNoNewParametersAdded() throws IOException, CompileExceptionError, NoSuchFieldException, IllegalAccessException {
+		// Initialize project
+		Project project = new Project(new DefaultFileSystem());
+		project.scanJavaClasses();
+
+		// Access private static field classToParamsDigest
+		Class<?> builderClass = Builder.class;
+		Field field = builderClass.getDeclaredField("classToParamsDigest");
+		field.setAccessible(true);
+		Map<Class<?>, byte[]> map = (Map<Class<?>, byte[]>) field.get(null);
+
+		// Get all available command line options
+		List<Bob.CommandLineOption> commandLineOptions = Bob.getCommandLineOptions();
+		List<String> allOptions = new ArrayList<>();
+
+		// Collect all long options
+		for (Bob.CommandLineOption option : commandLineOptions) {
+			allOptions.add(option.longOpt);
+		}
+		Collections.sort(allOptions);
+
+		List<String> existentParameters = new ArrayList<>(List.of(new String[]{
+                "architectures",
+                "archive",
+                "archive-resource-padding",
+                "auth",
+                "binary-output",
+                "build-artifacts",
+                "build-report",
+                "build-report-html",
+                "build-report-json",
+                "build-server",
+                "build-server-header",
+                "bundle-format",
+                "bundle-output",
+                "certificate",
+                "debug",
+                "debug-ne-upload",
+                "debug-output-hlsl",
+                "debug-output-spirv",
+                "debug-output-wgsl",
+                "defoldsdk",
+                "email",
+                "exclude-archive",
+                "exclude-build-folder",
+                "help",
+                "identity",
+                "input",
+                "key-pass",
+                "keystore",
+                "keystore-alias",
+                "keystore-pass",
+                "liveupdate",
+                "manifest-private-key",
+                "manifest-public-key",
+                "max-cpu-threads",
+                "mobileprovisioning",
+                "ne-build-dir",
+                "ne-output-name",
+                "output",
+                "platform",
+                "private-key",
+                "resource-cache-local",
+                "resource-cache-remote",
+                "resource-cache-remote-pass",
+                "resource-cache-remote-user",
+                "root",
+                "settings",
+                "strip-executable",
+                "texture-compression",
+                "texture-profiles",
+                "use-async-build-server",
+                "use-lua-bytecode-delta",
+                "use-uncompressed-lua-source",
+                "use-vanilla-lua",
+                "variant",
+                "verbose",
+                "version",
+                "with-sha1",
+                "with-symbols"}));
+
+		Collections.sort(existentParameters);
+
+		assertEquals("Lists are not equal!", existentParameters, allOptions);
 	}
 }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Bob.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Bob.java
@@ -55,7 +55,6 @@ import com.dynamo.bob.logging.LogHelper;
 import com.dynamo.bob.util.BobProjectProperties;
 import com.dynamo.bob.util.TimeProfiler;
 import com.dynamo.bob.util.HttpUtil;
-import com.dynamo.bob.cache.ResourceCacheKey;
 import com.dynamo.bob.util.FileUtil;
 
 import static com.dynamo.bob.Bob.CommandLineOption.ArgCount.*;
@@ -512,102 +511,98 @@ public class Bob {
         public enum ArgType {UNSPECIFIED, ABS_OR_CWD_REL_PATH}
     }
 
-    private static CommandLineOption opt(String shortOpt, String longOpt, CommandLineOption.ArgCount argCount, CommandLineOption.ArgType argType, String description,
-                                         boolean usedByResourceCacheKey) {
-        if (usedByResourceCacheKey) {
-            ResourceCacheKey.includeOption(longOpt);
-        }
+    private static CommandLineOption opt(String shortOpt, String longOpt, CommandLineOption.ArgCount argCount, CommandLineOption.ArgType argType, String description) {
         if (argCount == MANY) {
             description = description + ". More than one occurrence is allowed";
         }
         return new CommandLineOption(shortOpt, longOpt, argCount, argType, description);
     };
 
-    private static CommandLineOption opt(String shortOpt, String longOpt, CommandLineOption.ArgCount argCount, String description, boolean usedByResourceCacheKey) {
-        return opt(shortOpt, longOpt, argCount, CommandLineOption.ArgType.UNSPECIFIED, description, usedByResourceCacheKey);
+    private static CommandLineOption opt(String shortOpt, String longOpt, CommandLineOption.ArgCount argCount, String description) {
+        return opt(shortOpt, longOpt, argCount, CommandLineOption.ArgType.UNSPECIFIED, description);
     }
 
     public static List<CommandLineOption> getCommandLineOptions() {
         return List.of(
-                opt("r", "root", ONE, ABS_OR_CWD_REL_PATH, "Build root directory. Default is current directory", true),
-                opt("o", "output", ONE, "Output directory. Default is \"build/default\"", false),
-                opt("i", "input", ONE, "DEPRECATED! Use --root instead", true),
-                opt("v", "verbose", ZERO, "Verbose output", false),
-                opt("h", "help", ZERO, "This help message", false),
-                opt("a", "archive", ZERO, "Build archive", false),
-                opt("ea", "exclude-archive", ZERO, "Exclude resource archives from application bundle. Use this to create an empty Defold application for use as a build target", false),
-                opt("e", "email", ONE, "User email", false),
-                opt("u", "auth", ONE, "User auth token", false),
+                opt("r", "root", ONE, ABS_OR_CWD_REL_PATH, "Build root directory. Default is current directory"),
+                opt("o", "output", ONE, "Output directory. Default is \"build/default\""),
+                opt("i", "input", ONE, "DEPRECATED! Use --root instead"),
+                opt("v", "verbose", ZERO, "Verbose output"),
+                opt("h", "help", ZERO, "This help message"),
+                opt("a", "archive", ZERO, "Build archive"),
+                opt("ea", "exclude-archive", ZERO, "Exclude resource archives from application bundle. Use this to create an empty Defold application for use as a build target"),
+                opt("e", "email", ONE, "User email"),
+                opt("u", "auth", ONE, "User auth token"),
 
-                opt("p", "platform", ONE, "Platform (when building and bundling)", true),
-                opt("bo", "bundle-output", ONE, ABS_OR_CWD_REL_PATH,"Bundle output directory", false),
-                opt("bf", "bundle-format", ONE, "Which formats to create the application bundle in. Comma separated list. (Android: 'apk' and 'aab')", false),
+                opt("p", "platform", ONE, "Platform (when building and bundling)"),
+                opt("bo", "bundle-output", ONE, ABS_OR_CWD_REL_PATH,"Bundle output directory"),
+                opt("bf", "bundle-format", ONE, "Which formats to create the application bundle in. Comma separated list. (Android: 'apk' and 'aab')"),
 
-                opt("mp", "mobileprovisioning", ONE, ABS_OR_CWD_REL_PATH, "mobileprovisioning profile (iOS)", false),
-                opt(null, "identity", ONE, "Sign identity (iOS)", false),
+                opt("mp", "mobileprovisioning", ONE, ABS_OR_CWD_REL_PATH, "mobileprovisioning profile (iOS)"),
+                opt(null, "identity", ONE, "Sign identity (iOS)"),
 
-                opt("ce", "certificate", ONE, "DEPRECATED! Use --keystore instead", false),
-                opt("pk", "private-key", ONE, "DEPRECATED! Use --keystore instead", false),
+                opt("ce", "certificate", ONE, "DEPRECATED! Use --keystore instead"),
+                opt("pk", "private-key", ONE, "DEPRECATED! Use --keystore instead"),
 
-                opt("ks", "keystore", ONE, "Deployment keystore used to sign APKs (Android)", false),
-                opt("ksp", "keystore-pass", ONE, "Password of the deployment keystore (Android)", false),
-                opt("ksa", "keystore-alias", ONE, "The alias of the signing key+cert you want to use (Android)", false),
-                opt("kp", "key-pass", ONE, "Password of the deployment key if different from the keystore password (Android)", false),
+                opt("ks", "keystore", ONE, "Deployment keystore used to sign APKs (Android)"),
+                opt("ksp", "keystore-pass", ONE, "Password of the deployment keystore (Android)"),
+                opt("ksa", "keystore-alias", ONE, "The alias of the signing key+cert you want to use (Android)"),
+                opt("kp", "key-pass", ONE, "Password of the deployment key if different from the keystore password (Android)"),
 
-                opt("d", "debug", ZERO, "DEPRECATED! Use --variant=debug instead", false),
-                opt(null, "variant", ONE, "Specify debug, release or headless version of dmengine (when bundling)", false),
-                opt(null, "strip-executable", ZERO, "Strip the dmengine of debug symbols (when bundling iOS or Android)", false),
-                opt(null, "with-symbols", ZERO, "Generate the symbol file (if applicable)", false),
+                opt("d", "debug", ZERO, "DEPRECATED! Use --variant=debug instead"),
+                opt(null, "variant", ONE, "Specify debug, release or headless version of dmengine (when bundling)"),
+                opt(null, "strip-executable", ZERO, "Strip the dmengine of debug symbols (when bundling iOS or Android)"),
+                opt(null, "with-symbols", ZERO, "Generate the symbol file (if applicable)"),
 
-                opt("tp", "texture-profiles", ONE, "DEPRECATED! Use --texture-compression instead", true),
-                opt("tc", "texture-compression", ZERO, "Use texture compression as specified in texture profiles", true),
+                opt("tp", "texture-profiles", ONE, "DEPRECATED! Use --texture-compression instead"),
+                opt("tc", "texture-compression", ZERO, "Use texture compression as specified in texture profiles"),
 
-                opt(null, "exclude-build-folder", ONE, "DEPRECATED! Use '.defignore' file instead", true),
+                opt(null, "exclude-build-folder", ONE, "DEPRECATED! Use '.defignore' file instead"),
 
-                opt("br", "build-report", ONE, ABS_OR_CWD_REL_PATH, "DEPRECATED! Use --build-report-json instead", false),
-                opt("brjson", "build-report-json", ONE, ABS_OR_CWD_REL_PATH, "Filepath where to save a build report as JSON", false),
-                opt("brhtml", "build-report-html", ONE, ABS_OR_CWD_REL_PATH, "Filepath where to save a build report as HTML", false),
+                opt("br", "build-report", ONE, ABS_OR_CWD_REL_PATH, "DEPRECATED! Use --build-report-json instead"),
+                opt("brjson", "build-report-json", ONE, ABS_OR_CWD_REL_PATH, "Filepath where to save a build report as JSON"),
+                opt("brhtml", "build-report-html", ONE, ABS_OR_CWD_REL_PATH, "Filepath where to save a build report as HTML"),
 
-                opt(null, "build-server", ONE, "The build server (when using native extensions)", true),
-                opt(null, "build-server-header", MANY, "Additional build server header to set", true),
-                opt(null, "use-async-build-server", ZERO, "DEPRECATED! Asynchronous build is now the default", true),
-                opt(null, "defoldsdk", ONE, "What version of the defold sdk (sha1) to use", true),
-                opt(null, "binary-output", ONE, ABS_OR_CWD_REL_PATH, "Location where built engine binary will be placed. Default is \"<build-output>/<platform>/\"", true),
+                opt(null, "build-server", ONE, "The build server (when using native extensions)"),
+                opt(null, "build-server-header", MANY, "Additional build server header to set"),
+                opt(null, "use-async-build-server", ZERO, "DEPRECATED! Asynchronous build is now the default"),
+                opt(null, "defoldsdk", ONE, "What version of the defold sdk (sha1) to use"),
+                opt(null, "binary-output", ONE, ABS_OR_CWD_REL_PATH, "Location where built engine binary will be placed. Default is \"<build-output>/<platform>/\""),
 
-                opt(null, "use-vanilla-lua", ZERO, "DEPRECATED! Use --use-uncompressed-lua-source instead", true),
-                opt(null, "use-uncompressed-lua-source", ZERO, "Use uncompressed and unencrypted Lua source code instead of byte code", true),
-                opt(null, "use-lua-bytecode-delta", ZERO, "Use byte code delta compression when building for multiple architectures", true),
-                opt(null, "archive-resource-padding", ONE, "The alignment of the resources in the game archive. Default is 4", true),
+                opt(null, "use-vanilla-lua", ZERO, "DEPRECATED! Use --use-uncompressed-lua-source instead"),
+                opt(null, "use-uncompressed-lua-source", ZERO, "Use uncompressed and unencrypted Lua source code instead of byte code"),
+                opt(null, "use-lua-bytecode-delta", ZERO, "Use byte code delta compression when building for multiple architectures"),
+                opt(null, "archive-resource-padding", ONE, "The alignment of the resources in the game archive. Default is 4"),
 
-                opt("l", "liveupdate", ONE, "Yes if liveupdate content should be published", true),
+                opt("l", "liveupdate", ONE, "Yes if liveupdate content should be published"),
 
-                opt(null, "with-sha1", ZERO, "Generate (and verify) sha1 signatures from build artifacts (when bunding for web)", false),
+                opt(null, "with-sha1", ZERO, "Generate (and verify) sha1 signatures from build artifacts (when bunding for web)"),
 
-                opt("ar", "architectures", ONE, "Comma separated list of architectures to include for the platform", true),
+                opt("ar", "architectures", ONE, "Comma separated list of architectures to include for the platform"),
 
-                opt(null, "settings", MANY, ABS_OR_CWD_REL_PATH, "Path to a game project settings file. The settings files are applied left to right", false),
+                opt(null, "settings", MANY, ABS_OR_CWD_REL_PATH, "Path to a game project settings file. The settings files are applied left to right"),
 
-                opt(null, "version", ZERO, "Prints the version number to the output", false),
+                opt(null, "version", ZERO, "Prints the version number to the output"),
 
-                opt(null, "build-artifacts", ONE, "If left out, will default to build the engine. Choices: 'engine', 'plugins', 'library'. Comma separated list", false),
-                opt(null, "ne-build-dir", MANY, ABS_OR_CWD_REL_PATH, "Specify a folder with includes or source, to build a specific library", false),
-                opt(null, "ne-output-name", ONE, "Specify a library target name", false),
+                opt(null, "build-artifacts", ONE, "If left out, will default to build the engine. Choices: 'engine', 'plugins', 'library'. Comma separated list"),
+                opt(null, "ne-build-dir", MANY, ABS_OR_CWD_REL_PATH, "Specify a folder with includes or source, to build a specific library"),
+                opt(null, "ne-output-name", ONE, "Specify a library target name"),
 
-                opt(null, "resource-cache-local", ONE, ABS_OR_CWD_REL_PATH, "Path to local resource cache", false),
-                opt(null, "resource-cache-remote", ONE, "URL to remote resource cache", false),
-                opt(null, "resource-cache-remote-user", ONE, "Username to authenticate access to the remote resource cache", false),
-                opt(null, "resource-cache-remote-pass", ONE, "Password/token to authenticate access to the remote resource cache", false),
+                opt(null, "resource-cache-local", ONE, ABS_OR_CWD_REL_PATH, "Path to local resource cache"),
+                opt(null, "resource-cache-remote", ONE, "URL to remote resource cache"),
+                opt(null, "resource-cache-remote-user", ONE, "Username to authenticate access to the remote resource cache"),
+                opt(null, "resource-cache-remote-pass", ONE, "Password/token to authenticate access to the remote resource cache"),
 
-                opt(null, "manifest-private-key", ONE, "Private key to use when signing manifest and archive", false),
-                opt(null, "manifest-public-key", ONE, "Public key to use when signing manifest and archive", false),
+                opt(null, "manifest-private-key", ONE, "Private key to use when signing manifest and archive"),
+                opt(null, "manifest-public-key", ONE, "Public key to use when signing manifest and archive"),
 
-                opt(null, "max-cpu-threads", ONE, "Max count of threads that bob.jar can use", false),
+                opt(null, "max-cpu-threads", ONE, "Max count of threads that bob.jar can use"),
 
                 // debug options
-                opt(null, "debug-ne-upload", ZERO, "Outputs the files sent to build server as upload.zip", false),
-                opt(null, "debug-output-spirv", ONE, "Force build SPIR-V shaders", false),
-                opt(null, "debug-output-wgsl", ONE, "Force build WGSL shaders", false),
-                opt(null, "debug-output-hlsl", ONE, "Force build HLSL shaders", false)
+                opt(null, "debug-ne-upload", ZERO, "Outputs the files sent to build server as upload.zip"),
+                opt(null, "debug-output-spirv", ONE, "Force build SPIR-V shaders"),
+                opt(null, "debug-output-wgsl", ONE, "Force build WGSL shaders"),
+                opt(null, "debug-output-hlsl", ONE, "Force build HLSL shaders")
         );
     }
 

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Builder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Builder.java
@@ -16,6 +16,10 @@ package com.dynamo.bob;
 
 import java.io.IOException;
 import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 
 import com.dynamo.bob.fs.IResource;
 import com.dynamo.bob.pipeline.BuilderUtil;
@@ -25,6 +29,30 @@ import com.dynamo.bob.pipeline.BuilderUtil;
  * @author Christian Murray
  */
 public abstract class Builder {
+
+    private static Map<Class<?>,  byte[]> classToParamsDigest = new HashMap<Class<?>,  byte[]>();
+
+    public static void addProtoDigest(Class<?> klass, Project project, BuilderParams builderParams) throws NoSuchAlgorithmException {
+        if (classToParamsDigest.get(klass) == null) {
+            String[] params = builderParams.paramsForSignature();
+            if (params.length == 0) {
+                return;
+            }
+            MessageDigest digest = MessageDigest.getInstance("SHA1");
+            Map<String, String> options = project.getOptions();
+            Arrays.sort(params);
+            for (String param: params) {
+                if (options.containsKey(param)) {
+                    digest.update(param.getBytes());
+                    String value = options.get(param);
+                    if (value != null && !value.isEmpty()) {
+                        digest.update(value.getBytes());
+                    }
+                }
+            }
+            classToParamsDigest.put(klass, digest.digest());
+        }
+    }
 
     protected BuilderParams params;
     protected Project project;
@@ -119,7 +147,10 @@ public abstract class Builder {
      * @param digest message digest to update
      */
     public void signature(MessageDigest digest) {
-
+        byte[] paramsDigest = classToParamsDigest.get(this.getClass());
+        if (paramsDigest != null) {
+            digest.update(paramsDigest);
+        }
     }
 
     /**

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Builder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Builder.java
@@ -19,9 +19,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 
 import com.dynamo.bob.fs.IResource;
 import com.dynamo.bob.pipeline.BuilderUtil;
@@ -36,9 +34,8 @@ public abstract class Builder {
 
     public static void addParamsDigest(Class<?> klass, Map<String, String> options, BuilderParams builderParams) throws NoSuchAlgorithmException {
         String[] params = builderParams.paramsForSignature();
-        Set<String> paramSet = new HashSet<>(Arrays.asList(params));
-        if (paramSet.add("defoldsdk")) {
-            params = paramSet.toArray(new String[0]);
+        if (params.length == 0) {
+            return;
         }
         MessageDigest digest = MessageDigest.getInstance("SHA1");
         Arrays.sort(params);

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Builder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Builder.java
@@ -19,7 +19,9 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 import com.dynamo.bob.fs.IResource;
 import com.dynamo.bob.pipeline.BuilderUtil;
@@ -34,8 +36,9 @@ public abstract class Builder {
 
     public static void addParamsDigest(Class<?> klass, Map<String, String> options, BuilderParams builderParams) throws NoSuchAlgorithmException {
         String[] params = builderParams.paramsForSignature();
-        if (params.length == 0) {
-            return;
+        Set<String> paramSet = new HashSet<>(Arrays.asList(params));
+        if (paramSet.add("defoldsdk")) {
+            params = paramSet.toArray(new String[0]);
         }
         MessageDigest digest = MessageDigest.getInstance("SHA1");
         Arrays.sort(params);

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Builder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Builder.java
@@ -33,24 +33,22 @@ public abstract class Builder {
     private static Map<Class<?>,  byte[]> classToParamsDigest = new HashMap<Class<?>,  byte[]>();
 
     public static void addParamsDigest(Class<?> klass, Map<String, String> options, BuilderParams builderParams) throws NoSuchAlgorithmException {
-        if (classToParamsDigest.get(klass) == null) {
-            String[] params = builderParams.paramsForSignature();
-            if (params.length == 0) {
-                return;
-            }
-            MessageDigest digest = MessageDigest.getInstance("SHA1");
-            Arrays.sort(params);
-            for (String param: params) {
-                if (options.containsKey(param)) {
-                    digest.update(param.getBytes());
-                    String value = options.get(param);
-                    if (value != null && !value.isEmpty()) {
-                        digest.update(value.getBytes());
-                    }
+        String[] params = builderParams.paramsForSignature();
+        if (params.length == 0) {
+            return;
+        }
+        MessageDigest digest = MessageDigest.getInstance("SHA1");
+        Arrays.sort(params);
+        for (String param: params) {
+            if (options.containsKey(param)) {
+                digest.update(param.getBytes());
+                String value = options.get(param);
+                if (value != null && !value.isEmpty()) {
+                    digest.update(value.getBytes());
                 }
             }
-            classToParamsDigest.put(klass, digest.digest());
         }
+        classToParamsDigest.put(klass, digest.digest());
     }
 
     protected BuilderParams params;

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Builder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Builder.java
@@ -32,14 +32,13 @@ public abstract class Builder {
 
     private static Map<Class<?>,  byte[]> classToParamsDigest = new HashMap<Class<?>,  byte[]>();
 
-    public static void addProtoDigest(Class<?> klass, Project project, BuilderParams builderParams) throws NoSuchAlgorithmException {
+    public static void addParamsDigest(Class<?> klass, Map<String, String> options, BuilderParams builderParams) throws NoSuchAlgorithmException {
         if (classToParamsDigest.get(klass) == null) {
             String[] params = builderParams.paramsForSignature();
             if (params.length == 0) {
                 return;
             }
             MessageDigest digest = MessageDigest.getInstance("SHA1");
-            Map<String, String> options = project.getOptions();
             Arrays.sort(params);
             for (String param: params) {
                 if (options.containsKey(param)) {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/BuilderParams.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/BuilderParams.java
@@ -50,4 +50,10 @@ public @interface BuilderParams {
      * @return if task should be cached
      */
     boolean isCacheble() default false;
+
+    /**
+     * Get parameters that should be included in the task signature produced by the builder
+     * @return Bob parameters that may affect the builder's task signature
+     */
+    String[] paramsForSignature() default {};
 }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
@@ -355,7 +355,7 @@ public class Project {
                             extToBuilder.put(inExt, (Class<? extends Builder>) klass);
                             inextToOutext.put(inExt, builderParams.outExt());
                         }
-                        Builder.addProtoDigest(klass, this, builderParams);
+                        Builder.addParamsDigest(klass, this.getOptions(), builderParams);
                         ProtoParams protoParams = klass.getAnnotation(ProtoParams.class);
                         if (protoParams != null) {
                             ProtoBuilder.addMessageClass(builderParams.outExt(), protoParams.messageClass());

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
@@ -1321,7 +1321,6 @@ public class Project {
         createClassLoaderScanner();
         registerPipelinePlugins();
         scan(scanner, "com.dynamo.bob");
-        scan(scanner, "com.dynamo.bob.pipeline");
         scan(scanner, "com.defold.extension.pipeline");
     }
 

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
@@ -25,7 +25,6 @@ import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
-import java.lang.reflect.Array;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -34,7 +33,6 @@ import java.net.HttpURLConnection;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URI;
-import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.FileTime;
 import java.text.ParseException;
 import java.util.*;
@@ -100,7 +98,6 @@ import com.dynamo.graphics.proto.Graphics.TextureProfiles;
 
 import com.dynamo.bob.cache.ResourceCache;
 import org.codehaus.jackson.JsonNode;
-import org.codehaus.jackson.JsonProcessingException;
 import org.codehaus.jackson.map.ObjectMapper;
 
 /**
@@ -358,7 +355,7 @@ public class Project {
                             extToBuilder.put(inExt, (Class<? extends Builder>) klass);
                             inextToOutext.put(inExt, builderParams.outExt());
                         }
-
+                        Builder.addProtoDigest(klass, this, builderParams);
                         ProtoParams protoParams = klass.getAnnotation(ProtoParams.class);
                         if (protoParams != null) {
                             ProtoBuilder.addMessageClass(builderParams.outExt(), protoParams.messageClass());

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/ProtoBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/ProtoBuilder.java
@@ -203,6 +203,9 @@ public abstract class ProtoBuilder<B extends GeneratedMessageV3.Builder<B>> exte
     @Override
     public void signature(MessageDigest digest) {
         super.signature(digest);
-        digest.update(classToProtoDigest.get(protoParams.messageClass()));
+        byte[] protoDigest = classToProtoDigest.get(protoParams.messageClass());
+        if (protoDigest != null) {
+            digest.update(protoDigest);
+        }
     }
 }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Task.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Task.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.HashSet;
 import java.util.Comparator;
 
+import com.dynamo.bob.archive.EngineVersion;
 import com.dynamo.bob.fs.IResource;
 
 /**
@@ -192,6 +193,7 @@ public class Task {
             throw new RuntimeException(e);
         }
 
+        digest.update(EngineVersion.sha1.getBytes());
         updateDigestWithResources(digest, inputs);
         updateDigestWithExtraCacheKeys(digest, extraCacheKeys);
 

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Task.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Task.java
@@ -193,7 +193,6 @@ public class Task {
             throw new RuntimeException(e);
         }
 
-        digest.update(EngineVersion.sha1.getBytes());
         updateDigestWithResources(digest, inputs);
         updateDigestWithExtraCacheKeys(digest, extraCacheKeys);
 

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/TaskBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/TaskBuilder.java
@@ -14,15 +14,14 @@
 
 package com.dynamo.bob;
 
-import com.dynamo.bob.TaskResult;
 import com.dynamo.bob.TaskResult.Result;
+import com.dynamo.bob.cache.ResourceCacheKey;
 import com.dynamo.bob.fs.IResource;
 import com.dynamo.bob.bundle.BundleHelper;
 import com.dynamo.bob.util.TimeProfiler;
 import com.dynamo.bob.util.TimeProfiler.ProfilingScope;
 import com.dynamo.bob.util.StringUtil;
 import com.dynamo.bob.cache.ResourceCache;
-import com.dynamo.bob.cache.ResourceCacheKey;
 import com.dynamo.bob.logging.Logger;
 
 import java.util.Arrays;
@@ -32,7 +31,6 @@ import java.util.ArrayList;
 import java.util.Map;
 import java.util.HashMap;
 import java.util.Set;
-import java.util.EnumSet;
 import java.util.HashSet;
 
 import java.io.IOException;
@@ -42,7 +40,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 import java.util.concurrent.Executors;
-
 
 public class TaskBuilder {
 
@@ -68,7 +65,6 @@ public class TaskBuilder {
     private Set<Task> tasks;
 
     private Project project;
-    private Map<String, String> options;
     private State state;
     private ResourceCache resourceCache;
 
@@ -84,7 +80,6 @@ public class TaskBuilder {
     public TaskBuilder(List<Task> tasks, Project project) {
         this.tasks = new HashSet<Task>(tasks);
         this.project = project;
-        this.options = project.getOptions();
         this.state = project.getState();
         this.resourceCache = project.getResourceCache();
 
@@ -130,7 +125,6 @@ public class TaskBuilder {
         return dependencies;
     }
 
-
     private boolean checkIfResourcesExist(final List<IResource> resources) {
         // do all output files exist?
         boolean allResourcesExists = true;
@@ -173,7 +167,7 @@ public class TaskBuilder {
                     // check if all output resources exist in the resource cache
                     boolean allResourcesCached = true;
                     for (IResource r : outputResources) {
-                        final String key = ResourceCacheKey.calculate(task, options, r);
+                        final String key = ResourceCacheKey.calculate(taskSignature, r);
                         outputResourceToCacheKey.put(r, key);
                         if (!r.isCacheable()) {
                             allResourcesCached = false;

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/cache/ResourceCacheKey.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/cache/ResourceCacheKey.java
@@ -15,65 +15,26 @@
 package com.dynamo.bob.cache;
 
 import java.security.MessageDigest;
-import java.util.List;
-import java.util.ArrayList;
-import java.util.Map;
-import java.util.Set;
-import java.util.HashSet;
-import java.util.Collections;
+import java.security.NoSuchAlgorithmException;
 import java.io.IOException;
 import java.math.BigInteger;
 
-import com.dynamo.bob.Task;
 import com.dynamo.bob.fs.IResource;
-import com.dynamo.bob.archive.EngineVersion;
 
 public class ResourceCacheKey {
 
-	/*
-	 * A set of options which have an impact on the created resources
-	 * and must be included when calculating the resource key
-	 */
-	private static Set<String> options = new HashSet<String>();
-
-	/**
-	 * Add an option that should be included in the resource key
-	 * calculation
-	 */
-	public static void includeOption(String option) {
-		options.add(option);
-	}
-
-
 	/**
 	 * Calculate the key to use when caching a resource.
-	 * The key is created from the task used which created the resource, the
-	 * bytes of the resource itself, as well as engine sha and project options.
-	 * @param task The task which created the resource
-	 * @param projectOptions The project options
+	 * The key is created from the task used which created the resource and the
+	 * bytes of the resource path.
+	 * @param taskSignature The task which created the resource
 	 * @param resource The resource to calculate cache key for
 	 * @return The cache key as a hex string
 	 */
-	public static String calculate(Task task, Map<String, String> projectOptions, IResource resource) throws RuntimeException, IOException {
-		MessageDigest digest = task.calculateSignatureDigest();
-
+	public static String calculate(byte[] taskSignature, IResource resource) throws RuntimeException, IOException, NoSuchAlgorithmException {
+		MessageDigest digest = MessageDigest.getInstance("SHA1");
+        digest.update(taskSignature);
 		digest.update(resource.getPath().getBytes());
-		digest.update(EngineVersion.sha1.getBytes());
-
-		// sort and add project options
-		List<String> keys = new ArrayList<String>(projectOptions.keySet());
-		Collections.sort(keys);
-		for (String key : keys) {
-			if (options.contains(key)) {
-				digest.update(key.getBytes());
-				String value = projectOptions.get(key);
-				if (value == null) {
-					value = "";
-				}
-				digest.update(value.getBytes());
-			}
-		}
-
 		byte[] key = digest.digest();
 		// byte digest to hex string
 		return new BigInteger(1, key).toString(16);

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/cache/ResourceCacheKey.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/cache/ResourceCacheKey.java
@@ -19,6 +19,7 @@ import java.security.NoSuchAlgorithmException;
 import java.io.IOException;
 import java.math.BigInteger;
 
+import com.dynamo.bob.archive.EngineVersion;
 import com.dynamo.bob.fs.IResource;
 
 public class ResourceCacheKey {
@@ -34,6 +35,7 @@ public class ResourceCacheKey {
 	public static String calculate(byte[] taskSignature, IResource resource) throws RuntimeException, IOException, NoSuchAlgorithmException {
 		MessageDigest digest = MessageDigest.getInstance("SHA1");
         digest.update(taskSignature);
+		digest.update(EngineVersion.sha1.getBytes());
 		digest.update(resource.getPath().getBytes());
 		byte[] key = digest.digest();
 		// byte digest to hex string

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/AtlasBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/AtlasBuilder.java
@@ -48,7 +48,7 @@ import com.dynamo.gamesys.proto.AtlasProto.AtlasImage;
 import com.google.protobuf.TextFormat;
 
 @ProtoParams(srcClass = Atlas.class, messageClass = TextureSet.class)
-@BuilderParams(name = "Atlas", inExts = {".atlas"}, outExt = ".a.texturesetc", isCacheble = true)
+@BuilderParams(name = "Atlas", inExts = {".atlas"}, outExt = ".a.texturesetc", isCacheble = true, paramsForSignature = {"texture-compression"})
 public class AtlasBuilder extends ProtoBuilder<Atlas.Builder> {
 
     private static final Logger logger = Logger.getLogger(AtlasBuilder.class.getName());

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/CubemapBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/CubemapBuilder.java
@@ -34,7 +34,7 @@ import com.dynamo.graphics.proto.Graphics.TextureImage.Type;
 import com.dynamo.graphics.proto.Graphics.TextureProfile;
 
 @ProtoParams(srcClass = Cubemap.class, messageClass = Cubemap.class)
-@BuilderParams(name = "Cubemap", inExts = {".cubemap"}, outExt = ".cubemapc", isCacheble = true)
+@BuilderParams(name = "Cubemap", inExts = {".cubemap"}, outExt = ".cubemapc", isCacheble = true, paramsForSignature = {"texture-compression"})
 public class CubemapBuilder extends ProtoBuilder<Cubemap.Builder> {
 
     private static Logger logger = Logger.getLogger(CubemapBuilder.class.getName());

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/GameProjectBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/GameProjectBuilder.java
@@ -68,7 +68,8 @@ import com.dynamo.rig.proto.Rig.AnimationSet;
 
 import static com.dynamo.bob.util.ComponentsCounter.isCompCounterStorage;
 
-@BuilderParams(name = "GameProjectBuilder", inExts = ".project", outExt = "")
+@BuilderParams(name = "GameProjectBuilder", inExts = ".project", outExt = "", paramsForSignature = {"liveupdate", "variant", "archive", "archive-resource-padding",
+                "platform", "manifest-private-key", "manifest-public-key"})
 public class GameProjectBuilder extends Builder {
 
     // Root nodes to follow (default values from engine.cpp)

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ScriptBuilders.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ScriptBuilders.java
@@ -21,19 +21,19 @@ import com.dynamo.lua.proto.Lua.LuaModule;
 public class ScriptBuilders {
 
     @ProtoParams(srcClass = LuaModule.class, messageClass = LuaModule.class)
-    @BuilderParams(name = "Lua", inExts = ".lua", outExt = ".luac")
+    @BuilderParams(name = "Lua", inExts = ".lua", outExt = ".luac", paramsForSignature = {"use-uncompressed-lua-source", "use-lua-bytecode-delta", "platform", "architectures"})
     public static class LuaScriptBuilder extends LuaBuilder {}
 
     @ProtoParams(srcClass = LuaModule.class, messageClass = LuaModule.class)
-    @BuilderParams(name = "Script", inExts = ".script", outExt = ".scriptc")
+    @BuilderParams(name = "Script", inExts = ".script", outExt = ".scriptc", paramsForSignature = {"use-uncompressed-lua-source", "use-lua-bytecode-delta", "platform", "architectures"})
     public static class ScriptBuilder extends LuaBuilder {}
 
     @ProtoParams(srcClass = LuaModule.class, messageClass = LuaModule.class)
-    @BuilderParams(name = "GuiScript", inExts = ".gui_script", outExt = ".gui_scriptc")
+    @BuilderParams(name = "GuiScript", inExts = ".gui_script", outExt = ".gui_scriptc", paramsForSignature = {"use-uncompressed-lua-source", "use-lua-bytecode-delta", "platform", "architectures"})
     public static class GuiScriptBuilder extends LuaBuilder {}
 
     @ProtoParams(srcClass = LuaModule.class, messageClass = LuaModule.class)
-    @BuilderParams(name = "RenderScript", inExts = ".render_script", outExt = ".render_scriptc")
+    @BuilderParams(name = "RenderScript", inExts = ".render_script", outExt = ".render_scriptc", paramsForSignature = {"use-uncompressed-lua-source", "use-lua-bytecode-delta", "platform", "architectures"})
     public static class RenderScriptBuilder extends LuaBuilder {}
 
 }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderProgramBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderProgramBuilder.java
@@ -39,7 +39,7 @@ import com.dynamo.bob.pipeline.shader.SPIRVReflector;
 
 import com.dynamo.graphics.proto.Graphics.ShaderDesc;
 
-@BuilderParams(name="ShaderProgramBuilder", inExts= {".shbundle", ".shbundlec"}, outExt=".spc")
+@BuilderParams(name="ShaderProgramBuilder", inExts= {".shbundle", ".shbundlec"}, outExt=".spc", paramsForSignature = {"platform"})
 public class ShaderProgramBuilder extends Builder {
 
     static public class ShaderBuildResult {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderProgramBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderProgramBuilder.java
@@ -99,14 +99,9 @@ public class ShaderProgramBuilder extends Builder {
 
         compileOptions = modules.getCompileOptions();
 
-        String platformString = this.project.getPlatformStrings()[0];
-
-        // Include the spir-v flag into the cache key so we can invalidate the output results accordingly
-        // NOTE: We include the platform string as well for the same reason as spirv, but it doesn't seem to work correctly.
-        //       Keeping the build folder and rebuilding for a different platform _should_ invalidate the cache, but it doesn't.
-        //       Needs further investigation!
-        String shaderCacheKey = String.format("output_spirv=%s;output_hlsl=%s;output_wgsl=%s;platform_key=%s",
-                getOutputSpirvFlag(), getOutputHlslFlag(), getOutputWGSLFlag(),  platformString);
+        // Include the spir-v flag into the cache key, so we can invalidate the output results accordingly
+        String shaderCacheKey = String.format("output_spirv=%s;output_hlsl=%s;output_wgsl=%s",
+                getOutputSpirvFlag(), getOutputHlslFlag(), getOutputWGSLFlag());
 
         taskBuilder.addOutput(input.changeExt(params.outExt()));
         taskBuilder.addExtraCacheKey(shaderCacheKey);

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/TextureBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/TextureBuilder.java
@@ -27,7 +27,7 @@ import com.dynamo.bob.logging.Logger;
 import com.dynamo.bob.util.TextureUtil;
 import com.dynamo.graphics.proto.Graphics.TextureProfile;
 
-@BuilderParams(name = "Texture", inExts = {".png", ".jpg"}, outExt = ".texturec", isCacheble = true)
+@BuilderParams(name = "Texture", inExts = {".png", ".jpg"}, outExt = ".texturec", isCacheble = true, paramsForSignature = {"texture-compression"})
 public class TextureBuilder extends Builder {
 
     private static Logger logger = Logger.getLogger(TextureBuilder.class.getName());

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/TextureProfilesBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/TextureProfilesBuilder.java
@@ -14,7 +14,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 @ProtoParams(srcClass = Graphics.TextureProfiles.class, messageClass = Graphics.TextureProfiles.class)
-@BuilderParams(name = "TextureProfile", inExts = {".texture_profiles"}, outExt = ".texture_profilesc")
+@BuilderParams(name = "TextureProfile", inExts = {".texture_profiles"}, outExt = ".texture_profilesc", paramsForSignature = {"platform"})
 public class TextureProfilesBuilder extends ProtoBuilder<Graphics.TextureProfiles.Builder> {
 
     public void build(Task task) throws CompileExceptionError, IOException {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/TileSetBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/TileSetBuilder.java
@@ -39,7 +39,7 @@ import com.dynamo.gamesys.proto.TextureSetProto.TextureSet;
 import com.dynamo.gamesys.proto.Tile.TileSet;
 
 @ProtoParams(srcClass = TileSet.class, messageClass = TileSet.class)
-@BuilderParams(name = "TileSet", inExts = {".tileset", ".tilesource"}, outExt = ".t.texturesetc", isCacheble = true)
+@BuilderParams(name = "TileSet", inExts = {".tileset", ".tilesource"}, outExt = ".t.texturesetc", isCacheble = true, paramsForSignature = {"texture-compression"})
 public class TileSetBuilder extends ProtoBuilder<TileSet.Builder> {
 
     private static Logger logger = Logger.getLogger(TileSetBuilder.class.getName());


### PR DESCRIPTION
Now Bob knows which resources may be affected by its parameters and rebuilds only those resources. For example, if the first bundle is done with `--texture-compression` and the second bundle is done without it, all textures, atlases, and other related resources will be rebuilt.
This should improve the experience when bundling without the `clean` parameter for Bob.

Fix https://github.com/defold/defold/issues/10217
Fix https://github.com/defold/defold/issues/3306