### PR TITLE
Fix editor exception when double-clicking on a Build Error from a resource with an empty Outline 

### DIFF
--- a/editor/src/clj/editor/build_errors_view.clj
+++ b/editor/src/clj/editor/build_errors_view.clj
@@ -204,15 +204,20 @@
      :style style}))
 
 (defn- find-outline-node [resource-node-id error-node-id]
-  (if-not (g/node-instance? outline/OutlineNode error-node-id)
-    resource-node-id
-    (some (fn [{:keys [node-id] :as node-outline}]
-            (when (or (= error-node-id node-id)
-                      (= error-node-id (:node-id (:alt-outline node-outline))))
-              node-id))
-          (tree-seq (comp sequential? :children)
-                    :children
-                    (g/node-value resource-node-id :node-outline)))))
+  (or (when error-node-id
+        (g/with-auto-evaluation-context evaluation-context
+          (let [basis (:basis evaluation-context)
+                error-node (g/node-by-id-at basis error-node-id)]
+            (when (and (some? error-node)
+                       (g/node-instance*? outline/OutlineNode error-node))
+              (some (fn [{:keys [node-id] :as node-outline}]
+                      (when (or (= error-node-id node-id)
+                                (= error-node-id (:node-id (:alt-outline node-outline))))
+                        node-id))
+                    (tree-seq (comp sequential? :children)
+                              :children
+                              (g/node-value resource-node-id :node-outline evaluation-context)))))))
+      resource-node-id))
 
 (defn error-item-open-info
   "Returns data describing how an error should be opened when double-clicked.

--- a/editor/src/clj/editor/tile_source.clj
+++ b/editor/src/clj/editor/tile_source.clj
@@ -342,12 +342,13 @@
   (input anim-data g/Any)
   (input gpu-texture g/Any)
 
-  (output node-outline outline/OutlineData :cached (g/fnk [_node-id ddf-message id tile-count]
+  (output node-outline outline/OutlineData :cached (g/fnk [_node-id ddf-message id ^:try tile-count]
                                                      {:node-id _node-id
                                                       :node-outline-key id
                                                       :label id
                                                       :icon animation-icon
-                                                      :outline-error? (some? (animation-ddf-errors tile-count _node-id ddf-message))}))
+                                                      :outline-error? (and (not (g/error-value? tile-count))
+                                                                           (some? (animation-ddf-errors tile-count _node-id ddf-message)))}))
   (output ddf-message g/Any produce-animation-ddf)
   (output animation-data g/Any (g/fnk [_node-id ddf-message] {:node-id _node-id :ddf-message ddf-message}))
   (output updatable g/Any produce-animation-updatable)


### PR DESCRIPTION
* Fixed exception in the editor if the user double-clicked a Build Error originating from a resource whose Outline view was empty after opened.
* Fixed empty Outline view for Tile Sources whose tile count couldn't be determined as a result of invalid property values. This was a regression introduced by #11442.

Fixes #11462
