### PR TITLE
Fix property-type-preservation-test

### DIFF
--- a/editor/src/clj/editor/app_manifest.clj
+++ b/editor/src/clj/editor/app_manifest.clj
@@ -382,7 +382,8 @@
     :vulkan (concat
               vulkan-toggles
               (exclude-libs-toggles vulkan ["graphics"])
-              (generic-contains-toggles vulkan :excludeSymbols ["GraphicsAdapterOpenGL"]))
+              (generic-contains-toggles (disj vulkan :arm64-linux) :excludeSymbols ["GraphicsAdapterOpenGL"])
+              [(contains-toggle :arm64-linux :excludeSymbols "GraphicsAdapterOpenGLES")])
     :both vulkan-toggles
     :open-gl))
 

--- a/editor/test/integration/property_type_preservation_test.clj
+++ b/editor/test/integration/property_type_preservation_test.clj
@@ -106,7 +106,6 @@
 
 (defn- make-property-widget
   ^Parent [edit-type node-id prop-kw]
-  #_(test-util/with-ui-run-later-rebound)
   (let [context {}
         coalesced-prop-info-fn (make-coalesced-prop-info-fn node-id prop-kw)
         [widget _update-ui-fn] (properties-view/create-property-control! edit-type context coalesced-prop-info-fn)]

--- a/editor/test/integration/property_type_preservation_test.clj
+++ b/editor/test/integration/property_type_preservation_test.clj
@@ -106,6 +106,7 @@
 
 (defn- make-property-widget
   ^Parent [edit-type node-id prop-kw]
+  #_(test-util/with-ui-run-later-rebound)
   (let [context {}
         coalesced-prop-info-fn (make-coalesced-prop-info-fn node-id prop-kw)
         [widget _update-ui-fn] (properties-view/create-property-control! edit-type context coalesced-prop-info-fn)]
@@ -207,28 +208,29 @@
 
 (defn- ensure-numeric-properties-preserve-type! [original-property-values]
   (with-clean-system
-    (let [original-meta {:version "original"}
+    (test-util/with-ui-run-later-rebound
+      (let [original-meta {:version "original"}
 
-          property-values
-          (into (sorted-map)
-                (map (fn [[prop-kw prop-value]]
-                       (let [decorated-value (if (vector? prop-value)
-                                               (with-meta prop-value original-meta)
-                                               prop-value)]
-                         [prop-kw decorated-value])))
-                original-property-values)
-
-          graph-id (g/make-graph! :history true)
-          node-id (apply g/make-node! graph-id NumericPropertiesNode (mapcat identity property-values))]
-      (let [edit-type-by-prop-kw
+            property-values
             (into (sorted-map)
-                  (map (fn [[prop-kw prop-info]]
-                         (let [edit-type (properties/property-edit-type prop-info)]
-                           [prop-kw edit-type])))
-                  (:properties (g/node-value node-id :_properties)))]
-        (doseq [[prop-kw edit-type] edit-type-by-prop-kw]
-          (testing (format "Types preserved after editing (property %s)" (name prop-kw))
-            (test-property-widget! edit-type node-id prop-kw)))))))
+                  (map (fn [[prop-kw prop-value]]
+                         (let [decorated-value (if (vector? prop-value)
+                                                 (with-meta prop-value original-meta)
+                                                 prop-value)]
+                           [prop-kw decorated-value])))
+                  original-property-values)
+
+            graph-id (g/make-graph! :history true)
+            node-id (apply g/make-node! graph-id NumericPropertiesNode (mapcat identity property-values))]
+        (let [edit-type-by-prop-kw
+              (into (sorted-map)
+                    (map (fn [[prop-kw prop-info]]
+                           (let [edit-type (properties/property-edit-type prop-info)]
+                             [prop-kw edit-type])))
+                    (:properties (g/node-value node-id :_properties)))]
+          (doseq [[prop-kw edit-type] edit-type-by-prop-kw]
+            (testing (format "Types preserved after editing (property %s)" (name prop-kw))
+              (test-property-widget! edit-type node-id prop-kw))))))))
 
 (deftest numeric-properties-preserve-type-test
   (testing "Values are floats in generic vectors before editing"


### PR DESCRIPTION
Now that we use `run-later` in the properties view, we need to rebind it for tests that use the views.