### PR TITLE
Move the sound::update after all game state has been updated

### DIFF
--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -1879,8 +1879,6 @@ bail:
                     }
                 }
 
-                dmSound::Update();
-
                 bool esc_pressed = false;
                 if (engine->m_QuitOnEsc)
                 {
@@ -1923,6 +1921,8 @@ bail:
                 update_context.m_FixedUpdateFrequency = engine->m_FixedUpdateFrequency;
                 update_context.m_AccumFrameTime = engine->m_AccumFrameTime;
                 dmGameObject::Update(engine->m_MainCollection, &update_context);
+
+                dmSound::Update();
 
                 // Don't render while iconified
                 if (!dmGraphics::GetWindowStateParam(engine->m_GraphicsContext, dmPlatform::WINDOW_STATE_ICONIFIED)


### PR DESCRIPTION
The reasoning here is that this gives the sound a chance to get started after a keypress and not wait for the next frame. 
 fixes #11040