### PR TITLE
Fix sorting issue (h)tml5

### DIFF
--- a/engine/render/src/render/render.cpp
+++ b/engine/render/src/render/render.cpp
@@ -590,9 +590,10 @@ namespace dmRender
         const uint32_t ORDER_SCALE_MASK = 0xfffff0;
         const uint32_t ORDER_BASE_FRONT = 0x000008;
         const uint32_t ORDER_BASE_BACK = 0xfffff8;
-        const bool front_to_back = (sort_order == SORT_FRONT_TO_BACK);
-        const float order_multiplier = (front_to_back ? 1.0f : -1.0f) * ORDER_SCALE_MASK * rc;
-        const float order_bias = (front_to_back ? ORDER_BASE_FRONT : ORDER_BASE_BACK) - order_multiplier * minZW;
+        const uint32_t ftb  = (sort_order == SORT_FRONT_TO_BACK);
+        const float    base = (float)(ORDER_BASE_FRONT + ((uint32_t)!ftb) * ORDER_SCALE_MASK);
+        const float    sign = ftb * 2.0f - 1.0f;
+        const float    order_multiplier = sign * ORDER_SCALE_MASK * rc;
 
         for( uint32_t i = 0; i < num_ranges; ++i)
         {
@@ -614,7 +615,7 @@ namespace dmRender
                 if (entry->m_MajorOrder == RENDER_ORDER_WORLD)
                 {
                     const float z = sort_values[idx].m_ZW;
-                    sort_values[idx].m_Order = (uint32_t) (order_bias + order_multiplier * z);
+                    sort_values[idx].m_Order = (uint32_t)(base + order_multiplier * (z - minZW));
                 }
                 else
                 {


### PR DESCRIPTION
The fix avoids float precision loss from subtracting big numbers.
It now uses (z - minZW) so the range stays small and gives the same sort order on all platforms.