### PR TITLE
Fix crashes in `sys.load()` when trying to load corrupt files

### DIFF
--- a/engine/script/src/script_table.cpp
+++ b/engine/script/src/script_table.cpp
@@ -182,7 +182,6 @@ namespace dmScript
         bool supported = false;
         switch(header.m_Version)
         {
-        case 0:
         case 1:
         case 2:
         case 3:

--- a/engine/script/src/test/test_script_table.cpp
+++ b/engine/script/src/test/test_script_table.cpp
@@ -121,16 +121,13 @@ TEST_F(LuaTableTest, AttemptReadUnsupportedVersion)
     lua_pop(L, 1);
 }
 
-TEST_F(LuaTableTest, VerifyCosTableOriginal)
+TEST_F(LuaTableTest, DeprecatedVersion0)
 {
     int result = lua_cpcall(L, ReadCosTableDataOriginal, 0x0);
-    ASSERT_EQ(0, result);
-}
+    ASSERT_EQ(LUA_ERRRUN, result);
 
-TEST_F(LuaTableTest, VerifySinTableOriginal)
-{
-    int result = lua_cpcall(L, ReadSinTableDataOriginal, 0x0);
-    ASSERT_EQ(0, result);
+    result = lua_cpcall(L, ReadSinTableDataOriginal, 0x0);
+    ASSERT_EQ(LUA_ERRRUN, result);
 }
 
 


### PR DESCRIPTION
When using `sys.load()` to read from a corrupt file or from a file which wasn't created using `sys.save()` the engine would treat the file as using the legacy save file format from more than 11 years ago. This fallback to loading legacy format files would actually mostly result in engine crashes on corrupt files and cause more problems than it solved. The engine will now ignore such files and throw a Lua error.

Fixes #10765 

## PR checklist

* [x] Code
	* [x] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [x] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [x] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
