### PR TITLE
Move the start_success to postRun to avoid success indicator if main fails

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/resources/jsweb/dmloader.js
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/resources/jsweb/dmloader.js
@@ -1233,6 +1233,15 @@ var Module = {
         } else if (Module['isDMFSSupported']) {
             // kick off the content download now that we have FS access
             GameArchiveLoader.downloadContent();
+            GameArchiveLoader.addArchiveLoadedListener(() => {
+                if (typeof CUSTOM_PARAMETERS["start_success"] === "function") {
+                    CUSTOM_PARAMETERS["start_success"]();
+                }
+            });
+            return;
+        }
+        if (typeof CUSTOM_PARAMETERS["start_success"] === "function") {
+            CUSTOM_PARAMETERS["start_success"]();
         }
     }],
 
@@ -1255,10 +1264,10 @@ var Module = {
         if (!Module._isMainCalled) {
             Module._isMainCalled = true;
             ProgressView.removeProgress();
-            if (typeof CUSTOM_PARAMETERS["start_success"] === "function") {
-                CUSTOM_PARAMETERS["start_success"]();
-            }
             if (Module.callMain === undefined) {
+                if (typeof CUSTOM_PARAMETERS["start_error"] === "function") {
+                    CUSTOM_PARAMETERS["start_error"](new Error("Unable to find main function"));
+                }
                 Module.noInitialRun = false;
             } else {
                 Module.callMain(Module.arguments);


### PR DESCRIPTION
We've had errors where running wasm entry point has failed, so better to not indicate success until we can get past that.