### PR TITLE
Fixed issue when using a resource from a library in custom `custom_resources`

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/fs/AbstractFileSystem.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/fs/AbstractFileSystem.java
@@ -90,7 +90,9 @@ public abstract class AbstractFileSystem<F extends IFileSystem, R extends IResou
     private void walk(IWalker walker, String path, Collection<String> results) {
         String absolutePath = FilenameUtils.normalizeNoEndSeparator(FilenameUtils.concat(this.rootDirectory, path));
         File file = new File(absolutePath);
-
+        if (!file.exists()) {
+            return;
+        }
         if (file.isDirectory()) {
             if (walker.handleDirectory(path, results)) {
                 String[] children = file.list();


### PR DESCRIPTION
Now using a directory or a resource from a library (connected as a dependency) is possible not only in the editor, but also when bundling.

Fix https://github.com/defold/defold/issues/8320
Fix https://github.com/defold/defold/issues/4675