### PR TITLE
Simplify `dmGraphics::IsTextureType3D(TextureType)`

### DIFF
--- a/engine/graphics/src/graphics.h
+++ b/engine/graphics/src/graphics.h
@@ -535,7 +535,7 @@ namespace dmGraphics
 
     static inline bool IsTextureType3D(TextureType type)
     {
-        return type == TEXTURE_TYPE_3D || type == TEXTURE_TYPE_3D || type == TEXTURE_TYPE_IMAGE_3D;
+        return type == TEXTURE_TYPE_3D || type == TEXTURE_TYPE_IMAGE_3D;
     }
 
     static inline uint32_t GetLayerCount(TextureType type)


### PR DESCRIPTION
This resolves [`misc-redundant-expression`](https://clang.llvm.org/extra/clang-tidy/checks/misc/redundant-expression.html).

I did not observe more warnings of that type in defold code.

Fixes #11360.
