### PR TITLE
Make id resolution on move/cut'n'paste less eager

### DIFF
--- a/editor/src/clj/editor/id.clj
+++ b/editor/src/clj/editor/id.clj
@@ -55,7 +55,7 @@
 (defn resolve
   "Resolve a wanted id to an id that does not intersect with taken ids
 
-  Returns an id
+  Only performs a rename if there is a conflict. Returns an id
 
   Args:
     wanted-id    wanted id, a string with an optional number suffix that will be
@@ -63,12 +63,16 @@
     taken-ids    a collection of taken ids, either a map with id keys, a set, or
                  another type of id collection that will be coerced to set"
   [wanted-id taken-ids]
-  (gen (trim-digits wanted-id) (ids->lookup taken-ids)))
+  (let [lookup (ids->lookup taken-ids)]
+    (if (contains? lookup wanted-id)
+      (gen (trim-digits wanted-id) lookup)
+      wanted-id)))
 
 (defn resolve-all
   "Resolve all wanted ids to ids that don't intersect with taken ids
 
-  Returns a vector of ids, one for each input wanted ids
+  Only performs renames if there are conflicts. Returns a vector of ids, one for
+  each input wanted ids
 
   Args:
     wanted-ids    a sequential collection of wanted ids, i.e., strings with
@@ -81,7 +85,9 @@
       (reduce
         (fn [e wanted-id]
           (let [lookup (val e)
-                id (gen-impl (trim-digits wanted-id) lookup)]
+                id (if (contains? lookup wanted-id)
+                     (gen-impl (trim-digits wanted-id) lookup)
+                     wanted-id)]
             (coll/pair (conj! (key e) id)
                        (cond
                          (set? lookup) (conj lookup id)

--- a/editor/test/editor/id_test.clj
+++ b/editor/test/editor/id_test.clj
@@ -26,7 +26,7 @@
           (is (= [expected-id] (id/resolve-all [candidate-id] taken-ids))))
 
       "sprite" "sprite" #{""}
-      "sprite1" "sprite2" #{"sprite"}
+      "sprite2" "sprite2" #{"sprite"}
       "sprite1" "sprite" #{"sprite"}
       "sprite2" "sprite" #{"sprite" "sprite1"}
       "sprite2" "sprite1" #{"sprite" "sprite1"}
@@ -54,11 +54,11 @@
     (is (= expected (id/gen basename taken-ids))))
   (doseq [[wanted-id taken-ids expected]
           [["go" ["go"] #_=> "go1"]
-           ["go2" ["go"] #_=> "go1"]
+           ["go2" ["go"] #_=> "go2"]
            ["a1" #{"a" "a1"} #_=> "a2"]]]
     (is (= expected (id/resolve wanted-id taken-ids))))
   (doseq [[wanted-ids taken-ids expected]
           [[["go" "go" "go"] ["go" "go2"] #_=> ["go1" "go3" "go4"]]
            [["go" "go1" "go2"] ["go1"] #_=> ["go" "go2" "go3"]]
-           [["a" "b" "b" "c2"] ["a" "a1" "b1"] #_=> ["a2" "b" "b2" "c"]]]]
+           [["a" "b" "b" "c2"] ["a" "a1" "b1"] #_=> ["a2" "b" "b2" "c2"]]]]
     (is (= expected (id/resolve-all wanted-ids taken-ids)))))


### PR DESCRIPTION
Now, it will only rename an id on conflict.

Fixes #11194
Fixes #11085