### PR TITLE
Report old and new shader combinations

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/ShaderCompilePipelineTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/ShaderCompilePipelineTest.java
@@ -159,7 +159,7 @@ public class ShaderCompilePipelineTest {
                 in mediump vec2 texcoord0;
                 out mediump vec2 var_texcoord0;
                 uniform vs_uniforms { highp mat4 view_proj; };
-                uniform shared_uniforms { vec4 tint; };  
+                uniform shared_uniforms { vec4 tint; };
                 uniform sampler2D shared_texture;
                 void main()
                 {
@@ -251,7 +251,7 @@ public class ShaderCompilePipelineTest {
                 """
                 #version 430
                 out vec4 out_fragColor;
-               
+
                 struct nested
                 {
                     float nested;
@@ -336,14 +336,14 @@ public class ShaderCompilePipelineTest {
                 in vec4 color;
                 out vec2 var_texcoord0;
                 out vec4 var_color;
-                out vec3 var_position;          
+                out vec3 var_position;
                 void main()
                 {
                     var_position = position;
                     var_texcoord0 = texcoord0;
                     var_color = vec4(color.rgb * color.a, color.a);
                     gl_Position = vec4(position.xyz, 1.0);
-                }                    
+                }
                 """;
 
         String fsShader =

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderProgramBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderProgramBuilder.java
@@ -493,6 +493,18 @@ public class ShaderProgramBuilder extends Builder {
         if (newShaders.size() > 0 && oldShaders.size() > 0) {
             System.out.println("Warning: Mixing old shaders with new shaders is slow. Consider migrating old shaders to using the new shader pipeline.");
 
+            System.out.print("  Old shaders:");
+            for (ShaderCompilePipeline.ShaderModuleDesc old : oldShaders) {
+                System.out.print(" " + old.resourcePath);
+            }
+            System.out.println();
+
+            System.out.print("  New shaders:");
+            for (ShaderCompilePipeline.ShaderModuleDesc shader : newShaders) {
+                System.out.print(" " + shader.resourcePath);
+            }
+            System.out.println();
+
             ArrayList<ShaderCompilePipeline.ShaderModuleDesc> newDescs = new ArrayList<>(newShaders);
             for (ShaderCompilePipeline.ShaderModuleDesc old : oldShaders) {
                 ShaderUtil.ES2ToES3Converter.Result transformResult = ShaderUtil.ES2ToES3Converter.transform(old.source, old.type, "", 140, true, options.splitTextureSamplers);


### PR DESCRIPTION
When mixing old and new shader pipelines, we currently show a warning but don't tell the users which shaders is causing it. Instead, we now show which shader resources that are causing this to happen.

Fixes #11739 