### PR TITLE
Make sure physics fixed update is called after script fixed update

### DIFF
--- a/engine/gameobject/src/gameobject/gameobject.cpp
+++ b/engine/gameobject/src/gameobject/gameobject.cpp
@@ -2762,25 +2762,23 @@ namespace dmGameObject
 
         uint32_t component_type_count = collection->m_Register->m_ComponentTypeCount;
 
-        // 1. call script fixed update function first
+        // 1. for each fixed step, run a user fixed_update, followed by a physics engine tick (and message dispatch)
         for (uint32_t step = 0; step < num_fixed_steps; ++step)
         {
+            // call script fixed_update
             ret = ret && UpdateComponentFunction(collection, component_type_count, UPDATE_FUNCTION_TYPE_PRE_FIXED_UPDATE, fixed_update_params);
+
+            // call physics simulation
+            ret = ret && UpdateComponentFunction(collection, component_type_count, UPDATE_FUNCTION_TYPE_FIXED_UPDATE, fixed_update_params);
         }
 
         // 2. call script and animation update
         ret = ret && UpdateComponentFunction(collection, component_type_count, UPDATE_FUNCTION_TYPE_PRE_UPDATE, update_params);
 
-        // 3. call physics simulation
-        for (uint32_t step = 0; step < num_fixed_steps; ++step)
-        {
-            ret = ret && UpdateComponentFunction(collection, component_type_count, UPDATE_FUNCTION_TYPE_FIXED_UPDATE, fixed_update_params);
-        }
-
-        // 4. call component's regular update
+        // 3. call component's regular update
         ret = ret && UpdateComponentFunction(collection, component_type_count, UPDATE_FUNCTION_TYPE_UPDATE, update_params);
 
-        // 5. call component's late update
+        // 4. call component's late update
         ret = ret && UpdateComponentFunction(collection, component_type_count, UPDATE_FUNCTION_TYPE_LATE_UPDATE, update_params);
 
         collection->m_InUpdate = 0;


### PR DESCRIPTION
This makes sure that the physics fixed update happens after each script fixed_update, but before the regular update loop.

Fixes https://github.com/defold/defold/issues/11667

### Technical documentation

(old draft PR notes)
This is a sketch PR to provide a concrete implementation of an update loop with stable, deterministic physics regardless of update frequency, for discussion.

The current and planned implementation is update-frequency-dependent, such that "fixed_update" is a misnomer. Without pairing a `fixed_update` with a physics engine tick, it's not possible to create stable simulations, because the simulation state becomes dependent on the dynamic update speed. For example:

---

Let’s say our `fixed_update` applies gravity to a kinematic sphere that is sliding down a 45-degree hill. Here’s a frame where N=2 (N being the number of fixed updates per frame):

1. `fixed_update` sees sphere at position 00, moves down to 01
2. `fixed_update sees sphere at position 01, moves down to 03 (gravity compounds velocity)
3. physics engine Fixed Update
4. `on_message` “contact_point_response” moves the sphere right from 03 to 33, projects velocity along the tangent
5. physics engine Fixed Update
6. collision already resolved, no movement, stays at 33
7. (new iteration of the update loop)
8. `fixed_update` sees the sphere at position 33

Now the exact same code across frames where N=1:

1. `fixed_update` sees sphere at position 00, moves to 01
2. physics engine Fixed Update
3. `on_message` “contact_point_response” moves the sphere from 01 to 11, projects velocity along the tangent
4. (new iteration of the update loop)
5. `fixed_update` sees sphere at position 11, moves to 12
6. physics engine Fixed Update
7. `on_message` “contact_point_response” moves the sphere from 12 to 22
8. (new iteration of the update loop)
9. `fixed_update` sees sphere at 22

Despite running the same code from the same starting situation, our first three `fixed_update` callbacks see different states:

- N=2: 00, 01, 33
- N=1: 00, 11, 22

--- 

I apologize for pushing on this issue so much here, and on the forums. If it were work-around-able in user space, I wouldn't worry about it so much. But I believe that the 1.12 approach to a "fixed" update loop in Defold makes it impossible to build framerate-independent physics objects in the engine. I could be wrong about that, or I could be misunderstanding something else. I wanted to share this concrete example in order to communicate the issue more clearly.

If it would be helpful, I could also put together an example physics-based Defold project that would run reliably and deterministically with this PR's update flow, but that would be unstable and non-deterministic when running in the 1.12 beta. (assuming this would even compile... the source code is remarkably readable btw, nice job on that, but I'm unfamiliar with the codebase so I could have missed major things)