### PR TITLE
Change Android bundling process to be compatible with the new "Support 16 KB page sizes" requirement.

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/AndroidBundler.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/AndroidBundler.java
@@ -701,6 +701,7 @@ public class AndroidBundler implements IBundler {
     /**
     * Build the app bundle using bundletool
     * https://developer.android.com/studio/build/building-cmdline#build_your_app_bundle_using_bundletool
+    * https://github.com/google/bundletool/blob/master/src/main/proto/config.proto
     */
     private static File createBundle(Project project, File outDir, File baseZip, ICanceled canceled) throws CompileExceptionError {
         logger.info("Creating Android Application Bundle");

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
@@ -568,7 +568,7 @@ proguard.default =
 
 extract_native_libs.type = bool
 extract_native_libs.help = This attribute indicates whether the package installer extracts native libraries from the APK to the file system 
-extract_native_libs.default = 1
+extract_native_libs.default = 0
 
 [osx]
 help = Mac OSX related settings

--- a/editor/resources/meta.edn
+++ b/editor/resources/meta.edn
@@ -797,7 +797,7 @@
    :path ["android" "proguard"]}
   {:type :boolean,
    :help "This attribute indicates whether the package installer extracts native libraries from the APK to the file system",
-   :default true,
+   :default false,
    :path ["android" "extract_native_libs"]}
   {:type :resource,
    :filter "icns",


### PR DESCRIPTION
⚠️ This fix changes the default for `android.extract_native_libs` to `false`, which is a requirement for API 35.  
It will increase your AAB/APK size, but according to https://developer.android.com/studio/debug/apk-analyzer,  
it doesn't affect the download size from the Play Store, because it uses its own compression:
<img width="1788" height="796" alt="CleanShot 2025-07-18 at 15 26 17@2x" src="https://github.com/user-attachments/assets/0d8b405d-3bde-4f58-ab67-662e866e6e9f" />


Fix https://github.com/defold/defold/issues/10976

# Technical changes

Bundle tool updated to the latest at the moment https://github.com/google/bundletool/releases/tag/1.18.1 version
In version 1.15.1 alignment for `*.so` in archives were introduced with default 16kb : https://github.com/google/bundletool/commit/0b00e4a8d3129cdfa2a98119fe7a3373ff49cdd3#diff-285d19cf023954460f3466b1efa792eea6b66cf787f52547c1cd5fe206811e0a

<img width="2382" height="1180" alt="CleanShot 2025-07-18 at 15 15 24@2x" src="https://github.com/user-attachments/assets/44b8bf68-8aac-4e29-aaa9-6bfde24a7d48" />


Another change is change of Default for `extract_native_libs` in android, which is another requirement: 
https://developer.android.com/guide/practices/page-sizes#agp_version_85_or_lower