### PR TITLE
Significantly improve load time and memory consumption of large projects

### DIFF
--- a/editor/src/clj/dynamo/graph.clj
+++ b/editor/src/clj/dynamo/graph.clj
@@ -43,7 +43,7 @@
 
 (namespaces/import-vars [internal.node value-type-schema value-type? node-type? value-type-dispatch-value inherits? has-input? has-output? has-property? type-compatible? merge-display-order NodeType supertypes declared-properties declared-property-labels declared-inputs declared-outputs cached-outputs input-dependencies input-cardinality cascade-deletes substitute-for input-type output-type input-labels output-labels abstract-output-labels property-display-order])
 
-(namespaces/import-vars [internal.graph arc explicit-arcs-by-source explicit-arcs-by-target node-ids pre-traverse])
+(namespaces/import-vars [internal.graph arc explicit-arcs-by-source explicit-arcs-by-target node-ids pre-traverse successors])
 
 (namespaces/import-vars [internal.system endpoint-invalidated-since? evaluation-context-invalidate-counters])
 

--- a/editor/src/clj/editor/defold_project.clj
+++ b/editor/src/clj/editor/defold_project.clj
@@ -1784,26 +1784,26 @@
               (g/make-nodes plugin-graph [code-transpilers code.transpilers/CodeTranspilersNode]
                 (g/connect code-preprocessors :lua-preprocessors code-transpilers :lua-preprocessors)))))
         project-id
-    (second
-          (g/tx-nodes-added
-            (g/transact
-              (g/make-nodes graph
-                  [script-intelligence si/ScriptIntelligenceNode
-                   project [Project :workspace workspace-id]
-                   script-annotations script-annotations/ScriptAnnotations
-                   editor-localization-bundle editor-localization-bundle/EditorLocalizationBundle]
-                (g/connect workspace-id :root script-annotations :root)
-                (g/connect script-annotations :_node-id project :script-annotations)
-                (g/connect editor-localization-bundle :_node-id project :editor-localization-bundle)
-                (g/connect extensions :_node-id project :editor-extensions)
-                (g/connect script-intelligence :_node-id project :script-intelligence)
-                (g/connect workspace-id :build-settings project :build-settings)
-                (g/connect workspace-id :dependencies project :dependencies)
-                (g/connect workspace-id :resource-list project :resources)
-                (g/connect workspace-id :resource-map project :resource-map)
-                (g/set-graph-value graph :project-id project)
-                (g/set-graph-value graph :lsp (lsp/make project get-resource-node))
-                (g/set-graph-value graph :code-transpilers transpilers-id)))))]
+        (second
+              (g/tx-nodes-added
+                (g/transact
+                  (g/make-nodes graph
+                      [script-intelligence si/ScriptIntelligenceNode
+                       project [Project :workspace workspace-id]
+                       script-annotations script-annotations/ScriptAnnotations
+                       editor-localization-bundle editor-localization-bundle/EditorLocalizationBundle]
+                    (g/connect workspace-id :root script-annotations :root)
+                    (g/connect script-annotations :_node-id project :script-annotations)
+                    (g/connect editor-localization-bundle :_node-id project :editor-localization-bundle)
+                    (g/connect extensions :_node-id project :editor-extensions)
+                    (g/connect script-intelligence :_node-id project :script-intelligence)
+                    (g/connect workspace-id :build-settings project :build-settings)
+                    (g/connect workspace-id :dependencies project :dependencies)
+                    (g/connect workspace-id :resource-list project :resources)
+                    (g/connect workspace-id :resource-map project :resource-map)
+                    (g/set-graph-value graph :project-id project)
+                    (g/set-graph-value graph :lsp (lsp/make project get-resource-node))
+                    (g/set-graph-value graph :code-transpilers transpilers-id)))))]
     (reload-plugins! project-id (g/node-value project-id :resources))
     (workspace/add-resource-listener! workspace-id 1 (ProjectResourceListener. project-id))
     (g/reset-undo! graph)

