### PR TITLE
Allow setting game.project properties using editor scripts

### DIFF
--- a/editor/src/clj/dynamo/graph.clj
+++ b/editor/src/clj/dynamo/graph.clj
@@ -241,6 +241,13 @@
 ;; ---------------------------------------------------------------------------
 ;; Using transaction values
 ;; ---------------------------------------------------------------------------
+(defn tx-result? [x]
+  (and (map? x)
+       (contains? x :status)
+       (contains? x :basis)
+       (contains? x :graphs-modified)
+       (contains? x :nodes-added)))
+
 (defn tx-nodes-added
  "Returns a list of the node-ids added given a result from a transaction, (tx-result)."
   [tx-result]

--- a/editor/src/clj/editor/cljfx_form_view.clj
+++ b/editor/src/clj/editor/cljfx_form_view.clj
@@ -1636,11 +1636,11 @@
                      {:dispatch fx/dispatch-effect
                       :set (fn [[path value] _]
                              (let [ops (:form-ops (g/node-value view-id :form-data))]
-                               (form/set-value! ops path value)))
+                               (g/transact (form/set-value ops path value))))
                       :clear (fn [path _]
                                (let [ops (:form-ops (g/node-value view-id :form-data))]
                                  (when (form/can-clear? ops)
-                                   (form/clear-value! ops path))))
+                                   (g/transact (form/clear-value ops path)))))
                       :set-ui-state (fn [ui-state _]
                                       (g/set-property! view-id :ui-state ui-state))
                       :cancel-edit (fn [x _]

--- a/editor/src/clj/editor/form.clj
+++ b/editor/src/clj/editor/form.clj
@@ -13,15 +13,25 @@
 ;; specific language governing permissions and limitations under the License.
 
 (ns editor.form
-  (:require [editor.util :as util])
+  (:require [dynamo.graph :as g]
+            [editor.util :as util])
   (:import [java.net URI]))
 
 (set! *warn-on-reflection* true)
 
+(defn- ensure-does-not-transact [ret f]
+  (when (g/tx-result? ret)
+    (throw
+      (IllegalStateException.
+        (str "Invalid implementation of form-ops\nFunction: "
+             (Compiler/demunge (.getName (class f)))
+             "\nIt should return transaction steps instead of performing a transaction. Use, e.g.:\n- `g/set-property` instead of `g/set-property!`\n- `g/clear-property` instead of `g/clear-property!`"))))
+  ret)
+
 (defn set-value
   "Returns transaction steps for setting the value"
   [{:keys [user-data set]} path value]
-  (set user-data path value))
+  (ensure-does-not-transact (set user-data path value) set))
 
 (defn can-clear? [{:keys [clear]}]
   (not (nil? clear)))
