### PR TITLE
Set size of pose matrix cache only once per frame if needed

### DIFF
--- a/engine/rig/src/rig.cpp
+++ b/engine/rig/src/rig.cpp
@@ -54,7 +54,7 @@ namespace dmRig
     {
         cache->m_PoseMatrices.SetSize(0);
         cache->m_CacheEntryOffsets.SetSize(0);
-        cache->m_TotalBoneCount = 0;
+        cache->m_TotalPoseCount = 0;
         cache->m_MaxBoneCount = 0;
     }
 
@@ -475,7 +475,7 @@ namespace dmRig
         // Animate()
         // See AcquirePoseMatrixCacheEntry
         dmArray<Matrix4>& cache_pose_matrices = context->m_PoseMatrixCache.m_PoseMatrices;
-        uint32_t size = context->m_PoseMatrixCache.m_TotalBoneCount;
+        uint32_t size = context->m_PoseMatrixCache.m_TotalPoseCount;
         cache_pose_matrices.SetCapacity(size);
         cache_pose_matrices.SetSize(size);
 
@@ -1227,8 +1227,8 @@ namespace dmRig
 
         instance->m_PoseMatrixCacheIndex = next_index;
 
-        cache->m_CacheEntryOffsets[next_index] = cache->m_TotalBoneCount;
-        cache->m_TotalBoneCount += GetBoneCount(instance);
+        cache->m_CacheEntryOffsets[next_index] = cache->m_TotalPoseCount;
+        cache->m_TotalPoseCount += instance->m_BindPose->Size();
         return next_index;
     }
 

--- a/engine/rig/src/rig_private.h
+++ b/engine/rig/src/rig_private.h
@@ -107,6 +107,8 @@ namespace dmRig
         dmArray<dmVMath::Matrix4> m_PoseMatrices;
         /// The array of bone counts for the rig instances that have acquired a pose matrix cache slot
         dmArray<uint32_t>         m_CacheEntryOffsets;
+        /// The total number of cached bones
+        uint32_t                  m_TotalBoneCount;
         /// The max bone count found in the set of pose matrices (I think this can be removed?)
         uint32_t                  m_MaxBoneCount;
     };

--- a/engine/rig/src/rig_private.h
+++ b/engine/rig/src/rig_private.h
@@ -107,8 +107,8 @@ namespace dmRig
         dmArray<dmVMath::Matrix4> m_PoseMatrices;
         /// The array of bone counts for the rig instances that have acquired a pose matrix cache slot
         dmArray<uint32_t>         m_CacheEntryOffsets;
-        /// The total number of cached bones
-        uint32_t                  m_TotalBoneCount;
+        /// The total number of cached bone pose matrices
+        uint32_t                  m_TotalPoseCount;
         /// The max bone count found in the set of pose matrices (I think this can be removed?)
         uint32_t                  m_MaxBoneCount;
     };

--- a/engine/rig/src/test/test_rig.cpp
+++ b/engine/rig/src/test/test_rig.cpp
@@ -1904,17 +1904,19 @@ TEST_F(RigContextTest, TestBindPoseCache)
     create_params.m_AnimationSet     = animation_set;
 
     ASSERT_EQ(dmRig::RESULT_OK, dmRig::InstanceCreate(m_Context, create_params, &instance));
+    const dmRig::PoseMatrixCache* cache = dmRig::GetPoseMatrixCache(m_Context);
     dmRig::HCachePoseMatrixEntry pose_matrix_entry = dmRig::AcquirePoseMatrixCacheEntry(m_Context, instance);
+    ASSERT_EQ(bind_pose.Size(), cache->m_TotalPoseCount);
 
     ASSERT_NE(dmRig::INVALID_POSE_MATRIX_CACHE_ENTRY, pose_matrix_entry);
     ASSERT_EQ(dmRig::RESULT_OK, dmRig::Update(m_Context, 1.0f));
 
-    const dmRig::PoseMatrixCache* cache = dmRig::GetPoseMatrixCache(m_Context);
     ASSERT_EQ(bind_pose.Size(), cache->m_PoseMatrices.Size());
 
-    // If we update the cache again without resetting, we just write the same data into the cache again.
+    // If we update the cache again without resetting, we write the same data
+    // into the cache again at the same acquired cache position
     ASSERT_EQ(dmRig::RESULT_OK, dmRig::Update(m_Context, 1.0f));
-    ASSERT_EQ(bind_pose.Size() * 2, cache->m_PoseMatrices.Size());
+    ASSERT_EQ(bind_pose.Size(), cache->m_PoseMatrices.Size());
 
     dmRig::ResetPoseMatrixCache(m_Context);
     ASSERT_EQ(0, cache->m_PoseMatrices.Size());


### PR DESCRIPTION
The pose matrix cache in rig.cpp was resized once per rig instance. This caused a big slowdown when a large number of instances were added in a single frame. The pose matrix size is now calculated once per frame and the cache itself is resized only once per frame if needed.