### PR TITLE
Fix issues around textures shared between Model Scenes

### DIFF
--- a/editor/src/clj/editor/buffers.clj
+++ b/editor/src/clj/editor/buffers.clj
@@ -19,7 +19,7 @@
             [util.defonce :as defonce]
             [util.fn :as fn]
             [util.num :as num])
-  (:import [clojure.lang Counted IHashEq IReduceInit Murmur3 Util]
+  (:import [clojure.lang Counted IHashEq IReduceInit Murmur3]
            [com.google.protobuf ByteString]
            [java.nio Buffer ByteBuffer ByteOrder CharBuffer DoubleBuffer FloatBuffer IntBuffer LongBuffer ShortBuffer]
            [java.nio.charset StandardCharsets]))
@@ -317,9 +317,10 @@
 
 (defn topology-hash
   ^long [^Buffer buffer]
-  (-> (hash (class buffer))
-      (Util/hashCombine (.hashCode (byte-order buffer)))
-      (Util/hashCombine (Murmur3/hashLong (total-byte-size buffer)))))
+  (java/combine-hashes
+    (hash (class buffer))
+    (.hashCode (byte-order buffer))
+    (Murmur3/hashLong (total-byte-size buffer))))
 
 (defn topology-equals? [^Buffer a ^Buffer b]
   (and (= (class a) (class b))
@@ -388,12 +389,14 @@
   Object
   (hashCode [this]
     (.hasheq this))
+
   (equals [this that]
     (or (identical? this that)
         (let [^BufferData that that]
           (and (instance? BufferData that)
                (= data-version (.-data-version that))
                (= topology-hash (.-topology-hash that))))))
+
   (toString [_this]
     (format "data=[pos=%d lim=%d cap=%d] ver=%#x"
             (.position data)

--- a/editor/src/clj/editor/cubemap.clj
+++ b/editor/src/clj/editor/cubemap.clj
@@ -20,7 +20,6 @@
             [editor.gl :as gl]
             [editor.gl.pass :as pass]
             [editor.gl.shader :as shader]
-            [editor.gl.texture :as texture]
             [editor.gl.vertex :as vtx]
             [editor.graph-util :as gu]
             [editor.image :as image]
@@ -31,12 +30,12 @@
             [editor.resource :as resource]
             [editor.resource-node :as resource-node]
             [editor.scene :as scene]
+            [editor.texture-util :as texture-util]
             [editor.types :as types]
             [editor.validation :as validation]
             [editor.workspace :as workspace])
   (:import [com.dynamo.graphics.proto Graphics$Cubemap]
-           [com.jogamp.opengl GL GL2]
-           [java.awt.image BufferedImage]))
+           [com.jogamp.opengl GL2]))
 
 (set! *warn-on-reflection* true)
 
@@ -86,14 +85,10 @@
     (shader/set-uniform cubemap-shader gl "world" geom/Identity4d)
     (shader/set-uniform cubemap-shader gl "cameraPosition" (types/position camera))
     (shader/set-uniform cubemap-shader gl "envMap" 0)
-    (gl/gl-enable gl GL/GL_CULL_FACE)
-    (gl/gl-cull-face gl GL/GL_BACK)
-    (gl/gl-draw-arrays gl GL/GL_TRIANGLES 0 (* 6 (* sphere-lats sphere-longs)))
-    (gl/gl-disable gl GL/GL_CULL_FACE)))
-
-(g/defnk produce-gpu-texture
-  [_node-id gpu-texture-generator]
-  ((:f gpu-texture-generator) (:args gpu-texture-generator) _node-id texture/default-cubemap-texture-params 0))
+    (gl/gl-enable gl GL2/GL_CULL_FACE)
+    (gl/gl-cull-face gl GL2/GL_BACK)
+    (gl/gl-draw-arrays gl GL2/GL_TRIANGLES 0 (* 6 (* sphere-lats sphere-longs)))
+    (gl/gl-disable gl GL2/GL_CULL_FACE)))
 
 (g/defnk produce-save-value [right left top bottom front back]
   (protobuf/make-map-without-defaults Graphics$Cubemap
@@ -117,20 +112,12 @@
                   :tags #{:cubemap}
                   :passes [pass/transparent]}}))
 
-(defn- cubemap-side-setter [resource-label image-label image-generator-label size-label]
+(defn- cubemap-side-setter [resource-label image-generator-label size-label]
   (fn [evaluation-context self old-value new-value]
     (project/resource-setter evaluation-context self old-value new-value
                              [:resource resource-label]
-                             [:content image-label]
                              [:content-generator image-generator-label]
                              [:size size-label])))
-
-(defn- generate-gpu-texture [{:keys [cubemap-images texture-profile]} request-id params unit]
-  (texture/cubemap-texture-images->gpu-texture
-    request-id
-    (tex-gen/make-preview-cubemap-texture-images cubemap-images texture-profile)
-    params
-    unit))
 
 (defn- generate-images [image-generators]
   (into {}
@@ -209,42 +196,42 @@
 
   (property right resource/Resource                         ; Required protobuf field.
             (value (gu/passthrough right-resource))
-            (set (cubemap-side-setter :right-resource :right-image :right-image-generator :right-size))
+            (set (cubemap-side-setter :right-resource :right-image-generator :right-size))
             (dynamic edit-type (g/constantly {:type resource/Resource :ext image/exts}))
             (dynamic error (cubemap-side-error right))
             (dynamic label (properties/label-dynamic :cubemap :right))
             (dynamic tooltip (properties/tooltip-dynamic :cubemap :right)))
   (property left resource/Resource                          ; Required protobuf field.
             (value (gu/passthrough left-resource))
-            (set (cubemap-side-setter :left-resource :left-image :left-image-generator :left-size))
+            (set (cubemap-side-setter :left-resource :left-image-generator :left-size))
             (dynamic edit-type (g/constantly {:type resource/Resource :ext image/exts}))
             (dynamic error (cubemap-side-error left))
             (dynamic label (properties/label-dynamic :cubemap :left))
             (dynamic tooltip (properties/tooltip-dynamic :cubemap :left)))
   (property top resource/Resource                           ; Required protobuf field.
             (value (gu/passthrough top-resource))
-            (set (cubemap-side-setter :top-resource :top-image :top-image-generator :top-size))
+            (set (cubemap-side-setter :top-resource :top-image-generator :top-size))
             (dynamic edit-type (g/constantly {:type resource/Resource :ext image/exts}))
             (dynamic error (cubemap-side-error top))
             (dynamic label (properties/label-dynamic :cubemap :top))
             (dynamic tooltip (properties/tooltip-dynamic :cubemap :top)))
   (property bottom resource/Resource                        ; Required protobuf field.
             (value (gu/passthrough bottom-resource))
-            (set (cubemap-side-setter :bottom-resource :bottom-image :bottom-image-generator :bottom-size))
+            (set (cubemap-side-setter :bottom-resource :bottom-image-generator :bottom-size))
             (dynamic edit-type (g/constantly {:type resource/Resource :ext image/exts}))
             (dynamic error (cubemap-side-error bottom))
             (dynamic label (properties/label-dynamic :cubemap :bottom))
             (dynamic tooltip (properties/tooltip-dynamic :cubemap :bottom)))
   (property front resource/Resource                         ; Required protobuf field.
             (value (gu/passthrough front-resource))
-            (set (cubemap-side-setter :front-resource :front-image :front-image-generator :front-size))
+            (set (cubemap-side-setter :front-resource :front-image-generator :front-size))
             (dynamic edit-type (g/constantly {:type resource/Resource :ext image/exts}))
             (dynamic error (cubemap-side-error front))
             (dynamic label (properties/label-dynamic :cubemap :front))
             (dynamic tooltip (properties/tooltip-dynamic :cubemap :front)))
   (property back resource/Resource                          ; Required protobuf field.
             (value (gu/passthrough back-resource))
-            (set (cubemap-side-setter :back-resource :back-image :back-image-generator :back-size))
+            (set (cubemap-side-setter :back-resource :back-image-generator :back-size))
             (dynamic edit-type (g/constantly {:type resource/Resource :ext image/exts}))
             (dynamic error (cubemap-side-error back))
             (dynamic label (properties/label-dynamic :cubemap :back))
@@ -256,13 +243,6 @@
   (input bottom-resource resource/Resource)
   (input front-resource  resource/Resource)
   (input back-resource   resource/Resource)
-
-  (input right-image  BufferedImage)
-  (input left-image   BufferedImage)
-  (input top-image    BufferedImage)
-  (input bottom-image BufferedImage)
-  (input front-image  BufferedImage)
-  (input back-image   BufferedImage)
 
   (input right-image-generator  g/Any)
   (input left-image-generator   g/Any)
@@ -278,34 +258,33 @@
   (input front-size  g/Any)
   (input back-size   g/Any)
 
+  (output cubemap-image-resources g/Any
+          (g/fnk [right-resource left-resource top-resource bottom-resource front-resource back-resource]
+            {:px right-resource :nx left-resource :py top-resource :ny bottom-resource :pz front-resource :nz back-resource}))
 
-  (output cubemap-image-resources g/Any :cached (g/fnk [right-resource left-resource top-resource bottom-resource front-resource back-resource]
-                                                  {:px right-resource :nx left-resource :py top-resource :ny bottom-resource :pz front-resource :nz back-resource}))
+  (output cubemap-image-generators g/Any
+          (g/fnk [right-image-generator left-image-generator top-image-generator bottom-image-generator front-image-generator back-image-generator]
+            {:px right-image-generator :nx left-image-generator :py top-image-generator :ny bottom-image-generator :pz front-image-generator :nz back-image-generator}))
 
-  (output cubemap-images g/Any :cached (g/fnk [right-image left-image top-image bottom-image front-image back-image]
-                                         {:px right-image :nx left-image :py top-image :ny bottom-image :pz front-image :nz back-image}))
+  (output cubemap-image-sizes g/Any
+          (g/fnk [right-size left-size top-size bottom-size front-size back-size]
+            {:px right-size :nx left-size :py top-size :ny bottom-size :pz front-size :nz back-size}))
 
-  (output cubemap-image-generators g/Any (g/fnk [right-image-generator left-image-generator top-image-generator bottom-image-generator front-image-generator back-image-generator]
-                                           {:px right-image-generator :nx left-image-generator :py top-image-generator :ny bottom-image-generator :pz front-image-generator :nz back-image-generator}))
+  (output gpu-texture-generator g/Any :cached
+          (g/fnk [_node-id cubemap-image-resources cubemap-image-generators cubemap-image-sizes texture-profile]
+            (g/precluding-errors
+              [(cubemap-images-missing-error _node-id cubemap-image-resources)
+               (cubemap-image-sizes-error _node-id cubemap-image-sizes)]
+              (texture-util/make-cubemap-gpu-texture-generator _node-id cubemap-image-generators texture-profile))))
 
-
-  (output cubemap-image-sizes g/Any :cached (g/fnk [right-size left-size top-size bottom-size front-size back-size]
-                                              {:px right-size :nx left-size :py top-size :ny bottom-size :pz front-size :nz back-size}))
-
-  (output gpu-texture-generator g/Any :cached (g/fnk [_node-id cubemap-image-resources cubemap-images cubemap-image-sizes texture-profile]
-                                                (g/precluding-errors
-                                                  [(cubemap-images-missing-error _node-id cubemap-image-resources)
-                                                   (cubemap-image-sizes-error _node-id cubemap-image-sizes)]
-                                                  {:f generate-gpu-texture
-                                                   :args {:cubemap-images cubemap-images
-                                                          :texture-profile texture-profile}})))
+  (output gpu-texture g/Any :cached
+          (g/fnk [gpu-texture-generator]
+            (texture-util/generate-cubemap-gpu-texture gpu-texture-generator)))
 
   (output build-targets g/Any :cached produce-build-targets)
-
   (output transform-properties g/Any scene/produce-no-transform-properties)
-  (output gpu-texture g/Any :cached produce-gpu-texture)
-  (output save-value  g/Any :cached produce-save-value)
-  (output scene       g/Any :cached produce-scene))
+  (output save-value g/Any :cached produce-save-value)
+  (output scene g/Any :cached produce-scene))
 
 (defn load-cubemap [project self resource cubemap]
   {:pre [(map? cubemap)]} ; Graphics$Cubemap in map format.

--- a/editor/src/clj/editor/cubemap.clj
+++ b/editor/src/clj/editor/cubemap.clj
@@ -279,7 +279,7 @@
 
   (output gpu-texture g/Any :cached
           (g/fnk [gpu-texture-generator]
-            (texture-util/generate-cubemap-gpu-texture gpu-texture-generator)))
+            (texture-util/generate-gpu-texture gpu-texture-generator)))
 
   (output build-targets g/Any :cached produce-build-targets)
   (output transform-properties g/Any scene/produce-no-transform-properties)

--- a/editor/src/clj/editor/font.clj
+++ b/editor/src/clj/editor/font.clj
@@ -837,7 +837,7 @@
                                                    h (:cache-height font-map)
                                                    channels (:glyph-channels font-map)
                                                    data-format (glyph-channels->data-format channels)]
