### PR TITLE
Added `sort_order` option to `render.draw()` in `render_script`

### DIFF
--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -1967,7 +1967,7 @@ bail:
                                             (float)((engine->m_ClearColor>>16)&0xFF),
                                             (float)((engine->m_ClearColor>>24)&0xFF),
                                             1.0f, 0);
-                        dmRender::DrawRenderList(engine->m_RenderContext, 0x0, 0x0, 0x0);
+                        dmRender::DrawRenderList(engine->m_RenderContext, 0x0, 0x0, 0x0, dmRender::SORT_BACK_TO_FRONT);
                     }
                 }
 

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -1527,7 +1527,7 @@ TEST_F(GuiTest, TextureResources)
     dmGameObject::Render(m_Collection);
 
     dmRender::RenderListEnd(m_RenderContext);
-    dmRender::DrawRenderList(m_RenderContext, 0x0, 0x0, 0x0);
+    dmRender::DrawRenderList(m_RenderContext, 0x0, 0x0, 0x0, dmRender::SORT_BACK_TO_FRONT);
 
     uint32_t component_type_index        = dmGameObject::GetComponentTypeIndex(m_Collection, dmHashString64("guic"));
     dmGameSystem::GuiWorld* gui_world    = (dmGameSystem::GuiWorld*) dmGameObject::GetWorld(m_Collection, component_type_index);
@@ -1610,7 +1610,7 @@ TEST_F(GuiTest, MaxDynamictextures)
     dmGameObject::Render(m_Collection);
 
     dmRender::RenderListEnd(m_RenderContext);
-    dmRender::DrawRenderList(m_RenderContext, 0x0, 0x0, 0x0);
+    dmRender::DrawRenderList(m_RenderContext, 0x0, 0x0, 0x0, dmRender::SORT_BACK_TO_FRONT);
 
     ASSERT_EQ(0, scene->m_DynamicTextures.Size());
 
@@ -1640,7 +1640,7 @@ TEST_F(ResourceTest, ScriptSetFonts)
         dmGameObject::Render(m_Collection);
 
         dmRender::RenderListEnd(m_RenderContext);
-        dmRender::DrawRenderList(m_RenderContext, 0x0, 0x0, 0x0);
+        dmRender::DrawRenderList(m_RenderContext, 0x0, 0x0, 0x0, dmRender::SORT_BACK_TO_FRONT);
     }
 
     dmResource::Release(m_Factory, font1);
@@ -2475,7 +2475,7 @@ TEST_P(DrawCountTest, DrawCount)
     dmGameObject::Render(m_Collection);
 
     dmRender::RenderListEnd(m_RenderContext);
-    dmRender::DrawRenderList(m_RenderContext, 0x0, 0x0, 0x0);
+    dmRender::DrawRenderList(m_RenderContext, 0x0, 0x0, 0x0, dmRender::SORT_BACK_TO_FRONT);
 
     ASSERT_TRUE(dmGameObject::PostUpdate(m_Collection));
 
@@ -2531,7 +2531,7 @@ TEST_P(BoxRenderTest, BoxRender)
     dmGameObject::Render(m_Collection);
 
     dmRender::RenderListEnd(m_RenderContext);
-    dmRender::DrawRenderList(m_RenderContext, 0x0, 0x0, 0x0);
+    dmRender::DrawRenderList(m_RenderContext, 0x0, 0x0, 0x0, dmRender::SORT_BACK_TO_FRONT);
 
     ASSERT_EQ(world->m_ClientVertexBuffer.Size(), (uint32_t)p.m_ExpectedVerticesCount);
 
@@ -2944,7 +2944,7 @@ TEST_F(ComponentTest, DispatchBuffersTest)
     const uint8_t num_draws = 4;
     for (int i = 0; i < num_draws; ++i)
     {
-        dmRender::DrawRenderList(m_RenderContext, 0x0, 0x0, 0x0);
+        dmRender::DrawRenderList(m_RenderContext, 0x0, 0x0, 0x0, dmRender::SORT_BACK_TO_FRONT);
     }
 
     // Vertex format for /misc/dispatch_buffers_test/vs_format_a.vp:
@@ -3208,7 +3208,7 @@ TEST_F(ComponentTest, DispatchBuffersInstancingTest)
     dmRender::RenderListBegin(m_RenderContext);
     dmGameObject::Render(m_Collection);
     dmRender::RenderListEnd(m_RenderContext);
