### PR TITLE
Check ENV and validate DM_SERVICE_PORT

### DIFF
--- a/editor/src/clj/editor/engine.clj
+++ b/editor/src/clj/editor/engine.clj
@@ -276,6 +276,13 @@
       (copy-dmengine-dependencies! engine-dir extender-platform)
       engine-file)))
 
+(defn- validate-service-port [port-str]
+  (try
+    (let [port (Integer/parseInt port-str)]
+      (when (<= 0 port 65535)
+        (str port)))
+    (catch Exception _ false)))
+
 (defn launch! [^File engine project-directory prefs debug? instance-index]
   (let [defold-log-dir (some-> (System/getProperty "defold.log.dir")
                                (File.)
@@ -295,7 +302,8 @@
 
                      (not (str/blank? engine-arguments))
                      (into (remove str/blank?) (split-lines engine-arguments)))
-        env {"DM_SERVICE_PORT" "dynamic"
+        env {"DM_SERVICE_PORT" (or (validate-service-port (System/getenv "DM_SERVICE_PORT"))
+                                   "dynamic")
              "DM_QUIT_ON_ESC" (if (prefs/get prefs [:run :quit-on-escape])
                                 "1" "0")
              ;; Windows only. Sets the correct symbol search path, since we're also setting the cwd (https://docs.microsoft.com/en-us/windows/win32/debug/symbol-paths)

--- a/editor/src/clj/editor/engine.clj
+++ b/editor/src/clj/editor/engine.clj
@@ -277,11 +277,12 @@
       engine-file)))
 
 (defn- validate-service-port [port-str]
-  (try
-    (let [port (Integer/parseInt port-str)]
-      (when (<= 0 port 65535)
-        (str port)))
-    (catch Exception _ false)))
+  (when port-str
+    (try
+      (let [port (Integer/parseInt port-str)]
+        (when (<= 0 port 65535)
+          (str port)))
+      (catch Exception _))))
 
 (defn launch! [^File engine project-directory prefs debug? instance-index]
   (let [defold-log-dir (some-> (System/getProperty "defold.log.dir")


### PR DESCRIPTION
Editor used to ignore `DM_SERVICE_PORT` and always use a dynamic port. Now the editor can read the port when the environment variable supplied.

Fixes #11334
Fixes #9813
