### PR TITLE
Allow users to cancel an ongoing build in the editor

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -83,6 +83,7 @@
             [service.smoke-log :as slog]
             [util.coll :as coll :refer [pair]]
             [util.eduction :as e]
+            [util.fn :as fn]
             [util.http-server :as http-server]
             [util.profiler :as profiler]
             [util.thread-util :as thread-util])
@@ -637,11 +638,13 @@
    :fetch-libraries (ref progress/done)
    :download-update (ref progress/done)})
 
+(declare ^:private render-task-progress!)
+
 (defn- cancel-task!
   [task-key]
   (dosync
     (let [progress-ref (task-key app-task-progress)]
-      (ref-set progress-ref (progress/cancel! @progress-ref)))))
+      (render-task-progress! task-key (progress/cancel @progress-ref)))))
 
 (def ^:private app-task-ui-priority
   "Task priority in descending order (from highest to lowest)"
@@ -705,8 +708,27 @@
   (progress/throttle-render-progress
     (fn [progress] (render-task-progress! key progress))))
 
-(defn make-task-cancelled-query [keyword]
-  (fn [] (progress/cancelled? @(keyword app-task-progress))))
+(defn begin-task-progress! [key]
+  (let [progress-ref (get app-task-progress key)
+        prev-progress-atom (atom nil)]
+    (assert (some? progress-ref))
+    (pair
+      (fn render-progress! [progress]
+        ;; Combined throttling and inheritance of cancel state.
+        ;; The first call to render-progress! overwrites the cancel state of the
+        ;; progress-ref, and then subsequent calls will inherit the cancel state
+        ;; from the progress-ref. This is to ensure we see changes to the
+        ;; progress-refs cancel state from the cancel-task! function.
+        (let [prev-progress @prev-progress-atom
+              progress (cond-> progress
+                               prev-progress
+                               (progress/with-inherited-cancel-state @progress-ref))]
+          (when (progress/relevant-change? prev-progress progress)
+            (reset! prev-progress-atom progress)
+            (render-task-progress! key progress))))
+
+      (fn task-cancelled? []
+        (progress/cancelled? @progress-ref)))))
 
 (defn render-main-task-progress! [progress]
   (render-task-progress! :main progress))
