### PR TITLE
Added sound group mute functionality to C++ dmSDK

### DIFF
--- a/engine/sdk/src/dmsdk/sdk.h
+++ b/engine/sdk/src/dmsdk/sdk.h
@@ -36,6 +36,7 @@
 #include <dmsdk/dlib/hash.h>
 #include <dmsdk/graphics/graphics_native.h>
 #include <dmsdk/graphics/graphics.h>
+#include <dmsdk/sound/sound.h>
 #include <dmsdk/dlib/transform.h>
 #include <dmsdk/dlib/vmath.h>
 

--- a/engine/sound/src/dmsdk/sound/sound.h
+++ b/engine/sound/src/dmsdk/sound/sound.h
@@ -15,6 +15,8 @@
 #ifndef DMSDK_SOUND_SOUND_H
 #define DMSDK_SOUND_SOUND_H
 
+#include <dmsdk/dlib/hash.h>
+
 /*# Sound API documentation
  *
  * Functions for controlling the engine sound mixer from native extensions.
@@ -27,7 +29,6 @@
 
 namespace dmSound
 {
-    // Forward declaration supplied by the runtime.
     enum Result : int;
 
     /*# Set master mute state
@@ -38,6 +39,32 @@ namespace dmSound
      * @return result [type:Result] RESULT_OK on success
      */
     Result SetMasterMute(bool mute);
+
+    /*# Set mute state for a mixer group
+     * Temporarily mute or restore an individual mixer group.
+     *
+     * @name SetGroupMute
+     * @param group [type:dmhash_t] hash of the mixer group (e.g. `hash("master")`)
+     * @param mute [type:bool] `true` to mute, `false` to restore audio
+     * @return result [type:Result] RESULT_OK on success
+     */
+    Result SetGroupMute(dmhash_t group, bool mute);
+
+    /*# Toggle mute state for a mixer group
+     * Convenience toggle for `SetGroupMute`.
+     *
+     * @name ToggleGroupMute
+     * @param group [type:dmhash_t] hash of the mixer group (e.g. `hash("master")`)
+     * @return result [type:Result] RESULT_OK on success
+     */
+    Result ToggleGroupMute(dmhash_t group);
+
+    /*# Query group mute state
+     * @name IsGroupMuted
+     * @param group [type:dmhash_t] hash of the mixer group (e.g. `hash("master")`)
+     * @return muted [type:bool] `true` if the mixer group is muted
+     */
+    bool IsGroupMuted(dmhash_t group);
 
     /*# Toggle master mute
      * Toggle the master mixer group mute state.

--- a/engine/sound/src/dmsdk/sound/sound.h
+++ b/engine/sound/src/dmsdk/sound/sound.h
@@ -29,16 +29,30 @@
 
 namespace dmSound
 {
-    enum Result : int;
-
-    /*# Set master mute state
-     * Mute or unmute the master mixer group.
-     *
-     * @name SetMasterMute
-     * @param mute [type:bool] `true` to mute, `false` to restore audio
-     * @return result [type:Result] RESULT_OK on success
-     */
-    Result SetMasterMute(bool mute);
+    enum Result
+    {
+        RESULT_OK                 =  0,
+        RESULT_PARTIAL_DATA       =  1,
+        RESULT_OUT_OF_SOURCES     = -1,
+        RESULT_EFFECT_NOT_FOUND   = -2,
+        RESULT_OUT_OF_INSTANCES   = -3,
+        RESULT_RESOURCE_LEAK      = -4,
+        RESULT_OUT_OF_BUFFERS     = -5,
+        RESULT_INVALID_PROPERTY   = -6,
+        RESULT_UNKNOWN_SOUND_TYPE = -7,
+        RESULT_INVALID_STREAM_DATA= -8,
+        RESULT_OUT_OF_MEMORY      = -9,
+        RESULT_UNSUPPORTED        = -10,
+        RESULT_DEVICE_NOT_FOUND   = -11,
+        RESULT_OUT_OF_GROUPS      = -12,
+        RESULT_NO_SUCH_GROUP      = -13,
+        RESULT_NOTHING_TO_PLAY    = -14,
+        RESULT_INIT_ERROR         = -15,
+        RESULT_FINI_ERROR         = -16,
+        RESULT_NO_DATA            = -17,
+        RESULT_END_OF_STREAM      = -18,
+        RESULT_UNKNOWN_ERROR      = -1000,
+    };
 
     /*# Set mute state for a mixer group
      * Temporarily mute or restore an individual mixer group.
@@ -66,19 +80,6 @@ namespace dmSound
      */
     bool IsGroupMuted(dmhash_t group);
 
