### PR TITLE
Moved GetAbsoluteIdentifier to dmSDK

### DIFF
--- a/engine/gameobject/src/dmsdk/gameobject/gameobject.h
+++ b/engine/gameobject/src/dmsdk/gameobject/gameobject.h
@@ -626,12 +626,14 @@ namespace dmGameObject
     Result SetIdentifier(HCollection collection, HInstance instance, dmhash_t identifier);
 
     /*#
-     * Get absolute identifier relative to #instance. The returned identifier is the
-     * representation of the qualified name, i.e. the path from root-collection to the sub-collection which the #instance belongs to.
-     * Example: if #instance is part of a sub-collection in the root-collection named "sub" and id == "a" the returned identifier represents the path "sub.a"
+     * Get absolute identifier relative to instance. The returned identifier is the
+     * representation of the qualified name, i.e. the path from root-collection to
+     * the sub-collection which the #instance belongs to.
+     * Example: if instance is part of a sub-collection in the root-collection
+     * named "sub" and id == "a" the returned identifier represents the path "sub.a"
      * @name GetAbsoluteIdentifier
      * @param instance [type:dmGameObject::HInstance] Gameobject instance to get absolute identifier to
-     * @param identifier [type:char*] Identifier relative to #instance
+     * @param identifier [type:const char*] Identifier relative to instance
      * @return [type:dmhash_t] Absolute identifier.
      */
     dmhash_t GetAbsoluteIdentifier(HInstance instance, const char* identifier);

