### PR TITLE
Improve callback invalidation

### DIFF
--- a/engine/gameobject/src/gameobject/gameobject_script.cpp
+++ b/engine/gameobject/src/gameobject/gameobject_script.cpp
@@ -363,6 +363,13 @@ namespace dmGameObject
         return 1;
     }
 
+    static int ScriptGetUniqueScriptId(lua_State* L)
+    {
+        ScriptInstance* inst = (ScriptInstance*)lua_touserdata(L, 1);
+        lua_pushinteger(L, (lua_Integer)inst->m_UniqueScriptId);
+        return 1;
+    }
+
     static const luaL_reg ScriptInstance_methods[] =
     {
         {0,0}
@@ -379,6 +386,7 @@ namespace dmGameObject
         {dmScript::META_TABLE_IS_VALID,                 ScriptInstanceIsValid},
         {dmScript::META_GET_INSTANCE_CONTEXT_TABLE_REF, ScriptGetInstanceContextTableRef},
         {dmScript::META_GET_INSTANCE_DATA_TABLE_REF,    ScriptGetInstanceDataTableRef},
+        {dmScript::META_GET_UNIQUE_SCRIPT_ID,           ScriptGetUniqueScriptId},
         {0, 0}
     };
 
@@ -2451,6 +2459,7 @@ bail:
         i->m_Instance = instance;
         i->m_ScriptWorld = script_world->m_ScriptWorld;
         i->m_ComponentIndex = component_index;
+        i->m_UniqueScriptId = dmScript::GenerateUniqueScriptId();
         NewPropertiesParams params;
         params.m_ResolvePathCallback = ScriptInstanceResolvePathCB;
         params.m_ResolvePathUserData = (uintptr_t)L;

--- a/engine/gameobject/src/gameobject/gameobject_script.h
+++ b/engine/gameobject/src/gameobject/gameobject_script.h
@@ -74,11 +74,14 @@ namespace dmGameObject
         HScript     m_Script;
         Instance*   m_Instance;
         dmScript::HScriptWorld m_ScriptWorld;
+        HProperties m_Properties;
+
         int         m_InstanceReference;
         int         m_ScriptDataReference;
         int         m_ContextTableReference;
+        uint32_t    m_UniqueScriptId;
+
         uint16_t    m_ComponentIndex;
-        HProperties m_Properties;
         uint8_t    m_Update       : 1;
         uint8_t    m_Initialized  : 1;
         uint8_t    m_Padding      : 6;

--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -2306,6 +2306,7 @@ namespace dmGui
     Result SetSceneScript(HScene scene, HScript script)
     {
         scene->m_Script = script;
+        scene->m_UniqueScriptId = dmScript::GenerateUniqueScriptId();
         return RESULT_OK;
     }
 

--- a/engine/gui/src/gui_private.h
+++ b/engine/gui/src/gui_private.h
@@ -252,6 +252,7 @@ namespace dmGui
         int                                   m_InstanceReference;
         int                                   m_DataReference;
         int                                   m_ContextTableReference;
+        uint32_t                              m_UniqueScriptId;
         Context*                              m_Context;
         Script*                               m_Script;
         dmIndexPool16                         m_NodePool;

--- a/engine/gui/src/gui_script.cpp
+++ b/engine/gui/src/gui_script.cpp
@@ -291,6 +291,13 @@ namespace dmGui
         return 1;
     }
 
+    static int GuiScriptGetUniqueScriptId(lua_State* L)
+    {
+        Scene* inst = (Scene*)lua_touserdata(L, 1);
+        lua_pushinteger(L, (lua_Integer)inst->m_UniqueScriptId);
+        return 1;
+    }
+
     static const luaL_reg GuiScriptInstance_methods[] =
     {
         {0,0}
@@ -306,6 +313,7 @@ namespace dmGui
         {dmScript::META_TABLE_IS_VALID,                 GuiScriptInstanceIsValid},
         {dmScript::META_GET_INSTANCE_CONTEXT_TABLE_REF, GuiScriptGetInstanceContextTableRef},
         {dmScript::META_GET_INSTANCE_DATA_TABLE_REF,    GuiScriptGetInstanceDataTableRef},
+        {dmScript::META_GET_UNIQUE_SCRIPT_ID,           GuiScriptGetUniqueScriptId},
         {0, 0}
     };
 

