### PR TITLE
Make zoom on scroll pref disabled by default

### DIFF
--- a/editor/src/clj/editor/prefs.clj
+++ b/editor/src/clj/editor/prefs.clj
@@ -84,7 +84,7 @@
            {:custom-editor {:type :string}
             :open-file {:type :string :default "{file}"}
             :open-file-at-line {:type :string :default "{file}:{line}" :label "Open File at Line"}
-            :zoom-on-scroll {:type :boolean :default true}
+            :zoom-on-scroll {:type :boolean}
             :font {:type :object
                    :properties
                    {:name {:type :string :default "Dejavu Sans Mono"}


### PR DESCRIPTION
### Technical changes
I think we may have to mark this as breaking, since a default functionality is going be disabled. We could also cherry pick this and the introduced pref for 1.9.9 to reduce the exposure, although I am not sure if that's going to help much.