### PR TITLE
Edit GUI layers using editor scripts

### DIFF
--- a/editor/src/clj/editor/attachment.clj
+++ b/editor/src/clj/editor/attachment.clj
@@ -119,7 +119,7 @@
   [node-type list-kw]
   (-> @state-atom :add (get node-type) (contains? list-kw)))
 
-(defn reorder?
+(defn reorderable?
   "Checks if a node type allows reordering of a list-kw list"
   [node-type list-kw]
   (-> @state-atom :reorder (get node-type) (contains? list-kw)))
@@ -189,7 +189,7 @@
 
   The implementation will assert that the supplied child node ids are the same
   node ids as defined by [[getter]]. It will also assert that the container
-  node-id defines reorder of a list identified by list-kw (see [[reorder?]])"
+  node-id defines reorder of a list identified by list-kw (see [[reorderable?]])"
   [node-id list-kw reordered-child-node-ids]
   (g/expand-ec reorder-tx node-id list-kw reordered-child-node-ids))
 

--- a/editor/src/clj/editor/attachment.clj
+++ b/editor/src/clj/editor/attachment.clj
@@ -22,10 +22,12 @@
 (defonce ^:private state-atom
   ;; :add -> type -> list-kw -> type -> tx-attach-fn
   ;; :get -> type -> list-kw -> get-fn
+  ;; :reorder -> type -> list-kw -> reorder-fn
   ;;
   ;; tx-attach-fn: fn of parent-node, child-node -> txs
   ;; get-fn: fn of node, evaluation-context -> vector of nodes
-  (atom {:add {} :get {}}))
+  ;; reorder-fn: fn of reordered-nodes -> txs
+  (atom {:add {} :get {} :reorder {}}))
 
 (defn register!
   "Register a semantical list of child components
@@ -35,20 +37,25 @@
     list-kw      name of the node component list
 
   Kv-args (at least one is required):
-    :add    a map that defines how new items are added to the list;
-            where keys are child node types used for constructing new nodes, and
-            values are attach functions, i.e. functions of parent-node-id
-            (container) and child-node-id (item) that should return transaction
-            steps that connect the child node into the parent
-    :get    a function that defines how to read a list of children, will receive
-            2 args: parent-node-id (container) and evaluation-context; should
-            return a vector of node ids"
-  [node-type list-kw & {:keys [add get]}]
-  {:pre [(or (ifn? get) (map? add))]}
+    :add        a map that defines how new items are added to the list; where
+                keys are child node types used for constructing new nodes, and
+                values are attach functions, i.e. functions of parent-node-id
+                (container) and child-node-id (item) that should return
+                transaction steps that connect the child node into the parent
+    :get        a function that defines how to read a list of children, will
+                receive 2 args: parent-node-id (container) and
+                evaluation-context; should return a vector of node ids
+    :reorder    a function that defines how to reorder a list of children, will
+                receive 1 arg: reordered-node-ids (vector of item node ids,
+                validated to be the same node ids as those returned by :get);
+                should return transaction steps that set the new order"
+  [node-type list-kw & {:keys [add get reorder]}]
+  {:pre [(or (ifn? get) (map? add) (ifn? reorder))]}
   (swap! state-atom (fn [s]
                       (cond-> s
                               add (update :add update node-type update list-kw merge add)
-                              get (update :get update node-type assoc list-kw get))))
+                              get (update :get update node-type assoc list-kw get)
+                              reorder (update :reorder update node-type assoc list-kw reorder))))
   nil)
 
 (defn add-impl [current-state parent-node-type parent-node-id attachment-tree init-fn]
@@ -112,6 +119,11 @@
   [node-type list-kw]
   (-> @state-atom :add (get node-type) (contains? list-kw)))
 
+(defn reorder?
+  "Checks if a node type allows reordering of a list-kw list"
+  [node-type list-kw]
+  (-> @state-atom :reorder (get node-type) (contains? list-kw)))
+
 (defn child-node-types
   "Returns defined child node-types for a parent node-type's list-kw
 
@@ -160,6 +172,26 @@
   node-id defines a list identified by list-kw (see [[defines?]])"
   [node-id list-kw child-node-id]
   (g/expand-ec remove-tx node-id list-kw child-node-id))
