### PR TITLE
Fixed missing tracking when doing layout of glyphs

### DIFF
--- a/engine/font/src/test/test_font.cpp
+++ b/engine/font/src/test/test_font.cpp
@@ -382,6 +382,9 @@ TEST_F(FontTest, LayoutTrackingAndLeading)
     ASSERT_EQ(TEXT_RESULT_OK, r);
     ASSERT_NE((HTextLayout)0, layout);
     float width_no_tracking = layout->m_Width;
+#if !defined(FONT_USE_SKRIBIDI)
+    float first_advance = layout->m_Glyphs[0].m_Advance;
+#endif
     TextLayoutFree(layout);
 
     float tracking_value = 0.25f;
@@ -392,7 +395,8 @@ TEST_F(FontTest, LayoutTrackingAndLeading)
     float width_tracking = layout->m_Width;
     TextLayoutFree(layout);
 
-    // Legacy tracking scales by line height, Skribidi scales by font size.
+    // Legacy tracking scales by line height and is quantized to integer pixel steps.
+    // Skribidi scales by font size in pixels.
     float expected_tracking = 0.0f;
 #if defined(FONT_USE_SKRIBIDI)
     // Skribidi interprets tracking in pixels based on font size.
@@ -400,7 +404,10 @@ TEST_F(FontTest, LayoutTrackingAndLeading)
 #else
     // Legacy uses line height (font metrics scaled by size) for tracking.
     float scale = FontGetScaleFromSize(m_Font, settings.m_Size);
-    expected_tracking = tracking_value * line_height * scale;
+    float raw_tracking = tracking_value * line_height * scale;
+    uint32_t advance_px = (uint32_t)first_advance;
+    uint32_t advance_plus_tracking_px = (uint32_t)(first_advance + raw_tracking);
+    expected_tracking = (float)(advance_plus_tracking_px - advance_px);
 #endif
 
     const float epsilon = 0.05f;

--- a/engine/font/src/test/test_font.cpp
+++ b/engine/font/src/test/test_font.cpp
@@ -352,6 +352,92 @@ TEST_F(FontTest, LayoutExplicitDoubleLineBreaks)
     TextLayoutFree(layout);
 }
 
