### PR TITLE
Expose tilesource animations and collision groups to editor scripts

### DIFF
--- a/editor/src/clj/editor/collection.clj
+++ b/editor/src/clj/editor/collection.clj
@@ -25,6 +25,7 @@
             [editor.game-object-common :as game-object-common]
             [editor.graph-util :as gu]
             [editor.handler :as handler]
+            [editor.id :as id]
             [editor.outline :as outline]
             [editor.properties :as properties]
             [editor.protobuf :as protobuf]
@@ -624,12 +625,7 @@
   (output go-inst-ids g/Any :cached (g/fnk [id go-inst-ids] (into {} (map (fn [[k v]] [(format "%s/%s" id k) v]) go-inst-ids)))))
 
 (defn- gen-instance-id [coll-node base]
-  (let [ids (g/node-value coll-node :ids)]
-    (loop [postfix 0]
-      (let [id (if (= postfix 0) base (str base postfix))]
-        (if (empty? (filter #(= id %) ids))
-          id
-          (recur (inc postfix)))))))
+  (id/gen base (g/node-value coll-node :ids)))
 
 (defn- make-ref-go [self source-resource id transform-properties parent overrides select-fn]
   (let [path {:resource source-resource

--- a/editor/src/clj/editor/collection.clj
+++ b/editor/src/clj/editor/collection.clj
@@ -158,14 +158,14 @@
                      :tx-attach-fn (fn [self-id child-id]
                                      (let [coll-id (core/scope-of-type self-id CollectionNode)]
                                        (concat
-                                         (g/update-property child-id :id outline/resolve-id (go-id->node-ids self-id))
+                                         (g/update-property child-id :id id/resolve (go-id->node-ids self-id))
                                          (attach-coll-ref-go coll-id child-id)
                                          (child-go-go self-id child-id))))}
                     {:node-type EmbeddedGOInstanceNode
                      :tx-attach-fn (fn [self-id child-id]
                                      (let [coll-id (core/scope-of-type self-id CollectionNode)]
                                        (concat
-                                         (g/update-property child-id :id outline/resolve-id (go-id->node-ids self-id))
+                                         (g/update-property child-id :id id/resolve (go-id->node-ids self-id))
                                          (attach-coll-embedded-go coll-id child-id)
                                          (child-go-go self-id child-id))))}]}
       (merge node-outline-extras)
@@ -436,19 +436,19 @@
      :child-reqs [{:node-type ReferencedGOInstanceNode
                    :tx-attach-fn (fn [self-id child-id]
                                    (concat
-                                     (g/update-property child-id :id outline/resolve-id (g/node-value self-id :ids))
+                                     (g/update-property child-id :id id/resolve (g/node-value self-id :ids))
                                      (attach-coll-ref-go self-id child-id)
                                      (child-coll-any self-id child-id)))}
                   {:node-type EmbeddedGOInstanceNode
                    :tx-attach-fn (fn [self-id child-id]
                                    (concat
-                                     (g/update-property child-id :id outline/resolve-id (g/node-value self-id :ids))
+                                     (g/update-property child-id :id id/resolve (g/node-value self-id :ids))
                                      (attach-coll-embedded-go self-id child-id)
                                      (child-coll-any self-id child-id)))}
                   {:node-type CollectionInstanceNode
                    :tx-attach-fn (fn [self-id child-id]
                                    (concat
-                                     (g/update-property child-id :id outline/resolve-id (g/node-value self-id :ids))
+                                     (g/update-property child-id :id id/resolve (g/node-value self-id :ids))
                                      (attach-coll-coll self-id child-id)
                                      (child-coll-any self-id child-id)))}]}))
 

--- a/editor/src/clj/editor/game_object.clj
+++ b/editor/src/clj/editor/game_object.clj
@@ -23,6 +23,7 @@
             [editor.game-object-common :as game-object-common]
             [editor.graph-util :as gu]
             [editor.handler :as handler]
+            [editor.id :as id]
             [editor.outline :as outline]
             [editor.properties :as properties]
             [editor.protobuf :as protobuf]
@@ -472,12 +473,7 @@
                                                  {} (map first component-id-pairs)))))
 
 (defn- gen-component-id [go-node base]
-  (let [ids (map first (g/node-value go-node :component-ids))]
-    (loop [postfix 0]
-      (let [id (if (= postfix 0) base (str base postfix))]
-        (if (empty? (filter #(= id %) ids))
-          id
-          (recur (inc postfix)))))))
+  (id/gen base (e/map first (g/node-value go-node :component-ids))))
 
 (defn- add-component [self source-resource id transform-properties properties select-fn]
   (let [path {:resource source-resource

--- a/editor/src/clj/editor/game_object.clj
+++ b/editor/src/clj/editor/game_object.clj
@@ -396,7 +396,7 @@
     (when resolve-id?
       (->> (g/node-value self-id :component-ids)
            keys
-           (g/update-property comp-id :id outline/resolve-id)))
+           (g/update-property comp-id :id id/resolve)))
     (for [[from to] [[:node-outline :child-outlines]
                      [:_node-id :nodes]
                      [:build-targets :dep-build-targets]

--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -32,6 +32,7 @@
             [editor.graph-util :as gu]
             [editor.gui-clipping :as clipping]
             [editor.handler :as handler]
+            [editor.id :as id]
             [editor.material :as material]
             [editor.math :as math]
             [editor.outline :as outline]
@@ -469,7 +470,7 @@
           child-indices (g/node-value target :child-indices)
           next-index (next-child-index child-indices)]
       (concat
-        (g/update-property source :id outline/resolve-id taken-ids)
+        (g/update-property source :id id/resolve taken-ids)
         (g/set-property source :child-index next-index)
         (attach-gui-node node-tree target source type)))))
 
@@ -485,7 +486,7 @@
        ;; update-gui-resource-references call in the property setter does not
        ;; treat this as a rename refactoring.
        (concat
-         (g/update-property source :name outline/resolve-id taken-id-names)
+         (g/update-property source :name id/resolve taken-id-names)
          (attach-fn node-tree target source))))))
 
 ;; Schema validation is disabled because it severely affects project load times.
