### PR TITLE
Produce better local space vertices for sprites and particles

### DIFF
--- a/engine/gamesys/src/gamesys/components/comp_sprite.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sprite.cpp
@@ -804,6 +804,7 @@ namespace dmGameSystem
         uint8_t* vertices,
         uint8_t* indices,
         bool is_indices_16_bit,
+        bool has_world_position_attribute,
         bool has_local_position_attribute,
         const Matrix4& world_matrix,
         uint32_t vertex_offset,
@@ -938,7 +939,11 @@ namespace dmGameSystem
         ys[1] = sy * slice9.getW();
         ys[2] = 1 - sy * slice9.getY();
 
-        EnsureSize(*scratch_positions_world, SPRITE_VERTEX_COUNT_SLICE9);
+        if (has_world_position_attribute)
+        {
+            EnsureSize(*scratch_positions_world, SPRITE_VERTEX_COUNT_SLICE9);
+        }
+
         if (has_local_position_attribute)
         {
             EnsureSize(*scratch_positions_local, SPRITE_VERTEX_COUNT_SLICE9);
@@ -971,18 +976,25 @@ namespace dmGameSystem
         {
             for (int x=0; x<4; x++)
             {
-                // convert from [0,1] to [-0.5, 0.5]
-                float px = xs[x] - 0.5f;
-                float py = ys[y] - 0.5f;
-                Point3 p = Point3(px - pivot_x, py - pivot_y, 0);
-
-                // Local space has size applied; world = mtx_world * local (mtx_world has no scale)
-                Vector4 local_pos(p.getX() * sp_width, p.getY() * sp_height, 0.0f, 1.0f);
-                if (has_local_position_attribute)
+                if (has_local_position_attribute || has_world_position_attribute)
                 {
-                    (*scratch_positions_local)[vertex_index] = local_pos;
+                    // convert from [0,1] to [-0.5, 0.5]
+                    float px = xs[x] - 0.5f;
+                    float py = ys[y] - 0.5f;
+                    Point3 p = Point3(px - pivot_x, py - pivot_y, 0);
+
+                    // Local space has size applied; world = mtx_world * local (mtx_world has no scale)
+                    Vector4 local_pos(p.getX() * sp_width, p.getY() * sp_height, 0.0f, 1.0f);
+
+                    if (has_local_position_attribute)
+                    {
+                        (*scratch_positions_local)[vertex_index] = local_pos;
+                    }
+                    if (has_world_position_attribute)
+                    {
+                        (*scratch_positions_world)[vertex_index] = world_matrix * local_pos;
+                    }
                 }
-                (*scratch_positions_world)[vertex_index] = world_matrix * local_pos;
 
                 vertices = dmGraphics::WriteAttributes(vertices, vertex_index++, 1, params);
             }
@@ -1321,8 +1333,8 @@ namespace dmGameSystem
         return anim_data;
     }
 
-    static void CreateVertexData(SpriteWorld* sprite_world, dmGraphics::VertexAttributeInfos* material_attribute_info, 
-        bool has_local_position_attribute, uint8_t** vb_where, uint8_t** ib_where, dmRender::RenderListEntry* buf, uint32_t* begin, uint32_t* end)
+    static void CreateVertexData(SpriteWorld* sprite_world, dmGraphics::VertexAttributeInfos* material_attribute_info,
+        uint8_t** vb_where, uint8_t** ib_where, dmRender::RenderListEntry* buf, uint32_t* begin, uint32_t* end)
     {
         DM_PROFILE("CreateVertexData");
 
@@ -1369,6 +1381,10 @@ namespace dmGameSystem
             {
                 CopyAttributeInfos(scratch_attribute_infos, material_attribute_info, dmGraphics::COORDINATE_SPACE_WORLD);
             }
+
+            dmGraphics::VertexAttributeInfoMetadata attribute_infos_meta = dmGraphics::GetVertexAttributeInfosMetaData(*scratch_attribute_infos);
+            bool has_local_position_attribute = attribute_infos_meta.m_HasAttributeLocalPosition;
+            bool has_world_position_attribute = attribute_infos_meta.m_HasAttributeWorldPosition;
 
             // We need to pad the buffer if the vertex stride doesn't start at an even byte offset from the start
             const uint32_t vb_buffer_offset = vertices - sprite_world->m_VertexBufferData;
@@ -1426,7 +1442,10 @@ namespace dmGameSystem
                     {
                         sprite_world->m_ScratchPositionLocal[vertex_index] = local_pos;
                     }
-                    sprite_world->m_ScratchPositionWorld[vertex_index] = world_matrix * local_pos;
+                    if (has_world_position_attribute)
+                    {
+                        sprite_world->m_ScratchPositionWorld[vertex_index] = world_matrix * local_pos;
+                    }
                     vertices = dmGraphics::WriteAttributes(vertices, vertex_index, 1, write_params);
                 }
 
@@ -1475,6 +1494,7 @@ namespace dmGameSystem
                         vertices,
                         indices,
                         sprite_world->m_Is16BitIndex,
+                        has_world_position_attribute,
                         has_local_position_attribute,
                         world_matrix,
                         vertex_offset,
@@ -1513,24 +1533,20 @@ namespace dmGameSystem
                     Vector4 positions_local[4];
                     Vector4 positions_world[4];
 
-                    if (has_local_position_attribute)
+                    if (has_local_position_attribute || has_world_position_attribute)
                     {
                         positions_local[0] = Vector4(x0 * sp_width, y0 * sp_height, 0.0f, 1.0f);
                         positions_local[1] = Vector4(x0 * sp_width, y1 * sp_height, 0.0f, 1.0f);
                         positions_local[2] = Vector4(x1 * sp_width, y1 * sp_height, 0.0f, 1.0f);
                         positions_local[3] = Vector4(x1 * sp_width, y0 * sp_height, 0.0f, 1.0f);
 
-                        positions_world[0] = world_matrix * positions_local[0];
-                        positions_world[1] = world_matrix * positions_local[1];
-                        positions_world[2] = world_matrix * positions_local[2];
-                        positions_world[3] = world_matrix * positions_local[3];
-                    }
-                    else
-                    {
-                        positions_world[0] = world_matrix * Vector4(x0 * sp_width, y0 * sp_height, 0.0f, 1.0f);
-                        positions_world[1] = world_matrix * Vector4(x0 * sp_width, y1 * sp_height, 0.0f, 1.0f);
-                        positions_world[2] = world_matrix * Vector4(x1 * sp_width, y1 * sp_height, 0.0f, 1.0f);
-                        positions_world[3] = world_matrix * Vector4(x1 * sp_width, y0 * sp_height, 0.0f, 1.0f);
+                        if (has_world_position_attribute)
+                        {
+                            positions_world[0] = world_matrix * positions_local[0];
+                            positions_world[1] = world_matrix * positions_local[1];
+                            positions_world[2] = world_matrix * positions_local[2];
+                            positions_world[3] = world_matrix * positions_local[3];
+                        }
                     }
 
                     const float* world_matrix_channel[]    = { (float*) &world_matrix };
@@ -1623,8 +1639,7 @@ namespace dmGameSystem
         uint8_t* vb_iter  = vb_begin;
         uint8_t* ib_iter  = ib_begin;
 
-        dmGraphics::VertexAttributeInfoMetadata material_attribute_info_meta = dmGraphics::GetVertexAttributeInfosMetaData(material_attribute_info);
-        CreateVertexData(sprite_world, &material_attribute_info, material_attribute_info_meta.m_HasAttributeLocalPosition, &vb_iter, &ib_iter, buf, begin, end);
+        CreateVertexData(sprite_world, &material_attribute_info, &vb_iter, &ib_iter, buf, begin, end);
 
         sprite_world->m_VertexBufferWritePtr = vb_iter;
         sprite_world->m_IndexBufferWritePtr = ib_iter;
@@ -2008,7 +2023,7 @@ namespace dmGameSystem
             GetPivot(anim_data, &pivot_x, &pivot_y);
             Vector3 size = dmVMath::MulPerElem(component->m_Size, component->m_Scale);
             Point3 pivot_scaled(-pivot_x * size.getX(), -pivot_y * size.getY(), 0.f);
-            Vector3 world_pos = (component->m_World * Vector4(pivot_scaled.getX(), pivot_scaled.getY(), 0.f, 1.f)).getXYZ();
+            Vector3 world_pos = (component->m_World * pivot_scaled).getXYZ();
 
             bool intersect = dmIntersection::TestFrustumSphereSq(frustum, Point3(world_pos), radius_sq);
             entry->m_Visibility = intersect ? dmRender::VISIBILITY_FULL : dmRender::VISIBILITY_NONE;

--- a/engine/gamesys/src/gamesys/components/comp_sprite.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sprite.cpp
@@ -1433,18 +1433,21 @@ namespace dmGameSystem
                 uint32_t num_vertices = sprite_world->m_ScratchPositionWorld.Size();
                 for (uint32_t vertex_index = 0; vertex_index < num_vertices; ++vertex_index)
                 {
-                    // Local space has size applied; world = mtx_world * local (mtx_world has no scale)
-                    Vector4 local_pos(
-                        sprite_world->m_ScratchPositionWorld[vertex_index].getX() * sp_width,
-                        sprite_world->m_ScratchPositionWorld[vertex_index].getY() * sp_height,
-                        0.0f, 1.0f);
-                    if (has_local_position_attribute)
+                    if (has_local_position_attribute || has_world_position_attribute)
                     {
-                        sprite_world->m_ScratchPositionLocal[vertex_index] = local_pos;
-                    }
-                    if (has_world_position_attribute)
-                    {
-                        sprite_world->m_ScratchPositionWorld[vertex_index] = world_matrix * local_pos;
+                        // Local space has size applied; world = mtx_world * local (mtx_world has no scale)
+                        Vector4 local_pos(
+                            sprite_world->m_ScratchPositionWorld[vertex_index].getX() * sp_width,
+                            sprite_world->m_ScratchPositionWorld[vertex_index].getY() * sp_height,
+                            0.0f, 1.0f);
+                        if (has_local_position_attribute)
+                        {
+                            sprite_world->m_ScratchPositionLocal[vertex_index] = local_pos;
+                        }
+                        if (has_world_position_attribute)
+                        {
+                            sprite_world->m_ScratchPositionWorld[vertex_index] = world_matrix * local_pos;
+                        }
                     }
                     vertices = dmGraphics::WriteAttributes(vertices, vertex_index, 1, write_params);
                 }

--- a/engine/gamesys/src/gamesys/components/comp_sprite.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sprite.cpp
@@ -976,15 +976,13 @@ namespace dmGameSystem
                 float py = ys[y] - 0.5f;
                 Point3 p = Point3(px - pivot_x, py - pivot_y, 0);
 
+                // Local space has size applied; world = mtx_world * local (mtx_world has no scale)
+                Vector4 local_pos(p.getX() * sp_width, p.getY() * sp_height, 0.0f, 1.0f);
                 if (has_local_position_attribute)
                 {
-                    (*scratch_positions_local)[vertex_index] = Vector4(
-                        p.getX() * sp_width,
-                        p.getY() * sp_height,
-                        0.0f, 1.0f);
+                    (*scratch_positions_local)[vertex_index] = local_pos;
                 }
-
-                (*scratch_positions_world)[vertex_index] = world_matrix * p;
+                (*scratch_positions_world)[vertex_index] = world_matrix * local_pos;
 
                 vertices = dmGraphics::WriteAttributes(vertices, vertex_index++, 1, params);
             }
