### PR TITLE
Resolve lein init SHA argument as git-ref

### DIFF
--- a/editor/tasks/leiningen/init.clj
+++ b/editor/tasks/leiningen/init.clj
@@ -55,7 +55,7 @@
       "dynamo-home"     nil ; for symmetry
       "archived-stable" (sha-from-version-file)
       "archived"        (sha-from-ref "HEAD")
-      version)))
+      (sha-from-ref version))))
 
 (defn- resolve-archive-domain
   [user_domain]


### PR DESCRIPTION
You can now use a shortened commit SHA, as well as local tags and branch names for the SHA argument to `lein init`.