-    /*# Toggle master mute
-     * Toggle the master mixer group mute state.
-     *
-     * @name ToggleMasterMute
-     * @return result [type:Result] RESULT_OK on success
-     */
-    Result ToggleMasterMute();
-
-    /*# Query master mute state
-     * @name IsMasterMuted
-     * @return muted [type:bool] `true` if the mixer master group is muted
-     */
-    bool IsMasterMuted();
 }
 
 #endif // DMSDK_SOUND_SOUND_H

--- a/engine/sound/src/dmsdk/sound/sound.h
+++ b/engine/sound/src/dmsdk/sound/sound.h
@@ -1,0 +1,57 @@
+// Copyright 2020-2025 The Defold Foundation
+// Copyright 2014-2020 King
+// Copyright 2009-2014 Ragnar Svensson, Christian Murray
+// Licensed under the Defold License version 1.0 (the "License"); you may not use
+// this file except in compliance with the License.
+//
+// You may obtain a copy of the License, together with FAQs at
+// https://www.defold.com/license
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#ifndef DMSDK_SOUND_SOUND_H
+#define DMSDK_SOUND_SOUND_H
+
+/*# Sound API documentation
+ *
+ * Functions for controlling the engine sound mixer from native extensions.
+ *
+ * @document
+ * @name Sound
+ * @namespace dmSound
+ * @language C++
+ */
+
+namespace dmSound
+{
+    // Forward declaration supplied by the runtime.
+    enum Result : int;
+
+    /*# Set master mute state
+     * Mute or unmute the master mixer group.
+     *
+     * @name SetMasterMute
+     * @param mute [type:bool] `true` to mute, `false` to restore audio
+     * @return result [type:Result] RESULT_OK on success
+     */
+    Result SetMasterMute(bool mute);
+
+    /*# Toggle master mute
+     * Toggle the master mixer group mute state.
+     *
+     * @name ToggleMasterMute
+     * @return result [type:Result] RESULT_OK on success
+     */
+    Result ToggleMasterMute();
+
+    /*# Query master mute state
+     * @name IsMasterMuted
+     * @return muted [type:bool] `true` if the mixer master group is muted
+     */
+    bool IsMasterMuted();
+}
+
+#endif // DMSDK_SOUND_SOUND_H

