### PR TITLE
Limit max dialog height to the height of the screen

### DIFF
--- a/editor/src/clj/editor/dialogs.clj
+++ b/editor/src/clj/editor/dialogs.clj
@@ -55,7 +55,7 @@
            [javafx.event Event]
            [javafx.scene.control ListView TextField]
            [javafx.scene.input KeyCode KeyEvent MouseButton MouseEvent]
-           [javafx.stage DirectoryChooser FileChooser FileChooser$ExtensionFilter Stage Window]
+           [javafx.stage DirectoryChooser FileChooser FileChooser$ExtensionFilter Screen Stage Window]
            [org.apache.commons.io FilenameUtils]))
 
 (set! *warn-on-reflection* true)
@@ -65,6 +65,15 @@
 
 (def ^:private dialogs-css-delay
   (delay (str (io/resource "dialogs.css"))))
+
+(defn max-dialog-stage-height []
+  (let [screens (Screen/getScreens)
+        n (.size screens)]
+    (loop [i 0
+           min-height Double/MAX_VALUE]
+      (if (= i n)
+        min-height
+        (recur (unchecked-inc i) (min min-height (.getHeight (.getVisualBounds ^Screen (.get screens i)))))))))
 
 (defn dialog-stage
   "Dialog `:stage` that manages scene graph itself and provides layout common
@@ -88,6 +97,7 @@
   (-> props
       (dissoc :size :header :content :footer :root-props)
       (assoc :fx/type fxui/dialog-stage
+             :max-height (max-dialog-stage-height)
              :scene {:fx/type fx.scene/lifecycle
                      :stylesheets [@dialogs-css-delay]
                      :root (-> root-props

--- a/editor/src/clj/editor/dialogs.clj
+++ b/editor/src/clj/editor/dialogs.clj
@@ -70,10 +70,10 @@
   (let [screens (Screen/getScreens)
         n (.size screens)]
     (loop [i 0
-           min-height Double/MAX_VALUE]
+           max-height 0.0]
       (if (= i n)
-        min-height
-        (recur (unchecked-inc i) (min min-height (.getHeight (.getVisualBounds ^Screen (.get screens i)))))))))
+        max-height
+        (recur (unchecked-inc i) (max max-height (.getHeight (.getVisualBounds ^Screen (.get screens i)))))))))
 
 (defn dialog-stage
   "Dialog `:stage` that manages scene graph itself and provides layout common


### PR DESCRIPTION
Dialog height is now limited to the height of the screen to prevent dialog content from overflowing outside of the visible area.

### Technical changes

We recently limited dialog heights to some reasonable value. It was not enough for computers with very small screens. This change ensures we don't exceed the height of the screen visual bounds. 

Fixes #11786