### PR TITLE
11860 - copying shared libraries on windows

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/bundle/test/BundleHelperTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/bundle/test/BundleHelperTest.java
@@ -26,6 +26,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -456,5 +457,33 @@ public class BundleHelperTest {
             FileUtils.deleteDirectory(sourceDir);
             FileUtils.deleteDirectory(targetDir);
         }
+    }
+
+    @Test
+    public void testFilterBundleResourcesBySharedLibPattern() {
+        Platform platform = Platform.X86_64Win32;
+        String libPrefix = platform.getLibPrefix();  // ""
+        String libSuffix = platform.getLibSuffix();  // ".dll"
+
+        Map<String, String> resources = new HashMap<>();
+        resources.put("example.dll", "dll");
+        resources.put("example_studio.dll", "dll");
+        resources.put("icon.ico", "ico");
+        resources.put("data.txt", "txt");
+        resources.put("example_vc.lib", "lib");
+
+        Map<String, String> filtered = new HashMap<>();
+        for (Map.Entry<String, String> entry : resources.entrySet()) {
+            String name = org.apache.commons.io.FilenameUtils.getName(entry.getKey());
+            if (name.startsWith(libPrefix) && name.endsWith(libSuffix)) {
+                filtered.put(entry.getKey(), entry.getValue());
+            }
+        }
+
+        assertEquals(2, filtered.size());
+        assertTrue(filtered.containsKey("example.dll"));
+        assertTrue(filtered.containsKey("example_studio.dll"));
+        assertFalse(filtered.containsKey("icon.ico"));
+        assertFalse(filtered.containsKey("example_vc.lib"));
     }
 }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
@@ -1845,6 +1845,33 @@ public class Project {
                             // original exception is included in the ExecutionException
                             try {
                                 remoteBuildFuture.get();
+
+                                // Widows: copy shared libraries from extension bundle resources to the build output.
+                                for (String platformStr : platforms) {
+                                    Platform archPlatform = Platform.get(platformStr);
+                                    if (archPlatform == null || !archPlatform.isWindows()) {
+                                        continue;
+                                    }
+
+                                    List<Platform> archPlatforms = new ArrayList<>();
+                                    archPlatforms.add(archPlatform);
+                                    Map<String, IResource> bundleResources = ExtenderUtil.collectBundleResources(
+                                        Project.this, archPlatforms);
+
+                                    String libSuffix = archPlatform.getLibSuffix();
+                                    String libPrefix = archPlatform.getLibPrefix();
+                                    File binaryDir = new File(FilenameUtils.concat(
+                                        getBinaryOutputDirectory(), archPlatform.getExtenderPair()));
+
+                                    Map<String, IResource> sharedLibResources = new HashMap<>();
+                                    for (Map.Entry<String, IResource> entry : bundleResources.entrySet()) {
+                                        String name = FilenameUtils.getName(entry.getKey());
+                                        if (name.startsWith(libPrefix) && name.endsWith(libSuffix)) {
+                                            sharedLibResources.put(entry.getKey(), entry.getValue());
+                                        }
+                                    }
+                                    ExtenderUtil.writeResourcesToDirectory(sharedLibResources, binaryDir);
+                                }
                             }
                             catch (ExecutionException|InterruptedException e) {
                                 Throwable cause = e.getCause();


### PR DESCRIPTION
Extensions DLLs weren't getting copied or linked when executing `dmengine.exe` running a build. Bundling worked due to new copying. On windows RPATH was no use unlike mac/linux. 

Fixes #11860 

We collect bundle resources for Windows platforms, filter down to just `.dll` files using the platform's lib prefix/suffix, and write them to the binary output dir.

## PR checklist

* [ ] Code
	* [x] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [x] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.
