### PR TITLE
Use injected evaluation context in editor handlers

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -2374,45 +2374,45 @@
   (run [selection app-view prefs localization workspace project user-data]
        (let [resource (context-openable-resource app-view selection)]
          (open-resource app-view prefs localization workspace project resource user-data)))
-  (options [app-view prefs workspace selection user-data]
-           (when-not user-data
-             (let [[resource active-view-type-id]
-                   (g/with-auto-evaluation-context evaluation-context
-                     (if-let [selected-resource (selection->single-resource selection)]
-                       (pair selected-resource nil)
-                       (let [active-resource (g/node-value app-view :active-resource evaluation-context)
-                             active-view-type-id (:id (:view-type (g/node-value app-view :active-view-info evaluation-context)))]
-                         (pair active-resource active-view-type-id))))
+  (options [app-view prefs workspace selection user-data evaluation-context]
+    (when-not user-data
+      (let [[resource active-view-type-id]
+            (if-let [selected-resource (selection->single-resource selection)]
+              (pair selected-resource nil)
+              (let [active-resource (g/node-value app-view :active-resource evaluation-context)
+                    active-view-type-id (:id (:view-type (g/node-value app-view :active-view-info evaluation-context)))]
+                (pair active-resource active-view-type-id)))]
+        (when (and (resource/openable-resource? resource)
+                   (resource/exists? resource))
+          (let [is-custom-code-editor-configured (some? (custom-code-editor-executable-path-preference prefs))
 
-                   is-custom-code-editor-configured (some? (custom-code-editor-executable-path-preference prefs))
+                make-option
+                (fn make-option [label user-data]
+                  {:label label
+                   :command :file.open-as
+                   :user-data user-data})
 
-                   make-option
-                   (fn make-option [label user-data]
-                     {:label label
-                      :command :file.open-as
-                      :user-data user-data})
+                view-type->option
+                (fn view-type->option [{:keys [label] :as view-type}]
+                  (make-option (or label (localization/message "command.file.open-as.option.associated-application"))
+                               {:selected-view-type view-type}))]
 
-                   view-type->option
-                   (fn view-type->option [{:keys [label] :as view-type}]
-                     (make-option (or label (localization/message "command.file.open-as.option.associated-application"))
-                                  {:selected-view-type view-type}))]
+            (into []
+                  (if is-custom-code-editor-configured
+                    (mapcat (fn [{:keys [id label] :as view-type}]
+                              (case id
+                                (:code :text)
+                                [(make-option (localization/message "command.file.open-as.option.in-custom-editor" {"view" label})
+                                              {:selected-view-type view-type})
+                                 (make-option (localization/message "command.file.open-as.option.in-defold-editor" {"view" label})
+                                              {:selected-view-type view-type
+                                               :use-custom-editor false})]
+                                [(view-type->option view-type)])))
+                    (map view-type->option))
+                  (cond->> (view-types resource)
 
-               (into []
-                     (if is-custom-code-editor-configured
-                       (mapcat (fn [{:keys [id label] :as view-type}]
-                                 (case id
-                                   (:code :text)
-                                   [(make-option (localization/message "command.file.open-as.option.in-custom-editor" {"view" label})
-                                                 {:selected-view-type view-type})
-                                    (make-option (localization/message "command.file.open-as.option.in-defold-editor" {"view" label})
-                                                 {:selected-view-type view-type
-                                                  :use-custom-editor false})]
-                                   [(view-type->option view-type)])))
-                       (map view-type->option))
-                     (cond->> (view-types resource)
-
-                              active-view-type-id
-                              (e/filter #(not= active-view-type-id (:id %)))))))))
+                           active-view-type-id
+                           (e/filter #(not= active-view-type-id (:id %)))))))))))
 
 (handler/defhandler :private/recent-files :global
   (enabled? [prefs workspace evaluation-context]

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -2418,26 +2418,25 @@
   (enabled? [prefs workspace evaluation-context]
     (recent-files/exist? prefs workspace evaluation-context))
   (active? [] true)
-  (options [prefs workspace app-view]
-    (g/with-auto-evaluation-context evaluation-context
-      (-> [{:label (localization/message "command.file.reopen-recent")
-            :command :file.reopen-recent}]
-          (cond-> (recent-files/exist? prefs workspace evaluation-context)
-                  (->
-                    (conj menu-items/separator)
-                    (into
-                      (map (fn [[resource view-type :as resource+view-type]]
-                             {:label (-> "command.private.recent-files.option.entry"
-                                         (localization/message
-                                           {"path" (resource/proj-path resource)
-                                            "view" (:label view-type)})
-                                         (localization/transform string/replace "_" "__"))
-                              :command :private/open-selected-recent-file
-                              :user-data resource+view-type}))
-                      (recent-files/some-recent prefs workspace evaluation-context))
-                    (conj menu-items/separator)))
-          (conj {:label (localization/message "command.private.recent-files.option.more")
-                 :command :file.open-recent})))))
+  (options [prefs workspace app-view evaluation-context]
+    (-> [{:label (localization/message "command.file.reopen-recent")
+          :command :file.reopen-recent}]
+        (cond-> (recent-files/exist? prefs workspace evaluation-context)
+                (->
+                  (conj menu-items/separator)
+                  (into
+                    (map (fn [[resource view-type :as resource+view-type]]
+                           {:label (-> "command.private.recent-files.option.entry"
+                                       (localization/message
+                                         {"path" (resource/proj-path resource)
+                                          "view" (:label view-type)})
+                                       (localization/transform string/replace "_" "__"))
+                            :command :private/open-selected-recent-file
+                            :user-data resource+view-type}))
+                    (recent-files/some-recent prefs workspace evaluation-context))
+                  (conj menu-items/separator)))
+        (conj {:label (localization/message "command.private.recent-files.option.more")
+               :command :file.open-recent}))))
 
 (handler/defhandler :private/open-selected-recent-file :global
   (run [prefs localization app-view workspace project user-data]
@@ -2698,16 +2697,15 @@
         (if-let [node-id (handler/selection->node-id selection)]
           (not (coll/empty? (g/overridden-properties node-id evaluation-context)))
           false)))
-  (options [selection user-data]
+  (options [selection user-data evaluation-context]
     (when (nil? user-data)
       (when-let [node-id (handler/selection->node-id selection)]
-        (g/with-auto-evaluation-context evaluation-context
-          (when-let [source-prop-infos-by-prop-kw (properties/transferred-properties node-id :all evaluation-context)]
-            (mapv (fn [transfer-overrides-plan]
-                    {:label (properties/transfer-overrides-description transfer-overrides-plan evaluation-context)
-                     :command :edit.pull-up-overrides
-                     :user-data {:transfer-overrides-plan transfer-overrides-plan}})
-                  (properties/pull-up-overrides-plan-alternatives node-id source-prop-infos-by-prop-kw evaluation-context)))))))
+        (when-let [source-prop-infos-by-prop-kw (properties/transferred-properties node-id :all evaluation-context)]
+          (mapv (fn [transfer-overrides-plan]
+                  {:label (properties/transfer-overrides-description transfer-overrides-plan evaluation-context)
+                   :command :edit.pull-up-overrides
+                   :user-data {:transfer-overrides-plan transfer-overrides-plan}})
+                (properties/pull-up-overrides-plan-alternatives node-id source-prop-infos-by-prop-kw evaluation-context))))))
   (run [user-data]
     (properties/transfer-overrides! (:transfer-overrides-plan user-data))))
 
@@ -2720,16 +2718,15 @@
           (and (not (coll/empty? (g/overrides basis node-id)))
                (not (coll/empty? (g/overridden-properties node-id evaluation-context)))))
         false)))
-  (options [selection user-data]
+  (options [selection user-data evaluation-context]
     (when (nil? user-data)
       (when-let [node-id (handler/selection->node-id selection)]
-        (g/with-auto-evaluation-context evaluation-context
-          (when-let [source-prop-infos-by-prop-kw (properties/transferred-properties node-id :all evaluation-context)]
-            (mapv (fn [transfer-overrides-plan]
-                    {:label (properties/transfer-overrides-description transfer-overrides-plan evaluation-context)
-                     :command :edit.push-down-overrides
-                     :user-data {:transfer-overrides-plan transfer-overrides-plan}})
-                  (properties/push-down-overrides-plan-alternatives node-id source-prop-infos-by-prop-kw evaluation-context)))))))
+        (when-let [source-prop-infos-by-prop-kw (properties/transferred-properties node-id :all evaluation-context)]
+          (mapv (fn [transfer-overrides-plan]
+                  {:label (properties/transfer-overrides-description transfer-overrides-plan evaluation-context)
+                   :command :edit.push-down-overrides
+                   :user-data {:transfer-overrides-plan transfer-overrides-plan}})
+                (properties/push-down-overrides-plan-alternatives node-id source-prop-infos-by-prop-kw evaluation-context))))))
   (run [user-data]
     (properties/transfer-overrides! (:transfer-overrides-plan user-data))))
 

--- a/editor/src/clj/editor/asset_browser.clj
+++ b/editor/src/clj/editor/asset_browser.clj
@@ -547,7 +547,7 @@
             (when (resource/loaded? resource)
               (app-view/open-resource app-view prefs localization workspace project resource))
             (select-resource! asset-browser resource))))))
