### PR TITLE
Added dmResource::GetWithExt() to dmsdk for more robust resource loading

### DIFF
--- a/engine/resource/src/dmsdk/resource/resource.h
+++ b/engine/resource/src/dmsdk/resource/resource.h
@@ -179,24 +179,52 @@ void ResourceRegisterDecryptionFunction(FResourceDecryption decrypt_resource);
 
 
 /*#
- * Get a resource from factory
+ * Get (load) a resource from factory
+ * @note if succesful, it increments the ref count by one
  * @name ResourceGet
  * @param factory [type: HResourceFactory] Factory handle
- * @param name [type: const char*] Resource name
+ * @param path [type: const char*] Resource path
  * @param resource [type: void**] Created resource
  * @return result [type: ResourceResult] RESOURCE_RESULT_OK on success
  */
-ResourceResult ResourceGet(HResourceFactory factory, const char* name, void** resource);
+ResourceResult ResourceGet(HResourceFactory factory, const char* path, void** resource);
 
 /*#
- * Get a resource from factory
+ * Get (load) a resource from factory
+ * @note if succesful, it increments the ref count by one
+ * @name ResourceGetWithExt
+ * @param factory [type: HResourceFactory] Factory handle
+ * @param path [type: const char*] Resource path
+ * @param ext [type: const char*] Resource extension (e.g. "texturec", "ttf"). Must match the extension of the path.
+ * @param resource [type: void**] Created resource
+ * @return result [type: ResourceResult] RESOURCE_RESULT_OK on success.
+ *                                       RESOURCE_RESULT_INVALID_FILE_EXTENSION if the path extension doesn't match the required extension.
+ */
+ResourceResult ResourceGetWithExt(HResourceFactory factory, const char* path, const char* ext, void** resource);
+
+/*#
+ * Get a loaded resource from factory
+ * @note this currently doesn't load a resource
+ * @note if succesful, it increments the ref count by one
  * @name ResourceGetByHash
  * @param factory [type: HResourceFactory] Factory handle
- * @param name [type: dmhash_t] Resource name
+ * @param path_hash [type: dmhash_t] Resource path hash
  * @param resource [type: void**] Created resource
  * @return result [type: ResourceResult] RESOURCE_RESULT_OK on success
  */
-ResourceResult ResourceGetByHash(HResourceFactory factory, dmhash_t name, void** resource);
+ResourceResult ResourceGetByHash(HResourceFactory factory, dmhash_t path_hash, void** resource);
+
+/*#
+ * Get a loaded resource from factory and also verifying that it's the expected file type
+ * @name ResourceGetByHashAndExt
+ * @param factory [type: HResourceFactory] Factory handle
+ * @param path_hash [type: dmhash_t] Resource path hash
+ * @param ext_hash [type: dmhash_t] Resource extension hash (e.g. "texturec", "ttf"). Must match the extension of the path.
+ * @param resource [type: void**] Created resource
+ * @return result [type: ResourceResult] RESOURCE_RESULT_OK on success.
+ *                                       RESOURCE_RESULT_INVALID_FILE_EXTENSION if the path extension doesn't match the required extension.
+ */
+ResourceResult ResourceGetByHashAndExt(HResourceFactory factory, dmhash_t path_hash, dmhash_t ext_hash, void** resource);
 
 /**
  * Increase resource reference count by 1.
@@ -516,7 +544,7 @@ const char* ResourceTypeGetName(HResourceType type);
 /*# get registered extension name hash of the type
  * @name ResourceTypeGetNameHash
  * @param type [type: HResourceType] The type
- * @return hash [type: dmhash_t] The name hash
+ * @return hash [type: dmhash_t] The name hash of the type (e.g. "collectionc")
  */
 dmhash_t ResourceTypeGetNameHash(HResourceType type);
 

