### PR TITLE
Fix for double acquire instance index calls

### DIFF
--- a/engine/gamesys/proto/gamesys/gamesys_ddf.proto
+++ b/engine/gamesys/proto/gamesys/gamesys_ddf.proto
@@ -28,7 +28,6 @@ message Create
     optional uint64         id       = 3 [default=0];
     optional float          scale    = 4 [default=1];
     optional dmMath.Vector3 scale3   = 5 [(field_align)=true]; // if zero, 'scale' is used instead
-    optional uint32         index    = 6 [default=0xffffffff]; // Must be same as dmGameObject::INVALID_INSTANCE_POOL_INDEX.
 }
 
 message CollectionProxyDesc

--- a/engine/gamesys/src/gamesys/components/comp_factory.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_factory.cpp
@@ -76,6 +76,53 @@ namespace dmGameSystem
         uint32_t                    m_TotalFactoryCount;
     };
 
+    inline dmGameObject::Result DoSpawn(HFactoryWorld world, HFactoryComponent component, dmGameObject::HCollection collection,
+                                        dmhash_t id, uint32_t index,
+                                        const dmVMath::Point3& position, const dmVMath::Quat& rotation, const dmVMath::Vector3& scale,
+                                        dmGameObject::HPropertyContainer properties, dmGameObject::HInstance* out_instance)
+    {
+        if (index == dmGameObject::INVALID_INSTANCE_POOL_INDEX)
+        {
+            index = dmGameObject::AcquireInstanceIndex(collection);
+            if (index == dmGameObject::INVALID_INSTANCE_POOL_INDEX)
+            {
+                dmLogWarning("Gameobject buffer is full. See `collection.max_instances` in game.project.");
+                return dmGameObject::RESULT_OUT_OF_RESOURCES;
+            }
+        }
+
+        if (!id)
+        {
+            id = dmGameObject::CreateInstanceId();
+        }
+
+        dmGameObject::HPrototype prototype = CompFactoryGetPrototype(world, component);
+        if (prototype == 0x0)
+        {
+            dmLogError("Unable to find the prototype specified in the factory component.");
+            return dmGameObject::RESULT_RESOURCE_ERROR;
+        }
+
+        const char* path = CompFactoryGetPrototypePath(world, component);
+
+        dmGameObject::Result result = dmGameObject::Spawn(collection, prototype, path, id, properties, position, rotation, scale, out_instance);
+        if (result != dmGameObject::RESULT_OK)
+        {
+            dmLogError("Could not spawn an instance of prototype %s.", path);
+            return result;
+        }
+
+        if (*out_instance != 0x0)
+        {
+            dmGameObject::AssignInstanceIndex(index, *out_instance);
+        }
+        else
+        {
+            dmGameObject::ReleaseInstanceIndex(index, collection);
+        }
+        return result;
+    }
+
     dmGameObject::CreateResult CompFactoryNewWorld(const dmGameObject::ComponentNewWorldParams& params)
     {
         FactoryContext* context = (FactoryContext*)params.m_Context;
@@ -196,26 +243,7 @@ namespace dmGameSystem
                 properties = dmGameObject::PropertyContainerAllocateWithSize(property_buffer_size);
                 PropertyContainerDeserialize(property_buffer, property_buffer_size, properties);
             }
-            FactoryComponent* fc = (FactoryComponent*) *params.m_UserData;
-
-            uint32_t index = create->m_Index;
-            dmhash_t id = create->m_Id;
-
-            if (id == 0)
-            {
-                if (index == dmGameObject::INVALID_INSTANCE_POOL_INDEX)
-                {
-                    index = dmGameObject::AcquireInstanceIndex(collection);
-                }
-
-                if (index == dmGameObject::INVALID_INSTANCE_POOL_INDEX)
-                {
-                    dmLogError("Can not create gameobject since the buffer is full.");
-                    return dmGameObject::UPDATE_RESULT_OK;
-                }
-
-                id = dmGameObject::CreateInstanceId();
-            }
+            FactoryComponent* component = (FactoryComponent*) *params.m_UserData;
 
             // m_Scale is legacy, so use it if Scale3 is all zeroes
             Vector3 scale;
@@ -227,23 +255,14 @@ namespace dmGameSystem
             {
                 scale = create->m_Scale3;
             }
