### PR TITLE
Reduce the size of the `dmanifest` file in the build and in LiveUpdate

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/archive/ManifestBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/archive/ManifestBuilder.java
@@ -44,6 +44,7 @@ import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.NoSuchPaddingException;
 import javax.security.auth.DestroyFailedException;
 
+import com.dynamo.bob.Bob;
 import com.dynamo.bob.pipeline.graph.ResourceNode;
 import com.dynamo.bob.pipeline.graph.ResourceGraph;
 import com.dynamo.bob.util.MurmurHash;
@@ -283,6 +284,7 @@ public class ManifestBuilder {
     private String privateKeyFilepath = null;
     private String publicKeyFilepath = null;
     private String projectIdentifier = null;
+    private String buildVariant = null;
     private ResourceGraph resourceGraph = null;
     private boolean outputManifestHash = false;
     private byte[] manifestDataHash = null;
@@ -375,6 +377,10 @@ public class ManifestBuilder {
 
     public void setProjectIdentifier(String projectIdentifier) {
         this.projectIdentifier = projectIdentifier;
+    }
+
+    public void setBuildVariant(String variant) {
+        buildVariant = variant;
     }
 
     public void setArchiveIdentifier(byte[] archiveIdentifier) {
@@ -491,7 +497,6 @@ public class ManifestBuilder {
         buildUrlToResourceMap(this.resourceEntries);
 
         builder.addAllEngineVersions(this.supportedEngineVersions);
-
         for (ResourceEntry entry : this.resourceEntries) {
             String url = entry.getUrl();
             ResourceEntry.Builder resourceEntryBuilder = entry.toBuilder();
@@ -515,6 +520,9 @@ public class ManifestBuilder {
                     }
                     resourceEntryBuilder.addDependants(resource.getUrlHash());
                 }
+            }
+            if (buildVariant.equals(Bob.VARIANT_RELEASE)) {
+                resourceEntryBuilder.setUrl("");
             }
             builder.addResources(resourceEntryBuilder.build());
         }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/archive/ManifestBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/archive/ManifestBuilder.java
@@ -521,7 +521,7 @@ public class ManifestBuilder {
                     resourceEntryBuilder.addDependants(resource.getUrlHash());
                 }
             }
-            if (buildVariant.equals(Bob.VARIANT_RELEASE)) {
+            if (buildVariant != null && buildVariant.equals(Bob.VARIANT_RELEASE)) {
                 resourceEntryBuilder.setUrl("");
             }
             builder.addResources(resourceEntryBuilder.build());

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/GameProjectBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/GameProjectBuilder.java
@@ -245,6 +245,7 @@ public class GameProjectBuilder extends Builder {
 
     private ManifestBuilder createManifestBuilder(ResourceGraph resourceGraph) throws IOException {
         String projectIdentifier = project.getProjectProperties().getStringValue("project", "title", "<anonymous>");
+        final String variant = project.option("variant", Bob.VARIANT_RELEASE);
         String supportedEngineVersionsString = project.getPublisher().getSupportedVersions();
         String privateKeyFilepath = project.getPublisher().getManifestPrivateKey();
         String publicKeyFilepath = project.getPublisher().getManifestPublicKey();
@@ -254,6 +255,7 @@ public class GameProjectBuilder extends Builder {
         manifestBuilder.setSignatureHashAlgorithm(HashAlgorithm.HASH_SHA256);
         manifestBuilder.setSignatureSignAlgorithm(SignAlgorithm.SIGN_RSA);
         manifestBuilder.setProjectIdentifier(projectIdentifier);
+        manifestBuilder.setBuildVariant(variant);
         manifestBuilder.setResourceGraph(resourceGraph);
 
         // Try manifest signing keys specified through the publisher


### PR DESCRIPTION
The `dmanifest` in the release bundle no longer contains the full project path to the file `url`, as this information is only needed for debugging. This reduces its size.  

Fix https://github.com/defold/defold/issues/8947