### PR TITLE
Fixed code editor freeze when matching against very long strings

### DIFF
--- a/editor/src/clj/editor/fuzzy_text.clj
+++ b/editor/src/clj/editor/fuzzy_text.clj
@@ -15,7 +15,9 @@
 (ns editor.fuzzy-text
   (:require [clojure.string :as string]
             [util.bit-set :as bit-set]
-            [util.coll :as coll :refer [pair]]))
+            [util.coll :as coll :refer [pair]])
+  (:import [clojure.lang Numbers]
+           [java.util.concurrent.atomic AtomicInteger]))
 
 ;; Sublime Text-style fuzzy text matching.
 ;;
@@ -62,24 +64,49 @@
 (set! *warn-on-reflection* true)
 (set! *unchecked-math* :warn-on-boxed)
 
+(defn- set-matching-index-bits-in-bit-set!
+  "Sets bits in the supplied bit-set to true at each index where the specified
+  code point is found in the string."
+  [bits ^String string ^long ch ^long from-index]
+  (loop [from-index (int from-index)]
+    (let [index (.indexOf string ch from-index)]
+      (when-not (neg? index)
+        (bit-set/set-bit! bits index)
+        (recur (inc index))))))
+
 (defn- case-insensitive-character-indices
   "Returns a bit-set of the indices where the specified code point exists in the
   string. Both upper- and lower-case matches are included."
   [^String string ^long upper-ch ^long lower-ch ^long from-index]
-  (let [upper-ch (int upper-ch)
-        lower-ch (int lower-ch)
-        bits (bit-set/of-capacity (.length string))]
+  (let [bits (bit-set/of-capacity (.length string))]
     (assert (not (Character/isWhitespace upper-ch)))
-    (loop [from-index (int from-index)]
-      (let [upper (.indexOf string upper-ch from-index)
-            lower (.indexOf string lower-ch from-index)]
-        (when-not (and (neg? upper) (neg? lower))
-          (let [index (int (cond (neg? upper) lower
-                                 (neg? lower) upper
-                                 :else (min upper lower)))]
-            (bit-set/set-bit! bits index)
-            (recur (inc index))))))
+    (set-matching-index-bits-in-bit-set! bits string upper-ch from-index)
+    (set-matching-index-bits-in-bit-set! bits string lower-ch from-index)
     bits))
+
+(defn- set-relative-matching-index-bits-in-long
+  "Sets bits in the supplied bit-set to true at each index where the specified
+  code point is found in the string relative to from-index."
+  ^long [^long bits ^String string ^long ch ^long from-index]
+  (let [to-index (min (int (+ from-index Long/SIZE)) (.length string))]
+    (loop [next-index (int from-index)
+           bits bits]
+      (let [index (long (.indexOf string ch next-index to-index))]
+        (if (neg? index)
+          bits
+          (recur (inc index)
+                 (Numbers/setBit bits (- index from-index))))))))
+
+(defn- nearby-case-insensitive-character-indices
+  "Returns a long with bits set on the indices where the specified code point
+  exists in the string relative to from-index. Both upper- and lower-case
+  matches are included."
+  ^long [^String string ^long upper-ch ^long lower-ch ^long from-index]
+  (let [bits (bit-set/of-capacity (.length string))]
+    (assert (not (Character/isWhitespace upper-ch)))
+    (-> bits
+        (set-relative-matching-index-bits-in-long string upper-ch from-index)
+        (set-relative-matching-index-bits-in-long string lower-ch from-index))))
 
 (defn- whitespace-length
   "Counts the number of code points that represent whitespace in a string,
@@ -102,7 +129,8 @@
   [^String upper-pattern ^String lower-pattern ^String string ^long from-index]
   (when-not (or (.isEmpty string)
                 (string/blank? upper-pattern))
-    (let [pattern-length (.length upper-pattern)
+    (let [bit-set-count-volatile (volatile! 0)
+          pattern-length (.length upper-pattern)
           string-length (.length string)]
       (assert (= pattern-length (.length lower-pattern)))
       (loop [pattern-index (int 1)
@@ -124,7 +152,7 @@
                                from-index (if (pos? pattern-whitespace-length)
                                             (+ 2 prev-matching-index)
                                             (inc prev-matching-index))]
-                           (when (not= string-length from-index)
+                           (when (< from-index string-length)
                              (let [upper-ch (.codePointAt upper-pattern pattern-index)
                                    lower-ch (.codePointAt lower-pattern pattern-index)
                                    bits (case-insensitive-character-indices string upper-ch lower-ch from-index)]
@@ -132,7 +160,14 @@
                                  0 nil
                                  1 [(bit-set/or-bits! bits matching-indices)] ; Fast case: mutate the bit-set in place.
                                  (bit-set/transfer bits []
-                                   (map #(bit-set/set-bit matching-indices %)))))))))))))))))
+                                   (map (fn [^long bit]
+                                          (when (< 10000000 (long (vswap! bit-set-count-volatile (fn [^long bit-set-count] (inc bit-set-count)))))
+                                            (throw (ex-info "Too many BitSets!"
+                                                            {:pattern-index pattern-index
+                                                             :lower-ch (char lower-ch)
+                                                             :acc-bits matching-indices
+                                                             :new-bits bits})))
+                                          (bit-set/set-bit matching-indices bit))))))))))))))))))
 
 (defn- every-character-is-letter-or-digit?
   "Returns true if every code point within the specified half-open range
@@ -254,6 +289,130 @@
     nil
     (matching-index-permutations upper-pattern lower-pattern string from-index)))
 
