### PR TITLE
Cleanup the input action table

### DIFF
--- a/engine/gameobject/src/gameobject/comp_script.cpp
+++ b/engine/gameobject/src/gameobject/comp_script.cpp
@@ -564,7 +564,7 @@ namespace dmGameObject
                 lua_settable(L, -3);
             }
 
-            if (params.m_InputAction->m_ActionId != 0)
+            if (params.m_InputAction->m_ActionId != 0 && !params.m_InputAction->m_HasText)
             {
                 lua_pushliteral(L, "value");
                 lua_pushnumber(L, params.m_InputAction->m_Value);

--- a/engine/gameobject/src/gameobject/gameobject_script.cpp
+++ b/engine/gameobject/src/gameobject/gameobject_script.cpp
@@ -2810,22 +2810,36 @@ bail:
      *
      * Here is a brief description of the available table fields:
      *
-     * Field       | Description
-     * ----------- | ----------------------------------------------------------
-     * `value`     | The amount of input given by the user. This is usually 1 for buttons and 0-1 for analogue inputs. This is not present for mouse movement.
-     * `pressed`   | If the input was pressed this frame. This is not present for mouse movement.
-     * `released`  | If the input was released this frame. This is not present for mouse movement.
-     * `repeated`  | If the input was repeated this frame. This is similar to how a key on a keyboard is repeated when you hold it down. This is not present for mouse movement.
-     * `x`         | The x value of a pointer device, if present.
-     * `y`         | The y value of a pointer device, if present.
-     * `screen_x`  | The screen space x value of a pointer device, if present.
-     * `screen_y`  | The screen space y value of a pointer device, if present.
-     * `dx`        | The change in x value of a pointer device, if present.
-     * `dy`        | The change in y value of a pointer device, if present.
-     * `screen_dx` | The change in screen space x value of a pointer device, if present.
-     * `screen_dy` | The change in screen space y value of a pointer device, if present.
-     * `gamepad`   | The index of the gamepad device that provided the input.
-     * `touch`     | List of touch input, one element per finger, if present. See table below about touch input
+     * Field         | Description
+     * ------------- | ----------------------------------------------------------
+     * `value`       | The amount of input given by the user. This is usually 1 for buttons and 0-1 for analogue inputs. This is not present for mouse movement and text input.
+     * `pressed`     | If the input was pressed this frame. This is not present for mouse movement and text input.
+     * `released`    | If the input was released this frame. This is not present for mouse movement and text input.
+     * `repeated`    | If the input was repeated this frame. This is similar to how a key on a keyboard is repeated when you hold it down. This is not present for mouse movement and text input.
+     * `x`           | The x value of a pointer device, if present. This is not present for gamepad, key and text input.
+     * `y`           | The y value of a pointer device, if present. This is not present for gamepad, key and text input.
+     * `screen_x`    | The screen space x value of a pointer device, if present. This is not present for gamepad, key and text input.
+     * `screen_y`    | The screen space y value of a pointer device, if present. This is not present for gamepad, key and text input.
+     * `dx`          | The change in x value of a pointer device, if present. This is not present for gamepad, key and text input.
+     * `dy`          | The change in y value of a pointer device, if present. This is not present for gamepad, key and text input.
+     * `screen_dx`   | The change in screen space x value of a pointer device, if present. This is not present for gamepad, key and text input.
+     * `screen_dy`   | The change in screen space y value of a pointer device, if present. This is not present for gamepad, key and text input.
+     * `gamepad`     | The index of the gamepad device that provided the input. See table below about gamepad input.
+     * `touch`       | List of touch input, one element per finger, if present. See table below about touch input
+     * `text`        | Text input from a (virtual) keyboard or similar.
+     * `marked_text` | Sequence of entered symbols while entering a symbol combination, for example Japanese Kana.
+     *
+     * Gamepad specific fields:
+     *
+     * Field             | Description
+     * ----------------- | ----------------------------------------------------------
+     * `gamepad`         | The index of the gamepad device that provided the input.
+     * `userid`          | Id of the user associated with the controller. Usually only relevant on consoles.
+     * `gamepad_unknown` | True if the inout originated from an unknown/unmapped gamepad.
+     * `gamepad_name`    | Name of the gamepad
+     * `gamepad_axis`    | List of gamepad axis values. For raw gamepad input only.
+     * `gamepadhats`     | List of gamepad hat values. For raw gamepad input only.
+     * `gamepad_buttons` | List of gamepad button values. For raw gamepad input only.
      *
      * Touch input table:
      *

--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -1832,7 +1832,7 @@ namespace dmGui
                         lua_settable(L, -3);
                     }
 
