### PR TITLE
Make sure hashes are comparable even after the game object is removed

### DIFF
--- a/engine/gamesys/src/gamesys/test/factory/factory_hash_test.go
+++ b/engine/gamesys/src/gamesys/test/factory/factory_hash_test.go
@@ -1,0 +1,8 @@
+components {
+  id: "script"
+  component: "/factory/factory_hash_test.script"
+}
+components {
+  id: "factory"
+  component: "/factory/factory_test.factory"
+}

--- a/engine/gamesys/src/gamesys/test/factory/factory_hash_test.script
+++ b/engine/gamesys/src/gamesys/test/factory/factory_hash_test.script
@@ -1,0 +1,22 @@
+-- Copyright 2020-2025 The Defold Foundation
+-- Copyright 2014-2020 King
+-- Copyright 2009-2014 Ragnar Svensson, Christian Murray
+-- Licensed under the Defold License version 1.0 (the "License"); you may not use
+-- this file except in compliance with the License.
+--
+-- You may obtain a copy of the License, together with FAQs at
+-- https://www.defold.com/license
+--
+-- Unless required by applicable law or agreed to in writing, software distributed
+-- under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+-- CONDITIONS OF ANY KIND, either express or implied. See the License for the
+-- specific language governing permissions and limitations under the License.
+
+
+function init(self)
+    self.first_instance = factory.create("/go#factory")
+    local path = tostring(self.first_instance):match("%[(.-)%]")
+    go.delete(self.first_instance)
+    local h = hash(path)
+    assert(self.first_instance == h, "Hashes shouldn't be unique! Instance:'"..self.first_instance.."' value:'"..h.."'")
+end

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -3800,6 +3800,7 @@ FactoryTestParams factory_testparams [] =
     {"/factory/dynamic_factory_test.goc", true, false},
     {"/factory/factory_test.goc", false, true},
     {"/factory/factory_test.goc", false, false},
+    {"/factory/factory_hash_test.goc", true, true},
 };
 INSTANTIATE_TEST_CASE_P(Factory, FactoryTest, jc_test_values_in(factory_testparams));
 

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -2059,6 +2059,35 @@ TEST_P(FactoryTest, Test)
     dmGameSystem::FinalizeScriptLibs(scriptlibcontext);
 }
 
+TEST_P(FactoryTest, IdHashTest)
+{
+    dmHashEnableReverseHash(true);
+    lua_State* L = dmScript::GetLuaState(m_ScriptContext);
+
+    dmGameSystem::ScriptLibContext scriptlibcontext;
+    scriptlibcontext.m_Factory         = m_Factory;
+    scriptlibcontext.m_Register        = m_Register;
+    scriptlibcontext.m_LuaState        = L;
+    scriptlibcontext.m_GraphicsContext = m_GraphicsContext;
+    scriptlibcontext.m_ScriptContext   = m_ScriptContext;
+
+    dmGameSystem::InitializeScriptLibs(scriptlibcontext);
+
+    // Spawn the game object with the script we want to call
+    ASSERT_TRUE(dmGameObject::Init(m_Collection));
+    dmhash_t go_hash = dmHashString64("/go");
+    dmGameObject::HInstance go = Spawn(m_Factory, m_Collection, "/factory/factory_hash_test.goc", go_hash, 0, Point3(0, 0, 0), Quat(0, 0, 0, 1), Vector3(1, 1, 1));
+    ASSERT_NE((void*)0, go);
+    go = dmGameObject::GetInstanceFromIdentifier(m_Collection, go_hash);
+    ASSERT_NE((void*)0, go);
+
+    ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+    ASSERT_TRUE(dmGameObject::PostUpdate(m_Collection));
+    dmGameObject::PostUpdate(m_Register);
+
+    dmGameSystem::FinalizeScriptLibs(scriptlibcontext);
+}
+
 /* Collection factory dynamic and static loading */
 
 TEST_P(CollectionFactoryTest, Test)
@@ -3800,7 +3829,6 @@ FactoryTestParams factory_testparams [] =
     {"/factory/dynamic_factory_test.goc", true, false},
     {"/factory/factory_test.goc", false, true},
     {"/factory/factory_test.goc", false, false},
