### PR TITLE
Fix glitches on the first frame of the GPU-skinned instanced animation right after spawn.

### DIFF
--- a/engine/gamesys/src/gamesys/components/comp_model.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_model.cpp
@@ -1906,6 +1906,8 @@ namespace dmGameSystem
 
         dmRig::Result rig_res = dmRig::Update(world->m_RigContext, params.m_UpdateContext->m_DT);
 
+        WritePoseMatricesToTexture(world);
+
         assert(world->m_MaxBatchIndex < VERTEX_BUFFER_MAX_BATCHES);
         for (int i = 0; i <= world->m_MaxBatchIndex; ++i)
         {
@@ -1991,8 +1993,6 @@ namespace dmGameSystem
                     dmRender::SetBufferData(params.m_Context, gfx_vertex_buffer, vb_size, vertex_buffer_data.Begin(), dmGraphics::BUFFER_USAGE_DYNAMIC_DRAW);
                     world->m_VertexBufferDispatchCounts[batch_index]++;
                 }
-
-                WritePoseMatricesToTexture(world);
 
                 DM_PROPERTY_ADD_U32(rmtp_ModelVertexCount, world->m_StatisticsVertexCount);
                 DM_PROPERTY_ADD_U32(rmtp_ModelVertexSize, world->m_StatisticsVertexDataSize);


### PR DESCRIPTION
It also increases performance for GPU-skinned instanced animation by about 30–50%, depending on the platform and the specific case.

### Technical changes
This fix moves writing texture matrices into the component update to ensure that the animation's cached texture is ready in advance, before the first render call happens.