### PR TITLE
Hide toolbars of inactive tabs

### DIFF
--- a/editor/src/clj/editor/ui.clj
+++ b/editor/src/clj/editor/ui.clj
@@ -1914,10 +1914,17 @@
   [^Scene scene evaluation-context]
   (let [visible-command-contexts (visible-command-contexts scene)
         current-command-contexts (current-command-contexts scene)
-        root (.getRoot scene)]
+        root (.getRoot scene)
+        app-view (-> current-command-contexts first :env :app-view)
+        active-tab (g/maybe-node-value app-view :active-tab evaluation-context)]
     (doseq [td (vals (user-data root ::toolbars))]
-      (refresh-toolbar td visible-command-contexts evaluation-context)
-      (refresh-toolbar-state (:control td) current-command-contexts evaluation-context))))
+      (let [control (:control td)
+            is-active (boolean (when active-tab
+                                 (nodes-along-path? control (.getContent ^Tab active-tab) root)))]
+        (visible! control is-active)
+        (when is-active
+          (refresh-toolbar td visible-command-contexts evaluation-context)
+          (refresh-toolbar-state (:control td) current-command-contexts evaluation-context))))))
 
 (defn refresh
   [^Scene scene]


### PR DESCRIPTION
This should hide all toolbars of inactive tabs.

Fixes #10468