### PR TITLE
Add `editor.ui.image()` editor script function

### DIFF
--- a/editor/src/clj/editor/editor_extensions/ui_components.clj
+++ b/editor/src/clj/editor/editor_extensions/ui_components.clj
@@ -21,11 +21,13 @@
             [cljfx.fx.label :as fx.label]
             [cljfx.fx.region :as fx.region]
             [cljfx.fx.row-constraints :as fx.row-constraints]
+            [cljfx.fx.stack-pane :as fx.stack-pane]
             [cljfx.fx.stage :as fx.stage]
             [cljfx.fx.v-box :as fx.v-box]
             [cljfx.lifecycle :as fx.lifecycle]
             [cljfx.mutator :as fx.mutator]
             [cljfx.prop :as fx.prop]
+            [clojure.java.io :as io]
             [clojure.spec.alpha :as s]
             [clojure.string :as string]
             [dynamo.graph :as g]
@@ -44,10 +46,12 @@
             [editor.resource :as resource]
             [editor.resource-dialog :as resource-dialog]
             [editor.ui :as ui]
+            [editor.workspace :as workspace]
             [internal.util :as iutil]
             [util.coll :as coll :refer [pair]]
             [util.fn :as fn])
   (:import [com.defold.editor.luart DefoldLuaFn]
+           [java.net URI URISyntaxException]
            [java.nio.file Path]
            [java.util Collection List]
            [javafx.beans.property ReadOnlyProperty]
@@ -64,6 +68,16 @@
 ;; See also:
 ;; - Components doc: https://docs.google.com/document/d/1e6kmVLspQEoe17Ys1nmbbf54cqUn2fNPZowIe7JBwl4/edit
 ;; - Reactive UI doc: https://docs.google.com/document/d/1cgqFPLUc3YQih2tsEA067Pz9Q0nWlKoVflqLEVX8CPY/edit
+
+;; The value gets bound to a volatile with evaluation context. When the context
+;; becomes invalid (fills the cache after use), the volatile is set to nil to
+;; signal that this context can't be used anymore. The default value is a
+;; reduced instance to support `deref`, but not `vreset!`
+(def ^:private ^:dynamic *lifecycle-evaluation-context-ideref* (reduced nil))
+
+(defn- lifecycle-evaluation-context []
+  {:post [(some? %)]}
+  @*lifecycle-evaluation-context-ideref*)
 
 (s/def ::create ifn?)
 (s/def ::advance ifn?)
@@ -295,6 +309,31 @@
                    :fit-width fit-size
                    :fit-height fit-size}]}
       alignment)))
+
+(fxui/defc image-view
+  {:compose [{:fx/type fx/ext-get-env :env [:workspace]}]}
+  [{:keys [image alignment width height workspace]
+    :or {alignment :top-left}}]
+  (or
+    (when-let [image (if (string/starts-with? image "/")
+                       (when-let [resource (workspace/find-resource workspace image (lifecycle-evaluation-context))]
+                         (when (resource/exists? resource)
+                           {:is (io/input-stream resource)
+                            :background-loading true}))
+                       (when-let [^URI uri (try (URI. image) (catch URISyntaxException _))]
+                         (when (.getScheme uri)
+                           {:url image
+                            :background-loading true})))]
+      (wrap-in-alignment-container
+        (-> {:fx/type fx.stack-pane/lifecycle
+             :children [(cond-> {:fx/type fxui/resizable-image
+                                 :image image})]}
+            (apply-alignment alignment)
+            (cond->
+              width (assoc :min-width width :pref-width width :max-width width)
+              height (assoc :min-height height :pref-height height :max-height height)))
+        alignment))
+    {:fx/type fx.region/lifecycle}))
 
 ;; endregion
 
@@ -723,16 +762,6 @@
 
 ;; region functions
 
