### PR TITLE
Add support for enabling file logging in release mode  

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
@@ -25,6 +25,12 @@ developer.default =
 write_log.type = bool
 write_log.help = Write log file to disk
 write_log.default = 0
+write_log.deprecated = 1
+
+write_log_file.type = integer
+write_log_file.help = Write log file to disk
+write_log_file.default = 0
+write_log_file.options = 0:Never,1:Debug,2:Always
 
 minimum_log_level.type = string
 minimum_log_level.help = only the minimum log level and higher levels will be shown

--- a/editor/test/resources/save_data_project/game.project
+++ b/editor/test/resources/save_data_project/game.project
@@ -62,6 +62,7 @@ version = 1.1
 publisher = Defold Foundation
 developer = Defold Foundation
 write_log = 1
+write_log_file = 1
 minimum_log_level = 2
 compress_archive = 1
 custom_resources = /referenced/custom

--- a/engine/dlib/src/dlib/log.cpp
+++ b/engine/dlib/src/dlib/log.cpp
@@ -320,12 +320,6 @@ static void DoLogPlatform(LogSeverity severity, const char* output, int output_l
 #elif !defined(ANDROID)
         fwrite(output, 1, output_len, stderr);
 #endif
-
-    if (dmLog::g_LogFile && dmLog::g_TotalBytesLogged < dmLog::MAX_LOG_FILE_SIZE) {
-        dmLog::g_TotalBytesLogged += output_len;
-        fwrite(output, 1, output_len, dmLog::g_LogFile);
-        fflush(dmLog::g_LogFile);
-    }
 }
 
 // Here we put logging that needs to be thread safe
@@ -630,9 +624,9 @@ void LogInternal(LogSeverity severity, const char* domain, const char* format, .
         return;
     }
 
-    // In release mode, if there are no custom listeners, we'll return here
+    // In release mode, if there are no custom listeners, and no log.txt file, we'll return here
     bool is_debug_mode = dLib::IsDebugMode();
-    if (!is_debug_mode && (dmAtomicGet32(&dmLog::g_ListenersCount) == 0))
+    if (!is_debug_mode && !dmLog::g_LogFile && (dmAtomicGet32(&dmLog::g_ListenersCount) == 0))
     {
         return;
     }
@@ -689,6 +683,13 @@ void LogInternal(LogSeverity severity, const char* domain, const char* format, .
     if (is_debug_mode)
     {
         dmLog::DoLogPlatform(severity, str_buf, actual_n);
+    }
+
+    if (dmLog::g_LogFile && dmLog::g_TotalBytesLogged < dmLog::MAX_LOG_FILE_SIZE)
+    {
+        dmLog::g_TotalBytesLogged += actual_n;
+        fwrite(str_buf, 1, actual_n, dmLog::g_LogFile);
+        fflush(dmLog::g_LogFile);
     }
 
     if (!dmLog::IsServerInitialized()) // in case the server lock isn't even created

--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -930,8 +930,12 @@ namespace dmEngine
 #if !defined(DM_RELEASE)
         instance_index = dmConfigFile::GetInt(engine->m_Config, "project.instance_index", 0);
 #endif
-        int write_log = dmConfigFile::GetInt(engine->m_Config, "project.write_log", 0);
-        if (write_log) {
+        int write_log = dmConfigFile::GetInt(engine->m_Config, "project.write_log", 0); // Deprecated
+        int write_log_file = dmConfigFile::GetInt(engine->m_Config, "project.write_log_file", 0);
+        // for backward compatibility if write_log_file is 0, but write_log is 1
+        write_log_file = write_log_file == 0 ? write_log : write_log_file;
+        // 0 - no logs, 1 - debug only, 2 - always
+        if (write_log_file + dLib::IsDebugMode() >= 2) {
             uint32_t count = 0;
             char* log_paths[3];
 

--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -935,7 +935,8 @@ namespace dmEngine
         // for backward compatibility if write_log_file is 0, but write_log is 1
         write_log_file = write_log_file == 0 ? write_log : write_log_file;
         // 0 - no logs, 1 - debug only, 2 - always
-        if (write_log_file + dLib::IsDebugMode() >= 2) {
+        if ((write_log_file == 2) || (write_log_file == 1 && dLib::IsDebugMode()))
+        {
             uint32_t count = 0;
             char* log_paths[3];
 


### PR DESCRIPTION
You can now enable file logging in Release mode.  
The previous `Write Log` option has been deprecated and replaced with a new `Write Log File` setting, which offers three choices: `Never`, `Debug`, and `Always`.  

<img width="967" height="339" alt="CleanShot 2025-09-12 at 15 22 00@2x" src="https://github.com/user-attachments/assets/b7bd7237-d701-47a3-93a4-d1982cc68690" />

Fix https://github.com/defold/defold/issues/10255