### PR TITLE
Added `--keep-bob-uncompressed` for bob to speedup development

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/build.gradle
+++ b/com.dynamo.cr/com.dynamo.cr.bob/build.gradle
@@ -6,7 +6,7 @@ allprojects {
     tasks.withType(Jar) {
         exclude('tmp/**')
         includeEmptyDirs = false
-        if (project.hasProperty('uncompressed')) {
+        if (project.hasProperty('keep-bob-uncompressed')) {
             entryCompression = ZipEntryCompression.STORED
         }
     }

--- a/com.dynamo.cr/com.dynamo.cr.bob/build.gradle
+++ b/com.dynamo.cr/com.dynamo.cr.bob/build.gradle
@@ -6,6 +6,9 @@ allprojects {
     tasks.withType(Jar) {
         exclude('tmp/**')
         includeEmptyDirs = false
+        if (project.hasProperty('uncompressed')) {
+            entryCompression = ZipEntryCompression.STORED
+        }
     }
     tasks.withType(Zip) {
         includeEmptyDirs = false

--- a/editor/README_BUILD.md
+++ b/editor/README_BUILD.md
@@ -54,7 +54,7 @@ cd defold
 ./scripts/build.py build_docs
 
 # Build Bob
-./scripts/build.py build_bob --skip-tests --uncompressed
+./scripts/build.py build_bob --skip-tests --keep-bob-uncompressed
 
 # Change directory to the editor subdirectory
 cd editor

--- a/editor/README_BUILD.md
+++ b/editor/README_BUILD.md
@@ -54,7 +54,7 @@ cd defold
 ./scripts/build.py build_docs
 
 # Build Bob
-./scripts/build.py build_bob --skip-tests
+./scripts/build.py build_bob --skip-tests --uncompressed
 
 # Change directory to the editor subdirectory
 cd editor

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -410,7 +410,7 @@ class Configuration(object):
                  dynamo_home = None,
                  target_platform = None,
                  skip_tests = False,
-                 uncompressed = False,
+                 keep_bob_uncompressed = False,
                  skip_codesign = False,
                  skip_docs = False,
                  incremental = False,
@@ -459,7 +459,7 @@ class Configuration(object):
         self.build_utility = BuildUtility.BuildUtility(self.target_platform, self.host, self.dynamo_home)
 
         self.skip_tests = skip_tests
-        self.uncompressed = uncompressed
+        self.keep_bob_uncompressed = keep_bob_uncompressed
         self.skip_codesign = skip_codesign
         self.skip_docs = skip_docs
         self.incremental = incremental
@@ -1380,7 +1380,7 @@ class Configuration(object):
         env['GRADLE_OPTS'] = '-Dorg.gradle.parallel=true' #-Dorg.gradle.daemon=true
 
         # Clean and build the project
-        s = run.command(" ".join([gradle, '-Puncompressed', 'clean', 'installBobLight'] + gradle_args), cwd = bob_dir, shell = True, env = env)
+        s = run.command(" ".join([gradle, '-Pkeep-bob-uncompressed', 'clean', 'installBobLight'] + gradle_args), cwd = bob_dir, shell = True, env = env)
         if self.verbose:
         	print (s)
 
@@ -1558,8 +1558,8 @@ class Configuration(object):
 
         env['GRADLE_OPTS'] = '-Dorg.gradle.parallel=true' #-Dorg.gradle.daemon=true
         flags = ''
-        if self.uncompressed:
-            flags = '-Puncompressed'
+        if self.keep_bob_uncompressed:
+            flags = '-Pkeep-bob-uncompressed'
 
         # Clean and build the project
         run.command(" ".join([gradle, flags, 'clean', 'install'] + gradle_args), cwd=bob_dir, shell = True, env = env)
@@ -2575,7 +2575,7 @@ To pass on arbitrary options to waf: build.py OPTIONS COMMANDS -- WAF_OPTIONS
                       default = False,
                       help = 'Skip unit-tests. Default is false')
 
-    parser.add_option('--uncompressed', dest='uncompressed',
+    parser.add_option('--keep-bob-uncompressed', dest='keep_bob_uncompressed',
                     action = 'store_true',
                     default = False,
                     help = 'do not apply compression to bob.jar. Default is false')
@@ -2723,7 +2723,7 @@ To pass on arbitrary options to waf: build.py OPTIONS COMMANDS -- WAF_OPTIONS
     c = Configuration(dynamo_home = os.environ.get('DYNAMO_HOME', None),
                       target_platform = target_platform,
                       skip_tests = options.skip_tests,
-                      uncompressed = options.uncompressed,
+                      keep_bob_uncompressed = options.keep_bob_uncompressed,
                       skip_codesign = options.skip_codesign,
                       skip_docs = options.skip_docs,
                       incremental = options.incremental,


### PR DESCRIPTION
New flag for bob development that speed up bob building twice from the terminal:
> ./scripts/build.py build_bob --skip-tests --keep-bob-uncompressed

and 10 times using gradle daemon (e.g. IDEA):
![CleanShot 2025-04-09 at 15 37 36@2x](https://github.com/user-attachments/assets/a21c721d-ba2b-4f00-a45b-6ae0d8e87ea6)