-                                               (texture/empty-texture _node-id w h data-format
+                                               (texture/empty-texture _node-id data-format w h
                                                                       (material/sampler->tex-params (first material-samplers)) 0)))))
   (output material-shader ShaderLifecycle (gu/passthrough material-shader))
   (output type g/Keyword produce-font-type)
@@ -968,7 +968,7 @@
                                                   (.put src-data)
                                                   (.flip))]
                                    (when (> (:glyph-data-size glyph) 0)
-                                     (texture/tex-sub-image gl texture 0 tgt-data x y w h data-format))
+                                     (texture/update-sub-image! texture gl 0 tgt-data data-format x y w h))
                                    (assoc m glyph {:x x :y y})))))))
             glyph)))))
 

--- a/editor/src/clj/editor/gl/texture.clj
+++ b/editor/src/clj/editor/gl/texture.clj
@@ -14,25 +14,78 @@
 
 (ns editor.gl.texture
   "Functions for creating and using textures"
-  (:require [editor.gl :as gl]
+  (:require [editor.buffers :as buffers]
+            [editor.gl :as gl]
             [editor.gl.types :as gl.types]
             [editor.graphics.types :as graphics.types]
             [editor.image-util :as image-util]
             [editor.scene-cache :as scene-cache]
-            [internal.util :as util]
+            [internal.java :as java]
             [service.log :as log]
             [util.coll :as coll]
             [util.defonce :as defonce])
-  (:import [com.dynamo.bob.pipeline TextureGenerator$GenerateResult]
+  (:import [clojure.lang IHashEq Murmur3 Util]
+           [com.dynamo.bob.pipeline TextureGenerator$GenerateResult]
            [com.dynamo.graphics.proto Graphics$TextureImage Graphics$TextureImage$Image Graphics$TextureImage$TextureFormat]
            [com.jogamp.opengl GL GL2 GL3 GLProfile]
            [com.jogamp.opengl.util.awt ImageUtil]
            [com.jogamp.opengl.util.texture Texture TextureData TextureIO]
            [java.awt.image BufferedImage DataBufferByte]
-           [java.nio Buffer ByteBuffer]))
+           [java.nio Buffer ByteBuffer]
+           [java.util Arrays]))
 
 (set! *warn-on-reflection* true)
 (set! *unchecked-math* :warn-on-boxed)
+
+;; A wrapper around TextureData with equality semantics based on the topology of
+;; the TextureData and an explicit data version number. The TextureData class
+;; only implements reference equality, so in theory this would work fine as data
+;; for a scene cache request if the TextureData instance is cached. However,
+;; since we currently use an LRU cache, it is possible for several TextureData
+;; instances produced at different times to exist for the same source image.
+;; This wrapper exists to avoid expensive VRAM texture uploads if that happens.
+;; These duplicate instances of TextureDatas will still use unnecessary heap
+;; memory, but at least the frame rate won't tank.
+(defonce/type TextureRequestData
+  [^TextureData texture-data
+   ^int data-version
+   ^int topology-hash]
+
+  Comparable
+  (compareTo [_this that]
+    (let [^TextureRequestData that that]
+      (java/combine-comparisons
+        (Integer/compare data-version (.-data-version that))
+        (Integer/compare topology-hash (.-topology-hash that)))))
+
+  IHashEq
+  (hasheq [_this]
+    (java/combine-hashes topology-hash data-version))
+
+  Object
+  (hashCode [this]
+    (.hasheq this))
+
+  (equals [this that]
+    (or (identical? this that)
+        (let [^TextureRequestData that that]
+          (and (instance? TextureRequestData that)
+               (= data-version (.-data-version that))
+               (= topology-hash (.-topology-hash that))))))
+
+  (toString [_this]
+    (format "data=[%d x %d %s mipmap=%b] ver=%#x"
+            (.getWidth texture-data)
+            (.getHeight texture-data)
+            (.name (.-pfmt (.getPixelAttributes texture-data)))
+            (.getMipmap texture-data)
+            data-version)))
+
+(defn texture-request-data? [value]
+  (instance? TextureRequestData value))
+
+(defn- texture-request-data-has-mipmaps? [^TextureRequestData texture-request-data]
+  (< 1 (count (.getMipmapData ^TextureData (.-texture-data texture-request-data)))))
 
 (def
   ^{:doc "Special constant used as the page-count for non-paged textures.
@@ -115,15 +168,12 @@
     (conj request-id sub-request-id)
     [request-id sub-request-id]))
 
-(defn- texture-data-has-mipmaps? [^TextureData texture-data]
-  (< 1 (count (.getMipmapData texture-data))))
-
 (defonce/protocol TextureProxy
   (->texture ^Texture [this ^GL2 gl texture-array-index]))
 
 (declare texture-lifecycle->texture bind-texture-lifecycle! unbind-texture-lifecycle!)
 
