### PR TITLE
Fixed an issue where a 16k x 16k atlas couldn’t be unpacked if the file size was bigger than 1 GB

### DIFF
--- a/engine/dlib/src/dlib/lz4.cpp
+++ b/engine/dlib/src/dlib/lz4.cpp
@@ -21,7 +21,6 @@ namespace dmLZ4
     Result DecompressBuffer(const void* buffer, uint32_t buffer_size, void* decompressed_buffer, uint32_t max_output, int* decompressed_size)
     {
         Result r;
-        // When we set an output size larger than 1G (or closer to 2G) lz4 fails for some reason...
         if(max_output <= DMLZ4_MAX_OUTPUT_SIZE)
         {
             *decompressed_size = LZ4_decompress_safe((const char*)buffer, (char *)decompressed_buffer, buffer_size, max_output);

--- a/engine/dlib/src/dlib/lz4.h
+++ b/engine/dlib/src/dlib/lz4.h
@@ -18,7 +18,7 @@
 #include <stdint.h>
 #include "shared_library.h"
 
-#define DMLZ4_MAX_OUTPUT_SIZE (1 << 30)
+#define DMLZ4_MAX_OUTPUT_SIZE (1LL << 31)  // 2GB limit instead of 1GB
 
 namespace dmLZ4
 {

--- a/engine/dlib/src/dlib/lz4.h
+++ b/engine/dlib/src/dlib/lz4.h
@@ -18,7 +18,7 @@
 #include <stdint.h>
 #include "shared_library.h"
 
-#define DMLZ4_MAX_OUTPUT_SIZE (1LL << 31)  // 2GB limit instead of 1GB
+#define DMLZ4_MAX_OUTPUT_SIZE (1LL << 31)  // 2GB limit, build pipeline doesn't support bigger files
 
 namespace dmLZ4
 {

--- a/engine/resource/src/resource_archive.cpp
+++ b/engine/resource/src/resource_archive.cpp
@@ -605,6 +605,10 @@ namespace dmResourceArchive
             dmLZ4::Result r = dmLZ4::DecompressBuffer(source_data, source_data_size, buffer, size, &decompressed_size);
             if (dmLZ4::RESULT_OK != r)
             {
+                dmLogError("LZ4 decompression failed: result=%d, expected size=%u, actual size=%d", r, size, decompressed_size);
+                if (r == dmLZ4::RESULT_OUTPUT_SIZE_TOO_LARGE) {
+                    dmLogError("Resource too large for LZ4 decompression: %u bytes exceeds maximum limit", size);
+                }
                 delete[] temp_data;
                 return dmResourceArchive::RESULT_OUTBUFFER_TOO_SMALL;
             }


### PR DESCRIPTION
The 1 GB limitation for compressed files was doubled to make it possible to work with 16k x 16k atlases.

Fix https://github.com/defold/defold/issues/10404