### PR TITLE
⚠️ Removed `scale_along_z` from the engine

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/CollectionBuilderTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/CollectionBuilderTest.java
@@ -228,14 +228,14 @@ public class CollectionBuilderTest extends AbstractProtoBuilderTest {
         assertEquals(new Quat4d(0, 1, 0, 0), inst.getRotation(), epsilon);
         Assert.assertEquals(0.25, inst.getScale3().getX(), epsilon);
         Assert.assertEquals(0.25, inst.getScale3().getY(), epsilon);
-        Assert.assertEquals(0.5, inst.getScale3().getZ(), epsilon);
+        Assert.assertEquals(0.25, inst.getScale3().getZ(), epsilon);
 
         inst = instances.get("/sub/sub_sub/test");
-        assertEquals(new Point3d(0.5, 0, -0.5), inst.getPosition(), epsilon);
+        assertEquals(new Point3d(0.75, 0, -0.5), inst.getPosition(), epsilon);
         assertEquals(new Quat4d(0, sq2, 0, -sq2), inst.getRotation(), epsilon);
         Assert.assertEquals(0.125, inst.getScale3().getX(), epsilon);
         Assert.assertEquals(0.125, inst.getScale3().getY(), epsilon);
-        Assert.assertEquals(0.5, inst.getScale3().getZ(), epsilon);
+        Assert.assertEquals(0.125, inst.getScale3().getZ(), epsilon);
 
         inst = instances.get("/sub/sub_sub/test_child");
         assertEquals(new Point3d(1, 0, 0), inst.getPosition(), epsilon);
@@ -245,11 +245,11 @@ public class CollectionBuilderTest extends AbstractProtoBuilderTest {
         Assert.assertEquals(0.5, inst.getScale3().getZ(), epsilon);
 
         inst = instances.get("/sub/sub_sub/test_embed");
-        assertEquals(new Point3d(0.5, 0, -0.5), inst.getPosition(), epsilon);
+        assertEquals(new Point3d(0.75, 0, -0.5), inst.getPosition(), epsilon);
         assertEquals(new Quat4d(0, sq2, 0, -sq2), inst.getRotation(), epsilon);
         Assert.assertEquals(0.125, inst.getScale3().getX(), epsilon);
         Assert.assertEquals(0.125, inst.getScale3().getY(), epsilon);
-        Assert.assertEquals(0.5, inst.getScale3().getZ(), epsilon);
+        Assert.assertEquals(0.125, inst.getScale3().getZ(), epsilon);
 
         inst = instances.get("/sub/sub_sub/test_embed_child");
         assertEquals(new Point3d(1, 0, 0), inst.getPosition(), epsilon);
@@ -308,7 +308,7 @@ public class CollectionBuilderTest extends AbstractProtoBuilderTest {
         assertEquals(new Quat4d(0, 1, 0, 0), inst.getRotation(), epsilon);
         Assert.assertEquals(0.25, inst.getScale3().getX(), epsilon);
         Assert.assertEquals(0.25, inst.getScale3().getY(), epsilon);
-        Assert.assertEquals(0.5, inst.getScale3().getZ(), epsilon);
+        Assert.assertEquals(0.25, inst.getScale3().getZ(), epsilon);
         Assert.assertEquals("/sub/child", inst.getChildren(0));
 
         inst = instances.get("/sub/child");

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/CollectionBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/CollectionBuilder.java
@@ -216,11 +216,7 @@ public class CollectionBuilder extends ProtoBuilder<CollectionDesc.Builder> {
                 s = MathUtil.ddfToVecmath(collInst.getScale3());
             } else {
                 double scale = collInst.getScale();
-                if (subCollBuilder.getScaleAlongZ() != 0) {
-                    s = new Vector3d(scale, scale, scale);
-                } else {
-                    s = new Vector3d(scale, scale, 1);
-                }
+                s = new Vector3d(scale, scale, scale);
             }
 
             for (InstanceDesc inst : subCollBuilder.getInstancesList()) {
@@ -291,11 +287,7 @@ public class CollectionBuilder extends ProtoBuilder<CollectionDesc.Builder> {
                     instS.set(instS.getX() * s.getX(), instS.getY() * s.getY(), instS.getZ() * s.getZ());
 
                     Point3d instP = MathUtil.ddfToVecmath(inst.getPosition());
-                    if (subCollBuilder.getScaleAlongZ() != 0) {
-                        instP.set(s.getX() * instP.getX(), s.getY() * instP.getY(), s.getZ() * instP.getZ());
-                    } else {
-                        instP.set(s.getX() * instP.getX(), s.getY() * instP.getY(), instP.getZ());
-                    }
+                    instP.set(s.getX() * instP.getX(), s.getY() * instP.getY(), s.getZ() * instP.getZ());
                     MathUtil.rotate(r, instP);
                     instP.add(p);
                     instBuilder.setPosition(MathUtil.vecmathToDDF(instP));

--- a/editor/src/clj/editor/collection.clj
+++ b/editor/src/clj/editor/collection.clj
@@ -377,10 +377,9 @@
                                    (gen-ref-ddf id child-ids position rotation scale source-resource ddf-component-properties)))
   (output build-targets g/Any produce-referenced-go-build-targets))
 
-(g/defnk produce-proto-msg [name scale-along-z ref-inst-ddf embed-inst-ddf ref-coll-ddf]
+(g/defnk produce-proto-msg [name ref-inst-ddf embed-inst-ddf ref-coll-ddf]
   (protobuf/make-map-without-defaults GameObject$CollectionDesc
     :name name
-    :scale-along-z (protobuf/boolean->int scale-along-z)
     :instances ref-inst-ddf
     :embedded-instances embed-inst-ddf
     :collection-instances ref-coll-ddf))
@@ -414,11 +413,11 @@
       (protobuf/sanitize-repeated :embedded-instances embedded-instance-desc-save-value)
       (protobuf/sanitize-repeated :collection-instances collection-instance-desc-save-value)))
 
-(g/defnk produce-build-targets [_node-id name resource sub-build-targets dep-build-targets id-counts scale-along-z]
+(g/defnk produce-build-targets [_node-id name resource sub-build-targets dep-build-targets id-counts]
   (or (let [dup-ids (keep (fn [[id count]] (when (> count 1) id)) id-counts)]
         (game-object-common/maybe-duplicate-id-error _node-id dup-ids))
       (let [build-resource (workspace/make-build-resource resource)]
-        [(collection-common/collection-build-target build-resource _node-id name scale-along-z dep-build-targets sub-build-targets)])))
+        [(collection-common/collection-build-target build-resource _node-id name dep-build-targets sub-build-targets)])))
 
 (declare CollectionInstanceNode)
 

--- a/editor/src/clj/editor/collection.clj
+++ b/editor/src/clj/editor/collection.clj
@@ -377,9 +377,10 @@
                                    (gen-ref-ddf id child-ids position rotation scale source-resource ddf-component-properties)))
   (output build-targets g/Any produce-referenced-go-build-targets))
 
-(g/defnk produce-proto-msg [name ref-inst-ddf embed-inst-ddf ref-coll-ddf]
+(g/defnk produce-proto-msg [name scale-along-z ref-inst-ddf embed-inst-ddf ref-coll-ddf]
   (protobuf/make-map-without-defaults GameObject$CollectionDesc
     :name name
+    :scale-along-z (protobuf/boolean->int scale-along-z)
     :instances ref-inst-ddf
     :embedded-instances embed-inst-ddf
     :collection-instances ref-coll-ddf))

--- a/editor/src/clj/editor/collection_common.clj
+++ b/editor/src/clj/editor/collection_common.clj
@@ -284,7 +284,7 @@
   ;; equivalent. We must update any references to these BuildResources
   ;; to instead point to the resulting fused BuildResource. The same goes for
   ;; resource property overrides inside the InstanceDescs.
-  (let [{:keys [name game-object-instance-datas scale-along-z]} user-data
+  (let [{:keys [name game-object-instance-datas]} user-data
         build-go-props (partial properties/build-go-props dep-resources)
         go-instance-msgs (map :instance-msg game-object-instance-datas)
         go-instance-transform-properties (map (comp pose->transform-properties :pose) game-object-instance-datas)
@@ -315,16 +315,14 @@
                                       go-instance-component-go-props)
         collection-desc {:name name
                          :instances (sort-instance-descs-for-build-output instance-descs)
-                         :scale-along-z (protobuf/boolean->int scale-along-z)
                          :property-resources property-resource-paths}]
     {:resource build-resource
      :content (protobuf/map->bytes GameObject$CollectionDesc collection-desc)}))
 
-(defn collection-build-target [build-resource node-id name scale-along-z game-object-instance-build-targets collection-instance-build-targets]
+(defn collection-build-target [build-resource node-id name game-object-instance-build-targets collection-instance-build-targets]
   {:pre [(workspace/build-resource? build-resource)
          (g/node-id? node-id)
          (or (nil? name) (string? name))
-         (boolean? scale-along-z)
          (seqable? game-object-instance-build-targets)
          (seqable? collection-instance-build-targets)]}
   ;; Extract the :game-object-instance-datas from the game object instance build
@@ -345,7 +343,6 @@
        :resource build-resource
        :build-fn build-collection
        :user-data {:name (or name "")
-                   :scale-along-z scale-along-z
                    :game-object-instance-datas (mapv #(dissoc % :property-deps)
                                                      game-object-instance-datas)}
        :deps (into (vec (concat game-object-instance-build-targets property-deps))

--- a/editor/src/clj/editor/collection_non_editable.clj
+++ b/editor/src/clj/editor/collection_non_editable.clj
@@ -129,7 +129,6 @@
           (game-object-common/maybe-duplicate-id-error _node-id dup-ids))
         (let [build-resource (workspace/make-build-resource resource)
               name (:name collection-desc)
-              scale-along-z (not= 0 (:scale-along-z collection-desc))
 
               game-object-instance-build-targets
               (into embedded-game-object-instance-build-targets
@@ -146,7 +145,7 @@
                             instance-property-descs (mapv #(instance-property-desc-with-go-props % proj-path->source-resource) (:instance-properties collection-instance-desc))]
                         (collection-common/collection-instance-build-target collection-instance-id pose instance-property-descs referenced-collection-build-target proj-path->build-target)))
                     collection-instance-descs)]
-          [(collection-common/collection-build-target build-resource _node-id name scale-along-z game-object-instance-build-targets collection-instance-build-targets)]))))
+          [(collection-common/collection-build-target build-resource _node-id name game-object-instance-build-targets collection-instance-build-targets)]))))
 
 (defn component-property-desc-overrides-properties? [component-property-desc]
   (not (empty? (:properties component-property-desc))))

