### PR TITLE
Fix LSP errors in tests that deleted the project dir on completion

### DIFF
--- a/editor/src/clj/editor/lsp.clj
+++ b/editor/src/clj/editor/lsp.clj
@@ -13,6 +13,7 @@
 ;; specific language governing permissions and limitations under the License.
 
 (ns editor.lsp
+  (:refer-clojure :exclude [await])
   (:require [clojure.core.async :as a :refer [<! >!]]
             [clojure.set :as set]
             [clojure.spec.alpha :as s]
@@ -440,7 +441,7 @@
 
 (defn set-servers [new-servers]
   {:pre [(s/assert ::new-servers new-servers)]}
-  (fn [{:keys [server->server-state project] :as state}]
+  (bound-fn [{:keys [server->server-state project] :as state}]
     (let [old-servers (set (keys server->server-state))
           to-remove (set/difference old-servers new-servers)
           to-add (set/difference new-servers old-servers)]
@@ -582,7 +583,7 @@
 (defn notify-lines-modified!
   "Notify the LSP manager about new lines of a resource node"
   [lsp resource old-source-value new-lines]
-  (lsp (fn notify-lines-modified [state]
+  (lsp (bound-fn notify-lines-modified [state]
          (cond-> state
                  (resource/file-resource? resource)
                  (sync-modified-lines-of-existing-node! resource old-source-value new-lines)))))
@@ -936,6 +937,15 @@
                                 [(lsp.server/rename resource cursor new-name)]))
                :timeout-ms timeout-ms))))
     (throw (IllegalArgumentException. "Expected a prepared range" {:range prepared-range}))))
+
+(defn await
+  "For tests only: await for all enqueued LSP invocations to complete"
+  [lsp]
+  (let [p (promise)]
+    (lsp (bound-fn [state]
+           (deliver p nil)
+           state))
+    @p))
 
 (comment
   (val (first @running-lsps))

--- a/editor/test/integration/non_editable_resources_test.clj
+++ b/editor/test/integration/non_editable_resources_test.clj
@@ -19,6 +19,7 @@
             [dynamo.graph :as g]
             [editor.fs :as fs]
             [editor.game-project :as game-project]
+            [editor.lsp :as lsp]
             [editor.math :as math]
             [editor.protobuf :as protobuf]
             [editor.resource :as resource]
@@ -241,6 +242,7 @@
                                        :house (g/node-value house :build-targets)}}]
                   (tu/save-project! project)
                   (tu/set-non-editable-directories! project-path ["/assets"])
+                  (lsp/await (lsp/get-node-lsp project))
                   editable-results)))]
         ;; Reload the project now that the resources are in a non-editable state
         ;; and compare the non-editable output to the editable output.
@@ -253,7 +255,8 @@
                       :let [non-editable-node-id (non-editable-node-ids-by-node-key node-key)]]
                 (testing (str node-key)
                   (is (= editable-build-source-paths
-                         (tu/node-built-source-paths non-editable-node-id))))))))))))
+                         (tu/node-built-source-paths non-editable-node-id))))))
+            (lsp/await (lsp/get-node-lsp (:project non-editable-node-ids-by-node-key)))))))))
 
 (deftest build-target-test
   (doseq [atlas-property-proj-paths-by-node-key
@@ -332,7 +335,8 @@
                 (is (= "/non-editable-room/go" (:id non-editable-room-instance-pb-map)))
                 (is (string/includes? (:prototype editable-room-instance-pb-map) "generated"))
                 (is (= (:prototype editable-room-instance-pb-map)
-                       (:prototype non-editable-room-instance-pb-map)))))))))))
+                       (:prototype non-editable-room-instance-pb-map))))))
+          (lsp/await (lsp/get-node-lsp project)))))))
 
 ;; -----------------------------------------------------------------------------
 ;; scene-test
@@ -446,6 +450,7 @@
                                :house (g/node-value house :scene)}}]
                   (tu/save-project! project)
                   (tu/set-non-editable-directories! project-path ["/assets"])
+                  (lsp/await (lsp/get-node-lsp project))
                   editable-results)))]
         ;; Reload the project now that the resources are in a non-editable state
         ;; and compare the non-editable output to the editable output.

