### PR TITLE
Make it clear that some resources cannot be edited

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -2017,9 +2017,10 @@ If you do not specifically require different script states, consider changing th
         right-link (Hyperlink. "Read more…")
         spacer (Region.)]
     (HBox/setHgrow spacer Priority/ALWAYS)
-    (.setStyle info-panel "-fx-background-color: #444; -fx-padding: 4;")
-    (.setTextFill left-label Color/LIGHTGRAY)
-    (.setTextFill right-link Color/CORNFLOWERBLUE)
+    (.getStyleClass info-panel)
+    (ui/set-style! info-panel "info-panel" true)
+    (ui/set-style! left-label "info-panel-label" true)
+    (ui/set-style! right-link "info-panel-link" true)
     (.setOnAction right-link (ui/event-handler _ (ui/open-url "https://www.defold.com/manuals/editor/")))
     (.addAll  (.getChildren info-panel) (Arrays/asList (into-array Node [left-label spacer right-link])))
     info-panel))
@@ -2028,10 +2029,11 @@ If you do not specifically require different script states, consider changing th
                   resource-type view-type make-view-fn ^ObservableList tabs
                   open-resource opts]
   (let [parent (AnchorPane.)
-        tab-content (VBox.)
-        content-nodes (if (resource/read-only? resource)
+        res-read-only? (if (resource/read-only? resource) true false)
+        tab-content (if res-read-only? (VBox.) parent)
+        content-nodes (if res-read-only?
                         [(make-info-box!) parent]
-                        [parent])
+                        [])
         tab (doto (Tab. (tab-title resource false))
               (.setContent tab-content)
               (.setTooltip (Tooltip. (or (resource/proj-path resource) "unknown")))

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -90,17 +90,17 @@
            [com.sun.javafx.scene NodeHelper]
            [java.io File PipedInputStream PipedOutputStream]
            [java.net URL]
-           [java.util Collection List]
+           [java.util Arrays Collection List]
            [java.util.concurrent ExecutionException]
            [javafx.beans.value ChangeListener]
            [javafx.collections ListChangeListener ObservableList]
            [javafx.event Event]
            [javafx.geometry HPos Orientation Pos]
-           [javafx.scene Parent Scene]
-           [javafx.scene.control Label MenuBar SplitPane Tab TabPane TabPane$TabClosingPolicy TabPane$TabDragPolicy Tooltip]
+           [javafx.scene Parent Scene Node]
+           [javafx.scene.control Label Hyperlink MenuBar SplitPane Tab TabPane TabPane$TabClosingPolicy TabPane$TabDragPolicy Tooltip]
            [javafx.scene.image Image ImageView]
            [javafx.scene.input Clipboard ClipboardContent MouseButton MouseEvent]
-           [javafx.scene.layout AnchorPane GridPane HBox Region StackPane]
+           [javafx.scene.layout AnchorPane GridPane VBox HBox Region StackPane Priority]
            [javafx.scene.paint Color]
            [javafx.scene.shape Ellipse]
            [javafx.scene.text Font]
@@ -2011,26 +2011,45 @@ If you do not specifically require different script states, consider changing th
       (ui/on-closed! stage (fn [_] (dispose-scene-views! app-view)))
       app-view)))
 