--- a/engine/dlib/src/dlib/transform.h
+++ b/engine/dlib/src/dlib/transform.h
@@ -91,17 +91,6 @@ namespace dmTransform
     }
 
     /**
-     * Apply the transform on a point, but without scaling the Z-component of the point (includes the transform translation).
-     * @param t Transform
-     * @param p Point
-     * @return Transformed point
-     */
-    inline dmVMath::Point3 ApplyNoScaleZ(const TransformS1& t, const dmVMath::Point3 p)
-    {
-        return dmVMath::Point3(rotate(t.GetRotation(), mulPerElem(dmVMath::Vector3(t.GetScale(), t.GetScale(), 1.0f), dmVMath::Vector3(p))) + t.GetTranslation());
-    }
-
-    /**
      * Apply the transform on a vector (excludes the transform translation).
      * @param t Transform
      * @param v Vector
@@ -110,17 +99,6 @@ namespace dmTransform
     inline dmVMath::Vector3 Apply(const TransformS1& t, const dmVMath::Vector3 v)
     {
         return dmVMath::Vector3(rotate(t.GetRotation(), v * t.GetScale()));
-    }
-
-    /**
-     * Apply the transform on a vector, but without scaling the Z-component of the vector (excludes the transform translation).
-     * @param t Transform
-     * @param v Vector
-     * @return Transformed vector
-     */
-    inline dmVMath::Vector3 ApplyNoScaleZ(const TransformS1& t, const dmVMath::Vector3 v)
-    {
-        return dmVMath::Vector3(rotate(t.GetRotation(), mulPerElem(dmVMath::Vector3(t.GetScale(), t.GetScale(), 1.0f), v)));
     }
 
     /**
@@ -134,21 +112,6 @@ namespace dmTransform
         TransformS1 res;
         res.SetRotation(lhs.GetRotation() * rhs.GetRotation());
         res.SetTranslation(dmVMath::Vector3(Apply(lhs, dmVMath::Point3(rhs.GetTranslation()))));
-        res.SetScale(lhs.GetScale() * rhs.GetScale());
-        return res;
-    }
-
-    /**
-     * Transforms the right-hand transform by the left-hand transform, without scaling the Z-component of the transition of the transformed transform
-     * @param lhs Transforming transform
-     * @param rhs Transformed transform
-     * @return Transformed transform
-     */
-    inline TransformS1 MulNoScaleZ(const TransformS1& lhs, const TransformS1& rhs)
-    {
-        TransformS1 res;
-        res.SetRotation(lhs.GetRotation() * rhs.GetRotation());
-        res.SetTranslation(dmVMath::Vector3(ApplyNoScaleZ(lhs, dmVMath::Point3(rhs.GetTranslation()))));
         res.SetScale(lhs.GetScale() * rhs.GetScale());
         return res;
     }

--- a/engine/dlib/src/dmsdk/dlib/transform.h
+++ b/engine/dlib/src/dmsdk/dlib/transform.h
@@ -161,8 +161,9 @@ namespace dmTransform
         }
 
         /*# set scale for x and y
-         * @name SetScale
-         * @return scale [type: dmVMath::Vector3]
+         * @name SetScaleXY
+         * @param scale_x [type: float]
+         * @param scale_y [type: float]
          */
         inline void SetScaleXY(float scale_x, float scale_y)
         {

--- a/engine/dlib/src/dmsdk/dlib/transform.h
+++ b/engine/dlib/src/dmsdk/dlib/transform.h
@@ -160,6 +160,16 @@ namespace dmTransform
             m_Scale = dmVMath::Vector3(scale);
         }
 
+        /*# set scale for x and y
+         * @name SetScale
+         * @return scale [type: dmVMath::Vector3]
+         */
+        inline void SetScaleXY(float scale_x, float scale_y)
+        {
+            m_Scale.setX(scale_x);
+            m_Scale.setY(scale_y);
+        }
+
         /*# get rotatiom
          * @name GetRotation
          * @return rotation [type: dmVMath::Quat]

--- a/engine/dlib/src/dmsdk/dlib/transform.h
+++ b/engine/dlib/src/dmsdk/dlib/transform.h
@@ -197,20 +197,6 @@ namespace dmTransform
     }
 
     /*#
-     * Apply the transform on a point, but without scaling the Z-component of the point (includes the transform translation).
-     * @name ApplyNoScaleZ
-     * @param t [type: dmTransform::Transform&] Transform
-     * @param p [type: dmVMath::Point3&] Point
-     * @return point [type: dmVMath::Point3] Transformed point
-     */
-    inline dmVMath::Point3 ApplyNoScaleZ(const Transform& t, const dmVMath::Point3 p)
-    {
-        dmVMath::Vector3 s = t.GetScale();
-        s.setZ(1.0f);
-        return dmVMath::Point3(rotate(t.GetRotation(), mulPerElem(dmVMath::Vector3(p), s)) + t.GetTranslation());
-    }
-
-    /*#
      * Apply the transform on a vector (excludes the transform translation).
      * @name Apply
      * @param t [type: dmTransform::Transform&] Transform
@@ -220,20 +206,6 @@ namespace dmTransform
     inline dmVMath::Vector3 Apply(const Transform& t, const dmVMath::Vector3 v)
     {
         return dmVMath::Vector3(rotate(t.GetRotation(), mulPerElem(v, t.GetScale())));
-    }
-
-    /*#
-     * Apply the transform on a vector, but without scaling the Z-component of the vector (excludes the transform translation).
-     * @name ApplyNoScaleZ
-     * @param t [type: dmTransform::Transform&] Transform
-     * @param v [type: dmVMath::Vector3&] Vector
-     * @return point [type: dmVMath::Vector3] Transformed vector
-     */
-    inline dmVMath::Vector3 ApplyNoScaleZ(const Transform& t, const dmVMath::Vector3 v)
-    {
-        dmVMath::Vector3 s = t.GetScale();
-        s.setZ(1.0f);
-        return dmVMath::Vector3(rotate(t.GetRotation(), mulPerElem(v, s)));
     }
 
     /*#
@@ -248,22 +220,6 @@ namespace dmTransform
         Transform res;
         res.SetRotation(lhs.GetRotation() * rhs.GetRotation());
         res.SetTranslation(dmVMath::Vector3(Apply(lhs, dmVMath::Point3(rhs.GetTranslation()))));
-        res.SetScale(mulPerElem(lhs.GetScale(), rhs.GetScale()));
-        return res;
-    }
-
-    /*#
-     * Transforms the right-hand transform by the left-hand transform, without scaling the Z-component of the transition of the transformed transform
-     * @name MulNoScaleZ
-     * @param lhs [type: const dmTransform::Transform&]
-     * @param rhs [type: const dmTransform::Transform&]
-     * @return result [type: dmTransform::Transform] Transformed transform
-     */
-    inline Transform MulNoScaleZ(const Transform& lhs, const Transform& rhs)
-    {
-        Transform res;
-        res.SetRotation(lhs.GetRotation() * rhs.GetRotation());
-        res.SetTranslation(dmVMath::Vector3(ApplyNoScaleZ(lhs, dmVMath::Point3(rhs.GetTranslation()))));
         res.SetScale(mulPerElem(lhs.GetScale(), rhs.GetScale()));
         return res;
     }
@@ -370,23 +326,6 @@ namespace dmTransform
     {
         *target = source;
         NormalizeZScale(target);
-    }
-
-    /*#
-     * Multiply two matrices without z-scaling the translation in m2
-     * @name MulNoScaleZ
-     * @param m1 [type: const dmVMath::Matrix&] First matrix
-     * @param m2 [type: const dmVMath::Matrix&] Second matrix
-     * @return result [type: dmVMath::Matrix] The resulting transform
-     */
-    inline dmVMath::Matrix4 MulNoScaleZ(dmVMath::Matrix4 const &m1, dmVMath::Matrix4 const &m2)
-    {
-        // tmp is the non-z scaling version of m1
-        dmVMath::Matrix4 tmp, res;
-        NormalizeZScale(m1, &tmp);
-        res = m1 * m2;
-        res.setCol(3, tmp * m2.getCol(3));
-        return res;
     }
 }
 

