### PR TITLE
Property options refactor

### DIFF
--- a/engine/gameobject/src/dmsdk/gameobject/component.h
+++ b/engine/gameobject/src/dmsdk/gameobject/component.h
@@ -468,7 +468,7 @@ namespace dmGameObject
      * @member m_Instance [type: HInstance] Game object instance
      * @member m_PropertyId [type: dmhash_t] Id of the property
      * @member m_UserData [type: uintptr_t*] User data storage pointer
-     * @member m_Options [type: PropertyOptions] Options for getting the property
+     * @member m_Options [type: HPropertyOptions] Options for getting the property
      */
     struct ComponentGetPropertyParams
     {
@@ -477,7 +477,7 @@ namespace dmGameObject
         HInstance m_Instance;
         dmhash_t m_PropertyId;
         uintptr_t* m_UserData;
-        PropertyOptions m_Options;
+        HPropertyOptions m_Options;
     };
 
     /*#
@@ -500,7 +500,7 @@ namespace dmGameObject
      * @member m_PropertyId [type: dmhash_t] Id of the property
      * @member m_UserData [type: uintptr_t*] User data storage pointer
      * @member m_Value [type: PropertyVar] New value of the property
-     * @member m_Options [type: PropertyOptions] Options for setting the property
+     * @member m_Options [type: HPropertyOptions] Options for setting the property
      */
     struct ComponentSetPropertyParams
     {
@@ -510,7 +510,7 @@ namespace dmGameObject
         dmhash_t m_PropertyId;
         uintptr_t* m_UserData;
         PropertyVar m_Value;
-        PropertyOptions m_Options;
+        HPropertyOptions m_Options;
     };
 
     /*#

--- a/engine/gameobject/src/dmsdk/gameobject/gameobject.h
+++ b/engine/gameobject/src/dmsdk/gameobject/gameobject.h
@@ -866,11 +866,33 @@ namespace dmGameObject
      */
     void AddDynamicResourceHash(HCollection collection, dmhash_t path_hash);
 
+    /*#
+     * Get the property count from a PropertyOptions container
+     * @name GetPropertyOptionsCount
+     * @param options [type:HPropertyOptions] Options handle
+     * @return count [type:uint32_t] The number of property options
+     */
     uint32_t GetPropertyOptionsCount(HPropertyOptions options);
 
-    PropertyResult GetPropertyOptionsIndex(HPropertyOptions options, int index, int32_t* result);
+    /*#
+     * Get the index value from a property option at a specific index
+     * @name GetPropertyOptionsIndex
+     * @param options [type:HPropertyOptions] Options handle
+     * @param options_index [type:int32_t] The options index into the property options container
+     * @param result [type:int32_t*] If the option at the index is valid, store the result. Pointer is untouched otherwise
+     * @return PROPERTY_RESULT_OK if the property option at the index is valid
+     */
+    PropertyResult GetPropertyOptionsIndex(HPropertyOptions options, uint32_t options_index, int32_t* result);
 
-    PropertyResult GetPropertyOptionsKey(HPropertyOptions options, int index, dmhash_t* result);
+    /*#
+     * Get the key value from a property option at a specific index
+     * @name GetPropertyOptionsKey
+     * @param options [type:HPropertyOptions] Options handle
+     * @param options_index [type:int32_t] The options index into the property options container
+     * @param result [type:dmhash_t*] If the option at the index is valid, store the result. Pointer is untouched otherwise
+     * @return PROPERTY_RESULT_OK if the property option at the index is valid
+     */
+    PropertyResult GetPropertyOptionsKey(HPropertyOptions options, uint32_t options_index, dmhash_t* result);
 
     /*#
      * Retrieve a hash property from a component.

--- a/engine/gameobject/src/dmsdk/gameobject/gameobject.h
+++ b/engine/gameobject/src/dmsdk/gameobject/gameobject.h
@@ -95,6 +95,13 @@ namespace dmGameObject
     typedef struct PropertyContainer* HPropertyContainer;
 
     /*#
+     * Handle to a list of property options
+     * @typedef
+     * @name HPropertyOptions
+     */
+    typedef struct PropertyOptions* HPropertyOptions;
+
+    /*#
      * Opaque handle to component instance
      * @typedef
      * @name HComponent
@@ -318,29 +325,6 @@ namespace dmGameObject
     {
         PROP_VALUE_ARRAY = 0,
         PROP_VALUE_HASHTABLE = 1,
-    };
-
-    /*# Property Options
-     *
-     * Parameters variant that holds key or index for a propertys data structure.
-     *
-     * @struct
-     * @name PropertyOptions
-     * @member m_Index [type:int32_t] The index of the property to set, only applicable if property is array.
-     * @member m_Key [type:dmhash_t] The key of the property to set, only applicable if property is hashtable.
-     * @member m_HasKey [type:uint8_t] A flag if structure contain m_Key value (it can't contain both)
-     */
-    struct PropertyOptions
-    {
-        union
-        {
-            dmhash_t m_Key;
-            int32_t m_Index;
-        };
-
-        uint8_t m_HasKey : 1;
-
-        PropertyOptions();
     };
 
     /*# property variant
@@ -881,6 +865,12 @@ namespace dmGameObject
      * @param path_hash [type:dmhash_t] resource path hash
      */
     void AddDynamicResourceHash(HCollection collection, dmhash_t path_hash);
+
+    uint32_t GetPropertyOptionsCount(HPropertyOptions options);
+
+    PropertyResult GetPropertyOptionsIndex(HPropertyOptions options, int index, int32_t* result);
+
+    PropertyResult GetPropertyOptionsKey(HPropertyOptions options, int index, dmhash_t* result);
 
     // These functions are used for profiling functionality
 

--- a/engine/gameobject/src/gameobject/comp_anim.cpp
+++ b/engine/gameobject/src/gameobject/comp_anim.cpp
@@ -22,6 +22,7 @@
 
 #include "component.h"
 #include "gameobject_script.h"
+#include "gameobject_props.h"
 #include "gameobject_props_lua.h"
 
 extern "C"
@@ -211,7 +212,8 @@ namespace dmGameObject
                     {
                         PropertyDesc desc;
                         PropertyOptions property_opt;
-                        property_opt.m_Index = 0;
+                        AddPropertyOptionsIndex(&property_opt, 0);
+
                         GetProperty(anim.m_Instance, anim.m_ComponentId, anim.m_PropertyId, property_opt, desc);
                         anim.m_From = (float)desc.m_Variant.m_Number;
                     }
@@ -317,7 +319,7 @@ namespace dmGameObject
                 else
                 {
                     PropertyOptions property_opt;
-                    property_opt.m_Index = 0;
+                    AddPropertyOptionsIndex(&property_opt, 0);
                     SetProperty(anim.m_Instance, anim.m_ComponentId, anim.m_PropertyId, property_opt, PropertyVar(v));
                 }
             }
@@ -548,7 +550,8 @@ namespace dmGameObject
             return PROPERTY_RESULT_INVALID_INSTANCE;
         PropertyDesc prop_desc;
         PropertyOptions property_opt;
-        property_opt.m_Index = 0;
+        AddPropertyOptionsIndex(&property_opt, 0);
+
         PropertyResult prop_result = GetProperty(instance, component_id, property_id, property_opt, prop_desc);
         if (prop_result != PROPERTY_RESULT_OK)
         {
@@ -623,7 +626,7 @@ namespace dmGameObject
         }
         PropertyDesc prop_desc;
         PropertyOptions property_opt;
