### PR TITLE
New functions: `gui.set_layout()` and `gui.get_layouts()`

### DIFF
--- a/editor/test/resources/save_data_project/checked.display_profiles
+++ b/editor/test/resources/save_data_project/checked.display_profiles
@@ -1,3 +1,5 @@
+auto_layout_selection: false
+
 profiles {
   name: "Landscape"
   qualifiers {

--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -658,6 +658,22 @@ namespace dmGameSystem
         SetNode(scene, n, (const dmGuiDDF::NodeDesc*) node_desc);
     }
 
+    static void SendLayoutChangedMessage(const dmGui::HScene scene, dmhash_t layout_id, dmhash_t previous_layout_id)
+    {
+        char buf[sizeof(dmMessage::Message) + sizeof(dmGuiDDF::LayoutChanged)];
+        dmMessage::Message* message = (dmMessage::Message*)buf;
+        memset(message, 0, sizeof(dmMessage::Message));
+        message->m_Sender = dmMessage::URL();
+        message->m_Receiver = dmMessage::URL();
+        message->m_Id = dmHashString64("layout_changed");
+        message->m_Descriptor = (uintptr_t)dmGuiDDF::LayoutChanged::m_DDFDescriptor;
+        message->m_DataSize = sizeof(dmGuiDDF::LayoutChanged);
+        dmGuiDDF::LayoutChanged* message_data = (dmGuiDDF::LayoutChanged*)message->m_Data;
+        message_data->m_Id = layout_id;
+        message_data->m_PreviousId = previous_layout_id;
+        DispatchMessage(scene, message);
+    }
+
     static void OnWindowResizeCallback(const dmGui::HScene scene, uint32_t width, uint32_t height)
     {
         dmRender::HDisplayProfiles display_profiles = (dmRender::HDisplayProfiles) dmGui::GetDisplayProfiles(scene);
@@ -690,18 +706,7 @@ namespace dmGameSystem
             dmGui::SetLayout(scene, layout_id, SetNodeCallback);
 
             // Notify the scene script. The callback originates from the dmGraphics::SetWindowSize firing the callback.
-            char buf[sizeof(dmMessage::Message) + sizeof(dmGuiDDF::LayoutChanged)];
-            dmMessage::Message* message = (dmMessage::Message*)buf;
-            memset(message, 0, sizeof(dmMessage::Message));
-            message->m_Sender = dmMessage::URL();
-            message->m_Receiver = dmMessage::URL();
-            message->m_Id = dmHashString64("layout_changed");
-            message->m_Descriptor = (uintptr_t)dmGuiDDF::LayoutChanged::m_DDFDescriptor;
-            message->m_DataSize = sizeof(dmGuiDDF::LayoutChanged);
-            dmGuiDDF::LayoutChanged* message_data = (dmGuiDDF::LayoutChanged*)message->m_Data;
-            message_data->m_Id = layout_id;
-            message_data->m_PreviousId = current_layout_id;
-            DispatchMessage(scene, message);
+            SendLayoutChangedMessage(scene, layout_id, current_layout_id);
         }
     }
 
@@ -738,18 +743,7 @@ namespace dmGameSystem
 
         dmGui::SetLayout(scene, layout_id, SetNodeCallback);
 
-        char buf[sizeof(dmMessage::Message) + sizeof(dmGuiDDF::LayoutChanged)];
-        dmMessage::Message* message = (dmMessage::Message*)buf;
-        memset(message, 0, sizeof(dmMessage::Message));
-        message->m_Sender = dmMessage::URL();
-        message->m_Receiver = dmMessage::URL();
-        message->m_Id = dmHashString64("layout_changed");
-        message->m_Descriptor = (uintptr_t)dmGuiDDF::LayoutChanged::m_DDFDescriptor;
-        message->m_DataSize = sizeof(dmGuiDDF::LayoutChanged);
-        dmGuiDDF::LayoutChanged* message_data = (dmGuiDDF::LayoutChanged*)message->m_Data;
-        message_data->m_Id = layout_id;
-        message_data->m_PreviousId = current_layout_id;
-        DispatchMessage(scene, message);
+        SendLayoutChangedMessage(scene, layout_id, current_layout_id);
     }
 
     static bool GetDisplayProfileDescForGui(const dmGui::HScene scene, dmhash_t layout_id, uint32_t* out_width, uint32_t* out_height)

