### PR TITLE
Create GUI dependencies on drop 

### DIFF
--- a/editor/src/clj/editor/asset_browser.clj
+++ b/editor/src/clj/editor/asset_browser.clj
@@ -691,6 +691,9 @@
 (defn- drag-detected [^MouseEvent e selection]
   (let [resources (roots selection)
         files (fileify-resources! resources)
+        paths (->> resources
+                   (mapv resource/proj-path)
+                   (string/join "\n"))
         ;; Note: It would seem we should use the TransferMode/COPY_OR_MOVE mode
         ;; here in order to support making copies of non-readonly files, but
         ;; that results in every drag operation becoming a copy on macOS due to
@@ -707,6 +710,7 @@
       (.setDragView db (icons/get-image (workspace/resource-icon (first resources)) 16)
                     0 16))
     (.putFiles content files)
+    (.putString content paths)
     (.setContent db content)
     (.consume e)))
 

--- a/editor/src/clj/editor/atlas.clj
+++ b/editor/src/clj/editor/atlas.clj
@@ -1232,7 +1232,8 @@
                           ui-context (first (ui/node-contexts image-view false))
                           {:keys [app-view selection workspace]} (:env ui-context)]
                       (when-let [parent (parent-animation-or-atlas selection)]
-                        (let [image-resources (workspace/get-resources-from-files files workspace (partial filter-image-files workspace))
+                        (let [image-resources (->> (filter-image-files workspace files)
+                                                   (workspace/get-resources-from-files workspace))
                               op-seq (gensym)
                               image-nodes (create-dropped-images! parent image-resources op-seq)
                               drag-event ^DragEvent (:event action)]

--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -2634,20 +2634,13 @@
   (g/make-nodes (g/node-id->graph-id scene) [node [MaterialNode :name name :material resource]]
     (attach-material scene materials-node node)))
 
-(defn new-material-resource? [parent resource]
-  (->> (g/node-value parent :child-outlines)
-       (map :node-id)
-       (not-any? #(= (resource/resource->proj-path resource)
-                     (when-let [mat-res (g/node-value % :material-resource)]
-                       (resource/resource->proj-path mat-res))))))
-
 (defn- add-materials-handler [project {:keys [scene parent]} select-fn]
   (query-and-add-resources!
    "Materials" ["material"]
    (g/node-value parent :name-counts)
    project select-fn
    (partial add-material scene parent)
-   (partial new-material-resource? parent)))
+   (partial new-resource? parent)))
 
 (g/defnode MaterialsNode
   (inherits outline/OutlineNode)

--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -2519,15 +2519,23 @@
   (output template-build-targets g/Any (gu/passthrough template-build-targets)))
 
 
-(defn- browse [title project exts]
-  (seq (resource-dialog/make (project/workspace project) project {:ext exts :title title :selection :multiple})))
+(defn- browse [title project exts accept-fn]
+  (seq (resource-dialog/make (project/workspace project) project {:ext exts
+                                                                  :title title
+                                                                  :accept-fn accept-fn
+                                                                  :selection :multiple})))
 
 (defn- resource->id [resource]
   (resource/base-name resource))
 
