### PR TITLE
Edit GUI fonts using editor scripts

### DIFF
--- a/editor/src/clj/editor/editor_extensions/graph.clj
+++ b/editor/src/clj/editor/editor_extensions/graph.clj
@@ -517,6 +517,12 @@
         "name" (gen-gui-component-name attachment "texture" gui-attachment/scene-node->textures-node rt parent-node-id evaluation-context))
       (attachment->set-tx-steps child-node-id rt project evaluation-context)))
 
+(defmethod init-attachment :editor.gui/FontNode [evaluation-context rt project parent-node-id _ child-node-id attachment]
+  (-> attachment
+      (util/provide-defaults
+        "name" (gen-gui-component-name attachment "font" gui-attachment/scene-node->fonts-node rt parent-node-id evaluation-context))
+      (attachment->set-tx-steps child-node-id rt project evaluation-context)))
+
 (def ^:private attachment-coercer (coerce/map-of coerce/string coerce/untouched))
 (def ^:private attachments-coercer (coerce/vector-of attachment-coercer))
 

--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -3846,6 +3846,17 @@
   :add {TextureNode (attach-to-gui-scene-fn gui-attachment/scene-node->textures-node attach-texture)}
   :get gui-scene-texture-nodes-getter)
 
+(defn- gui-scene-font-nodes-getter [scene-node {:keys [basis]}]
+  (let [fonts-node (gui-attachment/scene-node->fonts-node basis scene-node)]
+    ;; NOTE: we use :names instead of :nodes to get a list of fonts because it
+    ;; excludes the internal fallback font
+    (mapv gt/source-id (g/explicit-arcs-by-target basis fonts-node :names))))
+
+(attachment/register!
+  GuiSceneNode :fonts
+  :add {FontNode (attach-to-gui-scene-fn gui-attachment/scene-node->fonts-node attach-font)}
+  :get gui-scene-font-nodes-getter)
+
 (def default-pb-read-node-color (protobuf/default Gui$NodeDesc :color))
 (def default-pb-read-node-alpha (protobuf/default Gui$NodeDesc :alpha))
 (assert (= (float 1.0) default-pb-read-node-alpha))

--- a/editor/src/clj/editor/gui_attachment.clj
+++ b/editor/src/clj/editor/gui_attachment.clj
@@ -35,6 +35,9 @@
 (defn scene-node->textures-node [basis scene-node]
   (scene-input-node basis scene-node :textures-node))
 
+(defn scene-node->fonts-node [basis scene-node]
+  (scene-input-node basis scene-node :fonts-node))
+
 (defn next-child-index [parent-node evaluation-context]
   (->> (g/node-value parent-node :child-indices evaluation-context)
        (e/map second)

--- a/editor/test/integration/editor_extensions_test.clj
+++ b/editor/test/integration/editor_extensions_test.clj
@@ -1331,6 +1331,7 @@ GUI initial state:
   materials: 0
   particlefxs: 0
   textures: 0
+  fonts: 0
 Transaction: edit GUI
 After transaction (edit):
   layers: 2
@@ -1348,6 +1349,10 @@ After transaction (edit):
   textures: 2
     texture: test /test.tilesource
     texture: test1 /test.atlas
+  fonts: 3
+    font: test /test.font
+    font: font
+    font: font1
 can reorder layers: true
 Transaction: reorder
 After transaction (reorder):
@@ -1366,6 +1371,10 @@ After transaction (reorder):
   textures: 2
     texture: test /test.tilesource
     texture: test1 /test.atlas
+  fonts: 3
+    font: test /test.font
+    font: font
+    font: font1
 Expected reorder errors:
   undefined property => GuiSceneNode does not define \"not-a-property\"
   reorder not defined => CollisionObjectNode does not support \"shapes\" reordering
@@ -1378,6 +1387,7 @@ After transaction (clear):
   materials: 0
   particlefxs: 0
   textures: 0
+  fonts: 0
 ")
 
 (deftest attachment-properties-test

--- a/editor/test/resources/editor_extensions/transact_attachment_project/test.editor_script
+++ b/editor/test/resources/editor_extensions/transact_attachment_project/test.editor_script
@@ -135,6 +135,13 @@ local function print_gui(gui)
         local texture_res = editor.get(texture, "texture")
         print(("    texture: %s%s"):format(editor.get(texture, "name"), texture_res and " " .. texture_res or ""))
     end
+    local fonts = editor.get(gui, "fonts")
+    print(("  fonts: %s"):format(#fonts))
+    for i = 1, #fonts do
+        local font = fonts[i]
+        local font_res = editor.get(font, "font")
+        print(("    font: %s%s"):format(editor.get(font, "name"), font_res and " " .. font_res or ""))
+    end
 end
 
 function M.get_commands()
@@ -340,7 +347,10 @@ function M.get_commands()
                     editor.tx.add(gui, "particlefxs", {particlefx = "/test.particlefx"}),
                     editor.tx.add(gui, "particlefxs", {}),
                     editor.tx.add(gui, "textures", {texture = "/test.tilesource"}),
-                    editor.tx.add(gui, "textures", {texture = "/test.atlas"})
+                    editor.tx.add(gui, "textures", {texture = "/test.atlas"}),
+                    editor.tx.add(gui, "fonts", {font = "/test.font"}),
+                    editor.tx.add(gui, "fonts", {}),
+                    editor.tx.add(gui, "fonts", {})
                 })
 
                 print("After transaction (edit):")
@@ -366,7 +376,8 @@ function M.get_commands()
                     editor.tx.clear(gui, "layers"),
                     editor.tx.clear(gui, "materials"),
                     editor.tx.clear(gui, "particlefxs"),
-                    editor.tx.clear(gui, "textures")
+                    editor.tx.clear(gui, "textures"),
+                    editor.tx.clear(gui, "fonts")
                 })
 
                 print("After transaction (clear):")

--- a/editor/test/resources/editor_extensions/transact_attachment_project/test.font
+++ b/editor/test/resources/editor_extensions/transact_attachment_project/test.font
@@ -1,0 +1,4 @@
+font: "/builtins/fonts/vera_mo_bd.ttf"
+material: "/builtins/fonts/font.material"
+size: 15
+characters: " !\"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~"


### PR DESCRIPTION
You can now edit GUI fonts using editor scripts, e.g.:
```lua
editor.transact({
    editor.tx.add("/main.gui", "fonts", {
        name = "font",
        font = "/main.font"
    })
})
```

Related to #8504