### PR TITLE
Show settings from `/game.properties` and `ext.properties`

### DIFF
--- a/editor/project.clj
+++ b/editor/project.clj
@@ -219,7 +219,7 @@
                       :reveal {:source-paths ["src/reveal"]
                                :jvm-opts ["-Djol.magicFieldOffset=true" "-XX:+EnableDynamicAgentLoading"]
                                :injections [(require 'editor.reveal)]
-                               :dependencies [[vlaaad/reveal "1.3.287"]
+                               :dependencies [[vlaaad/reveal "1.3.290"]
                                               [org.openjfx/javafx-web "23.0.1"]]}
                       :metrics {:jvm-opts ["-Ddefold.metrics=true"]}
                       :jamm {:dependencies [[com.github.jbellis/jamm "0.4.0"]]

--- a/editor/src/clj/editor/app_manifest.clj
+++ b/editor/src/clj/editor/app_manifest.clj
@@ -338,8 +338,7 @@
       (generic-contains-toggles android :excludeSymbols ["ProfilerRemotery"])
       (generic-contains-toggles ios :excludeSymbols ["ProfilerRemotery"])
       (generic-contains-toggles web :excludeSymbols ["ProfilerJS"])
-      (generic-contains-toggles all-platforms :excludeSymbols ["ProfilerBasic", "ProfilerRemotery"])
-      )))
+      (generic-contains-toggles all-platforms :excludeSymbols ["ProfilerBasic", "ProfilerRemotery"]))))
 
 (def sound-setting
   (make-check-box-setting

--- a/editor/src/clj/editor/cljfx_form_view.clj
+++ b/editor/src/clj/editor/cljfx_form_view.clj
@@ -178,7 +178,7 @@
 (defmethod form-input-view :default [{:keys [value type] :as field}]
   {:fx/type fx.label/lifecycle
    :wrap-text true
-   :text (str type " " (if (nil? value) "***NIL***" value) " " field)})
+   :text (str value)})
 
 (defmulti cell-input-view
   "Analogous to form input, but displayed in a cell (in list-view or table-view)

--- a/editor/src/clj/editor/cljfx_form_view.clj
+++ b/editor/src/clj/editor/cljfx_form_view.clj
@@ -175,7 +175,7 @@
   - `:resource-string-converter` - a resource string converter"
   :type)
 
-(defmethod form-input-view :default [{:keys [value type] :as field}]
+(defmethod form-input-view :default [{:keys [value]}]
   {:fx/type fx.label/lifecycle
    :wrap-text true
    :text (str value)})

--- a/editor/src/clj/editor/code/lang/ini.clj
+++ b/editor/src/clj/editor/code/lang/ini.clj
@@ -12,7 +12,10 @@
 ;; CONDITIONS OF ANY KIND, either express or implied. See the License for the
 ;; specific language governing permissions and limitations under the License.
 
-(ns editor.ini)
+(ns editor.code.lang.ini)
+
+(set! *warn-on-reflection* true)
+(set! *unchecked-math* :warn-on-boxed)
 
 (def grammar
   "Defold-style ini grammar"

--- a/editor/src/clj/editor/defold_project.clj
+++ b/editor/src/clj/editor/defold_project.clj
@@ -55,7 +55,8 @@
             [util.fn :as fn]
             [util.thread-util :as thread-util])
   (:import [java.io File]
-           [java.util.concurrent.atomic AtomicLong]))
+           [java.util.concurrent.atomic AtomicLong]
+           [org.apache.commons.io FilenameUtils]))
 
 (set! *warn-on-reflection* true)
 
@@ -1509,6 +1510,7 @@
   (input collision-group-nodes g/Any :array :substitute gu/array-subst-remove-errors)
   (input build-settings g/Any)
   (input breakpoints Breakpoints :array :substitute gu/array-subst-remove-errors)
