### PR TITLE
Fixing occasional deadlock in profiler

### DIFF
--- a/engine/profiler/src/profiler.cpp
+++ b/engine/profiler/src/profiler.cpp
@@ -118,14 +118,16 @@ void RenderProfiler(dmProfile::HProfile profile, dmGraphics::HContext graphics_c
 {
     if(gRenderProfile && g_ProfilerCurrentFrame)
     {
-        DM_MUTEX_SCOPED_LOCK(g_ProfilerMutex);
-
         DM_PROFILE("RenderProfiler");
+
+        {
+        DM_MUTEX_SCOPED_LOCK(g_ProfilerMutex);
 
         // Make sure the main thread is at the front so it's picked by default
         std::sort(g_ProfilerCurrentFrame->m_Threads.Begin(), g_ProfilerCurrentFrame->m_Threads.End(), ThreadSortPred(&g_ProfilerThreadSortOrder));
 
         dmProfileRender::UpdateRenderProfile(gRenderProfile, g_ProfilerCurrentFrame);
+        }
 
         // Enable alpha blending
         dmGraphics::PipelineState ps_before = dmGraphics::GetPipelineState(graphics_context);


### PR DESCRIPTION
Fixes occasional deadlock when using profiler with scopes on threads other than the main thread.

### Technical changes

- limited profiler's own mutex lock to essential parts of the code
- hence moved all profile scopes within the original mutexed area outside of it
- that resolves the AB BA deadlock that could happen if any profile scopes were active outside of the main thread