--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -661,7 +661,7 @@ namespace dmGameSystem
     static void OnWindowResizeCallback(const dmGui::HScene scene, uint32_t width, uint32_t height)
     {
         dmRender::HDisplayProfiles display_profiles = (dmRender::HDisplayProfiles) dmGui::GetDisplayProfiles(scene);
-        if (display_profiles && !dmRender::GetAutoLayoutSelection(display_profiles))
+        if (!dmRender::GetAutoLayoutSelection(display_profiles))
         {
             return;
         }
@@ -730,13 +730,10 @@ namespace dmGameSystem
         }
 
         dmRender::HDisplayProfiles display_profiles = (dmRender::HDisplayProfiles) dmGui::GetDisplayProfiles(scene);
-        if (display_profiles)
+        dmRender::DisplayProfileDesc profile_desc;
+        if (dmRender::GetDisplayProfileDesc(display_profiles, layout_id, profile_desc) == dmRender::RESULT_OK)
         {
-            dmRender::DisplayProfileDesc profile_desc;
-            if (dmRender::GetDisplayProfileDesc(display_profiles, layout_id, profile_desc) == dmRender::RESULT_OK)
-            {
-                dmGui::SetSceneResolution(scene, profile_desc.m_Width, profile_desc.m_Height);
-            }
+            dmGui::SetSceneResolution(scene, profile_desc.m_Width, profile_desc.m_Height);
         }
 
         dmGui::SetLayout(scene, layout_id, SetNodeCallback);
@@ -974,7 +971,7 @@ namespace dmGameSystem
 
             // we might have any resolution starting the scene, so let's set the best alternative layout directly
             dmRender::HDisplayProfiles display_profiles = (dmRender::HDisplayProfiles)dmGui::GetDisplayProfiles(scene);
-            if (display_profiles && !dmRender::GetAutoLayoutSelection(display_profiles))
+            if (!dmRender::GetAutoLayoutSelection(display_profiles))
             {
                 // Skip auto layout selection when disabled
                 return result;

--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -660,6 +660,11 @@ namespace dmGameSystem
 
     static void OnWindowResizeCallback(const dmGui::HScene scene, uint32_t width, uint32_t height)
     {
+        dmRender::HDisplayProfiles display_profiles = (dmRender::HDisplayProfiles) dmGui::GetDisplayProfiles(scene);
+        if (display_profiles && !dmRender::GetAutoLayoutSelection(display_profiles))
+        {
+            return;
+        }
         dmArray<dmhash_t> scene_layouts;
         uint16_t layout_count = dmGui::GetLayoutCount(scene);
         scene_layouts.SetCapacity(layout_count);
@@ -675,7 +680,6 @@ namespace dmGameSystem
             scene_layouts.Push(id);
         }
 
-        dmRender::HDisplayProfiles display_profiles = (dmRender::HDisplayProfiles) dmGui::GetDisplayProfiles(scene);
         dmhash_t current_layout_id = GetLayout(scene);
         dmhash_t layout_id = dmRender::GetOptimalDisplayProfile(display_profiles, width, height, dmGui::GetDisplayDpi(scene), &scene_layouts);
         if(layout_id != current_layout_id)
@@ -699,6 +703,56 @@ namespace dmGameSystem
             message_data->m_PreviousId = current_layout_id;
             DispatchMessage(scene, message);
         }
