### PR TITLE
Fix frustrum culling for sprites with pivot point

### DIFF
--- a/engine/dlib/src/dlib/double_linked_list.cpp
+++ b/engine/dlib/src/dlib/double_linked_list.cpp
@@ -1,0 +1,62 @@
+// Copyright 2020-2025 The Defold Foundation
+// Copyright 2014-2020 King
+// Copyright 2009-2014 Ragnar Svensson, Christian Murray
+// Licensed under the Defold License version 1.0 (the "License"); you may not use
+// this file except in compliance with the License.
+//
+// You may obtain a copy of the License, together with FAQs at
+// https://www.defold.com/license
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#include <dlib/double_linked_list.h>
+
+namespace dmDoubleLinkedList
+{
+    void ListInit(List* list)
+    {
+        list->m_Head.m_Prev = 0;
+        list->m_Tail.m_Next = 0;
+        list->m_Head.m_Next = &list->m_Tail;
+        list->m_Tail.m_Prev = &list->m_Head;
+    }
+
+    void ListRemove(List* list, ListNode* item)
+    {
+        ListNode* prev = item->m_Prev;
+        ListNode* next = item->m_Next;
+        item->m_Prev = 0;
+        item->m_Next = 0;
+        if (prev != 0 && next != 0)
+        {
+            prev->m_Next = next;
+            next->m_Prev = prev;
+        }
+    }
+
+    void ListAdd(List* list, ListNode* item)
+    {
+        ListNode* prev = &list->m_Head;
+        ListNode* next = prev->m_Next;
+        item->m_Prev = prev;
+        item->m_Next = next;
+        prev->m_Next = item;
+        next->m_Prev = item;
+    }
+
+    ListNode* ListGetLast(List* list)
+    {
+        ListNode* last = list->m_Tail.m_Prev;
+        return last == &list->m_Head ? 0 : last;
+    }
+
+    ListNode* ListGetFirst(List* list)
+    {
+        ListNode* first = list->m_Head.m_Next;
+        return first == &list->m_Tail ? 0 : first;
+    }
+
+}

--- a/engine/dlib/src/dlib/double_linked_list.h
+++ b/engine/dlib/src/dlib/double_linked_list.h
@@ -1,0 +1,20 @@
+// Copyright 2020-2025 The Defold Foundation
+// Copyright 2014-2020 King
+// Copyright 2009-2014 Ragnar Svensson, Christian Murray
+// Licensed under the Defold License version 1.0 (the "License"); you may not use
+// this file except in compliance with the License.
+//
+// You may obtain a copy of the License, together with FAQs at
+// https://www.defold.com/license
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#ifndef DM_DOUBLE_LINKED_LIST_H
+#define DM_DOUBLE_LINKED_LIST_H
+
+#include <dmsdk/dlib/double_linked_list.h>
+
+#endif

--- a/engine/dlib/src/dmsdk/dlib/double_linked_list.h
+++ b/engine/dlib/src/dmsdk/dlib/double_linked_list.h
@@ -1,0 +1,100 @@
+// Copyright 2020-2025 The Defold Foundation
+// Copyright 2014-2020 King
+// Copyright 2009-2014 Ragnar Svensson, Christian Murray
+// Licensed under the Defold License version 1.0 (the "License"); you may not use
+// this file except in compliance with the License.
+//
+// You may obtain a copy of the License, together with FAQs at
+// https://www.defold.com/license
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#ifndef DMSDK_DOUBLE_LINKED_LIST_H
+#define DMSDK_DOUBLE_LINKED_LIST_H
+
+/*#
+ * Double linked list structs and functions
+ *
+ * @document
+ * @name Double linked list structs and functions
+ * @namespace dmDoubleLinkedList
+ * @path engine/dlib/src/dmsdk/dlib/double_linked_list.h
+ * @language C++
+ */
+namespace dmDoubleLinkedList
+{
+    /*
+     * Double linked list node
+     * @struct
+     * @name dmDoubleLinkedList::ListNode
+     * @member m_Prev [type:dmDoubleLinkedList::ListNode*] pointer to the previous element in the linked list
+     * @member m_Next [type:dmDobuleLinkedList::ListNode*] pointer to the next element in the linked list
+     */
+    struct ListNode
+    {
+        ListNode()
+            : m_Prev(0)
+            , m_Next(0)
+        { }
+        struct ListNode* m_Prev;
+        struct ListNode* m_Next;
+    };
+
+    /*
+     * Double linked list
+     * @struct
+     * @name dmDoubleLinkedList::List
+     * @member m_Head [type:dmDoubleLinkedList::ListNode] the head of the linked list
+     * @member m_Tail [type:dmDoubleLinkedList::ListNode] the tail of the linked list
+     */
+    struct List
+    {
+        ListNode m_Head;
+        ListNode m_Tail;
+    };
+
+    /*#
+     * Initialize empty double linked list
+     * @name dmDoubleLinkedList::ListInit
+     * @param list [type:dmDoubleLinkedList::List*] the list
+     */
+    void ListInit(List* list);
+
+    /*#
+     * Remove item from the list. Doesn't deallocate memory allocated for the item.
+     * If element is not in the list function doesn't affect linked list.
+     * @name dmDoubleLinkedList::ListRemove
+     * @param list [type:dmDoubleLinkedList::List*] the list
+     * @param item [type:dmDoubleLinkedList::ListNode*] removed item
+     */
+    void ListRemove(List* list, ListNode* item);
+
+    /*#
+     * Added new list element as a head of the list
+     * @name dmDoubleLinkedList::ListAdd
+     * @param list [type:dmDoubleLinkedList::List*] the list
+     * @param item [type:dmDoubleLinkedList::ListNode*] new list element
+     */
+    void ListAdd(List* list, ListNode* item);
+
+    /*#
+     * Get the last element of the list. If the list is empty (tail == head) returns 0.
+     * @name dmDoubleLinkedList::ListGetLast
+     * @param list [type:dmDoubleLinkedList::List*] the list
+     * @return last_element [type:dmDoubleLinkedList::ListNode*] the last element of the list. If the list is empty (tail == head) returns 0
+     */
+    ListNode* ListGetLast(List* list);
+
+    /*#
+     * Get the first element of the list. If the list is empty (tail == head) returns 0.
+     * @name dmDoubleLinkedList::ListGetFirst
+     * @param list [type:dmDoubleLinkedList::List*] the list
+     * @return first_element [type:dmDoubleLinkedList::ListNode*] the first element of the list.  If the list is empty (tail == head) returns 0
+     */
+    ListNode* ListGetFirst(List* list);
+}
+
+#endif

--- a/engine/dlib/src/test/test_double_linked_list.cpp
+++ b/engine/dlib/src/test/test_double_linked_list.cpp
@@ -1,0 +1,149 @@
+// Copyright 2020-2025 The Defold Foundation
+// Copyright 2014-2020 King
+// Copyright 2009-2014 Ragnar Svensson, Christian Murray
+// Licensed under the Defold License version 1.0 (the "License"); you may not use
+// this file except in compliance with the License.
+//
+// You may obtain a copy of the License, together with FAQs at
+// https://www.defold.com/license
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#include "dlib/double_linked_list.h"
+
+#define JC_TEST_IMPLEMENTATION
+#include <jc_test/jc_test.h>
+
+size_t countListNodes(dmDoubleLinkedList::List* list)
+{
+    dmDoubleLinkedList::ListNode* node = list->m_Head.m_Next;
+    size_t nodes_count = 0;
+    while (node != &list->m_Tail)
+    {
+        nodes_count++;
+        node = node->m_Next;
+    }
+    return nodes_count;
+}
+
+TEST(dmDoubleLinkedList, Init)
+{
+    dmDoubleLinkedList::List list;
+    dmDoubleLinkedList::ListInit(&list);
+
+    ASSERT_TRUE(list.m_Head.m_Prev == 0);
+    ASSERT_EQ(list.m_Head.m_Next, &list.m_Tail);
+    ASSERT_EQ(list.m_Tail.m_Prev, &list.m_Head);
+    ASSERT_TRUE(list.m_Tail.m_Next == 0);
+}
+
+TEST(dmDoubleLinkedList, Add)
+{
+    dmDoubleLinkedList::List list;
+    dmDoubleLinkedList::ListInit(&list);
+
+    dmDoubleLinkedList::ListNode node_1;
+    dmDoubleLinkedList::ListNode node_2;
+    dmDoubleLinkedList::ListNode node_3;
+
+    dmDoubleLinkedList::ListAdd(&list, &node_2);
+    dmDoubleLinkedList::ListAdd(&list, &node_1);
+    dmDoubleLinkedList::ListAdd(&list, &node_3);
+    ASSERT_EQ(list.m_Tail.m_Prev, &node_2);
+    ASSERT_EQ(list.m_Head.m_Next, &node_3);
+    ASSERT_EQ(node_1.m_Prev, &node_3);
+    ASSERT_EQ(node_1.m_Next, &node_2);
+    ASSERT_TRUE(node_3.m_Prev == &list.m_Head);
+    ASSERT_EQ(node_3.m_Next, &node_1);
+    ASSERT_EQ(node_2.m_Prev, &node_1);
+    ASSERT_TRUE(node_2.m_Next == &list.m_Tail);
+
+    size_t nodes_count = countListNodes(&list);
+    ASSERT_EQ(nodes_count, 3);
+}
+
+TEST(dmDoubleLinkedList, Remove)
+{
+    dmDoubleLinkedList::List list;
+    dmDoubleLinkedList::ListInit(&list);
+
+    dmDoubleLinkedList::ListNode node_1;
+    dmDoubleLinkedList::ListNode node_2;
+    dmDoubleLinkedList::ListNode node_3;
+    dmDoubleLinkedList::ListNode node_not_in_list;
+
+    dmDoubleLinkedList::ListAdd(&list, &node_2);
+    dmDoubleLinkedList::ListAdd(&list, &node_1);
+    dmDoubleLinkedList::ListAdd(&list, &node_3);
+
+    dmDoubleLinkedList::ListRemove(&list, &node_not_in_list);
+    size_t nodes_count = countListNodes(&list);
+    ASSERT_EQ(nodes_count, 3);
+
+    dmDoubleLinkedList::ListRemove(&list, &node_1);
+    ASSERT_EQ(list.m_Tail.m_Prev, &node_2);
+    ASSERT_EQ(list.m_Head.m_Next, &node_3);
+    ASSERT_EQ(node_3.m_Next, &node_2);
+    ASSERT_EQ(node_2.m_Prev, &node_3);
+    ASSERT_TRUE(node_1.m_Next == 0);
+    ASSERT_TRUE(node_1.m_Prev == 0);
+
+    nodes_count = countListNodes(&list);
+    ASSERT_EQ(nodes_count, 2);
+
+    dmDoubleLinkedList::ListRemove(&list, &node_2);
+    dmDoubleLinkedList::ListRemove(&list, &node_3);
+    ASSERT_EQ(&list.m_Head, list.m_Tail.m_Prev);
+    nodes_count = countListNodes(&list);
+    ASSERT_EQ(nodes_count, 0);
+}
+
+TEST(dmDoubleLinkedList, GetLast)
+{
+    dmDoubleLinkedList::List list;
+    dmDoubleLinkedList::ListInit(&list);
+
+    dmDoubleLinkedList::ListNode* tail = dmDoubleLinkedList::ListGetLast(&list);
+    ASSERT_TRUE(tail == 0);
+
+    size_t node_size = sizeof(dmDoubleLinkedList::ListNode);
+    dmDoubleLinkedList::ListNode* node_1 = (dmDoubleLinkedList::ListNode*)malloc(node_size);
+    dmDoubleLinkedList::ListAdd(&list, node_1);
+
+    dmDoubleLinkedList::ListNode* last_node = dmDoubleLinkedList::ListGetLast(&list);
+    ASSERT_EQ(node_1, last_node);
+
+    dmDoubleLinkedList::ListNode* node_2 = (dmDoubleLinkedList::ListNode*)malloc(node_size);
+    dmDoubleLinkedList::ListAdd(&list, node_2);
+
+    last_node = dmDoubleLinkedList::ListGetLast(&list);
+    ASSERT_EQ(node_1, last_node);
+}
+
+TEST(dmDoubleLinkedList, GetFirst)
+{
+    dmDoubleLinkedList::List list;
+    dmDoubleLinkedList::ListInit(&list);
+
+    dmDoubleLinkedList::ListNode* first = dmDoubleLinkedList::ListGetFirst(&list);
+    ASSERT_TRUE(first == 0);
+
+    size_t node_size = sizeof(dmDoubleLinkedList::ListNode);
+    for (size_t idx = 0; idx < 5; ++idx)
+    {
+        dmDoubleLinkedList::ListNode* new_node = (dmDoubleLinkedList::ListNode*)malloc(node_size);
+        dmDoubleLinkedList::ListAdd(&list, new_node);
+
+        dmDoubleLinkedList::ListNode* first_node = dmDoubleLinkedList::ListGetFirst(&list);
+        ASSERT_EQ(new_node, first_node);
+    }
+}
+
+int main(int argc, char **argv)
+{
+    jc_test_init(&argc, argv);
+    return jc_test_run_all();
+}

--- a/engine/dlib/src/test/wscript
+++ b/engine/dlib/src/test/wscript
@@ -140,6 +140,7 @@ def build(bld):
     create_test(bld, 'test_transform', extra_libs = ['THREAD'])
     create_test(bld, 'test_hashtable')
     create_test(bld, 'test_array')
+    create_test(bld, 'test_double_linked_list')
     create_test(bld, 'test_set')
     create_test(bld, 'test_indexpool')
     create_test(bld, 'test_dlib', extra_libs = ['THREAD'])

--- a/engine/dlib/src/wscript
+++ b/engine/dlib/src/wscript
@@ -350,6 +350,7 @@ def build(bld):
     bld.install_files('${PREFIX}/include/dlib', 'dlib/crypt.h')
     bld.install_files('${PREFIX}/include/dlib', 'dlib/dalloca.h')
     bld.install_files('${PREFIX}/include/dlib', 'dlib/dlib.h')
+    bld.install_files('${PREFIX}/include/dlib', 'dlib/double_linked_list.h')
     bld.install_files('${PREFIX}/include/dlib', 'dlib/dstrings.h')
     bld.install_files('${PREFIX}/include/dlib', 'dlib/easing.h')
     bld.install_files('${PREFIX}/include/dlib', 'dlib/endian.h')

--- a/engine/gamesys/src/gamesys/components/comp_model.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_model.cpp
@@ -869,7 +869,6 @@ namespace dmGameSystem
         #undef UNPACK_ATTRIBUTE_PTR
 
             vertex_write_ptr = dmGraphics::WriteAttributes(vertex_write_ptr, 0, vertex_count, params);
-
             rd->m_VertexBuffer = dmGraphics::NewVertexBuffer(graphics_context, vertex_data_size, attribute_data, dmGraphics::BUFFER_USAGE_DYNAMIC_DRAW);
 
             free(attribute_data);

--- a/engine/gamesys/src/gamesys/components/comp_sprite.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sprite.cpp
@@ -20,6 +20,7 @@
 
 #include <dlib/array.h>
 #include <dlib/hash.h>
+#include <dlib/double_linked_list.h>
 #include <dlib/log.h>
 #include <dlib/message.h>
 #include <dlib/profile.h>