-                    if (ia->m_ActionId != 0)
+                    if (ia->m_ActionId != 0 && !ia->m_HasText)
                     {
                         lua_pushliteral(L, "value");
                         lua_pushnumber(L, ia->m_Value);

--- a/engine/gui/src/gui_script.cpp
+++ b/engine/gui/src/gui_script.cpp
@@ -5608,22 +5608,37 @@ namespace dmGui
      *
      * Here is a brief description of the available table fields:
      *
-     * Field       | Description
-     * ----------- | ----------------------------------------------------------
-     * `value`     | The amount of input given by the user. This is usually 1 for buttons and 0-1 for analogue inputs. This is not present for mouse movement.
-     * `pressed`   | If the input was pressed this frame. This is not present for mouse movement.
-     * `released`  | If the input was released this frame. This is not present for mouse movement.
-     * `repeated`  | If the input was repeated this frame. This is similar to how a key on a keyboard is repeated when you hold it down. This is not present for mouse movement.
-     * `x`         | The x value of a pointer device, if present.
-     * `y`         | The y value of a pointer device, if present.
-     * `screen_x`  | The screen space x value of a pointer device, if present.
-     * `screen_y`  | The screen space y value of a pointer device, if present.
-     * `dx`        | The change in x value of a pointer device, if present.
-     * `dy`        | The change in y value of a pointer device, if present.
-     * `screen_dx` | The change in screen space x value of a pointer device, if present.
-     * `screen_dy` | The change in screen space y value of a pointer device, if present.
-     * `gamepad`   | The index of the gamepad device that provided the input.
-     * `touch`     | List of touch input, one element per finger, if present. See table below about touch input
+     *
+     * Field         | Description
+     * ------------- | ----------------------------------------------------------
+     * `value`       | The amount of input given by the user. This is usually 1 for buttons and 0-1 for analogue inputs. This is not present for mouse movement and text input.
+     * `pressed`     | If the input was pressed this frame. This is not present for mouse movement and text input.
+     * `released`    | If the input was released this frame. This is not present for mouse movement and text input.
+     * `repeated`    | If the input was repeated this frame. This is similar to how a key on a keyboard is repeated when you hold it down. This is not present for mouse movement and text input.
+     * `x`           | The x value of a pointer device, if present. This is not present for gamepad, key and text input.
+     * `y`           | The y value of a pointer device, if present. This is not present for gamepad, key and text input.
+     * `screen_x`    | The screen space x value of a pointer device, if present. This is not present for gamepad, key and text input.
+     * `screen_y`    | The screen space y value of a pointer device, if present. This is not present for gamepad, key and text input.
+     * `dx`          | The change in x value of a pointer device, if present. This is not present for gamepad, key and text input.
+     * `dy`          | The change in y value of a pointer device, if present. This is not present for gamepad, key and text input.
+     * `screen_dx`   | The change in screen space x value of a pointer device, if present. This is not present for gamepad, key and text input.
+     * `screen_dy`   | The change in screen space y value of a pointer device, if present. This is not present for gamepad, key and text input.
+     * `gamepad`     | The index of the gamepad device that provided the input. See table below about gamepad input.
+     * `touch`       | List of touch input, one element per finger, if present. See table below about touch input
+     * `text`        | Text input from a (virtual) keyboard or similar.
+     * `marked_text` | Sequence of entered symbols while entering a symbol combination, for example Japanese Kana.
+     *
+     * Gamepad specific fields:
+     *
+     * Field             | Description
+     * ----------------- | ----------------------------------------------------------
+     * `gamepad`         | The index of the gamepad device that provided the input.
+     * `userid`          | Id of the user associated with the controller. Usually only relevant on consoles.
+     * `gamepad_unknown` | True if the inout originated from an unknown/unmapped gamepad.
+     * `gamepad_name`    | Name of the gamepad
+     * `gamepad_axis`    | List of gamepad axis values. For raw gamepad input only.
+     * `gamepadhats`     | List of gamepad hat values. For raw gamepad input only.
+     * `gamepad_buttons` | List of gamepad button values. For raw gamepad input only.
      *
      * Touch input table:
      *

--- a/engine/input/src/input.cpp
+++ b/engine/input/src/input.cpp
@@ -839,7 +839,8 @@ namespace dmInput
                                     Action* action = gamepad_binding->m_Actions.Get(trigger.m_ActionId);
                                     if (action != 0x0)
                                     {
-                                        if (dmMath::Abs(action->m_Value) < dmMath::Abs(v)) {
+                                        if (dmMath::Abs(action->m_Value) < dmMath::Abs(v))
+                                        {
                                             action->m_Value = v;
                                         }
 

--- a/engine/input/src/input.cpp
+++ b/engine/input/src/input.cpp
@@ -559,31 +559,9 @@ namespace dmInput
         action->m_HasGamepadPacket = 0;
     }
 
-    struct UpdateActionContext
+    void UpdateActionPressedReleasedRepeated(Action* action, Context* context, float dt)
     {
-        UpdateActionContext()
-        {
-            memset(this, 0, sizeof(UpdateActionContext));
-        }
-
-        float m_DT;
-        Context* m_Context;
-        int32_t m_X;
-        int32_t m_Y;
-        int32_t m_DX;
-        int32_t m_DY;
-        float m_AccX;
-        float m_AccY;
-        float m_AccZ;
-        uint32_t m_PositionSet : 1;
-        uint32_t m_AccelerationSet : 1;
-    };
-
-    void UpdateAction(void* context, const dmhash_t* id, Action* action)
-    {
-        UpdateActionContext* update_context = (UpdateActionContext*)context;
-
-        float pressed_threshold = update_context->m_Context->m_PressedThreshold;
+        float pressed_threshold = context->m_PressedThreshold;
         action->m_Pressed = (action->m_PrevValue < pressed_threshold && action->m_Value >= pressed_threshold) ? 1 : 0;
         action->m_Released = (action->m_PrevValue >= pressed_threshold && action->m_Value < pressed_threshold) ? 1 : 0;
 
@@ -593,32 +571,17 @@ namespace dmInput
             if (action->m_Pressed)
             {
                 action->m_Repeated = true;
-                action->m_RepeatTimer = update_context->m_Context->m_RepeatDelay;
+                action->m_RepeatTimer = context->m_RepeatDelay;
             }
             else
             {
-                action->m_RepeatTimer -= update_context->m_DT;
+                action->m_RepeatTimer -= dt;
                 if (action->m_RepeatTimer <= 0.0f)
                 {
                     action->m_Repeated = true;
-                    action->m_RepeatTimer += update_context->m_Context->m_RepeatInterval;
+                    action->m_RepeatTimer += context->m_RepeatInterval;
                 }
             }
-        }
-        if (action->m_PositionSet == 0)
-        {
-            action->m_X = update_context->m_X;
-            action->m_Y = update_context->m_Y;
-            action->m_DX = update_context->m_DX;
-            action->m_DY = update_context->m_DY;
-            action->m_PositionSet = update_context->m_PositionSet;
-        }
-        if (action->m_AccelerationSet == 0)
-        {
-            action->m_AccX = update_context->m_AccX;
-            action->m_AccY = update_context->m_AccY;
-            action->m_AccZ = update_context->m_AccZ;
-            action->m_AccelerationSet = update_context->m_AccelerationSet;
         }
     }
 
@@ -628,7 +591,6 @@ namespace dmInput
         binding->m_Actions.Iterate<void>(ClearAction, 0x0);
 
         dmHID::HContext hid_context = binding->m_Context->m_HidContext;
-        UpdateActionContext context;
         if (binding->m_KeyboardBinding != 0x0)
         {
             KeyboardBinding* keyboard_binding = binding->m_KeyboardBinding;
@@ -706,11 +668,6 @@ namespace dmInput
             dmHID::MousePacket* prev_packet = &mouse_binding->m_PreviousPacket;
             if (dmHID::GetMousePacket(mouse_binding->m_Mouse, packet))
             {
-                context.m_X = packet->m_PositionX;
-                context.m_Y = packet->m_PositionY;
-                context.m_DX = packet->m_PositionX - prev_packet->m_PositionX;
-                context.m_DY = packet->m_PositionY - prev_packet->m_PositionY;
-                context.m_PositionSet = 1;
                 const dmArray<MouseTrigger>& triggers = mouse_binding->m_Triggers;
                 for (uint32_t i = 0; i < triggers.Size(); ++i)
                 {
@@ -732,11 +689,32 @@ namespace dmInput
                     v = dmMath::Clamp(v, 0.0f, 1.0f);
                     Action* action = binding->m_Actions.Get(trigger.m_ActionId);
 
-                    if (action != 0x0 && dmMath::Abs(action->m_Value) < dmMath::Abs(v))
+                    if (action != 0x0)
                     {
-                        action->m_Value = (float) dmMath::Abs(v);
+                        if (dmMath::Abs(action->m_Value) < dmMath::Abs(v))
+                        {
+                            action->m_Value = (float) dmMath::Abs(v);
+                        }
+                        action->m_X = packet->m_PositionX;
+                        action->m_Y = packet->m_PositionY;
+                        action->m_DX = packet->m_PositionX - prev_packet->m_PositionX;
+                        action->m_DY = packet->m_PositionY - prev_packet->m_PositionY;
+                        action->m_PositionSet = 1;
+                        UpdateActionPressedReleasedRepeated(action, binding->m_Context, dt);
                     }
+
                 }
+                // mouse movement action
+                Action* action = binding->m_Actions.Get(0);
+                if (action != 0x0)
+                {
+                    action->m_X = packet->m_PositionX;
+                    action->m_Y = packet->m_PositionY;
+                    action->m_DX = packet->m_PositionX - prev_packet->m_PositionX;
+                    action->m_DY = packet->m_PositionY - prev_packet->m_PositionY;
+                    action->m_PositionSet = 1;
+                }
+
                 *prev_packet = *packet;
             }
         }
@@ -847,6 +825,7 @@ namespace dmInput
                                 {
                                     action->m_GamepadPacket = gamepad_binding->m_Packet;
                                     action->m_HasGamepadPacket = 1;
+                                    UpdateActionPressedReleasedRepeated(action, binding->m_Context, dt);
                                 }
                             }
                             else
