### PR TITLE
Allow typing tilde (`~`) on Swedish keyboard layout

### DIFF
--- a/editor/src/clj/editor/code/view.clj
+++ b/editor/src/clj/editor/code/view.clj
@@ -3793,7 +3793,7 @@
       (insert-text! view-node prefs ({"≃" "~="} x x)))))
 
 (defn- setup-input-method-requests! [^Canvas canvas view-node prefs]
-  (when (os/is-linux?)
+  (when-not (os/is-win32?)
     (doto canvas
       (.setInputMethodRequests
         (reify InputMethodRequests

--- a/editor/src/clj/editor/localization.clj
+++ b/editor/src/clj/editor/localization.clj
@@ -647,4 +647,4 @@
 ;;  - editor scripts localization
 ;;  - form views
 ;;  - missed things...
-;;  - contribution doc / crowdin setup / link in drop-down
+;;  - link in drop-down

--- a/editor/test/integration/test_util.clj
+++ b/editor/test/integration/test_util.clj
@@ -16,7 +16,7 @@
   (:require [clojure.java.io :as io]
             [clojure.string :as string]
             [clojure.test :as test :refer [is testing]]
-            clojure.test.check.clojure-test
+            [clojure.test.check.clojure-test]
             [dynamo.graph :as g]
             [editor.app-view :as app-view]
             [editor.atlas :as atlas]


### PR DESCRIPTION
Now it's possible to enter the tilde character (`~`) when using the Swedish keyboard layout by pressing <kbd>⌥ ^</kbd> followed by space or another character.

Fixes #11379