+TEST_F(FontTest, LayoutTrackingAndLeading)
+{
+    dmArray<uint32_t> codepoints;
+
+    HTextLayout layout = 0;
+
+    TextLayoutSettings settings = {0};
+    settings.m_LineBreak = false;
+    settings.m_Width = 0.0f;
+    settings.m_Size = 32.0f;
+    settings.m_Leading = 1.0f;
+    settings.m_Tracking = 0.0f;
+
+    // Capture the layout line height used by the engine for comparison.
+    const char* line_height_text = "A";
+    TextToCodePoints(line_height_text, codepoints);
+
+    TextResult r = TestLayout(m_FontCollection, codepoints, &settings, &layout);
+    ASSERT_EQ(TEXT_RESULT_OK, r);
+    ASSERT_NE((HTextLayout)0, layout);
+    float line_height = layout->m_Height;
+    TextLayoutFree(layout);
+
+    // Measure tracking impact as a width delta between two adjacent glyphs.
+    const char* tracking_text = "AA";
+    TextToCodePoints(tracking_text, codepoints);
+    r = TestLayout(m_FontCollection, codepoints, &settings, &layout);
+    ASSERT_EQ(TEXT_RESULT_OK, r);
+    ASSERT_NE((HTextLayout)0, layout);
+    float width_no_tracking = layout->m_Width;
+    TextLayoutFree(layout);
+
+    float tracking_value = 0.25f;
+    settings.m_Tracking = tracking_value;
+    r = TestLayout(m_FontCollection, codepoints, &settings, &layout);
+    ASSERT_EQ(TEXT_RESULT_OK, r);
+    ASSERT_NE((HTextLayout)0, layout);
+    float width_tracking = layout->m_Width;
+    TextLayoutFree(layout);
+
+    // Legacy tracking scales by line height, Skribidi scales by font size.
+    float expected_tracking = 0.0f;
+#if defined(FONT_USE_SKRIBIDI)
+    // Skribidi interprets tracking in pixels based on font size.
+    expected_tracking = tracking_value * settings.m_Size;
+#else
+    // Legacy uses line height (font metrics scaled by size) for tracking.
+    float scale = FontGetScaleFromSize(m_Font, settings.m_Size);
+    expected_tracking = tracking_value * line_height * scale;
+#endif
+
+    const float epsilon = 0.05f;
+    ASSERT_NEAR(expected_tracking, width_tracking - width_no_tracking, epsilon);
+
+    // Enable explicit line breaks and compare leading deltas across two lines.
+    // Skribidi layout height is normalized in text_layout_skribidi.cpp to match legacy.
+    const char* leading_text = "A\nA";
+    TextToCodePoints(leading_text, codepoints);
+
+    settings.m_LineBreak = true;
+    settings.m_Width = 1000.0f;
+    settings.m_Tracking = 0.0f;
+    settings.m_Leading = 1.0f;
+
+    r = TestLayout(m_FontCollection, codepoints, &settings, &layout);
+    ASSERT_EQ(TEXT_RESULT_OK, r);
+    ASSERT_NE((HTextLayout)0, layout);
+    uint32_t line_count = layout->m_Lines.Size();
+    ASSERT_EQ(2u, line_count);
+    float height_leading_1 = layout->m_Height;
+    TextLayoutFree(layout);
+
+    settings.m_Leading = 2.0f;
+    r = TestLayout(m_FontCollection, codepoints, &settings, &layout);
+    ASSERT_EQ(TEXT_RESULT_OK, r);
+    ASSERT_NE((HTextLayout)0, layout);
+    ASSERT_EQ(2u, layout->m_Lines.Size());
+    float height_leading_2 = layout->m_Height;
+    TextLayoutFree(layout);
+
+    // Leading should add one extra line height for the entire layout.
+    float expected_leading_delta = line_height;
+    float height_leading_delta = height_leading_2 - height_leading_1;
+    ASSERT_NEAR(expected_leading_delta, height_leading_delta, epsilon);
+}
+
 
 #if !defined(FONT_USE_SKRIBIDI) && defined(FOO)
 static void CreateTestGlyphs(TextShapeInfo* info, const char* text, int32_t x_step, dmArray<uint32_t>& codepoints)

