### PR TITLE
Resolve `modernize-use-equals-default`

### DIFF
--- a/engine/dlib/src/dlib/configfile.cpp
+++ b/engine/dlib/src/dlib/configfile.cpp
@@ -501,9 +501,7 @@ namespace dmConfigFile
 
     struct HttpContext
     {
-        HttpContext()
-        {
-        }
+        HttpContext() = default;
         dmArray<char> m_Buffer;
     };
 

--- a/engine/dlib/src/dlib/log.cpp
+++ b/engine/dlib/src/dlib/log.cpp
@@ -50,12 +50,9 @@ const int MAX_LOG_FILE_SIZE = 1024 * 1024 * 32;
 
 struct dmLogConnection
 {
-    dmLogConnection()
-    {
-        m_Socket = dmSocket::INVALID_SOCKET_HANDLE;
-    }
+    dmLogConnection() = default;
 
-    dmSocket::Socket m_Socket;
+    dmSocket::Socket m_Socket = dmSocket::INVALID_SOCKET_HANDLE;
 };
 
 static const uint32_t DLIB_MAX_LOG_CONNECTIONS = 16;

--- a/engine/dlib/src/dlib/log.h
+++ b/engine/dlib/src/dlib/log.h
@@ -54,9 +54,7 @@ struct LogMessage
 const uint32_t MAX_STRING_SIZE = dmMessage::DM_MESSAGE_MAX_DATA_SIZE - sizeof(LogMessage);
 struct LogParams
 {
-    LogParams()
-    {
-    }
+    LogParams() = default;
 };
 
 /**

--- a/engine/engine/src/test/test_engine.h
+++ b/engine/engine/src/test/test_engine.h
@@ -73,5 +73,5 @@ struct DrawCountParams
 class DrawCountTest : public EngineParamsTest<DrawCountParams>
 {
 public:
-    virtual ~DrawCountTest() {}
+    virtual ~DrawCountTest() = default;
 };

--- a/engine/gameobject/src/gameobject/gameobject_private.h
+++ b/engine/gameobject/src/gameobject/gameobject_private.h
@@ -116,9 +116,7 @@ namespace dmGameObject
             m_ToBeAdded = 0;
         }
 
-        ~Instance()
-        {
-        }
+        ~Instance() = default;
 
         dmTransform::Transform m_Transform;
 

--- a/engine/gamesys/src/gamesys/components/comp_gui_private.h
+++ b/engine/gamesys/src/gamesys/components/comp_gui_private.h
@@ -48,7 +48,7 @@ namespace dmGameSystem
 
     struct BoxVertex
     {
-        inline BoxVertex() {}
+        inline BoxVertex() = default;
         inline BoxVertex(const dmVMath::Vector4& p, float u, float v, const dmVMath::Vector4& color, uint32_t page_index)
         {
             SetPosition(p);
@@ -116,7 +116,7 @@ namespace dmGameSystem
 
     struct CompGuiNodeType
     {
-        CompGuiNodeType() {}
+        CompGuiNodeType() = default;
 
         CompGuiNodeTypeDescriptor*  m_TypeDesc;
         void*                       m_Context;

--- a/engine/gamesys/src/gamesys/components/comp_sprite.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sprite.cpp
@@ -60,10 +60,10 @@ namespace dmGameSystem
     // In general, rare overrides should be kept out of the struct, to keep memory down
     struct SpriteResourceOverrides
     {
-        MaterialResource*       m_Material;
+        MaterialResource*       m_Material {0};
         dmArray<SpriteTexture>  m_Textures; // sampler name to texture set
 
-        SpriteResourceOverrides() : m_Material(0) {}
+        SpriteResourceOverrides() = default;
     };
 
     const uint32_t MAX_TEXTURE_COUNT = dmRender::RenderObject::MAX_TEXTURE_COUNT;

--- a/engine/gamesys/src/gamesys/test/test_gamesys.h
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.h
@@ -175,7 +175,7 @@ public:
         GamesysTest::TearDown();
     }
 
-    virtual ~ScriptBaseTest() { }
+    virtual ~ScriptBaseTest() = default;
 
     dmGameSystem::ScriptLibContext m_Scriptlibcontext;
 };
@@ -240,7 +240,7 @@ public:
 class ResourceTest : public GamesysTest<const char*>
 {
 public:
-    virtual ~ResourceTest() {}
+    virtual ~ResourceTest() = default;
 };
 
 struct ResourceReloadParams
@@ -253,7 +253,7 @@ struct ResourceReloadParams
 class ResourceReloadTest : public GamesysTest<ResourceReloadParams>
 {
 public:
-    virtual ~ResourceReloadTest() {}
+    virtual ~ResourceReloadTest() = default;
 };
 
 struct ResourceFailParams
@@ -452,7 +452,7 @@ public:
 class RenderConstantsTest : public GamesysTest<const char*>
 {
 public:
-    virtual ~RenderConstantsTest() {}
+    virtual ~RenderConstantsTest() = default;
 };
 
 class MaterialTest : public ScriptBaseTest

--- a/engine/graphics/src/vulkan/graphics_vulkan_private.h
+++ b/engine/graphics/src/vulkan/graphics_vulkan_private.h
@@ -46,7 +46,7 @@ namespace dmGraphics
 
     struct DeviceBuffer
     {
-        DeviceBuffer(){}
+        DeviceBuffer() = default;
         DeviceBuffer(const VkBufferUsageFlags usage)
         : m_MappedDataPtr(0)
         , m_Usage(usage)

--- a/engine/gui/src/gui_null.cpp
+++ b/engine/gui/src/gui_null.cpp
@@ -47,9 +47,7 @@ namespace dmGui
     const dmhash_t DEFAULT_LAYOUT = DEFAULT_LAYER;
     const uint16_t INVALID_INDEX = 0xffff;
 
-    InputAction::InputAction()
-    {
-    }
+    InputAction::InputAction() = default;
 
     HContext NewContext(const NewContextParams* params)
     {

--- a/engine/jni/src/test/testapi.h
+++ b/engine/jni/src/test/testapi.h
@@ -44,7 +44,7 @@ namespace dmJniTest
     {
         int x, y;
 
-        Vec2i() {}
+        Vec2i() = default;
         Vec2i(int _x, int _y) : x(_x), y(_y) {}
     };
 

--- a/engine/modelc/src/modelimporter.cpp
+++ b/engine/modelc/src/modelimporter.cpp
@@ -53,9 +53,7 @@ struct ModelImporterInitializer
 namespace dmModelImporter
 {
 
-Options::Options()
-{
-}
+Options::Options() = default;
 
 static void DestroyMesh(Mesh* mesh)
 {

--- a/engine/particle/src/particle.h
+++ b/engine/particle/src/particle.h
@@ -190,14 +190,11 @@ namespace dmParticle
      */
     struct Stats
     {
-        Stats()
-        {
-            m_StructSize = sizeof(*this);
-        }
+        Stats() = default;
 
         uint32_t m_Particles;
         uint32_t m_MaxParticles;
-        uint32_t m_StructSize;
+        uint32_t m_StructSize = sizeof(*this);
     };
 
     /**
@@ -205,13 +202,10 @@ namespace dmParticle
      */
     struct InstanceStats
     {
-        InstanceStats()
-        {
-            m_StructSize = sizeof(*this);
-        }
+        InstanceStats() = default;
 
         float m_Time;
-        uint32_t m_StructSize;
+        uint32_t m_StructSize = sizeof(*this);
     };
 
     // For tests