-        property_opt.m_Index = 0;
+        AddPropertyOptionsIndex(&property_opt, 0);
         PropertyResult prop_result = GetProperty(instance, component_id, property_id, property_opt, prop_desc);
         if (prop_result != PROPERTY_RESULT_OK)
         {

--- a/engine/gameobject/src/gameobject/gameobject.cpp
+++ b/engine/gameobject/src/gameobject/gameobject.cpp
@@ -4002,7 +4002,7 @@ namespace dmGameObject
     {
         if (!options || index >= options->m_OptionsCount)
             return PROPERTY_RESULT_NOT_FOUND;
-        if (!options->m_Options[index].m_HasKey)
+        if (options->m_Options[index].m_HasKey)
             return PROPERTY_RESULT_TYPE_MISMATCH;
         *result = options->m_Options[index].m_Index;
         return PROPERTY_RESULT_OK;

--- a/engine/gameobject/src/gameobject/gameobject.cpp
+++ b/engine/gameobject/src/gameobject/gameobject.cpp
@@ -30,9 +30,9 @@
 #include "gameobject.h"
 #include "gameobject_script.h"
 #include "gameobject_private.h"
+#include "gameobject_props.h"
 #include "gameobject_props_lua.h"
 #include "gameobject_props_ddf.h"
-#include "gameobject_props.h"
 
 #include "gameobject/gameobject_ddf.h"
 
@@ -107,8 +107,9 @@ namespace dmGameObject
     }
 
     PropertyOptions::PropertyOptions()
-    : m_Index(0)
-    , m_HasKey(0) {}
+    {
+        memset(this, 0, sizeof(*this));
+    }
 
     PropertyVar::PropertyVar()
     {
@@ -3547,7 +3548,7 @@ namespace dmGameObject
                     p.m_World = instance->m_Collection->m_ComponentWorlds[component.m_TypeIndex];
                     p.m_Instance = instance;
                     p.m_PropertyId = property_id;
-                    p.m_Options = options;
+                    p.m_Options = &options;
                     p.m_UserData = user_data;
                     PropertyDesc prop_desc;
                     PropertyResult result = type->m_GetPropertyFunction(p, prop_desc);
@@ -3766,7 +3767,7 @@ namespace dmGameObject
                     p.m_PropertyId = property_id;
                     p.m_UserData = user_data;
                     p.m_Value = value;
-                    p.m_Options = options;
+                    p.m_Options = &options;
                     return type->m_SetPropertyFunction(p);
                 }
                 else
@@ -3780,6 +3781,24 @@ namespace dmGameObject
             }
         }
         return PROPERTY_RESULT_OK;
+    }
+
+    bool AddPropertyOptionsKey(PropertyOptions* options, dmhash_t key)
+    {
+        if (options->m_OptionsCount >= MAX_PROPERTY_OPTIONS_COUNT)
+            return false;
+        options->m_Options[options->m_OptionsCount].m_Key = key;
+        options->m_Options[options->m_OptionsCount].m_HasKey = 1;
+        options->m_OptionsCount++;
+    }
+
+    bool AddPropertyOptionsIndex(PropertyOptions* options, int32_t index)
+    {
+        if (options->m_OptionsCount >= MAX_PROPERTY_OPTIONS_COUNT)
+            return false;
+        options->m_Options[options->m_OptionsCount].m_Index = index;
+        options->m_Options[options->m_OptionsCount].m_HasKey = 0;
+        options->m_OptionsCount++;
     }
 
     // Recreate the instance at the given index with a new prototype.

--- a/engine/gameobject/src/gameobject/gameobject.cpp
+++ b/engine/gameobject/src/gameobject/gameobject.cpp
@@ -3783,22 +3783,31 @@ namespace dmGameObject
         return PROPERTY_RESULT_OK;
     }
 
-    bool AddPropertyOptionsKey(PropertyOptions* options, dmhash_t key)
+    static inline PropertyOption* NextPropertyOption(PropertyOptions* options)
     {
         if (options->m_OptionsCount >= MAX_PROPERTY_OPTIONS_COUNT)
+            return 0;
+        return &options->m_Options[options->m_OptionsCount++];
+    }
+
+    bool AddPropertyOptionsKey(PropertyOptions* options, dmhash_t key)
+    {
+        PropertyOption* option = NextPropertyOption(options);
+        if (!option)
             return false;
-        options->m_Options[options->m_OptionsCount].m_Key = key;
-        options->m_Options[options->m_OptionsCount].m_HasKey = 1;
-        options->m_OptionsCount++;
+        option->m_Key = key;
+        option->m_HasKey = 1;
+        return true;
     }
 
     bool AddPropertyOptionsIndex(PropertyOptions* options, int32_t index)
     {
-        if (options->m_OptionsCount >= MAX_PROPERTY_OPTIONS_COUNT)
+        PropertyOption* option = NextPropertyOption(options);
+        if (!option)
             return false;
-        options->m_Options[options->m_OptionsCount].m_Index = index;
-        options->m_Options[options->m_OptionsCount].m_HasKey = 0;
-        options->m_OptionsCount++;
+        option->m_Index = index;
+        option->m_HasKey = 0;
+        return true;
     }
 
     // Recreate the instance at the given index with a new prototype.

--- a/engine/gameobject/src/gameobject/gameobject.cpp
+++ b/engine/gameobject/src/gameobject/gameobject.cpp
@@ -3972,6 +3972,52 @@ namespace dmGameObject
         return true;
     }
 
+    bool AddPropertyOption(PropertyOptions* options, PropertyOption option)
+    {
+        PropertyOption* opt = NextPropertyOption(options);
+        if (!opt)
+            return false;
+        *opt = option;
+        return true;
+    }
+
+    bool SetPropertyOptionsByIndex(PropertyOptions* options, uint32_t index, int32_t value)
+    {
+        if (index >= options->m_OptionsCount)
+            return false;
+        PropertyOption* option = &options->m_Options[index];
+        option->m_Index = value;
+        option->m_HasKey = 0;
+        return true;
+    }
+
+    uint32_t GetPropertyOptionsCount(HPropertyOptions options)
+    {
+        if (!options)
+            return 0;
+        return options->m_OptionsCount;
+    }
+
+    PropertyResult GetPropertyOptionsIndex(HPropertyOptions options, int index, int32_t* result)
+    {
+        if (!options || index >= options->m_OptionsCount)
+            return PROPERTY_RESULT_NOT_FOUND;
+        if (!options->m_Options[index].m_HasKey)
+            return PROPERTY_RESULT_TYPE_MISMATCH;
+        *result = options->m_Options[index].m_Index;
+        return PROPERTY_RESULT_OK;
+    }
+
+    PropertyResult GetPropertyOptionsKey(HPropertyOptions options, int index, dmhash_t* result)
+    {
+        if (!options || index >= options->m_OptionsCount)
+            return PROPERTY_RESULT_NOT_FOUND;
+        if (!options->m_Options[index].m_HasKey)
+            return PROPERTY_RESULT_TYPE_MISMATCH;
+        *result = options->m_Options[index].m_Key;
+        return PROPERTY_RESULT_OK;
+    }
+
     PropertyResult SetPropertyFromHash(HInstance instance, dmhash_t component_id, dmhash_t property_id, dmhash_t value)
     {
         PropertyOptions options;

--- a/engine/gameobject/src/gameobject/gameobject.cpp
+++ b/engine/gameobject/src/gameobject/gameobject.cpp
@@ -3998,20 +3998,20 @@ namespace dmGameObject
         return options->m_OptionsCount;
     }
 
-    PropertyResult GetPropertyOptionsIndex(HPropertyOptions options, int index, int32_t* result)
+    PropertyResult GetPropertyOptionsIndex(HPropertyOptions options, uint32_t index, int32_t* result)
     {
         if (!options || index >= options->m_OptionsCount)
-            return PROPERTY_RESULT_NOT_FOUND;
+            return PROPERTY_RESULT_INVALID_INDEX;
         if (options->m_Options[index].m_HasKey)
             return PROPERTY_RESULT_TYPE_MISMATCH;
         *result = options->m_Options[index].m_Index;
         return PROPERTY_RESULT_OK;
     }
 