+    }
+
+    static void ApplyLayoutFromScript(const dmGui::HScene scene, dmhash_t layout_id)
+    {
+        dmhash_t current_layout_id = GetLayout(scene);
+        if (current_layout_id == layout_id)
+            return;
+
+        // Verify that the layout exists in the scene
+        bool has_layout = false;
+        uint16_t layout_count = dmGui::GetLayoutCount(scene);
+        for (uint16_t i = 0; i < layout_count; ++i)
+        {
+            dmhash_t id;
+            if (dmGui::GetLayoutId(scene, i, id) == dmGui::RESULT_OK && id == layout_id)
+            {
+                has_layout = true;
+                break;
+            }
+        }
+        if (!has_layout)
+        {
+            dmLogError("Attempting to apply non-existent layout '%s'", dmHashReverseSafe64(layout_id));
+            return;
+        }
+
+        dmRender::HDisplayProfiles display_profiles = (dmRender::HDisplayProfiles) dmGui::GetDisplayProfiles(scene);
+        if (display_profiles)
+        {
+            dmRender::DisplayProfileDesc profile_desc;
+            if (dmRender::GetDisplayProfileDesc(display_profiles, layout_id, profile_desc) == dmRender::RESULT_OK)
+            {
+                dmGui::SetSceneResolution(scene, profile_desc.m_Width, profile_desc.m_Height);
+            }
+        }
+
+        dmGui::SetLayout(scene, layout_id, SetNodeCallback);
+
+        char buf[sizeof(dmMessage::Message) + sizeof(dmGuiDDF::LayoutChanged)];
+        dmMessage::Message* message = (dmMessage::Message*)buf;
+        memset(message, 0, sizeof(dmMessage::Message));
+        message->m_Sender = dmMessage::URL();
+        message->m_Receiver = dmMessage::URL();
+        message->m_Id = dmHashString64("layout_changed");
+        message->m_Descriptor = (uintptr_t)dmGuiDDF::LayoutChanged::m_DDFDescriptor;
+        message->m_DataSize = sizeof(dmGuiDDF::LayoutChanged);
+        dmGuiDDF::LayoutChanged* message_data = (dmGuiDDF::LayoutChanged*)message->m_Data;
+        message_data->m_Id = layout_id;
+        message_data->m_PreviousId = current_layout_id;
+        DispatchMessage(scene, message);
     }
 
     static void* GetSceneResourceByHash(void* ctx, dmGui::HScene scene, dmhash_t name_hash, dmhash_t suffix_with_dot)
@@ -904,6 +958,12 @@ namespace dmGameSystem
             }
 
             // we might have any resolution starting the scene, so let's set the best alternative layout directly
+            dmRender::HDisplayProfiles display_profiles = (dmRender::HDisplayProfiles)dmGui::GetDisplayProfiles(scene);
+            if (display_profiles && !dmRender::GetAutoLayoutSelection(display_profiles))
+            {
+                // Skip auto layout selection when disabled
+                return result;
+            }
             dmArray<dmhash_t> scene_layouts;
             scene_layouts.SetCapacity(layouts_count+1);
             for(uint16_t i = 0; i < layouts_count+1; ++i)
@@ -920,7 +980,6 @@ namespace dmGameSystem
 
             uint32_t display_width, display_height;
             dmGui::GetPhysicalResolution(scene, display_width, display_height);
-            dmRender::HDisplayProfiles display_profiles = (dmRender::HDisplayProfiles)dmGui::GetDisplayProfiles(scene);
             dmhash_t layout_id = dmRender::GetOptimalDisplayProfile(display_profiles, display_width, display_height, 0, &scene_layouts);
             if(layout_id != dmGui::DEFAULT_LAYOUT)
             {
@@ -984,6 +1043,7 @@ namespace dmGameSystem
         scene_params.m_DestroyRenderConstantsCallback = DestroyRenderConstantsCallback;
         scene_params.m_CloneRenderConstantsCallback = CloneRenderConstantsCallback;
         scene_params.m_OnWindowResizeCallback = &OnWindowResizeCallback;
+        scene_params.m_ApplyLayoutCallback    = &ApplyLayoutFromScript;
 
         scene_params.m_NewTextureResourceCallback    = &NewTextureResourceCallback;
         scene_params.m_DeleteTextureResourceCallback = &DeleteTextureResourceCallback;

--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -755,6 +755,21 @@ namespace dmGameSystem
         DispatchMessage(scene, message);
     }
 
