### PR TITLE
feat: Add editor preferences api endpoint

### DIFF
--- a/editor/src/clj/editor/boot_open_project.clj
+++ b/editor/src/clj/editor/boot_open_project.clj
@@ -43,6 +43,7 @@
             [editor.outline-view :as outline-view]
             [editor.pipeline.bob :as bob]
             [editor.prefs :as prefs]
+            [editor.prefs-api :as prefs-api]
             [editor.properties-view :as properties-view]
             [editor.resource :as resource]
             [editor.resource-types :as resource-types]
@@ -215,7 +216,8 @@
                                   (console/routes console-view)
                                   (hot-reload/routes workspace)
                                   (bob/routes project)
-                                  (command-requests/router root (app-view/make-render-task-progress :resource-sync))]))
+                                  (command-requests/router root (app-view/make-render-task-progress :resource-sync))
+                                  (prefs-api/router)]))
           server-port (:port cli-options)
           web-server (try
                        (http-server/start! server-handler :port server-port)

--- a/editor/src/clj/editor/prefs_api.clj
+++ b/editor/src/clj/editor/prefs_api.clj
@@ -1,0 +1,51 @@
+;; Copyright 2020-2025 The Defold Foundation
+;; Copyright 2014-2020 King
+;; Copyright 2009-2014 Ragnar Svensson, Christian Murray
+;; Licensed under the Defold License version 1.0 (the "License"); you may not use
+;; this file except in compliance with the License.
+;;
+;; You may obtain a copy of the License, together with FAQs at
+;; https://www.defold.com/license
+;;
+;; Unless required by applicable law or agreed to in writing, software distributed
+;; under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+;; CONDITIONS OF ANY KIND, either express or implied. See the License for the
+;; specific language governing permissions and limitations under the License.
+
+(ns editor.prefs-api
+  (:require [clojure.data.json :as json]
+            [clojure.java.io :as io]
+            [editor.prefs :as prefs]
+            [util.http-server :as http-server]))
+
+(defonce ^:const url-prefix "/prefs")
+(defonce ^:const allowed-keys [:code :tools])
+
+(set! *warn-on-reflection* true)
+
+(defn- json-response [status content]
+  (http-server/response
+   status
+   {"content-type" (http-server/ext->content-type "json")}
+   (json/write-str content)))
+
+(defn- read-json-body [request]
+  (json/read (io/reader (:body request)) :key-fn keyword))
+
+(defn handle-prefs [_]
+  (json-response 200 (select-keys (prefs/get (prefs/global) []) allowed-keys)))
+
+(defn handle-submit-prefs [request]
+  (try
+    (prefs/set! (prefs/global) [] (select-keys (read-json-body request) allowed-keys))
+    (prefs/sync!)
+    (json-response 200 {:status "OK"})
+
+    (catch Exception e
+      (json-response 500 {:error (.getMessage e)}))))
+
+(defn router []
+  {"/prefs" {"GET"  #'handle-prefs
+             "POST" #'handle-submit-prefs}})
+
+


### PR DESCRIPTION
This PR adds an API endpoint allowing external code editors to query and update (a subset of) the editor preferences. This specifically addresses [defold.nvim #34](https://github.com/atomicptr/defold.nvim/issues/34).

Why this is needed: Currently, in order to automatically set the external code editor I have to modify prefs.editor_settings directly, this requires me to ship an EDN parser and also a full editor restart for the changes to apply.

## Changes

- Added a GET /prefs endpoint to read current editor settings.
- Added a POST /prefs endpoint to update settings dynamically without a restart.

This allows me to significantly improve the plug and play experience in defold.nvim and would probably also benefit other external editors

## Alternatives

An alternative approach would be to add a new command request that allows me to get the editor to reload the written prefs.editor_settings alleviating the need to restart it