### PR TITLE
Fix minimum scrollbar thumb size

### DIFF
--- a/editor/styling/stylesheets/components/_scroll-bar.scss
+++ b/editor/styling/stylesheets/components/_scroll-bar.scss
@@ -6,8 +6,11 @@
         }
     }
     &:vertical {
+        -fx-pref-width: 10px;
         .increment-button, .decrement-button {
             -fx-padding: 0 10 0 0;
+            // this actually sets minimum scrollbar thumb height...
+            -fx-pref-width: 15px;
         }
     }
     .thumb {

--- a/editor/styling/stylesheets/components/_scroll-bar.scss
+++ b/editor/styling/stylesheets/components/_scroll-bar.scss
@@ -1,26 +1,17 @@
 .scroll-bar {
     -fx-background-color: -df-background-light;
     &:horizontal {
-        -fx-background-insets: 0px -1px -1px -1px;
-        //-fx-padding: 2px -1px -1px -1px;
-        >.thumb {
-            -fx-background-insets: 1px 5px 1px 5px;
-            -fx-padding: 0 20px 0 10px !important;
-        }
         .increment-button, .decrement-button {
             -fx-padding: 0 0 10 0;
         }
     }
     &:vertical {
-        >.thumb {
-            //-fx-background-insets: 5px 3px 5px 2px;
-            -fx-background-insets: 5px 1px 5px 1px;
-        }
         .increment-button, .decrement-button {
             -fx-padding: 0 10 0 0;
         }
     }
     .thumb {
+        -fx-background-insets: 1px;
         -fx-background-color: -df-component-dark;
         -fx-background-radius: 2em;
         &:hover {


### PR DESCRIPTION
Increased minimum scrollbar thumb size.

Before (600 nodes) -> After (600 nodes)
<img src="https://github.com/user-attachments/assets/51cd413b-362d-46d8-aec5-c2fc86074ed4" width="50%"><img src="https://github.com/user-attachments/assets/0a584ba6-25eb-44f6-9cd0-d7881d62fc74" width="50%">

Fixes #10597

### Technical changes
Setting a `min-height` or altering `padding` doesn't seem to have any effect. The existing `5px` inset was reducing the default minimum size of the thumb.