### PR TITLE
Make `/command/build` respond on build completion

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -1037,17 +1037,19 @@
 (defn async-build!
   "Asynchronously build the project and notify the :result-fn with results
 
+  Returns a CompletableFuture that will eventually be completed with a map with
+  the following keys:
+    :artifacts       build results for successfully built project resources
+    :artifact-map    build results by resource, used as input to future builds
+    :etags           map of built resource proj-paths to content fingerprint
+    :engine          the engine descriptor map when asked to build the engine,
+                     and it was successfully built
+    :error           the error value in case of any errors, be it project
+                     resources, linting or engine build error
+    :warning         error value in case there are non-critical issues reported
+                     by the build process
+
   Kv-args:
-    :result-fn           required fn that will receive build results, a map with
-                         the following keys:
-                         * :artifacts, :artifact-map and :etags - results for
-                           successfully built project resources
-                         * :engine - engine descriptor map when asked to build
-                           the engine, and it was successfully built
-                         * :error - error value in case of any errors, be it
-                           project resources, linting or engine build error
-                         * :warning - error value in case there are non-critical
-                           issues reported by the build process
     :build-engine        optional flag that indicates whether the engine should
                          be built in addition to the project
     :lint                optional flag that indicates whether to run LSP lints
@@ -1066,7 +1068,6 @@
     :old-artifact-map    optional old artifact map with previous build results
                          to speed up the build process"
   [project & {:keys [;; required
-                     result-fn
                      prefs
                      ;; optional
                      debug build-engine run-build-hooks render-progress! task-cancelled? old-artifact-map lint]
@@ -1076,9 +1077,9 @@
                    render-progress! progress/null-render-progress!
                    task-cancelled? fn/constantly-false
                    old-artifact-map {}}}]
-  {:pre [(ifn? result-fn)
-         (or (not build-engine) (some? prefs))]}
-  (let [lint (if (nil? lint)
+  {:pre [(or (not build-engine) (some? prefs))]}
+  (let [result-future (future/make)
+        lint (if (nil? lint)
                (prefs/get prefs [:build :lint-code])
                lint)
         ;; After any pre-build hooks have completed successfully, we will start
@@ -1132,11 +1133,13 @@
                       (reset! build-in-progress-atom false)
                       (render-progress! progress/done)
                       (cancel-engine-build!)
+                      (future/fail! result-future error)
                       (throw error)))))
               (catch Throwable error
                 (reset! build-in-progress-atom false)
                 (render-progress! progress/done)
                 (cancel-engine-build!)
+                (future/fail! result-future error)
                 (error-reporting/report-exception! error))))
           nil)
 
@@ -1145,7 +1148,7 @@
           (reset! build-in-progress-atom false)
           (render-progress! progress/done)
           (cancel-engine-build!)
-          (result-fn project-build-results)
+          (future/complete! result-future project-build-results)
           nil)
 
         phase-7-await-lint!
@@ -1302,7 +1305,8 @@
     ;; soon as they can.
     (assert (not @build-in-progress-atom))
     (reset! build-in-progress-atom true)
