### PR TITLE
Added `start_time` and `start_frame` parameters for `sound.play()`

### DIFF
--- a/engine/gamesys/proto/gamesys/gamesys_ddf.proto
+++ b/engine/gamesys/proto/gamesys/gamesys_ddf.proto
@@ -91,6 +91,10 @@ message PlaySound
     optional float pan      = 3 [default=0.0];
     optional float speed    = 4 [default=1.0];
     optional uint32 play_id = 5 [default=0xffffffff]; // Must be same as dmSound::INVALID_PLAY_ID
+    // Start playback from an offset. Only one of these should be set.
+    // If both are set (e.g. via manual message), start_frame takes precedence.
+    optional float  start_time  = 6 [default=0.0]; // seconds
+    optional uint32 start_frame = 7 [default=0];   // frames (samples per channel)
 }
 
 message StopSound

--- a/engine/gamesys/src/gamesys/components/comp_sound.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sound.cpp
@@ -378,6 +378,25 @@ namespace dmGameSystem
                     dmSound::SetParameter(entry.m_SoundInstance, dmSound::PARAMETER_SPEED, dmVMath::Vector4(speed, 0, 0, 0));
                     dmSound::SetLooping(entry.m_SoundInstance, sound->m_Looping, (sound->m_Looping && !sound->m_Loopcount) ? -1 : sound->m_Loopcount ); // loopcounter semantics differ a bit from loopcount. If -1, it means loopforever, otherwise it contains the # of loops remaining.
 
+                    // Apply start offset before playback (initial-only; not re-applied on loops)
+                    // If both are provided via message, start_frame wins
+                    if (play_sound->m_StartFrame != 0)
+                    {
+                        dmSound::Result rskip = dmSound::SetStartFrame(entry.m_SoundInstance, play_sound->m_StartFrame);
+                        if (rskip != dmSound::RESULT_OK)
+                        {
+                            dmLogWarning("Failed to set start_frame offset (%d)", rskip);
+                        }
+                    }
+                    else if (play_sound->m_StartTime > 0.0f)
+                    {
+                        dmSound::Result rskip = dmSound::SetStartTime(entry.m_SoundInstance, play_sound->m_StartTime);
+                        if (rskip != dmSound::RESULT_OK)
+                        {
+                            dmLogWarning("Failed to set start_time offset (%d)", rskip);
+                        }
+                    }
+
                     entry.m_Listener = params.m_Message->m_Sender;
                     uintptr_t callback = params.m_Message->m_UserData2;
                     if (callback == UINTPTR_MAX)

--- a/engine/sound/src/sound.cpp
+++ b/engine/sound/src/sound.cpp
@@ -1094,6 +1094,70 @@ namespace dmSound
         return RESULT_OK;
     }
 
