### PR TITLE
Fix for getting win32 user directories containing unicode characters

### DIFF
--- a/engine/dlib/src/dlib/path.cpp
+++ b/engine/dlib/src/dlib/path.cpp
@@ -31,6 +31,15 @@ namespace dmPath
         return path;
     }
 
+    static const wchar_t* SkipSlashesW(const wchar_t* path)
+    {
+        while (*path && (*path == L'/' || *path == L'\\'))
+        {
+            ++path;
+        }
+        return path;
+    }
+
     void Normalize(const char* path, char* out, uint32_t out_size)
     {
         assert(out_size > 0);
@@ -60,6 +69,37 @@ namespace dmPath
         }
 
         out[dmMath::Min(i, out_size-1)] = '\0';
+    }
+
+    void NormalizeW(const wchar_t* path, wchar_t* out, uint32_t out_size)
+    {
+        assert(out_size > 0);
+
+        uint32_t i = 0;
+        while (*path && i < out_size)
+        {
+            int c = *path;
+            if (c == L'/' || c == L'\\')
+            {
+                out[i] = L'/';
+                path = SkipSlashesW(path);
+            }
+            else
+            {
+                out[i] = c;
+                ++path;
+            }
+
+            ++i;
+        }
+
+        if (i > 1 && out[i-1] == L'/')
+        {
+            // Remove trailing /
+            out[i-1] = L'\0';
+        }
+
+        out[dmMath::Min(i, out_size-1)] = L'\0';
     }
 
     void Dirname(const char* path, char* out, uint32_t out_size)

--- a/engine/dlib/src/dlib/path.h
+++ b/engine/dlib/src/dlib/path.h
@@ -16,6 +16,7 @@
 #define DM_PATH_H
 
 #include <stdint.h>
+#include <stddef.h> // wchar_t
 
 /** Maximum path length convention. This size should large enough
  * such that path truncation never occurs in practice. No functions
@@ -41,6 +42,15 @@ namespace dmPath
      * @param out_size out buffer size
      */
     void Normalize(const char* path, char* out, uint32_t out_size);
+
+    /**
+     * Path normalization for wide strings. Redundant and trailing slashes are
+     * removed and backslashes are translated into backward slashes
+     * @param path path to normalize
+     * @param out out buffer
+     * @param out_size out buffer size
+     */
+    void NormalizeW(const wchar_t* wpath, wchar_t* out, uint32_t out_size);
 
     /**
      * Get directory part of path. The output path is potentially

--- a/engine/dlib/src/dlib/sys_posix.cpp
+++ b/engine/dlib/src/dlib/sys_posix.cpp
@@ -167,6 +167,86 @@ namespace dmSys
 
 #elif defined(_WIN32)
 
+    static const wchar_t* SkipSlashesW(const wchar_t* path)
+    {
+        while (*path && (*path == L'/' || *path == L'\\'))
+        {
+            ++path;
+        }
+        return path;
+    }
+
+    // Is a path contains unicode characters, we need to make it 8.3 in order to properly use char* functions
+    static bool MakePath_8_3(const wchar_t* wpath, wchar_t* out)
+    {
+        wchar_t tmp[MAX_PATH] = { 0 };
+        dmPath::NormalizeW(wpath, tmp, MAX_PATH);
+        out[0] = L'\0';
+
+        int has_drive = 0;
+        wchar_t* cursor = tmp;
+        while (*cursor != L'\0')
+        {
+            if (!has_drive)
+            {
+                cursor = wcschr(cursor, L':');
+                if (!cursor)
+                {
+                    dmLogError("Failed to find drive in path: '%ls'\n", wpath);
+                    return false;
+                }
+                has_drive = 1;
+                cursor++; // Skip past the ':'"
+
+                // Copy the drive "C:"
+                wchar_t c = *cursor;
+                *cursor = L'\0';
+                wcscpy(out, tmp);
+
+                *cursor = c;
+                cursor = (wchar_t*)SkipSlashesW(cursor+1);
+                continue;
+            }
+
+            wchar_t* sep = wcschr(cursor, L'\\');
+            if (!sep)
+                sep = wcschr(cursor, L'/');
+
+            // Temporarily null terminate the string
+            if (sep)
+                *sep = L'\0';
+
+            // Create a version of the previously parsed path, and the latest (untransformed) directory name
+            wchar_t testpath[MAX_PATH] = { 0 };
+            wcscpy(testpath, out); // The previously path with 8.3 names
+            wcscat(testpath, L"/");
+            wcscat(testpath, cursor); // The last folder to test
+
+            WIN32_FIND_DATAW fd{0};
+            HANDLE h = FindFirstFileW( tmp, &fd );
+            if (h == INVALID_HANDLE_VALUE)
+            {
+                dmLogError("FindFirstFileW failed\n");
+                return false;
+            }
+
+            wcscat(out, L"/");
+            if (fd.cAlternateFileName[0] == L'\0')
+                wcscat(out, fd.cFileName);
+            else
+                wcscat(out, fd.cAlternateFileName);
+
+            if (sep)
+                *sep = L'/';
+            else
+                break;
+
+            cursor = sep + 1;
+        }
+
+        return true;
+    }
+
     Result GetApplicationSavePath(const char* application_name, char* path, uint32_t path_len)
     {
         return GetApplicationSupportPath(application_name, path, path_len);
@@ -174,20 +254,36 @@ namespace dmSys
 
     Result GetApplicationSupportPath(const char* application_name, char* path, uint32_t path_len)
     {
-        char tmp_path[MAX_PATH];
+        wchar_t tmp_wpath[MAX_PATH];
 
-        if(SUCCEEDED(SHGetFolderPathA(NULL,
+        if(SUCCEEDED(SHGetFolderPathW(NULL,
                                      CSIDL_APPDATA | CSIDL_FLAG_CREATE,
                                      NULL,
                                      0,
-                                     tmp_path)))
+                                     tmp_wpath)))
         {
+            // Make any unicode directories into 8.3 format if necessary
+            wchar_t short_path[MAX_PATH];
+            MakePath_8_3(tmp_wpath, short_path);
+
+            int wlength = (int)wcslen(short_path);
+            int size_needed = WideCharToMultiByte(CP_UTF8, 0, short_path, wlength, NULL, 0, NULL, NULL);
+            if (size_needed == 0)
+            {
+                dmLogError("Failed converting wchar_t -> char\n");
+                return RESULT_UNKNOWN;
+            }
+
+            char* tmp_path = (char*)_alloca(size_needed);
+            WideCharToMultiByte(CP_UTF8, 0, short_path, wlength, tmp_path, size_needed, NULL, NULL);
+
             if (dmStrlCpy(path, tmp_path, path_len) >= path_len)
                 return RESULT_INVAL;
-            if (dmStrlCat(path, "\\", path_len) >= path_len)
+            if (dmStrlCat(path, "/", path_len) >= path_len)
                 return RESULT_INVAL;
             if (dmStrlCat(path, application_name, path_len) >= path_len)
                 return RESULT_INVAL;
+
             Result r =  Mkdir(path, 0755);
             if (r == RESULT_EXIST)
                 return RESULT_OK;


### PR DESCRIPTION
This fixes an issue where the engine wouldn't start for some users, when their app directory contained unicode characters.

Fixes https://github.com/defold/defold/issues/10722

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
