### PR TITLE
Issue 11298 resolve sound deadlock on Windows

### DIFF
--- a/engine/sound/src/devices/device_wasapi.cpp
+++ b/engine/sound/src/devices/device_wasapi.cpp
@@ -499,6 +499,15 @@ namespace dmDeviceWasapi
         SoundDevice* device = (SoundDevice*) _device;
         if (device->m_DeviceInvalidated)
         {
+            if (device->m_AudioClient)
+            {
+                HRESULT hr = device->m_AudioClient->Stop();
+                if (FAILED(hr))
+                {
+                    dmLogError("Failed to stop audio client");
+                    CheckAndPrintError(hr);
+                }
+            }
             return;
         }
         if (device->m_AudioClient)

--- a/engine/sound/src/devices/device_wasapi.cpp
+++ b/engine/sound/src/devices/device_wasapi.cpp
@@ -288,7 +288,6 @@ namespace dmDeviceWasapi
 
         if (device->m_DeviceInvalidated)
         {
-            dmTime::Sleep(1000);
             return 0;
         }
 
@@ -343,7 +342,6 @@ namespace dmDeviceWasapi
 
         if (device->m_DeviceInvalidated)
         {
-            dmTime::Sleep(1000);
             return dmSound::RESULT_INIT_ERROR;
         }
 

--- a/engine/sound/src/devices/device_wasapi.cpp
+++ b/engine/sound/src/devices/device_wasapi.cpp
@@ -40,10 +40,12 @@ namespace dmDeviceWasapi
 
         uint32_t            m_Format;
         uint32_t            m_FrameCount;
+        bool                m_DeviceInvalidated;
 
         SoundDevice()
         {
             memset(this, 0, sizeof(*this));
+            m_DeviceInvalidated = false;
         }
     };
 
@@ -53,6 +55,20 @@ namespace dmDeviceWasapi
         {
             dmLogError("WASAPI error 0x%X: %s", hr, "");
         }
+    }
+
+    static void MarkDeviceInvalidated(SoundDevice* device, const char* context, HRESULT hr)
+    {
+        if (!device)
+            return;
+
+        if (!device->m_DeviceInvalidated)
+        {
+            dmLogError("WASAPI device lost in %s (hr=0x%08X)", context, hr);
+            CheckAndPrintError(hr);
+        }
+
+        device->m_DeviceInvalidated = true;
     }
 
     static void DeleteDevice(SoundDevice* device)
@@ -253,6 +269,7 @@ namespace dmDeviceWasapi
             return dmSound::RESULT_INIT_ERROR;
         }
 
+        device->m_DeviceInvalidated = false;
         *outdevice = device;
         return dmSound::RESULT_OK;
     }
@@ -269,6 +286,12 @@ namespace dmDeviceWasapi
         assert(_device);
         SoundDevice* device = (SoundDevice*) _device;
 
