### PR TITLE
Fixed Android debug symbols for vanilla engine

### DIFF
--- a/build_tools/waf_dynamo.py
+++ b/build_tools/waf_dynamo.py
@@ -580,7 +580,8 @@ def default_flags(self):
         # -lsupc++
         self.env.append_value('LINKFLAGS', [
                 '-isysroot=%s' % sysroot,
-                '-static-libstdc++'] + getAndroidLinkFlags(target_arch))
+                '-static-libstdc++',
+                '-Wl,--build-id=uuid'] + getAndroidLinkFlags(target_arch))
     elif TargetOS.WEB == target_os:
 
         emflags_compile = ['DISABLE_EXCEPTION_CATCHING=1']

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
@@ -1284,6 +1284,10 @@ public class Project {
                 case "x86_64-win32":
                     symbolsFilename = String.format("dmengine%s.pdb", variantSuffix);
                     break;
+                case "arm64-android":
+                case "armv7-android":
+                    symbolsFilename = String.format("libdmengine%s.so", variantSuffix);
+                    break;
             }
 
             if (symbolsFilename != null) {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/AndroidBundler.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/AndroidBundler.java
@@ -370,12 +370,12 @@ public class AndroidBundler implements IBundler {
     * Get a list of dex files to include in the aab
     */
     private static ArrayList<File> getClassesDex(Project project) throws IOException {
-        ArrayList<File> classesDex = new ArrayList<File>();
+        ArrayList<File> classesDex = new ArrayList<>();
+        boolean hasExtensions = ExtenderUtil.hasNativeExtensions(project);
 
         final String extenderExeDir = project.getBinaryOutputDirectory();
         for (Platform architecture : getArchitectures(project)) {
-            List<File> bundleExe = ExtenderUtil.getNativeExtensionEngineBinaries(project, architecture);
-            if (bundleExe == null) {
+            if (!hasExtensions) {
                 if (classesDex.isEmpty()) {
                     classesDex.add(new File(Bob.getPath("lib/classes.dex")));
                 }
@@ -606,7 +606,7 @@ public class AndroidBundler implements IBundler {
                     continue;
                 }
                 // files starting with "assets/" and "lib/" should be copied as-is to their respective dirs
-                // other files should be copied to the to the root/ dir
+                // other files should be copied to the root/ dir
                 File file = null;
                 if (filename.startsWith(assetsPath) || filename.startsWith(libPath)) {
                     file = new File(baseDir, filename);
@@ -770,8 +770,8 @@ public class AndroidBundler implements IBundler {
     * Copy debug symbols
     */
     private static void copySymbols(Project project, File outDir, ICanceled canceled) throws IOException, CompileExceptionError {
-        final boolean has_symbols = project.hasOption("with-symbols");
-        if (!has_symbols) {
+        final boolean hasSymbols = project.hasOption("with-symbols");
+        if (!hasSymbols) {
             return;
         }
         File symbolsDir = new File(outDir, getBinaryNameFromProject(project) + ".apk.symbols");


### PR DESCRIPTION
Fixed vanilla engine symbols downloading for Android. Added linker flag to generate build uuid for Android

Fixed #7461 

### Technical changes
Before fix we didn't download any symbols for Android and Linux build. As I understand at some point of time decision was made to store stripped version of binaries inside Bob. As result stripped binary is copied as `symbols` (but it doesn't have symbols).
Fix includes downloading unstripped binary from S3 (if `--with-symbols` flag is passed). If `--strip-executable` flag is passed - unstripped vanilla engine copies as `symbols` to output and then strips.
As side effect if Bob will run with `--with-symbols` but without `--strip-executable` larger binary will be packed into result APK for vanilla engine.

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
