### PR TITLE
Hide reset button if some of the props are not overridable

### DIFF
--- a/editor/src/clj/editor/properties.clj
+++ b/editor/src/clj/editor/properties.clj
@@ -626,7 +626,9 @@
       v0)))
 
 (defn overridden? [property]
-  (and (contains? property :original-values) (not-every? nil? (:values property))))
+  (and (contains? property :original-values)
+       (every? some? (:original-values property))
+       (not-every? nil? (:values property))))
 
 (defn error-aggregate [vals]
   (when-let [errors (seq (remove nil? (distinct (filter g/error? vals))))]


### PR DESCRIPTION
Check if all props of on a multi-selection are overridable in order to display the reset button.

Fixes #10551