@@ -864,7 +843,10 @@ namespace dmInput
                                         // We want to make sure we report going back to 0 again
                                         action->m_Dirty = 0;
                                         if (input.m_Type == dmInputDDF::GAMEPAD_TYPE_AXIS && action->m_PrevValue != action->m_Value)
+                                        {
                                             action->m_Dirty = 1;
+                                        }
+                                        UpdateActionPressedReleasedRepeated(action, binding->m_Context, dt);
                                     }
                                 }
                             }
@@ -918,6 +900,7 @@ namespace dmInput
                             {
                                 action->m_Value = 1.0;
                             }
+                            UpdateActionPressedReleasedRepeated(action, binding->m_Context, dt);
                         }
                         action->m_TouchCount = packet->m_TouchCount;
                     }
@@ -927,35 +910,23 @@ namespace dmInput
         }
         if (binding->m_AccelerationBinding != 0x0)
         {
-            context.m_AccelerationSet = 0;
             if (dmHID::IsAccelerometerConnected(hid_context))
             {
-                AccelerationBinding* acceleration_binding = binding->m_AccelerationBinding;
-                dmHID::AccelerationPacket* packet = &acceleration_binding->m_Packet;
-                dmHID::AccelerationPacket* prev_packet = &acceleration_binding->m_PreviousPacket;
-                dmHID::GetAccelerationPacket(hid_context, packet);
-                context.m_AccX = packet->m_X;
-                context.m_AccY = packet->m_Y;
-                context.m_AccZ = packet->m_Z;
-                context.m_AccelerationSet = 1;
-                *prev_packet = *packet;
-            }
-        }
-        context.m_DT = dt;
-        context.m_Context = binding->m_Context;
-        binding->m_Actions.Iterate<void>(UpdateAction, &context);
-        if (binding->m_GamepadBindings.Size() > 0)
-        {
-            for (uint32_t i = 0; i < binding->m_GamepadBindings.Size(); ++i)
-            {
-                GamepadBinding* gamepad_binding = binding->m_GamepadBindings[i];
-                if (gamepad_binding == 0x0) {
-                    continue;
+                Action* action = binding->m_Actions.Get(0);
+                if (action)
+                {
+                    AccelerationBinding* acceleration_binding = binding->m_AccelerationBinding;
+                    dmHID::AccelerationPacket* packet = &acceleration_binding->m_Packet;
+                    dmHID::AccelerationPacket* prev_packet = &acceleration_binding->m_PreviousPacket;
+                    dmHID::GetAccelerationPacket(hid_context, packet);
+                    action->m_AccX = packet->m_X;
+                    action->m_AccY = packet->m_Y;
+                    action->m_AccZ = packet->m_Z;
+                    action->m_AccelerationSet = 1;
+                    *prev_packet = *packet;
                 }
-                gamepad_binding->m_Actions.Iterate<void>(UpdateAction, &context);
             }
         }
-
     }
 
     const Action* GetAction(HBinding binding, dmhash_t action_id)

