### PR TITLE
Add `zip.unpack` editor script function

### DIFF
--- a/editor/.idea/ClojureProjectResolveSettings.xml
+++ b/editor/.idea/ClojureProjectResolveSettings.xml
@@ -13,6 +13,7 @@
     <item key="editor.git-test/with-new-git" resolves-as="clojure.core/def" />
     <item key="editor.editor-extensions.runtime/lua-fn" resolves-as="clojure.core/fn" />
     <item key="editor.ui/with-controls" resolves-as="clojure.core/fn" />
+    <item key="editor.editor-extensions.runtime/suspendable-varargs-lua-fn" resolves-as="clojure.core/fn" />
     <item key="dynamo.graph/deftype" resolves-as="clojure.core/def" />
     <item key="util.defonce/type" resolves-as="clojure.core/deftype" />
     <item key="dynamo.graph/defnode" resolves-as="clojure.core/def" />

--- a/editor/src/clj/editor/editor_extensions/docs.clj
+++ b/editor/src/clj/editor/editor_extensions/docs.clj
@@ -881,6 +881,50 @@ zip.pack(\"build.zip\", {
   {\"../secrets/auth-key.txt\", \"auth-key.txt\"}
 })
 ```"})
+         {:name "zip.unpack"
+          :type :function
+          :parameters [{:name "archive_path"
+                        :types ["string"]
+                        :doc "zip file path, resolved against project root if relative"}
+                       {:name "[target_path]"
+                        :types ["string"]
+                        :doc "target path for extraction, defaults to parent of <code>archive_path</code> if omitted"}
+                       {:name "[opts]"
+                        :types ["table"]
+                        :doc (str "extraction options, a table with the following keys:"
+                                  (lua-completion/args-doc-html
+                                    [{:name "on_conflict"
+                                      :types ["string"]
+                                      :doc "conflict resolution strategy, defaults to <code>zip.ON_CONFLICT.ERROR</code>"}]))}
+                       {:name "[paths]"
+                        :types ["table"]
+                        :doc "entries to extract, relative string paths"}]
+          :description "Extract a ZIP archive"
+          :examples "Extract everything to a build dir:
+```lua
+zip.unpack(\"build/dev/resources.zip\")
+```
+Extract to a different directory:
+```lua
+zip.unpack(
+  \"build/dev/resources.zip\",
+  \"build/dev/tmp\",
+)
+```
+Extract while overwriting existing files on conflict:
+```lua
+zip.unpack(
+  \"build/dev/resources.zip\",
+  {on_conflict = zip.ON_CONFLICT.OVERWRITE}
+)
+```
+Extract a single file:
+```lua
+zip.unpack(
+  \"build/dev/resources.zip\",
+  {\"config.json\"}
+)
+```"}
          {:name "zip.METHOD"
           :type :module
           :description "Constants for zip compression methods"}
@@ -889,4 +933,16 @@ zip.pack(\"build.zip\", {
           :description "<code>\"deflated\"</code> compression method"}
          {:name "zip.METHOD.STORED"
           :type :constant
-          :description "<code>\"stored\"</code> compression method, i.e. no compression"}]))))
+          :description "<code>\"stored\"</code> compression method, i.e. no compression"}
+         {:name "zip.ON_CONFLICT"
+          :type :module
+          :description "Constants defining conflict resolution strategies for zip archive extraction"}
+         {:name "zip.ON_CONFLICT.ERROR"
+          :type :constant
+          :description "`\"error\"`, any conflict aborts extraction"}
+         {:name "zip.ON_CONFLICT.SKIP"
+          :type :constant
+          :description "`\"skip\"`, existing file is preserved"}
+         {:name "zip.ON_CONFLICT.OVERWRITE"
+          :type :constant
+          :description "`\"skip\"`, existing file is overwritten"}]))))

--- a/editor/src/clj/editor/editor_extensions/zip.clj
+++ b/editor/src/clj/editor/editor_extensions/zip.clj
@@ -18,9 +18,14 @@
             [editor.editor-extensions.coerce :as coerce]
             [editor.editor-extensions.runtime :as rt]
             [editor.fs :as fs]