+    static inline uint32_t GetSkipStrideBytes(const dmSoundCodec::Info& info)
+    {
+        // Match stride logic used in mixing when calling Decode/Skip
+        // If decoder delivers float non-interleaved (or mono), use sizeof(float) per frame
+        // Otherwise use interleaved stride: channels * (bits/8)
+        if (info.m_BitsPerSample == 32 && (!info.m_IsInterleaved || info.m_Channels == 1))
+            return (uint32_t)sizeof(float);
+        return (uint32_t)(info.m_Channels * (info.m_BitsPerSample / 8));
+    }
+
+    static Result SkipToStartFrameNoLock(HSoundInstance sound_instance, uint64_t start_frame)
+    {
+        DM_PROFILE(__FUNCTION__);
+        dmSoundCodec::Info info;
+        dmSoundCodec::GetInfo(g_SoundSystem->m_CodecContext, sound_instance->m_Decoder, &info);
+
+        uint64_t total_bytes = start_frame * (uint64_t)GetSkipStrideBytes(info);
+        while (total_bytes > 0)
+        {
+            uint32_t chunk = (uint32_t)dmMath::Min<uint64_t>(total_bytes, 1ULL << 30);
+            uint32_t skipped = 0;
+            dmSoundCodec::Result r = dmSoundCodec::Skip(g_SoundSystem->m_CodecContext, sound_instance->m_Decoder, chunk, &skipped);
+            if (r == dmSoundCodec::RESULT_END_OF_STREAM)
+            {
+                break;
+            }
+            if (r != dmSoundCodec::RESULT_OK)
+            {
+                return RESULT_INVALID_STREAM_DATA;
+            }
+            if (skipped == 0)
+            {
+                break;
+            }
+            total_bytes -= skipped;
+        }
+        return RESULT_OK;
+    }
+
+    Result SetStartFrame(HSoundInstance sound_instance, uint32_t start_frame)
+    {
+        if (!g_SoundSystem)
+            return RESULT_OK;
+        DM_MUTEX_OPTIONAL_SCOPED_LOCK(g_SoundSystem->m_Mutex);
+        return SkipToStartFrameNoLock(sound_instance, (uint64_t)start_frame);
+    }
+
+    Result SetStartTime(HSoundInstance sound_instance, float start_time_seconds)
+    {
+        if (!g_SoundSystem)
+            return RESULT_OK;
+        if (start_time_seconds <= 0.0f)
+            return RESULT_OK;
+        DM_MUTEX_OPTIONAL_SCOPED_LOCK(g_SoundSystem->m_Mutex);
+
+        dmSoundCodec::Info info;
+        dmSoundCodec::GetInfo(g_SoundSystem->m_CodecContext, sound_instance->m_Decoder, &info);
+        double frames_d = (double)start_time_seconds * (double)info.m_Rate;
+        if (frames_d <= 0.0)
+            return RESULT_OK;
+        uint64_t start_frame = (uint64_t)dmMath::Max(0.0, frames_d);
+        return SkipToStartFrameNoLock(sound_instance, start_frame);
+    }
+
     static inline void PrepTempBufferState(SoundInstance* instance, uint32_t channels)
     {
         if (instance->m_FrameCount > 0)

--- a/engine/sound/src/sound.cpp
+++ b/engine/sound/src/sound.cpp
@@ -1113,9 +1113,8 @@ namespace dmSound
         uint64_t total_bytes = start_frame * (uint64_t)GetSkipStrideBytes(info);
         while (total_bytes > 0)
         {
-            uint32_t chunk = (uint32_t)dmMath::Min<uint64_t>(total_bytes, 1ULL << 30);
             uint32_t skipped = 0;
-            dmSoundCodec::Result r = dmSoundCodec::Skip(g_SoundSystem->m_CodecContext, sound_instance->m_Decoder, chunk, &skipped);
+            dmSoundCodec::Result r = dmSoundCodec::Skip(g_SoundSystem->m_CodecContext, sound_instance->m_Decoder, total_bytes, &skipped);
             if (r == dmSoundCodec::RESULT_END_OF_STREAM)
             {
                 break;
@@ -1151,10 +1150,7 @@ namespace dmSound
 
         dmSoundCodec::Info info;
         dmSoundCodec::GetInfo(g_SoundSystem->m_CodecContext, sound_instance->m_Decoder, &info);
-        double frames_d = (double)start_time_seconds * (double)info.m_Rate;
-        if (frames_d <= 0.0)
-            return RESULT_OK;
-        uint64_t start_frame = (uint64_t)dmMath::Max(0.0, frames_d);
+        uint64_t start_frame = (uint64_t)((double)start_time_seconds * (double)info.m_Rate);
         return SkipToStartFrameNoLock(sound_instance, start_frame);
     }
 

--- a/engine/sound/src/sound.h
+++ b/engine/sound/src/sound.h
@@ -160,6 +160,10 @@ namespace dmSound
     Result SetParameter(HSoundInstance sound_instance, Parameter parameter, const dmVMath::Vector4& value);
     Result GetParameter(HSoundInstance sound_instance, Parameter parameter, dmVMath::Vector4& value);
 
+    // Set initial playback offset before playing; only applied to the initial playback
+    Result SetStartFrame(HSoundInstance sound_instance, uint32_t start_frame);
+    Result SetStartTime(HSoundInstance sound_instance, float start_time_seconds);
+
     // Platform dependent
     bool IsMusicPlaying();
     bool IsAudioInterrupted();

--- a/engine/sound/src/sound_null.cpp
+++ b/engine/sound/src/sound_null.cpp
@@ -256,6 +256,18 @@ namespace dmSound
         return RESULT_OK;
     }
 
+    Result SetStartFrame(HSoundInstance sound_instance, uint32_t start_frame)
+    {
+        (void)sound_instance; (void)start_frame;
+        return RESULT_OK;
+    }
+
+    Result SetStartTime(HSoundInstance sound_instance, float start_time_seconds)
+    {
+        (void)sound_instance; (void)start_time_seconds;
+        return RESULT_OK;
+    }
+
     bool IsMusicPlaying()
     {
         return false;


### PR DESCRIPTION
You can now specify `start_time` or `start_frame` (audio frame) when calling `sound.play()`.

Fix https://github.com/defold/defold/issues/9291