--- a/engine/particle/src/particle_private.h
+++ b/engine/particle/src/particle_private.h
@@ -198,10 +198,7 @@ namespace dmParticle
             m_InstanceIndexPool.SetCapacity(max_instance_count);
         }
 
-        ~Context()
-        {
-
-        }
+        ~Context() = default;
 
         /// Instance buffer.
         dmArray<Instance*>  m_Instances;
@@ -274,16 +271,12 @@ namespace dmParticle
      */
     struct Prototype
     {
-        Prototype()
-        : m_Emitters()
-        , m_DDF(0x0)
-        {
-        }
+        Prototype() = default;
 
         /// Emitter prototypes
-        dmArray<EmitterPrototype>   m_Emitters;
+        dmArray<EmitterPrototype>   m_Emitters {};
         /// DDF structure read from the resource.
-        dmParticleDDF::ParticleFX*  m_DDF;
+        dmParticleDDF::ParticleFX*  m_DDF {0x0};
     };
 
     void UpdateRenderData(HParticleContext context, HInstance instance, uint32_t emitter_index);

--- a/engine/physics/src/physics/box2d_defold/box2d_defold_physics.cpp
+++ b/engine/physics/src/physics/box2d_defold/box2d_defold_physics.cpp
@@ -74,7 +74,7 @@ namespace dmPhysics
             , m_CollisionMask((uint16_t)~0u)
             , m_ReturnAllResults(0) {}
 
