### PR TITLE
Edit collections using editor scripts

### DIFF
--- a/editor/src/clj/editor/attachment.clj
+++ b/editor/src/clj/editor/attachment.clj
@@ -202,6 +202,17 @@
   (let [[_ list-definition] (require-list-definition workspace node-id list-kw evaluation-context)]
     (list-definition-reorderable? list-definition)))
 
+(defn list-node-id
+  "Returns the real node id associated with the list
+
+  The returned node id might be different from the input node id when the input
+  node id defines an alternative
+
+  Asserts that the list exists (see [[defined?]])"
+  [workspace node-id list-kw evaluation-context]
+  (let [[node-id _] (require-list-definition workspace node-id list-kw evaluation-context)]
+    node-id))
+
 (defn child-node-types
   "Returns all possible child node types for a list, or nil if there is none
 
@@ -323,8 +334,11 @@
 
 ;; SDK api
 (defn nodes-getter
-  "Node list getter that returns :nodes output of a non-override node
+  "Node list getter that returns its :nodes output
 
   This function is suitable for use as a :get parameter to [[register]]"
   [node evaluation-context]
-  (mapv gt/source-id (g/explicit-arcs-by-target (:basis evaluation-context) node :nodes)))
+  (let [basis (:basis evaluation-context)]
+    (if (g/override? basis node)
+      (g/node-value node :nodes evaluation-context)
+      (mapv gt/source-id (g/explicit-arcs-by-target basis node :nodes)))))

--- a/editor/src/clj/editor/collection.clj
+++ b/editor/src/clj/editor/collection.clj
@@ -15,12 +15,17 @@
 (ns editor.collection
   (:require [dynamo.graph :as g]
             [editor.app-view :as app-view]
+            [editor.attachment :as attachment]
             [editor.build-target :as bt]
             [editor.code.script :as script]
             [editor.collection-common :as collection-common]
             [editor.collection-string-data :as collection-string-data]
             [editor.core :as core]
             [editor.defold-project :as project]
+            [editor.editor-extensions.coerce :as coerce]
+            [editor.editor-extensions.graph :as ext-graph]
+            [editor.editor-extensions.node-types :as node-types]
+            [editor.editor-extensions.runtime :as rt]
             [editor.game-object :as game-object]
             [editor.game-object-common :as game-object-common]
             [editor.graph-util :as gu]
@@ -34,13 +39,15 @@
             [editor.resource-node :as resource-node]
             [editor.scene :as scene]
             [editor.types :as types]
+            [editor.util :as eutil]
             [editor.validation :as validation]
             [editor.workspace :as workspace]
             [internal.cache :as c]
             [internal.util :as util]
             [util.eduction :as e])
   (:import [com.dynamo.gameobject.proto GameObject$CollectionDesc GameObject$CollectionInstanceDesc GameObject$EmbeddedInstanceDesc GameObject$InstanceDesc]
-           [internal.graph.types Arc]))
+           [internal.graph.types Arc]
+           [org.apache.commons.io FilenameUtils]))
 
 (set! *warn-on-reflection* true)
 
