### PR TITLE
Expose ReadPixels API

### DIFF
--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -2006,7 +2006,7 @@ bail:
                         uint32_t height = dmGraphics::GetHeight(engine->m_GraphicsContext);
                         uint32_t buffer_size = width * height * 4;
 
-                        dmGraphics::ReadPixels(engine->m_GraphicsContext, record_data->m_Buffer, buffer_size);
+                        dmGraphics::ReadPixels(engine->m_GraphicsContext, 0, 0, width, height, record_data->m_Buffer, buffer_size);
 
                         dmRecord::Result r = dmRecord::RecordFrame(record_data->m_Recorder, record_data->m_Buffer, buffer_size, dmRecord::BUFFER_FORMAT_BGRA);
                         if (r != dmRecord::RESULT_OK)

--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -2004,7 +2004,7 @@ bail:
                     {
                         int32_t x = 0, y = 0;
                         uint32_t w = 0, h = 0;
-                        dmGraphics::GetViewport(engine->m_GraphicsContext, x, y, w, h);
+                        dmGraphics::GetViewport(engine->m_GraphicsContext, &x, &y, &w, &h);
                         uint32_t buffer_size = w * h * 4;
 
                         dmGraphics::ReadPixels(engine->m_GraphicsContext, x, y, w, h, record_data->m_Buffer, buffer_size);
@@ -2180,7 +2180,7 @@ bail:
 
                 int32_t x = 0, y = 0;
                 uint32_t width = 0, height = 0;
-                dmGraphics::GetViewport(self->m_GraphicsContext, x, y, width, height);
+                dmGraphics::GetViewport(self->m_GraphicsContext, &x, &y, &width, &height);
                 dmRecord::NewParams params;
                 params.m_Width = width;
                 params.m_Height = height;

--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -2005,7 +2005,7 @@ bail:
                         int32_t x = 0, y = 0;
                         uint32_t w = 0, h = 0;
                         dmGraphics::GetViewport(engine->m_GraphicsContext, x, y, w, h);
-                        uint32_t buffer_size = (w - x) * (h - y) * 4;
+                        uint32_t buffer_size = w * h * 4;
 
                         dmGraphics::ReadPixels(engine->m_GraphicsContext, x, y, w, h, record_data->m_Buffer, buffer_size);
 
@@ -2182,15 +2182,15 @@ bail:
                 uint32_t width = 0, height = 0;
                 dmGraphics::GetViewport(self->m_GraphicsContext, x, y, width, height);
                 dmRecord::NewParams params;
-                params.m_Width = width - x;
-                params.m_Height = height - y;
+                params.m_Width = width;
+                params.m_Height = height;
                 params.m_Filename = start_record->m_FileName;
                 params.m_Fps = start_record->m_Fps;
 
                 dmRecord::Result r = dmRecord::New(&params, &record_data->m_Recorder);
                 if (r == dmRecord::RESULT_OK)
                 {
-                    record_data->m_Buffer = new char[(width - x) * (height - y) * 4];
+                    record_data->m_Buffer = new char[width * height * 4];
                     record_data->m_FrameCount = 0;
                 }
                 else

--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -2002,11 +2002,12 @@ bail:
                 {
                     if (record_data->m_FrameCount % record_data->m_FramePeriod == 0)
                     {
-                        uint32_t width = dmGraphics::GetWidth(engine->m_GraphicsContext);
-                        uint32_t height = dmGraphics::GetHeight(engine->m_GraphicsContext);
-                        uint32_t buffer_size = width * height * 4;
+                        int32_t x = 0, y = 0;
+                        uint32_t w = 0, h = 0;
+                        dmGraphics::GetViewport(engine->m_GraphicsContext, x, y, w, h);
+                        uint32_t buffer_size = (w - x) * (h - y) * 4;
 
-                        dmGraphics::ReadPixels(engine->m_GraphicsContext, 0, 0, width, height, record_data->m_Buffer, buffer_size);
+                        dmGraphics::ReadPixels(engine->m_GraphicsContext, x, y, w, h, record_data->m_Buffer, buffer_size);
 
                         dmRecord::Result r = dmRecord::RecordFrame(record_data->m_Recorder, record_data->m_Buffer, buffer_size, dmRecord::BUFFER_FORMAT_BGRA);
                         if (r != dmRecord::RESULT_OK)
@@ -2177,18 +2178,19 @@ bail:
 
                 record_data->m_FramePeriod = start_record->m_FramePeriod;
 
-                uint32_t width = dmGraphics::GetWidth(self->m_GraphicsContext);
-                uint32_t height = dmGraphics::GetHeight(self->m_GraphicsContext);
+                int32_t x = 0, y = 0;
+                uint32_t width = 0, height = 0;
+                dmGraphics::GetViewport(self->m_GraphicsContext, x, y, width, height);
                 dmRecord::NewParams params;
-                params.m_Width = width;
-                params.m_Height = height;
+                params.m_Width = width - x;
+                params.m_Height = height - y;
                 params.m_Filename = start_record->m_FileName;
                 params.m_Fps = start_record->m_Fps;
 
                 dmRecord::Result r = dmRecord::New(&params, &record_data->m_Recorder);
                 if (r == dmRecord::RESULT_OK)
                 {
-                    record_data->m_Buffer = new char[width * height * 4];
+                    record_data->m_Buffer = new char[(width - x) * (height - y) * 4];
                     record_data->m_FrameCount = 0;
                 }
                 else

--- a/engine/graphics/src/dmsdk/graphics/graphics.h
+++ b/engine/graphics/src/dmsdk/graphics/graphics.h
@@ -726,8 +726,8 @@ namespace dmGraphics
     /*# Get viewport's parameters
      * @name GetViewport
      * @param context [type:dmGraphics::HContext] the context
-     * @param x [type:int32_t] 
-     * @param y [type:int32_t] 
+     * @param x [type:int32_t] coordinate of left edge of viewport
+     * @param y [type:int32_t] coordinate of bottom edge of viewport
      * @param width [type:uint32_t] viewport width
      * @param height [type:uint32_t] viewport height
      */

--- a/engine/graphics/src/dmsdk/graphics/graphics.h
+++ b/engine/graphics/src/dmsdk/graphics/graphics.h
@@ -718,10 +718,10 @@ namespace dmGraphics
     /*# Read frame buffer pixels in BGRA format
      * @name ReadPixels
      * @param context [type:dmGraphics::HContext] the context
-     * @param x [type:int32_t] x coordinate of left bottom area's corener
-     * @param y [type:int32_t] y coordinate of left bottom area's corener
-     * @param width [type:uint32_t] area width
-     * @param height [type:uin32_t] area height
+     * @param x [type:int32_t] x-coordinate of the starting position
+     * @param y [type:int32_t] y-coordinate of the starting position
+     * @param width [type:uint32_t] width of the region
+     * @param height [type:uin32_t] height of the region
      * @param buffer [type:void*] buffer to read to
      * @param buffer_size [type:uint32_t] buffer size
      */
@@ -730,12 +730,12 @@ namespace dmGraphics
     /*# Get viewport's parameters
      * @name GetViewport
      * @param context [type:dmGraphics::HContext] the context
-     * @param x [type:int32_t] coordinate of left edge of viewport
-     * @param y [type:int32_t] coordinate of bottom edge of viewport
-     * @param width [type:uint32_t] viewport width
-     * @param height [type:uint32_t] viewport height
+     * @param x [type:int32_t] x-coordinate of the viewport's origin
+     * @param y [type:int32_t] y-coordinate of the viewport's origin
+     * @param width [type:uint32_t] viewport's width
+     * @param height [type:uint32_t] viewport's height
      */
-    void GetViewport(HContext context, int32_t& x, int32_t& y, uint32_t& width, uint32_t& height);
+    void GetViewport(HContext context, int32_t* x, int32_t* y, uint32_t* width, uint32_t* height);
 }
 
 #endif // DMSDK_GRAPHICS_H

--- a/engine/graphics/src/dmsdk/graphics/graphics.h
+++ b/engine/graphics/src/dmsdk/graphics/graphics.h
@@ -718,10 +718,14 @@ namespace dmGraphics
     /*# Read frame buffer pixels in BGRA format
      * @name ReadPixels
      * @param context [type:dmGraphics::HContext] the context
+     * @param x [type:int32_t]
+     * @param y [type:int32_t]
+     * @param width [type:uint32_t]
+     * @param height [type:uin32_t]
      * @param buffer [type:void*] buffer to read to
      * @param buffer_size [type:uint32_t] buffer size
      */
-    void ReadPixels(HContext context, void* buffer, uint32_t buffer_size);
+    void ReadPixels(HContext context, int32_t x, int32_t y, uint32_t width, uint32_t height, void* buffer, uint32_t buffer_size);
 
     /*# Get viewport's parameters
      * @name GetViewport

--- a/engine/graphics/src/dmsdk/graphics/graphics.h
+++ b/engine/graphics/src/dmsdk/graphics/graphics.h
@@ -718,10 +718,10 @@ namespace dmGraphics
     /*# Read frame buffer pixels in BGRA format
      * @name ReadPixels
      * @param context [type:dmGraphics::HContext] the context
-     * @param x [type:int32_t]
-     * @param y [type:int32_t]
-     * @param width [type:uint32_t]
-     * @param height [type:uin32_t]
+     * @param x [type:int32_t] x coordinate of left bottom area's corener
+     * @param y [type:int32_t] y coordinate of left bottom area's corener
+     * @param width [type:uint32_t] area width
+     * @param height [type:uin32_t] area height
      * @param buffer [type:void*] buffer to read to
      * @param buffer_size [type:uint32_t] buffer size
      */

--- a/engine/graphics/src/dmsdk/graphics/graphics.h
+++ b/engine/graphics/src/dmsdk/graphics/graphics.h
@@ -714,6 +714,24 @@ namespace dmGraphics
      * @return extension [type:const char*] the extension. 0 if index was out of bounds
      */
     const char* GetSupportedExtension(HContext context, uint32_t index);
+
+    /*# Read frame buffer pixels in BGRA format
+     * @name ReadPixels
+     * @param context [type:dmGraphics::HContext] the context
+     * @param buffer [type:void*] buffer to read to
+     * @param buffer_size [type:uint32_t] buffer size
+     */
+    void ReadPixels(HContext context, void* buffer, uint32_t buffer_size);
+
+    /*# Get viewport's parameters
+     * @name GetViewport
+     * @param context [type:dmGraphics::HContext] the context
+     * @param x [type:int32_t] 
+     * @param y [type:int32_t] 
+     * @param width [type:uint32_t] viewport width
+     * @param height [type:uint32_t] viewport height
+     */
+    void GetViewport(HContext context, int32_t& x, int32_t& y, uint32_t& width, uint32_t& height);
 }
 
 #endif // DMSDK_GRAPHICS_H

--- a/engine/graphics/src/dx12/graphics_dx12.cpp
+++ b/engine/graphics/src/dx12/graphics_dx12.cpp
@@ -2673,10 +2673,10 @@ namespace dmGraphics
 
     static void DX12GetViewport(HContext context, int32_t& x, int32_t& y, uint32_t& width, uint32_t& height)
     {
-        DX12Context* context = (DX12Context*) _context;
+        DX12Context* _context = (DX12Context*) context;
 
-        const DX12Viewport& viewport = context->m_CurrentViewport;
-        x = viewport.m_X, y = viewport.m_Y, widhth = viewport.m_W, height = viewport.m_H;
+        const DX12Viewport& viewport = _context->m_CurrentViewport;
+        x = viewport.m_X, y = viewport.m_Y, width = viewport.m_W, height = viewport.m_H;
     }
 
     static void DX12EnableState(HContext context, State state)

--- a/engine/graphics/src/dx12/graphics_dx12.cpp
+++ b/engine/graphics/src/dx12/graphics_dx12.cpp
@@ -2671,6 +2671,14 @@ namespace dmGraphics
         context->m_ViewportChanged = 1;
     }
 
