### PR TITLE
Fixed an issue with editor logs

### DIFF
--- a/editor/src/clj/editor/targets.clj
+++ b/editor/src/clj/editor/targets.clj
@@ -117,14 +117,14 @@
 (defn update-launched-target! [target target-info on-service-url-found]
   (let [old @launched-targets]
     (reset! launched-targets
-            (map (fn [launched-target]
-                   (if (= (:id launched-target) (:id target))
-                     (let [result-target (merge launched-target target-info)]
-                       ;(when (and (:url target-info) (not (:url launched-target)))
-                       ;  (on-service-url-found result-target))
-                       result-target)
-                     launched-target))
-                 old))
+            (mapv (fn [launched-target]
+                    (if (= (:id launched-target) (:id target))
+                      (let [result-target (merge launched-target target-info)]
+                        (when (and (:url target-info) (not (:url launched-target)))
+                          (on-service-url-found result-target))
+                        result-target)
+                      launched-target))
+                  old))
     (when (not= old @launched-targets)
       (clear-selected-target-hint!)
       (invalidate-target-menu!))))

--- a/editor/src/clj/editor/targets.clj
+++ b/editor/src/clj/editor/targets.clj
@@ -120,8 +120,8 @@
             (map (fn [launched-target]
                    (if (= (:id launched-target) (:id target))
                      (let [result-target (merge launched-target target-info)]
-                       (when (and (:url target-info) (not (:url launched-target)))
-                         (on-service-url-found result-target))
+                       ;(when (and (:url target-info) (not (:url launched-target)))
+                       ;  (on-service-url-found result-target))
                        result-target)
                      launched-target))
                  old))


### PR DESCRIPTION
Fixes the issue where logs in the Editor's console don't work when Simulated Resolution is used (Windows only).

Fix https://github.com/defold/defold/issues/10226