### PR TITLE
Expose the wasm instance on the module so it can be accessed once loaded

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/resources/jsweb/dmloader.js
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/resources/jsweb/dmloader.js
@@ -297,6 +297,7 @@ var EngineLoader = {
                     }
                 }
                 var wasmInstantiate = WebAssembly.instantiate(new Uint8Array(wasm), imports).then(function(output) {
+                    Module.instance = output.instance;
                     successCallback(output.instance);
                 }).catch(function(e) {
                     console.log('wasm instantiation failed! ' + e);
@@ -336,6 +337,7 @@ var EngineLoader = {
 
         WebAssembly.instantiateStreaming(fetchFn(src), imports).then(function(output) {
             ProgressUpdater.updateCurrent(EngineLoader.wasm_instantiate_progress);
+            Module.instance = output.instance;
             successCallback(output.instance);
         }).catch(function(e) {
             console.log('wasm streaming instantiation failed! ' + e);


### PR DESCRIPTION
This is needed in success callback to hook onto the instance