+        if (device->m_DeviceInvalidated)
+        {
+            dmTime::Sleep(1000);
+            return 0;
+        }
+
         HRESULT hr = WaitForSingleObject(device->m_ClientBufferEvent, 250);
         if (WAIT_OBJECT_0 != hr)
         {
@@ -282,17 +305,30 @@ namespace dmDeviceWasapi
         assert(_device);
         SoundDevice* device = (SoundDevice*) _device;
 
+        if (device->m_DeviceInvalidated)
+        {
+            return 0;
+        }
+
         uint32_t buffer_size = 0;
         uint32_t buffer_pos = 0;
         HRESULT hr = device->m_AudioClient->GetBufferSize(&buffer_size);
         if (FAILED(hr))
         {
+            if (hr == AUDCLNT_E_DEVICE_INVALIDATED)
+            {
+                MarkDeviceInvalidated(device, "GetBufferSize", hr);
+            }
             return 0;
         }
 
         hr = device->m_AudioClient->GetCurrentPadding(&buffer_pos);
         if (FAILED(hr))
         {
+            if (hr == AUDCLNT_E_DEVICE_INVALIDATED)
+            {
+                MarkDeviceInvalidated(device, "GetCurrentPadding", hr);
+            }
             return 0;
         }
         return buffer_size - buffer_pos;
@@ -305,18 +341,34 @@ namespace dmDeviceWasapi
         SoundDevice* device = (SoundDevice*) _device;
         const int16_t* samples = (const int16_t*)_samples;
 
+        if (device->m_DeviceInvalidated)
+        {
+            dmTime::Sleep(1000);
+            return dmSound::RESULT_INIT_ERROR;
+        }
+
         uint32_t buffer_size = 0;
         uint32_t buffer_pos = 0;
 
         HRESULT hr = device->m_AudioClient->GetBufferSize(&buffer_size);
         if (FAILED(hr))
         {
+            if (hr == AUDCLNT_E_DEVICE_INVALIDATED)
+            {
+                MarkDeviceInvalidated(device, "Queue/GetBufferSize", hr);
+                return dmSound::RESULT_INIT_ERROR;
+            }
             return dmSound::RESULT_OUT_OF_BUFFERS;
         }
 
         hr = device->m_AudioClient->GetCurrentPadding(&buffer_pos);
         if (FAILED(hr))
         {
+            if (hr == AUDCLNT_E_DEVICE_INVALIDATED)
+            {
+                MarkDeviceInvalidated(device, "Queue/GetCurrentPadding", hr);
+                return dmSound::RESULT_INIT_ERROR;
+            }
             return dmSound::RESULT_OUT_OF_BUFFERS;
         }
 
@@ -329,6 +381,11 @@ namespace dmDeviceWasapi
         hr = device->m_AudioRenderClient->GetBuffer(frames_available, &out);
         if (FAILED(hr))
         {
+            if (hr == AUDCLNT_E_DEVICE_INVALIDATED)
+            {
+                MarkDeviceInvalidated(device, "Queue/GetBuffer", hr);
+                return dmSound::RESULT_INIT_ERROR;
+            }
             return dmSound::RESULT_OUT_OF_BUFFERS;
         }
 
@@ -370,7 +427,16 @@ namespace dmDeviceWasapi
             }
         }
 
-        device->m_AudioRenderClient->ReleaseBuffer(frames_available, 0);
+        HRESULT release_hr = device->m_AudioRenderClient->ReleaseBuffer(frames_available, 0);
+        if (FAILED(release_hr))
+        {
+            if (release_hr == AUDCLNT_E_DEVICE_INVALIDATED)
+            {
+                MarkDeviceInvalidated(device, "Queue/ReleaseBuffer", release_hr);
+                return dmSound::RESULT_INIT_ERROR;
+            }
+            return dmSound::RESULT_OUT_OF_BUFFERS;
+        }
 
         return dmSound::RESULT_OK;
     }
@@ -394,19 +460,38 @@ namespace dmDeviceWasapi
     {
         assert(_device);
         SoundDevice* device = (SoundDevice*) _device;
+        if (device->m_DeviceInvalidated)
+        {
+            return;
+        }
         if (device->m_AudioClient)
         {
             HRESULT hr = device->m_AudioClient->Start();
             if (FAILED(hr))
             {
+                if (hr == AUDCLNT_E_DEVICE_INVALIDATED)
+                {
+                    MarkDeviceInvalidated(device, "Start", hr);
+                    return;
+                }
                 dmLogError("Failed to start audio client");
                 CheckAndPrintError(hr);
             }
 
             uint32_t buffer_size = 0;
             uint32_t buffer_pos = 0;
-            device->m_AudioClient->GetBufferSize(&buffer_size);
-            device->m_AudioClient->GetCurrentPadding(&buffer_pos);
+            hr = device->m_AudioClient->GetBufferSize(&buffer_size);
+            if (FAILED(hr) && hr == AUDCLNT_E_DEVICE_INVALIDATED)
+            {
+                MarkDeviceInvalidated(device, "Start/GetBufferSize", hr);
+                return;
+            }
+            hr = device->m_AudioClient->GetCurrentPadding(&buffer_pos);
+            if (FAILED(hr) && hr == AUDCLNT_E_DEVICE_INVALIDATED)
+            {
+                MarkDeviceInvalidated(device, "Start/GetCurrentPadding", hr);
+                return;
+            }
         }
     }
 
