### PR TITLE
Unified Windows MSVC detection between local/packaged sdks

### DIFF
--- a/build_tools/sdk.py
+++ b/build_tools/sdk.py
@@ -327,6 +327,70 @@ def get_local_compiler_version():
 
 windows_info = None
 
+def _fatal(msg):
+    print("sdk.py: %s" % msg)
+    sys.exit(1)
+
+def get_windows_include_dirs(vs_root, sdk_includes_root):
+    includes = [os.path.join(vs_root,'include'),
+                os.path.join(vs_root,'atlmfc','include'),
+                os.path.join(sdk_includes_root,'ucrt'),
+                os.path.join(sdk_includes_root,'winrt'),
+                os.path.join(sdk_includes_root,'um'),
+                os.path.join(sdk_includes_root,'shared')]
+
+    for x in includes:
+        if not os.path.exists(x):
+            _fatal("Path does not exist: %s" % x)
+
+    return ','.join(includes)
+
+def get_windows_lib_dirs(vs_root, sdk_libs_root, arch):
+    libdirs = [ os.path.join(vs_root,'lib',arch),
+                os.path.join(vs_root,'atlmfc','lib',arch),
+                os.path.join(sdk_libs_root,'ucrt',arch),
+                os.path.join(sdk_libs_root,'um',arch)]
+
+    for x in libdirs:
+        if not os.path.exists(x):
+            _fatal("Path does not exist: %s" % x)
+
+    return ','.join(libdirs)
+
+def get_windows_bin_dirs(vs_root, sdk_bin_root, arch):
+    bindirs = [ os.path.join(vs_root,'bin', 'Host%s'%arch, arch),
+                os.path.join(sdk_bin_root, arch)]
+
+    for x in bindirs:
+        if not os.path.exists(x):
+            _fatal("Path does not exist: %s" % x)
+
+    return ','.join(bindirs)
+
+def get_windows_info(vs_root, vs_version, sdk_root, sdk_version, platform):
+    arch = 'x64'
+    if platform == 'win32':
+        arch = 'x86'
+
+    sdk_includes_root = os.path.join(sdk_root, 'Include', sdk_version)
+    sdk_libs_root = os.path.join(sdk_root, 'Lib', sdk_version)
+    sdk_bin_root = os.path.join(sdk_root, 'bin', sdk_version)
+
+    includes = get_windows_include_dirs(vs_root, sdk_includes_root)
+    lib_paths = get_windows_lib_dirs(vs_root, sdk_libs_root, arch)
+    bin_paths = get_windows_bin_dirs(vs_root, sdk_bin_root, arch)
+
+    info = {}
+    info['sdk_root'] = sdk_root
+    info['sdk_version'] = sdk_version
+    info['includes'] = includes
+    info['lib_paths'] = lib_paths
+    info['bin_paths'] = bin_paths
+    info['vs_root'] = vs_root
+    info['vs_version'] = vs_version
+    return info
+
+
 def get_windows_local_sdk_info(platform):
     global windows_info
 
@@ -346,7 +410,7 @@ def get_windows_local_sdk_info(platform):
             print ("Couldn't find executable '%s'" % vswhere_path)
             return None
 
-    sdk_root = run.shell_command('%s --sdk_root' % vswhere_path).strip()
+    sdk_root = run.shell_command('%s --sdk_root' % vswhere_path).strip() # C:\Program Files (x86)\Windows Kits\10\
     sdk_version = run.shell_command('%s --sdk_version' % vswhere_path).strip()
     includes = run.shell_command('%s --includes' % vswhere_path).strip()
     lib_paths = run.shell_command('%s --lib_paths' % vswhere_path).strip()
@@ -354,22 +418,9 @@ def get_windows_local_sdk_info(platform):
     vs_root = run.shell_command('%s --vs_root' % vswhere_path).strip()
     vs_version = run.shell_command('%s --vs_version' % vswhere_path).strip()
 
-    if platform == 'win32':
-        arch64 = 'x64'
-        arch32 = 'x86'
-        bin_paths = bin_paths.replace(arch64, arch32)
-        lib_paths = lib_paths.replace(arch64, arch32)
-
-    info = {}
-    info['sdk_root'] = sdk_root
-    info['sdk_version'] = sdk_version
-    info['includes'] = includes
-    info['lib_paths'] = lib_paths
-    info['bin_paths'] = bin_paths
-    info['vs_root'] = vs_root
-    info['vs_version'] = vs_version
-    windows_info = info
+    windows_info = get_windows_info(vs_root, vs_version, sdk_root, sdk_version, platform)
     return windows_info
+
 
 def get_windows_packaged_sdk_info(sdkdir, platform):
     global windows_info
@@ -402,27 +453,10 @@ def get_windows_packaged_sdk_info(sdkdir, platform):
     msvc_path = (os.path.join(msvcdir,'VC', 'Tools', 'MSVC', msvc_version, 'bin', 'Host'+arch, arch),
                 os.path.join(windowskitsdir,'10','bin',ucrt_version,arch))
 
-    includes = [os.path.join(msvcdir,'VC','Tools','MSVC',msvc_version,'include'),
-                os.path.join(msvcdir,'VC','Tools','MSVC',msvc_version,'atlmfc','include'),
-                os.path.join(windowskitsdir,'10','Include',ucrt_version,'ucrt'),
-                os.path.join(windowskitsdir,'10','Include',ucrt_version,'winrt'),
-                os.path.join(windowskitsdir,'10','Include',ucrt_version,'um'),
-                os.path.join(windowskitsdir,'10','Include',ucrt_version,'shared')]
+    vs_root = os.path.join(msvcdir,'VC','Tools','MSVC',msvc_version)
+    sdk_root = os.path.join(windowskitsdir,'10')
 
-    libdirs = [ os.path.join(msvcdir,'VC','Tools','MSVC',msvc_version,'lib',arch),
-                os.path.join(msvcdir,'VC','Tools','MSVC',msvc_version,'atlmfc','lib',arch),
-                os.path.join(windowskitsdir,'10','Lib',ucrt_version,'ucrt',arch),
-                os.path.join(windowskitsdir,'10','Lib',ucrt_version,'um',arch)]
-
-    info = {}
-    info['sdk_root'] = os.path.join(windowskitsdir,'10')
-    info['sdk_version'] = ucrt_version
-    info['includes'] = ','.join(includes)
-    info['lib_paths'] = ','.join(libdirs)
-    info['bin_paths'] = ','.join(msvc_path)
-    info['vs_root'] = msvcdir
-    info['vs_version'] = msvc_version
-    windows_info = info
+    windows_info = get_windows_info(vs_root, msvc_version, sdk_root, ucrt_version, platform)
     return windows_info
 
 def _setup_info_from_windowsinfo(windowsinfo, platform):


### PR DESCRIPTION
This PR makes it easier to use locally installed Visual Studio and Windows SDK.

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
