### PR TITLE
Fix template property flattening regression when building

### DIFF
--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -3209,24 +3209,28 @@
     :else
     (dissoc node-desc :overridden-fields)))
 
-(defn- make-rt-layout-desc [layout-name decorated-node-msgs]
+(defn- make-rt-layout-desc [layout-name decorated-node-msgs id->node-desc-for-default-layout]
+  {:pre [(map? id->node-desc-for-default-layout)]}
   (protobuf/make-map-without-defaults Gui$SceneDesc$LayoutDesc
     :name layout-name
     :nodes (coll/transfer decorated-node-msgs []
              (keep
                (fn [{:keys [layout->prop->value] :as decorated-node-msg}]
                  {:pre [(map? layout->prop->value)]}
-                 (let [default-prop->value (layout->prop->value "")
-                       prop->value (layout->prop->value layout-name)]
-                   (assert (map? default-prop->value))
+                 (let [prop->value (layout->prop->value layout-name)]
                    (assert (map? prop->value))
-                   (when (not= default-prop->value prop->value)
-                     (some->> (-> decorated-node-msg
-                                  (select-keys [:custom-type :id :parent :template-node-child :type])
-                                  (into (map prop-entry->pb-field-entry)
-                                        prop->value)
-                                  (node-desc->rt-node-desc layout-name))
-                              (protobuf/clear-defaults Gui$NodeDesc)))))))))
+                   (when-some [node-desc-for-layout
+                               (some->> (-> decorated-node-msg
+                                            (select-keys [:custom-type :id :parent :template-node-child :type])
+                                            (into (map prop-entry->pb-field-entry)
+                                                  prop->value)
+                                            (node-desc->rt-node-desc layout-name))
+                                        (protobuf/clear-defaults Gui$NodeDesc))]
+                     (let [id (:id node-desc-for-layout)
+                           node-desc-for-default-layout (id->node-desc-for-default-layout id)]
+                       (assert (map? node-desc-for-default-layout))
+                       (when (not= node-desc-for-default-layout node-desc-for-layout)
+                         node-desc-for-layout)))))))))
 
 (g/defnk produce-build-targets [_node-id build-errors resource pb-msg dep-build-targets template-build-targets layout-names node-msgs]
   ;; Built Gui$NodeDescs should be fully-formed, since no additional merging of
@@ -3244,10 +3248,6 @@
     (g/precluding-errors build-errors
       (let [template-build-targets (flatten template-build-targets)
 
-            rt-layout-descs
-            (mapv #(make-rt-layout-desc % node-msgs)
-                  layout-names)
-
             rt-node-descs
             (coll/transfer node-msgs []
               (keep
@@ -3255,6 +3255,12 @@
                   (-> decorated-node-msg
                       (dissoc :layout->prop->override :layout->prop->value)
                       (node-desc->rt-node-desc "")))))
+
+            id->node-desc-for-default-layout (coll/pair-map-by :id rt-node-descs)
+
+            rt-layout-descs
+            (mapv #(make-rt-layout-desc % node-msgs id->node-desc-for-default-layout)
+                  layout-names)
 
             rt-pb-msg
             (protobuf/assign-repeated pb-msg

--- a/editor/src/clj/internal/node.clj
+++ b/editor/src/clj/internal/node.clj
@@ -1017,7 +1017,7 @@
 
 (defn- update-fn-maps [tree f]
   (-> tree
-      (update :output (partial util/map-vals f))
+      (update :output (partial coll/map-vals f))
       (update :property (fn [properties]
                           (into {}
                                 (map (fn [[property-label propdef]]
@@ -1029,7 +1029,7 @@
                                                                (update :default f)
 
                                                                (some? (-> propdef :dynamics))
-                                                               (update :dynamics (partial util/map-vals f)))]))
+                                                               (update :dynamics (partial coll/map-vals f)))]))
                                 properties)))))
 
 (defn- wrap-constant-fn? [fn]

--- a/editor/src/clj/internal/util.clj
+++ b/editor/src/clj/internal/util.clj
@@ -155,9 +155,9 @@
   [f m]
   (reduce-kv (fn [m k v] (assoc m (f k) v)) (empty m) m))
 
