### PR TITLE
Added new function `go.update_world_transform()`

### DIFF
--- a/engine/gameobject/src/gameobject/gameobject_private.h
+++ b/engine/gameobject/src/gameobject/gameobject_private.h
@@ -307,6 +307,7 @@ namespace dmGameObject
     bool CreateComponents(Collection* collection, HInstance instance);
     void Delete(Collection* collection, HInstance instance, bool recursive);
     void UpdateTransforms(Collection* collection);
+    void UpdateTransformsForInstance(Collection* collection, Instance* instance);
     void DeleteCollection(Collection* collection);
     bool IsCollectionInitialized(Collection* collection);
     Result AttachCollection(Collection* collection, const char* name, dmResource::HFactory factory, HRegister regist, HCollection hcollection);

--- a/engine/gameobject/src/gameobject/gameobject_script.cpp
+++ b/engine/gameobject/src/gameobject/gameobject_script.cpp
@@ -1260,6 +1260,7 @@ namespace dmGameObject
 
     /*# gets the game object instance world position
      * The function will return the world position calculated at the end of the previous frame.
+     * To recalculate it within the current frame, use [ref:go.update_world_transform] on the instance before calling this.
      * Use [ref:go.get_position] to retrieve the position relative to the parent.
      *
      * @name go.get_world_position
@@ -1288,6 +1289,7 @@ namespace dmGameObject
 
     /*# gets the game object instance world rotation
      * The function will return the world rotation calculated at the end of the previous frame.
+     * To recalculate it within the current frame, use [ref:go.update_world_transform] on the instance before calling this.
      * Use [ref:go.get_rotation] to retrieve the rotation relative to the parent.
      *
      * @name go.get_world_rotation
@@ -1316,6 +1318,7 @@ namespace dmGameObject
 
     /*# gets the game object instance world 3D scale factor
      * The function will return the world 3D scale factor calculated at the end of the previous frame.
+     * To recalculate it within the current frame, use [ref:go.update_world_transform] on the instance before calling this.
      * Use [ref:go.get_scale] to retrieve the 3D scale factor relative to the parent.
      * This vector is derived by decomposing the transformation matrix and should be used with care.
      * For most cases it should be fine to use [ref:go.get_world_scale_uniform] instead.
@@ -1346,6 +1349,7 @@ namespace dmGameObject
 
     /*# gets the uniform game object instance world scale factor
      * The function will return the world scale factor calculated at the end of the previous frame.
+     * To recalculate it within the current frame, use [ref:go.update_world_transform] on the instance before calling this.
      * Use [ref:go.get_scale_uniform] to retrieve the scale factor relative to the parent.
      *
      * @name go.get_world_scale_uniform
@@ -1374,6 +1378,7 @@ namespace dmGameObject
 
     /*# gets the game object instance world transform matrix
      * The function will return the world transform matrix calculated at the end of the previous frame.
+     * To recalculate it within the current frame, use [ref:go.update_world_transform] on the instance before calling this.
      *
      * @name go.get_world_transform
      * @param [id] [type:string|hash|url] optional id of the game object instance to get the world transform for, by default the instance of the calling script
@@ -1397,6 +1402,40 @@ namespace dmGameObject
         Instance* instance = ResolveInstance(L,1);
         dmScript::PushMatrix4(L, dmGameObject::GetWorldMatrix(instance));
         return 1;
+    }
+
+    /*# updates the world transform for a game object instance
+     * Recalculates and updates the cached world transform immediately for the target instance
+     * and its ancestors (parent chain up to the collection root). Descendants (children) are
+     * not updated by this function.
+     * If no id is provided, the instance of the calling script is used.
+     *
+     * [icon:attention] Use this after changing local transform mid-frame when you need the
+     * new world transform right away (e.g. before end-of-frame updates). Note that child
+     * instances will still have last-frame world transforms until the regular update.
+     *
+     * @name go.update_world_transform
+     * @param [id] [type:string|hash|url] optional id of the game object instance to update
+     * @examples
+     *
+     * Update this game object's world transform:
+     *
+     * ```lua
+     * go.update_world_transform()
+     * ```
+     *
+     * Update another game object's world transform:
+     *
+     * ```lua
+     * go.update_world_transform("/other")
+     * ```
+     */
+    static int Script_UpdateWorldTransform(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        Instance* instance = ResolveInstance(L, 1);
+        dmGameObject::UpdateTransformsForInstance(instance->m_Collection, instance);
+        return 0;
     }
 
     /*# gets the id of an instance
@@ -2194,6 +2233,7 @@ namespace dmGameObject
         {"get_world_scale",         Script_GetWorldScale},
         {"get_world_scale_uniform", Script_GetWorldScaleUniform},
         {"get_world_transform",     Script_GetWorldTransform},
+        {"update_world_transform",  Script_UpdateWorldTransform},
         {"get_id",                  Script_GetId},
         {"animate",                 Script_Animate},
         {"cancel_animations",       Script_CancelAnimations},


### PR DESCRIPTION
A new function `go.update_world_transform()` has been added. It recalculates the world transform of an object along with its entire hierarchy up to the root objects.

Fix https://github.com/defold/defold/issues/7902
Fix https://github.com/defold/defold/issues/9498