### PR TITLE
Added new camera functions for converting between world and screen coordinates.  

### DIFF
--- a/engine/gamesys/src/gamesys/components/comp_camera.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_camera.cpp
@@ -156,6 +156,7 @@ namespace dmGameSystem
         camera.m_RenderCamera   = dmRender::NewRenderCamera(render_context);
 
         dmRender::RenderCameraData camera_data = {};
+        camera_data.m_Viewport                 = dmVMath::Vector4(0.0f, 0.0f, 1.0f, 1.0f);
         camera_data.m_AspectRatio              = cam_resource->m_DDF->m_AspectRatio;
         camera_data.m_Fov                      = cam_resource->m_DDF->m_Fov;
         camera_data.m_NearZ                    = cam_resource->m_DDF->m_NearZ;
@@ -163,7 +164,7 @@ namespace dmGameSystem
         camera_data.m_AutoAspectRatio          = cam_resource->m_DDF->m_AutoAspectRatio != 0;
         camera_data.m_OrthographicProjection   = cam_resource->m_DDF->m_OrthographicProjection != 0;
         camera_data.m_OrthographicZoom         = cam_resource->m_DDF->m_OrthographicZoom;
-        camera_data.m_OrthographicMode     = (uint8_t) cam_resource->m_DDF->m_OrthographicMode;
+        camera_data.m_OrthographicMode         = (uint8_t)cam_resource->m_DDF->m_OrthographicMode;
 
         dmMessage::URL camera_url = CameraToURL(&camera);
         SetRenderCameraURL(render_context, camera.m_RenderCamera, &camera_url);

--- a/engine/render/src/render/camera.cpp
+++ b/engine/render/src/render/camera.cpp
@@ -202,6 +202,74 @@ namespace dmRender
         }
     }
 
