### PR TITLE
Scene view tools reflect behavior changes from held modifier keys without moving the mouse

### DIFF
--- a/editor/src/clj/editor/scene.clj
+++ b/editor/src/clj/editor/scene.clj
@@ -1467,7 +1467,7 @@
                             (catch Throwable error
                               (reset! process-events? false)
                               (error-reporting/report-exception! error)))))
-        simulate-mouse-on-modifier-keys! (fn [e]
+        simulate-mouse-on-modifier-keys! (fn [^KeyEvent e]
                                            (when (and @process-events? (.isEmpty (.getText e)))
                                              (when-let [last-action (ui/user-data parent ::last-mouse-action)]
                                                (let [updated-action (assoc last-action

--- a/editor/src/clj/editor/scene.clj
+++ b/editor/src/clj/editor/scene.clj
@@ -1444,27 +1444,38 @@
 
 (defn register-event-handler! [^Parent parent view-id]
   (let [process-events? (atom true)
-        event-handler   (ui/event-handler e
-                          (when @process-events?
-                            (try
-                              (profiler/profile "input-event" -1
-                                (let [action (augment-action view-id (i/action-from-jfx e))
-                                      x (:x action)
-                                      y (:y action)
-                                      pos [x y 0.0]
-                                      picking-rect (selection/calc-picking-rect pos pos)]
-                                  (when (= :mouse-pressed (:type action))
-                                    ;; Request focus and consume event to prevent someone else from stealing focus
-                                    (.requestFocus parent)
-                                    (.consume e))
-                                  (g/transact
-                                    (concat
-                                      (g/set-property view-id :cursor-pos [x y])
-                                      (g/set-property view-id :tool-picking-rect picking-rect)
-                                      (g/update-property view-id :input-action-queue conj action)))))
-                              (catch Throwable error
-                                (reset! process-events? false)
-                                (error-reporting/report-exception! error)))))]
+        event-handler (ui/event-handler e
+                        (when @process-events?
+                          (try
+                            (profiler/profile "input-event" -1
+                              (let [action (augment-action view-id (i/action-from-jfx e))
+                                    x (:x action)
+                                    y (:y action)
+                                    pos [x y 0.0]
+                                    picking-rect (selection/calc-picking-rect pos pos)]
+                                (when (= :mouse-pressed (:type action))
+                                  ;; Request focus and consume event to prevent someone else from stealing focus
+                                  (.requestFocus parent)
+                                  (.consume e))
+                                (when (= :mouse-moved (:type action))
+                                  (ui/user-data! parent ::last-mouse-action action))
+                                (g/transact
+                                  (concat
+                                    (g/set-property view-id :cursor-pos [x y])
+                                    (g/set-property view-id :tool-picking-rect picking-rect)
+                                    (g/update-property view-id :input-action-queue conj action)))))
+                            (catch Throwable error
+                              (reset! process-events? false)
+                              (error-reporting/report-exception! error)))))
+        simulate-mouse-on-modifier-keys! (fn [e]
+                                           (when (and @process-events? (.isEmpty (.getText e)))
+                                             (when-let [last-action (ui/user-data parent ::last-mouse-action)]
+                                               (let [updated-action (assoc last-action
+                                                                      :alt (.isAltDown e)
+                                                                      :shift (.isShiftDown e)
+                                                                      :meta (.isMetaDown e)
+                                                                      :control (.isControlDown e))]
+                                                 (g/update-property! view-id :input-action-queue conj updated-action)))))]
     (ui/on-mouse! parent (fn [type e] (cond
                                         (= type :exit)
                                         (g/set-property! view-id :cursor-pos nil))))
@@ -1476,9 +1487,11 @@
     (.setOnDragOver parent event-handler)
     (.setOnDragDropped parent event-handler)
     (.setOnScroll parent event-handler)
+    (.setOnKeyReleased parent simulate-mouse-on-modifier-keys!)
     (.setOnKeyPressed parent (ui/event-handler e
                                (when @process-events?
-                                 (handle-key-pressed! e))))))
+                                 (handle-key-pressed! e)
+                                 (simulate-mouse-on-modifier-keys! e))))))
 
 (defn make-gl-pane! [view-id opts]
   (let [image-view (doto (ImageView.)


### PR DESCRIPTION
Now holding modifier keys such as Alt, Ctrl, Shift, and Cmd sends its own event, which helps reflect cursor changes immediately without needing to move the cursor.  
It's important, for example, for the tilemap editor, where using modifier keys changes the behavior of the cursor (e.g. Shift+Alt for tile eraser).

Fix https://github.com/defold/defold/issues/9366