### PR TITLE
Add collections and game objects to root on drop

### DIFF
--- a/editor/src/clj/editor/atlas.clj
+++ b/editor/src/clj/editor/atlas.clj
@@ -1231,16 +1231,11 @@
     AtlasAnimation (->> (image-resources->image-msgs image-resources)
                         (make-image-nodes-in-animation parent))))
 
-(defn- parent-animation-or-atlas
-  [selection]
-  (or (first (handler/adapt-every selection AtlasAnimation))
-      (some #(core/scope-of-type % AtlasAnimation) selection)
-      (some #(core/scope-of-type % AtlasNode) selection)
-      (first (handler/adapt-every selection AtlasNode))))
-
 (defn- handle-drop
   [root-id selection _workspace _world-pos resources]
-  (let [parent (or (parent-animation-or-atlas selection) root-id)]
+  (let [parent (or (handler/adapt-single selection AtlasAnimation)
+                   (some #(core/scope-of-type % AtlasAnimation) selection)
+                   root-id)]
     (->> resources
          (e/filter image/image-resource?)
          (create-dropped-images parent))))

--- a/editor/src/clj/editor/atlas.clj
+++ b/editor/src/clj/editor/atlas.clj
@@ -1239,8 +1239,8 @@
       (first (handler/adapt-every selection AtlasNode))))
 
 (defn- handle-drop
-  [selection _workspace _world-pos resources]
-  (when-let [parent (parent-animation-or-atlas selection)]
+  [root-id selection _workspace _world-pos resources]
+  (let [parent (or (parent-animation-or-atlas selection) root-id)]
     (->> resources
          (e/filter image/image-resource?)
          (create-dropped-images parent))))

--- a/editor/src/clj/editor/collection.clj
+++ b/editor/src/clj/editor/collection.clj
@@ -26,7 +26,6 @@
             [editor.graph-util :as gu]
             [editor.handler :as handler]
             [editor.id :as id]
-            [editor.math :as math]
             [editor.outline :as outline]
             [editor.properties :as properties]
             [editor.protobuf :as protobuf]

--- a/editor/src/clj/editor/collection.clj
+++ b/editor/src/clj/editor/collection.clj
@@ -835,16 +835,14 @@
       nil)))
 
 (defn- handle-drop
-  [selection _workspace world-pos resources]
-  (when-let [collection (or (first (handler/adapt-every selection CollectionNode))
-                            (some #(core/scope-of-type % CollectionNode) selection))]
-    (let [transform-props {:position (types/Point3d->Vec3 world-pos)}
-          taken-ids (g/node-value collection :ids)
-          supported-exts #{"go" "collection"}]
-      (->> resources
-           (e/filter (comp (partial contains? supported-exts) resource/type-ext))
-           (outline/name-resource-pairs taken-ids)
-           (mapv (partial add-dropped-resource collection transform-props))))))
+  [root-id _selection _workspace world-pos resources]
+  (let [transform-props {:position (types/Point3d->Vec3 world-pos)}
+        taken-ids (g/node-value root-id :ids)
+        supported-exts #{"go" "collection"}]
+    (->> resources
+         (e/filter (comp (partial contains? supported-exts) resource/type-ext))
+         (outline/name-resource-pairs taken-ids)
+         (mapv (partial add-dropped-resource root-id transform-props)))))
 
 (defn register-resource-types [workspace]
   (resource-node/register-ddf-resource-type workspace

--- a/editor/src/clj/editor/game_object.clj
+++ b/editor/src/clj/editor/game_object.clj
@@ -611,17 +611,15 @@
     (collection-string-data/string-encode-prototype-desc ext->embedded-component-resource-type prototype-desc)))
 
 (defn- handle-drop
-  [selection workspace world-pos resources]
-  (when-let [parent (or (selection->game-object selection)
-                        (some #(core/scope-of-type % GameObjectNode) selection))]
-    (let [transform-props {:position (types/Point3d->Vec3 world-pos)}
-          taken-ids (map first (g/node-value parent :component-ids))
-          supported-exts (get-all-comp-exts workspace)]
-      (->> resources
-           (e/filter #(some #{(resource/type-ext %)} supported-exts))
-           (outline/name-resource-pairs taken-ids)
-           (mapv (fn [[id resource]]
-                   (add-component parent resource id transform-props nil nil)))))))
+  [root-id _selection workspace world-pos resources]
+  (let [transform-props {:position (types/Point3d->Vec3 world-pos)}
+        taken-ids (map first (g/node-value root-id :component-ids))
+        supported-exts (get-all-comp-exts workspace)]
+    (->> resources
+         (e/filter #(some #{(resource/type-ext %)} supported-exts))
+         (outline/name-resource-pairs taken-ids)
+         (mapv (fn [[id resource]]
+                 (add-component root-id resource id transform-props nil nil))))))
 
 (defn register-resource-types [workspace]
   (resource-node/register-ddf-resource-type workspace

--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -3981,10 +3981,8 @@
       nil)))
 
 (defn- handle-drop
-  [selection workspace _world-pos resources]
-  (when-let [scene (some-> selection first resource-node/owner-resource-node-id)]
-    (mapv (partial add-dropped-resource scene workspace)
-          resources)))
+  [root-id _selection workspace _world-pos resources]
+  (mapv (partial add-dropped-resource root-id workspace) resources))
 
 (defn- register [workspace def]
   (let [ext (:ext def)

--- a/editor/src/clj/editor/scene_selection.clj
+++ b/editor/src/clj/editor/scene_selection.clj
@@ -135,7 +135,7 @@
         (g/operation-label "Drop Resources")))))
 
 (defn- handle-drag-dropped!
-  [drop-fn select-fn action]
+  [drop-fn root-id select-fn action]
   (let [op-seq (gensym)
         {:keys [^DragEvent event string gesture-target world-pos world-dir]} action
         _ (ui/request-focus! gesture-target)
@@ -144,7 +144,7 @@
         resource-strings (-> string string/split-lines sort)
         resources (e/keep (partial workspace/resolve-workspace-resource workspace) resource-strings)
         z-plane-pos (math/line-plane-intersection world-pos world-dir (Point3d. 0.0 0.0 0.0) (Vector3d. 0.0 0.0 1.0))
-        drop-fn (partial drop-fn selection workspace z-plane-pos)
+        drop-fn (partial drop-fn root-id selection workspace z-plane-pos)
         added-nodes (add-dropped-resources! drop-fn resources op-seq)]
     (.consume event)
     (when (seq added-nodes)
@@ -160,13 +160,14 @@
         op-seq (g/node-value self :op-seq)
         mode (g/node-value self :mode)
         toggle? (g/node-value self :toggle?)
+        root-id (g/node-value self :root-id)
         cursor-pos [(:x action) (:y action) 0]
         contextual? (= (:button action) :secondary)]
     (case (:type action)
       :drag-dropped (let [drop-fn (g/node-value self :drop-fn)
                           select-fn (g/node-value self :select-fn)]
                       (when drop-fn
-                        (handle-drag-dropped! drop-fn select-fn action))
+                        (handle-drag-dropped! drop-fn root-id select-fn action))
                       nil)
       :mouse-pressed (let [op-seq (gensym)
                            toggle? (true? (some true? (map #(% action) toggle-modifiers)))


### PR DESCRIPTION
Fixes #10822

### Technical changes
I initially tried to fix the position recursively (see dc62eb6e54f65eca246ba88a66a30e00442ef875). This approach kind of worked, but I faced a considerable amount of issues that had to be be resolved
- Nodes and InstanceNodes should be handled differently.
- If the `z` position of the parent is not zero, there is an ambiguity regarding the expected `z` position of the dropped object.
- There is a preexisting issue when we add game objects or collections to nested collections. The created nodes are not going to be selected on the outline view, and that makes the visual feedback weird.
- If we look at the linked issue, users seem to prefer adding the dropped nodes at root.

Overall, I think maintaining the parent selection can be fixed, but it introduces a lot of problems to add questionable value. I decided to directly use the root node in this case. After multiple attempts to consistently get to the root node id from the current selection, I realized that the safest way to do that, is to pass it down to the drop fn from the selection controller. This change also fixed some edge cases where there is no selection (e.g. you can hold `Ctrl` and click on the selected root on the outline to remove it from the selection). We also got rid of some error prone calculations by directly using the root id.