-    PropertyResult GetPropertyOptionsKey(HPropertyOptions options, int index, dmhash_t* result)
+    PropertyResult GetPropertyOptionsKey(HPropertyOptions options, uint32_t index, dmhash_t* result)
     {
         if (!options || index >= options->m_OptionsCount)
-            return PROPERTY_RESULT_NOT_FOUND;
+            return PROPERTY_RESULT_INVALID_INDEX;
         if (!options->m_Options[index].m_HasKey)
             return PROPERTY_RESULT_TYPE_MISMATCH;
         *result = options->m_Options[index].m_Key;

--- a/engine/gameobject/src/gameobject/gameobject_props.h
+++ b/engine/gameobject/src/gameobject/gameobject_props.h
@@ -81,6 +81,8 @@ namespace dmGameObject
 
     bool AddPropertyOptionsKey(PropertyOptions* options, dmhash_t key);
     bool AddPropertyOptionsIndex(PropertyOptions* options, int32_t index);
+    bool AddPropertyOption(PropertyOptions* options, PropertyOption option);
+    bool SetPropertyOptionsByIndex(PropertyOptions* options, uint32_t index, int32_t value);
 
     HProperties NewProperties(const NewPropertiesParams& params);
     void DeleteProperties(HProperties properties);

--- a/engine/gameobject/src/gameobject/gameobject_props.h
+++ b/engine/gameobject/src/gameobject/gameobject_props.h
@@ -76,9 +76,6 @@ namespace dmGameObject
         uint8_t        m_OptionsCount;
     };
 
-    // dmhash_t paths[] = { ... };
-    // PropertyResult SetPropertyByHashes(HInstance instance, dmhash_t component_id, dmhash_t property_id, dmhash_t* hashes, uint32_t num_hashes, const PropertyVar& value);
-
     bool AddPropertyOptionsKey(PropertyOptions* options, dmhash_t key);
     bool AddPropertyOptionsIndex(PropertyOptions* options, int32_t index);
     bool AddPropertyOption(PropertyOptions* options, PropertyOption option);

--- a/engine/gameobject/src/gameobject/gameobject_props.h
+++ b/engine/gameobject/src/gameobject/gameobject_props.h
@@ -29,6 +29,8 @@
 
 namespace dmGameObject
 {
+    const uint8_t MAX_PROPERTY_OPTIONS_COUNT = 4;
+
     enum PropertyLayer
     {
         PROPERTY_LAYER_INSTANCE = 0,
@@ -55,6 +57,30 @@ namespace dmGameObject
         uintptr_t m_ResolvePathUserData;
         dmScript::GetURLCallback m_GetURLCallback;
     };
+
+    struct PropertyOption
+    {
+        union
+        {
+            dmhash_t m_Key;
+            int32_t  m_Index;
+        };
+
+        uint8_t m_HasKey : 1;
+    };
+
+    struct PropertyOptions
+    {
+        PropertyOptions();
+        PropertyOption m_Options[MAX_PROPERTY_OPTIONS_COUNT];
+        uint8_t        m_OptionsCount;
+    };
+
+    // dmhash_t paths[] = { ... };
+    // PropertyResult SetPropertyByHashes(HInstance instance, dmhash_t component_id, dmhash_t property_id, dmhash_t* hashes, uint32_t num_hashes, const PropertyVar& value);
+
+    bool AddPropertyOptionsKey(PropertyOptions* options, dmhash_t key);
+    bool AddPropertyOptionsIndex(PropertyOptions* options, int32_t index);
 
     HProperties NewProperties(const NewPropertiesParams& params);
     void DeleteProperties(HProperties properties);

--- a/engine/gameobject/src/gameobject/gameobject_script.cpp
+++ b/engine/gameobject/src/gameobject/gameobject_script.cpp
@@ -632,19 +632,18 @@ namespace dmGameObject
         }
 
         dmGameObject::PropertyOptions property_options;
-        // property_options.m_Index = 0;
-        // property_options.m_HasKey = 0;
+        dmGameObject::PropertyOption option = {};
+
         bool index_requested = false;
 
-        // TODO
-        return 0;
-
-        /*
         // Options table
         if (lua_gettop(L) > 2)
         {
-            dmGameObject::LuaToPropertyOptions(L, 3, &property_options, property_id, &index_requested);
+            dmGameObject::LuaToPropertyOption(L, 3, &option, &index_requested);
         }
+
+        AddPropertyOption(&property_options, option);
+
         dmGameObject::PropertyDesc property_desc;
         dmGameObject::PropertyResult result = dmGameObject::GetProperty(target_instance, target.m_Fragment, property_id, property_options, property_desc);
 
@@ -664,7 +663,7 @@ namespace dmGameObject
             // Get the rest of the array elements and check each result individually
             for (int i = 1; i < property_desc.m_ArrayLength; ++i)
             {
-                property_options.m_Index = i;
+                SetPropertyOptionsByIndex(&property_options, 0, i);
                 result                   = dmGameObject::GetProperty(target_instance, target.m_Fragment, property_id, property_options, property_desc);
                 handle_go_get_result     = CheckGetPropertyResult(L, "go", result, property_desc, property_id, target, property_options, index_requested);
                 if (handle_go_get_result != 1)
@@ -678,7 +677,6 @@ namespace dmGameObject
         }
 
         return CheckGetPropertyResult(L, "go", result, property_desc, property_id, target, property_options, index_requested);
-        */
     }
 
     /*# sets a named property of the specified game object or component, or a material constant
@@ -769,17 +767,20 @@ namespace dmGameObject
             return luaL_error(L, "could not find any instance with id '%s'.", dmHashReverseSafe64Alloc(&hash_ctx, target.m_Path));
         }
 
-        dmGameObject::PropertyOptions property_options = {};
+        dmGameObject::PropertyOptions property_options;
+        dmGameObject::PropertyOption option = {};
+
         if (lua_gettop(L) > 3)
         {
-            int options_result = LuaToPropertyOptions(L, 4, &property_options, property_id, 0);
+            int options_result = LuaToPropertyOption(L, 4, &option, 0);
             if (options_result != 0)
             {
                 return options_result;
             }
         }
 
-        /*
+        AddPropertyOption(&property_options, option);
+
         if (lua_istable(L, 3))
         {
             lua_pushvalue(L, 3);
@@ -801,7 +802,7 @@ namespace dmGameObject
                 dmGameObject::PropertyVar property_var;
                 dmGameObject::PropertyResult result = dmGameObject::LuaToVar(L, -1, property_var);
 
-                property_options.m_Index = table_index_lua - 1;
+                SetPropertyOptionsByIndex(&property_options, 0, table_index_lua - 1);
 
                 if (result == PROPERTY_RESULT_OK)
                 {
@@ -828,7 +829,6 @@ namespace dmGameObject
 
             return dmGameObject::HandleGoSetResult(L, result, property_id, target_instance, target, property_options);
         }
-        */
 
         return 0;
     }

--- a/engine/gameobject/src/gameobject/gameobject_script.cpp
+++ b/engine/gameobject/src/gameobject/gameobject_script.cpp
@@ -632,10 +632,14 @@ namespace dmGameObject
         }
 
         dmGameObject::PropertyOptions property_options;
-        property_options.m_Index = 0;
-        property_options.m_HasKey = 0;
+        // property_options.m_Index = 0;
+        // property_options.m_HasKey = 0;
         bool index_requested = false;
 
+        // TODO
+        return 0;
+
+        /*
         // Options table
         if (lua_gettop(L) > 2)
         {
@@ -674,6 +678,7 @@ namespace dmGameObject
         }
 
         return CheckGetPropertyResult(L, "go", result, property_desc, property_id, target, property_options, index_requested);
+        */
     }
 
     /*# sets a named property of the specified game object or component, or a material constant
@@ -774,6 +779,7 @@ namespace dmGameObject
             }
         }
 
+        /*
         if (lua_istable(L, 3))
         {
             lua_pushvalue(L, 3);
@@ -822,6 +828,7 @@ namespace dmGameObject
 
             return dmGameObject::HandleGoSetResult(L, result, property_id, target_instance, target, property_options);
         }
+        */
 
         return 0;
     }
