### PR TITLE
Fixed issue where build to remote target can't load a file more than once

### DIFF
--- a/engine/resource/src/providers/provider_http.cpp
+++ b/engine/resource/src/providers/provider_http.cpp
@@ -117,6 +117,7 @@ static void HttpContent(dmHttpClient::HResponse, void* user_data, int status_cod
 
     archive->m_HttpBuffer.PushArray((const char*) content_data, content_data_size);
     archive->m_HttpTotalBytesStreamed += content_data_size;
+    archive->m_HttpContentLength = content_length;
 }
 
 static dmHttpClient::Result HttpWriteHeaders(dmHttpClient::HResponse response, void* user_data)


### PR DESCRIPTION
Fixed issue where cached resources loaded remotely from the editor return the wrong file size, resulting in a `string length overflow` error

Fix https://github.com/defold/defold/issues/10669