+    Result CameraScreenToWorld(HRenderContext render_context, HRenderCamera camera_handle, float screen_x, float screen_y, float z, dmVMath::Vector3* out_world)
+    {
+        RenderCamera* camera = render_context->m_RenderCameras.Get(camera_handle);
+        if (!camera)
+        {
+            return RESULT_INVALID_PARAMETER;
+        }
+
+        // Window size
+        dmGraphics::HContext gc = GetGraphicsContext(render_context);
+        float win_w = (float) dmGraphics::GetWindowWidth(gc);
+        float win_h = (float) dmGraphics::GetWindowHeight(gc);
+        if (win_w <= 0.0f)
+        {
+            win_w = 1.0f;
+        }
+        if (win_h <= 0.0f)
+        {
+            win_h = 1.0f;
+        }
+
+        // Viewport-aware screen->Normalized Device Coordinates
+        const dmVMath::Vector4& vp = camera->m_Data.m_Viewport;
+        float vx = vp.getX() * win_w;
+        float vy = vp.getY() * win_h;
+        float vw = vp.getZ() * win_w;
+        float vh = vp.getW() * win_h;
+        if (vw <= 0.0f || vh <= 0.0f)
+        {
+            vx = 0.0f; vy = 0.0f; vw = win_w; vh = win_h;
+        }
+        float x_ndc = 2.0f * ((screen_x - vx) / vw) - 1.0f;
+        float y_ndc = 2.0f * ((screen_y - vy) / vh) - 1.0f;
+
+        dmVMath::Matrix4 inv_vp = dmVMath::Inverse(camera->m_ViewProjection);
+
+        // Unproject near/far points and build pixel ray (world)
+        dmVMath::Vector4 v_near_clip(x_ndc, y_ndc, -1.0f, 1.0f);
+        dmVMath::Vector4 v_far_clip (x_ndc, y_ndc,  1.0f, 1.0f);
+        dmVMath::Vector4 v0 = inv_vp * v_near_clip;
+        dmVMath::Vector4 v1 = inv_vp * v_far_clip;
+        float iw0 = 1.0f / v0.getW();
+        float iw1 = 1.0f / v1.getW();
+        dmVMath::Point3  p_near(v0.getX() * iw0, v0.getY() * iw0, v0.getZ() * iw0);
+        dmVMath::Point3  p_far (v1.getX() * iw1, v1.getY() * iw1, v1.getZ() * iw1);
+        dmVMath::Vector3 dir    = dmVMath::Normalize(p_far - p_near);
+
+        // Camera forward (world)
+        dmVMath::Vector3 forward = dmVMath::Rotate(camera->m_LastRotation, dmVMath::Vector3(0.0f, 0.0f, -1.0f));
+        forward = dmVMath::Normalize(forward);
+
+        // z is view-depth along forward (world units from camera plane)
+        float denom = dmVMath::Dot(dir, forward);
+        const float EPS_DENOM = 1.0e-8f;
+        if (denom > -EPS_DENOM && denom < EPS_DENOM)
+        {
+            return RESULT_INVALID_PARAMETER;
+        }
+
+        dmVMath::Point3 cam_pos = camera->m_LastPosition;
+        // Intersect the ray r(s) = p_near + s * dir with the view-depth plane at distance z along 'forward'
+        float dot0 = dmVMath::Dot(p_near - cam_pos, forward);
+        float s = (z - dot0) / denom;
+        dmVMath::Point3 p_point = p_near + dir * s;
+        *out_world = dmVMath::Vector3(p_point.getX(), p_point.getY(), p_point.getZ());
+        return RESULT_OK;
+    }
+
     // render_private.h
     RenderCamera* GetRenderCameraByUrl(HRenderContext render_context, const dmMessage::URL& camera_url)
     {

--- a/engine/render/src/render/camera.cpp
+++ b/engine/render/src/render/camera.cpp
@@ -18,6 +18,8 @@
 
 namespace dmRender
 {
+    const float EPS = 1e-6f;
+
     HRenderCamera NewRenderCamera(HRenderContext render_context)
     {
         if (render_context->m_RenderCameras.Full())
@@ -205,10 +207,6 @@ namespace dmRender
     Result CameraScreenToWorld(HRenderContext render_context, HRenderCamera camera_handle, float screen_x, float screen_y, float z, dmVMath::Vector3* out_world)
     {
         RenderCamera* camera = render_context->m_RenderCameras.Get(camera_handle);
-        if (!camera)
-        {
-            return RESULT_INVALID_PARAMETER;
-        }
 
         // Window size
         dmGraphics::HContext gc = GetGraphicsContext(render_context);
@@ -223,7 +221,7 @@ namespace dmRender
             win_h = 1.0f;
         }
 
-        // Viewport-aware screen->Normalized Device Coordinates
+        // Viewport-aware screen -> Normalized Device Coordinates
         const dmVMath::Vector4& vp = camera->m_Data.m_Viewport;
         float vx = vp.getX() * win_w;
         float vy = vp.getY() * win_h;
@@ -255,8 +253,7 @@ namespace dmRender
 
         // z is view-depth along forward (world units from camera plane)
         float denom = dmVMath::Dot(dir, forward);
-        const float EPS_DENOM = 1.0e-8f;
-        if (denom > -EPS_DENOM && denom < EPS_DENOM)
+        if (denom > -EPS && denom < EPS)
         {
             return RESULT_INVALID_PARAMETER;
         }
@@ -267,6 +264,59 @@ namespace dmRender
         float s = (z - dot0) / denom;
         dmVMath::Point3 p_point = p_near + dir * s;
         *out_world = dmVMath::Vector3(p_point.getX(), p_point.getY(), p_point.getZ());
+        return RESULT_OK;
+    }
+
+    Result CameraWorldToScreen(HRenderContext render_context, HRenderCamera camera_handle, const dmVMath::Vector3& world, dmVMath::Vector3* out_screen)
+    {
+        RenderCamera* camera = render_context->m_RenderCameras.Get(camera_handle);
+
+        // Project world to clip space
+        dmVMath::Vector4 world4(world.getX(), world.getY(), world.getZ(), 1.0f);
+        dmVMath::Vector4 clip = camera->m_ViewProjection * world4;
+        float w = clip.getW();
+        if (w > -EPS && w < EPS)
+        {
+            return RESULT_INVALID_PARAMETER;
+        }
+        float inv_w = 1.0f / w;
+        float x_ndc = clip.getX() * inv_w;
+        float y_ndc = clip.getY() * inv_w;
+
+        // Window size
+        dmGraphics::HContext gc = GetGraphicsContext(render_context);
+        float win_w = (float) dmGraphics::GetWindowWidth(gc);
+        float win_h = (float) dmGraphics::GetWindowHeight(gc);
+        if (win_w <= 0.0f)
+        {
+            win_w = 1.0f;
+        }
+        if (win_h <= 0.0f)
+        {
+            win_h = 1.0f;
+        }
+
+        // Viewport mapping (Normalized Device Coordinates -> screen pixels)
+        const dmVMath::Vector4& vp = camera->m_Data.m_Viewport;
+        float vx = vp.getX() * win_w;
+        float vy = vp.getY() * win_h;
+        float vw = vp.getZ() * win_w;
+        float vh = vp.getW() * win_h;
+        if (vw <= 0.0f || vh <= 0.0f)
+        {
+            vx = 0.0f; vy = 0.0f; vw = win_w; vh = win_h;
+        }
+
+        float sx = vx + (x_ndc + 1.0f) * 0.5f * vw;
+        float sy = vy + (y_ndc + 1.0f) * 0.5f * vh;
+
+        // View depth along camera forward
+        dmVMath::Vector3 forward = dmVMath::Rotate(camera->m_LastRotation, dmVMath::Vector3(0.0f, 0.0f, -1.0f));
+        forward = dmVMath::Normalize(forward);
+        dmVMath::Point3 world_p(world.getX(), world.getY(), world.getZ());
+        float z_view = dmVMath::Dot(world_p - camera->m_LastPosition, forward);
+
+        *out_screen = dmVMath::Vector3(sx, sy, z_view);
         return RESULT_OK;
     }
 

--- a/engine/render/src/render/render.cpp
+++ b/engine/render/src/render/render.cpp
@@ -589,7 +589,6 @@ namespace dmRender
 
         const uint32_t ORDER_SCALE_MASK = 0xfffff0;
         const uint32_t ORDER_BASE_FRONT = 0x000008;
-        const uint32_t ORDER_BASE_BACK = 0xfffff8;
         const uint32_t ftb  = (sort_order == SORT_FRONT_TO_BACK);
         const float    base = (float)(ORDER_BASE_FRONT + ((uint32_t)!ftb) * ORDER_SCALE_MASK);
         const float    sign = ftb * 2.0f - 1.0f;

--- a/engine/render/src/render/render.h
+++ b/engine/render/src/render/render.h
@@ -240,6 +240,25 @@ namespace dmRender
     void Square2d(HRenderContext context, float x0, float y0, float x1, float y1, dmVMath::Vector4 color);
 
     /**
+     * Maps screen coordinates to a world-space point along the pixel ray.
+     * The mapping is viewport-aware and woks for both perspective and orthographic cameras.
+     *
+     * z is interpreted as view depth in world units measured from the camera plane,
+     * along the camera forward axis. The returned point lies on the ray passing through
+     * (screen_x, screen_y) at the specified view depth. The point is guaranteed to be
+     * inside the camera frustum only if z is between the camera near and far planes.
+     *
+     * @param render_context Render context handle
+     * @param camera         Camera handle
+     * @param screen_x       X coordinate in window pixels
+     * @param screen_y       Y coordinate in window pixels
+     * @param z              View depth in world units from the camera plane
+     * @param out_world      Output world-space position
+     * @return Result        RESULT_OK on success, error otherwise
+     */
+    Result CameraScreenToWorld(HRenderContext render_context, HRenderCamera camera, float screen_x, float screen_y, float z, dmVMath::Vector3* out_world);
+
+    /**
      * Render debug triangle in world space.
      * @param context Render context handle
      * @param vertices Vertices of the triangle, CW winding

--- a/engine/render/src/render/render.h
+++ b/engine/render/src/render/render.h
@@ -259,6 +259,22 @@ namespace dmRender
     Result CameraScreenToWorld(HRenderContext render_context, HRenderCamera camera, float screen_x, float screen_y, float z, dmVMath::Vector3* out_world);
 
     /**
+     * Maps a world-space position to screen coordinates.
+     * The mapping is viewport-aware and works for both perspective and orthographic cameras.
+     *
+     * Returns screen-space X and Y in window pixels and Z as the view depth in world units
+     * measured from the camera plane along the camera forward axis. The value of Z can be
+     * used with CameraScreenToWorld to reconstruct the world position on the same pixel ray.
+     *
+     * @param render_context Render context handle
+     * @param camera         Camera handle
+     * @param world          World-space position
+     * @param out_screen     Output screen-space position (x,y in pixels, z is view depth)
+     * @return Result        RESULT_OK on success, error otherwise
+     */
+    Result CameraWorldToScreen(HRenderContext render_context, HRenderCamera camera, const dmVMath::Vector3& world, dmVMath::Vector3* out_screen);
+
+    /**
      * Render debug triangle in world space.
      * @param context Render context handle
      * @param vertices Vertices of the triangle, CW winding

--- a/engine/render/src/render/render_script_camera.cpp
+++ b/engine/render/src/render/render_script_camera.cpp
@@ -126,6 +126,21 @@ namespace dmRender
      * @param y [type:number] Y coordinate on screen.
      * @param [camera] [type:url|number|nil] optional camera id
      * @return world_pos [type:vector3] the world coordinate on the camera near plane
+     *
+     * @examples
+     * Place objects at the touch point.
+     *
+     * ```lua
+     *  function on_input(self, action_id, action)
+     *      if action_id == hash("touch") then
+     *          if action.pressed then
+     *              local world_position = camera.screen_xy_to_world(action.screen_x, action.screen_y)
+     *              go.set_position(world_position, "/go1")
+     *          end
+     *      end
+     *  end
+     * ```
+     *
      */
     static int RenderScriptCamera_ScreenXYToWorld(lua_State* L)
     {
@@ -158,6 +173,23 @@ namespace dmRender
      * @param pos [type:vector3] Screen-space position (x, y) with z as view depth in world units
      * @param [camera] [type:url|number|nil] optional camera id
      * @return world_pos [type:vector3] the world coordinate
+     *
+     * @examples
+     * Place objects at the touch point with a random Z position, keeping them within the visible view zone.
+     *
+     * ```lua
+     *  function on_input(self, action_id, action)
+     *      if action_id == hash("touch") then
+     *          if action.pressed then
+     *              local percpective_camera = msg.url("#perspective_camera")
+     *              local random_z = math.random(camera.get_near_z(percpective_camera) + 0.01, camera.get_far_z(percpective_camera) - 0.01)
+     *              local world_position = camera.screen_to_world(vmath.vector3(action.screen_x, action.screen_y, random_z), percpective_camera)
+     *              go.set_position(world_position, "/go1")
+     *          end
+     *      end
+     *  end
+     * ```
+     *
      */
     static int RenderScriptCamera_ScreenToWorld(lua_State* L)
     {
@@ -187,6 +219,16 @@ namespace dmRender
      * @param world_pos [type:vector3] World-space position
      * @param [camera] [type:url|number|nil] optional camera id
      * @return screen_pos [type:vector3] Screen position (x,y in pixels, z is view depth)
+     *
+     * @examples
+     * Convert go position into screen pisition
+     *
+     * ```lua
+     *  go.update_world_transform("/go1")
+     *  local world_pos = go.get_world_position("/go1")
+     *  local screen_pos = camera.world_to_screen(world_pos)
+     * ```
+     *
      */
     static int RenderScriptCamera_WorldToScreen(lua_State* L)
     {

--- a/engine/render/src/render/render_script_camera.cpp
+++ b/engine/render/src/render/render_script_camera.cpp
@@ -95,7 +95,7 @@ namespace dmRender
 
     // Resolve a camera from an optional argument. If no argument is given (or nil),
     // prefer the last enabled camera (matching default render script behavior).
-    static RenderCamera* ResolveRenderCameraOrDefault(lua_State* L, int index, HRenderContext render_context)
+    static RenderCamera* CheckRenderCameraOrDefault(lua_State* L, int index, HRenderContext render_context)
     {
         int top = lua_gettop(L);
 
@@ -135,7 +135,7 @@ namespace dmRender
         float sy = (float) luaL_checknumber(L, 2);
 
         HRenderContext render_context = g_RenderScriptCameraModule.m_RenderContext;
-        RenderCamera* camera = ResolveRenderCameraOrDefault(L, 3, render_context);
+        RenderCamera* camera = CheckRenderCameraOrDefault(L, 3, render_context);
 
         dmVMath::Vector3 world;
         float near_z = camera->m_Data.m_NearZ;
@@ -143,13 +143,13 @@ namespace dmRender
         dmRender::Result r = dmRender::CameraScreenToWorld(render_context, camera->m_Handle, sx, sy, near_z + eps, &world);
         if (r != dmRender::RESULT_OK)
         {
-            return DM_LUA_ERROR("camera.screen_xy_to_world failed (%d)", r);
+            return DM_LUA_ERROR("Can't convert position (%d)", r);
         }
         dmScript::PushVector3(L, world);
         return 1;
     }
 
-    /*# Convert screen vector3 to world
+    /*# Convert screen vector3 position to world
      * Converts a screen-space 2D point with view depth to a 3D world point.
      * z is the view depth in world units measured from the camera plane along the camera forward axis.
      * If a camera isn't specified, the last enabled camera is used.
@@ -165,14 +165,44 @@ namespace dmRender
 
         dmVMath::Vector3* pos = dmScript::CheckVector3(L, 1);
         HRenderContext render_context = g_RenderScriptCameraModule.m_RenderContext;
-        RenderCamera* camera = ResolveRenderCameraOrDefault(L, 2, render_context);
+        RenderCamera* camera = CheckRenderCameraOrDefault(L, 2, render_context);
         dmVMath::Vector3 world;
         dmRender::Result r = dmRender::CameraScreenToWorld(render_context, camera->m_Handle, pos->getX(), pos->getY(), pos->getZ(), &world);
         if (r != dmRender::RESULT_OK)
         {
-            return DM_LUA_ERROR("camera.screen_to_world failed (%d)", r);
+            return DM_LUA_ERROR("Can't convert position (%d)", r);
         }
         dmScript::PushVector3(L, world);
+        return 1;
+    }
+
+    /*# Convert world vector3 position to screen
+     * Converts a 3D world position to screen-space coordinates with view depth.
+     * Returns a vector3 where x and y are in screen pixels and z is the view depth in world units
+     * measured from the camera plane along the camera forward axis. The returned z can be used with
+     * camera.screen_to_world to reconstruct the world position on the same pixel ray.
+     * If a camera isn't specified, the last enabled camera is used.
+     *
+     * @name camera.world_to_screen
+     * @param world_pos [type:vector3] World-space position
+     * @param [camera] [type:url|number|nil] optional camera id
+     * @return screen_pos [type:vector3] Screen position (x,y in pixels, z is view depth)
+     */
+    static int RenderScriptCamera_WorldToScreen(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+
+        dmVMath::Vector3* world = dmScript::CheckVector3(L, 1);
+        HRenderContext render_context = g_RenderScriptCameraModule.m_RenderContext;
+        RenderCamera* camera = CheckRenderCameraOrDefault(L, 2, render_context);
+
+        dmVMath::Vector3 screen;
+        dmRender::Result r = dmRender::CameraWorldToScreen(render_context, camera->m_Handle, *world, &screen);
+        if (r != dmRender::RESULT_OK)
+        {
+            return DM_LUA_ERROR("Can't convert position (%d)", r);
+        }
+        dmScript::PushVector3(L, screen);
         return 1;
     }
 
@@ -451,6 +481,7 @@ namespace dmRender
         // CONVERSIONS
         {"screen_xy_to_world",      RenderScriptCamera_ScreenXYToWorld},
         {"screen_to_world",         RenderScriptCamera_ScreenToWorld},
+        {"world_to_screen",         RenderScriptCamera_WorldToScreen},
 
         // READ-WRITE
         {"get_aspect_ratio",        RenderScriptCamera_GetAspectRatio},

--- a/engine/render/src/render/render_script_camera.cpp
+++ b/engine/render/src/render/render_script_camera.cpp
@@ -93,6 +93,89 @@ namespace dmRender
         return camera;
     }
 
+    // Resolve a camera from an optional argument. If no argument is given (or nil),
+    // prefer the last enabled camera (matching default render script behavior).
+    static RenderCamera* ResolveRenderCameraOrDefault(lua_State* L, int index, HRenderContext render_context)
+    {
+        int top = lua_gettop(L);
+
+        if (index <= top && !lua_isnil(L, index))
+        {
+            return CheckRenderCamera(L, index, render_context);
+        }
+
+        // Pick the last enabled camera (iterate from the end)
+        for (int i = render_context->m_RenderCameras.Capacity() - 1; i >= 0; --i)
+        {
+            RenderCamera* camera = render_context->m_RenderCameras.GetByIndex(i);
+            if (camera && camera->m_Enabled)
+            {
+                return camera;
+            }
+        }
+
+        return (RenderCamera*) (uintptr_t) luaL_error(L, "No camera found.");
+    }
+
+    /*# Convert screen XY to world point at near plane
+     * Converts 2D screen coordinates (x,y) to the 3D world-space point on the camera's near plane for that pixel.
+     * If a camera isn't specified, the last enabled camera is used.
+     *
+     * @name camera.screen_xy_to_world
+     * @param x [type:number] X coordinate on screen.
+     * @param y [type:number] Y coordinate on screen.
+     * @param [camera] [type:url|number|nil] optional camera id
+     * @return world_pos [type:vector3] the world coordinate on the camera near plane
+     */
+    static int RenderScriptCamera_ScreenXYToWorld(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+
+        float sx = (float) luaL_checknumber(L, 1);
+        float sy = (float) luaL_checknumber(L, 2);
+
+        HRenderContext render_context = g_RenderScriptCameraModule.m_RenderContext;
+        RenderCamera* camera = ResolveRenderCameraOrDefault(L, 3, render_context);
+
+        dmVMath::Vector3 world;
+        float near_z = camera->m_Data.m_NearZ;
+        const float eps = 0.0001;
+        dmRender::Result r = dmRender::CameraScreenToWorld(render_context, camera->m_Handle, sx, sy, near_z + eps, &world);
+        if (r != dmRender::RESULT_OK)
+        {
+            return DM_LUA_ERROR("camera.screen_xy_to_world failed (%d)", r);
+        }
+        dmScript::PushVector3(L, world);
+        return 1;
+    }
+
+    /*# Convert screen vector3 to world
+     * Converts a screen-space 2D point with view depth to a 3D world point.
+     * z is the view depth in world units measured from the camera plane along the camera forward axis.
+     * If a camera isn't specified, the last enabled camera is used.
+     *
+     * @name camera.screen_to_world
+     * @param pos [type:vector3] Screen-space position (x, y) with z as view depth in world units
+     * @param [camera] [type:url|number|nil] optional camera id
+     * @return world_pos [type:vector3] the world coordinate
+     */
+    static int RenderScriptCamera_ScreenToWorld(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+
+        dmVMath::Vector3* pos = dmScript::CheckVector3(L, 1);
+        HRenderContext render_context = g_RenderScriptCameraModule.m_RenderContext;
+        RenderCamera* camera = ResolveRenderCameraOrDefault(L, 2, render_context);
+        dmVMath::Vector3 world;
+        dmRender::Result r = dmRender::CameraScreenToWorld(render_context, camera->m_Handle, pos->getX(), pos->getY(), pos->getZ(), &world);
+        if (r != dmRender::RESULT_OK)
+        {
+            return DM_LUA_ERROR("camera.screen_to_world failed (%d)", r);
+        }
+        dmScript::PushVector3(L, world);
+        return 1;
+    }
+
     /*# get all camera URLs
     * This function returns a table with all the camera URLs that have been
     * registered in the render context.
@@ -364,6 +447,10 @@ namespace dmRender
         {"get_projection",          RenderScriptCamera_GetProjection},
         {"get_view",                RenderScriptCamera_GetView},
         {"get_enabled",             RenderScriptCamera_GetEnabled},
+
+        // CONVERSIONS
+        {"screen_xy_to_world",      RenderScriptCamera_ScreenXYToWorld},
+        {"screen_to_world",         RenderScriptCamera_ScreenToWorld},
 
         // READ-WRITE
         {"get_aspect_ratio",        RenderScriptCamera_GetAspectRatio},

--- a/engine/render/src/test/test_render_script.cpp
+++ b/engine/render/src/test/test_render_script.cpp
@@ -1683,6 +1683,153 @@ TEST_F(dmRenderScriptTest, TestCameraScreenToWorldPerspective)
     dmRender::DeleteRenderScript(m_Context, render_script);
 }
 
+TEST_F(dmRenderScriptTest, TestCameraWorldToScreenPerspective)
+{
+    // Perspective camera
+    dmRender::HRenderCamera cam_handle = dmRender::NewRenderCamera(m_Context);
+
+    dmMessage::URL cam_url = {};
+    cam_url.m_Socket   = dmHashString64("main");
+    cam_url.m_Path     = dmHashString64("test_go");
+    cam_url.m_Fragment = dmHashString64("camera");
+    dmRender::SetRenderCameraURL(m_Context, cam_handle, &cam_url);
+
+    dmRender::RenderCameraData data = {};
+    data.m_Viewport                 = dmVMath::Vector4(0.0f, 0.0f, 1.0f, 1.0f);
+    data.m_Fov                      = 90.0f;
+    data.m_NearZ                    = 1.0f;
+    data.m_FarZ                     = 100.0f;
+    data.m_AspectRatio              = 2.0f; // 20/10
+    data.m_OrthographicProjection   = 0;
+    data.m_AutoAspectRatio          = 0;
+    dmRender::SetRenderCameraData(m_Context, cam_handle, &data);
+
+    dmVMath::Point3 pos(25.0f, 0.0f, 0.0f);
+    dmVMath::Quat   rot(0.0f, 0.0f, 0.0f, 1.0f);
+    dmRender::UpdateRenderCamera(m_Context, cam_handle, &pos, &rot);
+
+    const char* script =
+        "local function assert_near(a,b)\n"
+        "    assert(math.abs(a-b) < 1e-3, tostring(a)..' ~= '..tostring(b))\n"
+        "end\n"
+        "function init(self)\n"
+        "    local cams = camera.get_cameras()\n"
+        "    assert(#cams == 1)\n"
+        "    local cam = cams[1]\n"
+        "    local cx = render.get_window_width() / 2\n"
+        "    local cy = render.get_window_height() / 2\n"
+        "    -- world at center pixel with depth 5\n"
+        "    local s = camera.world_to_screen(vmath.vector3(25, 0, -5), cam)\n"
+        "    assert_near(s.x, cx)\n"
+        "    assert_near(s.y, cy)\n"
+        "    assert_near(s.z, 5)\n"
+        "    -- near plane center maps back to (cx,cy,near_z)\n"
+        "    local pn = camera.screen_xy_to_world(cx, cy, cam)\n"
+        "    local sn = camera.world_to_screen(pn, cam)\n"
+        "    assert_near(sn.x, cx)\n"
+        "    assert_near(sn.y, cy)\n"
+        "    assert_near(sn.z, camera.get_near_z(cam))\n"
+        "end\n";
+
+    dmRender::HRenderScript         render_script = dmRender::NewRenderScript(m_Context, LuaSourceFromString(script));
+    dmRender::HRenderScriptInstance inst          = dmRender::NewRenderScriptInstance(m_Context, render_script);
+    ASSERT_EQ(dmRender::RENDER_SCRIPT_RESULT_OK, dmRender::InitRenderScriptInstance(inst));
+    dmRender::DeleteRenderScriptInstance(inst);
+    dmRender::DeleteRenderScript(m_Context, render_script);
+}
+
+TEST_F(dmRenderScriptTest, TestCameraWorldToScreenOrthographic)
+{
+    dmRender::HRenderCamera cam_handle = dmRender::NewRenderCamera(m_Context);
+
+    dmMessage::URL cam_url = {};
+    cam_url.m_Socket   = dmHashString64("main");
+    cam_url.m_Path     = dmHashString64("test_go");
+    cam_url.m_Fragment = dmHashString64("camera");
+    dmRender::SetRenderCameraURL(m_Context, cam_handle, &cam_url);
+
+    dmRender::RenderCameraData data = {};
+    data.m_Viewport                 = dmVMath::Vector4(0.0f, 0.0f, 1.0f, 1.0f);
+    data.m_NearZ                    = 1.0f;
+    data.m_FarZ                     = 100.0f;
+    data.m_AspectRatio              = 2.0f;
+    data.m_OrthographicProjection   = 1;
+    data.m_OrthographicZoom         = 1.0f;
+    data.m_AutoAspectRatio          = 0;
+    dmRender::SetRenderCameraData(m_Context, cam_handle, &data);
+
+    dmVMath::Point3 pos(0.0f, 0.0f, 0.0f);
+    dmVMath::Quat   rot(0.0f, 0.0f, 0.0f, 1.0f);
+    dmRender::UpdateRenderCamera(m_Context, cam_handle, &pos, &rot);
+
+    const char* script =
+        "local function assert_near(a,b)\n"
+        "    assert(math.abs(a-b) < 1e-3, tostring(a)..' ~= '..tostring(b))\n"
+        "end\n"
+        "function init(self)\n"
+        "    local cams = camera.get_cameras()\n"
+        "    assert(#cams == 1)\n"
+        "    local cam = cams[1]\n"
+        "    local cx = render.get_window_width() / 2\n"
+        "    local cy = render.get_window_height() / 2\n"
+        "    local s = camera.world_to_screen(vmath.vector3(0, 0, -camera.get_near_z(cam)), cam)\n"
+        "    assert_near(s.x, cx)\n"
+        "    assert_near(s.y, cy)\n"
+        "    assert_near(s.z, camera.get_near_z(cam))\n"
+        "end\n";
+
+    dmRender::HRenderScript         render_script = dmRender::NewRenderScript(m_Context, LuaSourceFromString(script));
+    dmRender::HRenderScriptInstance inst          = dmRender::NewRenderScriptInstance(m_Context, render_script);
+    ASSERT_EQ(dmRender::RENDER_SCRIPT_RESULT_OK, dmRender::InitRenderScriptInstance(inst));
+    dmRender::DeleteRenderScriptInstance(inst);
+    dmRender::DeleteRenderScript(m_Context, render_script);
+}
+
+TEST_F(dmRenderScriptTest, TestCameraScreenWorldRoundtrip)
+{
+    // Perspective camera
+    dmRender::HRenderCamera cam_handle = dmRender::NewRenderCamera(m_Context);
+
+    dmMessage::URL cam_url = {};
+    cam_url.m_Socket   = dmHashString64("main");
+    cam_url.m_Path     = dmHashString64("test_go");
+    cam_url.m_Fragment = dmHashString64("camera");
+    dmRender::SetRenderCameraURL(m_Context, cam_handle, &cam_url);
+
+    dmRender::RenderCameraData data = {};
+    data.m_Viewport                 = dmVMath::Vector4(0.0f, 0.0f, 1.0f, 1.0f);
+    data.m_Fov                      = 60.0f;
+    data.m_NearZ                    = 0.5f;
+    data.m_FarZ                     = 250.0f;
+    data.m_AspectRatio              = 2.0f;
+    data.m_OrthographicProjection   = 0;
+    data.m_AutoAspectRatio          = 0;
+    dmRender::SetRenderCameraData(m_Context, cam_handle, &data);
+
+    dmVMath::Point3 pos(4.0f, 3.0f, 2.0f);
+    dmVMath::Quat   rot(0.0f, 0.0f, 0.0f, 1.0f);
+    dmRender::UpdateRenderCamera(m_Context, cam_handle, &pos, &rot);
+
+    const char* script =
+        "local function assert_near(a,b)\n"
+        "    assert(math.abs(a-b) < 1e-3, tostring(a)..' ~= '..tostring(b))\n"
+        "end\n"
+        "function init(self)\n"
+        "    local cam = camera.get_cameras()[1]\n"
+        "    local x, y, z = 8, 3, 7\n"
+        "    local w = camera.screen_to_world(vmath.vector3(x,y,z), cam)\n"
+        "    local s = camera.world_to_screen(w, cam)\n"
+        "    assert_near(s.x, x)\n"
+        "    assert_near(s.y, y)\n"
+        "    assert_near(s.z, z)\n"
+        "end\n";
+
+    dmRender::HRenderScript         render_script = dmRender::NewRenderScript(m_Context, LuaSourceFromString(script));
+    dmRender::HRenderScriptInstance inst          = dmRender::NewRenderScriptInstance(m_Context, render_script);
+    ASSERT_EQ(dmRender::RENDER_SCRIPT_RESULT_OK, dmRender::InitRenderScriptInstance(inst));
+    dmRender::DeleteRenderScriptInstance(inst);
+    dmRender::DeleteRenderScript(m_Context, render_script);
+}
 TEST_F(dmRenderScriptTest, TestCameraScreenToWorldOrthographic)
 {
     // Create an orthographic camera with near=1, far=100

--- a/engine/render/src/test/test_render_script.cpp
+++ b/engine/render/src/test/test_render_script.cpp
@@ -1629,6 +1629,217 @@ TEST_F(dmRenderScriptTest, TestRenderResourceTable)
     dmRender::DeleteRenderScript(m_Context, render_script);
 }
 
+TEST_F(dmRenderScriptTest, TestCameraScreenToWorldPerspective)
+{
+    // Create a perspective camera with known parameters
+    dmRender::HRenderCamera cam_handle = dmRender::NewRenderCamera(m_Context);
+
+    dmMessage::URL cam_url = {};
+    cam_url.m_Socket   = dmHashString64("main");
+    cam_url.m_Path     = dmHashString64("test_go");
+    cam_url.m_Fragment = dmHashString64("camera");
+    dmRender::SetRenderCameraURL(m_Context, cam_handle, &cam_url);
+
+    dmRender::RenderCameraData data = {};
+    data.m_Viewport                 = dmVMath::Vector4(0.0f, 0.0f, 1.0f, 1.0f);
+    data.m_Fov                      = 90.0f;
+    data.m_NearZ                    = 1.0f;
+    data.m_FarZ                     = 100.0f;
+    data.m_AspectRatio              = 2.0f; // match window (20/10)
+    data.m_OrthographicZoom         = 1.0f;
+    data.m_OrthographicProjection   = 0;
+    data.m_AutoAspectRatio          = 0;
+    dmRender::SetRenderCameraData(m_Context, cam_handle, &data);
+
+    // Update camera transform: identity rotation, position at (25, 0, 0)
+    dmVMath::Point3 pos(25.0f, 0.0f, 0.0f);
+    dmVMath::Quat   rot(0.0f, 0.0f, 0.0f, 1.0f);
+    dmRender::UpdateRenderCamera(m_Context, cam_handle, &pos, &rot);
+
+    const char* script =
+        "local function assert_near(a,b)\n"
+        "    assert(math.abs(a-b) < 1e-3, tostring(a)..' ~= '..tostring(b))\n"
+        "end\n"
+        "function init(self)\n"
+        "    local cams = camera.get_cameras()\n"
+        "    assert(#cams == 1)\n"
+        "    local cam = cams[1]\n"
+        "    local cx = render.get_window_width() / 2\n"
+        "    local cy = render.get_window_height() / 2\n"
+        "    local p = camera.screen_to_world(vmath.vector3(cx, cy, 5), cam)\n"
+        "    assert_near(p.x, 25)\n"
+        "    assert_near(p.y, 0)\n"
+        "    assert_near(p.z, -5)\n"
+        "    local pn = camera.screen_xy_to_world(cx, cy, cam)\n"
+        "    assert_near(pn.x, 25)\n"
+        "    assert_near(pn.y, 0)\n"
+        "    assert_near(pn.z, -camera.get_near_z(cam))\n"
+        "end\n";
+
+    dmRender::HRenderScript                  render_script = dmRender::NewRenderScript(m_Context, LuaSourceFromString(script));
+    dmRender::HRenderScriptInstance          inst          = dmRender::NewRenderScriptInstance(m_Context, render_script);
+    ASSERT_EQ(dmRender::RENDER_SCRIPT_RESULT_OK, dmRender::InitRenderScriptInstance(inst));
+    dmRender::DeleteRenderScriptInstance(inst);
+    dmRender::DeleteRenderScript(m_Context, render_script);
+}
+
+TEST_F(dmRenderScriptTest, TestCameraScreenToWorldOrthographic)
+{
+    // Create an orthographic camera with near=1, far=100
+    dmRender::HRenderCamera cam_handle = dmRender::NewRenderCamera(m_Context);
+
+    dmMessage::URL cam_url = {};
+    cam_url.m_Socket   = dmHashString64("main");
+    cam_url.m_Path     = dmHashString64("test_go");
+    cam_url.m_Fragment = dmHashString64("camera");
+    dmRender::SetRenderCameraURL(m_Context, cam_handle, &cam_url);
+
+    dmRender::RenderCameraData data = {};
+    data.m_Viewport                 = dmVMath::Vector4(0.0f, 0.0f, 1.0f, 1.0f);
+    data.m_Fov                      = 60.0f; // ignored in ortho
+    data.m_NearZ                    = 1.0f;
+    data.m_FarZ                     = 100.0f;
+    data.m_AspectRatio              = 2.0f;
+    data.m_OrthographicZoom         = 1.0f;
+    data.m_OrthographicProjection   = 1;
+    data.m_AutoAspectRatio          = 0;
+    dmRender::SetRenderCameraData(m_Context, cam_handle, &data);
+
+    // Update matrices with identity transform at origin
+    dmVMath::Point3 pos(0.0f, 0.0f, 0.0f);
+    dmVMath::Quat   rot(0.0f, 0.0f, 0.0f, 1.0f);
+    dmRender::UpdateRenderCamera(m_Context, cam_handle, &pos, &rot);
+
+    const char* script =
+        "local function assert_near(a,b)\n"
+        "    assert(math.abs(a-b) < 1e-3, tostring(a)..' ~= '..tostring(b))\n"
+        "end\n"
+        "function init(self)\n"
+        "    local cams = camera.get_cameras()\n"
+        "    assert(#cams == 1)\n"
+        "    local cam = cams[1]\n"
+        "    local cx = render.get_window_width() / 2\n"
+        "    local cy = render.get_window_height() / 2\n"
+        "    local pn = camera.screen_to_world(vmath.vector3(cx, cy, camera.get_near_z(cam)), cam)\n"
+        "    assert_near(pn.x, 0)\n"
+        "    assert_near(pn.y, 0)\n"
+        "    assert_near(pn.z, -camera.get_near_z(cam))\n"
+        "    local pf = camera.screen_to_world(vmath.vector3(cx, cy, camera.get_far_z(cam)), cam)\n"
+        "    assert_near(pf.x, 0)\n"
+        "    assert_near(pf.y, 0)\n"
+        "    assert_near(pf.z, -camera.get_far_z(cam))\n"
+        "    local p0 = camera.screen_xy_to_world(cx, cy, cam)\n"
+        "    assert_near(p0.x, 0)\n"
+        "    assert_near(p0.y, 0)\n"
+        "    assert_near(p0.z, -camera.get_near_z(cam))\n"
+        "end\n";
+
+    dmRender::HRenderScript                  render_script = dmRender::NewRenderScript(m_Context, LuaSourceFromString(script));
+    dmRender::HRenderScriptInstance          inst          = dmRender::NewRenderScriptInstance(m_Context, render_script);
+    ASSERT_EQ(dmRender::RENDER_SCRIPT_RESULT_OK, dmRender::InitRenderScriptInstance(inst));
+    dmRender::DeleteRenderScriptInstance(inst);
+    dmRender::DeleteRenderScript(m_Context, render_script);
+}
+
+TEST_F(dmRenderScriptTest, TestCameraScreenToWorldViewport)
+{
+    // Orthographic camera with viewport covering left half of the window
+    dmRender::HRenderCamera cam_handle = dmRender::NewRenderCamera(m_Context);
+
+    dmMessage::URL cam_url = {};
+    cam_url.m_Socket   = dmHashString64("main");
+    cam_url.m_Path     = dmHashString64("test_go");
+    cam_url.m_Fragment = dmHashString64("camera");
+    dmRender::SetRenderCameraURL(m_Context, cam_handle, &cam_url);
+
+    dmRender::RenderCameraData data = {};
+    data.m_Viewport                 = dmVMath::Vector4(0.0f, 0.0f, 0.5f, 1.0f); // left half
+    data.m_Fov                      = 60.0f;
+    data.m_NearZ                    = 1.0f;
+    data.m_FarZ                     = 100.0f;
+    data.m_AspectRatio              = 2.0f;
+    data.m_OrthographicZoom         = 1.0f;
+    data.m_OrthographicProjection   = 1;
+    data.m_AutoAspectRatio          = 0;
+    dmRender::SetRenderCameraData(m_Context, cam_handle, &data);
+
+    dmVMath::Point3 pos(0.0f, 0.0f, 0.0f);
+    dmVMath::Quat   rot(0.0f, 0.0f, 0.0f, 1.0f);
+    dmRender::UpdateRenderCamera(m_Context, cam_handle, &pos, &rot);
+
+    const char* script =
+        "local function assert_near(a,b)\n"
+        "    assert(math.abs(a-b) < 1e-3, tostring(a)..' ~= '..tostring(b))\n"
+        "end\n"
+        "function init(self)\n"
+        "    local cams = camera.get_cameras()\n"
+        "    local cam = cams[1]\n"
+        "    local cx = render.get_window_width() * 0.25 -- center of left-half viewport\n"
+        "    local cy = render.get_window_height() * 0.5\n"
+        "    local p = camera.screen_to_world(vmath.vector3(cx, cy, camera.get_near_z(cam)), cam)\n"
+        "    assert_near(p.x, 0)\n"
+        "    assert_near(p.y, 0)\n"
+        "    local p0 = camera.screen_xy_to_world(cx, cy, cam)\n"
+        "    assert_near(p0.x, 0)\n"
+        "    assert_near(p0.y, 0)\n"
+        "    assert_near(p0.z, -camera.get_near_z(cam))\n"
+        "end\n";
+
+    dmRender::HRenderScript                  render_script = dmRender::NewRenderScript(m_Context, LuaSourceFromString(script));
+    dmRender::HRenderScriptInstance          inst          = dmRender::NewRenderScriptInstance(m_Context, render_script);
+    ASSERT_EQ(dmRender::RENDER_SCRIPT_RESULT_OK, dmRender::InitRenderScriptInstance(inst));
+    dmRender::DeleteRenderScriptInstance(inst);
+    dmRender::DeleteRenderScript(m_Context, render_script);
+}
+
+TEST_F(dmRenderScriptTest, TestCameraScreenToWorld_Ortho_LargeCoords_ExplicitURL)
+{
+    // Orthographic camera with explicit URL and large screen coordinates
+    dmRender::HRenderCamera cam_handle = dmRender::NewRenderCamera(m_Context);
+
+    dmMessage::URL cam_url = {};
+    cam_url.m_Socket   = dmHashString64("main");
+    cam_url.m_Path     = dmHashString64("go");
+    cam_url.m_Fragment = dmHashString64("camera1");
+    dmRender::SetRenderCameraURL(m_Context, cam_handle, &cam_url);
+
+    dmRender::RenderCameraData data = {};
+    data.m_Viewport                 = dmVMath::Vector4(0.0f, 0.0f, 1.0f, 1.0f);
+    data.m_Fov                      = 60.0f; // ignored in ortho
+    data.m_NearZ                    = 0.1f;
+    data.m_FarZ                     = 1000.0f;
+    data.m_AspectRatio              = 2.0f;
+    data.m_OrthographicZoom         = 1.0f;
+    data.m_OrthographicProjection   = 1;
+    data.m_AutoAspectRatio          = 0;
+    dmRender::SetRenderCameraData(m_Context, cam_handle, &data);
+
+    dmVMath::Point3 pos(0.0f, 0.0f, 0.0f);
+    dmVMath::Quat   rot(0.0f, 0.0f, 0.0f, 1.0f);
+    dmRender::UpdateRenderCamera(m_Context, cam_handle, &pos, &rot);
+
+    const char* script =
+        "local function assert_near(a,b)\n"
+        "    assert(math.abs(a-b) < 1e-3, tostring(a)..' ~= '..tostring(b))\n"
+        "end\n"
+        "function init(self)\n"
+        "    local cams = camera.get_cameras()\n"
+        "    assert(#cams >= 1)\n"
+        "    local cam = cams[#cams]\n"
+        "    local x, y = 2230, 818\n"
+        "    local p0 = camera.screen_xy_to_world(x, y, cam)\n"
+        "    assert_near(p0.z, -camera.get_near_z(cam))\n"
+        "    local p1 = camera.screen_to_world(vmath.vector3(x, y, camera.get_near_z(cam)), cam)\n"
+        "    assert_near(p1.z, -camera.get_near_z(cam))\n"
+        "end\n";
+
+    dmRender::HRenderScript                  render_script = dmRender::NewRenderScript(m_Context, LuaSourceFromString(script));
+    dmRender::HRenderScriptInstance          inst          = dmRender::NewRenderScriptInstance(m_Context, render_script);
+    ASSERT_EQ(dmRender::RENDER_SCRIPT_RESULT_OK, dmRender::InitRenderScriptInstance(inst));
+    dmRender::DeleteRenderScriptInstance(inst);
+    dmRender::DeleteRenderScript(m_Context, render_script);
+}
+
 TEST_F(dmRenderScriptTest, TestComputeEnableDisable)
 {
     const char* script =


### PR DESCRIPTION
Adds three camera-space conversion helpers to the Lua `camera` module:
  - `camera.world_to_screen(world_pos, [camera])`
  - `camera.screen_xy_to_world(x, y, [camera])`
  - `camera.screen_to_world(pos, [camera])`
```lua
-- Place objects at the touch point.
function on_input(self, action_id, action)
    if action_id == hash("touch") then
        if action.pressed then
            local world_position = camera.screen_xy_to_world(action.screen_x, action.screen_y)
            go.set_position(world_position, "/go1")
        end
    end
end
```

```lua
-- Place objects at the touch point with a random Z position, keeping them within the visible view zone.
function on_input(self, action_id, action)
    if action_id == hash("touch") then
        if action.pressed then
            local percpective_camera = msg.url("#perspective_camera")
            local random_z = math.random(camera.get_near_z(percpective_camera) + 0.01, camera.get_far_z(percpective_camera) - 0.01)
            local world_position = camera.screen_to_world(vmath.vector3(action.screen_x, action.screen_y, random_z), percpective_camera)
            go.set_position(world_position, "/go1")
        end
    end
end
```

```lua
-- Convert go position into screen position
go.update_world_transform("/go1")
local world_pos = go.get_world_position("/go1")
local screen_pos = camera.world_to_screen(world_pos)
```
Fix https://github.com/defold/defold/issues/11386