@@ -29,7 +39,7 @@
 (defn clear-value
   "Returns transaction steps for clearing the value"
   [{:keys [user-data clear]} path]
-  (clear user-data path))
+  (ensure-does-not-transact (clear user-data path) clear))
 
 (def ^:private type-defaults
   {:table []

--- a/editor/src/clj/editor/form.clj
+++ b/editor/src/clj/editor/form.clj
@@ -18,13 +18,17 @@
 
 (set! *warn-on-reflection* true)
 
-(defn set-value! [{:keys [user-data set]} path value]
+(defn set-value
+  "Returns transaction steps for setting the value"
+  [{:keys [user-data set]} path value]
   (set user-data path value))
 
 (defn can-clear? [{:keys [clear]}]
   (not (nil? clear)))
 
-(defn clear-value! [{:keys [user-data clear]} path]
+(defn clear-value
+  "Returns transaction steps for clearing the value"
+  [{:keys [user-data clear]} path]
   (clear user-data path))
 
 (def ^:private type-defaults

--- a/editor/src/clj/editor/game_project.clj
+++ b/editor/src/clj/editor/game_project.clj
@@ -17,6 +17,7 @@
             [clojure.string :as string]
             [dynamo.graph :as g]
             [editor.build-target :as bt]
+            [editor.form :as form]
             [editor.fs :as fs]
             [editor.game-project-core :as gpcore]
             [editor.graph-util :as gu]
@@ -240,9 +241,7 @@
 (defn set-setting!
   "Exposed for tests"
   [game-project path value]
-  (let [form-data (g/node-value game-project :form-data)]
-    (let [{:keys [user-data set]} (:form-ops form-data)]
-      (set user-data path value))))
+  (g/transact (form/set-value (:form-ops (g/node-value game-project :form-data)) path value)))
 
 (defn get-setting
   ([game-project path]

--- a/editor/src/clj/editor/material.clj
+++ b/editor/src/clj/editor/material.clj
@@ -442,7 +442,7 @@
 
 (defn- set-form-op [{:keys [node-id] :as user-data} [property] value]
   (let [processed-value (set-form-value-fn property value user-data)]
-    (g/set-property! node-id property processed-value)))
+    (g/set-property node-id property processed-value)))
 
 (g/defnk produce-form-data [_node-id name attributes vertex-program fragment-program vertex-constants fragment-constants max-page-count ^:raw samplers tags vertex-space :as args]
   (let [values (select-keys args (mapcat :path (get-in form-data [:sections 0 :fields])))

--- a/editor/src/clj/editor/protobuf_forms.clj
+++ b/editor/src/clj/editor/protobuf_forms.clj
@@ -25,10 +25,10 @@
 (set! *warn-on-reflection* true)
 
 (defn- clear-form-op [{:keys [node-id]} path]
-  (g/update-property! node-id :pb util/dissoc-in path))
+  (g/update-property node-id :pb util/dissoc-in path))
 
 (defn- set-form-op [{:keys [node-id]} path value]
-  (g/update-property! node-id :pb assoc-in path value))
+  (g/update-property node-id :pb assoc-in path value))
 
 (defn- longest-prefix-size [enum-values]
   (case (count enum-values)
@@ -155,7 +155,7 @@
   (let [old-pb (g/node-value node-id :pb)
         old-form-pb (gamepad-pb->form-pb old-pb)
         upd-form-pb (assoc-in old-form-pb path value)]
-    (g/set-property! node-id :pb (form-pb->gamepad-pb upd-form-pb))))
+    (g/set-property node-id :pb (form-pb->gamepad-pb upd-form-pb))))
 
 (defmethod protobuf-form-data Input$GamepadMaps [node-id pb _def]
   (let [gamepad-values (butlast (protobuf/enum-values Input$Gamepad)) ; skip MAX_GAMEPAD_COUNT

--- a/editor/src/clj/editor/protobuf_forms_util.clj
+++ b/editor/src/clj/editor/protobuf_forms_util.clj
@@ -18,7 +18,7 @@
 (set! *warn-on-reflection* true)
 
 (defn set-form-op [{:keys [node-id]} [property] value]
-  (g/set-property! node-id property value))
+  (g/set-property node-id property value))
 
 (defn clear-form-op [{:keys [node-id]} [property]]
-  (g/clear-property! node-id property))
+  (g/clear-property node-id property))

--- a/editor/src/clj/editor/render_pb.clj
+++ b/editor/src/clj/editor/render_pb.clj
@@ -48,8 +48,8 @@
 
   (output dep-build-targets g/Any (gu/passthrough dep-build-targets))
   (output named-render-resource g/Any (g/fnk [_node-id name render-resource]
-                                 {:name name
-                                  :path render-resource})))
+                                        {:name name
+                                         :path render-resource})))
 
 (defn- make-named-render-resource-node
   [graph-id render-node name render-resource-resource]
@@ -83,14 +83,13 @@
 
 (defn- set-form-op [{:keys [node-id] :as user-data} path value]
   (condp = path
-    [:script]          (g/set-property! node-id :script value)
+    [:script] (g/set-property node-id :script value)
     [:named-render-resources] (let [graph-id (g/node-id->graph-id node-id)]
-                                (g/transact
-                                  (concat
-                                    (for [[named-render-resource-id _] (g/sources-of node-id :named-render-resources)]
-                                      (g/delete-node named-render-resource-id))
-                                    (for [{:keys [name path]} value]
-                                      (make-named-render-resource-node graph-id node-id name path)))))))
+                                (concat
+                                  (for [[named-render-resource-id _] (g/sources-of node-id :named-render-resources)]
+                                    (g/delete-node named-render-resource-id))
+                                  (for [{:keys [name path]} value]
+                                    (make-named-render-resource-node graph-id node-id name path))))))
 
 (g/defnk produce-form-data [_node-id script-resource named-render-resources]
   (-> form-sections

--- a/editor/src/clj/editor/settings.clj
+++ b/editor/src/clj/editor/settings.clj
@@ -73,10 +73,13 @@
       (g/update-property node-id :raw-settings set-raw-setting meta-setting value))))
 
 (defn- set-form-op [{:keys [project owner-resource] :as user-data} path value]
-  (g/transact (set-tx-data user-data path value))
-  (when (and (= "/game.project" (resource/proj-path owner-resource))
-             (= path ["project" "dependencies"]))
-    (project/update-fetch-libraries-notification! project)))
+  (concat
+    (set-tx-data user-data path value)
+    (when (and (= "/game.project" (resource/proj-path owner-resource))
+               (= path ["project" "dependencies"]))
+      (g/expand-ec
+        (fn update-fetch-libraries-notification [evaluation-context]
+          (project/update-fetch-libraries-notification project evaluation-context))))))
 
 (defn clear-tx-data [{:keys [node-id resource-setting-nodes meta-settings] :as _user-data} path]
   (concat
@@ -86,7 +89,7 @@
     (g/update-property node-id :raw-settings settings-core/clear-setting path)))
 
 (defn- clear-form-op [user-data path]
-  (g/transact (clear-tx-data user-data path)))
+  (clear-tx-data user-data path))
 
 (defn- make-form-values-map [settings]
   (settings-core/make-settings-map settings))

