### PR TITLE
Make code editor resilient against defective resource nodes

### DIFF
--- a/editor/src/clj/editor/code/resource.clj
+++ b/editor/src/clj/editor/code/resource.clj
@@ -46,7 +46,7 @@
 (g/deftype Regions [TRegion])
 (g/deftype RegionGrouping {s/Any [TRegion]})
 
-(def ^:private default-indent-type :tabs)
+(def default-indent-type :tabs)
 
 (defn make-code-error-user-data [^String path line-number]
   (let [cursor-range (some-> line-number data/line-number->CursorRange)]

--- a/editor/src/clj/editor/code/view.clj
+++ b/editor/src/clj/editor/code/view.clj
@@ -65,6 +65,7 @@
             [schema.core :as s]
             [service.smoke-log :as slog]
             [util.coll :as coll :refer [pair]]
+            [util.defonce :as defonce]
             [util.eduction :as e]
             [util.fn :as fn])
   (:import [com.defold.control ListView]
@@ -97,11 +98,11 @@
 
 (defonce ^:private default-font-size 12.0)
 
-(defprotocol GutterView
+(defonce/protocol GutterView
   (gutter-metrics [this lines regions glyph-metrics] "A two-element vector with a rounded double representing the width of the gutter and another representing the margin on each side within the gutter.")
   (draw-gutter! [this gc gutter-rect layout hovered-ui-element font color-scheme lines regions visible-cursors hovered-row] "Draws the gutter into the specified Rect."))
 
-(defrecord CursorRangeDrawInfo [type fill stroke cursor-range])
+(defonce/record CursorRangeDrawInfo [type fill stroke cursor-range])
 
 (defn- cursor-range-draw-info [type fill stroke cursor-range]
   {:pre [(case type (:range :squiggle :underline :word) true false)
@@ -163,7 +164,7 @@
             width)
           cached-width)))))
 
-(defrecord GlyphMetrics [char-width-cache ^double line-height ^double ascent]
+(defonce/record GlyphMetrics [char-width-cache ^double line-height ^double ascent]
   data/GlyphMetrics
   (ascent [_this] ascent)
   (line-height [_this] line-height)
@@ -1387,15 +1388,12 @@
   (property rename-cursor-range g/Any (dynamic visible (g/constantly false)))
   (output rename-view g/Any :cached (g/fnk [_node-id rename-cursor-range canvas-repaint-info :as props]
                                       (assoc props :fx/type rename-popup-view)))
-  (input open-views g/Any) ;; open views from app-view
 
   (output completions-selected-index g/Any :cached produce-completions-selected-index) ;; either in completions index range or nil
   (output completions-selection g/Any produce-completions-selection)
   (output completions-combined g/Any :cached produce-completions-combined)
   (output completions-combined-ids g/Any :cached produce-completions-combined-ids)
-  (input project g/NodeID) ;; used for completions doc popup, e.g. for opening defold:// URIs
 
-  (input keymap g/Any)
   (output completions-shortcut-text g/Any :cached (g/fnk [keymap]
                                                     (keymap/display-text keymap :code.show-completions nil)))
 
@@ -1411,13 +1409,19 @@
   (property visible-minimap? g/Bool (default false))
   (property visible-whitespace VisibleWhitespace (default :none))
 
-  (input completions g/Any)
-  (input cursor-ranges r/CursorRanges)
-  (input indent-type r/IndentType)
-  (input invalidated-rows r/InvalidatedRows)
+  ;; Inputs from CodeEditorResourceNode.
+  (input completions g/Any :substitute {})
+  (input cursor-ranges r/CursorRanges :substitute nil) ; Fall back on fallback-cursor-ranges.
+  (input indent-type r/IndentType :substitute r/default-indent-type)
+  (input invalidated-rows r/InvalidatedRows :substitute [])
   (input lines types/Lines :substitute [""])
-  (input regions r/Regions)
+  (input regions r/Regions :substitute [])
+
+  ;; Inputs from elsewhere.
+  (input open-views g/Any) ;; open views from app-view
+  (input project g/NodeID) ;; used for completions doc popup, e.g. for opening defold:// URIs
   (input debugger-execution-locations g/Any)
+  (input keymap g/Any)
 
   (output completion-context g/Any :cached produce-completion-context)
   (output cursor-ranges r/CursorRanges (g/fnk [cursor-ranges fallback-cursor-ranges]
@@ -3653,7 +3657,7 @@
       :ys (double-array [y1 y1 y0 y2 y4 y3 y3])
       :n  7})))
 
-(deftype CodeEditorGutterView []
+(defonce/type CodeEditorGutterView []
   GutterView
 
   (gutter-metrics [this lines regions glyph-metrics]

--- a/editor/src/dev/dev.clj
+++ b/editor/src/dev/dev.clj
@@ -306,6 +306,18 @@
   (let [wrapped-value-fn (deep-keep-kv-wrapped-value-fn value-fn)]
     (util/deep-keep-kv deep-keep-finalize-coll-value-fn wrapped-value-fn value)))
 
+(defn nodes-of-type
+  ([node-type]
+   (nodes-of-type (g/now) node-type))
+  ([basis node-type]
+   (sequence
+     (comp (map val)
+           (mapcat :nodes)
+           (map val)
+           (filter #(g/node-instance*? node-type %))
+           (map gt/node-id))
+     (:graphs basis))))
+
 (defn views-of-type [node-type]
   (keep (fn [node-id]
           (when (g/node-instance? node-type node-id)


### PR DESCRIPTION
Fixed an exception in the editor when a resource open in a code editor view became defective while the view had input focus.

Fixes #6300
Fixes #11268
Fixes #11759

### Technical changes
* All inputs in the `CodeEditorView` node that are connected to the resource node now have sensible substitute values in the event that the resource node becomes defective. This ensures the `handler` predicates operate on sensible values.
* Added `dev/nodes-of-type` dev helper function.