### PR TITLE
Make sure ASTC used in maximum possible cases in HTML5 bundle

### DIFF
--- a/engine/gamesys/src/gamesys/resources/res_texture.cpp
+++ b/engine/gamesys/src/gamesys/resources/res_texture.cpp
@@ -189,7 +189,8 @@ namespace dmGameSystem
             if (dmGraphics::IsFormatTranscoded(image->m_CompressionType))
             {
                 num_mips = MAX_MIPMAP_COUNT;
-                output_format = dmGraphics::GetSupportedCompressionFormat(context, output_format, image->m_Width, image->m_Height);
+                dmGraphics::TextureType texture_type = TextureImageToTextureType(image_desc->m_DDFImage->m_Type);
+                output_format = dmGraphics::GetSupportedCompressionFormatForType(context, output_format, image->m_Width, image->m_Height, texture_type);
 
                 if (!dmGraphics::Transcode(path, image, image_desc->m_DDFImage->m_Count, image_data_alternative, output_format, image_desc->m_DecompressedData, image_desc->m_DecompressedDataSize, &num_mips))
                 {
@@ -198,7 +199,7 @@ namespace dmGameSystem
                 }
             }
 
-            if (!dmGraphics::IsTextureFormatSupported(context, output_format))
+            if (!dmGraphics::IsTextureFormatSupportedForType(context, TextureImageToTextureType(image_desc->m_DDFImage->m_Type), output_format))
             {
                 continue;
             }

--- a/engine/gamesys/src/gamesys/scripts/script_resource.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_resource.cpp
@@ -21,6 +21,7 @@
 #include <gamesys/mesh_ddf.h>
 #include <gamesys/texture_set_ddf.h>
 #include <graphics/graphics_ddf.h>
+#include <graphics/graphics.h>
 #include <render/font_renderer.h>
 #include <resource/resource.h>
 #include <resource/resource_util.h>
@@ -651,7 +652,7 @@ static int CheckCreateTextureResourceParams(lua_State* L, CreateTextureResourceP
     dmGraphics::TextureImage::Type tex_type            = GraphicsTextureTypeToImageType(type);
     dmGraphics::TextureImage::TextureFormat tex_format = GraphicsTextureFormatToImageFormat(format);
 
-    if (!dmGraphics::IsTextureFormatSupported(g_ResourceModule.m_GraphicsContext, format))
+    if (!dmGraphics::IsTextureFormatSupportedForType(g_ResourceModule.m_GraphicsContext, type, format))
     {
         return luaL_error(L, "Unable to set texture, unsupported texture format '%s'.", dmGraphics::GetTextureFormatLiteral(format));
     }
@@ -1208,7 +1209,7 @@ static int CreateTextureAsync(lua_State* L)
         assert(create_params.m_Buffer != 0);
 
         uint32_t num_mips = 1;
-        texture_params.m_Format = dmGraphics::GetSupportedCompressionFormat(g_ResourceModule.m_GraphicsContext, texture_params.m_Format, texture_params.m_Width, texture_params.m_Height);
+        texture_params.m_Format = dmGraphics::GetSupportedCompressionFormatForType(g_ResourceModule.m_GraphicsContext, texture_params.m_Format, texture_params.m_Width, texture_params.m_Height, create_params.m_Type);
 
         uint8_t* decompressed_data;
         uint32_t decompressed_data_size;
@@ -1507,7 +1508,7 @@ static int SetTexture(lua_State* L)
     int32_t y                        = (int32_t)  CheckTableInteger(L, 2, "y", DEFAULT_INT_NOT_SET);
     int32_t z                        = (int32_t)  CheckTableInteger(L, 2, "z", DEFAULT_INT_NOT_SET);
 
-    if (!dmGraphics::IsTextureFormatSupported(g_ResourceModule.m_GraphicsContext, format))
+    if (!dmGraphics::IsTextureFormatSupportedForType(g_ResourceModule.m_GraphicsContext, type, format))
     {
         return luaL_error(L, "Unable to set texture, unsupported texture format '%s'.", dmGraphics::GetTextureFormatLiteral(format));
     }

--- a/engine/graphics/src/graphics.cpp
+++ b/engine/graphics/src/graphics.cpp
@@ -674,6 +674,16 @@ namespace dmGraphics
                format == TEXTURE_FORMAT_RGBA_ASTC_12X12;
     }
 