+    static void DX12GetViewport(HContext context, int32_t& x, int32_t& y, uint32_t& width, uint32_t& height)
+    {
+        DX12Context* context = (DX12Context*) _context;
+
+        const DX12Viewport& viewport = context->m_CurrentViewport;
+        x = viewport.m_X, y = viewport.m_Y, widhth = viewport.m_W, height = viewport.m_H;
+    }
+
     static void DX12EnableState(HContext context, State state)
     {
         SetPipelineStateValue(g_DX12Context->m_PipelineState, state, 1);

--- a/engine/graphics/src/dx12/graphics_dx12.cpp
+++ b/engine/graphics/src/dx12/graphics_dx12.cpp
@@ -2671,12 +2671,12 @@ namespace dmGraphics
         context->m_ViewportChanged = 1;
     }
 
-    static void DX12GetViewport(HContext context, int32_t& x, int32_t& y, uint32_t& width, uint32_t& height)
+    static void DX12GetViewport(HContext context, int32_t* x, int32_t* y, uint32_t* width, uint32_t* height)
     {
         DX12Context* _context = (DX12Context*) context;
 
         const DX12Viewport& viewport = _context->m_CurrentViewport;
-        x = viewport.m_X, y = viewport.m_Y, width = viewport.m_W, height = viewport.m_H;
+        *x = viewport.m_X, *y = viewport.m_Y, *width = viewport.m_W, *height = viewport.m_H;
     }
 
     static void DX12EnableState(HContext context, State state)