+
+(defn- reorder-tx [evaluation-context node-id list-kw reordered-child-node-ids]
+  (let [basis (:basis evaluation-context)
+        node-type (g/node-type* basis node-id)
+        get-fn (getter node-type list-kw)
+        children-set (set (get-fn node-id evaluation-context))
+        reorder-fn (-> @state-atom :reorder (get node-type) (get list-kw))]
+    (assert (every? children-set reordered-child-node-ids))
+    (assert (= (count children-set) (count reordered-child-node-ids))) ;; no duplicates
+    (assert reorder-fn)
+    (reorder-fn reordered-child-node-ids)))
+
+(defn reorder
+  "Create transaction steps for reordering a list of children
+
+  The implementation will assert that the supplied child node ids are the same
+  node ids as defined by [[getter]]. It will also assert that the container
+  node-id defines reorder of a list identified by list-kw (see [[reorder?]])"
+  [node-id list-kw reordered-child-node-ids]
+  (g/expand-ec reorder-tx node-id list-kw reordered-child-node-ids))
 
 (defn nodes-by-type-getter
   "Create a node list getter using a type filter over the :nodes output

--- a/editor/src/clj/editor/editor_extensions.clj
+++ b/editor/src/clj/editor/editor_extensions.clj
@@ -843,6 +843,7 @@
                                "get" (make-ext-get-fn project)
                                "can_add" (graph/make-ext-can-add-fn project)
                                "can_get" (make-ext-can-get-fn project)
+                               "can_reorder" (graph/make-ext-can-reorder-fn project)
                                "can_set" (make-ext-can-set-fn project)
                                "command" commands/ext-command-fn
                                "create_directory" (make-ext-create-directory-fn project reload-resources!)
@@ -860,7 +861,8 @@
                                "tx" {"set" (make-ext-tx-set-fn project)
                                      "add" (graph/make-ext-add-fn project)
                                      "clear" (graph/make-ext-clear-fn project)
-                                     "remove" (graph/make-ext-remove-fn project)}
+                                     "remove" (graph/make-ext-remove-fn project)
+                                     "reorder" (graph/make-ext-reorder-fn project)}
                                "ui" (assoc
                                       (ui-components/env workspace project project-path)
                                       "open_resource" (make-open-resource-fn workspace open-resource!))