@@ -900,19 +922,25 @@
     exception))
 
 (defn- build-project!
-  [project evaluation-context extra-build-targets old-artifact-map render-progress!]
+  [project old-artifact-map opts evaluation-context]
   (let [game-project (project/get-resource-node project "/game.project" evaluation-context)
-        render-progress! (progress/throttle-render-progress render-progress!)]
+        render-progress! (or (:render-progress! opts)
+                             progress/null-render-progress!)]
     (try
       (ui/with-progress [render-progress! render-progress!]
-        (build/build-project! project game-project evaluation-context extra-build-targets old-artifact-map render-progress!))
+        (build/build-project! project game-project old-artifact-map opts evaluation-context))
       (catch Throwable error
         (let [error (if (instance? ExecutionException error)
                       (ex-cause error)
                       error)
-              cause-ex-data (-> error ex-root-cause ex-data)
-              is-cyclic-resource-dependency-error (= :cycle-detected (:ex-type cause-ex-data))]
-          (if is-cyclic-resource-dependency-error
+              cause (ex-root-cause error)
+              cause-ex-data (ex-data cause)
+              ex-type (:ex-type cause-ex-data)]
+          (case ex-type
+            :task-cancelled
+            nil ; We'll just produce an error signaling that the build was cancelled below.
+
+            :cycle-detected
             (ui/run-later
               (dialogs/make-info-dialog
                 {:title "Build Error"
@@ -921,9 +949,15 @@
                  :content {:fx/type fxui/legacy-label
                            :style-class "dialog-content-padding"
                            :text (get-cycle-detected-help-message (-> cause-ex-data :endpoint gt/endpoint-node-id))}}))
+
+            ;; Default case.
             (error-reporting/report-exception! error))
           {:error (cond
-                    is-cyclic-resource-dependency-error
+                    (= :task-cancelled ex-type)
+                    {:severity :fatal
+                     :message (ex-message cause)}
+
+                    (= :cycle-detected ex-type)
                     {:severity :fatal
                      :message (str "Cyclic resource dependency detected. " (get-cycle-detected-help-message (-> cause-ex-data :endpoint gt/endpoint-node-id)))}
 
@@ -969,17 +1003,20 @@
     :run-build-hooks     optional flag that indicates whether to run pre- and
                          post-build hooks
     :render-progress!    optional progress reporter fn
+    :task-cancelled?     optional fn that will be called periodically to check
+                         if the user has cancelled the build process.
     :old-artifact-map    optional old artifact map with previous build results
                          to speed up the build process"
   [project & {:keys [;; required
                      result-fn
                      prefs
                      ;; optional
-                     debug build-engine run-build-hooks render-progress! old-artifact-map lint]
+                     debug build-engine run-build-hooks render-progress! task-cancelled? old-artifact-map lint]
               :or {debug false
                    build-engine true
                    run-build-hooks true
                    render-progress! progress/null-render-progress!
+                   task-cancelled? fn/constantly-false
                    old-artifact-map {}}}]
   {:pre [(ifn? result-fn)
          (or (not build-engine) (some? prefs))]}
@@ -1145,8 +1182,13 @@
               (fn run-project-build-on-background-thread! []
                 (let [extra-build-targets
                       (when debug
-                        (debug-view/build-targets project evaluation-context))]
-                  (build-project! project evaluation-context extra-build-targets old-artifact-map render-progress!)))
+                        (debug-view/build-targets project evaluation-context))
+
+                      opts
+                      {:extra-build-targets extra-build-targets
+                       :render-progress! render-progress!
+                       :task-cancelled? task-cancelled?}]
+                  (build-project! project old-artifact-map opts evaluation-context)))
               (fn process-project-build-results-on-ui-thread! [project-build-results]
                 (project/update-system-cache-build-targets! evaluation-context)
                 (project/log-cache-info! (g/cache) "Cached compiled build targets in system cache.")
@@ -1222,13 +1264,15 @@
   (let [project-directory (workspace/project-directory workspace)
         main-scene (.getScene ^Stage main-stage)
         render-build-error! (make-render-build-error main-scene tool-tab-pane build-errors-view)
-        skip-engine (target-cannot-swap-engine? (targets/selected-target prefs))]
+        skip-engine (target-cannot-swap-engine? (targets/selected-target prefs))
+        [render-progress! task-cancelled?] (begin-task-progress! :build)]
     (build-errors-view/clear-build-errors build-errors-view)
     (async-build! project
                   :debug true
                   :build-engine (not skip-engine)
                   :prefs prefs
-                  :render-progress! (make-render-task-progress :build)
+                  :render-progress! render-progress!
+                  :task-cancelled? task-cancelled?
                   :old-artifact-map (workspace/artifact-map workspace)
                   :result-fn (fn [{:keys [engine] :as build-results}]
                                (when (handle-build-results! workspace render-build-error! build-results)
@@ -1277,12 +1321,14 @@ If you do not specifically require different script states, consider changing th
 
 (defn- run-with-debugger! [workspace project prefs debug-view render-build-error! web-server]
   (let [project-directory (workspace/project-directory workspace)
-        skip-engine (target-cannot-swap-engine? (targets/selected-target prefs))]
+        skip-engine (target-cannot-swap-engine? (targets/selected-target prefs))
+        [render-progress! task-cancelled?] (begin-task-progress! :build)]
     (async-build! project
                   :debug true
                   :build-engine (not skip-engine)
                   :prefs prefs
-                  :render-progress! (make-render-task-progress :build)
+                  :render-progress! render-progress!
+                  :task-cancelled? task-cancelled?
                   :old-artifact-map (workspace/artifact-map workspace)
                   :result-fn (fn [{:keys [engine] :as build-results}]
                                (when (handle-build-results! workspace render-build-error! build-results)
@@ -1292,19 +1338,21 @@ If you do not specifically require different script states, consider changing th
                                        (debug-view/start-debugger! debug-view project (:address target "localhost") (:instance-index target 0))))))))))
 
 (defn- attach-debugger! [workspace project prefs debug-view render-build-error!]
-  (async-build! project
-                :debug true
-                :build-engine false
-                :run-build-hooks false
-                :lint false
-                :render-progress! (make-render-task-progress :build)
-                :old-artifact-map (workspace/artifact-map workspace)
-                :prefs prefs
-                :result-fn (fn [build-results]
-                             (when (handle-build-results! workspace render-build-error! build-results)
-                               (let [target (targets/selected-target prefs)]
-                                 (when (targets/controllable-target? target)
-                                   (debug-view/attach! debug-view project target (:artifacts build-results))))))))
+  (let [[render-progress! task-cancelled?] (begin-task-progress! :build)]
+    (async-build! project
+                  :debug true
+                  :build-engine false
+                  :run-build-hooks false
+                  :lint false
+                  :render-progress! render-progress!
+                  :task-cancelled? task-cancelled?
+                  :old-artifact-map (workspace/artifact-map workspace)
+                  :prefs prefs
+                  :result-fn (fn [build-results]
+                               (when (handle-build-results! workspace render-build-error! build-results)
+                                 (let [target (targets/selected-target prefs)]
+                                   (when (targets/controllable-target? target)
+                                     (debug-view/attach! debug-view project target (:artifacts build-results)))))))))
 
 (handler/defhandler :debugger.start :global
   ;; NOTE: Shares a shortcut with :debug-view/continue.
@@ -1352,12 +1400,11 @@ If you do not specifically require different script states, consider changing th
         render-build-error! (make-render-build-error main-scene tool-tab-pane build-errors-view)
         render-reload-progress! (make-render-task-progress :resource-sync)
         render-save-progress! (make-render-task-progress :save-all)
-        render-build-progress! (make-render-task-progress :build)
-        task-cancelled? (make-task-cancelled-query :build)
+        [render-build-progress! build-task-cancelled?] (begin-task-progress! :build)
         bob-args (bob/build-html5-bob-options project prefs)
         out (start-new-log-pipe!)]
     (build-errors-view/clear-build-errors build-errors-view)