+(defn new-resource? [parent resource]
+  (->> (g/node-value parent :child-outlines)
+       (map :link)
+       (not-any? #{resource})))
+
 ;; SDK api
-(defn query-and-add-resources! [resources-type-label resource-exts taken-ids project select-fn make-node-fn]
-  (when-let [resources (browse (str "Select " resources-type-label) project resource-exts)]
+(defn query-and-add-resources! [resources-type-label resource-exts taken-ids parent project select-fn make-node-fn]
+  (when-let [resources (browse (str "Select " resources-type-label) project resource-exts (partial new-resource? parent))]
     (let [names (outline/resolve-ids (map resource->id resources) taken-ids)
           pairs (map vector resources names)
           op-seq (gensym)
@@ -2574,7 +2582,10 @@
 
 (defn- add-textures-handler [project {:keys [scene parent]} select-fn]
   (query-and-add-resources!
-   "Textures" (workspace/resource-kind-extensions (project/workspace project) :atlas) (g/node-value parent :name-counts) project select-fn
+   "Textures"
+   (workspace/resource-kind-extensions (project/workspace project) :atlas)
+   (g/node-value parent :name-counts)
+   parent project select-fn
    (partial add-texture scene parent)))
 
 (g/defnode TexturesNode
@@ -2619,8 +2630,10 @@
 
 (defn- add-materials-handler [project {:keys [scene parent]} select-fn]
   (query-and-add-resources!
-    "Materials" ["material"] (g/node-value parent :name-counts) project select-fn
-    (partial add-material scene parent)))
+   "Materials" ["material"]
+   (g/node-value parent :name-counts)
+   parent project select-fn
+   (partial add-material scene parent)))
 
 (g/defnode MaterialsNode
   (inherits outline/OutlineNode)
@@ -2661,7 +2674,9 @@
 
 (defn- add-fonts-handler [project {:keys [scene parent]} select-fn]
   (query-and-add-resources!
-   "Fonts" ["font"] (g/node-value parent :name-counts) project select-fn
+   "Fonts" ["font"]
+   (g/node-value parent :name-counts)
+   parent project select-fn
    (partial add-font scene parent)))
 
 (g/defnode FontsNode
@@ -2801,7 +2816,9 @@
 
 (defn- add-particlefx-resources-handler [project {:keys [scene parent]} select-fn]
   (query-and-add-resources!
-   "Particle FX" [particlefx/particlefx-ext] (g/node-value parent :name-counts) project select-fn
+   "Particle FX" [particlefx/particlefx-ext]
+   (g/node-value parent :name-counts)
+   parent project select-fn
    (partial add-particlefx-resource scene parent)))
 
 (g/defnode ParticleFXResources
@@ -3944,16 +3961,20 @@
         gen-name #(->> (g/node-value (g/node-value scene %) :name-counts)
                        (outline/resolve-id base-name))]
     (cond
-      (= ext "particlefx")
+      (and (= ext "particlefx")
+           (new-resource? (g/node-value scene :particlefx-resources-node) resource))
       (add-particlefx-resource scene (g/node-value scene :particlefx-resources-node) resource (gen-name :particlefx-resources-node))
 
-      (= ext "font")
+      (and (= ext "font")
+           (new-resource? (g/node-value scene :fonts-node) resource))
       (add-font scene (g/node-value scene :fonts-node) resource (gen-name :fonts-node))
 
-      (some #{ext} (workspace/resource-kind-extensions workspace :atlas))
+      (and (some #{ext} (workspace/resource-kind-extensions workspace :atlas))
+           (new-resource? (g/node-value scene :textures-node) resource))
       (add-texture scene (g/node-value scene :textures-node) resource (gen-name :textures-node))
 
-      (= ext "material")
+      (and (= ext "material")
+           (new-resource? (g/node-value scene :materials-node) resource))
       (add-material scene (g/node-value scene :materials-node) resource (gen-name :materials-node))
 
       :else

--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -2634,13 +2634,20 @@
   (g/make-nodes (g/node-id->graph-id scene) [node [MaterialNode :name name :material resource]]
     (attach-material scene materials-node node)))
 
+(defn new-material-resource? [parent resource]
+  (->> (g/node-value parent :child-outlines)
+       (map :node-id)
+       (not-any? #(= (resource/resource->proj-path resource)
+                     (when-let [mat-res (g/node-value % :material-resource)]
+                       (resource/resource->proj-path mat-res))))))
+
 (defn- add-materials-handler [project {:keys [scene parent]} select-fn]
   (query-and-add-resources!
    "Materials" ["material"]
    (g/node-value parent :name-counts)
    project select-fn
    (partial add-material scene parent)
-   (partial new-resource? parent)))
+   (partial new-material-resource? parent)))
 
 (g/defnode MaterialsNode
   (inherits outline/OutlineNode)

--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -3961,15 +3961,15 @@
 
 (defn- handle-drop
   [action op-seq]
-  (let [{:keys [files gesture-target]} action
+  (let [{:keys [string gesture-target]} action
         ui-context (first (ui/node-contexts gesture-target false))
         {:keys [selection workspace]} (:env ui-context)
-        resources (workspace/get-resources-from-files workspace files)
-        add-resource (partial add-dropped-resource selection workspace)]
+        resources (->> (str/split-lines string)
+                       (keep (partial workspace/resolve-workspace-resource workspace)))]
     (g/tx-nodes-added
       (g/transact
         (concat
-          (keep add-resource resources)
+          (mapv (partial add-dropped-resource selection workspace) resources)
           (g/operation-sequence op-seq))))))
 
 (defn- register [workspace def]

--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -3943,7 +3943,7 @@
       "font" (add-font scene (g/node-value scene :fonts-node) resource resource-name)
       nil)))
 
-(defn handle-drop
+(defn- handle-drop
   [action op-seq]
   (let [{:keys [files gesture-target]} action
         ui-context (first (ui/node-contexts gesture-target false))

--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -47,6 +47,7 @@
             [editor.scene-tools :as scene-tools]
             [editor.texture-set :as texture-set]
             [editor.types :as types]
+            [editor.ui :as ui]
             [editor.util :as eutil]
             [editor.validation :as validation]
             [editor.workspace :as workspace]
@@ -61,7 +62,6 @@
            [com.jogamp.opengl GL GL2]
            [editor.gl.shader ShaderLifecycle]
            [editor.gl.texture TextureLifecycle]
-           [editor.pose Pose]
            [internal.graph.types Arc]
            [java.awt.image BufferedImage]
            [javax.vecmath Quat4d]))
@@ -3934,6 +3934,17 @@
         (protobuf/assign-repeated :resources merged-resource-descs)
         (update :material #(or % default-material-proj-path)))))
 
+(defn- add-dropped-resource
+  [scene selection op-seq resource]
+  (let [ext (resource/ext resource)]
+    ))
+
+(defn handle-drop
+  [files selection workspace op-seq]
+  (let [scene (ui/main-scene)
+        resources (workspace/get-resources-from-files files workspace identity)]
+    (mapv (partial add-dropped-resource scene selection op-seq) resources)))
+
 (defn- register [workspace def]
   (let [ext (:ext def)
         exts (if (vector? ext) ext [ext])]
@@ -3953,7 +3964,8 @@
         :tag-opts (:tag-opts def)
         :template (:template def)
         :view-types [:scene :text]
-        :view-opts {:scene {:grid true}}))))
+        :view-opts {:scene {:grid true
+                            :drop-fn handle-drop}}))))
 
 (defn register-resource-types [workspace]
   (register workspace pb-def))

--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -2348,15 +2348,13 @@
 
   (output node-id+child-index NodeIndex (g/fnk [_node-id child-index] [_node-id child-index]))
   (output name+child-index NameIndex (g/fnk [name child-index] [name child-index]))
-  (output node-outline outline/OutlineData :cached (g/fnk [_node-id name material-resource child-index build-errors]
-                                                     (cond-> {:node-id _node-id
-                                                              :node-outline-key name
-                                                              :label name
-                                                              :icon layer-icon
-                                                              :child-index child-index
-                                                              :outline-error? (g/error-fatal? build-errors)}
-                                                       (resource/resource? material-resource)
-                                                       (assoc :link material-resource :outline-show-link? true))))
+  (output node-outline outline/OutlineData :cached (g/fnk [_node-id name child-index build-errors]
+                                                     {:node-id _node-id
+                                                      :node-outline-key name
+                                                      :label name
+                                                      :icon layer-icon
+                                                      :child-index child-index
+                                                      :outline-error? (g/error-fatal? build-errors)}))
   (input dep-build-targets g/Any)
   (output dep-build-targets g/Any (gu/passthrough dep-build-targets))
   (output pb-msg g/Any (g/fnk [name material-resource]
@@ -2536,28 +2534,26 @@
        (not-any? #{resource})))
 
 ;; SDK api
-(defn query-and-add-resources!
-  ([resources-type-label resource-exts taken-ids project select-fn make-node-fn]
-   (query-and-add-resources! resources-type-label resource-exts taken-ids project select-fn make-node-fn fn/constantly-true))
-  ([resources-type-label resource-exts taken-ids project select-fn make-node-fn accept-fn]
-   (when-let [resources (browse (str "Select " resources-type-label) project resource-exts accept-fn)]
-     (let [names (outline/resolve-ids (map resource->id resources) taken-ids)
-           pairs (map vector resources names)
-           op-seq (gensym)
-           op-label (str "Add " resources-type-label)
-           new-nodes (g/tx-nodes-added
-                      (g/transact
-                       (concat
-                        (g/operation-sequence op-seq)
-                        (g/operation-label op-label)
-                        (for [[resource name] pairs]
-                          (make-node-fn resource name)))))]
-       (when (some? select-fn)
-         (g/transact
-          (concat
-           (g/operation-sequence op-seq)
-           (g/operation-label op-label)
-           (select-fn new-nodes))))))))
+(defn query-and-add-resources! [resources-type-label resource-exts taken-ids project select-fn make-node-fn & [parent]]
+  (let [accept-fn (if parent (partial new-resource? parent) fn/constantly-true)]
+    (when-let [resources (browse (str "Select " resources-type-label) project resource-exts accept-fn)]
+      (let [names (outline/resolve-ids (map resource->id resources) taken-ids)
+            pairs (map vector resources names)
+            op-seq (gensym)
+            op-label (str "Add " resources-type-label)
+            new-nodes (g/tx-nodes-added
+                        (g/transact
+                          (concat
+                            (g/operation-sequence op-seq)
+                            (g/operation-label op-label)
+                            (for [[resource name] pairs]
+                              (make-node-fn resource name)))))]
+        (when (some? select-fn)
+          (g/transact
+            (concat
+              (g/operation-sequence op-seq)
+              (g/operation-label op-label)
+              (select-fn new-nodes))))))))
 
 ;; //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -2592,7 +2588,7 @@
    (g/node-value parent :name-counts)
    project select-fn
    (partial add-texture scene parent) 
-   (partial new-resource? parent)))
+   parent))
 
 (g/defnode TexturesNode
   (inherits outline/OutlineNode)
@@ -2634,20 +2630,13 @@
   (g/make-nodes (g/node-id->graph-id scene) [node [MaterialNode :name name :material resource]]
     (attach-material scene materials-node node)))
 
-(defn new-material-resource? [parent resource]
-  (->> (g/node-value parent :child-outlines)
-       (map :node-id)
-       (not-any? #(= (resource/resource->proj-path resource)
-                     (when-let [mat-res (g/node-value % :material-resource)]
-                       (resource/resource->proj-path mat-res))))))
-
 (defn- add-materials-handler [project {:keys [scene parent]} select-fn]
   (query-and-add-resources!
    "Materials" ["material"]
    (g/node-value parent :name-counts)
    project select-fn
    (partial add-material scene parent)
-   (partial new-material-resource? parent)))
+   parent))
 
 (g/defnode MaterialsNode
   (inherits outline/OutlineNode)
@@ -2692,7 +2681,7 @@
    (g/node-value parent :name-counts)
    project select-fn
    (partial add-font scene parent)
-   (partial new-resource? parent)))
+   parent))
 
 (g/defnode FontsNode
   (inherits outline/OutlineNode)
@@ -2835,7 +2824,7 @@
    (g/node-value parent :name-counts)
    project select-fn
    (partial add-particlefx-resource scene parent)
-   (partial new-resource? parent)))
+   parent))
 
 (g/defnode ParticleFXResources
   (inherits outline/OutlineNode)

--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -2534,26 +2534,25 @@
        (not-any? #{resource})))
 
 ;; SDK api
-(defn query-and-add-resources! [resources-type-label resource-exts taken-ids project select-fn make-node-fn & [parent]]
-  (let [accept-fn (if parent (partial new-resource? parent) fn/constantly-true)]
-    (when-let [resources (browse (str "Select " resources-type-label) project resource-exts accept-fn)]
-      (let [names (outline/resolve-ids (map resource->id resources) taken-ids)
-            pairs (map vector resources names)
-            op-seq (gensym)
-            op-label (str "Add " resources-type-label)
-            new-nodes (g/tx-nodes-added
-                        (g/transact
-                          (concat
-                            (g/operation-sequence op-seq)
-                            (g/operation-label op-label)
-                            (for [[resource name] pairs]
-                              (make-node-fn resource name)))))]
-        (when (some? select-fn)
-          (g/transact
-            (concat
-              (g/operation-sequence op-seq)
-              (g/operation-label op-label)
-              (select-fn new-nodes))))))))
+(defn query-and-add-resources! [resources-type-label resource-exts taken-ids parent project select-fn make-node-fn]
+  (when-let [resources (browse (str "Select " resources-type-label) project resource-exts (partial new-resource? parent))]
+    (let [names (outline/resolve-ids (map resource->id resources) taken-ids)
+          pairs (map vector resources names)
+          op-seq (gensym)
+          op-label (str "Add " resources-type-label)
+          new-nodes (g/tx-nodes-added
+                     (g/transact
+                      (concat
+                       (g/operation-sequence op-seq)
+                       (g/operation-label op-label)
+                       (for [[resource name] pairs]
+                         (make-node-fn resource name)))))]
+      (when (some? select-fn)
+        (g/transact
+         (concat
+          (g/operation-sequence op-seq)
+          (g/operation-label op-label)
+          (select-fn new-nodes)))))))
 
 ;; //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -2586,9 +2585,8 @@
    "Textures"
    (workspace/resource-kind-extensions (project/workspace project) :atlas)
    (g/node-value parent :name-counts)
-   project select-fn
-   (partial add-texture scene parent) 
-   parent))
+   parent project select-fn
+   (partial add-texture scene parent)))
 
 (g/defnode TexturesNode
   (inherits outline/OutlineNode)
@@ -2634,9 +2632,8 @@
   (query-and-add-resources!
    "Materials" ["material"]
    (g/node-value parent :name-counts)
-   project select-fn
-   (partial add-material scene parent)
-   parent))
+   parent project select-fn
+   (partial add-material scene parent)))
 
 (g/defnode MaterialsNode
   (inherits outline/OutlineNode)
@@ -2679,9 +2676,8 @@
   (query-and-add-resources!
    "Fonts" ["font"]
    (g/node-value parent :name-counts)
-   project select-fn
-   (partial add-font scene parent)
-   parent))
+   parent project select-fn
+   (partial add-font scene parent)))
 
 (g/defnode FontsNode
   (inherits outline/OutlineNode)
@@ -2822,9 +2818,8 @@
   (query-and-add-resources!
    "Particle FX" [particlefx/particlefx-ext]
    (g/node-value parent :name-counts)
-   project select-fn
-   (partial add-particlefx-resource scene parent)
-   parent))
+   parent project select-fn
+   (partial add-particlefx-resource scene parent)))
 
 (g/defnode ParticleFXResources
   (inherits outline/OutlineNode)

--- a/editor/src/clj/editor/image.clj
+++ b/editor/src/clj/editor/image.clj
@@ -13,7 +13,8 @@
 ;; specific language governing permissions and limitations under the License.
 
 (ns editor.image
-  (:require [dynamo.graph :as g]
+  (:require [clojure.string :as str]
+            [dynamo.graph :as g]
             [editor.build-target :as bt]
             [editor.gl :as gl]
             [editor.gl.texture :as texture]
@@ -25,12 +26,15 @@
             [editor.workspace :as workspace])
   (:import [com.dynamo.bob.pipeline TextureGenerator$GenerateResult]
            [com.dynamo.bob.textureset TextureSetGenerator$UVTransform]
-           [com.dynamo.bob.util TextureUtil]
            [java.awt.image BufferedImage]))
 
 (set! *warn-on-reflection* true)
 
 (def exts ["jpg" "png"])
+
+(defn image-path?
+  [path]
+  (boolean (some (partial str/ends-with? path) exts)))
 
 (defn- build-texture [resource _dep-resources user-data]
   (let [{:keys [content-generator texture-profile compress?]} user-data

--- a/editor/src/clj/editor/image.clj
+++ b/editor/src/clj/editor/image.clj
@@ -34,7 +34,9 @@
 
 (defn image-path?
   [path]
-  (boolean (some (partial str/ends-with? path) exts)))
+  (->> exts
+       (some (partial str/ends-with? (str/lower-case path)))
+       boolean))
 
 (defn- build-texture [resource _dep-resources user-data]
   (let [{:keys [content-generator texture-profile compress?]} user-data

--- a/editor/src/clj/editor/input.clj
+++ b/editor/src/clj/editor/input.clj
@@ -70,6 +70,7 @@
                         :x (.getX drag-event)
                         :y (.getY drag-event)
                         :files (.getFiles dragboard)
+                        :string (.getString dragboard)
                         :transfer-mode (.getTransferMode drag-event)
                         :gesture-target (.getGestureTarget drag-event)
                         :gesture-source (.getGestureSource drag-event)))

--- a/editor/src/clj/editor/scene.clj
+++ b/editor/src/clj/editor/scene.clj
@@ -929,7 +929,6 @@
   (let [x          (:x action)
         y          (:y action)
         screen-pos (Vector3d. x y 0)
-        view-graph (g/node-id->graph-id view)
         camera     (g/node-value (view->camera view) :camera)
         viewport   (g/node-value view :viewport)
         world-pos  (Point3d. (screen->world camera viewport screen-pos))

--- a/editor/src/clj/editor/scene.clj
+++ b/editor/src/clj/editor/scene.clj
@@ -1542,7 +1542,8 @@
         tool-controller-type (get opts :tool-controller scene-tools/ToolController)]
     (g/make-nodes view-graph
                   [background      background/Background
-                   selection       [selection/SelectionController :select-fn (fn [selection op-seq]
+                   selection       [selection/SelectionController :drop-fn (:drop-fn opts)
+                                                                  :select-fn (fn [selection op-seq]
                                                                                (g/transact
                                                                                  (concat
                                                                                    (g/operation-sequence op-seq)

--- a/editor/src/clj/editor/scene_selection.clj
+++ b/editor/src/clj/editor/scene_selection.clj
@@ -129,18 +129,16 @@
         contextual? (= (:button action) :secondary)]
     (case (:type action)
       :drag-dropped (when-let [drop-fn (g/node-value self :drop-fn)]
-                      (let [select-fn (g/node-value self :select-fn)
+                      (let [op-seq (gensym)
+                            select-fn (g/node-value self :select-fn)
                             drag-event ^DragEvent (:event action)
-                            files (:files action)
-                            image-view (:gesture-target action)
-                            _ (ui/request-focus! image-view)
-                            ui-context (first (ui/node-contexts image-view false))
-                            {:keys [selection workspace]} (:env ui-context)
-                            added-nodes (drop-fn files selection workspace op-seq)]
-                        (select-fn added-nodes op-seq)
+                            _ (ui/request-focus! (:gesture-target action))
+                            added-nodes (drop-fn action op-seq)]
                         (.consume drag-event)
-                        (ui/user-data! (ui/main-scene) ::ui/refresh-requested? true)
-                        (.setDropCompleted drag-event true))
+                        (when (seq added-nodes)
+                          (select-fn added-nodes op-seq)
+                          (ui/user-data! (ui/main-scene) ::ui/refresh-requested? true)
+                          (.setDropCompleted drag-event true)))
                       nil)
       :mouse-pressed (let [op-seq (gensym)
                            toggle? (true? (some true? (map #(% action) toggle-modifiers)))

--- a/editor/src/clj/editor/workspace.clj
+++ b/editor/src/clj/editor/workspace.clj
@@ -1109,7 +1109,7 @@ ordinary paths."
     (resolve-workspace-resource workspace path)))
 
 (defn get-resources-from-files
-  [files workspace filter-fn]
-  (->> (filter-fn files)
+  [workspace files]
+  (->> files
        (keep (partial get-resource-from-file workspace))
        (sort-by resource/path)))

--- a/editor/src/clj/editor/workspace.clj
+++ b/editor/src/clj/editor/workspace.clj
@@ -1102,14 +1102,3 @@ ordinary paths."
                          (when text-selection-fn
                            {:text-selection-fn text-selection-fn}))]
      (g/update-property workspace :view-types assoc (:id view-type) view-type)))
-
-(defn- get-resource-from-file
-  [workspace ^File file]
-  (when-let [path (as-proj-path workspace (.getAbsolutePath file))]
-    (resolve-workspace-resource workspace path)))
-
-(defn get-resources-from-files
-  [workspace files]
-  (->> files
-       (keep (partial get-resource-from-file workspace))
-       (sort-by resource/path)))

--- a/editor/src/clj/editor/workspace.clj
+++ b/editor/src/clj/editor/workspace.clj
@@ -32,7 +32,6 @@ ordinary paths."
             [editor.ui :as ui]
             [editor.url :as url]
             [editor.util :as util]
-            [internal.cache :as c]
             [internal.java :as java]
             [internal.util :as iutil]
             [schema.core :as s]
@@ -1103,3 +1102,14 @@ ordinary paths."
                          (when text-selection-fn
                            {:text-selection-fn text-selection-fn}))]
      (g/update-property workspace :view-types assoc (:id view-type) view-type)))
+
+(defn- get-resource-from-file
+  [workspace ^File file]
+  (when-let [path (as-proj-path workspace (.getAbsolutePath file))]
+    (resolve-workspace-resource workspace path)))
+
+(defn get-resources-from-files
+  [files workspace filter-fn]
+  (->> (filter-fn files)
+       (keep (partial get-resource-from-file workspace))
+       (sort-by resource/path)))


### PR DESCRIPTION
Allow dropping assets to GUI scenes to create dependencies.

![gui-drop](https://github.com/user-attachments/assets/a7f2568b-db8e-4c6a-86f7-450b4cf05978)

### Technical changes
* Refactor some of the code added on #10298.
* Use string paths instead of files on dnd.
* Pass a `drop-fn` function to the `SelectionController` and call the existing `select-fn` when new node ids are returned. I think it makes more sense to handle dropping on the selection controller.
* Use the introduced `drop-fn` property to allow adding GUI dependencies on dnd from the asset tree.