### PR TITLE
Added physics solver parameters into `game.project` -> `Box2D`

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
@@ -202,8 +202,8 @@ position_iterations.help = number of position iterations for Box2D 2.2 physics s
 position_iterations.default = 10
 
 sub_step_count.type = integer
-sub_step_count.help = number of sub-steps for Box2D 3.x physics solver, 10 by default
-sub_step_count.default = 10
+sub_step_count.help = number of sub-steps for Box2D 3.x physics solver, 4 by default
+sub_step_count.default = 4
 
 [bootstrap]
 help = Initial settings for the engine

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
@@ -190,6 +190,21 @@ max_fixed_timesteps.type = integer
 max_fixed_timesteps.help = max number of steps in the simulation when using fixed timestep
 max_fixed_timesteps.default = 2
 
+[box2d]
+help = Box2D physics settings. Availability of options depends on the Box2D version.
+
+velocity_iterations.type = integer
+velocity_iterations.help = number of velocity iterations for Box2D 2.2 physics solver, 10 by default
+velocity_iterations.default = 10
+
+position_iterations.type = integer
+position_iterations.help = number of position iterations for Box2D 2.2 physics solver, 10 by default
+position_iterations.default = 10
+
+sub_step_count.type = integer
+sub_step_count.help = number of sub-steps for Box2D 3.x physics solver, 10 by default
+sub_step_count.default = 10
+
 [bootstrap]
 help = Initial settings for the engine
 main_collection.type = resource

--- a/editor/resources/meta.edn
+++ b/editor/resources/meta.edn
@@ -971,7 +971,19 @@
   {:type :integer,
    :help "max number of concurrent (visible) tiles in a collection",
    :default 2048,
-   :path ["tilemap" "max_tile_count"]}]
+   :path ["tilemap" "max_tile_count"]},
+  {:type :integer,
+   :help "number of velocity iterations for Box2D 2.2 physics solver, 10 by default",
+   :default 10,
+   :path ["box2d" "velocity_iterations"]},
+  {:type :integer,
+   :help "number of position iterations for Box2D 2.2 physics solver, 10 by default",
+   :default 10,
+   :path ["box2d" "position_iterations"]},
+  {:type :integer,
+   :help "number of sub-steps for Box2D 3.x physics solver, 10 by default",
+   :default 10,
+   :path ["box2d" "sub_step_count"]}]
  :group-order ["Main" "Platforms" "Components" "Runtime" "Distribution"]
  :default-category "project"
  :categories
@@ -1002,6 +1014,8 @@
                       :group "Components"}
   "physics" {:help "Physics settings"
              :group "Runtime"},
+  "box2d" {:help "Box2D physics settings. Availability of options depends on the Box2D version."
+           :group "Runtime"},
   "osx" {:help "Mac OSX related settings"
          :title "OSX"
          :group "Platforms"},

--- a/editor/resources/meta.edn
+++ b/editor/resources/meta.edn
@@ -981,8 +981,8 @@
    :default 10,
    :path ["box2d" "position_iterations"]},
   {:type :integer,
-   :help "number of sub-steps for Box2D 3.x physics solver, 10 by default",
-   :default 10,
+   :help "number of sub-steps for Box2D 3.x physics solver, 4 by default",
+   :default 4,
    :path ["box2d" "sub_step_count"]}]
  :group-order ["Main" "Platforms" "Components" "Runtime" "Distribution"]
  :default-category "project"

--- a/editor/test/resources/save_data_project/game.project
+++ b/editor/test/resources/save_data_project/game.project
@@ -239,6 +239,11 @@ trigger_overlap_capacity = 8
 velocity_threshold = 0.9
 max_fixed_timesteps = 3
 
+[box2d]
+velocity_iterations = 1
+position_iterations = 2
+sub_step_count = 3
+
 [profiler]
 track_cpu = 1
 sleep_between_server_updates = 10

--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -714,7 +714,7 @@ namespace dmEngine
         physics->m_MaxFixedTimesteps = dmConfigFile::GetInt(config, dmGameSystem::PHYSICS_MAX_FIXED_TIMESTEPS, 2);
         physics->m_Box2DVelocityIterations = dmConfigFile::GetInt(config, dmGameSystem::BOX2D_VELOCITY_ITERATIONS, 10);
         physics->m_Box2DPositionIterations = dmConfigFile::GetInt(config, dmGameSystem::BOX2D_POSITION_ITERATIONS, 10);
-        physics->m_Box2DSubStepCount = dmConfigFile::GetInt(config, dmGameSystem::BOX2D_SUB_STEP_COUNT, 10);
+        physics->m_Box2DSubStepCount = dmConfigFile::GetInt(config, dmGameSystem::BOX2D_SUB_STEP_COUNT, 4);
         // TODO: Should move inside the ifdef release? Is this usable without the debug callbacks?
         physics->m_Debug = (bool) dmConfigFile::GetInt(config, "physics.debug", 0);
     }

