### PR TITLE
Ensure bob and the editor produce identical atlas data

### DIFF
--- a/editor/src/clj/editor/atlas.clj
+++ b/editor/src/clj/editor/atlas.clj
@@ -59,7 +59,7 @@
             [util.murmur :as murmur])
   (:import [com.dynamo.bob.pipeline AtlasUtil]
            [com.dynamo.bob.textureset TextureSetGenerator$LayoutResult TextureSetLayout]
-           [com.dynamo.gamesys.proto AtlasProto$Atlas AtlasProto$AtlasAnimation AtlasProto$AtlasImage TextureSetProto$TextureSet Tile$Playback]
+           [com.dynamo.gamesys.proto AtlasProto$Atlas AtlasProto$AtlasAnimation AtlasProto$AtlasImage TextureSetProto$TextureSet Tile$Playback Tile$SpriteTrimmingMode]
            [com.jogamp.opengl GL GL2]
            [editor.types Animation Image]
            [java.lang.ref WeakReference]
@@ -591,29 +591,30 @@
     (count (.layouts ^TextureSetGenerator$LayoutResult (:layout layout-data)))
     texture/non-paged-page-count))
 
-(defn- single-frame-animation-images? [animation-images]
-  (every? #(= 1 (count %)) animation-images))
+(defn- atlas-image-sort-key
+  [{:keys [path sprite-trim-mode]}]
+  [(resource/proj-path path)
+   (.getNumber ^Tile$SpriteTrimmingMode (protobuf/val->pb-enum Tile$SpriteTrimmingMode sprite-trim-mode))])
 
-(defn- single-frame-animations? [animations]
-  (every? #(= 1 (count (:images %))) animations))
+(defn- explicit-animation-ids [anim-ddf]
+  (into #{} (keep :id) anim-ddf))
 
-(defn- sort-single-frame-animation-images [animation-images]
-  (if (single-frame-animation-images? animation-images)
-    (sort-by (comp resource/proj-path :path first) animation-images)
-    animation-images))
-
-(defn- sort-single-frame-animations [animations]
-  (if (single-frame-animations? animations)
-    (sort-by (comp resource/proj-path :path first :images) animations)
-    animations))
-
-(defn- sort-images-by-path-when-single-frame-animations [images animations]
-  (if (single-frame-animations? animations)
-    (sort-by (comp resource/proj-path :path) images)
-    images))
+;; Sort like in Bob
+(defn- sort-animations [animations anim-ddf]
+  (let [explicit-ids (explicit-animation-ids anim-ddf)
+        [explicit-animations top-level-image-animations]
+        (reduce (fn [[explicit implicit] animation]
+                  (if (contains? explicit-ids (:id animation))
+                    [(conj explicit animation) implicit]
+                    [explicit (conj implicit animation)]))
+                [[] []]
+                animations)]
+    ;; Bob keeps explicit animations in atlas order and appends sorted top-level image animations.
+    (into explicit-animations
+          (sort-by (comp atlas-image-sort-key first :images) top-level-image-animations))))
 
 (g/defnk produce-layout-data-generator
-  [_node-id animation-images all-atlas-images extrude-borders inner-padding margin max-page-size :as args]
+  [_node-id animations anim-ddf all-atlas-images extrude-borders inner-padding margin max-page-size :as args]
   ;; The TextureSetGenerator.calculateLayout() method inherited from Bob also
   ;; compiles a TextureSetProto$TextureSet including the animation data in
   ;; addition to generating the layout. This means that modifying a property on
@@ -624,12 +625,13 @@
   ;; to the TextureSetGenerator.calculateLayout() method that only includes data
   ;; that can affect the layout.
   (or (validate-layout-properties _node-id margin inner-padding extrude-borders)
-      (let [sorted-animation-images (sort-single-frame-animation-images animation-images)
+      (let [sorted-animations (sort-animations animations anim-ddf)
+            sorted-animation-images (mapv :images sorted-animations)
             fake-animations (mapv make-animation
                                   (repeat "")
                                   sorted-animation-images)
             augmented-args (-> args
-                               (dissoc :_node-id :animation-images)
+                               (dissoc :_node-id :animations :anim-ddf)
                                (assoc :animations fake-animations
                                       :digest-ignored/error-node-id _node-id))]
         {:f generate-texture-set-data
@@ -678,9 +680,9 @@
   ;; In order to produce a valid TextureSetResult, we complete the protobuf
   ;; animations inside the embedded TextureSet with our animation properties.
   [anim-ddf animations layout-data all-atlas-images rename-patterns]
-  (let [sorted-animations (sort-single-frame-animations animations)
-        sorted-all-atlas-images (sort-images-by-path-when-single-frame-animations all-atlas-images sorted-animations)
-        explicit-animation-ids (into #{} (keep :id) anim-ddf)
+  (let [sorted-animations (sort-animations animations anim-ddf)
+        sorted-all-atlas-images (sort-by atlas-image-sort-key all-atlas-images)
+        explicit-animation-id-set (explicit-animation-ids anim-ddf)
         incomplete-ddf-texture-set (:texture-set layout-data)
         incomplete-ddf-animations (:animations incomplete-ddf-texture-set)
         animation-present-in-ddf? (comp coll/not-empty :images)
@@ -707,7 +709,7 @@
                                         (fn [{:keys [id images]}]
                                           (e/map (fn [image]
                                                    (murmur/hash64
-                                                     (if (contains? explicit-animation-ids id)
+                                                     (if (contains? explicit-animation-id-set id)
                                                        (texture-set-gen/resource-id (:path image) id rename-patterns)
                                                        (texture-set-gen/resource-id (:path image) rename-patterns))))
                                                  images)))

--- a/editor/src/clj/editor/atlas.clj
+++ b/editor/src/clj/editor/atlas.clj
@@ -591,6 +591,27 @@
     (count (.layouts ^TextureSetGenerator$LayoutResult (:layout layout-data)))
     texture/non-paged-page-count))
 
+(defn- single-frame-animation-images? [animation-images]
+  (every? #(= 1 (count %)) animation-images))
+
+(defn- single-frame-animations? [animations]
+  (every? #(= 1 (count (:images %))) animations))
+
+(defn- sort-single-frame-animation-images [animation-images]
+  (if (single-frame-animation-images? animation-images)
+    (sort-by (comp resource/proj-path :path first) animation-images)
+    animation-images))
+
+(defn- sort-single-frame-animations [animations]
+  (if (single-frame-animations? animations)
+    (sort-by (comp resource/proj-path :path first :images) animations)
+    animations))
+
+(defn- sort-images-by-path-when-single-frame-animations [images animations]
+  (if (single-frame-animations? animations)
+    (sort-by (comp resource/proj-path :path) images)
+    images))
+
 (g/defnk produce-layout-data-generator
   [_node-id animation-images all-atlas-images extrude-borders inner-padding margin max-page-size :as args]
   ;; The TextureSetGenerator.calculateLayout() method inherited from Bob also
@@ -603,9 +624,10 @@
   ;; to the TextureSetGenerator.calculateLayout() method that only includes data
   ;; that can affect the layout.
   (or (validate-layout-properties _node-id margin inner-padding extrude-borders)
-      (let [fake-animations (mapv make-animation
+      (let [sorted-animation-images (sort-single-frame-animation-images animation-images)
+            fake-animations (mapv make-animation
                                   (repeat "")
-                                  animation-images)
+                                  sorted-animation-images)
             augmented-args (-> args
                                (dissoc :_node-id :animation-images)
                                (assoc :animations fake-animations
@@ -655,12 +677,15 @@
   ;; contain the animation metadata since it was produced from fake animations.
   ;; In order to produce a valid TextureSetResult, we complete the protobuf
   ;; animations inside the embedded TextureSet with our animation properties.
-  [animations layout-data all-atlas-images rename-patterns]
-  (let [incomplete-ddf-texture-set (:texture-set layout-data)
+  [anim-ddf animations layout-data all-atlas-images rename-patterns]
+  (let [sorted-animations (sort-single-frame-animations animations)
+        sorted-all-atlas-images (sort-images-by-path-when-single-frame-animations all-atlas-images sorted-animations)
+        explicit-animation-ids (into #{} (keep :id) anim-ddf)
+        incomplete-ddf-texture-set (:texture-set layout-data)
         incomplete-ddf-animations (:animations incomplete-ddf-texture-set)
         animation-present-in-ddf? (comp coll/not-empty :images)
         animations-in-ddf (filter animation-present-in-ddf?
-                                  animations)
+                                  sorted-animations)
         complete-ddf-animations (mapv complete-ddf-animation
                                       incomplete-ddf-animations
                                       animations-in-ddf)
@@ -676,13 +701,17 @@
         fixed-image-name-hashes (-> []
                                     (into
                                       (map #(-> % :path (texture-set-gen/resource-id rename-patterns) murmur/hash64))
-                                      all-atlas-images)
+                                      sorted-all-atlas-images)
                                     (into
                                       (mapcat
                                         (fn [{:keys [id images]}]
-                                          (e/map #(-> % :path (texture-set-gen/resource-id id rename-patterns) murmur/hash64)
+                                          (e/map (fn [image]
+                                                   (murmur/hash64
+                                                     (if (contains? explicit-animation-ids id)
+                                                       (texture-set-gen/resource-id (:path image) id rename-patterns)
+                                                       (texture-set-gen/resource-id (:path image) rename-patterns))))
                                                  images)))
-                                      animations))
+                                      animations-in-ddf))
         complete-ddf-texture-set (assoc incomplete-ddf-texture-set
                                    :animations complete-ddf-animations
                                    :image-name-hashes fixed-image-name-hashes)]

--- a/editor/src/clj/editor/atlas.clj
+++ b/editor/src/clj/editor/atlas.clj
@@ -59,7 +59,7 @@
             [util.murmur :as murmur])
   (:import [com.dynamo.bob.pipeline AtlasUtil]
            [com.dynamo.bob.textureset TextureSetGenerator$LayoutResult TextureSetLayout]
-           [com.dynamo.gamesys.proto AtlasProto$Atlas AtlasProto$AtlasAnimation AtlasProto$AtlasImage TextureSetProto$TextureSet Tile$Playback Tile$SpriteTrimmingMode]
+           [com.dynamo.gamesys.proto AtlasProto$Atlas AtlasProto$AtlasAnimation AtlasProto$AtlasImage TextureSetProto$TextureSet Tile$Playback]
            [com.jogamp.opengl GL GL2]
            [editor.types Animation Image]
            [java.lang.ref WeakReference]
@@ -591,11 +591,6 @@
     (count (.layouts ^TextureSetGenerator$LayoutResult (:layout layout-data)))
     texture/non-paged-page-count))
 
-(defn- atlas-image-sort-key
-  [{:keys [path sprite-trim-mode]}]
-  [(resource/proj-path path)
-   (.getNumber ^Tile$SpriteTrimmingMode (protobuf/val->pb-enum Tile$SpriteTrimmingMode sprite-trim-mode))])
-
 (defn- explicit-animation-ids [anim-ddf]
   (into #{} (keep :id) anim-ddf))
 
@@ -611,7 +606,7 @@
                 animations)]
     ;; Bob keeps explicit animations in atlas order and appends sorted top-level image animations.
     (into explicit-animations
-          (sort-by (comp atlas-image-sort-key first :images) top-level-image-animations))))
+          (sort-by (comp texture-set-gen/image-sort-key first :images) top-level-image-animations))))
 
 (g/defnk produce-layout-data-generator
   [_node-id animations anim-ddf all-atlas-images extrude-borders inner-padding margin max-page-size :as args]
@@ -681,7 +676,7 @@
   ;; animations inside the embedded TextureSet with our animation properties.
   [anim-ddf animations layout-data all-atlas-images rename-patterns]
   (let [sorted-animations (sort-animations animations anim-ddf)
-        sorted-all-atlas-images (sort-by atlas-image-sort-key all-atlas-images)
+        sorted-all-atlas-images (sort-by texture-set-gen/image-sort-key all-atlas-images)
         explicit-animation-id-set (explicit-animation-ids anim-ddf)
         incomplete-ddf-texture-set (:texture-set layout-data)
         incomplete-ddf-animations (:animations incomplete-ddf-texture-set)

--- a/editor/src/clj/editor/pipeline/texture_set_gen.clj
+++ b/editor/src/clj/editor/pipeline/texture_set_gen.clj
@@ -95,6 +95,11 @@
   [sprite-trim-mode]
   (protobuf/val->pb-enum Tile$SpriteTrimmingMode sprite-trim-mode))
 
+(defn- image-sort-key
+  [{:keys [path sprite-trim-mode]}]
+  [(resource/proj-path path)
+   (.getNumber ^Tile$SpriteTrimmingMode (sprite-trim-mode->enum sprite-trim-mode))])
+
 (defn resource-id
   ([resource rename-patterns]
    (resource-id resource nil rename-patterns))
@@ -155,7 +160,7 @@
   [animations images margin inner-padding extrude-borders max-page-size]
   ;; NOTE: Images order matters when generating the layouts, especially if they are of the same size.
   ;; Since the SHA1 for the packed-page-images-generator is insensitive to order, things could get out of sync
-  (let [images (sort-by #(-> % :path resource/proj-path) images)
+  (let [images (sort-by image-sort-key images)
         sprite-geometries (mapv make-image-sprite-geometry images)]
     (g/precluding-errors sprite-geometries
       (let [img-to-index (into {}

--- a/editor/src/clj/editor/pipeline/texture_set_gen.clj
+++ b/editor/src/clj/editor/pipeline/texture_set_gen.clj
@@ -95,7 +95,7 @@
   [sprite-trim-mode]
   (protobuf/val->pb-enum Tile$SpriteTrimmingMode sprite-trim-mode))
 
-(defn- image-sort-key
+(defn image-sort-key
   [{:keys [path sprite-trim-mode]}]
   [(resource/proj-path path)
    (.getNumber ^Tile$SpriteTrimmingMode (sprite-trim-mode->enum sprite-trim-mode))])

--- a/editor/test/integration/atlas_test.clj
+++ b/editor/test/integration/atlas_test.clj
@@ -84,6 +84,19 @@
                (murmur/hash64 "left_hud")}
              (set animation-hashes))))))
 
+(deftest mixed-atlas-animation-order-matches-bob
+  (test-util/with-loaded-project
+    (let [atlas (test-util/resource-node project "/graphics/mixed_order.atlas")
+          ddf-texture-set (g/node-value atlas :texture-set)
+          animation-ids-in-ddf (mapv :id (:animations ddf-texture-set))]
+      (is (= ["anim_a"
+              "anim_b"
+              "anim_c"
+              "ball"
+              "pow"
+              "right_hud"]
+             animation-ids-in-ddf)))))
+
 (deftest sprite-trim-mode-image-io-error
   (test-support/with-clean-system
     (let [workspace (test-util/setup-scratch-workspace! world "test/resources/image_project")

--- a/editor/test/integration/atlas_test.clj
+++ b/editor/test/integration/atlas_test.clj
@@ -21,7 +21,8 @@
             [editor.texture-util :as texture-util]
             [editor.workspace :as workspace]
             [integration.test-util :as test-util]
-            [support.test-support :as test-support]))
+            [support.test-support :as test-support]
+            [util.murmur :as murmur]))
 
 (deftest valid-fps
   (test-util/with-loaded-project
@@ -58,6 +59,30 @@
                "diamond_dogs"
                "test_anim"}
              animation-ids-in-ddf)))))
+
+(deftest top-level-images-sorted-in-single-frame-atlas
+  (test-util/with-loaded-project
+    (let [atlas (test-util/resource-node project "/graphics/top_level_unsorted.atlas")
+          ddf-texture-set (g/node-value atlas :texture-set)
+          animation-ids-in-ddf (mapv :id (:animations ddf-texture-set))]
+      (is (= ["ball"
+              "left_hud"]
+             animation-ids-in-ddf)))))
+
+(deftest image-name-hashes-prefix-rules-match-bob
+  (test-util/with-loaded-project
+    (let [atlas (test-util/resource-node project "/graphics/atlas.atlas")
+          ddf-texture-set (g/node-value atlas :texture-set)
+          image-name-hashes (vec (:image-name-hashes ddf-texture-set))
+          tile-count (:tile-count ddf-texture-set)
+          animation-hashes (subvec image-name-hashes tile-count)]
+      (is (= [(murmur/hash64 "ball")
+              (murmur/hash64 "left_hud")]
+             (subvec image-name-hashes 0 tile-count)))
+      (is (= #{(murmur/hash64 "anim/ball")
+               (murmur/hash64 "ball")
+               (murmur/hash64 "left_hud")}
+             (set animation-hashes))))))
 
 (deftest sprite-trim-mode-image-io-error
   (test-support/with-clean-system

--- a/editor/test/resources/test_project/graphics/mixed_order.atlas
+++ b/editor/test/resources/test_project/graphics/mixed_order.atlas
@@ -1,0 +1,38 @@
+images {
+  image: "/graphics/right_hud.png"
+}
+images {
+  image: "/graphics/ball.png"
+}
+images {
+  image: "/graphics/pow.png"
+}
+animations {
+  id: "anim_a"
+  images {
+    image: "/graphics/right_hud.png"
+  }
+  images {
+    image: "/graphics/ball.png"
+  }
+  playback: PLAYBACK_LOOP_FORWARD
+}
+animations {
+  id: "anim_b"
+  images {
+    image: "/graphics/right_hud.png"
+  }
+  playback: PLAYBACK_LOOP_FORWARD
+}
+animations {
+  id: "anim_c"
+  images {
+    image: "/graphics/right_hud.png"
+  }
+  images {
+    image: "/graphics/pow.png"
+  }
+  playback: PLAYBACK_LOOP_FORWARD
+}
+margin: 8
+extrude_borders: 2

--- a/editor/test/resources/test_project/graphics/top_level_unsorted.atlas
+++ b/editor/test/resources/test_project/graphics/top_level_unsorted.atlas
@@ -1,0 +1,8 @@
+images {
+  image: "/graphics/left_hud.png"
+}
+images {
+  image: "/graphics/ball.png"
+}
+margin: 0
+extrude_borders: 0


### PR DESCRIPTION
Fix an issue where atlas data generated by bob can differ from the editor’s output. In some cases, this may lead to confusion when accessing atlas data through runtime APIs.

### Technical changes

This PR makes fixes in sorting to make and in a way how keys formed to make it the same way as bob does.
As result it makes files almost identical. The only diff I see is diff in FPS, But i decided do not tough it since I'm not sure for 100% which one is right one

Diff before:
```
diff bob.txt editor.txt                                                                                          !10141
1c1
< texture : "/example/main.texturec" len: 22
---
> texture : "/_generated_3b27f909.texturec" len: 29
3a4
> texture_hash : 0      (0x0000000000000000) TYPE_UINT64
5c6
<   id : "New Animation" len: 13
---
>   id : "logo_vertical" len: 13
8a10,18
>   end : 5     (0x00000005) TYPE_UINT32
>   fps : 30    (0x0000001e) TYPE_UINT32
>   playback : PLAYBACK_NONE TYPE_ENUM
>   flip_horizontal : 0 (0x00000000) TYPE_UINT32
>   flip_vertical : 0   (0x00000000) TYPE_UINT32
>   id : "ramp" len: 4
>   width : 256 (0x00000100) TYPE_UINT32
>   height : 16 (0x00000010) TYPE_UINT32
>   start : 5   (0x00000005) TYPE_UINT32
11c21
<   playback : PLAYBACK_LOOP_FORWARD TYPE_ENUM
---
>   playback : PLAYBACK_NONE TYPE_ENUM
14,16c24,26
<   id : "1" len: 1
<   width : 500 (0x000001f4) TYPE_UINT32
<   height : 589        (0x0000024d) TYPE_UINT32
---
>   id : "noise" len: 5
>   width : 512 (0x00000200) TYPE_UINT32
>   height : 512        (0x00000200) TYPE_UINT32
20c30
<   playback : PLAYBACK_LOOP_FORWARD TYPE_ENUM
---
>   playback : PLAYBACK_NONE TYPE_ENUM
23c33
<   id : "3" len: 1
---
>   id : "logo_horizontal" len: 15
25c35
<   height : 589        (0x0000024d) TYPE_UINT32
---
>   height : 105        (0x00000069) TYPE_UINT32
27c37
<   end : 13    (0x0000000d) TYPE_UINT32
---
>   end : 8     (0x00000008) TYPE_UINT32
29c39
<   playback : PLAYBACK_LOOP_FORWARD TYPE_ENUM
---
>   playback : PLAYBACK_NONE TYPE_ENUM
32c42
<   id : "4" len: 1
---
>   id : "New Animation" len: 13
35,36c45,46
<   start : 13  (0x0000000d) TYPE_UINT32
<   end : 19    (0x00000013) TYPE_UINT32
---
>   start : 8   (0x00000008) TYPE_UINT32
>   end : 10    (0x0000000a) TYPE_UINT32
41,56c51,57
<   id : "noise" len: 5
<   width : 512 (0x00000200) TYPE_UINT32
<   height : 512        (0x00000200) TYPE_UINT32
<   start : 19  (0x00000013) TYPE_UINT32
<   end : 20    (0x00000014) TYPE_UINT32
<   fps : 0     (0x00000000) TYPE_UINT32
<   playback : PLAYBACK_NONE TYPE_ENUM
<   flip_horizontal : 0 (0x00000000) TYPE_UINT32
<   flip_vertical : 0   (0x00000000) TYPE_UINT32
<   id : "ramp" len: 4
<   width : 256 (0x00000100) TYPE_UINT32
<   height : 16 (0x00000010) TYPE_UINT32
<   start : 20  (0x00000014) TYPE_UINT32
<   end : 21    (0x00000015) TYPE_UINT32
<   fps : 0     (0x00000000) TYPE_UINT32
<   playback : PLAYBACK_NONE TYPE_ENUM
---
>   id : "1" len: 1
>   width : 500 (0x000001f4) TYPE_UINT32
>   height : 589        (0x0000024d) TYPE_UINT32
>   start : 10  (0x0000000a) TYPE_UINT32
>   end : 11    (0x0000000b) TYPE_UINT32
>   fps : 30    (0x0000001e) TYPE_UINT32
>   playback : PLAYBACK_LOOP_FORWARD TYPE_ENUM
59c60
<   id : "logo_horizontal" len: 15
---
>   id : "3" len: 1
61,65c62,66
<   height : 105        (0x00000069) TYPE_UINT32
<   start : 21  (0x00000015) TYPE_UINT32
<   end : 22    (0x00000016) TYPE_UINT32
<   fps : 0     (0x00000000) TYPE_UINT32
<   playback : PLAYBACK_NONE TYPE_ENUM
---
>   height : 589        (0x0000024d) TYPE_UINT32
>   start : 11  (0x0000000b) TYPE_UINT32
>   end : 17    (0x00000011) TYPE_UINT32
>   fps : 30    (0x0000001e) TYPE_UINT32
>   playback : PLAYBACK_LOOP_FORWARD TYPE_ENUM
68c69
<   id : "logo_vertical" len: 13
---
>   id : "4" len: 1
71c72
<   start : 22  (0x00000016) TYPE_UINT32                                                                                    ---
>   start : 17  (0x00000011) TYPE_UINT32                                                                                    73,74c74,75
<   fps : 0     (0x00000000) TYPE_UINT32                                                                                    <   playback : PLAYBACK_NONE TYPE_ENUM
---                                                                                                                         >   fps : 30    (0x0000001e) TYPE_UINT32
>   playback : PLAYBACK_LOOP_FORWARD TYPE_ENUM                                                                              77a79,80
> tile_width : 0        (0x00000000) TYPE_UINT32                                                                            > tile_height : 0       (0x00000000) TYPE_UINT32
81c84                                                                                                                       < image_name_hashes : 15198975908318134433      (0xd2ed9c0f9d05c0a1) TYPE_UINT64
---                                                                                                                         > image_name_hashes : 3649236778466120652       (0x32a4b183f9c393cc) TYPE_UINT64
82a86                                                                                                                       > image_name_hashes : 15198975908318134433      (0xd2ed9c0f9d05c0a1) TYPE_UINT64
84c88,91                                                                                                                    < image_name_hashes : 3649236778466120652       (0x32a4b183f9c393cc) TYPE_UINT64
---                                                                                                                         > image_name_hashes : 13579938526822381688      (0xbc75a223fae3b878) TYPE_UINT64
> image_name_hashes : 14875981499123853313      (0xce721a5b6c8f6801) TYPE_UINT64                                            > image_name_hashes : 1193521887809061681       (0x10903dd55a834331) TYPE_UINT64
> image_name_hashes : 5190263163758375997       (0x480784d9269cf43d) TYPE_UINT64                                            100,103d106
< image_name_hashes : 15198975908318134433      (0xd2ed9c0f9d05c0a1) TYPE_UINT64                                            < image_name_hashes : 2310752616288175098       (0x20117142f9a943fa) TYPE_UINT64
< image_name_hashes : 11945998815952482054      (0xa5c8b6a16815af06) TYPE_UINT64                                            < image_name_hashes : 3649236778466120652       (0x32a4b183f9c393cc) TYPE_UINT64
109a113,114                                                                                                                 > frame_indices : 0     (0x00000000) TYPE_UINT32
> frame_indices : 2     (0x00000002) TYPE_UINT32                                                                            110a116
> frame_indices : 1     (0x00000001) TYPE_UINT32                                                                            111a118
> frame_indices : 3     (0x00000003) TYPE_UINT32                                                                            123,128c130,131
< frame_indices : 0     (0x00000000) TYPE_UINT32                                                                            < frame_indices : 1     (0x00000001) TYPE_UINT32
< frame_indices : 2     (0x00000002) TYPE_UINT32                                                                            < frame_indices : 3     (0x00000003) TYPE_UINT32
< tex_coords : [0080823e0000fb3e0080823e00807d3f0040013f00807d3f0040013f0000fb3e0080823e0000ed3e0080823e0000f53e0080c23e0000f53e0080c23e0000ed3e0000a03b00009a3e0000a03b0080ce3e00007f3e0080ce3e00007f3e00009a3e0000a03b0080d43e0000a03b00807d3f00007f3e00807d3f00007f3e0080d43e0000a03b0080d43e0000a03b00807d3f00007f3e00807d3f00007f3e0080d43e0080823e0000ed3e0080823e0000f53e0080c23e0000f53e0080c23e0000ed3e0000a03b0080d43e0000a03b00807d3f00007f3e00807d3f00007f3e0080d43e0000a03b0080d43e0000a03b00807d3f00007f3e00807d3f00007f3e0080d43e0080823e0000ed3e0080823e0000f53e0080c23e0000f53e0080c23e0000ed3e0080823e0000fb3e0080823e00807d3f0040013f00807d3f0040013f0000fb3e0080823e0000ed3e0080823e0000f53e0080c23e0000f53e0080c23e0000ed3e0000a03b0080d43e0000a03b00807d3f00007f3e00807d3f00007f3e0080d43e0080823e0000ed3e0080823e0000f53e0080c23e0000f53e0080c23e0000ed3e0000a03b0080d43e0000a03b00807d3f00007f3e00807d3f00007f3e0080d43e0080823e0000ed3e0080823e0000f53e0080c23e0000f53e0080c23e0000ed3e0080823e0000fb3e0080823e00807d3f0040013f00807d3f0040013f0000fb3e0080823e0000ed3e0080823e0000f53e0080c23e0000f53e0080c23e0000ed3e0000a03b0080d43e0000a03b00807d3f00007f3e00807d3f00007f3e0080d43e0080823e0000ed3e0080823e0000f53e0080c23e0000f53e0080c23e0000ed3e0080823e0000fb3e0080823e00807d3f0040013f00807d3f0040013f0000fb3e0080823e0000ed3e0080823e0000f53e0080c23e0000f53e0080c23e0000ed3e0000a03b00009a3e0000a03b0080ce3e00007f3e0080ce3e00007f3e00009a3e0000a03b0080d43e0000a03b00807d3f00007f3e00807d3f00007f3e0080d43e] len: 736                                                                                                                  < tex_dims : [000000440000004400008043000080410000fa430000d2420000fa43004013440000fa430040134400008043000080410000fa43004013440000fa43004013440000804300008041000000440000004400008043000080410000fa430040134400008043000080410000fa43004013440000804300008041000000440000004400008043000080410000fa43004013440000804300008041000000440000004400008043000080410000fa430000d2420000fa4300401344] len: 184
---
> tex_coords : [0080823e0000fb3e0080823e00807d3f0040013f00807d3f0040013f0000fb3e0080823e0000ed3e0080823e0000f53e0080c23e0000f53e0080c23e0000ed3e0000a03b00009a3e0000a03b0080ce3e00007f3e0080ce3e00007f3e00009a3e0000a03b0080d43e0000a03b00807d3f00007f3e00807d3f00007f3e0080d43e0000a03b0080d43e0000a03b00807d3f00007f3e00807d3f00007f3e0080d43e0080823e0000ed3e0080823e0000f53e0080c23e0000f53e0080c23e0000ed3e0080823e0000fb3e0080823e00807d3f0040013f00807d3f0040013f0000fb3e0000a03b00009a3e0000a03b0080ce3e00007f3e0080ce3e00007f3e00009a3e0000a03b0080d43e0000a03b00807d3f00007f3e00807d3f00007f3e0080d43e0080823e0000ed3e0080823e0000f53e0080c23e0000f53e0080c23e0000ed3e0000a03b0080d43e0000a03b00807d3f00007f3e00807d3f00007f3e0080d43e0000a03b0080d43e0000a03b00807d3f00007f3e00807d3f00007f3e0080d43e0080823e0000ed3e0080823e0000f53e0080c23e0000f53e0080c23e0000ed3e0080823e0000fb3e0080823e00807d3f0040013f00807d3f0040013f0000fb3e0080823e0000ed3e0080823e0000f53e0080c23e0000f53e0080c23e0000ed3e0000a03b0080d43e0000a03b00807d3f00007f3e00807d3f00007f3e0080d43e0080823e0000ed3e0080823e0000f53e0080c23e0000f53e0080c23e0000ed3e0000a03b0080d43e0000a03b00807d3f00007f3e00807d3f00007f3e0080d43e0080823e0000ed3e0080823e0000f53e0080c23e0000f53e0080c23e0000ed3e0080823e0000fb3e0080823e00807d3f0040013f00807d3f0040013f0000fb3e0080823e0000ed3e0080823e0000f53e0080c23e0000f53e0080c23e0000ed3e0000a03b0080d43e0000a03b00807d3f00007f3e00807d3f00007f3e0080d43e0080823e0000ed3e0080823e0000f53e0080c23e0000f53e0080c23e0000ed3e] len: 736
> tex_dims : [000000440000004400008043000080410000fa430000d2420000fa43004013440000fa4300401344000080430000804100000044000000440000fa430000d2420000fa430040134400008043000080410000fa43004013440000fa43004013440000804300008041000000440000004400008043000080410000fa430040134400008043000080410000fa43004013440000804300008041000000440000004400008043000080410000fa43004013440000804300008041] len: 184
```

Diff after:
```
diff bob.txt editor.txt 
1c1
< texture : "/example/main.texturec" len: 22
---
> texture : "/_generated_2c83c380.texturec" len: 29
3a4
> texture_hash : 0      (0x0000000000000000) TYPE_UINT64
37c38
<   fps : 0     (0x00000000) TYPE_UINT32
---
>   fps : 30    (0x0000001e) TYPE_UINT32
46c47
<   fps : 0     (0x00000000) TYPE_UINT32
---
>   fps : 30    (0x0000001e) TYPE_UINT32
55c56
<   fps : 0     (0x00000000) TYPE_UINT32
---
>   fps : 30    (0x0000001e) TYPE_UINT32
64c65
<   fps : 0     (0x00000000) TYPE_UINT32
---
>   fps : 30    (0x0000001e) TYPE_UINT32
68a70,71
> tile_width : 0        (0x00000000) TYPE_UINT32
> tile_height : 0       (0x00000000) TYPE_UINT32
```