### PR TITLE
Adding check to avoid zero delta values in sound mixer

### DIFF
--- a/engine/sound/src/sound.cpp
+++ b/engine/sound/src/sound.cpp
@@ -1310,6 +1310,10 @@ namespace dmSound
 
         // Compute how many input samples we will need to produce the requested output samples
         uint64_t delta = (uint64_t)(((float)(info.m_Rate << RESAMPLE_FRACTION_BITS) / sound->m_MixRate) * instance->m_Speed);
+        if (delta == 0) {
+            // very low speed settings can get the delta to be zero due to precision limits - we skip the mixing as resulting rates are also (alsmost) inaudibly low as a result
+            return;
+        }
         uint32_t mixed_instance_frame_count = (uint32_t)((instance->m_FrameFraction + mix_context->m_FrameCount * delta + ((1UL << RESAMPLE_FRACTION_BITS) - 1)) >> RESAMPLE_FRACTION_BITS) + SOUND_MAX_FUTURE;
 
         // Compute initial amount of samples in temp buffer once we restore per instance state prior to actual mixing


### PR DESCRIPTION
This change fixes a recently introduced issue where the engine would crash if a sound was played with a very low speed.

### Technical changes
Low speed settings or extreme ratios of mix and sample rate can push "delta" for mixing code down to zero (as it has only 21 bits fractional precision). Adding code to reject mixing in this case as the resulting playback would be very low frequency and quality anyway.

Fixes #10700 