### PR TITLE
Fix strange sprite behavior when change atlas in runtime

### DIFF
--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -1422,6 +1422,7 @@ namespace dmEngine
 #endif
 
         engine->m_SpriteContext.m_RenderContext = engine->m_RenderContext;
+        engine->m_SpriteContext.m_Factory = engine->m_Factory;
         engine->m_SpriteContext.m_MaxSpriteCount = dmConfigFile::GetInt(engine->m_Config, "sprite.max_count", 128);
         engine->m_SpriteContext.m_Subpixels = dmConfigFile::GetInt(engine->m_Config, "sprite.subpixels", 1);
 

--- a/engine/gamesys/src/dmsdk/gamesys/resources/res_sprite.h
+++ b/engine/gamesys/src/dmsdk/gamesys/resources/res_sprite.h
@@ -30,7 +30,6 @@ namespace dmGameSystem
     {
         dmhash_t            m_SamplerNameHash;
         TextureSetResource* m_TextureSet;
-        uint8_t             m_TexturesGeneration;
     };
 
     struct SpriteResource

--- a/engine/gamesys/src/dmsdk/gamesys/resources/res_sprite.h
+++ b/engine/gamesys/src/dmsdk/gamesys/resources/res_sprite.h
@@ -30,13 +30,14 @@ namespace dmGameSystem
     {
         dmhash_t            m_SamplerNameHash;
         TextureSetResource* m_TextureSet;
+        uint8_t             m_TexturesGeneration;
     };
 
     struct SpriteResource
     {
         dmGameSystemDDF::SpriteDesc* m_DDF;
-        MaterialResource*           m_Material;
-        dmhash_t                    m_DefaultAnimation;
+        MaterialResource*            m_Material;
+        dmhash_t                     m_DefaultAnimation;
 
         // Sorted by the order of occurrance of samplers in the .material file
         SpriteTexture* m_Textures;

--- a/engine/gamesys/src/dmsdk/gamesys/resources/res_textureset.h
+++ b/engine/gamesys/src/dmsdk/gamesys/resources/res_textureset.h
@@ -33,6 +33,7 @@ namespace dmGameSystem
             m_Texture = 0;
             m_TextureSet = 0;
             m_HullSet = 0;
+            m_TexturesGeneration = 0;
         }
 
         dmArray<dmhash_t>                   m_HullCollisionGroups;
@@ -42,6 +43,7 @@ namespace dmGameSystem
         dmhash_t                            m_TexturePath;
         dmGameSystemDDF::TextureSet*        m_TextureSet;
         dmPhysics::HHullSet2D               m_HullSet;
+        uint8_t                             m_TexturesGeneration; // increase counter when reload resource data
     };
 }
 

--- a/engine/gamesys/src/gamesys/components/comp_sprite.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sprite.cpp
@@ -19,7 +19,6 @@
 #include <algorithm>
 
 #include <dlib/array.h>
-#include <dlib/set.h>
 #include <dlib/hash.h>
 #include <dlib/double_linked_list.h>
 #include <dlib/log.h>
@@ -484,17 +483,6 @@ namespace dmGameSystem
         return texture ? texture->m_TextureSet : 0;
     }
 
-    static SpriteTexture* GetSpriteTextureByIndex(const SpriteComponent* component, uint32_t index)
-    {
-        SpriteResourceOverrides* overrides = component->m_Overrides;
-        SpriteTexture* texture = 0x0;
-        if (overrides && index < overrides->m_Textures.Size())
-            texture = &overrides->m_Textures[index];
-        if (!texture || !texture->m_TextureSet)
-            texture = &component->m_Resource->m_Textures[index];
-        return texture;
-    }
-
     static inline TextureSetResource* GetTextureSetByHash(const SpriteComponent* component, dmhash_t sampler_name_hash)
     {
         if (component->m_Overrides)
@@ -535,6 +523,20 @@ namespace dmGameSystem
                 return overrides->m_Textures[texture_unit].m_TextureSet->m_Texture;
         }
         return component->m_Resource->m_Textures[texture_unit].m_TextureSet->m_Texture;
