### PR TITLE
Fix floating point type mismatch for atlas images

### DIFF
--- a/editor/src/clj/editor/atlas.clj
+++ b/editor/src/clj/editor/atlas.clj
@@ -242,10 +242,10 @@
                                               :precision 0.1})))
 
   (property pivot-x g/Num
-            (default (protobuf/default AtlasProto$AtlasImage :pivot-x))
+            (default (double (protobuf/default AtlasProto$AtlasImage :pivot-x)))
             (dynamic visible (g/constantly false)))
   (property pivot-y g/Num
-            (default (protobuf/default AtlasProto$AtlasImage :pivot-y))
+            (default (double (protobuf/default AtlasProto$AtlasImage :pivot-y)))
             (dynamic visible (g/constantly false)))
 
   (property sprite-trim-mode g/Keyword (default (protobuf/default AtlasProto$AtlasImage :sprite-trim-mode))

--- a/editor/src/clj/editor/atlas.clj
+++ b/editor/src/clj/editor/atlas.clj
@@ -856,8 +856,8 @@
         (gu/set-properties-from-pb-map atlas-image AtlasProto$AtlasImage image-msg
           image :image
           sprite-trim-mode :sprite-trim-mode
-          pivot-x :pivot-x
-          pivot-y :pivot-y)
+          pivot-x (double :pivot-x)
+          pivot-y (double :pivot-y))
         (attach-fn parent atlas-image)))))
 
 (def ^:private make-image-nodes-in-atlas (partial make-image-nodes attach-image-to-atlas))

--- a/editor/src/clj/editor/atlas.clj
+++ b/editor/src/clj/editor/atlas.clj
@@ -236,16 +236,16 @@
             (value (g/fnk [pivot-x pivot-y] [pivot-x pivot-y]))
             (set (fn [_evaluation-context self old-value new-value]
                    (concat
-                     (g/set-property self :pivot-x (new-value 0))
-                     (g/set-property self :pivot-y (new-value 1)))))
+                     (g/set-property self :pivot-x (float (new-value 0)))
+                     (g/set-property self :pivot-y (float (new-value 1))))))
             (dynamic edit-type (g/constantly {:type types/Vec2 :labels ["X" "Y"]
                                               :precision 0.1})))
 
   (property pivot-x g/Num
-            (default (double (protobuf/default AtlasProto$AtlasImage :pivot-x)))
+            (default (protobuf/default AtlasProto$AtlasImage :pivot-x))
             (dynamic visible (g/constantly false)))
   (property pivot-y g/Num
-            (default (double (protobuf/default AtlasProto$AtlasImage :pivot-y)))
+            (default (protobuf/default AtlasProto$AtlasImage :pivot-y))
             (dynamic visible (g/constantly false)))
 
   (property sprite-trim-mode g/Keyword (default (protobuf/default AtlasProto$AtlasImage :sprite-trim-mode))
@@ -856,8 +856,8 @@
         (gu/set-properties-from-pb-map atlas-image AtlasProto$AtlasImage image-msg
           image :image
           sprite-trim-mode :sprite-trim-mode
-          pivot-x (double :pivot-x)
-          pivot-y (double :pivot-y))
+          pivot-x :pivot-x
+          pivot-y :pivot-y)
         (attach-fn parent atlas-image)))))
 
 (def ^:private make-image-nodes-in-atlas (partial make-image-nodes attach-image-to-atlas))
@@ -1070,8 +1070,8 @@
         {:keys [rotated ^double pivot-x ^double pivot-y]} geometry
         pivot-x (+ 0.5 pivot-x)
         pivot-y (- 0.5 pivot-y)
-        delta-x (/ (cond-> ^double (.x delta) rotated -) width)
-        delta-y (/ ^double (.y delta) height)
+        delta-x (/ (cond-> (.x delta) rotated -) width)
+        delta-y (/ (.y delta) height)
         pivot (if rotated
                 [(- pivot-x delta-y) (+ pivot-y delta-x)]
                 [(+ pivot-x delta-x) (- pivot-y delta-y)])]
@@ -1086,7 +1086,7 @@
         absolute-pivot-x (* pivot-x (if rotated height width))
         absolute-pivot-y (* pivot-y (if rotated width height))
         page-offset-x (get-rect-page-offset layout-width page)
-        x (+ x page-offset-x (if rotated (- width absolute-pivot-y) absolute-pivot-x))
+        x (+ x ^double page-offset-x (if rotated (- width absolute-pivot-y) absolute-pivot-x))
         y (+ y (- height (if rotated absolute-pivot-x absolute-pivot-y)))]
     [x y 0.0]))
 

--- a/editor/src/clj/editor/image_util.clj
+++ b/editor/src/clj/editor/image_util.clj
@@ -74,7 +74,7 @@
 
 (s/defn make-image :- Image
   [nm :- s/Any contents :- BufferedImage]
-  (Image. nm contents (.getWidth contents) (.getHeight contents) 0.5 0.5 :sprite-trim-mode-off))
+  (Image. nm contents (.getWidth contents) (.getHeight contents) (float 0.5) (float 0.5) :sprite-trim-mode-off))
 
 (s/defn blank-image :- BufferedImage
   ([space :- Rect]

--- a/editor/src/clj/editor/types.clj
+++ b/editor/src/clj/editor/types.clj
@@ -68,7 +68,7 @@
 
 ;; note - Int32 is a schema, not a value type
 (def Int32   (s/both s/Int (s/pred #(< Integer/MIN_VALUE % Integer/MAX_VALUE) 'int32?)))
-(def Float64 (s/pred #(instance? Double %) "double"))
+(def Float32 (s/pred #(instance? Float %) "float"))
 
 (g/deftype Icon    s/Str)
 
@@ -206,8 +206,8 @@
    contents :- (s/maybe BufferedImage)
    width    :- Int32
    height   :- Int32
-   pivot-x  :- Float64
-   pivot-y  :- Float64
+   pivot-x  :- Float32
+   pivot-y  :- Float32
    sprite-trim-mode :- sprite-trim-modes]
   ImageHolder
   (contents [this] contents))

--- a/editor/src/clj/editor/types.clj
+++ b/editor/src/clj/editor/types.clj
@@ -68,6 +68,7 @@
 
 ;; note - Int32 is a schema, not a value type
 (def Int32   (s/both s/Int (s/pred #(< Integer/MIN_VALUE % Integer/MAX_VALUE) 'int32?)))
+(def Float64 (s/pred #(instance? Double %) "double"))
 
 (g/deftype Icon    s/Str)
 
@@ -205,8 +206,8 @@
    contents :- (s/maybe BufferedImage)
    width    :- Int32
    height   :- Int32
-   pivot-x  :- s/Num
-   pivot-y  :- s/Num
+   pivot-x  :- Float64
+   pivot-y  :- Float64
    sprite-trim-mode :- sprite-trim-modes]
   ImageHolder
   (contents [this] contents))


### PR DESCRIPTION
Fix issue when creating new animations while reusing existing atlas images where the image would get temporarily duplicated into the atlas until a restart.

Fixes #11907

### Technical changes

```
message AtlasImage
{
    required string image                           = 1 [(resource) = true];
    optional SpriteTrimmingMode sprite_trim_mode    = 2 [default = SPRITE_TRIM_MODE_OFF];
    optional float  pivot_x                         = 3 [default = 0.5];
    optional float  pivot_y                         = 4 [default = 0.5];
}
```

It seems that the protobuf definition uses `float` but everywhere in the `atlas.clj` code we treat pivots as double, so this PR casts to double at the boundary. Also added an additional schema check to the `Image` record.