-            [editor.future :as future])
-  (:import [java.nio.file Path]
-           [org.apache.commons.compress.archivers.zip ZipArchiveEntry ZipArchiveOutputStream]
+            [editor.future :as future]
+            [editor.os :as os]
+            [util.coll :as coll])
+  (:import [java.nio.file Files Path]
+           [java.nio.file.attribute PosixFilePermission]
+           [java.util EnumSet]
+           [org.apache.commons.compress.archivers.zip ZipArchiveEntry ZipArchiveOutputStream ZipFile ZipArchiveInputStream]
+           [org.apache.commons.io FilenameUtils]
            [org.luaj.vm2 LuaError LuaValue]))
 
 (set! *warn-on-reflection* true)
@@ -62,11 +67,36 @@
   (when (.startsWith p "..")
     (throw (LuaError. (str "Target path is above archive root: " p)))))
 
+(def ^:private permission-bits
+  [(coll/pair PosixFilePermission/OWNER_READ     0400)
+   (coll/pair PosixFilePermission/OWNER_WRITE    0200)
+   (coll/pair PosixFilePermission/OWNER_EXECUTE  0100)
+   (coll/pair PosixFilePermission/GROUP_READ     0040)
+   (coll/pair PosixFilePermission/GROUP_WRITE    0020)
+   (coll/pair PosixFilePermission/GROUP_EXECUTE  0010)
+   (coll/pair PosixFilePermission/OTHERS_READ    0004)
+   (coll/pair PosixFilePermission/OTHERS_WRITE   0002)
+   (coll/pair PosixFilePermission/OTHERS_EXECUTE 0001)])
+
+(defn- get-unix-mode [^Path source]
+  (let [permissions (Files/getPosixFilePermissions source fs/empty-link-option-array)]
+    (transduce (map #(if (.contains permissions (key %)) (val %) 0)) + 0 permission-bits)))
+
+(defn- get-permissions [unix-mode]
+  (reduce
+    (fn [^EnumSet acc e]
+      (if (zero? (bit-and unix-mode (val e)))
+        acc
+        (doto acc (.add (key e)))))
+    (EnumSet/noneOf PosixFilePermission)
+    permission-bits))
+
 (defn- write-file! [^ZipArchiveOutputStream zos ^Path source ^Path target]
   (let [entry-name (string/replace target \\ \/)]
     (.putArchiveEntry
       zos
       (doto (ZipArchiveEntry. entry-name)
+        (cond-> (not (os/is-win32?)) (.setUnixMode (get-unix-mode source)))
         (.setSize (fs/path-size source))
         (.setTime (fs/path-last-modified-time source))))
     (with-open [is (io/input-stream source)]
@@ -110,7 +140,80 @@
            (future/then (fn [_] (reload-resources!)))
            (future/then rt/and-refresh-context))))))
 
+(def ^:private unpack-args-coercer
+  (coerce/regex :archive-path coerce/string
+                :target-path :? coerce/string
+                :opts :? (coerce/wrap-with-pred
+                           (coerce/hash-map :opt {:on_conflict (coerce/enum :error :skip :overwrite)}
+                                            :extra-keys false)
+                           #(pos? (count %)) "at least one option is required")
+                :paths :? (coerce/vector-of
+                            (-> coerce/string
+                                (coerce/wrap-transform #(.normalize (fs/path %)))
+                                (coerce/wrap-with-pred #(not (.startsWith ^Path % "..")) "is above root")
+                                (coerce/wrap-with-pred #(not (.isAbsolute ^Path %)) "is absolute")
+                                (coerce/wrap-transform #(FilenameUtils/separatorsToUnix (str %)))
+                                (coerce/wrap-with-pred #(not (coll/empty? %)) "is empty"))
+                            :min-count 1)))
+
+(def ^:private default-unpack-opts {:on_conflict :error})
+
+(defn- make-ext-unpack-fn [^Path project-path reload-resources!]
+  (rt/suspendable-varargs-lua-fn ext-unpack [{:keys [rt]} varargs]
+    (let [{:keys [^String archive-path ^String target-path opts paths]
+           :or {opts default-unpack-opts}} (rt/->clj rt unpack-args-coercer varargs)]
+      (-> (future/io
+            (let [archive-path (.resolve project-path archive-path)
+                  ^Path target-path (if target-path
+                                      (.resolve project-path target-path)
+                                      (.getParent archive-path))]
+              (cond
+                (not (fs/path-exists? archive-path)) (throw (LuaError. (str "Archive path does not exist: " archive-path)))
+                (fs/path-is-directory? archive-path) (throw (LuaError. (str "Archive path is a directory: " archive-path))))
+              (with-open [zip (ZipFile. (.toFile archive-path))]
+                (let [entries (.getEntries zip)]
+                  (while (.hasMoreElements entries)
+                    (let [^ZipArchiveEntry e (.nextElement entries)]
+                      (when-not (.isDirectory e)
+                        (let [entry-path-str (FilenameUtils/separatorsToUnix (.getName e))]
+                          (when (or (nil? paths)
+                                    (coll/some (fn [^String s]
+                                                 (or (= s entry-path-str)
+                                                     (and (< (.length s) (.length entry-path-str))
+                                                          (= \/ (.charAt entry-path-str (.length s)))
+                                                          (.startsWith entry-path-str s))))
+                                               paths))
+                            (let [target-relative-path (.normalize (fs/path entry-path-str))]
+                              (when-not paths
+                                ;; when we have paths, we only allow the valid
+                                ;; ones already; if we don't have paths, we need
+                                ;; to validate them separately
+                                (validate-entry-target-path! target-relative-path))
+                              (let [target (.resolve target-path target-relative-path)]
+                                (when (or (not (fs/path-exists? target))
+                                          (case (:on_conflict opts)
+                                            :skip false
+                                            :overwrite (if (fs/path-is-directory? target)
+                                                         (throw (LuaError. (str "Can't overwrite directory: " target)))
+                                                         true)
+                                            :error (throw (LuaError. (str "Path already exists: " target)))))
+                                  (fs/create-path-parent-directories! target)
+                                  (with-open [in (.getInputStream zip e)
+                                              out (io/output-stream target)]
+                                    (io/copy in out))
+                                  (some->> (.getLastModifiedTime e) (Files/setLastModifiedTime target))
+                                  (when-not (os/is-win32?)
+                                    (let [unix-mode (.getUnixMode e)]
+                                      (when-not (zero? unix-mode)
+                                        (Files/setPosixFilePermissions target (get-permissions unix-mode)))))))))))))))))
+          (future/then (fn [_] (reload-resources!)))
+          (future/then rt/and-refresh-context)))))
+
 (defn env [project-path reload-resources!]
   {"pack" (make-ext-pack-fn project-path reload-resources!)
+   "unpack" (make-ext-unpack-fn project-path reload-resources!)
+   "ON_CONFLICT" {"ERROR" (coerce/enum-lua-value-cache :error)
+                  "SKIP" (coerce/enum-lua-value-cache :skip)
+                  "OVERWRITE" (coerce/enum-lua-value-cache :overwrite)}
    "METHOD" {"DEFLATED" (coerce/enum-lua-value-cache :deflated)
              "STORED" (coerce/enum-lua-value-cache :stored)}})

--- a/editor/src/clj/editor/fs.clj
+++ b/editor/src/clj/editor/fs.clj
@@ -21,7 +21,7 @@
            [java.nio.channels OverlappingFileLockException]
            [java.nio.charset Charset StandardCharsets]
            [java.nio.file AccessDeniedException CopyOption FileAlreadyExistsException FileVisitResult FileVisitor Files LinkOption NoSuchFileException NotDirectoryException OpenOption Path SimpleFileVisitor StandardCopyOption StandardOpenOption]
-           [java.nio.file.attribute BasicFileAttributes FileAttribute FileTime]
+           [java.nio.file.attribute BasicFileAttributes FileAttribute]
            [java.util UUID]))
 
 (set! *warn-on-reflection* true)

--- a/editor/src/clj/editor/fs.clj
+++ b/editor/src/clj/editor/fs.clj
@@ -21,7 +21,7 @@
            [java.nio.channels OverlappingFileLockException]
            [java.nio.charset Charset StandardCharsets]
            [java.nio.file AccessDeniedException CopyOption FileAlreadyExistsException FileVisitResult FileVisitor Files LinkOption NoSuchFileException NotDirectoryException OpenOption Path SimpleFileVisitor StandardCopyOption StandardOpenOption]
-           [java.nio.file.attribute BasicFileAttributes FileAttribute]
+           [java.nio.file.attribute BasicFileAttributes FileAttribute FileTime]
            [java.util UUID]))
 
 (set! *warn-on-reflection* true)

--- a/editor/test/integration/editor_extensions_test.clj
+++ b/editor/test/integration/editor_extensions_test.clj
@@ -28,6 +28,7 @@
             [editor.future :as future]
             [editor.graph-util :as gu]
             [editor.handler :as handler]
+            [editor.os :as os]
             [editor.pipeline.bob :as bob]
             [editor.prefs :as prefs]
             [editor.process :as process]
@@ -40,7 +41,9 @@
             [support.test-support :as test-support]
             [util.diff :as diff]
             [util.http-server :as http-server])
-  (:import [java.util.zip ZipEntry]
+  (:import [java.nio.file Files]
+           [java.nio.file.attribute PosixFilePermission]
+           [java.util.zip ZipEntry]
            [org.apache.commons.compress.archivers.zip ZipArchiveInputStream]
            [org.luaj.vm2 LuaError]))
 
@@ -883,8 +886,7 @@ nesting:
 (defn- expect-script-output [expected actual]
   (let [actual (normalize-pprint-output (str actual))]
     (let [output-matches-expectation (= expected actual)]
-      (when-not output-matches-expectation
-        (is output-matches-expectation (string/join "\n" (diff/make-diff-output-lines expected actual 3)))))))
+      (is output-matches-expectation (when-not output-matches-expectation (string/join "\n" (diff/make-diff-output-lines expected actual 3)))))))
 
 (deftest pprint-test
   (test-util/with-loaded-project "test/resources/editor_extensions/pprint-test"
@@ -993,10 +995,93 @@ editor.create_resources({\"/test/repeated.go\", \"/test/repeated.go\"}) => Resou
       (run-edit-menu-test-command!)
       (expect-script-output resource-io-test-output out))))
 
+(defn- expected-zip-test-output [root]
+  (str "Testing zip.pack...
+A file:
+zip.pack('gitignore.zip', {'.gitignore'}) => ok
+A directory:
+zip.pack('foo.zip', {'foo'}) => ok
+Multiple:
+zip.pack('multiple.zip', {'foo', {'foo', 'bar'}, '.gitignore', {'game.project', 'settings.ini'}}) => ok
+Outside:
+zip.pack('outside.zip', {{'" (System/getenv "PWD") "/project.clj', 'project.clj'}}) => ok
+Stored method:
+zip.pack('stored.zip', {method = 'stored'}, {'foo'}) => ok
+Compression level 0:
+zip.pack('level_0.zip', {level = 0}, {'foo', {'foo', 'bar'}, '.gitignore', 'game.project'}) => ok
+Compression level 1:
+zip.pack('level_1.zip', {level = 1}, {'foo', {'foo', 'bar'}, '.gitignore', 'game.project'}) => ok
+Compression level 2:
+zip.pack('level_2.zip', {level = 2}, {'foo', {'foo', 'bar'}, '.gitignore', 'game.project'}) => ok
+Compression level 3:
+zip.pack('level_3.zip', {level = 3}, {'foo', {'foo', 'bar'}, '.gitignore', 'game.project'}) => ok
+Compression level 4:
+zip.pack('level_4.zip', {level = 4}, {'foo', {'foo', 'bar'}, '.gitignore', 'game.project'}) => ok
+Compression level 5:
+zip.pack('level_5.zip', {level = 5}, {'foo', {'foo', 'bar'}, '.gitignore', 'game.project'}) => ok
+Compression level 6:
+zip.pack('level_6.zip', {level = 6}, {'foo', {'foo', 'bar'}, '.gitignore', 'game.project'}) => ok
+Compression level 7:
+zip.pack('level_7.zip', {level = 7}, {'foo', {'foo', 'bar'}, '.gitignore', 'game.project'}) => ok
+Compression level 8:
+zip.pack('level_8.zip', {level = 8}, {'foo', {'foo', 'bar'}, '.gitignore', 'game.project'}) => ok
+Compression level 9:
+zip.pack('level_9.zip', {level = 9}, {'foo', {'foo', 'bar'}, '.gitignore', 'game.project'}) => ok
+Unix:
+zip.pack('script.zip', {'script.sh'}) => ok
+Mixed compression settings:
+zip.pack('mixed.zip', {{'foo', '9', level = 9}, {'foo', '1', level = 1}, {'foo', '0', level = 0}, {'foo', 'stored', method = 'stored'}}) => ok
+Archive path is a directory:
+zip.pack('foo', {'game.project'}) => error: Output path is a directory: foo
+Source path does not exist:
+zip.pack('error.zip', {'does-not-exist.txt'}) => error: Source path does not exist: " root "/does-not-exist.txt
+Target path is absolute:
+zip.pack('error.zip', {'" (System/getenv "HOME") "'}) => error: Target path must be relative: " (System/getenv "HOME") "
+Target path is a relative path above root:
+zip.pack('error.zip', {{'game.project', '../../game.project'}}) => error: Target path is above archive root: ../../game.project
+zip.pack('error.zip', {{'game.project', 'foo/bar/../../../../game.project'}}) => error: Target path is above archive root: ../../game.project
+Testing zip.unpack...
+zip.unpack('script.zip', 'build', {'script.sh'}) => ok
+Default conflict resolution is error:
+zip.unpack('script.zip', 'build', {'script.sh'}) => error: Path already exists: " root "/build/script.sh
+Overwrite option:
+zip.unpack('script.zip', 'build', {on_conflict = 'overwrite'}, {'script.sh'}) => ok
+Skip:
+zip.unpack('foo.zip', 'build/skip') => ok
+build/skip/foo exists: true
+build/skip/bar exists: false
+zip.unpack('multiple.zip', 'build/skip', {on_conflict = 'skip'}) => ok
+build/skip/foo exists: true
+build/skip/bar exists: true
+Overwrite can't replace directory with a file:
+zip.unpack('script.zip', 'build/dir_conflict', {on_conflict = 'overwrite'}) => error: Can't overwrite directory: " root "/build/dir_conflict/script.sh
+Partial unpack:
+zip.unpack('multiple.zip', 'build/subset', {'settings.ini'}) => ok
+build/subset/settings.ini exists: true
+build/subset/bar exists: false
+build/subset/foo exists: false
+Archive validation:
+zip.unpack('does-not-exist.zip') => error: Archive path does not exist: " root "/does-not-exist.zip
+zip.unpack('foo') => error: Archive path is a directory: " root "/foo
+Paths validation:
+zip.unpack('script.zip', 'build', {on_conflict = 'skip'}, {'foo/../../../bar'}) => error: Invalid argument:
+- \"foo/../../../bar\" is above root
+- {\"foo/../../../bar\"} is unexpected
+zip.unpack('script.zip', 'build', {on_conflict = 'skip'}, {'/tmp'}) => error: Invalid argument:
+- \"/tmp\" is absolute
+- {\"/tmp\"} is unexpected
+zip.unpack('script.zip', 'build', {on_conflict = 'skip'}, {'tmp/..'}) => error: Invalid argument:
+- \"tmp/..\" is empty
+- {\"tmp/..\"} is unexpected
+Extract to parent:
+zip.pack('build/nested/archive.zip', {'game.project'}) => ok
+zip.unpack('build/nested/archive.zip') => ok
+build/nested/game.project exists: true
+"))
+
 (deftest zip-test
   (test-util/with-scratch-project "test/resources/editor_extensions/zip_project"
-    (let [output (atom [])
-          root (workspace/project-directory workspace)
+    (let [root (workspace/project-directory workspace)
           list-entries (fn list-entries [path-str]
                          (with-open [zis (ZipArchiveInputStream. (io/input-stream (fs/path root path-str)))]
                            (loop [acc (transient #{})]
@@ -1012,61 +1097,13 @@ editor.create_resources({\"/test/repeated.go\", \"/test/repeated.go\"}) => Resou
                                (recur (assoc! acc (.getName e) (condp = (.getMethod e)
                                                                  ZipEntry/STORED :stored
                                                                  ZipEntry/DEFLATED :deflated)))
-                               (persistent! acc)))))]
-      (reload-editor-scripts! project :display-output! #(swap! output conj [%1 %2]))
+                               (persistent! acc)))))
+          out (StringBuilder.)]
+      (reload-editor-scripts! project :display-output! #(doto out (.append %2) (.append \newline)))
       (run-edit-menu-test-command!)
       ;; See test.editor_script: the script creates a bunch of archives and logs pack
       ;; arguments with the result of execution
-      (is (= [;; Pack a single file
-              [:out "A file:"]
-              [:out "zip.pack(\"gitignore.zip\", {\".gitignore\"}) => ok"]
-              ;; Pack a directory
-              [:out "A directory:"]
-              [:out "zip.pack(\"foo.zip\", {\"foo\"}) => ok"]
-              ;; Pack multiple files
-              [:out "Multiple:"]
-              [:out "zip.pack(\"multiple.zip\", {\"foo\", {\"foo\", \"bar\"}, \".gitignore\", {\"game.project\", \"settings.ini\"}}) => ok"]
-              ;; Pack a file from outside the project
-              [:out "Outside:"]
-              [:out (str "zip.pack(\"outside.zip\", {{\"" (System/getenv "PWD") "/project.clj\", \"project.clj\"}}) => ok")]
-              ;; Pack using stored compression method
-              [:out "Stored method:"]
-              [:out "zip.pack(\"stored.zip\", {method = \"stored\"}, {\"foo\"}) => ok"]
-              ;; Pack using different compression levels
-              [:out "Compression level 0:"]
-              [:out "zip.pack(\"level_0.zip\", {level = 0}, {\"foo\", {\"foo\", \"bar\"}, \".gitignore\", \"game.project\"}) => ok"]
-              [:out "Compression level 1:"]
-              [:out "zip.pack(\"level_1.zip\", {level = 1}, {\"foo\", {\"foo\", \"bar\"}, \".gitignore\", \"game.project\"}) => ok"]
-              [:out "Compression level 2:"]
-              [:out "zip.pack(\"level_2.zip\", {level = 2}, {\"foo\", {\"foo\", \"bar\"}, \".gitignore\", \"game.project\"}) => ok"]
-              [:out "Compression level 3:"]
-              [:out "zip.pack(\"level_3.zip\", {level = 3}, {\"foo\", {\"foo\", \"bar\"}, \".gitignore\", \"game.project\"}) => ok"]
-              [:out "Compression level 4:"]
-              [:out "zip.pack(\"level_4.zip\", {level = 4}, {\"foo\", {\"foo\", \"bar\"}, \".gitignore\", \"game.project\"}) => ok"]
-              [:out "Compression level 5:"]
-              [:out "zip.pack(\"level_5.zip\", {level = 5}, {\"foo\", {\"foo\", \"bar\"}, \".gitignore\", \"game.project\"}) => ok"]
-              [:out "Compression level 6:"]
-              [:out "zip.pack(\"level_6.zip\", {level = 6}, {\"foo\", {\"foo\", \"bar\"}, \".gitignore\", \"game.project\"}) => ok"]
-              [:out "Compression level 7:"]
-              [:out "zip.pack(\"level_7.zip\", {level = 7}, {\"foo\", {\"foo\", \"bar\"}, \".gitignore\", \"game.project\"}) => ok"]
-              [:out "Compression level 8:"]
-              [:out "zip.pack(\"level_8.zip\", {level = 8}, {\"foo\", {\"foo\", \"bar\"}, \".gitignore\", \"game.project\"}) => ok"]
-              [:out "Compression level 9:"]
-              [:out "zip.pack(\"level_9.zip\", {level = 9}, {\"foo\", {\"foo\", \"bar\"}, \".gitignore\", \"game.project\"}) => ok"]
-              ;; Different compression settings for different entries
-              [:out "Mixed compression settings:"]
-              [:out "zip.pack(\"mixed.zip\", {{\"foo\", \"9\", level = 9}, {\"foo\", \"1\", level = 1}, {\"foo\", \"0\", level = 0}, {\"foo\", \"stored\", method = \"stored\"}}) => ok"]
-              ;; Expected errors
-              [:out "Archive path is a directory:"]
-              [:out "zip.pack(\"foo\", {\"game.project\"}) => error: Output path is a directory: foo"]
-              [:out "Source path does not exist:"]
-              [:out (str "zip.pack(\"error.zip\", {\"does-not-exist.txt\"}) => error: Source path does not exist: " root "/does-not-exist.txt")]
-              [:out "Target path is absolute:"]
-              [:out (str "zip.pack(\"error.zip\", {\"" (System/getenv "HOME") "\"}) => error: Target path must be relative: " (System/getenv "HOME"))]
-              [:out "Target path is a relative path above root:"]
-              [:out "zip.pack(\"error.zip\", {{\"game.project\", \"../../game.project\"}}) => error: Target path is above archive root: ../../game.project"]
-              [:out "zip.pack(\"error.zip\", {{\"game.project\", \"foo/bar/../../../../game.project\"}}) => error: Target path is above archive root: ../../game.project"]]
-             @output))
+      (expect-script-output (expected-zip-test-output root) out)
       (is (= #{".gitignore"} (list-entries "gitignore.zip")))
       (is (= #{"foo/bar.txt" "foo/long.txt" "foo/subdir/baz.txt"} (list-entries "foo.zip")))
       (is (= #{"foo/bar.txt" "foo/long.txt" "foo/subdir/baz.txt"
@@ -1100,7 +1137,11 @@ editor.create_resources({\"/test/repeated.go\", \"/test/repeated.go\"}) => Resou
               "stored/bar.txt" :stored
               "stored/long.txt" :stored
               "stored/subdir/baz.txt" :stored}
-             (list-methods "mixed.zip"))))))
+             (list-methods "mixed.zip")))
+      (when-not (os/is-win32?)
+        (is (contains?
+              (Files/getPosixFilePermissions (fs/path root "build" "script.sh") fs/empty-link-option-array)
+              PosixFilePermission/OWNER_EXECUTE))))))
 
 (def expected-http-server-test-output
   "Omitting conflicting routes for 'GET /test/conflict/same-path-and-method' defined in /test.editor_script

--- a/editor/test/resources/editor_extensions/zip_project/script.sh
+++ b/editor/test/resources/editor_extensions/zip_project/script.sh
@@ -1,0 +1,1 @@
+echo "hello"

--- a/editor/test/resources/editor_extensions/zip_project/test.editor_script
+++ b/editor/test/resources/editor_extensions/zip_project/test.editor_script
@@ -3,7 +3,7 @@ local M = {}
 
 local function stringify(x)
     if type(x) == "string" then
-        return string.format("%q", x)
+        return string.format("'%s'", x)
     elseif type(x) == "function" then
         return "function() end"
     elseif type(x) == "table" then
@@ -27,7 +27,7 @@ local function stringify(x)
     end
 end
 
-local function test(...)
+local function pack(...)
     local args = {...}
     local s = "zip.pack("
     for i = 1, #args do
@@ -45,41 +45,102 @@ local function test(...)
     end
 end
 
+local function unpack(...)
+    local args = {...}
+    local s = "zip.unpack("
+    for i = 1, #args do
+        s = s .. stringify(args[i])
+        if i < #args then
+            s = s .. ", "
+        end
+    end
+    s = s .. ")"
+    local success, error = pcall(zip.unpack, ...)
+    if success then
+        print(("%s => ok"):format(s))
+    else
+        print(("%s => error: %s"):format(s, error))
+    end
+end
+
+local function print_exists(path)
+    print(("%s exists: %s"):format(path, tostring(editor.external_file_attributes(path).exists)))
+end
+
 function M.get_commands()
     return {{
         label = "Test",
+        id = "defold.test",
         locations = {"Edit"},
         run = function()
+            print("Testing zip.pack...")
             print("A file:")
-            test("gitignore.zip", {".gitignore"})
+            pack("gitignore.zip", {".gitignore"})
             print("A directory:")
-            test("foo.zip", {"foo"})
+            pack("foo.zip", {"foo"})
             print("Multiple:")
-            test("multiple.zip", {"foo", {"foo", "bar"}, ".gitignore", {"game.project", "settings.ini"}})
+            pack("multiple.zip", {"foo", {"foo", "bar"}, ".gitignore", {"game.project", "settings.ini"}})
             print("Outside:")
-            test("outside.zip", {{os.getenv("PWD") .. "/project.clj", "project.clj"}})
+            pack("outside.zip", {{os.getenv("PWD") .. "/project.clj", "project.clj"}})
             print("Stored method:")
-            test("stored.zip", {method = zip.METHOD.STORED}, {"foo"})
+            pack("stored.zip", {method = zip.METHOD.STORED}, {"foo"})
             for i = 0, 9 do
                 print("Compression level " .. i .. ":")
-                test("level_" .. i .. ".zip", {level = i}, {"foo", {"foo", "bar"}, ".gitignore", "game.project"})
+                pack("level_" .. i .. ".zip", {level = i}, {"foo", {"foo", "bar"}, ".gitignore", "game.project"})
             end
+            print("Unix:")
+            pack("script.zip", {"script.sh"})
             print("Mixed compression settings:")
-            test("mixed.zip", {
+            pack("mixed.zip", {
                 {"foo", "9", level = 9},
                 {"foo", "1", level = 1},
                 {"foo", "0", level = 0},
                 {"foo", "stored", method = zip.METHOD.STORED},
             })
             print("Archive path is a directory:")
-            test("foo", {"game.project"})
+            pack("foo", {"game.project"})
             print("Source path does not exist:")
-            test("error.zip", {"does-not-exist.txt"})
+            pack("error.zip", {"does-not-exist.txt"})
             print("Target path is absolute:")
-            test("error.zip", {os.getenv("HOME")})
+            pack("error.zip", {os.getenv("HOME")})
             print("Target path is a relative path above root:")
-            test("error.zip", {{"game.project", "../../game.project"}})
-            test("error.zip", {{"game.project", "foo/bar/../../../../game.project"}})
+            pack("error.zip", {{"game.project", "../../game.project"}})
+            pack("error.zip", {{"game.project", "foo/bar/../../../../game.project"}})
+
+            print("Testing zip.unpack...")
+            
+            editor.delete_directory("/build")
+            unpack("script.zip", "build", {"script.sh"})
+            print("Default conflict resolution is error:")
+            unpack("script.zip", "build", {"script.sh"})
+            print("Overwrite option:")
+            unpack("script.zip", "build", {on_conflict = zip.ON_CONFLICT.OVERWRITE}, {"script.sh"})
+            print("Skip:")
+            unpack("foo.zip", "build/skip")
+            print_exists("build/skip/foo")
+            print_exists("build/skip/bar")
+            unpack("multiple.zip", "build/skip", {on_conflict = zip.ON_CONFLICT.SKIP})
+            print_exists("build/skip/foo")
+            print_exists("build/skip/bar")
+            editor.create_directory("/build/dir_conflict/script.sh")
+            print("Overwrite can't replace directory with a file:")
+            unpack("script.zip", "build/dir_conflict", {on_conflict = zip.ON_CONFLICT.OVERWRITE})
+            print("Partial unpack:")
+            unpack("multiple.zip", "build/subset", {"settings.ini"})
+            print_exists("build/subset/settings.ini")
+            print_exists("build/subset/bar")
+            print_exists("build/subset/foo")
+            print("Archive validation:")
+            unpack("does-not-exist.zip")
+            unpack("foo")
+            print("Paths validation:")
+            unpack("script.zip", "build", {on_conflict = zip.ON_CONFLICT.SKIP}, {"foo/../../../bar"})
+            unpack("script.zip", "build", {on_conflict = zip.ON_CONFLICT.SKIP}, {"/tmp"})
+            unpack("script.zip", "build", {on_conflict = zip.ON_CONFLICT.SKIP}, {"tmp/.."})
+            print("Extract to parent:")
+            pack("build/nested/archive.zip", {"game.project"})
+            unpack("build/nested/archive.zip")
+            print_exists("build/nested/game.project")
         end
     }}
 end


### PR DESCRIPTION
Now it's possible to unpack ZIP files using editor scripts, e.g.:
```lua
-- simply unpack
zip.unpack("build/dev/archive.zip")
-- unpack to another directory
zip.unpack("build/dev/archive.zip", "build/dev/tmp")
-- overwrite on conflict
zip.unpack("build/dev/archive.zip", {on_conflict = zip.ON_CONFLICT.OVERWRITE})
-- unpack a subset of files
zip.unpack("build/dev/archive.zip", {"config.json", "src"})
```

Fixes #10407
