### PR TITLE
Add Move Step tab with regular and Shift move step options

### DIFF
--- a/editor/resources/localization/en.editor_localization
+++ b/editor/resources/localization/en.editor_localization
@@ -507,7 +507,7 @@ prefs.tab.general = General
 prefs.tab.code = Code
 prefs.tab.extensions = Extensions
 prefs.tab.tools = Tools
-prefs.tab.move-step = MoveStep
+prefs.tab.move-step = Move Step
 prefs.tab.dev = Dev
 prefs.tab.keymap = Keymap
 
@@ -549,7 +549,7 @@ prefs.help.tools.ios-deploy-path = Path to ios-deploy command that might be used
 
 # MoveStep tab
 prefs.label.move-step.move-step = Move Step
-prefs.label.move-step.fine-move-step = Fine Move Step
+prefs.label.move-step.fine-move-step = Shift move step
 
 # Dev tab
 prefs.label.dev.custom-engine = Custom Engine

--- a/editor/resources/localization/en.editor_localization
+++ b/editor/resources/localization/en.editor_localization
@@ -507,6 +507,7 @@ prefs.tab.general = General
 prefs.tab.code = Code
 prefs.tab.extensions = Extensions
 prefs.tab.tools = Tools
+prefs.tab.move-step = MoveStep
 prefs.tab.dev = Dev
 prefs.tab.keymap = Keymap
 
@@ -545,6 +546,10 @@ prefs.label.tools.adb-path = ADB path
 prefs.help.tools.adb-path = Path to ADB command that might be used to install and launch the Android app when it's bundled
 prefs.label.tools.ios-deploy-path = ios-deploy path
 prefs.help.tools.ios-deploy-path = Path to ios-deploy command that might be used to install and launch iOS app when it's bundled
+
+# MoveStep tab
+prefs.label.move-step.move-step = Move Step
+prefs.label.move-step.fine-move-step = Fine Move Step
 
 # Dev tab
 prefs.label.dev.custom-engine = Custom Engine

--- a/editor/src/clj/editor/prefs.clj
+++ b/editor/src/clj/editor/prefs.clj
@@ -122,8 +122,8 @@
 
   :move-step {:type :object
             :properties
-            {:move-step {:type :number :default 10.0}
-             :fine-move-step {:type :number :default 1.0}}}
+            {:move-step {:type :string :default "10"}
+             :fine-move-step {:type :string :default "1"}}}
 
     :extensions {:type :object
                  :properties

--- a/editor/src/clj/editor/prefs.clj
+++ b/editor/src/clj/editor/prefs.clj
@@ -119,6 +119,12 @@
             :properties
             {:adb-path {:type :string}
              :ios-deploy-path {:type :string}}}
+
+  :move-step {:type :object
+            :properties
+            {:move-step {:type :number :default 10.0}
+             :fine-move-step {:type :number :default 1.0}}}
+
     :extensions {:type :object
                  :properties
                  {:build-server {:type :string
@@ -863,7 +869,10 @@
      "scene-move-whole-pixels?" [:scene :move-whole-pixels]
      "dev-custom-engine" [:dev :custom-engine]
      "open-project-directory" [:welcome :last-opened-project-directory]
-     "recent-project-entries" [:welcome :recent-projects]}))
+     "recent-project-entries" [:welcome :recent-projects]
+     "move-step" [:move-step :move-step]
+     "fine-move-step" [:move-step :fine-move-step]
+     }))
 
 (defn migrate-project-prefs!
   "Migrate project prefs from the old prefs storage
@@ -920,5 +929,3 @@
                                       "instance-count" [:run :instance-count]
                                       "simulate-rotated-device" [:run :simulate-rotated-device]
                                       "simulated-resolution" [:run :simulated-resolution]})))))
-
-;; end region

