### PR TITLE
Editor: Replace all calls to workspace/project-path with the new project-directory function

### DIFF
--- a/editor/src/clj/editor/animation_set.clj
+++ b/editor/src/clj/editor/animation_set.clj
@@ -75,8 +75,8 @@
         animation-set-builder (Rig$AnimationSet/newBuilder)
         animation-ids (ArrayList.)
         workspace (resource/workspace resource)
-        project-path (workspace/project-path workspace)
-        data-resolver (ModelUtil/createFileDataResolver project-path)]
+        project-directory (workspace/project-directory workspace)
+        data-resolver (ModelUtil/createFileDataResolver project-directory)]
 
     (AnimationSetBuilder/buildAnimations is-animation-set paths streams data-resolver parent-ids animation-set-builder animation-ids)
     (let [animation-set (protobuf/pb->map-with-defaults (.build animation-set-builder))]

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -1220,7 +1220,7 @@
     (nil? error)))
 
 (defn- build-handler [project workspace prefs web-server build-errors-view main-stage tool-tab-pane]
-  (let [project-directory (io/file (workspace/project-path workspace))
+  (let [project-directory (workspace/project-directory workspace)
         main-scene (.getScene ^Stage main-stage)
         render-build-error! (make-render-build-error main-scene tool-tab-pane build-errors-view)
         skip-engine (target-cannot-swap-engine? (targets/selected-target prefs))]
@@ -1267,7 +1267,7 @@ If you do not specifically require different script states, consider changing th
         false)))
 
 (defn- run-with-debugger! [workspace project prefs debug-view render-build-error! web-server]
-  (let [project-directory (io/file (workspace/project-path workspace))
+  (let [project-directory (workspace/project-directory workspace)
         skip-engine (target-cannot-swap-engine? (targets/selected-target prefs))]
     (async-build! project
                   :debug true
@@ -2111,7 +2111,7 @@ If you do not specifically require different script states, consider changing th
                args (->> (string/split arg-tmpl #" ")
                          (map #(substitute-args % arg-sub)))]
            (doto (ProcessBuilder. ^List (cons custom-editor args))
-             (.directory (workspace/project-path workspace))
+             (.directory (workspace/project-directory workspace))
              (.start))
            false)
          (if (contains? view-type :make-view-fn)

--- a/editor/src/clj/editor/changes_view.clj
+++ b/editor/src/clj/editor/changes_view.clj
@@ -13,8 +13,7 @@
 ;; specific language governing permissions and limitations under the License.
 
 (ns editor.changes-view
-  (:require [clojure.java.io :as io]
-            [dynamo.graph :as g]
+  (:require [dynamo.graph :as g]
             [editor.core :as core]
             [editor.dialogs :as dialogs]
             [editor.diff-view :as diff-view]
@@ -100,8 +99,9 @@
     :icon "icons/32/Icons_S_02_Reset.png"
     :command :revert}])
 
-(defn- path->file [workspace ^String path]
-  (File. ^File (workspace/project-path workspace) path))
+(defn- path->file
+  ^File [workspace ^String path]
+  (File. (workspace/project-directory workspace) path))
 
 (handler/defhandler :revert :changes-view
   (enabled? [selection]
@@ -143,8 +143,8 @@
 
 (defn- try-open-git
   ^Git [workspace]
-  (let [repo-path (io/as-file (g/node-value workspace :root))
-        git (git/try-open repo-path)
+  (let [repo-directory (workspace/project-directory workspace)
+        git (git/try-open repo-directory)
         head-commit (some-> git .getRepository (git/get-commit "HEAD"))]
     (if (some? head-commit)
       git

--- a/editor/src/clj/editor/cljfx_form_view.clj
+++ b/editor/src/clj/editor/cljfx_form_view.clj
@@ -527,7 +527,7 @@
     :directory
     (when-some [selected-directory (dialogs/make-directory-dialog
                                      (or (:title element) "Select Directory")
-                                     (workspace/project-path workspace)
+                                     (workspace/project-directory workspace)
                                      (fxui/event->window event))]
       (if-some [valid-directory-path (absolute-or-maybe-proj-path selected-directory workspace (:in-project element))]
         (add-list-elements [valid-directory-path] map-event)

--- a/editor/src/clj/editor/disk.clj
+++ b/editor/src/clj/editor/disk.clj
@@ -72,7 +72,7 @@
 (defonce ^:private reload-job-atom (atom nil))
 
 (defn- start-reload-job! [render-progress! workspace moved-files changes-view]
-  (let [project-path (workspace/project-path workspace)
+  (let [project-directory (workspace/project-directory workspace)
         dependencies (workspace/dependencies workspace)
         snapshot-cache (workspace/snapshot-cache workspace)
         success-promise (promise)
@@ -86,7 +86,7 @@
     (future
       (try
         (render-progress! (progress/make-indeterminate "Loading external changes..."))
-        (let [snapshot-info (workspace/make-snapshot-info workspace project-path dependencies snapshot-cache)]
+        (let [snapshot-info (workspace/make-snapshot-info workspace project-directory dependencies snapshot-cache)]
           (render-progress! progress/done)
           (ui/run-later
             (try

--- a/editor/src/clj/editor/editor_extensions/actions.clj
+++ b/editor/src/clj/editor/editor_extensions/actions.clj
@@ -83,9 +83,9 @@
 (defn- shell! [commands project state]
   (let [{:keys [reload-resources! display-output!]} state
         root (lsp.async/with-auto-evaluation-context evaluation-context
-               (-> project
-                   (project/workspace evaluation-context)
-                   (workspace/project-path evaluation-context)))]
+               (let [basis (:basis evaluation-context)
+                     workspace (project/workspace project evaluation-context)]
+                 (workspace/project-directory basis workspace)))]
     (-> (await-all-sequentially
           (eduction
             (map

--- a/editor/src/clj/editor/engine/native_extensions.clj
+++ b/editor/src/clj/editor/engine/native_extensions.clj
@@ -256,8 +256,9 @@
 (defn get-engine-archive [project platform prefs evaluation-context]
   (if-not (supported-platform? platform)
     (throw (engine-build-errors/unsupported-platform-error platform))
-    (let [extender-platform (get-in extender-platforms [platform :platform])
-          project-directory (workspace/project-path (project/workspace project evaluation-context) evaluation-context)
+    (let [basis (:basis evaluation-context)
+          extender-platform (get-in extender-platforms [platform :platform])
+          project-directory (workspace/project-directory basis (project/workspace project evaluation-context))
           cache-directory (cache-dir project-directory)
           sdk-version (system/defold-engine-sha1)
           cache (ExtenderClientCache. cache-directory)

--- a/editor/src/clj/editor/markdown.clj
+++ b/editor/src/clj/editor/markdown.clj
@@ -70,8 +70,9 @@
 
       "file"
       (if-let [resource (g/with-auto-evaluation-context evaluation-context
-                          (let [workspace (project/workspace project evaluation-context)]
-                            (when-let [proj-path (workspace/as-proj-path workspace resolved-url evaluation-context)]
+                          (let [basis (:basis evaluation-context)
+                                workspace (project/workspace project evaluation-context)]
+                            (when-let [proj-path (workspace/as-proj-path basis workspace resolved-url)]
                               (workspace/find-resource workspace proj-path))))]
         (ui/execute-command (ui/contexts (ui/main-scene)) :open {:resources [resource]})
         (ui/open-url resolved-url))

--- a/editor/src/clj/editor/model_loader.clj
+++ b/editor/src/clj/editor/model_loader.clj
@@ -47,12 +47,12 @@
 
 (defn- load-model-scene [resource ^InputStream stream]
   (let [workspace (resource/workspace resource)
-        project-path (workspace/project-path workspace)
+        project-directory (workspace/project-directory workspace)
         mesh-set-builder (Rig$MeshSet/newBuilder)
         skeleton-builder (Rig$Skeleton/newBuilder)
         path (resource/path resource)
         options nil
-        data-resolver (ModelUtil/createFileDataResolver project-path)
+        data-resolver (ModelUtil/createFileDataResolver project-directory)
         scene (ModelUtil/loadScene stream ^String path options data-resolver)
         bones (ModelUtil/loadSkeleton scene)
         material-ids (ModelUtil/loadMaterialNames scene)

--- a/editor/src/clj/editor/pipeline/bob.clj
+++ b/editor/src/clj/editor/pipeline/bob.clj
@@ -189,6 +189,7 @@
         render-progress! (progress/until-done render-progress!)
         provided-evaluation-context (some? evaluation-context)
         evaluation-context (or evaluation-context (g/make-evaluation-context))
+        basis (:basis evaluation-context)
         prev-out System/out
         prev-err System/err
         log-output-stream (or log-output-stream
@@ -205,7 +206,7 @@
                               (assoc "root" ".")
                               (not (contains? options "verbose"))
                               (assoc "verbose" true))
-              [cli-options internal-options] (parse-options (.toPath (workspace/project-path workspace evaluation-context)) options)
+              [cli-options internal-options] (parse-options (.toPath (workspace/project-directory basis workspace)) options)
               cli-args (-> [] (into cli-options) (into commands))]
           (log/info :bob-command (string/join " " (into ["java" "-jar" "bob.jar"] (map quote-arg-if-needed) cli-args)))
           (System/setOut build-out)

--- a/editor/src/clj/editor/scene.clj
+++ b/editor/src/clj/editor/scene.clj
@@ -32,6 +32,7 @@
             [editor.protobuf :as protobuf]
             [editor.render :as render]
             [editor.resource :as resource]
+            [editor.resource-node :as resource-node]
             [editor.rulers :as rulers]
             [editor.scene-async :as scene-async]
             [editor.scene-cache :as scene-cache]
@@ -99,8 +100,8 @@
   (scene-text/overlay gl text x y))
 
 (defn- get-resource-name [node-id]
-  (let [{:keys [resource] :as resource-node} (and node-id (g/node-by-id node-id))]
-    (and resource (resource/resource-name resource))))
+  (when-let [resource (resource-node/as-resource node-id)]
+    (resource/resource-name resource)))
 
 (defn- render-error
   [gl render-args renderables nrenderables]

--- a/editor/test/editor/build_target_test.clj
+++ b/editor/test/editor/build_target_test.clj
@@ -43,7 +43,7 @@
      (.toString writer))))
 
 (defn- make-fake-file-resource [workspace path text]
-  (let [root-dir (workspace/project-path workspace)]
+  (let [root-dir (workspace/project-directory workspace)]
     (test-util/make-fake-file-resource workspace
                                        (.getPath root-dir)
                                        (io/file root-dir path)

--- a/editor/test/editor/engine/build_errors_test.clj
+++ b/editor/test/editor/engine/build_errors_test.clj
@@ -18,7 +18,6 @@
             [editor.engine.build-errors :as build-errors]
             [editor.workspace :as workspace]
             [integration.test-util :as tu]
-            [support.test-support :as ts]
             [dynamo.graph :as g]))
 
 (defn- slurp-test-file
@@ -26,7 +25,7 @@
   (slurp (str "test/resources/native_extension_error_parsing/" name)))
 
 (defn- make-fake-file-resource [workspace proj-path text opts]
-  (let [root-dir (workspace/project-path workspace)]
+  (let [root-dir (workspace/project-directory workspace)]
     (tu/make-fake-file-resource workspace (.getPath root-dir) (io/file root-dir proj-path) (.getBytes text "UTF-8") opts)))
 
 (defn- make-fake-empty-files

--- a/editor/test/integration/app_view_test.clj
+++ b/editor/test/integration/app_view_test.clj
@@ -131,8 +131,8 @@
           atlas-path2 "/atlas/single2.atlas"
           atlas-res2 (workspace/resolve-workspace-resource workspace atlas-path2)
           [atlas scene-view] (test-util/open-scene-view! project app-view atlas-path 64 64)
-          proj-path (.getAbsolutePath (workspace/project-path workspace))
-          git (init-git proj-path)
+          project-path (.getAbsolutePath (workspace/project-directory workspace))
+          git (init-git project-path)
           atlas-outline (fn [path] (test-util/outline (g/node-value app-view :active-resource-node) path))]
       (is (= atlas-res (g/node-value app-view :active-resource)))
       (test-util/move-file! workspace atlas-path atlas-path2)

--- a/editor/test/integration/asset_browser_test.clj
+++ b/editor/test/integration/asset_browser_test.clj
@@ -58,7 +58,7 @@
 
 (deftest allow-resource-move
   (test-util/with-loaded-project
-    (let [root-dir (workspace/project-path workspace)
+    (let [root-dir (workspace/project-directory workspace)
           make-file (fn [proj-path]
                       (io/file root-dir proj-path))
           make-dir-resource (fn [proj-path opts]
@@ -104,7 +104,7 @@
 (deftest paste
   (with-clean-system
     (let [workspace (test-util/setup-scratch-workspace! world)
-          root-dir (workspace/project-path workspace)
+          root-dir (workspace/project-directory workspace)
           make-file (partial io/file root-dir)
           make-dir-resource (fn [path opts] (test-util/make-fake-file-resource workspace (.getPath root-dir) (make-file path) nil (merge opts {:source-type :folder})))
           root-resource (make-dir-resource "" {})
@@ -147,7 +147,7 @@
 
 (deftest rename
   (test-util/with-loaded-project
-    (let [root-dir (workspace/project-path workspace)
+    (let [root-dir (workspace/project-directory workspace)
           make-file (partial io/file root-dir)
           make-dir-resource (fn [path opts] (test-util/make-fake-file-resource workspace (.getPath root-dir) (make-file path) nil (merge opts {:source-type :folder})))
           make-file-resource (fn [path opts] (test-util/make-fake-file-resource workspace (.getPath root-dir) (make-file path) nil (merge opts {:source-type :file})))
@@ -179,7 +179,7 @@
 
 (deftest delete
   (test-util/with-loaded-project
-    (let [root-dir (workspace/project-path workspace)
+    (let [root-dir (workspace/project-directory workspace)
           make-file (partial io/file root-dir)
           make-dir-resource (fn [path opts] (test-util/make-fake-file-resource workspace (.getPath root-dir) (make-file path) nil (merge opts {:source-type :folder})))
           make-file-resource (fn [path opts] (test-util/make-fake-file-resource workspace (.getPath root-dir) (make-file path) nil (merge opts {:source-type :file})))
@@ -205,7 +205,7 @@
 
 (deftest new-folder
   (test-util/with-loaded-project
-    (let [root-dir (workspace/project-path workspace)
+    (let [root-dir (workspace/project-directory workspace)
           make-file (partial io/file root-dir)
           make-dir-resource (fn [path opts] (test-util/make-fake-file-resource workspace (.getPath root-dir) (make-file path) nil (merge opts {:source-type :folder})))
           make-file-resource (fn [path opts] (test-util/make-fake-file-resource workspace (.getPath root-dir) (make-file path) nil (merge opts {:source-type :file})))
@@ -239,7 +239,7 @@
 (deftest drop-move
   (with-clean-system
     (let [workspace (test-util/setup-scratch-workspace! world)
-          root-dir (workspace/project-path workspace)
+          root-dir (workspace/project-directory workspace)
           make-file (partial io/file root-dir)
           resource-map (g/node-value workspace :resource-map)]
       (testing "drag-moving game.project becomes copy"

--- a/editor/test/integration/build_test.clj
+++ b/editor/test/integration/build_test.clj
@@ -471,7 +471,7 @@
   (io/file (workspace/build-path workspace) proj-path))
 
 (defn- abs-project-path [workspace proj-path]
-  (io/file (workspace/project-path workspace) proj-path))
+  (io/file (workspace/project-directory workspace) proj-path))
 
 (defn mtime [^File f]
   (.lastModified f))
@@ -845,7 +845,7 @@
       (let [br (project-build project game-project (g/make-evaluation-context))]
         (is (not (contains? br :error))))
       (testing "Removing an unreferenced collisionobject should not break the build"
-        (let [f (File. (workspace/project-path workspace) "knight.collisionobject")]
+        (let [f (File. (workspace/project-directory workspace) "knight.collisionobject")]
           (fs/delete-file! f)
           (workspace/resource-sync! workspace))
         (let [br (project-build project game-project (g/make-evaluation-context))]

--- a/editor/test/integration/editor_extensions_test.clj
+++ b/editor/test/integration/editor_extensions_test.clj
@@ -919,7 +919,7 @@ POST http://localhost:23456/echo hello world! as string => 200
 (deftest zip-test
   (test-util/with-scratch-project "test/resources/editor_extensions/zip_project"
     (let [output (atom [])
-          root (g/node-value workspace :root)
+          root (workspace/project-directory workspace)
           list-entries (fn list-entries [path-str]
                          (with-open [zis (ZipArchiveInputStream. (io/input-stream (fs/path root path-str)))]
                            (loop [acc (transient #{})]

--- a/editor/test/integration/engine/native_extensions_test.clj
+++ b/editor/test/integration/engine/native_extensions_test.clj
@@ -22,6 +22,7 @@
             [editor.engine.native-extensions :as native-extensions]
             [editor.fs :as fs]
             [editor.resource :as resource]
+            [editor.workspace :as workspace]
             [integration.test-util :as test-util]
             [support.test-support :refer [with-clean-system]]
             [util.repo :as repo])
@@ -48,7 +49,7 @@
    (with-clean-system
      (let [workspace (test-util/setup-scratch-workspace! world "test/resources/extension_project")
            _ (test-util/setup-project! workspace)
-           root (g/node-value workspace :root)]
+           root (workspace/project-directory workspace)]
        ;; The plugins/${platform}.zip archive has a following structure:
        ;; /bin
        ;;   /${platform}

--- a/editor/test/integration/library_test.clj
+++ b/editor/test/integration/library_test.clj
@@ -65,11 +65,11 @@
   (with-clean-system
     (let [[workspace project] (log/without-logging (setup-scratch world))]
       (testing "initially no library files"
-        (let [files (library/library-files (workspace/project-path workspace))]
+        (let [files (library/library-files (workspace/project-directory workspace))]
           (is (= 0 (count files)))))
       (testing "initially unknown library state"
         (let [states (library/current-library-state
-                      (workspace/project-path workspace)
+                      (workspace/project-directory workspace)
                       uris)]
           (is (every? (fn [state] (= (:status state) :unknown)) states))
           (is (not (seq (filter :file states)))))))))
@@ -77,7 +77,7 @@
 (deftest libraries-present
   (with-clean-system
     (let [[workspace project] (log/without-logging (setup-scratch world))]
-      (let [project-directory (workspace/project-path workspace)]
+      (let [project-directory (workspace/project-directory workspace)]
         ;; copy to proper place
         (FileUtils/copyDirectory
          (io/file "test/resources/lib_resource_project/.internal/lib")
@@ -104,7 +104,7 @@
 (deftest library-update
   (with-clean-system
     (let [[workspace project] (log/without-logging (setup-scratch world))]
-      (let [project-directory (workspace/project-path workspace)]
+      (let [project-directory (workspace/project-directory workspace)]
         (let [update-states   (->> (library/current-library-state project-directory uris)
                                    (library/fetch-library-updates dummy-lib-resolver progress/null-render-progress!)
                                    (library/validate-updated-libraries)

--- a/editor/test/integration/reload_test.clj
+++ b/editor/test/integration/reload_test.clj
@@ -125,7 +125,7 @@
   ([workspace name]
    (touch-file workspace name true))
   ([workspace ^String name sync?]
-   (let [f (File. (workspace/project-path workspace) name)]
+   (let [f (File. (workspace/project-directory workspace) name)]
      (fs/create-parent-directories! f)
      (touch-until-new-mtime f))
    (when sync?
@@ -137,41 +137,41 @@
   (sync! workspace))
 
 (defn- write-file [workspace ^String name content]
-  (let [f (File. (workspace/project-path workspace) name)]
+  (let [f (File. (workspace/project-directory workspace) name)]
     (fs/create-parent-directories! f)
     (spit-until-new-mtime f content))
   (sync! workspace))
 
 (defn- read-file [workspace name]
-  (slurp (str (workspace/project-path workspace) name)))
+  (slurp (str (workspace/project-directory workspace) name)))
 
 (defn- add-file [workspace name]
   (write-file workspace name (template workspace name)))
 
 (defn- delete-file [workspace ^String name]
-  (let [f (File. (workspace/project-path workspace) name)]
+  (let [f (File. (workspace/project-directory workspace) name)]
     (fs/delete-file! f))
   (sync! workspace))
 
 (defn- copy-file [workspace name new-name]
-  (let [[f new-f] (mapv #(File. (workspace/project-path workspace) ^String %) [name new-name])]
+  (let [[f new-f] (mapv #(File. (workspace/project-directory workspace) ^String %) [name new-name])]
     (fs/copy-file! f new-f))
   (sync! workspace))
 
 (defn- copy-directory [workspace name new-name]
-  (let [[f new-f] (mapv #(File. (workspace/project-path workspace) ^String %) [name new-name])]
+  (let [[f new-f] (mapv #(File. (workspace/project-directory workspace) ^String %) [name new-name])]
     (fs/copy-directory! f new-f))
   (sync! workspace))
 
 (defn- move-file [workspace name new-name]
-  (let [[f new-f] (mapv #(File. (workspace/project-path workspace) ^String %) [name new-name])]
+  (let [[f new-f] (mapv #(File. (workspace/project-directory workspace) ^String %) [name new-name])]
     (fs/move-file! f new-f)
     (sync! workspace [[f new-f]])))
 
 (defn- add-img [workspace ^String name width height]
   (let [img (BufferedImage. width height BufferedImage/TYPE_INT_ARGB)
         type (resource/filename->type-ext name)
-        f (File. (workspace/project-path workspace) name)]
+        f (File. (workspace/project-directory workspace) name)]
     (do-until-new-mtime (fn [^File f] (ImageIO/write img type f)) f)
     (sync! workspace)))
 

--- a/editor/test/integration/resource_watch_test.clj
+++ b/editor/test/integration/resource_watch_test.clj
@@ -130,7 +130,7 @@
         (is (empty? (:changed remove-il1-diff))))
       (workspace/set-project-dependencies! workspace [{:uri imagelib1-uri}])
       (workspace/resource-sync! workspace)
-      (let [project-directory (workspace/project-path workspace)]
+      (let [project-directory (workspace/project-directory workspace)]
         ;; this fakes having downloaded a different version of the library
         (fs/move-file! (library/library-file project-directory imagelib1-uri "")
                        (library/library-file project-directory imagelib1-uri "updated")))

--- a/editor/test/integration/save_test.clj
+++ b/editor/test/integration/save_test.clj
@@ -133,7 +133,7 @@
 (defn- workspace-file
   ^File [workspace proj-path]
   (assert (= \/ (first proj-path)))
-  (File. (workspace/project-path workspace) (subs proj-path 1)))
+  (File. (workspace/project-directory workspace) (subs proj-path 1)))
 
 (defn- slurp-file
   ^String [workspace proj-path]

--- a/editor/test/integration/script_properties_test.clj
+++ b/editor/test/integration/script_properties_test.clj
@@ -74,11 +74,11 @@
     (tu/prop-clear! node-id key)))
 
 (defn- make-fake-file-resource [workspace proj-path text]
-  (let [root-dir (workspace/project-path workspace)]
+  (let [root-dir (workspace/project-directory workspace)]
     (tu/make-fake-file-resource workspace (.getPath root-dir) (io/file root-dir proj-path) (.getBytes text "UTF-8"))))
 
 (defn- write-file! [workspace name content]
-  (let [root-dir (workspace/project-path workspace)
+  (let [root-dir (workspace/project-directory workspace)
         file (io/file root-dir name)]
     (fs/create-parent-directories! file)
     (spit-until-new-mtime file content))
@@ -330,7 +330,7 @@
           make-atlas! (partial tu/make-atlas-resource-node! project)
           make-material! (partial make-material! project)
           make-resource-node! (partial tu/make-resource-node! project)]
-      (with-open [_ (tu/make-directory-deleter (workspace/project-path workspace))]
+      (with-open [_ (tu/make-directory-deleter (workspace/project-directory workspace))]
         (make-atlas!    "/from-props-script.atlas")
         (make-material! "/from-props-script.material")
         (let [props-script (doto (make-resource-node! "/props.script")
@@ -434,7 +434,7 @@
           make-atlas! (partial tu/make-atlas-resource-node! project)
           make-material! (partial make-material! project)
           make-resource-node! (partial tu/make-resource-node! project)]
-      (with-open [_ (tu/make-directory-deleter (workspace/project-path workspace))]
+      (with-open [_ (tu/make-directory-deleter (workspace/project-directory workspace))]
         (make-atlas!    "/from-props-script.atlas")
         (make-material! "/from-props-script.material")
         (make-atlas!    "/from-props-game-object.atlas")
@@ -634,7 +634,7 @@
           build-output (partial tu/build-output project)
           make-atlas! (partial tu/make-atlas-resource-node! project)
           make-resource-node! (partial tu/make-resource-node! project)]
-      (with-open [_ (tu/make-directory-deleter (workspace/project-path workspace))]
+      (with-open [_ (tu/make-directory-deleter (workspace/project-directory workspace))]
         (make-atlas! "/from-props-script.atlas")
         (make-atlas! "/from-props-game-object.atlas")
         (let [props-script (doto (make-resource-node! "/props.script")
@@ -680,7 +680,7 @@
           make-atlas! (partial tu/make-atlas-resource-node! project)
           make-material! (partial make-material! project)
           make-resource-node! (partial tu/make-resource-node! project)]
-      (with-open [_ (tu/make-directory-deleter (workspace/project-path workspace))]
+      (with-open [_ (tu/make-directory-deleter (workspace/project-directory workspace))]
         (make-atlas!    "/from-props-script.atlas")
         (make-material! "/from-props-script.material")
         (make-atlas!    "/from-props-game-object.atlas")
@@ -899,7 +899,7 @@
           build-output (partial tu/build-output project)
           make-atlas! (partial tu/make-atlas-resource-node! project)
           make-resource-node! (partial tu/make-resource-node! project)]
-      (with-open [_ (tu/make-directory-deleter (workspace/project-path workspace))]
+      (with-open [_ (tu/make-directory-deleter (workspace/project-directory workspace))]
         (make-atlas! "/from-props-script.atlas")
         (make-atlas! "/from-props-collection.atlas")
         (let [props-script (doto (make-resource-node! "/props.script")
@@ -951,7 +951,7 @@
           make-atlas! (partial tu/make-atlas-resource-node! project)
           make-material! (partial make-material! project)
           make-resource-node! (partial tu/make-resource-node! project)]
-      (with-open [_ (tu/make-directory-deleter (workspace/project-path workspace))]
+      (with-open [_ (tu/make-directory-deleter (workspace/project-directory workspace))]
         (make-atlas!    "/from-props-script.atlas")
         (make-material! "/from-props-script.material")
         (make-atlas!    "/from-props-game-object.atlas")
@@ -1194,7 +1194,7 @@
           make-atlas! (partial tu/make-atlas-resource-node! project)
           make-material! (partial make-material! project)
           make-resource-node! (partial tu/make-resource-node! project)]
-      (with-open [_ (tu/make-directory-deleter (workspace/project-path workspace))]
+      (with-open [_ (tu/make-directory-deleter (workspace/project-directory workspace))]
         (make-atlas!    "/from-props-script.atlas")
         (make-material! "/from-props-script.material")
         (make-atlas!    "/from-embedded-game-object.atlas")
@@ -1432,7 +1432,7 @@
           build-output (partial tu/build-output project)
           make-atlas! (partial tu/make-atlas-resource-node! project)
           make-resource-node! (partial tu/make-resource-node! project)]
-      (with-open [_ (tu/make-directory-deleter (workspace/project-path workspace))]
+      (with-open [_ (tu/make-directory-deleter (workspace/project-directory workspace))]
         (make-atlas! "/from-props-script.atlas")
         (make-atlas! "/from-sub-props-collection.atlas")
         (let [props-script (doto (make-resource-node! "/props.script")
@@ -1484,7 +1484,7 @@
           edit-property! (fn [node-id proj-path] (edit-property! node-id :__atlas (tu/resource workspace proj-path)))
           assigned-property? (fn [node-id proj-path] (atlas-resource-property? (get (properties node-id) :__atlas) (tu/resource workspace proj-path)))
           overridden-property? (fn [node-id] (overridden? node-id "atlas"))]
-      (with-open [_ (tu/make-directory-deleter (workspace/project-path workspace))]
+      (with-open [_ (tu/make-directory-deleter (workspace/project-directory workspace))]
         (make-atlas! "/from-props-script.atlas")
         (make-atlas! "/from-props-game-object.atlas")
         (make-atlas! "/from-props-collection.atlas")
@@ -1633,7 +1633,7 @@
           resource (partial tu/resource workspace)
           make-atlas! (partial tu/make-atlas-resource-node! project)
           make-resource-node! (partial tu/make-resource-node! project)]
-      (with-open [_ (tu/make-directory-deleter (workspace/project-path workspace))]
+      (with-open [_ (tu/make-directory-deleter (workspace/project-directory workspace))]
         (make-atlas! "/from-props-script.atlas")
         (make-atlas! "/from-props-game-object.atlas")
         (let [props-script (doto (make-resource-node! "/props.script")
@@ -1685,7 +1685,7 @@
           edit-property! (fn [node-id proj-path] (edit-property! node-id :__atlas (tu/resource workspace proj-path)))
           assigned-property? (fn [node-id proj-path] (atlas-resource-property? (get (properties node-id) :__atlas) (tu/resource workspace proj-path)))
           overridden-property? (fn [node-id] (overridden? node-id "atlas"))]
-      (with-open [_ (tu/make-directory-deleter (workspace/project-path workspace))]
+      (with-open [_ (tu/make-directory-deleter (workspace/project-directory workspace))]
         (make-atlas! "/from-props-script.atlas")
         (make-atlas! "/from-props-game-object.atlas")
         (make-atlas! "/from-props-collection.atlas")
@@ -1750,7 +1750,7 @@
   (with-clean-system
     (let [workspace (tu/setup-scratch-workspace! world "test/resources/empty_project")
           project (tu/setup-project! workspace)]
-      (with-open [_ (tu/make-directory-deleter (workspace/project-path workspace))]
+      (with-open [_ (tu/make-directory-deleter (workspace/project-directory workspace))]
         (doto (tu/make-resource-node! project "/props.script")
           (edit-script! ["go.property('image', resource.atlas('/builtins/graphics/particle_blob.tilesource'))"]))
 

--- a/editor/test/integration/script_test.clj
+++ b/editor/test/integration/script_test.clj
@@ -26,7 +26,7 @@
 
 (defn make-script-resource
   [world workspace path code]
-  (let [root-dir (workspace/project-path workspace)]
+  (let [root-dir (workspace/project-directory workspace)]
     (test-util/make-fake-file-resource workspace (.getPath root-dir) (io/file root-dir path) (.getBytes code "UTF-8"))))
 
 (deftest script-node-dependencies

--- a/editor/test/integration/sparse_protobuf_test.clj
+++ b/editor/test/integration/sparse_protobuf_test.clj
@@ -359,11 +359,11 @@
                     resource-types)))
         (test-util/distinct-resource-types-by-editability workspace relevant-protobuf-resource-type?)))
 
-(defn- with-absolute-file-keys [^File project-root-directory values-by-proj-path]
+(defn- with-absolute-file-keys [^File project-directory values-by-proj-path]
   (into (sorted-map)
         (map (fn [[proj-path content]]
                (let [relative-path (subs proj-path 1) ; Strip leading slash.
-                     absolute-file (io/file project-root-directory relative-path)]
+                     absolute-file (io/file project-directory relative-path)]
                  (pair absolute-file content))))
         values-by-proj-path))
 
@@ -529,10 +529,10 @@
           (test-util/set-libraries! workspace test-util/sanctioned-extension-urls)
 
           ;; With the extensions added, we can populate the workspace.
-          (let [project-root-directory (workspace/project-path workspace)
+          (let [project-directory (workspace/project-directory workspace)
                 sparse-protobuf-content-by-proj-path (sparse-protobuf-content-by-proj-path workspace)
-                sparse-protobuf-content-by-absolute-file (with-absolute-file-keys project-root-directory sparse-protobuf-content-by-proj-path)
-                supplemental-save-values-by-absolute-file (with-absolute-file-keys project-root-directory supplemental-save-values-by-proj-path)]
+                sparse-protobuf-content-by-absolute-file (with-absolute-file-keys project-directory sparse-protobuf-content-by-proj-path)
+                supplemental-save-values-by-absolute-file (with-absolute-file-keys project-directory supplemental-save-values-by-proj-path)]
 
             ;; Ensure we have the parent directories in place for our content.
             (create-parent-directories! sparse-protobuf-content-by-absolute-file)

--- a/editor/test/integration/web_server_test.clj
+++ b/editor/test/integration/web_server_test.clj
@@ -90,7 +90,7 @@
     ;; editor resources: file->path
     (is (= {:status 200
             :headers {"content-type" "text/plain"}
-            :body (fs/path (g/valid-node-value workspace :root) "game.project")}
+            :body (fs/path (workspace/project-directory workspace) "game.project")}
            (http-server/response 200 (workspace/find-resource workspace "/game.project"))))
     ;; editor resources: zip as is
     (is (= {:status 200


### PR DESCRIPTION
### Technical changes
* Removed `workspace/project-path`, which took an `evaluation-context`.
* Replaced all calls to `workspace/project-path` with `workspace/project-directory`, which takes a `basis`.
* Replaced some instances where we were accessing the `:root` property of the `workspace` with calls to `workspace/project-directory`.