### PR TITLE
Add a preference to disable auto-closing parens in the editor.

### DIFF
--- a/editor/src/clj/editor/code/data.clj
+++ b/editor/src/clj/editor/code/data.clj
@@ -2285,10 +2285,10 @@
             (empty? clean-lines)
             (assoc :invalidated-row 0))))
 
-(defn delete-character-before-cursor [lines grammar syntax-info cursor-range]
+(defn delete-character-before-cursor [lines grammar auto-closing-parens syntax-info cursor-range]
   (let [cursor (adjust-cursor lines (CursorRange->Cursor cursor-range))]
     (or
-      (when-let [{:keys [characters exclude-scopes open-scopes]} (:auto-insert grammar)]
+      (when-let [{:keys [characters exclude-scopes open-scopes]} (when auto-closing-parens (:auto-insert grammar))]
         ;; auto-remove closing parens only across a single line
         (let [row (.-row cursor)
               ^String line (lines row)
@@ -2316,17 +2316,17 @@
                    [""]]))))))
       [(->CursorRange cursor (cursor-left lines cursor)) [""]])))
 
-(defn delete-word-before-cursor [lines _grammar _syntax-info cursor-range]
+(defn delete-word-before-cursor [lines _grammar _auto-closing-parens _syntax-info cursor-range]
   (let [from (CursorRange->Cursor cursor-range)
         to (cursor-prev-word lines from)]
     [(->CursorRange from to) [""]]))
 
-(defn delete-character-after-cursor [lines _grammar _syntax-info cursor-range]
+(defn delete-character-after-cursor [lines _grammar _auto-closing-parens _syntax-info cursor-range]
   (let [from (CursorRange->Cursor cursor-range)
         to (cursor-right lines from)]
     [(->CursorRange from to) [""]]))
 
-(defn delete-word-after-cursor [lines _grammar _syntax-info cursor-range]
+(defn delete-word-after-cursor [lines _grammar _auto-closing-parens _syntax-info cursor-range]
   (let [from (CursorRange->Cursor cursor-range)
         to (cursor-next-word lines from)]
     [(->CursorRange from to) [""]]))
@@ -2497,13 +2497,14 @@
               cursor-ranges)))
         (frame-cursor layout))))
 