-    (phase-1-await-current-reload!)))
+    (phase-1-await-current-reload!)
+    result-future))
 
 (defn- handle-build-results! [workspace render-build-error! build-results]
   (let [{:keys [error warning artifact-map etags project-build-successful]} build-results
@@ -1325,18 +1329,20 @@
         skip-engine (target-cannot-swap-engine? (targets/selected-target prefs))
         [render-progress! task-cancelled?] (begin-task-progress! :build)]
     (build-errors-view/clear-build-errors build-errors-view)
-    (async-build! project
-                  :debug true
-                  :build-engine (not skip-engine)
-                  :prefs prefs
-                  :render-progress! render-progress!
-                  :task-cancelled? task-cancelled?
-                  :old-artifact-map (workspace/artifact-map workspace)
-                  :result-fn (fn [{:keys [engine] :as build-results}]
-                               (when (handle-build-results! workspace render-build-error! build-results)
-                                 (when (or engine skip-engine)
-                                   (show-console! main-scene tool-tab-pane)
-                                   (launch-built-project! project engine project-directory prefs web-server false)))))))
+    (future/then
+      (async-build! project
+                    :debug true
+                    :build-engine (not skip-engine)
+                    :prefs prefs
+                    :render-progress! render-progress!
+                    :task-cancelled? task-cancelled?
+                    :old-artifact-map (workspace/artifact-map workspace))
+      (fn [{:keys [engine] :as build-results}]
+        (when (handle-build-results! workspace render-build-error! build-results)
+          (when (or engine skip-engine)
+            (show-console! main-scene tool-tab-pane)
+            (launch-built-project! project engine project-directory prefs web-server false)))
+        build-results))))
 
 (handler/defhandler :project.build :global
   (enabled? [] (not (build-in-progress?)))
@@ -1377,36 +1383,38 @@
   (let [project-directory (workspace/project-directory workspace)
         skip-engine (target-cannot-swap-engine? (targets/selected-target prefs))
         [render-progress! task-cancelled?] (begin-task-progress! :build)]
-    (async-build! project
-                  :debug true
-                  :build-engine (not skip-engine)
-                  :prefs prefs
-                  :render-progress! render-progress!
-                  :task-cancelled? task-cancelled?
-                  :old-artifact-map (workspace/artifact-map workspace)
-                  :result-fn (fn [{:keys [engine] :as build-results}]
-                               (when (handle-build-results! workspace render-build-error! build-results)
-                                 (when (or engine skip-engine)
-                                   (when-let [target (launch-built-project! project engine project-directory prefs web-server true)]
-                                     (when (nil? (debug-view/current-session debug-view))
-                                       (debug-view/start-debugger! debug-view project (:address target "localhost") (:instance-index target 0))))))))))
+    (future/then
+      (async-build! project
+                    :debug true
+                    :build-engine (not skip-engine)
+                    :prefs prefs
+                    :render-progress! render-progress!
+                    :task-cancelled? task-cancelled?
+                    :old-artifact-map (workspace/artifact-map workspace))
+      (fn [{:keys [engine] :as build-results}]
+        (when (handle-build-results! workspace render-build-error! build-results)
+          (when (or engine skip-engine)
+            (when-let [target (launch-built-project! project engine project-directory prefs web-server true)]
+              (when (nil? (debug-view/current-session debug-view))
+                (debug-view/start-debugger! debug-view project (:address target "localhost") (:instance-index target 0))))))))))
 
 (defn- attach-debugger! [workspace project prefs debug-view render-build-error!]
   (let [[render-progress! task-cancelled?] (begin-task-progress! :build)]
-    (async-build! project
-                  :debug true
-                  :build-engine false
-                  :run-build-hooks false
-                  :lint false
-                  :render-progress! render-progress!
-                  :task-cancelled? task-cancelled?
-                  :old-artifact-map (workspace/artifact-map workspace)
-                  :prefs prefs
-                  :result-fn (fn [build-results]
-                               (when (handle-build-results! workspace render-build-error! build-results)
-                                 (let [target (targets/selected-target prefs)]
-                                   (when (targets/controllable-target? target)
-                                     (debug-view/attach! debug-view project target (:artifacts build-results)))))))))
+    (future/then
+      (async-build! project
+                    :debug true
+                    :build-engine false
+                    :run-build-hooks false
+                    :lint false
+                    :render-progress! render-progress!
+                    :task-cancelled? task-cancelled?
+                    :old-artifact-map (workspace/artifact-map workspace)
+                    :prefs prefs)
+      (fn [build-results]
+        (when (handle-build-results! workspace render-build-error! build-results)
+          (let [target (targets/selected-target prefs)]
+            (when (targets/controllable-target? target)
+              (debug-view/attach! debug-view project target (:artifacts build-results)))))))))
 
 (handler/defhandler :debugger.start :global
   ;; NOTE: Shares a shortcut with :debug-view/continue.
@@ -1524,40 +1532,41 @@
     ;; keep track of which resource versions have been loaded by the engine,
     ;; or we might miss resources that were recompiled but never reloaded.
     (build-errors-view/clear-build-errors build-errors-view)
-    (async-build! project
-                  :debug false
-                  :build-engine false
-                  :run-build-hooks false
-                  :lint false
-                  :render-progress! render-progress!
-                  :task-cancelled? task-cancelled?
-                  :old-artifact-map (workspace/artifact-map workspace)
-                  :prefs prefs
-                  :result-fn (fn [{:keys [error artifact-map etags]}]
-                               (if (some? error)
-                                 (render-build-error! error)
-                                 (do
-                                   (workspace/artifact-map! workspace artifact-map)
-                                   (workspace/etags! workspace etags)
-                                   (workspace/save-build-cache! workspace)
-                                   (try
-                                     (when-some [updated-build-resources
-                                                 (not-empty
-                                                   (g/with-auto-evaluation-context evaluation-context
-                                                     (updated-build-resources evaluation-context project old-etags etags "/game.project")))]
-                                       (if (targets/all-launched-targets? target)
-                                         (doseq [launched-target (targets/all-launched-targets)]
-                                           (engine/reload-build-resources! launched-target updated-build-resources))
-                                         (engine/reload-build-resources! target updated-build-resources)))
-                                     (catch Exception e
-                                       (dialogs/make-info-dialog
-                                         localization
-                                         {:title (localization/message "dialog.hot-reload-failed.title")
-                                          :icon :icon/triangle-error
-                                          :header (localization/message
-                                                    "dialog.hot-reload-failed.header"
-                                                    {"engine" (targets/target-message (targets/selected-target prefs))})
-                                          :content (.getMessage e)})))))))))
+    (future/then
+      (async-build! project
+                    :debug false
+                    :build-engine false
+                    :run-build-hooks false
+                    :lint false
+                    :render-progress! render-progress!
+                    :task-cancelled? task-cancelled?
+                    :old-artifact-map (workspace/artifact-map workspace)
+                    :prefs prefs)
+      (fn [{:keys [error artifact-map etags]}]
+        (if (some? error)
+          (render-build-error! error)
+          (do
+            (workspace/artifact-map! workspace artifact-map)
+            (workspace/etags! workspace etags)
+            (workspace/save-build-cache! workspace)
+            (try
+              (when-some [updated-build-resources
+                          (not-empty
+                            (g/with-auto-evaluation-context evaluation-context
+                              (updated-build-resources evaluation-context project old-etags etags "/game.project")))]
+                (if (targets/all-launched-targets? target)
+                  (doseq [launched-target (targets/all-launched-targets)]
+                    (engine/reload-build-resources! launched-target updated-build-resources))
+                  (engine/reload-build-resources! target updated-build-resources)))
+              (catch Exception e
+                (dialogs/make-info-dialog
+                  localization
+                  {:title (localization/message "dialog.hot-reload-failed.title")
+                   :icon :icon/triangle-error
+                   :header (localization/message
+                             "dialog.hot-reload-failed.header"
+                             {"engine" (targets/target-message (targets/selected-target prefs))})
+                   :content (.getMessage e)})))))))))
 
 (handler/defhandler :run.hot-reload :global
   (enabled? [debug-view prefs evaluation-context]

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -1139,7 +1139,7 @@
                 (reset! build-in-progress-atom false)
                 (render-progress! progress/done)
                 (cancel-engine-build!)
-                (future/fail! result-future error)
+                (ui/run-later (future/fail! result-future error))
                 (error-reporting/report-exception! error))))
           nil)
 

