### PR TITLE
Added dmLogInitialize and dmLogFinalize to dmsdk

### DIFF
--- a/engine/dlib/src/dlib/log.cpp
+++ b/engine/dlib/src/dlib/log.cpp
@@ -625,6 +625,16 @@ void dmLogUnregisterListener(FLogListener listener)
     dmLogWarning("dmLog listener not found");
 }
 
+void dmLogInitialize(const LogParams* params)
+{
+    dmLog::LogInitialize(params);
+}
+
+void dmLogFinalize()
+{
+    dmLog::LogFinalize();
+}
+
 void dmLogSetLevel(LogSeverity severity)
 {
     dmLog::g_LogLevel = severity;

--- a/engine/dlib/src/dlib/log.h
+++ b/engine/dlib/src/dlib/log.h
@@ -56,25 +56,6 @@ struct LogMessage
 };
 
 const uint32_t MAX_STRING_SIZE = dmMessage::DM_MESSAGE_MAX_DATA_SIZE - sizeof(LogMessage);
-struct LogParams
-{
-    LogParams()
-    {
-    }
-};
-
-/**
- * Initialize logging system. Running this function is only required in order to start the log-server.
- * The function will never fail even if the log-server can't be started. Any errors will be reported to stderr though
- * @param params log parameters
- */
-void LogInitialize(const LogParams* params);
-
-
-/**
- * Finalize logging system
- */
-void LogFinalize();
 
 /**
  * Get log server port

--- a/engine/dlib/src/dmsdk/dlib/log.h
+++ b/engine/dlib/src/dmsdk/dlib/log.h
@@ -240,6 +240,39 @@ void LogInternal(LogSeverity severity, const char* domain, const char* format, .
  */
 typedef void (*FLogListener)(LogSeverity severity, const char* domain, const char* formatted_string);
 
+/*# Log parameters.
+ *
+ * Parameters for dmLogInitialize().
+ *
+ * @struct
+ * @name LogParams
+ * @member m_Padding [type:uint8_t] Reserved for future use. Set to 0.
+ */
+typedef struct LogParams
+{
+#if !defined(__cplusplus)
+    uint8_t _padding; // to avoid empty C struct
+#endif
+
+} LogParams;
+
+/*# initialize the logging system.
+ *
+ * Running this function is only required in order to start the log server.
+ * The function never fails even if the log server cannot be started.
+ * Any startup errors are reported to stderr.
+ *
+ * @name dmLogInitialize
+ * @param params [type:LogParams*] log parameters
+ */
+void dmLogInitialize(const LogParams* params);
+
+/*# finalize the logging system.
+ *
+ * @name dmLogFinalize
+ */
+void dmLogFinalize();
+
 /*# register a log listener.
  *
  * Registers a log listener.
@@ -289,6 +322,22 @@ LogSeverity dmLogGetLevel();
 
 namespace dmLog
 {
+    typedef ::LogParams LogParams;
+
+    /**
+     * Initialize the logging system.
+     * Running this function is only required in order to start the log server.
+     * The function never fails even if the log server cannot be started.
+     * Any startup errors are reported to stderr.
+     * @param params log parameters
+     */
+    void LogInitialize(const LogParams* params);
+
+    /**
+     * Finalize the logging system.
+     */
+    void LogFinalize();
+
     void RegisterLogListener(FLogListener listener);
     void UnregisterLogListener(FLogListener listener);
     void Setlevel(LogSeverity severity);

--- a/engine/dlib/src/dmsdk/dlib/log.h
+++ b/engine/dlib/src/dmsdk/dlib/log.h
@@ -246,7 +246,6 @@ typedef void (*FLogListener)(LogSeverity severity, const char* domain, const cha
  *
  * @struct
  * @name LogParams
- * @member m_Padding [type:uint8_t] Reserved for future use. Set to 0.
  */
 typedef struct LogParams
 {


### PR DESCRIPTION
This allows standalone tools to initialize the defold logging system, thus using the logging functions in tools etc.

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
