### PR TITLE
Added IsURL(), ToURL(), PushURL() and 2 variants of CheckURL() to dmsdk.

### DIFF
--- a/engine/script/src/dmsdk/script/script.h
+++ b/engine/script/src/dmsdk/script/script.h
@@ -460,6 +460,50 @@ namespace dmScript
     const char* GetStringFromHashOrString(lua_State* L, int index, char* buffer, uint32_t bufferlength);
 
     /*#
+     * Check if the value at #index is a URL
+     * @name IsURL
+     * @param L [type:lua_State*] Lua state
+     * @param index [type:int] Index of the value
+     * @return result [type:bool] true if the value at #index is a URL
+     */
+    bool IsURL(lua_State *L, int index);
+
+    /*#
+     * get the value at index as a dmMessage::URL*
+     * @name ToURL
+     * @param L [type:lua_State*] Lua state
+     * @param index [type:int] Index of the value
+     * @return hash [type:dmhash_t*] pointer to URL or 0 if it's not a URL
+     */
+    dmMessage::URL* ToURL(lua_State *L, int index);
+
+    /*#
+     * Push a URL value onto the supplied lua state, will increase the stack by 1.
+     * @name PushURL
+     * @param L [type:lua_State*] Lua state
+     * @param url [type:dmMessage::URL&] URL reference to push
+     */
+    void PushURL(lua_State* L, const dmMessage::URL& url);
+
+    /*#
+     * Check if the value in the supplied index on the lua stack is a dmMessage::URL and returns it if so.
+     * @name CheckURL
+     * @param L [type:lua_State*] Lua state
+     * @param index [type:int] Index of the value
+     * @return url [type:dmMessage::URL*] The pointer to the value
+     */
+    dmMessage::URL* CheckURL(lua_State* L, int index);
+
+    /*#
+     * Get the current game object URL
+     * @name CheckURL
+     * @param L [type:lua_State*] Lua state
+     * @param out_url [type:dmMessage::URL*] where to store the result
+     * @return result [type:bool] true if successful
+     */
+    bool CheckURL(lua_State* L, dmMessage::URL* out_url);
+
+    /*#
      * Push DDF message to Lua stack
      * @name PushDDF
      * @param L [type: lua_State*] the Lua state
@@ -639,15 +683,6 @@ namespace dmScript
      * Lua stack on exit
      */
     void UnrefInInstance(lua_State* L, int ref);
