### PR TITLE
Fix opening SHA-2 projects

### DIFF
--- a/editor/src/clj/editor/git.clj
+++ b/editor/src/clj/editor/git.clj
@@ -23,7 +23,7 @@
            [java.util Collection]
            [org.eclipse.jgit.api Git]
            [org.eclipse.jgit.diff DiffEntry RenameDetector]
-           [org.eclipse.jgit.errors MissingObjectException InvalidObjectIdException]
+           [org.eclipse.jgit.errors MissingObjectException]
            [org.eclipse.jgit.lib BranchConfig ObjectId Repository]
            [org.eclipse.jgit.revwalk RevCommit RevWalk]
            [org.eclipse.jgit.transport RemoteConfig URIish]
@@ -50,12 +50,7 @@
 
 (defn get-commit
   ^RevCommit [^Repository repository revision]
-  (when-some [object-id 
-              (try
-                ;; Repository resolution errors can cause the editor to hang
-                (.resolve repository revision)
-                (catch InvalidObjectIdException _
-                  nil))]
+  (when-some [object-id (.resolve repository revision)]
     (let [walk (RevWalk. repository)]
       (.setRetainBody walk true)
       (.parseCommit walk object-id))))

--- a/editor/src/clj/editor/git.clj
+++ b/editor/src/clj/editor/git.clj
@@ -23,7 +23,7 @@
            [java.util Collection]
            [org.eclipse.jgit.api Git]
            [org.eclipse.jgit.diff DiffEntry RenameDetector]
-           [org.eclipse.jgit.errors MissingObjectException]
+           [org.eclipse.jgit.errors MissingObjectException InvalidObjectIdException]
            [org.eclipse.jgit.lib BranchConfig ObjectId Repository]
            [org.eclipse.jgit.revwalk RevCommit RevWalk]
            [org.eclipse.jgit.transport RemoteConfig URIish]
@@ -50,7 +50,12 @@
 
 (defn get-commit
   ^RevCommit [^Repository repository revision]
-  (when-some [object-id (.resolve repository revision)]
+  (when-some [object-id 
+              (try
+                ;; Repository resolution errors can cause the editor to hang
+                (.resolve repository revision)
+                (catch InvalidObjectIdException _
+                  nil))]
     (let [walk (RevWalk. repository)]
       (.setRetainBody walk true)
       (.parseCommit walk object-id))))


### PR DESCRIPTION
The editor used to hang when trying to open SHA256 Git repositories, due to an upstream bug with JGit. Now, these projects can be opened, but without Defold version control features.

Fixes #10506

### Technical changes
* The exception `InvalidObjectIdException` seems to also be thrown when trying to access a private repo without proper authentication. I don't think this will cause any issues, as it would fail in the same way and so it's fixed in the same way, but it's worth noting.
* I want to include a test for this, but because JGit doesn't support SHA256 repos, I can't create a repo that actually tests it within the test suite. You could probably clone an existing repo, but github ALSO doesn't support SHA256 repos yet.
* (A requirement for git 3.0 is currently that SHA256 is the default - but there's quite a bit of work to be done, including ensuring the support it out there)
* This is against the `editor-dev` branch because I don't see any issues arising.

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests. (See Technical Changes)
	* [x] New and changed code follows the overall code style of existing code
	* [x] Add comments where needed
* [x] Documentation
	* [x] ~~Make sure that API documentation is updated in code comments~~
	* [x] ~~Make sure that manuals are updated (in github.com/defold/doc)~~
* [x] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [x] ~~Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.~~
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------