-(defonce/record TextureLifecycle [request-id cache-id params texture-datas texture-units]
+(defonce/record TextureLifecycle [request-id cache-id params texture-request-datas texture-units]
   TextureProxy
   (->texture [this gl texture-array-index]
     (texture-lifecycle->texture this gl texture-array-index))
@@ -137,30 +187,25 @@
 
 (defn- texture-lifecycle->texture
   ^Texture [^TextureLifecycle texture-lifecycle gl texture-array-index]
-  ;; A note about equality: The TextureData class, which constitutes the data
-  ;; for the scene-cache request, is only reference-equatable. To avoid churn,
-  ;; you should make sure the TextureData is produced once and cached somewhere.
-  ;; If new TextureData instances are created with each request, you will be
-  ;; continuously re-uploading new texture buffers to VRAM.
   (let [request-id (.-request-id texture-lifecycle)
         cache-id (.-cache-id texture-lifecycle)
-        texture-datas (.-texture-datas texture-lifecycle)
+        texture-request-datas (.-texture-request-datas texture-lifecycle)
         texture-request-id (merge-request-ids request-id texture-array-index)
-        texture-data (texture-datas texture-array-index)]
-    (scene-cache/request-object! cache-id texture-request-id gl texture-data)))
+        texture-request-data (texture-request-datas texture-array-index)]
+    (scene-cache/request-object! cache-id texture-request-id gl texture-request-data)))
 
 (defn- bind-texture-lifecycle!
   [^TextureLifecycle texture-lifecycle gl]
   (let [params (.-params texture-lifecycle)
-        texture-datas (.-texture-datas texture-lifecycle)
+        texture-request-datas (.-texture-request-datas texture-lifecycle)
         texture-units (.-texture-units texture-lifecycle)]
-    (doseq [texture-unit-index (range 0 (min (count texture-units) (count texture-datas)))]
-      (let [texture-unit (int (texture-units texture-unit-index))
-            texture-data (texture-datas texture-unit-index)
+    (doseq [texture-unit-index (range 0 (min (count texture-units) (count texture-request-datas)))]
+      (let [texture-unit (int (nth texture-units texture-unit-index))
+            texture-request-data (texture-request-datas texture-unit-index)
             gl-texture-unit (+ texture-unit GL2/GL_TEXTURE0)
-            has-mipmaps (if (map? texture-data) ; Cubemaps have maps of side keywords to TextureData.
-                          (some-> texture-data first val texture-data-has-mipmaps?)
-                          (texture-data-has-mipmaps? texture-data))]
+            has-mipmaps (if (map? texture-request-data) ; Cubemaps have maps of side-kws to TextureRequestData.
+                          (some-> texture-request-data first val texture-request-data-has-mipmaps?)
+                          (texture-request-data-has-mipmaps? texture-request-data))]
         (.glActiveTexture ^GL2 gl gl-texture-unit) ; Set the active texture unit. Implicit parameter to (.bind ...) and (texture-lifecycle->texture ...)
         (let [texture (texture-lifecycle->texture texture-lifecycle gl texture-unit-index)
               gl-target (.getTarget texture)]
@@ -170,10 +215,10 @@
 
 (defn- unbind-texture-lifecycle!
   [^TextureLifecycle texture-lifecycle gl]
-  (let [texture-datas (.-texture-datas texture-lifecycle)
+  (let [texture-request-datas (.-texture-request-datas texture-lifecycle)
         texture-units (.-texture-units texture-lifecycle)]
-    (doseq [texture-unit-index (range 0 (min (count texture-units) (count texture-datas)))]
-      (let [texture-unit (int (texture-units texture-unit-index))
+    (doseq [texture-unit-index (range 0 (min (count texture-units) (count texture-request-datas)))]
+      (let [texture-unit (int (nth texture-units texture-unit-index))
             gl-texture-unit (+ texture-unit GL2/GL_TEXTURE0)]
         (.glActiveTexture ^GL2 gl gl-texture-unit) ; Set the active texture unit. Implicit parameter to (.glBindTexture ...) and (texture-lifecycle->texture ...)
         (let [tex (texture-lifecycle->texture texture-lifecycle gl texture-unit-index)
@@ -185,8 +230,25 @@
 (defn texture-lifecycle? [value]
   (instance? TextureLifecycle value))
 
-(defn set-params [^TextureLifecycle tlc params]
-  (update tlc :params merge params))
+(defn set-params
+  ^TextureLifecycle [^TextureLifecycle texture-lifecycle texture-params]
+  ;; Return nil or ErrorValue unaltered.
+  (if (texture-lifecycle? texture-lifecycle)
+    (update texture-lifecycle :params coll/merge texture-params)
+    texture-lifecycle))
+
+(defn set-base-unit
+  ^TextureLifecycle [^TextureLifecycle texture-lifecycle ^long base-texture-unit]
+  {:pre [(nat-int? base-texture-unit)]}
+  ;; Return nil or ErrorValue unaltered.
+  (if (texture-lifecycle? texture-lifecycle)
+    (assoc texture-lifecycle
+      :texture-units
+      (apply vector-of :int
+             (range base-texture-unit
+                    (+ base-texture-unit
+                       (count (.-texture-request-datas texture-lifecycle))))))
+    texture-lifecycle))
 
 (def
   ^{:doc "If you do not supply parameters to `image-texture`, these will be used as defaults."}
@@ -233,45 +295,78 @@
     BufferedImage/TYPE_4BYTE_ABGR :abgr
     BufferedImage/TYPE_4BYTE_ABGR_PRE :abgr))
 
-(defn make-texture-data
-  ^TextureData [^Buffer data width height data-format mipmap]
+(defn- make-texture-data
+  "For internal use only - Use the make-texture-request-data function to
+ construct a TextureRequestData instead."
+  ^TextureData [^Buffer data data-format width height mipmap]
   (let [internal-format (data-format->internal-format data-format)
         pixel-format (data-format->pixel-format data-format)
         type (data-format->type data-format)
         border 0]
     (TextureData. (GLProfile/getGL2GL3) internal-format width height border pixel-format type mipmap false false data nil)))
 
-(defn image->texture-data
-  ^TextureData [^BufferedImage img mipmap]
+(defn texture-data-topology-hash
+  ^long [^TextureData texture-data]
+  (java/combine-hashes
+    (Murmur3/hashInt (.getWidth texture-data))
+    (Murmur3/hashInt (.getHeight texture-data))
+    (Murmur3/hashInt (.getBorder texture-data))
+    (.hashCode (.getPixelAttributes texture-data))
+    (Murmur3/hashInt (.getInternalFormat texture-data))
+    (hash (.getMipmap texture-data))
+    (hash (.isDataCompressed texture-data))
+    (hash (.getMustFlipVertically texture-data))
+    (Murmur3/hashInt (.getAlignment texture-data))
+    (Murmur3/hashInt (.getRowLength texture-data))))
+
+(defn make-texture-request-data
+  ^TextureRequestData [^Buffer data data-version data-format width height mipmap]
+  (let [texture-data (make-texture-data data data-format width height mipmap)
+        topology-hash (texture-data-topology-hash texture-data)]
+    (TextureRequestData. texture-data (int data-version) topology-hash)))
+
+(defn image->texture-request-data
+  ^TextureRequestData [^BufferedImage img mipmap]
   (let [channels (image-util/image-color-components img)
         type (case channels
                4 BufferedImage/TYPE_4BYTE_ABGR_PRE
                3 BufferedImage/TYPE_3BYTE_BGR
                1 BufferedImage/TYPE_BYTE_GRAY)
         img (image-util/image-convert-type img type)
-        data-type (image-type->data-format type)
-        data (ByteBuffer/wrap (.getData ^DataBufferByte (.getDataBuffer (.getRaster img))))]
-    (make-texture-data data (.getWidth img) (.getHeight img) data-type mipmap)))
+        img-bytes (.getData ^DataBufferByte (.getDataBuffer (.getRaster img)))
+        data (buffers/wrap-byte-array img-bytes :byte-order/native)
+        data-version (buffers/data-hash data)
+        data-format (image-type->data-format type)]
+    (make-texture-request-data data data-version data-format (.getWidth img) (.getHeight img) mipmap)))
 
-(def ^:private placeholder-texture-datas
-  [(image->texture-data (:contents image-util/placeholder-image) true)])
+(def placeholder-texture-request-datas
+  [(image->texture-request-data (:contents image-util/placeholder-image) true)])
 
 (defn- make-gpu-texture-impl
-  ^TextureLifecycle [request-id cache-id params texture-datas texture-units]
+  ^TextureLifecycle [request-id cache-id params texture-request-datas texture-units]
   {:pre [(graphics.types/request-id? request-id)
          (keyword? cache-id)
          (map? params)
          (= :int (coll/primitive-vector-type texture-units))
-         (= (count texture-datas) (count texture-units))]}
-  (->TextureLifecycle request-id cache-id params texture-datas texture-units))
+         (= (count texture-request-datas) (count texture-units))]}
+  (->TextureLifecycle request-id cache-id params texture-request-datas texture-units))
 
 (defn make-gpu-texture
-  "Create a 2D TextureLifecycle from the supplied vector of TextureDatas and the
-  supplied int primitive vector of texture units to assign them to."
-  ^TextureLifecycle [request-id texture-datas texture-units texture-params]
-  {:pre [(vector? texture-datas)
-         (every? #(instance? TextureData %) texture-datas)]}
-  (make-gpu-texture-impl request-id ::texture texture-params texture-datas texture-units))
+  "Create a 2D TextureLifecycle from the supplied vector of TextureRequestDatas
+  and the supplied (vector-of :int) of texture units to assign them to. The
+  returned value satisfies the GLBinding protocol.
+
+  The texture-units argument should be a (vector-of :int) of offsets from
+  GL_TEXTURE0 that the Textures created from the texture-request-datas should be
+  assigned to when the TextureLifecycle is bound.
+
+  The texture-params argument must be a map of parameter names to OpenGL values.
+  Parameter names can be OpenGL constants (e.g., GL_TEXTURE_WRAP_S) or their
+  keyword equivalents from `texture-params` (e.g., :wrap-s)."
+  ^TextureLifecycle [request-id texture-request-datas texture-units texture-params]
+  {:pre [(vector? texture-request-datas)
+         (every? texture-request-data? texture-request-datas)]}
+  (make-gpu-texture-impl request-id ::texture texture-params texture-request-datas texture-units))
 
 (defn- flip-y
   ^BufferedImage [^BufferedImage img]
@@ -295,17 +390,20 @@
 
   If supplied, the unit is the offset of GL_TEXTURE0, i.e. 0 => GL_TEXTURE0. The
   default is 0."
-  ([request-id img]
-   (image-texture request-id img default-image-texture-params 0))
-  ([request-id img params]
-   (image-texture request-id img params 0))
-  ([request-id ^BufferedImage img params unit-index]
-   (let [texture-datas (if img
-                         [(image->texture-data (flip-y img) true)]
-                         placeholder-texture-datas)
+  (^TextureLifecycle [request-id ^BufferedImage buffered-image]
+   (image-texture request-id buffered-image default-image-texture-params 0))
+  (^TextureLifecycle [request-id ^BufferedImage buffered-image params]
+   (image-texture request-id buffered-image params 0))
+  (^TextureLifecycle [request-id ^BufferedImage buffered-image params unit-index]
+   {:pre [(nat-int? unit-index)]}
+   (let [texture-request-datas
+         (if buffered-image
+           [(image->texture-request-data (flip-y buffered-image) true)]
+           placeholder-texture-request-datas)
+
          texture-units (vector-of :int unit-index)
-         texture-params (or params default-image-texture-params)]
-     (make-gpu-texture request-id texture-datas texture-units texture-params))))
+         texture-params (coll/merge default-image-texture-params params)]
+     (make-gpu-texture request-id texture-request-datas texture-units texture-params))))
 
 (def format->gl-format
   {Graphics$TextureImage$TextureFormat/TEXTURE_FORMAT_LUMINANCE
@@ -334,66 +432,62 @@
           (recur (inc i)))
         bufs))))
 
-(defn texture-image->texture-data
-  ^TextureData [^TextureGenerator$GenerateResult texture-generate-result]
-  (let [texture-image (.textureImage texture-generate-result)
-        mip-image-byte-arrays (.imageDatas texture-generate-result)
-        image (select-texture-image-image texture-image)
-        gl-profile (GLProfile/getGL2GL3)
-        gl-format (int (format->gl-format (.getFormat image)))
-        mipmap-buffers (image->mipmap-buffers image mip-image-byte-arrays)]
-    (TextureData. gl-profile
-                  gl-format
-                  (.getWidth image)
-                  (.getHeight image)
-                  0                       ; border
-                  gl-format
-                  GL/GL_UNSIGNED_BYTE     ; gl type
-                  false                   ; compressed?
-                  false                   ; flip vertically?
-                  mipmap-buffers
-                  nil)))
+(defn texture-image->texture-request-data
+  (^TextureRequestData [^TextureGenerator$GenerateResult texture-generator-result]
+   (let [data-version
+         (transduce
+           (map ^[byte/1] Arrays/hashCode)
+           (fn
+             (^long [^long hash] hash)
+             (^long [^long seed ^long hash] (Util/hashCombine seed hash)))
+           0
+           (.-imageDatas texture-generator-result))]
+     (texture-image->texture-request-data texture-generator-result data-version)))
+  (^TextureRequestData [^TextureGenerator$GenerateResult texture-generator-result data-version]
+   (let [texture-image (.textureImage texture-generator-result)
+         mip-image-byte-arrays (.imageDatas texture-generator-result)
+         image (select-texture-image-image texture-image)
+         gl-profile (GLProfile/getGL2GL3)
+         gl-format (int (format->gl-format (.getFormat image)))
+         mipmap-buffers (image->mipmap-buffers image mip-image-byte-arrays)
 
+         texture-data
+         (TextureData.
+           gl-profile
+           gl-format
+           (.getWidth image)
+           (.getHeight image)
+           0                   ; border
+           gl-format
+           GL/GL_UNSIGNED_BYTE ; gl type
+           false               ; compressed?
+           false               ; flip vertically?
+           mipmap-buffers
+           nil)
+
+         topology-hash (texture-data-topology-hash texture-data)]
+
+     (TextureRequestData. texture-data (int data-version) topology-hash))))
+
+;; SDK api (DEPRECATE with the next release of extension-texturepacker).
 (defn texture-images->gpu-texture
   ([request-id texture-images]
    (texture-images->gpu-texture request-id texture-images default-image-texture-params 0))
   ([request-id texture-images params]
    (texture-images->gpu-texture request-id texture-images params 0))
-  ([request-id texture-images params ^long start-texture-unit]
-   (let [texture-datas (mapv texture-image->texture-data texture-images)
-         texture-units (into (vector-of :int)
-                             (range start-texture-unit (+ start-texture-unit (count texture-images))))
+  ([request-id texture-images params ^long base-texture-unit]
+   (let [texture-request-datas (mapv texture-image->texture-request-data texture-images)
+         texture-units (apply vector-of :int (range base-texture-unit (+ base-texture-unit (count texture-images))))
          texture-params (or params default-image-texture-params)]
-     (make-gpu-texture request-id texture-datas texture-units texture-params))))
+     (make-gpu-texture request-id texture-request-datas texture-units texture-params))))
 
-(defn texture-image->gpu-texture
-  "Create an image texture from a generated `TextureImage`. The returned value
-  satisfies the GLBinding protocol.
-
-  If supplied, the params argument must be a map of parameter name to value.
-  Parameter names can be OpenGL constants (e.g., GL_TEXTURE_WRAP_S) or their
-  keyword equivalents from `texture-params` (e.g., :wrap-s).
-
-  If you supply parameters, then those parameters are used. If you do not supply
-  parameters, then defaults in `default-image-texture-params` are used.
-
-  If supplied, the unit is the offset of GL_TEXTURE0, i.e. 0 => GL_TEXTURE0. The
-  default is 0."
-  ([request-id img]
-   (texture-image->gpu-texture request-id img default-image-texture-params 0))
-  ([request-id img params]
-   (texture-image->gpu-texture request-id img params 0))
-  ([request-id ^Graphics$TextureImage img params unit-index]
-   (let [texture-datas [(texture-image->texture-data img)]
-         texture-units (vector-of :int unit-index)
-         texture-params (or params default-image-texture-params)]
-     (make-gpu-texture request-id texture-datas texture-units texture-params))))
-
-(defn empty-texture [request-id width height data-format params unit-index]
-  {:pre [(graphics.types/request-id? request-id)]}
-  (let [texture-datas [(make-texture-data nil width height data-format false)]
+(defn empty-texture [request-id data-format width height params unit-index]
+  {:pre [(graphics.types/request-id? request-id)
+         (nat-int? unit-index)]}
+  (let [unit-index (int unit-index)
+        texture-request-datas [(make-texture-request-data nil 0 data-format width height false)]
         texture-units (vector-of :int unit-index)]
-    (make-gpu-texture request-id texture-datas texture-units params)))
+    (make-gpu-texture request-id texture-request-datas texture-units params)))
 
 (defonce white-pixel
   (delay
@@ -415,9 +509,18 @@
         :min-filter GL2/GL_NEAREST
         :mag-filter GL2/GL_NEAREST))))
 
-(defn tex-sub-image [^GL2 gl ^TextureLifecycle texture page-index data x y w h data-format]
+(defonce placeholder
+  (delay
+    (image-texture
+      ::placeholder
+      nil
+      (assoc default-image-texture-params
+        :min-filter GL2/GL_NEAREST
+        :mag-filter GL2/GL_NEAREST))))
+
+(defn update-sub-image! [^TextureLifecycle texture ^GL2 gl page-index data data-format x y w h]
   (let [tex (->texture texture gl page-index)
-        data (make-texture-data data w h data-format false)]
+        data (make-texture-data data data-format w h false)]
     (.updateSubImage tex gl data 0 x y)))
 
 (def default-cubemap-texture-params
@@ -435,40 +538,38 @@
    :pz GL/GL_TEXTURE_CUBE_MAP_POSITIVE_Z
    :nz GL/GL_TEXTURE_CUBE_MAP_NEGATIVE_Z})
 
-(defn- texture-datas-by-side-kw-map? [value]
+(defn cubemap-side-kw? [value]
+  (contains? cubemap-gl-targets-by-side-kw value))
+
+(defn- texture-request-datas-by-side-kw-map? [value]
   (and (map? value)
-       (every? (fn [[side-kw texture-data]]
+       (every? (fn [[side-kw texture-request-data]]
                  (and (contains? cubemap-gl-targets-by-side-kw side-kw)
-                      (instance? TextureData texture-data)))
+                      (texture-request-data? texture-request-data)))
                value)))
 
 (defn make-gpu-cubemap-texture
   "Create a cubemap TextureLifecycle from the supplied vector of maps of cubemap
-  side keywords to TextureDatas. The texture-units should be an int primitive
-  vector of texture units to assign the cubemaps to."
-  ^TextureLifecycle [request-id vector-of-texture-datas-by-side-kw-maps texture-units texture-params]
-  {:pre [(vector? vector-of-texture-datas-by-side-kw-maps)
-         (every? texture-datas-by-side-kw-map? vector-of-texture-datas-by-side-kw-maps)]}
-  (make-gpu-texture-impl request-id ::cubemap-texture texture-params vector-of-texture-datas-by-side-kw-maps texture-units))
+  side-kws to TextureRequestDatas.
 
-(defn cubemap-texture-images->gpu-texture
-  ([request-id texture-images]
-   (cubemap-texture-images->gpu-texture request-id texture-images default-cubemap-texture-params))
-  ([request-id texture-images params]
-   (cubemap-texture-images->gpu-texture request-id texture-images params 0))
-  ([request-id texture-images params unit-index]
-   {:pre [(graphics.types/request-id? request-id)
-          (or (nil? params) (map? params))]}
-   (let [vector-of-texture-datas-by-side-kw-maps [(util/map-vals texture-image->texture-data texture-images)]
-         texture-units (vector-of :int unit-index)
-         texture-params (or params default-cubemap-texture-params)]
-     (make-gpu-cubemap-texture request-id vector-of-texture-datas-by-side-kw-maps texture-units texture-params))))
+  The texture-units argument should be a (vector-of :int) of offsets from
+  GL_TEXTURE0 that the Textures created from the
+  texture-request-datas-by-side-kw-maps should be assigned to when the
+  TextureLifecycle is bound.
 
-(defn- make-texture [^GL2 gl ^TextureData texture-data]
-  (Texture. gl texture-data))
+  The texture-params argument must be a map of parameter names to OpenGL values.
+  Parameter names can be OpenGL constants (e.g., GL_TEXTURE_WRAP_S) or their
+  keyword equivalents from `texture-params` (e.g., :wrap-s)."
+  ^TextureLifecycle [request-id vector-of-texture-request-datas-by-side-kw-maps texture-units texture-params]
+  {:pre [(vector? vector-of-texture-request-datas-by-side-kw-maps)
+         (every? texture-request-datas-by-side-kw-map? vector-of-texture-request-datas-by-side-kw-maps)]}
+  (make-gpu-texture-impl request-id ::cubemap-texture texture-params vector-of-texture-request-datas-by-side-kw-maps texture-units))
 
-(defn- update-texture [^GL2 gl ^Texture texture ^TextureData texture-data]
-  (.updateImage texture gl texture-data)
+(defn- make-texture [^GL2 gl ^TextureRequestData texture-request-data]
+  (Texture. gl (.texture-data texture-request-data)))
+
+(defn- update-texture [^GL2 gl ^Texture texture ^TextureRequestData texture-request-data]
+  (.updateImage texture gl (.texture-data texture-request-data))
   texture)
 
 (defn- destroy-textures [^GL2 gl textures _]
@@ -477,13 +578,15 @@
 
 (scene-cache/register-object-cache! ::texture make-texture update-texture destroy-textures)
 
-(defn- update-cubemap-texture [^GL2 gl ^Texture texture texture-datas-by-side-kw]
-  (doseq [[side-kw gl-target] cubemap-gl-targets-by-side-kw]
-    (.updateImage texture gl ^TextureData (side-kw texture-datas-by-side-kw) gl-target))
+(defn- update-cubemap-texture [^GL2 gl ^Texture texture texture-request-datas-by-side-kw]
+  (doseq [[side-kw ^int gl-target] cubemap-gl-targets-by-side-kw]
+    (let [^TextureRequestData texture-request-data (get texture-request-datas-by-side-kw side-kw)
+          ^TextureData texture-data (.-texture-data texture-request-data)]
+      (.updateImage texture gl texture-data gl-target)))
   texture)
 
-(defn- make-cubemap-texture [^GL2 gl texture-datas-by-side-kw]
+(defn- make-cubemap-texture [^GL2 gl texture-request-datas-by-side-kw]
   (let [^Texture texture (TextureIO/newTexture GL/GL_TEXTURE_CUBE_MAP)]
-    (update-cubemap-texture gl texture texture-datas-by-side-kw)))
+    (update-cubemap-texture gl texture texture-request-datas-by-side-kw)))
 
 (scene-cache/register-object-cache! ::cubemap-texture make-cubemap-texture update-cubemap-texture destroy-textures)

--- a/editor/src/clj/editor/gl/texture.clj
+++ b/editor/src/clj/editor/gl/texture.clj
@@ -21,6 +21,7 @@
             [editor.scene-cache :as scene-cache]
             [internal.util :as util]
             [service.log :as log]
+            [util.coll :as coll]
             [util.defonce :as defonce])
   (:import [com.dynamo.bob.pipeline TextureGenerator$GenerateResult]
            [com.dynamo.graphics.proto Graphics$TextureImage Graphics$TextureImage$Image Graphics$TextureImage$TextureFormat]
@@ -136,6 +137,11 @@
 
 (defn- texture-lifecycle->texture
   ^Texture [^TextureLifecycle texture-lifecycle gl texture-array-index]
+  ;; A note about equality: The TextureData class, which constitutes the data
+  ;; for the scene-cache request, is only reference-equatable. To avoid churn,
+  ;; you should make sure the TextureData is produced once and cached somewhere.
+  ;; If new TextureData instances are created with each request, you will be
+  ;; continuously re-uploading new texture buffers to VRAM.
   (let [request-id (.-request-id texture-lifecycle)
         cache-id (.-cache-id texture-lifecycle)
         texture-datas (.-texture-datas texture-lifecycle)
@@ -190,7 +196,8 @@
    :wrap-s     gl/clamp
    :wrap-t     gl/clamp})
 
-(defn- data-format->internal-format [data-format]
+(defn- data-format->internal-format
+  ^long [data-format]
   ;; Internal format signifies only color content, not channel order.
   (case data-format
     :gray GL2/GL_LUMINANCE
@@ -199,7 +206,8 @@
     :rgb  GL2/GL_RGB
     :rgba GL2/GL_RGBA))
 
-(defn- data-format->pixel-format [data-format]
+(defn- data-format->pixel-format
+  ^long [data-format]
   ;; Pixel format signifies channel order.
   (case data-format
     :gray GL2/GL_LUMINANCE
@@ -208,7 +216,8 @@
     :rgb  GL2/GL_RGB
     :rgba GL2/GL_RGBA))
 
-(defn- data-format->type [data-format]
+(defn- data-format->type
+  ^long [data-format]
   ;; Type signifies packing / endian order.
   (case data-format
     :gray GL2/GL_UNSIGNED_BYTE
@@ -224,14 +233,16 @@
     BufferedImage/TYPE_4BYTE_ABGR :abgr
     BufferedImage/TYPE_4BYTE_ABGR_PRE :abgr))
 
-(defn- ->texture-data [width height data-format data mipmap]
+(defn make-texture-data
+  ^TextureData [^Buffer data width height data-format mipmap]
   (let [internal-format (data-format->internal-format data-format)
         pixel-format (data-format->pixel-format data-format)
         type (data-format->type data-format)
         border 0]
     (TextureData. (GLProfile/getGL2GL3) internal-format width height border pixel-format type mipmap false false data nil)))
 
-(defn- image->texture-data ^TextureData [img mipmap]
+(defn image->texture-data
+  ^TextureData [^BufferedImage img mipmap]
   (let [channels (image-util/image-color-components img)
         type (case channels
                4 BufferedImage/TYPE_4BYTE_ABGR_PRE
@@ -240,9 +251,30 @@
         img (image-util/image-convert-type img type)
         data-type (image-type->data-format type)
         data (ByteBuffer/wrap (.getData ^DataBufferByte (.getDataBuffer (.getRaster img))))]
-    (->texture-data (.getWidth img) (.getHeight img) data-type data mipmap)))
+    (make-texture-data data (.getWidth img) (.getHeight img) data-type mipmap)))
 
-(defn- flip-y [^BufferedImage img]
+(def ^:private placeholder-texture-datas
+  [(image->texture-data (:contents image-util/placeholder-image) true)])
+
+(defn- make-gpu-texture-impl
+  ^TextureLifecycle [request-id cache-id params texture-datas texture-units]
+  {:pre [(graphics.types/request-id? request-id)
+         (keyword? cache-id)
+         (map? params)
+         (= :int (coll/primitive-vector-type texture-units))
+         (= (count texture-datas) (count texture-units))]}
+  (->TextureLifecycle request-id cache-id params texture-datas texture-units))
+
+(defn make-gpu-texture
+  "Create a 2D TextureLifecycle from the supplied vector of TextureDatas and the
+  supplied int primitive vector of texture units to assign them to."
+  ^TextureLifecycle [request-id texture-datas texture-units texture-params]
+  {:pre [(vector? texture-datas)
+         (every? #(instance? TextureData %) texture-datas)]}
+  (make-gpu-texture-impl request-id ::texture texture-params texture-datas texture-units))
+
+(defn- flip-y
+  ^BufferedImage [^BufferedImage img]
   ;; Flip the image before we create a OGL texture, to mimic how UVs are handled in engine.
   ;; We do this since all our generated UVs are based on bottom-left being texture coord (0,0).
   (let [cm (.getColorModel img)
@@ -268,11 +300,12 @@
   ([request-id img params]
    (image-texture request-id img params 0))
   ([request-id ^BufferedImage img params unit-index]
-   {:pre [(graphics.types/request-id? request-id)]}
-   (let [texture-datas [(image->texture-data (flip-y (or img (:contents image-util/placeholder-image))) true)]
-         texture-units (vector-of :int unit-index)]
-     (->TextureLifecycle request-id ::texture params texture-datas texture-units))))
-
+   (let [texture-datas (if img
+                         [(image->texture-data (flip-y img) true)]
+                         placeholder-texture-datas)
+         texture-units (vector-of :int unit-index)
+         texture-params (or params default-image-texture-params)]
+     (make-gpu-texture request-id texture-datas texture-units texture-params))))
 
 (def format->gl-format
   {Graphics$TextureImage$TextureFormat/TEXTURE_FORMAT_LUMINANCE
@@ -301,7 +334,7 @@
           (recur (inc i)))
         bufs))))
 
-(defn- texture-image->texture-data
+(defn texture-image->texture-data
   ^TextureData [^TextureGenerator$GenerateResult texture-generate-result]
   (let [texture-image (.textureImage texture-generate-result)
         mip-image-byte-arrays (.imageDatas texture-generate-result)
@@ -321,18 +354,17 @@
                   mipmap-buffers
                   nil)))
 
-
 (defn texture-images->gpu-texture
   ([request-id texture-images]
    (texture-images->gpu-texture request-id texture-images default-image-texture-params 0))
   ([request-id texture-images params]
    (texture-images->gpu-texture request-id texture-images params 0))
   ([request-id texture-images params ^long start-texture-unit]
-   {:pre [(graphics.types/request-id? request-id)]}
    (let [texture-datas (mapv texture-image->texture-data texture-images)
          texture-units (into (vector-of :int)
-                             (range start-texture-unit (+ start-texture-unit (count texture-images))))]
-     (->TextureLifecycle request-id ::texture params texture-datas texture-units))))
+                             (range start-texture-unit (+ start-texture-unit (count texture-images))))
+         texture-params (or params default-image-texture-params)]
+     (make-gpu-texture request-id texture-datas texture-units texture-params))))
 
 (defn texture-image->gpu-texture
   "Create an image texture from a generated `TextureImage`. The returned value
@@ -352,16 +384,16 @@
   ([request-id img params]
    (texture-image->gpu-texture request-id img params 0))
   ([request-id ^Graphics$TextureImage img params unit-index]
-   {:pre [(graphics.types/request-id? request-id)]}
    (let [texture-datas [(texture-image->texture-data img)]
-         texture-units (vector-of :int unit-index)]
-      (->TextureLifecycle request-id ::texture params texture-datas texture-units))))
+         texture-units (vector-of :int unit-index)
+         texture-params (or params default-image-texture-params)]
+     (make-gpu-texture request-id texture-datas texture-units texture-params))))
 
 (defn empty-texture [request-id width height data-format params unit-index]
   {:pre [(graphics.types/request-id? request-id)]}
-  (let [texture-datas [(->texture-data width height data-format nil false)]
+  (let [texture-datas [(make-texture-data nil width height data-format false)]
         texture-units (vector-of :int unit-index)]
-    (->TextureLifecycle request-id ::texture params texture-datas texture-units)))
+    (make-gpu-texture request-id texture-datas texture-units params)))
 
 (defonce white-pixel
   (delay
@@ -385,7 +417,7 @@
 
 (defn tex-sub-image [^GL2 gl ^TextureLifecycle texture page-index data x y w h data-format]
   (let [tex (->texture texture gl page-index)
-        data (->texture-data w h data-format data false)]
+        data (make-texture-data data w h data-format false)]
     (.updateSubImage tex gl data 0 x y)))
 
 (def default-cubemap-texture-params
@@ -395,16 +427,42 @@
    :wrap-s     gl/clamp-to-edge
    :wrap-t     gl/clamp-to-edge})
 
+(def ^:private cubemap-gl-targets-by-side-kw
+  {:px GL/GL_TEXTURE_CUBE_MAP_POSITIVE_X
+   :nx GL/GL_TEXTURE_CUBE_MAP_NEGATIVE_X
+   :py GL/GL_TEXTURE_CUBE_MAP_POSITIVE_Y
+   :ny GL/GL_TEXTURE_CUBE_MAP_NEGATIVE_Y
+   :pz GL/GL_TEXTURE_CUBE_MAP_POSITIVE_Z
+   :nz GL/GL_TEXTURE_CUBE_MAP_NEGATIVE_Z})
+
+(defn- texture-datas-by-side-kw-map? [value]
+  (and (map? value)
+       (every? (fn [[side-kw texture-data]]
+                 (and (contains? cubemap-gl-targets-by-side-kw side-kw)
+                      (instance? TextureData texture-data)))
+               value)))
+
+(defn make-gpu-cubemap-texture
+  "Create a cubemap TextureLifecycle from the supplied vector of maps of cubemap
+  side keywords to TextureDatas. The texture-units should be an int primitive
+  vector of texture units to assign the cubemaps to."
+  ^TextureLifecycle [request-id vector-of-texture-datas-by-side-kw-maps texture-units texture-params]
+  {:pre [(vector? vector-of-texture-datas-by-side-kw-maps)
+         (every? texture-datas-by-side-kw-map? vector-of-texture-datas-by-side-kw-maps)]}
+  (make-gpu-texture-impl request-id ::cubemap-texture texture-params vector-of-texture-datas-by-side-kw-maps texture-units))
+
 (defn cubemap-texture-images->gpu-texture
   ([request-id texture-images]
    (cubemap-texture-images->gpu-texture request-id texture-images default-cubemap-texture-params))
   ([request-id texture-images params]
    (cubemap-texture-images->gpu-texture request-id texture-images params 0))
   ([request-id texture-images params unit-index]
-   {:pre [(graphics.types/request-id? request-id)]}
-   (let [texture-datas [(util/map-vals texture-image->texture-data texture-images)]
-         texture-units (vector-of :int unit-index)]
-     (->TextureLifecycle request-id ::cubemap-texture params texture-datas texture-units))))
+   {:pre [(graphics.types/request-id? request-id)
+          (or (nil? params) (map? params))]}
+   (let [vector-of-texture-datas-by-side-kw-maps [(util/map-vals texture-image->texture-data texture-images)]
+         texture-units (vector-of :int unit-index)
+         texture-params (or params default-cubemap-texture-params)]
+     (make-gpu-cubemap-texture request-id vector-of-texture-datas-by-side-kw-maps texture-units texture-params))))
 
 (defn- make-texture [^GL2 gl ^TextureData texture-data]
   (Texture. gl texture-data))
@@ -419,21 +477,13 @@
 
 (scene-cache/register-object-cache! ::texture make-texture update-texture destroy-textures)
 
-(def ^:private cubemap-targets
-  {:px GL/GL_TEXTURE_CUBE_MAP_POSITIVE_X
-   :nx GL/GL_TEXTURE_CUBE_MAP_NEGATIVE_X
-   :py GL/GL_TEXTURE_CUBE_MAP_POSITIVE_Y
-   :ny GL/GL_TEXTURE_CUBE_MAP_NEGATIVE_Y
-   :pz GL/GL_TEXTURE_CUBE_MAP_POSITIVE_Z
-   :nz GL/GL_TEXTURE_CUBE_MAP_NEGATIVE_Z})
-
-(defn- update-cubemap-texture [^GL2 gl ^Texture texture texture-datas]
-  (doseq [[target-key target] cubemap-targets]
-    (.updateImage texture gl ^TextureData (target-key texture-datas) target))
+(defn- update-cubemap-texture [^GL2 gl ^Texture texture texture-datas-by-side-kw]
+  (doseq [[side-kw gl-target] cubemap-gl-targets-by-side-kw]
+    (.updateImage texture gl ^TextureData (side-kw texture-datas-by-side-kw) gl-target))
   texture)
 
-(defn- make-cubemap-texture [^GL2 gl texture-datas]
+(defn- make-cubemap-texture [^GL2 gl texture-datas-by-side-kw]
   (let [^Texture texture (TextureIO/newTexture GL/GL_TEXTURE_CUBE_MAP)]
-    (update-cubemap-texture gl texture texture-datas)))
+    (update-cubemap-texture gl texture texture-datas-by-side-kw)))
 
 (scene-cache/register-object-cache! ::cubemap-texture make-cubemap-texture update-cubemap-texture destroy-textures)

--- a/editor/src/clj/editor/gl/types.clj
+++ b/editor/src/clj/editor/gl/types.clj
@@ -28,8 +28,14 @@
   (bind! [this gl render-args] "Bind this object to the GPU context.")
   (unbind! [this gl render-args] "Unbind this object from the GPU context."))
 
-(defn gl-binding? [value]
-  (satisfies? GLBinding value))
+(def
+  ^{:doc "Returns true if the value satisfies the GLBinding protocol."
+    :arglists '([value])}
+  gl-binding?
+  ;; This is quite a bit faster than the satisfies? function.
+  (let [gl-binding-class (:on-interface GLBinding)]
+    (fn gl-binding? [value]
+      (instance? gl-binding-class value))))
 
 (defn data-type-gl-type
   ^long [data-type]

--- a/editor/src/clj/editor/image.clj
+++ b/editor/src/clj/editor/image.clj
@@ -15,7 +15,6 @@
 (ns editor.image
   (:require [dynamo.graph :as g]
             [editor.build-target :as bt]
-            [editor.gl :as gl]
             [editor.gl.texture :as texture]
             [editor.image-util :as image-util]
             [editor.localization :as localization]
@@ -23,6 +22,7 @@
             [editor.resource :as resource]
             [editor.resource-io :as resource-io]
             [editor.resource-node :as resource-node]
+            [editor.texture-util :as texture-util]
             [editor.workspace :as workspace])
   (:import [com.dynamo.bob.pipeline TextureGenerator$GenerateResult]
            [com.dynamo.bob.textureset TextureSetGenerator$UVTransform]))
@@ -88,20 +88,6 @@
                   :compress? (:compress-textures? build-settings false)
                   :texture-profile texture-profile}})])
 
-;; TODO: Remove _ignored-request-id parameter from calls everywhere.
-(defn- generate-gpu-texture [{:keys [_node-id texture-data-delay]} _ignored-request-id params unit]
-  (let [texture-data (force texture-data-delay)]
-    (if (g/error-value? texture-data)
-      texture-data
-      (let [texture-datas [texture-data]
-            texture-units (vector-of :int unit)
-            texture-params (or params texture/default-image-texture-params)]
-        (texture/make-gpu-texture _node-id texture-datas texture-units texture-params)))))
-
-(defn- generate-content [{:keys [digest-ignored/error-node-id resource]}]
-  (resource-io/with-error-translation resource error-node-id :resource
-    (image-util/read-image resource)))
-
 (g/defnode ImageNode
   (inherits resource-node/ResourceNode)
 
@@ -115,27 +101,17 @@
                                (resource-io/with-error-translation resource _node-id :size
                                  (image-util/read-size resource))))
 
-  (output content-generator g/Any
-          (g/fnk [_node-id resource :as args]
-            (let [sha1 (resource-io/with-error-translation resource _node-id :content-generator
-                         (resource/resource->path-inclusive-sha1-hex resource))]
-              (if (g/error-value? sha1)
-                sha1
-                {:f generate-content
-                 :args (-> args
-                           (dissoc :_node-id)
-                           (assoc :digest-ignored/error-node-id _node-id))
-                 :sha1 sha1}))))
+  (output content-generator g/Any :cached
+          (g/fnk [_node-id resource]
+            (texture-util/make-buffered-image-generator resource _node-id :content-generator)))
 
-  (output texture-data-delay g/Any :cached
+  (output gpu-texture-generator g/Any :cached
           (g/fnk [_node-id content-generator texture-profile]
-            (let [result (delay
-                           (let [content ((:f content-generator) (:args content-generator))]
-                             (if (g/error-value? content)
-                               content
-                               (let [texture-image (tex-gen/make-preview-texture-image content texture-profile)]
-                                 (texture/texture-image->texture-data texture-image)))))]
-              result)))
+            (texture-util/make-gpu-texture-generator _node-id content-generator texture-profile)))
+
+  (output gpu-texture g/Any :cached
+          (g/fnk [gpu-texture-generator]
+            (texture-util/generate-gpu-texture gpu-texture-generator)))
 
   ;; NOTE: The anim-data and gpu-texture outputs allow standalone images to be used in place of texture sets in legacy projects.
   (output anim-data g/Any (g/fnk [size]
@@ -144,22 +120,6 @@
                                    :uv-transforms [(TextureSetGenerator$UVTransform.)])}))
 
   (output texture-page-count g/Int (g/constantly texture/non-paged-page-count))
