### PR TITLE
Repaint up to last visible minimap row

### DIFF
--- a/editor/src/clj/editor/code/view.clj
+++ b/editor/src/clj/editor/code/view.clj
@@ -3532,7 +3532,7 @@
     ;; Repaint canvas if needed.
     (when-not (identical? prev-canvas-repaint-info canvas-repaint-info)
       (g/user-data! view-node :canvas-repaint-info canvas-repaint-info)
-      (let [row (data/last-visible-row (:layout canvas-repaint-info))]
+      (let [row (data/last-visible-row (:minimap-layout canvas-repaint-info))]
         (repaint-canvas! canvas-repaint-info (get-valid-syntax-info resource-node canvas-repaint-info row))))
 
     (when editable


### PR DESCRIPTION
The minimap in the code editor wasn't syntax highlighting all the lines visible in larger files. Now the minimap will have syntax colors all the way through.

Fixes #11377