### PR TITLE
Faster LU archive creation + Added option for compression level.  

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,4 @@ editor/.lsp/sqlite.db
 /com.dynamo.cr/com.dynamo.cr.bob/lib/**/wrap_oal*
 /com.dynamo.cr/out/
 /com.dynamo.cr/com.dynamo.cr.bob.test/test/proj/build/
+/com.dynamo.cr/test_resources/

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/archive/test/ArchiveTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/archive/test/ArchiveTest.java
@@ -24,7 +24,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/archive/test/ZipPublisherTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/archive/test/ZipPublisherTest.java
@@ -1,5 +1,6 @@
 package com.dynamo.bob.archive.test;
 
+import com.dynamo.bob.CompileExceptionError;
 import com.dynamo.bob.archive.ArchiveEntry;
 import com.dynamo.bob.archive.publisher.PublisherSettings;
 import com.dynamo.bob.archive.publisher.ZipPublisher;
@@ -57,9 +58,9 @@ public class ZipPublisherTest {
             // Step 2: Publish all ArchiveEntry objects
             long startPublishTime = System.currentTimeMillis();
             for (Map.Entry<String, AbstractMap.SimpleEntry<ArchiveEntry, byte[]>> entry : archiveMap.entrySet()) {
-                try (ByteArrayInputStream bais = new ByteArrayInputStream(entry.getValue().getValue())) {
-                    zipPublisher.publish(entry.getValue().getKey(), bais);
-                } catch (IOException e) {
+                try {
+                    zipPublisher.publish(entry.getValue().getKey(), entry.getValue().getValue());
+                } catch (CompileExceptionError e) {
                     fail("Error publishing entry: " + entry.getKey());
                 }
             }

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/archive/test/ZipPublisherTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/archive/test/ZipPublisherTest.java
@@ -1,0 +1,63 @@
+package com.dynamo.bob.archive.test;
+
+import com.dynamo.bob.archive.ArchiveEntry;
+import com.dynamo.bob.archive.publisher.PublisherSettings;
+import com.dynamo.bob.archive.publisher.ZipPublisher;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+
+public class ZipPublisherTest {
+
+    @Test
+    public void testCreateArchiveFromFolder() {
+        String projectRoot = "test_resources"; // Folder to read files from
+        String outputFilename = "test_archive.zip";
+        File inputFolder = new File(projectRoot);
+        assertTrue("Input folder does not exist " + inputFolder.getAbsolutePath(), inputFolder.exists() && inputFolder.isDirectory());
+
+        PublisherSettings settings = new PublisherSettings();
+        settings.setZipFilepath("output"); // Output folder for the zip archive
+        settings.setZipFilename(outputFilename);
+
+        ZipPublisher zipPublisher = new ZipPublisher(projectRoot, settings);
+        zipPublisher.setFilename(outputFilename);
+
+        try {
+            zipPublisher.start();
+            long startTime = System.currentTimeMillis();
+
+            File[] files = inputFolder.listFiles();
+            assertNotNull("No files found in the input folder", files);
+
+            for (File file : files) {
+                if (file.isFile()) {
+                    try (FileInputStream fis = new FileInputStream(file)) {
+                        ArchiveEntry entry = new ArchiveEntry(file.getParentFile().getAbsolutePath(), file.getAbsolutePath());
+                        zipPublisher.publish(entry, fis);
+                    } catch (IOException e) {
+                        fail("Error reading file: " + file.getAbsolutePath());
+                    }
+                }
+            }
+
+            zipPublisher.stop();
+            long endTime = System.currentTimeMillis();
+            long duration = endTime - startTime;
+
+            System.out.println("Archive created: " + zipPublisher.getZipFile().getAbsolutePath());
+            System.out.println("Time taken: " + duration + " s");
+
+            File outputZip = zipPublisher.getZipFile();
+            assertTrue("Zip file was not created", outputZip.exists());
+            assertTrue("Zip file is empty", outputZip.length() > 0);
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail("An error occurred during archiving: " + e.getMessage());
+        }
+    }
+}

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/archive/test/ZipPublisherTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/archive/test/ZipPublisherTest.java
@@ -5,15 +5,21 @@ import com.dynamo.bob.archive.ArchiveEntry;
 import com.dynamo.bob.archive.publisher.PublisherSettings;
 import com.dynamo.bob.archive.publisher.ZipPublisher;
 import org.junit.Test;
-import static org.junit.Assert.*;
 
-import java.io.ByteArrayInputStream;
+import java.io.BufferedInputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.util.AbstractMap;
-import java.util.HashMap;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ForkJoinPool;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class ZipPublisherTest {
 
@@ -25,7 +31,7 @@ public class ZipPublisherTest {
         assertTrue("Input folder does not exist " + inputFolder.getAbsolutePath(), inputFolder.exists() && inputFolder.isDirectory());
 
         PublisherSettings settings = new PublisherSettings();
-        settings.setZipFilepath("output"); // Output folder for the zip archive
+        settings.setZipFilepath(inputFolder.getAbsoluteFile().getParent()); // Output folder for the zip archive
         settings.setZipFilename(outputFilename);
 
         ZipPublisher zipPublisher = new ZipPublisher(projectRoot, settings);
@@ -36,44 +42,59 @@ public class ZipPublisherTest {
 
             // Step 1: Read files and create ArchiveEntry objects
             long startReadTime = System.currentTimeMillis();
-            Map<String, AbstractMap.SimpleEntry<ArchiveEntry, byte[]>> archiveMap = new HashMap<>();
-            File[] files = inputFolder.listFiles();
-            assertNotNull("No files found in the input folder", files);
+            List<Path> toZip = Arrays.asList(Path.of(inputFolder.getAbsolutePath()));
 
-            for (File file : files) {
-                if (file.isFile()) {
-                    try (FileInputStream fis = new FileInputStream(file)) {
-                        byte[] data = fis.readAllBytes();
-                        ArchiveEntry entry = new ArchiveEntry(file.getParentFile().getAbsolutePath(), file.getAbsolutePath());
-                        archiveMap.put(entry.getFilename(), new AbstractMap.SimpleEntry<>(entry, data));
-                    } catch (IOException e) {
-                        fail("Error reading file: " + file.getAbsolutePath());
+            var archiveMap = new ConcurrentHashMap<ArchiveEntry, byte[]>();
+            ForkJoinPool pool = ForkJoinPool.commonPool();
+            try {
+                toZip.forEach(root -> {
+                    try (var pathStream = Files.walk(root)) {
+                        pathStream.filter(o -> !Files.isDirectory(o)).forEach(
+                                path -> pool.execute(() -> {
+                                    BufferedInputStream fileStream = null;
+                                    File file = new File(String.valueOf(path));
+                                    try {
+                                        fileStream = new BufferedInputStream(Files.newInputStream(path));
+                                        ArchiveEntry entry = null;
+                                        entry = new ArchiveEntry(file.getParentFile().getAbsolutePath(), file.getAbsolutePath());
+                                        archiveMap.put(entry, fileStream.readAllBytes());
+                                    } catch (IOException e) {
+                                        throw new RuntimeException(e);
+                                    }
+                                }));
                     }
-                }
+                    catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                });
+                pool.awaitQuiescence(Long.MAX_VALUE, java.util.concurrent.TimeUnit.SECONDS);
+            } finally {
+                pool.shutdown(); // Manually close the pool
             }
+
             long endReadTime = System.currentTimeMillis();
             long readDuration = endReadTime - startReadTime;
             System.out.println("File reading and entry creation time: " + readDuration + " ms, Entries read: " + archiveMap.size());
 
             // Step 2: Publish all ArchiveEntry objects
             long startPublishTime = System.currentTimeMillis();
-            for (Map.Entry<String, AbstractMap.SimpleEntry<ArchiveEntry, byte[]>> entry : archiveMap.entrySet()) {
+            for (Map.Entry<ArchiveEntry, byte[]> entry : archiveMap.entrySet()) {
                 try {
-                    zipPublisher.publish(entry.getValue().getKey(), entry.getValue().getValue());
+                    zipPublisher.publish(entry.getKey(), entry.getValue());
                 } catch (CompileExceptionError e) {
                     fail("Error publishing entry: " + entry.getKey());
                 }
             }
-            long endPublishTime = System.currentTimeMillis();
-            long publishDuration = endPublishTime - startPublishTime;
-            System.out.println("Publishing time: " + publishDuration + " ms, Entries written: " + archiveMap.size());
-
             zipPublisher.stop();
 
             File outputZip = zipPublisher.getZipFile();
             assertTrue("Zip file was not created", outputZip.exists());
             assertTrue("Zip file is empty", outputZip.length() > 0);
             System.out.println("Archive created: " + zipPublisher.getZipFile().getAbsolutePath());
+
+            long endPublishTime = System.currentTimeMillis();
+            long publishDuration = endPublishTime - startPublishTime;
+            System.out.println("Publishing time: " + publishDuration + " ms, Entries written: " + archiveMap.size());
 
         } catch (Exception e) {
             e.printStackTrace();

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/archive/test/ZipPublisherTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/archive/test/ZipPublisherTest.java
@@ -24,8 +24,9 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class ZipPublisherTest {
-
-    @Test
+// This isn't a test really, this is setup for development to be able to iterate faster on the archiving
+// see https://github.com/defold/defold/issues/10012
+//    @Test
     public void testCreateArchiveFromFolder() throws IOException {
         String projectRoot = "test_resources"; // Folder to read files from
         String outputFilename = "test_archive.zip";

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/archive/ArchiveBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/archive/ArchiveBuilder.java
@@ -58,7 +58,7 @@ import net.jpountz.lz4.LZ4Factory;
 
 public class ArchiveBuilder {
 
-    private static final Logger logger = Logger.getLogger(ArchiveBuilder.class.getName());
+    private static Logger logger = Logger.getLogger(ArchiveBuilder.class.getName());
 
     public static final int VERSION = 5;
     public static final int HASH_MAX_LENGTH = 64; // 512 bits
@@ -147,6 +147,10 @@ public class ArchiveBuilder {
         return ResourceEncryption.encrypt(buffer);
     }
 
+    public void writeResourcePack(ArchiveEntry entry, byte[] buffer) throws IOException, CompileExceptionError {
+        publisher.publish(entry, buffer);
+    }
+
 
     public List<ArchiveEntry> getExcludedEntries() {
         return excludedEntries;
@@ -206,7 +210,7 @@ public class ArchiveBuilder {
                     .put(archiveEntryPadding) // 11 bytes
                     .array();
                 entry.setHeader(header);
-                this.publisher.publish(entry, buffer);
+                this.writeResourcePack(entry, buffer);
             }
             resourceEntryFlags |= ResourceEntryFlag.EXCLUDED.getNumber();
         } else {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/archive/ArchiveBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/archive/ArchiveBuilder.java
@@ -58,7 +58,7 @@ import net.jpountz.lz4.LZ4Factory;
 
 public class ArchiveBuilder {
 
-    private static Logger logger = Logger.getLogger(ArchiveBuilder.class.getName());
+    private static final Logger logger = Logger.getLogger(ArchiveBuilder.class.getName());
 
     public static final int VERSION = 5;
     public static final int HASH_MAX_LENGTH = 64; // 512 bits
@@ -147,10 +147,6 @@ public class ArchiveBuilder {
         return ResourceEncryption.encrypt(buffer);
     }
 
-    public void writeResourcePack(ArchiveEntry entry, byte[] buffer) throws IOException, CompileExceptionError {
-        publisher.publish(entry, buffer);
-    }
-
 
     public List<ArchiveEntry> getExcludedEntries() {
         return excludedEntries;
@@ -210,7 +206,7 @@ public class ArchiveBuilder {
                     .put(archiveEntryPadding) // 11 bytes
                     .array();
                 entry.setHeader(header);
-                this.writeResourcePack(entry, buffer);
+                this.publisher.publish(entry, buffer);
             }
             resourceEntryFlags |= ResourceEntryFlag.EXCLUDED.getNumber();
         } else {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/archive/publisher/Publisher.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/archive/publisher/Publisher.java
@@ -18,7 +18,6 @@ import java.io.IOException;
 import java.io.File;
 import java.io.InputStream;
 import java.io.FileInputStream;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/archive/publisher/Publisher.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/archive/publisher/Publisher.java
@@ -20,6 +20,7 @@ import java.io.InputStream;
 import java.io.FileInputStream;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import com.dynamo.bob.archive.ArchiveEntry;
 import com.dynamo.bob.CompileExceptionError;
@@ -27,7 +28,7 @@ import com.dynamo.bob.CompileExceptionError;
 public abstract class Publisher {
 
     private final PublisherSettings settings;
-    protected final Map<String, ArchiveEntry> entries = new HashMap<String, ArchiveEntry>();
+    protected final Map<String, ArchiveEntry> entries = new ConcurrentHashMap<>();
     protected String platform = "";
 
     public Publisher(PublisherSettings settings) {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/archive/publisher/PublisherSettings.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/archive/publisher/PublisherSettings.java
@@ -156,6 +156,10 @@ public class PublisherSettings {
         return value != null && value.equals("1");
     }
 
+    public int getCompressionLevel() {
+        return Integer.parseInt(this.getValue("liveupdate", "zip-compression-level"));
+    }
+
     private static PublisherSettings doLoad(InputStream in) throws IOException, ParseException {
         PublisherSettings settings = new PublisherSettings();
         BufferedReader reader = new BufferedReader(new InputStreamReader(in));

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/archive/publisher/PublisherSettings.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/archive/publisher/PublisherSettings.java
@@ -157,7 +157,10 @@ public class PublisherSettings {
     }
 
     public int getCompressionLevel() {
-        return Integer.parseInt(this.getValue("liveupdate", "zip-compression-level"));
+        if (this.getValue("liveupdate", "zip-compression-level") != null) {
+            return Integer.parseInt(this.getValue("liveupdate", "zip-compression-level"));
+        }
+        return 1;
     }
 
     private static PublisherSettings doLoad(InputStream in) throws IOException, ParseException {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/archive/publisher/ZipPublisher.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/archive/publisher/ZipPublisher.java
@@ -26,6 +26,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
@@ -38,6 +40,7 @@ public class ZipPublisher extends Publisher {
     private String projectRoot = null;
     private String filename = null;
     private ZipOutputStream zipOutputStream;
+    private Set<String> zipEntries =  new HashSet<>();
 
     public ZipPublisher(String projectRoot, PublisherSettings settings) {
         super(settings);
@@ -78,6 +81,7 @@ public class ZipPublisher extends Publisher {
                 this.destZipFile = new File(cwd, this.destZipFile.getPath());
             }
 
+            zipEntries.clear();
             entries.clear();
 
             BufferedOutputStream resourcePackOutputStream = new BufferedOutputStream(Files.newOutputStream(this.tempZipFile.toPath()));
@@ -115,8 +119,11 @@ public class ZipPublisher extends Publisher {
         final String archiveEntryHexdigest = entry.getHexDigest();
         final String archiveEntryName = entry.getName();
         final String zipEntryName = (archiveEntryHexdigest != null) ? archiveEntryHexdigest : archiveEntryName;
-        if (entries.put(archiveEntryName, entry) != null) {
-            return;
+        entries.put(archiveEntryName, entry);
+        synchronized (zipEntries) {
+            if (!zipEntries.add(zipEntryName)) {
+                return;
+            }
         }
         try {
             ZipEntry currentEntry = new ZipEntry(zipEntryName);
@@ -138,8 +145,11 @@ public class ZipPublisher extends Publisher {
         final String archiveEntryHexdigest = entry.getHexDigest();
         final String archiveEntryName = entry.getName();
         final String zipEntryName = (archiveEntryHexdigest != null) ? archiveEntryHexdigest : archiveEntryName;
-        if (entries.put(archiveEntryName, entry) != null) {
-            return;
+        entries.put(archiveEntryName, entry);
+        synchronized (zipEntries) {
+            if (!zipEntries.add(zipEntryName)) {
+                return;
+            }
         }
         try {
             ZipEntry currentEntry = new ZipEntry(zipEntryName);

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/archive/publisher/ZipPublisher.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/archive/publisher/ZipPublisher.java
@@ -42,7 +42,6 @@ public class ZipPublisher extends Publisher {
     private String projectRoot = null;
     private String filename = null;
     private ZipOutputStream zipOutputStream;
-    private Set<String> zipEntries =  new HashSet<>();
 
     public ZipPublisher(String projectRoot, PublisherSettings settings) {
         super(settings);
@@ -83,7 +82,7 @@ public class ZipPublisher extends Publisher {
                 this.destZipFile = new File(cwd, this.destZipFile.getPath());
             }
 
-            zipEntries.clear();
+            entries.clear();
 
             BufferedOutputStream resourcePackOutputStream = new BufferedOutputStream(Files.newOutputStream(this.tempZipFile.toPath()));
             zipOutputStream = new ZipOutputStream(resourcePackOutputStream);
@@ -119,10 +118,8 @@ public class ZipPublisher extends Publisher {
         final String archiveEntryHexdigest = entry.getHexDigest();
         final String archiveEntryName = entry.getName();
         final String zipEntryName = (archiveEntryHexdigest != null) ? archiveEntryHexdigest : archiveEntryName;
-        synchronized (zipEntries) {
-            if (!zipEntries.add(zipEntryName)) {
-                return;
-            }
+        if (entries.put(archiveEntryName, entry) != null) {
+            return;
         }
         try {
             ZipEntry currentEntry = new ZipEntry(zipEntryName);
@@ -144,11 +141,8 @@ public class ZipPublisher extends Publisher {
         final String archiveEntryHexdigest = entry.getHexDigest();
         final String archiveEntryName = entry.getName();
         final String zipEntryName = (archiveEntryHexdigest != null) ? archiveEntryHexdigest : archiveEntryName;
-        entries.put(archiveEntryName, entry);
-        synchronized (zipEntries) {
-            if (!zipEntries.add(zipEntryName)) {
-                return;
-            }
+        if (entries.put(archiveEntryName, entry) != null) {
+            return;
         }
         try {
             ZipEntry currentEntry = new ZipEntry(zipEntryName);

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/archive/publisher/ZipPublisher.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/archive/publisher/ZipPublisher.java
@@ -119,10 +119,9 @@ public class ZipPublisher extends Publisher {
         final String archiveEntryName = entry.getName();
         final String zipEntryName = (archiveEntryHexdigest != null) ? archiveEntryHexdigest : archiveEntryName;
         synchronized (zipEntries) {
-            if (zipEntries.contains(zipEntryName)) {
+            if (!zipEntries.add(zipEntryName)) {
                 return;
             }
-            zipEntries.add(zipEntryName);
         }
         try {
             ZipEntry currentEntry = new ZipEntry(zipEntryName);
@@ -130,7 +129,6 @@ public class ZipPublisher extends Publisher {
                 zipOutputStream.putNextEntry(currentEntry);
                 zipOutputStream.write(entry.getHeader());
                 data.transferTo(zipOutputStream);
-                zipOutputStream.flush();
                 zipOutputStream.closeEntry();
             }
         } catch (FileNotFoundException exception) {
@@ -147,10 +145,9 @@ public class ZipPublisher extends Publisher {
         final String zipEntryName = (archiveEntryHexdigest != null) ? archiveEntryHexdigest : archiveEntryName;
         entries.put(archiveEntryName, entry);
         synchronized (zipEntries) {
-            if (zipEntries.contains(zipEntryName)) {
+            if (!zipEntries.add(zipEntryName)) {
                 return;
             }
-            zipEntries.add(zipEntryName);
         }
         try {
             ZipEntry currentEntry = new ZipEntry(zipEntryName);
@@ -158,7 +155,6 @@ public class ZipPublisher extends Publisher {
                 zipOutputStream.putNextEntry(currentEntry);
                 zipOutputStream.write(entry.getHeader());
                 zipOutputStream.write(data);
-                zipOutputStream.flush();
                 zipOutputStream.closeEntry();
             }
         } catch (FileNotFoundException exception) {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/archive/publisher/ZipPublisher.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/archive/publisher/ZipPublisher.java
@@ -14,6 +14,11 @@
 
 package com.dynamo.bob.archive.publisher;
 
+import com.dynamo.bob.CompileExceptionError;
+import com.dynamo.bob.archive.ArchiveEntry;
+import com.dynamo.bob.logging.Logger;
+import org.apache.commons.io.IOUtils;
+
 import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -21,17 +26,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
-import java.util.Set;
-import java.util.HashSet;
-import java.util.zip.Deflater;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
-
-import org.apache.commons.io.IOUtils;
-
-import com.dynamo.bob.logging.Logger;
-import com.dynamo.bob.archive.ArchiveEntry;
-import com.dynamo.bob.CompileExceptionError;
 
 public class ZipPublisher extends Publisher {
 
@@ -86,6 +82,7 @@ public class ZipPublisher extends Publisher {
 
             BufferedOutputStream resourcePackOutputStream = new BufferedOutputStream(Files.newOutputStream(this.tempZipFile.toPath()));
             zipOutputStream = new ZipOutputStream(resourcePackOutputStream);
+            zipOutputStream.setLevel(settings.getCompressionLevel());
         } catch (IOException exception) {
             throw new CompileExceptionError("Unable to create zip archive for liveupdate resources: " + exception.getMessage(), exception);
         }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/archive/publisher/ZipPublisher.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/archive/publisher/ZipPublisher.java
@@ -14,15 +14,16 @@
 
 package com.dynamo.bob.archive.publisher;
 
+import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.util.Set;
 import java.util.HashSet;
+import java.util.zip.Deflater;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
@@ -84,7 +85,7 @@ public class ZipPublisher extends Publisher {
 
             zipEntries.clear();
 
-            FileOutputStream resourcePackOutputStream = new FileOutputStream(this.tempZipFile);
+            BufferedOutputStream resourcePackOutputStream = new BufferedOutputStream(Files.newOutputStream(this.tempZipFile.toPath()));
             zipOutputStream = new ZipOutputStream(resourcePackOutputStream);
         } catch (IOException exception) {
             throw new CompileExceptionError("Unable to create zip archive for liveupdate resources: " + exception.getMessage(), exception);

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/archive/publisher/ZipPublisher.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/archive/publisher/ZipPublisher.java
@@ -95,6 +95,7 @@ public class ZipPublisher extends Publisher {
     @Override
     public void stop() throws CompileExceptionError {
         try {
+            zipOutputStream.flush();
             IOUtils.closeQuietly(zipOutputStream);
 
             // make sure parent directories exist

--- a/editor/resources/live-update-meta.edn
+++ b/editor/resources/live-update-meta.edn
@@ -37,6 +37,14 @@
    :default ""
    :presentation-category "Zip"
    :path ["liveupdate" "zip-filename"]}
+  {:type :integer,
+   :title "Zip archive compression level"
+   :help "compression level will be used when creating LiveUpdate zip archive",
+   :default 1,
+   :minimum 0,
+   :maximum 9,
+   :presentation-category "Zip"
+   :path ["liveupdate" "zip-compression-level"]}
   {:type :file,
    :title "Select Manifest Public Key"
    :filter [["Public key (*.der)" "*.der"]]

--- a/editor/test/resources/save_data_project/liveupdate.settings
+++ b/editor/test/resources/save_data_project/liveupdate.settings
@@ -5,6 +5,7 @@ amazon-bucket = bucket
 amazon-prefix = prefix
 zip-filepath = zip_file_path
 zip-filename = zip_filename
+zip-compression-level = 2
 save-zip-in-bundle-folder = true
 supported-versions = "1.2.3"
 publickey = referenced/liveupdate_manifest_public.der


### PR DESCRIPTION
A new option was added to the LiveUpdate settings: ZIP archive compression level, with levels ranging from 0 to 9.  
The default level is 1 (the same as before the changes).
This option is useful in cases where compression is not needed at all—e.g., when Poki repacks the archive and applies their own compression.  In such cases, using level 0 will significantly speed up archive creation and the bundling process.  
Additionally, the archive writer itself was improved, making archive creation at least twice as fast (regardless of whether compression is used or not).

On a test suite with 172,296 files, which were used for benchmarking on a Mac M1 Pro Max:  

- Archive creation before changes (level 1 compression): **56 seconds**  
- With performance improvements and default level 1 compression: **28 seconds**  
- With performance improvements and level 0 compression: **1.8 seconds**  

Fix https://github.com/defold/defold/issues/10012