### PR TITLE
Add build server username/password prefs fields

### DIFF
--- a/editor/src/clj/editor/editor_extensions/prefs_docs.clj
+++ b/editor/src/clj/editor/editor_extensions/prefs_docs.clj
@@ -70,6 +70,11 @@
        :props [(make-default-prop "string")
                scope-prop])
      (ui-docs/component
+       "password"
+       :description "password schema\n\nA password is a string that is encrypted when stored in a preference file"
+       :props [(make-default-prop "string")
+               scope-prop])
+     (ui-docs/component
        "keyword"
        :description "keyword schema\n\nA keyword is a short string that is interned within the editor runtime, useful e.g. for identifiers"
        :props [(make-default-prop "string")

--- a/editor/src/clj/editor/editor_extensions/prefs_functions.clj
+++ b/editor/src/clj/editor/editor_extensions/prefs_functions.clj
@@ -42,6 +42,7 @@
     :any coerce/any
     :boolean coerce/boolean
     :string coerce/string
+    :password coerce/string
     :keyword prefs-docs/serializable-keyword-coercer
     :integer coerce/integer
     :number number->double-coercer

--- a/editor/src/clj/editor/engine.clj
+++ b/editor/src/clj/editor/engine.clj
@@ -211,9 +211,7 @@
   [project evaluation-context prefs platform]
   (or (dev-custom-engine prefs platform)
       (if (native-extensions/has-engine-extensions? project evaluation-context)
-        (let [build-server-url (native-extensions/get-build-server-url prefs project evaluation-context)
-              build-server-headers (native-extensions/get-build-server-headers prefs)]
-          (native-extensions/get-engine-archive project evaluation-context platform build-server-url build-server-headers))
+        (native-extensions/get-engine-archive project platform prefs evaluation-context)
         (bundled-engine platform))))
 
 (defn- unpack-dmengine!

--- a/editor/src/clj/editor/engine/native_extensions.clj
+++ b/editor/src/clj/editor/engine/native_extensions.clj
@@ -25,7 +25,8 @@
             [editor.resource-node :as resource-node]
             [editor.shared-editor-settings :as shared-editor-settings]
             [editor.system :as system]
-            [editor.workspace :as workspace])
+            [editor.workspace :as workspace]
+            [util.coll :as coll])
   (:import [com.defold.extender.client ExtenderClient ExtenderClientCache ExtenderResource]
            [com.dynamo.bob Platform]
            [java.io File]
@@ -252,7 +253,7 @@
            (extension-resource-nodes-by-upload-path project evaluation-context platform)
            (get-main-manifest-file-upload-resource project evaluation-context platform))))
 
