### PR TITLE
Edit GUI nodes using editor scripts

### DIFF
--- a/editor/project.clj
+++ b/editor/project.clj
@@ -287,7 +287,7 @@
                                 :jvm-opts          ["-Ddefold.extension.lua-preprocessor.url=https://github.com/defold/extension-lua-preprocessor/archive/refs/tags/1.1.3.zip"
                                                     "-Ddefold.extension.rive.url=https://github.com/defold/extension-rive/archive/refs/tags/3.9.0.zip"
                                                     "-Ddefold.extension.simpledata.url=https://github.com/defold/extension-simpledata/archive/refs/tags/v1.1.0.zip"
-                                                    "-Ddefold.extension.spine.url=https://github.com/defold/extension-spine/archive/refs/tags/3.8.4.zip"
+                                                    "-Ddefold.extension.spine.url=https://github.com/defold/extension-spine/archive/refs/heads/issue-8504-gui-nodes.zip"
                                                     "-Ddefold.extension.teal.url=https://github.com/defold/extension-teal/archive/refs/tags/v1.2.zip"
                                                     "-Ddefold.extension.texturepacker.url=https://github.com/defold/extension-texturepacker/archive/refs/tags/2.2.0.zip"
                                                     "-Ddefold.unpack.path=tmp/unpack"

--- a/editor/src/clj/dynamo/graph.clj
+++ b/editor/src/clj/dynamo/graph.clj
@@ -1582,10 +1582,14 @@
      true)))
 
 (defn node-property-dynamic
-  "Returns the value of a dynamic associated with a specific node property, or
-  not-found value if the dynamic does not exist"
+  "Returns the value of a dynamic associated with a specific node property
+  If the dynamic does not exist, returns the provided not-found value, or throws
+  an assertion error if there was no not-found value provided"
   ([node property-label dynamic-label evaluation-context]
-   (node-property-dynamic node property-label dynamic-label nil evaluation-context))
+   (let [ret (node-property-dynamic node property-label dynamic-label ::not-found evaluation-context)]
+     (assert (not (identical? ret ::not-found))
+             (format "Dynamic %s not found on property %s in node-type %s." dynamic-label property-label (:k (node-type node))))
+     ret))
   ([node property-label dynamic-label not-found evaluation-context]
    (let [node-type (node-type node)
          property-def (get (in/all-properties node-type) property-label)

--- a/editor/src/clj/editor/attachment.clj
+++ b/editor/src/clj/editor/attachment.clj
@@ -263,6 +263,7 @@
         get-fn (getter basis workspace node-type list-kw)
         children-set (set (get-fn node-id evaluation-context))
         reorder-fn (-> basis (workspace/node-attachments workspace) (get node-type) list-kw :reorder)]
+    (assert (editable? basis workspace node-type list-kw))
     (assert (not (read-only? workspace node-id list-kw evaluation-context)))
     (assert (every? children-set reordered-child-node-ids))
     (assert (= (count children-set) (count reordered-child-node-ids))) ;; no duplicates
@@ -274,8 +275,8 @@
 
   The implementation will assert that the supplied child node ids are the same
   node ids as defined by [[getter]]. It will also assert that the container
-  node-id defines reorder of a list identified by list-kw (see [[reorderable?]])
-  and is not [[read-only?]]"
+  node-id defines an editable and reorderable list (see [[reorderable?]],
+  [[editable?]]) and is not [[read-only?]]"
   [workspace node-id list-kw reordered-child-node-ids]
   (g/expand-ec reorder-tx workspace node-id list-kw reordered-child-node-ids))
 

--- a/editor/src/clj/editor/attachment.clj
+++ b/editor/src/clj/editor/attachment.clj
@@ -14,11 +14,20 @@
 
 (ns editor.attachment
   "Extensible definitions for semantical node attachments"
-  (:refer-clojure :exclude [remove])
+  (:refer-clojure :exclude [remove alias])
   (:require [dynamo.graph :as g]
             [editor.workspace :as workspace]
             [internal.graph.types :as gt]
             [util.coll :as coll]))
+
+(defn- assoc-list-definition [state node-type list-kw {:keys [aliases] :as definition}]
+  (let [state (update state node-type assoc list-kw definition)]
+    (if aliases
+      (let [aliased-definition (-> definition
+                                   (dissoc :aliases)
+                                   (assoc :alias node-type))]
+        (reduce #(update %1 %2 assoc list-kw aliased-definition) state aliases))
+      state)))
 
 ;; SDK api
 (defn register
@@ -30,50 +39,99 @@
     list-kw      name of the node component list
 
   Kv-args (at least one is required):
-    :add        a map that defines how new items are added to the list; where
-                keys are child node types used for constructing new nodes, and
-                values are attach functions, i.e. functions of parent-node-id
-                (container) and child-node-id (item) that should return
-                transaction steps that connect the child node into the parent
-    :get        a function that defines how to read a list of children, will
-                receive 2 args: parent-node-id (container) and
-                evaluation-context; should return a vector of node ids
-    :reorder    a function that defines how to reorder a list of children, will
-                receive 1 arg: reordered-node-ids (vector of item node ids,
-                validated to be the same node ids as those returned by :get);
-                should return transaction steps that set the new order"
-  [workspace node-type list-kw & {:keys [add get reorder]}]
+    :add           a map that defines how new items are added to the list; where
+                   keys are child node types used for constructing new nodes,
+                   and values are attach functions, i.e. functions of
+                   parent-node-id (container) and child-node-id (item) that
+                   should return transaction steps that connect the child node
+                   into the parent
+    :get           a function that defines how to read a list of children, will
+                   receive 2 args: parent-node-id (container) and
+                   evaluation-context; should return a vector of node ids
+    :reorder       a function that defines how to reorder a list of children,
+                   will receive 1 arg: reordered-node-ids (vector of item node
+                   ids, validated to be the same node ids as those returned by
+                   :get); should return transaction steps that set the new order
+    :read-only?    a function that checks if an editable container node is
+                   read-only, i.e., can't be edited, will receive 2 args:
+                   node-id (container) and evaluation-context; should return
+                   a boolean"
+  [workspace node-type list-kw & {:keys [add get reorder read-only?]}]
   {:pre [(g/node-id? workspace)
          (g/node-type? node-type)
          (simple-keyword? list-kw)
-         (or (ifn? get) (map? add) (ifn? reorder))]}
+         (or (nil? get) (ifn? get))
+         (or (nil? add) (map? add))
+         (or (nil? reorder) (ifn? reorder))
+         (or (nil? read-only?) (ifn? read-only?))
+         (or get add reorder read-only?)]}
   (g/update-property
     workspace
     :node-attachments
     (fn [s]
-      (cond-> s
-              add (update :add update node-type update list-kw merge add)
-              get (update :get update node-type assoc list-kw get)
-              reorder (update :reorder update node-type assoc list-kw reorder)))))
+      (let [definition (-> s
+                           (clojure.core/get node-type)
+                           list-kw
+                           (cond->
+                             add (update :add coll/merge add)
+                             get (assoc :get get)
+                             reorder (assoc :reorder reorder)
+                             read-only? (assoc :read-only? read-only?)))]
+        ;; The first registration has to provide :get
+        ;; Subsequent registrations typically add additional :add fns
+        (assert (contains? definition :get))
+        (assert (not (contains? definition :alias)) "Cannot modify an alias")
+        (assoc-list-definition s node-type list-kw definition)))))
+
+(defn alias
+  "Define a node list as an alias of another node type's list with the same name"
+  [workspace node-type list-kw alias-node-type]
+  {:pre [(not= node-type alias-node-type)]}
+  (g/update-property
+    workspace
+    :node-attachments
+    (fn [s]
+      (let [definition (list-kw (clojure.core/get s alias-node-type))
+            _ (assert definition "Can't alias undefined list")]
+        (assert definition "Can't alias undefined list")
+        (assert (not (contains? definition :alias)) "Can't alias another alias")
+        (assoc-list-definition s alias-node-type list-kw (update definition :aliases coll/conj-set node-type))))))
+
+(defmacro ^:private with-read-only-check [parent-node-type-expr parent-node-id-expr list-kw-expr read-only?-expr & body]
+  `(let [parent-node-id# ~parent-node-id-expr
+         read-only?# ~read-only?-expr
+         parent-node-type# ~parent-node-type-expr
+         list-kw# ~list-kw-expr]
+     (if read-only?#
+       (g/expand-ec
+         (fn [evaluation-context#]
+           (when (read-only?# parent-node-id# evaluation-context#)
+             (throw (ex-info (str (name (:k parent-node-type#)) " instance is read-only")
+                             {:parent-node-id parent-node-id# :list-kw list-kw#})))
+           (do ~@body)))
+       (do ~@body))))
 
 (defn add-impl [current-state parent-node-type parent-node-id attachment-tree init-fn]
   (coll/mapcat
     (fn [[list-kw {:keys [init add node-type] :as attachment}]]
       (when-not node-type
         (throw (ex-info "node type is required" {:parent-node-type parent-node-id :list-kw list-kw :attachment attachment})))
-      (if-let [node-type->tx-attach-fn (-> current-state :add (get parent-node-type) list-kw)]
-        (let [tx-attach-fn (or (node-type->tx-attach-fn node-type)
-                               (throw (ex-info (str (name (:k parent-node-type)) " does not support " (name list-kw) " attachments of type " (name (:k node-type)))
-                                               {:parent-node-type parent-node-id :list-kw list-kw :node-type node-type})))
-              child-node-id (first (g/take-node-ids (g/node-id->graph-id parent-node-id) 1))]
-          (concat
-            (g/add-node (g/construct node-type :_node-id child-node-id))
-            (init-fn parent-node-id node-type child-node-id init)
-            (tx-attach-fn parent-node-id child-node-id)
-            (add-impl current-state node-type child-node-id add init-fn)))
-        (throw (ex-info (str (name (:k parent-node-type)) " does not define a " (name list-kw) " attachment list")
-                        {:parent-node-type parent-node-type
-                         :list-kw list-kw}))))
+      (let [definition (-> current-state (get parent-node-type) list-kw)]
+        (if-let [node-type->tx-attach-fn (:add definition)]
+          (let [tx-attach-fn (or (node-type->tx-attach-fn node-type)
+                                 (throw (ex-info (str (name (:k parent-node-type)) " does not support " (name list-kw) " attachments of type " (name (:k node-type)))
+                                                 {:parent-node-type parent-node-id :list-kw list-kw :node-type node-type})))
+                child-node-id (first (g/take-node-ids (g/node-id->graph-id parent-node-id) 1))]
+            (with-read-only-check
+              parent-node-type parent-node-id list-kw (:read-only? definition)
+              (concat
+                (g/add-node (g/construct node-type :_node-id child-node-id))
+                (init-fn parent-node-id node-type child-node-id init)
+                (tx-attach-fn parent-node-id child-node-id)
+                (add-impl current-state node-type child-node-id add init-fn))))
+          (throw (ex-info (str (name (:k parent-node-type)) " does not define a " (name list-kw) " attachment list")
+                          {:parent-node-type parent-node-type
+                           :list-kw list-kw})))))
     attachment-tree))
 
 (defn add
@@ -116,22 +174,39 @@
 (defn defines?
   "Checks if a node-type is extended to define a list-kw list"
   [basis workspace node-type list-kw]
-  (-> basis (workspace/node-attachments workspace) :add (get node-type) (contains? list-kw)))
+  (-> basis (workspace/node-attachments workspace) (get node-type) (contains? list-kw)))
+
+(defn read-only?
+  "Checks if a node is read-only, i.e., can't be edited even when editable
+
+  Asserts that list exists (see [[defines?]])"
+  [workspace node-id list-kw evaluation-context]
+  (let [{:keys [basis]} evaluation-context
+        node-type (g/node-type* basis node-id)]
+    (assert (defines? basis workspace node-type list-kw))
+    (if-let [pred (-> basis (workspace/node-attachments workspace) (get node-type) list-kw :read-only?)]
+      (pred node-id evaluation-context)
+      false)))
+
+(defn editable?
+  "Checks if a node-type supports editing items of the list"
+  [basis workspace node-type list-kw]
+  (-> basis (workspace/node-attachments workspace) (get node-type) list-kw (contains? :add)))
 
 (defn reorderable?
   "Checks if a node type allows reordering of a list-kw list"
   [basis workspace node-type list-kw]
-  (-> basis (workspace/node-attachments workspace) :reorder (get node-type) (contains? list-kw)))
+  (-> basis (workspace/node-attachments workspace) (get node-type) list-kw (contains? :reorder)))
 
 (defn child-node-types
   "Returns defined child node-types for a parent node-type's list-kw
 
   Returns a map from child node type to tx-attach-fn
 
-  Asserts that it exists. See [[defines?]]"
+  Asserts that it exists. See [[editable?]]"
   [basis workspace node-type list-kw]
   {:post [(some? %)]}
-  (-> basis (workspace/node-attachments workspace) :add (get node-type) (get list-kw)))
+  (-> basis (workspace/node-attachments workspace) (get node-type) list-kw :add))
 
 (defn getter
   "Returns a getter function for a container node-type's list-kw
@@ -142,24 +217,33 @@
   Asserts that it exists. See [[defines?]]"
   [basis workspace node-type list-kw]
   {:post [(some? %)]}
-  (-> basis (workspace/node-attachments workspace) :get (get node-type) (get list-kw)))
+  (-> basis (workspace/node-attachments workspace) (get node-type) list-kw :get))
 
 (defn- clear-tx [evaluation-context workspace node-id list-kw]
   (let [basis (:basis evaluation-context)
-        get-fn (getter basis workspace (g/node-type* basis node-id) list-kw)]
+        node-type (g/node-type* basis node-id)
+        get-fn (getter basis workspace node-type list-kw)]
+    (assert (editable? basis workspace node-type list-kw))
+    (assert (not (read-only? workspace node-id list-kw evaluation-context)))
     (mapcat
       #(g/delete-node (g/override-root basis %))
       (get-fn node-id evaluation-context))))
 
 (defn clear
-  "Create transaction steps for clearing a list of container node-id's list"
+  "Create transaction steps for clearing a list of container node-id's list
+
+  The implementation will assert that the container node-id defines an editable
+  list (see [[editable?]]) and is not [[read-only?]]"
   [workspace node-id list-kw]
   (g/expand-ec clear-tx workspace node-id list-kw))
 
 (defn- remove-tx [evaluation-context workspace node-id list-kw child-node-id]
   (let [basis (:basis evaluation-context)
-        get-fn (getter basis workspace (g/node-type* basis node-id) list-kw)
+        node-type (g/node-type* basis node-id)
+        get-fn (getter basis workspace node-type list-kw)
         children (get-fn node-id evaluation-context)]
+    (assert (editable? basis workspace node-type list-kw))
+    (assert (not (read-only? workspace node-id list-kw evaluation-context)))
     (assert (some #(= child-node-id %) children))
     (g/delete-node (g/override-root basis child-node-id))))
 
@@ -168,7 +252,8 @@
 
   The implementation will assert that the child node id actually exists in the
   container as defined by [[getter]]. It will also assert that the container
-  node-id defines a list identified by list-kw (see [[defines?]])"
+  node-id defines an editable list identified by list-kw (see [[editable?]]) and
+  is not [[read-only?]]"
   [workspace node-id list-kw child-node-id]
   (g/expand-ec remove-tx workspace node-id list-kw child-node-id))
 
@@ -177,7 +262,8 @@
         node-type (g/node-type* basis node-id)
         get-fn (getter basis workspace node-type list-kw)
         children-set (set (get-fn node-id evaluation-context))
-        reorder-fn (-> basis (workspace/node-attachments workspace) :reorder (get node-type) (get list-kw))]
+        reorder-fn (-> basis (workspace/node-attachments workspace) (get node-type) list-kw :reorder)]
+    (assert (not (read-only? workspace node-id list-kw evaluation-context)))
     (assert (every? children-set reordered-child-node-ids))
     (assert (= (count children-set) (count reordered-child-node-ids))) ;; no duplicates
     (assert reorder-fn)
@@ -188,7 +274,8 @@
 
   The implementation will assert that the supplied child node ids are the same
   node ids as defined by [[getter]]. It will also assert that the container
-  node-id defines reorder of a list identified by list-kw (see [[reorderable?]])"
+  node-id defines reorder of a list identified by list-kw (see [[reorderable?]])
+  and is not [[read-only?]]"
   [workspace node-id list-kw reordered-child-node-ids]
   (g/expand-ec reorder-tx workspace node-id list-kw reordered-child-node-ids))
 

--- a/editor/src/clj/editor/editor_extensions.clj
+++ b/editor/src/clj/editor/editor_extensions.clj
@@ -844,6 +844,7 @@
                                "can_add" (graph/make-ext-can-add-fn project)
                                "can_get" (make-ext-can-get-fn project)
                                "can_reorder" (graph/make-ext-can-reorder-fn project)
+                               "can_reset" (graph/make-ext-can-reset-fn project)
                                "can_set" (make-ext-can-set-fn project)
                                "command" commands/ext-command-fn
                                "create_directory" (make-ext-create-directory-fn project reload-resources!)
@@ -862,7 +863,8 @@
                                      "add" (graph/make-ext-add-fn project)
                                      "clear" (graph/make-ext-clear-fn project)
                                      "remove" (graph/make-ext-remove-fn project)
-                                     "reorder" (graph/make-ext-reorder-fn project)}
+                                     "reorder" (graph/make-ext-reorder-fn project)
+                                     "reset" (graph/make-ext-reset-fn project)}
                                "ui" (assoc
                                       (ui-components/env workspace project project-path)
                                       "open_resource" (make-open-resource-fn workspace open-resource!))

--- a/editor/src/clj/editor/editor_extensions/docs.clj
+++ b/editor/src/clj/editor/editor_extensions/docs.clj
@@ -295,7 +295,7 @@ editor.command({
           :type :function
           :parameters [node-param property-param]
           :returnvalues [transaction-step-param]
-          :description "Create a transaction step that will delete all items from node's list property when transacted with `editor.transact()`."}
+          :description "Create a transaction step that will remove all items from node's list property when transacted with `editor.transact()`."}
          {:name "editor.tx.remove"
           :type :function
           :parameters [node-param property-param (assoc node-param :name "child_node")]

--- a/editor/src/clj/editor/editor_extensions/docs.clj
+++ b/editor/src/clj/editor/editor_extensions/docs.clj
@@ -74,6 +74,11 @@
           :parameters [node-param property-param]
           :returnvalues [boolean-ret-param]
           :description "Check if `editor.tx.reorder()` transaction with this property won't throw an error"}
+         {:name "editor.can_reset"
+          :type :function
+          :parameters [node-param property-param]
+          :returnvalues [boolean-ret-param]
+          :description "Check if `editor.tx.reset()` transaction with this property won't throw an error"}
          {:name "editor.command"
           :type :function
           :description "Create an editor command"
@@ -290,7 +295,7 @@ editor.command({
           :type :function
           :parameters [node-param property-param]
           :returnvalues [transaction-step-param]
-          :description "Create a transaction step that will deletes all items from node's list property when transacted with `editor.transact()`."}
+          :description "Create a transaction step that will delete all items from node's list property when transacted with `editor.transact()`."}
          {:name "editor.tx.remove"
           :type :function
           :parameters [node-param property-param (assoc node-param :name "child_node")]
@@ -301,6 +306,11 @@ editor.command({
           :parameters [node-param property-param {:name "child_nodes" :types ["table"] :doc "array of child nodes (the same as returned by <code>editor.get(node, property)</code>) in new order"}]
           :returnvalues [transaction-step-param]
           :description "Create a transaction step that reorders child nodes in a node list defined by the property if supported (see <code>editor.can_reorder()</code>)"}
+         {:name "editor.tx.reset"
+          :type :function
+          :parameters [node-param property-param]
+          :returnvalues [transaction-step-param]
+          :description "Create a transaction step that will reset an overridden property to its default value when transacted with `editor.transact()`."}
          {:name "editor.version"
           :type :variable
           :description "A string, version name of Defold"}

--- a/editor/src/clj/editor/editor_extensions/graph.clj
+++ b/editor/src/clj/editor/editor_extensions/graph.clj
@@ -21,8 +21,8 @@
             [editor.collision-groups :as collision-groups]
             [editor.defold-project :as project]
             [editor.editor-extensions.coerce :as coerce]
-            [editor.editor-extensions.runtime :as rt]
             [editor.editor-extensions.node-types :as node-types]
+            [editor.editor-extensions.runtime :as rt]
             [editor.editor-extensions.tile-map :as tile-map]
             [editor.game-project :as game-project]
             [editor.gui-attachment :as gui-attachment]
@@ -35,11 +35,15 @@
             [editor.util :as util]
             [editor.workspace :as workspace]
             [util.coll :as coll]
+            [util.defonce :as defonce]
             [util.fn :as fn]
             [util.id-vec :as iv])
-  (:import [com.dynamo.particle.proto Particle$ModifierType]
+  (:import [clojure.lang IFn]
+           [com.dynamo.particle.proto Particle$ModifierType]
            [editor.editor_extensions.tile_map Tiles]
            [editor.properties Curve CurveSpread]
+           [java.util ArrayDeque HashSet]
+           [java.util.concurrent.locks ReentrantReadWriteLock]
            [javax.vecmath Vector3d]
            [org.apache.commons.io FilenameUtils]
            [org.luaj.vm2 LuaError]))
@@ -82,7 +86,7 @@
 ;; region get
 
 (defn- coercing-converter [coercer]
-  (fn [lua-value rt _outline-property _project _evaluation-context]
+  (fn [lua-value rt _edit-type _project _evaluation-context]
     (rt/->clj rt coercer lua-value)))
 
 (def node-id-or-path-or-empty-string-coercer
@@ -90,7 +94,7 @@
     node-id-or-path-coercer
     (coerce/enum "")))
 
-(defn- resource-converter [lua-value rt outline-property project evaluation-context]
+(defn- resource-converter [lua-value rt edit-type project evaluation-context]
   (let [node-id-or-path (rt/->clj rt node-id-or-path-or-empty-string-coercer lua-value)]
     (when-not (= node-id-or-path "")
       (let [resource (if (string? node-id-or-path)
@@ -98,19 +102,20 @@
                            (project/workspace evaluation-context)
                            (workspace/resolve-workspace-resource node-id-or-path evaluation-context))
                        (g/node-value node-id-or-path :resource evaluation-context))
-            ext (:ext (properties/property-edit-type outline-property))]
+            ext (:ext edit-type)
+            ext (if (string? ext) [ext] ext)]
         (when (and (seq ext)
                    (not ((set ext) (resource/type-ext resource))))
           (throw (LuaError. (str "resource extension should be "
                                  (->> ext sort (util/join-words ", " " or "))))))
         resource))))
 
-(defn- choicebox-converter [lua-value rt outline-property _project _evaluation-context]
-  (let [opts (->> outline-property properties/property-edit-type :options (mapv first))]
+(defn- choicebox-converter [lua-value rt edit-type _project _evaluation-context]
+  (let [opts (->> edit-type :options (mapv first))]
     (rt/->clj rt (apply coerce/enum opts) lua-value)))
 
-(defn- slider-converter [lua-value rt outline-property _project _evaluation-context]
-  (let [{:keys [min max] :or {min 0.0 max 1.0}} (properties/property-edit-type outline-property)
+(defn- slider-converter [lua-value rt edit-type _project _evaluation-context]
+  (let [{:keys [min max] :or {min 0.0 max 1.0}} edit-type
         coercer (coerce/wrap-with-pred coerce/number #(<= min % max) (str "should be between " min " and " max))]
     (double (rt/->clj rt coercer lua-value))))
 
@@ -179,7 +184,7 @@
                        :extra-keys false))
     #(properties/->curve-spread (:points %) (:spread %))))
 
-(def ^:private edit-type-id->value-converter
+(def edit-type-id->value-converter
   {g/Str {:to identity :from (coercing-converter coerce/string)}
    g/Bool {:to identity :from (coercing-converter coerce/boolean)}
    g/Num {:to identity :from (coercing-converter coerce/number)}
@@ -201,38 +206,172 @@
     (keyword (string/replace property "_" "-"))))
 
 (defn- outline-property [node-id property evaluation-context]
-  (when (g/node-instance? (:basis evaluation-context) outline/OutlineNode node-id)
-    (let [prop-kw (property->prop-kw property)
-          outline-property (-> node-id
-                               (g/node-value :_properties evaluation-context)
-                               (get-in [:properties prop-kw]))]
-      (when (and outline-property
-                 (properties/visible? outline-property)
-                 (edit-type-id->value-converter (properties/edit-type-id outline-property)))
-        (cond-> outline-property
-                (not (contains? outline-property :prop-kw))
-                (assoc :prop-kw prop-kw))))))
+  (let [prop-kw (property->prop-kw property)
+        outline-property (-> node-id
+                             (g/node-value :_properties evaluation-context)
+                             (get-in [:properties prop-kw]))]
+    (when (and outline-property
+               (properties/visible? outline-property)
+               (edit-type-id->value-converter (properties/property-edit-type-id outline-property)))
+      (cond-> outline-property
+              (not (contains? outline-property :prop-kw))
+              (assoc :prop-kw prop-kw)))))
 
-(defmulti ext-get (fn [node-id property evaluation-context]
-                    [(node-id->type-keyword node-id evaluation-context) property]))
+(defn- make-property-fn-builder [{:keys [parents]} node-type-kw->f]
+  (fn/memoize
+    (fn build-property-fn [node-type-kw]
+      (let [seen (HashSet.)
+            queue (doto (ArrayDeque.) (.add node-type-kw))
+            fs (loop [fs (transient [])]
+                 (if-let [node-type-kw (.pollFirst queue)]
+                   (if (.contains seen node-type-kw)
+                     (recur fs)
+                     (do
+                       (.add seen node-type-kw)
+                       (some->> (parents node-type-kw) (run! #(.add queue %)))
+                       (recur (if-let [f (node-type-kw->f node-type-kw)]
+                                (conj! fs f)
+                                fs))))
+                   (persistent! fs)))]
+        (case (count fs)
+          0 fn/constantly-nil
+          1 (fs 0)
+          (fn
+            ([] (coll/some #(%) fs))
+            ([a] (coll/some #(% a) fs))
+            ([a b] (coll/some #(% a b) fs))
+            ([a b c] (coll/some #(% a b c) fs))
+            ([a b c d] (coll/some #(% a b c d) fs))
+            ([a b c d e] (coll/some #(% a b c d e) fs))))))))
 
-(defmethod ext-get [:editor.code.resource/CodeEditorResourceNode "text"] [node-id _ evaluation-context]
-  (string/join \newline (g/node-value node-id :lines evaluation-context)))
+(defonce/type InheritanceChain
+  [^:unsynchronized-mutable node-type-kw->f
+   ^:unsynchronized-mutable hierarchy
+   ^:unsynchronized-mutable builder
+   hierarchy-ref
+   ^ReentrantReadWriteLock lock]
+  IFn
+  (invoke [this node-type-kw]
+    ;; The code below is based on Java code snippet in ReentrantReadWriteLock's
+    ;; Javadoc.
+    (let [r (.readLock lock)]
+      (.lock r)
+      (try
+        (let [h @hierarchy-ref
+              builder-valid (and (.-builder this) (identical? hierarchy h))]
+          (when-not builder-valid
+            ;; Must release read lock before acquiring write lock
+            (.unlock r)
+            (let [w (.writeLock lock)]
+              (.lock w)
+              (try
+                ;; Recheck state because another thread might have
+                ;; acquired write lock and changed state before we did
+                (let [h @hierarchy-ref
+                      builder-valid (and (.-builder this) (identical? hierarchy h))]
+                  (when-not builder-valid
+                    (set! (.-hierarchy this) h)
+                    (set! (.-builder this) (make-property-fn-builder h (.-node-type-kw->f this))))
+                  ;; Downgrade by acquiring read lock before releasing write lock
+                  (.lock r))
+                (finally
+                  ;; Unlock write lock, still hold read
+                  (.unlock w)))))
+          ((.-builder this) node-type-kw))
+        (finally (.unlock r)))))
+  (invoke [this node-type-kw f]
+    (let [w (.writeLock lock)]
+      (.lock w)
+      (try
+        (set! (.-node-type-kw->f this) (assoc node-type-kw->f node-type-kw f))
+        (set! (.-builder this) nil)
+        (finally
+          (.unlock w))))))
 
-(defmethod ext-get [:editor.resource/ResourceNode "path"] [node-id _ evaluation-context]
-  (resource/resource->proj-path (g/node-value node-id :resource evaluation-context)))
+(defn make-inheritance-chain
+  "Create an inheritance chain
 
-(defmethod ext-get [:editor.tile-source/TileSourceNode "tile_collision_groups"] [node-id _ evaluation-context]
-  (coll/pair-map-by
-    (comp inc key) ;; 0-indexed to 1-indexed
-    #(g/node-value (val %) :id evaluation-context)
-    (g/node-value node-id :tile->collision-group-node evaluation-context)))
+  The inheritance chain is somewhat similar to multimethods. It uses hierarchy,
+  though it dispatches only on a single value. Register methods by calling the
+  inheritance chain instance with 2 args: dispatch value and a function.
+  Get a method chain by calling the inheritance chain instance with a dispatch
+  value. If there are multiple methods that satisfy the dispatch value, they
+  will be tried in order, from most specific to least specific, until a method
+  returns a non-nil value."
+  ([]
+   (make-inheritance-chain #'clojure.core/global-hierarchy))
+  ([hierarchy-ref]
+   (->InheritanceChain {} @hierarchy-ref fn/constantly-constantly-nil hierarchy-ref (ReentrantReadWriteLock.))))
 
-(defmethod ext-get [:editor.tile-map/LayerNode "tiles"] [node-id _ evaluation-context]
-  (tile-map/make (g/node-value node-id :cell-map evaluation-context)))
+(defonce ^:private ext-property-getter
+  (make-inheritance-chain))
 
-(defmethod ext-get [:editor.particlefx/ModifierNode "type"] [node-id _ evaluation-context]
-  (g/node-value node-id :type evaluation-context))
+(defn register-property-getter!
+  "Register a getter associated with a node type
+
+  Args:
+    node-type-kw    keyword of a graph node type
+    f               a function of 3 args:
+                      node-id               the node id to resolve the value
+                      property              string property name
+                      evaluation-context    the evaluation context"
+  [node-type-kw f]
+  {:pre [(qualified-keyword? node-type-kw) (ifn? f)]}
+  (ext-property-getter node-type-kw f))
+
+(register-property-getter!
+  :editor.code.resource/CodeEditorResourceNode
+  (fn CodeEditorResourceNode-getter [node-id property evaluation-context]
+    (case property
+      "text" #(coll/join-to-string \newline (g/node-value node-id :lines evaluation-context))
+      nil)))
+
+(register-property-getter!
+  :editor.resource/ResourceNode
+  (fn ResourceNode-getter [node-id property evaluation-context]
+    (case property
+      "path" #(resource/resource->proj-path (g/node-value node-id :resource evaluation-context))
+      nil)))
+
+(register-property-getter!
+  :editor.tile-source/TileSourceNode
+  (fn TileSourceNode-getter [node-id property evaluation-context]
+    (case property
+      "tile_collision_groups"
+      (fn get-tile-collision-groups []
+        (coll/pair-map-by
+          (comp inc key) ;; 0-indexed to 1-indexed
+          #(g/node-value (val %) :id evaluation-context)
+          (g/node-value node-id :tile->collision-group-node evaluation-context)))
+      nil)))
+
+(register-property-getter!
+  :editor.tile-map/LayerNode
+  (fn LayerNode-getter [node-id property evaluation-context]
+    (case property
+      "tiles" #(tile-map/make (g/node-value node-id :cell-map evaluation-context))
+      nil)))
+
+(register-property-getter!
+  :editor.particlefx/ModifierNode
+  (fn ModifierNode-getter [node-id property evaluation-context]
+    (case property
+      "type" #(g/node-value node-id :type evaluation-context)
+      nil)))
+
+(register-property-getter!
+  :editor.game-project/GameProjectNode
+  (fn GameProjectNode-getter [node-id property evaluation-context]
+    (when (re-matches #"^[a-zA-Z_][a-zA-Z0-9_]*\.[a-zA-Z_][a-zA-Z0-9_]*$" property)
+      (let [path (string/split property #"\." 2)]
+        #(game-project/get-setting node-id path evaluation-context)))))
+
+(register-property-getter!
+  ::outline/OutlineNode
+  (fn OutlineNode-getter [node-id property evaluation-context]
+    (when-let [outline-property (outline-property node-id property evaluation-context)]
+      (when-let [to (-> outline-property properties/property-edit-type-id edit-type-id->value-converter :to)]
+        #(some-> (properties/value outline-property) to)))))
 
 (defn ext-value-getter
   "Create 0-arg fn that produces node property value
@@ -250,109 +389,196 @@
       "path" #(resource/proj-path node-id-or-resource)
       "children" #(mapv resource/proj-path (resource/children node-id-or-resource))
       nil)
-    (let [node-id node-id-or-resource]
-      (or (when (fn/multi-responds? ext-get node-id property evaluation-context)
-            #(ext-get node-id property evaluation-context))
-          (when (and (= :editor.game-project/GameProjectNode (node-id->type-keyword node-id evaluation-context))
-                     (re-matches #"^[a-zA-Z_][a-zA-Z0-9_]*\.[a-zA-Z_][a-zA-Z0-9_]*$" property))
-            #(game-project/get-setting node-id (string/split property #"\." 2) evaluation-context))
-          (when-let [outline-property (outline-property node-id property evaluation-context)]
-            (when-let [to (-> outline-property
-                              properties/edit-type-id
-                              edit-type-id->value-converter
-                              :to)]
-              #(some-> (properties/value outline-property) to)))
+    (let [node-id node-id-or-resource
+          {:keys [basis]} evaluation-context
+          node-type (g/node-type* basis node-id)]
+      (or ((ext-property-getter (:k node-type)) node-id property evaluation-context)
           (case property
-            "type" (when-let [type-name (node-types/->name (g/node-type* (:basis evaluation-context) node-id))]
+            "type" (when-let [type-name (node-types/->name node-type)]
                      (constantly type-name))
-            nil)
-          (let [{:keys [basis]} evaluation-context
-                workspace (project/workspace project evaluation-context)
-                node-type (g/node-type* basis node-id)
-                list-kw (property->prop-kw property)]
-            (when (attachment/defines? basis workspace node-type list-kw)
-              (let [f (attachment/getter basis workspace node-type list-kw)]
-                #(mapv rt/wrap-userdata (f node-id evaluation-context)))))))))
+            (let [workspace (project/workspace project evaluation-context)
+                  list-kw (property->prop-kw property)]
+              (when (attachment/defines? basis workspace node-type list-kw)
+                (let [f (attachment/getter basis workspace node-type list-kw)]
+                  #(mapv rt/wrap-userdata (f node-id evaluation-context))))))))))
 
 ;; endregion
 
 ;; region set
 
-(defmulti ext-setter
-  "Returns a function that receives a LuaValue and returns txs"
-  (fn [node-id property _rt _project evaluation-context]
-    [(node-id->type-keyword node-id evaluation-context) property]))
+(defonce ^:private ext-property-setter
+  (make-inheritance-chain))
 
-(defmethod ext-setter [:editor.code.resource/CodeEditorResourceNode "text"]
-  [node-id _ rt _ _]
-  (fn [lua-value]
-    [(g/set-property node-id :modified-lines (code.util/split-lines (rt/->clj rt coerce/string lua-value)))
-     (g/update-property node-id :invalidated-rows conj 0)
-     (g/set-property node-id :cursor-ranges [#code/range[[0 0] [0 0]]])
-     (g/set-property node-id :regions [])]))
+(defn register-property-setter!
+  "Register a setter associated with a node type
+
+  Args:
+    node-type-kw    keyword of a graph node type
+    f               a function of 5 args:
+                      node-id               the node id to resolve the value
+                      property              string property name
+                      rt                    editor script runtime
+                      project               the project node id
+                      evaluation-context    the evaluation context
+                    the function should return either a 1-arg function from lua
+                    value to transaction steps or nil"
+  [node-type-kw f]
+  {:pre [(qualified-keyword? node-type-kw) (ifn? f)]}
+  (ext-property-setter node-type-kw f))
+
+(register-property-setter!
+  :editor.code.resource/CodeEditorResourceNode
+  (fn CodeEditorResourceNode-setter [node-id property rt _ _]
+    (case property
+      "text" (fn set-text [lua-value]
+               [(g/set-property node-id :modified-lines (code.util/split-lines (rt/->clj rt coerce/string lua-value)))
+                (g/update-property node-id :invalidated-rows conj 0)
+                (g/set-property node-id :cursor-ranges [#code/range[[0 0] [0 0]]])
+                (g/set-property node-id :regions [])])
+      nil)))
 
 (def ^:private tile-collision-group-coercer
   (coerce/map-of coerce/integer coerce/string))
 
-(defmethod ext-setter [:editor.tile-source/TileSourceNode "tile_collision_groups"]
-  [node-id _ rt project _]
-  (fn [lua-value]
-    (let [one-indexed-tile-index->collision-group-id (rt/->clj rt tile-collision-group-coercer lua-value)]
-      (g/expand-ec
-        (fn [evaluation-context]
-          (let [basis (:basis evaluation-context)
-                workspace (project/workspace project evaluation-context)
-                collision-id->node-id
-                (coll/pair-map-by
-                  #(g/node-value % :id evaluation-context)
-                  ((attachment/getter basis workspace (g/node-type* basis node-id) :collision-groups) node-id evaluation-context))
-                new-tile->collision-group-node
-                (coll/pair-map-by
-                  (comp dec key) ;; 1-indexed to 0-indexed
-                  (fn [e]
-                    (let [id (val e)]
-                      (or (collision-id->node-id id)
-                          (throw (LuaError. (format "Collision group \"%s\" is not defined in the tilesource" id))))))
-                  one-indexed-tile-index->collision-group-id)]
-            (g/set-property node-id :tile->collision-group-node new-tile->collision-group-node)))))))
+(register-property-setter!
+  :editor.tile-source/TileSourceNode
+  (fn TileSourceNode-setter [node-id property rt project _]
+    (case property
+      "tile_collision_groups"
+      (fn set-tile-collision-groups [lua-value]
+        (let [one-indexed-tile-index->collision-group-id (rt/->clj rt tile-collision-group-coercer lua-value)]
+          (g/expand-ec
+            (fn [evaluation-context]
+              (let [basis (:basis evaluation-context)
+                    workspace (project/workspace project evaluation-context)
+                    collision-id->node-id
+                    (coll/pair-map-by
+                      #(g/node-value % :id evaluation-context)
+                      ((attachment/getter basis workspace (g/node-type* basis node-id) :collision-groups) node-id evaluation-context))
+                    new-tile->collision-group-node
+                    (coll/pair-map-by
+                      (comp dec key) ;; 1-indexed to 0-indexed
+                      (fn [e]
+                        (let [id (val e)]
+                          (or (collision-id->node-id id)
+                              (throw (LuaError. (format "Collision group \"%s\" is not defined in the tilesource" id))))))
+                      one-indexed-tile-index->collision-group-id)]
+                (g/set-property node-id :tile->collision-group-node new-tile->collision-group-node))))))
+      nil)))
 
 (def ^:private tiles-coercer
   (coerce/wrap-with-pred coerce/userdata #(instance? Tiles %) "is not a tiles datatype"))
 
-(defmethod ext-setter [:editor.tile-map/LayerNode "tiles"] [node-id _ rt _ _]
-  (fn [lua-value]
-    (g/set-property node-id :cell-map ((rt/->clj rt tiles-coercer lua-value)))))
+(register-property-setter!
+  :editor.tile-map/LayerNode
+  (fn LayerNode-setter [node-id property rt _ _]
+    (case property
+      "tiles" (fn set-tiles [lua-value]
+                (g/set-property node-id :cell-map ((rt/->clj rt tiles-coercer lua-value))))
+      nil)))
 
-(defmethod ext-setter [:editor.particlefx/EmitterNode "animation"] [node-id _ rt _ _]
-  ;; set property directly instead of going through outline so that there is no
-  ;; order dependency between setting animation and material
-  (fn set-emitter-animation [lua-value]
-    (g/set-property node-id :animation (rt/->clj rt coerce/string lua-value))))
+(register-property-setter!
+  :editor.particlefx/EmitterNode
+  (fn EmitterNode-setter [node-id property rt _ _]
+    (case property
+      "animation"
+      ;; set property directly instead of going through outline so that there is no
+      ;; order dependency between setting animation and material
+      (fn set-emitter-animation [lua-value]
+        (g/set-property node-id :animation (rt/->clj rt coerce/string lua-value)))
+
+      nil)))
 
 (def ^:private modifier-type-coercer
   (apply coerce/enum (mapv first (protobuf/enum-values Particle$ModifierType))))
 
-(defmethod ext-setter [:editor.particlefx/ModifierNode "type"] [node-id _ rt _ _]
-  ;; hidden in the outline, but we want to set it from editor scripts
-  (fn set-modifier-type [lua-value]
-    (g/set-property node-id :type (rt/->clj rt modifier-type-coercer lua-value))))
+(register-property-setter!
+  :editor.particlefx/ModifierNode
+  (fn ModifierNode-setter [node-id property rt _ _]
+    (case property
+      "type"
+      ;; hidden in the outline, but we want to set it from editor scripts
+      (fn set-modifier-type [lua-value]
+        (g/set-property node-id :type (rt/->clj rt modifier-type-coercer lua-value)))
+
+      nil)))
+
+(register-property-setter!
+  ::outline/OutlineNode
+  (fn OutlineNode-setter [node-id property rt project evaluation-context]
+    (when-let [outline-property (outline-property node-id property evaluation-context)]
+      (when-not (properties/read-only? outline-property)
+        (let [edit-type (properties/property-edit-type outline-property)]
+          (when-let [from (-> edit-type
+                              properties/edit-type-id
+                              edit-type-id->value-converter
+                              :from)]
+            #(properties/set-value evaluation-context
+                                   outline-property
+                                   (from % rt edit-type project evaluation-context))))))))
 
 (defn ext-lua-value-setter
   "Create 1-arg fn from new lua value to transaction steps setting the property
 
   Returns nil if there is no setter for the node-id+property pair"
   [node-id property rt project evaluation-context]
-  (if (fn/multi-responds? ext-setter node-id property rt project evaluation-context)
-    (ext-setter node-id property rt project evaluation-context)
-    (when-let [outline-property (outline-property node-id property evaluation-context)]
-      (when-not (properties/read-only? outline-property)
-        (when-let [from (-> outline-property
-                            properties/edit-type-id
-                            edit-type-id->value-converter
-                            :from)]
-          #(properties/set-value evaluation-context
-                                 outline-property
-                                 (from % rt outline-property project evaluation-context)))))))
+  ((ext-property-setter (node-id->type-keyword node-id evaluation-context)) node-id property rt project evaluation-context))
+
+;; endregion
+
+;; region reset
+
+(defonce ^:private ext-property-resetter
+  (make-inheritance-chain))
+
+(defn register-property-resetter!
+  "Register a setter associated with a node type
+
+  Args:
+    node-type-kw    keyword of a graph node type
+    f               a function of 3 args:
+                      node-id               the node id to resolve the value
+                      property              string property name
+                      evaluation-context    the evaluation context
+                    the function should return either a 0-arg function that
+                    creates transaction steps or nil"
+  [node-type-kw f]
+  {:pre [(qualified-keyword? node-type-kw) (ifn? f)]}
+  (ext-property-resetter node-type-kw f))
+
+(register-property-resetter!
+  ::outline/OutlineNode
+  (fn OutlineNode-resetter [node-id property evaluation-context]
+    (when-let [property (outline-property node-id property evaluation-context)]
+      (when (and (not (properties/read-only? property))
+                 (properties/overridden-uncoalesced? property))
+        #(properties/clear-override-uncoalesced property)))))
+
+(def ^:private can-reset-args-coercer
+  (coerce/regex :node node-id-or-path-coercer :property coerce/string))
+
+(defn make-ext-can-reset-fn [project]
+  (rt/varargs-lua-fn ext-can-reset [{:keys [rt evaluation-context]} varargs]
+    (let [{:keys [node property]} (rt/->clj rt can-reset-args-coercer varargs)
+          node-id-or-resource (resolve-node-id-or-path node project evaluation-context)]
+      (and (not (resource/resource? node-id-or-resource))
+           (let [node-id node-id-or-resource]
+             (some? ((ext-property-resetter (node-id->type-keyword node-id evaluation-context)) node-id property evaluation-context)))))))
+
+(def ^:private reset-args-coercer
+  (coerce/regex :node node-id-or-path-coercer :property coerce/string))
+
+(defn make-ext-reset-fn [project]
+  (rt/varargs-lua-fn ext-reset [{:keys [rt evaluation-context]} varargs]
+    (let [{:keys [node property]} (rt/->clj rt reset-args-coercer varargs)
+          node-id (node-id-or-path->node-id node project evaluation-context)]
+      (if-let [resetter ((ext-property-resetter (node-id->type-keyword node-id evaluation-context)) node-id property evaluation-context)]
+        (-> (resetter)
+            (with-meta {:type :transaction-step})
+            (rt/wrap-userdata "editor.tx.reset(...)"))
+        (throw (LuaError. (format "Can't reset property \"%s\" of %s"
+                                  property
+                                  (name (node-id->type-keyword node-id evaluation-context)))))))))
 
 ;; endregion
 
@@ -485,7 +711,7 @@
           "height" default-capsule-height)
         (attachment->set-tx-steps child-node-id rt project evaluation-context))))
 
-(defmethod init-attachment :editor.gui/LayerNode [evaluation-context rt project parent-node-id _child-node-type child-node-id attachment]
+(defmethod init-attachment :editor.gui/LayerNode [evaluation-context rt project parent-node-id _ child-node-id attachment]
   (let [layers-node (gui-attachment/scene-node->layers-node (:basis evaluation-context) parent-node-id)]
     (concat
       (g/set-property child-node-id :child-index (gui-attachment/next-child-index layers-node evaluation-context))
@@ -561,7 +787,7 @@
     (reduce-kv
       (fn [acc property lua-value]
         (let [list-kw (property->prop-kw property)]
-          (if (attachment/defines? basis workspace node-type list-kw)
+          (if (attachment/editable? basis workspace node-type list-kw)
             (let [child-node-types (attachment/child-node-types basis workspace node-type list-kw)]
               (update acc :add
                       into
@@ -583,11 +809,17 @@
           workspace (project/workspace project evaluation-context)
           node-id (node-id-or-path->node-id node project evaluation-context)
           node-type (g/node-type* basis node-id)
-          list-kw (property->prop-kw property)
-          _ (when-not (attachment/defines? basis workspace node-type list-kw)
-              (throw (LuaError. (format "%s does not define \"%s\"" (name (:k node-type)) property))))
-          tree [[list-kw (parse-attachment basis workspace rt (attachment/child-node-types basis workspace node-type list-kw) attachment)]]]
-      (-> (attachment/add basis workspace node-id tree (partial g/expand-ec init-attachment rt project))
+          list-kw (property->prop-kw property)]
+      (when-not (attachment/defines? basis workspace node-type list-kw)
+        (throw (LuaError. (format "%s does not define \"%s\"" (name (:k node-type)) property))))
+      (when-not (attachment/editable? basis workspace node-type list-kw)
+        (throw (LuaError. (format "\"%s\" is not editable" property))))
+      (when (attachment/read-only? workspace node-id list-kw evaluation-context)
+        (throw (LuaError. (format "\"%s\" is read-only" property))))
+      (-> (attachment/add
+            basis workspace node-id
+            [[list-kw (parse-attachment basis workspace rt (attachment/child-node-types basis workspace node-type list-kw) attachment)]]
+            (partial g/expand-ec init-attachment rt project))
           (with-meta {:type :transaction-step})
           (rt/wrap-userdata "editor.tx.add(...)")))))
 
@@ -598,13 +830,12 @@
   (rt/varargs-lua-fn ext-can-add [{:keys [rt evaluation-context]} varargs]
     (let [{:keys [node property]} (rt/->clj rt can-add-args-coercer varargs)
           {:keys [basis]} evaluation-context
-          node-id-or-resource (resolve-node-id-or-path node project evaluation-context)]
+          node-id-or-resource (resolve-node-id-or-path node project evaluation-context)
+          list-kw (property->prop-kw property)
+          workspace (project/workspace project evaluation-context)]
       (and (not (resource/resource? node-id-or-resource))
-           (attachment/defines?
-             basis
-             (project/workspace project evaluation-context)
-             (g/node-type* basis node-id-or-resource)
-             (property->prop-kw property))))))
+           (attachment/editable? basis workspace (g/node-type* basis node-id-or-resource) list-kw)
+           (not (attachment/read-only? workspace node-id-or-resource list-kw evaluation-context))))))
 
 (def ^:private clear-args-coercer
   (coerce/regex :node node-id-or-path-coercer :property coerce/string))
@@ -619,6 +850,10 @@
           list-kw (property->prop-kw property)]
       (when-not (attachment/defines? basis workspace node-type list-kw)
         (throw (LuaError. (format "%s does not define \"%s\"" (name (:k node-type)) property))))
+      (when-not (attachment/editable? basis workspace node-type list-kw)
+        (throw (LuaError. (format "\"%s\" is not editable" property))))
+      (when (attachment/read-only? workspace node-id list-kw evaluation-context)
+        (throw (LuaError. (format "\"%s\" is read-only" property))))
       (-> (attachment/clear workspace node-id list-kw)
           (with-meta {:type :transaction-step})
           (rt/wrap-userdata "editor.tx.clear(...)")))))
@@ -637,6 +872,10 @@
           list-kw (property->prop-kw property)]
       (when-not (attachment/defines? basis workspace node-type list-kw)
         (throw (LuaError. (format "%s does not define \"%s\"" (name (:k node-type)) property))))
+      (when-not (attachment/editable? basis workspace node-type list-kw)
+        (throw (LuaError. (format "\"%s\" is not editable" property))))
+      (when (attachment/read-only? workspace node-id list-kw evaluation-context)
+        (throw (LuaError. (format "\"%s\" is read-only" property))))
       (when-not (some #(= child-node-id %) ((attachment/getter basis workspace node-type list-kw) node-id evaluation-context))
         (throw (LuaError. (format "%s is not in the \"%s\" list of %s" child property node))))
       (-> (attachment/remove workspace node-id list-kw child-node-id)
@@ -650,13 +889,12 @@
   (rt/varargs-lua-fn ext-can-reorder [{:keys [rt evaluation-context]} varargs]
     (let [{:keys [node property]} (rt/->clj rt can-reorder-args-coercer varargs)
           {:keys [basis]} evaluation-context
-          node-id-or-resource (resolve-node-id-or-path node project evaluation-context)]
+          node-id-or-resource (resolve-node-id-or-path node project evaluation-context)
+          workspace (project/workspace project evaluation-context)
+          list-kw (property->prop-kw property)]
       (and (not (resource/resource? node-id-or-resource))
-           (attachment/reorderable?
-             basis
-             (project/workspace project evaluation-context)
-             (g/node-type* basis node-id-or-resource)
-             (property->prop-kw property))))))
+           (attachment/reorderable? basis workspace (g/node-type* basis node-id-or-resource) list-kw)
+           (not (attachment/read-only? workspace node-id-or-resource list-kw evaluation-context))))))
 
 (def ^:private reorder-args-coercer
   (coerce/regex :node node-id-or-path-coercer
@@ -676,6 +914,8 @@
         (throw (LuaError. (format "%s does not define \"%s\"" (name (:k node-type)) property))))
       (when-not (attachment/reorderable? basis workspace node-type list-kw)
         (throw (LuaError. (format "%s does not support \"%s\" reordering" (name (:k node-type)) property))))
+      (when (attachment/read-only? workspace node-id list-kw evaluation-context)
+        (throw (LuaError. (format "\"%s\" is read-only" property))))
       (let [current-child-node-set (set ((attachment/getter basis workspace node-type list-kw) node-id evaluation-context))]
         (when (or (not (every? current-child-node-set reordered-child-node-ids))
                   (not (= (count current-child-node-set) (count reordered-child-node-ids))))

--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -4329,7 +4329,7 @@
 (def ^:private empty-node-type-registry
   {;; graph-node-type -> non-deprecated info
    :node-cls->type-info {}
-   ;; node-type-kw -> custom-type -> info
+   ;; node-desc-type keyword -> custom-type -> info
    :node-type->custom-type->type-info {}
    ;; flat list
    :type-infos []})
@@ -4431,8 +4431,6 @@
               (when-let [prop-kw->override (layout->prop->override layout-name)]
                 (when (contains? prop-kw->override prop-kw)
                   #(layout-property-clear-in-specific-layout evaluation-context layout-name node-id prop-kw))))))))))
-
-;; TODO: template nodes????
 
 (defn- init-gui-node-attachment [{:keys [basis] :as evaluation-context} rt project parent-node-id child-node-type child-node-id attachment node-id-base-name-fn]
   (let [{:keys [node-type custom-type defaults]} (get-registered-node-type-info child-node-type)

--- a/editor/src/clj/editor/gui_attachment.clj
+++ b/editor/src/clj/editor/gui_attachment.clj
@@ -41,6 +41,9 @@
 (defn scene-node->fonts-node [basis scene-node]
   (scene-input-node basis scene-node :fonts-node))
 
+(defn scene-node->node-tree [basis scene-node]
+  (scene-input-node basis scene-node :node-tree))
+
 (defn next-child-index [parent-node evaluation-context]
   (->> (g/node-value parent-node :child-indices evaluation-context)
        (e/map second)

--- a/editor/src/clj/editor/properties.clj
+++ b/editor/src/clj/editor/properties.clj
@@ -361,12 +361,15 @@
   (or (get property :edit-type)
       {:type (:type property)}))
 
-(defn edit-type-id [property]
-  (let [t (:type (property-edit-type property))
+(defn edit-type-id [edit-type]
+  (let [t (:type edit-type)
         t (or (g/value-type-dispatch-value t) t)]
     (if (:on-interface t)
       (:on t)
       t)))
+
+(defn property-edit-type-id [property]
+  (edit-type-id (property-edit-type property)))
 
 (defn value [property]
   ((get-in property [:edit-type :to-type] identity) (:value property)))
@@ -631,6 +634,10 @@
        (every? some? (:original-values property))
        (not-every? nil? (:values property))))
 
+(defn overridden-uncoalesced? [property]
+  (and (contains? property :original-value)
+       (not (g/error? (:original-value property)))))
+
 (defn error-aggregate [vals]
   (when-let [errors (seq (remove nil? (distinct (filter g/error? vals))))]
     (g/error-aggregate errors)))
@@ -638,6 +645,9 @@
 (defn validation-message [property]
   (when-let [err (error-aggregate (:errors property))]
     {:severity (:severity err) :message (g/error-message err)}))
+
+(defn clear-override-uncoalesced [property]
+  ((-> property :edit-type (:clear-fn g/clear-property)) (:node-id property) (:prop-kw property)))
 
 (defn clear-override! [property]
   (when (overridden? property)

--- a/editor/src/clj/editor/workspace.clj
+++ b/editor/src/clj/editor/workspace.clj
@@ -896,14 +896,24 @@ ordinary paths."
   (property unloaded-proj-path? g/Any)
   (property resource-kind-extensions g/Any (default {:atlas ["atlas" "tilesource"]}))
   ;; See editor.attachment ns
-  ;; :add -> type -> list-kw -> type -> tx-attach-fn
-  ;; :get -> type -> list-kw -> get-fn
-  ;; :reorder -> type -> list-kw -> reorder-fn
+  ;; {node-type {list-kw {:add {node-type tx-attach-fn}
+  ;;                      :get get-fn
+  ;;                      :reorder reorder-fn
+  ;;                      :read-only? read-only-pred
+  ;;                      ;; one of:
+  ;;                      :alias node-type
+  ;;                      :aliases #{node-types}}}}
   ;;
   ;; tx-attach-fn: fn of parent-node, child-node -> txs
   ;; get-fn: fn of node, evaluation-context -> vector of nodes
   ;; reorder-fn: fn of reordered-nodes -> txs
-  (property node-attachments g/Any (default {:add {} :get {} :reorder {}}))
+  ;; read-only-pred: fn of parent-node, evaluation-context -> boolean
+  ;;
+  ;; :alias refers to a node type that this list definition tracks (i.e. a link
+  ;; to the "original")
+  ;; :aliases refers to a set of all node types that track this definition (i.e.
+  ;; links to "copies")
+  (property node-attachments g/Any (default {}))
 
   (input code-preprocessors g/NodeID :cascade-delete)
   (input notifications g/NodeID :cascade-delete)

--- a/editor/src/clj/util/fn.clj
+++ b/editor/src/clj/util/fn.clj
@@ -25,6 +25,7 @@
 (defonce constantly-false (constantly false))
 (defonce constantly-true (constantly true))
 (defonce constantly-nil (constantly nil))
+(defonce constantly-constantly-nil (constantly constantly-nil))
 
 (defmacro constantly-fail
   ([message-expr]

--- a/editor/test/integration/editor_extensions_test.clj
+++ b/editor/test/integration/editor_extensions_test.clj
@@ -1334,6 +1334,7 @@ GUI initial state:
   layouts: 0
   spine scenes: 0
   fonts: 0
+  nodes: 0
 Transaction: edit GUI
 After transaction (edit):
   layers: 2
@@ -1363,7 +1364,63 @@ After transaction (edit):
     font: test /test.font
     font: font
     font: font1
+  nodes: 2
+  - type: gui-node-type-box
+    id: box
+    nodes: 5
+    - type: gui-node-type-pie
+      id: pie
+      nodes: 0
+    - type: gui-node-type-text
+      id: text
+      nodes: 0
+    - type: gui-node-type-template
+      id: button
+      nodes: 2
+      - type: gui-node-type-box
+        id: button/box
+        nodes: 0
+      - type: gui-node-type-text
+        id: button/text
+        nodes: 0
+    - type: gui-node-type-particlefx
+      id: particlefx
+      nodes: 0
+    - type: gui-node-type-spine
+      id: spine
+      nodes: 1
+      - type: gui-node-type-box
+        id: box1
+        nodes: 0
+  - type: gui-node-type-text
+    id: text1
+    nodes: 0
+Transaction: set Landscape position
+  position = {10, 10, 10}, can reset = false
+  Landscape:position = {20, 20, 20}, can reset = true
+  Portrait:position = {10, 10, 10}, can reset = false
+Transaction: reset Landscape position
+  position = {10, 10, 10}, can reset = false
+  Landscape:position = {10, 10, 10}, can reset = false
+  Portrait:position = {10, 10, 10}, can reset = false
+Template node: button
+  can add: false
+  can reorder: false
+Override text node: button/text
+  can add: false
+  can reorder: false
+Transaction: set override node property
+  text: custom text
+  can reset: true
+Transaction: reset override node property
+  text: <text>
+  can reset: false
+Transaction: set override position and layout position properties
+  position = {10, 10, 10}, can reset = true
+  Landscape:position = {20, 20, 20}, can reset = true
+  Portrait:position = {10, 10, 10}, can reset = false
 can reorder layers: true
+can reorder nodes: true
 Transaction: reorder
 After transaction (reorder):
   layers: 2
@@ -1393,12 +1450,48 @@ After transaction (reorder):
     font: test /test.font
     font: font
     font: font1
+  nodes: 2
+  - type: gui-node-type-text
+    id: text1
+    nodes: 0
+  - type: gui-node-type-box
+    id: box
+    nodes: 5
+    - type: gui-node-type-pie
+      id: pie
+      nodes: 0
+    - type: gui-node-type-text
+      id: text
+      nodes: 0
+    - type: gui-node-type-template
+      id: button
+      nodes: 2
+      - type: gui-node-type-box
+        id: button/box
+        nodes: 0
+      - type: gui-node-type-text
+        id: button/text
+        nodes: 0
+    - type: gui-node-type-particlefx
+      id: particlefx
+      nodes: 0
+    - type: gui-node-type-spine
+      id: spine
+      nodes: 1
+      - type: gui-node-type-box
+        id: box1
+        nodes: 0
 Expected reorder errors:
   undefined property => GuiSceneNode does not define \"not-a-property\"
   reorder not defined => CollisionObjectNode does not support \"shapes\" reordering
   duplicates => Reordered child nodes are not the same as current child nodes
   missing children => Reordered child nodes are not the same as current child nodes
   wrong child nodes => Reordered child nodes are not the same as current child nodes
+  add to template node => \"nodes\" is not editable
+  reorder template node => TemplateNode does not support \"nodes\" reordering
+  add to overridden text node => \"nodes\" is read-only
+  reorder overridden text node => \"nodes\" is read-only
+  reset unresettable => Can't reset property \"text\" of TextNode
 Transaction: clear GUI
 Expected layout errors:
   no name => layout name is required
@@ -1412,6 +1505,7 @@ After transaction (clear):
   layouts: 0
   spine scenes: 0
   fonts: 0
+  nodes: 0
 ")
 
 (deftest attachment-properties-test
@@ -1493,3 +1587,37 @@ emitters: 0
       (reload-editor-scripts! project :display-output! #(doto out (.append %2) (.append \newline)))
       (run-edit-menu-test-command!)
       (expect-script-output expected-particlefx-test-output out))))
+
+(deftest inheritance-chain-test
+  (testing "hierarchy adherence"
+    (let [h-ref (atom (-> (make-hierarchy)
+                          (derive :mammal :animal)
+                          (derive :bird :animal)
+                          (derive :dog :mammal)
+                          (derive :cat :mammal)
+                          (derive :sparrow :bird)
+                          (derive :eagle :bird)))
+          sound-chain (graph/make-inheritance-chain h-ref)]
+      (sound-chain :animal (constantly :grunt))
+      (sound-chain :mammal (constantly :roar))
+      (sound-chain :bird (constantly :chirp))
+      (sound-chain :cat #(when (:happy %) :meow))
+      (sound-chain :eagle (constantly :screech))
+      (is (= :chirp ((sound-chain :sparrow) {})))
+      (is (= :screech ((sound-chain :eagle) {})))
+      (is (= :roar ((sound-chain :dog) {})))
+      (is (= :roar ((sound-chain :cat) {})))
+      (is (= :meow ((sound-chain :cat) {:happy true})))))
+  (testing "hierarchy modification"
+    (let [h-ref (atom (derive (make-hierarchy) :mammal :animal))
+          sound-chain (graph/make-inheritance-chain h-ref)]
+      (sound-chain :animal (constantly :grunt))
+      (sound-chain :mammal (constantly :roar))
+      (is (= :roar ((sound-chain :mammal) {})))
+      (is (nil? ((sound-chain :cat) {})))
+      ;; hierarchy is modified
+      (swap! h-ref derive :cat :mammal)
+      (is (= :roar ((sound-chain :cat) {})))
+      ;; chain is modified
+      (sound-chain :cat (constantly :meow))
+      (is (= :meow ((sound-chain :cat) {}))))))

--- a/editor/test/integration/editor_extensions_test.clj
+++ b/editor/test/integration/editor_extensions_test.clj
@@ -1488,7 +1488,7 @@ Expected reorder errors:
   missing children => Reordered child nodes are not the same as current child nodes
   wrong child nodes => Reordered child nodes are not the same as current child nodes
   add to template node => \"nodes\" is not editable
-  reorder template node => TemplateNode does not support \"nodes\" reordering
+  reorder template node => \"nodes\" is not editable
   add to overridden text node => \"nodes\" is read-only
   reorder overridden text node => \"nodes\" is read-only
   reset unresettable => Can't reset property \"text\" of TextNode

--- a/editor/test/resources/editor_extensions/transact_attachment_project/button.gui
+++ b/editor/test/resources/editor_extensions/transact_attachment_project/button.gui
@@ -1,0 +1,32 @@
+fonts {
+  name: "test"
+  font: "/test.font"
+}
+nodes {
+  size {
+    x: 200.0
+    y: 100.0
+  }
+  type: TYPE_BOX
+  id: "box"
+  inherit_alpha: true
+  size_mode: SIZE_MODE_AUTO
+}
+nodes {
+  size {
+    x: 200.0
+    y: 100.0
+  }
+  color {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+  }
+  type: TYPE_TEXT
+  text: "<text>"
+  font: "test"
+  id: "text"
+  inherit_alpha: true
+}
+material: "/builtins/materials/gui.material"
+adjust_reference: ADJUST_REFERENCE_PARENT

--- a/editor/test/resources/editor_extensions/transact_attachment_project/test.editor_script
+++ b/editor/test/resources/editor_extensions/transact_attachment_project/test.editor_script
@@ -155,6 +155,28 @@ local function print_gui(gui)
         local font_res = editor.get(font, "font")
         print(("    font: %s%s"):format(editor.get(font, "name"), font_res and " " .. font_res or ""))
     end
+    local function print_gui_nodes(nodes, indent)
+        print(("%snodes: %s"):format(indent, #nodes))
+        local child_indent = indent .. "  "
+        for i = 1, #nodes do
+            local node = nodes[i]
+            local id_prop = editor.can_get(node, "id") and "id" or "generated_id"
+            print(("%s- type: %s"):format(indent, editor.get(node, "type")))
+            print(("%s  id: %s"):format(indent, editor.get(node, id_prop)))
+            print_gui_nodes(editor.get(node, "nodes"), child_indent)
+        end
+    end
+    print_gui_nodes(editor.get(gui, "nodes"), "  ")
+end
+
+local function print_gui_node_positions(node)
+    local props = {"position", "Landscape:position", "Portrait:position"}
+    for i = 1, #props do
+        local prop = props[i]
+        local position = editor.get(node, prop)
+        local can_reset = editor.can_reset(node, prop)
+        print(("  %s = {%s, %s, %s}, can reset = %s"):format(prop, position[1], position[2], position[3], tostring(can_reset)))
+    end
 end
 
 function M.get_commands()
@@ -358,6 +380,24 @@ function M.get_commands()
                     editor.tx.add(gui, "materials", {material = "/test.material"}),
                     editor.tx.add(gui, "materials", {material = "/test.material"}),
                     editor.tx.add(gui, "materials", {}),
+                    editor.tx.add(gui, "nodes", {
+                        type = "gui-node-type-box",
+                        position = {10, 10, 10},
+                        nodes = {
+                            {type = "gui-node-type-pie"},
+                            {type = "gui-node-type-text"},
+                            {
+                                type = "gui-node-type-template",
+                                template = "/button.gui"
+                            },
+                            {type = "gui-node-type-particlefx"},
+                            {
+                                type = "gui-node-type-spine",
+                                nodes = {{type = "gui-node-type-box"}}
+                            },
+                        }
+                    }),
+                    editor.tx.add(gui, "nodes", {type = "gui-node-type-text"}),
                     editor.tx.add(gui, "particlefxs", {}),
                     editor.tx.add(gui, "particlefxs", {particlefx = "/test.particlefx"}),
                     editor.tx.add(gui, "particlefxs", {}),
@@ -375,11 +415,50 @@ function M.get_commands()
                 print("After transaction (edit):")
                 print_gui(gui)
 
+                local nodes = editor.get(gui, "nodes")
+                local node = nodes[1]
+                print("Transaction: set Landscape position")
+                editor.transact({editor.tx.set(node, "Landscape:position", {20, 20, 20})})
+                print_gui_node_positions(node)
+
+                print("Transaction: reset Landscape position")
+                editor.transact({editor.tx.reset(node, "Landscape:position")})
+                print_gui_node_positions(node)
+
+                local template_node = editor.get(node, "nodes")[3]
+                print(("Template node: %s"):format(editor.get(template_node, "id")))
+                print(("  can add: %s"):format(tostring(editor.can_add(template_node, "nodes"))))
+                print(("  can reorder: %s"):format(tostring(editor.can_reorder(template_node, "nodes"))))
+                local override_text_node = editor.get(template_node, "nodes")[2]
+                print(("Override text node: %s"):format(editor.get(override_text_node, "generated_id")))
+                print(("  can add: %s"):format(tostring(editor.can_add(override_text_node, "nodes"))))
+                print(("  can reorder: %s"):format(tostring(editor.can_reorder(override_text_node, "nodes"))))
+
+                print("Transaction: set override node property")
+                editor.transact({editor.tx.set(override_text_node, "text", "custom text")})
+                print(("  text: %s"):format(editor.get(override_text_node, "text")))
+                print(("  can reset: %s"):format(tostring(editor.can_reset(override_text_node, "text"))))
+
+                print("Transaction: reset override node property")
+                editor.transact({editor.tx.reset(override_text_node, "text")})
+                print(("  text: %s"):format(editor.get(override_text_node, "text")))
+                print(("  can reset: %s"):format(tostring(editor.can_reset(override_text_node, "text"))))
+
+                print("Transaction: set override position and layout position properties")
+                editor.transact({
+                    editor.tx.set(override_text_node, "position", {10, 10, 10}),
+                    editor.tx.set(override_text_node, "Landscape:position", {20, 20, 20})
+                })
+                print_gui_node_positions(override_text_node)
+
                 print(("can reorder layers: %s"):format(tostring(editor.can_reorder(gui, "layers"))))
+                print(("can reorder nodes: %s"):format(tostring(editor.can_reorder(gui, "nodes"))))
                 local bg_layer, fg_layer = table.unpack(editor.get(gui, "layers"))
+                local node_a, node_b = nodes[1], nodes[2]
                 print("Transaction: reorder")
                 editor.transact({
-                    editor.tx.reorder(gui, "layers", {fg_layer, bg_layer})
+                    editor.tx.reorder(gui, "layers", {fg_layer, bg_layer}),
+                    editor.tx.reorder(gui, "nodes", {node_b, node_a}),
                 })
                 print("After transaction (reorder):")
                 print_gui(gui)
@@ -390,12 +469,18 @@ function M.get_commands()
                 expect_error("duplicates", editor.tx.reorder, gui, "layers", {fg_layer, fg_layer, bg_layer})
                 expect_error("missing children", editor.tx.reorder, gui, "layers", {fg_layer})
                 expect_error("wrong child nodes", editor.tx.reorder, gui, "layers", {fg_layer, gui})
+                expect_error("add to template node", editor.tx.add, template_node, "nodes", {type = "gui-node-type-box"})
+                expect_error("reorder template node", editor.tx.reorder, template_node, "nodes", {})
+                expect_error("add to overridden text node", editor.tx.add, override_text_node, "nodes", {type = "gui-node-type-box"})
+                expect_error("reorder overridden text node", editor.tx.reorder, override_text_node, "nodes", editor.get(override_text_node, "nodes"))
+                expect_error("reset unresettable", editor.tx.reset, override_text_node, "text")
 
                 print("Transaction: clear GUI")
                 editor.transact({
                     editor.tx.clear(gui, "layers"),
                     editor.tx.clear(gui, "layouts"),
                     editor.tx.clear(gui, "materials"),
+                    editor.tx.clear(gui, "nodes"),
                     editor.tx.clear(gui, "particlefxs"),
                     editor.tx.clear(gui, "spine_scenes"),
                     editor.tx.clear(gui, "textures"),


### PR DESCRIPTION
Now you can edit GUI nodes using editor scripts, e.g.:
```lua
editor.transact({
    editor.tx.add("/main.gui", "nodes", {
        type = "gui-node-type-box",
        position = {20, 20, 20}
    }),
    editor.tx.add("/main.gui", "nodes", {
        type = "gui-node-type-template",
        template = "/button.gui"
    }),
})
```

If the GUI file defines layouts, you can get and set the values from layouts using `layout:property` syntax, e.g.:
```lua
local node = editor.get("/main.gui", "nodes")[1]

-- GET:
local position = editor.get(node, "position")
pprint(position) -- {20, 20, 20}
local landscape_position = editor.get(node, "Landscape:position")
pprint(landscape_position) -- {20, 20, 20}

-- SET:
editor.transact({
    editor.tx.set(node, "Landscape:position", {30, 30, 30})
})
pprint(editor.get(node, "Landscape:position")) -- {30, 30, 30}
```

Layout properties that were set can be reset to their default values using `editor.tx.reset`:
```lua
print(editor.can_reset(node, "Landscape:position")) -- true
editor.transact({
    editor.tx.reset(node, "Landscape:position")
})
```
Template nodes can be read, but not edited: you can only set the properties of the template node tree:
```lua
local template = editor.get("/main.gui", "nodes")[2]
print(editor.can_add(template, "nodes")) -- false
local node_in_template = editor.get(template, "nodes")[1]
editor.transact({
    editor.tx.set(node_in_template, "text", "Button text")
})
print(editor.can_reset(node_in_template, "text")) -- true (overrides a value in the template)
```

Related to #8504
