### PR TITLE
Remove validation of glyph order

### DIFF
--- a/engine/render/src/render/font/font_glyphbank.cpp
+++ b/engine/render/src/render/font/font_glyphbank.cpp
@@ -174,16 +174,5 @@ HFont CreateGlyphBankFont(const char* path, dmRenderDDF::GlyphBank* glyph_bank)
 
     font->m_GlyphBank = glyph_bank;
 
-    // Making sure that it's an increasing list of codepoints, as it's required
-    // by the binary search algorithm
-    int32_t c = -1;
-    uint32_t n = glyph_bank->m_Glyphs.m_Count;
-    for (uint32_t i = 0; i < n; ++i)
-    {
-        dmRenderDDF::GlyphBank::Glyph& glyph = glyph_bank->m_Glyphs[i];
-        assert(c < (int)glyph.m_Character);
-        c = glyph.m_Character;
-    }
-
     return (Font*)font;
 }


### PR DESCRIPTION
This fixes a crash when using fonts in the BMFont format when the glyphs of the font are not sorted in increasing order.

Fixes #11743 

# Technical changes
In Defold 1.12.0 we assume that the glyphs of a BMFont (.fnt) file are sorted in increasing codepoint order, but we have not added sorting in bob+editor AND we have not implemented binary search for glyphs yet as seen by comment in font_gl,yphbank.cpp:

```cpp
static dmRenderDDF::GlyphBank::Glyph* FindByCodePoint(dmRenderDDF::GlyphBank* bank, uint32_t c)
{
//TODO: Make it a binary search!!!
```

