### PR TITLE
Fix for potential race condition on Register->m_Collections

### DIFF
--- a/engine/gameobject/src/gameobject/gameobject.cpp
+++ b/engine/gameobject/src/gameobject/gameobject.cpp
@@ -318,6 +318,7 @@ namespace dmGameObject
 
     void DeleteCollections(HRegister regist)
     {
+        DM_MUTEX_SCOPED_LOCK(regist->m_Mutex);
         uint32_t collection_count = regist->m_Collections.Size();
         for (uint32_t i = 0; i < collection_count; ++i)
         {
@@ -332,6 +333,7 @@ namespace dmGameObject
 
     HCollection GetCollectionByHash(HRegister regist, dmhash_t socket_name)
     {
+        DM_MUTEX_SCOPED_LOCK(regist->m_Mutex);
         uint32_t collection_count = regist->m_Collections.Size();
         for (uint32_t i = 0; i < collection_count; ++i)
         {
@@ -2853,6 +2855,7 @@ namespace dmGameObject
 
         bool result = true;
 
+        DM_MUTEX_SCOPED_LOCK(reg->m_Mutex);
         uint32_t collection_count = reg->m_Collections.Size();
         uint32_t i = 0;
         while (i < collection_count)

--- a/engine/gameobject/src/gameobject/gameobject_profile.cpp
+++ b/engine/gameobject/src/gameobject/gameobject_profile.cpp
@@ -200,6 +200,7 @@ static void IterateComponentChildren(SceneNodeIterator* it, SceneNode* node)
 
 bool TraverseGetRoot(HRegister regist, SceneNode* node)
 {
+    DM_MUTEX_SCOPED_LOCK(regist->m_Mutex);
     if (regist->m_Collections.Empty())
         return false;
 


### PR DESCRIPTION
### Technical changes
* I haven't actually observed any issues with `Register->m_Collections` race conditions, I expect these issues to be extremely rare but possible, and may lead to crashes.
* `Register` has a Mutex, I suspect for async collection loading?
* In any case, it implies m_Collections is accessed from different threads.
* Currently not all access to m_Collections is locking the mutex.
* This could lead to race conditions, for example:
  *  A collection [can be moved](https://github.com/defold/defold/blob/bed6b56d2da7adf252cd8fc8fa72de7c40a94399/engine/gameobject/src/gameobject/gameobject.cpp#L478) meanwhile returning the wrong data [somewhere else](https://github.com/defold/defold/blob/bed6b56d2da7adf252cd8fc8fa72de7c40a94399/engine/gameobject/src/gameobject/gameobject.cpp#L343)
* I may well be wrong on this, I haven't check exactly under what conditions from which threads m_Collections is accessed and written to. But generally speaking I would expect locks on all access to a piece of data, not some.
* Extra consideration: [`DeleteCollections()`](https://github.com/defold/defold/blob/bed6b56d2da7adf252cd8fc8fa72de7c40a94399/engine/gameobject/src/gameobject/gameobject.cpp#L331) is now locked, and eventually calls [`DetachCollection()`](https://github.com/defold/defold/blob/bed6b56d2da7adf252cd8fc8fa72de7c40a94399/engine/gameobject/src/gameobject/gameobject.cpp#L465) which also locks the same mutex. This should be fine because [recursive mutex is used, although a note there suggests that may not always be the case...](https://github.com/defold/defold/blob/bed6b56d2da7adf252cd8fc8fa72de7c40a94399/engine/dlib/src/dlib/mutex_posix.cpp#L38)