### PR TITLE
Added empty mutex implementation for single-threaded environments

### DIFF
--- a/engine/dlib/src/dlib/mutex_empty.cpp
+++ b/engine/dlib/src/dlib/mutex_empty.cpp
@@ -12,27 +12,31 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
-#ifndef DM_MUTEX_H
-#define DM_MUTEX_H
+#include "mutex.h"
 
-#include <dmsdk/dlib/mutex.h> // the api + typedef
+// empty implementation for Mutex. Applied to platforms that should be single threaded (some web targets)
+namespace dmMutex
+{
+    HMutex New()
+    {
+        Mutex* mutex = new Mutex();
+        return mutex;
+    }
 
-#if defined(DM_PLATFORM_VENDOR)
-    #include <dlib/mutex_vendor.h>
+    void Delete(HMutex mutex)
+    {
+        delete mutex;
+    }
 
-#elif defined(_WIN32)
-    #include <dlib/win32/mutex.h>
+    void Lock(HMutex mutex)
+    { }
 
-#elif defined(__linux__) || defined(__MACH__)
-    #include <dlib/mutex_posix.h>
-#elif defined (__EMSCRIPTEN__)
-    #if defined(DM_NO_THREAD_SUPPORT)
-        #include <dlib/mutex_empty.h>
-    #else
-        #include <dlib/mutex_posix.h>
-    #endif
-#else
-    #error "Unsupported platform"
-#endif
+    bool TryLock(HMutex mutex)
+    {
+        return true;
+    }
 
-#endif // DM_MUTEX_H
+    void Unlock(HMutex mutex)
+    { }
+
+}

--- a/engine/dlib/src/dlib/mutex_empty.h
+++ b/engine/dlib/src/dlib/mutex_empty.h
@@ -12,27 +12,13 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
-#ifndef DM_MUTEX_H
-#define DM_MUTEX_H
+#ifndef DM_MUTEX_EMPTY_H
+#define DM_MUTEX_EMPTY_H
 
-#include <dmsdk/dlib/mutex.h> // the api + typedef
+namespace dmMutex
+{
+    struct Mutex
+    { };
+}
 
-#if defined(DM_PLATFORM_VENDOR)
-    #include <dlib/mutex_vendor.h>
-
-#elif defined(_WIN32)
-    #include <dlib/win32/mutex.h>
-
-#elif defined(__linux__) || defined(__MACH__)
-    #include <dlib/mutex_posix.h>
-#elif defined (__EMSCRIPTEN__)
-    #if defined(DM_NO_THREAD_SUPPORT)
-        #include <dlib/mutex_empty.h>
-    #else
-        #include <dlib/mutex_posix.h>
-    #endif
-#else
-    #error "Unsupported platform"
-#endif
-
-#endif // DM_MUTEX_H
+#endif // DM_MUTEX_EMPTY_H

--- a/engine/dlib/src/wscript
+++ b/engine/dlib/src/wscript
@@ -82,6 +82,7 @@ def build(bld):
     if 'arm64-nx64' in bld.env.PLATFORM:
         source_files = remove_files(source_files, ['condition_variable.cpp',
                                                     'mutex_posix.cpp',
+                                                    'mutex_empty.cpp',
                                                     'sys_posix.cpp',
                                                     'socket_posix.cpp',
                                                     'time.cpp'])
@@ -90,6 +91,7 @@ def build(bld):
         source_files = remove_files(source_files, ['condition_variable.cpp',
                                                     'file_descriptor_posix.cpp',
                                                     'mutex_posix.cpp',
+                                                    'mutex_empty.cpp',
                                                     'socket_posix.cpp',
                                                     'thread_posix.cpp',
                                                     'sys_posix.cpp'])
@@ -98,9 +100,14 @@ def build(bld):
         source_files = remove_files(source_files, ['time_posix.cpp'])
         source_files = remove_files(source_files, ['thread_posix.cpp'])
         source_files = remove_files(source_files, ['mutex_posix.cpp'])
+        source_files = remove_files(source_files, ['mutex_empty.cpp'])
     else:
         source_files = remove_files(source_files, ['thread_win32.cpp'])
         source_files = remove_files(source_files, ['mutex_win32.cpp'])
+        if bld.env.PLATFORM in ('wasm-web', 'js-web'):
+            source_files = remove_files(source_files, ['mutex_posix.cpp'])
+        else:
+            source_files = remove_files(source_files, ['mutex_empty.cpp'])
 
     if build_util.get_target_os() in ['macos', 'ios']:
         source_files = remove_files(source_files, ['time_posix.cpp'])
@@ -416,6 +423,7 @@ def build(bld):
     bld.install_files('${PREFIX}/include/dlib', 'dlib/message.h')
     bld.install_files('${PREFIX}/include/dlib', 'dlib/mutex.h')
     bld.install_files('${PREFIX}/include/dlib', 'dlib/mutex_posix.h')
+    bld.install_files('${PREFIX}/include/dlib', 'dlib/mutex_empty.h')
     bld.install_files('${PREFIX}/include/dlib', 'dlib/object_pool.h')
     bld.install_files('${PREFIX}/include/dlib', 'dlib/opaque_handle_container.h')
     bld.install_files('${PREFIX}/include/dlib', 'dlib/path.h')


### PR DESCRIPTION
Fixes #10720 

### Technical changes
Added empty mutex implementation which allows to avoid large code changes in case if some function used in single- and multi-threaded environment with synchronization.

Iniital problem was with mutex in `graphics_opengl` which isn't created because of single-threaded variant but that mutex used to synchronize access to arrays with handles. Now `DM_MUTEX_SCOPED_LOCK` does nothing in single-threaded web builds.


## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