@@ -70,7 +77,12 @@
   (inherits core/Scope)
   (property id g/Str ; Required pb field.
             (dynamic error (g/fnk [_node-id id id-counts]
-                             (or (validation/prop-error :fatal _node-id :id (partial validation/prop-id-duplicate? id-counts) id)
+                             (or (when id-counts
+                                   ;; We evaluate the _properties output before
+                                   ;; the node is connected into parent when
+                                   ;; creating nodes from editor scripts. At
+                                   ;; that point, id-counts may be nil
+                                   (validation/prop-error :fatal _node-id :id (partial validation/prop-id-duplicate? id-counts) id))
                                  (validation/prop-error :warning _node-id :id validation/prop-contains-prohibited-characters? id "Id"))))
             (dynamic read-only? (g/fnk [_node-id]
                                   (g/override? _node-id))))
@@ -130,8 +142,7 @@
   ;; coll-id: CollectionNode
   ;; child-id: CollectionInstanceNode
   (concat
-    (for [[from to] [[:_node-id :nodes]
-                     [:ddf-message :ref-coll-ddf]
+    (for [[from to] [[:ddf-message :ref-coll-ddf]
                      [:id :ids]
                      [:source-resource :referenced-collection-resources]
                      [:build-targets :sub-build-targets]
@@ -145,9 +156,31 @@
 
 (declare EmbeddedGOInstanceNode ReferencedGOInstanceNode CollectionNode)
 
-(defn- go-id->node-ids [go-id]
-  (let [collection (core/scope-of-type go-id CollectionNode)]
-    (g/node-value collection :ids)))
+(defn- tx-attach-go-referenced-go
+  ([self-id child-id]
+   (tx-attach-go-referenced-go self-id child-id true))
+  ([self-id child-id resolve-id]
+   (g/expand-ec
+     (fn tx-attach [evaluation-context]
+       (let [coll-id (core/scope-of-type (:basis evaluation-context) self-id CollectionNode)]
+         (concat
+           (when resolve-id
+             (g/update-property child-id :id id/resolve (g/node-value coll-id :ids evaluation-context)))
+           (attach-coll-ref-go coll-id child-id)
+           (child-go-go self-id child-id)))))))
+
+(defn- tx-attach-go-embedded-go
+  ([self-id child-id]
+   (tx-attach-go-embedded-go self-id child-id true))
+  ([self-id child-id resolve-id]
+   (g/expand-ec
+     (fn tx-attach [evaluation-context]
+       (let [coll-id (core/scope-of-type (:basis evaluation-context) self-id CollectionNode)]
+         (concat
+           (when resolve-id
+             (g/update-property child-id :id id/resolve (g/node-value coll-id :ids evaluation-context)))
+           (attach-coll-embedded-go coll-id child-id)
+           (child-go-go self-id child-id)))))))
 
 (g/defnk produce-go-outline [_node-id id source-outline source-resource child-outlines node-outline-extras]
   (-> {:node-id _node-id
@@ -156,19 +189,9 @@
        :icon (or (not-empty (:icon source-outline)) game-object-common/game-object-icon)
        :children (into (outline/natural-sort child-outlines) (:children source-outline))
        :child-reqs [{:node-type ReferencedGOInstanceNode
-                     :tx-attach-fn (fn [self-id child-id]
-                                     (let [coll-id (core/scope-of-type self-id CollectionNode)]
-                                       (concat
-                                         (g/update-property child-id :id id/resolve (go-id->node-ids self-id))
-                                         (attach-coll-ref-go coll-id child-id)
-                                         (child-go-go self-id child-id))))}
+                     :tx-attach-fn tx-attach-go-referenced-go}
                     {:node-type EmbeddedGOInstanceNode
-                     :tx-attach-fn (fn [self-id child-id]
-                                     (let [coll-id (core/scope-of-type self-id CollectionNode)]
-                                       (concat
-                                         (g/update-property child-id :id id/resolve (go-id->node-ids self-id))
-                                         (attach-coll-embedded-go coll-id child-id)
-                                         (child-go-go self-id child-id))))}]}
+                     :tx-attach-fn tx-attach-go-embedded-go}]}
       (merge node-outline-extras)
       (cond->
         (some-> source-resource resource/proj-path) (assoc :link source-resource :outline-reference? true))))
@@ -420,6 +443,39 @@
 
 (declare CollectionInstanceNode)
 
+(defn- tx-attach-coll-referenced-go [self-id child-id]
+  (concat
+    (attach-coll-ref-go self-id child-id)
+    (child-coll-any self-id child-id)))
+
+(defn- tx-attach-coll-embedded-go [self-id child-id]
+  (concat
+    (attach-coll-embedded-go self-id child-id)
+    (child-coll-any self-id child-id)))
+
+(defn- tx-attach-coll-coll [self-id child-id]
+  (concat
+    (attach-coll-coll self-id child-id)
+    (child-coll-any self-id child-id)))
+
+(defn- outline-coll-resolve-id [self-id child-id]
+  (g/update-property child-id :id id/resolve (g/node-value self-id :ids)))
+
+(defn- outline-tx-attach-coll-referenced-go [self-id child-id]
+  (concat
+    (outline-coll-resolve-id self-id child-id)
+    (tx-attach-coll-referenced-go self-id child-id)))
+
+(defn- outline-tx-attach-coll-embedded-go [self-id child-id]
+  (concat
+    (outline-coll-resolve-id self-id child-id)
+    (tx-attach-coll-embedded-go self-id child-id)))
+
+(defn- outline-tx-attach-coll-coll [self-id child-id]
+  (concat
+    (outline-coll-resolve-id self-id child-id)
+    (tx-attach-coll-coll self-id child-id)))
+
 (g/defnk produce-coll-outline [_node-id child-outlines]
   (let [[go-outlines coll-outlines] (let [outlines (group-by #(g/node-instance? CollectionInstanceNode (:node-id %)) child-outlines)]
                                       [(get outlines false) (get outlines true)])]
@@ -429,23 +485,11 @@
      :icon collection-common/collection-icon
      :children (into (outline/natural-sort coll-outlines) (outline/natural-sort go-outlines))
      :child-reqs [{:node-type ReferencedGOInstanceNode
-                   :tx-attach-fn (fn [self-id child-id]
-                                   (concat
-                                     (g/update-property child-id :id id/resolve (g/node-value self-id :ids))
-                                     (attach-coll-ref-go self-id child-id)
-                                     (child-coll-any self-id child-id)))}
+                   :tx-attach-fn outline-tx-attach-coll-referenced-go}
                   {:node-type EmbeddedGOInstanceNode
-                   :tx-attach-fn (fn [self-id child-id]
-                                   (concat
-                                     (g/update-property child-id :id id/resolve (g/node-value self-id :ids))
-                                     (attach-coll-embedded-go self-id child-id)
-                                     (child-coll-any self-id child-id)))}
+                   :tx-attach-fn outline-tx-attach-coll-embedded-go}
                   {:node-type CollectionInstanceNode
-                   :tx-attach-fn (fn [self-id child-id]
-                                   (concat
-                                     (g/update-property child-id :id id/resolve (g/node-value self-id :ids))
-                                     (attach-coll-coll self-id child-id)
-                                     (child-coll-any self-id child-id)))}]}))
+                   :tx-attach-fn outline-tx-attach-coll-coll}]}))
 
 (g/defnode CollectionNode
   (inherits resource-node/ResourceNode)
@@ -669,6 +713,17 @@
          (when-let [resource (first (resource-dialog/make workspace project {:ext "go" :title "Select Game Object File"}))]
            (add-referenced-game-object! collection collection resource (fn [node-ids] (app-view/select app-view node-ids)))))))
 
