### PR TITLE
Outline returns nil for getLastVisibleCell when it's closed during startup

### DIFF
--- a/editor/src/clj/editor/ui.clj
+++ b/editor/src/clj/editor/ui.clj
@@ -1163,7 +1163,7 @@
          last-index (int (last selected-indices))
          skin ^ExtendedTreeViewSkin (.getSkin tree-view)
          flow (.getVirtualFlowInstance skin)
-         last-visible-idx (int (.getIndex (.getLastVisibleCell flow)))]
+         last-visible-idx (or (some-> flow .getLastVisibleCell .getIndex int) 0)]
      (when (and (>= last-index first-index 0) (.shouldScrollTo skin first-index))
        (run-later
          (if (> last-index last-visible-idx)

--- a/editor/src/clj/editor/ui.clj
+++ b/editor/src/clj/editor/ui.clj
@@ -1163,7 +1163,7 @@
          last-index (int (last selected-indices))
          skin ^ExtendedTreeViewSkin (.getSkin tree-view)
          flow (.getVirtualFlowInstance skin)
-         last-visible-idx (or (some-> flow .getLastVisibleCell .getIndex int) 0)]
+         last-visible-idx (int (or (some-> flow .getLastVisibleCell .getIndex) 0))]
      (when (and (>= last-index first-index 0) (.shouldScrollTo skin first-index))
        (run-later
          (if (> last-index last-visible-idx)


### PR DESCRIPTION
If you close the Outline View, then restart the editor, getLastVisibleCell returns nil. Fixes issue introduced in https://github.com/defold/defold/pull/11752