### PR TITLE
SDK build speedup

### DIFF
--- a/build_tools/http_cache.py
+++ b/build_tools/http_cache.py
@@ -120,7 +120,7 @@ def _extract_md5_from_headers(headers):
             md5_hex = etag
     return md5_hex
 
-def download(url, cb=None, cb_count=10, retries=5, timeout=60):
+def download(url, cb=None, cb_count=10, retries=8, timeout=60):
     """
     Download with retries and validation.
     Returns absolute cache file path on success.

--- a/com.dynamo.cr/com.dynamo.cr.bob/gradle/wrapper/gradle-wrapper.properties
+++ b/com.dynamo.cr/com.dynamo.cr.bob/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
-networkTimeout=10000
+networkTimeout=20000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -1973,20 +1973,37 @@ class Configuration(object):
 
         platform_zips = []  # (platform, zip_path)
         try:
-            for platform in platforms:
-                prefix = os.path.join(base_prefix, 'engine', platform, 'defoldsdk.zip')
-                entry = bucket.Object(prefix)
+            DOWNLOAD_WORKERS = 4
+            download_pool = ThreadPool(DOWNLOAD_WORKERS)
 
-                platform_sdk_zip = tempfile.NamedTemporaryFile(delete = False)
-                print ("Downloading", entry.key)
-                entry.download_file(platform_sdk_zip.name)
-                print ("Downloaded", entry.key, "to", platform_sdk_zip.name)
-                platform_zips.append((platform, platform_sdk_zip.name))
-                print ("")
+            def _download_platform_sdk_zip(netloc, key, out_path):
+                # Create a fresh bucket per thread to avoid shared boto3 state across threads.
+                thread_bucket = s3.get_bucket(netloc)
+                entry = thread_bucket.Object(key)
+                print("Downloading", entry.key)
+                entry.download_file(out_path)
+                print("Downloaded", entry.key, "to", out_path)
+                print("")
+                return out_path
+
+            download_futures = []
+            platform_zip_paths = {}
+            for platform in platforms:
+                key = os.path.join(base_prefix, 'engine', platform, 'defoldsdk.zip')
+                tmp = tempfile.NamedTemporaryFile(delete=False)
+                tmp.close()
+                platform_zip_paths[platform] = tmp.name
+                download_futures.append((platform, Future(download_pool, _download_platform_sdk_zip, u.netloc, key, tmp.name)))
+
+            # Preserve platform ordering for deterministic conflict resolution semantics.
+            for platform, fut in download_futures:
+                fut()
+                platform_zips.append((platform, platform_zip_paths[platform]))
 
             platform_rank = {p: i for i, (p, _) in enumerate(platform_zips)}
             canonical_platform = 'x86_64-linux' if any(p == 'x86_64-linux' for p, _ in platform_zips) else platform_zips[-1][0]
-            strict_merge = os.environ.get('DEFOLD_SDK_MERGE_STRICT', '1') not in ('0', 'false', 'False', 'no', 'NO')
+            # Default to non-strict to preserve historical "last extracted wins" behaviour unless explicitly enabled.
+            strict_merge = os.environ.get('DEFOLD_SDK_MERGE_STRICT', '0') not in ('0', 'false', 'False', 'no', 'NO')
 
             # Build candidate list per output path.
             candidates_by_path = {}  # filename -> [_SdkZipEntry...]

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -29,6 +29,7 @@ import release_to_steam
 import release_to_egs
 import BuildUtility
 import http_cache
+import sdk_merge
 from datetime import datetime
 from urllib.parse import urlparse
 from glob import glob
@@ -1921,7 +1922,6 @@ class Configuration(object):
 
         sha1 = self._git_sha1()
         u = urlparse(self.get_archive_path())
-        bucket = s3.get_bucket(u.netloc)
 
         root = urlparse(self.get_archive_path()).path[1:]
         base_prefix = os.path.join(root, sha1)
@@ -1943,169 +1943,15 @@ class Configuration(object):
             platforms.remove('x86_64-linux')
             platforms.append('x86_64-linux')
 
-        # We merge platform SDK zips by building a per-zip index and selecting a single source
-        # for each output path, instead of repeatedly extracting and overwriting shared files.
-        #
-        # Rules:
-        # - Unique paths (present in only one zip) are included.
-        # - Paths under platform-specific prefixes always come from that platform's zip.
-        # - If the same path exists in multiple zips and differs (size/CRC), we either error
-        #   or fall back to old "last extracted wins" depending on DEFOLD_SDK_MERGE_STRICT.
-        from dataclasses import dataclass
-
-        @dataclass(frozen=True)
-        class _SdkZipEntry(object):
-            platform: str
-            zip_path: str
-            filename: str
-            file_size: int
-            crc: int
-            external_attr: int
-            is_dir: bool
-
-        def _platform_prefixes(p):
-            # Note: These prefixes exist inside the per-platform zips as produced by _package_platform_sdk().
-            return (
-                f"defoldsdk/lib/{p}/",
-                f"defoldsdk/ext/lib/{p}/",
-                f"defoldsdk/ext/bin/{p}/",
-            )
-
-        platform_zips = []  # (platform, zip_path)
-        try:
-            DOWNLOAD_WORKERS = 4
-            download_pool = ThreadPool(DOWNLOAD_WORKERS)
-
-            def _download_platform_sdk_zip(netloc, key, out_path):
-                # Create a fresh bucket per thread to avoid shared boto3 state across threads.
-                thread_bucket = s3.get_bucket(netloc)
-                entry = thread_bucket.Object(key)
-                print("Downloading", entry.key)
-                entry.download_file(out_path)
-                print("Downloaded", entry.key, "to", out_path)
-                print("")
-                return out_path
-
-            download_futures = []
-            platform_zip_paths = {}
-            for platform in platforms:
-                key = os.path.join(base_prefix, 'engine', platform, 'defoldsdk.zip')
-                tmp = tempfile.NamedTemporaryFile(delete=False)
-                tmp.close()
-                platform_zip_paths[platform] = tmp.name
-                download_futures.append((platform, Future(download_pool, _download_platform_sdk_zip, u.netloc, key, tmp.name)))
-
-            # Preserve platform ordering for deterministic conflict resolution semantics.
-            for platform, fut in download_futures:
-                fut()
-                platform_zips.append((platform, platform_zip_paths[platform]))
-
-            platform_rank = {p: i for i, (p, _) in enumerate(platform_zips)}
-            canonical_platform = 'x86_64-linux' if any(p == 'x86_64-linux' for p, _ in platform_zips) else platform_zips[-1][0]
-            # Default to non-strict to preserve historical "last extracted wins" behaviour unless explicitly enabled.
-            strict_merge = os.environ.get('DEFOLD_SDK_MERGE_STRICT', '0') not in ('0', 'false', 'False', 'no', 'NO')
-
-            # Build candidate list per output path.
-            candidates_by_path = {}  # filename -> [_SdkZipEntry...]
-            for platform, zip_path in platform_zips:
-                with zipfile.ZipFile(zip_path, 'r') as zf:
-                    for info in zf.infolist():
-                        # Basic hardening: reject absolute paths and path traversal attempts.
-                        name = info.filename.replace('\\', '/')
-                        if not name or name.startswith('/') or '..' in name.split('/'):
-                            raise Exception(f"Invalid zip entry path in {platform}: {info.filename}")
-
-                        candidates_by_path.setdefault(name, []).append(_SdkZipEntry(
-                            platform=platform,
-                            zip_path=zip_path,
-                            filename=name,
-                            file_size=getattr(info, 'file_size', 0),
-                            crc=getattr(info, 'CRC', 0),
-                            external_attr=getattr(info, 'external_attr', 0),
-                            is_dir=bool(getattr(info, 'is_dir', lambda: name.endswith('/'))()),
-                        ))
-
-            selected_by_path = {}  # filename -> _SdkZipEntry
-            conflicts = []         # (filename, [entries], chosen_entry)
-
-            for filename, entries in candidates_by_path.items():
-                file_entries = [e for e in entries if not e.is_dir]
-                if not file_entries:
-                    continue
-
-                # If this filename belongs to a platform-specific prefix, select from that platform.
-                expected_platform = None
-                for p, _ in platform_zips:
-                    if any(filename.startswith(pref) for pref in _platform_prefixes(p)):
-                        expected_platform = p
-                        break
-
-                chosen = None
-                if expected_platform is not None:
-                    for e in file_entries:
-                        if e.platform == expected_platform:
-                            chosen = e
-                            break
-                    if chosen is None:
-                        # Unexpected: platform prefix but no matching platform source.
-                        chosen = max(file_entries, key=lambda e: platform_rank.get(e.platform, -1))
-                else:
-                    unique_payloads = {(e.file_size, e.crc) for e in file_entries}
-                    if len(unique_payloads) == 1:
-                        # Identical across platforms: prefer canonical platform for determinism.
-                        chosen = next((e for e in file_entries if e.platform == canonical_platform), None)
-                        if chosen is None:
-                            chosen = max(file_entries, key=lambda e: platform_rank.get(e.platform, -1))
-                    else:
-                        # Non-identical collision: old behaviour is "last extracted wins".
-                        chosen = max(file_entries, key=lambda e: platform_rank.get(e.platform, -1))
-                        conflicts.append((filename, file_entries, chosen))
-
-                selected_by_path[filename] = chosen
-
-            if conflicts:
-                msg_lines = [
-                    "Found conflicting SDK paths across platforms (same path, different payload):",
-                ]
-                # Print a bounded set to keep logs readable.
-                for filename, entries, chosen in conflicts[:50]:
-                    details = ", ".join([f"{e.platform}(size={e.file_size},crc={e.crc:08x})" for e in entries])
-                    msg_lines.append(f"  - {filename}: {details} -> using {chosen.platform}")
-                if len(conflicts) > 50:
-                    msg_lines.append(f"  ... and {len(conflicts) - 50} more")
-
-                full_msg = "\n".join(msg_lines)
-                if strict_merge:
-                    raise Exception(full_msg + "\nSet DEFOLD_SDK_MERGE_STRICT=0 to preserve previous overwrite behaviour.")
-                else:
-                    print("WARNING:", full_msg)
-
-            # Extract only selected entries, grouped by source zip for performance.
-            extract_map = {}  # zip_path -> [filename...]
-            for filename, entry in selected_by_path.items():
-                extract_map.setdefault(entry.zip_path, []).append(filename)
-
-            for zip_path, filenames in extract_map.items():
-                with zipfile.ZipFile(zip_path, 'r') as zf:
-                    for filename in sorted(filenames):
-                        info = zf.getinfo(filename)
-                        if getattr(info, 'is_dir', lambda: filename.endswith('/'))():
-                            continue
-                        out_path = os.path.join(tempdir, filename)
-                        self._mkdirs(os.path.dirname(out_path))
-                        with zf.open(filename, 'r') as src, open(out_path, 'wb') as dst:
-                            shutil.copyfileobj(src, dst)
-                        perm = (getattr(info, 'external_attr', 0) >> 16) & 0o7777
-                        if perm:
-                            os.chmod(out_path, perm)
-
-            print("Merged platform SDKs into", tempdir)
-        finally:
-            for _, zip_path in platform_zips:
-                try:
-                    os.unlink(zip_path)
-                except Exception:
-                    pass
+        # Default to non-strict to preserve historical "last extracted wins" behaviour unless explicitly enabled.
+        strict_merge = os.environ.get('DEFOLD_SDK_MERGE_STRICT', '0') not in ('0', 'false', 'False', 'no', 'NO')
+        sdk_merge.build_combined_sdk_tree(
+            netloc=u.netloc,
+            base_prefix=base_prefix,
+            platforms=platforms,
+            extract_dir=tempdir,
+            strict_merge=strict_merge,
+            canonical_platform='x86_64-linux')
 
         # Due to an issue with how the attributes are preserved, let's go through the bin/ folders
         # and set the flags explicitly

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -1329,9 +1329,10 @@ class Configuration(object):
 
                 self._add_files_to_zip(zip, protobuf_files, self.dynamo_home, topfolder)
 
-                # bob pipeline classes
-                bob_light = os.path.join(self.dynamo_home, 'share/java/bob-light.jar')
-                self._add_files_to_zip(zip, [bob_light], self.dynamo_home, topfolder)
+                # bob pipeline classes include only in one sdk
+                if platform in ('x86_64-linux'):
+                    bob_light = os.path.join(self.dynamo_home, 'share/java/bob-light.jar')
+                    self._add_files_to_zip(zip, [bob_light], self.dynamo_home, topfolder)
 
 
             # For logging, print all paths in zip:

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -1933,16 +1933,6 @@ class Configuration(object):
         else:
             platforms = get_target_platforms()
 
-        # For the linux build tools (protoc, dlib_shared etc)
-        if 'x86_64-linux' not in platforms:
-            platforms.append('x86_64-linux')
-
-        # Since we usually want to use the scripts in this package on a linux machine, we'll unpack
-        # it last, in order to preserve unix line endings in the files
-        if 'x86_64-linux' in platforms:
-            platforms.remove('x86_64-linux')
-            platforms.append('x86_64-linux')
-
         sdk_merge.build_combined_sdk_tree(
             netloc=u.netloc,
             base_prefix=base_prefix,

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -1943,20 +1943,152 @@ class Configuration(object):
             platforms.remove('x86_64-linux')
             platforms.append('x86_64-linux')
 
-        for platform in platforms:
-            prefix = os.path.join(base_prefix, 'engine', platform, 'defoldsdk.zip')
-            entry = bucket.Object(prefix)
+        # We merge platform SDK zips by building a per-zip index and selecting a single source
+        # for each output path, instead of repeatedly extracting and overwriting shared files.
+        #
+        # Rules:
+        # - Unique paths (present in only one zip) are included.
+        # - Paths under platform-specific prefixes always come from that platform's zip.
+        # - If the same path exists in multiple zips and differs (size/CRC), we either error
+        #   or fall back to old "last extracted wins" depending on DEFOLD_SDK_MERGE_STRICT.
+        from dataclasses import dataclass
 
-            platform_sdk_zip = tempfile.NamedTemporaryFile(delete = False)
-            print ("Downloading", entry.key)
-            entry.download_file(platform_sdk_zip.name)
-            print ("Downloaded", entry.key, "to", platform_sdk_zip.name)
+        @dataclass(frozen=True)
+        class _SdkZipEntry(object):
+            platform: str
+            zip_path: str
+            filename: str
+            file_size: int
+            crc: int
+            external_attr: int
+            is_dir: bool
 
-            self._extract_zip(platform_sdk_zip.name, tempdir)
-            print ("Extracted", platform_sdk_zip.name, "to", tempdir)
+        def _platform_prefixes(p):
+            # Note: These prefixes exist inside the per-platform zips as produced by _package_platform_sdk().
+            return (
+                f"defoldsdk/lib/{p}/",
+                f"defoldsdk/ext/lib/{p}/",
+                f"defoldsdk/ext/bin/{p}/",
+            )
 
-            os.unlink(platform_sdk_zip.name)
-            print ("")
+        platform_zips = []  # (platform, zip_path)
+        try:
+            for platform in platforms:
+                prefix = os.path.join(base_prefix, 'engine', platform, 'defoldsdk.zip')
+                entry = bucket.Object(prefix)
+
+                platform_sdk_zip = tempfile.NamedTemporaryFile(delete = False)
+                print ("Downloading", entry.key)
+                entry.download_file(platform_sdk_zip.name)
+                print ("Downloaded", entry.key, "to", platform_sdk_zip.name)
+                platform_zips.append((platform, platform_sdk_zip.name))
+                print ("")
+
+            platform_rank = {p: i for i, (p, _) in enumerate(platform_zips)}
+            canonical_platform = 'x86_64-linux' if any(p == 'x86_64-linux' for p, _ in platform_zips) else platform_zips[-1][0]
+            strict_merge = os.environ.get('DEFOLD_SDK_MERGE_STRICT', '1') not in ('0', 'false', 'False', 'no', 'NO')
+
+            # Build candidate list per output path.
+            candidates_by_path = {}  # filename -> [_SdkZipEntry...]
+            for platform, zip_path in platform_zips:
+                with zipfile.ZipFile(zip_path, 'r') as zf:
+                    for info in zf.infolist():
+                        # Basic hardening: reject absolute paths and path traversal attempts.
+                        name = info.filename.replace('\\', '/')
+                        if not name or name.startswith('/') or '..' in name.split('/'):
+                            raise Exception(f"Invalid zip entry path in {platform}: {info.filename}")
+
+                        candidates_by_path.setdefault(name, []).append(_SdkZipEntry(
+                            platform=platform,
+                            zip_path=zip_path,
+                            filename=name,
+                            file_size=getattr(info, 'file_size', 0),
+                            crc=getattr(info, 'CRC', 0),
+                            external_attr=getattr(info, 'external_attr', 0),
+                            is_dir=bool(getattr(info, 'is_dir', lambda: name.endswith('/'))()),
+                        ))
+
+            selected_by_path = {}  # filename -> _SdkZipEntry
+            conflicts = []         # (filename, [entries], chosen_entry)
+
+            for filename, entries in candidates_by_path.items():
+                file_entries = [e for e in entries if not e.is_dir]
+                if not file_entries:
+                    continue
+
+                # If this filename belongs to a platform-specific prefix, select from that platform.
+                expected_platform = None
+                for p, _ in platform_zips:
+                    if any(filename.startswith(pref) for pref in _platform_prefixes(p)):
+                        expected_platform = p
+                        break
+
+                chosen = None
+                if expected_platform is not None:
+                    for e in file_entries:
+                        if e.platform == expected_platform:
+                            chosen = e
+                            break
+                    if chosen is None:
+                        # Unexpected: platform prefix but no matching platform source.
+                        chosen = max(file_entries, key=lambda e: platform_rank.get(e.platform, -1))
+                else:
+                    unique_payloads = {(e.file_size, e.crc) for e in file_entries}
+                    if len(unique_payloads) == 1:
+                        # Identical across platforms: prefer canonical platform for determinism.
+                        chosen = next((e for e in file_entries if e.platform == canonical_platform), None)
+                        if chosen is None:
+                            chosen = max(file_entries, key=lambda e: platform_rank.get(e.platform, -1))
+                    else:
+                        # Non-identical collision: old behaviour is "last extracted wins".
+                        chosen = max(file_entries, key=lambda e: platform_rank.get(e.platform, -1))
+                        conflicts.append((filename, file_entries, chosen))
+
+                selected_by_path[filename] = chosen
+
+            if conflicts:
+                msg_lines = [
+                    "Found conflicting SDK paths across platforms (same path, different payload):",
+                ]
+                # Print a bounded set to keep logs readable.
+                for filename, entries, chosen in conflicts[:50]:
+                    details = ", ".join([f"{e.platform}(size={e.file_size},crc={e.crc:08x})" for e in entries])
+                    msg_lines.append(f"  - {filename}: {details} -> using {chosen.platform}")
+                if len(conflicts) > 50:
+                    msg_lines.append(f"  ... and {len(conflicts) - 50} more")
+
+                full_msg = "\n".join(msg_lines)
+                if strict_merge:
+                    raise Exception(full_msg + "\nSet DEFOLD_SDK_MERGE_STRICT=0 to preserve previous overwrite behaviour.")
+                else:
+                    print("WARNING:", full_msg)
+
+            # Extract only selected entries, grouped by source zip for performance.
+            extract_map = {}  # zip_path -> [filename...]
+            for filename, entry in selected_by_path.items():
+                extract_map.setdefault(entry.zip_path, []).append(filename)
+
+            for zip_path, filenames in extract_map.items():
+                with zipfile.ZipFile(zip_path, 'r') as zf:
+                    for filename in sorted(filenames):
+                        info = zf.getinfo(filename)
+                        if getattr(info, 'is_dir', lambda: filename.endswith('/'))():
+                            continue
+                        out_path = os.path.join(tempdir, filename)
+                        self._mkdirs(os.path.dirname(out_path))
+                        with zf.open(filename, 'r') as src, open(out_path, 'wb') as dst:
+                            shutil.copyfileobj(src, dst)
+                        perm = (getattr(info, 'external_attr', 0) >> 16) & 0o7777
+                        if perm:
+                            os.chmod(out_path, perm)
+
+            print("Merged platform SDKs into", tempdir)
+        finally:
+            for _, zip_path in platform_zips:
+                try:
+                    os.unlink(zip_path)
+                except Exception:
+                    pass
 
         # Due to an issue with how the attributes are preserved, let's go through the bin/ folders
         # and set the flags explicitly

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -1943,14 +1943,11 @@ class Configuration(object):
             platforms.remove('x86_64-linux')
             platforms.append('x86_64-linux')
 
-        # Default to non-strict to preserve historical "last extracted wins" behaviour unless explicitly enabled.
-        strict_merge = os.environ.get('DEFOLD_SDK_MERGE_STRICT', '0') not in ('0', 'false', 'False', 'no', 'NO')
         sdk_merge.build_combined_sdk_tree(
             netloc=u.netloc,
             base_prefix=base_prefix,
             platforms=platforms,
             extract_dir=tempdir,
-            strict_merge=strict_merge,
             canonical_platform='x86_64-linux')
 
         # Due to an issue with how the attributes are preserved, let's go through the bin/ folders

--- a/scripts/sdk_merge.py
+++ b/scripts/sdk_merge.py
@@ -1,0 +1,182 @@
+import os
+import shutil
+import tempfile
+import zipfile
+from dataclasses import dataclass
+from concurrent.futures import ThreadPoolExecutor
+
+import s3
+
+
+DOWNLOAD_WORKERS = 4
+
+
+@dataclass(frozen=True)
+class _SdkZipEntry(object):
+    platform: str
+    zip_path: str
+    filename: str
+    file_size: int
+    crc: int
+    external_attr: int
+    is_dir: bool
+
+
+def _platform_prefixes(platform):
+    return (
+        f"defoldsdk/lib/{platform}/",
+        f"defoldsdk/ext/lib/{platform}/",
+        f"defoldsdk/ext/bin/{platform}/",
+    )
+
+
+def _download_platform_sdk_zip(netloc, key, out_path):
+    # Create a fresh bucket per thread to avoid shared boto3 state across threads.
+    bucket = s3.get_bucket(netloc)
+    entry = bucket.Object(key)
+    print("Downloading", entry.key)
+    entry.download_file(out_path)
+    print("Downloaded", entry.key, "to", out_path)
+    print("")
+    return out_path
+
+
+def download_platform_sdk_zips(netloc, base_prefix, platforms):
+    """
+    Downloads per-platform defoldsdk.zip files in parallel.
+    Returns an ordered list of (platform, local_zip_path) matching `platforms` order.
+    """
+    keys = {platform: os.path.join(base_prefix, 'engine', platform, 'defoldsdk.zip') for platform in platforms}
+    tmp_paths = {}
+    for platform in platforms:
+        tmp = tempfile.NamedTemporaryFile(delete=False)
+        tmp.close()
+        tmp_paths[platform] = tmp.name
+
+    with ThreadPoolExecutor(max_workers=DOWNLOAD_WORKERS) as ex:
+        futures = {platform: ex.submit(_download_platform_sdk_zip, netloc, keys[platform], tmp_paths[platform])
+                   for platform in platforms}
+        # Preserve order for deterministic merge tie-breaking.
+        for platform in platforms:
+            futures[platform].result()
+
+    return [(platform, tmp_paths[platform]) for platform in platforms]
+
+
+def merge_platform_sdk_zips_into_tree(platform_zips, extract_dir, strict_merge=False, canonical_platform='x86_64-linux'):
+    """
+    Merge multiple per-platform SDK zips into `extract_dir` by selecting a single source zip per output path.
+    - Includes unique paths from any zip.
+    - For platform-specific prefixes, always selects that platform's zip.
+    - For identical duplicates (same size+CRC), prefers `canonical_platform` for determinism.
+    - For non-identical duplicates, either errors (strict_merge=True) or warns and uses the
+      last platform in `platform_zips` order (historical overwrite semantics).
+    """
+    platform_rank = {p: i for i, (p, _) in enumerate(platform_zips)}
+    if not any(p == canonical_platform for p, _ in platform_zips):
+        canonical_platform = platform_zips[-1][0]
+
+    candidates_by_path = {}  # filename -> [_SdkZipEntry...]
+    for platform, zip_path in platform_zips:
+        with zipfile.ZipFile(zip_path, 'r') as zf:
+            for info in zf.infolist():
+                name = info.filename.replace('\\', '/')
+                if not name or name.startswith('/') or '..' in name.split('/'):
+                    raise Exception(f"Invalid zip entry path in {platform}: {info.filename}")
+
+                candidates_by_path.setdefault(name, []).append(_SdkZipEntry(
+                    platform=platform,
+                    zip_path=zip_path,
+                    filename=name,
+                    file_size=getattr(info, 'file_size', 0),
+                    crc=getattr(info, 'CRC', 0),
+                    external_attr=getattr(info, 'external_attr', 0),
+                    is_dir=bool(getattr(info, 'is_dir', lambda: name.endswith('/'))()),
+                ))
+
+    selected_by_path = {}  # filename -> _SdkZipEntry
+    conflicts = []         # (filename, [entries], chosen_entry)
+
+    for filename, entries in candidates_by_path.items():
+        file_entries = [e for e in entries if not e.is_dir]
+        if not file_entries:
+            continue
+
+        expected_platform = None
+        for p, _ in platform_zips:
+            if any(filename.startswith(pref) for pref in _platform_prefixes(p)):
+                expected_platform = p
+                break
+
+        chosen = None
+        if expected_platform is not None:
+            for e in file_entries:
+                if e.platform == expected_platform:
+                    chosen = e
+                    break
+            if chosen is None:
+                chosen = max(file_entries, key=lambda e: platform_rank.get(e.platform, -1))
+        else:
+            unique_payloads = {(e.file_size, e.crc) for e in file_entries}
+            if len(unique_payloads) == 1:
+                chosen = next((e for e in file_entries if e.platform == canonical_platform), None)
+                if chosen is None:
+                    chosen = max(file_entries, key=lambda e: platform_rank.get(e.platform, -1))
+            else:
+                chosen = max(file_entries, key=lambda e: platform_rank.get(e.platform, -1))
+                conflicts.append((filename, file_entries, chosen))
+
+        selected_by_path[filename] = chosen
+
+    if conflicts:
+        msg_lines = [
+            "Found conflicting SDK paths across platforms (same path, different payload):",
+        ]
+        for filename, entries, chosen in conflicts[:50]:
+            details = ", ".join([f"{e.platform}(size={e.file_size},crc={e.crc:08x})" for e in entries])
+            msg_lines.append(f"  - {filename}: {details} -> using {chosen.platform}")
+        if len(conflicts) > 50:
+            msg_lines.append(f"  ... and {len(conflicts) - 50} more")
+
+        full_msg = "\n".join(msg_lines)
+        if strict_merge:
+            raise Exception(full_msg + "\nSet DEFOLD_SDK_MERGE_STRICT=0 to preserve previous overwrite behaviour.")
+        else:
+            print("WARNING:", full_msg)
+
+    extract_map = {}  # zip_path -> [filename...]
+    for filename, entry in selected_by_path.items():
+        extract_map.setdefault(entry.zip_path, []).append(filename)
+
+    for zip_path, filenames in extract_map.items():
+        with zipfile.ZipFile(zip_path, 'r') as zf:
+            for filename in sorted(filenames):
+                info = zf.getinfo(filename)
+                if getattr(info, 'is_dir', lambda: filename.endswith('/'))():
+                    continue
+                out_path = os.path.join(extract_dir, filename)
+                os.makedirs(os.path.dirname(out_path), exist_ok=True)
+                with zf.open(filename, 'r') as src, open(out_path, 'wb') as dst:
+                    shutil.copyfileobj(src, dst)
+                perm = (getattr(info, 'external_attr', 0) >> 16) & 0o7777
+                if perm:
+                    os.chmod(out_path, perm)
+
+    print("Merged platform SDKs into", extract_dir)
+
+
+def build_combined_sdk_tree(netloc, base_prefix, platforms, extract_dir, strict_merge=False, canonical_platform='x86_64-linux'):
+    """
+    High-level helper used by scripts/build.py: downloads per-platform zips, merges them into a single tree,
+    and cleans up the downloaded zip files.
+    """
+    platform_zips = download_platform_sdk_zips(netloc, base_prefix, platforms)
+    try:
+        merge_platform_sdk_zips_into_tree(platform_zips, extract_dir, strict_merge=strict_merge, canonical_platform=canonical_platform)
+    finally:
+        for _, zip_path in platform_zips:
+            try:
+                os.unlink(zip_path)
+            except Exception:
+                pass
+

--- a/scripts/sdk_merge.py
+++ b/scripts/sdk_merge.py
@@ -2,32 +2,12 @@ import os
 import shutil
 import tempfile
 import zipfile
-from dataclasses import dataclass
 from concurrent.futures import ThreadPoolExecutor
 
 import s3
 
 
 DOWNLOAD_WORKERS = 4
-
-
-@dataclass(frozen=True)
-class _SdkZipEntry(object):
-    platform: str
-    zip_path: str
-    filename: str
-    file_size: int
-    crc: int
-    external_attr: int
-    is_dir: bool
-
-
-def _platform_prefixes(platform):
-    return (
-        f"defoldsdk/lib/{platform}/",
-        f"defoldsdk/ext/lib/{platform}/",
-        f"defoldsdk/ext/bin/{platform}/",
-    )
 
 
 def _download_platform_sdk_zip(netloc, key, out_path):
@@ -63,90 +43,35 @@ def download_platform_sdk_zips(netloc, base_prefix, platforms):
     return [(platform, tmp_paths[platform]) for platform in platforms]
 
 
-def merge_platform_sdk_zips_into_tree(platform_zips, extract_dir, strict_merge=False, canonical_platform='x86_64-linux'):
+def merge_platform_sdk_zips_into_tree(platform_zips, extract_dir, canonical_platform='x86_64-linux'):
     """
     Merge multiple per-platform SDK zips into `extract_dir` by selecting a single source zip per output path.
