### PR TITLE
Fixed issue when `sys.open_url()` reports false when a url is opened on Windows

### DIFF
--- a/engine/dlib/src/dlib/sys_posix.cpp
+++ b/engine/dlib/src/dlib/sys_posix.cpp
@@ -329,7 +329,7 @@ namespace dmSys
     Result OpenURL(const char* url, const char* target)
     {
         intptr_t ret = (intptr_t) ShellExecuteA(NULL, "open", url, NULL, NULL, SW_SHOWNORMAL);
-        if (ret == 32)
+        if (ret > 32)
         {
             return RESULT_OK;
         }


### PR DESCRIPTION
Fix https://github.com/defold/defold/issues/5549