-    dmRender::DrawRenderList(m_RenderContext, 0x0, 0x0, 0x0);
+    dmRender::DrawRenderList(m_RenderContext, 0x0, 0x0, 0x0, dmRender::SORT_BACK_TO_FRONT);
 
     struct vs_format_a
     {
@@ -5694,7 +5694,7 @@ TEST_F(ModelTest, PbrProperties)
     dmGameObject::Render(m_Collection);
 
     dmRender::RenderListEnd(m_RenderContext);
-    dmRender::DrawRenderList(m_RenderContext, 0x0, 0x0, 0x0);
+    dmRender::DrawRenderList(m_RenderContext, 0x0, 0x0, 0x0, dmRender::SORT_BACK_TO_FRONT);
 
     uint32_t component_type;
     dmGameObject::HComponent component;

--- a/engine/gamesys/src/gamesys/test/test_gamesys.h
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.h
@@ -753,7 +753,7 @@ void GamesysTest<T>::WaitForTestsDone(int update_count, bool render, bool* resul
             dmGameObject::Render(m_Collection);
 
             dmRender::RenderListEnd(m_RenderContext);
-            dmRender::DrawRenderList(m_RenderContext, 0x0, 0x0, 0x0);
+            dmRender::DrawRenderList(m_RenderContext, 0x0, 0x0, 0x0, dmRender::SORT_BACK_TO_FRONT);
         }
 
         // check if tests are done
@@ -935,4 +935,3 @@ protected:
 };
 
 #endif // DM_TEST_GAMESYS_H
-

--- a/engine/profiler/src/profiler.cpp
+++ b/engine/profiler/src/profiler.cpp
@@ -140,7 +140,7 @@ void RenderProfiler(HProfile profile, dmGraphics::HContext graphics_context, dmR
         dmRender::RenderListEnd(render_context);
         dmRender::SetViewMatrix(render_context, dmVMath::Matrix4::identity());
         dmRender::SetProjectionMatrix(render_context, dmVMath::Matrix4::orthographic(0.0f, dmGraphics::GetWindowWidth(graphics_context), 0.0f, dmGraphics::GetWindowHeight(graphics_context), 1.0f, -1.0f));
-        dmRender::DrawRenderList(render_context, 0, 0, 0);
+        dmRender::DrawRenderList(render_context, 0, 0, 0, dmRender::SORT_BACK_TO_FRONT);
         dmRender::ClearRenderObjects(render_context);
 
         // Restore blend state

--- a/engine/render/src/render/render.cpp
+++ b/engine/render/src/render/render.cpp
@@ -928,13 +928,15 @@ namespace dmRender
             }
         }
 