--- a/editor/src/clj/editor/boot_open_project.clj
+++ b/editor/src/clj/editor/boot_open_project.clj
@@ -217,7 +217,7 @@
                                   (console/routes console-view)
                                   (hot-reload/routes workspace)
                                   (bob/routes project)
-                                  (command-requests/router root (app-view/make-render-task-progress :resource-sync))
+                                  (command-requests/router root localization (app-view/make-render-task-progress :resource-sync))
                                   (http-server.prefs/routes prefs)]))
           server-port (:port cli-options)
           web-server (try

--- a/editor/src/clj/editor/command_requests.clj
+++ b/editor/src/clj/editor/command_requests.clj
@@ -39,8 +39,11 @@
                      (mapcat :children)
                      (map (fn [{:keys [message severity parent cursor-range]}]
                             (let [maybe-resource (:resource parent)]
-                              (cond-> {:severity (case severity :fatal :error :info :information severity)
-                                       :message (localization-state message)}
+                              (cond-> {:message (localization-state message)
+                                       :severity (case severity
+                                                   :fatal :error
+                                                   :info :information
+                                                   severity)}
                                       maybe-resource (assoc :resource (resource/proj-path maybe-resource))
                                       cursor-range (assoc :range (lsp.server/editor-cursor-range->lsp-range cursor-range)))))))]
         (http-server/json-response {:success (not error) :issues issues} (if error 422 200))))))

