### PR TITLE
Fixed models not rendering in the editor in some situations

### DIFF
--- a/editor/src/clj/editor/defold_project.clj
+++ b/editor/src/clj/editor/defold_project.clj
@@ -1466,6 +1466,27 @@
       {:min-filter min
        :mag-filter mag})))
 
+(g/defnk produce-default-sampler-filter-modes
+  [default-tex-params]
+  ;; Values are keyword equivalents to Material$MaterialDesc$FilterModeMin and Material$MaterialDesc$FilterModeMag.
+  {:filter-mode-min-default
+   (condp = (:min-filter default-tex-params)
+     gl/nearest :filter-mode-min-nearest
+     gl/linear :filter-mode-min-linear
+     gl/nearest-mipmap-nearest :filter-mode-min-nearest-mipmap-nearest
+     gl/nearest-mipmap-linear :filter-mode-min-nearest-mipmap-linear
+     gl/linear-mipmap-nearest :filter-mode-min-linear-mipmap-nearest
+     gl/linear-mipmap-linear :filter-mode-min-linear-mipmap-linear)
+
+   :filter-mode-mag-default ; We convert the various mipmap filtering variants to non-mipmap ones.
+   (condp = (:mag-filter default-tex-params)
+     gl/nearest :filter-mode-mag-nearest
+     gl/linear :filter-mode-mag-linear
+     gl/nearest-mipmap-nearest :filter-mode-mag-nearest
+     gl/nearest-mipmap-linear :filter-mode-mag-nearest
+     gl/linear-mipmap-nearest :filter-mode-mag-linear
+     gl/linear-mipmap-linear :filter-mode-mag-linear)})
+
 (g/defnode Project
   (inherits core/Scope)
 
@@ -1482,7 +1503,7 @@
   (input resource-map g/Any)
   (input save-data g/Any :array :substitute gu/array-subst-remove-errors)
   (input node-id+resources g/Any :array)
-  (input settings g/Any :substitute (constantly (gpc/default-settings)))
+  (input settings g/Any :substitute nil)
   (input display-profiles g/Any)
   (input texture-profiles g/Any)
   (input collision-group-nodes g/Any :array :substitute gu/array-subst-remove-errors)
@@ -1516,12 +1537,13 @@
                                                             (and (resource/editable? resource)
                                                                  (not (resource/read-only? resource))))))
                                                    save-data)))
-  (output settings g/Any :cached (gu/passthrough settings))
+  (output settings g/Any (g/fnk [settings] (or settings gpc/default-settings)))
   (output display-profiles g/Any :cached (gu/passthrough display-profiles))
   (output texture-profiles g/Any :cached (gu/passthrough texture-profiles))
   (output nil-resource resource/Resource (g/constantly nil))
   (output collision-groups-data g/Any :cached produce-collision-groups-data)
   (output default-tex-params g/Any :cached produce-default-tex-params)
+  (output default-sampler-filter-modes g/Any :cached produce-default-sampler-filter-modes)
   (output build-settings g/Any (gu/passthrough build-settings))
   (output breakpoints Breakpoints :cached (g/fnk [breakpoints] (into [] cat breakpoints))))
 

--- a/editor/src/clj/editor/game_project_core.clj
+++ b/editor/src/clj/editor/game_project_core.clj
@@ -24,7 +24,7 @@
 
 (def meta-settings (:settings basic-meta-info))
 
-(defn default-settings []
+(def default-settings
   (-> meta-settings
       settings-core/make-default-settings
       settings-core/make-settings-map))


### PR DESCRIPTION
* Fixed an issue where model materials whose texture samplers were configured to use the project default filtering setting would not render in the editor viewport.
* Fixed an issue where model materials whose shaders used attributes that were not declared in the material or present in the mesh data would not render in the editor viewport.

Fixes #10545

### Technical changes
* The `:settings` output of the `Project` node will now output default settings if the `game.project` resource has not been loaded yet.
* The `:samplers` output of `Material` nodes will now resolve the `:filter-mag` and `:filter-min` settings to the project default filtering settings when set to `:filter-mode-mag-default` or `:filter-mode-min-default`, respectively.
* The `:mag-filter` and `:min-filter` in the map returned by `material/sampler->tex-params` will now always have valid default GL filter modes rather than `nil`.