### PR TITLE
Added check if font glyph bitmap will fit into the font glyph texture before uploading

### DIFF
--- a/engine/render/src/render/font/fontmap.cpp
+++ b/engine/render/src/render/font/fontmap.cpp
@@ -738,7 +738,36 @@ namespace dmRender
         // Locate a cache cell candidate
         CacheGlyph* cache_glyph = AcquireFreeGlyphFromCache(font_map);
 
-        if (cache_glyph->m_Glyph && cache_glyph->m_Frame == frame)
+        if (cache_glyph->m_Glyph)
+        {
+            if (cache_glyph->m_Frame == frame)
+            {
+                bool can_resize = CanCacheTextureGrow(font_map);
+                if (can_resize)
+                {
+                    font_map->m_IsCacheSizeDirty = 1;
+                    font_map->m_IsCacheSizeTooSmall = 1;
+                    return;
+                }
+
+                // It means we've filled the entire cache with upload requests
+                // We might then just as well skip the next uploads until the next frame
+                dmLogWarning("Entire font glyph cache (%u x %u) is filled in a single frame %u ('%c' %u / %u). Consider increasing the cache for %s", font_map->m_CacheWidth, font_map->m_CacheHeight, frame, glyph->m_Codepoint < 255 ? glyph->m_Codepoint : ' ', glyph->m_Codepoint, glyph->m_GlyphIndex  , dmHashReverseSafe64(font_map->m_NameHash));
+                return;
+            }
+        }
+
+        if (cache_glyph->m_Glyph) // It already existed in the cache
+        {
+            // Clear the old data from the cache
+            font_map->m_GlyphCache.Erase(cache_glyph->m_GlyphKey);
+        }
+
+        // If the blit would write outside of the texture, then we try to resize it
+        uint32_t glyph_image_width  = glyph->m_Bitmap.m_Width;
+        uint32_t glyph_image_height = glyph->m_Bitmap.m_Height;
+        if ( (cache_glyph->m_X + glyph_image_width) > font_map->m_CacheWidth ||
+             (cache_glyph->m_Y + glyph_image_height + g_offset_y) > font_map->m_CacheHeight)
         {
             bool can_resize = CanCacheTextureGrow(font_map);
             if (can_resize)
@@ -750,21 +779,15 @@ namespace dmRender
 
             // It means we've filled the entire cache with upload requests
             // We might then just as well skip the next uploads until the next frame
-            dmLogWarning("Entire font glyph cache (%u x %u) is filled in a single frame %u ('%c' %u / %u). Consider increasing the cache for %s", font_map->m_CacheWidth, font_map->m_CacheHeight, frame, glyph->m_Codepoint < 255 ? glyph->m_Codepoint : ' ', glyph->m_Codepoint, glyph->m_GlyphIndex  , dmHashReverseSafe64(font_map->m_NameHash));
+            dmLogWarning("The font glyph cache (%u x %u) needed resizing to fit glyph bitmap.", font_map->m_CacheWidth, font_map->m_CacheHeight);
             return;
         }
 
-        if (cache_glyph->m_Glyph) // It already existed in the cache
-        {
-            // Clear the old data from the cache
-            font_map->m_GlyphCache.Erase(cache_glyph->m_GlyphKey);
-        }
         cache_glyph->m_Glyph = glyph;
         cache_glyph->m_GlyphKey = glyph_key;
         cache_glyph->m_Frame = frame;
 
         font_map->m_GlyphCache.Put(glyph_key, cache_glyph);
-
 
         UpdateGlyphTexture(font_map, glyph, cache_glyph->m_X, cache_glyph->m_Y, g_offset_y);
     }


### PR DESCRIPTION
This fixes an issue where blitting an image outside of the texture size is throwing errors on OpenGL backend.

Fixes https://github.com/defold/defold/issues/11683

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
