### PR TITLE
Editor: Add rudimentary support for Portal dev tool during editor development

### DIFF
--- a/editor/.idea/leiningen.xml
+++ b/editor/.idea/leiningen.xml
@@ -10,6 +10,7 @@
         <option value="dev" />
         <option value="test" />
         <option value="reveal" />
+        <option value="portal" />
       </list>
     </option>
   </component>

--- a/editor/README_PORTAL.md
+++ b/editor/README_PORTAL.md
@@ -1,0 +1,35 @@
+## Using Portal While Working on the Defold Editor
+
+Portal is a web-based UI for inspecting Clojure values that can run standalone in a web browser or be integrated into various popular IDEs. Once running, you can call `(tap> some-value)` to inspect it in Portal.
+
+This PR introduces a new `portal` Leiningen profile that will include the relevant dependencies to run Portal when working on the Defold Editor, as well as some editor-specific functionality, such as inspecting graph nodes and resources.
+
+Portal is only a simple value inspector. If you desire full REPL-replacement with more advanced capabilities, look into using [Reveal](https://vlaaad.github.io/reveal/) instead. It has similar Defold Editor-specific inspection capabilities and more.
+
+### Setup Instructions
+
+Install the relevant Portal plugin for your IDE of choice. This enables you to run the Portal inspector in a docked panel inside your editor.
+  * Cursive: https://plugins.jetbrains.com/plugin/18467-portal-inspector/
+  * Visual Studio Code: https://marketplace.visualstudio.com/items?itemName=djblue.portal
+
+Once installed,
+  * Use `lein with-profile +portal ...` when starting up to include Portal
+    on the class path.
+  * Evaluate the following expression through the REPL connection:
+    ```clj
+    ((requiring-resolve 'editor.portal/open!))
+    ```
+    You might want to set up a REPL Command for this in your IDE.
+
+### General Functionality
+* Call `(tap> some-value)` to inspect any Clojure value or Java object in Portal.
+* In Portal, you can double-click a `node-id` or a `Resource` value to inspect the corresponding node.
+
+### Node View Functionality
+This view shows details related to a node in the graph.
+
+* Nodes that belong to a `ResourceNode` will display their owner `Resource`.
+* Override nodes will show the chain of original `node-ids`.
+* The **properties** map shows raw field values, and includes defaults when viewing a base node. When viewing an override node, only overridden values are shown.
+* For the **inputs** and **outputs**, we show incoming and outgoing connections instead of values.
+* Double-click the `:keyword` for a **property**, **input**, or **output** to evaluate it.

--- a/editor/project.clj
+++ b/editor/project.clj
@@ -211,6 +211,8 @@
                                  :dependencies [[org.testfx/openjfx-monocle "jdk-12.0.1+2"]]}
                       :smoke-test {:jvm-opts ["-Ddefold.smoke.log=true"]}
                       :cache-libraries {:jvm-opts ["-Ddefold.cache.libraries=true"]}
+                      :portal {:source-paths ["src/portal"]
+                               :dependencies [[djblue/portal "0.60.2"]]}
                       :reveal {:source-paths ["src/reveal"]
                                :jvm-opts ["-Djol.magicFieldOffset=true" "-XX:+EnableDynamicAgentLoading"]
                                :injections [(require 'editor.reveal)]

--- a/editor/src/clj/util/fn.clj
+++ b/editor/src/clj/util/fn.clj
@@ -180,6 +180,19 @@
         nil)
       (throw (IllegalArgumentException. "The function was not memoized by us.")))))
 
