### PR TITLE
Automatically save any changes in the editor whenever it loses focus

### DIFF
--- a/editor/resources/localization/en.editor_localization
+++ b/editor/resources/localization/en.editor_localization
@@ -509,6 +509,7 @@ prefs.tab.keymap = Keymap
 
 # General tab
 prefs.label.workflow.load-external-changes-on-app-focus = Load External Changes on App Focus
+prefs.label.workflow.save-on-app-focus-lost = Save All on App Focus Lost
 prefs.label.bundle.open-output-directory = Open Bundle Target Folder
 prefs.label.build.open-html5-build = Open Browser After "Build HTML5"
 prefs.label.build.texture-compression = Enable Texture Compression

--- a/editor/resources/localization/ru.editor_localization
+++ b/editor/resources/localization/ru.editor_localization
@@ -497,6 +497,7 @@ prefs.tab.keymap = Клавиши
 
 # General tab
 prefs.label.workflow.load-external-changes-on-app-focus = Загружать изменения при фокусе
+prefs.label.workflow.save-on-app-focus-lost = Сохранять всё при потере фокуса приложения
 prefs.label.bundle.open-output-directory = Открывать папку сборки
 prefs.label.build.open-html5-build = Открывать браузер после HTML5-сборки
 prefs.label.build.texture-compression = Сжатие текстур

--- a/editor/resources/localization/ru.editor_localization
+++ b/editor/resources/localization/ru.editor_localization
@@ -497,7 +497,7 @@ prefs.tab.keymap = Клавиши
 
 # General tab
 prefs.label.workflow.load-external-changes-on-app-focus = Загружать изменения при фокусе
-prefs.label.workflow.save-on-app-focus-lost = Сохранять всё при потере фокуса приложения
+prefs.label.workflow.save-on-app-focus-lost = Сохранять при потере фокуса
 prefs.label.bundle.open-output-directory = Открывать папку сборки
 prefs.label.build.open-html5-build = Открывать браузер после HTML5-сборки
 prefs.label.build.texture-compression = Сжатие текстур

--- a/editor/src/clj/editor/boot_open_project.clj
+++ b/editor/src/clj/editor/boot_open_project.clj
@@ -244,6 +244,7 @@
               (.delete port-file)))))
       (.addEventFilter ^StackPane (.lookup root "#overlay") MouseEvent/ANY ui/ignore-event-filter)
       (ui/add-application-focused-callback! :main-stage app-view/handle-application-focused! app-view changes-view workspace prefs)
+      (ui/add-application-unfocused-callback! :main-stage-unfocused app-view/handle-application-unfocused! app-view changes-view project prefs)
       (app-view/reload-extensions! app-view project :all workspace changes-view build-errors-view prefs localization web-server)
 
       (when updater
@@ -304,6 +305,7 @@
       (ui/on-closed! stage (fn [_]
                              (http-server/stop! web-server)
                              (ui/remove-application-focused-callback! :main-stage)
+                             (ui/remove-application-unfocused-callback! :main-stage-unfocused)
 
                              ;; TODO: This takes a long time in large projects.
                              ;; Disabled for now since we don't really need to

--- a/editor/src/clj/editor/prefs.clj
+++ b/editor/src/clj/editor/prefs.clj
@@ -169,6 +169,8 @@
                :properties
                {:load-external-changes-on-app-focus {:type :boolean
                                                      :default true}
+                :save-on-app-focus-lost {:type :boolean
+                                         :default true}
                 :recent-files {:type :array
                                :item {:type :tuple :items [{:type :string} {:type :keyword}]}
                                :scope :project}

--- a/editor/src/clj/editor/prefs.clj
+++ b/editor/src/clj/editor/prefs.clj
@@ -170,7 +170,7 @@
                {:load-external-changes-on-app-focus {:type :boolean
                                                      :default true}
                 :save-on-app-focus-lost {:type :boolean
-                                         :default true}
+                                         :default false}
                 :recent-files {:type :array
                                :item {:type :tuple :items [{:type :string} {:type :keyword}]}
                                :scope :project}

--- a/editor/src/clj/editor/prefs_dialog.clj
+++ b/editor/src/clj/editor/prefs_dialog.clj
@@ -57,6 +57,7 @@
     (cond->
       [{:pattern (localization/message "prefs.tab.general")
         :paths [[:workflow :load-external-changes-on-app-focus]
+                [:workflow :save-on-app-focus-lost]
                 [:bundle :open-output-directory]
                 [:build :open-html5-build]
                 [:build :texture-compression]

--- a/editor/src/clj/editor/ui.clj
+++ b/editor/src/clj/editor/ui.clj
@@ -125,6 +125,19 @@
   (remove-watch focus-state key)
   nil)
 
+(defn add-application-unfocused-callback! [key application-unfocused! & args]
+  (add-watch focus-state key
+             (fn [_key _ref old new]
+               (when (and old
+                          (:focused old)
+                          (not (:focused new)))
+                 (apply application-unfocused! args))))
+  nil)
+
+(defn remove-application-unfocused-callback! [key]
+  (remove-watch focus-state key)
+  nil)
+
 (defprotocol Text
   (text ^String [this])
   (text! [this ^String val]))


### PR DESCRIPTION
Introduced a new option that automatically saves all open files in the editor whenever it loses focus.

Fix https://github.com/defold/defold/issues/7930