-  (options [workspace selection user-data]
+  (options [workspace selection user-data evaluation-context]
     (when (not user-data)
       (localization/annotate-as-sorted
         localization/natural-sort-by-label
@@ -556,13 +556,13 @@
                 :command :file.new
                 :user-data {:any-file true}}]
               (keep (fn [[_ext resource-type]]
-                      (when (workspace/has-template? workspace resource-type)
+                      (when (workspace/has-template? workspace resource-type evaluation-context)
                         {:label (or (:label resource-type) (:ext resource-type))
                          :icon (:icon resource-type)
                          :style (resource/type-style-classes resource-type)
                          :command :file.new
                          :user-data {:resource-type resource-type}})))
-              (workspace/get-resource-type-map workspace))))))
+              (resource/resource-types-by-type-ext (:basis evaluation-context) workspace :editable))))))
 
 (defn- resolve-sub-folder [^File base-folder ^String new-folder-name]
   (.toFile (.resolve (.toPath base-folder) new-folder-name)))

--- a/editor/src/clj/editor/game_object.clj
+++ b/editor/src/clj/editor/game_object.clj
@@ -579,9 +579,9 @@
              resource-type))
          (resource/resource-types-by-type-ext (:basis evaluation-context) workspace :editable))))
 
-(defn add-embedded-component-options [self workspace user-data]
+(defn- add-embedded-component-options [self workspace user-data evaluation-context]
   (when (not user-data)
-    (->> (embeddable-component-resource-types workspace)
+    (->> (embeddable-component-resource-types workspace evaluation-context)
          (mapv (fn [res-type]
                  {:label (or (:label res-type) (:ext res-type))
                   :icon (:icon res-type)
@@ -597,10 +597,10 @@
         (or (:label rt) (:ext rt)))))
   (active? [selection] (selection->game-object selection))
   (run [user-data app-view] (add-embedded-component-handler user-data (fn [node-ids] (app-view/select app-view node-ids))))
-  (options [selection user-data]
-           (let [self (selection->game-object selection)
-                 workspace (:workspace (g/node-value self :resource))]
-             (add-embedded-component-options self workspace user-data))))
+  (options [selection user-data evaluation-context]
+    (let [self (selection->game-object selection)
+          workspace (:workspace (g/node-value self :resource evaluation-context))]
+      (add-embedded-component-options self workspace user-data evaluation-context))))
 
 (defn load-game-object [project self resource prototype-desc]
   {:pre [(map? prototype-desc)]} ; GameObject$PrototypeDesc in map format.

--- a/editor/src/clj/editor/properties_view.clj
+++ b/editor/src/clj/editor/properties_view.clj
@@ -128,18 +128,17 @@
     (if user-data
       (properties/can-transfer-overrides? (:transfer-overrides-plan user-data))
       true))
-  (options [property selection user-data]
+  (options [property selection user-data evaluation-context]
     (when (nil? user-data)
       (when-let [node-id (handler/selection->node-id selection)]
-        (g/with-auto-evaluation-context evaluation-context
-          (let [prop-kws [(:key property)]
-                source-prop-infos-by-prop-kw (properties/transferred-properties node-id prop-kws evaluation-context)]
-            (when source-prop-infos-by-prop-kw
-              (mapv (fn [transfer-overrides-plan]
-                      {:label (properties/transfer-overrides-description transfer-overrides-plan evaluation-context)
-                       :command :edit.pull-up-overrides
-                       :user-data {:transfer-overrides-plan transfer-overrides-plan}})
-                    (properties/pull-up-overrides-plan-alternatives node-id source-prop-infos-by-prop-kw evaluation-context))))))))
+        (let [prop-kws [(:key property)]
+              source-prop-infos-by-prop-kw (properties/transferred-properties node-id prop-kws evaluation-context)]
+          (when source-prop-infos-by-prop-kw
+            (mapv (fn [transfer-overrides-plan]
+                    {:label (properties/transfer-overrides-description transfer-overrides-plan evaluation-context)
+                     :command :edit.pull-up-overrides
+                     :user-data {:transfer-overrides-plan transfer-overrides-plan}})
+                  (properties/pull-up-overrides-plan-alternatives node-id source-prop-infos-by-prop-kw evaluation-context)))))))
   (run [user-data]
     (properties/transfer-overrides! (:transfer-overrides-plan user-data))))
 
