### PR TITLE
On opengl the graphics frame start now sets the default framebuffer

### DIFF
--- a/engine/graphics/src/dmsdk/graphics/graphics_opengl.h
+++ b/engine/graphics/src/dmsdk/graphics/graphics_opengl.h
@@ -37,6 +37,14 @@ namespace dmGraphics
      * @return id [type: uint32_t] the OpenGL render target id
      */
 	uint32_t OpenGLGetRenderTargetId(HContext context, HRenderTarget render_target);
+
+    /*#
+     * Get the default framebuffer ID
+     * @name OpenGLGetDefaultFramebufferId
+     * @param context [type: dmGraphics::HContext] the OpenGL context
+     * @return framebuffer [type: uint32_t] the framebuffer id
+     */
+    uint32_t OpenGLGetDefaultFramebufferId(HContext context);
 }
 
 #endif

--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -1662,6 +1662,7 @@ static void LogFrameBufferError(GLenum status)
 #if defined(ANDROID)
         dmPlatform::AndroidBeginFrame(((OpenGLContext*) context)->m_Window);
 #endif
+        glBindFramebuffer(GL_FRAMEBUFFER, dmPlatform::OpenGLGetDefaultFramebufferId());
     }
 
     static void OpenGLFlip(HContext _context)
@@ -3499,6 +3500,11 @@ static void LogFrameBufferError(GLenum status)
         g_Context->m_AssetHandleContainer.Release(render_target);
 
         delete rt;
+    }
+
+    uint32_t OpenGLGetDefaultFramebufferId(HContext context)
+    {
+        return dmPlatform::OpenGLGetDefaultFramebufferId();
     }
 
     static void OpenGLSetRenderTarget(HContext _context, HRenderTarget render_target, uint32_t transient_buffer_types)


### PR DESCRIPTION
This helps when other extensions accidentally leave the wrong framebuffer set.

Also added `dmGraphics::OpenGLGetDefaultFramebufferId(context)` to `dmSDK`

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