+(defn- connect-embedded-go [node-type resource-node go-node]
+  (gu/connect-existing-outputs node-type resource-node go-node
+    [[:_node-id :source-id]
+     [:resource :source-resource]
+     [:node-outline :source-outline]
+     [:proto-msg :proto-msg]
+     [:build-targets :source-build-targets]
+     [:scene :scene]
+     [:ddf-component-properties :ddf-component-properties]
+     [:resource-property-build-targets :resource-property-build-targets]]))
+
 (defn- make-embedded-go [self project prototype-desc id transform-properties parent select-fn]
   {:pre [(map? prototype-desc)]} ; GameObject$PrototypeDesc in map format.
   (let [graph (g/node-id->graph-id self)
@@ -682,15 +737,7 @@
         scale :scale3)
       (g/connect go-node :url resource-node :base-url)
       (project/load-embedded-resource-node project resource-node resource prototype-desc)
-      (gu/connect-existing-outputs node-type resource-node go-node
-        [[:_node-id :source-id]
-         [:resource :source-resource]
-         [:node-outline :source-outline]
-         [:proto-msg :proto-msg]
-         [:build-targets :source-build-targets]
-         [:scene :scene]
-         [:ddf-component-properties :ddf-component-properties]
-         [:resource-property-build-targets :resource-property-build-targets]])
+      (connect-embedded-go node-type resource-node go-node)
       (attach-coll-embedded-go self go-node)
       (when parent
         (if (= parent self)
@@ -845,19 +892,89 @@
            (outline/name-resource-pairs taken-ids)
            (mapv #(add-dropped-resource root-id transform-props % evaluation-context))))))
 
+(defmethod ext-graph/create-extra-nodes ::EmbeddedGOInstanceNode [evaluation-context _rt project workspace _attachment node-id]
+  (let [resource-type ((resource/resource-types-by-type-ext (:basis evaluation-context) workspace :editable) "go")
+        pb-map (game-object-common/template-pb-map workspace resource-type evaluation-context)
+        resource (resource/make-memory-resource workspace resource-type pb-map)
+        graph (g/node-id->graph-id node-id)
+        node-type (:node-type resource-type)]
+    (g/make-nodes graph [resource-node [node-type :resource resource]]
+      (project/load-embedded-resource-node project resource-node resource pb-map)
+      (connect-embedded-go node-type resource-node node-id))))
+
+(defn- gen-lua-id [base-name parent-node-id evaluation-context]
+  (let [basis (:basis evaluation-context)
+        coll-node-id (if (g/node-instance? basis CollectionNode parent-node-id)
+                       parent-node-id
+                       (core/scope-of-type basis parent-node-id CollectionNode))]
+    (rt/->lua (id/gen base-name (g/node-value coll-node-id :ids evaluation-context)))))
+
+(defmethod ext-graph/init-attachment ::EmbeddedGOInstanceNode [evaluation-context rt project parent-node-id _child-node-type child-node-id attachment]
+  (-> attachment
+      (eutil/provide-defaults
+        "id" (gen-lua-id "go" parent-node-id evaluation-context))
+      (ext-graph/attachment->set-tx-steps child-node-id rt project evaluation-context)))
+
+(defmethod ext-graph/init-attachment ::ReferencedGOInstanceNode [evaluation-context rt project parent-node-id _child-node-type child-node-id attachment]
+  (let [base-name (if-let [lua-path (attachment "path")]
+                    (FilenameUtils/getBaseName (rt/->clj rt coerce/string lua-path))
+                    "go")]
+    (-> attachment
+        (eutil/provide-defaults
+          "id" (gen-lua-id base-name parent-node-id evaluation-context))
+        (ext-graph/attachment->set-tx-steps child-node-id rt project evaluation-context))))
+
+(defmethod ext-graph/init-attachment ::CollectionInstanceNode [evaluation-context rt project parent-node-id _child-node-type child-node-id attachment]
+  (let [base-name (if-let [lua-path (attachment "path")]
+                    (FilenameUtils/getBaseName (rt/->clj rt coerce/string lua-path))
+                    "collection")]
+    (-> attachment
+        (eutil/provide-defaults
+          "id" (gen-lua-id base-name parent-node-id evaluation-context))
+        (ext-graph/attachment->set-tx-steps child-node-id rt project evaluation-context))))
+
+(defn- override? [node-id evaluation-context]
+  (g/override? (:basis evaluation-context) node-id))
+
+(defn- source-id [node-id evaluation-context]
+  (g/node-value node-id :source-id evaluation-context))
+
+(node-types/register-node-type-name! EmbeddedGOInstanceNode "go")
+(node-types/register-node-type-name! ReferencedGOInstanceNode "reference-go")
+(node-types/register-node-type-name! CollectionInstanceNode "reference-collection")
+
 (defn register-resource-types [workspace]
-  (resource-node/register-ddf-resource-type workspace
-    :ext "collection"
-    :label "Collection"
-    :node-type CollectionNode
-    :ddf-type GameObject$CollectionDesc
-    :load-fn load-collection
-    :allow-unloaded-use true
-    :dependencies-fn (collection-common/make-collection-dependencies-fn #(workspace/get-resource-type workspace :editable "go"))
-    :sanitize-fn (partial sanitize-collection workspace)
-    :string-encode-fn (partial string-encode-collection workspace)
-    :icon collection-common/collection-icon
-    :icon-class :design
-    :view-types [:scene :text]
-    :view-opts {:scene {:grid true
-                        :drop-fn handle-drop}}))
+  (concat
+    (attachment/register
+      workspace CollectionNode :children
+      :add {EmbeddedGOInstanceNode tx-attach-coll-embedded-go
+            ReferencedGOInstanceNode tx-attach-coll-referenced-go
+            CollectionInstanceNode tx-attach-coll-coll}
+      :get attachment/nodes-getter
+      :read-only? override?)
+    (attachment/register
+      workspace GameObjectInstanceNode :children
+      :add {EmbeddedGOInstanceNode #(tx-attach-go-embedded-go %1 %2 false)
+            ReferencedGOInstanceNode #(tx-attach-go-referenced-go %1 %2 false)}
+      :get attachment/nodes-getter
+      :read-only? override?)
+    (attachment/alias workspace EmbeddedGOInstanceNode :children GameObjectInstanceNode)
+    (attachment/alias workspace ReferencedGOInstanceNode :children GameObjectInstanceNode)
+    (attachment/define-alternative workspace EmbeddedGOInstanceNode source-id)
+    (attachment/define-alternative workspace ReferencedGOInstanceNode source-id)
+    (attachment/define-alternative workspace CollectionInstanceNode source-id)
+    (resource-node/register-ddf-resource-type workspace
+      :ext "collection"
+      :label "Collection"
+      :node-type CollectionNode
+      :ddf-type GameObject$CollectionDesc
+      :load-fn load-collection
+      :allow-unloaded-use true
+      :dependencies-fn (collection-common/make-collection-dependencies-fn #(workspace/get-resource-type workspace :editable "go"))
+      :sanitize-fn (partial sanitize-collection workspace)
+      :string-encode-fn (partial string-encode-collection workspace)
+      :icon collection-common/collection-icon
+      :icon-class :design
+      :view-types [:scene :text]
+      :view-opts {:scene {:grid true
+                          :drop-fn handle-drop}})))

--- a/editor/src/clj/editor/collection.clj
+++ b/editor/src/clj/editor/collection.clj
@@ -940,8 +940,8 @@
   (g/node-value node-id :source-id evaluation-context))
 
 (node-types/register-node-type-name! EmbeddedGOInstanceNode "go")
-(node-types/register-node-type-name! ReferencedGOInstanceNode "reference-go")
-(node-types/register-node-type-name! CollectionInstanceNode "reference-collection")
+(node-types/register-node-type-name! ReferencedGOInstanceNode "go-reference")
+(node-types/register-node-type-name! CollectionInstanceNode "collection-reference")
 
 (defn register-resource-types [workspace]
   (concat

--- a/editor/src/clj/editor/collection_non_editable.clj
+++ b/editor/src/clj/editor/collection_non_editable.clj
@@ -14,6 +14,7 @@
 
 (ns editor.collection-non-editable
   (:require [dynamo.graph :as g]
+            [editor.attachment :as attachment]
             [editor.build-target :as bt]
             [editor.collection-common :as collection-common]
             [editor.collection-string-data :as collection-string-data]
@@ -426,18 +427,20 @@
   (g/set-property self :collection-desc collection-desc))
 
 (defn register-resource-types [workspace]
-  (resource-node/register-ddf-resource-type workspace
-    :editable false
-    :ext "collection"
-    :label "Non-Editable Collection"
-    :node-type NonEditableCollectionNode
-    :ddf-type GameObject$CollectionDesc
-    :dependencies-fn (collection-common/make-collection-dependencies-fn #(workspace/get-resource-type workspace :non-editable "go"))
-    :sanitize-fn (partial sanitize-non-editable-collection workspace)
-    :string-encode-fn (partial string-encode-non-editable-collection workspace)
-    :load-fn load-non-editable-collection
-    :allow-unloaded-use true
-    :icon collection-common/collection-icon
-    :icon-class :design
-    :view-types [:scene :text]
-    :view-opts {:scene {:grid true}}))
+  (concat
+    (attachment/register workspace NonEditableCollectionNode :children :get (constantly []))
+    (resource-node/register-ddf-resource-type workspace
+      :editable false
+      :ext "collection"
+      :label "Non-Editable Collection"
+      :node-type NonEditableCollectionNode
+      :ddf-type GameObject$CollectionDesc
+      :dependencies-fn (collection-common/make-collection-dependencies-fn #(workspace/get-resource-type workspace :non-editable "go"))
+      :sanitize-fn (partial sanitize-non-editable-collection workspace)
+      :string-encode-fn (partial string-encode-non-editable-collection workspace)
+      :load-fn load-non-editable-collection
+      :allow-unloaded-use true
+      :icon collection-common/collection-icon
+      :icon-class :design
+      :view-types [:scene :text]
+      :view-opts {:scene {:grid true}})))

--- a/editor/src/clj/editor/editor_extensions/graph.clj
+++ b/editor/src/clj/editor/editor_extensions/graph.clj
@@ -750,8 +750,9 @@
   "Given an attachment, return a tuple of attachment+node-type
 
   The returned attachment might be modified, typically stripped of the type key"
-  (fn extract-node-type-dispatch-fn [_rt _attachment _workspace node-id list-kw evaluation-context]
-    [(g/node-type-kw (:basis evaluation-context) node-id) list-kw]))
+  (fn extract-node-type-dispatch-fn [_rt _attachment workspace node-id list-kw evaluation-context]
+    (let [node-id (attachment/list-node-id workspace node-id list-kw evaluation-context)]
+      [(g/node-type-kw (:basis evaluation-context) node-id) list-kw])))
 
 (defmethod extract-node-type :default [rt attachment workspace node-id list-kw evaluation-context]
   (let [possible-node-types (attachment/child-node-types workspace node-id list-kw evaluation-context)

--- a/editor/src/clj/editor/game_object.clj
+++ b/editor/src/clj/editor/game_object.clj
@@ -641,7 +641,7 @@
          (mapv (fn [[id resource]]
                  (add-component root-id resource id transform-props nil nil))))))
 
-(def ^:private ext-referenced-component-type "reference")
+(def ^:private ext-referenced-component-type "component-reference")
 (def ^:private constantly-ext-referenced-component-type (constantly ext-referenced-component-type))
 
 (ext-graph/register-property-getter!

--- a/editor/src/clj/editor/game_object.clj
+++ b/editor/src/clj/editor/game_object.clj
@@ -728,7 +728,8 @@
       workspace GameObjectNode :components
       :add {EmbeddedComponent attach-embedded-component
             ReferencedComponent attach-referenced-component}
-      :get attachment/nodes-getter)
+      :get attachment/nodes-getter
+      :read-only? #(g/override? (:basis %2) %1))
     (attachment/define-alternative workspace EmbeddedComponent embedded-component-attachment-alternative)
     (resource-node/register-ddf-resource-type workspace
       :ext "go"

--- a/editor/src/clj/editor/game_object_non_editable.clj
+++ b/editor/src/clj/editor/game_object_non_editable.clj
@@ -14,6 +14,7 @@
 
 (ns editor.game-object-non-editable
   (:require [dynamo.graph :as g]
+            [editor.attachment :as attachment]
             [editor.build-target :as bt]
             [editor.collection-string-data :as collection-string-data]
             [editor.defold-project :as project]
@@ -374,18 +375,20 @@
   (g/set-property self :prototype-desc prototype-desc))
 
 (defn register-resource-types [workspace]
-  (resource-node/register-ddf-resource-type workspace
-    :editable false
-    :ext "go"
-    :label "Non-Editable Game Object"
-    :node-type NonEditableGameObjectNode
-    :ddf-type GameObject$PrototypeDesc
-    :dependencies-fn (game-object-common/make-game-object-dependencies-fn #(workspace/get-resource-type-map workspace :non-editable))
-    :sanitize-fn (partial sanitize-non-editable-game-object workspace)
-    :string-encode-fn (partial string-encode-non-editable-game-object workspace)
-    :load-fn load-non-editable-game-object
-    :allow-unloaded-use true
-    :icon game-object-common/game-object-icon
-    :icon-class :design
-    :view-types [:scene :text]
-    :view-opts {:scene {:grid true}}))
+  (concat
+    (attachment/register workspace NonEditableGameObjectNode :components :get (constantly []))
+    (resource-node/register-ddf-resource-type workspace
+      :editable false
+      :ext "go"
+      :label "Non-Editable Game Object"
+      :node-type NonEditableGameObjectNode
+      :ddf-type GameObject$PrototypeDesc
+      :dependencies-fn (game-object-common/make-game-object-dependencies-fn #(workspace/get-resource-type-map workspace :non-editable))
+      :sanitize-fn (partial sanitize-non-editable-game-object workspace)
+      :string-encode-fn (partial string-encode-non-editable-game-object workspace)
+      :load-fn load-non-editable-game-object
+      :allow-unloaded-use true
+      :icon game-object-common/game-object-icon
+      :icon-class :design
+      :view-types [:scene :text]
+      :view-opts {:scene {:grid true}})))

--- a/editor/src/clj/editor/particlefx.clj
+++ b/editor/src/clj/editor/particlefx.clj
@@ -916,8 +916,7 @@
                                                       :icon emitter-icon
                                                       :children (outline/natural-sort child-outlines)
                                                       :child-reqs [{:node-type ModifierNode
-                                                                    :tx-attach-fn (fn [self-id child-id]
-                                                                                    (attach-modifier self-id child-id true))}]}))
+                                                                    :tx-attach-fn attach-modifier}]}))
   (output aabb AABB produce-emitter-aabb)
   (output visibility-aabb AABB produce-emitter-visibility-aabb)
   (output emitter-sim-data g/Any :cached
@@ -1077,8 +1076,7 @@
                              :tx-attach-fn (fn [self-id child-id]
                                              (attach-emitter self-id child-id true))}
                             {:node-type ModifierNode
-                             :tx-attach-fn (fn [self-id child-id]
-                                             (attach-modifier self-id child-id true))}]})))
+                             :tx-attach-fn attach-modifier}]})))
   (output fetch-anim-fn Runnable :cached (g/fnk [emitter-sim-data] (fn [index] (get emitter-sim-data index)))))
 
 (defn- make-modifier

--- a/editor/test/integration/editor_extensions_test.clj
+++ b/editor/test/integration/editor_extensions_test.clj
@@ -1584,6 +1584,138 @@ Collision object components have shapes property:
 Transaction: clear go components
 After transaction (clear go components):
   components: 0
+Collection initial state
+  children: 0 (editable)
+Transaction: add gos and collections
+After transaction (add gos and collections):
+  children: 5 (editable)
+  - id: go
+    url: /go
+    type: go
+    position: {0, 0, 0}
+    rotation: {0, 0, 0}
+    scale: {0.5, 0.5, 0.5}
+    components: 0
+    children: 4 (editable)
+    - id: go1
+      url: /go1
+      type: go
+      position: {0, 0, 0}
+      rotation: {0, 0, 0}
+      scale: {1, 1, 1}
+      components: 0
+      children: 0 (editable)
+    - id: ref
+      url: /ref
+      type: reference-go
+      path: /ref.go
+      position: {3.14, 3.14, 0}
+      rotation: {0, 0, 0}
+      scale: {1, 1, 1}
+      components: 0
+      children: 0 (editable)
+    - id: go2
+      url: /go2
+      type: go
+      position: {0, 0, 0}
+      rotation: {0, 0, 0}
+      scale: {1, 1, 1}
+      components: 0
+      children: 1 (editable)
+      - id: char
+        url: /char
+        type: go
+        position: {0, 0, 0}
+        rotation: {0, 0, 0}
+        scale: {1, 1, 1}
+        components: 3
+        - type: sprite
+          id: sprite
+          position: {0.5, 0.5, 0.5}
+          rotation: {0, 0, 0}
+          scale: {1, 1, 1}
+        - type: collisionobject
+          id: collisionobject
+          shapes: 1
+          - id: box
+            type: shape-type-box
+            dimensions: 2.5 2.5 2.5
+        - type: reference
+          id: test
+        children: 0 (editable)
+    - id: empty-ref
+      url: /empty-ref
+      type: reference-go
+      path: -
+      position: {0, 0, 0}
+      rotation: {0, 0, 0}
+      scale: {1, 1, 1}
+      children: 0 (editable)
+  - id: empty-collection
+    url: /empty-collection
+    type: reference-collection
+    path: -
+    position: {0, 0, 0}
+    rotation: {0, 0, 0}
+    scale: {1, 1, 1}
+  - id: ref1
+    url: /ref1
+    type: reference-collection
+    path: /ref.collection
+    position: {0, 0, 0}
+    rotation: {0, 0, 0}
+    scale: {1, 1, 1}
+    children: 1 (readonly)
+    - id: go
+      url: /ref1/go
+      type: go
+      position: {0, 0, 0}
+      rotation: {0, 0, 0}
+      scale: {1, 1, 1}
+      components: 1
+      - type: sprite
+        id: sprite
+        position: {0, 0, 0}
+        rotation: {0, 0, 0}
+        scale: {1, 1, 1}
+      children: 1 (readonly)
+      - id: ref
+        url: /ref1/ref
+        type: reference-go
+        path: /ref.go
+        position: {0, 0, 0}
+        rotation: {0, 0, 0}
+        scale: {1, 1, 1}
+        components: 0
+        children: 0 (readonly)
+  - id: readonly
+    url: /readonly
+    type: reference-collection
+    path: /readonly/readonly.collection
+    position: {0, 0, 0}
+    rotation: {0, 0, 0}
+    scale: {1, 1, 1}
+    children: 0 (readonly)
+  - id: readonly1
+    url: /readonly1
+    type: reference-go
+    path: /readonly/readonly.go
+    position: {0, 0, 0}
+    rotation: {0, 0, 0}
+    scale: {1, 1, 1}
+    components: 0
+    children: 1 (editable)
+    - id: allowed-child-of-readonly-go
+      url: /allowed-child-of-readonly-go
+      type: go
+      position: {0, 0, 0}
+      rotation: {0, 0, 0}
+      scale: {1, 1, 1}
+      components: 0
+      children: 0 (editable)
+Transaction: clear collection
+After transaction (clear collection)
+  children: 0 (editable)
 ")
 
 (deftest attachment-properties-test

--- a/editor/test/integration/editor_extensions_test.clj
+++ b/editor/test/integration/editor_extensions_test.clj
@@ -1567,11 +1567,11 @@ After transaction (add go components):
     position: {0, 0, 0}
     rotation: {0, 0, 0}
     scale: {1, 1, 1}
-  - type: reference
+  - type: component-reference
     id: test
-  - type: reference
+  - type: component-reference
     id: collisionobject-referenced
-  - type: reference
+  - type: component-reference
     id: referenced-tilemap
     position: {0, 0, 0}
     rotation: {0, 0, 0}
@@ -1607,7 +1607,7 @@ After transaction (add gos and collections):
       children: 0 (editable)
     - id: ref
       url: /ref
-      type: reference-go
+      type: go-reference
       path: /ref.go
       position: {3.14, 3.14, 0}
       rotation: {0, 0, 0}
@@ -1640,12 +1640,12 @@ After transaction (add gos and collections):
           - id: box
             type: shape-type-box
             dimensions: 2.5 2.5 2.5
-        - type: reference
+        - type: component-reference
           id: test
         children: 0 (editable)
     - id: empty-ref
       url: /empty-ref
-      type: reference-go
+      type: go-reference
       path: -
       position: {0, 0, 0}
       rotation: {0, 0, 0}
@@ -1653,14 +1653,14 @@ After transaction (add gos and collections):
       children: 0 (editable)
   - id: empty-collection
     url: /empty-collection
-    type: reference-collection
+    type: collection-reference
     path: -
     position: {0, 0, 0}
     rotation: {0, 0, 0}
     scale: {1, 1, 1}
   - id: ref1
     url: /ref1
-    type: reference-collection
+    type: collection-reference
     path: /ref.collection
     position: {0, 0, 0}
     rotation: {0, 0, 0}
@@ -1681,7 +1681,7 @@ After transaction (add gos and collections):
       children: 1 (readonly)
       - id: ref
         url: /ref1/ref
-        type: reference-go
+        type: go-reference
         path: /ref.go
         position: {0, 0, 0}
         rotation: {0, 0, 0}
@@ -1690,7 +1690,7 @@ After transaction (add gos and collections):
         children: 0 (readonly)
   - id: readonly
     url: /readonly
-    type: reference-collection
+    type: collection-reference
     path: /readonly/readonly.collection
     position: {0, 0, 0}
     rotation: {0, 0, 0}
@@ -1698,7 +1698,7 @@ After transaction (add gos and collections):
     children: 0 (readonly)
   - id: readonly1
     url: /readonly1
-    type: reference-go
+    type: go-reference
     path: /readonly/readonly.go
     position: {0, 0, 0}
     rotation: {0, 0, 0}
@@ -1713,6 +1713,163 @@ After transaction (add gos and collections):
       scale: {1, 1, 1}
       components: 0
       children: 0 (editable)
+Transaction: edit already existing collection elements
+After transaction (edit already existing collection elements):
+  children: 5 (editable)
+  - id: go
+    url: /go
+    type: go
+    position: {0, 0, 0}
+    rotation: {0, 0, 0}
+    scale: {0.5, 0.5, 0.5}
+    components: 0
+    children: 5 (editable)
+    - id: go1
+      url: /go1
+      type: go
+      position: {0, 0, 0}
+      rotation: {0, 0, 0}
+      scale: {1, 1, 1}
+      components: 0
+      children: 0 (editable)
+    - id: ref
+      url: /ref
+      type: go-reference
+      path: /ref.go
+      position: {3.14, 3.14, 0}
+      rotation: {0, 0, 0}
+      scale: {1, 1, 1}
+      components: 0
+      children: 1 (editable)
+      - id: new-referenced-go-child
+        url: /new-referenced-go-child
+        type: go
+        position: {0, 0, 0}
+        rotation: {0, 0, 0}
+        scale: {1, 1, 1}
+        components: 0
+        children: 0 (editable)
+    - id: go2
+      url: /go2
+      type: go
+      position: {0, 0, 0}
+      rotation: {0, 0, 0}
+      scale: {1, 1, 1}
+      components: 0
+      children: 1 (editable)
+      - id: char
+        url: /char
+        type: go
+        position: {0, 0, 0}
+        rotation: {0, 0, 0}
+        scale: {1, 1, 1}
+        components: 3
+        - type: sprite
+          id: sprite
+          position: {0.5, 0.5, 0.5}
+          rotation: {0, 0, 0}
+          scale: {1, 1, 1}
+        - type: collisionobject
+          id: collisionobject
+          shapes: 1
+          - id: box
+            type: shape-type-box
+            dimensions: 2.5 2.5 2.5
+        - type: component-reference
+          id: test
+        children: 0 (editable)
+    - id: empty-ref
+      url: /empty-ref
+      type: go-reference
+      path: -
+      position: {0, 0, 0}
+      rotation: {0, 0, 0}
+      scale: {1, 1, 1}
+      children: 0 (editable)
+    - id: new-embedded-go-child
+      url: /new-embedded-go-child
+      type: go
+      position: {0, 0, 0}
+      rotation: {0, 0, 0}
+      scale: {1, 1, 1}
+      components: 0
+      children: 0 (editable)
+  - id: empty-collection
+    url: /empty-collection
+    type: collection-reference
+    path: -
+    position: {0, 0, 0}
+    rotation: {0, 0, 0}
+    scale: {1, 1, 1}
+  - id: ref1
+    url: /ref1
+    type: collection-reference
+    path: /ref.collection
+    position: {0, 0, 0}
+    rotation: {0, 0, 0}
+    scale: {1, 1, 1}
+    children: 1 (readonly)
+    - id: go
+      url: /ref1/go
+      type: go
+      position: {0, 0, 0}
+      rotation: {0, 0, 0}
+      scale: {1, 1, 1}
+      components: 1
+      - type: sprite
+        id: sprite
+        position: {0, 0, 0}
+        rotation: {0, 0, 0}
+        scale: {1, 1, 1}
+      children: 1 (readonly)
+      - id: ref
+        url: /ref1/ref
+        type: go-reference
+        path: /ref.go
+        position: {0, 0, 0}
+        rotation: {0, 0, 0}
+        scale: {1, 1, 1}
+        components: 0
+        children: 0 (readonly)
+  - id: readonly
+    url: /readonly
+    type: collection-reference
+    path: /readonly/readonly.collection
+    position: {0, 0, 0}
+    rotation: {0, 0, 0}
+    scale: {1, 1, 1}
+    children: 0 (readonly)
+  - id: readonly1
+    url: /readonly1
+    type: go-reference
+    path: /readonly/readonly.go
+    position: {0, 0, 0}
+    rotation: {0, 0, 0}
+    scale: {1, 1, 1}
+    components: 0
+    children: 2 (editable)
+    - id: allowed-child-of-readonly-go
+      url: /allowed-child-of-readonly-go
+      type: go
+      position: {0, 0, 0}
+      rotation: {0, 0, 0}
+      scale: {1, 1, 1}
+      components: 0
+      children: 0 (editable)
+    - id: new-readonly-referenced-go-child
+      url: /new-readonly-referenced-go-child
+      type: go
+      position: {0, 0, 0}
+      rotation: {0, 0, 0}
+      scale: {1, 1, 1}
+      components: 0
+      children: 0 (editable)
+Expected collection errors:
+  add child to referenced collection => \"children\" is read-only
+  remove child of referenced collection => \"children\" is read-only
+  add child to go in referenced collection => \"children\" is read-only
+  clear children of a go in referenced collection => \"children\" is read-only
+  add child to readonly referenced collection => \"children\" is read-only
 Transaction: clear collection
 After transaction (clear collection)
   children: 0 (editable)

--- a/editor/test/resources/editor_extensions/transact_attachment_project/project.shared_editor_settings
+++ b/editor/test/resources/editor_extensions/transact_attachment_project/project.shared_editor_settings
@@ -1,0 +1,3 @@
+[performance]
+non_editable_directories#0 = /readonly
+

--- a/editor/test/resources/editor_extensions/transact_attachment_project/readonly/readonly.collection
+++ b/editor/test/resources/editor_extensions/transact_attachment_project/readonly/readonly.collection
@@ -1,0 +1,26 @@
+name: "readonly"
+instances {
+  id: "readonly"
+  prototype: "/readonly/readonly.go"
+}
+collection_instances {
+  id: "ref"
+  collection: "/ref.collection"
+  position {
+    x: 13.0
+    y: 24.0
+  }
+}
+scale_along_z: 0
+embedded_instances {
+  id: "readonly_go"
+  children: "readonly"
+  data: "embedded_components {\n"
+  "  id: \"readonly_sprite\"\n"
+  "  type: \"sprite\"\n"
+  "  data: \"default_animation: \\\"\\\"\\n"
+  "material: \\\"/builtins/materials/sprite.material\\\"\\n"
+  "\"\n"
+  "}\n"
+  ""
+}

--- a/editor/test/resources/editor_extensions/transact_attachment_project/readonly/readonly.go
+++ b/editor/test/resources/editor_extensions/transact_attachment_project/readonly/readonly.go
@@ -1,0 +1,7 @@
+embedded_components {
+  id: "readonly_sprite"
+  type: "sprite"
+  data: "default_animation: \"\"\n"
+  "material: \"/builtins/materials/sprite.material\"\n"
+  ""
+}

--- a/editor/test/resources/editor_extensions/transact_attachment_project/ref.collection
+++ b/editor/test/resources/editor_extensions/transact_attachment_project/ref.collection
@@ -1,0 +1,22 @@
+name: "ref"
+instances {
+  id: "ref"
+  prototype: "/ref.go"
+}
+scale_along_z: 0
+embedded_instances {
+  id: "go"
+  children: "ref"
+  data: "embedded_components {\n"
+  "  id: \"sprite\"\n"
+  "  type: \"sprite\"\n"
+  "  data: \"default_animation: \\\"anim\\\"\\n"
+  "material: \\\"/builtins/materials/sprite.material\\\"\\n"
+  "textures {\\n"
+  "  sampler: \\\"texture_sampler\\\"\\n"
+  "  texture: \\\"/builtins/graphics/particle_blob.tilesource\\\"\\n"
+  "}\\n"
+  "\"\n"
+  "}\n"
+  ""
+}

--- a/editor/test/resources/editor_extensions/transact_attachment_project/test.collection
+++ b/editor/test/resources/editor_extensions/transact_attachment_project/test.collection
@@ -1,0 +1,2 @@
+name: "test"
+scale_along_z: 0

--- a/editor/test/resources/editor_extensions/transact_attachment_project/test.editor_script
+++ b/editor/test/resources/editor_extensions/transact_attachment_project/test.editor_script
@@ -182,23 +182,53 @@ end
 
 local transform_props = {"position", "rotation", "scale"}
 
-local function print_go(go)
+local function print_go(go, indent)
+    indent = indent or "  "
     local components = editor.get(go, "components")
-    print(("  components: %s"):format(#components))
+    print(("%scomponents: %s"):format(indent, #components))
     for i = 1, #components do
         local component = components[i]
         local type = editor.get(component, "type")
-        print(("  - type: %s"):format(type))
-        print(("    id: %s"):format(editor.get(component, "id")))
+        print(("%s- type: %s"):format(indent, type))
+        print(("%s  id: %s"):format(indent, editor.get(component, "id")))
         for j = 1, #transform_props do
             local p = transform_props[j]
             if editor.can_get(component, p) then
-                local position = editor.get(component, p)
-                print(("    %s: {%s, %s, %s}"):format(p, position[1], position[2], position[3]))
+                local v = editor.get(component, p)
+                print(("%s  %s: {%s, %s, %s}"):format(indent, p, v[1], v[2], v[3]))
             end
         end
         if type == "collisionobject" then
-            print_collision_object(component, "    ")
+            print_collision_object(component, indent .. "  ")
+        end
+    end
+end
+
+local function print_coll(coll, indent)
+    indent = indent or "  "
+    local children = editor.get(coll, "children")
+    local editable = editor.can_add(coll, "children")
+    print(("%schildren: %s (%s)"):format(indent, #children, editable and "editable" or "readonly"))
+    for i = 1, #children do
+        local child = children[i]
+        local type = editor.get(child, "type")
+        print(("%s- id: %s"):format(indent, editor.get(child, "id")))
+        print(("%s  url: %s"):format(indent, editor.get(child, "url")))
+        print(("%s  type: %s"):format(indent, type))
+        if type == "reference-go" or type == "reference-collection" then
+            print(("%s  path: %s"):format(indent, editor.get(child, "path") or "-"))
+        end
+        for j = 1, #transform_props do
+            local p = transform_props[j]
+            local v = editor.get(child, p)
+            print(("%s  %s: {%s, %s, %s}"):format(indent, p, v[1], v[2], v[3]))
+        end
+        local child_indent = indent .. "  "
+        if editor.can_get(child, "components") then
+            print_go(child, child_indent)
+        end
+        if editor.can_get(child, "children") then
+            print_coll(child, child_indent)
         end
     end
 end
@@ -631,6 +661,93 @@ function M.get_commands()
 
                 print("After transaction (clear go components):")
                 print_go(go)
+
+                print("Collection initial state")
+                local coll = "/test.collection"
+                print_coll(coll)
+
+                print("Transaction: add gos and collections")
+                editor.transact({
+                    editor.tx.add(coll, "children", {
+                        type = "go",
+                        scale = {0.5, 0.5, 0.5},
+                        children = {
+                            {
+                                type = "go"
+                            },
+                            {
+                                type = "reference-go",
+                                path = "/ref.go",
+                                position = {3.14, 3.14, 0}
+                            },
+                            {
+                                type = "go",
+                                children = {
+                                    {
+                                        type = "go",
+                                        id = "char",
+                                        components = {
+                                            {
+                                                type = "sprite",
+                                                position = {0.5, 0.5, 0.5}
+                                            },
+                                            {
+                                                type = "collisionobject",
+                                                shapes = {
+                                                    {
+                                                        id = "box",
+                                                        type = "shape-type-box",
+                                                        dimensions = {2.5, 2.5, 2.5},
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                type = "reference",
+                                                path = "/test.script",
+                                                __num = 37
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                type = "reference-go",
+                                id = "empty-ref"
+                            }
+                        }
+                    }),
+                    editor.tx.add(coll, "children", {
+                        type = "reference-collection",
+                        id = "empty-collection"
+                    }),
+                    editor.tx.add(coll, "children", {
+                        type = "reference-collection",
+                        path = "/ref.collection"
+                    }),
+                    editor.tx.add(coll, "children", {
+                        type = "reference-collection",
+                        path = "/readonly/readonly.collection"
+                    }),
+                    editor.tx.add(coll, "children", {
+                        type = "reference-go",
+                        path = "/readonly/readonly.go",
+                        children = {
+                            {
+                                type = "go",
+                                id = "allowed-child-of-readonly-go"
+                            }
+                        }
+                    })
+                })
+
+                print("After transaction (add gos and collections):")
+                print_coll(coll)
+
+                print("Transaction: clear collection")
+                editor.transact({ editor.tx.clear(coll, "children") })
+
+                print("After transaction (clear collection)")
+                print_coll(coll)
             end
         })
     }

--- a/editor/test/resources/editor_extensions/transact_attachment_project/test.editor_script
+++ b/editor/test/resources/editor_extensions/transact_attachment_project/test.editor_script
@@ -215,7 +215,7 @@ local function print_coll(coll, indent)
         print(("%s- id: %s"):format(indent, editor.get(child, "id")))
         print(("%s  url: %s"):format(indent, editor.get(child, "url")))
         print(("%s  type: %s"):format(indent, type))
-        if type == "reference-go" or type == "reference-collection" then
+        if type == "go-reference" or type == "collection-reference" then
             print(("%s  path: %s"):format(indent, editor.get(child, "path") or "-"))
         end
         for j = 1, #transform_props do
@@ -614,18 +614,18 @@ function M.get_commands()
                         id = "blob"
                     }),
                     editor.tx.add(go, "components", { 
-                        type = "reference",
+                        type = "component-reference",
                         path = "/test.script",
                         __num = 42
                     }),
                     editor.tx.add(go, "components", {
                         id = "collisionobject-referenced",
-                        type = "reference",
+                        type = "component-reference",
                         path = "/test.collisionobject"
                     }),
                     editor.tx.add(go, "components", {
                         id = "referenced-tilemap",
-                        type = "reference",
+                        type = "component-reference",
                         path = "/test.tilemap"
                     })
                 })
@@ -676,7 +676,7 @@ function M.get_commands()
                                 type = "go"
                             },
                             {
-                                type = "reference-go",
+                                type = "go-reference",
                                 path = "/ref.go",
                                 position = {3.14, 3.14, 0}
                             },
@@ -702,7 +702,7 @@ function M.get_commands()
                                                 }
                                             },
                                             {
-                                                type = "reference",
+                                                type = "component-reference",
                                                 path = "/test.script",
                                                 __num = 37
                                             }
@@ -711,25 +711,25 @@ function M.get_commands()
                                 }
                             },
                             {
-                                type = "reference-go",
+                                type = "go-reference",
                                 id = "empty-ref"
                             }
                         }
                     }),
                     editor.tx.add(coll, "children", {
-                        type = "reference-collection",
+                        type = "collection-reference",
                         id = "empty-collection"
                     }),
                     editor.tx.add(coll, "children", {
-                        type = "reference-collection",
+                        type = "collection-reference",
                         path = "/ref.collection"
                     }),
                     editor.tx.add(coll, "children", {
-                        type = "reference-collection",
+                        type = "collection-reference",
                         path = "/readonly/readonly.collection"
                     }),
                     editor.tx.add(coll, "children", {
-                        type = "reference-go",
+                        type = "go-reference",
                         path = "/readonly/readonly.go",
                         children = {
                             {
@@ -742,6 +742,60 @@ function M.get_commands()
 
                 print("After transaction (add gos and collections):")
                 print_coll(coll)
+
+                local embedded_go
+                local referenced_go
+                local referenced_coll
+                local referenced_coll_go
+                local readonly_referenced_go
+                local readonly_referenced_coll
+                local children = editor.get(coll, "children")
+                for i = 1, #children do
+                    local child = children[i]
+                    if editor.get(child, "type") == "go" then
+                        embedded_go = child
+                        local go_children = editor.get(child, "children")
+                        for j = 1, #go_children do
+                            local go_child = go_children[j]
+                            if editor.can_get(go_child, "path") and editor.get(go_child, "path") == "/ref.go" then
+                                referenced_go = go_child
+                            end
+                        end
+                    elseif editor.can_get(child, "path") then
+                        local path = editor.get(child, "path")
+                        if path == "/ref.collection" then
+                            referenced_coll = child
+                            referenced_coll_go = editor.get(referenced_coll, "children")[1]
+                        elseif path == "/readonly/readonly.collection" then
+                            readonly_referenced_coll = child
+                        elseif path == "/readonly/readonly.go" then
+                            readonly_referenced_go = child
+                        end
+                    end
+                end
+                assert(embedded_go, "embedded go not found")
+                assert(referenced_go, "referenced go not found")
+                assert(referenced_coll, "referenced collection not found")
+                assert(referenced_coll_go, "referenced collection's go not found")
+                assert(readonly_referenced_coll, "readonly referenced collection not found")
+                assert(readonly_referenced_go, "readonly referenced go not found")
+
+                print("Transaction: edit already existing collection elements")
+                editor.transact({
+                    editor.tx.add(embedded_go, "children", {type = "go", id = "new-embedded-go-child"}),
+                    editor.tx.add(referenced_go, "children", {type = "go", id = "new-referenced-go-child"}),
+                    editor.tx.add(readonly_referenced_go, "children", {type = "go", id = "new-readonly-referenced-go-child"}),
+                })
+
+                print("After transaction (edit already existing collection elements):")
+                print_coll(coll)
+
+                print("Expected collection errors:")
+                expect_error("add child to referenced collection", editor.tx.add, referenced_coll, "children", {type = "go"})
+                expect_error("remove child of referenced collection", editor.tx.remove, referenced_coll, "children", referenced_coll_go)
+                expect_error("add child to go in referenced collection", editor.tx.add, referenced_coll_go, "children", {type = "go"})
+                expect_error("clear children of a go in referenced collection", editor.tx.clear, referenced_coll_go, "children")
+                expect_error("add child to readonly referenced collection", editor.tx.add, readonly_referenced_coll, "children", {type = "go"})
 
                 print("Transaction: clear collection")
                 editor.transact({ editor.tx.clear(coll, "children") })


### PR DESCRIPTION
Now it's possible to edit collections using editor scripts. You can add game objects (embedded or referenced) and collections (referenced). For example:
```lua
local coll = "/char.collection"
editor.transact({
    editor.tx.add(coll, "children", {
        -- embbedded game object
        type = "go",
        id = "root",
        children = {
            {
                -- referenced game object
                type = "go-reference",
                path = "/char-view.go"
                id = "view"
            },
            {
                -- referenced collection
                type = "collection-reference",
                path = "/body-attachments.collection"
                id = "attachments"
            }
        },
        -- embedded gos can also have components
        components = {
            {
                type = "collisionobject",
                id = "collision",
                shapes = {
                    {type = "shape-type-box", dimensions = {2.5, 2.5, 2.5}}
                }
            },
            {
                type = "component-reference",
                id = "controller",
                path = "/char.script",
                __hp = 100 -- set a go property defined in the script
            }
        }
    })
})
```

Related to #8504
