### PR TITLE
Include oneof member number in message payload

### DIFF
--- a/engine/ddf/src/ddf/ddf.cpp
+++ b/engine/ddf/src/ddf/ddf.cpp
@@ -253,7 +253,7 @@ namespace dmDDF
 
     Result SaveMessage(const void* message, const Descriptor* desc, void* context, SaveFunction save_function)
     {
-        return DoSaveMessage(message, desc, context, save_function);
+        return DoSaveMessage(message, desc, context, save_function, 0);
     }
 
     static bool DDFFileSaveFunction(void* context, const void* buffer, uint32_t buffer_size)

--- a/engine/ddf/src/ddf/ddf.h
+++ b/engine/ddf/src/ddf/ddf.h
@@ -52,6 +52,7 @@ namespace dmDDF
         Descriptor* m_MessageDescriptor;
         uint32_t    m_Offset;
         const char* m_DefaultValue;
+        // Index of which oneof block inside this field is in
         uint8_t     m_OneOfIndex;
     };
 
@@ -64,8 +65,9 @@ namespace dmDDF
         uint32_t         m_Size;
         FieldDescriptor* m_Fields;
         uint8_t          m_FieldCount;  // TODO: Where to check < 255...?
+        // Offset of a uint8_t value that indicates which oneof member has been set
         uint32_t*        m_OneOfDataOffsets;
-        uint8_t          m_OneOfCount;
+        uint8_t          m_OneOfDataOffsetsCount;
         void*            m_NextDescriptor;
     };
 

--- a/engine/ddf/src/ddf/ddf.h
+++ b/engine/ddf/src/ddf/ddf.h
@@ -52,8 +52,7 @@ namespace dmDDF
         Descriptor* m_MessageDescriptor;
         uint32_t    m_Offset;
         const char* m_DefaultValue;
-        uint8_t     m_OneOfIndex : 7;
-        uint8_t     m_OneOfSet   : 1;
+        uint8_t     m_OneOfIndex;
     };
 
     struct Descriptor
@@ -65,6 +64,8 @@ namespace dmDDF
         uint32_t         m_Size;
         FieldDescriptor* m_Fields;
         uint8_t          m_FieldCount;  // TODO: Where to check < 255...?
+        uint32_t*        m_OneOfDataOffsets;
+        uint8_t          m_OneOfCount;
         void*            m_NextDescriptor;
     };
 

--- a/engine/ddf/src/ddf/ddf_load.cpp
+++ b/engine/ddf/src/ddf/ddf_load.cpp
@@ -179,7 +179,7 @@ namespace dmDDF
                     if (field->m_OneOfIndex != DDF_NO_ONE_OF_INDEX)
                     {
                         FieldDescriptor* field_non_const = (FieldDescriptor*) field;
-                        field_non_const->m_OneOfSet = 1;
+                        //field_non_const->m_OneOfSet = 1;
                     }
                 }
             }

--- a/engine/ddf/src/ddf/ddf_load.cpp
+++ b/engine/ddf/src/ddf/ddf_load.cpp
@@ -178,8 +178,7 @@ namespace dmDDF
 
                     if (field->m_OneOfIndex != DDF_NO_ONE_OF_INDEX)
                     {
-                        FieldDescriptor* field_non_const = (FieldDescriptor*) field;
-                        //field_non_const->m_OneOfSet = 1;
+                        message->SetOneOf(desc, field);
                     }
                 }
             }

--- a/engine/ddf/src/ddf/ddf_message.cpp
+++ b/engine/ddf/src/ddf/ddf_message.cpp
@@ -228,7 +228,7 @@ namespace dmDDF
         // Note: The -1 is because we offset it by 1 in ddfc.py
         assert(field->m_OneOfIndex > 0);
         int32_t oneof_index_from_zero = field->m_OneOfIndex-1;
-        assert(oneof_index_from_zero < desc->m_OneOfCount);
+        assert(oneof_index_from_zero < desc->m_OneOfDataOffsetsCount);
 
         if (!m_DryRun)
         {

--- a/engine/ddf/src/ddf/ddf_message.cpp
+++ b/engine/ddf/src/ddf/ddf_message.cpp
@@ -223,6 +223,21 @@ namespace dmDDF
         }
     }
 
