### PR TITLE
Report debugger attaching exception through a notification

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -1418,7 +1418,7 @@
               :message (localization/message "notification.debug-view.connect-failed.error" {"error" "Testing"})})
             (throw (ex-info "Failed to attach to debugger"
                             {:type ::cannot-check-attach
-                             :suppressed? true}
+                             :suppress-dialog-window? true}
                             e))))))))
 
 (def ^:private clean-build-dialog-info

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -96,7 +96,7 @@
            [com.dynamo.bob Platform]
            [com.sun.javafx.scene NodeHelper]
            [java.io File PipedInputStream PipedOutputStream]
-           [java.net URL SocketTimeoutException]
+           [java.net SocketTimeoutException URL]
            [java.util Arrays Collection List]
            [java.util.concurrent ExecutionException]
            [javafx.beans.value ChangeListener]
@@ -873,7 +873,7 @@
 (defn- on-service-url-found [prefs target]
   (engine/apply-simulated-resolution! prefs target))
 
-(defn- launch-built-project! [project workspace engine-descriptor project-directory prefs web-server debug?]
+(defn- launch-built-project! [project engine-descriptor project-directory prefs web-server debug?]
   (let [selected-target (targets/selected-target prefs)
         launch-new-engine! (fn []
                              (targets/kill-launched-targets!)
@@ -919,7 +919,7 @@
               (reboot-engine! selected-target web-server debug?))
             (launch-new-engine!))))
       (catch SocketTimeoutException e
-        (debug-view/show-connect-failed-info! e workspace))
+        (debug-view/show-connect-failed-info! e (project/workspace project)))
       (catch Exception e
         (log/warn :exception e)
         (let [localization (g/with-auto-evaluation-context evaluation-context
@@ -1324,7 +1324,7 @@
                                (when (handle-build-results! workspace render-build-error! build-results)
                                  (when (or engine skip-engine)
                                    (show-console! main-scene tool-tab-pane)
-                                   (launch-built-project! project workspace engine project-directory prefs web-server false)))))))
+                                   (launch-built-project! project engine project-directory prefs web-server false)))))))
 
 (handler/defhandler :project.build :global
   (enabled? [] (not (build-in-progress?)))
@@ -1375,7 +1375,7 @@
                   :result-fn (fn [{:keys [engine] :as build-results}]
                                (when (handle-build-results! workspace render-build-error! build-results)
                                  (when (or engine skip-engine)
-                                   (when-let [target (launch-built-project! project workspace engine project-directory prefs web-server true)]
+                                   (when-let [target (launch-built-project! project engine project-directory prefs web-server true)]
                                      (when (nil? (debug-view/current-session debug-view))
                                        (debug-view/start-debugger! debug-view project (:address target "localhost") (:instance-index target 0))))))))))
 

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -1410,16 +1410,8 @@
           (if (debug-view/can-attach? prefs)
             (attach-debugger! workspace project prefs debug-view render-build-error!)
             (run-with-debugger! workspace project prefs debug-view render-build-error! web-server))
-          (catch Exception e
-            (notifications/show!
-             (workspace/notifications workspace)
-             {:type :error
-              :id ::debugger-connection-error
-              :message (localization/message "notification.debug-view.connect-failed.error" {"error" "Testing"})})
-            (throw (ex-info "Failed to attach to debugger"
-                            {:type ::cannot-check-attach
-                             :suppress-dialog-window? true}
-                            e))))))))
+          (catch java.net.SocketTimeoutException e
+            (debug-view/show-connect-failed-info! e workspace)))))))
 
 (def ^:private clean-build-dialog-info
   {:title (localization/message "dialog.clean-build.title")

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -96,7 +96,7 @@
            [com.dynamo.bob Platform]
            [com.sun.javafx.scene NodeHelper]
            [java.io File PipedInputStream PipedOutputStream]
-           [java.net URL]
+           [java.net URL SocketTimeoutException]
            [java.util Arrays Collection List]
            [java.util.concurrent ExecutionException]
            [javafx.beans.value ChangeListener]
@@ -873,7 +873,7 @@
 (defn- on-service-url-found [prefs target]
   (engine/apply-simulated-resolution! prefs target))
 
-(defn- launch-built-project! [project engine-descriptor project-directory prefs web-server debug?]
+(defn- launch-built-project! [project workspace engine-descriptor project-directory prefs web-server debug?]
   (let [selected-target (targets/selected-target prefs)
         launch-new-engine! (fn []
                              (targets/kill-launched-targets!)
@@ -918,6 +918,8 @@
               ;; not consumed.
               (reboot-engine! selected-target web-server debug?))
             (launch-new-engine!))))
+      (catch SocketTimeoutException e
+        (debug-view/show-connect-failed-info! e workspace))
       (catch Exception e
         (log/warn :exception e)
         (let [localization (g/with-auto-evaluation-context evaluation-context
@@ -1322,7 +1324,7 @@
                                (when (handle-build-results! workspace render-build-error! build-results)
                                  (when (or engine skip-engine)
                                    (show-console! main-scene tool-tab-pane)
-                                   (launch-built-project! project engine project-directory prefs web-server false)))))))
+                                   (launch-built-project! project workspace engine project-directory prefs web-server false)))))))
 
 (handler/defhandler :project.build :global
   (enabled? [] (not (build-in-progress?)))
@@ -1373,7 +1375,7 @@
                   :result-fn (fn [{:keys [engine] :as build-results}]
                                (when (handle-build-results! workspace render-build-error! build-results)
                                  (when (or engine skip-engine)
-                                   (when-let [target (launch-built-project! project engine project-directory prefs web-server true)]
+                                   (when-let [target (launch-built-project! project workspace engine project-directory prefs web-server true)]
                                      (when (nil? (debug-view/current-session debug-view))
                                        (debug-view/start-debugger! debug-view project (:address target "localhost") (:instance-index target 0))))))))))
 
