### PR TITLE
Switched from NSLog to os_log

### DIFF
--- a/engine/dlib/src/dlib/log_ios.mm
+++ b/engine/dlib/src/dlib/log_ios.mm
@@ -22,36 +22,7 @@ namespace dmLog
 
 void __ios_log_print(LogSeverity severity, const char* str_buf)
 {
-    // https://developer.apple.com/documentation/os/os_log_type_t/os_log_type_default?language=objc
-    os_log_type_t log_type;
-    switch (severity)
-    {
-        case LOG_SEVERITY_DEBUG:
-        case LOG_SEVERITY_USER_DEBUG:
-            log_type = OS_LOG_TYPE_DEBUG;
-            break;
-
-        case LOG_SEVERITY_INFO:
-            log_type = OS_LOG_TYPE_INFO;
-            break;
-
-        case LOG_SEVERITY_WARNING:
-            log_type = OS_LOG_TYPE_DEFAULT;
-            break;
-
-        case LOG_SEVERITY_ERROR:
-            log_type = OS_LOG_TYPE_ERROR;
-            break;
-
-        case LOG_SEVERITY_FATAL:
-            log_type = OS_LOG_TYPE_FAULT;
-            break;
-
-        default:
-            log_type = OS_LOG_TYPE_INFO;
-            break;
-    }
-    os_log_with_type(OS_LOG_DEFAULT, log_type, "%{public}s", str_buf);
+    os_log_with_type(OS_LOG_DEFAULT, OS_LOG_TYPE_DEFAULT, "%{public}s", str_buf);
 }
 
 } //namespace dmLog

--- a/engine/dlib/src/dlib/log_ios.mm
+++ b/engine/dlib/src/dlib/log_ios.mm
@@ -22,44 +22,36 @@ namespace dmLog
 
 void __ios_log_print(LogSeverity severity, const char* str_buf)
 {
-    if (@available(iOS 10, *))
+    // https://developer.apple.com/documentation/os/os_log_type_t/os_log_type_default?language=objc
+    os_log_type_t log_type;
+    switch (severity)
     {
-        // https://developer.apple.com/documentation/os/os_log_type_t/os_log_type_default?language=objc
-        os_log_type_t log_type;
-        switch (severity)
-        {
-            case LOG_SEVERITY_DEBUG:
-            case LOG_SEVERITY_USER_DEBUG:
-                log_type = OS_LOG_TYPE_DEBUG;
-                break;
+        case LOG_SEVERITY_DEBUG:
+        case LOG_SEVERITY_USER_DEBUG:
+            log_type = OS_LOG_TYPE_DEBUG;
+            break;
 
-            case LOG_SEVERITY_INFO:
-                log_type = OS_LOG_TYPE_INFO;
-                break;
+        case LOG_SEVERITY_INFO:
+            log_type = OS_LOG_TYPE_INFO;
+            break;
 
-            case LOG_SEVERITY_WARNING:
-                log_type = OS_LOG_TYPE_DEFAULT;
-                break;
+        case LOG_SEVERITY_WARNING:
+            log_type = OS_LOG_TYPE_DEFAULT;
+            break;
 
-            case LOG_SEVERITY_ERROR:
-                log_type = OS_LOG_TYPE_ERROR;
-                break;
+        case LOG_SEVERITY_ERROR:
+            log_type = OS_LOG_TYPE_ERROR;
+            break;
 
-            case LOG_SEVERITY_FATAL:
-                log_type = OS_LOG_TYPE_FAULT;
-                break;
+        case LOG_SEVERITY_FATAL:
+            log_type = OS_LOG_TYPE_FAULT;
+            break;
 
-            default:
-                log_type = OS_LOG_TYPE_INFO;
-                break;
-        }
-        os_log_with_type(OS_LOG_DEFAULT, log_type, "%{public}s", str_buf);
+        default:
+            log_type = OS_LOG_TYPE_INFO;
+            break;
     }
-    else
-    {
-        NSLog(@"%@", @(str_buf));
-    }
-    
+    os_log_with_type(OS_LOG_DEFAULT, log_type, "%{public}s", str_buf);
 }
 
 } //namespace dmLog

--- a/engine/dlib/src/dlib/log_ios.mm
+++ b/engine/dlib/src/dlib/log_ios.mm
@@ -53,7 +53,7 @@ void __ios_log_print(LogSeverity severity, const char* str_buf)
                 log_type = OS_LOG_TYPE_INFO;
                 break;
         }
-        os_log_with_type(OS_LOG_DEFAULT, log_type, "%s", str_buf);
+        os_log_with_type(OS_LOG_DEFAULT, log_type, "%{public}s", str_buf);
     }
     else
     {

--- a/engine/dlib/src/dlib/log_ios.mm
+++ b/engine/dlib/src/dlib/log_ios.mm
@@ -15,13 +15,51 @@
 #include "log.h"
 
 #import <Foundation/Foundation.h>
+#import <os/log.h>
 
 namespace dmLog
 {
 
 void __ios_log_print(LogSeverity severity, const char* str_buf)
 {
-    NSLog(@"%@", @(str_buf));
+    if (@available(iOS 10, *))
+    {
+        // https://developer.apple.com/documentation/os/os_log_type_t/os_log_type_default?language=objc
+        os_log_type_t log_type;
+        switch (severity)
+        {
+            case LOG_SEVERITY_DEBUG:
+            case LOG_SEVERITY_USER_DEBUG:
+                log_type = OS_LOG_TYPE_DEBUG;
+                break;
+
+            case LOG_SEVERITY_INFO:
+                log_type = OS_LOG_TYPE_INFO;
+                break;
+
+            case LOG_SEVERITY_WARNING:
+                log_type = OS_LOG_TYPE_DEFAULT;
+                break;
+
+            case LOG_SEVERITY_ERROR:
+                log_type = OS_LOG_TYPE_ERROR;
+                break;
+
+            case LOG_SEVERITY_FATAL:
+                log_type = OS_LOG_TYPE_FAULT;
+                break;
+
+            default:
+                log_type = OS_LOG_TYPE_INFO;
+                break;
+        }
+        os_log_with_type(OS_LOG_DEFAULT, log_type, "%s", str_buf);
+    }
+    else
+    {
+        NSLog(@"%@", @(str_buf));
+    }
+    
 }
 
 } //namespace dmLog


### PR DESCRIPTION
Changes iOS logging from NSLog to os_log due to change in iOS 26 where all strings logged with NSLog are considered private.

Fixes #11242

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