@@ -1419,15 +1417,16 @@ namespace dmGameSystem
                 uint32_t num_vertices = sprite_world->m_ScratchPositionWorld.Size();
                 for (uint32_t vertex_index = 0; vertex_index < num_vertices; ++vertex_index)
                 {
+                    // Local space has size applied; world = mtx_world * local (mtx_world has no scale)
+                    Vector4 local_pos(
+                        sprite_world->m_ScratchPositionWorld[vertex_index].getX() * sp_width,
+                        sprite_world->m_ScratchPositionWorld[vertex_index].getY() * sp_height,
+                        0.0f, 1.0f);
                     if (has_local_position_attribute)
                     {
-                        sprite_world->m_ScratchPositionLocal[vertex_index] = Vector4(
-                            sprite_world->m_ScratchPositionWorld[vertex_index].getX() * sp_width,
-                            sprite_world->m_ScratchPositionWorld[vertex_index].getY() * sp_height,
-                            0.0f, 1.0f);
+                        sprite_world->m_ScratchPositionLocal[vertex_index] = local_pos;
                     }
-
-                    sprite_world->m_ScratchPositionWorld[vertex_index] = world_matrix * sprite_world->m_ScratchPositionWorld[vertex_index];
+                    sprite_world->m_ScratchPositionWorld[vertex_index] = world_matrix * local_pos;
                     vertices = dmGraphics::WriteAttributes(vertices, vertex_index, 1, write_params);
                 }
 