+;; TODO: REMOVE!
+(def stuff (atom []))
+(def ^AtomicInteger watchdog-atomic (AtomicInteger. 0))
+
+(defn- visualize-pattern-index [^long pattern-index pattern-chs]
+  (let [length (count pattern-chs)
+        sb (StringBuilder.)]
+    (loop [index 0]
+      (when (< index length)
+        (let [is-match (= pattern-index index)]
+          (when is-match
+            (.append sb \[))
+          (.appendCodePoint sb (int (nth pattern-chs index)))
+          (when is-match
+            (.append sb \]))
+          (recur (inc index)))))
+    (pair pattern-index (.toString sb))))
+
+(defn- visualize-matching-indices [matching-indices ^String string]
+  (let [length (.length string)
+        sb (StringBuilder.)]
+    (loop [index 0]
+      (when (< index length)
+        (let [is-match (bit-set/bit matching-indices index)]
+          (when is-match
+            (.append sb \[))
+          (.appendCodePoint sb (.codePointAt string index))
+          (when is-match
+            (.append sb \]))
+          (recur (inc index)))))
+    (if (bit-set/empty? matching-indices)
+      []
+      (conj (bit-set/into [] matching-indices)
+            (.toString sb)))))
+
+(defn- match-impl-new
+  [upper-pattern-chs lower-pattern-chs ^String string ^long from-index]
+  (reset! stuff [])
+  (.set watchdog-atomic 0)
+  (let [pattern-length (count upper-pattern-chs)]
+    (assert (= pattern-length (count lower-pattern-chs)))
+    (let [string-length (.length string)
+          best-score-atomic (AtomicInteger. Integer/MAX_VALUE)
+          best-matching-indices (bit-set/of-capacity string-length)
+          candidate-matching-indices (bit-set/of-capacity string-length)
+          search-start-indices (int-array pattern-length 0)
+
+          per-character-indices
+          (mapv (fn [^long upper-ch ^long lower-ch]
+                  (case-insensitive-character-indices string upper-ch lower-ch from-index))
+                upper-pattern-chs
+                lower-pattern-chs)]
+
+      (loop [tick-index-in-pattern (int 0)
+             ingress "Begin."]
+        (swap!
+          stuff conj
+          {:ingress ingress
+           :tick-index-in-pattern (visualize-pattern-index tick-index-in-pattern lower-pattern-chs)
+           :best-score (.get best-score-atomic)
+           :best-matching-indices (visualize-matching-indices best-matching-indices string)
+           :candidate-matching-indices (visualize-matching-indices candidate-matching-indices string)
+           :search-start-indices (into [] search-start-indices)})
+        (when (< 10000000 (.incrementAndGet watchdog-atomic))
+          (throw (ex-info "Watchdog tripped."
+                          {:tick-index-in-pattern tick-index-in-pattern})))
+        (cond
+          (= pattern-length tick-index-in-pattern)
+          ;; We have a fully formed candidate.
+          (let [candidate-score (score string from-index candidate-matching-indices)
+                best-score (.get best-score-atomic)]
+            (if (< candidate-score best-score)
+              ;; We're the new best match.
+              ;; Register it, but keep searching for a better match at the
+              ;; final position. Yes, the one we found is the closest, but a
+              ;; later match after a word boundary could score even better.
+              (let [last-matched-index-in-string (bit-set/last-set-bit candidate-matching-indices)
+                    pending-tick-index-in-pattern (dec tick-index-in-pattern)]
+                (.set best-score-atomic candidate-score)
+                (bit-set/assign! best-matching-indices candidate-matching-indices)
+                (bit-set/clear-bit! candidate-matching-indices last-matched-index-in-string)
+                (recur pending-tick-index-in-pattern
+                       "We're the new best match."))
+
+              ;; We're no better than the previous best match.
+              (let [last-matched-index-in-string (bit-set/last-set-bit candidate-matching-indices)
+                    pending-tick-index-in-pattern (dec tick-index-in-pattern)]
+                (bit-set/clear-bit! candidate-matching-indices last-matched-index-in-string)
+                (recur pending-tick-index-in-pattern
+                       "We're no better than the previous best match."))))
+
+          (neg? tick-index-in-pattern)
+          ;; We've checked every permutation. We're done.
+          (when-not (bit-set/empty? best-matching-indices)
+            (let [best-score (.get best-score-atomic)]
+              (pair best-score best-matching-indices)))
+
+          :else
+          ;; Still matching...
+          (let [search-start-index (aget search-start-indices tick-index-in-pattern)
+                character-indices-in-string (per-character-indices tick-index-in-pattern)
+                matching-index-in-string (bit-set/next-set-bit character-indices-in-string search-start-index)]
+            (if (neg? matching-index-in-string)
+              ;; This is a dead branch.
+              ;; Backtrack by popping the last matched index from the candidate
+              ;; and moving the tick-index back one step.
+              (let [last-matched-index-in-string (bit-set/last-set-bit candidate-matching-indices)
+                    pending-tick-index-in-pattern (dec tick-index-in-pattern)]
+                (when-not (neg? last-matched-index-in-string)
+                  (bit-set/clear-bit! candidate-matching-indices last-matched-index-in-string))
+                (aset search-start-indices tick-index-in-pattern (int 0)) ; Not necessary, but leaving the original value can be confusing while debugging.
+                (recur pending-tick-index-in-pattern
+                       "Backtrack by popping the last matched index from the candidate and moving the tick-index back one step."))
+
+              ;; We matched a character.
+              (let [next-search-start-index (inc matching-index-in-string)
+                    pending-tick-index-in-pattern (inc tick-index-in-pattern)]
+                (bit-set/set-bit! candidate-matching-indices matching-index-in-string)
+                (aset search-start-indices tick-index-in-pattern next-search-start-index)
+                (when (not= pattern-length pending-tick-index-in-pattern)
+                  (aset search-start-indices pending-tick-index-in-pattern next-search-start-index))
+                (recur pending-tick-index-in-pattern
+                       "We matched a character.")))))))))
+
 (defn prepare-pattern
   "Given a pattern string, returns a trimmed and case-agnostic prepared-pattern
   for use with the match functions."
@@ -261,6 +420,25 @@
   (let [trimmed-pattern (string/trim pattern)]
     (pair (string/upper-case trimmed-pattern)
           (string/lower-case trimmed-pattern))))
