### PR TITLE
Add game objects, collections and components on drop

### DIFF
--- a/editor/src/clj/editor/atlas.clj
+++ b/editor/src/clj/editor/atlas.clj
@@ -1206,13 +1206,13 @@
 (defn- parent-animation-or-atlas
   [selection]
   (or (first (handler/adapt-every selection AtlasAnimation))
-      (first (map #(core/scope-of-type % AtlasAnimation) selection))
-      (first (map #(core/scope-of-type % AtlasNode) selection))
+      (some #(core/scope-of-type % AtlasAnimation) selection)
+      (some #(core/scope-of-type % AtlasNode) selection)
       (first (handler/adapt-every selection AtlasNode))))
 
 (defn- handle-drop
   [selection workspace _world-pos resources]
-  (let [parent (parent-animation-or-atlas selection)]
+  (when-let [parent (parent-animation-or-atlas selection)]
     (->> resources
          (filter image/image-path?)
          (keep (partial workspace/resolve-workspace-resource workspace))

--- a/editor/src/clj/editor/atlas.clj
+++ b/editor/src/clj/editor/atlas.clj
@@ -1211,11 +1211,10 @@
       (first (handler/adapt-every selection AtlasNode))))
 
 (defn- handle-drop
-  [selection workspace _world-pos resources]
+  [selection _workspace _world-pos resources]
   (when-let [parent (parent-animation-or-atlas selection)]
     (->> resources
-         (e/filter image/image-path?)
-         (e/keep (partial workspace/resolve-workspace-resource workspace))
+         (e/filter image/image-resource?)
          (create-dropped-images parent))))
 
 (defn handle-input [self action selection-data]

--- a/editor/src/clj/editor/atlas.clj
+++ b/editor/src/clj/editor/atlas.clj
@@ -1214,8 +1214,8 @@
   [selection workspace _world-pos resources]
   (when-let [parent (parent-animation-or-atlas selection)]
     (->> resources
-         (filter image/image-path?)
-         (keep (partial workspace/resolve-workspace-resource workspace))
+         (e/filter image/image-path?)
+         (e/keep (partial workspace/resolve-workspace-resource workspace))
          (create-dropped-images parent))))
 
 (defn handle-input [self action selection-data]

--- a/editor/src/clj/editor/atlas.clj
+++ b/editor/src/clj/editor/atlas.clj
@@ -1192,7 +1192,7 @@
   [image-resources]
   (mapv (partial hash-map :image) image-resources))
 
-(defn- create-dropped-images!
+(defn- create-dropped-images
   [parent image-resources]
   (condp g/node-instance? parent
     AtlasNode (let [existing-image-resources (set (g/node-value parent :image-resources))
@@ -1216,7 +1216,7 @@
     (->> resources
          (filter image/image-path?)
          (keep (partial workspace/resolve-workspace-resource workspace))
-         (create-dropped-images! parent))))
+         (create-dropped-images parent))))
 
 (defn handle-input [self action selection-data]
   (case (:type action)

--- a/editor/src/clj/editor/atlas.clj
+++ b/editor/src/clj/editor/atlas.clj
@@ -13,8 +13,7 @@
 ;; specific language governing permissions and limitations under the License.
 
 (ns editor.atlas
-  (:require [clojure.string :as str]
-            [dynamo.graph :as g]
+  (:require [dynamo.graph :as g]
             [editor.app-view :as app-view]
             [editor.camera :as c]
             [editor.colors :as colors]
@@ -45,7 +44,6 @@
             [editor.scene-tools :as scene-tools]
             [editor.texture-set :as texture-set]
             [editor.types :as types]
-            [editor.ui :as ui]
             [editor.validation :as validation]
             [editor.workspace :as workspace]
             [internal.util :as util]
@@ -62,10 +60,8 @@
            [editor.gl.vertex2 VertexBuffer]
            [editor.types AABB Animation Image]
            [java.awt.image BufferedImage]
-           [java.io File]
            [java.nio ByteBuffer]
            [java.util List]
-           [javafx.scene.input DragEvent]
            [javax.vecmath AxisAngle4d Matrix4d Point3d Vector3d]))
 
 (set! *warn-on-reflection* true)
@@ -1220,16 +1216,12 @@
       (first (handler/adapt-every selection AtlasNode))))
 
 (defn- handle-drop
-  [action op-seq]
-  (let [{:keys [string gesture-target]} action
-        ui-context (first (ui/node-contexts gesture-target false))
-        {:keys [selection workspace]} (:env ui-context)]
-    (when-let [parent (parent-animation-or-atlas selection)]
-      (let [image-resources (->> (str/split-lines string)
-                                 (filter image/image-path?)
-                                 (sort)
-                                 (keep (partial workspace/resolve-workspace-resource workspace)))]
-        (create-dropped-images! parent image-resources op-seq)))))
+  [selection workspace _world-pos resources op-seq]
+  (when-let [parent (parent-animation-or-atlas selection)]
+    (let [image-resources (->> resources
+                               (filter image/image-path?)
+                               (keep (partial workspace/resolve-workspace-resource workspace)))]
+      (create-dropped-images! parent image-resources op-seq))))
 
 (defn handle-input [self action selection-data]
   (case (:type action)

--- a/editor/src/clj/editor/collection.clj
+++ b/editor/src/clj/editor/collection.clj
@@ -841,8 +841,11 @@
   (let [ext (resource/type-ext resource)]
     (case ext
       "go"
-      (let [game-object (selection->game-object-instance selection)
-            parent (or game-object collection)]
+      (let [go-node (selection->game-object-instance selection)
+            parent (or go-node collection)
+            collection (if go-node
+                         (core/scope-of-type go-node CollectionNode)
+                         collection)]
         (make-ref-go collection resource id transform-props parent nil nil))
 
       "collection"

--- a/editor/src/clj/editor/collection.clj
+++ b/editor/src/clj/editor/collection.clj
@@ -820,11 +820,9 @@
     (collection-string-data/string-encode-collection-desc ext->embedded-component-resource-type collection-desc)))
 
 (defn- add-dropped-resource
-  [selection transform-props resource]
+  [selection collection transform-props resource]
   (let [ext (str/lower-case (resource/ext resource))
-        base-name (resource/base-name resource)
-        collection (or (selection->collection selection)
-                       (first (map #(core/scope-of-type % CollectionNode) selection)))]
+        base-name (resource/base-name resource)]
     (case ext
       "go"
       (let [id (gen-instance-id collection base-name)
@@ -843,14 +841,13 @@
       nil)))
 
 (defn- handle-drop
-  [selection workspace world-pos resources op-seq]
-  (let [resources (keep (partial workspace/resolve-workspace-resource workspace) resources)
-        transform-props {:position (types/Point3d->Vec3 world-pos)}]
-    (g/tx-nodes-added
-      (g/transact
-        (concat
-          (mapv (partial add-dropped-resource selection transform-props) resources)
-          (g/operation-sequence op-seq))))))
+  [selection workspace world-pos resources]
+  (let [transform-props {:position (types/Point3d->Vec3 world-pos)}
+        collection (or (selection->collection selection)
+                       (first (map #(core/scope-of-type % CollectionNode) selection)))]
+    (->> resources
+         (keep (partial workspace/resolve-workspace-resource workspace))
+         (mapv (partial add-dropped-resource selection collection transform-props)))))
 
 (defn register-resource-types [workspace]
   (resource-node/register-ddf-resource-type workspace

--- a/editor/src/clj/editor/collection.clj
+++ b/editor/src/clj/editor/collection.clj
@@ -835,15 +835,14 @@
       nil)))
 
 (defn- handle-drop
-  [selection workspace world-pos resources]
+  [selection _workspace world-pos resources]
   (when-let [collection (or (selection->collection selection)
                             (some #(core/scope-of-type % CollectionNode) selection))]
     (let [transform-props {:position (types/Point3d->Vec3 world-pos)}
           taken-ids (g/node-value collection :ids)
           supported-exts #{"go" "collection"}]
       (->> resources
-           (e/keep (partial workspace/resolve-workspace-resource workspace))
-           (e/filter #(some #{(resource/type-ext %)} supported-exts))
+           (e/filter (comp (partial contains? supported-exts) resource/type-ext))
            (outline/name-resource-pairs taken-ids)
            (mapv (partial add-dropped-resource selection collection transform-props))))))
 

--- a/editor/src/clj/editor/collection.clj
+++ b/editor/src/clj/editor/collection.clj
@@ -841,10 +841,11 @@
   (let [transform-props {:position (types/Point3d->Vec3 world-pos)}
         collection (or (selection->collection selection)
                        (some #(core/scope-of-type % CollectionNode) selection))]
-    (into []
-          (comp (keep (partial workspace/resolve-workspace-resource workspace))
-                (map (partial add-dropped-resource selection collection transform-props)))
-          resources)))
+    (when collection
+      (into []
+            (comp (keep (partial workspace/resolve-workspace-resource workspace))
+                  (map (partial add-dropped-resource selection collection transform-props)))
+            resources))))
 
 (defn register-resource-types [workspace]
   (resource-node/register-ddf-resource-type workspace

--- a/editor/src/clj/editor/collection.clj
+++ b/editor/src/clj/editor/collection.clj
@@ -32,7 +32,6 @@
             [editor.resource-dialog :as resource-dialog]
             [editor.resource-node :as resource-node]
             [editor.scene :as scene]
-            [editor.scene-picking :as scene-picking]
             [editor.types :as types]
             [editor.validation :as validation]
             [editor.workspace :as workspace]
@@ -758,7 +757,7 @@
   (let [acc-fn (fn [target-node resource]
                  (->> (g/node-value target-node :ref-coll-ddf)
                       (keep #(workspace/resolve-resource resource (:collection %)))))]
-    (scene-picking/contains-resource? project acc-fn collection resource)))
+    (project/node-refers-to-resource? project collection resource acc-fn)))
 
 (handler/defhandler :edit.add-secondary-referenced-component :workbench
   (active? [selection] (or (selection->collection selection)

--- a/editor/src/clj/editor/collection.clj
+++ b/editor/src/clj/editor/collection.clj
@@ -34,7 +34,6 @@
             [editor.resource-node :as resource-node]
             [editor.scene :as scene]
             [editor.types :as types]
-            [editor.ui :as ui]
             [editor.validation :as validation]
             [editor.workspace :as workspace]
             [internal.cache :as c]
@@ -844,13 +843,9 @@
       nil)))
 
 (defn- handle-drop
-  [action op-seq]
-  (let [{:keys [string gesture-target world-pos]} action
-        ui-context (first (ui/node-contexts gesture-target false))
-        {:keys [selection workspace]} (:env ui-context)
-        transform-props {:position (types/Point3d->Vec3 world-pos)}
-        resources (->> (str/split-lines string)
-                       (keep (partial workspace/resolve-workspace-resource workspace)))]
+  [selection workspace world-pos resources op-seq]
+  (let [resources (keep (partial workspace/resolve-workspace-resource workspace) resources)
+        transform-props {:position (types/Point3d->Vec3 world-pos)}]
     (g/tx-nodes-added
       (g/transact
         (concat

--- a/editor/src/clj/editor/collection.clj
+++ b/editor/src/clj/editor/collection.clj
@@ -831,12 +831,9 @@
         (make-ref-go collection resource id transform-props parent nil nil))
 
       "collection"
-      (let [collection-resource (g/node-value collection :resource)
-            dropping-resource-path (resource/proj-path resource)
-            collection-resource-path (resource/proj-path collection-resource)]
-        (when (not= dropping-resource-path collection-resource-path)
-          (let [id (gen-instance-id collection base-name)]
-            (make-collection-instance collection resource id transform-props nil nil))))
+      (when (not= (g/maybe-node-value collection :resource) resource)
+        (let [id (gen-instance-id collection base-name)]
+          (make-collection-instance collection resource id transform-props nil nil)))
 
       nil)))
 

--- a/editor/src/clj/editor/game_object.clj
+++ b/editor/src/clj/editor/game_object.clj
@@ -622,7 +622,6 @@
           taken-ids (map first (g/node-value parent :component-ids))
           supported-exts (get-all-comp-exts workspace)]
       (->> resources
-           (e/keep (partial workspace/resolve-workspace-resource workspace))
            (e/filter #(some #{(resource/type-ext %)} supported-exts))
            (outline/name-resource-pairs taken-ids)
            (mapv (fn [[id resource]]

--- a/editor/src/clj/editor/game_object.clj
+++ b/editor/src/clj/editor/game_object.clj
@@ -625,10 +625,11 @@
   (let [transform-props {:position (types/Point3d->Vec3 world-pos)}
         parent (or (selection->game-object selection)
                    (some #(core/scope-of-type % GameObjectNode) selection))]
-    (into []
-          (comp (keep (partial workspace/resolve-workspace-resource workspace))
-                (map (partial add-dropped-resource parent workspace transform-props)))
-          resources)))
+    (when parent
+      (into []
+            (comp (keep (partial workspace/resolve-workspace-resource workspace))
+                  (map (partial add-dropped-resource parent workspace transform-props)))
+            resources))))
 
 (defn register-resource-types [workspace]
   (resource-node/register-ddf-resource-type workspace

--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -47,7 +47,6 @@
             [editor.scene-tools :as scene-tools]
             [editor.texture-set :as texture-set]
             [editor.types :as types]
-            [editor.ui :as ui]
             [editor.util :as eutil]
             [editor.validation :as validation]
             [editor.workspace :as workspace]
@@ -3960,12 +3959,8 @@
       nil)))
 
 (defn- handle-drop
-  [action op-seq]
-  (let [{:keys [string gesture-target]} action
-        ui-context (first (ui/node-contexts gesture-target false))
-        {:keys [selection workspace]} (:env ui-context)
-        resources (->> (str/split-lines string)
-                       (keep (partial workspace/resolve-workspace-resource workspace)))]
+  [selection workspace _world-pos resources op-seq]
+  (let [resources (keep (partial workspace/resolve-workspace-resource workspace) resources)]
     (g/tx-nodes-added
       (g/transact
         (concat

--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -3961,10 +3961,9 @@
   [selection workspace _world-pos resources]
   (when (seq selection)
     (when-let [scene (node->gui-scene (first selection))]
-      (into []
-            (comp (keep (partial workspace/resolve-workspace-resource workspace))
-                  (map (partial add-dropped-resource scene workspace)))
-            resources))))
+      (->> resources
+           (e/keep (partial workspace/resolve-workspace-resource workspace))
+           (mapv (partial add-dropped-resource scene workspace))))))
 
 (defn- register [workspace def]
   (let [ext (:ext def)

--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -3959,11 +3959,12 @@
 
 (defn- handle-drop
   [selection workspace _world-pos resources]
-  (let [scene (node->gui-scene (first selection))]
-    (into []
-          (comp (keep (partial workspace/resolve-workspace-resource workspace))
-                (map (partial add-dropped-resource scene workspace)))
-          resources)))
+  (when (seq selection)
+    (when-let [scene (node->gui-scene (first selection))]
+      (into []
+            (comp (keep (partial workspace/resolve-workspace-resource workspace))
+                  (map (partial add-dropped-resource scene workspace)))
+            resources))))
 
 (defn- register [workspace def]
   (let [ext (:ext def)

--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -3937,7 +3937,7 @@
 
 (defn- add-dropped-resource
   [scene workspace resource]
-  (let [ext (str/lower-case (resource/ext resource))
+  (let [ext (resource/type-ext resource)
         base-name (resource/base-name resource)
         gen-name #(->> (g/node-value (g/node-value scene %) :name-counts)
                        (outline/resolve-id base-name))]
@@ -3960,9 +3960,10 @@
 (defn- handle-drop
   [selection workspace _world-pos resources]
   (let [scene (node->gui-scene (first selection))]
-    (->> resources
-         (keep (partial workspace/resolve-workspace-resource workspace))
-         (mapv (partial add-dropped-resource scene workspace)))))
+    (into []
+          (comp (keep (partial workspace/resolve-workspace-resource workspace))
+                (map (partial add-dropped-resource scene workspace)))
+          resources)))
 
 (defn- register [workspace def]
   (let [ext (:ext def)

--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -3970,9 +3970,9 @@
 
 (defn- handle-drop
   [selection workspace _world-pos resources]
-  (when (seq selection)
-    (when-let [scene (node->gui-scene (first selection))]
-      (mapv (partial add-dropped-resource scene workspace) resources))))
+  (when-let [scene (some-> selection first resource-node/owner-resource-node-id)]
+    (mapv (partial add-dropped-resource scene workspace)
+          resources)))
 
 (defn- register [workspace def]
   (let [ext (:ext def)

--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -1921,7 +1921,7 @@
                  (->> (g/node-value target-node :node-msgs)
                       (filter #(= :type-template (:type %)))
                       (keep #(workspace/resolve-resource resource (:template %)))))]
-    (scene-picking/contains-resource? project acc-fn gui-scene resource)))
+    (project/node-refers-to-resource? project gui-scene resource acc-fn)))
 
 (g/defnode TemplateNode
   (inherits GuiNode)

--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -3936,9 +3936,8 @@
         (update :material #(or % default-material-proj-path)))))
 
 (defn- add-dropped-resource
-  [selection workspace resource]
-  (let [scene (node->gui-scene (first selection))
-        ext (str/lower-case (resource/ext resource))
+  [scene workspace resource]
+  (let [ext (str/lower-case (resource/ext resource))
         base-name (resource/base-name resource)
         gen-name #(->> (g/node-value (g/node-value scene %) :name-counts)
                        (outline/resolve-id base-name))]
@@ -3959,13 +3958,11 @@
       nil)))
 
 (defn- handle-drop
-  [selection workspace _world-pos resources op-seq]
-  (let [resources (keep (partial workspace/resolve-workspace-resource workspace) resources)]
-    (g/tx-nodes-added
-      (g/transact
-        (concat
-          (mapv (partial add-dropped-resource selection workspace) resources)
-          (g/operation-sequence op-seq))))))
+  [selection workspace _world-pos resources]
+  (let [scene (node->gui-scene (first selection))]
+    (->> resources
+         (keep (partial workspace/resolve-workspace-resource workspace))
+         (mapv (partial add-dropped-resource scene workspace)))))
 
 (defn- register [workspace def]
   (let [ext (:ext def)

--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -3961,9 +3961,7 @@
   [selection workspace _world-pos resources]
   (when (seq selection)
     (when-let [scene (node->gui-scene (first selection))]
-      (->> resources
-           (e/keep (partial workspace/resolve-workspace-resource workspace))
-           (mapv (partial add-dropped-resource scene workspace))))))
+      (mapv (partial add-dropped-resource scene workspace) resources))))
 
 (defn- register [workspace def]
   (let [ext (:ext def)

--- a/editor/src/clj/editor/image.clj
+++ b/editor/src/clj/editor/image.clj
@@ -13,8 +13,7 @@
 ;; specific language governing permissions and limitations under the License.
 
 (ns editor.image
-  (:require [clojure.string :as str]
-            [dynamo.graph :as g]
+  (:require [dynamo.graph :as g]
             [editor.build-target :as bt]
             [editor.gl :as gl]
             [editor.gl.texture :as texture]
@@ -32,11 +31,9 @@
 
 (def exts ["jpg" "png"])
 
-(defn image-path?
-  [path]
-  (->> exts
-       (some (partial str/ends-with? (str/lower-case path)))
-       boolean))
+(defn image-resource?
+  [resource]
+  (boolean (some #{(resource/type-ext resource)} exts)))
 
 (defn- build-texture [resource _dep-resources user-data]
   (let [{:keys [content-generator texture-profile compress?]} user-data

--- a/editor/src/clj/editor/outline.clj
+++ b/editor/src/clj/editor/outline.clj
@@ -353,6 +353,10 @@
                  [[] (ids->lookup taken-ids)]
                  wanted-ids)))
 
+(defn name-resource-pairs [taken-ids resources]
+  (let [names (resolve-ids (map resource/base-name resources) taken-ids)]
+    (map vector names resources)))
+
 (defn natural-sort [items]
   (->> items (sort-by :label util/natural-order) vec))
 

--- a/editor/src/clj/editor/scene_picking.clj
+++ b/editor/src/clj/editor/scene_picking.clj
@@ -13,10 +13,7 @@
 ;; specific language governing permissions and limitations under the License.
 
 (ns editor.scene-picking
-  (:require [dynamo.graph :as g]
-            [editor.defold-project :as project]
-            [editor.resource :as resource]
-            [util.coll :as coll]
+  (:require [util.coll :as coll]
             [util.eduction :as e]))
 
 (defn picking-id->color [^long picking-id]
@@ -44,21 +41,3 @@
                       (coll/some #(and (not= % (:node-id node))
                                        (contains? node-ids %)))))]
     (e/remove child? nodes)))
-
-(defn contains-resource?
-  [project acc-fn node-id resource]
-  (let [path (resource/proj-path (g/node-value node-id :resource))]
-    (println path)
-    (loop [resources [resource]
-           checked-paths #{}]
-      (when-let [resource (first resources)]
-        (let [current-path (resource/proj-path resource)]
-          (or (= path current-path)
-              (let [resources (rest resources)]
-                (recur (if (contains? checked-paths current-path)
-                         resources
-                         (let [target-node (project/get-resource-node project resource)]
-                           (cond-> resources
-                             target-node
-                             (concat (acc-fn target-node resource)))))
-                       (conj checked-paths current-path)))))))))

--- a/editor/src/clj/editor/scene_picking.clj
+++ b/editor/src/clj/editor/scene_picking.clj
@@ -13,7 +13,10 @@
 ;; specific language governing permissions and limitations under the License.
 
 (ns editor.scene-picking
-  (:require [util.coll :as coll]
+  (:require [dynamo.graph :as g]
+            [editor.defold-project :as project]
+            [editor.resource :as resource]
+            [util.coll :as coll]
             [util.eduction :as e]))
 
 (defn picking-id->color [^long picking-id]
@@ -41,3 +44,21 @@
                       (coll/some #(and (not= % (:node-id node))
                                        (contains? node-ids %)))))]
     (e/remove child? nodes)))
+
+(defn contains-resource?
+  [project acc-fn node-id resource]
+  (let [path (resource/proj-path (g/node-value node-id :resource))]
+    (println path)
+    (loop [resources [resource]
+           checked-paths #{}]
+      (when-let [resource (first resources)]
+        (let [current-path (resource/proj-path resource)]
+          (or (= path current-path)
+              (let [resources (rest resources)]
+                (recur (if (contains? checked-paths current-path)
+                         resources
+                         (let [target-node (project/get-resource-node project resource)]
+                           (cond-> resources
+                             target-node
+                             (concat (acc-fn target-node resource)))))
+                       (conj checked-paths current-path)))))))))

--- a/editor/src/clj/editor/scene_picking.clj
+++ b/editor/src/clj/editor/scene_picking.clj
@@ -12,7 +12,9 @@
 ;; CONDITIONS OF ANY KIND, either express or implied. See the License for the
 ;; specific language governing permissions and limitations under the License.
 
-(ns editor.scene-picking)
+(ns editor.scene-picking
+  (:require [util.coll :as coll]
+            [util.eduction :as e]))
 
 (defn picking-id->color [^long picking-id]
   (assert (<= picking-id 0xffffff))
@@ -30,3 +32,12 @@
   (let [picking-id (:picking-id renderable)
         id-color (picking-id->color picking-id)]
     (float-array id-color)))
+
+(defn top-nodes
+  [nodes]
+  (let [node-ids (into #{} (map :node-id) nodes)
+        child? (fn [node]
+                 (->> (:node-id-path node)
+                      (coll/some #(and (not= % (:node-id node))
+                                       (contains? node-ids %)))))]
+    (e/remove child? nodes)))

--- a/editor/src/clj/editor/scene_selection.clj
+++ b/editor/src/clj/editor/scene_selection.clj
@@ -18,6 +18,7 @@
             [editor.system :as system]
             [editor.geom :as geom]
             [editor.handler :as handler]
+            [editor.scene-picking :as scene-picking]
             [editor.types :as types]
             [editor.ui :as ui]
             [editor.gl.pass :as pass]
@@ -145,9 +146,10 @@
         added-nodes (add-dropped-resources! drop-fn resources op-seq)]
     (.consume event)
     (when (seq added-nodes)
-      (let [top-ids (filterv (comp not :node-id g/node-by-id) added-nodes)
-            ids-to-select (if (empty? top-ids) added-nodes top-ids)]
-        (select-fn ids-to-select op-seq))
+      (let [top-ids (->> (e/map g/node-by-id added-nodes)
+                         (scene-picking/top-nodes)
+                         (e/keep :_node-id))]
+        (select-fn top-ids op-seq))
       (ui/user-data! (ui/main-scene) ::ui/refresh-requested? true)
       (.setDropCompleted event true))))
 

--- a/editor/src/clj/editor/scene_selection.clj
+++ b/editor/src/clj/editor/scene_selection.clj
@@ -137,8 +137,9 @@
                           (g/operation-label "Drop Resources"))))]
     (.consume event)
     (when (seq added-nodes)
-      (let [top-ids (filterv (comp not :node-id g/node-by-id) added-nodes)]
-        (select-fn top-ids op-seq))
+      (let [top-ids (filterv (comp not :node-id g/node-by-id) added-nodes)
+            ids-to-select (if (empty? top-ids) added-nodes top-ids)]
+        (select-fn ids-to-select op-seq))
       (ui/user-data! (ui/main-scene) ::ui/refresh-requested? true)
       (.setDropCompleted event true))))
 

--- a/editor/src/clj/editor/scene_selection.clj
+++ b/editor/src/clj/editor/scene_selection.clj
@@ -13,7 +13,8 @@
 ;; specific language governing permissions and limitations under the License.
 
 (ns editor.scene-selection
-  (:require [dynamo.graph :as g]
+  (:require [clojure.string :as str]
+            [dynamo.graph :as g]
             [editor.system :as system]
             [editor.geom :as geom]
             [editor.handler :as handler]
@@ -120,6 +121,21 @@
   [[x0 y0 z0] [x1 y1 z1]]
   (.distance (Point3d. x0 y0 z0) (Point3d. x1 y1 z1)))
 
+(defn- handle-drag-dropped
+  [drop-fn select-fn action]
+  (let [op-seq (gensym)
+        {:keys [^DragEvent event string gesture-target world-pos]} action
+        _ (ui/request-focus! gesture-target)
+        env (-> gesture-target (ui/node-contexts false) first :env)
+        {:keys [selection workspace]} env
+        resources (-> string str/split-lines sort)
+        added-nodes (drop-fn selection workspace world-pos resources op-seq)]
+    (.consume event)
+    (when (seq added-nodes)
+      (select-fn added-nodes op-seq)
+      (ui/user-data! (ui/main-scene) ::ui/refresh-requested? true)
+      (.setDropCompleted event true))))
+
 (defn handle-selection-input [self action _user-data]
   (let [start (g/node-value self :start)
         op-seq (g/node-value self :op-seq)
@@ -128,17 +144,10 @@
         cursor-pos [(:x action) (:y action) 0]
         contextual? (= (:button action) :secondary)]
     (case (:type action)
-      :drag-dropped (when-let [drop-fn (g/node-value self :drop-fn)]
-                      (let [op-seq (gensym)
-                            select-fn (g/node-value self :select-fn)
-                            drag-event ^DragEvent (:event action)
-                            _ (ui/request-focus! (:gesture-target action))
-                            added-nodes (drop-fn action op-seq)]
-                        (.consume drag-event)
-                        (when (seq added-nodes)
-                          (select-fn added-nodes op-seq)
-                          (ui/user-data! (ui/main-scene) ::ui/refresh-requested? true)
-                          (.setDropCompleted drag-event true)))
+      :drag-dropped (let [drop-fn (g/node-value self :drop-fn)
+                          select-fn (g/node-value self :select-fn)]
+                      (when drop-fn
+                        (handle-drag-dropped drop-fn select-fn action))
                       nil)
       :mouse-pressed (let [op-seq (gensym)
                            toggle? (true? (some true? (map #(% action) toggle-modifiers)))

--- a/editor/src/clj/editor/scene_selection.clj
+++ b/editor/src/clj/editor/scene_selection.clj
@@ -139,10 +139,8 @@
         _ (ui/request-focus! gesture-target)
         env (-> gesture-target (ui/node-contexts false) first :env)
         {:keys [selection workspace]} env
-        resource-strings (string/split-lines string)
-        resources (->>  resource-strings
-                        (e/keep (partial workspace/resolve-workspace-resource workspace))
-                        (sort-by :id))
+        resource-strings (-> string string/split-lines sort)
+        resources (e/keep (partial workspace/resolve-workspace-resource workspace) resource-strings)
         drop-fn (partial drop-fn selection workspace world-pos)
         added-nodes (add-dropped-resources! drop-fn resources op-seq)]
     (.consume event)

--- a/editor/src/clj/editor/scene_selection.clj
+++ b/editor/src/clj/editor/scene_selection.clj
@@ -129,7 +129,12 @@
         env (-> gesture-target (ui/node-contexts false) first :env)
         {:keys [selection workspace]} env
         resources (-> string str/split-lines sort)
-        added-nodes (drop-fn selection workspace world-pos resources op-seq)]
+        added-nodes (g/tx-nodes-added
+                      (g/transact
+                        (concat
+                          (drop-fn selection workspace world-pos resources)
+                          (g/operation-sequence op-seq)
+                          (g/operation-label "Drop resources"))))]
     (.consume event)
     (when (seq added-nodes)
       (select-fn added-nodes op-seq)

--- a/editor/src/clj/editor/scene_tools.clj
+++ b/editor/src/clj/editor/scene_tools.clj
@@ -24,9 +24,7 @@
             [editor.gl.vertex :as vtx]
             [editor.math :as math]
             [editor.prefs :as prefs]
-            [editor.scene-picking :as scene-picking]
-            [util.coll :as coll]
-            [util.eduction :as e])
+            [editor.scene-picking :as scene-picking])
   (:import [com.jogamp.opengl GL GL2]
            [java.lang Math Runnable]
            [javax.vecmath AxisAngle4d Matrix3d Matrix4d Point3d Quat4d Tuple3d Vector3d]))
@@ -502,15 +500,6 @@
       (apply-fn start-pos pos))))
 
 (def ^:private original-values #(select-keys % [:node-id :world-rotation :world-transform :parent-world-transform]))
- 
-(defn- top-nodes
-  [nodes]
-  (let [node-ids (into #{} (map :node-id) nodes)
-        child? (fn [node]
-                 (->> (:node-id-path node)
-                      (coll/some #(and (not= % (:node-id node))
-                                       (contains? node-ids %)))))]
-    (e/remove child? nodes)))
 
 (defn handle-input [self action selection-data]
   (case (:type action)
@@ -521,7 +510,7 @@
                            filter-fn (:filter-fn tool)
                            selected-renderables (filter #(filter-fn (:node-id %)) (g/node-value self :selected-renderables evaluation-context))
                            original-values (->> selected-renderables
-                                                top-nodes
+                                                scene-picking/top-nodes
                                                 (mapv original-values))]
                        (when (not (empty? original-values))
                          (g/transact


### PR DESCRIPTION
Add game objects, collections and components on drop to scenes.
![collection-dnd](https://github.com/user-attachments/assets/d6fb4374-52b2-41c1-8821-e24580810380)

Fixes #10605
Fixes #10604
Fixes #6568

### Technical changes
Moved some parts to `scene_selection.clj` to reuse them and added a `drop-fn` handler to `collection` and `go` scenes. Also used `world-pos` to add the resources to the dropped position. Dropping on assets on the outline will be handled on a follow-up PR.