### PR TITLE
Move first batch of functions to dmsdk

### DIFF
--- a/engine/graphics/src/dmsdk/graphics/graphics.h
+++ b/engine/graphics/src/dmsdk/graphics/graphics.h
@@ -263,6 +263,44 @@ namespace dmGraphics
     };
 
     /*#
+    * @enum
+    * @name TextureFilter
+    * @member TEXTURE_FILTER_DEFAULT
+    * @member TEXTURE_FILTER_NEAREST
+    * @member TEXTURE_FILTER_LINEAR
+    * @member TEXTURE_FILTER_NEAREST_MIPMAP_NEAREST
+    * @member TEXTURE_FILTER_NEAREST_MIPMAP_LINEAR
+    * @member TEXTURE_FILTER_LINEAR_MIPMAP_NEAREST
+    * @member TEXTURE_FILTER_LINEAR_MIPMAP_LINEAR
+    */
+    enum TextureFilter
+    {
+        TEXTURE_FILTER_DEFAULT                = 0,
+        TEXTURE_FILTER_NEAREST                = 1,
+        TEXTURE_FILTER_LINEAR                 = 2,
+        TEXTURE_FILTER_NEAREST_MIPMAP_NEAREST = 3,
+        TEXTURE_FILTER_NEAREST_MIPMAP_LINEAR  = 4,
+        TEXTURE_FILTER_LINEAR_MIPMAP_NEAREST  = 5,
+        TEXTURE_FILTER_LINEAR_MIPMAP_LINEAR   = 6,
+    };
+
+    /*#
+    * @enum
+    * @name TextureWrap
+    * @member TEXTURE_WRAP_CLAMP_TO_BORDER
+    * @member TEXTURE_WRAP_CLAMP_TO_EDGE
+    * @member TEXTURE_WRAP_MIRRORED_REPEAT
+    * @member TEXTURE_WRAP_REPEAT
+    */
+    enum TextureWrap
+    {
+        TEXTURE_WRAP_CLAMP_TO_BORDER = 0,
+        TEXTURE_WRAP_CLAMP_TO_EDGE   = 1,
+        TEXTURE_WRAP_MIRRORED_REPEAT = 2,
+        TEXTURE_WRAP_REPEAT          = 3,
+    };
+
+    /*#
      * Get the attachment texture from a render target. Returns zero if no such attachment texture exists.
      * @name GetRenderTargetAttachment
      * @param render_target [type: dmGraphics::HRenderTarget] the render target

--- a/engine/graphics/src/graphics.h
+++ b/engine/graphics/src/graphics.h
@@ -143,27 +143,6 @@ namespace dmGraphics
         TEXTURE_TYPE_TEXTURE_CUBE     = 7
     };
 
-    // Texture filter
-    enum TextureFilter
-    {
-        TEXTURE_FILTER_DEFAULT                = 0,
-        TEXTURE_FILTER_NEAREST                = 1,
-        TEXTURE_FILTER_LINEAR                 = 2,
-        TEXTURE_FILTER_NEAREST_MIPMAP_NEAREST = 3,
-        TEXTURE_FILTER_NEAREST_MIPMAP_LINEAR  = 4,
-        TEXTURE_FILTER_LINEAR_MIPMAP_NEAREST  = 5,
-        TEXTURE_FILTER_LINEAR_MIPMAP_LINEAR   = 6,
-    };
-
-    // Texture wrap
-    enum TextureWrap
-    {
-        TEXTURE_WRAP_CLAMP_TO_BORDER = 0,
-        TEXTURE_WRAP_CLAMP_TO_EDGE   = 1,
-        TEXTURE_WRAP_MIRRORED_REPEAT = 2,
-        TEXTURE_WRAP_REPEAT          = 3,
-    };
-
     // Face type
     enum FaceType
     {

--- a/engine/render/src/dmsdk/render/render.h
+++ b/engine/render/src/dmsdk/render/render.h
@@ -419,6 +419,55 @@ namespace dmRender
     Result AddToRender(HRenderContext context, RenderObject* ro);
 
     /*#
+    * Gets the current view matrix that is set on the render context
+    * @name GetViewMatrix
+    * @param render_context [type: dmRender::HRenderContext] the render context
+    * @return matrix [type: dmVMath::Matrix4] the view matrix
+    */
+    const dmVMath::Matrix4& GetViewMatrix(HRenderContext render_context);
+
+    /*#
+    * Creates a new material from a shader program
+    * @name NewMaterial
+    * @param render_context [type: dmRender::HRenderContext] the render context
+    * @param program [type: dmGraphics::HProgram] the shader program
+    * @return material [type: dmRender::HMaterial] the material, or NULL if no material could be created
+    */
+    HMaterial NewMaterial(dmRender::HRenderContext render_context, dmGraphics::HProgram program);
+
+    /*#
+    * Deletes a material
+    * @name DeleteMaterial
+    * @param render_context [type: dmRender::HRenderContext] the render context
+    * @param material [type: dmRender::HMaterial] the material
+    */
+    void DeleteMaterial(dmRender::HRenderContext render_context, HMaterial material);
+
+    /*#
+    * Sets the material tags for a material
+    * @name SetMaterialTags
+    * @param material [type: dmGraphics::HMaterial] the material
+    * @param tag_count [type: uint32_t] the number of tags to use
+    * @param tags [type: const dmhash_t*] an array of tags
+    */
+    void SetMaterialTags(HMaterial material, uint32_t tag_count, const dmhash_t* tags);
+
+    /*#
+    * Configures a texture sampler on a material
+    * @name SetMaterialSampler
+    * @param material [type: dmGraphics::HMaterial] the material
+    * @param name_hash [type: dmhash_t] the name hash of the sampler to set
+    * @param unit [type: uint32_t] the texture unit to configure the sampler for
+    * @param u_wrap [type: dmGraphics::TextureWrap] the U wrap parameter
+    * @param v_wrap [type: dmGraphics::TextureWrap] the V wrap parameter
+    * @param min_filter [type: dmGraphics::TextureFilter] the minification filter
+    * @param mag_filter [type: dmGraphics::TextureFilter] the magification filter
+    * @param max_anisotropy [type: float] the max anisotropy value
+    * @return result [type: bool] true if the sampler was found
+    */
+    bool SetMaterialSampler(HMaterial material, dmhash_t name_hash, uint32_t unit, dmGraphics::TextureWrap u_wrap, dmGraphics::TextureWrap v_wrap, dmGraphics::TextureFilter min_filter, dmGraphics::TextureFilter mag_filter, float max_anisotropy);
+
+    /*#
      * Gets the key to the material tag list
      * @name GetMaterialTagListKey
      * @param material [type: dmGraphics::HMaterial] the material

--- a/engine/render/src/render/material.cpp
+++ b/engine/render/src/render/material.cpp
@@ -288,7 +288,6 @@ namespace dmRender
 
     void DeleteMaterial(dmRender::HRenderContext render_context, HMaterial material)
     {
-        dmGraphics::HContext graphics_context = dmRender::GetGraphicsContext(render_context);
         dmGraphics::DeleteVertexDeclaration(material->m_VertexDeclarationPerVertex);
 
         if (material->m_VertexDeclarationPerInstance)


### PR DESCRIPTION
A few render functions has been moved into dmSDK:

```cpp
// Get the current view matrix from the render context
const dmVMath::Matrix4& GetViewMatrix(HRenderContext render_context);
// Create a new material from a shader program
HMaterial NewMaterial(dmRender::HRenderContext render_context, dmGraphics::HProgram program);
// Delete a material
void DeleteMaterial(dmRender::HRenderContext render_context, HMaterial material);
// Set material tags
void SetMaterialTags(HMaterial material, uint32_t tag_count, const dmhash_t* tags);
// Configure a material sampler
bool SetMaterialSampler(HMaterial material, dmhash_t name_hash, uint32_t unit, dmGraphics::TextureWrap u_wrap, dmGraphics::TextureWrap v_wrap, dmGraphics::TextureFilter min_filter, dmGraphics::TextureFilter mag_filter, float max_anisotropy);
```