### PR TITLE
Editor: Pretty-print vecmath types and Arcs in Reveal

### DIFF
--- a/editor/.idea/codeStyles/Project.xml
+++ b/editor/.idea/codeStyles/Project.xml
@@ -106,6 +106,7 @@
           <entry key="util.debug-util/metrics-time" value="-1" />
           <entry key="util.profiler/profile" value="-1" />
           <entry key="vlaaad.reveal/defaction" value="-1" />
+          <entry key="vlaaad.reveal/defstream" value="-1" />
         </map>
       </option>
     </ClojureCodeStyleSettings>

--- a/editor/src/clj/data_readers.clj
+++ b/editor/src/clj/data_readers.clj
@@ -14,4 +14,5 @@
 
 {code/range editor.code.data/read-cursor-range
  code/cursor editor.code.data/read-cursor
+ g/arc internal.graph.types/read-arc
  g/endpoint internal.graph.types/read-endpoint}

--- a/editor/src/clj/internal/graph/types.clj
+++ b/editor/src/clj/internal/graph/types.clj
@@ -22,6 +22,21 @@
 
 (defrecord Arc [source-id source-label target-id target-label])
 
+(defn arc-print-data [^Arc arc]
+  (into [(.-source-id arc) (.-source-label arc)
+         (.-target-id arc) (.-target-label arc)]
+        cat
+        (dissoc arc :source-id :source-label :target-id :target-label)))
+
+(defmethod print-method Arc [^Arc arc ^Writer writer]
+  (.write writer "#g/arc ")
+  (print-method (arc-print-data arc) writer))
+
+(defn- read-arc [[source-id source-label target-id target-label & {:as kvs}]]
+  (if kvs
+    `(Arc. ~source-id ~source-label ~target-id ~target-label nil ~kvs)
+    `(Arc. ~source-id ~source-label ~target-id ~target-label)))
+
 (defn source-id [^Arc arc] (.source-id arc))
 (defn source-label [^Arc arc] (.source-label arc))
 (defn source [^Arc arc] [(.source-id arc) (.source-label arc)])

--- a/editor/src/dev/dev.clj
+++ b/editor/src/dev/dev.clj
@@ -82,7 +82,7 @@
            [java.nio ByteBuffer]
            [javafx.scene Node]
            [javafx.stage Window]
-           [javax.vecmath Matrix3d Matrix4d Point2d Point3d Point4d Quat4d Vector2d Vector3d Vector4d]))
+           [javax.vecmath Matrix3d Matrix3f Matrix4d Matrix4f Point2d Point3d Point4d Quat4d Vector2d Vector3d Vector4d]))
 
 (set! *warn-on-reflection* true)
 (set! *unchecked-math* :warn-on-boxed)
