### PR TITLE
Optimized the gui node size

### DIFF
--- a/engine/gamesys/proto/gamesys/gui_ddf.proto
+++ b/engine/gamesys/proto/gamesys/gui_ddf.proto
@@ -88,7 +88,7 @@ message NodeDesc
         SIZE_MODE_AUTO      = 1 [(displayName) = "Auto"];
     }
 
-    enum PieBounds
+    enum PieBounds : uint8_t
     {
         PIEBOUNDS_RECTANGLE = 0 [(displayName) = "Rectangle"];
         PIEBOUNDS_ELLIPSE   = 1 [(displayName) = "Ellipse"];

--- a/engine/gamesys/proto/gamesys/gui_ddf.proto
+++ b/engine/gamesys/proto/gamesys/gui_ddf.proto
@@ -88,7 +88,7 @@ message NodeDesc
         SIZE_MODE_AUTO      = 1 [(displayName) = "Auto"];
     }
 
-    enum PieBounds : uint8_t
+    enum PieBounds
     {
         PIEBOUNDS_RECTANGLE = 0 [(displayName) = "Rectangle"];
         PIEBOUNDS_ELLIPSE   = 1 [(displayName) = "Ellipse"];

--- a/engine/gui/src/dmsdk/gui/gui.h
+++ b/engine/gui/src/dmsdk/gui/gui.h
@@ -117,7 +117,7 @@ namespace dmGui
      * @member NODE_TEXTURE_TYPE_TEXTURE
      * @member NODE_TEXTURE_TYPE_TEXTURE_SET
      */
-    enum NodeTextureType
+    enum NodeTextureType : uint8_t
     {
         NODE_TEXTURE_TYPE_NONE,
         NODE_TEXTURE_TYPE_TEXTURE,

--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -2519,9 +2519,7 @@ namespace dmGui
         }
         if (n->m_Node.m_Text)
             free((void*)n->m_Node.m_Text);
-        if (n->m_Node.m_HasResetPoint) {
-            free(n->m_Node.m_ResetPointProperties);
-        }
+        free(n->m_Node.m_ResetPointProperties);
         memset(n, 0, sizeof(InternalNode));
         n->m_Index = INVALID_INDEX;
     }
@@ -4233,7 +4231,7 @@ namespace dmGui
 
         InternalNode* n = GetNode(scene, node);
         out_n->m_Node = n->m_Node;
-        out_n->m_Node.m_HasResetPoint = false;
+        out_n->m_Node.m_HasResetPoint = 0;
         out_n->m_Node.m_ResetPointProperties = 0;
         if (n->m_Node.m_Text != 0x0)
             out_n->m_Node.m_Text = strdup(n->m_Node.m_Text);

--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -2519,6 +2519,9 @@ namespace dmGui
         }
         if (n->m_Node.m_Text)
             free((void*)n->m_Node.m_Text);
+        if (n->m_Node.m_HasResetPoint) {
+            free(n->m_Node.m_ResetPointProperties);
+        }
         memset(n, 0, sizeof(InternalNode));
         n->m_Index = INVALID_INDEX;
     }