@@ -157,18 +156,17 @@
     (if user-data
       (properties/can-transfer-overrides? (:transfer-overrides-plan user-data))
       true))
-  (options [property selection user-data]
+  (options [property selection user-data evaluation-context]
     (when (nil? user-data)
       (when-let [node-id (handler/selection->node-id selection)]
-        (g/with-auto-evaluation-context evaluation-context
-          (let [prop-kws [(:key property)]
-                source-prop-infos-by-prop-kw (properties/transferred-properties node-id prop-kws evaluation-context)]
-            (when source-prop-infos-by-prop-kw
-              (mapv (fn [transfer-overrides-plan]
-                      {:label (properties/transfer-overrides-description transfer-overrides-plan evaluation-context)
-                       :command :edit.push-down-overrides
-                       :user-data {:transfer-overrides-plan transfer-overrides-plan}})
-                    (properties/push-down-overrides-plan-alternatives node-id source-prop-infos-by-prop-kw evaluation-context))))))))
+        (let [prop-kws [(:key property)]
+              source-prop-infos-by-prop-kw (properties/transferred-properties node-id prop-kws evaluation-context)]
+          (when source-prop-infos-by-prop-kw
+            (mapv (fn [transfer-overrides-plan]
+                    {:label (properties/transfer-overrides-description transfer-overrides-plan evaluation-context)
+                     :command :edit.push-down-overrides
+                     :user-data {:transfer-overrides-plan transfer-overrides-plan}})
+                  (properties/push-down-overrides-plan-alternatives node-id source-prop-infos-by-prop-kw evaluation-context)))))))
   (run [user-data]
     (properties/transfer-overrides! (:transfer-overrides-plan user-data))))
 