+    }
+
+    uint8_t GetTextureResourceGeneration(const SpriteComponent* component, uint32_t texture_unit)
+    {
+        if(texture_unit >= component->m_Resource->m_NumTextures)
+            return 0;
+
+        const SpriteResourceOverrides* overrides = component->m_Overrides;
+        if (overrides && texture_unit < overrides->m_Textures.Size())
+        {
+            if (overrides->m_Textures[texture_unit].m_TextureSet)
+                return overrides->m_Textures[texture_unit].m_TextureSet->m_TexturesGeneration;
+        }
+        return component->m_Resource->m_Textures[texture_unit].m_TextureSet->m_TexturesGeneration;
     }
 
     dmGraphics::HTexture GetMaterialTexture(const SpriteComponent* component, uint32_t texture_unit)
@@ -649,6 +651,12 @@ namespace dmGameSystem
         }
 
         dmHashUpdateBuffer32(&state, resource->m_Textures, sizeof(SpriteTexture) * resource->m_NumTextures);
+        for (size_t idx = 0; idx < resource->m_NumTextures; ++idx)
+        {
+            uint8_t generation = GetTextureResourceGeneration(component, idx);
+            dmHashUpdateBuffer32(&state, &generation, sizeof(generation));
+        }
+        dmHashUpdateBuffer32(&state, resource->m_Textures->m_TextureSet, sizeof(resource->m_Textures->m_TextureSet));
         dmHashUpdateBuffer32(&state, resource->m_Material, sizeof(MaterialResource*));
 
         HashResourceOverrides(&state, component->m_Overrides);
@@ -1080,7 +1088,7 @@ namespace dmGameSystem
         for (uint8_t i = 0; i < texture_num; ++i)
         {
             TextureSetResource* resource = GetTextureSetByIndex(component, i);
-            
+
             const dmGameSystemDDF::TextureSet* texture_set_ddf = resource->m_TextureSet;
             const uint32_t* frame_indices = texture_set_ddf->m_FrameIndices.m_Data;
             const uint32_t* page_indices = texture_set_ddf->m_PageIndices.m_Data;
@@ -2678,8 +2686,6 @@ namespace dmGameSystem
         SpriteWorld* sprite_world = (SpriteWorld*) params->m_UserData;
         dmArray<SpriteComponent>& components = sprite_world->m_Components.GetRawObjects();
         uint32_t component_count = components.Size();
-        dmSet<SpriteTexture*> updated_sprite_textures;
-        updated_sprite_textures.SetCapacity(64);
 
         const void* resource = dmResource::GetResource(params->m_Resource);
         for (uint32_t i = 0; i < component_count; ++i)
@@ -2687,21 +2693,12 @@ namespace dmGameSystem
             SpriteComponent* component = &components[i];
             if (component->m_Resource != 0x0)
             {
-                for (uint32_t texture_idx = 0; texture_idx < MAX_TEXTURE_COUNT; ++texture_idx)
+                uint32_t num_textures = component->m_NumTextures;
+                for (uint32_t texture_idx = 0; texture_idx < num_textures; ++texture_idx)
                 {
                     uintptr_t texture = (uintptr_t)GetTextureSetByIndex(component, texture_idx);
                     if (texture == (uintptr_t) resource)
                     {
-                        SpriteTexture* sprite_texture = GetSpriteTextureByIndex(component, texture_idx);
-                        if (!updated_sprite_textures.Contains(sprite_texture))
-                        {
-                            sprite_texture->m_TexturesGeneration++;
-                            if (updated_sprite_textures.Full())
-                            {
-                                updated_sprite_textures.OffsetCapacity(32);
-                            }
-                            updated_sprite_textures.Add(sprite_texture);
-                        }
                         component->m_ReHash = 1;
                         break;
                     }

--- a/engine/gamesys/src/gamesys/components/comp_sprite.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sprite.cpp
@@ -2683,6 +2683,11 @@ namespace dmGameSystem
 
     static void ResourceReloadedCallback(const dmResource::ResourceReloadedParams* params)
     {
+        dmhash_t name_hash = ResourceTypeGetNameHash(params->m_Type);
+        if (name_hash != TEXTURE_SET_EXT_HASH)
+        {
+            return;
+        }
         SpriteWorld* sprite_world = (SpriteWorld*) params->m_UserData;
         dmArray<SpriteComponent>& components = sprite_world->m_Components.GetRawObjects();
         uint32_t component_count = components.Size();

--- a/engine/gamesys/src/gamesys/components/comp_sprite.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sprite.cpp
@@ -19,6 +19,7 @@
 #include <algorithm>
 
 #include <dlib/array.h>
+#include <dlib/set.h>
 #include <dlib/hash.h>
 #include <dlib/double_linked_list.h>
 #include <dlib/log.h>
@@ -214,6 +215,7 @@ namespace dmGameSystem
     static void SetCursor(SpriteComponent* component, float cursor);
     static float GetPlaybackRate(SpriteComponent* component);
     static void SetPlaybackRate(SpriteComponent* component, float playback_rate);
+    static void ResourceReloadedCallback(const dmResource::ResourceReloadedParams* params);
 
     static void ReAllocateBuffers(SpriteWorld* sprite_world, dmRender::HRenderContext render_context)
     {
@@ -262,6 +264,8 @@ namespace dmGameSystem
         InitializeMaterialAttributeInfos(sprite_world->m_DynamicVertexAttributePool, 8);
 
         *params.m_World = sprite_world;
+
+        dmResource::RegisterResourceReloadedCallback(sprite_context->m_Factory, ResourceReloadedCallback, sprite_world);
         return dmGameObject::CREATE_RESULT_OK;
     }
 
@@ -289,6 +293,7 @@ namespace dmGameSystem
             free(data);
         }
 
+        dmResource::UnregisterResourceReloadedCallback(sprite_context->m_Factory, ResourceReloadedCallback, sprite_world);
         delete sprite_world;
         return dmGameObject::CREATE_RESULT_OK;
     }
@@ -477,6 +482,17 @@ namespace dmGameSystem
         if (!texture || !texture->m_TextureSet)
             texture = &component->m_Resource->m_Textures[index];
         return texture ? texture->m_TextureSet : 0;
+    }
+
+    static SpriteTexture* GetSpriteTextureByIndex(const SpriteComponent* component, uint32_t index)
+    {
+        SpriteResourceOverrides* overrides = component->m_Overrides;
+        SpriteTexture* texture = 0x0;
+        if (overrides && index < overrides->m_Textures.Size())
+            texture = &overrides->m_Textures[index];
+        if (!texture || !texture->m_TextureSet)
+            texture = &component->m_Resource->m_Textures[index];
+        return texture;
     }
 
     static inline TextureSetResource* GetTextureSetByHash(const SpriteComponent* component, dmhash_t sampler_name_hash)
@@ -1347,6 +1363,7 @@ namespace dmGameSystem
                 dmDoubleLinkedList::ListAdd(&sprite_world->m_AnimationDataCache.m_LRU, node);
                 (*found)->m_LastAccessTick = sprite_world->m_AnimationDataCache.m_CurrentEngineTick;
             }
