### PR TITLE
Remove empty property from the `game.projectc`

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
@@ -637,6 +637,7 @@ public class Project {
         try {
             // load meta.properties embeded in bob.jar
             properties.loadDefaultMetaFile();
+            properties.cleanupEmptyProperties();
             if (scanExtensions) {
                 // load property files from extensions
                 List<String> extensionFolders = ExtenderUtil.getExtensionFolders(project);

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/BobProjectProperties.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/BobProjectProperties.java
@@ -36,7 +36,6 @@ import java.lang.IllegalAccessException;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.io.IOUtils;
 
-import com.dynamo.bob.util.StringUtil;
 import com.dynamo.bob.Bob;
 
 /**
@@ -273,6 +272,10 @@ public class BobProjectProperties {
      */
     public void load(InputStream in) throws IOException, ParseException {
         load(in, false);
+    }
+
+    public void cleanupEmptyProperties() {
+        properties.remove("");
     }
 
     /**


### PR DESCRIPTION
In `meta.properties` we have :
```
[]
group-order = Main,Platforms,Components,Runtime,Distribution
default-category = project
```

It's needed for the editor. But it's not needed it in the output file. This PR removes it from the output file.

Fix https://github.com/defold/defold/issues/11364