### PR TITLE
Added missing function stubs to OpenAL sound backend

### DIFF
--- a/engine/sound/src/sound_openal.cpp
+++ b/engine/sound/src/sound_openal.cpp
@@ -1180,6 +1180,28 @@ namespace dmSound
         return RESULT_OK;
     }
 
+    // private function. Currently part of the test_sound.cpp
+    void GetPanScale(float pan, float* left_scale, float* right_scale)
+    {
+    }
+
+    // private function. Currently part of the test_sound.cpp
+    Result GetScaleFromGain(float gain, float* scale)
+    {
+        //*scale = GainToScale(gain);
+        return RESULT_UNSUPPORTED;
+    }
+
+    Result SetStartFrame(HSoundInstance sound_instance, uint32_t start_frame)
+    {
+        return RESULT_UNSUPPORTED;
+    }
+
+    Result SetStartTime(HSoundInstance sound_instance, float start_time_seconds)
+    {
+        return RESULT_UNSUPPORTED;
+    }
+
     static Result UpdateInternal(SoundSystem* sound)
     {
         DM_PROFILE(__FUNCTION__);

--- a/engine/sound/src/test/wscript
+++ b/engine/sound/src/test/wscript
@@ -173,6 +173,14 @@ def build(bld):
         for f in ['CFLAGS', 'CXXFLAGS']:
             test.env.append_value(f, ['-msimd128', '-msse4.2', '-DDM_SOUND_DSP_IMPL=WASM'])
 
+    # making sure we test link the openal backend
+    test_sound_libs = [x for x in test.use if x != 'sound'] # keep the libraries in sync
+    bld.program(features = 'cxx embed test skip_test',
+                    includes = '../../src .',
+                    use = ['sound_openal'] + test_sound_libs,
+                    exported_symbols = exported_symbols,
+                    target = 'test_sound_openal',
+                    source = 'test_sound.cpp')
 
     # test that the linkage doesn't break again
     exported_symbols = 'NullSoundDevice TestNullDevice'

--- a/engine/sound/src/test/wscript
+++ b/engine/sound/src/test/wscript
@@ -62,7 +62,7 @@ def build(bld):
     if waflib.Options.options.skip_build_tests:
         return
 
-    build_util = create_build_utility(self.env)
+    build_util = create_build_utility(bld.env)
     target_os = build_util.get_target_os()
 
     platform = bld.env['PLATFORM']

--- a/engine/sound/src/test/wscript
+++ b/engine/sound/src/test/wscript
@@ -178,6 +178,7 @@ def build(bld):
     bld.program(features = 'cxx embed test skip_test',
                     includes = '../../src .',
                     use = ['sound_openal'] + test_sound_libs,
+                    defines = ['DM_TEST_SOUND_USE_OPENAL'],
                     exported_symbols = exported_symbols,
                     target = 'test_sound_openal',
                     source = 'test_sound.cpp')

--- a/engine/sound/src/test/wscript
+++ b/engine/sound/src/test/wscript
@@ -4,6 +4,8 @@ import os, re, wave, io, math, struct
 import waflib.Task, waflib.TaskGen, waflib.Options
 from waf_dynamo import copy_file_task
 from waflib.TaskGen import extension, extension
+from BuildUtility import create_build_utility
+from build_constants import TargetOS
 
 def gen_tone(task):
     tone_freq = int(task.generator.tone)
@@ -59,6 +61,9 @@ def gen_dc(task):
 def build(bld):
     if waflib.Options.options.skip_build_tests:
         return
+
+    build_util = create_build_utility(self.env)
+    target_os = build_util.get_target_os()
 
     platform = bld.env['PLATFORM']
 
@@ -174,14 +179,15 @@ def build(bld):
             test.env.append_value(f, ['-msimd128', '-msse4.2', '-DDM_SOUND_DSP_IMPL=WASM'])
 
     # making sure we test link the openal backend
-    test_sound_libs = [x for x in test.use if x != 'sound'] # keep the libraries in sync
-    bld.program(features = 'cxx embed test skip_test',
-                    includes = '../../src .',
-                    use = ['sound_openal'] + test_sound_libs,
-                    defines = ['DM_TEST_SOUND_USE_OPENAL'],
-                    exported_symbols = exported_symbols,
-                    target = 'test_sound_openal',
-                    source = 'test_sound.cpp')
+    if target_os in [TargetOS.MACOS, TargetOS.LINUX]:
+        test_sound_libs = [x for x in test.use if x != 'sound'] # keep the libraries in sync
+        bld.program(features = 'cxx embed test skip_test',
+                        includes = '../../src .',
+                        use = ['sound_openal'] + test_sound_libs,
+                        defines = ['DM_TEST_SOUND_USE_OPENAL'],
+                        exported_symbols = exported_symbols,
+                        target = 'test_sound_openal',
+                        source = 'test_sound.cpp')
 
     # test that the linkage doesn't break again
     exported_symbols = 'NullSoundDevice TestNullDevice'


### PR DESCRIPTION
## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