-
-  (output gpu-texture g/Any
-          (g/fnk [_node-id gpu-texture-generator]
-            (let [tex-fn (:f gpu-texture-generator)
-                  args (:args gpu-texture-generator)
-                  request-id _node-id
-                  texture-unit 0
-                  texture-params {:min-filter gl/nearest
-                                  :mag-filter gl/nearest}]
-              (tex-fn args request-id texture-params texture-unit))))
-
-  (output gpu-texture-generator g/Any
-          (g/fnk [_node-id texture-data-delay :as args]
-            {:f generate-gpu-texture
-             :args args}))
-
   (output build-targets g/Any :cached produce-build-targets))
 
 (defn- load-image

--- a/editor/src/clj/editor/image.clj
+++ b/editor/src/clj/editor/image.clj
@@ -25,8 +25,7 @@
             [editor.resource-node :as resource-node]
             [editor.workspace :as workspace])
   (:import [com.dynamo.bob.pipeline TextureGenerator$GenerateResult]
-           [com.dynamo.bob.textureset TextureSetGenerator$UVTransform]
-           [java.awt.image BufferedImage]))
+           [com.dynamo.bob.textureset TextureSetGenerator$UVTransform]))
 
 (set! *warn-on-reflection* true)
 
@@ -89,8 +88,15 @@
                   :compress? (:compress-textures? build-settings false)
                   :texture-profile texture-profile}})])
 
