### PR TITLE
Unblock main thread while loading a collection and a texture at the same time

### DIFF
--- a/engine/graphics/src/vulkan/graphics_vulkan.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan.cpp
@@ -4262,8 +4262,11 @@ bail:
             return 0;
         }
 
-        DM_MUTEX_SCOPED_LOCK(context->m_AssetHandleContainerMutex);
-        VulkanTexture* tex = GetAssetFromContainer<VulkanTexture>(context->m_AssetHandleContainer, ap.m_Texture);
+        VulkanTexture* tex;
+        {
+            DM_MUTEX_SCOPED_LOCK(context->m_AssetHandleContainerMutex);
+            tex = GetAssetFromContainer<VulkanTexture>(context->m_AssetHandleContainer, ap.m_Texture);
+        }
 
         // Texture might have been deleted before the job thread has started processing this job.
         if (tex == NULL)


### PR DESCRIPTION
This fixes an issue where the main thread locked for an extender period of time when loading and initialising a collection while at the same time doing a texture upload on Vulkan.

## Technical change

This is what it looked like with the main thread blocked:

<img width="2540" height="1090" alt="image" src="https://github.com/user-attachments/assets/95179639-b96b-4e18-a760-da5843d98ba6" />

After:

<img width="2038" height="420" alt="image" src="https://github.com/user-attachments/assets/6484fbf7-13a7-4088-8a82-6c7c2b1f9d09" />


Fixes #11613 