@@ -414,21 +499,70 @@ namespace dmDeviceWasapi
     {
         assert(_device);
         SoundDevice* device = (SoundDevice*) _device;
+        if (device->m_DeviceInvalidated)
+        {
+            return;
+        }
         if (device->m_AudioClient)
         {
             uint32_t buffer_size = 0;
             uint32_t buffer_pos = 0;
             uint8_t* out;
-            device->m_AudioClient->GetBufferSize(&buffer_size);
-            device->m_AudioClient->GetCurrentPadding(&buffer_pos);
-
-            uint32_t frames_available = buffer_size;// buffer_size - buffer_pos;
-            device->m_AudioRenderClient->GetBuffer(frames_available, &out);
-            device->m_AudioRenderClient->ReleaseBuffer(frames_available, AUDCLNT_BUFFERFLAGS_SILENT);
-
-            HRESULT hr = device->m_AudioClient->Stop();
+            HRESULT hr = device->m_AudioClient->GetBufferSize(&buffer_size);
             if (FAILED(hr))
             {
+                if (hr == AUDCLNT_E_DEVICE_INVALIDATED)
+                {
+                    MarkDeviceInvalidated(device, "Stop/GetBufferSize", hr);
+                    return;
+                }
+                CheckAndPrintError(hr);
+                return;
+            }
+            hr = device->m_AudioClient->GetCurrentPadding(&buffer_pos);
+            if (FAILED(hr))
+            {
+                if (hr == AUDCLNT_E_DEVICE_INVALIDATED)
+                {
+                    MarkDeviceInvalidated(device, "Stop/GetCurrentPadding", hr);
+                    return;
+                }
+                CheckAndPrintError(hr);
+                return;
+            }
+
+            uint32_t frames_available = buffer_size;// buffer_size - buffer_pos;
+            hr = device->m_AudioRenderClient->GetBuffer(frames_available, &out);
+            if (FAILED(hr))
+            {
+                if (hr == AUDCLNT_E_DEVICE_INVALIDATED)
+                {
+                    MarkDeviceInvalidated(device, "Stop/GetBuffer", hr);
+                    return;
+                }
+                CheckAndPrintError(hr);
+                return;
+            }
+            hr = device->m_AudioRenderClient->ReleaseBuffer(frames_available, AUDCLNT_BUFFERFLAGS_SILENT);
+            if (FAILED(hr))
+            {
+                if (hr == AUDCLNT_E_DEVICE_INVALIDATED)
+                {
+                    MarkDeviceInvalidated(device, "Stop/ReleaseBuffer", hr);
+                    return;
+                }
+                CheckAndPrintError(hr);
+                return;
+            }
+
+            hr = device->m_AudioClient->Stop();
+            if (FAILED(hr))
+            {
+                if (hr == AUDCLNT_E_DEVICE_INVALIDATED)
+                {
+                    MarkDeviceInvalidated(device, "Stop", hr);
+                    return;
+                }
                 dmLogError("Failed to stop audio client");
                 CheckAndPrintError(hr);
             }

--- a/engine/sound/src/sound.cpp
+++ b/engine/sound/src/sound.cpp
@@ -1781,7 +1781,6 @@ namespace dmSound
                 }
             }
 
-            bool skip_queue = false;
             uint32_t buffer_index = 0;
 
             {
@@ -1791,7 +1790,7 @@ namespace dmSound
 
                 if (frame_count < SOUND_MAX_HISTORY)
                 {
-                    skip_queue = true;
+                    continue;
                 }
                 else
                 {
@@ -1803,11 +1802,6 @@ namespace dmSound
                     buffer_index = sound->m_NextOutBuffer;
                     sound->m_NextOutBuffer = (sound->m_NextOutBuffer + 1) % sound->m_OutBufferCount;
                 }
-            }
-
-            if (skip_queue)
-            {
-                continue;
             }
 
             dmSound::Result queue_result;

--- a/engine/sound/src/sound.cpp
+++ b/engine/sound/src/sound.cpp
@@ -1758,44 +1758,74 @@ namespace dmSound
             sound->m_IsDeviceStarted = true;
         }
 
-        DM_MUTEX_OPTIONAL_SCOPED_LOCK(g_SoundSystem->m_Mutex);
-
         uint32_t free_slots = sound->m_DeviceType->m_FreeBufferSlots(sound->m_Device);
