### PR TITLE
Fix outline re-ordering

### DIFF
--- a/editor/src/java/com/defold/control/OutlineTreeViewSkin.java
+++ b/editor/src/java/com/defold/control/OutlineTreeViewSkin.java
@@ -1,0 +1,25 @@
+package com.defold.control;
+
+import javafx.scene.control.TreeCell;
+import javafx.scene.control.TreeView;
+import javafx.scene.control.skin.TreeViewSkin;
+import javafx.scene.control.skin.VirtualFlow;
+
+public class OutlineTreeViewSkin<T> extends TreeViewSkin<T> {
+    public OutlineTreeViewSkin(TreeView treeView) {
+        super(treeView);
+    }
+
+    public boolean shouldScrollTo(int index) {
+        VirtualFlow<TreeCell<T>> flow = getVirtualFlow();
+        TreeCell<T> firstVisibleCell = flow.getFirstVisibleCell();
+        if (firstVisibleCell == null) {
+            return false;
+        }
+        TreeCell<T> lastVisibleCell = flow.getLastVisibleCell();
+        if (lastVisibleCell == null) {
+            return false;
+        }
+        return firstVisibleCell.getIndex() > index || lastVisibleCell.getIndex() < index;
+    }
+}


### PR DESCRIPTION
We introduced a regression in 1.11.2 during the outline refactor that made re-ordering behavior erratic. Now the issue is fixed.

Fixes #11461
