### PR TITLE
Doubled the object limit to 65,534 per collection

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
@@ -494,7 +494,7 @@ max_instances.type = integer
 max_instances.help = max number of instances per collection, 1024 by default
 max_instances.default = 1024
 max_instances.minimum = 1
-max_instances.maximum = 32765
+max_instances.maximum = 65534
 
 max_input_stack_entries.type = integer
 max_input_stack_entries.help = max number of game objects in the input stack, 16 by default

--- a/engine/gameobject/src/gameobject/gameobject.cpp
+++ b/engine/gameobject/src/gameobject/gameobject.cpp
@@ -255,7 +255,7 @@ namespace dmGameObject
     Result SetCollectionDefaultCapacity(HRegister regist, uint32_t capacity)
     {
         assert(regist != 0x0);
-        if(capacity >= INVALID_INSTANCE_INDEX - 1 || capacity == 0)
+        if (capacity >= INVALID_INSTANCE_INDEX || capacity == 0)
             return RESULT_INVALID_OPERATION;
         regist->m_DefaultCollectionCapacity = capacity;
         return RESULT_OK;
@@ -506,7 +506,7 @@ namespace dmGameObject
 
     HCollection NewCollection(const char* name, dmResource::HFactory factory, HRegister regist, uint32_t max_instances, HCollectionDesc collection_desc)
     {
-        if (max_instances > INVALID_INSTANCE_INDEX)
+        if (max_instances >= INVALID_INSTANCE_INDEX)
         {
             dmLogError("max_instances must be less or equal to %d", INVALID_INSTANCE_INDEX - 1);
             return 0;

--- a/engine/gameobject/src/gameobject/gameobject.h
+++ b/engine/gameobject/src/gameobject/gameobject.h
@@ -78,7 +78,7 @@ namespace dmGameObject
     /**
      * Set default capacity of collections in this register. This does not affect existing collections.
      * @param regist Register
-     * @param capacity Default capacity of collections in this register (0-32766).
+     * @param capacity Default capacity of collections in this register (0-65534).
      * @return RESULT_OK on success or RESULT_INVALID_OPERATION if max_count is not within range
      */
     Result SetCollectionDefaultCapacity(HRegister regist, uint32_t capacity);

--- a/engine/gameobject/src/gameobject/gameobject_private.h
+++ b/engine/gameobject/src/gameobject/gameobject_private.h
@@ -85,8 +85,8 @@ namespace dmGameObject
         dmArray<void*> m_PropertyResources;
     };
 
-    // Invalid instance index. Implies that maximum number of instances is 32766 (ie 0x7fff - 1)
-    const uint32_t INVALID_INSTANCE_INDEX = 0x7fff;
+    // Invalid instance index. Implies that maximum number of instances is 65534 (i.e. 0xffff - 1)
+    const uint32_t INVALID_INSTANCE_INDEX = 0xffff;
 
     // NOTE: Actual size of Instance is sizeof(Instance) + sizeof(uintptr_t) * m_UserDataCount
     struct Instance
@@ -146,22 +146,23 @@ namespace dmGameObject
         uint16_t        m_Bone : 1;
         // If this is a generated instance, i.e. if the instance id is uniquely generated
         uint16_t        m_Generated : 1;
+        // Used for deferred deletion
+        uint16_t        m_ToBeDeleted : 1;
+        // Used for deferred add-to-update
+        uint16_t        m_ToBeAdded : 1;
         // Padding
-        uint16_t        m_Pad : 5;
+        uint16_t        m_Pad : 3;
 
         // Index to parent
         uint16_t        m_Parent : 16;
 
         // Index to Collection::m_Instances
-        uint16_t        m_Index : 15;
-        // Used for deferred deletion
-        uint16_t        m_ToBeDeleted : 1;
+        uint16_t        m_Index : 16;
 
         // Index to Collection::m_LevelIndex. Index is relative to current level (m_Depth), eg first object in level L always has level-index 0
         // Level-index is used to reorder Collection::m_LevelIndex entries in O(1). Given an instance we need to find where the
         // instance index is located in Collection::m_LevelIndex
-        uint16_t        m_LevelIndex : 15;
-        uint16_t        m_Pad2 : 1;
+        uint16_t        m_LevelIndex : 16;
 
         // Index to next instance to delete or INVALID_INSTANCE_INDEX
         uint16_t        m_NextToDelete : 16;
@@ -170,12 +171,10 @@ namespace dmGameObject
         uint16_t        m_NextToAdd;
 
         // Next sibling index. Index to Collection::m_Instances
-        uint16_t        m_SiblingIndex : 15;
-        uint16_t        m_ToBeAdded : 1;
+        uint16_t        m_SiblingIndex : 16;
 
         // First child index. Index to Collection::m_Instances
-        uint16_t        m_FirstChildIndex : 15;
-        uint16_t        m_Pad4 : 1;
+        uint16_t        m_FirstChildIndex : 16;
 
         uint32_t        m_ComponentInstanceUserDataCount;
         uintptr_t       m_ComponentInstanceUserData[0];

--- a/engine/gameobject/src/gameobject/test/collection/test_gameobject_limit.cpp
+++ b/engine/gameobject/src/gameobject/test/collection/test_gameobject_limit.cpp
@@ -1,0 +1,113 @@
+// Copyright 2020-2025 The Defold Foundation
+// Copyright 2014-2020 King
+// Copyright 2009-2014 Ragnar Svensson, Christian Murray
+// Licensed under the Defold License version 1.0 (the "License"); you may not use
+// this file except in compliance with the License.
+//
+// You may obtain a copy of the License, together with FAQs at
+// https://www.defold.com/license
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#include <jc_test/jc_test.h>
+
+#include <stdint.h>
+
+#include <dlib/hash.h>
+
+#include "../gameobject.h"
+#include "../gameobject_private.h"
+
+#include <dmsdk/resource/resource.h>
+
+using namespace dmVMath;
+
+class CollectionLimitTest : public jc_test_base_class
+{
+protected:
+    virtual void SetUp()
+    {
+        m_UpdateContext.m_DT = 1.0f / 60.0f;
+
+        dmResource::NewFactoryParams params;
+        params.m_MaxResources = 16;
+        params.m_Flags = RESOURCE_FACTORY_FLAGS_EMPTY;
+        m_Factory = dmResource::NewFactory(&params, "build/src/gameobject/test/collection");
+
+        dmScript::ContextParams script_context_params = {};
+        m_ScriptContext = dmScript::NewContext(script_context_params);
+        dmScript::Initialize(m_ScriptContext);
+        m_Register = dmGameObject::NewRegister();
+        dmGameObject::Initialize(m_Register, m_ScriptContext);
+
+        m_Contexts.SetCapacity(7,16);
+        m_Contexts.Put(dmHashString64("goc"), m_Register);
+        m_Contexts.Put(dmHashString64("collectionc"), m_Register);
+        m_Contexts.Put(dmHashString64("scriptc"), m_ScriptContext);
+        m_Contexts.Put(dmHashString64("luac"), &m_ModuleContext);
+        dmResource::RegisterTypes(m_Factory, &m_Contexts);
+
+        dmGameObject::ComponentTypeCreateCtx component_create_ctx = {};
+        component_create_ctx.m_Script = m_ScriptContext;
+        component_create_ctx.m_Register = m_Register;
+        component_create_ctx.m_Factory = m_Factory;
+        dmGameObject::CreateRegisteredComponentTypes(&component_create_ctx);
+        dmGameObject::SortComponentTypes(m_Register);
+    }
+
+    virtual void TearDown()
+    {
+        if (m_Collection)
+        {
+            dmGameObject::DeleteCollection(m_Collection);
+            dmGameObject::PostUpdate(m_Register);
+        }
+        dmScript::Finalize(m_ScriptContext);
+        dmScript::DeleteContext(m_ScriptContext);
+        dmResource::DeleteFactory(m_Factory);
+        dmGameObject::DeleteRegister(m_Register);
+    }
+
+public:
+    dmScript::HContext m_ScriptContext;
+    dmGameObject::UpdateContext m_UpdateContext;
+    dmGameObject::HRegister m_Register;
+    dmGameObject::HCollection m_Collection = 0;
+    dmResource::HFactory m_Factory;
+    dmGameObject::ModuleContext m_ModuleContext;
+    dmHashTable64<void*> m_Contexts;
+};
+
+TEST_F(CollectionLimitTest, CreateAndHitLimitAndSetGetPosition)
+{
+    // Max usable index is INVALID_INSTANCE_INDEX - 1
+    const uint32_t max_instances = dmGameObject::INVALID_INSTANCE_INDEX - 1;
+
+    m_Collection = dmGameObject::NewCollection("limit_col", m_Factory, m_Register, max_instances, 0x0);
+    ASSERT_NE((void*)0, (void*)m_Collection);
+
+    // Create max_instances objects and set position.x to 1..max_instances
+    dmArray<dmGameObject::HInstance> instances;
+    instances.SetCapacity(max_instances);
+    for (uint32_t i = 0; i < max_instances; ++i)
+    {
+        dmGameObject::HInstance go = dmGameObject::New(m_Collection, "/go1.goc");
+        ASSERT_NE((void*)0, (void*)go);
+        instances.Push(go);
+        dmGameObject::SetPosition(go, Point3((float)(i + 1), 0.0f, 0.0f));
+    }
+
+    // Next creation should fail (buffer full)
+    dmGameObject::HInstance overflow = dmGameObject::New(m_Collection, "/go1.goc");
+    ASSERT_EQ((void*)0, (void*)overflow);
+
+    // Verify we can read back what we wrote
+    for (uint32_t i = 0; i < instances.Size(); ++i)
+    {
+        float expected = (float)(i + 1);
+        ASSERT_NEAR(expected, dmGameObject::GetPosition(instances[i]).getX(), 0.0f);
+    }
+}


### PR DESCRIPTION
You can now use double the number of objects per collection compared to before: 65,534.

Fix https://github.com/defold/defold/issues/9302