### PR TITLE
Added dynamic profiling scope for extensions

### DIFF
--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -1800,7 +1800,7 @@ bail:
                 dmJobThread::Update(engine->m_JobThreadContext);
 
                 {
-                    DM_PROFILE("Script");
+                    DM_PROFILE("Extension");
 
                     // Script context updates
                     dmGameSystem::ScriptLibContext script_lib_context;

--- a/engine/extension/src/extension.cpp
+++ b/engine/extension/src/extension.cpp
@@ -328,6 +328,7 @@ namespace dmExtension
         while (ed) {
             if (ed->m_Update && ed->m_Initialized)
             {
+                DM_PROFILE_DYN(ed->m_Name, 0);
                 ExtensionResult r = ed->m_Update(params);
                 if (r != EXTENSION_RESULT_OK) {
                     dmLogError("Failed to update extension: %s", ed->m_Name);

--- a/engine/extension/src/extension.cpp
+++ b/engine/extension/src/extension.cpp
@@ -16,8 +16,8 @@
 #include <dlib/log.h>
 #include <dlib/hashtable.h>
 #include <dlib/static_assert.h>
-#include <dlib/profile/profile.h>
 
+#include <dmsdk/dlib/profile.h>
 #include <dmsdk/extension/extension.h>
 #include "extension.hpp"
 

--- a/engine/extension/src/extension.cpp
+++ b/engine/extension/src/extension.cpp
@@ -16,7 +16,7 @@
 #include <dlib/log.h>
 #include <dlib/hashtable.h>
 #include <dlib/static_assert.h>
-#include <dmsdk/extension/extension.h>
+#include <dlib/profile/profile.h>
 
 #include <dmsdk/extension/extension.h>
 #include "extension.hpp"


### PR DESCRIPTION
Added per profiling scopes per extension update.

Example using profiler.dump_frame() shows the `Extension` scope and `WebView`, `LiveUpdate` and `Profiler` extensions:

```
INFO:PROFILER: Profiler threads:
INFO:PROFILER:     Thread 'sound': 0.000001
INFO:PROFILER:     'UpdateInternal': time: 0.001 ms self: 0.001 ms  count: 1
INFO:PROFILER:     Thread 'Main': 0.006706
INFO:PROFILER:     'Step': time: 6.706 ms self: 0.007 ms  count: 1
INFO:PROFILER:         'Frame': time: 6.699 ms self: 0.328 ms  count: 1
INFO:PROFILER:             'Sim': time: 0.563 ms self: 0.050 ms  count: 1
INFO:PROFILER:                 'Resource': time: 0.001 ms self: 0.001 ms  count: 1
INFO:PROFILER:                     'UpdateFactory': time: 0.000 ms self: 0.000 ms  count: 1
INFO:PROFILER:                         'JobThreadUpdate': time: 0.000 ms self: 0.000 ms  count: 1
INFO:PROFILER:                 'Hid': time: 0.207 ms self: 0.207 ms  count: 1
INFO:PROFILER:                 'JobThreadUpdate': time: 0.000 ms self: 0.000 ms  count: 1
INFO:PROFILER:                 'Extension': time: 0.082 ms self: 0.003 ms  count: 1
INFO:PROFILER:                     'WebView': time: 0.000 ms self: 0.000 ms  count: 1
INFO:PROFILER:                     'LiveUpdate': time: 0.001 ms self: 0.000 ms  count: 1
INFO:PROFILER:                         'LiveUpdate': time: 0.001 ms self: 0.001 ms  count: 1
INFO:PROFILER:                             'JobThreadUpdate': time: 0.000 ms self: 0.000 ms  count: 1
INFO:PROFILER:                     'Profiler': time: 0.078 ms self: 0.078 ms  count: 1
INFO:PROFILER:                 'Sound': time: 0.000 ms self: 0.000 ms  count: 1
```

Fixes #10435

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
