### PR TITLE
Fixed an issue where the camera component icon would disappear after copy-pasting a camera component

### DIFF
--- a/editor/src/clj/editor/outline.clj
+++ b/editor/src/clj/editor/outline.clj
@@ -149,6 +149,8 @@
                                         :external-refs {project :project}
                                         :external-labels {project #{:collision-group-nodes
                                                                     :collision-groups-data
+                                                                    :display-height
+                                                                    :display-width
                                                                     :default-tex-params
                                                                     :settings}}})
                       (add-attachments root-ids))]


### PR DESCRIPTION
Fix https://github.com/defold/defold/issues/11556