### PR TITLE
Fix exceptions from removed nodes when getting overridden properties

### DIFF
--- a/editor/src/clj/dynamo/graph.clj
+++ b/editor/src/clj/dynamo/graph.clj
@@ -1654,14 +1654,15 @@
   "Returns a map of overridden prop-keywords to property values. Values will be
   produced by property value functions if possible."
   [node-id {:keys [basis] :as evaluation-context}]
-  (let [node (node-by-id basis node-id)
-        node-type (gt/node-type node)]
-    (into {}
-          (map (fn [[prop-kw raw-prop-value]]
-                 [prop-kw (if (has-property? node-type prop-kw)
-                            (in/node-value node prop-kw evaluation-context)
-                            raw-prop-value)]))
-          (in/node-value node :_overridden-properties evaluation-context))))
+  (if-let [node (node-by-id basis node-id)]
+    (let [node-type (gt/node-type node)]
+      (into {}
+            (map (fn [[prop-kw raw-prop-value]]
+                   [prop-kw (if (has-property? node-type prop-kw)
+                              (in/node-value node prop-kw evaluation-context)
+                              raw-prop-value)]))
+            (in/node-value node :_overridden-properties evaluation-context)))
+    {}))
 
 (defn collect-overridden-properties
   "Collects overridden property values from override nodes originating from the


### PR DESCRIPTION
Fixes #11452

### Technical changes
* The `g/overridden-properties` function will now return an empty map if the specified `node-id` can't be found in the graph. This behavior of being resilient against non-existing `node-ids` is consistent with other functions in the `dynamo.graph` namespace.