### PR TITLE
Fix issue with search in path cache.

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/BundleResourcesTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/BundleResourcesTest.java
@@ -191,7 +191,6 @@ public class BundleResourcesTest {
         assertTrue(resourceMap.containsKey("test.txt"));
 
         project.getProjectProperties().putStringValue("project", "bundle_resources", "/restest2");
-        project.cleanupResourcePathsCache();
         resourceMap = ExtenderUtil.collectBundleResources(project, Arrays.asList(Platform.getHostPlatform()));
         assertEquals(3, resourceMap.size());
     }
@@ -228,14 +227,12 @@ public class BundleResourcesTest {
 
         // Exclude the conflicting file from bundle_resources
         project.getProjectProperties().putStringValue("project", "bundle_exclude_resources", "/restest1/common/collision.txt");
-        project.cleanupResourcePathsCache();
         Map<String, IResource> resourceMap = ExtenderUtil.collectBundleResources(project, Arrays.asList(Platform.getHostPlatform()));
         assertEquals(3, resourceMap.size());
         assertTrue(resourceMap.containsKey("collision.txt"));
 
         // Exclude the conflicting file from extension
         project.getProjectProperties().putStringValue("project", "bundle_exclude_resources", "/extension1/res/common/collision.txt");
-        project.cleanupResourcePathsCache();
         resourceMap = ExtenderUtil.collectBundleResources(project, Arrays.asList(Platform.getHostPlatform()));
         assertEquals(3, resourceMap.size());
         assertTrue(resourceMap.containsKey("collision.txt"));
@@ -331,7 +328,6 @@ public class BundleResourcesTest {
             Platform expectedPlatform = entry.getKey();
             String[] expectedFiles = entry.getValue();
 
-            project.cleanupResourcePathsCache();
             Map<String, IResource> resourceMap = ExtenderUtil.collectBundleResources(project, Arrays.asList(expectedPlatform));
 
             // +3 size since collision.txt, common.txt subdir/subdirtest.txt always included.

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/ProjectTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/ProjectTest.java
@@ -122,6 +122,7 @@ public class ProjectTest {
         libraryUrls.add(new URL("http://localhost:8081/test_lib2.zip"));
         libraryUrls.add(new URL("http://" + BASIC_AUTH + "@localhost:8081/test_lib5.zip"));
         libraryUrls.add(new URL("http://" + BASIC_AUTH_ENV_TOKEN + "@localhost:8081/test_lib6.zip"));
+        libraryUrls.add(new URL("http://localhost:8081/test.zip"));
 
         fileSystem = new MockFileSystem();
         project = new MockProject(fileSystem, Files.createTempDirectory("defold_").toString(), "build/default");
@@ -254,7 +255,7 @@ public class ProjectTest {
         results = filterBuiltins(results);
 
         assertFalse(results.isEmpty());
-        assertEquals(6, results.size());
+        assertEquals(7, results.size());
         System.out.printf("end");
     }
 
@@ -283,6 +284,31 @@ public class ProjectTest {
         assertTrue(results.contains("testdir2"));
         System.out.printf("end");
     }
+
+//    @Test
+//    public void testAllResourcePathsCacheLibrary() throws Exception {
+//        System.out.printf("testTestZipLibrary start");
+//        project.resolveLibUrls(new NullProgress());
+//        project.mount(new ClassLoaderResourceScanner());
+//        project.setInputs(Arrays.asList("test/file.in", "builtins/cp_test.in"));
+//        List<TaskResult> results = build("resolve", "build");
+//        assertEquals(2, results.size());
+//        for (TaskResult result : results) {
+//            assertTrue(result.isOk());
+//        }
+//
+//        ArrayList<String> pathResults = new ArrayList<String>();
+//        project.findResourcePaths("/test_non", pathResults);
+//        assertEquals(0, pathResults.size());
+//
+//        ArrayList<String> pathResults1 = new ArrayList<String>();
+//        project.findResourcePaths("/test/file.in", pathResults1);
+//        assertEquals(1, pathResults1.size());
+//
+//        ArrayList<String> pathResults2 = new ArrayList<String>();
+//        project.findResourcePaths("/test", pathResults2);
+//        assertEquals(1, pathResults2.size());
+//    }
 
     private class FileHandler extends ResourceHandler {
         public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException ,javax.servlet.ServletException {

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/ProjectTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/ProjectTest.java
@@ -285,30 +285,29 @@ public class ProjectTest {
         System.out.printf("end");
     }
 
-//    @Test
-//    public void testAllResourcePathsCacheLibrary() throws Exception {
-//        System.out.printf("testTestZipLibrary start");
-//        project.resolveLibUrls(new NullProgress());
-//        project.mount(new ClassLoaderResourceScanner());
-//        project.setInputs(Arrays.asList("test/file.in", "builtins/cp_test.in"));
-//        List<TaskResult> results = build("resolve", "build");
-//        assertEquals(2, results.size());
-//        for (TaskResult result : results) {
-//            assertTrue(result.isOk());
-//        }
-//
-//        ArrayList<String> pathResults = new ArrayList<String>();
-//        project.findResourcePaths("/test_non", pathResults);
-//        assertEquals(0, pathResults.size());
-//
-//        ArrayList<String> pathResults1 = new ArrayList<String>();
-//        project.findResourcePaths("/test/file.in", pathResults1);
-//        assertEquals(1, pathResults1.size());
-//
-//        ArrayList<String> pathResults2 = new ArrayList<String>();
-//        project.findResourcePaths("/test", pathResults2);
-//        assertEquals(1, pathResults2.size());
-//    }
+    @Test
+    public void testAllResourcePathsCacheLibrary() throws Exception {
+        project.resolveLibUrls(new NullProgress());
+        project.mount(new ClassLoaderResourceScanner());
+        project.setInputs(Arrays.asList("test/file.in", "builtins/cp_test.in"));
+        List<TaskResult> results = build("resolve", "build");
+        assertEquals(2, results.size());
+        for (TaskResult result : results) {
+            assertTrue(result.isOk());
+        }
+
+        ArrayList<String> pathResults = new ArrayList<String>();
+        project.findResourcePaths("/test_non", pathResults);
+        assertEquals(0, pathResults.size());
+
+        ArrayList<String> pathResults1 = new ArrayList<String>();
+        project.findResourcePaths("/test/file.in", pathResults1);
+        assertEquals(1, pathResults1.size());
+
+        ArrayList<String> pathResults2 = new ArrayList<String>();
+        project.findResourcePaths("/test", pathResults2);
+        assertEquals(1, pathResults2.size());
+    }
 
     private class FileHandler extends ResourceHandler {
         public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException ,javax.servlet.ServletException {

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/TestLibrariesRule.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/TestLibrariesRule.java
@@ -61,6 +61,21 @@ public class TestLibrariesRule extends ExternalResource {
         out.close();
     }
 
+    void createTestLib(String root, String sha1) throws IOException {
+        File file = new File(String.format("%s/test.zip", root));
+        ZipOutputStream out = new ZipOutputStream(new FileOutputStream(file));
+        out.setComment(sha1);
+        ZipEntry ze;
+
+        createEntry(out, "game.project", "[library]\ninclude_dirs=test".getBytes());
+        createEntry(out, "test/", null);
+        createEntry(out, "test/testdir1/", null);
+        createEntry(out, "test/testdir2/", null);
+        createEntry(out, "test/file.in", "testfile".getBytes());
+
+        out.close();
+    }
+
     @Override
     protected void before() throws Throwable {
         serverLocation = new File("server_root");
@@ -71,6 +86,7 @@ public class TestLibrariesRule extends ExternalResource {
         createLib(serverLocation.getAbsolutePath(), "subdir/second/", "4", "444");
         createLib(serverLocation.getAbsolutePath(), "", "5", "555");
         createLib(serverLocation.getAbsolutePath(), "", "6", "666");
+        createTestLib(serverLocation.getAbsolutePath(), "test123");
     }
 
     @Override


### PR DESCRIPTION
Since we don't work with path themselves but with strings, the logic that search in cache strings should take into account corner cases like it isn't enough to check `.startwith` path `test` when you are checking `test_folder/path.file`.

Tests also added