@@ -1471,10 +1470,21 @@ namespace dmGameSystem
                 //      submitting more vertices than needed.
                 if (component->m_UseSlice9)
                 {
-                    CreateVertexDataSlice9(component, vertices, indices, sprite_world->m_Is16BitIndex, has_local_position_attribute,
-                        world_matrix, vertex_offset, vertex_stride,
-                        animations, sprite_world->m_ScratchUVs, scratch_uv_ptrs, scratch_pi_ptrs,
-                        &sprite_world->m_ScratchPositionWorld, &sprite_world->m_ScratchPositionLocal,
+                    CreateVertexDataSlice9(
+                        component,
+                        vertices,
+                        indices,
+                        sprite_world->m_Is16BitIndex,
+                        has_local_position_attribute,
+                        world_matrix,
+                        vertex_offset,
+                        vertex_stride,
+                        animations,
+                        sprite_world->m_ScratchUVs,
+                        scratch_uv_ptrs,
+                        scratch_pi_ptrs,
+                        &sprite_world->m_ScratchPositionWorld,
+                        &sprite_world->m_ScratchPositionLocal,
                         scratch_attribute_infos);
 
                     indices       += index_type_size * SPRITE_INDEX_COUNT_SLICE9;
@@ -1500,19 +1510,27 @@ namespace dmGameSystem
                     float y0 = -0.5f - pivot_y;
                     float y1 =  0.5f - pivot_y;
 
-                    Vector4 positions_world[] = {
-                        world_matrix * Point3(x0, y0, 0.0f),
-                        world_matrix * Point3(x0, y1, 0.0f),
-                        world_matrix * Point3(x1, y1, 0.0f),
-                        world_matrix * Point3(x1, y0, 0.0f)};
-
                     Vector4 positions_local[4];
+                    Vector4 positions_world[4];
+
                     if (has_local_position_attribute)
                     {
                         positions_local[0] = Vector4(x0 * sp_width, y0 * sp_height, 0.0f, 1.0f);
                         positions_local[1] = Vector4(x0 * sp_width, y1 * sp_height, 0.0f, 1.0f);
                         positions_local[2] = Vector4(x1 * sp_width, y1 * sp_height, 0.0f, 1.0f);
                         positions_local[3] = Vector4(x1 * sp_width, y0 * sp_height, 0.0f, 1.0f);
+
+                        positions_world[0] = world_matrix * positions_local[0];
+                        positions_world[1] = world_matrix * positions_local[1];
+                        positions_world[2] = world_matrix * positions_local[2];
+                        positions_world[3] = world_matrix * positions_local[3];
+                    }
+                    else
+                    {
+                        positions_world[0] = world_matrix * Vector4(x0 * sp_width, y0 * sp_height, 0.0f, 1.0f);
+                        positions_world[1] = world_matrix * Vector4(x0 * sp_width, y1 * sp_height, 0.0f, 1.0f);
+                        positions_world[2] = world_matrix * Vector4(x1 * sp_width, y1 * sp_height, 0.0f, 1.0f);
+                        positions_world[3] = world_matrix * Vector4(x1 * sp_width, y0 * sp_height, 0.0f, 1.0f);
                     }
 
                     const float* world_matrix_channel[]    = { (float*) &world_matrix };
@@ -1688,9 +1706,8 @@ namespace dmGameSystem
     {
         Matrix4 local = dmTransform::ToMatrix4(dmTransform::Transform(component->m_Position, component->m_Rotation, 1.0f));
         Matrix4 world = dmGameObject::GetWorldMatrix(component->m_Instance);
-        Vector3 size = dmVMath::MulPerElem(component->m_Size, component->m_Scale);
-        size.setZ(1.f);
-        Matrix4 w = dmVMath::AppendScale(world * local, size);
+        // World matrix is position + rotation only; size is applied when producing world-space positions
+        Matrix4 w = world * local;
         if (!sub_pixels)
         {
             Vector4 position = w.getCol3();
@@ -1960,9 +1977,10 @@ namespace dmGameSystem
             if (!component->m_Enabled || !component->m_AddedToUpdate)
                 continue;
             UpdateTransform(component, sub_pixels);
-            // we need to consider the full scale here
-            // I.e. we want the length of the diagonal C, where C = X + Y
-            float radius_sq = dmVMath::LengthSqr((component->m_World.getCol(0).getXYZ() + component->m_World.getCol(1).getXYZ()) * 0.5f);
+            // Bounding radius: world matrix has no scale, so incorporate size
+            Vector3 size = dmVMath::MulPerElem(component->m_Size, component->m_Scale);
+            Vector3 half_diagonal = (component->m_World.getCol(0).getXYZ() * size.getX() + component->m_World.getCol(1).getXYZ() * size.getY()) * 0.5f;
+            float radius_sq = dmVMath::LengthSqr(half_diagonal);
             world->m_BoundingVolumes[i] = radius_sq;
         }
         return dmGameObject::UPDATE_RESULT_OK;
@@ -1988,8 +2006,9 @@ namespace dmGameSystem
             const AnimationData* anim_data = GetOrCreateAnimationData(sprite_world, component);
             float pivot_x = 0.f, pivot_y = 0.f;
             GetPivot(anim_data, &pivot_x, &pivot_y);
-            Point3 pivot(-pivot_x, -pivot_y, 0.f);
-            Vector3 world_pos = (component->m_World * pivot).getXYZ();
+            Vector3 size = dmVMath::MulPerElem(component->m_Size, component->m_Scale);
+            Point3 pivot_scaled(-pivot_x * size.getX(), -pivot_y * size.getY(), 0.f);
+            Vector3 world_pos = (component->m_World * Vector4(pivot_scaled.getX(), pivot_scaled.getY(), 0.f, 1.f)).getXYZ();
 
             bool intersect = dmIntersection::TestFrustumSphereSq(frustum, Point3(world_pos), radius_sq);
             entry->m_Visibility = intersect ? dmRender::VISIBILITY_FULL : dmRender::VISIBILITY_NONE;
@@ -2538,8 +2557,9 @@ namespace dmGameSystem
                     break;
                 }
                 case 3:
-                    // the size is baked into this matrix as the scale
-                    value = Vector4(transform.GetScale());
+                    // world_size: size is not in the matrix, return component size * scale
+                    value = Vector4(dmVMath::MulPerElem(component->m_Size, component->m_Scale));
+                    value.setZ(1.0f);
                     break;
                 default: return false;
             }

--- a/engine/particle/src/particle.cpp
+++ b/engine/particle/src/particle.cpp
@@ -1246,8 +1246,8 @@ namespace dmParticle
                 ddf->m_Pivot.getZ()));
         }
 