-    (disk/async-bob-build! render-reload-progress! render-save-progress! render-build-progress! out task-cancelled?
+    (disk/async-bob-build! render-reload-progress! render-save-progress! render-build-progress! out build-task-cancelled?
                            render-build-error! bob-commands bob-args project changes-view
                            (fn [successful?]
                              (when successful?
@@ -1412,7 +1459,8 @@ If you do not specifically require different script states, consider changing th
         target (targets/selected-target prefs)
         workspace (project/workspace project)
         old-etags (workspace/etags workspace)
-        render-build-error! (make-render-build-error main-scene tool-tab-pane build-errors-view)]
+        render-build-error! (make-render-build-error main-scene tool-tab-pane build-errors-view)
+        [render-progress! task-cancelled?] (begin-task-progress! :build)]
     ;; NOTE: We must build the entire project even if we only want to reload a
     ;; subset of resources in order to maintain a functioning build cache.
     ;; If we decide to support hot reload of a subset of resources, we must
@@ -1424,7 +1472,8 @@ If you do not specifically require different script states, consider changing th
                   :build-engine false
                   :run-build-hooks false
                   :lint false
-                  :render-progress! (make-render-task-progress :build)
+                  :render-progress! render-progress!
+                  :task-cancelled? task-cancelled?
                   :old-artifact-map (workspace/artifact-map workspace)
                   :prefs prefs
                   :result-fn (fn [{:keys [error artifact-map etags]}]
@@ -2763,15 +2812,14 @@ If you do not specifically require different script states, consider changing th
                              render-build-error! (make-render-build-error main-scene tool-tab-pane build-errors-view)
                              render-reload-progress! (make-render-task-progress :resource-sync)
                              render-save-progress! (make-render-task-progress :save-all)
-                             render-build-progress! (make-render-task-progress :build)
-                             task-cancelled? (make-task-cancelled-query :build)
+                             [render-build-progress! build-task-cancelled?] (begin-task-progress! :build)
                              out (start-new-log-pipe!)]
                          (build-errors-view/clear-build-errors build-errors-view)
                          (disk/async-bob-build! render-reload-progress!
                                                 render-save-progress!
                                                 render-build-progress!
                                                 out
-                                                task-cancelled?
+                                                build-task-cancelled?
                                                 render-build-error!
                                                 commands
                                                 options

--- a/editor/src/clj/editor/library.clj
+++ b/editor/src/clj/editor/library.clj
@@ -287,7 +287,7 @@
   * :new-file to downloaded file if any
   * :tag with etag from resolver"
   [resolver render-progress! lib-states]
-  (progress/mapv
+  (progress/progress-mapv
     (fn [lib-state progress]
       (if (= (:status lib-state) :unknown)
         (fetch-library-update! lib-state resolver

--- a/editor/src/clj/editor/progress.clj
+++ b/editor/src/clj/editor/progress.clj
@@ -13,89 +13,137 @@
 ;; specific language governing permissions and limitations under the License.
 
 (ns editor.progress
-  (:refer-clojure :exclude [mapv]))
+  (:require [util.coll :refer [pair]]
+            [util.defonce :as defonce]))
+
+(set! *warn-on-reflection* true)
+(set! *unchecked-math* :warn-on-boxed)
+
+(defonce/record Progress
+  [^String message
+   ^long size
+   ^long pos
+   cancel-state])
+
+(defn ->progress
+  ^Progress [^String message ^long size ^long pos cancel-state]
+  {:pre [(string? message)
+         (nat-int? size) ; size 0 means indeterminate.
+         (nat-int? pos)
+         (<= pos size)
+         (case cancel-state (:not-cancellable :cancellable :cancelled) true false)]}
+  (->Progress message size pos cancel-state))
 
 (defn make
-  ([msg]
-   (make msg 1))
-  ([msg size]
-   (make msg size 0))
-  ([msg size pos]
-   (make msg size pos false))
-  ([msg size pos cancellable?]
-   {:pre [(<= pos size)]}
-   {:message msg :size size :pos pos :cancellable cancellable? :cancelled false}))
+  (^Progress [^String message]
+   (->progress message 1 0 :not-cancellable))
+  (^Progress [^String message ^long size]
+   (->progress message size 0 :not-cancellable))
+  (^Progress [^String message ^long size ^long pos]
+   (->progress message size pos :not-cancellable))
+  (^Progress [^String message ^long size ^long pos cancellable]
+   (->progress message size pos (if cancellable :cancellable :not-cancellable))))
 
-(defn make-indeterminate [msg]
-  (make msg 0))
+(defn make-indeterminate
+  ^Progress [^String message]
+  (->progress message 0 0 :not-cancellable))
 
-(defn make-cancellable-indeterminate [msg]
-  (make msg 0 0 true))
+(defn make-cancellable-indeterminate
+  ^Progress [^String message]
+  (->progress message 0 0 :cancellable))
 
-(def done (make "Ready" 1 1))
+(def ^Progress done (->progress "Ready" 1 1 :not-cancellable))
 
-(defn with-message [p msg]
-  (assoc p :message msg))
+(defn with-message
+  ^Progress [^Progress progress ^String message]
+  (assoc progress :message message))
 
 (defn jump
-  ([p pos]
-   (assoc p :pos (min (:size p) pos)))
-  ([p pos msg]
-   (with-message (jump p pos) msg)))
+  (^Progress [^Progress progress ^long pos]
+   (assoc progress :pos (min pos (.-size progress))))
+  (^Progress [^Progress progress ^long pos ^String message]
+   (with-message (jump progress pos) message)))
 
 (defn advance
-  ([p]
-   (advance p 1))
-  ([p n]
-   (jump p (+ (:pos p) n)))
-  ([p n msg]
-   (with-message (advance p n) msg)))
+  (^Progress [^Progress progress]
+   (advance progress 1))
+  (^Progress [^Progress progress ^long delta]
+   (jump progress (+ (.-pos progress) delta)))
+  (^Progress [^Progress progress ^long delta ^String message]
+   (with-message (advance progress delta) message)))
 
-(defn fraction [{:keys [pos size] :as _progress}]
-  (when (pos? size)
-    (/ pos size)))
+(defn fraction [^Progress progress]
+  (let [size (.-size progress)]
+    (when (pos? size)
+      (/ (.-pos progress) size))))
 
-(defn percentage [progress]
+(defn percentage [^Progress progress]
   (when-some [fraction (fraction progress)]
-    (int (* 100 fraction))))
+    (int (* 100.0 (double fraction)))))
 
-(defn message [progress]
-  (:message progress))
+(definline message
+  ^String [^Progress progress]
+  `(.-message ~(with-meta progress {:tag `Progress})))
 
