### PR TITLE
Fixing 8-bit WAV sample playback #10642

### DIFF
--- a/engine/sound/src/sound_dsp.h
+++ b/engine/sound/src/sound_dsp.h
@@ -464,7 +464,8 @@ static inline void ConvertFromS8(float* out, const int8_t* in, uint32_t num)
     }
     for(; num>0; --num)
     {
-        *(out++) = (float)*(in++);
+        int16_t s = *(in++);
+        *(out++) = (float)((s << 8) | (s && 0xff));
     }
 }
 
@@ -531,8 +532,10 @@ static inline void DeinterleaveFromS8(float* out[], const int8_t* in, uint32_t n
     float* out_r = (float*)vout_r;
     for(; num>0; --num)
     {
-        *(out_l++) = (float)*(in++);
-        *(out_r++) = (float)*(in++);
+        int16_t sl = *(in++);
+        int16_t sr = *(in++);
+        *(out_l++) = (float)((sl << 8) | (sl && 0xff));
+        *(out_r++) = (float)((sr << 8) | (sr && 0xff));
     }
 }
 
@@ -1007,7 +1010,8 @@ static inline void ConvertFromS8(float* out, const int8_t* in, uint32_t num)
     in = (const int8_t*)vin;
     for(; num>0; --num)
     {
-        *(out++) = (float)*(in++);
+        int16_t s = *(in++);
+        *(out++) = (float)((s << 8) | (s && 0xff));
     }
 }
 
@@ -1096,8 +1100,10 @@ static inline void DeinterleaveFromS8(float* out[], const int8_t* in, uint32_t n
     in = (const int8_t*)vin;
     for(; num>0; --num)
     {
-        *(out_l++) = (float)*(in++);
-        *(out_r++) = (float)*(in++);
+        int16_t sl = *(in++);
+        int16_t sr = *(in++);
+        *(out_l++) = (float)((sl << 8) | (sl && 0xff));
+        *(out_r++) = (float)((sr << 8) | (sr && 0xff));
     }
 }
 
@@ -1286,7 +1292,8 @@ static inline void ConvertFromS8(float* out, const int8_t* in, uint32_t num)
 {
     for(; num>0; --num)
     {
-        *(out++) = (float)*(in++);
+        int16_t s = *(in++);
+        *(out++) = (float)((s << 8) | (s && 0xff));
     }
 }
 
@@ -1318,8 +1325,10 @@ static inline void DeinterleaveFromS8(float* out[], const int8_t* in, uint32_t n
     float* out_r = out[1];
     for(; num>0; --num)
     {
-        *(out_l++) = (float)*(in++);
-        *(out_r++) = (float)*(in++);
+        int16_t sl = *(in++);
+        int16_t sr = *(in++);
+        *(out_l++) = (float)((sl << 8) | (sl && 0xff));
+        *(out_r++) = (float)((sr << 8) | (sr && 0xff));
     }
 }
 


### PR DESCRIPTION
The original bug describes this as a resampling bug, but in reality the 8 to 16 bit data conversion for 8-bit samples had been faulty for all DSP backends. Audible artifacts introduced were dependent on block sizes and backend variant, hence the red herring of this seaming related to the resampler.

Fixed all DSP variants and tested with original asset given as repro case for #10642.

Fixes #10642