+  (input proj-path->meta-info g/Any :array :substitute gu/array-subst-remove-errors)
 
   (output selected-node-ids-by-resource-node g/Any :cached (g/fnk [all-selected-node-ids all-selections]
                                                              (let [selected-node-id-set (set all-selected-node-ids)]
@@ -1546,7 +1548,20 @@
   (output default-tex-params g/Any :cached produce-default-tex-params)
   (output default-sampler-filter-modes g/Any :cached produce-default-sampler-filter-modes)
   (output build-settings g/Any (gu/passthrough build-settings))
-  (output breakpoints Breakpoints :cached (g/fnk [breakpoints] (into [] cat breakpoints))))
+  (output breakpoints Breakpoints :cached (g/fnk [breakpoints] (into [] cat breakpoints)))
+  (output meta-infos g/Any :cached
+          (g/fnk [proj-path->meta-info]
+            {:ext-meta-info
+             (when-not (coll/empty? proj-path->meta-info)
+               (transduce
+                 (keep (fn [e]
+                         (when (= "ext" (FilenameUtils/getBaseName (key e)))
+                           (val e))))
+                 settings-core/merge-meta-infos
+                 proj-path->meta-info))
+
+             :game-project-proj-path->additional-meta-info
+             (coll/pair-map-by #(str (FilenameUtils/removeExtension (key %)) ".project") val proj-path->meta-info)})))
 
 (defn get-project
   ([node]

--- a/editor/src/clj/editor/defold_project.clj
+++ b/editor/src/clj/editor/defold_project.clj
@@ -1510,7 +1510,7 @@
   (input collision-group-nodes g/Any :array :substitute gu/array-subst-remove-errors)
   (input build-settings g/Any)
   (input breakpoints Breakpoints :array :substitute gu/array-subst-remove-errors)
-  (input proj-path->meta-info g/Any :array :substitute gu/array-subst-remove-errors)
+  (input proj-path+meta-info-pairs g/Any :array :substitute gu/array-subst-remove-errors)
 
   (output selected-node-ids-by-resource-node g/Any :cached (g/fnk [all-selected-node-ids all-selections]
                                                              (let [selected-node-id-set (set all-selected-node-ids)]
@@ -1550,18 +1550,18 @@
   (output build-settings g/Any (gu/passthrough build-settings))
   (output breakpoints Breakpoints :cached (g/fnk [breakpoints] (into [] cat breakpoints)))
   (output meta-infos g/Any :cached
-          (g/fnk [proj-path->meta-info]
+          (g/fnk [proj-path+meta-info-pairs]
             {:ext-meta-info
-             (when-not (coll/empty? proj-path->meta-info)
+             (when-not (coll/empty? proj-path+meta-info-pairs)
                (transduce
                  (keep (fn [e]
                          (when (= "ext" (FilenameUtils/getBaseName (key e)))
                            (val e))))
                  settings-core/merge-meta-infos
-                 proj-path->meta-info))
+                 proj-path+meta-info-pairs))
 
              :game-project-proj-path->additional-meta-info
-             (coll/pair-map-by #(str (FilenameUtils/removeExtension (key %)) ".project") val proj-path->meta-info)})))
+             (coll/pair-map-by #(str (FilenameUtils/removeExtension (key %)) ".project") val proj-path+meta-info-pairs)})))
 
 (defn get-project
   ([node]

--- a/editor/src/clj/editor/game_project.clj
+++ b/editor/src/clj/editor/game_project.clj
@@ -13,19 +13,20 @@
 ;; specific language governing permissions and limitations under the License.
 
 (ns editor.game-project
-  (:require [clojure.string :as string]
-            [clojure.java.io :as io]
+  (:require [clojure.java.io :as io]
+            [clojure.string :as string]
             [dynamo.graph :as g]
-            [util.murmur :as murmur]
             [editor.build-target :as bt]
+            [editor.fs :as fs]
+            [editor.game-project-core :as gpcore]
+            [editor.graph-util :as gu]
+            [editor.ini :as ini]
+            [editor.resource :as resource]
+            [editor.resource-node :as resource-node]
             [editor.settings :as settings]
             [editor.settings-core :as settings-core]
-            [editor.fs :as fs]
-            [editor.graph-util :as gu]
-            [editor.game-project-core :as gpcore]
             [editor.workspace :as workspace]
-            [editor.resource :as resource]
-            [editor.resource-node :as resource-node])
+            [util.murmur :as murmur])
   (:import [org.apache.commons.io IOUtils]))
 
 (set! *warn-on-reflection* true)
@@ -231,7 +232,7 @@
                     (g/connect settings-node :meta-info self :meta-info)
                     (g/connect settings-node :resource-settings self :resource-settings)
                     (g/connect settings-node :setting-errors self :build-errors)
-                    (settings/load-settings-node settings-node resource source-value gpcore/basic-meta-info resource-setting-connections))
+                    (settings/load-settings-node project self settings-node resource source-value gpcore/basic-meta-info resource-setting-connections))
       (g/connect project :resource-map self :resource-map))))
 
 ;; Test support
@@ -259,4 +260,6 @@
     :meta-settings (:settings gpcore/basic-meta-info)
     :icon game-project-icon
     :icon-class :property
-    :view-types [:cljfx-form-view :text]))
+    :view-types [:cljfx-form-view :text]
+    :language "ini"
+    :view-opts {:text {:grammar ini/grammar}}))

--- a/editor/src/clj/editor/game_project.clj
+++ b/editor/src/clj/editor/game_project.clj
@@ -20,7 +20,7 @@
             [editor.fs :as fs]
             [editor.game-project-core :as gpcore]
             [editor.graph-util :as gu]
-            [editor.ini :as ini]
+            [editor.code.lang.ini :as ini]
             [editor.resource :as resource]
             [editor.resource-node :as resource-node]
             [editor.settings :as settings]

--- a/editor/src/clj/editor/game_properties.clj
+++ b/editor/src/clj/editor/game_properties.clj
@@ -16,7 +16,7 @@
   (:require [dynamo.graph :as g]
             [editor.code.data :as data]
             [editor.code.resource :as r]
-            [editor.ini :as ini]
+            [editor.code.lang.ini :as ini]
             [editor.resource :as resource]
             [editor.settings-core :as settings-core]
             [util.coll :as coll])
@@ -33,7 +33,7 @@
                 (g/->error _node-id :meta-info :fatal resource (.getMessage e) (ex-data e)))))))
 
 (defn- additional-load-fn [project self _resource]
-  (g/connect self :proj-path+meta-info project :proj-path->meta-info))
+  (g/connect self :proj-path+meta-info project :proj-path+meta-info-pairs))
 
 (defn register-resource-types [workspace]
   (r/register-code-resource-type

--- a/editor/src/clj/editor/game_properties.clj
+++ b/editor/src/clj/editor/game_properties.clj
@@ -1,0 +1,48 @@
+;; Copyright 2020-2025 The Defold Foundation
+;; Copyright 2014-2020 King
+;; Copyright 2009-2014 Ragnar Svensson, Christian Murray
+;; Licensed under the Defold License version 1.0 (the "License"); you may not use
+;; this file except in compliance with the License.
+;;
+;; You may obtain a copy of the License, together with FAQs at
+;; https://www.defold.com/license
+;;
+;; Unless required by applicable law or agreed to in writing, software distributed
+;; under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+;; CONDITIONS OF ANY KIND, either express or implied. See the License for the
+;; specific language governing permissions and limitations under the License.
+
+(ns editor.game-properties
+  (:require [dynamo.graph :as g]
+            [editor.code.data :as data]
+            [editor.code.resource :as r]
+            [editor.ini :as ini]
+            [editor.resource :as resource]
+            [editor.settings-core :as settings-core]
+            [util.coll :as coll])
+  (:import [java.io BufferedReader]))
+
+(g/defnode GameProperties
+  (inherits r/CodeEditorResourceNode)
+  (output proj-path+meta-info g/Any :cached
+          (g/fnk [_node-id resource lines]
+            (try
+              (with-open [rdr (BufferedReader. (data/lines-reader lines))]
+                (coll/pair (resource/proj-path resource) (settings-core/load-meta-properties rdr)))
+              (catch Exception e
+                (g/->error _node-id :meta-info :fatal resource (.getMessage e) (ex-data e)))))))
+
+(defn- additional-load-fn [project self _resource]
+  (g/connect self :proj-path+meta-info project :proj-path->meta-info))
+
+(defn register-resource-types [workspace]
+  (r/register-code-resource-type
+    workspace
+    :ext "properties"
+    :node-type GameProperties
+    :additional-load-fn additional-load-fn
+    :label "Properties"
+    :icon "icons/32/Icons_05-Project-info.png"
+    :language "ini"
+    :view-types [:code :default]
+    :view-opts {:code {:grammar ini/grammar}}))

--- a/editor/src/clj/editor/graph_util.clj
+++ b/editor/src/clj/editor/graph_util.clj
@@ -34,7 +34,7 @@
   `(g/fnk [~field] ~field))
 
 (defn array-subst-remove-errors [arr]
-  (vec (remove g/error? arr)))
+  (filterv (complement g/error?) arr))
 
 (defn explicit-outputs
   ([node-id]

--- a/editor/src/clj/editor/ini.clj
+++ b/editor/src/clj/editor/ini.clj
@@ -1,0 +1,37 @@
+;; Copyright 2020-2025 The Defold Foundation
+;; Copyright 2014-2020 King
+;; Copyright 2009-2014 Ragnar Svensson, Christian Murray
+;; Licensed under the Defold License version 1.0 (the "License"); you may not use
+;; this file except in compliance with the License.
+;;
+;; You may obtain a copy of the License, together with FAQs at
+;; https://www.defold.com/license
+;;
+;; Unless required by applicable law or agreed to in writing, software distributed
+;; under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+;; CONDITIONS OF ANY KIND, either express or implied. See the License for the
+;; specific language governing permissions and limitations under the License.
+
+(ns editor.ini)
+
+(def grammar
+  "Defold-style ini grammar"
+  {:name "Ini"
+   :scope-name "source.ini"
+   :auto-insert {:characters {\[ \]}
+                 :close-characters #{\]}
+                 :exclude-scopes #{}
+                 :open-scopes {\[ "punctuation.definition.entity.ini"}
+                 :close-scopes {\] "punctuation.definition.entity.ini"}}
+   :patterns [;; section headers like [foo]
+              {:match #"^(\[)(.*?)(\])"
+               :captures {1 {:name "punctuation.definition.entity.ini"}
+                          2 {:name "entity.name.section.ini"}
+                          3 {:name "punctuation.definition.entity.ini"}}
+               :name "meta.section.ini"}
+              ;; key = value
+              {:match #"^\s*([^=]+?)(\s*=\s*)(.*)$"
+               :captures {1 {:name "entity.name.key.ini"}
+                          2 {:name "punctuation.separator.key-value.ini"}
+                          3 {:name "string.unquoted.ini"}}
+               :name "meta.key-value.ini"}]})

--- a/editor/src/clj/editor/live_update_settings.clj
+++ b/editor/src/clj/editor/live_update_settings.clj
@@ -106,7 +106,7 @@
                     (g/connect settings-node :settings-map self :settings-map)
                     (g/connect settings-node :save-value self :save-value)
                     (g/connect settings-node :form-data self :form-data)
-                    (settings/load-settings-node settings-node resource source-value basic-meta-info nil)))))
+                    (settings/load-settings-node project self settings-node resource source-value basic-meta-info nil)))))
 
 (defn register-resource-types [workspace]
   (resource-node/register-settings-resource-type workspace

--- a/editor/src/clj/editor/resource_types.clj
+++ b/editor/src/clj/editor/resource_types.clj
@@ -36,6 +36,7 @@
             [editor.game-object :as game-object]
             [editor.game-object-non-editable :as game-object-non-editable]
             [editor.game-project :as game-project]
+            [editor.game-properties :as game-properties]
             [editor.gui :as gui]
             [editor.html :as html]
             [editor.image :as image]
@@ -80,6 +81,7 @@
       (game-object/register-resource-types workspace)
       (game-object-non-editable/register-resource-types workspace)
       (game-project/register-resource-types workspace)
+      (game-properties/register-resource-types workspace)
       (gui/register-resource-types workspace)
       (html/register-resource-types workspace)
       (image/register-resource-types workspace)

--- a/editor/src/clj/editor/settings.clj
+++ b/editor/src/clj/editor/settings.clj
@@ -13,8 +13,7 @@
 ;; specific language governing permissions and limitations under the License.
 
 (ns editor.settings
-  (:require [camel-snake-kebab :as camel]
-            [clojure.string :as string]
+  (:require [clojure.string :as string]
             [dynamo.graph :as g]
             [editor.core :as core]
             [editor.defold-project :as project]
@@ -54,12 +53,23 @@
 (defn- set-raw-setting [settings {:keys [path] :as meta-setting} value]
   (settings-core/set-setting settings path (settings-core/render-raw-setting-value meta-setting value)))
 
-(defn set-tx-data [{:keys [node-id resource-setting-nodes meta-settings] :as _user-data} path value]
+(defn- make-resource-setting-node [self resource path resource-setting-connections]
+  (g/make-nodes (g/node-id->graph-id self) [resource-setting-node [ResourceSettingNode :path path :resource-connections (resource-setting-connections path)]]
+    (g/connect resource-setting-node :_node-id self :nodes)
+    (when resource
+      (g/set-property resource-setting-node :value resource))
+    (g/connect resource-setting-node :resource-setting-reference self :resource-setting-references)))
+
+(defn set-tx-data [{:keys [node-id resource-setting-nodes meta-settings resource-setting-connections] :as _user-data} path value]
   (let [meta-setting (settings-core/get-meta-setting meta-settings path)]
-    (if-let [resource-setting-node-id (resource-setting-nodes path)]
+    (case (:type meta-setting)
+      :resource
       (concat
-        (g/set-property resource-setting-node-id :value value)
+        (if-let [resource-setting-node-id (resource-setting-nodes path)]
+          (g/set-property resource-setting-node-id :value value)
+          (make-resource-setting-node node-id value (:path meta-setting) resource-setting-connections))
         (g/update-property node-id :raw-settings set-raw-setting meta-setting (resource/resource->proj-path value)))
+
       (g/update-property node-id :raw-settings set-raw-setting meta-setting value))))
 
 (defn- set-form-op [user-data path value]
@@ -75,8 +85,11 @@
 (defn- clear-form-op [user-data path]
   (g/transact (clear-tx-data user-data path)))
 
-(defn- make-form-ops [node-id resource-setting-nodes meta-settings]
-  {:user-data {:node-id node-id :resource-setting-nodes resource-setting-nodes :meta-settings meta-settings}
+(defn- make-form-ops [node-id resource-setting-nodes meta-settings resource-setting-connections]
+  {:user-data {:node-id node-id
+               :resource-setting-nodes resource-setting-nodes
+               :meta-settings meta-settings
+               :resource-setting-connections resource-setting-connections}
    :set set-form-op
    :clear clear-form-op})
 
@@ -158,21 +171,28 @@
                       error))))
           setting-values)))
 
-(g/defnk produce-form-data [_node-id meta-info raw-settings resource-setting-nodes resource-settings]
+(g/defnk produce-form-data [_node-id meta-info raw-settings resource-setting-nodes resource-settings resource-setting-connections]
   (let [meta-settings (:settings meta-info)
         sanitized-settings (settings-core/sanitize-settings meta-settings (settings-core/settings-with-value raw-settings))
-        non-defaulted-setting-paths (into #{} (map :path (filter :value sanitized-settings)))
+        non-defaulted-setting-paths (into #{}
+                                          (comp
+                                            (filter :value)
+                                            (map :path))
+                                          sanitized-settings)
         non-default-resource-settings (filter (comp non-defaulted-setting-paths :path) resource-settings)
         all-settings (concat sanitized-settings non-default-resource-settings)]
-    (make-form-data (make-form-ops _node-id resource-setting-nodes meta-settings) meta-info all-settings)))
+    (make-form-data (make-form-ops _node-id resource-setting-nodes meta-settings resource-setting-connections) meta-info all-settings)))
 
 (g/defnode SettingsNode
   (inherits core/Scope) ;; not a resource node, but a scope node for ResourceSettingNode's
 
   (property raw-settings g/Any (dynamic visible (g/constantly false)))
-  (property meta-info g/Any (dynamic visible (g/constantly false)))
+  (property raw-meta-info g/Any (dynamic visible (g/constantly false)))
+  (property resource-setting-connections g/Any (dynamic visible (g/constantly false)))
 
   (input resource-setting-references g/Any :array)
+  (input owner-resource resource/Resource)
+  (input meta-infos g/Any)
 
   (output resource-setting-nodes g/Any :cached
           (g/fnk [resource-setting-references]
@@ -187,10 +207,10 @@
                        raw-resource-settings (mapv (fn [setting]
                                                     (update setting :value
                                                             #(when %
-                                                               (settings-core/render-raw-setting-value (meta-settings-map (:path setting))
-                                                                                                (resource/resource->proj-path %)))))
-                                                  resource-settings)
-                       meta-settings (:meta-settings meta-info)]
+                                                               (settings-core/render-raw-setting-value
+                                                                 (meta-settings-map (:path setting))
+                                                                 (resource/resource->proj-path %)))))
+                                                  resource-settings)]
                    (reduce (fn [raw {:keys [path value]}]
                              (if (settings-core/get-setting raw path)
                                (settings-core/set-setting raw path value)
@@ -203,7 +223,14 @@
 
   (output save-value g/Any (gu/passthrough merged-raw-settings))
   (output setting-errors g/Any :cached (g/fnk [form-data]
-                                              (get-settings-errors form-data))))
+                                              (get-settings-errors form-data)))
+  (output meta-info g/Any :cached
+          (g/fnk [raw-meta-info meta-infos owner-resource]
+            (let [{:keys [ext-meta-info game-project-proj-path->additional-meta-info]} meta-infos
+                  project-meta-info (game-project-proj-path->additional-meta-info (resource/proj-path owner-resource))]
+              (cond-> raw-meta-info
+                      project-meta-info (settings-core/merge-meta-infos project-meta-info)
+                      (and ext-meta-info (= "project" (resource/type-ext owner-resource))) (settings-core/merge-meta-infos ext-meta-info))))))
 
 (defn- resolve-resource-settings [settings base-resource value-field]
   (mapv (fn [setting]
@@ -216,16 +243,14 @@
   (let [meta-settings-map (settings-core/make-meta-settings-map meta-settings)]
     (mapv #(assoc % :type (:type (meta-settings-map (:path %)))) settings)))
 
-(defn load-settings-node [self resource raw-settings initial-meta-info resource-setting-connections]
+(defn load-settings-node [project owner-resource-node self resource raw-settings initial-meta-info resource-setting-connections]
   (let [meta-info (-> (settings-core/add-meta-info-for-unknown-settings initial-meta-info raw-settings)
                       (update :settings resolve-resource-settings resource :default))
         meta-settings (:settings meta-info)
         settings (-> (settings-core/sanitize-settings meta-settings raw-settings) ; this provokes parse errors if any
                      (type-annotate-settings meta-settings)
                      (resolve-resource-settings resource :value))
-        resource-setting-paths (set (map :path (filter #(= :resource (:type %)) meta-settings)))
-        graph-id (g/node-id->graph-id self)]
-
+        resource-setting-paths (set (map :path (filter #(= :resource (:type %)) meta-settings)))]
     (concat
       ;; We retain the actual raw string settings and update these when/if the user changes a setting,
       ;; rather than parse to proper typed/sanitized values and rendering these on save - again only to
@@ -233,14 +258,12 @@
       ;; Resource settings are also stored in separate ResourceSettingNodes, and this is the canonical place to look
       ;; for the settings current value. The corresponding setting in raw-settings may be stale and is only used to track
       ;; whether the value is/was set or cleared.
-      (g/set-properties self :raw-settings raw-settings :meta-info meta-info)
-      (for [resource-setting-path resource-setting-paths]
-        (let [resource (settings-core/get-setting-or-default meta-settings settings resource-setting-path)]
-          (g/make-nodes graph-id [resource-setting-node [ResourceSettingNode :path resource-setting-path :resource-connections (resource-setting-connections resource-setting-path)]]
-                        (g/connect resource-setting-node :_node-id self :nodes)
-                        (when resource
-                          (g/set-property resource-setting-node :value resource))
-                        (g/connect resource-setting-node :resource-setting-reference self :resource-setting-references)))))))
+      (g/set-properties self :raw-settings raw-settings :raw-meta-info meta-info :resource-setting-connections resource-setting-connections)
+      (g/connect project :meta-infos self :meta-infos)
+      (g/connect owner-resource-node :resource self :owner-resource)
+      (for [path resource-setting-paths]
+        (let [resource (settings-core/get-setting-or-default meta-settings settings path)]
+          (make-resource-setting-node self resource path resource-setting-connections))))))
 
 (g/defnode SimpleSettingsResourceNode
   (inherits resource-node/ResourceNode)
@@ -262,7 +285,7 @@
         (g/connect settings-node :save-value self :save-value)
         (g/connect settings-node :form-data self :form-data)
         (g/connect settings-node :settings-map self :settings-map)
-        (load-settings-node settings-node resource source-value meta-info nil)))))
+        (load-settings-node project self settings-node resource source-value meta-info nil)))))
 
 (defn register-simple-settings-resource-type [workspace & {:keys [ext label icon meta-info]}]
   (resource-node/register-settings-resource-type workspace

--- a/editor/test/integration/game_properties_test.clj
+++ b/editor/test/integration/game_properties_test.clj
@@ -1,6 +1,23 @@
+;; Copyright 2020-2025 The Defold Foundation
+;; Copyright 2014-2020 King
+;; Copyright 2009-2014 Ragnar Svensson, Christian Murray
+;; Licensed under the Defold License version 1.0 (the "License"); you may not use
+;; this file except in compliance with the License.
+;;
+;; You may obtain a copy of the License, together with FAQs at
+;; https://www.defold.com/license
+;;
+;; Unless required by applicable law or agreed to in writing, software distributed
+;; under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+;; CONDITIONS OF ANY KIND, either express or implied. See the License for the
+;; specific language governing permissions and limitations under the License.
+
 (ns integration.game-properties-test
   (:require [clojure.test :refer :all]
             [integration.test-util :as test-util]))
+
+(set! *warn-on-reflection* true)
+(set! *unchecked-math* :warn-on-boxed)
 
 (deftest game-properties-test
   (test-util/with-loaded-project "test/resources/game_properties_project"

--- a/editor/test/integration/game_properties_test.clj
+++ b/editor/test/integration/game_properties_test.clj
@@ -1,0 +1,11 @@
+(ns integration.game-properties-test
+  (:require [clojure.test :refer :all]
+            [integration.test-util :as test-util]))
+
+(deftest game-properties-test
+  (test-util/with-loaded-project "test/resources/game_properties_project"
+    (let [game-project (test-util/resource-node project "/game.project")]
+      (is (true? (test-util/get-setting game-project ["project" "subtitles"])))
+      (is (true? (test-util/get-setting game-project ["tv" "show_ads"])))
+      (is (= 128 (test-util/get-setting game-project ["spine" "max_count"])))
+      (is (thrown-with-msg? Throwable #"Invalid setting path." (test-util/get-setting game-project ["unrelated" "unexpected"]))))))

--- a/editor/test/resources/game_properties_project/.gitignore
+++ b/editor/test/resources/game_properties_project/.gitignore
@@ -1,0 +1,11 @@
+/.editor_settings
+/.internal
+/build
+.externalToolBuilders
+.DS_Store
+Thumbs.db
+.lock-wscript
+*.pyc
+.project
+.cproject
+builtins

--- a/editor/test/resources/game_properties_project/ext/ext.properties
+++ b/editor/test/resources/game_properties_project/ext/ext.properties
@@ -1,0 +1,5 @@
+[spine]
+group = Components
+
+max_count.type = integer
+max_count.default = 128

--- a/editor/test/resources/game_properties_project/game.project
+++ b/editor/test/resources/game_properties_project/game.project
@@ -1,0 +1,20 @@
+[bootstrap]
+main_collection = /main/main.collectionc
+
+[script]
+shared_state = 1
+
+[display]
+width = 960
+height = 640
+high_dpi = 1
+
+[android]
+input_method = HiddenInputField
+
+[html5]
+scale_mode = stretch
+
+[project]
+title = game_properties_project
+

--- a/editor/test/resources/game_properties_project/game.properties
+++ b/editor/test/resources/game_properties_project/game.properties
@@ -1,0 +1,10 @@
+[tv]
+title = TV
+group = Platforms
+
+show_ads.type = bool
+show_ads.default = 1
+
+[project]
+subtitles.type = bool
+subtitles.default = 1

--- a/editor/test/resources/game_properties_project/unrelated.properties
+++ b/editor/test/resources/game_properties_project/unrelated.properties
@@ -1,0 +1,4 @@
+[unrelated]
+
+unexpected.type = number
+unexpected.default = 1.4

--- a/editor/test/resources/save_data_project/checked.properties
+++ b/editor/test/resources/save_data_project/checked.properties
@@ -1,0 +1,5 @@
+[section]
+group = Main
+
+string_prop.type = string
+resource_prop.type = resource


### PR DESCRIPTION
Now, `/game.project` form will show settings from `/game.properties`, as well as from `ext.properties` files coming from extensions.

Technical notes:
Related PRs:
- https://github.com/defold/extension-spine/pull/228
- https://github.com/AppLovin/AppLovin-MAX-Defold/pull/15
- https://github.com/defold/extension-fontgen/pull/5
- https://github.com/Lerg/extension-cas/pull/3
- https://github.com/defold/extension-ironsource/pull/37
- https://github.com/defold/extension-rive/pull/194
- https://github.com/defold/extension-websocket/pull/59
- https://github.com/defold/extension-webmonetization/pull/6
- https://github.com/defold/extension-safearea/pull/14
- https://github.com/dapetcu21/defold-fmod/pull/36
- https://github.com/defold/extension-iap/pull/75
- https://github.com/defold/extension-gpgs/pull/53
- https://github.com/defold/extension-facebook/pull/66
- https://github.com/defold/extension-admob/pull/56
- https://github.com/defold/extension-adinfo/pull/8
- https://github.com/defold/extension-simpledata/pull/18
- https://github.com/defold/extension-prometheus/pull/7
- https://github.com/Insality/druid/pull/322
- https://github.com/Insality/panthera/pull/19
- https://github.com/selimanac/defold-daabbcc/pull/21
- https://github.com/indiesoftby/defold-yagames/pull/43
- https://github.com/Insality/defold-event/pull/15
- https://github.com/Insality/defold-tweener/pull/10

Fixes #3157