+
             return *found;
         }
 
@@ -2654,6 +2671,43 @@ namespace dmGameSystem
         pit->m_Node = node;
         pit->m_Next = 0;
         pit->m_FnIterateNext = CompSpriteIterPropertiesGetNext;
+    }
+
+    static void ResourceReloadedCallback(const dmResource::ResourceReloadedParams* params)
+    {
+        SpriteWorld* sprite_world = (SpriteWorld*) params->m_UserData;
+        dmArray<SpriteComponent>& components = sprite_world->m_Components.GetRawObjects();
+        uint32_t component_count = components.Size();
+        dmSet<SpriteTexture*> updated_sprite_textures;
+        updated_sprite_textures.SetCapacity(64);
+
+        const void* resource = dmResource::GetResource(params->m_Resource);
+        for (uint32_t i = 0; i < component_count; ++i)
+        {
+            SpriteComponent* component = &components[i];
+            if (component->m_Resource != 0x0)
+            {
+                for (uint32_t texture_idx = 0; texture_idx < MAX_TEXTURE_COUNT; ++texture_idx)
+                {
+                    uintptr_t texture = (uintptr_t)GetTextureSetByIndex(component, texture_idx);
+                    if (texture == (uintptr_t) resource)
+                    {
+                        SpriteTexture* sprite_texture = GetSpriteTextureByIndex(component, texture_idx);
+                        if (!updated_sprite_textures.Contains(sprite_texture))
+                        {
+                            sprite_texture->m_TexturesGeneration++;
+                            if (updated_sprite_textures.Full())
+                            {
+                                updated_sprite_textures.OffsetCapacity(32);
+                            }
+                            updated_sprite_textures.Add(sprite_texture);
+                        }
+                        component->m_ReHash = 1;
+                        break;
+                    }
+                }
+            }
+        }
     }
 
     // For tests

--- a/engine/gamesys/src/gamesys/gamesys.h
+++ b/engine/gamesys/src/gamesys/gamesys.h
@@ -233,6 +233,7 @@ namespace dmGameSystem
             memset(this, 0, sizeof(*this));
         }
         dmRender::HRenderContext    m_RenderContext;
