### PR TITLE
Fixing up html5 audio outpput to correctly pass data into browser audio buffers

### DIFF
--- a/engine/sound/src/js/library_sound.js
+++ b/engine/sound/src/js/library_sound.js
@@ -76,8 +76,9 @@ var LibrarySoundDevice =
 
                     // Copy data from WASM memory
                     for(var c=0;c<2;c++) {
-                        var input = new Float32Array(HEAPF32, samples, frame_count);
-                        buf.copyToChannel(input, c);
+                        var input = new Float32Array(HEAPF32.buffer, samples, frame_count);
+                        // "double copy" - in threaded mode we will get a SharedArrayBuffer as the basis of HEAPF32. copyToChannel cannot handle shared buffers, hence we make a copy (which is no longer shared)
+                        buf.copyToChannel(input.slice(), c);
                         samples += frame_count * 4; // 4 bytes = sizeof(float)
                     }
                     var source = shared.audioCtx.createBufferSource();


### PR DESCRIPTION
Update the code to ensure that copyToChannel on the AudioBuffer is not called with an array based on a SharedArrayBuiffer to avoid triggering an exception. A secondary copy into a non-shared array is used to enable this.
(original code created a new array from a given array, based on a SharedArrayBuffer, which does not trigger an exception, but also does not in correctly delivering the data)