### PR TITLE
Added `{{build-timestamp}}` token

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/BundleHelper.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/BundleHelper.java
@@ -275,7 +275,7 @@ public class BundleHelper {
         String title = this.projectProperties.getStringValue("project", "title", "Unnamed");
         String exeName = BundleHelper.projectNameToBinaryName(title);
         this.templateProperties.put("exe-name", exeName);
-
+        this.templateProperties.put("build-timestamp", String.valueOf(System.currentTimeMillis() / 1000));
         IBundler bundler = getOrCreateBundler();
         bundler.updateManifestProperties(project, platform, this.projectProperties, this.propertiesMap, this.templateProperties);
     }


### PR DESCRIPTION
New token `{{build-timestamp}}` added, which can be used in manifests or the `index.html` template.

Fix https://github.com/defold/defold/issues/6090