### PR TITLE
Edit collision shapes using editor scripts

### DIFF
--- a/editor/src/clj/editor/atlas.clj
+++ b/editor/src/clj/editor/atlas.clj
@@ -527,7 +527,7 @@
 
 (attachment/register!
   AtlasAnimation :images
-  :add {:node-type AtlasImage :tx-attach-fn attach-image-to-animation}
+  :add {AtlasImage attach-image-to-animation}
   :get get-animation-images)
 
 (g/defnk produce-save-value [margin inner-padding extrude-borders max-page-size img-ddf anim-ddf rename-patterns]
@@ -929,12 +929,12 @@
 
 (attachment/register!
   AtlasNode :animations
-  :add {:node-type AtlasAnimation :tx-attach-fn attach-animation-to-atlas}
+  :add {AtlasAnimation attach-animation-to-atlas}
   :get (attachment/nodes-by-type-getter AtlasAnimation))
 
 (attachment/register!
   AtlasNode :images
-  :add {:node-type AtlasImage :tx-attach-fn attach-image-to-atlas}
+  :add {AtlasImage attach-image-to-atlas}
   :get (attachment/nodes-by-type-getter AtlasImage))
 
 (defn- make-image-nodes

--- a/editor/src/clj/editor/attachment.clj
+++ b/editor/src/clj/editor/attachment.clj
@@ -20,7 +20,7 @@
             [util.coll :as coll]))
 
 (defonce ^:private state-atom
-  ;; :add -> type -> list-kw -> type -> {:node-type ... :tx-attach-fn ...}
+  ;; :add -> type -> list-kw -> type -> tx-attach-fn
   ;; :get -> type -> list-kw -> get-fn
   ;;
   ;; tx-attach-fn: fn of parent-node, child-node -> txs
@@ -34,38 +34,40 @@
     node-type    container graph node type to extend
     list-kw      name of the node component list
 
-  Kv-args:
-    :add    required, a map that defines how new items are added to the list;
-            with the following keys:
-              :node-type       child node type used for constructing new added
-                               items
-              :tx-attach-fn    a function of parent-node-id (container),
-                               child-node-id (element); should return
-                               transaction steps that connect the child node
-                               into the parent
-    :get    required, a function that defines how to read a list of children,
-            will receive 2 args: parent-node-id (container), evaluation-context;
-            should return a vector of node ids"
+  Kv-args (at least one is required):
+    :add    a map that defines how new items are added to the list;
+            where keys are child node types used for constructing new nodes, and
+            values are attach functions, i.e. functions of parent-node-id
+            (container) and child-node-id (item) that should return transaction
+            steps that connect the child node into the parent
+    :get    a function that defines how to read a list of children, will receive
+            2 args: parent-node-id (container) and evaluation-context; should
+            return a vector of node ids"
   [node-type list-kw & {:keys [add get]}]
-  {:pre [(g/node-type? (:node-type add)) (ifn? (:tx-attach-fn add)) (ifn? get)]}
+  {:pre [(or (ifn? get) (map? add))]}
   (swap! state-atom (fn [s]
-                      (-> s
-                          (update :add update node-type assoc list-kw add)
-                          (update :get update node-type assoc list-kw get))))
+                      (cond-> s
+                              add (update :add update node-type update list-kw merge add)
+                              get (update :get update node-type assoc list-kw get))))
   nil)
 
 (defn add-impl [current-state parent-node-type parent-node-id attachment-tree init-fn]
   (coll/mapcat
-    (fn [[list-kw {:keys [init add]}]]
-      (if-let [{:keys [node-type tx-attach-fn]} (-> current-state :add (get parent-node-type) list-kw)]
-        (let [child-node-id (first (g/take-node-ids (g/node-id->graph-id parent-node-id) 1))]
+    (fn [[list-kw {:keys [init add node-type] :as attachment}]]
+      (when-not node-type
+        (throw (ex-info "node type is required" {:parent-node-type parent-node-id :list-kw list-kw :attachment attachment})))
+      (if-let [node-type->tx-attach-fn (-> current-state :add (get parent-node-type) list-kw)]
+        (let [tx-attach-fn (or (node-type->tx-attach-fn node-type)
+                               (throw (ex-info (str (name (:k parent-node-type)) " does not support " (name list-kw) " attachments of type " (name (:k node-type)))
+                                               {:parent-node-type parent-node-id :list-kw list-kw :node-type node-type})))
+              child-node-id (first (g/take-node-ids (g/node-id->graph-id parent-node-id) 1))]
           (concat
             (g/add-node (g/construct node-type :_node-id child-node-id))
             (init-fn parent-node-id node-type child-node-id init)
             (tx-attach-fn parent-node-id child-node-id)
             (add-impl current-state node-type child-node-id add init-fn)))
         (throw (ex-info (str (name (:k parent-node-type)) " does not define a " (name list-kw) " attachment list")
-                        {:node-type parent-node-type
+                        {:parent-node-type parent-node-type
                          :list-kw list-kw}))))
     attachment-tree))
 
@@ -79,10 +81,13 @@
                        additions; a coll of 2-element tuples where first element
                        is a list-kw keyword, and second is a map with the
                        following keys:
-                         :init    required, data structure that will be supplied
-                                  to the init-fn to create element
-                                  initialization transaction steps
-                         :add     optional, attachment tree of the created item
+                         :init         required, data structure that will be
+                                       supplied to the init-fn to create element
+                                       initialization transaction steps
+                         :node-type    required, node type of child node
+                         :add          optional, attachment tree of the created
+                                       item
+
     init-fn            a function that initializes the newly created element
                        node, will receive 4 args:
                          parent-node-id     container node id
@@ -107,13 +112,15 @@
   [node-type list-kw]
   (-> @state-atom :add (get node-type) (contains? list-kw)))
 
-(defn child-node-type
-  "Returns defined child node-type for a parent node-type's list-kw
+(defn child-node-types
+  "Returns defined child node-types for a parent node-type's list-kw
+
+  Returns a map from child node type to tx-attach-fn
 
   Asserts that it exists. See [[defines?]]"
   [node-type list-kw]
-  {:post (some? %)}
-  (-> @state-atom :add (get node-type) (get list-kw) :node-type))
+  {:post [(some? %)]}
+  (-> @state-atom :add (get node-type) (get list-kw)))
 
 (defn getter
   "Returns a getter function for a container node-type's list-kw

--- a/editor/src/clj/editor/collision_object.clj
+++ b/editor/src/clj/editor/collision_object.clj
@@ -16,9 +16,11 @@
   (:require [clojure.string :as string]
             [dynamo.graph :as g]
             [editor.app-view :as app-view]
+            [editor.attachment :as attachment]
             [editor.build-target :as bt]
             [editor.collision-groups :as collision-groups]
             [editor.defold-project :as project]
+            [editor.editor-extensions.node-types :as node-types]
             [editor.geom :as geom]
             [editor.gl.pass :as pass]
             [editor.gl.vertex2 :as vtx]
@@ -253,6 +255,7 @@
   (inherits Shape)
 
   (property diameter g/Num ; Always assigned in load-fn.
+            (default 0.0) ; Used to prevent validation errors during node initialization from editor scripts
             (dynamic error (validation/prop-error-fnk :fatal validation/prop-zero-or-below? diameter)))
 
   (display-order [Shape :diameter])
@@ -279,6 +282,7 @@
   (inherits Shape)
 
   (property dimensions types/Vec3 ; Always assigned in load-fn.
+            (default [0.0 0.0 0.0]) ; Used to prevent validation errors during node initialization from editor scripts
             (dynamic error (validation/prop-error-fnk :fatal
                                                       (fn [d _] (when (some #(<= % 0.0) d)
                                                                   "All dimensions must be greater than zero"))
@@ -305,8 +309,10 @@
   (inherits Shape)
 
   (property diameter g/Num ; Always assigned in load-fn.
+            (default 0.0) ; Used to prevent validation errors during node initialization from editor scripts
             (dynamic error (validation/prop-error-fnk :fatal validation/prop-zero-or-below? diameter)))
   (property height g/Num ; Always assigned in load-fn.
+            (default 0.0) ; Used to prevent validation errors during node initialization from editor scripts
             (dynamic error (validation/prop-error-fnk :fatal validation/prop-zero-or-below? height)))
 
   (display-order [Shape :diameter :height])
@@ -330,18 +336,27 @@
   [node-id]
   [:scale-x :scale-y :scale-xy])
 
+(defn- resolve-shape-node-outline-key [evaluation-context parent-node shape-node]
+  (let [type-label (:label (shape-type-ui (g/node-value shape-node :shape-type evaluation-context)))
+        taken-keys (outline/taken-node-outline-keys parent-node evaluation-context)]
+    (g/update-property shape-node :node-outline-key (fnil outline/next-node-outline-key type-label) taken-keys)))
+
 (defn attach-shape-node
-  [resolve-node-outline-key? parent shape-node]
-  (concat
-    (g/connect shape-node :_node-id              parent     :nodes)
-    (g/connect shape-node :node-outline          parent     :child-outlines)
-    (g/connect shape-node :scene                 parent     :child-scenes)
-    (g/connect shape-node :shape                 parent     :shapes)
-    (g/connect parent     :id-counts             shape-node :id-counts)
-    (g/connect parent     :collision-group-color shape-node :color)
-    (g/connect parent     :project-physics-type  shape-node :project-physics-type)
-    (when resolve-node-outline-key?
-      (g/update-property shape-node :node-outline-key outline/next-node-outline-key (outline/taken-node-outline-keys parent)))))
+  ([parent shape-node]
+   (attach-shape-node true parent shape-node))
+  ([resolve-node-outline-key? parent shape-node]
+   (concat
+     (when resolve-node-outline-key?
+       ;; resolve the node outline key before connecting the shape node so taken
+       ;; node outline keys don't include the shape node key
+       (g/expand-ec resolve-shape-node-outline-key parent shape-node))
+     (g/connect shape-node :_node-id              parent     :nodes)
+     (g/connect shape-node :node-outline          parent     :child-outlines)
+     (g/connect shape-node :scene                 parent     :child-scenes)
+     (g/connect shape-node :shape                 parent     :shapes)
+     (g/connect parent     :id-counts             shape-node :id-counts)
+     (g/connect parent     :collision-group-color shape-node :color)
+     (g/connect parent     :project-physics-type  shape-node :project-physics-type))))
 
 (defmulti decode-shape-data
   (fn [shape data] (:shape-type shape)))
@@ -652,13 +667,23 @@
                                                       :icon collision-object-icon
                                                       :children (outline/natural-sort child-outlines)
                                                       :child-reqs [{:node-type Shape
-                                                                    :tx-attach-fn (partial attach-shape-node true)}]}))
+                                                                    :tx-attach-fn attach-shape-node}]}))
 
   (output id-counts NameCounts :cached (g/fnk [shapes] (frequencies (keep :id shapes))))
   (output save-value g/Any :cached produce-save-value)
   (output build-targets g/Any :cached produce-build-targets)
   (output collision-group-node g/Any :cached (g/fnk [_node-id group] {:node-id _node-id :collision-group group}))
   (output collision-group-color g/Any :cached produce-collision-group-color))
