### PR TITLE
Make it possible to set GUI resources using `gui.set()`

### DIFF
--- a/engine/engine/src/test/script_props/gui/prop_gui.gui_script
+++ b/engine/engine/src/test/script_props/gui/prop_gui.gui_script
@@ -40,6 +40,13 @@ local function test(self)
             gui.set_font(self.text_node, "system_font_BIG")
         end)
 
+    -- Add font with another name using gui.set()
+    gui.set(msg.url(), "fonts", self.font_resource, {key = "new_font_name"})
+    assert_not_error(function()
+            gui.set_font(self.text_node, "new_font_name")
+        end)
+    assert_exit(self.font_resource == gui.get_font_resource(gui.get_font(self.text_node)), "Error when setting font using `gui.set()`")
+
     msg.post("#prop_guiscript", "test_done")
 end
 

--- a/engine/gameobject/src/gameobject/gameobject_script_util.h
+++ b/engine/gameobject/src/gameobject/gameobject_script_util.h
@@ -28,6 +28,18 @@ namespace dmGameObject
     Result LuaLoad(dmResource::HFactory factory, dmScript::HContext context, dmLuaDDF::LuaModule* module);
     int    LuaToPropertyOptions(lua_State* L, int index, PropertyOptions* property_options, dmhash_t property_id, bool* index_requested);
     int    CheckGetPropertyResult(lua_State* L, const char* module_name, dmGameObject::PropertyResult result, const PropertyDesc& property_desc, dmhash_t property_id, const dmMessage::URL& target, const dmGameObject::PropertyOptions& property_options, bool index_requested);
+    int    HandleGoSetResult(lua_State* L, dmGameObject::PropertyResult result, dmhash_t property_id, dmGameObject::HInstance target_instance, const dmMessage::URL& target, const dmGameObject::PropertyOptions& property_options);
+
+    static const char* TYPE_NAMES[PROPERTY_TYPE_COUNT] = {
+        "number",        // PROPERTY_TYPE_NUMBER
+        "hash",          // PROPERTY_TYPE_HASH
+        "msg.url",       // PROPERTY_TYPE_URL
+        "vmath.vector3", // PROPERTY_TYPE_VECTOR3
+        "vmath.vector4", // PROPERTY_TYPE_VECTOR4
+        "vmath.quat",    // PROPERTY_TYPE_QUAT
+        "boolean",       // PROPERTY_TYPE_BOOLEAN
+        "vmath.matrix4", // PROPERTY_TYPE_MATRIX4
+    };
 }
 
 #endif // #ifndef DM_GAMEOBJECT_SCRIPT_UTIL_H

--- a/engine/gui/src/gui_script.cpp
+++ b/engine/gui/src/gui_script.cpp
@@ -22,7 +22,6 @@
 #include <dmsdk/dlib/vmath.h>
 
 #include <script/script.h>
-#include <gamesys/components/comp_gui.h> 
 #include <gameobject/gameobject_props_lua.h>
 #include <gameobject/gameobject_script_util.h>
 
@@ -808,11 +807,12 @@ namespace dmGui
      * If the material has a constant array called 'tint_array' specified in the material, you can use `gui.set(node, "tint_array", vmath.vec4(1,0,0,1), { index = 4})` to set the fourth array element to a different value.
      *
      * @name gui.set
-     * @param node [type:node] node to set the property for
+     * @param node [type:node|url] node to set the property for, or msg.url() to the gui itself
      * @param property [type:string|hash|constant] the property to set 
      * @param value [type:number|vector4|vector3|quat] the property to set
      * @param [options] [type:table] optional options table (only applicable for material constants)
      * - `index` [type:integer] index into array property (1 based)
+     * - `key` [type:hash] name of internal property
      *
      * @examples
      *
@@ -855,6 +855,21 @@ namespace dmGui
      * -- update a sub-element in an array constant at position 4
      * gui.set(node, "tint_array.x", 1, {index = 4})
      * ```
+     *
+     * Set a named property
+     *
+     * ```lua
+     * function on_message(self, message_id, message, sender)
+     *    if message_id == hash("set_font") then
+     *        gui.set(msg.url(), "fonts", message.font, {key = "my_font_name"})
+     *        gui.set_font(gui.get_node("text"), "my_font_name")
+     *    elseif message_id == hash("set_texture") then
+     *        gui.set(msg.url(), "textures", message.texture, {key = "my_texture"})
+     *        gui.set_texture(gui.get_node("box"), "my_texture")
+     *        gui.play_flipbook(gui.get_node("box"), "logo_256")
+     *    end
+     * end
+     * ```
      */
     static int LuaSet(lua_State* L)
     {
@@ -896,7 +911,7 @@ namespace dmGui
             {
                 return DM_LUA_ERROR("'gui.set()' can only be used to change a property of the GUI component itself, use 'msg.url()'");
             }
-            dmGameObject::HInstance instance = (dmGameObject::HInstance)dmGameSystem::GuiGetUserDataCallback(scene);
+            dmGameObject::HInstance instance = (dmGameObject::HInstance)scene->m_Context->m_GetUserDataCallback(scene);
             result = dmGameObject::SetProperty(instance, target.m_Fragment, property_hash, property_options, property_var);
             if (result != dmGameObject::PROPERTY_RESULT_OK)
             {


### PR DESCRIPTION
It is now possible to set Font or Texture resources for a GUI using the `gui.set()` function from the GUI component itself, provided that `msg.url()` is used as the first argument instead of a node.

```lua
function on_message(self, message_id, message, sender)
   if message_id == hash("set_font") then
       gui.set(msg.url(), "fonts", message.font, {key = "my_font_name"})
       gui.set_font(gui.get_node("text"), "my_font_name")
   elseif message_id == hash("set_texture") then
       gui.set(msg.url(), "textures", message.texture, {key = "my_texture"})
       gui.set_texture(gui.get_node("box"), "my_texture")
       gui.play_flipbook(gui.get_node("box"), "logo_256")
   end
end
```

Fix https://github.com/defold/defold/issues/10471