-(defn done? [{:keys [pos size] :as _progress}]
-  (and (pos? size)
-       (= pos size)))
+(defn done? [^Progress progress]
+  (let [size (.-size progress)]
+    (and (pos? size)
+         (= size (.-pos progress)))))
 
-(defn cancellable? [progress]
-  (:cancellable progress))
+(definline cancellable? [^Progress progress]
+  `(= :cancellable (.-cancel-state ~(with-meta progress {:tag `Progress}))))
 
-(defn cancel! [progress]
-  (assoc progress :cancelled true))
+(defn cancel
+  ^Progress [^Progress progress]
+  (assert (cancellable? progress))
+  (assoc progress :cancel-state :cancelled))
 
-(defn cancelled? [progress]
-  (:cancelled progress))
+(definline cancelled? [^Progress progress]
+  `(= :cancelled (.-cancel-state ~(with-meta progress {:tag `Progress}))))
+
+(defn- inherited-cancel-state [^Progress new-progress old-cancellable old-cancelled]
+  (cond
+    (or old-cancelled (cancelled? new-progress))
+    :cancelled
+
+    (or old-cancellable (cancellable? new-progress))
+    :cancellable
+
+    :else
+    :not-cancellable))
+
+(defn with-inherited-cancel-state
+  ^Progress [^Progress new-progress ^Progress old-progress]
+  (if (nil? old-progress)
+    new-progress
+    (let [old-cancellable (cancellable? old-progress)
+          old-cancelled (cancelled? old-progress)
+          inherited-cancel-state (inherited-cancel-state new-progress old-cancellable old-cancelled)]
+      (assoc new-progress :cancel-state inherited-cancel-state))))
 
 ;; ----------------------------------------------------------
 
