### PR TITLE
Fix WebGPU crash when mipmaps are enabled

### DIFF
--- a/engine/graphics/src/webgpu/graphics_webgpu.cpp
+++ b/engine/graphics/src/webgpu/graphics_webgpu.cpp
@@ -503,6 +503,8 @@ static void WebGPUSetTextureInternal(WebGPUTexture* texture, const TextureParams
         {
             wgpuTextureRelease(texture->m_Texture);
             texture->m_Texture = NULL;
+            wgpuTextureViewRelease(texture->m_TextureView);
+            texture->m_TextureView = NULL;
         }
     }
     {


### PR DESCRIPTION
This fixes a crash when mipmaps are enabled when using WebGPU on Chrome.

Fixes #11567
