### PR TITLE
Improve project load performance by 19%

### DIFF
--- a/editor/src/clj/internal/graph.clj
+++ b/editor/src/clj/internal/graph.clj
@@ -732,7 +732,9 @@
                         ;; overrides along the wrong "branches" (for which there may be another
                         ;; better -earlier- matching source node).
                         conflicting-overrides-chain (mapv (fn [node next-override]
-                                                            (disj (into (int-map/int-set) (map #(gt/override-id (source-graph-nodes %))) (overrides source-graph node))
+                                                            (disj (into (int-map/int-set)
+                                                                        (map #(gt/override-id (source-graph-nodes %)))
+                                                                        (overrides source-graph node))
                                                                   next-override))
                                                           (conj override-node-chain source)
                                                           override-chain)]
@@ -751,7 +753,9 @@
     (let [source (.source-id ^Arc (first arcs))
           source-graph (node-id->graph basis source)
           source-graph-nodes (:nodes source-graph)
-          source-overrides (into #{} (map (comp gt/override-id source-graph-nodes)) (overrides source-graph source))]
+          source-overrides (into #{}
+                                 (map (comp gt/override-id source-graph-nodes))
+                                 (overrides source-graph source))]
       ;; Here we can (assert (every? #(= source (:source-id %)) arcs)), but it's too costly to run permantently.
       (loop [arcs arcs
              result arcs]

--- a/editor/src/clj/internal/graph.clj
+++ b/editor/src/clj/internal/graph.clj
@@ -14,6 +14,7 @@
 
 (ns internal.graph
   (:require [clojure.core.reducers :as r]
+            [clojure.data.int-map :as int-map]
             [internal.graph.types :as gt]
             [internal.node :as in]
             [internal.util :as util]
@@ -374,7 +375,7 @@
 
 (defn empty-graph
   []
-  {:nodes {}
+  {:nodes (int-map/int-map)
    :sarcs {}
    :successors {}
    :tarcs {}
@@ -564,12 +565,13 @@
 
 (defn override-of [graph node-id override-id]
   (let [^Indexed os (overrides graph node-id)
-        n (count os)]
+        n (count os)
+        nodes (:nodes graph)]
     (loop [i 0]
       (if (= i n)
         nil
         (let [override-node-id (.nth os i)]
-          (if (= override-id (gt/override-id (node-id->node graph override-node-id)))
+          (if (= override-id (gt/override-id (nodes override-node-id)))
             override-node-id
             (recur (inc i))))))))
 
@@ -683,6 +685,7 @@
       [arc]
       (let [^IPersistentSet disallowed-override-ids (first conflicting-source-overrides-chain)
             target-graph (node-id->graph basis target)
+            target-graph-nodes (:nodes target-graph)
             target-override-node-ids (overrides target-graph target)]
         (into []
               (comp
@@ -691,7 +694,7 @@
                 ;; up the wrong branch
                 (remove (fn [target-override-node-id]
                           ;; measurably faster than contains?
-                          (.contains disallowed-override-ids (gt/override-id (node-id->node target-graph target-override-node-id)))))
+                          (.contains disallowed-override-ids (gt/override-id (target-graph-nodes target-override-node-id)))))
                 ;; An explicit arc shadows/blocks implicit arcs
                 (filter (fn [target-override-node-id]
                           (nil? (graph-explicit-arcs-by-target target-graph target-override-node-id target-label))))
@@ -699,7 +702,7 @@
                 ;; depending on if the current target override matches
                 ;; the (current) source.
                 (mapcat (fn [target-override-node-id]
-                          (let [target-override-id (gt/override-id (node-id->node target-graph target-override-node-id))]
+                          (let [target-override-id (gt/override-id (target-graph-nodes target-override-node-id))]
                             (if (= target-override-id (first source-override-chain))
                               (lift-source-arc basis
                                                (rest source-override-chain)
@@ -724,12 +727,12 @@
                   ;; Here we can (assert (every? #(= (:source-id %) (:source-id (first explicit-arcs))) explicit-arcs))
                   (let [source (.source-id ^Arc (first explicit-arcs))
                         source-graph (node-id->graph basis source)
+                        source-graph-nodes (:nodes source-graph)
                         ;; conflicting-overrides is to prevent following target
                         ;; overrides along the wrong "branches" (for which there may be another
                         ;; better -earlier- matching source node).
                         conflicting-overrides-chain (mapv (fn [node next-override]
-                                                            (disj (into #{} (map #(gt/override-id (node-id->node source-graph %)))
-                                                                        (overrides source-graph node))
+                                                            (disj (into (int-map/int-set) (map #(gt/override-id (source-graph-nodes %))) (overrides source-graph node))
                                                                   next-override))
                                                           (conj override-node-chain source)
                                                           override-chain)]
@@ -747,7 +750,8 @@
   (when (seq arcs)
     (let [source (.source-id ^Arc (first arcs))
           source-graph (node-id->graph basis source)
-          source-overrides (into #{} (map (comp gt/override-id #(node-id->node source-graph %))) (overrides source-graph source))]
+          source-graph-nodes (:nodes source-graph)
+          source-overrides (into #{} (map (comp gt/override-id source-graph-nodes)) (overrides source-graph source))]
       ;; Here we can (assert (every? #(= source (:source-id %)) arcs)), but it's too costly to run permantently.
       (loop [arcs arcs
              result arcs]
@@ -755,10 +759,11 @@
                                     (mapcat (fn [^Arc target-arc]
                                               (let [target (.target-id target-arc)
                                                     label (.target-label target-arc)
-                                                    target-graph (node-id->graph basis target)]
+                                                    target-graph (node-id->graph basis target)
+                                                    target-graph-nodes (:nodes target-graph)]
                                                 (into []
                                                       (comp
-                                                        (map (partial node-id->node target-graph))
+                                                        (map target-graph-nodes)
                                                         (keep (fn [target-override-node]
                                                                 ;; no better matching override node, and no shadowing explicit arc
                                                                 (when (and (not (contains? source-overrides (gt/override-id target-override-node)))
@@ -804,21 +809,22 @@
   ;; override-node-chains (reductions conj '() originals)
   ;; override-chains (reductions conj '() overrides)
   ;; override-chains+explicit-arcs (map vector override-chains override-node-chains node-explicit-arcs)
-  (loop [node-id start-node-id
-         override-chain '()
-         override-node-chain '()
-         result (transient [])]
-    (let [node (node-id->node graph node-id)
-          explicit-arcs (explicit-arcs-fn graph node-id)
-          result' (if (seq explicit-arcs)
-                    (conj! result [override-chain override-node-chain explicit-arcs])
-                    result)]
-      (if-some [original (gt/original node)]
-        (recur original
-               (conj override-chain (gt/override-id node))
-               (conj override-node-chain node-id)
-               result')
-        (persistent! result')))))
+  (let [graph-nodes (:nodes graph)]
+    (loop [node-id start-node-id
+           override-chain '()
+           override-node-chain '()
+           result (transient [])]
+      (let [node (graph-nodes node-id)
+            explicit-arcs (explicit-arcs-fn graph node-id)
+            result' (if (seq explicit-arcs)
+                      (conj! result [override-chain override-node-chain explicit-arcs])
+                      result)]
+        (if-some [original (gt/original node)]
+          (recur original
+                 (conj override-chain (gt/override-id node))
+                 (conj override-node-chain node-id)
+                 result')
+          (persistent! result'))))))
 
 (def ^:private ^Cache basis-dependencies-cache
   (-> (Caffeine/newBuilder)
@@ -891,11 +897,12 @@
   (arcs-by-target
     [this node-id]
     (let [graph (node-id->graph this node-id)
+          graph-nodes (:nodes graph)
           override-chains+explicit-arcs (loop [node-id node-id
                                                override-chain '()
                                                seen-inputs #{}
                                                result (transient [])]
-                                          (let [node (node-id->node graph node-id)
+                                          (let [node (graph-nodes node-id)
                                                 explicit-arcs (remove (comp seen-inputs :target-label) (graph-explicit-arcs-by-target graph node-id))
                                                 result' (if (seq explicit-arcs)
                                                           (conj! result (pair override-chain explicit-arcs))


### PR DESCRIPTION
This performance optimization improves project load performance on big projects. As measured on a large project, the load time decreased from 3:01 to 2:25, a 19% improvement.

### Technical changes

This changeset contains 2 improvements:
1. Reduce nested map access in hot loops (reduced the load time by 9s).
2. Use int-map for nodes storage (reduced the load time by 27s).

Related to #10166

#### Notes on how I measured
1. I disabled the project dependency check during open, always using deps from the disc cache, to reduce network-induced latency variation
2. I purged the disc cache (`sudo purge` before opening a project) so it doesn't affect subsequent measurements.

#### Numbers
##### baseline
```
2025-12-09 16:31:06.826 INFO  default    editor.defold-project - {:line nil, :message "Project loading completed in 3:01"}
2025-12-09 16:31:12.495 INFO  default    editor.defold-project - {:line nil, :message "Project loaded", :allocated "7.03 GB"}
```
##### hoisted :nodes 
```
2025-12-09 16:43:44.085 INFO  default    editor.defold-project - {:line nil, :message "Project loading completed in 2:52"}
2025-12-09 16:43:48.681 INFO  default    editor.defold-project - {:line nil, :message "Project loaded", :allocated "7.02 GB"}
```
##### int-map, hoisted :nodes (no network, purge disc cache)
```
2025-12-09 16:35:55.531 INFO  default    editor.defold-project - {:line nil, :message "Project loading completed in 2:25"}
2025-12-09 16:35:59.621 INFO  default    editor.defold-project - {:line nil, :message "Project loaded", :allocated "7.01 GB"}
```

#### Some more notes
Tests now run a tiny bit faster (3%... maybe it's just noise):
```sh
# new
lein -o test  275.55s user 54.02s system 121% cpu 4:32.26 total
# old
lein -o test  286.38s user 59.19s system 122% cpu 4:42.24 total
```
Build speed didn't really change (there could be a tiny improvement caused by using intmap for nodes). Measured improvement of a clean build is just 1%, probably noise:
```
clean build before
"Elapsed time: 387356.811584 msecs"
clean build after
"Elapsed time: 382030.10725 msecs"
```