### PR TITLE
Sanitize float values and escape strings for valid JSON output in scene graph dump

### DIFF
--- a/engine/engine/src/engine_service.cpp
+++ b/engine/engine/src/engine_service.cpp
@@ -816,7 +816,12 @@ namespace dmEngineService
                 case '\n': SendText(request, "\\n"); break;
                 case '\r': SendText(request, "\\r"); break;
                 case '\t': SendText(request, "\\t"); break;
-                default: SendText(request, (char[2]){*p, 0});
+                default:
+                {
+                    char buf[2] = {*p, 0};
+                    SendText(request, buf);
+                    break;
+                }
             }
         }
         SendText(request, "\"");

--- a/engine/engine/src/engine_service.cpp
+++ b/engine/engine/src/engine_service.cpp
@@ -829,7 +829,7 @@ namespace dmEngineService
 
     static float JsonSafeFloat(float f)
     {
-        return isfinite(f) ? f : 0.0f;
+        return isfinite(f) ? f : std::numeric_limits<float>::max();
     }
 
     static void OutputJsonProperty(dmGameObject::SceneNodeProperty* property, dmWebServer::Request* request, int indent)

--- a/engine/engine/src/engine_service.cpp
+++ b/engine/engine/src/engine_service.cpp
@@ -14,7 +14,7 @@
 
 #include <stdint.h>
 #include <string.h>
-#include <limits>
+#include <float.h>
 #include <dlib/webserver.h>
 #include <dlib/message.h>
 #include <dlib/dstrings.h>
@@ -830,7 +830,7 @@ namespace dmEngineService
 
     static float JsonSafeFloat(float f)
     {
-        return isfinite(f) ? f : std::numeric_limits<float>::max();
+        return isfinite(f) ? f : FLT_MAX;
     }
 
     static void OutputJsonProperty(dmGameObject::SceneNodeProperty* property, dmWebServer::Request* request, int indent)

--- a/engine/engine/src/engine_service.cpp
+++ b/engine/engine/src/engine_service.cpp
@@ -804,6 +804,29 @@ namespace dmEngineService
             dmWebServer::Send(request, buf, sizeof(buf));
     }
 
+    static void SendJsonEscapedText(dmWebServer::Request* request, const char* text)
+    {
+        SendText(request, "\"");
+        for (const char* p = text; *p; ++p)
+        {
+            switch (*p)
+            {
+                case '\"': SendText(request, "\\\""); break;
+                case '\\': SendText(request, "\\\\"); break;
+                case '\n': SendText(request, "\\n"); break;
+                case '\r': SendText(request, "\\r"); break;
+                case '\t': SendText(request, "\\t"); break;
+                default: SendText(request, (char[2]){*p, 0});
+            }
+        }
+        SendText(request, "\"");
+    }
+
+    static float JsonSafeFloat(float f)
+    {
+        return isfinite(f) ? f : 0.0f;
+    }
+
     static void OutputJsonProperty(dmGameObject::SceneNodeProperty* property, dmWebServer::Request* request, int indent)
     {
         SendIndent(request, indent);
@@ -825,13 +848,22 @@ namespace dmEngineService
                     dmSnPrintf(buffer, sizeof(buffer), "\"0x%016llX\"", (unsigned long long)property->m_Value.m_Hash);
             }
             break;
-        case dmGameObject::SCENE_NODE_PROPERTY_TYPE_NUMBER: dmSnPrintf(buffer, sizeof(buffer), "%f", property->m_Value.m_Number); break;
+        case dmGameObject::SCENE_NODE_PROPERTY_TYPE_NUMBER: dmSnPrintf(buffer, sizeof(buffer), "%f", JsonSafeFloat(property->m_Value.m_Number)); break;
         case dmGameObject::SCENE_NODE_PROPERTY_TYPE_BOOLEAN: dmSnPrintf(buffer, sizeof(buffer), "%d", property->m_Value.m_Bool?1:0); break;