-(defn get-engine-archive [project evaluation-context platform build-server-url build-server-headers]
+(defn get-engine-archive [project platform prefs evaluation-context]
   (if-not (supported-platform? platform)
     (throw (engine-build-errors/unsupported-platform-error platform))
     (let [extender-platform (get-in extender-platforms [platform :platform])
@@ -261,22 +262,29 @@
           sdk-version (system/defold-engine-sha1)
           cache (ExtenderClientCache. cache-directory)
           extender-resources (make-extender-resources project platform evaluation-context)
-          cache-key (.calcKey cache extender-platform sdk-version extender-resources)]
+          cache-key (.calcKey cache extender-platform sdk-version extender-resources)
+          url (get-build-server-url prefs project evaluation-context)
+          headers (get-build-server-headers prefs)
+          username (string/trim (prefs/get prefs [:extensions :build-server-username]))
+          password (prefs/get prefs [:extensions :build-server-password])]
       (if (.isCached cache extender-platform cache-key)
         {:id {:type :custom :version cache-key}
          :cached true
          :engine-archive (.getCachedBuildFile cache extender-platform)
          :extender-platform extender-platform}
-        (let [extender-client (ExtenderClient. build-server-url cache-directory)
-              user-info (.getUserInfo (URI. build-server-url))
+        (let [extender-client (ExtenderClient. url cache-directory)
               destination-file (fs/create-temp-file! (str "build_" sdk-version) ".zip")
               log-file (fs/create-temp-file! (str "build_" sdk-version) ".txt")
               async true]
           (try
-            (when (pos? (count user-info))
-              (.setHeader extender-client "Authorization" (str "Basic " (.encodeToString (Base64/getEncoder) (.getBytes user-info StandardCharsets/UTF_8)))))
-            (when (pos? (count build-server-headers))
-              (.setHeaders extender-client build-server-headers))
+            (when-let [^String auth (or
+                                      (and (not (string/blank? username))
+                                           (not (coll/empty? password))
+                                           (str username ":" password))
+                                      (.getUserInfo (URI. url)))]
+              (.setHeader extender-client "Authorization" (str "Basic " (.encodeToString (Base64/getEncoder) (.getBytes auth StandardCharsets/UTF_8)))))
+            (when (pos? (count headers))
+              (.setHeaders extender-client headers))
             (.build extender-client extender-platform sdk-version extender-resources destination-file log-file async)
             {:id {:type :custom :version cache-key}
              :engine-archive destination-file

--- a/editor/src/clj/editor/prefs.clj
+++ b/editor/src/clj/editor/prefs.clj
@@ -22,7 +22,7 @@
     :any           anything goes, no validation is performed
     :boolean       a boolean value
     :string        a string
-    :password      a string, stored securely
+    :password      a string, stored encrypted
     :keyword       a keyword
     :integer       an integer
     :number        floating point number

--- a/editor/src/clj/editor/prefs_dialog.clj
+++ b/editor/src/clj/editor/prefs_dialog.clj
@@ -21,7 +21,7 @@
   (:import [com.defold.control DefoldStringConverter LongField]
            [javafx.geometry VPos]
            [javafx.scene Parent Scene]
-           [javafx.scene.control CheckBox ChoiceBox ColorPicker Label Tab TabPane TextArea TextField TextInputControl]
+           [javafx.scene.control CheckBox ChoiceBox ColorPicker Label PasswordField Tab TabPane TextArea TextField TextInputControl]
            [javafx.scene.input KeyCode KeyEvent]
            [javafx.scene.layout ColumnConstraints GridPane Priority]))
 
@@ -48,6 +48,11 @@
   (let [control (if (:multi-line desc)
                   (create-generic TextArea prefs grid desc)
                   (create-generic TextField prefs grid desc))]
+    (when (:prompt-value desc) (.setPromptText ^TextInputControl control (:prompt-value desc)))
+    control))
+
+(defmethod create-control! :password [prefs grid desc]
+  (let [control (create-generic PasswordField prefs grid desc)]
     (when (:prompt-value desc) (.setPromptText ^TextInputControl control (:prompt-value desc)))
     control))
 
@@ -117,6 +122,8 @@
                     {:label "Zoom on Scroll" :type :boolean :key [:code :zoom-on-scroll]}]}
            {:name  "Extensions"
             :prefs [{:label "Build Server" :type :string :key [:extensions :build-server] :prompt-value native-extensions/defold-build-server-url}
+                    {:label "Build Server Username" :type :string :key [:extensions :build-server-username]}
+                    {:label "Build Server Password" :type :password :key [:extensions :build-server-password]}
                     {:label "Build Server Headers" :type :string :key [:extensions :build-server-headers] :multi-line true}]}
            {:name "Tools"
             :prefs [{:label "ADB path" :type :string :key [:tools :adb-path] :tooltip "Path to ADB command that might be used to install and launch the Android app when it's bundled"}

--- a/editor/src/clj/util/crypto.clj
+++ b/editor/src/clj/util/crypto.clj
@@ -33,7 +33,7 @@
   ^String [^bytes bytes]
   (.encodeToString (Base64/getUrlEncoder) bytes))
 
-(defn- base64->bytes
+(defn base64->bytes
   ^bytes [^String base64-string]
   (.decode (Base64/getUrlDecoder) base64-string))
 

--- a/editor/test/integration/editor_extensions_test.clj
+++ b/editor/test/integration/editor_extensions_test.clj
@@ -714,6 +714,8 @@
               [:out "set: table foo = true, bar = nil"]
               [:out "string: a string"]
               [:out "string: another_string"]
+              [:out "password: password"]
+              [:out "password: another_password"]
               [:out "tuple: a string 12"]
               [:out "tuple: another string 42"]]
              @output)))))

--- a/editor/test/resources/editor_extensions/prefs_get_set_test/test.editor_script
+++ b/editor/test/resources/editor_extensions/prefs_get_set_test/test.editor_script
@@ -17,6 +17,7 @@ function M.get_prefs_schema()
         }),
         ["test.set"] = editor.prefs.schema.set({item = editor.prefs.schema.string()}),
         ["test.string"] = editor.prefs.schema.string(),
+        ["test.password"] = editor.prefs.schema.password(),
         ["test.tuple"] = editor.prefs.schema.tuple({items = {
             editor.prefs.schema.string(),
             editor.prefs.schema.integer(),
@@ -100,6 +101,13 @@ function M.get_commands()
             editor.prefs.set("test.string", "another_string")
             string = editor.prefs.get("test.string")
             print(("string: %s"):format(string))
+
+            editor.prefs.set("test.password", "password")
+            local password = editor.prefs.get("test.password")
+            print(("password: %s"):format(password))
+            editor.prefs.set("test.password", "another_password")
+            password = editor.prefs.get("test.password")
+            print(("password: %s"):format(password))
             
             editor.prefs.set("test.tuple", {"a string", 12})
             local tuple = editor.prefs.get("test.tuple")


### PR DESCRIPTION
This changeset also adds a new prefs schema type in editor scripts: password, e.g.
```lua
function M.get_prefs_schema()
    return {["my-extension.third-party-api-key"] = editor.prefs.schema.password()}
end
```
Password schema behaves as a string schema, but the value is encrypted in the prefs file.

Fixes #9785