### PR TITLE
Build runtime-generated fonts from the editor

### DIFF
--- a/editor/src/clj/editor/resource.clj
+++ b/editor/src/clj/editor/resource.clj
@@ -581,6 +581,11 @@
   (with-open [rs (io/input-stream resource)]
     (digest/stream->sha256-hex rs)))
 
+(defn resource->bytes
+  ^bytes [resource]
+  (with-open [rs (io/input-stream resource)]
+    (IOUtils/toByteArray rs)))
+
 (defn resource->path-inclusive-sha1-hex
   "For certain files, we want to include the proj-path in the sha1 identifier
   along with the file contents. For example, it used to be that two atlases


### PR DESCRIPTION
The editor now respects the `font.runtime_generation` setting in `game.project`. Previously only Bob would produce runtime-generated fonts when this setting was enabled for the project.

Fixes #10999.
