### PR TITLE
Extend build.py to track build times

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,4 @@ editor/.lsp/sqlite.db
 /com.dynamo.cr/out/
 /com.dynamo.cr/com.dynamo.cr.bob.test/test/proj/build/
 /com.dynamo.cr/test_resources/
+/build_times.json

--- a/build_tools/BuildTimeTracker.py
+++ b/build_tools/BuildTimeTracker.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python
+# Copyright 2020-2025 The Defold Foundation
+# Copyright 2014-2020 King
+# Copyright 2009-2014 Ragnar Svensson, Christian Murray
+# Licensed under the Defold License version 1.0 (the "License"); you may not use
+# this file except in compliance with the License.
+#
+# You may obtain a copy of the License, together with FAQs at
+# https://www.defold.com/license
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+import os
+import json
+import time
+from datetime import datetime
+
+class BuildTimeTracker:
+    """
+    Tracks build times for commands and engine components.
+    Provides functionality to log, save, and analyze build performance.
+    """
+    
+    def __init__(self, output_file=None, logger=None):
+        self.start_times = {}
+        self.end_times = {}
+        self.component_times = {}
+        self.command_times = {}
+        self.output_file = output_file or "build_times.json"
+        self.current_command = None
+        self.logger = logger or print
+        
+    def start_command(self, command_name):
+        """Start timing a build command"""
+        self.current_command = command_name
+        self.start_times[command_name] = time.time()
+        self.logger(f"Starting '{command_name}' at {datetime.now().strftime('%H:%M:%S')}")
+        
+    def end_command(self, command_name):
+        """End timing a build command"""
+        if command_name in self.start_times:
+            end_time = time.time()
+            duration = end_time - self.start_times[command_name]
+            self.command_times[command_name] = {
+                'start_time': self.start_times[command_name],
+                'end_time': end_time,
+                'duration': duration,
+                'timestamp': datetime.now().isoformat()
+            }
+            self.logger(f"'{command_name}' completed in {duration:.2f} s")
+            
+    def start_component(self, component_name, platform=None):
+        """Start timing an engine component build"""
+        key = f"{component_name}_{platform}" if platform else component_name
+        self.start_times[key] = time.time()
+        
+        # Log the start of component build
+        platform_str = f" for {platform}" if platform else ""
+        self.logger(f"Building {component_name}{platform_str}")
+        
+    def end_component(self, component_name, platform=None):
+        """End timing an engine component build"""
+        key = f"{component_name}_{platform}" if platform else component_name
+        if key in self.start_times:
+            end_time = time.time()
+            duration = end_time - self.start_times[key]
+            
+            if component_name not in self.component_times:
+                self.component_times[component_name] = {}
+            
+            self.component_times[component_name][platform or 'default'] = {
+                'start_time': self.start_times[key],
+                'end_time': end_time,
+                'duration': duration,
+                'timestamp': datetime.now().isoformat()
+            }
+            
+            self.logger(f"  {component_name} ({platform}) completed in {duration:.2f} s")
+            
+    def get_summary(self):
+        """Get a summary of all build times"""
+        summary = {
+            'build_session': {
+                'start_time': min(self.start_times.values()) if self.start_times else None,
+                'end_time': max(self.end_times.values()) if self.end_times else None,
+                'total_duration': sum(cmd['duration'] for cmd in self.command_times.values()) if self.command_times else 0,
+                'timestamp': datetime.now().isoformat()
+            },
+            'commands': self.command_times,
+            'components': self.component_times
+        }
+        
+        # Calculate component totals
+        component_totals = {}
+        for component, platforms in self.component_times.items():
+            total_duration = sum(platform_data['duration'] for platform_data in platforms.values())
+            component_totals[component] = {
+                'total_duration': total_duration,
+                'platforms': len(platforms),
+                'average_per_platform': total_duration / len(platforms) if platforms else 0
+            }
+        
+        summary['component_totals'] = component_totals
+        return summary
+        
+    def save_times(self, filename=None):
+        """Save build times to JSON file"""
+        output_file = filename or self.output_file
+        summary = self.get_summary()
+        
+        # Save only the current build session (overwrite file)
+        with open(output_file, 'w') as f:
+            json.dump(summary, f, indent=2)
+            
+        self.logger(f"Build times saved to {output_file}")
+        
+    def print_summary(self):
+        """Print a formatted summary of build times"""
+        summary = self.get_summary()
+        
+        self.logger("\n" + "="*60)
+        self.logger("BUILD TIME SUMMARY")
+        self.logger("="*60)
+        
+        # Command times
+        if self.command_times:
+            self.logger("\nCOMMAND TIMES:")
+            for cmd, data in sorted(self.command_times.items(), key=lambda x: x[1]['duration'], reverse=True):
+                self.logger(f"  {cmd:<20} {data['duration']:>8.2f} s")
+        
+        # Component times
+        if self.component_times:
+            self.logger("\nCOMPONENT TIMES (by platform):")
+            for component, platforms in self.component_times.items():
+                self.logger(f"\n  {component}:")
+                for platform, data in sorted(platforms.items(), key=lambda x: x[1]['duration'], reverse=True):
+                    self.logger(f"    {platform:<15} {data['duration']:>8.2f} s")
+        
+        # Component totals
+        if summary.get('component_totals'):
+            self.logger("\nCOMPONENT TOTALS:")
+            total_component_time = 0.0
+            for component, data in sorted(summary['component_totals'].items(), 
+                                        key=lambda x: x[1]['total_duration'], reverse=True):
+                self.logger(f"  {component:<20} {data['total_duration']:>8.2f} s ({data['platforms']} platforms, avg: {data['average_per_platform']:.2f} s)")
+                total_component_time += data['total_duration']
+            self.logger(f"\n  TOTAL COMPONENT TIME: {total_component_time:>8.2f} s")
+        
+        self.logger("="*60) 

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -35,6 +35,7 @@ from glob import glob
 from threading import Thread, Event
 from queue import Queue
 from configparser import ConfigParser
