### PR TITLE
WelcomeScreen: Enter keybinding to open selected project

### DIFF
--- a/editor/resources/welcome/new-project-pane.fxml
+++ b/editor/resources/welcome/new-project-pane.fxml
@@ -18,7 +18,7 @@
             <HBox id="new-project-location-field" HBox.hgrow="ALWAYS" />
         </HBox>
         <HBox HBox.hgrow="NEVER">
-            <Button id="create-new-project-button" styleClass="df-button, submit-button" text="Create New Project" HBox.hgrow="NEVER" />
+            <Button id="create-new-project-button" styleClass="df-button, submit-button" text="Create New Project" HBox.hgrow="NEVER" defaultButton="true" />
         </HBox>
     </HBox>
 </VBox>

--- a/editor/src/clj/editor/welcome.clj
+++ b/editor/src/clj/editor/welcome.clj
@@ -412,7 +412,10 @@
               {:graphic (make-recent-project-entry recent-project recent-projects-list prefs localization)}))
           (.setOnMouseClicked (ui/event-handler event
                                 (when (= 2 (.getClickCount ^MouseEvent event))
-                                  (open-selected-project!)))))))
+                                  (open-selected-project!))))
+          (.setOnKeyPressed (ui/event-handler event
+                      (when (= javafx.scene.input.KeyCode/ENTER (.getCode ^KeyEvent event))
+                        (open-selected-project!)))))))
     home-pane))
 
 ;; -----------------------------------------------------------------------------
@@ -473,7 +476,7 @@
   (ui/with-controls root [^ButtonBase create-new-project-button
                           new-project-location-field
                           ^TextField new-project-title-field
-                          ^ListVew template-list
+                          ^ListView template-list
                           new-project-title-label
                           new-project-location-label]
     (.setText new-project-title-field (localization (localization/message "welcome.new-project.default-name")))
@@ -486,7 +489,11 @@
       (b/bind! (location-field-title-property new-project-location-field) sanitized-title-property))
     (doto template-list
       (ui/cell-factory! (fn [project-template]
-                          {:graphic (make-template-entry project-template localization)})))
+                          {:graphic (make-template-entry project-template localization)}))
+      (.setOnKeyPressed (ui/event-handler event
+                                            (when (= javafx.scene.input.KeyCode/ENTER (.getCode ^KeyEvent event))
+                                              (when-some [project-template (first (ui/selection template-list))]
+                                                (.fire create-new-project-button))))))
     (when (some? templates)
       (ui/items! template-list templates)
       (when (seq templates)
@@ -815,7 +822,7 @@
                                 (let [key-event ^KeyEvent event
                                       selected-pane-button (.getSelectedToggle pane-buttons-toggle-group)]
                                   (when (and (.isShortcutDown key-event)
-                                             (= "r" (.getText key-event)))
+                                             (= javafx.scene.input.KeyCode/R (.getCode key-event)))
                                     (ui/close! stage)
                                     (show-welcome-dialog! prefs localization updater open-project-fn
                                                           {:x (.getX stage)

--- a/editor/src/clj/editor/welcome.clj
+++ b/editor/src/clj/editor/welcome.clj
@@ -511,7 +511,7 @@
       (.setOnKeyPressed (ui/event-handler event
                           (when (and (= javafx.scene.input.KeyCode/ENTER (.getCode ^KeyEvent event))
                                      (first (ui/selection template-list)))
-                              (.fire create-new-project-button)))))
+                            (.fire create-new-project-button)))))
     (when (some? templates)
       (ui/items! template-list templates)
       (when (seq templates)

--- a/editor/src/clj/editor/welcome.clj
+++ b/editor/src/clj/editor/welcome.clj
@@ -507,11 +507,11 @@
                                 (.clearSelection (.getSelectionModel template-list)))
                               (when (and (= 2 (.getClickCount mouse-event))
                                          (not-empty (ui/selection template-list)))
-                                (.fire create-new-project-button)))))
+                                (.requestFocus new-project-title-field)))))
       (.setOnKeyPressed (ui/event-handler event
                           (when (and (= KeyCode/ENTER (.getCode ^KeyEvent event))
                                      (first (ui/selection template-list)))
-                            (.fire create-new-project-button)))))
+                            (.requestFocus new-project-title-field)))))
     (when (some? templates)
       (ui/items! template-list templates)
       (when (seq templates)

--- a/editor/src/clj/editor/welcome.clj
+++ b/editor/src/clj/editor/welcome.clj
@@ -53,7 +53,7 @@
            [javafx.scene Node Parent Scene]
            [javafx.scene.control Button ButtonBase ComboBox Hyperlink Label ListCell ListView OverrunStyle ProgressBar RadioButton TextArea TextField ToggleGroup]
            [javafx.scene.image Image ImageView]
-           [javafx.scene.input KeyEvent MouseEvent]
+           [javafx.scene.input KeyEvent KeyCode MouseEvent]
            [javafx.scene.layout HBox Priority Region StackPane VBox]
            [javafx.scene.shape Rectangle]
            [javafx.scene.text Text TextFlow]
@@ -413,14 +413,14 @@
           (.setOnMouseClicked (ui/event-handler event
                                 (let [^MouseEvent mouse-event event
                                       ^Node target (.getTarget mouse-event)]
-                                  (when (and (instance? javafx.scene.control.ListCell target)
+                                  (when (and (instance? ListCell target)
                                              (nil? (.getItem ^ListCell target)))
                                     (.clearSelection (.getSelectionModel recent-projects-list)))
                                   (when (and (= 2 (.getClickCount mouse-event))
                                              (not-empty (ui/selection recent-projects-list)))
                                     (open-selected-project!)))))
           (.setOnKeyPressed (ui/event-handler event
-                              (when (= javafx.scene.input.KeyCode/ENTER (.getCode ^KeyEvent event))
+                              (when (= KeyCode/ENTER (.getCode ^KeyEvent event))
                                 (open-selected-project!))))
           (when (not-empty (recent-projects prefs))
             (ui/select-index! recent-projects-list 0)
@@ -502,14 +502,14 @@
       (.setOnMouseClicked (ui/event-handler event
                             (let [^MouseEvent mouse-event event
                                   ^Node target (.getTarget mouse-event)]
-                              (when (and (instance? javafx.scene.control.ListCell target)
+                              (when (and (instance? ListCell target)
                                          (nil? (.getItem ^ListCell target)))
                                 (.clearSelection (.getSelectionModel template-list)))
                               (when (and (= 2 (.getClickCount mouse-event))
                                          (not-empty (ui/selection template-list)))
                                 (.fire create-new-project-button)))))
       (.setOnKeyPressed (ui/event-handler event
-                          (when (and (= javafx.scene.input.KeyCode/ENTER (.getCode ^KeyEvent event))
+                          (when (and (= KeyCode/ENTER (.getCode ^KeyEvent event))
                                      (first (ui/selection template-list)))
                             (.fire create-new-project-button)))))
     (when (some? templates)
@@ -840,7 +840,7 @@
                                 (let [key-event ^KeyEvent event
                                       selected-pane-button (.getSelectedToggle pane-buttons-toggle-group)]
                                   (when (and (.isShortcutDown key-event)
-                                             (= javafx.scene.input.KeyCode/R (.getCode key-event)))
+                                             (= KeyCode/R (.getCode key-event)))
                                     (ui/close! stage)
                                     (show-welcome-dialog! prefs localization updater open-project-fn
                                                           {:x (.getX stage)

--- a/editor/src/clj/editor/welcome.clj
+++ b/editor/src/clj/editor/welcome.clj
@@ -421,7 +421,10 @@
                                     (open-selected-project!)))))
           (.setOnKeyPressed (ui/event-handler event
                               (when (= javafx.scene.input.KeyCode/ENTER (.getCode ^KeyEvent event))
-                                (open-selected-project!)))))))
+                                (open-selected-project!))))
+          (when (not-empty (recent-projects prefs))
+            (ui/select-index! recent-projects-list 0)
+            (.requestFocus recent-projects-list)))))
     home-pane))
 
 ;; -----------------------------------------------------------------------------

