### PR TITLE
The textures that were set using `go.set()/gui.set()` for the GUI component are internally used as dynamic textures.

### DIFF
--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -2355,7 +2355,12 @@ namespace dmGameSystem
         GuiComponent* component = (GuiComponent*)dmGui::GetSceneUserData(scene);
         char resource_path[dmResource::RESOURCE_PATH_MAX];
         dmhash_t resolved_path_hash = ResolveDynamicTexturePath(component, path_hash, resource_path, sizeof(resource_path));
-        ReleaseDynamicResource(dmGameObject::GetFactory(component->m_Instance), dmGameObject::GetCollection(component->m_Instance), resolved_path_hash);
+        dmResource::HFactory factory = dmGameObject::GetFactory(component->m_Instance);
+        ResourceDescriptor* rd = dmResource::FindByHash(factory, resolved_path_hash);
+        if (rd)
+        {
+            dmResource::Release(factory, dmResource::GetResource(rd));
+        }
     }
 
     static void SetTextureResourceCallback(dmGui::HScene scene, const dmhash_t path_hash, uint32_t width, uint32_t height, dmImage::Type type, const void* buffer)

--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -931,7 +931,7 @@ namespace dmGameSystem
         scene_params.m_UserData = gui_component;
         scene_params.m_MaxFonts = 64;
         scene_params.m_MaxDynamicTextures = scene_desc->m_MaxDynamicTextures;
-        int texture_count = scene_resource->m_GuiTextureSets.Size();
+        uint32_t texture_count = scene_resource->m_GuiTextureSets.Size();
         scene_params.m_MaxTextures = texture_count > 0 ? texture_count : 1;
         scene_params.m_MaxMaterials = 16;
         scene_params.m_MaxAnimations = gui_world->m_MaxAnimationCount;

--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -931,7 +931,8 @@ namespace dmGameSystem
         scene_params.m_UserData = gui_component;
         scene_params.m_MaxFonts = 64;
         scene_params.m_MaxDynamicTextures = scene_desc->m_MaxDynamicTextures;
-        scene_params.m_MaxTextures = 128;
+        int texture_count = scene_resource->m_GuiTextureSets.Size();
+        scene_params.m_MaxTextures = texture_count > 0 ? texture_count : 1;
         scene_params.m_MaxMaterials = 16;
         scene_params.m_MaxAnimations = gui_world->m_MaxAnimationCount;
         scene_params.m_MaxParticlefx = gui_world->m_MaxParticleFXCount;
@@ -2856,7 +2857,7 @@ namespace dmGameSystem
             if (res == dmGameObject::PROPERTY_RESULT_OK)
             {
                 dmGraphics::HTexture texture = texture_source->m_Texture->m_Texture;
-                dmGui::Result r = dmGui::AddTexture(gui_component->m_Scene, params.m_Options.m_Key, (dmGui::HTextureSource) texture_source, dmGui::NODE_TEXTURE_TYPE_TEXTURE_SET, dmGraphics::GetOriginalTextureWidth(texture), dmGraphics::GetOriginalTextureHeight(texture));
+                dmGui::Result r = dmGui::AddDynamicTexture(gui_component->m_Scene, params.m_Options.m_Key, (dmGui::HTextureSource) texture_source, dmGui::NODE_TEXTURE_TYPE_TEXTURE_SET, dmGraphics::GetOriginalTextureWidth(texture), dmGraphics::GetOriginalTextureHeight(texture));
                 if (r != dmGui::RESULT_OK)
                 {
                     dmLogError("Unable to add texture '%s' to scene (%d)", dmHashReverseSafe64(params.m_Options.m_Key),  r);

--- a/engine/gamesys/src/gamesys/gamesys_private.h
+++ b/engine/gamesys/src/gamesys/gamesys_private.h
@@ -182,7 +182,6 @@ namespace dmGameSystem
     void FillTextureResourceBuffer(const dmGraphics::TextureImage* texture_image, dmArray<uint8_t>& texture_resource_buffer);
     dmResource::Result CreateTextureResource(dmResource::HFactory factory, const CreateTextureResourceParams& create_params, void** resource_out);
     dmResource::Result SetTextureResource(dmResource::HFactory factory, const SetTextureResourceParams& params);
-    dmResource::Result ReleaseDynamicResource(dmResource::HFactory factory, dmGameObject::HCollection collection, dmhash_t path_hash);
 }
 
 #endif // DM_GAMESYS_PRIVER_H

--- a/engine/gamesys/src/gamesys/gamesys_resource.cpp
+++ b/engine/gamesys/src/gamesys/gamesys_resource.cpp
@@ -209,7 +209,6 @@ namespace dmGameSystem
         }
 
         assert(create_params.m_Collection);