--- a/editor/test/integration/script_properties_test.clj
+++ b/editor/test/integration/script_properties_test.clj
@@ -26,6 +26,7 @@
             [editor.defold-project :as project]
             [editor.fs :as fs]
             [editor.game-object :as game-object]
+            [editor.lsp :as lsp]
             [editor.properties :as properties]
             [editor.protobuf :as protobuf]
             [editor.resource :as resource]
@@ -422,7 +423,8 @@
                       (is (= [(resource "/props.script") props-script]
                              (error-item-open-info-without-opts error-item-of-parent-resource)))
                       (is (= [(resource "/props.script") props-script]
-                             (error-item-open-info-without-opts error-item-of-faulty-node))))))))))))))
+                             (error-item-open-info-without-opts error-item-of-faulty-node))))))))))
+        (lsp/await (lsp/get-node-lsp project))))))
 
 (deftest edit-component-instance-resource-properties-test
   (with-clean-system
@@ -628,7 +630,8 @@
               "Texture '/missing-resource.png' could not be found"
 
               ["go.property('texture', resource.texture('/from-props-script.material'))"]
-              "Texture '/from-props-script.material' is not of type .cubemap, .jpeg, .jpg, .png or .render_target")))))))
+              "Texture '/from-props-script.material' is not of type .cubemap, .jpeg, .jpg, .png or .render_target")))
+        (lsp/await (lsp/get-node-lsp project))))))
 
 (deftest rename-resource-referenced-from-component-instance-test
   (with-clean-system
@@ -668,7 +671,8 @@
               (is (= (tu/unpack-property-declarations (:property-decls built-props-script-component))
                      {"atlas" (murmur/hash64 renamed-build-resource-path)}))
               (is (= (:property-resources built-props-game-object)
-                     [renamed-build-resource-path])))))))))
+                     [renamed-build-resource-path])))))
+        (lsp/await (lsp/get-node-lsp project))))))
 
 (deftest edit-game-object-instance-resource-properties-test
   (with-clean-system
@@ -893,7 +897,8 @@
               "Texture '/missing-resource.png' could not be found"
 
               ["go.property('texture', resource.texture('/from-props-script.material'))"]
-              "Texture '/from-props-script.material' is not of type .cubemap, .jpeg, .jpg, .png or .render_target")))))))
+              "Texture '/from-props-script.material' is not of type .cubemap, .jpeg, .jpg, .png or .render_target")))
+        (lsp/await (lsp/get-node-lsp project))))))
 
 (deftest rename-resource-referenced-from-game-object-instance-test
   (with-clean-system
@@ -939,7 +944,8 @@
               (is (= (tu/unpack-property-declarations (:property-decls built-props-script-component))
                      {"atlas" (murmur/hash64 renamed-build-resource-path)}))
               (is (= (:property-resources built-props-collection)
-                     [renamed-build-resource-path])))))))))
+                     [renamed-build-resource-path])))))
+        (lsp/await (lsp/get-node-lsp project))))))
 
 (deftest edit-collection-instance-resource-properties-test
   (with-clean-system
@@ -1181,7 +1187,8 @@
               "Texture '/missing-resource.png' could not be found"
 
               ["go.property('texture', resource.texture('/from-props-script.material'))"]
-              "Texture '/from-props-script.material' is not of type .cubemap, .jpeg, .jpg, .png or .render_target")))))))
+              "Texture '/from-props-script.material' is not of type .cubemap, .jpeg, .jpg, .png or .render_target")))
+        (lsp/await (lsp/get-node-lsp project))))))
 
 (deftest edit-collection-instance-embedded-game-object-resource-properties-test
   (with-clean-system
@@ -1426,7 +1433,8 @@
               "Texture '/missing-resource.png' could not be found"
 
               ["go.property('texture', resource.texture('/from-props-script.material'))"]
-              "Texture '/from-props-script.material' is not of type .cubemap, .jpeg, .jpg, .png or .render_target")))))))
+              "Texture '/from-props-script.material' is not of type .cubemap, .jpeg, .jpg, .png or .render_target")))
+        (lsp/await (lsp/get-node-lsp project))))))
 
 (deftest rename-resource-referenced-from-collection-instance-test
   (with-clean-system
@@ -1477,7 +1485,8 @@
               (is (= (tu/unpack-property-declarations (:property-decls built-props-script-component))
                      {"atlas" (murmur/hash64 renamed-build-resource-path)}))
               (is (= (:property-resources built-sub-props-collection)
-                     [renamed-build-resource-path])))))))))
+                     [renamed-build-resource-path])))))
+        (lsp/await (lsp/get-node-lsp project))))))
 
 (deftest layered-resource-property-override-test
   (with-clean-system
@@ -1628,7 +1637,8 @@
                      "/from-props-collection.atlas"
                      "/from-props-game-object.atlas"
                      "/from-props-script.atlas"}
-                   (tu/node-built-source-paths sub-props-collection)))))))))
+                   (tu/node-built-source-paths sub-props-collection)))))
+        (lsp/await (lsp/get-node-lsp project))))))
 
 (deftest overrides-remain-after-script-edit-test
   (with-clean-system
@@ -1679,7 +1689,8 @@
                     (is (= [(resource "/props.go") props-game-object]
                            (error-item-open-info-without-opts error-item-of-parent-resource)))
                     (is (= [(resource "/props.go") props-script-component]
-                           (error-item-open-info-without-opts error-item-of-faulty-node)))))))))))))
+                           (error-item-open-info-without-opts error-item-of-faulty-node)))))))))
+        (lsp/await (lsp/get-node-lsp project))))))
 
 (deftest overrides-remain-after-script-reload-test
   (with-clean-system
@@ -1741,7 +1752,8 @@
           (is (assigned-property? ov-ov-props-script-component "/from-sub-props-collection.atlas"))
           (is (overridden-property? props-script-component))
           (is (overridden-property? ov-props-script-component))
-          (is (overridden-property? ov-ov-props-script-component)))))))
+          (is (overridden-property? ov-ov-props-script-component)))
+        (lsp/await (lsp/get-node-lsp project))))))
 
 (deftest zip-resource-reference-remains-valid-after-script-reload-test
   ;; It seems currently all ZipResources are recreated during resource sync.
@@ -1775,4 +1787,6 @@
         (let [props-script (tu/resource-node project "/props.script")]
           (is (= #{"/props.script"
                    "/builtins/graphics/particle_blob.tilesource"}
-                 (tu/node-built-source-paths props-script))))))))
+                 (tu/node-built-source-paths props-script))))
+
+        (lsp/await (lsp/get-node-lsp project))))))

