### PR TITLE
Make hashes sortable by their numeric value

### DIFF
--- a/engine/script/src/script_hash.cpp
+++ b/engine/script/src/script_hash.cpp
@@ -265,6 +265,14 @@ namespace dmScript
         return 1;
     }
 
+    static int Hash_lt(lua_State* L)
+    {
+        dmhash_t hash_1 = CheckHash(L, 1);
+        dmhash_t hash_2 = CheckHash(L, 2);
+        lua_pushboolean(L, hash_1 < hash_2);
+        return 1;
+    }
+
     static int Hash_tostring(lua_State* L)
     {
         dmhash_t hash = CheckHash(L, 1);
@@ -330,6 +338,10 @@ namespace dmScript
 
         lua_pushliteral(L, "__concat");
         lua_pushcfunction(L, Hash_concat);
+        lua_settable(L, -3);
+
+        lua_pushliteral(L, "__lt");
+        lua_pushcfunction(L, Hash_lt);
         lua_settable(L, -3);
 
         lua_pushcfunction(L, Hash_new);


### PR DESCRIPTION
Now it's possible to sort a table of hashes: 

```lua
local player_list = { hash("p2345"), hash("p1234") }
table.sort(player_list)
```


Fix https://github.com/defold/defold/issues/9853