### PR TITLE
Improved the dialogs' appearance

### DIFF
--- a/editor/styling/stylesheets/_dialogs.scss
+++ b/editor/styling/stylesheets/_dialogs.scss
@@ -141,17 +141,17 @@ $spacing-largest: 40px;
 }
 
 .dialog-with-content-header {
-  -fx-padding: $spacing-default;
+  -fx-padding: 12px $spacing-default 12px $spacing-default;
 }
 .dialog-without-content-header {
-  -fx-padding: $spacing-default $spacing-default 0 $spacing-default;
+  -fx-padding: 12px $spacing-default 0 $spacing-default;
 }
 
 .dialog-with-content-footer {
-  -fx-padding: $spacing-default;
+  -fx-padding: 12px $spacing-default 12px $spacing-default;
 }
 .dialog-without-content-footer {
-  -fx-padding: 0 $spacing-default $spacing-default $spacing-default;
+  -fx-padding: 0 $spacing-default 12px $spacing-default;
 }
 
 // text inputs

--- a/editor/styling/stylesheets/modules/_extensions.scss
+++ b/editor/styling/stylesheets/modules/_extensions.scss
@@ -1,6 +1,6 @@
-$ext-spacing-small: 4px;
-$ext-spacing-medium: 8px;
-$ext-spacing-large: 16px;
+$ext-spacing-small: 2px;
+$ext-spacing-medium: 6px;
+$ext-spacing-large: 12px;
 $ext-line-height: 26px;
 
 .ext {
@@ -18,9 +18,9 @@ $ext-line-height: 26px;
     }
     &-padding {
         &-none        { -fx-padding: 0; }
-        &-small       { -fx-padding: 16px; }
-        &-medium      { -fx-padding: 24px; }
-        &-large       { -fx-padding: 40px; }
+        &-small       { -fx-padding: 6px; }
+        &-medium      { -fx-padding: 10px; }
+        &-large       { -fx-padding: 12px 22px 12px 22px; }
     }
     &-heading-style {
         &-h1 { -fx-font-size: 26px; -fx-font-family: "Source Sans Pro Light"; }
@@ -98,7 +98,7 @@ $ext-line-height: 26px;
         -fx-font-size: 110%;
         -fx-font-family: "Source Sans Pro";
         -fx-text-fill: -df-text;
-        -fx-label-padding: 0 0 0 $ext-spacing-small;
+        -fx-label-padding: 0 0 0 4px;
         -fx-min-height: $ext-line-height;
         -fx-max-height: $ext-line-height;
         &:warning {


### PR DESCRIPTION
I had a small problem with the new layout of the Android bundling dialog. The 'Create Bundle' and 'Close' buttons were almost hidden, making it inconvenient to use. To improve this, I changed the dialogs' style.
Related to this:
https://forum.defold.com/t/defold-1-9-8-beta/79816/26?u=ultimani

Here are screenshots showing the changes before and after:
On a 1366x768 screen resolution:
- Before:
![1366 before](https://github.com/user-attachments/assets/884631eb-e8f1-4426-bfdd-9da855c9345e)

- After:
![1366 after](https://github.com/user-attachments/assets/e308c7d7-0d79-4fa2-b03e-9f6741abb5ae)

On a 1280x720 screen resolution:
- Before:
![1280 before](https://github.com/user-attachments/assets/832c9a0c-c74b-46bd-a5a2-1db2898fc945)

- After:
![1280 after](https://github.com/user-attachments/assets/a8ad2fae-cdee-4e06-b03a-8b9edf04e7c9)

