### PR TITLE
Add OpenAPI spec to editor HTTP server

### DIFF
--- a/editor/doc/http-api.md
+++ b/editor/doc/http-api.md
@@ -7,16 +7,27 @@ External tools can connect to the running editor and interact with it using a RE
 > This HTTP API is currently in an experimental state. It might change drastically or even be removed completely if we deem it necessary. But hopefully, it shouldn't come to that.
 
 ### Overview
-The editor can be interacted with by performing GET requests to the following URLs:
+
+The editor exposes a local HTTP server while a project is open.
+
+To quickly discover the current port, run the editor command `Help → Open Editor Server`. This opens the local server page in your browser.
+
+Interact with it by sending HTTP requests to:
 ```
-http://localhost:[port]/command
-http://localhost:[port]/console
+http://localhost:[port]/[endpoint]
 ```
+
+Endpoint descriptions are available in the OpenAPI ([v3.0.3](https://spec.openapis.org/oas/v3.0.3.html)) document:
+```
+http://localhost:[port]/openapi.json
+```
+A link to this document is displayed on the index page that opens when you invoke the `Help → Open Editor Server` command.
 
 #### Port Configuration
-Currently, the port is assigned randomly from a broad subrange. Since 1.11.0, the port is written to the `.internal/editor.port` file.
 
-Additionally, since 1.11.0, the editor executable has a command line option `--port` (or `-p`), which allows specifying the port during launch, e.g.:
+By default, the port is assigned randomly from a broad subrange. It is written to the `.internal/editor.port` file.
+
+Additionally, the editor executable has a command line option `--port` (or `-p`), which allows specifying the port during launch, e.g.:
 ```bash
 # on Windows
 .\Defold.exe --port 8181
@@ -28,86 +39,13 @@ Additionally, since 1.11.0, the editor executable has a command line option `--p
 ./Defold.app/Contents/MacOS/Defold --port 8181
 ```
 
-### The Command Endpoint
-The command endpoint exposes a subset of the commands available from the editor menu bar. To trigger a command, perform an empty POST request to a URL in the format:
+### OpenAPI
+
+The OpenAPI ([v3.0.3](https://spec.openapis.org/oas/v3.0.3.html)) document is available from the local server index page via the `OpenAPI spec` link.
+
+If needed, you can also request it directly at:
 ```
-http://localhost:[port]/command/[command]
-```
-You can obtain a list of the available commands along with a short description in JSON format by making a GET request to `http://localhost:[port]/command`. At the time of writing, this returns:
-```json
-{
-  "asset-portal"             : "Open the Asset Portal in a web browser.",
-  "build"                    : "Build and run the project.",
-  "build-html5"              : "Build the project for HTML5 and open it in a web browser.",
-  "debugger-break"           : "Break into the debugger.",
-  "debugger-continue"        : "Resume execution in the debugger.",
-  "debugger-detach"          : "Detach the debugger from the running project.",
-  "debugger-start"           : "Start the project with the debugger, or attach the debugger to the running project.",
-  "debugger-step-into"       : "Step into the current expression in the debugger.",
-  "debugger-step-out"        : "Step out of the current expression in the debugger.",
-  "debugger-step-over"       : "Step over the current expression in the debugger.",
-  "debugger-stop"            : "Stop the debugger and the running project.",
-  "documentation"            : "Open the Defold documentation in a web browser.",
-  "donate-page"              : "Open the Donate to Defold page in a web browser.",
-  "editor-logs"              : "Show the directory containing the editor logs.",
-  "engine-profiler"          : "Open the Engine Profiler in a web browser.",
-  "engine-resource-profiler" : "Open the Engine Resource Profiler in a web browser.",
-  "fetch-libraries"          : "Download the latest version of the project library dependencies.",
-  "hot-reload"               : "Hot-reload all modified files into the running project.",
-  "issues"                   : "Open the Defold Issue Tracker in a web browser.",
-  "rebuild"                  : "Rebuild and run the project.",
-  "rebundle"                 : "Re-bundle the project using the previous Bundle dialog settings.",
-  "reload-extensions"        : "Reload editor extensions.",
-  "reload-stylesheets"       : "Reload editor stylesheets.",
-  "report-issue"             : "Open the Report Issue page in a web browser.",
-  "report-suggestion"        : "Open the Report Suggestion page in a web browser.",
-  "show-build-errors"        : "Show the Build Errors tab.",
-  "show-console"             : "Show the Console tab.",
-  "show-curve-editor"        : "Show the Curve Editor tab.",
-  "support-forum"            : "Open the Defold Support Forum in a web browser.",
-  "toggle-pane-bottom"       : "Toggle visibility of the bottom editor pane.",
-  "toggle-pane-left"         : "Toggle visibility of the left editor pane.",
-  "toggle-pane-right"        : "Toggle visibility of the right editor pane."
-}
+http://localhost:[port]/openapi.json
 ```
 
-#### Response Codes
-Commands are fire-and-forget. You will not know if a command succeeds or not, only if your request was accepted. As such, all command requests will return the same response codes. They are as follows:
-
-* `202 Accepted` - The request was accepted and we are processing it. We use this instead of `200 OK` since we won't be able to tell you when it is done or how it went.
-* `400 Bad Request` - The request was malformed.
-* `403 Forbidden` - The command is supported, but it can't be executed right now (for example if a build is already in progress).
-* `404 Not Found` - The string after `command/` is not a supported command.
-* `405 Method Not Allowed` - The request method is invalid. For example, trying to GET a command or POST to the console.
-* `500 Internal Server Error` - Something unexpected went wrong when executing the command. The error will be logged in the editor log.
-
-### The Console Endpoint
-The console endpoint allows external tools to obtain the current contents of the Console View in the editor. Send a GET request to `http://localhost:[port]/console` to obtain the console contents in JSON format. The returned object contains `lines` and `regions`.
-
-* The `lines` are returned as an array of strings, each string representing a line in the Console.
-* The `regions` contain metadata about sub-regions of the `lines` that can inform formatting, etc.
-
-#### Region Objects
-Each region object will be in the following format:
-```json
-{
-  "from": {"row": 0, "col": 0},
-  "to":   {"row": 0, "col": 42},
-  "type": "repeat"
-}
-```
-* `from` and `to` specify the row and columns that encompass the region as zero-based indices into the `lines`.
-* `type` is the type of the region, and can inform formatting.
-
-#### Region Types
-Depending on the `type` of a region, it might have additional fields. Here is a non-exhaustive list of region types used in the editor.
-
-* `eval-expression` - An expression posted from the Evaluate Lua field in the debugger.
-* `eval-result` - The result returned by the `eval-expression`.
-* `eval-error` - A runtime error resulting from an `eval-expression`.
-* `extension-output` - Output from an editor script or extension.
-* `extension-error` - Errors from an editor script or extension.
-* `repeat` - Repeated console output that has been collapsed. Its `count` is the number of repeats.
-* `resource-reference` - A substring that matches an existing path in the project. It has a `proj-path-candidates` array of project-relative paths to matching resources, and can also have a zero-based `row` index into the resource if it is text-based.
-
-In particular, `resource-reference` regions could be made clickable to allow the user to  navigate to the source of a Lua error as the editor will attempt to parse this information from callstacks.
+Use this document as the source of truth for the currently available API operations, including their request and response schemas.

--- a/editor/resources/localization/en.editor_localization
+++ b/editor/resources/localization/en.editor_localization
@@ -975,6 +975,7 @@ command.help.open-logs = Show Logs
 command.file.create-desktop-entry = Create Desktop Entry
 command.help.open-documentation = Documentation
 command.help.open-forum = Support Forum
+command.help.open-editor-server = Open Editor Server
 command.help.open-asset-portal = Find Assets
 command.help.report-issue = Report Issue
 command.help.report-suggestion = Report Suggestion

--- a/editor/resources/localization/ru.editor_localization
+++ b/editor/resources/localization/ru.editor_localization
@@ -975,6 +975,7 @@ command.help.open-logs = Показать логи
 command.file.create-desktop-entry = Создать ярлык на рабочем столе
 command.help.open-documentation = Документация
 command.help.open-forum = Открыть форум
+command.help.open-editor-server = Открыть сервер редактора
 command.help.open-asset-portal = Найти ассеты
 command.help.report-issue = Сообщить о проблеме
 command.help.report-suggestion = Предложить улучшение

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -1834,6 +1834,10 @@
 (handler/defhandler :help.open-logs :global
   (run [] (ui/open-file (.getAbsoluteFile (.toFile (Editor/getLogDirectory))))))
 
+(handler/defhandler :help.open-editor-server :global
+  (run [web-server]
+    (ui/open-url (http-server/local-url web-server))))
+
 (handler/defhandler :help.open-donations :global
   (run [] (ui/open-url "https://www.defold.com/donate")))
 
@@ -1960,6 +1964,8 @@
                 :command :help.open-documentation}
                {:label (localization/message "command.help.open-forum")
                 :command :help.open-forum}
+               {:label (localization/message "command.help.open-editor-server")
+                :command :help.open-editor-server}
                {:label (localization/message "command.help.open-asset-portal")
                 :command :help.open-asset-portal}
                menu-items/separator

--- a/editor/src/clj/editor/boot_open_project.clj
+++ b/editor/src/clj/editor/boot_open_project.clj
@@ -213,7 +213,7 @@
           server-handler (web-server/make-dynamic-handler
                            (into []
                                  cat
-                                 [(web-server/built-in-routes project-path)
+                                 [(web-server/built-in-routes project)
                                   (engine-profiler/routes)
                                   (console/routes console-view)
                                   (hot-reload/routes workspace)

--- a/editor/src/clj/editor/boot_open_project.clj
+++ b/editor/src/clj/editor/boot_open_project.clj
@@ -213,7 +213,8 @@
           server-handler (web-server/make-dynamic-handler
                            (into []
                                  cat
-                                 [(engine-profiler/routes)
+                                 [(web-server/built-in-routes project-path)
+                                  (engine-profiler/routes)
                                   (console/routes console-view)
                                   (hot-reload/routes workspace)
                                   (bob/routes project)

--- a/editor/src/clj/editor/command_requests.clj
+++ b/editor/src/clj/editor/command_requests.clj
@@ -14,8 +14,6 @@
 
 (ns editor.command-requests
   (:require [cljfx.api :as fx]
-            [clojure.data.json :as json]
-            [clojure.string :as string]
             [dynamo.graph :as g]
             [editor.build-errors-view :as build-errors-view]
             [editor.disk :as disk]
@@ -188,27 +186,32 @@
    {:ui-handler :window.toggle-right-pane
     :help "Toggle visibility of the right editor pane."}})
 
-(def ^:private api-response
-  (let [longest-command-length
-        (reduce (fn [result [command]]
-                  (max result (count (name command))))
-                Long/MIN_VALUE
-                supported-commands)
-
-        command-format-string
-        (str "  %-" (+ longest-command-length 2) "s : %s")
-
-        help-json-string
-        (str "{\n"
-             (->> supported-commands
-                  (sort-by key)
-                  (map (fn [[command {:keys [help]}]]
-                         (format command-format-string
-                                 (json/write-str (name command))
-                                 (json/write-str help))))
-                  (string/join ",\n"))
-             "\n}\n")]
-    (http-server/response 200 {"content-type" (http-server/ext->content-type "json")} help-json-string)))
+(defn- command-openapi []
+  (let [command->help (coll/into-> supported-commands (sorted-map)
+                       (map (fn [[command {:keys [help]}]]
+                              (coll/pair (name command) help))))]
+    {:summary "Execute an editor command"
+     :description (str "Available commands:\n"
+                       (coll/join-to-string
+                         (coll/into-> command->help :eduction
+                           (map (fn [[command help]]
+                                  (str "- `" command "`: " help "\n"))))))
+     :parameters [{:name "command"
+                   :in "path"
+                   :required true
+                   :description "Command to execute."
+                   :schema {:type "string"
+                            :enum (persistent!
+                                    (reduce-kv (fn [acc command _]
+                                                 (conj! acc command))
+                                               (transient [])
+                                               command->help))}}]
+     :responses {"200" {:description "Command completed and returned a response body"}
+                 "202" {:description "Accepted"}
+                 "403" {:description "Forbidden"}
+                 "404" {:description "Unknown command"}
+                 "422" {:description "Command failed validation/build checks"}
+                 "500" {:description "Internal server error"}}}))
 
 (defn- resolve-ui-handler-ctx [ui-node ui-handler user-data]
   {:pre [(ui/node? ui-node)
@@ -219,54 +222,55 @@
        (ui/resolve-handler-ctx command-contexts ui-handler user-data))))
 
 (defn router [ui-node localization render-reload-progress!]
-  {"/command" {"GET" (constantly api-response)}
-   "/command/{command}"
-   {"POST" (bound-fn [request]
-             (let [command (-> request :path-params :command keyword)]
-               (if-let [{:keys [ui-handler resource-sync response-fn]} (supported-commands command)]
-                 (let [ui-handler-ctx (resolve-ui-handler-ctx ui-node ui-handler {})]
-                   (case ui-handler-ctx
-                     (::ui/not-active ::ui/not-enabled) http-server/forbidden
-                     (let [{:keys [changes-view workspace]} (:env (second ui-handler-ctx))
-                           result-future (future/make)
-                           execute-command!
-                           (bound-fn execute-command! []
-                             (-> (try
-                                   (future/completed (ui/execute-handler-ctx ui-handler-ctx))
-                                   (catch Throwable e (future/failed e)))
-                                 (future/then
-                                   (fn [result]
-                                     (if response-fn
-                                       (response-fn result @localization)
-                                       http-server/accepted)))
-                                 (future/then
-                                   (fn [response]
-                                     (future/complete! result-future response)))
-                                 (future/catch
-                                   (fn [error]
-                                     (log/error :msg "Failed to handle command request"
-                                                :request request
-                                                :exception error)
-                                     (future/complete! result-future http-server/internal-server-error)))))]
-                       (assert (g/node-id? changes-view))
-                       (assert (g/node-id? workspace))
-                       (when-not (Boolean/getBoolean "defold.tests")
-                         (log/info :msg "Processing request" :command command))
-                       (if-not resource-sync
-                         (ui/run-later (execute-command!))
-                         (disk/async-reload!
-                           render-reload-progress! workspace [] changes-view
-                           (fn async-reload-continuation [success]
-                             ;; This callback is executed on the ui thread.
-                             (if success
-                               (execute-command!)
-                               (do
-                                 ;; Explicitly refresh the UI after the reload, since
-                                 ;; the ui-handler will not have done so on failure.
-                                 (ui/user-data! (ui/scene ui-node) ::ui/refresh-requested? true)
-                                 (future/complete! result-future http-server/internal-server-error))))))
-                       result-future)))
-                 http-server/not-found)))}})
+  {"/command/{command}"
+   {"POST" (with-meta
+             (bound-fn [request]
+               (let [command (-> request :path-params :command keyword)]
+                 (if-let [{:keys [ui-handler resource-sync response-fn]} (supported-commands command)]
+                   (let [ui-handler-ctx (resolve-ui-handler-ctx ui-node ui-handler {})]
+                     (case ui-handler-ctx
+                       (::ui/not-active ::ui/not-enabled) http-server/forbidden
+                       (let [{:keys [changes-view workspace]} (:env (second ui-handler-ctx))
+                             result-future (future/make)
+                             execute-command!
+                             (bound-fn execute-command! []
+                               (-> (try
+                                     (future/completed (ui/execute-handler-ctx ui-handler-ctx))
+                                     (catch Throwable e (future/failed e)))
+                                   (future/then
+                                     (fn [result]
+                                       (if response-fn
+                                         (response-fn result @localization)
+                                         http-server/accepted)))
+                                   (future/then
+                                     (fn [response]
+                                       (future/complete! result-future response)))
+                                   (future/catch
+                                     (fn [error]
+                                       (log/error :msg "Failed to handle command request"
+                                                  :request request
+                                                  :exception error)
+                                       (future/complete! result-future http-server/internal-server-error)))))]
+                         (assert (g/node-id? changes-view))
+                         (assert (g/node-id? workspace))
+                         (when-not (Boolean/getBoolean "defold.tests")
+                           (log/info :msg "Processing request" :command command))
+                         (if-not resource-sync
+                           (ui/run-later (execute-command!))
+                           (disk/async-reload!
+                             render-reload-progress! workspace [] changes-view
+                             (fn async-reload-continuation [success]
+                               ;; This callback is executed on the ui thread.
+                               (if success
+                                 (execute-command!)
+                                 (do
+                                   ;; Explicitly refresh the UI after the reload, since
+                                   ;; the ui-handler will not have done so on failure.
+                                   (ui/user-data! (ui/scene ui-node) ::ui/refresh-requested? true)
+                                   (future/complete! result-future http-server/internal-server-error))))))
+                         result-future)))
+                   http-server/not-found)))
+             {:openapi (command-openapi)})}})
 
 (comment
 

--- a/editor/src/clj/editor/command_requests.clj
+++ b/editor/src/clj/editor/command_requests.clj
@@ -193,9 +193,10 @@
     {:summary "Execute an editor command"
      :description (str "Available commands:\n"
                        (coll/join-to-string
+                         "\n"
                          (coll/into-> command->help :eduction
                            (map (fn [[command help]]
-                                  (str "- `" command "`: " help "\n"))))))
+                                  (str "- `" command "`: " help))))))
      :parameters [{:name "command"
                    :in "path"
                    :required true

--- a/editor/src/clj/editor/console.clj
+++ b/editor/src/clj/editor/console.clj
@@ -817,4 +817,23 @@
                  {:description "Console lines and regions"
                   :content
                   {"application/json"
-                   {:schema {:type "object"}}}}}}})}}))
+                   {:schema
+                    {:type "object"
+                     :required ["lines" "regions"]
+                     :properties
+                     {:lines {:type "array"
+                              :items {:type "string"}}
+                      :regions {:type "array"
+                                :items {:type "object"
+                                        :required ["from" "to" "type"]
+                                        :properties
+                                        {:from {:type "object"
+                                                :required ["row" "col"]
+                                                :properties {:row {:type "integer"}
+                                                             :col {:type "integer"}}}
+                                         :to {:type "object"
+                                              :required ["row" "col"]
+                                              :properties {:row {:type "integer"}
+                                                           :col {:type "integer"}}}
+                                         :type {:type "string"
+                                                :description "Region type, e.g. extension-output, extension-error, resource-reference, repeat, eval-expression, eval-result, or eval-error."}}}}}}}}}}}})}}))