--- a/engine/sound/src/dmsdk/sound/sound.h
+++ b/engine/sound/src/dmsdk/sound/sound.h
@@ -29,6 +29,31 @@
 
 namespace dmSound
 {
+    /*#
+     * @enum
+     * @name Result
+     * @member RESULT_OK
+     * @member RESULT_PARTIAL_DATA
+     * @member RESULT_OUT_OF_SOURCES
+     * @member RESULT_EFFECT_NOT_FOUND
+     * @member RESULT_OUT_OF_INSTANCES
+     * @member RESULT_RESOURCE_LEAK
+     * @member RESULT_OUT_OF_BUFFERS
+     * @member RESULT_INVALID_PROPERTY
+     * @member RESULT_UNKNOWN_SOUND_TYPE
+     * @member RESULT_INVALID_STREAM_DATA
+     * @member RESULT_OUT_OF_MEMORY
+     * @member RESULT_UNSUPPORTED
+     * @member RESULT_DEVICE_NOT_FOUND
+     * @member RESULT_OUT_OF_GROUPS
+     * @member RESULT_NO_SUCH_GROUP
+     * @member RESULT_NOTHING_TO_PLAY
+     * @member RESULT_INIT_ERROR
+     * @member RESULT_FINI_ERROR
+     * @member RESULT_NO_DATA
+     * @member RESULT_END_OF_STREAM
+     * @member RESULT_UNKNOWN_ERROR
+     */
     enum Result
     {
         RESULT_OK                 =  0,

--- a/engine/sound/src/sound.cpp
+++ b/engine/sound/src/sound.cpp
@@ -459,11 +459,6 @@ namespace dmSound
         sound->m_NextOutBuffer = 0;
 
         sound->m_GroupMap.SetCapacity(MAX_GROUPS * 2 + 1, MAX_GROUPS);
-        for (uint32_t i = 0; i < MAX_GROUPS; ++i) {
-            memset(&sound->m_Groups[i], 0, sizeof(SoundGroup));
-            sound->m_Groups[i].m_GainBeforeMute = 1.0f;
-            sound->m_Groups[i].m_IsMuted = false;
-        }
 
         int master_index = GetOrCreateGroup("master");
         SoundGroup* master = &sound->m_Groups[master_index];
@@ -952,7 +947,7 @@ namespace dmSound
             }
             else
             {
-                target_gain = group->m_GainBeforeMute > 0.0f ? group->m_GainBeforeMute : 1.0f;
+                target_gain = group->m_GainBeforeMute;
                 group->m_IsMuted = false;
             }
         }
@@ -977,24 +972,6 @@ namespace dmSound
             return false;
 
         return sound->m_Groups[*index].m_IsMuted;
-    }
-
-    Result SetMasterMute(bool mute)
-    {
-        return SetGroupMute(MASTER_GROUP_HASH, mute);
-    }
-
-    Result ToggleMasterMute()
-    {
-        return SetMasterMute(!IsMasterMuted());
-    }
-
-    bool IsMasterMuted()
-    {
-        if (!g_SoundSystem)
-            return false;
-
-        return IsGroupMuted(MASTER_GROUP_HASH);
     }
 
     Result GetGroupHashes(uint32_t* count, dmhash_t* buffer)

--- a/engine/sound/src/sound.cpp
+++ b/engine/sound/src/sound.cpp
@@ -1331,37 +1331,14 @@ namespace dmSound
         }
     }
 
