### PR TITLE
Don’t apply Model material assignments unless fully-formed

### DIFF
--- a/editor/src/clj/editor/model.clj
+++ b/editor/src/clj/editor/model.clj
@@ -441,13 +441,7 @@
 
   (output material-name->material-scene-info g/Any :cached
           (g/fnk [material-scene-infos]
-            (let [material-scene-infos-by-material-name (coll/pair-map-by :name material-scene-infos)]
-              (fn material-name->material-scene-info [^String material-name]
-                ;; If we have no material associated with the index, we mirror the
-                ;; engine behavior by picking the first one:
-                ;; https://github.com/defold/defold/blob/a265a1714dc892eea285d54eae61d0846b48899d/engine/gamesys/src/gamesys/resources/res_model.cpp#L234-L238
-                (or (material-scene-infos-by-material-name material-name)
-                    (first material-scene-infos))))))
+            (model-scene/make-material-name->material-scene-info material-scene-infos)))
 
   (property skeleton resource/Resource ; Nil is valid default.
             (value (gu/passthrough skeleton-resource))

--- a/editor/src/clj/editor/model_scene.clj
+++ b/editor/src/clj/editor/model_scene.clj
@@ -405,7 +405,6 @@
         (assert (every? map? material-attribute-infos))
         (assert (every? keyword? (map :name-key material-attribute-infos)))
         (assert (shader/shader-lifecycle? shader))
-        (assert (map? vertex-attribute-bytes))
         (assert (every? keyword? (keys vertex-attribute-bytes)))
         (assert (every? bytes? (vals vertex-attribute-bytes)))
         (assert (#{:vertex-space-local :vertex-space-world} vertex-space))
@@ -439,6 +438,33 @@
         :node-outline-key new-node-outline-key
         :children (mapv #(augment-model-scene % old-node-id new-node-id new-node-outline-key material-name->material-scene-info)
                         model-scenes)))))
+
+(defn make-material-name->material-scene-info
+  "Given some material-scene-infos, return a material-name->material-scene-info
+  fn suitable for use with the augment-scene function."
+  [material-scene-infos]
+  (let [;; When augmenting the scene, we only want to use material-scene-infos
+        ;; that are fully formed, and ignore the others.
+        usable-material-scene-infos
+        (filterv
+          (fn [material-scene-info]
+            (and (some? (:shader material-scene-info))
+                 (some? (:vertex-space material-scene-info))))
+          material-scene-infos)
+
+        ;; If we have no material associated with the index, we mirror the
+        ;; engine behavior by picking the first one:
+        ;; https://github.com/defold/defold/blob/a265a1714dc892eea285d54eae61d0846b48899d/engine/gamesys/src/gamesys/resources/res_model.cpp#L234-L238
+        fallback-material-scene-info
+        (first usable-material-scene-infos)
+
+        usable-material-scene-infos-by-material-name
+        (->> usable-material-scene-infos
+             (coll/pair-map-by :name)
+             (coll/not-empty))]
+
+    (fn material-name->material-scene-info [^String material-name]
+      (get usable-material-scene-infos-by-material-name material-name fallback-material-scene-info))))
 
 (g/defnode ModelSceneNode
   (inherits resource-node/ResourceNode)


### PR DESCRIPTION
The editor will no longer try to apply Model material assignments that do not refer to a `.material` resource when rendering Models in the Scene View. This fixes an issue where manually deleting the path from the material resource field of a previously assigned material, that is no longer defined in the referenced Mesh, would cause an exception that locked up the editor.

Fixes #10600