--- a/editor/src/clj/editor/console.clj
+++ b/editor/src/clj/editor/console.clj
@@ -806,5 +806,15 @@
 (defn routes [console-view]
   (let [console-node (g/node-value console-view :resource-node)]
     (assert (g/node-instance? ConsoleNode console-node))
-    {"/console" {"GET" (bound-fn [_]
-                         (g/node-value console-node :request-response))}}))
+    {"/console"
+     {"GET" (with-meta
+              (bound-fn [_]
+                (g/node-value console-node :request-response))
+              {:openapi
+               {:summary "Read console output"
+                :responses
+                {"200"
+                 {:description "Console lines and regions"
+                  :content
+                  {"application/json"
+                   {:schema {:type "object"}}}}}}})}}))

--- a/editor/src/clj/editor/editor_extensions.clj
+++ b/editor/src/clj/editor/editor_extensions.clj
@@ -733,7 +733,7 @@
            (fn [acc [path method :as path+method] routes]
              (if (= 1 (count routes))
                (let [{:keys [handler proj-path]} (routes 0)]
-                 (assoc-in acc path+method (with-meta handler {:proj-path proj-path})))
+                 (assoc-in acc path+method (vary-meta handler assoc :proj-path proj-path)))
                (do
                  (display-output! :err (str "Omitting conflicting routes for '"
                                             method " " path "' defined in "

--- a/editor/src/clj/editor/editor_extensions/docs.clj
+++ b/editor/src/clj/editor/editor_extensions/docs.clj
@@ -482,6 +482,9 @@ editor.create_resources({
                        {:name "[as]"
                         :types ["string"]
                         :doc "Request body converter, either <code>\"string\"</code> or <code>\"json\"</code>; the body will be discarded if not specified"}
+                       {:name "[openapi]"
+                        :types ["table"]
+                        :doc "Optional OpenAPI Operation Object for this route method, exposed from <code>/openapi.json</code>. Must follow <code>https://spec.openapis.org/oas/v3.0.3.html#operation-object</code>."}
                        {:name "handler"
                         :types ["function"]
                         :doc (str "Request handler function, will receive request argument, a table with the following keys:"

--- a/editor/src/clj/editor/editor_extensions/http_server.clj
+++ b/editor/src/clj/editor/editor_extensions/http_server.clj
@@ -166,7 +166,7 @@
            :method method
            :handler (bound-fn ext-http-request-handler [request]
                       (let [request (-> request
-                                        (dissoc :path-params)
+                                        (dissoc :path-params :router)
                                         (coll/merge (:path-params request)))]
                         (try
                           (let [request (case as

--- a/editor/src/clj/editor/editor_extensions/http_server.clj
+++ b/editor/src/clj/editor/editor_extensions/http_server.clj
@@ -142,6 +142,7 @@
   (coerce/regex :path coerce/string
                 :method :? request-method-coercer
                 :as :? (coerce/enum :string :json)
+                :openapi :? json-value-coercer
                 :handler coerce/function))
 
 (def ^:private reserved-path-param-names
@@ -154,7 +155,7 @@
 
 (def ^:private ext-route-fn
   (rt/varargs-lua-fn ext-route [{:keys [rt]} varargs]
-    (let [{:keys [path method as handler]
+    (let [{:keys [path method as openapi handler]
            :or {method "GET" as :discard}} (rt/->clj rt route-args-coercer varargs)
           {:keys [path-params]} (reitit.impl/parse path {:syntax :bracket})]
       (run!
@@ -164,29 +165,30 @@
         path-params)
       (-> {:path path
            :method method
-           :handler (bound-fn ext-http-request-handler [request]
-                      (let [request (-> request
-                                        (dissoc :path-params :router)
-                                        (coll/merge (:path-params request)))]
-                        (try
-                          (let [request (case as
-                                          :discard (do (.close ^InputStream (:body request))
-                                                       (dissoc request :body))
-                                          :string (update request :body slurp)
-                                          :json (with-open [r (io/reader (:body request))]
-                                                  (assoc request :body (json/read r))))]
-                            (-> (rt/invoke-suspending rt handler (rt/->lua request))
-                                (future/then
-                                  (fn [varargs]
-                                    (let [{:keys [status headers body]
-                                           :or {status 200}} (rt/->clj rt response-coercer varargs)]
-                                      (http-server/response status headers body))))
-                                (future/catch
-                                  (fn [e]
-                                    (.println (rt/stderr rt) (or (ex-message e) (.getSimpleName (class e))))
-                                    http-server/internal-server-error))))
-                          (catch Throwable e
-                            (http-server/response 400 (or (ex-message e) (.getSimpleName (class e))))))))}
+           :handler (cond-> (bound-fn ext-http-request-handler [request]
+                              (let [request (-> request
+                                                (dissoc :path-params :router)
+                                                (coll/merge (:path-params request)))]
+                                (try
+                                  (let [request (case as
+                                                  :discard (do (.close ^InputStream (:body request))
+                                                               (dissoc request :body))
+                                                  :string (update request :body slurp)
+                                                  :json (with-open [r (io/reader (:body request))]
+                                                          (assoc request :body (json/read r))))]
+                                    (-> (rt/invoke-suspending rt handler (rt/->lua request))
+                                        (future/then
+                                          (fn [varargs]
+                                            (let [{:keys [status headers body]
+                                                   :or {status 200}} (rt/->clj rt response-coercer varargs)]
+                                              (http-server/response status headers body))))
+                                        (future/catch
+                                          (fn [e]
+                                            (.println (rt/stderr rt) (or (ex-message e) (.getSimpleName (class e))))
+                                            http-server/internal-server-error))))
+                                  (catch Throwable e
+                                    (http-server/response 400 (or (ex-message e) (.getSimpleName (class e))))))))
+                            openapi (with-meta {:openapi openapi}))}
           (with-meta {:type :route})
           (rt/wrap-userdata "http.server.route(...)")))))
 

--- a/editor/src/clj/editor/http_server/prefs.clj
+++ b/editor/src/clj/editor/http_server/prefs.clj
@@ -157,5 +157,30 @@
         (throw e)))))
 
 (defn routes [prefs]
-  {"/prefs/{*path}" {"GET" (partial #'handle-get-prefs prefs)
-                     "POST" (partial #'handle-post-prefs prefs)}})
+  (let [prefs-path-openapi-parameters
+        [{:name "path"
+          :in "path"
+          :required true
+          :description "Slash-delimited preference path. You can target either a preference group (for example `code/font`) or a leaf value (for example `code/font/size`)."
+          :schema {:type "string"}
+          :examples {"code-font" {:summary "Preference group"
+                                  :value "code/font"}
+                     "code-font-size" {:summary "Leaf value in preference group"
+                                       :value "code/font/size"}}}]]
+    {"/prefs/{*path}" {"GET" (with-meta
+                               (partial #'handle-get-prefs prefs)
+                               {:openapi
+                                {:summary "Read a preference value"
+                                 :parameters prefs-path-openapi-parameters
+                                 :responses {"200" {:description "Preference value"
+                                                    :content {"application/json" {}}}
+                                             "400" {:description "Invalid path"}}}})
+                       "POST" (with-meta
+                                (partial #'handle-post-prefs prefs)
+                                {:openapi
+                                 {:summary "Write a preference value"
+                                  :parameters prefs-path-openapi-parameters
+                                  :requestBody {:required true
+                                                :content {"application/json" {}}}
+                                  :responses {"200" {:description "Preference updated"}
+                                              "400" {:description "Invalid path or value"}}}})}}))

--- a/editor/src/clj/editor/web_server.clj
+++ b/editor/src/clj/editor/web_server.clj
@@ -13,11 +13,15 @@
 ;; specific language governing permissions and limitations under the License.
 
 (ns editor.web-server
-  (:require [clojure.string :as string]
+  (:require [clojure.java.io :as io]
+            [clojure.string :as string]
+            [dynamo.graph :as g]
+            [editor.lsp.async :as lsp.async]
             [editor.util :as util]
             [reitit.core :as reitit]
             [util.coll :as coll]
-            [util.http-server :as http-server]))
+            [util.http-server :as http-server])
+  (:import [org.apache.commons.io FilenameUtils]))
 
 (set! *warn-on-reflection* true)
 
@@ -40,25 +44,33 @@
             :version "1.0"}
      :paths (openapi-paths (:router request))}))
 
-(defn- index-response [project-path]
-  (http-server/response
-    200
-    {"content-type" "text/html; charset=utf-8"}
-    (str "<!doctype html>\n"
-         "<html>\n"
-         "  <head>\n"
-         "    <meta charset=\"utf-8\">\n"
-         "    <title>Defold Editor HTTP Server</title>\n"
-         "  </head>\n"
-         "  <body>\n"
-         "    <h1>Defold Editor HTTP Server</h1>\n"
-         "    <p><strong>Project:</strong> <code>" project-path "</code></p>\n"
-         "    <p><a href=\"/openapi.json\">OpenAPI spec</a></p>\n"
-         "  </body>\n"
-         "</html>\n")))
+(defn- index-response [project]
+  (lsp.async/with-auto-evaluation-context evaluation-context
+    (let [project-path (-> project
+                           (g/node-value :workspace evaluation-context)
+                           (g/node-value :root evaluation-context))
+          title (-> project
+                    (g/maybe-node-value :settings evaluation-context)
+                    (get ["project" "title"]))
+          project-title (or title (FilenameUtils/getName project-path))]
+      (http-server/response
+        200
+        {"content-type" "text/html; charset=utf-8"}
+        (str "<!doctype html>\n"
+             "<html>\n"
+             "  <head>\n"
+             "    <meta charset=\"utf-8\">\n"
+             "    <title>Defold Editor HTTP Server - " project-title "</title>\n"
+             "  </head>\n"
+             "  <body>\n"
+             "    <h1>Defold Editor HTTP Server - " project-title "</h1>\n"
+             "    <p><strong>Project:</strong> <code>" project-path "</code></p>\n"
+             "    <p><a href=\"/openapi.json\">OpenAPI spec</a></p>\n"
+             "  </body>\n"
+             "</html>\n")))))
 
-(defn built-in-routes [project-path]
-  {"/" {"GET" (constantly (index-response project-path))}
+(defn built-in-routes [project]
+  {"/" {"GET" (bound-fn [_] (index-response project))}
    "/openapi.json" {"GET" openapi-response}})
 
 (defn make-dynamic-handler

--- a/editor/src/clj/editor/web_server.clj
+++ b/editor/src/clj/editor/web_server.clj
@@ -13,9 +13,53 @@
 ;; specific language governing permissions and limitations under the License.
 
 (ns editor.web-server
-  (:require [util.http-server :as http-server]))
+  (:require [clojure.string :as string]
+            [editor.util :as util]
+            [reitit.core :as reitit]
+            [util.coll :as coll]
+            [util.http-server :as http-server]))
 
 (set! *warn-on-reflection* true)
+
+(defn- openapi-paths [router]
+  (coll/into-> (reitit/routes router) {}
+    (keep
+      (fn [[path method->handler]]
+        (let [method->operation (coll/into-> method->handler {}
+                                  (keep (fn [[method handler]]
+                                          (when-let [operation (:openapi (meta handler))]
+                                            (coll/pair (util/lower-case* method) operation)))))]
+          (when-not (coll/empty? method->operation)
+            ;; Convert reitit rest-parameter syntax `{*param}` to OpenAPI `{param}`.
+            (coll/pair (string/replace path #"\{\*([^}]+)\}" "{$1}") method->operation)))))))
+
+(defn- openapi-response [request]
+  (http-server/json-response
+    {:openapi "3.0.3"
+     :info {:title "Defold Editor HTTP API"
+            :version "1.0"}
+     :paths (openapi-paths (:router request))}))
+
+(defn- index-response [project-path]
+  (http-server/response
+    200
+    {"content-type" "text/html; charset=utf-8"}
+    (str "<!doctype html>\n"
+         "<html>\n"
+         "  <head>\n"
+         "    <meta charset=\"utf-8\">\n"
+         "    <title>Defold Editor HTTP Server</title>\n"
+         "  </head>\n"
+         "  <body>\n"
+         "    <h1>Defold Editor HTTP Server</h1>\n"
+         "    <p><strong>Project:</strong> <code>" project-path "</code></p>\n"
+         "    <p><a href=\"/openapi.json\">OpenAPI spec</a></p>\n"
+         "  </body>\n"
+         "</html>\n")))
+
+(defn built-in-routes [project-path]
+  {"/" {"GET" (constantly (index-response project-path))}
+   "/openapi.json" {"GET" openapi-response}})
 
 (defn make-dynamic-handler
   "Create an HTTP request handler that supports setting dynamic routes
@@ -40,3 +84,20 @@
   (let [{::keys [built-in-routes state]} (meta web-handler)]
     (reset! state (http-server/router-handler (into built-in-routes dynamic-routes))))
   nil)
+
+(comment
+
+  (println
+    (editor.process/exec!
+      {:err :stdout}
+      "sh" "-lc"
+      (str "curl -sS " (http-server/local-url (dev/web-server)) "/openapi.json"
+           " | npx -y @redocly/cli lint /dev/stdin"
+           "   --skip-rule no-empty-servers"
+           "   --skip-rule security-defined"
+           "   --skip-rule info-license"
+           "   --skip-rule operation-operationId"
+           "   --skip-rule operation-4xx-response"
+           " || true")))
+
+  #__)

--- a/editor/src/clj/editor/web_server.clj
+++ b/editor/src/clj/editor/web_server.clj
@@ -13,8 +13,7 @@
 ;; specific language governing permissions and limitations under the License.
 
 (ns editor.web-server
-  (:require [clojure.java.io :as io]
-            [clojure.string :as string]
+  (:require [clojure.string :as string]
             [dynamo.graph :as g]
             [editor.lsp.async :as lsp.async]
             [editor.util :as util]

--- a/editor/src/clj/editor/web_server.clj
+++ b/editor/src/clj/editor/web_server.clj
@@ -44,15 +44,23 @@
             :version "1.0"}
      :paths (openapi-paths (:router request))}))
 
+(defn- html-escape [s]
+  (string/escape s {\& "&amp;"
+                    \< "&lt;"
+                    \> "&gt;"
+                    \" "&quot;"
+                    \' "&#39;"}))
+
 (defn- index-response [project]
   (lsp.async/with-auto-evaluation-context evaluation-context
     (let [project-path (-> project
                            (g/node-value :workspace evaluation-context)
                            (g/node-value :root evaluation-context))
-          title (-> project
-                    (g/maybe-node-value :settings evaluation-context)
-                    (get ["project" "title"]))
-          project-title (or title (FilenameUtils/getName project-path))]
+          project-title-html (html-escape
+                               (or (-> project
+                                       (g/maybe-node-value :settings evaluation-context)
+                                       (get ["project" "title"]))
+                                   (FilenameUtils/getName project-path)))]
       (http-server/response
         200
         {"content-type" "text/html; charset=utf-8"}
@@ -60,11 +68,11 @@
              "<html>\n"
              "  <head>\n"
              "    <meta charset=\"utf-8\">\n"
-             "    <title>Defold Editor HTTP Server - " project-title "</title>\n"
+             "    <title>Defold Editor HTTP Server - " project-title-html "</title>\n"
              "  </head>\n"
              "  <body>\n"
-             "    <h1>Defold Editor HTTP Server - " project-title "</h1>\n"
-             "    <p><strong>Project:</strong> <code>" project-path "</code></p>\n"
+             "    <h1>Defold Editor HTTP Server - " project-title-html "</h1>\n"
+             "    <p><strong>Project:</strong> <code>" (html-escape project-path) "</code></p>\n"
              "    <p><a href=\"/openapi.json\">OpenAPI spec</a></p>\n"
              "  </body>\n"
              "</html>\n")))))

--- a/editor/src/clj/editor/web_server.clj
+++ b/editor/src/clj/editor/web_server.clj
@@ -99,6 +99,8 @@
 
 (comment
 
+  ;; If you are adding built-in OpenAPI routes, this is a handy validator tool
+  ;; to run against a running server:
   (println
     (editor.process/exec!
       {:err :stdout}

--- a/editor/src/clj/util/http_server.clj
+++ b/editor/src/clj/util/http_server.clj
@@ -397,8 +397,8 @@
         method-set (cond-> method-set (contains? method-set "GET") (conj "HEAD"))]
     (string/join ", " (sort method-set))))
 
-(defn- invoke-handler [handler request match]
-  (handler (assoc request :path-params (:path-params match))))
+(defn- invoke-handler [handler request router match]
+  (handler (assoc request :path-params (:path-params match) :router router)))
 
 (defn router-handler
   "Create HTTP request handler function from reitit routes
@@ -449,7 +449,7 @@
           (let [method->handler (:data match)
                 method (:method request)]
             (if-let [handler (method->handler method)]
-              (invoke-handler handler request match)
+              (invoke-handler handler request router match)
               (case method
                 "OPTIONS" (response
                             200
@@ -457,7 +457,7 @@
                              "access-control-allow-methods" (allowed-methods method->handler)}
                             nil)
                 "HEAD" (if-let [get-handler (method->handler "GET")]
-                         (invoke-handler get-handler request match) ;; http server will strip the body
+                         (invoke-handler get-handler request router match) ;; http server will strip the body
                          (update method-not-allowed :headers assoc "allow" (allowed-methods method->handler)))
                 (update method-not-allowed :headers assoc "allow" (allowed-methods method->handler)))))
           not-found)))))

--- a/editor/src/dev/dev.clj
+++ b/editor/src/dev/dev.clj
@@ -234,6 +234,9 @@
 (defn localization []
   (some #(-> % :env :localization) (ui/contexts (ui/main-scene) true)))
 
+(defn web-server []
+  (some #(-> % :env :web-server) (ui/contexts (ui/main-scene) true)))
+
 (declare ^:private exclude-keys-deep-helper)
 
 (defn- exclude-keys-deep-value-helper [excluded-map-entry? value]

--- a/editor/test/integration/editor_extensions_test.clj
+++ b/editor/test/integration/editor_extensions_test.clj
@@ -1232,8 +1232,7 @@ GET /test/resources/test.json as json => 200
     (with-open [server (http-server/start!
                          (web-server/make-dynamic-handler
                            ;; for testing conflicts with the built-in handlers
-                           {"/command" {"GET" (constantly http-server/not-found)}
-                            "/command/{command}" {"POST" (constantly http-server/not-found)}}))]
+                           {"/command/{command}" {"POST" (constantly http-server/not-found)}}))]
       (let [out (StringBuilder.)]
         (reload-editor-scripts! project
                                 :display-output! #(doto out (.append %2) (.append \newline))

--- a/editor/test/integration/editor_extensions_test.clj
+++ b/editor/test/integration/editor_extensions_test.clj
@@ -1225,6 +1225,13 @@ GET /test/resources/test.json as json => 200
 { --[[0x2]]
   test = true
 }
+POST /test/openapi/foo '{}' as string => 200
+< content-length: 6
+< content-type: text/plain; charset=utf-8
+\"ok:foo\"
+GET /openapi.json as json => 200
+openapi route summary => OpenAPI route from script
+openapi route has 200 => true
 ")
 
 (deftest http-server-test
@@ -1232,7 +1239,8 @@ GET /test/resources/test.json as json => 200
     (with-open [server (http-server/start!
                          (web-server/make-dynamic-handler
                            ;; for testing conflicts with the built-in handlers
-                           {"/command/{command}" {"POST" (constantly http-server/not-found)}}))]
+                           (merge (web-server/built-in-routes project)
+                                  {"/command/{command}" {"POST" (constantly http-server/not-found)}})))]
       (let [out (StringBuilder.)]
         (reload-editor-scripts! project
                                 :display-output! #(doto out (.append %2) (.append \newline))

--- a/editor/test/integration/web_server_test.clj
+++ b/editor/test/integration/web_server_test.clj
@@ -272,7 +272,7 @@
         (with-open [server (http-server/start!
                              (web-server/make-dynamic-handler
                                (into [] cat [(engine-profiler/routes)
-                                             (web-server/built-in-routes (workspace/project-directory workspace))
+                                             (web-server/built-in-routes project)
                                              (console/routes console-view)
                                              (hot-reload/routes workspace)
                                              (bob/routes project)

--- a/editor/test/integration/web_server_test.clj
+++ b/editor/test/integration/web_server_test.clj
@@ -272,11 +272,27 @@
         (with-open [server (http-server/start!
                              (web-server/make-dynamic-handler
                                (into [] cat [(engine-profiler/routes)
+                                             (web-server/built-in-routes (workspace/project-directory workspace))
                                              (console/routes console-view)
                                              (hot-reload/routes workspace)
                                              (bob/routes project)
                                              (command-requests/router root test-util/localization progress/null-render-progress!)])))]
           (let [url (http-server/local-url server)]
+            (let [{:keys [status headers body]} @(http/request (str url "/") :as :string)]
+              (is (= 200 status))
+              (is (= "text/html; charset=utf-8" (get headers "content-type")))
+              (is (string/includes? body "Defold Editor HTTP Server"))
+              (is (string/includes? body "/openapi.json")))
+            (let [{:keys [status headers body]} @(http/request (str url "/openapi.json") :as :string)]
+              (is (= 200 status))
+              (is (= "application/json" (get headers "content-type")))
+              (let [json-body (json/read-str body)]
+                (is (= "3.0.3" (get json-body "openapi")))
+                (is (contains? (get json-body "paths") "/console"))
+                (let [post-command (get-in json-body ["paths" "/command/{command}" "post"])]
+                  (is (= "Execute an editor command" (get post-command "summary")))
+                  (is (string/includes? (get post-command "description") "`build-html5`"))
+                  (is (some #{"build-html5"} (get-in post-command ["parameters" 0 "schema" "enum"]))))))
             (let [{:keys [status headers body]} @(http/request (str url "/engine-profiler/") :as :string)]
               (is (= 200 status))
               (is (= "text/html" (get headers "content-type")))
@@ -289,10 +305,8 @@
               (is (= 200 status))
               (is (= "application/json" (get headers "content-type")))
               (is (string/includes? body "\"lines\":")))
-            (let [{:keys [status headers body]} (update @(http/request (str url "/command/") :as :string) :body json/read-str :key-fn keyword)]
-              (is (= 200 status))
-              (is (= "application/json" (get headers "content-type")))
-              (is (contains? body :build-html5)))
+            (let [{:keys [status]} @(http/request (str url "/command/") :as :string)]
+              (is (= 404 status)))
             (let [{:keys [status headers body]} @(http/request (str url "/command/build-html5") :as :string)]
               (is (= 405 status))
               (is (= "OPTIONS, POST" (get headers "allow")))

--- a/editor/test/resources/editor_extensions/http_server_project/test.editor_script
+++ b/editor/test/resources/editor_extensions/http_server_project/test.editor_script
@@ -41,6 +41,17 @@ function M.get_http_server_routes()
                 return attrs.is_directory and 400 or 404
             end
         end),
+        http.server.route("/test/openapi/{id}", "POST", "json", {
+            summary = "OpenAPI route from script",
+            parameters = {
+                {name = "id", ["in"] = "path", required = true, schema = {type = "string"}}
+            },
+            responses = {
+                ["200"] = {description = "OK"}
+            }
+        }, function(request)
+            return "ok:" .. request.id
+        end),
         http.server.route("/test/conflict/same-path-and-method", "GET", ok_handler),
         http.server.route("/test/conflict/same-path-and-method", "GET", ok_handler),
         http.server.route("/test/conflict/no-param", ok_handler),
@@ -95,6 +106,12 @@ function M.get_commands()
             test("/test/resources/not-found.txt", {method = "GET", as = "string"})
             test("/test/resources/test.txt", {method = "GET", as = "string"})
             test("/test/resources/test.json", {method = "GET", as = "json"})
+            test("/test/openapi/foo", {method = "POST", body = "{}", as = "string"})
+            local response = http.request(http.server.url .. "/openapi.json", {as = "json"})
+            print(("GET /openapi.json as json => %s"):format(response.status))
+            local operation = response.body.paths["/test/openapi/{id}"].post
+            print("openapi route summary => " .. operation.summary)
+            print("openapi route has 200 => " .. tostring(operation.responses["200"] ~= nil))
         end
     }}
 end


### PR DESCRIPTION
We added an [OpenAPI](https://spec.openapis.org/oas/v3.0.3.html) spec to the editor's built-in HTTP server. This makes it more discoverable for AI agents, now they only need to know that the port is in `.internal/editor.port`, and they can learn the rest themselves.

#### Example using your favorite coding agent:
```md
> given a local server in .internal/editor.port, what can you do with the server? 
• I found a live Defold Editor HTTP server. Next I’ll inspect its OpenAPI spec to list exactly
  what operations are available...
• With the server on port in `.internal/editor.port` file, I can control/read parts
  of your Defold editor via HTTP:

  Read editor console output
  `GET /console`

  Execute built-in editor commands
  `POST /command/{command}`
  Examples: build, rebuild, build-html5, hot-reload, debugger commands, fetch-libraries, 
  pane toggles, open docs/issues/profiler pages.

  Read/write editor preferences
  `GET /prefs/{path} and POST /prefs/{path}`
  Examples of paths: `code/font`, `code/font/size`.
```

Fix #11964 