### PR TITLE
Fix false positive physics overflow warning logs when physics.max_collision/physics.max_contacts are set to 0

### DIFF
--- a/engine/gamesys/src/gamesys/components/box2d/comp_collision_object_box2d.cpp
+++ b/engine/gamesys/src/gamesys/components/box2d/comp_collision_object_box2d.cpp
@@ -544,7 +544,7 @@ namespace dmGameSystem
         DM_PROFILE("StepWorld2D");
         dmPhysics::StepWorld2D(world->m_World2D, *step_ctx);
 
-        if (collision_user_data->m_Count >= physics_context->m_BaseContext.m_MaxCollisionCount)
+        if (collision_user_data->m_Count >= physics_context->m_BaseContext.m_MaxCollisionCount && physics_context->m_BaseContext.m_MaxCollisionCount > 0)
         {
             if (!g_CollisionOverflowWarning)
             {
@@ -556,7 +556,7 @@ namespace dmGameSystem
         {
             g_CollisionOverflowWarning = false;
         }
-        if (contact_user_data->m_Count >= physics_context->m_BaseContext.m_MaxContactPointCount)
+        if (contact_user_data->m_Count >= physics_context->m_BaseContext.m_MaxContactPointCount && physics_context->m_BaseContext.m_MaxContactPointCount > 0)
         {
             if (!g_ContactOverflowWarning)
             {

--- a/engine/gamesys/src/gamesys/components/bullet3d/comp_collision_object_bullet3d.cpp
+++ b/engine/gamesys/src/gamesys/components/bullet3d/comp_collision_object_bullet3d.cpp
@@ -337,7 +337,7 @@ namespace dmGameSystem
         DM_PROFILE("StepWorld3D");
         dmPhysics::StepWorld3D(world->m_World3D, *step_ctx);
 
-        if (collision_user_data->m_Count >= physics_context->m_BaseContext.m_MaxCollisionCount)
+        if (collision_user_data->m_Count >= physics_context->m_BaseContext.m_MaxCollisionCount && physics_context->m_BaseContext.m_MaxCollisionCount > 0)
         {
             if (!g_CollisionOverflowWarning)
             {
@@ -349,7 +349,7 @@ namespace dmGameSystem
         {
             g_CollisionOverflowWarning = false;
         }
-        if (contact_user_data->m_Count >= physics_context->m_BaseContext.m_MaxContactPointCount)
+        if (contact_user_data->m_Count >= physics_context->m_BaseContext.m_MaxContactPointCount && physics_context->m_BaseContext.m_MaxContactPointCount > 0)
         {
             if (!g_ContactOverflowWarning)
             {


### PR DESCRIPTION
Fix false positive physics overflow warning logs when physics.max_collision/physics.max_contacts are set to 0
Fixes #10872

## Technical changes
Logic is correct as long as max limit > 0. If max_collision or max_contacts is zero the condition (count >= 0) is always true, so we will always log on startup before any actual collision occurs.

Fixed by only checking overflow when max limit > 0.