-        dmGameObject::AddDynamicResourceHash(create_params.m_Collection, create_params.m_PathHash);
         *resource_out = resource;
         return dmResource::RESULT_OK;
     }
@@ -265,20 +264,5 @@ namespace dmGameSystem
         upload_params.m_UploadSpecificMipmap  = 1;
 
         return dmResource::SetResource(factory, params.m_PathHash, (void*) &recreate_params);
-    }
-
-    dmResource::Result ReleaseDynamicResource(dmResource::HFactory factory, dmGameObject::HCollection collection, dmhash_t path_hash)
-    {
-        HResourceDescriptor rd = dmResource::FindByHash(factory, path_hash);
-        if (!rd)
-        {
-            return dmResource::RESULT_RESOURCE_NOT_FOUND;
-        }
-
-        // This will remove the entry in the collections list of dynamically allocated resource (if it exists),
-        // but we do the actual release here since we allow releasing arbitrary resources now
-        dmGameObject::RemoveDynamicResourceHash(collection, path_hash);
-        dmResource::Release(factory, dmResource::GetResource(rd));
-        return dmResource::RESULT_OK;
     }
 }

--- a/engine/gamesys/src/gamesys/scripts/script_resource.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_resource.cpp
@@ -930,6 +930,7 @@ static int CreateTexture(lua_State* L)
         return ReportPathError(L, res, create_params.m_PathHash);
     }
 
+    dmGameObject::AddDynamicResourceHash(create_params.m_Collection, create_params.m_PathHash);
     dmScript::PushHash(L, create_params.m_PathHash);
     assert((top+1) == lua_gettop(L));
     return 1;
@@ -1251,13 +1252,15 @@ static int ReleaseResource(lua_State* L)
 {
     DM_LUA_STACK_CHECK(L, 0);
     dmhash_t path_hash                      = dmScript::CheckHashOrString(L, 1);
+    HResourceDescriptor rd = dmResource::FindByHash(g_ResourceModule.m_Factory, path_hash);
+    if (!rd) {
+        luaL_error(L, "Could not release resource: %s", dmHashReverseSafe64(path_hash));
+        return 0;
+    }
     dmGameObject::HInstance sender_instance = dmScript::CheckGOInstance(L);
     dmGameObject::HCollection collection    = dmGameObject::GetCollection(sender_instance);
-
-    if (ReleaseDynamicResource(g_ResourceModule.m_Factory, collection, path_hash) != dmResource::RESULT_OK)
-    {
-        return DM_LUA_ERROR("Could not release resource: %s", dmHashReverseSafe64(path_hash));
-    }
+    dmGameObject::RemoveDynamicResourceHash(collection, path_hash);
+    dmResource::Release(g_ResourceModule.m_Factory, dmResource::GetResource(rd));
     return 0;
 }
 

