### PR TITLE
Re-enable stopped timers and add dev helper function

### DIFF
--- a/editor/src/dev/dev.clj
+++ b/editor/src/dev/dev.clj
@@ -1630,3 +1630,10 @@
                       (inc batch-index)
                       (conj! batches batch)))))
          (persistent! batches))))))
+
+(defn clear-enable-all! []
+  (clear-caches!)
+  (handler/enable-disabled-handlers!)
+  (ui/enable-stopped-timers!)
+  (println "Re-enabled all disabled handlers and timers")
+  nil)


### PR DESCRIPTION
This PR will add a private atom of a set called `stopped-timers` which will keep track of them so we can then restart them from a debug/dev function. More work can be done to do this automatically for users.

Related #11299
Possibly related: #3883


