### PR TITLE
Add Project and Debug locations for editor script commands

### DIFF
--- a/editor/src/clj/editor/debug_view.clj
+++ b/editor/src/clj/editor/debug_view.clj
@@ -912,4 +912,6 @@
                                                     :height 800}}]}
                            {:label "Rotated Device"
                             :command :set-rotate-device
-                            :check true}]}]}])
+                            :check true}]}
+               {:label :separator
+                :id ::debug-end}]}])

--- a/editor/src/clj/editor/defold_project.clj
+++ b/editor/src/clj/editor/defold_project.clj
@@ -1138,19 +1138,21 @@
                {:label "Live Update Settings"
                 :command :live-update-settings}
                {:label :separator
+                :id ::targets}
+               {:label :separator
                 :id ::project-end}]}])
 
 (defn- update-selection [s open-resource-nodes active-resource-node selection-value]
   (->> (assoc s active-resource-node selection-value)
-    (filter (comp (set open-resource-nodes) first))
-    (into {})))
+       (filter (comp (set open-resource-nodes) first))
+       (into {})))
 
 (defn- perform-selection [project all-selections]
   (let [all-node-ids (->> all-selections
-                       vals
-                       (reduce into [])
-                       distinct
-                       vec)
+                          vals
+                          (reduce into [])
+                          distinct
+                          vec)
         old-all-selections (g/node-value project :all-selections)]
     (when-not (= old-all-selections all-selections)
       (concat

--- a/editor/src/clj/editor/editor_extensions.clj
+++ b/editor/src/clj/editor/editor_extensions.clj
@@ -586,7 +586,7 @@
     (coerce/hash-map
       :req {:label coerce/string
             :locations (coerce/vector-of
-                         (coerce/enum "Edit" "View" "Assets" "Outline" "Bundle")
+                         (coerce/enum "Assets" "Bundle" "Debug" "Edit" "Outline" "Project" "View")
                          :distinct true
                          :min-count 1)}
       :opt {:query (coerce/hash-map

--- a/editor/src/clj/editor/editor_extensions/commands.clj
+++ b/editor/src/clj/editor/editor_extensions/commands.clj
@@ -95,15 +95,19 @@
         contexts (into #{}
                        (map {"Assets" :asset-browser
                              "Bundle" :global
-                             "Outline" :outline
+                             "Debug" :global
                              "Edit" :global
+                             "Outline" :outline
+                             "Project" :global
                              "View" :global})
                        locations)
         locations (into #{}
                         (map {"Assets" :editor.asset-browser/context-menu-end
                               "Bundle" :editor.bundle/menu
-                              "Outline" :editor.outline-view/context-menu-end
+                              "Debug" :editor.debug-view/debug-end
                               "Edit" :editor.app-view/edit-end
+                              "Outline" :editor.outline-view/context-menu-end
+                              "Project" ::project/project-end
                               "View" :editor.app-view/view-end})
                         locations)]
     (cond-> {:contexts contexts

--- a/editor/src/clj/editor/targets.clj
+++ b/editor/src/clj/editor/targets.clj
@@ -442,7 +442,7 @@
   (run []
        (kill-launched-targets!)))
 
-(handler/register-menu! ::menubar :editor.defold-project/project-end
+(handler/register-menu! ::menubar :editor.defold-project/targets
   [{:label "Target"
     :id ::target
     :on-submenu-open update!


### PR DESCRIPTION
Now this editor script will work:
```lua
local M = {}

function M.get_commands()
    return {
        {
            label = "Project command",
            locations = {"Project"},
            run = function()
                print("Run project command")
            end
        },
        {
            label = "Debug command",
            locations = {"Debug"},
            run = function()
                print("Run debug command")
            end
        }
    }
end

return M
```

Fixes #10409
