### PR TITLE
Fix remotery web-profiler connection on macOS

### DIFF
--- a/share/extender/build_input.yml
+++ b/share/extender/build_input.yml
@@ -297,7 +297,7 @@ platforms:
         cxxLinkShFlags: ["-O2", "-g", "-stdlib=libc++", "-mmacosx-version-min={{osMinVersion}}", "-isysroot", "{{env.SYSROOT}}", "-Wl,-rpath,@loader_path/.", "-Wl,-U,_objc_loadClassref"]
         libs:           ['clang_rt.osx']
         dynamicLibs:    []
-        symbols:        ["AudioDecoderTremolo", "GraphicsAdapterVulkan"]
+        symbols:        ["AudioDecoderTremolo", "GraphicsAdapterVulkan", "ProfilerRemotery"]
         libStartGroup_replace:  []
         libEndGroup_replace:    []
         osMinVersion:   "{{env.MACOS_VERSION_MIN}}"


### PR DESCRIPTION
Fixes a regression where the Remotery web profiler is unable to connect to the build on macOS

Fix https://github.com/defold/defold/issues/11216