-    {"/factory/factory_hash_test.goc", true, true},
 };
 INSTANTIATE_TEST_CASE_P(Factory, FactoryTest, jc_test_values_in(factory_testparams));
 

--- a/engine/script/src/script.cpp
+++ b/engine/script/src/script.cpp
@@ -281,6 +281,8 @@ namespace dmScript
 
         Unref(L, LUA_REGISTRYINDEX, context->m_ContextTableRef);
         Unref(L, LUA_REGISTRYINDEX, context->m_ContextWeakTableRef);
+        context->m_ContextTableRef = LUA_NOREF;
+        context->m_ContextWeakTableRef = LUA_NOREF;
     }
 
     lua_State* GetLuaState(HContext context)

--- a/engine/script/src/script_ddf.cpp
+++ b/engine/script/src/script_ddf.cpp
@@ -547,16 +547,16 @@ namespace dmScript
                     else if (d->m_NameHash == DDF_TYPE_NAME_HASH_LUAREF)
                     {
                         dmScriptDDF::LuaRef* lua_ref = (dmScriptDDF::LuaRef*) ptr;
-                        if (lua_ref->m_Ref)
+                        lua_rawgeti(L, LUA_REGISTRYINDEX, lua_ref->m_ContextTableRef);
+                        lua_rawgeti(L, -1, lua_ref->m_Ref);
+                        if (lua_isnil(L, -1))
                         {
-                            lua_rawgeti(L, LUA_REGISTRYINDEX, lua_ref->m_ContextTableRef);
+                            lua_pop(L, 1); // remove nil
+                            lua_getfield(L, -1, "__weak"); // context_table["__weak"]
                             lua_rawgeti(L, -1, lua_ref->m_Ref);
-                            lua_remove(L, -2);
+                            lua_remove(L, -2); // remove weak table
                         }
-                        else
-                        {
-                            lua_pushnil(L);
-                        }
+                        lua_remove(L, -2); // remove context table
                     }
                     else
                     {

--- a/engine/script/src/script_hash.cpp
+++ b/engine/script/src/script_hash.cpp
@@ -156,6 +156,14 @@ namespace dmScript
             lua_rawgeti(L, -1, *refp);
             // [-2] Context table
             // [-1] hash
+            if (lua_isnil(L, -1))
+            {
+                lua_pop(L, 1);
+                lua_rawgeti(L, LUA_REGISTRYINDEX, context->m_ContextWeakTableRef);
+                lua_rawgeti(L, -1, *refp);
+                lua_remove(L, -2);
+            }
+
             lua_remove(L, -2);
             // [-1] hash
         }
@@ -194,17 +202,51 @@ namespace dmScript
     void ReleaseHash(lua_State* L, dmhash_t hash)
     {
         int top = lua_gettop(L);
+
         HContext context = dmScript::GetScriptContext(L);
         dmHashTable64<int>* instances = &context->m_HashInstances;
         int* refp = instances->Get(hash);
-        if (refp != 0x0)
+        if (!refp)
         {
-            lua_rawgeti(L, LUA_REGISTRYINDEX, context->m_ContextTableRef);
-            // [-1] context table
-            luaL_unref(L, -1, *refp);
-            lua_pop(L, 1);
-            instances->Erase(hash);
+            assert(top == lua_gettop(L));
+            return;
         }
+
+        int ref = *refp;
+
+        // Retrieve the value from the strong table
+        lua_rawgeti(L, LUA_REGISTRYINDEX, context->m_ContextTableRef);
+        // [-1] context_table
+        lua_rawgeti(L, -1, ref);
+        // [-2] context_table
+        // [-1] value
+        lua_remove(L, -2);
+        // [-1] value
+
+        // Store the value in the weak table with the same key
+        lua_rawgeti(L, LUA_REGISTRYINDEX, context->m_ContextWeakTableRef);
+        // [-2] value
+        // [-1] weak_table
+        lua_pushvalue(L, -2);
+        // [-3] value
+        // [-2] weak_table
+        // [-1] value_copy
+        lua_rawseti(L, -2, ref);
+        // [-2] value
+        // [-1] weak_table
+        lua_pop(L, 1);
+        // [-1] value
+
+        // Remove value from strong table
+        lua_rawgeti(L, LUA_REGISTRYINDEX, context->m_ContextTableRef);
+        // [-2] value
+        // [-1] context_table
+        luaL_unref(L, -1, ref);
+        lua_pop(L, 1);
+        // [-1] value
+
+        lua_pop(L, 1); // pop value
+        // stack balanced
 
         assert(top == lua_gettop(L));
     }
