### PR TITLE
Buffer release will trigger a AUDCLNT_E_BUFFER_TOO_LARGE on shutdown

### DIFF
--- a/engine/sound/src/devices/device_wasapi.cpp
+++ b/engine/sound/src/devices/device_wasapi.cpp
@@ -538,7 +538,7 @@ namespace dmDeviceWasapi
                 return;
             }
 
-            uint32_t frames_available = buffer_size;// buffer_size - buffer_pos;
+            uint32_t frames_available = buffer_size - buffer_pos;
             hr = device->m_AudioRenderClient->GetBuffer(frames_available, &out);
             if (FAILED(hr))
             {


### PR DESCRIPTION
Fix wasapi error on buffer release, also removes the WASAPI error log on app close.

### Technical changes
set correct frame count when releasing wasapi buffer. Made in order to be cherry picked to beta build. This fix is also included in the wasapi_device_recovery branch that contains logic to recover from dropped sound device.