### PR TITLE
Fix text layout regression

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/FontBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/FontBuilder.java
@@ -129,8 +129,6 @@ public class FontBuilder extends ProtoBuilder<FontDesc.Builder> {
             fontMapBuilder.setSdfShadow(Fontc.GetFontMapSdfShadow(fontDesc));
         }
 
-        fontMapBuilder.setPadding(Fontc.GetFontMapPadding(fontDesc));
-
         fontMapBuilder.setOutputFormat(fontDesc.getOutputFormat());
         fontMapBuilder.setRenderMode(fontDesc.getRenderMode());
 

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/FontBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/FontBuilder.java
@@ -129,6 +129,8 @@ public class FontBuilder extends ProtoBuilder<FontDesc.Builder> {
             fontMapBuilder.setSdfShadow(Fontc.GetFontMapSdfShadow(fontDesc));
         }
 
+        fontMapBuilder.setPadding(Fontc.GetFontMapPadding(fontDesc));
+
         fontMapBuilder.setOutputFormat(fontDesc.getOutputFormat());
         fontMapBuilder.setRenderMode(fontDesc.getRenderMode());
 

--- a/engine/font/src/text_layout_legacy.cpp
+++ b/engine/font/src/text_layout_legacy.cpp
@@ -153,7 +153,13 @@ static float GetLineTextMetrics(TextGlyph* glyphs, uint32_t row_start, uint32_t 
     TextGlyph& last = glyphs[n-1];
 
     float row_start_x = glyphs[0].m_X;
-    float extent_last = monospace ? (last.m_Advance + padding) : (last.m_Advance);
+
+    // the width of the last glyph should consider only the width of the bounding
+    // box of the glyph, UNLESS the last glyph is a whitespace in which case the
+    // width is the full advance of the whitespace
+    float last_width = (last.m_Codepoint == dmUtf8::UTF_WHITESPACE_SPACE) ? last.m_Advance : last.m_Width;
+    float extent_last = monospace ? (last_width + padding) : last_width;
+
     float width = last.m_X - row_start_x + extent_last;
     return width;
 }

--- a/engine/font/src/text_layout_legacy.cpp
+++ b/engine/font/src/text_layout_legacy.cpp
@@ -158,7 +158,7 @@ static float GetLineTextMetrics(TextGlyph* glyphs, uint32_t row_start, uint32_t 
     // box of the glyph, UNLESS the last glyph is a whitespace in which case the
     // width is the full advance of the whitespace
     float last_width = (last.m_Codepoint == dmUtf8::UTF_WHITESPACE_SPACE) ? last.m_Advance : last.m_Width;
-    float extent_last = monospace ? (last_width + padding) : last_width;
+    float extent_last = last.m_LeftBearing + last_width + (monospace ? padding : 0);
 
     float width = last.m_X - row_start_x + extent_last;
     return width;

--- a/engine/font/src/text_layout_legacy.cpp
+++ b/engine/font/src/text_layout_legacy.cpp
@@ -175,7 +175,7 @@ static float GetLineTextMetrics(TextGlyph* glyphs, uint32_t row_start, uint32_t 
             last = g;
             break;
         }
-        trailing_space_width = trailing_space_width + g.m_Advance;
+        trailing_space_width += g.m_Advance;
     }
     float extent_last = last.m_LeftBearing + last.m_Width;
     float width = last.m_X - row_start_x + extent_last + trailing_space_width;

--- a/engine/font/src/text_layout_legacy.cpp
+++ b/engine/font/src/text_layout_legacy.cpp
@@ -150,6 +150,9 @@ static float GetLineTextMetrics(TextGlyph* glyphs, uint32_t row_start, uint32_t 
         }
     }
 
+    // note: tracking is ignored since it's already added in TextLayoutLegacyCreate
+    // note: padding is only intended for monospaced fonts, see comment in fontmap.h
+
     TextGlyph last = glyphs[n-1];
 
     float row_start_x = glyphs[0].m_X;
@@ -157,7 +160,7 @@ static float GetLineTextMetrics(TextGlyph* glyphs, uint32_t row_start, uint32_t 
     if (monospace)
     {
         float extent_last = last.m_Advance + padding;
-        float width = last.m_X - row_start_x + (n-1) * tracking + extent_last;
+        float width = last.m_X - row_start_x + extent_last;
         return width;
     }
 
@@ -175,7 +178,7 @@ static float GetLineTextMetrics(TextGlyph* glyphs, uint32_t row_start, uint32_t 
         trailing_space_width = trailing_space_width + g.m_Advance;
     }
     float extent_last = last.m_Width;
-    float width = last.m_X - row_start_x + (n-1) * tracking + extent_last + trailing_space_width;
+    float width = last.m_X - row_start_x + extent_last + trailing_space_width;
     return width;
 }
 

--- a/engine/font/src/text_layout_legacy.cpp
+++ b/engine/font/src/text_layout_legacy.cpp
@@ -150,7 +150,7 @@ static float GetLineTextMetrics(TextGlyph* glyphs, uint32_t row_start, uint32_t 
         }
     }
 
