### PR TITLE
Fixed Crash when using raycasts under certain conditions

### DIFF
--- a/engine/physics/src/physics/box2d/box2d_physics.cpp
+++ b/engine/physics/src/physics/box2d/box2d_physics.cpp
@@ -2105,6 +2105,12 @@ namespace dmPhysics
         ToB2(from2d, from, scale);
         b2Vec2 to;
         ToB2(to2d, to, scale);
+        
+        if (b2LengthSquared((to - from)) <= 0.0f)
+        {
+            dmLogWarning("Ray had 0 length when ray casting after applying physics scale, ignoring request.");
+            return;
+        }
 
         // Box2d V3 requires a translation vector, not a point
         b2Vec2 translate = b2Sub(to, from);

--- a/engine/physics/src/physics/box2d/box2d_physics.cpp
+++ b/engine/physics/src/physics/box2d/box2d_physics.cpp
@@ -2093,11 +2093,6 @@ namespace dmPhysics
 
         const Point3 from2d = Point3(request.m_From.getX(), request.m_From.getY(), 0.0);
         const Point3 to2d = Point3(request.m_To.getX(), request.m_To.getY(), 0.0);
-        if (lengthSqr(to2d - from2d) <= 0.0f)
-        {
-            dmLogWarning("Ray had 0 length when ray casting, ignoring request.");
-            return;
-        }
 
         float scale = world->m_Context->m_Scale;
 

--- a/engine/physics/src/physics/box2d_defold/box2d_defold_physics.cpp
+++ b/engine/physics/src/physics/box2d_defold/box2d_defold_physics.cpp
@@ -1396,18 +1396,26 @@ namespace dmPhysics
         }
 
         float scale = world->m_Context->m_Scale;
+        b2Vec2 from;
+        ToB2(from2d, from, scale);
+        b2Vec2 to;
+        ToB2(to2d, to, scale);
+        
+        if ((to - from).LengthSquared() <= 0.0f)
+        {
+            dmLogWarning("Ray had 0 length when ray casting after applying physics scale, ignoring request.");
+            return;
+        }
+
         ProcessRayCastResultCallback2D query;
         query.m_Request = &request;
         query.m_ReturnAllResults = request.m_ReturnAllResults;
         query.m_Context = world->m_Context;
         query.m_Results = &results;
-        b2Vec2 from;
-        ToB2(from2d, from, scale);
-        b2Vec2 to;
-        ToB2(to2d, to, scale);
         query.m_IgnoredUserData = request.m_IgnoredUserData;
         query.m_CollisionMask = request.m_Mask;
         query.m_Response.m_Hit = 0;