@@ -2923,6 +2926,10 @@ namespace dmGui
     void SetNodeResetPoint(HScene scene, HNode node)
     {
         InternalNode* n = GetNode(scene, node);
+        if (!n->m_Node.m_ResetPointProperties)
+        {
+            n->m_Node.m_ResetPointProperties = (dmVMath::Vector4*)malloc(sizeof(dmVMath::Vector4) * PROPERTY_COUNT);
+        }
         memcpy(n->m_Node.m_ResetPointProperties, n->m_Node.m_Properties, sizeof(n->m_Node.m_Properties));
         n->m_Node.m_ResetPointState = n->m_Node.m_State;
         n->m_Node.m_HasResetPoint = 1;
@@ -4226,6 +4233,8 @@ namespace dmGui
 
         InternalNode* n = GetNode(scene, node);
         out_n->m_Node = n->m_Node;
+        out_n->m_Node.m_HasResetPoint = false;
+        out_n->m_Node.m_ResetPointProperties = 0;
         if (n->m_Node.m_Text != 0x0)
             out_n->m_Node.m_Text = strdup(n->m_Node.m_Text);
         out_n->m_NameHash = dmHashString64(name);

--- a/engine/gui/src/gui.h
+++ b/engine/gui/src/gui.h
@@ -353,7 +353,7 @@ namespace dmGui
 
     // NOTE: These enum values are duplicated in scene desc in gamesys (gui_ddf.proto)
     // Don't forget to change gui_ddf.proto if you change here
-    enum PieBounds
+    enum PieBounds : uint8_t
     {
         PIEBOUNDS_RECTANGLE = 0,
         PIEBOUNDS_ELLIPSE   = 1,

--- a/engine/gui/src/gui_private.h
+++ b/engine/gui/src/gui_private.h
@@ -105,72 +105,65 @@ namespace dmGui
 
     struct Node
     {
-        dmVMath::Vector4    m_Properties[PROPERTY_COUNT];
-        dmVMath::Vector4    m_ResetPointProperties[PROPERTY_COUNT];
-        dmVMath::Matrix4    m_LocalTransform;
-        dmVMath::Vector4    m_LocalAdjustScale;
-        uint32_t            m_ResetPointState;
+        dmVMath::Matrix4        m_LocalTransform;
+        dmVMath::Vector4        m_Properties[PROPERTY_COUNT];
+        dmVMath::Vector4        m_LocalAdjustScale;
 
-        uint32_t    m_HasResetPoint         : 1; // If true, we have stored a copy of the m_State, into m_ResetPointState
-        uint32_t    m_PerimeterVertices     :31;
-        PieBounds   m_OuterBounds;
+        uint64_t                m_TextureHash;
+        uint64_t                m_FlipbookAnimHash;
+        uint64_t                m_FontHash;
+        uint64_t                m_ParticlefxHash;
+        dmhash_t                m_LayerHash;
+        dmhash_t                m_MaterialNameHash;
+
+        HTextureSource          m_Texture;
+        void*                   m_Font;
+        void*                   m_Material;
+        void*                   m_RenderConstants;
+        void*                   m_CustomData;
+        void*                   m_ParticlefxPrototype;
+        dmParticle::HInstance   m_ParticleInstance;
+        dmVMath::Vector4*       m_ResetPointProperties;
+        uint32_t                m_ResetPointState;
+        uint32_t                m_RenderConstantsHash;
+        uint32_t                m_CustomType; // Only valid if m_NodeType == NODE_TYPE_CUSTOM
+
+        uint32_t                m_PerimeterVertices : 31;
+        uint32_t                m_HasResetPoint : 1;
 
         union
         {
             struct
             {
-                uint32_t    m_BlendMode : 4;
-                uint32_t    m_NodeType : 4;
-                uint32_t    m_XAnchor : 2;
-                uint32_t    m_YAnchor : 2;
-                uint32_t    m_Pivot : 4;
-                uint32_t    m_AdjustMode : 2;
-                uint32_t    m_SizeMode : 1;
-                uint32_t    m_LineBreak : 1;
-                uint32_t    m_Enabled : 1; // Only enabled (1) nodes are animated and rendered
-                uint32_t    m_IsVisible : 1;
-                uint32_t    m_DirtyLocal : 1;
-                uint32_t    m_InheritAlpha : 1;
-                uint32_t    m_ClippingMode : 2;
-                uint32_t    m_ClippingVisible : 1;
-                uint32_t    m_ClippingInverted : 1;
-                uint32_t    m_IsBone : 1;
-                uint32_t    m_HasHeadlessPfx : 1;
-                uint32_t    m_Reserved : 2;
+                uint32_t        m_BlendMode : 4;
+                uint32_t        m_NodeType : 4;
+                uint32_t        m_XAnchor : 2;
+                uint32_t        m_YAnchor : 2;
+                uint32_t        m_Pivot : 4;
+                uint32_t        m_AdjustMode : 2;
+                uint32_t        m_SizeMode : 1;
+                uint32_t        m_LineBreak : 1;
+                uint32_t        m_Enabled : 1; // Only enabled (1) nodes are animated and rendered
+                uint32_t        m_IsVisible : 1;
+                uint32_t        m_DirtyLocal : 1;
+                uint32_t        m_InheritAlpha : 1;
+                uint32_t        m_ClippingMode : 2;
+                uint32_t        m_ClippingVisible : 1;
+                uint32_t        m_ClippingInverted : 1;
+                uint32_t        m_IsBone : 1;
+                uint32_t        m_HasHeadlessPfx : 1;
+                uint32_t        m_Reserved : 2;
             };
-
             uint32_t m_State;
         };
 
-        uint32_t    m_CustomType; // Valid if m_State.m_NodeType == NODE_TYPE_CUSTOM
-
-        const char* m_Text;
-
-        uint64_t        m_TextureHash;
-        HTextureSource  m_Texture;
-        NodeTextureType m_TextureType;
-
-        TextureSetAnimDesc m_TextureSetAnimDesc;
-        uint64_t    m_FlipbookAnimHash;
-        float       m_FlipbookAnimPosition;
-
-        uint64_t    m_FontHash;
-        void*       m_Font;
-        dmhash_t    m_LayerHash;
-        uint16_t    m_LayerIndex;
-
-        void**      m_NodeDescTable;
-
-        void*       m_CustomData;
-
-        dmhash_t    m_MaterialNameHash;
-        void*       m_Material;
-        void*       m_RenderConstants;
-        uint32_t    m_RenderConstantsHash;
-
-        uint64_t                m_ParticlefxHash;
-        void*                   m_ParticlefxPrototype;
-        dmParticle::HInstance   m_ParticleInstance;
+        const char*             m_Text;
+        void**                  m_NodeDescTable;
+        TextureSetAnimDesc      m_TextureSetAnimDesc;
+        float                   m_FlipbookAnimPosition;
+        uint16_t                m_LayerIndex;
+        PieBounds               m_OuterBounds;
+        NodeTextureType         m_TextureType;
     };
 
     struct InternalNode


### PR DESCRIPTION
The size is now 512 bytes instead of 720 bytes for dynamically created nodes and 704 bytes for nodes loaded from resources. 

### Technical changes
Smaller enums helped save a few bytes, and together with alignment improvements, reduced the structure size to 688 bytes.  

However, I then discovered that each structure contains a copy of all the properties for reset, which is rarely need. Yet, we "pay" with a much larger node size for each node just to have this rarely used functionality.  