@@ -1105,19 +1105,71 @@
                        (conj (subvec verts 0 (min 3 (count verts)))
                              '...)))))
 
-(defmulti matrix-row (fn [matrix ^long _row-index] (class matrix)))
+(defn- vecmath-matrix-dim
+  ^long [matrix]
+  (condp instance? matrix
+    Matrix3d 3
+    Matrix3f 3
+    Matrix4d 4
+    Matrix4f 4))
 
-(defmethod matrix-row Matrix3d
-  [^Matrix3d matrix ^long row-index]
+(defmulti ^:private vecmath-matrix-row (fn [matrix ^long _row-index] (class matrix)))
+
+(defmethod vecmath-matrix-row Matrix3d [^Matrix3d matrix ^long row-index]
   (let [row (double-array 3)]
     (.getRow matrix row-index row)
     row))
 
-(defmethod matrix-row Matrix4d
-  [^Matrix4d matrix ^long row-index]
+(defmethod vecmath-matrix-row Matrix3f [^Matrix3f matrix ^long row-index]
+  (let [row (float-array 3)]
+    (.getRow matrix row-index row)
+    row))
+
+(defmethod vecmath-matrix-row Matrix4d [^Matrix4d matrix ^long row-index]
   (let [row (double-array 4)]
     (.getRow matrix row-index row)
     row))
+
+(defmethod vecmath-matrix-row Matrix4f [^Matrix4f matrix ^long row-index]
+  (let [row (float-array 4)]
+    (.getRow matrix row-index row)
+    row))
+
+(defn vecmath-matrix-pprint-strings [matrix]
+  (let [dim (vecmath-matrix-dim matrix)
+        fmt-num #(eutil/format* "%.3f" %)
+        num-strs (coll/transfer (range dim) []
+                   (mapcat (fn [^long row-index]
+                             (let [row (vecmath-matrix-row matrix row-index)]
+                               (map fmt-num row)))))
+        first-col-width (transduce (comp (take-nth dim)
+                                         (map count))
+                                   max
+                                   0
+                                   num-strs)
+        rest-col-width (transduce (map count)
+                                  max
+                                  0
+                                  num-strs)
+        first-col-width-fmt (str \% first-col-width \s)
+        rest-col-width-fmt (str \% rest-col-width \s)
+        fmt-col (fn [^long index num-str]
+                  (let [fmt (if (zero? (rem index dim))
+                              first-col-width-fmt
+                              rest-col-width-fmt)]
+                    (eutil/format* fmt num-str)))]
+    (coll/transfer num-strs []
+      (partition-all dim)
+      (map (partial into [] (map-indexed fmt-col))))))
+
+(defn zero-vecmath-matrix-col-str? [^String col-str]
+  (let [last-index (.lastIndexOf col-str "0.000")]
+    (case last-index
+      -1 false
+      0 true
+      (case (.charAt col-str (dec last-index))
+        (\space \-) true
+        false))))
 
 (def pretty-printer
   (let [fmt-doc puget.printer/format-doc
@@ -1191,41 +1243,21 @@
                project-resource-pprint-handler})
 
             vecmath-pprint-handlers
-            (letfn [(vecmath-tuple-pprint-handler [printer vecmath-value]
-                      (object-data-pprint-handler nil math/vecmath->clj printer vecmath-value))
+            (letfn [(vecmath-tuple-pprint-handler [printer tuple]
+                      (object-data-pprint-handler nil math/vecmath->clj printer tuple))
 
-                    (vecmath-matrix-pprint-handler [^long dim printer matrix]
-                      (let [fmt-num #(eutil/format* "%.3f" %)
-                            num-strs (into []
-                                           (mapcat (fn [^long row-index]
-                                                     (let [row (matrix-row matrix row-index)]
-                                                       (map fmt-num row))))
-                                           (range dim))
-                            first-col-width (transduce (comp (take-nth 4)
-                                                             (map count))
-                                                       max
-                                                       0
-                                                       num-strs)
-                            rest-col-width (transduce (map count)
-                                                      max
-                                                      0
-                                                      num-strs)
-                            first-col-width-fmt (str \% first-col-width \s)
-                            rest-col-width-fmt (str \% rest-col-width \s)
-                            fmt-col (fn [^long index num-str]
-                                      (let [element (case num-str
-                                                      ("-0.000" "0.000") :number
-                                                      :string)
-                                            fmt (if (zero? (rem index 4))
-                                                  first-col-width-fmt
-                                                  rest-col-width-fmt)]
-                                        (col-txt printer element (format fmt num-str))))
-                            data (into [:align]
-                                       (comp (partition-all dim)
-                                             (map (fn [row-num-strs]
-                                                    (interpose " " (map-indexed fmt-col row-num-strs))))
-                                             (interpose :break))
-                                       num-strs)]
+                    (vecmath-matrix-pprint-handler [printer matrix]
+                      (let [row-col-strs (vecmath-matrix-pprint-strings matrix)
+                            fmt-col (fn [^String num-str]
+                                      ;; Colorize zero values differently.
+                                      (let [element (if (zero-vecmath-matrix-col-str? num-str)
+                                                      :number
+                                                      :string)]
+                                        (col-txt printer element num-str)))
+                            data (coll/transfer row-col-strs [:align]
+                                   (map (fn [col-strs]
+                                          (interpose " " (map fmt-col col-strs))))
+                                   (interpose :break))]
                         [:group
                          (cls-tag printer (class matrix))
                          (col-doc printer :delimiter "[")
@@ -1233,10 +1265,16 @@
                          (col-doc printer :delimiter "]")]))]
 
               {(namespaced-class-symbol Matrix3d)
-               (partial vecmath-matrix-pprint-handler 3)
+               vecmath-matrix-pprint-handler
+
+               (namespaced-class-symbol Matrix3f)
+               vecmath-matrix-pprint-handler
 
                (namespaced-class-symbol Matrix4d)
-               (partial vecmath-matrix-pprint-handler 4)
+               vecmath-matrix-pprint-handler
+
+               (namespaced-class-symbol Matrix4f)
+               vecmath-matrix-pprint-handler
 
                (namespaced-class-symbol Point2d)
                vecmath-tuple-pprint-handler

--- a/editor/src/reveal/data_readers.clj
+++ b/editor/src/reveal/data_readers.clj
@@ -13,4 +13,24 @@
 ;; specific language governing permissions and limitations under the License.
 
 {resource/file editor.reveal/read-file-resource
- resource/zip editor.reveal/read-zip-resource}
+ resource/zip editor.reveal/read-zip-resource
+ v/Color3f editor.reveal/read-color-3f
+ v/Color4f editor.reveal/read-color-4f
+ v/Matrix3d editor.reveal/read-matrix-3d
+ v/Matrix3f editor.reveal/read-matrix-3f
+ v/Matrix4d editor.reveal/read-matrix-4d
+ v/Matrix4f editor.reveal/read-matrix-4f
+ v/Point2d editor.reveal/read-point-2d
+ v/Point2f editor.reveal/read-point-2f
+ v/Point3d editor.reveal/read-point-3d
+ v/Point3f editor.reveal/read-point-3f
+ v/Point4d editor.reveal/read-point-4d
+ v/Point4f editor.reveal/read-point-4f
+ v/Quat4d editor.reveal/read-quat-4d
+ v/Quat4f editor.reveal/read-quat-4f
+ v/Vector2d editor.reveal/read-vector-2d
+ v/Vector2f editor.reveal/read-vector-2f
+ v/Vector3d editor.reveal/read-vector-3d
+ v/Vector3f editor.reveal/read-vector-3f
+ v/Vector4d editor.reveal/read-vector-4d
+ v/Vector4f editor.reveal/read-vector-4f}

--- a/editor/src/reveal/editor/reveal.clj
+++ b/editor/src/reveal/editor/reveal.clj
@@ -18,6 +18,7 @@
             [cljfx.fx.label :as fx.label]
             [cljfx.fx.v-box :as fx.v-box]
             [clojure.core.async :as a]
+            [clojure.core.async.impl.channels]
             [clojure.main :as m]
             [clojure.string :as str]
             [dev]
@@ -26,18 +27,22 @@
             [editor.resource :as resource]
             [editor.resource-node :as resource-node]
             [editor.workspace :as workspace]
-            [editor.workspace]
+            [internal.graph.types :as gt]
             [internal.system :as is]
+            [util.coll :as coll]
+            [util.eduction :as e]
             [vlaaad.reveal :as r])
   (:import [clojure.core.async.impl.channels ManyToManyChannel]
            [clojure.lang IRef]
            [editor.code.data Cursor CursorRange]
            [editor.resource FileResource ZipResource]
            [editor.workspace BuildResource]
-           [internal.graph.types Endpoint]
-           [javafx.scene Parent]))
+           [internal.graph.types Arc Endpoint]
+           [javafx.scene Parent]
+           [javax.vecmath Color3f Color4f Matrix3d Matrix3f Matrix4d Matrix4f Point2d Point2f Point3d Point3f Point4d Point4f Quat4d Quat4f Tuple2d Tuple2f Tuple3d Tuple3f Tuple4d Tuple4f Vector2d Vector2f Vector3d Vector3f Vector4d Vector4f]))
 
 (set! *warn-on-reflection* true)
+(set! *unchecked-math* :warn-on-boxed)
 
 (defn- node-value-or-err [ec node-id label]
   (try
@@ -187,6 +192,28 @@
   (when node-id+label
     #(apply watch-all node-id+label)))
 
+(defn- stream-arc-contents [arc]
+  (apply
+    r/horizontal
+    (r/stream (gt/source-id arc))
+    r/separator
+    (r/stream (gt/source-label arc))
+    r/separator
+    (r/stream (gt/target-id arc))
+    r/separator
+    (r/stream (gt/target-label arc))
+    (when-let [other (seq (dissoc arc :source-id :source-label :target-id :target-label))]
+      [r/separator
+       (->> other
+            (eduction (map r/horizontally))
+            (r/horizontally))])))
+
+(r/defstream Arc [arc]
+  (r/horizontal
+    (r/raw-string "#g/arc [" {:fill :object})
+    (stream-arc-contents arc)
+    (r/raw-string "]" {:fill :object})))
+
 (r/defstream Endpoint [endpoint]
   (r/horizontal
     (r/raw-string "#g/endpoint [" {:fill :object})
@@ -308,3 +335,165 @@
                                       {:fx/type r/value-view
                                        :v-box/vgrow :always
                                        :value state}]})})})))
+
+(defn- vecmath-matrix-sf [matrix]
+  (let [row-col-strs (dev/vecmath-matrix-pprint-strings matrix)]
+    (r/horizontal
+      (r/raw-string "#v/" {:fill :object})
+      (r/raw-string (.getSimpleName (class matrix)) {:fill :object})
+      (r/raw-string " [" {:fill :object})
+      (apply
+        r/vertical
+        (coll/transfer row-col-strs :eduction
+          (map (fn [col-strs]
+                 (apply
+                   r/horizontal
+                   (coll/transfer col-strs :eduction
+                     (map (fn [col-str]
+                            (let [style (if (dev/zero-vecmath-matrix-col-str? col-str)
+                                          {:fill :util}
+                                          {:fill :scalar})]
+                              (r/raw-string col-str style))))
+                     (interpose r/separator)))))))
+      (r/raw-string "]" {:fill :object}))))
+
+(r/defstream Matrix3d [^Matrix3d matrix]
+  (vecmath-matrix-sf matrix))
+
+(r/defstream Matrix3f [^Matrix3f matrix]
+  (vecmath-matrix-sf matrix))
+
+(r/defstream Matrix4d [^Matrix4d matrix]
+  (vecmath-matrix-sf matrix))
+
+(r/defstream Matrix4f [^Matrix4f matrix]
+  (vecmath-matrix-sf matrix))
+
+(defn- vecmath-tuple-sf [^Class tuple-class & component-values]
+  (apply
+    r/horizontal
+    (r/raw-string "#v/" {:fill :object})
+    (r/raw-string (.getSimpleName tuple-class) {:fill :object})
+    (r/raw-string " [" {:fill :object})
+    (-> component-values
+        (coll/transfer :eduction
+          (map r/stream)
+          (interpose r/separator))
+        (e/conj (r/raw-string "]" {:fill :object})))))
+
+(r/defstream Tuple2d [^Tuple2d tuple]
+  (vecmath-tuple-sf (class tuple) (.getX tuple) (.getY tuple)))
+
+(r/defstream Tuple2f [^Tuple2f tuple]
+  (vecmath-tuple-sf (class tuple) (.getX tuple) (.getY tuple)))
+
+(r/defstream Tuple3d [^Tuple3d tuple]
+  (vecmath-tuple-sf (class tuple) (.getX tuple) (.getY tuple) (.getZ tuple)))
+
+(r/defstream Tuple3f [^Tuple3f tuple]
+  (vecmath-tuple-sf (class tuple) (.getX tuple) (.getY tuple) (.getZ tuple)))
+
+(r/defstream Tuple4d [^Tuple4d tuple]
+  (vecmath-tuple-sf (class tuple) (.getX tuple) (.getY tuple) (.getZ tuple) (.getW tuple)))
+
+(r/defstream Tuple4f [^Tuple4f tuple]
+  (vecmath-tuple-sf (class tuple) (.getX tuple) (.getY tuple) (.getZ tuple) (.getW tuple)))
+
+(defn- read-color-3f [[x y z]]
+  `(Color3f. ~x ~y ~z))
+
+(defn- read-color-4f [[x y z w]]
+  `(Color4f. ~x ~y ~z ~w))
+
+(defn- read-matrix-3d [[m00 m01 m02 m10 m11 m12 m20 m21 m22]]
+  `(Matrix3d. ~m00 ~m01 ~m02 ~m10 ~m11 ~m12 ~m20 ~m21 ~m22))
+
+(defn- read-matrix-3f [[m00 m01 m02 m10 m11 m12 m20 m21 m22]]
+  `(Matrix3f. ~m00 ~m01 ~m02 ~m10 ~m11 ~m12 ~m20 ~m21 ~m22))
+
+(defn- read-matrix-4d [[m00 m01 m02 m03 m10 m11 m12 m13 m20 m21 m22 m23 m30 m31 m32 m33]]
+  `(Matrix4d. ~m00 ~m01 ~m02 ~m03 ~m10 ~m11 ~m12 ~m13 ~m20 ~m21 ~m22 ~m23 ~m30 ~m31 ~m32 ~m33))
+
+(defn- read-matrix-4f [[m00 m01 m02 m03 m10 m11 m12 m13 m20 m21 m22 m23 m30 m31 m32 m33]]
+  `(Matrix4f. ~m00 ~m01 ~m02 ~m03 ~m10 ~m11 ~m12 ~m13 ~m20 ~m21 ~m22 ~m23 ~m30 ~m31 ~m32 ~m33))
+
+(defn- read-point-2d [[x y]]
+  `(Point2d. ~x ~y))
+
+(defn- read-point-2f [[x y]]
+  `(Point2f. ~x ~y))
+
+(defn- read-point-3d [[x y z]]
+  `(Point3d. ~x ~y ~z))
+
+(defn- read-point-3f [[x y z]]
+  `(Point3f. ~x ~y ~z))
+
+(defn- read-point-4d [[x y z w]]
+  `(Point4d. ~x ~y ~z ~w))
+
+(defn- read-point-4f [[x y z w]]
+  `(Point4f. ~x ~y ~z ~w))
+
+(defn- read-quat-4d [[x y z w]]
+  `(Quat4d. ~x ~y ~z ~w))
+
+(defn- read-quat-4f [[x y z w]]
+  `(Quat4f. ~x ~y ~z ~w))
+
+(defn- read-vector-2d [[x y]]
+  `(Vector2d. ~x ~y))
+
+(defn- read-vector-2f [[x y]]
+  `(Vector2f. ~x ~y))
+
+(defn- read-vector-3d [[x y z]]
+  `(Vector3d. ~x ~y ~z))
+
+(defn- read-vector-3f [[x y z]]
+  `(Vector3f. ~x ~y ~z))
+
+(defn- read-vector-4d [[x y z w]]
+  `(Vector4d. ~x ~y ~z ~w))
+
+(defn- read-vector-4f [[x y z w]]
+  `(Vector4f. ~x ~y ~z ~w))
+
+(comment
+  ;; A map containing simple values for manual testing.
+  (sorted-map
+    :arc (assoc (gt/->Arc 12345 :source-label 54321 :target-label) :ex/arc "ex")
+    :color-3f (Color3f. 0.0 0.1 0.2)
+    :color-4f (Color4f. 0.0 0.1 0.2 0.3)
+    :cursor (assoc (Cursor. 5 80) :ex/cursor "ex")
+    :cursor-range (assoc (CursorRange. (assoc (Cursor. 4 0) :ex/from-cursor "ex")
+                                       (assoc (Cursor. 5 80) :ex/to-cursor "ex")) :ex/cursor-range "ex")
+    :endpoint (g/endpoint 12345 :label)
+    :matrix-3d (Matrix3d. 0.0 0.1 0.2
+                          1.0 1.1 1.2
+                          2.0 2.1 2.2)
+    :matrix-3f (Matrix3f. 0.0 0.1 0.2
+                          1.0 1.1 1.2
+                          2.0 2.1 2.2)
+    :matrix-4d (Matrix4d. 0.0 0.1 0.2 0.3
+                          1.0 1.1 1.2 1.3
+                          2.0 2.1 2.2 2.3
+                          3.0 3.1 3.2 3.3)
+    :matrix-4f (Matrix4f. 0.0 0.1 0.2 0.3
+                          1.0 1.1 1.2 1.3
+                          2.0 2.1 2.2 2.3
+                          3.0 3.1 3.2 3.3)
+    :point-2d (Point2d. 0.0 0.1)
+    :point-2f (Point2f. 0.0 0.1)
+    :point-3d (Point3d. 0.0 0.1 0.2)
+    :point-3f (Point3f. 0.0 0.1 0.2)
+    :point-4d (Point4d. 0.0 0.1 0.2 0.3)
+    :point-4f (Point4f. 0.0 0.1 0.2 0.3)
+    :quat-4d (Quat4d. 0.0 0.1 0.2 0.3)
+    :quat-4f (Quat4f. 0.0 0.1 0.2 0.3)
+    :vector-2d (Vector2d. 0.0 0.1)
+    :vector-2f (Vector2f. 0.0 0.1)
+    :vector-3d (Vector3d. 0.0 0.1 0.2)
+    :vector-3f (Vector3f. 0.0 0.1 0.2)
+    :vector-4d (Vector4d. 0.0 0.1 0.2 0.3)
+    :vector-4f (Vector4f. 0.0 0.1 0.2 0.3)))


### PR DESCRIPTION
### Technical changes
* Added Reveal stream handlers and readers for all floating-point `javax.vecmath` types.
* Added Reveal stream handler and reader for `gt/Arc`.