### PR TITLE
Fixed an issue where files larger than 2GB couldn’t be read on windows

### DIFF
--- a/engine/dlib/src/dlib/sys_posix.cpp
+++ b/engine/dlib/src/dlib/sys_posix.cpp
@@ -977,8 +977,13 @@ namespace dmSys
             return true;
         }
 #endif
+#ifdef _WIN32
+        struct _stat64 file_stat;
+        return _stat64(path, &file_stat) == 0;
+#else
         struct stat file_stat;
         return stat(path, &file_stat) == 0;
+#endif
     }
 
     Result ResourceSize(const char* path, uint32_t* resource_size)
@@ -994,8 +999,13 @@ namespace dmSys
             return RESULT_OK;
         }
 #endif
+#ifdef _WIN32
+        struct _stat64 file_stat;
+        if (_stat64(path, &file_stat) == 0) {
+#else
         struct stat file_stat;
         if (stat(path, &file_stat) == 0) {
+#endif
             if (!S_ISREG(file_stat.st_mode)) {
                 return RESULT_NOENT;
             }
@@ -1030,8 +1040,13 @@ namespace dmSys
             return RESULT_OK;
         }
 #endif
+#ifdef _WIN32
+        struct _stat64 file_stat;
+        if (_stat64(path, &file_stat) == 0) {
+#else
         struct stat file_stat;
         if (stat(path, &file_stat) == 0) {
+#endif
             if (!S_ISREG(file_stat.st_mode)) {
                 return RESULT_NOENT;
             }
@@ -1074,8 +1089,13 @@ namespace dmSys
             return RESULT_OK;
         }
 #endif
+#ifdef _WIN32
+        struct _stat64 file_stat;
+        if (_stat64(path, &file_stat) == 0) {
+#else
         struct stat file_stat;
         if (stat(path, &file_stat) == 0) {
+#endif
             if (!S_ISREG(file_stat.st_mode)) {
                 return RESULT_NOENT;
             }
@@ -1132,8 +1152,13 @@ namespace dmSys
 
     Result IsDir(const char* path)
     {
+#ifdef _WIN32
+        struct _stat64 path_stat;
+        int ret = _stat64(path, &path_stat);
+#else
         struct stat path_stat;
         int ret = stat(path, &path_stat);
+#endif
         if (ret != 0)
             return ErrnoToResult(errno);
         return path_stat.st_mode & S_IFDIR ? RESULT_OK : RESULT_UNKNOWN;
@@ -1141,8 +1166,13 @@ namespace dmSys
 
     bool Exists(const char* path)
     {
+#ifdef _WIN32
+        struct _stat64 path_stat;
+        int ret = _stat64(path, &path_stat);
+#else
         struct stat path_stat;
         int ret = stat(path, &path_stat);
+#endif
         return ret == 0;
     }
 
@@ -1168,8 +1198,13 @@ namespace dmSys
             char abs_path[1024];
             dmSnPrintf(abs_path, sizeof(abs_path), "%s/%s", dirpath, entry->d_name);
 
+#ifdef _WIN32
+            struct _stat64 path_stat;
+            _stat64(abs_path, &path_stat);
+#else
             struct stat path_stat;
             stat(abs_path, &path_stat);
+#endif
 
             bool isdir = S_ISDIR(path_stat.st_mode);
 
@@ -1218,8 +1253,13 @@ namespace dmSys
 
     Result Stat(const char* path, StatInfo* stat_info)
     {
+#ifdef _WIN32
+        struct _stat64 info;
+        int ret = _stat64(path, &info);
+#else
         struct stat info;
         int ret = stat(path, &info);
+#endif
         if (ret != 0)
             return RESULT_NOENT;
         stat_info->m_Size = (uint64_t)info.st_size;

--- a/engine/resource/src/providers/provider_archive.cpp
+++ b/engine/resource/src/providers/provider_archive.cpp
@@ -62,12 +62,12 @@ namespace dmResourceProviderArchive
         char mount_archive_data_path[DMPATH_MAX_PATH];
         if (dmSys::RESULT_OK != dmSys::ResolveMountFileName(mount_archive_index_path, sizeof(mount_archive_index_path), archive_index_path))
         {
-            dmLogError("Path to small to fit into buffer: %s", archive_index_path);
+            dmLogError("File doesn’t exist or can’t be read: %s", archive_index_path);
             return dmResourceProvider::RESULT_ERROR_UNKNOWN;
         }
         if (dmSys::RESULT_OK != dmSys::ResolveMountFileName(mount_archive_data_path, sizeof(mount_archive_data_path), archive_data_path))
         {
-            dmLogError("Path to small to fit into buffer: %s", mount_archive_data_path);
+            dmLogError("File doesn’t exist or can’t be read: %s", mount_archive_data_path);
             return dmResourceProvider::RESULT_ERROR_UNKNOWN;
         }
 


### PR DESCRIPTION
This PR fixes the issue where having an `arcd` archive larger than 2 GB on Windows results in a runtime error:
```
ERROR:RESOURCE: Path to small to fit into buffer: game.arcd
ERROR:RESOURCE: Failed to mount base archive: -1000 for mount archive://game.dmanifest
WARNING:RESOURCE: No resource loaders mounted that could match uri archive:game.dmanifest
```

Fix https://github.com/defold/defold/issues/11060