### PR TITLE
Add support for building Defold on Nix/OS

### DIFF
--- a/scripts/build.py
+++ b/scripts/build.py
@@ -631,7 +631,7 @@ class Configuration(object):
         if self.package_path is None:
             print("No package path provided. Use either --package-path option or DM_PACKAGES_URL environment variable")
             sys.exit(1)
-    
+
     def install_waf(self):
         def make_package_path(root, platform, package):
             return join(root, 'packages', package) + '-%s.tar.gz' % platform
@@ -646,7 +646,7 @@ class Configuration(object):
 
         def make_package_paths(root, platform, packages):
             return [make_package_path(root, platform, package) for package in packages]
-        
+
         self.install_waf()
 
         print("Installing common packages")
@@ -1881,7 +1881,10 @@ class Configuration(object):
 
         args = [SHELL, '-l']
 
-        process = subprocess.Popen(args, env=self._form_env(), shell=True)
+        if os.path.exists("/nix"):
+            args = ["nix-shell", os.path.join("scripts", "nix", "shell.nix"), "--run", " ".join(args)]
+
+        process = subprocess.Popen(args, env=self._form_env())
         try:
             output = process.communicate()[0]
         except KeyboardInterrupt as e:
@@ -2480,7 +2483,7 @@ class Configuration(object):
                     _threads[i].join()
                     self._log('Uploaded #%d %s -> %s' % (i + 1, path, url))
 
-                
+
                 if len(list(mp.parts.all())) == chunkcount:
                     try:
                         parts = []

--- a/scripts/nix/shell.nix
+++ b/scripts/nix/shell.nix
@@ -1,0 +1,56 @@
+{
+  pkgs ? import <nixpkgs> { },
+}:
+
+pkgs.mkShell {
+  buildInputs = with pkgs; [
+    clang
+    cmake
+    freeglut
+    git
+    glib
+    leiningen
+    libGL
+    libGLU
+    ninja
+    openal
+    openjdk21
+    pkg-config
+    protobuf
+    xorg.libX11
+    xorg.libXcursor
+    xorg.libXi
+    xorg.libXinerama
+    xorg.libXrandr
+    xorg.libXtst
+    xorg.libXxf86vm
+
+    (python313.withPackages (
+      ps: with ps; [
+        pip
+        virtualenv
+      ]
+    ))
+  ];
+
+  shellHook = ''
+    export CC=clang
+    export CXX=clang++
+    export LD_LIBRARY_PATH=${
+      pkgs.lib.makeLibraryPath [
+        pkgs.freeglut
+        pkgs.glib
+        pkgs.libGL
+        pkgs.libGLU
+        pkgs.openal
+        pkgs.xorg.libX11
+        pkgs.xorg.libXcursor
+        pkgs.xorg.libXi
+        pkgs.xorg.libXinerama
+        pkgs.xorg.libXrandr
+        pkgs.xorg.libXtst
+        pkgs.xorg.libXxf86vm
+      ]
+    }:$LD_LIBRARY_PATH
+  '';
+}


### PR DESCRIPTION
NixOS differs significantly from other Linux distributions making it difficult to build the engine without providing some special configuration which is what this PR does.

To explain how Nix works simplified: It generally keeps different versions of dependencies around in `/nix/store` which are linked together per application in a unique environment depending on the applications need, which does however mean that even if you install certain dependencies they are not directly available to you in any path you'd expect (since NixOS doesn't support the default FHS ([Filesystem Hierarchy Standard](https://refspecs.linuxfoundation.org/FHS_3.0/fhs/index.html)) by default meaning in order to build the engine we have to make our own little environment with the required dependencies, effectively replicating what `./scripts/build.py shell` does. I was initially considering expanding the `./scripts/build.py shell` script, but deemed this to be a fairly invasive change for a platform that probably barely anyone here uses. 

This PR provides a nix-shell script that provides a working environment to build the engine without installing or setting up anything (assuming you have nix available), you can simply run:

```bash
$ ./scripts/nix/run.sh
$ ./scripts/build.py install_ext
$ ./scripts/build.py build_engine --skip-tests -- --skip-build-tests
$ cd editor
$ lein init <sha1>
$ lein run
```

This will build the engine, the editor and as far as I've seen so far everything works as expected

One remaining issue however, 1 test from build_engine fails and I haven't yet been able to figure out why:

```
...
dmSSDPTest took 0.551522 s
dmSSDPTest.Search failed
Ran 7 tests, with 14 assertions in 0.551522 s
6 tests passed, 0 skipped and 1 tests FAILED
test failed test_ssdp

[exec] /nix/store/yba3raw18d8vb5dnb4bczxd0063yxk81-python3-3.12.11-env/bin/python3.12 /home/christopher/dev/_clones/defold/tmp/dynamo_home/ext/bin/waf --prefix=/home/christopher/dev/_clones/defold/tmp/dynamo_home distclean configure build install --platform=x86_64-linux
Error:
Traceback (most recent call last):
  File "/home/christopher/dev/_clones/defold/./scripts/build.py", line 2803, in <module>
    f()
  File "/home/christopher/dev/_clones/defold/./scripts/build.py", line 1423, in build_engine
    self._build_engine_lib(args, lib, host)
  File "/home/christopher/dev/_clones/defold/./scripts/build.py", line 1369, in _build_engine_lib
    run.env_command(self._form_env(), args + plf_args + self.waf_options + skip_build_tests, cwd = cwd)
  File "/home/christopher/dev/_clones/defold/build_tools/run.py", line 98, in env_command
    return _exec_command(args, shell = False, stdout = None, env = env, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/christopher/dev/_clones/defold/build_tools/run.py", line 75, in _exec_command
    raise e
run.ExecException: 1
```