### PR TITLE
Fixed the issue where transformation gizmos for models disappeared when "Component Guides" was turned off

### DIFF
--- a/editor/src/clj/editor/model_scene.clj
+++ b/editor/src/clj/editor/model_scene.clj
@@ -372,15 +372,23 @@
 (defn- make-scene [renderable-mesh-set model-scene-resource-node-id]
   (let [{:keys [aabb renderable-models]} renderable-mesh-set
         model-scenes (mapv #(make-model-scene % model-scene-resource-node-id)
-                           renderable-models)]
+                           renderable-models)
+        children-scenes (into [{:node-id model-scene-resource-node-id
+                                :aabb aabb
+                                :renderable {:render-fn render-outline
+                                             :tags #{:model :outline}
+                                             :batch-key nil
+                                             :select-batch-key :not-rendered
+                                             :passes [pass/outline]}}]
+                              model-scenes)]
     {:node-id model-scene-resource-node-id
      :aabb aabb
      :renderable {:render-fn render-outline
-                  :tags #{:model :outline}
+                  :tags #{:model}
                   :batch-key nil ; Batching is disabled in the editor for simplicity.
                   :select-batch-key :not-rendered ; The render-fn only does anything during the outline pass.
-                  :passes [pass/outline pass/opaque-selection]} ; Include in a selection pass to ensure it can be selected and manipulated.
-     :children model-scenes}))
+                  :passes [pass/opaque-selection]} ; Include in a selection pass to ensure it can be selected and manipulated.
+     :children children-scenes}))
 
 (g/defnk produce-scene [_node-id renderable-mesh-set]
   (make-scene renderable-mesh-set _node-id))

--- a/editor/src/clj/editor/model_scene.clj
+++ b/editor/src/clj/editor/model_scene.clj
@@ -375,10 +375,8 @@
                            renderable-models)
         children-scenes (into [{:node-id model-scene-resource-node-id
                                 :aabb aabb
-                                :renderable {:render-fn render-outline
-                                             :tags #{:model :outline}
+                                :renderable {:tags #{:model :outline}
                                              :batch-key nil
-                                             :select-batch-key :not-rendered
                                              :passes [pass/outline]}}]
                               model-scenes)]
     {:node-id model-scene-resource-node-id

--- a/editor/src/clj/editor/model_scene.clj
+++ b/editor/src/clj/editor/model_scene.clj
@@ -375,8 +375,10 @@
                            renderable-models)
         children-scenes (into [{:node-id model-scene-resource-node-id
                                 :aabb aabb
-                                :renderable {:tags #{:model :outline}
+                                :renderable {:render-fn render-outline
+                                             :tags #{:model :outline}
                                              :batch-key nil
+                                             :select-batch-key :not-rendered
                                              :passes [pass/outline]}}]
                               model-scenes)]
     {:node-id model-scene-resource-node-id

--- a/editor/src/clj/editor/model_scene.clj
+++ b/editor/src/clj/editor/model_scene.clj
@@ -383,11 +383,9 @@
                               model-scenes)]
     {:node-id model-scene-resource-node-id
      :aabb aabb
-     :renderable {:render-fn render-outline
-                  :tags #{:model}
+     :renderable {:tags #{:model}
                   :batch-key nil ; Batching is disabled in the editor for simplicity.
-                  :select-batch-key :not-rendered ; The render-fn only does anything during the outline pass.
-                  :passes [pass/opaque-selection]} ; Include in a selection pass to ensure it can be selected and manipulated.
+                  :passes [pass/opaque-selection]} ; A selection pass to ensure it can be selected and manipulated.
      :children children-scenes}))
 
 (g/defnk produce-scene [_node-id renderable-mesh-set]

--- a/editor/src/clj/editor/model_scene.clj
+++ b/editor/src/clj/editor/model_scene.clj
@@ -377,12 +377,16 @@
                                 :aabb aabb
                                 :renderable {:render-fn render-outline
                                              :tags #{:model :outline}
+                                             :batch-key nil
+                                             :select-batch-key :not-rendered
                                              :passes [pass/outline]}}]
                               model-scenes)]
     {:node-id model-scene-resource-node-id
      :aabb aabb
      :renderable {:render-fn render-outline
                   :tags #{:model}
+                  :batch-key nil ; Batching is disabled in the editor for simplicity.
+                  :select-batch-key :not-rendered ; The render-fn only does anything during the outline pass.
                   :passes [pass/opaque-selection]} ; Include in a selection pass to ensure it can be selected and manipulated.
      :children children-scenes}))
 

--- a/editor/src/clj/editor/model_scene.clj
+++ b/editor/src/clj/editor/model_scene.clj
@@ -377,16 +377,12 @@
                                 :aabb aabb
                                 :renderable {:render-fn render-outline
                                              :tags #{:model :outline}
-                                             :batch-key nil
-                                             :select-batch-key :not-rendered
                                              :passes [pass/outline]}}]
                               model-scenes)]
     {:node-id model-scene-resource-node-id
      :aabb aabb
      :renderable {:render-fn render-outline
                   :tags #{:model}
-                  :batch-key nil ; Batching is disabled in the editor for simplicity.
-                  :select-batch-key :not-rendered ; The render-fn only does anything during the outline pass.
                   :passes [pass/opaque-selection]} ; Include in a selection pass to ensure it can be selected and manipulated.
      :children children-scenes}))
 


### PR DESCRIPTION
Fix https://github.com/defold/defold/issues/9571
Fix https://github.com/defold/defold/issues/10498