--- a/engine/dlib/src/test/test_transform.cpp
+++ b/engine/dlib/src/test/test_transform.cpp
@@ -56,23 +56,6 @@ TEST(dmTransform, Apply)
     ASSERT_V3_NEAR(Point3(1.0f, 2.0f, 0.0f), dmTransform::Apply(t, Point3(1.0f, 0.0f, 0.0f)));
 }
 
-TEST(dmTransform, ApplyNoScaleZ)
-{
-    TransformS1 ts1(Vector3(0.0f, 0.0f, 0.0f),
-            Quat::identity(),
-            2.0f);
-
-    ASSERT_V3_NEAR(Vector3(2.0f, 0.0f, 1.0f), dmTransform::ApplyNoScaleZ(ts1, Vector3(1.0f, 0.0f, 1.0f)));
-    ASSERT_V3_NEAR(Point3(2.0f, 0.0f, 1.0f), dmTransform::ApplyNoScaleZ(ts1, Point3(1.0f, 0.0f, 1.0f)));
-
-    Transform t(Vector3(0.0f, 0.0f, 0.0f),
-            Quat::identity(),
-            Vector3(2.0f, 2.0f, 2.0f));
-
-    ASSERT_V3_NEAR(Vector3(2.0f, 0.0f, 1.0f), dmTransform::ApplyNoScaleZ(t, Vector3(1.0f, 0.0f, 1.0f)));
-    ASSERT_V3_NEAR(Point3(2.0f, 0.0f, 1.0f), dmTransform::ApplyNoScaleZ(t, Point3(1.0f, 0.0f, 1.0f)));
-}
-
 TEST(dmTransform, Multiply)
 {
     TransformS1 ts10(Vector3(1.0f, 0.0f, 0.0f),
@@ -92,50 +75,6 @@ TEST(dmTransform, Multiply)
     ASSERT_V3_NEAR(Vector3(1.0f, 2.0f, 0.0f), res.GetTranslation());
     ASSERT_V4_NEAR(Quat::rotationZ((float) M_PI), res.GetRotation());
     ASSERT_V3_NEAR(Vector3(4.0f, 4.0f, 4.0f), res.GetScale());
-}
-
-TEST(dmTransform, MultiplyNoScaleZ)
-{
-    TransformS1 ts10(Vector3(0.0f, 0.0f, 1.0f),
-            Quat::identity(),
-            2.0f);
-
-    TransformS1 ress1 = Mul(ts10, ts10);
-    ASSERT_V3_NEAR(Vector3(0.0f, 0.0f, 3.0f), ress1.GetTranslation());
-    ress1 = MulNoScaleZ(ts10, ts10);
-    ASSERT_V3_NEAR(Vector3(0.0f, 0.0f, 2.0f), ress1.GetTranslation());
-
-    Transform t0(Vector3(0.0f, 0.0f, 1.0f),
-            Quat::identity(),
-            Vector3(2.0f, 2.0f, 2.0f));
-
-    Transform res = Mul(t0, t0);
-    ASSERT_V3_NEAR(Vector3(0.0f, 0.0f, 3.0f), res.GetTranslation());
-    res = MulNoScaleZ(t0, t0);
-    ASSERT_V3_NEAR(Vector3(0.0f, 0.0f, 2.0f), res.GetTranslation());
-}
-
-TEST(dmTransform, MultiplyNoScaleZMatrix)
-{
-    Transform ts10(Vector3(0.0f, 0.0f, 1.0f),
-            Quat::identity(),
-            Vector3(2.0f, 2.0f, 2.0f));
-
-    Matrix4 ts10mtx = ToMatrix4(ts10);
-    Matrix4 ress1 = ts10mtx * ts10mtx;
-    ASSERT_V3_NEAR(Vector3(0.0f, 0.0f, 3.0f), ress1.getCol(3));
-    ress1 = MulNoScaleZ(ts10mtx, ts10mtx);
-    ASSERT_V3_NEAR(Vector3(0.0f, 0.0f, 2.0f), ress1.getCol(3));
-
-    Transform t0(Vector3(0.0f, 0.0f, 1.0f),
-            Quat::identity(),
-            Vector3(2.0f, 2.0f, 2.0f));
-
-    Matrix4 t0mtx = ToMatrix4(t0);
-    Matrix4 res = t0mtx * t0mtx;
-    ASSERT_V3_NEAR(Vector3(0.0f, 0.0f, 3.0f), res.getCol(3));
-    res = MulNoScaleZ(t0mtx, t0mtx);
-    ASSERT_V3_NEAR(Vector3(0.0f, 0.0f, 2.0f), res.getCol(3));
 }
 
 TEST(dmTransform, Conversion)

--- a/engine/engine/src/test/label/label.script
+++ b/engine/engine/src/test/label/label.script
@@ -97,6 +97,20 @@ local function test_set_vector4(name, startvalue)
 	test_vector4(name, expected)
 end
 
+local function test_set_scale_xy(val)
+	local expected = vmath.vector3(val, val+1, 3)
+	local set_value = vmath.vector3(val, val+1, val+2)
+	go.set("#label", "scale.xy", set_value)
+    local v = go.get("#label", "scale")
+    assert(expected == v)
+
+	expected = vmath.vector3(val+3, val+3, 3)
+	set_value = val + 3
+	go.set("#label", "scale.xy", set_value)
+	v = go.get("#label", "scale")
+    assert(expected == v)
+end
+
 
 local function test_bad_url()
 	label.set_text(nil, "hello") -- script
@@ -120,6 +134,8 @@ function init(self)
 	-- SET PROPERTIES
 	--
 
+	test_set_scale_xy(50)
+
 	test_set_vector3("scale", 100)
 	test_set_vector3("size", 200)
 
@@ -135,9 +151,37 @@ function init(self)
 	test_bad_url()
 
 	--
+	--
+	--
+
+	go.set("#label", "scale.z", 99)
+	go.animate("#label", "scale.xy", go.PLAYBACK_ONCE_FORWARD, vmath.vector3(20), go.EASING_LINEAR, 1/120)
+
+	--
+	--
+	--
+
+	go.set(".", "scale.z", 199)
+	go.animate(".", "scale.xy", go.PLAYBACK_ONCE_FORWARD, vmath.vector3(198), go.EASING_LINEAR, 1/120)
+
+	--
 	-- END TEST
 	--
 
-	msg.post("main:/main#script", "done")
+	timer.delay(0.1, false, function()
+		msg.post(".", "finish_test")
+	end)
+end
+
+function on_message(self, message_id, message)
+	if hash("finish_test") == message_id then
+		local v = go.get("#label", "scale")
+		assert(vmath.vector3(20, 20, 99) == v)
+
+		v = go.get(".", "scale")
+		assert(vmath.vector3(198, 198, 199) == v)
+
+		msg.post("main:/main#script", "done")
+	end
 end
 

--- a/engine/engine/src/test/label/label.script
+++ b/engine/engine/src/test/label/label.script
@@ -166,8 +166,12 @@ function init(self)
 	--
 	--
 	--
-
-	go.set(".", "scale.z", 199)
+	go.set(".", "scale", 199)
+	go.set(".", "scale.xy", 100)
+	v = go.get(".", "scale")
+	assert_near(100, v.x, epsilon)
+	assert_near(100, v.y, epsilon)
+	assert_near(199, v.z, epsilon)
 	v = go.get(".", "scale")
 	go.animate(".", "scale.xy", go.PLAYBACK_ONCE_FORWARD, vmath.vector3(198), go.EASING_LINEAR, 1/120)
 

--- a/engine/engine/src/test/label/label.script
+++ b/engine/engine/src/test/label/label.script
@@ -13,6 +13,12 @@
 -- specific language governing permissions and limitations under the License.
 
 
+local function assert_near(exp, act, eps)
+    assert(math.abs(exp - act) < eps, string.format("expected %f but was %f, differing by %f which exceeds %f", exp, act, math.abs(exp - act), eps))
+end
+
+local epsilon = 0.000001
+
 local function compare_fp(lhs, rhs)
     local epsilon = 1e-10
     local diff = math.abs(lhs - rhs)
@@ -162,6 +168,7 @@ function init(self)
 	--
 
 	go.set(".", "scale.z", 199)
+	v = go.get(".", "scale")
 	go.animate(".", "scale.xy", go.PLAYBACK_ONCE_FORWARD, vmath.vector3(198), go.EASING_LINEAR, 1/120)
 
 	--
@@ -179,7 +186,9 @@ function on_message(self, message_id, message)
 		assert(vmath.vector3(20, 20, 99) == v)
 
 		v = go.get(".", "scale")
-		assert(vmath.vector3(198, 198, 199) == v)
+		assert_near(198, v.x, epsilon)
+		assert_near(198, v.y, epsilon)
+		assert_near(199, v.z, epsilon)
 
 		msg.post("main:/main#script", "done")
 	end

--- a/engine/engine/src/test/label/label.script
+++ b/engine/engine/src/test/label/label.script
@@ -14,43 +14,43 @@
 
 
 local function assert_near(exp, act, eps)
-    assert(math.abs(exp - act) < eps, string.format("expected %f but was %f, differing by %f which exceeds %f", exp, act, math.abs(exp - act), eps))
+	assert(math.abs(exp - act) < eps, string.format("expected %f but was %f, differing by %f which exceeds %f", exp, act, math.abs(exp - act), eps))
 end
 
 local epsilon = 0.000001
 
 local function compare_fp(lhs, rhs)
-    local epsilon = 1e-10
-    local diff = math.abs(lhs - rhs)
-    return epsilon > diff
+	local epsilon = 1e-10
+	local diff = math.abs(lhs - rhs)
+	return epsilon > diff
 end
 
 local function test_vector4(name, expected)
 
-    local v = go.get("#label", name)
-    local vx = go.get("#label", name .. ".x")
-    local vy = go.get("#label", name .. ".y")
-    local vz = go.get("#label", name .. ".z")
-    local vw = go.get("#label", name .. ".w")
+	local v = go.get("#label", name)
+	local vx = go.get("#label", name .. ".x")
+	local vy = go.get("#label", name .. ".y")
+	local vz = go.get("#label", name .. ".z")
+	local vw = go.get("#label", name .. ".w")
 
-    assert(expected == v)
-    assert(expected.x == vx)
-    assert(expected.y == vy)
-    assert(expected.z == vz)
-    assert(expected.w == vw)
+	assert(expected == v)
+	assert(expected.x == vx)
+	assert(expected.y == vy)
+	assert(expected.z == vz)
+	assert(expected.w == vw)
 end
 
 local function test_vector3(name, expected)
 
-    local v = go.get("#label", name)
-    local vx = go.get("#label", name .. ".x")
-    local vy = go.get("#label", name .. ".y")
-    local vz = go.get("#label", name .. ".z")
+	local v = go.get("#label", name)
+	local vx = go.get("#label", name .. ".x")
+	local vy = go.get("#label", name .. ".y")
+	local vz = go.get("#label", name .. ".z")
 
-    assert(expected == v)
-    assert(expected.x == vx)
-    assert(expected.y == vy)
-    assert(expected.z == vz)
+	assert(expected == v)
+	assert(expected.x == vx)
+	assert(expected.y == vy)
+	assert(expected.z == vz)
 end
 
 
@@ -107,14 +107,14 @@ local function test_set_scale_xy(val)
 	local expected = vmath.vector3(val, val+1, 3)
 	local set_value = vmath.vector3(val, val+1, val+2)
 	go.set("#label", "scale.xy", set_value)
-    local v = go.get("#label", "scale")
-    assert(expected == v)
+	local v = go.get("#label", "scale")
+	assert(expected == v)
 
 	expected = vmath.vector3(val+3, val+3, 3)
 	set_value = val + 3
 	go.set("#label", "scale.xy", set_value)
 	v = go.get("#label", "scale")
-    assert(expected == v)
+	assert(expected == v)
 end
 
 

--- a/engine/engine/src/test/sprite/coll.script
+++ b/engine/engine/src/test/sprite/coll.script
@@ -36,6 +36,16 @@ function init(self)
     go.set("#sprite", "scale.z", 6)
     assert(go.get("#sprite", "scale.z") == 6)
 
+    go.set("#sprite", "scale.xy", 7)
+    assert(go.get("#sprite", "scale.x") == 7)
+    assert(go.get("#sprite", "scale.y") == 7)
+    assert(go.get("#sprite", "scale.z") == 6)
+
+    go.set("#sprite", "scale.xy", vmath.vector3(8, 9, 10))
+    assert(go.get("#sprite", "scale.x") == 8)
+    assert(go.get("#sprite", "scale.y") == 9)
+    assert(go.get("#sprite", "scale.z") == 6)
+
     local size = go.get("#sprite", "size")
     local sx = go.get("#sprite", "size.x")
     local sy = go.get("#sprite", "size.y")
@@ -49,6 +59,8 @@ function init(self)
 
     msg.post(".", "try_set_size")
     msg.post(".", "try_animate_size")
+
+    go.animate("#sprite", "scale.xy", go.PLAYBACK_ONCE_FORWARD, 20, go.EASING_LINEAR, 1/120)
 end
 
 local function fail_set_size(self)
@@ -62,14 +74,26 @@ local function fail_animate_size(self)
     go.animate("#sprite", "size.x", go.PLAYBACK_ONCE_FORWARD, 20, go.EASING_LINEAR, 1)
 end
 
+local function check_scale_xy_animate_result()
+    local scale_x = go.get("#sprite", "scale.x")
+    local scale_y = go.get("#sprite", "scale.y")
+    local scale_z = go.get("#sprite", "scale.z")
+    assert(scale_x == 20)
+    assert(scale_y == 20)
+    assert(scale_z == 6)
+end
+
 function on_message(self, message_id, message, sender)
     if message_id == hash("animation_done") and sender == self.sprite then
         local anim_id = go.get("#sprite", "animation")
         assert(anim_id == hash("anim"))
-        msg.post("main:/main#script", "done")
+        timer.delay(0.1, false, function() msg.post("#", "delay_done") end)
     elseif message_id == hash("try_set_size") then
         fail_set_size(self)
     elseif message_id == hash("try_animate_size") then
         fail_animate_size(self)
+    elseif message_id == hash("delay_done") then
+        check_scale_xy_animate_result()
+        msg.post("main:/main#script", "done")
     end
 end

--- a/engine/gameobject/proto/gameobject/gameobject_ddf.proto
+++ b/engine/gameobject/proto/gameobject/gameobject_ddf.proto
@@ -117,7 +117,7 @@ message CollectionDesc
     required string                 name                    = 1;
     repeated InstanceDesc           instances               = 2;
     repeated CollectionInstanceDesc collection_instances    = 3;
-    optional uint32                 scale_along_z           = 4 [default = 0];
+    optional uint32                 scale_along_z           = 4 [default = 0]; // Deprecated
     repeated EmbeddedInstanceDesc   embedded_instances      = 5;
     repeated string                 property_resources      = 6 [(runtime_only) = true, (resource) = true];
     repeated ComponenTypeDesc       component_types         = 7 [(runtime_only) = true];

--- a/engine/gameobject/src/dmsdk/gameobject/gameobject.h
+++ b/engine/gameobject/src/dmsdk/gameobject/gameobject.h
@@ -664,6 +664,15 @@ namespace dmGameObject
      */
     void SetScale(HInstance instance, dmVMath::Vector3 scale);
 
+    /*# set scale only for width and height (x and y)
+     * Set gameobject instance x and y scale
+     * @name SetScaleXY
+     * @param instance [type:dmGameObject::HInstance] Gameobject instance
+     * @param scale_x New x scale
+     * @param scale_y New y scale
+     */
+    void SetScaleXY(HInstance instance, float scale_x, float scale_y);
+
     /*# get uniform scale
      * Get gameobject instance uniform scale
      * @name GetUniformScale

--- a/engine/gameobject/src/dmsdk/gameobject/gameobject.h
+++ b/engine/gameobject/src/dmsdk/gameobject/gameobject.h
@@ -664,7 +664,7 @@ namespace dmGameObject
      */
     void SetScale(HInstance instance, dmVMath::Vector3 scale);
 
-    /*# set scale only for width and height (x and y)
+    /*# set scale only for X and Y
      * Set gameobject instance x and y scale
      * @name SetScaleXY
      * @param instance [type:dmGameObject::HInstance] Gameobject instance

--- a/engine/gameobject/src/gameobject/comp_anim.cpp
+++ b/engine/gameobject/src/gameobject/comp_anim.cpp
@@ -514,14 +514,18 @@ namespace dmGameObject
                 duration, delay, animation_stopped, userdata1, userdata2, true);
     }
 
-    static uint32_t GetElementCount(PropertyType type)
+    static uint32_t GetElementCount(PropertyType type, dmhash_t* element_ids)
     {
         switch (type)
         {
         case PROPERTY_TYPE_NUMBER:
             return 1;
         case PROPERTY_TYPE_VECTOR3:
+        {
+            if (element_ids[2] == 0)
+                return 2;
             return 3;
+        }
         case PROPERTY_TYPE_VECTOR4:
         case PROPERTY_TYPE_QUAT:
             return 4;
@@ -568,7 +572,7 @@ namespace dmGameObject
                 return PROPERTY_RESULT_TYPE_MISMATCH;
             }
         }
-        uint32_t element_count = GetElementCount(prop_desc.m_Variant.m_Type);
+        uint32_t element_count = GetElementCount(prop_desc.m_Variant.m_Type, prop_desc.m_ElementIds);
         if (element_count == 0)
         {
             return PROPERTY_RESULT_UNSUPPORTED_TYPE;
@@ -625,7 +629,7 @@ namespace dmGameObject
         {
             return prop_result;
         }
-        uint32_t element_count = GetElementCount(prop_desc.m_Variant.m_Type);
+        uint32_t element_count = GetElementCount(prop_desc.m_Variant.m_Type, prop_desc.m_ElementIds);
         if (element_count == 0)
         {
             return PROPERTY_RESULT_UNSUPPORTED_TYPE;

--- a/engine/gameobject/src/gameobject/gameobject.cpp
+++ b/engine/gameobject/src/gameobject/gameobject.cpp
@@ -3242,9 +3242,10 @@ namespace dmGameObject
                 out_value.m_ValuePtr = scale;
                 out_value.m_ElementIds[0] = PROP_SCALE_X;
                 out_value.m_ElementIds[1] = PROP_SCALE_Y;
-                out_value.m_ElementIds[2] = PROP_SCALE_Z;
-                // Should z always return 1.0f here?
-                out_value.m_Variant = PropertyVar(instance->m_Transform.GetScale());
+                out_value.m_ElementIds[2] = 0;
+                Vector3 vec = instance->m_Transform.GetScale();
+                vec.setZ(1.0f);
+                out_value.m_Variant = PropertyVar(vec);
             }
             else if (property_id == PROP_SCALE_X)
             {

--- a/engine/gameobject/src/gameobject/gameobject.cpp
+++ b/engine/gameobject/src/gameobject/gameobject.cpp
@@ -77,6 +77,8 @@ namespace dmGameObject
     const dmhash_t PROP_##var_name##_Z = dmHashString64(#prop_name ".z");\
     const dmhash_t PROP_##var_name##_W = dmHashString64(#prop_name ".w");
 
+    static const dmhash_t PROP_SCALE_XY = dmHashString64("scale.xy");
+
     PROP_VECTOR3(POSITION, position);
     PROP_QUAT(ROTATION, rotation);
     PROP_VECTOR3(EULER, euler);
@@ -3007,6 +3009,11 @@ namespace dmGameObject
         instance->m_Transform.SetScale(scale);
     }
 
+    void SetScaleXY(HInstance instance, float scale_x, float scale_y)
+    {
+        instance->m_Transform.SetScaleXY(scale_x, scale_y);
+    }
+
     float GetUniformScale(HInstance instance)
     {
         return instance->m_Transform.GetUniformScale();
@@ -3227,6 +3234,16 @@ namespace dmGameObject
                 out_value.m_ElementIds[0] = PROP_SCALE_X;
                 out_value.m_ElementIds[1] = PROP_SCALE_Y;
                 out_value.m_ElementIds[2] = PROP_SCALE_Z;
+                out_value.m_Variant = PropertyVar(instance->m_Transform.GetScale());
+            }
+            else if (property_id == PROP_SCALE_XY)
+            {
+                float* scale = instance->m_Transform.GetScalePtr();
+                out_value.m_ValuePtr = scale;
+                out_value.m_ElementIds[0] = PROP_SCALE_X;
+                out_value.m_ElementIds[1] = PROP_SCALE_Y;
+                out_value.m_ElementIds[2] = PROP_SCALE_Z;
+                // Should z always return 1.0f here?
                 out_value.m_Variant = PropertyVar(instance->m_Transform.GetScale());
             }
             else if (property_id == PROP_SCALE_X)
@@ -3477,6 +3494,22 @@ namespace dmGameObject
                     scale[0] = value.m_V4[0];
                     scale[1] = value.m_V4[1];
                     scale[2] = value.m_V4[2];
+                    return PROPERTY_RESULT_OK;
+                }
+                return PROPERTY_RESULT_TYPE_MISMATCH;
+            }
+            else if (property_id == PROP_SCALE_XY)
+            {
+                if (value.m_Type == PROPERTY_TYPE_NUMBER)
+                {
+                    scale[0] = (float)value.m_Number;
+                    scale[1] = scale[0];
+                    return PROPERTY_RESULT_OK;
+                }
+                else if (value.m_Type == PROPERTY_TYPE_VECTOR3)
+                {
+                    scale[0] = value.m_V4[0];
+                    scale[1] = value.m_V4[1];
                     return PROPERTY_RESULT_OK;
                 }
                 return PROPERTY_RESULT_TYPE_MISMATCH;

--- a/engine/gameobject/src/gameobject/gameobject.h
+++ b/engine/gameobject/src/gameobject/gameobject.h
@@ -185,13 +185,6 @@ namespace dmGameObject
     Result GetComponentIndex(HInstance instance, dmhash_t component_id, uint16_t* component_index);
 
     /**
-     * Returns whether the scale of the supplied instance should be applied along Z or not.
-     * @param instance Instance
-     * @return if the scale should be applied along Z
-     */
-    bool ScaleAlongZ(HInstance instance);
-
-    /**
      * Initializes all game object instances in the supplied collection.
      * @param collection Game object collection
      */
@@ -281,13 +274,6 @@ namespace dmGameObject
      * @return The frame message socket of the specified collection
      */
     dmMessage::HSocket GetFrameMessageSocket(HCollection collection);
-
-    /**
-     * Returns whether the scale of the instances in a collection should be applied along Z or not.
-     * @param collection Collection
-     * @return if the scale should be applied along Z
-     */
-    bool ScaleAlongZ(HCollection collection);
 
     /**
      * Get instance hierarchical depth

--- a/engine/gameobject/src/gameobject/gameobject_private.h
+++ b/engine/gameobject/src/gameobject/gameobject_private.h
@@ -147,7 +147,7 @@ namespace dmGameObject
         // If this is a generated instance, i.e. if the instance id is uniquely generated
         uint16_t        m_Generated : 1;
         // Padding
-        uint16_t        m_Pad : 4;
+        uint16_t        m_Pad : 5;
 
         // Index to parent
         uint16_t        m_Parent : 16;

--- a/engine/gameobject/src/gameobject/gameobject_private.h
+++ b/engine/gameobject/src/gameobject/gameobject_private.h
@@ -103,7 +103,6 @@ namespace dmGameObject
             dmHashInit64(&m_CollectionPathHashState, false);
             m_Depth = 0;
             m_Initialized = 0;
-            m_ScaleAlongZ = 0;
             m_Bone = 0;
             m_Generated = 0;
             m_Parent = INVALID_INSTANCE_INDEX;
@@ -143,8 +142,6 @@ namespace dmGameObject
         uint16_t        m_Depth : 8;
         // If the instance was initialized or not (Init())
         uint16_t        m_Initialized : 1;
-        // If this game object should have the Z component of the position affected by scale
-        uint16_t        m_ScaleAlongZ : 1;
         // If this game object is part of a skeleton
         uint16_t        m_Bone : 1;
         // If this is a generated instance, i.e. if the instance id is uniquely generated
@@ -290,8 +287,6 @@ namespace dmGameObject
         uint32_t                 m_InUpdate : 1;
         // Used for deferred deletion
         uint32_t                 m_ToBeDeleted : 1;
-        // If the game object dynamically created in this collection should have the Z component of the position affected by scale
-        uint32_t                 m_ScaleAlongZ : 1;
         uint32_t                 m_DirtyTransforms : 1;
         uint32_t                 m_Initialized : 1;
         uint32_t                 m_FirstUpdate : 1;

--- a/engine/gameobject/src/gameobject/gameobject_script.cpp
+++ b/engine/gameobject/src/gameobject/gameobject_script.cpp
@@ -1109,7 +1109,7 @@ namespace dmGameObject
      * go.set_scale(s, "obj_id")
      * ```
      */
-    int Script_SetScale(lua_State* L)
+    static int Script_SetScale(lua_State* L)
     {
         Instance* instance = ResolveInstance(L, 2);
 
@@ -1159,7 +1159,7 @@ namespace dmGameObject
      * go.set_scale_xy(s, "obj_id") -- z will not be set here, only x and y
      * ```
      */
-    int Script_SetScaleXY(lua_State* L)
+    static int Script_SetScaleXY(lua_State* L)
     {
         Instance* instance = ResolveInstance(L, 2);
 

--- a/engine/gameobject/src/gameobject/gameobject_script.cpp
+++ b/engine/gameobject/src/gameobject/gameobject_script.cpp
@@ -1156,7 +1156,7 @@ namespace dmGameObject
      *
      * ```lua
      * local s = 1.2
-     * go.set_scale_xy(s, "obj_id")
+     * go.set_scale_xy(s, "obj_id") -- z will not be set here, only x and y
      * ```
      */
     int Script_SetScaleXY(lua_State* L)
@@ -1170,7 +1170,7 @@ namespace dmGameObject
             Vector3 scale = *v;
             if (scale.getX() <= 0.0f || scale.getY() <= 0.0f)
             {
-                return luaL_error(L, "Vector passed to go.set_scale contains components that are below or equal to zero");
+                return luaL_error(L, "Vector passed to go.set_scale_xy contains components that are below or equal to zero");
             }
             dmGameObject::SetScaleXY(instance, scale.getX(), scale.getY());
             return 0;
@@ -1179,7 +1179,7 @@ namespace dmGameObject
         lua_Number n = luaL_checknumber(L, 1);
         if (n <= 0.0)
         {
-            return luaL_error(L, "The scale supplied to go.set_scale must be greater than 0.");
+            return luaL_error(L, "The scale supplied to go.set_scale_xy must be greater than 0.");
         }
         float value = (float)n;
         dmGameObject::SetScaleXY(instance, value, value);

--- a/engine/gameobject/src/gameobject/gameobject_script.cpp
+++ b/engine/gameobject/src/gameobject/gameobject_script.cpp
@@ -1088,7 +1088,7 @@ namespace dmGameObject
     /*# sets the scale factor of the game object instance
      * The scale factor is relative to the parent (if any). The global world scale factor cannot be manually set.
      *
-     * [icon:attention] Physics are currently not affected when setting scale from this function.
+     * [icon:attention] See <a href="/manuals/project-settings/#allow-dynamic-transforms">manual</a> to know how physics affected when setting scale from this function.
      *
      * @name go.set_scale
      * @param scale [type:number|vector3] vector or uniform scale factor, must be greater than 0
@@ -1102,11 +1102,11 @@ namespace dmGameObject
      * go.set_scale(s)
      * ```
      *
-     * Set the scale of another game object instance with id "x":
+     * Set the scale of another game object instance with id "obj_id":
      *
      * ```lua
      * local s = 1.2
-     * go.set_scale(s, "x")
+     * go.set_scale(s, "obj_id")
      * ```
      */
     int Script_SetScale(lua_State* L)
@@ -1132,6 +1132,57 @@ namespace dmGameObject
             return luaL_error(L, "The scale supplied to go.set_scale must be greater than 0.");
         }
         dmGameObject::SetScale(instance, (float)n);
+        return 0;
+    }
+
+    /*# sets the scale factor only for width and height (x and y) of the game object instance
+     * The scale factor is relative to the parent (if any). The global world scale factor cannot be manually set.
+     *
+     * [icon:attention] See <a href="/manuals/project-settings/#allow-dynamic-transforms">manual</a> to know how physics affected when setting scale from this function.
+     *
+     * @name go.set_scale_xy
+     * @param scale [type:number|vector3] vector or uniform scale factor, must be greater than 0
+     * @param [id] [type:string|hash|url] optional id of the game object instance to get the scale for, by default the instance of the calling script
+     * @examples
+     *
+     * Set the scale of the game object instance the script is attached to:
+     *
+     * ```lua
+     * local s = vmath.vector3(2.0, 1.0, 5.0)
+     * go.set_scale_xy(s) -- z will not be set here, only x and y
+     * ```
+     *
+     * Set the scale of another game object instance with id "obj_id":
+     *
+     * ```lua
+     * local s = 1.2
+     * go.set_scale_xy(s, "obj_id")
+     * ```
+     */
+    int Script_SetScaleXY(lua_State* L)
+    {
+        Instance* instance = ResolveInstance(L, 2);
+
+        // Supports both vector and number
+        Vector3* v = dmScript::ToVector3(L, 1);
+        if (v != 0)
+        {
+            Vector3 scale = *v;
+            if (scale.getX() <= 0.0f || scale.getY() <= 0.0f)
+            {
+                return luaL_error(L, "Vector passed to go.set_scale contains components that are below or equal to zero");
+            }
+            dmGameObject::SetScaleXY(instance, scale.getX(), scale.getY());
+            return 0;
+        }
+
+        lua_Number n = luaL_checknumber(L, 1);
+        if (n <= 0.0)
+        {
+            return luaL_error(L, "The scale supplied to go.set_scale must be greater than 0.");
+        }
+        float value = (float)n;
+        dmGameObject::SetScaleXY(instance, value, value);
         return 0;
     }
 