-(defn key-typed [indent-level-pattern indent-string grammar lines cursor-ranges regions layout syntax-info ^String typed]
+(defn key-typed [indent-level-pattern indent-string grammar auto-closing-parens lines cursor-ranges regions layout syntax-info ^String typed]
   (case typed
     "\r" ; Enter or Return.
     (insert-text indent-level-pattern indent-string grammar lines cursor-ranges regions layout "\n")
 
     (when (not-any? #(Character/isISOControl ^char %) typed)
-      (if (and (= 1 (.length typed))
+      (if (and auto-closing-parens
+               (= 1 (.length typed))
                (contains? grammar :auto-insert))
         (key-type-with-auto-insert indent-level-pattern indent-string grammar lines cursor-ranges regions layout syntax-info typed)
         (insert-text indent-level-pattern indent-string grammar lines cursor-ranges regions layout typed)))))
@@ -2919,13 +2920,13 @@
   (or (can-paste-plain-text? clipboard)
       (can-paste-multi-selection? clipboard cursor-ranges)))
 
-(defn delete [lines grammar syntax-info cursor-ranges regions ^LayoutInfo layout delete-fn]
+(defn delete [lines grammar auto-closing-parens syntax-info cursor-ranges regions ^LayoutInfo layout delete-fn]
   (-> (if (every? cursor-range-empty? cursor-ranges)
-        (let [syntax-info (if (:auto-insert grammar)
+        (let [syntax-info (if (and auto-closing-parens (:auto-insert grammar))
                             (let [max-row (long (transduce (map #(-> % cursor-range-end .-row)) max 0 cursor-ranges))]
                               (ensure-syntax-info syntax-info (inc max-row) lines grammar))
                             syntax-info)]
-          (splice lines regions (map (partial delete-fn lines grammar syntax-info) cursor-ranges)))
+          (splice lines regions (map (partial delete-fn lines grammar auto-closing-parens syntax-info) cursor-ranges)))
         (splice lines regions (map (partial delete-range lines) cursor-ranges)))
       (frame-cursor layout)))
 

--- a/editor/src/clj/editor/code/script.clj
+++ b/editor/src/clj/editor/code/script.clj
@@ -121,7 +121,10 @@
                                    "string.quoted.other.multiline.lua"
                                    "string.quoted.double.lua"
                                    "string.quoted.single.lua"
-                                   "constant.character.escape.lua"}
+                                   "constant.character.escape.lua"
+                                   "punctuation.definition.comment.lua"
+                                   "comment.block.lua"
+                                   "comment.line.double-dash.lua"}
                  :open-scopes {\' "punctuation.definition.string.quoted.begin.lua"
                                \" "punctuation.definition.string.quoted.begin.lua"
                                \[ "punctuation.definition.string.begin.lua"}

--- a/editor/src/clj/editor/console.clj
+++ b/editor/src/clj/editor/console.clj
@@ -761,7 +761,7 @@
     ;; Configure canvas.
     (doto canvas
       (.setFocusTraversable true)
-      (.addEventFilter KeyEvent/KEY_PRESSED (ui/event-handler event (view/handle-key-pressed! view-node event false)))
+      (.addEventFilter KeyEvent/KEY_PRESSED (ui/event-handler event (view/handle-key-pressed! view-node prefs event false)))
       (.addEventHandler MouseEvent/MOUSE_MOVED (ui/event-handler event (view/handle-mouse-moved! view-node prefs event)))
       (.addEventHandler MouseEvent/MOUSE_PRESSED (ui/event-handler event (view/handle-mouse-pressed! view-node event)))
       (.addEventHandler MouseEvent/MOUSE_DRAGGED (ui/event-handler event (view/handle-mouse-moved! view-node prefs event)))

--- a/editor/src/clj/editor/prefs.clj
+++ b/editor/src/clj/editor/prefs.clj
@@ -117,6 +117,9 @@
                     :whole-word {:type :boolean}
                     :case-sensitive {:type :boolean}
                     :wrap {:type :boolean :default true}}}
+            :auto-closing-parens {:type :boolean
+                                  :default true
+                                  :ui {:label "Auto-insert closing parens"}}
             :visibility {:type :object
                          :properties
                          {:indentation-guides {:type :boolean :default true}

--- a/editor/src/clj/editor/prefs_dialog.clj
+++ b/editor/src/clj/editor/prefs_dialog.clj
@@ -67,7 +67,8 @@
                 [:code :open-file-at-line]
                 [:code :font :name]
                 [:code :zoom-on-scroll]
-                [:code :hover]]}
+                [:code :hover]
+                [:code :auto-closing-parens]]}
        {:name "Extensions"
         :paths [[:extensions :build-server]
                 [:extensions :build-server-username]

--- a/editor/test/editor/code/data_test.clj
+++ b/editor/test/editor/code/data_test.clj
@@ -827,8 +827,8 @@
 (deftest delete-test
   (let [grammar nil
         syntax-info []
-        backspace (fn [lines cursor-ranges] (data/delete lines grammar syntax-info cursor-ranges nil (layout-info lines) data/delete-character-before-cursor))
-        delete (fn [lines cursor-ranges] (data/delete lines grammar syntax-info cursor-ranges nil (layout-info lines) data/delete-character-after-cursor))]
+        backspace (fn [lines cursor-ranges] (data/delete lines grammar true syntax-info cursor-ranges nil (layout-info lines) data/delete-character-before-cursor))
+        delete (fn [lines cursor-ranges] (data/delete lines grammar true syntax-info cursor-ranges nil (layout-info lines) data/delete-character-after-cursor))]
     (testing "Single cursor"
       (is (= {:cursor-ranges [(c 0 0)]
               :invalidated-row 0
@@ -1560,6 +1560,7 @@
                         (data/indent-level-pattern 4)
                         (data/indent-type->indent-string :four-spaces)
                         script/lua-grammar
+                        true
                         lines
                         cursor-ranges
                         []
@@ -1572,6 +1573,7 @@
                             (data/delete
                               lines
                               script/lua-grammar
+                              true
                               []
                               [cursor-range]
                               []


### PR DESCRIPTION
New preference **Code → Auto-insert closing parens** allows turning off the auto-closing of parens in the editor.

Fixes #10781