### PR TITLE
Make sure that parameters from `game.project` may invalidate bob cache

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/cache/test/ResourceCacheKeyTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/cache/test/ResourceCacheKeyTest.java
@@ -21,6 +21,8 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -202,10 +204,14 @@ public class ResourceCacheKeyTest {
 
 	// Ensure that all parameters specified in all builders exist in Bob
 	@Test
-	public void testAllParametersExist() throws IOException, CompileExceptionError, NoSuchFieldException, IllegalAccessException {
+	public void testAllParametersExist() throws IOException, CompileExceptionError, NoSuchFieldException, IllegalAccessException, NoSuchMethodException, InvocationTargetException {
 		// Initialize project
 		Project project = new Project(new DefaultFileSystem());
 		project.scanJavaClasses();
+
+		Method method = Project.class.getDeclaredMethod("configurePreBuildProjectOptions");
+		method.setAccessible(true);
+		method.invoke(project);
 
 		// Access private static field classToParamsDigest
 		Class<?> builderClass = Builder.class;
@@ -220,6 +226,10 @@ public class ResourceCacheKeyTest {
 		// Collect all long options
 		for (Bob.CommandLineOption option : commandLineOptions) {
 			allOptions.add(option.longOpt);
+		}
+
+		for (String key :project.getOptions().keySet()) {
+			allOptions.add(key);
 		}
 
 		// Validate each parameter in classToParamsDigest

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/cache/test/ResourceCacheKeyTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/cache/test/ResourceCacheKeyTest.java
@@ -208,10 +208,7 @@ public class ResourceCacheKeyTest {
 		// Initialize project
 		Project project = new Project(new DefaultFileSystem());
 		project.scanJavaClasses();
-
-		Method method = Project.class.getDeclaredMethod("configurePreBuildProjectOptions");
-		method.setAccessible(true);
-		method.invoke(project);
+		project.configurePreBuildProjectOptions();
 
 		// Access private static field classToParamsDigest
 		Class<?> builderClass = Builder.class;

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
@@ -1432,32 +1432,46 @@ public class Project {
 
         return false;
     }
+    private static class UniOption {
+        public String inputOption, outputOption, propertyCategory, propertyKey, appManifestSymbol;
+        public UniOption(String inputOption, String outputOption, String propertyCategory, String propertyKey, String appManifestSymbol) {
+            this.inputOption = inputOption;
+            this.outputOption = outputOption;
+            this.propertyCategory = propertyCategory;
+            this.propertyKey = propertyKey;
+            this.appManifestSymbol = appManifestSymbol;
+        }
+    }
 
     private void configurePreBuildProjectOptions() throws IOException, CompileExceptionError {
-        // Build spir-v or HLSL either if:
-        //   1. If the user has specified explicitly to build or not to build with spir-v or HLSL
-        //   2. The project has an app manifest with vulkan or DX12 enabled
-        if (this.hasOption("debug-output-spirv")) {
-            this.setOption("output-spirv", this.option("debug-output-spirv", "false"));
-        } else {
-            this.setOption("output-spirv", hasSymbol("GraphicsAdapterVulkan") ? "true" : "false");
+        List<UniOption> options = new ArrayList<>();
+        options.add(new UniOption("debug-output-spirv", "output-spirv", "shader","output_spirv","GraphicsAdapterVulkan"));
+        options.add(new UniOption("debug-output-hlsl", "output-hlsl", "shader","output_hlsl","GraphicsAdapterDX12"));
+        options.add(new UniOption("debug-output-wgsl", "output-wgsl", "shader","output_wgsl","GraphicsAdapterWebGPU"));
+        options.add(new UniOption("output-glsles100", "output-glsles100", "shader","output_glsl_es100",null));
+        options.add(new UniOption("output-glsles300", "output-glsles300", "shader","output_glsl_es300",null));
+        options.add(new UniOption("output-glsl120", "output-glsl120", "shader","output_glsl120",null));
+        options.add(new UniOption("output-glsl330", "output-glsl330", "shader","output_glsl330",null));
+        options.add(new UniOption("output-glsl430", "output-glsl430", "shader","output_glsl430",null));
+
+        options.add(new UniOption("sound-stream-enabled", "sound-stream-enabled", "sound","stream_enabled",null));
+        options.add(new UniOption("model-split-large-meshes", "model-split-large-meshes", "model","split_meshes",null));
+        options.add(new UniOption("prometheus-disabled", "prometheus-disabled", "prometheus","disabled",null));
+
+        for(UniOption option:options) {
+            boolean fromProjectProperties = this.getProjectProperties().getBooleanValue(option.propertyCategory, option.propertyKey, false);
+            if (this.hasOption(option.inputOption)) {
+                boolean fromProjectOptions = this.option(option.inputOption, "false").equals("true");
+                this.setOption(option.outputOption, Boolean.toString(fromProjectProperties || fromProjectOptions));
+            } else if (option.appManifestSymbol != null) {
+                this.setOption(option.outputOption, Boolean.toString(hasSymbol(option.appManifestSymbol) || fromProjectProperties));
+            } else {
+                this.setOption(option.outputOption, Boolean.toString(fromProjectProperties));
+            }
         }
 
-        if (this.hasOption("debug-output-hlsl")) {
-            this.setOption("output-hlsl", this.option("debug-output-hlsl", "false"));
-        } else {
-            this.setOption("output-hlsl", hasSymbol("GraphicsAdapterDX12") ? "true" : "false");
-        }
-
-        // Build wgsl either if:
-        //   1. If the user has specified explicitly to build or not to build with wgsl
-        //   2. The project has an app manifest with webgpu enabled
-        String outputWGSL;
-        if (this.hasOption("debug-output-wgsl"))
-            outputWGSL = this.option("debug-output-wgsl", "false");
-        else
-            outputWGSL = hasSymbol("GraphicsAdapterWebGPU") ? "true" : "false";
-        this.setOption("output-wgsl", outputWGSL);
+        boolean isPhysics2D = this.getProjectProperties().getStringValue("physics", "type", "2D").equals("2D");
+        this.setOption("physics-type-2D", Boolean.toString(isPhysics2D));
     }
 
     private ArrayList<TextureCompressorPreset> parseTextureCompressorPresetFromJSON(String fromPath, byte[] data) throws CompileExceptionError {
@@ -1648,7 +1662,6 @@ public class Project {
         mrep.beginTask("Reading tasks...", 1);
         TimeProfiler.start("Create tasks");
         BundleHelper.throwIfCanceled(monitor);
-        configurePreBuildProjectOptions();
         createTasks();
         validateBuildResourceMapping();
         TimeProfiler.addData("TasksCount", tasks.size());
@@ -1733,7 +1746,8 @@ public class Project {
         BundleHelper.throwIfCanceled(monitor);
 
         monitor.beginTask("Working...", 100);
-
+        // it should be done before scanJavaClasses to have updated options
+        configurePreBuildProjectOptions();
         {
             TimeProfiler.start("scanJavaClasses");
             IProgress mrep = monitor.subProgress(1);

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
@@ -1432,9 +1432,20 @@ public class Project {
 
         return false;
     }
-    private static class UniOption {
+
+    /**
+     *  Options from the `game.project` file that may affect build outputs.
+     */
+    private static class GameProjectBuildOption {
         public String inputOption, outputOption, propertyCategory, propertyKey, appManifestSymbol;
-        public UniOption(String inputOption, String outputOption, String propertyCategory, String propertyKey, String appManifestSymbol) {
+        /**
+         * @param inputOption        Option that may be used with Bob.
+         * @param outputOption       How the option will be saved in project options using project.setOption() for future use.
+         * @param propertyCategory   Category in the `game.project` file.
+         * @param propertyKey        Key in the `game.project` file.
+         * @param appManifestSymbol  A symbol from appManifest that makes this option true.
+         */
+        public GameProjectBuildOption(String inputOption, String outputOption, String propertyCategory, String propertyKey, String appManifestSymbol) {
             this.inputOption = inputOption;
             this.outputOption = outputOption;
             this.propertyCategory = propertyCategory;
@@ -1443,22 +1454,22 @@ public class Project {
         }
     }
 
-    private void configurePreBuildProjectOptions() throws IOException, CompileExceptionError {
-        List<UniOption> options = new ArrayList<>();
-        options.add(new UniOption("debug-output-spirv", "output-spirv", "shader","output_spirv","GraphicsAdapterVulkan"));
-        options.add(new UniOption("debug-output-hlsl", "output-hlsl", "shader","output_hlsl","GraphicsAdapterDX12"));
-        options.add(new UniOption("debug-output-wgsl", "output-wgsl", "shader","output_wgsl","GraphicsAdapterWebGPU"));
-        options.add(new UniOption("output-glsles100", "output-glsles100", "shader","output_glsl_es100",null));
-        options.add(new UniOption("output-glsles300", "output-glsles300", "shader","output_glsl_es300",null));
-        options.add(new UniOption("output-glsl120", "output-glsl120", "shader","output_glsl120",null));
-        options.add(new UniOption("output-glsl330", "output-glsl330", "shader","output_glsl330",null));
-        options.add(new UniOption("output-glsl430", "output-glsl430", "shader","output_glsl430",null));
+    public void configurePreBuildProjectOptions() throws IOException, CompileExceptionError {
+        List<GameProjectBuildOption> options = new ArrayList<>();
+        options.add(new GameProjectBuildOption("debug-output-spirv", "output-spirv", "shader","output_spirv","GraphicsAdapterVulkan"));
+        options.add(new GameProjectBuildOption("debug-output-hlsl", "output-hlsl", "shader","output_hlsl","GraphicsAdapterDX12"));
+        options.add(new GameProjectBuildOption("debug-output-wgsl", "output-wgsl", "shader","output_wgsl","GraphicsAdapterWebGPU"));
+        options.add(new GameProjectBuildOption("output-glsles100", "output-glsles100", "shader","output_glsl_es100",null));
+        options.add(new GameProjectBuildOption("output-glsles300", "output-glsles300", "shader","output_glsl_es300",null));
+        options.add(new GameProjectBuildOption("output-glsl120", "output-glsl120", "shader","output_glsl120",null));
+        options.add(new GameProjectBuildOption("output-glsl330", "output-glsl330", "shader","output_glsl330",null));
+        options.add(new GameProjectBuildOption("output-glsl430", "output-glsl430", "shader","output_glsl430",null));
 
-        options.add(new UniOption("sound-stream-enabled", "sound-stream-enabled", "sound","stream_enabled",null));
-        options.add(new UniOption("model-split-large-meshes", "model-split-large-meshes", "model","split_meshes",null));
-        options.add(new UniOption("prometheus-disabled", "prometheus-disabled", "prometheus","disabled",null));
+        options.add(new GameProjectBuildOption("sound-stream-enabled", "sound-stream-enabled", "sound","stream_enabled",null));
+        options.add(new GameProjectBuildOption("model-split-large-meshes", "model-split-large-meshes", "model","split_meshes",null));
+        options.add(new GameProjectBuildOption("prometheus-disabled", "prometheus-disabled", "prometheus","disabled",null));
 
-        for(UniOption option:options) {
+        for(GameProjectBuildOption option:options) {
             boolean fromProjectProperties = this.getProjectProperties().getBooleanValue(option.propertyCategory, option.propertyKey, false);
             if (this.hasOption(option.inputOption)) {
                 boolean fromProjectOptions = this.option(option.inputOption, "false").equals("true");

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/CopyBuilders.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/CopyBuilders.java
@@ -25,13 +25,13 @@ import com.dynamo.bob.fs.IResource;
 
 public class CopyBuilders {
 
-    @BuilderParams(name = "Wav", inExts = ".wav", outExt = ".wavc")
+    @BuilderParams(name = "Wav", inExts = ".wav", outExt = ".wavc", paramsForSignature = {"sound-stream-enabled"})
     public static class WavBuilder extends CopyBuilder {
         @Override
         public void build(Task task) throws IOException {
             super.build(task);
 
-            boolean soundStreaming = project.getProjectProperties().getBooleanValue("sound", "stream_enabled", false); // if no value set use old hardcoded path (backward compatability)
+            boolean soundStreaming = this.project.option("sound-stream-enabled", "false").equals("true"); // if no value set use old hardcoded path (backward compatability)
             boolean compressSounds = soundStreaming ? false : true; // We want to be able to read directly from the files as-is (without compression)
             for(IResource res : task.getOutputs()) {
                 if (!compressSounds) {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/MeshsetBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/MeshsetBuilder.java
@@ -37,7 +37,7 @@ import com.dynamo.rig.proto.Rig.MeshSet;
 import com.dynamo.rig.proto.Rig.Skeleton;
 
 
-@BuilderParams(name="Meshset", inExts={".dae",".gltf",".glb"}, outExt=".meshsetc")
+@BuilderParams(name="Meshset", inExts={".dae",".gltf",".glb"}, outExt=".meshsetc", paramsForSignature = {"model-split-large-meshes"})
 public class MeshsetBuilder extends Builder  {
     public static class ResourceDataResolver implements ModelImporterJni.DataResolver
     {
@@ -83,7 +83,7 @@ public class MeshsetBuilder extends Builder  {
         ByteArrayOutputStream out = new ByteArrayOutputStream(64 * 1024);
         MeshSet.Builder meshSetBuilder = MeshSet.newBuilder();
 
-        boolean split_meshes = this.project.getProjectProperties().getIntValue("model", "split_large_meshes", 0) != 0;
+        boolean split_meshes = this.project.option("model-split-large-meshes", "false").equals("true");
         try {
             ColladaUtil.loadMesh(collada_is, meshSetBuilder, true, split_meshes);
         } catch (XMLStreamException e) {
@@ -147,8 +147,8 @@ public class MeshsetBuilder extends Builder  {
         {
             MeshSet.Builder meshSetBuilder = MeshSet.newBuilder();
 
-            int split_meshes = this.project.getProjectProperties().getIntValue("model", "split_large_meshes", 0);
-            if (split_meshes != 0) {
+            boolean split_meshes = this.project.option("model-split-large-meshes", "false").equals("true");
+            if (split_meshes) {
                 ModelUtil.splitMeshes(scene);
             }
 

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/OggBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/OggBuilder.java
@@ -31,7 +31,7 @@ import com.dynamo.bob.Project;
 import com.dynamo.bob.Task;
 import com.dynamo.bob.fs.IResource;
 
-@BuilderParams(name = "Ogg", inExts = ".ogg", outExt = ".oggc")
+@BuilderParams(name = "Ogg", inExts = ".ogg", outExt = ".oggc", paramsForSignature = {"sound-stream-enabled"})
 public class OggBuilder extends CopyBuilder{
 
     @Override
@@ -68,7 +68,7 @@ public class OggBuilder extends CopyBuilder{
     public void build(Task task) throws IOException {
         super.build(task);
 
-        boolean soundStreaming = project.getProjectProperties().getBooleanValue("sound", "stream_enabled", false); // if no value set use old hardcoded path (backward compatability)
+        boolean soundStreaming = this.project.option("sound-stream-enabled", "false").equals("true"); // if no value set use old hardcoded path (backward compatability)
         boolean compressSounds = soundStreaming ? false : true; // We want to be able to read directly from the files as-is (without compression)
         for(IResource res : task.getOutputs()) {
             if (!compressSounds) {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ScriptBuilders.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ScriptBuilders.java
@@ -21,19 +21,19 @@ import com.dynamo.lua.proto.Lua.LuaModule;
 public class ScriptBuilders {
 
     @ProtoParams(srcClass = LuaModule.class, messageClass = LuaModule.class)
-    @BuilderParams(name = "Lua", inExts = ".lua", outExt = ".luac", paramsForSignature = {"use-uncompressed-lua-source", "use-lua-bytecode-delta", "platform", "architectures", "variant"})
+    @BuilderParams(name = "Lua", inExts = ".lua", outExt = ".luac", paramsForSignature = {"use-uncompressed-lua-source", "use-lua-bytecode-delta", "platform", "architectures", "variant", "prometheus-disabled"})
     public static class LuaScriptBuilder extends LuaBuilder {}
 
     @ProtoParams(srcClass = LuaModule.class, messageClass = LuaModule.class)
-    @BuilderParams(name = "Script", inExts = ".script", outExt = ".scriptc", paramsForSignature = {"use-uncompressed-lua-source", "use-lua-bytecode-delta", "platform", "architectures", "variant"})
+    @BuilderParams(name = "Script", inExts = ".script", outExt = ".scriptc", paramsForSignature = {"use-uncompressed-lua-source", "use-lua-bytecode-delta", "platform", "architectures", "variant", "prometheus-disabled"})
     public static class ScriptBuilder extends LuaBuilder {}
 
     @ProtoParams(srcClass = LuaModule.class, messageClass = LuaModule.class)
-    @BuilderParams(name = "GuiScript", inExts = ".gui_script", outExt = ".gui_scriptc", paramsForSignature = {"use-uncompressed-lua-source", "use-lua-bytecode-delta", "platform", "architectures", "variant"})
+    @BuilderParams(name = "GuiScript", inExts = ".gui_script", outExt = ".gui_scriptc", paramsForSignature = {"use-uncompressed-lua-source", "use-lua-bytecode-delta", "platform", "architectures", "variant", "prometheus-disabled"})
     public static class GuiScriptBuilder extends LuaBuilder {}
 
     @ProtoParams(srcClass = LuaModule.class, messageClass = LuaModule.class)
-    @BuilderParams(name = "RenderScript", inExts = ".render_script", outExt = ".render_scriptc", paramsForSignature = {"use-uncompressed-lua-source", "use-lua-bytecode-delta", "platform", "architectures", "variant"})
+    @BuilderParams(name = "RenderScript", inExts = ".render_script", outExt = ".render_scriptc", paramsForSignature = {"use-uncompressed-lua-source", "use-lua-bytecode-delta", "platform", "architectures", "variant", "prometheus-disabled"})
     public static class RenderScriptBuilder extends LuaBuilder {}
 
 }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderProgramBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderProgramBuilder.java
@@ -39,7 +39,10 @@ import com.dynamo.bob.pipeline.shader.SPIRVReflector;
 
 import com.dynamo.graphics.proto.Graphics.ShaderDesc;
 
-@BuilderParams(name="ShaderProgramBuilder", inExts= {".shbundle", ".shbundlec"}, outExt=".spc", paramsForSignature = {"platform"})
+@BuilderParams(name="ShaderProgramBuilder", inExts= {".shbundle", ".shbundlec"}, outExt=".spc",
+        // See configurePreBuildProjectOptions in Project.java
+        paramsForSignature = {"platform", "output-spirv", "output-wgsl", "output-hlsl", "output-glsles100",
+        "output-glsles300", "output-glsl120", "output-glsl330", "output-glsl430"})
 public class ShaderProgramBuilder extends Builder {
 
     static public class ShaderBuildResult {
@@ -98,13 +101,7 @@ public class ShaderProgramBuilder extends Builder {
         }
 
         compileOptions = modules.getCompileOptions();
-
-        // Include the spir-v flag into the cache key, so we can invalidate the output results accordingly
-        String shaderCacheKey = String.format("output_spirv=%s;output_hlsl=%s;output_wgsl=%s",
-                getOutputSpirvFlag(), getOutputHlslFlag(), getOutputWGSLFlag());
-
         taskBuilder.addOutput(input.changeExt(params.outExt()));
-        taskBuilder.addExtraCacheKey(shaderCacheKey);
 
         return taskBuilder.build();
     }
@@ -158,9 +155,8 @@ public class ShaderProgramBuilder extends Builder {
     }
 
     private boolean getOutputShaderFlag(String projectOption, String projectProperty) {
-        boolean fromProjectOptions    = this.project.option(projectOption, "false").equals("true");
-        boolean fromProjectProperties = this.project.getProjectProperties().getBooleanValue("shader", projectProperty, false);
-        return fromProjectOptions || fromProjectProperties;
+        // See configurePreBuildProjectOptions in Project.java
+        return this.project.option(projectOption, "false").equals("true");
     }
 
     private boolean getOutputSpirvFlag() { return getOutputShaderFlag("output-spirv", "output_spirv"); }


### PR DESCRIPTION
In previous PRs, I only considered Bob arguments. However, there are also parameters in `appmanifest` and some in `game.project` that may affect the outputs as well.  

This should be taken into account, but at the same time, I don’t want to build an entirely new system for it. Since `appmanifest` values already use the options system, I decided to use it for `game.project` options as well. This helps reduce the number of systems we need for the same purpose.  

The only unresolved question is how to protect the codebase from future usage of `game.project` parameters that may affect outputs. I have a couple of ideas, and I'll try to implement them in a separate PR.  