### PR TITLE
Refactored editor project loading for simpler profiling

### DIFF
--- a/editor/.cljfmt.edn
+++ b/editor/.cljfmt.edn
@@ -21,6 +21,7 @@
                  clojure.core/vector-of [[:inner 0]]
                  clojure.test/are [[:inner 0]]
                  dev/run-with-progress [[:inner 0]]
+                 dev/run-with-terminal-progress [[:inner 0]]
                  dynamo.graph/construct [[:inner 0]]
                  dynamo.graph/make-nodes [[:inner 0]]
                  dynamo.graph/fnk [[:block 1]]

--- a/editor/.idea/codeStyles/Project.xml
+++ b/editor/.idea/codeStyles/Project.xml
@@ -16,6 +16,7 @@
           <entry key="clojure.core/vector-of" value="-1" />
           <entry key="clojure.test/are" value="-1" />
           <entry key="dev/run-with-progress" value="-1" />
+          <entry key="dev/run-with-terminal-progress" value="-1" />
           <entry key="dynamo.graph/construct" value="-1" />
           <entry key="dynamo.graph/make-nodes" value="-1" />
           <entry key="dynamo.graph/override" value="-1" />

--- a/editor/resources/localization/en.editor_localization
+++ b/editor/resources/localization/en.editor_localization
@@ -696,6 +696,7 @@ progress.initializing-editor = Initializing editor {lib}
 progress.loading-editor = Loading editor
 progress.loading = Loading
 progress.loading-resource = Loading {resource}
+progress.processing-resource = Processing {resource}
 progress.resolving-resource = Resolving {resource}
 progress.reading-resource = Reading {resource}
 progress.finalizing = Finalizing…

--- a/editor/src/clj/editor/localization.clj
+++ b/editor/src/clj/editor/localization.clj
@@ -457,6 +457,23 @@
      (->MessageWithNestedPatterns key variables fallback localizable-keys)
      (->SimpleMessage key variables fallback))))
 
