### PR TITLE
Fix for when bitmap font uses 4 channels which caused a crash

### DIFF
--- a/engine/render/src/render/font.cpp
+++ b/engine/render/src/render/font.cpp
@@ -217,7 +217,7 @@ namespace dmRender
         SetupCache(font_map, font_map->m_CacheWidth, font_map->m_CacheHeight,
                                 cell_width, cell_height, params.m_CacheCellMaxAscent);
 
-        switch (params.m_GlyphChannels)
+        switch (font_map->m_CacheChannels)
         {
             case 1:
                 font_map->m_CacheFormat = dmGraphics::TEXTURE_FORMAT_LUMINANCE;

--- a/engine/render/src/render/font_renderer_private.h
+++ b/engine/render/src/render/font_renderer_private.h
@@ -54,7 +54,8 @@ namespace dmRender
             free(m_CellTempData);
             m_CellTempData = 0;
 
-            dmGraphics::DeleteTexture(m_GraphicsContext, m_Texture);
+            if (m_Texture)
+                dmGraphics::DeleteTexture(m_GraphicsContext, m_Texture);
         }
 
         dmMutex::HMutex         m_Mutex;
@@ -108,7 +109,7 @@ namespace dmRender
         uint8_t                 m_IsCacheSizeDirty:1;   // if the glyph cell size has changed, or if the layout needs to be recalculated
         uint8_t                 m_DynamicCacheSize:1;
         uint8_t                 m_IsCacheSizeTooSmall:1;
-        uint8_t                 m_CacheChannels:2;      // Number of channels
+        uint8_t                 m_CacheChannels:3;      // Number of channels (1-4)
     };
 
     ///////////////////////////////////////////////////////////////////////////////

--- a/engine/render/src/test/test_render.cpp
+++ b/engine/render/src/test/test_render.cpp
@@ -1830,6 +1830,28 @@ TEST_F(dmRenderTest, FindRanges)
     ASSERT_EQ(6, range.m_Count);
 }
 
+TEST_F(dmRenderTest, FontMapSetup)
+{
+    dmRender::FontMapParams font_map_params;
+    font_map_params.m_CacheWidth = 128;
+    font_map_params.m_CacheHeight = 128;
+    font_map_params.m_CacheCellWidth = 8;
+    font_map_params.m_CacheCellHeight = 8;
+    font_map_params.m_MaxAscent = 2;
+    font_map_params.m_MaxDescent = 1;
+    font_map_params.m_GetGlyph = GetGlyph;
+    font_map_params.m_GetGlyphData = GetGlyphData;
+    font_map_params.m_GetFontMetrics = GetFontMetrics;
+
+    font_map_params.m_GlyphChannels = 4; // Issue https://github.com/defold/defold/issues/11397
+
+    dmRender::HFontMap font = dmRender::NewFontMap(m_Context, m_GraphicsContext, font_map_params);
+
+    ASSERT_NE((dmRender::HFontMap)0, font);
+
+    dmRender::DeleteFontMap(font);
+}
+
 TEST(Constants, Constant)
 {
     dmhash_t original_name_hash = dmHashString64("test_constant");


### PR DESCRIPTION
Fixes https://github.com/defold/defold/issues/11397

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