--- a/editor/src/clj/editor/prefs_dialog.clj
+++ b/editor/src/clj/editor/prefs_dialog.clj
@@ -81,7 +81,11 @@
                 [:extensions :build-server-headers]]}
        {:pattern (localization/message "prefs.tab.tools")
         :paths [[:tools :adb-path]
-                [:tools :ios-deploy-path]]}]
+                [:tools :ios-deploy-path]]}
+                
+        {:pattern (localization/message "prefs.tab.move-step")
+        :paths [[:move-step :move-step]
+                [:move-step :fine-move-step]]}]
 
       (system/defold-dev?)
       (conj {:pattern (localization/message "prefs.tab.dev")

--- a/editor/src/clj/editor/scene_tools.clj
+++ b/editor/src/clj/editor/scene_tools.clj
@@ -580,12 +580,14 @@
 (defn move-snap-fn [prefs]
   (if (move-whole-pixels? prefs)
     (fn [^Vector3d v]
-      (let [factor (if (:shift *current-action*) (prefs/get prefs [:move-step :move-step]) (prefs/get prefs [:move-step :fine-move-step]))]
+      (let [factor-raw (if (:shift *current-action*)
+                         (prefs/get prefs [:move-step :fine-move-step])
+                         (prefs/get prefs [:move-step :move-step]))
+            f (try (Double/parseDouble (str factor-raw)) (catch Exception _ 1.0))
+            factor (if (pos? f) (/ 1.0 f) 1.0)]
         (snap-vector v factor)))
     identity))
 
-
-    
 
 (g/defnk produce-manip-opts [prefs]
   {:move-snap-fn (move-snap-fn prefs)})

--- a/editor/src/clj/editor/scene_tools.clj
+++ b/editor/src/clj/editor/scene_tools.clj
@@ -32,6 +32,8 @@
 
 (set! *warn-on-reflection* true)
 
+(def ^:dynamic *current-action* nil)
+
 (defmulti manip-movable? (fn [node-id] (g/node-type-kw node-id)))
 (defmethod manip-movable? :default [_] false)
 (defmulti manip-move (fn [evaluation-context node-id ^Vector3d delta]
@@ -498,7 +500,8 @@
     (let [proj-fn (manip->project-fn manip camera viewport)
           apply-fn (manip->apply-fn manip-opts evaluation-context manip manip-origin original-values)
           [start-pos pos] (map #(action->manip-pos % lead-transform manip manip-rotation proj-fn) [start-action action])]
-      (apply-fn start-pos pos))))
+      (binding [*current-action* action]
+        (apply-fn start-pos pos)))))
 
 (def ^:private original-values #(select-keys % [:node-id :world-rotation :world-transform :parent-world-transform]))
 
@@ -566,10 +569,23 @@
   {:pre [(boolean? enabled)]}
   (prefs/set! prefs [:scene :move-whole-pixels] enabled))
 
+(defn- snap-component ^double [^double value ^double factor]
+  (/ (double (Math/round (* value factor))) factor))
+
+(defn- snap-vector [^Vector3d v ^double factor]
+  (Vector3d. (snap-component (.x v) factor)
+             (snap-component (.y v) factor)
+             (snap-component (.z v) factor)))
+
 (defn move-snap-fn [prefs]
   (if (move-whole-pixels? prefs)
-    math/round-vector
+    (fn [^Vector3d v]
+      (let [factor (if (:shift *current-action*) (prefs/get prefs [:move-step :move-step]) (prefs/get prefs [:move-step :fine-move-step]))]
+        (snap-vector v factor)))
     identity))
+
+
+    
 
 (g/defnk produce-manip-opts [prefs]
   {:move-snap-fn (move-snap-fn prefs)})


### PR DESCRIPTION
This pull request introduces a new "Move Step" tab in the Editor preferences.

Users can now configure two separate movement step values:
* Regular move step – used for standard object movement.
* Shift move step – used when holding the Shift key to move objects with a different step size.

This feature improves precision and flexibility when positioning objects in the scene.

https://github.com/user-attachments/assets/1a2c0215-1098-4ed4-8eb4-7f718f62ecd3