+    static bool GetDisplayProfileDescForGui(const dmGui::HScene scene, dmhash_t layout_id, uint32_t* out_width, uint32_t* out_height)
+    {
+        dmRender::HDisplayProfiles display_profiles = (dmRender::HDisplayProfiles) dmGui::GetDisplayProfiles(scene);
+        if (!display_profiles)
+            return false;
+        dmRender::DisplayProfileDesc desc;
+        if (dmRender::GetDisplayProfileDesc(display_profiles, layout_id, desc) == dmRender::RESULT_OK)
+        {
+            *out_width = desc.m_Width;
+            *out_height = desc.m_Height;
+            return true;
+        }
+        return false;
+    }
+
     static void* GetSceneResourceByHash(void* ctx, dmGui::HScene scene, dmhash_t name_hash, dmhash_t suffix_with_dot)
     {
         (void)scene;
@@ -1044,6 +1059,7 @@ namespace dmGameSystem
         scene_params.m_CloneRenderConstantsCallback = CloneRenderConstantsCallback;
         scene_params.m_OnWindowResizeCallback = &OnWindowResizeCallback;
         scene_params.m_ApplyLayoutCallback    = &ApplyLayoutFromScript;
+        scene_params.m_GetDisplayProfileDescCallback = &GetDisplayProfileDescForGui;
 
         scene_params.m_NewTextureResourceCallback    = &NewTextureResourceCallback;
         scene_params.m_DeleteTextureResourceCallback = &DeleteTextureResourceCallback;

--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -396,6 +396,7 @@ namespace dmGui
         scene->m_CloneRenderConstantsCallback = params->m_CloneRenderConstantsCallback;
         scene->m_OnWindowResizeCallback = params->m_OnWindowResizeCallback;
         scene->m_ApplyLayoutCallback    = params->m_ApplyLayoutCallback;
+        scene->m_GetDisplayProfileDescCallback = params->m_GetDisplayProfileDescCallback;
         scene->m_NewTextureResourceCallback = params->m_NewTextureResourceCallback;
         scene->m_DeleteTextureResourceCallback = params->m_DeleteTextureResourceCallback;
         scene->m_SetTextureResourceCallback = params->m_SetTextureResourceCallback;

--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -395,6 +395,7 @@ namespace dmGui
         scene->m_DestroyRenderConstantsCallback = params->m_DestroyRenderConstantsCallback;
         scene->m_CloneRenderConstantsCallback = params->m_CloneRenderConstantsCallback;
         scene->m_OnWindowResizeCallback = params->m_OnWindowResizeCallback;
+        scene->m_ApplyLayoutCallback    = params->m_ApplyLayoutCallback;
         scene->m_NewTextureResourceCallback = params->m_NewTextureResourceCallback;
         scene->m_DeleteTextureResourceCallback = params->m_DeleteTextureResourceCallback;
         scene->m_SetTextureResourceCallback = params->m_SetTextureResourceCallback;

--- a/engine/gui/src/gui.h
+++ b/engine/gui/src/gui.h
@@ -117,6 +117,11 @@ namespace dmGui
     typedef void (*OnWindowResizeCallback)(const HScene scene, uint32_t width, uint32_t height);
 
     /**
+     * Callback for applying a layout from script
+     */
+    typedef void (*ApplyLayoutCallback)(const HScene scene, dmhash_t layout_id);
+
+    /**
      * Callback to create custom node data
      */
     typedef void* (*CreateCustomNodeCallback)(void* context, dmGui::HScene scene, dmGui::HNode node, uint32_t custom_type);
@@ -211,6 +216,7 @@ namespace dmGui
         CloneRenderConstantsCallback   m_CloneRenderConstantsCallback;
         FetchTextureSetAnimCallback    m_FetchTextureSetAnimCallback;
         OnWindowResizeCallback         m_OnWindowResizeCallback;
+        ApplyLayoutCallback            m_ApplyLayoutCallback;
         NewTextureResourceCallback     m_NewTextureResourceCallback;
         DeleteTextureResourceCallback  m_DeleteTextureResourceCallback;
         SetTextureResourceCallback     m_SetTextureResourceCallback;

--- a/engine/gui/src/gui.h
+++ b/engine/gui/src/gui.h
@@ -182,6 +182,12 @@ namespace dmGui
     typedef void (*SetTextureResourceCallback)(HScene scene, const dmhash_t path_hash, uint32_t width, uint32_t height, dmImage::Type type, const void* buffer);
 
     /**
+     * Callback to query display profile resolution for a layout id
+     * Should return true and fill out parameters when found; false otherwise
+     */
+    typedef bool (*GetDisplayProfileDescCallback)(HScene scene, dmhash_t layout_id, uint32_t* out_width, uint32_t* out_height);
+
+    /**
      * Scene creation
      */
     struct NewSceneParams;
@@ -217,6 +223,7 @@ namespace dmGui
         FetchTextureSetAnimCallback    m_FetchTextureSetAnimCallback;
         OnWindowResizeCallback         m_OnWindowResizeCallback;
         ApplyLayoutCallback            m_ApplyLayoutCallback;
+        GetDisplayProfileDescCallback  m_GetDisplayProfileDescCallback;
         NewTextureResourceCallback     m_NewTextureResourceCallback;
         DeleteTextureResourceCallback  m_DeleteTextureResourceCallback;
         SetTextureResourceCallback     m_SetTextureResourceCallback;

--- a/engine/gui/src/gui_private.h
+++ b/engine/gui/src/gui_private.h
@@ -301,6 +301,7 @@ namespace dmGui
         NewTextureResourceCallback            m_NewTextureResourceCallback;
         DeleteTextureResourceCallback         m_DeleteTextureResourceCallback;
         SetTextureResourceCallback            m_SetTextureResourceCallback;
+        GetDisplayProfileDescCallback         m_GetDisplayProfileDescCallback;
     };
 
     InternalNode* GetNode(HScene scene, HNode node);

