### PR TITLE
Set minimum zoom level

### DIFF
--- a/editor/src/clj/editor/camera.clj
+++ b/editor/src/clj/editor/camera.clj
@@ -349,9 +349,10 @@
 
 (defn- dolly-orthographic [camera delta]
   (let [dolly-fn (fn [fov]
-                   (max 0.01 (+ (or fov 0)
-                                (* (or fov 1)
-                                   delta))))]
+                   (min 1000000.0
+                        (max 0.01 (+ (or fov 0)
+                                     (* (or fov 1)
+                                        delta)))))]
     (-> camera
         (update :fov-x dolly-fn)
         (update :fov-y dolly-fn))))


### PR DESCRIPTION
Set minimum camera zoom level (related issue reported [here](https://discord.com/channels/250018174974689280/817015161737969705/1409148683664101416)).

## Technical details
Since we already have a max fov value, I think it makes sense to also add a min fov value on camera dolly, instead of trying to handle individual exceptions. Excessive panning towards a single direction might also be a problem, but that is a different story. It's relatively easy to reproduce the zoom issue using a mouse that supports free-spin wheel mode (see video below), and we currently don't support panning using the mouse wheel, so I think it's going to be really hard to pan that far anyway. The introduced min fov will make this even harder.

https://github.com/user-attachments/assets/047728e0-b3c6-4e2b-99c2-ae90aa6ef70c