### PR TITLE
Fix precision issue with multipage atlas

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderUtil.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderUtil.java
@@ -255,7 +255,7 @@ public class ShaderUtil {
     public static class VariantTextureArrayFallback {
         private static void generateTextureArrayFn(ArrayList<String> buffer, String samplerName, int maxPages) {
             buffer.add(String.format("vec4 texture2DArray_%s(vec3 dm_texture_array_args) {", samplerName));
-            buffer.add("    int page_index = int(dm_texture_array_args.z);");
+            buffer.add("    int page_index = int(dm_texture_array_args.z + 0.5);");
             String lineFmt = "    %s if (page_index == %d) return texture2D(%s_%d, dm_texture_array_args.st);";
 
             for (int i = 0; i < maxPages; i++) {


### PR DESCRIPTION
Fixed an issue where, in a paged atlas, textures were taken from the wrong page. This occurred in rare cases on devices using the WebGL1/OpenGL ES 2.0 graphics backend.

Fix https://github.com/defold/defold/issues/8728