+(defn set-message-key
+  "Returns a new message pattern with the key and fallback replaced
+
+  To actually format, invoke localization (or its state) with pattern
+
+  Args:
+    original    localization message created using [[message]] fn
+    key         localization key, a dot-separated string, e.g. \"dialog.title\"
+    fallback    optional fallback string used in the case when localization key
+                does not exist"
+  ([original key]
+   (set-message-key original key nil))
+  ([original key fallback]
+   {:pre [(or (instance? SimpleMessage original)
+              (instance? MessageWithNestedPatterns original))]}
+   (message key (:m original) fallback)))
+
 (defn vary-message-variables
   "Transforms message variable map with a supplied function
 

--- a/editor/src/clj/internal/graph/types.clj
+++ b/editor/src/clj/internal/graph/types.clj
@@ -13,6 +13,7 @@
 ;; specific language governing permissions and limitations under the License.
 
 (ns internal.graph.types
+  (:require [util.defonce :as defonce])
   (:import [clojure.lang IHashEq Keyword Murmur3 Util]
            [com.defold.util WeakInterner]
            [java.io Writer]))
@@ -20,7 +21,7 @@
 (set! *warn-on-reflection* true)
 (set! *unchecked-math* :warn-on-boxed)
 
-(defrecord Arc [source-id source-label target-id target-label])
+(defonce/record Arc [source-id source-label target-id target-label])
 
 (defn arc-print-data [^Arc arc]
   (into [(.-source-id arc) (.-source-label arc)
@@ -47,7 +48,7 @@
 (definline node-id-hash [node-id]
   `(Murmur3/hashLong ~node-id))
 
-(deftype Endpoint [^long node-id ^Keyword label]
+(defonce/type Endpoint [^long node-id ^Keyword label]
   Comparable
   (compareTo [_ that]
     (let [^Endpoint that that
@@ -97,12 +98,20 @@
 (defn endpoint? [x]
   (instance? Endpoint x))
 
+(defn source-endpoint
+  ^Endpoint [^Arc arc]
+  (endpoint (source-id arc) (source-label arc)))
+
+(defn target-endpoint
+  ^Endpoint [^Arc arc]
+  (endpoint (target-id arc) (target-label arc)))
+
 (defn node-id? [v] (integer? v))
 
-(defprotocol Evaluation
+(defonce/protocol Evaluation
   (produce-value       [this label evaluation-context] "Pull a value using an evaluation context"))
 
-(defprotocol Node
+(defonce/protocol Node
   (node-id               [this]                          "Return an ID that can be used to get this node (or a future value of it).")
   (node-type             [this]                          "Return the node type that created this node.")
   (get-property          [this basis property]           "Return the value of the named property")
@@ -111,13 +120,13 @@
   (overridden-properties [this]                          "Return a map of property name to override value")
   (property-overridden?  [this property]))
 
-(defprotocol OverrideNode
+(defonce/protocol OverrideNode
   (clear-property      [this basis property]           "Clear the named property (this is only valid for override nodes)")
   (override-id         [this]                          "Return the ID of the override this node belongs to, if any")
   (original            [this]                          "Return the ID of the original of this node, if any")
   (set-original        [this original-id]              "Set the ID of the original of this node, if any"))
 
-(defprotocol IBasis
+(defonce/protocol IBasis
   (node-by-id-at    [this node-id])
   (node-by-property [this label value])
   (arcs-by-source   [this node-id] [this node-id label])

--- a/editor/src/clj/internal/transaction.clj
+++ b/editor/src/clj/internal/transaction.clj
@@ -928,7 +928,7 @@
   [{:keys [node-id output-label]}]
   (pair node-id output-label))
 
-(defn- apply-tx
+(defn apply-tx
   [ctx actions]
   (reduce
     (fn [ctx action]
@@ -951,7 +951,7 @@
     ctx
     actions))
 
-(defn- mark-nodes-modified
+(defn mark-nodes-modified
   [{:keys [nodes-affected] :as ctx}]
   (assoc ctx :nodes-modified (into #{} (map gt/endpoint-node-id) nodes-affected)))
 
@@ -959,7 +959,7 @@
   [m f]
   (util/map-vals f m))
 
-(defn- apply-tx-label
+(defn apply-tx-label
   [{:keys [basis label sequence-label] :as ctx}]
   (cond-> (update-in ctx [:basis :graphs] map-vals-bargs #(assoc % :tx-sequence-label sequence-label))
 
@@ -970,8 +970,7 @@
   (cond-> [:basis :graphs-modified :nodes-added :nodes-modified :nodes-deleted :outputs-modified :label :sequence-label]
           (du/metrics-enabled?) (conj :metrics)))
 
-(defn- finalize-update
-  "Makes the transacted graph the new value of the world-state graph."
+(defn finalize-update
   [{:keys [nodes-modified graphs-modified tx-data-context] :as ctx}]
   (-> (select-keys ctx tx-report-keys)
       (assoc :status (if (zero? (:completed-action-count ctx)) :empty :ok)
@@ -999,19 +998,19 @@
    :metrics metrics-collector
    :track-changes track-changes})
 
-(defn- update-overrides
+(defn update-overrides
   [{:keys [override-nodes-affected-ordered] :as ctx}]
   (du/measuring (:metrics ctx) :update-overrides
     (reduce populate-overrides
             ctx
             override-nodes-affected-ordered)))
 
-(defn- update-successors
+(defn update-successors
   [{:keys [successors-changed] :as ctx}]
   (du/measuring (:metrics ctx) :update-successors
     (update ctx :basis ig/update-successors successors-changed)))
 
-(defn- trace-dependencies
+(defn trace-dependencies
   [ctx]
   ;; At this point, :nodes-affected is a set of all output Endpoints that have
   ;; been directly affected by the transaction changes.

--- a/editor/src/dev/load_project.clj
+++ b/editor/src/dev/load_project.clj
@@ -19,6 +19,7 @@
             [editor.editor-extensions :as extensions]
             [editor.localization :as localization]
             [editor.prefs :as prefs]
+            [editor.progress :as progress]
             [editor.resource :as resource]
             [editor.resource-node :as resource-node]
             [editor.shared-editor-settings :as shared-editor-settings]
@@ -26,7 +27,9 @@
             [integration.test-util :as test-util]
             [internal.graph.types]
             [internal.system :as is]
+            [internal.transaction :as it]
             [service.log :as log]
+            [util.coll :as coll :refer [pair]]
             [util.debug-util :as du]
             [util.eduction :as e])
   (:import [java.util List]))
@@ -36,8 +39,13 @@
 ;; Set to the path of the project directory you want to load.
 (defonce project-path "test/resources/save_data_project")
 
+;; When true, generate tx-data for loaded nodes in a separate step before
+;; applying it in a transaction. Allows us to profile the two phases in
+;; isolation at the cost of increased peak memory usage.
+(defonce separate-load-tx-data-generation true)
+
 ;; Set to one of the task-phases below to skip the rest of the tasks.
-(defonce final-task :cache-save-data)
+(def final-task :cache-save-data)
 
 ;; You can use this to start and stop your own profiling tool for certain tasks.
 (defn- user-profiling-hook! [task-key task-fn]
@@ -57,17 +65,22 @@
     ;; A task we do not care about. Just invoke the task-fn.
     (task-fn)))
 
-(defonce ^:private ^List task-phases
+(def ^:private ^List task-phases
   [:setup-workspace
    :fetch-libraries
    :resource-sync
    :list-resources
    :make-project
    :read-resources
-   :load-nodes
-   :cache-save-data])
+   :generate-load-tx-data
+   :apply-load-tx-data
+   :update-overrides
+   :update-successors
+   :cache-save-data
+   :store-post-load-system
+   :calculate-scene-deps])
 
-(defonce ^:private final-task-index
+(def ^:private final-task-index
   (let [task-index (.indexOf task-phases final-task)]
     (assert (nat-int? task-index) (str "Invalid final-task: " final-task))
     task-index))
@@ -100,6 +113,10 @@
   (let [task-fn-sym (symbol (str "measure-" (name task-key)))]
     `(measure-task-impl! ~task-key (fn ~task-fn-sym [] (do ~@body)))))
 
+(defmacro ^:private run-task! [task-key & body]
+  `(when (run-task? ~task-key)
+     ~@body))
+
 (defmacro ^:private run-and-measure-task! [task-key & body]
   `(when (run-task? ~task-key)
      (measure-task! ~task-key ~@body)))
@@ -122,14 +139,13 @@
   (workspace/find-resource workspace "/game.project"))
 
 (defonce up-to-date-lib-states
-  (when (run-task? :fetch-libraries)
-    (dev/run-with-progress "Fetching Libraries..."
+  (run-and-measure-task!
+    :fetch-libraries
+    (dev/run-with-terminal-progress "Fetching Libraries..."
       (fn fetch-libraries-with-progress [render-progress!]
-        (measure-task!
-          :fetch-libraries
-          (let [dependencies (project/read-dependencies game-project-resource)
-                stale-lib-states (workspace/fetch-and-validate-libraries workspace dependencies render-progress!)]
-            (workspace/install-validated-libraries! workspace stale-lib-states)))))))
+        (let [dependencies (project/read-dependencies game-project-resource)
+              stale-lib-states (workspace/fetch-and-validate-libraries workspace dependencies render-progress!)]
+          (workspace/install-validated-libraries! workspace stale-lib-states))))))
 
 (defonce ^:private -initial-resource-sync-
   (run-and-measure-task!
@@ -159,28 +175,70 @@
       (project/make-project project-graph-id workspace extensions))))
 
 (defonce node-load-infos
-  (when (run-task? :read-resources)
-    (dev/run-with-progress "Reading Files..."
+  (run-and-measure-task!
+    :read-resources
+    (dev/run-with-terminal-progress "Reading Files..."
       (fn read-resources-with-progress [render-progress!]
-        (measure-task!
-          :read-resources
-          (project/read-nodes node-id+resource-pairs
-            :render-progress! render-progress!
-            :resource-metrics resource-metrics))))))
+        (project/read-nodes node-id+resource-pairs
+          :render-progress! render-progress!
+          :resource-metrics resource-metrics)))))
+
+(defn ^:dynamic render-apply-tx-data-progress! [_progress])
 
 (defonce migrated-resource-node-ids
-  (let [prelude-tx-data
-        (e/concat
-          (project/make-resource-nodes-tx-data project node-id+resource-pairs)
-          (project/setup-game-project-tx-data project game-project-node-id))
+  (let [tx-data
+        (run-and-measure-task!
+          :generate-load-tx-data
+          (let [{:keys [disk-sha256s-by-node-id node-id+source-value-pairs]}
+                (project/node-load-infos->stored-disk-state node-load-infos)]
+            (resource-node/merge-source-values! node-id+source-value-pairs)
+            (dev/run-with-terminal-progress "Generating Transaction Steps..."
+              (fn generate-load-tx-data-with-progress [render-progress!]
+                (let [[transfer-target render-generate-tx-data-progress!]
+                      (if separate-load-tx-data-generation
+                        [[] render-progress!]
+                        [:eduction progress/null-render-progress!])]
+                  (coll/transfer
+                    (e/concat
+                      (project/make-resource-nodes-tx-data project node-id+resource-pairs)
+                      (project/setup-game-project-tx-data project game-project-node-id)
+                      (workspace/merge-disk-sha256s workspace disk-sha256s-by-node-id)
+                      (project/load-nodes-tx-data project node-load-infos render-generate-tx-data-progress! #'render-apply-tx-data-progress! resource-metrics))
+                    transfer-target
+                    coll/flatten-xf))))))
+
+        tx-result
+        (as-> (g/make-transaction-context transact-opts) transaction-context
+
+              (run-and-measure-task!
+                :apply-load-tx-data
+                (dev/run-with-terminal-progress "Applying Transaction Steps..."
+                  (fn apply-load-tx-data-with-progress [render-progress!]
+                    (binding [render-apply-tx-data-progress! render-progress!]
+                      (it/apply-tx transaction-context tx-data)))))
+
+              (run-and-measure-task!
+                :update-overrides
+                (it/update-overrides transaction-context))
+
+              (it/mark-nodes-modified transaction-context)
+
+              (run-and-measure-task!
+                :update-successors
+                (it/update-successors transaction-context))
+
+              (it/trace-dependencies transaction-context)
+              (it/apply-tx-label transaction-context)
+              (it/finalize-update transaction-context))
+
+        _ (g/commit-tx-result! tx-result transact-opts)
 
         migrated-resource-node-ids
-        (when (run-task? :load-nodes)
-          (dev/run-with-progress "Loading Nodes..."
-            (fn load-nodes-with-progress [render-progress!]
-              (measure-task!
-                :load-nodes
-                (project/load-nodes! project prelude-tx-data node-load-infos render-progress! resource-metrics transact-opts)))))]
+        (let [basis (:basis tx-result)]
+          (into #{}
+                (keep #(resource-node/owner-resource-node-id basis %))
+                (g/migrated-node-ids tx-result)))]
+
     (when-not change-tracked-transact
       (g/clear-system-cache!))
     (run-and-measure-task!
@@ -217,3 +275,36 @@
      :task-metrics @task-metrics
      :resource-metrics @resource-metrics
      :transaction-metrics @transaction-metrics}))
+
+(defonce post-load-system
+  (run-task!
+    :store-post-load-system
+    @g/*the-system*))
+
+(defn- evaluated-endpoints-by-proj-path [project output-label render-progress!]
+  (g/with-auto-evaluation-context evaluation-context
+    (let [basis (:basis evaluation-context)
+
+          proj-paths+node-ids
+          (->> (g/valid-node-value project :nodes-by-resource-path evaluation-context)
+               (filterv (fn [[_proj-path node-id]]
+                          (some-> (g/node-type* basis node-id)
+                                  (g/has-output? output-label))))
+               (sort-by key))
+
+          proj-path-count (count proj-paths+node-ids)]
+      (coll/transfer proj-paths+node-ids {}
+        (map-indexed
+          (fn [proj-path-index [proj-path node-id]]
+            (let [message (localization/message nil [] proj-path)
+                  progress (progress/make message proj-path-count proj-path-index)]
+              (render-progress! progress)
+              (let [evaluated-endpoints (dev/recursive-predecessor-endpoints basis node-id output-label)]
+                (pair proj-path evaluated-endpoints)))))))))
+
+(defonce evaluated-scene-endpoints-by-proj-path
+  (run-and-measure-task!
+    :calculate-scene-deps
+    (dev/run-with-terminal-progress "Calculating Scene Dependencies..."
+      (fn calc-scene-deps-with-progress [render-progress!]
+        (evaluated-endpoints-by-proj-path project :scene render-progress!)))))

--- a/editor/src/dev/load_project.clj
+++ b/editor/src/dev/load_project.clj
@@ -141,11 +141,9 @@
 (defonce up-to-date-lib-states
   (run-and-measure-task!
     :fetch-libraries
-    (dev/run-with-terminal-progress "Fetching Libraries..."
-      (fn fetch-libraries-with-progress [render-progress!]
-        (let [dependencies (project/read-dependencies game-project-resource)
-              stale-lib-states (workspace/fetch-and-validate-libraries workspace dependencies render-progress!)]
-          (workspace/install-validated-libraries! workspace stale-lib-states))))))
+    (let [dependencies (project/read-dependencies game-project-resource)
+          stale-lib-states (workspace/fetch-and-validate-libraries workspace dependencies progress/null-render-progress!)]
+      (workspace/install-validated-libraries! workspace stale-lib-states))))
 
 (defonce ^:private -initial-resource-sync-
   (run-and-measure-task!
@@ -177,13 +175,8 @@
 (defonce node-load-infos
   (run-and-measure-task!
     :read-resources
-    (dev/run-with-terminal-progress "Reading Files..."
-      (fn read-resources-with-progress [render-progress!]
-        (project/read-nodes node-id+resource-pairs
-          :render-progress! render-progress!
-          :resource-metrics resource-metrics)))))
-
-(defn ^:dynamic render-apply-tx-data-progress! [_progress])
+    (project/read-nodes node-id+resource-pairs
+      :resource-metrics resource-metrics)))
 
 (defonce migrated-resource-node-ids
   (let [tx-data
@@ -192,30 +185,21 @@
           (let [{:keys [disk-sha256s-by-node-id node-id+source-value-pairs]}
                 (project/node-load-infos->stored-disk-state node-load-infos)]
             (resource-node/merge-source-values! node-id+source-value-pairs)
-            (dev/run-with-terminal-progress "Generating Transaction Steps..."
-              (fn generate-load-tx-data-with-progress [render-progress!]
-                (let [[transfer-target render-generate-tx-data-progress!]
-                      (if separate-load-tx-data-generation
-                        [[] render-progress!]
-                        [:eduction progress/null-render-progress!])]
-                  (coll/transfer
-                    (e/concat
-                      (project/make-resource-nodes-tx-data project node-id+resource-pairs)
-                      (project/setup-game-project-tx-data project game-project-node-id)
-                      (workspace/merge-disk-sha256s workspace disk-sha256s-by-node-id)
-                      (project/load-nodes-tx-data project node-load-infos render-generate-tx-data-progress! #'render-apply-tx-data-progress! resource-metrics))
-                    transfer-target
-                    coll/flatten-xf))))))
+            (coll/transfer
+              (e/concat
+                (project/make-resource-nodes-tx-data project node-id+resource-pairs)
+                (project/setup-game-project-tx-data project game-project-node-id)
+                (workspace/merge-disk-sha256s workspace disk-sha256s-by-node-id)
+                (project/load-nodes-tx-data project node-load-infos progress/null-render-progress! progress/null-render-progress! resource-metrics))
+              (if separate-load-tx-data-generation [] :eduction)
+              coll/flatten-xf)))
 
         tx-result
         (as-> (g/make-transaction-context transact-opts) transaction-context
 
               (run-and-measure-task!
                 :apply-load-tx-data
-                (dev/run-with-terminal-progress "Applying Transaction Steps..."
-                  (fn apply-load-tx-data-with-progress [render-progress!]
-                    (binding [render-apply-tx-data-progress! render-progress!]
-                      (it/apply-tx transaction-context tx-data)))))
+                (it/apply-tx transaction-context tx-data))
 
               (run-and-measure-task!
                 :update-overrides


### PR DESCRIPTION
* Make it easier to call individual post-transaction steps from `load_project.clj`.
* Gather stats around `:scene` output dependencies in `load_project.clj`.
* Add `localization/set-message-key`, for when you want to alter the message key but keep the arguments of a message pattern.
* Add `dev/run-with-terminal-progress` for reporting progress from tasks without involving JavaFX.
* Removed progress reporting from `load_project.clj`, since it was interfering with timings.