### PR TITLE
Cancel outline rename on drag

### DIFF
--- a/editor/src/clj/editor/outline_view.clj
+++ b/editor/src/clj/editor/outline_view.clj
@@ -718,7 +718,9 @@
     (doto tree-view
       (ui/customize-tree-view! {:double-click-expand? true})
       (.. getSelectionModel (setSelectionMode SelectionMode/MULTIPLE))
-      (.setOnDragDetected (ui/event-handler e (drag-detected project outline-view e)))
+      (.setOnDragDetected (ui/event-handler e 
+                            (drag-detected project outline-view e)
+                            (cancel-rename! tree-view)))
       (.setOnDragOver (ui/event-handler e (drag-over project outline-view e)))
       (.setOnDragDropped (ui/event-handler e (error-reporting/catch-all! (drag-dropped project app-view outline-view e))))
       (.setCellFactory (reify Callback (call ^TreeCell [this view] (make-tree-cell view drag-entered-handler drag-exited-handler))))


### PR DESCRIPTION
Fixes #11117

### Technical changes
If we drag an already selected element by its label, we will also trigger a rename (also see the video on #11103). This PR should cancel the future rename, if we start dragging before the rename activation. This change indirectly fixes the mentioned issue, because the future event on `drag-entered` will not be interfered by the rename future event. It is worth noting that the actual root cause is that the filtered event of the label is `MOUSE_PRESSED` instead of `MOUSE_CLICKED` or `MOUSE_RELEASED`. The rationale behind this questionable decision at the time, was the way the selection works on the tree node (on mouse pressed).