### PR TITLE
Improve responsiveness when typing a filter term in the Asset Picker

### DIFF
--- a/editor/src/clj/editor/dialogs.clj
+++ b/editor/src/clj/editor/dialogs.clj
@@ -23,6 +23,7 @@
             [cljfx.fx.list-cell :as fx.list-cell]
             [cljfx.fx.list-view :as fx.list-view]
             [cljfx.fx.progress-bar :as fx.progress-bar]
+            [cljfx.fx.progress-indicator :as fx.progress-indicator]
             [cljfx.fx.region :as fx.region]
             [cljfx.fx.scene :as fx.scene]
             [cljfx.fx.v-box :as fx.v-box]
@@ -38,7 +39,9 @@
             [editor.progress :as progress]
             [editor.ui :as ui]
             [editor.util :as util]
-            [service.log :as log])
+            [service.log :as log]
+            [util.coll :as coll]
+            [util.thread-util :as thread-util])
   (:import [clojure.lang Named]
            [java.io File]
            [java.nio.file Path Paths]
@@ -505,10 +508,13 @@
       (.showDialog owner-window)))
 
 (defn- default-filter-fn [filter-on text items]
-  (let [text (string/lower-case text)]
-    (filterv (fn [item]
-               (string/starts-with? (string/lower-case (filter-on item)) text))
-             items)))
+  (if (coll/empty? text)
+    items
+    (let [text (string/lower-case text)]
+      (filterv (fn [item]
+                 (thread-util/throw-if-interrupted!)
+                 (string/starts-with? (string/lower-case (filter-on item)) text))
+               items))))
 
 (def ext-with-identity-items-props
   (fx/make-ext-with-props
@@ -531,7 +537,7 @@
                               (.put properties "isDefaultAnchor" true)))))))
 
 (defn- select-list-dialog
-  [{:keys [filter-term filtered-items title ok-label prompt cell-fn selection owner]
+  [{:keys [filter-term filtered-items filter-in-progress title ok-label prompt cell-fn selection owner]
     :as props}]
   {:fx/type dialog-stage
    :title title
@@ -555,20 +561,28 @@
                                   :fixed-cell-size 27
                                   :cell-factory {:fx/cell-type fx.list-cell/lifecycle
                                                  :describe cell-fn}}}}}
-   :footer {:fx/type dialog-buttons
-            :children [{:fx/type fxui/button
-                        :text ok-label
-                        :variant :primary
-                        :disable (zero? (count filtered-items))
-                        :on-action {:event-type :confirm}
-                        :default-button true}]}})
+   :footer {:fx/type fx.h-box/lifecycle
+            :alignment :center-left
+            :children [{:fx/type fx.progress-indicator/lifecycle
+                        :h-box/hgrow :never
+                        :pref-width 32.0
+                        :pref-height 32.0
+                        :visible filter-in-progress}
+                       {:fx/type dialog-buttons
+                        :h-box/hgrow :always
+                        :children [{:fx/type fxui/button
+                                    :text ok-label
+                                    :variant :primary
+                                    :disable (zero? (count filtered-items))
+                                    :on-action {:event-type :confirm}
+                                    :default-button true}]}]}})
 
 (defn- wrap-cell-fn [f]
   (fn [item]
     (when (some? item)
       (assoc (f item) :on-mouse-clicked {:event-type :select-item-on-double-click}))))
 
-(defn- select-list-dialog-event-handler [filter-fn items]
+(defn- select-list-dialog-event-handler [set-filter-term-fn]
   (fn [state event]
     (case (:event-type event)
       :cancel (assoc state ::fxui/result nil)
@@ -620,12 +634,8 @@
                                   KeyCode/ESCAPE (recur state (assoc event :event-type :cancel))
                                   state))
                               state))
