### PR TITLE
Editor: Add fn/and and fn/or functions

### DIFF
--- a/editor/src/clj/editor/code_completion.clj
+++ b/editor/src/clj/editor/code_completion.clj
@@ -17,7 +17,8 @@
             [clojure.java.io :as io]
             [clojure.spec.alpha :as s]
             [editor.code.data]
-            [internal.util :as util])
+            [internal.util :as util]
+            [util.fn :as fn])
   (:import [editor.code.data CursorRange]
            [java.net URI]))
 
@@ -224,8 +225,8 @@
                 :snippet (reduce prepare-tab-triggers tab-triggers children)
                 :rule (prepare-tab-triggers tab-triggers (first children))
                 :tab_stop (reduce prepare-tab-triggers tab-triggers children)
-                :naked_tab_stop (update tab-triggers (nth children 1) #(or % {}))
-                :curly_tab_stop (update tab-triggers (nth children 2) #(or % {}))
+                :naked_tab_stop (update tab-triggers (nth children 1) fn/or {})
+                :curly_tab_stop (update tab-triggers (nth children 2) fn/or {})
                 :placeholder (update tab-triggers (nth children 2) assoc
                                      :placeholder (content-string (nth children 4)))
                 :choice (update tab-triggers (nth children 2) assoc

--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -4091,7 +4091,7 @@
         (protobuf/sanitize-repeated :nodes sanitize-scene-node)
         (protobuf/sanitize-repeated :layouts sanitize-layout)
         (protobuf/assign-repeated :resources merged-resource-descs)
-        (update :material #(or % default-material-proj-path)))))
+        (update :material fn/or default-material-proj-path))))
 
 (defn- add-dropped-resource
   [scene workspace resource]

--- a/editor/src/clj/editor/lsp.clj
+++ b/editor/src/clj/editor/lsp.clj
@@ -28,7 +28,8 @@
             [editor.ui :as ui]
             [internal.util :as util]
             [service.log :as log]
-            [util.coll :refer [pair]])
+            [util.coll :refer [pair]]
+            [util.fn :as fn])
   (:import [editor.code.data CursorRange]
            [java.util.regex Pattern]
            [sun.nio.fs Globs]))
@@ -812,9 +813,6 @@
                     (contains? (:languages server) language))))
        boolean))
 
-(defn- and-fn [a b]
-  (and a b))
-
 (defn request-completions!
   "Request completions for a specific cursor position in the text resource
 
@@ -849,7 +847,7 @@
              (a/go (result-callback (<! (a/reduce
                                           (fn [acc {:keys [complete items]}]
                                             (-> acc
-                                                (update :complete and-fn complete)
+                                                (update :complete fn/and complete)
                                                 (update :items into items)))
                                           {:complete true
                                            :items []}

--- a/editor/src/clj/editor/outline_view.clj
+++ b/editor/src/clj/editor/outline_view.clj
@@ -24,14 +24,15 @@
             [editor.resource :as resource]
             [editor.scene-visibility :as scene-visibility]
             [editor.types :as types]
-            [editor.ui :as ui])
+            [editor.ui :as ui]
+            [util.fn :as fn])
   (:import [com.defold.control TreeCell]
            [java.awt Toolkit]
            [javafx.collections FXCollections ObservableList]
            [javafx.event Event]
            [javafx.geometry Orientation]
            [javafx.scene Node]
-           [javafx.scene.control ScrollBar SelectionMode TreeItem TreeView ToggleButton Label TextField]
+           [javafx.scene.control Label ScrollBar SelectionMode TextField ToggleButton TreeItem TreeView]
            [javafx.scene.image ImageView]
            [javafx.scene.input Clipboard ContextMenuEvent DataFormat DragEvent KeyCode KeyCodeCombination KeyEvent MouseButton MouseEvent TransferMode]
            [javafx.scene.layout AnchorPane HBox Priority]
@@ -96,11 +97,16 @@
   new-root)
 
 (defn- auto-expand [items selected-ids]
-  (reduce #(or %1 %2) false (map (fn [^TreeItem item] (let [id (item->node-id item)
-                                                            selected (boolean (selected-ids id))
-                                                            expanded (auto-expand (.getChildren item) selected-ids)]
-                                                        (when expanded (.setExpanded item expanded))
-                                                        (or selected expanded))) items)))
+  (transduce
+    (map (fn [^TreeItem item]
+           (let [id (item->node-id item)
+                 selected (boolean (selected-ids id))
+                 expanded (auto-expand (.getChildren item) selected-ids)]
+             (when expanded (.setExpanded item expanded))
+             (or selected expanded))))
+    fn/or
+    false
+    items))
 
 (defn- sync-selection [^TreeView tree-view selection old-selected-ids]
   (let [root (.getRoot tree-view)

--- a/editor/src/clj/editor/render_target.clj
+++ b/editor/src/clj/editor/render_target.clj
@@ -22,7 +22,8 @@
             [editor.protobuf-forms-util :as protobuf-forms-util]
             [editor.resource-node :as resource-node]
             [editor.validation :as validation]
-            [editor.workspace :as workspace])
+            [editor.workspace :as workspace]
+            [util.fn :as fn])
   (:import [com.dynamo.graphics.proto Graphics$TextureImage$TextureFormat]
            [com.dynamo.render.proto RenderTarget$RenderTargetDesc RenderTarget$RenderTargetDesc$ColorAttachment RenderTarget$RenderTargetDesc$DepthStencilAttachment]))
 
