### PR TITLE
Added sdk test for macos, ios, linux and android when running check_sdk

### DIFF
--- a/build_tools/sdk.py
+++ b/build_tools/sdk.py
@@ -851,6 +851,7 @@ def _compile_file_clang(platform, info, srcfile, exefile, verbose):
 
     clang = 'clang++'
     sysroot = ''
+    arch = ''
 
     if platform in ['arm64-android', 'armv7-android']:
         clang = os.path.join(info['bintools'], info['clangname'])

--- a/build_tools/waf_dynamo.py
+++ b/build_tools/waf_dynamo.py
@@ -1824,11 +1824,8 @@ def detect(conf):
             exe_suffix = '.exe'
         target_arch = build_util.get_target_architecture()
         api_version = sdkinfo['api']
-        clang_name  = getAndroidCompilerName(target_arch, api_version)
-        # NDK doesn't support arm64 yet
-        if bp_arch == 'arm64':
-            bp_arch = 'x86_64';
-        bintools    = '%s/toolchains/llvm/prebuilt/%s-%s/bin' % (sdkinfo['ndk'], bp_os, bp_arch)
+        clang_name  = sdkinfo['clangname']
+        bintools    = sdkinfo['bintools']
         bintools    = os.path.normpath(bintools)
         sep         = os.path.sep
 

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -766,6 +766,11 @@ class Configuration(object):
             print("SDK info:")
             pprint.pprint(self.sdk_info)
 
+
+        result = sdk.test_sdk(target_platform, self.sdk_info, verbose = self.verbose)
+        if not result:
+            self.fatal("Failed sdk check")
+
     def verify_sdk(self):
         was_verbose = self.verbose
         self.verbose = True


### PR DESCRIPTION
This will help when new contributors setup their environment, to see if their compiler can build and possibly run a test executable.

### Technical changes

Example building and running a test executable in verbose mode:

```bash
~/work/defold $ ./scripts/build.py check_sdk --platform=arm64-macos --verbose
Couldn't find build_vendor.py. Skipping.
[exec] git remote get-url origin
Starting 'check_sdk' at 11:32:38
check_defold_sdk: arm64-macos /Users/mathiaswesterdahl/work/defold/tmp/dynamo_home/ext/SDKs
  Missing SDK in /Users/mathiaswesterdahl/work/defold/tmp/dynamo_home/ext/SDKs/XcodeDefault16.2.xctoolchain
  Missing SDK in /Users/mathiaswesterdahl/work/defold/tmp/dynamo_home/ext/SDKs/MacOSX15.2.sdk
  No prepackaged sdk found.
check_local_sdk: arm64-macos
[exec] /usr/bin/xcodebuild -version
[exec] /usr/bin/xcodebuild -version
[exec] xcode-select -print-path
[exec] clang --version
[exec] xcrun -f --sdk macosx --show-sdk-platform-version
[exec] xcrun -f --sdk macosx --show-sdk-path
SDK info:
{'arm64-macos': {'path': '/Applications/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.4.sdk',
                 'version': '15.4'},
 'asan': {'path': '/Applications/Xcode-beta.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17.0.0/lib/darwin/libclang_rt.asan_osx_dynamic.dylib'},
 'xcode': {'path': '/Applications/Xcode-beta.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain',
           'version': '16.3'},
 'xcode-clang': '17.0.0'}
[exec] which clang++
/usr/bin/clang++
[exec] clang++  --target=arm64-apple-darwin19  /Users/mathiaswesterdahl/work/defold/tmp/dynamo_home/sdktest/hello.cpp -o /Users/mathiaswesterdahl/work/defold/tmp/dynamo_home/sdktest/a.out
[exec] file /Users/mathiaswesterdahl/work/defold/tmp/dynamo_home/sdktest/a.out
/Users/mathiaswesterdahl/work/defold/tmp/dynamo_home/sdktest/a.out: Mach-O 64-bit executable arm64
[exec] /Users/mathiaswesterdahl/work/defold/tmp/dynamo_home/sdktest/a.out
hello world!
'check_sdk' completed in 0.27 s
```

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