+
+(attachment/register!
+  CollisionObjectNode :shapes
+  :add {SphereShape attach-shape-node
+        BoxShape attach-shape-node
+        CapsuleShape attach-shape-node}
+  :get attachment/nodes-getter)
+(node-types/register-node-type-name! SphereShape "shape-type-sphere")
+(node-types/register-node-type-name! BoxShape "shape-type-box")
+(node-types/register-node-type-name! CapsuleShape "shape-type-capsule")
 
 (defn- sanitize-collision-object [collision-object-desc]
   (strip-empty-embedded-collision-shape collision-object-desc))

--- a/editor/src/clj/editor/editor_extensions/graph.clj
+++ b/editor/src/clj/editor/editor_extensions/graph.clj
@@ -353,7 +353,7 @@
 ;; region attach
 
 (defn- attachment->set-tx-steps [attachment child-node-id rt project evaluation-context]
-  (mapcat
+  (coll/mapcat
     (fn [[property lua-value]]
       (if-let [setter (ext-lua-value-setter child-node-id property rt project evaluation-context)]
         (setter lua-value)

--- a/editor/src/clj/editor/editor_extensions/graph.clj
+++ b/editor/src/clj/editor/editor_extensions/graph.clj
@@ -260,7 +260,8 @@
                               :to)]
               #(some-> (properties/value outline-property) to)))
           (case property
-            "type" #(node-types/->name (g/node-type* (:basis evaluation-context) node-id))
+            "type" (when-let [type-name (node-types/->name (g/node-type* (:basis evaluation-context) node-id))]
+                     (constantly type-name))
             nil)
           (let [node-type (g/node-type* (:basis evaluation-context) node-id)
                 list-kw (property->prop-kw property)]

--- a/editor/src/clj/editor/editor_extensions/graph.clj
+++ b/editor/src/clj/editor/editor_extensions/graph.clj
@@ -22,6 +22,7 @@
             [editor.defold-project :as project]
             [editor.editor-extensions.coerce :as coerce]
             [editor.editor-extensions.runtime :as rt]
+            [editor.editor-extensions.node-types :as node-types]
             [editor.editor-extensions.tile-map :as tile-map]
             [editor.game-project :as game-project]
             [editor.id :as id]
@@ -258,6 +259,9 @@
                               edit-type-id->value-converter
                               :to)]
               #(some-> (properties/value outline-property) to)))
+          (case property
+            "type" #(node-types/->name (g/node-type* (:basis evaluation-context) node-id))
+            nil)
           (let [node-type (g/node-type* (:basis evaluation-context) node-id)
                 list-kw (property->prop-kw property)]
             (when (attachment/defines? node-type list-kw)
@@ -347,36 +351,54 @@
 
 ;; region attach
 
-(defmulti init-attachment (fn init-attachment-dispatch-fn [node-type _attachment _parent-node-id _project _evaluation-context]
-                            (:k node-type)))
+(defn- attachment->set-tx-steps [attachment child-node-id rt project evaluation-context]
+  (mapcat
+    (fn [[property lua-value]]
+      (if-let [setter (ext-lua-value-setter child-node-id property rt project evaluation-context)]
+        (setter lua-value)
+        (throw (LuaError. (format "Can't set property \"%s\" of %s"
+                                  property
+                                  (name (node-id->type-keyword child-node-id evaluation-context)))))))
+    attachment))
 
-(defmethod init-attachment :default [_ attachment _ _ _] attachment)
+(defmulti init-attachment
+  (fn init-attachment-dispatch-fn [_evaluation-context _rt _project _parent-node-id child-node-type _child-node-id _attachment]
+    (:k child-node-type)))
+
+(defmethod init-attachment :default [evaluation-context rt project _ _ child-node-id attachment]
+  (attachment->set-tx-steps attachment child-node-id rt project evaluation-context))
 
 (def ^:private default-new-animation-name-lua-value (rt/->lua "New Animation"))
-(defmethod init-attachment :editor.atlas/AtlasAnimation [_ attachment _ _ _]
-  (util/provide-defaults attachment "id" default-new-animation-name-lua-value))
+(defmethod init-attachment :editor.atlas/AtlasAnimation [evaluation-context rt project _ _ child-node-id attachment]
+  (-> attachment
+      (util/provide-defaults
+        "id" default-new-animation-name-lua-value)
+      (attachment->set-tx-steps child-node-id rt project evaluation-context)))
 
 (def ^:private default-start-tile-lua-value (rt/->lua 1))
 (def ^:private default-end-tile-lua-value (rt/->lua 1))
-(defmethod init-attachment :editor.tile-source/TileAnimationNode [_ attachment _ _ _]
-  (util/provide-defaults
-    attachment
-    "id" default-new-animation-name-lua-value
-    "start_tile" default-start-tile-lua-value
-    "end_tile" default-end-tile-lua-value))
+(defmethod init-attachment :editor.tile-source/TileAnimationNode [evaluation-context rt project _ _ child-node-id attachment]
+  (-> attachment
+      (util/provide-defaults
+        "id" default-new-animation-name-lua-value
+        "start_tile" default-start-tile-lua-value
+        "end_tile" default-end-tile-lua-value)
+      (attachment->set-tx-steps child-node-id rt project evaluation-context)))
 
-(defmethod init-attachment :editor.tile-source/CollisionGroupNode [_ attachment _ project evaluation-context]
-  (util/provide-defaults
-    attachment
-    "id" (rt/->lua
-           (id/gen "collision_group"
-                   (collision-groups/collision-groups
-                     (g/node-value project :collision-groups-data evaluation-context))))))
+(defmethod init-attachment :editor.tile-source/CollisionGroupNode [evaluation-context rt project _ _ child-node-id attachment]
+  (-> attachment
+      (util/provide-defaults
+        "id" (rt/->lua
+               (id/gen "collision_group"
+                       (collision-groups/collision-groups
+                         (g/node-value project :collision-groups-data evaluation-context)))))
+      (attachment->set-tx-steps child-node-id rt project evaluation-context)))
 
-(defmethod init-attachment :editor.tile-map/LayerNode [_ attachment tilemap-node-id _project evaluation-context]
-  (util/provide-defaults
-    attachment
-    "id" (rt/->lua (id/gen "layer" (g/node-value tilemap-node-id :layer-ids evaluation-context)))))
+(defmethod init-attachment :editor.tile-map/LayerNode [evaluation-context rt project parent-node-id _ child-node-id attachment]
+  (-> attachment
+      (util/provide-defaults
+        "id" (rt/->lua (id/gen "layer" (g/node-value parent-node-id :layer-ids evaluation-context))))
+      (attachment->set-tx-steps child-node-id rt project evaluation-context)))
 
 (def ^:private default-emitter-mode (rt/->lua :play-mode-loop))
 (def ^:private default-emitter-space (rt/->lua :emission-space-world))
@@ -388,68 +410,103 @@
 (def ^:private default-emitter-curve-1 (rt/->lua {:points [{:x 0 :y 1 :tx 1 :ty 0}]}))
 (def ^:private default-emitter-curve-10 (rt/->lua {:points [{:x 0 :y 10 :tx 1 :ty 0}]}))
 
-(defmethod init-attachment :editor.particlefx/EmitterNode [_ attachment parent-node-id _project evaluation-context]
-  (util/provide-defaults
-    attachment
-    "id" (rt/->lua (id/gen "emitter" (g/node-value parent-node-id :ids evaluation-context)))
-    "mode" default-emitter-mode
-    "space" default-emitter-space
-    "type" default-emitter-type
-    "max_particle_count" default-emitter-max-particle-count
-    "material" default-emitter-material
-    "tile_source" default-emitter-tile-source
-    "animation" default-emitter-animation
+(defmethod init-attachment :editor.particlefx/EmitterNode [evaluation-context rt project parent-node-id _ child-node-id attachment]
+  (-> attachment
+      (util/provide-defaults
+        "id" (rt/->lua (id/gen "emitter" (g/node-value parent-node-id :ids evaluation-context)))
+        "mode" default-emitter-mode
+        "space" default-emitter-space
+        "type" default-emitter-type
+        "max_particle_count" default-emitter-max-particle-count
+        "material" default-emitter-material
+        "tile_source" default-emitter-tile-source
+        "animation" default-emitter-animation
 
-    "emitter_key_particle_red" default-emitter-curve-1
-    "emitter_key_particle_green" default-emitter-curve-1
-    "emitter_key_particle_blue" default-emitter-curve-1
-    "emitter_key_particle_alpha" default-emitter-curve-1
+        "emitter_key_particle_red" default-emitter-curve-1
+        "emitter_key_particle_green" default-emitter-curve-1
+        "emitter_key_particle_blue" default-emitter-curve-1
+        "emitter_key_particle_alpha" default-emitter-curve-1
 
-    "emitter_key_particle_life_time" default-emitter-curve-1
-    "emitter_key_particle_size" default-emitter-curve-1
-    "emitter_key_particle_speed" default-emitter-curve-1
-    "emitter_key_spawn_rate" default-emitter-curve-10
+        "emitter_key_particle_life_time" default-emitter-curve-1
+        "emitter_key_particle_size" default-emitter-curve-1
+        "emitter_key_particle_speed" default-emitter-curve-1
+        "emitter_key_spawn_rate" default-emitter-curve-10
 
-    "particle_key_red" default-emitter-curve-1
-    "particle_key_green" default-emitter-curve-1
-    "particle_key_blue" default-emitter-curve-1
-    "particle_key_alpha" default-emitter-curve-1
+        "particle_key_red" default-emitter-curve-1
+        "particle_key_green" default-emitter-curve-1
+        "particle_key_blue" default-emitter-curve-1
+        "particle_key_alpha" default-emitter-curve-1
 
-    "particle_key_scale" default-emitter-curve-1))
+        "particle_key_scale" default-emitter-curve-1)
+      (attachment->set-tx-steps child-node-id rt project evaluation-context)))
 
 (def ^:private default-modifier-type (rt/->lua :modifier-type-acceleration))
-(defmethod init-attachment :editor.particlefx/ModifierNode [_ attachment _parent-node-id _project _evaluation-context]
-  (util/provide-defaults
-    attachment
-    "type" default-modifier-type))
+(defmethod init-attachment :editor.particlefx/ModifierNode [evaluation-context rt project _ _ child-node-id attachment]
+  (-> attachment
+      (util/provide-defaults
+        "type" default-modifier-type)
+      (attachment->set-tx-steps child-node-id rt project evaluation-context)))
 
-(defn- init-txs [evaluation-context rt project parent-node-id child-node-type child-node-id attachment]
-  (mapcat
-    (fn [[property lua-value]]
-      (if-let [setter (ext-lua-value-setter child-node-id property rt project evaluation-context)]
-        (setter lua-value)
-        (throw (LuaError. (format "Can't set property \"%s\" of %s"
-                                  property
-                                  (name (node-id->type-keyword child-node-id evaluation-context)))))))
-    (init-attachment child-node-type attachment parent-node-id project evaluation-context)))
+(def ^:private default-sphere-diameter (rt/->lua 20.0))
+(defmethod init-attachment :editor.collision-object/SphereShape [evaluation-context rt project _ _ child-node-id attachment]
+  (concat
+    (g/set-property child-node-id :shape-type :type-sphere)
+    (-> attachment
+        (util/provide-defaults
+          "diameter" default-sphere-diameter)
+        (attachment->set-tx-steps child-node-id rt project evaluation-context))))
+
+(def ^:private default-box-dimensions (rt/->lua [20.0 20.0 20.0]))
+(defmethod init-attachment :editor.collision-object/BoxShape [evaluation-context rt project _ _ child-node-id attachment]
+  (concat
+    (g/set-property child-node-id :shape-type :type-box)
+    (-> attachment
+        (util/provide-defaults
+          "dimensions" default-box-dimensions)
+        (attachment->set-tx-steps child-node-id rt project evaluation-context))))
+
+(def ^:private default-capsule-diameter (rt/->lua 20.0))
+(def ^:private default-capsule-height (rt/->lua 40.0))
+(defmethod init-attachment :editor.collision-object/CapsuleShape [evaluation-context rt project _ _ child-node-id attachment]
+  (concat
+    (g/set-property child-node-id :shape-type :type-capsule)
+    (-> attachment
+        (util/provide-defaults
+          "diameter" default-capsule-diameter
+          "height" default-capsule-height)
+        (attachment->set-tx-steps child-node-id rt project evaluation-context))))
 
 (def ^:private attachment-coercer (coerce/map-of coerce/string coerce/untouched))
 (def ^:private attachments-coercer (coerce/vector-of attachment-coercer))
 
-(defn- parse-attachment [rt node-type attachment]
-  (reduce-kv
-    (fn [acc property lua-value]
-      (let [list-kw (property->prop-kw property)]
-        (if (attachment/defines? node-type list-kw)
-          (let [child-node-type (attachment/child-node-type node-type list-kw)]
-            (update acc :add
-                    into
-                    (map #(coll/pair list-kw (parse-attachment rt child-node-type %)))
-                    (rt/->clj rt attachments-coercer lua-value)))
-          (update acc :init assoc property lua-value))))
-    {:init {}
-     :add []}
-    attachment))
+(defn- extract-node-type [rt attachment possible-node-types]
+  (if-let [lua-type (attachment "type")]
+    (let [name (rt/->clj rt coerce/string lua-type)
+          node-type (node-types/->type name)]
+      (if (and node-type (contains? possible-node-types node-type))
+        node-type
+        (throw (LuaError. (str name " is not " (->> possible-node-types keys (keep node-types/->name) sort (util/join-words ", " " or ")))))))
+    (throw (LuaError. "type is required"))))
+
+(defn- parse-attachment [rt possible-node-types attachment]
+  (let [requires-explicit-type (< 1 (count possible-node-types))
+        node-type (if requires-explicit-type
+                    (extract-node-type rt attachment possible-node-types)
+                    (reduce-kv (fn [_ k _] (reduced k)) nil possible-node-types))
+        tree {:init {} :add [] :node-type node-type}
+        attachment (cond-> attachment requires-explicit-type (dissoc "type"))]
+    (reduce-kv
+      (fn [acc property lua-value]
+        (let [list-kw (property->prop-kw property)]
+          (if (attachment/defines? node-type list-kw)
+            (let [child-node-types (attachment/child-node-types node-type list-kw)]
+              (update acc :add
+                      into
+                      (map #(coll/pair list-kw (parse-attachment rt child-node-types %)))
+                      (rt/->clj rt attachments-coercer lua-value)))
+            (update acc :init assoc property lua-value))))
+      tree
+      attachment)))
 
 (def ^:private add-args-coercer
   (coerce/regex :node node-id-or-path-coercer
@@ -465,8 +522,8 @@
           list-kw (property->prop-kw property)
           _ (when-not (attachment/defines? node-type list-kw)
               (throw (LuaError. (format "%s does not define \"%s\"" (name (:k node-type)) property))))
-          tree [[list-kw (parse-attachment rt (attachment/child-node-type node-type list-kw) attachment)]]]
-      (-> (attachment/add basis node-id tree (partial g/expand-ec init-txs rt project))
+          tree [[list-kw (parse-attachment rt (attachment/child-node-types node-type list-kw) attachment)]]]
+      (-> (attachment/add basis node-id tree (partial g/expand-ec init-attachment rt project))
           (with-meta {:type :transaction-step})
           (rt/wrap-userdata "editor.tx.add(...)")))))
 

--- a/editor/src/clj/editor/editor_extensions/node_types.clj
+++ b/editor/src/clj/editor/editor_extensions/node_types.clj
@@ -1,0 +1,46 @@
+;; Copyright 2020-2025 The Defold Foundation
+;; Copyright 2014-2020 King
+;; Copyright 2009-2014 Ragnar Svensson, Christian Murray
+;; Licensed under the Defold License version 1.0 (the "License"); you may not use
+;; this file except in compliance with the License.
+;;
+;; You may obtain a copy of the License, together with FAQs at
+;; https://www.defold.com/license
+;;
+;; Unless required by applicable law or agreed to in writing, software distributed
+;; under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+;; CONDITIONS OF ANY KIND, either express or implied. See the License for the
+;; specific language governing permissions and limitations under the License.
+
+(ns editor.editor-extensions.node-types
+  "Namespace for defining stable name aliases for editor node types"
+  (:require [dynamo.graph :as g]))
+
+(set! *warn-on-reflection* true)
+(set! *unchecked-math* :warn-on-boxed)
+
+(defonce ^:private state-atom
+  (atom {:name->type {}
+         :type->name {}}))
+
+(defn register-node-type-name!
+  "Register node type <-> editor script name mapping"
+  [node-type name]
+  {:pre [(string? name) (g/node-type? node-type)]}
+  (swap! state-atom (fn [state]
+                      (-> state
+                          (update :name->type assoc name node-type)
+                          (update :type->name assoc node-type name))))
+  nil)
+
+(defn ->name
+  "Given a node type, returns its name or nil if not registered"
+  [node-type]
+  {:pre [(g/node-type? node-type)]}
+  ((:type->name @state-atom) node-type))
+
+(defn ->type
+  "Returns a node type given its name, or nil if not registered"
+  [name]
+  {:pre [(string? name)]}
+  ((:name->type @state-atom) name))

--- a/editor/src/clj/editor/particlefx.clj
+++ b/editor/src/clj/editor/particlefx.clj
@@ -950,7 +950,7 @@
 
 (attachment/register!
   EmitterNode :modifiers
-  :add {:node-type ModifierNode :tx-attach-fn attach-modifier}
+  :add {ModifierNode attach-modifier}
   :get attachment/nodes-getter)
 
 (defn- build-pb [resource dep-resources user-data]
@@ -1088,12 +1088,12 @@
 
 (attachment/register!
   ParticleFXNode :emitters
-  :add {:node-type EmitterNode :tx-attach-fn attach-emitter}
+  :add {EmitterNode attach-emitter}
   :get (attachment/nodes-by-type-getter EmitterNode))
 
 (attachment/register!
   ParticleFXNode :modifiers
-  :add {:node-type ModifierNode :tx-attach-fn attach-modifier}
+  :add {ModifierNode attach-modifier}
   :get (attachment/nodes-by-type-getter ModifierNode))
 
 (defn- make-modifier

--- a/editor/src/clj/editor/tile_map.clj
+++ b/editor/src/clj/editor/tile_map.clj
@@ -727,7 +727,7 @@
 
 (attachment/register!
   TileMapNode :layers
-  :add {:node-type LayerNode :tx-attach-fn attach-layer-node}
+  :add {LayerNode attach-layer-node}
   :get attachment/nodes-getter)
 
 ;;--------------------------------------------------------------------

--- a/editor/src/clj/editor/tile_source.clj
+++ b/editor/src/clj/editor/tile_source.clj
@@ -733,12 +733,12 @@
 
 (attachment/register!
   TileSourceNode :animations
-  :add {:node-type TileAnimationNode :tx-attach-fn attach-animation-node}
+  :add {TileAnimationNode attach-animation-node}
   :get (attachment/nodes-by-type-getter TileAnimationNode))
 
 (attachment/register!
   TileSourceNode :collision-groups
-  :add {:node-type CollisionGroupNode :tx-attach-fn attach-collision-group-node}
+  :add {CollisionGroupNode attach-collision-group-node}
   :get (attachment/nodes-by-type-getter CollisionGroupNode))
 
 

--- a/editor/test/integration/editor_extensions_test.clj
+++ b/editor/test/integration/editor_extensions_test.clj
@@ -1305,6 +1305,27 @@ Transaction: clear particlefx
 After transaction (clear):
   emitters: 0
   modifiers: 0
+Collision object initial state:
+  shapes: 0
+Transaction: add 3 shapes
+After transaction (add 3 shapes):
+  shapes: 3
+  - id: box
+    type: shape-type-box
+    dimensions: 20 20 20
+  - id: sphere
+    type: shape-type-sphere
+    diameter: 20
+  - id: capsule
+    type: shape-type-capsule
+    diameter: 20
+    height: 40
+Transaction: clear
+After transaction (clear):
+  shapes: 0
+Expected errors:
+  missing type => type is required
+  wrong type => box is not shape-type-box, shape-type-capsule or shape-type-sphere
 ")
 
 (deftest attachment-properties-test

--- a/editor/test/resources/editor_extensions/transact_attachment_project/test.collisionobject
+++ b/editor/test/resources/editor_extensions/transact_attachment_project/test.collisionobject
@@ -1,0 +1,6 @@
+type: COLLISION_OBJECT_TYPE_DYNAMIC
+mass: 1.0
+friction: 0.1
+restitution: 0.5
+group: "default"
+mask: "default"

--- a/editor/test/resources/editor_extensions/transact_attachment_project/test.editor_script
+++ b/editor/test/resources/editor_extensions/transact_attachment_project/test.editor_script
@@ -87,6 +87,26 @@ local function print_particlefx_contents(particlefx)
     end
 end
 
+local function print_collision_object(collision)
+    local shapes = editor.get(collision, "shapes")
+    print(("  shapes: %s"):format(#shapes))
+    for i = 1, #shapes do
+        local shape = shapes[i]
+        print(("  - id: %s"):format(editor.get(shape, "id")))
+        local type = editor.get(shape, "type")
+        print(("    type: %s"):format(type))
+        if type == "shape-type-sphere" then
+            print(("    diameter: %s"):format(editor.get(shape, "diameter")))
+        elseif type == "shape-type-box" then
+            local x,y,z = table.unpack(editor.get(shape, "dimensions"))
+            print(("    dimensions: %s %s %s"):format(x, y, z))
+        elseif type == "shape-type-capsule" then
+            print(("    diameter: %s"):format(editor.get(shape, "diameter")))
+            print(("    height: %s"):format(editor.get(shape, "height")))
+        end
+    end
+end
+
 function M.get_commands()
     return {
         editor.command({
@@ -239,6 +259,41 @@ function M.get_commands()
 
                 print("After transaction (clear):")
                 print_particlefx_contents(pfx)
+
+                local collision = "/test.collisionobject"
+                
+                print("Collision object initial state:")
+                print_collision_object(collision)
+
+                print("Transaction: add 3 shapes")
+                editor.transact({
+                    editor.tx.add(collision, "shapes", {
+                        id = "box",
+                        type = "shape-type-box"
+                    }),
+                    editor.tx.add(collision, "shapes", {
+                        id = "sphere",
+                        type = "shape-type-sphere"
+                    }),
+                    editor.tx.add(collision, "shapes", {
+                        id = "capsule",
+                        type = "shape-type-capsule"
+                    })
+                })
+
+                print("After transaction (add 3 shapes):")
+                print_collision_object(collision)
+
+                print("Transaction: clear")
+                editor.transact({editor.tx.clear(collision, "shapes")})
+
+                print("After transaction (clear):")
+                print_collision_object(collision)
+
+                print("Expected errors:")
+                expect_error("missing type", editor.tx.add, collision, "shapes", {})
+                expect_error("wrong type", editor.tx.add, collision, "shapes", {type = "box"})
+                
             end
         })
     }


### PR DESCRIPTION
It is now possible to edit collision shapes using editor scripts! To support this, we added new `"shapes"` node list property to collision objects. For example, adding a new shape is done like this:
```lua
editor.transact({
    editor.tx.add("/hero.collisionobject", "shapes", {
        type = "shape-type-box" -- or "shape-type-sphere", "shape-type-capsule"
    })
})
```

To create a new collision shape, it is necessary to specify the type of the shape. The available types are:
- `shape-type-box` - box shape with `dimensions` property
- `shape-type-sphere` - sphere shape with `diameter` property
- `shape-type-capsule` - capsule shape with `diameter` and `height` properties

Related to #8504