+        dmResource::HFactory        m_Factory;
         uint32_t                    m_MaxSpriteCount;
         uint32_t                    m_Subpixels : 1;
     };

--- a/engine/gamesys/src/gamesys/resources/res_textureset.cpp
+++ b/engine/gamesys/src/gamesys/resources/res_textureset.cpp
@@ -126,14 +126,16 @@ namespace dmGameSystem
 
         if (tile_set->m_HullSet)
             dmPhysics::DeleteHullSet2D(tile_set->m_HullSet);
+        tile_set->m_TexturesGeneration = 0;
     }
 
     static uint32_t GetResourceSize(TextureSetResource* res, uint32_t ddf_size)
     {
         uint32_t size = sizeof(TextureSetResource);
         size += ddf_size;
-        size += res->m_HullCollisionGroups.Capacity()*sizeof(dmhash_t);
-        size += res->m_AnimationIds.Capacity()*(sizeof(dmhash_t)+sizeof(uint32_t));
+        size += res->m_HullCollisionGroups.Capacity() * sizeof(dmhash_t);
+        size += res->m_AnimationIds.Capacity() * (sizeof(dmhash_t) + sizeof(uint32_t));
+        size += res->m_FrameIds.Capacity() * (sizeof(dmhash_t) + sizeof(uint32_t));
         return size;
     }
 
@@ -194,6 +196,7 @@ namespace dmGameSystem
         dmResource::Result r = AcquireResources(physics_context->m_Context, params->m_Factory, texture_set_ddf, &tmp_tile_set, params->m_Filename, true);
         if (r == dmResource::RESULT_OK)
         {
+            uint8_t current_generation = tile_set->m_TexturesGeneration;
             ReleaseResources(params->m_Factory, tile_set);
 
             tile_set->m_TextureSet = tmp_tile_set.m_TextureSet;
@@ -201,7 +204,9 @@ namespace dmGameSystem
             tile_set->m_HullCollisionGroups.Swap(tmp_tile_set.m_HullCollisionGroups);
             tile_set->m_HullSet = tmp_tile_set.m_HullSet;
             tile_set->m_AnimationIds.Swap(tmp_tile_set.m_AnimationIds);
+            tile_set->m_FrameIds.Swap(tmp_tile_set.m_FrameIds);
             dmResource::SetResourceSize(params->m_Resource, GetResourceSize(tile_set, params->m_BufferSize));
+            tile_set->m_TexturesGeneration = current_generation + 1;
         }
         else
         {

--- a/engine/gamesys/src/gamesys/test/test_gamesys.h
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.h
@@ -637,6 +637,7 @@ void GamesysTest<T>::SetUp()
 
     m_SpriteContext.m_RenderContext = m_RenderContext;
     m_SpriteContext.m_MaxSpriteCount = 32;
+    m_SpriteContext.m_Factory = m_Factory;
 
     m_CollectionProxyContext.m_Factory = m_Factory;
     m_CollectionProxyContext.m_MaxCollectionProxyCount = 8;

--- a/engine/resource/src/resource.cpp
+++ b/engine/resource/src/resource.cpp
@@ -1199,7 +1199,8 @@ static Result DoReloadResource(HFactory factory, const char* name, HResourceDesc
                 pair.m_Callback(&reload_params);
             }
         }
-        if (rd->m_PrevResource) {
+        if (rd->m_PrevResource)
+        {
             ResourceDescriptor tmp_resource = *rd;
             tmp_resource.m_Resource = rd->m_PrevResource;
             ResourceDestroyParams params;
@@ -1348,6 +1349,7 @@ Result SetResource(HFactory factory, uint64_t hashed_name, void* message)
                 params.m_Resource = rd;
                 params.m_Filename = 0;
                 params.m_FilenameHash = hashed_name;
+                params.m_Type = resource_type;
                 pair.m_Callback(&params);
             }
         }


### PR DESCRIPTION
Fix sprite strange behavior when sprite atlas was changed in runtime.

Fixes #11930 

### Technical changes
Reason:
Because pointer to `TextureSetResource` isn't changed when user updates atlas in runtime no sprite rehashing triggers. As a result after texture update sprite component used cached data about geometry, etc.
Fix:
Added resource reload callback to react to `TextureSetResource` changes. Also added `m_TexturesGeneration` field to `TextureSetResource` and use it to calculate hash to keep track that underlying texture resource was updated.

## PR checklist

* [x] Code
	* [x] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [x] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [x] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [x] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [x] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
