### PR TITLE
Remove dev module dependency from editor.reveal

### DIFF
--- a/editor/src/clj/editor/math.clj
+++ b/editor/src/clj/editor/math.clj
@@ -13,10 +13,11 @@
 ;; specific language governing permissions and limitations under the License.
 
 (ns editor.math
-  (:require [util.coll :as coll])
+  (:require [editor.util :as eutil]
+            [util.coll :as coll])
   (:import [java.lang Math]
            [java.math RoundingMode]
-           [javax.vecmath Matrix3d Matrix4d Point3d Quat4d Tuple2d Tuple3d Tuple4d Vector3d Vector4d]))
+           [javax.vecmath Matrix3d Matrix3f Matrix4d Matrix4f Point3d Quat4d Tuple2d Tuple3d Tuple4d Vector3d Vector4d]))
 
 (set! *warn-on-reflection* true)
 
@@ -600,3 +601,69 @@
       :view-proj view-proj
       :world-view world-view
       :world-view-proj world-view-proj})))
+
+(defn- vecmath-matrix-dim
+  ^long [matrix]
+  (condp instance? matrix
+    Matrix3d 3
+    Matrix3f 3
+    Matrix4d 4
+    Matrix4f 4))
+
+(defmulti ^:private vecmath-matrix-row (fn [matrix ^long _row-index] (class matrix)))
+
+(defmethod vecmath-matrix-row Matrix3d [^Matrix3d matrix ^long row-index]
+  (let [row (double-array 3)]
+    (.getRow matrix row-index row)
+    row))
+
+(defmethod vecmath-matrix-row Matrix3f [^Matrix3f matrix ^long row-index]
+  (let [row (float-array 3)]
+    (.getRow matrix row-index row)
+    row))
+
+(defmethod vecmath-matrix-row Matrix4d [^Matrix4d matrix ^long row-index]
+  (let [row (double-array 4)]
+    (.getRow matrix row-index row)
+    row))
+
+(defmethod vecmath-matrix-row Matrix4f [^Matrix4f matrix ^long row-index]
+  (let [row (float-array 4)]
+    (.getRow matrix row-index row)
+    row))
+
+(defn vecmath-matrix-pprint-strings [matrix]
+  (let [dim (vecmath-matrix-dim matrix)
+        fmt-num #(eutil/format* "%.3f" %)
+        num-strs (coll/transfer (range dim) []
+                   (mapcat (fn [^long row-index]
+                             (let [row (vecmath-matrix-row matrix row-index)]
+                               (map fmt-num row)))))
+        first-col-width (transduce (comp (take-nth dim)
+                                         (map count))
+                                   max
+                                   0
+                                   num-strs)
+        rest-col-width (transduce (map count)
+                                  max
+                                  0
+                                  num-strs)
+        first-col-width-fmt (str \% first-col-width \s)
+        rest-col-width-fmt (str \% rest-col-width \s)
+        fmt-col (fn [^long index num-str]
+                  (let [fmt (if (zero? (rem index dim))
+                              first-col-width-fmt
+                              rest-col-width-fmt)]
+                    (eutil/format* fmt num-str)))]
+    (coll/transfer num-strs []
+      (partition-all dim)
+      (map (partial into [] (map-indexed fmt-col))))))
+
+(defn zero-vecmath-matrix-col-str? [^String col-str]
+  (let [last-index (.lastIndexOf col-str "0.000")]
+    (case last-index
+      -1 false
+      0 true
+      (case (.charAt col-str (dec last-index))
+        (\space \-) true
+        false))))

