### PR TITLE
Remove open as code option from binary resources

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -2135,8 +2135,8 @@ If you do not specifically require different script states, consider changing th
 (defn view-types
   [resource]
   (cond->> (:view-types (resource/resource-type resource))
-    (text-util/binary? resource)
-    (e/filter #(not= :code (:id %)))))
+           (text-util/binary? resource)
+           (e/filter #(not= :code (:id %)))))
 
 (defn open-resource
   ([app-view prefs workspace project resource]

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -2661,7 +2661,7 @@ If you do not specifically require different script states, consider changing th
 (defn- gen-tooltip [workspace project app-view resource]
   (when (resource/loaded? resource)
     (let [resource-type (resource/resource-type resource)
-          view-type (or (first (view-types resource))
+          view-type (or (first (:view-types resource-type))
                         (workspace/get-view-type workspace :text))]
       (when-let [make-preview-fn (:make-preview-fn view-type)]
         {:fx/type fx.tooltip/lifecycle

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -86,6 +86,7 @@
             [util.fn :as fn]
             [util.http-server :as http-server]
             [util.profiler :as profiler]
+            [util.text-util :as text-util]
             [util.thread-util :as thread-util])
   (:import [com.defold.editor Editor]
            [com.defold.editor UIUtil]
@@ -2131,6 +2132,12 @@ If you do not specifically require different script states, consider changing th
           (string/trim)
           (not-empty)))
 
+(defn view-types
+  [resource]
+  (cond->> (:view-types (resource/resource-type resource))
+    (text-util/binary? resource)
+    (e/filter #(not= :code (:id %)))))
+
 (defn open-resource
   ([app-view prefs workspace project resource]
    (open-resource app-view prefs workspace project resource {}))
@@ -2141,7 +2148,7 @@ If you do not specifically require different script states, consider changing th
                                             {})))
          text-view-type (workspace/get-view-type workspace :text)
          view-type      (or (:selected-view-type opts)
-                            (first (:view-types resource-type))
+                            (first (view-types resource))
                             text-view-type)
          view-type-id (:id view-type)
          specific-view-type-selected (some? (:selected-view-type opts))]
@@ -2245,7 +2252,6 @@ If you do not specifically require different script states, consider changing th
                              active-view-type-id (:id (:view-type (g/node-value app-view :active-view-info evaluation-context)))]
                          (pair active-resource active-view-type-id))))
 
-                   resource-type (resource/resource-type resource)
                    is-custom-code-editor-configured (some? (custom-code-editor-executable-path-preference prefs))
 
                    make-option
@@ -2271,7 +2277,7 @@ If you do not specifically require different script states, consider changing th
                                                   :use-custom-editor false})]
                                    [(view-type->option view-type)])))
                        (map view-type->option))
-                     (cond->> (:view-types resource-type)
+                     (cond->> (view-types resource)
 
                               active-view-type-id
                               (e/filter #(not= active-view-type-id (:id %)))))))))
@@ -2655,7 +2661,7 @@ If you do not specifically require different script states, consider changing th
 (defn- gen-tooltip [workspace project app-view resource]
   (when (resource/loaded? resource)
     (let [resource-type (resource/resource-type resource)
-          view-type (or (first (:view-types resource-type))
+          view-type (or (first (view-types resource))
                         (workspace/get-view-type workspace :text))]
       (when-let [make-preview-fn (:make-preview-fn view-type)]
         {:fx/type fx.tooltip/lifecycle

--- a/editor/src/clj/editor/resource.clj
+++ b/editor/src/clj/editor/resource.clj
@@ -132,11 +132,6 @@
   (and (openable-resource? value)
        (true? (:editor-openable (resource-type value)))))
 
-(defn has-view-type? [resource view-type]
-  {:pre [(keyword? view-type)]}
-  (boolean (some #(= view-type (:id %))
-                 (:view-types (resource-type resource)))))
-
 (defn- ->unix-seps ^String [^String path]
   (FilenameUtils/separatorsToUnix path))
 


### PR DESCRIPTION
Remove code view option from binary resources.

Fixes #11192

### Technical changes
The resource is not available when we register the `placeholder-resource-type-ext`, so we need to filter out the option later. I think that `:view-types` could be a function that produces the type vector based on a resource input, but I am not sure if we want to change that.