@@ -65,6 +66,56 @@ namespace dmGameSystem
         SpriteResourceOverrides() : m_Material(0) {}
     };
 
+    const uint32_t MAX_TEXTURE_COUNT = dmRender::RenderObject::MAX_TEXTURE_COUNT;
+    const uint8_t CACHE_EVICTION_FRAMES = 10; // how many frames cache entry is stored before eviction
+    const uint8_t MINIMUM_CACHE_CAPACITY = 100; // minimum hashtable capacity for AnimationData cache
+
+    /* AnimationData is used for storing calculation of sprite geometry.
+     * Those information is used during several parts of engine tick:
+     * 1. CompSpriteRender
+     * 2. RenderBatch
+     * 3. Pivot points which should be taken into account during frustrum culling
+     * So to avoid multiple calculation during the frame we caclulate it once and use in different places.
+     * Also some static sprites (without animations or with stopped animations) have the same AnimationData during several
+     * frames.
+     *
+     * AnimationData stores in hashtable to speedup accessing during the frame. Also AnimationData stores in double linked list
+     * to implement LRU cache.
+     * Every AnimationData entry stores engine tick when it was last accessed. Then every engine tick we check if AnimationData
+     * entry is old enough (see CACHE_EVICTION_FRAMES) and remove it from LRU and from hashtable.
+     *
+     * We use cache instead of resources here because AnimationData presents intemidiate calculations which can updates frequently
+     * and for different sprites it can be the same AnimationData entry (because they share the same texture set and same animation).
+     * So instead of storing cached information per component it stores as cache in sprite world to be sahrable between sprites.
+     */
+    struct AnimationData
+    {
+        dmDoubleLinkedList::ListNode    m_ListNode;
+        // Used after resolving info from all textures
+        dmhash_t                        m_AnimationID;                      // The animation of the driving atlas
+        uint32_t                        m_Frames[MAX_TEXTURE_COUNT];        // The resolved frame indices
+        uint32_t                        m_LastAccessTick;
+        uint32_t                        m_CacheKey;
+        uint32_t                        m_VertexCount;
+        uint32_t                        m_IndicesCount;
+        float                           m_PageIndices[MAX_TEXTURE_COUNT];
+
+        const dmGameSystemDDF::TextureSetAnimation* m_Animations[MAX_TEXTURE_COUNT];
+        const dmGameSystemDDF::SpriteGeometry*      m_Geometries[MAX_TEXTURE_COUNT];
+        bool                                        m_CanUseQuads;
+    };
+
+#if __cplusplus >= 201103L
+    DM_STATIC_ASSERT(offsetof(AnimationData, m_ListNode) == 0, "m_ListNode must be first in struct!");
+#endif
+
+    struct AnimationDataCache
+    {
+        dmHashTable32<AnimationData*> m_Cache;
+        dmDoubleLinkedList::List      m_LRU;
+        uint32_t                      m_CurrentEngineTick;
+    };
+
     struct SpriteComponent
     {
         Matrix4                     m_World;
@@ -83,10 +134,9 @@ namespace dmGameSystem
         int32_t                     m_FunctionRef; // Animation callback function
         // Hash of the m_Resource-pointer etc. Hash is used to be compatible with 64-bit arch as a 32-bit value is used for sorting
         uint32_t                    m_MixedHash;
+        uint32_t                    m_AnimationDataHash;
 
-        uint32_t                    m_AnimationID; // index into array
-        uint32_t                    m_DynamicVertexAttributeIndex;
-
+        int32_t                     m_AnimationFrameCount; // cached value when animation is playing
         /// Currently playing animation
         dmhash_t                    m_CurrentAnimation;
         uint32_t                    m_CurrentAnimationFrame;
@@ -95,24 +145,27 @@ namespace dmGameSystem
         /// Timer in local space: [0,1]
         float                       m_AnimTimer;
         float                       m_PlaybackRate;
+        uint16_t                    m_AnimationID; // index into array
+        uint16_t                    m_DynamicVertexAttributeIndex;
         uint16_t                    m_ComponentIndex;
-        uint16_t                    m_AnimPingPong : 1;
-        uint16_t                    m_AnimBackwards : 1;
         uint16_t                    m_Enabled : 1;
-        uint16_t                    m_Playing : 1;
         uint16_t                    m_DoTick : 1;
         uint16_t                    m_FlipHorizontal : 1;
         uint16_t                    m_FlipVertical : 1;
         uint16_t                    m_AddedToUpdate : 1;
         uint16_t                    m_ReHash : 1;
         uint16_t                    m_UseSlice9 : 1;
-        uint16_t                    : 6;
+        uint16_t                    m_AnimationReHash : 1;
+        uint16_t                    m_IsPlaying : 1;
+        // currently we don't support multiple animation cursors that's why we can use Playback from the first
+        // texture set
+        uint16_t                    m_AnimationPlayback : 7; // narrowed enum dmGameSystemDDF::Playback
+        uint8_t                     m_NumTextures; // cached value from m_Resource->m_NumTextures
     };
-
-    const uint32_t MAX_TEXTURE_COUNT = dmRender::RenderObject::MAX_TEXTURE_COUNT;
 
     struct SpriteWorld
     {
+        AnimationDataCache                  m_AnimationDataCache;
         dmObjectPool<SpriteComponent>       m_Components;
         DynamicAttributePool                m_DynamicVertexAttributePool;
         dmArray<dmRender::RenderObject*>    m_RenderObjects;
@@ -135,22 +188,6 @@ namespace dmGameSystem
         uint8_t*                            m_IndexBufferWritePtr;
         uint8_t                             m_Is16BitIndex : 1;
         uint8_t                             m_ReallocBuffers : 1;
-    };
-
-    struct TexturesData
-    {
-        TextureSetResource*             m_Resources[MAX_TEXTURE_COUNT];
-        dmGameSystemDDF::TextureSet*    m_TextureSets[MAX_TEXTURE_COUNT];
-        uint32_t                        m_NumTextures;
-
-        // Used after resolving info from all textures
-        dmhash_t                        m_AnimationID;                      // The animation of the driving atlas
-        uint32_t                        m_Frames[MAX_TEXTURE_COUNT];        // The resolved frame indices
-        float                           m_PageIndices[MAX_TEXTURE_COUNT];
-
-        const dmGameSystemDDF::TextureSetAnimation* m_Animations[MAX_TEXTURE_COUNT];
-        const dmGameSystemDDF::SpriteGeometry*      m_Geometries[MAX_TEXTURE_COUNT];
-        bool                                        m_UsesGeometries;
     };
 
     DM_GAMESYS_PROP_VECTOR3(SPRITE_PROP_SCALE, scale, false);
@@ -177,7 +214,8 @@ namespace dmGameSystem
     static float GetPlaybackRate(SpriteComponent* component);
     static void SetPlaybackRate(SpriteComponent* component, float playback_rate);
 