--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -712,6 +712,9 @@ namespace dmEngine
         physics->m_MaxContactPointCount = dmConfigFile::GetInt(config, dmGameSystem::PHYSICS_MAX_CONTACTS_KEY, 128);
         physics->m_UseFixedTimestep = dmConfigFile::GetInt(config, dmGameSystem::PHYSICS_USE_FIXED_TIMESTEP, 1) ? 1 : 0;
         physics->m_MaxFixedTimesteps = dmConfigFile::GetInt(config, dmGameSystem::PHYSICS_MAX_FIXED_TIMESTEPS, 2);
+        physics->m_Box2DVelocityIterations = dmConfigFile::GetInt(config, dmGameSystem::BOX2D_VELOCITY_ITERATIONS, 10);
+        physics->m_Box2DPositionIterations = dmConfigFile::GetInt(config, dmGameSystem::BOX2D_POSITION_ITERATIONS, 10);
+        physics->m_Box2DSubStepCount = dmConfigFile::GetInt(config, dmGameSystem::BOX2D_SUB_STEP_COUNT, 10);
         // TODO: Should move inside the ifdef release? Is this usable without the debug callbacks?
         physics->m_Debug = (bool) dmConfigFile::GetInt(config, "physics.debug", 0);
     }

--- a/engine/gamesys/src/gamesys/components/box2d/comp_collision_object_box2d.cpp
+++ b/engine/gamesys/src/gamesys/components/box2d/comp_collision_object_box2d.cpp
@@ -636,6 +636,9 @@ namespace dmGameSystem
         step_world_context.m_RayCastUserData = world;
         step_world_context.m_FixedTimeStep = physics_context->m_BaseContext.m_UseFixedTimestep;
         step_world_context.m_MaxFixedTimeSteps = physics_context->m_BaseContext.m_MaxFixedTimesteps;
+        step_world_context.m_Box2DVelocityIterations = physics_context->m_BaseContext.m_Box2DVelocityIterations;
+        step_world_context.m_Box2DPositionIterations = physics_context->m_BaseContext.m_Box2DPositionIterations;
+        step_world_context.m_Box2DSubStepCount = physics_context->m_BaseContext.m_Box2DSubStepCount;
 
         step_world_context.m_DT = params.m_UpdateContext->m_DT;
 

--- a/engine/gamesys/src/gamesys/components/comp_collision_object.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_collision_object.cpp
@@ -36,6 +36,12 @@ namespace dmGameSystem
     const char* PHYSICS_USE_FIXED_TIMESTEP          = "physics.use_fixed_timestep";
     /// Config key for using max updates during a single step
     const char* PHYSICS_MAX_FIXED_TIMESTEPS         = "physics.max_fixed_timesteps";
+    /// Config key for Box2D 2.2 velocity iterations
+    const char* BOX2D_VELOCITY_ITERATIONS            = "box2d.velocity_iterations";
+    /// Config key for Box2D 2.2 position iterations  
+    const char* BOX2D_POSITION_ITERATIONS            = "box2d.position_iterations";
+    /// Config key for Box2D 3.x sub-step count
+    const char* BOX2D_SUB_STEP_COUNT                 = "box2d.sub_step_count";
 
     dmGameObject::CreateResult CompCollisionObjectNewWorld(const dmGameObject::ComponentNewWorldParams& params)
     {

--- a/engine/gamesys/src/gamesys/gamesys.h
+++ b/engine/gamesys/src/gamesys/gamesys.h
@@ -48,6 +48,12 @@ namespace dmGameSystem
     extern const char* PHYSICS_USE_FIXED_TIMESTEP;
     /// Config key for using max updates during a single step
     extern const char* PHYSICS_MAX_FIXED_TIMESTEPS;
+    /// Config key for Box2D 2.2 velocity iterations
+    extern const char* BOX2D_VELOCITY_ITERATIONS;
+    /// Config key for Box2D 2.2 position iterations
+    extern const char* BOX2D_POSITION_ITERATIONS;
+    /// Config key for Box2D 3.x sub-step count
+    extern const char* BOX2D_SUB_STEP_COUNT;
     /// Config key to use for tweaking maximum number of collection proxies
     extern const char* COLLECTION_PROXY_MAX_COUNT_KEY;
     /// Config key to use for tweaking maximum number of factories
@@ -179,6 +185,9 @@ namespace dmGameSystem
         bool              m_Debug;
         bool              m_UseFixedTimestep;
         uint32_t          m_MaxFixedTimesteps;
+        uint32_t          m_Box2DVelocityIterations;
+        uint32_t          m_Box2DPositionIterations;
+        uint32_t          m_Box2DSubStepCount;
         PhysicsEngineType m_PhysicsType;
     };
 

