### PR TITLE
Fixed a regression in panning volume

### DIFF
--- a/engine/sound/src/sound.cpp
+++ b/engine/sound/src/sound.cpp
@@ -1199,11 +1199,10 @@ namespace dmSound
                 assert(info->m_Channels == 2);
 
                 float rs, ls;
-                GetPanScale(dmMath::Max(0.0f, instance->m_Pan.m_Current - 0.5f), &ls, &rs);
+                GetPanScale(instance->m_Pan.m_Current, &ls, &rs);
                 instance->m_ScaleL[0].Set(ls * gain, reset);
-                instance->m_ScaleR[0].Set(rs * gain, reset);
-                GetPanScale(dmMath::Min(instance->m_Pan.m_Current + 0.5f, 1.0f), &ls, &rs);
-                instance->m_ScaleL[1].Set(ls * gain, reset);
+                instance->m_ScaleR[0].Set(0.0f, reset);
+                instance->m_ScaleL[1].Set(0.0f, reset);
                 instance->m_ScaleR[1].Set(rs * gain, reset);
             }
         }

--- a/engine/sound/src/sound.cpp
+++ b/engine/sound/src/sound.cpp
@@ -1047,7 +1047,7 @@ namespace dmSound
         return RESULT_OK;
     }
 
-    static inline void GetPanScale(float pan, float* left_scale, float* right_scale)
+    void GetPanScale(float pan, float* left_scale, float* right_scale)
     {
         // Constant power panning: https://www.cs.cmu.edu/~music/icm-online/readings/panlaws/index.html
         const float theta = pan * M_PI_2;

--- a/engine/sound/src/sound_private.h
+++ b/engine/sound/src/sound_private.h
@@ -30,6 +30,13 @@ namespace dmSound
 
     uint32_t GetDefaultFrameCount(uint32_t mix_rate);
 
+    /*
+     * @param pan [type: float] Range [0, 1]. 0.5 == center panning, 0 == full left, 1 == full right
+     * @param left_scale [type: float*] (out)Range [0, 1]
+     * @param right_scale [type: float*] (out)Range [0, 1]
+     */
+    void GetPanScale(float pan, float* left_scale, float* right_scale);
+
     // Unit tests
     int64_t GetInternalPos(HSoundInstance);
     int32_t GetRefCount(HSoundData);

--- a/engine/sound/src/test/test_sound.cpp
+++ b/engine/sound/src/test/test_sound.cpp
@@ -1650,7 +1650,7 @@ INSTANTIATE_TEST_CASE_P(dmSoundVerifyAdpcmTest, dmSoundVerifyAdpcmTest, jc_test_
 #endif
 
 #if !defined(GITHUB_CI) || (defined(GITHUB_CI) && !defined(WIN32))
-TEST_P(dmSoundTestPlayTest, Play)
+TEST_P(dmSoundTestPlayTest, Panning)
 {
 
     TestParams params = GetParam();
@@ -1686,7 +1686,8 @@ TEST_P(dmSoundTestPlayTest, Play)
         if (a > M_PI*2) {
             a-= M_PI*2;
         }
-        r = dmSound::SetParameter(instance, dmSound::PARAMETER_PAN, dmVMath::Vector4(cosf(a),0,0,0));
+        float pan = cosf(a);
+        r = dmSound::SetParameter(instance, dmSound::PARAMETER_PAN, dmVMath::Vector4(pan,0,0,0));
         ASSERT_EQ(dmSound::RESULT_OK, r);
 
         uint64_t tend = dmTime::GetMonotonicTime();

--- a/engine/sound/src/test/test_sound.cpp
+++ b/engine/sound/src/test/test_sound.cpp
@@ -606,6 +606,9 @@ TEST_P(dmSoundVerifyTest, Mix)
     ASSERT_EQ(dmSound::RESULT_OK, r);
     ASSERT_NE((dmSound::HSoundInstance) 0, instance);
 
+    r = dmSound::SetParameter(instance, dmSound::PARAMETER_PAN, dmVMath::Vector4(params.m_Pan,0,0,0));
+    ASSERT_EQ(dmSound::RESULT_OK, r);
+
     r = dmSound::Play(instance);
     ASSERT_EQ(dmSound::RESULT_OK, r);
     printf("Playing: %d\n", dmSound::IsPlaying(instance));
@@ -621,11 +624,22 @@ TEST_P(dmSoundVerifyTest, Mix)
 
     const double f = 44100.0;
     const int n = (int)(frame_count * (f / mix_rate));
+    const double level = 1.0f;
 
-    const double level = sin(M_PI_4); // center panning introduces this loss of signal
+    ASSERT_GE(g_LoopbackDevice->m_AllOutput.Size(), n * 2U);
 
-    assert(g_LoopbackDevice->m_AllOutput.Size() >= n * 2);
 
+
+    // We need to check that the panning works as intended.
+    // Instead of checking the panning cintinuously, we check the -1 (left), 1 (right) and 0 (center)
+    // Note: currently center panning introduces ~3dB loss of signal (see dmSound::GetPanScale())
+
+    // map [-1,1] to [0,1] for use with
+    float pan_01 = dmMath::Max(-1.0f, dmMath::Min(1.0f, params.m_Pan));
+    pan_01 = (pan_01 + 1.0f) * 0.5f;
+
+    float ls, rs;
+    dmSound::GetPanScale(pan_01, &ls, &rs);
     uint64_t delta = (uint64_t)(mix_rate * (1UL << dmSound::RESAMPLE_FRACTION_BITS) / f);
     uint64_t pos = 0;
     for (int32_t i = 0; i < n - 1; i++) {
@@ -634,9 +648,11 @@ TEST_P(dmSoundVerifyTest, Mix)
         pos += delta;
 
         int16_t as = (int16_t)dmMath::Clamp(a, -32768.0, 32767.0);
+        int16_t aleft = as * ls;
+        int16_t aright = as * rs;
 
-        ASSERT_NEAR(g_LoopbackDevice->m_AllOutput[2 * i], as, 27);
-        ASSERT_NEAR(g_LoopbackDevice->m_AllOutput[2 * i + 1], as, 27);
+        ASSERT_NEAR(g_LoopbackDevice->m_AllOutput[2 * i], aleft, 27);
+        ASSERT_NEAR(g_LoopbackDevice->m_AllOutput[2 * i + 1], aright, 27);
     }
 
     ASSERT_EQ(0u, g_LoopbackDevice->m_AllOutput.Size() % 2);
@@ -649,14 +665,14 @@ TEST_P(dmSoundVerifyTest, Mix)
     dmSound::GetGroupRMS(dmHashString64("master"), params.m_BufferFrameCount / f, &rms_left, &rms_right);
     dmSound::GetGroupRMS(dmHashString64("master"), params.m_BufferFrameCount / f, &rms_left, &rms_right);
     // Theoretical RMS for a sin-function with amplitude a is a / sqrt(2)
-    ASSERT_NEAR(0.8f / sqrtf(2.0f) * level, rms_left, 0.02f);
-    ASSERT_NEAR(0.8f / sqrtf(2.0f) * level, rms_right, 0.02f);
+    ASSERT_NEAR(0.8f / sqrtf(2.0f) * level * ls, rms_left, 0.02f);
+    ASSERT_NEAR(0.8f / sqrtf(2.0f) * level * rs, rms_right, 0.02f);
 
     float peak_left, peak_right;
     dmSound::GetGroupPeak(dmHashString64("master"), params.m_BufferFrameCount / f, &peak_left, &peak_right);
     dmSound::GetGroupPeak(dmHashString64("master"), params.m_BufferFrameCount / f, &peak_left, &peak_right);
-    ASSERT_NEAR(0.8f* level, peak_left, 0.01f);
-    ASSERT_NEAR(0.8f* level, peak_right, 0.01f);
+    ASSERT_NEAR(0.8f* level * ls, peak_left, 0.01f);
+    ASSERT_NEAR(0.8f* level * rs, peak_right, 0.01f);
 
     int expected_queued = (frame_count * (int)f) / ((int) mix_rate * params.m_BufferFrameCount)
                             + dmMath::Min(1U, (frame_count * (int)f) % ((int) mix_rate * params.m_BufferFrameCount));
@@ -840,6 +856,31 @@ TestParams("loopback",
 
 INSTANTIATE_TEST_CASE_P(dmSoundVerifyTest, dmSoundVerifyTest, jc_test_values_in(params_verify_test));
 
+// We also want to test the panning outputs correctly
+const TestParams params_verify_test_pan[] = {
+    TestParams("loopback",
+            MONO_TONE_440_44100_88200_WAV,
+            MONO_TONE_440_44100_88200_WAV_SIZE,
+            dmSound::SOUND_DATA_TYPE_WAV,
+            440,
+            44100,
+            88200,
+            1056,
+            -1.0f,
+            1.0f),
+    TestParams("loopback",
+            STEREO_TONE_440_44100_88200_WAV,
+            STEREO_TONE_440_44100_88200_WAV_SIZE,
+            dmSound::SOUND_DATA_TYPE_WAV,
+            440,
+            44100,
+            88200,
+            1056,
+            1.0f,
+            1.0f)
+};
+
+INSTANTIATE_TEST_CASE_P(dmSoundVerifyTestPan, dmSoundVerifyTest, jc_test_values_in(params_verify_test_pan));
 
 #if !defined(GITHUB_CI) || (defined(GITHUB_CI) && !defined(WIN32))
 TEST_P(dmSoundTestGroupRampTest, GroupRamp)

--- a/engine/sound/src/test/test_sound.cpp
+++ b/engine/sound/src/test/test_sound.cpp
@@ -549,7 +549,7 @@ static float GainToScale(float gain)
     return scale;
 }
 
-// Generate sine wave per given parametyers and resasmple it as needed to mimic runtimes signal path for generated test waves
+// Generate sine wave per given parameters and resample it as needed to mimic runtimes signal path for generated test waves
 static double GenAndMixTone(uint64_t pos, float tone_frq, float sample_rate, float mix_rate, int num_frames, bool ramp_active, float scale)
 {
     static_assert(_pfb_num_phases == 1 << 11, "PFB header does not readily offer this constant - update needed (see below)!");
@@ -622,7 +622,7 @@ TEST_P(dmSoundVerifyTest, Mix)
     const double f = 44100.0;
     const int n = (int)(frame_count * (f / mix_rate));
 
-    const double level = (params.m_Channels == 2) ? 1.0f : sin(M_PI_4); // center panning introduces this (only for mono samples)
+    const double level = sin(M_PI_4); // center panning introduces this loss of signal
 
     assert(g_LoopbackDevice->m_AllOutput.Size() >= n * 2);
 


### PR DESCRIPTION
Fixes https://github.com/defold/defold/issues/10879

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
