### PR TITLE
Use full texture dimensions in res_texture when uploading specific mipmaps

### DIFF
--- a/engine/gamesys/src/gamesys/resources/res_texture.cpp
+++ b/engine/gamesys/src/gamesys/resources/res_texture.cpp
@@ -282,8 +282,15 @@ namespace dmGameSystem
             // This should not be happening if the max width/height check goes through
             assert(image->m_MipMapOffset.m_Count <= MAX_MIPMAP_COUNT);
 
-            uint16_t tex_width_full  = dmGraphics::GetTextureWidth(texture);
-            uint16_t tex_height_full = dmGraphics::GetTextureHeight(texture);
+            uint16_t tex_width_full  = image->m_Width;
+            uint16_t tex_height_full = image->m_Height;
+
+            // If we are uploading data for a mipmap, we need to pass the actual texture size for the validation
+            if (params.m_MipMap > 0)
+            {
+                tex_width_full  = dmGraphics::GetTextureWidth(texture);
+                tex_height_full = dmGraphics::GetTextureHeight(texture);
+            }
 
             // If we requested to upload a specific mipmap, upload only that level
             // It is expected that we only have offsets for that level in the image desc as well

--- a/engine/gamesys/src/gamesys/resources/res_texture.cpp
+++ b/engine/gamesys/src/gamesys/resources/res_texture.cpp
@@ -282,6 +282,9 @@ namespace dmGameSystem
             // This should not be happening if the max width/height check goes through
             assert(image->m_MipMapOffset.m_Count <= MAX_MIPMAP_COUNT);
 
+            uint16_t tex_width_full  = dmGraphics::GetTextureWidth(texture);
+            uint16_t tex_height_full = dmGraphics::GetTextureHeight(texture);
+
             // If we requested to upload a specific mipmap, upload only that level
             // It is expected that we only have offsets for that level in the image desc as well
             // -> See script_resource.cpp::SetTexture
@@ -298,7 +301,7 @@ namespace dmGameSystem
                     params.m_DataSize = image_desc->m_DecompressedDataSize[0];
                 }
 
-                if (!ValidateTextureParams(image->m_Width, image->m_Height, params))
+                if (!ValidateTextureParams(tex_width_full, tex_height_full, params))
                 {
                     dmLogError("Unable to create mipmap %d, texture parameters are invalid.", params.m_MipMap);
                     return dmResource::RESULT_FORMAT_ERROR;
@@ -324,7 +327,7 @@ namespace dmGameSystem
                     params.m_Width  = dmMath::Max((uint32_t) 1, image->m_MipMapDimensions[i * 2]);
                     params.m_Height = dmMath::Max((uint32_t) 1, image->m_MipMapDimensions[i * 2 + 1]);
 
-                    if (!ValidateTextureParams(image->m_Width, image->m_Height, params))
+                    if (!ValidateTextureParams(tex_width_full, tex_height_full, params))
                     {
                         dmLogError("Unable to create mipmap %d, texture parameters are invalid.", params.m_MipMap);
                         return dmResource::RESULT_FORMAT_ERROR;

--- a/engine/gamesys/src/gamesys/test/resource/set_texture.script
+++ b/engine/gamesys/src/gamesys/test/resource/set_texture.script
@@ -107,6 +107,31 @@ local function test_success_compressed(self)
     resource.set_texture(go.get("#sprite", "texture0"), args, tex_buffer)
 end
 
+function test_success_mipmap()
+    local tparams_mipmaps = {
+        width          = 32,
+        height         = 32,
+        depth          = 1,
+        mipmap         = 0,
+        type           = graphics.TEXTURE_TYPE_2D,
+        format         = graphics.TEXTURE_FORMAT_RGBA,
+        max_mipmaps    = 6,
+    }
+
+    local t_id = resource.create_texture("/test_mipmap_textures.texturec", tparams_mipmaps)
+    local num_mipmaps = 6 -- 32,16,8,4,2,1
+
+    -- num mipmaps
+    for i=0,num_mipmaps-1 do
+        local mm_buffer = buffer.create(tparams_mipmaps.width * tparams_mipmaps.height, {{name = hash("data"), type = buffer.VALUE_TYPE_UINT8, count = 4 }})
+
+        tparams_mipmaps.mipmap = i
+        resource.set_texture(t_id, tparams_mipmaps, mm_buffer)
+        tparams_mipmaps.width = tparams_mipmaps.width / 2
+        tparams_mipmaps.height = tparams_mipmaps.height / 2
+    end
+end
+
 function update(self, dt)
     self.update_counter = self.update_counter + 1
 
@@ -116,6 +141,7 @@ function update(self, dt)
         test_fail_out_of_bounds,
         test_fail_wrong_mipmap,
         test_success_compressed,
+        test_success_mipmap
     }
 
     tests[self.update_counter](self)

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -601,6 +601,12 @@ TEST_F(ResourceTest, TestSetTextureFromScript)
     ASSERT_EQ(dmGraphics::GetTextureWidth(backing_texture), 32);
     ASSERT_EQ(dmGraphics::GetTextureHeight(backing_texture), 32);
 
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    // Test 6: Set texture with mipmaps
+    //      -> set_texture.script::test_success_mipmap
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+
     // cleanup
     ASSERT_TRUE(dmGameObject::Final(m_Collection));
     ASSERT_TRUE(dmGameObject::Init(m_Collection));


### PR DESCRIPTION
Fixes a regression for when using dynamic textures