### PR TITLE
Update `camera.set_orthographic_zoom` to accept numeric zoom value

### DIFF
--- a/engine/render/src/render/render_script_camera.cpp
+++ b/engine/render/src/render/render_script_camera.cpp
@@ -206,7 +206,7 @@ namespace dmRender
     *
     * @name camera.get_orthographic_zoom
     * @param camera [type:url|handle|nil] camera id
-    * @return orthographic_zoom [type:boolean] true if the camera is using an orthographic projection.
+    * @return orthographic_zoom [type:number] the zoom level when the camera uses orthographic projection.
     */
     GET_CAMERA_DATA_PROPERTY_FN(OrthographicZoom, lua_pushnumber);
 
@@ -246,9 +246,9 @@ namespace dmRender
     *
     * @name camera.set_orthographic_zoom
     * @param camera [type:url|handle|nil] camera id
-    * @param orthographic_zoom [type:boolean] true if the camera is using an orthographic projection.
+    * @param orthographic_zoom [type:number] the zoom level when the camera uses orthographic projection.
     */
-    SET_CAMERA_DATA_PROPERTY_FN(OrthographicZoom, lua_toboolean);
+    SET_CAMERA_DATA_PROPERTY_FN(OrthographicZoom, lua_tonumber);
 
 #undef GET_CAMERA_DATA_PROPERTY_FN
 #undef SET_CAMERA_DATA_PROPERTY_FN

--- a/engine/render/src/test/test_render_script.cpp
+++ b/engine/render/src/test/test_render_script.cpp
@@ -1419,7 +1419,7 @@ TEST_F(dmRenderScriptTest, TestRenderTargetResource)
     dmRender::DeleteRenderScript(m_Context, render_script);
 }
 
-TEST_F(dmRenderScriptTest, TestRenderCameraGetInfo)
+TEST_F(dmRenderScriptTest, TestRenderCameraGetSetInfo)
 {
     dmRender::HRenderCamera camera = dmRender::NewRenderCamera(m_Context);
 
@@ -1432,9 +1432,11 @@ TEST_F(dmRenderScriptTest, TestRenderCameraGetInfo)
 
     dmRender::RenderCameraData data = {};
     data.m_Viewport = dmVMath::Vector4(0.0f, 0.0f, 1.0f, 1.0f);
-    data.m_Fov      = 90.0f;
-    data.m_NearZ    = 0.1f;
-    data.m_FarZ     = 100.0f;
+    data.m_Fov              = 90.0f;
+    data.m_NearZ            = 0.1f;
+    data.m_FarZ             = 100.0f;
+    data.m_AspectRatio      = 1.0f;
+    data.m_OrthographicZoom = 1.0f;
 
     dmRender::SetRenderCameraData(m_Context, camera, &data);
 
@@ -1451,9 +1453,21 @@ TEST_F(dmRenderScriptTest, TestRenderCameraGetInfo)
         "    assert(cams[1].socket == hash('main'))\n"
         "    assert(cams[1].path == hash('test_go'))\n"
         "    assert(cams[1].fragment == hash('camera'))\n"
+        // Test "get"
+        "    assert_near(camera.get_aspect_ratio(cams[1]), 1)\n"
         "    assert_near(camera.get_near_z(cams[1]), 0.1)\n"
         "    assert_near(camera.get_far_z(cams[1]), 100)\n"
         "    assert_near(camera.get_fov(cams[1]), 90)\n"
+        "    assert_near(camera.get_orthographic_zoom(cams[1]), 1)\n"
+        // Test "set"
+        "    camera.set_near_z(cams[1], -1)\n"
+        "    assert_near(camera.get_near_z(cams[1]), -1)\n"
+        "    camera.set_far_z(cams[1], 1)\n"
+        "    assert_near(camera.get_far_z(cams[1]), 1)\n"
+        "    camera.set_fov(cams[1], 45)\n"
+        "    assert_near(camera.get_fov(cams[1]), 45)\n"
+        "    camera.set_orthographic_zoom(cams[1], 2)\n"
+        "    assert_near(camera.get_orthographic_zoom(cams[1]), 2)\n"
         // Test set_camera()
         "    render.set_camera(cams[1])\n"
         "    render.set_camera()\n"

--- a/engine/render/src/test/test_render_script.cpp
+++ b/engine/render/src/test/test_render_script.cpp
@@ -1431,7 +1431,7 @@ TEST_F(dmRenderScriptTest, TestRenderCameraGetSetInfo)
     dmRender::SetRenderCameraURL(m_Context, camera, &camera_url);
 
     dmRender::RenderCameraData data = {};
-    data.m_Viewport = dmVMath::Vector4(0.0f, 0.0f, 1.0f, 1.0f);
+    data.m_Viewport         = dmVMath::Vector4(0.0f, 0.0f, 1.0f, 1.0f);
     data.m_Fov              = 90.0f;
     data.m_NearZ            = 0.1f;
     data.m_FarZ             = 100.0f;


### PR DESCRIPTION
The function `camera.set_orthographic_zoom()` now accepts the value as number (before it was boolean) and works the same as setting this value via go.set.

Fixes #10623

### Technical changes
* I improved the test, where previously only getting values was checked, but now setting them as well.
