### PR TITLE
Fix issue where rebuilding the game from the Editor doesn't keep the simulated resolution

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -820,7 +820,10 @@
               ;; running to keep engine process
               ;; from halting because stdout/err is
               ;; not consumed.
-              (reboot-engine! selected-target web-server debug?))
+              (reboot-engine! selected-target web-server debug?)
+              (console/start-one-line-log-pump!
+                (:log-stream selected-target)
+                (fn [_] (on-service-url-found prefs selected-target))))
             (launch-new-engine!))))
       (catch Exception e
         (log/warn :exception e)

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -753,9 +753,9 @@
           (let [result-target (targets/update-launched-target! launched-target target-info)]
             (reset! updated-target result-target)))
         (when (not @version-line)
-          (when-let [engine-version-line (engine/parse-engine-version-line @initial-output)]
+          (when-let [engine-version-line (engine/parse-engine-version-line line)]
             (reset! version-line engine-version-line))))
-      (when (and @updated-target line (= @version-line line))
+      (when (and @updated-target (= @version-line line))
         (on-service-url-found @updated-target))
       (when (console/current-stream? (:log-stream launched-target))
         (console/append-console-line! line)))))

--- a/editor/src/clj/editor/console.clj
+++ b/editor/src/clj/editor/console.clj
@@ -110,6 +110,7 @@
   (reset! console-stream stream)
   (clear-console!))
 
+;; Start a background thread that continuously reads lines from log-stream and calls sink-fn for each line.
 (defn start-log-pump! [log-stream sink-fn]
   (doto (Thread. (fn []
                    (try
@@ -126,6 +127,22 @@
                      (catch InterruptedException _
                        ;; Losing the log connection is ok and even expected
                        nil))))
+    (.start)))
+
+;; Start a background thread that waits for a single line from the log-stream,
+;; calls sink-fn with it, and then stops.
+(defn start-one-line-log-pump!
+  "Reads a single line from log-stream in a background thread and calls sink-fn with it.
+   Does NOT close the stream."
+  [log-stream sink-fn]
+  (doto (Thread.
+          (fn []
+            (try
+              (let [reader (BufferedReader. (io/reader log-stream :encoding "UTF-8"))]
+                (when-let [line (.readLine ^BufferedReader reader)]
+                  (sink-fn line)))
+              (catch IOException _ nil)
+              (catch InterruptedException _ nil))))
     (.start)))
 
 (defn make-remote-log-sink [log-stream]

--- a/editor/src/clj/editor/console.clj
+++ b/editor/src/clj/editor/console.clj
@@ -129,22 +129,6 @@
                        nil))))
     (.start)))
 
-;; Start a background thread that waits for a single line from the log-stream,
-;; calls sink-fn with it, and then stops.
-(defn start-one-line-log-pump!
-  "Reads a single line from log-stream in a background thread and calls sink-fn with it.
-   Does NOT close the stream."
-  [log-stream sink-fn]
-  (doto (Thread.
-          (fn []
-            (try
-              (let [reader (BufferedReader. (io/reader log-stream :encoding "UTF-8"))]
-                (when-let [line (.readLine ^BufferedReader reader)]
-                  (sink-fn line)))
-              (catch IOException _ nil)
-              (catch InterruptedException _ nil))))
-    (.start)))
-
 (defn make-remote-log-sink [log-stream]
   (fn [line]
     (when (= @console-stream log-stream)

--- a/editor/src/clj/editor/engine.clj
+++ b/editor/src/clj/editor/engine.clj
@@ -174,6 +174,13 @@
              {:log-port log-port
               :address loopback-address}))))
 
+;; Parse a line from engine output to extract engine version info.
+(defn parse-engine-version-line [output]
+  (some (fn [line]
+          (when-let [[_ version sha] (re-find #"INFO:ENGINE: Defold Engine ([^\s]+) \(([^)]+)\)" line)]
+            line))
+        (split-lines output)))
+
 (defn- dmengine-filename
   ^String [^String platform]
   ;; Only the WasmWeb platform use two binary names, '.js' and '.wasm'.

--- a/editor/src/clj/editor/engine.clj
+++ b/editor/src/clj/editor/engine.clj
@@ -175,11 +175,9 @@
               :address loopback-address}))))
 
 ;; Parse a line from engine output to extract engine version info.
-(defn parse-engine-version-line [output]
-  (some (fn [line]
-          (when-let [[_ version sha] (re-find #"INFO:ENGINE: Defold Engine ([^\s]+) \(([^)]+)\)" line)]
-            line))
-        (split-lines output)))
+(defn parse-engine-version-line [line]
+  (when (re-find #"INFO:ENGINE: Defold Engine ([^\s]+) \(([^)]+)\)" line)
+    line))
 
 (defn- dmengine-filename
   ^String [^String platform]

--- a/editor/src/clj/editor/targets.clj
+++ b/editor/src/clj/editor/targets.clj
@@ -114,27 +114,21 @@
       (callback url)
       (add-watch launched-targets [::url id callback] (url-watcher id callback)))))
 
-(defn update-launched-target! [target target-info on-service-url-found]
-  (let [old @launched-targets]
+(defn update-launched-target! [target target-info]
+  (let [old @launched-targets
+        result-target (volatile! nil)]
     (reset! launched-targets
             (map (fn [launched-target]
                    (if (= (:id launched-target) (:id target))
-                     (let [result-target (merge launched-target target-info)]
-                       (when (and (:url target-info) (not (:url launched-target)))
-                         (future
-                           ;; Wait for the console stream to be marked as active
-                           (loop []
-                             (if (console/current-stream? (:log-stream result-target))
-                               (on-service-url-found result-target)
-                               (do
-                                 (Thread/sleep 100)
-                                 (recur))))))
-                       result-target)
+                     (let [rt (merge launched-target target-info)]
+                       (vreset! result-target rt)
+                       rt)
                      launched-target))
                  old))
     (when (not= old @launched-targets)
       (clear-selected-target-hint!)
-      (invalidate-target-menu!))))
+      (invalidate-target-menu!))
+    @result-target))
 
 (defn launched-targets? []
   (seq @launched-targets))


### PR DESCRIPTION
If the window resolution has been set in the Editor, it will be applied again when the engine is restarted from the Editor using Build To Target.

Fix https://github.com/defold/defold/issues/10670