### PR TITLE
Fixed issue with clamped glyph positions for distance field fonts

### DIFF
--- a/engine/font/src/test/test_font.cpp
+++ b/engine/font/src/test/test_font.cpp
@@ -410,7 +410,7 @@ TEST_F(FontTest, LayoutTrackingAndLeading)
     TextResult r = TestLayout(m_FontCollection, codepoints, &settings, &layout);
     ASSERT_EQ(TEXT_RESULT_OK, r);
     ASSERT_NE((HTextLayout)0, layout);
-    float line_height = layout->m_Height;
+    float layout_line_height = layout->m_Height;
     TextLayoutFree(layout);
 
     // Measure tracking impact as a width delta between two adjacent glyphs.
@@ -420,9 +420,6 @@ TEST_F(FontTest, LayoutTrackingAndLeading)
     ASSERT_EQ(TEXT_RESULT_OK, r);
     ASSERT_NE((HTextLayout)0, layout);
     float width_no_tracking = layout->m_Width;
-#if !defined(FONT_USE_SKRIBIDI)
-    float first_advance = layout->m_Glyphs[0].m_Advance;
-#endif
     TextLayoutFree(layout);
 
     float tracking_value = 0.25f;
@@ -433,19 +430,17 @@ TEST_F(FontTest, LayoutTrackingAndLeading)
     float width_tracking = layout->m_Width;
     TextLayoutFree(layout);
 
-    // Legacy tracking scales by line height and is quantized to integer pixel steps.
-    // Skribidi scales by font size in pixels.
+    // Legacy tracking scales by line height. Skribidi scales by font size in pixels.
     float expected_tracking = 0.0f;
 #if defined(FONT_USE_SKRIBIDI)
     // Skribidi interprets tracking in pixels based on font size.
     expected_tracking = tracking_value * settings.m_Size;
 #else
-    // Legacy uses line height (font metrics scaled by size) for tracking.
     float scale = FontGetScaleFromSize(m_Font, settings.m_Size);
-    float raw_tracking = tracking_value * line_height * scale;
-    uint32_t advance_px = (uint32_t)first_advance;
-    uint32_t advance_plus_tracking_px = (uint32_t)(first_advance + raw_tracking);
-    expected_tracking = (float)(advance_plus_tracking_px - advance_px);
+    uint32_t ascent = (uint32_t)FontGetAscent(m_Font, 1.0f);
+    uint32_t descent = (uint32_t)FontGetDescent(m_Font, 1.0f);
+    float tracking_line_height = (ascent + descent) * scale;
+    expected_tracking = tracking_value * tracking_line_height;
 #endif
 
     const float epsilon = 0.05f;
@@ -478,11 +473,132 @@ TEST_F(FontTest, LayoutTrackingAndLeading)
     TextLayoutFree(layout);
 
     // Leading should add one extra line height for the entire layout.
-    float expected_leading_delta = line_height;
+    float expected_leading_delta = layout_line_height;
     float height_leading_delta = height_leading_2 - height_leading_1;
     ASSERT_NEAR(expected_leading_delta, height_leading_delta, epsilon);
 }
 
