### PR TITLE
Bob performance optimizations for sequential builds

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/BundleResourcesTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/BundleResourcesTest.java
@@ -158,6 +158,7 @@ public class BundleResourcesTest {
         List<String> folders = ExtenderUtil.getExtensionFolders(project);
         assertEquals(1, folders.size());
         assertEquals("extension1", folders.get(0));
+        project.cleanupResourcePathsCache();
 
         // Add one more extension folder at root
         addFile("extension2/ext.manifest", "name: \"extension2\"");
@@ -165,6 +166,7 @@ public class BundleResourcesTest {
         assertEquals(2, folders.size());
         assertEquals("extension1", folders.get(0));
         assertEquals("extension2", folders.get(1));
+        project.cleanupResourcePathsCache();
 
         // Add one more extension folder in a nested subfolder
         addFile("subfolder/extension3/ext.manifest", "name: \"extension3\"");
@@ -173,7 +175,7 @@ public class BundleResourcesTest {
         assertEquals("extension1", folders.get(0));
         assertEquals("extension2", folders.get(1));
         assertEquals("subfolder/extension3", folders.get(2));
-
+        project.cleanupResourcePathsCache();
     }
 
     @Test

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/ExtenderUtilTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/ExtenderUtilTest.java
@@ -77,7 +77,7 @@ public class ExtenderUtilTest {
 
         project = new Project(fileSystem, tmpDir.getAbsolutePath(), "build/default");
 
-        project.loadProjectFile();
+        project.loadProjectFile(true);
     }
 
     @After

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/BobProjectPropertiesTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/BobProjectPropertiesTest.java
@@ -97,7 +97,7 @@ public class BobProjectPropertiesTest {
         createFile(contentRoot, "extension1/"+BobProjectProperties.PROPERTIES_EXTENSION_FILE, "[project]\ncustom_property.private = 1");
 
         Project project = new Project(new DefaultFileSystem(), contentRoot, "build");
-        project.loadProjectFile();
+        project.loadProjectFile(true);
         BobProjectProperties properties = project.getProjectProperties();
 
         assertEquals(true, properties.isPrivate("project", "custom_property"));
@@ -111,7 +111,7 @@ public class BobProjectPropertiesTest {
         createFile(contentRoot, BobProjectProperties.PROPERTIES_PROJECT_FILE, "[project]\ncustom_property.private = 0");
 
         Project project = new Project(new DefaultFileSystem(), contentRoot, "build");
-        project.loadProjectFile();
+        project.loadProjectFile(true);
         BobProjectProperties properties = project.getProjectProperties();
 
         assertEquals(false, properties.isPrivate("project", "custom_property"));

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Bob.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Bob.java
@@ -159,6 +159,7 @@ public class Bob {
     }
 
     public static void initLua() {
+        init();
         PackedResources.unpackAllLibsAsync(Platform.getHostPlatform());
         PackedResources.waitForuUpackAllLibsAsync();
     }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Bob.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Bob.java
@@ -643,6 +643,7 @@ public class Bob {
     }
 
     private static void setupProject(Project project, boolean resolveLibraries, IProgress progress) throws IOException, LibraryException, CompileExceptionError {
+        project.loadProjectFile(false);
         BobProjectProperties projectProperties = project.getProjectProperties();
         String[] dependencies = projectProperties.getStringArrayValue("project", "dependencies");
         List<URL> libUrls = new ArrayList<>();
@@ -820,10 +821,6 @@ public class Bob {
                     project.addBuildServerHeader(header);
                 }
             }
-            TimeProfiler.stop();
-
-            TimeProfiler.start("loadProjectFile");
-            project.loadProjectFile();
             TimeProfiler.stop();
 
             TimeProfiler.start("setupProject");

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/CopyBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/CopyBuilder.java
@@ -37,7 +37,7 @@ public abstract class CopyBuilder extends Builder {
     }
 
     @Override
-    public void build(Task task) throws IOException {
+    public void build(Task task) throws IOException, CompileExceptionError {
         IResource in = task.input(0);
         IResource out = task.output(0);
         out.setContent(in.getContent());

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
@@ -2262,7 +2262,7 @@ public class Project {
         TimeProfiler.start("findResourcePathsByExtension");
         TimeProfiler.addData("path", _path);
         TimeProfiler.addData("ext", ext);
-
+        _path = ".".equals(_path) ? "" : _path;
         final String path = Project.stripLeadingSlash(_path);
 
         // Initialize and cache all paths only once

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
@@ -2267,7 +2267,7 @@ public class Project {
         TimeProfiler.start("findResourcePathsByExtension");
         TimeProfiler.addData("path", _path);
         TimeProfiler.addData("ext", ext);
-        _path = ".".equals(_path) ? "" : _path;
+        _path = FilenameUtils.getPath(_path);
         final String path = Project.stripLeadingSlash(_path);
 
         // Initialize and cache all paths only once

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
@@ -2267,7 +2267,10 @@ public class Project {
         TimeProfiler.start("findResourcePathsByExtension");
         TimeProfiler.addData("path", _path);
         TimeProfiler.addData("ext", ext);
-        _path = FilenameUtils.getPath(_path);
+        _path = FilenameUtils.normalize(_path, true);
+        if (_path.startsWith("/")) {
+            _path = _path.substring(1);
+        }
         final String path = Project.stripLeadingSlash(_path);
 
         // Initialize and cache all paths only once

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
@@ -138,9 +138,8 @@ public class Project {
     private List<URL> libUrls = new ArrayList<URL>();
     private List<String> propertyFiles = new ArrayList<>();
     private List<String> buildServerHeaders = new ArrayList<>();
-    private List<String> excludedFilesAndFoldersEntries = new ArrayList<>();
     private List<String> engineBuildDirs = new ArrayList<>();
-
+    private List<String> allResourcePathsCache; // Cache for all resource paths, since Bob doesn't change project files during build
     private BobProjectProperties projectProperties;
     private Publisher publisher;
     private Map<String, Map<Long, IResource>> hashToResource = new HashMap<>();
@@ -167,6 +166,7 @@ public class Project {
         this.fileSystem = fileSystem;
         this.fileSystem.setRootDirectory(rootDirectory);
         this.fileSystem.setBuildDirectory(buildDirectory);
+        this.allResourcePathsCache = null;
         clearProjectProperties();
     }
 
@@ -176,6 +176,7 @@ public class Project {
         this.fileSystem = fileSystem;
         this.fileSystem.setRootDirectory(this.rootDirectory);
         this.fileSystem.setBuildDirectory(this.buildDirectory);
+        this.allResourcePathsCache = null;
         clearProjectProperties();
     }
 
@@ -187,6 +188,7 @@ public class Project {
         this.fileSystem = fileSystem;
         this.fileSystem.setRootDirectory(this.rootDirectory);
         this.fileSystem.setBuildDirectory(this.buildDirectory);
+        this.allResourcePathsCache = null;
         clearProjectProperties();
     }
 
@@ -618,7 +620,7 @@ public class Project {
 
     // Loads the properties from a game project settings file
     // Also adds any properties specified with the "--settings" flag
-    public static BobProjectProperties loadProperties(Project project, IResource projectFile, List<String> settingsFiles) throws IOException {
+    public static BobProjectProperties loadProperties(Project project, IResource projectFile, List<String> settingsFiles, boolean scanExtensions) throws IOException {
         if (!projectFile.exists()) {
             throw new IOException(String.format("Project file not found: %s", projectFile.getAbsPath()));
         }
@@ -627,14 +629,16 @@ public class Project {
         try {
             // load meta.properties embeded in bob.jar
             properties.loadDefaultMetaFile();
-            // load property files from extensions
-            List<String> extensionFolders = ExtenderUtil.getExtensionFolders(project);
-            if (!extensionFolders.isEmpty()) {
-                for (String extension : extensionFolders) {
-                    IResource resource = project.getResource(extension + "/" + BobProjectProperties.PROPERTIES_EXTENSION_FILE);
-                    if (resource.exists()) {
-                        // resources from extensions in ZIP files can't be read as files, but getContent() works fine
-                        loadPropertiesData(properties, resource.getContent(), true, resource.getPath());
+            if (scanExtensions) {
+                // load property files from extensions
+                List<String> extensionFolders = ExtenderUtil.getExtensionFolders(project);
+                if (!extensionFolders.isEmpty()) {
+                    for (String extension : extensionFolders) {
+                        IResource resource = project.getResource(extension + "/" + BobProjectProperties.PROPERTIES_EXTENSION_FILE);
+                        if (resource.exists()) {
+                            // resources from extensions in ZIP files can't be read as files, but getContent() works fine
+                            loadPropertiesData(properties, resource.getContent(), true, resource.getPath());
+                        }
                     }
                 }
             }
@@ -656,10 +660,10 @@ public class Project {
         return properties;
     }
 
-    public void loadProjectFile() throws IOException {
+    public void loadProjectFile(boolean scanExtensions) throws IOException {
         IResource gameProject = getGameProjectResource();
         if (gameProject.exists()) {
-            projectProperties = Project.loadProperties(this, gameProject, this.getPropertyFiles());
+            projectProperties = Project.loadProperties(this, gameProject, this.getPropertyFiles(), scanExtensions);
         }
     }
 
@@ -708,7 +712,7 @@ public class Project {
     public List<TaskResult> build(IProgress monitor, String... commands) throws IOException, CompileExceptionError, MultipleCompileException {
         try {
             TimeProfiler.start("loadProjectFile");
-            loadProjectFile();
+            loadProjectFile(true);
             TimeProfiler.stop();
 
             String title = projectProperties.getStringValue("project", "title");
@@ -2255,29 +2259,37 @@ public class Project {
     }
 
     private void findResourcePathsByExtension(String _path, String ext, Collection<String> result) {
+        TimeProfiler.start("findResourcePathsByExtension");
+        TimeProfiler.addData("path", _path);
+        TimeProfiler.addData("ext", ext);
+
         final String path = Project.stripLeadingSlash(_path);
-        fileSystem.walk(path, new FileSystemWalker() {
-            public void handleFile(String path, Collection<String> results) {
-                boolean shouldAdd = true;
 
-                // Do a first pass on the path to check if it satisfies the ext check
-                if (ext != null) {
-                    shouldAdd = path.endsWith(ext);
+        // Initialize and cache all paths only once
+        if (allResourcePathsCache == null) {
+            List<String> allPaths = new ArrayList<>();
+            fileSystem.walk("", new FileSystemWalker() {
+                public void handleFile(String filePath, Collection<String> results) {
+                    results.add(FilenameUtils.normalize(filePath, true));
                 }
+            }, allPaths);
+            allResourcePathsCache = allPaths;
+        }
 
-                // Ignore for native extensions and the other systems.
-                // Check comment for loadIgnoredFilesAndFolders()
-                for (String prefix : excludedFilesAndFoldersEntries) {
-                    if (path.startsWith(prefix)) {
-                        shouldAdd = false;
-                        break;
-                    }
-                }
-                if (shouldAdd) {
-                    results.add(FilenameUtils.normalize(path, true));
-                }
-            }
-        }, result);
+        // Fast path: if no filter, return everything
+        if ((ext == null || ext.isEmpty()) && (path == null || path.isEmpty())) {
+            result.addAll(allResourcePathsCache);
+            TimeProfiler.stop();
+            return;
+        }
+
+        // Filter the cached list
+        allResourcePathsCache.parallelStream()
+            .filter(p -> (ext == null || p.endsWith(ext)) &&
+                         (path == null || path.isEmpty() || p.startsWith(path)))
+            .forEach(result::add);
+
+        TimeProfiler.stop();
     }
 
     public void findResourcePaths(String _path, Collection<String> result) {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
@@ -363,6 +363,8 @@ public class Project {
                         !className.startsWith("com.dynamo.bob.pipeline.TexcLibrary") &&
                         !className.startsWith("com.dynamo.bob.pipeline.Shaderc") &&
                         !className.startsWith("com.dynamo.bob.pipeline.ModelImporter") &&
+                        // namespaces we don't need to scan
+                        !className.startsWith("com.dynamo.bob.pipeline.antlr") &&
                         // classes we don't need to bob light
                         !(is_bob_light && className.startsWith("com.dynamo.bob.archive.publisher.AWSPublisher")) &&
                         !(is_bob_light && className.startsWith("com.dynamo.bob.pipeline.ExtenderUtil")) &&
@@ -370,6 +372,7 @@ public class Project {
                 .collect(Collectors.toList());
         for (String className : filteredClassNames) {
             try {
+                TimeProfiler.start(className);
                 Class<?> klass = Class.forName(className, true, scanner.getClassLoader());
                 BuilderParams builderParams = klass.getAnnotation(BuilderParams.class);
                 if (builderParams != null) {
@@ -414,6 +417,7 @@ public class Project {
                         pluginClasses.add((Class<? extends IPlugin>) klass);
                     }
                 }
+                TimeProfiler.stop();
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
@@ -192,6 +192,11 @@ public class Project {
         clearProjectProperties();
     }
 
+    // For tests
+    public void cleanupResourcePathsCache() {
+        allResourcePathsCache = null;
+    }
+
     public void dispose() {
         this.fileSystem.close();
     }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/BundleHelper.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/BundleHelper.java
@@ -39,6 +39,7 @@ import java.util.zip.ZipInputStream;
 
 import com.dynamo.bob.archive.publisher.Publisher;
 import com.dynamo.bob.archive.publisher.ZipPublisher;
+import com.dynamo.bob.util.TimeProfiler;
 import com.sun.istack.Nullable;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
@@ -925,11 +926,14 @@ public class BundleHelper {
     }
 
     public static List<File> getPipelinePlugins(Project project, String pluginsDir) {
+        TimeProfiler.start("getPipelinePlugins");
         List<File> files = ExtenderUtil.listFilesRecursive(new File(pluginsDir), ExtenderUtil.JAR_RE);
+        TimeProfiler.stop();
         return files;
     }
 
     public static void extractPipelinePlugins(Project project, String pluginsDir) throws CompileExceptionError {
+        TimeProfiler.start("extractPipelinePlugins");
         List<IResource> sources = new ArrayList<>();
         List<String> extensionFolders = ExtenderUtil.getExtensionFolders(project);
         for (String extension : extensionFolders) {
@@ -942,6 +946,7 @@ public class BundleHelper {
         }
 
         ExtenderUtil.storeResources(new File(pluginsDir), sources);
+        TimeProfiler.stop();
     }
 
     public static boolean isArchiveIncluded(Project project) {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/CollisionObjectBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/CollisionObjectBuilder.java
@@ -1,10 +1,12 @@
 package com.dynamo.bob.pipeline;
 
-
-import com.dynamo.bob.*;
+import com.dynamo.bob.BuilderParams;
+import com.dynamo.bob.CompileExceptionError;
+import com.dynamo.bob.ProtoBuilder;
+import com.dynamo.bob.ProtoParams;
+import com.dynamo.bob.Task;
 import com.dynamo.bob.fs.IResource;
 import com.dynamo.bob.util.BobNLS;
-import com.dynamo.bob.util.StringUtil;
 import com.dynamo.bob.util.MurmurHash;
 import com.dynamo.gamesys.proto.Physics.ConvexShape;
 import com.dynamo.gamesys.proto.Physics.CollisionObjectDesc;

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/CopyBuilders.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/CopyBuilders.java
@@ -28,7 +28,7 @@ public class CopyBuilders {
     @BuilderParams(name = "Wav", inExts = ".wav", outExt = ".wavc", paramsForSignature = {"sound-stream-enabled"})
     public static class WavBuilder extends CopyBuilder {
         @Override
-        public void build(Task task) throws IOException {
+        public void build(Task task) throws IOException, CompileExceptionError {
             super.build(task);
 
             boolean soundStreaming = this.project.option("sound-stream-enabled", "false").equals("true"); // if no value set use old hardcoded path (backward compatability)

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ExtenderUtil.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ExtenderUtil.java
@@ -680,7 +680,7 @@ public class ExtenderUtil {
 
             if (files.containsKey(r.getPath())) {
                 IResource previous = files.get(r.getPath());
-                throw new CompileExceptionError(r, 0, String.format("The files' relative path conflict:\n'%s' and\n'%s", r.getAbsPath(), r.getAbsPath()));
+                throw new CompileExceptionError(r, 0, String.format("The files' relative path conflict:\n'%s' and\n'%s", r.getAbsPath(), previous.getAbsPath()));
             }
             files.put(r.getPath(), r);
         }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/GameProjectBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/GameProjectBuilder.java
@@ -349,7 +349,7 @@ public class GameProjectBuilder extends Builder {
 
         IResource input = task.input(0);
 
-        BobProjectProperties properties = Project.loadProperties(project, input, project.getPropertyFiles());
+        BobProjectProperties properties = Project.loadProperties(project, input, project.getPropertyFiles(), true);
         final String root = FilenameUtils.concat(project.getRootDirectory(), project.getBuildDirectory());
 
         try {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/OpusBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/OpusBuilder.java
@@ -31,7 +31,7 @@ import com.dynamo.bob.Project;
 import com.dynamo.bob.Task;
 import com.dynamo.bob.fs.IResource;
 
-@BuilderParams(name = "Opus", inExts = ".opus", outExt = ".opusc")
+@BuilderParams(name = "Opus", inExts = ".opus", outExt = ".opusc", paramsForSignature = {"sound-stream-enabled"})
 public class OpusBuilder extends CopyBuilder{
     private static String oggzValidateExePath;
 
@@ -63,7 +63,7 @@ public class OpusBuilder extends CopyBuilder{
     }
 
     @Override
-    public void build(Task task) throws IOException {
+    public void build(Task task) throws IOException, CompileExceptionError {
         super.build(task);
 
         boolean soundStreaming = project.getProjectProperties().getBooleanValue("sound", "stream_enabled", false); // if no value set use old hardcoded path (backward compatability)

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ProtoBuilders.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ProtoBuilders.java
@@ -172,7 +172,16 @@ public class ProtoBuilders {
 
     @ProtoParams(srcClass = GamepadMaps.class, messageClass = GamepadMaps.class)
     @BuilderParams(name="GamepadMaps", inExts=".gamepads", outExt=".gamepadsc")
-    public static class GamepadMapsBuilder extends ProtoBuilder<GamepadMaps.Builder> {}
+    public static class GamepadMapsBuilder extends ProtoBuilder<GamepadMaps.Builder> {
+        @Override
+        public Task create(IResource input) throws IOException, CompileExceptionError {
+            Task.TaskBuilder taskBuilder = Task.newBuilder(this)
+                    .setName(params.name())
+                    .addInput(input)
+                    .addOutput(input.changeExt(params.outExt()));
+            return taskBuilder.build();
+        }
+    }
 
     @ProtoParams(srcClass = RenderTargetDesc.class, messageClass = RenderTargetDesc.class)
     @BuilderParams(name="RenderTarget", inExts=".render_target", outExt=".render_targetc")

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/BobProjectProperties.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/BobProjectProperties.java
@@ -537,7 +537,7 @@ public class BobProjectProperties {
         int cursor = 0;
         String line = reader.readLine();
         while (line != null) {
-            line.trim();
+            line = line.trim();
             if (line.startsWith("[")) {
                 if (!line.endsWith("]")) {
                     throw new ParseException("invalid category: " + line, cursor);


### PR DESCRIPTION
This fix speeds up Bob.jar initialization, which is especially useful for sequential builds without many changes (e.g. Cmd+M to Build HTML5 from the editor, or bundling).  
* About 4 times faster initialization. In the test setup, it's 400 ms vs 1600 ms (for a project with a large file count, it's 3.5 s vs 20 s)  
* Speed-up of the task creation stage for a small project in the test setup: 900 ms vs 2000 ms (for a large project, about 5%)

Fix https://github.com/defold/defold/issues/10854

# Technical details


## `findResourcePaths`
Reading through the code, `findResourcePaths` appears suspicious.  
A dedicated scope in the build time profiler, highlighted in green, shows the usage of this function and the time it takes.

<img width="2878" height="1436" alt="CleanShot 2025-07-15 at 14 34 52@2x" src="https://github.com/user-attachments/assets/6d6c4bc8-7e61-459c-9298-4b5dbc0415bb" />
Profiler shows that `findResourcePaths` is called multiple times, each time scanning the file system.  
The `findResourcePaths()` method internally calls `findResourcePathsByExtension()`, where a file extension can be specified.  
In this test project, that function is called 7+ times, resulting in at least 20 full scan operations during a build (depending on project setup).

Given that `bob.jar` doesn’t modify the project folder during the build, it makes sense to scan the disk once and reuse the results.  
A cache was implemented at the `findResourcePathsByExtension()` level to avoid redundant scans.

**Result**:  
This change significantly speeds up the build process — about 5x faster for the test project.

<img width="2896" height="1866" alt="CleanShot 2025-07-15 at 17 09 06@2x" src="https://github.com/user-attachments/assets/6e422ddb-7161-4cbd-8768-4dcac372678e" />

## doScan
Further investigation shows that our Java class scanner calls all the static initializers, which isn't necessary at this stage.  
Excluding such classes from the scan stage helped reduce `doScan` time by 2x — from about 1s to 300–500 ms.  
Excluding the `com.dynamo.bob.pipeline.antlr` namespace further reduced scan time to about 160–230 ms.

## Ogg Validation
The Defold build pipeline has two main stages: task creation and task building.  
Profiling showed anomalously long creation times for `.ogg` files. Investigation revealed that `.ogg` validation occurred during the task creation stage, which is unnecessary.  
Moving validation to the task building stage saved about 500 ms during creation — important for sequential builds.

## Various Optimizations
- By default, we have a fairly large gamepads file that doesn't reference other resources.  
  Calling `createSubTasks` on it was a waste of time. Overriding the default `create` method saved about 120 ms on each iterative build.
- Lua parser is one of the heaviest operations during task creation.  
  Small improvements in the parser reduced parsing time by about 10%.

**Result**:  
All these improvements helped reduce sequential build time on a test project from **3.6s to 1.4s** (on average).
