### PR TITLE
Fixed crash when a material constant was used in a cloned node but the prototype node had been removed

### DIFF
--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -268,6 +268,34 @@ namespace dmGameSystem
         }
     }
 
+    static void* CloneRenderConstantsCallback(void* node_render_constants)
+    {
+        HComponentRenderConstants src_constants = (HComponentRenderConstants) node_render_constants;
+        if (!src_constants)
+        {
+            return 0x0;
+        }
+
+        HComponentRenderConstants cloned_constants = dmGameSystem::CreateRenderConstants();
+        
+        uint32_t count = dmGameSystem::GetRenderConstantCount(src_constants);
+        for (uint32_t i = 0; i < count; ++i)
+        {
+            dmRender::HConstant constant = dmGameSystem::GetRenderConstant(src_constants, i);
+            dmhash_t name_hash = dmRender::GetConstantName(constant);
+            
+            uint32_t num_values;
+            dmVMath::Vector4* values = dmRender::GetConstantValues(constant, &num_values);
+            
+            if (values)
+            {
+                dmGameSystem::SetRenderConstant(cloned_constants, name_hash, values, num_values);
+            }
+        }
+        
+        return cloned_constants;
+    }
+
     static bool SetMaterialPropertyCallback(void* ctx, dmGui::HScene scene, dmGui::HNode node, dmhash_t property_id, const dmGameObject::PropertyVar& property_var, const dmGameObject::PropertyOptions* options)
     {
         GuiComponent* gui_component  = (GuiComponent*) ctx;
@@ -950,6 +978,7 @@ namespace dmGameSystem
         scene_params.m_SetMaterialPropertyCallback = SetMaterialPropertyCallback;
         scene_params.m_SetMaterialPropertyCallbackContext = gui_component;
         scene_params.m_DestroyRenderConstantsCallback = DestroyRenderConstantsCallback;
+        scene_params.m_CloneRenderConstantsCallback = CloneRenderConstantsCallback;
         scene_params.m_OnWindowResizeCallback = &OnWindowResizeCallback;
 
         scene_params.m_NewTextureResourceCallback    = &NewTextureResourceCallback;

--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -393,6 +393,7 @@ namespace dmGui
         scene->m_SetMaterialPropertyCallback = params->m_SetMaterialPropertyCallback;
         scene->m_SetMaterialPropertyCallbackContext = params->m_SetMaterialPropertyCallbackContext;
         scene->m_DestroyRenderConstantsCallback = params->m_DestroyRenderConstantsCallback;
+        scene->m_CloneRenderConstantsCallback = params->m_CloneRenderConstantsCallback;
         scene->m_OnWindowResizeCallback = params->m_OnWindowResizeCallback;
         scene->m_NewTextureResourceCallback = params->m_NewTextureResourceCallback;
         scene->m_DeleteTextureResourceCallback = params->m_DeleteTextureResourceCallback;
@@ -4269,6 +4270,19 @@ namespace dmGui
         out_n->m_Node.m_ResetPointProperties = 0;
         if (n->m_Node.m_Text != 0x0)
             out_n->m_Node.m_Text = strdup(n->m_Node.m_Text);
+        
+        // Handle render constants - clone them if callback is available and source has them
+        if (n->m_Node.m_RenderConstants && scene->m_CloneRenderConstantsCallback)
+        {
+            out_n->m_Node.m_RenderConstants = scene->m_CloneRenderConstantsCallback(n->m_Node.m_RenderConstants);
+            out_n->m_Node.m_RenderConstantsHash = n->m_Node.m_RenderConstantsHash;
+        }
+        else
+        {
+            // Ensure cloned nodes don't share the pointer if no callback available
+            out_n->m_Node.m_RenderConstants = 0x0;
+            out_n->m_Node.m_RenderConstantsHash = 0;
+        }
         out_n->m_NameHash = dmHashString64(name);
         out_n->m_Version = version;
         out_n->m_Index = index;

--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -4279,7 +4279,6 @@ namespace dmGui
         }
         else
         {
-            // Ensure cloned nodes don't share the pointer if no callback available
             out_n->m_Node.m_RenderConstants = 0x0;
             out_n->m_Node.m_RenderConstantsHash = 0;
         }

--- a/engine/gui/src/gui.h
+++ b/engine/gui/src/gui.h
@@ -157,6 +157,11 @@ namespace dmGui
     typedef void (*DestroyRenderConstantsCallback)(void* render_constants);
 
     /**
+     * Callback to clone render constants
+     */
+    typedef void* (*CloneRenderConstantsCallback)(void* render_constants);
+
+    /**
      * Callback to create a texture resource
      */
     typedef HTextureSource (*NewTextureResourceCallback)(HScene scene, const dmhash_t path_hash, uint32_t width, uint32_t height, dmImage::Type type, const void* buffer);
@@ -203,6 +208,7 @@ namespace dmGui
         SetMaterialPropertyCallback    m_SetMaterialPropertyCallback;
         void*                          m_SetMaterialPropertyCallbackContext;
         DestroyRenderConstantsCallback m_DestroyRenderConstantsCallback;
+        CloneRenderConstantsCallback   m_CloneRenderConstantsCallback;
         FetchTextureSetAnimCallback    m_FetchTextureSetAnimCallback;
         OnWindowResizeCallback         m_OnWindowResizeCallback;
         NewTextureResourceCallback     m_NewTextureResourceCallback;

--- a/engine/gui/src/gui_private.h
+++ b/engine/gui/src/gui_private.h
@@ -296,6 +296,7 @@ namespace dmGui
         SetMaterialPropertyCallback           m_SetMaterialPropertyCallback;
         void*                                 m_SetMaterialPropertyCallbackContext;
         DestroyRenderConstantsCallback        m_DestroyRenderConstantsCallback;
+        CloneRenderConstantsCallback          m_CloneRenderConstantsCallback;
         NewTextureResourceCallback            m_NewTextureResourceCallback;
         DeleteTextureResourceCallback         m_DeleteTextureResourceCallback;
         SetTextureResourceCallback            m_SetTextureResourceCallback;


### PR DESCRIPTION
This fix creates a separate material constant buffer for cloned nodes. This not only fixes the crash when the prototype node is removed, but also makes it possible to use independent values per cloned node.

Fix https://github.com/defold/defold/issues/11011