### PR TITLE
`bob.jar` now scans for `ext.properties` in all folders, not just extension folders

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/BobProjectPropertiesTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/BobProjectPropertiesTest.java
@@ -94,7 +94,7 @@ public class BobProjectPropertiesTest {
     public void testExtensionMetaProperties() throws IOException, ConfigurationException, CompileExceptionError, MultipleCompileException, ParseException {
         createFile(contentRoot, "game.project", "[project]\ntitle = random\ncustom_property = just content");
         createFile(contentRoot, "extension1/ext.manifest", "name: Extension1\n");
-        createFile(contentRoot, "extension1/"+BobProjectProperties.PROPERTIES_EXTENSION_FILE, "[project]\ncustom_property.private = 1");
+        createFile(contentRoot, "extension1/"+BobProjectProperties.PROPERTIES_FILE, "[project]\ncustom_property.private = 1");
 
         Project project = new Project(new DefaultFileSystem(), contentRoot, "build");
         project.loadProjectFile(true);
@@ -107,7 +107,7 @@ public class BobProjectPropertiesTest {
     public void testOverrideExtensionMetaProperties() throws IOException, ConfigurationException, CompileExceptionError, MultipleCompileException, ParseException {
         createFile(contentRoot, "game.project", "[project]\ntitle = random\ncustom_property = just content");
         createFile(contentRoot, "extension1/ext.manifest", "name: Extension1\n");
-        createFile(contentRoot, "extension1/"+BobProjectProperties.PROPERTIES_EXTENSION_FILE, "[project]\ncustom_property.private = 1");
+        createFile(contentRoot, "extension1/"+BobProjectProperties.PROPERTIES_FILE, "[project]\ncustom_property.private = 1");
         createFile(contentRoot, BobProjectProperties.PROPERTIES_PROJECT_FILE, "[project]\ncustom_property.private = 0");
 
         Project project = new Project(new DefaultFileSystem(), contentRoot, "build");

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
@@ -628,7 +628,7 @@ public class Project {
 
     // Loads the properties from a game project settings file
     // Also adds any properties specified with the "--settings" flag
-    public static BobProjectProperties loadProperties(Project project, IResource projectFile, List<String> settingsFiles, boolean scanExtensions) throws IOException {
+    public static BobProjectProperties loadProperties(Project project, IResource projectFile, List<String> settingsFiles, boolean scanProjectPropertyFiles) throws IOException {
         if (!projectFile.exists()) {
             throw new IOException(String.format("Project file not found: %s", projectFile.getAbsPath()));
         }
@@ -638,12 +638,15 @@ public class Project {
             // load meta.properties embeded in bob.jar
             properties.loadDefaultMetaFile();
             properties.cleanupEmptyProperties();
-            if (scanExtensions) {
-                // load property files from extensions
-                List<String> extensionFolders = ExtenderUtil.getExtensionFolders(project);
-                if (!extensionFolders.isEmpty()) {
-                    for (String extension : extensionFolders) {
-                        IResource resource = project.getResource(extension + "/" + BobProjectProperties.PROPERTIES_EXTENSION_FILE);
+            if (scanProjectPropertyFiles) {
+                // load property files from the project (including extensions)
+                List<String> resourcePaths = new ArrayList<>();
+                project.findResourcePaths("", resourcePaths);
+                String propertiesSuffix = "/" + BobProjectProperties.PROPERTIES_FILE;
+                for (String resourcePath : resourcePaths) {
+                    if (resourcePath.equals(BobProjectProperties.PROPERTIES_FILE) ||
+                            resourcePath.endsWith(propertiesSuffix)) {
+                        IResource resource = project.getResource(resourcePath);
                         if (resource.exists()) {
                             // resources from extensions in ZIP files can't be read as files, but getContent() works fine
                             loadPropertiesData(properties, resource.getContent(), true, resource.getPath());
@@ -669,10 +672,10 @@ public class Project {
         return properties;
     }
 
-    public void loadProjectFile(boolean scanExtensions) throws IOException {
+    public void loadProjectFile(boolean scanProjectPropertyFiles) throws IOException {
         IResource gameProject = getGameProjectResource();
         if (gameProject.exists()) {
-            projectProperties = Project.loadProperties(this, gameProject, this.getPropertyFiles(), scanExtensions);
+            projectProperties = Project.loadProperties(this, gameProject, this.getPropertyFiles(), scanProjectPropertyFiles);
         }
     }
 

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/BobProjectProperties.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/BobProjectProperties.java
@@ -45,7 +45,7 @@ import com.dynamo.bob.Bob;
 public class BobProjectProperties {
 
     public final static String PROPERTIES_PROJECT_FILE = "game.properties";
-    public final static String PROPERTIES_EXTENSION_FILE = "ext.properties";
+    public final static String PROPERTIES_FILE = "ext.properties";
     public final static String PROPERTIES_INTERNAL_FILE = "meta.properties";
 
     public enum PropertyType {


### PR DESCRIPTION
Fix an inconsistency where the Editor scans `ext.properties` in all folders, while `bob.jar` only scans extension folders.

Fix https://github.com/defold/defold/issues/11689