+    bool IsTextureFormatSupportedForType(HContext context, TextureType type, TextureFormat format)
+    {
+        if (type == TEXTURE_TYPE_2D_ARRAY && IsTextureFormatASTC(format))
+        {
+            if (!IsContextFeatureSupported(context, CONTEXT_FEATURE_ASTC_ARRAY_TEXTURES))
+                return false;
+        }
+        return IsTextureFormatSupported(context, format);
+    }
+
     // For estimating resource size
     uint32_t GetTextureFormatBitsPerPixel(TextureFormat format)
     {
@@ -893,14 +903,15 @@ namespace dmGraphics
 
     // The goal is to find a supported compression format, since they're smaller than the uncompressed ones
     // The user can also choose RGB(a) 16BPP as the fallback if they wish to have smaller size than full RGB(a)
-    dmGraphics::TextureFormat GetSupportedCompressionFormat(dmGraphics::HContext context, dmGraphics::TextureFormat format, uint32_t width, uint32_t height)
+    dmGraphics::TextureFormat GetSupportedCompressionFormatForType(dmGraphics::HContext context, dmGraphics::TextureFormat format, uint32_t width, uint32_t height, TextureType type)
     {
         #define TEST_AND_RETURN(_TYPEN_ENUM) if (dmGraphics::IsTextureFormatSupported(context, (_TYPEN_ENUM))) return (_TYPEN_ENUM);
+        #define TEST_AND_RETURN_FOR_TYPE(_TYPEN_ENUM) if (dmGraphics::IsTextureFormatSupportedForType(context, type, (_TYPEN_ENUM))) return (_TYPEN_ENUM);
 
         if (IsFormatRGBA(format))
         {
             TEST_AND_RETURN(dmGraphics::TEXTURE_FORMAT_RGBA_BC7);
-            TEST_AND_RETURN(dmGraphics::TEXTURE_FORMAT_RGBA_ASTC_4X4);
+            TEST_AND_RETURN_FOR_TYPE(dmGraphics::TEXTURE_FORMAT_RGBA_ASTC_4X4);
             TEST_AND_RETURN(dmGraphics::TEXTURE_FORMAT_RGBA_ETC2);
             if (width == height) {
                 TEST_AND_RETURN(dmGraphics::TEXTURE_FORMAT_RGBA_PVRTC_4BPPV1);
@@ -937,7 +948,13 @@ namespace dmGraphics
         }
 
         #undef TEST_AND_RETURN
+        #undef TEST_AND_RETURN_FOR_TYPE
         return format;
+    }
+
+    dmGraphics::TextureFormat GetSupportedCompressionFormat(dmGraphics::HContext context, dmGraphics::TextureFormat format, uint32_t width, uint32_t height)
+    {
+        return GetSupportedCompressionFormatForType(context, format, width, height, TEXTURE_TYPE_2D);
     }
 
     void SetPipelineStateValue(dmGraphics::PipelineState& pipeline_state, State state, uint8_t value)

--- a/engine/graphics/src/graphics.cpp
+++ b/engine/graphics/src/graphics.cpp
@@ -676,10 +676,12 @@ namespace dmGraphics
 
     bool IsTextureFormatSupportedForType(HContext context, TextureType type, TextureFormat format)
     {
-        if (type == TEXTURE_TYPE_2D_ARRAY && IsTextureFormatASTC(format))
+        if ((type == TEXTURE_TYPE_2D_ARRAY || type == TEXTURE_TYPE_3D) && IsTextureFormatASTC(format))
         {
             if (!IsContextFeatureSupported(context, CONTEXT_FEATURE_ASTC_ARRAY_TEXTURES))
+            {
                 return false;
+            }
         }
         return IsTextureFormatSupported(context, format);
     }

--- a/engine/graphics/src/graphics.h
+++ b/engine/graphics/src/graphics.h
@@ -103,6 +103,9 @@ namespace dmGraphics
         CONTEXT_FEATURE_VSYNC                  = 4,
         CONTEXT_FEATURE_INSTANCING             = 5,
         CONTEXT_FEATURE_3D_TEXTURES            = 6,
+        // ASTC for 2D array textures (paged atlases). Some WebGL/GLES drivers
+        // fail array texture ASTC uploads while 2D ASTC works.
+        CONTEXT_FEATURE_ASTC_ARRAY_TEXTURES    = 7,
     };
 
     // Translation table to translate RenderTargetAttachment to BufferType
@@ -420,6 +423,9 @@ namespace dmGraphics
     BufferType    GetBufferTypeFromIndex(uint32_t index);
     const char*   GetBufferTypeLiteral(BufferType buffer_type);
     bool          IsContextFeatureSupported(HContext context, ContextFeature feature);
+
+    bool          IsTextureFormatSupportedForType(HContext context, TextureType type, TextureFormat format);
+    TextureFormat GetSupportedCompressionFormatForType(HContext context, TextureFormat format, uint32_t width, uint32_t height, TextureType type);
 
     TextureFormat GetSupportedCompressionFormat(HContext context, TextureFormat format, uint32_t width, uint32_t height);
 

--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -815,6 +815,7 @@ static void LogFrameBufferError(GLenum status)
             case CONTEXT_FEATURE_STORAGE_BUFFER:         return context->m_StorageBufferSupport;
             case CONTEXT_FEATURE_INSTANCING:             return context->m_InstancingSupport;
             case CONTEXT_FEATURE_3D_TEXTURES:            return context->m_3DTextureSupport;
+            case CONTEXT_FEATURE_ASTC_ARRAY_TEXTURES:    return context->m_ASTCArrayTextureSupport;
             case CONTEXT_FEATURE_VSYNC:
                 break;
         }
