### PR TITLE
Do not clean the bundle folder to speed up the bundling process

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ScriptBuilders.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ScriptBuilders.java
@@ -21,19 +21,19 @@ import com.dynamo.lua.proto.Lua.LuaModule;
 public class ScriptBuilders {
 
     @ProtoParams(srcClass = LuaModule.class, messageClass = LuaModule.class)
-    @BuilderParams(name = "Lua", inExts = ".lua", outExt = ".luac", paramsForSignature = {"use-uncompressed-lua-source", "use-lua-bytecode-delta", "platform", "architectures"})
+    @BuilderParams(name = "Lua", inExts = ".lua", outExt = ".luac", paramsForSignature = {"use-uncompressed-lua-source", "use-lua-bytecode-delta", "platform", "architectures", "variant"})
     public static class LuaScriptBuilder extends LuaBuilder {}
 
     @ProtoParams(srcClass = LuaModule.class, messageClass = LuaModule.class)
-    @BuilderParams(name = "Script", inExts = ".script", outExt = ".scriptc", paramsForSignature = {"use-uncompressed-lua-source", "use-lua-bytecode-delta", "platform", "architectures"})
+    @BuilderParams(name = "Script", inExts = ".script", outExt = ".scriptc", paramsForSignature = {"use-uncompressed-lua-source", "use-lua-bytecode-delta", "platform", "architectures", "variant"})
     public static class ScriptBuilder extends LuaBuilder {}
 
     @ProtoParams(srcClass = LuaModule.class, messageClass = LuaModule.class)
-    @BuilderParams(name = "GuiScript", inExts = ".gui_script", outExt = ".gui_scriptc", paramsForSignature = {"use-uncompressed-lua-source", "use-lua-bytecode-delta", "platform", "architectures"})
+    @BuilderParams(name = "GuiScript", inExts = ".gui_script", outExt = ".gui_scriptc", paramsForSignature = {"use-uncompressed-lua-source", "use-lua-bytecode-delta", "platform", "architectures", "variant"})
     public static class GuiScriptBuilder extends LuaBuilder {}
 
     @ProtoParams(srcClass = LuaModule.class, messageClass = LuaModule.class)
-    @BuilderParams(name = "RenderScript", inExts = ".render_script", outExt = ".render_scriptc", paramsForSignature = {"use-uncompressed-lua-source", "use-lua-bytecode-delta", "platform", "architectures"})
+    @BuilderParams(name = "RenderScript", inExts = ".render_script", outExt = ".render_scriptc", paramsForSignature = {"use-uncompressed-lua-source", "use-lua-bytecode-delta", "platform", "architectures", "variant"})
     public static class RenderScriptBuilder extends LuaBuilder {}
 
 }

--- a/editor/resources/prelude.lua
+++ b/editor/resources/prelude.lua
@@ -356,7 +356,7 @@ function editor.bundle.create(config, output_directory, extra_bob_opts)
         end
     end
 
-    editor.bob(bob_opts, "distclean", "resolve", "build", "bundle")
+    editor.bob(bob_opts, "resolve", "build", "bundle")
 
     if editor.prefs.get("bundle.open-output-directory") then
         editor.open_external_file(output_directory)

--- a/editor/resources/prelude.lua
+++ b/editor/resources/prelude.lua
@@ -203,7 +203,6 @@ end
 
 function editor.bundle.check_boxes_grid_row(config, set_config)
     return editor.bundle.grid_row(nil, {
-        editor.bundle.check_box(config, set_config, "distclean", "Clean build folder before bundling"),
         editor.bundle.check_box(config, set_config, "with_symbols", "Generate debug symbols"),
         editor.bundle.check_box(config, set_config, "build_report", "Generate build report"),
         editor.bundle.check_box(config, set_config, "liveupdate", "Publish Live Update content"),
@@ -357,12 +356,7 @@ function editor.bundle.create(config, output_directory, extra_bob_opts)
         end
     end
 
-    local commands = {"distclean", "resolve", "build", "bundle"}
-    if not config.distclean then
-        table.remove(commands, 1)
-    end
-
-    editor.bob(bob_opts, table.unpack(commands))
+    editor.bob(bob_opts, "distclean", "resolve", "build", "bundle")
 
     if editor.prefs.get("bundle.open-output-directory") then
         editor.open_external_file(output_directory)
@@ -401,7 +395,6 @@ editor.bundle.common_variant_schema = editor.prefs.schema.enum({ values = common
 
 function editor.bundle.config_schema(variant_schema, properties)
     properties = properties or {}
-    properties.distclean = editor.prefs.schema.boolean({default = true})
     properties.variant = variant_schema
     properties.texture_compression = editor.prefs.schema.enum({values = texture_compressions})
     properties.with_symbols = editor.prefs.schema.boolean({default = true})

--- a/editor/resources/prelude.lua
+++ b/editor/resources/prelude.lua
@@ -203,6 +203,7 @@ end
 
 function editor.bundle.check_boxes_grid_row(config, set_config)
     return editor.bundle.grid_row(nil, {
+        editor.bundle.check_box(config, set_config, "distclean", "Clean build folder before bundling"),
         editor.bundle.check_box(config, set_config, "with_symbols", "Generate debug symbols"),
         editor.bundle.check_box(config, set_config, "build_report", "Generate build report"),
         editor.bundle.check_box(config, set_config, "liveupdate", "Publish Live Update content"),
@@ -356,7 +357,12 @@ function editor.bundle.create(config, output_directory, extra_bob_opts)
         end
     end
 
-    editor.bob(bob_opts, "distclean", "resolve", "build", "bundle")
+    local commands = {"distclean", "resolve", "build", "bundle"}
+    if not config.distclean then
+        table.remove(commands, 1)
+    end
+
+    editor.bob(bob_opts, table.unpack(commands))
 
     if editor.prefs.get("bundle.open-output-directory") then
         editor.open_external_file(output_directory)
@@ -395,6 +401,7 @@ editor.bundle.common_variant_schema = editor.prefs.schema.enum({ values = common
 
 function editor.bundle.config_schema(variant_schema, properties)
     properties = properties or {}
+    properties.distclean = editor.prefs.schema.boolean({default = true})
     properties.variant = variant_schema
     properties.texture_compression = editor.prefs.schema.enum({values = texture_compressions})
     properties.with_symbols = editor.prefs.schema.boolean({default = true})


### PR DESCRIPTION
From now on, the bundle option in the editor does not clean the bundle folder (equivalent to the `distclean` option in Bob) to speed up bundling.

Fix https://github.com/defold/defold/issues/3369

### Technical notes

Now, when [this PR](https://github.com/defold/defold/pull/10254) has been merged, we should have much more robust cache invalidation when bundling. And now it might be useful to reuse already built assets between builds.

