### PR TITLE
Suggest fetching libraries when modifying game.project dependencies

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -2857,7 +2857,8 @@ If you do not specifically require different script states, consider changing th
                   (disk/async-reload! render-install-progress! workspace [] changes-view
                                       (fn [success]
                                         (when success
-                                          (reload-extensions! app-view project :library workspace changes-view build-errors-view prefs web-server)))))))))))))
+                                          (reload-extensions! app-view project :library workspace changes-view build-errors-view prefs web-server)
+                                          (project/update-fetch-libraries-notification! project)))))))))))))
 
 (handler/defhandler :private/add-dependency :global
   (enabled? [] (disk-availability/available?))

--- a/editor/src/clj/editor/workspace.clj
+++ b/editor/src/clj/editor/workspace.clj
@@ -576,8 +576,12 @@ ordinary paths."
   (update-dependency-notifications! workspace lib-states)
   lib-states)
 
-(defn dependencies [workspace]
-  (g/node-value workspace :dependency-uris))
+(defn dependencies
+  ([workspace]
+   (g/with-auto-evaluation-context evaluation-context
+     (dependencies workspace evaluation-context)))
+  ([workspace evaluation-context]
+   (g/node-value workspace :dependency-uris evaluation-context)))
 
 (defn dependencies-reachable? [dependencies]
   (let [hosts (into #{} (map url/strip-path) dependencies)]


### PR DESCRIPTION
We now show a notification when dependencies change:
<img width="450" height="184" alt="Screenshot 2025-08-29 at 10 21 09" src="https://github.com/user-attachments/assets/ad9126bf-1452-4233-99eb-022e16ea88d1" />

Related to #6557