### PR TITLE
Allow easily bundling template projects with the editor.

### DIFF
--- a/editor/.gitignore
+++ b/editor/.gitignore
@@ -18,6 +18,7 @@ pom.xml.asc
 /resources/dialogs.css
 /resources/editor.css
 /resources/splash.css
+/resources/template-projects
 /editor2.*.log
 /log.txt
 /.project

--- a/editor/resources/welcome/welcome.edn
+++ b/editor/resources/welcome/welcome.edn
@@ -6,6 +6,7 @@
                              :duration "Short"
                              :user-level "Beginner"
                              :zip-url "https://github.com/defold/template-empty/archive/master.zip"
+                             :bundle true
                              :skip-root? true}
 
                             {:name "Mobile game"

--- a/editor/tasks/leiningen/init.clj
+++ b/editor/tasks/leiningen/init.clj
@@ -68,6 +68,7 @@
    ["local-jars"]
    ; ["builtins"] builtins is in bob which we install in `local-jars` step
    ["ref-doc"]
+   ["project-templates"]
    ["protobuf"]
    ["sass" "once"]
    ["pack"]])

--- a/editor/tasks/leiningen/project_templates.clj
+++ b/editor/tasks/leiningen/project_templates.clj
@@ -1,0 +1,20 @@
+(ns leiningen.project-templates
+  (:require [clojure.edn :as edn]
+            [leiningen.util.http-cache :as http-cache]
+            [clojure.java.io :as io])
+  (:import [org.apache.commons.io FileUtils]))
+
+(defn project-templates [_project]
+  (FileUtils/deleteQuietly (io/file "resources/template-projects"))
+  (->> (io/file "resources/welcome/welcome.edn")
+       (slurp)
+       (edn/read-string)
+       :new-project
+       :categories
+       (eduction
+         (mapcat :templates)
+         (filter :bundle)
+         (map (juxt #(http-cache/download (:zip-url %)) :name)))
+       (run! (fn [[zip name]]
+               (println (str "Bundle '" name "' template project"))
+               (FileUtils/copyFile (io/file zip) (io/file "resources/template-projects" (str name ".zip")))))))


### PR DESCRIPTION
For starters, I bundle the empty project, as I assume it's the most used. It's just 2.5 kb. I decided not to bundle desktop/mobile templates since they are noticeably bigger (600 KB/400 KB), but with the pipeline in place, we can simply bundle more templates if needed by adding `:bundle true` in `welcome.edn`.

Fixes #3930