### PR TITLE
Added more tests to keep physics api implementations in sync

### DIFF
--- a/engine/physics/src/physics/box2d_defold/box2d_defold_physics.cpp
+++ b/engine/physics/src/physics/box2d_defold/box2d_defold_physics.cpp
@@ -1268,7 +1268,7 @@ namespace dmPhysics
         body->SetBullet(value);
     }
 
-    void SetGroup2D(HCollisionObject2D collision_object, uint16_t groupbit) {
+    void SetGroup2D(HWorld2D world, HCollisionObject2D collision_object, uint16_t groupbit) {
         b2Fixture* fixture = ((b2Body*)collision_object)->GetFixtureList();
         while (fixture) {
             // do sth with the fixture
@@ -1281,7 +1281,7 @@ namespace dmPhysics
         }
     }
 
-    uint16_t GetGroup2D(HCollisionObject2D collision_object) {
+    uint16_t GetGroup2D(HWorld2D world, HCollisionObject2D collision_object) {
         b2Fixture* fixture = ((b2Body*)collision_object)->GetFixtureList();
         if (fixture) {
             if (fixture->GetType() != b2Shape::e_grid) {
@@ -1293,7 +1293,7 @@ namespace dmPhysics
     }
 
     // updates a specific group bit of a collision object's current mask
-    void SetMaskBit2D(HCollisionObject2D collision_object, uint16_t groupbit, bool boolvalue) {
+    void SetMaskBit2D(HWorld2D world, HCollisionObject2D collision_object, uint16_t groupbit, bool boolvalue) {
         b2Fixture* fixture = ((b2Body*)collision_object)->GetFixtureList();
         while (fixture) {
             // do sth with the fixture
@@ -1337,7 +1337,7 @@ namespace dmPhysics
         return true;
     }
 
-    bool GetMaskBit2D(HCollisionObject2D collision_object, uint16_t groupbit) {
+    bool GetMaskBit2D(HWorld2D world, HCollisionObject2D collision_object, uint16_t groupbit) {
         b2Fixture* fixture = ((b2Body*)collision_object)->GetFixtureList();
         if (fixture) {
             if (fixture->GetType() != b2Shape::e_grid) {

--- a/engine/physics/src/physics/box2d_defold/box2d_defold_physics.cpp
+++ b/engine/physics/src/physics/box2d_defold/box2d_defold_physics.cpp
@@ -682,6 +682,10 @@ namespace dmPhysics
         return (b2GridShape*) fixture->GetShape();
     }
 
+    void CreateGridCellShape(HCollisionObject2D collision_object, uint32_t shape_index, uint32_t child)
+    {
+    }
+
     bool SetGridShapeHull(HCollisionObject2D collision_object, uint32_t shape_index, uint32_t row, uint32_t column, uint32_t hull, HullFlags flags)
     {
         b2Body* body = (b2Body*) collision_object;

--- a/engine/physics/src/physics/physics_2d_null.cpp
+++ b/engine/physics/src/physics/physics_2d_null.cpp
@@ -234,21 +234,21 @@ namespace dmPhysics
     {
     }
 
-    uint16_t GetGroup2D(HCollisionObject2D collision_object)
+    uint16_t GetGroup2D(HWorld2D world, HCollisionObject2D collision_object)
     {
         return 0;
     }
 
-    void SetGroup2D(HCollisionObject2D collision_object, uint16_t groupbit)
+    void SetGroup2D(HWorld2D world, HCollisionObject2D collision_object, uint16_t groupbit)
     {
     }
 
-    bool GetMaskBit2D(HCollisionObject2D collision_object, uint16_t groupbit)
+    bool GetMaskBit2D(HWorld2D world, HCollisionObject2D collision_object, uint16_t groupbit)
     {
         return false;
     }
 
-    void SetMaskBit2D(HCollisionObject2D collision_object, uint16_t groupbit, bool boolvalue)
+    void SetMaskBit2D(HWorld2D world, HCollisionObject2D collision_object, uint16_t groupbit, bool boolvalue)
     {
     }
 

--- a/engine/physics/src/physics/physics_2d_null.cpp
+++ b/engine/physics/src/physics/physics_2d_null.cpp
@@ -91,6 +91,10 @@ namespace dmPhysics
     {
     }
 
+    void CreateGridCellShape(HCollisionObject2D collision_object, uint32_t shape_index, uint32_t child)
+    {
+    }
+
     bool SetGridShapeHull(HCollisionObject2D collision_object, uint32_t shape_index, uint32_t row, uint32_t column, uint32_t hull, HullFlags flags)
     {
         return false;

--- a/engine/physics/src/physics/physics_2d_null.cpp
+++ b/engine/physics/src/physics/physics_2d_null.cpp
@@ -252,7 +252,7 @@ namespace dmPhysics
     {
     }
 
-    bool UpdateMass2D(HCollisionObject2D collision_object, float mass)
+    bool UpdateMass2D(HWorld2D world, HCollisionObject2D collision_object, float mass)
     {
         return false;
     }

--- a/engine/physics/src/physics/test/test_physics_2d.cpp
+++ b/engine/physics/src/physics/test/test_physics_2d.cpp
@@ -239,6 +239,8 @@ TYPED_TEST(PhysicsTest, SetGridShapeHull)
     ASSERT_TRUE(dmPhysics::SetGridShapeHull(grid_co, 0, 0, 0, 0, EMPTY_FLAGS));
     ASSERT_FALSE(dmPhysics::SetGridShapeHull(grid_co, 1, 0, 0, 0, EMPTY_FLAGS));
 
+    dmPhysics::CreateGridCellShape(grid_co, 0, 0);
+
     (*TestFixture::m_Test.m_DeleteCollisionObjectFunc)(TestFixture::m_World, grid_co);
     (*TestFixture::m_Test.m_DeleteCollisionShapeFunc)(grid_shape);
     dmPhysics::DeleteHullSet2D(hull_set);

--- a/engine/physics/src/physics/test/test_physics_2d.cpp
+++ b/engine/physics/src/physics/test/test_physics_2d.cpp
@@ -1931,6 +1931,67 @@ TYPED_TEST(PhysicsTest, SetGridShapeEnable)
     dmPhysics::DeleteHullSet2D(hull_set);
 }
 
+TYPED_TEST(PhysicsTest, GetSetGroup2D)
+{
+    int32_t rows = 4;
+    int32_t columns = 10;
+    int32_t cell_width = 16;
+    int32_t cell_height = 16;
+    dmPhysics::CollisionObjectData data;
+    data.m_Type = dmPhysics::COLLISION_OBJECT_TYPE_STATIC;
+    data.m_Mass = 0.0f;
+    data.m_UserData = 0;
+    data.m_Group = 0xffff;
+    data.m_Mask = 0xffff;
+    data.m_Restitution = 0.0f;
+
+    dmPhysics::HCollisionShape2D shape = dmPhysics::NewBoxShape2D(TestFixture::m_Context, dmVMath::Vector3(0.5f, 0.5f, 0.0f));
+    typename TypeParam::CollisionObjectType co = (*TestFixture::m_Test.m_NewCollisionObjectFunc)(TestFixture::m_World, data, &shape, 1u);
+
+    uint16_t group = dmPhysics::GetGroup2D(TestFixture::m_World, co);
+    ASSERT_EQ((uint16_t)0xffff, group);
+
+    dmPhysics::SetGroup2D(TestFixture::m_World, co, (uint16_t)0xabcd);
+    group = dmPhysics::GetGroup2D(TestFixture::m_World, co);
+
+    ASSERT_EQ((uint16_t)0xabcd, group);
+
+    (*TestFixture::m_Test.m_DeleteCollisionObjectFunc)(TestFixture::m_World, co);
+    dmPhysics::DeleteCollisionShape2D(shape);
+}
+
+TYPED_TEST(PhysicsTest, GetSetMaskD)
+{
+    int32_t rows = 4;
+    int32_t columns = 10;
+    int32_t cell_width = 16;
+    int32_t cell_height = 16;
+    dmPhysics::CollisionObjectData data;
+    data.m_Type = dmPhysics::COLLISION_OBJECT_TYPE_STATIC;
+    data.m_Mass = 0.0f;
+    data.m_UserData = 0;
+    data.m_Group = 0xffff;
+    data.m_Mask = 0xffff;
+    data.m_Restitution = 0.0f;
+
+    dmPhysics::HCollisionShape2D shape = dmPhysics::NewBoxShape2D(TestFixture::m_Context, dmVMath::Vector3(0.5f, 0.5f, 0.0f));
+    typename TypeParam::CollisionObjectType co = (*TestFixture::m_Test.m_NewCollisionObjectFunc)(TestFixture::m_World, data, &shape, 1u);
+
+    bool is_set = dmPhysics::GetMaskBit2D(TestFixture::m_World, co, 1);
+    ASSERT_TRUE(is_set);
+
+    dmPhysics::SetMaskBit2D(TestFixture::m_World, co, (uint16_t)0x00FF, true);
+    dmPhysics::SetMaskBit2D(TestFixture::m_World, co, (uint16_t)0xFF00, false);
+
+    is_set = dmPhysics::GetMaskBit2D(TestFixture::m_World, co, (uint16_t)0xFF00);
+    ASSERT_FALSE(is_set);
+    is_set = dmPhysics::GetMaskBit2D(TestFixture::m_World, co, (uint16_t)0x00F0);
+    ASSERT_TRUE(is_set);
+
+    (*TestFixture::m_Test.m_DeleteCollisionObjectFunc)(TestFixture::m_World, co);
+    dmPhysics::DeleteCollisionShape2D(shape);
+}
+
 TYPED_TEST(PhysicsTest, ScriptApiBox2D)
 {
     ASSERT_NE((void*)0, (*TestFixture::m_Test.m_GetWorldContextFunc)(TestFixture::m_World));

--- a/engine/physics/src/physics/test/test_physics_2d.cpp
+++ b/engine/physics/src/physics/test/test_physics_2d.cpp
@@ -1960,7 +1960,7 @@ TYPED_TEST(PhysicsTest, GetSetGroup2D)
     dmPhysics::DeleteCollisionShape2D(shape);
 }
 
-TYPED_TEST(PhysicsTest, GetSetMaskD)
+TYPED_TEST(PhysicsTest, GetSetMaskBit2D)
 {
     int32_t rows = 4;
     int32_t columns = 10;
@@ -1987,6 +1987,35 @@ TYPED_TEST(PhysicsTest, GetSetMaskD)
     ASSERT_FALSE(is_set);
     is_set = dmPhysics::GetMaskBit2D(TestFixture::m_World, co, (uint16_t)0x00F0);
     ASSERT_TRUE(is_set);
+
+    (*TestFixture::m_Test.m_DeleteCollisionObjectFunc)(TestFixture::m_World, co);
+    dmPhysics::DeleteCollisionShape2D(shape);
+}
+
+TYPED_TEST(PhysicsTest, UpdateMass2D)
+{
+    int32_t rows = 4;
+    int32_t columns = 10;
+    int32_t cell_width = 16;
+    int32_t cell_height = 16;
+    dmPhysics::CollisionObjectData data;
+    data.m_Type = dmPhysics::COLLISION_OBJECT_TYPE_DYNAMIC;
+    data.m_Mass = 1.0f;
+    data.m_UserData = 0;
+    data.m_Group = 0xffff;
+    data.m_Mask = 0xffff;
+    data.m_Restitution = 0.0f;
+
+    dmPhysics::HCollisionShape2D shape = dmPhysics::NewBoxShape2D(TestFixture::m_Context, dmVMath::Vector3(0.5f, 0.5f, 0.0f));
+    typename TypeParam::CollisionObjectType co = (*TestFixture::m_Test.m_NewCollisionObjectFunc)(TestFixture::m_World, data, &shape, 1u);
+
+    float mass = dmPhysics::GetMass2D(co);
+    ASSERT_EQ(1.0f, mass);
+
+    dmPhysics::UpdateMass2D(TestFixture::m_World, co, 2.0f);
+
+    mass = dmPhysics::GetMass2D(co);
+    ASSERT_EQ(2.0f, mass);
 
     (*TestFixture::m_Test.m_DeleteCollisionObjectFunc)(TestFixture::m_World, co);
     dmPhysics::DeleteCollisionShape2D(shape);


### PR DESCRIPTION
## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
