### PR TITLE
Make sure that if the user doesn't serialize a table with a hash key, the version of the data remains backward compatible

### DIFF
--- a/engine/script/src/script_private.h
+++ b/engine/script/src/script_private.h
@@ -81,6 +81,18 @@ namespace dmScript
         int                         m_ContextWeakTableRef;
     };
 
+    struct TableHeader
+    {
+        uint32_t m_Magic;
+        uint32_t m_Version;
+
+        TableHeader() : m_Magic(0), m_Version(0)
+        {
+        }
+    };
+
+    const char* ReadHeader(const char* buffer, TableHeader& header);
+
     HContext GetScriptContext(lua_State* L);
 
     bool ResolvePath(lua_State* L, const char* path, uint32_t path_size, dmhash_t& out_hash);

--- a/engine/script/src/script_table.cpp
+++ b/engine/script/src/script_table.cpp
@@ -37,6 +37,8 @@ namespace dmScript
 {
     const int TABLE_MAGIC = 0x42544448;
     const uint32_t TABLE_VERSION_CURRENT = 5;
+    const uint32_t TABLE_VERSION_BASE = 4;
+    const uint32_t TABLE_VERSION_HASH_KEYS_ADDED = TABLE_VERSION_CURRENT;
 
     /*
      * Version 0:
@@ -90,16 +92,6 @@ namespace dmScript
      * Version 5:
      *    Adds support for hash userdata (type LUA_THASH) as keys.
      */
-
-    struct TableHeader
-    {
-        uint32_t m_Magic;
-        uint32_t m_Version;
-
-        TableHeader() : m_Magic(0), m_Version(0)
-        {
-        }
-    };
 
     static bool EncodeMSB(uint32_t value, char*& buffer, const char* buffer_end)
     {
@@ -462,7 +454,7 @@ namespace dmScript
         return size;
     }
 
-    uint32_t DoCheckTable(lua_State* L, const TableHeader& header, const char* original_buffer, char* buffer, uint32_t buffer_size, int index, dmArray<const void*>& table_stack)
+    uint32_t DoCheckTable(lua_State* L, TableHeader& header, const char* original_buffer, char* buffer, uint32_t buffer_size, int index, dmArray<const void*>& table_stack)
     {
         int top = lua_gettop(L);
         (void)top;
@@ -528,6 +520,7 @@ namespace dmScript
             }
             else if (key_hash)
             {
+                header.m_Version = TABLE_VERSION_HASH_KEYS_ADDED;
                 (*buffer++) = (char) LUA_THASH;
                 (*buffer++) = (char) value_type;
             
@@ -751,7 +744,7 @@ namespace dmScript
 
             TableHeader* header = (TableHeader*)buffer;
             header->m_Magic = TABLE_MAGIC;
-            header->m_Version = TABLE_VERSION_CURRENT;
+            header->m_Version = TABLE_VERSION_BASE;
             buffer += sizeof(TableHeader);
             buffer_size -= (buffer - original_buffer);
 
@@ -763,7 +756,7 @@ namespace dmScript
         }
     }
 