@@ -1280,6 +1281,7 @@ static void LogFrameBufferError(GLenum status)
             OpenGLIsExtensionSupported(context, "WEBGL_compressed_texture_astc"))
         {
             context->m_ASTCSupport = 1;
+            context->m_ASTCArrayTextureSupport = 1;
         }
 
         // Check if we're using a recent enough OpenGL version
@@ -1353,7 +1355,8 @@ static void LogFrameBufferError(GLenum status)
                 GLint err = glGetError();
                 if (err != 0)
                 {
-                    context->m_ASTCSupport = 0;
+                    // Only disable ASTC for array textures; keep 2D ASTC enabled
+                    context->m_ASTCArrayTextureSupport = 0;
                     isPagedASTCSupported = false;
                 }
                 glDeleteTextures(1, &texture);
@@ -1362,9 +1365,11 @@ static void LogFrameBufferError(GLenum status)
             for (int i = 0; i < iNumCompressedFormats; i++)
             {
                 // If 4x4 is supported, all ASTC formats should be supported.
-                if (isPagedASTCSupported && pCompressedFormats[i] == DMGRAPHICS_TEXTURE_FORMAT_RGBA_ASTC_4x4_KHR)
+                if (pCompressedFormats[i] == DMGRAPHICS_TEXTURE_FORMAT_RGBA_ASTC_4x4_KHR)
                 {
                     context->m_ASTCSupport = 1;
+                    if (isPagedASTCSupported)
+                        context->m_ASTCArrayTextureSupport = 1;
                 }
                 else 
                 {

--- a/engine/graphics/src/opengl/graphics_opengl_private.h
+++ b/engine/graphics/src/opengl/graphics_opengl_private.h
@@ -191,6 +191,11 @@ namespace dmGraphics
         uint32_t                m_StorageBufferSupport             : 1;
         uint32_t                m_InstancingSupport                : 1;
         uint32_t                m_ASTCSupport                      : 1;
+        // ASTC for 2D array textures (paged atlases). Some HTML5/GLES drivers
+        // fail on ASTC uploads for array targets even if 2D works. This flag
+        // allows us to disable ASTC only for array textures without disabling
+        // ASTC entirely.
+        uint32_t                m_ASTCArrayTextureSupport          : 1;
         uint32_t                m_3DTextureSupport                 : 1;
     };
 }

--- a/engine/graphics/src/vulkan/graphics_vulkan.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan.cpp
@@ -1012,6 +1012,7 @@ namespace dmGraphics
         if (context->m_PhysicalDevice.m_Features.textureCompressionASTC_LDR)
         {
             context->m_ASTCSupport = 1;
+            context->m_ASTCArrayTextureSupport = 1;
         }
 
         TextureFormat texture_formats[] = { TEXTURE_FORMAT_LUMINANCE,

--- a/engine/graphics/src/vulkan/graphics_vulkan_private.h
+++ b/engine/graphics/src/vulkan/graphics_vulkan_private.h
@@ -456,6 +456,8 @@ namespace dmGraphics
         uint32_t                        m_UseValidationLayers  : 1;
         uint32_t                        m_RenderDocSupport     : 1;
         uint32_t                        m_ASTCSupport          : 1;
+        // See OpenGL backend: separate flag for ASTC array textures
+        uint32_t                        m_ASTCArrayTextureSupport : 1;
         uint32_t                        m_AsyncProcessingSupport : 1;
     };
 


### PR DESCRIPTION
[Because of a Chromium-side issue](https://issues.chromium.org/issues/434983812), Defold uses a workaround that disables ASTC compression when the issue is detected, falling back to ETC2 - which offers lower visual quality.  

This update narrows the fallback to ETC2 so it only applies to **paged atlases** in affected cases.  
As a result, single-paged atlases now use ASTC for maximum texture quality, while multi-paged atlases remain visible even on devices impacted by the Chromium problem.  

Fix https://github.com/defold/defold/issues/11416