### PR TITLE
Fixed trigger_response message appearing upon leaving even when `Generate Trigger Events` is turned off

### DIFF
--- a/engine/gamesys/src/gamesys/components/comp_collision_object.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_collision_object.cpp
@@ -507,6 +507,12 @@ namespace dmGameSystem
         CollisionWorld* world = (CollisionWorld*)user_data;
         CollisionComponent* component_a = (CollisionComponent*)trigger_exit.m_UserDataA;
         CollisionComponent* component_b = (CollisionComponent*)trigger_exit.m_UserDataB;
+
+        bool event_supported_a = SupportsEvent(component_a, EVENT_MASK_TRIGGER);
+        bool event_supported_b = SupportsEvent(component_b, EVENT_MASK_TRIGGER);
+        if (!event_supported_a && !event_supported_b)
+            return; // We early out because neither supported this event
+
         dmGameObject::HInstance instance_a = component_a->m_Instance;
         dmGameObject::HInstance instance_b = component_b->m_Instance;
         dmhash_t instance_a_id = dmGameObject::GetIdentifier(instance_a);
@@ -536,18 +542,24 @@ namespace dmGameSystem
         ddf.m_Enter = 0;
 
         // Broadcast to A components
-        ddf.m_OtherId = instance_b_id;
-        ddf.m_Group = group_hash_b;
-        ddf.m_OwnGroup = group_hash_a;
-        ddf.m_OtherGroup = group_hash_b;
-        BroadCast(&ddf, instance_a, instance_a_id, component_a->m_ComponentIndex);
+        if (event_supported_a)
+        {
+            ddf.m_OtherId = instance_b_id;
+            ddf.m_Group = group_hash_b;
+            ddf.m_OwnGroup = group_hash_a;
+            ddf.m_OtherGroup = group_hash_b;
+            BroadCast(&ddf, instance_a, instance_a_id, component_a->m_ComponentIndex);
+        }
 
         // Broadcast to B components
-        ddf.m_OtherId = instance_a_id;
-        ddf.m_Group = group_hash_a;
-        ddf.m_OwnGroup = group_hash_b;
-        ddf.m_OtherGroup = group_hash_a;
-        BroadCast(&ddf, instance_b, instance_b_id, component_b->m_ComponentIndex);
+        if (event_supported_b)
+        {
+            ddf.m_OtherId = instance_a_id;
+            ddf.m_Group = group_hash_a;
+            ddf.m_OwnGroup = group_hash_b;
+            ddf.m_OtherGroup = group_hash_a;
+            BroadCast(&ddf, instance_b, instance_b_id, component_b->m_ComponentIndex);
+        }
     }
 
     void TriggerEnteredCallback(const dmPhysics::TriggerEnter& trigger_enter, void* user_data)

--- a/engine/gamesys/src/gamesys/test/collision_object/eventtrigger_false_body1.collisionobject
+++ b/engine/gamesys/src/gamesys/test/collision_object/eventtrigger_false_body1.collisionobject
@@ -1,0 +1,32 @@
+collision_shape: ""
+type: COLLISION_OBJECT_TYPE_DYNAMIC
+mass: 1.0
+friction: 0.1
+restitution: 0.5
+group: "default"
+mask: "default"
+embedded_collision_shape {
+  shapes {
+    shape_type: TYPE_BOX
+    position {
+      x: 0.0
+      y: 0.0
+      z: 0.0
+    }
+    rotation {
+      x: 0.0
+      y: 0.0
+      z: 0.0
+      w: 1.0
+    }
+    index: 0
+    count: 3
+  }
+  data: 10.0
+  data: 10.0
+  data: 10.0
+}
+linear_damping: 0.0
+angular_damping: 0.0
+locked_rotation: false
+event_trigger: false

--- a/engine/gamesys/src/gamesys/test/collision_object/eventtrigger_false_body1.go
+++ b/engine/gamesys/src/gamesys/test/collision_object/eventtrigger_false_body1.go
@@ -1,0 +1,8 @@
+components {
+  id: "co"
+  component: "/collision_object/eventtrigger_false_body1.collisionobject"
+}
+components {
+  id: "script"
+  component: "/collision_object/eventtrigger_false_body1.script"
+}

--- a/engine/gamesys/src/gamesys/test/collision_object/eventtrigger_false_body1.script
+++ b/engine/gamesys/src/gamesys/test/collision_object/eventtrigger_false_body1.script
@@ -1,0 +1,46 @@
+-- Copyright 2020-2025 The Defold Foundation
+-- Copyright 2014-2020 King
+-- Copyright 2009-2014 Ragnar Svensson, Christian Murray
+-- Licensed under the Defold License version 1.0 (the "License"); you may not use
+-- this file except in compliance with the License.
+--
+-- You may obtain a copy of the License, together with FAQs at
+-- https://www.defold.com/license
+--
+-- Unless required by applicable law or agreed to in writing, software distributed
+-- under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+-- CONDITIONS OF ANY KIND, either express or implied. See the License for the
+-- specific language governing permissions and limitations under the License.
+
+-- scenario: body1-go is dynamic, body2-go is trigger collision, both have event_trigger: false, body1-go is thrown to body2-go, trigger results are asserted
+
+function init(self)
+  -- throw object
+  go.set("/body1-go#co", "linear_velocity", vmath.vector3(100,0,0))
+end
+
+tests_done = false -- flag end of test to C level
+local counter = 0
+
+local trigger_entered = false
+local trigger_exited = false
+function on_message(self, message_id, message, sender)
+  if message_id == hash("trigger_response") then
+    if message.enter == true then
+      trigger_entered = true
+    elseif message.enter == false then
+      trigger_exited = true
+    end
+  end
+end
+
+function update(self, dt)
+  counter = counter + 1
+
+  if counter >= 120 then
+    assert(not trigger_entered)
+    assert(not trigger_exited)
+    tests_done = true
+  end
+end
+

