### PR TITLE
Edit GUI layouts using editor scripts

### DIFF
--- a/editor/src/clj/editor/code/script.clj
+++ b/editor/src/clj/editor/code/script.clj
@@ -75,7 +75,7 @@
               (cond
                 escaped (recur (inc i) token in-quote false skip-rest last-non-space tokens)
                 (= ch \\) (recur (inc i) token in-quote true skip-rest last-non-space tokens)
-                (= ch in-quote) (recur (inc i) token nil false skip-rest last-non-space tokens)
+                (= ch (.charValue ^Character in-quote)) (recur (inc i) token nil false skip-rest last-non-space tokens)
                 :else (recur (inc i) token in-quote false skip-rest last-non-space tokens))
 
               ;; Inline comment

--- a/editor/src/clj/editor/editor_extensions/graph.clj
+++ b/editor/src/clj/editor/editor_extensions/graph.clj
@@ -517,10 +517,10 @@
         "name" (gen-gui-component-name attachment "texture" gui-attachment/scene-node->textures-node rt parent-node-id evaluation-context))
       (attachment->set-tx-steps child-node-id rt project evaluation-context)))
 
-(defmethod init-attachment :editor.gui/LayoutNode [evaluation-context rt project _ _ child-node-id attachment]
+(defmethod init-attachment :editor.gui/LayoutNode [evaluation-context rt project parent-node-id _ child-node-id attachment]
   (if-let [lua-name (get attachment "name")]
     (concat
-      (g/set-property child-node-id :name (rt/->clj rt coerce/string lua-name))
+      (g/set-property child-node-id :name (rt/->clj rt (apply coerce/enum (g/node-value parent-node-id :unused-display-profiles evaluation-context)) lua-name))
       (-> attachment
           (dissoc "name")
           (attachment->set-tx-steps child-node-id rt project evaluation-context)))

--- a/editor/src/clj/editor/editor_extensions/graph.clj
+++ b/editor/src/clj/editor/editor_extensions/graph.clj
@@ -517,6 +517,15 @@
         "name" (gen-gui-component-name attachment "texture" gui-attachment/scene-node->textures-node rt parent-node-id evaluation-context))
       (attachment->set-tx-steps child-node-id rt project evaluation-context)))
 
+(defmethod init-attachment :editor.gui/LayoutNode [evaluation-context rt project _ _ child-node-id attachment]
+  (if-let [lua-name (get attachment "name")]
+    (concat
+      (g/set-property child-node-id :name (rt/->clj rt coerce/string lua-name))
+      (-> attachment
+          (dissoc "name")
+          (attachment->set-tx-steps child-node-id rt project evaluation-context)))
+    (throw (LuaError. "layout name is required"))))
+
 (def ^:private attachment-coercer (coerce/map-of coerce/string coerce/untouched))
 (def ^:private attachments-coercer (coerce/vector-of attachment-coercer))
 

--- a/editor/src/clj/editor/gui_attachment.clj
+++ b/editor/src/clj/editor/gui_attachment.clj
@@ -35,6 +35,9 @@
 (defn scene-node->textures-node [basis scene-node]
   (scene-input-node basis scene-node :textures-node))
 