+
+(defn- map-code-points [f ^String string]
+  (stream-into! (vector-of :int)
+                (map f)
+                (.codePoints string)))
+
+(defn prepare-pattern-new
+  "Given a pattern string, returns a trimmed and case-agnostic prepared-pattern
+  for use with the match functions."
+  [^String pattern]
+  (let [trimmed-pattern (string/trim pattern)]
+    (pair (map-code-points
+            (fn [^long ch]
+              (Character/toUpperCase ch))
+            trimmed-pattern)
+          (map-code-points
+            (fn [^long ch]
+              (Character/toLowerCase ch))
+            trimmed-pattern))))
 
 (defn empty-prepared-pattern?
   "Returns true if the supplied prepared-pattern is empty."
@@ -277,6 +455,16 @@
   [prepared-pattern ^String string]
   (let [[upper-pattern lower-pattern] prepared-pattern]
     (match-impl upper-pattern lower-pattern string 0)))
+
+(defn match-new
+  "Performs a fuzzy text match against a string using the prepared-pattern.
+  Returns a two-element vector of [score, matching-indices], or nil if the
+  pattern is empty or there is no match. The matching-indices bit-set will
+  contain the character indices in the string that matched the pattern in
+  sequential order. A lower score represents a better match."
+  [prepared-pattern ^String string]
+  (let [[upper-pattern-chs lower-pattern-chs] prepared-pattern]
+    (match-impl-new upper-pattern-chs lower-pattern-chs string 0)))
 
 (defn- apply-filename-bonus
   "Applies a bonus for a match on the filename part of a path."
@@ -313,6 +501,22 @@
             path-match))
         path-match))))
 
+(defn match-path-new
+  "Convenience function for matching against paths. The match is performed
+  against the entire path as well as just the file name. We return the
+  best-scoring match of the two, or nil if there was no match."
+  [prepared-pattern ^String path]
+  (let [[upper-pattern-chs lower-pattern-chs] prepared-pattern]
+    (when-some [path-match (match-impl-new upper-pattern-chs lower-pattern-chs path 0)]
+      (if-some [last-slash-index (string/last-index-of path \/)]
+        (let [name-index (inc ^long last-slash-index)]
+          (if-some [name-match
+                    (some->> (match-impl-new upper-pattern-chs lower-pattern-chs path name-index)
+                             (apply-filename-bonus path name-index))]
+            (best-match name-match path-match)
+            path-match))
+        path-match))))
+
 (defn runs
   "Given a string length and a bit-set of matching-indices inside that string,
   returns a vector of character ranges that should be highlighted or not.
@@ -337,3 +541,48 @@
                          (conj runs [false (peek run) matching-index])
                          runs)
                        [true matching-index (inc matching-index)])))))))
