### PR TITLE
Correctly apply model material overrides in editor scene view

### DIFF
--- a/editor/src/clj/editor/model_scene.clj
+++ b/editor/src/clj/editor/model_scene.clj
@@ -393,7 +393,7 @@
 
 (defn- augment-mesh-scene [mesh-scene old-node-id new-node-id new-node-outline-key material-name->material-scene-info]
   (let [mesh-renderable (:renderable mesh-scene)
-        material-name (:material-name mesh-renderable)
+        material-name (:material-name (:user-data mesh-renderable))
         material-scene-info (material-name->material-scene-info material-name)
         claimed-scene (scene/claim-child-scene old-node-id new-node-id new-node-outline-key mesh-scene)]
     (if (nil? material-scene-info)


### PR DESCRIPTION
Fixed an issue where model material overrides were not being correctly applied in when viewed in the editor Scene View.

Fixes #10578