--- a/engine/graphics/src/dx12/graphics_dx12.cpp
+++ b/engine/graphics/src/dx12/graphics_dx12.cpp
@@ -2655,7 +2655,7 @@ namespace dmGraphics
         g_DX12Context->m_CurrentTextures[unit] = 0x0;
     }
 
-    static void DX12ReadPixels(HContext context, void* buffer, uint32_t buffer_size)
+    static void DX12ReadPixels(HContext context, int32_t x, int32_t y, uint32_t width, uint32_t height, void* buffer, uint32_t buffer_size)
     {
     }
 

--- a/engine/graphics/src/graphics.cpp
+++ b/engine/graphics/src/graphics.cpp
@@ -1897,7 +1897,7 @@ namespace dmGraphics
     {
         g_functions.m_InvalidateGraphicsHandles(context);
     }
-    void GetViewport(HContext context, int32_t& x, int32_t& y, uint32_t& width, uint32_t& height)
+    void GetViewport(HContext context, int32_t* x, int32_t* y, uint32_t* width, uint32_t* height)
     {
         g_functions.m_GetViewport(context, x, y, width, height);
     }

--- a/engine/graphics/src/graphics.cpp
+++ b/engine/graphics/src/graphics.cpp
@@ -1843,9 +1843,9 @@ namespace dmGraphics
     {
         return g_functions.m_GetTextureStatusFlags(texture);
     }