+
+(comment
+  ;; n e e d l e
+  ;; - - - - - -
+  ;; 0 - - - - -
+  ;; 0 0 - - - -
+  ;; 0 0 0 - - -
+  ;; 0 0 0 0 - -
+  ;; 0 0 0 0 0 -
+  ;; 0 0 0 0 0 0
+  ;; 0 0 0 0 0 1
+  ;; 0 0 0 0 0 2
+  ;; 0 0 0 0 0 - No hit. Pop bit & dec outer index.
+  ;; 0 0 0 0 1 -
+  ;; 0 0 0 0 1 0
+  ;; 0 0 0 0 1 1
+  ;; 0 0 0 0 1 - No hit.
+  ;; 0 0 0 0 - - No hit.
+  ;; 0 0 0 1 - -
+  ;; 0 0 0 1 0 -
+  ;; 0 0 0 1 0 0
+  ;; 0 0 0 1 0 1
+  ;; 0 0 0 1 0 - No hit.
+  ;; 0 0 0 1 1 -
+  ;; 0 0 0 1 1 0
+  ;; 0 0 0 1 1 - No hit.
+  )
+
+(comment
+  ["XM" "X0mM000000"]
+  ["GDA" "GdDA"])
+
+(defn check! []
+  (let [[needle haystack] ["GDA" "GdDA"]
+        [upper-pattern-chs lower-pattern-chs] (prepare-pattern-new needle)
+        from-index 0]
+    (match-impl-new upper-pattern-chs lower-pattern-chs haystack from-index)))
+
+(comment
+  (do
+    (try
+      (check!)
+      (catch Exception e
+        (prn (ex-message e))))
+    @stuff))

