### PR TITLE
Fix the scale tool for rotated objects in the editor

### DIFF
--- a/editor/src/clj/editor/scene_tools.clj
+++ b/editor/src/clj/editor/scene_tools.clj
@@ -460,7 +460,7 @@
       (let [world-transform (:world-transform (peek original-values))
             start-delta (doto (Vector3d.) (.sub start-pos manip-pos))
             delta (doto (Vector3d.) (.sub pos manip-pos))
-            axis-scale (fn [local]
+            axis-scale (fn [^Vector3d local]
                          (.transform ^Matrix4d world-transform local)
                          (.normalize local)
                          (let [start-len (.dot start-delta local)

--- a/editor/src/clj/editor/scene_tools.clj
+++ b/editor/src/clj/editor/scene_tools.clj
@@ -460,26 +460,22 @@
       (let [world-transform (:world-transform (peek original-values))
             start-delta (doto (Vector3d.) (.sub start-pos manip-pos))
             delta (doto (Vector3d.) (.sub pos manip-pos))
-            axis-scale (fn [axis]
-                         (let [local (case axis
-                                       :x (Vector3d. 1.0 0.0 0.0)
-                                       :y (Vector3d. 0.0 1.0 0.0)
-                                       :z (Vector3d. 0.0 0.0 1.0))]
-                           (.normalize local)
-                           (.transform ^Matrix4d world-transform local)
-                           (let [start-len (.dot start-delta local)
-                                 curr-len (.dot delta local)]
-                             (if (> (Math/abs start-len) 1e-12)
-                               (/ curr-len start-len)
-                               1.0))))
+            axis-scale (fn [local]
+                         (.transform ^Matrix4d world-transform local)
+                         (.normalize local)
+                         (let [start-len (.dot start-delta local)
+                               curr-len (.dot delta local)]
+                           (if (> (Math/abs start-len) 1e-12)
+                             (/ curr-len start-len)
+                             1.0)))
             sx (case manip
-                 (:scale-x :scale-xy :scale-xz) (axis-scale :x)
+                 (:scale-x :scale-xy :scale-xz) (axis-scale (Vector3d. 1.0 0.0 0.0))
                  1.0)
             sy (case manip
-                 (:scale-y :scale-xy :scale-yz) (axis-scale :y)
+                 (:scale-y :scale-xy :scale-yz) (axis-scale (Vector3d. 0.0 1.0 0.0))
                  1.0)
             sz (case manip
-                 (:scale-z :scale-xz :scale-yz) (axis-scale :z)
+                 (:scale-z :scale-xz :scale-yz) (axis-scale (Vector3d. 0.0 0.0 1.0))
                  1.0)
             scale-factor (Vector3d. sx sy sz)]
         (for [{:keys [node-id]} original-values]

--- a/editor/src/clj/editor/scene_tools.clj
+++ b/editor/src/clj/editor/scene_tools.clj
@@ -457,22 +457,31 @@
           (manip-rotate evaluation-context node-id local-rotation))))
     (:scale-x :scale-y :scale-z :scale-xy :scale-xz :scale-yz)
     (fn [start-pos pos]
-      (let [start-delta (doto (Vector3d.) (.sub start-pos manip-pos))
+      (let [world-transform (:world-transform (peek original-values))
+            start-delta (doto (Vector3d.) (.sub start-pos manip-pos))
             delta (doto (Vector3d.) (.sub pos manip-pos))
-            div-fn (fn [v ^Double sv] (if (> (Math/abs sv) math/epsilon) (/ v sv) 1.0))
-            scale-factor (Vector3d.
-                           (case manip
-                             (:scale-x :scale-xy :scale-xz)
-                             (div-fn (.x delta) (.x start-delta))
-                             1.0)
-                           (case manip
-                             (:scale-y :scale-xy :scale-yz)
-                             (div-fn (.y delta) (.y start-delta))
-                             1.0)
-                           (case manip
-                             (:scale-z :scale-xz :scale-yz)
-                             (div-fn (.z delta) (.z start-delta))
-                             1.0))]
+            axis-scale (fn [axis]
+                         (let [local (case axis
+                                       :x (Vector3d. 1.0 0.0 0.0)
+                                       :y (Vector3d. 0.0 1.0 0.0)
+                                       :z (Vector3d. 0.0 0.0 1.0))]
+                           (.normalize local)
+                           (.transform ^Matrix4d world-transform local)
+                           (let [start-len (.dot start-delta local)
+                                 curr-len (.dot delta local)]
+                             (if (> (Math/abs start-len) 1e-12)
+                               (/ curr-len start-len)
+                               1.0))))
+            sx (case manip
+                 (:scale-x :scale-xy :scale-xz) (axis-scale :x)
+                 1.0)
+            sy (case manip
+                 (:scale-y :scale-xy :scale-yz) (axis-scale :y)
+                 1.0)
+            sz (case manip
+                 (:scale-z :scale-xz :scale-yz) (axis-scale :z)
+                 1.0)
+            scale-factor (Vector3d. sx sy sz)]
         (for [{:keys [node-id]} original-values]
           (manip-scale evaluation-context node-id scale-factor))))
     :scale-uniform


### PR DESCRIPTION
The scale tool in the scene editor will now work regardless of how the object was initially rotated. Previously an object rotated exactly 90 degrees along any axis would not be possible to rotate using the scale tool.

Fix https://github.com/defold/defold/issues/9177