-;; The value gets bound to a volatile with evaluation context. When the context
-;; becomes invalid (fills the cache after use), the volatile is set to nil to
-;; signal that this context can't be used anymore. The default value is a
-;; reduced instance to support `deref`, but not `vreset!`
-(def ^:private ^:dynamic *lifecycle-evaluation-context-ideref* (reduced nil))
-
-(defn- lifecycle-evaluation-context []
-  {:post [(some? %)]}
-  @*lifecycle-evaluation-context-ideref*)
-
 (defmacro ^:private with-nestable-evaluation-context [& body]
   `(if @*lifecycle-evaluation-context-ideref*
      (do ~@body)
@@ -766,6 +795,7 @@
          Expected keys:
            :desc            extension cljfx description
            :localization    localization instance
+           :workspace       node id of a Workspace
 
          Provides:
            - evaluation context: shared along the whole cljfx tree during
@@ -774,7 +804,7 @@
            - localization state: available in cljfx env using [[fx/ext-get-env]]
              with :localization-state key"
    :compose [{:fx/type fx/ext-watcher :ref (:localization props) :key :localization-state}
-             {:fx/type fx/ext-set-env :env {:localization-state (:localization-state props)}}
+             {:fx/type fx/ext-set-env :env {:localization-state (:localization-state props) :workspace (:workspace props)}}
              {:fx/type ext-with-evaluation-context}]}
   [{:keys [desc]}]
   desc)
@@ -789,11 +819,12 @@
    :props {:showing (fxui/dialog-showing? props)}
    :desc desc})
 
-(defn- make-lua-show-dialog-fn [localization]
+(defn- make-lua-show-dialog-fn [workspace localization]
   (rt/suspendable-lua-fn show-dialog [{:keys [rt]} lua-dialog-component]
     (let [desc {:fx/type show-dialog-wrapper-view
                 :desc {:fx/type root-view
                        :localization localization
+                       :workspace workspace
                        :desc (rt/->clj rt ui-docs/component-coercer lua-dialog-component)}}
           f (future/make)]
       (fx/run-later
@@ -1254,6 +1285,7 @@
             [ui-docs/paragraph-component paragraph-view]
             [ui-docs/heading-component heading-view]
             [ui-docs/icon-component icon-view]
+            [ui-docs/image-component image-view]
             [ui-docs/button-component button-view]
             [ui-docs/check-box-component check-box-view]
             [ui-docs/select-box-component select-box-view]
@@ -1269,7 +1301,7 @@
          (eduction
            (map (fn [[script-doc lua-fn]]
                   [(:name script-doc) lua-fn]))
-           [[ui-docs/show-dialog-doc (make-lua-show-dialog-fn localization)]
+           [[ui-docs/show-dialog-doc (make-lua-show-dialog-fn workspace localization)]
             [ui-docs/function-component-doc function-component-lua-fn]
             [ui-docs/show-external-file-dialog-doc (make-show-external-file-dialog-lua-fn project-path localization)]
             [ui-docs/show-external-directory-dialog-doc (make-show-external-directory-dialog-lua-fn project-path localization)]

--- a/editor/src/clj/editor/editor_extensions/ui_components.clj
+++ b/editor/src/clj/editor/editor_extensions/ui_components.clj
@@ -328,8 +328,7 @@
     :or {alignment :top-left}}]
   (if image
     (-> {:fx/type fx.stack-pane/lifecycle
-         :children [(cond-> {:fx/type fxui/resizable-image
-                             :image image})]}
+         :children [{:fx/type fxui/resizable-image :image image}]}
         (apply-alignment alignment)
         (cond->
           width (assoc :min-width width :pref-width width :max-width width)

--- a/editor/src/clj/editor/editor_extensions/ui_components.clj
+++ b/editor/src/clj/editor/editor_extensions/ui_components.clj
@@ -59,6 +59,7 @@
            [javafx.event Event]
            [javafx.scene Node]
            [javafx.scene.control CheckBox TextField]
+           [javafx.scene.image Image]
            [javafx.scene.input KeyCode KeyEvent]
            [javafx.stage DirectoryChooser FileChooser FileChooser$ExtensionFilter]
            [org.luaj.vm2 LuaError LuaValue]))
@@ -310,29 +311,30 @@
                    :fit-height fit-size}]}
       alignment)))
 
+(defn- construct-image [s workspace]
+  (if (string/starts-with? s "/")
+    (when-let [resource (workspace/find-resource workspace s (lifecycle-evaluation-context))]
+      (when (resource/exists? resource)
+        (with-open [is (io/input-stream resource)]
+          (Image. is))))
+    (when-let [^URI uri (try (URI. s) (catch URISyntaxException _))]
+      (when (.getScheme uri)
+        (Image. s #_background-loading true)))))
+
 (fxui/defc image-view
-  {:compose [{:fx/type fx/ext-get-env :env [:workspace]}]}
-  [{:keys [image alignment width height workspace]
+  {:compose [{:fx/type fx/ext-get-env :env [:workspace]}
+             {:fx/type fxui/ext-memo :fn construct-image :args [(:image props) (:workspace props)] :key :image}]}
+  [{:keys [image alignment width height]
     :or {alignment :top-left}}]
-  (or
-    (when-let [image (if (string/starts-with? image "/")
-                       (when-let [resource (workspace/find-resource workspace image (lifecycle-evaluation-context))]
-                         (when (resource/exists? resource)
-                           {:is (io/input-stream resource)
-                            :background-loading true}))
-                       (when-let [^URI uri (try (URI. image) (catch URISyntaxException _))]
-                         (when (.getScheme uri)
-                           {:url image
-                            :background-loading true})))]
-      (wrap-in-alignment-container
-        (-> {:fx/type fx.stack-pane/lifecycle
-             :children [(cond-> {:fx/type fxui/resizable-image
-                                 :image image})]}
-            (apply-alignment alignment)
-            (cond->
-              width (assoc :min-width width :pref-width width :max-width width)
-              height (assoc :min-height height :pref-height height :max-height height)))
-        alignment))
+  (if image
+    (-> {:fx/type fx.stack-pane/lifecycle
+         :children [(cond-> {:fx/type fxui/resizable-image
+                             :image image})]}
+        (apply-alignment alignment)
+        (cond->
+          width (assoc :min-width width :pref-width width :max-width width)
+          height (assoc :min-height height :pref-height height :max-height height))
+        (wrap-in-alignment-container alignment))
     {:fx/type fx.region/lifecycle}))
 
 ;; endregion

--- a/editor/src/clj/editor/editor_extensions/ui_docs.clj
+++ b/editor/src/clj/editor/editor_extensions/ui_docs.clj
@@ -256,10 +256,13 @@
 (def ^:private icon-props
   (into icon-specific-props common-props))
 
+(def image-size-coercer
+  (coerce/wrap-with-pred coerce/number pos? "is not positive"))
+
 (def ^:private image-props
   (into [(make-prop :image :coerce coerce/string :required true :doc "either a resource path (starts with <code>/</code>), or an URL")
-         (make-prop :width :coerce coerce/number :doc "width of the image")
-         (make-prop :height :coerce coerce/number :doc "height of the image")]
+         (make-prop :width :coerce image-size-coercer :doc "width of the image view, the image will be fit inside it while preserving its aspect ratio")
+         (make-prop :height :coerce image-size-coercer :doc "height of the image view, the image will be fit inside it while preserving its aspect ratio")]
         common-props))
 
 (def ^:private common-input-props

--- a/editor/src/clj/editor/editor_extensions/ui_docs.clj
+++ b/editor/src/clj/editor/editor_extensions/ui_docs.clj
@@ -256,6 +256,12 @@
 (def ^:private icon-props
   (into icon-specific-props common-props))
 
+(def ^:private image-props
+  (into [(make-prop :image :coerce coerce/string :required true :doc "either a resource path (starts with <code>/</code>), or an URL")
+         (make-prop :width :coerce coerce/number :doc "width of the image")
+         (make-prop :height :coerce coerce/number :doc "height of the image")]
+        common-props))
+
 (def ^:private common-input-props
   (into [(make-prop :enabled
                     :coerce coerce/boolean
@@ -480,6 +486,12 @@
     "icon"
     :description "An icon from a predefined set"
     :props icon-props))
+
+(def image-component
+  (component
+    "image"
+    :description "An image"
+    :props image-props))
 
 (def button-component
   (component
@@ -746,6 +758,7 @@ end)</code></pre>"})
               paragraph-component
               heading-component
               icon-component
+              image-component
               button-component
               check-box-component
               select-box-component

--- a/editor/src/clj/editor/fxui.clj
+++ b/editor/src/clj/editor/fxui.clj
@@ -16,6 +16,7 @@
   (:require [cljfx.api :as fx]
             [cljfx.coerce :as fx.coerce]
             [cljfx.component :as fx.component]
+            [cljfx.composite :as fx.composite]
             [cljfx.fx.anchor-pane :as fx.anchor-pane]
             [cljfx.fx.button :as fx.button]
             [cljfx.fx.check-box :as fx.check-box]
@@ -23,6 +24,7 @@
             [cljfx.fx.column-constraints :as fx.column-constraints]
             [cljfx.fx.grid-pane :as fx.grid-pane]
             [cljfx.fx.h-box :as fx.h-box]
+            [cljfx.fx.image-view :as fx.image-view]
             [cljfx.fx.label :as fx.label]
             [cljfx.fx.list-cell :as fx.list-cell]
             [cljfx.fx.menu-button :as fx.menu-button]
@@ -55,14 +57,14 @@
             [util.coll :as coll]
             [util.fn :as fn])
   (:import [clojure.lang MultiFn]
-           [com.defold.control ButtonWithCappedMinWidth ListCell]
+           [com.defold.control ButtonWithCappedMinWidth ListCell ResizableImageView]
            [java.util Collection]
            [javafx.animation Animation KeyFrame KeyValue SequentialTransition Timeline TranslateTransition]
            [javafx.application Platform]
-           [javafx.beans InvalidationListener Observable]
+           [javafx.beans Observable]
            [javafx.beans.binding Bindings]
            [javafx.beans.value ChangeListener ObservableValue]
-           [javafx.collections MapChangeListener MapChangeListener$Change ObservableList ObservableMap]
+           [javafx.collections ObservableList]
            [javafx.css PseudoClass]
            [javafx.event Event EventHandler]
            [javafx.geometry Bounds Insets]
@@ -1703,3 +1705,11 @@
                 child-instance-meta))))))
     (delete [_ component opts]
       (fx.lifecycle/delete fx.lifecycle/dynamic (:child component) opts))))
+
+(def resizable-image
+  (fx.composite/describe
+    ResizableImageView
+    :ctor []
+    ;; ResizableImageView uses fitToWidth and fitToHeight internally during
+    ;; resize, ignoring externally set values
+    :props (dissoc fx.image-view/props :fit-to-width :fit-to-height)))

--- a/editor/src/clj/editor/markdown.clj
+++ b/editor/src/clj/editor/markdown.clj
@@ -389,9 +389,6 @@
          :hgap 4
          :children views}))))
 
-(def ^:private ext-with-image-view-props
-  (fx/make-ext-with-props fx.image-view/props))
-
 (defn- image-view [^Element node ctx]
   (or
     (let [src (coll/not-empty (.attr node "src"))]
@@ -404,10 +401,9 @@
                                (when (resource/exists? resource)
                                  {:is (io/input-stream resource)
                                   :background-loading true}))))]
-          {:fx/type ext-with-image-view-props
-           :desc {:fx/type fx/ext-instance-factory
-                  :create ResizableImageView/new}
-           :props {:image image}})))
+          {:fx/type fx.h-box/lifecycle
+           :children [{:fx/type fxui/resizable-image
+                       :image image}]})))
     {:fx/type fx.region/lifecycle}))
 
 (defn- kbd-view [^Element node ctx]

--- a/editor/src/clj/editor/markdown.clj
+++ b/editor/src/clj/editor/markdown.clj
@@ -18,7 +18,6 @@
             [cljfx.fx.column-constraints :as fx.column-constraints]
             [cljfx.fx.grid-pane :as fx.grid-pane]
             [cljfx.fx.h-box :as fx.h-box]
-            [cljfx.fx.image-view :as fx.image-view]
             [cljfx.fx.region :as fx.region]
             [cljfx.fx.scroll-pane :as fx.scroll-pane]
             [cljfx.fx.stack-pane :as fx.stack-pane]
@@ -44,9 +43,9 @@
             [editor.workspace :as workspace]
             [util.coll :as coll]
             [util.fn :as fn])
-  (:import [com.defold.control ResizableImageView]
-           [java.net URI URISyntaxException URLDecoder]
+  (:import [java.net URI URISyntaxException URLDecoder]
            [javafx.scene.control ContextMenu MenuItem ScrollPane]
+           [javafx.scene.image Image]
            [javafx.scene.input Clipboard ClipboardContent MouseButton MouseEvent]
            [org.commonmark.ext.autolink AutolinkExtension]
            [org.commonmark.ext.front.matter YamlFrontMatterExtension]
@@ -389,22 +388,31 @@
          :hgap 4
          :children views}))))
 
-(defn- image-view [^Element node ctx]
-  (or
-    (let [src (coll/not-empty (.attr node "src"))]
-      (when-let [^URI uri (when src
-                            (try (URI. src) (catch URISyntaxException _)))]
-        (when-let [image (if (or (.getAuthority uri) (.getScheme uri))
-                           {:url src :background-loading true}
-                           (when-let [base-resource (:base-resource ctx)]
-                             (let [resource (workspace/resolve-resource base-resource (.getPath uri))]
-                               (when (resource/exists? resource)
-                                 {:is (io/input-stream resource)
-                                  :background-loading true}))))]
-          {:fx/type fx.h-box/lifecycle
-           :children [{:fx/type fxui/resizable-image
-                       :image image}]})))
+(defn- construct-image [src base-resource]
+  (when-not (coll/empty? src)
+    (when-let [^URI uri (try (URI. src) (catch URISyntaxException _))]
+      (if (or (.getAuthority uri) (.getScheme uri))
+        (Image. src #_background-loading true)
+        (when-let [base-resource base-resource]
+          (let [resource (workspace/resolve-resource base-resource (.getPath uri))]
+            (when (resource/exists? resource)
+              (with-open [is (io/input-stream resource)]
+                (Image. is)))))))))
+
+(fxui/defc image-view-impl
+  {:compose [{:fx/type fxui/ext-memo
+              :fn construct-image
+              :args [(:src props) (:base-resource props)]
+              :key :image}]}
+  [{:keys [image]}]
+  (if image
+    {:fx/type fx.h-box/lifecycle :children [{:fx/type fxui/resizable-image :image image}]}
     {:fx/type fx.region/lifecycle}))
+
+(defn- image-view [^Element node ctx]
+  {:fx/type image-view-impl
+   :src (.attr node "src")
+   :base-resource (:base-resource ctx)})
 
 (defn- kbd-view [^Element node ctx]
   (when-let [view (children-section-view node (-> ctx (style "code")))]

--- a/editor/src/java/com/defold/control/ResizableImageView.java
+++ b/editor/src/java/com/defold/control/ResizableImageView.java
@@ -79,6 +79,16 @@ public class ResizableImageView extends ImageView {
     }
 
     @Override
+    public double maxWidth(double v) {
+        return Double.MAX_VALUE;
+    }
+
+    @Override
+    public double maxHeight(double v) {
+        return Double.MAX_VALUE;
+    }
+
+    @Override
     public Orientation getContentBias() {
         return Orientation.HORIZONTAL;
     }

--- a/editor/test/integration/editor_extensions_test.clj
+++ b/editor/test/integration/editor_extensions_test.clj
@@ -656,6 +656,11 @@
         (is (thrown-with-msg? LuaError #"more arguments expected" (coerce required-after-optional "foo")))
         (is (thrown-with-msg? LuaError #"(\"bar\" is not a boolean)\n.+(\"bar\" is not an integer)" (coerce required-after-optional "foo" "bar")))))))
 
+(defn- expect-script-output [expected actual]
+  (let [actual (normalize-pprint-output (str actual))]
+    (let [output-matches-expectation (= expected actual)]
+      (is output-matches-expectation (when-not output-matches-expectation (string/join "\n" (diff/make-diff-output-lines expected actual 3)))))))
+
 (deftest external-file-attributes-test
   (test-util/with-loaded-project "test/resources/editor_extensions/external_file_attributes_project"
     (let [output (atom [])]
@@ -668,15 +673,22 @@
               [:out "path = 'does_not_exist.txt', exists = false, file = false, directory = false"]]
              @output)))))
 
+(def expected-ui-test-output
+  "editor.ui.image({}) => {} must have the \"image\" key
+editor.ui.image({image = false}) => false is not a string
+editor.ui.image({image = 'foo', width = false}) => false is not a number
+editor.ui.image({image = 'foo', width = -1}) => -1 is not positive
+")
+
 (deftest ui-test
   (test-util/with-loaded-project "test/resources/editor_extensions/ui_project"
-    (let [output (atom [])]
-      (reload-editor-scripts! project :display-output! #(swap! output conj [%1 %2]))
+    (let [out (StringBuilder.)]
+      (reload-editor-scripts! project :display-output! #(doto out (.append %2) (.append \newline)))
       (run-edit-menu-test-command!)
       ;; see test.editor_script: it creates a lot of ui components that should
       ;; form a valid UI tree. In case of any errors the output will get error
       ;; entries.
-      (is (= [] @output)))))
+      (expect-script-output expected-ui-test-output out))))
 
 (deftest prefs-round-trip-test
   (test-util/with-loaded-project "test/resources/editor_extensions/prefs_round_trip_project"
@@ -885,11 +897,6 @@ nesting:
       (fn [s]
         (or (@hash->stable-id s)
             ((vswap! hash->stable-id #(assoc % s (str "0x" (count %)))) s))))))
-
-(defn- expect-script-output [expected actual]
-  (let [actual (normalize-pprint-output (str actual))]
-    (let [output-matches-expectation (= expected actual)]
-      (is output-matches-expectation (when-not output-matches-expectation (string/join "\n" (diff/make-diff-output-lines expected actual 3)))))))
 
 (deftest pprint-test
   (test-util/with-loaded-project "test/resources/editor_extensions/pprint-test"

--- a/editor/test/integration/editor_extensions_test.clj
+++ b/editor/test/integration/editor_extensions_test.clj
@@ -656,6 +656,15 @@
         (is (thrown-with-msg? LuaError #"more arguments expected" (coerce required-after-optional "foo")))
         (is (thrown-with-msg? LuaError #"(\"bar\" is not a boolean)\n.+(\"bar\" is not an integer)" (coerce required-after-optional "foo" "bar")))))))
 
+(defn- normalize-pprint-output [output-string]
+  (let [hash->stable-id (volatile! {})]
+    (string/replace
+      output-string
+      #"0x[0-9a-f]+"
+      (fn [s]
+        (or (@hash->stable-id s)
+            ((vswap! hash->stable-id #(assoc % s (str "0x" (count %)))) s))))))
+
 (defn- expect-script-output [expected actual]
   (let [actual (normalize-pprint-output (str actual))]
     (let [output-matches-expectation (= expected actual)]
@@ -888,15 +897,6 @@ nesting:
   \"a\"
 }
 ")
-
-(defn- normalize-pprint-output [output-string]
-  (let [hash->stable-id (volatile! {})]
-    (string/replace
-      output-string
-      #"0x[0-9a-f]+"
-      (fn [s]
-        (or (@hash->stable-id s)
-            ((vswap! hash->stable-id #(assoc % s (str "0x" (count %)))) s))))))
 
 (deftest pprint-test
   (test-util/with-loaded-project "test/resources/editor_extensions/pprint-test"

--- a/editor/test/resources/editor_extensions/ui_project/test.editor_script
+++ b/editor/test/resources/editor_extensions/ui_project/test.editor_script
@@ -5,6 +5,7 @@ function M.get_commands()
         {
             label = "Test UI",
             locations = {"Edit"},
+            id = "defold.test",
             run = function()
                 local dialog = editor.ui.dialog({
                     title = "Dialog title",
@@ -44,6 +45,68 @@ function M.get_commands()
                                             editor.ui.button({ icon = editor.ui.ICON.MINUS }),
                                             editor.ui.button({ icon = editor.ui.ICON.OPEN_RESOURCE }),
                                             editor.ui.button({ icon = editor.ui.ICON.PLUS }),
+                                        }
+                                    })
+                                },
+                                {
+                                    editor.ui.label({
+                                        text = "Images",
+                                        alignment = editor.ui.ALIGNMENT.RIGHT
+                                    }),
+                                    editor.ui.grid({
+                                        spacing = editor.ui.SPACING.NONE,
+                                        children = {
+                                            {
+                                                -- resources
+                                                editor.ui.image({
+                                                    image = "/builtins/assets/images/logo/logo_256.png",
+                                                    width = 16,
+                                                    alignment = editor.ui.ALIGNMENT.BOTTOM_LEFT
+                                                }),
+                                                editor.ui.image({
+                                                    image = "/builtins/assets/images/logo/logo_256.png",
+                                                    width = 32,
+                                                    alignment = editor.ui.ALIGNMENT.CENTER
+                                                }),
+                                                editor.ui.image({
+                                                    image = "/builtins/assets/images/logo/logo_256.png",
+                                                    width = 64
+                                                })
+                                            },
+                                            {
+                                                -- URLs
+                                                editor.ui.image({
+                                                    image = "https://avatars.githubusercontent.com/u/111111",
+                                                    width = 32
+                                                }),
+                                                editor.ui.image({
+                                                    image = "https://avatars.githubusercontent.com/u/732554",
+                                                    width = 32
+                                                }),
+                                                editor.ui.image({
+                                                    image = "https://avatars.githubusercontent.com/u/123456",
+                                                    width = 32,
+                                                    alignment = editor.ui.ALIGNMENT.RIGHT
+                                                })
+                                            },
+                                            {
+                                                -- invalid resources
+                                                editor.ui.image({
+                                                    image = "/does-not-exist.png"
+                                                }),
+                                                editor.ui.image({
+                                                    image = "/game.project"
+                                                })
+                                            },
+                                            {
+                                                -- invalid URLs
+                                                editor.ui.image({
+                                                    image = "https://defold.com/"
+                                                }),
+                                                editor.ui.image({
+                                                    image = "https://probably-does-not-exist.com/"
+                                                }),
+                                            }
                                         }
                                     })
                                 },

--- a/editor/test/resources/editor_extensions/ui_project/test.editor_script
+++ b/editor/test/resources/editor_extensions/ui_project/test.editor_script
@@ -1,5 +1,14 @@
 local M = {}
 
+local function expect_error(msg, fn, ...)
+    local success, error = pcall(fn, ...)
+    if success then
+        print(("%s => unexpected success!"):format(msg))
+    else
+        print(("%s => %s"):format(msg, error))
+    end
+end
+
 function M.get_commands()
     return {
         {
@@ -250,6 +259,11 @@ function M.get_commands()
                         })
                     }
                 })
+
+                expect_error("editor.ui.image({})", editor.ui.image, {})
+                expect_error("editor.ui.image({image = false})", editor.ui.image, {image = false})
+                expect_error("editor.ui.image({image = 'foo', width = false})", editor.ui.image, {image = 'foo', width = false})
+                expect_error("editor.ui.image({image = 'foo', width = -1})", editor.ui.image, {image = 'foo', width = -1})
 
                 -- editor.ui.show_dialog(dialog)
             end


### PR DESCRIPTION
Now, editor scripts can show images, supporting both project files and external URLs, e.g.:
```lua
editor.ui.show_dialog(editor.ui.dialog({
    title = "Images",
    content = editor.ui.horizontal({
        padding = editor.ui.PADDING.LARGE,
        children = {
            editor.ui.image({image = "/builtins/assets/images/logo/logo_256.png", width = 64, height = 64}),
            editor.ui.image({image = "https://defold.com/images/assets/monarch-hero.jpg"})
        }
    })
}))
```
<img width="652" height="443" alt="Screenshot 2026-01-20 at 14 10 30" src="https://github.com/user-attachments/assets/4703f47b-630f-407b-8565-899fa418a13d" />

Fixes #10220

