### PR TITLE
Add support for ASAN and UBSAN for wasm builds

### DIFF
--- a/engine/dlib/src/test/wscript
+++ b/engine/dlib/src/test/wscript
@@ -133,7 +133,7 @@ def build(bld):
     skip_threads = False
     if bld.env.PLATFORM in ('js-web', 'wasm-web', 'wasm_pthread-web'):
         skip_http = True
-        if bld.env in ('js-web', 'wasm-web'):
+        if bld.env.PLATFORM in ('js-web', 'wasm-web'):
             skip_threads = True
 
     if _is_mac_ci():

--- a/engine/dlib/src/test/wscript
+++ b/engine/dlib/src/test/wscript
@@ -55,7 +55,8 @@ def create_test(bld, name, extra_libs = None, extra_features = None, embed_sourc
 
     local_libs = 'dlib mbedtls zip'.split()
 
-    if bld.env.PLATFORM in ('js-web', 'wasm-web', 'wasm_pthread-web', 'arm64-nx64', 'x86_64-ps4', 'x86_64-ps5'):
+    use_profile_null = bld.env.PLATFORM in ('js-web', 'wasm-web', 'wasm_pthread-web', 'arm64-nx64', 'x86_64-ps4', 'x86_64-ps5')
+    if use_profile_null:
         local_libs += ['profile_null']
     else:
         local_libs += ['profile']
@@ -117,6 +118,8 @@ def build(bld):
     if bld.env.PLATFORM in ('arm64-ios', 'x86_64-ios'):
         extra_defines = ['DM_NO_SYSTEM_FUNCTION'] # Needed because we wish to build the tests for all platforms, but not all platforms have the system() function
 
+    use_profile_null = bld.env.PLATFORM in ('js-web', 'wasm-web', 'wasm_pthread-web', 'arm64-nx64', 'x86_64-ps4', 'x86_64-ps5')
+
     skip_run = False
     if 'web' in bld.env['PLATFORM']:
         skip_run = True # Emscripten/Nodejs doesn't support popen()
@@ -159,7 +162,7 @@ def build(bld):
         create_test(bld, 'test_thread', extra_libs = ['THREAD'])
         create_test(bld, 'test_mutex', extra_libs =['THREAD'])
 
-    create_test(bld, 'test_profile', extra_libs = ['THREAD'], extra_source = ['test_profiler_dummy.cpp'])
+    create_test(bld, 'test_profile', extra_libs = ['THREAD'], extra_source = ['test_profiler_dummy.cpp'], skip_run = use_profile_null)
     create_test(bld, 'test_profile',
                                         extra_libs = ['THREAD'],
                                         extra_local_libs = ['profile_null'],
@@ -199,7 +202,7 @@ def build(bld):
         create_test(bld, 'test_condition_variable', extra_libs = ['THREAD'])
         create_test(bld, 'test_job_thread')
 
-    create_test(bld, 'test_sys', extra_libs = ['THREAD'], extra_defines = extra_defines)
+    create_test(bld, 'test_sys', extra_libs = ['THREAD'], extra_defines = extra_defines, skip_run = skip_run)
     create_test(bld, 'test_template', extra_libs = ['THREAD'])
     create_test(bld, 'test_ssdp_internals', extra_libs = ['THREAD'], skip_run = skip_run or skip_ssdp)
     create_test(bld, 'test_ssdp', extra_libs = ['THREAD'], skip_run = skip_run or skip_ssdp)

--- a/engine/resource/src/test/test_resource_archive.cpp
+++ b/engine/resource/src/test/test_resource_archive.cpp
@@ -464,7 +464,7 @@ This test is failing intermittenly on Linux. Typical output from a failed test:
 #if !defined(__linux__)
 TEST(dmResourceArchive, ManifestSignatureVerification)
 {
-    dmResource::HManifest manifest = new dmResource::Manifest();
+    dmResource::HManifest manifest = 0;
     ASSERT_EQ(dmResource::RESULT_OK, dmResource::LoadManifestFromBuffer(RESOURCES_DMANIFEST, RESOURCES_DMANIFEST_SIZE, &manifest));
 
     uint32_t expected_digest_len = dmResource::HashLength(manifest->m_DDFData->m_Header.m_SignatureHashAlgorithm);
@@ -527,7 +527,7 @@ This test is failing intermittenly on Linux. Typical output from a failed test:
 #if !defined(__linux__)
 TEST(dmResourceArchive, ManifestSignatureVerificationLengthFail)
 {
-    dmResource::HManifest manifest = new dmResource::Manifest();
+    dmResource::HManifest manifest = 0;
     ASSERT_EQ(dmResource::RESULT_OK, dmResource::LoadManifestFromBuffer(RESOURCES_DMANIFEST, RESOURCES_DMANIFEST_SIZE, &manifest));
 
     uint32_t expected_digest_len = dmResource::HashLength(manifest->m_DDFData->m_Header.m_SignatureHashAlgorithm);
@@ -540,9 +540,7 @@ TEST(dmResourceArchive, ManifestSignatureVerificationLengthFail)
     ASSERT_EQ(dmResource::RESULT_FORMAT_ERROR, dmResource::MemCompare(hex_digest, hex_digest_len, expected_digest, expected_digest_len));
 
     free(hex_digest);
-    dmDDF::FreeMessage(manifest->m_DDFData);
-    dmDDF::FreeMessage(manifest->m_DDF);
-    delete manifest;
+    dmResource::DeleteManifest(manifest);
 }
 #endif
 
@@ -556,7 +554,7 @@ This test is failing intermittenly on Linux. Typical output from a failed test:
 #if !defined(__linux__)
 TEST(dmResourceArchive, ManifestSignatureVerificationHashFail)
 {
-    dmResource::HManifest manifest = new dmResource::Manifest();
+    dmResource::HManifest manifest = 0;
     ASSERT_EQ(dmResource::RESULT_OK, dmResource::LoadManifestFromBuffer(RESOURCES_DMANIFEST, RESOURCES_DMANIFEST_SIZE, &manifest));
 
     uint32_t expected_digest_len = dmResource::HashLength(manifest->m_DDFData->m_Header.m_SignatureHashAlgorithm);
@@ -569,9 +567,7 @@ TEST(dmResourceArchive, ManifestSignatureVerificationHashFail)
     ASSERT_EQ(dmResource::RESULT_SIGNATURE_MISMATCH, dmResource::MemCompare(hex_digest, hex_digest_len, expected_digest, expected_digest_len));
 
     free(hex_digest);
-    dmDDF::FreeMessage(manifest->m_DDFData);
-    dmDDF::FreeMessage(manifest->m_DDF);
-    delete manifest;
+    dmResource::DeleteManifest(manifest);
 }
 #endif
 

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -1731,8 +1731,9 @@ class Configuration(object):
         host = self.host
 
         # Make sure we build these for the host platform for the toolchain (bob light)
+        host_lib_skip_tests = host != self.target_platform
         for lib in HOST_LIBS:
-            self._build_engine_lib(args, lib, host)
+            self._build_engine_lib(args, lib, host, skip_tests = host_lib_skip_tests)
         if not self.skip_bob_light:
             # We must build bob-light, which builds content during the engine build
             self.build_bob_light()

--- a/scripts/cmake/functions_test.cmake
+++ b/scripts/cmake/functions_test.cmake
@@ -8,6 +8,47 @@ defold_log("functions_test.cmake:")
 #               adds it to global run_tests
 #   - run_workdir: optional working directory for executing the test
 
+function(_defold_find_nodejs out_var)
+  set(_nodejs "")
+  if(DEFINED DEFOLD_SDK_ROOT)
+    file(GLOB _nodes "${DEFOLD_SDK_ROOT}/ext/SDKs/emsdk*/node/*/bin/node")
+    list(SORT _nodes)
+    list(LENGTH _nodes _len)
+    if(_len GREATER 0)
+      math(EXPR _idx "${_len} - 1")
+      list(GET _nodes ${_idx} _nodejs)
+    endif()
+  endif()
+
+  if(DEFINED ENV{EMSDK})
+    file(GLOB _nodes "$ENV{EMSDK}/node/*/bin/node")
+    list(SORT _nodes)
+    list(LENGTH _nodes _len)
+    if(_len GREATER 0)
+      math(EXPR _idx "${_len} - 1")
+      list(GET _nodes ${_idx} _nodejs)
+    endif()
+  endif()
+
+  if(NOT _nodejs AND DEFINED EMSCRIPTEN)
+    get_filename_component(_emsdk_root "${EMSCRIPTEN}" DIRECTORY)
+    get_filename_component(_emsdk_root "${_emsdk_root}" DIRECTORY)
+    file(GLOB _nodes "${_emsdk_root}/node/*/bin/node")
+    list(SORT _nodes)
+    list(LENGTH _nodes _len)
+    if(_len GREATER 0)
+      math(EXPR _idx "${_len} - 1")
+      list(GET _nodes ${_idx} _nodejs)
+    endif()
+  endif()
+
+  if(NOT _nodejs)
+    find_program(_nodejs node)
+  endif()
+
+  set(${out_var} "${_nodejs}" PARENT_SCOPE)
+endfunction()
+
 function(defold_register_test_target target_name)
   if(NOT TARGET ${target_name})
     message(FATAL_ERROR "defold_register_test_target: target '${target_name}' does not exist")
@@ -49,15 +90,33 @@ function(defold_register_test_target target_name)
   if(_RUN_TEST)
     set(_run_target "run_${target_name}")
     if(NOT TARGET ${_run_target})
+      if(TARGET_PLATFORM MATCHES "js-web|wasm-web|wasm_pthread-web")
+        set(_pre_js "${DEFOLD_SDK_ROOT}/share/js-web-pre.js")
+        if(EXISTS "${_pre_js}")
+          target_link_options(${target_name} PRIVATE "--pre-js" "${_pre_js}" "-lnodefs.js")
+        else()
+          message(FATAL_ERROR "defold_register_test_target: missing pre-js file '${_pre_js}' for web test '${target_name}'")
+        endif()
+      endif()
+      set(_run_exe "$<TARGET_FILE:${target_name}>")
+      set(_run_args "")
+      if(TARGET_PLATFORM MATCHES "js-web|wasm-web|wasm_pthread-web")
+        _defold_find_nodejs(_nodejs)
+        if(NOT _nodejs)
+          message(FATAL_ERROR "defold_register_test_target: node not found for web test '${target_name}'")
+        endif()
+        set(_run_exe "${_nodejs}")
+        set(_run_args "$<TARGET_FILE:${target_name}>")
+      endif()
       if(_RUN_DIR_NORM)
         add_custom_target(${_run_target}
-          COMMAND ${CMAKE_COMMAND} -E chdir "${_RUN_DIR_NORM}" $<TARGET_FILE:${target_name}>
+          COMMAND ${CMAKE_COMMAND} -E chdir "${_RUN_DIR_NORM}" ${_run_exe} ${_run_args}
           DEPENDS ${target_name}
           USES_TERMINAL
           COMMENT "Running ${target_name} in ${_RUN_DIR_NORM}")
       else()
         add_custom_target(${_run_target}
-          COMMAND $<TARGET_FILE:${target_name}>
+          COMMAND ${_run_exe} ${_run_args}
           DEPENDS ${target_name}
           USES_TERMINAL
           COMMENT "Running ${target_name}")


### PR DESCRIPTION
This PR adds support for compiler flags needed for ASAN and UBSAN and makes it possible to run tests for modules built with `cmake`.
Also, a small fix to skip tests for host platforms libs e.g. to be able to build wasm we build `dlib`, and before this fix this dlib build run tests as well as target platform tests later.

But tests will need to be fixed before running them by default or in nightly builds. For now there are many fails.