### PR TITLE
Use raw input for gamepads even if no gamepad is specified in the gamepad mappings

### DIFF
--- a/engine/input/src/input.cpp
+++ b/engine/input/src/input.cpp
@@ -467,12 +467,6 @@ namespace dmInput
             }
         }
 
-        if (count == 0)
-        {
-            dmLogInfo("No gamepads supporting this platform");
-            return;
-        }
-
         context->m_GamepadMaps.SetCapacity(dmMath::Max(1, (count + 1) / 3), count + 1);
 
         // Add a gamepad config that will be used when an unidentified gamepad
@@ -488,6 +482,11 @@ namespace dmInput
         }
         context->m_GamepadMaps.Put(UNKNOWN_GAMEPAD_CONFIG_ID, unknownGamepadConfig);
 
+        if (count == 0)
+        {
+            dmLogInfo("No gamepads found in the gamepad map for this platform");
+            return;
+        }
 
         for (uint32_t i = 0; i < ddf->m_Driver.m_Count; ++i)
         {


### PR DESCRIPTION
Games which use only raw gamepad data will now receive input events even if the gamepad bindings file is empty.

Fix https://github.com/defold/defold/issues/10171