### PR TITLE
Remove usage of webgpu swapchain and just use the surface directly

### DIFF
--- a/engine/graphics/src/webgpu/graphics_webgpu_private.h
+++ b/engine/graphics/src/webgpu/graphics_webgpu_private.h
@@ -208,7 +208,6 @@ namespace dmGraphics
         WGPUQueue                          m_Queue;
         WGPUSurface                        m_Surface;
         WGPUTextureFormat                  m_Format;
-        WGPUSwapChain                      m_SwapChain;
         WGPUCommandEncoder                 m_CommandEncoder;
         uint32_t                           m_RenderPasses;
         uint32_t                           m_LastSubmittedRenderPass;


### PR DESCRIPTION
Swapchain is not really necessary as we can configure the surface directly and it has been removed in latest webgpu.h