### PR TITLE
Increased text contrast in diff view

### DIFF
--- a/editor/styling/stylesheets/modules/_diff-view.scss
+++ b/editor/styling/stylesheets/modules/_diff-view.scss
@@ -12,7 +12,15 @@
   }
 
   Text {
-    -fx-fill: -df-text;
+      -fx-fill: -df-text;
+      
+      &.insert {
+        -fx-fill: -df-text-light;
+      }
+
+      &.delete {
+        -fx-fill: -df-text-light;
+      }
   }
 
   #markers {

--- a/editor/styling/stylesheets/modules/_diff-view.scss
+++ b/editor/styling/stylesheets/modules/_diff-view.scss
@@ -12,15 +12,15 @@
   }
 
   Text {
-      -fx-fill: -df-text;
-      
-      &.insert {
-        -fx-fill: -df-text-light;
-      }
+    -fx-fill: -df-text;
+    
+    &.insert {
+      -fx-fill: -df-text-light;
+    }
 
-      &.delete {
-        -fx-fill: -df-text-light;
-      }
+    &.delete {
+      -fx-fill: -df-text-light;
+    }
   }
 
   #markers {


### PR DESCRIPTION
Increased text contrast on green background when showing change diffs.

Old:

![CleanShot 2025-04-14 at 11 31 45@2x](https://github.com/user-attachments/assets/991e51d7-09c3-46ea-9953-70c88b9d354b)

New:

![CleanShot 2025-04-14 at 11 29 26@2x](https://github.com/user-attachments/assets/65fdb644-643f-4ac0-9a13-a8f8556e2114)


Fixes #10480 
