### PR TITLE
Render convex hull collision shape

### DIFF
--- a/editor/src/clj/editor/collision_groups.clj
+++ b/editor/src/clj/editor/collision_groups.clj
@@ -14,10 +14,7 @@
 
 (ns editor.collision-groups
   "Manages allocation of stable and limited ids to collision-groups."
-  (:require
-   [clojure.set :as set]
-   [dynamo.graph :as g]
-   [editor.colors :as colors]))
+  (:require [editor.colors :as colors]))
 
 (def MAX-GROUPS 16)
 

--- a/editor/src/clj/editor/collision_object.clj
+++ b/editor/src/clj/editor/collision_object.clj
@@ -415,7 +415,7 @@
   [_node-id convex-shape-data color]
   (when (and (= (:shape-type convex-shape-data) :type-hull)
              (not-empty (:data convex-shape-data)))
-    (let [points (->> convex-shape-data :data (partition 3) vec)
+    (let [points (partition 3 (:data convex-shape-data))
           [min-coords max-coords] (reduce (fn [[min-point max-point] point]
                                             [(mapv min min-point point) (mapv max max-point point)])
                                           [(repeat Double/MAX_VALUE) (repeat Double/MIN_VALUE)]

--- a/editor/src/clj/editor/collision_object.clj
+++ b/editor/src/clj/editor/collision_object.clj
@@ -466,7 +466,6 @@
                  [(convex-hull-scene _node-id convex-shape-data collision-group-color)]
                  child-scenes)}))
 
-
 (defn- make-embedded-collision-shape [shapes]
   (loop [idx 0
          [shape & rest] shapes

--- a/editor/src/clj/editor/collision_object.clj
+++ b/editor/src/clj/editor/collision_object.clj
@@ -421,14 +421,9 @@
                                           [(repeat Double/MAX_VALUE) (repeat Double/MIN_VALUE)]
                                           points)
           aabb (geom/coords->aabb max-coords min-coords)
-          polygon (->> points
-                       (reduce (fn [vb [x y z]] (scene-shapes/pos-vtx-put! vb x y z 0.0))
-                               (scene-shapes/->pos-vtx (count points) :static))
-                       vtx/flip!)
-          outline (->> points
-                       (reduce (fn [vb [x y z]] (scene-shapes/pos-vtx-put! vb x y z 0.0))
-                               (scene-shapes/->pos-vtx (count points) :static))
-                       vtx/flip!)]
+          vbuf (vtx/flip! (reduce (fn [vb [x y z]] (scene-shapes/pos-vtx-put! vb x y z 0.0))
+                                  (scene-shapes/->pos-vtx (count points) :static)
+                                  points))]
       {:node-id _node-id
        :node-outline-key "Convex Hull"
        :aabb aabb
@@ -438,7 +433,7 @@
                     :user-data {:color color
                                 :double-sided true
                                 :geometry {:primitive-type GL2/GL_POLYGON
-                                           :vbuf polygon}}}
+                                           :vbuf vbuf}}}
        :children [{:node-id _node-id
                    :aabb aabb
                    :renderable {:render-fn render-lines-uniform-scale
@@ -446,7 +441,7 @@
                                 :passes [pass/outline]
                                 :user-data {:color color
                                             :geometry {:primitive-type GL2/GL_LINE_LOOP
-                                                       :vbuf outline}}}}]})))
+                                                       :vbuf vbuf}}}}]})))
 
 (g/defnk produce-scene
   [_node-id child-scenes collision-shape dep-build-targets collision-group-color]

--- a/editor/src/clj/editor/collision_object.clj
+++ b/editor/src/clj/editor/collision_object.clj
@@ -421,18 +421,14 @@
                                           [(repeat Double/MAX_VALUE) (repeat Double/MIN_VALUE)]
                                           points)
           aabb (geom/coords->aabb max-coords min-coords)
-          point-count (count points)
           polygon (->> points
                        (reduce (fn [vb [x y z]] (scene-shapes/pos-vtx-put! vb x y z 0.0))
-                               (scene-shapes/->pos-vtx point-count :static))
+                               (scene-shapes/->pos-vtx (count points) :static))
                        vtx/flip!)
-          lines (->> points
-                     (reduce-kv (fn [vb i [x y z]]
-                                  (let [[next-x next-y next-z] (nth points (inc i) (first points))]
-                                    (-> (scene-shapes/pos-vtx-put! vb x y z 0.0)
-                                        (scene-shapes/pos-vtx-put! next-x next-y next-z 0.0))))
-                                (scene-shapes/->pos-vtx (* 2 point-count) :static))
-                     vtx/flip!)]
+          outline (->> points
+                       (reduce (fn [vb [x y z]] (scene-shapes/pos-vtx-put! vb x y z 0.0))
+                               (scene-shapes/->pos-vtx (count points) :static))
+                       vtx/flip!)]
       {:node-id _node-id
        :node-outline-key "Convex Hull"
        :aabb aabb
@@ -449,8 +445,8 @@
                                 :tags #{:collision-shape :outline}
                                 :passes [pass/outline]
                                 :user-data {:color color
-                                            :geometry {:primitive-type GL2/GL_LINES
-                                                       :vbuf lines}}}}]})))
+                                            :geometry {:primitive-type GL2/GL_LINE_LOOP
+                                                       :vbuf outline}}}}]})))
 
 (g/defnk produce-scene
   [_node-id child-scenes collision-shape dep-build-targets collision-group-color]


### PR DESCRIPTION
Renders the collision polygon of `.convexshape` files.

![Screenshot From 2025-04-17 12-43-07](https://github.com/user-attachments/assets/9ec2dbd8-0a26-4380-a6f2-df949b5189b0)

Fixes #10083

### Technical changes
I tried to allow editing the file within the editor, but it looks like we are using the saved data differently on protobuf nodes, so only the rendering part is supported for now. 