-        Vector3 position_world_flat[6];
-        Vector3 position_local_flat[6];
+        Point3 position_world_flat[6];
+        Point3 position_local_flat[6];
         float tex_coord_flat[6 * 2];
 
         Vector4 color_to_write;
@@ -1337,11 +1337,11 @@ namespace dmParticle
             // Local space has size applied (like sprites); world matrix has no scale so view_proj * mtx_world * position_local == view_proj * position_world
             float hx = width_factor * size.getX();
             float hy = height_factor * size.getY();
-            position_local_flat[0] = Vector3(-hx, -hy, 0.0f);
-            position_local_flat[1] = Vector3(-hx,  hy, 0.0f);
-            position_local_flat[2] = Vector3( hx,  hy, 0.0f);
+            position_local_flat[0] = Point3(-hx, -hy, 0.0f);
+            position_local_flat[1] = Point3(-hx,  hy, 0.0f);
+            position_local_flat[2] = Point3( hx,  hy, 0.0f);
             position_local_flat[3] = position_local_flat[2];
-            position_local_flat[4] = Vector3( hx, -hy, 0.0f);
+            position_local_flat[4] = Point3( hx, -hy, 0.0f);
             position_local_flat[5] = position_local_flat[0];
 
             dmTransform::Transform particle_transform_no_scale = particle_transform;
