### PR TITLE
Improve `hash` management when creating objects using collectionfactory

### DIFF
--- a/engine/script/src/script.cpp
+++ b/engine/script/src/script.cpp
@@ -222,10 +222,6 @@ namespace dmScript
         // [-2] context_table
         // [-1] weak_table
 
-        // context_table["__weak"] = weak_table
-        lua_pushvalue(L, -1);        // duplicate weak_table for storing in context
-        lua_setfield(L, -3, "__weak");  // context_table["__weak"] = weak_table
-
         // Now store weak_table ref separately
         context->m_ContextWeakTableRef = Ref(L, LUA_REGISTRYINDEX);
 

--- a/engine/script/src/script_ddf.cpp
+++ b/engine/script/src/script_ddf.cpp
@@ -547,16 +547,16 @@ namespace dmScript
                     else if (d->m_NameHash == DDF_TYPE_NAME_HASH_LUAREF)
                     {
                         dmScriptDDF::LuaRef* lua_ref = (dmScriptDDF::LuaRef*) ptr;
-                        lua_rawgeti(L, LUA_REGISTRYINDEX, lua_ref->m_ContextTableRef);
-                        lua_rawgeti(L, -1, lua_ref->m_Ref);
-                        if (lua_isnil(L, -1))
+                        if (lua_ref->m_Ref)
                         {
-                            lua_pop(L, 1); // remove nil
-                            lua_getfield(L, -1, "__weak"); // context_table["__weak"]
+                            lua_rawgeti(L, LUA_REGISTRYINDEX, lua_ref->m_ContextTableRef);
                             lua_rawgeti(L, -1, lua_ref->m_Ref);
-                            lua_remove(L, -2); // remove weak table
+                            lua_remove(L, -2);
                         }
-                        lua_remove(L, -2); // remove context table
+                        else
+                        {
+                            lua_pushnil(L);
+                        }
                     }
                     else
                     {

--- a/engine/script/src/script_hash.cpp
+++ b/engine/script/src/script_hash.cpp
@@ -393,9 +393,18 @@ namespace dmScript
         if (context)
         {
             int* refp = context->m_HashInstances.Get(hash);
-            if (refp)
+            if (refp && context->m_ContextWeakTableRef != LUA_NOREF)
             {
-                context->m_HashInstances.Erase(hash);
+                lua_rawgeti(L, LUA_REGISTRYINDEX, context->m_ContextWeakTableRef);
+                // [-1] weak_table
+                lua_rawgeti(L, -1, (lua_Integer)hash);
+                // [-2] weak_table
+                // [-1] hash
+                if (lua_isnil(L, -1))
+                {
+                    context->m_HashInstances.Erase(hash);
+                }
+                lua_pop(L, 2);
             }
         }
         return 0;


### PR DESCRIPTION
Fix issue where `hash` can be removed while it's in use

Fix https://github.com/defold/defold/issues/10704