### PR TITLE
Fix the issue with `has no hex digest` for materials when building with LiveUpdate

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/MaterialBuilderTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/MaterialBuilderTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import com.dynamo.render.proto.Material.MaterialDesc;
 
 import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 public class MaterialBuilderTest extends AbstractProtoBuilderTest {
 
@@ -71,6 +72,9 @@ public class MaterialBuilderTest extends AbstractProtoBuilderTest {
                 """;
 
         MaterialDesc material = getMessage(build("/test_migrate_vx_attributes.material", src), MaterialDesc.class);
+        // We don't use them in runtime, so they should be empty
+        assertEquals("", material.getVertexProgram());
+        assertEquals("", material.getFragmentProgram());
 
         assertNotNull(material);
         assertTrue(material.hasProgram());

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/MaterialBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/MaterialBuilder.java
@@ -156,6 +156,8 @@ public class MaterialBuilder extends ProtoBuilder<MaterialDesc.Builder> {
         IResource shaderResource = getShaderProgram(materialBuilder);
 
         materialBuilder.setProgram("/" + BuilderUtil.replaceExt(shaderResource.getPath(), ".spc"));
+        materialBuilder.setVertexProgram("");
+        materialBuilder.setFragmentProgram("");
 
         ShaderDesc.Builder shaderBuilder = ShaderDesc.newBuilder();
         shaderBuilder.mergeFrom(resShader.getContent());


### PR DESCRIPTION
Fix https://github.com/defold/defold/issues/10497