--- a/engine/render/src/render/render_script.cpp
+++ b/engine/render/src/render/render_script.cpp
@@ -579,6 +579,13 @@ namespace dmRender
         return 1;
     }
 
+    static int RenderScriptGetUniqueScriptId(lua_State* L)
+    {
+        RenderScriptInstance* inst = (RenderScriptInstance*)lua_touserdata(L, 1);
+        lua_pushinteger(L, (lua_Integer)inst->m_UniqueScriptId);
+        return 1;
+    }
+
     static const luaL_reg RenderScriptInstance_methods[] =
     {
         {0,0}
@@ -594,6 +601,7 @@ namespace dmRender
         {dmScript::META_TABLE_IS_VALID,                 RenderScriptInstanceIsValid},
         {dmScript::META_GET_INSTANCE_CONTEXT_TABLE_REF, RenderScriptGetInstanceContextTableRef},
         {dmScript::META_GET_INSTANCE_DATA_TABLE_REF,    RenderScriptGetInstanceDataTableRef},
+        {dmScript::META_GET_UNIQUE_SCRIPT_ID,           RenderScriptGetUniqueScriptId},
         {0, 0}
     };
 
@@ -3325,6 +3333,7 @@ bail:
         RenderScriptInstance* i = (RenderScriptInstance*)lua_newuserdata(L, sizeof(RenderScriptInstance));
         ResetRenderScriptInstance(i);
         i->m_PredicateCount = 0;
+        i->m_UniqueScriptId = dmScript::GenerateUniqueScriptId();
         i->m_RenderScript = render_script;
         i->m_ScriptWorld = render_context->m_ScriptWorld;
         i->m_RenderContext = render_context;

--- a/engine/render/src/render/render_script.h
+++ b/engine/render/src/render/render_script.h
@@ -63,6 +63,7 @@ namespace dmRender
         HRenderScript                 m_RenderScript;
         dmScript::ScriptWorld*        m_ScriptWorld;
         uint32_t                      m_PredicateCount;
+        uint32_t                      m_UniqueScriptId;
         int                           m_InstanceReference;
         int                           m_RenderScriptDataReference;
         int                           m_ContextTableReference;

--- a/engine/script/src/script.cpp
+++ b/engine/script/src/script.cpp
@@ -65,12 +65,14 @@ namespace dmScript
     const char META_TABLE_IS_VALID[]                 = "__is_valid";
     const char META_GET_INSTANCE_CONTEXT_TABLE_REF[] = "__get_instance_context_table_ref";
     const char META_GET_INSTANCE_DATA_TABLE_REF[]    = "__get_instance_data_table_ref";
+    const char META_GET_UNIQUE_SCRIPT_ID[]           = "__get_unique_script_id";
 
     const char SCRIPT_METATABLE_TYPE_HASH_KEY_NAME[] = "__dmengine_type";
     static const uint32_t SCRIPT_METATABLE_TYPE_HASH_KEY = dmHashBufferNoReverse32(SCRIPT_METATABLE_TYPE_HASH_KEY_NAME, sizeof(SCRIPT_METATABLE_TYPE_HASH_KEY_NAME) - 1);
 
     // A debug value for profiling lua references
     int g_LuaReferenceCount = 0;
+    const uint32_t INVALID_SCRIPT_ID = 0xFFFFFFFF;
 
     HContext NewContext(const ContextParams& params)
     {
@@ -1127,6 +1129,18 @@ namespace dmScript
 
         lua_pop(L, 1);
         // [-1] value
+    }
+
+    uint32_t GenerateUniqueScriptId()
+    {
+        static uint32_t counter = 0;
+
+        if (counter == INVALID_SCRIPT_ID - 1)
+            counter = 0;
+        else
+            ++counter;
+
+        return counter;
     }
 
     HScriptWorld NewScriptWorld(HContext context)

--- a/engine/script/src/script.cpp
+++ b/engine/script/src/script.cpp
@@ -1587,7 +1587,9 @@ namespace dmScript
         GetInstance(L);
         // [-1] instance
 
