### PR TITLE
Custom game.project fields now show the correct UI after editor restart

### DIFF
--- a/editor/src/clj/editor/game_project.clj
+++ b/editor/src/clj/editor/game_project.clj
@@ -52,7 +52,7 @@
   (let [{:keys [settings-map meta-settings path->built-resource-settings]} user-data
         settings (into []
                        (comp (keep (fn [[path value]]
-                                     (if (:unknown-setting? (settings-core/get-meta-setting meta-settings path))
+                                     (if (:unknown-setting (settings-core/get-meta-setting meta-settings path))
                                        {:path path :value value}
                                        (when (and (some? value) (not= "" value))
                                          {:path path :value value}))))

--- a/editor/src/clj/editor/settings.clj
+++ b/editor/src/clj/editor/settings.clj
@@ -23,7 +23,8 @@
             [editor.settings-core :as settings-core]
             [editor.validation :as validation]
             [editor.workspace :as workspace]
-            [util.coll :as coll]))
+            [util.coll :as coll]
+            [util.eduction :as e]))
 
 (g/defnode ResourceSettingNode
   (property resource-connections g/Any) ; [target-node-id [connections]]
@@ -189,14 +190,28 @@
 
 (g/defnk produce-form-data [_node-id project owner-resource meta-info raw-settings resource-setting-nodes resource-settings resource-setting-connections]
   (let [meta-settings (:settings meta-info)
-        sanitized-settings (settings-core/sanitize-settings meta-settings (settings-core/settings-with-value raw-settings))
+        meta-settings-map (settings-core/make-meta-settings-map meta-settings)
+        sanitized-settings (->> raw-settings
+                                (settings-core/settings-with-value)
+                                (settings-core/sanitize-settings meta-settings)
+                                (mapv
+                                  (fn [{:keys [path value] :as setting}]
+                                    ;; We resolve raw string values to resources
+                                    ;; so the form gets typed values; this may
+                                    ;; happen when a :resource setting is
+                                    ;; defined via, e.g., game.properties,
+                                    ;; without a corresponding
+                                    ;; ResourceSettingNode in the graph.
+                                    (cond-> setting
+                                            (and (string? value) (= :resource (:type (meta-settings-map path))))
+                                            (assoc :value (workspace/resolve-resource owner-resource value))))))
         non-defaulted-setting-paths (into #{}
                                           (comp
                                             (filter :value)
                                             (map :path))
                                           sanitized-settings)
-        non-default-resource-settings (filter (comp non-defaulted-setting-paths :path) resource-settings)
-        all-settings (concat sanitized-settings non-default-resource-settings)]
+        non-default-resource-settings (filterv (comp non-defaulted-setting-paths :path) resource-settings)
+        all-settings (e/concat sanitized-settings non-default-resource-settings)]
     (make-form-data
       {:user-data {:node-id _node-id
                    :project project
@@ -222,12 +237,21 @@
   (input meta-infos g/Any)
   (input project-dependencies g/Any)
 
+  (output resource-setting-references g/Any :cached
+          (g/fnk [resource-setting-references meta-info]
+            (let [meta-settings (:settings meta-info)
+                  meta-settings-map (settings-core/make-meta-settings-map meta-settings)]
+              ;; We filter out nodes for settings that were resource, but stopped
+              ;; being them; which may happen when we define a resource setting
+              ;; using, e.g., game.properties file, then set the property, and
+              ;; then we change the type to be a string
+              (filterv #(= :resource (:type (meta-settings-map (:path %)))) resource-setting-references))))
   (output resource-setting-nodes g/Any :cached
           (g/fnk [resource-setting-references]
-                 (into {} (map (juxt :path :node-id) resource-setting-references))))
+            (into {} (map (juxt :path :node-id) resource-setting-references))))
   (output resource-settings g/Any :cached
           (g/fnk [resource-setting-references]
-                 (map #(select-keys % [:path :value]) resource-setting-references)))
+            (mapv #(select-keys % [:path :value]) resource-setting-references)))
 
   (output merged-raw-settings g/Any :cached
           (g/fnk [raw-settings meta-info resource-settings]

--- a/editor/src/clj/editor/settings.clj
+++ b/editor/src/clj/editor/settings.clj
@@ -188,7 +188,9 @@
                                      (str uri) (str required) (str current))}))))
         dependencies))
 
-(g/defnk produce-form-data [_node-id project owner-resource meta-info raw-settings resource-setting-nodes resource-settings resource-setting-connections]
+(g/defnk produce-form-data [^:unsafe _evaluation-context _node-id project owner-resource meta-info raw-settings resource-setting-nodes resource-settings resource-setting-connections]
+  ;; we use evaluation context to resolve a resource; we only need the resource
+  ;; for its path, so it's safe to use it here
   (let [meta-settings (:settings meta-info)
         meta-settings-map (settings-core/make-meta-settings-map meta-settings)
         sanitized-settings (->> raw-settings
@@ -204,7 +206,7 @@
                                     ;; ResourceSettingNode in the graph.
                                     (cond-> setting
                                             (and (string? value) (= :resource (:type (meta-settings-map path))))
-                                            (assoc :value (workspace/resolve-resource owner-resource value))))))
+                                            (assoc :value (workspace/resolve-resource owner-resource value _evaluation-context))))))
         non-defaulted-setting-paths (into #{}
                                           (comp
                                             (filter :value)

--- a/editor/test/editor/settings_test.clj
+++ b/editor/test/editor/settings_test.clj
@@ -1,0 +1,34 @@
+;; Copyright 2020-2026 The Defold Foundation
+;; Copyright 2014-2020 King
+;; Copyright 2009-2014 Ragnar Svensson, Christian Murray
+;; Licensed under the Defold License version 1.0 (the "License"); you may not use
+;; this file except in compliance with the License.
+;;
+;; You may obtain a copy of the License, together with FAQs at
+;; https://www.defold.com/license
+;;
+;; Unless required by applicable law or agreed to in writing, software distributed
+;; under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+;; CONDITIONS OF ANY KIND, either express or implied. See the License for the
+;; specific language governing permissions and limitations under the License.
+
+(ns editor.settings-test
+  (:require [clojure.test :refer :all]
+            [editor.settings-core :as settings-core]))
+
+(deftest merge-meta-infos-prefers-known-settings
+  (let [known-setting {:path ["section" "key"]
+                       :type :string
+                       :help "Known"}
+        unknown-setting {:path ["section" "key"]
+                         :type :string
+                         :help "Unknown"
+                         :unknown-setting true}]
+    (is (= {:settings [known-setting]}
+           (settings-core/merge-meta-infos
+             {:settings [unknown-setting]}
+             {:settings [known-setting]})))
+    (is (= {:settings [known-setting]}
+           (settings-core/merge-meta-infos
+             {:settings [known-setting]}
+             {:settings [unknown-setting]})))))


### PR DESCRIPTION
Previously, custom values defined in `game.project` via the `game.properties` or `ext.properties` would always be shown as strings upon restarting the editor. Now they are displayed with their correct types (e.g., checkboxes for booleans, list views for lists).

### Technical changes

I implemented 2 changes:
1. Made custom settings override unknown string settings, so the UI shows the expected UI
2. Added guards for situations where existing `ResourceSettingNode` connections don't match the settings meta, i.e., we might have a node for a setting, but change its type to string, or we might have no node, and we changed the setting type to be a resource.


Fixes #11793
Fixes #11293