### PR TITLE
Provide bundle input data information as `build_input_data.json` in the bundle folder

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Bob.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Bob.java
@@ -37,6 +37,7 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import java.lang.NumberFormatException;
 
+import com.dynamo.bob.util.BuildInputDataCollector;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.HelpFormatter;
@@ -747,6 +748,7 @@ public class Bob {
 
         String cwd = new File(".").getAbsolutePath();
 
+        BuildInputDataCollector.setArgs(args);
         CommandLine cmd = parse(args);
         if (cmd == null) { // nothing to do: requested to print help
             return new InvocationResult(true, Collections.emptyList());

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
@@ -890,7 +890,8 @@ public class Project {
         BundleHelper.throwIfCanceled(monitor);
         bundleDir.mkdirs();
         bundler.bundleApplication(this, platform, bundleDir, monitor);
-        BuildInputDataCollector.saveDataAsJson(getRootDirectory(), bundleDir);
+        String defoldSdk = this.option("defoldsdk", EngineVersion.sha1);
+        BuildInputDataCollector.saveDataAsJson(getRootDirectory(), bundleDir, defoldSdk);
         m.worked(1);
         m.done();
     }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/BuildInputDataCollector.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/BuildInputDataCollector.java
@@ -43,7 +43,6 @@ public class BuildInputDataCollector {
         bobVersion.put("timestamp", EngineVersion.timestamp);
         data.put("BobVersion", bobVersion);
         data.put("DefoldSDK", defoldSdk);
-        data.put("Environment", System.getenv());
 
         Map<String, String> gitInfo = getGitInfoIfAvailable(rootDirectory);
         if (gitInfo != null) {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/BuildInputDataCollector.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/BuildInputDataCollector.java
@@ -35,7 +35,7 @@ public class BuildInputDataCollector {
     public static void saveDataAsJson(String rootDirectory, File bundleOutputDirectory, String defoldSdk) {
         TimeProfiler.start("BuildInputDataCollector");
         Map<String, Object> data = new HashMap<>();
-        data.put("BobArguments", bobArguments);
+        data.put("bob_arguments", bobArguments);
 
         Map<String, String> bobVersion = new HashMap<>();
         bobVersion.put("sha1", EngineVersion.sha1);

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/BuildInputDataCollector.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/BuildInputDataCollector.java
@@ -41,12 +41,12 @@ public class BuildInputDataCollector {
         bobVersion.put("sha1", EngineVersion.sha1);
         bobVersion.put("version", EngineVersion.version);
         bobVersion.put("timestamp", EngineVersion.timestamp);
-        data.put("BobVersion", bobVersion);
-        data.put("DefoldSDK", defoldSdk);
+        data.put("bob_arguments", bobVersion);
+        data.put("defold_sdk", defoldSdk);
 
         Map<String, String> gitInfo = getGitInfoIfAvailable(rootDirectory);
         if (gitInfo != null) {
-            data.put("ProjectGit", gitInfo);
+            data.put("project_git", gitInfo);
         }
 
         if (dependencies != null && !dependencies.isEmpty()) {
@@ -60,7 +60,7 @@ public class BuildInputDataCollector {
                         md.update(fileBytes);
                         Map<String, String> depEntry = new HashMap<>();
                         depEntry.put("link", entry.getKey());
-                        depEntry.put("MD5", DatatypeConverter.printHexBinary(md.digest()).toUpperCase());
+                        depEntry.put("md5", DatatypeConverter.printHexBinary(md.digest()).toUpperCase());
                         depsList.add(depEntry);
                     } catch (Exception e) {
                         throw new RuntimeException("Failed to generate dependencies info", e);
@@ -92,7 +92,7 @@ public class BuildInputDataCollector {
 
             String sha = runGitCommand(rootDirectory, "rev-parse", "HEAD");
             if (sha != null) {
-                gitInfo.put("Sha1", sha);
+                gitInfo.put("sha1", sha);
             }
 
             String branch = runGitCommand(rootDirectory, "rev-parse", "--abbrev-ref", "HEAD");


### PR DESCRIPTION
Project bundling now creates an `build_input_data.json` file that provides information about the input data used to create the bundle: bob version, project Git info (if available), dependencies, and more.  

Fix https://github.com/defold/defold/issues/10321