### PR TITLE
Display tile attributes error on scene

### DIFF
--- a/editor/src/clj/editor/tile_source.clj
+++ b/editor/src/clj/editor/tile_source.clj
@@ -540,7 +540,7 @@
             metrics (texture-set-gen/calculate-tile-metrics image-size properties collision-size)]
         (when metrics
           (merge properties metrics)))
-      (g/error-fatal "tile data could not be generated due to invalid values")))
+      (g/->error _node-id :image :fatal image-resource "tile data could not be generated due to invalid values")))
 
 (defn- check-anim-error [tile-count anim-data]
   (let [node-id (:node-id anim-data)


### PR DESCRIPTION
Display tile attributes error on the scene view, instead of throwing an exception.

Fixes #10832

