### PR TITLE
Add `zlib` module to editor scripts

### DIFF
--- a/editor/src/clj/editor/editor_extensions.clj
+++ b/editor/src/clj/editor/editor_extensions.clj
@@ -36,6 +36,7 @@
             [editor.editor-extensions.tile-map :as tile-map]
             [editor.editor-extensions.ui-components :as ui-components]
             [editor.editor-extensions.zip :as zip]
+            [editor.editor-extensions.zlib :as zlib]
             [editor.error-reporting :as error-reporting]
             [editor.fs :as fs]
             [editor.future :as future]
@@ -969,7 +970,8 @@
                            "tmpname" nil}
                      "pprint" ext-pprint
                      "tilemap" tile-map/env
-                     "zip" (zip/env project-path reload-resources!)})
+                     "zip" (zip/env project-path reload-resources!)
+                     "zlib" zlib/env})
           _ (rt/invoke-immediate rt (rt/bind rt @prelude-prototype) evaluation-context)
           new-state (re-create-ext-state
                       (assoc opts

--- a/editor/src/clj/editor/editor_extensions/docs.clj
+++ b/editor/src/clj/editor/editor_extensions/docs.clj
@@ -981,4 +981,17 @@ zip.unpack(
           :description "`\"skip\"`, existing file is preserved"}
          {:name "zip.ON_CONFLICT.OVERWRITE"
           :type :constant
-          :description "`\"skip\"`, existing file is overwritten"}]))))
+          :description "`\"skip\"`, existing file is overwritten"}
+         {:name "zlib"
+          :type :module
+          :description "Module for compressing and decompressing string buffers"}
+         {:name "zlib.deflate"
+          :type :function
+          :parameters [{:name "buf" :types ["string"] :doc "buffer to deflate"}]
+          :returnvalues [{:name "buf" :types ["string"] :doc "deflated buffer"}]
+          :description "Deflate (compress) a buffer"}
+         {:name "zlib.inflate"
+          :type :function
+          :parameters [{:name "buf" :types ["string"] :doc "buffer to inflate"}]
+          :returnvalues [{:name "buf" :types ["string"] :doc "inflated buffer"}]
+          :description "Inflate (decompress) a buffer"}]))))

--- a/editor/src/clj/editor/editor_extensions/zlib.clj
+++ b/editor/src/clj/editor/editor_extensions/zlib.clj
@@ -1,0 +1,71 @@
+;; Copyright 2020-2025 The Defold Foundation
+;; Copyright 2014-2020 King
+;; Copyright 2009-2014 Ragnar Svensson, Christian Murray
+;; Licensed under the Defold License version 1.0 (the "License"); you may not use
+;; this file except in compliance with the License.
+;;
+;; You may obtain a copy of the License, together with FAQs at
+;; https://www.defold.com/license
+;;
+;; Unless required by applicable law or agreed to in writing, software distributed
+;; under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+;; CONDITIONS OF ANY KIND, either express or implied. See the License for the
+;; specific language governing permissions and limitations under the License.
+
+(ns editor.editor-extensions.zlib
+  (:require [clojure.java.io :as io])
+  (:import [com.defold.editor.luart DefoldOneArgLuaFn]
+           [java.io ByteArrayInputStream ByteArrayOutputStream]
+           [java.util.zip Deflater DeflaterOutputStream GZIPInputStream Inflater InflaterInputStream]
+           [org.luaj.vm2 LuaError LuaString LuaValue]))
+
+(set! *warn-on-reflection* true)
+(set! *unchecked-math* :warn-on-boxed)
+
+(defn- gzip? [^LuaString lua-string]
+  (and (<= 2 (.-m_length lua-string))
+       (= 0x1f (bit-and 0xff (aget (.-m_bytes lua-string) (.-m_offset lua-string))))
+       (= 0x8b (bit-and 0xff (aget (.-m_bytes lua-string) (unchecked-inc-int (.-m_offset lua-string)))))))
+
+(defn- inflate-gzip [^LuaString lua-string]
+  (with-open [in (GZIPInputStream. (ByteArrayInputStream. (.-m_bytes lua-string) (.-m_offset lua-string) (.-m_length lua-string)))
+              out (ByteArrayOutputStream.)]
+    (io/copy in out)
+    (.toByteArray out)))
+
+(defn- inflate-zlib [^LuaString lua-string]
+  (with-open [in (InflaterInputStream.
+                   (ByteArrayInputStream. (.-m_bytes lua-string) (.-m_offset lua-string) (.-m_length lua-string))
+                   (Inflater.))
+              out (ByteArrayOutputStream.)]
+    (io/copy in out)
+    (.toByteArray out)))
+
+(defn- ext-inflate [^LuaValue lua-buf]
+  (let [lua-string (.checkstring lua-buf)
+        bytes (try
+                (if (gzip? lua-string)
+                  (inflate-gzip lua-string)
+                  (inflate-zlib lua-string))
+                (catch Throwable e
+                  (throw (LuaError. (format "Failed to inflate buffer (%s)" (.getMessage e))))))]
+    (LuaString/valueOf ^byte/1 bytes)))
+
+(defn- deflate-bytes
+  [^LuaString lua-string]
+  (with-open [out (ByteArrayOutputStream.)
+              stream (DeflaterOutputStream. out (Deflater. #_level 3))]
+    (.write stream (.-m_bytes lua-string) (.-m_offset lua-string) (.-m_length lua-string))
+    (.finish stream)
+    (.toByteArray out)))
+
+(defn- ext-deflate [^LuaValue lua-buf]
+  (let [lua-string (.checkstring lua-buf)]
+    (try
+      (LuaString/valueOf ^byte/1 (deflate-bytes lua-string))
+      (catch Throwable e
+        (throw (LuaError. (format "Failed to deflate buffer (%s)" (.getMessage e))))))))
+
+(def env
+  {"inflate" (DefoldOneArgLuaFn. ext-inflate)
+   "deflate" (DefoldOneArgLuaFn. ext-deflate)})

--- a/editor/test/integration/editor_extensions_test.clj
+++ b/editor/test/integration/editor_extensions_test.clj
@@ -1144,6 +1144,25 @@ build/nested/game.project exists: true
               (Files/getPosixFilePermissions (fs/path root "build" "script.sh") fs/empty-link-option-array)
               PosixFilePermission/OWNER_EXECUTE))))))
 