--- a/engine/resource/src/dmsdk/resource/resource.h
+++ b/engine/resource/src/dmsdk/resource/resource.h
@@ -180,7 +180,7 @@ void ResourceRegisterDecryptionFunction(FResourceDecryption decrypt_resource);
 
 /*#
  * Get (load) a resource from factory
- * @note if succesful, it increments the ref count by one
+ * @note if successful, it increments the ref count by one
  * @name ResourceGet
  * @param factory [type: HResourceFactory] Factory handle
  * @param path [type: const char*] Resource path
@@ -191,7 +191,7 @@ ResourceResult ResourceGet(HResourceFactory factory, const char* path, void** re
 
 /*#
  * Get (load) a resource from factory
- * @note if succesful, it increments the ref count by one
+ * @note if successful, it increments the ref count by one
  * @name ResourceGetWithExt
  * @param factory [type: HResourceFactory] Factory handle
  * @param path [type: const char*] Resource path
@@ -205,7 +205,7 @@ ResourceResult ResourceGetWithExt(HResourceFactory factory, const char* path, co
 /*#
  * Get a loaded resource from factory
  * @note this currently doesn't load a resource
- * @note if succesful, it increments the ref count by one
+ * @note if successful, it increments the ref count by one
  * @name ResourceGetByHash
  * @param factory [type: HResourceFactory] Factory handle
  * @param path_hash [type: dmhash_t] Resource path hash

--- a/engine/resource/src/dmsdk/resource/resource.hpp
+++ b/engine/resource/src/dmsdk/resource/resource.hpp
@@ -49,21 +49,45 @@ namespace dmResource
     * Get a resource from factory
     * @name Get
     * @param factory [type: dmResource::HFactory] Factory handle
-    * @param name [type: const char*] Resource name
+    * @param path [type: const char*] Resource path
     * @param resource [type: void**] (out) Created resource
     * @return result [type: dmResource::Result]  RESULT_OK on success
     */
-   Result Get(HFactory factory, const char* name, void** resource);
+   Result Get(HFactory factory, const char* path, void** resource);
 
    /*#
-    * Get a resource from factory
+    * Get (load) a resource from factory
+    * @name GetWithExt
+    * @param factory [type: dmResource::HFactory] Factory handle
+    * @param path [type: const char*] Resource path
+    * @param ext [type: const char*] Resource extension. Must match the extension of the path
+    * @param resource [type: void**] (out) Created resource
+    * @return result [type: dmResource::Result]  RESULT_OK on success.
+    *                                            RESULT_INVALID_FILE_EXTENSION if the path extension doesn't match the required extension.
+    */
+   Result GetWithExt(HFactory factory, const char* path, const char* ext, void** resource);
+
+   /*#
+    * Get a loaded resource from factory
     * @name Get
     * @param factory [type: dmResource::HFactory] Factory handle
-    * @param name [type: dmhash_t] Resource name
+    * @param path_hash [type: const char*] Resource path hash
     * @param resource [type: void**] (out) Created resource
     * @return result [type: dmResource::Result]  RESULT_OK on success
     */
