### PR TITLE
Adjusted font metrics measurement slightly

### DIFF
--- a/engine/font/src/text_layout_legacy.cpp
+++ b/engine/font/src/text_layout_legacy.cpp
@@ -177,7 +177,7 @@ static float GetLineTextMetrics(TextGlyph* glyphs, uint32_t row_start, uint32_t 
         }
         trailing_space_width += g.m_Advance;
     }
-    float extent_last = last.m_LeftBearing + last.m_Width;
+    float extent_last = last.m_Width;
     float width = last.m_X - row_start_x + extent_last + trailing_space_width;
     return width;
 }
@@ -271,7 +271,23 @@ TextResult TextLayoutLegacyCreate(HFontCollection collection,
             g.m_Advance = font_glyph.m_Advance * scale;
             g.m_LeftBearing = font_glyph.m_LeftBearing * scale;
 
-            x += g.m_Advance + tracking;
+            // add tracking to the width of all but the first glyph
+            if (i > 0)
+            {
+                x += tracking;
+            }
+
+            // monospaced fonts have all glyphs of equal width
+            // the left bearing of the glyph should be ignored
+            if (settings->m_Monospace)
+            {
+                x += g.m_Advance;
+            }
+            else
+            {
+                x += g.m_Advance;
+                x += g.m_LeftBearing;
+            }
         }
 
         layout->m_Glyphs[i] = g;

--- a/engine/font/src/text_layout_legacy.cpp
+++ b/engine/font/src/text_layout_legacy.cpp
@@ -271,17 +271,7 @@ TextResult TextLayoutLegacyCreate(HFontCollection collection,
             g.m_Advance = font_glyph.m_Advance * scale;
             g.m_LeftBearing = font_glyph.m_LeftBearing * scale;
 
-            // monospaced fonts have all glyphs of equal width
-            // the left bearing of the glyph should be ignored
-            if (settings->m_Monospace)
-            {
-                x += g.m_Advance;
-            }
-            else
-            {
-                x += g.m_Advance;
-                x += g.m_LeftBearing;
-            }
+            x += g.m_Advance;
             x += tracking;
         }
 

--- a/engine/font/src/text_layout_legacy.cpp
+++ b/engine/font/src/text_layout_legacy.cpp
@@ -271,12 +271,6 @@ TextResult TextLayoutLegacyCreate(HFontCollection collection,
             g.m_Advance = font_glyph.m_Advance * scale;
             g.m_LeftBearing = font_glyph.m_LeftBearing * scale;
 
-            // add tracking to the width of all but the first glyph
-            if (i > 0)
-            {
-                x += tracking;
-            }
-
             // monospaced fonts have all glyphs of equal width
             // the left bearing of the glyph should be ignored
             if (settings->m_Monospace)
@@ -288,6 +282,7 @@ TextResult TextLayoutLegacyCreate(HFontCollection collection,
                 x += g.m_Advance;
                 x += g.m_LeftBearing;
             }
+            x += tracking;
         }
 
         layout->m_Glyphs[i] = g;