@@ -2538,7 +2539,7 @@
 ;; SDK api
 (defn query-and-add-resources! [resources-type-label resource-exts taken-ids project select-fn make-node-fn]
   (when-let [resources (browse (str "Select " resources-type-label) project resource-exts)]
-    (let [names (outline/resolve-ids (map resource->id resources) taken-ids)
+    (let [names (id/resolve-all (map resource->id resources) taken-ids)
           pairs (map vector resources names)
           op-seq (gensym)
           op-label (str "Add " resources-type-label)
@@ -2713,7 +2714,7 @@
       (select-fn [node]))))
 
 (defn- add-layer-handler [project {:keys [scene parent]} select-fn]
-  (let [name (outline/resolve-id "layer" (g/node-value parent :name-counts))
+  (let [name (id/gen "layer" (g/node-value parent :name-counts))
         child-indices (g/node-value parent :child-indices)
         next-index (next-child-index child-indices)]
     (g/transact
@@ -3477,8 +3478,8 @@
 (defn add-gui-node-with-props! [scene parent node-type custom-type props select-fn]
   (let [node-tree (g/node-value scene :node-tree)
         id (or (:id props)
-               (outline/resolve-id (subs (name node-type) 5)
-                                   (g/node-value node-tree :id-counts)))
+               (id/resolve (subs (name node-type) 5)
+                           (g/node-value node-tree :id-counts)))
         def-node-type (get-registered-node-type-cls node-type custom-type)
         child-indices (g/node-value parent :child-indices)
         next-index (next-child-index child-indices)
@@ -3950,8 +3951,7 @@
   [scene workspace resource]
   (let [ext (resource/type-ext resource)
         base-name (resource/base-name resource)
-        gen-name #(->> (g/node-value (g/node-value scene %) :name-counts)
-                       (outline/resolve-id base-name))]
+        gen-name #(id/gen base-name (g/node-value (g/node-value scene %) :name-counts))]
     (cond
       (= ext "particlefx")
       (add-particlefx-resource scene (g/node-value scene :particlefx-resources-node) resource (gen-name :particlefx-resources-node))

--- a/editor/src/clj/editor/id.clj
+++ b/editor/src/clj/editor/id.clj
@@ -1,0 +1,25 @@
+;; Copyright 2020-2025 The Defold Foundation
+;; Copyright 2014-2020 King
+;; Copyright 2009-2014 Ragnar Svensson, Christian Murray
+;; Licensed under the Defold License version 1.0 (the "License"); you may not use
+;; this file except in compliance with the License.
+;;
+;; You may obtain a copy of the License, together with FAQs at
+;; https://www.defold.com/license
+;;
+;; Unless required by applicable law or agreed to in writing, software distributed
+;; under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+;; CONDITIONS OF ANY KIND, either express or implied. See the License for the
+;; specific language governing permissions and limitations under the License.
+
+(ns editor.id)
+
+(defn gen
+  "Generate unique id that does not intersect with existing ids"
+  [basename existing-ids]
+  (let [existing-names (set existing-ids)]
+    (loop [postfix 0]
+      (let [name (if (= postfix 0) basename (str basename postfix))]
+        (if (existing-names name)
+          (recur (inc postfix))
+          name)))))

--- a/editor/src/clj/editor/id.clj
+++ b/editor/src/clj/editor/id.clj
@@ -12,14 +12,82 @@
 ;; CONDITIONS OF ANY KIND, either express or implied. See the License for the
 ;; specific language governing permissions and limitations under the License.
 
-(ns editor.id)
+(ns editor.id
+  (:refer-clojure :exclude [resolve])
+  (:require [util.coll :as coll]))
+
+(set! *warn-on-reflection* true)
+(set! *unchecked-math* :warn-on-boxed)
+
+(defn- ids->lookup [ids]
+  (if (or (set? ids) (map? ids))
+    ids
+    (set ids)))
+
+(defn- gen-impl [basename lookup]
+  (loop [postfix 0]
+    (let [name (if (= postfix 0) basename (str basename postfix))]
+      (if (contains? lookup name)
+        (recur (inc postfix))
+        name))))
 
 (defn gen
-  "Generate unique id that does not intersect with existing ids"
-  [basename existing-ids]
-  (let [existing-names (set existing-ids)]
-    (loop [postfix 0]
-      (let [name (if (= postfix 0) basename (str basename postfix))]
-        (if (existing-names name)
-          (recur (inc postfix))
-          name)))))
+  "Generate unique id that does not intersect with taken ids
+
+  Returns an id
+
+  Args:
+    basename     a base name for an id to generate, e.g. \"go\"
+    taken-ids    collection of taken ids, either a map with id keys, a set, or
+                 another type of id collection that will be coerced to set"
+  [basename taken-ids]
+  (gen-impl basename (ids->lookup taken-ids)))
+
+(defn- trim-digits
+  ^String [^String id]
+  (loop [index (.length id)]
+    (if (zero? index)
+      ""
+      (if (Character/isDigit (.charAt id (unchecked-dec index)))
+        (recur (unchecked-dec index))
+        (subs id 0 index)))))
+
+(defn resolve
+  "Resolve a wanted id to an id that does not intersect with taken ids
+
+  Returns an id
+
+  Args:
+    wanted-id    wanted id, a string with an optional number suffix that will be
+                 stripped
+    taken-ids    a collection of taken ids, either a map with id keys, a set, or
+                 another type of id collection that will be coerced to set"
+  [wanted-id taken-ids]
+  (gen (trim-digits wanted-id) (ids->lookup taken-ids)))
+
+(defn resolve-all
+  "Resolve all wanted ids to ids that don't intersect with taken ids
+
+  Returns a vector of ids, one for each input wanted ids
+
+  Args:
+    wanted-ids    a sequential collection of wanted ids, i.e., strings with
+                  optional number suffixes that will be stripped
+    taken-ids     a collection of taken ids, either a map with id keys, a set,
+                  or another type of id collection that will be coerced to set"
+  [wanted-ids taken-ids]
+  (persistent!
+    (key
+      (reduce
+        (fn [e wanted-id]
+          (let [lookup (val e)
+                id (gen-impl (trim-digits wanted-id) lookup)]
+            (coll/pair (conj! (key e) id)
+                       (cond
+                         (set? lookup) (conj lookup id)
+                         (map? lookup) (assoc lookup id id)
+                         :else (throw (AssertionError. (str "lookup is neither set nor map: " (class lookup))))))))
+        (coll/pair
+          (transient [])
+          (ids->lookup taken-ids))
+        wanted-ids))))

--- a/editor/src/clj/editor/outline.clj
+++ b/editor/src/clj/editor/outline.clj
@@ -17,6 +17,7 @@
             [clojure.string :as string]
             [dynamo.graph :as g]
             [editor.core :as core]
+            [editor.id :as id]
             [editor.resource :as resource]
             [editor.util :as util]
             [internal.cache :as c]
@@ -313,18 +314,6 @@
                 (g/delete-node (g/override-root (:node-id (value it)))))))
           (do-paste! "Drop" op-seq paste-data (:attachments fragment) item reqs select-fn))))))
 
-(defn- ids->lookup [ids]
-  (if (or (set? ids) (map? ids))
-    ids
-    (set ids)))
-
-(defn- lookup-insert [lookup id]
-  (cond (set? lookup) (conj lookup id)
-        (map? lookup) (assoc lookup id id)
-        :else (throw (ex-info (str "Unsupported lookup " (type lookup))
-                              {:id id
-                               :lookup lookup}))))
-
 (defn- trim-digits
   ^String [^String id]
   (loop [index (.length id)]
@@ -334,27 +323,8 @@
         (recur (unchecked-dec index))
         (subs id 0 index)))))
 