-    void ReadPixels(HContext context, void* buffer, uint32_t buffer_size)
+    void ReadPixels(HContext context, int32_t x, int32_t y, uint32_t width, uint32_t height, void* buffer, uint32_t buffer_size)
     {
-        g_functions.m_ReadPixels(context, buffer, buffer_size);
+        g_functions.m_ReadPixels(context, x, y, width, height, buffer, buffer_size);
     }
     void RunApplicationLoop(void* user_data, WindowStepMethod step_method, WindowIsRunning is_running)
     {

--- a/engine/graphics/src/graphics.cpp
+++ b/engine/graphics/src/graphics.cpp
@@ -1897,6 +1897,10 @@ namespace dmGraphics
     {
         g_functions.m_InvalidateGraphicsHandles(context);
     }
+    void GetViewport(HContext context, int32_t& x, int32_t& y, uint32_t& width, uint32_t& height)
+    {
+        g_functions.m_GetViewport(context, x, y, width, height);
+    }
 
 #if defined(DM_PLATFORM_IOS)
     void AppBootstrap(int argc, char** argv, void* init_ctx, EngineInit init_fn, EngineExit exit_fn, EngineCreate create_fn, EngineDestroy destroy_fn, EngineUpdate update_fn, EngineGetResult result_fn)

--- a/engine/graphics/src/graphics.h
+++ b/engine/graphics/src/graphics.h
@@ -940,13 +940,6 @@ namespace dmGraphics
      */
     bool Transcode(const char* path, TextureImage::Image* image, uint8_t image_count, uint8_t* image_bytes, TextureFormat format, uint8_t** images, uint32_t* sizes, uint32_t* num_transcoded_mips);
 
-    /**
-     * Read frame buffer pixels in BGRA format
-     * @param buffer buffer to read to
-     * @param buffer_size buffer size
-     */
-    void ReadPixels(HContext context, void* buffer, uint32_t buffer_size);
-
     uint32_t    GetTypeSize(Type type);
     const char* GetGraphicsTypeLiteral(Type type);
 

--- a/engine/graphics/src/graphics_adapter.h
+++ b/engine/graphics/src/graphics_adapter.h
@@ -138,7 +138,7 @@ namespace dmGraphics
     typedef void (*DisableTextureFn)(HContext context, uint32_t unit, HTexture texture);
     typedef uint32_t (*GetMaxTextureSizeFn)(HContext context);
     typedef uint32_t (*GetTextureStatusFlagsFn)(HTexture texture);
-    typedef void (*ReadPixelsFn)(HContext context, void* buffer, uint32_t buffer_size);
+    typedef void (*ReadPixelsFn)(HContext context, int32_t x, int32_t y, uint32_t width, uint32_t height, void* buffer, uint32_t buffer_size);
     typedef void (*RunApplicationLoopFn)(void* user_data, WindowStepMethod step_method, WindowIsRunning is_running);
     typedef HandleResult (*GetTextureHandleFn)(HTexture texture, void** out_handle);
     typedef bool (*IsExtensionSupportedFn)(HContext context, const char* extension);

--- a/engine/graphics/src/graphics_adapter.h
+++ b/engine/graphics/src/graphics_adapter.h
@@ -149,7 +149,7 @@ namespace dmGraphics
     typedef bool (*IsContextFeatureSupportedFn)(HContext context, ContextFeature feature);
     typedef bool (*IsAssetHandleValidFn)(HContext context, HAssetHandle asset_handle);
     typedef void (*InvalidateGraphicsHandlesFn)(HContext context);
-    typedef void (*GetViewportFn)(HContext context, int32_t& x, int32_t& y, uint32_t& width, uint32_t& height);
+    typedef void (*GetViewportFn)(HContext context, int32_t* x, int32_t* y, uint32_t* width, uint32_t* height);
 
     struct GraphicsAdapterFunctionTable
     {

--- a/engine/graphics/src/graphics_adapter.h
+++ b/engine/graphics/src/graphics_adapter.h
@@ -149,6 +149,7 @@ namespace dmGraphics
     typedef bool (*IsContextFeatureSupportedFn)(HContext context, ContextFeature feature);
     typedef bool (*IsAssetHandleValidFn)(HContext context, HAssetHandle asset_handle);
     typedef void (*InvalidateGraphicsHandlesFn)(HContext context);
+    typedef void (*GetViewportFn)(HContext context, int32_t& x, int32_t& y, uint32_t& width, uint32_t& height);
 
     struct GraphicsAdapterFunctionTable
     {
@@ -252,6 +253,7 @@ namespace dmGraphics
         IsContextFeatureSupportedFn m_IsContextFeatureSupported;
         IsAssetHandleValidFn m_IsAssetHandleValid;
         InvalidateGraphicsHandlesFn m_InvalidateGraphicsHandles;
+        GetViewportFn m_GetViewport;
     };
 
     #define DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, fn_name) \
@@ -356,7 +358,8 @@ namespace dmGraphics
         DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, GetPipelineState); \
         DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, IsContextFeatureSupported); \
         DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, IsAssetHandleValid); \