+    void Message::SetOneOf(const Descriptor* desc, const FieldDescriptor* field)
+    {
+        // Note: The -1 is because we offset it by 1 in ddfc.py
+        assert(field->m_OneOfIndex > 0);
+        int32_t oneof_index_from_zero = field->m_OneOfIndex-1;
+        assert(oneof_index_from_zero < desc->m_OneOfCount);
+
+        if (!m_DryRun)
+        {
+            uint32_t data_offset = desc->m_OneOfDataOffsets[oneof_index_from_zero];
+            uint8_t* oneof_index = (uint8_t*) GetBuffer(data_offset);
+            *oneof_index = field->m_Number;
+        }
+    }
+
     void Message::SetScalar(const FieldDescriptor* field, const void* buffer, int buffer_size)
     {
         assert((Label) field->m_Label != LABEL_REPEATED);

--- a/engine/ddf/src/ddf/ddf_message.h
+++ b/engine/ddf/src/ddf/ddf_message.h
@@ -42,6 +42,7 @@ namespace dmDDF
         void     SetString(LoadContext* load_context, const FieldDescriptor* field, const char* buffer, int buffer_len);
         void     AddString(LoadContext* load_context, const FieldDescriptor* field, const char* buffer, int buffer_len);
         void     SetBytes(LoadContext* load_context, const FieldDescriptor* field, const char* buffer, int buffer_len);
+        void     SetOneOf(const Descriptor* desc, const FieldDescriptor* field);
 
         Message  SubMessage(const FieldDescriptor* field);
 

--- a/engine/ddf/src/ddf/ddf_save.cpp
+++ b/engine/ddf/src/ddf/ddf_save.cpp
@@ -40,9 +40,16 @@ namespace dmDDF
             FieldDescriptor* field_desc = &desc->m_Fields[i];
             Type type = (Type) field_desc->m_Type;
 
-            if (field_desc->m_OneOfIndex != DDF_NO_ONE_OF_INDEX) // && field_desc->m_OneOfSet == 0)
+            if (field_desc->m_OneOfIndex != DDF_NO_ONE_OF_INDEX)
             {
-                continue;
+                // Resolve the oneof member for this field
+                assert(field_desc->m_OneOfIndex > 0);
+                uint32_t oneof_offset = desc->m_OneOfDataOffsets[field_desc->m_OneOfIndex-1];
+                uint8_t oneof_member  = message[oneof_offset];
+                if (oneof_member != field_desc->m_Number)
+                {
+                    continue;
+                }
             }
 
     #define DDF_SAVEMESSAGE_CASE(t, wt, func) \
@@ -83,11 +90,12 @@ namespace dmDDF
             {
                 const uint8_t* data = data_start + j * element_size;
 
+            #if 0
                 char prefix_levels[32];
                 memset(prefix_levels, ' ', level);
                 prefix_levels[level] = 0;
-
                 dmLogInfo("%sSaving field %s[%d]", prefix_levels, field_desc->m_Name, j);
+            #endif
 
                 switch (field_desc->m_Type)
                 {

--- a/engine/ddf/src/ddf/ddf_save.cpp
+++ b/engine/ddf/src/ddf/ddf_save.cpp
@@ -17,6 +17,8 @@
 #include "ddf_save.h"
 #include "ddf_outputstream.h"
 
+#include <dlib/log.h>
+
 namespace dmDDF
 {
 
@@ -27,7 +29,7 @@ namespace dmDDF
         return true;
     }
 
-    Result DoSaveMessage(const void* message_, const Descriptor* desc, void* context, SaveFunction save_function)
+    Result DoSaveMessage(const void* message_, const Descriptor* desc, void* context, SaveFunction save_function, int level)
     {
         OutputStream output_stream(save_function, context);
         const uint8_t* message = (const uint8_t*) message_;
@@ -38,7 +40,7 @@ namespace dmDDF
             FieldDescriptor* field_desc = &desc->m_Fields[i];
             Type type = (Type) field_desc->m_Type;
 
-            if (field_desc->m_OneOfIndex != DDF_NO_ONE_OF_INDEX && field_desc->m_OneOfSet == 0)
+            if (field_desc->m_OneOfIndex != DDF_NO_ONE_OF_INDEX) // && field_desc->m_OneOfSet == 0)
             {
                 continue;
             }
@@ -81,6 +83,12 @@ namespace dmDDF
             {
                 const uint8_t* data = data_start + j * element_size;
 
+                char prefix_levels[32];
+                memset(prefix_levels, ' ', level);
+                prefix_levels[level] = 0;
+
+                dmLogInfo("%sSaving field %s[%d]", prefix_levels, field_desc->m_Name, j);
+
                 switch (field_desc->m_Type)
                 {
                     case TYPE_DOUBLE:
@@ -119,7 +127,7 @@ namespace dmDDF
                     case TYPE_MESSAGE:
                     {
                         uint32_t len = 0;
-                        Result e = SaveMessage(data, field_desc->m_MessageDescriptor, &len, &DDFCountSaveFunction);
+                        Result e = DoSaveMessage(data, field_desc->m_MessageDescriptor, &len, &DDFCountSaveFunction, level + 1);
                         if (e != RESULT_OK)
                             return e;
 
@@ -127,7 +135,7 @@ namespace dmDDF
                         if (!write_result)
                             return RESULT_IO_ERROR;
 
-                        e = SaveMessage(data, field_desc->m_MessageDescriptor, context, save_function);
+                        e = DoSaveMessage(data, field_desc->m_MessageDescriptor, context, save_function, level + 1);
                         if (e != RESULT_OK)
                             return e;
                     }

--- a/engine/ddf/src/ddf/ddf_save.h
+++ b/engine/ddf/src/ddf/ddf_save.h
@@ -19,7 +19,7 @@
 
 namespace dmDDF
 {
-    Result DoSaveMessage(const void* message, const Descriptor* desc, void* context, SaveFunction save_function);
+    Result DoSaveMessage(const void* message, const Descriptor* desc, void* context, SaveFunction save_function, int level);
 }
 
 #endif // DDF_SAVE_H

--- a/engine/ddf/src/ddfc.py
+++ b/engine/ddf/src/ddfc.py
@@ -228,12 +228,14 @@ def to_cxx_struct(context, pp, message_type):
             if oneof_scope == None or oneof_scope != oneof_decl.name:
                 if oneof_scope != None:
                     pp.end(" m_%s", to_camel_case(oneof_scope))
+                    pp.p("uint8_t m_%sOneOfIndex;", to_camel_case(oneof_scope))
 
                 oneof_scope = oneof_decl.name
                 pp.begin("union")
         else:
             if oneof_scope != None:
                 pp.end(" m_%s", to_camel_case(oneof_scope))
+                pp.p("uint8_t m_%sOneOfIndex;", to_camel_case(oneof_scope))
                 oneof_scope = None
 
         if (field_align):
@@ -268,6 +270,9 @@ def to_cxx_struct(context, pp, message_type):
 
     if oneof_scope != None:
         pp.end(" m_%s", to_camel_case(oneof_scope))
+
+        pp.p("uint8_t m_%sOneOfIndex;", to_camel_case(oneof_scope))
+        pp.p("")
 
     pp.p('')
     pp.p('static dmDDF::Descriptor* m_DDFDescriptor;')
@@ -330,6 +335,7 @@ def to_cxx_descriptor(context, pp_cpp, pp_h, message_type, namespace_lst):
         if '"' in default:
             pp_cpp.p('char DM_ALIGNED(4) %s_%s_%s_DEFAULT_VALUE[] = %s;', namespace, message_type.name, f.name, default)
 
+    oneof_scope_names = []
     oneof_scope = None
     lst = []
     for f in message_type.field:
@@ -344,6 +350,7 @@ def to_cxx_descriptor(context, pp_cpp, pp_h, message_type, namespace_lst):
 
             if oneof_scope == None or oneof_scope != oneof_decl.name:
                 oneof_scope = oneof_decl.name
+                oneof_scope_names.append(to_camel_case(oneof_decl.name))
         else:
             if oneof_scope != None:
                 oneof_scope = None
@@ -371,27 +378,47 @@ def to_cxx_descriptor(context, pp_cpp, pp_h, message_type, namespace_lst):
 
         lst.append(tpl)
 
-    # For clarity, set the 'm_OneOfSet' bit in the field descriptor to zero
-    one_of_index_set = 0
-
     if len(lst) > 0:
         pp_cpp.begin("dmDDF::FieldDescriptor %s_%s_FIELDS_DESCRIPTOR[] = ", namespace, message_type.name)
         for name, number, type, label, one_of_index, msg_desc, offset, default_value in lst:
-            pp_cpp.p('{ "%s", %d, %d, %d, %s, %s, %s, %d, %d},'  % (name, number, type, label, msg_desc, offset, default_value, one_of_index, one_of_index_set))
+            pp_cpp.p('{ "%s", %d, %d, %d, %s, %s, %s, %d},'  % (name, number, type, label, msg_desc, offset, default_value, one_of_index))
         pp_cpp.end()
     else:
         pp_cpp.p("dmDDF::FieldDescriptor* %s_%s_FIELDS_DESCRIPTOR = 0x0;", namespace, message_type.name)
+
+    # uint32_t TestDDF_OneOfMessageSave_FIELDS_ONEOF_OFFSETS[] = {
+    #     (uint32_t)DDF_OFFSET_OF(TestDDF::OneOfMessageSave, m_OneOfField),
+    #     (uint32_t)DDF_OFFSET_OF(TestDDF::OneOfMessageSave, m_OneOfFieldString),
+    # };
+
+    if len(oneof_scope_names) > 0:
+        pp_cpp.p('uint32_t %s_%s_ONEOF_OFFSETS[] = {', namespace, message_type.name)
+        for name in oneof_scope_names:
+            pp_cpp.p('    (uint32_t)DDF_OFFSET_OF(%s::%s, m_%sOneOfIndex),' % (namespace.replace("_", "::"), message_type.name, name))
+        pp_cpp.p('};')
+    else:
+        pp_cpp.p('uint32_t* %s_%s_ONEOF_OFFSETS = 0x0;', namespace, message_type.name)
 
     pp_cpp.begin("dmDDF::Descriptor %s_%s_DESCRIPTOR = ", namespace, message_type.name)
     pp_cpp.p('%d, %d,', DDF_MAJOR_VERSION, DDF_MINOR_VERSION)
     pp_cpp.p('"%s",', to_lower_case(message_type.name))
     pp_cpp.p('0x%016XULL,', dlib.dmHashBuffer64(to_lower_case(message_type.name)))
     pp_cpp.p('sizeof(%s::%s),', namespace.replace("_", "::"), message_type.name)
+
+    # Descriptors
     pp_cpp.p('%s_%s_FIELDS_DESCRIPTOR,', namespace, message_type.name)
     if len(lst) > 0:
         pp_cpp.p('sizeof(%s_%s_FIELDS_DESCRIPTOR)/sizeof(dmDDF::FieldDescriptor),', namespace, message_type.name)
     else:
         pp_cpp.p('0,')
+
+    # One-of offsets
+    pp_cpp.p('%s_%s_ONEOF_OFFSETS,', namespace, message_type.name)
+    if len(oneof_scope_names) > 0:
+        pp_cpp.p('sizeof(%s_%s_ONEOF_OFFSETS)/sizeof(uint32_t),', namespace, message_type.name)
+    else:
+        pp_cpp.p('0,')
+
     pp_cpp.end()
 
     pp_cpp.p('dmDDF::Descriptor* %s::%s::m_DDFDescriptor = &%s_%s_DESCRIPTOR;' % ('::'.join(namespace_lst), message_type.name, namespace, message_type.name))

--- a/engine/ddf/src/ddfc.py
+++ b/engine/ddf/src/ddfc.py
@@ -386,11 +386,6 @@ def to_cxx_descriptor(context, pp_cpp, pp_h, message_type, namespace_lst):
     else:
         pp_cpp.p("dmDDF::FieldDescriptor* %s_%s_FIELDS_DESCRIPTOR = 0x0;", namespace, message_type.name)
 
-    # uint32_t TestDDF_OneOfMessageSave_FIELDS_ONEOF_OFFSETS[] = {
-    #     (uint32_t)DDF_OFFSET_OF(TestDDF::OneOfMessageSave, m_OneOfField),
-    #     (uint32_t)DDF_OFFSET_OF(TestDDF::OneOfMessageSave, m_OneOfFieldString),
-    # };
-
     if len(oneof_scope_names) > 0:
         pp_cpp.p('uint32_t %s_%s_ONEOF_OFFSETS[] = {', namespace, message_type.name)
         for name in oneof_scope_names:

--- a/engine/ddf/src/test/test_ddf.cpp
+++ b/engine/ddf/src/test/test_ddf.cpp
@@ -858,6 +858,9 @@ TEST(OneOfTests, Save)
     dmDDF::Result e = dmDDF::LoadMessage((void*) msg_buf, msg_buf_size, &DUMMY::TestDDF_OneOfMessageSave_DESCRIPTOR, (void**)&message);
     ASSERT_EQ(dmDDF::RESULT_OK, e);
 
+    ASSERT_EQ(message->m_OneOfFieldOneOfIndex, 2);
+    ASSERT_EQ(message->m_OneOfFieldStringOneOfIndex, 3);
+
     std::string save_str;
     e = DDFSaveToString(message, &DUMMY::TestDDF_OneOfMessageSave_DESCRIPTOR, save_str);
     ASSERT_EQ(dmDDF::RESULT_OK, e);

--- a/engine/ddf/src/test/test_ddf.cpp
+++ b/engine/ddf/src/test/test_ddf.cpp
@@ -858,8 +858,9 @@ TEST(OneOfTests, Save)
     dmDDF::Result e = dmDDF::LoadMessage((void*) msg_buf, msg_buf_size, &DUMMY::TestDDF_OneOfMessageSave_DESCRIPTOR, (void**)&message);
     ASSERT_EQ(dmDDF::RESULT_OK, e);
 
+    // These are member numbers in the protobuf message
     ASSERT_EQ(message->m_OneOfFieldOneOfIndex, 2);
-    ASSERT_EQ(message->m_OneOfFieldStringOneOfIndex, 3);
+    ASSERT_EQ(message->m_OneOfFieldStringOneOfIndex, 6);
 
     std::string save_str;
     e = DDFSaveToString(message, &DUMMY::TestDDF_OneOfMessageSave_DESCRIPTOR, save_str);

--- a/engine/ddf/src/test/test_ddf_proto.proto
+++ b/engine/ddf/src/test/test_ddf_proto.proto
@@ -351,4 +351,3 @@ message OneOfMessageSave
         string string_val       = 6;
     }
 }
-

--- a/engine/ddf/src/test/test_ddf_proto.proto
+++ b/engine/ddf/src/test/test_ddf_proto.proto
@@ -339,14 +339,16 @@ message OneOfMessageSave
 {
     oneof one_of_field
     {
-        int32 int_val = 1;
-        bool bool_val = 2;
+        bool bool_val     = 1;
+        int32 int_val     = 2;
+        uint64 uint64_val = 3;
     }
 
     oneof one_of_field_string
     {
-        int32 int_val_no_string = 3;
-        string string_val       = 4;
+        int32 int_val_no_string = 4;
+        bool bool_val_no_string = 5;
+        string string_val       = 6;
     }
 }
 


### PR DESCRIPTION
### Technical changes
This PR fixes and issue where oneof constructs are used in protobuf message definitions. Basically, the old parser would mutate the static descriptors we generate when oneof values are set. See the comment for more details.