### PR TITLE
Bob performance optimizations for sequential builds

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Bob.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Bob.java
@@ -157,7 +157,7 @@ public class Bob {
         TimeProfiler.stop();
     }
 
-    public static void initLua() {
+    public static void ensureBobInitialized() {
         init();
         PackedResources.unpackAllLibsAsync(Platform.getHostPlatform());
         PackedResources.waitForuUpackAllLibsAsync();

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
@@ -1648,7 +1648,9 @@ public class Project {
         }
 
         IProgress m = monitor.subProgress(99);
-
+        TimeProfiler.start("ensureBobInitialized");
+        Bob.ensureBobInitialized();
+        TimeProfiler.stop();
         IProgress mrep = m.subProgress(1);
         mrep.beginTask(IProgress.Task.READING_TASKS, 1);
         TimeProfiler.start("Create tasks");

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/LuaBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/LuaBuilder.java
@@ -161,7 +161,6 @@ public abstract class LuaBuilder extends Builder {
 
         // check if the platform is using Lua 5.1 or LuaJIT
         // get path of LuaJIT executable if the platform uses LuaJIT
-        Bob.initLua();
         useLua51 = LUA51_PLATFORMS.contains(this.project.getPlatform());
         luaJITExePath = Bob.getHostExeOnce("luajit-64", luaJITExePath);
 

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/BuildInputDataCollector.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/BuildInputDataCollector.java
@@ -79,6 +79,7 @@ public class BuildInputDataCollector {
         } catch (IOException e) {
             throw new RuntimeException("Failed to write data to JSON file", e);
         }
+        TimeProfiler.stop();
     }
 
     private static Map<String, String> getGitInfoIfAvailable(String rootDirectory) {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/PackedResources.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/PackedResources.java
@@ -2,6 +2,9 @@ package com.dynamo.bob.util;
 
 import com.dynamo.bob.Bob;
 import com.dynamo.bob.Platform;
+import com.dynamo.bob.pipeline.ModelImporterJni;
+import com.dynamo.bob.pipeline.ShadercJni;
+import com.dynamo.bob.pipeline.TexcLibraryJni;
 
 import java.io.File;
 import java.io.IOException;
@@ -18,6 +21,12 @@ public class PackedResources {
 
     private static void runUnpackAllLibsAsync(Platform platform) throws IOException {
         TimeProfiler.start("runUnpackAllLibsAsync");
+        // unpacking for these happens in static initializers
+        new TexcLibraryJni();
+        new ShadercJni();
+        new ModelImporterJni();
+
+        // regular libs
         String platformPair = platform.getPair();
         File targetDir = new File(Bob.getRootFolder(), platformPair);
 

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/PackedResources.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/PackedResources.java
@@ -77,7 +77,6 @@ public class PackedResources {
 
     private static void runUnpackAllLibsAsync(Platform platform, Thread[] nativeLibThreads, AtomicReference<Throwable> nativeLibError) throws IOException {
         TimeProfiler.start("runUnpackAllLibsAsync");
-        // regular libs
         String platformPair = platform.getPair();
         File targetDir = new File(Bob.getRootFolder(), platformPair);
 
@@ -160,7 +159,6 @@ public class PackedResources {
         } else {
             throw new IOException("Unsupported protocol for /libexec/" + platformPair + ": " + libexecRoot.getProtocol());
         }
-        awaitNativeLibLoads(nativeLibThreads, nativeLibError);
         TimeProfiler.stop();
     }
 
@@ -179,6 +177,7 @@ public class PackedResources {
         Thread unpackThread = new Thread(() -> {
             try {
                 runUnpackAllLibsAsync(platform, nativeLibThreads, nativeLibError);
+                awaitNativeLibLoads(nativeLibThreads, nativeLibError);
             } catch (IOException e) {
                 throw new RuntimeException("Failed to unpack tools", e);
             } finally {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/PackedResources.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/PackedResources.java
@@ -8,8 +8,10 @@ import com.dynamo.bob.pipeline.TexcLibraryJni;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.net.JarURLConnection;
 import java.net.URL;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.jar.JarFile;
 
 public class PackedResources {
@@ -18,14 +20,63 @@ public class PackedResources {
     private static volatile boolean unpackDone = false;
     private static final Object unpackLock = new Object();
     private static JarFile jarFile;
+    private static final Class<?>[] NATIVE_LIB_CLASSES = new Class<?>[] {
+            TexcLibraryJni.class,
+            ShadercJni.class,
+            ModelImporterJni.class
+    };
 
-    private static void runUnpackAllLibsAsync(Platform platform) throws IOException {
+    private static void loadNativeLib(Class<?> libClass) {
+        TimeProfiler.start("loadNativeLib %s", libClass.getSimpleName());
+        try {
+            libClass.getDeclaredConstructor().newInstance();
+        } catch (InvocationTargetException e) {
+            Throwable cause = e.getCause() != null ? e.getCause() : e;
+            throw new RuntimeException("Failed to load native library: " + libClass.getSimpleName(), cause);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException("Failed to load native library: " + libClass.getSimpleName(), e);
+        } finally {
+            TimeProfiler.stop();
+        }
+    }
+
+    private static Thread[] startNativeLibLoads(AtomicReference<Throwable> nativeLibError) {
+        Thread[] threads = new Thread[NATIVE_LIB_CLASSES.length];
+        for (int i = 0; i < NATIVE_LIB_CLASSES.length; i++) {
+            final Class<?> libClass = NATIVE_LIB_CLASSES[i];
+            threads[i] = new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        loadNativeLib(libClass);
+                    } catch (Throwable t) {
+                        nativeLibError.compareAndSet(null, t);
+                    }
+                }
+            });
+            threads[i].start();
+        }
+        return threads;
+    }
+
+    private static void awaitNativeLibLoads(Thread[] threads, AtomicReference<Throwable> nativeLibError) {
+        for (Thread thread : threads) {
+            try {
+                thread.join();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException("Interrupted while loading native libraries", e);
+            }
+        }
+
+        Throwable loadError = nativeLibError.get();
+        if (loadError != null) {
+            throw new RuntimeException("Failed to load native libraries", loadError);
+        }
+    }
+
+    private static void runUnpackAllLibsAsync(Platform platform, Thread[] nativeLibThreads, AtomicReference<Throwable> nativeLibError) throws IOException {
         TimeProfiler.start("runUnpackAllLibsAsync");
-        // unpacking for these happens in static initializers
-        new TexcLibraryJni();
-        new ShadercJni();
-        new ModelImporterJni();
-
         // regular libs
         String platformPair = platform.getPair();
         File targetDir = new File(Bob.getRootFolder(), platformPair);
@@ -109,6 +160,7 @@ public class PackedResources {
         } else {
             throw new IOException("Unsupported protocol for /libexec/" + platformPair + ": " + libexecRoot.getProtocol());
         }
+        awaitNativeLibLoads(nativeLibThreads, nativeLibError);
         TimeProfiler.stop();
     }
 
@@ -122,9 +174,11 @@ public class PackedResources {
             }
             unpackStarted = true;
         }
+        final AtomicReference<Throwable> nativeLibError = new AtomicReference<>();
+        final Thread[] nativeLibThreads = startNativeLibLoads(nativeLibError);
         Thread unpackThread = new Thread(() -> {
             try {
-                runUnpackAllLibsAsync(platform);
+                runUnpackAllLibsAsync(platform, nativeLibThreads, nativeLibError);
             } catch (IOException e) {
                 throw new RuntimeException("Failed to unpack tools", e);
             } finally {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/TextureUtil.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/TextureUtil.java
@@ -50,7 +50,9 @@ import static com.dynamo.bob.util.MiscUtil.concatenateArrays;
 public class TextureUtil {
 
     static {
+        TimeProfiler.start("ImageIO.setUseCache");
         ImageIO.setUseCache(false);
+        TimeProfiler.stop();
     }
 
     public static int closestPOT(int i) {


### PR DESCRIPTION
Load the native libraries used for shader, model and texture building in advance during Bob’s initialisation stage, and do it in parallel. This can save up to 2 seconds during a rebuild when all three libraries are needed. While that might not be a big deal for a full build, for sequential builds (builds without `clean`) it can be a noticeable improvement (for example, 4s -> 2s).

# Technical details

Native lib loading may take up to a second:
<img width="1418" height="1464" alt="CleanShot 2025-11-26 at 16 09 51@2x" src="https://github.com/user-attachments/assets/080b8a6c-74ee-4be4-b101-f7bf7d39058c" />


That’s why I decided to load them in parallel while unpacking the other libs and initializing Bob. It uses the same mechanism as the other library unpacking, and before we start creating tasks we wait until all libs are fully unpacked and loaded via `ensureBobInitialized`.