### PR TITLE
Fix Tile Source Collision Group colors in Outline

### DIFF
--- a/editor/src/clj/editor/outline_view.clj
+++ b/editor/src/clj/editor/outline_view.clj
@@ -639,7 +639,7 @@
                          (ui/on-click! (partial toggle-visibility! node-outline-key-path)))
                        (proxy-super setGraphic pane)
                        (when-let [[r g b a] color]
-                         (proxy-super setStyle (format "-fx-text-fill: rgba(%d, %d, %d %d);" (int (* 255 r)) (int (* 255 g)) (int (* 255 b)) (int (* 255 a)))))
+                         (.setStyle text-label (format "-fx-text-fill: rgba(%d, %d, %d %d);" (int (* 255 r)) (int (* 255 g)) (int (* 255 b)) (int (* 255 a)))))
                        (if parent-reference?
                          (ui/add-style! this "parent-reference")
                          (ui/remove-style! this "parent-reference"))

--- a/editor/src/dev/jfx.clj
+++ b/editor/src/dev/jfx.clj
@@ -234,11 +234,17 @@
 
 (defn- styleable-props [^Styleable styleable]
   {:id (.getId styleable)
-   :style-classes (not-empty (vec (sort (.getStyleClass styleable))))})
+   :style (not-empty (.getStyle styleable))
+   :style-classes (not-empty (vec (sort (.getStyleClass styleable))))
+   :pseudo-classes (not-empty (into (sorted-set) (map str) (.getPseudoClassStates styleable)))})
 
 (defn- node-props [^Node node]
   (let [layout-bounds (.getLayoutBounds node)]
-    {:layout-size [(.getWidth layout-bounds) (.getHeight layout-bounds)]}))
+    (cond-> {:layout-size [(.getWidth layout-bounds) (.getHeight layout-bounds)]}
+            (.isDisable node) (assoc :disable true)
+            (.isMouseTransparent node) (assoc :mouse-transparent true)
+            (not (.isManaged node)) (assoc :managed false)
+            (not (.isVisible node)) (assoc :visible false))))
 
 (defn- to-coll [items]
   (cond


### PR DESCRIPTION
Fixes #11290

### Technical changes
* Added some more info to the maps returned by the `dev/javafx-tree` function.