### PR TITLE
Throw an exception if the quaternion in GO or Collection is invalid

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/ColladaUtilTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/ColladaUtilTest.java
@@ -133,7 +133,7 @@ public class ColladaUtilTest {
      */
     private void assertBone(Rig.Bone bone, Vector3d expectedPosition, Quat4d expectedRotation) {
         assertV(expectedPosition, MathUtil.ddfToVecmath(bone.getLocal().getTranslation()));
-        assertV(expectedRotation, MathUtil.ddfToVecmath(bone.getLocal().getRotation(), "bone " + bone.getName()));
+        assertV(expectedRotation, MathUtil.ddfToVecmath(bone.getLocal().getRotation(), "bone %s".formatted(bone.getName())));
     }
 
     /*

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/ColladaUtilTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/ColladaUtilTest.java
@@ -133,7 +133,7 @@ public class ColladaUtilTest {
      */
     private void assertBone(Rig.Bone bone, Vector3d expectedPosition, Quat4d expectedRotation) {
         assertV(expectedPosition, MathUtil.ddfToVecmath(bone.getLocal().getTranslation()));
-        assertV(expectedRotation, MathUtil.ddfToVecmath(bone.getLocal().getRotation()));
+        assertV(expectedRotation, MathUtil.ddfToVecmath(bone.getLocal().getRotation(), "bone " + bone.getName()));
     }
 
     /*

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/ModelUtilTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/ModelUtilTest.java
@@ -124,7 +124,7 @@ public class ModelUtilTest {
      */
     private void assertBone(Rig.Bone bone, Vector3d expectedPosition, Quat4d expectedRotation) {
         assertV(expectedPosition, MathUtil.ddfToVecmath(bone.getLocal().getTranslation()));
-        assertV(expectedRotation, MathUtil.ddfToVecmath(bone.getLocal().getRotation(), "bone " + bone.getName()));
+        assertV(expectedRotation, MathUtil.ddfToVecmath(bone.getLocal().getRotation(), "bone %s".formatted(bone.getName())));
     }
 
     /*

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/ModelUtilTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/ModelUtilTest.java
@@ -124,7 +124,7 @@ public class ModelUtilTest {
      */
     private void assertBone(Rig.Bone bone, Vector3d expectedPosition, Quat4d expectedRotation) {
         assertV(expectedPosition, MathUtil.ddfToVecmath(bone.getLocal().getTranslation()));
-        assertV(expectedRotation, MathUtil.ddfToVecmath(bone.getLocal().getRotation()));
+        assertV(expectedRotation, MathUtil.ddfToVecmath(bone.getLocal().getRotation(), "bone " + bone.getName()));
     }
 
     /*

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/CollectionBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/CollectionBuilder.java
@@ -41,7 +41,6 @@ import com.dynamo.gameobject.proto.GameObject.InstanceDesc;
 import com.dynamo.gameobject.proto.GameObject.InstancePropertyDesc;
 import com.dynamo.gameobject.proto.GameObject.PropertyDesc;
 import com.dynamo.properties.proto.PropertiesProto.PropertyDeclarations;
-import com.dynamo.proto.DdfMath;
 
 @ProtoParams(srcClass = CollectionDesc.class, messageClass = CollectionDesc.class)
 @BuilderParams(name="Collection", inExts=".collection", outExt=".collectionc")
@@ -258,11 +257,7 @@ public class CollectionBuilder extends ProtoBuilder<CollectionDesc.Builder> {
                     instBuilder.setPosition(MathUtil.vecmathToDDF(instP));
                     Quat4d instR = MathUtil.ddfToVecmath(inst.getRotation());
                     instR.mul(r, instR);
-                    DdfMath.Quat resultQuat = MathUtil.vecmathToDDF(instR);
-                    if (!MathUtil.isValid(resultQuat)) {
-                        throw new CompileExceptionError(String.format("Invalid result quaternion for %s. Check quaternion values for '%s' and '%s'", instBuilder.getId(), collInst.getId(), inst.getId()));
-                    }
-                    instBuilder.setRotation(resultQuat);
+                    instBuilder.setRotation(MathUtil.vecmathToDDF(instR));
                     instBuilder.setScale3(MathUtil.vecmathToDDFOne(instS));
                 }
                 // adjust child ids
@@ -306,11 +301,7 @@ public class CollectionBuilder extends ProtoBuilder<CollectionDesc.Builder> {
                     instBuilder.setPosition(MathUtil.vecmathToDDF(instP));
                     Quat4d instR = MathUtil.ddfToVecmath(inst.getRotation());
                     instR.mul(r, instR);
-                    DdfMath.Quat resultQuat = MathUtil.vecmathToDDF(instR);
-                    if (!MathUtil.isValid(resultQuat)) {
-                        throw new CompileExceptionError(String.format("Invalid result quaternion for '%s'. Check quaternion values for '%s' and '%s'", instBuilder.getId(), collInst.getId(), inst.getId()));
-                    }
-                    instBuilder.setRotation(resultQuat);
+                    instBuilder.setRotation(MathUtil.vecmathToDDF(instR));
                     instBuilder.setScale3(MathUtil.vecmathToDDFOne(instS));
                 }
                 // adjust child ids

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/CollectionBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/CollectionBuilder.java
@@ -41,6 +41,7 @@ import com.dynamo.gameobject.proto.GameObject.InstanceDesc;
 import com.dynamo.gameobject.proto.GameObject.InstancePropertyDesc;
 import com.dynamo.gameobject.proto.GameObject.PropertyDesc;
 import com.dynamo.properties.proto.PropertiesProto.PropertyDeclarations;
+import com.dynamo.proto.DdfMath;
 
 @ProtoParams(srcClass = CollectionDesc.class, messageClass = CollectionDesc.class)
 @BuilderParams(name="Collection", inExts=".collection", outExt=".collectionc")
@@ -257,7 +258,11 @@ public class CollectionBuilder extends ProtoBuilder<CollectionDesc.Builder> {
                     instBuilder.setPosition(MathUtil.vecmathToDDF(instP));
                     Quat4d instR = MathUtil.ddfToVecmath(inst.getRotation());
                     instR.mul(r, instR);
-                    instBuilder.setRotation(MathUtil.vecmathToDDF(instR));
+                    DdfMath.Quat resultQuat = MathUtil.vecmathToDDF(instR);
+                    if (!MathUtil.isValid(resultQuat)) {
+                        throw new CompileExceptionError(String.format("Invalid result quaternion for %s. Check quaternion values for '%s' and '%s'", instBuilder.getId(), collInst.getId(), inst.getId()));
+                    }
+                    instBuilder.setRotation(resultQuat);
                     instBuilder.setScale3(MathUtil.vecmathToDDFOne(instS));
                 }
                 // adjust child ids
@@ -301,7 +306,11 @@ public class CollectionBuilder extends ProtoBuilder<CollectionDesc.Builder> {
                     instBuilder.setPosition(MathUtil.vecmathToDDF(instP));
                     Quat4d instR = MathUtil.ddfToVecmath(inst.getRotation());
                     instR.mul(r, instR);
-                    instBuilder.setRotation(MathUtil.vecmathToDDF(instR));
+                    DdfMath.Quat resultQuat = MathUtil.vecmathToDDF(instR);
+                    if (!MathUtil.isValid(resultQuat)) {
+                        throw new CompileExceptionError(String.format("Invalid result quaternion for '%s'. Check quaternion values for '%s' and '%s'", instBuilder.getId(), collInst.getId(), inst.getId()));
+                    }
+                    instBuilder.setRotation(resultQuat);
                     instBuilder.setScale3(MathUtil.vecmathToDDFOne(instS));
                 }
                 // adjust child ids

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/CollectionBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/CollectionBuilder.java
@@ -209,7 +209,7 @@ public class CollectionBuilder extends ProtoBuilder<CollectionDesc.Builder> {
                 properties.put(pathPrefix + instProps.getId(), instProps.getPropertiesList());
             }
             Point3d p = MathUtil.ddfToVecmath(collInst.getPosition());
-            Quat4d r = MathUtil.ddfToVecmath(collInst.getRotation(), new StringBuilder().append(owner).append(" collection: ").append(collInst.getId()).toString());
+            Quat4d r = MathUtil.ddfToVecmath(collInst.getRotation(), "%s collection: %s".formatted(owner, collInst.getId()));
 
             Vector3d s;
             if (collInst.hasScale3()) {
@@ -255,7 +255,7 @@ public class CollectionBuilder extends ProtoBuilder<CollectionDesc.Builder> {
                     MathUtil.rotate(r, instP);
                     instP.add(p);
                     instBuilder.setPosition(MathUtil.vecmathToDDF(instP));
-                    Quat4d instR = MathUtil.ddfToVecmath(inst.getRotation(), new StringBuilder().append(owner).append(" gameobject: ").append(inst.getId()).toString());
+                    Quat4d instR = MathUtil.ddfToVecmath(inst.getRotation(), "%s gameobject: %s".formatted(owner, inst.getId()));
                     instR.mul(r, instR);
                     instBuilder.setRotation(MathUtil.vecmathToDDF(instR));
                     instBuilder.setScale3(MathUtil.vecmathToDDFOne(instS));
@@ -299,7 +299,7 @@ public class CollectionBuilder extends ProtoBuilder<CollectionDesc.Builder> {
                     MathUtil.rotate(r, instP);
                     instP.add(p);
                     instBuilder.setPosition(MathUtil.vecmathToDDF(instP));
-                    Quat4d instR = MathUtil.ddfToVecmath(inst.getRotation(), new StringBuilder().append(owner).append(" go: ").append(inst.getId()).toString());
+                    Quat4d instR = MathUtil.ddfToVecmath(inst.getRotation(), "%s go: %s".formatted(owner, inst.getId()));
                     instR.mul(r, instR);
                     instBuilder.setRotation(MathUtil.vecmathToDDF(instR));
                     instBuilder.setScale3(MathUtil.vecmathToDDFOne(instS));

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/CollectionBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/CollectionBuilder.java
@@ -209,7 +209,7 @@ public class CollectionBuilder extends ProtoBuilder<CollectionDesc.Builder> {
                 properties.put(pathPrefix + instProps.getId(), instProps.getPropertiesList());
             }
             Point3d p = MathUtil.ddfToVecmath(collInst.getPosition());
-            Quat4d r = MathUtil.ddfToVecmath(collInst.getRotation());
+            Quat4d r = MathUtil.ddfToVecmath(collInst.getRotation(), new StringBuilder().append(owner).append(" collection: ").append(collInst.getId()).toString());
 
             Vector3d s;
             if (collInst.hasScale3()) {
@@ -255,7 +255,7 @@ public class CollectionBuilder extends ProtoBuilder<CollectionDesc.Builder> {
                     MathUtil.rotate(r, instP);
                     instP.add(p);
                     instBuilder.setPosition(MathUtil.vecmathToDDF(instP));
-                    Quat4d instR = MathUtil.ddfToVecmath(inst.getRotation());
+                    Quat4d instR = MathUtil.ddfToVecmath(inst.getRotation(), new StringBuilder().append(owner).append(" gameobject: ").append(inst.getId()).toString());
                     instR.mul(r, instR);
                     instBuilder.setRotation(MathUtil.vecmathToDDF(instR));
                     instBuilder.setScale3(MathUtil.vecmathToDDFOne(instS));
@@ -299,7 +299,7 @@ public class CollectionBuilder extends ProtoBuilder<CollectionDesc.Builder> {
                     MathUtil.rotate(r, instP);
                     instP.add(p);
                     instBuilder.setPosition(MathUtil.vecmathToDDF(instP));
-                    Quat4d instR = MathUtil.ddfToVecmath(inst.getRotation());
+                    Quat4d instR = MathUtil.ddfToVecmath(inst.getRotation(), new StringBuilder().append(owner).append(" go: ").append(inst.getId()).toString());
                     instR.mul(r, instR);
                     instBuilder.setRotation(MathUtil.vecmathToDDF(instR));
                     instBuilder.setScale3(MathUtil.vecmathToDDFOne(instS));

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ProtoBuilders.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ProtoBuilders.java
@@ -384,11 +384,11 @@ public class ProtoBuilders {
                 emitterBuilder.setMaterial(BuilderUtil.replaceExt(emitterBuilder.getMaterial(), "material", "materialc"));
 
                 Point3d ep = MathUtil.ddfToVecmath(emitterBuilder.getPosition());
-                Quat4d er = MathUtil.ddfToVecmath(emitterBuilder.getRotation());
+                Quat4d er = MathUtil.ddfToVecmath(emitterBuilder.getRotation(), new StringBuilder().append(resource).append(" emitter: ").append(emitterBuilder.getId()).toString());
                 for (Modifier modifier : modifiers) {
                     Modifier.Builder mb = Modifier.newBuilder(modifier);
                     Point3d p = MathUtil.ddfToVecmath(modifier.getPosition());
-                    Quat4d r = MathUtil.ddfToVecmath(modifier.getRotation());
+                    Quat4d r = MathUtil.ddfToVecmath(modifier.getRotation(), new StringBuilder().append(resource).append(" emitter: ").append(emitterBuilder.getId()).append(" modifier: ").append(mb.getType().toString()).toString());
                     MathUtil.invTransform(ep, er, p);
                     mb.setPosition(MathUtil.vecmathToDDF(p));
                     MathUtil.invTransform(er, r);

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ProtoBuilders.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ProtoBuilders.java
@@ -384,11 +384,11 @@ public class ProtoBuilders {
                 emitterBuilder.setMaterial(BuilderUtil.replaceExt(emitterBuilder.getMaterial(), "material", "materialc"));
 
                 Point3d ep = MathUtil.ddfToVecmath(emitterBuilder.getPosition());
-                Quat4d er = MathUtil.ddfToVecmath(emitterBuilder.getRotation(), new StringBuilder().append(resource).append(" emitter: ").append(emitterBuilder.getId()).toString());
+                Quat4d er = MathUtil.ddfToVecmath(emitterBuilder.getRotation(), "%s emitter: %s".formatted(resource, emitterBuilder.getId()));
                 for (Modifier modifier : modifiers) {
                     Modifier.Builder mb = Modifier.newBuilder(modifier);
                     Point3d p = MathUtil.ddfToVecmath(modifier.getPosition());
-                    Quat4d r = MathUtil.ddfToVecmath(modifier.getRotation(), new StringBuilder().append(resource).append(" emitter: ").append(emitterBuilder.getId()).append(" modifier: ").append(mb.getType().toString()).toString());
+                    Quat4d r = MathUtil.ddfToVecmath(modifier.getRotation(), "%s emitter: %s modifier: %s".formatted(resource, emitterBuilder.getId(), mb.getType().toString()));
                     MathUtil.invTransform(ep, er, p);
                     mb.setPosition(MathUtil.vecmathToDDF(p));
                     MathUtil.invTransform(er, r);

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/MathUtil.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/MathUtil.java
@@ -249,11 +249,4 @@ public class MathUtil {
         r.set(dR);
         s.set(dS);
     }
-
-    public static boolean isValid(Quat resultQuat) {
-        if (Float.isNaN(resultQuat.getX()) || Float.isNaN(resultQuat.getY()) || Float.isNaN(resultQuat.getZ()) || Float.isNaN(resultQuat.getW())) {
-            return false;
-        }
-        return true;
-    }
 }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/MathUtil.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/MathUtil.java
@@ -24,6 +24,8 @@ import javax.vecmath.Vector3d;
 import javax.vecmath.Vector3f;
 import javax.vecmath.Vector4d;
 
+import com.dynamo.bob.CompileExceptionError;
+import com.dynamo.bob.fs.IResource;
 import com.dynamo.proto.DdfMath.Point3;
 import com.dynamo.proto.DdfMath.Quat;
 import com.dynamo.proto.DdfMath.Vector3;
@@ -46,7 +48,28 @@ public class MathUtil {
         return new Vector3d(v.getX(), v.getY(), v.getZ());
     }
 
-    public static Quat4d ddfToVecmath(Quat q) {
+    public static boolean isValid(Quat q) {
+        if (q.getX() == 0  && q.getY() == 0 && q.getZ() == 0 && q.getW() == 0) {
+            return false;
+        }
+        if (Float.isNaN(q.getX()) || Float.isNaN(q.getY()) || Float.isNaN(q.getZ()) || Float.isNaN(q.getW())) {
+            return false;
+        }
+        if (Float.isInfinite(q.getX()) || Float.isInfinite(q.getY()) || Float.isInfinite(q.getZ()) || Float.isInfinite(q.getW())) {
+            return false;
+        }
+        float lenSq = q.getX()*q.getX() + q.getY()*q.getY() + q.getZ()*q.getZ() + q.getW()*q.getW();
+        if (Math.abs(lenSq - 1.0f) > 1e-4f) {
+            return false;
+        }
+        return true;
+    }
+
+    public static Quat4d ddfToVecmath(Quat q, String owner) {
+        if (!isValid(q)) {
+            String err = new StringBuilder().append("Invalid quaternion: ").append(q).append(" in ").append(owner).toString();
+            throw new RuntimeException(new CompileExceptionError(err));
+        }
         return new Quat4d(q.getX(), q.getY(), q.getZ(), q.getW());
     }
 

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/MathUtil.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/MathUtil.java
@@ -249,4 +249,11 @@ public class MathUtil {
         r.set(dR);
         s.set(dS);
     }
+
+    public static boolean isValid(Quat resultQuat) {
+        if (Float.isNaN(resultQuat.getX()) || Float.isNaN(resultQuat.getY()) || Float.isNaN(resultQuat.getZ()) || Float.isNaN(resultQuat.getW())) {
+            return false;
+        }
+        return true;
+    }
 }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/MathUtil.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/MathUtil.java
@@ -49,9 +49,6 @@ public class MathUtil {
     }
 
     public static boolean isValid(Quat q) {
-        if (q.getX() == 0  && q.getY() == 0 && q.getZ() == 0 && q.getW() == 0) {
-            return false;
-        }
         if (Float.isNaN(q.getX()) || Float.isNaN(q.getY()) || Float.isNaN(q.getZ()) || Float.isNaN(q.getW())) {
             return false;
         }


### PR DESCRIPTION
This isn't an issue we have, since the editor itself can't produce invalid values.  
But if the user adds an invalid value manually, the editor and runtime handle it fine, while Bob and the runtime do not.  
So I decided to validate the value on Bob's side to avoid inconsistencies.  