--- a/editor/src/clj/editor/command_requests.clj
+++ b/editor/src/clj/editor/command_requests.clj
@@ -17,15 +17,33 @@
             [clojure.data.json :as json]
             [clojure.string :as string]
             [dynamo.graph :as g]
+            [editor.build-errors-view :as build-errors-view]
             [editor.disk :as disk]
             [editor.future :as future]
+            [editor.lsp.server :as lsp.server]
+            [editor.resource :as resource]
             [editor.ui :as ui]
             [service.log :as log]
+            [util.coll :as coll]
             [util.http-server :as http-server]))
 
 (set! *warn-on-reflection* true)
 
-(defonce ^:const url-prefix "/command")
+(defn- build-response [result localization-state]
+  (future/then
+    result
+    (fn [{:keys [error warning]}]
+      (let [issues (coll/into-> [error warning] []
+                     (filter some?)
+                     (mapcat #(:children (build-errors-view/build-resource-tree %)))
+                     (mapcat :children)
+                     (map (fn [{:keys [message severity parent cursor-range]}]
+                            (let [maybe-resource (:resource parent)]
+                              (cond-> {:severity (case severity :fatal :error :info :information severity)
+                                       :message (localization-state message)}
+                                      maybe-resource (assoc :resource (resource/proj-path maybe-resource))
+                                      cursor-range (assoc :range (lsp.server/editor-cursor-range->lsp-range cursor-range)))))))]
+        (http-server/json-response {:success (not error) :issues issues} (if error 422 200))))))
 
 (def ^:private supported-commands
   ;; Notable exclusions:
@@ -37,7 +55,8 @@
    :build
    {:ui-handler :project.build
     :help "Build and run the project."
-    :resource-sync true}
+    :resource-sync true
+    :response-fn build-response}
 
    :build-html5
    {:ui-handler :project.build-html5
@@ -196,12 +215,12 @@
      (g/let-ec [command-contexts (ui/node-contexts ui-node true evaluation-context)]
        (ui/resolve-handler-ctx command-contexts ui-handler user-data))))
 
-(defn router [ui-node render-reload-progress!]
+(defn router [ui-node localization render-reload-progress!]
   {"/command" {"GET" (constantly api-response)}
    "/command/{command}"
    {"POST" (bound-fn [request]
              (let [command (-> request :path-params :command keyword)]
-               (if-let [{:keys [ui-handler resource-sync]} (supported-commands command)]
+               (if-let [{:keys [ui-handler resource-sync response-fn]} (supported-commands command)]
                  (let [ui-handler-ctx (resolve-ui-handler-ctx ui-node ui-handler {})]
                    (case ui-handler-ctx
                      (::ui/not-active ::ui/not-enabled) http-server/forbidden
@@ -209,14 +228,23 @@
                            result-future (future/make)
                            execute-command!
                            (bound-fn execute-command! []
-                             (try
-                               (ui/execute-handler-ctx ui-handler-ctx)
-                               (future/complete! result-future http-server/accepted)
-                               (catch Exception error
-                                 (log/error :msg "Failed to handle command request"
-                                            :request request
-                                            :exception error)
-                                 (future/complete! result-future http-server/internal-server-error))))]
+                             (-> (try
+                                   (future/completed (ui/execute-handler-ctx ui-handler-ctx))
+                                   (catch Throwable e (future/failed e)))
+                                 (future/then
+                                   (fn [result]
+                                     (if response-fn
+                                       (response-fn result @localization)
+                                       http-server/accepted)))
+                                 (future/then
+                                   (fn [response]
+                                     (future/complete! result-future response)))
+                                 (future/catch
+                                   (fn [error]
+                                     (log/error :msg "Failed to handle command request"
+                                                :request request
+                                                :exception error)
+                                     (future/complete! result-future http-server/internal-server-error)))))]
                        (assert (g/node-id? changes-view))
                        (assert (g/node-id? workspace))
                        (when-not (Boolean/getBoolean "defold.tests")
@@ -236,3 +264,16 @@
                                  (future/complete! result-future http-server/internal-server-error))))))
                        result-future)))
                  http-server/not-found)))}})
