### PR TITLE
Add warnings to open-url and open-file

### DIFF
--- a/editor/src/clj/editor/ui.clj
+++ b/editor/src/clj/editor/ui.clj
@@ -2234,7 +2234,10 @@
     (do
       (.start (Thread. #(.browse desktop (as-url url))))
       true)
-    false))
+    (do
+      (log/warn :message (format "Cannot open browser"))
+      (if (os/is-linux?) (log/warn :message (format "Installing gvfs may fix this error")))
+    false)))
 
 (defn open-file
   ([^File file]
@@ -2250,7 +2253,9 @@
                                 (on-error-fn (.getMessage e))
                                 (throw e)))))))
        true)
-     false)))
+     (do
+       (log/warn :message (format "Cannot open file handler"))
+     false))))
 
 (defn- make-path-data
   ^String [^double col ^double row outlines]

--- a/editor/src/clj/editor/ui.clj
+++ b/editor/src/clj/editor/ui.clj
@@ -2235,9 +2235,8 @@
       (.start (Thread. #(.browse desktop (as-url url))))
       true)
     (do
-      (log/warn :message (format "Cannot open browser"))
-      (if (os/is-linux?) (log/warn :message (format "Installing gvfs may fix this error")))
-    false)))
+      (log/warn :message (str "Cannot open browser." (when (os/is-linux?) " Installing gvfs may fix this.")))
+      false)))
 
 (defn open-file
   ([^File file]
@@ -2254,8 +2253,8 @@
                                 (throw e)))))))
        true)
      (do
-       (log/warn :message (format "Cannot open file handler"))
-     false))))
+       (log/warn :message "Cannot open file handler")
+       false))))
 
 (defn- make-path-data
   ^String [^double col ^double row outlines]


### PR DESCRIPTION
On Linux, users reported not being able to open the web profiler. The problem seems to stem from missing `gvfs` required to open their browser. Users experiencing this will now see a warning in their log telling them that installing `gvfs` might fix the issue. The editor will now also log a warning if opening files isn't supported.

Fixes #7819

### Technical Changes
* This change is against `editor-dev` due to its low impact. (but actually this time)
* I doubt anyone has encountered the false clause of open-file, but we might as well log it if it happens.
* Because the GVFS issue is specific to Linux, but any future failure of Desktop$Action/BROWSE may not be, we just print the warning, and then only on Linux print another line about GVFS. I will be so embarrassed if a different issue also causes this error.
* It's in the linked issue, but here is my comment about why this fixes the issue: 
* Opening the web profiler uses `java.awt.Desktop.Action.BROWSE` which calls `gtk_show_uri()` [The GTK docs](https://docs.gtk.org/gtk3/func.show_uri_on_window.html) say:
>The uri must be of a form understood by GIO (i.e. you need to install gvfs to get support for uri schemes such as http:// or ftp://, as only local files are handled by GIO itself).

* I can reproduce this error successfully by uninstalling and re-installing `gvfs`.
* And here's what it looks like in a terminal (in case you can't uninstall GVFS or have no access to a Linux host)
![defold-gvfs](https://github.com/user-attachments/assets/bdd4da76-9f53-47d0-b27b-20eebdb3deac)

## PR checklist

* [x] Code
	* [x] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [x] Add comments where needed
* [x] Documentation
	* [x] Make sure that API documentation is updated in code comments
	* [x] Make sure that manuals are updated (in github.com/defold/doc)
* [x] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [x] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [x] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------