--- a/engine/gamesys/src/gamesys/scripts/script_resource.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_resource.cpp
@@ -1254,8 +1254,7 @@ static int ReleaseResource(lua_State* L)
     dmhash_t path_hash                      = dmScript::CheckHashOrString(L, 1);
     HResourceDescriptor rd = dmResource::FindByHash(g_ResourceModule.m_Factory, path_hash);
     if (!rd) {
-        luaL_error(L, "Could not release resource: %s", dmHashReverseSafe64(path_hash));
-        return 0;
+        return luaL_error(L, "Could not release resource: %s", dmHashReverseSafe64(path_hash));
     }
     dmGameObject::HInstance sender_instance = dmScript::CheckGOInstance(L);
     dmGameObject::HCollection collection    = dmGameObject::GetCollection(sender_instance);

--- a/engine/gamesys/src/gamesys/test/gui/gui_max_dynamic_textures.go
+++ b/engine/gamesys/src/gamesys/test/gui/gui_max_dynamic_textures.go
@@ -1,4 +1,4 @@
 components {
   id: "gui"
-  component: "/gui/gui_max_dynamic_textures_256.gui"
+  component: "/gui/gui_max_dynamic_textures_32.gui"
 }

--- a/engine/gamesys/src/gamesys/test/gui/gui_max_dynamic_textures.gui_script
+++ b/engine/gamesys/src/gamesys/test/gui/gui_max_dynamic_textures.gui_script
@@ -12,7 +12,7 @@
 -- CONDITIONS OF ANY KIND, either express or implied. See the License for the
 -- specific language governing permissions and limitations under the License.
 
-MAX_DYNAMIC_TEXTURES = 256
+MAX_DYNAMIC_TEXTURES = 32
 WIDTH = 4
 HEIGHT = 4
 

--- a/engine/gamesys/src/gamesys/test/gui/gui_max_dynamic_textures_32.gui
+++ b/engine/gamesys/src/gamesys/test/gui/gui_max_dynamic_textures_32.gui
@@ -8,4 +8,4 @@ background_color {
 material: "/gui/gui.material"
 adjust_reference: ADJUST_REFERENCE_PARENT
 max_nodes: 512
-max_dynamic_textures: 256
+max_dynamic_textures: 32

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -1583,13 +1583,13 @@ TEST_F(GuiTest, MaxDynamictextures)
 
     dmGui::Scene* scene = gui_comp->m_Scene;
 
-    ASSERT_EQ(256, scene->m_DynamicTextures.Capacity());
+    ASSERT_EQ(32, scene->m_DynamicTextures.Capacity());
     ASSERT_EQ(0, scene->m_DynamicTextures.Size());
 
     // Test 1: create textures
     ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
 
-    ASSERT_EQ(256, scene->m_DynamicTextures.Size());
+    ASSERT_EQ(32, scene->m_DynamicTextures.Size());
 
     // Test 2: delete textures
     ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));

--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -501,6 +501,11 @@ namespace dmGui
         TextureInfo* t = scene->m_DynamicTextures.Get(texture_name_hash);
         if (t)
         {
+            if (t->m_ImageType != -1)
+            {
+                uint32_t buffer_size_mb = t->m_OriginalWidth * t->m_OriginalHeight * dmImage::BytesPerPixel(t->m_ImageType);
+                DM_PROPERTY_ADD_F32(rmtp_GuiDynamicTexturesSizeMb, - buffer_size_mb);
+            }
             scene->m_DeleteTextureResourceCallback(scene, texture_name_hash, t->m_TextureSource);
         }
         return AddTexture(scene, scene->m_DynamicTextures, texture_name_hash, texture_source, texture_type, original_width, original_height, (dmImage::Type) -1);

--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -616,6 +616,11 @@ namespace dmGui
         HTextureSource res = scene->m_NewTextureResourceCallback(scene, path, width, height, type, data);
         free(data);
 
+        if (!res)
+        {
+            return RESULT_OUT_OF_RESOURCES;
+        }
+
         uint32_t buffer_size_mb = expected_buffer_size / 1024.0 / 1024.0;
         DM_PROPERTY_ADD_F32(rmtp_GuiDynamicTexturesSizeMb, buffer_size_mb);
 