+
         world->m_World.RayCast(&query, from, to);
 
         if (!request.m_ReturnAllResults) {

--- a/engine/physics/src/physics/box2d_defold/box2d_defold_physics.cpp
+++ b/engine/physics/src/physics/box2d_defold/box2d_defold_physics.cpp
@@ -1389,13 +1389,9 @@ namespace dmPhysics
 
         const Point3 from2d = Point3(request.m_From.getX(), request.m_From.getY(), 0.0);
         const Point3 to2d = Point3(request.m_To.getX(), request.m_To.getY(), 0.0);
-        if (lengthSqr(to2d - from2d) <= 0.0f)
-        {
-            dmLogWarning("Ray had 0 length when ray casting, ignoring request.");
-            return;
-        }
 
         float scale = world->m_Context->m_Scale;
+        
         b2Vec2 from;
         ToB2(from2d, from, scale);
         b2Vec2 to;

--- a/engine/physics/src/physics/physics_3d.cpp
+++ b/engine/physics/src/physics/physics_3d.cpp
@@ -1213,6 +1213,12 @@ namespace dmPhysics
         ToBt(request.m_From, from, scale);
         btVector3 to;
         ToBt(request.m_To, to, scale);
+        
+        if ((to - from).length2() <= 0.0f)
+        {
+            dmLogWarning("Ray had 0 length when ray casting after applying physics scale, ignoring request.");
+            return;
+        }
 
         float inv_scale = world->m_Context->m_InvScale;
 

--- a/engine/physics/src/physics/physics_3d.cpp
+++ b/engine/physics/src/physics/physics_3d.cpp
@@ -1201,13 +1201,7 @@ namespace dmPhysics
     void RayCast3D(HWorld3D world, const RayCastRequest& request, dmArray<RayCastResponse>& results)
     {
         DM_PROFILE("RayCast3D");
-
-        if (lengthSqr(request.m_To - request.m_From) <= 0.0f)
-        {
-            dmLogWarning("Ray had 0 length when ray casting, ignoring request.");
-            return;
-        }
-
+        
         float scale = world->m_Context->m_Scale;
         btVector3 from;
         ToBt(request.m_From, from, scale);

--- a/engine/physics/src/physics/test/test_physics.cpp
+++ b/engine/physics/src/physics/test/test_physics.cpp
@@ -226,6 +226,7 @@ typedef jc_test_type1<Test2D> TestTypes;
 #endif
 
 TYPED_TEST_CASE(PhysicsTest, TestTypes);
+TYPED_TEST_CASE(PhysicsPrecisionRoundingTest, TestTypes);
 
 TYPED_TEST(PhysicsTest, BoxShape)
 {
@@ -1032,6 +1033,34 @@ TYPED_TEST(PhysicsTest, EmptyRayCasting)
 
     // Check that the result was not handled
     ASSERT_EQ(0u, result.m_UserData);
+}
+
+TYPED_TEST(PhysicsPrecisionRoundingTest, ZeroLengthRayCasting)
+{
+    dmArray<dmPhysics::RayCastResponse> hits;
+    hits.SetCapacity(8);
+
+    dmPhysics::RayCastRequest request;
+    request.m_UserId = 0;
+    request.m_Mask = 1;
+
+    // A zero length raycast from inputs
+    hits.SetSize(0);
+    request.m_From = Point3(0.0f, -13200000.0f, 0.0f);
+    request.m_To = Point3(0.0f, -13200000.0f, 0.0f);
+    request.m_ReturnAllResults = 0;
+    (*TestFixture::m_Test.m_RayCastFunc)(TestFixture::m_World, request, hits);
+
+    ASSERT_EQ(0u, hits.Size());
+
+    // A zero length raycast after applying scale
+    hits.SetSize(0);
+    request.m_From = Point3(0.0f, -13200000.0f, 0.0f);
+    request.m_To = Point3(0.0f, -13200001.0f, 0.0f);
+    request.m_ReturnAllResults = 0;
+    (*TestFixture::m_Test.m_RayCastFunc)(TestFixture::m_World, request, hits);
+
+    ASSERT_EQ(0u, hits.Size());
 }
 
 TYPED_TEST(PhysicsTest, RayCasting)

--- a/engine/physics/src/physics/test/test_physics.h
+++ b/engine/physics/src/physics/test/test_physics.h
@@ -38,6 +38,7 @@ bool CollisionCallback(void* user_data_a, uint16_t group_a, void* user_data_b, u
 bool ContactPointCallback(const dmPhysics::ContactPoint& contact_point, void* user_data);
 
 static const float PHYSICS_SCALE = 0.5f;
+static const float PRECISION_ROUNDING_PHYSICS_SCALE = 0.00999999978f;
 
 template<typename T>
 class PhysicsTest : public jc_test_base_class
@@ -46,8 +47,13 @@ protected:
 
     virtual void SetUp()
     {
+        SetupContextAndWorld(PHYSICS_SCALE);
+    }
+
+    void SetupContextAndWorld(float physics_scale)
+    {
         dmPhysics::NewContextParams context_params = dmPhysics::NewContextParams();
-        context_params.m_Scale = PHYSICS_SCALE;
+        context_params.m_Scale = physics_scale;
         context_params.m_RayCastLimit2D = 64;
         context_params.m_RayCastLimit3D = 128;
         context_params.m_TriggerOverlapCapacity = 16;
@@ -82,6 +88,17 @@ protected:
     dmPhysics::StepWorldContext m_StepWorldContext;
     int m_CollisionCount;
     int m_ContactPointCount;
+};
+
+template<typename T>
+class PhysicsPrecisionRoundingTest : public PhysicsTest<T>
+{
+protected:
+
+    virtual void SetUp()
+    {
+        SetupContextAndWorld(PRECISION_ROUNDING_PHYSICS_SCALE);
+    }
 };
 
 template<typename T>

--- a/engine/physics/src/physics/test/test_physics.h
+++ b/engine/physics/src/physics/test/test_physics.h
@@ -97,7 +97,7 @@ protected:
 
     virtual void SetUp()
     {
-        SetupContextAndWorld(PRECISION_ROUNDING_PHYSICS_SCALE);
+        this->SetupContextAndWorld(PRECISION_ROUNDING_PHYSICS_SCALE);
     }
 };
 


### PR DESCRIPTION
This fixes a crash when the length of a 2D or 3D raycast is zero.
This fix specifically takes into account the case when the ray length becomes zero after applying the `physics.scale` setting in game.project.

Fixes #10312

### Technical notes
Added extra dmLogWarning if ray had 0 length after applying physics scale
Added Unit Test to test for zero length raycast before and oafter applying scale
