### PR TITLE
CMake adds AGL, breaks Tahoe engine builds

### DIFF
--- a/scripts/cmake/functions_opengl.cmake
+++ b/scripts/cmake/functions_opengl.cmake
@@ -33,7 +33,7 @@ function(defold_target_link_opengl target platform)
     elseif(_PLAT_OS STREQUAL "macos")
         # macOS frameworks
         target_link_libraries(${target} ${DOGL_SCOPE}
-            "-framework OpenGL" "-framework AGL")
+            "-framework OpenGL")
 
     elseif(_PLAT_OS STREQUAL "ios")
         # iOS uses OpenGLES


### PR DESCRIPTION
CMake script adds dependency on AGL. Removed it to be able to build engine on Tahoe.