-(defn resolve-id [id ids]
-  (let [ids (ids->lookup ids)]
-    (if (ids id)
-      (let [prefix (trim-digits id)]
-        (loop [suffix ""
-               index 1]
-          (let [id (str prefix suffix)]
-            (if (contains? ids id)
-              (recur (str index) (inc index))
-              id))))
-      id)))
-
-(defn resolve-ids [wanted-ids taken-ids]
-  (first (reduce (fn [[resolved-ids taken-ids] wanted-id]
-                   (let [id (resolve-id wanted-id taken-ids)]
-                     [(conj resolved-ids id) (lookup-insert taken-ids id)]))
-                 [[] (ids->lookup taken-ids)]
-                 wanted-ids)))
-
 (defn name-resource-pairs [taken-ids resources]
-  (let [names (resolve-ids (map resource/base-name resources) taken-ids)]
+  (let [names (id/resolve-all (map resource/base-name resources) taken-ids)]
     (map vector names resources)))
 
 (defn natural-sort [items]

--- a/editor/src/clj/editor/particlefx.clj
+++ b/editor/src/clj/editor/particlefx.clj
@@ -30,6 +30,7 @@
             [editor.graph-util :as gu]
             [editor.graphics :as graphics]
             [editor.handler :as handler]
+            [editor.id :as id]
             [editor.material :as material]
             [editor.math :as math]
             [editor.outline :as outline]
@@ -1004,7 +1005,7 @@
                      [:emitter-indices :emitter-indices]]]
       (g/connect self-id from emitter-id to))
     (when resolve-id?
-      (g/update-property emitter-id :id outline/resolve-id (g/node-value self-id :ids)))))
+      (g/update-property emitter-id :id id/resolve (g/node-value self-id :ids)))))
 
 (g/defnode ParticleFXNode
   (inherits resource-node/ResourceNode)

--- a/editor/src/clj/editor/tile_map.clj
+++ b/editor/src/clj/editor/tile_map.clj
@@ -27,6 +27,7 @@
             [editor.gl.vertex2 :as vtx]
             [editor.graph-util :as gu]
             [editor.handler :as handler]
+            [editor.id :as id]
             [editor.material :as material]
             [editor.math :as math]
             [editor.outline :as outline]
@@ -1436,15 +1437,6 @@
       (some-> (selection->layer selection)
         core/scope)))
 
