### PR TITLE
Fix Console not working when the custom resolution feature is enabled

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -809,8 +809,19 @@
         (when (not @version-line)
           (when-let [engine-version-line (engine/parse-engine-version-line line)]
             (reset! version-line engine-version-line))))
+      ;; After the version line, wait briefly for stream readiness, then call the callback.
       (when (and @updated-target (= @version-line line))
-        (on-service-url-found @updated-target))
+        (future
+          (let [max-wait-ms 2000
+                step-ms 100
+                deadline (+ (System/currentTimeMillis) max-wait-ms)]
+            (loop []
+              (if (or (console/current-stream? (:log-stream @updated-target))
+                      (>= (System/currentTimeMillis) deadline))
+                (on-service-url-found @updated-target)
+                (do
+                  (Thread/sleep step-ms)
+                  (recur)))))))
       (when (console/current-stream? (:log-stream launched-target))
         (console/append-console-line! line)))))
 


### PR DESCRIPTION
Fixes the issue where logs in the Editor's console don't work when Simulated Resolution is used (Windows only).

Fix https://github.com/defold/defold/issues/11141