### PR TITLE
Fixed issue with font cache invalidation

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/font/Fontc.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/font/Fontc.java
@@ -48,7 +48,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.nio.ByteBuffer;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/FontBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/FontBuilder.java
@@ -52,9 +52,8 @@ public class FontBuilder extends ProtoBuilder<FontDesc.Builder> {
 
     @Override
     public void build(Task task) throws CompileExceptionError, IOException {
-        FontDesc.Builder fontDescbuilder = FontDesc.newBuilder();
-        ProtoUtil.merge(task.firstInput(), fontDescbuilder);
-        FontDesc fontDesc = fontDescbuilder.build();
+        FontDesc.Builder builder = getSrcBuilder(task.firstInput());
+        FontDesc fontDesc = builder.build();
 
         BuilderUtil.checkResource(this.project, task.firstInput(), "material", fontDesc.getMaterial());
 

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/FontBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/FontBuilder.java
@@ -16,9 +16,10 @@ package com.dynamo.bob.pipeline;
 
 import java.io.IOException;
 
-import com.dynamo.bob.Builder;
 import com.dynamo.bob.BuilderParams;
 import com.dynamo.bob.CompileExceptionError;
+import com.dynamo.bob.ProtoBuilder;
+import com.dynamo.bob.ProtoParams;
 import com.dynamo.bob.Task;
 import com.dynamo.bob.font.Fontc;
 import com.dynamo.bob.fs.IResource;
@@ -26,14 +27,14 @@ import com.dynamo.bob.fs.IResource;
 import com.dynamo.render.proto.Font.FontDesc;
 import com.dynamo.render.proto.Font.FontMap;
 
+@ProtoParams(srcClass = FontDesc.class, messageClass = FontDesc.class)
 @BuilderParams(name = "Font", inExts = ".font", outExt = ".fontc")
-public class FontBuilder extends Builder  {
+public class FontBuilder extends ProtoBuilder<FontDesc.Builder> {
 
     @Override
     public Task create(IResource input) throws IOException, CompileExceptionError {
-        FontDesc.Builder fontDescbuilder = FontDesc.newBuilder();
-        ProtoUtil.merge(input, fontDescbuilder);
-        FontDesc fontDesc = fontDescbuilder.build();
+        FontDesc.Builder builder = getSrcBuilder(input);
+        FontDesc fontDesc = builder.build();
 
         Task.TaskBuilder taskBuilder = Task.newBuilder(this)
                 .setName(params.name())

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/GlyphBankBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/GlyphBankBuilder.java
@@ -22,25 +22,27 @@ import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.io.IOException;
 
-import com.dynamo.bob.Builder;
 import com.dynamo.bob.BuilderParams;
 import com.dynamo.bob.CompileExceptionError;
+import com.dynamo.bob.ProtoBuilder;
+import com.dynamo.bob.ProtoParams;
 import com.dynamo.bob.Task;
 import com.dynamo.bob.fs.IResource;
 
 import com.dynamo.bob.font.Fontc;
 import com.dynamo.bob.font.Fontc.FontResourceResolver;
+import com.dynamo.render.proto.Font.GlyphBank;
 import com.dynamo.render.proto.Font.FontDesc;
 
+@ProtoParams(srcClass = FontDesc.class, messageClass = GlyphBank.class)
 @BuilderParams(name = "Glyph Bank", inExts = ".glyph_bank", outExt = ".glyph_bankc", isCacheble = true)
-public class GlyphBankBuilder extends Builder {
+public class GlyphBankBuilder extends ProtoBuilder<FontDesc.Builder> {
 
     @Override
     public Task create(IResource input) throws IOException, CompileExceptionError {
 
-    	FontDesc.Builder fontDescbuilder = FontDesc.newBuilder();
-        ProtoUtil.merge(input, fontDescbuilder);
-        FontDesc fontDesc = fontDescbuilder.build();
+    	FontDesc.Builder builder = getSrcBuilder(input);
+        FontDesc fontDesc = builder.build();
 
         File file = new File(fontDesc.getFont());
         String fileNameWithExtension = file.getName();

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/GlyphBankBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/GlyphBankBuilder.java
@@ -61,9 +61,8 @@ public class GlyphBankBuilder extends ProtoBuilder<FontDesc.Builder> {
 
     @Override
     public void build(Task task) throws CompileExceptionError, IOException {
-    	FontDesc.Builder fontDescbuilder = FontDesc.newBuilder();
-        ProtoUtil.merge(task.firstInput(), fontDescbuilder);
-        FontDesc fontDesc = fontDescbuilder.build();
+    	FontDesc.Builder builder = getSrcBuilder(task.firstInput());
+        FontDesc fontDesc = builder.build();
 
         final IResource inputFontFile = BuilderUtil.checkResource(this.project, task.firstInput(), "font", fontDesc.getFont());
         BufferedInputStream fontStream = new BufferedInputStream(new ByteArrayInputStream(inputFontFile.getContent()));


### PR DESCRIPTION
Fixed issue where the cache stayed invalidated after updating to a newer version of Defold where the font or glyph bank output format was changed.  
Usually, it appeared as a `Unable to create resource: /_generated_font_f8188ecab1e82fcc.glyph_bankc: FORMAT_ERROR` and could only be fixed by removing the `build` folder, which is no longer necessary.

Fix https://github.com/defold/defold/issues/10786