### PR TITLE
Adding basic convdvar implementation for WASM targets

### DIFF
--- a/engine/dlib/src/dlib/condition_variable.cpp
+++ b/engine/dlib/src/dlib/condition_variable.cpp
@@ -131,7 +131,7 @@ namespace dmConditionVariable
     {
         // dmLog uses dmMessage, which in turn uses dmConditionVariable (Wait & Signal).
         // We cannot place assertions here.
-    #if defined(DM_NO_THREAD_SUPPORT)
+    #if !defined(DM_NO_THREAD_SUPPORT)
         pthread_cond_wait(&condition->m_NativeHandle, &mutex->m_NativeHandle);
     #endif
     }
@@ -139,7 +139,7 @@ namespace dmConditionVariable
     void Signal(HConditionVariable condition)
     {
         assert(condition);
-    #if defined(DM_NO_THREAD_SUPPORT)
+    #if !defined(DM_NO_THREAD_SUPPORT)
         int ret = pthread_cond_signal(&condition->m_NativeHandle);
         assert(ret == 0);
     #endif

--- a/engine/dlib/src/dlib/condition_variable.cpp
+++ b/engine/dlib/src/dlib/condition_variable.cpp
@@ -131,14 +131,18 @@ namespace dmConditionVariable
     {
         // dmLog uses dmMessage, which in turn uses dmConditionVariable (Wait & Signal).
         // We cannot place assertions here.
+    #if defined(DM_NO_THREAD_SUPPORT)
         pthread_cond_wait(&condition->m_NativeHandle, &mutex->m_NativeHandle);
+    #endif
     }
 
     void Signal(HConditionVariable condition)
     {
         assert(condition);
+    #if defined(DM_NO_THREAD_SUPPORT)
         int ret = pthread_cond_signal(&condition->m_NativeHandle);
         assert(ret == 0);
+    #endif
     }
 
     void Broadcast(HConditionVariable condition)

--- a/engine/dlib/src/dlib/condition_variable.cpp
+++ b/engine/dlib/src/dlib/condition_variable.cpp
@@ -131,11 +131,14 @@ namespace dmConditionVariable
     {
         // dmLog uses dmMessage, which in turn uses dmConditionVariable (Wait & Signal).
         // We cannot place assertions here.
+        pthread_cond_wait(&condition->m_NativeHandle, &mutex->m_NativeHandle);
     }
 
     void Signal(HConditionVariable condition)
     {
-
+        assert(condition);
+        int ret = pthread_cond_signal(&condition->m_NativeHandle);
+        assert(ret == 0);
     }
 
     void Broadcast(HConditionVariable condition)


### PR DESCRIPTION
Implements dmConditionVariable for Emsccripten based platforms

### Technical changes
* implementation uses the pthread API as supported by Emscripten
* note that broadcast is not supported (signal is)