+
+(comment
+
+  (-> @(util.http-client/request
+         (str "http://localhost:"
+              (slurp (str (g/node-value (dev/workspace) :root) "/.internal/editor.port"))
+              "/command/build")
+         :method "POST"
+         :as :string)
+      :body
+      (clojure.data.json/read-str :key-fn keyword))
+
+  #__)

--- a/editor/src/clj/editor/lsp/server.clj
+++ b/editor/src/clj/editor/lsp/server.clj
@@ -177,7 +177,7 @@
     (lsp-position->editor-cursor start)
     (lsp-position->editor-cursor end)))
 
-(defn- editor-cursor-range->lsp-range [{:keys [from to]}]
+(defn editor-cursor-range->lsp-range [{:keys [from to]}]
   {:start (editor-cursor->lsp-position from)
    :end (editor-cursor->lsp-position to)})
 

--- a/editor/src/clj/editor/ui.clj
+++ b/editor/src/clj/editor/ui.clj
@@ -385,12 +385,11 @@
 
 (defmacro run-now
   [& body]
-  `(do-run-now
-     (fn [] ~@body)))
+  `(do-run-now (bound-fn [] ~@body)))
 
 (defmacro run-later
   [& body]
-  `(do-run-later (fn [] ~@body)))
+  `(do-run-later (bound-fn [] ~@body)))
 
 (defn send-event! [^EventTarget event-target ^Event event]
   (Event/fireEvent event-target (DirectEvent. (.copyFor event event-target event-target))))

--- a/editor/src/clj/util/http_server.clj
+++ b/editor/src/clj/util/http_server.clj
@@ -17,7 +17,6 @@
             [clojure.java.io :as io]
             [clojure.string :as string]
             [editor.error-reporting :as error-reporting]
-            [editor.fs :as fs]
             [editor.future :as future]
             [editor.util :as util]
             [reitit.core :as reitit]
@@ -27,7 +26,7 @@
            [java.io Closeable File IOException]
            [java.net InetSocketAddress URI URL]
            [java.nio.charset StandardCharsets]
-           [java.nio.file Files Path]
+           [java.nio.file Path]
            [java.util List]
            [org.apache.commons.io FilenameUtils]
            [org.apache.commons.io.output ByteArrayOutputStream]))

--- a/editor/test/integration/app_view_test.clj
+++ b/editor/test/integration/app_view_test.clj
@@ -197,29 +197,24 @@
                                                                          ;; This is a project (i.e. not embedded) resource node.
                                                                          (when-some [source-node-id (test-util/resource-node project source-resource)]
                                                                            (node-cacheable-build-target-endpoints source-node-id))))))
