### PR TITLE
Add Linux XDG tests and fix errors

### DIFF
--- a/engine/dlib/src/dlib/sys_posix.cpp
+++ b/engine/dlib/src/dlib/sys_posix.cpp
@@ -414,20 +414,27 @@ namespace dmSys
         return GetApplicationSupportPath(application_name, path, path_len);
     }
 
-    Result GetApplicationSupportPath(const char* application_name, char* path_out, uint32_t path_len)
+    Result GetApplicationSupportPath(const char* application_name, char* path_out, const uint32_t path_len)
     {
         const char* xdg_env = dmSys::GetEnv("XDG_DATA_HOME");
-        const char* xdg = xdg_env ? xdg_env : "$HOME/.local/share";
+        const char* xdg = xdg_env ? xdg_env : dmSys::GetEnv("HOME");
         char xdg_buf[path_len];
 
         dmStrlCpy(xdg_buf, xdg, path_len);
+        //The spec expects us to make $HOME/.local/share with 0700 if it doesn't exist.
+        if (!xdg_env)
+        {
+            dmStrlCat(xdg_buf, "/.local", path_len);
+            dmSys::Mkdir(xdg_buf, 0700);
+            dmStrlCat(xdg_buf, "/share", path_len);
+            dmSys::Mkdir(xdg_buf, 0700);
+        }
         dmStrlCat(xdg_buf, "/", path_len);
         if (dmStrlCat(xdg_buf, application_name, path_len) >= path_len)
             return RESULT_INVAL;
-        const char* xdg_path = xdg_buf;
 
         // No need to continue if {application_name} dir already exists
-        if (realpath(xdg_path, path_out))
+        if (realpath(xdg_buf, path_out))
             return RESULT_OK;
 
         const char* dirs[] = {"HOME", "TMPDIR", "TMP", "TEMP"}; // Added common temp directories since server instances usually don't have a HOME set
@@ -454,19 +461,19 @@ namespace dmSys
             return RESULT_INVAL;
         if (dmStrlCat(home_buf, application_name, path_len) >= path_len)
             return RESULT_INVAL;
-        const char* home_path = home_buf;
 
         // If {home}/.{application_name exists}, return it here
-        if (realpath(home_path, path_out))
+        if (realpath(home_buf, path_out))
         {
-            if (dmStrlCpy(path_out, home_path, path_len) >= path_len)
+            if (dmStrlCpy(path_out, home_buf, path_len) >= path_len)
                 return RESULT_INVAL;
             return RESULT_OK;
         }
         // Default to $HOME/.local/store or $XDG_DATA_DIR
-        if (dmStrlCpy(path_out, xdg_path, path_len) >= path_len)
+        if (dmStrlCpy(path_out, xdg_buf, path_len) >= path_len)
             return RESULT_INVAL;
-        Result r = Mkdir(path_out, 0755);
+        
+        Result r = dmSys::Mkdir(path_out, 0755);
         if (r == RESULT_EXIST)
             return RESULT_OK;
         else

--- a/engine/dlib/src/test/test_sys.cpp
+++ b/engine/dlib/src/test/test_sys.cpp
@@ -132,8 +132,9 @@ TEST(dmSys, Unlink)
 TEST(dmSys, GetApplicationSupportPathBuffer)
 {
     char path[4];
+    char discard[128];
     path[3] = '!';
-    dmSys::Result result = dmSys::GetApplicationSupportPath("testing", path, 3);
+    dmSys::Result result = dmSys::GetApplicationSupportPath(dmTestUtil::MakeHostPath(discard, sizeof(discard), "testdir"), path, 3);
     ASSERT_EQ(dmSys::RESULT_INVAL, result);
     ASSERT_EQ('\0', path[2]);
     ASSERT_EQ('!', path[3]);
@@ -142,8 +143,9 @@ TEST(dmSys, GetApplicationSupportPathBuffer)
 TEST(dmSys, GetApplicationSavePathBuffer)
 {
     char path[4];
+    char discard[128];
     path[3] = '!';
-    dmSys::Result result = dmSys::GetApplicationSavePath("testing", path, 3);
+    dmSys::Result result = dmSys::GetApplicationSavePath(dmTestUtil::MakeHostPath(discard, sizeof(discard), "testdir"), path, 3);
     ASSERT_EQ(dmSys::RESULT_INVAL, result);
     ASSERT_EQ('\0', path[2]);
     ASSERT_EQ('!', path[3]);
@@ -152,7 +154,7 @@ TEST(dmSys, GetApplicationSavePathBuffer)
 TEST(dmSys, GetApplicationSupportPath)
 {
     char path[1024];
-    dmSys::Result result = dmSys::GetApplicationSupportPath("testing", path, sizeof(path));
+    dmSys::Result result = dmSys::GetApplicationSupportPath(dmTestUtil::MakeHostPath(path, sizeof(path), "testdir"), path, sizeof(path));
     ASSERT_EQ(dmSys::RESULT_OK, result);
     ASSERT_EQ(dmSys::RESULT_OK, dmSys::IsDir(path));
 }

--- a/engine/dlib/src/test/test_xdg.cpp
+++ b/engine/dlib/src/test/test_xdg.cpp
@@ -1,0 +1,142 @@
+// Copyright 2020-2025 The Defold Foundation
+// Copyright 2014-2020 King
+// Copyright 2009-2014 Ragnar Svensson, Christian Murray
+// Licensed under the Defold License version 1.0 (the "License"); you may not use
+// this file except in compliance with the License.
+//
+// You may obtain a copy of the License, together with FAQs at
+// https://www.defold.com/license
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string>
+#define JC_TEST_IMPLEMENTATION
+#include <jc_test/jc_test.h>
+
+#include <dlib/dstrings.h>
+#include <dlib/sys.h>
+#include <dlib/sys_internal.h>
+#include <dlib/path.h>
+#include <dlib/log.h>
+#include <dlib/testutil.h>
+
+#if defined(__linux__)
+
+struct dmSysXDG : public jc_test_base_class {
+    const char* originalXDG = dmSys::GetEnv("XDG_DATA_HOME");
+    const char* originalHome = dmSys::GetEnv("HOME");
+    char testHome[128];
+    char testXDG[128];
+    void SetUp()
+    {   
+        dmSys::Mkdir(dmTestUtil::MakeHostPath(testHome, sizeof(testHome), "testdir"), 0777);
+        dmSys::Mkdir(dmTestUtil::MakeHostPath(testXDG, sizeof(testXDG), "testdir/xdg"), 0777);
+        setenv("HOME", testHome, 1);
+        setenv("XDG_DATA_HOME", testXDG, 1);
+    };
+    void TearDown()
+    {
+        char testPath[128];
+        dmSys::RmTree(dmTestUtil::MakeHostPath(testPath, sizeof(testPath), "testdir"));
+        setenv("HOME", originalHome, 1);
+        setenv("XDG_DATA_HOME", originalXDG, 1);
+    };
+};
+
+//Check that the legacy support path works
+TEST_F(dmSysXDG, LegacySupportPath)
+{
+    char path[128];
+    char legacy[128];
+    dmTestUtil::MakeHostPath(legacy, sizeof(legacy), "testdir/.Defold");
+    dmSys::Mkdir(legacy, 0777);
+
+    dmSys::Result result = dmSys::GetApplicationSupportPath(DMSYS_APPLICATION_NAME, path, sizeof(path));
+    ASSERT_EQ(dmSys::RESULT_OK, result);
+    ASSERT_STREQ(legacy, path);
+}
+
+//Check that XDG support works
+TEST_F(dmSysXDG, XDGSupportPath)
+{
+    char path[128];
+    char xdg[128];
+    dmTestUtil::MakeHostPath(xdg, sizeof(xdg), "testdir/xdg/Defold");
+    
+    dmSys::Result result = dmSys::GetApplicationSupportPath(DMSYS_APPLICATION_NAME, path, sizeof(path));
+    ASSERT_EQ(dmSys::RESULT_OK, result);
+    ASSERT_STREQ(xdg, path);
+}
+
+//If application_folder at XDG exists, it has first priority
+TEST_F(dmSysXDG, XDGBeforeAll)
+{
+    char path[128];
+    char legacy[128];
+    char xdg[128];
+    char fallback[128];
+    dmTestUtil::MakeHostPath(xdg, sizeof(xdg), "testdir/xdg/Defold");
+    dmTestUtil::MakeHostPath(legacy, sizeof(legacy), "testdir/.Defold");
+    dmTestUtil::MakeHostPath(fallback, sizeof(fallback), "testdir/.local/share/Defold");
+
+    dmSys::Result result = dmSys::GetApplicationSupportPath(DMSYS_APPLICATION_NAME, path, sizeof(path));
+    ASSERT_EQ(dmSys::RESULT_OK, result);
+    ASSERT_STREQ(xdg, path);
+}
+
+//If legacy application_folder exists, it has second priority
+TEST_F(dmSysXDG, LegacyBeforeXDG)
+{
+    char path[128];
+    char legacy[128];
+    char fallback[128];
+    dmTestUtil::MakeHostPath(legacy, sizeof(legacy), "testdir/.Defold");
+    dmSys::Mkdir(legacy, 0777);
+    dmTestUtil::MakeHostPath(fallback, sizeof(fallback), "testdir/.local/share/");
+
+    dmSys::Result result = dmSys::GetApplicationSupportPath(DMSYS_APPLICATION_NAME, path, sizeof(path));
+    ASSERT_EQ(dmSys::RESULT_OK, result);
+    ASSERT_STREQ(legacy, path);
+}
+
+// If neither legacy nor $XDG_DATA_HOME exist, fallback has priority
+TEST_F(dmSysXDG, FallbackSupportPath)
+{
+    char path[128];
+    char fallback[128];
+    dmTestUtil::MakeHostPath(fallback, sizeof(fallback), "testdir/.local/share/Defold");
+    dmSys::Mkdir(fallback, 0777);
+    unsetenv("XDG_DATA_HOME");
+    
+    dmSys::Result result = dmSys::GetApplicationSupportPath(DMSYS_APPLICATION_NAME, path, sizeof(path));
+    ASSERT_EQ(dmSys::RESULT_OK, result);
+    ASSERT_STREQ(fallback, path);
+}
+
+//If $XDG_DATA_HOME is set, it has priority over the fallback
+TEST_F(dmSysXDG, XDGBeforeFallback)
+{
+    char path[128];
+    char fallback[128];
+    char xdg[128];
+    dmTestUtil::MakeHostPath(xdg, sizeof(xdg), "testdir/xdg/Defold");
+    dmTestUtil::MakeHostPath(fallback, sizeof(fallback), "testdir/.local/share/Defold");
+    
+    dmSys::Result result = dmSys::GetApplicationSupportPath(DMSYS_APPLICATION_NAME, path, sizeof(path));
+    ASSERT_EQ(dmSys::RESULT_OK, result);
+    ASSERT_STREQ(xdg, path);
+}
+
+#endif
+
+int main(int argc, char **argv)
+{
+    jc_test_init(&argc, argv);
+    return jc_test_run_all();
+}
+

--- a/engine/dlib/src/test/wscript
+++ b/engine/dlib/src/test/wscript
@@ -185,6 +185,7 @@ def build(bld):
         create_test(bld, 'test_job_thread')
 
     create_test(bld, 'test_sys', extra_libs = ['THREAD'], extra_defines = extra_defines)
+    create_test(bld, 'test_xdg', extra_libs = ['THREAD'])
     create_test(bld, 'test_template', extra_libs = ['THREAD'])
     create_test(bld, 'test_ssdp_internals', extra_libs = ['THREAD'], skip_run = skip_run or skip_ssdp)
     create_test(bld, 'test_ssdp', extra_libs = ['THREAD'], skip_run = skip_run or skip_ssdp)


### PR DESCRIPTION
@JCash merged #10318 before I managed to finish the tests (my fault, the push wasn't supposed to be to remote. Thank you for working with me as you had been!).

This PR:
1. Adds tests for the XDG features on Linux.
2. Fixes a few things in the support path feature so the tests pass
3. Fixes three tests in `test_sys` that previously would use only the support path by making them use DM_HOSTFS (`dmTestUtil::MakeHostPath` in the test suite). i.e. `~/.testing` becomes `DM_HOSTFS/testdir` to match the other tests.

It has no attached issues, but it should probably skip release notes.
## PR checklist

* [x] Code
	* [x] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [x] Add comments where needed
* [x] Documentation
	* [x] Make sure that API documentation is updated in code comments
	* [x] Make sure that manuals are updated (in github.com/defold/doc)
* [x] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] ~~Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.~~
	* [x] ~~Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.~~
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.