--- a/engine/gui/src/gui_private.h
+++ b/engine/gui/src/gui_private.h
@@ -291,6 +291,7 @@ namespace dmGui
         void*                                 m_GetResourceCallbackContext;
         FetchTextureSetAnimCallback           m_FetchTextureSetAnimCallback;
         OnWindowResizeCallback                m_OnWindowResizeCallback;
+        ApplyLayoutCallback                   m_ApplyLayoutCallback;
         GetMaterialPropertyCallback           m_GetMaterialPropertyCallback;
         void*                                 m_GetMaterialPropertyCallbackContext;
         SetMaterialPropertyCallback           m_SetMaterialPropertyCallback;

--- a/engine/gui/src/gui_script.cpp
+++ b/engine/gui/src/gui_script.cpp
@@ -27,7 +27,6 @@
 
 #include "gui.h"
 #include "gui_private.h"
-#include <render/display_profiles.h>
 
 extern "C"
 {
@@ -2659,8 +2658,8 @@ namespace dmGui
     /*# returns available layouts with sizes
      *
      * Returns a table mapping each layout id hash to a vector3(width, height, 0). For the default layout,
-     * the current scene resolution is returned. If a layout name is not present in the Display Profiles,
-     * the width/height pair is 0.
+     * the current scene resolution is returned. If a layout name is not present in the Display Profiles (or when
+     * no display profiles are assigned), the width/height pair is 0.
      *
      * @name gui.get_layouts
      * @return [type:table] layout_id_hash -> vmath.vector3(width, height, 0)
@@ -2673,7 +2672,6 @@ namespace dmGui
         lua_newtable(L);
 
         uint16_t layout_count = dmGui::GetLayoutCount(scene);
-        dmRender::HDisplayProfiles display_profiles = (dmRender::HDisplayProfiles) dmGui::GetDisplayProfiles(scene);
         for (uint16_t i = 0; i < layout_count; ++i)
         {
             dmhash_t id;
@@ -2685,14 +2683,9 @@ namespace dmGui
             {
                 dmGui::GetSceneResolution(scene, w, h);
             }
-            else if (display_profiles)
+            else if (scene->m_GetDisplayProfileDescCallback)
             {
-                dmRender::DisplayProfileDesc desc;
-                if (dmRender::GetDisplayProfileDesc(display_profiles, id, desc) == dmRender::RESULT_OK)
-                {
-                    w = desc.m_Width;
-                    h = desc.m_Height;
-                }
+                scene->m_GetDisplayProfileDescCallback(scene, id, &w, &h);
             }
 
             dmScript::PushHash(L, id);

--- a/engine/render/proto/render/render_ddf.proto
+++ b/engine/render/proto/render/render_ddf.proto
@@ -161,4 +161,5 @@ message DisplayProfile
 message DisplayProfiles
 {
     repeated DisplayProfile profiles = 1;
+    optional bool auto_layout_selection = 2 [default = true];
 }

--- a/engine/render/src/render/display_profiles.cpp
+++ b/engine/render/src/render/display_profiles.cpp
@@ -43,6 +43,7 @@ namespace dmRender
     {
         DisplayProfiles* profiles = new DisplayProfiles();
         profiles->m_NameHash = 0x0;
+        profiles->m_AutoLayoutSelection = true;
         return profiles;
     }
 
@@ -84,6 +85,7 @@ namespace dmRender
         }
 
         dmRenderDDF::DisplayProfiles& ddf = *params.m_DisplayProfilesDDF;
+        profiles->m_AutoLayoutSelection = ddf.m_AutoLayoutSelection;
         uint32_t profile_count = 0;
         uint32_t qualifier_count = 0;
         for(uint32_t i = 0; i < ddf.m_Profiles.m_Count; ++i)
@@ -231,6 +233,11 @@ namespace dmRender
     dmhash_t GetDisplayProfilesName(HDisplayProfiles profiles)
     {
         return profiles->m_NameHash;
+    }
+
+    bool GetAutoLayoutSelection(HDisplayProfiles profiles)
+    {
+        return profiles->m_AutoLayoutSelection;
     }
 
 }

--- a/engine/render/src/render/display_profiles.h
+++ b/engine/render/src/render/display_profiles.h
@@ -93,7 +93,13 @@ namespace dmRender
      */
     dmhash_t GetDisplayProfilesName(HDisplayProfiles profiles);
 
+    /**
+     * Get whether automatic layout selection is enabled
+     * @param profiles Display profiles handle
+     * @return true if auto layout selection is enabled
+     */
+    bool GetAutoLayoutSelection(HDisplayProfiles profiles);
+
 }
 
 #endif // DISPLAY_PROFILES_H
-

--- a/engine/render/src/render/display_profiles_private.h
+++ b/engine/render/src/render/display_profiles_private.h
@@ -53,6 +53,7 @@ namespace dmRender
         dmArray<Profile> m_Profiles;
         dmArray<Qualifier> m_Qualifiers;
         dmhash_t m_NameHash;
+        bool     m_AutoLayoutSelection;
     };
 
     /**
@@ -64,4 +65,3 @@ namespace dmRender
 }
 
 #endif // DISPLAY_PROFILES_PRIVATE_H
-


### PR DESCRIPTION
Added new functions `gui.set_layout()` and `gui.get_layouts()`:

```lua
local ok = gui.set_layout("Portrait")
  if not ok then
      print("Portrait layout not found in this scene")
  end
```

```lua
local layouts = gui.get_layouts()
for id, size in pairs(layouts) do
    print(id, size.x, size.y)
end
```

A new checkbox, `Auto Layout Selection`, has been added to Display Profiles. It disables automatic layout detection in the project:  

![](https://raw.githubusercontent.com/defold/doc/8a8bfa1f08eed87e9683b359407b425f11ab2a32/docs/en/manuals/images/gui-layouts/new_profiles.png)


Fix https://github.com/defold/defold/issues/5889