--- a/editor/test/integration/editor_extensions_test.clj
+++ b/editor/test/integration/editor_extensions_test.clj
@@ -2093,3 +2093,40 @@ emitters: 0
       ;; chain is modified
       (sound-chain :cat (constantly :meow))
       (is (= :meow ((sound-chain :cat) {}))))))
+
+(def ^:private expected-game-project-properties-test-output
+  "Initial state:
+  project.title: unnamed
+  sound.gain: 1
+  display.width: 960
+  display.fullscreen: false
+  input.game_binding: /input/game.input_binding
+  physics.type: 2D
+  project.dependencies:
+Set settings...
+After transaction:
+  project.title: Set from Editor Script!
+  sound.gain: 0.5
+  display.width: 1000
+  display.fullscreen: true
+  input.game_binding: /builtins/input/all.input_binding
+  physics.type: 3D
+  project.dependencies: https://github.com/defold/extension-spine/archive/refs/tags/3.10.0.zip
+Expected errors:
+  set undefined property => Can't set property \"gooboo.gaabaa\" of GameProjectNode
+  not a string type => 1 is not a string
+  not a number type => \"max\" is not a number
+  not an integer type => 0.5 is not an integer
+  not a boolean type => 1 is not a boolean
+  not a valid resource type => resource extension should be input_binding
+  not a valid enum value => \"2D+3D\" is not \"2D\" or \"3D\"
+  not an array => \"https://defold.com/\" is not an array
+  not a valid url => \"latest spine\" is not a valid URL
+")
+
+(deftest game-project-properties-test
+  (test-util/with-scratch-project "test/resources/editor_extensions/game_project_properties_test"
+    (let [out (StringBuilder.)]
+      (reload-editor-scripts! project :display-output! #(doto out (.append %2) (.append \newline)))
+      (run-edit-menu-test-command!)
+      (expect-script-output expected-game-project-properties-test-output out))))

--- a/editor/test/integration/editor_extensions_test.clj
+++ b/editor/test/integration/editor_extensions_test.clj
@@ -2102,7 +2102,7 @@ emitters: 0
   display.fullscreen: false
   input.game_binding: /input/game.input_binding
   physics.type: 2D
-  project.dependencies:
+  project.dependencies: -
 Set settings...
 After transaction:
   project.title: Set from Editor Script!

--- a/editor/test/integration/form_type_preservation_test.clj
+++ b/editor/test/integration/form_type_preservation_test.clj
@@ -37,12 +37,12 @@
 (defn- set-form-op [{:keys [node-id]} path value]
   {:pre [(= 1 (count path))]}
   (let [prop-kw (first path)]
-    (g/set-property! node-id prop-kw value)))
+    (g/set-property node-id prop-kw value)))
 
 (defn- clear-form-op [{:keys [node-id]} path]
   {:pre [(= 1 (count path))]}
   (let [prop-kw (first path)]
-    (g/clear-property! node-id prop-kw)))
+    (g/clear-property node-id prop-kw)))
 
 (g/defnk produce-form-data [_node-id integer number vec4]
   (let [fields

--- a/editor/test/resources/editor_extensions/game_project_properties_test/.gitignore
+++ b/editor/test/resources/editor_extensions/game_project_properties_test/.gitignore
@@ -1,0 +1,11 @@
+/.editor_settings
+/.internal
+/build
+.externalToolBuilders
+.DS_Store
+Thumbs.db
+.lock-wscript
+*.pyc
+.project
+.cproject
+builtins

--- a/editor/test/resources/editor_extensions/game_project_properties_test/game.project
+++ b/editor/test/resources/editor_extensions/game_project_properties_test/game.project
@@ -1,0 +1,17 @@
+[bootstrap]
+main_collection = /main/main.collectionc
+
+[script]
+shared_state = 1
+
+[display]
+width = 960
+height = 640
+high_dpi = 1
+
+[android]
+input_method = HiddenInputField
+
+[html5]
+scale_mode = stretch
+

--- a/editor/test/resources/editor_extensions/game_project_properties_test/test.editor_script
+++ b/editor/test/resources/editor_extensions/game_project_properties_test/test.editor_script
@@ -7,7 +7,11 @@ local function print_properties(gp)
     print("  display.fullscreen: " .. tostring(editor.get(gp, "display.fullscreen")))
     print("  input.game_binding: " .. editor.get(gp, "input.game_binding"))
     print("  physics.type: " .. editor.get(gp, "physics.type"))
-    print("  project.dependencies: " .. table.concat(editor.get(gp, "project.dependencies"), ","))
+    local deps_str = table.concat(editor.get(gp, "project.dependencies"), ",")
+    if #deps_str == 0 then
+        deps_str = "-"
+    end
+    print("  project.dependencies: " .. deps_str)
 end
 
 local function expect_error(message, ...) 

--- a/editor/test/resources/editor_extensions/game_project_properties_test/test.editor_script
+++ b/editor/test/resources/editor_extensions/game_project_properties_test/test.editor_script
@@ -1,0 +1,68 @@
+local M = {}
+
+local function print_properties(gp)
+    print("  project.title: " .. editor.get(gp, "project.title"))
+    print("  sound.gain: " .. editor.get(gp, "sound.gain"))
+    print("  display.width: " .. editor.get(gp, "display.width"))
+    print("  display.fullscreen: " .. tostring(editor.get(gp, "display.fullscreen")))
+    print("  input.game_binding: " .. editor.get(gp, "input.game_binding"))
+    print("  physics.type: " .. editor.get(gp, "physics.type"))
+    print("  project.dependencies: " .. table.concat(editor.get(gp, "project.dependencies"), ","))
+end
+
+local function expect_error(message, ...) 
+    local success, ret_or_error_message = pcall(...)
+    local error_message
+    if success then
+        error_message = "??? unexpected success ???"
+    else
+        error_message = ret_or_error_message
+    end
+    print(("  %s => %s"):format(message, error_message))
+end
+
+function M.get_commands()
+    return {editor.command({
+        label = "Test",
+        locations = {"Edit"},
+        id = "defold.test",
+        run = function()
+            local gp = "/game.project"
+            print("Initial state:")
+            print_properties(gp)
+            print("Set settings...")
+            editor.transact({
+                -- string
+                editor.tx.set(gp, "project.title", "Set from Editor Script!"),
+                -- number
+                editor.tx.set(gp, "sound.gain", 0.5),
+                -- integer
+                editor.tx.set(gp, "display.width", 1000),
+                -- boolean
+                editor.tx.set(gp, "display.fullscreen", true),
+                -- resource
+                editor.tx.set(gp, "input.game_binding", "/builtins/input/all.input_binding"),
+                -- enum
+                editor.tx.set(gp, "physics.type", "3D"),
+                -- deps
+                editor.tx.set(gp, "project.dependencies", {
+                    "https://github.com/defold/extension-spine/archive/refs/tags/3.10.0.zip"
+                })
+            })
+            print("After transaction:")
+            print_properties(gp)
+            print("Expected errors:")
+            expect_error("set undefined property", editor.tx.set, gp, "gooboo.gaabaa", 1)
+            expect_error("not a string type", editor.tx.set, gp, "project.title", 1)
+            expect_error("not a number type", editor.tx.set, gp, "sound.gain", "max")
+            expect_error("not an integer type", editor.tx.set, gp, "display.width", 0.5)
+            expect_error("not a boolean type", editor.tx.set, gp, "display.fullscreen", 1)
+            expect_error("not a valid resource type", editor.tx.set, gp, "input.game_binding", "/game.project")
+            expect_error("not a valid enum value", editor.tx.set, gp, "physics.type", "2D+3D")
+            expect_error("not an array", editor.tx.set, gp, "project.dependencies", "https://defold.com/")
+            expect_error("not a valid url", editor.tx.set, gp, "project.dependencies", {"latest spine"})
+        end
+    })}
+end
+
+return M


### PR DESCRIPTION
Now, it's possible to set properties in the `game.project` file using editor scripts:
```lua
editor.transact({
    editor.tx.set("/game.project", "project.dependencies", {
        "https://github.com/defold/extension-spine/archive/refs/tags/3.10.0.zip"
    })
})
```

🚨 **Breaking change** 🚨 for extensions that are based on [extension-simpledata](https://github.com/defold/extension-simpledata): Now, the editor expects the code that is invoked when form values are set/cleared to return transaction steps instead of performing a transaction. See [this PR](https://github.com/defold/extension-simpledata/pull/19/files) for the changes you need to make.

Fixes #11163