--- a/editor/src/clj/editor/scene.clj
+++ b/editor/src/clj/editor/scene.clj
@@ -1030,8 +1030,9 @@
    (g/with-auto-evaluation-context evaluation-context
      (active-scene-view app-view evaluation-context)))
   ([app-view evaluation-context]
-   (let [view (g/node-value app-view :active-view evaluation-context)]
-     (when (and view (g/node-instance? SceneView view))
+   (let [basis (:basis evaluation-context)
+         view (g/node-value app-view :active-view evaluation-context)]
+     (when (and view (g/node-instance? basis SceneView view))
        view))))
 
 (defn- play-handler [view-id]
@@ -1303,7 +1304,7 @@
         :command :scene.set-manipulator-space
         :user-data {:manip-space :local}}]))
   (run [app-view user-data] (set-manip-space! app-view (:manip-space user-data)))
-  (state [app-view user-data] (= (g/node-value app-view :manip-space) (:manip-space user-data))))
+  (state [app-view user-data evaluation-context] (= (g/node-value app-view :manip-space evaluation-context) (:manip-space user-data))))
 
 (handler/defhandler :scene.toggle-move-whole-pixels :global
   (active? [app-view evaluation-context] (active-scene-view app-view evaluation-context))

--- a/editor/src/clj/editor/scene_visibility.clj
+++ b/editor/src/clj/editor/scene_visibility.clj
@@ -401,8 +401,8 @@
                 (when-let [active-view (g/node-value app-view :active-view evaluation-context)]
                   (some? (g/maybe-node-value active-view :grid evaluation-context)))))
   (run [scene-visibility] (toggle-tag-visibility! scene-visibility :grid))
-  (state [scene-visibility]
-         (not (:grid (g/node-value scene-visibility :filtered-renderable-tags)))))
+  (state [scene-visibility evaluation-context]
+         (not (:grid (g/node-value scene-visibility :filtered-renderable-tags evaluation-context)))))
 
 (defn hidden-outline-key-path?
   [hidden-node-outline-key-paths node-outline-key-path]


### PR DESCRIPTION
Fix a few places where we were not using the `evaluation-context` that is automatically injected into handlers.