-(defn- relevant-change? [last-progress progress]
+(defn relevant-change? [^Progress last-progress ^Progress progress]
   (or (nil? last-progress)
-      (not= (message last-progress)
-            (message progress))
+      (not= (.-cancel-state last-progress)
+            (.-cancel-state progress))
+      (not= (.-message last-progress)
+            (.-message progress))
       (not= (percentage last-progress)
             (percentage progress))))
 
 (defn null-render-progress! [_])
 
-(defn println-render-progress! [progress]
+(defn println-render-progress! [^Progress progress]
   (if-some [percentage (percentage progress)]
     (println (message progress) percentage "%")
     (println (message progress))))
 
 (defn throttle-render-progress [render-progress!]
   (let [last-progress (atom nil)]
-    (fn [progress]
+    (fn throttled-render-progress! [^Progress progress]
       (when (relevant-change? @last-progress progress)
-        (swap! last-progress progress)
+        (reset! last-progress progress)
         (render-progress! progress)))))
 
 (defn until-done [render-progress!]
@@ -105,7 +153,7 @@
                            :before (if (= new-progress done) :done :before)
                            :done :after
                            :after :after))]
-    (fn until-done-progress [progress]
+    (fn until-done-progress [^Progress progress]
       (when-not (= :after (swap! state-atom track-progress progress))
         (render-progress! progress)))))
 
@@ -125,48 +173,37 @@
   and a `span` - the number of parent steps steps the sub task
   represents. When returning from the sub task, the parent task should
   seem to have advanced `span` steps."
-  ([render-progress! parent-progress]
+  ([render-progress! ^Progress parent-progress]
    (nest-render-progress render-progress! parent-progress 1))
-  ([render-progress! parent-progress span]
-   {:pre [(<= (+ (:pos parent-progress) span) (:size parent-progress))]}
+  ([render-progress! ^Progress parent-progress ^long span]
    (if (= render-progress! null-render-progress!)
      null-render-progress!
-     (fn [progress]
-       (let [scale (:size progress)]
-         (render-progress!
-           (make
-             (message progress)
-             (* scale (:size parent-progress))
-             (+ (* scale (:pos parent-progress)) (* (:pos progress) span)))))))))
+     (let [parent-size (.-size parent-progress)
+           parent-pos (.-pos parent-progress)
+           parent-cancellable (cancellable? parent-progress)
+           parent-cancelled (cancelled? parent-progress)]
+       (assert (<= (+ parent-pos span) parent-size))
+       (fn nested-render-progress! [^Progress progress]
+         (let [size (.-size progress)
+               pos (.-pos progress)]
+           (render-progress!
+             (->progress
+               (message progress)
+               (* size parent-size)
+               (+ (* size parent-pos) (* pos span))
+               (inherited-cancel-state progress parent-cancellable parent-cancelled)))))))))
 
 (defn progress-mapv
   ([f coll render-progress!]
    (progress-mapv f coll render-progress! (constantly "")))
   ([f coll render-progress! message-fn]
-   (let [progress (make "" (count coll))]
+   (persistent!
      (first
-      (reduce (fn [[result progress] e]
-                (let [progress (with-message progress (or (message-fn e) ""))]
-                  (render-progress! progress)
-                  [(conj result (f e progress)) (advance progress)]))
-              [[] progress]
-              coll)))))
-
-(defn mapv
-  "Similar to progress-mapv, but is mapv compatible and will call f with same
-  args as regular mapv."
-  ([f coll render-progress!]
-   (progress-mapv f coll render-progress! (constantly "")))
-  ([f coll render-progress! message-fn]
-   (let [progress (make "" (count coll))]
-     (first
-      (reduce (fn [[result progress] e]
-                (let [progress (with-message progress (or (message-fn e) ""))]
-                  (render-progress! progress)
-                  [(conj result (f e)) (advance progress)]))
-              [[] progress]
-              coll)))))
-
-(defn make-mapv
-  [render-progress! message-fn]
-  (fn [f coll] (mapv f coll render-progress! message-fn)))
+       (reduce (fn [[result progress] item]
+                 (let [progress (with-message progress (or (message-fn item) ""))]
+                   (render-progress! progress)
+                   (pair (conj! result (f item progress))
+                         (advance progress))))
+               (pair (transient [])
+                     (->progress "" (count coll) 0 :not-cancellable))
+               coll)))))

