### PR TITLE
Make editor server port more accessible

### DIFF
--- a/editor/scripts/bundle.py
+++ b/editor/scripts/bundle.py
@@ -656,7 +656,7 @@ Commands:
 
     parser.add_option('--launcher', dest='launcher',
                       default = None,
-                      help = 'Specific local launcher to use when creating the bundle. Useful when testing.')
+                      help = 'Specific local launcher to use when creating the bundle, e.g. "../engine/tools/build/src/launcher/launcher". Useful when testing.')
 
     parser.add_option('--skip-tests', dest='skip_tests',
                       action = 'store_true',

--- a/editor/src/clj/editor.clj
+++ b/editor/src/clj/editor.clj
@@ -17,4 +17,4 @@
 
 (defn -main [& args]
   (println "Launching")
-  (Application/launch (Class/forName "com.defold.editor.Start") args))
+  (Application/launch (Class/forName "com.defold.editor.Start") (into-array String args)))

--- a/editor/src/clj/editor/boot_open_project.clj
+++ b/editor/src/clj/editor/boot_open_project.clj
@@ -59,7 +59,6 @@
             [service.smoke-log :as slog]
             [util.http-server :as http-server])
   (:import [java.io File]
-           [java.net BindException]
            [javafx.scene Node Scene]
            [javafx.scene.control MenuBar SplitPane Tab TabPane TreeView]
            [javafx.scene.input DragEvent InputEvent KeyCombination KeyEvent MouseEvent]
@@ -214,12 +213,12 @@
           server-port (:port cli-options)
           web-server (try
                        (http-server/start! server-handler :port server-port)
-                       (catch BindException e
+                       (catch Exception e
                          (let [server (http-server/start! server-handler)]
                            (notifications/show!
                              (workspace/notifications workspace)
                              {:type :warning
-                              :text (format "Failed to start a server on port %s: %s. Using port %s instead."
+                              :text (format "Failed to start a server on port %s (%s). Using port %s instead."
                                             server-port
                                             (.getMessage e)
                                             (http-server/port server))})

--- a/editor/src/clj/editor/boot_open_project.clj
+++ b/editor/src/clj/editor/boot_open_project.clj
@@ -13,7 +13,8 @@
 ;; specific language governing permissions and limitations under the License.
 
 (ns editor.boot-open-project
-  (:require [dynamo.graph :as g]
+  (:require [clojure.java.io :as io]
+            [dynamo.graph :as g]
             [editor.app-view :as app-view]
             [editor.asset-browser :as asset-browser]
             [editor.build-errors-view :as build-errors-view]
@@ -36,6 +37,7 @@
             [editor.hot-reload :as hot-reload]
             [editor.html-view :as html-view]
             [editor.icons :as icons]
+            [editor.notifications :as notifications]
             [editor.notifications-view :as notifications-view]
             [editor.os :as os]
             [editor.outline-view :as outline-view]
@@ -57,6 +59,7 @@
             [service.smoke-log :as slog]
             [util.http-server :as http-server])
   (:import [java.io File]
+           [java.net BindException]
            [javafx.scene Node Scene]
            [javafx.scene.control MenuBar SplitPane Tab TabPane TreeView]
            [javafx.scene.input DragEvent InputEvent KeyCombination KeyEvent MouseEvent]
@@ -147,7 +150,7 @@
     MouseEvent/MOUSE_PRESSED
     MouseEvent/MOUSE_RELEASED})
 
-(defn- load-stage! [workspace project prefs updater newly-created?]
+(defn- load-stage! [workspace project prefs project-path cli-options updater newly-created?]
   (let [^StackPane root (ui/load-fxml "editor.fxml")
         stage (ui/make-stage)
         scene (Scene. root)]
@@ -200,15 +203,30 @@
                                                       root
                                                       open-resource
                                                       (partial app-view/debugger-state-changed! scene tool-tabs))
-          web-server (http-server/start!
-                       (web-server/make-dynamic-handler
-                         (into []
-                               cat
-                               [(engine-profiler/routes)
-                                (console/routes console-view)
-                                (hot-reload/routes workspace)
-                                (bob/routes project)
-                                (command-requests/router root (app-view/make-render-task-progress :resource-sync))])))]
+          server-handler (web-server/make-dynamic-handler
+                           (into []
+                                 cat
+                                 [(engine-profiler/routes)
+                                  (console/routes console-view)
+                                  (hot-reload/routes workspace)
+                                  (bob/routes project)
+                                  (command-requests/router root (app-view/make-render-task-progress :resource-sync))]))
+          server-port (:port cli-options)
+          web-server (try
+                       (http-server/start! server-handler :port server-port)
+                       (catch BindException e
+                         (let [server (http-server/start! server-handler)]
+                           (notifications/show!
+                             (workspace/notifications workspace)
+                             {:type :warning
+                              :text (format "Failed to start a server on port %s: %s. Using port %s instead."
+                                            server-port
+                                            (.getMessage e)
+                                            (http-server/port server))})
+                           server)))]
+      (doto (io/file project-path ".internal" "editor-port")
+        (io/make-parents)
+        (spit (str (http-server/port web-server))))
       (.addEventFilter ^StackPane (.lookup root "#overlay") MouseEvent/ANY ui/ignore-event-filter)
       (ui/add-application-focused-callback! :main-stage app-view/handle-application-focused! app-view changes-view workspace prefs)
       (app-view/reload-extensions! app-view project :all workspace changes-view build-errors-view prefs web-server)
@@ -357,7 +375,7 @@
     root))
 
 (defn open-project!
-  [^File game-project-file prefs render-progress! updater newly-created?]
+  [^File game-project-file prefs cli-options render-progress! updater newly-created?]
   (let [project-path (.getPath (.getParentFile (.getAbsoluteFile game-project-file)))
         build-settings (workspace/make-build-settings prefs)
         workspace-config (shared-editor-settings/load-project-workspace-config project-path)
@@ -367,6 +385,6 @@
         project (project/open-project! *project-graph* extensions workspace game-project-res render-progress!)]
     (ui/run-now
       (icons/initialize! workspace)
-      (load-stage! workspace project prefs updater newly-created?))
+      (load-stage! workspace project prefs project-path cli-options updater newly-created?))
     (g/reset-undo! *project-graph*)
     (log/info :message "project loaded")))

--- a/engine/tools/src/launcher/launcher.cpp
+++ b/engine/tools/src/launcher/launcher.cpp
@@ -260,7 +260,7 @@ int Launch(int argc, char **argv) {
         p++;
       }
     }
-#else
+#endif
     // Assumption that any command line option that does not start with --config
     // is a command line argument that we should pass on.
     for(int j = 1; j < argc && i < max_args; ++j) {
@@ -268,7 +268,6 @@ int Launch(int argc, char **argv) {
         args[i++] = argv[j];
       }
     }
-#endif
     args[i++] = 0;
 
     for (int j = 0; j < i; j++) {


### PR DESCRIPTION
When the editor opens a project, it will start a web server on a random port. This port is now written to the `.internal/editor.port` file.

Additionally, we added a command line option `--port` (or `-p`) to the editor executable, which allows specifying the port during launch.

Example use:
```shell
# on Windows
.\Defold.exe --port 8181

# on Linux:
./Defold --port 8181

# on macOS:
./Defold.app/Contents/MacOS/Defold --port 8181
```

Fixes #8737