+TEST_F(FontTest, FontTracking)
+{
+    const char text[] = "test with many characters";
+    const float spacing_epsilon = 0.01f;
+    const float width_epsilon = 0.02f;
+
+    dmArray<uint32_t> codepoints;
+    TextToCodePoints(text, codepoints);
+    ASSERT_GT(codepoints.Size(), 1u);
+
+    TextLayoutSettings settings = {0};
+    settings.m_LineBreak = false;
+    settings.m_Width = 0.0f;
+    settings.m_Size = 28.0f;
+    settings.m_Leading = 1.0f;
+    settings.m_Tracking = 0.0f;
+
+    HTextLayout layout = 0;
+
+    // Match the legacy tracking unit:
+    // tracking_px = tracking * ((uint32_t)ascent + (uint32_t)descent) * scale
+    float scale = FontGetScaleFromSize(m_Font, settings.m_Size);
+    uint32_t ascent = (uint32_t)FontGetAscent(m_Font, 1.0f);
+    uint32_t descent = (uint32_t)FontGetDescent(m_Font, 1.0f);
+    const float line_height = (ascent + descent) * scale;
+    ASSERT_GT(line_height, 0.0f);
+
+    const uint32_t max_glyphs = 256;
+    ASSERT_LE(codepoints.Size(), max_glyphs);
+    const uint32_t tracking_steps = 11; // -0.05 .. 0.05 in 0.01 increments
+
+    float baseline_spacing[max_glyphs];
+    float baseline_prev_advance[max_glyphs];
+    uint32_t baseline_tracking_pair_count = 0;
+    for (uint32_t i = 0; i < max_glyphs; ++i)
+    {
+        baseline_spacing[i] = 0.0f;
+        baseline_prev_advance[i] = 0.0f;
+    }
+
+    float full_width_at_zero = 0.0f;
+    uint32_t baseline_glyph_count = 0;
+
+    // Baseline pass: capture spacing between consecutive glyph pen positions at tracking=0.
+    {
+        TextResult r = TestLayout(m_FontCollection, codepoints, &settings, &layout);
+        ASSERT_EQ(TEXT_RESULT_OK, r);
+        ASSERT_NE((HTextLayout)0, layout);
+        ASSERT_GT(layout->m_Glyphs.Size(), 1u);
+
+        baseline_glyph_count = layout->m_Glyphs.Size();
+        full_width_at_zero = layout->m_Width;
+
+        for (uint32_t i = 0; i < baseline_glyph_count; ++i)
+        {
+            TextGlyph& glyph = layout->m_Glyphs[i];
+
+            if (i > 0)
+            {
+                TextGlyph& prev_glyph = layout->m_Glyphs[i - 1];
+                baseline_spacing[i] = glyph.m_X - prev_glyph.m_X;
+                baseline_prev_advance[i] = prev_glyph.m_Advance;
+                if (baseline_prev_advance[i] > 0.0f)
+                    ++baseline_tracking_pair_count;
+            }
+        }
+
+        TextLayoutFree(layout);
+        layout = 0;
+    }
+
+    // Sweep tracking values and verify adjacent glyph spacing and total width progression.
+    for (uint32_t step = 0; step < tracking_steps; ++step)
+    {
+        if (step == 5) // tracking == 0.0f
+            continue;
+
+        const float tracking = -0.05f + step * 0.01f;
+        float tracking_pixels = 0.0f;
+#if defined(FONT_USE_SKRIBIDI)
+        tracking_pixels = tracking * settings.m_Size;
+#else
+        tracking_pixels = tracking * line_height;
+#endif
+        settings.m_Tracking = tracking;
+
+        TextResult r = TestLayout(m_FontCollection, codepoints, &settings, &layout);
+        ASSERT_EQ(TEXT_RESULT_OK, r);
+        ASSERT_NE((HTextLayout)0, layout);
+        ASSERT_EQ(baseline_glyph_count, layout->m_Glyphs.Size());
+
+        for (uint32_t i = 1; i < layout->m_Glyphs.Size(); ++i)
+        {
+            TextGlyph& prev_glyph = layout->m_Glyphs[i - 1];
+            TextGlyph& glyph = layout->m_Glyphs[i];
+
+            float actual_spacing = glyph.m_X - prev_glyph.m_X;
+            bool has_prev_advance = true;
+#if !defined(FONT_USE_SKRIBIDI)
+            has_prev_advance = baseline_prev_advance[i] > 0.0f;
+#endif
+            float expected_spacing = has_prev_advance ? (baseline_spacing[i] + tracking_pixels) : baseline_spacing[i];
+            ASSERT_NEAR(expected_spacing, actual_spacing, spacing_epsilon);
+        }
+
+        float expected_width = 0.0f;
+#if defined(FONT_USE_SKRIBIDI)
+        // Skribidi spacing applies to all glyphs in the run; for positive tracking
+        // the layout code compensates one slot in the final width.
+        expected_width = full_width_at_zero + baseline_glyph_count * tracking_pixels;
+        if (tracking > 0.0f)
+            expected_width -= tracking_pixels;
+#else
+        expected_width = full_width_at_zero + baseline_tracking_pair_count * tracking_pixels;
+#endif
+        ASSERT_NEAR(expected_width, layout->m_Width, width_epsilon);
+
+        TextLayoutFree(layout);
+        layout = 0;
+    }
+}
 
 #if !defined(FONT_USE_SKRIBIDI) && defined(FOO)
 static void CreateTestGlyphs(TextShapeInfo* info, const char* text, int32_t x_step, dmArray<uint32_t>& codepoints)

--- a/engine/font/src/text_layout_legacy.cpp
+++ b/engine/font/src/text_layout_legacy.cpp
@@ -235,8 +235,8 @@ TextResult TextLayoutLegacyCreate(HFontCollection collection,
     uint32_t num_whitespaces = 0;
     // Lay them all out in a single line, using points
 // TODO: Make this optional, so that user can choose to use pixel alignment
-    uint32_t x = 0;
-    uint32_t y = 0; // the legacy "shaping" doesn't support Y offsets
+    float x = 0;
+    float y = 0; // the legacy "shaping" doesn't support Y offsets
     FontGlyph font_glyph;
     for (uint32_t i = 0; i < num_codepoints; ++i)
     {


### PR DESCRIPTION
This fixes a regression from 1.12.0 where the glyph positions for .ttf fonts were accidentally aligned to the nearest pixel.

Fixes https://github.com/defold/defold/issues/11922

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
