### PR TITLE
Move Path-related editor functions from fs module to new util.path module

### DIFF
--- a/editor/src/clj/editor/asset_browser.clj
+++ b/editor/src/clj/editor/asset_browser.clj
@@ -38,7 +38,8 @@
             [util.coll :as coll :refer [pair]]
             [util.defonce :as defonce]
             [util.eduction :as e]
-            [util.fn :as fn])
+            [util.fn :as fn]
+            [util.path :as path])
   (:import [com.defold.control LazyTreeItem]
            [editor.resource FileResource]
            [java.io File]
@@ -423,7 +424,7 @@
       ;; plain case change causes irrelevant conflict on case-insensitive file systems
       ;; fs/move! handles this, no need to resolve
       (let [{case-changes true possible-conflicts false}
-            (group-by #(fs/same-file? (key %) (val %)) rename-pairs)]
+            (group-by #(path/same? (key %) (val %)) rename-pairs)]
         (when-let [resolved-conflicts (resolve-any-conflicts localization possible-conflicts)]
           (let [resolved-rename-pairs (into resolved-conflicts case-changes)]
             (when (seq resolved-rename-pairs)

--- a/editor/src/clj/editor/code/script_annotations.clj
+++ b/editor/src/clj/editor/code/script_annotations.clj
@@ -22,7 +22,8 @@
             [editor.types :as types]
             [schema.core :as s]
             [util.coll :as coll]
-            [util.eduction :as e])
+            [util.eduction :as e]
+            [util.path :as path])
   (:import [java.io IOException]))
 
 (set! *warn-on-reflection* true)
@@ -34,25 +35,25 @@
 
 (g/defnk produce-sync-hash [_node-id root script-annotations]
   (try
-    (let [root-path (fs/path root ".internal" "lua-annotations")
+    (let [root-path (path/path root ".internal" "lua-annotations")
           path->mtime+lines (coll/pair-map-by
                               #(.normalize (.resolve root-path (fs/without-leading-slash (resource/proj-path (:resource %)))))
-                              (coll/pair-fn #(fs/path-last-modified-time (fs/path (io/as-file (:resource %))))
+                              (coll/pair-fn #(path/last-modified-ms (:resource %))
                                             :lines)
                               script-annotations)]
       ;; Remove files that are no longer relevant
-      (when (fs/path-exists? root-path)
-        (->> root-path (fs/path-walker) (e/remove path->mtime+lines) (run! fs/delete-path-file!)))
+      (when (path/exists? root-path)
+        (->> root-path (path/tree-walker) (e/remove path->mtime+lines) (run! path/delete!)))
       ;; Write changed files
       (run!
         (fn [[path [mtime lines]]]
-          (when-not (and (fs/path-exists? path)
-                         (= mtime (fs/path-last-modified-time path)))
-            (fs/create-path-parent-directories! path)
+          (when-not (and (path/exists? path)
+                         (= mtime (path/last-modified-ms path)))
+            (path/create-parent-directories! path)
             (with-open [writer (io/writer path)]
               (.write writer "---@meta\n")
               (io/copy (data/lines-reader lines) writer))
-            (fs/set-path-last-modified-time! path mtime)))
+            (path/set-last-modified-ms! path mtime)))
         path->mtime+lines)
       (hash path->mtime+lines))
     (catch IOException e

--- a/editor/src/clj/editor/code/script_annotations.clj
+++ b/editor/src/clj/editor/code/script_annotations.clj
@@ -35,7 +35,7 @@
 
 (g/defnk produce-sync-hash [_node-id root script-annotations]
   (try
-    (let [root-path (path/path root ".internal" "lua-annotations")
+    (let [root-path (path/of root ".internal" "lua-annotations")
           path->mtime+lines (coll/pair-map-by
                               #(.normalize (.resolve root-path (fs/without-leading-slash (resource/proj-path (:resource %)))))
                               (coll/pair-fn #(path/last-modified-ms (:resource %))

--- a/editor/src/clj/editor/editor_extensions.clj
+++ b/editor/src/clj/editor/editor_extensions.clj
@@ -186,13 +186,13 @@
                                (fn type-ext->template [ext]
                                  (or (workspace/template workspace (get resource-types ext) evaluation-context) "")))]
       (-> (future/io
-            (let [root-path (path/real-path project-dir)
+            (let [root-path (path/real project-dir)
                   path+contents (mapv (fn [{proj-path 1 content 2}]
-                                        (let [file-path (path/normalized-path (str root-path proj-path))]
+                                        (let [file-path (path/normalized (str root-path proj-path))]
                                           (when-not (.startsWith file-path root-path)
                                             (throw (LuaError. (str "Can't create " proj-path ": outside of project directory"))))
                                           (when (path/exists? file-path)
-                                            (if (path/existing-directory? file-path)
+                                            (if (path/directory? file-path)
                                               (throw (LuaError. (str "Directory already exists in place of file: " proj-path)))
                                               (throw (LuaError. (str "Resource already exists: " proj-path)))))
                                           (let [content (or content
@@ -221,9 +221,9 @@
       (let [basis (:basis evaluation-context)
             workspace (project/workspace project evaluation-context)
             root-path (-> (workspace/project-directory basis workspace)
-                          (path/real-path))
+                          (path/real))
             dir-path (-> (str root-path proj-path)
-                         (path/normalized-path))]
+                         (path/normalized))]
         (if (.startsWith dir-path root-path)
           (try
             (path/create-directories! dir-path)
@@ -240,9 +240,9 @@
           proj-path (rt/->clj rt graph/resource-path-coercer lua-proj-path)
           workspace (project/workspace project evaluation-context)
           root-path (-> (workspace/project-directory basis workspace)
-                        (path/real-path))
+                        (path/real))
           dir-path (-> (str root-path proj-path)
-                       (path/normalized-path))
+                       (path/normalized))
           protected-paths (mapv #(.resolve root-path ^String %)
                                 [".git"
                                  ".internal"])
@@ -275,7 +275,7 @@
       (future/io
         (if (path/exists? path)
           (let [attrs (path/attributes path)]
-            {:path (str (path/real-path path))
+            {:path (str (path/real path))
              :exists true
              :is_file (.isRegularFile attrs)
              :is_directory (.isDirectory attrs)})

--- a/editor/src/clj/editor/editor_extensions.clj
+++ b/editor/src/clj/editor/editor_extensions.clj
@@ -57,7 +57,8 @@
             [util.eduction :as e]
             [util.fn :as fn]
             [util.http-client :as http]
-            [util.http-server :as http-server])
+            [util.http-server :as http-server]
+            [util.path :as path])
   (:import [clojure.lang IDeref]
            [com.dynamo.bob Platform]
            [com.dynamo.bob.bundle BundleHelper]
@@ -185,13 +186,13 @@
                                (fn type-ext->template [ext]
                                  (or (workspace/template workspace (get resource-types ext) evaluation-context) "")))]
       (-> (future/io
-            (let [root-path (fs/real-path project-dir)
+            (let [root-path (path/real-path project-dir)
                   path+contents (mapv (fn [{proj-path 1 content 2}]
-                                        (let [file-path (.normalize (fs/path (str root-path proj-path)))]
+                                        (let [file-path (path/normalized-path (str root-path proj-path))]
                                           (when-not (.startsWith file-path root-path)
                                             (throw (LuaError. (str "Can't create " proj-path ": outside of project directory"))))
-                                          (when (fs/path-exists? file-path)
-                                            (if (fs/path-is-directory? file-path)
+                                          (when (path/exists? file-path)
+                                            (if (path/existing-directory? file-path)
                                               (throw (LuaError. (str "Directory already exists in place of file: " proj-path)))
                                               (throw (LuaError. (str "Resource already exists: " proj-path)))))
                                           (let [content (or content
@@ -208,7 +209,7 @@
                            (when (< 1 frequency)
                              (throw (LuaError. (str "Resource repeated more than once: /" (string/replace (str (.relativize root-path path)) \\ \/))))))))
               (run! (fn [[file-path content]]
-                      (fs/create-path-parent-directories! file-path)
+                      (path/create-parent-directories! file-path)
                       (spit file-path content))
                     path+contents)))
           (future/then (fn [_] (reload-resources!)))
@@ -220,13 +221,12 @@
       (let [basis (:basis evaluation-context)
             workspace (project/workspace project evaluation-context)
             root-path (-> (workspace/project-directory basis workspace)
-                          (fs/real-path))
+                          (path/real-path))
             dir-path (-> (str root-path proj-path)
-                         (fs/as-path)
-                         (.normalize))]
+                         (path/normalized-path))]
         (if (.startsWith dir-path root-path)
           (try
-            (fs/create-path-directories! dir-path)
+            (path/create-directories! dir-path)
             (future/then (reload-resources!) rt/and-refresh-context)
             (catch FileAlreadyExistsException e
               (throw (LuaError. (str "File already exists: " (.getMessage e)))))
@@ -240,10 +240,9 @@
           proj-path (rt/->clj rt graph/resource-path-coercer lua-proj-path)
           workspace (project/workspace project evaluation-context)
           root-path (-> (workspace/project-directory basis workspace)
-                        (fs/real-path))
+                        (path/real-path))
           dir-path (-> (str root-path proj-path)
-                       (fs/as-path)
-                       (.normalize))
+                       (path/normalized-path))
           protected-paths (mapv #(.resolve root-path ^String %)
                                 [".git"
                                  ".internal"])
@@ -274,9 +273,9 @@
     (let [^String path-str (rt/->clj rt coerce/string lua-path)
           path (.normalize (.resolve project-path path-str))]
       (future/io
-        (if (fs/path-exists? path)
-          (let [attrs (fs/path-attributes path)]
-            {:path (str (.toRealPath path fs/empty-link-option-array))
+        (if (path/exists? path)
+          (let [attrs (path/attributes path)]
+            {:path (str (path/real-path path))
              :exists true
              :is_file (.isRegularFile attrs)
              :is_directory (.isDirectory attrs)})
@@ -385,7 +384,7 @@
   (rt/suspendable-lua-fn ext-remove-file [{:keys [rt]} lua-file-name]
     (let [file-name (rt/->clj rt coerce/string lua-file-name)
           file-path (ensure-file-path-in-project-directory project-path file-name)]
-      (when-not (Files/exists file-path fs/empty-link-option-array)
+      (when-not (path/exists? file-path)
         (throw (LuaError. (str "No such file or directory: " file-name))))
       (Files/delete file-path)
       (future/then (reload-resources!) rt/and-refresh-context))))

--- a/editor/src/clj/editor/editor_extensions/ui_components.clj
+++ b/editor/src/clj/editor/editor_extensions/ui_components.clj
@@ -863,11 +863,11 @@
            initial-path (.normalize (.resolve project-path path))
            [^Path initial-directory-path initial-file-name]
            (if (path/exists? initial-path)
-             (if (path/existing-directory? initial-path)
+             (if (path/directory? initial-path)
                [initial-path nil]
                [(.getParent initial-path) (str (.getFileName initial-path))])
              (let [parent-path (.getParent initial-path)]
-               (if (path/existing-directory? parent-path)
+               (if (path/directory? parent-path)
                  [parent-path (str (.getFileName initial-path))]
                  [project-path nil])))
            dialog (doto (FileChooser.)
@@ -916,7 +916,7 @@
            resolved-path (.normalize (.resolve project-path path))
            ^Path initial-path (cond
                                 (not (path/exists? resolved-path)) project-path
-                                (path/existing-directory? resolved-path) resolved-path
+                                (path/directory? resolved-path) resolved-path
                                 :else (.getParent resolved-path))
            dialog (doto (DirectoryChooser.)
                     (.setTitle (localization title))

--- a/editor/src/clj/editor/editor_extensions/ui_components.clj
+++ b/editor/src/clj/editor/editor_extensions/ui_components.clj
@@ -49,7 +49,8 @@
             [editor.workspace :as workspace]
             [internal.util :as iutil]
             [util.coll :as coll :refer [pair]]
-            [util.fn :as fn])
+            [util.fn :as fn]
+            [util.path :as path])
   (:import [com.defold.editor.luart DefoldLuaFn]
            [java.net URI URISyntaxException]
            [java.nio.file Path]
@@ -861,12 +862,12 @@
             :or {title default-select-external-file-dialog-title-message path "."}} opts
            initial-path (.normalize (.resolve project-path path))
            [^Path initial-directory-path initial-file-name]
-           (if (fs/path-exists? initial-path)
-             (if (fs/path-is-directory? initial-path)
+           (if (path/exists? initial-path)
+             (if (path/existing-directory? initial-path)
                [initial-path nil]
                [(.getParent initial-path) (str (.getFileName initial-path))])
              (let [parent-path (.getParent initial-path)]
-               (if (fs/path-is-directory? parent-path)
+               (if (path/existing-directory? parent-path)
                  [parent-path (str (.getFileName initial-path))]
                  [project-path nil])))
            dialog (doto (FileChooser.)
@@ -914,8 +915,8 @@
             :or {title default-select-external-directory-dialog-title-message path "."}} opts
            resolved-path (.normalize (.resolve project-path path))
            ^Path initial-path (cond
-                                (not (fs/path-exists? resolved-path)) project-path
-                                (fs/path-is-directory? resolved-path) resolved-path
+                                (not (path/exists? resolved-path)) project-path
+                                (path/existing-directory? resolved-path) resolved-path
                                 :else (.getParent resolved-path))
            dialog (doto (DirectoryChooser.)
                     (.setTitle (localization title))

--- a/editor/src/clj/editor/editor_extensions/zip.clj
+++ b/editor/src/clj/editor/editor_extensions/zip.clj
@@ -120,7 +120,7 @@
              (let [output-path (.normalize (.resolve project-path archive-path))]
                (cond
                  (not (path/exists? output-path)) (path/create-parent-directories! output-path)
-                 (path/existing-directory? output-path) (throw (LuaError. (str "Output path is a directory: " archive-path)))
+                 (path/directory? output-path) (throw (LuaError. (str "Output path is a directory: " archive-path)))
                  :else (path/delete! output-path))
                (with-open [zos (ZipArchiveOutputStream. (.toFile output-path))]
                  (run!
@@ -129,12 +129,12 @@
                            source-str ^String (get entry 1)
                            source (doto (.resolve project-path source-str) validate-entry-source-path!)
                            target-str (get entry 2 source-str)
-                           target (doto (path/normalized-path target-str) validate-entry-target-path!)
+                           target (doto (path/normalized target-str) validate-entry-target-path!)
                            method (method-enum->value (:method entry) default-method)
                            level (:level entry default-level)]
                        (.setMethod zos method)
                        (.setLevel zos level)
-                       (if (path/existing-directory? source)
+                       (if (path/directory? source)
                          (run! (fn pack-file [^Path file-path]
                                  (write-file! zos file-path (.resolve target (.relativize source file-path))))
                                (path/tree-walker source))
@@ -152,7 +152,7 @@
                            #(pos? (count %)) "at least one option is required")
                 :paths :? (coerce/vector-of
                             (-> coerce/string
-                                (coerce/wrap-transform path/normalized-path)
+                                (coerce/wrap-transform path/normalized)
                                 (coerce/wrap-with-pred #(not (.startsWith ^Path % "..")) "is above root")
                                 (coerce/wrap-with-pred #(not (absolute-path? %)) "is absolute")
                                 (coerce/wrap-transform #(FilenameUtils/separatorsToUnix (str %)))
@@ -172,7 +172,7 @@
                                       (.getParent archive-path))]
               (cond
                 (not (path/exists? archive-path)) (throw (LuaError. (str "Archive path does not exist: " archive-path)))
-                (path/existing-directory? archive-path) (throw (LuaError. (str "Archive path is a directory: " archive-path))))
+                (path/directory? archive-path) (throw (LuaError. (str "Archive path is a directory: " archive-path))))
               (with-open [zip (ZipFile. (.toFile archive-path))]
                 (let [entries (.getEntries zip)]
                   (while (.hasMoreElements entries)
@@ -186,7 +186,7 @@
                                                           (= \/ (.charAt entry-path-str (.length s)))
                                                           (.startsWith entry-path-str s))))
                                                paths))
-                            (let [target-relative-path (path/normalized-path entry-path-str)]
+                            (let [target-relative-path (path/normalized entry-path-str)]
                               (when-not paths
                                 ;; when we have paths, we only allow the valid
                                 ;; ones already; if we don't have paths, we need
@@ -196,7 +196,7 @@
                                 (when (or (not (path/exists? target))
                                           (case (:on_conflict opts)
                                             :skip false
-                                            :overwrite (if (path/existing-directory? target)
+                                            :overwrite (if (path/directory? target)
                                                          (throw (LuaError. (str "Can't overwrite directory: " target)))
                                                          true)
                                             :error (throw (LuaError. (str "Path already exists: " target)))))

--- a/editor/src/clj/editor/editor_extensions/zip.clj
+++ b/editor/src/clj/editor/editor_extensions/zip.clj
@@ -17,14 +17,14 @@
             [clojure.string :as string]
             [editor.editor-extensions.coerce :as coerce]
             [editor.editor-extensions.runtime :as rt]
-            [editor.fs :as fs]
             [editor.future :as future]
             [editor.os :as os]
-            [util.coll :as coll])
+            [util.coll :as coll]
+            [util.path :as path])
   (:import [java.nio.file Files Path]
            [java.nio.file.attribute PosixFilePermission]
            [java.util EnumSet]
-           [org.apache.commons.compress.archivers.zip ZipArchiveEntry ZipArchiveOutputStream ZipFile ZipArchiveInputStream]
+           [org.apache.commons.compress.archivers.zip ZipArchiveEntry ZipArchiveOutputStream ZipFile]
            [org.apache.commons.io FilenameUtils]
            [org.luaj.vm2 LuaError LuaValue]))
 
@@ -53,7 +53,7 @@
    :stored ZipArchiveOutputStream/STORED})
 
 (defn- validate-entry-source-path! [p]
-  (when-not (fs/path-exists? p)
+  (when-not (path/exists? p)
     (throw (LuaError. (str "Source path does not exist: " p)))))
 
 (defn- absolute-path? [^Path p]
@@ -82,7 +82,7 @@
    (coll/pair PosixFilePermission/OTHERS_EXECUTE 0001)])
 
 (defn- get-unix-mode [^Path source]
-  (let [permissions (Files/getPosixFilePermissions source fs/empty-link-option-array)]
+  (let [permissions (path/posix-file-permissions source)]
     (transduce (map #(if (.contains permissions (key %)) (val %) 0)) + 0 permission-bits)))
 
 (defn- get-permissions [unix-mode]
@@ -100,8 +100,8 @@
       zos
       (doto (ZipArchiveEntry. entry-name)
         (cond-> (not (os/is-win32?)) (.setUnixMode (get-unix-mode source)))
-        (.setSize (fs/path-size source))
-        (.setTime (fs/path-last-modified-time source))))
+        (.setSize (path/byte-size source))
+        (.setTime (path/last-modified-ms source))))
     (with-open [is (io/input-stream source)]
       (io/copy is zos))
     (.closeArchiveEntry zos)))
@@ -119,9 +119,9 @@
        (-> (future/io
              (let [output-path (.normalize (.resolve project-path archive-path))]
                (cond
-                 (not (fs/path-exists? output-path)) (fs/make-path-parents output-path)
-                 (fs/path-is-directory? output-path) (throw (LuaError. (str "Output path is a directory: " archive-path)))
-                 :else (fs/delete-path-file! output-path))
+                 (not (path/exists? output-path)) (path/create-parent-directories! output-path)
+                 (path/existing-directory? output-path) (throw (LuaError. (str "Output path is a directory: " archive-path)))
+                 :else (path/delete! output-path))
                (with-open [zos (ZipArchiveOutputStream. (.toFile output-path))]
                  (run!
                    (fn pack-entry [entry]
@@ -129,15 +129,15 @@
                            source-str ^String (get entry 1)
                            source (doto (.resolve project-path source-str) validate-entry-source-path!)
                            target-str (get entry 2 source-str)
-                           target (doto (.normalize (fs/path target-str)) validate-entry-target-path!)
+                           target (doto (path/normalized-path target-str) validate-entry-target-path!)
                            method (method-enum->value (:method entry) default-method)
                            level (:level entry default-level)]
                        (.setMethod zos method)
                        (.setLevel zos level)
-                       (if (fs/path-is-directory? source)
+                       (if (path/existing-directory? source)
                          (run! (fn pack-file [^Path file-path]
                                  (write-file! zos file-path (.resolve target (.relativize source file-path))))
-                               (fs/path-walker source))
+                               (path/tree-walker source))
                          (write-file! zos source target))))
                    entries))))
            (future/then (fn [_] (reload-resources!)))
@@ -152,7 +152,7 @@
                            #(pos? (count %)) "at least one option is required")
                 :paths :? (coerce/vector-of
                             (-> coerce/string
-                                (coerce/wrap-transform #(.normalize (fs/path %)))
+                                (coerce/wrap-transform path/normalized-path)
                                 (coerce/wrap-with-pred #(not (.startsWith ^Path % "..")) "is above root")
                                 (coerce/wrap-with-pred #(not (absolute-path? %)) "is absolute")
                                 (coerce/wrap-transform #(FilenameUtils/separatorsToUnix (str %)))
@@ -171,8 +171,8 @@
                                       (.resolve project-path target-path)
                                       (.getParent archive-path))]
               (cond
-                (not (fs/path-exists? archive-path)) (throw (LuaError. (str "Archive path does not exist: " archive-path)))
-                (fs/path-is-directory? archive-path) (throw (LuaError. (str "Archive path is a directory: " archive-path))))
+                (not (path/exists? archive-path)) (throw (LuaError. (str "Archive path does not exist: " archive-path)))
+                (path/existing-directory? archive-path) (throw (LuaError. (str "Archive path is a directory: " archive-path))))
               (with-open [zip (ZipFile. (.toFile archive-path))]
                 (let [entries (.getEntries zip)]
                   (while (.hasMoreElements entries)
@@ -186,21 +186,21 @@
                                                           (= \/ (.charAt entry-path-str (.length s)))
                                                           (.startsWith entry-path-str s))))
                                                paths))
-                            (let [target-relative-path (.normalize (fs/path entry-path-str))]
+                            (let [target-relative-path (path/normalized-path entry-path-str)]
                               (when-not paths
                                 ;; when we have paths, we only allow the valid
                                 ;; ones already; if we don't have paths, we need
                                 ;; to validate them separately
                                 (validate-entry-target-path! target-relative-path))
                               (let [target (.resolve target-path target-relative-path)]
-                                (when (or (not (fs/path-exists? target))
+                                (when (or (not (path/exists? target))
                                           (case (:on_conflict opts)
                                             :skip false
-                                            :overwrite (if (fs/path-is-directory? target)
+                                            :overwrite (if (path/existing-directory? target)
                                                          (throw (LuaError. (str "Can't overwrite directory: " target)))
                                                          true)
                                             :error (throw (LuaError. (str "Path already exists: " target)))))
-                                  (fs/create-path-parent-directories! target)
+                                  (path/create-parent-directories! target)
                                   (with-open [in (.getInputStream zip e)
                                               out (io/output-stream target)]
                                     (io/copy in out))

--- a/editor/src/clj/editor/fs.clj
+++ b/editor/src/clj/editor/fs.clj
@@ -602,7 +602,7 @@
                         (.startsWith url-str "jar:")
                         (let [[file-uri-str entry-path] (string/split (URLDecoder/decode (.getPath url) StandardCharsets/UTF_8) #"!" 2)
                               [file-scheme file-path] (string/split file-uri-str #":" 2)]
-                          (with-open [fs (^[Path Map] FileSystems/newFileSystem (path/path (URI. file-scheme nil file-path nil)) {})]
+                          (with-open [fs (^[Path Map] FileSystems/newFileSystem (path/of (URI. file-scheme nil file-path nil)) {})]
                             (reduce (coll/preserving-reduced f) acc (path/tree-walker (.getPath fs entry-path empty-string-array)))))
 
                         :else

--- a/editor/src/clj/editor/fs.clj
+++ b/editor/src/clj/editor/fs.clj
@@ -15,89 +15,24 @@
 (ns editor.fs
   (:require [clojure.java.io :as io]
             [clojure.string :as string]
-            [util.coll :as coll])
+            [util.coll :as coll]
+            [util.path :as path])
   (:import [clojure.lang IReduceInit]
            [java.awt Desktop Desktop$Action]
-           [java.io BufferedInputStream BufferedOutputStream File FileNotFoundException IOException RandomAccessFile]
+           [java.io File FileNotFoundException IOException RandomAccessFile]
            [java.net URI URL URLDecoder]
            [java.nio.channels OverlappingFileLockException]
-           [java.nio.charset Charset StandardCharsets]
-           [java.nio.file AccessDeniedException CopyOption FileAlreadyExistsException FileSystems FileVisitResult FileVisitor Files LinkOption NoSuchFileException NotDirectoryException OpenOption Path SimpleFileVisitor StandardCopyOption StandardOpenOption]
-           [java.nio.file.attribute BasicFileAttributes FileAttribute FileTime]
+           [java.nio.charset StandardCharsets]
+           [java.nio.file AccessDeniedException CopyOption FileAlreadyExistsException FileSystems FileVisitResult Files LinkOption NotDirectoryException OpenOption Path SimpleFileVisitor StandardCopyOption StandardOpenOption]
+           [java.nio.file.attribute BasicFileAttributes FileAttribute]
            [java.util Map UUID]))
 
 (set! *warn-on-reflection* true)
 
 ;; util
 
-(defonce empty-link-option-array (make-array LinkOption 0))
-(defonce ^:private empty-string-array (make-array String 0))
-(defonce ^:private ^"[Ljava.nio.file.OpenOption;" append-open-options (into-array OpenOption [StandardOpenOption/WRITE StandardOpenOption/CREATE StandardOpenOption/APPEND]))
-(defonce ^:private ^"[Ljava.nio.file.OpenOption;" overwrite-open-options (into-array OpenOption [StandardOpenOption/WRITE StandardOpenOption/CREATE StandardOpenOption/TRUNCATE_EXISTING]))
-
-(defprotocol PathCoercions
-  "Convert to Path objects."
-  (^Path as-path [this] "Coerce argument to a Path."))
-
-(extend-protocol PathCoercions
-  nil
-  (as-path [_this] nil)
-
-  File
-  (as-path [this] (.toPath this))
-
-  Path
-  (as-path [this] this)
-
-  URI
-  (as-path [this] (Path/of this))
-
-  URL
-  (as-path [this] (as-path (.toURI this)))
-
-  String
-  (as-path [this] (Path/of this empty-string-array)))
-
-(extend-protocol io/IOFactory
-  Path
-  (make-reader [x opts]
-    (Files/newBufferedReader x (or (some-> (:encoding opts) Charset/forName)
-                                   StandardCharsets/UTF_8)))
-  (make-writer [x opts]
-    (Files/newBufferedWriter
-      x
-      (or (some-> (:encoding opts) Charset/forName)
-          StandardCharsets/UTF_8)
-      (if (:append opts)
-        append-open-options
-        overwrite-open-options)))
-  (make-input-stream [x _]
-    (BufferedInputStream.
-      (Files/newInputStream x empty-link-option-array)))
-  (make-output-stream [x opts]
-    (BufferedOutputStream.
-      (Files/newOutputStream
-        x
-        (if (:append opts)
-          append-open-options
-          overwrite-open-options)))))
-
-(defn path
-  (^Path [x]
-   (as-path x))
-  (^Path [parent child]
-   (let [child-path ^Path (as-path child)]
-     (if (.isAbsolute child-path)
-       (throw (IllegalArgumentException. (str child " is not a relative path")))
-       (.resolve ^Path (as-path parent) child-path))))
-  (^Path [parent child & children]
-   (reduce path (path parent child) children)))
-
-(defn real-path
-  "Returns the canonical, real path to an existing file system entry. Throws an
-  IOException if there was no matching entry in the file system."
-  ^Path [p & ps]
-  (.toRealPath ^Path (apply path p ps) empty-link-option-array))
+(defonce ^:private ^String/1 empty-string-array (make-array String 0))
+(defonce ^:private ^OpenOption/1 overwrite-open-options (into-array OpenOption [StandardOpenOption/WRITE StandardOpenOption/CREATE StandardOpenOption/TRUNCATE_EXISTING]))
 
 (defn with-leading-slash
   ^String [^String path]
@@ -113,14 +48,6 @@
 
 (defn to-folder ^File [^File file]
   (if (.isFile file) (.getParentFile file) file))
-
-(defn- same-path? [^Path src ^Path tgt]
-  (try (Files/isSameFile src tgt)
-       (catch NoSuchFileException _
-         false)))
-
-(defn same-file? [^File file1 ^File file2]
-  (same-path? (.toPath file1) (.toPath file2)))
 
 (defn set-executable! [^File target executable]
   (.setExecutable target executable))
@@ -334,26 +261,21 @@
 
 ;; create directories, files
 
-(defn create-path-directories!
-  "Creates the directory path up to and including directory. Returns the directory as Path."
-  ^Path [^Path path]
-  (Files/createDirectories path empty-file-attrs))
-
 (defn create-directories!
   "Creates the directory path up to and including directory. Returns the directory as File."
-  ^File [^File directory]
-  (.toFile (create-path-directories! (.toPath directory))))
+  ^File [directory]
+  (.toFile (path/create-directories! directory)))
 
 (defn create-parent-directories!
-  "Creates the directory path (if any) up to the parent directory of file. Returns the parent directory."
-  ^File [^File file]
-  (when-let [parent (.getParentFile file)]
-    (create-directories! parent)))
+  "Creates the directory path (if any) up to the parent directory of file. Returns nil."
+  [file]
+  (path/create-parent-directories! file)
+  nil)
 
 (defn create-directory!
   "Creates a directory assuming all parent directories are in place. Returns the directory."
-  ^File [^File directory]
-  (.toFile (Files/createDirectory (.toPath directory) empty-file-attrs)))
+  ^File [directory]
+  (.toFile (path/create-directory! directory)))
 
 (def ^:private ^"[Ljava.nio.file.LinkOption;" no-follow-link-options (into-array LinkOption [LinkOption/NOFOLLOW_LINKS]))
 
@@ -396,7 +318,7 @@
   (let [lower-file (io/file (io/file fs-temp-dir "casetest"))
         upper-file (io/file (io/file fs-temp-dir "CASETEST"))]
     (touch-file! lower-file)
-    (not (same-path? (.toPath lower-file) (.toPath upper-file)))))
+    (not (path/same? lower-file upper-file))))
 
 (defn- comparable-path
   ^String [entry]
@@ -472,7 +394,7 @@
   (let [src-path (.toPath src)
         tgt-path (.toPath tgt)
         copy-options (if (= target :replace) replace-move-options keep-move-options)]
-    (if-not (same-path? src-path tgt-path)
+    (if-not (path/same? src-path tgt-path)
       (do (when-not (= target :keep)
             (delete! tgt))
           (create-parent-directories! tgt)
@@ -525,7 +447,7 @@
   (let [src-path (.toPath src)
         tgt-path (.toPath tgt)
         copy-options (if (= target :replace) replace-copy-options keep-copy-options)]
-    (if (same-path? src-path tgt-path)
+    (if (path/same? src-path tgt-path)
       [[src src]] ; nop - NB [src src] because no case-change is performed on a fs that determines (same-path? src tgt)
       (do (when-not (= target :keep)
             (delete! tgt))
@@ -570,13 +492,13 @@
       FileVisitResult/CONTINUE)))
 
 (defn- copy-tree! [^Path source-path ^Path target-path]
-  (create-parent-directories! (.toFile target-path))
+  (path/create-parent-directories! target-path)
   (Files/walkFileTree source-path (make-tree-copier source-path target-path)))
 
 (defn- do-copy-directory! [^File src ^File tgt {:keys [target]}]
   (let [src-path (.toPath src)
         tgt-path (.toPath tgt)]
-    (if (same-path? src-path tgt-path)
+    (if (path/same? src-path tgt-path)
       [[src src]]
       (do
         (case target
@@ -665,48 +587,6 @@
   ^bytes [^File src]
   (Files/readAllBytes (.toPath src)))
 
-(defn path-walker
-  "Given a directory Path, returns a reducible that walks over all file Paths in
-  the dir, recursively. The optional dir-path-pred should take a directory Path,
-  and return true if the walk should recurse into the directory."
-  ([^Path dir-path]
-   (path-walker dir-path nil))
-  ([^Path dir-path dir-path-pred]
-   {:pre [(instance? Path dir-path)
-          (or (nil? dir-path-pred) (ifn? dir-path-pred))]}
-   (reify IReduceInit
-     (reduce [_ f init]
-       (let [acc-vol (volatile! init)]
-         (Files/walkFileTree
-           dir-path
-           (reify FileVisitor
-             (preVisitDirectory [_ path _]
-               (cond
-                 (nil? dir-path-pred)
-                 FileVisitResult/CONTINUE
-
-                 (dir-path-pred path)
-                 FileVisitResult/CONTINUE
-
-                 :else
-                 FileVisitResult/SKIP_SUBTREE))
-
-             (visitFile [_ path _]
-               (let [acc (vswap! acc-vol f path)]
-                 (if (reduced? acc)
-                   FileVisitResult/TERMINATE
-                   FileVisitResult/CONTINUE)))
-
-             (visitFileFailed [_ _ exception]
-               (throw exception))
-
-             (postVisitDirectory [_ _ exception]
-               (if exception
-                 (throw exception)
-                 FileVisitResult/CONTINUE))))
-
-         (unreduced @acc-vol))))))
-
 (defn class-path-walker [^ClassLoader class-loader dir-path]
   (reify IReduceInit
     (reduce [_ f init]
@@ -717,13 +597,13 @@
                   url-str (str url)
                   acc (cond
                         (.startsWith url-str "file:")
-                        (reduce (coll/preserving-reduced f) acc (path-walker (path url)))
+                        (reduce (coll/preserving-reduced f) acc (path/tree-walker url))
 
                         (.startsWith url-str "jar:")
                         (let [[file-uri-str entry-path] (string/split (URLDecoder/decode (.getPath url) StandardCharsets/UTF_8) #"!" 2)
                               [file-scheme file-path] (string/split file-uri-str #":" 2)]
-                          (with-open [fs (^[Path Map] FileSystems/newFileSystem (path (URI. file-scheme nil file-path nil)) {})]
-                            (reduce (coll/preserving-reduced f) acc (path-walker (.getPath fs entry-path empty-string-array)))))
+                          (with-open [fs (^[Path Map] FileSystems/newFileSystem (path/path (URI. file-scheme nil file-path nil)) {})]
+                            (reduce (coll/preserving-reduced f) acc (path/tree-walker (.getPath fs entry-path empty-string-array)))))
 
                         :else
                         (throw (IllegalArgumentException. (str "Unsupported URL scheme: " url))))]
@@ -733,60 +613,22 @@
             acc))))))
 
 (defn file-walker
-  "Given a directory File, returns a reducible that walks over all Files in
-  the dir, recursively."
-  ([^File dir-file include-hidden]
-   (file-walker dir-file include-hidden nil))
-  ([^File dir-file include-hidden ignored-dirnames]
-   {:pre [(instance? File dir-file)
-          (every? string? ignored-dirnames)]}
+  "Given a value that can be coerced into a directory path, returns a reducible
+  that walks over all java.io.Files in the directory, recursively."
+  ([root-dir include-hidden]
+   (file-walker root-dir include-hidden nil))
+  ([root-dir include-hidden ignored-dirnames]
+   {:pre [(every? string? ignored-dirnames)]}
    (->Eduction
-     (cond->> (map #(.toFile ^Path %))
+     (cond->> (map path/to-file)
               (not include-hidden)
-              (comp (remove #(Files/isHidden %))))
+              (comp (remove path/hidden?)))
      (if (and include-hidden
               (coll/empty? ignored-dirnames))
-       (path-walker (.toPath dir-file))
-       (path-walker (.toPath dir-file)
-                    (fn dir-path-pred [^Path dir-path]
-                      (and (not-any? (fn [^String ignored-dirname]
-                                       (.endsWith dir-path ignored-dirname))
-                                     ignored-dirnames)
-                           (or include-hidden
-                               (not (Files/isHidden dir-path))))))))))
-
-(defn path-exists? [path]
-  (Files/exists path empty-link-option-array))
-
-(defn path-is-directory? [path]
-  (Files/isDirectory path empty-link-option-array))
-
-(defn path-attributes
-  ^BasicFileAttributes [path]
-  (Files/readAttributes ^Path path BasicFileAttributes ^"[Ljava.nio.file.LinkOption;" empty-link-option-array))
-
-(defn path? [x]
-  (instance? Path x))
-
-(defn create-path-parent-directories! [^Path path]
-  (when-let [p (.getParent path)]
-    (create-path-directories! p)))
-
-(defn path-last-modified-time
-  ^long [p]
-  (.toMillis (Files/getLastModifiedTime p empty-link-option-array)))
-
-(defn set-path-last-modified-time!
-  [p ^long mtime]
-  (Files/setLastModifiedTime p (FileTime/fromMillis mtime)))
-
-(defn path-size
-  ^long [p]
-  (Files/size p))
-
-(defn make-path-parents [^Path p]
-  (when-let [parent (.getParent p)]
-    (Files/createDirectories parent empty-file-attrs)))
-
-(defn delete-path-file! [p]
-  (Files/delete p))
+       (path/tree-walker root-dir)
+       (path/tree-walker root-dir
+                         (fn dir-path-pred [^Path dir-path]
+                           (and (not-any? #(path/ends-with? dir-path %)
+                                          ignored-dirnames)
+                                (or include-hidden
+                                    (not (path/hidden? dir-path))))))))))

--- a/editor/src/clj/editor/hot_reload.clj
+++ b/editor/src/clj/editor/hot_reload.clj
@@ -14,9 +14,9 @@
 
 (ns editor.hot-reload
   (:require [clojure.string :as string]
-            [editor.fs :as fs]
             [editor.workspace :as workspace]
-            [util.http-server :as http-server])
+            [util.http-server :as http-server]
+            [util.path :as path])
   (:import [java.net URI URISyntaxException]))
 
 (set! *warn-on-reflection* true)
@@ -51,10 +51,9 @@
     {"/build/{*path}"
      {"GET" (bound-fn [{:keys [path-params headers]}]
               (let [^String path (:path path-params)
-                    full-path (.normalize (.resolve build-path path))]
-                (if (and (.startsWith full-path build-path) ;; Avoid going outside the build path with '..'
-                         (fs/path-exists? full-path)
-                         (not (fs/path-is-directory? full-path)))
+                    full-path (path/normalized-path (path/resolve build-path path))]
+                (if (and (path/starts-with? full-path build-path) ;; Avoid going outside the build path with '..'
+                         (path/existing-file? full-path))
                   (let [etag (workspace/etag workspace (str "/" path))
                         remote-etag (get headers "if-none-match")]
                     (if (and remote-etag (= etag remote-etag))

--- a/editor/src/clj/editor/hot_reload.clj
+++ b/editor/src/clj/editor/hot_reload.clj
@@ -51,9 +51,9 @@
     {"/build/{*path}"
      {"GET" (bound-fn [{:keys [path-params headers]}]
               (let [^String path (:path path-params)
-                    full-path (path/normalized-path (path/resolve build-path path))]
+                    full-path (path/normalized (path/resolve build-path path))]
                 (if (and (path/starts-with? full-path build-path) ;; Avoid going outside the build path with '..'
-                         (path/existing-file? full-path))
+                         (path/file? full-path))
                   (let [etag (workspace/etag workspace (str "/" path))
                         remote-etag (get headers "if-none-match")]
                     (if (and remote-etag (= etag remote-etag))

--- a/editor/src/clj/editor/localization.clj
+++ b/editor/src/clj/editor/localization.clj
@@ -26,7 +26,8 @@
             [internal.util :as util]
             [util.coll :as coll]
             [util.defonce :as defonce]
-            [util.eduction :as e])
+            [util.eduction :as e]
+            [util.path :as path])
   (:import [clojure.lang AFn Agent IFn IRef]
            [com.defold.editor.localization MessagePattern]
            [com.ibm.icu.text DateFormat ListFormatter ListFormatter$Type ListFormatter$Width LocaleDisplayNames MessageFormat]
@@ -382,14 +383,14 @@
                      ;; the zip file), but the actual reading is done later,
                      ;; during reload. Converting path to a URL allows reading
                      ;; from the zip file later.
-                     (let [url (.toURL (.toUri (fs/path path)))]
+                     (let [url (.toURL (.toUri (path/path path)))]
                        #(io/reader url))))))]
     (let [resource-dir "localization"
           localization (make prefs ::editor (get-bundle resource-dir))]
       (when (system/defold-dev?)
         (let [url (io/resource resource-dir)]
           (when (.startsWith (str url) "file:")
-            (let [resource-path (fs/path url)
+            (let [resource-path (path/path url)
                   watch-service (.newWatchService (.getFileSystem resource-path))]
               (.register resource-path watch-service (into-array WatchEvent$Kind [StandardWatchEventKinds/ENTRY_CREATE
                                                                                   StandardWatchEventKinds/ENTRY_DELETE

--- a/editor/src/clj/editor/localization.clj
+++ b/editor/src/clj/editor/localization.clj
@@ -383,14 +383,14 @@
                      ;; the zip file), but the actual reading is done later,
                      ;; during reload. Converting path to a URL allows reading
                      ;; from the zip file later.
-                     (let [url (.toURL (.toUri (path/path path)))]
+                     (let [url (.toURL (.toUri (path/of path)))]
                        #(io/reader url))))))]
     (let [resource-dir "localization"
           localization (make prefs ::editor (get-bundle resource-dir))]
       (when (system/defold-dev?)
         (let [url (io/resource resource-dir)]
           (when (.startsWith (str url) "file:")
-            (let [resource-path (path/path url)
+            (let [resource-path (path/of url)
                   watch-service (.newWatchService (.getFileSystem resource-path))]
               (.register resource-path watch-service (into-array WatchEvent$Kind [StandardWatchEventKinds/ENTRY_CREATE
                                                                                   StandardWatchEventKinds/ENTRY_DELETE

--- a/editor/src/clj/editor/lsp/server.clj
+++ b/editor/src/clj/editor/lsp/server.clj
@@ -31,7 +31,8 @@
             [editor.workspace :as workspace]
             [service.log :as log]
             [util.coll :as coll]
-            [util.eduction :as e])
+            [util.eduction :as e]
+            [util.path :as path])
   (:import [editor.code.data Cursor CursorRange]
            [java.io File InputStream]
            [java.lang ProcessBuilder$Redirect ProcessHandle]
@@ -267,7 +268,7 @@
                :diagnostics {:globals (-> lua/defined-globals
                                           (into (lua/extract-globals-from-completions completions))
                                           (into (lua/extract-globals-from-completions lua/editor-completions)))}
-               :workspace {:library [(str (fs/path root ".internal" "lua-annotations"))]}})
+               :workspace {:library [(str (path/path root ".internal" "lua-annotations"))]}})
 
             "files.associations"
             (let [workspace (g/node-value project :workspace evaluation-context)

--- a/editor/src/clj/editor/lsp/server.clj
+++ b/editor/src/clj/editor/lsp/server.clj
@@ -268,7 +268,7 @@
                :diagnostics {:globals (-> lua/defined-globals
                                           (into (lua/extract-globals-from-completions completions))
                                           (into (lua/extract-globals-from-completions lua/editor-completions)))}
-               :workspace {:library [(str (path/path root ".internal" "lua-annotations"))]}})
+               :workspace {:library [(str (path/of root ".internal" "lua-annotations"))]}})
 
             "files.associations"
             (let [workspace (g/node-value project :workspace evaluation-context)

--- a/editor/src/clj/editor/pipeline/bob.clj
+++ b/editor/src/clj/editor/pipeline/bob.clj
@@ -295,6 +295,6 @@
                                           (.resolve ^String path-str)
                                           (.normalize))]
                     (if (and (.startsWith resource-path output-path)
-                             (path/existing-file? resource-path))
+                             (path/file? resource-path))
                       (http-server/response 200 resource-path)
                       http-server/not-found)))))}}))

--- a/editor/src/clj/editor/pipeline/bob.clj
+++ b/editor/src/clj/editor/pipeline/bob.clj
@@ -20,7 +20,6 @@
             [editor.engine.build-errors :as engine-build-errors]
             [editor.engine.native-extensions :as native-extensions]
             [editor.error-reporting :as error-reporting]
-            [editor.fs :as fs]
             [editor.localization :as localization]
             [editor.prefs :as prefs]
             [editor.progress :as progress]
@@ -32,7 +31,8 @@
             [service.log :as log]
             [util.coll :as coll]
             [util.fn :as fn]
-            [util.http-server :as http-server])
+            [util.http-server :as http-server]
+            [util.path :as path])
   (:import [com.dynamo.bob Bob Bob$CommandLineOption Bob$CommandLineOption$ArgCount Bob$CommandLineOption$ArgType IProgress IProgress$Task TaskResult]
            [com.dynamo.bob.logging LogHelper]
            [java.io File OutputStream PrintStream PrintWriter]
@@ -295,7 +295,6 @@
                                           (.resolve ^String path-str)
                                           (.normalize))]
                     (if (and (.startsWith resource-path output-path)
-                             (fs/path-exists? resource-path)
-                             (not (fs/path-is-directory? resource-path)))
+                             (path/existing-file? resource-path))
                       (http-server/response 200 resource-path)
                       http-server/not-found)))))}}))

--- a/editor/src/clj/editor/prefs.clj
+++ b/editor/src/clj/editor/prefs.clj
@@ -705,7 +705,7 @@
     :parent     a parent preferences map, defines initial scopes and schemas"
   [& {:keys [scopes schemas parent]}]
   {:post [(s/assert ::preferences %)]}
-  (let [scopes (coll/pair-map-by key #(-> % val path/absolute-path (doto ensure-loaded!)) scopes)
+  (let [scopes (coll/pair-map-by key #(-> % val path/absolute (doto ensure-loaded!)) scopes)
         scopes (cond->> (or scopes {}) parent (conj (:scopes parent)))
         schemas (into [] (comp cat (distinct)) [(:schemas parent) schemas])]
     {:scopes scopes
@@ -791,7 +791,7 @@
 
   Any attempt to get project-scoped values will return defaults"
   ([]
-   (global (path/path
+   (global (path/of
              (case (os/os)
                :macos (fs/evaluate-path "~/Library/Preferences")
                :linux (some fs/evaluate-path ["$XDG_CONFIG_HOME" "~/.config"])
@@ -810,9 +810,9 @@
   ([project-path]
    (project project-path (global)))
   ([project-path parent-prefs]
-   (let [real-path (path/real-path project-path)]
+   (let [real-path (path/real project-path)]
      (make :parent parent-prefs
-           :scopes {:project (path/path real-path ".editor_settings")}
+           :scopes {:project (path/of real-path ".editor_settings")}
            :schemas [real-path]))))
 
 (defn register-project-schema!
@@ -820,7 +820,7 @@
 
   Uses real path of the project root of the project root as a schema id"
   [project-path schema]
-  (register-schema! (path/real-path project-path) schema))
+  (register-schema! (path/real project-path) schema))
 
 (defn sync!
   "Immediately write all unsaved preference changes into files"

--- a/editor/src/clj/editor/prefs.clj
+++ b/editor/src/clj/editor/prefs.clj
@@ -66,7 +66,8 @@
             [util.coll :as coll]
             [util.crypto :as crypto]
             [util.eduction :as e]
-            [util.fn :as fn])
+            [util.fn :as fn]
+            [util.path :as path])
   (:import [java.io ByteArrayInputStream PushbackReader]
            [java.nio.charset StandardCharsets]
            [java.nio.file Path]
@@ -385,7 +386,7 @@
 (s/def ::values (s/coll-of any? :min-count 1 :kind vector?))
 (defmethod type-spec :enum [_] (s/keys :req-un [::values]))
 
-(s/def ::scopes (s/map-of ::scope fs/path? :min-count 1))
+(s/def ::scopes (s/map-of ::scope path/path? :min-count 1))
 (s/def ::schemas (s/coll-of any? :kind vector? :distinct true :min-count 1))
 (s/def ::preferences (s/keys :req-un [::scopes ::schemas]))
 
@@ -394,7 +395,7 @@
 ;; region internal global state
 
 (defn- read-config! [path]
-  (if (fs/path-exists? path)
+  (if (path/exists? path)
     (with-open [rdr (PushbackReader. (io/reader path))]
       (try
         (edn/read {:default fn/constantly-nil} rdr)
@@ -406,7 +407,7 @@
     ::not-found))
 
 (defn- write-config! [path config]
-  (fs/create-path-parent-directories! path)
+  (path/create-parent-directories! path)
   (with-open [w (io/writer path)]
     (letfn [(write-contents-indented! [prefix suffix xs indent]
               (let [child-indent (+ indent 2)
@@ -704,7 +705,7 @@
     :parent     a parent preferences map, defines initial scopes and schemas"
   [& {:keys [scopes schemas parent]}]
   {:post [(s/assert ::preferences %)]}
-  (let [scopes (coll/pair-map-by key #(-> % val fs/path .toAbsolutePath (doto ensure-loaded!)) scopes)
+  (let [scopes (coll/pair-map-by key #(-> % val path/absolute-path (doto ensure-loaded!)) scopes)
         scopes (cond->> (or scopes {}) parent (conj (:scopes parent)))
         schemas (into [] (comp cat (distinct)) [(:schemas parent) schemas])]
     {:scopes scopes
@@ -790,7 +791,7 @@
 
   Any attempt to get project-scoped values will return defaults"
   ([]
-   (global (fs/path
+   (global (path/path
              (case (os/os)
                :macos (fs/evaluate-path "~/Library/Preferences")
                :linux (some fs/evaluate-path ["$XDG_CONFIG_HOME" "~/.config"])
@@ -809,9 +810,9 @@
   ([project-path]
    (project project-path (global)))
   ([project-path parent-prefs]
-   (let [real-path (fs/real-path project-path)]
+   (let [real-path (path/real-path project-path)]
      (make :parent parent-prefs
-           :scopes {:project (fs/path real-path ".editor_settings")}
+           :scopes {:project (path/path real-path ".editor_settings")}
            :schemas [real-path]))))
 
 (defn register-project-schema!
@@ -819,7 +820,7 @@
 
   Uses real path of the project root of the project root as a schema id"
   [project-path schema]
-  (register-schema! (fs/real-path project-path) schema))
+  (register-schema! (path/real-path project-path) schema))
 
 (defn sync!
   "Immediately write all unsaved preference changes into files"

--- a/editor/src/clj/editor/resource.clj
+++ b/editor/src/clj/editor/resource.clj
@@ -25,6 +25,7 @@
             [util.digest :as digest]
             [util.fn :as fn]
             [util.http-server :as http-server]
+            [util.path :as path]
             [util.text-util :as text-util])
   (:import [clojure.lang PersistentHashMap]
            [com.defold.editor Editor]
@@ -310,11 +311,14 @@
   io/Coercions
   (as-file [this] (File. abs-path))
 
+  path/Coercions
+  (as-path [_this] (path/as-path abs-path))
+
   http-server/ContentType
   (content-type [resource] (content-type resource))
 
   http-server/->Data
-  (->data [_] (fs/path abs-path)))
+  (->data [_] (path/as-path abs-path)))
 
 (defn make-file-resource [workspace ^String root-path ^File file children editable-proj-path? unloaded-proj-path?]
   {:pre [(g/node-id? workspace)
@@ -442,6 +446,9 @@
 
   io/Coercions
   (as-file [this] (io/as-file zip-uri))
+
+  path/Coercions
+  (as-path [_this] (path/as-path zip-uri))
 
   http-server/ContentType
   (content-type [resource] (content-type resource))

--- a/editor/src/clj/editor/workspace.clj
+++ b/editor/src/clj/editor/workspace.clj
@@ -41,7 +41,8 @@ ordinary paths."
             [util.coll :as coll :refer [pair]]
             [util.digest :as digest]
             [util.eduction :as e]
-            [util.fn :as fn])
+            [util.fn :as fn]
+            [util.path :as path])
   (:import [clojure.lang DynamicClassLoader]
            [editor.resource FileResource]
            [com.dynamo.bob Platform]
@@ -140,7 +141,10 @@ ordinary paths."
   (make-writer [this opts] (io/make-writer (io/make-output-stream this opts) opts))
 
   io/Coercions
-  (as-file [this] (File. (resource/abs-path this))))
+  (as-file [this] (File. (resource/abs-path this)))
+
+  path/Coercions
+  (as-path [this] (path/as-path (resource/abs-path this))))
 
 (defmethod print-method BuildResource [build-resource ^java.io.Writer w]
   ;; Avoid evaluating resource-type, since it requires a live system. As a

--- a/editor/src/clj/util/http_server.clj
+++ b/editor/src/clj/util/http_server.clj
@@ -21,7 +21,8 @@
             [editor.future :as future]
             [editor.util :as util]
             [reitit.core :as reitit]
-            [service.log :as log])
+            [service.log :as log]
+            [util.path :as path])
   (:import [com.sun.net.httpserver Headers HttpHandler HttpServer]
            [java.io Closeable File IOException]
            [java.net InetSocketAddress URI URL]
@@ -217,7 +218,7 @@
     (format "http://%s:%d" (.getHostString address) (.getPort address))))
 
 (extend-protocol ConnectionContentLength
-  Path (connection-content-length [path] (fs/path-size path))
+  Path (connection-content-length [path] (path/byte-size path))
   Object (connection-content-length [_])
   nil (connection-content-length [_]))
 

--- a/editor/src/clj/util/path.clj
+++ b/editor/src/clj/util/path.clj
@@ -1,0 +1,371 @@
+;; Copyright 2020-2026 The Defold Foundation
+;; Copyright 2014-2020 King
+;; Copyright 2009-2014 Ragnar Svensson, Christian Murray
+;; Licensed under the Defold License version 1.0 (the "License"); you may not use
+;; this file except in compliance with the License.
+;;
+;; You may obtain a copy of the License, together with FAQs at
+;; https://www.defold.com/license
+;;
+;; Unless required by applicable law or agreed to in writing, software distributed
+;; under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+;; CONDITIONS OF ANY KIND, either express or implied. See the License for the
+;; specific language governing permissions and limitations under the License.
+
+(ns util.path
+  (:require [clojure.java.io :as io]
+            [util.defonce :as defonce])
+  (:import [clojure.lang IReduceInit]
+           [java.io BufferedInputStream BufferedOutputStream File]
+           [java.net URI URL]
+           [java.nio.charset Charset StandardCharsets]
+           [java.nio.file FileVisitResult FileVisitor Files LinkOption NoSuchFileException OpenOption Path StandardOpenOption]
+           [java.nio.file.attribute BasicFileAttributes FileAttribute FileTime]
+           [java.util Set]))
+
+(set! *warn-on-reflection* true)
+(set! *unchecked-math* :warn-on-boxed)
+
+(defonce ^:private ^FileAttribute/1 empty-file-attribute-array (make-array FileAttribute 0))
+(defonce ^:private ^LinkOption/1 empty-link-option-array (make-array LinkOption 0))
+(defonce ^:private ^String/1 empty-string-array (make-array String 0))
+(defonce ^:private ^OpenOption/1 append-open-options (into-array OpenOption [StandardOpenOption/WRITE StandardOpenOption/CREATE StandardOpenOption/APPEND]))
+(defonce ^:private ^OpenOption/1 overwrite-open-options (into-array OpenOption [StandardOpenOption/WRITE StandardOpenOption/CREATE StandardOpenOption/TRUNCATE_EXISTING]))
+
+(defonce/protocol Coercions
+  "Convert to Path objects."
+  (^Path as-path [this] "Coerce argument to a Path."))
+
+(extend-protocol Coercions
+  nil
+  (as-path [_this] nil)
+
+  File
+  (as-path [this] (.toPath this))
+
+  Path
+  (as-path [this] this)
+
+  URI
+  (as-path [this] (Path/of this))
+
+  URL
+  (as-path [this] (Path/of (.toURI this)))
+
+  String
+  (as-path [this] (Path/of this empty-string-array)))
+
+(extend-protocol io/Coercions
+  Path
+  (as-file [this] (.toFile this))
+  (as-url [this] (.toURL (.toUri this))))
+
+(extend-protocol io/IOFactory
+  Path
+  (make-reader [this opts]
+    (Files/newBufferedReader
+      this
+      (or (some-> (:encoding opts) Charset/forName)
+          StandardCharsets/UTF_8)))
+  (make-writer [this opts]
+    (Files/newBufferedWriter
+      this
+      (or (some-> (:encoding opts) Charset/forName)
+          StandardCharsets/UTF_8)
+      (if (:append opts)
+        append-open-options
+        overwrite-open-options)))
+  (make-input-stream [this _opts]
+    (BufferedInputStream.
+      (Files/newInputStream this empty-link-option-array)))
+  (make-output-stream [this opts]
+    (BufferedOutputStream.
+      (Files/newOutputStream
+        this
+        (if (:append opts)
+          append-open-options
+          overwrite-open-options)))))
+
+(defn path?
+  "Returns true if the supplied value is a java.nio.file.Path."
+  [value]
+  (instance? Path value))
+
+(defn path
+  "Returns a java.nio.file.Path, passing each argument to as-path. When called
+  with multiple arguments, the first argument is treated as the parent and
+  later arguments as children relative to the parent."
+  (^Path [x]
+   (as-path x))
+  (^Path [parent child]
+   (let [child-path ^Path (as-path child)]
+     (if (.isAbsolute child-path)
+       (throw (IllegalArgumentException. (str child " is not a relative path")))
+       (.resolve ^Path (as-path parent) child-path))))
+  (^Path [parent child & children]
+   (reduce path (path parent child) children)))
+
+(defn normalized-path
+  "Returns a normalized java.nio.file.Path, passing each argument to as-path.
+  When called with multiple arguments, the first argument is treated as the
+  parent and later arguments as children relative to the parent."
+  (^Path [x]
+   (.normalize (as-path x)))
+  (^Path [x & xs]
+   (.normalize ^Path (apply path x xs))))
+
+(defn absolute-path
+  "Returns an absolute java.nio.file.Path, passing each argument to as-path.
+  When called with multiple arguments, the first argument is treated as the
+  parent and later arguments as children relative to the parent."
+  (^Path [x]
+   (.toAbsolutePath (as-path x)))
+  (^Path [x & xs]
+   (.toAbsolutePath ^Path (apply path x xs))))
+
+(defn real-path
+  "Returns the canonical, real path to an existing file system entry. Throws an
+  IOException if there was no matching entry in the file system."
+  (^Path [x]
+   (.toRealPath (as-path x) empty-link-option-array))
+  (^Path [x & xs]
+   (.toRealPath ^Path (apply path x xs) empty-link-option-array)))
+
+(defn to-file
+  "Converts the supplied java.nio.file.Path to a java.io.File. Does not coerce
+  the argument into a Path. Returns nil if called with a nil value."
+  ^File [^Path path]
+  (when path
+    (.toFile path)))
+
+(defn to-uri
+  "Converts the supplied java.nio.file.Path to a java.net.URI. Does not coerce
+  the argument into a Path. Returns nil if called with a nil value."
+  ^URI [^Path path]
+  (when path
+    (.toUri path)))
+
+(defn relativize
+  "Coerces both arguments to java.nio.file.Path and returns a relative Path
+  that, when resolved against this path, yields a path that locates the same
+  file as the other path. For example, on UNIX, if this path is `/a/b` and the
+  other path is `/a/b/c/d`, then the resulting relative path would be `c/d`."
+  ^Path [this other]
+  (.relativize (as-path this) (as-path other)))
+
+(defn resolve
+  "Coerces both arguments to java.nio.file.Path and resolves the other path
+  against this path. If the other parameter is an absolute path, returns its
+  coerced Path. If other is an empty path, returns the Path coerced from the
+  first argument. Otherwise, we consider this path to be a directory and
+  resolve the other path against this path. For example, on UNIX, if this path
+  is `/a/b` and the other path is `../c/d`, then the resulting resolved path would
+  be `/a/c/d`."
+  ^Path [this other]
+  (.resolve (as-path this) (as-path other)))
+
+(defn resolve-sibling
+  "Coerces both arguments to java.nio.file.Path and resolves the other path
+  against this path's parent path. This is useful when a file name needs to be
+  replaced with another file name."
+  ^Path [this other]
+  (.resolveSibling (as-path this) (as-path other)))
+
+(defn root
+  "Coerces the argument to a java.nio.file.Path and returns its root component
+  as a Path, or nil if the path does not have a root component."
+  ^Path [x]
+  (.getRoot (as-path x)))
+
+(defn parent
+  "Coerces the argument to a java.nio.file.Path and returns its parent Path, or
+  nil if the path does not have a parent."
+  ^Path [x]
+  (.getParent (as-path x)))
+
+(defn leaf
+  "Coerces the argument to a java.nio.file.Path and returns its file name as a
+  Path, or nil if the path is empty."
+  ^Path [x]
+  (.getFileName (as-path x)))
+
+(defn byte-size
+  "Coerces the argument to a java.nio.file.Path and returns the byte size of the
+  corresponding file system entry. Beware that the size of entries that are not
+  regular files is implementation-specific."
+  ^long [x]
+  (Files/size (as-path x)))
+
+(defn last-modified-ms
+  "Coerces the argument to a java.nio.file.Path and returns the last modified
+  time of the corresponding file system entry in milliseconds since the UNIX
+  epoch."
+  ^long [x]
+  (.toMillis (Files/getLastModifiedTime (as-path x) empty-link-option-array)))
+
+(defn set-last-modified-ms!
+  "Coerces the argument to a java.nio.file.Path and sets the last modified
+  time of the corresponding file system entry. The time is in milliseconds since
+  the UNIX epoch. Returns the Path."
+  ^Path [x ^long epoch-time]
+  (Files/setLastModifiedTime (as-path x) (FileTime/fromMillis epoch-time)))
+
+(defn attributes
+  "Coerces the argument to a java.nio.file.Path and reads the attributes of the
+  denoted file system entry as a bulk operation. Returns an instance of the
+  java.nio.file.attribute.BasicFileAttributes interface."
+  ^BasicFileAttributes [x]
+  (^[Path Class LinkOption/1] Files/readAttributes (as-path x) BasicFileAttributes empty-link-option-array))
+
+(defn posix-file-permissions
+  "Coerces the argument to a java.nio.file.Path and returns its POSIX file
+  permissions as a set of java.nio.file.attribute.PosixFilePermission enum
+  values."
+  ^Set [x]
+  (Files/getPosixFilePermissions (as-path x) empty-link-option-array))
+
+(defn exists?
+  "Coerces the argument to a java.nio.file.Path and returns true if a
+  corresponding file system entry exists."
+  [x]
+  (Files/exists (as-path x) empty-link-option-array))
+
+(defn existing-directory?
+  "Coerces the argument to a java.nio.file.Path and returns true if a
+  corresponding file system entry exists and is a directory."
+  [x]
+  (Files/isDirectory (as-path x) empty-link-option-array))
+
+(defn existing-file?
+  "Coerces the argument to a java.nio.file.Path and returns true if a
+  corresponding file system entry exists and is a regular file."
+  [x]
+  (Files/isRegularFile (as-path x) empty-link-option-array))
+
+(defn absolute?
+  "Coerces the argument to a java.nio.file.Path and returns true if the path is
+  absolute."
+  [x]
+  (.isAbsolute (as-path x)))
+
+(defn hidden?
+  "Coerces the argument to a java.nio.file.Path and returns true if it denotes a
+  hidden file system entry."
+  [x]
+  (Files/isHidden (as-path x)))
+
+(defn same?
+  "Coerces both arguments to java.nio.file.Path and returns true if both paths
+  refer to the same file system entry. Returns false when one or more of the
+  paths do not exist."
+  [x y]
+  (let [a (as-path x)
+        b (as-path y)]
+    (try
+      (Files/isSameFile a b)
+      (catch NoSuchFileException _
+        false))))
+
+(defn compare
+  "Coerces both arguments to java.nio.file.Path and compares the two paths
+  lexicographically. This function does not access the file system."
+  ^long [x y]
+  (.compareTo (as-path x) (as-path y)))
+
+(defn starts-with?
+  "Coerces both arguments to java.nio.file.Path and returns true if this path
+  starts with the denoted prefix."
+  [this prefix]
+  (.startsWith (as-path this) (as-path prefix)))
+
+(defn ends-with?
+  "Coerces both arguments to java.nio.file.Path and returns true if this path
+  ends with the denoted suffix."
+  [this suffix]
+  (.endsWith (as-path this) (as-path suffix)))
+
+(defn delete!
+  "Coerces the argument to a java.nio.file.Path and deletes the corresponding
+  entry from the file system. If the entry is a symbolic link, then the symbolic
+  link itself, not the final target of the link, is deleted. If the path refers
+  to a directory, then the directory must be empty. Returns nil."
+  [x]
+  (Files/delete (as-path x)))
+
+(defn create-directory!
+  "Coerces the argument to a java.nio.file.Path and creates a directory
+  in the file system assuming all parent directories are in place. Returns the
+  Path to the directory."
+  ^Path [x]
+  (Files/createDirectory (as-path x) empty-file-attribute-array))
+
+(defn create-directories!
+  "Coerces the argument to a java.nio.file.Path and creates missing directories
+  in the file system for the entire path. Throws an exception if the path refers
+  to an already-existing file. Returns the resulting Path."
+  ^Path [x]
+  (Files/createDirectories (as-path x) empty-file-attribute-array))
+
+(defn create-parent-directories!
+  "Coerces the argument to a java.nio.file.Path and creates missing parent
+  directories in the file system leading up to the path. Throws an exception if
+  the parent of the path refers to an already-existing file. Returns the Path
+  the argument was coerced into."
+  ^Path [x]
+  (let [path (as-path x)]
+    (when-let [parent (.getParent (as-path x))]
+      (create-directories! parent))
+    path))
+
+(defn create-symbolic-link!
+  "Coerces both arguments to java.nio.file.Path and creates a symbolic link in
+  the file system at the path denoted by the link argument referring to the path
+  denoted by the target argument."
+  ^Path [link target]
+  (let [link-path (as-path link)
+        target-path (as-path target)]
+    (create-parent-directories! link-path)
+    (Files/createSymbolicLink link-path target-path empty-file-attribute-array)))
+
+(defn tree-walker
+  "Coerces the argument to a java.nio.file.Path and returns a reducible that
+  walks over all file Paths in the denoted directory, recursively. The optional
+  dir-path-pred should take a subdirectory Path and return true if the walk
+  should recurse into the subdirectory."
+  ([root-dir]
+   (tree-walker root-dir nil))
+  ([root-dir dir-path-pred]
+   {:pre [(or (nil? dir-path-pred) (ifn? dir-path-pred))]}
+   (let [root-dir-path (as-path root-dir)]
+     (reify IReduceInit
+       (reduce [_ f init]
+         (let [acc-vol (volatile! init)]
+           (Files/walkFileTree
+             root-dir-path
+             (reify FileVisitor
+               (preVisitDirectory [_ path _]
+                 (cond
+                   (nil? dir-path-pred)
+                   FileVisitResult/CONTINUE
+
+                   (dir-path-pred path)
+                   FileVisitResult/CONTINUE
+
+                   :else
+                   FileVisitResult/SKIP_SUBTREE))
+
+               (visitFile [_ path _]
+                 (let [acc (vswap! acc-vol f path)]
+                   (if (reduced? acc)
+                     FileVisitResult/TERMINATE
+                     FileVisitResult/CONTINUE)))
+
+               (visitFileFailed [_ _ exception]
+                 (throw exception))
+
+               (postVisitDirectory [_ _ exception]
+                 (if exception
+                   (throw exception)
+                   FileVisitResult/CONTINUE))))
+
+           (unreduced @acc-vol)))))))

--- a/editor/src/clj/util/path.clj
+++ b/editor/src/clj/util/path.clj
@@ -13,6 +13,7 @@
 ;; specific language governing permissions and limitations under the License.
 
 (ns util.path
+  (:refer-clojure :exclude [compare resolve])
   (:require [clojure.java.io :as io]
             [util.defonce :as defonce])
   (:import [clojure.lang IReduceInit]
@@ -91,7 +92,7 @@
   [value]
   (instance? Path value))
 
-(defn path
+(defn of
   "Returns a java.nio.file.Path, passing each argument to as-path. When called
   with multiple arguments, the first argument is treated as the parent and
   later arguments as children relative to the parent."
@@ -103,33 +104,33 @@
        (throw (IllegalArgumentException. (str child " is not a relative path")))
        (.resolve ^Path (as-path parent) child-path))))
   (^Path [parent child & children]
-   (reduce path (path parent child) children)))
+   (reduce of (of parent child) children)))
 
-(defn normalized-path
+(defn normalized
   "Returns a normalized java.nio.file.Path, passing each argument to as-path.
   When called with multiple arguments, the first argument is treated as the
   parent and later arguments as children relative to the parent."
   (^Path [x]
    (.normalize (as-path x)))
   (^Path [x & xs]
-   (.normalize ^Path (apply path x xs))))
+   (.normalize ^Path (apply of x xs))))
 
-(defn absolute-path
+(defn absolute
   "Returns an absolute java.nio.file.Path, passing each argument to as-path.
   When called with multiple arguments, the first argument is treated as the
   parent and later arguments as children relative to the parent."
   (^Path [x]
    (.toAbsolutePath (as-path x)))
   (^Path [x & xs]
-   (.toAbsolutePath ^Path (apply path x xs))))
+   (.toAbsolutePath ^Path (apply of x xs))))
 
-(defn real-path
+(defn real
   "Returns the canonical, real path to an existing file system entry. Throws an
   IOException if there was no matching entry in the file system."
   (^Path [x]
    (.toRealPath (as-path x) empty-link-option-array))
   (^Path [x & xs]
-   (.toRealPath ^Path (apply path x xs) empty-link-option-array)))
+   (.toRealPath ^Path (apply of x xs) empty-link-option-array)))
 
 (defn to-file
   "Converts the supplied java.nio.file.Path to a java.io.File. Does not coerce
@@ -230,13 +231,13 @@
   [x]
   (Files/exists (as-path x) empty-link-option-array))
 
-(defn existing-directory?
+(defn directory?
   "Coerces the argument to a java.nio.file.Path and returns true if a
   corresponding file system entry exists and is a directory."
   [x]
   (Files/isDirectory (as-path x) empty-link-option-array))
 
-(defn existing-file?
+(defn file?
   "Coerces the argument to a java.nio.file.Path and returns true if a
   corresponding file system entry exists and is a regular file."
   [x]

--- a/editor/test/editor/localization_test.clj
+++ b/editor/test/editor/localization_test.clj
@@ -110,7 +110,7 @@
                  (coll/transfer (fs/class-path-walker java/class-loader "localization") :eduction
                    (filter #(.endsWith (str %) ".editor_localization"))
                    (mapcat (fn [path]
-                             (e/map #(-> {:path (str (.getFileName (path/path path))) :key (key %) :string (val %)})
+                             (e/map #(-> {:path (str (.getFileName (path/of path))) :key (key %) :string (val %)})
                                     (java-properties/parse (io/reader path)))))
                    (filter #(string/includes? (:string %) "..."))))]
     (is (empty? errors)

--- a/editor/test/editor/localization_test.clj
+++ b/editor/test/editor/localization_test.clj
@@ -9,10 +9,13 @@
             [internal.java :as java]
             [internal.util :as util]
             [util.coll :as coll]
-            [util.eduction :as e])
+            [util.eduction :as e]
+            [util.path :as path])
   (:import [java.io StringReader]
            [java.time LocalDate]
            [javafx.scene.control Label]))
+
+(set! *warn-on-reflection* true)
 
 (defn- bundle [locale->content]
   (coll/pair-map-by
@@ -107,7 +110,7 @@
                  (coll/transfer (fs/class-path-walker java/class-loader "localization") :eduction
                    (filter #(.endsWith (str %) ".editor_localization"))
                    (mapcat (fn [path]
-                             (e/map #(-> {:path (str (.getFileName (fs/path path))) :key (key %) :string (val %)})
+                             (e/map #(-> {:path (str (.getFileName (path/path path))) :key (key %) :string (val %)})
                                     (java-properties/parse (io/reader path)))))
                    (filter #(string/includes? (:string %) "..."))))]
     (is (empty? errors)

--- a/editor/test/integration/editor_extensions_test.clj
+++ b/editor/test/integration/editor_extensions_test.clj
@@ -24,7 +24,6 @@
             [editor.editor-extensions.prefs-functions :as prefs-functions]
             [editor.editor-extensions.runtime :as rt]
             [editor.editor-extensions.vm :as vm]
-            [editor.fs :as fs]
             [editor.future :as future]
             [editor.graph-util :as gu]
             [editor.handler :as handler]
@@ -40,9 +39,9 @@
             [integration.test-util :as test-util]
             [support.test-support :as test-support]
             [util.diff :as diff]
-            [util.http-server :as http-server])
-  (:import [java.nio.file Files]
-           [java.nio.file.attribute PosixFilePermission]
+            [util.http-server :as http-server]
+            [util.path :as path])
+  (:import [java.nio.file.attribute PosixFilePermission]
            [java.util.zip ZipEntry]
            [org.apache.commons.compress.archivers.zip ZipArchiveInputStream]
            [org.luaj.vm2 LuaError]))
@@ -1087,15 +1086,15 @@ build/nested/game.project exists: true
   (test-util/with-scratch-project "test/resources/editor_extensions/zip_project"
     (let [root (workspace/project-directory workspace)
           list-entries (fn list-entries [path-str]
-                         (with-open [zis (ZipArchiveInputStream. (io/input-stream (fs/path root path-str)))]
+                         (with-open [zis (ZipArchiveInputStream. (io/input-stream (path/path root path-str)))]
                            (loop [acc (transient #{})]
                              (if-let [e (.getNextZipEntry zis)]
                                (recur (conj! acc (.getName e)))
                                (persistent! acc)))))
           size (fn size [path-str]
-                 (fs/path-size (fs/path root path-str)))
+                 (path/byte-size (path/path root path-str)))
           list-methods (fn list-methods [path-str]
-                         (with-open [zis (ZipArchiveInputStream. (io/input-stream (fs/path root path-str)))]
+                         (with-open [zis (ZipArchiveInputStream. (io/input-stream (path/path root path-str)))]
                            (loop [acc (transient {})]
                              (if-let [e (.getNextZipEntry zis)]
                                (recur (assoc! acc (.getName e) (condp = (.getMethod e)
@@ -1144,7 +1143,7 @@ build/nested/game.project exists: true
              (list-methods "mixed.zip")))
       (when-not (os/is-win32?)
         (is (contains?
-              (Files/getPosixFilePermissions (fs/path root "build" "script.sh") fs/empty-link-option-array)
+              (path/posix-file-permissions (path/path root "build" "script.sh"))
               PosixFilePermission/OWNER_EXECUTE))))))
 
 (def expected-zlib-test-output

--- a/editor/test/integration/editor_extensions_test.clj
+++ b/editor/test/integration/editor_extensions_test.clj
@@ -1086,15 +1086,15 @@ build/nested/game.project exists: true
   (test-util/with-scratch-project "test/resources/editor_extensions/zip_project"
     (let [root (workspace/project-directory workspace)
           list-entries (fn list-entries [path-str]
-                         (with-open [zis (ZipArchiveInputStream. (io/input-stream (path/path root path-str)))]
+                         (with-open [zis (ZipArchiveInputStream. (io/input-stream (path/of root path-str)))]
                            (loop [acc (transient #{})]
                              (if-let [e (.getNextZipEntry zis)]
                                (recur (conj! acc (.getName e)))
                                (persistent! acc)))))
           size (fn size [path-str]
-                 (path/byte-size (path/path root path-str)))
+                 (path/byte-size (path/of root path-str)))
           list-methods (fn list-methods [path-str]
-                         (with-open [zis (ZipArchiveInputStream. (io/input-stream (path/path root path-str)))]
+                         (with-open [zis (ZipArchiveInputStream. (io/input-stream (path/of root path-str)))]
                            (loop [acc (transient {})]
                              (if-let [e (.getNextZipEntry zis)]
                                (recur (assoc! acc (.getName e) (condp = (.getMethod e)
@@ -1143,7 +1143,7 @@ build/nested/game.project exists: true
              (list-methods "mixed.zip")))
       (when-not (os/is-win32?)
         (is (contains?
-              (path/posix-file-permissions (path/path root "build" "script.sh"))
+              (path/posix-file-permissions (path/of root "build" "script.sh"))
               PosixFilePermission/OWNER_EXECUTE))))))
 
 (def expected-zlib-test-output

--- a/editor/test/integration/web_server_test.clj
+++ b/editor/test/integration/web_server_test.clj
@@ -78,7 +78,7 @@
   ;; file->path
   (is (= {:status 200
           :headers {"content-type" "text/plain"}
-          :body (path/path "project.clj")}
+          :body (path/of "project.clj")}
          (http-server/response 200 (io/file "project.clj"))))
   ;; resource: jar file url
   (is (= {:status 200
@@ -94,7 +94,7 @@
     ;; editor resources: file->path
     (is (= {:status 200
             :headers {"content-type" "text/plain"}
-            :body (path/path (workspace/project-directory workspace) "game.project")}
+            :body (path/of (workspace/project-directory workspace) "game.project")}
            (http-server/response 200 (workspace/find-resource workspace "/game.project"))))
     ;; editor resources: zip as is
     (is (= {:status 200

--- a/editor/test/integration/web_server_test.clj
+++ b/editor/test/integration/web_server_test.clj
@@ -37,7 +37,8 @@
             [util.coll :as coll]
             [util.eduction :as e]
             [util.http-client :as http]
-            [util.http-server :as http-server])
+            [util.http-server :as http-server]
+            [util.path :as path])
   (:import [java.io ByteArrayInputStream ByteArrayOutputStream]
            [java.nio.charset StandardCharsets]
            [javafx.scene Scene]
@@ -77,7 +78,7 @@
   ;; file->path
   (is (= {:status 200
           :headers {"content-type" "text/plain"}
-          :body (fs/path "project.clj")}
+          :body (path/path "project.clj")}
          (http-server/response 200 (io/file "project.clj"))))
   ;; resource: jar file url
   (is (= {:status 200
@@ -93,7 +94,7 @@
     ;; editor resources: file->path
     (is (= {:status 200
             :headers {"content-type" "text/plain"}
-            :body (fs/path (workspace/project-directory workspace) "game.project")}
+            :body (path/path (workspace/project-directory workspace) "game.project")}
            (http-server/response 200 (workspace/find-resource workspace "/game.project"))))
     ;; editor resources: zip as is
     (is (= {:status 200
@@ -113,7 +114,7 @@
 
 (deftest response-write-test
   ;; file
-  (let [project-clj-size (fs/path-size (fs/path "project.clj"))]
+  (let [project-clj-size (path/byte-size "project.clj")]
     (is (= {:status 200
             :headers {"content-length" (str project-clj-size)
                       "content-type" "text/plain"}


### PR DESCRIPTION
The `fs` module had a lot of variant functions that operate on either `File` or `Path` objects. This PR moves most of the `Path` functions to their own `util.path` module, and ensures we have counterparts for all the methods on the `Path` class. As a result, a few modules are no longer dependent on the larger `fn` module.

The `util.path` module will try to coerce its arguments into `Path` objects, so it can operate on `File` objects, `URI` objects, strings and so on.

We also now implement the `as-path` coercion on all our `Resource` types, and extend the `clojure.java.io/Coercions` protocol methods `as-file` and `as-url` on the `Path` class.

### Technical changes
* The return value of `fs/create-parent-directories!` has changed from returning the `File` denoting the innermost created directory to simply returning `nil`. The old return value was not used anywhere.