### PR TITLE
Fix issue when debug bundle can't load

### DIFF
--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -1460,6 +1460,10 @@ namespace dmEngine
                 char* filename = dmStrTok(tmp, ",", &iter);
                 do
                 {
+                    if (!filename || strlen(filename) == 0) {
+                        continue;
+                    }
+                    
                     // We need the size, in order to send it as a proper LuaModule message
                     void* data;
                     uint32_t datasize;


### PR DESCRIPTION
When we changed default for `bootstrap.debug_init_script` if breaks the loading logic in bundle. 