+from BuildTimeTracker import BuildTimeTracker
 
 BASE_PLATFORMS = [  'x86_64-linux', 'arm64-linux',
                     'x86_64-macos', 'arm64-macos',
@@ -504,6 +505,7 @@ class Configuration(object):
         self.gcloud_certfile = gcloud_certfile
         self.gcloud_keyfile = gcloud_keyfile
         self.verbose = verbose
+        self.build_tracker = BuildTimeTracker(logger=self._log)
 
         if self.github_token is None:
             self.github_token = os.environ.get("GITHUB_TOKEN")
@@ -1351,7 +1353,7 @@ class Configuration(object):
         return '%s %s/ext/bin/waf --prefix=%s %s %s %s %s %s' % (' '.join(self.get_python()), self.dynamo_home, prefix, skip_tests, skip_codesign, disable_ccache, generate_compile_commands, commands)
 
     def _build_engine_lib(self, args, lib, platform, skip_tests = False, dir = 'engine'):
-        self._log('Building %s for %s' % (lib, platform))
+        self.build_tracker.start_component(lib, platform)
         skip_build_tests = []
         if skip_tests and '--skip-build-tests' not in self.waf_options:
             skip_build_tests.append('--skip-tests')
@@ -1359,6 +1361,7 @@ class Configuration(object):
         cwd = join(self.defold_root, '%s/%s' % (dir, lib))
         plf_args = ['--platform=%s' % platform]
         run.env_command(self._form_env(), args + plf_args + self.waf_options + skip_build_tests, cwd = cwd)
+        self.build_tracker.end_component(lib, platform)
 
 # For now gradle right in
 # - 'com.dynamo.cr/com.dynamo.cr.bob'
@@ -1372,7 +1375,7 @@ class Configuration(object):
             return join('.', 'gradlew')
 
     def build_bob_light(self):
-        self._log('Building bob light')
+        self.build_tracker.start_component('bob_light', self.host)
 
         bob_dir = join(self.defold_root, 'com.dynamo.cr/com.dynamo.cr.bob')
         # common_dir = join(self.defold_root, 'com.dynamo.cr/com.dynamo.cr.common')
@@ -1396,6 +1399,7 @@ class Configuration(object):
         s = run.command(" ".join([gradle, '-Pkeep-bob-uncompressed', 'clean', 'installBobLight'] + gradle_args), cwd = bob_dir, shell = True, env = env)
         if self.verbose:
         	print (s)
+        self.build_tracker.end_component('bob_light', self.host)
 
     def build_engine(self):
         self.check_sdk()
@@ -2789,11 +2793,13 @@ To pass on arbitrary options to waf: build.py OPTIONS COMMANDS -- WAF_OPTIONS
         if not f:
             parser.error('Unknown command %s' % cmd)
         else:
-            start = time.time()
-            print("Running '%s'" % cmd)
+            c.build_tracker.start_command(cmd)
             f()
             c.wait_uploads()
-            duration = (time.time() - start)
-            print("'%s' completed in %.2f s" % (cmd, duration))
+            c.build_tracker.end_command(cmd)
+
+    # Print and save build time summary
+    c.build_tracker.print_summary()
+    c.build_tracker.save_times()
 
     print('Done')


### PR DESCRIPTION
When build is done `build.py` provides summary how long each command/component took time.
Also, it creates a json file with detailed info which might be useful in the future if we decide to track this time in a dashboard.
```
============================================================
BUILD TIME SUMMARY
============================================================

COMMAND TIMES:
  build_engine           322.34 s

COMPONENT TIMES (by platform):

  testmain:
    arm64-macos         0.41 s

  dlib:
    arm64-macos        70.93 s

  jni:
    arm64-macos         1.85 s

  texc:
    arm64-macos         8.54 s

  modelc:
    arm64-macos         1.75 s

  shaderc:
    arm64-macos         1.87 s

  bob_light:
    arm64-macos        30.97 s

  ddf:
    arm64-macos         2.59 s

  platform:
    arm64-macos         1.01 s

  graphics:
    arm64-macos         2.52 s

  particle:
    arm64-macos         2.98 s

  lua:
    arm64-macos         0.97 s

  hid:
    arm64-macos         0.95 s

  input:
    arm64-macos         1.20 s

  physics:
    arm64-macos         1.99 s

  resource:
    arm64-macos        18.35 s

  extension:
    arm64-macos         0.80 s

  script:
    arm64-macos        10.63 s

  render:
    arm64-macos         3.50 s

  rig:
    arm64-macos         0.89 s

  gameobject:
    arm64-macos         8.89 s

  gui:
    arm64-macos         5.56 s

  sound:
    arm64-macos        46.25 s

  liveupdate:
    arm64-macos         1.25 s

  crash:
    arm64-macos         1.82 s

  gamesys:
    arm64-macos        30.40 s

  tools:
    arm64-macos         0.87 s

  record:
    arm64-macos         2.06 s

  profiler:
    arm64-macos         1.12 s

  engine:
    arm64-macos        40.02 s

  sdk:
    arm64-macos         1.74 s

  extender:
    arm64-macos         0.34 s

COMPONENT TOTALS:
  dlib                    70.93 s (1 platforms, avg: 70.93 s)
  sound                   46.25 s (1 platforms, avg: 46.25 s)
  engine                  40.02 s (1 platforms, avg: 40.02 s)
  bob_light               30.97 s (1 platforms, avg: 30.97 s)
  gamesys                 30.40 s (1 platforms, avg: 30.40 s)
  resource                18.35 s (1 platforms, avg: 18.35 s)
  script                  10.63 s (1 platforms, avg: 10.63 s)
  gameobject               8.89 s (1 platforms, avg: 8.89 s)
  texc                     8.54 s (1 platforms, avg: 8.54 s)
  gui                      5.56 s (1 platforms, avg: 5.56 s)
  render                   3.50 s (1 platforms, avg: 3.50 s)
  particle                 2.98 s (1 platforms, avg: 2.98 s)
  ddf                      2.59 s (1 platforms, avg: 2.59 s)
  graphics                 2.52 s (1 platforms, avg: 2.52 s)
  record                   2.06 s (1 platforms, avg: 2.06 s)
  physics                  1.99 s (1 platforms, avg: 1.99 s)
  shaderc                  1.87 s (1 platforms, avg: 1.87 s)
  jni                      1.85 s (1 platforms, avg: 1.85 s)
  crash                    1.82 s (1 platforms, avg: 1.82 s)
  modelc                   1.75 s (1 platforms, avg: 1.75 s)
  sdk                      1.74 s (1 platforms, avg: 1.74 s)
  liveupdate               1.25 s (1 platforms, avg: 1.25 s)
  input                    1.20 s (1 platforms, avg: 1.20 s)
  profiler                 1.12 s (1 platforms, avg: 1.12 s)
  platform                 1.01 s (1 platforms, avg: 1.01 s)
  lua                      0.97 s (1 platforms, avg: 0.97 s)
  hid                      0.95 s (1 platforms, avg: 0.95 s)
  rig                      0.89 s (1 platforms, avg: 0.89 s)
  tools                    0.87 s (1 platforms, avg: 0.87 s)
  extension                0.80 s (1 platforms, avg: 0.80 s)
  testmain                 0.41 s (1 platforms, avg: 0.41 s)
  extender                 0.34 s (1 platforms, avg: 0.34 s)

  TOTAL COMPONENT TIME:   305.02 s
============================================================
Build times saved to build_times.json
Done
```

Fix https://github.com/defold/defold/issues/3281