-        DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, InvalidateGraphicsHandles);
+        DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, InvalidateGraphicsHandles); \
+        DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, GetViewport);
 }
 
 #endif

--- a/engine/graphics/src/null/graphics_null.cpp
+++ b/engine/graphics/src/null/graphics_null.cpp
@@ -1533,12 +1533,10 @@ namespace dmGraphics
         ((NullContext*) context)->m_Textures[unit] = 0;
     }
 
-    static void NullReadPixels(HContext context, void* buffer, uint32_t buffer_size)
+    static void NullReadPixels(HContext context, int32_t x, int32_t y, uint32_t width, uint32_t height, void* buffer, uint32_t buffer_size)
     {
-        uint32_t w = dmGraphics::GetWidth(context);
-        uint32_t h = dmGraphics::GetHeight(context);
-        assert (buffer_size >= w * h * 4);
-        memset(buffer, 0, w * h * 4);
+        assert (buffer_size >= (width - x) * (height - y) * 4);
+        memset(buffer, 0, (width - x) * (height - y) * 4);
     }
 
     static void NullEnableState(HContext context, State state)

--- a/engine/graphics/src/null/graphics_null.cpp
+++ b/engine/graphics/src/null/graphics_null.cpp
@@ -1535,8 +1535,8 @@ namespace dmGraphics
 
     static void NullReadPixels(HContext context, int32_t x, int32_t y, uint32_t width, uint32_t height, void* buffer, uint32_t buffer_size)
     {
-        assert (buffer_size >= (width - x) * (height - y) * 4);
-        memset(buffer, 0, (width - x) * (height - y) * 4);
+        assert (buffer_size >= width * height * 4);
+        memset(buffer, 0, width * height * 4);
     }
 
     static void NullEnableState(HContext context, State state)

--- a/engine/graphics/src/null/graphics_null.cpp
+++ b/engine/graphics/src/null/graphics_null.cpp
@@ -1821,10 +1821,10 @@ namespace dmGraphics
 
     static void NullInvalidateGraphicsHandles(HContext context) { }
 
-    static void NullGetViewport(HContext context, int32_t& x, int32_t& y, uint32_t& width, uint32_t& height)
+    static void NullGetViewport(HContext context, int32_t* x, int32_t* y, uint32_t* width, uint32_t* height)
     {
         assert(context);
-        x = 0, y = 0, width = 1000, height = 1000;
+        *x = 0, *y = 0, *width = 1000, *height = 1000;
     }
 
     bool UnmapIndexBuffer(HContext context, HIndexBuffer buffer)

--- a/engine/graphics/src/null/graphics_null.cpp
+++ b/engine/graphics/src/null/graphics_null.cpp
@@ -1823,6 +1823,12 @@ namespace dmGraphics
 
     static void NullInvalidateGraphicsHandles(HContext context) { }
 
