### PR TITLE
Cached include guards stop Defolds CMake helpers from reloading over multiple config runs

### DIFF
--- a/scripts/cmake/defold.cmake
+++ b/scripts/cmake/defold.cmake
@@ -1,7 +1,7 @@
 if(DEFINED DEFOLD_CMAKE_INCLUDED)
   return()
 endif()
-set(DEFOLD_CMAKE_INCLUDED ON CACHE INTERNAL "defold.cmake include guard")
+set(DEFOLD_CMAKE_INCLUDED ON)
 
 message(DEBUG "defold.cmake:")
 

--- a/scripts/cmake/functions.cmake
+++ b/scripts/cmake/functions.cmake
@@ -1,7 +1,7 @@
 if(DEFINED DEFOLD_FUNCTIONS_CMAKE_INCLUDED)
     return()
 endif()
-set(DEFOLD_FUNCTIONS_CMAKE_INCLUDED ON CACHE INTERNAL "functions.cmake include guard")
+set(DEFOLD_FUNCTIONS_CMAKE_INCLUDED ON)
 
 message(DEBUG "functions.cmake:")
 

--- a/scripts/cmake/functions_sdk.cmake
+++ b/scripts/cmake/functions_sdk.cmake
@@ -1,7 +1,7 @@
 if(DEFINED DEFOLD_FUNCTIONS_SDK_CMAKE_INCLUDED)
     return()
 endif()
-set(DEFOLD_FUNCTIONS_SDK_CMAKE_INCLUDED ON CACHE INTERNAL "functions_sdk.cmake include guard")
+set(DEFOLD_FUNCTIONS_SDK_CMAKE_INCLUDED ON)
 
 defold_log("functions_sdk.cmake:")
 
@@ -51,4 +51,3 @@ function(defold_set_from_sdk_py)
     # Export to caller's scope
     set(${DSDK_TARGET} "${_value}" PARENT_SCOPE)
 endfunction()
-

--- a/scripts/cmake/platform.cmake
+++ b/scripts/cmake/platform.cmake
@@ -1,7 +1,7 @@
 if(DEFINED DEFOLD_PLATFORM_CMAKE_INCLUDED)
     return()
 endif()
-set(DEFOLD_PLATFORM_CMAKE_INCLUDED ON CACHE INTERNAL "platform.cmake include guard")
+set(DEFOLD_PLATFORM_CMAKE_INCLUDED ON)
 
 defold_log("platform.cmake:")
 

--- a/scripts/cmake/platform_host.cmake
+++ b/scripts/cmake/platform_host.cmake
@@ -1,7 +1,7 @@
 if(DEFINED DEFOLD_PLATFORM_HOST_CMAKE_INCLUDED)
   return()
 endif()
-set(DEFOLD_PLATFORM_HOST_CMAKE_INCLUDED ON CACHE INTERNAL "platform_host.cmake include guard")
+set(DEFOLD_PLATFORM_HOST_CMAKE_INCLUDED ON)
 
 defold_log("platform_host.cmake:")
 

--- a/scripts/cmake/sdk.cmake
+++ b/scripts/cmake/sdk.cmake
@@ -1,7 +1,7 @@
 if(DEFINED DEFOLD_SDK_CMAKE_INCLUDED)
     return()
 endif()
-set(DEFOLD_SDK_CMAKE_INCLUDED ON CACHE INTERNAL "sdk.cmake include guard")
+set(DEFOLD_SDK_CMAKE_INCLUDED ON)
 
 if(DEFINED DEFOLD_SDK_DETECTED)
     # Avoid re-running detection when sdk.cmake is included multiple times
@@ -42,4 +42,4 @@ else()
     message(FATAL "Unsupported platform: ${TARGET_PLATFORM}")
 endif()
 
-set(DEFOLD_SDK_DETECTED ON CACHE INTERNAL "Defold SDK/toolchain detection has run")
+set(DEFOLD_SDK_DETECTED ON)


### PR DESCRIPTION
Cached include guards stop Defolds CMake helpers from reloading over multiple configuration runs so commands vanish on the second configure. Wiping CMakeCache fixes it,  but maybe use plain guards instead to guard during a single config session and let CMakeCache handle it, but not over multiple runs. IDEs like CLion and VSCode might become a bit sad.

From:
```
16:13 …/engine/input (HEAD ✗) $ cmake -S . -B build -G Ninja
-- Found Java: /Library/Java/JavaVirtualMachines/temurin-21.jdk/Contents/Home/bin/java (found suitable version "21.0.7", minimum required is "21") found components: Runtime Development
-- HOST_PLATFORM: arm64-macos
-- The C compiler identification is AppleClang 17.0.0.17000319
-- The CXX compiler identification is AppleClang 17.0.0.17000319
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done (0.4s)
-- Generating done (0.0s)
-- Build files have been written to: /Users/deurell/source/defold/engine/input/build
16:13 …/engine/input (HEAD ✗) $ cmake -S . -B build -G Ninja
CMake Error at CMakeLists.txt:16 (defold_protoc_gen_py):
  Unknown CMake command "defold_protoc_gen_py".


-- Configuring incomplete, errors occurred!
```
To:
```
16:00 …/engine/input (hid-cmake-test-guards ✗) $ cmake -S . -B build -G Ninja
-- Found Java: /Library/Java/JavaVirtualMachines/temurin-21.jdk/Contents/Home/bin/java (found suitable version "21.0.7", minimum required is "21") found components: Runtime Development
-- HOST_PLATFORM: arm64-macos
-- The C compiler identification is AppleClang 17.0.0.17000319
-- The CXX compiler identification is AppleClang 17.0.0.17000319
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done (0.4s)
-- Generating done (0.0s)
-- Build files have been written to: /Users/deurell/source/defold/engine/input/build
16:00 …/engine/input (hid-cmake-test-guards ✗) $ cmake -S . -B build -G Ninja
-- HOST_PLATFORM: arm64-macos
-- Configuring done (0.1s)
-- Generating done (0.0s)
-- Build files have been written to: /Users/deurell/source/defold/engine/input/build
```