-    static void ReAllocateBuffers(SpriteWorld* sprite_world, dmRender::HRenderContext render_context) {
+    static void ReAllocateBuffers(SpriteWorld* sprite_world, dmRender::HRenderContext render_context)
+    {
         if (sprite_world->m_VertexBuffer)
         {
             dmRender::DeleteBufferedRenderBuffer(render_context, sprite_world->m_VertexBuffer);
@@ -211,6 +249,8 @@ namespace dmGameSystem
         sprite_world->m_Components.SetCapacity(comp_count);
         sprite_world->m_BoundingVolumes.SetCapacity(comp_count);
         sprite_world->m_BoundingVolumes.SetSize(comp_count);
+        sprite_world->m_AnimationDataCache.m_Cache.SetCapacity(MINIMUM_CACHE_CAPACITY);
+        dmDoubleLinkedList::ListInit(&sprite_world->m_AnimationDataCache.m_LRU);
         memset(sprite_world->m_Components.GetRawObjects().Begin(), 0, sizeof(SpriteComponent) * comp_count);
         sprite_world->m_RenderObjectsInUse = 0;
         sprite_world->m_VertexBuffer     = 0;
@@ -241,11 +281,18 @@ namespace dmGameSystem
         dmRender::DeleteBufferedRenderBuffer(sprite_context->m_RenderContext, sprite_world->m_IndexBuffer);
         free(sprite_world->m_IndexBufferData);
 
+        dmHashTable32<AnimationData*>::Iterator iter = sprite_world->m_AnimationDataCache.m_Cache.GetIterator();
+        while(iter.Next())
+        {
+            AnimationData* data = iter.GetValue();
+            free(data);
+        }
+
         delete sprite_world;
         return dmGameObject::CREATE_RESULT_OK;
     }
 
-    static inline Vector3 GetSizeFromAnimation(const SpriteComponent* sprite, dmGameSystemDDF::TextureSet* texture_set_ddf, uint32_t anim_id)
+    static inline Vector3 GetSizeFromAnimation(const SpriteComponent* sprite, dmGameSystemDDF::TextureSet* texture_set_ddf, uint16_t anim_id)
     {
         Vector3 result;
         dmGameSystemDDF::TextureSetAnimation* animation = &texture_set_ddf->m_Animations[anim_id];
@@ -276,7 +323,8 @@ namespace dmGameSystem
             if (overrides->m_Textures[i].m_TextureSet) // it may be sparse
                 dmResource::Release(factory, overrides->m_Textures[i].m_TextureSet);
         }
-        if (overrides->m_Material) {
+        if (overrides->m_Material)
+        {
             dmResource::Release(factory, overrides->m_Material);
         }
         delete component->m_Overrides;
@@ -396,30 +444,31 @@ namespace dmGameSystem
         return SetResourceProperty(factory, resource, TEXTURE_SET_EXT_HASH, (void**)texture_set);
     }
 
-    static inline HComponentRenderConstants GetRenderConstants(const SpriteComponent* component) {
+    static inline HComponentRenderConstants GetRenderConstants(const SpriteComponent* component)
+    {
         return component->m_RenderConstants;
     }
 
-    static inline MaterialResource* GetMaterialResource(const SpriteComponent* component) {
+    static inline MaterialResource* GetMaterialResource(const SpriteComponent* component)
+    {
         const SpriteResource* resource = component->m_Resource;
         const SpriteResourceOverrides* overrides = component->m_Overrides;
         return (overrides && overrides->m_Material) ? overrides->m_Material : resource->m_Material;
     }
 
-    static inline dmRender::HMaterial GetComponentMaterial(const SpriteComponent* component) {
+    static inline dmRender::HMaterial GetComponentMaterial(const SpriteComponent* component)
+    {
         return GetMaterialResource(component)->m_Material;
     }
 
-    static inline dmRender::HMaterial GetRenderMaterial(dmRender::HRenderContext render_context, const SpriteComponent* component) {
+    static inline dmRender::HMaterial GetRenderMaterial(dmRender::HRenderContext render_context, const SpriteComponent* component)
+    {
         dmRender::HMaterial context_material = dmRender::GetContextMaterial(render_context);
         return context_material ? context_material : GetComponentMaterial(component);
     }
 
-    static inline uint32_t GetNumTextures(const SpriteComponent* component) {
-        return component->m_Resource->m_NumTextures;
-    }
-
-    static inline TextureSetResource* GetTextureSetByIndex(const SpriteComponent* component, uint32_t index) {
+    static inline TextureSetResource* GetTextureSetByIndex(const SpriteComponent* component, uint32_t index)
+    {
         const SpriteResourceOverrides* overrides = component->m_Overrides;
         const SpriteTexture* texture = 0;
         if (overrides && index < overrides->m_Textures.Size())
@@ -452,7 +501,8 @@ namespace dmGameSystem
     }
 
     // Until we can set multiple play cursors, we'll use the first texture set as the driving animation
-    static inline TextureSetResource* GetFirstTextureSet(const SpriteComponent* component) {
+    static inline TextureSetResource* GetFirstTextureSet(const SpriteComponent* component)
+    {
         return GetTextureSetByIndex(component, 0);
     }
 
@@ -476,34 +526,37 @@ namespace dmGameSystem
         return texture ? texture->m_Texture : 0;
     }
 
-    static void UpdateCurrentAnimationFrame(SpriteComponent* component) {
+    static void UpdateCurrentAnimationFrame(SpriteComponent* component)
+    {
         TextureSetResource* texture_set = GetFirstTextureSet(component);
         dmGameSystemDDF::TextureSet* texture_set_ddf = texture_set->m_TextureSet;
-        dmGameSystemDDF::TextureSetAnimation* animation_ddf = &texture_set_ddf->m_Animations[component->m_AnimationID];
+        const dmGameSystemDDF::Playback playback = (dmGameSystemDDF::Playback)component->m_AnimationPlayback;
 
         // Set frame from cursor (tileindex or animframe)
         float t = component->m_AnimTimer;
-        float backwards = (animation_ddf->m_Playback == dmGameSystemDDF::PLAYBACK_ONCE_BACKWARD
-                        || animation_ddf->m_Playback == dmGameSystemDDF::PLAYBACK_LOOP_BACKWARD) ? 1.0f : 0;
+        float backwards = (playback == dmGameSystemDDF::PLAYBACK_ONCE_BACKWARD
+                        || playback == dmGameSystemDDF::PLAYBACK_LOOP_BACKWARD) ? 1.0f : 0;
 
         // Original: t = backwards ? (1.0f - t) : t;
         // which translates to:
         t = backwards - 2 * t * backwards + t;
 
-        uint32_t interval = animation_ddf->m_End - animation_ddf->m_Start;
+        uint32_t interval = component->m_AnimationFrameCount;
         uint32_t frame_count = interval;
-        if (animation_ddf->m_Playback == dmGameSystemDDF::PLAYBACK_ONCE_PINGPONG ||
-            animation_ddf->m_Playback == dmGameSystemDDF::PLAYBACK_LOOP_PINGPONG)
+        if (playback == dmGameSystemDDF::PLAYBACK_ONCE_PINGPONG ||
+            playback == dmGameSystemDDF::PLAYBACK_LOOP_PINGPONG)
         {
             frame_count = dmMath::Max(1u, frame_count * 2 - 2);
         }
         uint32_t frame = dmMath::Min(frame_count - 1, (uint32_t)(t * frame_count));
-        if (frame >= interval) {
+        if (frame >= interval)
+        {
             frame = 2 * (interval - 1) - frame;
         }
 
         uint32_t frame_current = component->m_CurrentAnimationFrame;
         component->m_CurrentAnimationFrame = frame;
+        component->m_AnimationReHash |= frame != frame_current;
 
         if (component->m_Resource->m_DDF->m_SizeMode == dmGameSystemDDF::SpriteDesc::SIZE_MODE_AUTO && frame != frame_current)
         {
@@ -517,19 +570,22 @@ namespace dmGameSystem
         uint32_t* anim_id = texture_set ? texture_set->m_AnimationIds.Get(animation) : 0;
         if (anim_id)
         {
-            component->m_AnimationID = *anim_id;
+            component->m_AnimationID = (uint16_t)(*anim_id);
+            component->m_AnimationReHash |= component->m_CurrentAnimation != animation;
             component->m_CurrentAnimation = animation;
+
             dmGameSystemDDF::TextureSetAnimation* animation = &texture_set->m_TextureSet->m_Animations[*anim_id];
             uint32_t frame_count = animation->m_End - animation->m_Start;
-            if (animation->m_Playback == dmGameSystemDDF::PLAYBACK_ONCE_PINGPONG ||
-                animation->m_Playback == dmGameSystemDDF::PLAYBACK_LOOP_PINGPONG)
+            const dmGameSystemDDF::Playback playback = animation->m_Playback;
+            component->m_AnimationFrameCount = frame_count;
+            if (playback == dmGameSystemDDF::PLAYBACK_ONCE_PINGPONG ||
+                playback == dmGameSystemDDF::PLAYBACK_LOOP_PINGPONG)
             {
                 frame_count = dmMath::Max(1u, frame_count * 2 - 2);
             }
             component->m_AnimInvDuration = (float)animation->m_Fps / frame_count;
-            component->m_AnimPingPong = animation->m_Playback == dmGameSystemDDF::PLAYBACK_ONCE_PINGPONG || animation->m_Playback == dmGameSystemDDF::PLAYBACK_LOOP_PINGPONG;
-            component->m_AnimBackwards = animation->m_Playback == dmGameSystemDDF::PLAYBACK_ONCE_BACKWARD || animation->m_Playback == dmGameSystemDDF::PLAYBACK_LOOP_BACKWARD;
-            component->m_Playing = animation->m_Playback != dmGameSystemDDF::PLAYBACK_NONE;
+            component->m_AnimationPlayback = playback;
+            component->m_IsPlaying = playback != dmGameSystemDDF::PLAYBACK_NONE;
 
             if (component->m_Resource->m_DDF->m_SizeMode == dmGameSystemDDF::SpriteDesc::SIZE_MODE_AUTO)
             {
@@ -537,7 +593,9 @@ namespace dmGameSystem
             }
 
             offset = dmMath::Clamp(offset, 0.0f, 1.0f);
-            if (animation->m_Playback == dmGameSystemDDF::PLAYBACK_ONCE_BACKWARD || animation->m_Playback == dmGameSystemDDF::PLAYBACK_LOOP_BACKWARD) {
+            if (playback == dmGameSystemDDF::PLAYBACK_ONCE_BACKWARD ||
+                playback == dmGameSystemDDF::PLAYBACK_LOOP_BACKWARD)
+            {
                 offset = 1.0f - offset;
             }
 
@@ -547,8 +605,9 @@ namespace dmGameSystem
         }
         else
         {
+            component->m_AnimationReHash |= component->m_CurrentAnimation != 0x0 && component->m_CurrentAnimationFrame != 0;
             // TODO: Why stop the current animation? Shouldn't it continue playing the current animation?
-            component->m_Playing = 0;
+            component->m_IsPlaying = 0;
             component->m_CurrentAnimation = 0x0;
             component->m_CurrentAnimationFrame = 0;
             dmLogError("Unable to play animation '%s' from texture '%s' since it could not be found.", dmHashReverseSafe64(animation), dmHashReverseSafe64(texture_set->m_TexturePath));
@@ -579,6 +638,19 @@ namespace dmGameSystem
 
         component->m_MixedHash = dmHashFinal32(&state);
         component->m_ReHash = 0;
+        component->m_AnimationReHash = 1;
+    }
+
+    static void AnimationReHash(SpriteComponent* component)
+    {
+        // component, component->m_MixedHash, component->m_CurrentAnimation, component->m_CurrentAnimationFrame
+        HashState32 state;
+        dmHashInit32(&state, false);
+        dmHashUpdateBuffer32(&state, &component->m_MixedHash, sizeof(component->m_MixedHash));
+        dmHashUpdateBuffer32(&state, &component->m_CurrentAnimation, sizeof(component->m_CurrentAnimation));
+        dmHashUpdateBuffer32(&state, &component->m_CurrentAnimationFrame, sizeof(component->m_CurrentAnimationFrame));
+        component->m_AnimationDataHash = dmHashFinal32(&state);
+        component->m_AnimationReHash = 0;
     }
 
     dmGameObject::CreateResult CompSpriteCreate(const dmGameObject::ComponentCreateParams& params)
@@ -600,6 +672,8 @@ namespace dmGameSystem
         component->m_Scale = params.m_Scale;
         SpriteResource* resource = (SpriteResource*)params.m_Resource;
         component->m_Resource = resource;
+        // narrow to 8 bits because I don't believe that sprite can have more than 255 textures
+        component->m_NumTextures = (uint8_t)resource->m_NumTextures;
         component->m_Overrides = 0;
 
         dmMessage::ResetURL(&component->m_Listener);
@@ -608,6 +682,7 @@ namespace dmGameSystem
         component->m_Enabled = 1;
         component->m_FunctionRef = 0;
         component->m_ReHash = 1;
+        component->m_AnimationReHash = 1;
         component->m_Slice9 = component->m_Resource->m_DDF->m_Slice9;
         component->m_UseSlice9 = sum(component->m_Slice9) != 0 &&
                 component->m_Resource->m_DDF->m_SizeMode == dmGameSystemDDF::SpriteDesc::SIZE_MODE_MANUAL;
@@ -615,6 +690,8 @@ namespace dmGameSystem
         component->m_DynamicVertexAttributeIndex = INVALID_DYNAMIC_ATTRIBUTE_INDEX;
         component->m_Size = Vector3(0.0f, 0.0f, 0.0f);
         component->m_AnimationID = 0;
+        component->m_AnimationPlayback = dmGameSystemDDF::PLAYBACK_NONE;
+        component->m_AnimationFrameCount = 1;
 
         if (component->m_Resource->m_DDF->m_SizeMode == dmGameSystemDDF::SpriteDesc::SIZE_MODE_MANUAL)
         {
@@ -622,7 +699,7 @@ namespace dmGameSystem
             component->m_Size[1] = component->m_Resource->m_DDF->m_Size.getY();
         }
 
-        if (GetNumTextures(component) > 0)
+        if (component->m_NumTextures > 0)
         {
             PlayAnimation(component, resource->m_DefaultAnimation,
                     component->m_Resource->m_DDF->m_Offset, component->m_Resource->m_DDF->m_PlaybackRate);
@@ -693,8 +770,8 @@ namespace dmGameSystem
         const float** world_matrix,
         const float** positions_world_space,
         const float** positions_local_space,
-        const float** uv_channels, uint32_t uv_channels_count,
-        const float** pi_channels, uint32_t pi_channels_count)
+        const float** uv_channels, uint8_t uv_channels_count,
+        const float** pi_channels, uint8_t pi_channels_count)
     {
         memset(params, 0, sizeof(dmGraphics::WriteAttributeParams));
         params->m_VertexAttributeInfos = attribute_infos;
@@ -710,26 +787,41 @@ namespace dmGameSystem
         dmGraphics::SetWriteAttributeStreamDesc(&params->m_PageIndices, pi_channels, dmGraphics::VertexAttribute::VECTOR_TYPE_SCALAR, pi_channels_count, true);
     }
 
+    static inline void GetPivot(const AnimationData* animation_data, float* out_x_pivot, float* out_y_pivot)
+    {
+        // We always use the first geometry for the vertices
+        *out_x_pivot = 0.f;
+        *out_y_pivot = 0.f;
+        const dmGameSystemDDF::SpriteGeometry* geometry = animation_data->m_Geometries[0]; // textures_num == 0 then all elements in the array should 0x0
+        if (geometry)
+        {
+            *out_x_pivot = geometry->m_PivotX;
+            *out_y_pivot = geometry->m_PivotY;
+        }
+    }
+
     static void CreateVertexDataSlice9(
+        const SpriteComponent* component,
         uint8_t* vertices,
         uint8_t* indices,
         bool is_indices_16_bit,
         bool has_local_position_attribute,
         const Matrix4& world_matrix,
-        Vector3 sprite_size,
-        Vector4 slice9,
         uint32_t vertex_offset,
         uint32_t vertex_stride,
-        TexturesData* textures,
+        AnimationData* anim_data,
         dmArray<float>* scratch_uvs,
         float* scratch_uv_ptrs[MAX_TEXTURE_COUNT],
         float* scratch_pi_ptrs[MAX_TEXTURE_COUNT],
         dmArray<dmVMath::Vector4>* scratch_positions_world,
         dmArray<dmVMath::Vector4>* scratch_positions_local,
-        bool flip_u,
-        bool flip_v,
         dmGraphics::VertexAttributeInfos* sprite_infos)
     {
+        Vector3 sprite_size = component->m_Size;
+        Vector4 slice9 = component->m_Slice9;
+        bool flip_u = component->m_FlipHorizontal == 1;
+        bool flip_v = component->m_FlipVertical == 1;
+        uint8_t texture_num = component->m_NumTextures;
         // render 9-sliced node
         //   0 1     2 3
         // 0 *-*-----*-*
@@ -744,12 +836,12 @@ namespace dmGameSystem
 
         uint32_t uv_channels_count = 0;
 
-        for (uint32_t i = 0; i < textures->m_NumTextures; ++i)
+        for (uint8_t i = 0; i < texture_num; ++i)
         {
             dmArray<float>& uvs = scratch_uvs[i];
             EnsureSize(uvs, SPRITE_VERTEX_COUNT_SLICE9*2);
 
-            uint32_t frame_index = textures->m_Frames[i];
+            uint32_t frame_index = anim_data->m_Frames[i];
             if (frame_index == 0xFFFFFFFF)
             {
                 // The animation frame wasn't found in the textureset.
@@ -757,14 +849,15 @@ namespace dmGameSystem
                 continue;
             }
 
-            const dmGameSystemDDF::TextureSet* texture_set_ddf = textures->m_TextureSets[i];
+            const TextureSetResource* texture_set_resource = GetTextureSetByIndex(component, i);
+            const dmGameSystemDDF::TextureSet* texture_set_ddf = texture_set_resource->m_TextureSet;
             const float* tex_coords = (const float*) texture_set_ddf->m_TexCoords.m_Data;
             const float* tc         = &tex_coords[frame_index * 4 * 2];
 
             float us[4], vs[4];
 
-            uint32_t texture_width = textures->m_TextureSets[i]->m_Width;
-            uint32_t texture_height = textures->m_TextureSets[i]->m_Height;
+            uint32_t texture_width = texture_set_ddf->m_Width;
+            uint32_t texture_height = texture_set_ddf->m_Height;
 
             const float su = 1.0f / texture_width;
             const float sv = 1.0f / texture_height;
@@ -801,7 +894,7 @@ namespace dmGameSystem
             FillSlice9Uvs(us, vs, uv_rotated, uvs.Begin());
 
             scratch_uv_ptrs[i] = uvs.Begin();
-            scratch_pi_ptrs[i] = (float*) &textures->m_PageIndices[i];
+            scratch_pi_ptrs[i] = (float*) &anim_data->m_PageIndices[i];
             uv_channels_count++;
         }
 
@@ -809,7 +902,7 @@ namespace dmGameSystem
         // (avoid div by zero)
         const float s9_min_dim = 0.001f;
 
-        if (textures->m_NumTextures == 0)
+        if (texture_num == 0)
         {
             dmArray<float>& uvs = scratch_uvs[0];
             EnsureSize(uvs, SPRITE_VERTEX_COUNT_SLICE9*2);
@@ -829,7 +922,7 @@ namespace dmGameSystem
             FillSlice9Uvs(us, vs, false, uvs.Begin());
 
             scratch_uv_ptrs[0] = uvs.Begin();
-            scratch_pi_ptrs[0] = (float*) &textures->m_PageIndices[0];
+            scratch_pi_ptrs[0] = (float*) &anim_data->m_PageIndices[0];
             uv_channels_count  = 1;
         }
 
@@ -868,14 +961,9 @@ namespace dmGameSystem
             uv_channels_count);
 
         // We always use the first geometry for the vertices
-        float pivot_x = 0;
-        float pivot_y = 0;
-        const dmGameSystemDDF::SpriteGeometry* geometry = textures->m_NumTextures > 0 ? textures->m_Geometries[0] : 0;
-        if (geometry)
-        {
-            pivot_x = geometry->m_PivotX;
-            pivot_y = geometry->m_PivotY;
-        }
+        float pivot_x = 0.f;
+        float pivot_y = 0.f;
+        GetPivot(anim_data, &pivot_x, &pivot_y);
 
         uint32_t sp_width = sprite_size.getX();
         uint32_t sp_height = sprite_size.getY();
@@ -941,8 +1029,10 @@ namespace dmGameSystem
         }
     }
 
-    static void ResolveAnimationData(TexturesData* data, dmhash_t anim_id, uint32_t current_anim_frame_index)
+    static void ResolveAnimationData(const SpriteComponent* component, AnimationData* data)
     {
+        dmhash_t anim_id = component->m_CurrentAnimation;
+        uint32_t current_anim_frame_index = component->m_CurrentAnimationFrame;
         data->m_AnimationID = anim_id;
 
         // For the first texture set, we figure out the actual frame index,
@@ -952,14 +1042,17 @@ namespace dmGameSystem
 
         bool uses_geometries = false;
 
-        for (uint32_t i = 0; i < data->m_NumTextures; ++i)
+        uint8_t texture_num = component->m_NumTextures;
+        for (uint8_t i = 0; i < texture_num; ++i)
         {
-            const dmGameSystemDDF::TextureSet* texture_set_ddf = data->m_TextureSets[i];
+            TextureSetResource* resource = GetTextureSetByIndex(component, i);
+            
+            const dmGameSystemDDF::TextureSet* texture_set_ddf = resource->m_TextureSet;
             const uint32_t* frame_indices = texture_set_ddf->m_FrameIndices.m_Data;
             const uint32_t* page_indices = texture_set_ddf->m_PageIndices.m_Data;
             const dmGameSystemDDF::SpriteGeometry* geometries = texture_set_ddf->m_Geometries.m_Data;
 
-            uint32_t* anim_index = data->m_Resources[i]->m_AnimationIds.Get(anim_id);
+            uint32_t* anim_index = resource->m_AnimationIds.Get(anim_id);
             if (anim_index)
                 data->m_Animations[i] = &texture_set_ddf->m_Animations[*anim_index];
             else
@@ -979,7 +1072,7 @@ namespace dmGameSystem
             {
                 // Use the name hash of the current single frame animation from the driving atlas
                 // to lookup the frame number in this atlas
-                uint32_t* resource_frame_index = data->m_Resources[i]->m_FrameIds.Get(frame_anim_id);
+                uint32_t* resource_frame_index = resource->m_FrameIds.Get(frame_anim_id);
                 if (!resource_frame_index)
                 {
                     // Missing image in this atlas, we need to skip this texture slot
@@ -997,10 +1090,39 @@ namespace dmGameSystem
             uses_geometries |= data->m_Geometries[i]->m_TrimMode != dmGameSystemDDF::SPRITE_TRIM_MODE_OFF;
         }
 
-        data->m_UsesGeometries = uses_geometries;
+        data->m_CanUseQuads = !uses_geometries || data->m_Geometries[0]->m_TrimMode == dmGameSystemDDF::SPRITE_TRIM_MODE_OFF;
+
+        if (!data->m_CanUseQuads)
+        {
+            TextureSetResource* texture_set                     = GetFirstTextureSet(component);
+            dmGameSystemDDF::TextureSet* texture_set_ddf        = texture_set->m_TextureSet;
+            dmGameSystemDDF::TextureSetAnimation* animations    = texture_set_ddf->m_Animations.m_Data;
+            dmGameSystemDDF::TextureSetAnimation* animation_ddf = &animations[component->m_AnimationID];
+            uint32_t* frame_indices                             = texture_set_ddf->m_FrameIndices.m_Data;
+            uint32_t frame_index                                = frame_indices[animation_ddf->m_Start + component->m_CurrentAnimationFrame];
+            dmGameSystemDDF::SpriteGeometry* geometries         = texture_set_ddf->m_Geometries.m_Data;
+            dmGameSystemDDF::SpriteGeometry* geometry           = &geometries[frame_index];
+            uint32_t geometry_vx_count                          = geometry->m_Vertices.m_Count / 2;
+
+            data->m_VertexCount   = geometry_vx_count; // (x,y) coordinates
+            data->m_IndicesCount  = geometry->m_Indices.m_Count;
+        }
+        else
+        {
+            if (component->m_UseSlice9)
+            {
+                data->m_VertexCount   = SPRITE_VERTEX_COUNT_SLICE9;
+                data->m_IndicesCount  = SPRITE_INDEX_COUNT_SLICE9;
+            }
+            else
+            {
+                data->m_VertexCount   = SPRITE_VERTEX_COUNT_LEGACY;
+                data->m_IndicesCount  = SPRITE_INDEX_COUNT_LEGACY;
+            }
+        }
     }
 
-    static void ResolveUVDataFromQuads(TexturesData* data, dmArray<float>* scratch_uvs, float* scratch_uv_ptrs[MAX_TEXTURE_COUNT], float* scratch_pi_ptrs[MAX_TEXTURE_COUNT], uint16_t flip_horizontal, uint16_t flip_vertical)
+    static void ResolveUVDataFromQuads(const SpriteComponent* component, AnimationData* data, dmArray<float>* scratch_uvs, float* scratch_uv_ptrs[MAX_TEXTURE_COUNT], float* scratch_pi_ptrs[MAX_TEXTURE_COUNT])
     {
         static int tex_coord_order[] = {
             0,1,2,2,3,0,    // no flip
@@ -1008,8 +1130,11 @@ namespace dmGameSystem
             1,0,3,3,2,1,    // flip v
             2,3,0,0,1,2     // flip hv
         };
+        uint16_t flip_horizontal = component->m_FlipHorizontal;
+        uint16_t flip_vertical = component->m_FlipVertical;
+        uint8_t texture_num = component->m_NumTextures;
 
-        for (uint32_t i = 0; i < data->m_NumTextures; ++i)
+        for (uint8_t i = 0; i < texture_num; ++i)
         {
             dmArray<float>& uvs = scratch_uvs[i];
             EnsureSize(uvs, 4*2);
@@ -1022,7 +1147,8 @@ namespace dmGameSystem
                 continue;
             }
 
-            const dmGameSystemDDF::TextureSet* texture_set_ddf = data->m_TextureSets[i];
+            const TextureSetResource* texture_set_resource = GetTextureSetByIndex(component, i);
+            const dmGameSystemDDF::TextureSet* texture_set_ddf = texture_set_resource->m_TextureSet;
             const dmGameSystemDDF::TextureSetAnimation* animation_ddf = data->m_Animations[i];
             if (!animation_ddf)
             {
@@ -1059,7 +1185,7 @@ namespace dmGameSystem
             scratch_pi_ptrs[i] = &data->m_PageIndices[i];
         }
 
-        if (data->m_NumTextures == 0)
+        if (texture_num == 0)
         {
             dmArray<float>& uvs = scratch_uvs[0];
             EnsureSize(uvs, 4*2);
@@ -1085,42 +1211,40 @@ namespace dmGameSystem
         }
     }
 
-    static inline bool CanUseQuads(const TexturesData* data)
-    {
-        return !data->m_UsesGeometries ||
-                data->m_Geometries[0]->m_TrimMode == dmGameSystemDDF::SPRITE_TRIM_MODE_OFF;
-    }
-
     // Since each texture set may have different trimming, the geometry for each image may not map 1:1.
     // We therefore use the geometry of the first texture set as vertices.
     // Then, for each texture set, we map local vertex ([-0.5,0.5]) into a final UV for each image
     // It of course has some caveats:
     //   * The geometry may not map 1:1, and for polygon packed atlases, it may result in texture bleeding
-    static void ResolvePositionAndUVDataFromGeometry(TexturesData* data,
+    static void ResolvePositionAndUVDataFromGeometry(const SpriteComponent *component,
+        AnimationData* anim_data,
         dmArray<Vector4>& scratch_pos,
         dmArray<float>* scratch_uvs,
         float* scratch_uv_ptrs[MAX_TEXTURE_COUNT],
         float* scratch_pi_ptrs[MAX_TEXTURE_COUNT],
         float scale_x, float scale_y, int reverse)
     {
-        uint32_t num_vertices = data->m_Geometries[0]->m_Vertices.m_Count / 2;
-        float* orig_vertices = data->m_Geometries[0]->m_Vertices.m_Data;
+        uint32_t num_vertices = anim_data->m_Geometries[0]->m_Vertices.m_Count / 2;
+        float* orig_vertices = anim_data->m_Geometries[0]->m_Vertices.m_Data;
         int step = reverse ? -2 : 2;
 
         EnsureSize(scratch_pos, num_vertices);
 
-        for (uint32_t i = 0; i < data->m_NumTextures; ++i)
+        uint8_t textures_num = component->m_NumTextures;
+        for (uint8_t i = 0; i < textures_num; ++i)
         {
             dmArray<float>& uvs = scratch_uvs[i];
             EnsureSize(uvs, num_vertices * 2);
 
             scratch_uv_ptrs[i] = uvs.Begin();
-            scratch_pi_ptrs[i] = &data->m_PageIndices[i];
+            scratch_pi_ptrs[i] = &anim_data->m_PageIndices[i];
 
-            uint32_t width = data->m_TextureSets[i]->m_Width;
-            uint32_t height = data->m_TextureSets[i]->m_Height;
+            TextureSetResource* texture_set_resource = GetTextureSetByIndex(component, i);
+            dmGameSystemDDF::TextureSet* texture_set = texture_set_resource->m_TextureSet;
+            uint32_t width = texture_set->m_Width;
+            uint32_t height = texture_set->m_Height;
 
-            const dmGameSystemDDF::SpriteGeometry* geometry = data->m_Geometries[i];
+            const dmGameSystemDDF::SpriteGeometry* geometry = anim_data->m_Geometries[i];
             bool rotated = geometry->m_Rotated; // if true, rotate 90 deg (CCW)
             // width/height are not rotated
             float image_width = geometry->m_Width;
@@ -1135,13 +1259,9 @@ namespace dmGameSystem
             float center_x = geometry->m_CenterX;
             float center_y = geometry->m_CenterY;
 
-            float pivot_x = 0;
-            float pivot_y = 0;
-            if (i == 0) // We only need to do this for the vertex positions
-            {
-                pivot_x = geometry->m_PivotX;
-                pivot_y = geometry->m_PivotY;
-            }
+            float pivot_x = 0.f;
+            float pivot_y = 0.f;
+            GetPivot(anim_data, &pivot_x, &pivot_y);
 
             const float* vertices = reverse ? orig_vertices + num_vertices*2 - 2 : orig_vertices;
 
@@ -1182,7 +1302,43 @@ namespace dmGameSystem
         }
     }
 
-    static void CreateVertexData(SpriteWorld* sprite_world, dmGraphics::VertexAttributeInfos* material_attribute_info, bool has_local_position_attribute, uint8_t** vb_where, uint8_t** ib_where, dmRender::RenderListEntry* buf, uint32_t* begin, uint32_t* end)
+    static AnimationData* GetOrCreateAnimationData(SpriteWorld* sprite_world, const SpriteComponent* component)
+    {
+        // 1. Search in hastable
+        uint32_t hash = component->m_AnimationDataHash;
+        AnimationData** found = sprite_world->m_AnimationDataCache.m_Cache.Get(hash);
+        if (found != 0x0)
+        {
+            // updates only once per frame
+            if ((*found)->m_LastAccessTick != sprite_world->m_AnimationDataCache.m_CurrentEngineTick)
+            {
+                dmDoubleLinkedList::ListNode* node = (dmDoubleLinkedList::ListNode*)(*found);
+                dmDoubleLinkedList::ListRemove(&sprite_world->m_AnimationDataCache.m_LRU, node);
+                dmDoubleLinkedList::ListAdd(&sprite_world->m_AnimationDataCache.m_LRU, node);
+                (*found)->m_LastAccessTick = sprite_world->m_AnimationDataCache.m_CurrentEngineTick;
+            }
+            return *found;
+        }
+
+        // 2. Create if doesn't exist
+        // Get the correct animation frames, and other meta data
+        AnimationData* anim_data = (AnimationData*)malloc(sizeof(AnimationData));
+        memset(anim_data, 0, sizeof(AnimationData));
+        ResolveAnimationData(component, anim_data);
+
+        anim_data->m_LastAccessTick = sprite_world->m_AnimationDataCache.m_CurrentEngineTick;
+        anim_data->m_CacheKey = hash;
+        if (sprite_world->m_AnimationDataCache.m_Cache.Full())
+        {
+            sprite_world->m_AnimationDataCache.m_Cache.OffsetCapacity(30);
+        }
+        sprite_world->m_AnimationDataCache.m_Cache.Put(hash, anim_data);
+        dmDoubleLinkedList::ListAdd(&sprite_world->m_AnimationDataCache.m_LRU, (dmDoubleLinkedList::ListNode*)anim_data);
+        return anim_data;
+    }
+
+    static void CreateVertexData(SpriteWorld* sprite_world, dmGraphics::VertexAttributeInfos* material_attribute_info, 
+        bool has_local_position_attribute, uint8_t** vb_where, uint8_t** ib_where, dmRender::RenderListEntry* buf, uint32_t* begin, uint32_t* end)
     {
         DM_PROFILE("CreateVertexData");
 
@@ -1196,20 +1352,9 @@ namespace dmGameSystem
         uint32_t vertex_offset = sprite_world->m_VerticesWritten;
         uint32_t vertex_stride = material_attribute_info->m_VertexStride;
 
-        uint32_t component_index = (uint32_t)buf[*begin].m_UserData;
-        const SpriteComponent* first = (const SpriteComponent*) &sprite_world->m_Components.GetRawObjects()[component_index];
-
         // The list of pointers to the scratch uvs and page indices
         float* scratch_uv_ptrs[MAX_TEXTURE_COUNT] = {};
         float* scratch_pi_ptrs[MAX_TEXTURE_COUNT] = {};
-
-        TexturesData textures = {};
-        textures.m_NumTextures = GetNumTextures(first);
-        for (uint32_t i = 0; i < textures.m_NumTextures; ++i)
-        {
-            textures.m_Resources[i] = GetTextureSetByIndex(first, i);
-            textures.m_TextureSets[i] = textures.m_Resources[i]->m_TextureSet;
-        }
 
         dmGraphics::VertexAttributeInfos sprite_attribute_info = {};
         dmGraphics::WriteAttributeParams write_params = {};
@@ -1222,10 +1367,9 @@ namespace dmGameSystem
 
             float sp_width  = component->m_Size.getX();
             float sp_height = component->m_Size.getY();
-
-            // Get the correct animation frames, and other meta data
-            ResolveAnimationData(&textures, component->m_CurrentAnimation, component->m_CurrentAnimationFrame);
-
+            uint8_t textures_num = component->m_NumTextures;
+            AnimationData* animations = GetOrCreateAnimationData(sprite_world, component);
+    
             // Fill in the custom sprite attributes (if specified), otherwise fallback to use the material attributes
             dmGraphics::VertexAttributeInfos* sprite_attribute_info_ptr = material_attribute_info;
             if (component->m_Resource->m_DDF->m_Attributes.m_Count > 0 || component->m_DynamicVertexAttributeIndex != INVALID_DYNAMIC_ATTRIBUTE_INDEX)
@@ -1250,10 +1394,10 @@ namespace dmGameSystem
                 vertex_offset += 1;
             }
 
-            // if num_texture == 0, then we don't have a texture set to get any vertex/uv coordinates from
-            if (textures.m_NumTextures != 0 && !CanUseQuads(&textures))
+            // if textures_num == 0, then we don't have a texture set to get any vertex/uv coordinates from
+            if (textures_num != 0 && !animations->m_CanUseQuads)
             {
-                const dmGameSystemDDF::TextureSetAnimation* animation_ddf = textures.m_Animations[0];
+                const dmGameSystemDDF::TextureSetAnimation* animation_ddf = animations->m_Animations[0];
 
                 int flipx = animation_ddf->m_FlipHorizontal ^ component->m_FlipHorizontal;
                 int flipy = animation_ddf->m_FlipVertical ^ component->m_FlipVertical;
@@ -1264,7 +1408,7 @@ namespace dmGameSystem
                 // to respect face winding (and backface culling)
                 int reverse = flipx ^ flipy;
 
-                ResolvePositionAndUVDataFromGeometry(&textures, sprite_world->m_ScratchPositionWorld, sprite_world->m_ScratchUVs, scratch_uv_ptrs, scratch_pi_ptrs, scaleX, scaleY, reverse);
+                ResolvePositionAndUVDataFromGeometry(component, animations, sprite_world->m_ScratchPositionWorld, sprite_world->m_ScratchUVs, scratch_uv_ptrs, scratch_pi_ptrs, scaleX, scaleY, reverse);
 
                 if (has_local_position_attribute)
                 {
@@ -1280,9 +1424,9 @@ namespace dmGameSystem
                     world_position_channels,
                     local_position_channels,
                     (const float**) scratch_uv_ptrs,
-                    textures.m_NumTextures,
+                    textures_num,
                     (const float**) scratch_pi_ptrs,
-                    textures.m_NumTextures);
+                    textures_num);
 
                 uint32_t num_vertices = sprite_world->m_ScratchPositionWorld.Size();
                 for (uint32_t vertex_index = 0; vertex_index < num_vertices; ++vertex_index)
@@ -1299,7 +1443,7 @@ namespace dmGameSystem
                     vertices = dmGraphics::WriteAttributes(vertices, vertex_index, 1, write_params);
                 }
 
-                const dmGameSystemDDF::SpriteGeometry* geometry = textures.m_Geometries[0];
+                const dmGameSystemDDF::SpriteGeometry* geometry = animations->m_Geometries[0];
                 uint32_t index_count = geometry->m_Indices.m_Count;
                 uint32_t* geom_indices = geometry->m_Indices.m_Data;
                 if (sprite_world->m_Is16BitIndex)
@@ -1339,13 +1483,11 @@ namespace dmGameSystem
                 //      submitting more vertices than needed.
                 if (component->m_UseSlice9)
                 {
-                    int flipx = component->m_FlipHorizontal;
-                    int flipy = component->m_FlipVertical;
-                    CreateVertexDataSlice9(vertices, indices, sprite_world->m_Is16BitIndex, has_local_position_attribute,
-                        world_matrix, component->m_Size, component->m_Slice9, vertex_offset, vertex_stride,
-                        &textures, sprite_world->m_ScratchUVs, scratch_uv_ptrs, scratch_pi_ptrs,
+                    CreateVertexDataSlice9(component, vertices, indices, sprite_world->m_Is16BitIndex, has_local_position_attribute,
+                        world_matrix, vertex_offset, vertex_stride,
+                        animations, sprite_world->m_ScratchUVs, scratch_uv_ptrs, scratch_pi_ptrs,
                         &sprite_world->m_ScratchPositionWorld, &sprite_world->m_ScratchPositionLocal,
-                        flipx, flipy, sprite_attribute_info_ptr);
+                        sprite_attribute_info_ptr);
 
                     indices       += index_type_size * SPRITE_INDEX_COUNT_SLICE9;
                     vertices      += SPRITE_VERTEX_COUNT_SLICE9 * vertex_stride;
@@ -1358,17 +1500,12 @@ namespace dmGameSystem
                     //    Thus we can use the corresponding quad for each image
                     // B) The first image is a quad, and any remapping
                     //    for any subsequent geometry would yield a quad anyways.
-                    ResolveUVDataFromQuads(&textures, sprite_world->m_ScratchUVs, scratch_uv_ptrs, scratch_pi_ptrs, component->m_FlipHorizontal, component->m_FlipVertical);
+                    ResolveUVDataFromQuads(component, animations, sprite_world->m_ScratchUVs, scratch_uv_ptrs, scratch_pi_ptrs);
 
                     // We always use the first geometry for the vertices
-                    float pivot_x = 0;
-                    float pivot_y = 0;
-                    const dmGameSystemDDF::SpriteGeometry* geometry = textures.m_NumTextures > 0 ? textures.m_Geometries[0] : 0;
-                    if (geometry)
-                    {
-                        pivot_x = geometry->m_PivotX;
-                        pivot_y = geometry->m_PivotY;
-                    }
+                    float pivot_x = 0.f;
+                    float pivot_y = 0.f;
+                    GetPivot(animations, &pivot_x, &pivot_y);
 
                     float x0 = -0.5f - pivot_x;
                     float x1 =  0.5f - pivot_x;
@@ -1400,9 +1537,9 @@ namespace dmGameSystem
                         world_position_channels,
                         local_position_channels,
                         (const float**) scratch_uv_ptrs,
-                        textures.m_NumTextures,
+                        textures_num,
                         (const float**) scratch_pi_ptrs,
-                        textures.m_NumTextures);
+                        textures_num);
 
                     vertices = dmGraphics::WriteAttributes(vertices, 0, 4, write_params);
 
@@ -1556,36 +1693,21 @@ namespace dmGameSystem
         dmRender::AddToRender(render_context, &ro);
     }
 
-    static void UpdateTransforms(SpriteWorld* sprite_world, bool sub_pixels)
+    static void UpdateTransform(SpriteComponent* component, bool sub_pixels)
     {
-        DM_PROFILE("UpdateTransforms");
-
-        dmArray<SpriteComponent>& components = sprite_world->m_Components.GetRawObjects();
-        uint32_t n = components.Size();
-        // Note: We update all sprites, even though they might be disabled, or not added to update
-        for (uint32_t i = 0; i < n; ++i)
+        Matrix4 local = dmTransform::ToMatrix4(dmTransform::Transform(component->m_Position, component->m_Rotation, 1.0f));
+        Matrix4 world = dmGameObject::GetWorldMatrix(component->m_Instance);
+        Vector3 size = dmVMath::MulPerElem(component->m_Size, component->m_Scale);
+        size.setZ(1.f);
+        Matrix4 w = dmVMath::AppendScale(world * local, size);
+        if (!sub_pixels)
         {
-            SpriteComponent* c = &components[i];
-            Matrix4 local = dmTransform::ToMatrix4(dmTransform::Transform(c->m_Position, c->m_Rotation, 1.0f));
-            Matrix4 world = dmGameObject::GetWorldMatrix(c->m_Instance);
-            Vector3 size( c->m_Size.getX() * c->m_Scale.getX(), c->m_Size.getY() * c->m_Scale.getY(), 1);
-            c->m_World = dmVMath::AppendScale(world * local, size);
-            // we need to consider the full scale here
-            // I.e. we want the length of the diagonal C, where C = X + Y
-            float radius_sq = dmVMath::LengthSqr((c->m_World.getCol(0).getXYZ() + c->m_World.getCol(1).getXYZ()) * 0.5f);
-            sprite_world->m_BoundingVolumes[i] = radius_sq;
+            Vector4 position = w.getCol3();
+            position.setX((int) position.getX());
+            position.setY((int) position.getY());
+            w.setCol3(position);
         }
-
-        // The "sub_pixels" is set by default
-        if (!sub_pixels) {
-            for (uint32_t i = 0; i < n; ++i) {
-                SpriteComponent* c = &components[i];
-                Vector4 position = c->m_World.getCol3();
-                position.setX((int) position.getX());
-                position.setY((int) position.getY());
-                c->m_World.setCol3(position);
-            }
-        }
+        component->m_World = w;
     }
 
     static bool GetSender(SpriteComponent* component, dmMessage::URL* out_sender)
@@ -1605,202 +1727,115 @@ namespace dmGameSystem
         return false;
     }
 
-    static void PostMessages(SpriteWorld* sprite_world)
+    static void PostMessages(SpriteComponent* component)
     {
-        DM_PROFILE("PostMessages");
-
-        dmArray<SpriteComponent>& components = sprite_world->m_Components.GetRawObjects();
-        uint32_t n = components.Size();
-        for (uint32_t i = 0; i < n; ++i)
+        const dmGameSystemDDF::Playback playback = (dmGameSystemDDF::Playback)component->m_AnimationPlayback;
+        bool once = playback == dmGameSystemDDF::PLAYBACK_ONCE_FORWARD
+                || playback == dmGameSystemDDF::PLAYBACK_ONCE_BACKWARD
+                || playback == dmGameSystemDDF::PLAYBACK_ONCE_PINGPONG;
+        // Stop once-animation and broadcast animation_done
+        if (once && component->m_AnimTimer >= 1.0f)
         {
-            SpriteComponent* component = &components[i];
-            // NOTE: texture_set = c->m_Resource might be NULL so it's essential to "continue" here
-            if (!component->m_Enabled || !component->m_Playing)
-                continue;
-
-            TextureSetResource* texture_set = GetFirstTextureSet(component);
-            dmGameSystemDDF::TextureSet* texture_set_ddf = texture_set->m_TextureSet;
-            dmGameSystemDDF::TextureSetAnimation* animation_ddf = &texture_set_ddf->m_Animations[component->m_AnimationID];
-
-            bool once = animation_ddf->m_Playback == dmGameSystemDDF::PLAYBACK_ONCE_FORWARD
-                    || animation_ddf->m_Playback == dmGameSystemDDF::PLAYBACK_ONCE_BACKWARD
-                    || animation_ddf->m_Playback == dmGameSystemDDF::PLAYBACK_ONCE_PINGPONG;
-            // Stop once-animation and broadcast animation_done
-            if (once && component->m_AnimTimer >= 1.0f)
+            component->m_IsPlaying = 0;
+            if (component->m_Listener.m_Fragment != 0x0)
             {
-                component->m_Playing = 0;
-                if (component->m_Listener.m_Fragment != 0x0)
+                dmMessage::URL sender;
+                if (!GetSender(component, &sender))
                 {
-                    dmMessage::URL sender;
-                    if (!GetSender(component, &sender))
-                    {
-                        dmLogError("Could not send animation_done from component. Has it been deleted?");
-                        return;
-                    }
+                    dmLogError("Could not send animation_done from component. Has it been deleted?");
+                    return;
+                }
 
-                    // Should this check be handled by the comp_script.cpp?
-                    dmGameObject::HInstance listener_instance = dmGameObject::GetInstanceFromIdentifier(dmGameObject::GetCollection(component->m_Instance), component->m_Listener.m_Path);
-                    if (!listener_instance)
-                    {
-                        dmLogError("Could not send animation_done to instance: %s:%s#%s", dmHashReverseSafe64(component->m_Listener.m_Socket), dmHashReverseSafe64(component->m_Listener.m_Path), dmHashReverseSafe64(component->m_Listener.m_Fragment));
-                        return;
-                    }
+                // Should this check be handled by the comp_script.cpp?
+                dmGameObject::HInstance listener_instance = dmGameObject::GetInstanceFromIdentifier(dmGameObject::GetCollection(component->m_Instance), component->m_Listener.m_Path);
+                if (!listener_instance)
+                {
+                    dmLogError("Could not send animation_done to instance: %s:%s#%s", dmHashReverseSafe64(component->m_Listener.m_Socket), dmHashReverseSafe64(component->m_Listener.m_Path), dmHashReverseSafe64(component->m_Listener.m_Fragment));
+                    return;
+                }
 
-                    dmGameSystemDDF::AnimationDone message;
-                    message.m_CurrentTile = component->m_CurrentAnimationFrame + 1; // Engine has 0-based indices, scripts use 1-based
-                    message.m_Id = component->m_CurrentAnimation;
+                dmGameSystemDDF::AnimationDone message;
+                message.m_CurrentTile = component->m_CurrentAnimationFrame + 1; // Engine has 0-based indices, scripts use 1-based
+                message.m_Id = component->m_CurrentAnimation;
 
-                    // This is a 'done' callback, so we should tell the message system to remove the callback once it's been consumed
-                    dmGameObject::Result go_result = dmGameObject::PostDDF(&message, &sender, &component->m_Listener, component->m_FunctionRef, true);
-                    component->m_FunctionRef = 0;
+                // This is a 'done' callback, so we should tell the message system to remove the callback once it's been consumed
+                dmGameObject::Result go_result = dmGameObject::PostDDF(&message, &sender, &component->m_Listener, component->m_FunctionRef, true);
+                component->m_FunctionRef = 0;
 
-                    dmMessage::ResetURL(&component->m_Listener);
-                    if (go_result != dmGameObject::RESULT_OK)
-                    {
-                        dmLogError("Could not send animation_done to listener. Has it been deleted?");
-                    }
+                dmMessage::ResetURL(&component->m_Listener);
+                if (go_result != dmGameObject::RESULT_OK)
+                {
+                    dmLogError("Could not send animation_done to listener. Has it been deleted?");
                 }
             }
         }
     }
 
 
-    static void Animate(SpriteWorld* sprite_world, float dt)
+    static void Animate(SpriteComponent* component, float dt)
     {
-        DM_PROFILE("Animate");
-
-        dmArray<SpriteComponent>& components = sprite_world->m_Components.GetRawObjects();
-        uint32_t n = components.Size();
-        for (uint32_t i = 0; i < n; ++i)
+        if (component->m_IsPlaying && component->m_AddedToUpdate)
         {
-            SpriteComponent* component = &components[i];
-            // NOTE: texture_set = c->m_Resource might be NULL so it's essential to "continue" here
-            if (!component->m_Enabled)
-                continue;
-
-            if (component->m_Playing && component->m_AddedToUpdate)
+            // Animate
+            component->m_AnimTimer += dt * component->m_AnimInvDuration * component->m_PlaybackRate;
+            if (component->m_AnimTimer >= 1.0f)
             {
-                TextureSetResource* texture_set = GetFirstTextureSet(component);
-                dmGameSystemDDF::TextureSet* texture_set_ddf = texture_set->m_TextureSet;
-                dmGameSystemDDF::TextureSetAnimation* animation_ddf = &texture_set_ddf->m_Animations[component->m_AnimationID];
-
-                // Animate
-                component->m_AnimTimer += dt * component->m_AnimInvDuration * component->m_PlaybackRate;
-                if (component->m_AnimTimer >= 1.0f)
+                switch (component->m_AnimationPlayback)
                 {
-                    switch (animation_ddf->m_Playback)
-                    {
-                        case dmGameSystemDDF::PLAYBACK_ONCE_FORWARD:
-                        case dmGameSystemDDF::PLAYBACK_ONCE_BACKWARD:
-                        case dmGameSystemDDF::PLAYBACK_ONCE_PINGPONG:
-                            component->m_AnimTimer = 1.0f;
-                            break;
-                        default:
-                            component->m_AnimTimer -= floorf(component->m_AnimTimer);
-                            break;
-                    }
+                    case dmGameSystemDDF::PLAYBACK_ONCE_FORWARD:
+                    case dmGameSystemDDF::PLAYBACK_ONCE_BACKWARD:
+                    case dmGameSystemDDF::PLAYBACK_ONCE_PINGPONG:
+                        component->m_AnimTimer = 1.0f;
+                        break;
+                    default:
+                        component->m_AnimTimer -= floorf(component->m_AnimTimer);
+                        break;
                 }
-                component->m_DoTick = 1;
             }
+            component->m_DoTick = 1;
+        }
 
-            if (component->m_DoTick) {
-                component->m_DoTick = 0;
-                UpdateCurrentAnimationFrame(component);
-            }
+        if (component->m_DoTick)
+        {
+            component->m_DoTick = 0;
+            UpdateCurrentAnimationFrame(component);
         }
     }
 
-    static void UpdateVertexAndIndexCount(SpriteWorld* sprite_world, dmRender::HRenderContext render_context)
+    static void UpdateVertexAndIndexCount(SpriteWorld* sprite_world, const SpriteComponent* component, dmRender::HRenderContext render_context, uint32_t& num_vertices,
+        uint32_t& num_indices, uint32_t& vertex_memsize)
     {
-        DM_PROFILE("UpdateVertexAndIndexCount");
+        dmRender::HMaterial material           = GetRenderMaterial(render_context, component);
+        dmGraphics::HVertexDeclaration vx_decl = dmRender::GetVertexDeclaration(material);
+        uint32_t vertex_stride                 = dmGraphics::GetVertexDeclarationStride(vx_decl);
+        uint8_t textures_num                   = component->m_NumTextures;
 
-        dmArray<SpriteComponent>& components = sprite_world->m_Components.GetRawObjects();
-        uint32_t num_vertices    = 0;
-        uint32_t num_indices     = 0;
-        uint32_t vertex_memsize  = 0;
+        // We need to pad the buffer if the vertex stride doesn't start at an even byte offset from the start
+        vertex_memsize += vertex_stride - vertex_memsize % vertex_stride;
 
-        uint32_t n = components.Size();
-        for (uint32_t i = 0; i < n; ++i)
+        if (textures_num == 0)
         {
-            SpriteComponent* component = &components[i];
-            if (!component->m_Enabled || !component->m_AddedToUpdate)
+            if (component->m_UseSlice9)
             {
-                continue;
-            }
-
-            dmRender::HMaterial material           = GetRenderMaterial(render_context, component);
-            dmGraphics::HVertexDeclaration vx_decl = dmRender::GetVertexDeclaration(material);
-            uint32_t vertex_stride                 = dmGraphics::GetVertexDeclarationStride(vx_decl);
-
-            // We need to pad the buffer if the vertex stride doesn't start at an even byte offset from the start
-            vertex_memsize += vertex_stride - vertex_memsize % vertex_stride;
-
-            TexturesData textures = {};
-            textures.m_NumTextures = GetNumTextures(component);
-
-            if (textures.m_NumTextures == 0)
-            {
-                if (component->m_UseSlice9)
-                {
-                    num_vertices   += SPRITE_VERTEX_COUNT_SLICE9;
-                    num_indices    += SPRITE_INDEX_COUNT_SLICE9;
-                    vertex_memsize += SPRITE_VERTEX_COUNT_SLICE9 * vertex_stride;
-                }
-                else
-                {
-                    num_vertices   += SPRITE_VERTEX_COUNT_LEGACY;
-                    num_indices    += SPRITE_INDEX_COUNT_LEGACY;
-                    vertex_memsize += SPRITE_VERTEX_COUNT_LEGACY * vertex_stride;
-                }
-                continue;
-            }
-
-            for (uint32_t i = 0; i < textures.m_NumTextures; ++i)
-            {
-                textures.m_Resources[i] = GetTextureSetByIndex(component, i);
-                textures.m_TextureSets[i] = textures.m_Resources[i]->m_TextureSet;
-            }
-
-            // Get the correct animation frames, and other meta data
-            ResolveAnimationData(&textures, component->m_CurrentAnimation, component->m_CurrentAnimationFrame);
-
-            if (!CanUseQuads(&textures))
-            {
-                TextureSetResource* texture_set                     = GetFirstTextureSet(component);
-                dmGameSystemDDF::TextureSet* texture_set_ddf        = texture_set->m_TextureSet;
-                dmGameSystemDDF::TextureSetAnimation* animations    = texture_set_ddf->m_Animations.m_Data;
-                dmGameSystemDDF::TextureSetAnimation* animation_ddf = &animations[component->m_AnimationID];
-                uint32_t* frame_indices                             = texture_set_ddf->m_FrameIndices.m_Data;
-                uint32_t frame_index                                = frame_indices[animation_ddf->m_Start + component->m_CurrentAnimationFrame];
-                dmGameSystemDDF::SpriteGeometry* geometries         = texture_set_ddf->m_Geometries.m_Data;
-                dmGameSystemDDF::SpriteGeometry* geometry           = &geometries[frame_index];
-                uint32_t geometry_vx_count                          = geometry->m_Vertices.m_Count / 2;
-
-                num_vertices   += geometry_vx_count; // (x,y) coordinates
-                num_indices    += geometry->m_Indices.m_Count;
-                vertex_memsize += geometry_vx_count * vertex_stride;
+                num_vertices   += SPRITE_VERTEX_COUNT_SLICE9;
+                num_indices    += SPRITE_INDEX_COUNT_SLICE9;
+                vertex_memsize += SPRITE_VERTEX_COUNT_SLICE9 * vertex_stride;
             }
             else
             {
-                if (component->m_UseSlice9)
-                {
-                    num_vertices   += SPRITE_VERTEX_COUNT_SLICE9;
-                    num_indices    += SPRITE_INDEX_COUNT_SLICE9;
-                    vertex_memsize += SPRITE_VERTEX_COUNT_SLICE9 * vertex_stride;
-                }
-                else
-                {
-                    num_vertices   += SPRITE_VERTEX_COUNT_LEGACY;
-                    num_indices    += SPRITE_INDEX_COUNT_LEGACY;
-                    vertex_memsize += SPRITE_VERTEX_COUNT_LEGACY * vertex_stride;
-                }
+                num_vertices   += SPRITE_VERTEX_COUNT_LEGACY;
+                num_indices    += SPRITE_INDEX_COUNT_LEGACY;
+                vertex_memsize += SPRITE_VERTEX_COUNT_LEGACY * vertex_stride;
             }
+            return;
         }
 
-        sprite_world->m_ReallocBuffers   = vertex_memsize > sprite_world->m_VertexMemorySize || num_indices > sprite_world->m_IndexCount;
-        sprite_world->m_VertexCount      = num_vertices;
-        sprite_world->m_IndexCount       = num_indices;
-        sprite_world->m_VertexMemorySize = vertex_memsize;
+        // Get the correct animation frames, and other meta data
+        AnimationData* anim_data = GetOrCreateAnimationData(sprite_world, component);
+
+        num_vertices += anim_data->m_VertexCount;
+        num_indices += anim_data->m_IndicesCount;
+        vertex_memsize += anim_data->m_VertexCount * vertex_stride;
     }
 
     dmGameObject::CreateResult CompSpriteAddToUpdate(const dmGameObject::ComponentAddToUpdateParams& params) {
@@ -1809,6 +1844,39 @@ namespace dmGameSystem
         SpriteComponent* component = &sprite_world->m_Components.Get(index);
         component->m_AddedToUpdate = true;
         return dmGameObject::CREATE_RESULT_OK;
+    }
+
+    static void UpdateAnimationDataCache(SpriteWorld* sprite_world)
+    {
+        DM_PROFILE("UpdateAnimationDataCache");
+        // update current tick
+        sprite_world->m_AnimationDataCache.m_CurrentEngineTick++;
+        // evict all cache entries which older than CACHE_EVICTION_FRAMES ticks
+        dmDoubleLinkedList::List* list = &sprite_world->m_AnimationDataCache.m_LRU;
+        dmDoubleLinkedList::ListNode* current = dmDoubleLinkedList::ListGetLast(list);
+        while (current != 0x0)
+        {
+            // list node is used as pointer to memory block where AnimationData structure is placed
+            // cast to AnimationData allows to work with memory block as structure
+            AnimationData* data = (AnimationData*)current;
+            uint32_t cache_eviction_frame = data->m_LastAccessTick + CACHE_EVICTION_FRAMES;
+            uint32_t underflow_tick = sprite_world->m_AnimationDataCache.m_CurrentEngineTick - CACHE_EVICTION_FRAMES;
+
+            //in normal case we evict cache entry when CACHE_EVICTION_FRAMES passed
+            // but also in case if m_LastAccessTick tick or m_CurrentEngineTick is near overflow
+            if (cache_eviction_frame <= sprite_world->m_AnimationDataCache.m_CurrentEngineTick
+                && (data->m_LastAccessTick < cache_eviction_frame || underflow_tick > sprite_world->m_AnimationDataCache.m_CurrentEngineTick))
+            {
+                sprite_world->m_AnimationDataCache.m_Cache.Erase(data->m_CacheKey);
+                dmDoubleLinkedList::ListRemove(list, current);
+                free(data);
+            }
+            else
+            {
+                break;
+            }
+            current = dmDoubleLinkedList::ListGetLast(list);
+        }
     }
 
     dmGameObject::UpdateResult CompSpriteUpdate(const dmGameObject::ComponentsUpdateParams& params, dmGameObject::ComponentsUpdateResult& update_result)
@@ -1820,16 +1888,66 @@ namespace dmGameSystem
          */
 
         SpriteWorld* world = (SpriteWorld*)params.m_World;
-        Animate(world, params.m_UpdateContext->m_DT);
-
-        PostMessages(world);
-
         SpriteContext* sprite_context = (SpriteContext*)params.m_Context;
-        dmRender::TrimBuffer(sprite_context->m_RenderContext, world->m_VertexBuffer);
-        dmRender::RewindBuffer(sprite_context->m_RenderContext, world->m_VertexBuffer);
+        dmRender::HRenderContext render_context = sprite_context->m_RenderContext;
 
-        dmRender::TrimBuffer(sprite_context->m_RenderContext, world->m_IndexBuffer);
-        dmRender::RewindBuffer(sprite_context->m_RenderContext, world->m_IndexBuffer);
+        UpdateAnimationDataCache(world);
+
+        uint32_t num_vertices    = 0;
+        uint32_t num_indices     = 0;
+        uint32_t vertex_memsize  = 0;
+        dmArray<SpriteComponent>& components = world->m_Components.GetRawObjects();
+        uint32_t n = components.Size();
+
+        if (n == 0)
+        {
+            return dmGameObject::UPDATE_RESULT_OK;
+        }
+
+        bool sub_pixels = sprite_context->m_Subpixels;
+
+        for (uint32_t i = 0; i < n; ++i)
+        {
+            SpriteComponent* component = &components[i];
+            if (!component->m_Enabled || !component->m_AddedToUpdate)
+                continue;
+            UpdateTransform(component, sub_pixels);
+            // we need to consider the full scale here
+            // I.e. we want the length of the diagonal C, where C = X + Y
+            float radius_sq = dmVMath::LengthSqr((component->m_World.getCol(0).getXYZ() + component->m_World.getCol(1).getXYZ()) * 0.5f);
+            world->m_BoundingVolumes[i] = radius_sq;
+
+            Animate(component, params.m_UpdateContext->m_DT);
+            HComponentRenderConstants constants = GetRenderConstants(component);
+            if (component->m_ReHash || (constants && dmGameSystem::AreRenderConstantsUpdated(constants)))
+            {
+                ReHash(component);
+            }
+            if (component->m_AnimationReHash)
+            {
+                AnimationReHash(component);
+            }
+
+            UpdateVertexAndIndexCount(world, component, render_context, num_vertices, num_indices, vertex_memsize);
+
+            // TODO: check when we need send messages
+            if (!component->m_IsPlaying)
+                continue;
+            PostMessages(component);
+        }
+
+        // In case if CompSpriteUpdate will be called several times before CompSpriteRender - assign flag with "bit or"
+        // to save flag state from previous update until ReallocBuffers will be called
+        world->m_ReallocBuffers   |= vertex_memsize > world->m_VertexMemorySize || num_indices > world->m_IndexCount;
+        world->m_VertexCount      = num_vertices;
+        world->m_IndexCount       = num_indices;
+        world->m_VertexMemorySize = vertex_memsize;
+
+        dmRender::TrimBuffer(render_context, world->m_VertexBuffer);
+        dmRender::RewindBuffer(render_context, world->m_VertexBuffer);
+
+        dmRender::TrimBuffer(render_context, world->m_IndexBuffer);
+        dmRender::RewindBuffer(render_context, world->m_IndexBuffer);
 
         world->m_DispatchCount = 0;
 
@@ -1903,10 +2021,6 @@ namespace dmGameSystem
 
         sprite_world->m_VerticesWritten = 0;
 
-        UpdateTransforms(sprite_world, sprite_context->m_Subpixels); // TODO: Why is this not in the update function?
-
-        UpdateVertexAndIndexCount(sprite_world, render_context);
-
         dmArray<SpriteComponent>& components = sprite_world->m_Components.GetRawObjects();
         uint32_t sprite_count = components.Size();
 
@@ -1929,14 +2043,12 @@ namespace dmGameSystem
             if (!component.m_Enabled || !component.m_AddedToUpdate)
                 continue;
 
-            HComponentRenderConstants constants = GetRenderConstants(&component);
-            if (component.m_ReHash || (constants && dmGameSystem::AreRenderConstantsUpdated(constants)))
-            {
-                ReHash(&component);
-            }
-
-            const Vector4 trans = component.m_World.getCol(3);
-            write_ptr->m_WorldPosition = Point3(trans.getX(), trans.getY(), trans.getZ());
+            const AnimationData* anim_data = GetOrCreateAnimationData(sprite_world, &component);
+            float pivot_x = 0.f, pivot_y = 0.f;
+            GetPivot(anim_data, &pivot_x, &pivot_y);
+            Point3 pivot(-pivot_x, -pivot_y, 0.f);
+            Vector3 world_pos = (component.m_World * pivot).getXYZ();
+            write_ptr->m_WorldPosition = Point3(world_pos);
             write_ptr->m_UserData = i; // Assuming the object pool stays intact
             write_ptr->m_BatchKey = component.m_MixedHash;
             write_ptr->m_TagListKey = dmRender::GetMaterialTagListKey(GetComponentMaterial(&component));
@@ -1990,12 +2102,16 @@ namespace dmGameSystem
 
     static void SetCursor(SpriteComponent* component, float cursor)
     {
+        const dmGameSystemDDF::Playback playback = (dmGameSystemDDF::Playback)component->m_AnimationPlayback;
         cursor = dmMath::Clamp(cursor, 0.0f, 1.0f);
-        if (component->m_AnimPingPong) {
+        if (playback == dmGameSystemDDF::PLAYBACK_ONCE_PINGPONG 
+            || playback == dmGameSystemDDF::PLAYBACK_LOOP_PINGPONG)
+        {
             cursor /= 2.0f;
         }
-
-        if (component->m_AnimBackwards) {
+        else if (playback == dmGameSystemDDF::PLAYBACK_ONCE_BACKWARD 
+            || playback == dmGameSystemDDF::PLAYBACK_LOOP_BACKWARD)
+        {
             cursor = 1.0f - cursor;
         }
 
@@ -2006,13 +2122,19 @@ namespace dmGameSystem
     static float GetCursor(SpriteComponent* component)
     {
         float cursor = component->m_AnimTimer;
+        const dmGameSystemDDF::Playback playback = (dmGameSystemDDF::Playback)component->m_AnimationPlayback;
 
-        if (component->m_AnimBackwards)
+        if (playback == dmGameSystemDDF::PLAYBACK_ONCE_BACKWARD 
+            || playback == dmGameSystemDDF::PLAYBACK_LOOP_BACKWARD)
+        {
             cursor = 1.0f - cursor;
-
-        if (component->m_AnimPingPong) {
+        }
+        else if (playback == dmGameSystemDDF::PLAYBACK_ONCE_PINGPONG 
+            || playback == dmGameSystemDDF::PLAYBACK_LOOP_PINGPONG)
+        {
             cursor *= 2.0f;
-            if (cursor > 1.0f) {
+            if (cursor > 1.0f)
+            {
                 cursor = 2.0f - cursor;
             }
         }
@@ -2031,27 +2153,25 @@ namespace dmGameSystem
 
     static inline float GetAnimationFrameCount(SpriteComponent* component)
     {
-        TextureSetResource* texture_set                     = GetFirstTextureSet(component);
-        dmGameSystemDDF::TextureSet* texture_set_ddf        = texture_set->m_TextureSet;
-        dmGameSystemDDF::TextureSetAnimation* animation_ddf = &texture_set_ddf->m_Animations[component->m_AnimationID];
-        return (float)(animation_ddf->m_End - animation_ddf->m_Start);
+        return component->m_AnimationFrameCount;
     }
 
     dmGameObject::UpdateResult CompSpriteOnMessage(const dmGameObject::ComponentOnMessageParams& params)
     {
         SpriteWorld* sprite_world = (SpriteWorld*)params.m_World;
         SpriteComponent* component = &sprite_world->m_Components.Get(*params.m_UserData);
-        if (params.m_Message->m_Id == dmGameObjectDDF::Enable::m_DDFDescriptor->m_NameHash)
+        const dmhash_t message_id = params.m_Message->m_Id;
+        if (message_id == dmGameObjectDDF::Enable::m_DDFDescriptor->m_NameHash)
         {
             component->m_Enabled = 1;
         }
-        else if (params.m_Message->m_Id == dmGameObjectDDF::Disable::m_DDFDescriptor->m_NameHash)
+        else if (message_id == dmGameObjectDDF::Disable::m_DDFDescriptor->m_NameHash)
         {
             component->m_Enabled = 0;
         }
         else if (params.m_Message->m_Descriptor != 0x0)
         {
-            if (params.m_Message->m_Id == dmGameSystemDDF::PlayAnimation::m_DDFDescriptor->m_NameHash)
+            if (message_id == dmGameSystemDDF::PlayAnimation::m_DDFDescriptor->m_NameHash)
             {
                 dmGameSystemDDF::PlayAnimation* ddf = (dmGameSystemDDF::PlayAnimation*)params.m_Message->m_Data;
                 if (PlayAnimation(component, ddf->m_Id, ddf->m_Offset, ddf->m_PlaybackRate))
@@ -2067,17 +2187,17 @@ namespace dmGameSystem
                     component->m_FunctionRef = params.m_Message->m_UserData2;
                 }
             }
-            else if (params.m_Message->m_Id == dmGameSystemDDF::SetFlipHorizontal::m_DDFDescriptor->m_NameHash)
+            else if (message_id == dmGameSystemDDF::SetFlipHorizontal::m_DDFDescriptor->m_NameHash)
             {
                 dmGameSystemDDF::SetFlipHorizontal* ddf = (dmGameSystemDDF::SetFlipHorizontal*)params.m_Message->m_Data;
                 component->m_FlipHorizontal = ddf->m_Flip != 0 ? 1 : 0;
             }
-            else if (params.m_Message->m_Id == dmGameSystemDDF::SetFlipVertical::m_DDFDescriptor->m_NameHash)
+            else if (message_id == dmGameSystemDDF::SetFlipVertical::m_DDFDescriptor->m_NameHash)
             {
                 dmGameSystemDDF::SetFlipVertical* ddf = (dmGameSystemDDF::SetFlipVertical*)params.m_Message->m_Data;
                 component->m_FlipVertical = ddf->m_Flip != 0 ? 1 : 0;
             }
-            else if (params.m_Message->m_Id == dmGameSystemDDF::SetConstant::m_DDFDescriptor->m_NameHash)
+            else if (message_id == dmGameSystemDDF::SetConstant::m_DDFDescriptor->m_NameHash)
             {
                 dmGameSystemDDF::SetConstant* ddf = (dmGameSystemDDF::SetConstant*)params.m_Message->m_Data;
                 dmGameObject::PropertyResult result = dmGameSystem::SetMaterialConstant(GetComponentMaterial(component), ddf->m_NameHash,
@@ -2092,7 +2212,7 @@ namespace dmGameSystem
                             dmHashReverseSafe64(ddf->m_NameHash));
                 }
             }
-            else if (params.m_Message->m_Id == dmGameSystemDDF::ResetConstant::m_DDFDescriptor->m_NameHash)
+            else if (message_id == dmGameSystemDDF::ResetConstant::m_DDFDescriptor->m_NameHash)
             {
                 dmGameSystemDDF::ResetConstant* ddf = (dmGameSystemDDF::ResetConstant*)params.m_Message->m_Data;
                 if (component->m_RenderConstants && dmGameSystem::ClearRenderConstant(component->m_RenderConstants, ddf->m_NameHash))
@@ -2100,7 +2220,7 @@ namespace dmGameSystem
                     component->m_ReHash = 1;
                 }
             }
-            else if (params.m_Message->m_Id == dmGameSystemDDF::SetScale::m_DDFDescriptor->m_NameHash)
+            else if (message_id == dmGameSystemDDF::SetScale::m_DDFDescriptor->m_NameHash)
             {
                 dmGameSystemDDF::SetScale* ddf = (dmGameSystemDDF::SetScale*)params.m_Message->m_Data;
                 component->m_Scale = ddf->m_Scale;
@@ -2114,8 +2234,10 @@ namespace dmGameSystem
     {
         SpriteWorld* sprite_world = (SpriteWorld*)params.m_World;
         SpriteComponent* component = &sprite_world->m_Components.Get(*params.m_UserData);
-        if (component->m_Playing)
+        if (component->m_IsPlaying)
+        {
             PlayAnimation(component, component->m_CurrentAnimation, component->m_AnimTimer, component->m_PlaybackRate);
+        }
     }
 
     dmGameObject::PropertyResult CompSpriteGetProperty(const dmGameObject::ComponentGetPropertyParams& params, dmGameObject::PropertyDesc& out_value)
@@ -2260,20 +2382,45 @@ namespace dmGameSystem
             if (res == dmGameObject::PROPERTY_RESULT_OK)
             {
                 TextureSetResource* texture_set = GetFirstTextureSet(component);
-                uint32_t* anim_id = texture_set ? texture_set->m_AnimationIds.Get(component->m_CurrentAnimation) : 0;
+                dmhash_t current_animation = component->m_CurrentAnimation;
+                uint32_t* anim_id = texture_set ? texture_set->m_AnimationIds.Get(current_animation) : 0;
+                if (!anim_id)
+                {
+                    DM_HASH_REVERSE_MEM(hash_ctx, 1024);
+                    // it means that new atlas doesn't contain animation with the same name as it played before
+                    const char* error_message = dmHashReverseSafe64Alloc(&hash_ctx, current_animation);
+                    dmHashTable64<uint32_t>::Iterator animation_iterator = texture_set->m_AnimationIds.GetIterator();
+                    if (animation_iterator.Next())
+                    {
+                        current_animation = animation_iterator.GetKey();
+                        anim_id = const_cast<uint32_t*>(&animation_iterator.GetValue());
+
+                        const char* new_animation_name = dmHashReverseSafe64Alloc(&hash_ctx, current_animation);
+                        dmLogError("Atlas doesn't contains animation '%s'. Animation '%s' will be used", error_message, new_animation_name);
+                    }
+                    else
+                    {
+                        dmLogError("Atlas doesn't contains animation '%s'. No animation will be used", error_message);
+                    }
+                    // else anim_id still == 0
+                }
                 if (anim_id)
                 {
-                    PlayAnimation(component, component->m_CurrentAnimation, GetCursor(component), component->m_PlaybackRate);
+                    PlayAnimation(component, current_animation, GetCursor(component), component->m_PlaybackRate);
                 }
                 else
                 {
-                    component->m_Playing = 0;
+                    component->m_AnimationReHash |= current_animation != 0x0 && component->m_CurrentAnimationFrame != 0;
+                    component->m_AnimationPlayback = dmGameSystemDDF::PLAYBACK_NONE;
+                    component->m_IsPlaying = 0;
                     component->m_CurrentAnimation = 0x0;
                     component->m_CurrentAnimationFrame = 0;
                     dmGameSystemDDF::TextureSet* texture_set_ddf = texture_set->m_TextureSet;
-                    if (texture_set_ddf->m_Animations.m_Count <= component->m_AnimationID) {
+                    if ((uint16_t)texture_set_ddf->m_Animations.m_Count <= component->m_AnimationID)
+                    {
                         component->m_AnimationID = 0;
                     }
+                    component->m_AnimationReHash = 1;
                 }
             }
             return res;

--- a/engine/gamesys/src/gamesys/components/comp_sprite.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sprite.cpp
@@ -1911,13 +1911,13 @@ namespace dmGameSystem
             SpriteComponent* component = &components[i];
             if (!component->m_Enabled || !component->m_AddedToUpdate)
                 continue;
+            Animate(component, params.m_UpdateContext->m_DT);
             UpdateTransform(component, sub_pixels);
             // we need to consider the full scale here
             // I.e. we want the length of the diagonal C, where C = X + Y
             float radius_sq = dmVMath::LengthSqr((component->m_World.getCol(0).getXYZ() + component->m_World.getCol(1).getXYZ()) * 0.5f);
             world->m_BoundingVolumes[i] = radius_sq;
 
-            Animate(component, params.m_UpdateContext->m_DT);
             HComponentRenderConstants constants = GetRenderConstants(component);
             if (component->m_ReHash || (constants && dmGameSystem::AreRenderConstantsUpdated(constants)))
             {

--- a/engine/gamesys/src/gamesys/components/comp_sprite.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sprite.cpp
@@ -1961,7 +1961,14 @@ namespace dmGameSystem
 
             float radius_sq = radiuses[entry->m_UserData];
 
-            bool intersect = dmIntersection::TestFrustumSphereSq(frustum, entry->m_WorldPosition, radius_sq);
+            SpriteComponent* component = &sprite_world->m_Components.Get(entry->m_UserData);
+            const AnimationData* anim_data = GetOrCreateAnimationData(sprite_world, component);
+            float pivot_x = 0.f, pivot_y = 0.f;
+            GetPivot(anim_data, &pivot_x, &pivot_y);
+            Point3 pivot(-pivot_x, -pivot_y, 0.f);
+            Vector3 world_pos = (component->m_World * pivot).getXYZ();
+
+            bool intersect = dmIntersection::TestFrustumSphereSq(frustum, Point3(world_pos), radius_sq);
             entry->m_Visibility = intersect ? dmRender::VISIBILITY_FULL : dmRender::VISIBILITY_NONE;
         }
     }
@@ -2035,12 +2042,8 @@ namespace dmGameSystem
             if (!component.m_Enabled || !component.m_AddedToUpdate)
                 continue;
 
-            const AnimationData* anim_data = GetOrCreateAnimationData(sprite_world, &component);
-            float pivot_x = 0.f, pivot_y = 0.f;
-            GetPivot(anim_data, &pivot_x, &pivot_y);
-            Point3 pivot(-pivot_x, -pivot_y, 0.f);
-            Vector3 world_pos = (component.m_World * pivot).getXYZ();
-            write_ptr->m_WorldPosition = Point3(world_pos);
+            const Vector3 trans = component.m_World.getCol(3).getXYZ();
+            write_ptr->m_WorldPosition = Point3(trans);
             write_ptr->m_UserData = i; // Assuming the object pool stays intact
             write_ptr->m_BatchKey = component.m_MixedHash;
             write_ptr->m_TagListKey = dmRender::GetMaterialTagListKey(GetComponentMaterial(&component));

--- a/engine/gamesys/src/gamesys/components/comp_sprite.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sprite.cpp
@@ -693,7 +693,7 @@ namespace dmGameSystem
         component->m_AnimationPlayback = dmGameSystemDDF::PLAYBACK_NONE;
         component->m_AnimationFrameCount = 1;
 
-        if (component->m_Resource->m_DDF->m_SizeMode == dmGameSystemDDF::SpriteDesc::SIZE_MODE_MANUAL)
+        if (component->m_Resource->m_DDF->m_SizeMode == dmGameSystemDDF::SpriteDesc::SIZE_MODE_MANUAL || component->m_NumTextures == 0)
         {
             component->m_Size[0] = component->m_Resource->m_DDF->m_Size.getX();
             component->m_Size[1] = component->m_Resource->m_DDF->m_Size.getY();
@@ -1518,15 +1518,18 @@ namespace dmGameSystem
                     const float* local_position_channels[] = { (float*) &positions_local };
                     const float* world_position_channels[] = { (float*) &positions_world };
 
+                    const uint8_t uv_channels_count = textures_num != 0 ? textures_num : 1;
+                    const uint8_t pi_channels_count = textures_num != 0 ? textures_num : 1;
+
                     FillWriteVertexAttributeParams(&write_params,
                         sprite_attribute_info_ptr,
                         world_matrix_channel,
                         world_position_channels,
                         local_position_channels,
                         (const float**) scratch_uv_ptrs,
-                        textures_num,
+                        uv_channels_count,
                         (const float**) scratch_pi_ptrs,
-                        textures_num);
+                        pi_channels_count);
 
                     vertices = dmGraphics::WriteAttributes(vertices, 0, 4, write_params);
 
@@ -1803,19 +1806,16 @@ namespace dmGameSystem
         // Get the correct animation frames, and other meta data
         AnimationData* anim_data = GetOrCreateAnimationData(sprite_world, component);
 
-        dmLogWarning("-Update %d %d", textures_num, anim_data->m_CanUseQuads);
         if (textures_num == 0 || anim_data->m_CanUseQuads)
         {
             if (component->m_UseSlice9)
             {
-                dmLogWarning("--slice9");
                 num_vertices   += SPRITE_VERTEX_COUNT_SLICE9;
                 num_indices    += SPRITE_INDEX_COUNT_SLICE9;
                 vertex_memsize += SPRITE_VERTEX_COUNT_SLICE9 * vertex_stride;
             }
             else
             {
-                dmLogWarning("--non-slice9");
                 num_vertices   += SPRITE_VERTEX_COUNT_LEGACY;
                 num_indices    += SPRITE_INDEX_COUNT_LEGACY;
                 vertex_memsize += SPRITE_VERTEX_COUNT_LEGACY * vertex_stride;
@@ -1823,7 +1823,6 @@ namespace dmGameSystem
         }
         else
         {
-            dmLogWarning("--custom geometry %d %d", anim_data->m_VertexCount, anim_data->m_IndicesCount);
             num_vertices += anim_data->m_VertexCount;
             num_indices += anim_data->m_IndicesCount;
             vertex_memsize += anim_data->m_VertexCount * vertex_stride;

--- a/engine/gamesys/src/gamesys/gamesys_private.cpp
+++ b/engine/gamesys/src/gamesys/gamesys_private.cpp
@@ -396,7 +396,7 @@ namespace dmGameSystem
         }
     }
 
-    void FreeMaterialAttribute(DynamicAttributePool& pool, uint32_t dynamic_attribute_index)
+    void FreeMaterialAttribute(DynamicAttributePool& pool, uint16_t dynamic_attribute_index)
     {
         if (dynamic_attribute_index == INVALID_DYNAMIC_ATTRIBUTE_INDEX)
         {
@@ -469,7 +469,7 @@ namespace dmGameSystem
 
     dmGameObject::PropertyResult GetMaterialAttribute(
         DynamicAttributePool&            pool,
-        uint32_t                         dynamic_attribute_index,
+        uint16_t                         dynamic_attribute_index,
         dmRender::HMaterial              material,
         dmhash_t                         name_hash,
         dmGameObject::PropertyDesc&      out_desc,
@@ -522,7 +522,7 @@ namespace dmGameSystem
 
     dmGameObject::PropertyResult SetMaterialAttribute(
         DynamicAttributePool&            pool,
-        uint32_t*                        dynamic_attribute_index,
+        uint16_t*                        dynamic_attribute_index,
         dmRender::HMaterial              material,
         dmhash_t                         name_hash,
         const dmGameObject::PropertyVar& var,
@@ -575,7 +575,7 @@ namespace dmGameSystem
             pool.Set(new_index, new_info);
 
             dynamic_info = &pool.Get(new_index);
-            *dynamic_attribute_index = new_index;
+            *dynamic_attribute_index = (uint16_t)new_index;
             needs_initial_copying = true;
         }
         else

--- a/engine/gamesys/src/gamesys/gamesys_private.h
+++ b/engine/gamesys/src/gamesys/gamesys_private.h
@@ -147,10 +147,10 @@ namespace dmGameSystem
     void                         ConvertMaterialAttributeValuesToDataType(const DynamicAttributeInfo& info, uint32_t dynamic_attribute_index, const dmGraphics::VertexAttribute* attribute, uint8_t* value_ptr);
     void                         InitializeMaterialAttributeInfos(DynamicAttributePool& pool, uint32_t initial_capacity);
     void                         DestroyMaterialAttributeInfos(DynamicAttributePool& pool);
-    void                         FreeMaterialAttribute(DynamicAttributePool& pool, uint32_t dynamic_attribute_index);
+    void                         FreeMaterialAttribute(DynamicAttributePool& pool, uint16_t dynamic_attribute_index);
     dmGameObject::PropertyResult ClearMaterialAttribute(DynamicAttributePool& pool, uint32_t dynamic_attribute_index, dmhash_t name_hash);
-    dmGameObject::PropertyResult SetMaterialAttribute(DynamicAttributePool& pool, uint32_t* dynamic_attribute_index, dmRender::HMaterial material, dmhash_t name_hash, const dmGameObject::PropertyVar& var, CompGetMaterialAttributeCallback callback, void* callback_user_data);
-    dmGameObject::PropertyResult GetMaterialAttribute(DynamicAttributePool& pool, uint32_t dynamic_attribute_index, dmRender::HMaterial material, dmhash_t name_hash, dmGameObject::PropertyDesc& out_desc, CompGetMaterialAttributeCallback callback, void* callback_user_data);
+    dmGameObject::PropertyResult SetMaterialAttribute(DynamicAttributePool& pool, uint16_t* dynamic_attribute_index, dmRender::HMaterial material, dmhash_t name_hash, const dmGameObject::PropertyVar& var, CompGetMaterialAttributeCallback callback, void* callback_user_data);
+    dmGameObject::PropertyResult GetMaterialAttribute(DynamicAttributePool& pool, uint16_t dynamic_attribute_index, dmRender::HMaterial material, dmhash_t name_hash, dmGameObject::PropertyDesc& out_desc, CompGetMaterialAttributeCallback callback, void* callback_user_data);
 
     // gamesys_resource.cpp
     struct CreateTextureResourceParams

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -5135,14 +5135,14 @@ TEST_F(MaterialTest, DynamicVertexAttributes)
 
     // Attribute not found
     {
-        uint32_t index = dmGameSystem::INVALID_DYNAMIC_ATTRIBUTE_INDEX;
+        uint16_t index = dmGameSystem::INVALID_DYNAMIC_ATTRIBUTE_INDEX;
         dmGameObject::PropertyDesc desc = {};
         ASSERT_EQ(dmGameObject::PROPERTY_RESULT_NOT_FOUND, GetMaterialAttribute(dynamic_attribute_pool, index, material, dmHashString64("attribute_does_not_exist"), desc, Test_GetMaterialAttributeCallback, &ctx));
     }
 
     // Attribute(s) found
     {
-        uint32_t index = dmGameSystem::INVALID_DYNAMIC_ATTRIBUTE_INDEX;
+        uint16_t index = dmGameSystem::INVALID_DYNAMIC_ATTRIBUTE_INDEX;
         dmGameObject::PropertyDesc desc = {};
         ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, GetMaterialAttribute(dynamic_attribute_pool, index, material, dmHashString64("position"), desc, Test_GetMaterialAttributeCallback, &ctx));
         ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, GetMaterialAttribute(dynamic_attribute_pool, index, material, dmHashString64("normal"), desc, Test_GetMaterialAttributeCallback, &ctx));
@@ -5183,7 +5183,7 @@ TEST_F(MaterialTest, DynamicVertexAttributes)
 
     // Set a dynamic attribute by vector
     {
-        uint32_t index = dmGameSystem::INVALID_DYNAMIC_ATTRIBUTE_INDEX;
+        uint16_t index = dmGameSystem::INVALID_DYNAMIC_ATTRIBUTE_INDEX;
         dmhash_t attr_name_hash = dmHashString64("position");
 
         dmGameObject::PropertyVar var = {};
@@ -5216,7 +5216,7 @@ TEST_F(MaterialTest, DynamicVertexAttributes)
 
     // Set a dynamic attribute by value(s)
     {
-        uint32_t index = dmGameSystem::INVALID_DYNAMIC_ATTRIBUTE_INDEX;
+        uint16_t index = dmGameSystem::INVALID_DYNAMIC_ATTRIBUTE_INDEX;
         dmhash_t attr_name_hash_x    = dmHashString64("position.x");
         dmhash_t attr_name_hash_y    = dmHashString64("position.y");
         dmhash_t attr_name_hash_full = dmHashString64("position");
@@ -5261,7 +5261,7 @@ TEST_F(MaterialTest, DynamicVertexAttributes)
 
     // Set multiple dynamic attributes (more than original capacity)
     {
-        dmArray<uint32_t> allocated_indices;
+        dmArray<uint16_t> allocated_indices;
         allocated_indices.SetCapacity( dmGameSystem::DYNAMIC_ATTRIBUTE_INCREASE_COUNT * 2 + INITIAL_SIZE + 1); // Should equate to three resizes
 
         dmhash_t attr_name_hash = dmHashString64("position");
@@ -5272,7 +5272,7 @@ TEST_F(MaterialTest, DynamicVertexAttributes)
         {
             var.m_Number = (float) i;
 
-            uint32_t new_index = dmGameSystem::INVALID_DYNAMIC_ATTRIBUTE_INDEX;
+            uint16_t new_index = dmGameSystem::INVALID_DYNAMIC_ATTRIBUTE_INDEX;
             ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, SetMaterialAttribute(dynamic_attribute_pool, &new_index, material, attr_name_hash, var, Test_GetMaterialAttributeCallback, (void*) &ctx));
             ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, GetMaterialAttribute(dynamic_attribute_pool, new_index, material, attr_name_hash, desc, Test_GetMaterialAttributeCallback, (void*) &ctx));
 
@@ -5309,7 +5309,7 @@ TEST_F(MaterialTest, DynamicVertexAttributes)
         dmGameObject::PropertyVar var = {};
         dmGameObject::PropertyDesc desc = {};
 
-        uint32_t new_index = dmGameSystem::INVALID_DYNAMIC_ATTRIBUTE_INDEX;
+        uint16_t new_index = dmGameSystem::INVALID_DYNAMIC_ATTRIBUTE_INDEX;
         ASSERT_EQ(dmGameObject::PROPERTY_RESULT_UNSUPPORTED_VALUE, SetMaterialAttribute(tmp_pool, &new_index, material, attr_name_hash, var, Test_GetMaterialAttributeCallback, (void*) &ctx));
     }
 
@@ -5399,7 +5399,7 @@ TEST_F(MaterialTest, DynamicVertexAttributes)
 
     // Data conversion for dynamic attributes
     {
-        uint32_t index = dmGameSystem::INVALID_DYNAMIC_ATTRIBUTE_INDEX;
+        uint16_t index = dmGameSystem::INVALID_DYNAMIC_ATTRIBUTE_INDEX;
         dmhash_t attr_name_hash = dmHashString64("normal");
 
         dmGameObject::PropertyVar var = {};

--- a/engine/render/src/dmsdk/render/render.h
+++ b/engine/render/src/dmsdk/render/render.h
@@ -235,6 +235,7 @@ namespace dmRender
      * @param m_MajorOrder [type: uint32_t:2] If RENDER_ORDER_WORLD, then sorting is done based on the world position.
                                               Otherwise the sorting uses the m_Order value directly.
      * @param m_Dispatch [type: uint32_t:8] The dispatch function callback (dmRender::HRenderListDispatch)
+     * @param m_Visibility [type: uint32_t:1] Visibility flag. Used for frustrum culling. See enum Visibility
      */
     struct RenderListEntry
     {

--- a/engine/render/src/render/render.cpp
+++ b/engine/render/src/render/render.cpp
@@ -982,12 +982,13 @@ namespace dmRender
             {
                 uint32_t *idx = context->m_RenderListSortBuffer.Begin() + i;
                 const RenderListEntry *last_entry = &base[*last];
-                const RenderListEntry *current_entry = &base[*idx];
-
                 // continue batch on match, or dispatch
-                if (i < count && (last_entry->m_Dispatch == current_entry->m_Dispatch && last_entry->m_BatchKey == current_entry->m_BatchKey && last_entry->m_MinorOrder == current_entry->m_MinorOrder))
-                    continue;
-
+                if (i < count)
+                {
+                    const RenderListEntry *current_entry = &base[*idx];                
+                    if (last_entry->m_Dispatch == current_entry->m_Dispatch && last_entry->m_BatchKey == current_entry->m_BatchKey && last_entry->m_MinorOrder == current_entry->m_MinorOrder)
+                        continue;
+                }
                 if (last_entry->m_Dispatch != RENDERLIST_INVALID_DISPATCH)
                 {
                     assert(last_entry->m_Dispatch < context->m_RenderListDispatch.Size());

--- a/engine/resource/src/resource_chunk_cache.cpp
+++ b/engine/resource/src/resource_chunk_cache.cpp
@@ -16,6 +16,7 @@
 
 #include <dlib/static_assert.h>
 #include <dlib/array.h>
+#include <dlib/double_linked_list.h>
 #include <dlib/hash.h>
 #include <dlib/log.h>
 
@@ -23,21 +24,9 @@
 #include <stddef.h>  // offsetof
 #include <algorithm> // lower_bound
 
-struct DLListNode
-{
-    struct DLListNode* m_Prev;
-    struct DLListNode* m_Next;
-};
-
-struct DLList
-{
-    DLListNode m_Head;
-    DLListNode m_Tail;
-};
-
 struct ResourceInternalDataChunk
 {
-    DLListNode m_ListNode; // must be first in the struct
+    dmDoubleLinkedList::ListNode m_ListNode; // must be first in the struct
 
     dmhash_t m_PathHash;
     uint8_t* m_Data;
@@ -55,49 +44,11 @@ struct ResourceChunkCache
     // The array is sorted on (path_hash, offset)
     dmArray<ResourceInternalDataChunk*> m_Chunks;
 
-    uint32_t m_CacheSize;       // The cache size for all streaming sounds
-    uint32_t m_CacheSizeUsed;   // The amount of cache currently used
-    DLList   m_LRU;             // head is MRU, tail is LRU
-    DLList   m_LRUNoEvict;      // head is MRU, tail is LRU
+    uint32_t                   m_CacheSize;       // The cache size for all streaming sounds
+    uint32_t                   m_CacheSizeUsed;   // The amount of cache currently used
+    dmDoubleLinkedList::List   m_LRU;             // head is MRU, tail is LRU
+    dmDoubleLinkedList::List   m_LRUNoEvict;      // head is MRU, tail is LRU
 };
-
-// **********************************************************************************
-
-static void ListInit(DLList* list)
-{
-    list->m_Head.m_Prev = 0;
-    list->m_Tail.m_Next = 0;
-    list->m_Head.m_Next = &list->m_Tail;
-    list->m_Tail.m_Prev = &list->m_Head;
-}
-
-static void ListRemove(DLList* list, DLListNode* item)
-{
-    DLListNode* prev = item->m_Prev;
-    DLListNode* next = item->m_Next;
-    item->m_Prev = 0;
-    item->m_Next = 0;
-    prev->m_Next = next;
-    next->m_Prev = prev;
-}
-
-static void ListAdd(DLList* list, DLListNode* item)
-{
-    DLListNode* prev = &list->m_Head;
-    DLListNode* next = prev->m_Next;
-    item->m_Prev = prev;
-    item->m_Next = next;
-    prev->m_Next = item;
-    next->m_Prev = item;
-}
-
-static DLListNode* ListGetLast(DLList* list)
-{
-    DLListNode* last = list->m_Tail.m_Prev;
-    return last == &list->m_Head ? 0 : last;
-}
-
-// **********************************************************************************
 
 static ResourceInternalDataChunk* AllocChunk(ResourceChunkCache* cache, dmhash_t path_hash, uint8_t* data, uint32_t data_size, uint32_t offset, int flags)
 {
@@ -152,10 +103,10 @@ static void PrintChunk(ResourceChunkCache* cache, ResourceInternalDataChunk* chu
     printf("  offset: %8u  size: %8u  data: %p  noevict: %s  file: '%s'\n", chunk->m_Offset, chunk->m_Size, chunk->m_Data, chunk->m_NoEvict?"true":"false", dmHashReverseSafe64(chunk->m_PathHash));
 }
 
-static void PrintList(ResourceChunkCache* cache, DLList* list)
+static void PrintList(ResourceChunkCache* cache, dmDoubleLinkedList::List* list)
 {
-    DLListNode* item = list->m_Head.m_Next;
-    DLListNode* end = &list->m_Tail;
+    dmDoubleLinkedList::ListNode* item = list->m_Head.m_Next;
+    dmDoubleLinkedList::ListNode* end = &list->m_Tail;
     while (item != end)
     {
         ResourceInternalDataChunk* chunk = (ResourceInternalDataChunk*)item;
@@ -285,12 +236,12 @@ bool ResourceChunkCacheGet(HResourceChunkCache cache, dmhash_t path_hash, uint32
             out->m_Size = chunk_size;
 
             // Update the LRU by placing the item first in the queue
-            DLList* list = &cache->m_LRU;
+            dmDoubleLinkedList::List* list = &cache->m_LRU;
             if (chunk->m_NoEvict)
                 list = &cache->m_LRUNoEvict;
 
-            ListRemove(list, (DLListNode*)chunk);
-            ListAdd(list, (DLListNode*)chunk);
+            ListRemove(list, (dmDoubleLinkedList::ListNode*)chunk);
+            ListAdd(list, (dmDoubleLinkedList::ListNode*)chunk);
             return true;
         }
     }
@@ -322,10 +273,10 @@ bool ResourceChunkCachePut(HResourceChunkCache cache, uint64_t path_hash, int fl
     cache->m_Chunks.Push(chunk);
     SortChunksOnPathAndOffset(cache);
 
-    DLList* list = &cache->m_LRU;
+    dmDoubleLinkedList::List* list = &cache->m_LRU;
     if (flags & RESOURCE_CHUNK_CACHE_NO_EVICT)
         list = &cache->m_LRUNoEvict;
-    ListAdd(list, (DLListNode*)chunk); // add it first in the LRU
+    ListAdd(list, (dmDoubleLinkedList::ListNode*)chunk); // add it first in the LRU
     return true;
 }
 
@@ -360,10 +311,10 @@ static void RemoveChunks(HResourceChunkCache cache, uint32_t index, uint32_t cou
 
 bool ResourceChunkCacheEvictMemory(HResourceChunkCache cache, uint32_t size)
 {
-    DLList* list = &cache->m_LRU;
+    dmDoubleLinkedList::List* list = &cache->m_LRU;
     while (!ResourceChunkCacheCanFit(cache, size))
     {
-        DLListNode* last = ListGetLast(list);
+        dmDoubleLinkedList::ListNode* last = ListGetLast(list);
         if (!last)
             break;
 
@@ -399,11 +350,11 @@ void ResourceChunkCacheEvictPathHash(HResourceChunkCache cache, uint64_t path_ha
 
         ++count;
 
-        DLList* list = &cache->m_LRU;
+        dmDoubleLinkedList::List* list = &cache->m_LRU;
         if (chunk->m_NoEvict)
             list = &cache->m_LRUNoEvict;
 
-        ListRemove(list, (DLListNode*)chunk);
+        ListRemove(list, (dmDoubleLinkedList::ListNode*)chunk);
         FreeChunk(cache, chunk);
     }
 


### PR DESCRIPTION
Fixed culling for sprites with pivot points. Also implemented some optimization on how geometry data calculated and stored between batches. So no it should be a bit faster in terms of calculation but consume some memory to store cached information.

Fixes #9917 

### Technical notes
Implementation the same as it was https://github.com/defold/defold/pull/9943
+ fix from https://github.com/defold/defold/pull/11283
+ fix for untextured sprites
+ fix of render sorting problem for sprites with pivot point #11313
+ fix of crash #11320


**Notes for reviewer:**
I've commented all places which were presented in reverted PRs.

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
