### PR TITLE
Rename bit-set/transfer to bit-set/into-> to reflect changes in coll module

### DIFF
--- a/editor/.cljfmt.edn
+++ b/editor/.cljfmt.edn
@@ -105,7 +105,7 @@
                  integration.test-util/write-file-resource! [[:inner 0]]
                  org.httpkit.server/with-channel [[:inner 0]]
                  support.test-support/with-clean-system [[:inner 0]]
-                 util.bit-set/transfer [[:inner 0]]
+                 util.bit-set/into-> [[:inner 0]]
                  util.coll/assoc-in-ex [[:inner 0]]
                  util.coll/into-> [[:inner 0]]
                  util.coll/reduce-> [[:inner 0]]

--- a/editor/.idea/codeStyles/Project.xml
+++ b/editor/.idea/codeStyles/Project.xml
@@ -99,7 +99,7 @@
           <entry key="integration.test-util/write-file-resource!" value="-1" />
           <entry key="org.httpkit.server/with-channel" value="-1" />
           <entry key="support.test-support/with-clean-system" value="-1" />
-          <entry key="util.bit-set/transfer" value="-1" />
+          <entry key="util.bit-set/into-&gt;" value="-1" />
           <entry key="util.coll/assoc-in-ex" value="-1" />
           <entry key="util.coll/into-&gt;" value="-1" />
           <entry key="util.coll/reduce-&gt;" value="-1" />

--- a/editor/src/clj/util/bit_set.clj
+++ b/editor/src/clj/util/bit_set.clj
@@ -228,7 +228,7 @@
      :else
      (clojure.core/into to xform from))))
 
-(defmacro transfer
+(defmacro into->
   ([bit-set to]
    `(into ~to ~bit-set))
   ([bit-set to xform]

--- a/editor/test/util/bit_set_test.clj
+++ b/editor/test/util/bit_set_test.clj
@@ -323,6 +323,27 @@
     (is (= [2 4 1 3] (bit-set/into [2 4] [1 3])))
     (is (= [0 1 3 4] (bit-set/into [0 1] (map inc) [2 3])))))
 
+(deftest into->-test
+  (testing "bit-set into vector."
+    (is (= [] (bit-set/into-> (bit-set/of) [])))
+    (is (= [1 2 3] (bit-set/into-> (bit-set/of 1 2 3) [])))
+    (is (= [0 1 2 3] (bit-set/into-> (bit-set/of 1 2 3) [0])))
+    (is (= ["1" "2" "3"] (bit-set/into-> (bit-set/of 1 2 3) [] (map str))))
+    (is (= [4 6 8]
+           (bit-set/into-> (bit-set/of 1 2 3) []
+             (map inc)
+             (map (fn [^long x] (* 2 x)))))))
+
+  (testing "bit-set into bit-set."
+    (is (= (bit-set/of) (bit-set/into-> (bit-set/of) (bit-set/of))))
+    (is (= (bit-set/of 1 2 3) (bit-set/into-> (bit-set/of 1 2 3) (bit-set/of))))
+    (is (= (bit-set/of 0 1 2 3) (bit-set/into-> (bit-set/of 1 2 3) (bit-set/of 0))))
+    (is (= (bit-set/of 2 3 4) (bit-set/into-> (bit-set/of 1 2 3) (bit-set/of) (map inc))))
+    (is (= (bit-set/of 4 6 8)
+           (bit-set/into-> (bit-set/of 1 2 3) (bit-set/of)
+             (map inc)
+             (map (fn [^long x] (* 2 x))))))))
+
 (deftest indices-test
   (is (= (vector-of :int) (bit-set/indices (bit-set/of))))
   (is (= (vector-of :int 2 3 4) (bit-set/indices (bit-set/of 4 2 3)))))


### PR DESCRIPTION
The `coll/transfer` macro was recently renamed to `coll/into->` in #11814. Here we rename the `bit-set/transfer` counterpart to `bit-set/into->` to reflect these changes.

There were apparently no existing usages of `bit-set/transfer` in the code base.