### PR TITLE
Include engine log files among defignored patterns in the editor

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -1352,7 +1352,7 @@
                :command :run.set-instance-count
                :check true
                :user-data {:instance-count i}})
-            (range 1 5))))
+            (range 1 (inc system/max-engine-instance-count)))))
   (run [prefs user-data]
     (let [count (:instance-count user-data)]
       (prefs/set! prefs [:run :instance-count] count)))

--- a/editor/src/clj/editor/asset_browser.clj
+++ b/editor/src/clj/editor/asset_browser.clj
@@ -300,9 +300,11 @@
     (ui/user-data! tree-view ::pending-selection selected-paths)))
 
 (defn- reserved-project-file [^File project-path ^File f]
+  ;; The project-path is assumed to be canonical.
   (resource-watch/reserved-proj-path? project-path (resource/file->proj-path project-path f)))
 
 (defn- illegal-copy-move-pairs [^File project-path prospect-pairs]
+  ;; The project-path is assumed to be canonical.
   (seq (filter (comp (partial reserved-project-file project-path) second) prospect-pairs)))
 
 (defn allow-resource-move?

--- a/editor/src/clj/editor/disk.clj
+++ b/editor/src/clj/editor/disk.clj
@@ -227,6 +227,8 @@
          (g/node-id? project)
          (or (nil? changes-view) (g/node-id? changes-view))]}
   (let [workspace (project/workspace project)
+        project-directory (workspace/project-directory workspace)
+        old-defignore-patterns (resource/project-defignore-patterns project-directory)
         success-promise (promise)
         complete! (fn [successful?]
                     (render-save-progress! progress/done)
@@ -249,7 +251,8 @@
               save-data (project/save-data-with-progress project evaluation-context save-data-fn render-save-progress!)
               post-save-actions (write-save-data-to-disk! save-data snapshot-invalidate-counters {:render-progress! render-save-progress!})
               written-resources (into #{} (map :resource) save-data)
-              reload-required (some #(= "/.defignore" (resource/proj-path %)) written-resources)]
+              new-defignore-patterns (resource/project-defignore-patterns project-directory)
+              reload-required (not= old-defignore-patterns new-defignore-patterns)]
           (render-save-progress! (progress/make-indeterminate (localization/message "progress.caching-save-results")))
           (ui/run-later
             (try

--- a/editor/src/clj/editor/engine.clj
+++ b/editor/src/clj/editor/engine.clj
@@ -285,7 +285,7 @@
       (catch Exception _))))
 
 (defn launch! [^File engine project-directory prefs debug? instance-index]
-  (let [defold-log-dir (some-> (System/getProperty "defold.log.dir")
+  (let [defold-log-dir (some-> (system/defold-log-dir)
                                (File.)
                                (.getAbsolutePath))
         command (.getAbsolutePath engine)

--- a/editor/src/clj/editor/hot_reload.clj
+++ b/editor/src/clj/editor/hot_reload.clj
@@ -51,7 +51,7 @@
     {"/build/{*path}"
      {"GET" (bound-fn [{:keys [path-params headers]}]
               (let [^String path (:path path-params)
-                    full-path (path/normalized (path/resolve build-path path))]
+                    full-path (path/resolve-normalized build-path path)]
                 (if (and (path/starts-with? full-path build-path) ;; Avoid going outside the build path with '..'
                          (path/file? full-path))
                   (let [etag (workspace/etag workspace (str "/" path))

--- a/editor/src/clj/editor/resource.clj
+++ b/editor/src/clj/editor/resource.clj
@@ -14,12 +14,16 @@
 
 (ns editor.resource
   (:require [clojure.java.io :as io]
+            [clojure.spec.alpha :as s]
             [clojure.string :as string]
             [cognitect.transit :as transit]
             [dynamo.graph :as g]
             [editor.core :as core]
             [editor.fs :as fs]
-            [schema.core :as s]
+            [editor.settings-core :as settings-core]
+            [editor.system :as system]
+            [schema.core :as schema]
+            [service.log :as log]
             [util.coll :as coll :refer [pair]]
             [util.defonce :as defonce]
             [util.digest :as digest]
@@ -163,58 +167,226 @@
   (when-let [last-slash (string/last-index-of proj-path "/")]
     (subs proj-path 0 last-slash)))
 
-(def ^:private defignore-cache
-  ;; path->{:mtime ... :pred ...}
-  (atom {}))
+(defn project-directory? [^File value]
+  ;; The project directory must exist on disk and exactly match the real casing.
+  (and (instance? File value)
+       (.isDirectory value)
+       (= (.getPath value)
+          (str (path/actual-cased value)))))
 
-(defn lines->proj-path-patterns-pred
-  "Returns a predicate that takes a proj-path and returns true if it starts with
-  or matches one of the proj-paths listed among the lines, typically the
-  contents of something like a `.defignore` file."
+(defn proj-path-patterns-file? [^File value]
+  ;; These files may or may not exist in the project, but it is important for
+  ;; cache lookups that the casing matches the real casing in the file system.
+  ;; Thus, we have a whitelist of allowed file names and ensure they are located
+  ;; below a correctly-cased project-directory even if the file itself does not
+  ;; exist in the project.
+  (and (instance? File value)
+       (#{".defignore" ".defunload"} (.getName value))
+       (project-directory? (.getParentFile value))
+       (or (.isFile value)
+           (not (.exists value)))))
+
+(s/def ::proj-path-pattern
+  (s/and string?
+         #(string/starts-with? % "/")
+         #(not (string/ends-with? % "/"))))
+
+(s/def ::proj-path-patterns (s/every ::proj-path-pattern :kind vector?))
+(s/def ::proj-path-pred ifn?)
+(s/def ::project-directory project-directory?)
+(s/def ::proj-path-patterns-file proj-path-patterns-file?)
+(s/def ::mtime integer?)
+(s/def ::defignore-mtime ::mtime)
+(s/def ::game-project-mtime ::mtime)
+(s/def ::log-directory-override-pathname (s/nilable string?))
+
+(s/def ::defignore-patterns-key
+  (s/keys :req-un [::defignore-mtime
+                   ::project-directory
+                   (or ::log-directory-override-pathname ::game-project-mtime)]))
+
+(defn- make-defignore-patterns-key [^File project-directory]
+  {:pre [(s/assert ::project-directory project-directory)]
+   :post [(s/assert ::defignore-patterns-key %)]}
+  (let [defignore-file (io/file project-directory ".defignore")
+        defignore-mtime (.lastModified defignore-file) ; Returns zero if not exists.
+        common-args {:defignore-mtime defignore-mtime
+                     :project-directory project-directory}]
+    (if-some [log-directory-override-pathname (system/defold-log-dir)]
+      (assoc common-args :log-directory-override-pathname log-directory-override-pathname)
+      (let [game-project-file (io/file project-directory "game.project")
+            game-project-mtime (.lastModified game-project-file)]
+        (assoc common-args
+          :game-project-mtime game-project-mtime)))))
+
+(defn- read-project-log-directory-raw
+  ^File [^File project-directory game-project-mtime]
+  {:pre [(s/assert ::project-directory project-directory)
+         (s/assert ::game-project-mtime game-project-mtime)]} ; Argument invalidates the cached result.
+  (let [game-project-file (io/file project-directory "game.project")]
+    (if-not (.isFile game-project-file)
+      project-directory
+      (let [log-directory-pathname
+            (try
+              (with-open [reader (io/reader game-project-file)]
+                (-> (settings-core/parse-settings reader)
+                    (settings-core/get-setting ["project" "log_dir"])))
+              (catch Exception e
+                (log/error :message "Failed to parse project.log_dir setting from game.project" :exception e)
+                nil))]
+        (if (coll/empty? log-directory-pathname)
+          project-directory
+          (io/as-file (path/resolve-normalized project-directory log-directory-pathname)))))))
+
+(def ^:private read-project-log-directory-fn
+  (fn/memoize
+    (fn [^File project-directory]
+      {:pre [(s/assert ::project-directory project-directory)]}
+      (fn/memoize {:limit 1} #(read-project-log-directory-raw project-directory %)))))
+
+(defn- read-project-log-directory
+  ^File [^File project-directory game-project-mtime]
+  ((read-project-log-directory-fn project-directory) game-project-mtime))
+
+(defn- engine-instance-log-filename
+  ^String [^long instance-index]
+  {:pre [(<= 0 instance-index system/max-engine-instance-count)]}
+  ;; Note: These filename patterns are also hardcoded in the engine.
+  (case instance-index
+    0 "log.txt"
+    (format "instance_%d_log.txt" instance-index)))
+
+(defn- log-file-proj-path-patterns [defignore-patterns-key]
+  {:pre [(s/assert ::defignore-patterns-key defignore-patterns-key)]
+   :post [(s/assert ::proj-path-patterns %)]}
+  (let [^String log-directory-override-pathname (:log-directory-override-pathname defignore-patterns-key)
+        ^File project-directory (:project-directory defignore-patterns-key)
+
+        log-directory
+        (if (nil? log-directory-override-pathname)
+          (read-project-log-directory project-directory (:game-project-mtime defignore-patterns-key))
+          (let [working-directory (.getCanonicalFile (io/file "."))]
+            (if (= "" log-directory-override-pathname)
+              working-directory
+              (io/as-file (path/resolve-normalized working-directory log-directory-override-pathname)))))]
+
+    (if-not (path/starts-with? log-directory project-directory)
+      [] ; No need to ignore log files, since they are outside the project.
+      (let [log-filename->proj-path
+            (fn log-filename->proj-path [log-filename]
+              (let [log-file (io/file log-directory log-filename)]
+                (file->proj-path project-directory log-file)))]
+        ;; The zero instance uses the "log.txt" filename. The others are
+        ;; prefixed with "instance_1_", "instance_2_" and so on.
+        (coll/into-> (range (inc system/max-engine-instance-count)) []
+          (map engine-instance-log-filename)
+          (map log-filename->proj-path))))))
+
+(defn lines->proj-path-patterns
+  "Given the lines from something like a `.defignore` file, return a clean
+  vector of distinct proj-path-patterns. Only lines that start with a `/`
+  character are included. Trailing path separators are stripped."
   [lines]
-  (let [patterns (when lines
-                   (coll/into-> lines []
-                     (filter #(string/starts-with? % "/"))
-                     (map #(string/replace % #"/*$" ""))
-                     (distinct)))]
-    (if (zero? (count patterns))
-      fn/constantly-false
-      (fn matched-proj-path? [^String proj-path]
-        (let [proj-path-length (.length proj-path)]
-          (boolean
-            (coll/some
-              (fn [^String pattern]
-                ;; Make sure a "/dir" pattern matches "/dir" and "/dir/entry",
-                ;; but not "/dire".
-                (and (string/starts-with? proj-path pattern)
-                     (let [pattern-length (.length pattern)]
-                       (or (= pattern-length proj-path-length)
-                           (= \/ (.charAt proj-path pattern-length))))))
-              patterns)))))))
+  {:post [(s/assert ::proj-path-patterns %)]}
+  (coll/into-> lines []
+    (filter #(string/starts-with? % "/"))
+    (map #(string/replace % #"/*$" ""))
+    (remove string/blank?)
+    (distinct)))
 
-(defn- read-proj-path-patterns-pred [^File proj-path-patterns-file]
-  (lines->proj-path-patterns-pred
+(defn- read-proj-path-patterns-raw [^File proj-path-patterns-file proj-path-patterns-mtime]
+  {:pre [(s/assert ::mtime proj-path-patterns-mtime)] ; Argument invalidates the cached result.
+   :post [(s/assert ::proj-path-patterns %)]}
+  (lines->proj-path-patterns
     (when (.isFile proj-path-patterns-file)
-      (string/split-lines (slurp proj-path-patterns-file)))))
+      (try
+        (string/split-lines (slurp proj-path-patterns-file))
+        (catch Exception e
+          (log/error :message (str "Failed to read proj-path patterns from " (.getName proj-path-patterns-file)) :exception e)
+          nil)))))
 
-(defn defignore-pred [^File root]
-  (let [defignore-file (io/file root ".defignore")
-        defignore-path (.getCanonicalPath defignore-file)
-        latest-mtime (.lastModified defignore-file)
-        {:keys [mtime pred]} (get @defignore-cache defignore-path)]
-    (if (= mtime latest-mtime)
-      pred
-      (let [pred (read-proj-path-patterns-pred defignore-file)]
-        (swap! defignore-cache assoc defignore-path {:mtime latest-mtime :pred pred})
-        pred))))
+(def ^:private read-proj-path-patterns-fn
+  (fn/memoize
+    (fn [^File proj-path-patterns-file]
+      {:pre [(s/assert ::proj-path-patterns-file proj-path-patterns-file)]}
+      (fn/memoize {:limit 1} #(read-proj-path-patterns-raw proj-path-patterns-file %)))))
 
-(defn- defunload-pred-raw [^File root]
+(defn- read-proj-path-patterns [^File proj-path-patterns-file proj-path-patterns-mtime]
+  ((read-proj-path-patterns-fn proj-path-patterns-file) proj-path-patterns-mtime))
+
+(defn- make-defignore-patterns-raw [defignore-patterns-key]
+  {:pre [(s/assert ::defignore-patterns-key defignore-patterns-key)]
+   :post [(s/assert ::proj-path-patterns %)]}
+  (let [{:keys [defignore-mtime project-directory]} defignore-patterns-key
+        defignore-file (io/file project-directory ".defignore")]
+    (into []
+          (distinct)
+          (concat
+            (log-file-proj-path-patterns defignore-patterns-key)
+            (read-proj-path-patterns defignore-file defignore-mtime)))))
+
+(def ^:private make-defignore-patterns-fn
+  (fn/memoize
+    (fn [^File project-directory]
+      {:pre [(s/assert ::project-directory project-directory)]}
+      (fn/memoize {:limit 1} make-defignore-patterns-raw))))
+
+(defn- make-defignore-patterns [^File project-directory defignore-patterns-key]
+  ((make-defignore-patterns-fn project-directory) defignore-patterns-key))
+
+(defn project-defignore-patterns
+  "Returns a vector of proj-path-patterns that should be ignored under the
+  specified project-directory. Cached - will return the identical result every
+  time unless changes are detected."
+  [^File project-directory]
+  (->> project-directory
+       (make-defignore-patterns-key)
+       (make-defignore-patterns project-directory)))
+
+(defn make-proj-path-patterns-pred-raw
+  "Returns a predicate that takes a proj-path and returns true if it starts with
+  or matches one of the listed proj-paths."
+  [proj-path-patterns]
+  {:pre [(or (nil? proj-path-patterns)
+             (s/assert ::proj-path-patterns proj-path-patterns))]
+   :post [(s/assert ::proj-path-pred %)]}
+  (if (zero? (count proj-path-patterns))
+    fn/constantly-false
+    (fn matched-proj-path? [^String proj-path]
+      (let [proj-path-length (.length proj-path)]
+        (boolean
+          (coll/some
+            (fn [^String pattern]
+              ;; Make sure a "/dir" pattern matches "/dir" and "/dir/entry",
+              ;; but not "/dire".
+              (and (string/starts-with? proj-path pattern)
+                   (let [pattern-length (.length pattern)]
+                     (or (= pattern-length proj-path-length)
+                         (= \/ (.charAt proj-path pattern-length))))))
+            proj-path-patterns))))))
+
+(def ^:private make-proj-path-patterns-pred-fn
+  (fn/memoize
+    (fn [^File proj-path-patterns-file]
+      {:pre [(s/assert ::proj-path-patterns-file proj-path-patterns-file)]}
+      (fn/memoize {:limit 1} make-proj-path-patterns-pred-raw))))
+
+(defn- make-proj-path-patterns-pred [^File proj-path-patterns-file proj-path-patterns]
+  ((make-proj-path-patterns-pred-fn proj-path-patterns-file) proj-path-patterns))
+
+(defn defignore-pred [^File project-directory]
+  (let [defignore-file (io/file project-directory ".defignore")
+        proj-path-patterns (project-defignore-patterns project-directory)]
+    (make-proj-path-patterns-pred defignore-file proj-path-patterns)))
+
+(defn- defunload-pred-raw [^File project-directory]
   ;; Contrary to .defignore, we only read the .defunload file once and cache it
   ;; for the entire lifetime of the application. You'll have to restart the
   ;; editor for any changes to take effect.
-  {:pre [(instance? File root)]} ; Guard against duplicate memoization since io/file accepts multiple types.
-  (let [defunload-file (io/file root ".defunload")]
-    (read-proj-path-patterns-pred defunload-file)))
+  (let [defunload-file (io/file project-directory ".defunload")
+        defunload-mtime (.lastModified defunload-file)
+        proj-path-patterns (read-proj-path-patterns defunload-file defunload-mtime)]
+    (make-proj-path-patterns-pred defunload-file proj-path-patterns)))
 
 (def defunload-pred (fn/memoize defunload-pred-raw))
 
@@ -241,6 +413,7 @@
      ~@body))
 
 (defn ignored-project-path? [^File root proj-path]
+  ;; The root directory is assumed to be canonical.
   ((or *defignore-pred* (defignore-pred root)) proj-path))
 
 (defn- textual-resource-type?
@@ -643,7 +816,7 @@
           disk-sha256 (digest/completed-stream->hex input-stream)]
       (pair source-value disk-sha256))))
 
-(g/deftype ResourceVec [(s/maybe (s/protocol Resource))])
+(g/deftype ResourceVec [(schema/maybe (schema/protocol Resource))])
 
 (defn temp-path [resource]
   (when (and resource (= :file (source-type resource)))

--- a/editor/src/clj/editor/resource.clj
+++ b/editor/src/clj/editor/resource.clj
@@ -320,10 +320,10 @@
   (let [{:keys [defignore-mtime project-directory]} defignore-patterns-key
         defignore-file (io/file project-directory ".defignore")]
     (into []
-          (distinct)
-          (concat
-            (log-file-proj-path-patterns defignore-patterns-key)
-            (read-proj-path-patterns defignore-file defignore-mtime)))))
+          (comp cat
+                (distinct))
+          [(log-file-proj-path-patterns defignore-patterns-key)
+           (read-proj-path-patterns defignore-file defignore-mtime)])))
 
 (def ^:private make-defignore-patterns-fn
   (fn/memoize

--- a/editor/src/clj/editor/resource_watch.clj
+++ b/editor/src/clj/editor/resource_watch.clj
@@ -200,6 +200,11 @@
                     (.getAbsolutePath (io/file "bundle-resources"))
                     (system/defold-unpack-path))
         root (io/file base-path "_defold/debugger")
+        ;; Supplying this mount-root derived from the base-path appears to
+        ;; produce a strange file-resource-filter inside make-file-tree, which
+        ;; won't include defignore patterns and so on. It probably won't matter
+        ;; for this case, since this directory will not have any of those files
+        ;; below it anyway.
         mount-root (io/file base-path)
         resources (resource/children (make-file-tree workspace mount-root root fn/constantly-false fn/constantly-false))]
     {:resources resources

--- a/editor/src/clj/editor/system.clj
+++ b/editor/src/clj/editor/system.clj
@@ -35,6 +35,8 @@
    :free  (- (:free after) (:free before))
    :used  (- (:used after) (:used before))})
 
+(def ^:const ^:long max-engine-instance-count 4)
+
 (defn os-name
   ^String []
   (System/getProperty "os.name"))
@@ -91,6 +93,10 @@
 (defn defold-dev? []
   (or (some? (System/getProperty "defold.dev"))
       (not (defold-version))))
+
+(defn defold-log-dir
+  ^String []
+  (System/getProperty "defold.log.dir"))
 
 (defn defold-unpack-path
   ^String []

--- a/editor/src/clj/editor/workspace.clj
+++ b/editor/src/clj/editor/workspace.clj
@@ -44,7 +44,6 @@ ordinary paths."
             [util.fn :as fn]
             [util.path :as path])
   (:import [clojure.lang DynamicClassLoader]
-           [editor.resource FileResource]
            [com.dynamo.bob Platform]
            [editor.resource FileResource]
            [java.io File FileNotFoundException IOException PushbackReader]

--- a/editor/src/clj/util/fn.clj
+++ b/editor/src/clj/util/fn.clj
@@ -46,37 +46,69 @@
                ::memoize-arity ~arity
                ::memoize-cache ~cache}))
 
-(defn- memoize-one [unary-fn]
-  (let [cache (atom {})
+(defn- single-limited-assoc [map key value]
+  (with-meta {key value}
+             (meta map)))
+
+(defn- memoize-details [{:keys [limit] :as opts}]
+  (cond
+    (nil? limit)
+    (pair {} assoc)
+
+    (= 1 limit)
+    (pair (array-map) single-limited-assoc)
+
+    (and* (integer? limit)
+          (<= 2 (long limit) 8)) ; Once you assoc the 9:th element into a PersistentArrayMap, it no longer maintains order.
+    (let [limit (long limit)]
+      (pair (array-map)
+            (fn limited-assoc [array-map key value]
+              (if (< (count array-map) limit)
+                (assoc array-map key value)
+                (-> array-map
+                    (coll/transform-> (drop 1))
+                    (assoc key value))))))
+
+    :else
+    (throw
+      (ex-info
+        (str "If specified, :limit must be an integer between 1 and 8. Got: " (pr-str limit))
+        {:opts opts}))))
+
+(defn- memoize-one [opts unary-fn]
+  (let [[storage encache-fn] (memoize-details opts)
+        cache (atom storage)
         memoized-fn (fn memoized-fn [arg]
                       (let [cached-result (@cache arg cache)]
                         (if (identical? cache cached-result)
                           (let [result (unary-fn arg)]
-                            (swap! cache assoc arg result)
+                            (swap! cache encache-fn arg result)
                             result)
                           cached-result)))]
     (with-memoize-info memoized-fn cache 1)))
 
-(defn- memoize-two [binary-fn]
-  (let [cache (atom {})
+(defn- memoize-two [opts binary-fn]
+  (let [[storage encache-fn] (memoize-details opts)
+        cache (atom storage)
         memoized-fn (fn memoized-fn [arg1 arg2]
                       (let [key (pair arg1 arg2)
                             cached-result (@cache key cache)]
                         (if (identical? cache cached-result)
                           (let [result (binary-fn arg1 arg2)]
-                            (swap! cache assoc key result)
+                            (swap! cache encache-fn key result)
                             result)
                           cached-result)))]
     (with-memoize-info memoized-fn cache 2)))
 
-(defn- memoize-any [any-fn ^long arity]
-  (let [cache (atom {})
+(defn- memoize-any [opts any-fn ^long arity]
+  (let [[storage encache-fn] (memoize-details opts)
+        cache (atom storage)
         memoized-fn (fn memoized-fn [& args]
                       (let [key (vec args)
                             cached-result (@cache key cache)]
                         (if (identical? cache cached-result)
                           (let [result (apply any-fn args)]
-                            (swap! cache assoc key result)
+                            (swap! cache encache-fn key result)
                             result)
                           cached-result)))]
     (with-memoize-info memoized-fn cache arity)))
@@ -91,7 +123,7 @@
                   nil)))
         (java/get-declared-methods ifn-class)))
 
-(def ^:private ifn-class-arities (memoize-one ifn-class-arities-raw))
+(def ^:private ifn-class-arities (memoize-one nil ifn-class-arities-raw))
 
 (defn- ifn-class-max-arity-raw
   ^long [^Class ifn-class]
@@ -103,7 +135,7 @@
           0
           (java/get-declared-methods ifn-class)))
 
-(def ^:private ifn-class-max-arity (memoize-one ifn-class-max-arity-raw))
+(def ^:private ifn-class-max-arity (memoize-one nil ifn-class-max-arity-raw))
 
 (defn max-arity
   "Returns the maximum number of arguments the supplied function can accept, or
@@ -138,15 +170,22 @@
 (defn memoize
   "Like core.memoize, but uses an optimized cache based on the number of
   arguments the original function accepts. Also enables you to evict entries
-  from the cache using the evict-memoized! and clear-memoized! functions."
-  [ifn]
-  (if (::memoize-cache (meta ifn))
-    ifn ; Already memoized.
-    (let [arity (max-arity ifn)]
-      (case arity
-        1 (memoize-one ifn)
-        2 (memoize-two ifn)
-        (memoize-any ifn arity)))))
+  from the cache using the evict-memoized! and clear-memoized! functions.
+
+  Supported opts:
+    :limit <integer>
+      The maximum number of unique argument lists to cache. After the limit is
+      reached, old cache entries will be evicted in FIFO order."
+  ([ifn]
+   (memoize nil ifn))
+  ([opts ifn]
+   (if (::memoize-cache (meta ifn))
+     ifn ; Already memoized.
+     (let [arity (max-arity ifn)]
+       (case arity
+         1 (memoize-one opts ifn)
+         2 (memoize-two opts ifn)
+         (memoize-any opts ifn arity))))))
 
 (defn clear-memoized!
   "Clear all previously cached results from the cache of a memoized function

--- a/editor/src/clj/util/path.clj
+++ b/editor/src/clj/util/path.clj
@@ -173,10 +173,21 @@
   coerced Path. If other is an empty path, returns the Path coerced from the
   first argument. Otherwise, we consider this path to be a directory and
   resolve the other path against this path. For example, on UNIX, if this path
-  is `/a/b` and the other path is `../c/d`, then the resulting resolved path would
-  be `/a/c/d`."
+  is `/a/b` and the other path is `../c/d`, then the resulting resolved path
+  would be `/a/b/../c/d`."
   ^Path [this other]
   (.resolve (to-path this) (to-path other)))
+
+(defn resolve-normalized
+  "Coerces both arguments to java.nio.file.Path and resolves the other path
+  against this path. If the other parameter is an absolute path, returns its
+  normalized Path. If other is an empty path, returns the normalized Path
+  coerced from the first argument. Otherwise, we consider this path to be a
+  directory and resolve the other path against this path and return the
+  normalized Path. For example, on UNIX, if this path is `/a/b` and the other
+  path is `../c/d`, then the resulting resolved path would be `/a/c/d`."
+  ^Path [this other]
+  (.normalize (.resolve (to-path this) (to-path other))))
 
 (defn resolve-sibling
   "Coerces both arguments to java.nio.file.Path and resolves the other path

--- a/editor/test/editor/resource_test.clj
+++ b/editor/test/editor/resource_test.clj
@@ -13,56 +13,353 @@
 ;; specific language governing permissions and limitations under the License.
 
 (ns editor.resource-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.java.io :as io]
+            [clojure.string :as string]
+            [clojure.test :refer :all]
+            [editor.fs :as fs]
             [editor.resource :as resource]
-            [util.fn :as fn]))
+            [integration.test-util :as test-util]
+            [support.test-support :as test-support]
+            [util.fn :as fn]
+            [util.path :as path]))
 
 (set! *warn-on-reflection* true)
 
-(deftest lines->proj-path-patterns-pred-test
-  (testing "Patterns without the leading slash are ignored."
-    (let [proj-path-patterns-pred (resource/lines->proj-path-patterns-pred ["a"])]
-      (is (false? (proj-path-patterns-pred "/a")))))
+(deftest lines->proj-path-patterns-test
+  (testing "Returns empty vector for nil."
+    (is (= []
+           (resource/lines->proj-path-patterns nil))))
 
+  (testing "Patterns without a leading slash are ignored."
+    (is (= []
+           (resource/lines->proj-path-patterns ["a" "b" "c"]))))
+
+  (testing "Patterns with a leading slash are included."
+    (is (= ["/b" "/d"]
+           (resource/lines->proj-path-patterns ["a" "/b" "c" "/d"]))))
+
+  (testing "Patterns are distinct."
+    (is (= ["/a" "/b"]
+           (resource/lines->proj-path-patterns ["/a" "/b" "/b" "/a"]))))
+
+  (testing "Trailing slashes are stripped from patterns."
+    (is (= ["/a" "/b" "/c"]
+           (resource/lines->proj-path-patterns ["/a" "/b" "/b/" "/a/" "/c/"])))))
+
+(deftest make-proj-path-patterns-pred-test
   (testing "Returns fn/constantly-false when there are no valid patterns."
-    (is (identical? fn/constantly-false (resource/lines->proj-path-patterns-pred nil)))
-    (is (identical? fn/constantly-false (resource/lines->proj-path-patterns-pred [])))
-    (is (identical? fn/constantly-false (resource/lines->proj-path-patterns-pred ["a"])))
-    (is (identical? fn/constantly-false (resource/lines->proj-path-patterns-pred ["a" "b"]))))
+    (is (identical? fn/constantly-false (resource/make-proj-path-patterns-pred-raw nil)))
+    (is (identical? fn/constantly-false (resource/make-proj-path-patterns-pred-raw []))))
 
   (testing "Returns functioning predicate when there are some valid patterns."
-    (let [proj-path-patterns-pred (resource/lines->proj-path-patterns-pred ["a" "/b"])]
+    (let [proj-path-patterns-pred (resource/make-proj-path-patterns-pred-raw ["/b"])]
       (is (false? (proj-path-patterns-pred "/a")))
       (is (true? (proj-path-patterns-pred "/b")))))
 
   (testing "Matches multiple patterns."
-    (let [proj-path-patterns-pred (resource/lines->proj-path-patterns-pred ["/a" "/b"])]
+    (let [proj-path-patterns-pred (resource/make-proj-path-patterns-pred-raw ["/a" "/b"])]
       (is (true? (proj-path-patterns-pred "/a")))
       (is (true? (proj-path-patterns-pred "/b")))
       (is (false? (proj-path-patterns-pred "/c")))))
 
   (testing "Path match rules."
-    (let [proj-path-patterns-pred (resource/lines->proj-path-patterns-pred ["/A"])]
+    (let [proj-path-patterns-pred (resource/make-proj-path-patterns-pred-raw ["/A"])]
       (is (false? (proj-path-patterns-pred "/a")))
       (is (true? (proj-path-patterns-pred "/A"))))
-    (let [proj-path-patterns-pred (resource/lines->proj-path-patterns-pred ["/a"])]
+    (let [proj-path-patterns-pred (resource/make-proj-path-patterns-pred-raw ["/a"])]
       (is (true? (proj-path-patterns-pred "/a")))
       (is (false? (proj-path-patterns-pred "/A"))))
-    (let [proj-path-patterns-pred (resource/lines->proj-path-patterns-pred ["/a"])]
+    (let [proj-path-patterns-pred (resource/make-proj-path-patterns-pred-raw ["/a"])]
       (is (true? (proj-path-patterns-pred "/a")))
       (is (true? (proj-path-patterns-pred "/a/b")))
       (is (false? (proj-path-patterns-pred "/ab")))
       (is (false? (proj-path-patterns-pred "/aba")))
       (is (false? (proj-path-patterns-pred "/ab/a"))))
-    (let [proj-path-patterns-pred (resource/lines->proj-path-patterns-pred ["/ab"])]
-      (is (false? (proj-path-patterns-pred "/a")))
-      (is (false? (proj-path-patterns-pred "/a/b")))
-      (is (true? (proj-path-patterns-pred "/ab")))
-      (is (false? (proj-path-patterns-pred "/aba")))
-      (is (true? (proj-path-patterns-pred "/ab/a"))))
-    (let [proj-path-patterns-pred (resource/lines->proj-path-patterns-pred ["/ab/"])]
+    (let [proj-path-patterns-pred (resource/make-proj-path-patterns-pred-raw ["/ab"])]
       (is (false? (proj-path-patterns-pred "/a")))
       (is (false? (proj-path-patterns-pred "/a/b")))
       (is (true? (proj-path-patterns-pred "/ab")))
       (is (false? (proj-path-patterns-pred "/aba")))
       (is (true? (proj-path-patterns-pred "/ab/a"))))))
+
+(defn- set-file-lines! [file lines]
+  (if (nil? lines)
+    (fs/delete-file! file)
+    (let [content (string/join \newline lines)]
+      (test-support/write-until-new-mtime file content))))
+
+(defn- set-game-project-log-dir-pathname! [project-directory pathname]
+  (let [game-project-file (io/file project-directory "game.project")
+        lines (when (some? pathname)
+                ["[project]"
+                 (str "log_dir = " pathname)])]
+    (set-file-lines! game-project-file lines)))
+
+(defn- set-project-defignore-lines! [project-directory defignore-lines]
+  (let [defignore-file (io/file project-directory ".defignore")]
+    (set-file-lines! defignore-file defignore-lines)))
+
+(deftest project-defignore-patterns-test
+  (test-support/with-cleared-system-properties!
+    ["defold.log.dir"]
+
+    (testing "Throws unless called with an existing canonical directory File."
+      (let [temp-directory (fs/create-temp-directory!)
+            canonical-project-directory (fs/create-directory! (io/file temp-directory "TestProject"))
+            non-canonical-directory (io/file temp-directory "testProject")]
+        (with-open [_ (test-util/make-directory-deleter temp-directory)]
+          (is (any? (resource/project-defignore-patterns canonical-project-directory)))
+          (is (thrown? Exception (resource/project-defignore-patterns nil)))
+          (is (thrown? Exception (resource/project-defignore-patterns non-canonical-directory)))
+          (is (thrown? Exception (resource/project-defignore-patterns (.getCanonicalPath canonical-project-directory))))
+          (is (thrown? Exception (resource/project-defignore-patterns (path/of canonical-project-directory)))))))
+
+    (testing "Completely empty project directory."
+      (let [project-directory (fs/create-temp-directory!)]
+        (with-open [_ (test-util/make-directory-deleter project-directory)]
+          (is (= ["/log.txt"
+                  "/instance_1_log.txt"
+                  "/instance_2_log.txt"
+                  "/instance_3_log.txt"
+                  "/instance_4_log.txt"]
+                 (resource/project-defignore-patterns project-directory)))
+          (is (identical? (resource/project-defignore-patterns project-directory)
+                          (resource/project-defignore-patterns project-directory))))))
+
+    (testing "Defold project directory."
+      (let [project-directory (io/file (test-util/make-temp-project-copy! "test/resources/empty_project"))]
+        (with-open [_ (test-util/make-directory-deleter project-directory)]
+
+          (testing "Engine log paths are included by default."
+            (is (= ["/log.txt"
+                    "/instance_1_log.txt"
+                    "/instance_2_log.txt"
+                    "/instance_3_log.txt"
+                    "/instance_4_log.txt"]
+                   (resource/project-defignore-patterns project-directory)))
+            (is (identical? (resource/project-defignore-patterns project-directory)
+                            (resource/project-defignore-patterns project-directory))))
+
+          (testing "Engine log directory can be overridden using JVM property."
+            ;; Note: Relative to the editor process working directory when
+            ;; specified as a relative pathname.
+            (try
+
+              (testing "Relative pathname inside project directory."
+                (let [log-dir-path (path/relativize
+                                     (path/absolute ".")
+                                     (path/of project-directory "relative_logs"))]
+                  (System/setProperty "defold.log.dir" (str log-dir-path)))
+                (is (= ["/relative_logs/log.txt"
+                        "/relative_logs/instance_1_log.txt"
+                        "/relative_logs/instance_2_log.txt"
+                        "/relative_logs/instance_3_log.txt"
+                        "/relative_logs/instance_4_log.txt"]
+                       (resource/project-defignore-patterns project-directory)))
+                (is (identical? (resource/project-defignore-patterns project-directory)
+                                (resource/project-defignore-patterns project-directory))))
+
+              (testing "Relative pathname outside project directory."
+                (let [log-dir-path (path/relativize
+                                     (path/absolute ".")
+                                     (path/of project-directory ".." "relative_logs"))]
+                  (System/setProperty "defold.log.dir" (str log-dir-path)))
+                (is (= []
+                       (resource/project-defignore-patterns project-directory)))
+                (is (identical? (resource/project-defignore-patterns project-directory)
+                                (resource/project-defignore-patterns project-directory))))
+
+              (testing "Absolute pathname inside project directory."
+                (let [log-dir-path (path/absolute project-directory "absolute_logs")]
+                  (System/setProperty "defold.log.dir" (str log-dir-path)))
+                (is (= ["/absolute_logs/log.txt"
+                        "/absolute_logs/instance_1_log.txt"
+                        "/absolute_logs/instance_2_log.txt"
+                        "/absolute_logs/instance_3_log.txt"
+                        "/absolute_logs/instance_4_log.txt"]
+                       (resource/project-defignore-patterns project-directory)))
+                (is (identical? (resource/project-defignore-patterns project-directory)
+                                (resource/project-defignore-patterns project-directory))))
+
+              (testing "Absolute pathname outside project directory."
+                (let [log-dir-path (path/absolute project-directory ".." "absolute_logs")]
+                  (System/setProperty "defold.log.dir" (str log-dir-path)))
+                (is (= []
+                       (resource/project-defignore-patterns project-directory)))
+                (is (identical? (resource/project-defignore-patterns project-directory)
+                                (resource/project-defignore-patterns project-directory))))
+
+              (finally
+                (System/clearProperty "defold.log.dir"))))
+
+          (testing "Engine log directory can be overridden in game.project."
+            ;; Note: Relative to the project directory when specified as a
+            ;; relative pathname.
+            (try
+
+              (testing "Relative pathname inside project directory."
+                (let [log-dir-path (path/of "relative_logs")]
+                  (set-game-project-log-dir-pathname! project-directory (str log-dir-path)))
+                (is (= ["/relative_logs/log.txt"
+                        "/relative_logs/instance_1_log.txt"
+                        "/relative_logs/instance_2_log.txt"
+                        "/relative_logs/instance_3_log.txt"
+                        "/relative_logs/instance_4_log.txt"]
+                       (resource/project-defignore-patterns project-directory)))
+                (is (identical? (resource/project-defignore-patterns project-directory)
+                                (resource/project-defignore-patterns project-directory))))
+
+              (testing "Relative pathname outside project directory."
+                (let [log-dir-path (path/of ".." "relative_logs")]
+                  (set-game-project-log-dir-pathname! project-directory (str log-dir-path)))
+                (is (= []
+                       (resource/project-defignore-patterns project-directory)))
+                (is (identical? (resource/project-defignore-patterns project-directory)
+                                (resource/project-defignore-patterns project-directory))))
+
+              (testing "Absolute pathname inside project directory."
+                (let [log-dir-path (path/absolute project-directory "absolute_logs")]
+                  (set-game-project-log-dir-pathname! project-directory (str log-dir-path)))
+                (is (= ["/absolute_logs/log.txt"
+                        "/absolute_logs/instance_1_log.txt"
+                        "/absolute_logs/instance_2_log.txt"
+                        "/absolute_logs/instance_3_log.txt"
+                        "/absolute_logs/instance_4_log.txt"]
+                       (resource/project-defignore-patterns project-directory)))
+                (is (identical? (resource/project-defignore-patterns project-directory)
+                                (resource/project-defignore-patterns project-directory))))
+
+              (testing "Absolute pathname outside project directory."
+                (let [log-dir-path (path/absolute project-directory ".." "absolute_logs")]
+                  (set-game-project-log-dir-pathname! project-directory (str log-dir-path)))
+                (is (= []
+                       (resource/project-defignore-patterns project-directory)))
+                (is (identical? (resource/project-defignore-patterns project-directory)
+                                (resource/project-defignore-patterns project-directory))))
+
+              (finally
+                (set-game-project-log-dir-pathname! project-directory nil))))
+
+          (testing "Includes patterns from .defignore file."
+            (try
+
+              (testing "Patterns without a leading slash are ignored."
+                (set-project-defignore-lines! project-directory ["a" "b" "c"])
+                (is (= ["/log.txt"
+                        "/instance_1_log.txt"
+                        "/instance_2_log.txt"
+                        "/instance_3_log.txt"
+                        "/instance_4_log.txt"]
+                       (resource/project-defignore-patterns project-directory)))
+                (is (identical? (resource/project-defignore-patterns project-directory)
+                                (resource/project-defignore-patterns project-directory))))
+
+              (testing "Patterns with a leading slash are included."
+                (set-project-defignore-lines! project-directory ["a" "/b" "c" "/d"])
+                (is (= ["/log.txt"
+                        "/instance_1_log.txt"
+                        "/instance_2_log.txt"
+                        "/instance_3_log.txt"
+                        "/instance_4_log.txt"
+                        "/b"
+                        "/d"]
+                       (resource/project-defignore-patterns project-directory)))
+                (is (identical? (resource/project-defignore-patterns project-directory)
+                                (resource/project-defignore-patterns project-directory))))
+
+              (testing "Patterns are distinct."
+                (set-project-defignore-lines! project-directory ["/a" "/b" "/b" "/a" "/log.txt" "/instance_1_log.txt"])
+                (is (= ["/log.txt"
+                        "/instance_1_log.txt"
+                        "/instance_2_log.txt"
+                        "/instance_3_log.txt"
+                        "/instance_4_log.txt"
+                        "/a"
+                        "/b"]
+                       (resource/project-defignore-patterns project-directory)))
+                (is (identical? (resource/project-defignore-patterns project-directory)
+                                (resource/project-defignore-patterns project-directory))))
+
+              (testing "Trailing slashes are stripped from patterns."
+                (set-project-defignore-lines! project-directory ["/a" "/b" "/b/" "/a/" "/c/"])
+                (is (= ["/log.txt"
+                        "/instance_1_log.txt"
+                        "/instance_2_log.txt"
+                        "/instance_3_log.txt"
+                        "/instance_4_log.txt"
+                        "/a"
+                        "/b"
+                        "/c"]
+                       (resource/project-defignore-patterns project-directory)))
+                (is (identical? (resource/project-defignore-patterns project-directory)
+                                (resource/project-defignore-patterns project-directory))))
+
+              (finally
+                (set-project-defignore-lines! project-directory nil)))))))))
+
+(deftest defignore-pred-test
+  (test-support/with-cleared-system-properties!
+    ["defold.log.dir"]
+
+    (let [first-project-directory (io/file (test-util/make-temp-project-copy! "test/resources/empty_project"))
+          second-project-directory (io/file (test-util/make-temp-project-copy! "test/resources/empty_project"))]
+      (with-open [_first-project-deleter (test-util/make-directory-deleter first-project-directory)
+                  _second-project-deleter (test-util/make-directory-deleter second-project-directory)]
+
+        (testing "Caches individual predicates per project-directory."
+          (is (identical? (resource/defignore-pred first-project-directory)
+                          (resource/defignore-pred first-project-directory)))
+          (is (identical? (resource/defignore-pred second-project-directory)
+                          (resource/defignore-pred second-project-directory)))
+          (is (not (identical? (resource/defignore-pred first-project-directory)
+                               (resource/defignore-pred second-project-directory)))))
+
+        (testing "Invalidated by adding .defignore file."
+          (let [first-defignore-pred (resource/defignore-pred first-project-directory)
+                second-defignore-pred (resource/defignore-pred second-project-directory)]
+            (set-project-defignore-lines! first-project-directory ["/first.txt"])
+            (is (identical? second-defignore-pred (resource/defignore-pred second-project-directory)))
+            (is (not (identical? first-defignore-pred (resource/defignore-pred first-project-directory))))
+            (is (identical? (resource/defignore-pred first-project-directory)
+                            (resource/defignore-pred first-project-directory)))))
+
+        (testing "Invalidated by editing .defignore file."
+          (let [first-defignore-pred (resource/defignore-pred first-project-directory)
+                second-defignore-pred (resource/defignore-pred second-project-directory)]
+            (set-project-defignore-lines! first-project-directory ["/ignored.txt" "/neglected.txt"])
+            (is (identical? second-defignore-pred (resource/defignore-pred second-project-directory)))
+            (is (not (identical? first-defignore-pred (resource/defignore-pred first-project-directory))))
+            (is (identical? (resource/defignore-pred first-project-directory)
+                            (resource/defignore-pred first-project-directory)))))
+
+        (testing "Invalidated by deleting .defignore file."
+          (let [first-defignore-pred (resource/defignore-pred first-project-directory)
+                second-defignore-pred (resource/defignore-pred second-project-directory)]
+            (set-project-defignore-lines! first-project-directory nil)
+            (is (identical? second-defignore-pred (resource/defignore-pred second-project-directory)))
+            (is (not (identical? first-defignore-pred (resource/defignore-pred first-project-directory))))
+            (is (identical? (resource/defignore-pred first-project-directory)
+                            (resource/defignore-pred first-project-directory)))))
+
+        (testing "Invalidated by setting project.log_dir in game.project."
+          (let [first-defignore-pred (resource/defignore-pred first-project-directory)
+                second-defignore-pred (resource/defignore-pred second-project-directory)]
+            (set-game-project-log-dir-pathname! first-project-directory "logs")
+            (is (identical? second-defignore-pred (resource/defignore-pred second-project-directory)))
+            (is (not (identical? first-defignore-pred (resource/defignore-pred first-project-directory))))
+            (is (identical? (resource/defignore-pred first-project-directory)
+                            (resource/defignore-pred first-project-directory)))))
+
+        (testing "Invalidated by setting defold.log.dir property."
+          (let [first-defignore-pred (resource/defignore-pred first-project-directory)
+                second-defignore-pred (resource/defignore-pred second-project-directory)]
+            (System/setProperty "defold.log.dir" "logs")
+            (try
+              (is (not (identical? first-defignore-pred (resource/defignore-pred first-project-directory))))
+              (is (not (identical? second-defignore-pred (resource/defignore-pred second-project-directory))))
+              (is (identical? (resource/defignore-pred first-project-directory)
+                              (resource/defignore-pred first-project-directory)))
+              (is (identical? (resource/defignore-pred second-project-directory)
+                              (resource/defignore-pred second-project-directory)))
+              (finally
+                (System/clearProperty "defold.log.dir")))))))))

--- a/editor/test/support/test_support.clj
+++ b/editor/test/support/test_support.clj
@@ -92,3 +92,40 @@
   `(fn ~(symbol (name fn-sym)) [& ~'args]
      (g/with-auto-evaluation-context ~'evaluation-context
        (apply ~fn-sym (conj (vec ~'args) ~'evaluation-context)))))
+
+(defn set-system-property!
+  ^String [^String property-name ^String value]
+  (if (nil? value)
+    (System/clearProperty property-name)
+    (System/setProperty property-name value)))
+
+(defmacro with-cleared-system-properties! [property-names & body-exprs]
+  {:pre [(vector? property-names)
+         (every? string? property-names)
+         (every? not-empty property-names)]}
+  (let [sym+property-name-pairs
+        (into []
+              (map (fn [^String property-name]
+                     [(gensym (.replace property-name "." "-"))
+                      property-name]))
+              property-names)]
+
+    (list*
+      'let
+      (into []
+            (mapcat (fn [[sym ^String property-name]]
+                      [sym `(System/getProperty ~property-name)]))
+            sym+property-name-pairs)
+      (concat
+        (map (fn [^String property-name]
+               `(System/clearProperty ~property-name))
+             property-names)
+        [(list*
+           'try
+           (concat
+             body-exprs
+             [(list*
+                'finally
+                (map (fn [[sym ^String property-name]]
+                       `(set-system-property! ~property-name ~sym))
+                     (rseq sym+property-name-pairs)))]))]))))

--- a/editor/test/util/fn_test.clj
+++ b/editor/test/util/fn_test.clj
@@ -110,6 +110,9 @@
     (is (true? (fn/has-explicit-arity? arity-variadic-test-anonymous-fn 1)))
     (is (false? (fn/has-explicit-arity? arity-variadic-test-anonymous-fn 2)))))
 
+(defn- memoized-fn-cache [memoized-fn]
+  (deref (::fn/memoize-cache (meta memoized-fn))))
+
 (deftest memoize-test
   (testing "Returns unique instances"
     (is (not (identical? (fn/memoize identity) (fn/memoize identity)))))
@@ -164,7 +167,113 @@
       (is (= 1 @call-count-atom))
       (is (identical? (memoized-fn 2 3 4 5 6) (memoized-fn 2 3 4 5 6)))
       (is (= 2 @call-count-atom))
-      (is (= "1, 2, 3, 4, 5, 6, 7, 8, 9" (memoized-fn 1 2 3 4 5 6 7 8 9))))))
+      (is (= "1, 2, 3, 4, 5, 6, 7, 8, 9" (memoized-fn 1 2 3 4 5 6 7 8 9)))))
+
+  (testing "Limited unary function"
+    (let [memoized-fn (fn/memoize {:limit 1} #(str ":" % "::"))]
+      (is (= {} (memoized-fn-cache memoized-fn)))
+      (memoized-fn :f)
+      (is (= {:f "::f::"}
+             (memoized-fn-cache memoized-fn)))
+      (memoized-fn :i)
+      (is (= {:i "::i::"}
+             (memoized-fn-cache memoized-fn))))
+    (let [memoized-fn (fn/memoize {:limit 3} #(str ":" % "::"))]
+      (is (= {} (memoized-fn-cache memoized-fn)))
+      (memoized-fn :f)
+      (memoized-fn :i)
+      (memoized-fn :f)
+      (is (= {:f "::f::"
+              :i "::i::"}
+             (memoized-fn-cache memoized-fn)))
+      (memoized-fn :o)
+      (is (= {:f "::f::"
+              :i "::i::"
+              :o "::o::"}
+             (memoized-fn-cache memoized-fn)))
+      (memoized-fn :n)
+      (is (= {:i "::i::"
+              :o "::o::"
+              :n "::n::"}
+             (memoized-fn-cache memoized-fn)))))
+
+  (testing "Limited binary function"
+    (let [memoized-fn (fn/memoize {:limit 1} #(str ":" %1 ":" %2 "::"))]
+      (memoized-fn :f 0)
+      (is (= {[:f 0] "::f:0::"}
+             (memoized-fn-cache memoized-fn)))
+      (memoized-fn :i 1)
+      (is (= {[:i 1] "::i:1::"}
+             (memoized-fn-cache memoized-fn))))
+    (let [memoized-fn (fn/memoize {:limit 3} #(str ":" %1 ":" %2 "::"))]
+      (memoized-fn :f 0)
+      (memoized-fn :i 1)
+      (memoized-fn :f 0)
+      (is (= {[:f 0] "::f:0::"
+              [:i 1] "::i:1::"}
+             (memoized-fn-cache memoized-fn)))
+      (memoized-fn :o 2)
+      (is (= {[:f 0] "::f:0::"
+              [:i 1] "::i:1::"
+              [:o 2] "::o:2::"}
+             (memoized-fn-cache memoized-fn)))
+      (memoized-fn :n 3)
+      (is (= {[:i 1] "::i:1::"
+              [:o 2] "::o:2::"
+              [:n 3] "::n:3::"}
+             (memoized-fn-cache memoized-fn)))))
+
+  (testing "Limited general function"
+    (let [memoized-fn (fn/memoize {:limit 1} #(str ":" %1 ":" %2 ":" %3 "::"))]
+      (memoized-fn :f 0 "A")
+      (is (= {[:f 0 "A"] "::f:0:A::"}
+             (memoized-fn-cache memoized-fn)))
+      (memoized-fn :i 1 "B")
+      (is (= {[:i 1 "B"] "::i:1:B::"}
+             (memoized-fn-cache memoized-fn))))
+    (let [memoized-fn (fn/memoize {:limit 3} #(str ":" %1 ":" %2 ":" %3 "::"))]
+      (memoized-fn :f 0 "A")
+      (memoized-fn :i 1 "B")
+      (memoized-fn :f 0 "A")
+      (is (= {[:f 0 "A"] "::f:0:A::"
+              [:i 1 "B"] "::i:1:B::"}
+             (memoized-fn-cache memoized-fn)))
+      (memoized-fn :o 2 "C")
+      (is (= {[:f 0 "A"] "::f:0:A::"
+              [:i 1 "B"] "::i:1:B::"
+              [:o 2 "C"] "::o:2:C::"}
+             (memoized-fn-cache memoized-fn)))
+      (memoized-fn :n 3 "D")
+      (is (= {[:i 1 "B"] "::i:1:B::"
+              [:o 2 "C"] "::o:2:C::"
+              [:n 3 "D"] "::n:3:D::"}
+             (memoized-fn-cache memoized-fn)))))
+
+  (testing "Limited variadic function"
+    (let [memoized-fn (fn/memoize {:limit 1} str)]
+      (memoized-fn :f 0 "A")
+      (is (= {[:f 0 "A"] ":f0A"}
+             (memoized-fn-cache memoized-fn)))
+      (memoized-fn :i 1 "B")
+      (is (= {[:i 1 "B"] ":i1B"}
+             (memoized-fn-cache memoized-fn))))
+    (let [memoized-fn (fn/memoize {:limit 3} str)]
+      (memoized-fn :f 0 "A")
+      (memoized-fn :i 1 "B")
+      (memoized-fn :f 0 "A")
+      (is (= {[:f 0 "A"] ":f0A"
+              [:i 1 "B"] ":i1B"}
+             (memoized-fn-cache memoized-fn)))
+      (memoized-fn :o 2 "C")
+      (is (= {[:f 0 "A"] ":f0A"
+              [:i 1 "B"] ":i1B"
+              [:o 2 "C"] ":o2C"}
+             (memoized-fn-cache memoized-fn)))
+      (memoized-fn :n 3 "D")
+      (is (= {[:i 1 "B"] ":i1B"
+              [:o 2 "C"] ":o2C"
+              [:n 3 "D"] ":n3D"}
+             (memoized-fn-cache memoized-fn))))))
 
 (deftest clear-memoized!-test
   (testing "Non-memoized function"


### PR DESCRIPTION
The editor will now ignore log files written by the engine runtime when scanning the project for changes. Previously, changes to these log files would cause the editor to reload external changes into the graph and clear the undo queue unless the log file patterns were explicitly listed in a `.defignore` file or configured to be written outside the project directory.

Partially addresses #11408.

### Technical changes
The `defignore-pred` has been updated to ignore engine log files. For this, it needs to take into account:
  * The `proj-path` patterns listed in the `.defignore` file.
  * The hidden `project.log_dir` setting in `game.project`.
  * The `defold.log.dir` JVM property.
  
Since we need to obtain the `.defignore` patterns before we populate the `workspace`, the new implementation relies heavily on memoization to avoid parsing these files over and over. Every `project-directory` root is associated with several memoized functions limited to a single cached result based on the `last-modified-time` of each input file. These are in turn composed into "umbrella" memoized functions that produce the list of `proj-path-patterns` and finally the `defignore-pred` itself.

Extensive tests have been added to `resource_test.clj` to ensure the caching works as expected.

* Added optional `opts` map argument to `fn/memoize`, allowing you to specify a `:limit` to the number of cached calls.
* Added `path/resolve-normalized`, which is probably what you want most of the time. Updated `path/resolve` docs to reflect that it does not normalize the resulting path.
* Added `test-support/with-cleared-system-properties!` macro so the state of the `defold.log.dir` JVM property does not interfere with the tests.

### Testing notes
If you test the functionality in a `dev` build of the editor, make sure to comment out the `"-Ddefold.log.dir="` line under `:jvm-opts` in `project.clj` first. This setting causes the editor to override `project.log_dir` to the current working directory, which will be outside of the project directory.

### Intermittent Spec error logged during tests
This change appears to have unearthed an issue around how the `lsp` system works with the editor tests. You will occasionally see a "Spec assertion failed" error logged, caused by a message posted to the `lsp` async channel, which doesn't get handled until the originating test has deleted the project directory.

Running this command, I can get it to happen about half the time on my local machine:
```
lein test :only integration.script-properties-test/zip-resource-reference-remains-valid-after-script-reload-test integration.sound-test
```

The error does not cause a test failure - it just gets printed to `stdout`. I think we should investigate it as a separate problem rather than attempting to fix it as part of this PR.