-
-    /*#
-     * Get the current game object URL
-     * @name CheckURL
-     * @param L [type:lua_State*] Lua state
-     * @param out_url [type:dmMessage::URL*] where to store the result
-     * @return result [type:bool] true if successful
-     */
-    bool CheckURL(lua_State* L, dmMessage::URL* out_url);
 
     /*#
      * Resolves the value in the supplied index on the lua stack to a URL. It long jumps (calls luaL_error) on failure.

--- a/engine/script/src/dmsdk/script/script.h
+++ b/engine/script/src/dmsdk/script/script.h
@@ -641,6 +641,15 @@ namespace dmScript
     void UnrefInInstance(lua_State* L, int ref);
 
     /*#
+     * Get the current game object URL
+     * @name CheckURL
+     * @param L [type:lua_State*] Lua state
+     * @param out_url [type:dmMessage::URL*] where to store the result
+     * @return result [type:bool] true if successful
+     */
+    bool CheckURL(lua_State* L, dmMessage::URL* out_url);
+
+    /*#
      * Resolves the value in the supplied index on the lua stack to a URL. It long jumps (calls luaL_error) on failure.
      * It also gets the current (caller) url if the a pointer is passed to `out_default_url`
      * @name ResolveURL

--- a/engine/script/src/script.cpp
+++ b/engine/script/src/script.cpp
@@ -872,6 +872,14 @@ namespace dmScript
         return false;
     }
 
+    bool CheckURL(lua_State* L, dmMessage::URL* out_url) {
+        bool result = GetURL(L, out_url);
+        if (!result) {
+            luaL_error(L, "no URL could be found in the current script environment");
+        }
+        return result;
+    }
+
     bool GetUserData(lua_State* L, uintptr_t* out_user_data, uint32_t user_type_hash) {
         DM_LUA_STACK_CHECK(L, 0);
 

--- a/engine/script/src/script.cpp
+++ b/engine/script/src/script.cpp
@@ -845,7 +845,8 @@ namespace dmScript
         return false;
     }
 
-    bool GetURL(lua_State* L, dmMessage::URL& out_url) {
+    bool GetURL(lua_State* L, dmMessage::URL& out_url)
+    {
         DM_LUA_STACK_CHECK(L, 0);
         GetInstance(L);
 
@@ -872,10 +873,12 @@ namespace dmScript
         return false;
     }
 
-    bool CheckURL(lua_State* L, dmMessage::URL* out_url) {
+    bool CheckURL(lua_State* L, dmMessage::URL* out_url)
+    {
         bool result = GetURL(L, out_url);
-        if (!result) {
-            luaL_error(L, "no URL could be found in the current script environment");
+        if (!result)
+        {
+            return luaL_error(L, "No URL could be found in the current script environment.");
         }
         return result;
     }

--- a/engine/script/src/script_msg.cpp
+++ b/engine/script/src/script_msg.cpp
@@ -52,11 +52,6 @@ namespace dmScript
 
     const uint32_t MAX_MESSAGE_DATA_SIZE = 2048;
 
-    bool IsURL(lua_State *L, int index)
-    {
-        return (dmMessage::URL*)dmScript::ToUserType(L, index, SCRIPT_URL_TYPE_HASH);
-    }
-
     const char* UrlToString(const dmMessage::URL* url, char* buffer, uint32_t buffer_size)
     {
         DM_HASH_REVERSE_MEM(hash_ctx, 512);
@@ -585,6 +580,16 @@ namespace dmScript
         *urlp = url;
         luaL_getmetatable(L, SCRIPT_TYPE_NAME_URL);
         lua_setmetatable(L, -2);
+    }
+
+    bool IsURL(lua_State *L, int index)
+    {
+        return (dmMessage::URL*)dmScript::ToUserType(L, index, SCRIPT_URL_TYPE_HASH);
+    }
+
+    dmMessage::URL* ToURL(lua_State* L, int index)
+    {
+        return (dmMessage::URL*)dmScript::ToUserType(L, index, SCRIPT_URL_TYPE_HASH);
     }
 
     dmMessage::URL* CheckURL(lua_State* L, int index)

--- a/engine/script/src/script_msg.cpp
+++ b/engine/script/src/script_msg.cpp
@@ -584,7 +584,7 @@ namespace dmScript
 
     bool IsURL(lua_State *L, int index)
     {
-        return (dmMessage::URL*)dmScript::ToUserType(L, index, SCRIPT_URL_TYPE_HASH);
+        return dmScript::GetUserType(L, index) == SCRIPT_URL_TYPE_HASH;
     }
 
     dmMessage::URL* ToURL(lua_State* L, int index)


### PR DESCRIPTION
Allows native extensions to have better control over URLs in the lua state.
Closes https://github.com/defold/defold/issues/7220
### Technical changes
* Moved `IsURL()` in `script_msg.cpp` to the other URL related functions. Changed the `IsURL()` implementation to do the same as other [`IsXxx()`](https://github.com/defold/defold/blob/027491c8d5dbe0b592a7d41f348056f902c78113/engine/script/src/script_vmath.cpp#L188) implentations.
* As it stands the URL related implementations are split in [script_msg.cpp](https://github.com/defold/defold/blob/a562970c7fea4e059faf1f57ca704625fa1090ab/engine/script/src/script_msg.cpp#L582) and [script.cpp](https://github.com/defold/defold/blob/a562970c7fea4e059faf1f57ca704625fa1090ab/engine/script/src/script.cpp#L848). For now I put the implementation for CheckURL() in script.cpp because it's so closely related to it. Maybe a better place would be script_msg.cpp because there already is [different variant](https://github.com/defold/defold/blob/a562970c7fea4e059faf1f57ca704625fa1090ab/engine/script/src/script_msg.cpp#L590) of CheckURL().
* The specific use case for this change was getting an absolute URL from a relative URL string, when calling from Lua. The rest (IsURL(), ToURL(), PushURL() and other CheckURL()) of this PR escalated from there. Example of getting an absolute URL:
```
// called from lua
dmMessage::URL sender;
dmMessage::URL absoluteUrl;
if (dmScript::CheckURL(L, &sender)) {
  // lua stack 1: "object#component"
  dmScript::ResolveURL(L, 1, &absoluteUrl, &sender);
}
```