--- a/editor/src/clj/editor/editor_extensions/docs.clj
+++ b/editor/src/clj/editor/editor_extensions/docs.clj
@@ -40,7 +40,8 @@
                              :doc "Resource path (starting with <code>/</code>)"}
         transaction-step-param {:name "tx"
                                 :types ["transaction_step"]
-                                :doc "A transaction step"}]
+                                :doc "A transaction step"}
+        boolean-ret-param {:name "value" :types ["boolean"] :doc ""}]
     (vec
       (e/concat
         [{:name "editor"
@@ -56,24 +57,23 @@
          {:name "editor.can_get"
           :type :function
           :parameters [node-param property-param]
-          :returnvalues [{:name "value"
-                          :types ["boolean"]
-                          :doc ""}]
+          :returnvalues [boolean-ret-param]
           :description "Check if you can get this property so `editor.get()` won't throw an error"}
          {:name "editor.can_add"
           :type :function
           :parameters [node-param property-param]
-          :returnvalues [{:name "value"
-                          :types ["boolean"]
-                          :doc ""}]
+          :returnvalues [boolean-ret-param]
           :description "Check if `editor.tx.add()` (as well as `editor.tx.clear()` and `editor.tx.remove()`) transaction with this property won't throw an error"}
          {:name "editor.can_set"
           :type :function
           :parameters [node-param property-param]
-          :returnvalues [{:name "value"
-                          :types ["boolean"]
-                          :doc ""}]
+          :returnvalues [boolean-ret-param]
           :description "Check if `editor.tx.set()` transaction with this property won't throw an error"}
+         {:name "editor.can_reorder"
+          :type :function
+          :parameters [node-param property-param]
+          :returnvalues [boolean-ret-param]
+          :description "Check if `editor.tx.reorder()` transaction with this property won't throw an error"}
          {:name "editor.command"
           :type :function
           :description "Create an editor command"
@@ -296,6 +296,11 @@ editor.command({
           :parameters [node-param property-param (assoc node-param :name "child_node")]
           :returnvalues [transaction-step-param]
           :description "Create a transaction step that will remove a child node from the node's list property when transacted with `editor.transact()`."}
+         {:name "editor.tx.reorder"
+          :type :function
+          :parameters [node-param property-param {:name "child_nodes" :types ["table"] :doc "array of child nodes (the same as returned by <code>editor.get(node, property)</code>) in new order"}]
+          :returnvalues [transaction-step-param]
+          :description "Create a transaction step that reorders child nodes in a node list defined by the property if supported (see <code>editor.can_reorder()</code>)"}
          {:name "editor.version"
           :type :variable
           :description "A string, version name of Defold"}

--- a/editor/src/clj/editor/editor_extensions/graph.clj
+++ b/editor/src/clj/editor/editor_extensions/graph.clj
@@ -591,7 +591,7 @@
     (let [{:keys [node property]} (rt/->clj rt can-reorder-args-coercer varargs)
           node-id-or-resource (resolve-node-id-or-path node project evaluation-context)]
       (and (not (resource/resource? node-id-or-resource))
-           (attachment/reorder?
+           (attachment/reorderable?
              (g/node-type* (:basis evaluation-context) node-id-or-resource)
              (property->prop-kw property))))))
 
@@ -609,7 +609,7 @@
           reordered-child-node-ids (mapv #(node-id-or-path->node-id % project evaluation-context) children)]
       (when-not (attachment/defines? node-type list-kw)
         (throw (LuaError. (format "%s does not define \"%s\"" (name (:k node-type)) property))))
-      (when-not (attachment/reorder? node-type list-kw)
+      (when-not (attachment/reorderable? node-type list-kw)
         (throw (LuaError. (format "%s does not support \"%s\" reordering" (name (:k node-type)) property))))
       (let [current-child-node-set (set ((attachment/getter node-type list-kw) node-id evaluation-context))]
         (when (or (not (every? current-child-node-set reordered-child-node-ids))

--- a/editor/src/clj/editor/editor_extensions/graph.clj
+++ b/editor/src/clj/editor/editor_extensions/graph.clj
@@ -25,6 +25,7 @@
             [editor.editor-extensions.node-types :as node-types]
             [editor.editor-extensions.tile-map :as tile-map]
             [editor.game-project :as game-project]
+            [editor.gui-attachment :as gui-attachment]
             [editor.id :as id]
             [editor.outline :as outline]
             [editor.properties :as properties]
@@ -477,6 +478,15 @@
           "height" default-capsule-height)
         (attachment->set-tx-steps child-node-id rt project evaluation-context))))
 
+(defmethod init-attachment :editor.gui/LayerNode [evaluation-context rt project parent-node-id _child-node-type child-node-id attachment]
+  (let [layers-node (gui-attachment/scene-node->layers-node (:basis evaluation-context) parent-node-id)]
+    (concat
+      (g/set-property child-node-id :child-index (gui-attachment/next-child-index layers-node evaluation-context))
+      (-> attachment
+          (util/provide-defaults
+            "name" (rt/->lua (id/gen "layer" (g/node-value layers-node :name-counts evaluation-context))))
+          (attachment->set-tx-steps child-node-id rt project evaluation-context)))))
+
 (def ^:private attachment-coercer (coerce/map-of coerce/string coerce/untouched))
 (def ^:private attachments-coercer (coerce/vector-of attachment-coercer))
 
@@ -572,5 +582,41 @@
       (-> (attachment/remove node-id list-kw child-node-id)
           (with-meta {:type :transaction-step})
           (rt/wrap-userdata "editor.tx.remove(...)")))))
+
+(def ^:private can-reorder-args-coercer
+  (coerce/regex :node node-id-or-path-coercer :property coerce/string))
+
+(defn make-ext-can-reorder-fn [project]
+  (rt/varargs-lua-fn ext-can-reorder [{:keys [rt evaluation-context]} varargs]
+    (let [{:keys [node property]} (rt/->clj rt can-reorder-args-coercer varargs)
+          node-id-or-resource (resolve-node-id-or-path node project evaluation-context)]
+      (and (not (resource/resource? node-id-or-resource))
+           (attachment/reorder?
+             (g/node-type* (:basis evaluation-context) node-id-or-resource)
+             (property->prop-kw property))))))
+
+(def ^:private reorder-args-coercer
+  (coerce/regex :node node-id-or-path-coercer
+                :property coerce/string
+                :children (coerce/vector-of node-id-or-path-coercer)))
+
+(defn make-ext-reorder-fn [project]
+  (rt/varargs-lua-fn ext-reorder [{:keys [rt evaluation-context]} varargs]
+    (let [{:keys [node property children]} (rt/->clj rt reorder-args-coercer varargs)
+          node-id (node-id-or-path->node-id node project evaluation-context)
+          node-type (g/node-type* (:basis evaluation-context) node-id)
+          list-kw (property->prop-kw property)
+          reordered-child-node-ids (mapv #(node-id-or-path->node-id % project evaluation-context) children)]
+      (when-not (attachment/defines? node-type list-kw)
+        (throw (LuaError. (format "%s does not define \"%s\"" (name (:k node-type)) property))))
+      (when-not (attachment/reorder? node-type list-kw)
+        (throw (LuaError. (format "%s does not support \"%s\" reordering" (name (:k node-type)) property))))
+      (let [current-child-node-set (set ((attachment/getter node-type list-kw) node-id evaluation-context))]
+        (when (or (not (every? current-child-node-set reordered-child-node-ids))
+                  (not (= (count current-child-node-set) (count reordered-child-node-ids))))
+          (throw (LuaError. "Reordered child nodes are not the same as current child nodes"))))
+      (-> (attachment/reorder node-id list-kw reordered-child-node-ids)
+          (with-meta {:type :transaction-step})
+          (rt/wrap-userdata "editor.tx.reorder(...)")))))
 
 ;; endregion

--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -17,6 +17,7 @@
             [clojure.string :as str]
             [dynamo.graph :as g]
             [editor.app-view :as app-view]
+            [editor.attachment :as attachment]
             [editor.build-target :as bt]
             [editor.colors :as colors]
             [editor.core :as core]
@@ -30,6 +31,7 @@
             [editor.gl.vertex :as vtx]
             [editor.gl.vertex2 :as vtx2]
             [editor.graph-util :as gu]
+            [editor.gui-attachment :as gui-attachment]
             [editor.gui-clipping :as clipping]
             [editor.handler :as handler]
             [editor.id :as id]
@@ -460,19 +462,16 @@
      :else
      (core/scope basis node))))
 
-(defn- next-child-index [child-indices]
-  (inc (reduce max -1 (map second child-indices))))
-
 (defn- gen-gui-node-attach-fn [type]
   (fn [target source]
-    (let [node-tree (node->node-tree target)
-          taken-ids (g/node-value node-tree :id-counts)
-          child-indices (g/node-value target :child-indices)
-          next-index (next-child-index child-indices)]
-      (concat
-        (g/update-property source :id id/resolve taken-ids)
-        (g/set-property source :child-index next-index)
-        (attach-gui-node node-tree target source type)))))
+    (g/with-auto-evaluation-context evaluation-context
+      (let [node-tree (node->node-tree (:basis evaluation-context) target)
+            taken-ids (g/node-value node-tree :id-counts evaluation-context)
+            next-index (gui-attachment/next-child-index target evaluation-context)]
+        (concat
+          (g/update-property source :id id/resolve taken-ids)
+          (g/set-property source :child-index next-index)
+          (attach-gui-node node-tree target source type))))))
 
 ;; SDK api
 (defn gen-outline-node-tx-attach-fn
@@ -1322,8 +1321,6 @@
                                (validate-material-resource _node-id material-infos material)))))
 
   (output visual-base-node-msg g/Any produce-visual-base-node-msg)