-    static const char* ReadHeader(const char* buffer, TableHeader& header)
+    const char* ReadHeader(const char* buffer, TableHeader& header)
     {
         TableHeader* buffered_header = (TableHeader*)buffer;
         if (TABLE_MAGIC == buffered_header->m_Magic) {

--- a/engine/script/src/test/test_script_table.cpp
+++ b/engine/script/src/test/test_script_table.cpp
@@ -22,6 +22,7 @@
 #include <dlib/memory.h>
 
 #include "../script.h"
+#include "../script_private.h"
 #include "test_script.h"
 #include "test_script_private.h"
 #include "test/test_ddf.h"
@@ -657,6 +658,10 @@ TEST_F(LuaTableTest, TSTRING) // binary strings (def2821)
     (void) buffer_used;
     lua_pop(L, 1);
 
+    dmScript::TableHeader header;
+    (void) dmScript::ReadHeader(g_Buf, header);
+    ASSERT_EQ(header.m_Version, 4); // TABLE_VERSION_BASE
+
     dmScript::PushTable(L, g_Buf, sizeof(g_Buf));
 
     lua_getfield(L, -1, "key1");
@@ -693,6 +698,10 @@ TEST_F(LuaTableTest, Vector3)
     (void) buffer_used;
     lua_pop(L, 1);
 
+    dmScript::TableHeader header;
+    (void) dmScript::ReadHeader(g_Buf, header);
+    ASSERT_EQ(header.m_Version, 4); // TABLE_VERSION_BASE
+
     dmScript::PushTable(L, g_Buf, sizeof(g_Buf));
 
     lua_getfield(L, -1, "v");
@@ -720,6 +729,10 @@ TEST_F(LuaTableTest, Vector4)
     uint32_t buffer_used = dmScript::CheckTable(L, g_Buf, sizeof(g_Buf), -1);
     (void) buffer_used;
     lua_pop(L, 1);
+
+    dmScript::TableHeader header;
+    (void) dmScript::ReadHeader(g_Buf, header);
+    ASSERT_EQ(header.m_Version, 4); // TABLE_VERSION_BASE
 
     dmScript::PushTable(L, g_Buf, sizeof(g_Buf));
 
@@ -750,6 +763,10 @@ TEST_F(LuaTableTest, Quat)
     uint32_t buffer_used = dmScript::CheckTable(L, g_Buf, sizeof(g_Buf), -1);
     (void) buffer_used;
     lua_pop(L, 1);
+
+    dmScript::TableHeader header;
+    (void) dmScript::ReadHeader(g_Buf, header);
+    ASSERT_EQ(header.m_Version, 4); // TABLE_VERSION_BASE
 
     dmScript::PushTable(L, g_Buf, sizeof(g_Buf));
 
@@ -785,6 +802,10 @@ TEST_F(LuaTableTest, Matrix4)
     (void) buffer_used;
     lua_pop(L, 1);
 
+    dmScript::TableHeader header;
+    (void) dmScript::ReadHeader(g_Buf, header);
+    ASSERT_EQ(header.m_Version, 4); // TABLE_VERSION_BASE
+
     dmScript::PushTable(L, g_Buf, sizeof(g_Buf));
 
     lua_getfield(L, -1, "v");
@@ -816,6 +837,10 @@ TEST_F(LuaTableTest, Hash)
     (void) buffer_used;
     lua_pop(L, 1);
 
+    dmScript::TableHeader header;
+    (void) dmScript::ReadHeader(g_Buf, header);
+    ASSERT_EQ(header.m_Version, 4); // TABLE_VERSION_HASH_KEYS_ADDED
+
     dmScript::PushTable(L, g_Buf, sizeof(g_Buf));
 
     lua_getfield(L, -1, "h");
@@ -825,6 +850,44 @@ TEST_F(LuaTableTest, Hash)
     lua_pop(L, 1);
 
     lua_pop(L, 1);
+
+    ASSERT_EQ(top, lua_gettop(L));
+}
+
+TEST_F(LuaTableTest, Hashkey)
+{
+    int top = lua_gettop(L);
+
+    // Create table
+    lua_newtable(L);
+
+    dmhash_t hash = dmHashString64("key1");
+    dmScript::PushHash(L, hash);   // key
+    lua_pushnumber(L, 1234);       // value
+    lua_settable(L, -3);           // table[key] = 1234
+
+    // Serialize table into buffer
+    uint32_t buffer_used = dmScript::CheckTable(L, g_Buf, sizeof(g_Buf), -1);
+    (void) buffer_used;
+
+    lua_pop(L, 1); // pop the original table
+
+    // Deserialize table from buffer
+    dmScript::TableHeader header;
+    (void) dmScript::ReadHeader(g_Buf, header);
+    ASSERT_EQ(header.m_Version, 5); // TABLE_VERSION_HASH_KEYS_ADDED
+
+    dmScript::PushTable(L, g_Buf, sizeof(g_Buf));
+    ASSERT_TRUE(lua_istable(L, -1));
+
+    // Push hash key and get the value back
+    dmScript::PushHash(L, hash);
+    lua_gettable(L, -2); // value = table[hash]
+
+    ASSERT_TRUE(lua_isnumber(L, -1));
+    ASSERT_EQ(lua_tonumber(L, -1), 1234);
+
+    lua_pop(L, 2); // pop value and table
 
     ASSERT_EQ(top, lua_gettop(L));
 }
@@ -845,6 +908,10 @@ TEST_F(LuaTableTest, URL)
     uint32_t buffer_used = dmScript::CheckTable(L, g_Buf, sizeof(g_Buf), -1);
     (void) buffer_used;
     lua_pop(L, 1);
+
+    dmScript::TableHeader header;
+    (void) dmScript::ReadHeader(g_Buf, header);
+    ASSERT_EQ(header.m_Version, 4); // TABLE_VERSION_BASE
 
     dmScript::PushTable(L, g_Buf, sizeof(g_Buf));
 


### PR DESCRIPTION
It fixes the issue where a file can't be loaded anymore in Defold 1.10.1 if it was saved in Defold 1.10.2, even if no hash keys were used.