### PR TITLE
Use unique identifiers for factory-spawned game objects

### DIFF
--- a/engine/gameobject/src/dmsdk/gameobject/gameobject.h
+++ b/engine/gameobject/src/dmsdk/gameobject/gameobject.h
@@ -547,11 +547,11 @@ namespace dmGameObject
     void Delete(HCollection collection, HInstance instance, bool recursive);
 
     /*#
-     * Construct a hash of an instance id.
-     * @name ConstructInstanceId
-     * @return id [type: dmhash_t] hash of the instance id constructed.
+     * Creates a new unique instance ID and returns its hash.
+     * @name CreateIntanceId
+     * @return id [type: dmhash_t] hash of the new unique instance id
      */
-    dmhash_t ConstructInstanceId();
+    dmhash_t CreateIntanceId();
 
     /*#
      * Retrieve an instance index from the index pool for the collection.
@@ -594,15 +594,6 @@ namespace dmGameObject
      * @return instance [type: dmGameObject::HInstance] Instance. NULL if instance isn't found.
      */
     HInstance GetInstanceFromIdentifier(HCollection collection, dmhash_t identifier);
-
-    /*#
-     * Construct and set instance identifier.
-     * @name SetConstructedIdentifier
-     * @param collection [type: dmGameObject::HCollection] Collection
-     * @param instance [type: dmGameObject::HInstance] Instance
-     * @return result [type: dmGameObject::Result]  RESULT_OK on success
-     */
-    Result SetConstructedIdentifier(HCollection collection, HInstance instance);
 
     /*#
      * Get component id from component index.

--- a/engine/gameobject/src/dmsdk/gameobject/gameobject.h
+++ b/engine/gameobject/src/dmsdk/gameobject/gameobject.h
@@ -548,10 +548,10 @@ namespace dmGameObject
 
     /*#
      * Creates a new unique instance ID and returns its hash.
-     * @name CreateIntanceId
+     * @name CreateInstanceId
      * @return id [type: dmhash_t] hash of the new unique instance id
      */
-    dmhash_t CreateIntanceId();
+    dmhash_t CreateInstanceId();
 
     /*#
      * Retrieve an instance index from the index pool for the collection.

--- a/engine/gameobject/src/dmsdk/gameobject/gameobject.h
+++ b/engine/gameobject/src/dmsdk/gameobject/gameobject.h
@@ -547,7 +547,7 @@ namespace dmGameObject
     void Delete(HCollection collection, HInstance instance, bool recursive);
 
     /*#
-     * Construct a hash of an instance id based on the index provided.
+     * Construct a hash of an instance id.
      * @name ConstructInstanceId
      * @return id [type: dmhash_t] hash of the instance id constructed.
      */
@@ -594,6 +594,15 @@ namespace dmGameObject
      * @return instance [type: dmGameObject::HInstance] Instance. NULL if instance isn't found.
      */
     HInstance GetInstanceFromIdentifier(HCollection collection, dmhash_t identifier);
+
+    /*#
+     * Construct and set instance identifier.
+     * @name SetConstructedIdentifier
+     * @param collection [type: dmGameObject::HCollection] Collection
+     * @param instance [type: dmGameObject::HInstance] Instance
+     * @return result [type: dmGameObject::Result]  RESULT_OK on success
+     */
+    Result SetConstructedIdentifier(HCollection collection, HInstance instance);
 
     /*#
      * Get component id from component index.

--- a/engine/gameobject/src/dmsdk/gameobject/gameobject.h
+++ b/engine/gameobject/src/dmsdk/gameobject/gameobject.h
@@ -549,10 +549,9 @@ namespace dmGameObject
     /*#
      * Construct a hash of an instance id based on the index provided.
      * @name ConstructInstanceId
-     * @param index [type: uint32_t] The index to base the id off of.
      * @return id [type: dmhash_t] hash of the instance id constructed.
      */