-    TextGlyph& last = glyphs[n-1];
+    TextGlyph last = glyphs[n-1];
 
     float row_start_x = glyphs[0].m_X;
 
@@ -166,7 +166,7 @@ static float GetLineTextMetrics(TextGlyph* glyphs, uint32_t row_start, uint32_t 
     float trailing_space_width = 0;
     for (int i = n - 1; i >= 0; i--)
     {
-        TextGlyph& g = glyphs[i];
+        TextGlyph g = glyphs[i];
         if (g.m_Codepoint != dmUtf8::UTF_WHITESPACE_SPACE)
         {
             last = g;

--- a/engine/font/src/text_layout_legacy.cpp
+++ b/engine/font/src/text_layout_legacy.cpp
@@ -177,7 +177,7 @@ static float GetLineTextMetrics(TextGlyph* glyphs, uint32_t row_start, uint32_t 
         }
         trailing_space_width = trailing_space_width + g.m_Advance;
     }
-    float extent_last = last.m_Width;
+    float extent_last = last.m_LeftBearing + last.m_Width;
     float width = last.m_X - row_start_x + extent_last + trailing_space_width;
     return width;
 }

--- a/engine/font/src/text_layout_legacy.cpp
+++ b/engine/font/src/text_layout_legacy.cpp
@@ -134,7 +134,7 @@ void Layout(TextLayout*     layout,
     *text_width = max_width;
 }
 
-static float GetLineTextMetrics(TextGlyph* glyphs, uint32_t row_start, uint32_t n, bool monospace, float padding, bool measure_trailing_space)
+static float GetLineTextMetrics(TextGlyph* glyphs, uint32_t row_start, uint32_t n, bool monospace, float padding, float tracking, bool measure_trailing_space)
 {
     if (n <= 0)
         return 0;
@@ -154,13 +154,28 @@ static float GetLineTextMetrics(TextGlyph* glyphs, uint32_t row_start, uint32_t 
 
     float row_start_x = glyphs[0].m_X;
 
-    // the width of the last glyph should consider only the width of the bounding
-    // box of the glyph, UNLESS the last glyph is a whitespace in which case the
-    // width is the full advance of the whitespace
-    float last_width = (last.m_Codepoint == dmUtf8::UTF_WHITESPACE_SPACE) ? last.m_Advance : last.m_Width;
-    float extent_last = last.m_LeftBearing + last_width + (monospace ? padding : 0);
+    if (monospace)
+    {
+        float extent_last = last.m_Advance + padding;
+        float width = last.m_X - row_start_x + (n-1) * tracking + extent_last;
+        return width;
+    }
 
-    float width = last.m_X - row_start_x + extent_last;
+    // find the last non-whitespace character while also measuring the width
+    // of any trailing whitespace characters
+    float trailing_space_width = 0;
+    for (int i = n - 1; i >= 0; i--)
+    {
+        TextGlyph& g = glyphs[i];
+        if (g.m_Codepoint != dmUtf8::UTF_WHITESPACE_SPACE)
+        {
+            last = g;
+            break;
+        }
+        trailing_space_width = trailing_space_width + g.m_Advance;
+    }
+    float extent_last = last.m_Width;
+    float width = last.m_X - row_start_x + (n-1) * tracking + extent_last + trailing_space_width;
     return width;
 }
 
@@ -169,14 +184,16 @@ struct LayoutMetrics
     TextGlyph*  m_Glyphs;
     bool        m_Monospace;
     float       m_Padding;
-    LayoutMetrics(TextGlyph* glyphs, bool monospace, float padding)
+    float       m_Tracking;
+    LayoutMetrics(TextGlyph* glyphs, bool monospace, float padding, float tracking)
     : m_Glyphs(glyphs)
     , m_Monospace(monospace)
     , m_Padding(padding)
+    , m_Tracking(tracking)
     {}
     float operator()(uint32_t row_start, uint32_t n, bool measure_trailing_space)
     {
-        return GetLineTextMetrics(m_Glyphs, row_start, n, m_Monospace, m_Padding, measure_trailing_space);
+        return GetLineTextMetrics(m_Glyphs, row_start, n, m_Monospace, m_Padding, m_Tracking, measure_trailing_space);
     }
 };
 
@@ -257,7 +274,7 @@ TextResult TextLayoutLegacyCreate(HFontCollection collection,
 
     layout->m_NumValidGlyphs = layout->m_Glyphs.Size() - num_whitespaces;
 
-    LayoutMetrics lm(layout->m_Glyphs.Begin(), settings->m_Monospace, settings->m_Padding);
+    LayoutMetrics lm(layout->m_Glyphs.Begin(), settings->m_Monospace, settings->m_Padding, settings->m_Tracking);
     float max_line_width;
 
     float width = settings->m_Width;

--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -2909,6 +2909,9 @@ namespace dmGameSystem
         settings.m_LineBreak = line_break;
         settings.m_Leading = leading;
         settings.m_Tracking = tracking;
+        // legacy options for glyph bank fonts
+        settings.m_Monospace = dmRender::GetFontMapMonospaced(font);
+        settings.m_Padding = dmRender::GetFontMapPadding(font);
 
         dmRender::TextMetrics metrics;
         dmRender::GetTextMetrics(font, text, &settings, &metrics);

--- a/engine/gamesys/src/gamesys/components/comp_label.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_label.cpp
@@ -583,6 +583,9 @@ namespace dmGameSystem
         settings.m_LineBreak = component->m_LineBreak;
         settings.m_Leading = component->m_Leading;
         settings.m_Tracking = component->m_Tracking;
+        // legacy options for glyph bank fonts
+        settings.m_Monospace = dmRender::GetFontMapMonospaced(font_map);
+        settings.m_Padding = dmRender::GetFontMapPadding(font_map);
 
         dmRender::GetTextMetrics(font_map, component->m_Text, &settings, &metrics);
     }

--- a/engine/gamesys/src/gamesys/resources/res_font.cpp
+++ b/engine/gamesys/src/gamesys/resources/res_font.cpp
@@ -490,6 +490,7 @@ namespace dmGameSystem
         params->m_CacheCellMaxAscent = glyph_bank->m_CacheCellMaxAscent;
         params->m_CacheCellPadding   = glyph_bank->m_GlyphPadding;
         params->m_IsMonospaced       = glyph_bank->m_IsMonospaced;
+        params->m_Padding            = glyph_bank->m_Padding;
     }
 
     HFontCollection ResFontGetFontCollection(FontResource* resource)

