### PR TITLE
Enable `go.exists()` to query the existence of game objects across collections

### DIFF
--- a/engine/engine/src/test/collection_proxy/cross_collection_exists.collection
+++ b/engine/engine/src/test/collection_proxy/cross_collection_exists.collection
@@ -1,0 +1,5 @@
+name: "cross_collection_exists"
+instances {
+  id: "test_id"
+  prototype: "/collection_proxy/cross_collection_exists.go"
+}

--- a/engine/engine/src/test/collection_proxy/cross_collection_exists.go
+++ b/engine/engine/src/test/collection_proxy/cross_collection_exists.go
@@ -1,0 +1,9 @@
+components {
+  id: "script"
+  component: "/collection_proxy/cross_collection_exists.script"
+}
+embedded_components {
+  id: "target_proxy"
+  type: "collectionproxy"
+  data: "collection: \"/collection_proxy/cross_collection_target.collection\"\n"
+}

--- a/engine/engine/src/test/collection_proxy/cross_collection_exists.script
+++ b/engine/engine/src/test/collection_proxy/cross_collection_exists.script
@@ -1,0 +1,58 @@
+-- Copyright 2020-2025 The Defold Foundation
+-- Copyright 2014-2020 King
+-- Copyright 2009-2014 Ragnar Svensson, Christian Murray
+-- Licensed under the Defold License version 1.0 (the "License"); you may not use
+-- this file except in compliance with the License.
+--
+-- You may obtain a copy of the License, together with FAQs at
+-- https://www.defold.com/license
+--
+-- Unless required by applicable law or agreed to in writing, software distributed
+-- under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+-- CONDITIONS OF ANY KIND, either express or implied. See the License for the
+-- specific language governing permissions and limitations under the License.
+
+function init(self)
+    self.test_phase = "loading"
+    msg.post("#target_proxy", "load")
+end
+
+function on_message(self, message_id, message, sender)
+    if message_id == hash("proxy_loaded") then
+        if self.test_phase == "loading" then
+            self.test_phase = "testing"
+            msg.post("#target_proxy", "enable")
+            
+            -- Test cross-collection go.exists() functionality
+            print("Testing cross-collection go.exists() functionality...")
+            
+            -- Test 1: Positive case - object exists in loaded collection
+            local exists_result = go.exists("cross_collection_target:/target_object")
+            assert(exists_result == true, "Expected go.exists('cross_collection_target:/target_object') to return true")
+            
+            -- Test 2: Negative case - object does not exist in loaded collection
+            local not_exists_result = go.exists("cross_collection_target:/nonexistent_object")
+            assert(not_exists_result == false, "Expected go.exists('cross_collection_target:/nonexistent_object') to return false")
+            
+            -- Test 3: Non-existent collection should return false (not error)
+            local invalid_collection_result = go.exists("invalid_collection:/any_object")
+            assert(invalid_collection_result == false, "Expected go.exists('invalid_collection:/any_object') to return false")
+            
+            print("All cross-collection go.exists() tests passed!")
+            
+            -- Now test unload scenario
+            msg.post("#target_proxy", "unload")
+            self.test_phase = "unloading"
+        end
+    elseif message_id == hash("proxy_unloaded") then
+        if self.test_phase == "unloading" then
+            -- Test 4: After unload, cross-collection queries should return false
+            local unloaded_result = go.exists("cross_collection_target:/target_object")
+            assert(unloaded_result == false, "Expected go.exists('cross_collection_target:/target_object') to return false after unload")
+            msg.post("main:/main#script", "done")
+        end
+    elseif message_id == hash("init") then
+        -- Called by main test orchestrator, start the test
+        msg.post("#target_proxy", "load")
+    end
+end

--- a/engine/engine/src/test/collection_proxy/cross_collection_target.collection
+++ b/engine/engine/src/test/collection_proxy/cross_collection_target.collection
@@ -1,0 +1,5 @@
+name: "cross_collection_target"
+instances {
+  id: "target_object"
+  prototype: "/collection_proxy/cross_collection_target.go"
+}

--- a/engine/engine/src/test/collection_proxy/cross_collection_target.go
+++ b/engine/engine/src/test/collection_proxy/cross_collection_target.go
@@ -1,0 +1,4 @@
+components {
+  id: "script"
+  component: "/collection_proxy/cross_collection_target.script"
+}

--- a/engine/engine/src/test/collection_proxy/cross_collection_target.script
+++ b/engine/engine/src/test/collection_proxy/cross_collection_target.script
@@ -1,0 +1,18 @@
+-- Copyright 2020-2025 The Defold Foundation
+-- Copyright 2014-2020 King
+-- Copyright 2009-2014 Ragnar Svensson, Christian Murray
+-- Licensed under the Defold License version 1.0 (the "License"); you may not use
+-- this file except in compliance with the License.
+--
+-- You may obtain a copy of the License, together with FAQs at
+-- https://www.defold.com/license
+--
+-- Unless required by applicable law or agreed to in writing, software distributed
+-- under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+-- CONDITIONS OF ANY KIND, either express or implied. See the License for the
+-- specific language governing permissions and limitations under the License.
+
+-- Simple target script that just exists for cross-collection testing
+function init(self)
+    -- Nothing to do, just exist as a target for go.exists() tests
+end

--- a/engine/engine/src/test/game.project
+++ b/engine/engine/src/test/game.project
@@ -11,7 +11,7 @@ uri = src/test/build/default
 [physics]
 world_count = 18
 [collection_proxy]
-max_count = 39
+max_count = 40
 [particle_fx]
 max_count = 1
 

--- a/engine/engine/src/test/main.go
+++ b/engine/engine/src/test/main.go
@@ -334,3 +334,21 @@ embedded_components {
     w: 1.0
   }
 }
+embedded_components {
+  id: "cross_collection_exists_proxy"
+  type: "collectionproxy"
+  data: "collection: \"/collection_proxy/cross_collection_exists.collection\"\n"
+  "exclude: false\n"
+  ""
+  position {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+}

--- a/engine/engine/src/test/main.script
+++ b/engine/engine/src/test/main.script
@@ -25,7 +25,8 @@ function init(self)
         "#gui_proxy", "#attacker_target_proxy",
         "#identifiers_proxy", "#shared_state_proxy",
         "#label_proxy", "#ray_cast_proxy",
-        "#collision_groups_proxy", "#collectionfactoryprops_proxy"
+        "#collision_groups_proxy", "#collectionfactoryprops_proxy",
+        "#cross_collection_exists_proxy"
 	}
     self.test_index = 1
     msg.post(self.loading_proxy, "load")

--- a/engine/gameobject/src/gameobject/test/script/exists.script
+++ b/engine/gameobject/src/gameobject/test/script/exists.script
@@ -23,8 +23,6 @@ function init(self)
     if pcall(go.exists, nil) then
         assert(false, "Error expected when calling go.exists with nil")
     end
-    if pcall(go.exists, "foo:/bar") then
-        assert(false, "Error expected when calling go.exists with another collection")
-    end
+    assert(not go.exists("foo:/bar"), "Expected go 'foo:/bar' (non-existent collection) to not exist")
     assert(go.exists(), "Object itself always exists")
 end


### PR DESCRIPTION
With this fix, it will be possible to use the `go.exists()` function to check if a game object exists in another collection.

Fix https://github.com/defold/defold/issues/10795