### PR TITLE
Add support for mounting live update archives from Android assets

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/AndroidBundler.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/AndroidBundler.java
@@ -589,7 +589,7 @@ public class AndroidBundler implements IBundler {
             File aabDir = new File(outDir, "aab");
             File baseConfig = new File(aabDir, "BundleConfig.json");
             try (BufferedWriter writer = new BufferedWriter(new FileWriter(baseConfig))) {
-                String uncompressedGlob = "\"assets/game.arcd\"";
+                String uncompressedGlob = "\"assets/game.arcd\",\"assets/**/*.zip\"";
                 if (!extractNativeLibs) {
                     uncompressedGlob += ",";
                     uncompressedGlob += "\"lib/**/*.so\"";

--- a/engine/dlib/src/dlib/zip.cpp
+++ b/engine/dlib/src/dlib/zip.cpp
@@ -24,6 +24,12 @@ Result Open(const char* path, HZip* zip)
     return *zip != 0 ? RESULT_OK : RESULT_NO_SUCH_ENTRY;
 }
 
+Result OpenStream(const char *stream, uint32_t size, HZip* zip)
+{
+    *zip = zip_stream_open(stream, size, 9, 'r');
+    return *zip != 0 ? RESULT_OK : RESULT_NO_SUCH_ENTRY;
+}
+
 void Close(HZip zip)
 {
     if (zip)

--- a/engine/dlib/src/dlib/zip.h
+++ b/engine/dlib/src/dlib/zip.h
@@ -38,6 +38,15 @@ namespace dmZip
      */
     Result Open(const char* path, HZip* zip);
 
+    /*# Opens a read only zip archive stream from memory
+     *
+     * @param stream [type: const char*] zip archive stream
+     * @param size [type: uint32_t] stream size
+     * @param path [type: HZip*] pointer to zip handle
+     * @return [type:Result] path to the zip archive
+     */
+    Result OpenStream(const char *stream, uint32_t size, HZip* zip);
+
     /*# Closes the zip archive
      *
      * @param zip zip archive

--- a/engine/dlib/src/dmsdk/dlib/uri.h
+++ b/engine/dlib/src/dmsdk/dlib/uri.h
@@ -39,7 +39,7 @@ namespace dmURI
         RESULT_TOO_SMALL_BUFFER,            //!< RESULT_TOO_SMALL_BUFFER
     };
 
-    const uint32_t MAX_SCHEME_LEN = 8;      //!< MAX_SCHEME_LEN
+    const uint32_t MAX_SCHEME_LEN = 12;      //!< MAX_SCHEME_LEN
     const uint32_t MAX_LOCATION_LEN = 64;   //!< MAX_LOCATION_LEN
     const uint32_t MAX_PATH_LEN = 2048;     //!< MAX_PATH_LEN
 

--- a/engine/dlib/src/dmsdk/dlib/uri.h
+++ b/engine/dlib/src/dmsdk/dlib/uri.h
@@ -39,7 +39,7 @@ namespace dmURI
         RESULT_TOO_SMALL_BUFFER,            //!< RESULT_TOO_SMALL_BUFFER
     };
 
-    const uint32_t MAX_SCHEME_LEN = 12;      //!< MAX_SCHEME_LEN
+    const uint32_t MAX_SCHEME_LEN = 8;      //!< MAX_SCHEME_LEN
     const uint32_t MAX_LOCATION_LEN = 64;   //!< MAX_LOCATION_LEN
     const uint32_t MAX_PATH_LEN = 2048;     //!< MAX_PATH_LEN
 

--- a/engine/resource/src/mount/mount_android.cpp
+++ b/engine/resource/src/mount/mount_android.cpp
@@ -41,7 +41,7 @@ namespace dmResource
         uint32_t index_length;
     };
 
-    Result MapAsset(const char* path, void*& out_asset, uint32_t& out_size, void*& out_map)
+    Result MapAsset(const char* path, void*& out_asset, void*& out_map, uint32_t& out_size)
     {
         AAssetManager* am = g_AndroidApp->activity->assetManager;
 
@@ -133,7 +133,7 @@ namespace dmResource
         bool mem_mapped_data = false;
         if (strcmp(data_path, "game.arcd") == 0)
         {
-            r = MapAsset(data_path, (void*&)data_asset, data_length, data_map);
+            r = MapAsset(data_path, (void*&)data_asset, data_map, data_length);
             if (r != RESULT_OK)
             {
                 dmLogError("Error when mapping data file '%s', result = %i", data_path, r);
@@ -154,7 +154,7 @@ namespace dmResource
         bool mem_mapped_index = false;
         if (strcmp(index_path, "game.arci") == 0)
         {
-            r = MapAsset(index_path, (void*&)index_asset, index_length, index_map);
+            r = MapAsset(index_path, (void*&)index_asset, index_map, index_length);
             if (r != RESULT_OK)
             {
                 if (mem_mapped_data)

--- a/engine/resource/src/mount/mount_android.cpp
+++ b/engine/resource/src/mount/mount_android.cpp
@@ -89,7 +89,7 @@ namespace dmResource
         return RESULT_OK;
     }
 
-    static Result UnmapAsset(void*& asset, uint32_t size)
+    Result UnmapAsset(void*& asset, uint32_t size)
     {
         if (asset != 0x0)
         {
@@ -160,7 +160,7 @@ namespace dmResource
                 if (mem_mapped_data)
                     UnmapFile(data_map, data_length);
                 else
-                    UnmapAsset(data_asset);
+                    UnmapAsset((void*&)data_asset, data_length);
                 dmLogError("Error when mapping index file, result: %i", r);
                 return RESULT_IO_ERROR;
             }
@@ -173,7 +173,7 @@ namespace dmResource
                 if (mem_mapped_data)
                     UnmapFile(data_map, data_length);
                 else
-                    UnmapAsset(data_asset);
+                    UnmapAsset((void*&)data_asset, data_length);
                 dmLogError("Error mapping liveupdate index file, result = %i", r);
                 return RESULT_IO_ERROR;
             }
@@ -188,12 +188,12 @@ namespace dmResource
             if (mem_mapped_data)
                 UnmapFile(data_map, data_length);
             else
-                UnmapAsset(data_asset);
+                UnmapAsset((void*&)data_asset, data_length);
 
             if (mem_mapped_index)
                 UnmapFile(index_map, index_length);
             else
-                UnmapAsset(index_asset);
+                UnmapAsset((void*&)index_asset, index_length);
 
             if (res == dmResourceArchive::RESULT_VERSION_MISMATCH)
                 return RESULT_VERSION_MISMATCH;
@@ -222,7 +222,7 @@ namespace dmResource
 
         if (info->index_asset)
         {
-            UnmapAsset(info->index_asset);
+            UnmapAsset((void*&)info->index_asset, info->index_length);
         }
         else if (info->index_map)
         {
@@ -231,7 +231,7 @@ namespace dmResource
 
         if (info->data_asset)
         {
-            UnmapAsset(info->data_asset);
+            UnmapAsset((void*&)info->data_asset, info->data_length);
         } else if(info->data_map)
         {
             UnmapFile(info->data_map, info->data_length);

--- a/engine/resource/src/mount/mount_android.cpp
+++ b/engine/resource/src/mount/mount_android.cpp
@@ -41,8 +41,10 @@ namespace dmResource
         uint32_t index_length;
     };
 
-    Result MapAsset(AAssetManager* am, const char* path,  void*& out_asset, uint32_t& out_size, void*& out_map)
+    Result MapAsset(const char* path, void*& out_asset, uint32_t& out_size, void*& out_map)
     {
+        AAssetManager* am = g_AndroidApp->activity->assetManager;
+
         out_asset = (void*)AAssetManager_open(am, path, AASSET_MODE_RANDOM);
         if (!out_asset)
         {
@@ -87,11 +89,11 @@ namespace dmResource
         return RESULT_OK;
     }
 
-    static Result UnmapAsset(AAsset*& asset)
+    static Result UnmapAsset(void*& asset, uint32_t size)
     {
         if (asset != 0x0)
         {
-            AAsset_close(asset);
+            AAsset_close((AAsset*)asset);
         }
         return RESULT_OK;
     }
@@ -118,7 +120,6 @@ namespace dmResource
 
     Result MountArchiveInternal(const char* index_path, const char* data_path, dmResourceArchive::HArchiveIndexContainer* archive, void** mount_info)
     {
-        AAssetManager* am = g_AndroidApp->activity->assetManager;
         AAsset* index_asset = 0x0;
         uint32_t index_length = 0;
         void* index_map = 0x0;
@@ -132,7 +133,7 @@ namespace dmResource
         bool mem_mapped_data = false;
         if (strcmp(data_path, "game.arcd") == 0)
         {
-            r = MapAsset(am, data_path, (void*&)data_asset, data_length, data_map);
+            r = MapAsset(data_path, (void*&)data_asset, data_length, data_map);
             if (r != RESULT_OK)
             {
                 dmLogError("Error when mapping data file '%s', result = %i", data_path, r);
@@ -153,7 +154,7 @@ namespace dmResource
         bool mem_mapped_index = false;
         if (strcmp(index_path, "game.arci") == 0)
         {
-            r = MapAsset(am, index_path, (void*&)index_asset, index_length, index_map);
+            r = MapAsset(index_path, (void*&)index_asset, index_length, index_map);
             if (r != RESULT_OK)
             {
                 if (mem_mapped_data)

--- a/engine/resource/src/mount/mount_android.cpp
+++ b/engine/resource/src/mount/mount_android.cpp
@@ -41,7 +41,7 @@ namespace dmResource
         uint32_t index_length;
     };
 
-    Result MapAsset(const char* path, void*& out_asset, void*& out_map, uint32_t& out_size)
+    Result MapAsset(const char* path, void*& out_asset, uint32_t& out_size, void*& out_map)
     {
         AAssetManager* am = g_AndroidApp->activity->assetManager;
 
@@ -133,7 +133,7 @@ namespace dmResource
         bool mem_mapped_data = false;
         if (strcmp(data_path, "game.arcd") == 0)
         {
-            r = MapAsset(data_path, (void*&)data_asset, data_map, data_length);
+            r = MapAsset(data_path, (void*&)data_asset, data_length, data_map);
             if (r != RESULT_OK)
             {
                 dmLogError("Error when mapping data file '%s', result = %i", data_path, r);
@@ -154,7 +154,7 @@ namespace dmResource
         bool mem_mapped_index = false;
         if (strcmp(index_path, "game.arci") == 0)
         {
-            r = MapAsset(index_path, (void*&)index_asset, index_map, index_length);
+            r = MapAsset(index_path, (void*&)index_asset, index_length, index_map);
             if (r != RESULT_OK)
             {
                 if (mem_mapped_data)

--- a/engine/resource/src/mount/mount_generic.cpp
+++ b/engine/resource/src/mount/mount_generic.cpp
@@ -33,7 +33,7 @@ namespace dmResource
         return RESULT_OK;
     }
 
-    Result MapAsset(const char* name, void*& asset, void*& map, uint32_t& size)
+    Result MapAsset(const char* name, void*& out_asset, void*& out_map, uint32_t& out_size)
     {
         // Not used
         return RESULT_OK;

--- a/engine/resource/src/mount/mount_generic.cpp
+++ b/engine/resource/src/mount/mount_generic.cpp
@@ -33,6 +33,18 @@ namespace dmResource
         return RESULT_OK;
     }
 
+    Result MapAsset(const char* name, void*& asset, void*& map, uint32_t& size)
+    {
+        // Not used
+        return RESULT_OK;
+    }
+
+    Result UnmapAsset(void*& asset, uint32_t size)
+    {
+        // Not used
+        return RESULT_OK;
+    }
+
     Result MountManifest(const char* manifest_filename, void*& out_map, uint32_t& out_size)
     {
         // Not used

--- a/engine/resource/src/mount/mount_generic.cpp
+++ b/engine/resource/src/mount/mount_generic.cpp
@@ -33,7 +33,7 @@ namespace dmResource
         return RESULT_OK;
     }
 
-    Result MapAsset(const char* name, void*& out_asset, void*& out_map, uint32_t& out_size)
+    Result MapAsset(const char* name, void*& out_asset, uint32_t& out_size, void*& out_map)
     {
         // Not used
         return RESULT_OK;

--- a/engine/resource/src/mount/mount_mmap.cpp
+++ b/engine/resource/src/mount/mount_mmap.cpp
@@ -76,6 +76,18 @@ namespace dmResource
         return RESULT_OK;
     }
 
+    Result MapAsset(const char* name, void*& asset, void*& map, uint32_t& size)
+    {
+        // Not used
+        return RESULT_OK;
+    }
+
+    Result UnmapAsset(void*& asset, uint32_t size)
+    {
+        // Not used
+        return RESULT_OK;
+    }
+
     Result MountManifest(const char* manifest_filename, void*& out_map, uint32_t& out_size)
     {
         out_size = 0;

--- a/engine/resource/src/mount/mount_mmap.cpp
+++ b/engine/resource/src/mount/mount_mmap.cpp
@@ -76,7 +76,7 @@ namespace dmResource
         return RESULT_OK;
     }
 
-    Result MapAsset(const char* name, void*& asset, void*& map, uint32_t& size)
+    Result MapAsset(const char* name, void*& out_asset, void*& out_map, uint32_t& out_size)
     {
         // Not used
         return RESULT_OK;

--- a/engine/resource/src/mount/mount_mmap.cpp
+++ b/engine/resource/src/mount/mount_mmap.cpp
@@ -76,7 +76,7 @@ namespace dmResource
         return RESULT_OK;
     }
 
-    Result MapAsset(const char* name, void*& out_asset, void*& out_map, uint32_t& out_size)
+    Result MapAsset(const char* name, void*& out_asset, uint32_t& out_size, void*& out_map)
     {
         // Not used
         return RESULT_OK;

--- a/engine/resource/src/providers/provider_zip.cpp
+++ b/engine/resource/src/providers/provider_zip.cpp
@@ -220,7 +220,7 @@ static dmResourceProvider::Result Mount(const dmURI::Parts* uri, dmResourceProvi
 
         dmLogInfo("Mount zipasset dmResource::MapAsset %s", path);
         void* zip_map = 0x0;
-        dmResource::Result mr = dmResource::MapAsset((const char*)path, (void*&)archive->m_ZipAsset, zip_map, archive->m_ZipLength);
+        dmResource::Result mr = dmResource::MapAsset((const char*)path, (void*&)archive->m_ZipAsset, archive->m_ZipLength, zip_map);
         if (dmResource::RESULT_OK != mr)
         {
             dmLogError("Could not map asset '%s'", path);

--- a/engine/resource/src/providers/provider_zip.cpp
+++ b/engine/resource/src/providers/provider_zip.cpp
@@ -194,12 +194,6 @@ static dmResourceProvider::Result LoadManifest(dmZip::HZip zip, const char* path
     return result;
 }
 
-void SetAndNormalizePath(const char* path, char* out, uint32_t out_len)
-{
-    dmSnPrintf(out, out_len, "%s", path);
-    dmPath::Normalize(out, out, out_len);
-}
-
 static dmResourceProvider::Result Mount(const dmURI::Parts* uri, dmResourceProvider::HArchive base_archive, dmResourceProvider::HArchiveInternal* out_archive)
 {
     if (!MatchesUri(uri))
@@ -216,7 +210,8 @@ static dmResourceProvider::Result Mount(const dmURI::Parts* uri, dmResourceProvi
     // starts with /android_asset/ ?
     if (strncmp(ANDROID_ASSET_PATH, uri->m_Path, ANDROID_ASSET_PATH_LENGTH) == 0)
     {
-        SetAndNormalizePath(uri->m_Path + ANDROID_ASSET_PATH_LENGTH, path, sizeof(path));
+        dmSnPrintf(path, sizeof(path), "%s", uri->m_Path + ANDROID_ASSET_PATH_LENGTH);
+        dmPath::Normalize(path, path, sizeof(path));
 
         dmLogInfo("Mount zipasset dmResource::MapAsset %s", path);
         void* zip_map = 0x0;
@@ -238,7 +233,8 @@ static dmResourceProvider::Result Mount(const dmURI::Parts* uri, dmResourceProvi
     }
     else
     {
-        SetAndNormalizePath(uri->m_Path, path, sizeof(path));
+        dmSnPrintf(path, sizeof(path), "%s", uri->m_Path);
+        dmPath::Normalize(path, path, sizeof(path));
 
         dmLogInfo("Mount zip %s", path);
         char mount_path[1024];

--- a/engine/resource/src/providers/provider_zip.cpp
+++ b/engine/resource/src/providers/provider_zip.cpp
@@ -242,7 +242,7 @@ static dmResourceProvider::Result Mount(const dmURI::Parts* uri, dmResourceProvi
 
         char mount_path[1024];
 
-        dmSys::Result rr = dmSys::ResolveMountFileName(mount_path, sizeof(mount_path), path)
+        dmSys::Result rr = dmSys::ResolveMountFileName(mount_path, sizeof(mount_path), path);
         if (dmSys::RESULT_OK != rr)
         {
             dmLogError("Could not resolve a mount path '%s' (%d)", path, rr);

--- a/engine/resource/src/providers/provider_zip.cpp
+++ b/engine/resource/src/providers/provider_zip.cpp
@@ -203,8 +203,6 @@ static dmResourceProvider::Result Mount(const dmURI::Parts* uri, dmResourceProvi
     memset(archive, 0, sizeof(ZipProviderContext));
     memcpy(&archive->m_BaseUri, uri, sizeof(dmURI::Parts));
 
-    dmLogInfo("Mount %s", uri->m_Path);
-
     char path[1024];
 
     // starts with /android_asset/ ?
@@ -213,7 +211,6 @@ static dmResourceProvider::Result Mount(const dmURI::Parts* uri, dmResourceProvi
         dmSnPrintf(path, sizeof(path), "%s", uri->m_Path + ANDROID_ASSET_PATH_LENGTH);
         dmPath::Normalize(path, path, sizeof(path));
 
-        dmLogInfo("Mount zipasset dmResource::MapAsset %s", path);
         void* zip_map = 0x0;
         dmResource::Result mr = dmResource::MapAsset((const char*)path, (void*&)archive->m_ZipAsset, archive->m_ZipLength, zip_map);
         if (dmResource::RESULT_OK != mr)
@@ -236,7 +233,6 @@ static dmResourceProvider::Result Mount(const dmURI::Parts* uri, dmResourceProvi
         dmSnPrintf(path, sizeof(path), "%s", uri->m_Path);
         dmPath::Normalize(path, path, sizeof(path));
 
-        dmLogInfo("Mount zip %s", path);
         char mount_path[1024];
         if (dmSys::RESULT_OK != dmSys::ResolveMountFileName(mount_path, sizeof(mount_path), path))
         {
@@ -261,11 +257,9 @@ static dmResourceProvider::Result Mount(const dmURI::Parts* uri, dmResourceProvi
         return result;
     }
 
-    dmLogInfo("MountCreateEntryMap error");
     CreateEntryMap(archive);
 
     *out_archive = (dmResourceProvider::HArchiveInternal)archive;
-    dmLogInfo("Mount great success");
     return dmResourceProvider::RESULT_OK;
 }
 

--- a/engine/resource/src/resource_private.h
+++ b/engine/resource/src/resource_private.h
@@ -129,7 +129,7 @@ namespace dmResource
     Result MapFile(const char* filename, void*& map, uint32_t& size);
     Result UnmapFile(void*& map, uint32_t size);
     // Assets mapped with this function should be unmapped with UnmapAsset(...)
-    Result MapAsset(const char* name, void*& asset, void*& map, uint32_t& size);
+    Result MapAsset(const char* name, void*& out_asset, void*& out_map, uint32_t& out_size);
     Result UnmapAsset(void*& asset, uint32_t size);
 
     /**

--- a/engine/resource/src/resource_private.h
+++ b/engine/resource/src/resource_private.h
@@ -129,7 +129,7 @@ namespace dmResource
     Result MapFile(const char* filename, void*& map, uint32_t& size);
     Result UnmapFile(void*& map, uint32_t size);
     // Assets mapped with this function should be unmapped with UnmapAsset(...)
-    Result MapAsset(const char* name, void*& out_asset, void*& out_map, uint32_t& out_size);
+    Result MapAsset(const char* name, void*& out_asset, uint32_t& out_size, void*& out_map);
     Result UnmapAsset(void*& asset, uint32_t size);
 
     /**

--- a/engine/resource/src/resource_private.h
+++ b/engine/resource/src/resource_private.h
@@ -128,6 +128,9 @@ namespace dmResource
     // Files mapped with this function should be unmapped with UnmapFile(...)
     Result MapFile(const char* filename, void*& map, uint32_t& size);
     Result UnmapFile(void*& map, uint32_t size);
+    // Assets mapped with this function should be unmapped with UnmapAsset(...)
+    Result MapAsset(const char* name, void*& asset, void*& map, uint32_t& size);
+    Result UnmapAsset(void*& asset, uint32_t size);
 
     /**
      * In the case of an app-store upgrade, we dont want the runtime to load any existing local liveupdate.manifest.


### PR DESCRIPTION
It is now possible to mount a live update archive located inside the assets folder of an Android bundle by using a specific prefix to the archive path:

```lua
liveupdate.add_mount("my_mount", "zip:/android_asset/myassets.zip", priority, callback)
```

The archive can be added to the Android bundle using the bundle resources option or as an install-time Play Asset Delivery pack.

Fixes #11577 