### PR TITLE
Localize some missed places in the editor UI

### DIFF
--- a/editor/resources/about.fxml
+++ b/editor/resources/about.fxml
@@ -32,19 +32,19 @@
             <RowConstraints maxHeight="20.0" minHeight="10.0" prefHeight="20.0" vgrow="SOMETIMES"/>
           </rowConstraints>
           <children>
-            <Label text="Version:">
+            <Label id="version-label" text="Version:">
               <padding>
                 <Insets right="4.0"/>
               </padding>
             </Label>
             <Label GridPane.columnIndex="1" id="version" styleClass="about-value" text="2.0.0"/>
-            <Label GridPane.rowIndex="1" text="Channel:">
+            <Label GridPane.rowIndex="1" id="channel-label" text="Channel:">
               <padding>
                 <Insets right="4.0"/>
               </padding>
             </Label>
             <Label GridPane.columnIndex="1" GridPane.rowIndex="1" id="channel" styleClass="about-value" text="No Channel"/>
-            <Label GridPane.rowIndex="2" text="Build time:">
+            <Label GridPane.rowIndex="2" id="build-time-label" text="Build time:">
               <padding>
                 <Insets right="4.0"/>
               </padding>
@@ -62,12 +62,12 @@
             <RowConstraints minHeight="10.0" prefHeight="36.0" vgrow="SOMETIMES"/>
           </rowConstraints>
           <children>
-            <Label text="Editor SHA1:">
+            <Label id="editor-sha1-label" text="Editor SHA1:" minWidth="-Infinity">
               <padding>
                 <Insets right="4.0"/>
               </padding>
             </Label>
-            <Label GridPane.rowIndex="1" text="Engine SHA1:">
+            <Label GridPane.rowIndex="1" id="engine-sha1-label" text="Engine SHA1:" minWidth="-Infinity">
               <padding>
                 <Insets right="4.0"/>
               </padding>
@@ -92,12 +92,12 @@
               <Insets top="20.0"/>
             </VBox.margin>
         </TextFlow>
-        <Label alignment="CENTER" maxWidth="1.7976931348623157E308" text="Copyright © 2009-2025">
+        <Label alignment="CENTER" id="copyright-label" maxWidth="1.7976931348623157E308" text="Copyright © 2009-2025">
           <VBox.margin>
             <Insets top="20.0"/>
           </VBox.margin>
         </Label>
-        <Label alignment="CENTER" maxWidth="1.7976931348623157E308" text="Defold Foundation"/>
+        <Label alignment="CENTER" id="foundation-label" maxWidth="1.7976931348623157E308" text="Defold Foundation"/>
       </children>
       <padding>
         <Insets top="10.0"/>

--- a/editor/resources/localization/en.editor_localization
+++ b/editor/resources/localization/en.editor_localization
@@ -322,6 +322,7 @@ dialog.lua-transpilers-error.generic.header = Failed to load Lua transpilers
 
 # Diff view dialogs
 
+dialog.diff-view.title = Diff
 dialog.diff-view.unchanged.title = The File Is Unchanged
 dialog.diff-view.unchanged.header = The file is unchanged
 dialog.diff-view.binary.title = Unable to Diff Binary Files
@@ -842,6 +843,28 @@ command.help.open-donations = Development Fund
 command.app.about = About
 command.vcs.diff = View Diff
 command.vcs.revert = Revert
+
+# Code editor – find bar
+
+code.find.word = Word
+code.find.case = Case
+code.find.wrap = Wrap
+code.find.prev = Previous
+code.find.next = Next
+code.replace.next = Replace
+code.replace.all = Replace All
+
+# About dialog
+
+dialog.about.label.version = Version:
+dialog.about.label.channel = Channel:
+dialog.about.label.build-time = Build time:
+dialog.about.label.editor-sha1 = Editor SHA1:
+dialog.about.label.engine-sha1 = Engine SHA1:
+dialog.about.value.unavailable = Not available
+dialog.about.footer.copyright = Copyright © 2009-2025
+dialog.about.footer.foundation = Defold Foundation
+dialog.about.sponsor = Defold Foundation Development Fund
 
 # Overrides
 

--- a/editor/resources/localization/ru.editor_localization
+++ b/editor/resources/localization/ru.editor_localization
@@ -322,6 +322,7 @@ dialog.lua-transpilers-error.generic.header = Не удалось загрузи
 
 # Diff view dialogs
 
+dialog.diff-view.title = Сравнение
 dialog.diff-view.unchanged.title = Файл не изменён
 dialog.diff-view.unchanged.header = Файл не изменён
 dialog.diff-view.binary.title = Невозможно сравнить двоичные файлы
@@ -842,6 +843,28 @@ command.help.open-donations = Фонд разработки
 command.app.about = О программе
 command.vcs.diff = Сравнить
 command.vcs.revert = Откатить
+
+# Code editor – find bar
+
+code.find.word = Слово
+code.find.case = Регистр
+code.find.wrap = По кругу
+code.find.prev = Назад
+code.find.next = Вперёд
+code.replace.next = Заменить
+code.replace.all = Заменить все
+
+# About dialog
+
+dialog.about.label.version = Версия:
+dialog.about.label.channel = Канал:
+dialog.about.label.build-time = Время сборки:
+dialog.about.label.editor-sha1 = SHA1 редактора:
+dialog.about.label.engine-sha1 = SHA1 движка:
+dialog.about.value.unavailable = Нет данных
+dialog.about.footer.copyright = Copyright © 2009-2025
+dialog.about.footer.foundation = Фонд Defold
+dialog.about.sponsor = Фонд разработки Defold
 
 # Overrides
 

