### PR TITLE
Fixed race condition in sound test loopback device when using threads.

### DIFF
--- a/engine/sound/src/test/test_sound.cpp
+++ b/engine/sound/src/test/test_sound.cpp
@@ -21,11 +21,13 @@
 #include <dlib/array.h>
 #include <dlib/dstrings.h>
 #include <dlib/hash.h>
+#include <dlib/log.h>
+#include <dlib/math.h>
 #include <dlib/memory.h>
 #include <dlib/message.h>
-#include <dlib/log.h>
+#include <dlib/mutex.h>
 #include <dlib/time.h>
-#include <dlib/math.h>
+#include <dlib/thread.h> // DM_HAS_THREADS
 #include "../sound.h"
 #include "../sound_private.h"
 #include "../sound_codec.h"
@@ -375,6 +377,22 @@ struct LoopbackDevice
     int              m_QueueTime; // write cursor (frames)
     int              m_NumWrites;
     uint32_t         m_DeviceFrameCount;
+    dmMutex::HMutex  m_Mutex;
+
+    LoopbackDevice()
+    {
+#if defined(DM_HAS_THREADS)
+        m_Mutex = dmMutex::New();
+#else
+        m_Mutex = 0;
+#endif
+    }
+
+    ~LoopbackDevice()
+    {
+        if (m_Mutex)
+            dmMutex::Delete(m_Mutex);
+    }
 };
 
 
@@ -425,6 +443,9 @@ static dmSound::Result DeviceLoopbackQueue(dmSound::HDevice device, const void* 
     const int16_t* samples = (const int16_t*)_samples;
 
     LoopbackDevice* loopback = (LoopbackDevice*) device;
+
+    DM_MUTEX_OPTIONAL_SCOPED_LOCK(loopback->m_Mutex);
+
     loopback->m_NumWrites++;
 
     loopback->m_TotalBuffersQueued++;
@@ -627,8 +648,6 @@ TEST_P(dmSoundVerifyTest, Mix)
     const double level = 1.0f;
 
     ASSERT_GE(g_LoopbackDevice->m_AllOutput.Size(), n * 2U);
-
-
 
     // We need to check that the panning works as intended.
     // Instead of checking the panning cintinuously, we check the -1 (left), 1 (right) and 0 (center)
@@ -2020,7 +2039,6 @@ TEST_P(dmSoundMixerTest, Mixer)
     ASSERT_EQ(dmSound::RESULT_OK, r);
 
     r = dmSound::NewSoundInstance(sd2, &instance2);
-    r = dmSound::NewSoundInstance(sd2, &instance2);
     ASSERT_EQ(dmSound::RESULT_OK, r);
     ASSERT_NE((dmSound::HSoundInstance) 0, instance2);
     r = dmSound::SetInstanceGroup(instance2, "g2");
@@ -2088,6 +2106,8 @@ TEST_P(dmSoundMixerTest, Mixer)
 
         const int abs_error = 36;
         if ((uint32_t)i > params.m_BufferFrameCount * 2) {
+            DM_MUTEX_OPTIONAL_SCOPED_LOCK(g_LoopbackDevice->m_Mutex);
+
             ASSERT_NEAR(g_LoopbackDevice->m_AllOutput[2 * i], as, abs_error);
             ASSERT_NEAR(g_LoopbackDevice->m_AllOutput[2 * i + 1], as, abs_error);
             ASSERT_NEAR(g_LoopbackDevice->m_AllOutput[2 * i], as, abs_error);
@@ -2103,10 +2123,14 @@ TEST_P(dmSoundMixerTest, Mixer)
     ASSERT_NEAR(rms_left, last_rms, rms_tol);
     ASSERT_NEAR(rms_right, last_rms, rms_tol);
 
-    ASSERT_EQ(0, g_LoopbackDevice->m_AllOutput.Size() % 2);
-    for (uint32_t i = 2 * n; i < g_LoopbackDevice->m_AllOutput.Size() / 2; ++i) {
-        ASSERT_EQ(0, g_LoopbackDevice->m_AllOutput[2 * i]);
-        ASSERT_EQ(0, g_LoopbackDevice->m_AllOutput[2 * i + 1]);
+    {
+        DM_MUTEX_OPTIONAL_SCOPED_LOCK(g_LoopbackDevice->m_Mutex);
+
+        ASSERT_EQ(0, g_LoopbackDevice->m_AllOutput.Size() % 2);
+        for (uint32_t i = 2 * n; i < g_LoopbackDevice->m_AllOutput.Size() / 2; ++i) {
+            ASSERT_EQ(0, g_LoopbackDevice->m_AllOutput[2 * i]);
+            ASSERT_EQ(0, g_LoopbackDevice->m_AllOutput[2 * i + 1]);
+        }
     }
 
     r = dmSound::DeleteSoundData(sd1);

--- a/engine/sound/src/test/test_sound.cpp
+++ b/engine/sound/src/test/test_sound.cpp
@@ -2337,21 +2337,6 @@ static int PlaySound(const char* path, dmSound::SoundDataType type)
     return 0;
 }
 
-int main(int argc, char **argv)
-{
-    dmExportedSymbols();
-
-    dmSound::SoundDataType sound_type;
-    const char* sound_file = FindSoundFile(argc, argv, &sound_type);
-    if (sound_file)
-    {
-        return PlaySound(sound_file, sound_type);
-    }
-
-    jc_test_init(&argc, argv);
-    return jc_test_run_all();
-}
-
 // New tests for start_time/start_frame offset support
 
 TEST(SoundStartOffset, FrameIndependentOfSpeed)
@@ -2644,4 +2629,19 @@ TEST(SoundSdk, GroupToggleMute)
     EXPECT_FALSE(dmSound::IsGroupMuted(missing_hash));
 
     ASSERT_EQ(dmSound::RESULT_OK, dmSound::Finalize());
+}
+
+int main(int argc, char **argv)
+{
+    dmExportedSymbols();
+
+    dmSound::SoundDataType sound_type;
+    const char* sound_file = FindSoundFile(argc, argv, &sound_type);
+    if (sound_file)
+    {
+        return PlaySound(sound_file, sound_type);
+    }
+
+    jc_test_init(&argc, argv);
+    return jc_test_run_all();
 }


### PR DESCRIPTION
## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