--- a/engine/font/src/text_layout_legacy.cpp
+++ b/engine/font/src/text_layout_legacy.cpp
@@ -208,8 +208,9 @@ TextResult TextLayoutLegacyCreate(HFontCollection collection,
 
     uint32_t num_whitespaces = 0;
     // Lay them all out in a single line, using points
-    float x = 0;
-    float y = 0; // the legacy "shaping" doesn't support Y offsets
+// TODO: Make this optional, so that user can choose to use pixel alignment
+    uint32_t x = 0;
+    uint32_t y = 0; // the legacy "shaping" doesn't support Y offsets
     FontGlyph font_glyph;
     for (uint32_t i = 0; i < num_codepoints; ++i)
     {

--- a/engine/font/src/text_layout_legacy.cpp
+++ b/engine/font/src/text_layout_legacy.cpp
@@ -134,7 +134,7 @@ void Layout(TextLayout*     layout,
     *text_width = max_width;
 }
 
-static float GetLineTextMetrics(TextGlyph* glyphs, uint32_t row_start, uint32_t n, bool monospace, float padding, float tracking, bool measure_trailing_space)
+static float GetLineTextMetrics(TextGlyph* glyphs, uint32_t row_start, uint32_t n, bool monospace, float padding, bool measure_trailing_space)
 {
     if (n <= 0)
         return 0;
@@ -154,7 +154,7 @@ static float GetLineTextMetrics(TextGlyph* glyphs, uint32_t row_start, uint32_t 
 
     float row_start_x = glyphs[0].m_X;
     float extent_last = monospace ? (last.m_Advance + padding) : (last.m_Advance);
-    float width = last.m_X - row_start_x + (n-1) * tracking + extent_last;
+    float width = last.m_X - row_start_x + extent_last;
     return width;
 }
 
@@ -163,16 +163,14 @@ struct LayoutMetrics
     TextGlyph*  m_Glyphs;
     bool        m_Monospace;
     float       m_Padding;
-    float       m_Tracking;
-    LayoutMetrics(TextGlyph* glyphs, bool monospace, float padding, float tracking)
+    LayoutMetrics(TextGlyph* glyphs, bool monospace, float padding)
     : m_Glyphs(glyphs)
     , m_Monospace(monospace)
     , m_Padding(padding)
-    , m_Tracking(tracking)
     {}
     float operator()(uint32_t row_start, uint32_t n, bool measure_trailing_space)
     {
-        return GetLineTextMetrics(m_Glyphs, row_start, n, m_Monospace, m_Padding, m_Tracking, measure_trailing_space);
+        return GetLineTextMetrics(m_Glyphs, row_start, n, m_Monospace, m_Padding, measure_trailing_space);
     }
 };
 
@@ -198,14 +196,20 @@ TextResult TextLayoutLegacyCreate(HFontCollection collection,
     HFont font = FontCollectionGetFont(collection, 0);
     float scale = FontGetScaleFromSize(font, settings->m_Size);
 
+    uint32_t ascent = (uint32_t)FontGetAscent(font, 1.0f);
+    uint32_t descent = (uint32_t)FontGetDescent(font, 1.0f); // positive value
+    uint32_t line_height = ascent + descent;
+    float line_height_scaled = line_height * scale;
+    float tracking = line_height_scaled * settings->m_Tracking;
+
     FontGlyphOptions options;
     options.m_Scale = 1.0f; // Return in points
     options.m_GenerateImage = false;
 
     uint32_t num_whitespaces = 0;
     // Lay them all out in a single line, using points
-    uint32_t x = 0;
-    uint32_t y = 0; // the legacy "shaping" doesn't support Y offsets
+    float x = 0;
+    float y = 0; // the legacy "shaping" doesn't support Y offsets
     FontGlyph font_glyph;
     for (uint32_t i = 0; i < num_codepoints; ++i)
     {
@@ -238,7 +242,7 @@ TextResult TextLayoutLegacyCreate(HFontCollection collection,
             g.m_Advance = font_glyph.m_Advance * scale;
             g.m_LeftBearing = font_glyph.m_LeftBearing * scale;
 
-            x += g.m_Advance;
+            x += g.m_Advance + tracking;
         }
 
         layout->m_Glyphs[i] = g;
@@ -246,17 +250,13 @@ TextResult TextLayoutLegacyCreate(HFontCollection collection,
 
     layout->m_NumValidGlyphs = layout->m_Glyphs.Size() - num_whitespaces;
 
-    LayoutMetrics lm(layout->m_Glyphs.Begin(), settings->m_Monospace, settings->m_Padding, settings->m_Tracking);
+    LayoutMetrics lm(layout->m_Glyphs.Begin(), settings->m_Monospace, settings->m_Padding);
     float max_line_width;
 
     float width = settings->m_Width;
     if (!settings->m_LineBreak)
         width = 1000000.0f;
     Layout(layout, width, &max_line_width, lm, !settings->m_LineBreak);
-
-    uint32_t ascent = (uint32_t)FontGetAscent(font, 1.0f);
-    uint32_t descent = (uint32_t)FontGetDescent(font, 1.0f); // positive value
-    uint32_t line_height = ascent + descent;
 
     // metrics->m_MaxAscent = ascent;
     // metrics->m_MaxDescent = descent;


### PR DESCRIPTION
Fixes https://github.com/defold/defold/issues/11673

### Technical changes

Fixes a regression where the tracking was removed or not scaled properly.
Added test that checks for added dimensions of a layout when using tracking or leading.

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