-    static inline void Mix(const MixContext* mix_context, SoundInstance* instance, uint64_t delta, uint32_t avail_frames, const dmSoundCodec::Info* info, SoundGroup* group, bool is_muted)
+    static inline void Mix(const MixContext* mix_context, SoundInstance* instance, uint64_t delta, uint32_t avail_frames, const dmSoundCodec::Info* info, SoundGroup* group)
     {
         DM_PROFILE(__FUNCTION__);
-
-        static dmArray<float> s_ScratchStorage;
 
         uint32_t avail_mix_count = ((avail_frames << RESAMPLE_FRACTION_BITS) - instance->m_FrameFraction) / delta;
         uint32_t mix_count = dmMath::Min(mix_context->m_FrameCount, avail_mix_count);
 
-        if (is_muted)
-        {
-            uint32_t needed = SOUND_MAX_MIX_CHANNELS * mix_count;
-            if (s_ScratchStorage.Capacity() < needed)
-            {
-                s_ScratchStorage.SetCapacity(needed);
-            }
-            s_ScratchStorage.SetSize(needed);
-
-            float* scratch_buffers[SOUND_MAX_MIX_CHANNELS];
-            float* scratch_base = s_ScratchStorage.Begin();
-            for (uint32_t c = 0; c < SOUND_MAX_MIX_CHANNELS; ++c)
-            {
-                scratch_buffers[c] = scratch_base + c * mix_count;
-            }
-
-            MixResample(mix_context, instance, info, delta, scratch_buffers, mix_count, avail_frames);
-        }
-        else
-        {
-            MixResample(mix_context, instance, info, delta, group->m_MixBuffer, mix_count, avail_frames);
-        }
+        MixResample(mix_context, instance, info, delta, group->m_MixBuffer, mix_count, avail_frames);
     }
 
     static bool IsMuted(SoundInstance* instance) {
@@ -1619,7 +1596,7 @@ namespace dmSound
             // Mix the data
             //
             assert(frame_count > SOUND_MAX_FUTURE);
-            Mix(mix_context, instance, delta, frame_count - SOUND_MAX_FUTURE, &info, group, is_muted);
+            Mix(mix_context, instance, delta, frame_count - SOUND_MAX_FUTURE, &info, group);
         }
 
         if (instance->m_EndOfStream) {

--- a/engine/sound/src/sound.cpp
+++ b/engine/sound/src/sound.cpp
@@ -457,6 +457,9 @@ namespace dmSound
         sound->m_NextOutBuffer = 0;
 
         sound->m_GroupMap.SetCapacity(MAX_GROUPS * 2 + 1, MAX_GROUPS);
+        for (uint32_t i = 0; i < MAX_GROUPS; ++i) {
+            memset(&sound->m_Groups[i], 0, sizeof(SoundGroup));
+        }
 
         int master_index = GetOrCreateGroup("master");
         SoundGroup* master = &sound->m_Groups[master_index];

--- a/engine/sound/src/sound.h
+++ b/engine/sound/src/sound.h
@@ -144,6 +144,9 @@ namespace dmSound
     Result AddGroup(const char* group);
     Result SetGroupGain(dmhash_t group_hash, float gain);
     Result GetGroupGain(dmhash_t group_hash, float* gain);
+    Result SetMasterMute(bool mute);
+    Result ToggleMasterMute();
+    bool IsMasterMuted();
     Result GetGroupHashes(uint32_t* count, dmhash_t* buffer);
 
     Result GetGroupRMS(dmhash_t group_hash, float window, float* rms_left, float* rms_right);

--- a/engine/sound/src/sound.h
+++ b/engine/sound/src/sound.h
@@ -19,6 +19,7 @@
 #include <dlib/hash.h>
 
 #include <dmsdk/dlib/vmath.h>
+#include <dmsdk/sound/sound.h>
 
 namespace dmSound
 {
@@ -39,31 +40,6 @@ namespace dmSound
         PARAMETER_PAN   = 1,
         PARAMETER_SPEED = 2,
         PARAMETER_MAX   = 3
-    };
-
-    enum Result
-    {
-        RESULT_OK                 =  0,    //!< RESULT_OK
-        RESULT_PARTIAL_DATA       =  1,    //!< RESULT_PARTIAL_DATA
-        RESULT_OUT_OF_SOURCES     = -1,    //!< RESULT_OUT_OF_SOURCES
-        RESULT_EFFECT_NOT_FOUND   = -2,    //!< RESULT_EFFECT_NOT_FOUND
-        RESULT_OUT_OF_INSTANCES   = -3,    //!< RESULT_OUT_OF_INSTANCES
-        RESULT_RESOURCE_LEAK      = -4,    //!< RESULT_RESOURCE_LEAK
-        RESULT_OUT_OF_BUFFERS     = -5,    //!< RESULT_OUT_OF_BUFFERS
-        RESULT_INVALID_PROPERTY   = -6,    //!< RESULT_INVALID_PROPERTY
-        RESULT_UNKNOWN_SOUND_TYPE = -7,    //!< RESULT_UNKNOWN_SOUND_TYPE
-        RESULT_INVALID_STREAM_DATA= -8,    //!< RESULT_INVALID_STREAM_DATA
-        RESULT_OUT_OF_MEMORY      = -9,    //!< RESULT_OUT_OF_MEMORY
-        RESULT_UNSUPPORTED        = -10,   //!< RESULT_UNSUPPORTED
-        RESULT_DEVICE_NOT_FOUND   = -11,   //!< RESULT_DEVICE_NOT_FOUND
-        RESULT_OUT_OF_GROUPS      = -12,   //!< RESULT_OUT_OF_GROUPS
-        RESULT_NO_SUCH_GROUP      = -13,   //!< RESULT_NO_SUCH_GROUP
-        RESULT_NOTHING_TO_PLAY    = -14,   //!< RESULT_NOTHING_TO_PLAY
-        RESULT_INIT_ERROR         = -15,   //!< RESULT_INIT_ERROR
-        RESULT_FINI_ERROR         = -16,   //!< RESULT_FINI_ERROR
-        RESULT_NO_DATA            = -17,   //!< RESULT_NO_DATA
-        RESULT_END_OF_STREAM      = -18,   //!< RESULT_END_OF_STREAM
-        RESULT_UNKNOWN_ERROR      = -1000, //!< RESULT_UNKNOWN_ERROR
     };
 
     // Used to identify if a sound.play or play_sound msg
@@ -144,12 +120,6 @@ namespace dmSound
     Result AddGroup(const char* group);
     Result SetGroupGain(dmhash_t group_hash, float gain);
     Result GetGroupGain(dmhash_t group_hash, float* gain);
-    Result SetGroupMute(dmhash_t group_hash, bool mute);
-    Result ToggleGroupMute(dmhash_t group_hash);
-    bool IsGroupMuted(dmhash_t group_hash);
-    Result SetMasterMute(bool mute);
-    Result ToggleMasterMute();
-    bool IsMasterMuted();
     Result GetGroupHashes(uint32_t* count, dmhash_t* buffer);
 
     Result GetGroupRMS(dmhash_t group_hash, float window, float* rms_left, float* rms_right);

--- a/engine/sound/src/sound.h
+++ b/engine/sound/src/sound.h
@@ -144,6 +144,9 @@ namespace dmSound
     Result AddGroup(const char* group);
     Result SetGroupGain(dmhash_t group_hash, float gain);
     Result GetGroupGain(dmhash_t group_hash, float* gain);
+    Result SetGroupMute(dmhash_t group_hash, bool mute);
+    Result ToggleGroupMute(dmhash_t group_hash);
+    bool IsGroupMuted(dmhash_t group_hash);
     Result SetMasterMute(bool mute);
     Result ToggleMasterMute();
     bool IsMasterMuted();

--- a/engine/sound/src/sound_null.cpp
+++ b/engine/sound/src/sound_null.cpp
@@ -204,28 +204,6 @@ namespace dmSound
         return false;
     }
 