--- a/editor/src/clj/internal/graph.clj
+++ b/editor/src/clj/internal/graph.clj
@@ -13,11 +13,11 @@
 ;; specific language governing permissions and limitations under the License.
 
 (ns internal.graph
-  (:require [clojure.core.reducers :as r]
-            [clojure.data.int-map :as int-map]
+  (:require [clojure.data.int-map :as int-map]
             [internal.graph.types :as gt]
             [internal.node :as in]
             [internal.util :as util]
+            [util.array :as array]
             [util.coll :as coll :refer [pair]]
             [util.defonce :as defonce])
   (:import [clojure.lang IPersistentSet Indexed]
@@ -374,11 +374,22 @@
   (and (p (.source-id arc) (.source-label arc))
        (p (.target-id arc) (.target-label arc))))
 
+;; Referentially transparent cache that supports explicit invalidation
+;; and on-demand computation.
+;; `cache` is an atom for the "current generation" of successors: when
+;; invalidated, a new atom + new Successors instance is created.
+;; `cache` value is a map: {node-id {output Endpoint/1}}
+(defonce/type Successors [cache])
+
+(defn- make-successors
+  ^Successors ([] (make-successors {}))
+  ^Successors ([m] (->Successors (atom m))))
+
 (defn empty-graph
   []
   {:nodes (int-map/int-map)
    :sarcs {}
-   :successors {}
+   :successors (make-successors)
    :tarcs {}
    :tx-id 0})
 
@@ -837,6 +848,75 @@
                  result')
           (persistent! result'))))))
 
+(defn- update-successors
+  ^Successors [^Successors successors changes]
+  ;; changes = {node-id #{outputs}|nil}
+  ;; when changes value is nil, it means that every output was invalidated
+  (let [current-state @(.-cache successors)]
+    (make-successors
+      (persistent!
+        (reduce-kv
+          (fn [acc node-id outputs]
+            (let [output->endpoints (acc node-id ::not-found)]
+              (if (identical? ::not-found output->endpoints)
+                acc
+                (if (nil? outputs)
+                  (dissoc! acc node-id)
+                  (let [output->endpoints (reduce dissoc! (transient output->endpoints) outputs)]
+                    (if (zero? (count output->endpoints))
+                      (dissoc! acc node-id)
+                      (assoc! acc node-id (persistent! output->endpoints))))))))
+          (transient current-state)
+          changes)))))
+
+(defn- input-deps [basis node-id] (some-> (gt/node-by-id-at basis node-id) gt/node-type in/input-dependencies))
+
+(def ^:private empty-endpoints-array (array/empty-of-type Endpoint))
+
+(defn- query-successors
+  "The purpose of this fn is to return an array of endpoints that can be reached
+  from the incoming changes (node-id + output)
+   For a specific node-id-a + output-x, add:
+     the internal input-dependencies, i.e. outputs consuming the given output
+     the closest override-nodes, i.e. override-node-a + output-x, as they can be potential dependents
+     all connected nodes, where node-id-a + output-x => [[node-id-b + input-y] ...] => [[node-id-b + output+z] ...]"
+  [^Successors successors basis node-id label]
+  (let [cache (.-cache successors)]
+    (if-let [cached-value (-> @cache (get node-id) (get label))]
+      cached-value
+      (let [graph (node-id->graph basis node-id)
+            result (if-let [node (node-id->node graph node-id)]
+                     (let [node-type (gt/node-type node)
+                           overrides (get (:node->overrides graph) node-id)
+                           deps-by-label (in/input-dependencies node-type)
+                           dep-labels (get deps-by-label label)
+                           outgoing-arcs (gt/arcs-by-source basis node-id label)
+                           deps (ArrayList. (int (+ (count dep-labels)
+                                                    (count overrides)
+                                                    (* (long 10) (count outgoing-arcs)))))]
+
+                       ;; The internal dependent outputs.
+                       (doseq [dep-label dep-labels]
+                         (.add deps (gt/endpoint node-id dep-label)))
+
+                       ;; The closest overrides.
+                       (doseq [override-node-id overrides]
+                         (.add deps (gt/endpoint override-node-id label)))
+
+                       ;; The connected nodes and their outputs.
+                       (doseq [^Arc outgoing-arc outgoing-arcs
+                               :let [target-id (.target-id outgoing-arc)
+                                     target-label (.target-label outgoing-arc)]
+                               dep-label (get (input-deps basis target-id) target-label)]
+                         (.add deps (gt/endpoint target-id dep-label)))
+
+                       (if (.isEmpty deps)
+                         empty-endpoints-array
+                         (.toArray deps ^Endpoint/1 empty-endpoints-array)))
+                     empty-endpoints-array)]
+        (swap! cache update node-id assoc label result)
+        result))))
+
 (def ^:private ^Cache basis-dependencies-cache
   (-> (Caffeine/newBuilder)
       (.expireAfterAccess 10 TimeUnit/SECONDS)
@@ -847,7 +927,7 @@
   (assert (every? gt/endpoint? endpoints))
   (if (coll/empty? endpoints)
     #{}
-    (let [graph-id->node-successor-map
+    (let [graph-id->node-successors
           (persistent!
             (reduce-kv
               (fn [acc graph-id graph]
@@ -856,7 +936,7 @@
               (:graphs basis)))
           cache-key (into [endpoints]
                           (map #(System/identityHashCode (val %)))
-                          graph-id->node-successor-map)]
+                          graph-id->node-successors)]
       (.get basis-dependencies-cache
             cache-key
             (fn [_]
@@ -872,9 +952,8 @@
                                                      output (gt/endpoint-label endpoint)]
                                                  (-> node-id
                                                      gt/node-id->graph-id
-                                                     graph-id->node-successor-map
-                                                     (get node-id)
-                                                     (get output))))))
+                                                     graph-id->node-successors
+                                                     (query-successors basis node-id output))))))
                                          endpoints)))
                     endpoints->tasks-xf (comp (partition-all 512) (map make-task!))
                     future->tasks-xf (comp (mapcat deref) endpoints->tasks-xf)]
