### PR TITLE
Prevent the editor from crashing when loading a malformed collection

### DIFF
--- a/editor/src/clj/editor/collection.clj
+++ b/editor/src/clj/editor/collection.clj
@@ -849,6 +849,14 @@
                    select-fn (fn [node-ids] (app-view/select app-view node-ids))]
           (add-referenced-game-object! coll-node go-node resource select-fn))))))
 
+(defn- validate-child-references! [id->nid child->parent]
+  (run!
+    (fn [[child parent]]
+      (when (and parent (not (id->nid child)))
+        (throw (IllegalStateException.
+                 (format "Unresolved child id '%s' referenced by parent '%s'." child parent)))))
+    child->parent))
+
 (defn load-collection [project self resource collection]
   {:pre [(map? collection)]} ; GameObject$CollectionDesc in map format.
   (concat
@@ -885,6 +893,7 @@
                                                    children))))
                               (pair (:instances collection)
                                     (:embedded-instances collection))))]
+      (validate-child-references! id->nid child->parent)
       (concat
         tx-go-creation
         (for [[child parent] child->parent

--- a/editor/test/integration/invalid_content_test.clj
+++ b/editor/test/integration/invalid_content_test.clj
@@ -1,0 +1,31 @@
+;; Copyright 2020-2026 The Defold Foundation
+;; Copyright 2014-2020 King
+;; Copyright 2009-2014 Ragnar Svensson, Christian Murray
+;; Licensed under the Defold License version 1.0 (the "License"); you may not use
+;; this file except in compliance with the License.
+;;
+;; You may obtain a copy of the License, together with FAQs at
+;; https://www.defold.com/license
+;;
+;; Unless required by applicable law or agreed to in writing, software distributed
+;; under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+;; CONDITIONS OF ANY KIND, either express or implied. See the License for the
+;; specific language governing permissions and limitations under the License.
+
+(ns integration.invalid-content-test
+  (:require [clojure.test :refer :all]
+            [dynamo.graph :as g]
+            [integration.test-util :as test-util]))
+
+(def ^:private invalid-content-project-path "test/resources/invalid_content_project")
+
+(deftest malformed-collection-reports-invalid-content
+  (test-util/with-loaded-project invalid-content-project-path :logging-suppressed true
+    (let [node-id (test-util/resource-node project "/main/invalid_child_ref.collection")
+          error (test-util/build-error! node-id)
+          invalid-content-cause (first (:causes error))
+          exception (-> invalid-content-cause :user-data :exception)]
+      (is (g/error? error))
+      (is (= :invalid-content (-> invalid-content-cause :user-data :type)))
+      (is (= "Unresolved child id 'missing' referenced by parent 'root'."
+             (ex-message exception))))))

--- a/editor/test/resources/invalid_content_project/.gitignore
+++ b/editor/test/resources/invalid_content_project/.gitignore
@@ -1,0 +1,11 @@
+/.internal
+/.editor_settings
+/build
+.externalToolBuilders
+.DS_Store
+Thumbs.db
+.lock-wscript
+*.pyc
+.project
+.cproject
+builtins

--- a/editor/test/resources/invalid_content_project/game.project
+++ b/editor/test/resources/invalid_content_project/game.project
@@ -1,0 +1,5 @@
+[project]
+title = Invalid Content
+
+[bootstrap]
+main_collection = /main/main.collectionc

--- a/editor/test/resources/invalid_content_project/main/invalid_child_ref.collection
+++ b/editor/test/resources/invalid_content_project/main/invalid_child_ref.collection
@@ -1,0 +1,6 @@
+name: "invalid"
+embedded_instances {
+  id: "root"
+  children: "missing"
+  data: ""
+}

--- a/editor/test/resources/invalid_content_project/main/main.collection
+++ b/editor/test/resources/invalid_content_project/main/main.collection
@@ -1,0 +1,5 @@
+name: "main"
+collection_instances {
+  id: "invalid"
+  collection: "/main/invalid_child_ref.collection"
+}


### PR DESCRIPTION
Fix #8537