--- a/editor/test/integration/sparse_protobuf_test.clj
+++ b/editor/test/integration/sparse_protobuf_test.clj
@@ -18,6 +18,7 @@
             [dynamo.graph :as g]
             [editor.defold-project :as project]
             [editor.fs :as fs]
+            [editor.lsp :as lsp]
             [editor.protobuf :as protobuf]
             [editor.resource :as resource]
             [editor.resource-node :as resource-node]
@@ -577,4 +578,5 @@
                                   read-text (slurp resource)
                                   written-read-text (write-fn read-value)]
                               (test-util/check-value-equivalence! read-value save-value read-text)
-                              (test-util/check-text-equivalence! written-read-text save-text read-text))))))))))))))))
+                              (test-util/check-text-equivalence! written-read-text save-text read-text)))))))))
+              (lsp/await (lsp/get-node-lsp project)))))))))

--- a/editor/test/integration/symlink_test.clj
+++ b/editor/test/integration/symlink_test.clj
@@ -18,6 +18,7 @@
             [dynamo.graph :as g]
             [editor.defold-project :as project]
             [editor.fs :as fs]
+            [editor.lsp :as lsp]
             [editor.resource :as resource]
             [editor.workspace :as workspace]
             [integration.test-util :as test-util]
@@ -157,7 +158,9 @@
             (workspace/resource-sync! workspace)
 
             (testing "After breaking symlink."
-              (check-stateless-directory-symlink-broken! project referencing-directory))))))))
+              (check-stateless-directory-symlink-broken! project referencing-directory))
+
+            (lsp/await (lsp/get-node-lsp project))))))))
 
 (deftest stateless-directory-broken-symlink-test
   (let [referencing-project-path (test-util/make-temp-project-copy! "test/resources/empty_project")
@@ -187,7 +190,9 @@
             (workspace/resource-sync! workspace)
 
             (testing "After fixing symlink."
-              (check-stateless-directory-symlink-valid! project referencing-directory))))))))
+              (check-stateless-directory-symlink-valid! project referencing-directory))
+
+            (lsp/await (lsp/get-node-lsp project))))))))
 
 (defn- check-stateful-directory-symlink-valid! [project referencing-directory]
   (testing "Symlink appears as directory."
@@ -244,7 +249,9 @@
             (workspace/resource-sync! workspace)
 
             (testing "After breaking symlink."
-              (check-stateful-directory-symlink-broken! project referencing-directory))))))))
+              (check-stateful-directory-symlink-broken! project referencing-directory))
+
+            (lsp/await (lsp/get-node-lsp project))))))))
 
 (deftest stateful-directory-broken-symlink-test
   (let [referencing-project-path (test-util/make-temp-project-copy! "test/resources/empty_project")
@@ -274,7 +281,9 @@
             (workspace/resource-sync! workspace)
 
             (testing "After fixing symlink."
-              (check-stateful-directory-symlink-valid! project referencing-directory))))))))
+              (check-stateful-directory-symlink-valid! project referencing-directory))
+
+            (lsp/await (lsp/get-node-lsp project))))))))
 
 (defn- create-file-symlinks! [referencing-directory referenced-directory]
   (coll/reduce-> (path/tree-walker referenced-directory) {}
@@ -360,7 +369,9 @@
               (workspace/resource-sync! workspace)
 
               (testing "After breaking symlinks."
-                (check-stateless-file-symlinks-broken! project referencing-files referenced-project-path)))))))))
+                (check-stateless-file-symlinks-broken! project referencing-files referenced-project-path))
+
+              (lsp/await (lsp/get-node-lsp project)))))))))
 
 (deftest stateless-file-broken-symlink-test
   (let [referencing-project-path (test-util/make-temp-project-copy! "test/resources/empty_project")
@@ -392,7 +403,9 @@
               (workspace/resource-sync! workspace)
 
               (testing "After fixing symlinks."
-                (check-stateless-file-symlinks-valid! project referencing-files)))))))))
+                (check-stateless-file-symlinks-valid! project referencing-files))
+
+              (lsp/await (lsp/get-node-lsp project)))))))))
 
 (defn- check-stateful-file-symlinks-valid! [project referencing-files]
   (testing "Symlinks appear as files of their respective resource-type."
@@ -461,7 +474,9 @@
               (workspace/resource-sync! workspace)
 
               (testing "After breaking symlinks."
-                (check-stateful-file-symlinks-broken! project referencing-files referenced-project-path)))))))))
+                (check-stateful-file-symlinks-broken! project referencing-files referenced-project-path))
+
+              (lsp/await (lsp/get-node-lsp project)))))))))
 
 (deftest stateful-file-broken-symlink-test
   (let [referencing-project-path (test-util/make-temp-project-copy! "test/resources/empty_project")
@@ -493,4 +508,6 @@
               (workspace/resource-sync! workspace)
 
               (testing "After fixing symlinks."
-                (check-stateful-file-symlinks-valid! project referencing-files)))))))))
+                (check-stateful-file-symlinks-valid! project referencing-files))
+
+              (lsp/await (lsp/get-node-lsp project)))))))))