-            dmGameObject::HPrototype prototype = CompFactoryGetPrototype(world, fc);
-            dmGameObject::HInstance spawned_instance =  dmGameObject::Spawn(collection, prototype, CompFactoryGetPrototypePath(world, fc),
-                                                                            id, properties, create->m_Position, create->m_Rotation, scale);
-            if (index != dmGameObject::INVALID_INSTANCE_POOL_INDEX)
-            {
-                if (spawned_instance != 0x0)
-                {
-                    dmGameObject::AssignInstanceIndex(index, spawned_instance);
-                }
-                else
-                {
-                    dmGameObject::ReleaseInstanceIndex(index, collection);
-                }
-            }
+
+            dmGameObject::HInstance spawned_instance;
+            dmGameObject::Result result = DoSpawn(world, component, collection, create->m_Id, create->m_Index, create->m_Position, create->m_Rotation, scale, properties, &spawned_instance);
 
             if (properties)
+            {
                 dmGameObject::PropertyContainerDestroy(properties);
+            }
         }
         return dmGameObject::UPDATE_RESULT_OK;
     }
@@ -467,40 +486,7 @@ namespace dmGameSystem
                                                 const dmVMath::Point3& position, const dmVMath::Quat& rotation, const dmVMath::Vector3& scale,
                                                 dmGameObject::HPropertyContainer properties, dmGameObject::HInstance* out_instance)
     {
-        uint32_t index = dmGameObject::AcquireInstanceIndex(collection);
-        if (index == dmGameObject::INVALID_INSTANCE_POOL_INDEX)
-        {
-            dmLogWarning("Gameobject buffer is full. See `collection.max_instances` in game.project.");
-            return dmGameObject::RESULT_OUT_OF_RESOURCES;
-        }
-
-        if (!id)
-        {
-            id = dmGameObject::CreateInstanceId();
-        }
-      
-        dmGameObject::HPrototype prototype = CompFactoryGetPrototype(world, component);
-        if (prototype == 0x0) {
-            dmLogError("Unable to find the prototype specified in the factory component.");
-            return dmGameObject::RESULT_RESOURCE_ERROR;
-        }
-        const char* path = CompFactoryGetPrototypePath(world, component);
-
-        dmGameObject::Result result = dmGameObject::Spawn(collection, prototype, path, id, properties, position, rotation, scale, out_instance);
-        if (result != dmGameObject::RESULT_OK) {
-            dmLogError("Could not spawn an instance of prototype %s.", path);
-            return result;
-        }
-
-        if (*out_instance != 0x0)
-        {
-            dmGameObject::AssignInstanceIndex(index, *out_instance);
-        }
-        else
-        {
-            dmGameObject::ReleaseInstanceIndex(index, collection);
-        }
-        return result;
+        return DoSpawn(world, component, collection, id, dmGameObject::INVALID_INSTANCE_POOL_INDEX, position, rotation, scale, properties, out_instance);
     }
 
 }

--- a/engine/gamesys/src/gamesys/components/comp_factory.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_factory.cpp
@@ -77,18 +77,14 @@ namespace dmGameSystem
     };
 
     inline dmGameObject::Result DoSpawn(HFactoryWorld world, HFactoryComponent component, dmGameObject::HCollection collection,
-                                        dmhash_t id, uint32_t index,
-                                        const dmVMath::Point3& position, const dmVMath::Quat& rotation, const dmVMath::Vector3& scale,
+                                        dmhash_t id, const dmVMath::Point3& position, const dmVMath::Quat& rotation, const dmVMath::Vector3& scale,
                                         dmGameObject::HPropertyContainer properties, dmGameObject::HInstance* out_instance)
     {
+        uint32_t index = dmGameObject::AcquireInstanceIndex(collection);
         if (index == dmGameObject::INVALID_INSTANCE_POOL_INDEX)
         {
-            index = dmGameObject::AcquireInstanceIndex(collection);
-            if (index == dmGameObject::INVALID_INSTANCE_POOL_INDEX)
-            {
-                dmLogWarning("Gameobject buffer is full. See `collection.max_instances` in game.project.");
-                return dmGameObject::RESULT_OUT_OF_RESOURCES;
-            }
+            dmLogWarning("Gameobject buffer is full. See `collection.max_instances` in game.project.");
+            return dmGameObject::RESULT_OUT_OF_RESOURCES;
         }
 
         if (!id)
@@ -257,7 +253,7 @@ namespace dmGameSystem
             }
 
             dmGameObject::HInstance spawned_instance;
