### PR TITLE
Fix leaks in `sys.*` module on iOS and macOS

### DIFF
--- a/engine/resource/src/resource_mounts.cpp
+++ b/engine/resource/src/resource_mounts.cpp
@@ -171,6 +171,7 @@ static dmResource::Result RemoveMountByIndexInternal(HContext ctx, uint32_t inde
     if (index >= ctx->m_Mounts.Size())
         return dmResource::RESULT_RESOURCE_NOT_FOUND;
 
+    free((void*)ctx->m_Mounts[index].m_Name);
     ctx->m_Mounts.EraseSwap(index); // TODO: We'd like an Erase() function in dmArray, to keep the internal ordering
     SortMounts(ctx->m_Mounts);
 


### PR DESCRIPTION
Fixed a couple of leaks in the `sys.*` module, and freed memory allocated for a mount name upon unmount.