### PR TITLE
Nix: Add libXext

### DIFF
--- a/scripts/nix/shell.nix
+++ b/scripts/nix/shell.nix
@@ -12,6 +12,7 @@ pkgs.mkShell {
     leiningen
     libGL
     libGLU
+    libxext
     ninja
     openal
     openjdk21
@@ -42,6 +43,7 @@ pkgs.mkShell {
         pkgs.glib
         pkgs.libGL
         pkgs.libGLU
+        pkgs.libxext
         pkgs.openal
         pkgs.xorg.libX11
         pkgs.xorg.libXcursor


### PR DESCRIPTION
In https://github.com/defold/defold/pull/11107, I apparently didn't test building a game from the editor because this revealed another missing dependency: libXext