### PR TITLE
Backspace key (⌫) now performs a Delete action on macOS

### DIFF
--- a/editor/src/clj/editor/keymap.clj
+++ b/editor/src/clj/editor/keymap.clj
@@ -54,6 +54,7 @@
            ["Alt+Up" :code.goto-line-start]
            ["Alt+Up" :edit.reorder-up]
            ["Backspace" :code.delete-previous-char]
+           ["Backspace" :edit.delete]
            ["Ctrl+A" :code.goto-line-start]
            ["Ctrl+E" :code.goto-line-end]
            ["Ctrl+I" :code.reindent]


### PR DESCRIPTION
Pressing Backspace (⌫) now performs a Delete action on macOS.

Technical notes:

I verified it does not interfere with the code editor.

Fix #11000