--- a/engine/render/src/test/test_render.cpp
+++ b/engine/render/src/test/test_render.cpp
@@ -1535,7 +1535,8 @@ TEST_F(dmRenderTest, TextAlignment)
 {
     dmRender::TextMetrics metrics = {0};
 
-    const int charwidth     = 2;
+    const int advance       = 2;
+    const int charwidth     = 1;
     const int ascent        = 2;
     const int descent       = 1;
     const int lineheight    = ascent + descent;
@@ -1553,7 +1554,7 @@ TEST_F(dmRenderTest, TextAlignment)
         numlines = 3;
 
         TextLayoutSettings settings = {0};
-        settings.m_Width        = 8*charwidth;
+        settings.m_Width        = 8*advance;
         settings.m_Leading      = leading;
         settings.m_Tracking     = tracking;
         settings.m_LineBreak    = true;
@@ -1561,7 +1562,7 @@ TEST_F(dmRenderTest, TextAlignment)
         dmRender::GetTextMetrics(font_backend, m_SystemFontMap, "Hello World Bonanza", &settings, &metrics);
         ASSERT_EQ(ascent, metrics.m_MaxAscent);
         ASSERT_EQ(descent, metrics.m_MaxDescent);
-        ASSERT_EQ(charwidth*7, metrics.m_Width);
+        ASSERT_EQ(advance*6+charwidth*1, metrics.m_Width);
         ASSERT_EQ(ExpectedHeight(lineheight, numlines, leading), metrics.m_Height);
 
 
@@ -1594,7 +1595,8 @@ TEST_F(dmRenderTest, GetTextMetrics)
 
     dmRender::TextMetrics metrics = {0};
 
-    const int charwidth     = 2;
+    const int advance       = 2;
+    const int charwidth     = 1;
     const int ascent        = 2;
     const int descent       = 1;
     const int lineheight    = ascent + descent;
@@ -1609,13 +1611,13 @@ TEST_F(dmRenderTest, GetTextMetrics)
     GetTextMetrics(font_backend, m_SystemFontMap, "Hello World", &settings, &metrics);
     ASSERT_EQ(ascent, metrics.m_MaxAscent);
     ASSERT_EQ(descent, metrics.m_MaxDescent);
-    ASSERT_EQ(charwidth*11, metrics.m_Width);
+    ASSERT_EQ(advance*10+charwidth*1, metrics.m_Width);
     ASSERT_EQ(lineheight*1, metrics.m_Height);
 
     // line break in the middle of the sentence
     int numlines = 2;
 
-    settings.m_Width = 8*charwidth;
+    settings.m_Width = 8*advance;
     settings.m_Leading = 1.0f;
     settings.m_Tracking = 0.0f;
     settings.m_LineBreak = true;
@@ -1623,11 +1625,11 @@ TEST_F(dmRenderTest, GetTextMetrics)
     GetTextMetrics(font_backend, m_SystemFontMap, "Hello World", &settings, &metrics);
     ASSERT_EQ(ascent, metrics.m_MaxAscent);
     ASSERT_EQ(descent, metrics.m_MaxDescent);
-    ASSERT_EQ(charwidth*5, metrics.m_Width);
+    ASSERT_EQ(advance*4+charwidth*1, metrics.m_Width);
     ASSERT_EQ(lineheight*numlines, metrics.m_Height);
 
 
-    settings.m_Width = 8*charwidth;
+    settings.m_Width = 8*advance;
     settings.m_Leading = 2.0f;
     settings.m_Tracking = 0.0f;
     settings.m_LineBreak = true;
@@ -1635,10 +1637,10 @@ TEST_F(dmRenderTest, GetTextMetrics)
     GetTextMetrics(font_backend, m_SystemFontMap, "Hello World", &settings, &metrics);
     ASSERT_EQ(ascent, metrics.m_MaxAscent);
     ASSERT_EQ(descent, metrics.m_MaxDescent);
-    ASSERT_EQ(charwidth*5, metrics.m_Width);
+    ASSERT_EQ(advance*4+charwidth*1, metrics.m_Width);
     ASSERT_EQ(ExpectedHeight(lineheight, numlines, settings.m_Leading), metrics.m_Height);
 
-    settings.m_Width = 8*charwidth;
+    settings.m_Width = 8*advance;
     settings.m_Leading = 0.0f;
     settings.m_Tracking = 0.0f;
     settings.m_LineBreak = true;
@@ -1646,10 +1648,10 @@ TEST_F(dmRenderTest, GetTextMetrics)
     GetTextMetrics(font_backend, m_SystemFontMap, "Hello World", &settings, &metrics);
     ASSERT_EQ(ascent, metrics.m_MaxAscent);
     ASSERT_EQ(descent, metrics.m_MaxDescent);
-    ASSERT_EQ(charwidth*5, metrics.m_Width);
+    ASSERT_EQ(advance*4+charwidth*1, metrics.m_Width);
     ASSERT_EQ(ExpectedHeight(lineheight, numlines, settings.m_Leading), metrics.m_Height);
 
-    settings.m_Width = 8*charwidth;
+    settings.m_Width = 8*advance;
     settings.m_Leading = 1.0f;
     settings.m_Tracking = 0.0f;
     settings.m_LineBreak = true;
@@ -1658,7 +1660,7 @@ TEST_F(dmRenderTest, GetTextMetrics)
     GetTextMetrics(font_backend, m_SystemFontMap, "Hello World Bonanza", &settings, &metrics);
     ASSERT_EQ(ascent, metrics.m_MaxAscent);
     ASSERT_EQ(descent, metrics.m_MaxDescent);
-    ASSERT_EQ(charwidth*7, metrics.m_Width);
+    ASSERT_EQ(advance*6+charwidth*1, metrics.m_Width);
     ASSERT_EQ(ExpectedHeight(lineheight, numlines, settings.m_Leading), metrics.m_Height);
     ASSERT_EQ(numlines, metrics.m_LineCount);
 


### PR DESCRIPTION
Slight adjustment to the text measurement algorithm to match the editor and engine as close as possible.

EDITOR:
<img width="1814" height="1208" alt="editor" src="https://github.com/user-attachments/assets/6249a4ad-3158-4f27-88ff-50b9433bb0e9" />

ENGINE:
<img width="1814" height="1208" alt="engine" src="https://github.com/user-attachments/assets/17f8e94b-0ead-45bf-963a-99bb03e8bb9b" />

EDITOR w ENGINE overlaid at 50% transparency:
<img width="1814" height="1208" alt="editor-engine" src="https://github.com/user-attachments/assets/e61e3ae0-3402-496e-a968-6ed7bb6e6693" />

Fixes #11809