@@ -173,7 +174,7 @@
 (defn- sanitize-render-target [render-target-desc]
   {:pre [(map? render-target-desc)]} ; RenderTarget$RenderTargetDesc in map format.
   (-> render-target-desc
-      (update :depth-stencil-attachment #(or % default-pb-depth-stencil-attachment))))
+      (update :depth-stencil-attachment fn/or default-pb-depth-stencil-attachment)))
 
 (defn register-resource-types
   [workspace]

--- a/editor/src/docs/editor/docs.clj
+++ b/editor/src/docs/editor/docs.clj
@@ -16,7 +16,8 @@
   (:require [clojure.java.io :as io]
             [clojure.string :as string]
             [editor.editor-extensions.docs :as ext-docs]
-            [editor.util :as util])
+            [editor.util :as util]
+            [util.fn :as fn])
   (:import [java.io Writer]))
 
 (defn- script-doc-group [script-doc]
@@ -65,7 +66,7 @@
                              (update :returnvalues (fn [returnvalues]
                                                      (mapv
                                                        (fn [m]
-                                                         (update m :doc #(or % "")))
+                                                         (update m :doc fn/or ""))
                                                        returnvalues))))))
                   functions)])]
     (with-open [w (io/writer (doto (io/file output-dir "editor.apidoc") io/make-parents))]

--- a/editor/test/integration/gui_clipping_test.clj
+++ b/editor/test/integration/gui_clipping_test.clj
@@ -88,7 +88,7 @@
                       (:clear clipping-state)
                       (assoc :sb (->stencil-buffer))
 
-                      (reduce #(or %1 %2) test)
+                      (reduce fn/or test)
                       (->
                         (update :sb (partial mapv (fn [t v] (if t
                                                               (bit-or (bit-and (:ref-val clipping-state) (:write-mask clipping-state))

--- a/editor/test/integration/scene_test.clj
+++ b/editor/test/integration/scene_test.clj
@@ -23,7 +23,8 @@
             [editor.scene :as scene]
             [editor.system :as system]
             [editor.types :as types]
-            [integration.test-util :as test-util])
+            [integration.test-util :as test-util]
+            [util.fn :as fn])
   (:import [editor.types AABB]
            [javax.vecmath Matrix4d Quat4d Vector3d]))
 
@@ -76,7 +77,7 @@
              (let [path          "/sprite/small_atlas.sprite"
                    [resource-node view] (test-util/open-scene-view! project app-view path 128 128)
                    renderables   (g/node-value view :all-renderables)]
-               (is (reduce #(and %1 %2) (map #(contains? renderables %) [pass/transparent pass/selection])))))))
+               (is (reduce fn/and (map #(contains? renderables %) [pass/transparent pass/selection])))))))
 
 (deftest scene-selection
   (testing "Scene selection"

--- a/editor/test/util/fn_test.clj
+++ b/editor/test/util/fn_test.clj
@@ -389,3 +389,109 @@
 
   (is (= 1 ((fn/make-case-fn [[:a 1]]) :a)) "Accepts sequence of pairs")
   (is (= 1 ((fn/make-case-fn {:a 1}) :a)) "Accepts map"))
+
+(deftest and-test
+  (testing "No arguments."
+    (is (true? (fn/and))))
+
+  (testing "Single argument."
+    (is (false? (fn/and false)))
+    (is (nil? (fn/and nil)))
+    (is (true? (fn/and true))))
+
+  (testing "Two arguments."
+    (is (false? (fn/and false nil)))
+    (is (nil? (fn/and nil false)))
+    (is (false? (fn/and false true)))
+    (is (nil? (fn/and nil true)))
+    (is (false? (fn/and true false)))
+    (is (nil? (fn/and true nil))))
+
+  (testing "Many arguments."
+    (is (false? (fn/and false nil nil)))
+    (is (nil? (fn/and nil false false)))
+    (is (false? (fn/and false true true)))
+    (is (nil? (fn/and nil true true)))
+    (is (false? (fn/and true true false)))
+    (is (nil? (fn/and true true nil)))
+    (is (false? (fn/and true false true)))
+    (is (nil? (fn/and true nil true)))
+    (is (false? (fn/and true false nil)))
+    (is (nil? (fn/and true nil false))))
+
+  (testing "Returns final argument when all are true."
+    (doseq [arg-count (range 1 32)]
+      (let [args (repeatedly arg-count #(Object.))]
+        (is (identical? (last args) (apply fn/and args))))))
+
+  (testing "Returns first false argument found."
+    (let [arg-count 32]
+      (doseq [false-value [nil false]]
+        (doseq [false-arg-index (range 0 arg-count)]
+          (let [args (-> (repeatedly arg-count #(Object.))
+                         (vec)
+                         (assoc false-arg-index false-value))]
+            (is (identical? false-value (apply fn/and args))))))))
+
+  (testing "Boolean false instance handling matches core implementation."
+    (let [false-a (Boolean. false)
+          false-b (Boolean. false)]
+      (is (identical? (and true false-b)
+                      (fn/and true false-b)))
+      (is (identical? (and false-a true)
+                      (fn/and false-a true)))
+      (is (identical? (and false-a false-b)
+                      (fn/and false-a false-b))))))
+
+(deftest or-test
+  (testing "No arguments."
+    (is (nil? (fn/or))))
+
+  (testing "Single argument."
+    (is (false? (fn/or false)))
+    (is (nil? (fn/or nil)))
+    (is (true? (fn/or true))))
+
+  (testing "Two arguments."
+    (is (nil? (fn/or false nil)))
+    (is (false? (fn/or nil false)))
+    (is (true? (fn/or false true)))
+    (is (true? (fn/or nil true)))
+    (is (true? (fn/or true false)))
+    (is (true? (fn/or true nil))))
+
+  (testing "Many arguments."
+    (is (true? (fn/or true false false)))
+    (is (true? (fn/or true nil nil)))
+    (is (true? (fn/or false true false)))
+    (is (true? (fn/or nil true nil)))
+    (is (true? (fn/or false false true)))
+    (is (true? (fn/or nil nil true)))
+    (is (nil? (fn/or false false nil)))
+    (is (false? (fn/or nil nil false))))
+
+  (testing "Returns final argument when all are false."
+    (doseq [arg-count (range 1 32)]
+      (doseq [false-value [nil false]]
+        (let [args (repeat arg-count false-value)]
+          (is (identical? (last args) (apply fn/or args)))))))
+
+  (testing "Returns first true argument found."
+    (let [arg-count 32]
+      (doseq [false-value [nil false]]
+        (doseq [true-arg-index (range 0 arg-count)]
+          (let [true-value (Object.)
+                args (-> (repeat arg-count false-value)
+                         (vec)
+                         (assoc true-arg-index true-value))]
+            (is (identical? true-value (apply fn/or args))))))))
+
+  (testing "Boolean false instance handling matches core implementation."
+    (let [false-a (Boolean. false)
+          false-b (Boolean. false)]
+      (is (identical? (or true false-b)
+                      (fn/or true false-b)))
+      (is (identical? (or false-a true)
+                      (fn/or false-a true)))
+      (is (identical? (or false-a false-b)
+                      (fn/or false-a false-b))))))


### PR DESCRIPTION
### Technical changes
* Add `fn/and` and `fn/or`, which are functions that behave exactly like the `and` and `or` macros in `clojure.core`.
* Update existing code to use these shared functions.