-(defn- generate-gpu-texture [{:keys [texture-image]} request-id params unit]
-  (texture/texture-image->gpu-texture request-id texture-image params unit))
+;; TODO: Remove _ignored-request-id parameter from calls everywhere.
+(defn- generate-gpu-texture [{:keys [_node-id texture-data-delay]} _ignored-request-id params unit]
+  (let [texture-data (force texture-data-delay)]
+    (if (g/error-value? texture-data)
+      texture-data
+      (let [texture-datas [texture-data]
+            texture-units (vector-of :int unit)
+            texture-params (or params texture/default-image-texture-params)]
+        (texture/make-gpu-texture _node-id texture-datas texture-units texture-params)))))
 
 (defn- generate-content [{:keys [digest-ignored/error-node-id resource]}]
   (resource-io/with-error-translation resource error-node-id :resource
@@ -109,17 +115,27 @@
                                (resource-io/with-error-translation resource _node-id :size
                                  (image-util/read-size resource))))
 
-  (output content BufferedImage (g/fnk [content-generator]
-                                  ((:f content-generator) (:args content-generator))))
+  (output content-generator g/Any
+          (g/fnk [_node-id resource :as args]
+            (let [sha1 (resource-io/with-error-translation resource _node-id :content-generator
+                         (resource/resource->path-inclusive-sha1-hex resource))]
+              (if (g/error-value? sha1)
+                sha1
+                {:f generate-content
+                 :args (-> args
+                           (dissoc :_node-id)
+                           (assoc :digest-ignored/error-node-id _node-id))
+                 :sha1 sha1}))))
 
