### PR TITLE
Fix multi-contour artifacts in DF font generator

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/font/Fontc.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/font/Fontc.java
@@ -32,6 +32,7 @@ import java.awt.font.GlyphVector;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.FlatteningPathIterator;
 import java.awt.geom.PathIterator;
+import java.awt.geom.Area;
 import java.awt.geom.Rectangle2D;
 import java.awt.image.BufferedImage;
 import java.awt.image.ColorModel;
@@ -804,7 +805,11 @@ public class Fontc {
         int height = glyph.ascent + glyph.descent + padding * 2;
 
         Shape sh = glyph.vector.getGlyphOutline(0);
-        PathIterator pi = sh.getPathIterator(new AffineTransform(1,0,0,1,0,0));
+        // Normalize the outline by boolean-unioning overlapping contours to avoid
+        // internal edges contributing to the distance field (fixes artifacts for
+        // glyphs composed of multiple vector shapes; see issue #6577)
+        Area area = new Area(sh);
+        PathIterator pi = area.getPathIterator(new AffineTransform(1,0,0,1,0,0));
         pi = new FlatteningPathIterator(pi,  0.1);
 
         double _x = 0, _y = 0;
@@ -863,7 +868,7 @@ public class Fontc {
                 double distanceToEdge   = distanceData[ofs + u];
                 double distanceToBorder = -(distanceToEdge - fontDesc.getOutlineWidth());
 
-                if (!sh.contains(gx, gy)) {
+                if (!area.contains(gx, gy)) {
                     distanceToEdge = -distanceToEdge;
                 }
 

--- a/editor/src/clj/editor/pipeline/fontc.clj
+++ b/editor/src/clj/editor/pipeline/fontc.clj
@@ -21,10 +21,10 @@
            [com.dynamo.bob.font BMFont BMFont$Char DistanceFieldGenerator Fontc]
            [com.dynamo.render.proto Font$FontDesc]
            [com.google.protobuf ByteString]
-           [java.awt BasicStroke Canvas Color Composite CompositeContext Font FontMetrics Graphics2D RenderingHints Shape Transparency]
+           [java.awt BasicStroke Canvas Color Composite CompositeContext Font FontMetrics Graphics Graphics2D RenderingHints Shape Transparency]
            [java.awt.color ColorSpace]
            [java.awt.font FontRenderContext GlyphVector]
-           [java.awt.geom AffineTransform FlatteningPathIterator PathIterator Rectangle2D]
+           [java.awt.geom AffineTransform FlatteningPathIterator PathIterator Rectangle2D Area]
            [java.awt.image BufferedImage ComponentColorModel ConvolveOp DataBuffer DataBufferByte Kernel Raster WritableRaster]
            [java.io FileNotFoundException IOException InputStream]
            [java.nio.file Paths]
@@ -614,7 +614,10 @@
         ^int channel-count channel-count
         ^int shadow-blur shadow-blur
         {^int width :width ^int height :height} (pad-wh padding (glyph-wh glyph))
-        ^Shape glyph-outline (.getGlyphOutline glyph-vector 0)
+        ;; Normalize the outline by boolean-unioning overlapping contours to avoid
+        ;; internal edges contributing to the distance field (fixes artifacts for
+        ;; glyphs composed of multiple vector shapes; see issue #6577)
+        ^Shape glyph-outline (let [area (Area. (.getGlyphOutline glyph-vector 0))] area)
         ^PathIterator outline-iterator (FlatteningPathIterator. (.getPathIterator glyph-outline identity-transform) 0.1)
         segment-points (double-array 6 0.0)]
 


### PR DESCRIPTION
Fixed DF font artifacts that occur in some fonts with vector shapes overlapping each other:
![](https://forum.defold.com/uploads/default/original/3X/a/e/ae42187237af0d7f75ecce47e55ac5dff1629677.png)<img width="296" height="293" alt="CleanShot 2025-08-09 at 18 40 18@2x" src="https://github.com/user-attachments/assets/4bf77e6a-aa0b-4fae-a1c1-947bf08b2b56" />



Fix https://github.com/defold/defold/issues/6577