--- a/editor/src/clj/editor/lsp/server.clj
+++ b/editor/src/clj/editor/lsp/server.clj
@@ -263,6 +263,7 @@
                   workspace (g/node-value project :workspace evaluation-context)
                   root (g/raw-property-value (:basis evaluation-context) workspace :root)]
               {:runtime {:version "Lua 5.1" :pathStrict true}
+               :completion {:workspaceWord false}
                :diagnostics {:globals (-> lua/defined-globals
                                           (into (lua/extract-globals-from-completions completions))
                                           (into (lua/extract-globals-from-completions lua/editor-completions)))}

--- a/editor/test/editor/fuzzy_text_reference.clj
+++ b/editor/test/editor/fuzzy_text_reference.clj
@@ -1,0 +1,232 @@
+;; Copyright 2020-2025 The Defold Foundation
+;; Copyright 2014-2020 King
+;; Copyright 2009-2014 Ragnar Svensson, Christian Murray
+;; Licensed under the Defold License version 1.0 (the "License"); you may not use
+;; this file except in compliance with the License.
+;;
+;; You may obtain a copy of the License, together with FAQs at
+;; https://www.defold.com/license
+;;
+;; Unless required by applicable law or agreed to in writing, software distributed
+;; under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+;; CONDITIONS OF ANY KIND, either express or implied. See the License for the
+;; specific language governing permissions and limitations under the License.
+
+(ns editor.fuzzy-text-reference
+  (:require [clojure.string :as string]
+            [clojure.test :refer :all]
+            [util.coll :refer [pair]]))
+
+(set! *warn-on-reflection* true)
+(set! *unchecked-math* :warn-on-boxed)
+
+(defn- case-insensitive-character-indices
+  "Returns a vector of indices where the specified code point exists in the
+  string. Both upper- and lower-case matches are returned."
+  [^String string ^long ch ^long from-index]
+  (assert (not (Character/isWhitespace ch)))
+  (loop [from-index from-index
+         indices (transient [])]
+    (let [upper (.indexOf string (Character/toUpperCase ch) from-index)
+          lower (.indexOf string (Character/toLowerCase ch) from-index)]
+      (if (and (neg? upper) (neg? lower))
+        (persistent! indices)
+        (let [^long index (cond (neg? upper) lower
+                                (neg? lower) upper
+                                :else (min upper lower))]
+          (recur (inc index)
+                 (conj! indices index)))))))
+
+(defn- whitespace-length
+  "Counts the number of code points that represent whitespace in a string,
+  starting at from-index and counting until the next non-whitespace code point
+  or until it reaches string-length."
+  ^long [^String string ^long string-length ^long from-index]
+  (loop [index from-index
+         whitespace-length 0]
+    (if (or (= string-length index)
+            (not (Character/isWhitespace (.codePointAt string index))))
+      whitespace-length
+      (recur (inc index)
+             (inc whitespace-length)))))
+
+(defn- matching-index-permutations
+  "Returns a sequence of all permutations of indices inside the string where the
+  pattern characters appear in order. I.e. 'abc' appears in 'abbc' as [0 1 3]
+  and [0 2 3]. The from-index parameter can be used to limit the starting point
+  in the string."
+  [^String pattern ^String string ^long from-index]
+  (when-not (or (empty? string)
+                (string/blank? pattern))
+    (let [pattern (string/trim pattern)
+          pattern-length (.length pattern)
+          string-length (.length string)]
+      (loop [pattern-index 1
+             matching-index-permutations (mapv vector (case-insensitive-character-indices string (.codePointAt pattern 0) from-index))]
+        (if (= pattern-length pattern-index)
+          matching-index-permutations
+          (let [pattern-whitespace-length (whitespace-length pattern pattern-length pattern-index)
+                pattern-index (+ pattern-index pattern-whitespace-length)]
+            (recur (inc pattern-index)
+                   (into []
+                         (mapcat (fn [matching-indices]
+                                   (let [^long prev-matching-index (peek matching-indices)
+                                         from-index (if (pos? pattern-whitespace-length)
+                                                      (+ 2 prev-matching-index)
+                                                      (inc prev-matching-index))]
+                                     (when (not= string-length from-index)
+                                       (mapv (partial conj matching-indices)
+                                             (case-insensitive-character-indices string (.codePointAt pattern pattern-index) from-index))))))
+                         matching-index-permutations))))))))
+
+(defn- every-character-is-letter-or-digit?
+  "Returns true if every code point within the specified half-open range
+  represent either a letter or digit."
+  [^String string ^long from-index ^long to-index]
+  (cond (= to-index from-index) true
+        (not (Character/isLetterOrDigit (.codePointAt string from-index))) false
+        :else (recur string (inc from-index) to-index)))
+
+(defn- any-character-is-upper-case?
+  "Returns true if any code point within the specified half-open range represent
+  an upper-case character."
+  [^String string ^long from-index ^long to-index]
+  (cond (= to-index from-index) false
+        (Character/isUpperCase (.codePointAt string from-index)) true
+        :else (recur string (inc from-index) to-index)))
+
+(defn- prev-boundary-index
+  "Finds the previous boundary in a string. Starts at range-end (exclusive) and
+  iterates over each code point until it reaches a boundary character or
+  just past range-start. This means -1 is returned for no match if range-start
+  is zero. Used for scoring."
+  ^long [^String string ^long range-start ^long range-end]
+  (let [index (dec range-end)]
+    (cond (< index range-start) index
+          (Character/isLetterOrDigit (.codePointAt string index)) (recur string range-start index)
+          :else index)))
+
+(defn- score
+  "Scores the matching indices against the string that produced them. A lower
+  score is better. The from-index parameter can be used to limit the starting
+  point in the string. Typically several sequences of matching indices are
+  obtained with the matching-index-permutations function, then scored here."
+  ^long [^String string ^long from-index matching-indices]
+  (assert (not (empty? matching-indices)))
+  (loop [matching-indices matching-indices
+         prev-matching-index Long/MIN_VALUE
+         prev-match-type nil
+         streak-length 0
+         score 0]
+    (if (empty? matching-indices)
+      score
+      (let [matching-index (long (first matching-indices))]
+        (if (= from-index matching-index)
+
+          ;; We're matching the very first character in the considered string.
+          ;; It does not count towards the score. This gives a very slight
+          ;; scoring edge matches that include the start of the string.
+          (recur (next matching-indices)
+                 matching-index
+                 :string-start
+                 0
+                 0)
+
+          ;; The first matching character is at least one character in.
+          ;; This means we can safely examine the character before the match.
+          (let [before-matching-index (dec matching-index)
+                after-prev-match-index (if (= Long/MIN_VALUE prev-matching-index) from-index (inc prev-matching-index))
+                ch (.codePointAt string matching-index)
+                prev-ch (.codePointAt string before-matching-index)
+                match-type (cond
+                             (and (Character/isUpperCase ch)
+                                  (Character/isLetterOrDigit prev-ch)
+                                  (not (Character/isUpperCase prev-ch)))
+                             :camel-hump
+
+                             (and (Character/isLetterOrDigit ch)
+                                  (not (Character/isLetterOrDigit prev-ch)))
+                             :word-boundary)
+                streak? (or (= prev-matching-index before-matching-index)
+                            (case match-type
+                              nil false
+
+                              :camel-hump
+                              (and (case prev-match-type
+                                     :string-start (Character/isUpperCase (.codePointAt string from-index))
+                                     :camel-hump true
+                                     false)
+                                   (not (any-character-is-upper-case? string after-prev-match-index before-matching-index)))
+
+                              :word-boundary
+                              (case prev-match-type
+                                (:string-start :word-boundary)
+                                (every-character-is-letter-or-digit? string after-prev-match-index before-matching-index)
+                                false)))
+                streak-length (if streak? (inc streak-length) 0)]
+            (recur (next matching-indices)
+                   matching-index
+                   match-type
+                   streak-length
+                   (if streak?
+                     (if (< streak-length 2) (inc score) score)
+                     (let [scored-range-start (if (= Long/MIN_VALUE prev-matching-index)
+                                                (prev-boundary-index string from-index matching-index)
+                                                prev-matching-index)
+                           added-score (- matching-index scored-range-start)]
+                       (+ score added-score))))))))))
+
+(defn- best-match
+  "Takes two matches returned from the match function and returns the one that
+  is best match. Returns the second match if given nil as the first argument."
+  [match-a [^long score-b :as match-b]]
+  (let [^long score-a (if match-a (first match-a) Long/MAX_VALUE)]
+    (if (<= score-a score-b)
+      match-a
+      match-b)))
+
+(defn match
+  "Performs a fuzzy text match against a string using the specified pattern.
+  Returns a two-element vector of [score, matching-indices], or nil if the
+  pattern is empty or there is no match. The matching-indices vector will
+  contain the character indices in string that matched the pattern in sequential
+  order. A lower score represents a better match."
+  ([^String pattern ^String string]
+   (match pattern string 0))
+  ([^String pattern ^String string ^long from-index]
+   (transduce (map (fn [matching-indices]
+                     (pair (score string from-index matching-indices)
+                           matching-indices)))
+              (completing best-match)
+              nil
+              (matching-index-permutations pattern string from-index))))
+
+(defn- apply-filename-bonus
+  "Applies a bonus for a match on the filename part of a path."
+  [^String path ^long basename-start [^long score matched-indices]]
+  (let [basename-end (.lastIndexOf path ".")
+        basename-end (if (neg? basename-end) (.length path) basename-end)
+        basename-length (- basename-end basename-start)
+        ^long basename-streak (loop [count 0]
+                                (let [matched-index (get matched-indices count)]
+                                  (if (and (not= matched-index basename-end)
+                                           (= matched-index (+ count basename-start)))
+                                    (recur (inc count))
+                                    count)))
+        basename-match-adjustment (if (pos? basename-streak)
+                                    (quot (* 10 basename-streak) basename-length)
+                                    0)]
+    [(- score basename-match-adjustment 2) matched-indices]))
+
+(defn match-path
+  "Convenience function for matching against paths. The match function is
+  called for the entire path as well as just the file name. We return the
+  best-scoring match of the two, or nil if there was no match."
+  [^String pattern ^String path]
+  (when-some [path-match (match pattern path)]
+    (if-some [last-slash-index (string/last-index-of path \/)]
+      (let [name-index (inc ^long last-slash-index)]
+        (if-some [name-match (some->> (match pattern path name-index) (apply-filename-bonus path name-index))]
+          (best-match name-match path-match)
+          path-match))
+      path-match)))

--- a/editor/test/editor/fuzzy_text_reference.clj
+++ b/editor/test/editor/fuzzy_text_reference.clj
@@ -17,6 +17,11 @@
             [clojure.test :refer :all]
             [util.coll :refer [pair]]))
 
