### PR TITLE
Fixing EOS behavior of tremolo decoder when skipping data

### DIFF
--- a/engine/sound/src/decoders/decoder_tremolo.cpp
+++ b/engine/sound/src/decoders/decoder_tremolo.cpp
@@ -202,7 +202,7 @@ namespace dmSoundCodec
             bytes -= decoded;
         }
 
-        return (ret == RESULT_END_OF_STREAM && bytes != 0) ? RESULT_OK : ret;
+        return ret;
     }
 
     static void TremoloCloseStream(HDecodeStream stream)


### PR DESCRIPTION
This fixes a recently introduced issue with sound instances "hanging around" forever if they are played back with group volume down to zero.

### Technical changes
This will enable the "skip" mode in the decoder. The tremolo decoder code had a bug that did report EOS status incorrectly to the caller in this mode. Hence playback never stopped.

Fixes #10703