+    static void NullGetViewport(HContext context, int32_t& x, int32_t& y, uint32_t& width, uint32_t& height)
+    {
+        assert(context);
+        x = 0, y = 0, width = 1000, height = 1000;
+    }
+
     bool UnmapIndexBuffer(HContext context, HIndexBuffer buffer)
     {
         IndexBuffer* ib = (IndexBuffer*)buffer;

--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -4660,7 +4660,7 @@ static void LogFrameBufferError(GLenum status)
 
     static void OpenGLReadPixels(HContext context, int32_t x, int32_t y, uint32_t width, uint32_t height, void* buffer, uint32_t buffer_size)
     {
-        assert(buffer_size >= (width - x) * (height - y) * 4);
+        assert(buffer_size >= width * height * 4);
         glReadPixels(x, y, width, height,
                      GL_BGRA,
                      GL_UNSIGNED_BYTE,

--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -4668,6 +4668,20 @@ static void LogFrameBufferError(GLenum status)
                      GL_UNSIGNED_BYTE,
                      buffer);
         CHECK_GL_ERROR;
+        unsigned int *pixels = (unsigned int*)buffer;
+        // flip vertically
+        for (uint32_t yi = 0; yi < (h / 2); ++yi)
+        {
+            for (uint32_t xi = 0; xi < w; ++xi)
+            {
+                unsigned int offset1 = xi + (yi * w);
+                unsigned int offset2 = xi + ((h - 1 - yi) * w);
+                unsigned int pixel1 = pixels[offset1];
+                unsigned int pixel2 = pixels[offset2];
+                pixels[offset1] = pixel2;
+                pixels[offset2] = pixel1;
+            }
+        }
     }
 
     static void OpenGLEnableState(HContext context, State state)
@@ -4969,6 +4983,13 @@ static void LogFrameBufferError(GLenum status)
         ScopedLock lock(context->m_GLHandlesData.m_Mutex);
         // Set all handles to 0. It indicates that handles not valid.
         memset(context->m_GLHandlesData.m_AllGLHandles.Begin(), 0, (context->m_GLHandlesData.m_AllGLHandles.End() - context->m_GLHandlesData.m_AllGLHandles.Begin()) * sizeof(uint32_t));
+    }
+
+    static void OpenGLGetViewport(HContext context, int32_t& x, int32_t& y, uint32_t& width, uint32_t& height)
+    {
+        GLint vp[4];
+        glGetIntegerv(GL_VIEWPORT, vp);
+        x = vp[0], y = vp[1], width = vp[2], height = vp[3];
     }
 
     GLenum TEXTURE_UNIT_NAMES[32] =

--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -4662,7 +4662,7 @@ static void LogFrameBufferError(GLenum status)
     {
         assert(buffer_size >= (width - x) * (height - y) * 4);
         glReadPixels(x, y, width, height,
-                     GL_RGBA,
+                     GL_BGRA,
                      GL_UNSIGNED_BYTE,
                      buffer);
         CHECK_GL_ERROR;

--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -4658,24 +4658,22 @@ static void LogFrameBufferError(GLenum status)
         }
     }
 
-    static void OpenGLReadPixels(HContext context, void* buffer, uint32_t buffer_size)
+    static void OpenGLReadPixels(HContext context, int32_t x, int32_t y, uint32_t width, uint32_t height, void* buffer, uint32_t buffer_size)
     {
-        uint32_t w = dmGraphics::GetWidth(context);
-        uint32_t h = dmGraphics::GetHeight(context);
-        assert (buffer_size >= w * h * 4);
-        glReadPixels(0, 0, w, h,
-                     GL_BGRA,
+        assert(buffer_size >= (width - x) * (height - y) * 4);
+        glReadPixels(x, y, width, height,
+                     GL_RGBA,
                      GL_UNSIGNED_BYTE,
                      buffer);
         CHECK_GL_ERROR;
         unsigned int *pixels = (unsigned int*)buffer;
         // flip vertically
-        for (uint32_t yi = 0; yi < (h / 2); ++yi)
+        for (uint32_t yi = 0; yi < (height / 2); ++yi)
         {
-            for (uint32_t xi = 0; xi < w; ++xi)
+            for (uint32_t xi = 0; xi < width; ++xi)
             {
-                unsigned int offset1 = xi + (yi * w);
-                unsigned int offset2 = xi + ((h - 1 - yi) * w);
+                unsigned int offset1 = xi + (yi * width);
+                unsigned int offset2 = xi + ((height - 1 - yi) * width);
                 unsigned int pixel1 = pixels[offset1];
                 unsigned int pixel2 = pixels[offset2];
                 pixels[offset1] = pixel2;

--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -4983,11 +4983,11 @@ static void LogFrameBufferError(GLenum status)
         memset(context->m_GLHandlesData.m_AllGLHandles.Begin(), 0, (context->m_GLHandlesData.m_AllGLHandles.End() - context->m_GLHandlesData.m_AllGLHandles.Begin()) * sizeof(uint32_t));
     }
 
-    static void OpenGLGetViewport(HContext context, int32_t& x, int32_t& y, uint32_t& width, uint32_t& height)
+    static void OpenGLGetViewport(HContext context, int32_t* x, int32_t* y, uint32_t* width, uint32_t* height)
     {
         GLint vp[4];
         glGetIntegerv(GL_VIEWPORT, vp);
-        x = vp[0], y = vp[1], width = vp[2], height = vp[3];
+        *x = vp[0], *y = vp[1], *width = vp[2], *height = vp[3];
     }
 
     GLenum TEXTURE_UNIT_NAMES[32] =

--- a/engine/graphics/src/test/test_app_graphics.cpp
+++ b/engine/graphics/src/test/test_app_graphics.cpp
@@ -220,7 +220,7 @@ struct ReadPixelsTest : ITest
 
         int32_t x = 0, y = 0;
         uint32_t w = 0, h = 0;
-        dmGraphics::GetViewport(engine->m_GraphicsContext, x, y, w, h);
+        dmGraphics::GetViewport(engine->m_GraphicsContext, &x, &y, &w, &h);
         dmGraphics::ReadPixels(engine->m_GraphicsContext, x, y, w, h, m_Buffer, 512 * 512 * 4);
         dmLogInfo("%d, %d, %d, %d", m_Buffer[0], m_Buffer[1], m_Buffer[2], m_Buffer[3]);
     }

--- a/engine/graphics/src/test/test_app_graphics.cpp
+++ b/engine/graphics/src/test/test_app_graphics.cpp
@@ -218,7 +218,10 @@ struct ReadPixelsTest : ITest
                                     (float) color_a,
                                     1.0f, 0);
 
-        dmGraphics::ReadPixels(engine->m_GraphicsContext, m_Buffer, 512 * 512 * 4);
+        int32_t x = 0, y = 0;
+        uint32_t w = 0, h = 0;
+        dmGraphics::GetViewport(engine->m_GraphicsContext, x, y, w, h);
+        dmGraphics::ReadPixels(engine->m_GraphicsContext, x, y, w, h, m_Buffer, 512 * 512 * 4);
         dmLogInfo("%d, %d, %d, %d", m_Buffer[0], m_Buffer[1], m_Buffer[2], m_Buffer[3]);
     }
 };