-        if (free_slots > 0) {
+        if (free_slots > 0)
+        {
+            DM_MUTEX_OPTIONAL_SCOPED_LOCK(g_SoundSystem->m_Mutex);
             StepGroupValues();
             StepInstanceValues();
         }
 
         uint32_t current_buffer = 0;
         uint32_t total_buffers = free_slots;
-        while (free_slots > 0) {
-
-            // Get the number of frames available
+        while (free_slots > 0)
+        {
+            // Get the number of frames available (can block, so avoid holding the sound mutex here)
             uint32_t frame_count = sound->m_DeviceFrameCount;
             if (sound->m_DeviceType->m_GetAvailableFrames)
             {
                 frame_count = sound->m_DeviceType->m_GetAvailableFrames(sound->m_Device);
+                if (frame_count == 0)
+                {
+                    break;
+                }
             }
 
-            sound->m_FrameCount = frame_count;
+            bool skip_queue = false;
+            uint32_t buffer_index = 0;
 
-            if (frame_count < SOUND_MAX_HISTORY)
+            {
+                DM_MUTEX_OPTIONAL_SCOPED_LOCK(g_SoundSystem->m_Mutex);
+
+                sound->m_FrameCount = frame_count;
+
+                if (frame_count < SOUND_MAX_HISTORY)
+                {
+                    skip_queue = true;
+                }
+                else
+                {
+                    MixContext mix_context(current_buffer, total_buffers, frame_count);
+                    MixInstances(&mix_context);
+
+                    Master(&mix_context);
+
+                    buffer_index = sound->m_NextOutBuffer;
+                    sound->m_NextOutBuffer = (sound->m_NextOutBuffer + 1) % sound->m_OutBufferCount;
+                }
+            }
+
+            if (skip_queue)
+            {
                 continue;
+            }
 
-            MixContext mix_context(current_buffer, total_buffers, frame_count);
-            MixInstances(&mix_context);
-
-            Master(&mix_context);
+            dmSound::Result queue_result;
 
             // DEF-2540: Make sure to keep feeding the sound device if audio is being generated,
             // if you don't you'll get more slots free, thus updating sound (redundantly) every call,
             // resulting in a huge performance hit. Also, you'll fast forward the sounds.
             {
                 DM_PROFILE("QueueBuffer");
-                sound->m_DeviceType->m_Queue(sound->m_Device, sound->m_OutBuffers[sound->m_NextOutBuffer], frame_count);
+                queue_result = sound->m_DeviceType->m_Queue(sound->m_Device, sound->m_OutBuffers[buffer_index], frame_count);
             }
 
-            sound->m_NextOutBuffer = (sound->m_NextOutBuffer + 1) % sound->m_OutBufferCount;
+            if (queue_result == dmSound::RESULT_INIT_ERROR)
+            {
+                sound->m_IsDeviceStarted = false;
+                return queue_result;
+            }
+
             current_buffer++;
             free_slots--;
         }

--- a/engine/sound/src/sound.cpp
+++ b/engine/sound/src/sound.cpp
@@ -1792,16 +1792,14 @@ namespace dmSound
                 {
                     continue;
                 }
-                else
-                {
-                    MixContext mix_context(current_buffer, total_buffers, frame_count);
-                    MixInstances(&mix_context);
 
-                    Master(&mix_context);
+                MixContext mix_context(current_buffer, total_buffers, frame_count);
+                MixInstances(&mix_context);
 
-                    buffer_index = sound->m_NextOutBuffer;
-                    sound->m_NextOutBuffer = (sound->m_NextOutBuffer + 1) % sound->m_OutBufferCount;
-                }
+                Master(&mix_context);
+
+                buffer_index = sound->m_NextOutBuffer;
+                sound->m_NextOutBuffer = (sound->m_NextOutBuffer + 1) % sound->m_OutBufferCount;
             }
 
             dmSound::Result queue_result;


### PR DESCRIPTION
Resolve sound deadlock on Windows when disconnecting sound device. 

Fixes https://github.com/defold/defold/issues/11298

Technical changes
Fixed the WASAPI backend so a disappearing sound device no longer deadlocks the engine.
