### PR TITLE
Performance optimisations for atlas creation

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/textureset/MaxRectsLayoutStrategy.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/textureset/MaxRectsLayoutStrategy.java
@@ -62,7 +62,7 @@ public class MaxRectsLayoutStrategy implements TextureSetLayoutStrategy {
         }
 
         ArrayList<Page> pages = new ArrayList<Page>();
-        while (srcNodes.size() > 0) {
+        while (!srcNodes.isEmpty()) {
             Page result = packPage(srcNodes);
             pages.add(result);
             srcNodes = result.remainingRects;
@@ -140,14 +140,14 @@ public class MaxRectsLayoutStrategy implements TextureSetLayoutStrategy {
             BinarySearch sizeSearch = new BinarySearch(minSize, maxSize);
             int size = sizeSearch.reset();
             while (size != -1) {
-                Page result = packAtSize(true, size - settings.paddingX, size - settings.paddingY, inputRects, rectStats);
+                Page result = packAtSize(true, size - settings.paddingX, size - settings.paddingY, inputRects, rectStats, settings.rotation);
                 bestResult = getBest(bestResult, result);
                 size = sizeSearch.next(result == null);
             }
 
             // Rects don't fit on one page. Fill a whole page and return.
             if (bestResult == null) {
-                bestResult = packAtSize(false, maxSize - settings.paddingX, maxSize - settings.paddingY, inputRects, rectStats);
+                bestResult = packAtSize(false, maxSize - settings.paddingX, maxSize - settings.paddingY, inputRects, rectStats, settings.rotation);
             }
 
              bestResult.width = Math.max(bestResult.width, bestResult.height);
@@ -160,7 +160,7 @@ public class MaxRectsLayoutStrategy implements TextureSetLayoutStrategy {
             while (true) {
                 Page bestWidthResult = null;
                 while (width != -1) {
-                    Page result = packAtSize(true, width - settings.paddingX, height - settings.paddingY, inputRects, rectStats);
+                    Page result = packAtSize(true, width - settings.paddingX, height - settings.paddingY, inputRects, rectStats, settings.rotation);
                     bestWidthResult = getBest(bestWidthResult, result);
                     width = widthSearch.next(result == null);
                 }
@@ -173,7 +173,7 @@ public class MaxRectsLayoutStrategy implements TextureSetLayoutStrategy {
             }
             // Rects don't fit on one page. Fill a whole page and return.
             if (bestResult == null) {
-                bestResult = packAtSize(false, settings.maxPageWidth - settings.paddingX, settings.maxPageHeight - settings.paddingY, inputRects, rectStats);
+                bestResult = packAtSize(false, settings.maxPageWidth - settings.paddingX, settings.maxPageHeight - settings.paddingY, inputRects, rectStats, settings.rotation);
             }
         }
         return bestResult;
@@ -182,8 +182,8 @@ public class MaxRectsLayoutStrategy implements TextureSetLayoutStrategy {
     /** @param fully If true, the only results that pack all rects will be considered. If false, all results are considered, not all
      *           rects may be packed.
      **/
-    private Page packAtSize(boolean fully, int width, int height, ArrayList<RectNode> inputRects, RectStats rectStats) {
-        if (!canFitInPage(width, height, rectStats, fully)) {
+    private Page packAtSize(boolean fully, int width, int height, ArrayList<RectNode> inputRects, RectStats rectStats, boolean checkRotation) {
+        if (!canFitInPage(width, height, rectStats, fully, checkRotation)) {
             return null;
         }
 
@@ -204,10 +204,10 @@ public class MaxRectsLayoutStrategy implements TextureSetLayoutStrategy {
             result = maxRects.getResult();
             result.remainingRects = remaining;
 
-            if (fully && result.remainingRects.size() > 0) {
+            if (fully && !result.remainingRects.isEmpty()) {
                 continue;
             }
-            if (result.outputRects.size() == 0) {
+            if (result.outputRects.isEmpty()) {
                 continue;
             }
             bestResult = getBest(bestResult, result);
@@ -229,13 +229,13 @@ public class MaxRectsLayoutStrategy implements TextureSetLayoutStrategy {
         return exponent;
     }
 
-    private boolean canFitInPage(int width, int height, RectStats stats, boolean fully) {
+    private boolean canFitInPage(int width, int height, RectStats stats, boolean fully, boolean checkRotation) {
         long availableArea = (long)width * (long)height;
         if (fully && availableArea < stats.totalArea) {
             return false;
         }
 
-        if (!settings.rotation) {
+        if (!checkRotation) {
             return width >= stats.maxWidth && height >= stats.maxHeight;
         }
 
@@ -286,12 +286,6 @@ public class MaxRectsLayoutStrategy implements TextureSetLayoutStrategy {
             this.rect = new Rect(rect);
             this.score1 = 0;
             this.score2 = 0;
-        }
-
-        public RectNode(Rect rect, int score1, int score2) {
-            this.rect = new Rect(rect);
-            this.score1 = score1;
-            this.score2 = score2;
         }
 
         public RectNode(RectNode other) {
@@ -380,7 +374,7 @@ public class MaxRectsLayoutStrategy implements TextureSetLayoutStrategy {
         /** For each rectangle, packs each one then chooses the best and packs that. Slow! */
         public Page pack (ArrayList<RectNode> rects, FreeRectChoiceHeuristic method) {
             rects = new ArrayList<RectNode>(rects);
-            while (rects.size() > 0) {
+            while (!rects.isEmpty()) {
                 int bestRectIndex = -1;
                 RectNode bestNode = new RectNode(new Rect(null, 0, 0, 0, 0, 0));
                 bestNode.score1 = Integer.MAX_VALUE;
@@ -886,5 +880,5 @@ public class MaxRectsLayoutStrategy implements TextureSetLayoutStrategy {
         BottomLeftRule,
         // CP: Choosest the placement where the rectangle touches other rects as much as possible.
         ContactPointRule
-    };
+    }
 }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/textureset/MaxRectsLayoutStrategy.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/textureset/MaxRectsLayoutStrategy.java
@@ -15,6 +15,7 @@
 package com.dynamo.bob.textureset;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 
 import static com.dynamo.bob.textureset.TextureSetLayout.MAX_ATLAS_DIMENSION;
@@ -80,7 +81,7 @@ public class MaxRectsLayoutStrategy implements TextureSetLayoutStrategy {
             }
             int layoutWidth = 1 << getExponentNextOrMatchingPowerOfTwo(page.width);
             int layoutHeight = 1 << getExponentNextOrMatchingPowerOfTwo(page.height);
-            
+
             // Validate atlas size limits
             if (layoutWidth > MAX_ATLAS_DIMENSION || layoutHeight > MAX_ATLAS_DIMENSION) {
                 throw new CompileExceptionError(String.format(
@@ -100,10 +101,16 @@ public class MaxRectsLayoutStrategy implements TextureSetLayoutStrategy {
         // Find min size.
         int minWidth = Integer.MAX_VALUE;
         int minHeight = Integer.MAX_VALUE;
+        int maxRectWidth = 0;
+        int maxRectHeight = 0;
+        long totalRectArea = 0L;
         for (int i = 0, nn = inputRects.size(); i < nn; i++) {
             Rect rect = inputRects.get(i).rect;
             minWidth = Math.min(minWidth, rect.getWidth());
             minHeight = Math.min(minHeight, rect.getHeight());
+            maxRectWidth = Math.max(maxRectWidth, rect.getWidth());
+            maxRectHeight = Math.max(maxRectHeight, rect.getHeight());
+            totalRectArea += (long)rect.getWidth() * (long)rect.getHeight();
             if (settings.rotation) {
                 if ((rect.getWidth() > settings.maxPageWidth - settings.paddingX || rect.getHeight() > settings.maxPageHeight - settings.paddingY)
                     && (rect.getWidth() > settings.maxPageHeight - settings.paddingY || rect.getHeight() > settings.maxPageWidth - settings.paddingX)) {
@@ -123,6 +130,7 @@ public class MaxRectsLayoutStrategy implements TextureSetLayoutStrategy {
         }
         minWidth = Math.max(minWidth + settings.paddingX, settings.minPageWidth);
         minHeight = Math.max(minHeight + settings.paddingY, settings.minPageHeight);
+        RectStats rectStats = new RectStats(maxRectWidth, maxRectHeight, totalRectArea);
 
         // Find the minimal page size that fits all rects.
         Page bestResult = null;
@@ -132,14 +140,14 @@ public class MaxRectsLayoutStrategy implements TextureSetLayoutStrategy {
             BinarySearch sizeSearch = new BinarySearch(minSize, maxSize);
             int size = sizeSearch.reset();
             while (size != -1) {
-                Page result = packAtSize(true, size - settings.paddingX, size - settings.paddingY, inputRects);
+                Page result = packAtSize(true, size - settings.paddingX, size - settings.paddingY, inputRects, rectStats);
                 bestResult = getBest(bestResult, result);
                 size = sizeSearch.next(result == null);
             }
 
             // Rects don't fit on one page. Fill a whole page and return.
             if (bestResult == null) {
-                bestResult = packAtSize(false, maxSize - settings.paddingX, maxSize - settings.paddingY, inputRects);
+                bestResult = packAtSize(false, maxSize - settings.paddingX, maxSize - settings.paddingY, inputRects, rectStats);
             }
 
              bestResult.width = Math.max(bestResult.width, bestResult.height);
@@ -152,7 +160,7 @@ public class MaxRectsLayoutStrategy implements TextureSetLayoutStrategy {
             while (true) {
                 Page bestWidthResult = null;
                 while (width != -1) {
-                    Page result = packAtSize(true, width - settings.paddingX, height - settings.paddingY, inputRects);
+                    Page result = packAtSize(true, width - settings.paddingX, height - settings.paddingY, inputRects, rectStats);
                     bestWidthResult = getBest(bestWidthResult, result);
                     width = widthSearch.next(result == null);
                 }
@@ -165,7 +173,7 @@ public class MaxRectsLayoutStrategy implements TextureSetLayoutStrategy {
             }
             // Rects don't fit on one page. Fill a whole page and return.
             if (bestResult == null) {
-                bestResult = packAtSize(false, settings.maxPageWidth - settings.paddingX, settings.maxPageHeight - settings.paddingY, inputRects);
+                bestResult = packAtSize(false, settings.maxPageWidth - settings.paddingX, settings.maxPageHeight - settings.paddingY, inputRects, rectStats);
             }
         }
         return bestResult;
@@ -174,7 +182,11 @@ public class MaxRectsLayoutStrategy implements TextureSetLayoutStrategy {
     /** @param fully If true, the only results that pack all rects will be considered. If false, all results are considered, not all
      *           rects may be packed.
      **/
-    private Page packAtSize(boolean fully, int width, int height, ArrayList<RectNode> inputRects) {
+    private Page packAtSize(boolean fully, int width, int height, ArrayList<RectNode> inputRects, RectStats rectStats) {
+        if (!canFitInPage(width, height, rectStats, fully)) {
+            return null;
+        }
+
         Page bestResult = null;
         for (int i = 0, n = methods.length; i < n; i++) {
             maxRects.init(width, height);
@@ -215,6 +227,21 @@ public class MaxRectsLayoutStrategy implements TextureSetLayoutStrategy {
             ++exponent;
         }
         return exponent;
+    }
+
+    private boolean canFitInPage(int width, int height, RectStats stats, boolean fully) {
+        long availableArea = (long)width * (long)height;
+        if (fully && availableArea < stats.totalArea) {
+            return false;
+        }
+
+        if (!settings.rotation) {
+            return width >= stats.maxWidth && height >= stats.maxHeight;
+        }
+
+        boolean fitsUpright = width >= stats.maxWidth && height >= stats.maxHeight;
+        boolean fitsRotated = width >= stats.maxHeight && height >= stats.maxWidth;
+        return fitsUpright || fitsRotated;
     }
 
     static class BinarySearch {
@@ -284,6 +311,18 @@ public class MaxRectsLayoutStrategy implements TextureSetLayoutStrategy {
         public int width, height;
     }
 
+    static class RectStats {
+        final int maxWidth;
+        final int maxHeight;
+        final long totalArea;
+
+        RectStats(int maxWidth, int maxHeight, long totalArea) {
+            this.maxWidth = maxWidth;
+            this.maxHeight = maxHeight;
+            this.totalArea = totalArea;
+        }
+    }
+
     /** Maximal rectangles bin packing algorithm. Adapted from this C++ public domain source:
      * http://clb.demon.fi/projects/even-more-rectangle-bin-packing
      * @author Jukka Jyl�nki
@@ -295,6 +334,8 @@ public class MaxRectsLayoutStrategy implements TextureSetLayoutStrategy {
         private final ArrayList<RectNode> usedRectangles = new ArrayList<RectNode>();
         private final ArrayList<RectNode> freeRectangles = new ArrayList<RectNode>();
         private final ArrayList<RectNode> newFreeRectangles = new ArrayList<RectNode>();
+        private final HashMap<Integer, ArrayList<RectNode>> verticalEdges = new HashMap<Integer, ArrayList<RectNode>>();
+        private final HashMap<Integer, ArrayList<RectNode>> horizontalEdges = new HashMap<Integer, ArrayList<RectNode>>();
 
         public void init (int width, int height) {
             binWidth = width;
@@ -303,6 +344,8 @@ public class MaxRectsLayoutStrategy implements TextureSetLayoutStrategy {
             usedRectangles.clear();
             freeRectangles.clear();
             newFreeRectangles.clear();
+            verticalEdges.clear();
+            horizontalEdges.clear();
             RectNode n = new RectNode(new Rect(null, 0, 0, 0, width, height));
             freeRectangles.add(n);
         }
@@ -330,7 +373,7 @@ public class MaxRectsLayoutStrategy implements TextureSetLayoutStrategy {
             bestNode.rect.setId(rect.rect.getId());
             bestNode.rect.setIndex(rect.rect.getIndex());
 
-            usedRectangles.add(bestNode);
+            addUsedRectangle(bestNode);
             return bestNode;
         }
 
@@ -400,7 +443,29 @@ public class MaxRectsLayoutStrategy implements TextureSetLayoutStrategy {
 
             pruneFreeList();
 
+            addUsedRectangle(node);
+        }
+
+        private void addUsedRectangle(RectNode node) {
             usedRectangles.add(node);
+            registerEdges(node);
+        }
+
+        private void registerEdges(RectNode node) {
+            Rect rect = node.rect;
+            addEdge(verticalEdges, rect.getX(), node);
+            addEdge(verticalEdges, rect.getX() + rect.getWidth(), node);
+            addEdge(horizontalEdges, rect.getY(), node);
+            addEdge(horizontalEdges, rect.getY() + rect.getHeight(), node);
+        }
+
+        private void addEdge(HashMap<Integer, ArrayList<RectNode>> edges, int key, RectNode node) {
+            ArrayList<RectNode> list = edges.get(key);
+            if (list == null) {
+                list = new ArrayList<RectNode>();
+                edges.put(key, list);
+            }
+            list.add(node);
         }
 
         private RectNode scoreRect (RectNode node, FreeRectChoiceHeuristic method) {
@@ -452,6 +517,8 @@ public class MaxRectsLayoutStrategy implements TextureSetLayoutStrategy {
             bestNode.rect = new Rect(null, 0,0,0,0,0);
             bestNode.score1 = Integer.MAX_VALUE; // best y, score2 is best x
 
+            boolean doRotate = rotate && width != height;
+
             for (int i = 0; i < freeRectangles.size(); i++) {
                 // Try to place the rectangle in upright (non-rotated) orientation.
                 RectNode currentNode = freeRectangles.get(i);
@@ -463,7 +530,7 @@ public class MaxRectsLayoutStrategy implements TextureSetLayoutStrategy {
                         bestNode.score2 = currentNode.rect.getX();
                     }
                 }
-                if (rotate && currentNode.rect.getWidth() >= rotatedWidth && currentNode.rect.getHeight() >= rotatedHeight) {
+                if (doRotate && currentNode.rect.getWidth() >= rotatedWidth && currentNode.rect.getHeight() >= rotatedHeight) {
                     int topSideY = currentNode.rect.getY() + rotatedHeight;
                     if (topSideY < bestNode.score1 || (topSideY == bestNode.score1 && currentNode.rect.getX() < bestNode.score2)) {
                         bestNode.rect = new Rect(currentNode.rect.getId(), currentNode.rect.getIndex(), currentNode.rect.getX(), currentNode.rect.getY(), rotatedWidth, rotatedHeight);
@@ -482,6 +549,8 @@ public class MaxRectsLayoutStrategy implements TextureSetLayoutStrategy {
             bestNode.rect = new Rect(null, 0,0,0,0,0);
             bestNode.score1 = Integer.MAX_VALUE;
 
+            boolean doRotate = rotate && width != height;
+
             for (int i = 0; i < freeRectangles.size(); i++) {
                 // Try to place the rectangle in upright (non-rotated) orientation.
                 RectNode currentNode = freeRectangles.get(i);
@@ -498,7 +567,7 @@ public class MaxRectsLayoutStrategy implements TextureSetLayoutStrategy {
                     }
                 }
 
-                if (rotate && currentNode.rect.getWidth() >= rotatedWidth && currentNode.rect.getHeight() >= rotatedHeight) {
+                if (doRotate && currentNode.rect.getWidth() >= rotatedWidth && currentNode.rect.getHeight() >= rotatedHeight) {
                     int flippedLeftoverHoriz = Math.abs(currentNode.rect.getWidth() - rotatedWidth);
                     int flippedLeftoverVert = Math.abs(currentNode.rect.getHeight() - rotatedHeight);
                     int flippedShortSideFit = Math.min(flippedLeftoverHoriz, flippedLeftoverVert);
@@ -607,14 +676,48 @@ public class MaxRectsLayoutStrategy implements TextureSetLayoutStrategy {
             if (x == 0 || x + width == binWidth) score += height;
             if (y == 0 || y + height == binHeight) score += width;
 
-            for (int i = 0; i < usedRectangles.size(); i++) {
-                RectNode currentNode = usedRectangles.get(i);
-                if (currentNode.rect.getX() == x + width || currentNode.rect.getX() + currentNode.rect.getWidth() == x)
-                    score += commonIntervalLength(currentNode.rect.getY(), currentNode.rect.getY() + currentNode.rect.getHeight(), y,
-                        y + height);
-                if (currentNode.rect.getY() == y + height || currentNode.rect.getY() + currentNode.rect.getHeight() == y)
-                    score += commonIntervalLength(currentNode.rect.getX(), currentNode.rect.getX() + currentNode.rect.getWidth(), x, x
-                        + width);
+            ArrayList<RectNode> rightEdgeNodes = verticalEdges.get(x + width);
+            if (rightEdgeNodes != null) {
+                for (int i = 0; i < rightEdgeNodes.size(); i++) {
+                    RectNode currentNode = rightEdgeNodes.get(i);
+                    if (currentNode.rect.getX() == x + width) {
+                        score += commonIntervalLength(currentNode.rect.getY(), currentNode.rect.getY() + currentNode.rect.getHeight(), y,
+                            y + height);
+                    }
+                }
+            }
+
+            ArrayList<RectNode> leftEdgeNodes = verticalEdges.get(x);
+            if (leftEdgeNodes != null) {
+                for (int i = 0; i < leftEdgeNodes.size(); i++) {
+                    RectNode currentNode = leftEdgeNodes.get(i);
+                    if (currentNode.rect.getX() + currentNode.rect.getWidth() == x) {
+                        score += commonIntervalLength(currentNode.rect.getY(), currentNode.rect.getY() + currentNode.rect.getHeight(), y,
+                            y + height);
+                    }
+                }
+            }
+
+            ArrayList<RectNode> topEdgeNodes = horizontalEdges.get(y + height);
+            if (topEdgeNodes != null) {
+                for (int i = 0; i < topEdgeNodes.size(); i++) {
+                    RectNode currentNode = topEdgeNodes.get(i);
+                    if (currentNode.rect.getY() == y + height) {
+                        score += commonIntervalLength(currentNode.rect.getX(), currentNode.rect.getX() + currentNode.rect.getWidth(), x, x
+                            + width);
+                    }
+                }
+            }
+
+            ArrayList<RectNode> bottomEdgeNodes = horizontalEdges.get(y);
+            if (bottomEdgeNodes != null) {
+                for (int i = 0; i < bottomEdgeNodes.size(); i++) {
+                    RectNode currentNode = bottomEdgeNodes.get(i);
+                    if (currentNode.rect.getY() + currentNode.rect.getHeight() == y) {
+                        score += commonIntervalLength(currentNode.rect.getX(), currentNode.rect.getX() + currentNode.rect.getWidth(), x, x
+                            + width);
+                    }
+                }
             }
             return score;
         }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/textureset/TextureSetGenerator.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/textureset/TextureSetGenerator.java
@@ -746,12 +746,9 @@ public class TextureSetGenerator {
 
         AnimDesc animDesc = null;
         while ((animDesc = iterator.nextAnim()) != null) {
-            String animId = animDesc.getId();
-
             Rect ref = null;
             Integer index = null;
             int startIndex = quadIndex;
-            int localIndex = 0; // 0 .. num_frames(anim)-1
             while ((index = iterator.nextFrameIndex()) != null) {
 
                 String frameId = iterator.getFrameId(); // either "id" or "anim./id"
@@ -769,7 +766,6 @@ public class TextureSetGenerator {
                 textureSet.addPageIndices(r.getPage());
 
                 ++quadIndex;
-                ++localIndex;
             }
             if (ref == null) {
                 continue;

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/PackedResources.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/PackedResources.java
@@ -2,6 +2,9 @@ package com.dynamo.bob.util;
 
 import com.dynamo.bob.Bob;
 import com.dynamo.bob.Platform;
+import com.dynamo.bob.pipeline.ModelImporterJni;
+import com.dynamo.bob.pipeline.ShadercJni;
+import com.dynamo.bob.pipeline.TexcLibraryJni;
 
 import java.io.File;
 import java.io.IOException;
@@ -18,6 +21,12 @@ public class PackedResources {
 
     private static void runUnpackAllLibsAsync(Platform platform) throws IOException {
         TimeProfiler.start("runUnpackAllLibsAsync");
+        // unpacking for these happens in static initializers
+        new TexcLibraryJni();
+        new ShadercJni();
+        new ModelImporterJni();
+
+        // regular libs
         String platformPair = platform.getPair();
         File targetDir = new File(Bob.getRootFolder(), platformPair);
 

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/PackedResources.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/PackedResources.java
@@ -2,9 +2,6 @@ package com.dynamo.bob.util;
 
 import com.dynamo.bob.Bob;
 import com.dynamo.bob.Platform;
-import com.dynamo.bob.pipeline.ModelImporterJni;
-import com.dynamo.bob.pipeline.ShadercJni;
-import com.dynamo.bob.pipeline.TexcLibraryJni;
 
 import java.io.File;
 import java.io.IOException;
@@ -21,12 +18,6 @@ public class PackedResources {
 
     private static void runUnpackAllLibsAsync(Platform platform) throws IOException {
         TimeProfiler.start("runUnpackAllLibsAsync");
-        // unpacking for these happens in static initializers
-        new TexcLibraryJni();
-        new ShadercJni();
-        new ModelImporterJni();
-
-        // regular libs
         String platformPair = platform.getPair();
         File targetDir = new File(Bob.getRootFolder(), platformPair);
 

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/TextureUtil.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/TextureUtil.java
@@ -48,6 +48,11 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import static com.dynamo.bob.util.MiscUtil.concatenateArrays;
 
 public class TextureUtil {
+
+    static {
+        ImageIO.setUseCache(false);
+    }
+
     public static int closestPOT(int i) {
         int nextPow2 = 1;
         while (nextPow2 < i) {


### PR DESCRIPTION
These improvements reduced the total atlas build time in Bob.jar from ~2850ms down to ~1100ms for a tested atlas (8192x4096, 4818 images on MBP M1 Max), including a drop in layout calculation time from ~1300ms down to ~490ms. With the reduced algorithmic complexity, adding more images will affect performance far less than before.