-  (output gui-scene g/Any (g/fnk [_node-id]
-                                 (node->gui-scene _node-id)))
   (output material-shader ShaderLifecycle (g/fnk [costly-gui-scene-info material]
                                             (let [material-shaders (:material-shaders costly-gui-scene-info)]
                                               (or (get material-shaders material)
@@ -2691,36 +2688,31 @@
 ;; //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 (defn- attach-layer
-  ([self layers-node layer]
-   (attach-layer self layers-node layer false))
   ;; Self is not used here but added to conform all attach-*** functions
-  ([_self layers-node layer internal?]
-   (concat
+  [_self layers-node layer]
+  (concat
     (g/connect layer :_node-id layers-node :nodes)
-    (when (not internal?)
-      (concat
-       (g/connect layer :pb-msg layers-node :layer-msgs)
-       (g/connect layer :build-errors layers-node :build-errors)
-       (g/connect layer :node-outline layers-node :child-outlines)
-       (g/connect layer :node-id+child-index layers-node :child-indices)
-       (g/connect layer :name+child-index layers-node :indexed-layer-names)
-       (g/connect layers-node :name-counts layer :name-counts))))))
+    (g/connect layer :pb-msg layers-node :layer-msgs)
+    (g/connect layer :build-errors layers-node :build-errors)
+    (g/connect layer :node-outline layers-node :child-outlines)
+    (g/connect layer :node-id+child-index layers-node :child-indices)
+    (g/connect layer :name+child-index layers-node :indexed-layer-names)
+    (g/connect layers-node :name-counts layer :name-counts)))
 
-(defn add-layer [project scene parent name child-index select-fn]
+(defn add-layer [scene parent name child-index select-fn]
   (g/make-nodes (g/node-id->graph-id scene) [node [LayerNode :name name :child-index child-index]]
-    ;; Self is not used when attaching layers
-    (attach-layer nil parent node)
+    (attach-layer scene parent node)
     (when select-fn
       (select-fn [node]))))
 
-(defn- add-layer-handler [project {:keys [scene parent]} select-fn]
-  (let [name (id/gen "layer" (g/node-value parent :name-counts))
-        child-indices (g/node-value parent :child-indices)
-        next-index (next-child-index child-indices)]
-    (g/transact
-     (concat
-      (g/operation-label "Add Layer")
-      (add-layer project scene parent name next-index select-fn)))))
+(defn- add-layer-handler [_project {:keys [scene parent]} select-fn]
+  (g/transact
+    (g/with-auto-evaluation-context evaluation-context
+      (let [name (id/gen "layer" (g/node-value parent :name-counts evaluation-context))
+            next-index (gui-attachment/next-child-index parent evaluation-context)]
+        (concat
+          (g/operation-label "Add Layer")
+          (add-layer scene parent name next-index select-fn))))))
 
 (g/defnode LayersNode
   (inherits core/Scope)
@@ -3476,27 +3468,27 @@
   (get-in tx-entry [:node :_node-id]))
 
 (defn add-gui-node-with-props! [scene parent node-type custom-type props select-fn]
-  (let [node-tree (g/node-value scene :node-tree)
-        id (or (:id props)
-               (id/resolve (subs (name node-type) 5)
-                           (g/node-value node-tree :id-counts)))
-        def-node-type (get-registered-node-type-cls node-type custom-type)
-        child-indices (g/node-value parent :child-indices)
-        next-index (next-child-index child-indices)
-        node-properties (assoc props
-                          :id id
-                          :child-index next-index
-                          :custom-type custom-type
-                          :type node-type)]
-    (-> (concat
-          (g/operation-label "Add Gui Node")
-          (g/make-nodes (g/node-id->graph-id scene) [gui-node [def-node-type node-properties]]
-            (attach-gui-node node-tree parent gui-node node-type)
-            (when select-fn
-              (select-fn [gui-node]))))
-        g/transact
-        g/tx-nodes-added
-        first)))
+  (-> (g/with-auto-evaluation-context evaluation-context
+        (let [node-tree (g/node-value scene :node-tree evaluation-context)
+              id (or (:id props)
+                     (id/resolve (subs (name node-type) 5)
+                                 (g/node-value node-tree :id-counts evaluation-context)))
+              def-node-type (get-registered-node-type-cls node-type custom-type)
+              next-index (gui-attachment/next-child-index parent evaluation-context)
+              node-properties (assoc props
+                                :id id
+                                :child-index next-index
+                                :custom-type custom-type
+                                :type node-type)]
+          (concat
+            (g/operation-label "Add Gui Node")
+            (g/make-nodes (g/node-id->graph-id scene) [gui-node [def-node-type node-properties]]
+              (attach-gui-node node-tree parent gui-node node-type)
+              (when select-fn
+                (select-fn [gui-node]))))))
+      g/transact
+      g/tx-nodes-added
+      first))
 
 (defn add-gui-node! [project scene parent node-type custom-type select-fn]
   ;; TODO: The project argument is unused. Remove.
@@ -3762,10 +3754,8 @@
                                                                      :particlefx (resolve-resource (:particlefx particlefx-desc))]]
                                       (attach-particlefx-resource self particlefx-resources-node particlefx-resource)))))
 
