### PR TITLE
Remove transparent grid pass

### DIFF
--- a/editor/src/clj/editor/grid.clj
+++ b/editor/src/clj/editor/grid.clj
@@ -162,13 +162,6 @@
      :render-fn render-scaled-grids
      :user-render-data {:camera camera
                         :grids grids
-                        :options merged-options}}]
-   pass/transparent ; Grid lines potentially intersecting scene geometry.
-   [{:world-transform geom/Identity4d
-     :tags #{:grid}
-     :render-fn render-scaled-grids
-     :user-render-data {:camera camera
-                        :grids grids
                         :options merged-options}}]})
 
 (defn frustum-plane-projection


### PR DESCRIPTION
### Technical changes
Now that the `infinity-grid` pass is on top of the `transparent` pass, I believe the remaining transparent pass of the grid doesn't make sense. It also seems to create this weird effect on 3D mode
Before
<img width="2904" height="2119" alt="Screenshot From 2025-08-25 10-54-45" src="https://github.com/user-attachments/assets/5bbfea5f-b09b-4b26-982d-a52413b8f04b" />
After
<img width="2904" height="2119" alt="Screenshot From 2025-08-25 10-55-09" src="https://github.com/user-attachments/assets/a5b56ab4-53ed-4f9c-bba5-a88e843ee02d" />
