### PR TITLE
Added texture size=0 fixes for webgpu

### DIFF
--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -365,6 +365,7 @@ namespace dmGameSystem
         tex_params.m_DataSize = sizeof(white_texture);
         tex_params.m_Width = 2;
         tex_params.m_Height = 2;
+        tex_params.m_Depth = 1;
         tex_params.m_MinFilter = dmGraphics::TEXTURE_FILTER_NEAREST;
         tex_params.m_MagFilter = dmGraphics::TEXTURE_FILTER_NEAREST;
 

--- a/engine/graphics/src/webgpu/graphics_webgpu.cpp
+++ b/engine/graphics/src/webgpu/graphics_webgpu.cpp
@@ -371,7 +371,8 @@ static void WebGPURealizeTexture(WebGPUTexture* texture, WGPUTextureFormat forma
     {
         WGPUTextureDescriptor desc = {};
         desc.usage                 = texture->m_UsageFlags | usage;
-        desc.size                  = { texture->m_Width, texture->m_Height, depth };
+        // NOTE: Due to some issue with our webgpu texture handling, we cannot use a width/height of 0 when creating a new texture.
+        desc.size                  = { dmMath::Max(1U, texture->m_Width), dmMath::Max(1U, texture->m_Height), dmMath::Max((uint8_t)1, depth) };
         desc.sampleCount           = sampleCount;
         desc.format                = texture->m_Format;
         desc.mipLevelCount         = texture->m_MipMapCount;

--- a/engine/render/src/render/font.cpp
+++ b/engine/render/src/render/font.cpp
@@ -347,10 +347,17 @@ namespace dmRender
 
         font_map->m_MaxAscent = metrics->m_MaxAscent;
         font_map->m_MaxDescent = metrics->m_MaxDescent;
+
+#if defined(__EMSCRIPTEN__)
+        // Currently the web gpu backend has a bug in the SetTexture mechanism.
+        // So we recreate the texture for now.
+        RecreateTexture(font_map, graphics_context, font_map->m_CacheWidth, font_map->m_CacheHeight);
+#else
         if (recreate_texture)
             RecreateTexture(font_map, graphics_context, font_map->m_CacheWidth, font_map->m_CacheHeight);
         else
             ClearTexture(font_map, font_map->m_CacheWidth, font_map->m_CacheHeight);
+#endif
 
         SetFontMapCacheSize(font_map, metrics->m_MaxWidth, metrics->m_MaxHeight, metrics->m_MaxAscent);
     }
@@ -463,6 +470,7 @@ namespace dmRender
 
         tex_params.m_Width = glyph_image_width;
         tex_params.m_Height = glyph_image_height;
+        tex_params.m_Depth = 1;
 
         tex_params.m_X = x;
         tex_params.m_Y = y + offset_y;


### PR DESCRIPTION
This fixes an issue when creating new textures on WebGPU with width or height =0.

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