@@ -1787,7 +1794,7 @@ namespace dmGameObject
             return luaL_error(L, "Could not find any instance with id '%s'.", dmHashReverseSafe64Alloc(&hash_ctx, target.m_Path));
 
         dmGameObject::PropertyOptions opt;
-        opt.m_Index = 0;
+        //opt.m_Index = 0;
 
         dmGameObject::PropertyResult res = dmGameObject::CancelAnimations(collection, target_instance, target.m_Fragment, property_id);
 

--- a/engine/gameobject/src/gameobject/gameobject_script.cpp
+++ b/engine/gameobject/src/gameobject/gameobject_script.cpp
@@ -1794,8 +1794,6 @@ namespace dmGameObject
             return luaL_error(L, "Could not find any instance with id '%s'.", dmHashReverseSafe64Alloc(&hash_ctx, target.m_Path));
 
         dmGameObject::PropertyOptions opt;
-        //opt.m_Index = 0;
-
         dmGameObject::PropertyResult res = dmGameObject::CancelAnimations(collection, target_instance, target.m_Fragment, property_id);
 
         switch (res)

--- a/engine/gameobject/src/gameobject/gameobject_script_util.cpp
+++ b/engine/gameobject/src/gameobject/gameobject_script_util.cpp
@@ -83,24 +83,23 @@ namespace dmGameObject
         return dmGameObject::RESULT_OK;
     }
 
-    int LuaToPropertyOptions(lua_State* L, int index, PropertyOptions* property_options, dmhash_t property_id, bool* index_requested)
+    int LuaToPropertyOption(lua_State* L, int index, PropertyOption* property_option, bool* index_requested)
     {
-        /*
         luaL_checktype(L, index, LUA_TTABLE);
         lua_pushvalue(L, index);
 
         lua_getfield(L, -1, "key");
         if (!lua_isnil(L, -1))
         {
-            property_options->m_Key = dmScript::CheckHashOrString(L, -1);
-            property_options->m_HasKey = 1;
+            property_option->m_Key = dmScript::CheckHashOrString(L, -1);
+            property_option->m_HasKey = 1;
         }
         lua_pop(L, 1);
 
         lua_getfield(L, -1, "index");
         if (!lua_isnil(L, -1)) // make it optional
         {
-            if (property_options->m_HasKey)
+            if (property_option->m_HasKey)
             {
                 return luaL_error(L, "Options table cannot contain both 'key' and 'index'.");
             }
@@ -109,30 +108,32 @@ namespace dmGameObject
                 return luaL_error(L, "Invalid number passed as index argument in options table.");
             }
 
-            property_options->m_Index = luaL_checkinteger(L, -1) - 1;
+            property_option->m_Index = luaL_checkinteger(L, -1) - 1;
 
-            if (property_options->m_Index < 0)
+            if (property_option->m_Index < 0)
             {
-                return luaL_error(L, "Negative numbers passed as index argument in options table (%d).", property_options->m_Index);
+                return luaL_error(L, "Negative numbers passed as index argument in options table (%d).", property_option->m_Index);
             }
-
             if (index_requested)
-            {
                 *index_requested = true;
-            }
         }
         lua_pop(L, 1);
 
         lua_pop(L, 1);
-        */
 
         return 0;
     }
 
     int CheckGetPropertyResult(lua_State* L, const char* module_name, dmGameObject::PropertyResult result, const PropertyDesc& property_desc, dmhash_t property_id, const dmMessage::URL& target, const dmGameObject::PropertyOptions& property_options, bool index_requested)
     {
-        /*
         DM_HASH_REVERSE_MEM(hash_ctx, 512);
+
+        dmhash_t key = 0;
+        bool has_key = GetPropertyOptionsKey((HPropertyOptions) &property_options, 0, &key) == dmGameObject::PROPERTY_RESULT_OK;
+
+        int32_t index = 0;
+        GetPropertyOptionsIndex((HPropertyOptions) &property_options, 0, &index);
+
         switch (result)
         {
         case dmGameObject::PROPERTY_RESULT_OK:
@@ -141,7 +142,7 @@ namespace dmGameObject
                 {
                     return luaL_error(L, "Options table contains index, but property '%s' is not an array.", dmHashReverseSafe64Alloc(&hash_ctx, property_id));
                 }
-                else if (property_options.m_HasKey && (property_desc.m_ValueType != dmGameObject::PROP_VALUE_HASHTABLE))
+                else if (has_key && (property_desc.m_ValueType != dmGameObject::PROP_VALUE_HASHTABLE))
                 {
                     return luaL_error(L, "Options table contains key, but property '%s' is not a hashtable.", dmHashReverseSafe64Alloc(&hash_ctx, property_id));
                 }
@@ -152,9 +153,9 @@ namespace dmGameObject
             }
         case dmGameObject::PROPERTY_RESULT_RESOURCE_NOT_FOUND:
             {
-                if (property_options.m_HasKey)
+                if (has_key)
                 {
-                    return luaL_error(L, "Resource `%s` for property '%s' not found!", dmHashReverseSafe64Alloc(&hash_ctx, property_options.m_Key), dmHashReverseSafe64Alloc(&hash_ctx, property_id));
+                    return luaL_error(L, "Resource `%s` for property '%s' not found!", dmHashReverseSafe64Alloc(&hash_ctx, key), dmHashReverseSafe64Alloc(&hash_ctx, property_id));
                 }
                 else
                 {
@@ -163,19 +164,19 @@ namespace dmGameObject
             }
         case dmGameObject::PROPERTY_RESULT_INVALID_INDEX:
             {
-                if (property_options.m_HasKey)
+                if (has_key)
                 {
                     return luaL_error(L, "Property '%s' is an array, but in options table specified key instead of index.", dmHashReverseSafe64Alloc(&hash_ctx, property_id));
                 }
-                return luaL_error(L, "Invalid index %d for property '%s'", property_options.m_Index+1, dmHashReverseSafe64Alloc(&hash_ctx, property_id));
+                return luaL_error(L, "Invalid index %d for property '%s'", index+1, dmHashReverseSafe64Alloc(&hash_ctx, property_id));
             }
         case dmGameObject::PROPERTY_RESULT_INVALID_KEY:
             {
-                if (!property_options.m_HasKey)
+                if (!has_key)
                 {
                     return luaL_error(L, "Property '%s' is a hashtable, but in options table specified index instead of key.", dmHashReverseSafe64Alloc(&hash_ctx, property_id));
                 }
-                return luaL_error(L, "Invalid key '%s' for property '%s'", dmHashReverseSafe64Alloc(&hash_ctx, property_options.m_Key), dmHashReverseSafe64Alloc(&hash_ctx, property_id));
+                return luaL_error(L, "Invalid key '%s' for property '%s'", dmHashReverseSafe64Alloc(&hash_ctx, key), dmHashReverseSafe64Alloc(&hash_ctx, property_id));
             }
         case dmGameObject::PROPERTY_RESULT_NOT_FOUND:
             {
@@ -193,7 +194,6 @@ namespace dmGameObject
             // Should never happen, programmer error
             return luaL_error(L, "%s.get failed with error code %d", module_name, result);
         }
-        */
         return 0;
     }
 
