### PR TITLE
Make it clear when a collision object shape is unnamed

### DIFF
--- a/editor/src/clj/editor/collision_object.clj
+++ b/editor/src/clj/editor/collision_object.clj
@@ -113,7 +113,7 @@
                                                      {:node-id _node-id
                                                       :node-outline-key node-outline-key
                                                       :label (if (empty? id)
-                                                               (shape-type-label shape-type)
+                                                               (str "<Unnamed " (shape-type-label shape-type) ">")
                                                                id)
                                                       :icon (shape-type-icon shape-type)})))
 

--- a/editor/test/integration/collision_object_test.clj
+++ b/editor/test/integration/collision_object_test.clj
@@ -41,7 +41,7 @@
             outline   (g/node-value node-id :node-outline)
             scene     (g/node-value node-id :scene)]
         (is (= 3 (count (:children scene))))
-        (is (= ["Collision Object" "Box" "Capsule" "Sphere"] (outline-seq outline)))))))
+        (is (= ["Collision Object" "<Unnamed Box>" "<Unnamed Capsule>" "<Unnamed Sphere>"] (outline-seq outline)))))))
 
 (deftest add-shapes
   (testing "Adding a sphere"
@@ -51,7 +51,7 @@
         (test-util/handler-run :add [{:name :workbench :env {:selection [node-id] :app-view app-view}}] {:shape-type :type-sphere})
         (let [outline (g/node-value node-id :node-outline)]
           (is (= 4 (count (:children outline))))
-          (is (= "Sphere" (last (outline-seq outline)))))))))
+          (is (= "<Unnamed Sphere>" (last (outline-seq outline)))))))))
 
 (deftest validation
   (test-util/with-loaded-project


### PR DESCRIPTION
Make sure it's clear from the outline when physics shapes are unnamed (names are only needed for runtime operations):
![CleanShot 2025-04-14 at 08 05 16@2x](https://github.com/user-attachments/assets/c3110026-f0ce-4d6a-a386-1e6d9de2a347)

Fix https://github.com/defold/defold/issues/10429