-        if (!GetMetaFunction(L, -1, META_GET_INSTANCE_CONTEXT_TABLE_REF, sizeof(META_GET_INSTANCE_CONTEXT_TABLE_REF) - 1)) {
+        if (!GetMetaFunction(L, -1, META_GET_INSTANCE_CONTEXT_TABLE_REF, sizeof(META_GET_INSTANCE_CONTEXT_TABLE_REF) - 1))
+        {
+            dmLogError("CreateCallback failed: missing meta function for instance context table");
             lua_pop(L, 1);
             return 0x0;
         }
@@ -1615,6 +1617,7 @@ namespace dmScript
         // [-1] context table
         if (lua_type(L, -1) != LUA_TTABLE)
         {
+            dmLogError("CreateCallback failed: expected context table (LUA_TTABLE), got %s", lua_typename(L, lua_type(L, -1)));
             lua_pop(L, 2);
             return 0x0;
         }

--- a/engine/script/src/script.h
+++ b/engine/script/src/script.h
@@ -57,6 +57,7 @@ namespace dmScript
     extern const char META_TABLE_GET_USER_DATA[];
     extern const char META_TABLE_IS_VALID[];
     extern const char META_GET_INSTANCE_DATA_TABLE_REF[];
+    extern const char META_GET_UNIQUE_SCRIPT_ID[];
 
     /**
      * Implementor should return a Ref to the instance context table.
@@ -505,6 +506,17 @@ namespace dmScript
      *  [-1] value
     */
     void GetScriptWorldContextValue(HScriptWorld script_world);
+
+    /**
+     * Generate a new unique script ID.
+     *
+     * This function is responsible for producing a unique 32-bit identifier
+     * that can be used to uniquely identify a script instance during its lifetime.
+     * The returned ID is guaranteed to never be INVALID_SCRIPT_ID.
+     *
+     * @return a unique non-zero uint32_t script identifier
+     */
+    uint32_t GenerateUniqueScriptId();
 
     /**
      * Retrieve the Lua traceback from the current context

--- a/engine/script/src/test/test_script_lua.cpp
+++ b/engine/script/src/test/test_script_lua.cpp
@@ -219,7 +219,7 @@ struct TestDummy {
     dmMessage::URL  m_URL;
     int             m_InstanceReference;
     int             m_ContextTableReference;
-    int             m_UniqueScriptId;
+    uint32_t        m_UniqueScriptId;
 };
 
 static int TestGetURL(lua_State* L) {

--- a/engine/script/src/test/test_script_timer.cpp
+++ b/engine/script/src/test/test_script_timer.cpp
@@ -740,6 +740,7 @@ struct ScriptInstance
 {
     int m_InstanceReference;
     int m_ContextTableReference;
+    int m_UniqueScriptId;
 };
 
 static int ScriptGetInstanceContextTableRef(lua_State* L)
@@ -767,6 +768,13 @@ static int ScriptInstanceIsValid(lua_State* L)
     return 1;
 }
 
+static int ScriptScriptGetUniqueScriptId(lua_State* L)
+{
+    ScriptInstance* inst = (ScriptInstance*)lua_touserdata(L, 1);
+    lua_pushinteger(L, (lua_Integer)inst->m_UniqueScriptId);
+    return 1;
+}
+
 static const luaL_reg ScriptInstance_methods[] =
 {
     {0,0}
@@ -776,6 +784,7 @@ static const luaL_reg ScriptInstance_meta[] =
 {
     {dmScript::META_TABLE_IS_VALID,                 ScriptInstanceIsValid},
     {dmScript::META_GET_INSTANCE_CONTEXT_TABLE_REF, ScriptGetInstanceContextTableRef},
+    {dmScript::META_GET_UNIQUE_SCRIPT_ID,           ScriptScriptGetUniqueScriptId},
     {0, 0}
 };
 
@@ -786,6 +795,7 @@ static void CreateScriptInstance(lua_State* L, const char* type)
 
     lua_newtable(L);
     i->m_ContextTableReference = dmScript::Ref( L, LUA_REGISTRYINDEX );
+    i->m_UniqueScriptId = dmScript::GenerateUniqueScriptId();
 
     lua_rawgeti(L, LUA_REGISTRYINDEX, i->m_InstanceReference);
     luaL_getmetatable(L, type);


### PR DESCRIPTION
Ensure that callbacks properly track whether they are still valid and avoid situations where the wrong callback could be accidentally destroyed under certain conditions.

Fix https://github.com/defold/defold/issues/10868
Fix https://github.com/defold/defold/issues/8759