@@ -201,7 +201,12 @@ namespace dmGameObject
     {
         DM_HASH_REVERSE_MEM(hash_ctx, 512);
 
-        /*
+        dmhash_t key = 0;
+        bool has_key = GetPropertyOptionsKey((HPropertyOptions) &property_options, 0, &key) == dmGameObject::PROPERTY_RESULT_OK;
+
+        int32_t index = 0;
+        GetPropertyOptionsIndex((HPropertyOptions) &property_options, 0, &index);
+
         switch (result)
         {
             case dmGameObject::PROPERTY_RESULT_OK:
@@ -234,19 +239,19 @@ namespace dmGameObject
             }
             case dmGameObject::PROPERTY_RESULT_INVALID_INDEX:
             {
-                if (property_options.m_HasKey)
+                if (has_key)
                 {
                     return luaL_error(L, "Property '%s' is an array, but in options table specified key instead of index.", dmHashReverseSafe64Alloc(&hash_ctx, property_id));
                 }
-                return luaL_error(L, "Invalid index %d for property '%s'", property_options.m_Index+1, dmHashReverseSafe64Alloc(&hash_ctx, property_id));
+                return luaL_error(L, "Invalid index %d for property '%s'", index+1, dmHashReverseSafe64Alloc(&hash_ctx, property_id));
             }
             case dmGameObject::PROPERTY_RESULT_INVALID_KEY:
             {
-                if (!property_options.m_HasKey)
+                if (!has_key)
                 {
                     return luaL_error(L, "Property '%s' is a hashtable, but in options table specified index instead of key.", dmHashReverseSafe64Alloc(&hash_ctx, property_id));
                 }
-                return luaL_error(L, "Invalid key '%s' for property '%s'", dmHashReverseSafe64Alloc(&hash_ctx, property_options.m_Key), dmHashReverseSafe64Alloc(&hash_ctx, property_id));
+                return luaL_error(L, "Invalid key '%s' for property '%s'", dmHashReverseSafe64Alloc(&hash_ctx, key), dmHashReverseSafe64Alloc(&hash_ctx, property_id));
             }
             case dmGameObject::PROPERTY_RESULT_COMP_NOT_FOUND:
                 return luaL_error(L, "could not find component '%s' when resolving '%s'", dmHashReverseSafe64Alloc(&hash_ctx, target.m_Fragment), lua_tostring(L, 1));
@@ -258,7 +263,6 @@ namespace dmGameObject
                 // Should never happen, programmer error
                 return luaL_error(L, "go.set failed with error code %d", result);
         }
-        */
 
         return 0;
     }

--- a/engine/gameobject/src/gameobject/gameobject_script_util.cpp
+++ b/engine/gameobject/src/gameobject/gameobject_script_util.cpp
@@ -14,6 +14,7 @@
 
 #include "gameobject.h"
 #include "gameobject_private.h"
+#include "gameobject_props.h"
 #include <stdint.h>
 #include <ddf/ddf.h>
 #include <resource/resource.h>
@@ -84,6 +85,7 @@ namespace dmGameObject
 
     int LuaToPropertyOptions(lua_State* L, int index, PropertyOptions* property_options, dmhash_t property_id, bool* index_requested)
     {
+        /*
         luaL_checktype(L, index, LUA_TTABLE);
         lua_pushvalue(L, index);
 
@@ -122,12 +124,14 @@ namespace dmGameObject
         lua_pop(L, 1);
 
         lua_pop(L, 1);
+        */
 
         return 0;
     }
 
     int CheckGetPropertyResult(lua_State* L, const char* module_name, dmGameObject::PropertyResult result, const PropertyDesc& property_desc, dmhash_t property_id, const dmMessage::URL& target, const dmGameObject::PropertyOptions& property_options, bool index_requested)
     {
+        /*
         DM_HASH_REVERSE_MEM(hash_ctx, 512);
         switch (result)
         {
@@ -189,6 +193,7 @@ namespace dmGameObject
             // Should never happen, programmer error
             return luaL_error(L, "%s.get failed with error code %d", module_name, result);
         }
+        */
         return 0;
     }
 
@@ -196,6 +201,7 @@ namespace dmGameObject
     {
         DM_HASH_REVERSE_MEM(hash_ctx, 512);
 
+        /*
         switch (result)
         {
             case dmGameObject::PROPERTY_RESULT_OK:
@@ -252,6 +258,7 @@ namespace dmGameObject
                 // Should never happen, programmer error
                 return luaL_error(L, "go.set failed with error code %d", result);
         }
+        */
 
         return 0;
     }

--- a/engine/gameobject/src/gameobject/gameobject_script_util.h
+++ b/engine/gameobject/src/gameobject/gameobject_script_util.h
@@ -26,7 +26,7 @@ namespace dmGameObject
 {
     bool   RegisterSubModules(dmResource::HFactory factory, dmScript::HContext script_context, dmLuaDDF::LuaModule* lua_module);
     Result LuaLoad(dmResource::HFactory factory, dmScript::HContext context, dmLuaDDF::LuaModule* module);
-    int    LuaToPropertyOptions(lua_State* L, int index, PropertyOptions* property_options, dmhash_t property_id, bool* index_requested);
+    int    LuaToPropertyOption(lua_State* L, int index, struct PropertyOption* property_options, bool* index_requested);
     int    CheckGetPropertyResult(lua_State* L, const char* module_name, dmGameObject::PropertyResult result, const PropertyDesc& property_desc, dmhash_t property_id, const dmMessage::URL& target, const dmGameObject::PropertyOptions& property_options, bool index_requested);
     int    HandleGoSetResult(lua_State* L, dmGameObject::PropertyResult result, dmhash_t property_id, dmGameObject::HInstance target_instance, const dmMessage::URL& target, const dmGameObject::PropertyOptions& property_options);
 

--- a/engine/gameobject/src/gameobject/test/props/test_gameobject_props.cpp
+++ b/engine/gameobject/src/gameobject/test/props/test_gameobject_props.cpp
@@ -307,7 +307,6 @@ static dmhash_t hash(const char* s)
     {\
         dmGameObject::PropertyDesc desc;\
         dmGameObject::PropertyOptions opt;\
-        opt.m_Index = 0;\
         ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::GetProperty(go, 0, hash(prop), opt, desc));\
         ASSERT_EQ(dmGameObject::PROPERTY_TYPE_NUMBER, desc.m_Variant.m_Type);\
         ASSERT_NEAR(v0, desc.m_Variant.m_Number, epsilon);\
@@ -316,7 +315,6 @@ static dmhash_t hash(const char* s)
 #define ASSERT_SET_PROP_NUM(go, prop, v0, epsilon)\
     {\
         dmGameObject::PropertyOptions opt;\
-        opt.m_Index = 0;\
         dmGameObject::PropertyVar var(v0);\
         dmGameObject::SetProperty(go, 0, hash(prop), opt, var);\
         dmGameObject::PropertyDesc desc;\
@@ -329,7 +327,6 @@ static dmhash_t hash(const char* s)
         dmGameObject::SetScale(go, v0);\
         dmGameObject::PropertyDesc desc;\
         dmGameObject::PropertyOptions opt;\
-        opt.m_Index = 0;\
         ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::GetProperty(go, 0, hash(prop), opt, desc));\
         ASSERT_EQ(dmGameObject::PROPERTY_TYPE_NUMBER, desc.m_Variant.m_Type);\
         ASSERT_NEAR(v0, *desc.m_ValuePtr, epsilon);\
@@ -338,7 +335,6 @@ static dmhash_t hash(const char* s)
 #define ASSERT_SET_PROP_V1(go, prop, v0, epsilon)\
     {\
         dmGameObject::PropertyOptions opt;\
-        opt.m_Index = 0;\
         dmGameObject::PropertyVar var(v0);\
         dmGameObject::SetProperty(go, 0, hash(prop), opt, var);\
         dmGameObject::PropertyDesc desc;\
@@ -350,7 +346,6 @@ static dmhash_t hash(const char* s)
     {\
         dmGameObject::PropertyDesc desc;\
         dmGameObject::PropertyOptions opt;\
-        opt.m_Index = 0;\
         ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::GetProperty(go, 0, hash(prop), opt, desc));\
         ASSERT_EQ(dmGameObject::PROPERTY_TYPE_VECTOR3, desc.m_Variant.m_Type);\
         ASSERT_EQ(hash(prop ".x"), desc.m_ElementIds[0]);\
@@ -378,7 +373,6 @@ static dmhash_t hash(const char* s)
     {\
         dmGameObject::PropertyVar var(v);\
         dmGameObject::PropertyOptions opt;\
-        opt.m_Index = 0;\
         ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::SetProperty(go, 0, hash(prop), opt, var));\
         dmGameObject::PropertyDesc desc;\
         ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::GetProperty(go, 0, hash(prop), opt, desc));\
@@ -412,7 +406,6 @@ static dmhash_t hash(const char* s)
     {\
         dmGameObject::PropertyDesc desc;\
         dmGameObject::PropertyOptions opt;\
-        opt.m_Index = 0;\
         ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::GetProperty(go, 0, hash(prop), opt, desc));\
         ASSERT_TRUE(dmGameObject::PROPERTY_TYPE_VECTOR4 == desc.m_Variant.m_Type || dmGameObject::PROPERTY_TYPE_QUAT == desc.m_Variant.m_Type);\
         ASSERT_EQ(hash(prop ".x"), desc.m_ElementIds[0]);\
@@ -446,7 +439,6 @@ static dmhash_t hash(const char* s)
     {\
         dmGameObject::PropertyVar var(v);\
         dmGameObject::PropertyOptions opt;\
-        opt.m_Index = 0;\
         ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::SetProperty(go, 0, hash(prop), opt, var));\
         dmGameObject::PropertyDesc desc;\
         ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::GetProperty(go, 0, hash(prop), opt, desc));\