+(defn- make-info-box! []
+  (let [info-panel (HBox.)
+        left-label (Label. "This file is part of a library and cannot be saved.  ")
+        right-link (Hyperlink. "Read more…")
+        spacer (Region.)]
+    (HBox/setHgrow spacer Priority/ALWAYS)
+    (.setStyle info-panel "-fx-background-color: #444; -fx-padding: 4;")
+    (.setTextFill left-label Color/LIGHTGRAY)
+    (.setTextFill right-link Color/CORNFLOWERBLUE)
+    (.setOnAction right-link (ui/event-handler _ (ui/open-url "https://www.defold.com/manuals/editor/")))
+    (.addAll  (.getChildren info-panel) (Arrays/asList (into-array Node [left-label spacer right-link])))
+    info-panel))
+
 (defn- make-tab! [app-view prefs workspace project resource resource-node
                   resource-type view-type make-view-fn ^ObservableList tabs
                   open-resource opts]
-  (let [parent     (AnchorPane.)
-        tab        (doto (Tab. (tab-title resource false))
-                     (.setContent parent)
-                     (.setTooltip (Tooltip. (or (resource/proj-path resource) "unknown")))
-                     (ui/user-data! ::view-type view-type))
+  (let [parent (AnchorPane.)
+        tab-content (VBox.)
+        content-nodes (if (resource/read-only? resource)
+                        [(make-info-box!) parent]
+                        [parent])
+        tab (doto (Tab. (tab-title resource false))
+              (.setContent tab-content)
+              (.setTooltip (Tooltip. (or (resource/proj-path resource) "unknown")))
+              (ui/user-data! ::view-type view-type))
         view-graph (g/make-graph! :history false :volatility 2)
-        select-fn  (partial select app-view)
-        opts       (merge opts
-                          (get (:view-opts resource-type) (:id view-type))
-                          {:app-view app-view
-                           :select-fn select-fn
-                           :open-resource-fn (partial open-resource app-view prefs workspace project)
-                           :prefs prefs
-                           :project project
-                           :workspace workspace
-                           :tab tab})
-        view       (make-view-fn view-graph parent resource-node opts)]
+        select-fn (partial select app-view)
+        opts (merge opts
+                    (get (:view-opts resource-type) (:id view-type))
+                    {:app-view app-view
+                     :select-fn select-fn
+                     :open-resource-fn (partial open-resource app-view prefs workspace project)
+                     :prefs prefs
+                     :project project
+                     :workspace workspace
+                     :tab tab})
+        view (make-view-fn view-graph parent resource-node opts)]
+    (VBox/setVgrow parent Priority/ALWAYS)
+    (.addAll (.getChildren tab-content) (Arrays/asList (into-array Node content-nodes)))
     (assert (g/node-instance? view/WorkbenchView view))
     (recent-files/add! prefs resource view-type)
     (g/transact

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -2029,11 +2029,11 @@ If you do not specifically require different script states, consider changing th
                   resource-type view-type make-view-fn ^ObservableList tabs
                   open-resource opts]
   (let [parent (AnchorPane.)
-        res-read-only? (if (resource/read-only? resource) true false)
-        tab-content (if res-read-only? (VBox.) parent)
-        content-nodes (if res-read-only?
-                        [(make-info-box!) parent]
-                        [])
+        tab-content (if (resource/read-only? resource)
+                      (doto (VBox.)
+                        (ui/children! [(make-info-box!)
+                                       (doto parent (VBox/setVgrow Priority/ALWAYS))]))
+                      parent)
         tab (doto (Tab. (tab-title resource false))
               (.setContent tab-content)
               (.setTooltip (Tooltip. (or (resource/proj-path resource) "unknown")))
@@ -2050,8 +2050,6 @@ If you do not specifically require different script states, consider changing th
                      :workspace workspace
                      :tab tab})
         view (make-view-fn view-graph parent resource-node opts)]
-    (VBox/setVgrow parent Priority/ALWAYS)
-    (.addAll (.getChildren tab-content) (Arrays/asList (into-array Node content-nodes)))
     (assert (g/node-instance? view/WorkbenchView view))
     (recent-files/add! prefs resource view-type)
     (g/transact

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -2021,7 +2021,7 @@ If you do not specifically require different script states, consider changing th
     (ui/set-style! info-panel "info-panel" true)
     (ui/set-style! left-label "info-panel-label" true)
     (ui/set-style! right-link "info-panel-link" true)
-    (.setOnAction right-link (ui/event-handler _ (ui/open-url "https://www.defold.com/manuals/editor/")))
+    (.setOnAction right-link (ui/event-handler _ (ui/open-url "https://defold.com/manuals/libraries/#editing-files-in-library-dependencies")))
     (.addAll  (.getChildren info-panel) (Arrays/asList (into-array Node [left-label spacer right-link])))
     info-panel))
 

--- a/editor/styling/stylesheets/_editor.scss
+++ b/editor/styling/stylesheets/_editor.scss
@@ -53,6 +53,24 @@ Links:
   -fx-background-color: -df-background !important;
 }
 
+/* Info panel styles */
+.info-panel {
+  -fx-background-color: -df-background-lighter;
+  -fx-padding: 4;
+}
+
+.info-panel-label {
+  -fx-text-fill: -df-text;
+}
+
+.info-panel-link {
+  -fx-text-fill: -df-defold-blue-light;
+}
+
+.info-panel-link:hover {
+  -fx-text-fill: -df-defold-blue-lighter;
+}
+
 /* Overrides */
 
 .override-inspector-hyperlink {


### PR DESCRIPTION
The editor now displays a message indicating that changes to files from libraries cannot be saved.
![CleanShot 2025-04-22 at 11 06 45@2x](https://github.com/user-attachments/assets/d3bf1c11-897a-480f-9576-1b5713d0aaf0)


Fix https://github.com/defold/defold/issues/4052