-      (g/make-nodes graph-id [layers-node LayersNode
-                              no-layer [LayerNode
-                                        :name ""]]
-                    (g/connect layers-node :_node-id self :layers-node) ; for the tests :/
+      (g/make-nodes graph-id [layers-node LayersNode]
+                    (g/connect layers-node :_node-id self :layers-node)
                     (g/connect layers-node :_node-id self :nodes)
                     (g/connect layers-node :layer-msgs self :layer-msgs)
                     (g/connect layers-node :layer-names self :layer-names)
@@ -3773,7 +3763,6 @@
                     (g/connect layers-node :build-errors self :build-errors)
                     (g/connect layers-node :node-outline self :child-outlines)
                     (g/connect layers-node :add-handler-info self :handler-infos)
-                    (attach-layer self layers-node no-layer true)
                     (loop [[layer-desc & more] (:layers scene)
                            tx-data []
                            child-index 0]
@@ -3842,6 +3831,22 @@
                       (g/make-nodes graph-id [layout [LayoutNode (dissoc layout-desc :nodes)]]
                         (attach-layout self layouts-node layout))))
       custom-data)))
+
+(defn- attach-gui-scene-layer [{:keys [basis]} scene-node layer-node]
+  (attach-layer scene-node (gui-attachment/scene-node->layers-node basis scene-node) layer-node))
+
+(defn- gui-scene-layers-getter [scene-node {:keys [basis] :as evaluation-context}]
+  (let [layer-nodes (attachment/nodes-getter (gui-attachment/scene-node->layers-node basis scene-node) evaluation-context)]
+    (vec (sort-by #(g/raw-property-value basis % :child-index) layer-nodes))))
+
+(defn- reorder-gui-scene-layers [reordered-layer-node-ids]
+  (coll/mapcat-indexed #(g/set-property %2 :child-index %1) reordered-layer-node-ids))
+
+(attachment/register!
+  GuiSceneNode :layers
+  :add {LayerNode (partial g/expand-ec attach-gui-scene-layer)}
+  :get gui-scene-layers-getter
+  :reorder reorder-gui-scene-layers)
 
 (def default-pb-read-node-color (protobuf/default Gui$NodeDesc :color))
 (def default-pb-read-node-alpha (protobuf/default Gui$NodeDesc :alpha))

--- a/editor/src/clj/editor/gui_attachment.clj
+++ b/editor/src/clj/editor/gui_attachment.clj
@@ -1,0 +1,31 @@
+;; Copyright 2020-2025 The Defold Foundation
+;; Copyright 2014-2020 King
+;; Copyright 2009-2014 Ragnar Svensson, Christian Murray
+;; Licensed under the Defold License version 1.0 (the "License"); you may not use
+;; this file except in compliance with the License.
+;;
+;; You may obtain a copy of the License, together with FAQs at
+;; https://www.defold.com/license
+;;
+;; Unless required by applicable law or agreed to in writing, software distributed
+;; under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+;; CONDITIONS OF ANY KIND, either express or implied. See the License for the
+;; specific language governing permissions and limitations under the License.
+
+(ns editor.gui-attachment
+  (:require [dynamo.graph :as g]
+            [internal.graph.types :as gt]
+            [util.eduction :as e]))
+
+(set! *warn-on-reflection* true)
+(set! *unchecked-math* :warn-on-boxed)
+
+(defn scene-node->layers-node [basis scene-node]
+  (gt/source-id ((g/explicit-arcs-by-target basis scene-node :layers-node) 0)))
+
+(defn next-child-index [parent-node evaluation-context]
+  (->> (g/node-value parent-node :child-indices evaluation-context)
+       (e/map second)
+       (reduce max -1)
+       long
+       inc))

--- a/editor/test/integration/editor_extensions_test.clj
+++ b/editor/test/integration/editor_extensions_test.clj
@@ -1326,6 +1326,28 @@ After transaction (clear):
 Expected errors:
   missing type => type is required
   wrong type => box is not shape-type-box, shape-type-capsule or shape-type-sphere
+GUI initial state:
+  layers: 0
+Transaction: edit GUI
+After transaction (edit):
+  layers: 2
+    layer: bg
+    layer: fg
+can reorder layers: true
+Transaction: reorder
+After transaction (reorder):
+  layers: 2
+    layer: fg
+    layer: bg
+Expected reorder errors:
+  undefined property => GuiSceneNode does not define \"not-a-property\"
+  reorder not defined => CollisionObjectNode does not support \"shapes\" reordering
+  duplicates => Reordered child nodes are not the same as current child nodes
+  missing children => Reordered child nodes are not the same as current child nodes
+  wrong child nodes => Reordered child nodes are not the same as current child nodes
+Transaction: clear GUI
+After transaction (clear):
+  layers: 0
 ")
 
 (deftest attachment-properties-test

--- a/editor/test/integration/gui_clipping_test.clj
+++ b/editor/test/integration/gui_clipping_test.clj
@@ -55,12 +55,12 @@
   (let [n (atom -1)]
     #(swap! n inc)))
 
-(defn- add-layers! [project scene layers]
+(defn- add-layers! [scene layers]
   (let [parent (g/node-value scene :layers-node)
         counter (make-counter)]
     (g/transact
       (for [layer layers]
-        (gui/add-layer project scene parent layer (counter) nil)))))
+        (gui/add-layer scene parent layer (counter) nil)))))
 
 (defn- set-layer! [node-id layer]
   (g/set-property! node-id :layer layer))
@@ -526,7 +526,7 @@
     (let [scene (test-util/resource-node project "/gui/empty.gui")
           a (add-box! project scene nil)
           b (add-box! project scene a)]
-      (add-layers! project scene ["layer1"])
+      (add-layers! scene ["layer1"])
       (set-layer! a "layer1")
       (assert-render-order scene [a b]))))
 
@@ -541,7 +541,7 @@
     (let [scene (test-util/resource-node project "/gui/empty.gui")
           a (add-box! project scene nil)
           b (add-box! project scene a)]
-      (add-layers! project scene ["layer1" "layer2"])
+      (add-layers! scene ["layer1" "layer2"])
       (set-layer! a "layer2")
       (set-layer! b "layer1")
       (assert-render-order scene [b a]))))
@@ -574,7 +574,7 @@
           a (add-clipper! project scene nil false true)
           b (add-box! project scene a)
           c (add-box! project scene nil)]