+(defn demunged-symbol
+  "Given a munged name, such as the full name of a Clojure function class,
+  return a demunged symbol."
+  [^String munged-name]
+  (let [namespaced-name (Compiler/demunge munged-name)
+        separator-index (.indexOf namespaced-name (int \/))
+        namespace (when (pos? separator-index)
+                    (.intern (subs namespaced-name 0 separator-index)))
+        name (if (neg? separator-index)
+               namespaced-name
+               (.intern (subs namespaced-name (inc separator-index))))]
+    (symbol namespace name)))
+
 (defn declared-symbol
   "Given a declared function, returns the symbol that resolves to the function."
   [declared-fn]
@@ -190,14 +203,7 @@
         (throw (IllegalArgumentException.
                  (format "Unable to get declared symbol from anonymous function `%s`."
                          class-name)))
-        (let [namespaced-name (Compiler/demunge class-name)
-              separator-index (.indexOf namespaced-name (int \/))
-              namespace (when (pos? separator-index)
-                          (.intern (subs namespaced-name 0 separator-index)))
-              name (if (neg? separator-index)
-                     namespaced-name
-                     (.intern (subs namespaced-name (inc separator-index))))]
-          (symbol namespace name))))))
+        (demunged-symbol class-name)))))
 
 (defn make-case-fn
   "Given a collection of key-value pairs, return a function that returns the

--- a/editor/src/portal/editor/portal.clj
+++ b/editor/src/portal/editor/portal.clj
@@ -1,0 +1,126 @@
+;; Copyright 2020-2025 The Defold Foundation
+;; Copyright 2014-2020 King
+;; Copyright 2009-2014 Ragnar Svensson, Christian Murray
+;; Licensed under the Defold License version 1.0 (the "License"); you may not use
+;; this file except in compliance with the License.
+;;
+;; You may obtain a copy of the License, together with FAQs at
+;; https://www.defold.com/license
+;;
+;; Unless required by applicable law or agreed to in writing, software distributed
+;; under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+;; CONDITIONS OF ANY KIND, either express or implied. See the License for the
+;; specific language governing permissions and limitations under the License.
+
+(ns editor.portal
+  (:require [clojure.java.io :as io]
+            [editor.code.data]
+            [editor.resource :as resource]
+            [internal.graph.types]
+            [portal.api :as portal.api]
+            [portal.viewer :as portal.viewer]
+            [util.coll :as coll]
+            [util.defonce :as defonce])
+  (:import [editor.code.data Cursor CursorRange]
+           [editor.resource Resource]
+           [internal.graph.types Endpoint]))
+
+(set! *warn-on-reflection* true)
+(set! *unchecked-math* :warn-on-boxed)
+
+(defonce/protocol Viewable
+  (portal-view [value] "Returns a customized Portal viewer for the value."))
+
+(declare default-viewer)
+
+(extend-protocol Viewable
+  Cursor
+  (portal-view [cursor]
+    (portal.viewer/pprint cursor))
+
+  CursorRange
+  (portal-view [cursor-range]
+    (portal.viewer/pprint
+      (default-viewer cursor-range)))
+
+  Endpoint
+  (portal-view [endpoint]
+    (portal.viewer/pr-str endpoint))
+
+  Resource
+  (portal-view [resource]
+    (let [class-name (.getSimpleName (class resource))
+          class-keyword (keyword class-name)
+          proj-path (resource/proj-path resource)]
+      (portal.viewer/pr-str {class-keyword proj-path})))
+
+  byte/1
+  (portal-view [bytes]
+    (portal.viewer/bin bytes)))
+
+(declare viewer)
+
+(defn default-viewer [value]
+  (cond
+    (map? value)
+    (reduce-kv ; This also works with records, maintaining their type.
+      (fn [coll old-key old-value]
+        (let [new-key (viewer old-key)
+              new-value (viewer old-value)]
+          (cond-> (assoc coll new-key new-value)
+                  (not= old-key new-key) (dissoc old-key))))
+      value
+      value)
+
+    (coll? value)
+    (coll/transfer
+      value (coll/empty-with-meta value)
+      (map viewer))
+
+    :else
+    value))
+
+(defn viewer [value]
+  (if (satisfies? Viewable value)
+    (portal-view value)
+    (default-viewer value)))
+
+(defn submit! [value]
+  (portal.api/submit (viewer value)))
+
+;; Add the #'submit! var to the tap set rather than the function to ensure the
+;; set won't grow if the function is redefined.
+(defonce ^:private -add-tap-
+  (add-tap #'submit!))
+
+(defn editor-default-options []
+  ;; These temporary files will be present based on the editor integration.
+  (cond
+    (.exists (io/file ".portal" "emacs.edn"))
+    {:launcher :emacs}
+
+    (.exists (io/file ".portal" "intellij.edn"))
+    {:launcher :intellij}
+
+    (.exists (io/file ".portal" "vs-code.edn"))
+    {:launcher :vs-code}))
+
+(defonce ^:private portal-session-atom (atom nil))
+
+(defn open!
+  ([]
+   (open! (editor-default-options)))
+  ([options]
+   (println "Opening Portal with options" options)
+   (swap! portal-session-atom portal.api/open options)))
+
+(defn clear! []
+  (some-> (deref portal-session-atom)
+          (portal.api/clear)))
+
+(defn selected []
+  (some-> (deref portal-session-atom)
+          (portal.api/selected)))
+
+(defn sel []
+  (first (selected)))

--- a/editor/src/portal/editor/portal.clj
+++ b/editor/src/portal/editor/portal.clj
@@ -226,7 +226,8 @@
                                  (fn [target-label->source-key->source-node-id [input-label]]
                                    (update
                                      target-label->source-key->source-node-id input-label
-                                     #(or % no-viewer)))
+                                     fn/or
+                                     no-viewer))
                                  target-label->source-key->source-node-id
                                  (g/declared-inputs node-type)))
                  'outputs (as-> empty-navigable-node-label-map source-label->target-key->target-node-id
@@ -248,7 +249,8 @@
                                   (fn [source-label->target-key->target-node-id [output-label]]
                                     (update
                                       source-label->target-key->target-node-id output-label
-                                      #(or % no-viewer)))
+                                      fn/or
+                                      no-viewer))
                                   source-label->target-key->target-node-id
                                   (g/declared-outputs node-type)))})
               (with-meta {`protocols/nav default-nav-fn

--- a/editor/src/portal/editor/portal.clj
+++ b/editor/src/portal/editor/portal.clj
@@ -48,8 +48,7 @@
 ;;     on the class path.
 ;;   * Evaluate the following expression through the REPL connection:
 ;;     ```
-;;     (do (require '[editor.portal :as portal])
-;;         (portal/open!))
+;;     ((requiring-resolve 'editor.portal/open!))
 ;;     ```
 ;;     You might want to set up a REPL Command for this in your IDE.
 


### PR DESCRIPTION
[Portal](https://github.com/djblue/portal) is a web-based UI for inspecting Clojure values that can run standalone in a web browser or be integrated into various popular IDEs. Once running, you can call `(tap> some-value)` to inspect it in Portal.

This PR introduces a new `portal` Leiningen profile that will include the relevant dependencies to run Portal when working on the Defold Editor, as well as some editor-specific functionality, such as inspecting graph nodes and resources.

Portal is only a simple value inspector. If you desire full REPL-replacement with more advanced capabilities, look into using [Reveal](https://vlaaad.github.io/reveal/) instead. It has similar Defold Editor-specific inspection capabilities and more.

<img width="1852" height="1527" alt="portal-node-inspector" src="https://github.com/user-attachments/assets/62097c2c-43c7-434b-bed8-44ed4b1d473e" />

### Setup Instructions

Install the relevant Portal plugin for your IDE of choice. This enables you to run the Portal inspector in a docked panel inside your editor.
  * Cursive: https://plugins.jetbrains.com/plugin/18467-portal-inspector/
  * Visual Studio Code: https://marketplace.visualstudio.com/items?itemName=djblue.portal

Once installed,
  * Use `lein with-profile +portal ...` when starting up to include Portal
    on the class path.
  * Evaluate the following expression through the REPL connection:
    ```clj
    (do (require '[editor.portal :as portal])
        (portal/open!))
    ```
    You might want to set up a REPL Command for this in your IDE.

### General Functionality
* Call `(tap> some-value)` to inspect any Clojure value or Java object in Portal.
* In Portal, you can double-click a `node-id` or a `Resource` value to inspect the corresponding node.

### Node View Functionality
This view shows details related to a node in the graph.

* Nodes that belong to a `ResourceNode` will display their owner `Resource`.
* Override nodes will show the chain of original `node-ids`.
* The **properties** map shows raw field values, and includes defaults when viewing a base node. When viewing an override node, only overridden values are shown.
* For the **inputs** and **outputs**, we show incoming and outgoing connections instead of values.
* Double-click the `:keyword` for a **property**, **input**, or **output** to evaluate it.
