### PR TITLE
Added support for hash userdata type keys in lua table (de)serialization.

### DIFF
--- a/engine/script/src/script_table.cpp
+++ b/engine/script/src/script_table.cpp
@@ -352,7 +352,7 @@ namespace dmScript
 
             if (key_type != LUA_TSTRING && key_type != LUA_TNUMBER && key_type != LUA_THASH)
             {
-                luaL_error(L, "keys in table must be of type number or string (found %s)", lua_typename(L, key_type));
+                luaL_error(L, "keys in table must be of type number, string or hash (found %s)", lua_typename(L, key_type));
             }
 
             // key + value type

--- a/engine/script/src/script_table.cpp
+++ b/engine/script/src/script_table.cpp
@@ -501,7 +501,7 @@ namespace dmScript
             count++;
 
             int key_type = lua_type(L, -2);
-            dmhash_t *key_hash = ToHash(L, -2);
+            dmhash_t* key_hash = ToHash(L, -2);
             int value_type = lua_type(L, -1);
 
             if (key_type != LUA_TSTRING && key_type != LUA_TNUMBER && !key_hash)

--- a/engine/script/src/script_table.cpp
+++ b/engine/script/src/script_table.cpp
@@ -536,7 +536,7 @@ namespace dmScript
 
                 if (buffer_end - buffer < int32_t(hash_size))
                 {
-                    luaL_error(L, "buffer (%d bytes) too small for table, exceeded at key (hash) for element #%d", buffer_size, lua_typename(L, key_type), count);
+                    luaL_error(L, "buffer (%d bytes) too small for table, exceeded at key (hash) for element #%d", buffer_size, count);
                 }
 
                 memcpy(buffer, (const void*)key_hash, hash_size);

--- a/engine/script/src/script_table.cpp
+++ b/engine/script/src/script_table.cpp
@@ -536,7 +536,7 @@ namespace dmScript
 
                 if (buffer_end - buffer < int32_t(hash_size))
                 {
-                    luaL_error(L, "buffer (%d bytes) too small for table, exceeded at key (%s) for element #%d", buffer_size, lua_typename(L, key_type), count);
+                    luaL_error(L, "buffer (%d bytes) too small for table, exceeded at key (hash) for element #%d", buffer_size, lua_typename(L, key_type), count);
                 }
 
                 memcpy(buffer, (const void*)key_hash, hash_size);