@@ -1159,89 +1238,12 @@
     {:basis (update basis :graphs assoc graph-id (assoc graph-state :sarcs new-sarcs))
      :outputs-to-refresh outputs-to-refresh}))
 
-(defn- input-deps [basis node-id]
-  (some-> (gt/node-by-id-at basis node-id) gt/node-type in/input-dependencies))
-
-(defn- update-graph-successors
-  "The purpose of this fn is to build a data structure that reflects which set of endpoints that can be reached from the incoming changes (map of node-id + outputs)
-   For a specific node-id-a + output-x, add:
-     the internal input-dependencies, i.e. outputs consuming the given output
-     the closest override-nodes, i.e. override-node-a + output-x, as they can be potential dependents
-     all connected nodes, where node-id-a + output-x => [[node-id-b + input-y] ...] => [[node-id-b + output+z] ...]"
-  [old-successors basis graph changes]
-  (let [node-id->overrides (or (:node->overrides graph) (constantly nil))
-        changes+old-node-successors (mapv (fn [[node-id labels]]
-                                            [node-id labels (old-successors node-id)])
-                                          changes)
-        [new-successors removed-successor-entries]
-        (r/fold
-          (fn combinef
-            ([]
-             (pair {} []))
-            ([[new-successors-1 removed-successor-entries-1] [new-successors-2 removed-successor-entries-2]]
-             (pair (into new-successors-1 new-successors-2) (into removed-successor-entries-1 removed-successor-entries-2))))
-          (fn reducef
-            ([]
-             (pair {} []))
-            ([[new-acc remove-acc] [node-id labels old-node-successors]]
-             (let [new-node-successors
-                   (when-some [node (gt/node-by-id-at basis node-id)]
-                     (let [deps (ArrayList.)
-                           node-type (gt/node-type node)
-                           deps-by-label (in/input-dependencies node-type)
-                           overrides (node-id->overrides node-id)
-                           labels (or labels (in/output-labels node-type))
-                           arcs-by-source (if (> (count labels) 1)
-                                            (let [arcs (gt/arcs-by-source basis node-id)
-                                                  arcs-by-source-label (util/group-into #(.source-label ^Arc %) arcs)]
-                                              (fn get-arcs-by-source-label [_ _ label]
-                                                (arcs-by-source-label label)))
-                                            gt/arcs-by-source)]
-                       (reduce (fn reduce-labels [new-node-successors label]
-                                 (let [dep-labels (get deps-by-label label)
-                                       outgoing-arcs (arcs-by-source basis node-id label)]
-                                   (.clear deps)
-                                   (.ensureCapacity deps (+ (count dep-labels)
-                                                            (count overrides)
-                                                            (* (long 10) (count outgoing-arcs))))
-
-                                   ;; The internal dependent outputs.
-                                   (doseq [dep-label dep-labels]
-                                     (.add deps (gt/endpoint node-id dep-label)))
-
-                                   ;; The closest overrides.
-                                   (doseq [override-node-id overrides]
-                                     (.add deps (gt/endpoint override-node-id label)))
-
-                                   ;; The connected nodes and their outputs.
-                                   (doseq [^Arc outgoing-arc outgoing-arcs
-                                           :let [target-id (.target-id outgoing-arc)
-                                                 target-label (.target-label outgoing-arc)]
-                                           dep-label (get (input-deps basis target-id) target-label)]
-                                     (.add deps (gt/endpoint target-id dep-label)))
-
-                                   (if (.isEmpty deps)
-                                     (dissoc new-node-successors label)
-                                     (let [^"[Linternal.graph.types.Endpoint;" storage (make-array Endpoint (.size deps))
-                                           endpoint-array (.toArray deps storage)] ; Use a typed array to aid memory profilers.
-                                       (assoc new-node-successors label endpoint-array)))))
-                               old-node-successors
-                               labels)))]
-               (if (pos? (count new-node-successors))
-                 (pair (assoc new-acc node-id new-node-successors) remove-acc)
-                 (pair new-acc (conj remove-acc node-id))))))
-          changes+old-node-successors)]
-    (persistent!
-      (reduce dissoc!
-              (transient (into old-successors new-successors))
-              removed-successor-entries))))
-
 (defn update-successors
   [basis changes]
-  ;; changes = {node-id #{outputs}}
+  ;; changes = {node-id #{outputs}|nil}
   (reduce (fn [basis [graph-id changes]]
-            (if-let [graph (get (:graphs basis) graph-id)]
-              (update-in basis [:graphs graph-id :successors] update-graph-successors basis graph changes)
+            (if (contains? (:graphs basis) graph-id)
+              (update-in basis [:graphs graph-id :successors] update-successors changes)
               basis))
           basis
-          (util/group-into (comp gt/node-id->graph-id first) changes)))
+          (util/group-into {} {} (comp gt/node-id->graph-id first) changes)))

--- a/editor/src/clj/internal/graph.clj
+++ b/editor/src/clj/internal/graph.clj
@@ -383,7 +383,7 @@
 
 (defn- make-successors
   ^Successors ([] (make-successors {}))
-  ^Successors ([m] (->Successors (atom m))))
+  ^Successors ([m] {:pre [(map? m)]} (->Successors (atom m))))
 
 (defn empty-graph
   []
@@ -848,9 +848,9 @@
                  result')
           (persistent! result'))))))
 
-(defn- update-graph-successors
+(defn- invalidate-graph-successors
   ^Successors [^Successors successors changes]
-  ;; changes = {node-id #{outputs}|nil}
+  ;; changes = {node-id #{output-label ...}|nil}
   ;; when changes value is nil, it means that every output was invalidated
   (let [current-state @(.-cache successors)]
     (make-successors
@@ -869,7 +869,8 @@
           (transient current-state)
           changes)))))
 
-(defn- input-deps [basis node-id] (some-> (gt/node-by-id-at basis node-id) gt/node-type in/input-dependencies))
+(defn- input-deps [basis node-id]
+  (some-> (gt/node-by-id-at basis node-id) gt/node-type in/input-dependencies))
 
 (def ^:private empty-endpoints-array (array/empty-of-type Endpoint))
 
@@ -916,6 +917,15 @@
                      empty-endpoints-array)]
         (swap! cache update node-id assoc label result)
         result))))
