### PR TITLE
Option to hide the Changed File panel

### DIFF
--- a/editor/resources/editor.fxml
+++ b/editor/resources/editor.fxml
@@ -30,7 +30,7 @@
                         </TitledPane>
                       </children>
                     </AnchorPane>
-                    <AnchorPane prefHeight="100.0" prefWidth="160.0" SplitPane.resizableWithParent="false">
+                    <AnchorPane id="changed-files-pane" prefHeight="100.0" prefWidth="160.0" SplitPane.resizableWithParent="false">
                       <children>
                         <TitledPane animated="false" collapsible="false" layoutX="3.0" layoutY="38.0" prefHeight="200.0" prefWidth="200.0" text="Changed Files" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
                           <content>

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -2478,8 +2478,10 @@ If you do not specifically require different script states, consider changing th
          (set-pane-visible! main-scene :bottom (not (pane-visible? main-scene :bottom))))))
 
 (handler/defhandler :toggle-pane-changed-files :global
+  (enabled? [^Stage main-stage]
+            (pane-visible? (.getScene main-stage) :left))
   (run [^Stage main-stage]
-       (let [main-scene (.getScene ^Stage main-stage)]
+       (let [main-scene (.getScene main-stage)]
          (set-pane-visible! main-scene :changed-files (not (pane-visible? main-scene :changed-files))))))
 
 (handler/defhandler :show-console :global

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -118,7 +118,10 @@
            :split-id "workbench-split"}
    :bottom {:index 1
             :pane-id "bottom-pane"
-            :split-id "center-split"}})
+            :split-id "center-split"}
+   :changed-files {:index 1
+                   :pane-id "changed-files-pane"
+                   :split-id "assets-split"}})
 
 (defn- pane-visible? [^Scene main-scene pane-kw]
   (let [{:keys [pane-id split-id]} (split-info-by-pane-kw pane-kw)]
@@ -1710,6 +1713,8 @@ If you do not specifically require different script states, consider changing th
     :id ::view
     :children [{:label "Toggle Assets Pane"
                 :command :toggle-pane-left}
+               {:label "Toggle Changed Files Pane"
+                :command :toggle-pane-changed-files}
                {:label "Toggle Tools Pane"
                 :command :toggle-pane-bottom}
                {:label "Toggle Properties Pane"
@@ -2471,6 +2476,11 @@ If you do not specifically require different script states, consider changing th
   (run [^Stage main-stage]
        (let [main-scene (.getScene main-stage)]
          (set-pane-visible! main-scene :bottom (not (pane-visible? main-scene :bottom))))))
+
+(handler/defhandler :toggle-pane-changed-files :global
+  (run [^Stage main-stage]
+       (let [main-scene (.getScene ^Stage main-stage)]
+         (set-pane-visible! main-scene :changed-files (not (pane-visible? main-scene :changed-files))))))
 
 (handler/defhandler :show-console :global
   (run [^Stage main-stage tool-tab-pane] (show-console! (.getScene main-stage) tool-tab-pane)))

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -1713,7 +1713,7 @@ If you do not specifically require different script states, consider changing th
     :id ::view
     :children [{:label "Toggle Assets Pane"
                 :command :toggle-pane-left}
-               {:label "Toggle Changed Files Pane"
+               {:label "Toggle Changed Files"
                 :command :toggle-pane-changed-files}
                {:label "Toggle Tools Pane"
                 :command :toggle-pane-bottom}


### PR DESCRIPTION
New option `View -> Toggle Changed Files Pane` that hides the `Changed Files` panel.  

Fix https://github.com/defold/defold/issues/9908