--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -236,7 +236,9 @@ namespace dmGameSystem
         GuiComponent* gui_component  = (GuiComponent*) ctx;
         GuiSceneResource* resource   = gui_component->m_Resource;
         dmRender::HMaterial material = GetMaterial(gui_component, resource, scene, node);
-        uint32_t value_index         = options ? options->m_Index : 0;
+
+        int32_t value_index = 0;
+        GetPropertyOptionsIndex((dmGameObject::HPropertyOptions) options, 0, &value_index);
 
         CompGuiRenderConstantUserData user_data = {};
         user_data.m_GuiComponent = gui_component;
@@ -306,7 +308,8 @@ namespace dmGameSystem
         GuiComponent* gui_component  = (GuiComponent*) ctx;
         GuiSceneResource* resource   = gui_component->m_Resource;
         dmRender::HMaterial material = GetMaterial(gui_component, resource, scene, node);
-        uint32_t value_index         = options ? options->m_Index : 0;
+        int32_t value_index = 0;
+        GetPropertyOptionsIndex((dmGameObject::HPropertyOptions) options, 0, &value_index);
 
         CompGuiRenderConstantUserData user_data = {};
         user_data.m_GuiComponent = gui_component;
@@ -2930,31 +2933,34 @@ namespace dmGameSystem
         }
         else if (set_property == PROP_MATERIALS)
         {
-            if (!params.m_Options.m_HasKey)
+            dmhash_t key = 0;
+            if (GetPropertyOptionsKey(params.m_Options, 0, &key) != dmGameObject::PROPERTY_RESULT_OK)
             {
                 return dmGameObject::PROPERTY_RESULT_INVALID_KEY;
             }
 
             out_value.m_ValueType = dmGameObject::PROP_VALUE_HASHTABLE;
-            return GetResourceProperty(dmGameObject::GetFactory(params.m_Instance), dmGui::GetMaterial(gui_component->m_Scene, params.m_Options.m_Key), out_value);
+            return GetResourceProperty(dmGameObject::GetFactory(params.m_Instance), dmGui::GetMaterial(gui_component->m_Scene, key), out_value);
         }
         else if (set_property == PROP_FONTS)
         {
-            if (!params.m_Options.m_HasKey)
+            dmhash_t key = 0;
+            if (GetPropertyOptionsKey(params.m_Options, 0, &key) != dmGameObject::PROPERTY_RESULT_OK)
             {
                 return dmGameObject::PROPERTY_RESULT_INVALID_KEY;
             }
             out_value.m_ValueType = dmGameObject::PROP_VALUE_HASHTABLE;
-            return GetResourceProperty(dmGameObject::GetFactory(params.m_Instance), dmGui::GetFont(gui_component->m_Scene, params.m_Options.m_Key), out_value);
+            return GetResourceProperty(dmGameObject::GetFactory(params.m_Instance), dmGui::GetFont(gui_component->m_Scene, key), out_value);
         }
         else if (set_property == PROP_TEXTURES)
         {
-            if (!params.m_Options.m_HasKey)
+            dmhash_t key = 0;
+            if (GetPropertyOptionsKey(params.m_Options, 0, &key) != dmGameObject::PROPERTY_RESULT_OK)
             {
                 return dmGameObject::PROPERTY_RESULT_INVALID_KEY;
             }
             out_value.m_ValueType = dmGameObject::PROP_VALUE_HASHTABLE;
-            return GetResourceProperty(dmGameObject::GetFactory(params.m_Instance), (void*) dmGui::GetTexture(gui_component->m_Scene, params.m_Options.m_Key), out_value);
+            return GetResourceProperty(dmGameObject::GetFactory(params.m_Instance), (void*) dmGui::GetTexture(gui_component->m_Scene, key), out_value);
         }
 
         CompGuiPropertyGetterFn* getter_fn = g_CompGuiPropertyGetters.Get(set_property);