--- a/editor/src/clj/editor/ui.clj
+++ b/editor/src/clj/editor/ui.clj
@@ -59,6 +59,7 @@
            [javafx.util Callback Duration]))
 
 (set! *warn-on-reflection* true)
+(set! *unchecked-math* :warn-on-boxed)
 
 (def ^:private ^:dynamic *programmatic-selection* nil)
 
@@ -77,7 +78,7 @@
 
 ;; If no application-owned windows have had focus within this
 ;; threshold, we consider the application to have lost focus.
-(defonce ^:private application-unfocused-threshold-ms 500)
+(defonce ^:private ^:const application-unfocused-threshold-ms 500)
 (defonce ^:private focus-state (atom nil))
 
 (defn node? [value]
@@ -121,7 +122,9 @@
                (when (and old
                           (not (:focused old))
                           (:focused new))
-                 (let [unfocused-ms (- (:t new) (:t old))]
+                 (let [^long new-t (:t new)
+                       ^long old-t (:t old)
+                       unfocused-ms (- new-t old-t)]
                    (when (< application-unfocused-threshold-ms unfocused-ms)
                      (apply application-focused! args))))))
   nil)
@@ -2022,16 +2025,24 @@
       (refresh-toolbars! scene evaluation-context))))
 
 (defn render-progress-bar! [progress ^ProgressBar bar]
-  (let [frac (progress/fraction progress)]
-    (.setProgress bar (if (nil? frac) -1.0 (double frac)))))
+  (.setProgress
+    bar
+    (if-let [fraction (when-not (progress/cancelled? progress)
+                        (progress/fraction progress))]
+      (double fraction)
+      -1.0)))
 
 (defn render-progress-message! [progress ^Label label]
   (text! label (progress/message progress)))
 
 (defn render-progress-percentage! [progress ^Label label]
-  (if-some [percentage (progress/percentage progress)]
-    (text! label (str percentage "%"))
-    (text! label "")))
+  (text!
+    label
+    (if (progress/cancelled? progress)
+      "Aborting..."
+      (if-some [percentage (progress/percentage progress)]
+        (str percentage "%")
+        ""))))
 
 (defn render-progress-controls! [progress ^ProgressBar bar ^Label label]
   (when bar (render-progress-bar! progress bar))
@@ -2108,26 +2119,27 @@
   ([name tick-fn]
    (->timer nil name tick-fn))
   ([fps name tick-fn]
-   (let [start      (System/nanoTime)
-         last       (atom start)
-         interval   (when fps
-                      (long (* 1e9 (/ 1 (double fps)))))]
-     {:last  last
+   (let [start (System/nanoTime)
+         last (atom start)
+         interval (if fps
+                    (long (* 1e9 (/ 1 (double fps))))
+                    0)]
+     {:last last
       :timer (proxy [AnimationTimer] []
-               (handle [now]
+               (handle [^long now]
                  (profiler/profile "timer" name
-                                   (let [elapsed (- now start)
-                                         delta (- now @last)]
-                                     (when (or (nil? interval) (> delta interval))
-                                       (run-later
-                                         (try
-                                           (tick-fn this (* elapsed 1e-9) (/ delta 1e9))
-                                           (reset! last (- now (if interval
-                                                                 (- delta interval)
-                                                                 0)))
-                                           (catch Throwable t
-                                             (.stop ^AnimationTimer this)
-                                             (error-reporting/report-exception! t)))))))))})))
+                   (let [elapsed (- now start)
+                         delta (- now (long @last))]
+                     (when (or (zero? interval) (> delta interval))
+                       (run-later
+                         (try
+                           (tick-fn this (* elapsed 1e-9) (/ delta 1e9))
+                           (reset! last (if (zero? interval)
+                                          now
+                                          (- now (- delta interval))))
+                           (catch Throwable t
+                             (.stop ^AnimationTimer this)
+                             (error-reporting/report-exception! t)))))))))})))
 
 (defn timer-start! [timer]
   (.start ^AnimationTimer (:timer timer)))
