### PR TITLE
Fixes build_engine.

### DIFF
--- a/build_tools/waf_dynamo.py
+++ b/build_tools/waf_dynamo.py
@@ -307,7 +307,7 @@ def apidoc_extract_task(bld, src):
         for o in task.outputs:
             name = os.path.splitext(o.name)[0] # remove .apidoc
             docs = all_docs[name]
-            with open(str(o.get_bld()), 'w+') as out_f:
+            with open(str(o.get_bld()), 'w+', encoding='utf-8') as out_f:
                 out_f.write('\n'.join(docs))
 
     if not getattr(Options.options, 'skip_apidocs', False):


### PR DESCRIPTION
Running 
`$ ./scripts/build.py build_engine --skip-tests -- --skip-build-tests`
Produced this error: 
`UTF-8 decode error in file: ..\dlib\build\src\dmsdk-dlib-utf8.h.apidoc 'utf-8' codec can't decode byte 0xe5 in position 406: invalid continuation byte`
This was caused by dmsdk-dlib-utf8.h.apidoc being ANSI encoded instead utf-8.

Given that [the revision started this issue](https://github.com/defold/defold/commit/d0cff4f89a302d265bcb4d67a331da061f7950bc) is 2 weeks old, this is likely a Windows only problem (different default encoding from, let's say, MacOS).