### PR TITLE
Don't use `.` and `(` as completion auto-commit characters

### DIFF
--- a/editor/src/clj/editor/code/script.clj
+++ b/editor/src/clj/editor/code/script.clj
@@ -128,10 +128,6 @@
                  :close-scopes {\' "punctuation.definition.string.quoted.end.lua"
                                 \" "punctuation.definition.string.quoted.end.lua"
                                 \] "punctuation.definition.string.end.lua"}}
-   :commit-characters {:method #{"("}
-                       :function #{"("}
-                       :field #{"."}
-                       :module #{"."}}
    :completion-trigger-characters #{"."}
    :ignored-completion-trigger-characters #{"{" ","}
    :patterns [{:captures {1 {:name "keyword.control.lua"}

--- a/editor/src/clj/editor/code/view.clj
+++ b/editor/src/clj/editor/code/view.clj
@@ -2385,9 +2385,7 @@
         (cond
           (and selected-suggestion
                (or (= "\r" typed)
-                   (let [commit-characters (or (:commit-characters selected-suggestion)
-                                               (get-in grammar [:commit-characters (:type selected-suggestion)]))]
-                     (contains? commit-characters typed))))
+                   (contains? (:commit-characters selected-suggestion) typed)))
           (let [insertion (code-completion/insertion selected-suggestion)]
             (do (accept-suggestion! view-node insertion)
                 [;; insert-typed


### PR DESCRIPTION
Previously, the text editor would accept displayed completion if the user typed `.` or `(`. It results in a surprising behavior if the user was simply typing and didn't look at the completion list. Other editors like vscode don't accept selected completions when typing these characters, so we now follow the same behavior.

Related to #10781