### PR TITLE
Fix issues where DF fonts appear blurry in some cases.

### DIFF
--- a/engine/docs/FONTS_AND_TEXT.md
+++ b/engine/docs/FONTS_AND_TEXT.md
@@ -75,6 +75,8 @@ The render library also manages the texture cache, via its `HFontMap`
 
 Final vertex data generation is handled by `dmRender::CreateFontVertexData` in `engine/render/src/render/font/default/font_default_vertex.cpp`.
 
+For distance-field fonts, SDF smoothing is computed in screen space. The renderer derives a pixels-per-local-unit scale from the current view-projection matrix and viewport and uses it to keep edge thickness stable under camera zoom and perspective. If the projection is invalid for a text entry (e.g. clip `w` near zero or a zero-sized viewport), it falls back to the local/world scale.
+
 ### dmRender::HFontMap
 
 The font map holds cached information such as glyph metrics and glyph bitmap data.
@@ -140,5 +142,4 @@ The scripting module allows for associating a compatible `HFont` with a `HFontCo
 In particular, you can get a `HFont` from a `HFontCollection` (.fontc) and associate it with another `HFontCollection`. This will increase the reference count of the underlying `HFont` resource (.ttf).
 
 The scripting api will also allow for generating new glyphs on-the-fly. This operation is asynchronous, as the bitmap generation is time consuming.
-
 

--- a/engine/render/src/render/font/font_renderer_api.h
+++ b/engine/render/src/render/font/font_renderer_api.h
@@ -77,13 +77,14 @@ namespace dmRender
      * @param font_map [type: HFontMap] the fon
      * @param frame [type: uint32_t] the current frame. Used when caching new glyphs.t
      * @param text [type: const char*] the text
+     * @param sdf_screen_scale [type: float] screen space scale (pixels per local unit). Pass 0 to fallback to world scale.
      * @param recip_w [type: float] 1/texture_width
      * @param recip_h [type: float] 1/texture_height
      * @param vertices [type: uint8_t*] the vertex buffer
      * @param num_vertices [type: uint32_t] the number of vertices that will fit into the vertex buffer
      * @return num_vertices [type: uint32_t] Returns number of vertices consumed from the vertex buffer
      */
-    uint32_t CreateFontVertexData(HFontRenderBackend backend, HFontMap font_map, uint32_t frame, const char* text, const TextEntry& te, float recip_w, float recip_h, uint8_t* vertices, uint32_t num_vertices);
+    uint32_t CreateFontVertexData(HFontRenderBackend backend, HFontMap font_map, uint32_t frame, const char* text, const TextEntry& te, float sdf_screen_scale, float recip_w, float recip_h, uint8_t* vertices, uint32_t num_vertices);
 }
 
 #endif // DM_FONT_RENDERER_API_H


### PR DESCRIPTION
DF smoothing for distance-field fonts is now computed in screen space rather than world space. The renderer derives a pixels-per-local-unit scale from the current view-projection matrix and viewport, ensuring stable edge thickness under camera zoom and perspective.

<img width="600" height="300" alt="b_a_a" src="https://github.com/user-attachments/assets/5d49cd98-92aa-4dbe-ab55-332f80f136c5" />

Fix https://github.com/defold/defold/issues/9568
Fix https://github.com/defold/defold/issues/11779
Fix https://github.com/defold/defold/issues/9560