### PR TITLE
Added orthographic camera projection modes 

### DIFF
--- a/editor/resources/templates/template.camera
+++ b/editor/resources/templates/template.camera
@@ -5,4 +5,4 @@ far_z: 1000.0
 auto_aspect_ratio: 0
 orthographic_projection: 0
 orthographic_zoom: 1
-orthographic_zoom_mode: ORTHO_ZOOM_MODE_FIXED
+orthographic_mode: ORTHO_MODE_FIXED

--- a/editor/resources/templates/template.camera
+++ b/editor/resources/templates/template.camera
@@ -5,3 +5,4 @@ far_z: 1000.0
 auto_aspect_ratio: 0
 orthographic_projection: 0
 orthographic_zoom: 1
+orthographic_zoom_mode: ORTHO_ZOOM_MODE_FIXED

--- a/editor/src/clj/editor/camera_editor.clj
+++ b/editor/src/clj/editor/camera_editor.clj
@@ -57,7 +57,7 @@
     camera-mesh-lines-v4))
 
 (g/defnk produce-form-data
-  [_node-id aspect-ratio fov near-z far-z auto-aspect-ratio orthographic-projection orthographic-zoom orthographic-zoom-mode]
+  [_node-id aspect-ratio fov near-z far-z auto-aspect-ratio orthographic-projection orthographic-zoom orthographic-mode]
   {:form-ops {:user-data {:node-id _node-id}
               :set protobuf-forms-util/set-form-op
               :clear protobuf-forms-util/clear-form-op}
@@ -81,7 +81,7 @@
                         {:path [:orthographic-projection]
                          :label "Orthographic Projection"
                          :type :boolean}
-                        {:path [:orthographic-zoom-mode]
+                        {:path [:orthographic-mode]
                          :label "Orthographic Zoom Mode"
                          :type :choicebox
                          :options (sort-by first (protobuf-forms/make-enum-options Camera$OrthoZoomMode))}
@@ -95,10 +95,10 @@
             [:auto-aspect-ratio] auto-aspect-ratio
             [:orthographic-projection] orthographic-projection
             [:orthographic-zoom] orthographic-zoom
-            [:orthographic-zoom-mode] orthographic-zoom-mode}})
+            [:orthographic-mode] orthographic-mode}})
 
 (g/defnk produce-save-value
-  [aspect-ratio fov near-z far-z auto-aspect-ratio orthographic-projection orthographic-zoom orthographic-zoom-mode]
+  [aspect-ratio fov near-z far-z auto-aspect-ratio orthographic-projection orthographic-zoom orthographic-mode]
   (protobuf/make-map-without-defaults Camera$CameraDesc
     :aspect-ratio aspect-ratio
     :fov fov
@@ -107,7 +107,7 @@
     :auto-aspect-ratio (protobuf/boolean->int auto-aspect-ratio)
     :orthographic-projection (protobuf/boolean->int orthographic-projection)
     :orthographic-zoom orthographic-zoom
-    :orthographic-zoom-mode orthographic-zoom-mode))
+    :orthographic-mode orthographic-mode))
 
 (defn build-camera
   [resource dep-resources user-data]
@@ -285,7 +285,7 @@
     auto-aspect-ratio (protobuf/int->boolean :auto-aspect-ratio)
     orthographic-projection (protobuf/int->boolean :orthographic-projection)
     orthographic-zoom :orthographic-zoom
-    orthographic-zoom-mode :orthographic-zoom-mode))
+    orthographic-mode :orthographic-mode))
 
 (g/defnode CameraNode
   (inherits resource-node/ResourceNode)
@@ -296,11 +296,11 @@
   (property far-z g/Num) ; Required protobuf field.
   (property auto-aspect-ratio g/Bool (default (protobuf/int->boolean (protobuf/default Camera$CameraDesc :auto-aspect-ratio))))
   (property orthographic-projection g/Bool (default (protobuf/int->boolean (protobuf/default Camera$CameraDesc :orthographic-projection))))
-  (property orthographic-zoom-mode g/Keyword (default (protobuf/default Camera$CameraDesc :orthographic-zoom-mode))
+  (property orthographic-mode g/Keyword (default (protobuf/default Camera$CameraDesc :orthographic-mode))
             (dynamic read-only? (g/fnk [orthographic-projection] (not orthographic-projection)))
             (dynamic edit-type (g/constantly (properties/->pb-choicebox Camera$OrthoZoomMode))))
   (property orthographic-zoom g/Num (default (protobuf/default Camera$CameraDesc :orthographic-zoom))
-            (dynamic read-only? (g/fnk [orthographic-projection orthographic-zoom-mode] (not (and orthographic-projection (= orthographic-zoom-mode :ortho-zoom-mode-fixed))))))
+            (dynamic read-only? (g/fnk [orthographic-projection orthographic-mode] (not (and orthographic-projection (= orthographic-mode :ortho-mode-fixed))))))
 
   (output form-data g/Any produce-form-data)
 

--- a/editor/src/clj/editor/camera_editor.clj
+++ b/editor/src/clj/editor/camera_editor.clj
@@ -63,31 +63,31 @@
               :clear protobuf-forms-util/clear-form-op}
    :navigation false
    :sections [{:title "Camera"
-               :fields (cond-> [{:path [:aspect-ratio]
-                                 :label "Aspect Ratio"
-                                 :type :number}
-                                {:path [:fov]
-                                 :label "FOV"
-                                 :type :number}
-                                {:path [:near-z]
-                                 :label "Near-Z"
-                                 :type :number}
-                                {:path [:far-z]
-                                 :label "Far-Z"
-                                 :type :number}
-                                {:path [:auto-aspect-ratio]
-                                 :label "Auto Aspect Ratio"
-                                 :type :boolean}
-                                {:path [:orthographic-projection]
-                                 :label "Orthographic Projection"
-                                 :type :boolean}]
-                               {:path [:orthographic-zoom-mode]
-                                :label "Orthographic Zoom Mode"
-                                :type :choicebox
-                                :options (sort-by first (protobuf-forms/make-enum-options Camera$OrthoZoomMode))}
-                               {:path [:orthographic-zoom]
-                                :label "Orthographic Zoom"
-                                :type :number})}]
+               :fields [{:path [:aspect-ratio]
+                         :label "Aspect Ratio"
+                         :type :number}
+                        {:path [:fov]
+                         :label "FOV"
+                         :type :number}
+                        {:path [:near-z]
+                         :label "Near-Z"
+                         :type :number}
+                        {:path [:far-z]
+                         :label "Far-Z"
+                         :type :number}
+                        {:path [:auto-aspect-ratio]
+                         :label "Auto Aspect Ratio"
+                         :type :boolean}
+                        {:path [:orthographic-projection]
+                         :label "Orthographic Projection"
+                         :type :boolean}
+                        {:path [:orthographic-zoom-mode]
+                         :label "Orthographic Zoom Mode"
+                         :type :choicebox
+                         :options (sort-by first (protobuf-forms/make-enum-options Camera$OrthoZoomMode))}
+                        {:path [:orthographic-zoom]
+                         :label "Orthographic Zoom"
+                         :type :number}]}]
    :values {[:aspect-ratio] aspect-ratio
             [:fov] fov
             [:near-z] near-z

--- a/editor/test/resources/save_data_project/checked.camera
+++ b/editor/test/resources/save_data_project/checked.camera
@@ -5,3 +5,4 @@ far_z: 1100.0
 auto_aspect_ratio: 1
 orthographic_projection: 1
 orthographic_zoom: 0.9
+orthographic_zoom_mode: ORTHO_ZOOM_MODE_AUTO_COVER

--- a/editor/test/resources/save_data_project/checked.camera
+++ b/editor/test/resources/save_data_project/checked.camera
@@ -5,4 +5,4 @@ far_z: 1100.0
 auto_aspect_ratio: 1
 orthographic_projection: 1
 orthographic_zoom: 0.9
-orthographic_zoom_mode: ORTHO_ZOOM_MODE_AUTO_COVER
+orthographic_mode: ORTHO_MODE_AUTO_COVER

--- a/engine/gamesys/proto/gamesys/camera_ddf.proto
+++ b/engine/gamesys/proto/gamesys/camera_ddf.proto
@@ -17,6 +17,16 @@ option java_outer_classname = "Camera";
  * @language Lua
  */
 
+// NOTE: Enum values must correspond to the enum values in dmRender::OrthoZoomMode
+// Don't forget to change engine/render/src/render/render.h if you change here
+// Orthographic camera zoom modes
+enum OrthoZoomMode
+{
+    ORTHO_ZOOM_MODE_FIXED        = 0[(displayName) = "Fixed"]; // Use orthographic_zoom as-is
+    ORTHO_ZOOM_MODE_AUTO_FIT     = 1[(displayName) = "Auto Fit"]; // Fit original display area (fit)
+    ORTHO_ZOOM_MODE_AUTO_COVER   = 2[(displayName) = "Auto Cover"]; // Fill original display area (cover)
+}
+
 message CameraDesc
 {
     required float  aspect_ratio            = 1;
@@ -26,6 +36,7 @@ message CameraDesc
     optional uint32 auto_aspect_ratio       = 5 [default = 0];
     optional uint32 orthographic_projection = 6 [default = 0];
     optional float  orthographic_zoom       = 7 [default = 1.0];
+    optional OrthoZoomMode orthographic_zoom_mode  = 8 [default = ORTHO_ZOOM_MODE_FIXED];
 }
 
 /*# sets camera properties
@@ -41,6 +52,7 @@ message CameraDesc
  * @param far_z [type:number] position of the far clipping plane (distance from camera along relative z)
  * @param orthographic_projection [type:boolean] set to use an orthographic projection
  * @param orthographic_zoom [type:number] zoom level when the camera is using an orthographic projection
+ * @param orthographic_zoom_mode [type:number] orthographic zoom behavior when orthographic_projection is enabled
  * @examples
  *
  * In the examples, it is assumed that the instance of the script has a camera-component with id "camera".
@@ -57,6 +69,7 @@ message SetCamera
     required float  far_z                   = 4;
     optional uint32 orthographic_projection = 5 [default = 0];
     optional float  orthographic_zoom       = 6 [default = 1.0];
+    optional OrthoZoomMode orthographic_zoom_mode  = 7 [default = ORTHO_ZOOM_MODE_FIXED];
 }
 
 /** DEPRECATED! makes the receiving camera become the active camera

--- a/engine/gamesys/proto/gamesys/camera_ddf.proto
+++ b/engine/gamesys/proto/gamesys/camera_ddf.proto
@@ -22,9 +22,9 @@ option java_outer_classname = "Camera";
 // Orthographic camera zoom modes
 enum OrthoZoomMode
 {
-    ORTHO_ZOOM_MODE_FIXED        = 0[(displayName) = "Fixed"]; // Use orthographic_zoom as-is
-    ORTHO_ZOOM_MODE_AUTO_FIT     = 1[(displayName) = "Auto Fit"]; // Fit original display area (fit)
-    ORTHO_ZOOM_MODE_AUTO_COVER   = 2[(displayName) = "Auto Cover"]; // Fill original display area (cover)
+    ORTHO_MODE_FIXED        = 0[(displayName) = "Fixed"]; // Use orthographic_zoom as-is
+    ORTHO_MODE_AUTO_FIT     = 1[(displayName) = "Auto Fit"]; // Fit original display area (fit)
+    ORTHO_MODE_AUTO_COVER   = 2[(displayName) = "Auto Cover"]; // Fill original display area (cover)
 }
 
 message CameraDesc
@@ -36,7 +36,7 @@ message CameraDesc
     optional uint32 auto_aspect_ratio       = 5 [default = 0];
     optional uint32 orthographic_projection = 6 [default = 0];
     optional float  orthographic_zoom       = 7 [default = 1.0];
-    optional OrthoZoomMode orthographic_zoom_mode  = 8 [default = ORTHO_ZOOM_MODE_FIXED];
+    optional OrthoZoomMode orthographic_mode  = 8 [default = ORTHO_MODE_FIXED];
 }
 
 /*# sets camera properties
@@ -52,7 +52,7 @@ message CameraDesc
  * @param far_z [type:number] position of the far clipping plane (distance from camera along relative z)
  * @param orthographic_projection [type:boolean] set to use an orthographic projection
  * @param orthographic_zoom [type:number] zoom level when the camera is using an orthographic projection
- * @param orthographic_zoom_mode [type:number] orthographic zoom behavior when orthographic_projection is enabled
+ * @param orthographic_mode [type:number] orthographic zoom behavior when orthographic_projection is enabled
  * @examples
  *
  * In the examples, it is assumed that the instance of the script has a camera-component with id "camera".
@@ -69,7 +69,7 @@ message SetCamera
     required float  far_z                   = 4;
     optional uint32 orthographic_projection = 5 [default = 0];
     optional float  orthographic_zoom       = 6 [default = 1.0];
-    optional OrthoZoomMode orthographic_zoom_mode  = 7 [default = ORTHO_ZOOM_MODE_FIXED];
+    optional OrthoZoomMode orthographic_mode  = 7 [default = ORTHO_MODE_FIXED];
 }
 
 /** DEPRECATED! makes the receiving camera become the active camera

--- a/engine/gamesys/src/gamesys/components/comp_camera.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_camera.cpp
@@ -163,7 +163,7 @@ namespace dmGameSystem
         camera_data.m_AutoAspectRatio          = cam_resource->m_DDF->m_AutoAspectRatio != 0;
         camera_data.m_OrthographicProjection   = cam_resource->m_DDF->m_OrthographicProjection != 0;
         camera_data.m_OrthographicZoom         = cam_resource->m_DDF->m_OrthographicZoom;
-        camera_data.m_OrthographicZoomMode     = (uint8_t) cam_resource->m_DDF->m_OrthographicZoomMode;
+        camera_data.m_OrthographicMode     = (uint8_t) cam_resource->m_DDF->m_OrthographicMode;
 
         dmMessage::URL camera_url = CameraToURL(&camera);
         SetRenderCameraURL(render_context, camera.m_RenderCamera, &camera_url);
@@ -284,7 +284,7 @@ namespace dmGameSystem
             camera_data.m_FarZ                   = ddf->m_FarZ;
             camera_data.m_OrthographicProjection = ddf->m_OrthographicProjection;
             camera_data.m_OrthographicZoom       = ddf->m_OrthographicZoom;
-            camera_data.m_OrthographicZoomMode   = (uint8_t) ddf->m_OrthographicZoomMode;
+            camera_data.m_OrthographicMode   = (uint8_t) ddf->m_OrthographicMode;
 
             dmRender::SetRenderCameraData(render_context, camera->m_RenderCamera, &camera_data);
         }
@@ -319,7 +319,7 @@ namespace dmGameSystem
         camera_data.m_AutoAspectRatio          = cam_resource->m_DDF->m_AutoAspectRatio != 0;
         camera_data.m_OrthographicProjection   = cam_resource->m_DDF->m_OrthographicProjection != 0;
         camera_data.m_OrthographicZoom         = cam_resource->m_DDF->m_OrthographicZoom;
-        camera_data.m_OrthographicZoomMode     = (uint8_t) cam_resource->m_DDF->m_OrthographicZoomMode;
+        camera_data.m_OrthographicMode     = (uint8_t) cam_resource->m_DDF->m_OrthographicMode;
 
         dmRender::SetRenderCameraData(render_context, camera->m_RenderCamera, &camera_data);
         CompCameraUpdateViewProjection(camera, render_context);

--- a/engine/gamesys/src/gamesys/components/comp_camera.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_camera.cpp
@@ -163,6 +163,7 @@ namespace dmGameSystem
         camera_data.m_AutoAspectRatio          = cam_resource->m_DDF->m_AutoAspectRatio != 0;
         camera_data.m_OrthographicProjection   = cam_resource->m_DDF->m_OrthographicProjection != 0;
         camera_data.m_OrthographicZoom         = cam_resource->m_DDF->m_OrthographicZoom;
+        camera_data.m_OrthographicZoomMode     = (uint8_t) cam_resource->m_DDF->m_OrthographicZoomMode;
 
         dmMessage::URL camera_url = CameraToURL(&camera);
         SetRenderCameraURL(render_context, camera.m_RenderCamera, &camera_url);
@@ -283,6 +284,7 @@ namespace dmGameSystem
             camera_data.m_FarZ                   = ddf->m_FarZ;
             camera_data.m_OrthographicProjection = ddf->m_OrthographicProjection;
             camera_data.m_OrthographicZoom       = ddf->m_OrthographicZoom;
+            camera_data.m_OrthographicZoomMode   = (uint8_t) ddf->m_OrthographicZoomMode;
 
             dmRender::SetRenderCameraData(render_context, camera->m_RenderCamera, &camera_data);
         }
@@ -317,6 +319,7 @@ namespace dmGameSystem
         camera_data.m_AutoAspectRatio          = cam_resource->m_DDF->m_AutoAspectRatio != 0;
         camera_data.m_OrthographicProjection   = cam_resource->m_DDF->m_OrthographicProjection != 0;
         camera_data.m_OrthographicZoom         = cam_resource->m_DDF->m_OrthographicZoom;
+        camera_data.m_OrthographicZoomMode     = (uint8_t) cam_resource->m_DDF->m_OrthographicZoomMode;
 
         dmRender::SetRenderCameraData(render_context, camera->m_RenderCamera, &camera_data);
         CompCameraUpdateViewProjection(camera, render_context);

--- a/engine/render/src/render/camera.cpp
+++ b/engine/render/src/render/camera.cpp
@@ -31,7 +31,7 @@ namespace dmRender
 
         memset(&camera->m_Data, 0, sizeof(camera->m_Data));
         camera->m_Data.m_Viewport = dmVMath::Vector4(0.0f, 0.0f, 1.0f, 1.0f);
-        camera->m_Data.m_OrthographicZoomMode = ORTHO_ZOOM_MODE_FIXED;
+        camera->m_Data.m_OrthographicMode = ORTHO_MODE_FIXED;
 
         return camera->m_Handle;
     }
@@ -139,16 +139,16 @@ namespace dmRender
             }
 
             // Compute auto zoom if requested
-            if (c->m_Data.m_OrthographicZoomMode == ORTHO_ZOOM_MODE_AUTO_FIT || c->m_Data.m_OrthographicZoomMode == ORTHO_ZOOM_MODE_AUTO_COVER)
+            if (c->m_Data.m_OrthographicMode == ORTHO_MODE_AUTO_FIT || c->m_Data.m_OrthographicMode == ORTHO_MODE_AUTO_COVER)
             {
                 float zx = width / (display_scale * proj_width);
                 float zy = height / (display_scale * proj_height);
 
-                if (c->m_Data.m_OrthographicZoomMode == ORTHO_ZOOM_MODE_AUTO_FIT)
+                if (c->m_Data.m_OrthographicMode == ORTHO_MODE_AUTO_FIT)
                 {
                     zoom = (zx < zy) ? zx : zy;
                 }
-                else if (c->m_Data.m_OrthographicZoomMode == ORTHO_ZOOM_MODE_AUTO_COVER)
+                else if (c->m_Data.m_OrthographicMode == ORTHO_MODE_AUTO_COVER)
                 {
                     zoom = (zx > zy) ? zx : zy;
                 }

--- a/engine/render/src/render/camera.cpp
+++ b/engine/render/src/render/camera.cpp
@@ -31,6 +31,7 @@ namespace dmRender
 
         memset(&camera->m_Data, 0, sizeof(camera->m_Data));
         camera->m_Data.m_Viewport = dmVMath::Vector4(0.0f, 0.0f, 1.0f, 1.0f);
+        camera->m_Data.m_OrthographicZoomMode = ORTHO_ZOOM_MODE_FIXED;
 
         return camera->m_Handle;
     }
@@ -119,7 +120,45 @@ namespace dmRender
         if (c->m_Data.m_OrthographicProjection)
         {
             float display_scale = dmGraphics::GetDisplayScaleFactor(graphics_context);
+
+            // Determine zoom
             float zoom = c->m_Data.m_OrthographicZoom;
+
+            // Project (reference) size from game.project
+            float proj_width = (float) dmGraphics::GetWidth(graphics_context);
+            float proj_height = (float) dmGraphics::GetHeight(graphics_context);
+
+            // Fallbacks to avoid division by zero
+            if (proj_width <= 0.0f)
+            {
+            	proj_width = 1.0f;
+            }
+            if (proj_height <= 0.0f)
+            {
+            	proj_height = 1.0f;
+            }
+
+            // Compute auto zoom if requested
+            if (c->m_Data.m_OrthographicZoomMode == ORTHO_ZOOM_MODE_AUTO_FIT || c->m_Data.m_OrthographicZoomMode == ORTHO_ZOOM_MODE_AUTO_COVER)
+            {
+                float zx = width / (display_scale * proj_width);
+                float zy = height / (display_scale * proj_height);
+
+                if (c->m_Data.m_OrthographicZoomMode == ORTHO_ZOOM_MODE_AUTO_FIT)
+                {
+                    zoom = (zx < zy) ? zx : zy;
+                }
+                else if (c->m_Data.m_OrthographicZoomMode == ORTHO_ZOOM_MODE_AUTO_COVER)
+                {
+                    zoom = (zx > zy) ? zx : zy;
+                }
+
+                if (zoom <= 0.0f)
+                {
+                    zoom = 1.0f;
+                }
+            }
+
             float zoomed_width = width / display_scale / zoom;
             float zoomed_height = height / display_scale / zoom;
 

--- a/engine/render/src/render/render.h
+++ b/engine/render/src/render/render.h
@@ -159,9 +159,9 @@ namespace dmRender
     // Don't forget to change dmGamesysDDF::OrthoZoomMode if you change here
     enum OrthoZoomMode
     {
-        ORTHO_ZOOM_MODE_FIXED        = 0,
-        ORTHO_ZOOM_MODE_AUTO_FIT     = 1,
-        ORTHO_ZOOM_MODE_AUTO_COVER   = 2,
+        ORTHO_MODE_FIXED        = 0,
+        ORTHO_MODE_AUTO_FIT     = 1,
+        ORTHO_MODE_AUTO_COVER   = 2,
     };
 
     struct RenderCameraData
@@ -175,7 +175,7 @@ namespace dmRender
         // These bitfields are packed into a single byte
         uint8_t          m_AutoAspectRatio        : 1;
         uint8_t          m_OrthographicProjection : 1;
-        uint8_t          m_OrthographicZoomMode   : 2; // dmRender::OrthoZoomMode
+        uint8_t          m_OrthographicMode   : 2; // dmRender::OrthoZoomMode
     };
 
     struct MaterialProgramAttributeInfo

--- a/engine/render/src/render/render.h
+++ b/engine/render/src/render/render.h
@@ -155,6 +155,15 @@ namespace dmRender
         uint32_t                        m_MaxDebugVertexCount;
     };
 
+    // NOTE: These enum values are duplicated in gamesys camera DDF (camera_ddf.proto)
+    // Don't forget to change dmGamesysDDF::OrthoZoomMode if you change here
+    enum OrthoZoomMode
+    {
+        ORTHO_ZOOM_MODE_FIXED        = 0,
+        ORTHO_ZOOM_MODE_AUTO_FIT     = 1,
+        ORTHO_ZOOM_MODE_AUTO_COVER   = 2,
+    };
+
     struct RenderCameraData
     {
         dmVMath::Vector4 m_Viewport;
@@ -163,8 +172,10 @@ namespace dmRender
         float            m_NearZ;
         float            m_FarZ;
         float            m_OrthographicZoom;
+        // These bitfields are packed into a single byte
         uint8_t          m_AutoAspectRatio        : 1;
         uint8_t          m_OrthographicProjection : 1;
+        uint8_t          m_OrthographicZoomMode   : 2; // dmRender::OrthoZoomMode
     };
 
     struct MaterialProgramAttributeInfo

--- a/engine/render/src/render/render_script_camera.cpp
+++ b/engine/render/src/render/render_script_camera.cpp
@@ -33,7 +33,7 @@ namespace dmRender
     /*# fixed orthographic zoom mode
      * Uses the manually set orthographic zoom value (camera.set_orthographic_zoom).
      *
-     * @name camera.ORTHO_ZOOM_MODE_FIXED
+     * @name camera.ORTHO_MODE_FIXED
      * @constant
      */
 
@@ -41,7 +41,7 @@ namespace dmRender
      * Computes zoom so the original display area (game.project width/height) fits inside the window
      * while preserving aspect ratio. Equivalent to using min(window_width/width, window_height/height).
      *
-     * @name camera.ORTHO_ZOOM_MODE_AUTO_FIT
+     * @name camera.ORTHO_MODE_AUTO_FIT
      * @constant
      */
 
@@ -49,7 +49,7 @@ namespace dmRender
      * Computes zoom so the original display area covers the entire window while preserving aspect ratio.
      * Equivalent to using max(window_width/width, window_height/height).
      *
-     * @name camera.ORTHO_ZOOM_MODE_AUTO_COVER
+     * @name camera.ORTHO_MODE_AUTO_COVER
      * @constant
      */
 
@@ -289,21 +289,21 @@ namespace dmRender
 
     /*# get orthographic zoom mode
     *
-    * @name camera.get_orthographic_zoom_mode
+    * @name camera.get_orthographic_mode
     * @param camera [type:url|number|nil] camera id
-    * @return mode [type:number] one of camera.ORTHO_ZOOM_MODE_FIXED, camera.ORTHO_ZOOM_MODE_AUTO_FIT or
-    * camera.ORTHO_ZOOM_MODE_AUTO_COVER
+    * @return mode [type:number] one of camera.ORTHO_MODE_FIXED, camera.ORTHO_MODE_AUTO_FIT or
+    * camera.ORTHO_MODE_AUTO_COVER
     */
-    GET_CAMERA_DATA_PROPERTY_FN(OrthographicZoomMode, lua_pushnumber);
+    GET_CAMERA_DATA_PROPERTY_FN(OrthographicMode, lua_pushnumber);
 
     // Helper for enum parameter validation used by macro setter
     static uint8_t LuaCheckOrthoZoomMode(lua_State* L, int index)
     {
         DM_LUA_STACK_CHECK(L, 0);
         int mode = luaL_checkinteger(L, index);
-        if (mode != ORTHO_ZOOM_MODE_FIXED &&
-            mode != ORTHO_ZOOM_MODE_AUTO_FIT &&
-            mode != ORTHO_ZOOM_MODE_AUTO_COVER)
+        if (mode != ORTHO_MODE_FIXED &&
+            mode != ORTHO_MODE_AUTO_FIT &&
+            mode != ORTHO_MODE_AUTO_COVER)
         {
             return (uint8_t) DM_LUA_ERROR("Invalid orthographic zoom mode: %d", mode);
         }
@@ -312,11 +312,11 @@ namespace dmRender
 
     /*# set orthographic zoom mode
     *
-    * @name camera.set_orthographic_zoom_mode
+    * @name camera.set_orthographic_mode
     * @param camera [type:url|number|nil] camera id
-    * @param mode [type:number] camera.ORTHO_ZOOM_MODE_FIXED, _AUTO_FIT or _AUTO_COVER
+    * @param mode [type:number] camera.ORTHO_MODE_FIXED, camera.ORTHO_MODE_AUTO_FIT or camera.ORTHO_MODE_AUTO_COVER
     */
-    SET_CAMERA_DATA_PROPERTY_FN(OrthographicZoomMode, LuaCheckOrthoZoomMode);
+    SET_CAMERA_DATA_PROPERTY_FN(OrthographicMode, LuaCheckOrthoZoomMode);
 
     /*# get auto aspect ratio
     * Returns whether auto aspect ratio is enabled. When enabled, the camera automatically
@@ -378,8 +378,8 @@ namespace dmRender
         {"set_orthographic_zoom",   RenderScriptCamera_SetOrthographicZoom},
         {"get_auto_aspect_ratio",   RenderScriptCamera_GetAutoAspectRatio},
         {"set_auto_aspect_ratio",   RenderScriptCamera_SetAutoAspectRatio},
-        {"get_orthographic_zoom_mode",   RenderScriptCamera_GetOrthographicZoomMode},
-        {"set_orthographic_zoom_mode",   RenderScriptCamera_SetOrthographicZoomMode},
+        {"get_orthographic_mode",   RenderScriptCamera_GetOrthographicMode},
+        {"set_orthographic_mode",   RenderScriptCamera_SetOrthographicMode},
         {0, 0}
     };
 
@@ -390,14 +390,14 @@ namespace dmRender
 
         luaL_register(L, RENDER_SCRIPT_CAMERA_LIB_NAME, RenderScriptCamera_Methods);
 
-        // Add constants: camera.ORTHO_ZOOM_MODE_FIXED/AUTO_FIT/AUTO_COVER
+        // Add constants: camera.ORTHO_MODE_FIXED/AUTO_FIT/AUTO_COVER
         #define SETCONSTANT(name, val) \
             lua_pushnumber(L, (lua_Number) (val)); \
             lua_setfield(L, -2, #name);
 
-        SETCONSTANT(ORTHO_ZOOM_MODE_FIXED,      dmRender::ORTHO_ZOOM_MODE_FIXED);
-        SETCONSTANT(ORTHO_ZOOM_MODE_AUTO_FIT,   dmRender::ORTHO_ZOOM_MODE_AUTO_FIT);
-        SETCONSTANT(ORTHO_ZOOM_MODE_AUTO_COVER, dmRender::ORTHO_ZOOM_MODE_AUTO_COVER);
+        SETCONSTANT(ORTHO_MODE_FIXED,      dmRender::ORTHO_MODE_FIXED);
+        SETCONSTANT(ORTHO_MODE_AUTO_FIT,   dmRender::ORTHO_MODE_AUTO_FIT);
+        SETCONSTANT(ORTHO_MODE_AUTO_COVER, dmRender::ORTHO_MODE_AUTO_COVER);
 
         #undef SETCONSTANT
 

--- a/engine/render/src/render/render_script_camera.cpp
+++ b/engine/render/src/render/render_script_camera.cpp
@@ -30,6 +30,29 @@ namespace dmRender
 
     #define RENDER_SCRIPT_CAMERA_LIB_NAME "camera"
 
+    /*# fixed orthographic zoom mode
+     * Uses the manually set orthographic zoom value (camera.set_orthographic_zoom).
+     *
+     * @name camera.ORTHO_ZOOM_MODE_FIXED
+     * @constant
+     */
+
+    /*# auto-fit orthographic zoom mode
+     * Computes zoom so the original display area (game.project width/height) fits inside the window
+     * while preserving aspect ratio. Equivalent to using min(window_width/width, window_height/height).
+     *
+     * @name camera.ORTHO_ZOOM_MODE_AUTO_FIT
+     * @constant
+     */
+
+    /*# auto-cover orthographic zoom mode
+     * Computes zoom so the original display area covers the entire window while preserving aspect ratio.
+     * Equivalent to using max(window_width/width, window_height/height).
+     *
+     * @name camera.ORTHO_ZOOM_MODE_AUTO_COVER
+     * @constant
+     */
+
     struct RenderScriptCameraModule
     {
         dmRender::HRenderContext m_RenderContext;
@@ -264,6 +287,37 @@ namespace dmRender
     */
     SET_CAMERA_DATA_PROPERTY_FN(OrthographicZoom, lua_tonumber);
 
+    /*# get orthographic zoom mode
+    *
+    * @name camera.get_orthographic_zoom_mode
+    * @param camera [type:url|number|nil] camera id
+    * @return mode [type:number] one of camera.ORTHO_ZOOM_MODE_FIXED, camera.ORTHO_ZOOM_MODE_AUTO_FIT or
+    * camera.ORTHO_ZOOM_MODE_AUTO_COVER
+    */
+    GET_CAMERA_DATA_PROPERTY_FN(OrthographicZoomMode, lua_pushnumber);
+
+    // Helper for enum parameter validation used by macro setter
+    static uint8_t LuaCheckOrthoZoomMode(lua_State* L, int index)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        int mode = luaL_checkinteger(L, index);
+        if (mode != ORTHO_ZOOM_MODE_FIXED &&
+            mode != ORTHO_ZOOM_MODE_AUTO_FIT &&
+            mode != ORTHO_ZOOM_MODE_AUTO_COVER)
+        {
+            return (uint8_t) DM_LUA_ERROR("Invalid orthographic zoom mode: %d", mode);
+        }
+        return (uint8_t) mode;
+    }
+
+    /*# set orthographic zoom mode
+    *
+    * @name camera.set_orthographic_zoom_mode
+    * @param camera [type:url|number|nil] camera id
+    * @param mode [type:number] camera.ORTHO_ZOOM_MODE_FIXED, _AUTO_FIT or _AUTO_COVER
+    */
+    SET_CAMERA_DATA_PROPERTY_FN(OrthographicZoomMode, LuaCheckOrthoZoomMode);
+
     /*# get auto aspect ratio
     * Returns whether auto aspect ratio is enabled. When enabled, the camera automatically
     * calculates aspect ratio from render target dimensions. When disabled, uses the
@@ -324,6 +378,8 @@ namespace dmRender
         {"set_orthographic_zoom",   RenderScriptCamera_SetOrthographicZoom},
         {"get_auto_aspect_ratio",   RenderScriptCamera_GetAutoAspectRatio},
         {"set_auto_aspect_ratio",   RenderScriptCamera_SetAutoAspectRatio},
+        {"get_orthographic_zoom_mode",   RenderScriptCamera_GetOrthographicZoomMode},
+        {"set_orthographic_zoom_mode",   RenderScriptCamera_SetOrthographicZoomMode},
         {0, 0}
     };
 
@@ -333,6 +389,17 @@ namespace dmRender
         DM_LUA_STACK_CHECK(L, 0);
 
         luaL_register(L, RENDER_SCRIPT_CAMERA_LIB_NAME, RenderScriptCamera_Methods);
+
+        // Add constants: camera.ORTHO_ZOOM_MODE_FIXED/AUTO_FIT/AUTO_COVER
+        #define SETCONSTANT(name, val) \
+            lua_pushnumber(L, (lua_Number) (val)); \
+            lua_setfield(L, -2, #name);
+
+        SETCONSTANT(ORTHO_ZOOM_MODE_FIXED,      dmRender::ORTHO_ZOOM_MODE_FIXED);
+        SETCONSTANT(ORTHO_ZOOM_MODE_AUTO_FIT,   dmRender::ORTHO_ZOOM_MODE_AUTO_FIT);
+        SETCONSTANT(ORTHO_ZOOM_MODE_AUTO_COVER, dmRender::ORTHO_ZOOM_MODE_AUTO_COVER);
+
+        #undef SETCONSTANT
 
         lua_pop(L, 1);
 

--- a/scripts/unpack_ddf.py
+++ b/scripts/unpack_ddf.py
@@ -53,6 +53,7 @@ import gamesys.sprite_ddf_pb2
 import gamesys.physics_ddf_pb2
 import gamesys.gui_ddf_pb2
 import gamesys.label_ddf_pb2
+import gamesys.camera_ddf_pb2
 
 BUILDERS = {}
 BUILDERS['.animationsetc']  = rig.rig_ddf_pb2.AnimationSet
@@ -80,6 +81,7 @@ BUILDERS['.spc']            = graphics.graphics_ddf_pb2.ShaderDesc
 BUILDERS['.spritec']        = gamesys.sprite_ddf_pb2.SpriteDesc
 BUILDERS['.texturec']       = graphics.graphics_ddf_pb2.TextureImage
 BUILDERS['.texturesetc']    = gamesys.texture_set_ddf_pb2.TextureSet
+BUILDERS['.camerac']        = gamesys.camera_ddf_pb2.CameraDesc
 
 proto_type_to_string_map = {}
 proto_type_to_string_map[google.protobuf.descriptor.FieldDescriptor.TYPE_BOOL]    = 'TYPE_BOOL'


### PR DESCRIPTION
New functionality for camera added:
- Added orthographic camera modes: ORTHO_MODE_FIXED, ORTHO_MODE_AUTO_FIT (contain), and ORTHO_MODE_AUTO_COVER (zoom).
- New Camera properties in Editor: “Orthographic Mode” (available only when Orthographic Projection is enabled).
- Lua API: `camera.get_orthographic_mode()` and `camera.set_orthographic_mode()` 

```lua
camera.get_orthographic_mode("#camera")
camera.set_orthographic_mode("#camera", camera.ORTHO_MODE_AUTO_FIT)
```

Fix https://github.com/defold/defold/issues/6849
Fix https://github.com/defold/defold/issues/10579