### PR TITLE
Rearrange component's update

### DIFF
--- a/engine/gameobject/src/dmsdk/gameobject/component.h
+++ b/engine/gameobject/src/dmsdk/gameobject/component.h
@@ -634,6 +634,14 @@ namespace dmGameObject
      */
     void ComponentTypeSetRenderFn(HComponentType type, ComponentsRender fn);
 
+    /*# set the component pre-update callback
+     * Set the component pre-update callback. Called before regular update callback.
+     * @name ComponentTypeSetPreUpdateFn
+     * @param type [type: HComponentType] the type
+     * @param fn [type: ComponentsPreUpdate] callback
+     */
+    void ComponentTypeSetPreUpdateFn(HComponentType type, ComponentsPreUpdate fn);
+
     /*# set the component update callback
      * Set the component update callback. Called when it's time to update all component instances.
      * @name ComponentTypeSetUpdateFn

--- a/engine/gameobject/src/dmsdk/gameobject/component.h
+++ b/engine/gameobject/src/dmsdk/gameobject/component.h
@@ -298,6 +298,16 @@ namespace dmGameObject
     };
 
     /*#
+     * Component pre-update function. Run component logic before main Update and FixedUpdate (optional)
+     * @typedef
+     * @name ComponentsPreUpdate
+     * @param params [type: const dmGameObject::ComponentsUpdateParams&] Update parameters
+     * @param params [type: dmGameObject::ComponentsUpdateResult&] (out) Update result
+     * @return result [type: UpdateResult] UPDATE_RESULT_OK on success
+     */
+    typedef UpdateResult (*ComponentsPreUpdate)(const ComponentsUpdateParams& params, ComponentsUpdateResult& result);
+
+    /*#
      * Component update function. Updates all component of this type for all game objects
      * @typedef
      * @name ComponentsUpdate

--- a/engine/gameobject/src/gameobject/comp_anim.cpp
+++ b/engine/gameobject/src/gameobject/comp_anim.cpp
@@ -159,9 +159,9 @@ namespace dmGameObject
         return CREATE_RESULT_OK;
     }
 
-    UpdateResult CompAnimUpdate(const ComponentsUpdateParams& params, ComponentsUpdateResult& update_result)
+    UpdateResult CompAnimPreUpdate(const ComponentsUpdateParams& params, ComponentsUpdateResult& update_result)
     {
-        DM_PROFILE("Update");
+        DM_PROFILE("PreUpdate");
 
         /*
          * The update is divided into three passes.

--- a/engine/gameobject/src/gameobject/comp_anim.h
+++ b/engine/gameobject/src/gameobject/comp_anim.h
@@ -25,7 +25,7 @@ namespace dmGameObject
 
     CreateResult CompAnimAddToUpdate(const ComponentAddToUpdateParams& params);
 
-    UpdateResult CompAnimUpdate(const ComponentsUpdateParams& params, ComponentsUpdateResult& result);
+    UpdateResult CompAnimPreUpdate(const ComponentsUpdateParams& params, ComponentsUpdateResult& result);
 }
 
 #endif // DM_GAMEOBJECT_COMP_ANIM_H

--- a/engine/gameobject/src/gameobject/comp_script.cpp
+++ b/engine/gameobject/src/gameobject/comp_script.cpp
@@ -251,7 +251,7 @@ namespace dmGameObject
         return result;
     }
 
-    UpdateResult CompScriptUpdate(const ComponentsUpdateParams& params, ComponentsUpdateResult& update_result)
+    UpdateResult CompScriptPreUpdate(const ComponentsUpdateParams& params, ComponentsUpdateResult& update_result)
     {
         CompScriptWorld* script_world = (CompScriptWorld*)params.m_World;
         dmScript::UpdateScriptWorld(script_world->m_ScriptWorld, params.m_UpdateContext->m_DT);

--- a/engine/gameobject/src/gameobject/comp_script.h
+++ b/engine/gameobject/src/gameobject/comp_script.h
@@ -33,7 +33,7 @@ namespace dmGameObject
 
     CreateResult CompScriptAddToUpdate(const ComponentAddToUpdateParams& params);
 
-    UpdateResult CompScriptUpdate(const ComponentsUpdateParams& params, ComponentsUpdateResult& result);
+    UpdateResult CompScriptPreUpdate(const ComponentsUpdateParams& params, ComponentsUpdateResult& result);
     UpdateResult CompScriptFixedUpdate(const ComponentsUpdateParams& params, ComponentsUpdateResult& result);
 
     UpdateResult CompScriptOnMessage(const ComponentOnMessageParams& params);

--- a/engine/gameobject/src/gameobject/component.cpp
+++ b/engine/gameobject/src/gameobject/component.cpp
@@ -112,6 +112,7 @@ void ComponentTypeSetFinalFn(HComponentType type, ComponentFinal fn)            
 void ComponentTypeSetAddToUpdateFn(HComponentType type, ComponentAddToUpdate fn)            { type->m_AddToUpdateFunction = fn; }
 void ComponentTypeSetGetFn(HComponentType type, ComponentGet fn)                            { type->m_GetFunction = fn; }
 void ComponentTypeSetRenderFn(HComponentType type, ComponentsRender fn)                     { type->m_RenderFunction = fn; }
+void ComponentTypeSetPreUpdateFn(HComponentType type, ComponentsPreUpdate fn)               { type->m_PreUpdateFunction = fn; }
 void ComponentTypeSetUpdateFn(HComponentType type, ComponentsUpdate fn)                     { type->m_UpdateFunction = fn; }
 void ComponentTypeSetFixedUpdateFn(HComponentType type, ComponentsFixedUpdate fn)           { type->m_FixedUpdateFunction = fn; }
 void ComponentTypeSetPostUpdateFn(HComponentType type, ComponentsPostUpdate fn)             { type->m_PostUpdateFunction = fn; }

--- a/engine/gameobject/src/gameobject/component.h
+++ b/engine/gameobject/src/gameobject/component.h
@@ -41,6 +41,7 @@ namespace dmGameObject
         ComponentFinal          m_FinalFunction;
         ComponentAddToUpdate    m_AddToUpdateFunction;
         ComponentGet            m_GetFunction;
+        ComponentsPreUpdate     m_PreUpdateFunction;
         ComponentsUpdate        m_UpdateFunction;
         ComponentsFixedUpdate   m_FixedUpdateFunction;
         ComponentsRender        m_RenderFunction;

--- a/engine/gameobject/src/gameobject/gameobject.cpp
+++ b/engine/gameobject/src/gameobject/gameobject.cpp
@@ -661,8 +661,8 @@ namespace dmGameObject
         if (FindComponentType(regist, type.m_ResourceType, 0x0) != 0)
             return RESULT_ALREADY_REGISTERED;
 
-        if (type.m_UpdateFunction != 0x0 && type.m_AddToUpdateFunction == 0x0) {
-            dmLogWarning("Registering an Update function for '%s' requires the registration of an AddToUpdate function.", type.m_Name);
+        if ((type.m_UpdateFunction != 0x0 || type.m_PreUpdateFunction != 0x0 || type.m_FixedUpdateFunction != 0x0) && type.m_AddToUpdateFunction == 0x0) {
+            dmLogWarning("Registering an PreUpdate/Update/FixedUpdate function for '%s' requires the registration of an AddToUpdate function.", type.m_Name);
             return RESULT_INVALID_OPERATION;
         }
 
@@ -2620,13 +2620,47 @@ namespace dmGameObject
         }
 
         uint32_t component_types = collection->m_Register->m_ComponentTypeCount;
+        // pre update 
+        for (uint32_t i = 0; i < component_types; ++i)
+        {
+            uint16_t update_index = collection->m_Register->m_ComponentTypesOrder[i];
+            ComponentType* component_type = &collection->m_Register->m_ComponentTypes[update_index];
+            if (component_type->m_ReadsTransforms && collection->m_DirtyTransforms)
+            {
+                UpdateTransforms(collection);
+            }
+
+            if (component_type->m_PreUpdateFunction)
+            {
+                DM_PROFILE_DYN(component_type->m_Name, 0);
+                ComponentsUpdateParams params;
+                params.m_Collection = collection->m_HCollection;
+                params.m_UpdateContext = &dynamic_update_context;
+                params.m_World = collection->m_ComponentWorlds[update_index];
+                params.m_Context = component_type->m_Context;
+
+                ComponentsUpdateResult update_result;
+                update_result.m_TransformsUpdated = false;
+                UpdateResult res = component_type->m_PreUpdateFunction(params, update_result);
+                if (res != UPDATE_RESULT_OK)
+                {
+                    ret = false;
+                }
+
+                // Mark the collections transforms as dirty if this component has updated
+                // them in its update function.
+                collection->m_DirtyTransforms |= update_result.m_TransformsUpdated;
+            }
+        }
+        // regular update
         for (uint32_t i = 0; i < component_types; ++i)
         {
             uint16_t update_index = collection->m_Register->m_ComponentTypesOrder[i];
             ComponentType* component_type = &collection->m_Register->m_ComponentTypes[update_index];
 
             // Avoid to call UpdateTransforms for each/all component types.
-            if (component_type->m_ReadsTransforms && collection->m_DirtyTransforms) {
+            if (component_type->m_ReadsTransforms && collection->m_DirtyTransforms)
+            {
                 UpdateTransforms(collection);
             }
 
@@ -2721,7 +2755,8 @@ namespace dmGameObject
         }
 
         collection->m_InUpdate = 0;
-        if (collection->m_DirtyTransforms) {
+        if (collection->m_DirtyTransforms)
+        {
             UpdateTransforms(collection);
         }
 

--- a/engine/gameobject/src/gameobject/gameobject.cpp
+++ b/engine/gameobject/src/gameobject/gameobject.cpp
@@ -2652,43 +2652,6 @@ namespace dmGameObject
                 collection->m_DirtyTransforms |= update_result.m_TransformsUpdated;
             }
         }
-        // regular update
-        for (uint32_t i = 0; i < component_types; ++i)
-        {
-            uint16_t update_index = collection->m_Register->m_ComponentTypesOrder[i];
-            ComponentType* component_type = &collection->m_Register->m_ComponentTypes[update_index];
-
-            // Avoid to call UpdateTransforms for each/all component types.
-            if (component_type->m_ReadsTransforms && collection->m_DirtyTransforms)
-            {
-                UpdateTransforms(collection);
-            }
-
-            if (component_type->m_UpdateFunction)
-            {
-                DM_PROFILE_DYN(component_type->m_Name, 0);
-                ComponentsUpdateParams params;
-                params.m_Collection = collection->m_HCollection;
-                params.m_UpdateContext = &dynamic_update_context;
-                params.m_World = collection->m_ComponentWorlds[update_index];
-                params.m_Context = component_type->m_Context;
-
-                ComponentsUpdateResult update_result;
-                update_result.m_TransformsUpdated = false;
-                UpdateResult res = component_type->m_UpdateFunction(params, update_result);
-                if (res != UPDATE_RESULT_OK)
-                    ret = false;
-
-                // Mark the collections transforms as dirty if this component has updated
-                // them in its update function.
-                collection->m_DirtyTransforms |= update_result.m_TransformsUpdated;
-            }
-
-            if (!DispatchMessages(collection, &collection->m_ComponentSocket, 1))
-            {
-                ret = false;
-            }
-        }
 
         if (update_context->m_FixedUpdateFrequency != 0 && update_context->m_TimeScale > 0.001f)
         {
@@ -2751,6 +2714,44 @@ namespace dmGameObject
                     }
                 }
 
+            }
+        }
+
+        // regular update
+        for (uint32_t i = 0; i < component_types; ++i)
+        {
+            uint16_t update_index = collection->m_Register->m_ComponentTypesOrder[i];
+            ComponentType* component_type = &collection->m_Register->m_ComponentTypes[update_index];
+
+            // Avoid to call UpdateTransforms for each/all component types.
+            if (component_type->m_ReadsTransforms && collection->m_DirtyTransforms)
+            {
+                UpdateTransforms(collection);
+            }
+
+            if (component_type->m_UpdateFunction)
+            {
+                DM_PROFILE_DYN(component_type->m_Name, 0);
+                ComponentsUpdateParams params;
+                params.m_Collection = collection->m_HCollection;
+                params.m_UpdateContext = &dynamic_update_context;
+                params.m_World = collection->m_ComponentWorlds[update_index];
+                params.m_Context = component_type->m_Context;
+
+                ComponentsUpdateResult update_result;
+                update_result.m_TransformsUpdated = false;
+                UpdateResult res = component_type->m_UpdateFunction(params, update_result);
+                if (res != UPDATE_RESULT_OK)
+                    ret = false;
+
+                // Mark the collections transforms as dirty if this component has updated
+                // them in its update function.
+                collection->m_DirtyTransforms |= update_result.m_TransformsUpdated;
+            }
+
+            if (!DispatchMessages(collection, &collection->m_ComponentSocket, 1))
+            {
+                ret = false;
             }
         }
 

--- a/engine/gameobject/src/gameobject/gameobject_comp.cpp
+++ b/engine/gameobject/src/gameobject/gameobject_comp.cpp
@@ -34,7 +34,7 @@ namespace dmGameObject
         ComponentTypeSetInitFn(type, CompScriptInit);
         ComponentTypeSetFinalFn(type, CompScriptFinal);
         ComponentTypeSetAddToUpdateFn(type, CompScriptAddToUpdate);
-        ComponentTypeSetUpdateFn(type, CompScriptUpdate);
+        ComponentTypeSetPreUpdateFn(type, CompScriptPreUpdate);
         ComponentTypeSetFixedUpdateFn(type, CompScriptFixedUpdate);
         ComponentTypeSetOnMessageFn(type, CompScriptOnMessage);
         ComponentTypeSetOnInputFn(type, CompScriptOnInput);
@@ -54,7 +54,7 @@ namespace dmGameObject
         ComponentTypeSetNewWorldFn(type, CompAnimNewWorld);
         ComponentTypeSetDeleteWorldFn(type, CompAnimDeleteWorld);
         ComponentTypeSetAddToUpdateFn(type, CompAnimAddToUpdate);
-        ComponentTypeSetUpdateFn(type, CompAnimUpdate);
+        ComponentTypeSetPreUpdateFn(type, CompAnimPreUpdate);
         return dmGameObject::RESULT_OK;
     }
 

--- a/engine/gamesys/src/gamesys/gamesys.cpp
+++ b/engine/gamesys/src/gamesys/gamesys.cpp
@@ -190,7 +190,7 @@ namespace dmGameSystem
 
 #define REGISTER_COMPONENT_TYPE(extension, prio, context, new_world_func, delete_world_func, \
                                 create_func, destroy_func, init_func, final_func, add_to_update_func, get_func, \
-                                update_func, fixed_update_func, render_func, post_update_func, on_message_func, on_input_func, \
+                                preupdate_func, update_func, fixed_update_func, render_func, post_update_func, on_message_func, on_input_func, \
                                 on_reload_func, get_property_func, set_property_func, \
                                 iter_child_func, iter_property_func, \
                                 set_reads_transforms)\
@@ -213,6 +213,7 @@ namespace dmGameSystem
     component_type.m_AddToUpdateFunction = add_to_update_func;\
     component_type.m_GetFunction = get_func;\
     component_type.m_RenderFunction = render_func;\
+    component_type.m_PreUpdateFunction = preupdate_func; \
     component_type.m_UpdateFunction = update_func;\
     component_type.m_FixedUpdateFunction = fixed_update_func;\
     component_type.m_PostUpdateFunction = post_update_func;\
@@ -238,7 +239,7 @@ namespace dmGameSystem
         REGISTER_COMPONENT_TYPE("collectionproxyc", 100, collection_proxy_context,
                 &CompCollectionProxyNewWorld, &CompCollectionProxyDeleteWorld,
                 &CompCollectionProxyCreate, &CompCollectionProxyDestroy, 0, &CompCollectionProxyFinal, &CompCollectionProxyAddToUpdate, 0,
-                &CompCollectionProxyUpdate, 0, &CompCollectionProxyRender, &CompCollectionProxyPostUpdate, &CompCollectionProxyOnMessage, &CompCollectionProxyOnInput,
+                0, &CompCollectionProxyUpdate, 0, &CompCollectionProxyRender, &CompCollectionProxyPostUpdate, &CompCollectionProxyOnMessage, &CompCollectionProxyOnInput,
                 0, 0, 0,
                 &CompCollectionProxyIterChildren, 0,
                 0);
@@ -252,7 +253,7 @@ namespace dmGameSystem
         REGISTER_COMPONENT_TYPE("collisionobjectc", 400, physics_context,
                 &CompCollisionObjectNewWorld, &CompCollisionObjectDeleteWorld,
                 &CompCollisionObjectCreate, &CompCollisionObjectDestroy, 0, &CompCollisionObjectFinal, &CompCollisionObjectAddToUpdate, CompCollisionObjectGetComponent,
-                &CompCollisionObjectUpdate, CompCollisionObjectFixedUpdate, 0, &CompCollisionObjectPostUpdate, &CompCollisionObjectOnMessage, 0,
+                0, &CompCollisionObjectUpdate, CompCollisionObjectFixedUpdate, 0, &CompCollisionObjectPostUpdate, &CompCollisionObjectOnMessage, 0,
                 &CompCollisionObjectOnReload, CompCollisionObjectGetProperty, CompCollisionObjectSetProperty,
                 0, CompCollisionIterProperties,
                 1);
@@ -260,7 +261,7 @@ namespace dmGameSystem
         REGISTER_COMPONENT_TYPE("camerac", 500, render_context,
                 &CompCameraNewWorld, &CompCameraDeleteWorld,
                 &CompCameraCreate, &CompCameraDestroy, 0, 0, &CompCameraAddToUpdate, CompCameraGetComponent,
-                &CompCameraUpdate, 0, 0, 0, &CompCameraOnMessage, 0,
+                0, &CompCameraUpdate, 0, 0, 0, &CompCameraOnMessage, 0,
                 &CompCameraOnReload, CompCameraGetProperty, CompCameraSetProperty,
                 0, 0,
                 1);
@@ -268,7 +269,7 @@ namespace dmGameSystem
         REGISTER_COMPONENT_TYPE("modelc", 700, model_context,
                 CompModelNewWorld, CompModelDeleteWorld,
                 CompModelCreate, CompModelDestroy, 0, 0, CompModelAddToUpdate, CompModelGetComponent,
-                CompModelUpdate, 0, CompModelRender, 0, CompModelOnMessage, 0,
+                0, CompModelUpdate, 0, CompModelRender, 0, CompModelOnMessage, 0,
                 0, CompModelGetProperty, CompModelSetProperty,
                 0, CompModelIterProperties,
                 0);
@@ -278,7 +279,7 @@ namespace dmGameSystem
         REGISTER_COMPONENT_TYPE("particlefxc", 800, particlefx_context,
                 &CompParticleFXNewWorld, &CompParticleFXDeleteWorld,
                 &CompParticleFXCreate, &CompParticleFXDestroy, 0, 0, &CompParticleFXAddToUpdate, CompParticleFXGetComponent,
-                &CompParticleFXUpdate, 0, &CompParticleFXRender, 0, &CompParticleFXOnMessage, 0,
+                0, &CompParticleFXUpdate, 0, &CompParticleFXRender, 0, &CompParticleFXOnMessage, 0,
                 &CompParticleFXOnReload, 0, 0,
                 0, 0,
                 1);
@@ -286,7 +287,7 @@ namespace dmGameSystem
         REGISTER_COMPONENT_TYPE("factoryc", 900, factory_context,
                 CompFactoryNewWorld, CompFactoryDeleteWorld,
                 CompFactoryCreate, CompFactoryDestroy, 0, 0, CompFactoryAddToUpdate, CompFactoryGetComponent,
-                CompFactoryUpdate, 0, 0, 0, CompFactoryOnMessage, 0,
+                0, CompFactoryUpdate, 0, 0, 0, CompFactoryOnMessage, 0,
                 0, CompFactoryGetProperty, 0,
                 0, 0,
                 0);
@@ -294,7 +295,7 @@ namespace dmGameSystem
         REGISTER_COMPONENT_TYPE("collectionfactoryc", 950, collectionfactory_context,
                 CompCollectionFactoryNewWorld, CompCollectionFactoryDeleteWorld,
                 CompCollectionFactoryCreate, CompCollectionFactoryDestroy, 0, 0, CompCollectionFactoryAddToUpdate, 0,
-                CompCollectionFactoryUpdate, 0, 0, 0, 0, 0,
+                0, CompCollectionFactoryUpdate, 0, 0, 0, 0, 0,
                 0, CompCollectionFactoryGetProperty, 0,
                 0, 0,
                 0);
@@ -302,7 +303,7 @@ namespace dmGameSystem
         REGISTER_COMPONENT_TYPE("lightc", 1000, render_context,
                 CompLightNewWorld, CompLightDeleteWorld,
                 CompLightCreate, CompLightDestroy, 0, 0, CompLightAddToUpdate, CompLightGetComponent,
-                CompLightUpdate, 0, 0, 0, CompLightOnMessage, 0,
+                0, CompLightUpdate, 0, 0, 0, CompLightOnMessage, 0,
                 0, 0, 0,
                 0, 0,
                 1);
@@ -310,7 +311,7 @@ namespace dmGameSystem
         REGISTER_COMPONENT_TYPE("spritec", 1100, sprite_context,
                 CompSpriteNewWorld, CompSpriteDeleteWorld,
                 CompSpriteCreate, CompSpriteDestroy, 0, 0, CompSpriteAddToUpdate, CompSpriteGetComponent,
-                CompSpriteUpdate, 0, CompSpriteRender, 0, CompSpriteOnMessage, 0,
+                0, CompSpriteUpdate, 0, CompSpriteRender, 0, CompSpriteOnMessage, 0,
                 CompSpriteOnReload, CompSpriteGetProperty, CompSpriteSetProperty,
                 0, CompSpriteIterProperties,
                 1);
@@ -318,7 +319,7 @@ namespace dmGameSystem
         REGISTER_COMPONENT_TYPE(TILE_MAP_EXT, 1200, tilemap_context,
                 CompTileGridNewWorld, CompTileGridDeleteWorld,
                 CompTileGridCreate, CompTileGridDestroy, 0, 0, CompTileGridAddToUpdate, CompTileGridGetComponent,
-                CompTileGridUpdate, 0, CompTileGridRender, 0, CompTileGridOnMessage, 0,
+                0, CompTileGridUpdate, 0, CompTileGridRender, 0, CompTileGridOnMessage, 0,
                 CompTileGridOnReload, CompTileGridGetProperty, CompTileGridSetProperty,
                 0, CompTileGridIterProperties,
                 1);
@@ -326,7 +327,7 @@ namespace dmGameSystem
         REGISTER_COMPONENT_TYPE("labelc", 1400, label_context,
                 CompLabelNewWorld, CompLabelDeleteWorld,
                 CompLabelCreate, CompLabelDestroy, 0, 0, CompLabelAddToUpdate, CompLabelGetComponent,
-                CompLabelUpdate, 0, CompLabelRender, 0, CompLabelOnMessage, 0,
+                0, CompLabelUpdate, 0, CompLabelRender, 0, CompLabelOnMessage, 0,
                 CompLabelOnReload, CompLabelGetProperty, CompLabelSetProperty,
                 0, CompLabelIterProperties,
                 1);

--- a/engine/gamesys/src/gamesys/gamesys.cpp
+++ b/engine/gamesys/src/gamesys/gamesys.cpp
@@ -190,7 +190,7 @@ namespace dmGameSystem
 
 #define REGISTER_COMPONENT_TYPE(extension, prio, context, new_world_func, delete_world_func, \
                                 create_func, destroy_func, init_func, final_func, add_to_update_func, get_func, \
-                                preupdate_func, update_func, fixed_update_func, render_func, post_update_func, on_message_func, on_input_func, \
+                                update_func, fixed_update_func, render_func, post_update_func, on_message_func, on_input_func, \
                                 on_reload_func, get_property_func, set_property_func, \
                                 iter_child_func, iter_property_func, \
                                 set_reads_transforms)\
@@ -213,7 +213,6 @@ namespace dmGameSystem
     component_type.m_AddToUpdateFunction = add_to_update_func;\
     component_type.m_GetFunction = get_func;\
     component_type.m_RenderFunction = render_func;\
-    component_type.m_PreUpdateFunction = preupdate_func; \
     component_type.m_UpdateFunction = update_func;\
     component_type.m_FixedUpdateFunction = fixed_update_func;\
     component_type.m_PostUpdateFunction = post_update_func;\
@@ -239,7 +238,7 @@ namespace dmGameSystem
         REGISTER_COMPONENT_TYPE("collectionproxyc", 100, collection_proxy_context,
                 &CompCollectionProxyNewWorld, &CompCollectionProxyDeleteWorld,
                 &CompCollectionProxyCreate, &CompCollectionProxyDestroy, 0, &CompCollectionProxyFinal, &CompCollectionProxyAddToUpdate, 0,
-                0, &CompCollectionProxyUpdate, 0, &CompCollectionProxyRender, &CompCollectionProxyPostUpdate, &CompCollectionProxyOnMessage, &CompCollectionProxyOnInput,
+                &CompCollectionProxyUpdate, 0, &CompCollectionProxyRender, &CompCollectionProxyPostUpdate, &CompCollectionProxyOnMessage, &CompCollectionProxyOnInput,
                 0, 0, 0,
                 &CompCollectionProxyIterChildren, 0,
                 0);
@@ -253,7 +252,7 @@ namespace dmGameSystem
         REGISTER_COMPONENT_TYPE("collisionobjectc", 400, physics_context,
                 &CompCollisionObjectNewWorld, &CompCollisionObjectDeleteWorld,
                 &CompCollisionObjectCreate, &CompCollisionObjectDestroy, 0, &CompCollisionObjectFinal, &CompCollisionObjectAddToUpdate, CompCollisionObjectGetComponent,
-                0, &CompCollisionObjectUpdate, CompCollisionObjectFixedUpdate, 0, &CompCollisionObjectPostUpdate, &CompCollisionObjectOnMessage, 0,
+                &CompCollisionObjectUpdate, CompCollisionObjectFixedUpdate, 0, &CompCollisionObjectPostUpdate, &CompCollisionObjectOnMessage, 0,
                 &CompCollisionObjectOnReload, CompCollisionObjectGetProperty, CompCollisionObjectSetProperty,
                 0, CompCollisionIterProperties,
                 1);
@@ -261,7 +260,7 @@ namespace dmGameSystem
         REGISTER_COMPONENT_TYPE("camerac", 500, render_context,
                 &CompCameraNewWorld, &CompCameraDeleteWorld,
                 &CompCameraCreate, &CompCameraDestroy, 0, 0, &CompCameraAddToUpdate, CompCameraGetComponent,
-                0, &CompCameraUpdate, 0, 0, 0, &CompCameraOnMessage, 0,
+                &CompCameraUpdate, 0, 0, 0, &CompCameraOnMessage, 0,
                 &CompCameraOnReload, CompCameraGetProperty, CompCameraSetProperty,
                 0, 0,
                 1);
@@ -269,7 +268,7 @@ namespace dmGameSystem
         REGISTER_COMPONENT_TYPE("modelc", 700, model_context,
                 CompModelNewWorld, CompModelDeleteWorld,
                 CompModelCreate, CompModelDestroy, 0, 0, CompModelAddToUpdate, CompModelGetComponent,
-                0, CompModelUpdate, 0, CompModelRender, 0, CompModelOnMessage, 0,
+                CompModelUpdate, 0, CompModelRender, 0, CompModelOnMessage, 0,
                 0, CompModelGetProperty, CompModelSetProperty,
                 0, CompModelIterProperties,
                 0);
@@ -279,7 +278,7 @@ namespace dmGameSystem
         REGISTER_COMPONENT_TYPE("particlefxc", 800, particlefx_context,
                 &CompParticleFXNewWorld, &CompParticleFXDeleteWorld,
                 &CompParticleFXCreate, &CompParticleFXDestroy, 0, 0, &CompParticleFXAddToUpdate, CompParticleFXGetComponent,
-                0, &CompParticleFXUpdate, 0, &CompParticleFXRender, 0, &CompParticleFXOnMessage, 0,
+                &CompParticleFXUpdate, 0, &CompParticleFXRender, 0, &CompParticleFXOnMessage, 0,
                 &CompParticleFXOnReload, 0, 0,
                 0, 0,
                 1);
@@ -287,7 +286,7 @@ namespace dmGameSystem
         REGISTER_COMPONENT_TYPE("factoryc", 900, factory_context,
                 CompFactoryNewWorld, CompFactoryDeleteWorld,
                 CompFactoryCreate, CompFactoryDestroy, 0, 0, CompFactoryAddToUpdate, CompFactoryGetComponent,
-                0, CompFactoryUpdate, 0, 0, 0, CompFactoryOnMessage, 0,
+                CompFactoryUpdate, 0, 0, 0, CompFactoryOnMessage, 0,
                 0, CompFactoryGetProperty, 0,
                 0, 0,
                 0);
@@ -295,7 +294,7 @@ namespace dmGameSystem
         REGISTER_COMPONENT_TYPE("collectionfactoryc", 950, collectionfactory_context,
                 CompCollectionFactoryNewWorld, CompCollectionFactoryDeleteWorld,
                 CompCollectionFactoryCreate, CompCollectionFactoryDestroy, 0, 0, CompCollectionFactoryAddToUpdate, 0,
-                0, CompCollectionFactoryUpdate, 0, 0, 0, 0, 0,
+                CompCollectionFactoryUpdate, 0, 0, 0, 0, 0,
                 0, CompCollectionFactoryGetProperty, 0,
                 0, 0,
                 0);
@@ -303,7 +302,7 @@ namespace dmGameSystem
         REGISTER_COMPONENT_TYPE("lightc", 1000, render_context,
                 CompLightNewWorld, CompLightDeleteWorld,
                 CompLightCreate, CompLightDestroy, 0, 0, CompLightAddToUpdate, CompLightGetComponent,
-                0, CompLightUpdate, 0, 0, 0, CompLightOnMessage, 0,
+                CompLightUpdate, 0, 0, 0, CompLightOnMessage, 0,
                 0, 0, 0,
                 0, 0,
                 1);
@@ -311,7 +310,7 @@ namespace dmGameSystem
         REGISTER_COMPONENT_TYPE("spritec", 1100, sprite_context,
                 CompSpriteNewWorld, CompSpriteDeleteWorld,
                 CompSpriteCreate, CompSpriteDestroy, 0, 0, CompSpriteAddToUpdate, CompSpriteGetComponent,
-                0, CompSpriteUpdate, 0, CompSpriteRender, 0, CompSpriteOnMessage, 0,
+                CompSpriteUpdate, 0, CompSpriteRender, 0, CompSpriteOnMessage, 0,
                 CompSpriteOnReload, CompSpriteGetProperty, CompSpriteSetProperty,
                 0, CompSpriteIterProperties,
                 1);
@@ -319,7 +318,7 @@ namespace dmGameSystem
         REGISTER_COMPONENT_TYPE(TILE_MAP_EXT, 1200, tilemap_context,
                 CompTileGridNewWorld, CompTileGridDeleteWorld,
                 CompTileGridCreate, CompTileGridDestroy, 0, 0, CompTileGridAddToUpdate, CompTileGridGetComponent,
-                0, CompTileGridUpdate, 0, CompTileGridRender, 0, CompTileGridOnMessage, 0,
+                CompTileGridUpdate, 0, CompTileGridRender, 0, CompTileGridOnMessage, 0,
                 CompTileGridOnReload, CompTileGridGetProperty, CompTileGridSetProperty,
                 0, CompTileGridIterProperties,
                 1);
@@ -327,7 +326,7 @@ namespace dmGameSystem
         REGISTER_COMPONENT_TYPE("labelc", 1400, label_context,
                 CompLabelNewWorld, CompLabelDeleteWorld,
                 CompLabelCreate, CompLabelDestroy, 0, 0, CompLabelAddToUpdate, CompLabelGetComponent,
-                0, CompLabelUpdate, 0, CompLabelRender, 0, CompLabelOnMessage, 0,
+                CompLabelUpdate, 0, CompLabelRender, 0, CompLabelOnMessage, 0,
                 CompLabelOnReload, CompLabelGetProperty, CompLabelSetProperty,
                 0, CompLabelIterProperties,
                 1);


### PR DESCRIPTION
⚠️ ⚠️ ⚠️ **Possible breaking change** ⚠️ ⚠️ ⚠️
Our Lua script update order has changed, and fixed_update() is now called _before_ update().
We've also added `late_update()` which happens last in the engine frame, just before the render script is called.

For each engine update, you will now get:

    * fixed_update(fixed_dt) -- zero or more times *
    * update(dt)             -- one time
    * late_update(dt)        -- one time

In terms of how components are updated in relation to those functions.
Between each of these steps, we also flush any posted messages, it's just left out here to make the description more compact:

* Engine Component Fixed Update (zero or more steps)
    * Lua fixed_update(fixed_dt)
        * Lua Flush Messages
    * ...
    * Physics Fixed Update(fixed_dt) *
    * ...
* Engine Component Update
    * Lua update(dt)
        * Lua Flush Messages
    * ...
    * Physics Update(dt) *
    * ...
* Engine Component Late Update
    * Lua late_update(dt)
        * Lua Flush Messages
    * ...

*) Note that fixed_update() is only called if you've enabled it in project settings "Use fixed timestep"

For further information regarding life cycle, and component update order, we'll refer to the [documentation](https://defold.com/manuals/application-lifecycle/)



### Technical changes

In order to keep our current features, we've introduced PreFixedUpdate and PreUpdate functions for the components.
These are not reflected on the Lua side.

See code comment in gameobject.cpp `Update()` function for complete details.

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   4. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