--- a/engine/input/src/input.cpp
+++ b/engine/input/src/input.cpp
@@ -694,9 +694,9 @@ namespace dmInput
 
                     if (action != 0x0)
                     {
-                        if (dmMath::Abs(action->m_Value) < dmMath::Abs(v))
+                        if (dmMath::Abs(action->m_Value) < v)
                         {
-                            action->m_Value = (float) dmMath::Abs(v);
+                            action->m_Value = v;
                         }
                         action->m_X = packet->m_PositionX;
                         action->m_Y = packet->m_PositionY;

--- a/engine/input/src/input.cpp
+++ b/engine/input/src/input.cpp
@@ -904,8 +904,8 @@ namespace dmInput
                             {
                                 action->m_Value = 1.0;
                             }
-                            UpdateActionPressedReleasedRepeated(action, binding->m_Context, dt);
                         }
+                        UpdateActionPressedReleasedRepeated(action, binding->m_Context, dt);
                         action->m_TouchCount = packet->m_TouchCount;
                     }
                 }

--- a/engine/input/src/input.cpp
+++ b/engine/input/src/input.cpp
@@ -607,7 +607,10 @@ namespace dmInput
                     if (action != 0x0)
                     {
                         if (dmMath::Abs(action->m_Value) < v)
+                        {
                             action->m_Value = v;
+                        }
+                        UpdateActionPressedReleasedRepeated(action, binding->m_Context, dt);
                     }
                 }
                 *prev_packet = *packet;


### PR DESCRIPTION
If a mouse is connected the input action table always contains mouse position data even for input actions which are not related to the mouse. This change cleans up the input action table so that only values relevant to the input action is included:

* Text Triggers will only include `text`
* Key Triggers will include `pressed`, `released`, `repeated` and `value`
* Mouse Triggers will include `pressed`, `released`, `repeated`, `value`, `x`, `y`, `dx`, `dy`, `screen_x`, screen_y`, `screen_dx` and `screen_dy`
* As always mouse movement is implicitly sent if a Mouse Trigger is set. It will include  `x`, `y`, `dx`, `dy`, `screen_x`, screen_y`, `screen_dx`, `screen_dy` and accelerometer data if on mobile
* Touch Triggers will include `pressed`, `released`, `repeated`, `value`, `x`, `y`, `dx`, `dy`, `screen_x`, screen_y`, `screen_dx`, `screen_dy` and `touch`
* Gamepad Triggers will include `pressed`, `released`, `repeated`, `value`, `gamepad`

Fixes #10531 

## PR checklist

* [x] Code
	* [x] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [x] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [x] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
