### PR TITLE
Editor: Restored tabs right-click context menuu bug fixed

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -2268,10 +2268,10 @@
                                            resource-type view-type make-view-fn active-tab-pane-tabs opts)))
                  view-id (ui/user-data tab ::view)]
              (.select (.getSelectionModel (.getTabPane tab)) tab)
+             (when (or (nil? existing-tab) (:select-node opts))
+               (g/transact
+                (select app-view resource-node [(:select-node opts resource-node)])))
              (when (not (:ignore-refresh-layout opts))
-               (when (or (nil? existing-tab) (:select-node opts))
-                 (g/transact
-                   (select app-view resource-node [(:select-node opts resource-node)])))
                (when-let [focus (:focus-fn view-type)]
                  (ui/force-scene-layout! (g/node-value app-view :scene))
                  (focus view-id opts))


### PR DESCRIPTION
This PR moves a selection process that syncs some state so that the context menu doesn't fail

Fixes #11467