-(defn map-vals
-  [f m]
-  (reduce-kv (fn [m k v] (assoc m k (f v))) m m))
+(defmacro map-vals [f m]
+  ;; TODO: Replace all calls so we can get rid of this macro.
+  `(coll/map-vals ~f ~m))
 
 (defn map-first
   [f pairs]

--- a/editor/src/clj/util/coll.clj
+++ b/editor/src/clj/util/coll.clj
@@ -13,7 +13,7 @@
 ;; specific language governing permissions and limitations under the License.
 
 (ns util.coll
-  (:refer-clojure :exclude [any? bounded-count empty? every? mapcat merge merge-with not-any? not-empty not-every? some])
+  (:refer-clojure :exclude [any? bounded-count empty? every? mapcat merge merge-with not-any? not-empty not-every? some update-vals])
   (:import [clojure.core Eduction]
            [clojure.lang Cons Cycle IEditableCollection LazySeq MapEntry Repeat]
            [java.util ArrayList]))
@@ -225,6 +225,51 @@
 
 (defonce into-vector (fnil into []))
 
+(defn update-vals
+  "Like core.update-vals, but retains the type of the input map or record. Also
+  accepts additional arguments to f. Preserves metadata. If coll is nil, returns
+  nil without calling f."
+  [coll f & args]
+  (when coll
+    (let [use-transient (supports-transient? coll)
+          rf (if use-transient
+               (if (empty? args)
+                 #(assoc! %1 %2 (f %3))
+                 #(assoc! %1 %2 (apply f %3 args)))
+               (if (empty? args)
+                 #(assoc %1 %2 (f %3))
+                 #(assoc %1 %2 (apply f %3 args))))
+          init (if (record? coll)
+                 coll
+                 (cond-> (empty coll)
+                         use-transient transient))]
+      (with-meta (cond-> (reduce-kv rf init coll)
+                         use-transient persistent!)
+                 (meta coll)))))
+
+(defn update-vals-kv
+  "Like core.update-vals, but calls f with both the key and the value of each
+  map entry. Also retains the type of the input map or record and accepts
+  additional arguments to f. Preserves metadata. If coll is nil, returns nil
+  without calling f."
+  [coll f & args]
+  (when coll
+    (let [use-transient (supports-transient? coll)
+          rf (if use-transient
+               (if (empty? args)
+                 #(assoc! %1 %2 (f %2 %3))
+                 #(assoc! %1 %2 (apply f %2 %3 args)))
+               (if (empty? args)
+                 #(assoc %1 %2 (f %2 %3))
+                 #(assoc %1 %2 (apply f %2 %3 args))))
+          init (if (record? coll)
+                 coll
+                 (cond-> (empty coll)
+                         use-transient transient))]
+      (with-meta (cond-> (reduce-kv rf init coll)
+                         use-transient persistent!)
+                 (meta coll)))))
+
 (defn map-vals
   "Applies f to all values in the supplied associative collection. Returns a new
   associative collection of the same type with all the same keys, but the values
@@ -235,22 +280,13 @@
           (pair (key entry)
                 (f (val entry))))))
   ([f coll]
-   (when coll
-     (let [use-transient (supports-transient? coll)
-           rf (if use-transient
-                #(assoc! %1 %2 (f %3))
-                #(assoc %1 %2 (f %3)))
-           init (cond-> (empty coll)
-                        use-transient transient)]
-       (with-meta (cond-> (reduce-kv rf init coll)
-                          use-transient persistent!)
-                  (meta coll))))))
+   (update-vals coll f)))
 
 (defn map-vals-kv
   "Calls f with the key and value of each element in the supplied associative
   collection. Returns a new associative collection of the same type with all the
   same keys, but the values being the results of applying f to each previous key
-  and value.  Preserves metadata. If coll is nil, returns nil without calling f."
+  and value. Preserves metadata. If coll is nil, returns nil without calling f."
   ([f]
    (map (fn [entry]
           (let [k (key entry)
@@ -258,16 +294,7 @@
             (pair k
                   (f k v))))))
   ([f coll]
-   (when coll
-     (let [use-transient (supports-transient? coll)
-           rf (if use-transient
-                #(assoc! %1 %2 (f %2 %3))
-                #(assoc %1 %2 (f %2 %3)))
-           init (cond-> (empty coll)
-                        use-transient transient)]
-       (with-meta (cond-> (reduce-kv rf init coll)
-                          use-transient persistent!)
-                  (meta coll))))))
+   (update-vals-kv coll f)))
 
 (defn pair-map-by
   "Returns a hash-map where the keys are the result of applying the supplied

--- a/editor/test/integration/gui_test.clj
+++ b/editor/test/integration/gui_test.clj
@@ -3030,17 +3030,15 @@
         double-vec))
 
 (defn- round-layout->node->field->value [layout->node->field->value]
-  (->> layout->node->field->value
-       (coll/map-vals
-         (partial
-           coll/map-vals
-           (partial
-             coll/map-vals-kv
-             (fn [field value]
-               (case field
-                 (:alpha) (round-num value)
-                 (:position :rotation :scale) (round-vec value)
-                 value)))))))
+  (coll/update-vals
+    layout->node->field->value
+    coll/update-vals
+    coll/update-vals-kv
+    (fn [field value]
+      (case field
+        (:alpha) (round-num value)
+        (:position :rotation :scale) (round-vec value)
+        value))))
 
 (def ^:private gui-alpha-pb-field-index (gui/prop-key->pb-field-index :alpha))
 (def ^:private gui-enabled-pb-field-index (gui/prop-key->pb-field-index :enabled))

--- a/editor/test/integration/gui_test.clj
+++ b/editor/test/integration/gui_test.clj
@@ -21,6 +21,7 @@
             [editor.gl.pass :as pass]
             [editor.gui :as gui]
             [editor.handler :as handler]
+            [editor.math :as math]
             [editor.properties :as properties]
             [editor.protobuf :as protobuf]
             [editor.workspace :as workspace]
@@ -29,8 +30,7 @@
             [support.test-support :as test-support]
             [util.coll :as coll :refer [pair]]
             [util.fn :as fn])
-  (:import [com.dynamo.gamesys.proto Gui$NodeDesc]
-           [javax.vecmath Matrix4d Vector3d]))
+  (:import [com.dynamo.gamesys.proto Gui$NodeDesc]))
 
 (defn- prop [node-id label]
   (test-util/prop node-id label))
@@ -306,7 +306,7 @@
   (test-util/with-loaded-project
     (let [node-id (test-util/resource-node project "/gui/scene.gui")
           sub-node (gui-node node-id "sub_scene/sub_box")]
-      (let [alpha (prop sub-node :alpha)]
+      (let [^double alpha (prop sub-node :alpha)]
         (g/transact (g/set-property sub-node :alpha (* 0.5 alpha)))
         (is (not= alpha (prop sub-node :alpha)))
         (g/transact (g/clear-property sub-node :alpha))
@@ -534,13 +534,6 @@
 (defn- gui-text [scene id]
   (-> (gui-node scene id)
       (g/node-value :text)))
-
-(defn- trans-x [root-id target-id]
-  (let [s (tree-seq fn/constantly-true :children (g/node-value root-id :scene))]
-    (when-let [^Matrix4d m (some #(and (= (:node-id %) target-id) (:transform %)) s)]
-      (let [t (Vector3d.)]
-        (.get m t)
-        (.getX t)))))
 
 (deftest gui-layout-template
   (test-util/with-loaded-project
@@ -3026,3 +3019,549 @@
                                                                :layer "shadowing_layer_renamed"
                                                                :material "shadowing_material_renamed"}}}
                      (make-layout->node->resource-field-values referencing-scene))))))))))
+
+(defn- round-num
+  ^double [^double num]
+  (math/round-with-precision num 0.001))
+
+(defn- round-vec [double-vec]
+  (into (empty double-vec)
+        (map round-num)
+        double-vec))
+
+(defn- round-layout->node->field->value [layout->node->field->value]
+  (->> layout->node->field->value
+       (coll/map-vals
+         (partial
+           coll/map-vals
+           (partial
+             coll/map-vals-kv
+             (fn [field value]
+               (case field
+                 (:alpha) (round-num value)
+                 (:position :rotation :scale) (round-vec value)
+                 value)))))))
+
+(def ^:private gui-alpha-pb-field-index (gui/prop-key->pb-field-index :alpha))
+(def ^:private gui-enabled-pb-field-index (gui/prop-key->pb-field-index :enabled))
+(def ^:private gui-inherit-alpha-pb-field-index (gui/prop-key->pb-field-index :inherit-alpha))
+(def ^:private gui-layer-pb-field-index (gui/prop-key->pb-field-index :layer))
+(def ^:private gui-position-pb-field-index (gui/prop-key->pb-field-index :position))
+(def ^:private gui-rotation-pb-field-index (gui/prop-key->pb-field-index :rotation))
+(def ^:private gui-scale-pb-field-index (gui/prop-key->pb-field-index :scale))
+
+(deftest template-props-baked-into-imported-node-descs-test
+  (testing "Template children are reparented to the template node's parent."
+    (test-util/with-temp-project-content
+      {"/imported.gui"
+       {:nodes
+        [{:type :type-box
+          :id "box"}
+         {:type :type-box
+          :id "box_child"
+          :parent "box"}]}
+
+       "/importing.gui"
+       {:nodes
+        [{:type :type-box
+          :id "imported_parent"}
+         {:type :type-template
+          :id "imported"
+          :parent "imported_parent"
+          :template "/imported.gui"}
+         {:type :type-box
+          :template-node-child true
+          :id "imported/box"
+          :parent "imported"}
+         {:type :type-box
+          :template-node-child true
+          :id "imported/box_child"
+          :parent "imported/box"}]
+
+        :layouts
+        [{:name "Unaltered"}]}}
+
+      (is (= {"Default" {"imported_parent" {}
+                         "imported/box" {:parent "imported_parent"}
+                         "imported/box_child" {:parent "imported/box"}}
+              "Unaltered" {"imported_parent" {}
+                           "imported/box" {:parent "imported_parent"}
+                           "imported/box_child" {:parent "imported/box"}}}
+             (-> (project/get-resource-node project "/importing.gui")
+                 (make-built-layout->node->field->value))))))
+
+  (testing "Template may disable imported children."
+    (test-util/with-temp-project-content
+      {"/off.gui"
+       {:nodes
+        [{:type :type-box
+          :id "box"
+          :enabled false}]}
+
+       "/on.gui"
+       {:nodes
+        [{:type :type-box
+          :id "box"}]}
+
+       "/importing.gui"
+       {:nodes
+        [{:type :type-template
+          :id "disabled_off"
+          :template "/off.gui"
+          :enabled false}
+         {:type :type-box
+          :template-node-child true
+          :id "disabled_off/box"
+          :parent "disabled_off"}
+         {:type :type-template
+          :id "enabled_off"
+          :template "/off.gui"}
+         {:type :type-box
+          :template-node-child true
+          :id "enabled_off/box"
+          :parent "enabled_off"}
+         {:type :type-template
+          :id "disabled_on"
+          :template "/on.gui"
+          :enabled false}
+         {:type :type-box
+          :template-node-child true
+          :id "disabled_on/box"
+          :parent "disabled_on"}
+         {:type :type-template
+          :id "enabled_on"
+          :template "/on.gui"}
+         {:type :type-box
+          :template-node-child true
+          :id "enabled_on/box"
+          :parent "enabled_on"}]
+
+        :layouts
+        [{:name "Unaltered"}
+         {:name "Altered Parent"
+          :nodes
+          [{:type :type-template
+            :id "disabled_off"
+            :template "/off.gui"
+            :overridden-fields [gui-enabled-pb-field-index]}
+           {:type :type-template
+            :id "enabled_off"
+            :template "/off.gui"
+            :enabled false
+            :overridden-fields [gui-enabled-pb-field-index]}
+           {:type :type-template
+            :id "disabled_on"
+            :template "/on.gui"
+            :overridden-fields [gui-enabled-pb-field-index]}
+           {:type :type-template
+            :id "enabled_on"
+            :template "/on.gui"
+            :enabled false
+            :overridden-fields [gui-enabled-pb-field-index]}]}
+         {:name "Altered Child"
+          :nodes
+          [{:type :type-box
+            :template-node-child true
+            :id "disabled_off/box"
+            :parent "disabled_off"
+            :overridden-fields [gui-enabled-pb-field-index]}
+           {:type :type-box
+            :template-node-child true
+            :id "enabled_off/box"
+            :parent "enabled_off"
+            :overridden-fields [gui-enabled-pb-field-index]}
+           {:type :type-box
+            :template-node-child true
+            :id "disabled_on/box"
+            :parent "disabled_on"
+            :enabled false
+            :overridden-fields [gui-enabled-pb-field-index]}
+           {:type :type-box
+            :template-node-child true
+            :id "enabled_on/box"
+            :parent "enabled_on"
+            :enabled false
+            :overridden-fields [gui-enabled-pb-field-index]}]}]}}
+
+      (is (= {"Default" {"disabled_off/box" {:enabled false}
+                         "enabled_off/box" {:enabled false}
+                         "disabled_on/box" {:enabled false}
+                         "enabled_on/box" {}}
+              "Unaltered" {"disabled_off/box" {:enabled false}
+                           "enabled_off/box" {:enabled false}
+                           "disabled_on/box" {:enabled false}
+                           "enabled_on/box" {}}
+              "Altered Parent" {"disabled_off/box" {:enabled false}
+                                "enabled_off/box" {:enabled false}
+                                "disabled_on/box" {}
+                                "enabled_on/box" {:enabled false}}
+              "Altered Child" {"disabled_off/box" {:enabled false}
+                               "enabled_off/box" {}
+                               "disabled_on/box" {:enabled false}
+                               "enabled_on/box" {:enabled false}}}
+             (-> (project/get-resource-node project "/importing.gui")
+                 (make-built-layout->node->field->value))))))
+
+  (testing "Template layer is applied to imported nodes with no layer specified."
+    (test-util/with-temp-project-content
+      {"/unlayered.gui"
+       {:nodes
+        [{:type :type-box
+          :id "box"}]}
+
+       "/layered.gui"
+       {:layers
+        [{:name "imported_layer"}]
+
+        :nodes
+        [{:type :type-box
+          :id "box"
+          :layer "imported_layer"}]}
+
+       "/importing.gui"
+       {:layers
+        [{:name "importing_layer"}
+         {:name "other_importing_layer"}]
+
+        :nodes
+        [{:type :type-template
+          :id "unlayered"
+          :template "/unlayered.gui"
+          :layer "importing_layer"}
+         {:type :type-box
+          :template-node-child true
+          :id "unlayered/box"
+          :parent "unlayered"}
+         {:type :type-template
+          :id "layered"
+          :template "/layered.gui"
+          :layer "importing_layer"}
+         {:type :type-box
+          :template-node-child true
+          :id "layered/box"
+          :parent "layered"}]
+
+        :layouts
+        [{:name "Unaltered"}
+         {:name "Altered Parent"
+          :nodes
+          [{:type :type-template
+            :id "unlayered"
+            :template "/unlayered.gui"
+            :layer "other_importing_layer"
+            :overridden-fields [gui-layer-pb-field-index]}
+           {:type :type-template
+            :id "layered"
+            :template "/layered.gui"
+            :layer "other_importing_layer"
+            :overridden-fields [gui-layer-pb-field-index]}]}
+         {:name "Altered Child"
+          :nodes
+          [{:type :type-box
+            :template-node-child true
+            :id "unlayered/box"
+            :parent "unlayered"
+            :layer "other_importing_layer"
+            :overridden-fields [gui-layer-pb-field-index]}
+           {:type :type-box
+            :template-node-child true
+            :id "layered/box"
+            :parent "layered"
+            :layer "other_importing_layer"
+            :overridden-fields [gui-layer-pb-field-index]}]}]}}
+
+      (is (= {"Default" {"unlayered/box" {:layer "importing_layer"}
+                         "layered/box" {:layer "imported_layer"}}
+              "Unaltered" {"unlayered/box" {:layer "importing_layer"}
+                           "layered/box" {:layer "imported_layer"}}
+              "Altered Parent" {"unlayered/box" {:layer "other_importing_layer"}
+                                "layered/box" {:layer "imported_layer"}}
+              "Altered Child" {"unlayered/box" {:layer "other_importing_layer"}
+                               "layered/box" {:layer "other_importing_layer"}}}
+             (-> (project/get-resource-node project "/importing.gui")
+                 (make-built-layout->node->field->value))))))
+
+  (testing "Template alpha is applied to imported nodes."
+    (test-util/with-temp-project-content
+      {"/forsaking.gui"
+       {:nodes
+        [{:type :type-box
+          :id "box"
+          :alpha 0.5
+          :inherit-alpha false}]}
+
+       "/inheriting.gui"
+       {:nodes
+        [{:type :type-box
+          :id "box"
+          :alpha 0.5
+          :inherit-alpha true}]}
+
+       "/importing.gui"
+       {:nodes
+        [{:type :type-template
+          :id "forsaking"
+          :template "/forsaking.gui"
+          :alpha 0.5}
+         {:type :type-box
+          :template-node-child true
+          :id "forsaking/box"
+          :parent "forsaking"}
+         {:type :type-template
+          :id "inheriting"
+          :template "/inheriting.gui"
+          :alpha 0.5}
+         {:type :type-box
+          :template-node-child true
+          :id "inheriting/box"
+          :parent "inheriting"}]
+
+        :layouts
+        [{:name "Unaltered"}
+         {:name "Altered Parent"
+          :nodes
+          [{:type :type-template
+            :id "forsaking"
+            :template "/forsaking.gui"
+            :alpha 0.75
+            :overridden-fields [gui-alpha-pb-field-index]}
+           {:type :type-template
+            :id "inheriting"
+            :template "/inheriting.gui"
+            :alpha 0.75
+            :overridden-fields [gui-alpha-pb-field-index]}]}
+         {:name "Altered Child"
+          :nodes
+          [{:type :type-box
+            :template-node-child true
+            :id "forsaking/box"
+            :parent "forsaking"
+            :alpha 0.75
+            :overridden-fields [gui-alpha-pb-field-index]}
+           {:type :type-box
+            :template-node-child true
+            :id "inheriting/box"
+            :parent "inheriting"
+            :alpha 0.75
+            :overridden-fields [gui-alpha-pb-field-index]}]}]}}
+
+      (is (= {"Default" {"inheriting/box" {:alpha 0.25}
+                         "forsaking/box" {:alpha 0.5}}
+              "Unaltered" {"inheriting/box" {:alpha 0.25}
+                           "forsaking/box" {:alpha 0.5}}
+              "Altered Parent" {"inheriting/box" {:alpha 0.375}
+                                "forsaking/box" {:alpha 0.5}}
+              "Altered Child" {"inheriting/box" {:alpha 0.375}
+                               "forsaking/box" {:alpha 0.75}}}
+             (-> (project/get-resource-node project "/importing.gui")
+                 (make-built-layout->node->field->value)
+                 (round-layout->node->field->value))))))
+
+  (testing "Overriding inherit-alpha."
+    (test-util/with-temp-project-content
+      {"/forsaking.gui"
+       {:nodes
+        [{:type :type-box
+          :id "box"
+          :inherit-alpha false}]}
+
+       "/inheriting.gui"
+       {:nodes
+        [{:type :type-box
+          :id "box"
+          :inherit-alpha true}]}
+
+       "/importing.gui"
+       {:nodes
+        [{:type :type-template
+          :id "forsaking"
+          :template "/forsaking.gui"
+          :alpha 0.5}
+         {:type :type-box
+          :template-node-child true
+          :id "forsaking/box"
+          :parent "forsaking"}
+         {:type :type-template
+          :id "not_forsaking"
+          :template "/forsaking.gui"
+          :alpha 0.5}
+         {:type :type-box
+          :template-node-child true
+          :id "not_forsaking/box"
+          :parent "not_forsaking"
+          :inherit-alpha true
+          :overridden-fields [gui-inherit-alpha-pb-field-index]}
+         {:type :type-template
+          :id "inheriting"
+          :template "/inheriting.gui"
+          :alpha 0.5}
+         {:type :type-box
+          :template-node-child true
+          :id "inheriting/box"
+          :parent "inheriting"}
+         {:type :type-template
+          :id "not_inheriting"
+          :template "/inheriting.gui"
+          :alpha 0.5}
+         {:type :type-box
+          :template-node-child true
+          :id "not_inheriting/box"
+          :parent "not_inheriting"
+          :inherit-alpha false
+          :overridden-fields [gui-inherit-alpha-pb-field-index]}]
+
+        :layouts
+        [{:name "Unaltered"}
+         {:name "Altered Child"
+          :nodes
+          [{:type :type-box
+            :template-node-child true
+            :id "forsaking/box"
+            :parent "forsaking"
+            :inherit-alpha true
+            :overridden-fields [gui-inherit-alpha-pb-field-index]}
+           {:type :type-box
+            :template-node-child true
+            :id "not_forsaking/box"
+            :parent "not_forsaking"
+            :inherit-alpha false
+            :overridden-fields [gui-inherit-alpha-pb-field-index]}
+           {:type :type-box
+            :template-node-child true
+            :id "inheriting/box"
+            :parent "inheriting"
+            :inherit-alpha false
+            :overridden-fields [gui-inherit-alpha-pb-field-index]}
+           {:type :type-box
+            :template-node-child true
+            :id "not_inheriting/box"
+            :parent "not_inheriting"
+            :inherit-alpha true
+            :overridden-fields [gui-inherit-alpha-pb-field-index]}]}]}}
+
+      (is (= {"Default" {"inheriting/box" {:alpha 0.5}
+                         "not_inheriting/box" {}
+                         "forsaking/box" {}
+                         "not_forsaking/box" {:alpha 0.5}}
+              "Unaltered" {"inheriting/box" {:alpha 0.5}
+                           "not_inheriting/box" {}
+                           "forsaking/box" {}
+                           "not_forsaking/box" {:alpha 0.5}}
+              "Altered Child" {"inheriting/box" {}
+                               "not_inheriting/box" {:alpha 0.5}
+                               "forsaking/box" {:alpha 0.5}
+                               "not_forsaking/box" {}}}
+             (-> (project/get-resource-node project "/importing.gui")
+                 (make-built-layout->node->field->value)
+                 (round-layout->node->field->value))))))
+
+  (testing "Template transform is applied to imported node transforms."
+    (test-util/with-temp-project-content
+      {"/untransformed.gui"
+       {:nodes
+        [{:type :type-box
+          :id "box"}]}
+
+       "/transformed.gui"
+       {:nodes
+        [{:type :type-box
+          :id "box"
+          :position [10.0 0.0 0.0 1.0]
+          :rotation [0.0 0.0 90.0 0.0]
+          :scale [2.0 2.0 1.0 1.0]}]}
+
+       "/importing.gui"
+       {:nodes
+        [{:type :type-template
+          :id "untransformed"
+          :template "/untransformed.gui"
+          :position [10.0 0.0 0.0 1.0]
+          :rotation [0.0 0.0 90.0 0.0]
+          :scale [2.0 2.0 1.0 1.0]}
+         {:type :type-box
+          :template-node-child true
+          :id "untransformed/box"
+          :parent "untransformed"}
+         {:type :type-template
+          :id "transformed"
+          :template "/transformed.gui"
+          :position [10.0 0.0 0.0 1.0]
+          :rotation [0.0 0.0 90.0 0.0]
+          :scale [2.0 2.0 1.0 1.0]}
+         {:type :type-box
+          :template-node-child true
+          :id "transformed/box"
+          :parent "transformed"}]
+
+        :layouts
+        [{:name "Unaltered"}
+         {:name "Altered Parent"
+          :nodes
+          [{:type :type-template
+            :id "untransformed"
+            :template "/untransformed.gui"
+            :position [20.0 0.0 0.0 1.0]
+            :rotation [0.0 0.0 180.0 0.0]
+            :scale [3.0 3.0 1.0 1.0]
+            :overridden-fields [gui-position-pb-field-index
+                                gui-rotation-pb-field-index
+                                gui-scale-pb-field-index]}
+           {:type :type-template
+            :id "transformed"
+            :template "/transformed.gui"
+            :position [20.0 0.0 0.0 1.0]
+            :rotation [0.0 0.0 180.0 0.0]
+            :scale [3.0 3.0 1.0 1.0]
+            :overridden-fields [gui-position-pb-field-index
+                                gui-rotation-pb-field-index
+                                gui-scale-pb-field-index]}]}
+         {:name "Altered Child"
+          :nodes
+          [{:type :type-box
+            :template-node-child true
+            :id "untransformed/box"
+            :parent "untransformed"
+            :position [20.0 0.0 0.0 1.0]
+            :rotation [0.0 0.0 180.0 0.0]
+            :scale [3.0 3.0 1.0 1.0]
+            :overridden-fields [gui-position-pb-field-index
+                                gui-rotation-pb-field-index
+                                gui-scale-pb-field-index]}
+           {:type :type-box
+            :template-node-child true
+            :id "transformed/box"
+            :parent "transformed"
+            :position [20.0 0.0 0.0 1.0]
+            :rotation [0.0 0.0 180.0 0.0]
+            :scale [3.0 3.0 1.0 1.0]
+            :overridden-fields [gui-position-pb-field-index
+                                gui-rotation-pb-field-index
+                                gui-scale-pb-field-index]}]}]}}
+
+      (is (= {"Default" {"transformed/box" {:position [10.0 20.0 0.0 1.0]
+                                            :rotation [0.0 0.0 180.0 0.0]
+                                            :scale [4.0 4.0 1.0 1.0]}
+                         "untransformed/box" {:position [10.0 0.0 0.0 1.0]
+                                              :rotation [0.0 0.0 90.0 0.0]
+                                              :scale [2.0 2.0 1.0 1.0]}}
+              "Unaltered" {"transformed/box" {:position [10.0 20.0 0.0 1.0]
+                                              :rotation [0.0 0.0 180.0 0.0]
+                                              :scale [4.0 4.0 1.0 1.0]}
+                           "untransformed/box" {:position [10.0 0.0 0.0 1.0]
+                                                :rotation [0.0 0.0 90.0 0.0]
+                                                :scale [2.0 2.0 1.0 1.0]}}
+              "Altered Parent" {"transformed/box" {:position [-10.0 0.0 0.0 1.0]
+                                                   :rotation [0.0 0.0 270.0 0.0]
+                                                   :scale [6.0 6.0 1.0 1.0]}
+                                "untransformed/box" {:position [20.0 0.0 0.0 1.0]
+                                                     :rotation [0.0 0.0 180.0 0.0]
+                                                     :scale [3.0 3.0 1.0 1.0]}}
+              "Altered Child" {"transformed/box" {:position [10.0 40.0 0.0 1.0]
+                                                  :rotation [0.0 0.0 270.0 0.0]
+                                                  :scale [6.0 6.0 1.0 1.0]}
+                               "untransformed/box" {:position [10.0 40.0 0.0 1.0]
+                                                    :rotation [0.0 0.0 270.0 0.0]
+                                                    :scale [6.0 6.0 1.0 1.0]}}}
+             (-> (project/get-resource-node project "/importing.gui")
+                 (make-built-layout->node->field->value)
+                 (round-layout->node->field->value)))))))

--- a/editor/test/util/coll_test.clj
+++ b/editor/test/util/coll_test.clj
@@ -1040,6 +1040,59 @@
                                                   ["a1" "b1" "a2"]))]
         (is (identical? original-meta (meta altered-map)))))))
 
+(deftest map-vals-test
+  (testing "Over nil."
+    (is (nil? (coll/map-vals (fn [] :uncalled) nil))))
+
+  (testing "Over collection."
+    (doseq [target-coll [(array-map) (hash-map) (sorted-map)]]
+      (let [original-meta {:meta-key "meta-value"}
+            original-map (with-meta (into target-coll
+                                          {:a 1
+                                           :b 2})
+                                    original-meta)
+            altered-map (coll/map-vals inc original-map)]
+        (is (= {:a 2 :b 3} altered-map))
+        (is (identical? original-meta (meta altered-map))))))
+
+  (testing "As transducer."
+    (is (= {:a 0
+            :b 1}
+           (into {}
+                 (coll/map-vals dec)
+                 {:a 1
+                  :b 2})))))
+
+(deftest map-vals-kv-test
+  (testing "Over nil."
+    (is (nil? (coll/map-vals-kv (fn [] :uncalled) nil))))
+
+  (testing "Over collection."
+    (doseq [target-coll [(array-map) (hash-map) (sorted-map)]]
+      (let [original-meta {:meta-key "meta-value"}
+            original-map (with-meta (into target-coll
+                                          {:a 1
+                                           :b 2})
+                                    original-meta)
+            altered-map (coll/map-vals-kv (fn [k ^long v]
+                                            (case k
+                                              :b (+ 10 v)
+                                              v))
+                                          original-map)]
+        (is (= {:a 1 :b 12} altered-map))
+        (is (identical? original-meta (meta altered-map))))))
+
+  (testing "As transducer."
+    (is (= {:a "1"
+            :b 22}
+           (into {}
+                 (coll/map-vals-kv (fn [k ^long v]
+                                     (case k
+                                       :a (str v)
+                                       :b (+ 20 v))))
+                 {:a 1
+                  :b 2})))))
+
 (deftest mapcat-test
   (testing "Over collection."
     (is (= [[:< :a]


### PR DESCRIPTION
Fixed a regression when building GUI scenes that would cause certain properties (such as transform-related ones) to not be correctly applied to the imported nodes unless they had layout overrides.

Fixes #7213
Fixes #11110

### Technical changes
* Added `update-vals` and `update-vals-kv` to `coll` module. Our `update-vals` retains the input collection type and accepts additional arguments to the transform function.
* Added `map-vals` and `map-vals-kv` to `coll` module.
* Added extensive tests around template gui node flattening during build.