### PR TITLE
Transform top selected nodes only

### DIFF
--- a/editor/src/clj/editor/scene_tools.clj
+++ b/editor/src/clj/editor/scene_tools.clj
@@ -24,7 +24,9 @@
             [editor.gl.vertex :as vtx]
             [editor.math :as math]
             [editor.prefs :as prefs]
-            [editor.scene-picking :as scene-picking])
+            [editor.scene-picking :as scene-picking]
+            [util.coll :as coll]
+            [util.eduction :as e])
   (:import [com.jogamp.opengl GL GL2]
            [java.lang Math Runnable]
            [javax.vecmath AxisAngle4d Matrix3d Matrix4d Point3d Quat4d Tuple3d Vector3d]))
@@ -503,12 +505,12 @@
  
 (defn- top-nodes
   [nodes]
-  (let [node-ids (->> nodes (map :node-id) set)
+  (let [node-ids (into #{} (map :node-id) nodes)
         child? (fn [node]
                  (->> (:node-id-path node)
-                      (some #(and (not= % (:node-id node))
-                                  (contains? node-ids %)))))]
-    (filter (complement child?) nodes)))
+                      (coll/some #(and (not= % (:node-id node))
+                                       (contains? node-ids %)))))]
+    (e/remove child? nodes)))
 
 (defn handle-input [self action selection-data]
   (case (:type action)


### PR DESCRIPTION
Selected children of already selected parents should not be transformed.

Fixes #9286

### Technical changes
We now filter the `selected-renderables` to keep the top selected parents only. The related issue is about moving, but the problem also occurs when we scale or rotate elements. The `SelectionController` under `editor.scene-selection` seems to mitigate this when we select multiple elements on the scene, by selecting the top elements only, but that does not happen when we select elements on the outline. It also doesn't seem to work on gui scenes. I didn't investigate this, since we would have to find a way to handle this on a lower level because of the outline case.