### PR TITLE
Add editor shortcut keymap configuration

### DIFF
--- a/editor/.idea/ClojureProjectResolveSettings.xml
+++ b/editor/.idea/ClojureProjectResolveSettings.xml
@@ -3,6 +3,7 @@
   <component name="ClojureProjectResolveSettings">
     <item key="editor.git-test/with-new-git" resolves-as="clojure.core/def" />
     <item key="editor.editor-extensions.runtime/lua-fn" resolves-as="clojure.core/fn" />
+    <item key="editor.fxui/defc" resolves-as="clojure.core/defn" />
     <item key="dynamo.graph/fnk" resolves-as="clojure.core/fn" />
     <item key="editor.ui/with-controls" resolves-as="clojure.core/fn" />
     <item key="clojure.spec.alpha/fdef" resolves-as="clojure.core/def" />

--- a/editor/.idea/codeStyles/Project.xml
+++ b/editor/.idea/codeStyles/Project.xml
@@ -38,6 +38,7 @@
           <entry key="editor.file-test/with-temp-dir" value="-1" />
           <entry key="editor.file-test/with-temp-dir!" value="-1" />
           <entry key="editor.fs/maybe-silently" value="-1" />
+          <entry key="editor.fxui/defc" value="-1" />
           <entry key="editor.git-test/with-git" value="-1" />
           <entry key="editor.gl.shader/defshader" value="-1" />
           <entry key="editor.gl.vertex/defvertex" value="-1" />
@@ -69,6 +70,7 @@
           <entry key="editor.ui.bindings/-if" value="-1" />
           <entry key="editor.ui.bindings/when" value="-1" />
           <entry key="editor.ui.bindings/when-not" value="-1" />
+          <entry key="editor.ui/event-dispatcher" value="-1" />
           <entry key="editor.ui/event-handler" value="-1" />
           <entry key="editor.ui/invalidation-listener" value="-1" />
           <entry key="editor.ui/on-action!" value="-1" />

--- a/editor/project.clj
+++ b/editor/project.clj
@@ -81,7 +81,7 @@
 
                      [com.github.ben-manes.caffeine/caffeine "3.1.2"]
 
-                     [cljfx "1.9.3"
+                     [cljfx "1.9.5"
                       :exclusions [org.clojure/clojure
                                    org.openjfx/javafx-base
                                    org.openjfx/javafx-graphics

--- a/editor/resources/bundle.editor_script
+++ b/editor/resources/bundle.editor_script
@@ -518,14 +518,14 @@ local is_macos = editor.platform:sub(-#"macos") == "macos"
 
 function M.get_commands()
     return {
-        editor.bundle.command("iOS Application...", "bundle-ios", bundle_ios, {
+        editor.bundle.command("iOS Application...", "project.bundle-ios", bundle_ios, {
             active = function() return is_macos end
         }),
-        editor.bundle.command("Android Application...", "bundle-android", bundle_android),
-        editor.bundle.command("macOS Application...", "bundle-macos", bundle_macos),
-        editor.bundle.command("Windows Application...", "bundle-windows", bundle_windows),
-        editor.bundle.command("Linux Application...", "bundle-linux", bundle_linux),
-        editor.bundle.command("HTML5 Application...", "bundle-html5", bundle_html5),
+        editor.bundle.command("Android Application...", "project.bundle-android", bundle_android),
+        editor.bundle.command("macOS Application...", "project.bundle-macos", bundle_macos),
+        editor.bundle.command("Windows Application...", "project.bundle-windows", bundle_windows),
+        editor.bundle.command("Linux Application...", "project.bundle-linux", bundle_linux),
+        editor.bundle.command("HTML5 Application...", "project.bundle-html5", bundle_html5),
     }
 end
 

--- a/editor/resources/prelude.lua
+++ b/editor/resources/prelude.lua
@@ -374,7 +374,12 @@ function editor.bundle.command(label, id, fn, rest)
     result.locations = {"Bundle"}
     result.query = {argument = true}
     result.run = function(opts)
-        local success, ret_or_message = pcall(fn, opts.argument)
+        local argument = opts.argument
+        if opts.argument == nil then
+            argument = true
+        else
+        end
+        local success, ret_or_message = pcall(fn, argument)
         if success or ret_or_message == editor.bundle.abort_message then
             return
         end

--- a/editor/resources/quick-help-view.fxml
+++ b/editor/resources/quick-help-view.fxml
@@ -16,5 +16,5 @@
             </Insets>
         </VBox.margin>
     </ImageView>
-    <GridPane id="quick-help-items" alignment="CENTER" vgap="15"/>
+    <GridPane id="quick-help-items" alignment="CENTER" vgap="15" hgap="15"/>
 </VBox>

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -79,6 +79,7 @@
             [internal.util :refer [first-where]]
             [service.log :as log]
             [service.smoke-log :as slog]
+            [util.coll :as coll]
             [util.eduction :as e]
             [util.http-server :as http-server]
             [util.profiler :as profiler]
@@ -86,7 +87,6 @@
   (:import [com.defold.editor Editor]
            [com.defold.editor UIUtil]
            [com.dynamo.bob Platform]
-           [com.sun.javafx PlatformUtil]
            [com.sun.javafx.scene NodeHelper]
            [java.io File PipedInputStream PipedOutputStream]
            [java.net URL]
@@ -245,88 +245,43 @@
       (str "*" escaped-resource-name)
       escaped-resource-name)))
 
-(defn- is-macos [] (PlatformUtil/isMac))
-
-(defn- create-key-info [label key-combo]
-  (let [cmd (if (is-macos) "⌘" "Cmd")
-        ctrl (if (is-macos) "⌃" "Ctrl")
-        alt (if (is-macos) "⌥" "Alt")
-        shift (if (is-macos) "⇧" "Shift")
-        keys (into []
-                   (remove nil?)
-                   (list
-                     (when (:meta-down? key-combo) cmd)
-                     (when (:control-down? key-combo) ctrl)
-                     (when (:alt-down? key-combo) alt)
-                     (when (:shift-down? key-combo) shift)
-                     (str (:key key-combo))))]
-    {:label label :keys keys}))
-
 (defn- update-quick-help-pane [^SplitPane editor-tabs-split keymap]
   (let [tab-panes (.getItems editor-tabs-split)
         is-empty (not-any? #(-> ^TabPane % .getTabs count pos?) tab-panes)
         parent (.getParent editor-tabs-split)
         quick-help-box (.lookup parent "#quick-help-box")
-        ^GridPane box-items (.lookup parent "#quick-help-items")]
+        ^GridPane grid-pane (.lookup parent "#quick-help-items")]
 
     ;; Only make quick help visible when there is no-tabs.
     (.setVisible quick-help-box is-empty)
 
     (when is-empty
-      (let [command->key-combo
-            (into {}
-                  (mapcat (fn [[key-combo command-infos]]
-                            (map (fn [command-info] [(:command command-info) key-combo]) command-infos)))
-                  keymap)
-            items (keep (fn [[command label]]
-                          (when-some [key-combo (command->key-combo command)]
-                            (create-key-info label key-combo)))
-                        [[:open-asset "Open Asset"]
-                         [:reopen-recent-file "Re-Open Closed File"]
-                         [:search-in-files "Search in Files"]
-                         [:build "Build and Run Project"]
-                         [:start-debugger "Start or Attach Debugger"]])]
-        (-> box-items .getChildren .clear)
-
-        (doseq [[row-index item] (map-indexed vector items)]
-          (let [space-character (if (is-macos) "" "+")
-                space (if (is-macos) 5 10)
-                label-font (Font. "Dejavu Sans Mono" 13)
-                key-font (Font. "" 13)
-                color (Color. 1.0 1.0 0.59765625 0.6)
-                label (:label item)
-                keys (:keys item)]
-
-            ;; Add label in the first column
-            (let [label-ui (Label. label)]
-              (.setFont label-ui label-font)
-              (.setTextFill label-ui color)
-              (GridPane/setHalignment label-ui HPos/RIGHT)
-              (-> box-items (.add label-ui 0 row-index)))
-
-            ;; Add keys (in the hbox) in the second column
-            (let [hbox (HBox.)]
-              (.setAlignment hbox Pos/CENTER_LEFT)
-
-              (let [spacer (Region.)]
-                (.setPrefWidth spacer 10)
-                (-> hbox .getChildren (.add spacer)))
-
-              (doseq [[index key] (map-indexed vector keys)]
-                (when (pos? index)
-                  (let [plus-ui (Label. space-character)]
-                    (.setPrefWidth plus-ui space)
-                    (.setAlignment plus-ui Pos/CENTER)
-                    (-> hbox .getChildren (.add plus-ui))))
-
-                (let [key-ui (Label. key)]
-                  (.setFont key-ui key-font)
-                  (.setAlignment key-ui Pos/CENTER)
-                  (.setTextFill key-ui color)
-                  (-> key-ui .getStyleClass (.add "key-button"))
-                  (-> hbox .getChildren (.add key-ui))))
-
-              (-> box-items (.add hbox 1 row-index)))))))))
+      (let [label-font (Font. "Dejavu Sans Mono" 13)
+            key-font (Font. "" 13)
+            color (Color. 1.0 1.0 0.59765625 0.6)]
+        (.clear (.getChildren grid-pane))
+        (->> [[:file.open "Open Asset"]
+              [:file.reopen-recent "Re-Open Closed File"]
+              [:file.search "Search in Files"]
+              [:project.build "Build and Run Project"]
+              [:debugger.start "Start or Attach Debugger"]]
+             (e/keep (fn [[command label]]
+                       (when-let [display-text (keymap/display-text keymap command nil)]
+                         (coll/pair label display-text))))
+             (e/map-indexed coll/pair)
+             (run! (fn [[row [label display-text]]]
+                     (doto grid-pane
+                       (.add (doto (Label. label)
+                               (.setFont label-font)
+                               (GridPane/setHalignment HPos/RIGHT)
+                               (.setTextFill color))
+                             0 row)
+                       (.add (doto (Label. display-text)
+                               (.setFont key-font)
+                               (.setAlignment Pos/CENTER)
+                               (.setTextFill color)
+                               (-> .getStyleClass (.add "key-button")))
+                             1 row)))))))))
 
 (g/defnode AppView
   (property stage Stage)
@@ -338,7 +293,7 @@
   (property auto-pulls g/Any)
   (property active-tool g/Keyword)
   (property manip-space g/Keyword)
-  (property keymap-config g/Any)
+  (property keymap g/Any)
 
   (input open-views g/Any :array)
   (input open-dirty-views g/Any :array)
@@ -391,8 +346,6 @@
                                                             dirty (contains? open-dirty-views view)
                                                             title (tab-title resource dirty)]]
                                                 (ui/text! tab title)))))
-  (output keymap g/Any :cached (g/fnk [keymap-config]
-                                 (keymap/make-keymap keymap-config {:valid-command? (handler/available-commands)})))
   (output debugger-execution-locations g/Any (gu/passthrough debugger-execution-locations)))
 
 (defn- selection->openable-resources [selection]
@@ -444,19 +397,19 @@
       (g/set-property app-view :active-tab tab)))
   (ui/user-data! app-scene ::ui/refresh-requested? true))
 
-(handler/defhandler :move-tool :workbench
+(handler/defhandler :scene.select-move-tool :workbench
   (run [app-view] (g/transact (g/set-property app-view :active-tool :move)))
   (state [app-view] (= (g/node-value app-view :active-tool) :move)))
 
-(handler/defhandler :scale-tool :workbench
+(handler/defhandler :scene.select-scale-tool :workbench
   (run [app-view] (g/transact (g/set-property app-view :active-tool :scale)))
   (state [app-view]  (= (g/node-value app-view :active-tool) :scale)))
 
-(handler/defhandler :rotate-tool :workbench
+(handler/defhandler :scene.select-rotate-tool :workbench
   (run [app-view] (g/transact (g/set-property app-view :active-tool :rotate)))
   (state [app-view]  (= (g/node-value app-view :active-tool) :rotate)))
 
-(handler/defhandler :show-visibility-settings :workbench
+(handler/defhandler :scene.visibility.show-settings :workbench
   (run [app-view scene-visibility]
     (when-let [btn (some-> ^TabPane (g/node-value app-view :active-tab-pane)
                            ui/selected-tab
@@ -499,38 +452,38 @@
   [{:id :select
     :tooltip "Select tool"
     :icon "icons/45/Icons_T_01_Select.png"
-    :command :select-tool}
+    :command :scene.select-select-tool}
    {:id :move
     :tooltip "Move tool"
     :icon "icons/45/Icons_T_02_Move.png"
-    :command :move-tool}
+    :command :scene.select-move-tool}
    {:id :rotate
     :tooltip "Rotate tool"
     :icon "icons/45/Icons_T_03_Rotate.png"
-    :command :rotate-tool}
+    :command :scene.select-rotate-tool}
    {:id :scale
     :tooltip "Scale tool"
     :icon "icons/45/Icons_T_04_Scale.png"
-    :command :scale-tool}
+    :command :scene.select-scale-tool}
    {:label :separator}
    {:id :2d-mode
     :tooltip "2d mode"
     :graphic-fn (partial icons/make-svg-icon-graphic mode-2d-svg-path)
-    :command :toggle-2d-mode}
+    :command :scene.toggle-interaction-mode}
    {:id :perspective-camera
     :tooltip "Perspective camera"
     :graphic-fn (partial icons/make-svg-icon-graphic perspective-icon-svg-path)
-    :command :toggle-perspective-camera}
+    :command :scene.toggle-camera-type}
    {:id :visibility-settings
     :tooltip "Visibility settings"
     :graphic-fn make-visibility-settings-graphic
-    :command :show-visibility-settings}])
+    :command :scene.visibility.show-settings}])
 
 (def ^:const prefs-window-dimensions [:window :dimensions])
 (def ^:const prefs-split-positions [:window :split-positions])
 (def ^:const prefs-hidden-panes [:window :hidden-panes])
 
-(handler/defhandler :quit :global
+(handler/defhandler :file.quit :global
   (run []
     (let [^Stage main-stage (ui/main-stage)]
       (.fireEvent main-stage (WindowEvent. main-stage WindowEvent/WINDOW_CLOSE_REQUEST)))))
@@ -618,10 +571,13 @@
     (doseq [pane-kw hidden-panes]
       (set-pane-visible! scene pane-kw false))))
 
-(handler/defhandler :preferences :global
+(handler/defhandler :file.preferences :global
   (run [workspace prefs app-view]
     (prefs-dialog/open! prefs)
     (workspace/update-build-settings! workspace prefs)
+    (let [new-keymap (keymap/from-prefs prefs)]
+      (when-not (= new-keymap (g/raw-property-value (g/now) app-view :keymap))
+        (g/set-property! app-view :keymap new-keymap)))
     (ui/invalidate-menubar-item! ::file)))
 
 (defn- collect-resources [{:keys [children] :as resource}]
@@ -1240,19 +1196,29 @@
                                    (show-console! main-scene tool-tab-pane)
                                    (launch-built-project! project engine project-directory prefs web-server false)))))))
 
-(handler/defhandler :build :global
+(handler/defhandler :project.build :global
   (enabled? [] (not (build-in-progress?)))
   (run [project workspace prefs web-server build-errors-view debug-view main-stage tool-tab-pane]
     (debug-view/detach! debug-view)
     (build-handler project workspace prefs web-server build-errors-view main-stage tool-tab-pane)))
 
-(handler/defhandler :set-instance-count :global
+(handler/defhandler :run.set-instance-count :global
+  (options [prefs user-data]
+    (when-not user-data
+      (mapv (fn [i]
+              {:label (str i (if (> i 1)
+                               " Instances"
+                               " Instance"))
+               :command :run.set-instance-count
+               :check true
+               :user-data {:instance-count i}})
+            (range 1 5))))
   (run [prefs user-data]
-       (let [count (:instance-count user-data)]
-         (prefs/set! prefs [:run :instance-count] count)))
+    (let [count (:instance-count user-data)]
+      (prefs/set! prefs [:run :instance-count] count)))
   (state [prefs user-data]
-         (= (:instance-count user-data)
-            (prefs/get prefs [:run :instance-count]))))
+    (= (:instance-count user-data)
+       (prefs/get prefs [:run :instance-count]))))
 
 (defn- debugging-supported?
   [project]
@@ -1300,7 +1266,7 @@ If you do not specifically require different script states, consider changing th
                                  (when (targets/controllable-target? target)
                                    (debug-view/attach! debug-view project target (:artifacts build-results))))))))
 
-(handler/defhandler :start-debugger :global
+(handler/defhandler :debugger.start :global
   ;; NOTE: Shares a shortcut with :debug-view/continue.
   ;; Only one of them can be active at a time. This creates the impression that
   ;; there is a single menu item whose label changes in various states.
@@ -1316,21 +1282,21 @@ If you do not specifically require different script states, consider changing th
           (attach-debugger! workspace project prefs debug-view render-build-error!)
           (run-with-debugger! workspace project prefs debug-view render-build-error! web-server))))))
 
-(def ^:private rebuild-dialog-info
-  {:title "Rebuild Project?"
+(def ^:private clean-build-dialog-info
+  {:title "Perform Clean Project Build?"
    :icon :icon/circle-question
-   :header "Are you sure you want to rebuild the project?"
+   :header "Are you sure you want to perform a clean project build?"
    :buttons [{:text "Cancel"
               :cancel-button true
               :result false}
-             {:text "Rebuild"
+             {:text "Clean Build"
               :default-button true
               :result true}]})
 
-(handler/defhandler :rebuild :global
+(handler/defhandler :project.clean-build :global
   (enabled? [] (not (build-in-progress?)))
   (run [project workspace prefs web-server build-errors-view debug-view main-stage tool-tab-pane]
-    (when (dialogs/make-confirmation-dialog rebuild-dialog-info)
+    (when (dialogs/make-confirmation-dialog clean-build-dialog-info)
       (debug-view/detach! debug-view)
       (workspace/clear-build-cache! workspace)
       (build-handler project workspace prefs web-server build-errors-view main-stage tool-tab-pane))))
@@ -1361,13 +1327,13 @@ If you do not specifically require different script states, consider changing th
                                    (console/append-console-entry! nil (format "INFO: The game is available at %s" url))))
                                (.close out))))))
 
-(handler/defhandler :rebuild-html5 :global
+(handler/defhandler :project.clean-build-html5 :global
   (run [project prefs web-server build-errors-view changes-view main-stage tool-tab-pane]
-       (when (dialogs/make-confirmation-dialog rebuild-dialog-info)
+       (when (dialogs/make-confirmation-dialog clean-build-dialog-info)
          (build-html5! project prefs web-server build-errors-view changes-view main-stage tool-tab-pane
-                       bob/rebuild-html5-bob-commands))))
+                       bob/clean-build-html5-bob-commands))))
 
-(handler/defhandler :build-html5 :global
+(handler/defhandler :project.build-html5 :global
   (run [project prefs web-server build-errors-view changes-view main-stage tool-tab-pane]
        (build-html5! project prefs web-server build-errors-view changes-view main-stage tool-tab-pane
                      bob/build-html5-bob-commands)))
@@ -1445,13 +1411,13 @@ If you do not specifically require different script states, consider changing th
                                                           (targets/target-message-label (targets/selected-target prefs)))
                                           :content (.getMessage e)})))))))))
 
-(handler/defhandler :hot-reload :global
+(handler/defhandler :run.hot-reload :global
   (enabled? [debug-view prefs evaluation-context]
             (can-hot-reload? debug-view prefs evaluation-context))
   (run [project app-view prefs build-errors-view selection main-stage tool-tab-pane]
        (hot-reload! project prefs build-errors-view main-stage tool-tab-pane)))
 
-(handler/defhandler :close :global
+(handler/defhandler :window.tab.close :global
   (enabled? [app-view evaluation-context]
             (not-empty (get-active-tabs app-view evaluation-context)))
   (run [app-view]
@@ -1459,7 +1425,7 @@ If you do not specifically require different script states, consider changing th
       (when-let [tab (ui/selected-tab tab-pane)]
         (remove-tab! tab-pane tab)))))
 
-(handler/defhandler :close-other :global
+(handler/defhandler :window.tab.close-others :global
   (enabled? [app-view evaluation-context]
             (not-empty (next (get-active-tabs app-view evaluation-context))))
   (run [app-view]
@@ -1473,7 +1439,7 @@ If you do not specifically require different script states, consider changing th
           (when (not= tab selected-tab)
             (remove-tab! tab-pane tab)))))))
 
-(handler/defhandler :close-all :global
+(handler/defhandler :window.tab.close-all :global
   (enabled? [app-view evaluation-context]
             (not-empty (get-active-tabs app-view evaluation-context)))
   (run [app-view]
@@ -1522,7 +1488,7 @@ If you do not specifically require different script states, consider changing th
   (let [editor-tabs-split ^SplitPane (g/node-value app-view :editor-tabs-split evaluation-context)]
     (.size (.getItems editor-tabs-split))))
 
-(handler/defhandler :move-tab :global
+(handler/defhandler :window.tab.move-to-other-group :global
   (enabled? [app-view evaluation-context]
             (< 1 (open-tab-count app-view evaluation-context)))
   (run [app-view user-data]
@@ -1536,7 +1502,7 @@ If you do not specifically require different script states, consider changing th
          (.select (.getSelectionModel dest-tab-pane) selected-tab)
          (.requestFocus dest-tab-pane))))
 
-(handler/defhandler :swap-tabs :global
+(handler/defhandler :window.tab.swap :global
   (enabled? [app-view evaluation-context]
             (< 1 (open-tab-pane-count app-view evaluation-context)))
   (run [app-view user-data]
@@ -1562,7 +1528,7 @@ If you do not specifically require different script states, consider changing th
          (.select other-tab-pane-selection active-tab)
          (.requestFocus other-tab-pane))))
 
-(handler/defhandler :join-tab-panes :global
+(handler/defhandler :window.tab.join-groups :global
   (enabled? [app-view evaluation-context]
             (< 1 (open-tab-pane-count app-view evaluation-context)))
   (run [app-view user-data]
@@ -1595,37 +1561,37 @@ If you do not specifically require different script states, consider changing th
     (.setScene stage scene)
     (ui/show! stage)))
 
-(handler/defhandler :documentation :global
+(handler/defhandler :help.open-documentation :global
   (run [] (ui/open-url "https://www.defold.com/learn/")))
 
-(handler/defhandler :support-forum :global
+(handler/defhandler :help.open-forum :global
   (run [] (ui/open-url "https://forum.defold.com/")))
 
-(handler/defhandler :asset-portal :global
+(handler/defhandler :help.open-asset-portal :global
   (run [] (ui/open-url "https://www.defold.com/assets")))
 
-(handler/defhandler :report-issue :global
+(handler/defhandler :help.report-issue :global
   (run [] (ui/open-url (github/new-issue-link))))
 
-(handler/defhandler :report-suggestion :global
+(handler/defhandler :help.report-suggestion :global
   (run [] (ui/open-url (github/new-suggestion-link))))
 
-(handler/defhandler :search-issues :global
+(handler/defhandler :help.open-issues :global
   (run [] (ui/open-url (github/search-issues-link))))
 
-(handler/defhandler :show-logs :global
+(handler/defhandler :help.open-logs :global
   (run [] (ui/open-file (.getAbsoluteFile (.toFile (Editor/getLogDirectory))))))
 
-(handler/defhandler :donate :global
+(handler/defhandler :help.open-donations :global
   (run [] (ui/open-url "https://www.defold.com/donate")))
 
-(handler/defhandler :about :global
+(handler/defhandler :help.about :global
   (run [] (make-about-dialog)))
 
-(handler/defhandler :reload-stylesheet :global
+(handler/defhandler :window.reload-css :global
   (run [] (ui/reload-root-styles!)))
 
-(handler/defhandler :open-project :global
+(handler/defhandler :file.open-project :global
   (active? [] (and (system/defold-resourcespath) (system/defold-launcherpath)))
   (run [] (let [resources-path (system/defold-resourcespath)
                 install-dir (.getCanonicalFile
@@ -1639,163 +1605,161 @@ If you do not specifically require different script states, consider changing th
     :id ::file
     :children [{:label "New..."
                 :id ::new
-                :command :new-file}
-               {:label "Open"
+                :command :file.new}
+               {:label "Open..."
                 :id ::open
-                :command :open}
+                :command :file.open}
                {:label "Load External Changes"
                 :id ::async-reload
-                :command :async-reload}
+                :command :project.load-external-changes}
                {:label "Save All"
                 :id ::save-all
-                :command :save-all}
+                :command :file.save-all}
                {:label "Upgrade File Formats..."
                 :id ::save-and-upgrade-all
-                :command :save-and-upgrade-all}
+                :command :file.save-and-upgrade-all}
                {:label :separator}
-               {:label "Open Assets..."
-                :command :open-asset}
                {:label "Search in Files..."
-                :command :search-in-files}
+                :command :file.search}
                {:label "Recent Files"
-                :command :recent-files}
+                :command :private/recent-files}
                {:label :separator}
                {:label "Close"
-                :command :close}
+                :command :window.tab.close}
                {:label "Close All"
-                :command :close-all}
+                :command :window.tab.close-all}
                {:label "Close Others"
-                :command :close-other}
+                :command :window.tab.close-others}
                {:label :separator}
                {:label "Referencing Files..."
-                :command :referencing-files}
+                :command :file.show-references}
                {:label "Dependencies..."
-                :command :dependencies}
+                :command :file.show-dependencies}
                {:label "Show Overrides"
-                :command :show-overrides}
+                :command :window.show-overrides}
                {:label "Hot Reload"
-                :command :hot-reload}
+                :command :run.hot-reload}
                {:label :separator}
                {:label "Open Project..."
-                :command :open-project}
+                :command :file.open-project}
                {:label "Preferences..."
-                :command :preferences}
+                :command :file.preferences}
                {:label "Quit"
-                :command :quit}]}
+                :command :file.quit}]}
    {:label "Edit"
     :id ::edit
     :children [{:label "Undo"
                 :icon "icons/undo.png"
-                :command :undo}
+                :command :edit.undo}
                {:label "Redo"
                 :icon "icons/redo.png"
-                :command :redo}
+                :command :edit.redo}
                {:label :separator}
                {:label "Cut"
-                :command :cut}
+                :command :edit.cut}
                {:label "Copy"
-                :command :copy}
+                :command :edit.copy}
                {:label "Paste"
-                :command :paste}
+                :command :edit.paste}
                {:label "Select All"
-                :command :select-all}
+                :command :code.select-all}
                {:label "Delete"
                 :icon "icons/32/Icons_M_06_trash.png"
-                :command :delete}
+                :command :edit.delete}
                {:label :separator}
                {:label "Move Up"
-                :command :move-up}
+                :command :edit.reorder-up}
                {:label "Move Down"
-                :command :move-down}
+                :command :edit.reorder-down}
                {:label :separator
                 :id ::edit-end}]}
    {:label "View"
     :id ::view
     :children [{:label "Toggle Assets Pane"
-                :command :toggle-pane-left}
+                :command :window.toggle-left-pane}
                {:label "Toggle Changed Files"
-                :command :toggle-pane-changed-files}
+                :command :window.toggle-changed-files-pane}
                {:label "Toggle Tools Pane"
-                :command :toggle-pane-bottom}
+                :command :window.toggle-bottom-pane}
                {:label "Toggle Properties Pane"
-                :command :toggle-pane-right}
+                :command :window.toggle-right-pane}
                {:label :separator}
                {:label "Show Console"
-                :command :show-console}
+                :command :window.show-console}
                {:label "Show Curve Editor"
-                :command :show-curve-editor}
+                :command :window.show-curve-editor}
                {:label "Show Build Errors"
-                :command :show-build-errors}
+                :command :window.show-build-errors}
                {:label "Show Search Results"
-                :command :show-search-results}
+                :command :window.show-search-results}
                {:label :separator
                 :id ::view-end}]}
    {:label "Help"
     :children [{:label "Profiler"
                 :children [{:label "Measure and Show"
-                            :command :profile-show}]}
+                            :command :dev.open-profiler}]}
                {:label "Reload Stylesheet"
-                :command :reload-stylesheet}
+                :command :window.reload-css}
                {:label "Show Logs"
-                :command :show-logs}
+                :command :help.open-logs}
                {:label :separator}
                {:label "Create Desktop Entry"
-                :command :create-desktop-entry}
+                :command :file.create-desktop-entry}
                {:label :separator}
                {:label "Documentation"
-                :command :documentation}
+                :command :help.open-documentation}
                {:label "Support Forum"
-                :command :support-forum}
+                :command :help.open-forum}
                {:label "Find Assets"
-                :command :asset-portal}
+                :command :help.open-asset-portal}
                {:label :separator}
                {:label "Report Issue"
-                :command :report-issue}
+                :command :help.report-issue}
                {:label "Report Suggestion"
-                :command :report-suggestion}
+                :command :help.report-suggestion}
                {:label "Search Issues"
-                :command :search-issues}
+                :command :help.open-issues}
                {:label :separator}
                {:label "Development Fund"
-                :command :donate}
+                :command :help.open-donations}
                {:label :separator}
                {:label "About"
-                :command :about}]}])
+                :command :help.about}]}])
 
 (handler/register-menu! ::tab-menu
   [{:label "Close"
-    :command :close}
+    :command :window.tab.close}
    {:label "Close Others"
-    :command :close-other}
+    :command :window.tab.close-others}
    {:label "Close All"
-    :command :close-all}
+    :command :window.tab.close-all}
    {:label :separator}
    {:label "Move to Other Tab Pane"
-    :command :move-tab}
+    :command :window.tab.move-to-other-group}
    {:label "Swap With Other Tab Pane"
-    :command :swap-tabs}
+    :command :window.tab.swap}
    {:label "Join Tab Panes"
-    :command :join-tab-panes}
+    :command :window.tab.join-groups}
    {:label :separator}
-   {:label "Copy Project Path"
-    :command :copy-project-path}
+   {:label "Copy Resource Path"
+    :command :edit.copy-resource-path}
    {:label "Copy Full Path"
-    :command :copy-full-path}
+    :command :edit.copy-absolute-path}
    {:label "Copy Require Path"
-    :command :copy-require-path}
+    :command :edit.copy-require-path}
    {:label :separator}
    {:label "Show in Asset Browser"
     :icon "icons/32/Icons_S_14_linkarrow.png"
-    :command :show-in-asset-browser}
-   {:label "Show in Desktop"
+    :command :file.show-in-assets}
+   {:label "Open in Desktop"
     :icon "icons/32/Icons_S_14_linkarrow.png"
-    :command :show-in-desktop}
+    :command :file.open-in-desktop}
    {:label "Referencing Files..."
-    :command :referencing-files}
+    :command :file.show-references}
    {:label "Dependencies..."
-    :command :dependencies}
+    :command :file.show-dependencies}
    {:label "Show Overrides"
-    :command :show-overrides}])
+    :command :window.show-overrides}])
 
 (defrecord SelectionProvider [app-view]
   handler/SelectionProvider
@@ -1852,10 +1816,8 @@ If you do not specifically require different script states, consider changing th
       (.setTitle stage new-title))))
 
 (defn- refresh-menus-and-toolbars! [app-view ^Scene scene]
-  (let [keymap (g/node-value app-view :keymap)
-        command->shortcut (keymap/command->shortcut keymap)]
-    (ui/user-data! scene :command->shortcut command->shortcut)
-    (ui/refresh scene)))
+  (ui/user-data! scene :keymap (g/node-value app-view :keymap))
+  (ui/refresh scene))
 
 (defn- refresh-views! [app-view]
   (let [auto-pulls (g/node-value app-view :auto-pulls)]
@@ -1944,38 +1906,13 @@ If you do not specifically require different script states, consider changing th
         (g/set-property! app-view :active-tab-pane new-editor-tab-pane)
         (on-selected-tab-changed! app-view app-scene selected-tab resource-node view-type)))))
 
-(defn open-custom-keymap
-  [path]
-  (try (and (not= path "")
-            (some-> path
-                    slurp
-                    edn/read-string))
-       (catch Exception e
-         (dialogs/make-info-dialog
-          {:title "Couldn't load custom keymap config"
-           :icon :icon/triangle-error
-           :header {:fx/type fx.v-box/lifecycle
-                    :children [{:fx/type fxui/legacy-label
-                                :text (str "The keymap from " path " couldn't be opened.")}]}
-           :content (.getMessage e)})
-         (log/error :exception e)
-         nil)))
-
-(defn- merge-keymaps [prefs]
-  (let [custom-keymap (or (open-custom-keymap (prefs/get prefs [:input :keymap-path])) [])
-        default-keymap keymap/default-host-key-bindings]
-    (into []
-      (mapcat val)
-      (conj (group-by first default-keymap)
-            (group-by first custom-keymap)))))
-
 (defn make-app-view [view-graph project ^Stage stage ^MenuBar menu-bar ^SplitPane editor-tabs-split ^TabPane tool-tab-pane prefs]
   (let [app-scene (.getScene stage)]
     (ui/disable-menu-alt-key-mnemonic! menu-bar)
     (.setUseSystemMenuBar menu-bar true)
     (.setTitle stage (make-title))
     (let [editor-tab-pane (TabPane.)
-          keymap (merge-keymaps prefs)
+          keymap (keymap/from-prefs prefs)
           app-view (first (g/tx-nodes-added (g/transact (g/make-node view-graph AppView
                                                                      :stage stage
                                                                      :scene app-scene
@@ -1984,7 +1921,7 @@ If you do not specifically require different script states, consider changing th
                                                                      :tool-tab-pane tool-tab-pane
                                                                      :active-tool :move
                                                                      :manip-space :world
-                                                                     :keymap-config keymap))))]
+                                                                     :keymap keymap))))]
       (.add (.getItems editor-tabs-split) editor-tab-pane)
       (configure-editor-tab-pane! editor-tab-pane app-scene app-view)
       (ui/observe (.focusOwnerProperty app-scene)
@@ -1992,8 +1929,6 @@ If you do not specifically require different script states, consider changing th
                     (handle-focus-owner-change! app-view app-scene new-focus-owner)))
 
       (ui/register-menubar app-scene menu-bar ::menubar)
-
-      (keymap/install-key-bindings! (.getScene stage) (g/node-value app-view :keymap))
 
       (let [refresh-timer (ui/->timer
                             "refresh-app-view"
@@ -2184,14 +2119,14 @@ If you do not specifically require different script states, consider changing th
                                     :content (str "This can happen if the file type is not mapped to an application in your OS.\n\nUnderlying error from the OS:\n" msg)}))))
              false)))))))
 
-(handler/defhandler :open :global
-  (active? [selection user-data] (:resources user-data (not-empty (selection->openable-resources selection))))
-  (enabled? [selection user-data] (some resource/exists? (:resources user-data (selection->openable-resources selection))))
-  (run [selection app-view prefs workspace project user-data]
-       (doseq [resource (filter resource/exists? (:resources user-data (selection->openable-resources selection)))]
-         (open-resource app-view prefs workspace project resource))))
+(handler/defhandler :file.open-selected :global
+  (active? [selection] (not-empty (selection->openable-resources selection)))
+  (enabled? [selection] (some resource/exists? (selection->openable-resources selection)))
+  (run [selection app-view prefs workspace project]
+    (doseq [resource (filter resource/exists? (selection->openable-resources selection))]
+      (open-resource app-view prefs workspace project resource))))
 
-(handler/defhandler :open-as :global
+(handler/defhandler :file.open-as :global
   (active? [selection] (selection->single-openable-resource selection))
   (enabled? [selection user-data] (resource/exists? (selection->single-openable-resource selection)))
   (run [selection app-view prefs workspace project user-data]
@@ -2206,7 +2141,7 @@ If you do not specifically require different script states, consider changing th
                    make-option
                    (fn make-option [label user-data]
                      {:label label
-                      :command :open-as
+                      :command :file.open-as
                       :user-data user-data})
 
                    view-type->option
@@ -2228,34 +2163,34 @@ If you do not specifically require different script states, consider changing th
                        (map view-type->option))
                      (:view-types resource-type))))))
 
-(handler/defhandler :recent-files :global
+(handler/defhandler :private/recent-files :global
   (enabled? [prefs workspace evaluation-context]
     (recent-files/exist? prefs workspace evaluation-context))
   (active? [] true)
   (options [prefs workspace app-view]
     (g/with-auto-evaluation-context evaluation-context
       (-> [{:label "Re-Open Closed File"
-            :command :reopen-recent-file}]
+            :command :file.reopen-recent}]
           (cond-> (recent-files/exist? prefs workspace evaluation-context)
                   (->
                     (conj {:label :separator})
                     (into
                       (map (fn [[resource view-type :as resource+view-type]]
                              {:label (string/replace (str (resource/proj-path resource) " • " (:label view-type) " view") #"_" "__")
-                              :command :open-selected-recent-file
+                              :command :private/open-selected-recent-file
                               :user-data resource+view-type}))
                       (recent-files/some-recent prefs workspace evaluation-context))
                     (conj {:label :separator})))
           (conj {:label "More..."
-                 :command :open-recent-file})))))
+                 :command :file.open-recent})))))
 
-(handler/defhandler :open-selected-recent-file :global
+(handler/defhandler :private/open-selected-recent-file :global
   (run [prefs app-view workspace project user-data]
     (let [[resource view-type] user-data]
       (open-resource app-view prefs workspace project resource {:selected-view-type view-type
                                                                 :use-custom-editor false}))))
 
-(handler/defhandler :open-recent-file :global
+(handler/defhandler :file.open-recent :global
   (active? [prefs workspace evaluation-context]
     (recent-files/exist? prefs workspace evaluation-context))
   (run [prefs app-view workspace project]
@@ -2264,7 +2199,7 @@ If you do not specifically require different script states, consider changing th
         (open-resource app-view prefs workspace project resource {:selected-view-type view-type
                                                                   :use-custom-editor false})))))
 
-(handler/defhandler :reopen-recent-file :global
+(handler/defhandler :file.reopen-recent :global
   (enabled? [prefs workspace evaluation-context app-view]
     (recent-files/exist-closed? prefs workspace app-view evaluation-context))
   (run [prefs app-view workspace project]
@@ -2313,12 +2248,12 @@ If you do not specifically require different script states, consider changing th
                {:fx/type fx.text/lifecycle
                 :text "."}]}))
 
-(handler/defhandler :save-all :global
+(handler/defhandler :file.save-all :global
   (enabled? [] (not (bob/build-in-progress?)))
   (run [app-view changes-view project]
        (async-save! app-view changes-view project project/dirty-save-data)))
 
-(handler/defhandler :save-and-upgrade-all :global
+(handler/defhandler :file.save-and-upgrade-all :global
   (enabled? [] (not (bob/build-in-progress?)))
   (run [app-view changes-view project workspace]
        (let [git (g/node-value changes-view :git)]
@@ -2403,12 +2338,12 @@ If you do not specifically require different script states, consider changing th
                (project/clear-cached-save-data! project)
                (async-save! app-view changes-view project save-data-fn)))))))
 
-(handler/defhandler :async-reload :global
+(handler/defhandler :project.load-external-changes :global
   (active? [prefs] (not (async-reload-on-app-focus? prefs)))
   (enabled? [] (can-async-reload?))
   (run [app-view changes-view workspace] (async-reload! app-view changes-view workspace [])))
 
-(handler/defhandler :show-in-desktop :global
+(handler/defhandler :file.open-in-desktop :global
   (active? [app-view selection evaluation-context]
            (context-resource app-view selection evaluation-context))
   (enabled? [app-view selection evaluation-context]
@@ -2420,7 +2355,7 @@ If you do not specifically require different script states, consider changing th
                               (let [f (File. (resource/abs-path r))]
                                 (ui/open-file (fs/to-folder f))))))
 
-(handler/defhandler :referencing-files :global
+(handler/defhandler :file.show-references :global
   (active? [app-view selection evaluation-context]
            (context-openable-resource app-view selection evaluation-context))
   (enabled? [app-view selection evaluation-context]
@@ -2433,7 +2368,7 @@ If you do not specifically require different script states, consider changing th
            (run! #(open-resource app-view prefs workspace project %)
                  (e/filter resource/openable-resource? selected-resources))))))
 
-(handler/defhandler :dependencies :global
+(handler/defhandler :file.show-dependencies :global
   (active? [app-view selection evaluation-context]
            (context-openable-resource app-view selection evaluation-context))
   (enabled? [app-view selection evaluation-context]
@@ -2469,7 +2404,7 @@ If you do not specifically require different script states, consider changing th
         (when (contains? (:tags (resource/resource-type resource)) :overridable-properties)
           (project/get-resource-node project resource evaluation-context)))))
 
-(handler/defhandler :show-overrides :global
+(handler/defhandler :window.show-overrides :global
   (enabled? [selection project evaluation-context]
     (let [node-id (select-possibly-overridable-resource-node selection project evaluation-context)]
       (and node-id (pos? (count (g/overrides (:basis evaluation-context) node-id))))))
@@ -2481,38 +2416,38 @@ If you do not specifically require different script states, consider changing th
         (select-possibly-overridable-resource-node selection project evaluation-context))
       :all)))
 
-(handler/defhandler :toggle-pane-left :global
+(handler/defhandler :window.toggle-left-pane :global
   (run [^Stage main-stage]
        (let [main-scene (.getScene main-stage)]
          (set-pane-visible! main-scene :left (not (pane-visible? main-scene :left))))))
 
-(handler/defhandler :toggle-pane-right :global
+(handler/defhandler :window.toggle-right-pane :global
   (run [^Stage main-stage]
        (let [main-scene (.getScene main-stage)]
          (set-pane-visible! main-scene :right (not (pane-visible? main-scene :right))))))
 
-(handler/defhandler :toggle-pane-bottom :global
+(handler/defhandler :window.toggle-bottom-pane :global
   (run [^Stage main-stage]
        (let [main-scene (.getScene main-stage)]
          (set-pane-visible! main-scene :bottom (not (pane-visible? main-scene :bottom))))))
 
-(handler/defhandler :toggle-pane-changed-files :global
+(handler/defhandler :window.toggle-changed-files-pane :global
   (enabled? [^Stage main-stage]
             (pane-visible? (.getScene main-stage) :left))
   (run [^Stage main-stage]
        (let [main-scene (.getScene main-stage)]
          (set-pane-visible! main-scene :changed-files (not (pane-visible? main-scene :changed-files))))))
 
-(handler/defhandler :show-console :global
+(handler/defhandler :window.show-console :global
   (run [^Stage main-stage tool-tab-pane] (show-console! (.getScene main-stage) tool-tab-pane)))
 
-(handler/defhandler :show-curve-editor :global
+(handler/defhandler :window.show-curve-editor :global
   (run [^Stage main-stage tool-tab-pane] (show-curve-editor! (.getScene main-stage) tool-tab-pane)))
 
-(handler/defhandler :show-build-errors :global
+(handler/defhandler :window.show-build-errors :global
   (run [^Stage main-stage tool-tab-pane] (show-build-errors! (.getScene main-stage) tool-tab-pane)))
 
-(handler/defhandler :show-search-results :global
+(handler/defhandler :window.show-search-results :global
   (run [^Stage main-stage tool-tab-pane] (show-search-results! (.getScene main-stage) tool-tab-pane)))
 
 (defn- put-on-clipboard!
@@ -2521,7 +2456,7 @@ If you do not specifically require different script states, consider changing th
     (.setContent (doto (ClipboardContent.)
                    (.putString s)))))
 
-(handler/defhandler :copy-project-path :global
+(handler/defhandler :edit.copy-resource-path :global
   (active? [app-view selection evaluation-context]
            (context-resource app-view selection evaluation-context))
   (enabled? [app-view selection evaluation-context]
@@ -2532,7 +2467,7 @@ If you do not specifically require different script states, consider changing th
     (when-let [r (context-resource app-view selection)]
       (put-on-clipboard! (resource/proj-path r)))))
 
-(handler/defhandler :copy-full-path :global
+(handler/defhandler :edit.copy-absolute-path :global
   (active? [app-view selection evaluation-context]
            (context-resource app-view selection evaluation-context))
   (enabled? [app-view selection evaluation-context]
@@ -2543,7 +2478,7 @@ If you do not specifically require different script states, consider changing th
     (when-let [r (context-resource app-view selection)]
       (put-on-clipboard! (resource/abs-path r)))))
 
-(handler/defhandler :copy-require-path :global
+(handler/defhandler :edit.copy-require-path :global
   (active? [app-view selection evaluation-context]
            (when-let [r (context-resource app-view selection evaluation-context)]
              (= "lua" (resource/type-ext r))))
@@ -2602,19 +2537,42 @@ If you do not specifically require different script states, consider changing th
     (doseq [resource selected-resources]
       (open-resource app-view prefs workspace project resource))))
 
-(handler/defhandler :select-items :global
+(handler/defhandler :private/select-items :global
   (run [user-data] (dialogs/make-select-list-dialog (:items user-data) (:options user-data))))
 
 (defn- get-view-text-selection [{:keys [view-id view-type]}]
   (when-let [text-selection-fn (:text-selection-fn view-type)]
     (text-selection-fn view-id)))
 
-(handler/defhandler :open-asset :global
-  (run [workspace project app-view prefs]
-    (let [term (get-view-text-selection (g/node-value app-view :active-view-info))]
-      (query-and-open! workspace project app-view prefs term))))
+(defn file-open-user-data->openable-resources
+  ([workspace x]
+   (g/with-auto-evaluation-context evaluation-context
+     (file-open-user-data->openable-resources workspace x evaluation-context)))
+  ([workspace x evaluation-context]
+   (cond
+     (string? x)
+     (when-let [resource (workspace/find-resource workspace x evaluation-context)]
+       (recur workspace resource evaluation-context))
 
-(handler/defhandler :search-in-files :global
+     (resource/resource? x)
+     (when (and (resource/openable? x)
+                (resource/exists? x))
+       [x])
+
+     (sequential? x)
+     (e/mapcat #(file-open-user-data->openable-resources workspace % evaluation-context) x)
+
+     :else
+     (throw (IllegalArgumentException. (str "Didn't expect file.open argument to be " x))))))
+
+(handler/defhandler :file.open :global
+  (run [workspace project app-view prefs user-data]
+    (if user-data
+      (run! #(open-resource app-view prefs workspace project %) (file-open-user-data->openable-resources workspace user-data))
+      (let [term (get-view-text-selection (g/node-value app-view :active-view-info))]
+        (query-and-open! workspace project app-view prefs term)))))
+
+(handler/defhandler :file.search :global
   (run [project app-view prefs search-results-view main-stage tool-tab-pane]
     (when-let [term (get-view-text-selection (g/node-value app-view :active-view-info))]
       (search-results-view/set-search-term! prefs term))
@@ -2622,7 +2580,7 @@ If you do not specifically require different script states, consider changing th
           show-search-results-tab! (partial show-search-results! main-scene tool-tab-pane)]
       (search-results-view/show-search-in-files-dialog! search-results-view project prefs show-search-results-tab!))))
 
-(handler/defhandler :bundle :global
+(handler/defhandler :project.bundle :global
   (options [user-data _context]
     (when-not user-data
       (let [contexts [_context]]
@@ -2631,7 +2589,7 @@ If you do not specifically require different script states, consider changing th
                 (fn [{:keys [command]}]
                   (when command
                     (when-let [handler+context (handler/active command contexts true)]
-                      {:command :bundle
+                      {:command :project.bundle
                        :label (handler/label handler+context)
                        :user-data {:command command
                                    :handler+context handler+context}}))))
@@ -2642,7 +2600,7 @@ If you do not specifically require different script states, consider changing th
       (when (handler/enabled? handler+context)
         (handler/run handler+context)))))
 
-(handler/defhandler :rebundle :global
+(handler/defhandler :project.rebundle :global
   (enabled? [evaluation-context prefs]
     (keyword? (prefs/get prefs [:bundle :last-bundle-command])))
   (run [prefs _context]
@@ -2751,7 +2709,7 @@ If you do not specifically require different script states, consider changing th
                                         (when success
                                           (reload-extensions! app-view project :library workspace changes-view build-errors-view prefs web-server)))))))))))))
 
-(handler/defhandler :add-dependency :global
+(handler/defhandler :private/add-dependency :global
   (enabled? [] (disk-availability/available?))
   (run [selection app-view workspace project changes-view user-data build-errors-view prefs web-server]
     (let [game-project (project/get-resource-node project "/game.project")
@@ -2762,12 +2720,12 @@ If you do not specifically require different script states, consider changing th
                                    (conj (vec dependencies) dependency-uri))
         (fetch-libraries app-view workspace project changes-view build-errors-view prefs web-server)))))
 
-(handler/defhandler :fetch-libraries :global
+(handler/defhandler :project.fetch-libraries :global
   (enabled? [] (disk-availability/available?))
   (run [app-view workspace project changes-view build-errors-view prefs web-server]
     (fetch-libraries app-view workspace project changes-view build-errors-view prefs web-server)))
 
-(handler/defhandler :reload-extensions :global
+(handler/defhandler :project.reload-editor-scripts :global
   (enabled? [] (disk-availability/available?))
   (run [app-view project workspace changes-view build-errors-view prefs web-server]
     (reload-extensions! app-view project :all workspace changes-view build-errors-view prefs web-server)))
@@ -2785,13 +2743,13 @@ If you do not specifically require different script states, consider changing th
                                 (when-some [created-resource (workspace/find-resource workspace proj-path)]
                                   (open-resource app-view prefs workspace project created-resource)))))))))
 
-(handler/defhandler :live-update-settings :global
+(handler/defhandler :file.open-liveupdate-settings :global
   (enabled? [] (disk-availability/available?))
   (run [app-view changes-view prefs workspace project]
        (let [live-update-settings-proj-path (live-update-settings/get-live-update-settings-path project)]
          (ensure-exists-and-open-for-editing! live-update-settings-proj-path app-view changes-view prefs project))))
 
-(handler/defhandler :shared-editor-settings :global
+(handler/defhandler :file.open-shared-editor-settings :global
   (enabled? [] (disk-availability/available?))
   (run [app-view changes-view prefs workspace project]
        (ensure-exists-and-open-for-editing! shared-editor-settings/project-shared-editor-settings-proj-path app-view changes-view prefs project)))
@@ -2815,7 +2773,7 @@ If you do not specifically require different script states, consider changing th
         (process/exec! "which" "xdg-desktop-menu")
         (catch Throwable _)))))
 
-(handler/defhandler :create-desktop-entry :global
+(handler/defhandler :file.create-desktop-entry :global
   (active? [] (some? @xdg-desktop-menu-path))
   (enabled? [] (and (system/defold-resourcespath) (system/defold-launcherpath)))
   (run []

--- a/editor/src/clj/editor/asset_browser.clj
+++ b/editor/src/clj/editor/asset_browser.clj
@@ -99,19 +99,19 @@
    {:label "Copy Require Path"
     :command :edit.copy-require-path}
    {:label :separator}
-   {:label "Open in Desktop"
+   {:label "Show in Desktop"
     :icon "icons/32/Icons_S_14_linkarrow.png"
-    :command :file.open-in-desktop}
+    :command :file.show-in-desktop}
    {:label "Referencing Files..."
     :command :file.show-references}
    {:label "Dependencies..."
     :command :file.show-dependencies}
    {:label "Show Overrides"
-    :command :window.show-overrides}
+    :command :edit.show-overrides}
    {:label :separator}
    {:label "New"
     :command :file.new
-    :expand? true
+    :expand true
     :icon "icons/64/Icons_29-AT-Unknown.png"}
    {:label "New File"
     :command :file.new

--- a/editor/src/clj/editor/atlas.clj
+++ b/editor/src/clj/editor/atlas.clj
@@ -1013,7 +1013,7 @@
                                (make-atlas-animation atlas-node default-animation))))]
     (select! app-view [animation-node] op-seq)))
 
-(handler/defhandler :add :workbench
+(handler/defhandler :edit.add-embedded-component :workbench
   (label [] "Add Animation Group")
   (active? [selection] (selection->atlas selection))
   (run [app-view selection] (add-animation-group-handler app-view (selection->atlas selection))))
@@ -1044,7 +1044,7 @@
                                                 {:parent-node-type parent-node-type})))))))]
       (select! app-view image-nodes op-seq))))
 
-(handler/defhandler :add-from-file :workbench
+(handler/defhandler :edit.add-referenced-component :workbench
   (label [] "Add Images...")
   (active? [selection] (or (selection->atlas selection) (selection->animation selection)))
   (run [app-view project selection]
@@ -1088,7 +1088,7 @@
     core/scope
     (g/node-instance? AtlasAnimation)))
 
-(handler/defhandler :move-up :workbench
+(handler/defhandler :edit.reorder-up :workbench
   (active? [selection] (move-active? selection))
   (enabled? [selection] (let [node-id (selection->image selection)
                               parent (core/scope node-id)
@@ -1097,7 +1097,7 @@
                           (pos? node-child-index)))
   (run [selection] (move-node! (selection->image selection) -1)))
 
-(handler/defhandler :move-down :workbench
+(handler/defhandler :edit.reorder-down :workbench
   (active? [selection] (move-active? selection))
   (enabled? [selection] (let [node-id (selection->image selection)
                               parent (core/scope node-id)

--- a/editor/src/clj/editor/boot.clj
+++ b/editor/src/clj/editor/boot.clj
@@ -21,6 +21,7 @@
             [editor.dialogs :as dialogs]
             [editor.error-reporting :as error-reporting]
             [editor.gl :as gl]
+            [editor.keymap :as keymap]
             [editor.prefs :as prefs]
             [editor.progress :as progress]
             [editor.system :as system]
@@ -126,9 +127,11 @@
 
   (let [args (Arrays/asList args)
         opts (cli/parse-opts args cli-options)
-        prefs (if-let [prefs-path (get-in opts [:options :preferences])]
-                (prefs/global prefs-path)
-                (doto (prefs/global) prefs/migrate-global-prefs!))
+        prefs (doto
+                (if-let [prefs-path (get-in opts [:options :preferences])]
+                  (prefs/global prefs-path)
+                  (doto (prefs/global) prefs/migrate-global-prefs!))
+                keymap/migrate-from-file!)
         updater (updater/start!)
         analytics-url (get connection-properties :analytics-url)
         analytics-send-interval 300]

--- a/editor/src/clj/editor/boot_open_project.clj
+++ b/editor/src/clj/editor/boot_open_project.clj
@@ -51,7 +51,6 @@
             [editor.targets :as targets]
             [editor.ui :as ui]
             [editor.ui.updater :as ui.updater]
-            [editor.web-profiler :as web-profiler]
             [editor.web-server :as web-server]
             [editor.workspace :as workspace]
             [service.log :as log]
@@ -206,7 +205,6 @@
                          (into []
                                cat
                                [(engine-profiler/routes)
-                                (web-profiler/routes)
                                 (console/routes console-view)
                                 (hot-reload/routes workspace)
                                 (bob/routes project)

--- a/editor/src/clj/editor/build_errors_view.clj
+++ b/editor/src/clj/editor/build_errors_view.clj
@@ -255,7 +255,7 @@
                       (error-line-for-clipboard selection))]
     (str proj-path error-lines)))
 
-(handler/defhandler :copy :build-errors-view
+(handler/defhandler :edit.copy :build-errors-view
   (active? [selection] (not-empty selection))
   (enabled? [selection] (not-empty selection))
   (run [build-errors-view]
@@ -268,7 +268,7 @@
 
 (handler/register-menu! ::build-errors-menu
   [{:label "Copy"
-    :command :copy}])
+    :command :edit.copy}])
 
 (defn make-build-errors-view [^TreeView errors-tree open-resource-fn]
   (doto errors-tree

--- a/editor/src/clj/editor/changes_view.clj
+++ b/editor/src/clj/editor/changes_view.clj
@@ -67,43 +67,43 @@
 (handler/register-menu! ::changes-menu
   [{:label "Open"
     :icon "icons/32/Icons_S_14_linkarrow.png"
-    :command :open}
+    :command :file.open-selected}
    {:label "Open As"
     :icon "icons/32/Icons_S_14_linkarrow.png"
-    :command :open-as}
+    :command :file.open-as}
    {:label :separator}
-   {:label "Copy Project Path"
-    :command :copy-project-path}
+   {:label "Copy Resource Path"
+    :command :edit.copy-resource-path}
    {:label "Copy Full Path"
-    :command :copy-full-path}
+    :command :edit.copy-absolute-path}
    {:label "Copy Require Path"
-    :command :copy-require-path}
+    :command :edit.copy-require-path}
    {:label :separator}
    {:label "Show in Asset Browser"
     :icon "icons/32/Icons_S_14_linkarrow.png"
-    :command :show-in-asset-browser}
-   {:label "Show in Desktop"
+    :command :file.show-in-assets}
+   {:label "Open in Desktop"
     :icon "icons/32/Icons_S_14_linkarrow.png"
-    :command :show-in-desktop}
+    :command :file.open-in-desktop}
    {:label "Referencing Files..."
-    :command :referencing-files}
+    :command :file.show-references}
    {:label "Dependencies..."
-    :command :dependencies}
+    :command :file.show-dependencies}
    {:label "Show Overrides"
-    :command :show-overrides}
+    :command :window.show-overrides}
    {:label :separator}
    {:label "View Diff"
     :icon "icons/32/Icons_S_06_arrowup.png"
-    :command :diff}
+    :command :vcs.diff}
    {:label "Revert"
     :icon "icons/32/Icons_S_02_Reset.png"
-    :command :revert}])
+    :command :vcs.revert}])
 
 (defn- path->file
   ^File [workspace ^String path]
   (File. (workspace/project-directory workspace) path))
 
-(handler/defhandler :revert :changes-view
+(handler/defhandler :vcs.revert :changes-view
   (enabled? [selection]
             (and (disk-availability/available?)
                  (pos? (count selection))))
@@ -124,7 +124,7 @@
         (git/revert git (mapv (fn [status] (or (:new-path status) (:old-path status))) selection))
         (async-reload! changes-view moved-files)))))
 
-(handler/defhandler :diff :changes-view
+(handler/defhandler :vcs.diff :changes-view
   (enabled? [selection]
             (git/selection-diffable? selection))
   (run [selection ^Git git]
@@ -169,12 +169,13 @@
                  {resource/Resource (fn [status] (status->resource workspace status))})
     (ui/register-context-menu list-view ::changes-menu)
     (ui/cell-factory! list-view vcs-status/render)
-    (ui/bind-action! diff-button :diff)
-    (ui/bind-action! revert-button :revert)
+    (ui/bind-action! diff-button :vcs.diff)
+    (ui/bind-action! revert-button :vcs.revert)
     (ui/disable! diff-button true)
     (ui/disable! revert-button true)
     (ui/visible! progress-overlay false)
-    (ui/bind-double-click! list-view :open)
+    (ui/bind-double-click! list-view :file.open-selected)
+    (ui/bind-key-commands! list-view {"Enter" :file.open-selected})
     ; TODO: try/catch to protect against project without git setup
     ; Show warning/error etc?
     (try

--- a/editor/src/clj/editor/changes_view.clj
+++ b/editor/src/clj/editor/changes_view.clj
@@ -82,15 +82,15 @@
    {:label "Show in Asset Browser"
     :icon "icons/32/Icons_S_14_linkarrow.png"
     :command :file.show-in-assets}
-   {:label "Open in Desktop"
+   {:label "Show in Desktop"
     :icon "icons/32/Icons_S_14_linkarrow.png"
-    :command :file.open-in-desktop}
+    :command :file.show-in-desktop}
    {:label "Referencing Files..."
     :command :file.show-references}
    {:label "Dependencies..."
     :command :file.show-dependencies}
    {:label "Show Overrides"
-    :command :window.show-overrides}
+    :command :edit.show-overrides}
    {:label :separator}
    {:label "View Diff"
     :icon "icons/32/Icons_S_06_arrowup.png"

--- a/editor/src/clj/editor/cljfx_form_view.clj
+++ b/editor/src/clj/editor/cljfx_form_view.clj
@@ -52,12 +52,12 @@
             [editor.system :as system]
             [editor.ui :as ui]
             [editor.url :as url]
-            [editor.util :as eutil]
             [editor.view :as view]
             [editor.workspace :as workspace]
             [internal.util :as util]
             [util.coll :as coll]
-            [util.fn :as fn])
+            [util.fn :as fn]
+            [util.text-util :as text-util])
   (:import [com.defold.control DefoldStringConverter]
            [java.io File]
            [javafx.event Event]
@@ -1394,8 +1394,8 @@
 (defn- set-field-visibility [field values filter-term section-visible]
   (let [value (get values (:path field) ::no-value)
         visible (and (or section-visible
-                         (eutil/includes-ignore-case? (:label field) filter-term)
-                         (boolean (some #(eutil/includes-ignore-case? % filter-term)
+                         (text-util/includes-ignore-case? (:label field) filter-term)
+                         (boolean (some #(text-util/includes-ignore-case? % filter-term)
                                         (filterable-strings
                                           (assoc field :value (if (= value ::no-value)
                                                                 (form/field-default field)
@@ -1408,9 +1408,9 @@
     (assoc field :visible visible)))
 
 (defn- set-section-visibility [{:keys [title help fields] :as section} values filter-term]
-  (let [visible (or (eutil/includes-ignore-case? title filter-term)
+  (let [visible (or (text-util/includes-ignore-case? title filter-term)
                     (and (some? help)
-                         (eutil/includes-ignore-case? help filter-term)))
+                         (text-util/includes-ignore-case? help filter-term)))
         fields (into []
                      (comp
                        (remove :hidden?)

--- a/editor/src/clj/editor/cljfx_form_view.clj
+++ b/editor/src/clj/editor/cljfx_form_view.clj
@@ -52,6 +52,7 @@
             [editor.system :as system]
             [editor.ui :as ui]
             [editor.url :as url]
+            [editor.util :as eutil]
             [editor.view :as view]
             [editor.workspace :as workspace]
             [internal.util :as util]
@@ -137,17 +138,6 @@
     #(some->> (when-not (string/blank? %) %)
               (workspace/to-absolute-path)
               (workspace/resolve-workspace-resource workspace))))
-
-(defn- contains-ignore-case? [^String str ^String sub]
-  (let [sub-length (.length sub)]
-    (if (zero? sub-length)
-      true
-      (let [str-length (.length str)]
-        (loop [i 0]
-          (cond
-            (= i str-length) false
-            (.regionMatches str true i sub 0 sub-length) true
-            :else (recur (inc i))))))))
 
 (defn- text-field [props]
   (assoc props :fx/type fx.text-field/lifecycle
@@ -1404,8 +1394,8 @@
 (defn- set-field-visibility [field values filter-term section-visible]
   (let [value (get values (:path field) ::no-value)
         visible (and (or section-visible
-                         (contains-ignore-case? (:label field) filter-term)
-                         (boolean (some #(contains-ignore-case? % filter-term)
+                         (eutil/includes-ignore-case? (:label field) filter-term)
+                         (boolean (some #(eutil/includes-ignore-case? % filter-term)
                                         (filterable-strings
                                           (assoc field :value (if (= value ::no-value)
                                                                 (form/field-default field)
@@ -1418,9 +1408,9 @@
     (assoc field :visible visible)))
 
 (defn- set-section-visibility [{:keys [title help fields] :as section} values filter-term]
-  (let [visible (or (contains-ignore-case? title filter-term)
+  (let [visible (or (eutil/includes-ignore-case? title filter-term)
                     (and (some? help)
-                         (contains-ignore-case? help filter-term)))
+                         (eutil/includes-ignore-case? help filter-term)))
         fields (into []
                      (comp
                        (remove :hidden?)
@@ -1661,7 +1651,7 @@
                                        (instance? ListView x)
                                        (.edit ^ListView x -1)))
                       :open-resource (fn [[node value] _]
-                                       (ui/run-command node :open {:resources [value]}))
+                                       (ui/run-command node :file.open value))
                       :show-dialog (fn [dialog-type _]
                                      (case dialog-type
                                        :directory-not-in-project
@@ -1713,7 +1703,7 @@
                                 :label "Form"
                                 :make-view-fn make-form-view))
 
-(handler/defhandler :filter-form :form
+(handler/defhandler :edit.find :form
   (run [^Node root]
        (when-let [node (.lookup root "#filter-text-field")]
          (.requestFocus node))))

--- a/editor/src/clj/editor/code/view.clj
+++ b/editor/src/clj/editor/code/view.clj
@@ -3166,7 +3166,7 @@
    {:label :separator}
    {:command :code.toggle-comment :label "Toggle Comment"}
    {:command :code.reindent :label "Reindent Lines"}
-   {:command :code.convert-indentation :expand? true}
+   {:command :code.convert-indentation :expand true}
    {:label :separator}
    {:command :code.sort-lines :user-data :case-insensitive}
    {:command :code.sort-lines :user-data :case-sensitive}

--- a/editor/src/clj/editor/code/view.clj
+++ b/editor/src/clj/editor/code/view.clj
@@ -20,6 +20,7 @@
             [cljfx.fx.label :as fx.label]
             [cljfx.fx.list-cell :as fx.list-cell]
             [cljfx.fx.list-view :as fx.list-view]
+            [cljfx.fx.popup :as fx.popup]
             [cljfx.fx.region :as fx.region]
             [cljfx.fx.stack-pane :as fx.stack-pane]
             [cljfx.fx.svg-path :as fx.svg-path]
@@ -33,7 +34,7 @@
             [editor.code-completion :as code-completion]
             [editor.code.data :as data]
             [editor.code.resource :as r]
-            [editor.code.util :refer [find-insert-index split-lines]]
+            [editor.code.util :refer [split-lines]]
             [editor.error-reporting :as error-reporting]
             [editor.fxui :as fxui]
             [editor.graph-util :as gu]
@@ -1095,7 +1096,6 @@
 
   (property completions-showing g/Bool (default false) (dynamic visible (g/constantly false)))
   (property completions-doc g/Bool (default false) (dynamic visible (g/constantly false)))
-  (property completions-shortcut-text g/Any (dynamic visible (g/constantly false)))
   (property completions-insert-cursor g/Any (dynamic visible (g/constantly false)))
   (property completions-built-in g/Any (default []) (dynamic visible (g/constantly false)))
   (property completions-lsp g/Any)
@@ -1145,6 +1145,10 @@
   (output completions-combined g/Any :cached produce-completions-combined)
   (output completions-combined-ids g/Any :cached produce-completions-combined-ids)
   (input project g/NodeID) ;; used for completions doc popup, e.g. for opening defold:// URIs
+
+  (input keymap g/Any)
+  (output completions-shortcut-text g/Any :cached (g/fnk [keymap]
+                                                    (keymap/display-text keymap :code.show-completions nil)))
 
   (property font-name g/Str (default "Dejavu Sans Mono")
             (set (fn [evaluation-context self _old-value _new-value]
@@ -1994,17 +1998,19 @@
          {:fx/type fx/ext-many
           :desc
           (cond->
-            [{:fx/type fxui/with-popup
+            [{:fx/type fxui/with-popup-window
               :desc {:fx/type fxui/ext-value :value canvas}
-              :anchor-x (- (.getX anchor) 12.0)
-              :anchor-y (- (.getY anchor) 4.0)
-              :anchor-location :window-top-left
-              :showing completions-showing
-              :auto-fix false
-              :auto-hide true
-              :on-auto-hide {:event :auto-hide}
-              :hide-on-escape false
-              :content [{:fx/type fx/ext-get-ref :ref :content}]}]
+              :popup
+              {:fx/type fx.popup/lifecycle
+               :anchor-x (- (.getX anchor) 12.0)
+               :anchor-y (- (.getY anchor) 4.0)
+               :anchor-location :window-top-left
+               :showing completions-showing
+               :auto-fix false
+               :auto-hide true
+               :on-auto-hide {:event :auto-hide}
+               :hide-on-escape false
+               :content [{:fx/type fx/ext-get-ref :ref :content}]}}]
             completions-doc
             (conj
               (let [pref-doc-width 350.0
@@ -2031,36 +2037,38 @@
                                  (case (:type doc)
                                    :markdown (:value doc)
                                    :plaintext (format "<pre>%s</pre>" (:value doc))))]
-                {:fx/type fxui/with-popup
+                {:fx/type fxui/with-popup-window
                  :desc {:fx/type fx/ext-get-ref :ref :content}
-                 :anchor-x (let [x (- (.getX anchor) 12.0)]
-                             (if align-right
-                               (+ x completions-width spacing)
-                               (- x doc-width spacing)))
-                 :anchor-y (- (.getY anchor) 5.0)
-                 :anchor-location :window-top-left
-                 :showing true
-                 :auto-fix false
-                 :auto-hide false
-                 :hide-on-escape false
-                 :content [{:fx/type fx.stack-pane/lifecycle
-                            :stylesheets [(str (io/resource "editor.css"))]
-                            :children [{:fx/type fx.region/lifecycle
-                                        :style-class "flat-list-doc-background"}
-                                       (cond->
-                                         {:fx/type markdown/view
-                                          :base-url (:base-url doc)
-                                          :event-filter {:event :doc-event-filter}
-                                          :max-width doc-width
-                                          :max-height doc-max-height
-                                          :project project
-                                          :content (cond
-                                                     (and small-string doc-string) (str small-string "\n\n" doc-string)
-                                                     small-string small-string
-                                                     doc-string doc-string
-                                                     :else "<small>no documentation</small>")}
-                                         (not align-right)
-                                         (assoc :min-width doc-width))]}]})))}}))))
+                 :popup
+                 {:fx/type fx.popup/lifecycle
+                  :anchor-x (let [x (- (.getX anchor) 12.0)]
+                              (if align-right
+                                (+ x completions-width spacing)
+                                (- x doc-width spacing)))
+                  :anchor-y (- (.getY anchor) 5.0)
+                  :anchor-location :window-top-left
+                  :showing true
+                  :auto-fix false
+                  :auto-hide false
+                  :hide-on-escape false
+                  :content [{:fx/type fx.stack-pane/lifecycle
+                             :stylesheets [(str (io/resource "editor.css"))]
+                             :children [{:fx/type fx.region/lifecycle
+                                         :style-class "flat-list-doc-background"}
+                                        (cond->
+                                          {:fx/type markdown/view
+                                           :base-url (:base-url doc)
+                                           :event-filter {:event :doc-event-filter}
+                                           :max-width doc-width
+                                           :max-height doc-max-height
+                                           :project project
+                                           :content (cond
+                                                      (and small-string doc-string) (str small-string "\n\n" doc-string)
+                                                      small-string small-string
+                                                      doc-string doc-string
+                                                      :else "<small>no documentation</small>")}
+                                          (not align-right)
+                                          (assoc :min-width doc-width))]}]}})))}}))))
 
 (defn- handle-completion-popup-event [view-node e]
   (case (:event e)
@@ -2220,15 +2228,15 @@
     :else
     (deindent! view-node)))
 
-(handler/defhandler :tab :code-view
+(handler/defhandler :code.tab-forward :code-view
   (active? [editable] editable)
   (run [view-node] (tab! view-node)))
 
-(handler/defhandler :backwards-tab-trigger :code-view
+(handler/defhandler :code.tab-backward :code-view
   (active? [editable] editable)
   (run [view-node] (shift-tab! view-node)))
 
-(handler/defhandler :proposals :code-view
+(handler/defhandler :code.show-completions :code-view
   (active? [editable] editable)
   (run [view-node] (show-suggestions! view-node :explicit true)))
 
@@ -2316,16 +2324,10 @@
                   ::unhandled))
       (.consume event))))
 
-(defn- typable-key-event?
-  [^KeyEvent e]
-  (-> e
-      keymap/key-event->map
-      keymap/typable?))
-
 (defn handle-key-typed! [view-node ^KeyEvent event]
   (.consume event)
   (let [character (.getCharacter event)]
-    (when (and (typable-key-event? event)
+    (when (and (keymap/typable? event)
                ;; Ignore Alt+Space on macOS
                (not (and (os/is-mac-os?) (= " " character) (.isAltDown event)))
                ;; Ignore characters in the control range and the ASCII delete
@@ -2500,8 +2502,8 @@
   (when (if (.isShortcutDown event)
           (do (when zoom-on-scroll
                 (-> (g/node-value view-node :canvas)
-                    (ui/run-command (cond (pos? (.getDeltaY event)) :zoom-in
-                                          (neg? (.getDeltaY event)) :zoom-out))))
+                    (ui/run-command (cond (pos? (.getDeltaY event)) :code.zoom.increase
+                                          (neg? (.getDeltaY event)) :code.zoom.decrease))))
               true)
           (set-properties! view-node :navigation
                            (data/scroll (get-property view-node :lines)
@@ -2561,41 +2563,41 @@
                    (data/split-selection-into-lines (get-property view-node :lines)
                                                     (get-property view-node :cursor-ranges))))
 
-(handler/defhandler :cut :code-view
+(handler/defhandler :edit.cut :code-view
   (active? [editable] editable)
   (enabled? [view-node evaluation-context]
             (has-selection? view-node evaluation-context))
   (run [view-node clipboard] (cut! view-node clipboard)))
 
-(handler/defhandler :paste :code-view
+(handler/defhandler :edit.paste :code-view
   (active? [editable] editable)
   (enabled? [view-node clipboard evaluation-context]
             (can-paste? view-node clipboard evaluation-context))
   (run [view-node clipboard] (paste! view-node clipboard)))
 
-(handler/defhandler :delete :code-view
+(handler/defhandler :code.delete-next-char :code-view
   (active? [editable] editable)
   (run [view-node] (delete! view-node :delete-after)))
 
-(handler/defhandler :toggle-comment :code-view
+(handler/defhandler :code.toggle-comment :code-view
   (active? [editable view-node evaluation-context]
            (and editable
                 (contains? (get-property view-node :grammar evaluation-context) :line-comment)))
   (run [view-node] (toggle-comment! view-node)))
 
-(handler/defhandler :delete-backward :code-view
+(handler/defhandler :code.delete-previous-char :code-view
   (active? [editable] editable)
   (run [view-node] (delete! view-node :delete-before)))
 
-(handler/defhandler :delete-prev-word :code-view
+(handler/defhandler :code.delete-previous-word :code-view
   (active? [editable] editable)
   (run [view-node] (delete! view-node :delete-word-before)))
 
-(handler/defhandler :delete-next-word :code-view
+(handler/defhandler :code.delete-next-word :code-view
   (active? [editable] editable)
   (run [view-node] (delete! view-node :delete-word-after)))
 
-(handler/defhandler :toggle-breakpoint :code-view
+(handler/defhandler :debugger.toggle-breakpoint :code-view
   (run [view-node]
        (let [lines (get-property view-node :lines)
              cursor-ranges (get-property view-node :cursor-ranges)
@@ -2606,7 +2608,7 @@
                                                   regions
                                                   breakpoint-rows)))))
 
-(handler/defhandler :edit-breakpoint :code-view
+(handler/defhandler :debugger.edit-breakpoint :code-view
   (run [view-node]
     (let [lines (get-property view-node :lines)
           cursor-ranges (get-property view-node :cursor-ranges)
@@ -2616,7 +2618,7 @@
         nil
         (data/edit-breakpoint-from-single-cursor-range lines cursor-ranges regions)))))
 
-(handler/defhandler :reindent :code-view
+(handler/defhandler :code.reindent :code-view
   (active? [editable] editable)
   (enabled? [view-node evaluation-context]
             (not-every? data/cursor-range-empty?
@@ -2631,7 +2633,24 @@
                                        (get-property view-node :regions)
                                        (get-property view-node :layout)))))
 
-(handler/defhandler :convert-indentation :code-view
+(handler/defhandler :code.convert-indentation :code-view
+  (label [user-data]
+    (case user-data
+      :tabs "To Tabs"
+      :two-spaces "To Two Spaces"
+      :four-spaces "To Four Spaces"
+      nil "Convert Indentation"))
+  (options [user-data]
+    (when-not user-data
+      [{:label "To Tabs"
+        :command :code.convert-indentation
+        :user-data :tabs}
+       {:label "To Two Spaces"
+        :command :code.convert-indentation
+        :user-data :two-spaces}
+       {:label "To Four Spaces"
+        :command :code.convert-indentation
+        :user-data :four-spaces}]))
   (active? [editable] editable)
   (run [view-node user-data]
        (set-properties! view-node nil
@@ -2696,7 +2715,7 @@
        :actions [{:text "About LSP in Defold"
                   :on-action #(ui/open-url "https://forum.defold.com/t/linting-in-the-code-editor/72465")}]})))
 
-(handler/defhandler :goto-definition :code-view
+(handler/defhandler :code.goto-definition :code-view
   (enabled? [view-node evaluation-context]
     (let [resource-node (get-property view-node :resource-node evaluation-context)
           resource (g/node-value resource-node :resource evaluation-context)]
@@ -2720,7 +2739,7 @@
                 (show-goto-popup! view-node open-resource-fn results)))))
         (show-no-language-server-for-resource-language-notification! resource)))))
 
-(handler/defhandler :find-references :code-view
+(handler/defhandler :code.show-references :code-view
   (enabled? [view-node evaluation-context]
     (let [resource-node (get-property view-node :resource-node evaluation-context)
           resource (g/node-value resource-node :resource evaluation-context)]
@@ -2754,15 +2773,26 @@
                                     (get-property view-node :regions)
                                     sort-key-fn)))
 
-(handler/defhandler :sort-lines :code-view
+(handler/defhandler :code.sort-lines :code-view
+  (label [user-data]
+    (case user-data
+      :case-insensitive "Sort Lines"
+      :case-sensitive "Sort Lines (Case Sensitive)"
+      nil "Sort Lines"))
+  (options [user-data]
+    (when-not user-data
+      [{:label "Case Insensitive"
+        :command :code.sort-lines
+        :user-data :case-insensitive}
+       {:label "Case Sensitive"
+        :command :code.sort-lines
+        :user-data :case-sensitive}]))
   (active? [editable] editable)
   (enabled? [view-node evaluation-context] (can-sort-lines? view-node evaluation-context))
-  (run [view-node] (sort-lines! view-node string/lower-case)))
-
-(handler/defhandler :sort-lines-case-sensitive :code-view
-  (active? [editable] editable)
-  (enabled? [view-node evaluation-context] (can-sort-lines? view-node evaluation-context))
-  (run [view-node] (sort-lines! view-node identity)))
+  (run [view-node user-data]
+    (sort-lines! view-node (case user-data
+                             :case-insensitive string/lower-case
+                             :case-sensitive identity))))
 
 ;; -----------------------------------------------------------------------------
 ;; Properties shared among views
@@ -2813,28 +2843,28 @@
 ;; View Settings
 ;; -----------------------------------------------------------------------------
 
-(handler/defhandler :zoom-out :code-view-tools
+(handler/defhandler :code.zoom.decrease :code-view-tools
   (enabled? [] (<= 4.0 ^double (.getValue font-size-property)))
   (run [] (when (<= 4.0 ^double (.getValue font-size-property))
             (.setValue font-size-property (dec ^double (.getValue font-size-property))))))
 
-(handler/defhandler :zoom-in :code-view-tools
+(handler/defhandler :code.zoom.increase :code-view-tools
   (enabled? [] (>= 32.0 ^double (.getValue font-size-property)))
   (run [] (when (>= 32.0 ^double (.getValue font-size-property))
             (.setValue font-size-property (inc ^double (.getValue font-size-property))))))
 
-(handler/defhandler :reset-zoom :code-view-tools
+(handler/defhandler :code.zoom.reset :code-view-tools
   (run [] (.setValue font-size-property default-font-size)))
 
-(handler/defhandler :toggle-indentation-guides :code-view-tools
+(handler/defhandler :code.toggle-indentation-guides :code-view-tools
   (run [] (.setValue visible-indentation-guides-property (not (.getValue visible-indentation-guides-property))))
   (state [] (.getValue visible-indentation-guides-property)))
 
-(handler/defhandler :toggle-minimap :code-view-tools
+(handler/defhandler :code.toggle-minimap :code-view-tools
   (run [] (.setValue visible-minimap-property (not (.getValue visible-minimap-property))))
   (state [] (.getValue visible-minimap-property)))
 
-(handler/defhandler :toggle-visible-whitespace :code-view-tools
+(handler/defhandler :code.toggle-visible-whitespace :code-view-tools
   (run [] (.setValue visible-whitespace-property (not (.getValue visible-whitespace-property))))
   (state [] (.getValue visible-whitespace-property)))
 
@@ -2884,8 +2914,8 @@
 (defn- setup-goto-line-bar! [^GridPane goto-line-bar view-node]
   (b/bind-presence! goto-line-bar (b/= :goto-line bar-ui-type-property))
   (ui/with-controls goto-line-bar [^TextField line-field ^Button go-button]
-    (ui/bind-keys! goto-line-bar {KeyCode/ENTER :goto-entered-line})
-    (ui/bind-action! go-button :goto-entered-line)
+    (ui/bind-keys! goto-line-bar {KeyCode/ENTER :private/goto-entered-line})
+    (ui/bind-action! go-button :private/goto-entered-line)
     (ui/observe (.textProperty line-field)
                 (fn [_ _ line-field-text]
                   (ui/refresh-bound-action-enabled! go-button)
@@ -2904,14 +2934,14 @@
 (defn- dispose-goto-line-bar! [^GridPane goto-line-bar]
   (b/unbind! (.visibleProperty goto-line-bar)))
 
-(handler/defhandler :goto-line :code-view-tools
+(handler/defhandler :code.goto-line :code-view-tools
   (run [goto-line-bar]
        (set-bar-ui-type! :goto-line)
        (ui/with-controls goto-line-bar [^TextField line-field]
          (.requestFocus line-field)
          (.selectAll line-field))))
 
-(handler/defhandler :goto-entered-line :goto-line-bar
+(handler/defhandler :private/goto-entered-line :goto-line-bar
   (enabled? [goto-line-bar view-node evaluation-context]
             (some? (try-parse-goto-line-bar-row view-node goto-line-bar evaluation-context)))
   (run [goto-line-bar view-node]
@@ -2942,10 +2972,10 @@
     (b/bind-bidirectional! (.selectedProperty whole-word) find-whole-word-property)
     (b/bind-bidirectional! (.selectedProperty case-sensitive) find-case-sensitive-property)
     (b/bind-bidirectional! (.selectedProperty wrap) find-wrap-property)
-    (ui/bind-key-commands! find-bar {"Enter" :find-next
-                                     "Shift+Enter" :find-prev})
-    (ui/bind-action! next :find-next)
-    (ui/bind-action! prev :find-prev))
+    (ui/bind-key-commands! find-bar {"Enter" :code.find-next
+                                     "Shift+Enter" :code.find-previous})
+    (ui/bind-action! next :code.find-next)
+    (ui/bind-action! prev :code.find-previous))
   find-bar)
 
 (defn- dispose-find-bar! [^GridPane find-bar]
@@ -2968,10 +2998,10 @@
     (b/bind-bidirectional! (.selectedProperty whole-word) find-whole-word-property)
     (b/bind-bidirectional! (.selectedProperty case-sensitive) find-case-sensitive-property)
     (b/bind-bidirectional! (.selectedProperty wrap) find-wrap-property)
-    (ui/bind-action! next :find-next)
-    (ui/bind-action! replace :replace-next)
-    (ui/bind-keys! replace-bar {KeyCode/ENTER :replace-next})
-    (ui/bind-action! replace-all :replace-all))
+    (ui/bind-action! next :code.find-next)
+    (ui/bind-action! replace :code.replace-next)
+    (ui/bind-keys! replace-bar {KeyCode/ENTER :code.replace-next})
+    (ui/bind-action! replace-all :code.replace-all))
   replace-bar)
 
 (defn- dispose-replace-bar! [^GridPane replace-bar]
@@ -3048,14 +3078,14 @@
                                          (.getValue find-case-sensitive-property)
                                          (.getValue find-whole-word-property))))))
 
-(handler/defhandler :find-text :code-view
+(handler/defhandler :edit.find :code-view
   (run [find-bar view-node]
        (when-some [selected-text (non-empty-single-selection-text view-node)]
          (set-find-term! selected-text))
        (set-bar-ui-type! :find)
        (focus-term-field! find-bar)))
 
-(handler/defhandler :replace-text :code-view
+(handler/defhandler :code.replace-text :code-view
   (active? [editable] editable)
   (run [replace-bar view-node]
        (when-some [selected-text (non-empty-single-selection-text view-node)]
@@ -3063,18 +3093,18 @@
        (set-bar-ui-type! :replace)
        (focus-term-field! replace-bar)))
 
-(handler/defhandler :find-text :code-view-tools ;; In practice, from find / replace and go to line bars.
+(handler/defhandler :edit.find :code-view-tools ;; In practice, from find / replace and go to line bars.
   (run [find-bar]
        (set-bar-ui-type! :find)
        (focus-term-field! find-bar)))
 
-(handler/defhandler :replace-text :code-view-tools
+(handler/defhandler :code.replace-text :code-view-tools
   (active? [editable] editable)
   (run [replace-bar]
        (set-bar-ui-type! :replace)
        (focus-term-field! replace-bar)))
 
-(handler/defhandler :escape :code-view-tools
+(handler/defhandler :code.escape :code-view-tools
   (run [find-bar replace-bar view-node]
        (cond
          (in-tab-trigger? view-node)
@@ -3094,83 +3124,72 @@
          (set-properties! view-node :selection
                           (data/escape (get-property view-node :cursor-ranges))))))
 
-(handler/defhandler :find-next :code-view-find-bar
+(handler/defhandler :code.find-next :code-view-find-bar
   (run [view-node] (find-next! view-node)))
 
-(handler/defhandler :find-next :code-view-replace-bar
+(handler/defhandler :code.find-next :code-view-replace-bar
   (run [view-node] (find-next! view-node)))
 
-(handler/defhandler :find-next :code-view
+(handler/defhandler :code.find-next :code-view
   (run [view-node] (find-next! view-node)))
 
-(handler/defhandler :find-prev :code-view-find-bar
+(handler/defhandler :code.find-previous :code-view-find-bar
   (run [view-node] (find-prev! view-node)))
 
-(handler/defhandler :find-prev :code-view-replace-bar
+(handler/defhandler :code.find-previous :code-view-replace-bar
   (run [view-node] (find-prev! view-node)))
 
-(handler/defhandler :find-prev :code-view
+(handler/defhandler :code.find-previous :code-view
   (run [view-node] (find-prev! view-node)))
 
-(handler/defhandler :replace-next :code-view-replace-bar
+(handler/defhandler :code.replace-next :code-view-replace-bar
   (active? [editable] editable)
   (run [view-node] (replace-next! view-node)))
 
-(handler/defhandler :replace-next :code-view
+(handler/defhandler :code.replace-next :code-view
   (active? [editable] editable)
   (run [view-node] (replace-next! view-node)))
 
-(handler/defhandler :replace-all :code-view-replace-bar
+(handler/defhandler :code.replace-all :code-view-replace-bar
   (active? [editable] editable)
   (run [view-node] (replace-all! view-node)))
 
 ;; -----------------------------------------------------------------------------
 
 (handler/register-menu! ::menubar-edit :editor.app-view/edit-end
-  [{:command :find-text :label "Find..."}
-   {:command :find-next :label "Find Next"}
-   {:command :find-prev :label "Find Previous"}
+  [{:command :edit.find :label "Find..."}
+   {:command :code.find-next :label "Find Next"}
+   {:command :code.find-previous :label "Find Previous"}
    {:label :separator}
-   {:command :replace-text :label "Replace..."}
-   {:command :replace-next :label "Replace Next"}
+   {:command :code.replace-text :label "Replace..."}
+   {:command :code.replace-next :label "Replace Next"}
    {:label :separator}
-   {:command :toggle-comment :label "Toggle Comment"}
-   {:command :reindent :label "Reindent Lines"}
-
-   {:label "Convert Indentation"
-    :children [{:label "To Tabs"
-                :command :convert-indentation
-                :user-data :tabs}
-               {:label "To Two Spaces"
-                :command :convert-indentation
-                :user-data :two-spaces}
-               {:label "To Four Spaces"
-                :command :convert-indentation
-                :user-data :four-spaces}]}
-
+   {:command :code.toggle-comment :label "Toggle Comment"}
+   {:command :code.reindent :label "Reindent Lines"}
+   {:command :code.convert-indentation :expand? true}
    {:label :separator}
-   {:command :sort-lines :label "Sort Lines"}
-   {:command :sort-lines-case-sensitive :label "Sort Lines (Case Sensitive)"}
+   {:command :code.sort-lines :user-data :case-insensitive}
+   {:command :code.sort-lines :user-data :case-sensitive}
    {:label :separator}
-   {:command :select-next-occurrence :label "Select Next Occurrence"}
-   {:command :split-selection-into-lines :label "Split Selection Into Lines"}
+   {:command :code.select-next-occurrence :label "Select Next Occurrence"}
+   {:command :code.split-selection-into-lines :label "Split Selection Into Lines"}
    {:label :separator}
-   {:command :goto-definition :label "Go to Definition"}
-   {:command :find-references :label "Find References"}
+   {:command :code.goto-definition :label "Go to Definition"}
+   {:command :code.show-references :label "Find References"}
    {:label :separator}
-   {:command :toggle-breakpoint :label "Toggle Breakpoint"}
-   {:command :edit-breakpoint :label "Edit Breakpoint"}])
+   {:command :debugger.toggle-breakpoint :label "Toggle Breakpoint"}
+   {:command :debugger.edit-breakpoint :label "Edit Breakpoint"}])
 
 (handler/register-menu! ::menubar-view :editor.app-view/view-end
-  [{:command :toggle-minimap :label "Minimap" :check true}
-   {:command :toggle-indentation-guides :label "Indentation Guides" :check true}
-   {:command :toggle-visible-whitespace :label "Visible Whitespace" :check true}
+  [{:command :code.toggle-minimap :label "Minimap" :check true}
+   {:command :code.toggle-indentation-guides :label "Indentation Guides" :check true}
+   {:command :code.toggle-visible-whitespace :label "Visible Whitespace" :check true}
    {:label :separator}
-   {:command :zoom-in :label "Increase Font Size"}
-   {:command :zoom-out :label "Decrease Font Size"}
-   {:command :reset-zoom :label "Reset Font Size"}
+   {:command :code.zoom.increase :label "Increase Font Size"}
+   {:command :code.zoom.decrease :label "Decrease Font Size"}
+   {:command :code.zoom.reset :label "Reset Font Size"}
    {:label :separator}
-   {:command :goto-line :label "Go to Line..."}])
+   {:command :code.goto-line :label "Go to Line..."}])
 
 ;; -----------------------------------------------------------------------------
 
@@ -3261,44 +3280,46 @@
         ^Rectangle2D screen-rect (coll/some #(when (.contains ^Rectangle2D % anchor) %)
                                             screen-bounds)
         max-popup-height (- (.getY anchor) (.getMinY screen-rect))]
-    {:fx/type fxui/with-popup
+    {:fx/type fxui/with-popup-window
      :desc {:fx/type fxui/ext-value :value canvas}
-     :showing true
-     :anchor-x (.getX anchor)
-     :anchor-y (.getY anchor)
-     :anchor-location :window-bottom-left
-     :auto-hide true
-     :on-auto-hide (fn/partial handle-hover-popup-auto-hide! view-node)
-     :on-hidden (fn/partial handle-hover-popup-on-hidden! view-node)
-     :auto-fix true
-     :hide-on-escape true
-     :consume-auto-hiding-events true
-     :content
-     [{:fx/type fx.stack-pane/lifecycle
-       :stylesheets [(str (io/resource "editor.css"))]
-       :on-mouse-entered (fn/partial handle-hover-popup-mouse-entered! view-node)
-       :on-mouse-exited (fn/partial handle-hover-popup-mouse-exited! view-node)
-       :children
-       [{:fx/type fx.region/lifecycle
-         :min-width 10
-         :min-height 10
-         :style-class "hover-background"}
-        {:fx/type markdown/view
-         :content (->> hover-showing-regions
-                       (e/mapcat
-                         (fn [region]
-                           (when (:hoverable region)
-                             (case (:type region)
-                               :diagnostic (map plaintext->markdown (:messages region))
-                               :hover [(let [{:keys [content]} region
-                                             {:keys [type value]} content]
-                                         (case type
-                                           :plaintext (plaintext->markdown value)
-                                           :markdown value))]))))
-                       (coll/join-to-string "\n\n<hr>\n\n"))
-         :project project
-         :max-width 350.0
-         :max-height max-popup-height}]}]}))
+     :popup
+     {:fx/type fx.popup/lifecycle
+      :showing true
+      :anchor-x (.getX anchor)
+      :anchor-y (.getY anchor)
+      :anchor-location :window-bottom-left
+      :auto-hide true
+      :on-auto-hide (fn/partial handle-hover-popup-auto-hide! view-node)
+      :on-hidden (fn/partial handle-hover-popup-on-hidden! view-node)
+      :auto-fix true
+      :hide-on-escape true
+      :consume-auto-hiding-events true
+      :content
+      [{:fx/type fx.stack-pane/lifecycle
+        :stylesheets [(str (io/resource "editor.css"))]
+        :on-mouse-entered (fn/partial handle-hover-popup-mouse-entered! view-node)
+        :on-mouse-exited (fn/partial handle-hover-popup-mouse-exited! view-node)
+        :children
+        [{:fx/type fx.region/lifecycle
+          :min-width 10
+          :min-height 10
+          :style-class "hover-background"}
+         {:fx/type markdown/view
+          :content (->> hover-showing-regions
+                        (e/mapcat
+                          (fn [region]
+                            (when (:hoverable region)
+                              (case (:type region)
+                                :diagnostic (map plaintext->markdown (:messages region))
+                                :hover [(let [{:keys [content]} region
+                                              {:keys [type value]} content]
+                                          (case type
+                                            :plaintext (plaintext->markdown value)
+                                            :markdown value))]))))
+                        (coll/join-to-string "\n\n<hr>\n\n"))
+          :project project
+          :max-width 350.0
+          :max-height max-popup-height}]}]}}))
 
 (defn repaint-view! [view-node elapsed-time {:keys [cursor-visible editable] :as _opts}]
   (assert (boolean? cursor-visible))
@@ -3620,65 +3641,67 @@
                                   12) ;; shadow offset
                                (+ (* ^double (data/line-height (:glyph layout)) 0.5)
                                   (data/row->y layout (data/breakpoint-row edited-breakpoint))))]
-    {:fx/type fxui/with-popup
+    {:fx/type fxui/with-popup-window
      :desc {:fx/type fxui/ext-value :value (.getWindow (.getScene canvas))}
-     :showing true
-     :anchor-x (.getX anchor)
-     :anchor-y (.getY anchor)
-     :anchor-location :window-top-left
-     :auto-hide true
-     :auto-fix true
-     :hide-on-escape true
-     :on-auto-hide {:event :cancel}
-     :consume-auto-hiding-events true
-     :event-handler consume-breakpoint-popup-events
-     :content
-     [{:fx/type fx.v-box/lifecycle
-       :stylesheets [(str (io/resource "editor.css"))]
-       :children
-       [{:fx/type fx.v-box/lifecycle
-         :style-class "breakpoint-editor"
-         :fill-width false
-         :spacing -1
-         :children
-         [{:fx/type fx.region/lifecycle
-           :view-order -1
-           :style-class "breakpoint-editor-arrow"
-           :min-width 10
-           :min-height 10}
-          {:fx/type fx.stack-pane/lifecycle
-           :children
-           [{:fx/type fx.region/lifecycle
-             :style-class "breakpoint-editor-background"}
-            {:fx/type fx.v-box/lifecycle
-             :style-class "breakpoint-editor-content"
-             :spacing padding
-             :children
-             [{:fx/type fx.label/lifecycle
-               :style-class ["label" "breakpoint-editor-label" "breakpoint-editor-header"]
-               :text (format "Breakpoint on line %d" (data/CursorRange->line-number edited-breakpoint))}
-              {:fx/type fx.h-box/lifecycle
-               :spacing spacing
-               :alignment :baseline-left
-               :children
-               [{:fx/type fx.label/lifecycle
-                 :style-class ["label" "breakpoint-editor-label"]
-                 :text "Condition"}
-                {:fx/type fxui/legacy-text-field
-                 :h-box/hgrow :always
-                 :style-class ["text-field" "breakpoint-editor-label"]
-                 :prompt-text "e.g. i == 1"
-                 :text (:condition edited-breakpoint "")
-                 :on-text-changed {:event :edit}
-                 :on-action {:event :apply}}]}
-              {:fx/type fx.h-box/lifecycle
-               :spacing spacing
-               :alignment :center-right
-               :children
-               [{:fx/type fx.button/lifecycle
-                 :style-class ["button" "breakpoint-editor-button"]
-                 :text "OK"
-                 :on-action {:event :apply}}]}]}]}]}]}]}))
+     :popup
+     {:fx/type fx.popup/lifecycle
+      :showing true
+      :anchor-x (.getX anchor)
+      :anchor-y (.getY anchor)
+      :anchor-location :window-top-left
+      :auto-hide true
+      :auto-fix true
+      :hide-on-escape true
+      :on-auto-hide {:event :cancel}
+      :consume-auto-hiding-events true
+      :event-handler consume-breakpoint-popup-events
+      :content
+      [{:fx/type fx.v-box/lifecycle
+        :stylesheets [(str (io/resource "editor.css"))]
+        :children
+        [{:fx/type fx.v-box/lifecycle
+          :style-class "breakpoint-editor"
+          :fill-width false
+          :spacing -1
+          :children
+          [{:fx/type fx.region/lifecycle
+            :view-order -1
+            :style-class "breakpoint-editor-arrow"
+            :min-width 10
+            :min-height 10}
+           {:fx/type fx.stack-pane/lifecycle
+            :children
+            [{:fx/type fx.region/lifecycle
+              :style-class "breakpoint-editor-background"}
+             {:fx/type fx.v-box/lifecycle
+              :style-class "breakpoint-editor-content"
+              :spacing padding
+              :children
+              [{:fx/type fx.label/lifecycle
+                :style-class ["label" "breakpoint-editor-label" "breakpoint-editor-header"]
+                :text (format "Breakpoint on line %d" (data/CursorRange->line-number edited-breakpoint))}
+               {:fx/type fx.h-box/lifecycle
+                :spacing spacing
+                :alignment :baseline-left
+                :children
+                [{:fx/type fx.label/lifecycle
+                  :style-class ["label" "breakpoint-editor-label"]
+                  :text "Condition"}
+                 {:fx/type fxui/legacy-text-field
+                  :h-box/hgrow :always
+                  :style-class ["text-field" "breakpoint-editor-label"]
+                  :prompt-text "e.g. i == 1"
+                  :text (:condition edited-breakpoint "")
+                  :on-text-changed {:event :edit}
+                  :on-action {:event :apply}}]}
+               {:fx/type fx.h-box/lifecycle
+                :spacing spacing
+                :alignment :center-right
+                :children
+                [{:fx/type fx.button/lifecycle
+                  :style-class ["button" "breakpoint-editor-button"]
+                  :text "OK"
+                  :on-action {:event :apply}}]}]}]}]}]}]}}))
 
 (defn- create-breakpoint-editor! [view-node canvas ^Tab tab]
   (let [state (atom nil)
@@ -3735,13 +3758,6 @@
         canvas-pane (Pane. (into-array Node [canvas]))
         undo-grouping-info (pair :navigation (gensym))
         lsp (lsp/get-node-lsp basis resource-node)
-        completions-shortcut-text (transduce
-                                    (comp
-                                      (mapcat val)
-                                      (filter #(= :proposals (:command %)))
-                                      (map #(.getDisplayText ^KeyCombination (:key-combo %))))
-                                    util/first-rf
-                                    (g/node-value app-view :keymap))
         view-node
         (setup-view!
           resource-node
@@ -3755,12 +3771,12 @@
                        :gutter-view (->CodeEditorGutterView)
                        :highlighted-find-term (.getValue highlighted-find-term-property)
                        :line-height-factor 1.2
-                       :completions-shortcut-text completions-shortcut-text
                        :undo-grouping-info undo-grouping-info
                        :visible-indentation-guides? (.getValue visible-indentation-guides-property)
                        :visible-minimap? (.getValue visible-minimap-property)
                        :visible-whitespace (boolean->visible-whitespace (.getValue visible-whitespace-property))]]
-                (g/connect project :_node-id view :project))
+                (g/connect project :_node-id view :project)
+                (g/connect app-view :keymap view :keymap))
               g/transact
               g/tx-nodes-added
               first)
@@ -3880,109 +3896,109 @@
     view-node))
 
 (def ^:private fundamental-read-only-handlers
-  {[:view/select-up]
+  {[:view/code.select-up]
    {:run (g/fnk [view-node]
            (move! view-node :selection :up))}
 
-   [:view/select-down]
+   [:view/code.select-down]
    {:run (g/fnk [view-node]
            (move! view-node :selection :down))}
 
-   [:view/select-left]
+   [:view/code.select-left]
    {:run (g/fnk [view-node]
            (move! view-node :selection :left))}
 
-   [:view/select-right]
+   [:view/code.select-right]
    {:run (g/fnk [view-node]
            (move! view-node :selection :right))}
 
-   [:view/prev-word]
+   [:view/code.goto-previous-word]
    {:run (g/fnk [view-node]
            (move! view-node :navigation :prev-word))}
 
-   [:view/select-prev-word]
+   [:view/code.select-previous-word]
    {:run (g/fnk [view-node]
            (move! view-node :selection :prev-word))}
 
-   [:view/next-word]
+   [:view/code.goto-next-word]
    {:run (g/fnk [view-node]
            (move! view-node :navigation :next-word))}
 
-   [:view/select-next-word]
+   [:view/code.select-next-word]
    {:run (g/fnk [view-node]
            (move! view-node :selection :next-word))}
 
-   [:view/beginning-of-line]
+   [:view/code.goto-line-start]
    {:run (g/fnk [view-node]
            (move! view-node :navigation :line-start))}
 
-   [:view/select-beginning-of-line]
+   [:view/code.select-line-start]
    {:run (g/fnk [view-node]
            (move! view-node :selection :line-start))}
 
-   [:view/beginning-of-line-text]
+   [:view/code.goto-line-text-start]
    {:run (g/fnk [view-node]
            (move! view-node :navigation :home))}
 
-   [:view/select-beginning-of-line-text]
+   [:view/code.select-line-text-start]
    {:run (g/fnk [view-node]
            (move! view-node :selection :home))}
 
-   [:view/end-of-line]
+   [:view/code.goto-line-end]
    {:run (g/fnk [view-node]
            (move! view-node :navigation :end))}
 
-   [:view/select-end-of-line]
+   [:view/code.select-line-end]
    {:run (g/fnk [view-node]
            (move! view-node :selection :end))}
 
-   [:view/page-up]
+   [:view/code.page-up]
    {:run (g/fnk [view-node]
            (page-up! view-node :navigation))}
 
-   [:view/select-page-up]
+   [:view/code.select-page-up]
    {:run (g/fnk [view-node]
            (page-up! view-node :selection))}
 
-   [:view/page-down]
+   [:view/code.page-down]
    {:run (g/fnk [view-node]
            (page-down! view-node :navigation))}
 
-   [:view/select-page-down]
+   [:view/code.select-page-down]
    {:run (g/fnk [view-node]
            (page-down! view-node :selection))}
 
-   [:view/beginning-of-file]
+   [:view/code.goto-file-start]
    {:run (g/fnk [view-node]
            (move! view-node :navigation :file-start))}
 
-   [:view/select-beginning-of-file]
+   [:view/code.select-file-start]
    {:run (g/fnk [view-node]
            (move! view-node :selection :file-start))}
 
-   [:view/end-of-file]
+   [:view/code.goto-file-end]
    {:run (g/fnk [view-node]
            (move! view-node :navigation :file-end))}
 
-   [:view/select-end-of-file]
+   [:view/code.select-file-end]
    {:run (g/fnk [view-node]
            (move! view-node :selection :file-end))}
 
-   [:view/copy]
+   [:view/edit.copy]
    {:enabled? (g/fnk [view-node evaluation-context]
                 (has-selection? view-node evaluation-context))
     :run (g/fnk [view-node clipboard]
            (copy! view-node clipboard))}
 
-   [:view/select-all]
+   [:view/code.select-all]
    {:run (g/fnk [view-node]
            (select-all! view-node))}
 
-   [:view/select-next-occurrence :tool/select-next-occurrence]
+   [:view/code.select-next-occurrence :tool/code.select-next-occurrence]
    {:run (g/fnk [view-node]
            (select-next-occurrence! view-node))}
 
-   [:view/split-selection-into-lines]
+   [:view/code.split-selection-into-lines]
    {:run (g/fnk [view-node]
            (split-selection-into-lines! view-node))}})
 

--- a/editor/src/clj/editor/collection.clj
+++ b/editor/src/clj/editor/collection.clj
@@ -666,7 +666,7 @@
 (defn- select-go-file [workspace project]
   (first (resource-dialog/make workspace project {:ext "go" :title "Select Game Object File"})))
 
-(handler/defhandler :add-from-file :workbench
+(handler/defhandler :edit.add-referenced-component :workbench
   (active? [selection] (selection->collection selection))
   (label [selection] "Add Game Object File")
   (run [workspace project app-view selection]
@@ -714,7 +714,7 @@
         (g/operation-label "Add Game Object")
         (make-embedded-go coll-node project prototype-desc id nil parent select-fn)))))
 
-(handler/defhandler :add :workbench
+(handler/defhandler :edit.add-embedded-component :workbench
   (active? [selection] (selection->collection selection))
   (label [selection user-data] "Add Game Object")
   (run [selection workspace project user-data app-view]
@@ -742,7 +742,7 @@
       (g/operation-label "Add Collection")
       (make-collection-instance self source-resource id transform-properties overrides select-fn))))
 
-(handler/defhandler :add-secondary :workbench
+(handler/defhandler :edit.add-secondary-embedded-component :workbench
   (active? [selection] (selection->game-object-instance selection))
   (label [] "Add Game Object")
   (run [selection project workspace app-view]
@@ -750,7 +750,7 @@
              collection (core/scope-of-type go-node CollectionNode)]
          (add-embedded-game-object! workspace project collection go-node (fn [node-ids] (app-view/select app-view node-ids))))))
 
-(handler/defhandler :add-secondary-from-file :workbench
+(handler/defhandler :edit.add-secondary-referenced-component :workbench
   (active? [selection] (or (selection->collection selection)
                          (selection->game-object-instance selection)))
   (label [selection] (if (selection->collection selection)

--- a/editor/src/clj/editor/collision_object.clj
+++ b/editor/src/clj/editor/collision_object.clj
@@ -672,7 +672,7 @@
 (defn- selection->collision-object [selection]
   (handler/adapt-single selection CollisionObjectNode))
 
-(handler/defhandler :add :workbench
+(handler/defhandler :edit.add-embedded-component :workbench
   (label [user-data]
          (if-not user-data
            "Add Shape"
@@ -687,7 +687,7 @@
                     (reduce-kv (fn [res shape-type {:keys [label icon]}]
                                  (conj res {:label label
                                             :icon icon
-                                            :command :add
+                                            :command :edit.add-embedded-component
                                             :user-data {:_node-id self :shape-type shape-type}}))
                                [])
                     (sort-by :label)

--- a/editor/src/clj/editor/command_requests.clj
+++ b/editor/src/clj/editor/command_requests.clj
@@ -127,7 +127,7 @@
     :resource-sync true}
 
    :reload-stylesheets
-   {:ui-handler :window.reload-css
+   {:ui-handler :dev.reload-css
     :help "Reload editor stylesheets."}
 
    :report-issue

--- a/editor/src/clj/editor/command_requests.clj
+++ b/editor/src/clj/editor/command_requests.clj
@@ -31,139 +31,139 @@
   ;; Notable exclusions:
   ;; :save-all, :quit, anything that would open a modal dialog.
   {:asset-portal
-   {:ui-handler :asset-portal
+   {:ui-handler :help.open-asset-portal
     :help "Open the Asset Portal in a web browser."}
 
    :build
-   {:ui-handler :build
+   {:ui-handler :project.build
     :help "Build and run the project."
     :resource-sync true}
 
    :build-html5
-   {:ui-handler :build-html5
+   {:ui-handler :project.build-html5
     :help "Build the project for HTML5 and open it in a web browser."
     :resource-sync true}
 
    :debugger-break
-   {:ui-handler :break
+   {:ui-handler :debugger.break
     :help "Break into the debugger."}
 
    :debugger-continue
-   {:ui-handler :continue
+   {:ui-handler :debugger.continue
     :help "Resume execution in the debugger."}
 
    :debugger-detach
-   {:ui-handler :detach-debugger
+   {:ui-handler :debugger.detach
     :help "Detach the debugger from the running project."}
 
    :debugger-start
-   {:ui-handler :start-debugger
+   {:ui-handler :debugger.start
     :help "Start the project with the debugger, or attach the debugger to the running project."
     :resource-sync true}
 
    :debugger-step-into
-   {:ui-handler :step-into
+   {:ui-handler :debugger.step-into
     :help "Step into the current expression in the debugger."}
 
    :debugger-step-out
-   {:ui-handler :step-out
+   {:ui-handler :debugger.step-out
     :help "Step out of the current expression in the debugger."}
 
    :debugger-step-over
-   {:ui-handler :step-over
+   {:ui-handler :debugger.step-over
     :help "Step over the current expression in the debugger."}
 
    :debugger-stop
-   {:ui-handler :stop-debugger
+   {:ui-handler :debugger.stop
     :help "Stop the debugger and the running project."}
 
    :documentation
-   {:ui-handler :documentation
+   {:ui-handler :help.open-documentation
     :help "Open the Defold documentation in a web browser."}
 
    :donate-page
-   {:ui-handler :donate
+   {:ui-handler :help.open-donations
     :help "Open the Donate to Defold page in a web browser."}
 
    :editor-logs
-   {:ui-handler :show-logs
+   {:ui-handler :help.open-logs
     :help "Show the directory containing the editor logs."}
 
    :engine-profiler
-   {:ui-handler :engine-profile-show
+   {:ui-handler :run.open-profiler
     :help "Open the Engine Profiler in a web browser."}
 
    :engine-resource-profiler
-   {:ui-handler :engine-resource-profile-show
+   {:ui-handler :run.open-resource-profiler
     :help "Open the Engine Resource Profiler in a web browser."}
 
    :fetch-libraries
-   {:ui-handler :fetch-libraries
+   {:ui-handler :project.fetch-libraries
     :help "Download the latest version of the project library dependencies."
     :resource-sync true}
 
    :hot-reload
-   {:ui-handler :hot-reload
+   {:ui-handler :run.hot-reload
     :help "Hot-reload all modified files into the running project."
     :resource-sync true}
 
    :issues
-   {:ui-handler :search-issues
+   {:ui-handler :help.open-issues
     :help "Open the Defold Issue Tracker in a web browser."}
 
    :rebuild
-   {:ui-handler :rebuild
+   {:ui-handler :project.clean-build
     :help "Rebuild and run the project."
     :resource-sync true}
 
    :rebundle
-   {:ui-handler :rebundle
+   {:ui-handler :project.rebundle
     :help "Re-bundle the project using the previous Bundle dialog settings."
     :resource-sync true}
 
    :reload-extensions
-   {:ui-handler :reload-extensions
+   {:ui-handler :project.reload-editor-scripts
     :help "Reload editor extensions."
     :resource-sync true}
 
    :reload-stylesheets
-   {:ui-handler :reload-stylesheet
+   {:ui-handler :window.reload-css
     :help "Reload editor stylesheets."}
 
    :report-issue
-   {:ui-handler :report-issue
+   {:ui-handler :help.report-issue
     :help "Open the Report Issue page in a web browser."}
 
    :report-suggestion
-   {:ui-handler :report-suggestion
+   {:ui-handler :help.report-suggestion
     :help "Open the Report Suggestion page in a web browser."}
 
    :show-build-errors
-   {:ui-handler :show-build-errors
+   {:ui-handler :window.show-build-errors
     :help "Show the Build Errors tab."}
 
    :show-console
-   {:ui-handler :show-console
+   {:ui-handler :window.show-console
     :help "Show the Console tab."}
 
    :show-curve-editor
-   {:ui-handler :show-curve-editor
+   {:ui-handler :window.show-curve-editor
     :help "Show the Curve Editor tab."}
 
    :support-forum
-   {:ui-handler :support-forum
+   {:ui-handler :help.open-forum
     :help "Open the Defold Support Forum in a web browser."}
 
    :toggle-pane-bottom
-   {:ui-handler :toggle-pane-bottom
+   {:ui-handler :window.toggle-bottom-pane
     :help "Toggle visibility of the bottom editor pane."}
 
    :toggle-pane-left
-   {:ui-handler :toggle-pane-left
+   {:ui-handler :window.toggle-left-pane
     :help "Toggle visibility of the left editor pane."}
 
    :toggle-pane-right
-   {:ui-handler :toggle-pane-right
+   {:ui-handler :window.toggle-right-pane
     :help "Toggle visibility of the right editor pane."}})
 
 (def ^:private api-response

--- a/editor/src/clj/editor/console.clj
+++ b/editor/src/clj/editor/console.clj
@@ -283,7 +283,7 @@
                                      {:fx/type fx.list-view/lifecycle
                                       :focus-traversable false
                                       :style-class "console-filter-popup-list-view"
-                                      :items (into [] (map-indexed vector) filters)
+                                      :items (into [] (map-indexed coll/pair) filters)
                                       :fixed-cell-size 27
                                       :max-height (* 27 (min 10 (count filters)))
                                       :cell-factory {:fx/cell-type :list-cell
@@ -345,7 +345,7 @@
                                            "Shift+Enter" :code.find-previous})
     (ui/bind-action! prev-console :code.find-previous)
     (ui/bind-action! next-console :code.find-next)
-    (ui/bind-action! clear-console :window.clear-console))
+    (ui/bind-action! clear-console :console.clear))
   tool-bar)
 
 (defn- dispose-tool-bar! [^Parent tool-bar]
@@ -408,7 +408,7 @@
 ;; Console view action handlers
 ;; -----------------------------------------------------------------------------
 
-(handler/defhandler :window.clear-console :console-tool-bar
+(handler/defhandler :console.clear :console-tool-bar
   (run [view-node] (clear-console!)))
 
 ;; -----------------------------------------------------------------------------

--- a/editor/src/clj/editor/console.clj
+++ b/editor/src/clj/editor/console.clj
@@ -19,6 +19,7 @@
             [cljfx.fx.h-box :as fx.h-box]
             [cljfx.fx.label :as fx.label]
             [cljfx.fx.list-view :as fx.list-view]
+            [cljfx.fx.popup :as fx.popup]
             [cljfx.fx.region :as fx.region]
             [cljfx.fx.separator :as fx.separator]
             [cljfx.fx.stack-pane :as fx.stack-pane]
@@ -235,7 +236,7 @@
                                (- (.getMaxY (.getBoundsInLocal filter-console-button))
                                   ;; shadow offset
                                   4.0))]
-    {:fx/type fxui/with-popup
+    {:fx/type fxui/with-popup-window
      :desc {:fx/type ext-with-button-props
             :desc {:fx/type fxui/ext-value
                    :value filter-console-button}
@@ -251,48 +252,49 @@
                                           :pseudo-classes (if open #{:open} #{})
                                           :h-box/margin {:left 10}
                                           :id "filter-console-arrow"}]}}}
-     :showing open
-     :anchor-location :window-bottom-left
-     :anchor-x (.getX anchor)
-     :anchor-y (.getY anchor)
-     :auto-hide true
-     :auto-fix true
-     :hide-on-escape true
-     :consume-auto-hiding-events true
-     :on-auto-hide {:event-type :hide}
-     :content [{:fx/type fx.stack-pane/lifecycle
-                :stylesheets [(str (io/resource "editor.css"))]
-                :style-class "console-filter-popup"
-                :children [{:fx/type fx.region/lifecycle
-                            :mouse-transparent true
-                            :style-class "console-filter-popup-background"}
-                           {:fx/type fx.v-box/lifecycle
-                            :children
-                            [{:fx/type fx.check-box/lifecycle
-                              :focus-traversable false
-                              :max-width ##Inf
-                              :v-box/margin 4
-                              :id "global-console-filtering"
-                              :selected enabled
-                              :on-selected-changed {:event-type :toggle-global-filtering}
-                              :text "Enable filtering"}
-                             {:fx/type fx.separator/lifecycle
-                              :style-class "console-filter-popup-separator"}
-                             {:fx/type fx.list-view/lifecycle
-                              :focus-traversable false
-                              :style-class "console-filter-popup-list-view"
-                              :items (into [] (map-indexed vector) filters)
-                              :fixed-cell-size 27
-                              :max-height (* 27 (min 10 (count filters)))
-                              :cell-factory {:fx/cell-type :list-cell
-                                             :describe filter-console-list-cell-view}}
-                             {:fx/type fxui/ext-focused-by-default
-                              :v-box/margin 4
-                              :desc {:fx/type fx.text-field/lifecycle
-                                     :text text
-                                     :on-text-changed {:event-type :type}
-                                     :on-action {:event-type :add}
-                                     :prompt-text "Add filter (e.g. text, !exclude)"}}]}]}]}))
+     :popup {:fx/type fx.popup/lifecycle
+             :showing open
+             :anchor-location :window-bottom-left
+             :anchor-x (.getX anchor)
+             :anchor-y (.getY anchor)
+             :auto-hide true
+             :auto-fix true
+             :hide-on-escape true
+             :consume-auto-hiding-events true
+             :on-auto-hide {:event-type :hide}
+             :content [{:fx/type fx.stack-pane/lifecycle
+                        :stylesheets [(str (io/resource "editor.css"))]
+                        :style-class "console-filter-popup"
+                        :children [{:fx/type fx.region/lifecycle
+                                    :mouse-transparent true
+                                    :style-class "console-filter-popup-background"}
+                                   {:fx/type fx.v-box/lifecycle
+                                    :children
+                                    [{:fx/type fx.check-box/lifecycle
+                                      :focus-traversable false
+                                      :max-width ##Inf
+                                      :v-box/margin 4
+                                      :id "global-console-filtering"
+                                      :selected enabled
+                                      :on-selected-changed {:event-type :toggle-global-filtering}
+                                      :text "Enable filtering"}
+                                     {:fx/type fx.separator/lifecycle
+                                      :style-class "console-filter-popup-separator"}
+                                     {:fx/type fx.list-view/lifecycle
+                                      :focus-traversable false
+                                      :style-class "console-filter-popup-list-view"
+                                      :items (into [] (map-indexed vector) filters)
+                                      :fixed-cell-size 27
+                                      :max-height (* 27 (min 10 (count filters)))
+                                      :cell-factory {:fx/cell-type :list-cell
+                                                     :describe filter-console-list-cell-view}}
+                                     {:fx/type fxui/ext-focused-by-default
+                                      :v-box/margin 4
+                                      :desc {:fx/type fx.text-field/lifecycle
+                                             :text text
+                                             :on-text-changed {:event-type :type}
+                                             :on-action {:event-type :add}
+                                             :prompt-text "Add filter (e.g. text, !exclude)"}}]}]}]}}))
 
 (defn- handle-filter-event! [state prefs e]
   (case (:event-type e)
@@ -339,11 +341,11 @@
     (init-console-filter! filter-console prefs)
     (ui/context! tool-bar :console-tool-bar {:term-field search-console :view-node view-node} nil)
     (.bindBidirectional (.textProperty search-console) find-term-property)
-    (ui/bind-key-commands! search-console {"Enter" :find-next
-                                           "Shift+Enter" :find-prev})
-    (ui/bind-action! prev-console :find-prev)
-    (ui/bind-action! next-console :find-next)
-    (ui/bind-action! clear-console :clear-console))
+    (ui/bind-key-commands! search-console {"Enter" :code.find-next
+                                           "Shift+Enter" :code.find-previous})
+    (ui/bind-action! prev-console :code.find-previous)
+    (ui/bind-action! next-console :code.find-next)
+    (ui/bind-action! clear-console :window.clear-console))
   tool-bar)
 
 (defn- dispose-tool-bar! [^Parent tool-bar]
@@ -378,22 +380,22 @@
                                         false
                                         true)))
 
-(handler/defhandler :find-text :console-view
+(handler/defhandler :edit.find :console-view
   (run [term-field view-node]
        (when-some [selected-text (view/non-empty-single-selection-text view-node)]
          (set-find-term! selected-text))
        (focus-term-field! term-field)))
 
-(handler/defhandler :find-next :console-view
+(handler/defhandler :code.find-next :console-view
   (run [view-node] (find-next! view-node)))
 
-(handler/defhandler :find-next :console-tool-bar
+(handler/defhandler :code.find-next :console-tool-bar
   (run [view-node] (find-next! view-node)))
 
-(handler/defhandler :find-prev :console-view
+(handler/defhandler :code.find-previous :console-view
   (run [view-node] (find-prev! view-node)))
 
-(handler/defhandler :find-prev :console-tool-bar
+(handler/defhandler :code.find-previous :console-tool-bar
   (run [view-node] (find-prev! view-node)))
 
 ;; -----------------------------------------------------------------------------
@@ -406,7 +408,7 @@
 ;; Console view action handlers
 ;; -----------------------------------------------------------------------------
 
-(handler/defhandler :clear-console :console-tool-bar
+(handler/defhandler :window.clear-console :console-tool-bar
   (run [view-node] (clear-console!)))
 
 ;; -----------------------------------------------------------------------------

--- a/editor/src/clj/editor/curve_view.clj
+++ b/editor/src/clj/editor/curve_view.clj
@@ -673,9 +673,9 @@
       (for [[[nid prop] idx] m]
         (g/update-property nid prop types/geom-delete idx)))))
 
-(handler/defhandler :delete :curve-view
+(handler/defhandler :edit.delete :curve-view
   (enabled? [selection] (not (empty? selection)))
   (run [selection] (delete-cps selection)))
 
-(handler/defhandler :frame-selection :curve-view
+(handler/defhandler :scene.frame-selection :curve-view
   (run [view-id selection] (frame-selection view-id selection true)))

--- a/editor/src/clj/editor/debug_view.clj
+++ b/editor/src/clj/editor/debug_view.clj
@@ -199,12 +199,12 @@
     (ui/tooltip! step-out-debugger-button step-out-label)
     (ui/tooltip! step-over-debugger-button step-over-label)
     (ui/tooltip! stop-debugger-button stop-debugger-label)
-    (ui/bind-action! pause-debugger-button :break)
-    (ui/bind-action! play-debugger-button :continue)
-    (ui/bind-action! step-in-debugger-button :step-into)
-    (ui/bind-action! step-out-debugger-button :step-out)
-    (ui/bind-action! step-over-debugger-button :step-over)
-    (ui/bind-action! stop-debugger-button :stop-debugger)))
+    (ui/bind-action! pause-debugger-button :debugger.break)
+    (ui/bind-action! play-debugger-button :debugger.continue)
+    (ui/bind-action! step-in-debugger-button :debugger.step-into)
+    (ui/bind-action! step-out-debugger-button :debugger.step-out)
+    (ui/bind-action! step-over-debugger-button :debugger.step-over)
+    (ui/bind-action! stop-debugger-button :debugger.stop)))
 
 (defn- setup-call-stack-view!
   [^ListView debugger-call-stack]
@@ -572,12 +572,12 @@
   (when-some [debug-session (current-session debug-view)]
     (mobdebug/done! debug-session)))
 
-(handler/defhandler :break :global
+(handler/defhandler :debugger.break :global
   (enabled? [debug-view evaluation-context]
             (= :running (some-> (current-session debug-view evaluation-context) mobdebug/state)))
   (run [debug-view] (mobdebug/suspend! (current-session debug-view))))
 
-(handler/defhandler :continue :global
+(handler/defhandler :debugger.continue :global
   ;; NOTE: Shares a shortcut with :app-view/start-debugger.
   ;; Only one of them can be active at a time. This creates the impression that
   ;; there is a single menu item whose label changes in various states.
@@ -588,30 +588,30 @@
   (run [debug-view] (mobdebug/run! (current-session debug-view)
                                    (make-debugger-callbacks debug-view))))
 
-(handler/defhandler :step-over :global
+(handler/defhandler :debugger.step-over :global
   (enabled? [debug-view evaluation-context]
             (= :suspended (some-> (current-session debug-view evaluation-context) mobdebug/state)))
   (run [debug-view] (mobdebug/step-over! (current-session debug-view)
                                          (make-debugger-callbacks debug-view))))
 
-(handler/defhandler :step-into :global
+(handler/defhandler :debugger.step-into :global
   (enabled? [debug-view evaluation-context]
             (= :suspended (some-> (current-session debug-view evaluation-context) mobdebug/state)))
   (run [debug-view] (mobdebug/step-into! (current-session debug-view)
                                          (make-debugger-callbacks debug-view))))
 
-(handler/defhandler :step-out :global
+(handler/defhandler :debugger.step-out :global
   (enabled? [debug-view evaluation-context]
             (= :suspended (some-> (current-session debug-view evaluation-context) mobdebug/state)))
   (run [debug-view] (mobdebug/step-out! (current-session debug-view)
                                         (make-debugger-callbacks debug-view))))
 
-(handler/defhandler :detach-debugger :global
+(handler/defhandler :debugger.detach :global
   (enabled? [debug-view evaluation-context]
             (current-session debug-view evaluation-context))
   (run [debug-view] (mobdebug/done! (current-session debug-view))))
 
-(handler/defhandler :stop-debugger :global
+(handler/defhandler :debugger.stop :global
   (enabled? [debug-view evaluation-context]
             (current-session debug-view evaluation-context))
   (run [debug-view] (mobdebug/exit! (current-session debug-view))))
@@ -634,15 +634,230 @@
         height (get project-settings ["display" "height"])]
     {:width width :height height}))
 
-(handler/defhandler :set-resolution :global
-  (enabled? [] true)
-  (run [prefs user-data]
-       (prefs/set! prefs [:run :simulated-resolution] user-data)
-       (change-resolution! prefs (:width user-data) (:height user-data)))
+(handler/defhandler :run.set-resolution :global
+  (options [user-data]
+    (when-not user-data
+      [{:label "Custom Resolution..."
+        :command :run.set-resolution
+        :user-data :custom
+        :check true}
+       {:label "Apple"
+        :children [{:label "iPhone"
+                    :children [{:label "Viewport Resolutions"
+                                :command :private/disabled-menu-label}
+                               {:label "iPhone 4 (320x480)"
+                                :command :run.set-resolution
+                                :check true
+                                :user-data {:width 320
+                                            :height 480}}
+                               {:label "iPhone 5/SE (320x568)"
+                                :command :run.set-resolution
+                                :check true
+                                :user-data {:width 320
+                                            :height 568}}
+                               {:label "iPhone 6/7/8 (375x667)"
+                                :command :run.set-resolution
+                                :check true
+                                :user-data {:width 375
+                                            :height 667}}
+                               {:label "iPhone 6/7/8 Plus (414x736)"
+                                :command :run.set-resolution
+                                :check true
+                                :user-data {:width 414
+                                            :height 736}}
+                               {:label "iPhone X/XS (375x812)"
+                                :command :run.set-resolution
+                                :check true
+                                :user-data {:width 375
+                                            :height 812}}
+                               {:label "iPhone XR/XS Max (414x896)"
+                                :command :run.set-resolution
+                                :check true
+                                :user-data {:width 414
+                                            :height 896}}
+                               {:label "iPhone 12 Pro Max/13 Pro Max/14 Plus (428x926)"
+                                :command :run.set-resolution
+                                :check true
+                                :user-data {:width 428
+                                            :height 926}}
+                               {:label "iPhone 14 Pro Max/15 Plus/15 Pro Max (430x932)"
+                                :command :run.set-resolution
+                                :check true
+                                :user-data {:width 430
+                                            :height 932}}
+                               {:label :separator}
+                               {:label "Native Resolutions"
+                                :command :private/disabled-menu-label}
+                               {:label "iPhone 4 (640x960)"
+                                :command :run.set-resolution
+                                :check true
+                                :user-data {:width 640
+                                            :height 960}}
+                               {:label "iPhone 5/SE (640x1136)"
+                                :command :run.set-resolution
+                                :check true
+                                :user-data {:width 640
+                                            :height 1136}}
+                               {:label "iPhone 6/7/8 (750x1334)"
+                                :command :run.set-resolution
+                                :check true
+                                :user-data {:width 750
+                                            :height 1334}}
+                               {:label "iPhone 6/7/8 Plus (1242x2208)"
+                                :command :run.set-resolution
+                                :check true
+                                :user-data {:width 1242
+                                            :height 2208}}
+                               {:label "iPhone X/XS/11 Pro (1125x2436)"
+                                :command :run.set-resolution
+                                :check true
+                                :user-data {:width 1125
+                                            :height 2436}}
+                               {:label "iPhone XS Max/11 Pro Max (1242x2688)"
+                                :command :run.set-resolution
+                                :check true
+                                :user-data {:width 1242
+                                            :height 2688}}
+                               {:label "iPhone XR (828x1792)"
+                                :command :run.set-resolution
+                                :check true
+                                :user-data {:width 828
+                                            :height 1792}}
+                               {:label "iPhone 12 Pro Max/13 Pro Max/14 Plus (1284x2778)"
+                                :command :run.set-resolution
+                                :check true
+                                :user-data {:width 1284
+                                            :height 2778}}
+                               {:label "iPhone 14 Pro Max/15 Plus/15 Pro Max (1290x2796)"
+                                :command :run.set-resolution
+                                :check true
+                                :user-data {:width 1290
+                                            :height 2796}}]}
+                   {:label "iPad"
+                    :children [{:label "Viewport Resolutions"
+                                :command :private/disabled-menu-label}
+                               {:label "iPad Pro (1024x1366)"
+                                :command :run.set-resolution
+                                :check true
+                                :user-data {:width 1024
+                                            :height 1366}}
+                               {:label "iPad (768x1024)"
+                                :command :run.set-resolution
+                                :check true
+                                :user-data {:width 768
+                                            :height 1024}}
+                               {:label :separator}
+                               {:label "Native Resolutions"
+                                :command :private/disabled-menu-label}
+                               {:label "iPad Pro (2048x2732)"
+                                :command :run.set-resolution
+                                :check true
+                                :user-data {:width 2048
+                                            :height 2732}}
+                               {:label "iPad (1536x2048)"
+                                :command :run.set-resolution
+                                :check true
+                                :user-data {:width 1536
+                                            :height 2048}}
+                               {:label "iPad Mini (768x1024)"
+                                :command :run.set-resolution
+                                :check true
+                                :user-data {:width 768
+                                            :height 1024}}]}]}
+       {:label "Android Devices"
+        :children [{:label "Viewport Resolutions"
+                    :command :private/disabled-menu-label}
+                   {:label "Samsung Galaxy S7 (360x640)"
+                    :command :run.set-resolution
+                    :check true
+                    :user-data {:width 360
+                                :height 640}}
+                   {:label "Samsung Galaxy S8/S9/Note 9 (360x740)"
+                    :command :run.set-resolution
+                    :check true
+                    :user-data {:width 360
+                                :height 740}}
+                   {:label "Google Pixel 1/2/XL (412x732)"
+                    :command :run.set-resolution
+                    :check true
+                    :user-data {:width 412
+                                :height 732}}
+                   {:label "Google Pixel 3 (412x824)"
+                    :command :run.set-resolution
+                    :check true
+                    :user-data {:width 412
+                                :height 824}}
+                   {:label "Google Pixel 3 XL (412x847)"
+                    :command :run.set-resolution
+                    :check true
+                    :user-data {:width 412
+                                :height 847}}
+                   {:label :separator}
+                   {:label "Native Resolutions"
+                    :command :private/disabled-menu-label}
+                   {:label "Samsung Galaxy S7 (1440x2560)"
+                    :command :run.set-resolution
+                    :check true
+                    :user-data {:width 1440
+                                :height 2560}}
+                   {:label "Samsung Galaxy S8/S9/Note 9 (1440x2960)"
+                    :command :run.set-resolution
+                    :check true
+                    :user-data {:width 1440
+                                :height 2960}}
+                   {:label "Google Pixel (1080x1920)"
+                    :command :run.set-resolution
+                    :check true
+                    :user-data {:width 1080
+                                :height 1920}}
+                   {:label "Google Pixel 2/XL (1440x2560)"
+                    :command :run.set-resolution
+                    :check true
+                    :user-data {:width 1440
+                                :height 2560}}
+                   {:label "Google Pixel 3 (1080x2160)"
+                    :command :run.set-resolution
+                    :check true
+                    :user-data {:width 1080
+                                :height 2160}}
+                   {:label "Google Pixel 3 XL (1440x2960)"
+                    :command :run.set-resolution
+                    :check true
+                    :user-data {:width 1440
+                                :height 2960}}]}
+       {:label "Handheld"
+        :children [{:label "Native Resolutions"
+                    :command :private/disabled-menu-label}
+                   {:label "1080p (1920x1080)"
+                    :command :run.set-resolution
+                    :check true
+                    :user-data {:width 1920
+                                :height 1080}}
+                   {:label "720p (1280x720)"
+                    :command :run.set-resolution
+                    :check true
+                    :user-data {:width 1280
+                                :height 720}}
+                   {:label "Steam Deck (1280x800)"
+                    :command :run.set-resolution
+                    :check true
+                    :user-data {:width 1280
+                                :height 800}}]}]))
+  (run [project prefs user-data]
+    (if (= :custom user-data)
+      (let [data (or (prefs/get prefs [:run :simulated-resolution])
+                     (project-settings-screen-data project))]
+        (when-let [{:keys [width height]} (dialogs/make-resolution-dialog data)]
+          (prefs/set! prefs [:run :simulated-resolution] {:width width :height height :custom true})
+          (change-resolution! prefs width height)))
+      (do (prefs/set! prefs [:run :simulated-resolution] user-data)
+          (change-resolution! prefs (:width user-data) (:height user-data)))))
   (state [user-data prefs]
-         (= user-data (prefs/get prefs [:run :simulated-resolution]))))
+    (if (= :custom user-data)
+      (:custom (prefs/get prefs [:run :simulated-resolution]))
+      (= user-data (prefs/get prefs [:run :simulated-resolution])))))
 
-(handler/defhandler :reset-custom-resolution :global
+(handler/defhandler :run.reset-resolution :global
   (enabled? [prefs] (prefs/get prefs [:run :simulated-resolution]))
   (run [project prefs]
        (prefs/set! prefs [:run :simulated-resolution] nil)
@@ -650,21 +865,7 @@
        (let [project-settings-data (project-settings-screen-data project)]
          (change-resolution! prefs (:width project-settings-data) (:height project-settings-data)))))
 
-(handler/defhandler :set-custom-resolution :global
-  (enabled? [] true)
-  (run [project prefs user-data]
-       (let [data (or (prefs/get prefs [:run :simulated-resolution])
-                      (project-settings-screen-data project))]
-         (when-let [{:keys [width height]} (dialogs/make-resolution-dialog data)]
-           (prefs/set! prefs [:run :simulated-resolution] {:width width :height height :custom true})
-           (change-resolution! prefs width height))))
-  (state [user-data prefs]
-         (let [data (prefs/get prefs [:run :simulated-resolution])]
-           (when data
-             (:custom data)))))
-
-(handler/defhandler :set-rotate-device :global
-  (enabled? [] true)
+(handler/defhandler :run.toggle-device-rotated :global
   (run [project app-view prefs build-errors-view selection user-data workspace]
        (prefs/set! prefs [:run :simulate-rotated-device] (not (simulate-rotated-device? prefs)))
        (let [data (prefs/get prefs [:run :simulated-resolution])]
@@ -672,246 +873,42 @@
            (change-resolution! prefs (:width data) (:height data)))))
   (state [app-view user-data prefs workspace] (simulate-rotated-device? prefs)))
 
-(handler/defhandler :disabled-menu-label :global
+(handler/defhandler :private/disabled-menu-label :global
   (enabled? [] false))
 
 (handler/register-menu! ::menubar :editor.defold-project/project
   [{:label "Debug"
     :id ::debug
     :children [{:label start-debugger-label
-                :command :start-debugger}
+                :command :debugger.start}
                {:label continue-label
-                :command :continue}
+                :command :debugger.continue}
                {:label break-label
-                :command :break}
+                :command :debugger.break}
                {:label step-over-label
-                :command :step-over}
+                :command :debugger.step-over}
                {:label step-into-label
-                :command :step-into}
+                :command :debugger.step-into}
                {:label step-out-label
-                :command :step-out}
+                :command :debugger.step-out}
                {:label :separator}
                {:label detach-debugger-label
-                :command :detach-debugger}
+                :command :debugger.detach}
                {:label stop-debugger-label
-                :command :stop-debugger}
+                :command :debugger.stop}
                {:label :separator}
                {:label open-engine-profiler-label
-                :command :engine-profile-show}
+                :command :run.open-profiler}
                {:label open-engine-resource-profiler-label
-                :command :engine-resource-profile-show}
+                :command :run.open-resource-profiler}
                {:label :separator}
-               {:label "Simulate Resolution"
-                :children [{:label "Reset Simulated Resolution"
-                            :command :reset-custom-resolution}
-                           {:label :separator}
-                           {:label "Custom Resolution..."
-                            :command :set-custom-resolution
-                            :check true}
-                           {:label "Apple"
-                            :children [{:label "iPhone"
-                                        :children [{:label "Viewport Resolutions"
-                                                    :command :disabled-menu-label}
-                                                   {:label "iPhone 4 (320x480)"
-                                                    :command :set-resolution
-                                                    :check true
-                                                    :user-data {:width 320
-                                                                :height 480}}
-                                                   {:label "iPhone 5/SE (320x568)"
-                                                    :command :set-resolution
-                                                    :check true
-                                                    :user-data {:width 320
-                                                                :height 568}}
-                                                   {:label "iPhone 6/7/8 (375x667)"
-                                                    :command :set-resolution
-                                                    :check true
-                                                    :user-data {:width 375
-                                                                :height 667}}
-                                                   {:label "iPhone 6/7/8 Plus (414x736)"
-                                                    :command :set-resolution
-                                                    :check true
-                                                    :user-data {:width 414
-                                                                :height 736}}
-                                                   {:label "iPhone X/XS (375x812)"
-                                                    :command :set-resolution
-                                                    :check true
-                                                    :user-data {:width 375
-                                                                :height 812}}
-                                                   {:label "iPhone XR/XS Max (414x896)"
-                                                    :command :set-resolution
-                                                    :check true
-                                                    :user-data {:width 414
-                                                                :height 896}}
-                                                   {:label "iPhone 12 Pro Max/13 Pro Max/14 Plus (428x926)"
-                                                    :command :set-resolution
-                                                    :check true
-                                                    :user-data {:width 428
-                                                                :height 926}}
-                                                   {:label "iPhone 14 Pro Max/15 Plus/15 Pro Max (430x932)"
-                                                    :command :set-resolution
-                                                    :check true
-                                                    :user-data {:width 430
-                                                                :height 932}}
-                                                   {:label :separator}
-                                                   {:label "Native Resolutions"
-                                                    :command :disabled-menu-label}
-                                                   {:label "iPhone 4 (640x960)"
-                                                    :command :set-resolution
-                                                    :check true
-                                                    :user-data {:width 640
-                                                                :height 960}}
-                                                   {:label "iPhone 5/SE (640x1136)"
-                                                    :command :set-resolution
-                                                    :check true
-                                                    :user-data {:width 640
-                                                                :height 1136}}
-                                                   {:label "iPhone 6/7/8 (750x1334)"
-                                                    :command :set-resolution
-                                                    :check true
-                                                    :user-data {:width 750
-                                                                :height 1334}}
-                                                   {:label "iPhone 6/7/8 Plus (1242x2208)"
-                                                    :command :set-resolution
-                                                    :check true
-                                                    :user-data {:width 1242
-                                                                :height 2208}}
-                                                   {:label "iPhone X/XS/11 Pro (1125x2436)"
-                                                    :command :set-resolution
-                                                    :check true
-                                                    :user-data {:width 1125
-                                                                :height 2436}}
-                                                   {:label "iPhone XS Max/11 Pro Max (1242x2688)"
-                                                    :command :set-resolution
-                                                    :check true
-                                                    :user-data {:width 1242
-                                                                :height 2688}}
-                                                   {:label "iPhone XR (828x1792)"
-                                                    :command :set-resolution
-                                                    :check true
-                                                    :user-data {:width 828
-                                                                :height 1792}}
-                                                   {:label "iPhone 12 Pro Max/13 Pro Max/14 Plus (1284x2778)"
-                                                    :command :set-resolution
-                                                    :check true
-                                                    :user-data {:width 1284
-                                                                :height 2778}}
-                                                   {:label "iPhone 14 Pro Max/15 Plus/15 Pro Max (1290x2796)"
-                                                    :command :set-resolution
-                                                    :check true
-                                                    :user-data {:width 1290
-                                                                :height 2796}}]}
-                                       {:label "iPad"
-                                        :children [{:label "Viewport Resolutions"
-                                                    :command :disabled-menu-label}
-                                                   {:label "iPad Pro (1024x1366)"
-                                                    :command :set-resolution
-                                                    :check true
-                                                    :user-data {:width 1024
-                                                                :height 1366}}
-                                                   {:label "iPad (768x1024)"
-                                                    :command :set-resolution
-                                                    :check true
-                                                    :user-data {:width 768
-                                                                :height 1024}}
-                                                   {:label :separator}
-                                                   {:label "Native Resolutions"
-                                                    :command :disabled-menu-label}
-                                                   {:label "iPad Pro (2048x2732)"
-                                                    :command :set-resolution
-                                                    :check true
-                                                    :user-data {:width 2048
-                                                                :height 2732}}
-                                                   {:label "iPad (1536x2048)"
-                                                    :command :set-resolution
-                                                    :check true
-                                                    :user-data {:width 1536
-                                                                :height 2048}}
-                                                   {:label "iPad Mini (768x1024)"
-                                                    :command :set-resolution
-                                                    :check true
-                                                    :user-data {:width 768
-                                                                :height 1024}}]}]}
-                           {:label "Android Devices"
-                            :children [{:label "Viewport Resolutions"
-                                        :command :disabled-menu-label}
-                                       {:label "Samsung Galaxy S7 (360x640)"
-                                        :command :set-resolution
-                                        :check true
-                                        :user-data {:width 360
-                                                    :height 640}}
-                                       {:label "Samsung Galaxy S8/S9/Note 9 (360x740)"
-                                        :command :set-resolution
-                                        :check true
-                                        :user-data {:width 360
-                                                    :height 740}}
-                                       {:label "Google Pixel 1/2/XL (412x732)"
-                                        :command :set-resolution
-                                        :check true
-                                        :user-data {:width 412
-                                                    :height 732}}
-                                       {:label "Google Pixel 3 (412x824)"
-                                        :command :set-resolution
-                                        :check true
-                                        :user-data {:width 412
-                                                    :height 824}}
-                                       {:label "Google Pixel 3 XL (412x847)"
-                                        :command :set-resolution
-                                        :check true
-                                        :user-data {:width 412
-                                                    :height 847}}
-                                       {:label :separator}
-                                       {:label "Native Resolutions"
-                                        :command :disabled-menu-label}
-                                       {:label "Samsung Galaxy S7 (1440x2560)"
-                                        :command :set-resolution
-                                        :check true
-                                        :user-data {:width 1440
-                                                    :height 2560}}
-                                       {:label "Samsung Galaxy S8/S9/Note 9 (1440x2960)"
-                                        :command :set-resolution
-                                        :check true
-                                        :user-data {:width 1440
-                                                    :height 2960}}
-                                       {:label "Google Pixel (1080x1920)"
-                                        :command :set-resolution
-                                        :check true
-                                        :user-data {:width 1080
-                                                    :height 1920}}
-                                       {:label "Google Pixel 2/XL (1440x2560)"
-                                        :command :set-resolution
-                                        :check true
-                                        :user-data {:width 1440
-                                                    :height 2560}}
-                                       {:label "Google Pixel 3 (1080x2160)"
-                                        :command :set-resolution
-                                        :check true
-                                        :user-data {:width 1080
-                                                    :height 2160}}
-                                       {:label "Google Pixel 3 XL (1440x2960)"
-                                        :command :set-resolution
-                                        :check true
-                                        :user-data {:width 1440
-                                                    :height 2960}}]}
-                           {:label "Handheld"
-                            :children [{:label "Native Resolutions"
-                                        :command :disabled-menu-label}
-                                       {:label "1080p (1920x1080)"
-                                        :command :set-resolution
-                                        :check true
-                                        :user-data {:width 1920
-                                                    :height 1080}}
-                                       {:label "720p (1280x720)"
-                                        :command :set-resolution
-                                        :check true
-                                        :user-data {:width 1280
-                                                    :height 720}}
-                                       {:label "Steam Deck (1280x800)"
-                                        :command :set-resolution
-                                        :check true
-                                        :user-data {:width 1280
-                                                    :height 800}}]}
-                           {:label "Rotated Device"
-                            :command :set-rotate-device
-                            :check true}]}
+               {:label "Reset Simulated Resolution"
+                :command :run.reset-resolution}
+               {:label "Set Resolution"
+                :command :run.set-resolution
+                :expand? true}
+               {:label "Rotated Device"
+                :command :run.toggle-device-rotated
+                :check true}
                {:label :separator
                 :id ::debug-end}]}])

--- a/editor/src/clj/editor/debug_view.clj
+++ b/editor/src/clj/editor/debug_view.clj
@@ -906,7 +906,7 @@
                 :command :run.reset-resolution}
                {:label "Set Resolution"
                 :command :run.set-resolution
-                :expand? true}
+                :expand true}
                {:label "Rotated Device"
                 :command :run.toggle-device-rotated
                 :check true}

--- a/editor/src/clj/editor/defold_project.clj
+++ b/editor/src/clj/editor/defold_project.clj
@@ -1100,13 +1100,13 @@
           :fail
           nil)))))
 
-(handler/defhandler :undo :global
+(handler/defhandler :edit.undo :global
   (enabled? [project-graph] (g/has-undo? project-graph))
   (run [project-graph]
     (g/undo! project-graph)
     (lsp/check-if-polled-resources-are-modified! (lsp/get-graph-lsp project-graph))))
 
-(handler/defhandler :redo :global
+(handler/defhandler :edit.redo :global
   (enabled? [project-graph] (g/has-redo? project-graph))
   (run [project-graph]
     (g/redo! project-graph)
@@ -1116,27 +1116,27 @@
   [{:label "Project"
     :id ::project
     :children [{:label "Build"
-                :command :build}
-               {:label "Rebuild"
-                :command :rebuild}
+                :command :project.build}
+               {:label "Clean Build"
+                :command :project.clean-build}
                {:label "Build HTML5"
-                :command :build-html5}
-               {:label "Rebuild HTML5"
-                :command :rebuild-html5}
+                :command :project.build-html5}
+               {:label "Clean Build HTML5"
+                :command :project.clean-build-html5}
                {:label "Bundle"
                 :id ::bundle
-                :command :bundle}
+                :command :project.bundle}
                {:label "Rebundle"
-                :command :rebundle}
+                :command :project.rebundle}
                {:label "Fetch Libraries"
-                :command :fetch-libraries}
+                :command :project.fetch-libraries}
                {:label "Reload Editor Scripts"
-                :command :reload-extensions}
+                :command :project.reload-editor-scripts}
                {:label :separator}
                {:label "Shared Editor Settings"
-                :command :shared-editor-settings}
+                :command :file.open-shared-editor-settings}
                {:label "Live Update Settings"
-                :command :live-update-settings}
+                :command :file.open-liveupdate-settings}
                {:label :separator
                 :id ::targets}
                {:label :separator

--- a/editor/src/clj/editor/dialogs.clj
+++ b/editor/src/clj/editor/dialogs.clj
@@ -34,7 +34,6 @@
             [editor.field-expression :as field-expression]
             [editor.fxui :as fxui]
             [editor.github :as github]
-            [editor.handler :as handler]
             [editor.os :as os]
             [editor.progress :as progress]
             [editor.ui :as ui]
@@ -46,7 +45,6 @@
            [javafx.application Platform]
            [javafx.collections ListChangeListener]
            [javafx.event Event]
-           [javafx.scene Node]
            [javafx.scene.control ListView TextField]
            [javafx.scene.input KeyCode KeyEvent MouseButton MouseEvent]
            [javafx.stage DirectoryChooser FileChooser FileChooser$ExtensionFilter Stage Window]
@@ -504,25 +502,6 @@
         (.setInitialDirectory initial-dir)
         (.setTitle title))
       (.showDialog owner-window)))
-
-(handler/defhandler ::confirm :dialog
-  (enabled? [selection]
-            (seq selection))
-  (run [^Stage stage selection]
-       (ui/user-data! stage ::selected-items selection)
-       (ui/close! stage)))
-
-(handler/defhandler ::close :dialog
-  (run [^Stage stage]
-       (ui/close! stage)))
-
-(handler/defhandler ::focus :dialog
-  (active? [user-data] (if-let [active-fn (:active-fn user-data)]
-                         (active-fn nil)
-                         true))
-  (run [^Stage stage user-data]
-       (when-let [^Node node (:node user-data)]
-         (ui/request-focus! node))))
 
 (defn- default-filter-fn [filter-on text items]
   (let [text (string/lower-case text)]

--- a/editor/src/clj/editor/editor_extensions.clj
+++ b/editor/src/clj/editor/editor_extensions.clj
@@ -582,21 +582,7 @@
 ;; region reload
 
 (def commands-coercer
-  (coerce/vector-of
-    (coerce/hash-map
-      :req {:label coerce/string
-            :locations (coerce/vector-of
-                         (coerce/enum "Assets" "Bundle" "Debug" "Edit" "Outline" "Project" "View")
-                         :distinct true
-                         :min-count 1)}
-      :opt {:query (coerce/hash-map
-                     :opt {:selection (coerce/hash-map
-                                        :req {:type (coerce/enum :resource :outline)
-                                              :cardinality (coerce/enum :one :many)})
-                           :argument (coerce/const true)})
-            :id prefs-docs/serializable-keyword-coercer
-            :active coerce/function
-            :run coerce/function})))
+  (coerce/vector-of commands/command-coercer))
 
 (defn- reload-commands! [project state evaluation-context]
   (let [{:keys [display-output! rt]} state]
@@ -854,6 +840,7 @@
                                "get" (make-ext-get-fn project)
                                "can_get" (make-ext-can-get-fn project)
                                "can_set" (make-ext-can-set-fn project)
+                               "command" commands/ext-command-fn
                                "create_directory" (make-ext-create-directory-fn project reload-resources!)
                                "delete_directory" (make-ext-delete-directory-fn project reload-resources!)
                                "resource_attributes" (make-ext-resource-attributes-fn project)

--- a/editor/src/clj/editor/editor_extensions/docs.clj
+++ b/editor/src/clj/editor/editor_extensions/docs.clj
@@ -64,6 +64,68 @@
                           :types ["boolean"]
                           :doc ""}]
           :description "Check if `\"set\"` action with this property won't throw an error"}
+         {:name "editor.command"
+          :type :function
+          :description "Create an editor command"
+          :parameters [{:name "opts"
+                        :types ["table"]
+                        :doc (str "A table with the following keys:"
+                                  (lua-completion/args-doc-html
+                                    [{:name "label"
+                                      :types ["string"]
+                                      :doc "required, user-visible command name"}
+                                     {:name "locations"
+                                      :types ["string[]"]
+                                      :doc "required, a non-empty list of locations where the command is displayed in the editor, values are either <code>\"Edit\"</code>, <code>\"View\"</code>, <code>\"Project\"</code>, <code>\"Debug\"</code> (the editor menubar), <code>\"Assets\"</code> (the assets pane), or <code>\"Outline\"</code> (the outline pane)"}
+                                     {:name "query"
+                                      :types ["table"]
+                                      :doc (str "optional, a query that both controls the command availability and provides additional information to the command handler functions; a table with the following keys:"
+                                                (lua-completion/args-doc-html
+                                                  [{:name "selection"
+                                                    :types ["table"]
+                                                    :doc (str "current selection, a table with the following keys:"
+                                                              (lua-completion/args-doc-html
+                                                                [{:name "type"
+                                                                  :types ["string"]
+                                                                  :doc "either <code>\"resource\"</code> (selected resource) or <code>\"outline\"</code> (selected outline node)"}
+                                                                 {:name "cardinality"
+                                                                  :types ["string"]
+                                                                  :doc "either <code>\"one\"</code> (will use first selected item) or <code>\"many\"</code> (will use all selected items)"}]))}
+                                                   {:name "argument"
+                                                    :types ["table"]
+                                                    :doc "the command argument"}]))}
+                                     {:name "id"
+                                      :types ["string"]
+                                      :doc "optional, keyword identifier that may be used for assigning a shortcut to a command; should be a dot-separated identifier string, e.g. <code>\"my-extension.do-stuff\"</code>"}
+                                     {:name "active"
+                                      :types ["function"]
+                                      :doc "optional function that additionally checks if a command is active in the current context; will receive opts table with values populated by the query; should be fast to execute since the editor might invoke it in response to UI interactions (on key typed, mouse clicked)"}
+                                     {:name "run"
+                                      :types ["function"]
+                                      :doc "optional function that is invoked when the user decides to execute the command; will receive opts table with values populated by the query"}]))}]
+          :returnvalues [{:name "command"
+                          :types ["command"]
+                          :doc ""}]
+          :examples "Print Git history for a file:
+```
+editor.command({
+  label = \"Git History\",
+  query = {
+    selection = {
+      type = \"resource\",
+      cardinality = \"one\"
+    }
+  },
+  run = function(opts)
+    editor.execute(
+      \"git\",
+      \"log\",
+      \"--follow\",
+      \".\" .. editor.get(opts.selection, \"path\"),
+      {reload_resources=false})
+  end
+})
+```"}
          {:name "editor.resource_attributes"
           :type :function
           :description "Query information about a project resource"

--- a/editor/src/clj/editor/editor_extensions/prefs_docs.clj
+++ b/editor/src/clj/editor/editor_extensions/prefs_docs.clj
@@ -36,7 +36,7 @@
   (coerce/wrap-with-pred coerce/userdata editor-script-defined-schema? "is not a schema"))
 
 (definline allowed-keyword-character? [ch]
-  `(or (Character/isLetterOrDigit (char ~ch)) (= \- ~ch) (= \_ ~ch)))
+  `(or (Character/isLetterOrDigit (char ~ch)) (= \- ~ch) (= \. ~ch) (= \_ ~ch)))
 
 (defn- edn-serializable-keyword-name? [^String s]
   (let [n (.length s)]

--- a/editor/src/clj/editor/editor_extensions/ui_components.clj
+++ b/editor/src/clj/editor/editor_extensions/ui_components.clj
@@ -183,16 +183,7 @@
 
 (defn- scroll-view [{:keys [content]}]
   {:fx/type fxui/scroll
-   :content content}
-  ;; We need to set ScrollPane skin, so it creates ScrollBars, so we can grow
-  ;; the content to fill the ScrollPane
-  #_{:fx/type ext-with-expanded-scroll-pane-content-props
-     :props {:content content}
-     :desc {:fx/type ext-with-scroll-pane-skin-props
-            :props {:skin true}
-            :desc {:fx/type fx.scroll-pane/lifecycle
-                   :style-class "ext-scroll-pane"
-                   :fit-to-width true}}})
+   :content content})
 
 (defn- apply-constraints [props props-key lifecycle grow-key constraints]
   (assoc props props-key (mapv (fn [maybe-constraint]

--- a/editor/src/clj/editor/editor_extensions/ui_components.clj
+++ b/editor/src/clj/editor/editor_extensions/ui_components.clj
@@ -22,7 +22,6 @@
             [cljfx.fx.label :as fx.label]
             [cljfx.fx.region :as fx.region]
             [cljfx.fx.row-constraints :as fx.row-constraints]
-            [cljfx.fx.scroll-pane :as fx.scroll-pane]
             [cljfx.fx.stage :as fx.stage]
             [cljfx.fx.tooltip :as fx.tooltip]
             [cljfx.fx.v-box :as fx.v-box]
@@ -53,16 +52,12 @@
            [java.nio.file Path]
            [java.util Collection List]
            [javafx.animation SequentialTransition TranslateTransition]
-           [javafx.beans Observable]
-           [javafx.beans.binding Bindings]
            [javafx.beans.property ReadOnlyProperty]
            [javafx.beans.value ChangeListener]
            [javafx.event Event]
            [javafx.scene Node]
-           [javafx.scene.control CheckBox ComboBox ScrollPane TextField]
-           [javafx.scene.control.skin ScrollPaneSkin]
+           [javafx.scene.control CheckBox ComboBox TextField]
            [javafx.scene.input KeyCode KeyEvent]
-           [javafx.scene.layout Region]
            [javafx.stage DirectoryChooser FileChooser FileChooser$ExtensionFilter]
            [javafx.util Duration]
            [org.luaj.vm2 LuaError LuaValue]))
@@ -147,39 +142,6 @@
     :left (assoc props :alignment :center-left)
     :right (assoc props :alignment :center-right)
     :bottom (assoc props :alignment :bottom-center)))
-
-(def ^:private ext-with-expanded-scroll-pane-content-props
-  (fx/make-ext-with-props
-    {:content (fx.prop/make
-                (fx.mutator/adder-remover
-                  (fn add-scroll-pane-content [^ScrollPane scroll-pane ^Region content]
-                    (let [^Region scroll-bar (.lookup scroll-pane ".ext-scroll-pane>.scroll-bar:horizontal")]
-                      (.setContent scroll-pane content)
-                      (.bind (.minHeightProperty content)
-                             (Bindings/createDoubleBinding
-                               (fn []
-                                 (cond-> (.getHeight scroll-pane)
-                                         (.isVisible scroll-bar)
-                                         (- (.getHeight scroll-bar))))
-                               (into-array
-                                 Observable
-                                 [(.heightProperty scroll-pane)
-                                  (.visibleProperty scroll-bar)
-                                  (.heightProperty scroll-bar)])))))
-                  (fn remove-scroll-pane-content [_ ^Region content]
-                    (.unbind (.minHeightProperty content))))
-                fx.lifecycle/dynamic)}))
-
-(def ^:private ext-with-scroll-pane-skin-props
-  (fx/make-ext-with-props
-    {:skin (fx.prop/make
-             (fx.mutator/adder-remover
-               (fn add-skin [^ScrollPane instance flag]
-                 {:pre [(true? flag)]}
-                 (.setSkin instance (ScrollPaneSkin. instance)))
-               (fn remove-skin [_ _]
-                 (throw (AssertionError. "Can't remove skin!"))))
-             fx.lifecycle/scalar)}))
 
 (defn- scroll-view [{:keys [content]}]
   {:fx/type fxui/scroll

--- a/editor/src/clj/editor/engine_profiler.clj
+++ b/editor/src/clj/editor/engine_profiler.clj
@@ -21,13 +21,13 @@
 
 (def ^:private port 17815)
 
-(handler/defhandler :engine-profile-show :global
+(handler/defhandler :run.open-profiler :global
   (run [web-server prefs]
        (if (nil? (:address (targets/selected-target prefs)))
          (ui/open-url (format "%s/engine-profiler" (http-server/local-url web-server)))
          (ui/open-url (format "%s/engine-profiler?addr=%s:%d" (http-server/local-url web-server) (:address (targets/selected-target prefs)) port)))))
 
-(handler/defhandler :engine-resource-profile-show :global
+(handler/defhandler :run.open-resource-profiler :global
   (enabled? [prefs] (some? (targets/selected-target prefs)))
   (run [prefs]
        (let [address (:address (targets/selected-target prefs))]

--- a/editor/src/clj/editor/game_object.clj
+++ b/editor/src/clj/editor/game_object.clj
@@ -505,7 +505,7 @@
 (defn- selection->game-object [selection]
   (g/override-root (handler/adapt-single selection GameObjectNode)))
 
-(handler/defhandler :add-from-file :workbench
+(handler/defhandler :edit.add-referenced-component :workbench
   (active? [selection] (selection->game-object selection))
   (label [] "Add Component File")
   (run [workspace project selection app-view]
@@ -569,12 +569,12 @@
     (->> (embeddable-component-resource-types workspace)
          (map (fn [res-type] {:label (or (:label res-type) (:ext res-type))
                               :icon (:icon res-type)
-                              :command :add
+                              :command :edit.add-embedded-component
                               :user-data {:_node-id self :resource-type res-type :workspace workspace}}))
          (sort-by :label)
          vec)))
 
-(handler/defhandler :add :workbench
+(handler/defhandler :edit.add-embedded-component :workbench
   (label [user-data] (add-embedded-component-label user-data))
   (active? [selection] (selection->game-object selection))
   (run [user-data app-view] (add-embedded-component-handler user-data (fn [node-ids] (app-view/select app-view node-ids))))

--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -3508,7 +3508,7 @@
     (add-gui-node-with-props! scene parent node-type custom-type props select-fn))))
 
 (defn- make-add-handler [scene parent label icon handler-fn user-data]
-  {:label label :icon icon :command :add
+  {:label label :icon icon :command :edit.add-embedded-component
    :user-data (merge {:handler-fn handler-fn :scene scene :parent parent} user-data)})
 
 (defn- add-handler-options [node]
@@ -3560,7 +3560,7 @@
       (mapv #(make-add-handler scene parent % layout-icon add-layout-handler {:display-profile %})
             (g/node-value scene :unused-display-profiles evaluation-context)))))
 
-(handler/defhandler :add :workbench
+(handler/defhandler :edit.add-embedded-component :workbench
   (active? [selection] (not-empty (some->> (handler/selection->node-id selection) add-handler-options)))
   (run [project user-data app-view] (when user-data ((:handler-fn user-data) project user-data (fn [node-ids] (app-view/select app-view node-ids)))))
   (options [selection user-data]
@@ -4021,7 +4021,7 @@
 (defn- selection->layer-node [selection]
   (g/override-root (handler/adapt-single selection LayerNode)))
 
-(handler/defhandler :move-up :workbench
+(handler/defhandler :edit.reorder-up :workbench
   (active? [selection] (or (selection->gui-node selection)
                            (selection->layer-node selection)))
   (enabled? [selection] (let [selected-node-id (g/override-root (handler/selection->node-id selection))
@@ -4032,7 +4032,7 @@
   (run [selection] (let [selected (g/override-root (handler/selection->node-id selection))]
                      (move-child-node! selected -1))))
 
-(handler/defhandler :move-down :workbench
+(handler/defhandler :edit.reorder-down :workbench
   (active? [selection] (or (selection->gui-node selection)
                            (selection->layer-node selection)))
   (enabled? [selection] (let [selected-node-id (g/override-root (handler/selection->node-id selection))
@@ -4053,7 +4053,8 @@
      (when (and res-node (g/node-instance? GuiSceneNode res-node))
        res-node))))
 
-(handler/defhandler :set-gui-layout :workbench
+(handler/defhandler :scene.set-gui-layout :workbench
+  :label "Set GUI Layout"
   (active? [project active-resource evaluation-context]
            (boolean (resource->gui-scene project active-resource evaluation-context)))
   (run [project active-resource user-data] (when user-data
@@ -4063,7 +4064,7 @@
          (when-let [scene (resource->gui-scene project active-resource)]
            (let [visible (g/node-value scene :visible-layout)]
              {:label (if (empty? visible) "Default" visible)
-              :command :set-gui-layout
+              :command :scene.set-gui-layout
               :user-data visible})))
   (options [project active-resource user-data]
            (when-not user-data
@@ -4072,13 +4073,13 @@
                      layouts (cons "" layout-names)]
                  (for [l layouts]
                    {:label (if (empty? l) "Default" l)
-                    :command :set-gui-layout
+                    :command :scene.set-gui-layout
                     :user-data l}))))))
 
 (handler/register-menu! ::toolbar :visibility-settings
   [{:label :separator}
    {:icon layout-icon
-    :command :set-gui-layout
+    :command :scene.set-gui-layout
     :label "Test"}])
 
 ;; SDK api

--- a/editor/src/clj/editor/handler.clj
+++ b/editor/src/clj/editor/handler.clj
@@ -71,7 +71,9 @@
   (= (namespace x) synthetic-command-str))
 
 (defn private-command? [x]
-  (= (namespace x) "private"))
+  (case (namespace x)
+    "private" true
+    false))
 
 (defn- register [state registration menus handlers]
   (let [handlers (mapv (fn [h]

--- a/editor/src/clj/editor/handler.clj
+++ b/editor/src/clj/editor/handler.clj
@@ -70,6 +70,9 @@
 (defn synthetic-command? [x]
   (= (namespace x) synthetic-command-str))
 
+(defn private-command? [x]
+  (= (namespace x) "private"))
+
 (defn- register [state registration menus handlers]
   (let [handlers (mapv (fn [h]
                          (if (contains? h :command)
@@ -297,12 +300,18 @@
   ([name env selection-provider dynamics adapters]
    (->Context name env selection-provider dynamics adapters)))
 
-(defn available-commands []
-  (->> @state-atom
-       :handlers
-       keys
-       (e/map first)
-       (into #{})))
+(defn public-commands
+  "Returns a set of user-facing commands that may be e.g. assigned shortcuts"
+  ([]
+   (public-commands @state-atom))
+  ([handler-state]
+   (->> handler-state
+        :handlers
+        keys
+        (e/map first)
+        (e/remove synthetic-command?)
+        (e/remove private-command?)
+        (into #{}))))
 
 (defonce ^:private throwing-handlers (atom #{}))
 
@@ -369,12 +378,37 @@
 (defn options [[handler command-context]]
   (invoke-fnk handler :options command-context nil))
 
+(defn- flatten-menu-item-tree [item]
+  (->> item
+       :children
+       (e/mapcat (fn [child-item]
+                   (-> child-item
+                       (cond-> (not= :separator (:label child-item)) (update :label #(str (:label item) " → " %)))
+                       (flatten-menu-item-tree))))
+       (e/cons item)))
+
+(defn option-items
+  "Produce a flat list of options from menu items returned from options handler
+
+  Returns either a non-empty vector or nil"
+  [[{:keys [command]} :as handler+command-context]]
+  (when-let [opts (options handler+command-context)]
+    (->> opts
+         (e/mapcat flatten-menu-item-tree)
+         (e/remove #(= :separator (:label %)))
+         (e/filter #(= command (:command %)))
+         vec
+         coll/not-empty)))
+
 (defn- eval-dynamics [context]
   (cond-> context
     (contains? context :dynamics)
     (update :env merge (into {} (map (fn [[k [node v]]] [k (g/node-value (get-in context [:env node]) v)]) (:dynamics context))))))
 
 (defn active
+  ([command command-contexts]
+   (g/with-auto-evaluation-context evaluation-context
+     (active command command-contexts nil evaluation-context)))
   ([command command-contexts user-data]
    (g/with-auto-evaluation-context evaluation-context
      (active command command-contexts user-data evaluation-context)))

--- a/editor/src/clj/editor/html_view.clj
+++ b/editor/src/clj/editor/html_view.clj
@@ -101,17 +101,15 @@
 (defmethod url->command "open"
   [^URI uri {:keys [project]}]
   (let [params (query-params->map (.getQuery uri))
-        proj-path (:path params)
-        resource-id (project/get-resource-node project proj-path)
-        resource (g/node-value resource-id :resource)]
-    {:command   :open
-     :user-data {:resources [resource]}}))
+        proj-path (:path params)]
+    {:command   :file.open
+     :user-data proj-path}))
 
 (defmethod url->command "add-dependency"
   [^URI uri {:keys [project]}]
   (let [params (query-params->map (.getQuery uri))
         dep-url (:url params)]
-    {:command   :add-dependency
+    {:command   :private/add-dependency
      :user-data {:dep-url dep-url}}))
 
 (defmethod url->command :default
@@ -245,8 +243,6 @@
     (ui/children! parent [web-view])
     (ui/fill-control web-view)
 
-    (ui/context! web-view :browser {:web-engine web-engine} nil)
-
     (doto web-engine
       (.setOnAlert (ui/event-handler ev
                      (dialogs/make-info-dialog
@@ -265,10 +261,3 @@
                                 :id :html
                                 :label "Web"
                                 :make-view-fn make-view))
-
-(handler/defhandler :reload :browser
-  (run [^WebEngine web-engine]
-    (.reload web-engine)))
-
-(handler/register-menu! ::menubar :editor.app-view/edit-end
-  [{:command :reload :label "Reload"}])

--- a/editor/src/clj/editor/keymap.clj
+++ b/editor/src/clj/editor/keymap.clj
@@ -87,7 +87,7 @@
            ["Meta+B" :project.build]
            ["Meta+M" :project.build-html5]
            ["Meta+C" :edit.copy]
-           ["Meta+Comma" :file.preferences]
+           ["Meta+Comma" :app.preferences]
            ["Meta+D" :code.select-next-occurrence]
            ["Meta+Down" :code.goto-file-end]
            ["Meta+E" :scene.visibility.toggle-selection]
@@ -98,7 +98,7 @@
            ["Meta+N" :file.new]
            ["Meta+O" :file.open-selected]
            ["Meta+P" :file.open]
-           ["Meta+Q" :file.quit]
+           ["Meta+Q" :app.quit]
            ["Meta+R" :run.hot-reload]
            ["Meta+Right" :code.goto-line-end]
            ["Meta+S" :file.save-all]
@@ -149,7 +149,7 @@
            ["Shift+Meta+T" :file.reopen-recent]
            ["Shift+Meta+Up" :code.select-file-start]
            ["Shift+Meta+W" :window.tab.close-all]
-           ["Shift+Meta+Y" :project.load-external-changes]
+           ["Shift+Meta+Y" :file.load-external-changes]
            ["Shift+Meta+Z" :edit.redo]
            ["Shift+Page Down" :code.select-page-down]
            ["Shift+Page Up" :code.select-page-up]
@@ -182,7 +182,7 @@
            ["Ctrl+M" :project.build-html5]
            ["Ctrl+Backspace" :code.delete-previous-word]
            ["Ctrl+C" :edit.copy]
-           ["Ctrl+Comma" :file.preferences]
+           ["Ctrl+Comma" :app.preferences]
            ["Ctrl+D" :code.select-next-occurrence]
            ["Ctrl+Delete" :code.delete-next-word]
            ["Ctrl+E" :scene.visibility.toggle-selection]
@@ -198,7 +198,7 @@
            ["Ctrl+N" :file.new]
            ["Ctrl+O" :file.open-selected]
            ["Ctrl+P" :file.open]
-           ["Ctrl+Q" :file.quit]
+           ["Ctrl+Q" :app.quit]
            ["Ctrl+R" :run.hot-reload]
            ["Ctrl+Right" :code.goto-next-word]
            ["Ctrl+S" :file.save-all]
@@ -253,7 +253,7 @@
            ["Shift+Ctrl+Right" :code.select-next-word]
            ["Shift+Ctrl+T" :file.reopen-recent]
            ["Shift+Ctrl+W" :window.tab.close-all]
-           ["Shift+Ctrl+Y" :project.load-external-changes]
+           ["Shift+Ctrl+Y" :file.load-external-changes]
            ["Shift+Ctrl+Z" :edit.redo]
            ["Shift+Down" :scene.move-down-major]
            ["Shift+Down" :code.select-down]
@@ -296,7 +296,7 @@
            ["Ctrl+M" :project.build-html5]
            ["Ctrl+Backspace" :code.delete-previous-word]
            ["Ctrl+C" :edit.copy]
-           ["Ctrl+Comma" :file.preferences]
+           ["Ctrl+Comma" :app.preferences]
            ["Ctrl+D" :code.select-next-occurrence]
            ["Ctrl+Delete" :code.delete-next-word]
            ["Ctrl+E" :scene.visibility.toggle-selection]
@@ -312,7 +312,7 @@
            ["Ctrl+N" :file.new]
            ["Ctrl+O" :file.open-selected]
            ["Ctrl+P" :file.open]
-           ["Ctrl+Q" :file.quit]
+           ["Ctrl+Q" :app.quit]
            ["Ctrl+R" :run.hot-reload]
            ["Ctrl+Right" :code.goto-next-word]
            ["Ctrl+S" :file.save-all]
@@ -367,7 +367,7 @@
            ["Shift+Ctrl+Right" :code.select-next-word]
            ["Shift+Ctrl+T" :file.reopen-recent]
            ["Shift+Ctrl+W" :window.tab.close-all]
-           ["Shift+Ctrl+Y" :project.load-external-changes]
+           ["Shift+Ctrl+Y" :file.load-external-changes]
            ["Shift+Ctrl+Z" :edit.redo]
            ["Shift+Down" :scene.move-down-major]
            ["Shift+Down" :code.select-down]
@@ -677,11 +677,15 @@
   (get (:command->shortcuts keymap) command))
 
 (defn commands
-  "Returns a non-empty set of commands for a shortcut (or nil)"
-  [keymap shortcut]
-  {:pre [(or (string? shortcut) (instance? KeyCombination shortcut))]}
-  (let [shortcut (if (string? shortcut) (KeyCombination/valueOf shortcut) shortcut)]
-    (get (:shortcut->commands keymap) shortcut)))
+  "Returns a non-empty set of commands or nil
+
+  When provided a shortcut, returns commands or nil for the shortcut"
+  ([keymap]
+   (coll/not-empty (into #{} (keys (:command->shortcuts keymap)))))
+  ([keymap shortcut]
+   {:pre [(or (string? shortcut) (instance? KeyCombination shortcut))]}
+   (let [shortcut (if (string? shortcut) (KeyCombination/valueOf shortcut) shortcut)]
+     (get (:shortcut->commands keymap) shortcut))))
 
 (defn display-text
   "Return a display text string for one of its shortcuts (or not-found value)"
@@ -782,7 +786,7 @@
 
 (defn migrate-from-file! [prefs]
   (let [legacy-keymap-path (prefs/get prefs [:input :keymap-path])
-        legacy->new-command {:about :help.about
+        legacy->new-command {:about :app.about
                              :asset-portal :help.open-asset-portal
                              :documentation :help.open-documentation
                              :donate :help.open-donations
@@ -803,7 +807,7 @@
                              :rebuild :project.clean-build
                              :rebuild-html5 :project.clean-build-html5
                              :fetch-libraries :project.fetch-libraries
-                             :async-reload :project.load-external-changes
+                             :async-reload :file.load-external-changes
                              :rebundle :project.rebundle
                              :reload-extensions :project.reload-editor-scripts
                              :hot-reload :run.hot-reload
@@ -817,7 +821,7 @@
                              :close-other :window.tab.close-others
                              :join-tab-panes :window.tab.join-groups
                              :move-tab :window.tab.move-to-other-group
-                             :swap-tabs :window.tab.swap
+                             :swap-tabs :window.tab.swap-with-other-group
                              :break :debugger.break
                              :continue :debugger.continue
                              :detach-debugger :debugger.detach
@@ -835,18 +839,18 @@
                              :new-file :file.new
                              :new-folder :file.new-folder
                              :open-as :file.open-as
-                             :show-in-desktop :file.open-in-desktop
+                             :show-in-desktop :file.show-in-desktop
                              :live-update-settings :file.open-liveupdate-settings
                              :open-project :file.open-project
                              :open-recent-file :file.open-recent
                              :shared-editor-settings :file.open-shared-editor-settings
-                             :preferences :file.preferences
-                             :quit :file.quit
+                             :preferences :app.preferences
+                             :quit :app.quit
                              :show-search-results :window.show-search-results
                              :show-build-errors :window.show-build-errors
                              :show-console :window.show-console
                              :show-curve-editor :window.show-curve-editor
-                             :show-overrides :window.show-overrides
+                             :show-overrides :edit.show-overrides
                              :proposals :code.show-completions
                              :find-references :code.show-references
                              :goto-definition :code.goto-definition
@@ -887,8 +891,8 @@
                              :toggle-visibility-filters :scene.visibility.toggle-filters
                              :toggle-grid :scene.visibility.toggle-grid
                              :hide-toggle-selected :scene.visibility.toggle-selection
-                             :clear-console :window.clear-console
-                             :reload-stylesheet :window.reload-css
+                             :clear-console :console.clear
+                             :reload-stylesheet :dev.reload-css
                              :diff :vcs.diff
                              :revert :vcs.revert
                              :toggle-perspective-camera :scene.toggle-camera-type
@@ -956,7 +960,6 @@
                              :set-camera-type :scene.set-camera-type
                              :set-gui-layout :scene.set-gui-layout
                              :convert-indentation :code.convert-indentation
-                             :profile-show :dev.open-profiler
                              :find-text :edit.find
                              :filter-form :edit.find
                              :sort-lines :code.sort-lines

--- a/editor/src/clj/editor/keymap.clj
+++ b/editor/src/clj/editor/keymap.clj
@@ -13,11 +13,17 @@
 ;; specific language governing permissions and limitations under the License.
 
 (ns editor.keymap
-  (:require [editor.os :as os]
-            [editor.ui :as ui]
+  (:refer-clojure :exclude [empty])
+  (:require [clojure.edn :as edn]
+            [editor.os :as os]
+            [editor.prefs :as prefs]
+            [internal.util :as util]
+            [service.log :as log]
+            [util.coll :as coll]
+            [util.eduction :as e]
             [util.fn :as fn])
   (:import [javafx.scene Scene]
-           [javafx.scene.input KeyCharacterCombination KeyCodeCombination KeyCombination KeyCombination$ModifierValue KeyEvent]))
+           [javafx.scene.input KeyCharacterCombination KeyCode KeyCodeCombination KeyCombination KeyCombination$ModifierValue KeyEvent]))
 
 (set! *warn-on-reflection* true)
 
@@ -29,439 +35,365 @@
   ;; something you may want to type in the code editor.
   ;; The function key-binding-data->keymap attempts to catch this type
   ;; of mistake.
-  ;; Note that specifying Shortcut key (which is Meta on mac and Ctrl on windows
-  ;; and linux) is not allowed.
-  {:macos [["A" :add]
-           ["Alt+Backspace" :delete-prev-word]
-           ["Alt+Delete" :delete-next-word]
-           ["Alt+Down" :end-of-line]
-           ["Alt+Down" :move-down]
-           ["Alt+Left" :prev-word]
-           ["Alt+F9" :edit-breakpoint]
-           ["Alt+Meta+E" :select-next-occurrence]
-           ["Alt+Meta+F" :replace-text]
-           ["Alt+Meta+G" :replace-next]
-           ["Alt+Right" :next-word]
-           ["Alt+Space" :proposals]
-           ["Alt+Up" :beginning-of-line]
-           ["Alt+Up" :move-up]
-           ["Backspace" :delete-backward]
-           ["Ctrl+A" :beginning-of-line]
-           ["Ctrl+D" :delete-line]
-           ["Ctrl+E" :end-of-line]
-           ["Ctrl+I" :reindent]
-           ["Ctrl+K" :delete-to-end-of-line]
-           ["Ctrl+Meta+H" :toggle-component-guides]
-           ["Ctrl+R" :open-recent-file]
-           ["Ctrl+Space" :proposals]
-           ["Delete" :delete]
-           ["Down" :down]
-           ["E" :rotate-tool]
-           ["End" :end-of-line]
-           ["Enter" :enter]
-           ["Esc" :escape]
-           ["F" :frame-selection]
-           ["F1" :documentation]
-           ["F10" :step-over]
-           ["F11" :step-into]
-           ["F2" :rename]
-           ["F5" :start-debugger]
-           ["F5" :continue]
-           ["F6" :toggle-pane-left]
-           ["F7" :toggle-pane-bottom]
-           ["F8" :toggle-pane-right]
-           ["F9" :toggle-breakpoint]
-           ["F12" :goto-definition]
-           ["Home" :beginning-of-line-text]
-           ["Left" :left]
-           ["Meta+'+'" :zoom-in]
-           ["Meta+Add" :zoom-in]
-           ["Meta+'-'" :zoom-out]
-           ["Meta+Subtract" :zoom-out]
-           ["Meta+0" :reset-zoom]
-           ["Meta+A" :select-all]
-           ["Meta+B" :build]
-           ["Meta+M" :build-html5]
-           ["Meta+C" :copy]
-           ["Meta+Comma" :preferences]
-           ["Meta+D" :select-next-occurrence]
-           ["Meta+Delete" :delete-to-end-of-line]
-           ["Meta+Down" :end-of-file]
-           ["Meta+E" :hide-toggle-selected]
-           ["Meta+F" :filter-form]
-           ["Meta+F" :find-text]
-           ["Meta+G" :find-next]
-           ["Meta+L" :goto-line]
-           ["Meta+Left" :beginning-of-line-text]
-           ["Meta+N" :new-file]
-           ["Meta+O" :open]
-           ["Meta+P" :open-asset]
-           ["Meta+Q" :quit]
-           ["Meta+R" :hot-reload]
-           ["Meta+Right" :end-of-line]
-           ["Meta+S" :save-all]
-           ["Meta+'/'" :toggle-comment]
-           ["Meta+T" :scene-stop]
-           ["Meta+U" :rebundle]
-           ["Meta+J" :close-engine]
-           ["Meta+Up" :beginning-of-file]
-           ["Meta+V" :paste]
-           ["Meta+W" :close]
-           ["Meta+X" :cut]
-           ["Meta+Z" :undo]
-           ["Page Down" :page-down]
-           ["Page Up" :page-up]
-           ["Period" :realign-camera]
-           ["R" :scale-tool]
-           ["Right" :right]
-           ["Shift+A" :add-secondary]
-           ["Shift+Alt+Down" :select-end-of-line]
-           ["Shift+Alt+Left" :select-prev-word]
-           ["Shift+Alt+Right" :select-next-word]
-           ["Shift+Alt+Up" :select-beginning-of-line]
-           ["Shift+Backspace" :delete-backward]
-           ["Shift+Ctrl+A" :select-beginning-of-line]
-           ["Shift+Ctrl+E" :select-end-of-line]
-           ["Shift+Ctrl+Left" :select-prev-word]
-           ["Shift+Ctrl+Right" :select-next-word]
-           ["Shift+Down" :down-major]
-           ["Shift+Down" :select-down]
-           ["Shift+E" :erase-tool]
-           ["Shift+End" :select-end-of-line]
-           ["Shift+F11" :step-out]
-           ["Shift+F12" :find-references]
-           ["Shift+Home" :select-beginning-of-line-text]
-           ["Shift+Left" :left-major]
-           ["Shift+Left" :select-left]
-           ["Shift+Meta+B" :rebuild]
-           ["Shift+Meta+M" :rebuild-html5]
-           ["Shift+Meta+Delete" :delete-to-end-of-line]
-           ["Shift+Meta+Down" :select-end-of-file]
-           ["Shift+Meta+E" :show-last-hidden]
-           ["Shift+Meta+F" :search-in-files]
-           ["Shift+Meta+G" :find-prev]
-           ["Shift+Meta+I" :toggle-visibility-filters]
-           ["Shift+Meta+L" :split-selection-into-lines]
-           ["Shift+Meta+Left" :select-beginning-of-line-text]
-           ["Shift+Meta+R" :reload-extensions]
-           ["Shift+Meta+Right" :select-end-of-line]
-           ["Shift+Meta+T" :reopen-recent-file]
-           ["Shift+Meta+Up" :select-beginning-of-file]
-           ["Shift+Meta+W" :close-all]
-           ["Shift+Meta+Y" :async-reload]
-           ["Shift+Meta+Z" :redo]
-           ["Shift+Page Down" :select-page-down]
-           ["Shift+Page Up" :select-page-up]
-           ["Shift+Right" :right-major]
-           ["Shift+Right" :select-right]
-           ["Shift+Tab" :backwards-tab-trigger]
-           ["Shift+Up" :select-up]
-           ["Shift+Up" :up-major]
-           ["Space" :scene-play]
-           ["Space" :show-palette]
-           ["Tab" :tab]
-           ["Up" :up]
-           ["W" :move-tool]
-           ["X" :flip-brush-horizontally]
-           ["Y" :flip-brush-vertically]
-           ["Z" :rotate-brush-90-degrees]]
-   :win32 [["A" :add]
-           ["Alt+Down" :move-down]
-           ["Alt+F9" :edit-breakpoint]
-           ["Alt+R" :open-recent-file]
-           ["Alt+Up" :move-up]
-           ["Backspace" :delete-backward]
-           ["Ctrl+'+'" :zoom-in]
-           ["Ctrl+Add" :zoom-in]
-           ["Ctrl+'-'" :zoom-out]
-           ["Ctrl+Subtract" :zoom-out]
-           ["Ctrl+0" :reset-zoom]
-           ["Ctrl+A" :select-all]
-           ["Ctrl+B" :build]
-           ["Ctrl+M" :build-html5]
-           ["Ctrl+Backspace" :delete-prev-word]
-           ["Ctrl+C" :copy]
-           ["Ctrl+Comma" :preferences]
-           ["Ctrl+D" :select-next-occurrence]
-           ["Ctrl+Delete" :delete-next-word]
-           ["Ctrl+E" :hide-toggle-selected]
-           ["Ctrl+End" :end-of-file]
-           ["Ctrl+F" :filter-form]
-           ["Ctrl+F" :find-text]
-           ["Ctrl+G" :find-next]
-           ["Ctrl+H" :replace-text]
-           ["Ctrl+H" :toggle-component-guides]
-           ["Ctrl+Home" :beginning-of-file]
-           ["Ctrl+I" :reindent]
-           ["Ctrl+K" :delete-to-end-of-line]
-           ["Ctrl+L" :goto-line]
-           ["Ctrl+Left" :prev-word]
-           ["Ctrl+N" :new-file]
-           ["Ctrl+O" :open]
-           ["Ctrl+P" :open-asset]
-           ["Ctrl+Q" :quit]
-           ["Ctrl+R" :hot-reload]
-           ["Ctrl+Right" :next-word]
-           ["Ctrl+S" :save-all]
-           ["Ctrl+'/'" :toggle-comment]
-           ["Ctrl+Space" :proposals]
-           ["Ctrl+T" :scene-stop]
-           ["Ctrl+U" :rebundle]
-           ["Ctrl+J" :close-engine]
-           ["Ctrl+V" :paste]
-           ["Ctrl+W" :close]
-           ["Ctrl+X" :cut]
-           ["Ctrl+Z" :undo]
-           ["Delete" :delete]
-           ["Down" :down]
-           ["E" :rotate-tool]
-           ["End" :end-of-line]
-           ["Enter" :enter]
-           ["Esc" :escape]
-           ["F" :frame-selection]
-           ["F1" :documentation]
-           ["F10" :step-over]
-           ["F11" :step-into]
-           ["F2" :rename]
-           ["F5" :start-debugger]
-           ["F5" :continue]
-           ["F6" :toggle-pane-left]
-           ["F7" :toggle-pane-bottom]
-           ["F8" :toggle-pane-right]
-           ["F9" :toggle-breakpoint]
-           ["F12" :goto-definition]
-           ["Home" :beginning-of-line-text]
-           ["Left" :left]
-           ["Page Down" :page-down]
-           ["Page Up" :page-up]
-           ["Period" :realign-camera]
-           ["R" :scale-tool]
-           ["Right" :right]
-           ["Shift+A" :add-secondary]
-           ["Shift+Backspace" :delete-backward]
-           ["Shift+Ctrl+B" :rebuild]
-           ["Shift+Ctrl+M" :rebuild-html5]
-           ["Shift+Ctrl+Delete" :delete-to-end-of-line]
-           ["Shift+Ctrl+E" :show-last-hidden]
-           ["Shift+Ctrl+End" :select-end-of-file]
-           ["Shift+Ctrl+F" :search-in-files]
-           ["Shift+Ctrl+G" :find-prev]
-           ["Shift+Ctrl+H" :replace-next]
-           ["Shift+Ctrl+Home" :select-beginning-of-file]
-           ["Shift+Ctrl+I" :toggle-visibility-filters]
-           ["Shift+Ctrl+L" :split-selection-into-lines]
-           ["Shift+Ctrl+Left" :select-prev-word]
-           ["Shift+Ctrl+R" :reload-extensions]
-           ["Shift+Ctrl+Right" :select-next-word]
-           ["Shift+Ctrl+T" :reopen-recent-file]
-           ["Shift+Ctrl+W" :close-all]
-           ["Shift+Ctrl+Y" :async-reload]
-           ["Shift+Ctrl+Z" :redo]
-           ["Shift+Down" :down-major]
-           ["Shift+Down" :select-down]
-           ["Shift+E" :erase-tool]
-           ["Shift+End" :select-end-of-line]
-           ["Shift+F11" :step-out]
-           ["Shift+F12" :find-references]
-           ["Shift+F5" :stop-debugger]
-           ["Shift+Home" :select-beginning-of-line-text]
-           ["Shift+Left" :left-major]
-           ["Shift+Left" :select-left]
-           ["Shift+Page Down" :select-page-down]
-           ["Shift+Page Up" :select-page-up]
-           ["Shift+Right" :right-major]
-           ["Shift+Right" :select-right]
-           ["Shift+Tab" :backwards-tab-trigger]
-           ["Shift+Up" :select-up]
-           ["Shift+Up" :up-major]
-           ["Space" :scene-play]
-           ["Space" :show-palette]
-           ["Tab" :tab]
-           ["Up" :up]
-           ["W" :move-tool]
-           ["X" :flip-brush-horizontally]
-           ["Y" :flip-brush-vertically]
-           ["Z" :rotate-brush-90-degrees]]
-   :linux [["A" :add]
-           ["Alt+Down" :move-down]
-           ["Alt+F9" :edit-breakpoint]
-           ["Alt+R" :open-recent-file]
-           ["Alt+Up" :move-up]
-           ["Backspace" :delete-backward]
-           ["Ctrl+'+'" :zoom-in]
-           ["Ctrl+Add" :zoom-in]
-           ["Ctrl+'-'" :zoom-out]
-           ["Ctrl+Subtract" :zoom-out]
-           ["Ctrl+0" :reset-zoom]
-           ["Ctrl+A" :select-all]
-           ["Ctrl+B" :build]
-           ["Ctrl+M" :build-html5]
-           ["Ctrl+Backspace" :delete-prev-word]
-           ["Ctrl+C" :copy]
-           ["Ctrl+Comma" :preferences]
-           ["Ctrl+D" :select-next-occurrence]
-           ["Ctrl+Delete" :delete-next-word]
-           ["Ctrl+E" :hide-toggle-selected]
-           ["Ctrl+End" :end-of-file]
-           ["Ctrl+F" :filter-form]
-           ["Ctrl+F" :find-text]
-           ["Ctrl+G" :find-next]
-           ["Ctrl+H" :replace-text]
-           ["Ctrl+H" :toggle-component-guides]
-           ["Ctrl+Home" :beginning-of-file]
-           ["Ctrl+I" :reindent]
-           ["Ctrl+K" :delete-to-end-of-line]
-           ["Ctrl+L" :goto-line]
-           ["Ctrl+Left" :prev-word]
-           ["Ctrl+N" :new-file]
-           ["Ctrl+O" :open]
-           ["Ctrl+P" :open-asset]
-           ["Ctrl+Q" :quit]
-           ["Ctrl+R" :hot-reload]
-           ["Ctrl+Right" :next-word]
-           ["Ctrl+S" :save-all]
-           ["Ctrl+'/'" :toggle-comment]
-           ["Ctrl+Space" :proposals]
-           ["Ctrl+T" :scene-stop]
-           ["Ctrl+U" :rebundle]
-           ["Ctrl+J" :close-engine]
-           ["Ctrl+V" :paste]
-           ["Ctrl+W" :close]
-           ["Ctrl+X" :cut]
-           ["Ctrl+Z" :undo]
-           ["Delete" :delete]
-           ["Down" :down]
-           ["E" :rotate-tool]
-           ["End" :end-of-line]
-           ["Enter" :enter]
-           ["Esc" :escape]
-           ["F" :frame-selection]
-           ["F1" :documentation]
-           ["F10" :step-over]
-           ["F11" :step-into]
-           ["F2" :rename]
-           ["F5" :start-debugger]
-           ["F5" :continue]
-           ["F6" :toggle-pane-left]
-           ["F7" :toggle-pane-bottom]
-           ["F8" :toggle-pane-right]
-           ["F9" :toggle-breakpoint]
-           ["F12" :goto-definition]
-           ["Home" :beginning-of-line-text]
-           ["Left" :left]
-           ["Page Down" :page-down]
-           ["Page Up" :page-up]
-           ["Period" :realign-camera]
-           ["R" :scale-tool]
-           ["Right" :right]
-           ["Shift+A" :add-secondary]
-           ["Shift+Backspace" :delete-backward]
-           ["Shift+Ctrl+B" :rebuild]
-           ["Shift+Ctrl+M" :rebuild-html5]
-           ["Shift+Ctrl+Delete" :delete-to-end-of-line]
-           ["Shift+Ctrl+E" :show-last-hidden]
-           ["Shift+Ctrl+End" :select-end-of-file]
-           ["Shift+Ctrl+F" :search-in-files]
-           ["Shift+Ctrl+G" :find-prev]
-           ["Shift+Ctrl+H" :replace-next]
-           ["Shift+Ctrl+Home" :select-beginning-of-file]
-           ["Shift+Ctrl+I" :toggle-visibility-filters]
-           ["Shift+Ctrl+L" :split-selection-into-lines]
-           ["Shift+Ctrl+Left" :select-prev-word]
-           ["Shift+Ctrl+R" :reload-extensions]
-           ["Shift+Ctrl+Right" :select-next-word]
-           ["Shift+Ctrl+T" :reopen-recent-file]
-           ["Shift+Ctrl+W" :close-all]
-           ["Shift+Ctrl+Y" :async-reload]
-           ["Shift+Ctrl+Z" :redo]
-           ["Shift+Down" :down-major]
-           ["Shift+Down" :select-down]
-           ["Shift+E" :erase-tool]
-           ["Shift+End" :select-end-of-line]
-           ["Shift+F11" :step-out]
-           ["Shift+F12" :find-references]
-           ["Shift+F5" :stop-debugger]
-           ["Shift+Home" :select-beginning-of-line-text]
-           ["Shift+Left" :left-major]
-           ["Shift+Left" :select-left]
-           ["Shift+Page Down" :select-page-down]
-           ["Shift+Page Up" :select-page-up]
-           ["Shift+Right" :right-major]
-           ["Shift+Right" :select-right]
-           ["Shift+Tab" :backwards-tab-trigger]
-           ["Shift+Up" :select-up]
-           ["Shift+Up" :up-major]
-           ["Space" :scene-play]
-           ["Space" :show-palette]
-           ["Tab" :tab]
-           ["Up" :up]
-           ["W" :move-tool]
-           ["X" :flip-brush-horizontally]
-           ["Y" :flip-brush-vertically]
-           ["Z" :rotate-brush-90-degrees]]})
-
-(def default-host-key-bindings
-  (platform->default-key-bindings (os/os)))
-
-(def ^:private default-allowed-duplicate-shortcuts
-  #{"Alt+Down"
-    "Alt+Up"
-    "Ctrl+F"
-    "Ctrl+H"
-    "F5"
-    "Meta+F"
-    "Shift+Down"
-    "Shift+Left"
-    "Shift+Right"
-    "Shift+Up"
-    "Space"})
-
-;; These are only (?) used in contexts where there is no text field
-;; interested in the actual typable input.
-(def ^:private default-allowed-typable-shortcuts
-  #{"A"         ; :add
-    "E"         ; :rotate-tool
-    "F"         ; :frame-selection
-    "R"         ; :scale-tool
-    "W"         ; :move-tool
-    "X"         ; :flip-brush-horizontally
-    "Y"         ; :flip-brush-vertically
-    "Z"         ; :rotate-brush-90-degrees
-    "Shift+A"   ; :add-secondary
-    "Shift+E"}) ; :erase-tool
-
-(defprotocol KeyComboData
-  (key-combo->map [this] "returns a data representation of a KeyCombination."))
-
-(extend-protocol KeyComboData
-  KeyCodeCombination
-  (key-combo->map [key-combo]
-    {:key (.getName (.getCode key-combo))
-     :alt-down? (= KeyCombination$ModifierValue/DOWN (.getAlt key-combo))
-     :control-down? (= KeyCombination$ModifierValue/DOWN (.getControl key-combo))
-     :meta-down? (= KeyCombination$ModifierValue/DOWN (.getMeta key-combo))
-     :shift-down? (= KeyCombination$ModifierValue/DOWN (.getShift key-combo))
-     :shortcut-down? (= KeyCombination$ModifierValue/DOWN (.getShortcut key-combo))})
-
-  KeyCharacterCombination
-  (key-combo->map [key-combo]
-    {:key (.getCharacter key-combo)
-     :alt-down? (= KeyCombination$ModifierValue/DOWN (.getAlt key-combo))
-     :control-down? (= KeyCombination$ModifierValue/DOWN (.getControl key-combo))
-     :meta-down? (= KeyCombination$ModifierValue/DOWN (.getMeta key-combo))
-     :shift-down? (= KeyCombination$ModifierValue/DOWN (.getShift key-combo))
-     :shortcut-down? (= KeyCombination$ModifierValue/DOWN (.getShortcut key-combo))}))
-
-(defn key-event->map [^KeyEvent e]
-  {:key              (.getCharacter e)
-   :alt-down?        (.isAltDown e)
-   :control-down?    (.isControlDown e)
-   :meta-down?       (.isMetaDown e)
-   :shift-down?      (.isShiftDown e)
-   :shortcut-down?   (.isShortcutDown e)})
-
-(defn key-combo->display-text [s]
-  (.getDisplayText (KeyCombination/keyCombination s)))
+  ;; Note that specifying Shortcut key (which is Meta on macOS and Ctrl on
+  ;; Windows and Linux) is not allowed.
+  {:macos [["A" :edit.add-embedded-component]
+           ["Alt+Backspace" :code.delete-previous-word]
+           ["Alt+Delete" :code.delete-next-word]
+           ["Alt+Down" :code.goto-line-end]
+           ["Alt+Down" :edit.reorder-down]
+           ["Alt+Left" :code.goto-previous-word]
+           ["Alt+F9" :debugger.edit-breakpoint]
+           ["Alt+Meta+E" :code.select-next-occurrence]
+           ["Alt+Meta+F" :code.replace-text]
+           ["Alt+Meta+G" :code.replace-next]
+           ["Alt+Right" :code.goto-next-word]
+           ["Alt+Space" :code.show-completions]
+           ["Alt+Up" :code.goto-line-start]
+           ["Alt+Up" :edit.reorder-up]
+           ["Backspace" :code.delete-previous-char]
+           ["Ctrl+A" :code.goto-line-start]
+           ["Ctrl+E" :code.goto-line-end]
+           ["Ctrl+I" :code.reindent]
+           ["Ctrl+Meta+H" :scene.visibility.toggle-component-guides]
+           ["Ctrl+R" :file.open-recent]
+           ["Ctrl+Space" :code.show-completions]
+           ["Delete" :edit.delete]
+           ["Delete" :code.delete-next-char]
+           ["Down" :scene.move-down]
+           ["E" :scene.select-rotate-tool]
+           ["End" :code.goto-line-end]
+           ["Esc" :code.escape]
+           ["F" :scene.frame-selection]
+           ["F1" :help.open-documentation]
+           ["F10" :debugger.step-over]
+           ["F11" :debugger.step-into]
+           ["F2" :file.rename]
+           ["F5" :debugger.start]
+           ["F5" :debugger.continue]
+           ["F6" :window.toggle-left-pane]
+           ["F7" :window.toggle-bottom-pane]
+           ["F8" :window.toggle-right-pane]
+           ["F9" :debugger.toggle-breakpoint]
+           ["F12" :code.goto-definition]
+           ["Home" :code.goto-line-text-start]
+           ["Left" :scene.move-left]
+           ["Meta+'+'" :code.zoom.increase]
+           ["Meta+Add" :code.zoom.increase]
+           ["Meta+'-'" :code.zoom.decrease]
+           ["Meta+Subtract" :code.zoom.decrease]
+           ["Meta+0" :code.zoom.reset]
+           ["Meta+A" :code.select-all]
+           ["Meta+B" :project.build]
+           ["Meta+M" :project.build-html5]
+           ["Meta+C" :edit.copy]
+           ["Meta+Comma" :file.preferences]
+           ["Meta+D" :code.select-next-occurrence]
+           ["Meta+Down" :code.goto-file-end]
+           ["Meta+E" :scene.visibility.toggle-selection]
+           ["Meta+F" :edit.find]
+           ["Meta+G" :code.find-next]
+           ["Meta+L" :code.goto-line]
+           ["Meta+Left" :code.goto-line-text-start]
+           ["Meta+N" :file.new]
+           ["Meta+O" :file.open-selected]
+           ["Meta+P" :file.open]
+           ["Meta+Q" :file.quit]
+           ["Meta+R" :run.hot-reload]
+           ["Meta+Right" :code.goto-line-end]
+           ["Meta+S" :file.save-all]
+           ["Meta+'/'" :code.toggle-comment]
+           ["Meta+T" :scene.stop]
+           ["Meta+U" :project.rebundle]
+           ["Meta+J" :run.stop]
+           ["Meta+Up" :code.goto-file-start]
+           ["Meta+V" :edit.paste]
+           ["Meta+W" :window.tab.close]
+           ["Meta+X" :edit.cut]
+           ["Meta+Z" :edit.undo]
+           ["Page Down" :code.page-down]
+           ["Page Up" :code.page-up]
+           ["Period" :scene.realign-camera]
+           ["R" :scene.select-scale-tool]
+           ["Right" :scene.move-right]
+           ["Shift+A" :edit.add-secondary-embedded-component]
+           ["Shift+Alt+Down" :code.select-line-end]
+           ["Shift+Alt+Left" :code.select-previous-word]
+           ["Shift+Alt+Right" :code.select-next-word]
+           ["Shift+Alt+Up" :code.select-line-start]
+           ["Shift+Backspace" :code.delete-previous-char]
+           ["Shift+Ctrl+A" :code.select-line-start]
+           ["Shift+Ctrl+E" :code.select-line-end]
+           ["Shift+Ctrl+Left" :code.select-previous-word]
+           ["Shift+Ctrl+Right" :code.select-next-word]
+           ["Shift+Down" :scene.move-down-major]
+           ["Shift+Down" :code.select-down]
+           ["Shift+E" :scene.select-erase-tool]
+           ["Shift+End" :code.select-line-end]
+           ["Shift+F11" :debugger.step-out]
+           ["Shift+F12" :code.show-references]
+           ["Shift+Home" :code.select-line-text-start]
+           ["Shift+Left" :scene.move-left-major]
+           ["Shift+Left" :code.select-left]
+           ["Shift+Meta+B" :project.clean-build]
+           ["Shift+Meta+M" :project.clean-build-html5]
+           ["Shift+Meta+Down" :code.select-file-end]
+           ["Shift+Meta+E" :scene.visibility.show-last-hidden]
+           ["Shift+Meta+F" :file.search]
+           ["Shift+Meta+G" :code.find-previous]
+           ["Shift+Meta+I" :scene.visibility.toggle-filters]
+           ["Shift+Meta+L" :code.split-selection-into-lines]
+           ["Shift+Meta+Left" :code.select-line-text-start]
+           ["Shift+Meta+R" :project.reload-editor-scripts]
+           ["Shift+Meta+Right" :code.select-line-end]
+           ["Shift+Meta+T" :file.reopen-recent]
+           ["Shift+Meta+Up" :code.select-file-start]
+           ["Shift+Meta+W" :window.tab.close-all]
+           ["Shift+Meta+Y" :project.load-external-changes]
+           ["Shift+Meta+Z" :edit.redo]
+           ["Shift+Page Down" :code.select-page-down]
+           ["Shift+Page Up" :code.select-page-up]
+           ["Shift+Right" :scene.move-right-major]
+           ["Shift+Right" :code.select-right]
+           ["Shift+Tab" :code.tab-backward]
+           ["Shift+Up" :code.select-up]
+           ["Shift+Up" :scene.move-up-major]
+           ["Space" :scene.play]
+           ["Space" :scene.toggle-tile-palette]
+           ["Tab" :code.tab-forward]
+           ["Up" :scene.move-up]
+           ["W" :scene.select-move-tool]
+           ["X" :scene.flip-brush-horizontally]
+           ["Y" :scene.flip-brush-vertically]
+           ["Z" :scene.rotate-brush-90-degrees]]
+   :win32 [["A" :edit.add-embedded-component]
+           ["Alt+Down" :edit.reorder-down]
+           ["Alt+F9" :debugger.edit-breakpoint]
+           ["Alt+R" :file.open-recent]
+           ["Alt+Up" :edit.reorder-up]
+           ["Backspace" :code.delete-previous-char]
+           ["Ctrl+'+'" :code.zoom.increase]
+           ["Ctrl+Add" :code.zoom.increase]
+           ["Ctrl+'-'" :code.zoom.decrease]
+           ["Ctrl+Subtract" :code.zoom.decrease]
+           ["Ctrl+0" :code.zoom.reset]
+           ["Ctrl+A" :code.select-all]
+           ["Ctrl+B" :project.build]
+           ["Ctrl+M" :project.build-html5]
+           ["Ctrl+Backspace" :code.delete-previous-word]
+           ["Ctrl+C" :edit.copy]
+           ["Ctrl+Comma" :file.preferences]
+           ["Ctrl+D" :code.select-next-occurrence]
+           ["Ctrl+Delete" :code.delete-next-word]
+           ["Ctrl+E" :scene.visibility.toggle-selection]
+           ["Ctrl+End" :code.goto-file-end]
+           ["Ctrl+F" :edit.find]
+           ["Ctrl+G" :code.find-next]
+           ["Ctrl+H" :code.replace-text]
+           ["Ctrl+H" :scene.visibility.toggle-component-guides]
+           ["Ctrl+Home" :code.goto-file-start]
+           ["Ctrl+I" :code.reindent]
+           ["Ctrl+L" :code.goto-line]
+           ["Ctrl+Left" :code.goto-previous-word]
+           ["Ctrl+N" :file.new]
+           ["Ctrl+O" :file.open-selected]
+           ["Ctrl+P" :file.open]
+           ["Ctrl+Q" :file.quit]
+           ["Ctrl+R" :run.hot-reload]
+           ["Ctrl+Right" :code.goto-next-word]
+           ["Ctrl+S" :file.save-all]
+           ["Ctrl+'/'" :code.toggle-comment]
+           ["Ctrl+Space" :code.show-completions]
+           ["Ctrl+T" :scene.stop]
+           ["Ctrl+U" :project.rebundle]
+           ["Ctrl+J" :run.stop]
+           ["Ctrl+V" :edit.paste]
+           ["Ctrl+W" :window.tab.close]
+           ["Ctrl+X" :edit.cut]
+           ["Ctrl+Z" :edit.undo]
+           ["Delete" :edit.delete]
+           ["Delete" :code.delete-next-char]
+           ["Down" :scene.move-down]
+           ["E" :scene.select-rotate-tool]
+           ["End" :code.goto-line-end]
+           ["Esc" :code.escape]
+           ["F" :scene.frame-selection]
+           ["F1" :help.open-documentation]
+           ["F10" :debugger.step-over]
+           ["F11" :debugger.step-into]
+           ["F2" :file.rename]
+           ["F5" :debugger.start]
+           ["F5" :debugger.continue]
+           ["F6" :window.toggle-left-pane]
+           ["F7" :window.toggle-bottom-pane]
+           ["F8" :window.toggle-right-pane]
+           ["F9" :debugger.toggle-breakpoint]
+           ["F12" :code.goto-definition]
+           ["Home" :code.goto-line-text-start]
+           ["Left" :scene.move-left]
+           ["Page Down" :code.page-down]
+           ["Page Up" :code.page-up]
+           ["Period" :scene.realign-camera]
+           ["R" :scene.select-scale-tool]
+           ["Right" :scene.move-right]
+           ["Shift+A" :edit.add-secondary-embedded-component]
+           ["Shift+Backspace" :code.delete-previous-char]
+           ["Shift+Ctrl+B" :project.clean-build]
+           ["Shift+Ctrl+M" :project.clean-build-html5]
+           ["Shift+Ctrl+E" :scene.visibility.show-last-hidden]
+           ["Shift+Ctrl+End" :code.select-file-end]
+           ["Shift+Ctrl+F" :file.search]
+           ["Shift+Ctrl+G" :code.find-previous]
+           ["Shift+Ctrl+H" :code.replace-next]
+           ["Shift+Ctrl+Home" :code.select-file-start]
+           ["Shift+Ctrl+I" :scene.visibility.toggle-filters]
+           ["Shift+Ctrl+L" :code.split-selection-into-lines]
+           ["Shift+Ctrl+Left" :code.select-previous-word]
+           ["Shift+Ctrl+R" :project.reload-editor-scripts]
+           ["Shift+Ctrl+Right" :code.select-next-word]
+           ["Shift+Ctrl+T" :file.reopen-recent]
+           ["Shift+Ctrl+W" :window.tab.close-all]
+           ["Shift+Ctrl+Y" :project.load-external-changes]
+           ["Shift+Ctrl+Z" :edit.redo]
+           ["Shift+Down" :scene.move-down-major]
+           ["Shift+Down" :code.select-down]
+           ["Shift+E" :scene.select-erase-tool]
+           ["Shift+End" :code.select-line-end]
+           ["Shift+F11" :debugger.step-out]
+           ["Shift+F12" :code.show-references]
+           ["Shift+F5" :debugger.stop]
+           ["Shift+Home" :code.select-line-text-start]
+           ["Shift+Left" :scene.move-left-major]
+           ["Shift+Left" :code.select-left]
+           ["Shift+Page Down" :code.select-page-down]
+           ["Shift+Page Up" :code.select-page-up]
+           ["Shift+Right" :scene.move-right-major]
+           ["Shift+Right" :code.select-right]
+           ["Shift+Tab" :code.tab-backward]
+           ["Shift+Up" :code.select-up]
+           ["Shift+Up" :scene.move-up-major]
+           ["Space" :scene.play]
+           ["Space" :scene.toggle-tile-palette]
+           ["Tab" :code.tab-forward]
+           ["Up" :scene.move-up]
+           ["W" :scene.select-move-tool]
+           ["X" :scene.flip-brush-horizontally]
+           ["Y" :scene.flip-brush-vertically]
+           ["Z" :scene.rotate-brush-90-degrees]]
+   :linux [["A" :edit.add-embedded-component]
+           ["Alt+Down" :edit.reorder-down]
+           ["Alt+F9" :debugger.edit-breakpoint]
+           ["Alt+R" :file.open-recent]
+           ["Alt+Up" :edit.reorder-up]
+           ["Backspace" :code.delete-previous-char]
+           ["Ctrl+'+'" :code.zoom.increase]
+           ["Ctrl+Add" :code.zoom.increase]
+           ["Ctrl+'-'" :code.zoom.decrease]
+           ["Ctrl+Subtract" :code.zoom.decrease]
+           ["Ctrl+0" :code.zoom.reset]
+           ["Ctrl+A" :code.select-all]
+           ["Ctrl+B" :project.build]
+           ["Ctrl+M" :project.build-html5]
+           ["Ctrl+Backspace" :code.delete-previous-word]
+           ["Ctrl+C" :edit.copy]
+           ["Ctrl+Comma" :file.preferences]
+           ["Ctrl+D" :code.select-next-occurrence]
+           ["Ctrl+Delete" :code.delete-next-word]
+           ["Ctrl+E" :scene.visibility.toggle-selection]
+           ["Ctrl+End" :code.goto-file-end]
+           ["Ctrl+F" :edit.find]
+           ["Ctrl+G" :code.find-next]
+           ["Ctrl+H" :code.replace-text]
+           ["Ctrl+H" :scene.visibility.toggle-component-guides]
+           ["Ctrl+Home" :code.goto-file-start]
+           ["Ctrl+I" :code.reindent]
+           ["Ctrl+L" :code.goto-line]
+           ["Ctrl+Left" :code.goto-previous-word]
+           ["Ctrl+N" :file.new]
+           ["Ctrl+O" :file.open-selected]
+           ["Ctrl+P" :file.open]
+           ["Ctrl+Q" :file.quit]
+           ["Ctrl+R" :run.hot-reload]
+           ["Ctrl+Right" :code.goto-next-word]
+           ["Ctrl+S" :file.save-all]
+           ["Ctrl+'/'" :code.toggle-comment]
+           ["Ctrl+Space" :code.show-completions]
+           ["Ctrl+T" :scene.stop]
+           ["Ctrl+U" :project.rebundle]
+           ["Ctrl+J" :run.stop]
+           ["Ctrl+V" :edit.paste]
+           ["Ctrl+W" :window.tab.close]
+           ["Ctrl+X" :edit.cut]
+           ["Ctrl+Z" :edit.undo]
+           ["Delete" :edit.delete]
+           ["Delete" :code.delete-next-char]
+           ["Down" :scene.move-down]
+           ["E" :scene.select-rotate-tool]
+           ["End" :code.goto-line-end]
+           ["Esc" :code.escape]
+           ["F" :scene.frame-selection]
+           ["F1" :help.open-documentation]
+           ["F10" :debugger.step-over]
+           ["F11" :debugger.step-into]
+           ["F2" :file.rename]
+           ["F5" :debugger.start]
+           ["F5" :debugger.continue]
+           ["F6" :window.toggle-left-pane]
+           ["F7" :window.toggle-bottom-pane]
+           ["F8" :window.toggle-right-pane]
+           ["F9" :debugger.toggle-breakpoint]
+           ["F12" :code.goto-definition]
+           ["Home" :code.goto-line-text-start]
+           ["Left" :scene.move-left]
+           ["Page Down" :code.page-down]
+           ["Page Up" :code.page-up]
+           ["Period" :scene.realign-camera]
+           ["R" :scene.select-scale-tool]
+           ["Right" :scene.move-right]
+           ["Shift+A" :edit.add-secondary-embedded-component]
+           ["Shift+Backspace" :code.delete-previous-char]
+           ["Shift+Ctrl+B" :project.clean-build]
+           ["Shift+Ctrl+M" :project.clean-build-html5]
+           ["Shift+Ctrl+E" :scene.visibility.show-last-hidden]
+           ["Shift+Ctrl+End" :code.select-file-end]
+           ["Shift+Ctrl+F" :file.search]
+           ["Shift+Ctrl+G" :code.find-previous]
+           ["Shift+Ctrl+H" :code.replace-next]
+           ["Shift+Ctrl+Home" :code.select-file-start]
+           ["Shift+Ctrl+I" :scene.visibility.toggle-filters]
+           ["Shift+Ctrl+L" :code.split-selection-into-lines]
+           ["Shift+Ctrl+Left" :code.select-previous-word]
+           ["Shift+Ctrl+R" :project.reload-editor-scripts]
+           ["Shift+Ctrl+Right" :code.select-next-word]
+           ["Shift+Ctrl+T" :file.reopen-recent]
+           ["Shift+Ctrl+W" :window.tab.close-all]
+           ["Shift+Ctrl+Y" :project.load-external-changes]
+           ["Shift+Ctrl+Z" :edit.redo]
+           ["Shift+Down" :scene.move-down-major]
+           ["Shift+Down" :code.select-down]
+           ["Shift+E" :scene.select-erase-tool]
+           ["Shift+End" :code.select-line-end]
+           ["Shift+F11" :debugger.step-out]
+           ["Shift+F12" :code.show-references]
+           ["Shift+F5" :debugger.stop]
+           ["Shift+Home" :code.select-line-text-start]
+           ["Shift+Left" :scene.move-left-major]
+           ["Shift+Left" :code.select-left]
+           ["Shift+Page Down" :code.select-page-down]
+           ["Shift+Page Up" :code.select-page-up]
+           ["Shift+Right" :scene.move-right-major]
+           ["Shift+Right" :code.select-right]
+           ["Shift+Tab" :code.tab-backward]
+           ["Shift+Up" :code.select-up]
+           ["Shift+Up" :scene.move-up-major]
+           ["Space" :scene.play]
+           ["Space" :scene.toggle-tile-palette]
+           ["Tab" :code.tab-forward]
+           ["Up" :scene.move-up]
+           ["W" :scene.select-move-tool]
+           ["X" :scene.flip-brush-horizontally]
+           ["Y" :scene.flip-brush-vertically]
+           ["Z" :scene.rotate-brush-90-degrees]]})
 
 (def ^:private typable-truth-table
   "Only act on key pressed events that look like textual input, and
@@ -491,167 +423,574 @@
 
   Truth table:
 
-  MAC  CTRL ALT  META    RESULT
-  no   no   no   no   => typable
-  no   no   no   yes  => typable  -- Haven't been able to repro META on non-mac, assume not typable if even possible
-  no   no   yes  no   => shortcut
-  no   no   yes  yes  => shortcut
-  no   yes  no   no   => shortcut
-  no   yes  no   yes  => shortcut
-  no   yes  yes  no   => typable
-  no   yes  yes  yes  => typable  -- As above
-  yes  no   no   no   => typable
-  yes  no   no   yes  => shortcut
-  yes  no   yes  no   => typable
-  yes  no   yes  yes  => typable  -- No other tested mac app reacts like this, but seems you can use cmd (Meta) as modifier in keyboard input sources
-  yes  yes  no   no   => shortcut
-  yes  yes  no   yes  => shortcut
-  yes  yes  yes  no   => typable  -- As above
-  yes  yes  yes  yes  => typable  -- As above
+  MAC   CTRL  ALT   META     RESULT
+  false false false false => true
+  false false false true  => true  -- Haven't been able to repro META on non-mac, assume not typable if even possible
+  false false true  false => false
+  false false true  true  => false
+  false true  false false => false
+  false true  false true  => false
+  false true  true  false => true
+  false true  true  true  => true  -- As above
+  true  false false false => true
+  true  false false true  => false
+  true  false true  false => true
+  true  false true  true  => true  -- No other tested macOS app reacts like this, but seems you can use cmd (Meta) as modifier in keyboard input sources
+  true  true  false false => false
+  true  true  false true  => false
+  true  true  true  false => true  -- As above
+  true  true  true  true  => true  -- As above
 
   This does not seem right. We probably want something like that:
 
-    MAC   CTRL  ALT   META  RESULT"
-  {[:no   :no   :no   :no ] :typable
-   [:no   :no   :no   :yes] :shortcut   ;; Now treated as possibly shortcut
-   [:no   :no   :yes  :no ] :shortcut
-   [:no   :no   :yes  :yes] :shortcut
-   [:no   :yes  :no   :no ] :shortcut
-   [:no   :yes  :no   :yes] :shortcut
-   [:no   :yes  :yes  :no ] :typable
-   [:no   :yes  :yes  :yes] :shortcut   ;; As above
-   [:yes  :no   :no   :no ] :typable
-   [:yes  :no   :no   :yes] :shortcut
-   [:yes  :no   :yes  :no ] :typable
-   [:yes  :no   :yes  :yes] :shortcut   ;; Now treated as possibly shortcut
-   [:yes  :yes  :no   :no ] :shortcut
-   [:yes  :yes  :no   :yes] :shortcut
-   [:yes  :yes  :yes  :no ] :typable    ;; As above
-   [:yes  :yes  :yes  :yes] :shortcut}) ;; Now treated as possibly shortcut
+    MAC   CTRL  ALT   META   TYPABLE"
+  {[false false false false] true
+   [false false false true]  false   ;; Now treated as possibly shortcut
+   [false false true  false] false
+   [false false true  true]  false
+   [false true  false false] false
+   [false true  false true]  false
+   [false true  true  false] true
+   [false true  true  true]  false   ;; As above
+   [true  false false false] true
+   [true  false false true]  false
+   [true  false true  false] true
+   [true  false true  true]  false   ;; Now treated as possibly shortcut
+   [true  true  false false] false
+   [true  true  false true]  false
+   [true  true  true  false] true    ;; As above
+   [true  true  true  true]  false}) ;; Now treated as possibly shortcut
 
-(defn- boolean->kw [b]
-  (if b :yes :no))
+(def ^:private key-code->typable-char-strings
+  ;; Based on javafx.scene.input.KeyCodeCombination/getSingleChar
+  ;; Additions: SPACE
+  ;; Deletions: ENTER, LEFT, UP, RIGHT, DOWN
+  {KeyCode/ADD "+"
+   KeyCode/AMPERSAND "&"
+   KeyCode/ASTERISK "*"
+   KeyCode/AT "@"
+   KeyCode/BACK_QUOTE "`"
+   KeyCode/BACK_SLASH "\\"
+   KeyCode/BRACELEFT "{"
+   KeyCode/BRACERIGHT "}"
+   KeyCode/CIRCUMFLEX "^"
+   KeyCode/CLOSE_BRACKET "]"
+   KeyCode/COLON ":"
+   KeyCode/COMMA ","
+   KeyCode/DECIMAL "."
+   KeyCode/DIGIT0 "0"
+   KeyCode/DIGIT1 "1"
+   KeyCode/DIGIT2 "2"
+   KeyCode/DIGIT3 "3"
+   KeyCode/DIGIT4 "4"
+   KeyCode/DIGIT5 "5"
+   KeyCode/DIGIT6 "6"
+   KeyCode/DIGIT7 "7"
+   KeyCode/DIGIT8 "8"
+   KeyCode/DIGIT9 "9"
+   KeyCode/DIVIDE "/"
+   KeyCode/DOLLAR "$"
+   KeyCode/EQUALS "="
+   KeyCode/EURO_SIGN "€"
+   KeyCode/EXCLAMATION_MARK "!"
+   KeyCode/GREATER ">"
+   KeyCode/LEFT_PARENTHESIS "("
+   KeyCode/LESS "<"
+   KeyCode/MINUS "-"
+   KeyCode/MULTIPLY "*"
+   KeyCode/NUMBER_SIGN "#"
+   KeyCode/OPEN_BRACKET "["
+   KeyCode/PERIOD "."
+   KeyCode/PLUS "+"
+   KeyCode/QUOTE "\""
+   KeyCode/RIGHT_PARENTHESIS ")"
+   KeyCode/SEMICOLON ";"
+   KeyCode/SLASH "/"
+   KeyCode/SPACE " "
+   KeyCode/SUBTRACT "-"
+   KeyCode/UNDERSCORE "_"})
 
 (defn typable?
-  ([key-combo-data]
-   (typable? key-combo-data (os/os)))
-  ([{:keys [alt-down? control-down? meta-down?]} os]
-   (let [mac? (= os :macos)]
-     (-> typable-truth-table
-         (get (mapv boolean->kw [mac? control-down? alt-down? meta-down?]))
-         (= :typable)))))
+  "Returns true if the input is typable (on a specific OS)
 
-(defn- platform-typable-shortcut? [key-combo-data os]
-  (and (typable? key-combo-data os)
-       (= 1 (count (:key key-combo-data)))))
+  Args:
+    key    either KeyCombination or KeyEvent
+    os     target os keyword (:linux, :macos or :win32), defaults to host os"
+  ([key-data-source]
+   (typable? key-data-source (os/os)))
+  ([key os]
+   (let [mac (= os :macos)]
+     (condp instance? key
+       KeyCombination
+       (let [^KeyCombination key key]
+         (and (typable-truth-table
+                [mac
+                 (= KeyCombination$ModifierValue/DOWN (.getControl key))
+                 (= KeyCombination$ModifierValue/DOWN (.getAlt key))
+                 (= KeyCombination$ModifierValue/DOWN (.getMeta key))])
+              (= 1 (count
+                     (condp instance? key
+                       KeyCodeCombination
+                       (let [code (.getCode ^KeyCodeCombination key)]
+                         (or (key-code->typable-char-strings code)
+                             (.getName code)))
 
-(defn- key-binding-data [key-bindings]
-  (map (fn [[shortcut command]]
-         (let [key-combo (KeyCombination/keyCombination shortcut)
-               key-combo-data (key-combo->map key-combo)]
-           {:shortcut shortcut
-            :command command
-            :key-combo key-combo
-            :key-combo-data key-combo-data}))
-       key-bindings))
+                       KeyCharacterCombination
+                       (.getCharacter ^KeyCharacterCombination key))))))
 
-(defn- key-binding-data->keymap
-  [key-bindings-data platform valid-command? allowed-duplicate-shortcuts allowed-typable-shortcuts]
-  (reduce (fn [ret {:keys [key-combo-data shortcut command ^KeyCombination key-combo]}]
-            (cond
-              (not (valid-command? command))
-              (update ret :errors conj {:type :unknown-command
-                                        :command command
-                                        :shortcut shortcut})
+       KeyEvent
+       (let [^KeyEvent key key]
+         (typable-truth-table
+           [mac
+            (.isControlDown key)
+            (.isAltDown key)
+            (.isMetaDown key)]))))))
 
-              (not= shortcut (.getName key-combo))
-              (update ret :errors conj {:type :unknown-shortcut
-                                        :command command
-                                        :shortcut shortcut})
+(def empty
+  {;; KeyCombination->#{command}
+   :shortcut->commands {}
+   ;; command->#{KeyCombination}
+   :command->shortcuts {}
+   ;; command->KeyCombination->{:type ...}
+   :command->shortcut->warnings {}})
 
-              (:shortcut-down? key-combo-data)
-              (update ret :errors conj {:type :shortcut-key
-                                        :command command
-                                        :shortcut shortcut})
+(def ^:private set-conj (fnil conj #{}))
 
-              (and (platform-typable-shortcut? key-combo-data platform)
-                   (not (allowed-typable-shortcuts shortcut)))
-              (update ret :errors conj {:type :typable-shortcut
-                                        :command command
-                                        :shortcut shortcut})
+(defn- update-removing-empty
+  ([m k f v]
+   (let [v (f (get m k) v)]
+     (if (coll/empty? v)
+       (dissoc m k)
+       (assoc m k v))))
+  ([m k f v1 v2 v3]
+   (let [v (f (get m k) v1 v2 v3)]
+     (if (coll/empty? v)
+       (dissoc m k)
+       (assoc m k v)))))
 
-              (and (some? (get-in ret [:keymap key-combo-data]))
-                   (not (allowed-duplicate-shortcuts shortcut)))
-              (update ret :errors into [{:type :duplicate-shortcut
-                                         :command command
-                                         :shortcut shortcut}
-                                        {:type :duplicate-shortcut
-                                         :command (get-in ret [:keymap key-combo-data])
-                                         :shortcut shortcut}])
+(defn from
+  "Make a keymap based on another keymap
 
-              :else
-              (update-in ret [:keymap key-combo-data] (fnil conj []) {:command command
-                                                                      :shortcut shortcut
-                                                                      :key-combo key-combo})))
-          {:keymap {}
-           :errors #{}}
-          key-bindings-data))
+  Args:
+    parent     the parent keymap (see [[empty]], [[default]])
+    os         target os keyword (:macos, :linux or :win32), defaults to host os
+    changes    map of command keyword keys and map vals with the following keys:
+                 :add       set of new shortcuts (strings like \"Meta+A\") to
+                            add
+                 :remove    set of existing shortcuts (strings) to remove"
+  ([parent changes]
+   (from parent (os/os) changes))
+  ([parent os changes]
+   (-> (reduce-kv
+         (fn [acc command {:keys [add remove]}]
+           (let [acc (reduce
+                       (fn [acc s]
+                         (let [shortcut (KeyCombination/valueOf s)]
+                           (if (-> acc :shortcut->commands (get shortcut) (contains? command))
+                             (-> acc
+                                 (update :shortcut->commands update-removing-empty shortcut disj command)
+                                 (update :command->shortcuts update-removing-empty command disj shortcut)
+                                 (update :command->shortcut->warnings update-removing-empty command dissoc shortcut)
+                                 (as-> $
+                                       (reduce
+                                         (fn [acc warning]
+                                           (case (:type warning)
+                                             :conflict (update acc :command->shortcut->warnings
+                                                               update-removing-empty (:command warning)
+                                                               update-removing-empty shortcut
+                                                               disj {:type :conflict :command command})
+                                             acc))
+                                         $
+                                         (-> acc :command->shortcut->warnings (get command) (get shortcut)))))
+                             acc)))
+                       acc
+                       remove)
+                 acc (reduce
+                       (fn [acc s]
+                         (let [shortcut (KeyCombination/valueOf s)]
+                           (-> acc
+                               (update-in [:shortcut->commands shortcut] set-conj command)
+                               (update-in [:command->shortcuts command] set-conj shortcut)
+                               (cond->
+                                 (= KeyCombination$ModifierValue/DOWN (.getShortcut shortcut))
+                                 (update-in [:command->shortcut->warnings command shortcut] set-conj {:type :shortcut-modifier})
 
-(defn- make-keymap*
-  [key-bindings platform valid-command? allowed-duplicate-shortcuts allowed-typable-shortcuts]
-  (-> (key-binding-data key-bindings)
-      (key-binding-data->keymap platform valid-command? allowed-duplicate-shortcuts allowed-typable-shortcuts)))
+                                 (not= s (.getName shortcut))
+                                 (update-in [:command->shortcut->warnings command shortcut] set-conj {:type :non-canonical-name})
 
-(defn make-keymap
-  ([key-bindings]
-   (make-keymap key-bindings nil))
-  ([key-bindings {:keys [valid-command?
-                         platform
-                         throw-on-error?
-                         allowed-duplicate-shortcuts
-                         allowed-typable-shortcuts]
-                  :or   {valid-command? fn/constantly-true
-                         platform (os/os)
-                         throw-on-error? false
-                         allowed-duplicate-shortcuts default-allowed-duplicate-shortcuts
-                         allowed-typable-shortcuts default-allowed-typable-shortcuts}}]
-   (let [{:keys [errors keymap]} (make-keymap* key-bindings platform valid-command? allowed-duplicate-shortcuts allowed-typable-shortcuts)]
-     (if (and (seq errors) throw-on-error?)
-       (throw (ex-info "Keymap has errors"
-                       {:errors       errors
-                        :key-bindings key-bindings}))
-       keymap))))
+                                 (typable? shortcut os)
+                                 (update-in [:command->shortcut->warnings command shortcut] set-conj {:type :typable})
 
-(defn command->shortcut
-  [keymap]
-  (into {}
-        (comp cat
-              (map (fn [{:keys [command shortcut]}]
-                     [command shortcut])))
-        (vals keymap)))
+                                 (contains? (:shortcut->commands acc) shortcut)
+                                 (as-> $
+                                       (reduce
+                                         (fn [acc conflicting-command]
+                                           (-> acc
+                                               (update-in [:command->shortcut->warnings conflicting-command shortcut] set-conj {:type :conflict :command command})
+                                               (update-in [:command->shortcut->warnings command shortcut] set-conj {:type :conflict :command conflicting-command})))
+                                         $
+                                         (disj (get (:shortcut->commands acc) shortcut) command)))))))
+                       acc
+                       add)]
+             acc))
+         parent
+         changes))))
 
-(defn- execute-command
-  [commands]
-  ;; It is imperative that the handler is invoked using run-later as
-  ;; this avoids a JVM crash on some macOS versions. Prior to macOS
-  ;; Sierra, the order in which native menu events are delivered
-  ;; triggered a segfault in the native menu implementation when the
-  ;; stage is changed during the event dispatch. This happens for
-  ;; example when we have a shortcut triggering the opening of a
-  ;; dialog.
-  (ui/run-later (let [command-contexts (ui/contexts (ui/main-scene))]
-                  (loop [[command & rest] commands]
-                    (when (some? command)
-                      (let [ret (ui/invoke-handler command-contexts command)]
-                        (if (or (= ret ::ui/not-active)
-                                (= ret ::ui/not-enabled))
-                          (recur rest)
-                          ret)))))))
+(def ^:private ^{:arglists '([os])} default-keymap
+  (fn/memoize
+    (fn [os]
+      (from
+        empty
+        os
+        (-> {}
+            (util/group-into #{} #(% 1) #(% 0) (platform->default-key-bindings os))
+            (update-vals (fn [s] {:add s})))))))
 
-(defn install-key-bindings!
-  [^Scene scene keymap]
-  (let [accelerators (.getAccelerators scene)]
-    (run! (fn [[_ commands]]
-            (let [key-combo (-> commands first :key-combo)]
-              (.put accelerators key-combo #(execute-command (map :command commands)))))
-          keymap)))
+(defn default
+  "Returns default keymap (for a given os)"
+  ([]
+   (default (os/os)))
+  ([os]
+   (default-keymap os)))
+
+(defn from-prefs
+  "Returns a keymap with changes taken from prefs"
+  ([prefs]
+   (from-prefs @prefs/global-state prefs))
+  ([prefs-state prefs]
+   (let [os (os/os)]
+     (from (default-keymap os) os (prefs/get prefs-state prefs [:window :keymap])))))
+
+(defn warnings
+  ([keymap]
+   (:command->shortcut->warnings keymap))
+  ([keymap command]
+   (get (warnings keymap) command))
+  ([keymap command shortcut]
+   {:pre [(or (string? shortcut) (instance? KeyCombination shortcut))]}
+   (let [shortcut (if (string? shortcut) (KeyCombination/valueOf shortcut) shortcut)]
+     (get (warnings keymap command) shortcut))))
+
+(defn shortcuts
+  "Returns a non-empty set of KeyCombination shortcuts for a command (or nil)"
+  [keymap command]
+  (get (:command->shortcuts keymap) command))
+
+(defn commands
+  "Returns a non-empty set of commands for a shortcut (or nil)"
+  [keymap shortcut]
+  {:pre [(or (string? shortcut) (instance? KeyCombination shortcut))]}
+  (let [shortcut (if (string? shortcut) (KeyCombination/valueOf shortcut) shortcut)]
+    (get (:shortcut->commands keymap) shortcut)))
+
+(defn display-text
+  "Return a display text string for one of its shortcuts (or not-found value)"
+  [keymap command not-found]
+  (if-let [s (shortcuts keymap command)]
+    (.getDisplayText ^KeyCombination (first s))
+    not-found))
+
+(defn install!
+  "Install a keymap on a scene, replacing any predefined accelerators"
+  [keymap ^Scene scene execute-fn]
+  (doto (.getAccelerators scene)
+    (.clear)
+    (.putAll (persistent!
+               (reduce-kv
+                 (fn [acc shortcut commands]
+                   (assoc! acc shortcut #(execute-fn commands)))
+                 (transient {})
+                 (:shortcut->commands keymap)))))
+  nil)
+
+(defn shortcut-display-text
+  "Default display text of a shortcut"
+  [^KeyCombination shortcut]
+  (.getDisplayText shortcut))
+
+(defn shortcut-distinct-display-text
+  "Display text for a shortcut that takes shortcut type into account"
+  ([shortcut]
+   (shortcut-distinct-display-text shortcut (os/os)))
+  ([^KeyCombination shortcut os]
+   (condp instance? shortcut
+     KeyCodeCombination (.getDisplayText shortcut)
+     KeyCharacterCombination
+     (let [sb (StringBuilder.)
+           control (= KeyCombination$ModifierValue/DOWN (.getControl shortcut))
+           alt (= KeyCombination$ModifierValue/DOWN (.getAlt shortcut))
+           shift (= KeyCombination$ModifierValue/DOWN (.getShift shortcut))
+           meta (= KeyCombination$ModifierValue/DOWN (.getMeta shortcut))
+           shortcut-modifier (= KeyCombination$ModifierValue/DOWN (.getShortcut shortcut))]
+       (if (= os :macos)
+         (cond-> sb
+                 control (.append "⌃")
+                 alt (.append "⌥")
+                 shift (.append "⇧")
+                 (or meta shortcut-modifier) (.append "⌘"))
+         (cond-> sb
+                 (or control shortcut-modifier) (.append "Ctrl+")
+                 alt (.append "Alt+")
+                 shift (.append "Shift+")
+                 meta (.append "Meta+")))
+       (let [char-str (.getCharacter ^KeyCharacterCombination shortcut)]
+         (if (= "'" char-str)
+           (.append sb "\"'\"")
+           (.append sb (str "'" char-str "'"))))
+       (.toString sb)))))
+
+(defn shortcut-filterable-text
+  "User-typable shortcut text, uses Cmd/Win instead of Meta depending on the os"
+  ([^KeyCombination shortcut]
+   (shortcut-filterable-text shortcut (os/os)))
+  ([^KeyCombination shortcut os]
+   (let [sb (StringBuilder.)
+         control (= KeyCombination$ModifierValue/DOWN (.getControl shortcut))
+         alt (= KeyCombination$ModifierValue/DOWN (.getAlt shortcut))
+         shift (= KeyCombination$ModifierValue/DOWN (.getShift shortcut))
+         meta (= KeyCombination$ModifierValue/DOWN (.getMeta shortcut))
+         shortcut-modifier (= KeyCombination$ModifierValue/DOWN (.getShortcut shortcut))]
+     ;; See https://github.com/microsoft/vscode/blob/7ec68793e7d971def8c2ea3f669b8f85ebc726a4/src/vs/base/common/keybindingLabels.ts#L130-L152
+     (case os
+       :macos (cond-> sb
+                      control (.append "Ctrl+")
+                      alt (.append "Alt+")
+                      shift (.append "Shift+")
+                      (or meta shortcut-modifier) (.append "Cmd+"))
+       :win32 (cond-> sb
+                      (or control shortcut-modifier) (.append "Ctrl+")
+                      alt (.append "Alt+")
+                      shift (.append "Shift+")
+                      meta (.append "Win+"))
+       :linux (cond-> sb
+                      (or control shortcut-modifier) (.append "Ctrl+")
+                      alt (.append "Alt+")
+                      shift (.append "Shift+")
+                      meta (.append "Meta+")))
+     (condp instance? shortcut
+       KeyCharacterCombination
+       (.append sb (.getCharacter ^KeyCharacterCombination shortcut))
+
+       KeyCodeCombination
+       (let [code (.getCode ^KeyCodeCombination shortcut)]
+         (.append sb (or (when (= KeyCode/SPACE code) (.getName code))
+                         (key-code->typable-char-strings code)
+                         (.getName code)))))
+     (.toString sb))))
+
+;; TODO: remove migration from legacy keymap file after sufficient time has passed (e.g. after 2026-04-08)
+
+(defn migrate-from-file! [prefs]
+  (let [legacy-keymap-path (prefs/get prefs [:input :keymap-path])
+        legacy->new-command {:about :help.about
+                             :asset-portal :help.open-asset-portal
+                             :documentation :help.open-documentation
+                             :donate :help.open-donations
+                             :support-forum :help.open-forum
+                             :search-issues :help.open-issues
+                             :show-logs :help.open-logs
+                             :report-issue :help.report-issue
+                             :report-suggestion :help.report-suggestion
+                             :build :project.build
+                             :build-html5 :project.build-html5
+                             :bundle :project.bundle
+                             :bundle-android :project.bundle-android
+                             :bundle-html5 :project.bundle-html5
+                             :bundle-ios :project.bundle-ios
+                             :bundle-linux :project.bundle-linux
+                             :bundle-macos :project.bundle-macos
+                             :bundle-windows :project.bundle-windows
+                             :rebuild :project.clean-build
+                             :rebuild-html5 :project.clean-build-html5
+                             :fetch-libraries :project.fetch-libraries
+                             :async-reload :project.load-external-changes
+                             :rebundle :project.rebundle
+                             :reload-extensions :project.reload-editor-scripts
+                             :hot-reload :run.hot-reload
+                             :engine-profile-show :run.open-profiler
+                             :engine-resource-profile-show :run.open-resource-profiler
+                             :toggle-pane-bottom :window.toggle-bottom-pane
+                             :toggle-pane-left :window.toggle-left-pane
+                             :toggle-pane-right :window.toggle-right-pane
+                             :close :window.tab.close
+                             :close-all :window.tab.close-all
+                             :close-other :window.tab.close-others
+                             :join-tab-panes :window.tab.join-groups
+                             :move-tab :window.tab.move-to-other-group
+                             :swap-tabs :window.tab.swap
+                             :break :debugger.break
+                             :continue :debugger.continue
+                             :detach-debugger :debugger.detach
+                             :edit-breakpoint :debugger.edit-breakpoint
+                             :start-debugger :debugger.start
+                             :step-into :debugger.step-into
+                             :step-out :debugger.step-out
+                             :step-over :debugger.step-over
+                             :stop-debugger :debugger.stop
+                             :toggle-breakpoint :debugger.toggle-breakpoint
+                             :zoom-out :code.zoom.decrease
+                             :zoom-in :code.zoom.increase
+                             :reset-zoom :code.zoom.reset
+                             :create-desktop-entry :file.create-desktop-entry
+                             :new-file :file.new
+                             :new-folder :file.new-folder
+                             :open-as :file.open-as
+                             :show-in-desktop :file.open-in-desktop
+                             :live-update-settings :file.open-liveupdate-settings
+                             :open-project :file.open-project
+                             :open-recent-file :file.open-recent
+                             :shared-editor-settings :file.open-shared-editor-settings
+                             :preferences :file.preferences
+                             :quit :file.quit
+                             :show-search-results :window.show-search-results
+                             :show-build-errors :window.show-build-errors
+                             :show-console :window.show-console
+                             :show-curve-editor :window.show-curve-editor
+                             :show-overrides :window.show-overrides
+                             :proposals :code.show-completions
+                             :find-references :code.show-references
+                             :goto-definition :code.goto-definition
+                             :toggle-comment :code.toggle-comment
+                             :toggle-indentation-guides :code.toggle-indentation-guides
+                             :toggle-minimap :code.toggle-minimap
+                             :toggle-visible-whitespace :code.toggle-visible-whitespace
+                             :copy-full-path :edit.copy-absolute-path
+                             :copy-project-path :edit.copy-resource-path
+                             :copy-require-path :edit.copy-require-path
+                             :cut :edit.cut
+                             :copy :edit.copy
+                             :paste :edit.paste
+                             :redo :edit.redo
+                             :undo :edit.undo
+                             :target :run.select-target
+                             :target-ip :run.set-target-ip
+                             :target-log :run.show-target-log
+                             :close-engine :run.stop
+                             :set-rotate-device :run.toggle-device-rotated
+                             :reset-custom-resolution :run.reset-resolution
+                             :set-instance-count :run.set-instance-count
+                             :frame-selection :scene.frame-selection
+                             :flip-brush-horizontally :scene.flip-brush-horizontally
+                             :flip-brush-vertically :scene.flip-brush-vertically
+                             :rotate-brush-90-degrees :scene.rotate-brush-90-degrees
+                             :realign-camera :scene.realign-camera
+                             :erase-tool :scene.select-erase-tool
+                             :move-tool :scene.select-move-tool
+                             :rotate-tool :scene.select-rotate-tool
+                             :scale-tool :scene.select-scale-tool
+                             :show-palette :scene.toggle-tile-palette
+                             :hide-unselected :scene.visibility.hide-unselected
+                             :show-all-hidden :scene.visibility.show-all
+                             :show-last-hidden :scene.visibility.show-last-hidden
+                             :show-visibility-settings :scene.visibility.show-settings
+                             :toggle-component-guides :scene.visibility.toggle-component-guides
+                             :toggle-visibility-filters :scene.visibility.toggle-filters
+                             :toggle-grid :scene.visibility.toggle-grid
+                             :hide-toggle-selected :scene.visibility.toggle-selection
+                             :clear-console :window.clear-console
+                             :reload-stylesheet :window.reload-css
+                             :diff :vcs.diff
+                             :revert :vcs.revert
+                             :toggle-perspective-camera :scene.toggle-camera-type
+                             :toggle-move-whole-pixels :scene.toggle-move-whole-pixels
+                             :toggle-2d-mode :scene.toggle-interaction-mode
+                             :rename :file.rename
+                             :reopen-recent-file :file.reopen-recent
+                             :save-all :file.save-all
+                             :save-and-upgrade-all :file.save-and-upgrade-all
+                             :search-in-files :file.search
+                             :dependencies :file.show-dependencies
+                             :show-in-asset-browser :file.show-in-assets
+                             :referencing-files :file.show-references
+                             :down :scene.move-down
+                             :down-major :scene.move-down-major
+                             :left :scene.move-left
+                             :left-major :scene.move-left-major
+                             :right :scene.move-right
+                             :right-major :scene.move-right-major
+                             :up :scene.move-up
+                             :up-major :scene.move-up-major
+                             :move-down :edit.reorder-down
+                             :move-up :edit.reorder-up
+                             :select-up :code.select-up
+                             :select-right :code.select-right
+                             :select-down :code.select-down
+                             :select-left :code.select-left
+                             :select-next-word :code.select-next-word
+                             :select-prev-word :code.select-previous-word
+                             :select-page-down :code.select-page-down
+                             :select-page-up :code.select-page-up
+                             :split-selection-into-lines :code.split-selection-into-lines
+                             :backwards-tab-trigger :code.tab-backward
+                             :tab :code.tab-forward
+                             :select-end-of-line :code.select-line-end
+                             :select-beginning-of-line :code.select-line-start
+                             :select-beginning-of-line-text :code.select-line-text-start
+                             :select-next-occurrence :code.select-next-occurrence
+                             :select-all :code.select-all
+                             :select-end-of-file :code.select-file-end
+                             :select-beginning-of-file :code.select-file-start
+                             :end-of-file :code.goto-file-end
+                             :beginning-of-file :code.goto-file-start
+                             :goto-line :code.goto-line
+                             :end-of-line :code.goto-line-end
+                             :beginning-of-line :code.goto-line-start
+                             :beginning-of-line-text :code.goto-line-text-start
+                             :next-word :code.goto-next-word
+                             :prev-word :code.goto-previous-word
+                             :page-down :code.page-down
+                             :page-up :code.page-up
+                             :reindent :code.reindent
+                             :replace-all :code.replace-all
+                             :replace-next :code.replace-next
+                             :replace-text :code.replace-text
+                             :delete-next-word :code.delete-next-word
+                             :delete-backward :code.delete-previous-char
+                             :delete-prev-word :code.delete-previous-word
+                             :escape :code.escape
+                             :find-next :code.find-next
+                             :find-prev :code.find-previous
+                             :scene-play :scene.play
+                             :scene-stop :scene.stop
+                             :set-manip-space :scene.set-manipulator-space
+                             :set-camera-type :scene.set-camera-type
+                             :set-gui-layout :scene.set-gui-layout
+                             :convert-indentation :code.convert-indentation
+                             :profile-show :dev.open-profiler
+                             :find-text :edit.find
+                             :filter-form :edit.find
+                             :sort-lines :code.sort-lines
+                             :sort-lines-case-sensitive :code.sort-lines
+                             :set-custom-resolution :run.set-resolution
+                             :set-resolution :run.set-resolution
+                             :delete :edit.delete
+                             :add-secondary-from-file :edit.add-secondary-referenced-component
+                             :add-secondary :edit.add-secondary-embedded-component
+                             :add-from-file :edit.add-referenced-component
+                             :add :edit.add-embedded-component
+                             :open-asset :file.open
+                             :open :file.open-selected}]
+    (when (and (not= "" legacy-keymap-path)
+               (= {} (prefs/get prefs [:window :keymap])))
+      (let [keymap (default)]
+        (try
+          (prefs/set!
+            prefs
+            [:window :keymap]
+            (->> legacy-keymap-path
+                 slurp
+                 edn/read-string
+                 (e/keep
+                   (fn [[shortcut-str legacy-command]]
+                     (when-let [command (legacy->new-command legacy-command)]
+                       (coll/pair shortcut-str command))))
+                 (util/group-into {} [] key val)
+                 (reduce
+                   (fn [acc [shortcut shortcut-commands]]
+                     (let [conflicting-commands (commands keymap shortcut)
+                           acc (reduce #(update-in %1 [%2 :add] set-conj shortcut) acc shortcut-commands)
+                           acc (reduce #(update-in %1 [%2 :remove] set-conj shortcut) acc conflicting-commands)]
+                       acc))
+                   {})))
+          (catch Exception e (log/error :message "Failed to migrate legacy prefs" :exception e))
+          (finally (prefs/set! prefs [:input :keymap-path] "")))))))

--- a/editor/src/clj/editor/markdown.clj
+++ b/editor/src/clj/editor/markdown.clj
@@ -74,7 +74,7 @@
                                 workspace (project/workspace project evaluation-context)]
                             (when-let [proj-path (workspace/as-proj-path basis workspace resolved-url)]
                               (workspace/find-resource workspace proj-path))))]
-        (ui/execute-command (ui/contexts (ui/main-scene)) :open {:resources [resource]})
+        (ui/execute-command (ui/contexts (ui/main-scene)) :file.open resource)
         (ui/open-url resolved-url))
 
       (ui/open-url resolved-url))))

--- a/editor/src/clj/editor/outline_view.clj
+++ b/editor/src/clj/editor/outline_view.clj
@@ -235,20 +235,20 @@
    {:label "Show in Asset Browser"
     :icon "icons/32/Icons_S_14_linkarrow.png"
     :command :file.show-in-assets}
-   {:label "Open in Desktop"
+   {:label "Show in Desktop"
     :icon "icons/32/Icons_S_14_linkarrow.png"
-    :command :file.open-in-desktop}
+    :command :file.show-in-desktop}
    {:label "Referencing Files..."
     :command :file.show-references}
    {:label "Dependencies..."
     :command :file.show-dependencies}
    {:label "Show Overrides"
-    :command :window.show-overrides}
+    :command :edit.show-overrides}
    {:label :separator}
    {:label "Add"
     :icon "icons/32/Icons_M_07_plus.png"
     :command :edit.add-embedded-component
-    :expand? true}
+    :expand true}
    {:label "Add From File"
     :icon "icons/32/Icons_M_07_plus.png"
     :command :edit.add-referenced-component}

--- a/editor/src/clj/editor/outline_view.clj
+++ b/editor/src/clj/editor/outline_view.clj
@@ -220,68 +220,68 @@
 (handler/register-menu! ::outline-menu
   [{:label "Open"
     :icon "icons/32/Icons_S_14_linkarrow.png"
-    :command :open}
+    :command :file.open-selected}
    {:label "Open As"
     :icon "icons/32/Icons_S_14_linkarrow.png"
-    :command :open-as}
+    :command :file.open-as}
    {:label :separator}
-   {:label "Copy Project Path"
-    :command :copy-project-path}
+   {:label "Copy Resource Path"
+    :command :edit.copy-resource-path}
    {:label "Copy Full Path"
-    :command :copy-full-path}
+    :command :edit.copy-absolute-path}
    {:label "Copy Require Path"
-    :command :copy-require-path}
+    :command :edit.copy-require-path}
    {:label :separator}
    {:label "Show in Asset Browser"
     :icon "icons/32/Icons_S_14_linkarrow.png"
-    :command :show-in-asset-browser}
-   {:label "Show in Desktop"
+    :command :file.show-in-assets}
+   {:label "Open in Desktop"
     :icon "icons/32/Icons_S_14_linkarrow.png"
-    :command :show-in-desktop}
+    :command :file.open-in-desktop}
    {:label "Referencing Files..."
-    :command :referencing-files}
+    :command :file.show-references}
    {:label "Dependencies..."
-    :command :dependencies}
+    :command :file.show-dependencies}
    {:label "Show Overrides"
-    :command :show-overrides}
+    :command :window.show-overrides}
    {:label :separator}
    {:label "Add"
     :icon "icons/32/Icons_M_07_plus.png"
-    :command :add
+    :command :edit.add-embedded-component
     :expand? true}
    {:label "Add From File"
     :icon "icons/32/Icons_M_07_plus.png"
-    :command :add-from-file}
+    :command :edit.add-referenced-component}
    {:label "Add Secondary"
     :icon "icons/32/Icons_M_07_plus.png"
-    :command :add-secondary}
+    :command :edit.add-secondary-embedded-component}
    {:label "Add Secondary From File"
     :icon "icons/32/Icons_M_07_plus.png"
-    :command :add-secondary-from-file}
+    :command :edit.add-secondary-referenced-component}
    {:label :separator}
    {:label "Cut"
-    :command :cut}
+    :command :edit.cut}
    {:label "Copy"
-    :command :copy}
+    :command :edit.copy}
    {:label "Paste"
-    :command :paste}
+    :command :edit.paste}
    {:label "Delete"
     :icon "icons/32/Icons_M_06_trash.png"
-    :command :delete}
+    :command :edit.delete}
    {:label :separator}
    {:label "Move Up"
-    :command :move-up}
+    :command :edit.reorder-up}
    {:label "Move Down"
-    :command :move-down}
+    :command :edit.reorder-down}
    {:label :separator}
    {:label "Show/Hide Objects"
-    :command :hide-toggle-selected}
+    :command :scene.visibility.toggle-selection}
    {:label "Hide Unselected Objects"
-    :command :hide-unselected}
+    :command :scene.visibility.hide-unselected}
    {:label "Show Last Hidden Objects"
-    :command :show-last-hidden}
+    :command :scene.visibility.show-last-hidden}
    {:label "Show All Hidden Objects"
-    :command :show-all-hidden}
+    :command :scene.visibility.show-all}
    {:label :separator
     :id ::context-menu-end}])
 
@@ -295,7 +295,7 @@
   ([outline-view evaluation-context]
    (g/node-value outline-view :tree-selection-root-its evaluation-context)))
 
-(handler/defhandler :delete :workbench
+(handler/defhandler :edit.delete :workbench
   (active? [selection] (handler/selection->node-ids selection))
   (enabled? [selection outline-view evaluation-context]
             (and (< 0 (count selection))
@@ -328,7 +328,7 @@
 (defn- set-paste-parent! [root-its]
   (alter-var-root #'*paste-into-parent* (constantly (some-> (single-parent-it root-its) outline/value :node-id))))
 
-(handler/defhandler :copy :workbench
+(handler/defhandler :edit.copy :workbench
   (active? [selection] (handler/selection->node-ids selection))
   (enabled? [selection] (< 0 (count selection)))
   (run [outline-view project]
@@ -344,7 +344,7 @@
           single-parent)
       (first item-iterators))))
 
-(handler/defhandler :paste :workbench
+(handler/defhandler :edit.paste :workbench
   (active? [selection] (handler/selection->node-ids selection))
   (enabled? [project selection outline-view evaluation-context]
             (let [cb (Clipboard/getSystemClipboard)
@@ -360,7 +360,7 @@
       (outline/paste! project target-item-it (.getContent cb data-format) (partial app-view/select app-view))
       (set-paste-parent! (root-iterators outline-view)))))
 
-(handler/defhandler :cut :workbench
+(handler/defhandler :edit.cut :workbench
   (active? [selection] (handler/selection->node-ids selection))
   (enabled? [selection outline-view evaluation-context]
             (let [item-iterators (root-iterators outline-view evaluation-context)]
@@ -466,7 +466,7 @@
       (ui/user-data! cell :future-expand nil))))
 
 (defn- toggle-visibility! [node-outline-key-path ^MouseEvent event]
-  (ui/run-command (.getSource event) :hide-toggle {:node-outline-key-path node-outline-key-path}))
+  (ui/run-command (.getSource event) :private/hide-toggle {:node-outline-key-path node-outline-key-path}))
 
 (defn add-scroll-listeners!
   [visibility-button ^TreeView tree-view]
@@ -490,7 +490,7 @@
                             (ui/add-style! "visibility-toggle")
                             (AnchorPane/setRightAnchor 0.0))
         text-label (doto (Label.)
-                     (ui/bind-double-click! :open))
+                     (ui/bind-double-click! :file.open-selected))
         h-box (doto (HBox. 5 (ui/node-array [image-view-icon text-label]))
                 (ui/add-style! "h-box")
                 (AnchorPane/setRightAnchor 0.0)
@@ -583,6 +583,7 @@
       (.setCellFactory (reify Callback (call ^TreeCell [this view] (make-tree-cell view drag-entered-handler drag-exited-handler))))
       (ui/observe-selection #(propagate-selection %2 app-view))
       (ui/register-context-menu ::outline-menu)
+      (ui/bind-key-commands! {"Enter" :file.open-selected})
       (ui/context! :outline {} (SelectionProvider. outline-view) {} {java.lang.Long :node-id
                                                                      resource/Resource :link}))))
 

--- a/editor/src/clj/editor/particlefx.clj
+++ b/editor/src/clj/editor/particlefx.clj
@@ -1095,7 +1095,7 @@
 (defn- selection->particlefx [selection]
   (handler/adapt-single selection ParticleFXNode))
 
-(handler/defhandler :add-secondary :workbench
+(handler/defhandler :edit.add-secondary-embedded-component :workbench
   (active? [selection] (or (selection->emitter selection)
                            (selection->particlefx selection)))
   (label [user-data] (if-not user-data
@@ -1111,7 +1111,7 @@
     (when (not user-data)
       (mapv (fn [[type data]] {:label (:label data)
                                :icon modifier-icon
-                               :command :add-secondary
+                               :command :edit.add-secondary-embedded-component
                                :user-data {:modifier-type type}}) mod-types))))
 
 (defn- make-emitter
@@ -1173,7 +1173,7 @@
           (g/operation-label "Add Emitter")
           (make-emitter self (assoc emitter :type type) select-fn true))))))
 
-(handler/defhandler :add :workbench
+(handler/defhandler :edit.add-embedded-component :workbench
   (active? [selection] (selection->particlefx selection))
   (label [user-data] (if-not user-data
                        "Add Emitter"
@@ -1185,7 +1185,7 @@
              (let [self (selection->particlefx selection)]
                (mapv (fn [[type data]] {:label (:label data)
                                         :icon emitter-icon
-                                        :command :add
+                                        :command :edit.add-embedded-component
                                         :user-data {:emitter-type type}}) emitter-types)))))
 
 

--- a/editor/src/clj/editor/pipeline/bob.clj
+++ b/editor/src/clj/editor/pipeline/bob.clj
@@ -245,7 +245,7 @@
          build-path (workspace/build-html5-path ws)]
      (io/file build-path "__htmlLaunchDir"))))
 
-(def rebuild-html5-bob-commands ["distclean" "resolve" "build" "bundle"])
+(def clean-build-html5-bob-commands ["distclean" "resolve" "build" "bundle"])
 (def build-html5-bob-commands ["build" "bundle"])
 
 (defn build-html5-bob-options [project prefs]

--- a/editor/src/clj/editor/prefs.clj
+++ b/editor/src/clj/editor/prefs.clj
@@ -63,6 +63,7 @@
             [editor.connection-properties :as connection-properties]
             [editor.fs :as fs]
             [editor.os :as os]
+            [service.log :as log]
             [util.coll :as coll]
             [util.crypto :as crypto]
             [util.eduction :as e]
@@ -166,7 +167,14 @@
              :properties
              {:dimensions {:type :any}
               :split-positions {:type :any}
-              :hidden-panes {:type :set :item {:type :keyword}}}}
+              :hidden-panes {:type :set :item {:type :keyword}}
+              :keymap {:type :object-of
+                       :key {:type :keyword} ;; command
+                       :val {:type :object
+                             :properties {;; custom shortcuts to add to keymap
+                                          :add {:type :set :item {:type :string}}
+                                          ;; built-in shortcuts to remove from keymap
+                                          :remove {:type :set :item {:type :string}}}}}}}
     :workflow {:type :object
                :properties
                {:load-external-changes-on-app-focus {:type :boolean
@@ -349,7 +357,11 @@
     (with-open [rdr (PushbackReader. (io/reader path))]
       (try
         (edn/read {:default fn/constantly-nil} rdr)
-        (catch Throwable _ ::not-found)))
+        (catch Throwable e
+          (let [content (try (slurp path) (catch Throwable _ ""))]
+            (when-not (= content "")
+              (log/error :message "Failed to read config" :content content :exception e)))
+          ::not-found)))
     ::not-found))
 
 (defn- array? [x]
@@ -423,7 +435,8 @@
                            (assoc acc file-path config)))
                        storage
                        events))))]
-      (swap! global-state incorporate-updated-storage updated-storage))))
+      (swap! global-state incorporate-updated-storage updated-storage)))
+  nil)
 
 (def ^:private ^ScheduledExecutorService sync-executor
   (Executors/newSingleThreadScheduledExecutor
@@ -454,7 +467,7 @@
                                             (coll/pair-map-by key #(resolve-schema (val %) scope) m)))
        schema))))
 
-(def global-state
+(defonce global-state
   ;; global state value is a map with the following keys:
   ;;   :storage     a map from absolute file Path to its prefs map
   ;;   :registry    a map from schema id (anything) to a schema map (schema)
@@ -626,6 +639,15 @@
       [[(-> schema :scope scopes) path (value->storage-value schema value)]]
       (throw (value-error path value schema)))))
 
+(defn- set-value-at-path [current-state scopes schema path value]
+  (reduce
+    (fn [acc [file-path config-path storage-value]]
+      (-> acc
+          (update-in [:storage file-path] safe-assoc-in config-path storage-value)
+          (assoc-in [:events file-path config-path] storage-value)))
+    current-state
+    (set-value-events scopes schema path value)))
+
 ;; endregion
 
 ;; region public api
@@ -685,14 +707,22 @@
   (let [{:keys [scopes]} prefs]
     (swap! global-state (fn [{:keys [registry] :as m}]
                           (let [schema (combined-schema-at-path registry prefs path)]
-                            (->> value
-                                 (set-value-events scopes schema path)
-                                 (reduce
-                                   (fn [acc [file-path config-path storage-value]]
-                                     (-> acc
-                                         (update-in [:storage file-path] safe-assoc-in config-path storage-value)
-                                         (assoc-in [:events file-path config-path] storage-value)))
-                                   m)))))
+                            (set-value-at-path m scopes schema path value))))
+    nil))
+
+(defn update!
+  "Atomically update a value in preferences at a specified assoc-in path
+
+  The new value must satisfy the combined schema. Will throw if invalid
+  (unregistered) path is provided. Does not perform file IO.
+
+  Using [] as a path allows changing the whole preference state"
+  [prefs path f & args]
+  (let [{:keys [scopes]} prefs]
+    (swap! global-state (fn [{:keys [registry storage] :as m}]
+                          (let [schema (combined-schema-at-path registry prefs path)
+                                value (lookup-valid-value-at-path scopes storage schema path)]
+                            (set-value-at-path m scopes schema path (apply f value args)))))
     nil))
 
 (defn schema

--- a/editor/src/clj/editor/prefs_dialog.clj
+++ b/editor/src/clj/editor/prefs_dialog.clj
@@ -39,7 +39,8 @@
             [editor.util :as eutil]
             [util.coll :as coll]
             [util.eduction :as e]
-            [util.fn :as fn])
+            [util.fn :as fn]
+            [util.text-util :as text-util])
   (:import [javafx.event ActionEvent]
            [javafx.scene Scene]
            [javafx.scene.control MenuItem TableView]
@@ -172,8 +173,8 @@
     {}))
 
 (defn filtered-command? [command shortcuts filter-text]
-  (or (eutil/includes-ignore-case? (filterable-command-label command) filter-text)
-      (coll/some #(eutil/includes-ignore-case? (keymap/shortcut-filterable-text %) filter-text) shortcuts)))
+  (or (text-util/includes-ignore-case? (filterable-command-label command) filter-text)
+      (coll/some #(text-util/includes-ignore-case? (keymap/shortcut-filterable-text %) filter-text) shortcuts)))
 
 (defn- handle-table-view-context-menu-requested-event [swap-state ^ContextMenuEvent e]
   (let [^TableView table-view (.getSource e)]
@@ -311,6 +312,7 @@
   [{:keys [update-keymap state swap-state keymap handler-state]}]
   (let [{:keys [filter-text context-menu new-shortcut-popup]} state
         commands (-> (handler/public-commands handler-state)
+                     (into (keymap/commands keymap))
                      (cond->> (not= filter-text "")
                               (filterv #(filtered-command? % (keymap/shortcuts keymap %) filter-text)))
                      (sort)
@@ -423,7 +425,7 @@
                                                  {:fx/type fx.column-constraints/lifecycle
                                                   :hgrow :always}]
                             :children (->> paths
-                                           (coll/mapcat-indexed
+                                           (e/mapcat-indexed
                                              (fn [row path]
                                                (let [schema (prefs/schema prefs-state prefs path)
                                                      tooltip (:description (:ui schema))]

--- a/editor/src/clj/editor/prefs_dialog.clj
+++ b/editor/src/clj/editor/prefs_dialog.clj
@@ -13,20 +13,40 @@
 ;; specific language governing permissions and limitations under the License.
 
 (ns editor.prefs-dialog
-  (:require [cljfx.api :as fx]
+  (:require [camel-snake-kebab :as camel]
+            [cljfx.api :as fx]
             [cljfx.fx.column-constraints :as fx.column-constraints]
+            [cljfx.fx.context-menu :as fx.context-menu]
             [cljfx.fx.h-box :as fx.h-box]
+            [cljfx.fx.menu-item :as fx.menu-item]
+            [cljfx.fx.popup :as fx.popup]
+            [cljfx.fx.region :as fx.region]
             [cljfx.fx.scene :as fx.scene]
+            [cljfx.fx.stack-pane :as fx.stack-pane]
             [cljfx.fx.tab :as fx.tab]
             [cljfx.fx.tab-pane :as fx.tab-pane]
+            [cljfx.fx.table-cell :as fx.table-cell]
+            [cljfx.fx.table-column :as fx.table-column]
+            [cljfx.fx.table-view :as fx.table-view]
             [clojure.java.io :as io]
+            [clojure.set :as set]
+            [clojure.string :as string]
             [editor.fxui :as fxui]
+            [editor.handler :as handler]
+            [editor.keymap :as keymap]
             [editor.prefs :as prefs]
             [editor.system :as system]
+            [editor.util :as eutil]
             [util.coll :as coll]
+            [util.eduction :as e]
             [util.fn :as fn])
-  (:import [javafx.scene Scene]
-           [javafx.scene.input KeyCode KeyEvent]))
+  (:import [javafx.event ActionEvent]
+           [javafx.scene Scene]
+           [javafx.scene.control MenuItem TableView]
+           [javafx.scene.input ContextMenuEvent KeyCode KeyCodeCombination KeyCombination KeyCombination$ModifierValue KeyEvent MouseEvent]
+           [javafx.stage Window]))
+
+(set! *warn-on-reflection* true)
 
 (def pages
   (delay
@@ -39,7 +59,6 @@
                 [:run :quit-on-escape]
                 [:asset-browser :track-active-tab]
                 [:build :lint-code]
-                [:input :keymap-path]
                 [:run :engine-arguments]]}
        {:name "Code"
         :paths [[:code :custom-editor]
@@ -88,43 +107,350 @@
              :on-value-changed on-value-changed}
             prompt (assoc :prompt-text prompt))))
 
-(defn- prefs-tab-pane [{:keys [prefs] prefs-state :value}]
+(defn- describe-command-cell [keymap command]
+  (if command
+    (let [changed (not= (keymap/shortcuts keymap command)
+                        (keymap/shortcuts (keymap/default) command))]
+      {:graphic {:fx/type fxui/horizontal
+                 :style-class "keymap-command"
+                 :pseudo-classes (if changed #{:overridden} #{})
+                 :spacing :small
+                 :children (->> (string/split (name command) #"\.")
+                                (e/map (fn [part]
+                                         {:fx/type fxui/label
+                                          :text (camel/->TitleCase part)}))
+                                (e/interpose {:fx/type fxui/label
+                                              :style-class "keymap-command-arrow"
+                                              :text "→"})
+                                vec)}})
+    {}))
+
+(defn- command-label [command]
+  (->> (string/split (name command) #"\.")
+       (e/map camel/->TitleCase)
+       (coll/join-to-string " → ")))
+
+(defn- filterable-command-label [command]
+  (->> (string/split (name command) #"\.")
+       (e/map camel/->TitleCase)
+       (coll/join-to-string " ")))
+
+(defn- warnings-messages [warnings]
+  (e/map (fn [[type warnings]]
+           (case type
+             :typable "Typable (may interfere with text inputs)"
+             :conflict (str "Conflicts with "
+                            (->> warnings
+                                 (mapv #(-> % :command command-label))
+                                 sort
+                                 (eutil/join-words ", " " and ")))
+             (string/capitalize (name type))))
+         (group-by :type warnings)))
+
+(defn- describe-shortcut-cell [keymap command]
+  (if command
+    (let [shortcuts (keymap/shortcuts keymap command)]
+      {:graphic
+       {:fx/type fxui/horizontal
+        :spacing :small
+        :style-class "keymap-shortcuts"
+        :children
+        (->> shortcuts
+             (mapv (coll/pair-fn keymap/shortcut-distinct-display-text))
+             (sort-by key)
+             (mapv
+               (fn [[text shortcut]]
+                 (let [warnings (keymap/warnings keymap command shortcut)]
+                   (cond-> {:fx/type fxui/label
+                            :style-class "keymap-shortcut"
+                            :text text}
+                           warnings
+                           (assoc :pseudo-classes #{:warning}
+                                  :tooltip (->> warnings
+                                                warnings-messages
+                                                (coll/join-to-string "\n"))))))))}})
+    {}))
+
+(defn filtered-command? [command shortcuts filter-text]
+  (or (eutil/includes-ignore-case? (filterable-command-label command) filter-text)
+      (coll/some #(eutil/includes-ignore-case? (keymap/shortcut-filterable-text %) filter-text) shortcuts)))
+
+(defn- handle-table-view-context-menu-requested-event [swap-state ^ContextMenuEvent e]
+  (let [^TableView table-view (.getSource e)]
+    (when-let [command (.getSelectedItem (.getSelectionModel table-view))]
+      (swap-state assoc :context-menu {:command command :x (.getScreenX e) :y (.getScreenY e)}))))
+
+(defn- handle-reset-shortcuts-action [update-keymap command _]
+  (update-keymap dissoc command))
+
+(defn- handle-add-shortcut-action [update-keymap command shortcut _]
+  (let [shortcut-str (str shortcut)]
+    (update-keymap update command (fn [old-changes]
+                                    (if (and (contains? (keymap/shortcuts (keymap/default) command) shortcut)
+                                             (contains? (:remove old-changes) shortcut-str))
+                                      (update old-changes :remove (fnil disj #{}) shortcut-str)
+                                      (update old-changes :add (fnil conj #{}) shortcut-str))))))
+
+(defn handle-remove-shortcut-action [update-keymap command shortcut _]
+  (let [shortcut-str (str shortcut)]
+    (update-keymap
+      update
+      command
+      (fn [old-changes]
+        (cond-> old-changes
+                (contains? (:add old-changes) shortcut-str)
+                (update :add (fnil disj #{}) shortcut-str)
+
+                (contains? (keymap/shortcuts (keymap/default) command) shortcut)
+                (update :remove (fnil conj #{}) shortcut-str))))))
+
+(def ^:private ^:const new-shortcut-popup-width 400)
+(def ^:private ^:const new-shortcut-popup-height 200)
+(def ^:private enter-shortcut (KeyCombination/valueOf "Enter"))
+(def ^:private escape-shortcut (KeyCombination/valueOf "Esc"))
+
+(defn- filter-new-shortcut-text-field-events [command displayed-shortcut swap-shortcut swap-state update-keymap e]
+  (condp instance? e
+    KeyEvent
+    (let [^KeyEvent e e]
+      (.consume e)
+      (when (and (= KeyEvent/KEY_PRESSED (.getEventType e))
+                 (not= KeyCode/ALT (.getCode e))
+                 (not= KeyCode/CONTROL (.getCode e))
+                 (not= KeyCode/META (.getCode e))
+                 (not= KeyCode/SHIFT (.getCode e))
+                 (not= KeyCode/COMMAND (.getCode e))
+                 (not= KeyCode/UNDEFINED (.getCode e)))
+        (let [shift (if (.isShiftDown e) KeyCombination$ModifierValue/DOWN KeyCombination$ModifierValue/UP)
+              control (if (.isControlDown e) KeyCombination$ModifierValue/DOWN KeyCombination$ModifierValue/UP)
+              alt (if (.isAltDown e) KeyCombination$ModifierValue/DOWN KeyCombination$ModifierValue/UP)
+              meta (if (.isMetaDown e) KeyCombination$ModifierValue/DOWN KeyCombination$ModifierValue/UP)
+              shortcut (KeyCodeCombination. (.getCode e) shift control alt meta KeyCombination$ModifierValue/UP)]
+          (cond
+            (= displayed-shortcut shortcut escape-shortcut)
+            (swap-state dissoc :new-shortcut-popup)
+
+            (and displayed-shortcut (= shortcut enter-shortcut))
+            (let [shortcut-str (str displayed-shortcut)]
+              (swap-state dissoc :new-shortcut-popup)
+              (update-keymap update command (fn [old-changes]
+                                              (-> old-changes
+                                                  (update :remove (fnil disj #{}) shortcut-str)
+                                                  (update :add (fnil conj #{}) shortcut-str)))))
+            :else
+            (swap-shortcut (constantly shortcut))))))
+
+    ContextMenuEvent
+    (let [^ContextMenuEvent e e]
+      (.consume e))
+
+    nil))
+
+(fxui/defc new-shortcut-view
+  {:compose [{:fx/type fx/ext-state
+              :initial-state nil
+              :key :shortcut
+              :swap-key :swap-shortcut}]}
+  [{:keys [keymap command shortcut swap-shortcut swap-state update-keymap]}]
+  (let [warnings (when shortcut
+                   (keymap/warnings (keymap/from keymap {command {:add #{(str shortcut)}}}) command shortcut))]
+    {:fx/type fxui/vertical
+     :padding :small
+     :spacing :small
+     :children
+     (cond->
+       [{:fx/type fxui/label
+         :alignment :center
+         :text (str "New '" (command-label command) "' Shortcut")}
+        {:fx/type fxui/text-field
+         :event-filter #(filter-new-shortcut-text-field-events command shortcut swap-shortcut swap-state update-keymap %)
+         :alignment :center
+         :text (some-> shortcut keymap/shortcut-distinct-display-text)}
+        {:fx/type fxui/label
+         :alignment :center
+         :text-alignment :center
+         :color :hint
+         :text (if (not shortcut)
+                 "Press the desired key combination"
+                 (str
+                   (str "Press " (keymap/shortcut-display-text enter-shortcut) " to commit")
+                   (when (= shortcut escape-shortcut)
+                     (str ", " (keymap/shortcut-display-text escape-shortcut) " again to cancel"))))}]
+       warnings
+       (conj {:fx/type fxui/paragraph
+              :text (str "Warnings:\n• " (coll/join-to-string "\n• " (warnings-messages warnings)))}))}))
+
+(defn- show-new-shortcut-dialog! [swap-state command ^Window window]
+  (let [root (.getRoot (.getScene window))
+        screen-bounds (.localToScreen root (.getBoundsInLocal root))
+        x (- (.getCenterX screen-bounds) (* 0.5 new-shortcut-popup-width))
+        y (- (.getCenterY screen-bounds) (* 0.5 new-shortcut-popup-height))]
+    (swap-state assoc :new-shortcut-popup {:command command :x x :y y})))
+
+(defn- handle-new-shortcut-action [swap-state command ^ActionEvent e]
+  (show-new-shortcut-dialog! swap-state command (.getOwnerWindow (.getParentPopup ^MenuItem (.getSource e)))))
+
+(defn- handle-table-view-key-pressed [swap-state ^KeyEvent e]
+  (when (or (= KeyCode/SPACE (.getCode e)) (= KeyCode/ENTER (.getCode e)))
+    (let [^TableView table-view (.getSource e)]
+      (when-let [command (.getSelectedItem (.getSelectionModel table-view))]
+        (show-new-shortcut-dialog! swap-state command (.getWindow (.getScene table-view)))))))
+
+(defn- handle-table-view-mouse-clicked [swap-state ^MouseEvent e]
+  (when (= 2 (.getClickCount e))
+    (let [^TableView table-view (.getSource e)]
+      (when-let [command (.getSelectedItem (.getSelectionModel table-view))]
+        (show-new-shortcut-dialog! swap-state command (.getWindow (.getScene table-view)))))))
+
+(fxui/defc keymap-view
+  {:compose [{:fx/type fx/ext-watcher
+              :ref handler/state-atom
+              :key :handler-state}
+             {:fx/type fx/ext-state
+              :initial-state {:filter-text ""}}]}
+  [{:keys [update-keymap state swap-state keymap handler-state]}]
+  (let [{:keys [filter-text context-menu new-shortcut-popup]} state
+        commands (-> (handler/public-commands handler-state)
+                     (cond->> (not= filter-text "")
+                              (filterv #(filtered-command? % (keymap/shortcuts keymap %) filter-text)))
+                     (sort)
+                     (vec))]
+    {:fx/type fxui/vertical
+     :padding :medium
+     :spacing :medium
+     :children
+     [{:fx/type fxui/text-field
+       :prompt-text "Filter keymap..."
+       :text filter-text
+       :on-text-changed #(swap-state assoc :filter-text %)}
+      {:fx/type fxui/with-popup-window
+       :v-box/vgrow :always
+       :popup
+       (cond
+         new-shortcut-popup
+         (let [{:keys [command x y]} new-shortcut-popup]
+           {:fx/type fx.popup/lifecycle
+            :on-window true
+            :showing true
+            :anchor-x x
+            :anchor-y y
+            :auto-hide true
+            :on-hiding (fn [_] (swap-state dissoc :new-shortcut-popup))
+            :content [{:fx/type fx.stack-pane/lifecycle
+                       :pref-width new-shortcut-popup-width
+                       :children
+                       [{:fx/type fx.region/lifecycle
+                         :style-class "keymap-new-shortcut-background"}
+                        {:fx/type new-shortcut-view
+                         :keymap keymap
+                         :command command
+                         :swap-state swap-state
+                         :update-keymap update-keymap}]}]})
+
+         context-menu
+         (let [{:keys [command x y]} context-menu
+               shortcuts (keymap/shortcuts keymap command)
+               default-shortcuts (keymap/shortcuts (keymap/default) command)]
+           {:fx/type fx.context-menu/lifecycle
+            :on-window true
+            :showing true
+            :anchor-x x
+            :anchor-y y
+            :on-hiding (fn [_] (swap-state dissoc :context-menu))
+            :items (vec
+                     (e/cons
+                       {:fx/type fx.menu-item/lifecycle
+                        :text "New Shortcut..."
+                        :on-action #(handle-new-shortcut-action swap-state command %)}
+                       (e/concat
+                         (when (not= shortcuts default-shortcuts)
+                           [{:fx/type fx.menu-item/lifecycle
+                             :text "Reset to Default"
+                             :on-action #(handle-reset-shortcuts-action update-keymap command %)}])
+                         (->> shortcuts
+                              (mapv (coll/pair-fn keymap/shortcut-distinct-display-text))
+                              (sort-by key)
+                              (e/map (fn [[text shortcut]]
+                                       {:fx/type fx.menu-item/lifecycle
+                                        :text (str "Remove " text)
+                                        :on-action #(handle-remove-shortcut-action update-keymap command shortcut %)})))
+                         (when default-shortcuts
+                           (let [removed-built-in-shortcuts (set/difference default-shortcuts (or shortcuts #{}))]
+                             (->> removed-built-in-shortcuts
+                                  (mapv (coll/pair-fn keymap/shortcut-distinct-display-text))
+                                  (sort-by key)
+                                  (e/map (fn [[text shortcut]]
+                                           {:fx/type fx.menu-item/lifecycle
+                                            :text (str "Add " text)
+                                            :on-action #(handle-add-shortcut-action update-keymap command shortcut %)}))))))))}))
+       :desc
+       {:fx/type fx.table-view/lifecycle
+        :style-class ["table-view" "ext-table-view" "keymap-table"]
+        :column-resize-policy TableView/CONSTRAINED_RESIZE_POLICY_ALL_COLUMNS
+        :placeholder {:fx/type fx.region/lifecycle}
+        :columns [{:fx/type fx.table-column/lifecycle
+                   :reorderable false
+                   :sortable false
+                   :text "Command"
+                   :cell-value-factory identity
+                   :cell-factory {:fx/cell-type fx.table-cell/lifecycle
+                                  :describe (fn/partial #'describe-command-cell keymap)}}
+                  {:fx/type fx.table-column/lifecycle
+                   :reorderable false
+                   :sortable false
+                   :text "Shortcuts"
+                   :cell-value-factory identity
+                   :cell-factory {:fx/cell-type fx.table-cell/lifecycle
+                                  :describe (fn/partial #'describe-shortcut-cell keymap)}}]
+        :on-context-menu-requested #(handle-table-view-context-menu-requested-event swap-state %)
+        :on-key-pressed #(handle-table-view-key-pressed swap-state %)
+        :on-mouse-clicked #(handle-table-view-mouse-clicked swap-state %)
+        :items commands}}]}))
+
+(defn- prefs-tab-pane [{:keys [prefs prefs-state]}]
   {:fx/type fx.tab-pane/lifecycle
    :tab-closing-policy :unavailable
-   :tabs (mapv
-           (fn [{:keys [name paths]}]
+   :tabs (vec
+           (e/conj
+             (e/map
+               (fn [{:keys [name paths]}]
+                 {:fx/type fx.tab/lifecycle
+                  :text name
+                  :content {:fx/type fxui/grid
+                            :padding :medium
+                            :spacing :medium
+                            :column-constraints [{:fx/type fx.column-constraints/lifecycle}
+                                                 {:fx/type fx.column-constraints/lifecycle
+                                                  :hgrow :always}]
+                            :children (->> paths
+                                           (coll/mapcat-indexed
+                                             (fn [row path]
+                                               (let [schema (prefs/schema prefs-state prefs path)
+                                                     tooltip (:description (:ui schema))]
+                                                 [(cond-> {:fx/type fxui/label
+                                                           :grid-pane/row row
+                                                           :grid-pane/column 0
+                                                           :grid-pane/fill-width false
+                                                           :grid-pane/fill-height false
+                                                           :grid-pane/valignment :top
+                                                           :text (prefs/label prefs-state prefs path)}
+                                                          tooltip
+                                                          (assoc :tooltip tooltip))
+                                                  (assoc
+                                                    (form-input schema
+                                                                (prefs/get prefs-state prefs path)
+                                                                (fn/partial prefs/set! prefs path))
+                                                    :grid-pane/row row
+                                                    :grid-pane/column 1)])))
+                                           vec)}})
+               @pages)
              {:fx/type fx.tab/lifecycle
-              :text name
-              :content {:fx/type fxui/grid
-                        :padding :medium
-                        :spacing :medium
-                        :column-constraints [{:fx/type fx.column-constraints/lifecycle}
-                                             {:fx/type fx.column-constraints/lifecycle
-                                              :hgrow :always}]
-                        :children (->> paths
-                                       (coll/mapcat-indexed
-                                         (fn [row path]
-                                           (let [schema (prefs/schema prefs-state prefs path)
-                                                 tooltip (:description (:ui schema))]
-                                             [(cond-> {:fx/type fxui/label
-                                                       :grid-pane/row row
-                                                       :grid-pane/column 0
-                                                       :grid-pane/fill-width false
-                                                       :grid-pane/fill-height false
-                                                       :grid-pane/valignment :top
-                                                       :text (prefs/label prefs-state prefs path)}
-                                                      tooltip
-                                                      (assoc :tooltip tooltip))
-                                              (assoc
-                                                (form-input schema
-                                                            (prefs/get prefs-state prefs path)
-                                                            (fn/partial prefs/set! prefs path))
-                                                :grid-pane/row row
-                                                :grid-pane/column 1)])))
-                                       vec)}})
-           @pages)})
+              :text "Keymap"
+              :content {:fx/type keymap-view
+                        :keymap (keymap/from-prefs prefs-state prefs)
+                        :update-keymap (fn/partial prefs/update! prefs [:window :keymap])}}))})
 
-(defn handle-scene-key-pressed [^KeyEvent e]
+(defn- handle-scene-key-pressed [^KeyEvent e]
   (when (= KeyCode/ESCAPE (.getCode e))
     (.consume e)
     (.hide (.getWindow ^Scene (.getSource e)))))
@@ -146,6 +472,7 @@
                :on-key-pressed handle-scene-key-pressed
                :root {:fx/type fx/ext-watcher
                       :ref prefs/global-state
+                      :key :prefs-state
                       :desc {:fx/type prefs-tab-pane
                              :prefs prefs}}}}))
   nil)

--- a/editor/src/clj/editor/properties_view.clj
+++ b/editor/src/clj/editor/properties_view.clj
@@ -674,7 +674,7 @@
     (ui/on-action! open-button (fn [_]  (when-let [resource (-> (property-fn)
                                                               properties/values
                                                               properties/unify-values)]
-                                          (ui/run-command open-button :open {:resources [resource]}))))
+                                          (ui/run-command open-button :file.open resource))))
     (customize! text commit-fn cancel-fn)
     (ui/children! box [text browse-button open-button])
     (GridPane/setConstraints text 0 0)
@@ -840,7 +840,7 @@
     (.setMinWidth Label/USE_PREF_SIZE)
     (.setMinHeight 28.0)))
 
-(handler/defhandler :show-overrides :property
+(handler/defhandler :window.show-overrides :property
   (active? [evaluation-context selection]
     (when-let [node-id (handler/selection->node-id selection)]
       (pos? (count (g/overrides (:basis evaluation-context) node-id)))))
@@ -849,7 +849,7 @@
 
 (handler/register-menu! ::properties-menu
   [{:label "Show Overrides"
-    :command :show-overrides}])
+    :command :window.show-overrides}])
 
 (defrecord SelectionProvider [original-node-ids]
   handler/SelectionProvider

--- a/editor/src/clj/editor/properties_view.clj
+++ b/editor/src/clj/editor/properties_view.clj
@@ -840,7 +840,7 @@
     (.setMinWidth Label/USE_PREF_SIZE)
     (.setMinHeight 28.0)))
 
-(handler/defhandler :window.show-overrides :property
+(handler/defhandler :edit.show-overrides :property
   (active? [evaluation-context selection]
     (when-let [node-id (handler/selection->node-id selection)]
       (pos? (count (g/overrides (:basis evaluation-context) node-id)))))
@@ -849,7 +849,7 @@
 
 (handler/register-menu! ::properties-menu
   [{:label "Show Overrides"
-    :command :window.show-overrides}])
+    :command :edit.show-overrides}])
 
 (defrecord SelectionProvider [original-node-ids]
   handler/SelectionProvider

--- a/editor/src/clj/editor/scene_selection.clj
+++ b/editor/src/clj/editor/scene_selection.clj
@@ -32,21 +32,21 @@
 
 (handler/register-menu! ::scene-selection-menu
                         [{:label "Cut"
-                          :command :cut}
+                          :command :edit.cut}
                          {:label "Copy"
-                          :command :copy}
+                          :command :edit.copy}
                          {:label "Paste"
-                          :command :paste}
+                          :command :edit.paste}
                          {:label "Delete"
                           :icon "icons/32/Icons_M_06_trash.png"
-                          :command :delete}
+                          :command :edit.delete}
                          {:label :separator}
                          {:label "Show/Hide Objects"
-                          :command :hide-toggle-selected}
+                          :command :scene.visibility.toggle-selection}
                          {:label "Hide Unselected Objects"
-                          :command :hide-unselected}
+                          :command :scene.visibility.hide-unselected}
                          {:label "Show All Hidden Objects"
-                          :command :show-all-hidden}
+                          :command :scene.visibility.show-all}
                          {:label :separator
                           :id ::context-menu-end}])
 

--- a/editor/src/clj/editor/scene_visibility.clj
+++ b/editor/src/clj/editor/scene_visibility.clj
@@ -48,8 +48,8 @@
            {:label "Text" :tag :text}
            {:label "Tile Maps" :tag :tilemap}
            {:label :separator}
-           {:label "Component Guides" :tag :outline :command :toggle-component-guides :always-enabled true}
-           {:label "Grid" :tag :grid :always-enabled true}]
+           {:label "Component Guides" :tag :outline :command :scene.visibility.toggle-component-guides :always-enabled true}
+           {:label "Grid" :tag :grid :command :scene.visibility.toggle-grid :always-enabled true}]
 
           (system/defold-dev?)
           (into [{:label :separator}
@@ -227,14 +227,14 @@
                       (g/connect scene-resource-node :_node-id scene-hide-history-node :scene-resource-node)
                       (g/connect scene-hide-history-node :scene-hide-history-data scene-visibility :scene-hide-history-datas))))))
 
-(handler/defhandler :hide-unselected :workbench
+(handler/defhandler :scene.visibility.hide-unselected :workbench
   (active? [scene-visibility evaluation-context]
            (g/node-value scene-visibility :active-scene-resource-node evaluation-context))
   (enabled? [scene-visibility evaluation-context]
             (g/node-value scene-visibility :unselected-hideable-outline-name-paths evaluation-context))
   (run [scene-visibility] (hide-outline-name-paths! scene-visibility (g/node-value scene-visibility :unselected-hideable-outline-name-paths))))
 
-(handler/defhandler :hide-toggle-selected :workbench
+(handler/defhandler :scene.visibility.toggle-selection :workbench
   (active? [scene-visibility evaluation-context]
            (g/node-value scene-visibility :active-scene-resource-node evaluation-context))
   (enabled? [scene-visibility evaluation-context]
@@ -247,7 +247,7 @@
              (hide-outline-name-paths! scene-visibility (g/node-value scene-visibility :selected-hideable-outline-name-paths))
              (show-outline-name-paths! scene-visibility (g/node-value scene-visibility :selected-showable-outline-name-paths)))))))
 
-(handler/defhandler :hide-toggle :workbench
+(handler/defhandler :private/hide-toggle :workbench
   (active? [scene-visibility evaluation-context user-data]
            (g/node-value scene-visibility :active-scene-resource-node evaluation-context))
   (run [scene-visibility user-data]
@@ -257,14 +257,14 @@
            (show-outline-name-paths! scene-visibility name-paths-to-toggle)
            (hide-outline-name-paths! scene-visibility name-paths-to-toggle)))))
 
-(handler/defhandler :show-last-hidden :workbench
+(handler/defhandler :scene.visibility.show-last-hidden :workbench
   (active? [scene-visibility evaluation-context]
            (g/node-value scene-visibility :active-scene-resource-node evaluation-context))
   (enabled? [scene-visibility evaluation-context]
             (g/node-value scene-visibility :last-hidden-outline-name-paths evaluation-context))
   (run [scene-visibility] (show-outline-name-paths! scene-visibility (g/node-value scene-visibility :last-hidden-outline-name-paths))))
 
-(handler/defhandler :show-all-hidden :workbench
+(handler/defhandler :scene.visibility.show-all :workbench
   (active? [scene-visibility evaluation-context]
            (g/node-value scene-visibility :active-scene-resource-node evaluation-context))
   (enabled? [scene-visibility evaluation-context]
@@ -316,19 +316,13 @@
 (defn- make-visibility-toggles-list
   ^Region [app-view scene-visibility]
   (let [keymap (g/node-value app-view :keymap)
-        command->shortcut (keymap/command->shortcut keymap)
-        command->display-text (fn [command]
-                                (let [shortcut (get command->shortcut command)]
-                                  (if shortcut
-                                    (keymap/key-combo->display-text shortcut)
-                                    "")))
         make-control
         (fn [{:keys [label tag command always-enabled]}]
           (if (= :separator label)
             [(Separator.) nil]
             (let [[control update-fn]
                   (make-toggle {:label label
-                                :acc (if command (command->display-text command) "")
+                                :acc (if command (keymap/display-text keymap command "") "")
                                 :on-change (fn [checked]
                                              (set-tag-visibility! scene-visibility tag checked))})
                   update-from-hidden-tags
@@ -347,7 +341,7 @@
 
         [filters-enabled-control filters-enabled-update-fn]
         (make-toggle {:label "Visibility Filters"
-                      :acc (command->display-text :toggle-visibility-filters)
+                      :acc (keymap/display-text keymap :scene.visibility.toggle-filters "")
                       :on-change (fn [checked]
                                    (set-filters-enabled! scene-visibility checked))})
 
@@ -394,17 +388,17 @@
 (defn settings-visible? [^Parent owner]
   (some? (ui/user-data owner ::popup)))
 
-(handler/defhandler :toggle-visibility-filters :workbench
+(handler/defhandler :scene.visibility.toggle-filters :workbench
   (active? [scene-visibility evaluation-context]
            (g/node-value scene-visibility :active-scene-resource-node evaluation-context))
   (run [scene-visibility] (toggle-filters-enabled! scene-visibility)))
 
-(handler/defhandler :toggle-component-guides :workbench
+(handler/defhandler :scene.visibility.toggle-component-guides :workbench
   (active? [scene-visibility evaluation-context]
            (g/node-value scene-visibility :active-scene-resource-node evaluation-context))
   (run [scene-visibility] (toggle-tag-visibility! scene-visibility :outline)))
 
-(handler/defhandler :toggle-grid :workbench
+(handler/defhandler :scene.visibility.toggle-grid :workbench
   (active? [scene-visibility evaluation-context]
            (g/node-value scene-visibility :active-scene-resource-node evaluation-context))
   (run [scene-visibility] (toggle-tag-visibility! scene-visibility :grid)))

--- a/editor/src/clj/editor/search_results_view.clj
+++ b/editor/src/clj/editor/search_results_view.clj
@@ -389,7 +389,7 @@
                                  :text (resource/resource->proj-path resource)}]
                                qualifier
                                (conj {:fx/type fxui/legacy-label
-                                      :style {:-fx-text-fill :-df-text-darker}
+                                      :style {:-fx-text-fill :-df-text-dark}
                                       :text qualifier}))}})
 
 (defn- property->edit-type-dispatch-value [property]

--- a/editor/src/clj/editor/targets.clj
+++ b/editor/src/clj/editor/targets.clj
@@ -447,12 +447,12 @@
     :id ::target
     :on-submenu-open update!
     :command :run.select-target
-    :expand? true}
+    :expand true}
    {:label "Close Engine"
     :command :run.stop}
    {:label "Launched Instance Count"
     :command :run.set-instance-count
-    :expand? true}
+    :expand true}
    {:label "Enter Target IP"
     :command :run.set-target-ip}
    {:label "Target Discovery Log"

--- a/editor/src/clj/editor/targets.clj
+++ b/editor/src/clj/editor/targets.clj
@@ -365,13 +365,13 @@
 
 (defn- target-option [target]
   {:label     (target-menu-label target)
-   :command   :target
+   :command   :run.select-target
    :check     true
    :user-data target})
 
 (def ^:private separator {:label :separator})
 
-(handler/defhandler :target :global
+(handler/defhandler :run.select-target :global
   (run [user-data prefs workspace]
     (when user-data
       (try
@@ -379,23 +379,23 @@
         (catch Exception e
           (show-error-message e workspace)))))
   (state [user-data prefs]
-         (let [selected-target (selected-target prefs)]
-           (or (= user-data selected-target)
-               (= (:id user-data) (:id selected-target) :all-launched-targets)
-               (and (nil? selected-target)
-                    (= user-data :new-local-engine)))))
+    (let [selected-target (selected-target prefs)]
+      (or (= user-data selected-target)
+          (= (:id user-data) (:id selected-target) :all-launched-targets)
+          (and (nil? selected-target)
+               (= user-data :new-local-engine)))))
   (options [user-data]
-           (when-not user-data
-             (let [launched-options (mapv target-option @launched-targets)
-                   ssdp-options (mapv target-option @ssdp-targets)]
-               (cond
-                 (seq launched-options)
-                 (if (> (count launched-options) 1)
-                 (into [{:label "All Launched Instances" :check true :command :target :user-data {:id :all-launched-targets}}] (concat launched-options [separator] ssdp-options))
-                 (into launched-options (concat [separator] ssdp-options)))
+    (when-not user-data
+      (let [launched-options (mapv target-option @launched-targets)
+            ssdp-options (mapv target-option @ssdp-targets)]
+        (cond
+          (seq launched-options)
+          (if (> (count launched-options) 1)
+            (into [{:label "All Launched Instances" :check true :command :run.select-target :user-data {:id :all-launched-targets}}] (concat launched-options [separator] ssdp-options))
+            (into launched-options (concat [separator] ssdp-options)))
 
-                 :else
-                 (into [{:label "New Local Engine" :check true :command :target :user-data :new-local-engine} separator] ssdp-options))))))
+          :else
+          (into [{:label "New Local Engine" :check true :command :run.select-target :user-data :new-local-engine} separator] ssdp-options))))))
 
 (defn- locate-device [ip port]
   (when (not-empty ip)
@@ -411,32 +411,32 @@
         device
         (throw (ex-info (format "'%s' could not be reached from this host" ip) {}))))))
 
-(handler/defhandler :target-ip :global
+(handler/defhandler :run.set-target-ip :global
   (run [prefs]
-       (ui/run-later
-         (loop [manual-ip+port (dialogs/make-target-ip-dialog (prefs/get prefs [:run :manual-target-ip+port]) nil)]
-           (when (some? manual-ip+port)
-             (prefs/set! prefs [:run :manual-target-ip+port] manual-ip+port)
-             (let [[manual-ip port] (str/split manual-ip+port #":")
-                   device (try
-                            (locate-device manual-ip port)
-                            (catch Exception e (.getMessage e)))
-                   target (when (not (string? device))
-                            (device->target update-targets-context device))
-                   error-msg (or (and (string? target) target)
-                                 (and (string? device) device))]
-               (if error-msg
-                 (recur (dialogs/make-target-ip-dialog manual-ip+port error-msg))
-                 (do
-                   (reset! manual-device device)
-                   (select-target! prefs target)
-                   (invalidate-target-menu!)))))))))
+    (ui/run-later
+      (loop [manual-ip+port (dialogs/make-target-ip-dialog (prefs/get prefs [:run :manual-target-ip+port]) nil)]
+        (when (some? manual-ip+port)
+          (prefs/set! prefs [:run :manual-target-ip+port] manual-ip+port)
+          (let [[manual-ip port] (str/split manual-ip+port #":")
+                device (try
+                         (locate-device manual-ip port)
+                         (catch Exception e (.getMessage e)))
+                target (when (not (string? device))
+                         (device->target update-targets-context device))
+                error-msg (or (and (string? target) target)
+                              (and (string? device) device))]
+            (if error-msg
+              (recur (dialogs/make-target-ip-dialog manual-ip+port error-msg))
+              (do
+                (reset! manual-device device)
+                (select-target! prefs target)
+                (invalidate-target-menu!)))))))))
 
-(handler/defhandler :target-log :global
+(handler/defhandler :run.show-target-log :global
   (run []
-       (dialogs/make-target-log-dialog event-log #(reset! event-log []) restart)))
+    (dialogs/make-target-log-dialog event-log #(reset! event-log []) restart)))
 
-(handler/defhandler :close-engine :global
+(handler/defhandler :run.stop :global
   (enabled? [app-view] (launched-targets?))
   (active? [] true)
   (run []
@@ -446,19 +446,14 @@
   [{:label "Target"
     :id ::target
     :on-submenu-open update!
-    :command :target}
+    :command :run.select-target
+    :expand? true}
    {:label "Close Engine"
-    :command :close-engine}
+    :command :run.stop}
    {:label "Launched Instance Count"
-    :children (mapv (fn [i]
-                      {:label (str i (if (> i 1)
-                                       " Instances"
-                                       " Instance"))
-                       :command :set-instance-count
-                       :check true
-                       :user-data {:instance-count i}})
-                    (range 1 5))}
+    :command :run.set-instance-count
+    :expand? true}
    {:label "Enter Target IP"
-    :command :target-ip}
+    :command :run.set-target-ip}
    {:label "Target Discovery Log"
-    :command :target-log}])
+    :command :run.show-target-log}])

--- a/editor/src/clj/editor/tile_map.clj
+++ b/editor/src/clj/editor/tile_map.clj
@@ -1460,7 +1460,7 @@
       (g/operation-label "Add layer")
       (make-layer-node tile-map-node (make-new-layer layer-id))))))
 
-(handler/defhandler :add :workbench
+(handler/defhandler :edit.add-embedded-component :workbench
   (label [user-data] "Add layer")
   (active? [selection] (selection->tile-map selection))
   (run [selection user-data] (add-layer-handler (selection->tile-map selection))))
@@ -1487,7 +1487,7 @@
   (let [input-handlers (map first (g/sources-of scene-view :input-handlers))]
     (first (filter (partial g/node-instance? TileMapController) input-handlers))))
 
-(handler/defhandler :erase-tool :workbench
+(handler/defhandler :scene.select-erase-tool :workbench
   (label [user-data] "Select Eraser")
   (active? [app-view evaluation-context]
            (and (active-tile-map app-view evaluation-context)
@@ -1501,7 +1501,7 @@
 (defn- tile-map-palette-handler [tool-controller]
   (g/update-property! tool-controller :mode (toggler :palette :editor)))
 
-(handler/defhandler :show-palette :workbench
+(handler/defhandler :scene.toggle-tile-palette :workbench
   (active? [app-view evaluation-context]
            (and (active-tile-map app-view evaluation-context)
                 (active-scene-view app-view evaluation-context)))
@@ -1517,7 +1517,7 @@
         tool-controller (scene-view->tool-controller scene-view)]
     (g/update-property! tool-controller :brush transform-brush-fn)))
 
-(handler/defhandler :flip-brush-horizontally :workbench
+(handler/defhandler :scene.flip-brush-horizontally :workbench
   (active? [app-view evaluation-context]
            (and (active-tile-map app-view evaluation-context)
                 (active-scene-view app-view evaluation-context)))
@@ -1527,7 +1527,7 @@
              (g/node-value :tile-source-resource evaluation-context))))
   (run [app-view] (transform-brush! app-view flip-brush-horizontally)))
 
-(handler/defhandler :flip-brush-vertically :workbench
+(handler/defhandler :scene.flip-brush-vertically :workbench
   (active? [app-view evaluation-context]
            (and (active-tile-map app-view evaluation-context)
                 (active-scene-view app-view evaluation-context)))
@@ -1537,7 +1537,7 @@
                      (g/node-value :tile-source-resource evaluation-context))))
   (run [app-view] (transform-brush! app-view flip-brush-vertically)))
 
-(handler/defhandler :rotate-brush-90-degrees :workbench
+(handler/defhandler :scene.rotate-brush-90-degrees :workbench
   (active? [app-view evaluation-context]
            (and (active-tile-map app-view evaluation-context)
                 (active-scene-view app-view evaluation-context)))
@@ -1549,15 +1549,15 @@
 
 (handler/register-menu! ::menubar :editor.app-view/edit-end
   [{:label "Select Tile..."
-    :command :show-palette}
+    :command :scene.toggle-tile-palette}
    {:label "Select Eraser"
-    :command :erase-tool}
+    :command :scene.select-erase-tool}
    {:label "Flip Brush Horizontally"
-    :command :flip-brush-horizontally}
+    :command :scene.flip-brush-horizontally}
    {:label "Flip Brush Vertically"
-    :command :flip-brush-vertically}
+    :command :scene.flip-brush-vertically}
    {:label "Rotate Brush 90 Degrees"
-    :command :rotate-brush-90-degrees}])
+    :command :scene.rotate-brush-90-degrees}])
 
 (defn register-resource-types [workspace]
   (resource-node/register-ddf-resource-type workspace

--- a/editor/src/clj/editor/tile_source.clj
+++ b/editor/src/clj/editor/tile_source.clj
@@ -1005,7 +1005,7 @@
 (defn- selection->tile-source [selection]
   (handler/adapt-single selection TileSourceNode))
 
-(handler/defhandler :add :workbench
+(handler/defhandler :edit.add-embedded-component :workbench
   (active? [selection] (selection->tile-source selection))
   (label [selection user-data]
          (if-not user-data
@@ -1015,11 +1015,11 @@
            (when-not user-data
              [{:label "Animation"
                :icon animation-icon
-               :command :add
+               :command :edit.add-embedded-component
                :user-data {:action add-animation-node!}}
               {:label "Collision Group"
                :icon collision-icon
-               :command :add
+               :command :edit.add-embedded-component
                :user-data {:action add-collision-group-node!}}]))
   (run [selection user-data app-view]
     ((:action user-data) (selection->tile-source selection) (fn [node-ids] (app-view/select app-view node-ids)))))

--- a/editor/src/clj/editor/ui.clj
+++ b/editor/src/clj/editor/ui.clj
@@ -1418,7 +1418,7 @@
                   enabled? (handler/enabled? handler-ctx evaluation-context)
                   key-combo (first (keymap/shortcuts keymap command))]
               (if-let [options (handler/options handler-ctx)]
-                (if (and key-combo (not (:expand? item)))
+                (if (and key-combo (not (:expand item)))
                   (make-menu-command scene id label icon style-classes key-combo user-data command enabled? check)
                   (make-submenu id
                                 label

--- a/editor/src/clj/editor/util.clj
+++ b/editor/src/clj/editor/util.clj
@@ -179,16 +179,3 @@
           (assoc m k new-child)))
       m)
     (dissoc m k)))
-
-(defn includes-ignore-case?
-  "Like clojure.string/includes?, but case-insensitive"
-  [^String str ^String sub]
-  (let [sub-length (.length sub)]
-    (if (zero? sub-length)
-      true
-      (let [str-length (.length str)]
-        (loop [i 0]
-          (cond
-            (= i str-length) false
-            (.regionMatches str true i sub 0 sub-length) true
-            :else (recur (inc i))))))))

--- a/editor/src/clj/editor/util.clj
+++ b/editor/src/clj/editor/util.clj
@@ -179,3 +179,16 @@
           (assoc m k new-child)))
       m)
     (dissoc m k)))
+
+(defn includes-ignore-case?
+  "Like clojure.string/includes?, but case-insensitive"
+  [^String str ^String sub]
+  (let [sub-length (.length sub)]
+    (if (zero? sub-length)
+      true
+      (let [str-length (.length str)]
+        (loop [i 0]
+          (cond
+            (= i str-length) false
+            (.regionMatches str true i sub 0 sub-length) true
+            :else (recur (inc i))))))))

--- a/editor/src/clj/editor/web_profiler.clj
+++ b/editor/src/clj/editor/web_profiler.clj
@@ -16,13 +16,15 @@
   (:require [clojure.java.io :as io]
             [clojure.string :as string]
             [editor.handler :as handler]
+            [editor.system :as system]
             [editor.ui :as ui]
             [util.http-server :as http-server])
   (:import [com.defold.util Profiler]))
 
-(handler/defhandler :profile-show :global
-  (run [web-server]
-    (ui/open-url (str (http-server/local-url web-server) "/profiler"))))
+(when (system/defold-dev?)
+  (handler/defhandler :dev.open-profiler :global
+    (run [web-server]
+      (ui/open-url (str (http-server/local-url web-server) "/profiler")))))
 
 (defn routes []
   {"/profiler"

--- a/editor/src/clj/editor/workspace.clj
+++ b/editor/src/clj/editor/workspace.clj
@@ -542,7 +542,7 @@ ordinary paths."
          :actions [{:text "Fetch Libraries"
                     :on-action #(ui/execute-command
                                   (ui/contexts (ui/main-scene))
-                                  :fetch-libraries
+                                  :project.fetch-libraries
                                   nil)}]})
       (notifications/close! notifications ::dependencies-missing))
     (if (pos? (count error))
@@ -555,8 +555,8 @@ ordinary paths."
          :actions [{:text "Open game.project"
                     :on-action #(ui/execute-command
                                   (ui/contexts (ui/main-scene))
-                                  :open
-                                  {:resources [(find-resource workspace "/game.project")]})}]})
+                                  :file.open
+                                  "/game.project")}]})
       (notifications/close! notifications ::dependencies-error))))
 
 (defn set-project-dependencies! [workspace lib-states]

--- a/editor/src/clj/util/text_util.clj
+++ b/editor/src/clj/util/text_util.clj
@@ -309,3 +309,16 @@
   [^String text ^Pattern re-pattern]
   (let [matcher (re-matcher re-pattern text)]
     (.find matcher)))
+
+(defn includes-ignore-case?
+  "Like clojure.string/includes?, but case-insensitive"
+  [^String str ^String sub]
+  (let [sub-length (.length sub)]
+    (if (zero? sub-length)
+      true
+      (let [str-length (.length str)]
+        (loop [i 0]
+          (cond
+            (= i str-length) false
+            (.regionMatches str true i sub 0 sub-length) true
+            :else (recur (inc i))))))))

--- a/editor/styling/stylesheets/_dialogs.scss
+++ b/editor/styling/stylesheets/_dialogs.scss
@@ -354,7 +354,7 @@ Text {
 }
 
 .context-menu {
-  -fx-background-color: -df-component-light;
+  -fx-background-color: -df-component-dark;
   -fx-background-radius: 2px;
   -fx-padding: 5px;
   .menu-item {
@@ -362,7 +362,7 @@ Text {
       > .label {
         -fx-text-fill: -df-text-selected;
       }
-      -fx-background-color: -df-component-light;
+      -fx-background-color: -df-component-lighter;
       -fx-background-radius: 1px;
     }
     &:disabled {

--- a/editor/styling/stylesheets/dialogs.sass
+++ b/editor/styling/stylesheets/dialogs.sass
@@ -7,3 +7,4 @@
 @import 'components/_text-field'
 @import 'components/_tooltip'
 @import 'modules/_extensions'
+@import 'modules/_preferences'

--- a/editor/styling/stylesheets/editor.sass
+++ b/editor/styling/stylesheets/editor.sass
@@ -67,7 +67,6 @@
 @import 'modules/_diff-view'
 @import 'modules/_extensions'
 @import 'modules/_outline'
-@import 'modules/_preferences'
 @import 'modules/_properties'
 @import 'modules/_right-split'
 @import 'modules/_script-editor'

--- a/editor/styling/stylesheets/modules/_extensions.scss
+++ b/editor/styling/stylesheets/modules/_extensions.scss
@@ -166,4 +166,55 @@ $ext-line-height: 26px;
             &:pressed { -fx-background-color: -df-component-lighter; }
         }
     }
+    &-table-view {
+        -fx-border-width: 1;
+        -fx-padding: 1px;
+        -fx-border-color: -df-component-dark;
+        -fx-background-insets: 0;
+        -fx-background-color: -df-background-input;
+        &:hover { -fx-border-color: -df-component-light; }
+        &:focused {
+            -fx-border-color: -df-component-light -df-component-light -df-defold-orange -df-component-light;
+            -fx-border-width: 1px 1px 2px 1px;
+            -fx-padding: 1px 1px 0 1px;
+            -fx-background-color: -df-background;
+            & > .virtual-flow > .clipped-container > .sheet > .table-row-cell:selected {
+                -fx-background-color: -df-background-lighter;
+                & > .table-cell { -fx-text-fill: -df-text-selected; }
+            }
+        }
+        & > .column-header-background {
+            -fx-border-width: 0 0 1 0;
+            -fx-border-color: -df-component-dark;
+            -fx-background-color: transparent;
+            & > .filler {
+                -fx-background-color: transparent;
+            }
+            & > .nested-column-header > .column-header {
+                -fx-background-color: transparent;
+                -fx-border-width: 0 1 0 0;
+                -fx-border-color: -df-component-dark;
+                & > .label {
+                    -fx-text-fill: -df-text;
+                    -fx-alignment: center-left;
+                }
+            }
+        }
+        & > .virtual-flow {
+            & > .clipped-container > .sheet > .table-row-cell {
+                -fx-background-color: transparent;
+                & > .table-cell {
+                    -fx-border-width: 0 1 0 0;
+                    -fx-border-color: -df-component-dark;
+                    -fx-text-fill: -df-text;
+                    -fx-padding: 0 2px;
+                }
+            }
+            & > .scroll-bar > .thumb {
+                -fx-background-color: -df-component-dark;
+                &:hover { -fx-background-color: -df-component-light; }
+                &:pressed { -fx-background-color: -df-component-lighter; }
+            }
+        }
+    }
 }

--- a/editor/styling/stylesheets/modules/_preferences.scss
+++ b/editor/styling/stylesheets/modules/_preferences.scss
@@ -1,20 +1,43 @@
-/* Preferences dialog window */
-#prefs {
-    .tab-header-area {
-        .tab-header-background {
-        }
-        .tab {
-            -fx-padding: 2 14 2 18;
-            .tab-label {
-                -fx-padding: 0 2 0 0;
-            }
-            &:selected {
-                -fx-padding: 2 14 2 18;
-            }
+.keymap {
+    &-shortcut {
+        -fx-background-color: -df-component-light;
+        -fx-border-radius: 4px;
+        -fx-background-radius: 4px;
+        -fx-padding: 0px 4px;
+        -fx-alignment: center;
+        &:warning { -fx-text-fill: -df-defold-yellow-dark; }
+    }
+    &-shortcuts { -fx-padding: 2px 0; }
+    &-command:overridden > .label { -fx-text-fill: -df-defold-blue-light; }
+    &-command-arrow { -fx-opacity: 0.6; }
+    &-warning {
+        -fx-background-color: -df-component-light;
+        -fx-pref-width: 15px;
+        -fx-pref-height: 13px;
+        -fx-scale-y: -1;
+    }
+    &-new-shortcut {
+        &-background {
+            -fx-background-color: -df-component-dark;
+            -fx-border-color: -df-component-lighter;
+            -fx-border-width: 1px;
+            -fx-effect: dropshadow(gaussian, rgba(0, 0, 0, 0.2), 12, 0.0, 0, 8);
         }
     }
-    .tab-content-area {
-        -fx-background-color: -df-background-light;
-        -fx-padding: 25px 15px 15px 20px;
+}
+.table-view:focused > .virtual-flow > .clipped-container > .sheet > .table-row-cell:selected > .table-cell {
+    & > .keymap-command {
+        & > .label { -fx-text-fill: -df-text-selected; }
+        &:overridden > .label { -fx-text-fill: -df-defold-blue-lighter; }
+    }
+    & > .keymap-shortcuts {
+        & > .keymap-shortcut {
+            -fx-text-fill: -df-text-selected;
+            -fx-background-color: -df-component-lighter;
+            &:warning { -fx-text-fill: -df-defold-yellow; }
+        }
+        & > .keymap-warning-container > .keymap-warning {
+            -fx-background-color: -df-component-lighter;
+        }
     }
 }

--- a/editor/test/editor/handler_test.clj
+++ b/editor/test/editor/handler_test.clj
@@ -40,13 +40,13 @@
 
 (deftest run-test
   (with-clean-system
-    (handler/defhandler :open :global
+    (handler/defhandler :file.open :global
       (enabled? [instances] (every? #(= % :foo) instances))
       (run [instances] 123))
-    (are [inst exp] (= exp (enabled? :open [(handler/->context :global {:instances [inst]})] {}))
+    (are [inst exp] (= exp (enabled? :file.open [(handler/->context :global {:instances [inst]})] {}))
          :foo true
          :bar false)
-    (is (= 123 (run :open [(handler/->context :global {:instances [:foo]})] {})))))
+    (is (= 123 (run :file.open [(handler/->context :global {:instances [:foo]})] {})))))
 
 (deftest context
   (with-clean-system
@@ -321,21 +321,21 @@
                       :id ::file
                       :children [{:label "New"
                                   :id ::new
-                                  :command :new}
+                                  :command :file.new}
                                  {:label "Open"
                                   :id ::open
-                                  :command :open}]}
+                                  :command :file.open}]}
                      {:label "Edit"
                       :id ::edit
                       :children [{:label "Undo"
                                   :icon "icons/undo.png"
-                                  :command :undo}
+                                  :command :edit.undo}
                                  {:label "Redo"
                                   :icon "icons/redo.png"
-                                  :command :redo}]}
+                                  :command :edit.redo}]}
                      {:label "Help"
                       :children [{:label "About"
-                                  :command :about}]}])
+                                  :command :help.about}]}])
 
 (def scene-menu-data [{:label "Scene"
                        :children [{:label "Do stuff"}

--- a/editor/test/editor/handler_test.clj
+++ b/editor/test/editor/handler_test.clj
@@ -335,7 +335,7 @@
                                   :command :edit.redo}]}
                      {:label "Help"
                       :children [{:label "About"
-                                  :command :help.about}]}])
+                                  :command :app.about}]}])
 
 (def scene-menu-data [{:label "Scene"
                        :children [{:label "Do stuff"}

--- a/editor/test/editor/keymap_test.clj
+++ b/editor/test/editor/keymap_test.clj
@@ -13,38 +13,66 @@
 ;; specific language governing permissions and limitations under the License.
 
 (ns editor.keymap-test
-  (:require [clojure.test :refer [deftest is]]
+  (:require [clojure.test :refer :all]
             [editor.keymap :as keymap]
-            [util.fn :as fn]))
+            [util.coll :as coll])
+  (:import [javafx.scene.input KeyCombination]))
 
-(deftest default-bindings-are-valid
-  (doseq [[platform key-bindings] keymap/platform->default-key-bindings]
-    (is (keymap/make-keymap key-bindings {:valid-command? fn/constantly-true
-                                          :platform platform
-                                          :throw-on-error? true}))))
+(deftest default-bindings-are-valid-test
+  (doseq [os [:macos :win32 :linux]
+          [command shortcut->warnings] (keymap/warnings (keymap/default os))
+          [shortcut warnings] shortcut->warnings
+          warning warnings]
+    (is (contains? #{:typable :conflict} (:type warning))
+        (format "Unacceptable default shortcut %s for command %s (%s)" shortcut command (name (:type warning))))))
 
-(defn- make-keymap-errors [key-bindings platform]
-  (try
-    (keymap/make-keymap key-bindings {:throw-on-error? true :platform platform})
-    (catch Exception ex (:errors (ex-data ex)))))
+(deftest disallow-typable-shortcuts-test
+  (is (= {:s {(KeyCombination/valueOf "S") #{{:type :typable}}}
+          :t {(KeyCombination/valueOf "Alt+T") #{{:type :typable}}}
+          :u {(KeyCombination/valueOf "Ctrl+Alt+U") #{{:type :typable}}}
+          :x {(KeyCombination/valueOf "Shift+Alt+X") #{{:type :typable}}}}
+         (keymap/warnings
+           (keymap/from
+             keymap/empty
+             :macos
+             {:s {:add #{"S"}}
+              :t {:add #{"Alt+T"}}
+              :u {:add #{"Ctrl+Alt+U"}}
+              :x {:add #{"Shift+Alt+X"}}}))))
+  (doseq [os [:linux :win32]]
+    (is (= {:s {(KeyCombination/valueOf "S") #{{:type :typable}}}
+            :u {(KeyCombination/valueOf "Ctrl+Alt+U") #{{:type :typable}}}}
+           (keymap/warnings
+             (keymap/from keymap/empty os {:s {:add #{"S"}}
+                                           :u {:add #{"Ctrl+Alt+U"}}}))))))
 
-(deftest disallow-typable-shortcuts
-  ;; We don't test keymap/allowed-typable-shortcuts
-  (is (= (make-keymap-errors [["S" :s]
-                              ["Alt+T" :t]
-                              ["Ctrl+Alt+U" :u]
-                              ["Shift+Alt+X" :x]]
-                             :macos)
-         #{{:type :typable-shortcut :command :s :shortcut "S"}
-           {:type :typable-shortcut :command :t :shortcut "Alt+T"}
-           {:type :typable-shortcut :command :u :shortcut "Ctrl+Alt+U"}
-           {:type :typable-shortcut :command :x :shortcut "Shift+Alt+X"}}))
-  (doseq [platform [:linux :win32]]
-    (is (= (make-keymap-errors [["S" :s] ["Ctrl+Alt+U" :u]] platform)
-           #{{:type :typable-shortcut, :command :u, :shortcut "Ctrl+Alt+U"}
-             {:type :typable-shortcut, :command :s, :shortcut "S"}}))))
+(deftest keymap-does-not-allow-shortcut-key-test
+  (doseq [os (keys keymap/platform->default-key-bindings)]
+    (is (contains? (-> (keymap/from keymap/empty os {:a {:add #{"Shortcut+A"}}})
+                       (keymap/warnings :a "Shortcut+A"))
+                   {:type :shortcut-modifier}))))
 
-(deftest keymap-does-not-allow-shortcut-key
-  (doseq [platform (keys keymap/platform->default-key-bindings)]
-    (is (= (make-keymap-errors [["Shortcut+A" :a]] platform)
-           #{{:type :shortcut-key :command :a :shortcut "Shortcut+A"}}))))
+(deftest keymap-editing-test
+  (let [m1 (keymap/from keymap/empty {:a {:add #{"Meta+A"}}})]
+    (is (coll/empty? (keymap/warnings m1)))
+    (testing "add a conflicting shortcut"
+      (let [m2 (keymap/from m1 {:b {:add #{"Meta+A"}}})]
+        (is (= #{{:type :conflict :command :b}} (keymap/warnings m2 :a "Meta+A")))
+        (is (= #{{:type :conflict :command :a}} (keymap/warnings m2 :b "Meta+A")))
+        (is (= #{:a :b} (keymap/commands m2 "Meta+A")))
+        (is (= #{(KeyCombination/valueOf "Meta+A")} (keymap/shortcuts m2 :a)))
+        (is (= #{(KeyCombination/valueOf "Meta+A")} (keymap/shortcuts m2 :b)))))
+    (testing "avoiding conflicts"
+      (let [m2 (keymap/from m1 {:b {:add #{"Meta+A"}}
+                                :a {:add #{"Ctrl+A"}
+                                    :remove #{"Meta+A"}}})]
+        (is (coll/empty? (keymap/warnings m2)))
+        (is (= #{(KeyCombination/valueOf "Ctrl+A")} (keymap/shortcuts m2 :a)))
+        (is (= #{(KeyCombination/valueOf "Meta+A")} (keymap/shortcuts m2 :b)))
+        (is (= #{:a} (keymap/commands m2 "Ctrl+A")))
+        (is (= #{:b} (keymap/commands m2 "Meta+A")))))
+    (testing "removing a shortcut completely"
+      (let [m2 (keymap/from m1 {:a {:remove #{"Meta+A"}}})]
+        (is (nil? (keymap/commands m2 "Meta+A")))
+        (is (nil? (keymap/shortcuts m2 :a)))
+        (is (nil? (keymap/warnings m2 :a)))))))

--- a/editor/test/editor/ui_test.clj
+++ b/editor/test/editor/ui_test.clj
@@ -69,15 +69,15 @@
       [{:label "File"
         :children [{:label "Open"
                     :id ::open
-                    :command :open}
+                    :command :file.open}
                    {:label "Save"
-                    :command :save}]}])
+                    :command :file.save}]}])
 
-    (handler/defhandler :open :global
+    (handler/defhandler :file.open :global
         (enabled? [selection] true)
         (run [selection] 123))
 
-    (handler/defhandler :save :global
+    (handler/defhandler :file.save :global
       (enabled? [selection] true)
       (run [selection] 124))
 
@@ -95,16 +95,16 @@
   (test-support/with-clean-system
     (handler/register-menu! ::my-menu
       [{:label "Add"
-        :command :add}])
+        :command :edit.add-embedded-component}])
 
-    (handler/defhandler :add :global
+    (handler/defhandler :edit.add-embedded-component :global
       (run [user-data] user-data)
       (active? [user-data] (or (not user-data) (= user-data 1)))
       (options [user-data] (when-not user-data [{:label "first"
-                                                 :command :add
+                                                 :command :edit.add-embedded-component
                                                  :user-data 1}
                                                 {:label "second"
-                                                 :command :add
+                                                 :command :edit.add-embedded-component
                                                  :user-data 2}])))
 
     (let [command-context {:name :global :env {}}]
@@ -120,15 +120,15 @@
      (test-support/with-clean-system
        (handler/register-menu! ::my-menu
          [{:label "Open"
-           :command :open
+           :command :file.open
            :id ::open}])
 
-       (handler/defhandler :open :global
+       (handler/defhandler :file.open :global
          (enabled? [selection] true)
          (run [selection] 123)
          (state [] false))
 
-       (handler/defhandler :save :global
+       (handler/defhandler :file.save :global
          (enabled? [selection] true)
          (run [selection] 124)
          (state [] false))
@@ -152,7 +152,7 @@
 
          (handler/register-menu! ::extra ::open
            [{:label "Save"
-             :command :save}])
+             :command :file.save}])
          (ui/refresh scene)
          (is (= 2 (count (.getChildren root))))))))
 
@@ -164,13 +164,13 @@
            :children
            [{:label "Open"
              :id ::open
-             :command :open}]}])
+             :command :file.open}]}])
 
-       (handler/defhandler :open :global
+       (handler/defhandler :file.open :global
          (enabled? [selection] true)
          (run [selection] 123))
 
-       (handler/defhandler :save :global
+       (handler/defhandler :file.save :global
          (enabled? [selection] true)
          (run [selection] 124))
 
@@ -189,7 +189,7 @@
            (is (= (.get c1 0) (.get c2 0))))
          (handler/register-menu! ::extra ::open
            [{:label "Save"
-             :command :save}])
+             :command :file.save}])
          (ui/refresh scene)
          (let [c1 (do (ui/refresh scene) (.getItems (first (.getMenus menubar))))
                c2 (do (ui/refresh scene) (.getItems (first (.getMenus menubar))))]

--- a/editor/test/integration/collection_test.clj
+++ b/editor/test/integration/collection_test.clj
@@ -83,7 +83,7 @@
                ; Select the collection node
                (app-view/select! app-view [node-id])
                ; Run the add handler
-               (test-util/handler-run :add [{:name :workbench :env {:workspace workspace :project project :app-view app-view :selection [node-id]}}] {})
+               (test-util/handler-run :edit.add-embedded-component [{:name :workbench :env {:workspace workspace :project project :app-view app-view :selection [node-id]}}] {})
                ; Three game objects under the collection
                (is (= 3 (count (:children (g/node-value node-id :node-outline)))))))))
 

--- a/editor/test/integration/collision_object_test.clj
+++ b/editor/test/integration/collision_object_test.clj
@@ -48,7 +48,7 @@
     (test-util/with-loaded-project
       (let [node-id   (test-util/resource-node project "/collision_object/three_shapes.collisionobject")]
         (app-view/select! app-view [node-id])
-        (test-util/handler-run :add [{:name :workbench :env {:selection [node-id] :app-view app-view}}] {:shape-type :type-sphere})
+        (test-util/handler-run :edit.add-embedded-component [{:name :workbench :env {:selection [node-id] :app-view app-view}}] {:shape-type :type-sphere})
         (let [outline (g/node-value node-id :node-outline)]
           (is (= 4 (count (:children outline))))
           (is (= "<Unnamed Sphere>" (last (outline-seq outline)))))))))

--- a/editor/test/integration/curve_view_test.clj
+++ b/editor/test/integration/curve_view_test.clj
@@ -157,6 +157,6 @@
       (test-util/ensure-number-type-preserving! original-curve (g/node-value emitter :particle-key-alpha))
       ; Delete through handler
       (mouse-drag! curve-view 0.0 -2.0 1.0 2.0)
-      (test-util/handler-run :delete [context] {})
+      (test-util/handler-run :edit.delete [context] {})
       (is (every? (fn [i] (nil? (cp emitter :particle-key-alpha (+ i 2)))) (range 6)))
       (test-util/ensure-number-type-preserving! original-curve (g/node-value emitter :particle-key-alpha)))))

--- a/editor/test/integration/gui_test.clj
+++ b/editor/test/integration/gui_test.clj
@@ -479,11 +479,11 @@
 (defn- add-layout! [project app-view scene name]
   (let [parent (g/node-value scene :layouts-node)
         user-data {:scene scene :parent parent :display-profile name :handler-fn gui/add-layout-handler}]
-    (test-util/handler-run :add [{:name :workbench :env {:selection [parent] :project project :user-data user-data :app-view app-view}}] user-data)))
+    (test-util/handler-run :edit.add-embedded-component [{:name :workbench :env {:selection [parent] :project project :user-data user-data :app-view app-view}}] user-data)))
 
 (defn- run-add-gui-node! [project scene app-view parent node-type custom-type]
   (let [user-data {:scene scene :parent parent :node-type node-type :custom-type custom-type :handler-fn gui/add-gui-node-handler}]
-    (test-util/handler-run :add [{:name :workbench :env {:selection [parent] :project project :user-data user-data :app-view app-view}}] user-data)))
+    (test-util/handler-run :edit.add-embedded-component [{:name :workbench :env {:selection [parent] :project project :user-data user-data :app-view app-view}}] user-data)))
 
 (defn- set-visible-layout! [scene layout]
   (g/transact (g/set-property scene :visible-layout layout)))
@@ -569,12 +569,12 @@
     (let [node-id (test-util/resource-node project "/gui/layouts.gui")
           gui-resource (g/node-value node-id :resource)
           context (handler/->context :workbench {:active-resource gui-resource :project project})
-          options (test-util/handler-options :set-gui-layout [context] nil)
+          options (test-util/handler-options :scene.set-gui-layout [context] nil)
           options-by-label (zipmap (map :label options) options)]
       (is (= ["Default" "Landscape"] (map :label options)))
-      (is (= (get options-by-label "Default") (test-util/handler-state :set-gui-layout [context] nil)))
+      (is (= (get options-by-label "Default") (test-util/handler-state :scene.set-gui-layout [context] nil)))
       (g/set-property! node-id :visible-layout "Landscape")
-      (is (= (get options-by-label "Landscape") (test-util/handler-state :set-gui-layout [context] nil))))))
+      (is (= (get options-by-label "Landscape") (test-util/handler-state :scene.set-gui-layout [context] nil))))))
 
 (deftest paste-gui-resource-test
   (test-util/with-loaded-project "test/resources/gui_project"

--- a/editor/test/integration/lsp_test.clj
+++ b/editor/test/integration/lsp_test.clj
@@ -70,9 +70,9 @@
   (await-lsp
     (tu/handler-run command [{:name :global :env {:project-graph (project/graph project)}}] {})))
 
-(def ^:private undo! (partial handler-run! :undo))
+(def ^:private undo! (partial handler-run! :edit.undo))
 
-(def ^:private redo! (partial handler-run! :redo))
+(def ^:private redo! (partial handler-run! :edit.redo))
 
 (defn- pull-diagnostics! [lsp & args]
   (await-lsp

--- a/editor/test/integration/outline_test.clj
+++ b/editor/test/integration/outline_test.clj
@@ -725,7 +725,7 @@
   (test-util/handler-run command [{:name :workbench :env {:selection selection :app-view app-view}}] user-data))
 
 (defn- add-collision-shape [app-view collision-object shape-type]
-  (handler-run :add app-view [collision-object] {:shape-type shape-type}))
+  (handler-run :edit.add-embedded-component app-view [collision-object] {:shape-type shape-type}))
 
 (deftest dnd-collision-shape
   (test-util/with-loaded-project
@@ -795,13 +795,13 @@
           children-fn (fn [] (mapv :label (:children (test-util/outline pfx []))))]
       (is (= ["emitter" "Acceleration"] (children-fn)))
       ;; Add emitter through command
-      (handler-run :add app-view [pfx] {:emitter-type :emitter-type-circle})
+      (handler-run :edit.add-embedded-component app-view [pfx] {:emitter-type :emitter-type-circle})
       (is (= ["emitter" "emitter1" "Acceleration"] (children-fn)))
       ;; Copy-paste 'emitter'
       (copy-paste! project app-view pfx [0])
       (is (= ["emitter" "emitter1" "emitter2" "Acceleration"] (children-fn)))
       ;; Add modifier through command
-      (handler-run :add-secondary app-view [pfx] {:modifier-type :modifier-type-acceleration})
+      (handler-run :edit.add-secondary-embedded-component app-view [pfx] {:modifier-type :modifier-type-acceleration})
       (is (= ["emitter" "emitter1" "emitter2" "Acceleration" "Acceleration"] (children-fn)))
       ;; Copy-paste 'Acceleration'
       (copy-paste! project app-view pfx [3])
@@ -814,8 +814,8 @@
                         (let [parent (:node-id (outline root path))
                               env {:app-view app-view :project project :selection [parent] :workspace workspace}]
                           (test-util/handler-run command [{:env env :name :workbench}] user-data)))
-          add-game-object-to-collection! (partial run-handler! :add nil)
-          add-child-game-object! (partial run-handler! :add-secondary nil)
+          add-game-object-to-collection! (partial run-handler! :edit.add-embedded-component nil)
+          add-child-game-object! (partial run-handler! :edit.add-secondary-embedded-component nil)
           sub-props-collection (test-util/resource-node project "/collection/sub_props.collection")
           props-collection (test-util/resource-node project "/collection/props.collection")]
       ;; Original tree

--- a/editor/test/integration/web_server_test.clj
+++ b/editor/test/integration/web_server_test.clj
@@ -29,7 +29,6 @@
             [editor.pipeline.bob :as bob]
             [editor.progress :as progress]
             [editor.ui :as ui]
-            [editor.web-profiler :as web-profiler]
             [editor.web-server :as web-server]
             [editor.workspace :as workspace]
             [integration.test-util :as test-util]
@@ -177,7 +176,6 @@
         (with-open [server (http-server/start!
                              (web-server/make-dynamic-handler
                                (into [] cat [(engine-profiler/routes)
-                                             (web-profiler/routes)
                                              (console/routes console-view)
                                              (hot-reload/routes workspace)
                                              (bob/routes project)
@@ -191,10 +189,6 @@
               (is (= 200 status))
               (is (= "text/javascript" (get headers "content-type")))
               (is (string/includes? body "class ThreadFrame")))
-            (let [{:keys [status headers body]} @(http/request (str url "/profiler") :as :string)]
-              (is (= 200 status))
-              (is (= "text/html" (get headers "content-type")))
-              (is (string/includes? body "var data = [")))
             (let [{:keys [status headers body]} @(http/request (str url "/console") :as :string)]
               (is (= 200 status))
               (is (= "application/json" (get headers "content-type")))


### PR DESCRIPTION
We added the Keymap tab to the Preferences dialog — now it's possible to configure editor command shortcuts from within the editor:
![record](https://github.com/user-attachments/assets/e5ee9d18-3b3c-4655-a78e-e2c8a910be94)

Assigning shortcuts to commands defined in editor scripts is now also possible. If a command defines an id, it will appear in the Keymap configuration table. Example editor script:
```lua
local M = {}
function M.get_commands()
  return {
    editor.command({
      label = "Print Git Status",
      locations = {"Project"},
      id = "vcs.print-git-status",
      run = function(opts)
        editor.execute("git", "status", {reload_resources=false})
      end
    })
  }
end
return M
```
Now you can assign a shortcut:
![status](https://github.com/user-attachments/assets/39dc322e-02b4-4962-8c0f-3e41a9f45fe8)


Fixes #6901

Technical notes:
Texturepacker extension PR with command renames: https://github.com/defold/extension-texturepacker/pull/18