### PR TITLE
Improved gamepad connect handling

### DIFF
--- a/engine/hid/src/native/hid_gamepad_driver_glfw.cpp
+++ b/engine/hid/src/native/hid_gamepad_driver_glfw.cpp
@@ -421,7 +421,9 @@ namespace dmHID
         }
         else
         {
-            name[0] = '\0';
+            // the gamepad must have a non-empty string name
+            // in order to use it (even as the raw gamepad binding)
+            dmStrlCpy(name, "_", MAX_GAMEPAD_NAME_LENGTH);
         }
     }
 

--- a/engine/hid/src/native/hid_gamepad_driver_glfw.cpp
+++ b/engine/hid/src/native/hid_gamepad_driver_glfw.cpp
@@ -422,7 +422,7 @@ namespace dmHID
         else
         {
             // the gamepad must have a non-empty string name
-            // in order to use it (even as the raw gamepad binding)
+            // in order to use it (even as the a gamepad binding)
             dmStrlCpy(name, "_", MAX_GAMEPAD_NAME_LENGTH);
         }
     }

--- a/engine/hid/src/native/hid_gamepad_driver_glfw.cpp
+++ b/engine/hid/src/native/hid_gamepad_driver_glfw.cpp
@@ -415,7 +415,14 @@ namespace dmHID
     static void GetGamepadDeviceNameInternal(HContext context, int glfw_id, char name[MAX_GAMEPAD_NAME_LENGTH])
     {
         const char* device_name = dmPlatform::GetJoystickDeviceName(context->m_Window, glfw_id);
-        dmStrlCpy(name, device_name, MAX_GAMEPAD_NAME_LENGTH);
+        if (device_name != 0x0)
+        {
+            dmStrlCpy(name, device_name, MAX_GAMEPAD_NAME_LENGTH);
+        }
+        else
+        {
+            name[0] = '\0';
+        }
     }
 
     static void GLFWGamepadDriverGetGamepadDeviceName(HContext context, GamepadDriver* driver, HGamepad gamepad, char name[MAX_GAMEPAD_NAME_LENGTH])


### PR DESCRIPTION
If the engine fails to get the name of a connected gamepad a default name will be used to avoid a crash on Windows. 

Fixes #10856 