### PR TITLE
Increase initial delay before showing code hover

### DIFF
--- a/editor/src/clj/editor/code/view.clj
+++ b/editor/src/clj/editor/code/view.clj
@@ -1676,9 +1676,12 @@
     (and (get-property view-node :completions-showing evaluation-context)
          (pos? (count (get-property view-node :completions-combined evaluation-context))))))
 
-(defn- hover-visible? [view-node]
-  (g/with-auto-evaluation-context evaluation-context
-    (some? (get-property view-node :hover-showing-regions evaluation-context))))
+(defn- hover-visible?
+  ([view-node]
+   (g/with-auto-evaluation-context evaluation-context
+     (hover-visible? view-node evaluation-context)))
+  ([view-node evaluation-context]
+   (some? (get-property view-node :hover-showing-regions evaluation-context))))
 
 (defn- selected-suggestion [view-node]
   (g/with-auto-evaluation-context evaluation-context
@@ -2570,7 +2573,8 @@
      (schedule-hover-refresh! view-node evaluation-context)))
   ([view-node evaluation-context]
    (some-> (g/node-value view-node :hover-request evaluation-context) ui/cancel)
-   {:hover-request (ui/->future 0.2 #(refresh-hover-state! view-node))}))
+   (let [delay (if (hover-visible? view-node evaluation-context) 0.2 1.0)]
+     {:hover-request (ui/->future delay #(refresh-hover-state! view-node))})))
 
 (defn- request-lsp-hover! [view-node lsp resource-node new-hover-cursor evaluation-context]
   (let [old-hover-cursor (get-property view-node :hover-cursor evaluation-context)
@@ -2650,7 +2654,7 @@
         (data/mouse-exited (get-property view-node :gesture-start evaluation-context)
                            (get-property view-node :hovered-element evaluation-context))
         (when-not (get-property view-node :hover-mouse-over-popup evaluation-context)
-          (assoc (schedule-hover-refresh! view-node) :hover-cursor nil))))))
+          (assoc (schedule-hover-refresh! view-node evaluation-context) :hover-cursor nil))))))
 
 (defn handle-scroll! [view-node zoom-on-scroll ^ScrollEvent event]
   (.consume event)


### PR DESCRIPTION
Now the hover popup in the code editor is less annoying.