### PR TITLE
Fontc now uses the ttf font input to determine if it's monospaced

### DIFF
--- a/editor/src/clj/editor/pipeline/fontc.clj
+++ b/editor/src/clj/editor/pipeline/fontc.clj
@@ -180,6 +180,9 @@
                        0)]
     (every? #(= base-advance (:advance %)) semi-glyphs)))
 
+(defn font-is-monospaced [^FontRenderContext font-render-context ^Font font]
+  (Fontc/isMonospaced font-render-context font))
+
 (def ^:private positive-glyph-extent-pairs-xf (comp (map pair) (filter (comp positive-wh? :glyph-wh second))))
 
 (def ^:private ^Canvas metrics-canvas (Canvas.))
@@ -520,7 +523,7 @@
         cache-wh (cache-wh font-desc cache-cell-wh (count semi-glyphs))
         glyph-data-bank (make-glyph-data-bank glyph-extents)
         layer-mask (font-desc->layer-mask font-desc)
-        is-monospaced (check-monospaced semi-glyphs)]
+        is-monospaced (font-is-monospaced (font-render-context antialias) font)]
     (doall
       (pmap (fn [[semi-glyph glyph-extents]]
               (let [^BufferedImage glyph-image (let [face-color (Color. ^double (:alpha font-desc) 0.0 0.0)
@@ -720,7 +723,7 @@
         cache-wh (cache-wh font-desc cache-cell-wh (count semi-glyphs))
         glyph-data-bank (make-glyph-data-bank glyph-extents)
         layer-mask (font-desc->layer-mask font-desc)
-        is-monospaced (check-monospaced semi-glyphs)]
+        is-monospaced (font-is-monospaced (font-render-context antialias) font)]
     (dorun
       (pmap
         (fn [batch]

--- a/editor/src/clj/editor/pipeline/fontc.clj
+++ b/editor/src/clj/editor/pipeline/fontc.clj
@@ -178,9 +178,7 @@
   ; We can't know if it's only one glyph. And chances are it's a dynamic font
   (if (<= (count semi-glyphs) 1)
     false
-    (let [base-advance (if-let [first-glyph (first semi-glyphs)]
-                       (:advance first-glyph)
-                       0)]
+    (let [base-advance (:advance (first semi-glyphs))]
       (every? #(= base-advance (:advance %)) semi-glyphs))))
 
 (def ^:private positive-glyph-extent-pairs-xf (comp (map pair) (filter (comp positive-wh? :glyph-wh second))))


### PR DESCRIPTION
Previously, it was determined based on the output, but if the output was a single glyph, it was always determined as monospaced.

Fixes https://github.com/defold/defold/issues/10393

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
