### PR TITLE
An attempt to create an atlas bigger than 16384x16384 throws an error

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/textureset/test/TextureSetGeneratorTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/textureset/test/TextureSetGeneratorTest.java
@@ -26,6 +26,7 @@ import java.util.List;
 
 import org.junit.Test;
 
+import com.dynamo.bob.CompileExceptionError;
 import com.dynamo.bob.pipeline.AtlasUtil.MappedAnimDesc;
 import com.dynamo.bob.pipeline.AtlasUtil.MappedAnimIterator;
 import com.dynamo.bob.textureset.TextureSetGenerator;
@@ -59,7 +60,7 @@ public class TextureSetGeneratorTest {
     }
 
     @Test
-    public void test1() {
+    public void test1() throws CompileExceptionError {
         List<BufferedImage> images =
                 Arrays.asList(newImage(16, 16),
                               newImage(16, 16),
@@ -189,7 +190,7 @@ public class TextureSetGeneratorTest {
     }
 
     @Test
-    public void testRotatedAnimations() {
+    public void testRotatedAnimations() throws CompileExceptionError {
         List<BufferedImage> images = Arrays.asList(newImage(64,32), newImage(64,32), newImage(32,64), newImage(32,64));
 
         List<String> ids = Arrays.asList("1", "2", "3", "4");

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/textureset/test/TextureSetLayoutTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/textureset/test/TextureSetLayoutTest.java
@@ -27,6 +27,7 @@ import java.util.List;
 
 import org.junit.Test;
 
+import com.dynamo.bob.CompileExceptionError;
 import com.dynamo.bob.textureset.TextureSetLayout;
 import com.dynamo.bob.textureset.TextureSetLayout.Layout;
 import com.dynamo.bob.textureset.TextureSetLayout.Rect;
@@ -42,20 +43,20 @@ public class TextureSetLayoutTest {
         assertThat(r.getY(), is(y));
     }
 
-    private static List<Layout> packedLayout(int margin, List<Rect> rectangles) {
+    private static List<Layout> packedLayout(int margin, List<Rect> rectangles) throws CompileExceptionError {
         return TextureSetLayout.packedLayout(margin, rectangles, true, 0, 0);
     }
 
-    private static List<Layout> packedLayoutPaged(int margin, List<Rect> rectangles, float maxPageSizeW, float maxPageSizeH) {
+    private static List<Layout> packedLayoutPaged(int margin, List<Rect> rectangles, float maxPageSizeW, float maxPageSizeH) throws CompileExceptionError {
         return TextureSetLayout.packedLayout(margin, rectangles, true, maxPageSizeW, maxPageSizeH);
     }
 
-    private static Layout gridLayout(int margin, List<Rect> rectangles, Grid gridSize) {
+    private static Layout gridLayout(int margin, List<Rect> rectangles, Grid gridSize) throws CompileExceptionError {
         return TextureSetLayout.gridLayout(margin, rectangles, gridSize);
     }
 
     @Test
-    public void testEmpty() {
+    public void testEmpty() throws CompileExceptionError {
         List<TextureSetLayout.Rect> rectangles
             = Arrays.asList();
 
@@ -66,7 +67,7 @@ public class TextureSetLayoutTest {
     }
 
     @Test
-    public void testBasic1() {
+    public void testBasic1() throws CompileExceptionError {
         List<TextureSetLayout.Rect> rectangles
             = Arrays.asList(rect("0", 0, 16, 16),
                             rect("1", 1, 16, 16),
@@ -83,7 +84,7 @@ public class TextureSetLayoutTest {
     }
 
     @Test
-    public void testBasic2() {
+    public void testBasic2() throws CompileExceptionError {
         List<TextureSetLayout.Rect> rectangles
             = Arrays.asList(rect("0", 0, 16, 16),
                             rect("1", 1, 8, 8),
@@ -110,7 +111,7 @@ public class TextureSetLayoutTest {
     }
 
     @Test
-    public void testBasic3() {
+    public void testBasic3() throws CompileExceptionError {
         List<TextureSetLayout.Rect> rectangles
             = Arrays.asList(rect("0", 0, 512, 128));
 
@@ -121,7 +122,7 @@ public class TextureSetLayoutTest {
     }
 
     @Test
-    public void testBasic4() {
+    public void testBasic4() throws CompileExceptionError {
         List<TextureSetLayout.Rect> rectangles
             = Arrays.asList(rect("0", 0, 32, 12),
                             rect("1", 1, 16, 2),
@@ -136,7 +137,7 @@ public class TextureSetLayoutTest {
     }
 
     @Test
-    public void testBasicMargin1() {
+    public void testBasicMargin1() throws CompileExceptionError {
         int size = 16;
         List<TextureSetLayout.Rect> rectangles
             = Arrays.asList(rect("0", 0, size, size),
@@ -155,7 +156,7 @@ public class TextureSetLayoutTest {
     }
 
     @Test
-    public void testBasicMargin2() {
+    public void testBasicMargin2() throws CompileExceptionError {
         int size = 15;
         List<TextureSetLayout.Rect> rectangles
             = Arrays.asList(rect("0", 0, size, size),
@@ -173,7 +174,7 @@ public class TextureSetLayoutTest {
     }
 
     @Test
-    public void testThinStrip() {
+    public void testThinStrip() throws CompileExceptionError {
         List<TextureSetLayout.Rect> rectangles = Arrays.asList(rect("0", 0, 1, 16));
 
         Layout layout = packedLayout(0, rectangles).get(0);
@@ -183,7 +184,7 @@ public class TextureSetLayoutTest {
     }
 
     @Test
-    public void testBasicPaged() {
+    public void testBasicPaged() throws CompileExceptionError {
         List<TextureSetLayout.Rect> rectangles
             = Arrays.asList(rect("0", 0, 32, 32),
                             rect("1", 1, 16, 16));
@@ -231,7 +232,7 @@ public class TextureSetLayoutTest {
     }
 
     @Test
-    public void testAllIncluded() {
+    public void testAllIncluded() throws CompileExceptionError {
         List<Rect> rectangles = createSampleRectangles(1);
         Layout layout = packedLayout(0, rectangles).get(0);
 
@@ -262,7 +263,7 @@ public class TextureSetLayoutTest {
     }
 
     @Test
-    public void testNoOverlaps() {
+    public void testNoOverlaps() throws CompileExceptionError {
         List<Rect> rectangles = createSampleRectangles(1);
         Layout layout = packedLayout(0, rectangles).get(0);
         List<Rect> outputRectangles = layout.getRectangles();
@@ -276,7 +277,7 @@ public class TextureSetLayoutTest {
     }
 
     @Test
-    public void testGridLayout1() {
+    public void testGridLayout1() throws CompileExceptionError {
 
         List<Rect> rectangles
             = Arrays.asList(rect("0", 0, 16, 4),
@@ -291,7 +292,7 @@ public class TextureSetLayoutTest {
     }
 
     @Test
-    public void testGridLayout2() {
+    public void testGridLayout2() throws CompileExceptionError {
 
         List<Rect> rectangles
             = Arrays.asList(rect("0", 0, 32, 16));
@@ -303,7 +304,7 @@ public class TextureSetLayoutTest {
     }
 
     @Test
-    public void testGridNoOverlaps() {
+    public void testGridNoOverlaps() throws CompileExceptionError {
         List<Rect> rectangles
             = Arrays.asList(rect("0", 0, 16, 4),
                             rect("1", 1, 16, 4),
@@ -321,7 +322,7 @@ public class TextureSetLayoutTest {
     }
 
     @Test
-    public void testLargeLayout() {
+    public void testLargeLayout() throws CompileExceptionError {
         List<Rect> rectangles
             = Arrays.asList(rect("0", 0, 1000, 800),
                             rect("1", 1, 800, 1000),

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/tile/test/TileSetGeneratorTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/tile/test/TileSetGeneratorTest.java
@@ -30,6 +30,7 @@ import java.util.List;
 
 import org.junit.Test;
 
+import com.dynamo.bob.CompileExceptionError;
 import com.dynamo.bob.textureset.TextureSetGenerator.AnimDesc;
 import com.dynamo.bob.textureset.TextureSetGenerator.TextureSetResult;
 import com.dynamo.bob.tile.TileSetGenerator;
@@ -46,7 +47,7 @@ import com.dynamo.gamesys.proto.Tile.TileSet;
 public class TileSetGeneratorTest {
 
     // @Test
-    public void testTileSet() throws Exception {
+    public void testTileSet() throws Exception, CompileExceptionError {
         BufferedImage image = newImage(64, 32);
         int tileWidth = 32;
         int tileHeight = 32;
@@ -88,7 +89,7 @@ public class TileSetGeneratorTest {
     }
 
     @Test
-    public void testSplit() {
+    public void testSplit() throws CompileExceptionError {
         BufferedImage image = newImage(384, 384);
         int tileWidth = 128;
         int tileHeight = 128;
@@ -127,7 +128,7 @@ public class TileSetGeneratorTest {
     }
 
     @Test
-    public void testSplitStrip() {
+    public void testSplitStrip() throws CompileExceptionError {
         BufferedImage image = newImage(1, 16);
         int tileWidth = 1;
         int tileHeight = 16;
@@ -147,7 +148,7 @@ public class TileSetGeneratorTest {
     }
 
     @Test
-    public void testSplitStripExtrude() throws IOException {
+    public void testSplitStripExtrude() throws IOException, CompileExceptionError {
         BufferedImage image = newImage(1, 16);
 
         int tileWidth = 1;
@@ -169,7 +170,7 @@ public class TileSetGeneratorTest {
     }
 
     @Test
-    public void textIndexedAnimIterator() throws Exception {
+    public void textIndexedAnimIterator() throws Exception, CompileExceptionError {
         List<IndexedAnimDesc> anims = new ArrayList<IndexedAnimDesc>(1);
         anims.add(new IndexedAnimDesc(newAnim("test", 3, 1).build()));
         TileSetGenerator.IndexedAnimIterator iterator = new IndexedAnimIterator(anims, 4);

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/textureset/MaxRectsLayoutStrategy.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/textureset/MaxRectsLayoutStrategy.java
@@ -17,6 +17,9 @@ package com.dynamo.bob.textureset;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.dynamo.bob.textureset.TextureSetLayout.MAX_ATLAS_DIMENSION;
+
+import com.dynamo.bob.CompileExceptionError;
 import com.dynamo.bob.textureset.TextureSetLayout.Layout;
 import com.dynamo.bob.textureset.TextureSetLayout.Rect;
 
@@ -48,7 +51,7 @@ public class MaxRectsLayoutStrategy implements TextureSetLayoutStrategy {
     }
 
     @Override
-    public List<Layout> createLayout(List<Rect> srcRects) {
+    public List<Layout> createLayout(List<Rect> srcRects) throws CompileExceptionError {
         ArrayList<RectNode> srcNodes = new ArrayList<RectNode>(srcRects.size());
         for(Rect r : srcRects) {
             RectNode n = new RectNode(r);
@@ -77,6 +80,15 @@ public class MaxRectsLayoutStrategy implements TextureSetLayoutStrategy {
             }
             int layoutWidth = 1 << getExponentNextOrMatchingPowerOfTwo(page.width);
             int layoutHeight = 1 << getExponentNextOrMatchingPowerOfTwo(page.height);
+            
+            // Validate atlas size limits
+            if (layoutWidth > MAX_ATLAS_DIMENSION || layoutHeight > MAX_ATLAS_DIMENSION) {
+                throw new CompileExceptionError(String.format(
+                    "Atlas layout size (%dx%d) exceeds maximum allowed dimensions (%dx%d). " +
+                    "Consider reducing image sizes, using multiple atlases, or using the multi-page atlas.",
+                    layoutWidth, layoutHeight, MAX_ATLAS_DIMENSION, MAX_ATLAS_DIMENSION));
+            }
+            
             Layout layout = new Layout(layoutWidth, layoutHeight, rects);
             result.add(layout);
         }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/textureset/MaxRectsLayoutStrategy.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/textureset/MaxRectsLayoutStrategy.java
@@ -85,7 +85,7 @@ public class MaxRectsLayoutStrategy implements TextureSetLayoutStrategy {
             if (layoutWidth > MAX_ATLAS_DIMENSION || layoutHeight > MAX_ATLAS_DIMENSION) {
                 throw new CompileExceptionError(String.format(
                     "Atlas layout size (%dx%d) exceeds maximum allowed dimensions (%dx%d). " +
-                    "Consider reducing image sizes, using multiple atlases, or using the multi-page atlas.",
+                    "Consider reducing image sizes, using multiple atlases, or using a multi-page atlas.",
                     layoutWidth, layoutHeight, MAX_ATLAS_DIMENSION, MAX_ATLAS_DIMENSION));
             }
             

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/textureset/TextureSetGenerator.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/textureset/TextureSetGenerator.java
@@ -14,6 +14,7 @@
 
 package com.dynamo.bob.textureset;
 
+import com.dynamo.bob.CompileExceptionError;
 import com.dynamo.bob.pipeline.GraphicsUtil;
 import com.dynamo.bob.textureset.TextureSetLayout;
 import com.dynamo.bob.textureset.TextureSetLayout.Grid;
@@ -390,7 +391,7 @@ public class TextureSetGenerator {
      * 3. Shrink rects by previous extrusion
      */
     public static LayoutResult calculateLayoutResult(List<Rect> images, int margin, int innerPadding, int extrudeBorders,
-                                                    boolean rotate, boolean useTileGrid, Grid gridSize, float maxPageSizeW, float maxPageSizeH) {
+                                                    boolean rotate, boolean useTileGrid, Grid gridSize, float maxPageSizeW, float maxPageSizeH) throws CompileExceptionError {
         TimeProfiler.start("calculateLayoutResult");
 
         int totalSizeIncrease = 2 * (innerPadding + extrudeBorders);
@@ -484,7 +485,7 @@ public class TextureSetGenerator {
     // Deprecated
     public static TextureSetResult calculateLayout(List<Rect> images, List<SpriteGeometry> imageHulls, int useGeometries,
                                                     AnimIterator iterator, int margin, int innerPadding, int extrudeBorders,
-                                                    boolean rotate, boolean useTileGrid, Grid gridSize, float maxPageSizeW, float maxPageSizeH) {
+                                                    boolean rotate, boolean useTileGrid, Grid gridSize, float maxPageSizeW, float maxPageSizeH) throws CompileExceptionError {
 
         LayoutResult layout = calculateLayoutResult(images, margin, innerPadding, extrudeBorders, rotate,
                                                     useTileGrid, gridSize, maxPageSizeW, maxPageSizeH);
@@ -567,7 +568,7 @@ public class TextureSetGenerator {
      */
     public static TextureSetResult generate(List<BufferedImage> images, List<AtlasImage> atlasImages, List<String> paths, AnimIterator iterator,
             int margin, int innerPadding, int extrudeBorders, boolean rotate, boolean useTileGrid, Grid gridSize,
-            float maxPageSizeW, float maxPageSizeH) {
+            float maxPageSizeW, float maxPageSizeH) throws CompileExceptionError {
 
         List<Rect> imageRects = rectanglesFromImages(images, paths);
 

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/textureset/TextureSetLayout.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/textureset/TextureSetLayout.java
@@ -308,7 +308,7 @@ public class TextureSetLayout {
         if (layoutWidth > MAX_ATLAS_DIMENSION || layoutHeight > MAX_ATLAS_DIMENSION) {
             throw new CompileExceptionError(String.format(
                 "Atlas grid layout size (%dx%d) exceeds maximum allowed dimensions (%dx%d). " +
-                "Consider reducing image sizes, using multiple atlases, or using the multi-page atlas.",
+                "Consider reducing image sizes, using multiple atlases, or using a multi-page atlas.",
                 layoutWidth, layoutHeight, MAX_ATLAS_DIMENSION, MAX_ATLAS_DIMENSION, gridSize.columns, gridSize.rows));
         }
 

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/textureset/TextureSetLayoutStrategy.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/textureset/TextureSetLayoutStrategy.java
@@ -16,9 +16,10 @@ package com.dynamo.bob.textureset;
 
 import java.util.List;
 
+import com.dynamo.bob.CompileExceptionError;
 import com.dynamo.bob.textureset.TextureSetLayout.Layout;
 import com.dynamo.bob.textureset.TextureSetLayout.Rect;
 
 public interface TextureSetLayoutStrategy {
-    List<Layout> createLayout(List<Rect> srcRects);
+    List<Layout> createLayout(List<Rect> srcRects) throws CompileExceptionError;
 }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/tile/TileSetGenerator.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/tile/TileSetGenerator.java
@@ -19,6 +19,7 @@ import java.awt.image.BufferedImage;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.dynamo.bob.CompileExceptionError;
 import com.dynamo.bob.textureset.TextureSetGenerator;
 import com.dynamo.bob.textureset.TextureSetGenerator.AnimDesc;
 import com.dynamo.bob.textureset.TextureSetGenerator.AnimIterator;
@@ -106,7 +107,7 @@ public class TileSetGenerator {
         }
     }
 
-    public static TextureSetResult generate(TileSet tileSet, BufferedImage image, BufferedImage collisionImage) {
+    public static TextureSetResult generate(TileSet tileSet, BufferedImage image, BufferedImage collisionImage) throws CompileExceptionError {
         Rect imageRect = image != null ? new Rect(null, -1, image.getWidth(), image.getHeight()) : null;
         Rect collisionRect = collisionImage != null ? new Rect(null, -1, collisionImage.getWidth(), collisionImage.getHeight()) : null;
         TileSetUtil.Metrics metrics = TileSetUtil.calculateMetrics(imageRect, tileSet.getTileWidth(),

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/tile/TileSetc.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/tile/TileSetc.java
@@ -30,6 +30,7 @@ import java.io.Reader;
 
 import javax.imageio.ImageIO;
 
+import com.dynamo.bob.CompileExceptionError;
 import com.dynamo.bob.textureset.TextureSetGenerator.TextureSetResult;
 import com.dynamo.gamesys.proto.TextureSetProto.TextureSet;
 import com.dynamo.gamesys.proto.Tile.TileSet;
@@ -64,7 +65,7 @@ public class TileSetc {
         }
     }
 
-    public void compile(File inFile, File outFile) throws IOException {
+    public void compile(File inFile, File outFile) throws IOException, CompileExceptionError {
 
         try (Reader reader = new BufferedReader(new FileReader(inFile)); OutputStream output = new BufferedOutputStream(new FileOutputStream(outFile))) {
             TileSet.Builder builder = TileSet.newBuilder();
@@ -118,7 +119,7 @@ public class TileSetc {
         }
     }
 
-    public static void main(String[] args) throws IOException {
+    public static void main(String[] args) throws IOException, CompileExceptionError {
         System.setProperty("java.awt.headless", "true");
 
         String inFileName = args[0];

--- a/editor/src/clj/editor/atlas.clj
+++ b/editor/src/clj/editor/atlas.clj
@@ -56,7 +56,7 @@
             [util.fn :as fn]
             [util.murmur :as murmur])
   (:import [com.dynamo.bob.pipeline AtlasUtil ShaderUtil$Common ShaderUtil$VariantTextureArrayFallback]
-           [com.dynamo.bob.textureset TextureSetGenerator$LayoutResult]
+           [com.dynamo.bob.textureset TextureSetGenerator$LayoutResult TextureSetLayout]
            [com.dynamo.gamesys.proto AtlasProto$Atlas AtlasProto$AtlasAnimation AtlasProto$AtlasImage TextureSetProto$TextureSet Tile$Playback]
            [com.jogamp.opengl GL GL2]
            [editor.gl.vertex2 VertexBuffer]
@@ -545,6 +545,8 @@
   (cond
     (neg? x) "'Max Page Width' cannot be negative"
     (neg? y) "'Max Page Height' cannot be negative"
+    (> x (.intValue TextureSetLayout/MAX_ATLAS_DIMENSION)) (format "'Max Page Width' cannot exceed %d" (.intValue TextureSetLayout/MAX_ATLAS_DIMENSION))
+    (> y (.intValue TextureSetLayout/MAX_ATLAS_DIMENSION)) (format "'Max Page Height' cannot exceed %d" (.intValue TextureSetLayout/MAX_ATLAS_DIMENSION))
     :else nil))
 
 (defn- validate-max-page-size [node-id page-size]


### PR DESCRIPTION
Most modern GPUs don't support textures larger than 16384x16384. Defold doesn't support it either, and this fix simply adds a proper error to notify the user about the issue if they try to create such a texture.