### PR TITLE
Improve the correctness of reported deps and refs for resources

### DIFF
--- a/editor/project.clj
+++ b/editor/project.clj
@@ -214,7 +214,7 @@
                       :reveal {:source-paths ["src/reveal"]
                                :jvm-opts ["-Djol.magicFieldOffset=true" "-XX:+EnableDynamicAgentLoading"]
                                :injections [(require 'editor.reveal)]
-                               :dependencies [[vlaaad/reveal "1.3.284"]]}
+                               :dependencies [[vlaaad/reveal "1.3.287"]]}
                       :metrics {:jvm-opts ["-Ddefold.metrics=true"]}
                       :jamm {:dependencies [[com.github.jbellis/jamm "0.4.0"]]
                              :jvm-opts [~(str "-javaagent:"

--- a/editor/src/clj/util/coll.clj
+++ b/editor/src/clj/util/coll.clj
@@ -635,6 +635,19 @@
        (sequential? input) (reduce (preserving-reduced xf) result input)
        :else (rf result input)))))
 
+(defn tree-xf
+  "Like clojure.core/tree-seq, but transducer"
+  [branch? children]
+  (fn [rf]
+    (fn xf
+      ([] (rf))
+      ([result] (rf result))
+      ([result input]
+       (let [result (rf result input)]
+         (if (or (reduced? result) (not (branch? input)))
+           result
+           (reduce (preserving-reduced xf) result (children input))))))))
+
 (defn some
   "Like clojure.core/some, but uses reduce instead of lazy sequences."
   [pred coll]

--- a/editor/test/integration/refs_and_deps_test.clj
+++ b/editor/test/integration/refs_and_deps_test.clj
@@ -13,7 +13,6 @@
                                  [path {:refs (into #{} (map resource/proj-path) (resource-dialog/refs-filter-fn project path nil))
                                         :deps (into #{} (map resource/proj-path) (resource-dialog/deps-filter-fn project path nil))}])))
                         (g/node-value workspace :resource-list))]
-      (tap> (into (sorted-map) dep-map))
       (doseq [[path {:keys [refs deps]}] dep-map]
         (testing path
           (doseq [dep deps]

--- a/editor/test/integration/refs_and_deps_test.clj
+++ b/editor/test/integration/refs_and_deps_test.clj
@@ -1,0 +1,24 @@
+(ns integration.refs-and-deps-test
+  (:require [clojure.test :refer :all]
+            [dynamo.graph :as g]
+            [editor.resource :as resource]
+            [editor.resource-dialog :as resource-dialog]
+            [integration.test-util :as test-util]))
+
+(deftest refs-and-deps-symmetry-test
+  (test-util/with-loaded-project
+    (let [dep-map (into {}
+                        (map (fn [res]
+                               (let [path (resource/proj-path res)]
+                                 [path {:refs (into #{} (map resource/proj-path) (resource-dialog/refs-filter-fn project path nil))
+                                        :deps (into #{} (map resource/proj-path) (resource-dialog/deps-filter-fn project path nil))}])))
+                        (g/node-value workspace :resource-list))]
+      (tap> (into (sorted-map) dep-map))
+      (doseq [[path {:keys [refs deps]}] dep-map]
+        (testing path
+          (doseq [dep deps]
+            (testing (str "dep on " dep)
+              (is (contains? (:refs (dep-map dep)) path) (str path " depends on " dep ", but " dep " is not referenced by " path))))
+          (doseq [ref refs]
+            (testing (str "ref by "ref)
+              (is (contains? (:deps (dep-map ref)) path) (str path " is referenced by " ref ", but " ref " does not depend on " path)))))))))

--- a/editor/test/resources/test_project/.gitignore
+++ b/editor/test/resources/test_project/.gitignore
@@ -1,2 +1,3 @@
 /build
 /.editor_settings
+/.internal


### PR DESCRIPTION
Previously, when using "Referencing Files..." or "Dependencies...", the returned results were frequently incomplete or flat out incorrect. Now, the issue is fixed!

Fixes #10726