+;; Reference implementation of the fuzzy text matching algorithm. This
+;; implementation was used in the past but turned out to be too slow and memory
+;; hungry in some real-world scenarios. We now use it as ground truth for the
+;; tests covering the new algorithm.
+
 (set! *warn-on-reflection* true)
 (set! *unchecked-math* :warn-on-boxed)
 

--- a/editor/test/editor/fuzzy_text_test.clj
+++ b/editor/test/editor/fuzzy_text_test.clj
@@ -165,6 +165,10 @@
     (is (< (score "at" "abstract_tree")
            (score "at" "abstract_syntax_tree")))))
 
+(deftest empty-prepared-pattern?-test
+  (is (true? (fuzzy-text/empty-prepared-pattern? (fuzzy-text/prepare-pattern ""))))
+  (is (false? (fuzzy-text/empty-prepared-pattern? (fuzzy-text/prepare-pattern "a")))))
+
 (deftest runs-test
   (are [length matching-indices expected]
     (is (= expected (fuzzy-text/runs length (bit-set/from matching-indices))))
@@ -285,7 +289,20 @@
      :indices (bit-set/into (vector-of :int) matching-indices)
      :score score}))
 
-(deftest problematic-cases-test
+;; -----------------------------------------------------------------------------
+
+(deftest turkish-capital-i-test
+  (is (= [0 (bit-set/of 0)] (match "İ" "İ")))
+  (is (= [0 (bit-set/of 0)] (match "İ" "i"))))
+
+(deftest no-freeze-test
+  (let [needle "MYVARLONG"
+        haystack "yyyZhniZzzzZbarAnmrAgneBlryCaveDroeGkerGrjuGuruGgnaHinaHrbeHariHadnKanaKooaLntaLmylMayrOlmaTuleTiahTtbiTopoBiarBsnaCrehCihtErmhKgnoMrmyMmagOrnuRhniScrySaahTiiiYtrsDhtoGlatIdhuBonaHglgTbgaTtrpCbmiLbniLamsOwahSelaTragUiguBtpoCgalGrahKulaToepXolySgnfTilaBxusXookNgahPxnhPiraCmahCilaKcpeLicyLidyLkclOgnjRruaSdnuSiiaVtsvAumaBpygEimrAilhPitrPavaJihtKusiLietMbraShkrOrmaSanaLtvaTktaBharBdnaMmkaCcreMoreMdrlPdrhSaroSrkaTssaBbhgAlpuDablEnarGjohKdniSaniLjhaMinaMdneMidoMoorMtabNbraNmrePgnmHmlaPcuaPplhPddiShriTaraWmohAwulHrtaHtluMgnuHwngSmldAskhBcraMegsOgnaTaweNmnoGuhsNoyoSbnaZrgoDgnoGghoRakaMfdeMogoSdgoSmylEdnaNpnmHohcWsrhCkaiDstiKizeYnmpCrguOasnTotoThtiVhtmZiwaKmgaN"
+        [score matching-indices] (match needle haystack)]
+    (is (= 129 score))
+    (is (= (bit-set/of 17 26 29 50 56 75 87 113 128) matching-indices))))
+
+(deftest past-failures-test
   (doseq [[needle haystack]
           [["XM" "X0mM000000"]
            ["GDA" "GdDA"]

--- a/editor/test/editor/fuzzy_text_test.clj
+++ b/editor/test/editor/fuzzy_text_test.clj
@@ -13,9 +13,15 @@
 ;; specific language governing permissions and limitations under the License.
 
 (ns editor.fuzzy-text-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.string :as string]
+            [clojure.test :refer :all]
+            [clojure.test.check.clojure-test :refer [defspec]]
+            [clojure.test.check.generators :as gen]
+            [clojure.test.check.properties :as prop]
             [editor.fuzzy-text :as fuzzy-text]
-            [util.bit-set :as bit-set]))
+            [editor.fuzzy-text-reference :as fuzzy-text-ref]
+            [util.bit-set :as bit-set]
+            [util.coll :refer [pair]]))
 
 (set! *warn-on-reflection* true)
 (set! *unchecked-math* :warn-on-boxed)
@@ -175,3 +181,126 @@
     4 [0 1] [[true 0 2] [false 2 4]]
     4 [1 2] [[false 0 1] [true 1 3] [false 3 4]]
     4 [2 3] [[false 0 2] [true 2 4]]))