-            dmGameObject::Result result = DoSpawn(world, component, collection, create->m_Id, create->m_Index, create->m_Position, create->m_Rotation, scale, properties, &spawned_instance);
+            dmGameObject::Result result = DoSpawn(world, component, collection, create->m_Id, create->m_Position, create->m_Rotation, scale, properties, &spawned_instance);
 
             if (properties)
             {
@@ -486,7 +482,7 @@ namespace dmGameSystem
                                                 const dmVMath::Point3& position, const dmVMath::Quat& rotation, const dmVMath::Vector3& scale,
                                                 dmGameObject::HPropertyContainer properties, dmGameObject::HInstance* out_instance)
     {
-        return DoSpawn(world, component, collection, id, dmGameObject::INVALID_INSTANCE_POOL_INDEX, position, rotation, scale, properties, out_instance);
+        return DoSpawn(world, component, collection, id, position, rotation, scale, properties, out_instance);
     }
 
 }

--- a/engine/gamesys/src/gamesys/scripts/script_factory.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_factory.cpp
@@ -246,7 +246,6 @@ namespace dmGameSystem
 
         dmGameSystemDDF::Create* create_msg = (dmGameSystemDDF::Create*)buffer;
         create_msg->m_Id = id;
-        create_msg->m_Index = dmGameObject::INVALID_INSTANCE_POOL_INDEX;
         create_msg->m_Position = position;
         create_msg->m_Rotation = rotation;
         create_msg->m_Scale3 = scale;

--- a/engine/gamesys/src/gamesys/scripts/script_factory.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_factory.cpp
@@ -333,7 +333,7 @@ namespace dmGameSystem
 
         dmhash_t id = dmGameObject::CreateInstanceId();
 