--- a/engine/gameobject/src/dmsdk/gameobject/gameobject.h
+++ b/engine/gameobject/src/dmsdk/gameobject/gameobject.h
@@ -626,6 +626,17 @@ namespace dmGameObject
     Result SetIdentifier(HCollection collection, HInstance instance, dmhash_t identifier);
 
     /*#
+     * Get absolute identifier relative to #instance. The returned identifier is the
+     * representation of the qualified name, i.e. the path from root-collection to the sub-collection which the #instance belongs to.
+     * Example: if #instance is part of a sub-collection in the root-collection named "sub" and id == "a" the returned identifier represents the path "sub.a"
+     * @name GetAbsoluteIdentifier
+     * @param instance [type:dmGameObject::HInstance] Gameobject instance to get absolute identifier to
+     * @param identifier [type:char*] Identifier relative to #instance
+     * @return [type:dmhash_t] Absolute identifier.
+     */
+    dmhash_t GetAbsoluteIdentifier(HInstance instance, const char* identifier);
+
+    /*#
      * Get instance from identifier
      * @name GetInstanceFromIdentifier
      * @param collection [type: dmGameObject::HCollection] Collection

--- a/engine/gameobject/src/dmsdk/gameobject/gameobject.h
+++ b/engine/gameobject/src/dmsdk/gameobject/gameobject.h
@@ -628,8 +628,8 @@ namespace dmGameObject
     /*#
      * Get absolute identifier relative to instance. The returned identifier is the
      * representation of the qualified name, i.e. the path from root-collection to
-     * the sub-collection which the #instance belongs to.
-     * Example: if instance is part of a sub-collection in the root-collection
+     * the sub-collection which the instance belongs to.
+     * Example: if the instance is part of a sub-collection in the root-collection
      * named "sub" and id == "a" the returned identifier represents the path "sub.a"
      * @name GetAbsoluteIdentifier
      * @param instance [type:dmGameObject::HInstance] Gameobject instance to get absolute identifier to

--- a/engine/gameobject/src/gameobject/gameobject.cpp
+++ b/engine/gameobject/src/gameobject/gameobject.cpp
@@ -1460,7 +1460,7 @@ namespace dmGameObject
 
                 for (uint32_t j = 0; j < instance_desc.m_Children.m_Count; ++j)
                 {
-                    dmhash_t child_id = dmGameObject::GetAbsoluteIdentifier(parent, instance_desc.m_Children[j], strlen(instance_desc.m_Children[j]));
+                    dmhash_t child_id = dmGameObject::GetAbsoluteIdentifier(parent, instance_desc.m_Children[j]);
 
                     // It is not always the case that 'parent' has had the path prefix prepended to its id, so it is necessary
                     // to see if a remapping exists.
@@ -2094,19 +2094,19 @@ namespace dmGameObject
         return instance->m_Identifier;
     }
 
-    dmhash_t GetAbsoluteIdentifier(HInstance instance, const char* id, uint32_t id_size)
+    dmhash_t GetAbsoluteIdentifier(HInstance instance, const char* identifier)
     {
         // check for global id (/foo/bar)
-        if (*id == *ID_SEPARATOR)
+        if (*identifier == *ID_SEPARATOR)
         {
-            return dmHashBuffer64(id, id_size);
+            return dmHashBuffer64(identifier, strlen(identifier));
         }
         else
         {
             // Make a copy of the state.
             HashState64 tmp_state;
             dmHashClone64(&tmp_state, &instance->m_CollectionPathHashState, false);
-            dmHashUpdateBuffer64(&tmp_state, id, id_size);
+            dmHashUpdateBuffer64(&tmp_state, identifier, strlen(identifier));
             return dmHashFinal64(&tmp_state);
         }
     }

--- a/engine/gameobject/src/gameobject/gameobject.h
+++ b/engine/gameobject/src/gameobject/gameobject.h
@@ -173,17 +173,6 @@ namespace dmGameObject
     Result SetIdentifier(HCollection collection, HInstance instance, const char* identifier);
 
     /**
-     * Get absolute identifier relative to #instance. The returned identifier is the
-     * representation of the qualified name, i.e. the path from root-collection to the sub-collection which the #instance belongs to.
-     * Example: if #instance is part of a sub-collection in the root-collection named "sub" and id == "a" the returned identifier represents the path "sub.a"
-     * @param instance Instance to absolute identifier to
-     * @param id Identifier relative to #instance
-     * @param id_size Lenght of the id
-     * @return Absolute identifier
-     */
-    dmhash_t GetAbsoluteIdentifier(HInstance instance, const char* id, uint32_t id_size);
-
-    /**
      * Get component index from component identifier. This function has complexity O(n), where n is the number of components of the instance.
      * @param instance Instance
      * @param component_id Component id

--- a/engine/gameobject/src/gameobject/gameobject_script.cpp
+++ b/engine/gameobject/src/gameobject/gameobject_script.cpp
@@ -287,11 +287,11 @@ namespace dmGameObject
         out_url->m_Fragment = instance->m_Prototype->m_Components[i->m_ComponentIndex].m_Id;
     }
 
-    static dmhash_t ScriptInstanceResolvePathCB(uintptr_t resolve_user_data, const char* path, uint32_t path_size) {
+    static dmhash_t ScriptInstanceResolvePathCB(uintptr_t resolve_user_data, const char* path) {
         ScriptInstance* i = (ScriptInstance*)resolve_user_data;
         if (path != 0x0 && *path != 0)
         {
-            return GetAbsoluteIdentifier(i->m_Instance, path, strlen(path));
+            return GetAbsoluteIdentifier(i->m_Instance, path);
         }
         else
         {
@@ -325,7 +325,7 @@ namespace dmGameObject
 
         if (path != 0x0 && *path != 0)
         {
-            dmScript::PushHash(L, GetAbsoluteIdentifier(i->m_Instance, path, strlen(path)));
+            dmScript::PushHash(L, GetAbsoluteIdentifier(i->m_Instance, path));
         }
         else
         {
@@ -1379,7 +1379,7 @@ namespace dmGameObject
         if (lua_gettop(L) > 0)
         {
             const char* ident = luaL_checkstring(L, 1);
-            dmScript::PushHash(L, GetAbsoluteIdentifier(i->m_Instance, ident, strlen(ident)));
+            dmScript::PushHash(L, GetAbsoluteIdentifier(i->m_Instance, ident));
         }
         else
         {

--- a/engine/gameobject/src/gameobject/res_collection.cpp
+++ b/engine/gameobject/src/gameobject/res_collection.cpp
@@ -114,7 +114,7 @@ namespace dmGameObject
 
             for (uint32_t j = 0; j < instance_desc.m_Children.m_Count; ++j)
             {
-                dmGameObject::HInstance child = dmGameObject::GetInstanceFromIdentifier(collection, dmGameObject::GetAbsoluteIdentifier(parent, instance_desc.m_Children[j], strlen(instance_desc.m_Children[j])));
+                dmGameObject::HInstance child = dmGameObject::GetInstanceFromIdentifier(collection, dmGameObject::GetAbsoluteIdentifier(parent, instance_desc.m_Children[j]));
                 if (child)
                 {
                     dmGameObject::Result r = dmGameObject::SetParent(child, parent);

--- a/engine/gameobject/src/gameobject/test/collection/test_gameobject_collection.cpp
+++ b/engine/gameobject/src/gameobject/test/collection/test_gameobject_collection.cpp
@@ -494,12 +494,12 @@ TEST_F(CollectionTest, CollectionInCollection)
         ASSERT_NE((void*) 0, child_sub2);
 
         // Relative identifiers
-        ASSERT_EQ(dmHashString64("/a"), dmGameObject::GetAbsoluteIdentifier(go01, "a", strlen("a")));
-        ASSERT_EQ(dmHashString64("/a"), dmGameObject::GetAbsoluteIdentifier(go02, "a", strlen("a")));
-        ASSERT_EQ(dmHashString64("/sub1/a"), dmGameObject::GetAbsoluteIdentifier(parent_sub1, "a", strlen("a")));
-        ASSERT_EQ(dmHashString64("/sub2/a"), dmGameObject::GetAbsoluteIdentifier(parent_sub2, "a", strlen("a")));
-        ASSERT_EQ(dmHashString64("/sub1/a"), dmGameObject::GetAbsoluteIdentifier(parent_sub1, "/sub1/a", strlen("/sub1/a")));
-        ASSERT_EQ(dmHashString64("/sub2/a"), dmGameObject::GetAbsoluteIdentifier(parent_sub2, "/sub2/a", strlen("/sub2/a")));
+        ASSERT_EQ(dmHashString64("/a"), dmGameObject::GetAbsoluteIdentifier(go01, "a"));
+        ASSERT_EQ(dmHashString64("/a"), dmGameObject::GetAbsoluteIdentifier(go02, "a"));
+        ASSERT_EQ(dmHashString64("/sub1/a"), dmGameObject::GetAbsoluteIdentifier(parent_sub1, "a"));
+        ASSERT_EQ(dmHashString64("/sub2/a"), dmGameObject::GetAbsoluteIdentifier(parent_sub2, "a"));
+        ASSERT_EQ(dmHashString64("/sub1/a"), dmGameObject::GetAbsoluteIdentifier(parent_sub1, "/sub1/a"));
+        ASSERT_EQ(dmHashString64("/sub2/a"), dmGameObject::GetAbsoluteIdentifier(parent_sub2, "/sub2/a"));
 
         bool ret = dmGameObject::Update(coll, &m_UpdateContext);
         ASSERT_TRUE(ret);

--- a/engine/gameobject/src/gameobject/test/id/test_gameobject_id.cpp
+++ b/engine/gameobject/src/gameobject/test/id/test_gameobject_id.cpp
@@ -120,9 +120,9 @@ TEST_F(IdTest, TestHierarchies)
     ASSERT_NE((void*)0, (void*)sub1_instance);
     dmGameObject::HInstance sub2_instance = dmGameObject::GetInstanceFromIdentifier(collection, sub2_id);
     ASSERT_NE((void*)0, (void*)sub2_instance);
-    ASSERT_EQ(sub1_id, dmGameObject::GetAbsoluteIdentifier(instance, "sub/go1", strlen("sub/go1")));
-    ASSERT_EQ(id, dmGameObject::GetAbsoluteIdentifier(sub1_instance, "/go", strlen("/go")));
-    ASSERT_EQ(sub2_id, dmGameObject::GetAbsoluteIdentifier(sub1_instance, "go2", strlen("go2")));
-    ASSERT_EQ(id, dmGameObject::GetAbsoluteIdentifier(sub2_instance, "/go", strlen("/go")));
+    ASSERT_EQ(sub1_id, dmGameObject::GetAbsoluteIdentifier(instance, "sub/go1"));
+    ASSERT_EQ(id, dmGameObject::GetAbsoluteIdentifier(sub1_instance, "/go"));
+    ASSERT_EQ(sub2_id, dmGameObject::GetAbsoluteIdentifier(sub1_instance, "go2"));
+    ASSERT_EQ(id, dmGameObject::GetAbsoluteIdentifier(sub2_instance, "/go"));
     dmResource::Release(m_Factory, collection);
 }

--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -2743,12 +2743,13 @@ namespace dmGameSystem
     }
 
     // Public function used by engine (as callback from gui system)
-    dmhash_t GuiResolvePathCallback(dmGui::HScene scene, const char* path, uint32_t path_size)
+    dmhash_t GuiResolvePathCallback(dmGui::HScene scene, const char* path)
     {
         GuiComponent* component = (GuiComponent*)dmGui::GetSceneUserData(scene);
+        uint32_t path_size = strlen(path);
         if (path_size > 0)
         {
-            return dmGameObject::GetAbsoluteIdentifier(component->m_Instance, path, path_size);
+            return dmGameObject::GetAbsoluteIdentifier(component->m_Instance, path);
         }
         else
         {

--- a/engine/gamesys/src/gamesys/components/comp_gui.h
+++ b/engine/gamesys/src/gamesys/components/comp_gui.h
@@ -31,7 +31,7 @@ namespace dmGameSystem
     // Used by the engine to setup the dmGui::HContext
     void GuiGetURLCallback(dmGui::HScene scene, dmMessage::URL* url);
     uintptr_t GuiGetUserDataCallback(dmGui::HScene scene);
-    dmhash_t GuiResolvePathCallback(dmGui::HScene scene, const char* path, uint32_t path_size);
+    dmhash_t GuiResolvePathCallback(dmGui::HScene scene, const char* path);
     void GuiGetTextMetricsCallback(dmGameSystem::FontResource* font_resource, const char* text, float width, bool line_break, float leading, float tracking, dmGui::TextMetrics* out_metrics);
 
     // Used only in engine_service.cpp for resource profiling

--- a/engine/gui/src/gui.h
+++ b/engine/gui/src/gui.h
@@ -220,7 +220,7 @@ namespace dmGui
 
     typedef void (*GetURLCallback)(HScene scene, dmMessage::URL* url);
     typedef uintptr_t (*GetUserDataCallback)(HScene scene);
-    typedef dmhash_t (*ResolvePathCallback)(HScene scene, const char* path, uint32_t path_size);
+    typedef dmhash_t (*ResolvePathCallback)(HScene scene, const char* path);
 
     /**
      * Font metrics of a text string

--- a/engine/gui/src/gui_script.cpp
+++ b/engine/gui/src/gui_script.cpp
@@ -258,7 +258,7 @@ namespace dmGui
     {
         Scene* scene = (Scene*)lua_touserdata(L, 1);
         const char* path = luaL_checkstring(L, 2);
-        dmScript::PushHash(L, scene->m_Context->m_ResolvePathCallback(scene, path, strlen(path)));
+        dmScript::PushHash(L, scene->m_Context->m_ResolvePathCallback(scene, path));
         return 1;
     }
 

--- a/engine/gui/src/test/test_gui.cpp
+++ b/engine/gui/src/test/test_gui.cpp
@@ -77,7 +77,7 @@ void GetURLCallback(dmGui::HScene scene, dmMessage::URL* url);
 
 uintptr_t GetUserDataCallback(dmGui::HScene scene);
 
-dmhash_t ResolvePathCallback(dmGui::HScene scene, const char* path, uint32_t path_size);
+dmhash_t ResolvePathCallback(dmGui::HScene scene, const char* path);
 
 void GetTextMetricsCallback(const void* font, const char* text, float width, bool line_break, float leading, float tracking, dmGui::TextMetrics* out_metrics);
 
@@ -237,9 +237,9 @@ uintptr_t GetUserDataCallback(dmGui::HScene scene)
     return (uintptr_t)dmGui::GetSceneUserData(scene);
 }
 
-dmhash_t ResolvePathCallback(dmGui::HScene scene, const char* path, uint32_t path_size)
+dmhash_t ResolvePathCallback(dmGui::HScene scene, const char* path)
 {
-    return dmHashBuffer64(path, path_size);
+    return dmHashBuffer64(path, strlen(path));
 }
 
 void GetTextMetricsCallback(const void* font, const char* text, float width, bool line_break, float leading, float tracking, dmGui::TextMetrics* out_metrics)

--- a/engine/script/src/script.h
+++ b/engine/script/src/script.h
@@ -150,10 +150,9 @@ namespace dmScript
      * Implementations of this callback are expected to resolve the path given the user data.
      * @param resolve_user_data user data passed to the callback
      * @param path
-     * @param path_size
      * @return hashed resolved path
      */
-    typedef dmhash_t (*ResolvePathCallback)(uintptr_t resolve_user_data, const char* path, uint32_t path_size);
+    typedef dmhash_t (*ResolvePathCallback)(uintptr_t resolve_user_data, const char* path);
 
     /**
      * Callback used to retrieve url


### PR DESCRIPTION
Moved `dmGameObject::GetAbsoluteIdentifier(HInstance instance, const char* identifier)` to dmSDK. The function is used to get the absolute identifier relative to a game object instance. The returned identifier is the representation of the qualified name, i.e. the path from root-collection to the sub-collection which the instance belongs to.

Fixes #10947 

## PR checklist

* [x] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [x] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [x] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
