### PR TITLE
Make sure we unpack lib folder before calling any android tools

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/tools/AndroidTools.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/tools/AndroidTools.java
@@ -58,6 +58,7 @@ public class AndroidTools {
      * @return The result
      */
     public static Result exec(List<String> args) throws IOException {
+        init();
         logger.info("exec: " + String.join(" ", args));
         Map<String, String> env = new HashMap<String, String>();
         if (Platform.getHostPlatform() == Platform.X86_64Linux || Platform.getHostPlatform() == Platform.Arm64Linux) {


### PR DESCRIPTION
We used to unpack everything before using tools, but it's been changed during the last refactoring:
<img width="1124" height="1186" alt="CleanShot 2025-10-28 at 15 21 58@2x" src="https://github.com/user-attachments/assets/e1cb8081-e583-48b1-b6f3-70e0ed13b034" />

Fix https://github.com/defold/defold/issues/11423