+
+;; -----------------------------------------------------------------------------
+;; Verify behavior against slower reference implementation.
+;; -----------------------------------------------------------------------------
+
+(defn- ref-match [pattern string]
+  (when-some [[score matched-indices] (fuzzy-text-ref/match pattern string)]
+    (pair score (bit-set/from (count matched-indices) matched-indices))))
+
+(defspec match-impl-equates-to-reference-impl 10000
+  (let [needle-char-gen
+        (gen/frequency
+          [[1 (gen/return \space)]
+           [6 gen/char-alphanumeric]])
+
+        needle-gen
+        (gen/fmap
+          string/join
+          (gen/vector needle-char-gen 1 10))
+
+        haystack-gen
+        (gen/fmap
+          string/join
+          (gen/vector gen/char-alphanumeric 1 100))]
+
+    (prop/for-all
+      [needle needle-gen
+       haystack haystack-gen]
+      (= (ref-match needle haystack)
+         (match needle haystack)))))
+
+(defn- ref-match-path [pattern string]
+  (when-some [[score matched-indices] (fuzzy-text-ref/match-path pattern string)]
+    (pair score (bit-set/from (count matched-indices) matched-indices))))
+
+(defspec match-path-impl-equates-to-reference-impl 10000
+  (let [needle-char-gen
+        (gen/frequency
+          [[1 (gen/return \space)]
+           [1 (gen/elements [\- \. \/ \_])]
+           [5 gen/char-alphanumeric]])
+
+        needle-gen
+        (gen/fmap
+          string/join
+          (gen/vector needle-char-gen 1 10))
+
+        path-segment-char-gen
+        (gen/frequency
+          [[1 (gen/elements [\- \. \_ \space])]
+           [10 gen/char-alphanumeric]])
+
+        path-segment-string-gen
+        (gen/fmap
+          string/join
+          (gen/vector
+            path-segment-char-gen 1 20))
+
+        regular-path-segment-gen
+        (gen/such-that
+          #(not (#{"." ".."} %))
+          path-segment-string-gen
+          50)
+
+        hidden-path-segment-gen
+        (gen/fmap
+          #(str \. %)
+          regular-path-segment-gen)
+
+        dot-path-segment-gen
+        (gen/elements ["." ".."])
+
+        path-segment-gen
+        (gen/frequency
+          [[1 dot-path-segment-gen]
+           [2 hidden-path-segment-gen]
+           [8 regular-path-segment-gen]])
+
+        path-gen
+        (gen/let [segments (gen/vector path-segment-gen 1 10)]
+          (str \/ (string/join "/" segments)))]
+
+    (prop/for-all
+      [needle needle-gen
+       haystack path-gen]
+      (= (ref-match-path needle haystack)
+         (match-path needle haystack)))))
+
+(defn- highlight [[score matching-indices] ^String string]
+  (let [length (.length string)
+        ^StringBuilder sb (StringBuilder.)]
+    (loop [index 0]
+      (when (< index length)
+        (let [is-match (bit-set/bit matching-indices index)]
+          (when is-match
+            (.append sb \[))
+          (.appendCodePoint sb (.codePointAt string index))
+          (when is-match
+            (.append sb \]))
+          (recur (inc index)))))
+    {:text (.toString sb)
+     :indices (bit-set/into (vector-of :int) matching-indices)
+     :score score}))
+
+(deftest problematic-cases-test
+  (doseq [[needle haystack]
+          [["XM" "X0mM000000"]
+           ["GDA" "GdDA"]
+           ["0 0" "0"]
+           [" " "0"]
+           ["J E" "J0eE"]
+           ["M C" "0mM0C"]]]
+    (let [expected (some-> (ref-match needle haystack) (highlight haystack))
+          actual (some-> (match needle haystack) (highlight haystack))]
+      (is (= expected actual)))))
+
+(comment
+  ;; Use to visualize differences when there are discrepancies.
+  (let [[needle haystack] ["M C" "0mM0C"]]
+    (let [old (ref-match needle haystack)
+          new (match needle haystack)]
+      {:expected (some-> old (highlight haystack))
+       :actual (some-> new (highlight haystack))})))