@@ -1352,8 +1352,7 @@ namespace dmParticle
             {
                 for (int i = 0; i < 6; ++i)
                 {
-                    Vector4 p_local(position_local_flat[i].getX(), position_local_flat[i].getY(), position_local_flat[i].getZ(), 1.0f);
-                    position_world_flat[i] = (world_matrix * p_local).getXYZ();
+                    position_world_flat[i] = Point3((world_matrix * position_local_flat[i]).getXYZ());
                 }
             }
 

--- a/engine/particle/src/particle.cpp
+++ b/engine/particle/src/particle.cpp
@@ -1334,31 +1334,27 @@ namespace dmParticle
                 particle_transform = dmTransform::Mul(particle_transform, pivot_transform);
             }
 
+            // Local space has size applied (like sprites); world matrix has no scale so view_proj * mtx_world * position_local == view_proj * position_world
+            float hx = width_factor * size.getX();
+            float hy = height_factor * size.getY();
+            position_local_flat[0] = Vector3(-hx, -hy, 0.0f);
+            position_local_flat[1] = Vector3(-hx,  hy, 0.0f);
+            position_local_flat[2] = Vector3( hx,  hy, 0.0f);
+            position_local_flat[3] = position_local_flat[2];
+            position_local_flat[4] = Vector3( hx, -hy, 0.0f);
+            position_local_flat[5] = position_local_flat[0];
+
+            dmTransform::Transform particle_transform_no_scale = particle_transform;
+            particle_transform_no_scale.SetScale(Vector3(1.0f, 1.0f, 1.0f));
+            world_matrix = dmTransform::ToMatrix4(particle_transform_no_scale);
+
             if (material_attribute_info_meta.m_HasAttributeWorldPosition)
             {
-                Vector3 x_local = Vector3(width_factor, 0.0f, 0.0f);
-                Vector3 y_local = Vector3(0.0f, height_factor, 0.0f);
-                Vector3 x       = dmTransform::Apply(particle_transform, x_local);
-                Vector3 y       = dmTransform::Apply(particle_transform, y_local);
-                position_world_flat[0] = -x - y + particle_transform.GetTranslation();
-                position_world_flat[1] = -x + y + particle_transform.GetTranslation();
-                position_world_flat[2] = x + y + particle_transform.GetTranslation();
-                position_world_flat[3] = position_world_flat[2];
-                position_world_flat[4] = x - y + particle_transform.GetTranslation();
-                position_world_flat[5] = position_world_flat[0];
-            }
-
-            if (material_attribute_info_meta.m_HasAttributeLocalPosition)
-            {
-                // Pixel local coordinates (like sprites): apply size to local extents
-                Vector3 x_local_pixel = Vector3(width_factor * size.getX(), 0.0f, 0.0f);
-                Vector3 y_local_pixel = Vector3(0.0f, height_factor * size.getY(), 0.0f);
-                position_local_flat[0] = -x_local_pixel - y_local_pixel;
-                position_local_flat[1] = -x_local_pixel + y_local_pixel;
-                position_local_flat[2] = x_local_pixel + y_local_pixel;
-                position_local_flat[3] = position_local_flat[2];
-                position_local_flat[4] = x_local_pixel - y_local_pixel;
-                position_local_flat[5] = position_local_flat[0];
+                for (int i = 0; i < 6; ++i)
+                {
+                    Vector4 p_local(position_local_flat[i].getX(), position_local_flat[i].getY(), position_local_flat[i].getZ(), 1.0f);
+                    position_world_flat[i] = (world_matrix * p_local).getXYZ();
+                }
             }
 
             if (material_attribute_info_meta.m_HasAttributeColor)
@@ -1395,10 +1391,7 @@ namespace dmParticle
                 }
             }
 
-            if (material_attribute_info_meta.m_HasAttributeWorldMatrix)
-            {
-                world_matrix = dmTransform::ToMatrix4(particle_transform);
-            }
+            // world_matrix already set from particle_transform_no_scale (no size) above
 
             uint8_t* write_ptr = vertex_buffer + vertex_index * attribute_infos.m_VertexStride;
             write_ptr = dmGraphics::WriteAttributes(write_ptr, 0, 6, write_params);


### PR DESCRIPTION
Currently when writing custom vertex positions in the "local" coordinate space for sprites and particles, the size of the sprite/particle is applied to both the position _and_ the world transform. This means that you cannot render the primitive correctly when applying the world transform to the local position in a shader for example:

```glsl
// 1. the position attribute is in local space (i.e pixel local coordinate space)
gl_Position = view_proj * mtx_world * vec4(position.xyz, 1.0);
// 2. the position attribute is in world space
gl_Position = view_proj * vec4(position.xyz, 1.0);
```

These two statements should produce identical results, but doesn't since the size is applied to the world transform for both sprites and particles. This has now been fixed, which means that we can use custom vertex formats to properly do billboarding properly.
