### PR TITLE
Fix menu bar visibility on toolbar refresh

### DIFF
--- a/editor/src/clj/editor/outline_view.clj
+++ b/editor/src/clj/editor/outline_view.clj
@@ -488,7 +488,6 @@
         image-view-icon (ImageView.)
         visibility-button (doto (ToggleButton.)
                             (ui/add-style! "visibility-toggle")
-                            (.addEventFilter MouseEvent/MOUSE_PRESSED ui/ignore-event-filter)
                             (AnchorPane/setRightAnchor 0.0))
         text-label (doto (Label.)
                      (ui/bind-double-click! :open))

--- a/editor/src/clj/editor/properties_view.clj
+++ b/editor/src/clj/editor/properties_view.clj
@@ -625,7 +625,7 @@
         listen-fn (fn [_old-val new-val]
                     (when-not *programmatic-setting*
                       (properties/set-values! (property-fn) (repeat new-val))
-                      (ui/user-data! (ui/main-scene) ::ui/refresh-requested? true)))]
+                      (ui/refresh (ui/main-scene))))]
     (fuzzy-combo-box/observe! combo-box listen-fn)
     [combo-box update-ui-fn]))
 

--- a/editor/src/clj/editor/properties_view.clj
+++ b/editor/src/clj/editor/properties_view.clj
@@ -625,7 +625,7 @@
         listen-fn (fn [_old-val new-val]
                     (when-not *programmatic-setting*
                       (properties/set-values! (property-fn) (repeat new-val))
-                      (ui/refresh (ui/main-scene))))]
+                      (ui/user-data! (ui/main-scene) ::ui/refresh-requested? true)))]
     (fuzzy-combo-box/observe! combo-box listen-fn)
     [combo-box update-ui-fn]))
 

--- a/editor/src/clj/editor/ui.clj
+++ b/editor/src/clj/editor/ui.clj
@@ -59,6 +59,8 @@
 
 (set! *warn-on-reflection* true)
 
+(def ^:private ^:dynamic *programmatic-selection* nil)
+
 ;; Next line of code makes sure JavaFX is initialized, which is required during
 ;; compilation even when we are not actually running the editor. To properly
 ;; generate reflection-less code, clojure compiler loads classes and searches
@@ -1804,7 +1806,7 @@
                                                             (.setConverter (DefoldStringConverter. :label #(some #{%} (map :label opts)))))]
                                                    (.setAll (.getItems cb) ^Collection opts)
                                                    (observe (.valueProperty cb) (fn [this old new]
-                                                                                  (when new
+                                                                                  (when (and new (not *programmatic-selection*))
                                                                                     (let [command-contexts (contexts scene)]
                                                                                       (execute-command command-contexts (:command new) (:user-data new))))))
                                                    (.add (.getChildren hbox) (icons/get-image-view (:icon menu-item) 16))
@@ -1862,7 +1864,8 @@
             (let [selection-model (.getSelectionModel cb)
                   item (.getSelectedItem selection-model)]
               (when (not= item state)
-                (.select selection-model state)))))))))
+                (binding [*programmatic-selection* true]
+                  (.select selection-model state))))))))))
 
 (defn- window-parents [^Window window]
   (when-let [parent (condp instance? window


### PR DESCRIPTION
This fixes an occasional menu bar visibility issue, triggered by a toolbar refresh. 

Fixes #10361

### Technical changes
Refreshing the toolbars was triggering a command execution, when the selection of the ChoiceBox was programmatically set. That was affecting the focus state and the context of the menu-bar. Although this looks linux specific, it is also reproducible on macOS (and probably windows). The difference is that on mac, the custom title-bar is not visible, so the problem is less prominent. Hiding the native menu does not look as bad as the case on video of the reported issue, but it's part of the same problem. Note that the initial trigger of the reported problem is calling `(ui/user-data! (ui/main-scene) ::ui/refresh-requested? true)`, so whenever we attempt to automatically refresh the UI, there is a chance to face this issue.