--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -496,6 +496,16 @@ namespace dmGui
         return AddTexture(scene, scene->m_Textures, texture_name_hash, texture_source, texture_type, original_width, original_height, (dmImage::Type) -1);
     }
 
+    Result AddDynamicTexture(HScene scene, dmhash_t texture_name_hash, HTextureSource texture_source, NodeTextureType texture_type, uint32_t original_width, uint32_t original_height)
+    {
+        TextureInfo* t = scene->m_DynamicTextures.Get(texture_name_hash);
+        if (t)
+        {
+            scene->m_DeleteTextureResourceCallback(scene, texture_name_hash, t->m_TextureSource);
+        }
+        return AddTexture(scene, scene->m_DynamicTextures, texture_name_hash, texture_source, texture_type, original_width, original_height, (dmImage::Type) -1);
+    }
+
     static void UnassignTexture(HScene scene, dmhash_t texture_name_hash)
     {
         uint32_t n = scene->m_Nodes.Size();
@@ -539,9 +549,15 @@ namespace dmGui
         }
     }
 
+    static inline TextureInfo* GetTextureInfo(HScene scene, dmhash_t texture_id)
+    {
+        TextureInfo* texture_info = scene->m_DynamicTextures.Get(texture_id);
+        return texture_info ? texture_info : scene->m_Textures.Get(texture_id);
+    }
+
     HTextureSource GetTexture(HScene scene, dmhash_t texture_name_hash)
     {
-        TextureInfo* textureInfo = scene->m_Textures.Get(texture_name_hash);
+        TextureInfo* textureInfo = GetTextureInfo(scene, texture_name_hash);
         if (!textureInfo)
         {
             return 0;
@@ -3045,12 +3061,6 @@ namespace dmGui
     Result SetNodeMaterial(HScene scene, HNode node, const char* material_id)
     {
         return SetNodeMaterial(scene, node, dmHashString64(material_id));
-    }
-
-    static inline TextureInfo* GetTextureInfo(HScene scene, dmhash_t texture_id)
-    {
-        TextureInfo* texture_info = scene->m_Textures.Get(texture_id);
-        return texture_info ? texture_info : scene->m_DynamicTextures.Get(texture_id);
     }
 
     Result SetNodeTexture(HScene scene, HNode node, dmhash_t texture_id)

--- a/engine/gui/src/gui.h
+++ b/engine/gui/src/gui.h
@@ -544,6 +544,19 @@ namespace dmGui
     Result AddTexture(HScene scene, dmhash_t texture_name_hash, HTextureSource texture_source, NodeTextureType texture_type, uint32_t original_width, uint32_t original_height);
 
     /**
+     * Adds a texture and optional textureset with the specified name to the scene as Dynamic texture.
+     * @note Any nodes connected to the same texture_name will also be connected to the new texture/textureset. This makes this function O(n), where n is #nodes.
+     * @param scene Scene to add the texture/textureset to
+     * @param texture_name_hash Hash of the texture name that will be used in the gui scripts
+     * @param texture The texture to add
+     * @param textureset The textureset to add if animation is used, otherwise zero. If set, texture parameter is expected to be equal to textureset texture.
+     * @param original_width Original With of the texture
+     * @param original_height Original Height of the texture
+     * @return Outcome of the operation
+     */
+    Result AddDynamicTexture(HScene scene, dmhash_t texture_name_hash, HTextureSource texture_source, NodeTextureType texture_type, uint32_t original_width, uint32_t original_height);
+
+    /**
      * Removes a texture with the specified name from the scene.
      * @note Any nodes connected to the same texture will also be disconnected from the texture. This makes this function O(n), where n is #nodes.
      * @param scene Scene to remove texture from


### PR DESCRIPTION
Now, all the textures that were set to a `GUI` component from outside are internally considered dynamic GUI textures in the engine.

⚠️ Pay attention: if you set textures into the GUI this way, you may need to increase `Max Dynamic Textures` (default is 128) in the GUI component.

Fix https://github.com/defold/defold/issues/10472