### PR TITLE
Fix built Gui layout NodeDescs missing non-property pb-fields

### DIFF
--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -3221,7 +3221,7 @@
                    (assert (map? prop->value))
                    (when-some [node-desc-for-layout
                                (some->> (-> decorated-node-msg
-                                            (select-keys [:custom-type :id :parent :template-node-child :type])
+                                            (dissoc :layout->prop->override :layout->prop->value)
                                             (into (map prop-entry->pb-field-entry)
                                                   prop->value)
                                             (node-desc->rt-node-desc layout-name))

--- a/editor/test/integration/gui_test.clj
+++ b/editor/test/integration/gui_test.clj
@@ -476,7 +476,7 @@
     (let [node-id (test-util/resource-node project "/gui/scene.gui")]
       (is (= ["Landscape"] (map :name (:layouts (g/node-value node-id :save-value))))))))
 
-(defn- add-layout! [project app-view scene name]
+(defn add-layout! [project app-view scene name]
   (let [parent (g/node-value scene :layouts-node)
         user-data {:scene scene :parent parent :display-profile name :handler-fn gui/add-layout-handler}]
     (test-util/handler-run :edit.add-embedded-component [{:name :workbench :env {:selection [parent] :project project :user-data user-data :app-view app-view}}] user-data)))
@@ -485,7 +485,7 @@
   (let [user-data {:scene scene :parent parent :node-type node-type :custom-type custom-type :handler-fn gui/add-gui-node-handler}]
     (test-util/handler-run :edit.add-embedded-component [{:name :workbench :env {:selection [parent] :project project :user-data user-data :app-view app-view}}] user-data)))
 
-(defn- set-visible-layout! [scene layout]
+(defn set-visible-layout! [scene layout]
   (g/transact (g/set-property scene :visible-layout layout)))
 
 (defmacro with-visible-layout! [scene layout & body]


### PR DESCRIPTION
Fixed a regression where built Gui layout `NodeDescs` were missing all non-property Protobuf field values from the default layout `NodeDesc`, and as a result introducing a layout-specific override for the `NodeDesc` with bad values in the build output.

Fixes #11162.