--- a/editor/src/clj/editor/code/view.clj
+++ b/editor/src/clj/editor/code/view.clj
@@ -3140,13 +3140,18 @@
 ;; Find & Replace
 ;; -----------------------------------------------------------------------------
 
-(defn- setup-find-bar! [^GridPane find-bar view-node]
+(defn- setup-find-bar! [^GridPane find-bar view-node localization]
   (doto find-bar
     (b/bind-presence! (b/= :find bar-ui-type-property))
     (ui/context! :code-view-find-bar {:find-bar find-bar :view-node view-node} nil)
     (.setMaxWidth Double/MAX_VALUE)
     (GridPane/setConstraints 0 1))
   (ui/with-controls find-bar [^CheckBox whole-word ^CheckBox case-sensitive ^CheckBox wrap ^TextField term ^Button next ^Button prev]
+    (localization/localize! whole-word localization (localization/message "code.find.word"))
+    (localization/localize! case-sensitive localization (localization/message "code.find.case"))
+    (localization/localize! wrap localization (localization/message "code.find.wrap"))
+    (localization/localize! next localization (localization/message "code.find.next"))
+    (localization/localize! prev localization (localization/message "code.find.prev"))
     (b/bind-bidirectional! (.textProperty term) find-term-property)
     (b/bind-bidirectional! (.selectedProperty whole-word) find-whole-word-property)
     (b/bind-bidirectional! (.selectedProperty case-sensitive) find-case-sensitive-property)
@@ -3165,13 +3170,19 @@
     (b/unbind-bidirectional! (.selectedProperty case-sensitive) find-case-sensitive-property)
     (b/unbind-bidirectional! (.selectedProperty wrap) find-wrap-property)))
 
-(defn- setup-replace-bar! [^GridPane replace-bar view-node editable]
+(defn- setup-replace-bar! [^GridPane replace-bar view-node editable localization]
   (doto replace-bar
     (b/bind-presence! (b/= :replace bar-ui-type-property))
     (ui/context! :code-view-replace-bar {:editable editable :replace-bar replace-bar :view-node view-node} nil)
     (.setMaxWidth Double/MAX_VALUE)
     (GridPane/setConstraints 0 1))
   (ui/with-controls replace-bar [^CheckBox whole-word ^CheckBox case-sensitive ^CheckBox wrap ^TextField term ^TextField replacement ^Button next ^Button replace ^Button replace-all]
+    (localization/localize! whole-word localization (localization/message "code.find.word"))
+    (localization/localize! case-sensitive localization (localization/message "code.find.case"))
+    (localization/localize! wrap localization (localization/message "code.find.wrap"))
+    (localization/localize! next localization (localization/message "code.find.next"))
+    (localization/localize! replace localization (localization/message "code.replace.next"))
+    (localization/localize! replace-all localization (localization/message "code.replace.all"))
     (b/bind-bidirectional! (.textProperty term) find-term-property)
     (b/bind-bidirectional! (.textProperty replacement) find-replacement-property)
     (b/bind-bidirectional! (.selectedProperty whole-word) find-whole-word-property)
@@ -3964,8 +3975,8 @@
           app-view
           lsp)
         goto-line-bar (setup-goto-line-bar! (ui/load-fxml "goto-line.fxml") view-node localization)
-        find-bar (setup-find-bar! (ui/load-fxml "find.fxml") view-node)
-        replace-bar (setup-replace-bar! (ui/load-fxml "replace.fxml") view-node editable)
+        find-bar (setup-find-bar! (ui/load-fxml "find.fxml") view-node localization)
+        replace-bar (setup-replace-bar! (ui/load-fxml "replace.fxml") view-node editable localization)
         repainter (ui/->timer "repaint-code-editor-view"
                               (fn [_ elapsed-time _]
                                 (when (and (.isSelected tab) (not (ui/ui-disabled?)))

--- a/editor/src/clj/editor/diff_view.clj
+++ b/editor/src/clj/editor/diff_view.clj
@@ -93,7 +93,7 @@
         str-right (text-util/crlf->lf raw-str-right)
         {:keys [left-lines right-lines edits]} (diff/find-edits str-left str-right)]
 
-    (ui/title! stage "Diff")
+    (ui/title! stage (localization (localization/message "dialog.diff-view.title")))
     (.setOnKeyPressed scene (ui/event-handler event (when (= (.getCode ^KeyEvent event) KeyCode/ESCAPE) (.close stage))))
 
     (.setScene stage scene)

--- a/editor/src/clj/editor/localization.clj
+++ b/editor/src/clj/editor/localization.clj
@@ -645,6 +645,7 @@
 ;; TODO:
 ;;  - resource type label (requires outline!)
 ;;  - editor scripts localization
+;;  - build errors view
 ;;  - form views
 ;;  - missed things...
 ;;  - contribution doc / crowdin setup / link in drop-down


### PR DESCRIPTION
We now localize:
- Find/Replace UI in the code editor.
- About dialog (bonus: Esc closes it now).
- Diff viewer title.