-  (output content-generator g/Any (g/fnk [_node-id resource :as args]
-                                    {:f generate-content
-                                     :args (-> args
-                                               (dissoc :_node-id)
-                                               (assoc :digest-ignored/error-node-id _node-id))
-                                     :sha1 (resource/resource->path-inclusive-sha1-hex resource)}))
-
-  (output texture-image g/Any (g/fnk [content texture-profile] (tex-gen/make-preview-texture-image content texture-profile)))
+  (output texture-data-delay g/Any :cached
+          (g/fnk [_node-id content-generator texture-profile]
+            (let [result (delay
+                           (let [content ((:f content-generator) (:args content-generator))]
+                             (if (g/error-value? content)
+                               content
+                               (let [texture-image (tex-gen/make-preview-texture-image content texture-profile)]
+                                 (texture/texture-image->texture-data texture-image)))))]
+              result)))
 
   ;; NOTE: The anim-data and gpu-texture outputs allow standalone images to be used in place of texture sets in legacy projects.
   (output anim-data g/Any (g/fnk [size]
@@ -129,15 +145,20 @@
 
   (output texture-page-count g/Int (g/constantly texture/non-paged-page-count))
 
-  (output gpu-texture g/Any :cached (g/fnk [_node-id texture-image]
-                                      (texture/texture-image->gpu-texture _node-id
-                                                                          texture-image
-                                                                          {:min-filter gl/nearest
-                                                                           :mag-filter gl/nearest})))
+  (output gpu-texture g/Any
+          (g/fnk [_node-id gpu-texture-generator]
+            (let [tex-fn (:f gpu-texture-generator)
+                  args (:args gpu-texture-generator)
+                  request-id _node-id
+                  texture-unit 0
+                  texture-params {:min-filter gl/nearest
+                                  :mag-filter gl/nearest}]
+              (tex-fn args request-id texture-params texture-unit))))
 
-  (output gpu-texture-generator g/Any (g/fnk [texture-image :as args]
-                                        {:f    generate-gpu-texture
-                                         :args args}))
+  (output gpu-texture-generator g/Any
+          (g/fnk [_node-id texture-data-delay :as args]
+            {:f generate-gpu-texture
+             :args args}))
 
   (output build-targets g/Any :cached produce-build-targets))
 

--- a/editor/src/clj/editor/image.clj
+++ b/editor/src/clj/editor/image.clj
@@ -15,6 +15,7 @@
 (ns editor.image
   (:require [dynamo.graph :as g]
             [editor.build-target :as bt]
+            [editor.gl :as gl]
             [editor.gl.texture :as texture]
             [editor.image-util :as image-util]
             [editor.localization :as localization]
@@ -111,7 +112,9 @@
 
   (output gpu-texture g/Any :cached
           (g/fnk [gpu-texture-generator]
-            (texture-util/generate-gpu-texture gpu-texture-generator)))
+            (-> (texture-util/generate-gpu-texture gpu-texture-generator)
+                (texture/set-params {:min-filter gl/nearest
+                                     :mag-filter gl/nearest}))))
 
   ;; NOTE: The anim-data and gpu-texture outputs allow standalone images to be used in place of texture sets in legacy projects.
   (output anim-data g/Any (g/fnk [size]

--- a/editor/src/clj/editor/pipeline/tex_gen.clj
+++ b/editor/src/clj/editor/pipeline/tex_gen.clj
@@ -16,6 +16,7 @@
   (:require [clojure.java.io :as io]
             [editor.protobuf :as protobuf]
             [internal.util :as util]
+            [util.coll :as coll]
             [util.digest :as digest])
   (:import [com.dynamo.bob.pipeline Texc$FlipAxis]
            [com.dynamo.bob.pipeline TextureGenerator TextureGenerator$GenerateResult]
@@ -77,17 +78,18 @@
    (make-texture-image image texture-profile compress? true))
   (^TextureGenerator$GenerateResult [^BufferedImage image texture-profile compress? flip-y?]
    (let [^Graphics$TextureProfile texture-profile-data (some->> texture-profile (protobuf/map->pb Graphics$TextureProfile))
-         texture-generate-result (TextureGenerator/generate image texture-profile-data ^boolean compress? (if ^boolean flip-y? (EnumSet/of Texc$FlipAxis/FLIP_AXIS_Y) (EnumSet/noneOf Texc$FlipAxis)))]
-     texture-generate-result)))
+         texture-generator-result (TextureGenerator/generate image texture-profile-data ^boolean compress? (if ^boolean flip-y? (EnumSet/of Texc$FlipAxis/FLIP_AXIS_Y) (EnumSet/noneOf Texc$FlipAxis)))]
+     texture-generator-result)))
 
 (defn- make-preview-profile
   "Given a texture-profile, return a simplified texture-profile that can be used
   for previewing purposes in editor. Will only produce data for one texture
   format."
-  [{:keys [name platforms] :as texture-profile}]
-  (let [platform-profile (or (first (filter #(= :os-id-generic (:os %)) (:platforms texture-profile)))
-                             (first (:platforms texture-profile)))
-        texture-format   (first (:formats platform-profile))]
+  [texture-profile]
+  (let [platforms (:platforms texture-profile)
+        platform-profile (or (coll/first-where #(= :os-id-generic (:os %)) platforms)
+                             (first platforms))
+        texture-format (first (:formats platform-profile))]
     (when (and platform-profile texture-format)
       {:name      "editor"
        :platforms [{:os                :os-id-generic
@@ -96,10 +98,14 @@
                     :max-texture-size  (:max-texture-size platform-profile)
                     :premultiply-alpha (:premultiply-alpha platform-profile)}]})))
 
+;; SDK api (DEPRECATE 2-arity version with the next release of extension-texturepacker).
 (defn make-preview-texture-image
-  ^TextureGenerator$GenerateResult [^BufferedImage image texture-profile]
-  (let [preview-profile (make-preview-profile texture-profile)]
-    (make-texture-image image preview-profile false)))
+  (^TextureGenerator$GenerateResult [^BufferedImage image texture-profile]
+   (let [preview-profile (make-preview-profile texture-profile)]
+     (make-texture-image image preview-profile false)))
+  (^TextureGenerator$GenerateResult [^BufferedImage image texture-profile flip-y]
+   (let [preview-profile (make-preview-profile texture-profile)]
+     (make-texture-image image preview-profile false flip-y))))
 
 (defn make-cubemap-texture-images
   ^TextureGenerator$GenerateResult [images texture-profile compress?]
@@ -120,11 +126,6 @@
   (let [texture-images (into-array ((juxt :px :nx :py :ny :pz :nz) side->texture-image))
         type Graphics$TextureImage$Type/TYPE_CUBEMAP]
     (TextureUtil/createCombinedTextureImage texture-images type)))
-
-(defn make-preview-cubemap-texture-images
-  ^TextureGenerator$GenerateResult [images texture-profile]
-  (let [preview-profile (make-preview-profile texture-profile)]
-    (make-cubemap-texture-images images preview-profile false)))
 
 (defn write-texturec-content-fn [resource user-data]
   (let [digest-output-stream

--- a/editor/src/clj/editor/pipeline/texture_set_gen.clj
+++ b/editor/src/clj/editor/pipeline/texture_set_gen.clj
@@ -316,7 +316,7 @@
     (TextureSetResult->result result)))
 
 (defn layout-tile-source
-  [^TextureSetGenerator$LayoutResult layout-result ^BufferedImage image tile-source-attributes]
+  ^BufferedImage [^TextureSetGenerator$LayoutResult layout-result ^BufferedImage image tile-source-attributes]
   (let [layout (first (.-layouts layout-result))
         inner-padding (.-innerPadding layout-result)
         extrude-borders (.-extrudeBorders layout-result)

--- a/editor/src/clj/editor/render_target.clj
+++ b/editor/src/clj/editor/render_target.clj
@@ -15,13 +15,13 @@
 (ns editor.render-target
   (:require [dynamo.graph :as g]
             [editor.build-target :as bt]
-            [editor.gl.texture :as texture]
             [editor.graph-util :as gu]
             [editor.localization :as localization]
             [editor.protobuf :as protobuf]
             [editor.protobuf-forms :as protobuf-forms]
             [editor.protobuf-forms-util :as protobuf-forms-util]
             [editor.resource-node :as resource-node]
+            [editor.texture-util :as texture-util]
             [editor.validation :as validation]
             [editor.workspace :as workspace]
             [util.fn :as fn])
@@ -103,9 +103,6 @@
         :build-fn build-render-target
         :user-data {:pb-msg save-value}})]))
 
-(defn- generate-gpu-texture [_args request-id _params _unit]
-  (texture/image-texture request-id nil))
-
 (defn- validate-color-attachment-count [v name]
   (when (> (count v) max-color-attachment-count)
     (format "'%s' render targets cannot have more than %d color attachments"
@@ -138,7 +135,7 @@
 
   (output save-value g/Any :cached produce-save-value)
   (output form-data g/Any produce-form-data)
-  (output gpu-texture-generator g/Any {:f generate-gpu-texture})
+  (output gpu-texture-generator g/Any (g/constantly texture-util/placeholder-gpu-texture-generator))
   (output build-targets g/Any :cached produce-build-targets)
   (output build-errors g/Any (g/fnk [_node-id color-attachments depth-stencil-attachment-width depth-stencil-attachment-height]
                                (g/package-errors _node-id

--- a/editor/src/clj/editor/sprite.clj
+++ b/editor/src/clj/editor/sprite.clj
@@ -492,10 +492,7 @@
     (reduce
       (fn [acc i]
         (let [start-texture-unit (-> (acc (dec i)) :gpu-texture :texture-units peek inc)]
-          (update-in acc [i :gpu-texture :texture-units]
-                     (fn [texture-units]
-                       (vec (range start-texture-unit
-                                   (+ start-texture-unit (count texture-units))))))))
+          (update-in acc [i :gpu-texture] texture/set-base-unit start-texture-unit)))
       infos
       (range 1 (count infos)))))
 

--- a/editor/src/clj/editor/texture_util.clj
+++ b/editor/src/clj/editor/texture_util.clj
@@ -46,6 +46,11 @@
   (and (generator? value)
        (digest/sha1-hex? (:sha1 value))))
 
+(defn texture-lifecycle-generator?
+  [value]
+  (and (generator? value)
+       (graphics.types/request-id? (:request-id (:args value)))))
+
 (defn content-generatable?
   [value]
   (or (content-generator? value)
@@ -88,7 +93,8 @@
   ^TextureRequestData [content-generatable texture-profile flip-y]
   {:pre [(content-generatable? content-generatable)
          (or (nil? texture-profile)
-             (graphics.types/texture-profile? texture-profile))]
+             (graphics.types/texture-profile? texture-profile))
+         (boolean? flip-y)]
    :post [(or (g/error-value? %)
               (and (vector? %)
                    (every? texture/texture-request-data? %)))]}
@@ -106,7 +112,9 @@
 
                        (instance? BufferedImage content)
                        (let [texture-image (tex-gen/make-preview-texture-image content texture-profile flip-y)
-                             data-version (hash (:sha1 content-generator))]
+                             data-version (java/combine-hashes
+                                            (hash (:sha1 content-generator))
+                                            (hash flip-y))]
                          (texture/texture-image->texture-request-data texture-image data-version))
 
                        :else
@@ -121,7 +129,9 @@
     ;; return a BufferedImage, an ErrorValue, or a sequence of values that may
     ;; be a mix of BufferedImages or ErrorValues.
     (let [content (call-generator content-generatable)
-          data-version (hash (:sha1 content-generatable))]
+          data-version (java/combine-hashes
+                         (hash (:sha1 content-generatable))
+                         (hash flip-y))]
       (cond
         (g/error-value? content)
         content
@@ -192,10 +202,8 @@
 
 (defn gpu-texture-generator?
   [value]
-  (and (generator? value)
-       (let [args (:args value)]
-         (and (graphics.types/request-id? (:request-id args))
-              (delay? (:texture-request-datas-delay args))))))
+  (and (texture-lifecycle-generator? value)
+       (delay? (:texture-request-datas-delay (:args value)))))
 
 (defn make-gpu-texture-generator
   [request-id content-generatable texture-profile]
@@ -213,7 +221,7 @@
 
 (defn generate-gpu-texture
   ^TextureLifecycle [gpu-texture-generator]
-  {:pre [(gpu-texture-generator? gpu-texture-generator)]
+  {:pre [(texture-lifecycle-generator? gpu-texture-generator)]
    :post [(or (g/error-value? %)
               (texture/texture-lifecycle? %))]}
   (call-generator gpu-texture-generator))
@@ -270,13 +278,6 @@
     {:f cubemap-gpu-texture-gen-fn
      :args {:request-id request-id
             :texture-request-datas-by-side-kw-delay texture-request-datas-by-side-kw-delay}}))
-
-(defn generate-cubemap-gpu-texture
-  ^TextureLifecycle [cubemap-gpu-texture-generator]
-  {:pre [(cubemap-gpu-texture-generator? cubemap-gpu-texture-generator)]
-   :post [(or (g/error-value? %)
-              (texture/texture-lifecycle? %))]}
-  (call-generator cubemap-gpu-texture-generator))
 
 (defn construct-cubemap-gpu-texture
   ^TextureLifecycle [request-id content-generators-by-side-kw texture-profile]

--- a/editor/src/clj/editor/texture_util.clj
+++ b/editor/src/clj/editor/texture_util.clj
@@ -1,0 +1,286 @@
+;; Copyright 2020-2025 The Defold Foundation
+;; Copyright 2014-2020 King
+;; Copyright 2009-2014 Ragnar Svensson, Christian Murray
+;; Licensed under the Defold License version 1.0 (the "License"); you may not use
+;; this file except in compliance with the License.
+;;
+;; You may obtain a copy of the License, together with FAQs at
+;; https://www.defold.com/license
+;;
+;; Unless required by applicable law or agreed to in writing, software distributed
+;; under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+;; CONDITIONS OF ANY KIND, either express or implied. See the License for the
+;; specific language governing permissions and limitations under the License.
+
+(ns editor.texture-util
+  (:require [dynamo.graph :as g]
+            [editor.gl.texture :as texture]
+            [editor.graphics.types :as graphics.types]
+            [editor.image-util :as image-util]
+            [editor.pipeline.tex-gen :as tex-gen]
+            [editor.resource :as resource]
+            [editor.resource-io :as resource-io]
+            [internal.java :as java]
+            [util.coll :as coll :refer [pair]]
+            [util.digest :as digest])
+  (:import [editor.gl.texture TextureLifecycle TextureRequestData]
+           [java.awt.image BufferedImage]))
+
+(set! *warn-on-reflection* true)
+(set! *unchecked-math* :warn-on-boxed)
+
+;; -----------------------------------------------------------------------------
+;; Generators
+;; -----------------------------------------------------------------------------
+
+(defn generator?
+  [value]
+  (and (map? value)
+       (ifn? (:f value))
+       (let [args (:args value)]
+         (or (nil? args)
+             (map? args)))))
+
+(defn content-generator?
+  [value]
+  (and (generator? value)
+       (digest/sha1-hex? (:sha1 value))))
+
+(defn content-generatable?
+  [value]
+  (or (content-generator? value)
+      (and (sequential? value)
+           (every? content-generator? value))))
+
+(defn call-generator
+  [generator & additional-args]
+  (let [{:keys [f args]} generator]
+    (apply f args additional-args)))
+
+;; -----------------------------------------------------------------------------
+;; BufferedImages
+;; -----------------------------------------------------------------------------
+
+(defn- buffered-image-gen-fn
+  [{:keys [digest-ignored/error-label digest-ignored/error-node-id resource]}]
+  (resource-io/with-error-translation resource error-node-id error-label
+    (image-util/read-image resource)))
+
+(defn make-buffered-image-generator
+  [resource error-node-id error-label]
+  {:post [(or (g/error-value? %)
+              (content-generator? %))]}
+  (let [sha1 (resource-io/with-error-translation resource error-node-id error-label
+               (resource/resource->path-inclusive-sha1-hex resource))]
+    (if (g/error-value? sha1)
+      sha1
+      {:f buffered-image-gen-fn
+       :sha1 sha1
+       :args {:resource resource
+              :digest-ignored/error-node-id error-node-id
+              :digest-ignored/error-label error-label}})))
+
+;; -----------------------------------------------------------------------------
+;; TextureRequestData
+;; -----------------------------------------------------------------------------
+
+(defn make-texture-request-datas
+  ^TextureRequestData [content-generatable texture-profile flip-y]
+  {:pre [(content-generatable? content-generatable)
+         (or (nil? texture-profile)
+             (graphics.types/texture-profile? texture-profile))]
+   :post [(or (g/error-value? %)
+              (and (vector? %)
+                   (every? texture/texture-request-data? %)))]}
+  (if (sequential? content-generatable)
+    ;; This is a sequence of content-generators. In this situation, we expect
+    ;; each content-generator to return a single BufferedImage or an ErrorValue.
+    (let [texture-request-datas
+          (coll/transfer content-generatable []
+            (map (fn [content-generator]
+                   {:pre [(content-generator? content-generator)]}
+                   (let [content (call-generator content-generator)]
+                     (cond
+                       (g/error-value? content)
+                       content
+
+                       (instance? BufferedImage content)
+                       (let [texture-image (tex-gen/make-preview-texture-image content texture-profile flip-y)
+                             data-version (hash (:sha1 content-generator))]
+                         (texture/texture-image->texture-request-data texture-image data-version))
+
+                       :else
+                       (throw
+                         (ex-info
+                           "content-generator returned an unsupported value."
+                           {:content-generator content-generator
+                            :return-value content})))))))]
+      (g/precluding-errors texture-request-datas texture-request-datas))
+
+    ;; This is a single content-generator. In this situation we expect it to
+    ;; return a BufferedImage, an ErrorValue, or a sequence of values that may
+    ;; be a mix of BufferedImages or ErrorValues.
+    (let [content (call-generator content-generatable)
+          data-version (hash (:sha1 content-generatable))]
+      (cond
+        (g/error-value? content)
+        content
+
+        (instance? BufferedImage content)
+        (let [texture-image (tex-gen/make-preview-texture-image content texture-profile flip-y)]
+          [(texture/texture-image->texture-request-data texture-image data-version)])
+
+        (sequential? content)
+        (g/precluding-errors content
+          (coll/transfer content []
+            (map-indexed
+              (fn [^long image-index ^BufferedImage buffered-image]
+                {:pre [(instance? BufferedImage buffered-image)]}
+                (let [texture-image (tex-gen/make-preview-texture-image buffered-image texture-profile flip-y)
+                      data-version (java/combine-hashes data-version image-index)]
+                  (texture/texture-image->texture-request-data texture-image data-version))))))
+
+        :else
+        (throw
+          (ex-info
+            "content-generator returned an unsupported value."
+            {:content-generator content-generatable
+             :return-value content}))))))
+
+(defn make-texture-request-datas-by-key
+  [content-generators-by-key texture-profile flip-y]
+  {:post [(or (g/error-value? %)
+              (and (map? %)
+                   (every? texture/texture-request-data? (vals %))))]}
+  (let [[texture-request-datas-by-key error-values]
+        (reduce
+          (fn [[texture-request-datas-by-key error-values] [key content-generator]]
+            {:pre [(content-generator? content-generator)]}
+            (let [texture-request-datas (make-texture-request-datas content-generator texture-profile flip-y)]
+              (if (g/error-value? texture-request-datas)
+                (pair texture-request-datas-by-key
+                      (conj error-values texture-request-datas))
+                (let [texture-request-data (first texture-request-datas)]
+                  (if (texture/texture-request-data? texture-request-data)
+                    (pair (assoc texture-request-datas-by-key key texture-request-data)
+                          error-values)
+                    (throw
+                      (ex-info
+                        (format "content-generator for key %s returned an unsupported value." key)
+                        {:key key
+                         :content-generator content-generator
+                         :return-value texture-request-datas})))))))
+          (pair {} [])
+          content-generators-by-key)]
+    (g/precluding-errors error-values texture-request-datas-by-key)))
+
+;; -----------------------------------------------------------------------------
+;; 2D TextureLifecycles
+;; -----------------------------------------------------------------------------
+
+(defn make-gpu-texture
+  ^TextureLifecycle [request-id texture-request-datas]
+  (if (g/error-value? texture-request-datas)
+    texture-request-datas
+    (let [texture-units (apply vector-of :int (range (count texture-request-datas)))]
+      (texture/make-gpu-texture request-id texture-request-datas texture-units texture/default-image-texture-params))))
+
+(defn- gpu-texture-gen-fn
+  [{:keys [request-id texture-request-datas-delay]}]
+  (let [texture-request-datas (force texture-request-datas-delay)]
+    (make-gpu-texture request-id texture-request-datas)))
+
+(defn gpu-texture-generator?
+  [value]
+  (and (generator? value)
+       (let [args (:args value)]
+         (and (graphics.types/request-id? (:request-id args))
+              (delay? (:texture-request-datas-delay args))))))
+
+(defn make-gpu-texture-generator
+  [request-id content-generatable texture-profile]
+  {:pre [(graphics.types/request-id? request-id)
+         (content-generatable? content-generatable)
+         (or (nil? texture-profile)
+             (graphics.types/texture-profile? texture-profile))]
+   :post [(gpu-texture-generator? %)]}
+  (let [texture-request-datas-delay
+        (delay
+          (make-texture-request-datas content-generatable texture-profile true))]
+    {:f gpu-texture-gen-fn
+     :args {:request-id request-id
+            :texture-request-datas-delay texture-request-datas-delay}}))
+
+(defn generate-gpu-texture
+  ^TextureLifecycle [gpu-texture-generator]
+  {:pre [(gpu-texture-generator? gpu-texture-generator)]
+   :post [(or (g/error-value? %)
+              (texture/texture-lifecycle? %))]}
+  (call-generator gpu-texture-generator))
+
+(defn construct-gpu-texture
+  ^TextureLifecycle [request-id content-generatable texture-profile]
+  {:post [(or (g/error-value? %)
+              (texture/texture-lifecycle? %))]}
+  (let [texture-request-datas (make-texture-request-datas content-generatable texture-profile true)]
+    (make-gpu-texture request-id texture-request-datas)))
+
+(def placeholder-gpu-texture-generator
+  {:f gpu-texture-gen-fn
+   :args {:request-id ::placeholder-gpu-texture
+          :texture-request-datas-delay (delay texture/placeholder-texture-request-datas)}})
+
+(assert (gpu-texture-generator? placeholder-gpu-texture-generator))
+
+;; -----------------------------------------------------------------------------
+;; Cube TextureLifecycles
+;; -----------------------------------------------------------------------------
+
+(defn make-cubemap-gpu-texture
+  ^TextureLifecycle [request-id texture-request-datas-by-side-kw]
+  (if (g/error-value? texture-request-datas-by-side-kw)
+    texture-request-datas-by-side-kw
+    (let [texture-units (vector-of :int 0)]
+      (texture/make-gpu-cubemap-texture request-id [texture-request-datas-by-side-kw] texture-units texture/default-cubemap-texture-params))))
+
+(defn- cubemap-gpu-texture-gen-fn
+  [{:keys [request-id texture-request-datas-by-side-kw-delay]}]
+  (let [texture-request-datas-by-side-kw (force texture-request-datas-by-side-kw-delay)]
+    (make-cubemap-gpu-texture request-id texture-request-datas-by-side-kw)))
+
+(defn cubemap-gpu-texture-generator?
+  [value]
+  (and (generator? value)
+       (let [args (:args value)]
+         (and (graphics.types/request-id? (:request-id args))
+              (delay? (:texture-request-datas-by-side-kw-delay args))))))
+
+(defn make-cubemap-gpu-texture-generator
+  [request-id content-generators-by-side-kw texture-profile]
+  {:pre [(graphics.types/request-id? request-id)
+         (map? content-generators-by-side-kw)
+         (every? texture/cubemap-side-kw? (keys content-generators-by-side-kw))
+         (every? content-generator? (vals content-generators-by-side-kw))
+         (or (nil? texture-profile)
+             (graphics.types/texture-profile? texture-profile))]
+   :post [(cubemap-gpu-texture-generator? %)]}
+  (let [texture-request-datas-by-side-kw-delay
+        (delay
+          (make-texture-request-datas-by-key content-generators-by-side-kw texture-profile false))]
+    {:f cubemap-gpu-texture-gen-fn
+     :args {:request-id request-id
+            :texture-request-datas-by-side-kw-delay texture-request-datas-by-side-kw-delay}}))
+
+(defn generate-cubemap-gpu-texture
+  ^TextureLifecycle [cubemap-gpu-texture-generator]
+  {:pre [(cubemap-gpu-texture-generator? cubemap-gpu-texture-generator)]
+   :post [(or (g/error-value? %)
+              (texture/texture-lifecycle? %))]}
+  (call-generator cubemap-gpu-texture-generator))
+
+(defn construct-cubemap-gpu-texture
+  ^TextureLifecycle [request-id content-generators-by-side-kw texture-profile]
+  {:post [(or (g/error-value? %)
+              (texture/texture-lifecycle? %))]}
+  (let [texture-request-datas-by-side-kw (make-texture-request-datas-by-key content-generators-by-side-kw texture-profile false)]
+    (make-cubemap-gpu-texture request-id texture-request-datas-by-side-kw)))

--- a/editor/src/clj/internal/system.clj
+++ b/editor/src/clj/internal/system.clj
@@ -19,7 +19,8 @@
             [internal.history :as h]
             [internal.node :as in]
             [internal.util :as util]
-            [util.coll :as coll])
+            [util.coll :as coll]
+            [util.defonce :as defonce])
   (:import [java.util.concurrent.atomic AtomicLong]))
 
 (set! *warn-on-reflection* true)
@@ -41,7 +42,7 @@
 (defn- new-history []
   {:tape (conj (h/paper-tape history-size-max) [])})
 
-(defrecord HistoryState [label graph sequence-label cache-keys])
+(defonce/record HistoryState [label graph sequence-label cache-keys])
 
 (defn history-state [graph outputs-modified]
   (->HistoryState (:tx-label graph) graph (:tx-sequence-label graph) outputs-modified))

--- a/editor/test/editor/pipeline/tex_gen_test.clj
+++ b/editor/test/editor/pipeline/tex_gen_test.clj
@@ -53,18 +53,21 @@
     (is (= (* 1 32 64) (.. tex-img (getAlternatives 2) (getDataSize))))))
 
 (deftest make-preview-texture-image-test
-  (let [img     (ImageIO/read (io/resource "test_project/graphics/ball.png"))
+  (let [img (ImageIO/read (io/resource "test_project/graphics/ball.png"))
         ^TextureGenerator$GenerateResult
-        generator-result (tex-gen/make-preview-texture-image img {:name      "test-profile"
-                                                                  :platforms [{:os                :os-id-generic
-                                                                               :formats           [{:format            :texture-format-rgb
-                                                                                                    :compression-level :best}
-                                                                                                   {:format            :texture-format-rgba
-                                                                                                    :compression-level :best}
-                                                                                                   {:format            :texture-format-luminance
-                                                                                                    :compression-level :best}]
-                                                                               :mipmaps           false
-                                                                               :premultiply-alpha true}]})
+        generator-result (tex-gen/make-preview-texture-image
+                           img
+                           {:name "test-profile"
+                            :platforms [{:os :os-id-generic
+                                         :formats [{:format :texture-format-rgb
+                                                    :compression-level :best}
+                                                   {:format :texture-format-rgba
+                                                    :compression-level :best}
+                                                   {:format :texture-format-luminance
+                                                    :compression-level :best}]
+                                         :mipmaps false
+                                         :premultiply-alpha true}]}
+                           true)
         ^Graphics$TextureImage tex-img (.-textureImage generator-result)
         total-data-size (reduce + (map #(count %) (.-imageDatas generator-result)))]
     (is (= 1 (.getAlternativesCount tex-img)))

--- a/editor/test/integration/atlas_test.clj
+++ b/editor/test/integration/atlas_test.clj
@@ -16,9 +16,9 @@
   (:require [clojure.java.io :as io]
             [clojure.test :refer :all]
             [dynamo.graph :as g]
-            [editor.atlas :as atlas]
             [editor.defold-project :as project]
             [editor.fs :as fs]
+            [editor.texture-util :as texture-util]
             [editor.workspace :as workspace]
             [integration.test-util :as test-util]
             [support.test-support :as test-support]))
@@ -68,14 +68,13 @@
           image-file (io/as-file (g/node-value atlas-image :image))
           image-bytes (fs/read-bytes image-file)
           layout-data-generator (g/node-value atlas :layout-data-generator)
-          packed-page-images-generator (g/node-value atlas :packed-page-images-generator)
-          call-generator #'atlas/call-generator]
+          packed-page-images-generator (g/node-value atlas :packed-page-images-generator)]
 
       (testing "Initial project state"
         (is (not= :sprite-trim-mode-off (g/node-value atlas-image :sprite-trim-mode)))
         (testing "Generators"
-          (is (not (g/error? (call-generator layout-data-generator))))
-          (is (not (g/error? (call-generator packed-page-images-generator)))))
+          (is (not (g/error? (texture-util/call-generator layout-data-generator))))
+          (is (not (g/error? (texture-util/call-generator packed-page-images-generator)))))
         (testing "Graph"
           (is (not (g/error? (g/node-value atlas :scene))))
           (is (not (g/error? (g/node-value atlas :build-targets))))
@@ -85,8 +84,8 @@
         (test-support/spit-until-new-mtime image-file "This is no longer an image file.")
         (g/clear-system-cache!)
         (testing "Stale generators"
-          (is (g/error? (call-generator layout-data-generator)))
-          (is (g/error? (call-generator packed-page-images-generator))))
+          (is (g/error? (texture-util/call-generator layout-data-generator)))
+          (is (g/error? (texture-util/call-generator packed-page-images-generator))))
         (testing "Graph before resource-sync"
           (is (g/error? (g/node-value atlas :scene)))
           (is (g/error? (g/node-value atlas :build-targets)))
@@ -101,8 +100,8 @@
         (test-support/write-until-new-mtime image-file image-bytes)
         (g/clear-system-cache!)
         (testing "Stale generators"
-          (is (not (g/error? (call-generator layout-data-generator))))
-          (is (not (g/error? (call-generator packed-page-images-generator)))))
+          (is (not (g/error? (texture-util/call-generator layout-data-generator))))
+          (is (not (g/error? (texture-util/call-generator packed-page-images-generator)))))
         (testing "Graph before resource-sync"
           (is (not (g/error? (g/node-value atlas :scene))))
           (is (not (g/error? (g/node-value atlas :build-targets))))
@@ -117,8 +116,8 @@
         (fs/delete! image-file)
         (g/clear-system-cache!)
         (testing "Stale generators"
-          (is (g/error? (call-generator layout-data-generator)))
-          (is (g/error? (call-generator packed-page-images-generator))))
+          (is (g/error? (texture-util/call-generator layout-data-generator)))
+          (is (g/error? (texture-util/call-generator packed-page-images-generator))))
         (testing "Graph before resource-sync"
           (is (g/error? (g/node-value atlas :scene)))
           (is (g/error? (g/node-value atlas :build-targets)))

--- a/editor/test/integration/extension_texturepacker_test.clj
+++ b/editor/test/integration/extension_texturepacker_test.clj
@@ -20,8 +20,7 @@
             [editor.workspace :as workspace]
             [integration.test-util :as test-util])
   (:import [com.dynamo.bob.util TextureUtil]
-           [com.dynamo.gamesys.proto TextureSetProto$TextureSet]
-           [com.dynamo.graphics.proto Graphics$TextureImage]))
+           [com.dynamo.gamesys.proto TextureSetProto$TextureSet]))
 
 (set! *warn-on-reflection* true)
 

--- a/editor/test/integration/resource_watch_test.clj
+++ b/editor/test/integration/resource_watch_test.clj
@@ -165,10 +165,10 @@
       (workspace/set-project-dependencies! workspace [{:uri imagelib1-uri}])
       (workspace/resource-sync! workspace)
       (let [lib1-paddle (project/get-resource-node project "/images/paddle.png")]
-        (is (not (g/error? (g/node-value lib1-paddle :content))))
+        (is (not (g/error? (g/node-value lib1-paddle :size))))
         (workspace/set-project-dependencies! workspace [{:uri imagelib2-uri}])
         (workspace/resource-sync! workspace)
-        (is (g/error? (g/node-value lib1-paddle :content))))))) ; removed, should emit errors
+        (is (g/error? (g/node-value lib1-paddle :size))))))) ; removed, should emit errors
 
 (deftest project-with-reserved-directories-can-still-be-loaded
   (binding [*project-path* "test/resources/reserved_files_project"]

--- a/editor/test/integration/tile_source_test.clj
+++ b/editor/test/integration/tile_source_test.clj
@@ -19,6 +19,7 @@
             [editor.app-view :as app-view]
             [editor.defold-project :as project]
             [editor.fs :as fs]
+            [editor.texture-util :as texture-util]
             [editor.tile-source :as tile-source]
             [editor.workspace :as workspace]
             [integration.test-util :as test-util]
@@ -100,14 +101,13 @@
           image-file (io/as-file (g/node-value tile-source :image))
           image-bytes (fs/read-bytes image-file)
           texture-set-data-generator (g/node-value tile-source :texture-set-data-generator)
-          packed-image-generator (g/node-value tile-source :packed-image-generator)
-          call-generator #'tile-source/call-generator]
+          packed-image-generator (g/node-value tile-source :packed-image-generator)]
 
       (testing "Initial project state"
         (is (not= :sprite-trim-mode-off (g/node-value tile-source :sprite-trim-mode)))
         (testing "Generators"
-          (is (not (g/error? (call-generator texture-set-data-generator))))
-          (is (not (g/error? (call-generator packed-image-generator)))))
+          (is (not (g/error? (texture-util/call-generator texture-set-data-generator))))
+          (is (not (g/error? (texture-util/call-generator packed-image-generator)))))
         (testing "Graph"
           (is (not (g/error? (g/node-value tile-source :scene))))
           (is (not (g/error? (g/node-value tile-source :build-targets))))
@@ -117,8 +117,8 @@
         (test-support/spit-until-new-mtime image-file "This is no longer an image file.")
         (g/clear-system-cache!)
         (testing "Stale generators"
-          (is (g/error? (call-generator texture-set-data-generator)))
-          (is (g/error? (call-generator packed-image-generator))))
+          (is (g/error? (texture-util/call-generator texture-set-data-generator)))
+          (is (g/error? (texture-util/call-generator packed-image-generator))))
         (testing "Graph before resource-sync"
           (is (g/error? (g/node-value tile-source :scene)))
           (is (g/error? (g/node-value tile-source :build-targets)))
@@ -133,8 +133,8 @@
         (test-support/write-until-new-mtime image-file image-bytes)
         (g/clear-system-cache!)
         (testing "Stale generators"
-          (is (not (g/error? (call-generator texture-set-data-generator))))
-          (is (not (g/error? (call-generator packed-image-generator)))))
+          (is (not (g/error? (texture-util/call-generator texture-set-data-generator))))
+          (is (not (g/error? (texture-util/call-generator packed-image-generator)))))
         (testing "Graph before resource-sync"
           (is (not (g/error? (g/node-value tile-source :scene))))
           (is (not (g/error? (g/node-value tile-source :build-targets))))
@@ -149,8 +149,8 @@
         (fs/delete! image-file)
         (g/clear-system-cache!)
         (testing "Stale generators"
-          (is (g/error? (call-generator texture-set-data-generator)))
-          (is (g/error? (call-generator packed-image-generator))))
+          (is (g/error? (texture-util/call-generator texture-set-data-generator)))
+          (is (g/error? (texture-util/call-generator packed-image-generator))))
         (testing "Graph before resource-sync"
           (is (g/error? (g/node-value tile-source :scene)))
           (is (g/error? (g/node-value tile-source :build-targets)))


### PR DESCRIPTION
Texture resources shared across multiple Model Scenes (`.gltf` files) will now properly share VRAM resources.

Fixes #9401.
Fixes #9702.

### Technical changes
After the Scene View camera mode and Outline View object visibility toggles were implemented, some `defhandlers` were evaluating `state` clauses dependent on the `scene` output of the active resource tab. Since `state` was not using the shared `evaluation-context` we create when we refresh the UI, multiple versions of the same `scene` output could end up being produced during refresh. This resulted in multiple instances of `TextureData` being produced for the same `request-id` (based on the source image), and ending up across multiple cached `scene` outputs. The `scene-cache` would then assume the textures needed to be constantly re-uploaded to VRAM as different objects were drawn in the Scene View.

This PR addresses various issues to prevent this from happening:
* All `defhandler` clauses except `run` will now use the shared `evaluation-context` during UI refresh. We were missing `state`, `options`, and `label`.
* We also use the same shared `evaluation-context` when evaluating the `auto-pulls` and refreshing the app title.
* `app-view/refresh-scene-views!` was updated to not perform its graph mutations inside an `auto-evaluation-context` block, and now happens last in the UI update cycle.
* A `texture-util` module was added to consolidate the process of creating `TextureLifecycles` from `content-generators`. All `gpu-texture` outputs have been updated to use the `texture-util` module. This is a non-breaking change as far as our extensions are concerned, but there will be an upcoming PR to `extension-texturepacker`.
* We now wrap the `jogamp` `TextureData` instances in a `TextureRequestData` type with equality semantics based on manually managed `data-version` and `topology-hash`, just like we do for `java.nio.Buffer` with `BufferData`.

In addition, the following improvements were made to the Reveal Defold integration:
* Reveal actions that operate on `Endpoints` or `node-ids` will now try to coerce one into another when possible. For example, you can activate `defold:successors` on a `:label` in the `defold:node-tree` view, or use `defold:node-tree` on an `Endpoint`.
* Added a `defold:predecessors` action to Reveal. It works similarly to `defold:successors`, but shows a reverse tree of inputs affecting a particular `Endpoint`.
* Endpoints in the `defold:successors` or `defold:predecessors` views now show `self` instead of the `node-id` and `NodeType` if they belong to the same node as the queried `Endpoint`.

After this is merged, we have a corresponding code-cleanup PR in defold/extension-texturepacker#22.