### PR TITLE
Create texture script regression

### DIFF
--- a/engine/gamesys/src/gamesys/gamesys_resource.cpp
+++ b/engine/gamesys/src/gamesys/gamesys_resource.cpp
@@ -23,10 +23,10 @@ namespace dmGameSystem
 {
     void MakeTextureImage(CreateTextureResourceParams params, dmGraphics::TextureImage* texture_image)
     {
-        uint32_t* mip_map_sizes              = new uint32_t[params.m_MaxMipMaps];
+        uint32_t* mip_map_data_size          = new uint32_t[params.m_MaxMipMaps];
         uint32_t* mip_map_offsets            = new uint32_t[params.m_MaxMipMaps];
         uint32_t* mip_map_offsets_compressed = new uint32_t[1];
-        uint32_t* mip_map_dimensions         = new uint32_t[2];
+        uint32_t* mip_map_dimensions         = new uint32_t[params.m_MaxMipMaps * 2];
         uint8_t layer_count                  = GetLayerCount(params.m_Type);
 
         uint32_t data_size = 0;
@@ -34,11 +34,19 @@ namespace dmGameSystem
         uint16_t mm_height = params.m_Height;
         for (uint32_t i = 0; i < params.m_MaxMipMaps; ++i)
         {
-            mip_map_sizes[i]    = dmMath::Max(mm_width, mm_height);
-            mip_map_offsets[i]  = (data_size / 8);
-            data_size          += mm_width * mm_height * params.m_TextureBpp * layer_count;
-            mm_width           /= 2;
-            mm_height          /= 2;
+            mip_map_offsets[i]            = (data_size / 8);
+            mip_map_dimensions[i * 2 + 0] = mm_width;
+            mip_map_dimensions[i * 2 + 1] = mm_height;
+
+            // Calculate the data size per mipmap in bytes
+            // Graphics APIs require that the data size is _per slice_ and not the whole texture.
+            // This is a quirk from how the OpenGL adapter is implemented, and should probably be fixed.
+            uint32_t data_size_per_slice  = mm_width * mm_height * params.m_TextureBpp;
+            data_size                    += data_size_per_slice * layer_count;
+            mip_map_data_size[i]              = data_size_per_slice / 8;
+
+            mm_width                     /= 2;
+            mm_height                    /= 2;
         }
         assert(data_size > 0);
 
@@ -68,9 +76,6 @@ namespace dmGameSystem
         //       so we only need a pointer here for the data offset.
         mip_map_offsets_compressed[0] = image_data_size;
 
-        mip_map_dimensions[0] = params.m_Width;
-        mip_map_dimensions[1] = params.m_Height;
-
         dmGraphics::TextureImage::Image* image = new dmGraphics::TextureImage::Image();
         texture_image->m_Alternatives.m_Data   = image;
         texture_image->m_Alternatives.m_Count  = 1;
@@ -87,13 +92,13 @@ namespace dmGameSystem
         image->m_CompressionType              = params.m_CompressionType;
         image->m_MipMapOffset.m_Data          = mip_map_offsets;
         image->m_MipMapOffset.m_Count         = params.m_MaxMipMaps;
-        image->m_MipMapSize.m_Data            = mip_map_sizes;
+        image->m_MipMapSize.m_Data            = mip_map_data_size;
         image->m_MipMapSize.m_Count           = params.m_MaxMipMaps;
         image->m_MipMapSizeCompressed.m_Data  = mip_map_offsets_compressed;
         image->m_MipMapSizeCompressed.m_Count = 1;
 
         image->m_MipMapDimensions.m_Data  = mip_map_dimensions;
-        image->m_MipMapDimensions.m_Count = 2;
+        image->m_MipMapDimensions.m_Count = params.m_MaxMipMaps * 2;
     }
 
     void DestroyTextureImage(dmGraphics::TextureImage& texture_image, bool destroy_image_data)

--- a/engine/gamesys/src/gamesys/gamesys_resource.cpp
+++ b/engine/gamesys/src/gamesys/gamesys_resource.cpp
@@ -43,7 +43,7 @@ namespace dmGameSystem
             // This is a quirk from how the OpenGL adapter is implemented, and should probably be fixed.
             uint32_t data_size_per_slice  = mm_width * mm_height * params.m_TextureBpp;
             data_size                    += data_size_per_slice * layer_count;
-            mip_map_data_size[i]              = data_size_per_slice / 8;
+            mip_map_data_size[i]          = data_size_per_slice / 8;
 
             mm_width                     /= 2;
             mm_height                    /= 2;

--- a/engine/gamesys/src/gamesys/resources/res_texture.cpp
+++ b/engine/gamesys/src/gamesys/resources/res_texture.cpp
@@ -136,6 +136,36 @@ namespace dmGameSystem
         dmGraphics::SetTextureAsync(texture, params, 0, (void*) 0);
     }
 