@@ -2135,12 +2147,12 @@
 (defn timer-stop! [timer]
   (.stop ^AnimationTimer (:timer timer)))
 
-(defn anim! [duration anim-fn end-fn]
-  (let [duration   (long (* 1e9 duration))
-        start      (System/nanoTime)
-        end        (+ start (long duration))]
+(defn anim! [^double duration anim-fn end-fn]
+  (let [duration (long (* 1e9 duration))
+        start (System/nanoTime)
+        end (+ start (long duration))]
     (doto (proxy [AnimationTimer] []
-            (handle [now]
+            (handle [^long now]
               (run-later
                 (if (< now end)
                   (let [t (/ (double (- now start)) duration)]
@@ -2227,10 +2239,10 @@
     (throw (IllegalArgumentException. "stage cannot be nil")))
   (let [prev-exception-handler (Thread/getDefaultUncaughtExceptionHandler)
         thrown-exception (volatile! nil)]
-    (Thread/setDefaultUncaughtExceptionHandler (reify Thread$UncaughtExceptionHandler
-                                                 (uncaughtException [_ _ exception]
-                                                   (vreset! thrown-exception exception)
-                                                   (close! stage))))
+    (Thread/setDefaultUncaughtExceptionHandler
+      (fn close-and-store-exception-handler [_ exception]
+        (vreset! thrown-exception exception)
+        (close! stage)))
     (let [result (try
                    (show-and-wait! stage)
                    (finally
@@ -2321,7 +2333,7 @@
   (string/join " "
                (map (fn [outline]
                       (str "M" (string/join " L"
-                                            (map (fn [x y]
+                                            (map (fn [^double x ^double y]
                                                    (str (math/round-with-precision (* x col) 0.1)
                                                         ","
                                                         (math/round-with-precision (* y row) 0.1)))

--- a/editor/styling/stylesheets/_editor.scss
+++ b/editor/styling/stylesheets/_editor.scss
@@ -139,8 +139,8 @@ Links:
 }
 
 #status-pane #progress-hbox #progress-cancel-button {
-    -fx-background-color: -df-background-dark;
-    -cross-color: -df-text;
+    -fx-background-color: -df-background;
+    -cross-color: -df-background-lighter;
     -fx-background-radius: 50%;
     -fx-border-width: 0;
     -fx-padding: 0;
@@ -150,11 +150,11 @@ Links:
     -fx-max-height: 16px;
     -fx-content-display: center;
     &:hover {
-        -fx-background-color: -df-component-lighter;
-        -cross-color: -df-text-selected;
+        -fx-background-color: -df-background-lighter;
+        -cross-color: -df-text;
     }
     &:armed {
-        -fx-background-color: -df-background-light;
+        -fx-background-color: -df-background-lighter;
         -cross-color: -df-text-selected;
     }
 }

--- a/editor/test/integration/app_view_test.clj
+++ b/editor/test/integration/app_view_test.clj
@@ -21,7 +21,6 @@
             [editor.build :as build]
             [editor.defold-project :as project]
             [editor.git :as git]
-            [editor.progress :as progress]
             [editor.resource :as resource]
             [editor.resource-node :as resource-node]
             [editor.workspace :as workspace]
@@ -158,7 +157,7 @@
       (is main-dir)
       (let [evaluation-context (g/make-evaluation-context)
             old-artifact-map (workspace/artifact-map workspace)
-            build-results (build/build-project! project game-project evaluation-context nil old-artifact-map progress/null-render-progress!)]
+            build-results (build/build-project! project game-project old-artifact-map nil evaluation-context)]
         (g/update-cache-from-evaluation-context! evaluation-context)
         (is (seq (:artifacts build-results)))
         (is (not (g/error? (:error build-results))))
@@ -167,7 +166,7 @@
       (is (nil? (workspace/find-resource workspace "/main")))
       (is (workspace/find-resource workspace "/blahonga"))
       (let [old-artifact-map (workspace/artifact-map workspace)
-            build-results (build/build-project! project game-project (g/make-evaluation-context) nil old-artifact-map progress/null-render-progress!)]
+            build-results (build/build-project! project game-project old-artifact-map nil (g/make-evaluation-context))]
         (is (seq (:artifacts build-results)))
         (is (not (g/error? (:error build-results))))
         (workspace/artifact-map! workspace (:artifact-map build-results))))))

--- a/editor/test/integration/build_errors_test.clj
+++ b/editor/test/integration/build_errors_test.clj
@@ -18,7 +18,6 @@
             [editor.build :as build]
             [editor.build-errors-view :as build-errors-view]
             [editor.defold-project :as project]
-            [editor.progress :as progress]
             [editor.resource :as resource]
             [editor.workspace :as workspace]
             [integration.test-util :as test-util]
@@ -63,7 +62,7 @@
             (with-open [_ (make-restore-point!)]
               (add-component-from-file! workspace game-object component-resource-path)
               (let [old-artifact-map (workspace/artifact-map workspace)
-                    build-results (build/build-project! project main-collection (g/make-evaluation-context) nil old-artifact-map progress/null-render-progress!)
+                    build-results (build/build-project! project main-collection old-artifact-map nil (g/make-evaluation-context))
                     error-value (:error build-results)]
                 (if (is (some? error-value) component-resource-path)
                   (let [error-tree (build-errors-view/build-resource-tree error-value)
@@ -102,7 +101,7 @@
             (with-open [_ (make-restore-point!)]
               (add-fn resource-path)
               (let [old-artifact-map (workspace/artifact-map workspace)
-                    build-results (build/build-project! project main-collection (g/make-evaluation-context) nil old-artifact-map progress/null-render-progress!)
+                    build-results (build/build-project! project main-collection old-artifact-map nil (g/make-evaluation-context))
                     error-value (:error build-results)]
                 (if (is (some? error-value) resource-path)
                   (let [error-tree (build-errors-view/build-resource-tree error-value)
@@ -132,7 +131,7 @@
                         "/errors/window_using_panel_break_button.gui"]]
             (add-component-from-file! workspace game-object path))
           (let [old-artifact-map (workspace/artifact-map workspace)
-                build-results (build/build-project! project main-collection (g/make-evaluation-context) nil old-artifact-map progress/null-render-progress!)
+                build-results (build/build-project! project main-collection old-artifact-map nil (g/make-evaluation-context))
                 error-value (:error build-results)]
             (if (is (some? error-value))
               (let [error-tree (build-errors-view/build-resource-tree error-value)]

--- a/editor/test/integration/hot_reload_test.clj
+++ b/editor/test/integration/hot_reload_test.clj
@@ -19,7 +19,6 @@
             [editor.build :as build]
             [editor.defold-project :as project]
             [editor.hot-reload :as hot-reload]
-            [editor.progress :as progress]
             [editor.protobuf :as protobuf]
             [editor.workspace :as workspace]
             [integration.test-util :as test-util]
@@ -35,7 +34,7 @@
 (defn- project-build [project resource-node evaluation-context]
   (let [workspace (project/workspace project)
         old-artifact-map (workspace/artifact-map workspace)
-        build-results (build/build-project! project resource-node evaluation-context nil old-artifact-map progress/null-render-progress!)]
+        build-results (build/build-project! project resource-node old-artifact-map nil evaluation-context)]
     (when-not (contains? build-results :error)
       (workspace/artifact-map! workspace (:artifact-map build-results))
       (workspace/etags! workspace (:etags build-results)))

--- a/editor/test/integration/test_util.clj
+++ b/editor/test/integration/test_util.clj
@@ -56,7 +56,7 @@
             [lambdaisland.deep-diff2 :as deep-diff]
             [service.log :as log]
             [support.test-support :as test-support]
-            [util.coll :as coll :refer [pair]]
+            [util.coll :refer [pair]]
             [util.diff :as diff]
             [util.fn :as fn]
             [util.http-server :as http-server]
@@ -1310,7 +1310,7 @@
         workspace (project/workspace project)
         old-artifact-map (workspace/artifact-map workspace)]
     (g/with-auto-evaluation-context evaluation-context
-      (build/build-project! project resource-node evaluation-context nil old-artifact-map progress/null-render-progress!))))
+      (build/build-project! project resource-node old-artifact-map nil evaluation-context))))
 
 (defn build-node! [resource-node]
   (let [build-result (build-node-result! resource-node)]


### PR DESCRIPTION
You can now cancel the build process in the editor by clicking the Stop button next to the progress indicator in the status bar.

Fixes #10725

### Technical changes
* Simplified the optional arguments to `app-view/build-project!` and `build/build-project!`. Both now take an `opts` map instead.
* Made sure the progress cancellation flag set by `app-view/cancel-task!` is not overwritten by subsequent calls to `app-view/render-task-progress!`.
* Check the cancellation flag at frequent points inside `build/build-project!`.
* Use a record for Progress state instead of a map and fix boxed math.
* Removed unused `progress/mapv` function.
* Fixed boxed math in `editor.ui` module.