+(def expected-zlib-test-output
+  "inflate zlib: hello
+inflate gzip: hello
+deflate hello: \\120\\94\\203\\72\\205\\201\\201\\7\\0\\6\\44\\2\\21
+same as expected zlib buf: true
+roundtrip: true
+zlib.inflate(false) => bad argument: string expected, got boolean
+zlib.deflate(false) => bad argument: string expected, got boolean
+zlib.inflate('') => Failed to inflate buffer (Unexpected end of ZLIB input stream)
+zlib.inflate('not-a-buf') => Failed to inflate buffer (incorrect header check)
+")
+
+(deftest zlib-test
+  (test-util/with-scratch-project "test/resources/editor_extensions/zlib_project"
+    (let [out (StringBuilder.)]
+      (reload-editor-scripts! project :display-output! #(doto out (.append %2) (.append \newline)))
+      (run-edit-menu-test-command!)
+      (expect-script-output expected-zlib-test-output out))))
+
 (def expected-http-server-test-output
   "Omitting conflicting routes for 'GET /test/conflict/same-path-and-method' defined in /test.editor_script
 Omitting conflicting routes for '/command/{param}' defined in /test.editor_script (conflict with the editor's built-in routes)

--- a/editor/test/resources/editor_extensions/zlib_project/.gitignore
+++ b/editor/test/resources/editor_extensions/zlib_project/.gitignore
@@ -1,0 +1,11 @@
+/.editor_settings
+/.internal
+/build
+.externalToolBuilders
+.DS_Store
+Thumbs.db
+.lock-wscript
+*.pyc
+.project
+.cproject
+builtins

--- a/editor/test/resources/editor_extensions/zlib_project/game.project
+++ b/editor/test/resources/editor_extensions/zlib_project/game.project
@@ -1,0 +1,24 @@
+[bootstrap]
+main_collection = /main/main.collectionc
+
+[script]
+shared_state = 1
+
+[display]
+width = 960
+height = 640
+high_dpi = 1
+
+[android]
+input_method = HiddenInputField
+
+[physics]
+gravity_y = -1000.0
+scale = 0.01
+
+[html5]
+scale_mode = stretch
+
+[project]
+title = zlib_project
+

--- a/editor/test/resources/editor_extensions/zlib_project/test.editor_script
+++ b/editor/test/resources/editor_extensions/zlib_project/test.editor_script
@@ -1,0 +1,38 @@
+local M = {}
+
+local function test(message, f, ...) 
+    local success, ret = pcall(f, ...)
+    if success then
+        print(("%s => unexpected success!"):format(message))
+    else
+        print(("%s => %s"):format(message, ret))
+    end
+end
+
+function M.get_commands()
+    return {editor.command({
+        label = "Test",
+        locations = {"Edit"},
+        id = "defold.test",
+        run = function()
+            local zlib_buf = "\120\94\203\72\205\201\201\7\0\6\44\2\21"
+            local gzip_buf = "\31\139\8\0\0\0\0\0\2\255\203\72\205\201\201\7\0\134\166\16\54\5\0\0\0"
+            print(("inflate zlib: %s"):format(zlib.inflate(zlib_buf)))
+            print(("inflate gzip: %s"):format(zlib.inflate(gzip_buf)))
+            local compressed_data = zlib.deflate("hello")
+            local s = ""
+            for c in string.gmatch(compressed_data, ".") do
+                s = s .. '\\' .. string.byte(c)
+            end
+            print(("deflate hello: %s"):format(s))
+            print(("same as expected zlib buf: %s"):format(tostring(compressed_data == zlib_buf)))
+            print(("roundtrip: %s"):format(tostring(zlib.inflate(zlib.deflate("foo")) == "foo")))
+            test("zlib.inflate(false)", zlib.inflate, false)
+            test("zlib.deflate(false)", zlib.deflate, false)
+            test("zlib.inflate('')", zlib.inflate, '')
+            test("zlib.inflate('not-a-buf')", zlib.inflate, 'not-a-buf')
+        end
+    })}
+end
+
+return M


### PR DESCRIPTION
Now, the editor scripts' Lua runtime has `zlib` module — with the same semantics as the engine's `zlib` module.

Fixes #11676