### PR TITLE
Fix for initializing Vulkan on Android

### DIFF
--- a/engine/graphics/src/vulkan/graphics_vulkan.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan.cpp
@@ -960,7 +960,10 @@ namespace dmGraphics
         }
 
         context->m_FragmentShaderInterlockFeatures       = {};
-        context->m_FragmentShaderInterlockFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADER_INTERLOCK_FEATURES_EXT;
+        if (VulkanIsExtensionSupported((HContext) context, VK_EXT_FRAGMENT_SHADER_INTERLOCK_EXTENSION_NAME))
+        {
+            context->m_FragmentShaderInterlockFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADER_INTERLOCK_FEATURES_EXT;
+        }
 
         PhysicalDevice* device_list     = new PhysicalDevice[device_count];
         PhysicalDevice* selected_device = NULL;


### PR DESCRIPTION
Check if fragment shader interlock is supported before setting sType when initializing Vulkan.

Fixes #10614 

### Technical changes
Initializing Vulkan on Android seems to fatally crash because of "Unknown struct with type 0x3b9e9e78 provided to vkGetPhysicalDeviceFeatures2". This struct type is the VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADER_INTERLOCK_FEATURES_EXT = 1000251000 (defined on row 792 in vulkan_core.h). 
Which is provided to GetPhysicalDevices() as pNextFeatures and set as pNext on m_features2 provided to vkGetPhysicalFeatures2. (see row 344-349 in graphics_vulkan_device.cpp)

This change checks if fragment shader interlock is supported before setting this sType. If not supported pNextFeatures is an empty struct. 
