### PR TITLE
Improve project load time on big projects by 9%

### DIFF
--- a/editor/src/clj/editor/defold_project.clj
+++ b/editor/src/clj/editor/defold_project.clj
@@ -91,9 +91,6 @@
 
 (defn- load-resource-node [project resource-node-id resource source-value transpiler-tx-data-fn]
   (try
-    ;; TODO(save-value-cleanup): This shouldn't be able to happen anymore. Remove this check after some time in the wild.
-    (assert (and (not= :folder (resource/source-type resource))
-                 (resource/exists? resource)))
     (let [{:keys [read-fn load-fn] :as resource-type} (resource/resource-type resource)
           transpiler-tx-data (transpiler-tx-data-fn resource-node-id resource)]
       (cond-> []
@@ -1785,25 +1782,25 @@
                 (g/connect code-preprocessors :lua-preprocessors code-transpilers :lua-preprocessors)))))
         project-id
         (second
-              (g/tx-nodes-added
-                (g/transact
-                  (g/make-nodes graph
-                      [script-intelligence si/ScriptIntelligenceNode
-                       project [Project :workspace workspace-id]
-                       script-annotations script-annotations/ScriptAnnotations
-                       editor-localization-bundle editor-localization-bundle/EditorLocalizationBundle]
-                    (g/connect workspace-id :root script-annotations :root)
-                    (g/connect script-annotations :_node-id project :script-annotations)
-                    (g/connect editor-localization-bundle :_node-id project :editor-localization-bundle)
-                    (g/connect extensions :_node-id project :editor-extensions)
-                    (g/connect script-intelligence :_node-id project :script-intelligence)
-                    (g/connect workspace-id :build-settings project :build-settings)
-                    (g/connect workspace-id :dependencies project :dependencies)
-                    (g/connect workspace-id :resource-list project :resources)
-                    (g/connect workspace-id :resource-map project :resource-map)
-                    (g/set-graph-value graph :project-id project)
-                    (g/set-graph-value graph :lsp (lsp/make project get-resource-node))
-                    (g/set-graph-value graph :code-transpilers transpilers-id)))))]
+          (g/tx-nodes-added
+            (g/transact
+              (g/make-nodes graph
+                  [script-intelligence si/ScriptIntelligenceNode
+                   project [Project :workspace workspace-id]
+                   script-annotations script-annotations/ScriptAnnotations
+                   editor-localization-bundle editor-localization-bundle/EditorLocalizationBundle]
+                (g/connect workspace-id :root script-annotations :root)
+                (g/connect script-annotations :_node-id project :script-annotations)
+                (g/connect editor-localization-bundle :_node-id project :editor-localization-bundle)
+                (g/connect extensions :_node-id project :editor-extensions)
+                (g/connect script-intelligence :_node-id project :script-intelligence)
+                (g/connect workspace-id :build-settings project :build-settings)
+                (g/connect workspace-id :dependencies project :dependencies)
+                (g/connect workspace-id :resource-list project :resources)
+                (g/connect workspace-id :resource-map project :resource-map)
+                (g/set-graph-value graph :project-id project)
+                (g/set-graph-value graph :lsp (lsp/make project get-resource-node))
+                (g/set-graph-value graph :code-transpilers transpilers-id)))))]
     (reload-plugins! project-id (g/node-value project-id :resources))
     (workspace/add-resource-listener! workspace-id 1 (ProjectResourceListener. project-id))
     (g/reset-undo! graph)

--- a/editor/src/clj/editor/dialogs.clj
+++ b/editor/src/clj/editor/dialogs.clj
@@ -63,6 +63,9 @@
 (def clipping-container
   (fx.composite/describe ClippingContainer :ctor [] :props fx.stack-pane/props))
 
+(def ^:private dialogs-css-delay
+  (delay (str (io/resource "dialogs.css"))))
+
 (defn dialog-stage
   "Dialog `:stage` that manages scene graph itself and provides layout common
   for many dialogs.
@@ -86,7 +89,7 @@
       (dissoc :size :header :content :footer :root-props)
       (assoc :fx/type fxui/dialog-stage
              :scene {:fx/type fx.scene/lifecycle
-                     :stylesheets [(str (io/resource "dialogs.css"))]
+                     :stylesheets [@dialogs-css-delay]
                      :root (-> root-props
                                (fxui/add-style-classes
                                  "dialog-body"


### PR DESCRIPTION
Now the editor opens big projects a bit faster. As measured on an example big project, the load time reduced from 2m01s to 1m50s.

Technical notes:

Related to #10166