--- a/editor/test/util/bit_set_test.clj
+++ b/editor/test/util/bit_set_test.clj
@@ -13,6 +13,7 @@
 ;; specific language governing permissions and limitations under the License.
 
 (ns util.bit-set-test
+  (:refer-clojure :exclude [bit-test])
   (:require [clojure.test :refer :all]
             [util.bit-set :as bit-set])
   (:import [java.util BitSet]))
@@ -113,12 +114,30 @@
   (is (not= (bit-set/of) (bit-set/of 0)))
   (is (not= (bit-set/of 0) (bit-set/of 1))))
 
+(deftest assign!-test
+  (doseq [source [(bit-set/of)
+                  (bit-set/of 0)
+                  (bit-set/from (range 1 5))]
+          target [(bit-set/of)
+                  (bit-set/of 10)
+                  (bit-set/from (range 3 8))]]
+    (is (identical? target (bit-set/assign! target source)))
+    (is (= source target))))
+
 (deftest cardinality-test
   (is (= 0 (bit-set/cardinality (bit-set/of))))
   (is (= 1 (bit-set/cardinality (bit-set/of 0))))
   (is (= 2 (bit-set/cardinality (bit-set/of 0 1))))
   (is (= 4 (bit-set/cardinality (bit-set/of 1 3 5 7))))
   (is (= 100 (bit-set/cardinality (bit-set/from (range 100))))))
+
+(deftest bit-test
+  (is (false? (bit-set/bit (bit-set/of) 0)))
+  (is (true? (bit-set/bit (bit-set/of 0) 0)))
+  (is (false? (bit-set/bit (bit-set/of 0) 1)))
+  (is (false? (bit-set/bit (bit-set/of 1) 0)))
+  (is (true? (bit-set/bit (bit-set/of 1) 1)))
+  (is (thrown? IndexOutOfBoundsException (bit-set/bit (bit-set/of 0) -1))))
 
 (deftest set-bit-test
   (letfn [(check! [expected-values original index]
@@ -252,6 +271,32 @@
   (is (seq? (bit-set/seq (bit-set/of 0))))
   (is (= [0] (bit-set/seq (bit-set/of 0))))
   (is (= [2 3 4] (bit-set/seq (bit-set/of 2 3 4)))))
+
+(deftest reduce-test
+  (testing "Without init."
+    (is (= (reduce + (range 1 5))
+           (bit-set/reduce + (bit-set/from (range 1 5)))))
+    (is (= (reduce * (range 1 5))
+           (bit-set/reduce * (bit-set/from (range 1 5))))))
+
+  (testing "With init."
+    (is (= (reduce + 10 (range 1 5))
+           (bit-set/reduce + 10 (bit-set/from (range 1 5)))))
+    (is (= (reduce * 10 (range 1 5))
+           (bit-set/reduce * 10 (bit-set/from (range 1 5)))))))
+
+(deftest transduce-test
+  (testing "Without init."
+    (is (= (transduce (filter odd?) + (range 1 5))
+           (bit-set/transduce (filter odd?) + (bit-set/from (range 1 5)))))
+    (is (= (transduce (filter odd?) * (range 1 5))
+           (bit-set/transduce (filter odd?) * (bit-set/from (range 1 5))))))
+
+  (testing "With init."
+    (is (= (transduce (filter odd?) + 10 (range 1 5))
+           (bit-set/transduce (filter odd?) + 10 (bit-set/from (range 1 5)))))
+    (is (= (transduce (filter odd?) * 10 (range 1 5))
+           (bit-set/transduce (filter odd?) * 10 (bit-set/from (range 1 5)))))))
 
 (deftest into-test
   (testing "bit-set into vector."


### PR DESCRIPTION
* Rewrote the fuzzy text matching algorithm to use less memory and perform matches faster.
* Fixed a freeze that could occur in the code editor when attempting to perform a fuzzy text match against very long autocomplete suggestions originating from non-Lua files in some projects.
* Fixed an exception that would occur if a fuzzy text search term included the Turkish capital letter I (`İ`) on a machine running under a non-Turkish locale setting.

Fixes #11191.

### Technical changes
* Disabled workspace word autocomplete suggestions from the built-in Lua LSP server.