-      (add-layers! project scene ["layer1"])
+      (add-layers! scene ["layer1"])
       (set-layer! b "layer1")
       (assert-render-order scene [a c b])
       (assert-clipping-order scene a a)
@@ -592,7 +592,7 @@
           a (add-clipper! project scene nil false true)
           b (add-box! project scene a)
           c (add-box! project scene nil)]
-      (add-layers! project scene ["layer1"])
+      (add-layers! scene ["layer1"])
       (set-layer! a "layer1")
       (assert-render-order scene [c a b])
       (assert-clipping-order scene a a)
@@ -610,7 +610,7 @@
           a (add-clipper! project scene nil false true)
           b (add-box! project scene a)
           c (add-box! project scene nil)]
-      (add-layers! project scene ["layer1" "layer2"])
+      (add-layers! scene ["layer1" "layer2"])
       (set-layer! a "layer2")
       (set-layer! b "layer1")
       (assert-render-order scene [c b a])
@@ -628,7 +628,7 @@
           c (add-box! project scene nil)
           a (add-clipper! project scene nil false true)
           b (add-box! project scene a)]
-      (add-layers! project scene ["layer1" "layer2"])
+      (add-layers! scene ["layer1" "layer2"])
       (set-layer! a "layer2")
       (set-layer! b "layer1")
       (assert-render-order scene [c b a])
