### PR TITLE
Fix atlas dnd on windows

### DIFF
--- a/editor/src/clj/editor/input.clj
+++ b/editor/src/clj/editor/input.clj
@@ -64,11 +64,12 @@
                    (assoc action
                      :x (.getX drag-event)
                      :y (.getY drag-event)))
-      :drag-dropped (let [drag-event ^DragEvent jfx-event]
+      :drag-dropped (let [drag-event ^DragEvent jfx-event
+                          dragboard (.getDragboard drag-event)]
                       (assoc action
                         :x (.getX drag-event)
                         :y (.getY drag-event)
-                        :dragboard (.getDragboard drag-event)
+                        :files (.getFiles dragboard)
                         :transfer-mode (.getTransferMode drag-event)
                         :gesture-target (.getGestureTarget drag-event)
                         :gesture-source (.getGestureSource drag-event)))


### PR DESCRIPTION
Fixes #10375

### Technical changes
The `Dragboard` object appears to be mutated when we are trying to get the files on `atlas.clj` on Windows. Adding the files to the input map on `augment-action` fixes the issue.