-                                                           (build/resolve-node-dependencies game-project project))]
-          (test-util/run-event-loop!
-            (fn [exit-event-loop!]
+                                                           (build/resolve-node-dependencies game-project project))
+              _ (g/clear-system-cache!)
+              build-results @(app-view/async-build! project
+                                                    :debug false
+                                                    :build-engine false
+                                                    :old-artifact-map artifact-map
+                                                    :prefs (test-util/make-test-prefs))]
+          (when (is (nil? (:error build-results)))
+
+            (testing "Build targets remain in cache even though we've exceeded the cache limit."
+              (is (set/subset? expected-cached-build-target-endpoints (cached-endpoints))))
+
+            (testing "Build targets are always evicted from the cache after their dependencies change."
+              (let [background-atlas (test-util/resource-node project "/background/background.atlas")]
+                (is (contains? (cached-endpoints) (gt/endpoint background-atlas :build-targets)))
+                (test-util/prop! background-atlas :margin 10)
+                (is (not (contains? (cached-endpoints) (gt/endpoint background-atlas :build-targets))))))
+
+            (testing "Build targets are always evicted from the cache when it is explicitly cleared."
               (g/clear-system-cache!)
-              (app-view/async-build! project
-                                     :debug false
-                                     :build-engine false
-                                     :old-artifact-map artifact-map
-                                     :prefs (test-util/make-test-prefs)
-                                     :result-fn (fn [build-results]
-                                                  (when (is (nil? (:error build-results)))
-
-                                                    (testing "Build targets remain in cache even though we've exceeded the cache limit."
-                                                      (is (set/subset? expected-cached-build-target-endpoints (cached-endpoints))))
-
-                                                    (testing "Build targets are always evicted from the cache after their dependencies change."
-                                                      (let [background-atlas (test-util/resource-node project "/background/background.atlas")]
-                                                        (is (contains? (cached-endpoints) (gt/endpoint background-atlas :build-targets)))
-                                                        (test-util/prop! background-atlas :margin 10)
-                                                        (is (not (contains? (cached-endpoints) (gt/endpoint background-atlas :build-targets))))))
-
-                                                    (testing "Build targets are always evicted from the cache when it is explicitly cleared."
-                                                      (g/clear-system-cache!)
-                                                      (is (empty? (g/cache)))))
-
-                                                  (exit-event-loop!))))))))))
+              (is (empty? (g/cache))))))))))

--- a/editor/test/integration/engine/native_extensions_test.clj
+++ b/editor/test/integration/engine/native_extensions_test.clj
@@ -104,15 +104,7 @@
 (defn- dummy-file [] (fs/create-temp-file! "dummy" ""))
 
 (defn- blocking-async-build! [project prefs]
-  (let [result (promise)]
-    (test-util/run-event-loop!
-      (fn [exit-event-loop!]
-        (app-view/async-build! project
-                               :prefs prefs
-                               :result-fn (fn [build-results]
-                                            (deliver result build-results)
-                                            (exit-event-loop!)))))
-    (deref result)))
+  @(app-view/async-build! project :prefs prefs))
 
 (deftest ^:native-extensions async-build-on-build-server
   (with-clean-system

--- a/editor/test/integration/web_server_test.clj
+++ b/editor/test/integration/web_server_test.clj
@@ -275,7 +275,7 @@
                                              (console/routes console-view)
                                              (hot-reload/routes workspace)
                                              (bob/routes project)
-                                             (command-requests/router root progress/null-render-progress!)])))]
+                                             (command-requests/router root test-util/localization progress/null-render-progress!)])))]
           (let [url (http-server/local-url server)]
             (let [{:keys [status headers body]} @(http/request (str url "/engine-profiler/") :as :string)]
               (is (= 200 status))


### PR DESCRIPTION
We made the HTTP command that triggers the editor build block until the build completes, and made it respond with the build status + compilation issues. This should make it much more useful for AI agents and third-party IDE integrations.

## Example use
### Successful build
```sh
curl -X POST "http://127.0.0.1:$(cat .internal/editor.port)/command/build" --silent | jq
{
  "success": true,
  "issues": []
}
```
### Failed build
```sh
curl -X POST "http://127.0.0.1:$(cat .internal/editor.port)/command/build" --silent | jq
{
  "success": false,
  "issues": [
    {
      "severity": "error",
      "message": "go.property declaration should be a top-level statement",
      "resource": "/main/logo.script",
      "range": {
        "start": {
          "line": 3,
          "character": 4
        },
        "end": {
          "line": 3,
          "character": 35
        }
      }
    }
  ]
}
```
### Minimal AGENTS.md to get started
```md
# Docs
https://defold.com/llms.txt

# Build
- Read editor port from `.internal/editor.port`
- Build game: `curl -X POST http://127.0.0.1:<PORT>/command/build`

# Console
- After launch, check logs at `http://127.0.0.1:<PORT>/console`.
```

Fix #11733