+
+(defn successors
+  "Public only for tests and introspection tooling. Implementation detail."
+  [basis node-id label]
+  (query-successors
+    (-> basis :graphs (get (gt/node-id->graph-id node-id)) :successors)
+    basis
+    node-id
+    label))
 
 (def ^:private ^Cache basis-dependencies-cache
   (-> (Caffeine/newBuilder)
@@ -1240,10 +1250,11 @@
 
 (defn update-successors
   [basis changes]
-  ;; changes = {node-id #{outputs}|nil}
+  ;; changes = {node-id #{output-label ...}|nil}
+  ;; when changes value is nil, it means that every output was invalidated
   (reduce (fn [basis [graph-id changes]]
             (if (contains? (:graphs basis) graph-id)
-              (update-in basis [:graphs graph-id :successors] update-graph-successors changes)
+              (update-in basis [:graphs graph-id :successors] invalidate-graph-successors changes)
               basis))
           basis
           (util/group-into {} {} (comp gt/node-id->graph-id first) changes)))

--- a/editor/src/clj/internal/graph.clj
+++ b/editor/src/clj/internal/graph.clj
@@ -848,7 +848,7 @@
                  result')
           (persistent! result'))))))
 
-(defn- update-successors
+(defn- update-graph-successors
   ^Successors [^Successors successors changes]
   ;; changes = {node-id #{outputs}|nil}
   ;; when changes value is nil, it means that every output was invalidated
@@ -1243,7 +1243,7 @@
   ;; changes = {node-id #{outputs}|nil}
   (reduce (fn [basis [graph-id changes]]
             (if (contains? (:graphs basis) graph-id)
-              (update-in basis [:graphs graph-id :successors] update-successors changes)
+              (update-in basis [:graphs graph-id :successors] update-graph-successors changes)
               basis))
           basis
           (util/group-into {} {} (comp gt/node-id->graph-id first) changes)))

--- a/editor/src/clj/internal/graph.clj
+++ b/editor/src/clj/internal/graph.clj
@@ -850,22 +850,24 @@
 
 (defn- invalidate-graph-successors
   ^Successors [^Successors successors changes]
-  ;; changes = {node-id #{output-label ...}|nil}
-  ;; when changes value is nil, it means that every output was invalidated
+  ;; changes = vector of pairs: node-id + #{output-label ...}|nil
+  ;; when changes val is nil, it means that every output was invalidated
   (let [current-state @(.-cache successors)]
     (make-successors
       (persistent!
-        (reduce-kv
-          (fn [acc node-id outputs]
-            (let [output->endpoints (acc node-id ::not-found)]
+        (reduce
+          (fn [acc e]
+            (let [node-id (key e)
+                  output->endpoints (acc node-id ::not-found)]
               (if (identical? ::not-found output->endpoints)
                 acc
-                (if (nil? outputs)
-                  (dissoc! acc node-id)
-                  (let [output->endpoints (reduce dissoc! (transient output->endpoints) outputs)]
-                    (if (zero? (count output->endpoints))
-                      (dissoc! acc node-id)
-                      (assoc! acc node-id (persistent! output->endpoints))))))))
+                (let [outputs (val e)]
+                  (if (nil? outputs)
+                    (dissoc! acc node-id)
+                    (let [output->endpoints (reduce dissoc! (transient output->endpoints) outputs)]
+                      (if (zero? (count output->endpoints))
+                        (dissoc! acc node-id)
+                        (assoc! acc node-id (persistent! output->endpoints)))))))))
           (transient current-state)
           changes)))))
 
@@ -1253,8 +1255,9 @@
   ;; changes = {node-id #{output-label ...}|nil}
   ;; when changes value is nil, it means that every output was invalidated
   (reduce (fn [basis [graph-id changes]]
+            ;; now, changes are a vector of tuples!
             (if (contains? (:graphs basis) graph-id)
               (update-in basis [:graphs graph-id :successors] invalidate-graph-successors changes)
               basis))
           basis
-          (util/group-into {} {} (comp gt/node-id->graph-id first) changes)))
+          (util/group-into (comp gt/node-id->graph-id first) changes)))

--- a/editor/src/dev/dev.clj
+++ b/editor/src/dev/dev.clj
@@ -694,9 +694,8 @@
                                identity
                                (fn [endpoint]
                                  (let [node-id (gt/endpoint-node-id endpoint)
-                                       label (gt/endpoint-label endpoint)
-                                       graph-id (gt/node-id->graph-id node-id)]
-                                   (cond->> (get-in basis [:graphs graph-id :successors node-id label])
+                                       label (gt/endpoint-label endpoint)]
+                                   (cond->> (g/successors basis node-id label)
                                             successor-filter
                                             (into [] (filter #(successor-filter [endpoint %])))))))))
                          endpoints)]

--- a/editor/src/reveal/editor/reveal.clj
+++ b/editor/src/reveal/editor/reveal.clj
@@ -229,9 +229,7 @@
            :root endpoint})))))
 
 (defn- endpoint-successors [basis endpoint]
-  (let [node-id (g/endpoint-node-id endpoint)
-        graph-id (g/node-id->graph-id node-id)]
-    (get-in basis [:graphs graph-id :successors node-id (g/endpoint-label endpoint)])))
+  (g/successors basis (g/endpoint-node-id endpoint) (g/endpoint-label endpoint)))
 
 (r/defaction ::defold:successors [x ann]
   (when-some [endpoint (as-endpoint x ann)]

--- a/editor/test/integration/gui_test.clj
+++ b/editor/test/integration/gui_test.clj
@@ -1109,8 +1109,7 @@
   ([source-id+source-label target-id+target-label]
    (has-successor? (g/now) source-id+source-label target-id+target-label))
   ([basis [source-id source-label] [target-id target-label]]
-   (let [graph-id (g/node-id->graph-id source-id)
-         successor-endpoint-array (#'internal.graph/query-successors (get-in basis [:graphs graph-id :successors]) basis source-id source-label)
+   (let [successor-endpoint-array (g/successors basis source-id source-label)
          length (count successor-endpoint-array)
          target-endpoint (g/endpoint target-id target-label)]
      (loop [index 0]

--- a/editor/test/integration/gui_test.clj
+++ b/editor/test/integration/gui_test.clj
@@ -1110,7 +1110,7 @@
    (has-successor? (g/now) source-id+source-label target-id+target-label))
   ([basis [source-id source-label] [target-id target-label]]
    (let [graph-id (g/node-id->graph-id source-id)
-         successor-endpoint-array (get-in basis [:graphs graph-id :successors source-id source-label])
+         successor-endpoint-array (#'internal.graph/query-successors (get-in basis [:graphs graph-id :successors]) basis source-id source-label)
          length (count successor-endpoint-array)
          target-endpoint (g/endpoint target-id target-label)]
      (loop [index 0]

--- a/editor/test/internal/graph/generator.clj
+++ b/editor/test/internal/graph/generator.clj
@@ -151,6 +151,6 @@
   (= (builder) (builder))
   ;; => true
 
-  (= ((make-random-graph-builder)) ((make-random-graph-builder)))
+  (= ((make-random-graph-builder)) ((make-random-graph-builder))))
   ;; => false
-)
+

--- a/editor/test/internal/node_test.clj
+++ b/editor/test/internal/node_test.clj
@@ -970,9 +970,8 @@
    (successor-output-endpoints (g/now) node-id output-label))
   ([basis node-id output-label]
    (assert (g/has-output? (g/node-type* basis node-id) output-label) "Only outputs have successors.")
-   (let [graph-id (g/node-id->graph-id node-id)]
-     (into (sorted-set)
-           (#'internal.graph/query-successors (get-in basis [:graphs graph-id :successors]) basis node-id output-label)))))
+   (into (sorted-set)
+         (g/successors basis node-id output-label))))
 
 (defn- dependent-internal-output-endpoints
   ([node-id label]

--- a/editor/test/internal/node_test.clj
+++ b/editor/test/internal/node_test.clj
@@ -972,7 +972,7 @@
    (assert (g/has-output? (g/node-type* basis node-id) output-label) "Only outputs have successors.")
    (let [graph-id (g/node-id->graph-id node-id)]
      (into (sorted-set)
-           (get-in basis [:graphs graph-id :successors node-id output-label])))))
+           (#'internal.graph/query-successors (get-in basis [:graphs graph-id :successors]) basis node-id output-label)))))
 
 (defn- dependent-internal-output-endpoints
   ([node-id label]

--- a/editor/test/internal/system_test.clj
+++ b/editor/test/internal/system_test.clj
@@ -420,9 +420,7 @@
         (is (= nil (g/node-value sink :loud)))))))
 
 (defn- successors [node-id label]
-  (let [basis (g/now)
-        graph-id (g/node-id->graph-id node-id)]
-    (#'internal.graph/query-successors (get-in basis [:graphs graph-id :successors]) basis node-id label)))
+  (g/successors (g/now) node-id label))
 
 (defn- sarcs [node-id label]
   (get-in @g/*the-system* [:graphs (g/node-id->graph-id node-id) :sarcs node-id label]))

--- a/editor/test/internal/system_test.clj
+++ b/editor/test/internal/system_test.clj
@@ -420,7 +420,9 @@
         (is (= nil (g/node-value sink :loud)))))))
 
 (defn- successors [node-id label]
-  (get-in @g/*the-system* [:graphs (g/node-id->graph-id node-id) :successors node-id label]))
+  (let [basis (g/now)
+        graph-id (g/node-id->graph-id node-id)]
+    (#'internal.graph/query-successors (get-in basis [:graphs graph-id :successors]) basis node-id label)))
 
 (defn- sarcs [node-id label]
   (get-in @g/*the-system* [:graphs (g/node-id->graph-id node-id) :sarcs node-id label]))


### PR DESCRIPTION
On some large projects:
- The time to open the project was reduced by 50% (4m00s->2m01s on an example project)
- Memory consumption after load was reduced by 71% (10.59GB->3.04Gb on the same project)
- The time to perform a full build improved by 40% (13m50s->8m11s). 

This was achieved by delaying the computation of data that is used for applying changes in the editor until it is actually needed, rather than computing it eagerly when loading the project. 

The downside is that in some cases, the first time a change to a particular element is made, it will take longer than before (worst case: 6s->35s). It is noticeable only in some rare cases in large projects when changing resources that are widely used throughout the project (e.g., when changing a GUI button layout when the button is referenced in hundreds/thousands of places). Subsequent changes to the same element will be faster than before. 

Overall, the tradeoff is worth it, because previously, every user had to always pay this cost when opening the project, while now, the cost is only paid when actually making certain changes to edge case elements, and even then, the wait is significantly reduced (30s instead of 2m).

### Technical notes:
#### Load time before vs after
```sh
# before
2026-01-21 15:54:52.922 INFO  default    editor.defold-project - {:line nil, :message "Project loading completed in 4:00"}
# after 
2026-01-21 15:48:38.405 INFO  default    editor.defold-project - {:line nil, :message "Project loading completed in 2:01"}
```
Significant improvement 🚀 
#### Memory use before vs after
```sh
# before 
2026-01-21 15:55:05.791 INFO  default    editor.defold-project - {:line nil, :message "Project loaded", :allocated "10.59 GB"}
# after 
2026-01-21 15:48:39.419 INFO  default    editor.defold-project - {:line nil, :message "Project loaded", :allocated "3.04 GB"}
```
Significant improvement 🚀 
#### Worst case edit (first change)
```sh
# before
"Elapsed time: 6496.768416 msecs"
# after 
"Elapsed time: 35279.083125 msecs"
```
Got worse 😢 Still, waiting 30s in some rare cases is better than always waiting for 2 extra minutes during project load
#### More representative case edit (first change)
```sh
# before 
"Elapsed time: 2.802042 msecs"
# after
"Elapsed time: 5.771083 msecs"
```
Got worse 😢 But it's not noticeable, it's less than a frame.
#### Worst case edit (subsequent changes)
```sh
# before
"Elapsed time: 6516.027458 msecs"
# after 
"Elapsed time: 2212.596625 msecs"
```
Significant improvement, though still bad.
#### More representative case edit (subsequent changes)
```sh 
# before
"Elapsed time: 1.4385 msecs"
# after 
"Elapsed time: 0.873125 msecs"
```
Improvement, but not really noticeable.
#### Build time
```sh
# before 
2026-01-22 11:47:51.715 INFO  default    editor.build - {:line nil, :message "Build", :elapsed "13:50", :allocated "3.76 GB", :heap "14.53 GB"}
# after 
2026-01-22 11:25:38.114 INFO  default    editor.build - {:line nil, :message "Build", :elapsed "8:11", :allocated "4.36 GB", :heap "7.60 GB"}
```
Significant improvement 🚀 

Related to #10166
