### PR TITLE
Edit GUI spine scenes list using editor scripts

### DIFF
--- a/editor/project.clj
+++ b/editor/project.clj
@@ -163,9 +163,9 @@
                       ;; hide warnings about illegal reflective access by clojure
                       "--add-opens=java.xml/com.sun.org.apache.xerces.internal.jaxp=ALL-UNNAMED"
                       ;; used in editor.scene$read_to_buffered_image
-                      "--add-opens=java.desktop/sun.awt.image=ALL-UNNAMED"
+                      "--add-opens=java.desktop/sun.awt.image=ALL-UNNAMED"]
                       ;; "-XX:MaxJavaStackTraceDepth=1073741823"
-                      ]
+
   :main ^:skip-aot   com.defold.editor.Main
 
   :uberjar-exclusions [#"^natives/"]
@@ -287,7 +287,7 @@
                                 :jvm-opts          ["-Ddefold.extension.lua-preprocessor.url=https://github.com/defold/extension-lua-preprocessor/archive/refs/tags/1.1.3.zip"
                                                     "-Ddefold.extension.rive.url=https://github.com/defold/extension-rive/archive/refs/tags/3.9.0.zip"
                                                     "-Ddefold.extension.simpledata.url=https://github.com/defold/extension-simpledata/archive/refs/tags/v1.1.0.zip"
-                                                    "-Ddefold.extension.spine.url=https://github.com/defold/extension-spine/archive/refs/tags/3.7.0.zip"
+                                                    "-Ddefold.extension.spine.url=https://github.com/defold/extension-spine/archive/refs/heads/issue-8054.zip"
                                                     "-Ddefold.extension.teal.url=https://github.com/defold/extension-teal/archive/refs/tags/v1.2.zip"
                                                     "-Ddefold.extension.texturepacker.url=https://github.com/defold/extension-texturepacker/archive/refs/tags/2.2.0.zip"
                                                     "-Ddefold.unpack.path=tmp/unpack"

--- a/editor/src/clj/dynamo/graph.clj
+++ b/editor/src/clj/dynamo/graph.clj
@@ -601,6 +601,7 @@
   [f & args]
   (it/expand f args))
 
+;; SDK api
 (defn expand-ec
   "Call the specified function when reaching the transaction step with an
   in-transaction evaluation context as a first argument and apply the

--- a/editor/src/clj/editor/collision_object.clj
+++ b/editor/src/clj/editor/collision_object.clj
@@ -688,12 +688,6 @@
   (output collision-group-node g/Any :cached (g/fnk [_node-id group] {:node-id _node-id :collision-group group}))
   (output collision-group-color g/Any :cached produce-collision-group-color))
 
-(attachment/register!
-  CollisionObjectNode :shapes
-  :add {SphereShape attach-shape-node
-        BoxShape attach-shape-node
-        CapsuleShape attach-shape-node}
-  :get attachment/nodes-getter)
 (node-types/register-node-type-name! SphereShape "shape-type-sphere")
 (node-types/register-node-type-name! BoxShape "shape-type-box")
 (node-types/register-node-type-name! CapsuleShape "shape-type-capsule")
@@ -702,19 +696,26 @@
   (strip-empty-embedded-collision-shape collision-object-desc))
 
 (defn register-resource-types [workspace]
-  (resource-node/register-ddf-resource-type workspace
-    :ext "collisionobject"
-    :node-type CollisionObjectNode
-    :ddf-type Physics$CollisionObjectDesc
-    :load-fn load-collision-object
-    :sanitize-fn sanitize-collision-object
-    :icon collision-object-icon
-    :icon-class :design
-    :view-types [:scene :text]
-    :view-opts {:scene {:grid true}}
-    :tags #{:component}
-    :tag-opts {:component {:transform-properties #{}}}
-    :label "Collision Object"))
+  (concat
+    (attachment/register
+      workspace CollisionObjectNode :shapes
+      :add {SphereShape attach-shape-node
+            BoxShape attach-shape-node
+            CapsuleShape attach-shape-node}
+      :get attachment/nodes-getter)
+    (resource-node/register-ddf-resource-type workspace
+      :ext "collisionobject"
+      :node-type CollisionObjectNode
+      :ddf-type Physics$CollisionObjectDesc
+      :load-fn load-collision-object
+      :sanitize-fn sanitize-collision-object
+      :icon collision-object-icon
+      :icon-class :design
+      :view-types [:scene :text]
+      :view-opts {:scene {:grid true}}
+      :tags #{:component}
+      :tag-opts {:component {:transform-properties #{}}}
+      :label "Collision Object")))
 
 ;; outline context menu
 

--- a/editor/src/clj/editor/editor_extensions.clj
+++ b/editor/src/clj/editor/editor_extensions.clj
@@ -129,7 +129,7 @@
     (let [node-id-or-path (rt/->clj rt graph/node-id-or-path-coercer lua-node-id-or-path)
           property (rt/->clj rt coerce/string lua-property)
           node-id-or-resource (graph/resolve-node-id-or-path node-id-or-path project evaluation-context)
-          getter (graph/ext-value-getter node-id-or-resource property evaluation-context)]
+          getter (graph/ext-value-getter node-id-or-resource property project evaluation-context)]
       (if getter
         (getter)
         (throw (LuaError. (str (if (resource/resource? node-id-or-resource)
@@ -144,7 +144,7 @@
     (let [node-id-or-path (rt/->clj rt graph/node-id-or-path-coercer lua-node-id-or-path)
           property (rt/->clj rt coerce/string lua-property)
           node-id-or-resource (graph/resolve-node-id-or-path node-id-or-path project evaluation-context)]
-      (some? (graph/ext-value-getter node-id-or-resource property evaluation-context)))))
+      (some? (graph/ext-value-getter node-id-or-resource property project evaluation-context)))))
 
 (defn- make-ext-can-set-fn [project]
   (rt/lua-fn ext-can-set [{:keys [rt evaluation-context]} lua-node-id-or-path lua-property]

--- a/editor/src/clj/editor/editor_extensions/graph.clj
+++ b/editor/src/clj/editor/editor_extensions/graph.clj
@@ -242,8 +242,9 @@
   Args:
     node-id-or-resource    resolved node id or folder resource
     property               string property name
+    project                the project node id
     evaluation-context     used evaluation context"
-  [node-id-or-resource property evaluation-context]
+  [node-id-or-resource property project evaluation-context]
   (if (resource/resource? node-id-or-resource)
     (case property
       "path" #(resource/proj-path node-id-or-resource)
@@ -265,10 +266,12 @@
             "type" (when-let [type-name (node-types/->name (g/node-type* (:basis evaluation-context) node-id))]
                      (constantly type-name))
             nil)
-          (let [node-type (g/node-type* (:basis evaluation-context) node-id)
+          (let [{:keys [basis]} evaluation-context
+                workspace (project/workspace project evaluation-context)
+                node-type (g/node-type* basis node-id)
                 list-kw (property->prop-kw property)]
-            (when (attachment/defines? node-type list-kw)
-              (let [f (attachment/getter node-type list-kw)]
+            (when (attachment/defines? basis workspace node-type list-kw)
+              (let [f (attachment/getter basis workspace node-type list-kw)]
                 #(mapv rt/wrap-userdata (f node-id evaluation-context)))))))))
 
 ;; endregion
@@ -277,11 +280,11 @@
 
 (defmulti ext-setter
   "Returns a function that receives a LuaValue and returns txs"
-  (fn [node-id property _rt evaluation-context]
+  (fn [node-id property _rt _project evaluation-context]
     [(node-id->type-keyword node-id evaluation-context) property]))
 
 (defmethod ext-setter [:editor.code.resource/CodeEditorResourceNode "text"]
-  [node-id _ rt _]
+  [node-id _ rt _ _]
   (fn [lua-value]
     [(g/set-property node-id :modified-lines (code.util/split-lines (rt/->clj rt coerce/string lua-value)))
      (g/update-property node-id :invalidated-rows conj 0)
@@ -292,16 +295,17 @@
   (coerce/map-of coerce/integer coerce/string))
 
 (defmethod ext-setter [:editor.tile-source/TileSourceNode "tile_collision_groups"]
-  [node-id _ rt _]
+  [node-id _ rt project _]
   (fn [lua-value]
     (let [one-indexed-tile-index->collision-group-id (rt/->clj rt tile-collision-group-coercer lua-value)]
       (g/expand-ec
         (fn [evaluation-context]
           (let [basis (:basis evaluation-context)
+                workspace (project/workspace project evaluation-context)
                 collision-id->node-id
                 (coll/pair-map-by
                   #(g/node-value % :id evaluation-context)
-                  ((attachment/getter (g/node-type* basis node-id) :collision-groups) node-id evaluation-context))
+                  ((attachment/getter basis workspace (g/node-type* basis node-id) :collision-groups) node-id evaluation-context))
                 new-tile->collision-group-node
                 (coll/pair-map-by
                   (comp dec key) ;; 1-indexed to 0-indexed
@@ -315,11 +319,11 @@
 (def ^:private tiles-coercer
   (coerce/wrap-with-pred coerce/userdata #(instance? Tiles %) "is not a tiles datatype"))
 
-(defmethod ext-setter [:editor.tile-map/LayerNode "tiles"] [node-id _ rt _]
+(defmethod ext-setter [:editor.tile-map/LayerNode "tiles"] [node-id _ rt _ _]
   (fn [lua-value]
     (g/set-property node-id :cell-map ((rt/->clj rt tiles-coercer lua-value)))))
 
-(defmethod ext-setter [:editor.particlefx/EmitterNode "animation"] [node-id _ rt _]
+(defmethod ext-setter [:editor.particlefx/EmitterNode "animation"] [node-id _ rt _ _]
   ;; set property directly instead of going through outline so that there is no
   ;; order dependency between setting animation and material
   (fn set-emitter-animation [lua-value]
@@ -328,7 +332,7 @@
 (def ^:private modifier-type-coercer
   (apply coerce/enum (mapv first (protobuf/enum-values Particle$ModifierType))))
 
-(defmethod ext-setter [:editor.particlefx/ModifierNode "type"] [node-id _ rt _]
+(defmethod ext-setter [:editor.particlefx/ModifierNode "type"] [node-id _ rt _ _]
   ;; hidden in the outline, but we want to set it from editor scripts
   (fn set-modifier-type [lua-value]
     (g/set-property node-id :type (rt/->clj rt modifier-type-coercer lua-value))))
@@ -338,8 +342,8 @@
 
   Returns nil if there is no setter for the node-id+property pair"
   [node-id property rt project evaluation-context]
-  (if (fn/multi-responds? ext-setter node-id property rt evaluation-context)
-    (ext-setter node-id property rt evaluation-context)
+  (if (fn/multi-responds? ext-setter node-id property rt project evaluation-context)
+    (ext-setter node-id property rt project evaluation-context)
     (when-let [outline-property (outline-property node-id property evaluation-context)]
       (when-not (properties/read-only? outline-property)
         (when-let [from (-> outline-property
@@ -354,7 +358,8 @@
 
 ;; region attach
 
-(defn- attachment->set-tx-steps [attachment child-node-id rt project evaluation-context]
+;; SDK api
+(defn attachment->set-tx-steps [attachment child-node-id rt project evaluation-context]
   (coll/mapcat
     (fn [[property lua-value]]
       (if-let [setter (ext-lua-value-setter child-node-id property rt project evaluation-context)]
@@ -364,6 +369,7 @@
                                   (name (node-id->type-keyword child-node-id evaluation-context)))))))
     attachment))
 
+;; SDK api
 (defmulti init-attachment
   (fn init-attachment-dispatch-fn [_evaluation-context _rt _project _parent-node-id child-node-type _child-node-id _attachment]
     (:k child-node-type)))
@@ -488,7 +494,8 @@
             "name" (rt/->lua (id/gen "layer" (g/node-value layers-node :name-counts evaluation-context))))
           (attachment->set-tx-steps child-node-id rt project evaluation-context)))))
 
-(defn- gen-gui-component-name [attachment resource-key container-node-fn rt parent-node-id evaluation-context]
+;; SDK api
+(defn gen-gui-component-name [attachment resource-key container-node-fn rt parent-node-id evaluation-context]
   (rt/->lua
     (id/gen
       (if-let [lua-material-str (get attachment resource-key)]
@@ -538,7 +545,7 @@
         (throw (LuaError. (str name " is not " (->> possible-node-types keys (keep node-types/->name) sort (util/join-words ", " " or ")))))))
     (throw (LuaError. "type is required"))))
 
-(defn- parse-attachment [rt possible-node-types attachment]
+(defn- parse-attachment [basis workspace rt possible-node-types attachment]
   (let [requires-explicit-type (< 1 (count possible-node-types))
         node-type (if requires-explicit-type
                     (extract-node-type rt attachment possible-node-types)
@@ -548,11 +555,11 @@
     (reduce-kv
       (fn [acc property lua-value]
         (let [list-kw (property->prop-kw property)]
-          (if (attachment/defines? node-type list-kw)
-            (let [child-node-types (attachment/child-node-types node-type list-kw)]
+          (if (attachment/defines? basis workspace node-type list-kw)
+            (let [child-node-types (attachment/child-node-types basis workspace node-type list-kw)]
               (update acc :add
                       into
-                      (map #(coll/pair list-kw (parse-attachment rt child-node-types %)))
+                      (map #(coll/pair list-kw (parse-attachment basis workspace rt child-node-types %)))
                       (rt/->clj rt attachments-coercer lua-value)))
             (update acc :init assoc property lua-value))))
       tree
@@ -567,13 +574,14 @@
   (rt/varargs-lua-fn ext-add [{:keys [rt evaluation-context]} varargs]
     (let [{:keys [node property attachment]} (rt/->clj rt add-args-coercer varargs)
           {:keys [basis]} evaluation-context
+          workspace (project/workspace project evaluation-context)
           node-id (node-id-or-path->node-id node project evaluation-context)
           node-type (g/node-type* basis node-id)
           list-kw (property->prop-kw property)
-          _ (when-not (attachment/defines? node-type list-kw)
+          _ (when-not (attachment/defines? basis workspace node-type list-kw)
               (throw (LuaError. (format "%s does not define \"%s\"" (name (:k node-type)) property))))
-          tree [[list-kw (parse-attachment rt (attachment/child-node-types node-type list-kw) attachment)]]]
-      (-> (attachment/add basis node-id tree (partial g/expand-ec init-attachment rt project))
+          tree [[list-kw (parse-attachment basis workspace rt (attachment/child-node-types basis workspace node-type list-kw) attachment)]]]
+      (-> (attachment/add basis workspace node-id tree (partial g/expand-ec init-attachment rt project))
           (with-meta {:type :transaction-step})
           (rt/wrap-userdata "editor.tx.add(...)")))))
 
@@ -583,10 +591,13 @@
 (defn make-ext-can-add-fn [project]
   (rt/varargs-lua-fn ext-can-add [{:keys [rt evaluation-context]} varargs]
     (let [{:keys [node property]} (rt/->clj rt can-add-args-coercer varargs)
+          {:keys [basis]} evaluation-context
           node-id-or-resource (resolve-node-id-or-path node project evaluation-context)]
       (and (not (resource/resource? node-id-or-resource))
            (attachment/defines?
-             (g/node-type* (:basis evaluation-context) node-id-or-resource)
+             basis
+             (project/workspace project evaluation-context)
+             (g/node-type* basis node-id-or-resource)
              (property->prop-kw property))))))
 
 (def ^:private clear-args-coercer
@@ -595,12 +606,14 @@
 (defn make-ext-clear-fn [project]
   (rt/varargs-lua-fn ext-clear [{:keys [rt evaluation-context]} varargs]
     (let [{:keys [node property]} (rt/->clj rt clear-args-coercer varargs)
+          {:keys [basis]} evaluation-context
+          workspace (project/workspace project evaluation-context)
           node-id (node-id-or-path->node-id node project evaluation-context)
-          node-type (g/node-type* (:basis evaluation-context) node-id)
+          node-type (g/node-type* basis node-id)
           list-kw (property->prop-kw property)]
-      (when-not (attachment/defines? node-type list-kw)
+      (when-not (attachment/defines? basis workspace node-type list-kw)
         (throw (LuaError. (format "%s does not define \"%s\"" (name (:k node-type)) property))))
-      (-> (attachment/clear node-id list-kw)
+      (-> (attachment/clear workspace node-id list-kw)
           (with-meta {:type :transaction-step})
           (rt/wrap-userdata "editor.tx.clear(...)")))))
 
@@ -610,15 +623,17 @@
 (defn make-ext-remove-fn [project]
   (rt/varargs-lua-fn ext-remove [{:keys [rt evaluation-context]} varargs]
     (let [{:keys [node property child]} (rt/->clj rt remove-args-coercer varargs)
+          {:keys [basis]} evaluation-context
+          workspace (project/workspace project evaluation-context)
           node-id (node-id-or-path->node-id node project evaluation-context)
           child-node-id (node-id-or-path->node-id child project evaluation-context)
-          node-type (g/node-type* (:basis evaluation-context) node-id)
+          node-type (g/node-type* basis node-id)
           list-kw (property->prop-kw property)]
-      (when-not (attachment/defines? node-type list-kw)
+      (when-not (attachment/defines? basis workspace node-type list-kw)
         (throw (LuaError. (format "%s does not define \"%s\"" (name (:k node-type)) property))))
-      (when-not (some #(= child-node-id %) ((attachment/getter node-type list-kw) node-id evaluation-context))
+      (when-not (some #(= child-node-id %) ((attachment/getter basis workspace node-type list-kw) node-id evaluation-context))
         (throw (LuaError. (format "%s is not in the \"%s\" list of %s" child property node))))
-      (-> (attachment/remove node-id list-kw child-node-id)
+      (-> (attachment/remove workspace node-id list-kw child-node-id)
           (with-meta {:type :transaction-step})
           (rt/wrap-userdata "editor.tx.remove(...)")))))
 
@@ -628,10 +643,13 @@
 (defn make-ext-can-reorder-fn [project]
   (rt/varargs-lua-fn ext-can-reorder [{:keys [rt evaluation-context]} varargs]
     (let [{:keys [node property]} (rt/->clj rt can-reorder-args-coercer varargs)
+          {:keys [basis]} evaluation-context
           node-id-or-resource (resolve-node-id-or-path node project evaluation-context)]
       (and (not (resource/resource? node-id-or-resource))
            (attachment/reorderable?
-             (g/node-type* (:basis evaluation-context) node-id-or-resource)
+             basis
+             (project/workspace project evaluation-context)
+             (g/node-type* basis node-id-or-resource)
              (property->prop-kw property))))))
 
 (def ^:private reorder-args-coercer
@@ -642,19 +660,21 @@
 (defn make-ext-reorder-fn [project]
   (rt/varargs-lua-fn ext-reorder [{:keys [rt evaluation-context]} varargs]
     (let [{:keys [node property children]} (rt/->clj rt reorder-args-coercer varargs)
+          {:keys [basis]} evaluation-context
+          workspace (project/workspace project evaluation-context)
           node-id (node-id-or-path->node-id node project evaluation-context)
-          node-type (g/node-type* (:basis evaluation-context) node-id)
+          node-type (g/node-type* basis node-id)
           list-kw (property->prop-kw property)
           reordered-child-node-ids (mapv #(node-id-or-path->node-id % project evaluation-context) children)]
-      (when-not (attachment/defines? node-type list-kw)
+      (when-not (attachment/defines? basis workspace node-type list-kw)
         (throw (LuaError. (format "%s does not define \"%s\"" (name (:k node-type)) property))))
-      (when-not (attachment/reorderable? node-type list-kw)
+      (when-not (attachment/reorderable? basis workspace node-type list-kw)
         (throw (LuaError. (format "%s does not support \"%s\" reordering" (name (:k node-type)) property))))
-      (let [current-child-node-set (set ((attachment/getter node-type list-kw) node-id evaluation-context))]
+      (let [current-child-node-set (set ((attachment/getter basis workspace node-type list-kw) node-id evaluation-context))]
         (when (or (not (every? current-child-node-set reordered-child-node-ids))
                   (not (= (count current-child-node-set) (count reordered-child-node-ids))))
           (throw (LuaError. "Reordered child nodes are not the same as current child nodes"))))
-      (-> (attachment/reorder node-id list-kw reordered-child-node-ids)
+      (-> (attachment/reorder workspace node-id list-kw reordered-child-node-ids)
           (with-meta {:type :transaction-step})
           (rt/wrap-userdata "editor.tx.reorder(...)")))))
 

--- a/editor/src/clj/editor/particlefx.clj
+++ b/editor/src/clj/editor/particlefx.clj
@@ -948,11 +948,6 @@
   (output vertex-attribute-bytes g/Any :cached (g/fnk [_node-id material-attribute-infos vertex-attribute-overrides]
                                                  (graphics/attribute-bytes-by-attribute-key _node-id material-attribute-infos 0 vertex-attribute-overrides))))
 
-(attachment/register!
-  EmitterNode :modifiers
-  :add {ModifierNode attach-modifier}
-  :get attachment/nodes-getter)
-
 (defn- build-pb [resource dep-resources user-data]
   (let [pb  (:pb user-data)
         pb  (reduce (fn [pb [label resource]]
@@ -1085,16 +1080,6 @@
                              :tx-attach-fn (fn [self-id child-id]
                                              (attach-modifier self-id child-id true))}]})))
   (output fetch-anim-fn Runnable :cached (g/fnk [emitter-sim-data] (fn [index] (get emitter-sim-data index)))))
-
-(attachment/register!
-  ParticleFXNode :emitters
-  :add {EmitterNode attach-emitter}
-  :get (attachment/nodes-by-type-getter EmitterNode))
-
-(attachment/register!
-  ParticleFXNode :modifiers
-  :add {ModifierNode attach-modifier}
-  :get (attachment/nodes-by-type-getter ModifierNode))
 
 (defn- make-modifier
   [parent-id modifier node-outline-key]
@@ -1303,19 +1288,32 @@
       (protobuf/sanitize-repeated :modifiers sanitize-modifier)))
 
 (defn register-resource-types [workspace]
-  (resource-node/register-ddf-resource-type workspace
-    :ext particlefx-ext
-    :label "Particle FX"
-    :node-type ParticleFXNode
-    :ddf-type Particle$ParticleFX
-    :load-fn load-particle-fx
-    :sanitize-fn sanitize-particle-fx
-    :icon particle-fx-icon
-    :icon-class :design
-    :tags #{:component :non-embeddable}
-    :tag-opts {:component {:transform-properties #{:position :rotation}}}
-    :view-types [:scene :text]
-    :view-opts {:scene {:grid true}}))
+  (concat
+    (attachment/register
+      workspace EmitterNode :modifiers
+      :add {ModifierNode attach-modifier}
+      :get attachment/nodes-getter)
+    (attachment/register
+      workspace ParticleFXNode :emitters
+      :add {EmitterNode attach-emitter}
+      :get (attachment/nodes-by-type-getter EmitterNode))
+    (attachment/register
+      workspace ParticleFXNode :modifiers
+      :add {ModifierNode attach-modifier}
+      :get (attachment/nodes-by-type-getter ModifierNode))
+    (resource-node/register-ddf-resource-type workspace
+      :ext particlefx-ext
+      :label "Particle FX"
+      :node-type ParticleFXNode
+      :ddf-type Particle$ParticleFX
+      :load-fn load-particle-fx
+      :sanitize-fn sanitize-particle-fx
+      :icon particle-fx-icon
+      :icon-class :design
+      :tags #{:component :non-embeddable}
+      :tag-opts {:component {:transform-properties #{:position :rotation}}}
+      :view-types [:scene :text]
+      :view-opts {:scene {:grid true}})))
 
 (defn- make-pfx-sim [_ data]
   (let [[max-emitter-count max-particle-count rt-pb-data world-transform] data]

--- a/editor/src/clj/editor/tile_map.clj
+++ b/editor/src/clj/editor/tile_map.clj
@@ -725,11 +725,6 @@
   (output save-value g/Any :cached produce-save-value)
   (output build-targets g/Any :cached produce-build-targets))
 
-(attachment/register!
-  TileMapNode :layers
-  :add {LayerNode attach-layer-node}
-  :get attachment/nodes-getter)
-
 ;;--------------------------------------------------------------------
 ;; tool
 
@@ -1553,18 +1548,23 @@
     :command :scene.rotate-brush-90-degrees}])
 
 (defn register-resource-types [workspace]
-  (resource-node/register-ddf-resource-type workspace
-    :ext ["tilemap" "tilegrid"]
-    :build-ext "tilemapc"
-    :node-type TileMapNode
-    :ddf-type Tile$TileGrid
-    :load-fn load-tile-map
-    :sanitize-fn sanitize-tile-map
-    :icon tile-map-icon
-    :icon-class :design
-    :view-types [:scene :text]
-    :view-opts {:scene {:grid tile-map-grid/TileMapGrid
-                        :tool-controller TileMapController}}
-    :tags #{:component :non-embeddable}
-    :tag-opts {:component {:transform-properties #{:position :rotation}}}
-    :label "Tile Map"))
+  (concat
+    (attachment/register
+      workspace TileMapNode :layers
+      :add {LayerNode attach-layer-node}
+      :get attachment/nodes-getter)
+    (resource-node/register-ddf-resource-type workspace
+      :ext ["tilemap" "tilegrid"]
+      :build-ext "tilemapc"
+      :node-type TileMapNode
+      :ddf-type Tile$TileGrid
+      :load-fn load-tile-map
+      :sanitize-fn sanitize-tile-map
+      :icon tile-map-icon
+      :icon-class :design
+      :view-types [:scene :text]
+      :view-opts {:scene {:grid tile-map-grid/TileMapGrid
+                          :tool-controller TileMapController}}
+      :tags #{:component :non-embeddable}
+      :tag-opts {:component {:transform-properties #{:position :rotation}}}
+      :label "Tile Map")))

--- a/editor/src/clj/editor/tile_source.clj
+++ b/editor/src/clj/editor/tile_source.clj
@@ -731,17 +731,6 @@
                     (g/error-fatal (format "the total height ('Tile Height' + 'Tile Margin') is greater than the 'Image' height (%d vs %d)"
                                            total-h h)))))))))
 
-(attachment/register!
-  TileSourceNode :animations
-  :add {TileAnimationNode attach-animation-node}
-  :get (attachment/nodes-by-type-getter TileAnimationNode))
-
-(attachment/register!
-  TileSourceNode :collision-groups
-  :add {CollisionGroupNode attach-collision-group-node}
-  :get (attachment/nodes-by-type-getter CollisionGroupNode))
-
-
 ;;--------------------------------------------------------------------
 ;; tool
 
@@ -1042,14 +1031,23 @@
     ((:action user-data) (selection->tile-source selection) (fn [node-ids] (app-view/select app-view node-ids)))))
 
 (defn register-resource-types [workspace]
-  (resource-node/register-ddf-resource-type workspace
-    :ext ["tilesource" "tileset"]
-    :label "Tile Source"
-    :build-ext "t.texturesetc"
-    :node-type TileSourceNode
-    :ddf-type Tile$TileSet
-    :load-fn load-tile-source
-    :icon tile-source-icon
-    :icon-class :design
-    :view-types [:scene :text]
-    :view-opts {:scene {:tool-controller ToolController}}))
+  (concat
+    (attachment/register
+      workspace TileSourceNode :animations
+      :add {TileAnimationNode attach-animation-node}
+      :get (attachment/nodes-by-type-getter TileAnimationNode))
+    (attachment/register
+      workspace TileSourceNode :collision-groups
+      :add {CollisionGroupNode attach-collision-group-node}
+      :get (attachment/nodes-by-type-getter CollisionGroupNode))
+    (resource-node/register-ddf-resource-type workspace
+      :ext ["tilesource" "tileset"]
+      :label "Tile Source"
+      :build-ext "t.texturesetc"
+      :node-type TileSourceNode
+      :ddf-type Tile$TileSet
+      :load-fn load-tile-source
+      :icon tile-source-icon
+      :icon-class :design
+      :view-types [:scene :text]
+      :view-opts {:scene {:tool-controller ToolController}})))

--- a/editor/src/clj/editor/util.clj
+++ b/editor/src/clj/editor/util.clj
@@ -180,6 +180,7 @@
        m#
        (assoc m# k# ~v))))
 
+;; SDK api
 (defmacro provide-defaults
   "Like assoc, but does nothing if key is already in this map. Evaluates values
   only when key is not present"

--- a/editor/src/clj/editor/workspace.clj
+++ b/editor/src/clj/editor/workspace.clj
@@ -895,6 +895,15 @@ ordinary paths."
   (property editable-proj-path? g/Any)
   (property unloaded-proj-path? g/Any)
   (property resource-kind-extensions g/Any (default {:atlas ["atlas" "tilesource"]}))
+  ;; See editor.attachment ns
+  ;; :add -> type -> list-kw -> type -> tx-attach-fn
+  ;; :get -> type -> list-kw -> get-fn
+  ;; :reorder -> type -> list-kw -> reorder-fn
+  ;;
+  ;; tx-attach-fn: fn of parent-node, child-node -> txs
+  ;; get-fn: fn of node, evaluation-context -> vector of nodes
+  ;; reorder-fn: fn of reordered-nodes -> txs
+  (property node-attachments g/Any (default {:add {} :get {} :reorder {}}))
 
   (input code-preprocessors g/NodeID :cascade-delete)
   (input notifications g/NodeID :cascade-delete)
@@ -904,6 +913,10 @@ ordinary paths."
   (output resource-list g/Any :cached produce-resource-list)
   (output resource-map g/Any :cached produce-resource-map))
 
+(defn node-attachments [basis workspace]
+  (g/raw-property-value basis workspace :node-attachments))
+
+;; SDK api
 (defn register-resource-kind-extension [workspace resource-kind extension]
   (g/update-property
     workspace :resource-kind-extensions

--- a/editor/test/integration/editor_extensions_test.clj
+++ b/editor/test/integration/editor_extensions_test.clj
@@ -1122,7 +1122,7 @@ GET /test/resources/test.json as json => 200
              (run! (fn [{:keys [outline key] :as p}]
                      (let [{:keys [node-id]} outline
                            ext-key (string/replace (name key) \- \_)]
-                       (is (some? (graph/ext-value-getter node-id ext-key ec)))
+                       (is (some? (graph/ext-value-getter node-id ext-key project ec)))
                        (when-not (properties/read-only? p)
                          (is (some? (graph/ext-lua-value-setter node-id ext-key rt project ec))))))))))))
 
@@ -1332,6 +1332,7 @@ GUI initial state:
   particlefxs: 0
   textures: 0
   layouts: 0
+  spine scenes: 0
 Transaction: edit GUI
 After transaction (edit):
   layers: 2
@@ -1352,6 +1353,11 @@ After transaction (edit):
   layouts: 2
     layout: Landscape
     layout: Portrait
+  spine scenes: 4
+    spine scene: spine_scene
+    spine scene: explicit name
+    spine scene: template /defold-spine/assets/template/template.spinescene
+    spine scene: spine_scene1
 can reorder layers: true
 Transaction: reorder
 After transaction (reorder):
@@ -1373,6 +1379,11 @@ After transaction (reorder):
   layouts: 2
     layout: Landscape
     layout: Portrait
+  spine scenes: 4
+    spine scene: spine_scene
+    spine scene: explicit name
+    spine scene: template /defold-spine/assets/template/template.spinescene
+    spine scene: spine_scene1
 Expected reorder errors:
   undefined property => GuiSceneNode does not define \"not-a-property\"
   reorder not defined => CollisionObjectNode does not support \"shapes\" reordering
@@ -1390,6 +1401,7 @@ After transaction (clear):
   particlefxs: 0
   textures: 0
   layouts: 0
+  spine scenes: 0
 ")
 
 (deftest attachment-properties-test

--- a/editor/test/resources/editor_extensions/transact_attachment_project/game.project
+++ b/editor/test/resources/editor_extensions/transact_attachment_project/game.project
@@ -17,4 +17,5 @@ scale_mode = stretch
 
 [project]
 title = transact_attachment_project
+dependencies#0 = {{defold.extension.spine.url}}
 

--- a/editor/test/resources/editor_extensions/transact_attachment_project/test.editor_script
+++ b/editor/test/resources/editor_extensions/transact_attachment_project/test.editor_script
@@ -141,6 +141,13 @@ local function print_gui(gui)
         local layout = layouts[i]
         print(("    layout: %s"):format(editor.get(layout, "name")))
     end
+    local spine_scenes = editor.get(gui, "spine_scenes")
+    print(("  spine scenes: %s"):format(#spine_scenes))
+    for i = 1, #spine_scenes do
+        local spine_scene = spine_scenes[i]
+        local spine_scene_res = editor.get(spine_scene, "spine_scene")
+        print(("    spine scene: %s%s"):format(editor.get(spine_scene, "name"), spine_scene_res and " " .. spine_scene_res or ""))
+    end
 end
 
 function M.get_commands()
@@ -347,6 +354,10 @@ function M.get_commands()
                     editor.tx.add(gui, "particlefxs", {}),
                     editor.tx.add(gui, "particlefxs", {particlefx = "/test.particlefx"}),
                     editor.tx.add(gui, "particlefxs", {}),
+                    editor.tx.add(gui, "spine_scenes", {}),
+                    editor.tx.add(gui, "spine_scenes", {name = "explicit name"}),
+                    editor.tx.add(gui, "spine_scenes", {spine_scene = "/defold-spine/assets/template/template.spinescene"}),
+                    editor.tx.add(gui, "spine_scenes", {}),
                     editor.tx.add(gui, "textures", {texture = "/test.tilesource"}),
                     editor.tx.add(gui, "textures", {texture = "/test.atlas"})
                 })
@@ -376,6 +387,7 @@ function M.get_commands()
                     editor.tx.clear(gui, "layouts"),
                     editor.tx.clear(gui, "materials"),
                     editor.tx.clear(gui, "particlefxs"),
+                    editor.tx.clear(gui, "spine_scenes"),
                     editor.tx.clear(gui, "textures")
                 })
 


### PR DESCRIPTION
Now, when using extension spine, it's possible to edit the list of spine scenes in the GUI:
```lua
editor.transact({
    editor.tx.add("/main.gui", "spine_scenes", {
        spine_scene = "/bg.spinescene"
    }),
})
```

Related to #8504