-    - Includes unique paths from any zip.
-    - For platform-specific prefixes, always selects that platform's zip.
-    - For identical duplicates (same size+CRC), prefers `canonical_platform` for determinism.
-    - For non-identical duplicates, either errors (strict_merge=True) or warns and uses the
-      last platform in `platform_zips` order (historical overwrite semantics).
+    - Seeds the selection with `canonical_platform` first for determinism.
+    - Adds files from other platforms only if the path hasn't been selected yet.
     """
-    platform_rank = {p: i for i, (p, _) in enumerate(platform_zips)}
-    if not any(p == canonical_platform for p, _ in platform_zips):
-        canonical_platform = platform_zips[-1][0]
+    platform_to_zip = {p: z for p, z in platform_zips}
+    if canonical_platform not in platform_to_zip:
+        canonical_platform = platform_zips[0][0]
 
-    candidates_by_path = {}  # filename -> [_SdkZipEntry...]
-    for platform, zip_path in platform_zips:
+    ordered_platform_zips = [(canonical_platform, platform_to_zip[canonical_platform])]
+    ordered_platform_zips.extend([(p, z) for p, z in platform_zips if p != canonical_platform])
+
+    selected_by_path = {}  # filename -> (zip_path, platform)
+    for platform, zip_path in ordered_platform_zips:
         with zipfile.ZipFile(zip_path, 'r') as zf:
             for info in zf.infolist():
                 name = info.filename.replace('\\', '/')
                 if not name or name.startswith('/') or '..' in name.split('/'):
                     raise Exception(f"Invalid zip entry path in {platform}: {info.filename}")
+                if bool(getattr(info, 'is_dir', lambda: name.endswith('/'))()):
+                    continue
 
-                candidates_by_path.setdefault(name, []).append(_SdkZipEntry(
-                    platform=platform,
-                    zip_path=zip_path,
-                    filename=name,
-                    file_size=getattr(info, 'file_size', 0),
-                    crc=getattr(info, 'CRC', 0),
-                    external_attr=getattr(info, 'external_attr', 0),
-                    is_dir=bool(getattr(info, 'is_dir', lambda: name.endswith('/'))()),
-                ))
-
-    selected_by_path = {}  # filename -> _SdkZipEntry
-    conflicts = []         # (filename, [entries], chosen_entry)
-
-    for filename, entries in candidates_by_path.items():
-        file_entries = [e for e in entries if not e.is_dir]
-        if not file_entries:
-            continue
-
-        expected_platform = None
-        for p, _ in platform_zips:
-            if any(filename.startswith(pref) for pref in _platform_prefixes(p)):
-                expected_platform = p
-                break
-
-        chosen = None
-        if expected_platform is not None:
-            for e in file_entries:
-                if e.platform == expected_platform:
-                    chosen = e
-                    break
-            if chosen is None:
-                chosen = max(file_entries, key=lambda e: platform_rank.get(e.platform, -1))
-        else:
-            unique_payloads = {(e.file_size, e.crc) for e in file_entries}
-            if len(unique_payloads) == 1:
-                chosen = next((e for e in file_entries if e.platform == canonical_platform), None)
-                if chosen is None:
-                    chosen = max(file_entries, key=lambda e: platform_rank.get(e.platform, -1))
-            else:
-                chosen = max(file_entries, key=lambda e: platform_rank.get(e.platform, -1))
-                conflicts.append((filename, file_entries, chosen))
-
-        selected_by_path[filename] = chosen
-
-    if conflicts:
-        msg_lines = [
-            "Found conflicting SDK paths across platforms (same path, different payload):",
-        ]
-        for filename, entries, chosen in conflicts[:50]:
-            details = ", ".join([f"{e.platform}(size={e.file_size},crc={e.crc:08x})" for e in entries])
-            msg_lines.append(f"  - {filename}: {details} -> using {chosen.platform}")
-        if len(conflicts) > 50:
-            msg_lines.append(f"  ... and {len(conflicts) - 50} more")
-
-        full_msg = "\n".join(msg_lines)
-        if strict_merge:
-            raise Exception(full_msg + "\nSet DEFOLD_SDK_MERGE_STRICT=0 to preserve previous overwrite behaviour.")
-        else:
-            print("WARNING:", full_msg)
+                if name not in selected_by_path:
+                    selected_by_path[name] = (zip_path, platform)
 
     extract_map = {}  # zip_path -> [filename...]
-    for filename, entry in selected_by_path.items():
-        extract_map.setdefault(entry.zip_path, []).append(filename)
+    for filename, (zip_path, _) in selected_by_path.items():
+        extract_map.setdefault(zip_path, []).append(filename)
 
     for zip_path, filenames in extract_map.items():
         with zipfile.ZipFile(zip_path, 'r') as zf:
@@ -165,18 +90,17 @@ def merge_platform_sdk_zips_into_tree(platform_zips, extract_dir, strict_merge=F
     print("Merged platform SDKs into", extract_dir)
 
 
-def build_combined_sdk_tree(netloc, base_prefix, platforms, extract_dir, strict_merge=False, canonical_platform='x86_64-linux'):
+def build_combined_sdk_tree(netloc, base_prefix, platforms, extract_dir, canonical_platform='x86_64-linux'):
     """
     High-level helper used by scripts/build.py: downloads per-platform zips, merges them into a single tree,
     and cleans up the downloaded zip files.
     """
     platform_zips = download_platform_sdk_zips(netloc, base_prefix, platforms)
     try:
-        merge_platform_sdk_zips_into_tree(platform_zips, extract_dir, strict_merge=strict_merge, canonical_platform=canonical_platform)
+        merge_platform_sdk_zips_into_tree(platform_zips, extract_dir, canonical_platform=canonical_platform)
     finally:
         for _, zip_path in platform_zips:
             try:
                 os.unlink(zip_path)
             except Exception:
                 pass
-


### PR DESCRIPTION
 The previous implementation extracted every platform SDK zip into the same temp directory, repeatedly overwriting shared files (headers, protos, configs, etc.). This is I/O heavy and dominated by extraction time, making SDK builds slow. The new manifest-based merge extracts each unique file once and avoids redundant work.
  