-        // When calling factory.create() from something other than a .gui_script
+        // When calling factory.create() from a .gui_script (see engine/src/test/factory/factory.gui_script)
         bool msg_passing = dmGameObject::GetInstanceFromLua(L) == 0x0;
         if (msg_passing)
         {

--- a/engine/gamesys/src/gamesys/scripts/script_factory.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_factory.cpp
@@ -239,14 +239,14 @@ namespace dmGameSystem
      * ```
      */
     static int FactoryComp_CreateWithMessage(lua_State* L, dmGameObject::HCollection collection, dmMessage::URL* receiver,
-                                            uint32_t index, dmhash_t id, dmGameObject::HPropertyContainer properties,
+                                            dmhash_t id, dmGameObject::HPropertyContainer properties,
                                             const dmVMath::Point3& position, const dmVMath::Quat& rotation, const dmVMath::Vector3& scale)
     {
         uint8_t DM_ALIGNED(16) buffer[512];
 
         dmGameSystemDDF::Create* create_msg = (dmGameSystemDDF::Create*)buffer;
         create_msg->m_Id = id;
-        create_msg->m_Index = index;
+        create_msg->m_Index = dmGameObject::INVALID_INSTANCE_POOL_INDEX;
         create_msg->m_Position = position;
         create_msg->m_Rotation = rotation;
         create_msg->m_Scale3 = scale;
@@ -265,7 +265,6 @@ namespace dmGameSystem
 
         dmMessage::URL sender;
         if (!dmScript::GetURL(L, &sender)) {
-            dmGameObject::ReleaseInstanceIndex(index, collection);
             return luaL_error(L, "factory.create can not be called from this script type");
         }
 
@@ -332,47 +331,38 @@ namespace dmGameSystem
             scale = dmGameObject::GetWorldScale(sender_instance);
         }
 
-        uint32_t index = dmGameObject::AcquireInstanceIndex(collection);
-        if (index == dmGameObject::INVALID_INSTANCE_POOL_INDEX)
+        dmhash_t id = dmGameObject::CreateInstanceId();
+
+        // When calling factory.create() from something other than a .gui_script
+        bool msg_passing = dmGameObject::GetInstanceFromLua(L) == 0x0;
+        if (msg_passing)
         {
-            dmLogError("factory.create can not create gameobject since the buffer is full. See `collection.max_instances` in game.project");
-            lua_pushnil(L);
+            FactoryComp_CreateWithMessage(L, collection, &receiver, id, properties, position, rotation, scale);
+            // We currently don't know if the creation succeeds
+            dmScript::PushHash(L, id);
         }
         else
         {
-            dmhash_t id = dmGameObject::CreateInstanceId();
+            // Since the spawning will invoke any scripts on that new instance,
+            // we need a way to restore the state
+            dmScript::GetInstance(L);
+            int ref = dmScript::Ref(L, LUA_REGISTRYINDEX);
 
-            // TODO: When does this actually happen? In render scripts? Or unit tests only?
-            bool msg_passing = dmGameObject::GetInstanceFromLua(L) == 0x0;
-            if (msg_passing)
+            dmGameObject::HInstance instance;
+            dmGameObject::Result result = CompFactorySpawn(world, component, collection,
+                                                            id, position, rotation, scale, properties, &instance);
+
+            lua_rawgeti(L, LUA_REGISTRYINDEX, ref);
+            dmScript::SetInstance(L);
+            dmScript::Unref(L, LUA_REGISTRYINDEX, ref);
+
+            if (result == dmGameObject::RESULT_OK)
             {
-                FactoryComp_CreateWithMessage(L, collection, &receiver, index, id, properties, position, rotation, scale);
-                // We currently don't know if the creation succeeds
                 dmScript::PushHash(L, id);
             }
             else
             {
-                // Since the spawning will invoke any scripts on that new instance,
-                // we need a way to restore the state
-                dmScript::GetInstance(L);
-                int ref = dmScript::Ref(L, LUA_REGISTRYINDEX);
-
-                dmGameObject::HInstance instance;
-                dmGameObject::Result result = CompFactorySpawn(world, component, collection,
-                                                                id, position, rotation, scale, properties, &instance);
-
-                lua_rawgeti(L, LUA_REGISTRYINDEX, ref);
-                dmScript::SetInstance(L);
-                dmScript::Unref(L, LUA_REGISTRYINDEX, ref);
-
-                if (result == dmGameObject::RESULT_OK)
-                {
-                    dmScript::PushHash(L, id);
-                }
-                else
-                {
-                    lua_pushnil(L);
-                }
+                lua_pushnil(L);
             }
         }
 

--- a/engine/gamesys/src/gamesys/test/factory/factory_create_test.factory
+++ b/engine/gamesys/src/gamesys/test/factory/factory_create_test.factory
@@ -1,0 +1,1 @@
+prototype: "/factory/empty.go"

--- a/engine/gamesys/src/gamesys/test/factory/factory_create_test.go
+++ b/engine/gamesys/src/gamesys/test/factory/factory_create_test.go
@@ -1,0 +1,8 @@
+components {
+  id: "script"
+  component: "/factory/factory_create_test.script"
+}
+components {
+  id: "factory"
+  component: "/factory/factory_create_test.factory"
+}

--- a/engine/gamesys/src/gamesys/test/factory/factory_create_test.script
+++ b/engine/gamesys/src/gamesys/test/factory/factory_create_test.script
@@ -1,0 +1,21 @@
+function init(self)
+	-- MAX_INSTANCES is set before the test runs
+	-- it is the max instances value sent to the collection when created
+	-- try to create up to the cap
+	-- minus one for the game object this script is attached to
+	local amount = _G.MAX_INSTANCES - 1
+	local created = 0
+	for i=1,amount do
+		local id = factory.create("/go#factory")
+		if not id then
+			break
+		end
+		created = created + 1
+	end
+	assert(created == amount, "Expected " .. amount .. " number of game objects to be created. Actual " .. created)
+
+	-- try to create one more
+	-- this should fail
+	local id = factory.create("/go#factory")
+	assert(not id, "Expected game object to not be created")
+end

--- a/engine/gamesys/src/gamesys/test/factory/factory_create_test.script
+++ b/engine/gamesys/src/gamesys/test/factory/factory_create_test.script
@@ -1,9 +1,9 @@
 function init(self)
-	-- MAX_INSTANCES is set before the test runs
+	-- max_instances is set before the test runs
 	-- it is the max instances value sent to the collection when created
 	-- try to create up to the cap
 	-- minus one for the game object this script is attached to
-	local amount = _G.MAX_INSTANCES - 1
+	local amount = _G.max_instances - 1
 	local created = 0
 	for i=1,amount do
 		local id = factory.create("/go#factory")

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -2116,7 +2116,7 @@ TEST_P(FactoryTest, Create)
     dmGameSystem::InitializeScriptLibs(scriptlibcontext);
     
     lua_pushnumber(L, m_projectOptions.m_MaxInstances);
-    lua_setglobal(L, "MAX_INSTANCES");
+    lua_setglobal(L, "max_instances");
 
     // Spawn the game object with the script we want to call
     ASSERT_TRUE(dmGameObject::Init(m_Collection));

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -2008,7 +2008,7 @@ TEST_P(FactoryTest, Test)
         ASSERT_EQ(0, dmResource::GetRefCount(m_Factory, dmHashString64(resource_path[3])));
 
         // --- step 5 ---
-        // recreate resources without factoy.load having been called (sync load on demand)
+        // recreate resources without factory.load having been called (sync load on demand)
         ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
         ASSERT_TRUE(dmGameObject::PostUpdate(m_Collection));
         dmGameObject::PostUpdate(m_Register);
@@ -2093,6 +2093,35 @@ TEST_P(FactoryTest, IdHashTest)
     dmGameObject::HInstance go = Spawn(m_Factory, m_Collection, "/factory/factory_hash_test.goc", go_hash, 0, Point3(0, 0, 0), Quat(0, 0, 0, 1), Vector3(1, 1, 1));
     ASSERT_NE((void*)0, go);
     go = dmGameObject::GetInstanceFromIdentifier(m_Collection, go_hash);
+    ASSERT_NE((void*)0, go);
+
+    ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+    ASSERT_TRUE(dmGameObject::PostUpdate(m_Collection));
+    dmGameObject::PostUpdate(m_Register);
+
+    dmGameSystem::FinalizeScriptLibs(scriptlibcontext);
+}
+
+TEST_P(FactoryTest, Create)
+{
+    lua_State* L = dmScript::GetLuaState(m_ScriptContext);
+
+    dmGameSystem::ScriptLibContext scriptlibcontext;
+    scriptlibcontext.m_Factory         = m_Factory;
+    scriptlibcontext.m_Register        = m_Register;
+    scriptlibcontext.m_LuaState        = L;
+    scriptlibcontext.m_GraphicsContext = m_GraphicsContext;
+    scriptlibcontext.m_ScriptContext   = m_ScriptContext;
+
+    dmGameSystem::InitializeScriptLibs(scriptlibcontext);
+    
+    lua_pushnumber(L, m_projectOptions.m_MaxInstances);
+    lua_setglobal(L, "MAX_INSTANCES");
+
+    // Spawn the game object with the script we want to call
+    ASSERT_TRUE(dmGameObject::Init(m_Collection));
+    dmhash_t go_hash = dmHashString64("/go");
+    dmGameObject::HInstance go = Spawn(m_Factory, m_Collection, "/factory/factory_create_test.goc", go_hash, 0, Point3(0, 0, 0), Quat(0, 0, 0, 1), Vector3(1, 1, 1));
     ASSERT_NE((void*)0, go);
 
     ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));

--- a/engine/gamesys/src/gamesys/test/test_gamesys.h
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.h
@@ -69,6 +69,7 @@ struct ProjectOptions {
   uint32_t m_MaxCollisionCount;
   uint32_t m_MaxCollisionObjectCount;
   uint32_t m_MaxContactPointCount;
+  uint32_t m_MaxInstances;
   bool m_3D;
   float m_Scale;
   float m_VelocityThreshold;
@@ -100,6 +101,7 @@ public:
         this->m_projectOptions.m_MaxCollisionCount = 0;
         this->m_projectOptions.m_MaxCollisionObjectCount = 0;
         this->m_projectOptions.m_MaxContactPointCount = 0;
+        this->m_projectOptions.m_MaxInstances = 1024;
         this->m_projectOptions.m_3D = false;
         this->m_projectOptions.m_Scale = 1.0f;
         this->m_projectOptions.m_VelocityThreshold = 1.0f;
@@ -669,7 +671,7 @@ void GamesysTest<T>::SetUp()
     // TODO: Investigate why the ConsumeInputInCollectionProxy test fails if the components are actually sorted (the way they're supposed to)
     //dmGameObject::SortComponentTypes(m_Register);
 
-    m_Collection = dmGameObject::NewCollection("collection", m_Factory, m_Register, 1024, 0x0);
+    m_Collection = dmGameObject::NewCollection("collection", m_Factory, m_Register, this->m_projectOptions.m_MaxInstances, 0x0);
 }
 
 template<typename T>


### PR DESCRIPTION
PR https://github.com/defold/defold/pull/10679 contained an error where AcquireInstanceIndex() was called twice when spawning using factory.create() from script_factory.cpp.

## PR checklist

* [x] Code
	* [x] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [x] Add comments where needed
* [x] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [x] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