+(defn scene-node->layouts-node [basis scene-node]
+  (scene-input-node basis scene-node :layouts-node))
+
 (defn next-child-index [parent-node evaluation-context]
   (->> (g/node-value parent-node :child-indices evaluation-context)
        (e/map second)

--- a/editor/test/integration/editor_extensions_test.clj
+++ b/editor/test/integration/editor_extensions_test.clj
@@ -1382,6 +1382,8 @@ Expected reorder errors:
 Transaction: clear GUI
 Expected layout errors:
   no name => layout name is required
+  unknown profile => \"Not a profile\" is not \"Landscape\" or \"Portrait\"
+  duplicates => \"Landscape\" is not \"Portrait\"
 After transaction (clear):
   layers: 0
   materials: 0

--- a/editor/test/integration/editor_extensions_test.clj
+++ b/editor/test/integration/editor_extensions_test.clj
@@ -1331,6 +1331,7 @@ GUI initial state:
   materials: 0
   particlefxs: 0
   textures: 0
+  layouts: 0
 Transaction: edit GUI
 After transaction (edit):
   layers: 2
@@ -1348,6 +1349,9 @@ After transaction (edit):
   textures: 2
     texture: test /test.tilesource
     texture: test1 /test.atlas
+  layouts: 2
+    layout: Landscape
+    layout: Portrait
 can reorder layers: true
 Transaction: reorder
 After transaction (reorder):
@@ -1366,6 +1370,9 @@ After transaction (reorder):
   textures: 2
     texture: test /test.tilesource
     texture: test1 /test.atlas
+  layouts: 2
+    layout: Landscape
+    layout: Portrait
 Expected reorder errors:
   undefined property => GuiSceneNode does not define \"not-a-property\"
   reorder not defined => CollisionObjectNode does not support \"shapes\" reordering
@@ -1373,11 +1380,14 @@ Expected reorder errors:
   missing children => Reordered child nodes are not the same as current child nodes
   wrong child nodes => Reordered child nodes are not the same as current child nodes
 Transaction: clear GUI
+Expected layout errors:
+  no name => layout name is required
 After transaction (clear):
   layers: 0
   materials: 0
   particlefxs: 0
   textures: 0
+  layouts: 0
 ")
 
 (deftest attachment-properties-test

--- a/editor/test/resources/editor_extensions/transact_attachment_project/test.editor_script
+++ b/editor/test/resources/editor_extensions/transact_attachment_project/test.editor_script
@@ -135,6 +135,12 @@ local function print_gui(gui)
         local texture_res = editor.get(texture, "texture")
         print(("    texture: %s%s"):format(editor.get(texture, "name"), texture_res and " " .. texture_res or ""))
     end
+    local layouts = editor.get(gui, "layouts")
+    print(("  layouts: %s"):format(#layouts))
+    for i = 1, #layouts do
+        local layout = layouts[i]
+        print(("    layout: %s"):format(editor.get(layout, "name")))
+    end
 end
 
 function M.get_commands()
@@ -332,6 +338,8 @@ function M.get_commands()
                 editor.transact({
                     editor.tx.add(gui, "layers", {name = "bg"}),
                     editor.tx.add(gui, "layers", {name = "fg"}),
+                    editor.tx.add(gui, "layouts", {name = "Landscape"}),
+                    editor.tx.add(gui, "layouts", {name = "Portrait"}),
                     editor.tx.add(gui, "materials", {}),
                     editor.tx.add(gui, "materials", {material = "/test.material"}),
                     editor.tx.add(gui, "materials", {material = "/test.material"}),
@@ -354,6 +362,7 @@ function M.get_commands()
                 })
                 print("After transaction (reorder):")
                 print_gui(gui)
+                
                 print("Expected reorder errors:")
                 expect_error("undefined property", editor.tx.reorder, gui, "not-a-property", {})
                 expect_error("reorder not defined", editor.tx.reorder, collision, "shapes", {})
@@ -364,10 +373,14 @@ function M.get_commands()
                 print("Transaction: clear GUI")
                 editor.transact({
                     editor.tx.clear(gui, "layers"),
+                    editor.tx.clear(gui, "layouts"),
                     editor.tx.clear(gui, "materials"),
                     editor.tx.clear(gui, "particlefxs"),
                     editor.tx.clear(gui, "textures")
                 })
+
+                print("Expected layout errors:")
+                expect_error("no name", editor.transact, {editor.tx.add(gui, "layouts", {})})
 
                 print("After transaction (clear):")
                 print_gui(gui)

--- a/editor/test/resources/editor_extensions/transact_attachment_project/test.editor_script
+++ b/editor/test/resources/editor_extensions/transact_attachment_project/test.editor_script
@@ -381,6 +381,11 @@ function M.get_commands()
 
                 print("Expected layout errors:")
                 expect_error("no name", editor.transact, {editor.tx.add(gui, "layouts", {})})
+                expect_error("unknown profile", editor.transact, {editor.tx.add(gui, "layouts", {name = "Not a profile"})})
+                expect_error("duplicates", editor.transact, {
+                    editor.tx.add(gui, "layouts", {name = "Landscape"}),
+                    editor.tx.add(gui, "layouts", {name = "Landscape"})
+                })
 
                 print("After transaction (clear):")
                 print_gui(gui)


### PR DESCRIPTION
Now you can edit a list of GUI layouts using editor scripts, e.g.:
```lua
editor.transact({
    editor.tx.add("/main.gui", layouts, {name = "Landscape"}),
    editor.tx.add("/main.gui", layouts, {name = "Portrait"})
})
```

Related to #8504