### PR TITLE
Limit max height of editor script dialogs

### DIFF
--- a/editor/src/clj/editor/dialogs.clj
+++ b/editor/src/clj/editor/dialogs.clj
@@ -26,6 +26,7 @@
             [cljfx.fx.progress-indicator :as fx.progress-indicator]
             [cljfx.fx.region :as fx.region]
             [cljfx.fx.scene :as fx.scene]
+            [cljfx.fx.stack-pane :as fx.stack-pane]
             [cljfx.fx.v-box :as fx.v-box]
             [cljfx.lifecycle :as fx.lifecycle]
             [cljfx.prop :as fx.prop]
@@ -44,6 +45,7 @@
             [util.coll :as coll]
             [util.thread-util :as thread-util])
   (:import [clojure.lang Named]
+           [com.defold.control ClippingContainer]
            [java.io File]
            [java.nio.file Path Paths]
            [java.util Collection List]
@@ -56,6 +58,9 @@
            [org.apache.commons.io FilenameUtils]))
 
 (set! *warn-on-reflection* true)
+
+(def clipping-container
+  (cljfx.composite/describe ClippingContainer :ctor [] :props fx.stack-pane/props))
 
 (defn dialog-stage
   "Dialog `:stage` that manages scene graph itself and provides layout common
@@ -95,7 +100,12 @@
                                                     :children [header]}
                                                    {:fx/type fx.v-box/lifecycle
                                                     :style-class "dialog-content"
-                                                    :children [content]}
+                                                    :children [{:fx/type clipping-container
+                                                                :max-height (case size
+                                                                              :small 480.0
+                                                                              :default 600.0
+                                                                              :large 720.0)
+                                                                :children [content]}]}
                                                    {:fx/type fx.v-box/lifecycle
                                                     :style-class "dialog-with-content-footer"
                                                     :children [footer]}]

--- a/editor/src/clj/editor/dialogs.clj
+++ b/editor/src/clj/editor/dialogs.clj
@@ -15,6 +15,7 @@
 (ns editor.dialogs
   (:require [cljfx.api :as fx]
             [cljfx.ext.list-view :as fx.ext.list-view]
+            [cljfx.composite :as fx.composite]
             [cljfx.fx.group :as fx.group]
             [cljfx.fx.h-box :as fx.h-box]
             [cljfx.fx.hyperlink :as fx.hyperlink]
@@ -60,7 +61,7 @@
 (set! *warn-on-reflection* true)
 
 (def clipping-container
-  (cljfx.composite/describe ClippingContainer :ctor [] :props fx.stack-pane/props))
+  (fx.composite/describe ClippingContainer :ctor [] :props fx.stack-pane/props))
 
 (defn dialog-stage
   "Dialog `:stage` that manages scene graph itself and provides layout common

--- a/editor/src/java/com/defold/control/ClippingContainer.java
+++ b/editor/src/java/com/defold/control/ClippingContainer.java
@@ -1,0 +1,45 @@
+// Copyright 2020-2026 The Defold Foundation
+// Copyright 2014-2020 King
+// Copyright 2009-2014 Ragnar Svensson, Christian Murray
+// Licensed under the Defold License version 1.0 (the "License"); you may not use
+// this file except in compliance with the License.
+//
+// You may obtain a copy of the License, together with FAQs at
+// https://www.defold.com/license
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package com.defold.control;
+
+import javafx.scene.layout.StackPane;
+import javafx.scene.shape.Rectangle;
+
+public class ClippingContainer extends StackPane {
+
+    public ClippingContainer() {
+        Rectangle clip = new Rectangle();
+        clip.widthProperty().bind(widthProperty());
+        clip.heightProperty().bind(heightProperty());
+        setClip(clip);
+    }
+
+    @Override
+    protected double computeMinWidth(double height) {
+        return limitByMax(super.computeMinWidth(height), getMaxWidth());
+    }
+
+    @Override
+    protected double computeMinHeight(double width) {
+        return limitByMax(super.computeMinHeight(width), getMaxHeight());
+    }
+
+    private static double limitByMax(double minSize, double maxSize) {
+        if (maxSize < 0.0) {
+            return minSize;
+        }
+        return Math.min(minSize, maxSize);
+    }
+}


### PR DESCRIPTION
Now, editor dialogs are limited in height. Users are encouraged to use the `editor.ui.scroll()` container for dialogs that may display a lot of content.

Fix #11532