-    Result SetMasterMute(bool mute)
-    {
-        // NOTE: Not supported.
-        // sound_null is deprecated and should be replaced by sound2 with null-device
-        (void)mute;
-        return RESULT_OK;
-    }
-
-    Result ToggleMasterMute()
-    {
-        // NOTE: Not supported.
-        // sound_null is deprecated and should be replaced by sound2 with null-device
-        return RESULT_OK;
-    }
-
-    bool IsMasterMuted()
-    {
-        // NOTE: Not supported.
-        // sound_null is deprecated and should be replaced by sound2 with null-device
-        return false;
-    }
-
     Result GetGroupHashes(uint32_t* count, dmhash_t* buffer)
     {
         return RESULT_OK;

--- a/engine/sound/src/sound_null.cpp
+++ b/engine/sound/src/sound_null.cpp
@@ -183,6 +183,27 @@ namespace dmSound
         return RESULT_OK;
     }
 
+    Result SetGroupMute(dmhash_t group_hash, bool mute)
+    {
+        // NOTE: Not supported.
+        // sound_null is deprecated and should be replaced by sound2 with null-device
+        (void)group_hash;
+        (void)mute;
+        return RESULT_OK;
+    }
+
+    Result ToggleGroupMute(dmhash_t group_hash)
+    {
+        (void)group_hash;
+        return RESULT_OK;
+    }
+
+    bool IsGroupMuted(dmhash_t group_hash)
+    {
+        (void)group_hash;
+        return false;
+    }
+
     Result SetMasterMute(bool mute)
     {
         // NOTE: Not supported.

--- a/engine/sound/src/sound_null.cpp
+++ b/engine/sound/src/sound_null.cpp
@@ -183,6 +183,28 @@ namespace dmSound
         return RESULT_OK;
     }
 
