### PR TITLE
Hotfix: Auto-collapse/expand all with altDown; change type annotation

### DIFF
--- a/editor/src/clj/editor/ui.clj
+++ b/editor/src/clj/editor/ui.clj
@@ -1173,7 +1173,7 @@
   (when (= MouseButton/PRIMARY (.getButton event))
     (let [target (.getTarget event)]
       ;; Did the user click on a tree cell?
-      (when-some [^TreeCell tree-cell (closest-node-of-type TreeCell target)]
+      (when-some [^TreeCell tree-cell (closest-node-of-type javafx.scene.control.TreeCell target)]
         (when-some [disclosure-node (.getDisclosureNode tree-cell)]
           ;; Did the user click on the disclosure node?
           (when (nodes-along-path? target disclosure-node tree-cell)

--- a/editor/src/clj/editor/ui.clj
+++ b/editor/src/clj/editor/ui.clj
@@ -1173,7 +1173,7 @@
   (when (= MouseButton/PRIMARY (.getButton event))
     (let [target (.getTarget event)]
       ;; Did the user click on a tree cell?
-      (when-some [^TreeCell tree-cell (closest-node-of-type javafx.scene.control.TreeCell target)]
+      (when-some [^javafx.scene.control.TreeCell tree-cell (closest-node-of-type javafx.scene.control.TreeCell target)]
         (when-some [disclosure-node (.getDisclosureNode tree-cell)]
           ;; Did the user click on the disclosure node?
           (when (nodes-along-path? target disclosure-node tree-cell)


### PR DESCRIPTION
It seems that during a refactor, potentially during commit `5cbf75384b`, this missed a different type annotation.

```clojure
(defn- custom-tree-view-mouse-pressed! [^MouseEvent event]
  (when (= MouseButton/PRIMARY (.getButton event))
    (let [target (.getTarget event)]
      ;; Did the user click on a tree cell?
      (when-some [^TreeCell tree-cell (closest-node-of-type javafx.scene.control.TreeCell target)] <-- HERE!!!
        (when-some [disclosure-node (.getDisclosureNode tree-cell)]
          ;; Did the user click on the disclosure node?
          (when (nodes-along-path? target disclosure-node tree-cell)
            ;; Consume the event and manually toggle the expanded state for the
            ;; associated tree item. If the Alt modifier key is held, recursively
            ;; set the expanded state for all children.
            (when-some [tree-item (.getTreeItem tree-cell)]
              (.consume event)
              (let [new-expanded-state (not (.isExpanded tree-item))]
                (if-not (.isAltDown event)
                  (.setExpanded tree-item new-expanded-state)
                  (doseq [^TreeItem tree-item (tree-item-seq tree-item)]
                    (.setExpanded tree-item new-expanded-state)))))))))))
```

The type of `target` in this function is no longer `com.defold.control.TreeCell` but rather the javafx version. So when it was finding the `closest-node-of-type`.

```clojure
(defn closest-node-where
  ^Node [pred ^Node leaf-node]
  (cond
    (nil? leaf-node) nil
    (pred leaf-node) leaf-node
    :else (recur pred (.getParent leaf-node))))

(defn closest-node-of-type
  ^Node [^Class node-type ^Node leaf-node]
  (closest-node-where (partial instance? node-type) leaf-node))
```

So because the types differ, closest-node-where was retuning `nil`

Fixes #11772 