--- a/engine/gamesys/src/gamesys/resources/res_font.cpp
+++ b/engine/gamesys/src/gamesys/resources/res_font.cpp
@@ -490,7 +490,6 @@ namespace dmGameSystem
         params->m_CacheCellMaxAscent = glyph_bank->m_CacheCellMaxAscent;
         params->m_CacheCellPadding   = glyph_bank->m_GlyphPadding;
         params->m_IsMonospaced       = glyph_bank->m_IsMonospaced;
-        params->m_Padding            = glyph_bank->m_Padding;
     }
 
     HFontCollection ResFontGetFontCollection(FontResource* resource)

--- a/engine/render/src/render/font/default/font_default_vertex.cpp
+++ b/engine/render/src/render/font/default/font_default_vertex.cpp
@@ -368,6 +368,9 @@ uint32_t CreateFontVertexData(HFontRenderBackend backend, HFontMap font_map, uin
     layoutsettings.m_Width = te.m_Width;
     layoutsettings.m_Tracking = te.m_Tracking;
     layoutsettings.m_Leading = te.m_Leading;
+    // legacy options for glyph bank fonts
+    layoutsettings.m_Monospace = dmRender::GetFontMapMonospaced(font_map);
+    layoutsettings.m_Padding = dmRender::GetFontMapPadding(font_map);
 
     TextLayout* layout = 0;
     TextResult r = TextLayoutCreate(font_collection, codepoints.Begin(), codepoints.Size(), &layoutsettings, &layout);

--- a/engine/render/src/render/font/font_renderer.cpp
+++ b/engine/render/src/render/font/font_renderer.cpp
@@ -224,6 +224,9 @@ namespace dmRender
         settings.m_Leading = params.m_Leading;
         settings.m_Tracking = params.m_Tracking;
         settings.m_Size = dmRender::GetFontMapSize(font_map);
+        // legacy options for glyph bank fonts
+        settings.m_Monospace = dmRender::GetFontMapMonospaced(font_map);
+        settings.m_Padding = dmRender::GetFontMapPadding(font_map);
         TextMetrics metrics;
 
         // TODO: Allow for callers to have their prepared HTextLayout


### PR DESCRIPTION
This fixes a regression and discrepancy between how fonts are viewed in the editor and rendered in the engine. Monospace font padding were not properly respected and trailing spaces had an incorrect length.

Fixes #11736 


# Technical changes

Defold 1.10.3 (before any runtime font changes)
<img width="980" height="687" alt="Defold-1 10 3" src="https://github.com/user-attachments/assets/e0125bef-bc14-49d6-aaee-f9941187cae8" />

Defold 1.10.4 (notice some text shifting slightly to the right)
<img width="974" height="683" alt="Defold-1 10 4" src="https://github.com/user-attachments/assets/5cf26314-3242-47f6-be86-29d97d9f2d07" />

Defold 1.11.2 (same as 1.10.4)
<img width="975" height="680" alt="Defold-1 11 2" src="https://github.com/user-attachments/assets/23e977ac-1bf8-4207-99b5-cf2765da9e72" />

Defold 1.12.0 (notice AB shifted to the right)
<img width="973" height="681" alt="Defold-1 12 0" src="https://github.com/user-attachments/assets/f976b9cc-2ca4-4651-8f40-648f574be5a6" />

Defold 1.12.0 + this PR
<img width="971" height="679" alt="Defold-1 12 0-withfix" src="https://github.com/user-attachments/assets/f03d29e6-c802-433c-9421-c1dcc48ac0ad" />


