### PR TITLE
Sparse node property assignments

### DIFF
--- a/editor/project.clj
+++ b/editor/project.clj
@@ -219,9 +219,12 @@
                                            (.replace (System/getProperty "user.home") \\ \/)
                                            "/.m2/repository/com/github/jbellis/jamm/0.4.0/jamm-0.4.0.jar")
                                         "-Ddefold.jamm=true"
+                                        "--add-opens=java.base/java.util=ALL-UNNAMED"
                                         "--add-opens=java.base/java.util.function=ALL-UNNAMED"
                                         "--add-opens=java.base/java.util.regex=ALL-UNNAMED"
-                                        "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED"]}
+                                        "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED"
+                                        "--add-opens=java.net.http/jdk.internal.net.http=ALL-UNNAMED"
+                                        "--add-opens=java.net.http/jdk.internal.net.http.common=ALL-UNNAMED"]}
                       :no-asserts {:global-vars {*assert* false}}
                       :no-decorated-exceptions {:jvm-opts ["-Ddefold.exception.decorate.disable=true"]}
                       :no-schemas {:jvm-opts ["-Ddefold.schema.check.disable=true"]}

--- a/editor/src/clj/dynamo/graph.clj
+++ b/editor/src/clj/dynamo/graph.clj
@@ -114,6 +114,18 @@
 (defn node-override? [node]
   (some? (gt/original node)))
 
+(defn own-property-values
+  "Returns a map of property-label property-value for the specified node. If the
+  queried node is an override node, the map will contain overridden properties
+  only. Otherwise, the map will include assigned properties and defaults."
+  [node]
+  (or (if (node-override? node)
+        (gt/overridden-properties node)
+        (coll/merge
+          (in/defaults (gt/node-type node))
+          (gt/assigned-properties node)))
+      {}))
+
 (defn invalidate-counters
   "The current state of the invalidate counters in the system."
   []

--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -814,9 +814,9 @@
 (def ^:private node-type-deref->stripped-prop-kws (fn/memoize node-type-deref->stripped-prop-kws-raw))
 
 (defn- make-prop->value-for-default-layout [node]
-  (let [node-properties (gt/own-properties node)]
+  (let [node-properties (g/own-property-values node)]
     (if (coll/empty? node-properties)
-      {}
+      node-properties
       (let [node-type (g/node-type node)
             stripped-prop-kws (node-type-deref->stripped-prop-kws @node-type)]
         (persistent!
@@ -834,7 +834,7 @@
                   (if-let [override-node (g/node-by-id basis override-node-id)]
                     (reduce conj! node-properties (gt/overridden-properties override-node))
                     node-properties))
-                (transient (or (gt/own-properties root-node) {}))
+                (transient (g/own-property-values root-node))
                 override-node-ids)]
 
     (if (coll/empty? node-properties)

--- a/editor/src/clj/internal/graph/types.clj
+++ b/editor/src/clj/internal/graph/types.clj
@@ -92,7 +92,7 @@
   (node-type             [this]                          "Return the node type that created this node.")
   (get-property          [this basis property]           "Return the value of the named property")
   (set-property          [this basis property value]     "Set the named property")
-  (own-properties        [this]                          "Return a map of property name to value explicitly assigned to this node")
+  (assigned-properties   [this]                          "Return a map of property name to value explicitly assigned to this node")
   (overridden-properties [this]                          "Return a map of property name to override value")
   (property-overridden?  [this property]))
 

--- a/editor/src/clj/internal/transaction.clj
+++ b/editor/src/clj/internal/transaction.clj
@@ -640,20 +640,25 @@
   ;; activated, as we're doing this on a newly constructed node and ctx-add-node
   ;; will mark all our outputs activated regardless.
   (let [node-id (gt/node-id node)
-        node-type (gt/node-type node)
-        property-entries (gt/own-properties node)]
-    (reduce (fn [ctx property-entry]
-              (let [property-value (val property-entry)]
-                (if (nil? property-value)
-                  ctx
-                  (let [property-label (key property-entry)
-                        setter-fn (in/property-setter node-type property-label)]
-                    (validate-property-value node-type node-id property-label property-value)
-                    (if (nil? setter-fn)
-                      ctx
-                      (apply-tx ctx (call-setter-fn ctx property-label setter-fn (:basis ctx) node-id nil property-value)))))))
-            ctx
-            property-entries)))
+        node-type (gt/node-type node)]
+    (reduce
+      (fn [ctx [property-label property-value]]
+        (if (nil? property-value)
+          ctx
+          (let [setter-fn (in/property-setter node-type property-label)]
+            (validate-property-value node-type node-id property-label property-value)
+            (if (nil? setter-fn)
+              ctx
+              (apply-tx ctx (call-setter-fn ctx property-label setter-fn (:basis ctx) node-id nil property-value))))))
+      ctx
+      (if (some? (gt/original node))
+        (gt/overridden-properties node)
+        (let [default-property-values (in/defaults node-type)
+              assigned-property-values (gt/assigned-properties node)]
+          (e/map (fn [[property-label default-property-value]]
+                   (pair property-label
+                         (get assigned-property-values property-label default-property-value)))
+                 default-property-values))))))
 
 (defn- ctx-add-node [ctx node]
   (let [basis-after (gt/add-node (:basis ctx) node)

--- a/editor/test/internal/node_test.clj
+++ b/editor/test/internal/node_test.clj
@@ -34,7 +34,7 @@
   (property overridden-indirect           g/Str (default string-value)))
 
 (deftest node-property-defaults
-  (are [expected property] (= expected (get (g/construct WithDefaults) property))
+  (are [expected property] (= expected (gt/get-property (g/construct WithDefaults) (g/now) property))
        "o rly?"      :default-value
        "uff-da"      :overridden-indirect))
 
@@ -363,9 +363,9 @@
       (is (:string-property      (-> (g/construct BasicNode)         g/node-type g/declared-properties)))
       (is (:string-property      (-> (g/construct InheritsBasicNode) g/node-type g/declared-properties)))
       (is (:property-to-override (-> (g/construct InheritsBasicNode) g/node-type g/declared-properties)))
-      (is (= nil                 (-> (g/construct BasicNode)         :property-to-override)))
-      (is (= "override"          (-> (g/construct InheritsBasicNode) :property-to-override)))
-      (is (= "multiple"          (-> (g/construct InheritsBasicNode) :property-from-multiple)))))
+      (is (= nil                 (-> (g/construct BasicNode)         (gt/get-property (g/now) :property-to-override))))
+      (is (= "override"          (-> (g/construct InheritsBasicNode) (gt/get-property (g/now) :property-to-override))))
+      (is (= "multiple"          (-> (g/construct InheritsBasicNode) (gt/get-property (g/now) :property-from-multiple))))))
 
   (testing "transforms"
     (is (every? (-> (g/construct BasicNode) g/node-type g/output-labels)


### PR DESCRIPTION
Instead of assigning values for all properties in the node maps, we now look up the default values in a defaults map associated with the node type.

### Technical changes
* Renamed the `own-properties` method of the `Node` protocol to `assigned-properties` to reflect this change.
* Added `g/own-property-values` function that returns the equivalent result.
* Updated the list of opened Java modules in the `:jamm` Lein profile to make `mem/node-size-report` work again after recent changes.
* Improved `gu/node-debug-label` to distinguish between resource nodes and their overrides.
* You can no longer treat a `NodeImpl` instance like a Clojure map, because it won't contain values for defaults. This was arguably not the case before either, because it has the additional `:node-type` key, and it was never the case for `OverrideNode`. However, some older tests were using `keys` to test that the `NodeImpl` had all values assigned after construction.