-        MakeSortBuffer(context, predicate?predicate->m_TagCount:0, predicate?predicate->m_Tags:0, sort_order);
+        SortOrder effective_sort_order = (sort_order == SORT_UNSPECIFIED) ? SORT_BACK_TO_FRONT : sort_order;
+
+        MakeSortBuffer(context, predicate?predicate->m_TagCount:0, predicate?predicate->m_Tags:0, effective_sort_order);
 
         if (context->m_RenderListSortBuffer.Empty())
             return RESULT_OK;
 
         {
-            if (sort_order != SORT_NONE)
+            if (effective_sort_order != SORT_NONE)
             {
                 DM_PROFILE("DrawRenderList_SORT");
                 RenderListSorter sort;

--- a/engine/render/src/render/render.cpp
+++ b/engine/render/src/render/render.cpp
@@ -587,6 +587,13 @@ namespace dmRender
         if (maxZW > minZW)
             rc = 1.0f / (maxZW - minZW);
 
+        const uint32_t ORDER_SCALE_MASK = 0xfffff0;
+        const uint32_t ORDER_BASE_FRONT = 0x000008;
+        const uint32_t ORDER_BASE_BACK = 0xfffff8;
+        const bool front_to_back = (sort_order == SORT_FRONT_TO_BACK);
+        const float order_multiplier = (front_to_back ? 1.0f : -1.0f) * ORDER_SCALE_MASK * rc;
+        const float order_bias = (front_to_back ? ORDER_BASE_FRONT : ORDER_BASE_BACK) - order_multiplier * minZW;
+
         for( uint32_t i = 0; i < num_ranges; ++i)
         {
             const RenderListRange& range = ranges[i];
@@ -607,16 +614,7 @@ namespace dmRender
                 if (entry->m_MajorOrder == RENDER_ORDER_WORLD)
                 {
                     const float z = sort_values[idx].m_ZW;
-                    if (sort_order == SORT_FRONT_TO_BACK)
-                    {
-                        // Near-to-far
-                        sort_values[idx].m_Order = (uint32_t) (0x000008 + 0xfffff0 * rc * (z - minZW));
-                    }
-                    else
-                    {
-                        // Default: far-to-near
-                        sort_values[idx].m_Order = (uint32_t) (0xfffff8 - 0xfffff0 * rc * (z - minZW));
-                    }
+                    sort_values[idx].m_Order = (uint32_t) (order_bias + order_multiplier * z);
                 }
                 else
                 {

--- a/engine/render/src/render/render.cpp
+++ b/engine/render/src/render/render.cpp
@@ -517,7 +517,7 @@ namespace dmRender
     }
 
     // Compute new sort values for everything that matches tag_mask
-    static void MakeSortBuffer(HRenderContext context, uint32_t tag_count, dmhash_t* tags)
+    static void MakeSortBuffer(HRenderContext context, uint32_t tag_count, dmhash_t* tags, SortOrder sort_order)
     {
         DM_PROFILE("MakeSortBuffer");
 
@@ -607,7 +607,16 @@ namespace dmRender
                 if (entry->m_MajorOrder == RENDER_ORDER_WORLD)
                 {
                     const float z = sort_values[idx].m_ZW;
-                    sort_values[idx].m_Order = (uint32_t) (0xfffff8 - 0xfffff0 * rc * (z - minZW));
+                    if (sort_order == SORT_FRONT_TO_BACK)
+                    {
+                        // Near-to-far
+                        sort_values[idx].m_Order = (uint32_t) (0x000008 + 0xfffff0 * rc * (z - minZW));
+                    }
+                    else
+                    {
+                        // Default: far-to-near
+                        sort_values[idx].m_Order = (uint32_t) (0xfffff8 - 0xfffff0 * rc * (z - minZW));
+                    }
                 }
                 else
                 {
@@ -855,7 +864,7 @@ namespace dmRender
         }
     }
 
-    Result DrawRenderList(HRenderContext context, HPredicate predicate, HNamedConstantBuffer constant_buffer, const FrustumOptions* frustum_options)
+    Result DrawRenderList(HRenderContext context, HPredicate predicate, HNamedConstantBuffer constant_buffer, const FrustumOptions* frustum_options, SortOrder sort_order)
     {
         DM_PROFILE("DrawRenderList");
 
@@ -921,16 +930,19 @@ namespace dmRender
             }
         }
 
-        MakeSortBuffer(context, predicate?predicate->m_TagCount:0, predicate?predicate->m_Tags:0);
+        MakeSortBuffer(context, predicate?predicate->m_TagCount:0, predicate?predicate->m_Tags:0, sort_order);
 
         if (context->m_RenderListSortBuffer.Empty())
             return RESULT_OK;
 
         {
-            DM_PROFILE("DrawRenderList_SORT");
-            RenderListSorter sort;
-            sort.values = context->m_RenderListSortValues.Begin();
-            std::stable_sort(context->m_RenderListSortBuffer.Begin(), context->m_RenderListSortBuffer.End(), sort);
+            if (sort_order != SORT_NONE)
+            {
+                DM_PROFILE("DrawRenderList_SORT");
+                RenderListSorter sort;
+                sort.values = context->m_RenderListSortValues.Begin();
+                std::stable_sort(context->m_RenderListSortBuffer.Begin(), context->m_RenderListSortBuffer.End(), sort);
+            }
         }
 
         // Construct render objects
@@ -1218,7 +1230,7 @@ namespace dmRender
         if (!context->m_DebugRenderer.m_RenderContext) {
             return RESULT_INVALID_CONTEXT;
         }
-        return DrawRenderList(context, &context->m_DebugRenderer.m_3dPredicate, 0, frustum_options);
+        return DrawRenderList(context, &context->m_DebugRenderer.m_3dPredicate, 0, frustum_options, SORT_BACK_TO_FRONT);
     }
 
     Result DrawDebug2d(HRenderContext context) // Deprecated
@@ -1226,7 +1238,7 @@ namespace dmRender
         if (!context->m_DebugRenderer.m_RenderContext) {
             return RESULT_INVALID_CONTEXT;
         }
-        return DrawRenderList(context, &context->m_DebugRenderer.m_2dPredicate, 0, 0);
+        return DrawRenderList(context, &context->m_DebugRenderer.m_2dPredicate, 0, 0, SORT_BACK_TO_FRONT);
     }
 
     HPredicate NewPredicate()

--- a/engine/render/src/render/render.h
+++ b/engine/render/src/render/render.h
@@ -112,9 +112,10 @@ namespace dmRender
 
     enum SortOrder
     {
-        SORT_BACK_TO_FRONT = 0,
-        SORT_FRONT_TO_BACK = 1,
-        SORT_NONE          = 2,
+        SORT_UNSPECIFIED   = 0,
+        SORT_BACK_TO_FRONT = 1,
+        SORT_FRONT_TO_BACK = 2,
+        SORT_NONE          = 3
     };
 
     struct Predicate

--- a/engine/render/src/render/render.h
+++ b/engine/render/src/render/render.h
@@ -110,6 +110,13 @@ namespace dmRender
         CONTEXT_RESTORED = 1
     };
 
