### PR TITLE
Throw a Lua error if `nil` passed into `go.delete()` function

### DIFF
--- a/engine/gameobject/src/gameobject/gameobject_script.cpp
+++ b/engine/gameobject/src/gameobject/gameobject_script.cpp
@@ -1935,7 +1935,7 @@ namespace dmGameObject
             }
             else if(lua_isnil(L, 1))
             {
-                return luaL_error(L, "The url shouldn't be `nil`");
+                return luaL_error(L, "go.delete() invoked with first argument 'id' set to 'nil'");
             }
         }
 

--- a/engine/gameobject/src/gameobject/gameobject_script.cpp
+++ b/engine/gameobject/src/gameobject/gameobject_script.cpp
@@ -1935,7 +1935,7 @@ namespace dmGameObject
             }
             else if(lua_isnil(L, 1))
             {
-                dmLogWarning("go.delete() invoked with nil and self will be deleted");
+                return luaL_error(L, "The url shouldn't be `nil`");
             }
         }
 


### PR DESCRIPTION
⚠️ Passing `nil` to `go.delete()` results in a Lua error, as this aligns with expected behavior and helps catch logical issues in the code.

Fix https://github.com/defold/defold/issues/10428