### PR TITLE
Set center panel minimum width

### DIFF
--- a/editor/resources/editor.fxml
+++ b/editor/resources/editor.fxml
@@ -70,7 +70,7 @@
                   <items>
                     <AnchorPane prefHeight="160.0" prefWidth="100.0">
                       <children>
-                        <SplitPane id="center-split" dividerPositions="0.5746666666666667" layoutX="24.0" layoutY="398.0" orientation="VERTICAL" prefHeight="200.0" prefWidth="160.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+                        <SplitPane id="center-split" dividerPositions="0.5746666666666667" layoutX="24.0" layoutY="398.0" orientation="VERTICAL" prefHeight="200.0" prefWidth="160.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0" minWidth="100.0">
                           <items>
                             <AnchorPane prefHeight="100.0" prefWidth="160.0">
                               <children>


### PR DESCRIPTION
Set a minimum width for the center panel.

Fixes #11020

### Technical changes

I found a different way to work around the issue. By setting a minimum width, we avoid hiding the center panel without affecting the persisted height, and fix the mentioned issue indirectly. It also makes sense to have a min width set for the center panel in my opinion.