+    enum SortOrder
+    {
+        SORT_BACK_TO_FRONT = 0,
+        SORT_FRONT_TO_BACK = 1,
+        SORT_NONE          = 2,
+    };
+
     struct Predicate
     {
         static const uint32_t MAX_TAG_COUNT = 32;
@@ -201,7 +208,7 @@ namespace dmRender
 
     // Takes the contents of the render list, sorts by view and inserts all the objects in the
     // render list, unless they already are in place from a previous call.
-    Result DrawRenderList(HRenderContext context, HPredicate predicate, HNamedConstantBuffer constant_buffer, const FrustumOptions* frustum_options);
+    Result DrawRenderList(HRenderContext context, HPredicate predicate, HNamedConstantBuffer constant_buffer, const FrustumOptions* frustum_options, SortOrder sort_order);
 
     Result Draw(HRenderContext context, HPredicate predicate, HNamedConstantBuffer constant_buffer);
     Result DrawDebug3d(HRenderContext context, const FrustumOptions* frustum_options);

--- a/engine/render/src/render/render_command.cpp
+++ b/engine/render/src/render/render_command.cpp
@@ -177,9 +177,11 @@ namespace dmRender
                 case COMMAND_TYPE_DRAW:
                 {
                     FrustumOptions* frustum_options = (FrustumOptions*)c->m_Operands[2];
+                    dmRender::SortOrder sort_order = (dmRender::SortOrder)c->m_Operands[3];
                     dmRender::DrawRenderList(render_context, (dmRender::Predicate*)c->m_Operands[0],
                                                              (dmRender::HNamedConstantBuffer)c->m_Operands[1],
-                                                             frustum_options);
+                                                             frustum_options,
+                                                             sort_order);
                     delete frustum_options;
                     break;
                 }

--- a/engine/render/src/render/render_script.cpp
+++ b/engine/render/src/render/render_script.cpp
@@ -3218,7 +3218,7 @@ namespace dmRender
 #undef REGISTER_FRUSTUM_PLANES_CONSTANT
 
 #define REGISTER_SORT_ORDER_CONSTANT(name)\
