### PR TITLE
Edit GUI particlefx resources using editor scripts

### DIFF
--- a/editor/src/clj/editor/editor_extensions/graph.clj
+++ b/editor/src/clj/editor/editor_extensions/graph.clj
@@ -489,16 +489,32 @@
           (attachment->set-tx-steps child-node-id rt project evaluation-context)))))
 
 (defmethod init-attachment :editor.gui/MaterialNode [evaluation-context rt project parent-node-id _ child-node-id attachment]
-  (let [materials-node (gui-attachment/scene-node->materials-node (:basis evaluation-context) parent-node-id)]
-    (-> attachment
-        (util/provide-defaults
-          "name" (rt/->lua
-                   (id/gen
-                     (if-let [lua-material-str (get attachment "material")]
-                       (FilenameUtils/getBaseName (rt/->clj rt coerce/string lua-material-str))
-                       "material")
-                     (g/node-value materials-node :name-counts evaluation-context))))
-        (attachment->set-tx-steps child-node-id rt project evaluation-context))))
+  (-> attachment
+      (util/provide-defaults
+        "name" (rt/->lua
+                 (id/gen
+                   (if-let [lua-material-str (get attachment "material")]
+                     (FilenameUtils/getBaseName (rt/->clj rt coerce/string lua-material-str))
+                     "material")
+                   (-> evaluation-context
+                       :basis
+                       (gui-attachment/scene-node->materials-node parent-node-id)
+                       (g/node-value :name-counts evaluation-context)))))
+      (attachment->set-tx-steps child-node-id rt project evaluation-context)))
+
+(defmethod init-attachment :editor.gui/ParticleFXResource [evaluation-context rt project parent-node-id _ child-node-id attachment]
+  (-> attachment
+      (util/provide-defaults
+        "name" (rt/->lua
+                 (id/gen
+                   (if-let [lua-particlefx-str (get attachment "particlefx")]
+                     (FilenameUtils/getBaseName (rt/->clj rt coerce/string lua-particlefx-str))
+                     "particlefx")
+                   (-> evaluation-context
+                       :basis
+                       (gui-attachment/scene-node->particlefx-resources-node parent-node-id)
+                       (g/node-value :name-counts evaluation-context)))))
+      (attachment->set-tx-steps child-node-id rt project evaluation-context)))
 
 (def ^:private attachment-coercer (coerce/map-of coerce/string coerce/untouched))
 (def ^:private attachments-coercer (coerce/vector-of attachment-coercer))

--- a/editor/src/clj/editor/gui_attachment.clj
+++ b/editor/src/clj/editor/gui_attachment.clj
@@ -20,11 +20,17 @@
 (set! *warn-on-reflection* true)
 (set! *unchecked-math* :warn-on-boxed)
 
+(defn- scene-input-node [basis scene-node input]
+  (gt/source-id ((g/explicit-arcs-by-target basis scene-node input) 0)))
+
 (defn scene-node->layers-node [basis scene-node]
-  (gt/source-id ((g/explicit-arcs-by-target basis scene-node :layers-node) 0)))
+  (scene-input-node basis scene-node :layers-node))
 
 (defn scene-node->materials-node [basis scene-node]
-  (gt/source-id ((g/explicit-arcs-by-target basis scene-node :materials-node) 0)))
+  (scene-input-node basis scene-node :materials-node))
+
+(defn scene-node->particlefx-resources-node [basis scene-node]
+  (scene-input-node basis scene-node :particlefx-resources-node))
 
 (defn next-child-index [parent-node evaluation-context]
   (->> (g/node-value parent-node :child-indices evaluation-context)

--- a/editor/test/integration/editor_extensions_test.clj
+++ b/editor/test/integration/editor_extensions_test.clj
@@ -1329,6 +1329,7 @@ Expected errors:
 GUI initial state:
   layers: 0
   materials: 0
+  particlefxs: 0
 Transaction: edit GUI
 After transaction (edit):
   layers: 2
@@ -1339,6 +1340,10 @@ After transaction (edit):
     material: test /test.material
     material: test1 /test.material
     material: material1
+  particlefxs: 3
+    particlefx: particlefx
+    particlefx: test /test.particlefx
+    particlefx: particlefx1
 can reorder layers: true
 Transaction: reorder
 After transaction (reorder):
@@ -1350,6 +1355,10 @@ After transaction (reorder):
     material: test /test.material
     material: test1 /test.material
     material: material1
+  particlefxs: 3
+    particlefx: particlefx
+    particlefx: test /test.particlefx
+    particlefx: particlefx1
 Expected reorder errors:
   undefined property => GuiSceneNode does not define \"not-a-property\"
   reorder not defined => CollisionObjectNode does not support \"shapes\" reordering
@@ -1360,6 +1369,7 @@ Transaction: clear GUI
 After transaction (clear):
   layers: 0
   materials: 0
+  particlefxs: 0
 ")
 
 (deftest attachment-properties-test

--- a/editor/test/resources/editor_extensions/transact_attachment_project/test.editor_script
+++ b/editor/test/resources/editor_extensions/transact_attachment_project/test.editor_script
@@ -121,6 +121,13 @@ local function print_gui(gui)
         local material_res = editor.get(material, "material")
         print(("    material: %s%s"):format(editor.get(material, "name"), material_res and " " .. material_res or ""))
     end
+    local particlefxs = editor.get(gui, "particlefxs")
+    print(("  particlefxs: %s"):format(#particlefxs))
+    for i = 1, #particlefxs do
+        local particlefx = particlefxs[i]
+        local particlefx_res = editor.get(particlefx, "particlefx")
+        print(("    particlefx: %s%s"):format(editor.get(particlefx, "name"), particlefx_res and " " .. particlefx_res or ""))
+    end
 end
 
 function M.get_commands()
@@ -322,6 +329,9 @@ function M.get_commands()
                     editor.tx.add(gui, "materials", {material = "/test.material"}),
                     editor.tx.add(gui, "materials", {material = "/test.material"}),
                     editor.tx.add(gui, "materials", {}),
+                    editor.tx.add(gui, "particlefxs", {}),
+                    editor.tx.add(gui, "particlefxs", {particlefx = "/test.particlefx"}),
+                    editor.tx.add(gui, "particlefxs", {}),
                 })
 
                 print("After transaction (edit):")
@@ -346,6 +356,7 @@ function M.get_commands()
                 editor.transact({
                     editor.tx.clear(gui, "layers"),
                     editor.tx.clear(gui, "materials"),
+                    editor.tx.clear(gui, "particlefxs")
                 })
 
                 print("After transaction (clear):")


### PR DESCRIPTION
Now it's possible to edit particlefx resources in the GUI using editor scripts, e.g.:
```lua
editor.transact({
    editor.tx.add("/main.gui", "particlefxs", {
        particlefx = "/confetti.particlefx"
    })
})
```

Related to #8504