--- a/editor/src/dev/dev.clj
+++ b/editor/src/dev/dev.clj
@@ -1105,72 +1105,6 @@
                        (conj (subvec verts 0 (min 3 (count verts)))
                              '...)))))
 
-(defn- vecmath-matrix-dim
-  ^long [matrix]
-  (condp instance? matrix
-    Matrix3d 3
-    Matrix3f 3
-    Matrix4d 4
-    Matrix4f 4))
-
-(defmulti ^:private vecmath-matrix-row (fn [matrix ^long _row-index] (class matrix)))
-
-(defmethod vecmath-matrix-row Matrix3d [^Matrix3d matrix ^long row-index]
-  (let [row (double-array 3)]
-    (.getRow matrix row-index row)
-    row))
-
-(defmethod vecmath-matrix-row Matrix3f [^Matrix3f matrix ^long row-index]
-  (let [row (float-array 3)]
-    (.getRow matrix row-index row)
-    row))
-
-(defmethod vecmath-matrix-row Matrix4d [^Matrix4d matrix ^long row-index]
-  (let [row (double-array 4)]
-    (.getRow matrix row-index row)
-    row))
-
-(defmethod vecmath-matrix-row Matrix4f [^Matrix4f matrix ^long row-index]
-  (let [row (float-array 4)]
-    (.getRow matrix row-index row)
-    row))
-
-(defn vecmath-matrix-pprint-strings [matrix]
-  (let [dim (vecmath-matrix-dim matrix)
-        fmt-num #(eutil/format* "%.3f" %)
-        num-strs (coll/transfer (range dim) []
-                   (mapcat (fn [^long row-index]
-                             (let [row (vecmath-matrix-row matrix row-index)]
-                               (map fmt-num row)))))
-        first-col-width (transduce (comp (take-nth dim)
-                                         (map count))
-                                   max
-                                   0
-                                   num-strs)
-        rest-col-width (transduce (map count)
-                                  max
-                                  0
-                                  num-strs)
-        first-col-width-fmt (str \% first-col-width \s)
-        rest-col-width-fmt (str \% rest-col-width \s)
-        fmt-col (fn [^long index num-str]
-                  (let [fmt (if (zero? (rem index dim))
-                              first-col-width-fmt
-                              rest-col-width-fmt)]
-                    (eutil/format* fmt num-str)))]
-    (coll/transfer num-strs []
-      (partition-all dim)
-      (map (partial into [] (map-indexed fmt-col))))))
-
-(defn zero-vecmath-matrix-col-str? [^String col-str]
-  (let [last-index (.lastIndexOf col-str "0.000")]
-    (case last-index
-      -1 false
-      0 true
-      (case (.charAt col-str (dec last-index))
-        (\space \-) true
-        false))))
-
 (def pretty-printer
   (let [fmt-doc puget.printer/format-doc
         col-doc puget.color/document
@@ -1247,10 +1181,10 @@
                       (object-data-pprint-handler nil math/vecmath->clj printer tuple))
 
                     (vecmath-matrix-pprint-handler [printer matrix]
-                      (let [row-col-strs (vecmath-matrix-pprint-strings matrix)
+                      (let [row-col-strs (math/vecmath-matrix-pprint-strings matrix)
                             fmt-col (fn [^String num-str]
                                       ;; Colorize zero values differently.
-                                      (let [element (if (zero-vecmath-matrix-col-str? num-str)
+                                      (let [element (if (math/zero-vecmath-matrix-col-str? num-str)
                                                       :number
                                                       :string)]
                                         (col-txt printer element num-str)))

--- a/editor/src/reveal/editor/reveal.clj
+++ b/editor/src/reveal/editor/reveal.clj
@@ -21,9 +21,9 @@
             [clojure.core.async.impl.channels]
             [clojure.main :as m]
             [clojure.string :as str]
-            [dev]
             [dynamo.graph :as g]
             [editor.code.data]
+            [editor.math :as math]
             [editor.resource :as resource]
             [editor.resource-node :as resource-node]
             [editor.workspace :as workspace]
@@ -43,6 +43,9 @@
 
 (set! *warn-on-reflection* true)
 (set! *unchecked-math* :warn-on-boxed)
+
+(defn workspace []
+  0)
 
 (defn- node-value-or-err [ec node-id label]
   (try
@@ -223,7 +226,7 @@
     (r/raw-string "]" {:fill :object})))
 
 (defn- read-file-resource [str-expr]
-  `(workspace/resolve-workspace-resource (dev/workspace) ~str-expr))
+  `(workspace/resolve-workspace-resource (workspace) ~str-expr))
 
 (r/defstream FileResource [resource]
   (r/horizontal
@@ -232,7 +235,7 @@
     (r/stream (resource/proj-path resource))))
 
 (defn- read-zip-resource [str-expr]
-  `(workspace/find-resource (dev/workspace) ~str-expr))
+  `(workspace/find-resource (workspace) ~str-expr))
 
 (r/defstream ZipResource [resource]
   (r/horizontal
@@ -337,7 +340,7 @@
                                        :value state}]})})})))
 
 (defn- vecmath-matrix-sf [matrix]
-  (let [row-col-strs (dev/vecmath-matrix-pprint-strings matrix)]
+  (let [row-col-strs (math/vecmath-matrix-pprint-strings matrix)]
     (r/horizontal
       (r/raw-string "#v/" {:fill :object})
       (r/raw-string (.getSimpleName (class matrix)) {:fill :object})
@@ -350,7 +353,7 @@
                    r/horizontal
                    (coll/transfer col-strs :eduction
                      (map (fn [col-str]
-                            (let [style (if (dev/zero-vecmath-matrix-col-str? col-str)
+                            (let [style (if (math/zero-vecmath-matrix-col-str? col-str)
                                           {:fill :util}
                                           {:fill :scalar})]
                               (r/raw-string col-str style))))


### PR DESCRIPTION
### Technical changes
* Removed the need for the `editor.reveal` module to require the `dev` module. This allows for faster startup times and avoids issues around getting a Reveal REPL session up and running when there is a compile error in a required module, since `dev` brings in a lot of dependencies.