--- a/engine/gamesys/src/gamesys/test/test_gamesys.h
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.h
@@ -600,6 +600,9 @@ void GamesysTest<T>::SetUp()
         m_PhysicsContextBox2D.m_BaseContext.m_MaxContactPointCount = 128;
         m_PhysicsContextBox2D.m_BaseContext.m_MaxCollisionObjectCount = 512;
         m_PhysicsContextBox2D.m_BaseContext.m_PhysicsType = dmGameSystem::PHYSICS_ENGINE_BOX2D;
+        m_PhysicsContextBox2D.m_BaseContext.m_Box2DVelocityIterations = 10;
+        m_PhysicsContextBox2D.m_BaseContext.m_Box2DPositionIterations = 10;
+        m_PhysicsContextBox2D.m_BaseContext.m_Box2DSubStepCount = 4;
 
         dmPhysics::NewContextParams context2DParams = dmPhysics::NewContextParams();
         context2DParams.m_Scale = this->m_projectOptions.m_Scale;

--- a/engine/physics/src/physics/box2d/box2d_physics.cpp
+++ b/engine/physics/src/physics/box2d/box2d_physics.cpp
@@ -546,7 +546,7 @@ namespace dmPhysics
         {
             DM_PROFILE("StepSimulation");
 
-            b2World_Step(world->m_WorldId, dt, 10);
+            b2World_Step(world->m_WorldId, dt, step_context.m_Box2DSubStepCount);
 
             // Post-solve must happen after stepping
             if (step_context.m_CollisionCallback || step_context.m_ContactPointCallback)

--- a/engine/physics/src/physics/box2d_defold/box2d_defold_physics.cpp
+++ b/engine/physics/src/physics/box2d_defold/box2d_defold_physics.cpp
@@ -472,7 +472,7 @@ namespace dmPhysics
         {
             DM_PROFILE("StepSimulation");
             world->m_ContactListener.SetStepWorldContext(&step_context);
-            world->m_World.Step(dt, 10, 10);
+            world->m_World.Step(dt, step_context.m_Box2DVelocityIterations, step_context.m_Box2DPositionIterations);
             float inv_scale = world->m_Context->m_InvScale;
             // Update transforms of dynamic bodies
             if (world->m_SetWorldTransformCallback)

--- a/engine/physics/src/physics/physics.h
+++ b/engine/physics/src/physics/physics.h
@@ -361,6 +361,9 @@ namespace dmPhysics
         float                   m_DT;
         bool                    m_FixedTimeStep;
         uint32_t                m_MaxFixedTimeSteps;
+        uint32_t                m_Box2DVelocityIterations;
+        uint32_t                m_Box2DPositionIterations;
+        uint32_t                m_Box2DSubStepCount;
         /// Collision callback function
         CollisionCallback       m_CollisionCallback;
         /// Collision callback user data

--- a/engine/physics/src/physics/test/test_physics.h
+++ b/engine/physics/src/physics/test/test_physics.h
@@ -65,6 +65,10 @@ protected:
         m_StepWorldContext.m_ContactPointCallback = ContactPointCallback;
         m_StepWorldContext.m_ContactPointUserData = &m_ContactPointCount;
         m_StepWorldContext.m_MaxFixedTimeSteps = 2;
+        // Initialize Box2D solver parameters with defaults
+        m_StepWorldContext.m_Box2DVelocityIterations = 10;
+        m_StepWorldContext.m_Box2DPositionIterations = 10;
+        m_StepWorldContext.m_Box2DSubStepCount = 10;
     }
 
     virtual void TearDown()

--- a/engine/physics/src/physics/test/test_physics.h
+++ b/engine/physics/src/physics/test/test_physics.h
@@ -65,7 +65,6 @@ protected:
         m_StepWorldContext.m_ContactPointCallback = ContactPointCallback;
         m_StepWorldContext.m_ContactPointUserData = &m_ContactPointCount;
         m_StepWorldContext.m_MaxFixedTimeSteps = 2;
-        // Initialize Box2D solver parameters with defaults
         m_StepWorldContext.m_Box2DVelocityIterations = 10;
         m_StepWorldContext.m_Box2DPositionIterations = 10;
         m_StepWorldContext.m_Box2DSubStepCount = 10;


### PR DESCRIPTION
Added new `[box2d]` section in game.project:
  - `velocity_iterations` (default: 10) - Box2D 2.2 velocity solver iterations
  - `position_iterations` (default: 10) - Box2D 2.2 position solver iterations
  - `sub_step_count` (default: 4) - Box2D 3.x sub-stepping count
  
Using these new parameters, users can reduce iterations for better performance or increase for higher precision.

Fix https://github.com/defold/defold/issues/10692