### PR TITLE
Throw an error when the `build` folder inside the project folder is used for bundling

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
@@ -728,6 +728,9 @@ public class Project {
      */
     public List<TaskResult> build(IProgress monitor, String... commands) throws IOException, CompileExceptionError, MultipleCompileException {
         try {
+            if (isBundleCommandRequested(commands)) {
+                getBundleOutputDirectory();
+            }
             TimeProfiler.start("loadProjectFile");
             loadProjectFile(true);
             TimeProfiler.stop();
@@ -753,6 +756,18 @@ public class Project {
         } catch (Throwable e) {
             throw new CompileExceptionError(null, 0, e.getMessage(), e);
         }
+    }
+
+    private boolean isBundleCommandRequested(String... commands) {
+        if (commands == null) {
+            return false;
+        }
+        for (String command : commands) {
+            if ("bundle".equals(command)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**
@@ -917,15 +932,25 @@ public class Project {
         m.done();
     }
 
-    private File getBundleOutputDirectory() {
+    private File getBundleOutputDirectory() throws IOException, CompileExceptionError {
         String bundleOutput = option("bundle-output", null);
         File bundleDir = null;
         if (bundleOutput != null) {
             bundleDir = new File(bundleOutput);
         } else {
-            bundleDir = new File(getRootDirectory(), getBuildDirectory());
+            bundleDir = new File(FilenameUtils.concat(getRootDirectory(), getBuildDirectory()));
         }
+        validateBundleOutputDirectory(bundleDir);
         return bundleDir;
+    }
+
+    private void validateBundleOutputDirectory(File bundleDir) throws IOException, CompileExceptionError {
+        File buildDir = new File(FilenameUtils.concat(getRootDirectory(), "build"));
+        Path bundlePath = bundleDir.getCanonicalFile().toPath();
+        Path buildPath = buildDir.getCanonicalFile().toPath();
+        if (bundlePath.startsWith(buildPath)) {
+            throw new CompileExceptionError("Build folder '" + bundlePath + "' in the project folder can't be used for bundling as this folder is reserved for Defold build system.");
+        }
     }
 
     public void registerTextureCompressors() {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
@@ -728,8 +728,9 @@ public class Project {
      */
     public List<TaskResult> build(IProgress monitor, String... commands) throws IOException, CompileExceptionError, MultipleCompileException {
         try {
-            if (isBundleCommandRequested(commands)) {
-                getBundleOutputDirectory();
+            if (Arrays.asList(commands).contains("bundle")) {
+                File bundleDir = getBundleOutputDirectory();
+                validateBundleOutputDirectory(bundleDir);
             }
             TimeProfiler.start("loadProjectFile");
             loadProjectFile(true);
@@ -756,18 +757,6 @@ public class Project {
         } catch (Throwable e) {
             throw new CompileExceptionError(null, 0, e.getMessage(), e);
         }
-    }
-
-    private boolean isBundleCommandRequested(String... commands) {
-        if (commands == null) {
-            return false;
-        }
-        for (String command : commands) {
-            if ("bundle".equals(command)) {
-                return true;
-            }
-        }
-        return false;
     }
 
     /**
@@ -932,7 +921,7 @@ public class Project {
         m.done();
     }
 
-    private File getBundleOutputDirectory() throws IOException, CompileExceptionError {
+    private File getBundleOutputDirectory() throws CompileExceptionError {
         String bundleOutput = option("bundle-output", null);
         File bundleDir = null;
         if (bundleOutput != null) {
@@ -940,7 +929,6 @@ public class Project {
         } else {
             bundleDir = new File(FilenameUtils.concat(getRootDirectory(), getBuildDirectory()));
         }
-        validateBundleOutputDirectory(bundleDir);
         return bundleDir;
     }
 
@@ -949,7 +937,7 @@ public class Project {
         Path bundlePath = bundleDir.getCanonicalFile().toPath();
         Path buildPath = buildDir.getCanonicalFile().toPath();
         if (bundlePath.startsWith(buildPath)) {
-            throw new CompileExceptionError("Build folder '" + bundlePath + "' in the project folder can't be used for bundling as this folder is reserved for Defold build system.");
+            throw new CompileExceptionError("Folder '" + buildDir + "' in the project folder can't be used for bundling as this folder is reserved for Defold build system.");
         }
     }
 

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
@@ -936,7 +936,7 @@ public class Project {
         File buildDir = new File(FilenameUtils.concat(getRootDirectory(), "build"));
         Path bundlePath = bundleDir.getCanonicalFile().toPath();
         Path buildPath = buildDir.getCanonicalFile().toPath();
-        if (bundlePath.startsWith(buildPath)) {
+        if (bundlePath.startsWith(buildPath) && !bundlePath.toString().contains(getBuildDirectory())) {
             throw new CompileExceptionError("Folder '" + buildDir + "' in the project folder can't be used for bundling as this folder is reserved for Defold build system.");
         }
     }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/AndroidBundler.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/AndroidBundler.java
@@ -594,7 +594,7 @@ public class AndroidBundler implements IBundler {
             BundleHelper.throwIfCanceled(canceled);
             return baseZip;
         } catch (Exception e) {
-            throw new CompileExceptionError("Failed creating AAB base.zip", e);
+            throw new CompileExceptionError("Failed creating AAB base.zip. Cause: " + String.valueOf(e.getMessage()), e);
         }
     }
 


### PR DESCRIPTION
Notify the user that the `build` folder inside the project folder cannot be used for bundling.

Fix https://github.com/defold/defold/issues/11771