-   Result Get(HFactory factory, dmhash_t name, void** resource);
+   Result Get(HFactory factory, dmhash_t path_hash, void** resource);
+
+   /*#
+    * Get a loaded resource from factory
+    * @name GetWithExt
+    * @param factory [type: dmResource::HFactory] Factory handle
+    * @param path_hash [type: const char*] Resource path hash
+    * @param ext_hash [type: const char*] Resource extension hash. Must match the extension of the path.
+    * @param resource [type: void**] (out) Created resource
+    * @return result [type: dmResource::Result]  RESULT_OK on success.
+    *                                            RESULT_INVALID_FILE_EXTENSION if the path extension doesn't match the required extension.
+    */
+   Result GetWithExt(HFactory factory, dmhash_t path_hash, dmhash_t ext_hash, void** resource);
 
     /*#
     * Creates and inserts a resource into the factory

--- a/engine/resource/src/resource.cpp
+++ b/engine/resource/src/resource.cpp
@@ -915,15 +915,15 @@ static Result CheckAndGetResourceAndType(HFactory factory, const char* canonical
 }
 
 // Assumes m_LoadMutex is already held
-static Result CreateAndLoadResource(HFactory factory, const char* name, void** resource)
+static Result CreateAndLoadResource(HFactory factory, const char* path, void** resource)
 {
-    assert(name);
+    assert(path);
     assert(resource);
 
     DM_PROFILE(__FUNCTION__);
 
     char canonical_path[RESOURCE_PATH_MAX];
-    GetCanonicalPath(name, canonical_path, sizeof(canonical_path));
+    GetCanonicalPath(path, canonical_path, sizeof(canonical_path));
     dmhash_t canonical_path_hash = dmHashBuffer64(canonical_path, strlen(canonical_path));
 
     ResourceType* resource_type;
@@ -947,14 +947,14 @@ static Result CreateAndLoadResource(HFactory factory, const char* name, void** r
     void* buffer         = 0;
     uint32_t buffer_size = 0;
     uint32_t resource_size = 0;
-    Result result = LoadResource(factory, canonical_path, name, preload_size, &buffer, &buffer_size, &resource_size);
+    Result result = LoadResource(factory, canonical_path, path, preload_size, &buffer, &buffer_size, &resource_size);
     if (result != RESULT_OK)
     {
         return result;
     }
     assert(buffer == factory->m_Buffer.Begin());
 
-    return DoCreateResource(factory, resource_type, name, canonical_path, canonical_path_hash,
+    return DoCreateResource(factory, resource_type, path, canonical_path, canonical_path_hash,
                                 buffer, buffer_size, resource_size, resource);
 }
 
@@ -996,15 +996,24 @@ Result CreateResource(HFactory factory, const char* name, void* data, uint32_t d
     return CreateResourcePartial(factory, 0, name, data, data_size, data_size, resource);
 }
 
-Result Get(HFactory factory, const char* name, void** resource)
+Result GetWithExt(HFactory factory, const char* path, const char* ext, void** resource)
 {
-    assert(name);
+    assert(path);
     assert(resource);
     *resource = 0;
 
-    Result chk = CheckSuppliedResourcePath(name);
+    Result chk = CheckSuppliedResourcePath(path);
     if (chk != RESULT_OK)
         return chk;
+
+    if (ext != 0)
+    {
+        const char* path_ext = GetExtFromPath(path);
+        if (strcmp(path_ext, ext) != 0)
+        {
+            return RESULT_INVALID_FILE_EXTENSION;
+        }
+    }
 
     dmMutex::ScopedLock lk(factory->m_LoadMutex);
 
@@ -1019,7 +1028,7 @@ Result Get(HFactory factory, const char* name, void** resource)
     uint32_t n = stack.Size();
     for (uint32_t i=0;i<n;i++)
     {
-        if (strcmp(stack[i], name) == 0)
+        if (strcmp(stack[i], path) == 0)
         {
             dmLogError("Self referring resource detected");
             dmLogError("Reference chain:");
@@ -1027,7 +1036,7 @@ Result Get(HFactory factory, const char* name, void** resource)
             {
                 dmLogError("%d: %s", j, stack[j]);
             }
-            dmLogError("%d: %s", n, name);
+            dmLogError("%d: %s", n, path);
             --factory->m_RecursionDepth;
             return RESULT_RESOURCE_LOOP_ERROR;
         }
@@ -1037,11 +1046,16 @@ Result Get(HFactory factory, const char* name, void** resource)
     {
         stack.SetCapacity(stack.Capacity() + 16);
     }
-    stack.Push(name);
-    Result r = CreateAndLoadResource(factory, name, resource);
+    stack.Push(path);
+    Result r = CreateAndLoadResource(factory, path, resource);
     stack.SetSize(stack.Size() - 1);
     --factory->m_RecursionDepth;
     return r;
+}
+
+Result Get(HFactory factory, const char* path, void** resource)
+{
+    return GetWithExt(factory, path, 0, resource);
 }
 
 ResourceDescriptor* FindByHash(HFactory factory, uint64_t canonical_path_hash)
@@ -1049,16 +1063,25 @@ ResourceDescriptor* FindByHash(HFactory factory, uint64_t canonical_path_hash)
     return factory->m_Resources->Get(canonical_path_hash);
 }
 
-Result Get(HFactory factory, dmhash_t name, void** resource)
+Result GetWithExt(HFactory factory, dmhash_t path_hash, dmhash_t ext_hash, void** resource)
 {
-    ResourceDescriptor* rd = FindByHash(factory, name);
+    ResourceDescriptor* rd = FindByHash(factory, path_hash);
     if (!rd)
     {
         return RESULT_RESOURCE_NOT_FOUND;
     }
+    if (ext_hash && rd->m_ResourceType->m_ExtensionHash != ext_hash)
+    {
+        return RESULT_INVALID_FILE_EXTENSION;
+    }
     dmResource::IncRef(factory, rd->m_Resource);
     *resource = rd->m_Resource;
     return RESULT_OK;
+}
+
+Result Get(HFactory factory, dmhash_t path_hash, void** resource)
+{
+    return GetWithExt(factory, path_hash, 0, resource);
 }
 
 Result InsertResource(HFactory factory, const char* path, uint64_t canonical_path_hash, ResourceDescriptor* descriptor)
@@ -1698,14 +1721,24 @@ void ResourceRegisterDecryptionFunction(FResourceDecryption decrypt_resource)
    dmResource::RegisterResourceDecryptionFunction((dmResource::FDecryptResource)decrypt_resource);
 }
 
-ResourceResult ResourceGet(HResourceFactory factory, const char* name, void** resource)
+ResourceResult ResourceGet(HResourceFactory factory, const char* path, void** resource)
 {
-    return (ResourceResult)dmResource::Get(factory, name, resource);
+    return (ResourceResult)dmResource::Get(factory, path, resource);
 }
 
-ResourceResult ResourceGetByHash(HResourceFactory factory, dmhash_t name, void** resource)
+ResourceResult ResourceGetWithExt(HResourceFactory factory, const char* path, const char* ext, void** resource)
 {
-    return (ResourceResult)dmResource::Get(factory, name, resource);
+    return (ResourceResult)dmResource::GetWithExt(factory, path, ext, resource);
+}
+
+ResourceResult ResourceGetByHash(HResourceFactory factory, dmhash_t path_hash, void** resource)
+{
+    return (ResourceResult)dmResource::Get(factory, path_hash, resource);
+}
+
+ResourceResult ResourceGetByHashAndExt(HResourceFactory factory, dmhash_t path_hash, dmhash_t ext_hash, void** resource)
+{
+    return (ResourceResult)dmResource::GetWithExt(factory, path_hash, ext_hash, resource);
 }
 
 ResourceResult ResourceGetRaw(HResourceFactory factory, const char* name, void** resource, uint32_t* resource_size)

--- a/engine/resource/src/test/test_resource.cpp
+++ b/engine/resource/src/test/test_resource.cpp
@@ -565,6 +565,33 @@ TEST_P(GetResourceTest, GetDescriptorWithExt)
     ASSERT_EQ(dmResource::RESULT_NOT_LOADED, e);
 }
 
+TEST_P(GetResourceTest, GetWithExt)
+{
+    void* resource = 0;
+    dmResource::Result e = dmResource::GetWithExt(m_Factory, m_ResourceName, "cont", &resource);
+    ASSERT_EQ(dmResource::RESULT_OK, e);
+    ASSERT_NE((void*)0, resource);
+
+    void* sentinel = (void*)0xdeadbeef;
+    e = dmResource::GetWithExt(m_Factory, m_ResourceName, "foo", &sentinel);
+    ASSERT_EQ(dmResource::RESULT_INVALID_FILE_EXTENSION, e);
+    ASSERT_EQ((void*)0, sentinel);
+
+    void* hashed_resource = 0;
+    dmhash_t name_hash = dmHashString64(m_ResourceName);
+    e = dmResource::GetWithExt(m_Factory, name_hash, CONT_EXT_HASH, &hashed_resource);
+    ASSERT_EQ(dmResource::RESULT_OK, e);
+    ASSERT_NE((void*)0, hashed_resource);
+
+    void* hashed_sentinel = (void*)0xdeadbeef;
+    e = dmResource::GetWithExt(m_Factory, name_hash, FOO_EXT_HASH, &hashed_sentinel);
+    ASSERT_EQ(dmResource::RESULT_INVALID_FILE_EXTENSION, e);
+    ASSERT_EQ((void*)0xdeadbeef, hashed_sentinel);
+
+    dmResource::Release(m_Factory, hashed_resource);
+    dmResource::Release(m_Factory, resource);
+}
+
 const char* params_resource_paths[] = {
     "build/src/test",
 #if defined(DM_TEST_HTTP_SUPPORTED)


### PR DESCRIPTION
This allows the developer to pass in an expected extension, in order to make sure that the resources path passed in is the correct type. This is especially helpful if the code is data driven and the developer doesn't know the resource path beforehand.

[Documentation](https://defold.com/ref/beta/engine-resource-src-dmsdk-resource-resource-hpp/#GetWithExt:factory-path_hash-ext_hash-resource)

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
