### PR TITLE
Collision physics messages should be still sent when collision events are disabled in only one of the collision objects

### DIFF
--- a/engine/gamesys/src/gamesys/components/comp_collision_object.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_collision_object.cpp
@@ -552,8 +552,8 @@ namespace dmGameSystem
 
         bool event_supported_a = SupportsEvent(component_a, EVENT_MASK_TRIGGER);
         bool event_supported_b = SupportsEvent(component_b, EVENT_MASK_TRIGGER);
-        if (!event_supported_a && event_supported_a == event_supported_b)
-            return; // Neither supported this event
+        if (!event_supported_a && !event_supported_b)
+            return; // We early out because neither supported this event
 
         dmGameObject::HInstance instance_a = component_a->m_Instance;
         dmGameObject::HInstance instance_b = component_b->m_Instance;
@@ -615,8 +615,8 @@ namespace dmGameSystem
 
             bool event_supported_a = SupportsEvent(component_a, EVENT_MASK_COLLISION);
             bool event_supported_b = SupportsEvent(component_b, EVENT_MASK_COLLISION);
-            if (!event_supported_a && event_supported_a == event_supported_b)
-                return true; // Neither supported this event
+            if (!event_supported_a && !event_supported_b)
+                return true; // We early out because neither supported this event
 
             cud->m_Count += 1;
 
@@ -688,8 +688,8 @@ namespace dmGameSystem
 
             bool event_supported_a = SupportsEvent(component_a, EVENT_MASK_CONTACT);
             bool event_supported_b = SupportsEvent(component_b, EVENT_MASK_CONTACT);
-            if (!event_supported_a && event_supported_a == event_supported_b)
-                return true; // Neither supported this event
+            if (!event_supported_a && !event_supported_b)
+                return true; // We early out because neither supported this event
 
             cud->m_Count += 1;
 

--- a/engine/gamesys/src/gamesys/components/comp_collision_object.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_collision_object.cpp
@@ -616,7 +616,7 @@ namespace dmGameSystem
             bool event_supported_a = SupportsEvent(component_a, EVENT_MASK_COLLISION);
             bool event_supported_b = SupportsEvent(component_b, EVENT_MASK_COLLISION);
             if (!event_supported_a && event_supported_a == event_supported_b)
-                return false; // Neither supported this event
+                return true; // Neither supported this event
 
             cud->m_Count += 1;
 
@@ -689,7 +689,7 @@ namespace dmGameSystem
             bool event_supported_a = SupportsEvent(component_a, EVENT_MASK_CONTACT);
             bool event_supported_b = SupportsEvent(component_b, EVENT_MASK_CONTACT);
             if (!event_supported_a && event_supported_a == event_supported_b)
-                return false; // Neither supported this event
+                return true; // Neither supported this event
 
             cud->m_Count += 1;
 


### PR DESCRIPTION
Fixed a bug where disabling `Generate Collision Events` or `Generate Contact Events` in a collision object could cause collision physics messages to stop being sent in 3D physics for objects where this was not disabled.

Fixes #10796