-        virtual ~ProcessRayCastResultCallback2D() {}
+        virtual ~ProcessRayCastResultCallback2D() = default;
 
         /// Called for each fixture found in the query. You control how the ray cast
         /// proceeds by returning a float:

--- a/engine/physics/src/physics/debug_draw_3d.cpp
+++ b/engine/physics/src/physics/debug_draw_3d.cpp
@@ -26,10 +26,7 @@ namespace dmPhysics
     {
     }
 
-    DebugDraw3D::~DebugDraw3D()
-    {
-
-    }
+    DebugDraw3D::~DebugDraw3D() = default;
 
     void DebugDraw3D::drawLine(const btVector3 &from, const btVector3 &to, const btVector3 &color)
     {

--- a/engine/physics/src/physics/physics_3d.cpp
+++ b/engine/physics/src/physics/physics_3d.cpp
@@ -67,10 +67,7 @@ namespace dmPhysics
         {
         }
 
-        virtual ~MotionState()
-        {
-
-        }
+        virtual ~MotionState() = default;
 
         virtual void getWorldTransform(btTransform& world_trans) const
         {

--- a/engine/profiler/src/basic/profiler_basic.cpp
+++ b/engine/profiler/src/basic/profiler_basic.cpp
@@ -166,9 +166,7 @@ struct ProfileContext
     dmHashTable32<const char*> m_ThreadNames;
     dmHashTable32<ThreadData*> m_ThreadData;
 
-    ProfileContext()
-    {
-    }
+    ProfileContext() = default;
 
     ~ProfileContext()
     {
@@ -428,9 +426,7 @@ namespace dmProfiler
     {
     }
 
-    SampleIterator::~SampleIterator()
-    {
-    }
+    SampleIterator::~SampleIterator() = default;
 
     SampleIterator* SampleIterateChildren(HSample hsample, SampleIterator* iter)
     {

--- a/engine/profiler/src/js/profiler_js.cpp
+++ b/engine/profiler/src/js/profiler_js.cpp
@@ -120,9 +120,7 @@ struct ProfileContext
     dmHashTable32<const char*> m_ThreadNames;
     dmHashTable32<ThreadData*> m_ThreadData;
 
-    ProfileContext()
-    {
-    }
+    ProfileContext() = default;
 
     ~ProfileContext()
     {

--- a/engine/profiler/src/profiler_render.cpp
+++ b/engine/profiler/src/profiler_render.cpp
@@ -104,17 +104,9 @@ namespace dmProfileRender
     static ProfilerFrame* DuplicateProfilerFrame(const ProfilerFrame* frame);
     static ProfilerThread* GetSelectedThread(HRenderProfile render_profile, ProfilerFrame* frame);
 
-    ProfilerThread::ProfilerThread()
-    : m_NameHash(0)
-    , m_Time(0)
-    , m_SamplesTotalTime(0)
-    {
-    }
+    ProfilerThread::ProfilerThread() = default;
 
-    ProfilerFrame::ProfilerFrame()
-    : m_Time(0)
-    {
-    }
+    ProfilerFrame::ProfilerFrame() = default;
 
     // The RenderProfile contains the current "live" frame and
     // stats used to sort/purge sample items
@@ -327,7 +319,7 @@ namespace dmProfileRender
 
     struct ThreadSortTimePred
     {
-        ThreadSortTimePred() {}
+        ThreadSortTimePred() = default;
         bool operator()(ProfilerThread* a, ProfilerThread* b) const
         {
             return a->m_SamplesTotalTime > b->m_SamplesTotalTime;

--- a/engine/profiler/src/profiler_render.h
+++ b/engine/profiler/src/profiler_render.h
@@ -64,9 +64,9 @@ namespace dmProfileRender
     struct ProfilerThread
     {
         dmArray<ProfilerSample>     m_Samples;
-        uint32_t                    m_NameHash;
-        uint64_t                    m_Time;             // The time of the last update for this thread
-        uint64_t                    m_SamplesTotalTime; // The elapsed time of the samples in the thread
+        uint32_t                    m_NameHash {0};
+        uint64_t                    m_Time {0};             // The time of the last update for this thread
+        uint64_t                    m_SamplesTotalTime {0}; // The elapsed time of the samples in the thread
 
         ProfilerThread();
     };
@@ -76,7 +76,7 @@ namespace dmProfileRender
     {
         dmArray<ProfilerThread*>    m_Threads;
         dmArray<ProfilerProperty>   m_Properties;
-        uint64_t                    m_Time;           // The time of the last update for this frame
+        uint64_t                    m_Time {0};           // The time of the last update for this frame
 
         ProfilerFrame();
     };

--- a/engine/render/src/render/display_profiles.cpp
+++ b/engine/render/src/render/display_profiles.cpp
@@ -34,10 +34,7 @@
 
 namespace dmRender
 {
-    DisplayProfilesParams::DisplayProfilesParams()
-    : m_DisplayProfilesDDF(0x0)
-    , m_NameHash(0x0)
-    { }
+    DisplayProfilesParams::DisplayProfilesParams() = default;
 
     HDisplayProfiles NewDisplayProfiles()
     {

--- a/engine/render/src/render/display_profiles.h
+++ b/engine/render/src/render/display_profiles.h
@@ -43,8 +43,8 @@ namespace dmRender
         DisplayProfilesParams();
 
         /// Pointer to DDF buffer
-        dmRenderDDF::DisplayProfiles* m_DisplayProfilesDDF;
-        dmhash_t m_NameHash;
+        dmRenderDDF::DisplayProfiles* m_DisplayProfilesDDF {0x0};
+        dmhash_t m_NameHash {0x0};
     };
 
     /**

--- a/engine/rig/src/test/test_rig.cpp
+++ b/engine/rig/src/test/test_rig.cpp
@@ -964,19 +964,19 @@ protected:
 class RigInstanceCursorBackwardTest : public RigInstanceCursorTest<dmRig::RigPlayback>
 {
 public:
-    virtual ~RigInstanceCursorBackwardTest() {}
+    virtual ~RigInstanceCursorBackwardTest() = default;
 };
 
 class RigInstanceCursorForwardTest : public RigInstanceCursorTest<dmRig::RigPlayback>
 {
 public:
-    virtual ~RigInstanceCursorForwardTest() {}
+    virtual ~RigInstanceCursorForwardTest() = default;
 };
 
 class RigInstanceCursorPingpongTest : public RigInstanceCursorTest<dmRig::RigPlayback>
 {
 public:
-    virtual ~RigInstanceCursorPingpongTest() {}
+    virtual ~RigInstanceCursorPingpongTest() = default;
 };
 
 TEST_P(RigInstanceCursorPingpongTest, CursorSet)

--- a/engine/sound/src/decoders/decoder_wav.cpp
+++ b/engine/sound/src/decoders/decoder_wav.cpp
@@ -110,7 +110,7 @@ namespace dmSoundCodec
         };
 
         struct DecodeStreamInfo {
-            virtual ~DecodeStreamInfo() {}
+            virtual ~DecodeStreamInfo() = default;
 
             Info m_Info;
             bool m_IsADPCM : 1;

--- a/engine/sound/src/sound.h
+++ b/engine/sound/src/sound.h
@@ -190,11 +190,9 @@ namespace dmSound
      */
     struct OpenDeviceParams
     {
-        OpenDeviceParams() : m_BufferCount(0), m_FrameCount(0)
-        {
-        }
-        uint32_t m_BufferCount;
-        uint32_t m_FrameCount;
+        OpenDeviceParams() = default;
+        uint32_t m_BufferCount {0};
+        uint32_t m_FrameCount {0};
     };
 
     /**

--- a/engine/sound/src/sound_codec.h
+++ b/engine/sound/src/sound_codec.h
@@ -76,12 +76,9 @@ namespace dmSoundCodec
     struct NewCodecContextParams
     {
         /// Maximum number of decoders supported in context
-        uint32_t m_MaxDecoders;
+        uint32_t m_MaxDecoders {32};
 
-        NewCodecContextParams()
-        {
-            m_MaxDecoders = 32;
-        }
+        NewCodecContextParams() = default;
     };
 
     /**


### PR DESCRIPTION
This PR resolves _almost all_ of the [`modernize-use-equals-default`](https://clang.llvm.org/extra/clang-tidy/checks/modernize/use-equals-default.html) warnings.

Here are the remaining ones and the reasons why I decided to leave them:

- cf. the _TODO_ comment:
https://github.com/vil02/defold/blob/b631cb6c9de057f268c42cfefca570a66f7498f5/engine/dlib/src/dlib/http_client.cpp#L55

- not applicable (one would need to depend on the values of enums, too bug-prone):
https://github.com/vil02/defold/blob/b631cb6c9de057f268c42cfefca570a66f7498f5/engine/gamesys/src/gamesys/components/comp_gui.cpp#L108
https://github.com/vil02/defold/blob/b631cb6c9de057f268c42cfefca570a66f7498f5/engine/gamesys/src/gamesys/components/comp_gui.cpp#L93

- not applicable (derived classes have different default values):
https://github.com/vil02/defold/blob/b631cb6c9de057f268c42cfefca570a66f7498f5/engine/gamesys/src/gamesys/test/test_gamesys.h#L187
https://github.com/vil02/defold/blob/b631cb6c9de057f268c42cfefca570a66f7498f5/engine/gamesys/src/gamesys/test/test_gamesys.h#L203
https://github.com/vil02/defold/blob/b631cb6c9de057f268c42cfefca570a66f7498f5/engine/gamesys/src/gamesys/test/test_gamesys.h#L214
https://github.com/vil02/defold/blob/b631cb6c9de057f268c42cfefca570a66f7498f5/engine/gamesys/src/gamesys/test/test_gamesys.h#L226
https://github.com/vil02/defold/blob/b631cb6c9de057f268c42cfefca570a66f7498f5/engine/gamesys/src/gamesys/test/test_gamesys.h#L234

- not applicable (requires significant changes in the class design):
https://github.com/vil02/defold/blob/b631cb6c9de057f268c42cfefca570a66f7498f5/engine/physics/src/physics/physics_3d.cpp#L158
https://github.com/vil02/defold/blob/b631cb6c9de057f268c42cfefca570a66f7498f5/engine/profiler/src/basic/profiler_basic.cpp#L171
https://github.com/vil02/defold/blob/b631cb6c9de057f268c42cfefca570a66f7498f5/engine/profiler/src/js/profiler_js.cpp#L125
https://github.com/vil02/defold/blob/b631cb6c9de057f268c42cfefca570a66f7498f5/engine/resource/src/resource_preloader.cpp#L149

In my opinion, it fixes #11382.