@@ -2975,7 +2981,8 @@ namespace dmGameSystem
         }
         else if (set_property == PROP_FONTS)
         {
-            if (!params.m_Options.m_HasKey)
+            dmhash_t key = 0;
+            if (GetPropertyOptionsKey(params.m_Options, 0, &key) != dmGameObject::PROPERTY_RESULT_OK)
             {
                 return dmGameObject::PROPERTY_RESULT_INVALID_KEY;
             }
@@ -2984,10 +2991,10 @@ namespace dmGameSystem
             dmGameObject::PropertyResult res = SetResourceProperty(factory, params.m_Value, FONT_EXT_HASH, (void**)&font_resource);
             if (res == dmGameObject::PROPERTY_RESULT_OK)
             {
-                dmGui::Result r = dmGui::AddFont(gui_component->m_Scene, params.m_Options.m_Key, (void*)font_resource, params.m_Value.m_Hash);
+                dmGui::Result r = dmGui::AddFont(gui_component->m_Scene, key, (void*)font_resource, params.m_Value.m_Hash);
                 if (r != dmGui::RESULT_OK)
                 {
-                    dmLogError("Unable to set font `%s` property in component `%s`", dmHashReverseSafe64(params.m_Options.m_Key), gui_component->m_Resource->m_Path);
+                    dmLogError("Unable to set font `%s` property in component `%s`", dmHashReverseSafe64(key), gui_component->m_Resource->m_Path);
                     dmResource::Release(factory, font_resource);
                     return dmGameObject::PROPERTY_RESULT_BUFFER_OVERFLOW;
                 }
@@ -3000,7 +3007,8 @@ namespace dmGameSystem
         }
         else if (set_property == PROP_TEXTURES)
         {
-            if (!params.m_Options.m_HasKey)
+            dmhash_t key = 0;
+            if (GetPropertyOptionsKey(params.m_Options, 0, &key) != dmGameObject::PROPERTY_RESULT_OK)
             {
                 return dmGameObject::PROPERTY_RESULT_INVALID_KEY;
             }
@@ -3009,12 +3017,12 @@ namespace dmGameSystem
             dmGameObject::PropertyResult res = SetResourceProperty(factory, params.m_Value, TEXTURE_SET_EXT_HASH, (void**)&texture_source);
             if (res == dmGameObject::PROPERTY_RESULT_OK)
             {
-                dmGui::Result r = dmGui::AddDynamicTexture(gui_component->m_Scene, params.m_Options.m_Key, (dmGui::HTextureSource) texture_source, dmGui::NODE_TEXTURE_TYPE_TEXTURE_SET,
+                dmGui::Result r = dmGui::AddDynamicTexture(gui_component->m_Scene, key, (dmGui::HTextureSource) texture_source, dmGui::NODE_TEXTURE_TYPE_TEXTURE_SET,
                                                             texture_source->m_Texture->m_OriginalWidth,
                                                             texture_source->m_Texture->m_OriginalHeight);
                 if (r != dmGui::RESULT_OK)
                 {
-                    dmLogError("Unable to add texture '%s' to scene (%d)", dmHashReverseSafe64(params.m_Options.m_Key),  r);
+                    dmLogError("Unable to add texture '%s' to scene (%d)", dmHashReverseSafe64(key),  r);
                     return dmGameObject::PROPERTY_RESULT_BUFFER_OVERFLOW;
                 }
                 if(gui_component->m_ResourcePropertyPointers.Full())
@@ -3027,7 +3035,8 @@ namespace dmGameSystem
         }
         else if (set_property == PROP_MATERIALS)
         {
-            if (!params.m_Options.m_HasKey)
+            dmhash_t key = 0;
+            if (GetPropertyOptionsKey(params.m_Options, 0, &key) != dmGameObject::PROPERTY_RESULT_OK)
             {
                 return dmGameObject::PROPERTY_RESULT_INVALID_KEY;
             }
@@ -3038,11 +3047,11 @@ namespace dmGameSystem
 
             if (res == dmGameObject::PROPERTY_RESULT_OK)
             {
-                dmGui::Result r = dmGui::AddMaterial(gui_component->m_Scene, params.m_Options.m_Key, material_res);
+                dmGui::Result r = dmGui::AddMaterial(gui_component->m_Scene, key, material_res);
 
                 if (r != dmGui::RESULT_OK)
                 {
-                    dmLogError("Unable to add material '%s' to scene (%d)", dmHashReverseSafe64(params.m_Options.m_Key), r);
+                    dmLogError("Unable to add material '%s' to scene (%d)", dmHashReverseSafe64(key), r);
                     return dmGameObject::PROPERTY_RESULT_BUFFER_OVERFLOW;
                 }
 

--- a/engine/gamesys/src/gamesys/components/comp_label.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_label.cpp
@@ -644,7 +644,9 @@ namespace dmGameSystem
             out_value.m_Variant = dmGameObject::PropertyVar(component->m_LineBreak != 0);
             return dmGameObject::PROPERTY_RESULT_OK;
         }
-        return GetMaterialConstant(GetMaterial(component, component->m_Resource), get_property, params.m_Options.m_Index, out_value, false, CompLabelGetConstantCallback, component);
+        int32_t value_index = 0;
+        GetPropertyOptionsIndex(params.m_Options, 0, &value_index);
+        return GetMaterialConstant(GetMaterial(component, component->m_Resource), get_property, value_index, out_value, false, CompLabelGetConstantCallback, component);
     }
 
     dmGameObject::PropertyResult CompLabelSetProperty(const dmGameObject::ComponentSetPropertyParams& params)
@@ -712,7 +714,10 @@ namespace dmGameSystem
             component->m_LineBreak = params.m_Value.m_Bool;
             return dmGameObject::PROPERTY_RESULT_OK;
         }
-        return SetMaterialConstant(GetMaterial(component, component->m_Resource), set_property, params.m_Value, params.m_Options.m_Index, CompLabelSetConstantCallback, component);
+
+        int32_t value_index = 0;
+        GetPropertyOptionsIndex(params.m_Options, 0, &value_index);
+        return SetMaterialConstant(GetMaterial(component, component->m_Resource), set_property, params.m_Value, value_index, CompLabelSetConstantCallback, component);
     }
 
     static bool CompLabelIterPropertiesGetNext(dmGameObject::SceneNodePropertyIterator* pit)

--- a/engine/gamesys/src/gamesys/components/comp_mesh.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_mesh.cpp
@@ -524,7 +524,6 @@ namespace dmGameSystem
     {
         DM_PROFILE("LateUpdate");
         MeshContext* context = (MeshContext*)params.m_Context;
-        dmRender::HRenderContext render_context = context->m_RenderContext;
         MeshWorld* world = (MeshWorld*)params.m_World;
 
         UpdateTransforms(world);
@@ -1014,7 +1013,10 @@ namespace dmGameSystem
             }
         }
 
-        return GetMaterialConstant(GetMaterial(component, component->m_Resource), params.m_PropertyId, params.m_Options.m_Index, out_value, true, CompMeshGetConstantCallback, component);
+        int32_t value_index = 0;
+        GetPropertyOptionsIndex(params.m_Options, 0, &value_index);
+
+        return GetMaterialConstant(GetMaterial(component, component->m_Resource), params.m_PropertyId, value_index, out_value, true, CompMeshGetConstantCallback, component);
     }
 
     dmGameObject::PropertyResult CompMeshSetProperty(const dmGameObject::ComponentSetPropertyParams& params)
@@ -1095,7 +1097,10 @@ namespace dmGameSystem
             }
         }
 
-        dmGameObject::PropertyResult res = SetMaterialConstant(GetMaterial(component, component->m_Resource), params.m_PropertyId, params.m_Value, params.m_Options.m_Index, CompMeshSetConstantCallback, component);
+        int32_t value_index = 0;
+        GetPropertyOptionsIndex(params.m_Options, 0, &value_index);
+
+        dmGameObject::PropertyResult res = SetMaterialConstant(GetMaterial(component, component->m_Resource), params.m_PropertyId, params.m_Value, value_index, CompMeshSetConstantCallback, component);
         component->m_ReHash |= res == dmGameObject::PROPERTY_RESULT_OK;
 
         return res;

--- a/engine/gamesys/src/gamesys/components/comp_model.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_model.cpp
@@ -870,7 +870,6 @@ namespace dmGameSystem
 
     static void SetMeshAttributeRenderData(ModelWorld* world, ModelComponent* component, dmRender::HRenderContext render_context, dmRender::HMaterial material, MeshRenderItem* render_item, dmGraphics::VertexAttribute* model_attributes, uint32_t model_attribute_count, MeshAttributeRenderData* rd)
     {
-        dmGraphics::HContext graphics_context = dmRender::GetGraphicsContext(render_context);
         dmGraphics::HVertexDeclaration vx_decl_vert = dmRender::GetVertexDeclaration(material, dmGraphics::VERTEX_STEP_FUNCTION_VERTEX);
 
         dmGraphics::VertexAttributeInfos material_infos;
@@ -2684,9 +2683,11 @@ namespace dmGameSystem
             }
         }
 
-        dmRender::HMaterial material = GetComponentMaterial(component, component->m_Resource, 0);
+        int32_t value_index = 0;
+        GetPropertyOptionsIndex(params.m_Options, 0, &value_index);
 
-        if (GetMaterialConstant(material, params.m_PropertyId, params.m_Options.m_Index, out_value, false, CompModelGetConstantCallback, component) == dmGameObject::PROPERTY_RESULT_OK)
+        dmRender::HMaterial material = GetComponentMaterial(component, component->m_Resource, 0);
+        if (GetMaterialConstant(material, params.m_PropertyId, value_index, out_value, false, CompModelGetConstantCallback, component) == dmGameObject::PROPERTY_RESULT_OK)
         {
             return dmGameObject::PROPERTY_RESULT_OK;
         }
@@ -2759,8 +2760,11 @@ namespace dmGameSystem
             }
         }
 
+        int32_t value_index = 0;
+        GetPropertyOptionsIndex(params.m_Options, 0, &value_index);
+
         dmRender::HMaterial material = GetComponentMaterial(component, component->m_Resource, 0);
-        dmGameObject::PropertyResult res = SetMaterialConstant(material, params.m_PropertyId, params.m_Value, params.m_Options.m_Index, CompModelSetConstantCallback, component);
+        dmGameObject::PropertyResult res = SetMaterialConstant(material, params.m_PropertyId, params.m_Value, value_index, CompModelSetConstantCallback, component);
 
         // Only check attributes if the constant property was not found
         if (res == dmGameObject::PROPERTY_RESULT_NOT_FOUND)

