### PR TITLE
Add a window title to splash, welcome, and project loading

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -1958,18 +1958,12 @@
            (g/operation-label (localization/message "operation.select"))
            (project/sub-select project-id active-resource-node sub-selection open-resource-nodes)))))))
 
-(defn- make-title
-  ([] (if-some [version (system/defold-version)]
-        (str "Defold " version)
-        "Defold"))
-  ([project-title] (str project-title " - " (make-title))))
-
 (defn- refresh-app-title! [^Stage stage project evaluation-context]
   (let [project-title (some-> (g/maybe-node-value project :settings evaluation-context)
                               (get ["project" "title"]))
         new-title (if project-title
-                    (make-title project-title)
-                    (make-title))]
+                    (ui/make-title project-title)
+                    (ui/make-title))]
     (when (not= (.getTitle stage) new-title)
       (.setTitle stage new-title))))
 
@@ -2074,7 +2068,7 @@
   (let [app-scene (.getScene stage)]
     (ui/disable-menu-alt-key-mnemonic! menu-bar)
     (.setUseSystemMenuBar menu-bar true)
-    (.setTitle stage (make-title))
+    (.setTitle stage (ui/make-title))
     (let [editor-tab-pane (TabPane.)
           keymap (keymap/from-prefs prefs)
           app-view (first (g/tx-nodes-added (g/transact (g/make-node view-graph AppView

--- a/editor/src/clj/editor/dialogs.clj
+++ b/editor/src/clj/editor/dialogs.clj
@@ -426,6 +426,7 @@
 (defn- load-project-dialog [{:keys [progress localization] :as props}]
   {:fx/type dialog-stage
    :showing (fxui/dialog-showing? props)
+   :title (ui/make-title)
    :on-close-request (fn [_] (Platform/exit))
    :header {:fx/type fx.h-box/lifecycle
             :style-class "spacing-default"

--- a/editor/src/clj/editor/ui.clj
+++ b/editor/src/clj/editor/ui.clj
@@ -27,6 +27,7 @@
             [editor.math :as math]
             [editor.os :as os]
             [editor.progress :as progress]
+            [editor.system :as system]
             [internal.util :as util]
             [service.log :as log]
             [service.smoke-log :as slog]
@@ -527,6 +528,12 @@
 
 (defn title! [^Stage window t]
   (.setTitle window t))
+
+(defn make-title
+  ([] (if-some [version (system/defold-version)]
+        (str "Defold " version)
+        "Defold"))
+  ([project-title] (str project-title " - " (make-title))))
 
 (defn tooltip! [^Control ctrl tip localization]
   (.setTooltip ctrl (when tip (localization/localize! (Tooltip.) localization tip))))

--- a/editor/src/clj/editor/welcome.clj
+++ b/editor/src/clj/editor/welcome.clj
@@ -644,7 +644,9 @@
          root (ui/load-fxml "welcome/welcome-dialog.fxml")
          min-width 792.0
          min-height 338.0
-         stage (doto (ui/make-dialog-stage) (.setResizable true))
+         stage (doto (ui/make-dialog-stage)
+                 (.setTitle (ui/make-title))
+                 (.setResizable true))
          ;; Adapted from https://stackoverflow.com/questions/57425534/how-to-limit-how-much-the-user-can-resize-a-javafx-window
          ;; because setting minWidth/minHeight on a resizable stage does not prevent resizing the stage to a smaller size
          _ (.addListener (.widthProperty stage)

--- a/editor/src/java/com/defold/editor/Splash.java
+++ b/editor/src/java/com/defold/editor/Splash.java
@@ -130,7 +130,11 @@ public class Splash {
         String channelName = System.getProperty("defold.channel");
         String sha1 = System.getProperty("defold.editor.sha1");
 
-        versionString = (versionString == null || versionString.isEmpty()) ? "No version" : versionString;
+        boolean hasVersion = true;
+        if (versionString == null || versionString.isEmpty()) {
+            versionString = "No version";
+            hasVersion = false;
+        }
         channelName = (channelName == null || channelName.isEmpty()) ? "No channel" : channelName;
         channelName = channelName.equals("editor-alpha") ? "" : "   •   " + channelName;
         sha1 = (sha1 == null || sha1.isEmpty()) ? "no sha1" : sha1;
@@ -143,7 +147,7 @@ public class Splash {
         channelLabel.setVisible(true);
 
         String windowTitle = "Defold";
-        if (!versionString.equals("No version")) {
+        if (hasVersion) {
             windowTitle += " " + versionString;
         }
         stage.setTitle(windowTitle);

--- a/editor/src/java/com/defold/editor/Splash.java
+++ b/editor/src/java/com/defold/editor/Splash.java
@@ -142,6 +142,11 @@ public class Splash {
         channelLabel.setText(versionString + " (" + sha1 + ")" + channelName);
         channelLabel.setVisible(true);
 
+        String windowTitle = "Defold";
+        if (!versionString.equals("No version")) {
+            windowTitle += " " + versionString;
+        }
+        stage.setTitle(windowTitle);
         stage.setOnShown(event -> shown.set(true));
         stage.show();
     }


### PR DESCRIPTION
Defold now has an OS window title while starting up, showing the welcome screen, and during the project loading window.

Fixes #11607

### Technical changes

While the user reported this as a problem on Linux, this should affect all operating systems.