### PR TITLE
Correcting EOS logic for tremolo decoder

### DIFF
--- a/engine/sound/src/decoders/decoder_tremolo.cpp
+++ b/engine/sound/src/decoders/decoder_tremolo.cpp
@@ -192,6 +192,7 @@ namespace dmSoundCodec
         // Decode to 'NIL' (unfortunately with zero cycle savings vs. a real decode)
         char buffer[4096];
         char* ptrs[1] = {buffer};
+        *skipped = 0;
         Result ret = RESULT_OK;
         while(bytes && ret == RESULT_OK)
         {
@@ -202,7 +203,7 @@ namespace dmSoundCodec
             bytes -= decoded;
         }
 
-        return ret;
+        return (ret == RESULT_END_OF_STREAM && *skipped != 0) ? RESULT_OK : ret;
     }
 
     static void TremoloCloseStream(HDecodeStream stream)


### PR DESCRIPTION
Logic flagged EOS with tremolo decoder even if some data was still decoded before reaching EOS condition, hence triggering an assert() in general mixer code

Fixes #10732

### Technical changes
This de-facto is a correction of an earlier fix (#10712), which ms-judged the actual cause of the behavior corrected back then.