### PR TITLE
A pressed key should not immediately register as repeated

### DIFF
--- a/engine/input/src/input.cpp
+++ b/engine/input/src/input.cpp
@@ -578,7 +578,6 @@ namespace dmInput
         {
             if (action->m_Pressed)
             {
-                action->m_Repeated = true;
                 action->m_RepeatTimer = context->m_RepeatDelay;
             }
             else

--- a/engine/input/src/test/test_input.cpp
+++ b/engine/input/src/test/test_input.cpp
@@ -500,7 +500,7 @@ TEST_F(InputTest, Touch)
     ASSERT_EQ(1.0f, action->m_Value);
     ASSERT_TRUE(action->m_Pressed);
     ASSERT_FALSE(action->m_Released);
-    ASSERT_TRUE(action->m_Repeated);
+    ASSERT_FALSE(action->m_Repeated);
     ASSERT_TRUE(action->m_PositionSet);
     ASSERT_EQ(0, action->m_X);
     ASSERT_EQ(1, action->m_Y);
@@ -513,7 +513,7 @@ TEST_F(InputTest, Touch)
     ASSERT_EQ(1.0f, action->m_Value);
     ASSERT_TRUE(action->m_Pressed);
     ASSERT_FALSE(action->m_Released);
-    ASSERT_TRUE(action->m_Repeated);
+    ASSERT_FALSE(action->m_Repeated);
     ASSERT_TRUE(action->m_PositionSet);
     ASSERT_EQ(2, action->m_Touch[1].m_X);
     ASSERT_EQ(3, action->m_Touch[1].m_Y);
@@ -609,7 +609,7 @@ TEST_F(InputTest, TouchPhases)
     ASSERT_EQ(2, action->m_Count);
     ASSERT_TRUE(action->m_Pressed);
     ASSERT_FALSE(action->m_Released);
-    ASSERT_TRUE(action->m_Repeated);
+    ASSERT_FALSE(action->m_Repeated);
     ASSERT_TRUE(action->m_PositionSet);
     ASSERT_EQ(0, action->m_X);
     ASSERT_EQ(1, action->m_Y);
@@ -829,7 +829,7 @@ TEST_F(InputTest, TestRepeat)
     ASSERT_FALSE(dmInput::Repeated(binding, key_0_id));
 
     dmInput::UpdateBinding(binding, m_DT);
-    ASSERT_TRUE(dmInput::Repeated(binding, key_0_id));
+    ASSERT_FALSE(dmInput::Repeated(binding, key_0_id));
 
     for (int i = 0; i < 29; ++i)
     {


### PR DESCRIPTION
When a key is pressed it's state is also set to repeated without respect for the repeat delay.

Related to #8895

Specifically handles https://github.com/defold/defold/issues/8895#issuecomment-3622069139