### PR TITLE
Remove some unrealized sequences from the graph and elsewhere

### DIFF
--- a/editor/src/clj/editor/pipeline.clj
+++ b/editor/src/clj/editor/pipeline.clj
@@ -90,10 +90,10 @@
               :user-data {:pb-class pb-class
                           :pb-map pb-map}}
 
-             dep-build-targets
+             (coll/not-empty dep-build-targets)
              (assoc :deps dep-build-targets)
 
-             dynamic-deps
+             (coll/not-empty dynamic-deps)
              (assoc :dynamic-deps dynamic-deps)))))
 
 ;;--------------------------------------------------------------------

--- a/editor/src/clj/editor/scene_shapes.clj
+++ b/editor/src/clj/editor/scene_shapes.clj
@@ -196,22 +196,22 @@
         capsule-cap-longs 32
         sphere-faces (geom/unit-sphere-pos-nrm capsule-cap-lats capsule-cap-longs)
         hemisphere-face-count (/ (* capsule-cap-lats capsule-cap-longs) 2)]
-    (concat
-      ;; Top cap
-      (sequence (comp (take hemisphere-face-count)
-                      (map #(pos-nrm-face->quad % 1.0)))
-                sphere-faces)
+    (vec (concat
+           ;; Top cap
+           (sequence (comp (take hemisphere-face-count)
+                           (map #(pos-nrm-face->quad % 1.0)))
+                     sphere-faces)
 
-      ;; Waist
-      (sequence (comp (drop hemisphere-face-count)
-                      (take capsule-cap-longs)
-                      (map pos-nrm-face->waist-quad))
-                sphere-faces)
+           ;; Waist
+           (sequence (comp (drop hemisphere-face-count)
+                           (take capsule-cap-longs)
+                           (map pos-nrm-face->waist-quad))
+                     sphere-faces)
 
-      ;; Bottom cap
-      (sequence (comp (drop hemisphere-face-count)
-                      (map #(pos-nrm-face->quad % -1.0)))
-                sphere-faces))))
+           ;; Bottom cap
+           (sequence (comp (drop hemisphere-face-count)
+                           (map #(pos-nrm-face->quad % -1.0)))
+                     sphere-faces)))))
 
 (defn- pos-vtx-put-point! [vbuf ^Point4d point]
   (pos-vtx-put! vbuf (.x point) (.y point) (.z point) (.w point)))

--- a/editor/src/clj/internal/history.clj
+++ b/editor/src/clj/internal/history.clj
@@ -35,12 +35,11 @@
   (count [this]   (+ (count left) (count right)))
   (cons  [this o] (PaperTape. limit limiter on-drop (limiter (conj left o)) []))
   (empty [this]   (PaperTape. limit limiter on-drop [] []))
-  (equiv [this o] (let [is-paper-tape? (and (instance? PaperTape o) o)
-                        ^PaperTape that (when is-paper-tape? o)]
-                    (when that
-                      (= limit (.limit that))
-                      (= left  (.left that))
-                      (= right (.right that)))))
+  (equiv [this o] (and (instance? PaperTape o)
+                       (let [^PaperTape that o]
+                         (and (= limit (.limit that))
+                              (= left (.left that))
+                              (= right (.right that))))))
 
   Iterator
   ;; Move one from right to left

--- a/editor/src/clj/util/eduction.clj
+++ b/editor/src/clj/util/eduction.clj
@@ -14,12 +14,16 @@
 
 (ns util.eduction
   (:refer-clojure :exclude [cat concat conj cons dedupe distinct drop drop-while filter interpose keep keep-indexed map map-indexed mapcat partition-all partition-by random-sample remove replace take take-nth take-while])
-  (:require [util.array :as array]))
+  (:require [util.array :as array])
+  (:import [clojure.core Eduction]))
 
 (set! *warn-on-reflection* true)
 (set! *unchecked-math* :warn-on-boxed)
 
 (defonce empty-eduction (eduction))
+
+(defn eduction? [value]
+  (instance? Eduction value))
 
 (definline cat [coll]
   `(->Eduction
@@ -122,6 +126,11 @@
 (definline mapcat [f coll]
   `(->Eduction
      (clojure.core/mapcat ~f)
+     ~coll))
+
+(definline mapcat-indexed [f coll]
+  `(->Eduction
+     (comp (clojure.core/map-indexed ~f) clojure.core/cat)
      ~coll))
 
 (definline partition-all [n coll]

--- a/editor/test/util/eduction_test.clj
+++ b/editor/test/util/eduction_test.clj
@@ -14,6 +14,7 @@
 
 (ns util.eduction-test
   (:require [clojure.test :refer :all]
+            [util.coll :as coll]
             [util.eduction :as e])
   (:import [clojure.core Eduction]))
 
@@ -24,6 +25,21 @@
 
 ;; Note: Equality checks are performed twice to root out issues from repeat
 ;; evaluation of the eduction.
+
+(deftest eduction?-test
+  (is (true? (e/eduction? (eduction identity nil))))
+  (is (false? (e/eduction? nil)))
+  (is (false? (e/eduction? "a")))
+  (is (false? (e/eduction? [1])))
+  (is (false? (e/eduction? (vector-of :long 1))))
+  (is (false? (e/eduction? '(1))))
+  (is (false? (e/eduction? #{1})))
+  (is (false? (e/eduction? (sorted-set 1))))
+  (is (false? (e/eduction? (double-array 1))))
+  (is (false? (e/eduction? (object-array 1))))
+  (is (false? (e/eduction? (range 1))))
+  (is (false? (e/eduction? (repeatedly 1 rand))))
+  (is (false? (e/eduction? (sequence (map identity) (range 1))))))
 
 (deftest cat-test
   (let [expected (sequence cat [(range 0 3) (range 3 5)])
@@ -149,6 +165,13 @@
 (deftest mapcat-test
   (let [expected (mapcat range [0 1 2 3 4])
         actual (e/mapcat range [0 1 2 3 4])]
+    (is (eduction? actual))
+    (is (= expected actual))
+    (is (= expected actual))))
+
+(deftest mapcat-indexed-test
+  (let [expected (coll/mapcat-indexed repeat [0 1 2 3 4])
+        actual (e/mapcat-indexed repeat [0 1 2 3 4])]
     (is (eduction? actual))
     (is (= expected actual))
     (is (= expected actual))))


### PR DESCRIPTION
We generally want to avoid storing references to lazy sequences and eductions, since these may hold on to various large objects and prevent them from being garbage collected.

### Technical changes
* Converted various eductions and lazy sequences into vectors.
* Fixed `PaperTape` equivalence check throwing when compared to a non-`PaperTape` object.
* Added `eduction/eduction?` function.
* Added `eduction/mapcat-indexed` function.

