### PR TITLE
Moved GetCollectionByHash() to dmsdk.

### DIFF
--- a/engine/gameobject/src/dmsdk/gameobject/gameobject.h
+++ b/engine/gameobject/src/dmsdk/gameobject/gameobject.h
@@ -536,7 +536,7 @@ namespace dmGameObject
      * @param socket_name [type: dmhash_t] Socket name
      * @return collection [type: dmGameObject::HCollection] The collection the specified instance belongs to
      */
-    HCollection GetCollectionByHash(HRegister register, dmhash_t socket_name);
+    HCollection GetCollectionByHash(HRegister regist, dmhash_t socket_name);
 
     /*#
      * Create a new gameobject instance

--- a/engine/gameobject/src/dmsdk/gameobject/gameobject.h
+++ b/engine/gameobject/src/dmsdk/gameobject/gameobject.h
@@ -533,8 +533,8 @@ namespace dmGameObject
      * Note: in native extensions, the register can be retrieved during init using dmEngine::GetGameObjectRegister(dmExtension::AppParams *params)
      * @name GetCollectionByHash
      * @param regist [type: dmGameObject::HRegister] Register
-     * @param socket_name [type: dmhash_t] Socket name
-     * @return collection [type: dmGameObject::HCollection] The collection the specified instance belongs to
+     * @param socket_name [type: dmhash_t] The socket name
+     * @return collection [type: dmGameObject::HCollection] The collection if successful. 0 otherwise.
      */
     HCollection GetCollectionByHash(HRegister regist, dmhash_t socket_name);
 

--- a/engine/gameobject/src/dmsdk/gameobject/gameobject.h
+++ b/engine/gameobject/src/dmsdk/gameobject/gameobject.h
@@ -529,6 +529,16 @@ namespace dmGameObject
     HCollection GetCollection(HInstance instance);
 
     /*#
+     * Retrieve a collection by socket name hash
+     * Note: in native extensions, the register can be retrieved during init using dmEngine::GetGameObjectRegister(dmExtension::AppParams *params)
+     * @name GetCollectionByHash
+     * @param regist [type: dmGameObject::HRegister] Register
+     * @param socket_name [type: dmhash_t] Socket name
+     * @return collection [type: dmGameObject::HCollection] The collection the specified instance belongs to
+     */
+    HCollection GetCollectionByHash(HRegister register, dmhash_t socket_name);
+
+    /*#
      * Create a new gameobject instance
      * @note Calling this function during update is not permitted. Use #Spawn instead for deferred creation
      * @name New

--- a/engine/gameobject/src/gameobject/gameobject.h
+++ b/engine/gameobject/src/gameobject/gameobject.h
@@ -267,15 +267,6 @@ namespace dmGameObject
     HRegister GetRegister(HCollection collection);
 
     /**
-     * Retrieve a collection from the socket name hash
-     * @param regist The register bound to the specified collection
-     * @param socket_name The name of the socket
-     * @return The game object collection if successful. 0 otherwise.
-     */
-    // Used by comp_collision_object.cpp to do cold lookups of urls
-    HCollection GetCollectionByHash(HRegister regist, dmhash_t socket_name);
-
-    /**
      * Retrieve the frame message socket for the specified collection.
      * @param collection Collection handle
      * @return The frame message socket of the specified collection


### PR DESCRIPTION
Moved GetCollectionByHash() to dmsdk to allow for URLs to be turned into HCollection/HInstance/HComponent.

### Technical changes
* Specific use case: going from absolute URL to collection/instance/component without a lua context.
* Example:
```
// not called from lua
dmGameObject::HCollection collection = dmGameObject::GetCollectionByHash(
    register, absoluteUrl.m_Socket);
dmGameObject::HInstance instance = dmGameObject::GetInstanceFromIdentifier(collection, factoryUrl.m_Path);
dmGameObject::HComponentWorld world;
dmGameObject::HComponent component;
uint32_t componentTypeIndex = 0;
dmGameObject::Result result = dmGameObject::GetComponent(instance, absoluteUrl.m_Fragment, &componentTypeIndex, &component, &world);
```