@@ -1410,7 +1412,7 @@
           (if (debug-view/can-attach? prefs)
             (attach-debugger! workspace project prefs debug-view render-build-error!)
             (run-with-debugger! workspace project prefs debug-view render-build-error! web-server))
-          (catch java.net.SocketTimeoutException e
+          (catch SocketTimeoutException e
             (debug-view/show-connect-failed-info! e workspace)))))))
 
 (def ^:private clean-build-dialog-info

--- a/editor/src/clj/editor/debug_view.clj
+++ b/editor/src/clj/editor/debug_view.clj
@@ -472,7 +472,7 @@
 
 (def ^:private mobdebug-port 8172)
 
-(defn- show-connect-failed-info! [^Exception exception workspace]
+(defn show-connect-failed-info! [^Exception exception workspace]
   (ui/run-later
     (let [error-text (or (.getMessage exception) (.getSimpleName (class exception)))
           log-text (str error-text "\n\nCheck that the game is running and is reachable over the network.")]

--- a/editor/src/clj/editor/error_reporting.clj
+++ b/editor/src/clj/editor/error_reporting.clj
@@ -106,8 +106,8 @@
   ([^Throwable exception thread]
    (try
      (let [{:keys [ex-map]} (record-exception! exception)
-           suppressed? (some #(-> % :data :suppressed?) (:via ex-map))]
-       (if suppressed?
+           suppress-dialog-window? (some #(-> % :data :suppress-dialog-window?) (:via ex-map))]
+       (if suppress-dialog-window?
          (when (system/defold-dev?)
            (if-let [data (ex-data exception)]
              (log/debug :msg "Suppressed unhandled" :exception exception :ex-data data)

--- a/editor/src/clj/editor/error_reporting.clj
+++ b/editor/src/clj/editor/error_reporting.clj
@@ -105,7 +105,8 @@
    (report-exception! exception (Thread/currentThread)))
   ([^Throwable exception thread]
    (try
-     (let [{:keys [ex-map suppressed?]} (record-exception! exception)]
+     (let [{:keys [ex-map]} (record-exception! exception)
+           suppressed? (some #(-> % :data :suppressed?) (:via ex-map))]
        (if suppressed?
          (when (system/defold-dev?)
            (if-let [data (ex-data exception)]

--- a/editor/src/clj/editor/error_reporting.clj
+++ b/editor/src/clj/editor/error_reporting.clj
@@ -105,9 +105,8 @@
    (report-exception! exception (Thread/currentThread)))
   ([^Throwable exception thread]
    (try
-     (let [{:keys [ex-map]} (record-exception! exception)
-           suppress-dialog-window? (some #(-> % :data :suppress-dialog-window?) (:via ex-map))]
-       (if suppress-dialog-window?
+     (let [{:keys [ex-map suppressed?]} (record-exception! exception)]
+       (if suppressed?
          (when (system/defold-dev?)
            (if-let [data (ex-data exception)]
              (log/debug :msg "Suppressed unhandled" :exception exception :ex-data data)


### PR DESCRIPTION
We are presenting a Dialog Window when the user receives an exception because the debugger cannot connect. This PR will change it to a notification for better UX since it doesn't seem to affect anything, it's a stray attach attempt from hitting the <F5> key too quickly in succession.