### PR TITLE
Added support for WebP and AVIF image formats for the HTML5 splash screen

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
@@ -890,7 +890,7 @@ cssfile.label = Custom .css
 splash_image.type = resource
 splash_image.help = custom html splash screen image
 splash_image.preserve-extension = 1
-splash_image.filter = gif,jpg,png,svg
+splash_image.filter = gif,jpg,png,svg,webp,avif
 
 archive_location_prefix.type = string
 archive_location_prefix.help = string to prefix bundled archive file path with (can be a full URL)


### PR DESCRIPTION
It is now possible to select WebP and AVIF image files for the HTML5 Splash Image game.project field.

Fixes #11717