--- a/editor/test/integration/test_util.clj
+++ b/editor/test/integration/test_util.clj
@@ -32,6 +32,7 @@
             [editor.graph-util :as gu]
             [editor.handler :as handler]
             [editor.localization :as localization]
+            [editor.lsp :as lsp]
             [editor.material :as material]
             [editor.math :as math]
             [editor.outline :as outline]
@@ -184,7 +185,12 @@
 (defn make-directory-deleter
   "Returns an AutoCloseable that deletes the directory at the specified
   path when closed. Suitable for use with the (with-open) macro. The
-  directory path must be a temp directory."
+  directory path must be a temp directory.
+
+  IMPORTANT! If you use the deleter for a project directory where you set up a
+  system, you need to use (lsp/await (lsp/get-node-lsp project)) before the
+  body returns, otherwise you might get `:editor.resource/project-directory`
+  spec failures in the output."
   ^AutoCloseable [directory-path]
   (let [directory (io/file directory-path)]
     (assert (string/starts-with? (.getCanonicalPath directory)
@@ -691,8 +697,10 @@
            (workspace/resource-sync! ~'workspace)
            (fetch-libraries! ~'workspace)
            (let [~'project (setup-project! ~'workspace)
-                 ~'app-view (setup-app-view! ~'project)]
-             ~@body))))))
+                 ~'app-view (setup-app-view! ~'project)
+                 ret# (do ~@body)]
+             (lsp/await (lsp/get-node-lsp ~'project))
+             ret#))))))
 
 (defmacro with-ui-run-later-rebound
   [& forms]

--- a/editor/test/integration/test_util_test.clj
+++ b/editor/test/integration/test_util_test.clj
@@ -18,6 +18,7 @@
             [editor.collection :as collection]
             [editor.defold-project :as project]
             [editor.game-object :as game-object]
+            [editor.lsp :as lsp]
             [editor.properties :as properties]
             [editor.resource :as resource]
             [editor.resource-node :as resource-node]
@@ -351,4 +352,6 @@
 
             (testing "On house collection."
               (is (= [house-referenced-room] (test-util/referenced-collections house)))
-              (is (= room (g/override-original (test-util/to-collection-node-id house-referenced-room)))))))))))
+              (is (= room (g/override-original (test-util/to-collection-node-id house-referenced-room))))))
+
+          (lsp/await (lsp/get-node-lsp project)))))))

