### PR TITLE
Add option to disable OpenGL ES 2.0 shader compilation

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
@@ -1456,6 +1456,7 @@ public class Project {
         options.add(new GameProjectBuildOption("output-glsl120", "output-glsl120", "shader","output_glsl120",null));
         options.add(new GameProjectBuildOption("output-glsl330", "output-glsl330", "shader","output_glsl330",null));
         options.add(new GameProjectBuildOption("output-glsl430", "output-glsl430", "shader","output_glsl430",null));
+        options.add(new GameProjectBuildOption("exclude-gles-sm100", "exclude-gles-sm100", "shader", "exclude_gles_sm100", null));
 
         options.add(new GameProjectBuildOption("sound-stream-enabled", "sound-stream-enabled", "sound","stream_enabled",null));
         options.add(new GameProjectBuildOption("model-split-large-meshes", "model-split-large-meshes", "model","split_meshes",null));

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
@@ -251,6 +251,11 @@ output_spirv.type = bool
 output_spirv.help = This setting is deprecated. Compile and output SPIR-V shaders for use with Metal or Vulkan
 output_spirv.default = 0
 
+exclude_gles_sm100.type = bool
+exclude_gles_sm100.help = Don't compile shaders for devices running OpenGLES 2.0 / WebGL 1.0
+exclude_gles_sm100.default = 0
+exclude_gles_sm100.private = 1
+
 [sound]
 help = Sound related settings
 

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/IShaderCompiler.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/IShaderCompiler.java
@@ -27,6 +27,7 @@ public interface IShaderCompiler {
         public ArrayList<ShaderDesc.Language> forceIncludeShaderLanguages = new ArrayList<>();
         public int maxPageCount;
         public boolean forceSplitSamplers;
+        public boolean excludeGlesSm100;
     };
 
     ShaderProgramBuilder.ShaderCompileResult compile(ArrayList<ShaderCompilePipeline.ShaderModuleDesc> shaderModules, String resourceOutputPath, CompileOptions options) throws IOException, CompileExceptionError;

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderCompilers.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderCompilers.java
@@ -34,7 +34,7 @@ public class ShaderCompilers {
             this.platform = platform;
         }
 
-        private Set<ShaderDesc.Language> getPlatformShaderLanguages(boolean isComputeType, boolean outputSpirv, boolean outputWGLS, boolean outputHLSL, boolean outputGLSL) {
+        private Set<ShaderDesc.Language> getPlatformShaderLanguages(boolean isComputeType, boolean outputSpirv, boolean outputWGLS, boolean outputHLSL, boolean outputGLSL, CompileOptions compileOptions) {
             Set<ShaderDesc.Language> shaderLanguages = new LinkedHashSet<>();
 
             boolean spirvSupported = true;
@@ -64,7 +64,9 @@ public class ShaderCompilers {
             if (platform == Platform.Arm64Linux) {
                 if (!isComputeType) {
                     shaderLanguages.add(ShaderDesc.Language.LANGUAGE_GLES_SM300);
-                    shaderLanguages.add(ShaderDesc.Language.LANGUAGE_GLES_SM100);
+                    if (!compileOptions.excludeGlesSm100) {
+                        shaderLanguages.add(ShaderDesc.Language.LANGUAGE_GLES_SM100);
+                    }
                 }
             }
             else
@@ -79,7 +81,9 @@ public class ShaderCompilers {
                 platform == Platform.Arm64Android) {
                     if (!isComputeType) {
                         shaderLanguages.add(ShaderDesc.Language.LANGUAGE_GLES_SM300);
-                        shaderLanguages.add(ShaderDesc.Language.LANGUAGE_GLES_SM100);
+                        if (!compileOptions.excludeGlesSm100) {
+                            shaderLanguages.add(ShaderDesc.Language.LANGUAGE_GLES_SM100);
+                        }
                     }
             }
             else
@@ -88,7 +92,9 @@ public class ShaderCompilers {
                 platform == Platform.WasmPthreadWeb) {
                     if (!isComputeType) {
                         shaderLanguages.add(ShaderDesc.Language.LANGUAGE_GLES_SM300);
-                        shaderLanguages.add(ShaderDesc.Language.LANGUAGE_GLES_SM100);
+                        if (!compileOptions.excludeGlesSm100) {
+                            shaderLanguages.add(ShaderDesc.Language.LANGUAGE_GLES_SM100);
+                        }
                     }
                     if (outputWGLS)
                         shaderLanguages.add(ShaderDesc.Language.LANGUAGE_WGSL);
@@ -158,7 +164,7 @@ public class ShaderCompilers {
 
             validateModules(shaderModules);
 
-            Set<ShaderDesc.Language> shaderLanguages = getPlatformShaderLanguages(isComputeType, outputSpirv, outputWGSL, outputHLSL, outputGlsl);
+            Set<ShaderDesc.Language> shaderLanguages = getPlatformShaderLanguages(isComputeType, outputSpirv, outputWGSL, outputHLSL, outputGlsl, compileOptions);
             assert shaderLanguages != null;
 
             // Used for tests, merge in potentially unsupported languages here.

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderProgramBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderProgramBuilder.java
@@ -42,7 +42,7 @@ import com.dynamo.graphics.proto.Graphics.ShaderDesc;
 @BuilderParams(name="ShaderProgram", inExts= {".shbundle", ".shbundlec"}, outExt=".spc",
         // See configurePreBuildProjectOptions in Project.java
         paramsForSignature = {"platform", "output-spirv", "output-wgsl", "output-hlsl", "output-glsles100",
-        "output-glsles300", "output-glsl120", "output-glsl330", "output-glsl430"})
+        "output-glsles300", "output-glsl120", "output-glsl330", "output-glsl430", "exclude-gles-sm100"})
 public class ShaderProgramBuilder extends Builder {
 
     static public class ShaderBuildResult {
@@ -130,6 +130,7 @@ public class ShaderProgramBuilder extends Builder {
             this.modulesDescs.get(i).source = this.modulePreprocessors.get(i).getCompiledSource();
         }
 
+        compileOptions.excludeGlesSm100 = getExcludeGlesSm100Flag();
         if (getOutputHlslFlag()) {
             addUniqueShaderLanguage(ShaderDesc.Language.LANGUAGE_HLSL);
         }
@@ -170,17 +171,18 @@ public class ShaderProgramBuilder extends Builder {
         task.output(0).setContent(shaderDescBuildResult.shaderDesc.toByteArray());
     }
 
-    private boolean getOutputShaderFlag(String projectOption, String projectProperty) {
+    private boolean getOutputShaderFlag(String projectOption) {
         // See configurePreBuildProjectOptions in Project.java
         return this.project.option(projectOption, "false").equals("true");
     }
 
-    private boolean getOutputSpirvFlag() { return getOutputShaderFlag("output-spirv", "output_spirv"); }
-    private boolean getOutputHlslFlag() { return getOutputShaderFlag("output-hlsl", "output_hlsl"); }
-    private boolean getOutputWGSLFlag() { return getOutputShaderFlag("output-wgsl", "output_wgsl"); }
-    private boolean getOutputGLSLFlag() { return getOutputShaderFlag("output-glsl", "output_glsl"); }
-    private boolean getOutputGLSLESFlag(int version) { return getOutputShaderFlag("output-glsles" + version, "output_glsl_es" + version); }
-    private boolean getOutputGLSLFlag(int version) { return getOutputShaderFlag("output-glsl" + version, "output_glsl" + version); }
+    private boolean getOutputSpirvFlag() { return getOutputShaderFlag("output-spirv"); }
+    private boolean getOutputHlslFlag() { return getOutputShaderFlag("output-hlsl"); }
+    private boolean getOutputWGSLFlag() { return getOutputShaderFlag("output-wgsl"); }
+    private boolean getOutputGLSLFlag() { return getOutputShaderFlag("output-glsl"); }
+    private boolean getOutputGLSLESFlag(int version) { return getOutputShaderFlag("output-glsles" + version); }
+    private boolean getOutputGLSLFlag(int version) { return getOutputShaderFlag("output-glsl" + version); }
+    private boolean getExcludeGlesSm100Flag() { return getOutputShaderFlag("exclude-gles-sm100"); }
 
     static public ShaderDescBuildResult buildResultsToShaderDescBuildResults(ShaderCompileResult shaderCompileresult) throws CompileExceptionError {
         ShaderDescBuildResult shaderDescBuildResult = new ShaderDescBuildResult();

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderProgramBuilderEditor.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderProgramBuilderEditor.java
@@ -96,10 +96,11 @@ public class ShaderProgramBuilderEditor {
                     shaderTypeKeys.put(shaderModule.type, true);
                 }
 
-                byte[] source = pipeline.crossCompile(shaderModule.type, shaderLanguage);
-                if (source == null) {
-                    String[] shaderWarnings = new String[] { "Unable to cross-compile " + shaderModule.type + " to " + shaderLanguage};
-                    shaderBuildResults.add(new ShaderProgramBuilder.ShaderBuildResult(shaderWarnings));
+                byte[] source;
+                try {
+                    source = pipeline.crossCompile(shaderModule.type, shaderLanguage);
+                } catch (CompileExceptionError e) {
+                    shaderBuildResults.add(new ShaderProgramBuilder.ShaderBuildResult(new String[]{e.getMessage()}));
                     continue;
                 }
 

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/shader/ShaderCompilePipeline.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/shader/ShaderCompilePipeline.java
@@ -444,7 +444,9 @@ public class ShaderCompilePipeline {
             Shaderc.ShaderCompileResult result = generateCrossCompiledShader(shaderType, shaderLanguage, version);
 
             if (!result.lastError.isEmpty()) {
-                throw new CompileExceptionError("Cross-compilation of shader type: " + shaderType + ", to language: " + shaderLanguage + " failed, reason: " + result.lastError);
+                String excludeKey = shaderLanguage == ShaderDesc.Language.LANGUAGE_GLES_SM100 ? "exclude_gles_sm100" : null;
+                String exclusionMessage = excludeKey != null ? "\nEnable the 'shader." + excludeKey + "' option in game.project if you don't intend to use this language." : "";
+                throw new CompileExceptionError("Cross-compilation of shader type: " + shaderType + ", to language: " + shaderLanguage + " failed, reason: " + result.lastError + exclusionMessage);
             }
 
             byte[] bytes = result.data;

--- a/editor/resources/meta.edn
+++ b/editor/resources/meta.edn
@@ -339,6 +339,11 @@
    :deprecated true,
    :label "Output SPIR-V"
    :path ["shader" "output_spirv"]}
+  {:type :boolean
+   :help "Don't compile shaders for devices running OpenGLES 2.0 / WebGL 1.0"
+   :default false
+   :label "Exclude GLES 2.0"
+   :path ["shader" "exclude_gles_sm100"]}
   {:type :number,
    :help
    "seconds to wait before treating a held down keyboard-key to start repeating itself",
@@ -949,7 +954,7 @@
    :help "liveupdate settings"
    :preserve-extension true,
    :path ["liveupdate" "settings"]}
-   {:type :boolean
+  {:type :boolean
    :filter "settings"
    :default true
    :help "enables auto-mount of previously mounted resources when the application starts"

--- a/editor/src/clj/editor/code/shader_compilation.clj
+++ b/editor/src/clj/editor/code/shader_compilation.clj
@@ -20,6 +20,7 @@
             [editor.protobuf :as protobuf]
             [editor.resource :as resource]
             [editor.workspace :as workspace]
+            [util.array :as array]
             [util.eduction :as e])
   (:import [com.dynamo.bob.pipeline ShaderProgramBuilder$ShaderDescBuildResult ShaderProgramBuilderEditor]
            [com.dynamo.bob.pipeline.shader ShaderCompilePipeline$ShaderModuleDesc]
@@ -30,13 +31,19 @@
 
 (def built-pb-class Graphics$ShaderDesc)
 
-(defonce ^:private ^"[Lcom.dynamo.graphics.proto.Graphics$ShaderDesc$Language;" pb-shader-languages-with-spirv
-  (into-array
-    Graphics$ShaderDesc$Language
-    (map shader-gen/shader-language->pb-shader-language
-         ;; TODO: WGSL support (:language-wgsl)
-         ;; TODO(question): Does the order matter?
-         [:language-glsl-sm330 :language-gles-sm300 :language-gles-sm100 :language-glsl-sm430 :language-spirv])))
+(defn- pb-shader-languages [shader-languages]
+  (array/from-type Graphics$ShaderDesc$Language (mapv shader-gen/shader-language->pb-shader-language shader-languages)))
+
+(def ^:private default-shader-languages
+  ;; TODO: WGSL support (:language-wgsl)
+  ;; TODO(question): Does the order matter?
+  [:language-glsl-sm330 :language-gles-sm300 :language-gles-sm100 :language-glsl-sm430 :language-spirv])
+
+(defonce ^:private ^"[Lcom.dynamo.graphics.proto.Graphics$ShaderDesc$Language;" pb-default-shader-languages
+  (pb-shader-languages default-shader-languages))
+
+(defonce ^:private ^"[Lcom.dynamo.graphics.proto.Graphics$ShaderDesc$Language;" pb-shader-languages-without-gles-sm100
+  (pb-shader-languages (e/remove #(= :language-gles-sm100 %) default-shader-languages)))
 
 (defn- make-shader-module-desc
   ^ShaderCompilePipeline$ShaderModuleDesc [^String resource-proj-path ^String shader-source]
@@ -51,29 +58,28 @@
     (set! (. shader-module-desc type) pb-shader-type)
     shader-module-desc))
 
-(defn- make-shader-desc-with-variants
-  ^ShaderProgramBuilder$ShaderDescBuildResult [build-resource shader-module-descs max-page-count]
-  {:pre [(workspace/build-resource? build-resource)]}
-  (let [build-resource-path (resource/path build-resource)
-        shader-module-descs-array (into-array ShaderCompilePipeline$ShaderModuleDesc shader-module-descs)]
-    (ShaderProgramBuilderEditor/makeShaderDescWithVariants build-resource-path shader-module-descs-array pb-shader-languages-with-spirv (int max-page-count))))
-
 (defn- error-string->error-value [^String error-string]
   (g/error-fatal (string/trim error-string)))
 
 (defn- build-shader [build-resource _dep-resources user-data]
-  (let [max-page-count (:max-page-count user-data)
+  {:pre [(workspace/build-resource? build-resource)]}
+  (let [{:keys [max-page-count shader-infos exclude-gles-sm100]} user-data
         shader-module-descs (e/map (fn [{:keys [proj-path shader-source]}]
                                      (make-shader-module-desc proj-path shader-source))
-                                   (:shader-infos user-data))
-        shader-desc-build-result (make-shader-desc-with-variants build-resource shader-module-descs max-page-count)
+                                   shader-infos)
+        build-resource-path (resource/path build-resource)
+        shader-module-descs-array (into-array ShaderCompilePipeline$ShaderModuleDesc shader-module-descs)
+        pb-shader-languages (if exclude-gles-sm100
+                              pb-shader-languages-without-gles-sm100
+                              pb-default-shader-languages)
+        shader-desc-build-result (ShaderProgramBuilderEditor/makeShaderDescWithVariants build-resource-path shader-module-descs-array pb-shader-languages (int max-page-count))
         compile-warning-messages (.buildWarnings shader-desc-build-result)
         compile-error-values (mapv error-string->error-value compile-warning-messages)]
     (g/precluding-errors compile-error-values
       {:resource build-resource
        :content (protobuf/pb->bytes (.-shaderDesc shader-desc-build-result))})))
 
-(defn make-shader-build-target [node-id shader-source-infos max-page-count]
+(defn make-shader-build-target [node-id shader-source-infos max-page-count exclude-gles-sm100]
   {:pre [(g/node-id? node-id)
          (vector? shader-source-infos)
          (pos? (count shader-source-infos))
@@ -94,4 +100,5 @@
        :resource (workspace/make-placeholder-build-resource workspace "sp")
        :build-fn build-shader
        :user-data {:max-page-count max-page-count
-                   :shader-infos shader-infos}})))
+                   :shader-infos shader-infos
+                   :exclude-gles-sm100 exclude-gles-sm100}})))

--- a/editor/src/clj/editor/compute.clj
+++ b/editor/src/clj/editor/compute.clj
@@ -75,7 +75,7 @@
 (g/defnk produce-build-targets [_node-id save-value resource shader-source-info compute-program]
   (or (g/flatten-errors
         (prop-resource-error _node-id :compute-program compute-program "Compute Program" "cp"))
-      (let [compute-shader-build-target (shader-compilation/make-shader-build-target _node-id [shader-source-info] 0)
+      (let [compute-shader-build-target (shader-compilation/make-shader-build-target _node-id [shader-source-info] 0 true)
             dep-build-targets [compute-shader-build-target]
             compute-desc-with-build-resources (assoc save-value
                                                 :compute-program (:resource compute-shader-build-target)

--- a/editor/src/clj/editor/defold_project.clj
+++ b/editor/src/clj/editor/defold_project.clj
@@ -1538,6 +1538,7 @@
                                                                  (not (resource/read-only? resource))))))
                                                    save-data)))
   (output settings g/Any (g/fnk [settings] (or settings gpc/default-settings)))
+  (output exclude-gles-sm100 g/Any (g/fnk [settings] (get settings ["shader" "exclude_gles_sm100"])))
   (output display-profiles g/Any :cached (gu/passthrough display-profiles))
   (output texture-profiles g/Any :cached (gu/passthrough texture-profiles))
   (output nil-resource resource/Resource (g/constantly nil))

--- a/editor/src/clj/editor/material.clj
+++ b/editor/src/clj/editor/material.clj
@@ -123,12 +123,12 @@
                          (format "'%s' attribute uses normalize with float data type"
                                  name)))]))
 
-(g/defnk produce-build-targets [_node-id attribute-infos base-pb-msg fragment-program fragment-shader-source-info max-page-count resource vertex-program vertex-shader-source-info]
+(g/defnk produce-build-targets [_node-id attribute-infos base-pb-msg fragment-program fragment-shader-source-info max-page-count exclude-gles-sm100 resource vertex-program vertex-shader-source-info]
   (or (g/flatten-errors
         (prop-resource-error _node-id :vertex-program vertex-program "Vertex Program" "vp")
         (prop-resource-error _node-id :fragment-program fragment-program "Fragment Program" "fp")
         (mapcat #(attribute-info->error-values % _node-id :attributes) attribute-infos))
-      (let [shader-desc-build-target (shader-compilation/make-shader-build-target _node-id [vertex-shader-source-info fragment-shader-source-info] max-page-count)
+      (let [shader-desc-build-target (shader-compilation/make-shader-build-target _node-id [vertex-shader-source-info fragment-shader-source-info] max-page-count exclude-gles-sm100)
             build-target-samplers (build-target-samplers (:samplers base-pb-msg) max-page-count)
             build-target-attributes (build-target-attributes attribute-infos)
             dep-build-targets [shader-desc-build-target]
@@ -581,6 +581,7 @@
   (input vertex-shader-source-info g/Any)
   (input fragment-resource resource/Resource)
   (input fragment-shader-source-info g/Any)
+  (input exclude-gles-sm100 g/Any)
 
   (output base-pb-msg g/Any produce-base-pb-msg)
 
@@ -600,6 +601,7 @@
         attributes->editable-attributes #(mapv attribute->editable-attribute %)]
     (concat
       (g/connect project :default-sampler-filter-modes self :default-sampler-filter-modes)
+      (g/connect project :exclude-gles-sm100 self :exclude-gles-sm100)
       (gu/set-properties-from-pb-map self Material$MaterialDesc material-desc
         vertex-program (resolve-resource :vertex-program)
         fragment-program (resolve-resource :fragment-program)

--- a/editor/test/resources/save_data_project/game.project
+++ b/editor/test/resources/save_data_project/game.project
@@ -270,3 +270,5 @@ app_manifest = /checked.appmanifest
 player_name = Player One
 player_health = 120
 
+[shader]
+exclude_gles_sm100 = 0


### PR DESCRIPTION
New `game.project` property `shader.exclude_gles_sm100` allows skipping shader compilation to OpenGL ES 2.0 / WebGL 1.0 (GLES SM100) language.

Fixes #10684