### PR TITLE
Fixed tests that triggered ASan and TSan on nightly builds

### DIFF
--- a/engine/dlib/src/test/test_job_thread.cpp
+++ b/engine/dlib/src/test/test_job_thread.cpp
@@ -483,34 +483,32 @@ TEST_P(dmJobThreadTest, CancelParentAfterChild)
 
     for (uint32_t i = 0; i < CHILD_COUNT; ++i)
     {
-        if (m_NumThreads == 1)
+        int process_called = dmAtomicGet32(&children[i].m_ProcessCalled);
+        int callback_called = dmAtomicGet32(&children[i].m_CallbackCalled);
+        if (m_NumThreads == 1) // i.e. no threads
         {
             if (i <= MID_INDEX)
             {
-                ASSERT_EQ(1, dmAtomicGet32(&children[i].m_ProcessCalled));
-                ASSERT_EQ(1, dmAtomicGet32(&children[i].m_CallbackCalled));
+                ASSERT_EQ(1, process_called);
+                ASSERT_EQ(1, callback_called);
             }
             else
             {
-                ASSERT_EQ(0, dmAtomicGet32(&children[i].m_ProcessCalled));
-                ASSERT_EQ(0, dmAtomicGet32(&children[i].m_CallbackCalled));
+                ASSERT_EQ(0, process_called);
+                ASSERT_EQ(0, callback_called);
             }
         }
         else
         {
             if (i == MID_INDEX)
             {
-                ASSERT_EQ(1, dmAtomicGet32(&children[i].m_ProcessCalled));
-                ASSERT_EQ(1, dmAtomicGet32(&children[i].m_CallbackCalled));
-            }
-            else if (i < MID_INDEX)
-            {
-                ASSERT_EQ(1, dmAtomicGet32(&children[i].m_ProcessCalled));
-                ASSERT_EQ(0, dmAtomicGet32(&children[i].m_CallbackCalled));
+                ASSERT_EQ(1, process_called);
+                ASSERT_EQ(1, callback_called);
             }
             else
             {
-                // Since the MID_INDEX has finished, it's possible that the threads has already picked up
+                // As it is multi threaded, we cannot be certain that the tasks have either started
+                // and/or finished.
             }
         }
     }
@@ -569,16 +567,8 @@ TEST_P(dmJobThreadTest, CancelParentAfterChild)
             }
             else if (children[i].m_Job)
             {
-                // We know the ones prior to the MID_INDEX should have finished
-                if ((i < MID_INDEX))
-                {
-                    ASSERT_EQ(dmJobThread::JOB_STATUS_FINISHED, children[i].m_CallbackStatus);
-                    ASSERT_EQ(1, dmAtomicGet32(&children[i].m_ProcessCalled));
-                }
-                else
-                {
-                    // Can't guarantuee the state they're in
-                }
+                // As it is multi threaded, we cannot be certain that the tasks have either started
+                // and/or finished, or if they've been cancelled.
             }
         }
     }


### PR DESCRIPTION
## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