-      :set-filter-term (let [term (:fx/event event)
-                             filtered-items (vec (filter-fn term items))]
-                         (assoc state
-                           :filter-term term
-                           :filtered-items filtered-items
-                           :selected-indices (if (seq filtered-items) [0] []))))))
+      :set-filter-term (let [filter-term (:fx/event event)]
+                         (set-filter-term-fn state filter-term)))))
 
 (defn make-select-list-dialog
   "Show dialog that allows the user to select one or many of the suggested items
@@ -660,12 +670,44 @@
          filter-term (or (:filter options)
                          (some-> filter-atom deref)
                          "")
-         initial-filtered-items (vec (filter-fn filter-term items))
+         filter-future-atom (atom nil)
+         state-atom (atom {:filter-term ""
+                           :filter-in-progress false
+                           :filtered-items []
+                           :selected-indices []})
+
+         set-filter-term
+         (fn set-filter-term [state filter-term]
+           (if (= (:filter-term state) filter-term)
+             state
+             (do (swap! filter-future-atom
+                        (fn [pending-filter-future]
+                          (thread-util/cancel-future! pending-filter-future)
+                          (future
+                            (try
+                              (let [filtered-items (vec (filter-fn filter-term items))
+                                    selected-indices (if (coll/empty? filtered-items) [] [0])]
+                                (thread-util/throw-if-interrupted!)
+                                (swap! state-atom
+                                       (fn [state]
+                                         (thread-util/throw-if-interrupted!)
+                                         (assoc state
+                                           :filter-in-progress false
+                                           :filtered-items filtered-items
+                                           :selected-indices selected-indices))))
+                              (catch InterruptedException _
+                                nil)
+                              (catch Throwable error
+                                (error-reporting/report-exception! error))))))
+                 (assoc state
+                   :filter-term filter-term
+                   :filter-in-progress true))))
+
+         _ (swap! state-atom set-filter-term filter-term)
+         event-handler (select-list-dialog-event-handler set-filter-term)
          result (fxui/show-dialog-and-await-result!
-                  :initial-state {:filter-term filter-term
-                                  :filtered-items initial-filtered-items
-                                  :selected-indices (if (seq initial-filtered-items) [0] [])}
-                  :event-handler (select-list-dialog-event-handler filter-fn items)
+                  :state-atom state-atom
+                  :event-handler event-handler
                   :description {:fx/type select-list-dialog
                                 :title (:title options "Select Item")
                                 :ok-label (:ok-label options "OK")
@@ -673,6 +715,7 @@
                                 :cell-fn cell-fn
                                 :owner (or (:owner options) (ui/main-stage))
                                 :selection (:selection options :single)})]
