### PR TITLE
Show an error message if the decoder for a used sound isn't included in the App Manifest

### DIFF
--- a/engine/sound/src/sound.cpp
+++ b/engine/sound/src/sound.cpp
@@ -749,7 +749,7 @@ namespace dmSound
                 if (r == dmSoundCodec::RESULT_UNSUPPORTED) {
                     const char* name = dmHashReverseSafe64(sound_data->m_NameHash);
                     const char* format_str = dmSoundCodec::FormatToString(codec_format);
-                    dmLogWarning("Sound '%s' uses %s, but no decoder was found. Ensure the codec is included in your App Manifest.", name, format_str);
+                    dmLogError("Sound '%s' uses %s, but no decoder was found. Ensure the codec is included in your App Manifest.", name, format_str);
                 } else {
                     dmLogError("Failed to decode sound %s: (%d)", dmHashReverseSafe64(sound_data->m_NameHash), r);
                 }

--- a/engine/sound/src/sound.cpp
+++ b/engine/sound/src/sound.cpp
@@ -746,7 +746,13 @@ namespace dmSound
 
             dmSoundCodec::Result r = dmSoundCodec::NewDecoder(ss->m_CodecContext, codec_format, sound_data, &decoder);
             if (r != dmSoundCodec::RESULT_OK) {
-                dmLogError("Failed to decode sound %s: (%d)", dmHashReverseSafe64(sound_data->m_NameHash), r);
+                if (r == dmSoundCodec::RESULT_UNSUPPORTED) {
+                    const char* name = dmHashReverseSafe64(sound_data->m_NameHash);
+                    const char* format_str = dmSoundCodec::FormatToString(codec_format);
+                    dmLogWarning("Sound '%s' uses %s, but no decoder was found. Ensure the codec is included in your App Manifest.", name, format_str);
+                } else {
+                    dmLogError("Failed to decode sound %s: (%d)", dmHashReverseSafe64(sound_data->m_NameHash), r);
+                }
                 return RESULT_INVALID_STREAM_DATA;
             }
 

--- a/engine/sound/src/sound_codec.h
+++ b/engine/sound/src/sound_codec.h
@@ -152,6 +152,7 @@ namespace dmSoundCodec
     Result Reset(HCodecContext context, HDecoder decoder);
 
     const char* ResultToString(Result result);
+    const char* FormatToString(Format format);
 
     // Unit tests
     int64_t GetInternalPos(HCodecContext context, HDecoder decoder);

--- a/engine/sound/src/sound_decoder.cpp
+++ b/engine/sound/src/sound_decoder.cpp
@@ -72,8 +72,6 @@ namespace dmSoundCodec
 
             decoder = decoder->m_Next;
         }
-
-        assert(best != 0);
         return best;
     }
 
@@ -94,5 +92,20 @@ namespace dmSoundCodec
             default: return "Unknown";
         }
 #undef RESULT_CASE
+    }
+
+    const char* FormatToString(Format format)
+    {
+        switch(format)
+        {
+#define FORMAT_CASE(_NAME) \
+    case _NAME: return #_NAME
+
+            FORMAT_CASE(FORMAT_WAV);
+            FORMAT_CASE(FORMAT_VORBIS);
+            FORMAT_CASE(FORMAT_OPUS);
+            default: return "Unknown";
+        }
+#undef FORMAT_CASE
     }
 }


### PR DESCRIPTION
Fixes an issue where the engine crashes if an `opus` file is used without including the OPUS decoder in the App Manifest. Now the engine shows an error to help figure out what's going on.

Fix https://github.com/defold/defold/issues/11069