### PR TITLE
Fix memory leak / fragmentation in PreStepEmscripten

### DIFF
--- a/engine/engine/src/engine_loop.cpp
+++ b/engine/engine/src/engine_loop.cpp
@@ -136,11 +136,9 @@ namespace dmEngine
         const RunLoopParams* params = ctx->m_Params;
         HEngine engine = (HEngine)ctx->m_Engine;
 
-        int argc = params->m_Argc;
-        char** argv = params->m_Argv;
         int exit_code = 0;
         int result = 0;
-        params->m_EngineGetResult(engine, &result, &exit_code, &argc, &argv);
+        params->m_EngineGetResult(engine, &result, &exit_code, NULL, NULL);
 
         if (RESULT_OK != result)
         {
@@ -153,7 +151,18 @@ namespace dmEngine
 
             if (RESULT_REBOOT == result)
             {
+                // Only request argc/argv when actually rebooting
+                int argc = 0;
+                char** argv = NULL;
+                params->m_EngineGetResult(engine, NULL, NULL, &argc, &argv);
+
                 ctx->m_Engine = params->m_EngineCreate(argc, argv);
+
+                // Free argv allocated within dmEngineGetResult
+                for (int i = 0; i < argc; ++i)
+                    free(argv[i]);
+                free(argv);
+
                 if (ctx->m_Engine)
                 {
                     // Won't return from this


### PR DESCRIPTION
Fixed a memory leak on every frame with Emscripten builds, resulting in significant heap fragmentation and usage.

### Technical changes

The PreStepEmscripten function was requesting argc/argv from dmEngineGetResult on every frame, though these values are only used when handling a reboot. When argc > 0, this caused unnecessary malloc + strdup allocations that were never freed.

The other various call sites have it freed correctly, so this just impacted web builds.

Tested by monitoring the state of the Emscripten heap, observed that this fix prevents the leaky allocation.