--- a/engine/gamesys/src/gamesys/components/comp_sprite.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sprite.cpp
@@ -2293,10 +2293,11 @@ namespace dmGameSystem
         {
             TextureSetResource* texture_set = 0;
 
-            if (params.m_Options.m_HasKey)
+            dmhash_t key = 0;
+            if (GetPropertyOptionsKey(params.m_Options, 0, &key) == dmGameObject::PROPERTY_RESULT_OK)
             {
                 out_value.m_ValueType = dmGameObject::PROP_VALUE_HASHTABLE;
-                texture_set = GetTextureSetByHash(component, params.m_Options.m_Key);
+                texture_set = GetTextureSetByHash(component, key);
             }
             if (!texture_set)
             {
@@ -2326,8 +2327,10 @@ namespace dmGameSystem
             return dmGameObject::PROPERTY_RESULT_OK;
         }
 
+        int32_t value_index = 0;
+        GetPropertyOptionsIndex(params.m_Options, 0, &value_index);
         dmRender::HMaterial material = GetComponentMaterial(component);
-        if (GetMaterialConstant(material, get_property, params.m_Options.m_Index, out_value, false, CompSpriteGetConstantCallback, component) == dmGameObject::PROPERTY_RESULT_OK)
+        if (GetMaterialConstant(material, get_property, value_index, out_value, false, CompSpriteGetConstantCallback, component) == dmGameObject::PROPERTY_RESULT_OK)
         {
             return dmGameObject::PROPERTY_RESULT_OK;
         }
@@ -2391,7 +2394,9 @@ namespace dmGameSystem
         }
         else if (set_property == PROP_IMAGE)
         {
-            dmhash_t sampler_name_hash = params.m_Options.m_HasKey ? params.m_Options.m_Key : 0;
+            dmhash_t sampler_name_hash = 0;
+            GetPropertyOptionsKey(params.m_Options, 0, &sampler_name_hash);
+
             dmGameObject::PropertyResult res = AddOverrideTextureSet(dmGameObject::GetFactory(params.m_Instance), component, sampler_name_hash, params.m_Value.m_Hash);
             component->m_ReHash |= res == dmGameObject::PROPERTY_RESULT_OK;
 
@@ -2447,8 +2452,11 @@ namespace dmGameSystem
             return dmGameObject::PROPERTY_RESULT_READ_ONLY;
         }
 
+        int32_t value_index = 0;
+        GetPropertyOptionsIndex(params.m_Options, 0, &value_index);
+
         dmRender::HMaterial material = GetComponentMaterial(component);
-        dmGameObject::PropertyResult res = SetMaterialConstant(material, params.m_PropertyId, params.m_Value, params.m_Options.m_Index, CompSpriteSetConstantCallback, component);
+        dmGameObject::PropertyResult res = SetMaterialConstant(material, params.m_PropertyId, params.m_Value, value_index, CompSpriteSetConstantCallback, component);
 
         // Only check attributes if the constant property was not found
         if (res == dmGameObject::PROPERTY_RESULT_NOT_FOUND)

--- a/engine/gamesys/src/gamesys/components/comp_tilegrid.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_tilegrid.cpp
@@ -969,7 +969,9 @@ namespace dmGameSystem
         {
             return GetResourceProperty(dmGameObject::GetFactory(params.m_Instance), GetTextureSet(component), out_value);
         }
-        return GetMaterialConstant(GetMaterial(component), params.m_PropertyId, params.m_Options.m_Index, out_value, true, CompTileGridGetConstantCallback, component);
+        int32_t value_index = 0;
+        GetPropertyOptionsIndex(params.m_Options, 0, &value_index);
+        return GetMaterialConstant(GetMaterial(component), params.m_PropertyId, value_index, out_value, true, CompTileGridGetConstantCallback, component);
     }
 
     dmGameObject::PropertyResult CompTileGridSetProperty(const dmGameObject::ComponentSetPropertyParams& params)
@@ -985,7 +987,9 @@ namespace dmGameSystem
             ReHash(component);
             return res;
         }
-        return SetMaterialConstant(GetMaterial(component), params.m_PropertyId, params.m_Value, params.m_Options.m_Index, CompTileGridSetConstantCallback, component);
+        int32_t value_index = 0;
+        GetPropertyOptionsIndex(params.m_Options, 0, &value_index);
+        return SetMaterialConstant(GetMaterial(component), params.m_PropertyId, params.m_Value, value_index, CompTileGridSetConstantCallback, component);
     }
 
     static bool CompTileGridIterPropertiesGetNext(dmGameObject::SceneNodePropertyIterator* pit)

--- a/engine/gui/src/gui_script.cpp
+++ b/engine/gui/src/gui_script.cpp
@@ -726,14 +726,16 @@ namespace dmGui
             return 1;
         }
 
-        /*
         dmGameObject::PropertyOptions property_options = {};
+        dmGameObject::PropertyOption option = {};
         bool index_requested = false;
 
         if (lua_gettop(L) >= 3)
         {
-            dmGameObject::LuaToPropertyOptions(L, 3, &property_options, property_id, &index_requested);
+            dmGameObject::LuaToPropertyOption(L, 3, &option, &index_requested);
         }
+
+        AddPropertyOption(&property_options, option);
 
         dmMessage::URL target = {};
         dmGameObject::PropertyDesc property_desc;
@@ -763,7 +765,8 @@ namespace dmGui
 
             for (int i = 1; i < array_size; ++i)
             {
-                property_options.m_Index = i;
+                SetPropertyOptionsByIndex(&property_options, 0, i);
+
                 property_res = dmGui::GetMaterialProperty(scene, hnode, property_id, property_desc, &property_options) ?
                         dmGameObject::PROPERTY_RESULT_OK : dmGameObject::PROPERTY_RESULT_NOT_FOUND;
 
@@ -780,8 +783,6 @@ namespace dmGui
         }
 
         return dmGameObject::CheckGetPropertyResult(L, "gui", property_res, property_desc, property_id, target, property_options, index_requested);
-        */
-        return 0;
     }
 
     /*# sets the named property of a specified gui node
@@ -901,14 +902,17 @@ namespace dmGui
         }
 
         dmGameObject::PropertyOptions property_options = {};
+        dmGameObject::PropertyOption option = {};
+
         if (lua_gettop(L) > 3)
         {
-            int options_result = LuaToPropertyOptions(L, 4, &property_options, property_hash, 0);
+            int options_result = LuaToPropertyOption(L, 4, &option, 0);
             if (options_result != 0)
             {
                 return options_result;
             }
         }
+        AddPropertyOption(&property_options, option);
 
         if (dmScript::IsURL(L, 1))
         {

--- a/engine/gui/src/gui_script.cpp
+++ b/engine/gui/src/gui_script.cpp
@@ -726,6 +726,7 @@ namespace dmGui
             return 1;
         }
 
+        /*
         dmGameObject::PropertyOptions property_options = {};
         bool index_requested = false;
 
@@ -779,6 +780,8 @@ namespace dmGui
         }
 
         return dmGameObject::CheckGetPropertyResult(L, "gui", property_res, property_desc, property_id, target, property_options, index_requested);
+        */
+        return 0;
     }
 
     /*# sets the named property of a specified gui node


### PR DESCRIPTION
Refactored the `dmGameObject::PropertyOptions` struct from dmSDK into an API that can be used to encapsulate multiple options from an options table in the lua script API (e.g `go.get / go.set`):

```c++
typedef struct PropertyOptions* HPropertyOptions;
uint32_t GetPropertyOptionsCount(HPropertyOptions options);
PropertyResult GetPropertyOptionsIndex(HPropertyOptions options, uint32_t options_index, int32_t* result);
PropertyResult GetPropertyOptionsKey(HPropertyOptions options, uint32_t options_index, dmhash_t* result);
```

Since this is an SDK change, certain adjustments are required in custom components:

```c++
// Old code:
dmGameSystem::SetMaterialConstant(material, params.m_PropertyId, params.m_Value, params.m_Options.m_Index, set_constant_cb, component);

// New code:
int32_t value_index = 0;
dmGameObject::GetPropertyOptionsIndex(params.m_Options, 0, &value_index);
dmGameSystem::SetMaterialConstant(material, params.m_PropertyId, params.m_Value, value_index, set_constant_cb, component);
```

Fixes #11784 