--- a/engine/script/src/script_table.cpp
+++ b/engine/script/src/script_table.cpp
@@ -344,7 +344,13 @@ namespace dmScript
         {
             int key_type = lua_type(L, -2);
             int value_type = lua_type(L, -1);
-            if (key_type != LUA_TSTRING && key_type != LUA_TNUMBER)
+
+            if (IsHash(L, -2))
+            {
+                key_type = LUA_THASH;
+            }
+
+            if (key_type != LUA_TSTRING && key_type != LUA_TNUMBER && key_type != LUA_THASH)
             {
                 luaL_error(L, "keys in table must be of type number or string (found %s)", lua_typename(L, key_type));
             }

--- a/engine/script/src/test/test_script_table.cpp
+++ b/engine/script/src/test/test_script_table.cpp
@@ -115,7 +115,7 @@ TEST_F(LuaTableTest, AttemptReadUnsupportedVersion)
     int result = lua_cpcall(L, ReadUnsupportedVersion, 0x0);
     ASSERT_NE(0, result);
     char str[256];
-    dmSnPrintf(str, sizeof(str), "Unsupported serialized table data: version = 0x%x (current = 0x%x)", 818192, 4);
+    dmSnPrintf(str, sizeof(str), "Unsupported serialized table data: version = 0x%x (current = 0x%x)", 818192, 5);
     ASSERT_STREQ(str, lua_tostring(L, -1));
     // pop error message
     lua_pop(L, 1);
@@ -845,12 +845,20 @@ TEST_F(LuaTableTest, MixedKeys)
     lua_pushnumber(L, 3);
     lua_settable(L, -3);
 
-    lua_pushnumber(L, 2);
+    dmScript::PushHash(L, dmHashString64("key2"));
     lua_pushnumber(L, 4);
     lua_settable(L, -3);
 
-    lua_pushstring(L, "key2");
+    lua_pushnumber(L, 2);
     lua_pushnumber(L, 5);
+    lua_settable(L, -3);
+
+    lua_pushstring(L, "key3");
+    lua_pushnumber(L, 6);
+    lua_settable(L, -3);
+
+    dmScript::PushHash(L, dmHashString64("key4"));
+    lua_pushnumber(L, 7);
     lua_settable(L, -3);
 
     uint32_t buffer_used = dmScript::CheckTable(L, g_Buf, sizeof(g_Buf), -1);
@@ -871,16 +879,28 @@ TEST_F(LuaTableTest, MixedKeys)
     ASSERT_EQ(3, lua_tonumber(L, -1));
     lua_pop(L, 1);
 
-    lua_pushnumber(L, 2);
+    dmScript::PushHash(L, dmHashString64("key2"));
     lua_gettable(L, -2);
     ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
     ASSERT_EQ(4, lua_tonumber(L, -1));
     lua_pop(L, 1);
 
-    lua_pushstring(L, "key2");
+    lua_pushnumber(L, 2);
     lua_gettable(L, -2);
     ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
     ASSERT_EQ(5, lua_tonumber(L, -1));
+    lua_pop(L, 1);
+
+    lua_pushstring(L, "key3");
+    lua_gettable(L, -2);
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(6, lua_tonumber(L, -1));
+    lua_pop(L, 1);
+
+    dmScript::PushHash(L, dmHashString64("key4"));
+    lua_gettable(L, -2);
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(7, lua_tonumber(L, -1));
     lua_pop(L, 1);
 
     lua_pop(L, 1);

--- a/engine/script/src/test/test_script_table.cpp
+++ b/engine/script/src/test/test_script_table.cpp
@@ -421,6 +421,38 @@ TEST_F(LuaTableTest, NestedTableSizeCheck)
     ASSERT_EQ(calculated_table_size, actual_table_size);
 }
 
+TEST_F(LuaTableTest, KeyTypesTableSizeCheck)
+{
+    // create table
+    lua_newtable(L);
+
+    // string key
+    lua_pushnumber(L, 1234);
+    lua_setfield(L, -2, "foo");
+
+    // hash key
+    dmScript::PushHash(L, dmHashString64("key1"));
+    lua_pushnumber(L, 1234);
+    lua_settable(L, -3);
+
+    // number key
+    lua_pushnumber(L, 128);
+    lua_pushnumber(L, 1234);
+    lua_settable(L, -3);
+
+    // negative, bigger number key
+    lua_pushnumber(L, -123456789);
+    lua_pushnumber(L, 1234);
+    lua_settable(L, -3);
+
+    uint32_t calculated_table_size = dmScript::CheckTableSize(L, -1);
+    uint32_t actual_table_size = dmScript::CheckTable(L, g_Buf, sizeof(g_Buf), -1);
+
+    lua_pop(L, 1);
+
+    ASSERT_EQ(calculated_table_size, actual_table_size);
+}
+
 static int g_CustomPanicFunctionCalled = 0;
 static int CustomPanicFn(lua_State* L)
 {


### PR DESCRIPTION
It is now possible to use `sys.save()` and `sys.load()` to save and load tables with hashes as keys. This allows for example to (de)serialize tables that are produced and used by collectionfactory. This change also means that `sys.serialize()` and `sys.deserialize()` can serialize and deserialize tables with hashes as keys.

⚠️ Using a hash as a key in a serialized table makes the binary format incompatible with older versions of the engine.

Fixes #3208 

### Technical changes
* Added a special LUA_THASH type much like LUA_TNEGATIVENUMBER, instead of using LUA_TUSERDATA  and adding a userdata sub type, as is done for serializing hashes in values. This will make hash keys more compact. The alternative would be to add an extra SubType byte before each hash key, which would also often misalign the data.
* Incremented the version to 5 because version 4 can't read hash type keys.
* Changed the if structure for some version checks to not explicitly specify each version but use version ranges instead. This should perform slightly better at the cost of making it slightly harder to read. Additionally it's already done this way in other parts in script_table.cpp.
* Added a new test for size checking different key types.
* Updated MixedKeys test, added hash keys.