@@ -646,7 +646,7 @@
           a (add-inv-clipper! project scene nil true)
           b (add-box! project scene a)
           c (add-box! project scene nil)]
-      (add-layers! project scene ["layer1" "layer2"])
+      (add-layers! scene ["layer1" "layer2"])
       (set-layer! a "layer2")
       (set-layer! b "layer1")
       (assert-render-order scene [c b a])
@@ -666,7 +666,7 @@
           a (add-clipper! project scene z false true)
           b (add-box! project scene a)
           c (add-box! project scene z)]
-      (add-layers! project scene ["layer1" "layer2"])
+      (add-layers! scene ["layer1" "layer2"])
       (set-layer! a "layer2")
       (set-layer! b "layer1")
       (assert-render-order scene [z c b a])
@@ -691,7 +691,7 @@
           c (add-box! project scene b)
           d (add-box! project scene a)
           e (add-box! project scene nil)]
-      (add-layers! project scene ["layer1" "layer2" "layer3" "layer4"])
+      (add-layers! scene ["layer1" "layer2" "layer3" "layer4"])
       (set-layer! a "layer2")
       (set-layer! b "layer4")
       (set-layer! c "layer3")
@@ -712,7 +712,7 @@
           a (add-box! project scene nil)
           b (add-clipper! project scene a false true)
           c (add-box! project scene b)]