-    dmhash_t ConstructInstanceId(uint32_t index);
+    dmhash_t ConstructInstanceId();
 
     /*#
      * Retrieve an instance index from the index pool for the collection.

--- a/engine/gameobject/src/gameobject/gameobject.cpp
+++ b/engine/gameobject/src/gameobject/gameobject.cpp
@@ -970,7 +970,7 @@ namespace dmGameObject
     {
         static uint32_t index = 0;
         index += 1;
-        char buffer[16] = { 0 };
+        char buffer[32] = { 0 };
         int length = dmSnPrintf(buffer, sizeof(buffer), "%sinstance%d", ID_SEPARATOR, index);
         return dmHashBuffer64(buffer, (uint32_t)length);
     }
@@ -1035,9 +1035,15 @@ namespace dmGameObject
         return RESULT_OK;
     }
 
-    Result SetIdentifier(HCollection hcollection, HInstance instance, dmhash_t id)
+    Result SetIdentifier(HCollection collection, HInstance instance, dmhash_t id)
     {
-        return SetIdentifier(hcollection->m_Collection, instance, id);
+        return SetIdentifier(collection->m_Collection, instance, id);
+    }
+
+    Result SetConstructedIdentifier(HCollection collection, HInstance instance)
+    {
+        instance->m_Generated = true;
+        return SetIdentifier(collection->m_Collection, instance, ConstructInstanceId());
     }
 
     void ReleaseIdentifier(Collection* collection, HInstance instance)
@@ -1657,6 +1663,7 @@ namespace dmGameObject
         }
 
         HInstance instance = SpawnInternal(hcollection->m_Collection, proto, prototype_name, id, property_container, position, rotation, scale);
+        instance->m_Generated = 1;
 
         if (instance == 0) {
             dmLogError("Could not spawn an instance of prototype %s.", prototype_name);

--- a/engine/gameobject/src/gameobject/gameobject.cpp
+++ b/engine/gameobject/src/gameobject/gameobject.cpp
@@ -91,7 +91,7 @@ namespace dmGameObject
     static bool InitCollection(Collection* collection);
     static bool FinalCollection(Collection* collection);
 
-    static uint32_t g_instance_index = 0;
+    static uint32_t g_InstanceIndex = 0;
 
     Prototype::~Prototype()
     {
@@ -970,14 +970,15 @@ namespace dmGameObject
 
     void ResetInstanceIndex()
     {
-        g_instance_index = 0;
+        g_InstanceIndex = 0;
     }
 
-    dmhash_t ConstructInstanceId()
+    dmhash_t CreateIntanceId()
     {
+        //20 bytes: '/'' + 'instance' + uint32 + null terminator = 1 + 8 + 10 + 1
         char buffer[32] = { 0 };
-        int length = dmSnPrintf(buffer, sizeof(buffer), "%sinstance%d", ID_SEPARATOR, g_instance_index);
-        g_instance_index += 1;
+        int length = dmSnPrintf(buffer, sizeof(buffer), "%sinstance%d", ID_SEPARATOR, g_InstanceIndex);
+        g_InstanceIndex += 1;
         return dmHashBuffer64(buffer, (uint32_t)length);
     }
 
@@ -1044,12 +1045,6 @@ namespace dmGameObject
     Result SetIdentifier(HCollection hcollection, HInstance instance, dmhash_t id)
     {
         return SetIdentifier(hcollection->m_Collection, instance, id);
-    }
-
-    Result SetConstructedIdentifier(HCollection hcollection, HInstance instance)
-    {
-        instance->m_Generated = 1;
-        return SetIdentifier(hcollection->m_Collection, instance, ConstructInstanceId());
     }
 
     void ReleaseIdentifier(Collection* collection, HInstance instance)
@@ -1216,7 +1211,6 @@ namespace dmGameObject
 
         bool success = CreateComponents(collection, instance);
         if (!success) {
-            dmLogError("Could not create components.");
             ReleaseIdentifier(collection, instance);
             UndoNewInstance(collection, instance);
             return 0;
@@ -2191,6 +2185,7 @@ namespace dmGameObject
     void SetBone(HInstance instance, bool bone)
     {
         instance->m_Bone = bone;
+        instance->m_Generated = 1;
     }
 
     bool IsBone(HInstance instance)

--- a/engine/gameobject/src/gameobject/gameobject.cpp
+++ b/engine/gameobject/src/gameobject/gameobject.cpp
@@ -966,8 +966,10 @@ namespace dmGameObject
         return instance;
     }
 
-    dmhash_t ConstructInstanceId(uint32_t index)
+    dmhash_t ConstructInstanceId()
     {
+        static uint32_t index = 0;
+        index += 1;
         char buffer[16] = { 0 };
         int length = dmSnPrintf(buffer, sizeof(buffer), "%sinstance%d", ID_SEPARATOR, index);
         return dmHashBuffer64(buffer, (uint32_t)length);

--- a/engine/gameobject/src/gameobject/gameobject.cpp
+++ b/engine/gameobject/src/gameobject/gameobject.cpp
@@ -973,7 +973,7 @@ namespace dmGameObject
         g_InstanceIndex = 0;
     }
 
-    dmhash_t CreateIntanceId()
+    dmhash_t CreateInstanceId()
     {
         //20 bytes: '/'' + 'instance' + uint32 + null terminator = 1 + 8 + 10 + 1
         char buffer[32] = { 0 };

--- a/engine/gameobject/src/gameobject/gameobject.cpp
+++ b/engine/gameobject/src/gameobject/gameobject.cpp
@@ -1035,15 +1035,15 @@ namespace dmGameObject
         return RESULT_OK;
     }
 
-    Result SetIdentifier(HCollection collection, HInstance instance, dmhash_t id)
+    Result SetIdentifier(HCollection hcollection, HInstance instance, dmhash_t id)
     {
-        return SetIdentifier(collection->m_Collection, instance, id);
+        return SetIdentifier(hcollection->m_Collection, instance, id);
     }
 
-    Result SetConstructedIdentifier(HCollection collection, HInstance instance)
+    Result SetConstructedIdentifier(HCollection hcollection, HInstance instance)
     {
-        instance->m_Generated = true;
-        return SetIdentifier(collection->m_Collection, instance, ConstructInstanceId());
+        instance->m_Generated = 1;
+        return SetIdentifier(hcollection->m_Collection, instance, ConstructInstanceId());
     }
 
     void ReleaseIdentifier(Collection* collection, HInstance instance)
@@ -1210,6 +1210,7 @@ namespace dmGameObject
 
         bool success = CreateComponents(collection, instance);
         if (!success) {
+            dmLogError("Could not create components.");
             ReleaseIdentifier(collection, instance);
             UndoNewInstance(collection, instance);
             return 0;

--- a/engine/gameobject/src/gameobject/gameobject.cpp
+++ b/engine/gameobject/src/gameobject/gameobject.cpp
@@ -53,7 +53,8 @@ namespace dmGameObject
     const char* COLLECTION_MAX_INPUT_STACK_ENTRIES_KEY = "collection.max_input_stack_entries";
     const dmhash_t UNNAMED_IDENTIFIER = dmHashBuffer64("__unnamed__", strlen("__unnamed__"));
     const dmhash_t GAME_OBJECT_EXT = dmHashString64("goc");
-    const char* ID_SEPARATOR = "/";
+#define ID_SEPARATOR_CHAR "/"
+    const char* ID_SEPARATOR = ID_SEPARATOR_CHAR;
     const uint32_t MAX_DISPATCH_ITERATION_COUNT = 10;
 
     static Prototype EMPTY_PROTOTYPE;
@@ -90,8 +91,6 @@ namespace dmGameObject
     static void DeallocCollection(Collection* collection);
     static bool InitCollection(Collection* collection);
     static bool FinalCollection(Collection* collection);
-
-    static uint32_t g_InstanceIndex = 0;
 
     Prototype::~Prototype()
     {
@@ -968,17 +967,13 @@ namespace dmGameObject
         return instance;
     }
 
-    void ResetInstanceIndex()
-    {
-        g_InstanceIndex = 0;
-    }
-
     dmhash_t CreateInstanceId()
     {
+        static uint32_t index = 0;
         //20 bytes: '/'' + 'instance' + uint32 + null terminator = 1 + 8 + 10 + 1
         char buffer[32] = { 0 };
-        int length = dmSnPrintf(buffer, sizeof(buffer), "%sinstance%d", ID_SEPARATOR, g_InstanceIndex);
-        g_InstanceIndex += 1;
+        int length = dmSnPrintf(buffer, sizeof(buffer), ID_SEPARATOR_CHAR "instance%d", index);
+        index += 1;
         return dmHashBuffer64(buffer, (uint32_t)length);
     }
 

--- a/engine/gameobject/src/gameobject/gameobject.cpp
+++ b/engine/gameobject/src/gameobject/gameobject.cpp
@@ -91,6 +91,8 @@ namespace dmGameObject
     static bool InitCollection(Collection* collection);
     static bool FinalCollection(Collection* collection);
 
+    static uint32_t g_instance_index = 0;
+
     Prototype::~Prototype()
     {
         free(m_Components);
@@ -966,12 +968,16 @@ namespace dmGameObject
         return instance;
     }
 
+    void ResetInstanceIndex()
+    {
+        g_instance_index = 0;
+    }
+
     dmhash_t ConstructInstanceId()
     {
-        static uint32_t index = 0;
-        index += 1;
         char buffer[32] = { 0 };
-        int length = dmSnPrintf(buffer, sizeof(buffer), "%sinstance%d", ID_SEPARATOR, index);
+        int length = dmSnPrintf(buffer, sizeof(buffer), "%sinstance%d", ID_SEPARATOR, g_instance_index);
+        g_instance_index += 1;
         return dmHashBuffer64(buffer, (uint32_t)length);
     }
 

--- a/engine/gameobject/src/gameobject/gameobject.cpp
+++ b/engine/gameobject/src/gameobject/gameobject.cpp
@@ -1225,6 +1225,7 @@ namespace dmGameObject
 
         if (success) {
             AddToUpdate(collection, instance);
+            instance->m_Generated = 1;
         } else {
             Delete(collection, instance, false);
             return 0;
@@ -1663,7 +1664,6 @@ namespace dmGameObject
         }
 
         HInstance instance = SpawnInternal(hcollection->m_Collection, proto, prototype_name, id, property_container, position, rotation, scale);
-        instance->m_Generated = 1;
 
         if (instance == 0) {
             dmLogError("Could not spawn an instance of prototype %s.", prototype_name);

--- a/engine/gameobject/src/gameobject/gameobject.h
+++ b/engine/gameobject/src/gameobject/gameobject.h
@@ -391,9 +391,6 @@ namespace dmGameObject
      * tracked by the collection, e.g resource.release(id) has been called
      */
     void RemoveDynamicResourceHash(HCollection collection, dmhash_t resource_hash);
-
-    // For tests
-    void ResetInstanceIndex();
 }
 
 #endif // DM_GAMEOBJECT_H

--- a/engine/gameobject/src/gameobject/gameobject.h
+++ b/engine/gameobject/src/gameobject/gameobject.h
@@ -391,6 +391,9 @@ namespace dmGameObject
      * tracked by the collection, e.g resource.release(id) has been called
      */
     void RemoveDynamicResourceHash(HCollection collection, dmhash_t resource_hash);
+
+    // For tests
+    void ResetInstanceIndex();
 }
 
 #endif // DM_GAMEOBJECT_H

