### PR TITLE
Deduplicate resource data blobs in the ARCD archive.

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/bundle/test/BundlerTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/bundle/test/BundlerTest.java
@@ -401,15 +401,15 @@ public class BundlerTest {
         count++;
         createFile(outputContentRoot, "builtins/render/default.render_script", "");
         count++;
-        createFile(outputContentRoot, "builtins/render/default.display_profiles", "");
+        createFile(outputContentRoot, "builtins/render/default.display_profiles", " profiles { name: \"Landscape\" qualifiers { width: 1280 height: 720 } } profiles { name: \"Portrait\" qualifiers { width: 720 height: 1280 } } ");
         count++;
         createFile(outputContentRoot, "builtins/input/default.gamepads", "");
         count++;
-        createFile(outputContentRoot, "input/game.input_binding", "");
+        createFile(outputContentRoot, "input/game.input_binding", "key_trigger { input: KEY_SPACE action: \"\" }");
         count++;
 
         // These aren't put in the DARC file, so we don't count up
-        createFile(outputContentRoot, "builtins/graphics/default.texture_profiles", "");
+        createFile(outputContentRoot, "builtins/graphics/default.texture_profiles", "path_settings { path: \"**\" profile: \"Default\"}profiles { name: \"Default\" platforms { os: OS_ID_GENERIC formats { format: TEXTURE_FORMAT_RGBA compressor: \"Uncompressed\" compressor_preset: \"UNCOMPRESSED\" } mipmaps: true }}");
         createFile(outputContentRoot, "builtins/manifests/web/engine_template.html", "");
         createFile(outputContentRoot, "builtins/manifests/web/light_theme.css", "");
         createFile(outputContentRoot, "builtins/manifests/web/dark_theme.css", "");
@@ -472,10 +472,10 @@ public class BundlerTest {
         sub2.mkdir();
         int numBuiltins = createDefaultFiles(contentRoot);
         createFile(contentRoot, "m.txt", "dummy");
-        createFile(sub1.getAbsolutePath(), "s1-1.txt", "dummy");
-        createFile(sub1.getAbsolutePath(), "s1-2.txt", "dummy");
-        createFile(sub2.getAbsolutePath(), "s2-1.txt", "dummy");
-        createFile(sub2.getAbsolutePath(), "s2-2.txt", "dummy");
+        createFile(sub1.getAbsolutePath(), "s1-1.txt", "dummy1");
+        createFile(sub1.getAbsolutePath(), "s1-2.txt", "dummy2");
+        createFile(sub2.getAbsolutePath(), "s2-1.txt", "dummy3");
+        createFile(sub2.getAbsolutePath(), "s2-2.txt", "dummy4");
 
         createFile(contentRoot, "game.project", "[project]\ncustom_resources=custom,m.txt\n[display]\nwidth=640\nheight=480\n");
         build();

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/archive/ArchiveBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/archive/ArchiveBuilder.java
@@ -237,7 +237,7 @@ public class ArchiveBuilder {
         }
     }
 
-    private void writeArchiveIndex(RandomAccessFile archiveIndex, ArrayList<ArchiveEntry> archiveEntries) throws IOException {
+    private void writeArchiveIndex(RandomAccessFile archiveIndex, List<ArchiveEntry> archiveEntries) throws IOException {
         TimeProfiler.start("writeArchiveIndex");
 
         // INDEX
@@ -368,7 +368,8 @@ public class ArchiveBuilder {
             archiveData.close();
         }
 
-        writeArchiveIndex(archiveIndex, new ArrayList<ArchiveEntry>(writtenIntoArcd.values()));
+        entries = new ArrayList<ArchiveEntry>(writtenIntoArcd.values());
+        writeArchiveIndex(archiveIndex, entries);
     }
 
     private void alignBuffer(RandomAccessFile outFile, int align) throws IOException {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/archive/ArchiveBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/archive/ArchiveBuilder.java
@@ -296,6 +296,20 @@ public class ArchiveBuilder {
         TimeProfiler.stop();
     }
 
+    // URL → url_hash ───> Manifest: url_hash → data_hash
+    //                                            ↓
+    //                    Archive Index: binary search over sorted array of data_hashes
+    //                                            ↓
+    //                    Archive Index: if found, use index to get Entry from parallel EntryData array
+    //                                            ↓
+    //                    EntryData = { offset, size, compressed_size, flags }
+    //                                            ↓
+    //                    Read bytes from .arcd (using offset via fseek or mmap)
+    //                                            ↓
+    //                    Optionally decompress and/or decrypt
+    //                                            ↓
+    //                    → Final in-memory resource ready for use
+    //
     public void write(RandomAccessFile archiveIndex, RandomAccessFile archiveData, List<String> excludedResources) throws IOException, CompileExceptionError {
         // create the executor service to write entries in parallel
         int nThreads = project.getMaxCpuThreads();

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/archive/ArchiveBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/archive/ArchiveBuilder.java
@@ -92,6 +92,10 @@ public class ArchiveBuilder {
         Arrays.fill(archiveEntryPadding, (byte)0xED);
     }
 
+    public int getResourcePadding() {
+        return resourcePadding;
+    }
+
     private void add(String fileName, boolean compress, boolean encrypt, boolean isLiveUpdate) throws IOException {
         ArchiveEntry e = new ArchiveEntry(root, fileName, compress, encrypt, isLiveUpdate);
         if (lookup.add(e.getRelativeFilename())) {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/archive/ArchiveBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/archive/ArchiveBuilder.java
@@ -296,6 +296,7 @@ public class ArchiveBuilder {
         TimeProfiler.stop();
     }
 
+    // The flow of how a resource is found in the archive:
     // URL → url_hash ───> Manifest: url_hash → data_hash
     //                                            ↓
     //                    Archive Index: binary search over sorted array of data_hashes

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/archive/ArchiveEntry.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/archive/ArchiveEntry.java
@@ -34,6 +34,7 @@ public class ArchiveEntry implements Comparable<ArchiveEntry> {
     private String hexDigest;
     private byte[] hash = null;
     private byte[] header = new byte[0];
+    private boolean duplicatedDataBlob;
 
     public ArchiveEntry(String fileName) throws IOException {
         this.fileName = fileName;
@@ -215,5 +216,13 @@ public class ArchiveEntry implements Comparable<ArchiveEntry> {
     @Override
     public String toString() {
         return getClass().getName() + " " + this.fileName + ":" + this.hexDigest;
+    }
+
+    public void setDuplicatedDataBlob(boolean b) {
+        this.duplicatedDataBlob = b;
+    }
+
+    public boolean isDuplicatedDataBlob() {
+        return duplicatedDataBlob;
     }
 }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/archive/publisher/ZipPublisher.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/archive/publisher/ZipPublisher.java
@@ -149,6 +149,7 @@ public class ZipPublisher extends Publisher {
         entries.put(archiveEntryName, entry);
         synchronized (zipEntries) {
             if (!zipEntries.add(zipEntryName)) {
+                entry.setDuplicatedDataBlob(true);
                 return;
             }
         }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/ReportGenerator.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/ReportGenerator.java
@@ -26,9 +26,7 @@ import java.io.BufferedWriter;
 
 import com.dynamo.bob.Bob;
 import com.dynamo.bob.archive.ArchiveBuilder;
-import com.dynamo.bob.util.BobProjectProperties;
 import com.dynamo.bob.Project;
-import com.dynamo.bob.archive.ArchiveReader;
 import com.dynamo.bob.archive.ArchiveEntry;
 
 import com.dynamo.bob.archive.publisher.Publisher;
@@ -152,13 +150,18 @@ public class ReportGenerator {
         int padding = archiveBuilder.getResourcePadding();
 
         for (ArchiveEntry archiveEntry : includedEntries) {
-            long compressedSize = archiveEntry.isCompressed() ? archiveEntry.getCompressedSize() : archiveEntry.getSize();
-            compressedSize = ((compressedSize + padding - 1) / padding) * padding;
+            long compressedSize = 0;
+            long size = 0;
+            if (!archiveEntry.isDuplicatedDataBlob()) {
+                compressedSize = archiveEntry.isCompressed() ? archiveEntry.getCompressedSize() : archiveEntry.getSize();
+                compressedSize = ((compressedSize + padding - 1) / padding) * padding;
+                size= archiveEntry.getSize();
+            }
             boolean encrypted = archiveEntry.isEncrypted();
             boolean excluded = false;
 
             ResourceEntry resEntry = new ResourceEntry(archiveEntry.getRelativeFilename(),
-                    archiveEntry.getSize(),
+                    size,
                     compressedSize,
                     encrypted,
                     excluded);
@@ -167,12 +170,17 @@ public class ReportGenerator {
         }
 
         for (ArchiveEntry archiveEntry : excludedEntries) {
-            long compressedSize = archiveEntry.isCompressed() ? archiveEntry.getCompressedSize() : archiveEntry.getSize();
+            long compressedSize = 0;
+            long size = 0;
+            if (!archiveEntry.isDuplicatedDataBlob()) {
+                compressedSize = archiveEntry.isCompressed() ? archiveEntry.getCompressedSize() : archiveEntry.getSize();
+                size = archiveEntry.getSize();
+            }
             boolean encrypted = archiveEntry.isEncrypted();
             boolean excluded = true;
 
             ResourceEntry resEntry = new ResourceEntry(archiveEntry.getRelativeFilename(),
-                    archiveEntry.getSize(),
+                    size,
                     compressedSize,
                     encrypted,
                     excluded);

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/ReportGenerator.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/ReportGenerator.java
@@ -149,9 +149,11 @@ public class ReportGenerator {
     private void parseArchiveBuilder(ArchiveBuilder archiveBuilder) {
         List<ArchiveEntry> includedEntries = archiveBuilder.getIncludedEntries();
         List<ArchiveEntry> excludedEntries = archiveBuilder.getExcludedEntries();
+        int padding = archiveBuilder.getResourcePadding();
 
         for (ArchiveEntry archiveEntry : includedEntries) {
             long compressedSize = archiveEntry.isCompressed() ? archiveEntry.getCompressedSize() : archiveEntry.getSize();
+            compressedSize = (compressedSize + padding - 1) & ~(padding - 1);
             boolean encrypted = archiveEntry.isEncrypted();
             boolean excluded = false;
 

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/ReportGenerator.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/ReportGenerator.java
@@ -153,7 +153,7 @@ public class ReportGenerator {
 
         for (ArchiveEntry archiveEntry : includedEntries) {
             long compressedSize = archiveEntry.isCompressed() ? archiveEntry.getCompressedSize() : archiveEntry.getSize();
-            compressedSize = (compressedSize + padding - 1) & ~(padding - 1);
+            compressedSize = ((compressedSize + padding - 1) / padding) * padding;
             boolean encrypted = archiveEntry.isEncrypted();
             boolean excluded = false;
 


### PR DESCRIPTION
Fixes issue where two identical resources would be written into the `arcd` archive because they have different paths in the project.  
From now on, only one data blob will be written into the archive, and all duplicates will reference this single data blob from the manifest (and `arci`) file.

All the duplicates are still shown in the build report but with a size of 0.  
Also, the compressed size in the build report now includes alignment paddings for each file, which makes the `arcd` archive size equal to the total bytes shown in the report.

Fix https://github.com/defold/defold/issues/10650