### PR TITLE
HTML5 profiler now reports the correct memory usage

### DIFF
--- a/engine/profiler/src/profiler_web.cpp
+++ b/engine/profiler/src/profiler_web.cpp
@@ -1,0 +1,38 @@
+// Copyright 2020-2025 The Defold Foundation
+// Copyright 2014-2020 King
+// Copyright 2009-2014 Ragnar Svensson, Christian Murray
+// Licensed under the Defold License version 1.0 (the "License"); you may not use
+// this file except in compliance with the License.
+//
+// You may obtain a copy of the License, together with FAQs at
+// https://www.defold.com/license
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#include "profiler_private.h"
+
+#include <malloc.h>
+
+void dmProfilerExt::SampleCpuUsage()
+{
+    // nop
+}
+
+uint64_t dmProfilerExt::GetMemoryUsage()
+{
+    const struct mallinfo info = mallinfo();
+    return info.uordblks;
+}
+
+double dmProfilerExt::GetCpuUsage()
+{
+    return 0.0;
+}
+
+void dmProfilerExt::UpdatePlatformProfiler()
+{
+    // nop
+}

--- a/engine/profiler/src/wscript
+++ b/engine/profiler/src/wscript
@@ -21,6 +21,8 @@ def build(bld):
         source += ' profiler_proc_utils.cpp'
     elif 'win32' in bld.env.PLATFORM:
         source += ' profiler_win32.cpp'
+    elif bld.env['PLATFORM'] in ('js-web', 'wasm-web', 'wasm_pthread-web'):
+        source += ' profiler_web.cpp'
     else:
         source += ' profiler_unsupported.cpp'
 


### PR DESCRIPTION
On HTML5, our in game profiler now returns the memory usage as reported by Emscripten.
This affects both our in game profiler `Memory` variable, as well as the `profiler.get_memory_usage()` Lua function.