### PR TITLE
go.exist() will now throw a Lua error if referencing another collection

### DIFF
--- a/engine/gameobject/src/gameobject/gameobject_script.cpp
+++ b/engine/gameobject/src/gameobject/gameobject_script.cpp
@@ -1994,7 +1994,9 @@ namespace dmGameObject
 
 
     /*# check if the specified game object exists
-     *
+     * A lua-error will be raised if the game object belongs to another
+     * collection than the collection from which the function was called.
+     * 
      * @name go.exists
      * @param url [type:string|hash|url] url of the game object to check
      * @return exists [type:bool] true if the game object exists

--- a/engine/gameobject/src/gameobject/gameobject_script.cpp
+++ b/engine/gameobject/src/gameobject/gameobject_script.cpp
@@ -2009,13 +2009,23 @@ namespace dmGameObject
     int Script_Exists(lua_State* L)
     {
         DM_LUA_STACK_CHECK(L, 1);
-        int top = lua_gettop(L);
-        if (top == 1 && lua_isnil(L, 1))
+        if (lua_isnil(L, 1))
         {
             return luaL_error(L, "The url shouldn't be `nil`");
         }
+
+        // get "this" instance
         ScriptInstance* i = ScriptInstance_Check(L);
         Instance* instance = i->m_Instance;
+
+        // resolve instance provided as argument and make sure it is the same as "this"
+        dmMessage::URL receiver;
+        dmScript::ResolveURL(L, 1, &receiver, 0x0);
+        if (receiver.m_Socket != dmGameObject::GetMessageSocket(instance->m_Collection->m_HCollection))
+        {
+            luaL_error(L, "function called can only access instances within the same collection.");
+        }
+
         dmMessage::URL sender;
         dmScript::GetURL(L, &sender);
         dmMessage::URL target;

--- a/engine/gameobject/src/gameobject/test/script/exists.script
+++ b/engine/gameobject/src/gameobject/test/script/exists.script
@@ -21,7 +21,10 @@ function init(self)
     assert(go.exists(msg.url(nil, "b", nil)), "Expected go msg.url(nil, 'b', nil) to exist")
     assert(not go.exists("unknown"), "Expected go 'unknown' to not exist")
     if pcall(go.exists, nil) then
-        assert(false, "Error expected if call go.exists with nil")
+        assert(false, "Error expected when calling go.exists with nil")
+    end
+    if pcall(go.exists, "foo:/bar") then
+        assert(false, "Error expected when calling go.exists with another collection")
     end
     assert(go.exists(), "Object itself always exists")
 end


### PR DESCRIPTION
Like all other functions in the go.* namespace the `go.exists(url)` function will now throw a Lua error if specifying a url referencing a game object from a different collection than the one from which `go.exists()` was called.

Fixes #10652 

## PR checklist

* [x] Code
	* [x] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [x] Add comments where needed
* [ ] Documentation
	* [x] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [x] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
