### PR TITLE
Add `collision_type` editor script property for disambiguation

### DIFF
--- a/editor/src/clj/editor/attachment.clj
+++ b/editor/src/clj/editor/attachment.clj
@@ -332,6 +332,14 @@
         (map gt/source-id)
         (filter #(= child-node-type (g/node-type* basis %)))))))
 
+(defn alternative
+  "Return alternative node id for a given node id"
+  [workspace node-id {:keys [basis] :as evaluation-context}]
+  (let [current-state (workspace/node-attachments basis workspace)
+        node-type (g/node-type* basis node-id)]
+    (when-let [alternative-fn (:alternative (clojure.core/get current-state node-type))]
+      (alternative-fn node-id evaluation-context))))
+
 ;; SDK api
 (defn nodes-getter
   "Node list getter that returns its :nodes output

--- a/editor/src/clj/editor/attachment.clj
+++ b/editor/src/clj/editor/attachment.clj
@@ -153,18 +153,30 @@
   [workspace node-type alternative-fn]
   (g/update-property workspace :node-attachments #(update % node-type assoc :alternative alternative-fn)))
 
+(defn find-alternative
+  "Returns first truthy value given an alternative chain
+
+  Args:
+    workspace             the workspace that defines node alternatives
+    node-id               initial node id
+    pred                  predicate fn, will receive 1 arg: node id
+    evaluation-context    the evaluation context"
+  [workspace node-id pred {:keys [basis] :as evaluation-context}]
+  (let [current-state (workspace/node-attachments basis workspace)]
+    (loop [node-id node-id]
+      (or (pred node-id)
+          (when-let [alternative-fn (:alternative (clojure.core/get current-state (g/node-type* basis node-id)))]
+            (some-> (alternative-fn node-id evaluation-context) recur))))))
+
 (defn- get-list-definition
   "Internal. Returns either a tuple of node-id + list definition map or nil if
   it does not exist"
   [workspace node-id list-kw {:keys [basis] :as evaluation-context}]
   (let [current-state (workspace/node-attachments basis workspace)]
-    (loop [node-id node-id]
-      (let [node-type (g/node-type* basis node-id)]
-        (when-let [{:keys [lists alternative]} (clojure.core/get current-state node-type)]
-          (or (when-let [list-definition (list-kw lists)]
-                (coll/pair node-id list-definition))
-              (when alternative
-                (some-> (alternative node-id evaluation-context) recur))))))))
+    (find-alternative
+      workspace node-id
+      #(some->> (list-kw (:lists (clojure.core/get current-state (g/node-type* basis %)))) (coll/pair %))
+      evaluation-context)))
 
 (defn- require-list-definition
   [workspace node-id list-kw evaluation-context]
@@ -331,14 +343,6 @@
       (coll/transfer (g/explicit-arcs-by-target basis node :nodes) []
         (map gt/source-id)
         (filter #(= child-node-type (g/node-type* basis %)))))))
-
-(defn alternative
-  "Return alternative node id for a given node id"
-  [workspace node-id {:keys [basis] :as evaluation-context}]
-  (let [current-state (workspace/node-attachments basis workspace)
-        node-type (g/node-type* basis node-id)]
-    (when-let [alternative-fn (:alternative (clojure.core/get current-state node-type))]
-      (alternative-fn node-id evaluation-context))))
 
 ;; SDK api
 (defn nodes-getter

--- a/editor/src/clj/editor/editor_extensions/graph.clj
+++ b/editor/src/clj/editor/editor_extensions/graph.clj
@@ -359,13 +359,15 @@
       nil)
     (let [node-id node-id-or-resource
           {:keys [basis]} evaluation-context
-          node-type (g/node-type* basis node-id)]
+          node-type (g/node-type* basis node-id)
+          workspace (project/workspace project evaluation-context)]
       (or ((ext-property-getter (:k node-type)) node-id property evaluation-context)
+          (when-let [alt-node-id (attachment/alternative workspace node-id evaluation-context)]
+            ((ext-property-getter (:k (g/node-type* basis alt-node-id))) alt-node-id property evaluation-context))
           (case property
             "type" (when-let [type-name (node-types/->name node-type)]
                      (constantly type-name))
-            (let [workspace (project/workspace project evaluation-context)
-                  list-kw (property->prop-kw property)]
+            (let [list-kw (property->prop-kw property)]
               (when (attachment/defined? workspace node-id list-kw evaluation-context)
                 #(mapv rt/wrap-userdata (attachment/get workspace node-id list-kw evaluation-context)))))))))
 
@@ -488,7 +490,9 @@
 
   Returns nil if there is no setter for the node-id+property pair"
   [node-id property rt project evaluation-context]
-  ((ext-property-setter (node-id->type-keyword node-id evaluation-context)) node-id property rt project evaluation-context))
+  (or ((ext-property-setter (node-id->type-keyword node-id evaluation-context)) node-id property rt project evaluation-context)
+      (when-let [alt-node-id (attachment/alternative (project/workspace project evaluation-context) node-id evaluation-context)]
+        ((ext-property-setter (node-id->type-keyword alt-node-id evaluation-context)) alt-node-id property rt project evaluation-context))))
 
 ;; endregion
 

--- a/editor/test/integration/editor_extensions_test.clj
+++ b/editor/test/integration/editor_extensions_test.clj
@@ -1379,9 +1379,11 @@ After transaction (clear):
   emitters: 0
   modifiers: 0
 Collision object initial state:
+  collision_type: collision-object-type-dynamic
   shapes: 0
 Transaction: add 3 shapes
 After transaction (add 3 shapes):
+  collision_type: collision-object-type-static
   shapes: 3
   - id: box
     type: shape-type-box
@@ -1395,6 +1397,7 @@ After transaction (add 3 shapes):
     height: 40
 Transaction: clear
 After transaction (clear):
+  collision_type: collision-object-type-dynamic
   shapes: 0
 Expected errors:
   missing type => type is required
@@ -1594,6 +1597,7 @@ After transaction (add go components):
     id: collectionproxy1
   - type: collisionobject
     id: collisionobject-embedded
+    collision_type: collision-object-type-static
     shapes: 1
     - id: box
       type: shape-type-box
@@ -1694,6 +1698,7 @@ After transaction (add gos and collections):
           scale: {1, 1, 1}
         - type: collisionobject
           id: collisionobject
+          collision_type: collision-object-type-dynamic
           shapes: 1
           - id: box
             type: shape-type-box
@@ -1829,6 +1834,7 @@ After transaction (edit already existing collection elements):
           scale: {1, 1, 1}
         - type: collisionobject
           id: collisionobject
+          collision_type: collision-object-type-dynamic
           shapes: 1
           - id: box
             type: shape-type-box

--- a/editor/test/resources/editor_extensions/transact_attachment_project/test.editor_script
+++ b/editor/test/resources/editor_extensions/transact_attachment_project/test.editor_script
@@ -90,6 +90,7 @@ end
 local function print_collision_object(collision, indent)
     indent = indent or "  "
     local shapes = editor.get(collision, "shapes")
+    print(("%scollision_type: %s"):format(indent, editor.get(collision, "collision_type")))
     print(("%sshapes: %s"):format(indent, #shapes))
     for i = 1, #shapes do
         local shape = shapes[i]
@@ -393,6 +394,7 @@ function M.get_commands()
 
                 print("Transaction: add 3 shapes")
                 editor.transact({
+                    editor.tx.set(collision, "collision_type", "collision-object-type-static"),
                     editor.tx.add(collision, "shapes", {
                         id = "box",
                         type = "shape-type-box"
@@ -411,7 +413,10 @@ function M.get_commands()
                 print_collision_object(collision)
 
                 print("Transaction: clear")
-                editor.transact({editor.tx.clear(collision, "shapes")})
+                editor.transact({
+                    editor.tx.set(collision, "collision_type", "collision-object-type-dynamic"),
+                    editor.tx.clear(collision, "shapes")
+                })
 
                 print("After transaction (clear):")
                 print_collision_object(collision)
@@ -577,6 +582,7 @@ function M.get_commands()
                         id = "collisionobject-embedded",
                         type = "collisionobject",
                         locked_rotation = true,
+                        collision_type = "collision-object-type-static",
                         shapes = {
                             {
                                 id = "box",


### PR DESCRIPTION
Previously, the collision objects had a `type` property that could be shadowed by a collision component `type` property when the collision object is embedded in a game object. We added `collision_type` that should be used instead of `type` to refer to the collision object's physics object type.

Fixes #11003