--- a/engine/gameobject/src/gameobject/test/factory/test_gameobject_factory.cpp
+++ b/engine/gameobject/src/gameobject/test/factory/test_gameobject_factory.cpp
@@ -280,6 +280,7 @@ TEST_F(FactoryTest, FactoryPropertiesFailTypeMismatch)
 
 TEST_F(FactoryTest, FactoryCreateCallback)
 {
+    dmGameObject::ResetInstanceIndex();
     uint32_t index = dmGameObject::AcquireInstanceIndex(m_Collection);
     dmhash_t id = dmGameObject::ConstructInstanceId();
     dmGameObject::HInstance instance = Spawn(m_Factory, m_Collection, "/test_create.goc", id, 0, Point3(2.0f, 0.0f, 0.0f), Quat(), Vector3(2, 2, 2));

--- a/engine/gameobject/src/gameobject/test/factory/test_gameobject_factory.cpp
+++ b/engine/gameobject/src/gameobject/test/factory/test_gameobject_factory.cpp
@@ -159,8 +159,7 @@ TEST_F(FactoryTest, Factory)
     const int count = 10;
     for (int i = 0; i < count; ++i)
     {
-        uint32_t index = dmGameObject::AcquireInstanceIndex(m_Collection);
-        dmhash_t id = dmGameObject::ConstructInstanceId(index);
+        dmhash_t id = dmGameObject::ConstructInstanceId();
 
         ASSERT_NE(0u, id);
         dmGameObject::HInstance instance = Spawn(m_Factory, m_Collection, "/test.goc", id, 0, Point3(), Quat(), Vector3(1, 1, 1));
@@ -170,8 +169,7 @@ TEST_F(FactoryTest, Factory)
 
 TEST_F(FactoryTest, FactoryScale)
 {
-    uint32_t index = dmGameObject::AcquireInstanceIndex(m_Collection);
-    dmhash_t id = dmGameObject::ConstructInstanceId(index);
+    dmhash_t id = dmGameObject::ConstructInstanceId();
     ASSERT_NE(0u, id);
     dmGameObject::HInstance instance = Spawn(m_Factory, m_Collection, "/test.goc", id, 0, Point3(), Quat(), Vector3(2, 2, 2));
     ASSERT_EQ(2.0f, dmGameObject::GetUniformScale(instance));
@@ -179,15 +177,13 @@ TEST_F(FactoryTest, FactoryScale)
 
 TEST_F(FactoryTest, FactoryScaleAlongZ)
 {
-    uint32_t index = dmGameObject::AcquireInstanceIndex(m_Collection);
-    dmhash_t id = dmGameObject::ConstructInstanceId(index);
+    dmhash_t id = dmGameObject::ConstructInstanceId();
 
     m_Collection->m_Collection->m_ScaleAlongZ = 1;
     dmGameObject::HInstance instance = Spawn(m_Factory, m_Collection, "/test.goc", id, 0, Point3(), Quat(), Vector3(2, 2, 2));
     ASSERT_TRUE(dmGameObject::ScaleAlongZ(instance));
 
-    index = dmGameObject::AcquireInstanceIndex(m_Collection);
-    id = dmGameObject::ConstructInstanceId(index);
+    id = dmGameObject::ConstructInstanceId();
     m_Collection->m_Collection->m_ScaleAlongZ = 0;
     instance = Spawn(m_Factory, m_Collection, "/test.goc", id, 0, Point3(), Quat(), Vector3(2, 2, 2));
     ASSERT_FALSE(dmGameObject::ScaleAlongZ(instance));
@@ -227,13 +223,11 @@ TEST_F(FactoryTest, FactoryProperties)
 
     dmGameObject::PropertyContainerPrint(properties);
 
-    uint32_t index = dmGameObject::AcquireInstanceIndex(m_Collection);
-    dmhash_t id = dmGameObject::ConstructInstanceId(index);
+    dmhash_t id = dmGameObject::ConstructInstanceId();
     dmGameObject::HInstance instance = Spawn(m_Factory, m_Collection, "/test_props.goc", id, properties, Point3(), Quat(), Vector3(2, 2, 2));
     ASSERT_NE((void*)0, instance);
 
-    index = dmGameObject::AcquireInstanceIndex(m_Collection);
-    id = dmGameObject::ConstructInstanceId(index);
+    id = dmGameObject::ConstructInstanceId();
     instance = Spawn(m_Factory, m_Collection, "/test_props.goc", id, properties, Point3(), Quat(), Vector3(2, 2, 2));
     ASSERT_NE((void*)0, instance);
 
@@ -251,8 +245,7 @@ TEST_F(FactoryTest, FactoryPropertiesFailUnsupportedType)
     dmGameObject::HPropertyContainer properties = dmGameObject::PropertyContainerCreateFromLua(L, -1);
     lua_pop(L, 1);
 
-    uint32_t index = dmGameObject::AcquireInstanceIndex(m_Collection);
-    dmhash_t id = dmGameObject::ConstructInstanceId(index);
+    dmhash_t id = dmGameObject::ConstructInstanceId();
     dmGameObject::HInstance instance = Spawn(m_Factory, m_Collection, "/test_props.goc", id, properties, Point3(), Quat(), Vector3(2, 2, 2));
     ASSERT_EQ((void*)0, instance);
 
@@ -270,8 +263,7 @@ TEST_F(FactoryTest, FactoryPropertiesFailTypeMismatch)
     dmGameObject::HPropertyContainer properties = dmGameObject::PropertyContainerCreateFromLua(L, -1);
     lua_pop(L, 1);
 
-    uint32_t index = dmGameObject::AcquireInstanceIndex(m_Collection);
-    dmhash_t id = dmGameObject::ConstructInstanceId(index);
+    dmhash_t id = dmGameObject::ConstructInstanceId();
     dmGameObject::HInstance instance = Spawn(m_Factory, m_Collection, "/test_props.goc", id, properties, Point3(), Quat(), Vector3(2, 2, 2));
     ASSERT_EQ((void*)0, instance);
 
@@ -280,8 +272,7 @@ TEST_F(FactoryTest, FactoryPropertiesFailTypeMismatch)
 
 TEST_F(FactoryTest, FactoryCreateCallback)
 {
-    uint32_t index = dmGameObject::AcquireInstanceIndex(m_Collection);
-    dmhash_t id = dmGameObject::ConstructInstanceId(index);
+    dmhash_t id = dmGameObject::ConstructInstanceId();
     dmGameObject::HInstance instance = Spawn(m_Factory, m_Collection, "/test_create.goc", id, 0, Point3(2.0f, 0.0f, 0.0f), Quat(), Vector3(2, 2, 2));
     ASSERT_NE((void*)0, instance);
 }

--- a/engine/gameobject/src/gameobject/test/factory/test_gameobject_factory.cpp
+++ b/engine/gameobject/src/gameobject/test/factory/test_gameobject_factory.cpp
@@ -160,7 +160,7 @@ TEST_F(FactoryTest, Factory)
     for (int i = 0; i < count; ++i)
     {
         uint32_t index = dmGameObject::AcquireInstanceIndex(m_Collection);
-        dmhash_t id = dmGameObject::ConstructInstanceId(index);
+        dmhash_t id = dmGameObject::ConstructInstanceId();
 
         ASSERT_NE(0u, id);
         dmGameObject::HInstance instance = Spawn(m_Factory, m_Collection, "/test.goc", id, 0, Point3(), Quat(), Vector3(1, 1, 1));
@@ -171,7 +171,7 @@ TEST_F(FactoryTest, Factory)
 TEST_F(FactoryTest, FactoryScale)
 {
     uint32_t index = dmGameObject::AcquireInstanceIndex(m_Collection);
-    dmhash_t id = dmGameObject::ConstructInstanceId(index);
+    dmhash_t id = dmGameObject::ConstructInstanceId();
     ASSERT_NE(0u, id);
     dmGameObject::HInstance instance = Spawn(m_Factory, m_Collection, "/test.goc", id, 0, Point3(), Quat(), Vector3(2, 2, 2));
     ASSERT_EQ(2.0f, dmGameObject::GetUniformScale(instance));
@@ -180,14 +180,14 @@ TEST_F(FactoryTest, FactoryScale)
 TEST_F(FactoryTest, FactoryScaleAlongZ)
 {
     uint32_t index = dmGameObject::AcquireInstanceIndex(m_Collection);
-    dmhash_t id = dmGameObject::ConstructInstanceId(index);
+    dmhash_t id = dmGameObject::ConstructInstanceId();
 
     m_Collection->m_Collection->m_ScaleAlongZ = 1;
     dmGameObject::HInstance instance = Spawn(m_Factory, m_Collection, "/test.goc", id, 0, Point3(), Quat(), Vector3(2, 2, 2));
     ASSERT_TRUE(dmGameObject::ScaleAlongZ(instance));
 
     index = dmGameObject::AcquireInstanceIndex(m_Collection);
-    id = dmGameObject::ConstructInstanceId(index);
+    id = dmGameObject::ConstructInstanceId();
     m_Collection->m_Collection->m_ScaleAlongZ = 0;
     instance = Spawn(m_Factory, m_Collection, "/test.goc", id, 0, Point3(), Quat(), Vector3(2, 2, 2));
     ASSERT_FALSE(dmGameObject::ScaleAlongZ(instance));
@@ -228,12 +228,12 @@ TEST_F(FactoryTest, FactoryProperties)
     dmGameObject::PropertyContainerPrint(properties);
 
     uint32_t index = dmGameObject::AcquireInstanceIndex(m_Collection);
-    dmhash_t id = dmGameObject::ConstructInstanceId(index);
+    dmhash_t id = dmGameObject::ConstructInstanceId();
     dmGameObject::HInstance instance = Spawn(m_Factory, m_Collection, "/test_props.goc", id, properties, Point3(), Quat(), Vector3(2, 2, 2));
     ASSERT_NE((void*)0, instance);
 
     index = dmGameObject::AcquireInstanceIndex(m_Collection);
-    id = dmGameObject::ConstructInstanceId(index);
+    id = dmGameObject::ConstructInstanceId();
     instance = Spawn(m_Factory, m_Collection, "/test_props.goc", id, properties, Point3(), Quat(), Vector3(2, 2, 2));
     ASSERT_NE((void*)0, instance);
 
@@ -252,7 +252,7 @@ TEST_F(FactoryTest, FactoryPropertiesFailUnsupportedType)
     lua_pop(L, 1);
 
     uint32_t index = dmGameObject::AcquireInstanceIndex(m_Collection);
-    dmhash_t id = dmGameObject::ConstructInstanceId(index);
+    dmhash_t id = dmGameObject::ConstructInstanceId();
     dmGameObject::HInstance instance = Spawn(m_Factory, m_Collection, "/test_props.goc", id, properties, Point3(), Quat(), Vector3(2, 2, 2));
     ASSERT_EQ((void*)0, instance);
 
@@ -271,7 +271,7 @@ TEST_F(FactoryTest, FactoryPropertiesFailTypeMismatch)
     lua_pop(L, 1);
 
     uint32_t index = dmGameObject::AcquireInstanceIndex(m_Collection);
-    dmhash_t id = dmGameObject::ConstructInstanceId(index);
+    dmhash_t id = dmGameObject::ConstructInstanceId();
     dmGameObject::HInstance instance = Spawn(m_Factory, m_Collection, "/test_props.goc", id, properties, Point3(), Quat(), Vector3(2, 2, 2));
     ASSERT_EQ((void*)0, instance);
 
@@ -281,7 +281,7 @@ TEST_F(FactoryTest, FactoryPropertiesFailTypeMismatch)
 TEST_F(FactoryTest, FactoryCreateCallback)
 {
     uint32_t index = dmGameObject::AcquireInstanceIndex(m_Collection);
-    dmhash_t id = dmGameObject::ConstructInstanceId(index);
+    dmhash_t id = dmGameObject::ConstructInstanceId();
     dmGameObject::HInstance instance = Spawn(m_Factory, m_Collection, "/test_create.goc", id, 0, Point3(2.0f, 0.0f, 0.0f), Quat(), Vector3(2, 2, 2));
     ASSERT_NE((void*)0, instance);
 }

--- a/engine/gameobject/src/gameobject/test/factory/test_gameobject_factory.cpp
+++ b/engine/gameobject/src/gameobject/test/factory/test_gameobject_factory.cpp
@@ -124,9 +124,6 @@ static dmGameObject::CreateResult TestComponentCreate(const dmGameObject::Compon
 {
     // Hard coded for the specific case "CreateCallback" below
     dmGameObject::HInstance instance = params.m_Instance;
-    if (dmGameObject::GetIdentifier(instance) != dmHashString64("/instance0")) {
-        return dmGameObject::CREATE_RESULT_UNKNOWN_ERROR;
-    }
     if (dmGameObject::GetWorldPosition(instance).getX() != 2.0f) {
         return dmGameObject::CREATE_RESULT_UNKNOWN_ERROR;
     }
@@ -280,7 +277,6 @@ TEST_F(FactoryTest, FactoryPropertiesFailTypeMismatch)
 
 TEST_F(FactoryTest, FactoryCreateCallback)
 {
-    dmGameObject::ResetInstanceIndex();
     uint32_t index = dmGameObject::AcquireInstanceIndex(m_Collection);
     dmhash_t id = dmGameObject::CreateInstanceId();
     dmGameObject::HInstance instance = Spawn(m_Factory, m_Collection, "/test_create.goc", id, 0, Point3(2.0f, 0.0f, 0.0f), Quat(), Vector3(2, 2, 2));

--- a/engine/gameobject/src/gameobject/test/factory/test_gameobject_factory.cpp
+++ b/engine/gameobject/src/gameobject/test/factory/test_gameobject_factory.cpp
@@ -160,7 +160,7 @@ TEST_F(FactoryTest, Factory)
     for (int i = 0; i < count; ++i)
     {
         uint32_t index = dmGameObject::AcquireInstanceIndex(m_Collection);
-        dmhash_t id = dmGameObject::CreateIntanceId();
+        dmhash_t id = dmGameObject::CreateInstanceId();
 
         ASSERT_NE(0u, id);
         dmGameObject::HInstance instance = Spawn(m_Factory, m_Collection, "/test.goc", id, 0, Point3(), Quat(), Vector3(1, 1, 1));
@@ -171,7 +171,7 @@ TEST_F(FactoryTest, Factory)
 TEST_F(FactoryTest, FactoryScale)
 {
     uint32_t index = dmGameObject::AcquireInstanceIndex(m_Collection);
-    dmhash_t id = dmGameObject::CreateIntanceId();
+    dmhash_t id = dmGameObject::CreateInstanceId();
     ASSERT_NE(0u, id);
     dmGameObject::HInstance instance = Spawn(m_Factory, m_Collection, "/test.goc", id, 0, Point3(), Quat(), Vector3(2, 2, 2));
     ASSERT_EQ(2.0f, dmGameObject::GetUniformScale(instance));
@@ -180,14 +180,14 @@ TEST_F(FactoryTest, FactoryScale)
 TEST_F(FactoryTest, FactoryScaleAlongZ)
 {
     uint32_t index = dmGameObject::AcquireInstanceIndex(m_Collection);
-    dmhash_t id = dmGameObject::CreateIntanceId();
+    dmhash_t id = dmGameObject::CreateInstanceId();
 
     m_Collection->m_Collection->m_ScaleAlongZ = 1;
     dmGameObject::HInstance instance = Spawn(m_Factory, m_Collection, "/test.goc", id, 0, Point3(), Quat(), Vector3(2, 2, 2));
     ASSERT_TRUE(dmGameObject::ScaleAlongZ(instance));
 
     index = dmGameObject::AcquireInstanceIndex(m_Collection);
-    id = dmGameObject::CreateIntanceId();
+    id = dmGameObject::CreateInstanceId();
     m_Collection->m_Collection->m_ScaleAlongZ = 0;
     instance = Spawn(m_Factory, m_Collection, "/test.goc", id, 0, Point3(), Quat(), Vector3(2, 2, 2));
     ASSERT_FALSE(dmGameObject::ScaleAlongZ(instance));
@@ -228,12 +228,12 @@ TEST_F(FactoryTest, FactoryProperties)
     dmGameObject::PropertyContainerPrint(properties);
 
     uint32_t index = dmGameObject::AcquireInstanceIndex(m_Collection);
-    dmhash_t id = dmGameObject::CreateIntanceId();
+    dmhash_t id = dmGameObject::CreateInstanceId();
     dmGameObject::HInstance instance = Spawn(m_Factory, m_Collection, "/test_props.goc", id, properties, Point3(), Quat(), Vector3(2, 2, 2));
     ASSERT_NE((void*)0, instance);
 
     index = dmGameObject::AcquireInstanceIndex(m_Collection);
-    id = dmGameObject::CreateIntanceId();
+    id = dmGameObject::CreateInstanceId();
     instance = Spawn(m_Factory, m_Collection, "/test_props.goc", id, properties, Point3(), Quat(), Vector3(2, 2, 2));
     ASSERT_NE((void*)0, instance);
 
@@ -252,7 +252,7 @@ TEST_F(FactoryTest, FactoryPropertiesFailUnsupportedType)
     lua_pop(L, 1);
 
     uint32_t index = dmGameObject::AcquireInstanceIndex(m_Collection);
-    dmhash_t id = dmGameObject::CreateIntanceId();
+    dmhash_t id = dmGameObject::CreateInstanceId();
     dmGameObject::HInstance instance = Spawn(m_Factory, m_Collection, "/test_props.goc", id, properties, Point3(), Quat(), Vector3(2, 2, 2));
     ASSERT_EQ((void*)0, instance);
 
@@ -271,7 +271,7 @@ TEST_F(FactoryTest, FactoryPropertiesFailTypeMismatch)
     lua_pop(L, 1);
 
     uint32_t index = dmGameObject::AcquireInstanceIndex(m_Collection);
-    dmhash_t id = dmGameObject::CreateIntanceId();
+    dmhash_t id = dmGameObject::CreateInstanceId();
     dmGameObject::HInstance instance = Spawn(m_Factory, m_Collection, "/test_props.goc", id, properties, Point3(), Quat(), Vector3(2, 2, 2));
     ASSERT_EQ((void*)0, instance);
 
@@ -282,7 +282,7 @@ TEST_F(FactoryTest, FactoryCreateCallback)
 {
     dmGameObject::ResetInstanceIndex();
     uint32_t index = dmGameObject::AcquireInstanceIndex(m_Collection);
-    dmhash_t id = dmGameObject::CreateIntanceId();
+    dmhash_t id = dmGameObject::CreateInstanceId();
     dmGameObject::HInstance instance = Spawn(m_Factory, m_Collection, "/test_create.goc", id, 0, Point3(2.0f, 0.0f, 0.0f), Quat(), Vector3(2, 2, 2));
     ASSERT_NE((void*)0, instance);
 }

--- a/engine/gameobject/src/gameobject/test/factory/test_gameobject_factory.cpp
+++ b/engine/gameobject/src/gameobject/test/factory/test_gameobject_factory.cpp
@@ -160,7 +160,7 @@ TEST_F(FactoryTest, Factory)
     for (int i = 0; i < count; ++i)
     {
         uint32_t index = dmGameObject::AcquireInstanceIndex(m_Collection);
-        dmhash_t id = dmGameObject::ConstructInstanceId();
+        dmhash_t id = dmGameObject::CreateIntanceId();
 
         ASSERT_NE(0u, id);
         dmGameObject::HInstance instance = Spawn(m_Factory, m_Collection, "/test.goc", id, 0, Point3(), Quat(), Vector3(1, 1, 1));
@@ -171,7 +171,7 @@ TEST_F(FactoryTest, Factory)
 TEST_F(FactoryTest, FactoryScale)
 {
     uint32_t index = dmGameObject::AcquireInstanceIndex(m_Collection);
-    dmhash_t id = dmGameObject::ConstructInstanceId();
+    dmhash_t id = dmGameObject::CreateIntanceId();
     ASSERT_NE(0u, id);
     dmGameObject::HInstance instance = Spawn(m_Factory, m_Collection, "/test.goc", id, 0, Point3(), Quat(), Vector3(2, 2, 2));
     ASSERT_EQ(2.0f, dmGameObject::GetUniformScale(instance));
@@ -180,14 +180,14 @@ TEST_F(FactoryTest, FactoryScale)
 TEST_F(FactoryTest, FactoryScaleAlongZ)
 {
     uint32_t index = dmGameObject::AcquireInstanceIndex(m_Collection);
-    dmhash_t id = dmGameObject::ConstructInstanceId();
+    dmhash_t id = dmGameObject::CreateIntanceId();
 
     m_Collection->m_Collection->m_ScaleAlongZ = 1;
     dmGameObject::HInstance instance = Spawn(m_Factory, m_Collection, "/test.goc", id, 0, Point3(), Quat(), Vector3(2, 2, 2));
     ASSERT_TRUE(dmGameObject::ScaleAlongZ(instance));
 
     index = dmGameObject::AcquireInstanceIndex(m_Collection);
-    id = dmGameObject::ConstructInstanceId();
+    id = dmGameObject::CreateIntanceId();
     m_Collection->m_Collection->m_ScaleAlongZ = 0;
     instance = Spawn(m_Factory, m_Collection, "/test.goc", id, 0, Point3(), Quat(), Vector3(2, 2, 2));
     ASSERT_FALSE(dmGameObject::ScaleAlongZ(instance));
@@ -228,12 +228,12 @@ TEST_F(FactoryTest, FactoryProperties)
     dmGameObject::PropertyContainerPrint(properties);
 
     uint32_t index = dmGameObject::AcquireInstanceIndex(m_Collection);
-    dmhash_t id = dmGameObject::ConstructInstanceId();
+    dmhash_t id = dmGameObject::CreateIntanceId();
     dmGameObject::HInstance instance = Spawn(m_Factory, m_Collection, "/test_props.goc", id, properties, Point3(), Quat(), Vector3(2, 2, 2));
     ASSERT_NE((void*)0, instance);
 
     index = dmGameObject::AcquireInstanceIndex(m_Collection);
-    id = dmGameObject::ConstructInstanceId();
+    id = dmGameObject::CreateIntanceId();
     instance = Spawn(m_Factory, m_Collection, "/test_props.goc", id, properties, Point3(), Quat(), Vector3(2, 2, 2));
     ASSERT_NE((void*)0, instance);
 
@@ -252,7 +252,7 @@ TEST_F(FactoryTest, FactoryPropertiesFailUnsupportedType)
     lua_pop(L, 1);
 
     uint32_t index = dmGameObject::AcquireInstanceIndex(m_Collection);
-    dmhash_t id = dmGameObject::ConstructInstanceId();
+    dmhash_t id = dmGameObject::CreateIntanceId();
     dmGameObject::HInstance instance = Spawn(m_Factory, m_Collection, "/test_props.goc", id, properties, Point3(), Quat(), Vector3(2, 2, 2));
     ASSERT_EQ((void*)0, instance);
 
@@ -271,7 +271,7 @@ TEST_F(FactoryTest, FactoryPropertiesFailTypeMismatch)
     lua_pop(L, 1);
 
     uint32_t index = dmGameObject::AcquireInstanceIndex(m_Collection);
-    dmhash_t id = dmGameObject::ConstructInstanceId();
+    dmhash_t id = dmGameObject::CreateIntanceId();
     dmGameObject::HInstance instance = Spawn(m_Factory, m_Collection, "/test_props.goc", id, properties, Point3(), Quat(), Vector3(2, 2, 2));
     ASSERT_EQ((void*)0, instance);
 
@@ -282,7 +282,7 @@ TEST_F(FactoryTest, FactoryCreateCallback)
 {
     dmGameObject::ResetInstanceIndex();
     uint32_t index = dmGameObject::AcquireInstanceIndex(m_Collection);
-    dmhash_t id = dmGameObject::ConstructInstanceId();
+    dmhash_t id = dmGameObject::CreateIntanceId();
     dmGameObject::HInstance instance = Spawn(m_Factory, m_Collection, "/test_create.goc", id, 0, Point3(2.0f, 0.0f, 0.0f), Quat(), Vector3(2, 2, 2));
     ASSERT_NE((void*)0, instance);
 }

--- a/engine/gameobject/src/gameobject/test/factory/test_gameobject_factory.cpp
+++ b/engine/gameobject/src/gameobject/test/factory/test_gameobject_factory.cpp
@@ -159,7 +159,8 @@ TEST_F(FactoryTest, Factory)
     const int count = 10;
     for (int i = 0; i < count; ++i)
     {
-        dmhash_t id = dmGameObject::ConstructInstanceId();
+        uint32_t index = dmGameObject::AcquireInstanceIndex(m_Collection);
+        dmhash_t id = dmGameObject::ConstructInstanceId(index);
 
         ASSERT_NE(0u, id);
         dmGameObject::HInstance instance = Spawn(m_Factory, m_Collection, "/test.goc", id, 0, Point3(), Quat(), Vector3(1, 1, 1));
@@ -169,7 +170,8 @@ TEST_F(FactoryTest, Factory)
 
 TEST_F(FactoryTest, FactoryScale)
 {
-    dmhash_t id = dmGameObject::ConstructInstanceId();
+    uint32_t index = dmGameObject::AcquireInstanceIndex(m_Collection);
+    dmhash_t id = dmGameObject::ConstructInstanceId(index);
     ASSERT_NE(0u, id);
     dmGameObject::HInstance instance = Spawn(m_Factory, m_Collection, "/test.goc", id, 0, Point3(), Quat(), Vector3(2, 2, 2));
     ASSERT_EQ(2.0f, dmGameObject::GetUniformScale(instance));
@@ -177,13 +179,15 @@ TEST_F(FactoryTest, FactoryScale)
 
 TEST_F(FactoryTest, FactoryScaleAlongZ)
 {
-    dmhash_t id = dmGameObject::ConstructInstanceId();
+    uint32_t index = dmGameObject::AcquireInstanceIndex(m_Collection);
+    dmhash_t id = dmGameObject::ConstructInstanceId(index);
 
     m_Collection->m_Collection->m_ScaleAlongZ = 1;
     dmGameObject::HInstance instance = Spawn(m_Factory, m_Collection, "/test.goc", id, 0, Point3(), Quat(), Vector3(2, 2, 2));
     ASSERT_TRUE(dmGameObject::ScaleAlongZ(instance));
 
-    id = dmGameObject::ConstructInstanceId();
+    index = dmGameObject::AcquireInstanceIndex(m_Collection);
+    id = dmGameObject::ConstructInstanceId(index);
     m_Collection->m_Collection->m_ScaleAlongZ = 0;
     instance = Spawn(m_Factory, m_Collection, "/test.goc", id, 0, Point3(), Quat(), Vector3(2, 2, 2));
     ASSERT_FALSE(dmGameObject::ScaleAlongZ(instance));
@@ -223,11 +227,13 @@ TEST_F(FactoryTest, FactoryProperties)
 
     dmGameObject::PropertyContainerPrint(properties);
 
-    dmhash_t id = dmGameObject::ConstructInstanceId();
+    uint32_t index = dmGameObject::AcquireInstanceIndex(m_Collection);
+    dmhash_t id = dmGameObject::ConstructInstanceId(index);
     dmGameObject::HInstance instance = Spawn(m_Factory, m_Collection, "/test_props.goc", id, properties, Point3(), Quat(), Vector3(2, 2, 2));
     ASSERT_NE((void*)0, instance);
 
-    id = dmGameObject::ConstructInstanceId();
+    index = dmGameObject::AcquireInstanceIndex(m_Collection);
+    id = dmGameObject::ConstructInstanceId(index);
     instance = Spawn(m_Factory, m_Collection, "/test_props.goc", id, properties, Point3(), Quat(), Vector3(2, 2, 2));
     ASSERT_NE((void*)0, instance);
 
@@ -245,7 +251,8 @@ TEST_F(FactoryTest, FactoryPropertiesFailUnsupportedType)
     dmGameObject::HPropertyContainer properties = dmGameObject::PropertyContainerCreateFromLua(L, -1);
     lua_pop(L, 1);
 
-    dmhash_t id = dmGameObject::ConstructInstanceId();
+    uint32_t index = dmGameObject::AcquireInstanceIndex(m_Collection);
+    dmhash_t id = dmGameObject::ConstructInstanceId(index);
     dmGameObject::HInstance instance = Spawn(m_Factory, m_Collection, "/test_props.goc", id, properties, Point3(), Quat(), Vector3(2, 2, 2));
     ASSERT_EQ((void*)0, instance);
 
@@ -263,7 +270,8 @@ TEST_F(FactoryTest, FactoryPropertiesFailTypeMismatch)
     dmGameObject::HPropertyContainer properties = dmGameObject::PropertyContainerCreateFromLua(L, -1);
     lua_pop(L, 1);
 
-    dmhash_t id = dmGameObject::ConstructInstanceId();
+    uint32_t index = dmGameObject::AcquireInstanceIndex(m_Collection);
+    dmhash_t id = dmGameObject::ConstructInstanceId(index);
     dmGameObject::HInstance instance = Spawn(m_Factory, m_Collection, "/test_props.goc", id, properties, Point3(), Quat(), Vector3(2, 2, 2));
     ASSERT_EQ((void*)0, instance);
 
@@ -272,7 +280,8 @@ TEST_F(FactoryTest, FactoryPropertiesFailTypeMismatch)
 
 TEST_F(FactoryTest, FactoryCreateCallback)
 {
-    dmhash_t id = dmGameObject::ConstructInstanceId();
+    uint32_t index = dmGameObject::AcquireInstanceIndex(m_Collection);
+    dmhash_t id = dmGameObject::ConstructInstanceId(index);
     dmGameObject::HInstance instance = Spawn(m_Factory, m_Collection, "/test_create.goc", id, 0, Point3(2.0f, 0.0f, 0.0f), Quat(), Vector3(2, 2, 2));
     ASSERT_NE((void*)0, instance);
 }

--- a/engine/gameobject/src/gameobject/test/spawn_delete/test_gameobject_spawn_delete.cpp
+++ b/engine/gameobject/src/gameobject/test/spawn_delete/test_gameobject_spawn_delete.cpp
@@ -47,7 +47,7 @@ static int Lua_Spawn(lua_State* L) {
     dmGameObject::HInstance instance = dmGameObject::GetInstanceFromLua(L);
     dmGameObject::HCollection collection = dmGameObject::GetCollection(instance);
     uint32_t index = dmGameObject::AcquireInstanceIndex(collection);
-    dmhash_t id = dmGameObject::CreateIntanceId();
+    dmhash_t id = dmGameObject::CreateInstanceId();
     dmResource::HFactory factory = dmGameObject::GetFactory(collection);
     dmGameObject::HInstance spawned = Spawn(factory, collection, prototype, id, 0, dmVMath::Point3(0.0f, 0.0f, 0.0f), dmVMath::Quat(0.0f, 0.0f, 0.0f, 1.0f), Vector3(1, 1, 1));
     if (spawned == 0x0) {

--- a/engine/gameobject/src/gameobject/test/spawn_delete/test_gameobject_spawn_delete.cpp
+++ b/engine/gameobject/src/gameobject/test/spawn_delete/test_gameobject_spawn_delete.cpp
@@ -46,7 +46,8 @@ static int Lua_Spawn(lua_State* L) {
     const char* prototype = luaL_checkstring(L, 1);
     dmGameObject::HInstance instance = dmGameObject::GetInstanceFromLua(L);
     dmGameObject::HCollection collection = dmGameObject::GetCollection(instance);
-    dmhash_t id = dmGameObject::ConstructInstanceId();
+    uint32_t index = dmGameObject::AcquireInstanceIndex(collection);
+    dmhash_t id = dmGameObject::ConstructInstanceId(index);
     dmResource::HFactory factory = dmGameObject::GetFactory(collection);
     dmGameObject::HInstance spawned = Spawn(factory, collection, prototype, id, 0, dmVMath::Point3(0.0f, 0.0f, 0.0f), dmVMath::Quat(0.0f, 0.0f, 0.0f, 1.0f), Vector3(1, 1, 1));
     if (spawned == 0x0) {

--- a/engine/gameobject/src/gameobject/test/spawn_delete/test_gameobject_spawn_delete.cpp
+++ b/engine/gameobject/src/gameobject/test/spawn_delete/test_gameobject_spawn_delete.cpp
@@ -46,8 +46,7 @@ static int Lua_Spawn(lua_State* L) {
     const char* prototype = luaL_checkstring(L, 1);
     dmGameObject::HInstance instance = dmGameObject::GetInstanceFromLua(L);
     dmGameObject::HCollection collection = dmGameObject::GetCollection(instance);
-    uint32_t index = dmGameObject::AcquireInstanceIndex(collection);
-    dmhash_t id = dmGameObject::ConstructInstanceId(index);
+    dmhash_t id = dmGameObject::ConstructInstanceId();
     dmResource::HFactory factory = dmGameObject::GetFactory(collection);
     dmGameObject::HInstance spawned = Spawn(factory, collection, prototype, id, 0, dmVMath::Point3(0.0f, 0.0f, 0.0f), dmVMath::Quat(0.0f, 0.0f, 0.0f, 1.0f), Vector3(1, 1, 1));
     if (spawned == 0x0) {

--- a/engine/gameobject/src/gameobject/test/spawn_delete/test_gameobject_spawn_delete.cpp
+++ b/engine/gameobject/src/gameobject/test/spawn_delete/test_gameobject_spawn_delete.cpp
@@ -47,7 +47,7 @@ static int Lua_Spawn(lua_State* L) {
     dmGameObject::HInstance instance = dmGameObject::GetInstanceFromLua(L);
     dmGameObject::HCollection collection = dmGameObject::GetCollection(instance);
     uint32_t index = dmGameObject::AcquireInstanceIndex(collection);
-    dmhash_t id = dmGameObject::ConstructInstanceId(index);
+    dmhash_t id = dmGameObject::ConstructInstanceId();
     dmResource::HFactory factory = dmGameObject::GetFactory(collection);
     dmGameObject::HInstance spawned = Spawn(factory, collection, prototype, id, 0, dmVMath::Point3(0.0f, 0.0f, 0.0f), dmVMath::Quat(0.0f, 0.0f, 0.0f, 1.0f), Vector3(1, 1, 1));
     if (spawned == 0x0) {

--- a/engine/gameobject/src/gameobject/test/spawn_delete/test_gameobject_spawn_delete.cpp
+++ b/engine/gameobject/src/gameobject/test/spawn_delete/test_gameobject_spawn_delete.cpp
@@ -47,7 +47,7 @@ static int Lua_Spawn(lua_State* L) {
     dmGameObject::HInstance instance = dmGameObject::GetInstanceFromLua(L);
     dmGameObject::HCollection collection = dmGameObject::GetCollection(instance);
     uint32_t index = dmGameObject::AcquireInstanceIndex(collection);
-    dmhash_t id = dmGameObject::ConstructInstanceId();
+    dmhash_t id = dmGameObject::CreateIntanceId();
     dmResource::HFactory factory = dmGameObject::GetFactory(collection);
     dmGameObject::HInstance spawned = Spawn(factory, collection, prototype, id, 0, dmVMath::Point3(0.0f, 0.0f, 0.0f), dmVMath::Quat(0.0f, 0.0f, 0.0f, 1.0f), Vector3(1, 1, 1));
     if (spawned == 0x0) {

--- a/engine/gamesys/src/gamesys/components/comp_factory.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_factory.cpp
@@ -214,7 +214,7 @@ namespace dmGameSystem
                     return dmGameObject::UPDATE_RESULT_OK;
                 }
 
-                id = dmGameObject::ConstructInstanceId();
+                id = dmGameObject::CreateIntanceId();
             }
 
             // m_Scale is legacy, so use it if Scale3 is all zeroes

--- a/engine/gamesys/src/gamesys/components/comp_factory.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_factory.cpp
@@ -214,7 +214,7 @@ namespace dmGameSystem
                     return dmGameObject::UPDATE_RESULT_OK;
                 }
 
-                id = dmGameObject::CreateIntanceId();
+                id = dmGameObject::CreateInstanceId();
             }
 
             // m_Scale is legacy, so use it if Scale3 is all zeroes

--- a/engine/gamesys/src/gamesys/components/comp_factory.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_factory.cpp
@@ -214,7 +214,7 @@ namespace dmGameSystem
                     return dmGameObject::UPDATE_RESULT_OK;
                 }
 
-                id = dmGameObject::ConstructInstanceId(index);
+                id = dmGameObject::ConstructInstanceId();
             }
 
             // m_Scale is legacy, so use it if Scale3 is all zeroes

--- a/engine/gamesys/src/gamesys/components/comp_model.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_model.cpp
@@ -643,7 +643,7 @@ namespace dmGameSystem
                     return false;
                 }
 
-                dmhash_t id = dmGameObject::ConstructInstanceId(index);
+                dmhash_t id = dmGameObject::ConstructInstanceId();
                 dmGameObject::AssignInstanceIndex(index, bone_inst);
 
                 dmGameObject::Result result = dmGameObject::SetIdentifier(collection, bone_inst, id);

--- a/engine/gamesys/src/gamesys/components/comp_model.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_model.cpp
@@ -643,7 +643,7 @@ namespace dmGameSystem
                     return false;
                 }
                 dmGameObject::AssignInstanceIndex(index, bone_inst);
-                dmhash_t id = dmGameObject::ConstructInstanceId();
+                dmhash_t id = dmGameObject::CreateInstanceId();
                 dmGameObject::Result result = dmGameObject::SetIdentifier(collection, bone_inst, id);
                 if (dmGameObject::RESULT_OK != result)
                 {

--- a/engine/gamesys/src/gamesys/components/comp_model.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_model.cpp
@@ -646,7 +646,7 @@ namespace dmGameSystem
                 dmhash_t id = dmGameObject::ConstructInstanceId();
                 dmGameObject::AssignInstanceIndex(index, bone_inst);
 
-                dmGameObject::Result result = dmGameObject::SetIdentifier(collection, bone_inst, id);
+                dmGameObject::Result result = dmGameObject::SetConstructedIdentifier(collection, bone_inst);
                 if (dmGameObject::RESULT_OK != result)
                 {
                     dmGameObject::Delete(collection, bone_inst, false);

--- a/engine/gamesys/src/gamesys/components/comp_model.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_model.cpp
@@ -643,7 +643,6 @@ namespace dmGameSystem
                     return false;
                 }
 
-                dmhash_t id = dmGameObject::ConstructInstanceId();
                 dmGameObject::AssignInstanceIndex(index, bone_inst);
 
                 dmGameObject::Result result = dmGameObject::SetConstructedIdentifier(collection, bone_inst);

--- a/engine/gamesys/src/gamesys/components/comp_model.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_model.cpp
@@ -642,10 +642,9 @@ namespace dmGameSystem
                     component->m_NodeInstances.SetSize(i);
                     return false;
                 }
-
                 dmGameObject::AssignInstanceIndex(index, bone_inst);
-
-                dmGameObject::Result result = dmGameObject::SetConstructedIdentifier(collection, bone_inst);
+                dmhash_t id = dmGameObject::ConstructInstanceId();
+                dmGameObject::Result result = dmGameObject::SetIdentifier(collection, bone_inst, id);
                 if (dmGameObject::RESULT_OK != result)
                 {
                     dmGameObject::Delete(collection, bone_inst, false);

--- a/engine/gamesys/src/gamesys/scripts/script_factory.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_factory.cpp
@@ -339,7 +339,7 @@ namespace dmGameSystem
         }
         else
         {
-            dmhash_t id = dmGameObject::CreateIntanceId();
+            dmhash_t id = dmGameObject::CreateInstanceId();
 
             // TODO: When does this actually happen? In render scripts? Or unit tests only?
             bool msg_passing = dmGameObject::GetInstanceFromLua(L) == 0x0;

--- a/engine/gamesys/src/gamesys/scripts/script_factory.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_factory.cpp
@@ -339,7 +339,7 @@ namespace dmGameSystem
         }
         else
         {
-            dmhash_t id = dmGameObject::ConstructInstanceId(index);
+            dmhash_t id = dmGameObject::ConstructInstanceId();
 
             // TODO: When does this actually happen? In render scripts? Or unit tests only?
             bool msg_passing = dmGameObject::GetInstanceFromLua(L) == 0x0;

--- a/engine/gamesys/src/gamesys/scripts/script_factory.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_factory.cpp
@@ -339,7 +339,7 @@ namespace dmGameSystem
         }
         else
         {
-            dmhash_t id = dmGameObject::ConstructInstanceId();
+            dmhash_t id = dmGameObject::CreateIntanceId();
 
             // TODO: When does this actually happen? In render scripts? Or unit tests only?
             bool msg_passing = dmGameObject::GetInstanceFromLua(L) == 0x0;

--- a/engine/gamesys/src/gamesys/test/factory/dynamic_factory_test.script
+++ b/engine/gamesys/src/gamesys/test/factory/dynamic_factory_test.script
@@ -24,9 +24,10 @@ end
 
 function load_complete(self, url, result)
     assert(result == true)
-    factory.create(url)
-    factory.create(url)
+    first_instance = factory.create(url)
+    second_instance = factory.create(url)
     self.loaded = true
+    global_created = true
 end
 
 function update(self, dt)
@@ -48,8 +49,9 @@ function update(self, dt)
         if self.repeatloadunload == true then
            self.repeatloadunload = false
            self.load = true
-            go.delete("/instance0", true)
-            go.delete("/instance1", true)
+            go.delete(first_instance, true)
+            go.delete(second_instance, true)
+            global_created = nil
         else
             self.testunloadtwice = true
         end
@@ -68,21 +70,26 @@ function update(self, dt)
     if self.delete == true then
         self.delete = false
         self.create = true
-        go.delete("/instance0", true)
-        go.delete("/instance1", true)
+        go.delete(first_instance, true)
+        go.delete(second_instance, true)
+        global_created = nil
         return
     end
 
     --- step 5 ---
     if self.create == true then
         self.create = false
-        factory.create("/go#factory")
-        factory.create("/go#factory")
+        first_instance = factory.create("/go#factory")
+        second_instance = factory.create("/go#factory")
+        global_created = true
         return
     end
 end
 
 function final(self)
-    go.delete("/instance0", true)
-    go.delete("/instance1", true)
+    go.delete(first_instance, true)
+    go.delete(second_instance, true)
+    global_created = nil
+    first_instance = nil
+    second_instance = nil
 end

--- a/engine/gamesys/src/gamesys/test/factory/factory_test.script
+++ b/engine/gamesys/src/gamesys/test/factory/factory_test.script
@@ -22,8 +22,8 @@ end
 
 function load_complete(self, url, result)
     assert(result == true)
-    factory.create(url)
-    factory.create(url)
+    self.first_instance = factory.create(url)
+    self.second_instance = factory.create(url)
     self.unload = true
 end
 
@@ -36,6 +36,6 @@ function update(self, dt)
 end
 
 function final(self)
-    go.delete("/instance0", true)
-    go.delete("/instance1", true)
+    go.delete(self.first_instance, true)
+    go.delete(self.second_instance, true)
 end

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -1866,6 +1866,7 @@ TEST_F(WindowTest, Events)
 
 TEST_P(FactoryTest, Test)
 {
+    dmGameObject::ResetInstanceIndex();
     const char* resource_path[] = {
             "/factory/factory_resource.goc",
             "/sprite/valid.spritec",
@@ -1937,6 +1938,7 @@ TEST_P(FactoryTest, Test)
                 ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
                 ASSERT_TRUE(dmGameObject::PostUpdate(m_Collection));
                 dmGameObject::PostUpdate(m_Register);
+                dmGameObject::ResetInstanceIndex();
             }
             ASSERT_EQ(3, dmResource::GetRefCount(m_Factory, dmHashString64(resource_path[0])));
             ASSERT_EQ(1, dmResource::GetRefCount(m_Factory, dmHashString64(resource_path[1])));

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -1866,7 +1866,6 @@ TEST_F(WindowTest, Events)
 
 TEST_P(FactoryTest, Test)
 {
-    dmGameObject::ResetInstanceIndex();
     const char* resource_path[] = {
             "/factory/factory_resource.goc",
             "/sprite/valid.spritec",
@@ -1874,11 +1873,12 @@ TEST_P(FactoryTest, Test)
             "/sprite/sprite.materialc",
     };
     dmHashEnableReverseHash(true);
+    lua_State* L = dmScript::GetLuaState(m_ScriptContext);
 
     dmGameSystem::ScriptLibContext scriptlibcontext;
     scriptlibcontext.m_Factory         = m_Factory;
     scriptlibcontext.m_Register        = m_Register;
-    scriptlibcontext.m_LuaState        = dmScript::GetLuaState(m_ScriptContext);
+    scriptlibcontext.m_LuaState        = L;
     scriptlibcontext.m_GraphicsContext = m_GraphicsContext;
     scriptlibcontext.m_ScriptContext   = m_ScriptContext;
 
@@ -1930,15 +1930,26 @@ TEST_P(FactoryTest, Test)
         // Do this twice in order to ensure load/unload can be called multiple times, with and without deleting created objects
         for(uint32_t i = 0; i < 2; ++i)
         {
-            dmhash_t last_object_id = i == 0 ? dmHashString64("/instance1") : dmHashString64("/instance0"); // stacked index list in dynamic spawning
             for(;;)
             {
-                if(dmGameObject::GetInstanceFromIdentifier(m_Collection, last_object_id) != 0x0)
-                    break;
+                lua_getglobal(L, "global_created");
+                bool ready = !lua_isnil(L, -1);
+                lua_pop(L, 1);
+                if(ready)
+                {
+                    lua_getglobal(L, "first_instance");
+                    dmhash_t first_instance = dmScript::CheckHash(L, -1);
+                    lua_pop(L, 1);
+                    lua_getglobal(L, "second_instance");
+                    dmhash_t second_instance = dmScript::CheckHash(L, -1);
+                    lua_pop(L, 1);
+                    dmhash_t last_object_id = i == 0 ? second_instance : first_instance; // stacked index list in dynamic spawning
+                    if (dmGameObject::GetInstanceFromIdentifier(m_Collection, last_object_id) != 0x0)
+                        break;
+                }
                 ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
                 ASSERT_TRUE(dmGameObject::PostUpdate(m_Collection));
                 dmGameObject::PostUpdate(m_Register);
-                dmGameObject::ResetInstanceIndex();
             }
             ASSERT_EQ(3, dmResource::GetRefCount(m_Factory, dmHashString64(resource_path[0])));
             ASSERT_EQ(1, dmResource::GetRefCount(m_Factory, dmHashString64(resource_path[1])));


### PR DESCRIPTION
All objects spawned with factories now have unique identifiers, which helps to avoid hidden issues

Fix https://github.com/defold/defold/issues/9851