--- a/editor/test/integration/unload_test.clj
+++ b/editor/test/integration/unload_test.clj
@@ -18,6 +18,7 @@
             [dynamo.graph :as g]
             [editor.defold-project :as project]
             [editor.fs :as fs]
+            [editor.lsp :as lsp]
             [editor.resource :as resource]
             [editor.resource-node :as resource-node]
             [editor.workspace :as workspace]
@@ -111,7 +112,8 @@
                           (is (not (g/error? (g/node-value resource-node :node-outline evaluation-context))))
                           (is (not (g/error? (g/node-value resource-node :build-targets evaluation-context))))
                           (when (resource-type-has-view-type? resource-type :scene)
-                            (is (not (g/error? (g/node-value resource-node :scene evaluation-context))))))))))))))))))
+                            (is (not (g/error? (g/node-value resource-node :scene evaluation-context)))))))))))
+              (lsp/await (lsp/get-node-lsp project)))))))))
 
 (defn- loaded-proj-path? [project proj-path]
   (let [resource-node-id (project/get-resource-node project proj-path)]
@@ -342,7 +344,8 @@
                 (testing "Only the externally modified files were reloaded."
                   (is (= ["/loaded_referencing_unloaded_go.collection"]
                          (mapv (comp resource/proj-path :resource first)
-                               node-load-info-tx-data-calls))))))))))))
+                               node-load-info-tx-data-calls))))))
+            (lsp/await (lsp/get-node-lsp project))))))))
 
 (deftest defunload-scene-edit-test
   (let [project-path (test-util/make-temp-project-copy! "test/resources/empty_project")]
@@ -467,7 +470,8 @@
 
                   (is (= []
                          (mapv (comp resource/proj-path :resource first)
-                               node-load-info-tx-data-calls))))))))))))
+                               node-load-info-tx-data-calls))))))
+            (lsp/await (lsp/get-node-lsp project))))))))
 
 (deftest defunload-script-edit-test
   (let [project-path (test-util/make-temp-project-copy! "test/resources/empty_project")]
@@ -608,4 +612,6 @@
 
                   (is (= []
                          (mapv (comp resource/proj-path :resource first)
-                               node-load-info-tx-data-calls))))))))))))
+                               node-load-info-tx-data-calls))))))
+
+            (lsp/await (lsp/get-node-lsp project))))))))


### PR DESCRIPTION
The errors in the test output were caused by LSP asynchronously looking up resources after the project dir was deleted. I think the easiest fix would be to simply delete these folders on exit, but I think it's not unreasonable to want to make some tests "tidy" and "isolated". I also considered disabling the LSP system completely in tests by default, but it led to some tests being suddenly stuck (the tests that built a project, which included requesting an LSP lint...) without any feedback, which I think is worse than an error in the log — it makes it much harder to figure out what's wrong...