### PR TITLE
Add multithreaded encoding for ASTC encoder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,5 @@ editor/.lsp/sqlite.db
 
 # ChatGPT
 AGENTS.md
+/share/ext/astcenc/build/
+/share/ext/astcenc/source

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/defold/extension/pipeline/texture/TextureCompressorASTC.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/defold/extension/pipeline/texture/TextureCompressorASTC.java
@@ -16,6 +16,7 @@ package com.defold.extension.pipeline.texture;
 
 import com.dynamo.bob.pipeline.Texc;
 import com.dynamo.bob.pipeline.TexcLibraryJni;
+import com.dynamo.bob.pipeline.TextureGenerator;
 import com.dynamo.graphics.proto.Graphics;
 import com.dynamo.graphics.proto.Graphics.TextureImage;
 
@@ -138,11 +139,7 @@ public class TextureCompressorASTC implements ITextureCompressor {
         settings.height = params.getHeight();
         settings.pixelFormat = Texc.PixelFormat.fromValue(params.getPixelFormat());
         settings.colorSpace = Texc.ColorSpace.fromValue(params.getColorSpace());
-        // The library doesn't create threads for us. To use the multithreaded version, we need to spawn our own threads or workers.
-        // Because we encode many images in parallel, we can stick to single threaded encoding and still achieve parallelisation
-        // by processing multiple images simultaneously.
-         // https://github.com/ARM-software/astc-encoder/blob/701503966b1ac2ebd2616cba94adee5ae8ba6363/Source/astcenc.h#L37C2-L78C41
-        settings.numThreads = 1;
+        settings.numThreads = TextureGenerator.maxThreads;
         settings.data = input;
         settings.outPixelFormat = Texc.PixelFormat.fromValue(params.getPixelFormatOut());
 

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/defold/extension/pipeline/texture/TextureCompressorBasisU.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/defold/extension/pipeline/texture/TextureCompressorBasisU.java
@@ -106,7 +106,8 @@ public class TextureCompressorBasisU implements ITextureCompressor {
         settings.outPixelFormat = Texc.PixelFormat.fromValue(params.getPixelFormatOut());
         settings.colorSpace = Texc.ColorSpace.fromValue(params.getColorSpace());
 
-        settings.numThreads = TextureGenerator.maxThreads;
+        // increasing of threads count for basisu isn't that efficient, so keep it 4 for now
+        settings.numThreads = 4;
         settings.debug = false;
         settings.data = input;
 

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/defold/extension/pipeline/texture/TextureCompressorBasisU.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/defold/extension/pipeline/texture/TextureCompressorBasisU.java
@@ -16,6 +16,7 @@ package com.defold.extension.pipeline.texture;
 
 import com.dynamo.bob.pipeline.Texc;
 import com.dynamo.bob.pipeline.TexcLibraryJni;
+import com.dynamo.bob.pipeline.TextureGenerator;
 import com.dynamo.graphics.proto.Graphics;
 
 import java.util.ArrayList;
@@ -105,7 +106,7 @@ public class TextureCompressorBasisU implements ITextureCompressor {
         settings.outPixelFormat = Texc.PixelFormat.fromValue(params.getPixelFormatOut());
         settings.colorSpace = Texc.ColorSpace.fromValue(params.getColorSpace());
 
-        settings.numThreads = 4;
+        settings.numThreads = TextureGenerator.maxThreads;
         settings.debug = false;
         settings.data = input;
 

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/TextureGenerator.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/TextureGenerator.java
@@ -58,7 +58,7 @@ import com.dynamo.graphics.proto.Graphics.TextureProfile;
 public class TextureGenerator {
 
     // specify what is maximum of threads TextureGenerator may use
-    public static int maxThreads = Project.getDefaultMaxCpuThreads();
+    public static int maxThreads = 4; // set to getHalfThreads() in Project.java
 
     public static class GenerateResult {
         public TextureImage textureImage;


### PR DESCRIPTION
Speed up the ASTC encoder using a few threads per image (in addition to encoding a few images at the same time)