-(defn- gen-unique-name
-  [basename existing-names]
-  (let [existing-names (set existing-names)]
-    (loop [postfix 0]
-      (let [name (if (= postfix 0) basename (str basename postfix))]
-        (if (existing-names name)
-          (recur (inc postfix))
-          name)))))
-
 (defn- make-new-layer
   [id]
   (protobuf/make-map-without-defaults Tile$TileLayer
@@ -1453,8 +1445,7 @@
 
 (defn- add-layer-handler
   [tile-map-node]
-  (let [layer-ids (set (g/node-value tile-map-node :layer-ids))
-        layer-id (gen-unique-name "layer" layer-ids)]
+  (let [layer-id (id/gen "layer" (g/node-value tile-map-node :layer-ids))]
     (g/transact
      (concat
       (g/operation-label "Add layer")

--- a/editor/src/clj/editor/tile_source.clj
+++ b/editor/src/clj/editor/tile_source.clj
@@ -698,33 +698,37 @@
   (output anim-ids g/Any :cached (gu/passthrough animation-ids))
 
   (output collision-groups-data g/Any :cached (gu/passthrough collision-groups-data))
-  (output tile-count g/Int (g/fnk [tile-source-attributes]
-                             (* (:tiles-per-row tile-source-attributes) (:tiles-per-column tile-source-attributes))))
-  (output image-dim-error g/Err (g/fnk [image-size collision-size]
-                                  (when (and image-size collision-size)
-                                    (let [{img-w :width img-h :height} image-size
-                                          {coll-w :width coll-h :height} collision-size]
-                                      (when (or (not= img-w coll-w)
-                                                (not= img-h coll-h))
-                                        (g/error-fatal (format "both 'Image' and 'Collision' must have the same dimensions (%dx%d vs %dx%d)"
-                                                               img-w img-h
-                                                               coll-w coll-h)))))))
-  (output tile-width-error g/Err (g/fnk [image-size collision-size tile-width tile-margin]
-                                   (let [dims (or image-size collision-size)]
-                                     (when dims
-                                       (let [{w :width} dims
-                                             total-w (+ tile-width tile-margin)]
-                                         (when (< w total-w)
-                                           (g/error-fatal (format "the total width ('Tile Width' + 'Tile Margin') is greater than the 'Image' width (%d vs %d)"
-                                                                  total-w w))))))))
-  (output tile-height-error g/Err (g/fnk [image-size collision-size tile-height tile-margin]
-                                    (let [dims (or image-size collision-size)]
-                                      (when dims
-                                        (let [{h :height} dims
-                                              total-h (+ tile-height tile-margin)]
-                                          (when (< h total-h)
-                                            (g/error-fatal (format "the total height ('Tile Height' + 'Tile Margin') is greater than the 'Image' height (%d vs %d)"
-                                                                   total-h h)))))))))
+  (output tile-count g/Int
+          (g/fnk [tile-source-attributes]
+            (* (:tiles-per-row tile-source-attributes) (:tiles-per-column tile-source-attributes))))
+  (output image-dim-error g/Err
+          (g/fnk [image-size collision-size]
+            (when (and image-size collision-size)
+              (let [{img-w :width img-h :height} image-size
+                    {coll-w :width coll-h :height} collision-size]
+                (when (or (not= img-w coll-w)
+                          (not= img-h coll-h))
+                  (g/error-fatal (format "both 'Image' and 'Collision' must have the same dimensions (%dx%d vs %dx%d)"
+                                         img-w img-h
+                                         coll-w coll-h)))))))
+  (output tile-width-error g/Err
+          (g/fnk [image-size collision-size tile-width tile-margin]
+            (let [dims (or image-size collision-size)]
+              (when dims
+                (let [{w :width} dims
+                      total-w (+ tile-width tile-margin)]
+                  (when (< w total-w)
+                    (g/error-fatal (format "the total width ('Tile Width' + 'Tile Margin') is greater than the 'Image' width (%d vs %d)"
+                                           total-w w))))))))
+  (output tile-height-error g/Err
+          (g/fnk [image-size collision-size tile-height tile-margin]
+            (let [dims (or image-size collision-size)]
+              (when dims
+                (let [{h :height} dims
+                      total-h (+ tile-height tile-margin)]
+                  (when (< h total-h)
+                    (g/error-fatal (format "the total height ('Tile Height' + 'Tile Margin') is greater than the 'Image' height (%d vs %d)"
+                                           total-h h)))))))))
 
 (defn- get-nodes-by-type [child-node-type]
   (fn get-children-nodes-by-type [node evaluation-context]

--- a/editor/src/clj/editor/tile_source.clj
+++ b/editor/src/clj/editor/tile_source.clj
@@ -15,6 +15,7 @@
 (ns editor.tile-source
   (:require [dynamo.graph :as g]
             [editor.app-view :as app-view]
+            [editor.attachment :as attachment]
             [editor.build-target :as bt]
             [editor.camera :as camera]
             [editor.collision-groups :as collision-groups]
@@ -29,6 +30,7 @@
             [editor.gl.vertex2 :as vtx2]
             [editor.graph-util :as gu]
             [editor.handler :as handler]
+            [editor.id :as id]
             [editor.image :as image]
             [editor.image-util :as image-util]
             [editor.outline :as outline]
@@ -44,6 +46,7 @@
             [editor.types :as types]
             [editor.validation :as validation]
             [editor.workspace :as workspace]
+            [internal.graph.types :as gt]
             [util.coll :as coll :refer [pair]]
             [util.digestable :as digestable])
   (:import [com.dynamo.gamesys.proto TextureSetProto$TextureSet Tile$Animation Tile$ConvexHull Tile$Playback Tile$TileSet]
@@ -266,10 +269,18 @@
             (dynamic error (validation/prop-error-fnk :fatal validation/prop-empty? id)))
   (property start-tile g/Int ; Required protobuf field.
             (dynamic error (g/fnk [_node-id start-tile tile-count]
-                             (validation/prop-error :fatal _node-id :start-tile (partial prop-tile-range? tile-count) start-tile "Start Tile"))))
+                             ;; Editor scripts evaluate _properties output
+                             ;; during node initialization while it's not
+                             ;; connected to the tile source
+                             (when tile-count
+                               (validation/prop-error :fatal _node-id :start-tile (partial prop-tile-range? tile-count) start-tile "Start Tile")))))
   (property end-tile g/Int ; Required protobuf field.
             (dynamic error (g/fnk [_node-id end-tile tile-count]
-                             (validation/prop-error :fatal _node-id :end-tile (partial prop-tile-range? tile-count) end-tile "End Tile"))))
+                             ;; Editor scripts evaluate _properties output
+                             ;; during node initialization while it's not
+                             ;; connected to the tile source
+                             (when tile-count
+                               (validation/prop-error :fatal _node-id :end-tile (partial prop-tile-range? tile-count) end-tile "End Tile")))))
   (property playback types/AnimationPlayback (default (protobuf/default Tile$Animation :playback))
             (dynamic edit-type (g/constantly (properties/->pb-choicebox Tile$Playback))))
   (property fps g/Int (default (protobuf/default Tile$Animation :fps))
@@ -688,32 +699,49 @@
 
   (output collision-groups-data g/Any :cached (gu/passthrough collision-groups-data))
   (output tile-count g/Int (g/fnk [tile-source-attributes]
-                                       (* (:tiles-per-row tile-source-attributes) (:tiles-per-column tile-source-attributes))))
+                             (* (:tiles-per-row tile-source-attributes) (:tiles-per-column tile-source-attributes))))
   (output image-dim-error g/Err (g/fnk [image-size collision-size]
-                                       (when (and image-size collision-size)
-                                         (let [{img-w :width img-h :height} image-size
-                                               {coll-w :width coll-h :height} collision-size]
-                                           (when (or (not= img-w coll-w)
-                                                     (not= img-h coll-h))
-                                             (g/error-fatal (format "both 'Image' and 'Collision' must have the same dimensions (%dx%d vs %dx%d)"
-                                                                    img-w img-h
-                                                                    coll-w coll-h)))))))
+                                  (when (and image-size collision-size)
+                                    (let [{img-w :width img-h :height} image-size
+                                          {coll-w :width coll-h :height} collision-size]
+                                      (when (or (not= img-w coll-w)
+                                                (not= img-h coll-h))
+                                        (g/error-fatal (format "both 'Image' and 'Collision' must have the same dimensions (%dx%d vs %dx%d)"
+                                                               img-w img-h
+                                                               coll-w coll-h)))))))
   (output tile-width-error g/Err (g/fnk [image-size collision-size tile-width tile-margin]
-                                        (let [dims (or image-size collision-size)]
-                                          (when dims
-                                            (let [{w :width} dims
-                                                  total-w (+ tile-width tile-margin)]
-                                              (when (< w total-w)
-                                                (g/error-fatal (format "the total width ('Tile Width' + 'Tile Margin') is greater than the 'Image' width (%d vs %d)"
-                                                                       total-w w))))))))
+                                   (let [dims (or image-size collision-size)]
+                                     (when dims
+                                       (let [{w :width} dims
+                                             total-w (+ tile-width tile-margin)]
+                                         (when (< w total-w)
+                                           (g/error-fatal (format "the total width ('Tile Width' + 'Tile Margin') is greater than the 'Image' width (%d vs %d)"
+                                                                  total-w w))))))))
   (output tile-height-error g/Err (g/fnk [image-size collision-size tile-height tile-margin]
-                                         (let [dims (or image-size collision-size)]
-                                           (when dims
-                                             (let [{h :height} dims
-                                                   total-h (+ tile-height tile-margin)]
-                                               (when (< h total-h)
-                                                 (g/error-fatal (format "the total height ('Tile Height' + 'Tile Margin') is greater than the 'Image' height (%d vs %d)"
-                                                                        total-h h)))))))))
+                                    (let [dims (or image-size collision-size)]
+                                      (when dims
+                                        (let [{h :height} dims
+                                              total-h (+ tile-height tile-margin)]
+                                          (when (< h total-h)
+                                            (g/error-fatal (format "the total height ('Tile Height' + 'Tile Margin') is greater than the 'Image' height (%d vs %d)"
+                                                                   total-h h)))))))))
+
+(defn- get-nodes-by-type [child-node-type]
+  (fn get-children-nodes-by-type [node evaluation-context]
+    (let [basis (:basis evaluation-context)]
+      (coll/transfer (g/explicit-arcs-by-target basis node :nodes) []
+        (map gt/source-id)
+        (filter #(= child-node-type (g/node-type* basis %)))))))
+
+(attachment/register!
+  TileSourceNode :animations
+  :add {:node-type TileAnimationNode :tx-attach-fn attach-animation-node}
+  :get (get-nodes-by-type TileAnimationNode))
+
+(attachment/register!
+  TileSourceNode :collision-groups
+  :add {:node-type CollisionGroupNode :tx-attach-fn attach-collision-group-node}
+  :get (get-nodes-by-type CollisionGroupNode))
 
 
 ;;--------------------------------------------------------------------
@@ -985,22 +1013,13 @@
 (defn add-animation-node! [self select-fn]
   (g/transact (make-animation-node self (project/get-project self) select-fn default-animation)))
 
-(defn- gen-unique-name
-  [basename existing-names]
-  (let [existing-names (set existing-names)]
-    (loop [postfix 0]
-      (let [name (if (= postfix 0) basename (str basename postfix))]
-        (if (existing-names name)
-          (recur (inc postfix))
-          name)))))
-
 (defn add-collision-group-node!
   [self select-fn]
   (let [project (project/get-project self)
         collision-groups-data (g/node-value project :collision-groups-data)
-        collision-group (gen-unique-name "New Collision Group" (collision-groups/collision-groups collision-groups-data))]
+        id (id/gen "collision_group" (collision-groups/collision-groups collision-groups-data))]
     (g/transact
-      (make-collision-group-node self project select-fn collision-group))))
+      (make-collision-group-node self project select-fn id))))
 
 (defn- selection->tile-source [selection]
   (handler/adapt-single selection TileSourceNode))

--- a/editor/test/editor/id_test.clj
+++ b/editor/test/editor/id_test.clj
@@ -1,0 +1,64 @@
+;; Copyright 2020-2025 The Defold Foundation
+;; Copyright 2014-2020 King
+;; Copyright 2009-2014 Ragnar Svensson, Christian Murray
+;; Licensed under the Defold License version 1.0 (the "License"); you may not use
+;; this file except in compliance with the License.
+;;
+;; You may obtain a copy of the License, together with FAQs at
+;; https://www.defold.com/license
+;;
+;; Unless required by applicable law or agreed to in writing, software distributed
+;; under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+;; CONDITIONS OF ANY KIND, either express or implied. See the License for the
+;; specific language governing permissions and limitations under the License.
+
+(ns editor.id-test
+  (:require [clojure.test :refer :all]
+            [editor.id :as id]))
+
+(set! *warn-on-reflection* true)
+(set! *unchecked-math* :warn-on-boxed)
+
+(deftest outline-resolve-id-test
+  (testing "Single ids"
+    (are [expected-id candidate-id taken-ids]
+      (do (is (= expected-id (id/resolve candidate-id taken-ids)))
+          (is (= [expected-id] (id/resolve-all [candidate-id] taken-ids))))
+
+      "sprite" "sprite" #{""}
+      "sprite1" "sprite2" #{"sprite"}
+      "sprite1" "sprite" #{"sprite"}
+      "sprite2" "sprite" #{"sprite" "sprite1"}
+      "sprite2" "sprite1" #{"sprite" "sprite1"}
+      "sprite1" "sprite" #{"sprite" "sprite2"}
+      "sprite" "sprite1" #{"sprite1" "sprite2"}))
+
+  (testing "Multiple ids"
+    (is (= ["sprite" "sprite1" "sprite2"]
+           (id/resolve-all ["sprite" "sprite" "sprite"] #{})))
+
+    (is (= ["sprite3" "sprite4" "sprite5"]
+           (id/resolve-all ["sprite" "sprite" "sprite"] #{"sprite" "sprite1" "sprite2"})))
+
+    (is (= ["sprite3" "sprite4" "sprite5"]
+           (id/resolve-all ["sprite1" "sprite2" "sprite3"] #{"sprite" "sprite1" "sprite2"})))))
+
+
+(deftest id-test
+  (doseq [[basename taken-ids expected]
+          [["go" ["go"] #_=> "go1"]
+           ["go" ["go1"] #_=> "go"]
+           ["go" ["go" "go1" "go2"] #_=> "go3"]
+           ["go" {"go" nil "go1" false} #_=> "go2"]
+           ["go" #{"go" "foo" "go1"} #_=> "go2"]]]
+    (is (= expected (id/gen basename taken-ids))))
+  (doseq [[wanted-id taken-ids expected]
+          [["go" ["go"] #_=> "go1"]
+           ["go2" ["go"] #_=> "go1"]
+           ["a1" #{"a" "a1"} #_=> "a2"]]]
+    (is (= expected (id/resolve wanted-id taken-ids))))
+  (doseq [[wanted-ids taken-ids expected]
+          [[["go" "go" "go"] ["go" "go2"] #_=> ["go1" "go3" "go4"]]
+           [["go" "go1" "go2"] ["go1"] #_=> ["go" "go2" "go3"]]
+           [["a" "b" "b" "c2"] ["a" "a1" "b1"] #_=> ["a2" "b" "b2" "c"]]]]
+    (is (= expected (id/resolve-all wanted-ids taken-ids)))))

--- a/editor/test/integration/editor_extensions_test.clj
+++ b/editor/test/integration/editor_extensions_test.clj
@@ -1129,7 +1129,7 @@ GET /test/resources/test.json as json => 200
              dorun)))))
 
 (def ^:private expected-attachment-test-output
-  "Initial state:
+  "Atlas initial state:
   images: 0
   animations: 0
   can add images: true
@@ -1171,6 +1171,43 @@ Expected errors:
   Added nested value is not a table => \"/foo.png\" is not a table
   Added node has invalid property value => \"invalid-pivot\" is not a tuple
   Added resource has wrong type => resource extension should be jpg or png
+Tilesource initial state:
+  animations: 0
+  collision groups: 0
+  tile collision groups: 0
+Transaction: add animations and collision groups
+After transaction (add animations and collision groups):
+  animations: 2
+    animation: idle
+    animation: walk
+  collision groups: 4
+    collision group: obstacle
+    collision group: character
+    collision group: collision_group
+    collision group: collision_group1
+  tile collision groups: 2
+    tile collision group: 1 obstacle
+    tile collision group: 3 character
+Transaction: set tile_collision_groups to its current value
+After transaction (tile_collision_groups roundtrip):
+  animations: 2
+    animation: idle
+    animation: walk
+  collision groups: 4
+    collision group: obstacle
+    collision group: character
+    collision group: collision_group
+    collision group: collision_group1
+  tile collision groups: 2
+    tile collision group: 1 obstacle
+    tile collision group: 3 character
+Expected errors
+  Using non-existent collision group => Collision group \"does-not-exist\" is not defined in the tilesource
+Transaction: clear tilesource
+After transaction (clear):
+  animations: 0
+  collision groups: 0
+  tile collision groups: 0
 ")
 
 (deftest attachment-properties-test

--- a/editor/test/integration/outline_test.clj
+++ b/editor/test/integration/outline_test.clj
@@ -892,30 +892,6 @@
       (is (= 2 (child-count root [0 0 1])))
       (is (= 4 (count (keys (g/node-value props-collection :go-inst-ids))))))))
 
-(deftest resolve-id-test
-  (testing "Single ids"
-    (are [expected-id candidate-id taken-ids]
-      (do (is (= expected-id (outline/resolve-id candidate-id taken-ids)))
-          (is (= [expected-id] (outline/resolve-ids [candidate-id] taken-ids))))
-
-      "sprite" "sprite" #{""}
-      "sprite2" "sprite2" #{"sprite"}
-      "sprite1" "sprite" #{"sprite"}
-      "sprite2" "sprite" #{"sprite" "sprite1"}
-      "sprite2" "sprite1" #{"sprite" "sprite1"}
-      "sprite1" "sprite" #{"sprite" "sprite2"}
-      "sprite" "sprite1" #{"sprite1" "sprite2"}))
-
-  (testing "Multiple ids"
-    (is (= ["sprite" "sprite1" "sprite2"]
-           (outline/resolve-ids ["sprite" "sprite" "sprite"] #{})))
-
-    (is (= ["sprite3" "sprite4" "sprite5"]
-           (outline/resolve-ids ["sprite" "sprite" "sprite"] #{"sprite" "sprite1" "sprite2"})))
-
-    (is (= ["sprite3" "sprite4" "sprite5"]
-           (outline/resolve-ids ["sprite1" "sprite2" "sprite3"] #{"sprite" "sprite1" "sprite2"})))))
-
 (deftest gen-node-outline-keys-test
   (is (= [] (outline/gen-node-outline-keys nil)))
   (is (= ["a0"] (outline/gen-node-outline-keys ["a"])))

--- a/editor/test/resources/editor_extensions/transact_attachment_project/test.editor_script
+++ b/editor/test/resources/editor_extensions/transact_attachment_project/test.editor_script
@@ -30,6 +30,30 @@ local function print_atlas_contents(atlas)
     end
 end
 
+local function print_tilesource_contents(tilesource)
+    local animations = editor.get(tilesource, "animations")
+    print(("  animations: %s"):format(#animations))
+    for i = 1, #animations do
+        local animation_node = animations[i]
+        print(("    animation: %s"):format(editor.get(animation_node, "id")))
+    end
+    local collision_groups = editor.get(tilesource, "collision_groups")
+    print(("  collision groups: %s"):format(#collision_groups))
+    for i = 1, #collision_groups do
+        local node = collision_groups[i]
+        print(("    collision group: %s"):format(editor.get(node, "id")))
+    end
+    local tile_collision_groups = editor.get(tilesource, "tile_collision_groups")
+    local tile_collision_groups_count = 0
+    for _, _ in pairs(tile_collision_groups) do
+        tile_collision_groups_count = tile_collision_groups_count + 1
+    end
+    print(("  tile collision groups: %s"):format(tile_collision_groups_count))
+    for k, v in pairs(tile_collision_groups) do
+        print(("    tile collision group: %s %s"):format(k, v))
+    end
+end
+
 function M.get_commands()
     return {
         editor.command({
@@ -37,7 +61,7 @@ function M.get_commands()
             label = "Test",
             locations = {"Edit"},
             run = function()
-                print("Initial state:")
+                print("Atlas initial state:")
                 print_atlas_contents("/test.atlas")
                 print(("  can add images: %s"):format(tostring(editor.can_add("/test.atlas", "images"))))
                 print(("  can add animations: %s"):format(tostring(editor.can_add("/test.atlas", "animations"))))
@@ -87,6 +111,42 @@ function M.get_commands()
                 expect_error("Added nested value is not a table", editor.tx.add, "/test.atlas", "animations", { images = { "/foo.png" } })
                 expect_error("Added node has invalid property value", editor.transact, { editor.tx.add("/test.atlas", "images", { pivot = "invalid-pivot" }) })
                 expect_error("Added resource has wrong type", editor.transact, { editor.tx.add("/test.atlas", "images", { image = "/game.project" }) })
+
+                print("Tilesource initial state:")
+                local tilesource = "/test.tilesource"
+                print_tilesource_contents(tilesource)
+                
+                print("Transaction: add animations and collision groups")
+                editor.transact({
+                    editor.tx.add(tilesource, "animations", {id = "idle"}),
+                    editor.tx.add(tilesource, "animations", {id = "walk", start_tile = 2, end_tile = 6}),
+                    editor.tx.add(tilesource, "collision_groups", {id = "obstacle"}),
+                    editor.tx.add(tilesource, "collision_groups", {id = "character"}),
+                    editor.tx.add(tilesource, "collision_groups", {}),
+                    editor.tx.add(tilesource, "collision_groups", {}),
+                    editor.tx.set(tilesource, "tile_collision_groups", {[1] = "obstacle", [3] = "character"})
+                })
+
+                print("After transaction (add animations and collision groups):")
+                print_tilesource_contents(tilesource)
+
+                print("Transaction: set tile_collision_groups to its current value")
+                editor.transact({editor.tx.set(tilesource, "tile_collision_groups", editor.get(tilesource, "tile_collision_groups"))})
+
+                print("After transaction (tile_collision_groups roundtrip):")
+                print_tilesource_contents(tilesource)
+
+                print("Expected errors")
+                expect_error("Using non-existent collision group", editor.transact, {editor.tx.set(tilesource, "tile_collision_groups", {[2] = "does-not-exist"})})
+
+                print("Transaction: clear tilesource")
+                editor.transact({
+                    editor.tx.clear(tilesource, "animations"),
+                    editor.tx.clear(tilesource, "collision_groups"),
+                })
+
+                print("After transaction (clear):")
+                print_tilesource_contents(tilesource)
             end
         })
     }

--- a/editor/test/resources/editor_extensions/transact_attachment_project/test.tilesource
+++ b/editor/test/resources/editor_extensions/transact_attachment_project/test.tilesource
@@ -1,0 +1,25 @@
+image: "/builtins/graphics/particle_blob.png"
+tile_width: 16
+tile_height: 16
+collision: "/builtins/graphics/particle_blob.png"
+convex_hulls {
+  index: 0
+  count: 7
+  collision_group: ""
+}
+convex_hulls {
+  index: 7
+  count: 7
+  collision_group: ""
+}
+convex_hulls {
+  index: 14
+  count: 7
+  collision_group: ""
+}
+convex_hulls {
+  index: 21
+  count: 7
+  collision_group: ""
+}
+extrude_borders: 2


### PR DESCRIPTION
Now editor scripts can access and edit animations and collision groups of tilesources using these 3 new tilesource properties:
- `animations` - a list of animation nodes of the tilesource
- `collision_groups` - a list of collision group nodes of the tilesource
- `tile_collision_groups` - a table of collision group assignments for tiles in the tilesource

For example, here is how you can setup a tilesource:
```lua
local tilesource = "/game/world.tilesource"
editor.transact({
    editor.tx.add(tilesource, "animations", {id = "idle", start_tile = 1, end_tile = 1}),
    editor.tx.add(tilesource, "animations", {id = "walk", start_tile = 2, end_tile = 6, fps = 10}),
    editor.tx.add(tilesource, "collision_groups", {id = "player"}),
    editor.tx.add(tilesource, "collision_groups", {id = "obstacle"}),
    editor.tx.set(tilesource, "tile_collision_groups", {
        [1] = "player",
        [7] = "obstacle",
        [8] = "obstacle"
    })
})
```

Related to #8504