### PR TITLE
Mark `SetUp` and `TearDown` functions with `override`

### DIFF
--- a/engine/crash/src/test/test_crash.cpp
+++ b/engine/crash/src/test/test_crash.cpp
@@ -40,7 +40,7 @@ class dmCrashTest : public jc_test_base_class
 {
     public:
 
-        virtual void SetUp()
+        void SetUp() override
         {
 
             time_t t = time(NULL);
@@ -52,7 +52,7 @@ class dmCrashTest : public jc_test_base_class
             dmCrash::Init("TEST", m_EngineHash);
         }
 
-        virtual void TearDown()
+        void TearDown() override
         {
             dmCrash::Purge();
         }

--- a/engine/crash/src/test/test_script_crash.cpp
+++ b/engine/crash/src/test/test_script_crash.cpp
@@ -41,7 +41,7 @@ class ScriptCrashTest : public jc_test_base_class
 {
 protected:
 
-    virtual void SetUp()
+    void SetUp() override
     {
         dmCrash::Init("DefoldScriptTest", "0123456789abcdef");
 
@@ -69,7 +69,7 @@ protected:
         dmExtension::Initialize(&m_Params);
     }
 
-    virtual void TearDown()
+    void TearDown() override
     {
         dmConfigFile::Delete(m_ConfigFile);
         dmResource::DeleteFactory(m_ResourceFactory);

--- a/engine/crash/src/test/test_script_crash_null.cpp
+++ b/engine/crash/src/test/test_script_crash_null.cpp
@@ -40,7 +40,7 @@ extern "C"
 class ScriptCrashTest : public jc_test_base_class
 {
 protected:
-    virtual void SetUp()
+    void SetUp() override
     {
         dmCrash::Init("DefoldScriptTest", "0123456789abcdef");
 
@@ -64,7 +64,7 @@ protected:
 
     }
 
-    virtual void TearDown()
+    void TearDown() override
     {
         dmConfigFile::Delete(m_ConfigFile);
         dmResource::DeleteFactory(m_ResourceFactory);

--- a/engine/dlib/src/test/test_buffer.cpp
+++ b/engine/dlib/src/test/test_buffer.cpp
@@ -25,11 +25,11 @@
 
 class BufferTest : public jc_test_base_class
 {
-    virtual void SetUp() {
+    void SetUp() override {
         dmBuffer::NewContext();
     }
 
-    virtual void TearDown() {
+    void TearDown() override {
         dmBuffer::DeleteContext();
     }
 };
@@ -39,7 +39,7 @@ class MetaDataTest : public jc_test_base_class
 public:
     dmBuffer::HBuffer buffer;
 protected:
-    virtual void SetUp() {
+    void SetUp() override {
         dmBuffer::NewContext();
 
         dmBuffer::StreamDeclaration streams_decl[] = {
@@ -49,7 +49,7 @@ protected:
         dmBuffer::Create(4, streams_decl, 2, &buffer);
     }
 
-    virtual void TearDown() {
+    void TearDown() override {
         dmBuffer::Destroy(buffer);
         dmBuffer::DeleteContext();
     }
@@ -67,7 +67,7 @@ public:
     uint32_t          out_stride;
 
 protected:
-    virtual void SetUp() {
+    void SetUp() override {
         dmBuffer::NewContext();
 
         dmBuffer::StreamDeclaration streams_decl[] = {
@@ -80,7 +80,7 @@ protected:
         dmBuffer::Create(count, streams_decl, 2, &buffer);
     }
 
-    virtual void TearDown() {
+    void TearDown() override {
         dmBuffer::Destroy(buffer);
         dmBuffer::DeleteContext();
     }
@@ -105,12 +105,12 @@ public:
     uint32_t          out_stride;
 
 protected:
-    virtual void SetUp() {
+    void SetUp() override {
         dmBuffer::NewContext();
         buffer = 0x0;
     }
 
-    virtual void TearDown() {
+    void TearDown() override {
         dmBuffer::Destroy(buffer);
         dmBuffer::DeleteContext();
     }

--- a/engine/dlib/src/test/test_configfile.cpp
+++ b/engine/dlib/src/test/test_configfile.cpp
@@ -73,7 +73,7 @@ public:
     dmConfigFile::Result r;
     char* m_Buffer;
 
-    virtual void SetUp()
+    void SetUp() override
     {
         const uint32_t buffer_size = 1024 * 1024; // Big enough..
         m_Buffer = new char[buffer_size];
@@ -106,7 +106,7 @@ public:
         }
     }
 
-    virtual void TearDown()
+    void TearDown() override
     {
         delete [] m_Buffer;
         m_Buffer = 0;
@@ -390,14 +390,14 @@ static bool TestGetFloat(dmConfigFile::HConfig config, const char* key, float de
 DM_DECLARE_CONFIGFILE_EXTENSION(TestConfigfileExtension, "TestConfigfileExtension", TestCreate, TestDestroy, TestGetString, TestGetInt, TestGetFloat);
 
 class ConfigfileExtension : public ConfigTest {
-    virtual void SetUp()
+    void SetUp() override
     {
         g_ExtensionTestEnabled = 1;
         ConfigTest::SetUp();
 
         ASSERT_EQ(g_ExtensionTestCreated, 1);
     }
-    virtual void TearDown()
+    void TearDown() override
     {
         ConfigTest::TearDown();
         g_ExtensionTestEnabled = 0;

--- a/engine/dlib/src/test/test_connection_pool.cpp
+++ b/engine/dlib/src/test/test_connection_pool.cpp
@@ -35,7 +35,7 @@ class dmConnectionPoolTest: public jc_test_base_class
 public:
 
     dmConnectionPool::HPool pool;
-    virtual void SetUp()
+    void SetUp() override
     {
         dmConnectionPool::Params params;
         params.m_MaxConnections = MAX_CONNECTIONS;
@@ -52,7 +52,7 @@ public:
         ASSERT_EQ(in_use, stats.m_InUse);
     }
 
-    virtual void TearDown()
+    void TearDown() override
     {
         dmConnectionPool::Delete(pool);
     }

--- a/engine/dlib/src/test/test_dlib.cpp
+++ b/engine/dlib/src/test/test_dlib.cpp
@@ -25,7 +25,7 @@
 class dlib : public jc_test_base_class
 {
 protected:
-    virtual void SetUp()
+    void SetUp() override
     {
         dmHashEnableReverseHash(true);
     }

--- a/engine/dlib/src/test/test_httpcache.cpp
+++ b/engine/dlib/src/test/test_httpcache.cpp
@@ -26,7 +26,7 @@
 
 class dmHttpCacheTest : public jc_test_base_class
 {
-    virtual void SetUp()
+    void SetUp() override
     {
         char path[1024];
         dmTestUtil::MakeHostPath(path, sizeof(path), "tmp");

--- a/engine/dlib/src/test/test_httpclient.cpp
+++ b/engine/dlib/src/test/test_httpclient.cpp
@@ -215,7 +215,7 @@ public:
         CreateFile("tmp/http_files/d.txt", "You will find this data in a.txt and d.txt");
     }
 
-    virtual void SetUp()
+    void SetUp() override
     {
         m_Client = 0;
 
@@ -279,7 +279,7 @@ public:
         m_StatusCode = -1;
     }
 
-    virtual void TearDown()
+    void TearDown() override
     {
         if (m_Client)
             dmHttpClient::Delete(m_Client);
@@ -338,13 +338,13 @@ public:
         return r;
     }
 
-    virtual void SetUp()
+    void SetUp() override
     {
         m_Major = m_Minor = m_Status = m_ContentOffset = -1;
         m_StatusString = "NOT SET!";
     }
 
-    virtual void TearDown()
+    void TearDown() override
     {
     }
 };

--- a/engine/dlib/src/test/test_httpserver.cpp
+++ b/engine/dlib/src/test/test_httpserver.cpp
@@ -159,7 +159,7 @@ public:
         T_ASSERT_LE(iter, 10000);
     }
 
-    virtual void SetUp()
+    void SetUp() override
     {
         m_Quit = 0;
         m_ServerStarted = 0;
@@ -173,7 +173,7 @@ public:
         ASSERT_EQ(dmHttpServer::RESULT_OK, result_server);
     }
 
-    virtual void TearDown()
+    void TearDown() override
     {
         if (m_Server)
             dmHttpServer::Delete(m_Server);
@@ -222,12 +222,12 @@ public:
         return r;
     }
 
-    virtual void SetUp()
+    void SetUp() override
     {
         m_Major = m_Minor = m_ContentOffset = -1;
     }
 
-    virtual void TearDown()
+    void TearDown() override
     {
     }
 };

--- a/engine/dlib/src/test/test_ssdp.cpp
+++ b/engine/dlib/src/test/test_ssdp.cpp
@@ -159,7 +159,7 @@ public:
         UpdateClient();
     }
 
-    virtual void SetUp()
+    void SetUp() override
     {
         m_DeviceUDN = (char*) calloc(43, sizeof(char));
         m_DeviceUSN = (char*) calloc(60, sizeof(char));
@@ -187,7 +187,7 @@ public:
         m_Server = 0;
     }
 
-    virtual void TearDown()
+    void TearDown() override
     {
         dmSSDP::Result r;
 

--- a/engine/dlib/src/test/test_ssdp_internals.cpp
+++ b/engine/dlib/src/test/test_ssdp_internals.cpp
@@ -152,12 +152,12 @@ class dmSSDPInternalTest: public jc_test_base_class
 {
 public:
 
-    virtual void SetUp()
+    void SetUp() override
     {
         dmSocket::Initialize();
     }
 
-    virtual void TearDown()
+    void TearDown() override
     {
         dmSocket::Finalize();
     }

--- a/engine/dlib/src/test/test_webserver.cpp
+++ b/engine/dlib/src/test/test_webserver.cpp
@@ -81,7 +81,7 @@ public:
         self->m_Quit = true;
     }
 
-    virtual void SetUp()
+    void SetUp() override
     {
         m_Quit = false;
         m_ServerStarted = false;
@@ -103,7 +103,7 @@ public:
         dmWebServer::AddHandler(m_Server, "/header_mul", &handler_params);
     }
 
-    virtual void TearDown()
+    void TearDown() override
     {
         if (m_Server)
         {

--- a/engine/engine/src/test/test_engine.h
+++ b/engine/engine/src/test/test_engine.h
@@ -29,12 +29,12 @@
 class EngineTest : public jc_test_base_class
 {
 protected:
-    virtual void SetUp()
+    void SetUp() override
     {
         m_DT = 1.0f / 60.0f;
     }
 
-    virtual void TearDown()
+    void TearDown() override
     {
     }
 
@@ -46,14 +46,14 @@ template<typename T>
 class EngineParamsTest : public jc_test_params_class<T>
 {
 protected:
-    virtual void SetUp()
+    void SetUp() override
     {
         m_DT = 1.0f / 60.0f;
         dmEngineInitialize();
         m_Engine = dmEngine::New(0);
     }
 
-    virtual void TearDown()
+    void TearDown() override
     {
         dmEngine::Delete(m_Engine);
         dmEngineFinalize();

--- a/engine/gameobject/src/gameobject/test/anim/test_gameobject_anim.cpp
+++ b/engine/gameobject/src/gameobject/test/anim/test_gameobject_anim.cpp
@@ -26,7 +26,7 @@
 class AnimTest : public jc_test_base_class
 {
 protected:
-    virtual void SetUp()
+    void SetUp() override
     {
         m_UpdateContext.m_DT = 1.0f / 60.0f ;
 
@@ -59,7 +59,7 @@ protected:
         m_CancelCount = 0;
     }
 
-    virtual void TearDown()
+    void TearDown() override
     {
         dmGameObject::DeleteCollection(m_Collection);
         dmGameObject::PostUpdate(m_Register);

--- a/engine/gameobject/src/gameobject/test/bones/test_gameobject_bones.cpp
+++ b/engine/gameobject/src/gameobject/test/bones/test_gameobject_bones.cpp
@@ -28,7 +28,7 @@ using namespace dmVMath;
 class BonesTest : public jc_test_base_class
 {
 protected:
-    virtual void SetUp()
+    void SetUp() override
     {
         m_UpdateContext.m_DT = 1.0f / 60.0f;
 
@@ -79,7 +79,7 @@ protected:
         ASSERT_EQ(dmGameObject::RESULT_OK, result);
     }
 
-    virtual void TearDown()
+    void TearDown() override
     {
         dmScript::Finalize(m_ScriptContext);
         dmScript::DeleteContext(m_ScriptContext);

--- a/engine/gameobject/src/gameobject/test/collection/test_gameobject_collection.cpp
+++ b/engine/gameobject/src/gameobject/test/collection/test_gameobject_collection.cpp
@@ -32,7 +32,7 @@ using namespace dmVMath;
 class CollectionTest : public jc_test_base_class
 {
 protected:
-    virtual void SetUp()
+    void SetUp() override
     {
         m_UpdateContext.m_DT = 1.0f / 60.0f;
 
@@ -84,7 +84,7 @@ protected:
         ASSERT_EQ(dmGameObject::RESULT_OK, result);
     }
 
-    virtual void TearDown()
+    void TearDown() override
     {
         dmGameObject::DeleteCollection(m_Collection);
         dmGameObject::PostUpdate(m_Register);

--- a/engine/gameobject/src/gameobject/test/collection/test_gameobject_limit.cpp
+++ b/engine/gameobject/src/gameobject/test/collection/test_gameobject_limit.cpp
@@ -28,7 +28,7 @@ using namespace dmVMath;
 class CollectionLimitTest : public jc_test_base_class
 {
 protected:
-    virtual void SetUp()
+    void SetUp() override
     {
         m_UpdateContext.m_DT = 1.0f / 60.0f;
 
@@ -58,7 +58,7 @@ protected:
         dmGameObject::SortComponentTypes(m_Register);
     }
 
-    virtual void TearDown()
+    void TearDown() override
     {
         if (m_Collection)
         {

--- a/engine/gameobject/src/gameobject/test/component/test_gameobject_component.cpp
+++ b/engine/gameobject/src/gameobject/test/component/test_gameobject_component.cpp
@@ -32,7 +32,7 @@
 class ComponentTest : public jc_test_base_class
 {
 protected:
-    virtual void SetUp()
+    void SetUp() override
     {
         m_UpdateCount = 0;
         m_UpdateContext.m_DT = 1.0f / 60.0f;
@@ -135,7 +135,7 @@ protected:
         m_MaxComponentCreateCountMap[TestGameObjectDDF::AResource::m_DDFHash] = 1000000;
     }
 
-    virtual void TearDown()
+    void TearDown() override
     {
         dmGameObject::DeleteCollection(m_Collection);
         dmGameObject::PostUpdate(m_Register);

--- a/engine/gameobject/src/gameobject/test/delete/test_gameobject_delete.cpp
+++ b/engine/gameobject/src/gameobject/test/delete/test_gameobject_delete.cpp
@@ -28,7 +28,7 @@
 class DeleteTest : public jc_test_base_class
 {
 protected:
-    virtual void SetUp()
+    void SetUp() override
     {
         m_UpdateContext.m_DT = 1.0f / 60.0f;
 
@@ -75,7 +75,7 @@ protected:
         ASSERT_EQ(dmGameObject::RESULT_OK, result);
     }
 
-    virtual void TearDown()
+    void TearDown() override
     {
         dmGameObject::DeleteCollection(m_Collection);
         dmGameObject::PostUpdate(m_Register);

--- a/engine/gameobject/src/gameobject/test/factory/test_gameobject_factory.cpp
+++ b/engine/gameobject/src/gameobject/test/factory/test_gameobject_factory.cpp
@@ -33,7 +33,7 @@ using namespace dmVMath;
 class FactoryTest : public jc_test_base_class
 {
 protected:
-    virtual void SetUp()
+    void SetUp() override
     {
         m_UpdateContext.m_DT = 1.0f / 60.0f;
 
@@ -84,7 +84,7 @@ protected:
         ASSERT_EQ(dmGameObject::RESULT_OK, result);
     }
 
-    virtual void TearDown()
+    void TearDown() override
     {
         dmGameObject::DeleteCollection(m_Collection);
         dmGameObject::PostUpdate(m_Register);

--- a/engine/gameobject/src/gameobject/test/hierarchy/test_gameobject_hierarchy.cpp
+++ b/engine/gameobject/src/gameobject/test/hierarchy/test_gameobject_hierarchy.cpp
@@ -33,7 +33,7 @@ using namespace dmVMath;
 class HierarchyTest : public jc_test_base_class
 {
 protected:
-    virtual void SetUp()
+    void SetUp() override
     {
         m_UpdateContext.m_DT = 1.0f / 60.0f;
 
@@ -66,7 +66,7 @@ protected:
         m_Collection = dmGameObject::NewCollection("collection", m_Factory, m_Register, 1024, 0x0);
     }
 
-    virtual void TearDown()
+    void TearDown() override
     {
         dmGameObject::DeleteCollection(m_Collection);
         dmGameObject::PostUpdate(m_Register);

--- a/engine/gameobject/src/gameobject/test/id/test_gameobject_id.cpp
+++ b/engine/gameobject/src/gameobject/test/id/test_gameobject_id.cpp
@@ -22,7 +22,7 @@
 class IdTest : public jc_test_base_class
 {
 protected:
-    virtual void SetUp()
+    void SetUp() override
     {
         m_UpdateContext.m_DT = 1.0f / 60.0f;
 
@@ -53,7 +53,7 @@ protected:
         m_Collection = dmGameObject::NewCollection("collection", m_Factory, m_Register, 1024, 0x0);
     }
 
-    virtual void TearDown()
+    void TearDown() override
     {
         dmGameObject::DeleteCollection(m_Collection);
         dmGameObject::PostUpdate(m_Register);

--- a/engine/gameobject/src/gameobject/test/input/test_gameobject_input.cpp
+++ b/engine/gameobject/src/gameobject/test/input/test_gameobject_input.cpp
@@ -31,7 +31,7 @@ using namespace dmVMath;
 class InputTest : public jc_test_base_class
 {
 protected:
-    virtual void SetUp()
+    void SetUp() override
     {
         m_InputCounter = 0;
 
@@ -81,7 +81,7 @@ protected:
         ASSERT_EQ(dmGameObject::RESULT_OK, result);
     }
 
-    virtual void TearDown()
+    void TearDown() override
     {
         dmGameObject::DeleteCollection(m_Collection);
         dmGameObject::PostUpdate(m_Register);

--- a/engine/gameobject/src/gameobject/test/message/test_gameobject_message.cpp
+++ b/engine/gameobject/src/gameobject/test/message/test_gameobject_message.cpp
@@ -35,7 +35,7 @@ void DispatchCallback(dmMessage::Message *message, void* user_ptr);
 class MessageTest : public jc_test_base_class
 {
 protected:
-    virtual void SetUp()
+    void SetUp() override
     {
         m_UpdateContext.m_DT = 1.0f / 60.0f;
 
@@ -92,7 +92,7 @@ protected:
     }
 
 
-    virtual void TearDown()
+    void TearDown() override
     {
         dmMessage::DeleteSocket(m_Socket);
         dmGameObject::DeleteCollection(m_Collection);

--- a/engine/gameobject/src/gameobject/test/props/test_gameobject_props.cpp
+++ b/engine/gameobject/src/gameobject/test/props/test_gameobject_props.cpp
@@ -66,7 +66,7 @@ dmGameObject::PropertyResult CompNoUserDataSetProperties(const dmGameObject::Com
 class PropsTest : public jc_test_base_class
 {
 protected:
-    virtual void SetUp()
+    void SetUp() override
     {
         dmResource::NewFactoryParams params;
         params.m_MaxResources = 16;
@@ -115,7 +115,7 @@ protected:
         ASSERT_EQ(dmGameObject::RESULT_OK, result);
     }
 
-    virtual void TearDown()
+    void TearDown() override
     {
         dmGameObject::DeleteCollection(m_Collection);
         dmGameObject::PostUpdate(m_Register);

--- a/engine/gameobject/src/gameobject/test/reload/test_collection_reload.cpp
+++ b/engine/gameobject/src/gameobject/test/reload/test_collection_reload.cpp
@@ -61,7 +61,7 @@ static void ResetWorldCounters(Stats* stats) {
 class ReloadCollectionTest : public jc_test_base_class
 {
 protected:
-    virtual void SetUp()
+    void SetUp() override
     {
         m_NewResource = 0x0;
 
@@ -122,7 +122,7 @@ protected:
         m_Collection = 0;
     }
 
-    virtual void TearDown()
+    void TearDown() override
     {
         if (m_Collection)
             dmGameObject::DeleteCollection(m_Collection);

--- a/engine/gameobject/src/gameobject/test/reload/test_gameobject_reload.cpp
+++ b/engine/gameobject/src/gameobject/test/reload/test_gameobject_reload.cpp
@@ -60,7 +60,7 @@ static void ResetWorldCounters(ReloadTargetWorld* world) {
 class ReloadTest : public jc_test_base_class
 {
 protected:
-    virtual void SetUp()
+    void SetUp() override
     {
         m_NewResource = 0x0;
 
@@ -119,7 +119,7 @@ protected:
         m_Collection = dmGameObject::NewCollection("collection", m_Factory, m_Register, 1024, 0x0);
     }
 
-    virtual void TearDown()
+    void TearDown() override
     {
         dmGameObject::DeleteCollection(m_Collection);
         dmGameObject::PostUpdate(m_Register);

--- a/engine/gameobject/src/gameobject/test/script/test_gameobject_script.cpp
+++ b/engine/gameobject/src/gameobject/test/script/test_gameobject_script.cpp
@@ -33,7 +33,7 @@ using namespace dmVMath;
 class ScriptTest : public jc_test_base_class
 {
 protected:
-    virtual void SetUp()
+    void SetUp() override
     {
         m_UpdateContext.m_DT = 1.0f / 60.0f;
 
@@ -73,7 +73,7 @@ protected:
         assert(result == dmMessage::RESULT_OK);
     }
 
-    virtual void TearDown()
+    void TearDown() override
     {
         dmMessage::DeleteSocket(m_Socket);
         dmGameObject::DeleteCollection(m_Collection);

--- a/engine/gameobject/src/gameobject/test/spawn_delete/test_gameobject_spawn_delete.cpp
+++ b/engine/gameobject/src/gameobject/test/spawn_delete/test_gameobject_spawn_delete.cpp
@@ -61,7 +61,7 @@ static int Lua_Spawn(lua_State* L) {
 class SpawnDeleteTest : public jc_test_base_class
 {
 protected:
-    virtual void SetUp()
+    void SetUp() override
     {
         m_UpdateContext.m_DT = 1.0f / 60.0f;
 
@@ -131,7 +131,7 @@ protected:
         m_Collection = NewCollection("collection", m_Factory, m_Register, 10u, 0x0);
     }
 
-    virtual void TearDown()
+    void TearDown() override
     {
         dmGameObject::DeleteCollection(m_Collection);
         dmMessage::DeleteSocket(m_Socket);

--- a/engine/gamesys/src/gamesys/test/test_gamesys.h
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.h
@@ -90,7 +90,7 @@ protected:
         m_projectOptions = options;
     }
 
-    virtual void SetUp() = 0;
+    void SetUp() override = 0;
 };
 
 template<typename T>
@@ -108,8 +108,8 @@ public:
         this->m_projectOptions.m_VelocityThreshold = 1.0f;
     }
 protected:
-    virtual void SetUp();
-    virtual void TearDown();
+    void SetUp() override;
+    void TearDown() override;
     void SetupComponentCreateContext(dmGameObject::ComponentTypeCreateCtx& component_create_ctx);
 
     void WaitForTestsDone(int update_count, bool render, bool* result);
@@ -166,7 +166,7 @@ public:
         dmGameSystem::InitializeScriptLibs(m_Scriptlibcontext);
     }
 
-    virtual void TearDown()
+    void TearDown() override
     {
         dmGameSystem::FinalizeScriptLibs(m_Scriptlibcontext);
 
@@ -789,7 +789,7 @@ void GamesysTest<T>::WaitForTestsDone(int update_count, bool render, bool* resul
 class ScriptImageTest : public GamesysTest<const char*>
 {
 protected:
-    virtual void SetUp()
+    void SetUp() override
     {
         GamesysTest::SetUp();
 
@@ -802,7 +802,7 @@ protected:
 
         L = dmScript::GetLuaState(m_ScriptContext);
     }
-    virtual void TearDown()
+    void TearDown() override
     {
         dmGameSystem::FinalizeScriptLibs(m_ScriptLibContext);
         GamesysTest::TearDown();
@@ -816,7 +816,7 @@ protected:
 class ScriptBufferTest : public jc_test_base_class
 {
 protected:
-    virtual void SetUp()
+    void SetUp() override
     {
         dmBuffer::NewContext();
 
@@ -841,7 +841,7 @@ protected:
         dmBuffer::Create(m_Count, streams_decl, 2, &m_Buffer);
     }
 
-    virtual void TearDown()
+    void TearDown() override
     {
         if( m_Buffer )
             dmBuffer::Destroy(m_Buffer);
@@ -872,7 +872,7 @@ struct CopyBufferTestParams
 class ScriptBufferCopyTest : public jc_test_params_class<CopyBufferTestParams>
 {
 protected:
-    virtual void SetUp()
+    void SetUp() override
     {
         dmBuffer::NewContext();
         dmScript::ContextParams script_context_params = {};
@@ -897,7 +897,7 @@ protected:
         dmBuffer::Create(p.m_Count, streams_decl, 2, &m_Buffer);
     }
 
-    virtual void TearDown()
+    void TearDown() override
     {
         dmBuffer::Destroy(m_Buffer);
 
@@ -918,7 +918,7 @@ protected:
 class LabelTest : public jc_test_base_class
 {
 protected:
-    virtual void SetUp()
+    void SetUp() override
     {
         m_Position = dmVMath::Point3(0.0);
         m_Size = dmVMath::Vector3(2.0, 2.0, 0.0);

--- a/engine/gamesys/src/gamesys/test/test_script_http.cpp
+++ b/engine/gamesys/src/gamesys/test/test_script_http.cpp
@@ -105,7 +105,7 @@ public:
 
 protected:
 
-    virtual void SetUp()
+    void SetUp() override
     {
         char path[1024];
         dmTestUtil::MakeHostPath(path, sizeof(path), "src/gamesys/test/http/test_http.config.raw");
@@ -190,7 +190,7 @@ protected:
         m_NumberOfFails = 0;
     }
 
-    virtual void TearDown()
+    void TearDown() override
     {
         dmScript::GetInstance(L);
         ScriptInstance* script_instance = (ScriptInstance*)lua_touserdata(L, -1);

--- a/engine/graphics/src/test/test_graphics.cpp
+++ b/engine/graphics/src/test/test_graphics.cpp
@@ -82,7 +82,7 @@ public:
         return data->m_ShouldClose;
     }
 
-    virtual void SetUp()
+    void SetUp() override
     {
         dmGraphics::InstallAdapter();
 
@@ -122,7 +122,7 @@ public:
         m_ResizeData.m_Height = 0;
     }
 
-    virtual void TearDown()
+    void TearDown() override
     {
         if (m_JobThread)
             dmJobThread::Destroy(m_JobThread);

--- a/engine/gui/src/test/test_gui.cpp
+++ b/engine/gui/src/test/test_gui.cpp
@@ -132,7 +132,7 @@ public:
 
     DynamicTextureContainer m_DynamicTextures;
 
-    virtual void SetUp()
+    void SetUp() override
     {
         dmScript::ContextParams script_context_params = {};
         m_ScriptContext = dmScript::NewContext(script_context_params);
@@ -194,7 +194,7 @@ public:
         }
     }
 
-    virtual void TearDown()
+    void TearDown() override
     {
         dmParticle::DestroyContext(m_Scene->m_ParticlefxContext);
         dmGui::DeleteScript(m_Script);

--- a/engine/gui/src/test/test_gui_clipping.cpp
+++ b/engine/gui/src/test/test_gui_clipping.cpp
@@ -146,7 +146,7 @@ public:
         m_Renderer.Clear();
     }
 
-    virtual void SetUp()
+    void SetUp() override
     {
         dmScript::ContextParams script_context_params = {};
         m_ScriptContext = dmScript::NewContext(script_context_params);
@@ -163,7 +163,7 @@ public:
         Clear();
     }
 
-    virtual void TearDown()
+    void TearDown() override
     {
         dmGui::DeleteScene(m_Scene);
         dmGui::DeleteContext(m_Context, m_ScriptContext);

--- a/engine/gui/src/test/test_gui_script.cpp
+++ b/engine/gui/src/test/test_gui_script.cpp
@@ -66,7 +66,7 @@ public:
 
     DynamicTextureContainer m_DynamicTextures;
 
-    virtual void SetUp()
+    void SetUp() override
     {
         dmPlatform::WindowParams window_params = {};
         window_params.m_Width                  = 2;
@@ -95,7 +95,7 @@ public:
         m_RenderParams.m_RenderNodes = RenderNodesStoreTransform;
     }
 
-    virtual void TearDown()
+    void TearDown() override
     {
         dmGui::DeleteContext(m_Context, m_ScriptContext);
         dmScript::Finalize(m_ScriptContext);

--- a/engine/hid/src/test/test_hid.cpp
+++ b/engine/hid/src/test/test_hid.cpp
@@ -20,7 +20,7 @@
 class HIDTest : public jc_test_base_class
 {
 protected:
-    virtual void SetUp()
+    void SetUp() override
     {
         m_Context = dmHID::NewContext(dmHID::NewContextParams());
         dmHID::Init(m_Context);
@@ -35,7 +35,7 @@ protected:
 
     }
 
-    virtual void TearDown()
+    void TearDown() override
     {
         dmHID::Final(m_Context);
         dmHID::DeleteContext(m_Context);

--- a/engine/input/src/test/test_input.cpp
+++ b/engine/input/src/test/test_input.cpp
@@ -37,7 +37,7 @@
 class InputTest : public jc_test_base_class
 {
 protected:
-    virtual void SetUp()
+    void SetUp() override
     {
         m_HidContext = dmHID::NewContext(dmHID::NewContextParams());
         dmHID::Init(m_HidContext);
@@ -66,7 +66,7 @@ protected:
         #undef HOSTPATH
     }
 
-    virtual void TearDown()
+    void TearDown() override
     {
         dmDDF::FreeMessage(m_TestDDF);
         dmDDF::FreeMessage(m_Test2DDF);

--- a/engine/liveupdate/src/test/test_liveupdate_job.cpp
+++ b/engine/liveupdate/src/test/test_liveupdate_job.cpp
@@ -30,14 +30,14 @@ class AsyncTestSingleThread : public jc_test_base_class
 #endif
 {
 public:
-    virtual void SetUp()
+    void SetUp() override
     {
         dmJobThread::JobThreadCreationParams job_thread_create_param;
         job_thread_create_param.m_ThreadNames[0] = "test_jobs";
         job_thread_create_param.m_ThreadCount    = 1;
         m_JobThread = dmJobThread::Create(job_thread_create_param);
     }
-    virtual void TearDown()
+    void TearDown() override
     {
         dmJobThread::Destroy(m_JobThread);
     }

--- a/engine/particle/src/test/test_particle.cpp
+++ b/engine/particle/src/test/test_particle.cpp
@@ -59,7 +59,7 @@ static inline void FillAttribute(dmGraphics::VertexAttributeInfo& info, dmhash_t
 class ParticleTest : public jc_test_base_class
 {
 protected:
-    virtual void SetUp()
+    void SetUp() override
     {
         m_Context = dmParticle::CreateContext(64, 1024);
         assert(m_Context != 0);
@@ -76,7 +76,7 @@ protected:
         m_AttributeInfos.m_VertexStride = sizeof(TestVertex);
     }
 
-    virtual void TearDown()
+    void TearDown() override
     {
         if (m_Prototype != 0x0)
         {

--- a/engine/physics/src/physics/test/test_physics.h
+++ b/engine/physics/src/physics/test/test_physics.h
@@ -44,7 +44,7 @@ class PhysicsTest : public jc_test_base_class
 {
 protected:
 
-    virtual void SetUp()
+    void SetUp() override
     {
         dmPhysics::NewContextParams context_params = dmPhysics::NewContextParams();
         context_params.m_Scale = PHYSICS_SCALE;
@@ -70,7 +70,7 @@ protected:
         m_StepWorldContext.m_Box2DSubStepCount = 10;
     }
 
-    virtual void TearDown()
+    void TearDown() override
     {
         (*m_Test.m_DeleteWorldFunc)(m_Context, m_World);
         (*m_Test.m_DeleteContextFunc)(m_Context);

--- a/engine/platform/src/test/test_platform.cpp
+++ b/engine/platform/src/test/test_platform.cpp
@@ -42,7 +42,7 @@ protected:
         data->m_Height = height;
     }
 
-    virtual void SetUp()
+    void SetUp() override
     {
         m_Window = dmPlatform::NewWindow();
 
@@ -62,7 +62,7 @@ protected:
         dmPlatform::OpenWindow(m_Window, params);
     }
 
-    virtual void TearDown()
+    void TearDown() override
     {
         dmPlatform::DeleteWindow(m_Window);
     }

--- a/engine/render/src/test/test_render.cpp
+++ b/engine/render/src/test/test_render.cpp
@@ -71,7 +71,7 @@ protected:
     dmRender::HFontMap m_SystemFontMap;
     dmRender::FontGlyph m_Glyphs[128];
 
-    virtual void SetUp()
+    void SetUp() override
     {
         dmGraphics::InstallAdapter();
 
@@ -127,7 +127,7 @@ protected:
         dmRender::SetFontMapUserData(m_SystemFontMap, m_Glyphs);
     }
 
-    virtual void TearDown()
+    void TearDown() override
     {
         dmRender::DeleteRenderContext(m_Context, 0);
         dmRender::DeleteFontMap(m_SystemFontMap);

--- a/engine/render/src/test/test_render_buffer.cpp
+++ b/engine/render/src/test/test_render_buffer.cpp
@@ -30,7 +30,7 @@ public:
     dmRender::RenderContextParams m_Params;
     bool                          m_MultiBufferingRequired;
 
-    virtual void SetUp()
+    void SetUp() override
     {
         dmGraphics::InstallAdapter();
 
@@ -56,7 +56,7 @@ public:
 
         m_MultiBufferingRequired = m_RenderContext->m_MultiBufferingRequired;
     }
-    virtual void TearDown()
+    void TearDown() override
     {
         dmRender::DeleteRenderContext(m_RenderContext, 0);
         dmGraphics::DeleteContext(m_GraphicsContext);

--- a/engine/render/src/test/test_render_programs.cpp
+++ b/engine/render/src/test/test_render_programs.cpp
@@ -45,7 +45,7 @@ public:
     dmRender::HRenderContext      m_RenderContext;
     dmRender::RenderContextParams m_Params;
 
-    virtual void SetUp()
+    void SetUp() override
     {
         dmGraphics::InstallAdapter();
 
@@ -69,7 +69,7 @@ public:
         m_Params.m_MaxBatches    = 128;
         m_RenderContext          = dmRender::NewRenderContext(m_GraphicsContext, m_Params);
     }
-    virtual void TearDown()
+    void TearDown() override
     {
         dmRender::DeleteRenderContext(m_RenderContext, 0);
         dmGraphics::DeleteContext(m_GraphicsContext);

--- a/engine/render/src/test/test_render_script.cpp
+++ b/engine/render/src/test/test_render_script.cpp
@@ -78,7 +78,7 @@ protected:
 
     dmRender::HComputeProgram m_Compute;
 
-    virtual void SetUp()
+    void SetUp() override
     {
         dmGraphics::InstallAdapter();
 
@@ -150,7 +150,7 @@ protected:
         m_Compute = dmRender::NewComputeProgram(m_Context, m_ComputeProgram);
     }
 
-    virtual void TearDown()
+    void TearDown() override
     {
         dmGraphics::DeleteProgram(m_GraphicsContext, m_FontProgram);
         dmGraphics::DeleteProgram(m_GraphicsContext, m_ComputeProgram);

--- a/engine/resource/src/test/test_provider_archive.cpp
+++ b/engine/resource/src/test/test_provider_archive.cpp
@@ -107,7 +107,7 @@ TEST(ArchiveProviderBasic, CanMount)
 class ArchiveProviderArchive : public jc_test_base_class
 {
 protected:
-    virtual void SetUp()
+    void SetUp() override
     {
         m_Loader = dmResourceProvider::FindLoaderByName(dmHashString64("archive"));
         ASSERT_NE((ArchiveLoader*)0, m_Loader);
@@ -128,7 +128,7 @@ protected:
         ASSERT_EQ(dmResourceProvider::RESULT_OK, result);
     }
 
-    virtual void TearDown()
+    void TearDown() override
     {
         dmResourceProvider::Result result = dmResourceProvider::Unmount(m_Archive);
         ASSERT_EQ(dmResourceProvider::RESULT_OK, result);
@@ -258,7 +258,7 @@ struct InMemoryParams
 class ArchiveProviderArchiveInMemory : public jc_test_params_class<InMemoryParams>
 {
 protected:
-    virtual void SetUp()
+    void SetUp() override
     {
         const InMemoryParams& params = GetParam();
 
@@ -279,7 +279,7 @@ protected:
         ASSERT_EQ(dmResourceProvider::RESULT_OK, result);
     }
 
-    virtual void TearDown()
+    void TearDown() override
     {
         dmResourceProvider::Result result = dmResourceProvider::Unmount(m_Archive);
         ASSERT_EQ(dmResourceProvider::RESULT_OK, result);

--- a/engine/resource/src/test/test_provider_archive_mutable.cpp
+++ b/engine/resource/src/test/test_provider_archive_mutable.cpp
@@ -167,7 +167,7 @@ protected:
         }
     }
 
-    virtual void SetUp()
+    void SetUp() override
     {
         m_BaseLoader = dmResourceProvider::FindLoaderByName(dmHashString64("archive"));
         ASSERT_NE((ArchiveLoader*)0, m_BaseLoader);
@@ -188,7 +188,7 @@ protected:
         }
     }
 
-    virtual void TearDown()
+    void TearDown() override
     {
         dmResourceProvider::Result result;
 

--- a/engine/resource/src/test/test_provider_file.cpp
+++ b/engine/resource/src/test/test_provider_file.cpp
@@ -65,7 +65,7 @@ TEST(FileProviderBasic, CanMount)
 class FileProviderArchive : public jc_test_base_class
 {
 protected:
-    virtual void SetUp()
+    void SetUp() override
     {
         m_Loader = dmResourceProvider::FindLoaderByName(dmHashString64("file"));
         ASSERT_NE((ArchiveLoader*)0, m_Loader);
@@ -84,7 +84,7 @@ protected:
         ASSERT_EQ(dmResourceProvider::RESULT_OK, result);
     }
 
-    virtual void TearDown()
+    void TearDown() override
     {
         dmResourceProvider::Result result = dmResourceProvider::Unmount(m_Archive);
         ASSERT_EQ(dmResourceProvider::RESULT_OK, result);

--- a/engine/resource/src/test/test_provider_http.cpp
+++ b/engine/resource/src/test/test_provider_http.cpp
@@ -88,7 +88,7 @@ public:
     }
 
 protected:
-    virtual void SetUp()
+    void SetUp() override
     {
         m_Loader = dmResourceProvider::FindLoaderByName(dmHashString64("http"));
         ASSERT_NE((ArchiveLoader*)0, m_Loader);
@@ -103,7 +103,7 @@ protected:
         ASSERT_EQ(dmResourceProvider::RESULT_OK, result);
     }
 
-    virtual void TearDown()
+    void TearDown() override
     {
         dmResourceProvider::Result result = dmResourceProvider::Unmount(m_Archive);
         ASSERT_EQ(dmResourceProvider::RESULT_OK, result);

--- a/engine/resource/src/test/test_provider_multi.cpp
+++ b/engine/resource/src/test/test_provider_multi.cpp
@@ -74,7 +74,7 @@ TEST(ArchiveProviderBasic, Registered)
 class ArchiveProvidersMulti : public jc_test_base_class
 {
 protected:
-    virtual void SetUp()
+    void SetUp() override
     {
         dmResourceProvider::ArchiveLoader* loader_file = dmResourceProvider::FindLoaderByName(dmHashString64("file"));
         dmResourceProvider::ArchiveLoader* loader_zip = dmResourceProvider::FindLoaderByName(dmHashString64("zip"));
@@ -126,7 +126,7 @@ protected:
         }
     }
 
-    virtual void TearDown()
+    void TearDown() override
     {
         for (uint32_t i = 0; i < DM_ARRAY_SIZE(m_Archives); ++i)
         {

--- a/engine/resource/src/test/test_provider_zip.cpp
+++ b/engine/resource/src/test/test_provider_zip.cpp
@@ -145,7 +145,7 @@ struct ZipParams
 class ArchiveProviderZip : public jc_test_params_class<ZipParams>
 {
 protected:
-    virtual void SetUp()
+    void SetUp() override
     {
 #if defined(__EMSCRIPTEN__)
         // Trigger the vsf init for emscripten (hidden in MakeHostPath)
@@ -165,7 +165,7 @@ protected:
         ASSERT_EQ(dmResourceProvider::RESULT_OK, result);
     }
 
-    virtual void TearDown()
+    void TearDown() override
     {
         dmResourceProvider::Result result = dmResourceProvider::Unmount(m_Archive);
         ASSERT_EQ(dmResourceProvider::RESULT_OK, result);

--- a/engine/resource/src/test/test_resource.cpp
+++ b/engine/resource/src/test/test_resource.cpp
@@ -80,7 +80,7 @@ extern uint32_t RESOURCES_DMANIFEST_SIZE;
 class ResourceTest : public jc_test_base_class
 {
 protected:
-    virtual void SetUp()
+    void SetUp() override
     {
         dmResource::NewFactoryParams params;
         params.m_MaxResources = 16;
@@ -90,7 +90,7 @@ protected:
         ASSERT_NE((void*) 0, factory);
     }
 
-    virtual void TearDown()
+    void TearDown() override
     {
         if (factory != NULL)
         {
@@ -104,7 +104,7 @@ protected:
 class DynamicResourceTest : public jc_test_base_class
 {
 protected:
-    virtual void SetUp()
+    void SetUp() override
     {
         const char* test_dir = "build/src/test";
         dmResource::NewFactoryParams params;
@@ -114,7 +114,7 @@ protected:
         ASSERT_NE((void*) 0, factory);
     }
 
-    virtual void TearDown()
+    void TearDown() override
     {
         if (factory != NULL)
         {
@@ -219,7 +219,7 @@ dmResource::Result FooResourceDestroy(const dmResource::ResourceDestroyParams* p
 class GetResourceTest : public jc_test_params_class<const char*>
 {
 protected:
-    virtual void SetUp()
+    void SetUp() override
     {
         m_ResourceContainerCreateCallCount = 0;
         m_ResourceContainerDestroyCallCount = 0;
@@ -253,7 +253,7 @@ protected:
         ASSERT_EQ(dmResource::RESULT_OK, e);
     }
 
-    virtual void TearDown()
+    void TearDown() override
     {
         if (m_Factory != NULL)
         {

--- a/engine/resource/src/test/test_resource_mounts.cpp
+++ b/engine/resource/src/test/test_resource_mounts.cpp
@@ -197,7 +197,7 @@ TEST(MountsFile, ReadFileWithSpaces)
 class ArchiveProvidersMounts : public jc_test_base_class
 {
 protected:
-    virtual void SetUp()
+    void SetUp() override
     {
         dmArray<dmResourceMounts::MountFileEntry> entries;
         entries.SetCapacity(8);
@@ -248,7 +248,7 @@ protected:
         result = dmResourceMounts::LoadMounts(m_Mounts, path);
     }
 
-    virtual void TearDown()
+    void TearDown() override
     {
         dmResourceMounts::Destroy(m_Mounts);
 

--- a/engine/rig/src/test/test_rig.cpp
+++ b/engine/rig/src/test/test_rig.cpp
@@ -880,7 +880,7 @@ public:
     dmRig::HRigContext m_Context;
 
 protected:
-    virtual void SetUp() {
+    void SetUp() override {
         dmRig::NewContextParams params = {0};
         params.m_MaxRigInstanceCount = 2;
         if (dmRig::RESULT_OK != dmRig::NewContext(params, &m_Context)) {
@@ -888,7 +888,7 @@ protected:
         }
     }
 
-    virtual void TearDown() {
+    void TearDown() override {
         dmRig::DeleteContext(m_Context);
     }
 };
@@ -899,7 +899,7 @@ class RigContextCursorTest : public jc_test_params_class<T>
 public:
     dmRig::HRigContext m_Context;
 
-    virtual void SetUp() {
+    void SetUp() override {
         dmRig::NewContextParams params = {0};
         params.m_MaxRigInstanceCount = 2;
         if (dmRig::RESULT_OK != dmRig::NewContext(params, &m_Context)) {
@@ -907,7 +907,7 @@ public:
         }
     }
 
-    virtual void TearDown() {
+    void TearDown() override {
         dmRig::DeleteContext(m_Context);
     }
 };
@@ -924,7 +924,7 @@ public:
     dmRigDDF::AnimationSet* m_AnimationSet;
 
 protected:
-    virtual void SetUp() {
+    void SetUp() override {
         RigContextCursorTest<T>::SetUp();
 
         m_Instance = 0x0;
@@ -950,7 +950,7 @@ protected:
         }
     }
 
-    virtual void TearDown() {
+    void TearDown() override {
         if (dmRig::RESULT_OK != dmRig::InstanceDestroy(RigContextCursorTest<T>::m_Context, m_Instance)) {
             dmLogError("Could not delete rig instance!");
         }
@@ -1158,7 +1158,7 @@ public:
     dmRigDDF::AnimationSet* m_AnimationSet;
 
 protected:
-    virtual void SetUp() {
+    void SetUp() override {
         RigContextTest::SetUp();
 
         m_Instance = 0x0;
@@ -1186,7 +1186,7 @@ protected:
         }
     }
 
-    virtual void TearDown() {
+    void TearDown() override {
         if (dmRig::RESULT_OK != dmRig::InstanceDestroy(m_Context, m_Instance)) {
             dmLogError("Could not delete rig instance!");
         }

--- a/engine/script/src/test/test_script.h
+++ b/engine/script/src/test/test_script.h
@@ -38,11 +38,11 @@ namespace dmScriptTest
     class ScriptTest : public jc_test_base_class
     {
     public:
-        virtual void SetUp();
+        void SetUp() override;
 
         void FinalizeLogs();
 
-        virtual void TearDown();
+        void TearDown() override;
         char* GetLog();
         void AppendToLog(const char* log);
 

--- a/engine/script/src/test/test_script_msg.cpp
+++ b/engine/script/src/test/test_script_msg.cpp
@@ -53,7 +53,7 @@ static const luaL_reg META_TABLE[] =
 class ScriptMsgTest : public jc_test_base_class
 {
 protected:
-    virtual void SetUp()
+    void SetUp() override
     {
         dmScript::ContextParams script_context_params = {};
         m_ScriptContext = dmScript::NewContext(script_context_params);
@@ -77,7 +77,7 @@ protected:
         assert(top == lua_gettop(L));
     }
 
-    virtual void TearDown()
+    void TearDown() override
     {
         lua_pushnil(L);
         dmScript::SetInstance(L);

--- a/engine/script/src/test/test_script_table_log.cpp
+++ b/engine/script/src/test/test_script_table_log.cpp
@@ -24,7 +24,7 @@
 class PushTableLoggerTest : public jc_test_base_class
 {
 protected:
-    virtual void SetUp()
+    void SetUp() override
     {
         m_Result[PUSH_TABLE_LOGGER_CAPACITY] = '\0';
     }

--- a/engine/script/src/test/test_script_types.cpp
+++ b/engine/script/src/test/test_script_types.cpp
@@ -24,7 +24,7 @@ class ScriptTypesTest : public dmScriptTest::ScriptTest
     ExtensionAppParams  m_AppParams;
     ExtensionParams     m_Params;
 
-    virtual void SetUp() override
+    void SetUp() override
     {
         dmScriptTest::ScriptTest::SetUp();
 
@@ -36,7 +36,7 @@ class ScriptTypesTest : public dmScriptTest::ScriptTest
         dmExtension::Initialize(&m_Params);
     }
 
-    virtual void TearDown() override
+    void TearDown() override
     {
         dmExtension::Finalize(&m_Params);
         dmExtension::AppFinalize(&m_AppParams);

--- a/engine/sound/src/test/test_sound.cpp
+++ b/engine/sound/src/test/test_sound.cpp
@@ -258,7 +258,7 @@ public:
         m_DeviceName = GetParam().m_DeviceName;
     }
 
-    virtual void SetUp()
+    void SetUp() override
     {
         dmSound::InitializeParams params;
         params.m_MaxBuffers = MAX_BUFFERS;
@@ -271,7 +271,7 @@ public:
         ASSERT_EQ(dmSound::RESULT_OK, r);
     }
 
-    virtual void TearDown()
+    void TearDown() override
     {
         dmTime::Sleep(10000); // waiting for sounds to finish playing (to make it less choppy)
         dmSound::Result r = dmSound::Finalize();
@@ -288,7 +288,7 @@ public:
         m_DeviceName = GetParam().m_DeviceName;
     }
 
-    virtual void SetUp()
+    void SetUp() override
     {
         dmSound::InitializeParams params;
         params.m_MaxBuffers = MAX_BUFFERS;
@@ -301,7 +301,7 @@ public:
         ASSERT_EQ(dmSound::RESULT_OK, r);
     }
 
-    virtual void TearDown()
+    void TearDown() override
     {
         dmSound::Result r = dmSound::Finalize();
         ASSERT_EQ(dmSound::RESULT_OK, r);

--- a/engine/sound/src/test/test_sound_perf.cpp
+++ b/engine/sound/src/test/test_sound_perf.cpp
@@ -54,12 +54,12 @@ class dmSoundTest : public jc_test_base_class
 {
 public:
 
-    virtual void SetUp()
+    void SetUp() override
     {
 
     }
 
-    virtual void TearDown()
+    void TearDown() override
     {
 
     }

--- a/engine/texc/src/test/test_texc.cpp
+++ b/engine/texc/src/test/test_texc.cpp
@@ -26,11 +26,11 @@
 class TexcTest : public jc_test_base_class
 {
 protected:
-    virtual void SetUp()
+    void SetUp() override
     {
     }
 
-    virtual void TearDown()
+    void TearDown() override
     {
     }
 };
@@ -390,7 +390,7 @@ CompileInfo compile_info[] =
 class TexcCompileTest : public jc_test_params_class<CompileInfo>
 {
 protected:
-    virtual void SetUp()
+    void SetUp() override
     {
         const CompileInfo& info = GetParam();
         uint8_t* image = stbi_load(info.m_Path, &m_Width, &m_Height, 0, 0);
@@ -399,7 +399,7 @@ protected:
         m_Image = dmTexc::CreateImage(info.m_Path, m_Width, m_Height, info.m_InputFormat, info.m_ColorSpace, m_Width*m_Height*4, image);
     }
 
-    virtual void TearDown()
+    void TearDown() override
     {
         dmTexc::DestroyImage(m_Image);
     }


### PR DESCRIPTION
As discussed in #11282: this PR marks all of the `SetUp()` and `TearDown()` functions with `override`.

I checked that all of the modified files contain `Copyright 2020-2025 The Defold Foundation` as a substring.

### Technical changes
* `SetUp()` and `TearDown()` override virtual functions and should be marked with `override` (cf. [C++ core guidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rh-override))
