### PR TITLE
Resolve `modernize-use-override`

### DIFF
--- a/engine/gamesys/src/gamesys/test/test_gamesys.h
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.h
@@ -265,31 +265,31 @@ struct ResourceFailParams
 class ResourceFailTest : public GamesysTest<ResourceFailParams>
 {
 public:
-    virtual ~ResourceFailTest() {}
+    ~ResourceFailTest() override = default;
 };
 
 class InvalidVertexSpaceTest : public GamesysTest<const char*>
 {
 public:
-    virtual ~InvalidVertexSpaceTest() {}
+    ~InvalidVertexSpaceTest() override = default;
 };
 
 class ComponentTest : public ScriptBaseTest
 {
 public:
-    virtual ~ComponentTest() {}
+    ~ComponentTest() override = default;
 };
 
 class ComponentFailTest : public GamesysTest<const char*>
 {
 public:
-    virtual ~ComponentFailTest() {}
+    ~ComponentFailTest() override = default;
 };
 
 class BufferMetadataTest : public GamesysTest<const char*>
 {
 public:
-    virtual ~BufferMetadataTest() {}
+    ~BufferMetadataTest() override = default;
 };
 
 struct FactoryTestParams
@@ -302,7 +302,7 @@ struct FactoryTestParams
 class FactoryTest : public GamesysTest<FactoryTestParams>
 {
 public:
-    virtual ~FactoryTest() {}
+    ~FactoryTest() override = default;
 };
 
 struct CollectionFactoryTestParams
@@ -316,26 +316,26 @@ struct CollectionFactoryTestParams
 class CollectionFactoryTest : public GamesysTest<CollectionFactoryTestParams>
 {
 public:
-    virtual ~CollectionFactoryTest() {}
+    ~CollectionFactoryTest() override = default;
 };
 
 class SpriteTest : public ScriptBaseTest
 {
 public:
-    virtual ~SpriteTest() {}
+    ~SpriteTest() override = default;
 };
 
 class ParticleFxTest : public GamesysTest<const char*>
 {
 public:
-    virtual ~ParticleFxTest() {}
+    ~ParticleFxTest() override = default;
 };
 
 
 class WindowTest : public GamesysTest<const char*>
 {
 public:
-    virtual ~WindowTest() {}
+    ~WindowTest() override = default;
 };
 
 struct DrawCountParams
@@ -347,7 +347,7 @@ struct DrawCountParams
 class DrawCountTest : public GamesysTest<DrawCountParams>
 {
 public:
-    virtual ~DrawCountTest() {}
+    ~DrawCountTest() override = default;
 };
 
 struct BoxRenderParams
@@ -364,13 +364,13 @@ struct BoxRenderParams
 class BoxRenderTest : public GamesysTest<BoxRenderParams>
 {
 public:
-    virtual ~BoxRenderTest() {}
+    ~BoxRenderTest() override = default;
 };
 
 class GamepadConnectedTest : public GamesysTest<const char*>
 {
 public:
-    virtual ~GamepadConnectedTest() {}
+    ~GamepadConnectedTest() override = default;
 };
 
 struct ResourcePropParams {
@@ -394,13 +394,13 @@ protected:
         GamesysTest::SetUp();
     }
 public:
-    virtual ~ResourcePropTest() {}
+    ~ResourcePropTest() override = default;
 };
 
 class FlipbookTest : public GamesysTest<const char*>
 {
 public:
-    virtual ~FlipbookTest() {}
+    ~FlipbookTest() override = default;
 };
 
 struct CursorTestParams
@@ -415,19 +415,19 @@ struct CursorTestParams
 class CursorTest : public GamesysTest<CursorTestParams>
 {
 public:
-    virtual ~CursorTest() {}
+    ~CursorTest() override = default;
 };
 
 class FontTest : public GamesysTest<const char*>
 {
 public:
-    virtual ~FontTest() {}
+    ~FontTest() override = default;
 };
 
 class GuiTest : public ScriptBaseTest
 {
 public:
-    virtual ~GuiTest() {}
+    ~GuiTest() override = default;
 };
 
 struct ScriptComponentTestParams
@@ -440,13 +440,13 @@ struct ScriptComponentTestParams
 class ScriptComponentTest : public GamesysTest<ScriptComponentTestParams>
 {
 public:
-    virtual ~ScriptComponentTest() {}
+    ~ScriptComponentTest() override = default;
 };
 
 class SoundTest : public GamesysTest<const char*>
 {
 public:
-    virtual ~SoundTest() {}
+    ~SoundTest() override = default;
 };
 
 class RenderConstantsTest : public GamesysTest<const char*>
@@ -458,25 +458,25 @@ public:
 class MaterialTest : public ScriptBaseTest
 {
 public:
-    virtual ~MaterialTest() {}
+    ~MaterialTest() override = default;
 };
 
 class ModelTest : public ScriptBaseTest
 {
 public:
-    virtual ~ModelTest() {}
+    ~ModelTest() override = default;
 };
 
 class ShaderTest : public GamesysTest<const char*>
 {
 public:
-    virtual ~ShaderTest() {}
+    ~ShaderTest() override = default;
 };
 
 class SysTest : public ScriptBaseTest
 {
 public:
-    virtual ~SysTest() {}
+    ~SysTest() override = default;
 };
 
 bool CopyResource(const char* src, const char* dst);

--- a/engine/sound/src/decoders/decoder_wav.cpp
+++ b/engine/sound/src/decoders/decoder_wav.cpp
@@ -122,7 +122,7 @@ namespace dmSoundCodec
         };
 
         struct DecodeStreamInfoADPCM : public DecodeStreamInfo {
-            virtual ~DecodeStreamInfoADPCM() {}
+            ~DecodeStreamInfoADPCM() override = default;
 
             dmArray<int16_t> m_OutBuffer;
             dmArray<int8_t> m_InBuffer;


### PR DESCRIPTION
Resolves all of the `modernize-use-override` warnings in the defold code and `modernize-use-equals-default` for the modified destructors.

This PR consists of two parts:
- marks `virtual` destustors as `override`,
- makes these destructors (with empty body) `default` - it makes these types _trivially destructable_ and it allows for more compiler optimizations.

All of the modified files contain `Copyright 2020-2025 The Defold Foundation` as a substring.

Since there are no more warnings `modernize-use-override` in defold code, it fixes #11282.