--- a/editor/src/clj/editor/welcome.clj
+++ b/editor/src/clj/editor/welcome.clj
@@ -408,8 +408,8 @@
           (.setFixedCellSize 56.0)
           (ui/items! (recent-projects prefs))
           (ui/cell-factory!
-           (fn [recent-project]
-             {:graphic (make-recent-project-entry recent-project recent-projects-list prefs localization)}))
+            (fn [recent-project]
+              {:graphic (make-recent-project-entry recent-project recent-projects-list prefs localization)}))
           (.setOnMouseClicked (ui/event-handler event
                                 (let [^MouseEvent mouse-event event
                                       ^Node target (.getTarget mouse-event)]
@@ -506,9 +506,9 @@
                                          (not-empty (ui/selection template-list)))
                                 (.fire create-new-project-button)))))
       (.setOnKeyPressed (ui/event-handler event
-                          (when (= javafx.scene.input.KeyCode/ENTER (.getCode ^KeyEvent event))
-                            (when-some [project-template (first (ui/selection template-list))]
-                              (.fire create-new-project-button))))))
+                          (when (and (= javafx.scene.input.KeyCode/ENTER (.getCode ^KeyEvent event))
+                                     (first (ui/selection template-list)))
+                              (.fire create-new-project-button)))))
     (when (some? templates)
       (ui/items! template-list templates)
       (when (seq templates)


### PR DESCRIPTION
Currently pressing ENTER in the welcome screen to select a project doesn't do anything. This PR adds the ENTER keybinding so it opens the currently selected project.

Fixes #11184 