@@ -2174,6 +2225,7 @@ namespace dmGameObject
         {"set_position",            Script_SetPosition},
         {"set_rotation",            Script_SetRotation},
         {"set_scale",               Script_SetScale},
+        {"set_scale_xy",            Script_SetScaleXY},
         {"set_parent",              Script_SetParent},
         {"get_world_position",      Script_GetWorldPosition},
         {"get_world_rotation",      Script_GetWorldRotation},

--- a/engine/gameobject/src/gameobject/res_collection.cpp
+++ b/engine/gameobject/src/gameobject/res_collection.cpp
@@ -42,7 +42,6 @@ namespace dmGameObject
         }
 
         Collection* collection = hcollection->m_Collection;
-        collection->m_ScaleAlongZ = collection_desc->m_ScaleAlongZ;
 
         res = LoadPropertyResources(factory, collection_desc->m_PropertyResources.m_Data, collection_desc->m_PropertyResources.m_Count, collection->m_PropertyResources);
         if(res != dmResource::RESULT_OK)
@@ -50,7 +49,6 @@ namespace dmGameObject
             goto bail;
         }
 
-        collection->m_ScaleAlongZ = collection_desc->m_ScaleAlongZ;
         for (uint32_t i = 0; i < collection_desc->m_Instances.m_Count; ++i)
         {
             const dmGameObjectDDF::InstanceDesc& instance_desc = collection_desc->m_Instances[i];
@@ -68,8 +66,6 @@ namespace dmGameObject
             }
             if (instance != 0x0)
             {
-                instance->m_ScaleAlongZ = collection_desc->m_ScaleAlongZ;
-
                 // support legacy pipeline which outputs 0 for Scale3 and scale in Scale
                 Vector3 scale = instance_desc.m_Scale3;
                 if (scale.getX() == 0 && scale.getY() == 0 && scale.getZ() == 0) {

--- a/engine/gameobject/src/gameobject/test/factory/test_gameobject_factory.cpp
+++ b/engine/gameobject/src/gameobject/test/factory/test_gameobject_factory.cpp
@@ -174,22 +174,6 @@ TEST_F(FactoryTest, FactoryScale)
     ASSERT_EQ(2.0f, dmGameObject::GetUniformScale(instance));
 }
 
-TEST_F(FactoryTest, FactoryScaleAlongZ)
-{
-    uint32_t index = dmGameObject::AcquireInstanceIndex(m_Collection);
-    dmhash_t id = dmGameObject::CreateInstanceId();
-
-    m_Collection->m_Collection->m_ScaleAlongZ = 1;
-    dmGameObject::HInstance instance = Spawn(m_Factory, m_Collection, "/test.goc", id, 0, Point3(), Quat(), Vector3(2, 2, 2));
-    ASSERT_TRUE(dmGameObject::ScaleAlongZ(instance));
-
-    index = dmGameObject::AcquireInstanceIndex(m_Collection);
-    id = dmGameObject::CreateInstanceId();
-    m_Collection->m_Collection->m_ScaleAlongZ = 0;
-    instance = Spawn(m_Factory, m_Collection, "/test.goc", id, 0, Point3(), Quat(), Vector3(2, 2, 2));
-    ASSERT_FALSE(dmGameObject::ScaleAlongZ(instance));
-}
-
 TEST_F(FactoryTest, FactoryProperties)
 {
     lua_State* L = dmScript::GetLuaState(m_ScriptContext);

--- a/engine/gameobject/src/gameobject/test/script/go1.script
+++ b/engine/gameobject/src/gameobject/test/script/go1.script
@@ -66,6 +66,18 @@ function update(self, dt)
         assert_near(sv.x, 2*i, epsilon)
         assert_near(sv.y, 3*i, epsilon)
         assert_near(sv.z, 4*i, epsilon)
+
+        go.set_scale_xy(vmath.vector3(5*i,6*i,7*i), v)
+        sv = go.get_scale(v)
+        assert_near(sv.x, 5*i, epsilon)
+        assert_near(sv.y, 6*i, epsilon)
+        assert_near(sv.z, 4*i, epsilon)
+
+        go.set_scale_xy(i, v)
+        local sv = go.get_scale(v)
+        assert_near(i, sv.x, epsilon)
+        assert_near(i, sv.y, epsilon)
+        assert_near(4*i, sv.z, epsilon)
     end
 
     msg.post("@system:", "factory", {prototype = "test", pos = vmath.vector3(1, 2, 3)})

--- a/engine/gamesys/src/dmsdk/gamesys/property.h
+++ b/engine/gamesys/src/dmsdk/gamesys/property.h
@@ -31,14 +31,16 @@ namespace dmGameSystem
         dmhash_t m_X;
         dmhash_t m_Y;
         dmhash_t m_Z;
+        dmhash_t m_XY;
         bool m_ReadOnly;
 
-        PropVector3(dmhash_t v, dmhash_t x, dmhash_t y, dmhash_t z, bool readOnly)
+        PropVector3(dmhash_t v, dmhash_t x, dmhash_t y, dmhash_t z, dmhash_t xy, bool readOnly)
         {
             m_Vector = v;
             m_X = x;
             m_Y = y;
             m_Z = z;
+            m_XY = xy;
             m_ReadOnly = readOnly;
         }
     };
@@ -72,7 +74,7 @@ namespace dmGameSystem
      */
     inline bool IsReferencingProperty(const PropVector3& property, dmhash_t query)
     {
-        return property.m_Vector == query || property.m_X == query || property.m_Y == query || property.m_Z == query;
+        return property.m_Vector == query || property.m_X == query || property.m_Y == query || property.m_Z == query || property.m_XY == query;
     }
 
     /*#
@@ -116,6 +118,7 @@ namespace dmGameSystem
             dmHashString64(#prop_name ".x"),\
             dmHashString64(#prop_name ".y"),\
             dmHashString64(#prop_name ".z"),\
+            dmHashString64(#prop_name ".xy"),\
             readOnly);
 
 #define DM_GAMESYS_PROP_VECTOR4(var_name, prop_name, readOnly)\

--- a/engine/gamesys/src/gamesys/components/comp_label.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_label.cpp
@@ -326,17 +326,7 @@ namespace dmGameSystem
 
             Matrix4 local = CompLabelLocalTransform(c->m_Position, c->m_Rotation, c->m_Scale, c->m_Size, c->m_Pivot);
             Matrix4 world = dmGameObject::GetWorldMatrix(c->m_Instance);
-            Matrix4 w;
-
-            if (dmGameObject::ScaleAlongZ(c->m_Instance))
-            {
-                w = world * local;
-            }
-            else
-            {
-                w = dmTransform::MulNoScaleZ(world, local);
-            }
-
+            Matrix4 w = world * local;
             w = dmVMath::AppendScale(w, c->m_Scale);
 
             Vector4 position = w.getCol3();

--- a/engine/gamesys/src/gamesys/components/comp_mesh.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_mesh.cpp
@@ -375,14 +375,7 @@ namespace dmGameSystem
         component->m_BufferVersion = 0;
 
         const Matrix4& go_world = dmGameObject::GetWorldMatrix(component->m_Instance);
-        if (dmGameObject::ScaleAlongZ(component->m_Instance))
-        {
-            component->m_World = go_world * component->m_Local;
-        }
-        else
-        {
-            component->m_World = dmTransform::MulNoScaleZ(go_world, component->m_Local);
-        }
+        component->m_World = go_world * component->m_Local;
 
         // Local space uses separate vertex buffers
         if (dmRender::GetMaterialVertexSpace(GetMaterial(component, component->m_Resource)) == dmRenderDDF::MaterialDesc::VERTEX_SPACE_LOCAL)
@@ -456,14 +449,7 @@ namespace dmGameSystem
                 continue;
 
             const Matrix4& go_world = dmGameObject::GetWorldMatrix(c->m_Instance);
-            if (dmGameObject::ScaleAlongZ(c->m_Instance))
-            {
-                c->m_World = go_world * c->m_Local;
-            }
-            else
-            {
-                c->m_World = dmTransform::MulNoScaleZ(go_world, c->m_Local);
-            }
+            c->m_World = go_world * c->m_Local;
         }
     }
 

--- a/engine/gamesys/src/gamesys/components/comp_model.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_model.cpp
@@ -1844,16 +1844,7 @@ namespace dmGameSystem
 
             const Matrix4& go_world = dmGameObject::GetWorldMatrix(c->m_Instance);
             const Matrix4 local = dmTransform::ToMatrix4(c->m_Transform);
-
-            if (dmGameObject::ScaleAlongZ(c->m_Instance))
-            {
-                c->m_World = go_world * local;
-            }
-            else
-            {
-                c->m_World = dmTransform::MulNoScaleZ(go_world, local);
-            }
-
+            c->m_World = go_world * local;
             UpdateMeshTransforms(c);
 
             num_render_items += c->m_RenderItems.Size();

--- a/engine/gamesys/src/gamesys/components/comp_particlefx.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_particlefx.cpp
@@ -235,7 +235,6 @@ namespace dmGameSystem
                 dmParticle::SetPosition(particle_context, c.m_ParticleInstance, Point3(world_transform.GetTranslation()));
                 dmParticle::SetRotation(particle_context, c.m_ParticleInstance, world_transform.GetRotation());
                 dmParticle::SetScale(particle_context, c.m_ParticleInstance, world_transform.GetUniformScale());
-                dmParticle::SetScaleAlongZ(particle_context, c.m_ParticleInstance, dmGameObject::ScaleAlongZ(c.m_Instance));
                 if (prototype->m_AddedToUpdate && !c.m_AddedToUpdate) {
                     dmParticle::StartInstance(particle_context, c.m_ParticleInstance);
                     c.m_AddedToUpdate = true;
@@ -642,7 +641,6 @@ namespace dmGameSystem
             dmParticle::SetPosition(particle_context, instance, Point3(world_transform.GetTranslation()));
             dmParticle::SetRotation(particle_context, instance, world_transform.GetRotation());
             dmParticle::SetScale(particle_context, instance, world_transform.GetUniformScale());
-            dmParticle::SetScaleAlongZ(particle_context, instance, dmGameObject::ScaleAlongZ(params.m_Instance));
 
             if (prototype->m_AddedToUpdate)
             {

--- a/engine/gamesys/src/gamesys/components/comp_private.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_private.cpp
@@ -57,6 +57,13 @@ dmGameObject::PropertyResult GetProperty(dmGameObject::PropertyDesc& out_value, 
     {
         out_value.m_Variant = dmGameObject::PropertyVar(ref_value.getZ());
     }
+    else if (get_property == property.m_XY)
+    {
+        out_value.m_ElementIds[0] = property.m_X;
+        out_value.m_ElementIds[1] = property.m_Y;
+        out_value.m_ElementIds[2] = 1.0f;
+        out_value.m_Variant = dmGameObject::PropertyVar(ref_value);
+    }
     else
     {
         result = dmGameObject::PROPERTY_RESULT_NOT_FOUND;
@@ -115,6 +122,23 @@ dmGameObject::PropertyResult SetProperty(dmhash_t set_property, const dmGameObje
         if (in_value.m_Type == dmGameObject::PROPERTY_TYPE_NUMBER)
         {
             set_value.setZ(in_value.m_Number);
+        }
+        else
+        {
+            result = dmGameObject::PROPERTY_RESULT_TYPE_MISMATCH;
+        }
+    }
+    else if (set_property == property.m_XY)
+    {
+        if (in_value.m_Type == dmGameObject::PROPERTY_TYPE_NUMBER)
+        {
+            set_value.setX(in_value.m_Number);
+            set_value.setY(in_value.m_Number);
+        }
+        else if (in_value.m_Type == dmGameObject::PROPERTY_TYPE_VECTOR3)
+        {
+            set_value.setX(in_value.m_V4[0]);
+            set_value.setY(in_value.m_V4[1]);
         }
         else
         {

--- a/engine/gamesys/src/gamesys/components/comp_sprite.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sprite.cpp
@@ -1565,42 +1565,18 @@ namespace dmGameSystem
 
         dmArray<SpriteComponent>& components = sprite_world->m_Components.GetRawObjects();
         uint32_t n = components.Size();
-
-        bool scale_along_z = false;
-        if (n > 0) {
-            SpriteComponent* c = &components[0];
-            scale_along_z = dmGameObject::ScaleAlongZ(dmGameObject::GetCollection(c->m_Instance));
-        }
         // Note: We update all sprites, even though they might be disabled, or not added to update
-
-        if (scale_along_z) {
-            for (uint32_t i = 0; i < n; ++i)
-            {
-                SpriteComponent* c = &components[i];
-                Matrix4 local = dmTransform::ToMatrix4(dmTransform::Transform(c->m_Position, c->m_Rotation, 1.0f));
-                Matrix4 world = dmGameObject::GetWorldMatrix(c->m_Instance);
-                Vector3 size( c->m_Size.getX() * c->m_Scale.getX(), c->m_Size.getY() * c->m_Scale.getY(), 1);
-                c->m_World = dmVMath::AppendScale(world * local, size);
-                // we need to consider the full scale here
-                // I.e. we want the length of the diagonal C, where C = X + Y
-                float radius_sq = dmVMath::LengthSqr((c->m_World.getCol(0).getXYZ() + c->m_World.getCol(1).getXYZ()) * 0.5f);
-                sprite_world->m_BoundingVolumes[i] = radius_sq;
-            }
-        } else
+        for (uint32_t i = 0; i < n; ++i)
         {
-            for (uint32_t i = 0; i < n; ++i)
-            {
-                SpriteComponent* c = &components[i];
-                Matrix4 local = dmTransform::ToMatrix4(dmTransform::Transform(c->m_Position, c->m_Rotation, 1.0f));
-                Matrix4 world = dmGameObject::GetWorldMatrix(c->m_Instance);
-                Matrix4 w = dmTransform::MulNoScaleZ(world, local);
-                Vector3 size( c->m_Size.getX() * c->m_Scale.getX(), c->m_Size.getY() * c->m_Scale.getY(), 1);
-                c->m_World = dmVMath::AppendScale(w, size);
-                // we need to consider the full scale here
-                // I.e. we want the length of the diagonal C, where C = X + Y
-                float radius_sq = dmVMath::LengthSqr((c->m_World.getCol(0).getXYZ() + c->m_World.getCol(1).getXYZ()) * 0.5f);
-                sprite_world->m_BoundingVolumes[i] = radius_sq;
-            }
+            SpriteComponent* c = &components[i];
+            Matrix4 local = dmTransform::ToMatrix4(dmTransform::Transform(c->m_Position, c->m_Rotation, 1.0f));
+            Matrix4 world = dmGameObject::GetWorldMatrix(c->m_Instance);
+            Vector3 size( c->m_Size.getX() * c->m_Scale.getX(), c->m_Size.getY() * c->m_Scale.getY(), 1);
+            c->m_World = dmVMath::AppendScale(world * local, size);
+            // we need to consider the full scale here
+            // I.e. we want the length of the diagonal C, where C = X + Y
+            float radius_sq = dmVMath::LengthSqr((c->m_World.getCol(0).getXYZ() + c->m_World.getCol(1).getXYZ()) * 0.5f);
+            sprite_world->m_BoundingVolumes[i] = radius_sq;
         }
 
         // The "sub_pixels" is set by default

--- a/engine/gamesys/src/gamesys/components/comp_tilegrid.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_tilegrid.cpp
@@ -516,14 +516,7 @@ namespace dmGameSystem
 
             Matrix4 local(component->m_Rotation, component->m_Translation);
             const Matrix4& go_world = dmGameObject::GetWorldMatrix(component->m_Instance);
-            if (dmGameObject::ScaleAlongZ(component->m_Instance))
-            {
-                component->m_World = go_world * local;
-            }
-            else
-            {
-                component->m_World = dmTransform::MulNoScaleZ(go_world, local);
-            }
+            component->m_World = go_world * local;
         }
         DM_PROPERTY_ADD_U32(rmtp_Tilemap, world->m_Components.Size());
 

--- a/engine/particle/src/particle.cpp
+++ b/engine/particle/src/particle.cpp
@@ -553,13 +553,6 @@ namespace dmParticle
         i->m_WorldTransform.SetScale(scale);
     }
 
-    void SetScaleAlongZ(HParticleContext context, HInstance instance, bool scale_along_z)
-    {
-        Instance* i = GetInstance(context, instance);
-        if (!i) return;
-        i->m_ScaleAlongZ = scale_along_z;
-    }
-
     Vector3 GetPosition(HParticleContext context, HInstance instance)
     {
         Instance* i = GetInstance(context, instance);
@@ -866,10 +859,7 @@ namespace dmParticle
             Vector3 emitter_velocity(0.0f);
             if (emitter_ddf->m_Space == EMISSION_SPACE_WORLD)
             {
-                if (instance->m_ScaleAlongZ)
-                    emitter_transform = dmTransform::Mul(instance->m_WorldTransform, emitter_transform);
-                else
-                    emitter_transform = dmTransform::MulNoScaleZ(instance->m_WorldTransform, emitter_transform);
+                emitter_transform = dmTransform::Mul(instance->m_WorldTransform, emitter_transform);
                 emitter_velocity = emitter->m_Velocity * emitter_ddf->m_InheritVelocity;
             }
             for (uint32_t i = 0; i < count; ++i)
@@ -1626,10 +1616,7 @@ namespace dmParticle
         position = emitter_ddf->m_Position + rotate(emitter_ddf->m_Rotation, Vector3(position));
         if (emitter_ddf->m_Space == EMISSION_SPACE_WORLD)
         {
-            if (instance->m_ScaleAlongZ)
-                position = dmTransform::Apply(instance->m_WorldTransform, position);
-            else
-                position = dmTransform::ApplyNoScaleZ(instance->m_WorldTransform, position);
+            position = dmTransform::Apply(instance->m_WorldTransform, position);
         }
         return Point3(position);
     }
@@ -1728,10 +1715,7 @@ namespace dmParticle
                     color.setZ(t);
                 }
                 dmTransform::TransformS1 transform(Vector3(ddf->m_Position), ddf->m_Rotation, 1.0f);
-                if (instance->m_ScaleAlongZ)
-                    transform = dmTransform::Mul(instance->m_WorldTransform, transform);
-                else
-                    transform = dmTransform::MulNoScaleZ(instance->m_WorldTransform, transform);
+                transform = dmTransform::Mul(instance->m_WorldTransform, transform);
 
                 switch (ddf->m_Type)
                 {
@@ -1978,10 +1962,7 @@ namespace dmParticle
 
         dmParticleDDF::Emitter* ddf = &instance->m_Prototype->m_DDF->m_Emitters[emitter_index];
         dmTransform::TransformS1 transform(Vector3(ddf->m_Position), ddf->m_Rotation, 1.0f);
-        if (instance->m_ScaleAlongZ)
-            transform = dmTransform::Mul(instance->m_WorldTransform, transform);
-        else
-            transform = dmTransform::MulNoScaleZ(instance->m_WorldTransform, transform);
+        transform = dmTransform::Mul(instance->m_WorldTransform, transform);
         dmVMath::Matrix4 world = dmTransform::ToMatrix4(transform);
         dmParticle::EmitterPrototype* emitter_proto = &instance->m_Prototype->m_Emitters[emitter_index];
 
@@ -1994,10 +1975,7 @@ namespace dmParticle
         EmitterRenderData& render_data = emitter->m_RenderData;
 
         dmTransform::TransformS1 transform(Vector3(ddf->m_Position), ddf->m_Rotation, 1.0f);
-        if (inst->m_ScaleAlongZ)
-            transform = dmTransform::Mul(inst->m_WorldTransform, transform);
-        else
-            transform = dmTransform::MulNoScaleZ(inst->m_WorldTransform, transform);
+        transform = dmTransform::Mul(inst->m_WorldTransform, transform);
         dmVMath::Matrix4 world = dmTransform::ToMatrix4(transform);
         dmParticle::EmitterPrototype* emitter_proto = &inst->m_Prototype->m_Emitters[emitter_index];
 
@@ -2333,7 +2311,6 @@ namespace dmParticle
     DM_PARTICLE_TRAMPOLINE3(void, SetPosition, HParticleContext, HInstance, const Point3&);
     DM_PARTICLE_TRAMPOLINE3(void, SetRotation, HParticleContext, HInstance, const Quat&);
     DM_PARTICLE_TRAMPOLINE3(void, SetScale, HParticleContext, HInstance, float);
-    DM_PARTICLE_TRAMPOLINE3(void, SetScaleAlongZ, HParticleContext, HInstance, bool);
 
     DM_PARTICLE_TRAMPOLINE2(bool, IsSleeping, HParticleContext, HInstance);
     DM_PARTICLE_TRAMPOLINE3(void, Update, HParticleContext, float, FetchAnimationCallback);

--- a/engine/particle/src/particle.h
+++ b/engine/particle/src/particle.h
@@ -322,13 +322,6 @@ namespace dmParticle
      */
     DM_PARTICLE_PROTO(void, SetScale, HParticleContext context, HInstance instance, float scale);
     /**
-     * Set if the scale should be used along Z or not.
-     * @param context Context in which the instance exists.
-     * @param instance Instance to set the property for.
-     * @param scale_along_z Whether the scale should be used along Z.
-     */
-    DM_PARTICLE_PROTO(void, SetScaleAlongZ, HParticleContext context, HInstance instance, bool scale_along_z);
-    /**
      * Returns if the specified instance is spawning particles or not.
      * Instances are sleeping when they are not spawning and have no remaining living particles.
      */

--- a/engine/particle/src/particle_private.h
+++ b/engine/particle/src/particle_private.h
@@ -157,7 +157,6 @@ namespace dmParticle
         , m_EmitterStateChangedData()
         , m_PlayTime(0.0f)
         , m_VersionNumber(0)
-        , m_ScaleAlongZ(0)
         {
             m_WorldTransform.SetIdentity();
         }
@@ -176,8 +175,6 @@ namespace dmParticle
         float                   m_PlayTime;
         /// Version number used to check that the handle is still valid.
         uint16_t                m_VersionNumber;
-        /// Whether the scale of the world transform should be used along Z.
-        uint16_t                m_ScaleAlongZ : 1;
     };
 
     /**


### PR DESCRIPTION
`scale_along_z` has been fully removed from the engine. Read the following information to understand how to migrate your projects.

### ⚠️⚠️⚠️ Action Needed (Breaking Change)

#### What is `scale_along_z`?
`scale_along_z` was a hidden option in `*.collection` files, set to `0` by default.  
When set to `0`, scaling on objects and collections did **not** affect their z-position.  

For example, if your sprite has a position `x: 0.0, y: 0.0, z: 0.1`, and its GameObject has a scale `x: 1.0, y: 1.0, z: 2.0`:
- With `scale_along_z = 0`, the transform of the sprite remains `x: 0.0, y: 0.0, z: 0.1`
- With `scale_along_z = 1`, the transform becomes `x: 0.0, y: 0.0, z: 0.2`

#### Why Was It Removed?
This was a legacy feature that introduced special-case logic and added complexity to the engine. While it had utility in some 2D projects, it was often a source of confusion in 3D projects. To unify 2D and 3D workflows, we’ve made the difficult decision to remove it, even though it’s a breaking change.

#### Who Needs to Take Action?
If you are unfamiliar with `scale_along_z`, or you never explicitly set it to `1`, **you need to update your project**. If your project consistently used `scale_along_z: 1` across all collections, **no action is required**.

#### What Should Be Done in Lua Code?
To avoid unexpected behavior now that scaling affects Z-position:

- Replace all usages of `go.set_scale(number|vector3)` with `go.set_scale_xy(number|vector3)`
- When accessing the `scale` property via `go.get()`, `go.set()`, or `go.animate()`, use the `scale.xy` property instead

#### What Should Be Done in Project Files?
Review your GameObjects and Collections and check for use of the Z component in the `scale` property.  
If you find a non 1.0 Z scale in your project, investigate why it's there. In most of 2D cases, the Z scale should always be 1.0 because it doesn't affect anything. However, in some cases—such as pseudo-3D effects, perspective cameras, particles, 3D models, etc. Z-scaling may be intentional. These situations require manual review.

If all children of such an object have `position.z == 0`, then behavior will not change.  
But if `position.z` is non-zero, then the scale will now affect it, and you'll need to decide case by case how to proceed based on your game’s requirements.  
For example:
- You might need to adjust object positions to compensate for `scale.z` now affecting the children's positions.
- Or, set the parent object's `scale.z` to 1.0 and instead scale all children individually (adjusting positions accordingly).

Automatic migration is not possible due to the variety of use cases.  
Please review and adjust your project accordingly.  

We apologize for the inconvenience and hope that this change leads to a more consistent and understandable workflow for all users.

Fix https://github.com/defold/defold/issues/9529
Fix https://github.com/defold/defold/issues/7441
Fix https://github.com/defold/defold/issues/6165
Fix https://github.com/defold/defold/issues/5679
Fix https://github.com/defold/defold/issues/5631