### PR TITLE
Edit go files using editor scripts

### DIFF
--- a/editor/src/clj/editor/attachment.clj
+++ b/editor/src/clj/editor/attachment.clj
@@ -261,7 +261,7 @@
 (defn- clear-tx [{:keys [basis] :as evaluation-context} workspace node-id list-kw]
   (let [[node-id list-definition] (require-list-definition workspace node-id list-kw evaluation-context)]
     (assert (list-definition-editable? list-definition node-id evaluation-context))
-    (mapcat
+    (coll/mapcat
       #(g/delete-node (g/override-root basis %))
       (list-definition-get list-definition node-id evaluation-context))))
 

--- a/editor/src/clj/editor/attachment.clj
+++ b/editor/src/clj/editor/attachment.clj
@@ -13,25 +13,61 @@
 ;; specific language governing permissions and limitations under the License.
 
 (ns editor.attachment
-  "Extensible definitions for semantical node attachments"
-  (:refer-clojure :exclude [remove alias])
+  "Extensible definitions for semantical node attachment lists
+
+  Use register, alias, or define-alternative to configure the lists.
+  Use defined?, editable?, and reorderable? to query the status of node lists on
+  a given node.
+  Use get to list attached nodes.
+  Use add, remove, reorder and clear to edit the nodes.
+
+  The node attachment state has the following data shape:
+
+  {node-type {:lists {list-kw {:add {node-type tx-attach-fn}
+                               :get get-fn
+                               :reorder reorder-fn
+                               :read-only? read-only-pred
+                               :alias node-type
+                               :aliases #{node-type}}}
+              :alternative alternative-fn}}
+
+  In the list definition map, only :get is required. Fns:
+    tx-attach-fn      fn of parent-node, child-node -> txs
+    get-fn            fn of node, evaluation-context -> vector of nodes
+    reorder-fn        fn of reordered-nodes -> txs
+    read-only-pred    fn of parent-node, evaluation-context -> boolean
+
+  Aliasing allows treating a list as the same as another list. Any list
+  definition may have at most one of :alias, :aliases keys, where:
+    :alias      refers to a node type that this list definition follows, i.e., a
+                link to the \"original\"
+    :aliases    a set of all node types that follow this definition, i.e., a
+                link to \"copies\"
+
+  Similarly to outline's :alt-outline feature, it's possible to define an
+  alternative node to look up lists by defining an alternative-fn (fn of node,
+  evaluation-context -> alt-node | nil)"
+  (:refer-clojure :exclude [alias remove get])
   (:require [dynamo.graph :as g]
             [editor.workspace :as workspace]
             [internal.graph.types :as gt]
             [util.coll :as coll]))
 
 (defn- assoc-list-definition [state node-type list-kw {:keys [aliases] :as definition}]
-  (let [state (update state node-type assoc list-kw definition)]
+  (let [state (assoc-in state [node-type :lists list-kw] definition)]
     (if aliases
       (let [aliased-definition (-> definition
                                    (dissoc :aliases)
                                    (assoc :alias node-type))]
-        (reduce #(update %1 %2 assoc list-kw aliased-definition) state aliases))
+        (reduce #(assoc-in %1 [%2 :lists list-kw] aliased-definition) state aliases))
       state)))
 
 ;; SDK api
 (defn register
   "Create transaction steps that register a semantical list of child components
+
+  The very first registration has to specify :get. Further registrations may
+  extend the definition, for example, by adding additional :add entries
 
   Args:
     workspace    the workspace node id
@@ -71,6 +107,7 @@
     (fn [s]
       (let [definition (-> s
                            (clojure.core/get node-type)
+                           :lists
                            list-kw
                            (cond->
                              add (update :add coll/merge add)
@@ -84,191 +121,183 @@
         (assoc-list-definition s node-type list-kw definition)))))
 
 (defn alias
-  "Define a node list as an alias of another node type's list with the same name"
+  "Create transaction steps that alias a node type's list as another node-type
+
+  The other node type must define a list with the same name"
   [workspace node-type list-kw alias-node-type]
   {:pre [(not= node-type alias-node-type)]}
   (g/update-property
     workspace
     :node-attachments
     (fn [s]
-      (let [definition (list-kw (clojure.core/get s alias-node-type))
+      (let [definition (-> s (clojure.core/get alias-node-type) :lists list-kw)
             _ (assert definition "Can't alias undefined list")]
         (assert definition "Can't alias undefined list")
         (assert (not (contains? definition :alias)) "Can't alias another alias")
         (assoc-list-definition s alias-node-type list-kw (update definition :aliases coll/conj-set node-type))))))
 
-(defmacro ^:private with-read-only-check [parent-node-type-expr parent-node-id-expr list-kw-expr read-only?-expr & body]
-  `(let [parent-node-id# ~parent-node-id-expr
-         read-only?# ~read-only?-expr
-         parent-node-type# ~parent-node-type-expr
-         list-kw# ~list-kw-expr]
-     (if read-only?#
-       (g/expand-ec
-         (fn [evaluation-context#]
-           (when (read-only?# parent-node-id# evaluation-context#)
-             (throw (ex-info (str (name (:k parent-node-type#)) " instance is read-only")
-                             {:parent-node-id parent-node-id# :list-kw list-kw#})))
-           (do ~@body)))
-       (do ~@body))))
+(defn define-alternative
+  "Create transaction steps that define an alternative node to use for editing
 
-(defn add-impl [current-state parent-node-type parent-node-id attachment-tree init-fn]
-  (coll/mapcat
-    (fn [[list-kw {:keys [init add node-type] :as attachment}]]
-      (when-not node-type
-        (throw (ex-info "node type is required" {:parent-node-type parent-node-id :list-kw list-kw :attachment attachment})))
-      (let [definition (-> current-state (get parent-node-type) list-kw)]
-        (if-let [node-type->tx-attach-fn (:add definition)]
-          (let [tx-attach-fn (or (node-type->tx-attach-fn node-type)
-                                 (throw (ex-info (str (name (:k parent-node-type)) " does not support " (name list-kw) " attachments of type " (name (:k node-type)))
-                                                 {:parent-node-type parent-node-id :list-kw list-kw :node-type node-type})))
-                child-node-id (first (g/take-node-ids (g/node-id->graph-id parent-node-id) 1))]
-            (with-read-only-check
-              parent-node-type parent-node-id list-kw (:read-only? definition)
-              (concat
-                (g/add-node (g/construct node-type :_node-id child-node-id))
-                (init-fn parent-node-id node-type child-node-id init)
-                (tx-attach-fn parent-node-id child-node-id)
-                (add-impl current-state node-type child-node-id add init-fn))))
-          (throw (ex-info (str (name (:k parent-node-type)) " does not define a " (name list-kw) " attachment list")
-                          {:parent-node-type parent-node-type
-                           :list-kw list-kw})))))
-    attachment-tree))
-
-(defn add
-  "Create transaction steps for adding a tree to some node
+  If no list was found on a node type, an alternative node will be looked up and
+  checked for list definition
 
   Args:
-    basis              graph basis to use when looking up node-id's type
-    workspace          the workspace node id that defines attachments
-    node-id            container node id that should be extended
-    attachment-tree    a tree that describes several (potentially recursive)
-                       additions; a coll of 2-element tuples where first element
-                       is a list-kw keyword, and second is a map with the
-                       following keys:
-                         :init         required, data structure that will be
-                                       supplied to the init-fn to create element
-                                       initialization transaction steps
-                         :node-type    required, node type of child node
-                         :add          optional, attachment tree of the created
-                                       item
+    workspace         the workspace to transact to
+    node-type         the node type that defines an alternative
+    alternative-fn    a function that looks up an alternative node id if no
+                      matching list was found on the input node; will receive 2
+                      args: node id (instance of provided node-type) and
+                      evaluation-context, should return an alternative node-id
+                      or nil"
+  [workspace node-type alternative-fn]
+  (g/update-property workspace :node-attachments #(update % node-type assoc :alternative alternative-fn)))
 
-    init-fn            a function that initializes the newly created element
-                       node, will receive 4 args:
-                         parent-node-id     container node id
-                         child-node-type    created node type
-                         child-node-id      created node id
-                         init-value         init value from the attachment tree
-                       the function should return transaction steps that
-                       initialize the node
+(defn- get-list-definition
+  "Internal. Returns either a tuple of node-id + list definition map or nil if
+  it does not exist"
+  [workspace node-id list-kw {:keys [basis] :as evaluation-context}]
+  (let [current-state (workspace/node-attachments basis workspace)]
+    (loop [node-id node-id]
+      (let [node-type (g/node-type* basis node-id)]
+        (when-let [{:keys [lists alternative]} (clojure.core/get current-state node-type)]
+          (or (when-let [list-definition (list-kw lists)]
+                (coll/pair node-id list-definition))
+              (when alternative
+                (some-> (alternative node-id evaluation-context) recur))))))))
 
-  Example attachment tree for an atlas node:
-    [[:images {:init {:image \"/foo.png\"}}]
-     [:images {:init {:image \"/bar.png\"}}]
-     [:animations
-      {:init {:id \"foo-bar\"}
-       :add [[:images {:init {:image \"/foo.png\"}}]
-             [:images {:init {:image \"/bar.png\"}}]]}]]"
-  [basis workspace node-id attachment-tree init-fn]
-  (add-impl (workspace/node-attachments basis workspace) (g/node-type* basis node-id) node-id attachment-tree init-fn))
-
-(defn defines?
-  "Checks if a node-type is extended to define a list-kw list"
-  [basis workspace node-type list-kw]
-  (-> basis (workspace/node-attachments workspace) (get node-type) (contains? list-kw)))
-
-(defn read-only?
-  "Checks if a node is read-only, i.e., can't be edited even when editable
-
-  Asserts that list exists (see [[defines?]])"
+(defn- require-list-definition
   [workspace node-id list-kw evaluation-context]
-  (let [{:keys [basis]} evaluation-context
-        node-type (g/node-type* basis node-id)]
-    (assert (defines? basis workspace node-type list-kw))
-    (if-let [pred (-> basis (workspace/node-attachments workspace) (get node-type) list-kw :read-only?)]
-      (pred node-id evaluation-context)
-      false)))
+  (let [list-definition (get-list-definition workspace node-id list-kw evaluation-context)]
+    (assert list-definition (str list-kw " is not defined"))
+    list-definition))
+
+(defn defined?
+  "Checks if a node-type is extended to define a list-kw list"
+  [workspace node-id list-kw evaluation-context]
+  (some? (get-list-definition workspace node-id list-kw evaluation-context)))
+
+(defn- list-definition-editable? [list-definition node-id evaluation-context]
+  (and (contains? list-definition :add)
+       (if-let [pred (:read-only? list-definition)]
+         (not (pred node-id evaluation-context))
+         true)))
 
 (defn editable?
-  "Checks if a node-type supports editing items of the list"
-  [basis workspace node-type list-kw]
-  (-> basis (workspace/node-attachments workspace) (get node-type) list-kw (contains? :add)))
+  "Checks if a node list is editable
+
+  Asserts that list exists (see [[defined?]])"
+  [workspace node-id list-kw evaluation-context]
+  (let [[node-id list-definition] (require-list-definition workspace node-id list-kw evaluation-context)]
+    (list-definition-editable? list-definition node-id evaluation-context)))
+
+(defn- list-definition-reorderable? [list-definition]
+  (contains? list-definition :reorder))
 
 (defn reorderable?
-  "Checks if a node type allows reordering of a list-kw list"
-  [basis workspace node-type list-kw]
-  (-> basis (workspace/node-attachments workspace) (get node-type) list-kw (contains? :reorder)))
+  "Checks if a node type allows reordering of a list-kw list
+
+  Asserts that lists exists (see [[defined?]])"
+  [workspace node-id list-kw evaluation-context]
+  (let [[_ list-definition] (require-list-definition workspace node-id list-kw evaluation-context)]
+    (list-definition-reorderable? list-definition)))
 
 (defn child-node-types
-  "Returns defined child node-types for a parent node-type's list-kw
+  "Returns all possible child node types for a list, or nil if there is none
 
-  Returns a map from child node type to tx-attach-fn
+  Returned value is a map from possible node type to attachment fn
 
-  Asserts that it exists. See [[editable?]]"
-  [basis workspace node-type list-kw]
-  {:post [(some? %)]}
-  (-> basis (workspace/node-attachments workspace) (get node-type) list-kw :add))
+  Asserts that the list exists (see [[defined?]])"
+  [workspace node-id list-kw evaluation-context]
+  (let [[_ list-definition] (require-list-definition workspace node-id list-kw evaluation-context)]
+    (:add list-definition)))
 
-(defn getter
-  "Returns a getter function for a container node-type's list-kw
+(defn- tx-add [evaluation-context workspace parent-node-id list-kw child-node-type init-fn config-fn]
+  (let [[parent-node-id list-definition] (require-list-definition workspace parent-node-id list-kw evaluation-context)]
+    (assert (list-definition-editable? list-definition parent-node-id evaluation-context))
+    (let [tx-attach-fn (-> list-definition :add (clojure.core/get child-node-type))]
+      (assert tx-attach-fn)
+      (let [child-node-id (first (g/take-node-ids (g/node-id->graph-id parent-node-id) 1))]
+        (concat
+          (g/add-node (g/construct child-node-type :_node-id child-node-id))
+          (init-fn parent-node-id child-node-id)
+          (tx-attach-fn parent-node-id child-node-id)
+          (config-fn child-node-id))))))
+
+(defn add
+  "Create transaction steps for adding an attachment to a node
+
+  Args:
+    workspace    the workspace node id that defines attachments
+    node-id      container node id that should be extended
+    list-kw      keyword that defines a list on a node-id
+    node-type    the node-type of a node to create
+    init-fn      a function that initializes the newly created node, will
+                 receive 2 args: parent-node-id and child-node-id; should return
+                 transaction steps that initialize the node before it's attached
+    config-fn    a function that additionally configures the initialized and
+                 attached node, will receive child-node-id, should return
+                 transaction steps that configure the node (e.g. add more
+                 attachments to it)
+
+  Asserts that the list exists and is editable (see [[defined?]], [[editable?]])"
+  [workspace node-id list-kw node-type init-fn config-fn]
+  (g/expand-ec tx-add workspace node-id list-kw node-type init-fn config-fn))
+
+(defn- list-definition-get [list-definition node-id evaluation-context]
+  ((:get list-definition) node-id evaluation-context))
+
+(defn get
+  "Returns a vector of attached child node ids
 
   Returns a function of 2 args: node-id and evaluation-context, that returns a
   vector of child node ids when invoked
 
-  Asserts that it exists. See [[defines?]]"
-  [basis workspace node-type list-kw]
-  {:post [(some? %)]}
-  (-> basis (workspace/node-attachments workspace) (get node-type) list-kw :get))
+  Asserts that list is defined. See [[defined?]]"
+  [workspace node-id list-kw evaluation-context]
+  (let [[node-id list-definition] (require-list-definition workspace node-id list-kw evaluation-context)]
+    (list-definition-get list-definition node-id evaluation-context)))
 
-(defn- clear-tx [evaluation-context workspace node-id list-kw]
-  (let [basis (:basis evaluation-context)
-        node-type (g/node-type* basis node-id)
-        get-fn (getter basis workspace node-type list-kw)]
-    (assert (editable? basis workspace node-type list-kw))
-    (assert (not (read-only? workspace node-id list-kw evaluation-context)))
+(defn- clear-tx [{:keys [basis] :as evaluation-context} workspace node-id list-kw]
+  (let [[node-id list-definition] (require-list-definition workspace node-id list-kw evaluation-context)]
+    (assert (list-definition-editable? list-definition node-id evaluation-context))
     (mapcat
       #(g/delete-node (g/override-root basis %))
-      (get-fn node-id evaluation-context))))
+      (list-definition-get list-definition node-id evaluation-context))))
 
 (defn clear
   "Create transaction steps for clearing a list of container node-id's list
 
   The implementation will assert that the container node-id defines an editable
-  list (see [[editable?]]) and is not [[read-only?]]"
+  list (see [[editable?]])"
   [workspace node-id list-kw]
   (g/expand-ec clear-tx workspace node-id list-kw))
 
-(defn- remove-tx [evaluation-context workspace node-id list-kw child-node-id]
-  (let [basis (:basis evaluation-context)
-        node-type (g/node-type* basis node-id)
-        get-fn (getter basis workspace node-type list-kw)
-        children (get-fn node-id evaluation-context)]
-    (assert (editable? basis workspace node-type list-kw))
-    (assert (not (read-only? workspace node-id list-kw evaluation-context)))
-    (assert (some #(= child-node-id %) children))
-    (g/delete-node (g/override-root basis child-node-id))))
+(defn- remove-tx [{:keys [basis] :as evaluation-context} workspace node-id list-kw child-node-id]
+  (let [[node-id list-definition] (require-list-definition workspace node-id list-kw evaluation-context)]
+    (assert (list-definition-editable? list-definition node-id evaluation-context))
+    (let [children (list-definition-get list-definition node-id evaluation-context)]
+      (assert (coll/some #(= child-node-id %) children))
+      (g/delete-node (g/override-root basis child-node-id)))))
 
 (defn remove
   "Create transaction steps for removing a child from container node-id
 
   The implementation will assert that the child node id actually exists in the
-  container as defined by [[getter]]. It will also assert that the container
-  node-id defines an editable list identified by list-kw (see [[editable?]]) and
-  is not [[read-only?]]"
+  container as defined by [[get]]. It will also assert that the container
+  node-id defines an editable list identified by list-kw (see [[editable?]])"
   [workspace node-id list-kw child-node-id]
   (g/expand-ec remove-tx workspace node-id list-kw child-node-id))
 
 (defn- reorder-tx [evaluation-context workspace node-id list-kw reordered-child-node-ids]
-  (let [basis (:basis evaluation-context)
-        node-type (g/node-type* basis node-id)
-        get-fn (getter basis workspace node-type list-kw)
-        children-set (set (get-fn node-id evaluation-context))
-        reorder-fn (-> basis (workspace/node-attachments workspace) (get node-type) list-kw :reorder)]
-    (assert (editable? basis workspace node-type list-kw))
-    (assert (not (read-only? workspace node-id list-kw evaluation-context)))
-    (assert (every? children-set reordered-child-node-ids))
-    (assert (= (count children-set) (count reordered-child-node-ids))) ;; no duplicates
-    (assert reorder-fn)
-    (reorder-fn reordered-child-node-ids)))
+  (let [[node-id list-definition] (require-list-definition workspace node-id list-kw evaluation-context)]
+    (assert (list-definition-editable? list-definition node-id evaluation-context))
+    (assert (list-definition-reorderable? list-definition))
+    (let [children-set (set (list-definition-get list-definition node-id evaluation-context))
+          reorder-fn (:reorder list-definition)]
+      (assert (every? children-set reordered-child-node-ids))
+      (assert (= (count children-set) (count reordered-child-node-ids))) ;; no duplicates
+      (reorder-fn reordered-child-node-ids))))
 
 (defn reorder
   "Create transaction steps for reordering a list of children
@@ -276,14 +305,15 @@
   The implementation will assert that the supplied child node ids are the same
   node ids as defined by [[getter]]. It will also assert that the container
   node-id defines an editable and reorderable list (see [[reorderable?]],
-  [[editable?]]) and is not [[read-only?]]"
+  [[editable?]])"
   [workspace node-id list-kw reordered-child-node-ids]
   (g/expand-ec reorder-tx workspace node-id list-kw reordered-child-node-ids))
 
 (defn nodes-by-type-getter
-  "Create a node list getter using a type filter over the :nodes output
+  "Create a node list getter using a type filter over the :nodes output of a
+  non-override node
 
-  Returns a function suitable for use as a :get parameter to [[register!]]"
+  Returns a function suitable for use as a :get parameter to [[register]]"
   [child-node-type]
   (fn get-nodes-by-type [node evaluation-context]
     (let [basis (:basis evaluation-context)]
@@ -293,7 +323,7 @@
 
 ;; SDK api
 (defn nodes-getter
-  "node list getter that returns :nodes output
+  "Node list getter that returns :nodes output of a non-override node
 
   This function is suitable for use as a :get parameter to [[register]]"
   [node evaluation-context]

--- a/editor/src/clj/editor/game_object.clj
+++ b/editor/src/clj/editor/game_object.clj
@@ -14,12 +14,16 @@
 
 (ns editor.game-object
   (:require [clojure.set :as set]
+            [clojure.string :as string]
             [dynamo.graph :as g]
             [editor.app-view :as app-view]
+            [editor.attachment :as attachment]
             [editor.build-target :as bt]
             [editor.collection-string-data :as collection-string-data]
-            [editor.core :as core]
             [editor.defold-project :as project]
+            [editor.editor-extensions.coerce :as coerce]
+            [editor.editor-extensions.graph :as ext-graph]
+            [editor.editor-extensions.runtime :as rt]
             [editor.game-object-common :as game-object-common]
             [editor.graph-util :as gu]
             [editor.handler :as handler]
@@ -34,13 +38,16 @@
             [editor.scene-tools :as scene-tools]
             [editor.sound :as sound]
             [editor.types :as types]
+            [editor.util :as eutil]
             [editor.validation :as validation]
             [editor.workspace :as workspace]
             [internal.util :as util]
             [util.eduction :as e])
   (:import [com.dynamo.gameobject.proto GameObject$ComponentDesc GameObject$EmbeddedComponentDesc GameObject$PrototypeDesc]
            [com.dynamo.gamesys.proto Sound$SoundDesc]
-           [javax.vecmath Vector3d]))
+           [javax.vecmath Vector3d]
+           [org.apache.commons.io FilenameUtils]
+           [org.luaj.vm2 LuaError]))
 
 (set! *warn-on-reflection* true)
 
@@ -388,14 +395,10 @@
 (g/defnk produce-scene [_node-id child-scenes]
   (game-object-common/game-object-scene _node-id child-scenes))
 
-(defn- attach-component [self-id comp-id ddf-input resolve-id?]
+(defn- attach-component [self-id comp-id ddf-input]
   ;; self-id: GameObjectNode
   ;; comp-id: EmbeddedComponent, ReferencedComponent
   (concat
-    (when resolve-id?
-      (->> (g/node-value self-id :component-ids)
-           keys
-           (g/update-property comp-id :id id/resolve)))
     (for [[from to] [[:node-outline :child-outlines]
                      [:_node-id :nodes]
                      [:build-targets :dep-build-targets]
@@ -408,25 +411,32 @@
                      [:id-counts :id-counts]]]
       (g/connect self-id from comp-id to))))
 
-(defn- attach-ref-component [self-id comp-id]
+(defn- attach-referenced-component [self-id comp-id]
   ;; self-id: GameObjectNode
   ;; comp-id: ReferencedComponent
-  (attach-component self-id comp-id :ref-ddf false))
+  (attach-component self-id comp-id :ref-ddf))
 
 (defn- attach-embedded-component [self-id comp-id]
   ;; self-id: GameObjectNode
   ;; comp-id: EmbeddedComponent
-  (attach-component self-id comp-id :embed-ddf false))
+  (attach-component self-id comp-id :embed-ddf))
+
+(defn- resolve-id [self-id comp-id]
+  (g/update-property comp-id :id id/resolve (g/node-value self-id :component-ids)))
 
 (defn- outline-attach-ref-component [self-id comp-id]
   ;; self-id: GameObjectNode
   ;; comp-id: ReferencedComponent
-  (attach-component self-id comp-id :ref-ddf true))
+  (concat
+    (resolve-id self-id comp-id)
+    (attach-component self-id comp-id :ref-ddf)))
 
 (defn- outline-attach-embedded-component [self-id comp-id]
   ;; self-id: GameObjectNode
   ;; comp-id: EmbeddedComponent
-  (attach-component self-id comp-id :embed-ddf true))
+  (concat
+    (resolve-id self-id comp-id)
+    (attach-component self-id comp-id :embed-ddf)))
 
 (g/defnk produce-go-outline [_node-id child-outlines]
   {:node-id _node-id
@@ -484,7 +494,7 @@
         rotation :rotation
         scale :scale)
       (g/set-property comp-node :path path) ; Set last so the :alter-referenced-component-fn can alter component properties.
-      (attach-ref-component self comp-node)
+      (attach-referenced-component self comp-node)
       (when select-fn
         (select-fn [comp-node])))))
 
@@ -509,6 +519,16 @@
   (run [workspace project selection app-view]
        (add-component-handler workspace project (selection->game-object selection) (fn [node-ids] (app-view/select app-view node-ids)))))
 
+(defn- connect-embedded-resource [node-type resource-node comp-node]
+  (gu/connect-existing-outputs node-type resource-node comp-node
+    [[:_node-id :embedded-resource-id]
+     [:resource :source-resource]
+     [:_properties :source-properties]
+     [:node-outline :source-outline]
+     [:save-value :source-save-value]
+     [:scene :scene]
+     [:build-targets :source-build-targets]]))
+
 (defn- add-embedded-component [self project type pb-map id transform-properties select-fn]
   {:pre [(map? pb-map)]}
   (let [graph (g/node-id->graph-id self)
@@ -521,14 +541,7 @@
         rotation :rotation
         scale :scale)
       (project/load-embedded-resource-node project resource-node resource pb-map)
-      (gu/connect-existing-outputs node-type resource-node comp-node
-        [[:_node-id :embedded-resource-id]
-         [:resource :source-resource]
-         [:_properties :source-properties]
-         [:node-outline :source-outline]
-         [:save-value :source-save-value]
-         [:scene :scene]
-         [:build-targets :source-build-targets]])
+      (connect-embedded-resource node-type resource-node comp-node)
       (attach-embedded-component self comp-node)
       (when select-fn
         (select-fn [comp-node])))))
@@ -554,13 +567,21 @@
     (let [rt (:resource-type user-data)]
       (or (:label rt) (:ext rt)))))
 
-(defn embeddable-component-resource-types [workspace]
-  (keep (fn [[_ext {:keys [tags] :as resource-type}]]
-          (when (and (contains? tags :component)
-                     (not (contains? tags :non-embeddable))
-                     (workspace/has-template? workspace resource-type))
-            resource-type))
-        (workspace/get-resource-type-map workspace)))
+(defn- embeddable-component-resource-type? [resource-type workspace evaluation-context]
+  (let [{:keys [tags] :as resource-type} resource-type]
+    (and (contains? tags :component)
+         (not (contains? tags :non-embeddable))
+         (workspace/has-template? workspace resource-type evaluation-context))))
+
+(defn embeddable-component-resource-types
+  ([workspace]
+   (g/with-auto-evaluation-context evaluation-context
+     (embeddable-component-resource-types workspace evaluation-context)))
+  ([workspace evaluation-context]
+   (keep (fn [[_ext resource-type]]
+           (when (embeddable-component-resource-type? resource-type workspace evaluation-context)
+             resource-type))
+         (resource/resource-types-by-type-ext (:basis evaluation-context) workspace :editable))))
 
 (defn add-embedded-component-options [self workspace user-data]
   (when (not user-data)
@@ -620,19 +641,111 @@
          (mapv (fn [[id resource]]
                  (add-component root-id resource id transform-props nil nil))))))
 
+(def ^:private ext-embedded-component-type-prefix "embedded-component-type-")
+(def ^:private ext-referenced-component-type "referenced-component")
+(def ^:private constantly-ext-referenced-component-type (constantly ext-referenced-component-type))
+
+(ext-graph/register-property-getter!
+  ::ReferencedComponent
+  (fn ReferencedComponent-getter [_node-id property _evaluation-context]
+    (case property
+      "type" constantly-ext-referenced-component-type
+      nil)))
+
+(ext-graph/register-property-getter!
+  ::EmbeddedComponent
+  (fn EmbeddedComponent-getter [node-id property evaluation-context]
+    (case property
+      "type" #(str ext-embedded-component-type-prefix (resource/ext (g/node-value node-id :source-resource evaluation-context)))
+      nil)))
+
+(defmethod ext-graph/extract-node-type [::GameObjectNode :components]
+  [rt attachment workspace _node-id _list-kw evaluation-context]
+  (if-let [lua-type (attachment "type")]
+    (let [type-name (rt/->clj rt coerce/string lua-type)]
+      (if (= ext-referenced-component-type type-name)
+        [(dissoc attachment "type") ReferencedComponent]
+        (if (and (string/starts-with? type-name ext-embedded-component-type-prefix)
+                 (let [component-ext (subs type-name (count ext-embedded-component-type-prefix))
+                       resource-types (resource/resource-types-by-type-ext (:basis evaluation-context) workspace :editable)
+                       resource-type (resource-types component-ext)]
+                   (and resource-type
+                        (embeddable-component-resource-type? resource-type workspace evaluation-context))))
+          [attachment EmbeddedComponent]
+          (throw (LuaError. (str "type is not "
+                                 (->> (embeddable-component-resource-types workspace evaluation-context)
+                                      (map #(str ext-embedded-component-type-prefix (:ext %)))
+                                      (cons ext-referenced-component-type)
+                                      (eutil/join-words ", " " or "))))))))
+    (throw (LuaError. "type is required"))))
+
+(defmethod ext-graph/create-extra-nodes ::EmbeddedComponent [evaluation-context rt project workspace attachment node-id]
+  (let [component-ext (subs (rt/->clj rt coerce/string (attachment "type")) (count ext-embedded-component-type-prefix))
+        resource-types (resource/resource-types-by-type-ext (:basis evaluation-context) workspace :editable)
+        resource-type (resource-types component-ext)]
+    (assert resource-type)
+    (assert (embeddable-component-resource-type? resource-type workspace evaluation-context))
+    (let [graph (g/node-id->graph-id node-id)
+          pb-map (game-object-common/template-pb-map workspace resource-type evaluation-context)
+          resource (resource/make-memory-resource workspace resource-type pb-map)
+          node-type (:node-type resource-type)]
+      (g/make-nodes graph [resource-node [node-type :resource resource]]
+        (project/load-embedded-resource-node project resource-node resource pb-map)
+        (connect-embedded-resource node-type resource-node node-id)))))
+
+(defmethod ext-graph/init-attachment ::EmbeddedComponent
+  [evaluation-context rt project parent-node-id _child-node-type child-node-id attachment]
+  (let [component-ext (subs (rt/->clj rt coerce/string (attachment "type")) (count ext-embedded-component-type-prefix))]
+    (-> attachment
+        (dissoc "type")
+        (eutil/provide-defaults
+          "id" (rt/->lua (id/gen component-ext (g/node-value parent-node-id :component-ids evaluation-context))))
+        (ext-graph/attachment->set-tx-steps child-node-id rt project evaluation-context))))
+
+(defn- set-referenced-attachment-properties [evaluation-context rt project parent-node-id child-node-id attachment]
+  (-> attachment
+      ;; Ignore the path since it's applied first in init-attachment
+      (dissoc "path")
+      (eutil/provide-defaults
+        "id" (rt/->lua
+               (id/gen
+                 (if-let [lua-path (attachment "path")]
+                   (FilenameUtils/getBaseName (rt/->clj rt coerce/string lua-path))
+                   "component")
+                 (g/node-value parent-node-id :component-ids evaluation-context))))
+      (ext-graph/attachment->set-tx-steps child-node-id rt project evaluation-context)))
+
+(defmethod ext-graph/init-attachment ::ReferencedComponent
+  [evaluation-context rt project parent-node-id _child-node-type child-node-id attachment]
+  (if-let [lua-resource-path (attachment "path")]
+    (concat
+      (ext-graph/attachment->set-tx-steps {"path" lua-resource-path} child-node-id rt project evaluation-context)
+      (g/expand-ec set-referenced-attachment-properties rt project parent-node-id child-node-id attachment))
+    (set-referenced-attachment-properties evaluation-context rt project parent-node-id child-node-id attachment)))
+
+(defn- embedded-component-attachment-alternative [comp-id evaluation-context]
+  (g/node-value comp-id :embedded-resource-id evaluation-context))
+
 (defn register-resource-types [workspace]
-  (resource-node/register-ddf-resource-type workspace
-    :ext "go"
-    :label "Game Object"
-    :node-type GameObjectNode
-    :ddf-type GameObject$PrototypeDesc
-    :load-fn load-game-object
-    :allow-unloaded-use true
-    :dependencies-fn (game-object-common/make-game-object-dependencies-fn #(workspace/get-resource-type-map workspace))
-    :sanitize-fn (partial sanitize-game-object workspace)
-    :string-encode-fn (partial string-encode-game-object workspace)
-    :icon game-object-common/game-object-icon
-    :icon-class :design
-    :view-types [:scene :text]
-    :view-opts {:scene {:grid true
-                        :drop-fn handle-drop}}))
+  (concat
+    (attachment/register
+      workspace GameObjectNode :components
+      :add {EmbeddedComponent attach-embedded-component
+            ReferencedComponent attach-referenced-component}
+      :get attachment/nodes-getter)
+    (attachment/define-alternative workspace EmbeddedComponent embedded-component-attachment-alternative)
+    (resource-node/register-ddf-resource-type workspace
+      :ext "go"
+      :label "Game Object"
+      :node-type GameObjectNode
+      :ddf-type GameObject$PrototypeDesc
+      :load-fn load-game-object
+      :allow-unloaded-use true
+      :dependencies-fn (game-object-common/make-game-object-dependencies-fn #(workspace/get-resource-type-map workspace))
+      :sanitize-fn (partial sanitize-game-object workspace)
+      :string-encode-fn (partial string-encode-game-object workspace)
+      :icon game-object-common/game-object-icon
+      :icon-class :design
+      :view-types [:scene :text]
+      :view-opts {:scene {:grid true
+                          :drop-fn handle-drop}})))

--- a/editor/src/clj/editor/game_object_common.clj
+++ b/editor/src/clj/editor/game_object_common.clj
@@ -37,11 +37,15 @@
 
 (def component-transform-property-keys (set (keys scene/identity-transform-properties)))
 
-(defn template-pb-map [workspace resource-type]
-  (let [template (workspace/template workspace resource-type)
-        read-fn (:read-fn resource-type)]
-    (with-open [reader (StringReader. template)]
-      (read-fn reader))))
+(defn template-pb-map
+  ([workspace resource-type]
+   (g/with-auto-evaluation-context evaluation-context
+     (template-pb-map workspace resource-type evaluation-context)))
+  ([workspace resource-type evaluation-context]
+   (let [template (workspace/template workspace resource-type evaluation-context)
+         read-fn (:read-fn resource-type)]
+     (with-open [reader (StringReader. template)]
+       (read-fn reader)))))
 
 (defn strip-default-scale-from-component-desc [component-desc]
   ;; GameObject$ComponentDesc or GameObject$EmbeddedComponentDesc in map format.

--- a/editor/src/clj/editor/workspace.clj
+++ b/editor/src/clj/editor/workspace.clj
@@ -493,34 +493,41 @@ ordinary paths."
 (def ^:private default-user-resource-path "/templates/default.")
 (def ^:private java-resource-path "templates/template.")
 
-(defn- get-template-resource [workspace resource-type]
+(defn- get-template-resource [workspace resource-type evaluation-context]
   (when resource-type
     (let [resource-path (:template resource-type)
           ext (:ext resource-type)]
       (or
         ;; default user resource
-        (find-resource workspace (str default-user-resource-path ext))
+        (find-resource workspace (str default-user-resource-path ext) evaluation-context)
         ;; editor resource provided from extensions
-        (when resource-path (find-resource workspace resource-path))
+        (when resource-path (find-resource workspace resource-path evaluation-context))
         ;; java resource
         (io/resource (str java-resource-path ext))))))
 
-(defn has-template? [workspace resource-type]
-  (let [resource (get-template-resource workspace resource-type)]
-    (not= resource nil)))
+(defn has-template?
+  ([workspace resource-type]
+   (g/with-auto-evaluation-context evaluation-context
+     (has-template? workspace resource-type evaluation-context)))
+  ([workspace resource-type evaluation-context]
+   (some? (get-template-resource workspace resource-type evaluation-context))))
 
-(defn template [workspace resource-type]
-  (when-let [resource (get-template-resource workspace resource-type)]
-    (let [{:keys [read-fn write-fn]} resource-type]
-      (if (and read-fn write-fn)
-        ;; Sanitize the template.
-        (write-fn
-          (with-open [reader (io/reader resource)]
-            (read-fn reader)))
+(defn template
+  ([workspace resource-type]
+   (g/with-auto-evaluation-context evaluation-context
+     (template workspace resource-type evaluation-context)))
+  ([workspace resource-type evaluation-context]
+   (when-let [resource (get-template-resource workspace resource-type evaluation-context)]
+     (let [{:keys [read-fn write-fn]} resource-type]
+       (if (and read-fn write-fn)
+         ;; Sanitize the template.
+         (write-fn
+           (with-open [reader (io/reader resource)]
+             (read-fn reader)))
 
-        ;; Just read the file as-is.
-        (with-open [reader (io/reader resource)]
-          (slurp reader))))))
+         ;; Just read the file as-is.
+         (with-open [reader (io/reader resource)]
+           (slurp reader)))))))
 
 (defn- update-dependency-notifications! [workspace lib-states]
   (let [{:keys [error missing]} (->> lib-states
@@ -895,24 +902,6 @@ ordinary paths."
   (property editable-proj-path? g/Any)
   (property unloaded-proj-path? g/Any)
   (property resource-kind-extensions g/Any (default {:atlas ["atlas" "tilesource"]}))
-  ;; See editor.attachment ns
-  ;; {node-type {list-kw {:add {node-type tx-attach-fn}
-  ;;                      :get get-fn
-  ;;                      :reorder reorder-fn
-  ;;                      :read-only? read-only-pred
-  ;;                      ;; one of:
-  ;;                      :alias node-type
-  ;;                      :aliases #{node-types}}}}
-  ;;
-  ;; tx-attach-fn: fn of parent-node, child-node -> txs
-  ;; get-fn: fn of node, evaluation-context -> vector of nodes
-  ;; reorder-fn: fn of reordered-nodes -> txs
-  ;; read-only-pred: fn of parent-node, evaluation-context -> boolean
-  ;;
-  ;; :alias refers to a node type that this list definition tracks (i.e. a link
-  ;; to the "original")
-  ;; :aliases refers to a set of all node types that track this definition (i.e.
-  ;; links to "copies")
   (property node-attachments g/Any (default {}))
 
   (input code-preprocessors g/NodeID :cascade-delete)

--- a/editor/test/integration/editor_extensions_test.clj
+++ b/editor/test/integration/editor_extensions_test.clj
@@ -869,7 +869,7 @@ nesting:
   (let [actual (normalize-pprint-output (str actual))]
     (let [output-matches-expectation (= expected actual)]
       (when-not output-matches-expectation
-        (is output-matches-expectation (string/join "\n" (diff/make-diff-output-lines actual expected 3)))))))
+        (is output-matches-expectation (string/join "\n" (diff/make-diff-output-lines expected actual 3)))))))
 
 (deftest pprint-test
   (test-util/with-loaded-project "test/resources/editor_extensions/pprint-test"
@@ -1219,10 +1219,10 @@ After transaction (remove animation):
   images: 0
   animations: 0
 Expected errors:
-  Wrong list name to add => AtlasNode does not define \"layers\"
-  Wrong list name to remove => AtlasNode does not define \"layers\"
+  Wrong list name to add => \"layers\" is undefined
+  Wrong list name to remove => \"layers\" is undefined
   Wrong list item to remove => /test.atlas is not in the \"images\" list of /test.atlas
-  Wrong list name to clear => AtlasNode does not define \"layers\"
+  Wrong list name to clear => \"layers\" is undefined
   Wrong child property name => Can't set property \"no_such_prop\" of AtlasAnimation
   Added value is not a table => \"/foo.png\" is not a table
   Added nested value is not a table => \"/foo.png\" is not a table
@@ -1482,13 +1482,13 @@ After transaction (reorder):
         id: box1
         nodes: 0
 Expected reorder errors:
-  undefined property => GuiSceneNode does not define \"not-a-property\"
-  reorder not defined => CollisionObjectNode does not support \"shapes\" reordering
+  undefined property => \"not-a-property\" is undefined
+  reorder not defined => \"shapes\" is not reorderable
   duplicates => Reordered child nodes are not the same as current child nodes
   missing children => Reordered child nodes are not the same as current child nodes
   wrong child nodes => Reordered child nodes are not the same as current child nodes
-  add to template node => \"nodes\" is not editable
-  reorder template node => \"nodes\" is not editable
+  add to template node => \"nodes\" is read-only
+  reorder template node => \"nodes\" is read-only
   add to overridden text node => \"nodes\" is read-only
   reorder overridden text node => \"nodes\" is read-only
   reset unresettable => Can't reset property \"text\" of TextNode
@@ -1506,6 +1506,69 @@ After transaction (clear):
   spine scenes: 0
   fonts: 0
   nodes: 0
+Go initial state:
+  components: 0
+Transaction: add go components
+After transaction (add go components):
+  components: 15
+  - type: embedded-component-type-camera
+    id: camera
+  - type: embedded-component-type-collectionfactory
+    id: collectionfactory
+  - type: embedded-component-type-collectionproxy
+    id: collectionproxy
+  - type: embedded-component-type-collectionproxy
+    id: collectionproxy1
+  - type: embedded-component-type-collisionobject
+    id: collisionobject-embedded
+    shapes: 1
+    - id: box
+      type: shape-type-box
+      dimensions: 2.5 2.5 2.5
+  - type: embedded-component-type-factory
+    id: factory
+  - type: embedded-component-type-label
+    id: label
+    position: {0, 0, 0}
+    rotation: {0, 0, 0}
+    scale: {0.05, 0.05, 0.05}
+  - type: embedded-component-type-mesh
+    id: mesh
+    position: {0, 0, 0}
+    rotation: {0, 0, 0}
+  - type: embedded-component-type-model
+    id: model
+    position: {0, 0, 0}
+    rotation: {0, 0, 0}
+  - type: embedded-component-type-sound
+    id: boom
+  - type: embedded-component-type-spinemodel
+    id: spinemodel
+    position: {3.14, 3.14, 0}
+    rotation: {0, 0, 0}
+    scale: {1, 1, 1}
+  - type: embedded-component-type-sprite
+    id: blob
+    position: {0, 0, 0}
+    rotation: {0, 0, 0}
+    scale: {1, 1, 1}
+  - type: referenced-component
+    id: test
+  - type: referenced-component
+    id: collisionobject-referenced
+  - type: referenced-component
+    id: referenced-tilemap
+    position: {0, 0, 0}
+    rotation: {0, 0, 0}
+Collision object components found:
+  referenced: true
+  embedded: true
+Collision object components have shapes property:
+  referenced: false
+  embedded: true
+Transaction: clear go components
+After transaction (clear go components):
+  components: 0
 ")
 
 (deftest attachment-properties-test

--- a/editor/test/integration/editor_extensions_test.clj
+++ b/editor/test/integration/editor_extensions_test.clj
@@ -1511,52 +1511,52 @@ Go initial state:
 Transaction: add go components
 After transaction (add go components):
   components: 15
-  - type: embedded-component-type-camera
+  - type: camera
     id: camera
-  - type: embedded-component-type-collectionfactory
+  - type: collectionfactory
     id: collectionfactory
-  - type: embedded-component-type-collectionproxy
+  - type: collectionproxy
     id: collectionproxy
-  - type: embedded-component-type-collectionproxy
+  - type: collectionproxy
     id: collectionproxy1
-  - type: embedded-component-type-collisionobject
+  - type: collisionobject
     id: collisionobject-embedded
     shapes: 1
     - id: box
       type: shape-type-box
       dimensions: 2.5 2.5 2.5
-  - type: embedded-component-type-factory
+  - type: factory
     id: factory
-  - type: embedded-component-type-label
+  - type: label
     id: label
     position: {0, 0, 0}
     rotation: {0, 0, 0}
     scale: {0.05, 0.05, 0.05}
-  - type: embedded-component-type-mesh
+  - type: mesh
     id: mesh
     position: {0, 0, 0}
     rotation: {0, 0, 0}
-  - type: embedded-component-type-model
+  - type: model
     id: model
     position: {0, 0, 0}
     rotation: {0, 0, 0}
-  - type: embedded-component-type-sound
+  - type: sound
     id: boom
-  - type: embedded-component-type-spinemodel
+  - type: spinemodel
     id: spinemodel
     position: {3.14, 3.14, 0}
     rotation: {0, 0, 0}
     scale: {1, 1, 1}
-  - type: embedded-component-type-sprite
+  - type: sprite
     id: blob
     position: {0, 0, 0}
     rotation: {0, 0, 0}
     scale: {1, 1, 1}
-  - type: referenced-component
+  - type: reference
     id: test
-  - type: referenced-component
+  - type: reference
     id: collisionobject-referenced
-  - type: referenced-component
+  - type: reference
     id: referenced-tilemap
     position: {0, 0, 0}
     rotation: {0, 0, 0}

--- a/editor/test/resources/editor_extensions/transact_attachment_project/test.editor_script
+++ b/editor/test/resources/editor_extensions/transact_attachment_project/test.editor_script
@@ -87,22 +87,23 @@ local function print_particlefx_contents(particlefx)
     end
 end
 
-local function print_collision_object(collision)
+local function print_collision_object(collision, indent)
+    indent = indent or "  "
     local shapes = editor.get(collision, "shapes")
-    print(("  shapes: %s"):format(#shapes))
+    print(("%sshapes: %s"):format(indent, #shapes))
     for i = 1, #shapes do
         local shape = shapes[i]
-        print(("  - id: %s"):format(editor.get(shape, "id")))
+        print(("%s- id: %s"):format(indent, editor.get(shape, "id")))
         local type = editor.get(shape, "type")
-        print(("    type: %s"):format(type))
+        print(("%s  type: %s"):format(indent, type))
         if type == "shape-type-sphere" then
-            print(("    diameter: %s"):format(editor.get(shape, "diameter")))
+            print(("%s  diameter: %s"):format(indent, editor.get(shape, "diameter")))
         elseif type == "shape-type-box" then
             local x,y,z = table.unpack(editor.get(shape, "dimensions"))
-            print(("    dimensions: %s %s %s"):format(x, y, z))
+            print(("%s  dimensions: %s %s %s"):format(indent, x, y, z))
         elseif type == "shape-type-capsule" then
-            print(("    diameter: %s"):format(editor.get(shape, "diameter")))
-            print(("    height: %s"):format(editor.get(shape, "height")))
+            print(("%s  diameter: %s"):format(indent, editor.get(shape, "diameter")))
+            print(("%s  height: %s"):format(indent, editor.get(shape, "height")))
         end
     end
 end
@@ -179,6 +180,29 @@ local function print_gui_node_positions(node)
     end
 end
 
+local transform_props = {"position", "rotation", "scale"}
+
+local function print_go(go)
+    local components = editor.get(go, "components")
+    print(("  components: %s"):format(#components))
+    for i = 1, #components do
+        local component = components[i]
+        local type = editor.get(component, "type")
+        print(("  - type: %s"):format(type))
+        print(("    id: %s"):format(editor.get(component, "id")))
+        for j = 1, #transform_props do
+            local p = transform_props[j]
+            if editor.can_get(component, p) then
+                local position = editor.get(component, p)
+                print(("    %s: {%s, %s, %s}"):format(p, position[1], position[2], position[3]))
+            end
+        end
+        if type == "embedded-component-type-collisionobject" then
+            print_collision_object(component, "    ")
+        end
+    end
+end
+
 function M.get_commands()
     return {
         editor.command({
@@ -233,7 +257,7 @@ function M.get_commands()
                 expect_error("Wrong list name to clear", editor.tx.clear, "/test.atlas", "layers")
                 expect_error("Wrong child property name", editor.transact, { editor.tx.add("/test.atlas", "animations", { no_such_prop = true}) })
                 expect_error("Added value is not a table", editor.tx.add, "/test.atlas", "images", "/foo.png")
-                expect_error("Added nested value is not a table", editor.tx.add, "/test.atlas", "animations", { images = { "/foo.png" } })
+                expect_error("Added nested value is not a table", editor.transact, { editor.tx.add("/test.atlas", "animations", { images = { "/foo.png" } }) })
                 expect_error("Added node has invalid property value", editor.transact, { editor.tx.add("/test.atlas", "images", { pivot = "invalid-pivot" }) })
                 expect_error("Added resource has wrong type", editor.transact, { editor.tx.add("/test.atlas", "images", { image = "/game.project" }) })
 
@@ -497,6 +521,116 @@ function M.get_commands()
 
                 print("After transaction (clear):")
                 print_gui(gui)
+
+                local go = "/test.go"
+                print("Go initial state:")
+                print_go(go)
+
+                print("Transaction: add go components")
+
+                editor.transact({
+                    editor.tx.add(go, "components", {
+                        type = "embedded-component-type-camera",
+                        near_z = 1,
+                        far_z = 10
+                    }),
+                    editor.tx.add(go, "components", {
+                        type = "embedded-component-type-collectionfactory"
+                    }),
+                    editor.tx.add(go, "components", {
+                        type = "embedded-component-type-collectionproxy"
+                    }),
+                    editor.tx.add(go, "components", {
+                        type = "embedded-component-type-collectionproxy"
+                    }),
+                    editor.tx.add(go, "components", {
+                        id = "collisionobject-embedded",
+                        type = "embedded-component-type-collisionobject",
+                        locked_rotation = true,
+                        shapes = {
+                            {
+                                id = "box",
+                                type = "shape-type-box",
+                                dimensions = {2.5, 2.5, 2.5},
+                            }
+                        }
+                    }),
+                    editor.tx.add(go, "components", {
+                        type = "embedded-component-type-factory",
+                        load_dynamically = true
+                    }),
+                    editor.tx.add(go, "components", {
+                        type = "embedded-component-type-label",
+                        text = "Hello label!",
+                        scale = {0.05, 0.05, 0.05}
+                    }),
+                    editor.tx.add(go, "components", {
+                        type = "embedded-component-type-mesh"
+                    }),
+                    editor.tx.add(go, "components", {
+                        type = "embedded-component-type-model",
+                        mesh = "/builtins/assets/meshes/cube.dae"
+                    }),
+                    editor.tx.add(go, "components", {
+                        type = "embedded-component-type-sound",
+                        id = "boom"
+                    }),
+                    editor.tx.add(go, "components", {
+                        type = "embedded-component-type-spinemodel",
+                        position = {3.14, 3.14, 0}
+                    }),
+                    editor.tx.add(go, "components", {
+                        type = "embedded-component-type-sprite",
+                        id = "blob"
+                    }),
+                    editor.tx.add(go, "components", { 
+                        type = "referenced-component",
+                        path = "/test.script",
+                        __num = 42
+                    }),
+                    editor.tx.add(go, "components", {
+                        id = "collisionobject-referenced",
+                        type = "referenced-component",
+                        path = "/test.collisionobject"
+                    }),
+                    editor.tx.add(go, "components", {
+                        id = "referenced-tilemap",
+                        type = "referenced-component",
+                        path = "/test.tilemap"
+                    })
+                })
+
+                print("After transaction (add go components):")
+                print_go(go)
+
+                local referenced_collision
+                local embedded_collision
+                local components = editor.get(go, "components")
+                for i = 1, #components do
+                    local c = components[i]
+                    local id = editor.get(c, "id")
+                    if id == "collisionobject-referenced" then
+                        referenced_collision = c
+                    elseif id == "collisionobject-embedded" then
+                        embedded_collision = c
+                    end
+                end
+
+                print("Collision object components found:")
+                print(("  referenced: %s"):format(tostring(not not referenced_collision)))
+                print(("  embedded: %s"):format(tostring(not not embedded_collision)))
+                
+                print("Collision object components have shapes property:")
+                print(("  referenced: %s"):format(tostring(editor.can_get(referenced_collision, "shapes"))))
+                print(("  embedded: %s"):format(tostring(editor.can_get(embedded_collision, "shapes"))))
+
+                print("Transaction: clear go components")
+                editor.transact({
+                    editor.tx.clear(go, "components")
+                })
+
+                print("After transaction (clear go components):")
+                print_go(go)
             end
         })
     }

--- a/editor/test/resources/editor_extensions/transact_attachment_project/test.editor_script
+++ b/editor/test/resources/editor_extensions/transact_attachment_project/test.editor_script
@@ -197,7 +197,7 @@ local function print_go(go)
                 print(("    %s: {%s, %s, %s}"):format(p, position[1], position[2], position[3]))
             end
         end
-        if type == "embedded-component-type-collisionobject" then
+        if type == "collisionobject" then
             print_collision_object(component, "    ")
         end
     end
@@ -530,22 +530,22 @@ function M.get_commands()
 
                 editor.transact({
                     editor.tx.add(go, "components", {
-                        type = "embedded-component-type-camera",
+                        type = "camera",
                         near_z = 1,
                         far_z = 10
                     }),
                     editor.tx.add(go, "components", {
-                        type = "embedded-component-type-collectionfactory"
+                        type = "collectionfactory"
                     }),
                     editor.tx.add(go, "components", {
-                        type = "embedded-component-type-collectionproxy"
+                        type = "collectionproxy"
                     }),
                     editor.tx.add(go, "components", {
-                        type = "embedded-component-type-collectionproxy"
+                        type = "collectionproxy"
                     }),
                     editor.tx.add(go, "components", {
                         id = "collisionobject-embedded",
-                        type = "embedded-component-type-collisionobject",
+                        type = "collisionobject",
                         locked_rotation = true,
                         shapes = {
                             {
@@ -556,46 +556,46 @@ function M.get_commands()
                         }
                     }),
                     editor.tx.add(go, "components", {
-                        type = "embedded-component-type-factory",
+                        type = "factory",
                         load_dynamically = true
                     }),
                     editor.tx.add(go, "components", {
-                        type = "embedded-component-type-label",
+                        type = "label",
                         text = "Hello label!",
                         scale = {0.05, 0.05, 0.05}
                     }),
                     editor.tx.add(go, "components", {
-                        type = "embedded-component-type-mesh"
+                        type = "mesh"
                     }),
                     editor.tx.add(go, "components", {
-                        type = "embedded-component-type-model",
+                        type = "model",
                         mesh = "/builtins/assets/meshes/cube.dae"
                     }),
                     editor.tx.add(go, "components", {
-                        type = "embedded-component-type-sound",
+                        type = "sound",
                         id = "boom"
                     }),
                     editor.tx.add(go, "components", {
-                        type = "embedded-component-type-spinemodel",
+                        type = "spinemodel",
                         position = {3.14, 3.14, 0}
                     }),
                     editor.tx.add(go, "components", {
-                        type = "embedded-component-type-sprite",
+                        type = "sprite",
                         id = "blob"
                     }),
                     editor.tx.add(go, "components", { 
-                        type = "referenced-component",
+                        type = "reference",
                         path = "/test.script",
                         __num = 42
                     }),
                     editor.tx.add(go, "components", {
                         id = "collisionobject-referenced",
-                        type = "referenced-component",
+                        type = "reference",
                         path = "/test.collisionobject"
                     }),
                     editor.tx.add(go, "components", {
                         id = "referenced-tilemap",
-                        type = "referenced-component",
+                        type = "reference",
                         path = "/test.tilemap"
                     })
                 })

--- a/editor/test/resources/editor_extensions/transact_attachment_project/test.script
+++ b/editor/test/resources/editor_extensions/transact_attachment_project/test.script
@@ -1,0 +1,1 @@
+go.property("num", 15)


### PR DESCRIPTION
It's now possible to edit components of a game object file using editor scripts. The components come in 2 flavors: referenced and embedded. Referenced components use type `reference` and act as references to other resources, only allowing overrides of go properties defined in scripts. Embedded components use types like `sprite`, `label`, etc., and allow editing of all properties defined in the component type, as well as adding sub-components like shapes of collision objects. For example, you can use the following code to set up a game object:
```lua
editor.transact({
    editor.tx.add("/npc.go", "components", {
        type = "sprite",
        id = "view"
    }),
    editor.tx.add("/npc.go", "components", {
        type = "collisionobject",
        id = "collision",
        shapes = {
            {
                type = "shape-type-box",
                dimensions = {32, 32, 32}
            }
        }
    }),
    editor.tx.add("/npc.go", "components", {
        type = "reference",
        path = "/npc.script"
        id = "controller",
        __hp = 100 -- set a go property defined in the script
    })
})
```

### Technical notes

I had to refactor the whole attachment implementation to support what outline calls "alt-outline", meaning looking up an alternative node for attaching the attachment. Previously, attachment mostly worked on types: node types had lists, e.g., `AtlasNode` had `images`. With a dynamic alternative node lookup, now individual nodes have lists. This is necessary because the node type `EmbeddedComponent` has no way of telling if it has any lists. Instead, an instance of an `EmbeddedComponent` might refer to a resource node of type `CollisionObjectNode`, and only when we find the embedded node can we say that it has `shapes`.

Related to #8504