@@ -319,6 +361,25 @@ namespace dmScript
         {0, 0}
     };
 
+    static int Hash_gc(lua_State* L)
+    {
+        dmhash_t hash = *(dmhash_t*)lua_touserdata(L, 1);
+        HContext context = dmScript::GetScriptContext(L);
+        if (context)
+        {
+            context->m_HashInstances.Erase(hash);
+            lua_rawgeti(L, LUA_REGISTRYINDEX, context->m_ContextWeakTableRef);
+            int* refp = context->m_HashInstances.Get(hash);
+            if (refp) {
+                lua_pushinteger(L, *refp);
+                lua_pushnil(L);
+                lua_settable(L, -3);
+            }
+            lua_pop(L, 1);
+        }
+        return 0;
+    }
+
     void InitializeHash(lua_State* L)
     {
         int top = lua_gettop(L);
@@ -342,6 +403,11 @@ namespace dmScript
 
         lua_pushliteral(L, "__lt");
         lua_pushcfunction(L, Hash_lt);
+        lua_settable(L, -3);
+
+        // Add __gc
+        lua_pushliteral(L, "__gc");
+        lua_pushcfunction(L, Hash_gc);
         lua_settable(L, -3);
 
         lua_pushcfunction(L, Hash_new);

--- a/engine/script/src/script_hash.cpp
+++ b/engine/script/src/script_hash.cpp
@@ -374,15 +374,16 @@ namespace dmScript
         HContext context = dmScript::GetScriptContext(L);
         if (context)
         {
-            context->m_HashInstances.Erase(hash);
-            lua_rawgeti(L, LUA_REGISTRYINDEX, context->m_ContextWeakTableRef);
             int* refp = context->m_HashInstances.Get(hash);
-            if (refp) {
+            context->m_HashInstances.Erase(hash);
+            if (refp && context->m_ContextWeakTableRef != LUA_NOREF)
+            {
+                lua_rawgeti(L, LUA_REGISTRYINDEX, context->m_ContextWeakTableRef);
                 lua_pushinteger(L, *refp);
                 lua_pushnil(L);
                 lua_settable(L, -3);
+                lua_pop(L, 1);
             }
-            lua_pop(L, 1);
         }
         return 0;
     }
@@ -412,7 +413,6 @@ namespace dmScript
         lua_pushcfunction(L, Hash_lt);
         lua_settable(L, -3);
 
-        // Add __gc
         lua_pushliteral(L, "__gc");
         lua_pushcfunction(L, Hash_gc);
         lua_settable(L, -3);

--- a/engine/script/src/script_hash.cpp
+++ b/engine/script/src/script_hash.cpp
@@ -220,6 +220,13 @@ namespace dmScript
         lua_rawgeti(L, -1, ref);
         // [-2] context_table
         // [-1] value
+
+        if (lua_isnil(L, -1))
+        {
+            lua_pop(L, 2);
+            return;
+        }
+
         lua_remove(L, -2);
         // [-1] value
 

--- a/engine/script/src/script_private.h
+++ b/engine/script/src/script_private.h
@@ -78,6 +78,7 @@ namespace dmScript
         dmArray<HScriptExtension>   m_ScriptExtensions;
         lua_State*                  m_LuaState;
         int                         m_ContextTableRef;
+        int                         m_ContextWeakTableRef;
     };
 
     HContext GetScriptContext(lua_State* L);


### PR DESCRIPTION
Fixes an issue where, after removing a game object, its ID isn't equal to a hash with the same value.

Fix https://github.com/defold/defold/issues/9374