--- a/engine/graphics/src/vulkan/graphics_vulkan.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan.cpp
@@ -2964,6 +2964,12 @@ bail:
         g_VulkanContext->m_ViewportChanged = 1;
     }
 
+    static void VulkanGetViewport(HContext context, int32_t& x, int32_t& y, uint32_t& width, uint32_t& height)
+    {
+        const Viewport& viewport = g_VulkanContext->m_MainViewport;
+        x = viewport.m_X, y = viewport.m_Y, width = viewport.m_W, height = viewport.m_H;
+    }
+
     static void VulkanEnableState(HContext context, State state)
     {
         assert(context);

--- a/engine/graphics/src/vulkan/graphics_vulkan.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan.cpp
@@ -4447,7 +4447,7 @@ bail:
     {
         VulkanContext* context = (VulkanContext*) _context;
 
-        assert (buffer_size >= (width - x) * (height - y) * 4);
+        assert (buffer_size >= width * height * 4);
 
         HRenderTarget currentt_rt_h = context->m_CurrentRenderTarget;
         bool in_render_pass = IsRenderTargetbound(context, currentt_rt_h);

--- a/engine/graphics/src/vulkan/graphics_vulkan.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan.cpp
@@ -4443,7 +4443,7 @@ bail:
         return flags;
     }
 
-    static void VulkanReadPixels(HContext context, int32_t x, int32_t y, uint32_t width, uint32_t height, void* buffer, uint32_t buffer_size)
+    static void VulkanReadPixels(HContext _context, int32_t x, int32_t y, uint32_t width, uint32_t height, void* buffer, uint32_t buffer_size)
     {
         VulkanContext* context = (VulkanContext*) _context;
 

--- a/engine/graphics/src/vulkan/graphics_vulkan.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan.cpp
@@ -4443,13 +4443,11 @@ bail:
         return flags;
     }
 
-    static void VulkanReadPixels(HContext _context, void* buffer, uint32_t buffer_size)
+    static void VulkanReadPixels(HContext context, int32_t x, int32_t y, uint32_t width, uint32_t height, void* buffer, uint32_t buffer_size)
     {
         VulkanContext* context = (VulkanContext*) _context;
 
-        uint32_t w = context->m_WindowWidth;
-        uint32_t h = context->m_WindowHeight;
-        assert (buffer_size >= w * h * 4);
+        assert (buffer_size >= (width - x) * (height - y) * 4);
 
         HRenderTarget currentt_rt_h = context->m_CurrentRenderTarget;
         bool in_render_pass = IsRenderTargetbound(context, currentt_rt_h);
@@ -4487,8 +4485,10 @@ bail:
         CHECK_VK_ERROR(res);
 
         VkBufferImageCopy vk_copy_region = {};
-        vk_copy_region.imageExtent.width           = w;
-        vk_copy_region.imageExtent.height          = h;
+        vk_copy_region.imageOffset.x               = x;
+        vk_copy_region.imageOffset.y               = y;
+        vk_copy_region.imageExtent.width           = width;
+        vk_copy_region.imageExtent.height          = height;
         vk_copy_region.imageExtent.depth           = 1;
         vk_copy_region.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
         vk_copy_region.imageSubresource.layerCount = 1;

--- a/engine/graphics/src/vulkan/graphics_vulkan.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan.cpp
@@ -2964,10 +2964,10 @@ bail:
         g_VulkanContext->m_ViewportChanged = 1;
     }
 
-    static void VulkanGetViewport(HContext context, int32_t& x, int32_t& y, uint32_t& width, uint32_t& height)
+    static void VulkanGetViewport(HContext context, int32_t* x, int32_t* y, uint32_t* width, uint32_t* height)
     {
         const Viewport& viewport = g_VulkanContext->m_MainViewport;
-        x = viewport.m_X, y = viewport.m_Y, width = viewport.m_W, height = viewport.m_H;
+        *x = viewport.m_X, *y = viewport.m_Y, *width = viewport.m_W, *height = viewport.m_H;
     }
 
     static void VulkanEnableState(HContext context, State state)

--- a/engine/graphics/src/webgpu/graphics_webgpu.cpp
+++ b/engine/graphics/src/webgpu/graphics_webgpu.cpp
@@ -2923,14 +2923,14 @@ static void WebGPUSetViewport(HContext _context, int32_t x, int32_t y, int32_t w
     context->m_ViewportRect[3] = height;
 }
 
-static void WebGPUGetViewport(HContext _context, int32_t& x, int32_t& y, uint32_t& width, uint32_t& height)
+static void WebGPUGetViewport(HContext _context, int32_t* x, int32_t* y, uint32_t* width, uint32_t* height)
 {
     TRACE_CALL;
     WebGPUContext* context     = (WebGPUContext*)_context;
-    x = context->m_ViewportRect[0];
-    y = context->m_ViewportRect[1];
-    width = context->m_ViewportRect[2];
-    height = context->m_ViewportRect[3];
+    *x = context->m_ViewportRect[0];
+    *y = context->m_ViewportRect[1];
+    *width = context->m_ViewportRect[2];
+    *height = context->m_ViewportRect[3];
 }
 
 static void WebGPUSetScissor(HContext _context, int32_t x, int32_t y, int32_t width, int32_t height)

--- a/engine/graphics/src/webgpu/graphics_webgpu.cpp
+++ b/engine/graphics/src/webgpu/graphics_webgpu.cpp
@@ -2720,7 +2720,7 @@ static void WebGPUDisableTexture(HContext context, uint32_t unit, HTexture textu
     ((WebGPUContext*)context)->m_CurrentTextureUnits[unit] = NULL;
 }
 
-static void WebGPUReadPixels(HContext context, void* buffer, uint32_t buffer_size)
+static void WebGPUReadPixels(HContext context, int32_t x, int32_t y, uint32_t width, uint32_t height, void* buffer, uint32_t buffer_size)
 {
     TRACE_CALL;
     assert(false);

--- a/engine/graphics/src/webgpu/graphics_webgpu.cpp
+++ b/engine/graphics/src/webgpu/graphics_webgpu.cpp
@@ -2923,6 +2923,16 @@ static void WebGPUSetViewport(HContext _context, int32_t x, int32_t y, int32_t w
     context->m_ViewportRect[3] = height;
 }
 
+static void WebGPUGetViewport(HContext _context, int32_t& x, int32_t& y, uint32_t& width, uint32_t& height)
+{
+    TRACE_CALL;
+    WebGPUContext* context     = (WebGPUContext*)_context;
+    x = context->m_ViewportRect[0];
+    y = context->m_ViewportRect[1];
+    width = context->m_ViewportRect[2];
+    height = context->m_ViewportRect[3];
+}
+
 static void WebGPUSetScissor(HContext _context, int32_t x, int32_t y, int32_t width, int32_t height)
 {
     TRACE_CALL;


### PR DESCRIPTION
Expose `ReadPixels` API.
```cpp
uint8_t m_Buffer[512 * 512 * 4];
dmGraphics::ReadPixels(graphicsContext, 100, 50, 612, 562, m_Buffer, 512 * 512 * 4);
```

Added `GetViewport` API.
```cpp
int32_t x = 0, y = 0;
uint32_t w = 0, h = 0;
dmGraphics::GetViewport(graphicsContext, &x, &y, &w, &h);
```

### Technical changes
**Motivation**:
In 1.9.9 Vulkan became a default renderer backend. At least https://github.com/britzl/defold-screenshot relies on fact that default renderer is OpenGL. To fix extension's compilation I expose several API from dmGraphics namespace to use it inside extension.

Implementation:
1. Exposed `ReadPixels` API.
2. Modified `ReadPixels` API to take a coordinates and size of interesting region.
3. Added `GetViewport` API to get current viewport's attributes
4. In OpenGL implementation flip `ReadPixels` result by Y to be conform with other graphics API implementation.
5. Updated `dmRecord` module to use viewport's size instead of window size.
 
Related to https://github.com/britzl/defold-screenshot/pull/31
## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   7. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
