### PR TITLE
Fixing up sound openal builds by adding stub start offset/time calls

### DIFF
--- a/engine/sound/src/sound_openal.cpp
+++ b/engine/sound/src/sound_openal.cpp
@@ -1180,6 +1180,16 @@ namespace dmSound
         return RESULT_OK;
     }
 
+    Result SetStartFrame(HSoundInstance sound_instance, uint32_t start_frame)
+    {
+        return RESULT_UNSUPPORTED;
+    }
+
+    Result SetStartTime(HSoundInstance sound_instance, float start_time_seconds)
+    {
+        return RESULT_UNSUPPORTED;
+    }
+
     static Result UpdateInternal(SoundSystem* sound)
     {
         DM_PROFILE(__FUNCTION__);


### PR DESCRIPTION
- Standard sound.cpp code added two new methods to setup a start offset into a sound asset before playback starts
- sound_openal.cpp was lackinig this and hence would fail during link
- implementation of the methods is added, but as "stub only" (returning proper errors) as OpenAL does not trivially support this