+    Result SetMasterMute(bool mute)
+    {
+        // NOTE: Not supported.
+        // sound_null is deprecated and should be replaced by sound2 with null-device
+        (void)mute;
+        return RESULT_OK;
+    }
+
+    Result ToggleMasterMute()
+    {
+        // NOTE: Not supported.
+        // sound_null is deprecated and should be replaced by sound2 with null-device
+        return RESULT_OK;
+    }
+
+    bool IsMasterMuted()
+    {
+        // NOTE: Not supported.
+        // sound_null is deprecated and should be replaced by sound2 with null-device
+        return false;
+    }
+
     Result GetGroupHashes(uint32_t* count, dmhash_t* buffer)
     {
         return RESULT_OK;

--- a/engine/sound/src/sound_openal.cpp
+++ b/engine/sound/src/sound_openal.cpp
@@ -991,21 +991,6 @@ namespace dmSound
         return RESULT_OK;
     }
 
-    Result SetMasterMute(bool mute)
-    {
-        return SetGroupMute(MASTER_GROUP_HASH, mute);
-    }
-
-    Result ToggleMasterMute()
-    {
-        return SetMasterMute(!IsMasterMuted());
-    }
-
-    bool IsMasterMuted()
-    {
-        return IsGroupMuted(MASTER_GROUP_HASH);
-    }
-
     static dmSoundCodec::Result GetInstanceProperties(HSoundInstance sound_instance) {
         SoundSystem* sound = g_SoundSystem;
         SoundData &sound_data = sound->m_SoundData[sound_instance->m_SoundDataIndex];

--- a/engine/sound/src/test/test_sound.cpp
+++ b/engine/sound/src/test/test_sound.cpp
@@ -2527,15 +2527,15 @@ TEST(SoundSdk, MasterMuteUpdatesGroupGain)
     float master_gain = 0.0f;
     ASSERT_EQ(dmSound::RESULT_OK, dmSound::GetGroupGain(master_hash, &master_gain));
     EXPECT_NEAR(1.0f, master_gain, 1e-6f);
-    EXPECT_FALSE(dmSound::IsMasterMuted());
+    EXPECT_FALSE(dmSound::IsGroupMuted(master_hash));
 
-    EXPECT_EQ(dmSound::RESULT_OK, dmSound::SetMasterMute(true));
-    EXPECT_TRUE(dmSound::IsMasterMuted());
+    EXPECT_EQ(dmSound::RESULT_OK, dmSound::SetGroupMute(master_hash, true));
+    EXPECT_TRUE(dmSound::IsGroupMuted(master_hash));
     ASSERT_EQ(dmSound::RESULT_OK, dmSound::GetGroupGain(master_hash, &master_gain));
     EXPECT_NEAR(0.0f, master_gain, 1e-6f);
 
-    EXPECT_EQ(dmSound::RESULT_OK, dmSound::ToggleMasterMute());
-    EXPECT_FALSE(dmSound::IsMasterMuted());
+    EXPECT_EQ(dmSound::RESULT_OK, dmSound::ToggleGroupMute(master_hash));
+    EXPECT_FALSE(dmSound::IsGroupMuted(master_hash));
     ASSERT_EQ(dmSound::RESULT_OK, dmSound::GetGroupGain(master_hash, &master_gain));
     EXPECT_NEAR(1.0f, master_gain, 1e-6f);
 
@@ -2555,10 +2555,10 @@ TEST(SoundSdk, MasterMuteRestoresPreviousGain)
     const dmhash_t master_hash = dmHashString64("master");
     ASSERT_EQ(dmSound::RESULT_OK, dmSound::SetGroupGain(master_hash, 0.35f));
 
-    EXPECT_EQ(dmSound::RESULT_OK, dmSound::SetMasterMute(true));
-    EXPECT_TRUE(dmSound::IsMasterMuted());
-    EXPECT_EQ(dmSound::RESULT_OK, dmSound::SetMasterMute(false));
-    EXPECT_FALSE(dmSound::IsMasterMuted());
+    EXPECT_EQ(dmSound::RESULT_OK, dmSound::SetGroupMute(master_hash, true));
+    EXPECT_TRUE(dmSound::IsGroupMuted(master_hash));
+    EXPECT_EQ(dmSound::RESULT_OK, dmSound::SetGroupMute(master_hash, false));
+    EXPECT_FALSE(dmSound::IsGroupMuted(master_hash));
 
     float master_gain = 0.0f;
     ASSERT_EQ(dmSound::RESULT_OK, dmSound::GetGroupGain(master_hash, &master_gain));

--- a/engine/sound/src/test/test_sound.cpp
+++ b/engine/sound/src/test/test_sound.cpp
@@ -2513,7 +2513,7 @@ const TestParams params_starttime_play_test[] = {
 INSTANTIATE_TEST_CASE_P(dmSoundTestStartTimePlayTest, dmSoundTestStartTimePlayTest, jc_test_values_in(params_starttime_play_test));
 #endif
 
-TEST(SoundSdk, MasterMuteUpdatesGroupGain)
+TEST(SoundSdk, MasterMuteSilencesWithoutChangingGain)
 {
     dmSound::InitializeParams params;
     dmSound::SetDefaultInitializeParams(&params);
@@ -2567,7 +2567,7 @@ TEST(SoundSdk, MasterMuteRestoresPreviousGain)
     ASSERT_EQ(dmSound::RESULT_OK, dmSound::Finalize());
 }
 
-TEST(SoundSdk, GroupMuteRestoresPreviousGain)
+TEST(SoundSdk, GroupMuteSilencesWithoutChangingGain)
 {
     dmSound::InitializeParams params;
     dmSound::SetDefaultInitializeParams(&params);
@@ -2595,7 +2595,7 @@ TEST(SoundSdk, GroupMuteRestoresPreviousGain)
     ASSERT_EQ(dmSound::RESULT_OK, dmSound::Finalize());
 }
 
-TEST(SoundSdk, GroupMuteDefaultsToUnityGain)
+TEST(SoundSdk, GroupMuteDefaultsToUnityGainWhenMuted)
 {
     dmSound::InitializeParams params;
     dmSound::SetDefaultInitializeParams(&params);

--- a/engine/sound/src/test/test_sound.cpp
+++ b/engine/sound/src/test/test_sound.cpp
@@ -2532,7 +2532,7 @@ TEST(SoundSdk, MasterMuteUpdatesGroupGain)
     EXPECT_EQ(dmSound::RESULT_OK, dmSound::SetGroupMute(master_hash, true));
     EXPECT_TRUE(dmSound::IsGroupMuted(master_hash));
     ASSERT_EQ(dmSound::RESULT_OK, dmSound::GetGroupGain(master_hash, &master_gain));
-    EXPECT_NEAR(0.0f, master_gain, 1e-6f);
+    EXPECT_NEAR(1.0f, master_gain, 1e-6f);
 
     EXPECT_EQ(dmSound::RESULT_OK, dmSound::ToggleGroupMute(master_hash));
     EXPECT_FALSE(dmSound::IsGroupMuted(master_hash));
@@ -2584,7 +2584,7 @@ TEST(SoundSdk, GroupMuteRestoresPreviousGain)
     EXPECT_EQ(dmSound::RESULT_OK, dmSound::SetGroupMute(group_hash, true));
     float gain = 1.0f;
     ASSERT_EQ(dmSound::RESULT_OK, dmSound::GetGroupGain(group_hash, &gain));
-    EXPECT_NEAR(0.0f, gain, 1e-6f);
+    EXPECT_NEAR(0.25f, gain, 1e-6f);
     EXPECT_TRUE(dmSound::IsGroupMuted(group_hash));
 
     EXPECT_EQ(dmSound::RESULT_OK, dmSound::SetGroupMute(group_hash, false));
@@ -2612,7 +2612,7 @@ TEST(SoundSdk, GroupMuteDefaultsToUnityGain)
     EXPECT_EQ(dmSound::RESULT_OK, dmSound::SetGroupMute(group_hash, false));
     float gain = 0.0f;
     ASSERT_EQ(dmSound::RESULT_OK, dmSound::GetGroupGain(group_hash, &gain));
-    EXPECT_NEAR(1.0f, gain, 1e-6f);
+    EXPECT_NEAR(0.0f, gain, 1e-6f);
     EXPECT_FALSE(dmSound::IsGroupMuted(group_hash));
 
     ASSERT_EQ(dmSound::RESULT_OK, dmSound::Finalize());

--- a/engine/sound/src/wscript
+++ b/engine/sound/src/wscript
@@ -30,7 +30,7 @@ def build(bld):
         source += ['sound_generic.cpp']
 
     source_openal = source.copy()
-    source_openal += ['sound.cpp', 'sound_openal.cpp', 'devices/device_openal.cpp']
+    source_openal += ['sound_openal.cpp', 'devices/device_openal.cpp']
 
     source += ['sound.cpp']
 
@@ -131,7 +131,6 @@ def build(bld):
                            source   = source_null)
 
     bld.install_files('${PREFIX}/include/sound', 'sound.h')
-    dmsdk_add_files(bld, '${PREFIX}/sdk/include/dmsdk', 'dmsdk')
 
     if sys.platform == 'win32':
         #NOTE: _XBOX to get static lib and avoid dllimport/dllexport stuff

--- a/engine/sound/src/wscript
+++ b/engine/sound/src/wscript
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 import os, sys, re
 import waflib.Options
+from waf_dynamo import dmsdk_add_files
 
 def configure(conf):
     pass
@@ -29,7 +30,7 @@ def build(bld):
         source += ['sound_generic.cpp']
 
     source_openal = source.copy()
-    source_openal += ['sound_openal.cpp', 'devices/device_openal.cpp']
+    source_openal += ['sound.cpp', 'sound_openal.cpp', 'devices/device_openal.cpp']
 
     source += ['sound.cpp']
 
@@ -130,6 +131,7 @@ def build(bld):
                            source   = source_null)
 
     bld.install_files('${PREFIX}/include/sound', 'sound.h')
+    dmsdk_add_files(bld, '${PREFIX}/sdk/include/dmsdk', 'dmsdk')
 
     if sys.platform == 'win32':
         #NOTE: _XBOX to get static lib and avoid dllimport/dllexport stuff

--- a/engine/sound/src/wscript
+++ b/engine/sound/src/wscript
@@ -131,6 +131,7 @@ def build(bld):
                            source   = source_null)
 
     bld.install_files('${PREFIX}/include/sound', 'sound.h')
+    dmsdk_add_files(bld, '${PREFIX}/sdk/include/dmsdk', 'dmsdk')
 
     if sys.platform == 'win32':
         #NOTE: _XBOX to get static lib and avoid dllimport/dllexport stuff


### PR DESCRIPTION
Add functionality to mute sound groups from extensions.

Fixes #8763 

### Technical changes
- Expose sound muting functions to dmsdk
- Support both muting master and individual sound groups