### PR TITLE
Added experimental support for minification of internal resource paths to save memory 

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/cache/test/ResourceCacheKeyTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/cache/test/ResourceCacheKeyTest.java
@@ -297,6 +297,7 @@ public class ResourceCacheKeyTest {
                 "email",
                 "exclude-archive",
                 "exclude-build-folder",
+                "experimental-path-minification",
                 "help",
                 "identity",
                 "input",

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/fs/test/ResourceUtilTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/fs/test/ResourceUtilTest.java
@@ -1,0 +1,164 @@
+// Copyright 2020-2026 The Defold Foundation
+// Copyright 2014-2020 King
+// Copyright 2009-2014 Ragnar Svensson, Christian Murray
+// Licensed under the Defold License version 1.0 (the "License"); you may not use
+// this file except in compliance with the License.
+//
+// You may obtain a copy of the License, together with FAQs at
+// https://www.defold.com/license
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package com.dynamo.bob.fs.test;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.dynamo.bob.fs.ResourceUtil;
+
+public class ResourceUtilTest {
+    private static final String BUILD_DIR = "build/default";
+
+    private Map<String, String> savedExtensionMapping;
+    private Map<String, String> savedCachedPaths;
+    private Set<String> savedMinifiedPathSet;
+    private Set<String> savedMinifySupport;
+    private boolean savedMinifyEnabled;
+    private String savedBuildDirectory;
+
+    private static class ResourceUtilAccessor extends ResourceUtil {
+        static Map<String, String> snapshotExtensionMapping() {
+            return new HashMap<>(extensionMapping);
+        }
+
+        static Map<String, String> snapshotCachedPaths() {
+            return new HashMap<>(cachedPaths);
+        }
+
+        static Set<String> snapshotMinifiedPathSet() {
+            return new HashSet<>(minifiedPaths);
+        }
+
+        static Set<String> snapshotMinifySupport() {
+            return new HashSet<>(minifySupport);
+        }
+
+        static void restoreExtensionMapping(Map<String, String> snapshot) {
+            extensionMapping.clear();
+            extensionMapping.putAll(snapshot);
+        }
+
+        static void restoreCachedPaths(Map<String, String> snapshot) {
+            cachedPaths.clear();
+            cachedPaths.putAll(snapshot);
+        }
+
+        static void restoreMinifiedPaths(Set<String> snapshot) {
+            minifiedPaths.clear();
+            minifiedPaths.addAll(snapshot);
+        }
+
+        static void restoreMinifySupport(Set<String> snapshot) {
+            minifySupport.clear();
+            minifySupport.addAll(snapshot);
+        }
+
+        static void clearAll() {
+            extensionMapping.clear();
+            cachedPaths.clear();
+            minifiedPaths.clear();
+            minifySupport.clear();
+        }
+
+        static String getBuildDirectoryValue() {
+            return buildDirectory;
+        }
+
+        static void setBuildDirectoryValue(String buildDir) {
+            buildDirectory = buildDir;
+        }
+    }
+
+    @Before
+    public void setUp() {
+        savedExtensionMapping = ResourceUtilAccessor.snapshotExtensionMapping();
+        savedCachedPaths = ResourceUtilAccessor.snapshotCachedPaths();
+        savedMinifiedPathSet = ResourceUtilAccessor.snapshotMinifiedPathSet();
+        savedMinifySupport = ResourceUtilAccessor.snapshotMinifySupport();
+        savedMinifyEnabled = ResourceUtil.isMinificationEnabled();
+        savedBuildDirectory = ResourceUtilAccessor.getBuildDirectoryValue();
+
+        ResourceUtilAccessor.clearAll();
+        ResourceUtilAccessor.setBuildDirectoryValue(BUILD_DIR);
+        ResourceUtil.enableMinification(false);
+    }
+
+    @After
+    public void tearDown() {
+        ResourceUtilAccessor.restoreExtensionMapping(savedExtensionMapping);
+        ResourceUtilAccessor.restoreCachedPaths(savedCachedPaths);
+        ResourceUtilAccessor.restoreMinifiedPaths(savedMinifiedPathSet);
+        ResourceUtilAccessor.restoreMinifySupport(savedMinifySupport);
+        ResourceUtil.enableMinification(savedMinifyEnabled);
+        ResourceUtilAccessor.setBuildDirectoryValue(savedBuildDirectory);
+    }
+
+    @Test
+    public void testMinifyDisabledAddsLeadingSlashForNonBuildPaths() {
+        assertEquals("/foo.spc", ResourceUtil.minifyPath("foo.spc"));
+        assertEquals("/foo.spc", ResourceUtil.minifyPath("/foo.spc"));
+    }
+
+    @Test
+    public void testMinifyDisabledKeepsBuildPathsUnchanged() {
+        String input = BUILD_DIR + "/foo.spc";
+        assertEquals(input, ResourceUtil.minifyPath(input));
+    }
+
+    @Test
+    public void testMinifyEnabledUnsupportedSuffixKeepsPathAndAddsSlashForNonBuild() {
+        ResourceUtil.enableMinification(true);
+        assertEquals("/foo.bar", ResourceUtil.minifyPath("foo.bar"));
+        String buildInput = BUILD_DIR + "/foo.bar";
+        assertEquals(buildInput, ResourceUtil.minifyPath(buildInput));
+    }
+
+    @Test
+    public void testMinifyEnabledSupportedNonBuildPathIsMinifiedAndAbsolute() {
+        ResourceUtil.enableMinification(true);
+        ResourceUtil.registerMapping(".shbundle", ".spc");
+
+        String result = ResourceUtil.minifyPath("foo.spc");
+        assertTrue(result.startsWith("/"));
+        assertFalse(result.startsWith("/" + BUILD_DIR + "/"));
+        assertTrue(result.endsWith(".spc"));
+        assertNotEquals("/foo.spc", result);
+    }
+
+    @Test
+    public void testMinifyEnabledSupportedBuildPathIsMinifiedWithBuildPrefix() {
+        ResourceUtil.enableMinification(true);
+        ResourceUtil.registerMapping(".shbundle", ".spc");
+
+        String input = BUILD_DIR + "/foo.spc";
+        String result = ResourceUtil.minifyPath(input);
+        assertTrue(result.startsWith(BUILD_DIR + "/"));
+        assertFalse(result.startsWith("/" + BUILD_DIR + "/"));
+        assertTrue(result.endsWith(".spc"));
+        assertNotEquals(input, result);
+    }
+}

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/fs/test/ResourceUtilTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/fs/test/ResourceUtilTest.java
@@ -28,6 +28,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
+import com.dynamo.bob.fs.DefaultFileSystem;
+import com.dynamo.bob.fs.IResource;
 import com.dynamo.bob.fs.ResourceUtil;
 
 public class ResourceUtilTest {
@@ -160,5 +162,23 @@ public class ResourceUtilTest {
         assertFalse(result.startsWith("/" + BUILD_DIR + "/"));
         assertTrue(result.endsWith(".spc"));
         assertNotEquals(input, result);
+    }
+
+    @Test
+    public void testMinifyBuildOutputPathDoesNotCreateDoubleSlashes() {
+        ResourceUtil.enableMinification(true);
+        ResourceUtil.registerMapping(".font", ".glyph_bankc");
+
+        DefaultFileSystem fileSystem = new DefaultFileSystem();
+        fileSystem.setRootDirectory(".");
+        fileSystem.setBuildDirectory(BUILD_DIR);
+
+        IResource input = fileSystem.get(BUILD_DIR + "/builtins/fonts/default.font");
+        IResource output = input.changeExt(".glyph_bankc");
+        String outputPath = output.getPath();
+
+        assertTrue(outputPath.startsWith(BUILD_DIR + "/"));
+        assertFalse(outputPath.startsWith(BUILD_DIR + "//"));
+        assertFalse(outputPath.contains("//"));
     }
 }

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/BuilderUtilTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/BuilderUtilTest.java
@@ -1,0 +1,28 @@
+// Copyright 2020-2026 The Defold Foundation
+// Copyright 2014-2020 King
+// Copyright 2009-2014 Ragnar Svensson, Christian Murray
+// Licensed under the Defold License version 1.0 (the "License"); you may not use
+// this file except in compliance with the License.
+//
+// You may obtain a copy of the License, together with FAQs at
+// https://www.defold.com/license
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package com.dynamo.bob.pipeline;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class BuilderUtilTest {
+
+    @Test
+    public void testReplaceExtCompatibilityShim() {
+        assertEquals("/foo/bar.materialc", BuilderUtil.replaceExt("/foo/bar.material", ".material", ".materialc"));
+        assertEquals("/foo/bar.material", BuilderUtil.replaceExt("/foo/bar.material", ".font", ".fontc"));
+    }
+}

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/BuilderUtilTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/BuilderUtilTest.java
@@ -15,14 +15,43 @@
 package com.dynamo.bob.pipeline;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
 import org.junit.Test;
+
+import com.dynamo.bob.fs.ResourceUtil;
 
 public class BuilderUtilTest {
 
     @Test
     public void testReplaceExtCompatibilityShim() {
-        assertEquals("/foo/bar.materialc", BuilderUtil.replaceExt("/foo/bar.material", ".material", ".materialc"));
-        assertEquals("/foo/bar.material", BuilderUtil.replaceExt("/foo/bar.material", ".font", ".fontc"));
+        boolean oldMinification = ResourceUtil.isMinificationEnabled();
+        try {
+            ResourceUtil.enableMinification(false);
+            assertEquals("/foo/bar.materialc", BuilderUtil.replaceExt("/foo/bar.material", ".material", ".materialc"));
+            assertEquals("/foo/bar.material", BuilderUtil.replaceExt("/foo/bar.material", ".font", ".fontc"));
+        } finally {
+            ResourceUtil.enableMinification(oldMinification);
+        }
+    }
+
+    @Test
+    public void testReplaceExtCompatibilityShimWithMinification() {
+        final String inExt = ".compat_material_tmp";
+        final String outExt = ".compat_materialc_tmp";
+        boolean oldMinification = ResourceUtil.isMinificationEnabled();
+        try {
+            ResourceUtil.registerMapping(inExt, outExt);
+            ResourceUtil.enableMinification(true);
+
+            String expectedMinified = ResourceUtil.minifyPath("/foo/bar.compat_materialc_tmp");
+            String replaced = BuilderUtil.replaceExt("/foo/bar.compat_material_tmp", inExt, outExt);
+
+            assertNotEquals("/foo/bar.compat_materialc_tmp", replaced);
+            assertEquals(expectedMinified, replaced);
+        } finally {
+            ResourceUtil.enableMinification(oldMinification);
+            ResourceUtil.disableMinify(outExt);
+        }
     }
 }

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/FontBuilderTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/FontBuilderTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 
 import java.util.List;
 
+import com.dynamo.bob.fs.ResourceUtil;
 import com.dynamo.render.proto.Font.FontMap;
 
 import com.google.protobuf.Message;
@@ -67,7 +68,7 @@ public class FontBuilderTest extends AbstractProtoBuilderTest {
         src.append("size: 16\n");
 
         FontMap fontMap = getFontMap(build("/test.font", src.toString()));
-        assertEquals(fontMap.getMaterial(), "/test.materialc");
+        assertEquals(fontMap.getMaterial(), ResourceUtil.minifyPath("/test.materialc"));
     }
 
     @Test
@@ -79,7 +80,7 @@ public class FontBuilderTest extends AbstractProtoBuilderTest {
         src.append("size: 16\n");
         FontMap fontMap = getFontMap(build("/test.font", src.toString()));
 
-        assertEquals(fontMap.getMaterial(), "/test.materialc");
+        assertEquals(fontMap.getMaterial(), ResourceUtil.minifyPath("/test.materialc"));
     }
 
     @Test
@@ -94,7 +95,7 @@ public class FontBuilderTest extends AbstractProtoBuilderTest {
         src.append("size: 16\n");
         FontMap fontMap = getFontMap(build("/subdir/test.font", src.toString()));
 
-        assertEquals(fontMap.getMaterial(), "/test.materialc");
+        assertEquals(fontMap.getMaterial(), ResourceUtil.minifyPath("/test.materialc"));
     }
 
     @Test

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/LuaBuilderTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/LuaBuilderTest.java
@@ -18,6 +18,7 @@ import org.junit.Test;
 
 import com.dynamo.bob.Project;
 import com.dynamo.bob.CompileExceptionError;
+import com.dynamo.bob.fs.ResourceUtil;
 import com.dynamo.bob.test.util.PropertiesTestUtil;
 import com.dynamo.bob.util.MurmurHash;
 import com.dynamo.lua.proto.Lua.LuaModule;
@@ -72,7 +73,7 @@ public class LuaBuilderTest extends AbstractProtoBuilderTest {
         PropertiesTestUtil.assertNumber(properties, 1, 1);
         PropertiesTestUtil.assertNumber(properties, 1, 2);
         PropertiesTestUtil.assertHash(properties, MurmurHash.hash64("hash"), 0);
-        PropertiesTestUtil.assertHash(properties, MurmurHash.hash64("/material.materialc"), 1);
+        PropertiesTestUtil.assertHash(properties, MurmurHash.hash64(ResourceUtil.minifyPath("/material.materialc")), 1);
         PropertiesTestUtil.assertURL(properties, "", 0);
         PropertiesTestUtil.assertVector3(properties, 1, 2, 3, 0);
         PropertiesTestUtil.assertVector3(properties, 0, 0, 0, 1);
@@ -80,7 +81,7 @@ public class LuaBuilderTest extends AbstractProtoBuilderTest {
         PropertiesTestUtil.assertVector4(properties, 4, 5, 6, 7, 0);
         PropertiesTestUtil.assertQuat(properties, 8, 9, 10, 11, 0);
         PropertiesTestUtil.assertBoolean(properties, true, 0);
-        assertEquals("/material.materialc", luaModule.getPropertyResources(0));
+        assertEquals(ResourceUtil.minifyPath("/material.materialc"), luaModule.getPropertyResources(0));
 
         // Verify that .x, .y, .z and .w exists as sub element ids for Vec3, Vec4 and Quat.
         assertSubElementsV3(properties.getVector3Entries(0));

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/MaterialBuilderTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/MaterialBuilderTest.java
@@ -16,6 +16,7 @@ package com.dynamo.bob.pipeline;
 
 import java.util.List;
 
+import com.dynamo.bob.fs.ResourceUtil;
 import com.dynamo.bob.util.MurmurHash;
 import com.dynamo.graphics.proto.Graphics;
 import org.junit.Before;
@@ -80,8 +81,8 @@ public class MaterialBuilderTest extends AbstractProtoBuilderTest {
         assertTrue(material.hasProgram());
 
         String program = material.getProgram();
-        String expectedProgram = "/" + MaterialBuilder.getShaderName("/test_combined.vp", "/test_combined.fp", 0, ".spc");
-        assertEquals(expectedProgram, program);
+        String expectedProgram = MaterialBuilder.getShaderName("/test_combined.vp", "/test_combined.fp", 0, ".spc");
+        assertEquals(ResourceUtil.minifyPath(expectedProgram), program);
     }
 
     @Test

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/ModelBuilderTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/ModelBuilderTest.java
@@ -20,6 +20,7 @@ import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.dynamo.bob.fs.ResourceUtil;
 import com.dynamo.gamesys.proto.ModelProto.Model;
 import com.dynamo.gamesys.proto.ModelProto.Material;
 import com.dynamo.rig.proto.Rig.RigScene;
@@ -70,14 +71,14 @@ public class ModelBuilderTest extends AbstractProtoBuilderTest {
 
         assertEquals(1, materials.size());
         assertEquals("test2", materials.get(0).getName());
-        assertEquals("/test.materialc", materials.get(0).getMaterial());
-        assertEquals("/test.rigscenec", model.getRigScene());
+        assertEquals(ResourceUtil.minifyPath("/test.materialc"), materials.get(0).getMaterial());
+        assertEquals(ResourceUtil.minifyPath("/test.rigscenec"), model.getRigScene());
 
         assertEquals("test", model.getDefaultAnimation());
 
         RigScene rigScene = getMessage(outputs, RigScene.class);
         assertEquals("/test_meshset.meshsetc", rigScene.getMeshSet());
-        assertEquals("/test_skeleton.skeletonc", rigScene.getSkeleton());
+        assertEquals(ResourceUtil.minifyPath("/test_skeleton.skeletonc"), rigScene.getSkeleton());
         assertEquals("/test_animationset_generated_0.animationsetc", rigScene.getAnimationSet());
     }
 
@@ -119,12 +120,12 @@ public class ModelBuilderTest extends AbstractProtoBuilderTest {
 
         assertEquals(1, materials.size());
         assertEquals("default", materials.get(0).getName());
-        assertEquals("/test.materialc", materials.get(0).getMaterial());
-        assertEquals("/test.rigscenec", model.getRigScene());
+        assertEquals(ResourceUtil.minifyPath("/test.materialc"), materials.get(0).getMaterial());
+        assertEquals(ResourceUtil.minifyPath("/test.rigscenec"), model.getRigScene());
 
         RigScene rigScene = getMessage(outputs, RigScene.class);
         assertEquals("/test_meshset.meshsetc", rigScene.getMeshSet());
-        assertEquals("/test_skeleton.skeletonc", rigScene.getSkeleton());
+        assertEquals(ResourceUtil.minifyPath("/test_skeleton.skeletonc"), rigScene.getSkeleton());
         assertEquals("/test_animation_generated_0.animationsetc", rigScene.getAnimationSet());
     }
 }

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/RenderPrototypeBuilderTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/RenderPrototypeBuilderTest.java
@@ -21,6 +21,7 @@ import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.dynamo.bob.fs.ResourceUtil;
 import com.dynamo.bob.CompileExceptionError;
 import com.google.protobuf.Message;
 import com.dynamo.render.proto.Render.RenderPrototypeDesc;
@@ -64,7 +65,7 @@ public class RenderPrototypeBuilderTest extends AbstractProtoBuilderTest {
 
             RenderPrototypeDesc.RenderResourceDesc res_desc = output.getRenderResourcesList().get(0);
             assertTrue(res_desc.getName().equals("test"));
-            assertTrue(res_desc.getPath().equals("/test.materialc"));
+            assertTrue(res_desc.getPath().equals(ResourceUtil.minifyPath("/test.materialc")));
         }
 
         {
@@ -86,11 +87,11 @@ public class RenderPrototypeBuilderTest extends AbstractProtoBuilderTest {
 
             RenderPrototypeDesc.RenderResourceDesc res_desc_1 = output.getRenderResourcesList().get(0);
             assertTrue(res_desc_1.getName().equals("test"));
-            assertTrue(res_desc_1.getPath().equals("/test.materialc"));
+            assertTrue(res_desc_1.getPath().equals(ResourceUtil.minifyPath("/test.materialc")));
 
             RenderPrototypeDesc.RenderResourceDesc res_desc_2 = output.getRenderResourcesList().get(1);
             assertTrue(res_desc_2.getName().equals("test_2"));
-            assertTrue(res_desc_2.getPath().equals("/test.materialc"));
+            assertTrue(res_desc_2.getPath().equals(ResourceUtil.minifyPath("/test.materialc")));
         }
 
         {

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/JBobTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/JBobTest.java
@@ -44,6 +44,7 @@ import com.dynamo.bob.Project;
 import com.dynamo.bob.Task;
 import com.dynamo.bob.Task.TaskBuilder;
 import com.dynamo.bob.fs.IResource;
+import com.dynamo.bob.fs.ResourceUtil;
 import com.dynamo.bob.test.util.MockFileSystem;
 import com.dynamo.bob.test.util.MockResource;
 import com.dynamo.bob.TaskResult;
@@ -200,7 +201,7 @@ public class JBobTest {
         project.setInputs(Arrays.asList("test.in"));
         List<TaskResult> result = build();
         assertThat(result.size(), is(1));
-        IResource testOut = fileSystem.get("test.out").output();
+        IResource testOut = fileSystem.get(ResourceUtil.minifyPath("test.out")).output();
         assertNotNull(testOut);
         assertThat(new String(testOut.getContent()), is("test data"));
     }
@@ -219,7 +220,7 @@ public class JBobTest {
         project.setInputs(Arrays.asList("/root/test.in"));
         List<TaskResult> result = build();
         assertThat(result.size(), is(1));
-        IResource testOut = fileSystem.get("/root/test.out").output();
+        IResource testOut = fileSystem.get(ResourceUtil.minifyPath("/root/test.out")).output();
         assertThat(testOut.exists(), is(true));
         assertThat(new String(testOut.getContent()), is("test data"));
     }
@@ -259,7 +260,7 @@ public class JBobTest {
         assertThat(result.size(), is(1));
 
         // remove output
-        fileSystem.get("test.out").output().remove();
+        fileSystem.get(ResourceUtil.minifyPath("test.out")).output().remove();
 
         // rebuild
         result = build();
@@ -276,7 +277,7 @@ public class JBobTest {
         assertThat(result.size(), is(3));
 
         // remove generated output, ie input to another task
-        fileSystem.get("test_0.numberc").output().remove();
+        fileSystem.get(ResourceUtil.minifyPath("test_0.numberc")).output().remove();
 
         // rebuild
         result = build();
@@ -336,8 +337,8 @@ public class JBobTest {
         project.setInputs(Arrays.asList("test.dynamic"));
         List<TaskResult> result = build();
         assertThat(result.size(), is(3));
-        assertThat(getResourceString("test_0.numberc"), is("10"));
-        assertThat(getResourceString("test_1.numberc"), is("20"));
+        assertThat(getResourceString(ResourceUtil.minifyPath("test_0.numberc")), is("10"));
+        assertThat(getResourceString(ResourceUtil.minifyPath("test_1.numberc")), is("20"));
         assertThat(result.get(1).getTask().getProductOf(), is((Task) result.get(0).getTask()));
         assertThat(result.get(2).getTask().getProductOf(), is((Task) result.get(0).getTask()));
     }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Bob.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Bob.java
@@ -478,6 +478,9 @@ public class Bob {
 
                 opt(null, "max-cpu-threads", ONE, "Max count of threads that bob.jar can use"),
 
+                // experimental features
+                opt(null, "experimental-path-minification", ZERO, "Minimizes resource path names in order to save bundle size."),
+
                 // debug options
                 opt(null, "debug-ne-upload", ZERO, "Outputs the files sent to build server as upload.zip"),
                 opt(null, "debug-output-spirv", ONE, "Force build SPIR-V shaders"),

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
@@ -61,6 +61,7 @@ import com.dynamo.bob.fs.FileSystemMountPoint;
 import com.dynamo.bob.fs.FileSystemWalker;
 import com.dynamo.bob.fs.IFileSystem;
 import com.dynamo.bob.fs.IResource;
+import com.dynamo.bob.fs.ResourceUtil;
 import com.dynamo.bob.fs.ZipMountPoint;
 import com.dynamo.bob.plugin.PluginScanner;
 import com.dynamo.bob.util.BuildInputDataCollector;
@@ -96,6 +97,7 @@ import com.dynamo.bob.util.LibraryUtil;
 import com.dynamo.bob.util.ReportGenerator;
 import com.dynamo.bob.util.TimeProfiler;
 import com.dynamo.bob.util.StringUtil;
+import com.dynamo.bob.util.MinifyPathCollector;
 import com.dynamo.graphics.proto.Graphics.TextureProfiles;
 
 import com.dynamo.bob.cache.ResourceCache;
@@ -126,7 +128,6 @@ public class Project {
     private ResourceCache resourceCache = new ResourceCache();
     private IFileSystem fileSystem;
     private Map<String, Class<? extends Builder>> extToBuilder = new HashMap<String, Class<? extends Builder>>();
-    private Map<String, String> inextToOutext = new HashMap<>();
     private List<String> inputs = new ArrayList<String>();
     private HashMap<String, EnumSet<OutputFlags>> outputs = new HashMap<String, EnumSet<OutputFlags>>();
     private HashMap<String, Task> tasks;
@@ -378,7 +379,7 @@ public class Project {
                 if (builderParams != null) {
                     for (String inExt : builderParams.inExts()) {
                         extToBuilder.put(inExt, (Class<? extends Builder>) klass);
-                        inextToOutext.put(inExt, builderParams.outExt());
+                        ResourceUtil.registerMapping(inExt, builderParams.outExt());
                     }
                     Builder.addParamsDigest(klass, this.getOptions(), builderParams);
                     ProtoParams protoParams = klass.getAnnotation(ProtoParams.class);
@@ -425,29 +426,6 @@ public class Project {
         TimeProfiler.stop(); // Final stop after plugin registration
     }
 
-    static String[][] extensionMapping = new String[][] {
-        {".camera", ".camerac"},
-        {".buffer", ".bufferc"},
-        {".mesh", ".meshc"},
-        {".collectionproxy", ".collectionproxyc"},
-        {".collisionobject", ".collisionobjectc"},
-        {".particlefx", ".particlefxc"},
-        {".gui", ".guic"},
-        {".model", ".modelc"},
-        {".script", ".scriptc"},
-        {".sound", ".soundc"},
-        {".wav", ".soundc"},
-        {".ogg", ".soundc"},
-        {".opus", ".soundc"},
-        {".collectionfactory", ".collectionfactoryc"},
-        {".factory", ".factoryc"},
-        {".light", ".lightc"},
-        {".label", ".labelc"},
-        {".sprite", ".spritec"},
-        {".tilegrid", ".tilemapc"},
-        {".tilemap", ".tilemapc"},
-    };
-
     private String generateCircularDependencyErrorMessage(String dependency) {
         StringBuilder errorMessage = new StringBuilder("\nCircular dependency detected:\n");
 
@@ -461,19 +439,6 @@ public class Project {
         errorMessage.append("-> ").append(dependency).append(" (Circular Point)");
 
         return errorMessage.toString();
-    }
-
-    public String replaceExt(String inExt) {
-        for (int i = 0; i < extensionMapping.length; i++) {
-            if (extensionMapping[i][0].equals(inExt))
-            {
-                return extensionMapping[i][1];
-            }
-        }
-        String outExt = inextToOutext.get(inExt); // Get the output ext, or use the inExt as default
-        if (outExt != null)
-            return outExt;
-        return inExt;
     }
 
     private Class<? extends Builder> getBuilderFromExtension(String input) {
@@ -917,6 +882,8 @@ public class Project {
         bundler.bundleApplication(this, platform, bundleDir, monitor);
         String defoldSdk = this.option("defoldsdk", EngineVersion.sha1);
         BuildInputDataCollector.saveDataAsJson(getRootDirectory(), bundleDir, defoldSdk);
+        if (ResourceUtil.isMinificationEnabled())
+            MinifyPathCollector.saveAsJson(bundleDir);
         m.worked(1);
         m.done();
     }
@@ -1782,6 +1749,16 @@ public class Project {
         {
             registerTextureCompressors();
         }
+
+        boolean experimental_path_minification = hasOption("experimental-path-minification");
+
+        ResourceUtil.enableMinification(experimental_path_minification);
+        ResourceUtil.setBuildDirectory(buildDirectory);
+        ResourceUtil.disableMinify(".luac");
+        ResourceUtil.disableMinify(".scriptc");
+        ResourceUtil.disableMinify(".render_scriptc");
+        ResourceUtil.disableMinify(".gui_scriptc");
+        ResourceUtil.disableMinify(".collectionc");
 
         loop:
         for (String command : commands) {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/font/Fontc.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/font/Fontc.java
@@ -66,7 +66,7 @@ import com.sun.jna.Pointer;
 import com.dynamo.bob.pipeline.Texc;
 import com.dynamo.bob.pipeline.TexcLibraryJni;
 
-import com.dynamo.bob.pipeline.BuilderUtil;
+import com.dynamo.bob.fs.ResourceUtil;
 import com.dynamo.bob.pipeline.TextureGeneratorException;
 
 import com.dynamo.bob.util.StringUtil;
@@ -1150,7 +1150,7 @@ public class Fontc {
             Path basedirAbsolutePath = Paths.get(basedir).toAbsolutePath();
 
             FontMap.Builder fontMapBuilder = FontMap.newBuilder();
-            fontMapBuilder.setMaterial(BuilderUtil.replaceExt(fontDesc.getMaterial(), ".material", ".materialc"));
+            fontMapBuilder.setMaterial(ResourceUtil.minifyPathAndReplaceExt(fontDesc.getMaterial(), ".material", ".materialc"));
 
             if (!dynamic)
             {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/fs/AbstractResource.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/fs/AbstractResource.java
@@ -25,24 +25,43 @@ import org.apache.commons.io.FilenameUtils;
 
 public abstract class AbstractResource<F extends IFileSystem> implements IResource {
     protected F fileSystem;
-    protected String path;
+    protected String path; // Path relative to the current dir (or absolute). Starts with e.g. "build/default" build folder.
     private boolean cacheable = true;
+    private boolean isOutput = false;
+    private boolean minifyEnabled = true;
 
     public AbstractResource(F fileSystem, String path) {
         this.fileSystem = fileSystem;
         this.path = path;
+
+        this.isOutput = fileSystem != null &&
+                     (path.startsWith(fileSystem.getBuildDirectory() + "/")
+                     || path.startsWith(fileSystem.getBuildDirectory() + "\\"));
     }
 
     @Override
     public boolean isOutput() {
-        return path.startsWith(fileSystem.getBuildDirectory() + "/")
-        || path.startsWith(fileSystem.getBuildDirectory() + "\\");
+        return this.isOutput;
     }
 
     @Override
     public IResource changeExt(String ext) {
-        String newName = ResourceUtil.changeExt(path, ext);
-        IResource newResource = fileSystem.get(newName);
+        // Used to create an output node
+        String newPath = ResourceUtil.changeExt(path, ext);
+
+        if (minifyEnabled)
+        {
+            String buildDirectory = fileSystem.getBuildDirectory();
+            if (path.startsWith(buildDirectory))
+                newPath = newPath.substring(buildDirectory.length()+1);
+
+            newPath = ResourceUtil.minifyPath(newPath);
+
+            if (path.startsWith(buildDirectory))
+                newPath = buildDirectory + "/" + newPath;
+        }
+
+        IResource newResource = fileSystem.get(newPath);
         return newResource.output();
     }
 
@@ -64,7 +83,7 @@ public abstract class AbstractResource<F extends IFileSystem> implements IResour
 
     @Override
     public String getAbsPath() {
-        return concat(fileSystem.getRootDirectory(), path);
+        return concat(fileSystem.getRootDirectory(), getPath());
     }
 
     @Override
@@ -122,4 +141,13 @@ public abstract class AbstractResource<F extends IFileSystem> implements IResour
     public boolean isCacheable() {
         return isOutput() && cacheable;
     }
+
+    @Override
+    public IResource disableMinifyPath() {
+        minifyEnabled = false;
+        return this;
+    }
+
+    @Override
+    public boolean isMinifyPath() { return minifyEnabled; }
 }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/fs/AbstractResource.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/fs/AbstractResource.java
@@ -48,17 +48,22 @@ public abstract class AbstractResource<F extends IFileSystem> implements IResour
     public IResource changeExt(String ext) {
         // Used to create an output node
         String newPath = ResourceUtil.changeExt(path, ext);
+        boolean isBuildOutputPath = isOutput();
 
         if (minifyEnabled)
         {
             String buildDirectory = fileSystem.getBuildDirectory();
-            if (path.startsWith(buildDirectory))
+            if (isBuildOutputPath)
                 newPath = newPath.substring(buildDirectory.length()+1);
 
             newPath = ResourceUtil.minifyPath(newPath);
 
-            if (path.startsWith(buildDirectory))
+            if (isBuildOutputPath) {
+                while (newPath.startsWith("/") || newPath.startsWith("\\")) {
+                    newPath = newPath.substring(1);
+                }
                 newPath = buildDirectory + "/" + newPath;
+            }
         }
 
         IResource newResource = fileSystem.get(newPath);

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/fs/DefaultFileSystem.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/fs/DefaultFileSystem.java
@@ -46,7 +46,7 @@ public class DefaultFileSystem extends AbstractFileSystem<DefaultFileSystem, Def
     @Override
     public IResource get(String path) {
         // Paths are always root relative.
-        if (path.startsWith("/"))
+        while (path.startsWith("/") || path.startsWith("\\"))
             path = path.substring(1);
         IResource resource = getFromMountPoints(path);
         if (resource != null) {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/fs/FileSystemMountPoint.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/fs/FileSystemMountPoint.java
@@ -149,5 +149,12 @@ public class FileSystemMountPoint implements IMountPoint {
         public boolean isCacheable() {
             return resource.isCacheable();
         }
+
+        @Override
+        public IResource disableMinifyPath() { return resource.disableMinifyPath(); }
+
+        @Override
+        public boolean isMinifyPath() { return resource.isMinifyPath(); }
+
     }
 }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/fs/IResource.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/fs/IResource.java
@@ -135,4 +135,16 @@ public interface IResource {
      * @return True if resource can be cached. Defaults to true
      */
     boolean isCacheable();
+
+    /**
+     * Disable minification of an output resource path
+     * @return This instance (for function chaining)
+     */
+    IResource disableMinifyPath();
+
+    /**
+     * Check if this resource path should be minified
+     * @return True if resource output path should be minified
+     */
+    boolean isMinifyPath();
 }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/fs/ResourceUtil.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/fs/ResourceUtil.java
@@ -14,7 +14,33 @@
 
 package com.dynamo.bob.fs;
 
+import com.dynamo.bob.util.MurmurHash;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Collections;
+
 public class ResourceUtil {
+
+    protected static HashMap<String, String> extensionMapping = new HashMap<>();
+    protected static HashMap<String, String> cachedPaths = new HashMap<>();
+    // A set of the minified results, so we don't accidentally minify them again
+    protected static HashSet<String>         minifiedPaths = new HashSet<>();
+    protected static HashSet<String>         minifySupport = new HashSet<>();
+
+    private static boolean minifyPathEnabled = false;
+
+    protected static String buildDirectory = null;
+
+    public static void registerMapping(String inExt, String outExt) {
+        extensionMapping.put(inExt, outExt);
+        minifySupport.add(outExt);
+    }
+
+    public static void setBuildDirectory(String buildDirectory) {
+        ResourceUtil.buildDirectory = buildDirectory;
+    }
 
     /**
      * Change extension of filename
@@ -32,15 +58,141 @@ public class ResourceUtil {
     }
 
     /**
-     * Get extension of filename
-     * @param fileName file-name to get extension for
-     * @return the ext, including the '.' character
+     * Optionally change suffix of filename if the requested input suffix matches
+     * @param path path to change suffix for
+     * @param from input suffix
+     * @param to output suffix
+     * @return modified path if input suffix matched, otherwise the original input path
      */
-    public static String getExt(String fileName) {
-        int i = fileName.lastIndexOf(".");
-        if (i == -1) {
-            throw new IllegalArgumentException(String.format("Missing extension in name '%s'", fileName));
+    public static String replaceExt(String path, String from, String to) {
+        if (path.endsWith(from)) {
+            return path.substring(0, path.lastIndexOf(from)).concat(to);
         }
-        return fileName.substring(i);
+        return path;
     }
+
+   /**
+    * Get the output suffix from an input siffix
+    * @param inExt the input file suffix (including the '.')
+    * @return the output suffix (including the '.')
+    */
+    public static String getOutputExt(String inExt) {
+        String outExt = extensionMapping.get(inExt); // Get the output ext, or use the inExt as default
+        if (outExt != null)
+            return outExt;
+        return inExt;
+    }
+
+    // returns suffix with ".suffix"
+    public static String getSuffix(String path) {
+        int index = path.lastIndexOf(".");
+        if (index < 0)
+            return null;
+        return path.substring(index);
+    }
+
+    public static void enableMinification(boolean enable) {
+        minifyPathEnabled = enable;
+    }
+
+    public static boolean isMinificationEnabled() {
+        return minifyPathEnabled;
+    }
+
+    public static String minifyPathAndReplaceExt(String path, String from, String to) {
+        path = replaceExt(path, from, to);
+        return minifyPath(path);
+    }
+
+    public static String minifyPathAndChangeExt(String path, String to) {
+        path = changeExt(path, to);
+        return minifyPath(path);
+    }
+
+    public static void disableMinify(String ext) {
+        minifySupport.remove(ext);
+    }
+
+    /**
+     * Minify a resource path into a hashed bucket layout.
+     *
+     * Return value expectations:
+     * - If minification is disabled, the input path is returned unchanged.
+     * - If the path suffix is not in the minify support set, the input path is returned unchanged.
+     * - If minification is enabled and the suffix is supported, the path is replaced with a hashed bucket path
+     *   that preserves the original suffix (e.g. ".spc", ".materialc", ".texturesetc").
+     *
+     * Leading "/" expectations:
+     * - For non-build paths (not starting with buildDirectory), the returned minified path is forced to start with "/".
+     * - For build output paths (starting with buildDirectory), the returned minified path starts with buildDirectory
+     *   and does not include a leading "/".
+     * - If minification is disabled or unsupported for the suffix, non-build paths still get a leading "/".
+     *   Build output paths are returned unchanged.
+     *
+     */
+    public static String minifyPath(String path) {
+        if (path == null || path.length() == 0) {
+            return path;
+        }
+        boolean isBuildPath = buildDirectory != null && buildDirectory.length() > 0 && path.startsWith(buildDirectory);
+        if (!minifyPathEnabled) {
+            if (!isBuildPath && path.charAt(0) != '/') {
+                return "/" + path;
+            }
+            return path;
+        }
+
+        String suffix = getSuffix(path);
+        if (!minifySupport.contains(suffix)) {
+            if (!isBuildPath && path.charAt(0) != '/') {
+                return "/" + path;
+            }
+            return path;
+        }
+
+        if (isBuildPath) {
+            path = path.substring(buildDirectory.length());
+        }
+
+        if (path.charAt(0) != '/') {
+            path = "/" + path;
+        }
+
+        if (minifiedPaths.contains(path)) {
+            return path; // Already minified
+        }
+
+        String cachedPath = cachedPaths.getOrDefault(path, null);
+        if (cachedPath != null) {
+            return cachedPath;
+        }
+
+        long hash = MurmurHash.hash64(path);
+        String hex = Long.toHexString(hash);
+
+        // Normally I wouldn't put 65k files into the same folder, but here we are also
+        // relying on the fact that the hash has a good distribution, and thus getting us an "equal" spread
+        // over the different buckets. // MAWE
+        int bucket0 = (int)((hash >> 0 ) & 0xFFFFL);
+        int bucket1 = (int)((hash >> 16) & 0xFFFFL);
+        int bucket2 = (int)((hash >> 32) & 0xFFFFL);
+        int bucket3 = (int)((hash >> 48) & 0xFFFFL);
+
+        String prefix = isBuildPath ? buildDirectory : "";
+        String minifiedPath = String.format("%s/%s/%s/%s/%s%s", prefix,
+                Long.toHexString(bucket0), Long.toHexString(bucket1), Long.toHexString(bucket2), Long.toHexString(bucket3), suffix);
+
+        cachedPaths.put(path, minifiedPath);
+        minifiedPaths.add(minifiedPath);
+        return minifiedPath;
+    }
+
+    public static Map<String, String> snapshotMinifiedPaths() {
+        return Collections.unmodifiableMap(new HashMap<>(cachedPaths));
+    }
+
+    public static String getBuildDirectory() {
+        return buildDirectory;
+    }
+
 }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/BuilderUtil.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/BuilderUtil.java
@@ -21,21 +21,6 @@ import com.dynamo.bob.util.BobNLS;
 
 public class BuilderUtil {
 
-    public static String replaceExt(String str, String from, String to) {
-        if (str.endsWith(from)) {
-            return str.substring(0, str.lastIndexOf(from)).concat(to);
-        }
-        return str;
-    }
-
-    public static String replaceExt(String str, String to) {
-        int last_dot = str.lastIndexOf(".");
-        if (last_dot != -1) {
-            return str.substring(0, last_dot).concat(to);
-        }
-        return str.concat(to);
-    }
-
     // Returns "dae" from "path/to.dae"
     public static String getSuffix(String path) {
         return path.substring(path.lastIndexOf(".") + 1);

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/BuilderUtil.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/BuilderUtil.java
@@ -17,6 +17,7 @@ package com.dynamo.bob.pipeline;
 import com.dynamo.bob.CompileExceptionError;
 import com.dynamo.bob.Project;
 import com.dynamo.bob.fs.IResource;
+import com.dynamo.bob.fs.ResourceUtil;
 import com.dynamo.bob.util.BobNLS;
 
 public class BuilderUtil {
@@ -24,6 +25,15 @@ public class BuilderUtil {
     // Returns "dae" from "path/to.dae"
     public static String getSuffix(String path) {
         return path.substring(path.lastIndexOf(".") + 1);
+    }
+
+    /**
+     * Backward compatible shim for builders/extensions compiled against older bob.jar versions.
+     * Prefer {@link ResourceUtil#replaceExt(String, String, String)} in new code.
+     */
+    @Deprecated
+    public static String replaceExt(String path, String from, String to) {
+        return ResourceUtil.replaceExt(path, from, to);
     }
 
     public static IResource checkResource(Project project, IResource owner, String field, String path) throws CompileExceptionError {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/BuilderUtil.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/BuilderUtil.java
@@ -33,7 +33,7 @@ public class BuilderUtil {
      */
     @Deprecated
     public static String replaceExt(String path, String from, String to) {
-        return ResourceUtil.replaceExt(path, from, to);
+        return ResourceUtil.minifyPathAndReplaceExt(path, from, to);
     }
 
     public static IResource checkResource(Project project, IResource owner, String field, String path) throws CompileExceptionError {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/CollectionBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/CollectionBuilder.java
@@ -29,6 +29,7 @@ import com.dynamo.bob.ProtoParams;
 import com.dynamo.bob.Project;
 import com.dynamo.bob.Task;
 import com.dynamo.bob.fs.IResource;
+import com.dynamo.bob.fs.ResourceUtil;
 import com.dynamo.bob.util.MathUtil;
 import com.dynamo.bob.util.MurmurHash;
 import com.dynamo.bob.util.PropertiesUtil;
@@ -432,7 +433,8 @@ public class CollectionBuilder extends ProtoBuilder<CollectionDesc.Builder> {
                 b.setScale3(MathUtil.vecmathToDDFOne(new Vector3d(s, s, s)));
             }
 
-            b.setPrototype(BuilderUtil.replaceExt(b.getPrototype(), ".go", ".goc"));
+            b.setPrototype(ResourceUtil.minifyPathAndReplaceExt(b.getPrototype(), ".go", ".goc"));
+
             for (int j = 0; j < b.getComponentPropertiesCount(); ++j) {
                 ComponentPropertyDesc.Builder compPropBuilder = ComponentPropertyDesc.newBuilder(b.getComponentProperties(j));
                 PropertyDeclarations.Builder properties = PropertyDeclarations.newBuilder();

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/CollisionObjectBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/CollisionObjectBuilder.java
@@ -6,6 +6,7 @@ import com.dynamo.bob.ProtoBuilder;
 import com.dynamo.bob.ProtoParams;
 import com.dynamo.bob.Task;
 import com.dynamo.bob.fs.IResource;
+import com.dynamo.bob.fs.ResourceUtil;
 import com.dynamo.bob.util.BobNLS;
 import com.dynamo.bob.util.MurmurHash;
 import com.dynamo.gamesys.proto.Physics.ConvexShape;
@@ -71,9 +72,12 @@ public class CollisionObjectBuilder extends ProtoBuilder<CollisionObjectDesc.Bui
             shapeBuilder.setIdHash(MurmurHash.hash64(shapeBuilder.getId()));
         }
 
-        messageBuilder.setCollisionShape(BuilderUtil.replaceExt(messageBuilder.getCollisionShape(), ".convexshape", ".convexshapec"));
-        messageBuilder.setCollisionShape(BuilderUtil.replaceExt(messageBuilder.getCollisionShape(), ".tilegrid", ".tilemapc"));
-        messageBuilder.setCollisionShape(BuilderUtil.replaceExt(messageBuilder.getCollisionShape(), ".tilemap", ".tilemapc"));
+        String path = messageBuilder.getCollisionShape();
+        path = ResourceUtil.replaceExt(path, ".convexshape", ".convexshapec");
+        path = ResourceUtil.replaceExt(path, ".tilegrid", ".tilemapc");
+        path = ResourceUtil.replaceExt(path, ".tilemap", ".tilemapc");
+        messageBuilder.setCollisionShape(ResourceUtil.minifyPath(path));
+
         return messageBuilder;
     }
 }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ComputeBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ComputeBuilder.java
@@ -23,6 +23,7 @@ import com.dynamo.bob.BuilderParams;
 import com.dynamo.bob.CompileExceptionError;
 import com.dynamo.bob.Task;
 import com.dynamo.bob.fs.IResource;
+import com.dynamo.bob.fs.ResourceUtil;
 import com.dynamo.bob.ProtoParams;
 import com.dynamo.render.proto.Compute.ComputeDesc;
 import com.dynamo.render.proto.Material.MaterialDesc;
@@ -47,7 +48,7 @@ public class ComputeBuilder extends ProtoBuilder<ComputeDesc.Builder> {
     }
 
     private IResource getShaderProgram(ComputeDesc.Builder fromBuilder) {
-        String shaderPath = BuilderUtil.replaceExt(fromBuilder.getComputeProgram(), ".cp", ShaderProgramBuilderBundle.EXT);
+        String shaderPath = ResourceUtil.replaceExt(fromBuilder.getComputeProgram(), ".cp", ShaderProgramBuilderBundle.EXT);
         return this.project.getResource(shaderPath);
     }
 
@@ -82,7 +83,7 @@ public class ComputeBuilder extends ProtoBuilder<ComputeDesc.Builder> {
         BuilderUtil.checkResource(this.project, res, "compute program", computeBuilder.getComputeProgram());
         IResource shaderResourceOut = getShaderProgram(computeBuilder);
 
-        computeBuilder.setComputeProgram("/" + BuilderUtil.replaceExt(shaderResourceOut.getPath(), ".spc"));
+        computeBuilder.setComputeProgram(ResourceUtil.changeExt(shaderResourceOut.getPath(), ".spc"));
 
         buildSamplers(computeBuilder);
 

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ComputeBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ComputeBuilder.java
@@ -83,7 +83,7 @@ public class ComputeBuilder extends ProtoBuilder<ComputeDesc.Builder> {
         BuilderUtil.checkResource(this.project, res, "compute program", computeBuilder.getComputeProgram());
         IResource shaderResourceOut = getShaderProgram(computeBuilder);
 
-        computeBuilder.setComputeProgram(ResourceUtil.changeExt(shaderResourceOut.getPath(), ".spc"));
+        computeBuilder.setComputeProgram(ResourceUtil.minifyPathAndChangeExt(shaderResourceOut.getPath(), ".spc"));
 
         buildSamplers(computeBuilder);
 

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ExtenderUtil.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ExtenderUtil.java
@@ -261,6 +261,11 @@ public class ExtenderUtil {
             return false;
         }
 
+        @Override
+        public IResource disableMinifyPath() { return this; }
+
+        @Override
+        public boolean isMinifyPath() { return false; }
     }
 
     // Used to rename a resource in the multipart request and prefix the content with a base variant

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/FontBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/FontBuilder.java
@@ -23,6 +23,7 @@ import com.dynamo.bob.ProtoParams;
 import com.dynamo.bob.Task;
 import com.dynamo.bob.font.Fontc;
 import com.dynamo.bob.fs.IResource;
+import com.dynamo.bob.fs.ResourceUtil;
 
 import com.dynamo.render.proto.Font.FontDesc;
 import com.dynamo.render.proto.Font.FontMap;
@@ -99,7 +100,7 @@ public class FontBuilder extends ProtoBuilder<FontDesc.Builder> {
             fontMapBuilder.setGlyphBank(glyphBankPath);
         }
 
-        fontMapBuilder.setMaterial(BuilderUtil.replaceExt(fontDesc.getMaterial(), ".material", ".materialc"));
+        fontMapBuilder.setMaterial(ResourceUtil.minifyPathAndReplaceExt(fontDesc.getMaterial(), ".material", ".materialc"));
 
         boolean allChars = fontDesc.getAllChars();
 

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/GameObjectBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/GameObjectBuilder.java
@@ -31,12 +31,14 @@ import org.apache.commons.io.FilenameUtils;
 import com.dynamo.proto.DdfMath.Vector3One;
 import com.dynamo.proto.DdfMath.Vector4One;
 
+import com.dynamo.bob.Bob;
 import com.dynamo.bob.BuilderParams;
 import com.dynamo.bob.CompileExceptionError;
 import com.dynamo.bob.Task;
 import com.dynamo.bob.ProtoParams;
 import com.dynamo.bob.Task.TaskBuilder;
 import com.dynamo.bob.fs.IResource;
+import com.dynamo.bob.fs.ResourceUtil;
 import com.dynamo.bob.util.MurmurHash;
 import com.dynamo.bob.util.PropertiesUtil;
 import com.dynamo.bob.util.ComponentsCounter;
@@ -167,6 +169,8 @@ public class GameObjectBuilder extends ProtoBuilder<PrototypeDesc.Builder> {
             BuilderUtil.checkResource(this.project, input, "component", component);
         }
 
+        int buildDirLen = project.getBuildDirectory().length();
+
         // convert embedded components to generated components in the build folder
         for (EmbeddedComponentDesc ec : protoBuilder.getEmbeddedComponentsList()) {
             if (ec.getId().length() == 0) {
@@ -181,14 +185,13 @@ public class GameObjectBuilder extends ProtoBuilder<PrototypeDesc.Builder> {
             // TODO: We have to set content again here as distclean might have removed everything at this point (according to CollectionBuilder.java)
             genResource.setContent(data);
 
-            int buildDirLen = project.getBuildDirectory().length();
-            String path = genResource.getPath().substring(buildDirLen);
+            String relativePath = genResource.getPath().substring(buildDirLen);
 
             ComponentDesc.Builder b = ComponentDesc.newBuilder()
                     .setId(ec.getId())
                     .setPosition(ec.getPosition())
                     .setRotation(ec.getRotation())
-                    .setComponent(path);
+                    .setComponent(relativePath);
 
             // #3981
             // copy the scale from the embedded component only if it has a scale to
@@ -231,13 +234,13 @@ public class GameObjectBuilder extends ProtoBuilder<PrototypeDesc.Builder> {
             String ext = FilenameUtils.getExtension(c);
             compStorage.add(ext);
             String inExt = "." + ext;
-            String outExt = project.replaceExt(inExt);
+            String outExt = ResourceUtil.getOutputExt(inExt);
             if (ext.equals("gui_script") || ext.equals("render_script"))
             {
                 throw new CompileExceptionError(resource, 0, BobNLS.bind(Messages.BuilderUtil_WRONG_RESOURCE_TYPE,
                         new String[] { c, ext, "script" } ));
             }
-            c = BuilderUtil.replaceExt(c, inExt, outExt);
+            c = ResourceUtil.minifyPathAndReplaceExt(c, inExt, outExt);
 
             PropertyDeclarations.Builder properties = PropertyDeclarations.newBuilder();
             for (PropertyDesc desc : cd.getPropertiesList()) {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/GameProjectBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/GameProjectBuilder.java
@@ -125,7 +125,7 @@ public class GameProjectBuilder extends Builder {
         TaskBuilder builder = Task.newBuilder(this)
                 .setName(params.name())
                 .addInput(input)
-                .addOutput(input.changeExt(".projectc").disableCache());
+                .addOutput(input.disableMinifyPath().changeExt(".projectc").disableCache());
 
         for (IResource propertyFile : project.getPropertyFilesAsResources()) {
             builder.addInput(propertyFile);
@@ -133,11 +133,11 @@ public class GameProjectBuilder extends Builder {
 
         TimeProfiler.start("Add outputs");
         if (project.option("archive", "false").equals("true")) {
-            builder.addOutput(input.changeExt(".arci").disableCache());
-            builder.addOutput(input.changeExt(".arcd").disableCache());
-            builder.addOutput(input.changeExt(".dmanifest").disableCache());
-            builder.addOutput(input.changeExt(".public.der").disableCache());
-            builder.addOutput(input.changeExt(".graph.json").disableCache());
+            builder.addOutput(input.disableMinifyPath().changeExt(".arci").disableCache());
+            builder.addOutput(input.disableMinifyPath().changeExt(".arcd").disableCache());
+            builder.addOutput(input.disableMinifyPath().changeExt(".dmanifest").disableCache());
+            builder.addOutput(input.disableMinifyPath().changeExt(".public.der").disableCache());
+            builder.addOutput(input.disableMinifyPath().changeExt(".graph.json").disableCache());
         }
         TimeProfiler.stop();
 
@@ -147,19 +147,24 @@ public class GameProjectBuilder extends Builder {
             // initial values already have 'c' in the end
             if (path != null && path.length() > 0) {
                 path = path.substring(0, path.length() - 1);
+
+                String field = "";
                 if (ROOT_NODES.length < index) {
                     String[] tuples = ROOT_NODES[index];
-                    createSubTask(path, String.format("%s.%s", tuples[0], tuples[1]), builder);
+                    field = String.format("%s.%s", tuples[0], tuples[1]);
                 }
-                else {
-                    createSubTask(path, "", builder);
-                }
+
+                IResource res = BuilderUtil.checkResource(project, builder.firstInput(), field, path);
+                res.disableMinifyPath();
+                createSubTask(res, builder);
             }
             index++;
         }
 
         String textureProfilesPath = project.getProjectProperties().getStringValue("graphics", "texture_profiles", "/builtins/graphics/default.texture_profiles");
-        createSubTask(textureProfilesPath, "graphics.texture_profiles", builder);
+        IResource textureProfiles = BuilderUtil.checkResource(project, builder.firstInput(), "graphics.texture_profiles", textureProfilesPath);
+        textureProfiles.disableMinifyPath();
+        createSubTask(textureProfiles, builder);
 
         IResource publisherSettingsResorce = project.getPublisher().getPublisherSettingsResorce();
         if (publisherSettingsResorce != null) {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/GuiBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/GuiBuilder.java
@@ -32,6 +32,7 @@ import com.dynamo.bob.ProtoBuilder;
 import com.dynamo.bob.ProtoParams;
 import com.dynamo.bob.Task;
 import com.dynamo.bob.fs.IResource;
+import com.dynamo.bob.fs.ResourceUtil;
 import com.dynamo.bob.util.BobNLS;
 import com.dynamo.bob.util.MathUtil;
 import com.dynamo.bob.util.MurmurHash;
@@ -369,8 +370,8 @@ public class GuiBuilder extends ProtoBuilder<SceneDesc.Builder> {
                  throw new CompileExceptionError(builder.project.getResource(input), 0, BobNLS.bind(Messages.BuilderUtil_WRONG_RESOURCE_TYPE,
                          new String[] { scriptPath, suffix, "gui_script" } ));
             }
-            sceneBuilder.setScript(BuilderUtil.replaceExt(scriptPath, ".gui_script", ".gui_scriptc"));
-            sceneBuilder.setMaterial(BuilderUtil.replaceExt(sceneBuilder.getMaterial(), ".material", ".materialc"));
+            sceneBuilder.setScript(ResourceUtil.minifyPathAndReplaceExt(scriptPath, ".gui_script", ".gui_scriptc"));
+            sceneBuilder.setMaterial(ResourceUtil.minifyPathAndReplaceExt(sceneBuilder.getMaterial(), ".material", ".materialc"));
 
             for (FontDesc f : sceneBuilder.getFontsList()) {
                 if (fontNames.contains(f.getName())) {
@@ -378,7 +379,7 @@ public class GuiBuilder extends ProtoBuilder<SceneDesc.Builder> {
                             f.getName()));
                 }
                 fontNames.add(f.getName());
-                newFontList.add(FontDesc.newBuilder().mergeFrom(f).setFont(BuilderUtil.replaceExt(f.getFont(), ".font", ".fontc")).build());
+                newFontList.add(FontDesc.newBuilder().mergeFrom(f).setFont(ResourceUtil.minifyPathAndReplaceExt(f.getFont(), ".font", ".fontc")).build());
             }
 
             for (SpineSceneDesc f : sceneBuilder.getSpineScenesList()) {
@@ -387,7 +388,7 @@ public class GuiBuilder extends ProtoBuilder<SceneDesc.Builder> {
                             f.getName()));
                 }
                 resourceNames.add(f.getName());
-                ResourceDesc desc = ResourceDesc.newBuilder().setName(f.getName()).setPath(BuilderUtil.replaceExt(f.getSpineScene(), ".spinescene", ".spinescenec")).build();
+                ResourceDesc desc = ResourceDesc.newBuilder().setName(f.getName()).setPath(ResourceUtil.minifyPathAndReplaceExt(f.getSpineScene(), ".spinescene", ".spinescenec")).build();
                 newResourcesList.add(desc);
             }
 
@@ -397,7 +398,7 @@ public class GuiBuilder extends ProtoBuilder<SceneDesc.Builder> {
                             f.getName()));
                 }
                 particlefxNames.add(f.getName());
-                newParticleFXList.add(ParticleFXDesc.newBuilder().mergeFrom(f).setParticlefx(BuilderUtil.replaceExt(f.getParticlefx(), ".particlefx", ".particlefxc")).build());
+                newParticleFXList.add(ParticleFXDesc.newBuilder().mergeFrom(f).setParticlefx(ResourceUtil.minifyPathAndReplaceExt(f.getParticlefx(), ".particlefx", ".particlefxc")).build());
             }
 
             for (TextureDesc f : sceneBuilder.getTexturesList()) {
@@ -415,7 +416,7 @@ public class GuiBuilder extends ProtoBuilder<SceneDesc.Builder> {
                             f.getName()));
                 }
                 materialNames.add(f.getName());
-                newMaterialList.add(MaterialDesc.newBuilder().mergeFrom(f).setMaterial(BuilderUtil.replaceExt(f.getMaterial(), ".material", ".materialc")).build());
+                newMaterialList.add(MaterialDesc.newBuilder().mergeFrom(f).setMaterial(ResourceUtil.minifyPathAndReplaceExt(f.getMaterial(), ".material", ".materialc")).build());
             }
 
             for (ResourceDesc f : sceneBuilder.getResourcesList()) {
@@ -425,7 +426,7 @@ public class GuiBuilder extends ProtoBuilder<SceneDesc.Builder> {
                 }
                 // TODO: use the plugin for this
                 resourceNames.add(f.getName());
-                newResourcesList.add(ResourceDesc.newBuilder().mergeFrom(f).setPath(BuilderUtil.replaceExt(f.getPath(), ".spinescene", ".spinescenec")).build());
+                newResourcesList.add(ResourceDesc.newBuilder().mergeFrom(f).setPath(ResourceUtil.minifyPathAndReplaceExt(f.getPath(), ".spinescene", ".spinescenec")).build());
             }
 
             // transform scene internal resources

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/LuaBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/LuaBuilder.java
@@ -125,7 +125,7 @@ public abstract class LuaBuilder extends Builder {
         Task.TaskBuilder taskBuilder = Task.newBuilder(this)
                 .setName(params.name())
                 .addInput(input)
-                .addOutput(input.changeExt(params.outExt()));
+                .addOutput(input.disableMinifyPath().changeExt(params.outExt()));
 
         LuaScanner.Result result = getLuaScannerResult(input);
         long finalLuaHash = MurmurHash.hash64(result.code());

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/MaterialBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/MaterialBuilder.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.List;
 
 import com.dynamo.bob.fs.IResource;
+import com.dynamo.bob.fs.ResourceUtil;
 
 import com.dynamo.bob.pipeline.ShaderUtil.VariantTextureArrayFallback;
 import com.dynamo.bob.util.MurmurHash;
@@ -130,7 +131,7 @@ public class MaterialBuilder extends ProtoBuilder<MaterialDesc.Builder> {
         // The material should depend on the finally built shader resource file
         // that is a combination of one or more shader modules
         IResource shaderResource = getShaderProgram(materialBuilder);
-        IResource shaderResourceOut = shaderResource.changeExt(ShaderProgramBuilderBundle.EXT_OUT);
+        IResource shaderResourceOut = shaderResource.disableMinifyPath().changeExt(ShaderProgramBuilderBundle.EXT_OUT);
 
         IShaderCompiler.CompileOptions compileOptions = new IShaderCompiler.CompileOptions();
         compileOptions.maxPageCount = materialBuilder.getMaxPageCount();
@@ -257,7 +258,7 @@ public class MaterialBuilder extends ProtoBuilder<MaterialDesc.Builder> {
         getShaderProgram(materialBuilder);
         IResource shaderResource = getShaderProgram(materialBuilder);
 
-        materialBuilder.setProgram("/" + BuilderUtil.replaceExt(shaderResource.getPath(), ".spc"));
+        materialBuilder.setProgram(ResourceUtil.minifyPathAndChangeExt(shaderResource.getPath(), ".spc"));
         materialBuilder.setVertexProgram("");
         materialBuilder.setFragmentProgram("");
 

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/MeshBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/MeshBuilder.java
@@ -27,6 +27,7 @@ import com.dynamo.bob.ProtoBuilder;
 import com.dynamo.bob.ProtoParams;
 import com.dynamo.bob.Task;
 import com.dynamo.bob.fs.IResource;
+import com.dynamo.bob.fs.ResourceUtil;
 
 import com.dynamo.gamesys.proto.MeshProto.MeshDesc;
 import com.google.protobuf.TextFormat;
@@ -44,9 +45,9 @@ public class MeshBuilder extends ProtoBuilder<MeshDesc.Builder> {
 
         IResource resource = task.input(0);
         BuilderUtil.checkResource(this.project, resource, "vertices", meshDescBuilder.getVertices());
-        meshDescBuilder.setVertices(BuilderUtil.replaceExt(meshDescBuilder.getVertices(), ".buffer", ".bufferc"));
+        meshDescBuilder.setVertices(ResourceUtil.minifyPathAndReplaceExt(meshDescBuilder.getVertices(), ".buffer", ".bufferc"));
         BuilderUtil.checkResource(this.project, resource, "material", meshDescBuilder.getMaterial());
-        meshDescBuilder.setMaterial(BuilderUtil.replaceExt(meshDescBuilder.getMaterial(), ".material", ".materialc"));
+        meshDescBuilder.setMaterial(ResourceUtil.minifyPathAndReplaceExt(meshDescBuilder.getMaterial(), ".material", ".materialc"));
 
         List<String> newTextureList = new ArrayList<String>();
         for (String t : meshDescBuilder.getTexturesList()) {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ModelBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ModelBuilder.java
@@ -26,6 +26,7 @@ import com.dynamo.bob.ProtoParams;
 import com.dynamo.bob.ProtoBuilder;
 import com.dynamo.bob.Task;
 import com.dynamo.bob.fs.IResource;
+import com.dynamo.bob.fs.ResourceUtil;
 
 import com.dynamo.gamesys.proto.ModelProto.Material;
 import com.dynamo.gamesys.proto.ModelProto.Model;
@@ -95,9 +96,9 @@ public class ModelBuilder extends ProtoBuilder<ModelDesc.Builder> {
 
         // Rigscene
         RigScene.Builder rigBuilder = RigScene.newBuilder();
-        rigBuilder.setMeshSet(BuilderUtil.replaceExt(modelDescBuilder.getMesh(), ".meshsetc"));
+        rigBuilder.setMeshSet(ResourceUtil.changeExt(modelDescBuilder.getMesh(), ".meshsetc"));
         if(!modelDescBuilder.getSkeleton().isEmpty()) {
-            rigBuilder.setSkeleton(BuilderUtil.replaceExt(modelDescBuilder.getSkeleton(), ".skeletonc"));
+            rigBuilder.setSkeleton(ResourceUtil.changeExt(modelDescBuilder.getSkeleton(), ".skeletonc"));
         }
 
         if (modelDescBuilder.getAnimations().equals("")) {
@@ -105,13 +106,13 @@ public class ModelBuilder extends ProtoBuilder<ModelDesc.Builder> {
         }
         else if(modelDescBuilder.getAnimations().endsWith(".animationset")) {
             // if an animsetdesc file is animation input, use animations and skeleton from that file(s) and other related data (weights, boneindices..) from the mesh collada file
-            rigBuilder.setAnimationSet(BuilderUtil.replaceExt(modelDescBuilder.getAnimations(), ".animationsetc"));
+            rigBuilder.setAnimationSet(ResourceUtil.changeExt(modelDescBuilder.getAnimations(), ".animationsetc"));
         }
         else if(!modelDescBuilder.getAnimations().isEmpty()) {
             // if a collada file is animation input, use animations from that file and other related data (weights, boneindices..) from the mesh collada file
             // we define this a generated file as the animation set does not come from an .animationset resource, but is exported directly from this collada file
             // and because we also avoid possible resource name collision (ref: atlas <-> texture).
-            rigBuilder.setAnimationSet(BuilderUtil.replaceExt(modelDescBuilder.getAnimations(), "_generated_0.animationsetc"));
+            rigBuilder.setAnimationSet(ResourceUtil.changeExt(modelDescBuilder.getAnimations(), "_generated_0.animationsetc"));
         } else {
             throw new CompileExceptionError(task.firstInput(), -1, "No animation set in model!");
         }
@@ -134,7 +135,7 @@ public class ModelBuilder extends ProtoBuilder<ModelDesc.Builder> {
 
                 IResource materialSourceResource = BuilderUtil.checkResource(this.project, resource, "material", material.getMaterial());
                 materialBuilder.setName(material.getName());
-                materialBuilder.setMaterial(BuilderUtil.replaceExt(material.getMaterial(), ".material", ".materialc"));
+                materialBuilder.setMaterial(ResourceUtil.minifyPathAndReplaceExt(material.getMaterial(), ".material", ".materialc"));
 
                 List<Texture> texturesList = new ArrayList<>();
                 for (Texture t : material.getTexturesList()) {
@@ -179,7 +180,7 @@ public class ModelBuilder extends ProtoBuilder<ModelDesc.Builder> {
 
                 Material.Builder materialBuilder = Material.newBuilder();
                 materialBuilder.setName("default");
-                materialBuilder.setMaterial(BuilderUtil.replaceExt(singleMaterial, ".material", ".materialc"));
+                materialBuilder.setMaterial(ResourceUtil.minifyPathAndReplaceExt(singleMaterial, ".material", ".materialc"));
 
                 List<Texture> texturesList = new ArrayList<>();
                 for (String t : modelDescBuilder.getTexturesList()) {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ModelBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ModelBuilder.java
@@ -96,9 +96,9 @@ public class ModelBuilder extends ProtoBuilder<ModelDesc.Builder> {
 
         // Rigscene
         RigScene.Builder rigBuilder = RigScene.newBuilder();
-        rigBuilder.setMeshSet(ResourceUtil.changeExt(modelDescBuilder.getMesh(), ".meshsetc"));
+        rigBuilder.setMeshSet(ResourceUtil.minifyPathAndChangeExt(modelDescBuilder.getMesh(), ".meshsetc"));
         if(!modelDescBuilder.getSkeleton().isEmpty()) {
-            rigBuilder.setSkeleton(ResourceUtil.changeExt(modelDescBuilder.getSkeleton(), ".skeletonc"));
+            rigBuilder.setSkeleton(ResourceUtil.minifyPathAndChangeExt(modelDescBuilder.getSkeleton(), ".skeletonc"));
         }
 
         if (modelDescBuilder.getAnimations().equals("")) {
@@ -106,13 +106,13 @@ public class ModelBuilder extends ProtoBuilder<ModelDesc.Builder> {
         }
         else if(modelDescBuilder.getAnimations().endsWith(".animationset")) {
             // if an animsetdesc file is animation input, use animations and skeleton from that file(s) and other related data (weights, boneindices..) from the mesh collada file
-            rigBuilder.setAnimationSet(ResourceUtil.changeExt(modelDescBuilder.getAnimations(), ".animationsetc"));
+            rigBuilder.setAnimationSet(ResourceUtil.minifyPathAndChangeExt(modelDescBuilder.getAnimations(), ".animationsetc"));
         }
         else if(!modelDescBuilder.getAnimations().isEmpty()) {
             // if a collada file is animation input, use animations from that file and other related data (weights, boneindices..) from the mesh collada file
             // we define this a generated file as the animation set does not come from an .animationset resource, but is exported directly from this collada file
             // and because we also avoid possible resource name collision (ref: atlas <-> texture).
-            rigBuilder.setAnimationSet(ResourceUtil.changeExt(modelDescBuilder.getAnimations(), "_generated_0.animationsetc"));
+            rigBuilder.setAnimationSet(ResourceUtil.minifyPathAndChangeExt(modelDescBuilder.getAnimations(), "_generated_0.animationsetc"));
         } else {
             throw new CompileExceptionError(task.firstInput(), -1, "No animation set in model!");
         }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ProtoBuilders.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ProtoBuilders.java
@@ -33,6 +33,7 @@ import com.dynamo.bob.ProtoBuilder;
 import com.dynamo.bob.ProtoParams;
 import com.dynamo.bob.Task;
 import com.dynamo.bob.fs.IResource;
+import com.dynamo.bob.fs.ResourceUtil;
 import com.dynamo.bob.util.BobNLS;
 import com.dynamo.bob.util.MathUtil;
 import com.dynamo.bob.util.TextureUtil;
@@ -74,22 +75,22 @@ public class ProtoBuilders {
         throw new Exception(String.format("Cannot find a texture suffix replacement for texture: %s\n", str));
     }
 
-    private static String replaceAllExts(String str, String[][] extList) {
+    private static String minifyAndReplaceAllExts(String str, String[][] extList) {
         String out = str;
         for (String[] ext : extList) {
-            out = BuilderUtil.replaceExt(out, ext[0], ext[1]);
+            out = ResourceUtil.minifyPathAndReplaceExt(out, ext[0], ext[1]);
         }
         return out;
     }
 
     public static String replaceTextureName(String str) {
-        return replaceAllExts(str, textureSrcExts);
+        return minifyAndReplaceAllExts(str, textureSrcExts);
     }
 
     public static String replaceTextureSetName(String str) throws Exception {
         String replacement = getTextureSetExt(str);
         String suffix = "." + FilenameUtils.getExtension(str);
-        return BuilderUtil.replaceExt(str, suffix, replacement);
+        return ResourceUtil.minifyPathAndReplaceExt(str, suffix, replacement);
     }
 
     private static MaterialDesc.Builder getMaterialBuilderFromResource(IResource res) throws IOException {
@@ -154,7 +155,7 @@ public class ProtoBuilders {
         @Override
         protected CollectionProxyDesc.Builder transform(Task task, IResource resource, CollectionProxyDesc.Builder messageBuilder) throws CompileExceptionError {
             BuilderUtil.checkResource(this.project, resource, "collection", messageBuilder.getCollection());
-            return messageBuilder.setCollection(BuilderUtil.replaceExt(messageBuilder.getCollection(), ".collection", ".collectionc"));
+            return messageBuilder.setCollection(ResourceUtil.minifyPathAndReplaceExt(messageBuilder.getCollection(), ".collection", ".collectionc"));
         }
     }
 
@@ -194,7 +195,7 @@ public class ProtoBuilders {
         protected FactoryDesc.Builder transform(Task task, IResource resource, FactoryDesc.Builder messageBuilder) throws IOException,
                 CompileExceptionError {
             BuilderUtil.checkResource(this.project, resource, "prototype", messageBuilder.getPrototype());
-            return messageBuilder.setPrototype(BuilderUtil.replaceExt(messageBuilder.getPrototype(), ".go", ".goc"));
+            return messageBuilder.setPrototype(ResourceUtil.minifyPathAndReplaceExt(messageBuilder.getPrototype(), ".go", ".goc"));
         }
     }
 
@@ -205,7 +206,7 @@ public class ProtoBuilders {
         protected CollectionFactoryDesc.Builder transform(Task task, IResource resource, CollectionFactoryDesc.Builder messageBuilder) throws IOException,
                 CompileExceptionError {
             BuilderUtil.checkResource(this.project, resource, "prototype", messageBuilder.getPrototype());
-            return messageBuilder.setPrototype(BuilderUtil.replaceExt(messageBuilder.getPrototype(), ".collection", ".collectionc"));
+            return messageBuilder.setPrototype(ResourceUtil.minifyPathAndReplaceExt(messageBuilder.getPrototype(), ".collection", ".collectionc"));
         }
     }
 
@@ -242,7 +243,7 @@ public class ProtoBuilders {
             }
 
             BuilderUtil.checkResource(this.project, resource, "script", messageBuilder.getScript());
-            messageBuilder.setScript(BuilderUtil.replaceExt(messageBuilder.getScript(), ".render_script", ".render_scriptc"));
+            messageBuilder.setScript(ResourceUtil.minifyPathAndReplaceExt(messageBuilder.getScript(), ".render_script", ".render_scriptc"));
 
             // Content migration, the material entry is deprecated in the render proto
             // we should use render resources entry now!
@@ -252,7 +253,7 @@ public class ProtoBuilders {
 
                 RenderPrototypeDesc.RenderResourceDesc.Builder resBuilder = RenderPrototypeDesc.RenderResourceDesc.newBuilder();
                 resBuilder.setName(m.getName());
-                resBuilder.setPath(BuilderUtil.replaceExt(m.getMaterial(), ".material", ".materialc"));
+                resBuilder.setPath(ResourceUtil.minifyPathAndReplaceExt(m.getMaterial(), ".material", ".materialc"));
                 newRenderResourceList.add(resBuilder.build());
             }
 
@@ -260,7 +261,7 @@ public class ProtoBuilders {
                 BuilderUtil.checkResource(this.project, resource, "render resource", resourceDesc.getPath());
                 newRenderResourceList.add(RenderPrototypeDesc.RenderResourceDesc.newBuilder()
                                      .mergeFrom(resourceDesc)
-                                     .setPath(replaceAllExts(resourceDesc.getPath(), renderResourceExts))
+                                     .setPath(minifyAndReplaceAllExts(resourceDesc.getPath(), renderResourceExts))
                                      .build());
             }
 
@@ -317,7 +318,7 @@ public class ProtoBuilders {
             messageBuilder.clearTextures();
             messageBuilder.addAllTextures(textures);
 
-            messageBuilder.setMaterial(BuilderUtil.replaceExt(messageBuilder.getMaterial(), "material", "materialc"));
+            messageBuilder.setMaterial(ResourceUtil.minifyPathAndReplaceExt(messageBuilder.getMaterial(), "material", "materialc"));
 
             if (materialBuilder != null) {
                 List<VertexAttribute> materialAttributes       = materialBuilder.getAttributesList();
@@ -348,8 +349,8 @@ public class ProtoBuilders {
                 throws IOException, CompileExceptionError {
             BuilderUtil.checkResource(this.project, resource, "material", messageBuilder.getMaterial());
             BuilderUtil.checkResource(this.project, resource, "font", messageBuilder.getFont());
-            messageBuilder.setMaterial(BuilderUtil.replaceExt(messageBuilder.getMaterial(), "material", "materialc"));
-            messageBuilder.setFont(BuilderUtil.replaceExt(messageBuilder.getFont(), "font", "fontc"));
+            messageBuilder.setMaterial(ResourceUtil.minifyPathAndReplaceExt(messageBuilder.getMaterial(), "material", "materialc"));
+            messageBuilder.setFont(ResourceUtil.minifyPathAndReplaceExt(messageBuilder.getFont(), "font", "fontc"));
             return messageBuilder;
         }
     }
@@ -361,10 +362,10 @@ public class ProtoBuilders {
         protected TileGrid.Builder transform(Task task, IResource resource, TileGrid.Builder messageBuilder) throws IOException,
                 CompileExceptionError {
             BuilderUtil.checkResource(this.project, resource, "tile source", messageBuilder.getTileSet());
-            messageBuilder.setTileSet(BuilderUtil.replaceExt(messageBuilder.getTileSet(), "tileset", "t.texturesetc"));
-            messageBuilder.setTileSet(BuilderUtil.replaceExt(messageBuilder.getTileSet(), "tilesource", "t.texturesetc"));
-            messageBuilder.setTileSet(BuilderUtil.replaceExt(messageBuilder.getTileSet(), "atlas", "a.texturesetc"));
-            messageBuilder.setMaterial(BuilderUtil.replaceExt(messageBuilder.getMaterial(), "material", "materialc"));
+            messageBuilder.setTileSet(ResourceUtil.minifyPathAndReplaceExt(messageBuilder.getTileSet(), "tileset", "t.texturesetc"));
+            messageBuilder.setTileSet(ResourceUtil.minifyPathAndReplaceExt(messageBuilder.getTileSet(), "tilesource", "t.texturesetc"));
+            messageBuilder.setTileSet(ResourceUtil.minifyPathAndReplaceExt(messageBuilder.getTileSet(), "atlas", "a.texturesetc"));
+            messageBuilder.setMaterial(ResourceUtil.minifyPathAndReplaceExt(messageBuilder.getMaterial(), "material", "materialc"));
             return messageBuilder;
         }
     }
@@ -387,10 +388,10 @@ public class ProtoBuilders {
 
                 validateMaterialAtlasCompatability(this.project, resource, emitterBuilder.getMaterial(), materialBuilder, emitterBuilder.getTileSource());
 
-                emitterBuilder.setTileSource(BuilderUtil.replaceExt(emitterBuilder.getTileSource(), "tileset", "t.texturesetc"));
-                emitterBuilder.setTileSource(BuilderUtil.replaceExt(emitterBuilder.getTileSource(), "tilesource", "t.texturesetc"));
-                emitterBuilder.setTileSource(BuilderUtil.replaceExt(emitterBuilder.getTileSource(), "atlas", "a.texturesetc"));
-                emitterBuilder.setMaterial(BuilderUtil.replaceExt(emitterBuilder.getMaterial(), "material", "materialc"));
+                emitterBuilder.setTileSource(ResourceUtil.minifyPathAndReplaceExt(emitterBuilder.getTileSource(), "tileset", "t.texturesetc"));
+                emitterBuilder.setTileSource(ResourceUtil.minifyPathAndReplaceExt(emitterBuilder.getTileSource(), "tilesource", "t.texturesetc"));
+                emitterBuilder.setTileSource(ResourceUtil.minifyPathAndReplaceExt(emitterBuilder.getTileSource(), "atlas", "a.texturesetc"));
+                emitterBuilder.setMaterial(ResourceUtil.minifyPathAndReplaceExt(emitterBuilder.getMaterial(), "material", "materialc"));
 
                 Point3d ep = MathUtil.ddfToVecmath(emitterBuilder.getPosition());
                 Quat4d er = MathUtil.ddfToVecmath(emitterBuilder.getRotation(), "%s emitter: %s".formatted(resource, emitterBuilder.getId()));
@@ -434,9 +435,9 @@ public class ProtoBuilders {
         protected SoundDesc.Builder transform(Task task, IResource resource, SoundDesc.Builder messageBuilder)
                 throws IOException, CompileExceptionError {
             BuilderUtil.checkResource(this.project, resource, "sound", messageBuilder.getSound());
-            messageBuilder.setSound(BuilderUtil.replaceExt(messageBuilder.getSound(), "wav", "wavc"));
-            messageBuilder.setSound(BuilderUtil.replaceExt(messageBuilder.getSound(), "ogg", "oggc"));
-            messageBuilder.setSound(BuilderUtil.replaceExt(messageBuilder.getSound(), "opus", "opusc"));
+            messageBuilder.setSound(ResourceUtil.minifyPathAndReplaceExt(messageBuilder.getSound(), "wav", "wavc"));
+            messageBuilder.setSound(ResourceUtil.minifyPathAndReplaceExt(messageBuilder.getSound(), "ogg", "oggc"));
+            messageBuilder.setSound(ResourceUtil.minifyPathAndReplaceExt(messageBuilder.getSound(), "opus", "opusc"));
             return messageBuilder;
         }
     }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/ComponentsCounter.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/ComponentsCounter.java
@@ -36,7 +36,7 @@ import com.dynamo.bob.Task;
 import com.dynamo.bob.Task.TaskBuilder;
 import com.dynamo.bob.fs.IResource;
 import com.dynamo.bob.pipeline.ProtoUtil;
-import com.dynamo.bob.pipeline.BuilderUtil;
+import com.dynamo.bob.fs.ResourceUtil;
 import com.dynamo.gameobject.proto.GameObject.ComponenTypeDesc;
 import com.dynamo.gameobject.proto.GameObject.CollectionDesc;
 import com.dynamo.gameobject.proto.GameObject.ComponentDesc;
@@ -175,14 +175,14 @@ public class ComponentsCounter {
             FactoryDesc.Builder factoryDesc = FactoryDesc.newBuilder();
             ProtoUtil.merge(resource, resourceContent, factoryDesc);
             Boolean isDynamic = factoryDesc.getDynamicPrototype();
-            String counterName = BuilderUtil.replaceExt(factoryDesc.getPrototype(), ".go", EXT_GO);
+            String counterName = ResourceUtil.minifyPathAndReplaceExt(factoryDesc.getPrototype(), ".go", EXT_GO);
             Map.Entry<String,Boolean> entry = new AbstractMap.SimpleEntry<String, Boolean>(counterName, isDynamic);
             return entry;
         } else if (type.equals("collectionfactory")) {
             CollectionFactoryDesc.Builder factoryDesc = CollectionFactoryDesc.newBuilder();
             ProtoUtil.merge(resource, resourceContent, factoryDesc);
             Boolean isDynamic = factoryDesc.getDynamicPrototype();
-            String counterName = BuilderUtil.replaceExt(factoryDesc.getPrototype(), ".collection", EXT_COL);
+            String counterName = ResourceUtil.minifyPathAndReplaceExt(factoryDesc.getPrototype(), ".collection", EXT_COL);
             Map.Entry<String,Boolean> entry = new AbstractMap.SimpleEntry<String, Boolean>(counterName, isDynamic);
             return entry;
         }
@@ -266,9 +266,9 @@ public class ComponentsCounter {
 
     public static String replaceExt(String path) {
         if (path.endsWith(".go")) {
-            return BuilderUtil.replaceExt(path, ".go", EXT_GO);
+            return ResourceUtil.minifyPathAndReplaceExt(path, ".go", EXT_GO);
         } else if (path.endsWith(".collection")) {
-            return BuilderUtil.replaceExt(path, ".collection", EXT_COL);
+            return ResourceUtil.minifyPathAndReplaceExt(path, ".collection", EXT_COL);
         }
         return null;
     }
@@ -327,7 +327,7 @@ public class ComponentsCounter {
         for (Map.Entry<String, Integer> entry : components.entrySet()) {
             // different input component names may have the same output name
             // for example wav and sound both are soundc
-            String name = project.replaceExt("." + entry.getKey()).substring(1);
+            String name = ResourceUtil.getOutputExt("." + entry.getKey()).substring(1);
             Integer value = entry.getValue();
             if (mergedComponents.containsKey(name)) {
                 Integer mergedValue = mergedComponents.get(name);

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/MinifyPathCollector.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/MinifyPathCollector.java
@@ -1,0 +1,38 @@
+package com.dynamo.bob.util;
+
+import com.dynamo.bob.fs.ResourceUtil;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+public class MinifyPathCollector {
+    private static final String DATA_FILE_NAME = "minified_paths.json";
+
+    public static void saveAsJson(File bundleOutputDirectory) {
+        Map<String, String> paths = ResourceUtil.snapshotMinifiedPaths();
+        if (paths == null || paths.isEmpty()) {
+            return;
+        }
+
+        Map<String, Object> data = new HashMap<>();
+        String buildDir = ResourceUtil.getBuildDirectory();
+        if (buildDir != null) {
+            data.put("build_directory", buildDir);
+        }
+        data.put("paths", paths);
+
+        File outputFile = new File(bundleOutputDirectory, DATA_FILE_NAME);
+        try (FileWriter writer = new FileWriter(outputFile)) {
+            ObjectMapper mapper = new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
+            mapper.writeValue(writer, data);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to write build paths JSON", e);
+        }
+    }
+}
+

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/PropertiesUtil.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/PropertiesUtil.java
@@ -25,7 +25,7 @@ import org.apache.commons.io.FilenameUtils;
 import com.dynamo.bob.Project;
 import com.dynamo.bob.fs.IResource;
 import com.dynamo.bob.CompileExceptionError;
-import com.dynamo.bob.pipeline.BuilderUtil;
+import com.dynamo.bob.fs.ResourceUtil;
 import com.dynamo.bob.pipeline.ProtoBuilders;
 import com.dynamo.gameobject.proto.GameObject.PropertyDesc;
 import com.dynamo.gameobject.proto.GameObject.PropertyType;
@@ -135,9 +135,9 @@ public class PropertiesUtil {
     public static String transformResourcePropertyValue(IResource resource, String value) throws CompileExceptionError {
         String ext = "." + FilenameUtils.getExtension(value);
         // This is not optimal, but arguably ok for this case.
-        value = BuilderUtil.replaceExt(value, ".material", ".materialc");
-        value = BuilderUtil.replaceExt(value, ".font", ".fontc");
-        value = BuilderUtil.replaceExt(value, ".buffer", ".bufferc");
+        value = ResourceUtil.replaceExt(value, ".material", ".materialc");
+        value = ResourceUtil.replaceExt(value, ".font", ".fontc");
+        value = ResourceUtil.replaceExt(value, ".buffer", ".bufferc");
         value = ProtoBuilders.replaceTextureName(value);
         try {
             if (TextureUtil.isAtlasFileType(ext))
@@ -147,6 +147,7 @@ public class PropertiesUtil {
         } catch (Exception e) {
             throw new CompileExceptionError(resource, -1, e.getMessage(), e);
         }
+        value = ResourceUtil.minifyPath(value);
         return value;
     }
 

--- a/engine/engine/src/test/gui/material_script_functions.script
+++ b/engine/engine/src/test/gui/material_script_functions.script
@@ -12,6 +12,8 @@
 -- CONDITIONS OF ANY KIND, either express or implied. See the License for the
 -- specific language governing permissions and limitations under the License.
 
+go.property("my_material_a", resource.material("/gui/material_script_functions_a.material"))
+go.property("my_material_b", resource.material("/gui/material_script_functions_b.material"))
 go.property("my_material", resource.material())
 
 local ret_code = 0
@@ -24,16 +26,16 @@ local function assert_cond(assert_that)
 end
 
 function do_test(self)
-    assert_cond(go.get("#gui", "materials", { key = "material_a" }) == hash("/gui/material_script_functions_a.materialc"))
-    assert_cond(go.get("#gui", "materials", { key = "material_b" }) == hash("/gui/material_script_functions_b.materialc"))
+    assert_cond(go.get("#gui", "materials", { key = "material_a" }) == self.my_material_a)
+    assert_cond(go.get("#gui", "materials", { key = "material_b" }) == self.my_material_b)
 
     -- replace material_a with our custom material (material_c)
     go.set("#gui", "materials", self.my_material, { key = "material_a" })
-    assert_cond(go.get("#gui", "materials", { key = "material_a" }) == hash("/gui/material_script_functions_c.materialc"))
+    assert_cond(go.get("#gui", "materials", { key = "material_a" }) == self.my_material)
 
     -- create a named material slot in the list with our custom material (material_c)
     go.set("#gui", "materials", self.my_material, { key = "my_custom_material" })
-    assert_cond(go.get("#gui", "materials", { key = "my_custom_material" }) == hash("/gui/material_script_functions_c.materialc"))
+    assert_cond(go.get("#gui", "materials", { key = "my_custom_material" }) == self.my_material)
 end
 
 function do_exit(self)

--- a/engine/engine/src/test/wscript
+++ b/engine/engine/src/test/wscript
@@ -76,7 +76,7 @@ def build(bld):
     if platform == 'win32':
         platform = 'x86-win32'
 
-    bob_flags = []
+    bob_flags = ['--variant=debug']
     bob_flags.append("--platform=%s" % platform)
     if Options.options.use_vanilla_lua:
         bob_flags.append("--use-vanilla-lua")


### PR DESCRIPTION
This change helps projects with lots of resources as it likely will mean they have nested resources in many folders.
It will convert internal paths from the form `/very/long/path/to/my/resource.type` into `/0123/4567/890a/bcde.type`, so the savings will vary between projects.

Note: Currently, this option is experimental.

To use this feature, pass `--experimental-path-minification` to `bob.jar` when bundling.

Fixes https://github.com/defold/defold/issues/9918

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