--- a/engine/gamesys/src/gamesys/test/collision_object/eventtrigger_false_trigger.collisionobject
+++ b/engine/gamesys/src/gamesys/test/collision_object/eventtrigger_false_trigger.collisionobject
@@ -1,0 +1,32 @@
+collision_shape: ""
+type: COLLISION_OBJECT_TYPE_TRIGGER
+mass: 1.0
+friction: 0.1
+restitution: 0.5
+group: "default"
+mask: "default"
+embedded_collision_shape {
+  shapes {
+    shape_type: TYPE_BOX
+    position {
+      x: 0.0
+      y: 0.0
+      z: 0.0
+    }
+    rotation {
+      x: 0.0
+      y: 0.0
+      z: 0.0
+      w: 1.0
+    }
+    index: 0
+    count: 3
+  }
+  data: 10.0
+  data: 10.0
+  data: 10.0
+}
+linear_damping: 0.0
+angular_damping: 0.0
+locked_rotation: false
+event_trigger: false

--- a/engine/gamesys/src/gamesys/test/collision_object/eventtrigger_false_trigger.go
+++ b/engine/gamesys/src/gamesys/test/collision_object/eventtrigger_false_trigger.go
@@ -1,0 +1,4 @@
+components {
+  id: "co"
+  component: "/collision_object/eventtrigger_false_trigger.collisionobject"
+}

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -2702,6 +2702,46 @@ TEST_F(CollisionObject2DTest, PropertiesTest)
     ASSERT_TRUE(dmGameObject::Final(m_Collection));
 }
 
+TEST_F(Trigger2DTest, EventTriggerFalseTest)
+{
+    dmHashEnableReverseHash(true);
+    lua_State* L = dmScript::GetLuaState(m_ScriptContext);
+
+    dmGameSystem::ScriptLibContext scriptlibcontext;
+    scriptlibcontext.m_Factory         = m_Factory;
+    scriptlibcontext.m_Register        = m_Register;
+    scriptlibcontext.m_LuaState        = L;
+    scriptlibcontext.m_GraphicsContext = m_GraphicsContext;
+    scriptlibcontext.m_ScriptContext   = m_ScriptContext;
+    dmGameSystem::InitializeScriptLibs(scriptlibcontext);
+
+    const char* path_trigger_go = "/collision_object/eventtrigger_false_trigger.goc";
+    dmhash_t hash_trigger_go = dmHashString64("/trigger-go");
+    // place this body standing on the base with its center at (20,5)
+    dmGameObject::HInstance trigger_go = Spawn(m_Factory, m_Collection, path_trigger_go, hash_trigger_go, 0, Point3(30,5, 0), Quat(0, 0, 0, 1), Vector3(1, 1, 1));
+    ASSERT_NE((void*)0, trigger_go);
+
+    const char* path_body1_go = "/collision_object/eventtrigger_false_body1.goc";
+    dmhash_t hash_body1_go = dmHashString64("/body1-go");
+    // place this body standing on the base with its center at (5,5)
+    dmGameObject::HInstance body1_go = Spawn(m_Factory, m_Collection, path_body1_go, hash_body1_go, 0, Point3(5,5, 0), Quat(0, 0, 0, 1), Vector3(1, 1, 1));
+    ASSERT_NE((void*)0, body1_go);
+
+    // iterate until the lua env signals the end of the test of error occurs
+    bool tests_done = false;
+    while (!tests_done)
+    {
+        ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+        ASSERT_TRUE(dmGameObject::PostUpdate(m_Collection));
+        // check if tests are done
+        lua_getglobal(L, "tests_done");
+        tests_done = lua_toboolean(L, -1);
+        lua_pop(L, 1);
+    }
+
+    ASSERT_TRUE(dmGameObject::Final(m_Collection));
+}
+
 TEST_P(GroupAndMask2DTest, GroupAndMaskTest )
 {
     const GroupAndMaskParams& params = GetParam();

--- a/engine/gamesys/src/gamesys/test/test_gamesys.h
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.h
@@ -70,6 +70,7 @@ struct ProjectOptions {
   uint32_t m_MaxCollisionObjectCount;
   uint32_t m_MaxContactPointCount;
   uint32_t m_MaxInstances;
+  uint32_t m_TriggerOverlapCapacity;
   bool m_3D;
   float m_Scale;
   float m_VelocityThreshold;
@@ -219,6 +220,13 @@ public:
     }
 };
 
+class Trigger2DTest : public CollisionObject2DTest
+{
+public:
+	Trigger2DTest() {
+		m_projectOptions.m_TriggerOverlapCapacity = 1;
+	}
+};
 
 class VelocityThreshold2DTest : public CollisionObject2DTest
 {
@@ -615,6 +623,7 @@ void GamesysTest<T>::SetUp()
         dmPhysics::NewContextParams context2DParams = dmPhysics::NewContextParams();
         context2DParams.m_Scale = this->m_projectOptions.m_Scale;
         context2DParams.m_VelocityThreshold = this->m_projectOptions.m_VelocityThreshold;
+        context2DParams.m_TriggerOverlapCapacity = this->m_projectOptions.m_TriggerOverlapCapacity;
         m_PhysicsContextBox2D.m_Context = dmPhysics::NewContext2D(context2DParams);
 
         physics_context = &m_PhysicsContextBox2D.m_BaseContext;


### PR DESCRIPTION
Fixes #11257

Technical notes:
Just copied the SupportsEvent logic from TriggerEntered. ~A unit test would be nice but I couldn't figure out how the C++ part works~ Figured it out.

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