+    static bool ValidateTextureParams(uint32_t tex_width_full, uint32_t tex_height_full, const dmGraphics::TextureParams& params)
+    {
+        uint16_t tex_width_mipmap  = dmGraphics::GetMipmapSize(tex_width_full, params.m_MipMap);
+        uint16_t tex_height_mipmap = dmGraphics::GetMipmapSize(tex_height_full, params.m_MipMap);
+        uint8_t  tex_mipmap_count  = dmGraphics::GetMipmapCount(dmMath::Max(tex_width_full, tex_height_full));
+
+        // Validate mipmap dimensions
+        if (params.m_MipMap > tex_mipmap_count || tex_width_mipmap != params.m_Width || tex_height_mipmap != params.m_Height)
+        {
+            return false;
+        }
+
+        // Validate data size (this should be true even if a NULL pointer is passed for the data, i.e blank texture)
+        uint32_t bitspp = dmGraphics::GetTextureFormatBitsPerPixel(params.m_Format);
+
+        // NOTE! The params.m_Depth is NOT included here. This is because of how the pipeline (and I think, OpenGL adapter is built),
+        //       the data size is supposed to be per slice and not the full data size.
+        uint32_t data_size = params.m_Width * params.m_Height * bitspp / 8;
+
+        // NOTE! We can't check that the _exact_ size matches here (data_size != params.m_DataSize) because the data may be
+        //       passed in from a buffer, which can align the data buffer being passed in. So best we can do is make sure
+        //       the upload data is big enough.
+        if (data_size > params.m_DataSize)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
     static dmResource::Result AcquireResources(const char* path, dmGraphics::HContext context, ImageDesc* image_desc,
         ResTextureUploadParams upload_params, dmGraphics::HTexture texture, dmGraphics::HTexture* texture_out)
     {
@@ -261,6 +291,12 @@ namespace dmGameSystem
                     params.m_Data     = image_desc->m_DecompressedData[0];
                     params.m_DataSize = image_desc->m_DecompressedDataSize[0];
                 }
+
+                if (!ValidateTextureParams(image->m_Width, image->m_Height, params))
+                {
+                    dmLogError("Unable to create mipmap %d, texture parameters are invalid.", params.m_MipMap);
+                    return dmResource::RESULT_FORMAT_ERROR;
+                }
                 dmGraphics::SetTextureAsync(texture, params, 0, 0);
             }
             else
@@ -279,16 +315,13 @@ namespace dmGameSystem
                     }
 
                     params.m_MipMap = i;
-                    params.m_Width  = image->m_MipMapDimensions[i * 2];
-                    params.m_Height = image->m_MipMapDimensions[i * 2 + 1];
+                    params.m_Width  = dmMath::Max((uint32_t) 1, image->m_MipMapDimensions[i * 2]);
+                    params.m_Height = dmMath::Max((uint32_t) 1, image->m_MipMapDimensions[i * 2 + 1]);
 
-                    if (params.m_Width == 0)
+                    if (!ValidateTextureParams(image->m_Width, image->m_Height, params))
                     {
-                        params.m_Width = 1;
-                    }
-                    if (params.m_Height == 0)
-                    {
-                        params.m_Height = 1;
+                        dmLogError("Unable to create mipmap %d, texture parameters are invalid.", params.m_MipMap);
+                        return dmResource::RESULT_FORMAT_ERROR;
                     }
 
                     dmGraphics::SetTextureAsync(texture, params, 0, 0);

--- a/engine/gamesys/src/gamesys/resources/res_texture.cpp
+++ b/engine/gamesys/src/gamesys/resources/res_texture.cpp
@@ -138,8 +138,8 @@ namespace dmGameSystem
 
     static bool ValidateTextureParams(uint32_t tex_width_full, uint32_t tex_height_full, const dmGraphics::TextureParams& params)
     {
-        uint16_t tex_width_mipmap  = dmGraphics::GetMipmapSize(tex_width_full, params.m_MipMap);
-        uint16_t tex_height_mipmap = dmGraphics::GetMipmapSize(tex_height_full, params.m_MipMap);
+        uint16_t tex_width_mipmap  = dmMath::Max((uint16_t) 1, dmGraphics::GetMipmapSize(tex_width_full, params.m_MipMap));
+        uint16_t tex_height_mipmap = dmMath::Max((uint16_t) 1, dmGraphics::GetMipmapSize(tex_height_full, params.m_MipMap));
         uint8_t  tex_mipmap_count  = dmGraphics::GetMipmapCount(dmMath::Max(tex_width_full, tex_height_full));
 
         // Validate mipmap dimensions


### PR DESCRIPTION
Fixed an issue where dynamic texture resources where not created correctly on non-opengl graphics adapters due to a miscalculation of the data size parameter.

### Technical changes

The problem here was that the data size parameter was incorrectly passed in. I think this started being an issue when we migrated textures to be packed behind the DDF. It works on OpenGL (hence why this wasn't cought earlier) because we actually never use the datasize parameter when uploading texture data, and the null adapter don't care about the data size either - it just creates a buffer based on it, but we never actually check any parameters. So all of this combined causes issues on non-gl adapters, since we actually care about the data size parameter for those.