-      (add-layers! project scene ["layer1" "layer2"])
+      (add-layers! scene ["layer1" "layer2"])
       (set-layer! a "layer2")
       (set-layer! b "layer1")
       (set-layer! c "layer2")
@@ -732,7 +732,7 @@
           b (add-clipper! project scene a false false)
           c (add-box! project scene b)
           d (add-box! project scene b)]
-      (add-layers! project scene ["layer1" "layer2"])
+      (add-layers! scene ["layer1" "layer2"])
       (set-layer! a "layer2")
       (set-layer! c "layer1")
       (assert-render-order scene [c a d]))))

--- a/editor/test/integration/gui_test.clj
+++ b/editor/test/integration/gui_test.clj
@@ -717,7 +717,7 @@
   (first
     (g/tx-nodes-added
       (g/transact
-        (gui/add-layer nil scene (g/node-value scene :layers-node) name index nil)))))
+        (gui/add-layer scene (g/node-value scene :layers-node) name index nil)))))
 
 (defn- add-texture! [scene name resource]
   (first

--- a/editor/test/resources/editor_extensions/transact_attachment_project/test.editor_script
+++ b/editor/test/resources/editor_extensions/transact_attachment_project/test.editor_script
@@ -107,6 +107,15 @@ local function print_collision_object(collision)
     end
 end
 
+local function print_gui(gui)
+    local layers = editor.get(gui, "layers")
+    print(("  layers: %s"):format(#layers))
+    for i = 1, #layers do
+        local layer = layers[i]
+        print(("    layer: %s"):format(editor.get(layer, "name")))
+    end
+end
+
 function M.get_commands()
     return {
         editor.command({
@@ -293,7 +302,42 @@ function M.get_commands()
                 print("Expected errors:")
                 expect_error("missing type", editor.tx.add, collision, "shapes", {})
                 expect_error("wrong type", editor.tx.add, collision, "shapes", {type = "box"})
-                
+
+                local gui = "/test.gui"
+                print("GUI initial state:")
+                print_gui(gui)
+
+                print("Transaction: edit GUI")
+                editor.transact({
+                    editor.tx.add(gui, "layers", {name = "bg"}),
+                    editor.tx.add(gui, "layers", {name = "fg"})
+                })
+
+                print("After transaction (edit):")
+                print_gui(gui)
+
+                print(("can reorder layers: %s"):format(tostring(editor.can_reorder(gui, "layers"))))
+                local bg_layer, fg_layer = table.unpack(editor.get(gui, "layers"))
+                print("Transaction: reorder")
+                editor.transact({
+                    editor.tx.reorder(gui, "layers", {fg_layer, bg_layer})
+                })
+                print("After transaction (reorder):")
+                print_gui(gui)
+                print("Expected reorder errors:")
+                expect_error("undefined property", editor.tx.reorder, gui, "not-a-property", {})
+                expect_error("reorder not defined", editor.tx.reorder, collision, "shapes", {})
+                expect_error("duplicates", editor.tx.reorder, gui, "layers", {fg_layer, fg_layer, bg_layer})
+                expect_error("missing children", editor.tx.reorder, gui, "layers", {fg_layer})
+                expect_error("wrong child nodes", editor.tx.reorder, gui, "layers", {fg_layer, gui})
+
+                print("Transaction: clear GUI")
+                editor.transact({
+                    editor.tx.clear(gui, "layers")
+                })
+
+                print("After transaction (clear):")
+                print_gui(gui)
             end
         })
     }

--- a/editor/test/resources/editor_extensions/transact_attachment_project/test.gui
+++ b/editor/test/resources/editor_extensions/transact_attachment_project/test.gui
@@ -1,0 +1,2 @@
+material: "/builtins/materials/gui.material"
+adjust_reference: ADJUST_REFERENCE_PARENT


### PR DESCRIPTION
Now it's possible to edit GUI layers using editor scripts, e.g.:
```lua
editor.transact({
    editor.tx.add("/main.gui", "layers", {name = "foreground"}),
    editor.tx.add("/main.gui", "layers", {name = "background"})
})
```
Additionally, it's possible to reorder layers:
```lua
local fg, bg = table.unpack(editor.get("/main.gui", "layers"))
editor.transact({
    editor.tx.reorder("/main.gui", "layers", {bg, fg})
})
```

Related to #8504