-        case dmGameObject::SCENE_NODE_PROPERTY_TYPE_VECTOR3: dmSnPrintf(buffer, sizeof(buffer), "[%f, %f, %f]", property->m_Value.m_V4[0], property->m_Value.m_V4[1], property->m_Value.m_V4[2]); break;
-        case dmGameObject::SCENE_NODE_PROPERTY_TYPE_VECTOR4: dmSnPrintf(buffer, sizeof(buffer), "[%f, %f, %f, %f]", property->m_Value.m_V4[0], property->m_Value.m_V4[1], property->m_Value.m_V4[2], property->m_Value.m_V4[3]); break;
-        case dmGameObject::SCENE_NODE_PROPERTY_TYPE_QUAT: dmSnPrintf(buffer, sizeof(buffer), "[%f, %f, %f, %f]", property->m_Value.m_V4[0], property->m_Value.m_V4[1], property->m_Value.m_V4[2], property->m_Value.m_V4[3]); break;
+        case dmGameObject::SCENE_NODE_PROPERTY_TYPE_VECTOR3: dmSnPrintf(buffer, sizeof(buffer), "[%f, %f, %f]",
+            JsonSafeFloat(property->m_Value.m_V4[0]),
+            JsonSafeFloat(property->m_Value.m_V4[1]),
+            JsonSafeFloat(property->m_Value.m_V4[2]));
+            break;
+        case dmGameObject::SCENE_NODE_PROPERTY_TYPE_VECTOR4:
+        case dmGameObject::SCENE_NODE_PROPERTY_TYPE_QUAT: dmSnPrintf(buffer, sizeof(buffer), "[%f, %f, %f, %f]",
+            JsonSafeFloat(property->m_Value.m_V4[0]),
+            JsonSafeFloat(property->m_Value.m_V4[1]),
+            JsonSafeFloat(property->m_Value.m_V4[2]),
+            JsonSafeFloat(property->m_Value.m_V4[3]));
+            break;
         case dmGameObject::SCENE_NODE_PROPERTY_TYPE_URL: dmSnPrintf(buffer, sizeof(buffer), "\"%s\"", property->m_Value.m_URL); break;
-        case dmGameObject::SCENE_NODE_PROPERTY_TYPE_TEXT: SendText(request, "\""); SendText(request, property->m_Value.m_Text); SendText(request, "\""); break;
+        case dmGameObject::SCENE_NODE_PROPERTY_TYPE_TEXT: SendJsonEscapedText(request, property->m_Value.m_Text); break;
         default: break;
         }
 

--- a/engine/engine/src/engine_service.cpp
+++ b/engine/engine/src/engine_service.cpp
@@ -14,6 +14,7 @@
 
 #include <stdint.h>
 #include <string.h>
+#include <limits>
 #include <dlib/webserver.h>
 #include <dlib/message.h>
 #include <dlib/dstrings.h>

--- a/engine/gamesys/src/gamesys/components/comp_sprite.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sprite.cpp
@@ -17,7 +17,6 @@
 #include <string.h>
 #include <float.h>
 #include <algorithm>
-#include <limits>
 
 #include <dlib/array.h>
 #include <dlib/hash.h>

--- a/engine/gamesys/src/gamesys/components/comp_sprite.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sprite.cpp
@@ -2381,16 +2381,13 @@ namespace dmGameSystem
                     type = dmGameObject::SCENE_NODE_PROPERTY_TYPE_VECTOR4;
                     break;
                 case 2:
-                    {
-                        // Since the size is baked into the matrix, we divide by it here
-                        Vector3 size( component->m_Size.getX() * component->m_Scale.getX(), component->m_Size.getY() * component->m_Scale.getY(), 1);
-                        const float epsilon = 1e-6f;
-                        if (fabsf(size.getX()) < epsilon) size.setX(1.0f);
-                        if (fabsf(size.getY()) < epsilon) size.setY(1.0f);
-                        if (fabsf(size.getZ()) < epsilon) size.setZ(1.0f);
-                        value = Vector4(dmVMath::DivPerElem(transform.GetScale(), size));
-                    }
+                {
+                    Matrix4 parent_world = dmGameObject::GetWorldMatrix(component->m_Instance);
+                    Vector3 parent_scale = dmTransform::ToTransform(parent_world).GetScale();
+                    Vector3 world_scale = dmVMath::MulPerElem(parent_scale, component->m_Scale);
+                    value = Vector4(world_scale);
                     break;
+                }
                 case 3:
                     // the size is baked into this matrix as the scale
                     value = Vector4(transform.GetScale());

--- a/engine/gamesys/src/gamesys/components/comp_sprite.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sprite.cpp
@@ -2384,6 +2384,10 @@ namespace dmGameSystem
                     {
                         // Since the size is baked into the matrix, we divide by it here
                         Vector3 size( component->m_Size.getX() * component->m_Scale.getX(), component->m_Size.getY() * component->m_Scale.getY(), 1);
+                        const float epsilon = 1e-6f;
+                        if (fabsf(size.getX()) < epsilon) size.setX(1.0f);
+                        if (fabsf(size.getY()) < epsilon) size.setY(1.0f);
+                        if (fabsf(size.getZ()) < epsilon) size.setZ(1.0f);
                         value = Vector4(dmVMath::DivPerElem(transform.GetScale(), size));
                     }
                     break;

--- a/engine/gamesys/src/gamesys/components/comp_sprite.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sprite.cpp
@@ -17,6 +17,7 @@
 #include <string.h>
 #include <float.h>
 #include <algorithm>
+#include <limits>
 
 #include <dlib/array.h>
 #include <dlib/hash.h>


### PR DESCRIPTION
Fix for non-finite floats and unescaped strings generating invalid JSON output in scene graph dumps.

Fixes #10690 and #10691

Technical changes
- Added a utility to sanitize float values to ensure only valid JSON numbers are output.
- Updated string output to properly escape special characters for JSON compliance.
- Fix sprite world_scale calculation to not be dependent on sprite size.