-        lua_pushnumber(L, (lua_Number) dmRender::##name); \
+        lua_pushnumber(L, (lua_Number) dmRender::name); \
         lua_setfield(L, -2, #name);
 
         REGISTER_SORT_ORDER_CONSTANT(SORT_BACK_TO_FRONT);

--- a/engine/render/src/render/render_script.cpp
+++ b/engine/render/src/render/render_script.cpp
@@ -1740,7 +1740,7 @@ namespace dmRender
      * : [type:constant_buffer] optional constants to use while rendering
      *
      * `sort_order`
-     * : [type:int] How to sort draw order for world-ordered entries. Default is render.SORT_BACK_TO_FRONT.
+     * : [type:int] How to sort draw order for world-ordered entries. Default uses the renderer's preferred world sorting (back-to-front).
      *
      * @examples
      *
@@ -1795,7 +1795,7 @@ namespace dmRender
         dmVMath::Matrix4* frustum_matrix = 0;
         dmRender::FrustumPlanes frustum_num_planes = dmRender::FRUSTUM_PLANES_SIDES;
         HNamedConstantBuffer constant_buffer = 0;
-        dmRender::SortOrder sort_order = dmRender::SORT_BACK_TO_FRONT;
+        dmRender::SortOrder sort_order = dmRender::SORT_UNSPECIFIED;
 
         if (lua_istable(L, 2))
         {

--- a/engine/render/src/render/render_script.cpp
+++ b/engine/render/src/render/render_script.cpp
@@ -2001,16 +2001,19 @@ namespace dmRender
      */
 
     /*#
+     * Depth sort far-to-near (default; good for transparent passes).
      * @name render.SORT_BACK_TO_FRONT
      * @constant
      */
 
     /*#
+     * Depth sort near-to-far (good for opaque passes to reduce overdraw).
      * @name render.SORT_FRONT_TO_BACK
      * @constant
      */
 
     /*#
+     * No per-call sorting; draw entries in insertion order.
      * @name render.SORT_NONE
      * @constant
      */

--- a/engine/render/src/render/render_script.cpp
+++ b/engine/render/src/render/render_script.cpp
@@ -1739,6 +1739,9 @@ namespace dmRender
      * `constants`
      * : [type:constant_buffer] optional constants to use while rendering
      *
+     * `sort_order`
+     * : [type:int] How to sort draw order for world-ordered entries. Default is render.SORT_BACK_TO_FRONT.
+     *
      * @examples
      *
      * ```lua
@@ -1792,6 +1795,7 @@ namespace dmRender
         dmVMath::Matrix4* frustum_matrix = 0;
         dmRender::FrustumPlanes frustum_num_planes = dmRender::FRUSTUM_PLANES_SIDES;
         HNamedConstantBuffer constant_buffer = 0;
+        dmRender::SortOrder sort_order = dmRender::SORT_BACK_TO_FRONT;
 
         if (lua_istable(L, 2))
         {
@@ -1808,6 +1812,13 @@ namespace dmRender
 
             lua_getfield(L, -1, "constants");
             constant_buffer = lua_isnil(L, -1) ? 0 : *RenderScriptConstantBuffer_Check(L, -1);
+            lua_pop(L, 1);
+
+            lua_getfield(L, -1, "sort_order");
+            if (!lua_isnil(L, -1))
+            {
+                sort_order = (dmRender::SortOrder) luaL_checkinteger(L, -1);
+            }
             lua_pop(L, 1);
 
             lua_pop(L, 1);
@@ -1828,7 +1839,7 @@ namespace dmRender
             frustum_options->m_NumPlanes = frustum_num_planes;
         }
 
-        if (InsertCommand(i, Command(COMMAND_TYPE_DRAW, (uint64_t)predicate, (uint64_t) constant_buffer, (uint64_t) frustum_options)))
+        if (InsertCommand(i, Command(COMMAND_TYPE_DRAW, (uint64_t)predicate, (uint64_t) constant_buffer, (uint64_t) frustum_options, (uint64_t) sort_order)))
             return 0;
         else
             return luaL_error(L, "Command buffer is full (%d).", i->m_CommandBuffer.Capacity());
@@ -1986,6 +1997,21 @@ namespace dmRender
 
     /*#
      * @name render.FRUSTUM_PLANES_ALL
+     * @constant
+     */
+
+    /*#
+     * @name render.SORT_BACK_TO_FRONT
+     * @constant
+     */
+
+    /*#
+     * @name render.SORT_FRONT_TO_BACK
+     * @constant
+     */
+
+    /*#
+     * @name render.SORT_NONE
      * @constant
      */
 
@@ -3190,6 +3216,16 @@ namespace dmRender
         REGISTER_FRUSTUM_PLANES_CONSTANT(ALL);
 
 #undef REGISTER_FRUSTUM_PLANES_CONSTANT
+
+#define REGISTER_SORT_ORDER_CONSTANT(name)\
+        lua_pushnumber(L, (lua_Number) dmRender::##name); \
+        lua_setfield(L, -2, #name);
+
+        REGISTER_SORT_ORDER_CONSTANT(SORT_BACK_TO_FRONT);
+        REGISTER_SORT_ORDER_CONSTANT(SORT_FRONT_TO_BACK);
+        REGISTER_SORT_ORDER_CONSTANT(SORT_NONE);
+
+#undef REGISTER_SORT_ORDER_CONSTANT
 
         // Flags (only flag here currently, so no need for an enum)
         lua_pushnumber(L, RENDER_SCRIPT_FLAG_TEXTURE_BIT);

--- a/engine/render/src/test/test_render.cpp
+++ b/engine/render/src/test/test_render.cpp
@@ -416,7 +416,7 @@ TEST_F(dmRenderTest, TestRenderListDraw)
     dmRender::RenderListSubmit(m_Context, out, out + n);
     dmRender::RenderListEnd(m_Context);
 
-    dmRender::DrawRenderList(m_Context, 0, 0, 0);
+    dmRender::DrawRenderList(m_Context, 0, 0, 0, dmRender::SORT_BACK_TO_FRONT);
 
     ASSERT_EQ(ctx.m_BeginCalls, 1);
     ASSERT_GT(ctx.m_BatchCalls, 1);
@@ -544,7 +544,7 @@ TEST_F(dmRenderTest, TestRenderListDrawState)
 
     dmRender::RenderListSubmit(m_Context, out, out + 1);
     dmRender::RenderListEnd(m_Context);
-    dmRender::DrawRenderList(m_Context, 0, 0, 0);
+    dmRender::DrawRenderList(m_Context, 0, 0, 0, dmRender::SORT_BACK_TO_FRONT);
 
     dmGraphics::PipelineState ps_after = dmGraphics::GetPipelineState(m_GraphicsContext);
 
@@ -701,7 +701,7 @@ TEST_F(dmRenderTest, TestEnableTextureByHash)
     dmRender::RenderListSubmit(m_Context, out, out + 1);
     dmRender::RenderListEnd(m_Context);
 
-    dmRender::DrawRenderList(m_Context, 0, 0, 0);
+    dmRender::DrawRenderList(m_Context, 0, 0, 0, dmRender::SORT_BACK_TO_FRONT);
 
     // we bind test_texture_0 to unit 0, but that binding will be overwritten by the name hash binding
     // since the "texture_sampler_1" sampler is bound to unit 0
@@ -716,7 +716,7 @@ TEST_F(dmRenderTest, TestEnableTextureByHash)
 
     // we should allow binding the same texture to multiple logical units
     SetTextureBindingByHash(m_Context, texture_sampler_2_hash, test_texture_1);
-    dmRender::DrawRenderList(m_Context, 0, 0, 0);
+    dmRender::DrawRenderList(m_Context, 0, 0, 0, dmRender::SORT_BACK_TO_FRONT);
 
     ASSERT_EQ(m_Context->m_TextureBindTable[1].m_Texture, test_texture_1);
     ASSERT_EQ(m_Context->m_TextureBindTable[2].m_Texture, test_texture_1);
@@ -730,7 +730,7 @@ TEST_F(dmRenderTest, TestEnableTextureByHash)
     // Bind another texture after, to make sure we can bind something after an array and all the unit offsets should be valid
     SetTextureBindingByHash(m_Context, texture_sampler_4_hash, test_texture_0);
 
-    dmRender::DrawRenderList(m_Context, 0, 0, 0);
+    dmRender::DrawRenderList(m_Context, 0, 0, 0, dmRender::SORT_BACK_TO_FRONT);
 
     dmGraphics::Texture* tex_array = dmGraphics::GetAssetFromContainer<dmGraphics::Texture>(null_context->m_AssetHandleContainer, test_texture_array);
     ASSERT_EQ(m_Context->m_TextureBindTable[3].m_Texture, test_texture_array);
@@ -751,7 +751,7 @@ TEST_F(dmRenderTest, TestEnableTextureByHash)
 
     // Drawing should trim the texture bind table based on where the last valid texture was found
     // which will set the table to zero in this case
-    dmRender::DrawRenderList(m_Context, 0, 0, 0);
+    dmRender::DrawRenderList(m_Context, 0, 0, 0, dmRender::SORT_BACK_TO_FRONT);
     ASSERT_EQ(0, m_Context->m_TextureBindTable.Size());
 
     // table is [t0, 0, 0, t0];
@@ -764,7 +764,7 @@ TEST_F(dmRenderTest, TestEnableTextureByHash)
     SetTextureBindingByUnit(m_Context, 3, 0);
 
     // Draw should trim the array to [t0]
-    dmRender::DrawRenderList(m_Context, 0, 0, 0);
+    dmRender::DrawRenderList(m_Context, 0, 0, 0, dmRender::SORT_BACK_TO_FRONT);
     ASSERT_EQ(1, m_Context->m_TextureBindTable.Size());
     ASSERT_EQ(test_texture_0, m_Context->m_TextureBindTable[0].m_Texture);
 
@@ -1011,7 +1011,7 @@ TEST_F(dmRenderTest, TestDefaultSamplerFilters)
     {
         dmRender::RenderListSubmit(m_Context, out, out + 1);
         dmRender::RenderListEnd(m_Context);
-        dmRender::DrawRenderList(m_Context, 0, 0, 0);
+        dmRender::DrawRenderList(m_Context, 0, 0, 0, dmRender::SORT_BACK_TO_FRONT);
 
         dmGraphics::GetTextureFilters(m_GraphicsContext, 0, gfx_min_filter_active, gfx_mag_filter_active);
         ASSERT_EQ(dmGraphics::TEXTURE_FILTER_NEAREST, gfx_min_filter_active);
@@ -1031,7 +1031,7 @@ TEST_F(dmRenderTest, TestDefaultSamplerFilters)
     {
         dmRender::RenderListSubmit(m_Context, out, out + 1);
         dmRender::RenderListEnd(m_Context);
-        dmRender::DrawRenderList(m_Context, 0, 0, 0);
+        dmRender::DrawRenderList(m_Context, 0, 0, 0, dmRender::SORT_BACK_TO_FRONT);
 
         dmGraphics::GetTextureFilters(m_GraphicsContext, 0, gfx_min_filter_active, gfx_mag_filter_active);
         ASSERT_EQ(gfx_min_filter_default, gfx_min_filter_active);
@@ -1197,11 +1197,11 @@ TEST_F(dmRenderTest, TestRenderListCulling)
             dmRender::FrustumOptions frustum_options;
             frustum_options.m_Matrix = *frustum_matrices[c];
             frustum_options.m_NumPlanes = dmRender::FRUSTUM_PLANES_SIDES;
-            dmRender::DrawRenderList(m_Context, 0, 0, &frustum_options);
+            dmRender::DrawRenderList(m_Context, 0, 0, &frustum_options, dmRender::SORT_BACK_TO_FRONT);
         }
         else
         {
-            dmRender::DrawRenderList(m_Context, 0, 0, 0);
+            dmRender::DrawRenderList(m_Context, 0, 0, 0, dmRender::SORT_BACK_TO_FRONT);
         }
 
         ASSERT_EQ(ctx.m_BeginCalls, 2);
@@ -1296,7 +1296,7 @@ TEST_F(dmRenderTest, TestRenderListOrder)
     }
     dmRender::RenderListSubmit(m_Context, out, out + n);
     dmRender::RenderListEnd(m_Context);
-    dmRender::DrawRenderList(m_Context, 0, 0, 0);
+    dmRender::DrawRenderList(m_Context, 0, 0, 0, dmRender::SORT_BACK_TO_FRONT);
     ASSERT_EQ(ctx.m_BeginCalls, 1);
     ASSERT_EQ(ctx.m_BatchCalls, 1);
     ASSERT_EQ(ctx.m_EntriesRendered, 1);
@@ -1322,7 +1322,7 @@ TEST_F(dmRenderTest, TestRenderListOrder)
     }
     dmRender::RenderListSubmit(m_Context, out, out + n);
     dmRender::RenderListEnd(m_Context);
-    dmRender::DrawRenderList(m_Context, 0, 0, 0);
+    dmRender::DrawRenderList(m_Context, 0, 0, 0, dmRender::SORT_BACK_TO_FRONT);
     ASSERT_EQ(ctx.m_BeginCalls, 1);
     ASSERT_EQ(ctx.m_BatchCalls, 2);
     ASSERT_EQ(ctx.m_EntriesRendered, 2);
@@ -1349,9 +1349,155 @@ TEST_F(dmRenderTest, TestRenderListDebug)
     dmRender::Square2d(m_Context, 0, 0, 100, 100, Vector4(0,0,0,0));
     dmRender::RenderListEnd(m_Context);
 
-    dmRender::DrawRenderList(m_Context, 0, 0, 0);
+    dmRender::DrawRenderList(m_Context, 0, 0, 0, dmRender::SORT_BACK_TO_FRONT);
     dmRender::DrawDebug2d(m_Context);
     dmRender::DrawDebug3d(m_Context, 0);
+}
+
+struct TestSortFrontToBackCtx
+{
+    int   m_BeginCalls;
+    int   m_BatchCalls;
+    int   m_EndCalls;
+    float m_LastZ;
+    int   m_Count;
+};
+
+static void TestSortFrontToBackDispatch(dmRender::RenderListDispatchParams const & params)
+{
+    TestSortFrontToBackCtx* ctx = (TestSortFrontToBackCtx*) params.m_UserData;
+    switch (params.m_Operation)
+    {
+        case dmRender::RENDER_LIST_OPERATION_BEGIN:
+            ctx->m_BeginCalls++;
+            break;
+        case dmRender::RENDER_LIST_OPERATION_BATCH:
+        {
+            ctx->m_BatchCalls++;
+            for (uint32_t* i = params.m_Begin; i != params.m_End; ++i)
+            {
+                const dmRender::RenderListEntry& e = params.m_Buf[*i];
+                if (e.m_MajorOrder == dmRender::RENDER_ORDER_WORLD)
+                {
+                    if (ctx->m_Count > 0)
+                    {
+                        // For FRONT_TO_BACK we expect decreasing world z (relative to the default back-to-front tests)
+                        ASSERT_LT(e.m_WorldPosition.getZ(), ctx->m_LastZ);
+                    }
+                    ctx->m_LastZ = e.m_WorldPosition.getZ();
+                    ctx->m_Count++;
+                }
+            }
+        } break;
+        default:
+            ctx->m_EndCalls++;
+            break;
+    }
+}
+
+TEST_F(dmRenderTest, TestRenderListSortFrontToBack)
+{
+    // Ensure FRONT_TO_BACK produces the inverse ordering compared to the existing back-to-front behavior
+    TestSortFrontToBackCtx ctx = {};
+    ctx.m_LastZ = 0.0f;
+
+    dmVMath::Matrix4 view = dmVMath::Matrix4::identity();
+    dmVMath::Matrix4 proj = dmVMath::Matrix4::orthographic(0.0f, WIDTH, 0.0f, HEIGHT, 0.1f, 1.0f);
+    dmRender::SetViewMatrix(m_Context, view);
+    dmRender::SetProjectionMatrix(m_Context, proj);
+
+    dmRender::RenderListBegin(m_Context);
+    uint8_t dispatch = dmRender::RenderListMakeDispatch(m_Context, TestSortFrontToBackDispatch, 0, &ctx);
+
+    const uint32_t n = 5;
+    const uint32_t orders[n] = { 2, 5, 1, 4, 3 }; // unsorted insertion order
+
+    dmRender::RenderListEntry* out = dmRender::RenderListAlloc(m_Context, n);
+    for (uint32_t i = 0; i < n; ++i)
+    {
+        dmRender::RenderListEntry& e = out[i];
+        e.m_WorldPosition = Point3(0, 0, (float)orders[i]);
+        e.m_MajorOrder    = dmRender::RENDER_ORDER_WORLD;
+        e.m_MinorOrder    = 0;
+        e.m_TagListKey    = 0;
+        e.m_Order         = orders[i];
+        e.m_BatchKey      = 0;
+        e.m_Dispatch      = dispatch;
+        e.m_UserData      = 0;
+    }
+    dmRender::RenderListSubmit(m_Context, out, out + n);
+    dmRender::RenderListEnd(m_Context);
+
+    dmRender::DrawRenderList(m_Context, 0, 0, 0, dmRender::SORT_FRONT_TO_BACK);
+
+    ASSERT_EQ(ctx.m_BeginCalls, 1);
+    ASSERT_EQ(ctx.m_BatchCalls, 1);
+    ASSERT_EQ(ctx.m_EndCalls, 1);
+    ASSERT_EQ(ctx.m_Count, (int)n);
+}
+
+struct TestSortNoneCtx
+{
+    const uint32_t* m_Expected;
+    uint32_t        m_Count;
+    uint32_t        m_Index;
+};
+
+static void TestSortNoneDispatch(dmRender::RenderListDispatchParams const & params)
+{
+    TestSortNoneCtx* ctx = (TestSortNoneCtx*) params.m_UserData;
+    if (params.m_Operation != dmRender::RENDER_LIST_OPERATION_BATCH)
+        return;
+
+    for (uint32_t* i = params.m_Begin; i != params.m_End; ++i)
+    {
+        const dmRender::RenderListEntry& e = params.m_Buf[*i];
+        if (e.m_MajorOrder != dmRender::RENDER_ORDER_WORLD)
+            continue;
+        ASSERT_LT(ctx->m_Index, ctx->m_Count);
+        ASSERT_EQ((uint32_t)e.m_WorldPosition.getZ(), ctx->m_Expected[ctx->m_Index]);
+        ctx->m_Index++;
+    }
+}
+
+TEST_F(dmRenderTest, TestRenderListSortNoneUsesInsertionOrder)
+{
+    // With SORT_NONE we should iterate entries in insertion order
+    const uint32_t expected[] = { 7, 1, 5, 3, 9 };
+
+    TestSortNoneCtx ctx = {};
+    ctx.m_Expected = expected;
+    ctx.m_Count    = DM_ARRAY_SIZE(expected);
+    ctx.m_Index    = 0;
+
+    dmVMath::Matrix4 view = dmVMath::Matrix4::identity();
+    dmVMath::Matrix4 proj = dmVMath::Matrix4::orthographic(0.0f, WIDTH, 0.0f, HEIGHT, 0.1f, 1.0f);
+    dmRender::SetViewMatrix(m_Context, view);
+    dmRender::SetProjectionMatrix(m_Context, proj);
+
+    dmRender::RenderListBegin(m_Context);
+    uint8_t dispatch = dmRender::RenderListMakeDispatch(m_Context, TestSortNoneDispatch, 0, &ctx);
+
+    dmRender::RenderListEntry* out = dmRender::RenderListAlloc(m_Context, ctx.m_Count);
+    for (uint32_t i = 0; i < ctx.m_Count; ++i)
+    {
+        dmRender::RenderListEntry& e = out[i];
+        e.m_WorldPosition = Point3(0, 0, (float)expected[i]);
+        e.m_MajorOrder    = dmRender::RENDER_ORDER_WORLD;
+        e.m_MinorOrder    = 0;
+        e.m_TagListKey    = 0;
+        e.m_Order         = expected[i];
+        e.m_BatchKey      = 0;
+        e.m_Dispatch      = dispatch;
+        e.m_UserData      = 0;
+    }
+
+    dmRender::RenderListSubmit(m_Context, out, out + ctx.m_Count);
+    dmRender::RenderListEnd(m_Context);
+
+    dmRender::DrawRenderList(m_Context, 0, 0, 0, dmRender::SORT_NONE);
+
+    ASSERT_EQ(ctx.m_Index, ctx.m_Count);
 }
 
 static float Metric(const char* text, int n, bool measure_trailing_space)


### PR DESCRIPTION
You can now choose from the following sort orders when using `render.draw()`:  
- `render.SORT_BACK_TO_FRONT` (default)  
- `render.SORT_FRONT_TO_BACK`  
- `render.SORT_NONE`

Fix https://github.com/defold/defold/issues/3625