### PR TITLE
Default to $XDG_DATA_HOME as the Linux Application Path

### DIFF
--- a/engine/crash/src/crash.cpp
+++ b/engine/crash/src/crash.cpp
@@ -52,7 +52,7 @@ namespace dmCrash
         // Construct a file path with the app name 'Defold' until it is modified by the application;
         // this also means crash files can be stored in two different places. At the default path or in the
         // application-specific location. So need to look for both when loading.
-        dmSys::Result r = dmSys::GetApplicationSupportPath("Defold", g_FilePathDefault, sizeof(g_FilePathDefault));
+        dmSys::Result r = dmSys::GetApplicationSupportPath(DMSYS_APPLICATION_NAME, g_FilePathDefault, sizeof(g_FilePathDefault));
         if (r == dmSys::RESULT_OK)
         {
             dmStrlCat(g_FilePathDefault, "/", sizeof(g_FilePathDefault));

--- a/engine/dlib/src/dlib/sys.h
+++ b/engine/dlib/src/dlib/sys.h
@@ -20,6 +20,12 @@
 
 #include <dmsdk/dlib/sys.h>
 
+/**
+ * Engine supportpath folder name.
+ * e.g: /support/path/.Defold
+ */
+#define DMSYS_APPLICATION_NAME "Defold"
+
 namespace dmSys
 {
     /**

--- a/engine/dlib/src/dlib/sys_posix.cpp
+++ b/engine/dlib/src/dlib/sys_posix.cpp
@@ -416,57 +416,58 @@ namespace dmSys
 
     Result GetApplicationSupportPath(const char* application_name, char* path_out, uint32_t path_len)
     {
-    const char* xdg_env = dmSys::GetEnv("XDG_DATA_HOME");
-    const char* xdg = xdg_env ? xdg_env : "$HOME/.local/share";
-    const uint32_t char_len = path_len;
-    char xdg_buf[char_len];
+        const char* xdg_env = dmSys::GetEnv("XDG_DATA_HOME");
+        const char* xdg = xdg_env ? xdg_env : "$HOME/.local/share";
+        const uint32_t char_len = path_len;
+        char xdg_buf[char_len];
 
-    dmStrlCpy(xdg_buf, xdg, path_len);
-    dmStrlCat(xdg_buf, "/", path_len);
-    if (dmStrlCat(xdg_buf, application_name, path_len) >= path_len)
-        return RESULT_INVAL;
-    const char* xdg_path = xdg_buf;
-
-    // No need to continue if {application_name} dir already exists
-    if (realpath(xdg_path, path_out))
-        return RESULT_OK;
-
-    const char* dirs[] = {"HOME", "TMPDIR", "TMP", "TEMP"}; // Added common temp directories since server instances usually don't have a HOME set
-    size_t count = sizeof(dirs)/sizeof(dirs[0]);
-    const char* home = 0;
-
-    for (size_t i = 0; i < count; i++)
-    {
-        home = dmSys::GetEnv(dirs[i]);
-        if (home)
-            break;
-	}
-
-    if (!home){
-           home = "."; // fall back to current directory, because the server instance might not have any of those paths set
-	}
-    char home_buf[char_len];
-    if (dmStrlCpy(home_buf, home, path_len) >= path_len)
-        return RESULT_INVAL;
-    if (dmStrlCat(home_buf, "/", path_len) >= path_len)
-        return RESULT_INVAL;
-    if (dmStrlCat(home_buf, ".", path_len) >= path_len)
-        return RESULT_INVAL;
-    if (dmStrlCat(home_buf, application_name, path_len) >= path_len)
-        return RESULT_INVAL;
-	
-    // If {home}/.{application_name exists}, return it here
-    const char* home_path = home_buf;
-    if (realpath(home_path, path_out))
-    {
-        if (dmStrlCpy(path_out, home_path, path_len) >= path_len)
+        dmStrlCpy(xdg_buf, xdg, path_len);
+        dmStrlCat(xdg_buf, "/", path_len);
+        if (dmStrlCat(xdg_buf, application_name, path_len) >= path_len)
             return RESULT_INVAL;
-        return RESULT_OK;
-    }
-    // Default to $HOME/.local/store or $XDG_DATA_DIR
-    if (dmStrlCpy(path_out, xdg_path, path_len) >= path_len)
-        return RESULT_INVAL;
-    Result r = Mkdir(path_out, 0755);
+        const char* xdg_path = xdg_buf;
+
+        // No need to continue if {application_name} dir already exists
+        if (realpath(xdg_path, path_out))
+            return RESULT_OK;
+
+        const char* dirs[] = {"HOME", "TMPDIR", "TMP", "TEMP"}; // Added common temp directories since server instances usually don't have a HOME set
+        size_t count = sizeof(dirs)/sizeof(dirs[0]);
+        const char* home = 0;
+
+        for (size_t i = 0; i < count; i++)
+        {
+            home = dmSys::GetEnv(dirs[i]);
+            if (home)
+                break;
+        }
+
+        if (!home){
+               home = "."; // fall back to current directory, because the server instance might not have any of those paths set
+        }
+
+        char home_buf[char_len];
+        if (dmStrlCpy(home_buf, home, path_len) >= path_len);
+            return RESULT_INVAL;
+        if (dmStrlCat(home_buf, "/", path_len) >= path_len);
+            return RESULT_INVAL;
+        if (dmStrlCat(home_buf, ".", path_len) >= path_len);
+            return RESULT_INVAL;
+        if (dmStrlCat(home_buf, application_name, path_len) >= path_len)
+            return RESULT_INVAL;
+        const char* home_path = home_buf;
+
+        // If {home}/.{application_name exists}, return it here
+        if (realpath(home_path, path_out))
+        {
+            if (dmStrlCpy(path_out, home_path, path_len) >= path_len)
+                return RESULT_INVAL;
+            return RESULT_OK;
+        }
+        // Default to $HOME/.local/store or $XDG_DATA_DIR
+        if (dmStrlCpy(path_out, xdg_path, path_len) >= path_len)
+            return RESULT_INVAL;
+        Result r = Mkdir(path_out, 0755);
         if (r == RESULT_EXIST)
             return RESULT_OK;
         else

--- a/engine/dlib/src/dlib/sys_posix.cpp
+++ b/engine/dlib/src/dlib/sys_posix.cpp
@@ -414,36 +414,64 @@ namespace dmSys
         return GetApplicationSupportPath(application_name, path, path_len);
     }
 
-    Result GetApplicationSupportPath(const char* application_name, char* path, uint32_t path_len)
+    Result GetApplicationSupportPath(const char* application_name, char* path_out, uint32_t path_len)
     {
-        const char* dirs[] = {"HOME", "TMPDIR", "TMP", "TEMP"}; // Added common temp directories since server instances usually don't have a HOME set
-        size_t count = sizeof(dirs)/sizeof(dirs[0]);
-        const char* home = 0;
-        for (size_t i = 0; i < count; ++i)
-        {
-            home = getenv(dirs[i]);
-            if (home)
-                break;
-        }
-        if (!home) {
-            home = "."; // fall back to current directory, because the server instance might not have any of those paths set
-        }
+	const char* xdg = getenv("XDG_DATA_HOME") ? getenv("XDG_DATA_HOME") : "$HOME/.local/share/";
+	char xdg_buf[path_len];
 
-        if (dmStrlCpy(path, home, path_len) >= path_len)
+	dmStrlCpy(xdg_buf, xdg, path_len);
+	dmStrlCat(xdg_buf, "/", path_len);
+	if (dmStrlCat(xdg_buf, application_name, path_len) >= path_len)
+		return RESULT_INVAL;
+	const char* xdg_path = xdg_buf;
+
+	// No need to continue if {application_name} dir already exists
+	if (realpath(xdg_path, path_out))
+		return RESULT_OK;
+
+	const char* dirs[] = {"HOME", "TMPDIR", "TMP", "TEMP"}; // Added common temp directories since server instances usually don't have a HOME set
+	size_t count = sizeof(dirs)/sizeof(dirs[0]);
+	const char* home = 0;
+
+	for (size_t i = 0; i < count; i++)
+	{
+		home = getenv(dirs[i]);
+		if (home)
+			break;
+	}
+
+	if (!home){
+           home = "."; // fall back to current directory, because the server instance might not have any of those paths set
+	}
+	char home_buf[path_len];
+	if (dmStrlCpy(home_buf, home, path_len) >= path_len)
+		return RESULT_INVAL;
+        if (dmStrlCat(home_buf, "/", path_len) >= path_len)
             return RESULT_INVAL;
-        if (dmStrlCat(path, "/", path_len) >= path_len)
+        if (dmStrlCat(home_buf, ".", path_len) >= path_len)
             return RESULT_INVAL;
-        if (dmStrlCat(path, ".", path_len) >= path_len)
+        if (dmStrlCat(home_buf, application_name, path_len) >= path_len)
             return RESULT_INVAL;
-        if (dmStrlCat(path, application_name, path_len) >= path_len)
-            return RESULT_INVAL;
-        Result r =  Mkdir(path, 0755);
+	
+	// If {home}/.{application_name exists}, return it here
+	const char* home_path = home_buf;
+	if (realpath(home_path, path_out))
+	{
+		if (dmStrlCpy(path_out, home_path, path_len) >= path_len)
+			return RESULT_INVAL;
+		return RESULT_OK;
+	}
+	// Default to $HOME/.local/store or $XDG_DATA_DIR
+	if (dmStrlCpy(path_out, xdg_path, path_len) >= path_len)
+		return RESULT_INVAL;
+	Result r = Mkdir(path_out, 0755);
         if (r == RESULT_EXIST)
             return RESULT_OK;
         else
             return r;
-    }
 
+    }
+    
     Result OpenURL(const char* url, const char* target)
     {
         char buf[1024];

--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -1085,7 +1085,7 @@ namespace dmEngine
         {
             char path[1024];
             dmHttpCache::NewParams cache_params;
-            dmSys::Result sys_result = dmSys::GetApplicationSupportPath("Defold", path, sizeof(path));
+            dmSys::Result sys_result = dmSys::GetApplicationSupportPath(DMSYS_APPLICATION_NAME, path, sizeof(path));
             if (sys_result == dmSys::RESULT_OK)
             {
                 dmStrlCat(path, "/http-cache", sizeof(path));
@@ -1098,7 +1098,7 @@ namespace dmEngine
             }
             else
             {
-                dmLogWarning("Unable to locate application support path for \"%s\": (%d)", "Defold", sys_result);
+                dmLogWarning("Unable to locate application support path for \"%s\": (%d)", DMSYS_APPLICATION_NAME, sys_result);
             }
         }
 #endif

--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -1085,7 +1085,7 @@ namespace dmEngine
         {
             char path[1024];
             dmHttpCache::NewParams cache_params;
-            dmSys::Result sys_result = dmSys::GetApplicationSupportPath("defold", path, sizeof(path));
+            dmSys::Result sys_result = dmSys::GetApplicationSupportPath("Defold", path, sizeof(path));
             if (sys_result == dmSys::RESULT_OK)
             {
                 dmStrlCat(path, "/http-cache", sizeof(path));
@@ -1098,7 +1098,7 @@ namespace dmEngine
             }
             else
             {
-                dmLogWarning("Unable to locate application support path for \"%s\": (%d)", "defold", sys_result);
+                dmLogWarning("Unable to locate application support path for \"%s\": (%d)", "Defold", sys_result);
             }
         }
 #endif

--- a/engine/script/src/script_sys.cpp
+++ b/engine/script/src/script_sys.cpp
@@ -341,11 +341,28 @@ union SaveLoadBuffer
      * @return path [type:string] path to save-file
      * @examples
      *
-     * Find a path where we can store data (the example path is on the macOS platform):
+     * Find a path where we can store data:
      *
      * ```lua
      * local my_file_path = sys.get_save_file("my_game", "my_file")
-     * print(my_file_path) --> /Users/my_users/Library/Application Support/my_game/my_file
+     * -- macOS: /Users/foobar/Library/Application Support/my_game/my_file
+     * print(my_file_path) --> /Users/foobar/Library/Application Support/my_game/my_file
+     *
+     * -- Windows: C:\Users\foobar\AppData\Roaming\my_game\my_file
+     * print(my_file_path) --> C:\Users\foobar\AppData\Roaming\my_game\my_file
+     *
+     * -- Linux: $XDG_DATA_HOME/my_game/my_file or /home/foobar/.my_game/my_file
+     * -- Linux: Defaults to /home/foobar/.local/share/my_game/my_file if neither exist.
+     * print(my_file_path) --> /home/foobar/.local/share/my_game/my_file
+     *
+     * -- Android package name: com.foobar.packagename
+     * print(my_file_path) --> /data/data/0/com.foobar.packagename/files/my_file
+     *
+     * -- iOS: /var/mobile/Containers/Data/Application/123456AB-78CD-90DE-12345678ABCD/my_game/my_file
+     * print(my_file_path) --> /var/containers/Bundle/Applications/123456AB-78CD-90DE-12345678ABCD/my_game.app
+     *
+     * -- HTML5 path inside the IndexedDB: /data/.my_game/my_file or /.my_game/my_file
+     * print(my_file_path) --> /data/.my_game/my_file
      * ```
      */
     static int Sys_GetSaveFile(lua_State* L)


### PR DESCRIPTION
On Linux, the default support path (which includes saves) was `$HOME/.application` or a few temporary folders. Now `$XDG_DATA_HOME/application` is checked first, followed by the old paths. If neither is found, the path defaults to `/home/user/.local/share/application`. This gives users greater choice for where to keep their data. 

Part of #8078
Closes #10317
Closes #9618
### Technical changes
* The previous flow was to check if `$HOME, $TMPDIR, $TMP, or $TEMP` existed, and then build the path using `dmStrlCat`.
* A previous PR (#6874) was closed because making $XDG_DATA_HOME the priority without losing previous saves is not an easy ask.
* To address this, GetApplicationSupportPath now builds the XDG path and returns early if $XDG_DATA_HOME/application_name exists. Otherwise, it follows the exact code it used to (to ensure there's no chance of missing a save) and checks if that folder already exists (using realpath). If not, defaults to either $XDG_DATA_HOME if set or $HOME/.local/share
* Line 419 is left long for portability (the `x ? : y` ternary operator shorthand is a gcc extension, not available everywhere)
* Tested on 1.9.6, 1.9.7.
* Almost forgot to mention: also updates the http-cache folder from `defold` to `Defold` to be consistent with other folders in case-sensitive file systems. 
* EDIT: I've also now added the default save paths to to the `sys.get_save_file()`. Players asking where a game's saves are is fairly common, so that should help devs answer the question. It may vary some across the platforms, but I think they're reasonable expected locations. 
## PR checklist

* [ ] Code
	* [?] Add engine and/or editor unit tests. 
	* [x] New and changed code follows the overall code style of existing code
	* [x] Add comments where needed
* [x] Documentation
	* [x] Make sure that API documentation is updated in code comments ~~(not covered covered by api)~~
	* [x] Make sure that manuals are updated (in github.com/defold/doc)
* [x] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [x] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [x] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.