+     (swap! filter-future-atom thread-util/cancel-future!)
      (when result
        (let [{:keys [filter-term selected-items]} result]
          (when (and filter-atom selected-items)

--- a/editor/src/clj/editor/fxui.clj
+++ b/editor/src/clj/editor/fxui.clj
@@ -385,13 +385,17 @@
                       and pass it resulting props to check if dialog stage's
                       :showing property should be set to true
     :initial-state    optional, defaults to {}, map containing initial state of
-                      a dialog, should not contain ::result key to be shown
+                      a dialog, should not contain ::result key to be shown. The
+                      map will be put into a private state-atom accessible from
+                      the event-handler.
+    :state-atom       optional, will be used instead of initial-state when you
+                      need to access the state from outside of this function.
     :error-handler    optional, 1-arg Throwable handler, by default it shows an
                       error dialog and reports the exception to sentry"
-  [& {:keys [initial-state event-handler description error-handler]
-      :or {initial-state {}
-           error-handler error-reporting/report-exception!}}]
-  (let [state-atom (atom initial-state)
+  [& {:keys [state-atom initial-state event-handler description error-handler]
+      :or {error-handler error-reporting/report-exception!}}]
+  (let [state-atom (or state-atom
+                       (atom (or initial-state {})))
         renderer (fx/create-renderer
                    :error-handler error-handler
                    :opts {:fx.opt/map-event-handler #(swap! state-atom event-handler %)}

--- a/editor/src/clj/editor/resource_dialog.clj
+++ b/editor/src/clj/editor/resource_dialog.clj
@@ -25,7 +25,8 @@
             [editor.ui.fuzzy-choices :as fuzzy-choices]
             [editor.workspace :as workspace]
             [internal.graph.types :as gt]
-            [util.fn :as fn]))
+            [util.fn :as fn]
+            [util.thread-util :as thread-util]))
 
 (def ^:private fuzzy-resource-filter-fn (partial fuzzy-choices/filter-options resource/proj-path resource/proj-path))
 
@@ -33,11 +34,13 @@
   (let [project-resources
         (into []
               (comp
+                (map thread-util/abortable-identity!)
                 (map #(resource-node/resource basis %))
                 (filter (fn [resource]
                           (and (some? (resource/proj-path resource))
                                (resource/exists? resource)))))
               resource-node-ids)]
+    (thread-util/throw-if-interrupted!)
     (sort-by resource/proj-path project-resources)))
 
 (defn- node-ids->owner-resource-node-ids [basis node-ids]
@@ -55,6 +58,7 @@
             nodes-we-depend-on
             (into #{}
                   (comp
+                    (map thread-util/abortable-identity!)
                     (mapcat #(g/explicit-arcs-by-target basis %))
                     (map gt/source-id))
                   nodes-in-resource)
@@ -81,6 +85,7 @@
             nodes-that-depend-on-us
             (into #{}
                   (comp
+                    (map thread-util/abortable-identity!)
                     (mapcat #(g/explicit-arcs-by-source basis %))
                     (map gt/target-id))
                   all-overrides-of-nodes-in-resource)
@@ -115,8 +120,10 @@
                                          (accept-fn %)))
                            (g/node-value workspace :resource-list))
         tooltip-gen (:tooltip-gen options)
+        special-filter-fns {"refs" (partial refs-filter-fn project)
+                            "deps" (partial deps-filter-fn project)}
         options (-> {:title "Select Resource"
-                     :cell-fn (fn [r]
+                     :cell-fn (fn cell-fn [r]
                                 (let [text (resource/proj-path r)
                                       icon (workspace/resource-icon r)
                                       tooltip (when tooltip-gen (tooltip-gen r))
@@ -128,14 +135,12 @@
                                                      :matching-indices matching-indices}}
                                           tooltip
                                           (assoc :tooltip tooltip))))
-                     :filter-fn (fn [filter-value items]
-                                  (let [fns {"refs" (partial refs-filter-fn project)
-                                             "deps" (partial deps-filter-fn project)}
-                                        [command arg] (let [parts (string/split filter-value #":")]
+                     :filter-fn (fn filter-fn [filter-value items]
+                                  (let [[command arg] (let [parts (string/split filter-value #":")]
                                                         (if (< 1 (count parts))
                                                           parts
                                                           [nil (first parts)]))
-                                        f (get fns command fuzzy-resource-filter-fn)]
+                                        f (get special-filter-fns command fuzzy-resource-filter-fn)]
                                     (f arg items)))}
                     (merge options))]
     (dialogs/make-select-list-dialog items options)))

--- a/editor/src/clj/util/thread_util.clj
+++ b/editor/src/clj/util/thread_util.clj
@@ -30,6 +30,25 @@
   (throw-if-interrupted!)
   value)
 
+(defn thread-uninterrupted-predicate
+  "Returns a predicate function that takes a single value, ignores it, and
+  returns false if the specified thread has been interrupted. If no thread is
+  supplied, defaults to the calling thread."
+  ([]
+   (thread-uninterrupted-predicate (Thread/currentThread)))
+  ([^Thread thread]
+   {:pre [(instance? Thread thread)]}
+   (fn thread-uninterrupted? [_]
+     (not (.isInterrupted thread)))))
+
+(defn cancel-future!
+  "Cancels the supplied future. Does nothing if called with nil or a future that
+  was already cancelled. Always returns nil."
+  [future]
+  (when future
+    (future-cancel future)
+    nil))
+
 (defn preset!
   "Sets the value of atom to newval without regard for the current value.
   Returns the previous value that was in atom before newval was swapped in."

--- a/editor/styling/stylesheets/dialogs.sass
+++ b/editor/styling/stylesheets/dialogs.sass
@@ -3,6 +3,7 @@
 @import '_dialogs'
 @import 'components/_check-box'
 @import 'components/_combo-box'
+@import 'components/_progress-indicator'
 @import 'components/_tabs-dialogs'
 @import 'components/_text-field'
 @import 'components/_tooltip'


### PR DESCRIPTION
Filterable item list dialogs like the Open Asset dialog will now remain responsive while the list is filtered. A progress indicator in the bottom-left of the dialog indicates that we're still awaiting results from the search.

Fixes #10739
