### PR TITLE
Support new Protobuf features in the editor

### DIFF
--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -437,7 +437,7 @@
 
 (declare get-registered-node-type-cls)
 
-(def ^:private default-node-desc-pb-field-values (protobuf/default-value Gui$NodeDesc))
+(def ^:private default-node-desc-pb-field-values (protobuf/optional-field-defaults Gui$NodeDesc))
 
 (def ^:private default-pb-node-type (protobuf/default Gui$NodeDesc :type)) ; E.g. :type-box.
 

--- a/editor/src/clj/editor/material.clj
+++ b/editor/src/clj/editor/material.clj
@@ -50,7 +50,7 @@
 
 (def ^:private editable-attribute-optional-field-defaults
   (-> Graphics$VertexAttribute
-      (protobuf/default-message #{:optional})
+      (protobuf/optional-field-defaults)
       (dissoc :binary-values :double-values :long-values :name-hash)))
 
 (defn- attribute->editable-attribute [attribute]

--- a/editor/src/clj/editor/particlefx.clj
+++ b/editor/src/clj/editor/particlefx.clj
@@ -200,7 +200,7 @@
         :points points
         :spread spread))))
 
-(def ^:private default-pb-spline-point (protobuf/default-message Particle$SplinePoint #{:required}))
+(def ^:private default-pb-spline-point (protobuf/required-field-defaults Particle$SplinePoint))
 
 (defn- significant-pb-property? [pb-property]
   {:pre [(map? pb-property)]} ; Particle$Emitter$Property, Particle$Emitter$ParticleProperty, or Particle$Modifier$Property in map format.

--- a/editor/src/clj/editor/pipeline.clj
+++ b/editor/src/clj/editor/pipeline.clj
@@ -66,7 +66,7 @@
                              :deps-by-source field-value->fused-path}))
             (coll/assoc-in-ex pb-map field-path fused-path))))
       pb-map
-      (protobuf/get-field-value-paths pb-map pb-class))))
+      (protobuf/resource-field-value-paths pb-class pb-map))))
 
 (defn- build-protobuf
   [resource dep-resources user-data]

--- a/editor/src/clj/editor/protobuf.clj
+++ b/editor/src/clj/editor/protobuf.clj
@@ -30,7 +30,8 @@ Macros currently mean no foreseeable performance gain, however."
             [util.digest :as digest]
             [util.fn :as fn]
             [util.text-util :as text-util])
-  (:import [com.dynamo.proto DdfExtensions DdfMath$Matrix4 DdfMath$Point3 DdfMath$Quat DdfMath$Vector3 DdfMath$Vector3One DdfMath$Vector4 DdfMath$Vector4One DdfMath$Vector4WOne]
+  (:import [clojure.lang IPending]
+           [com.dynamo.proto DdfExtensions DdfMath$Matrix4 DdfMath$Point3 DdfMath$Quat DdfMath$Vector3 DdfMath$Vector3One DdfMath$Vector4 DdfMath$Vector4One DdfMath$Vector4WOne]
            [com.google.protobuf DescriptorProtos$FieldOptions Descriptors$Descriptor Descriptors$EnumDescriptor Descriptors$EnumValueDescriptor Descriptors$FieldDescriptor Descriptors$FieldDescriptor$JavaType Descriptors$FieldDescriptor$Type Descriptors$FileDescriptor Message Message$Builder ProtocolMessageEnum TextFormat]
            [java.io ByteArrayOutputStream StringReader]
            [java.lang.reflect Method]
@@ -61,6 +62,44 @@ Macros currently mean no foreseeable performance gain, however."
 (defonce/protocol PbConverter
   (msg->vecmath [^Message pb v] "Return the javax.vecmath equivalent for the Protocol Buffer message")
   (msg->clj [^Message pb v]))
+
+(defn- as-late-bound-fn [fn-or-promise]
+  (cond
+    (fn? fn-or-promise)
+    fn-or-promise
+
+    (instance? IPending fn-or-promise)
+    (fn late-fn [& args]
+      (let [fn (deref fn-or-promise)]
+        (apply fn args)))))
+
+(defn- memoize-late-bound [higher-order-fn]
+  (let [cache-atom (atom {})]
+    (fn memoized-higher-order-fn [& args]
+      (let [cache-key (vec args)
+            cache-value (get @cache-atom cache-key)]
+        (or (as-late-bound-fn cache-value)
+            (let [late-fn-promise (promise)
+
+                  cache-value
+                  (-> cache-atom
+                      (swap! update cache-key fn/or late-fn-promise)
+                      (get cache-key))]
+
+              (if (identical? late-fn-promise cache-value)
+                ;; We just inserted our promise into the cache, so we're
+                ;; responsible for delivering the result.
+                (let [late-fn (apply higher-order-fn args)]
+                  (assert (ifn? late-fn) "The higher-order-fn must return a function.")
+                  (deliver late-fn-promise late-fn)
+                  (swap! cache-atom assoc cache-key late-fn)
+                  late-fn)
+
+                ;; Found an already-existing promise or function in the cache.
+                ;; Return the function unaltered, or a function that
+                ;; dereferences the promise when called.
+                (or (as-late-bound-fn cache-value)
+                    (assert false "Unexpected value found in cache.")))))))))
 
 (def ^:private upper-pattern (re-pattern #"\p{javaUpperCase}"))
 
@@ -712,7 +751,7 @@ Macros currently mean no foreseeable performance gain, however."
                                (let [field-pb-value (.invoke field-get-method pb java/no-args-array)]
                                  (pb-value->clj field-pb-value))))))))))))))
 
-(def ^:private pb->clj-fn (fn/memoize pb->clj-fn-raw))
+(def ^:private pb->clj-fn (memoize-late-bound pb->clj-fn-raw))
 
 (def ^:private pb->clj-with-defaults-fn (fn/memoize #(pb->clj-fn % #{:pb-field-kind/optional :pb-field-kind/required})))
 

--- a/editor/src/clj/editor/protobuf.clj
+++ b/editor/src/clj/editor/protobuf.clj
@@ -95,6 +95,15 @@ Macros currently mean no foreseeable performance gain, however."
     Descriptors$FieldDescriptor$JavaType/ENUM (desc->pb-class (.getEnumType field-desc))
     Descriptors$FieldDescriptor$JavaType/MESSAGE (desc->pb-class (.getMessageType field-desc))))
 
+(defn pb-field-desc-field-kind
+  [^Descriptors$FieldDescriptor field-desc]
+  (cond
+    (.isMapField field-desc) :pb-field-kind/map
+    (.isRepeated field-desc) :pb-field-kind/list
+    (.isOptional field-desc) :pb-field-kind/optional
+    (.isRequired field-desc) :pb-field-kind/required
+    :else (assert false)))
+
 (defn- new-builder
   ^Message$Builder [^Class cls]
   (java/invoke-no-arg-class-method cls "newBuilder"))
@@ -336,14 +345,7 @@ Macros currently mean no foreseeable performance gain, however."
     (into {}
           (map (fn [^Descriptors$FieldDescriptor field-desc]
                  (let [field-key (field->key field-desc)
-
-                       field-kind
-                       (cond
-                         (.isMapField field-desc) :pb-field-kind/map
-                         (.isRepeated field-desc) :pb-field-kind/list
-                         (.isOptional field-desc) :pb-field-kind/optional
-                         (.isRequired field-desc) :pb-field-kind/required
-                         :else (assert false))
+                       field-kind (pb-field-desc-field-kind field-desc)
 
                        [key-info value-info]
                        (if (.isMapField field-desc)
@@ -457,17 +459,30 @@ Macros currently mean no foreseeable performance gain, however."
                       value-field-infos (field-infos value-class)]
                   (field-value-paths-impl path value value-field-infos field-info-pred)))
               (when (field-info-pred field-info)
-                (if-some [default-value (:value-default field-info)]
-                  (let [path (conj path field-key)
-                        field-value (get pb-map field-key)
-                        value (if (nil? field-value)
-                                default-value
-                                field-value)]
-                    [[path value]])
-                  (let [value (get pb-map field-key ::not-found)]
-                    (when (not= ::not-found value)
-                      (let [path (conj path field-key)]
-                        [[path value]]))))))))))))
+                (let [field-value (get pb-map field-key ::no-value)
+                      default-value (:value-default field-info)
+                      value (cond
+                              (:is-oneof-field field-info)
+                              (case field-value
+                                ::no-value ::no-value
+                                nil default-value
+                                field-value)
+
+                              (some? default-value)
+                              (case field-value
+                                ::no-value default-value
+                                nil default-value
+                                field-value)
+
+                              :else
+                              (case field-value
+                                ::no-value ::no-value
+                                nil nil
+                                field-value))]
+
+                  (when (not= ::no-value value)
+                    (let [path (conj path field-key)]
+                      [[path value]])))))))))))
 
 (defn field-value-paths
   [^Class pb-class pb-map field-info-pred]
@@ -585,16 +600,14 @@ Macros currently mean no foreseeable performance gain, however."
                     is-default
                     (let [entry-desc (.getMessageType field-desc)
                           value-field-desc (.findFieldByName entry-desc "value")]
-                      (if (not= Descriptors$FieldDescriptor$JavaType/MESSAGE (.getJavaType value-field-desc))
-                        is-default
-                        (do
-                          (doseq [index (range entry-count)]
-                            (let [entry-builder (.toBuilder ^Message (.getRepeatedField builder field-desc index))
-                                  value-builder (.toBuilder ^Message (.getField entry-builder value-field-desc))]
-                              (clear-defaults-from-builder! value-builder)
-                              (.setField entry-builder value-field-desc (.build value-builder))
-                              (.setRepeatedField builder field-desc index (.build entry-builder))))
-                          false)))))
+                      (when (= Descriptors$FieldDescriptor$JavaType/MESSAGE (.getJavaType value-field-desc))
+                        (doseq [index (range entry-count)]
+                          (let [entry-builder (.toBuilder ^Message (.getRepeatedField builder field-desc index))
+                                value-builder (.toBuilder ^Message (.getField entry-builder value-field-desc))]
+                            (clear-defaults-from-builder! value-builder)
+                            (.setField entry-builder value-field-desc (.build value-builder))
+                            (.setRepeatedField builder field-desc index (.build entry-builder)))))
+                      false)))
 
                 (.isRepeated field-desc)
                 (let [item-count (.getRepeatedFieldCount builder field-desc)]
@@ -610,7 +623,9 @@ Macros currently mean no foreseeable performance gain, however."
               ;; Non-message field.
               (cond
                 (.getRealContainingOneof field-desc)
-                false
+                (if (.hasField builder field-desc)
+                  false
+                  is-default)
 
                 (.isOptional field-desc)
                 (cond

--- a/editor/src/clj/editor/protobuf.clj
+++ b/editor/src/clj/editor/protobuf.clj
@@ -31,7 +31,7 @@ Macros currently mean no foreseeable performance gain, however."
             [util.fn :as fn]
             [util.text-util :as text-util])
   (:import [com.dynamo.proto DdfExtensions DdfMath$Matrix4 DdfMath$Point3 DdfMath$Quat DdfMath$Vector3 DdfMath$Vector3One DdfMath$Vector4 DdfMath$Vector4One DdfMath$Vector4WOne]
-           [com.google.protobuf DescriptorProtos$FieldOptions Descriptors$Descriptor Descriptors$EnumDescriptor Descriptors$EnumValueDescriptor Descriptors$FieldDescriptor Descriptors$FieldDescriptor$JavaType Descriptors$FieldDescriptor$Type Descriptors$FileDescriptor Message Message$Builder ProtocolMessageEnum TextFormat]
+           [com.google.protobuf ByteString DescriptorProtos$FieldOptions Descriptors$Descriptor Descriptors$EnumDescriptor Descriptors$EnumValueDescriptor Descriptors$FieldDescriptor Descriptors$FieldDescriptor$JavaType Descriptors$FieldDescriptor$Type Descriptors$FileDescriptor Message Message$Builder ProtocolMessageEnum TextFormat]
            [java.io ByteArrayOutputStream StringReader]
            [java.lang.reflect Method]
            [java.nio.charset StandardCharsets]
@@ -80,45 +80,20 @@ Macros currently mean no foreseeable performance gain, however."
        (not= Message value)
        (.isAssignableFrom Message value)))
 
-(declare underscores-to-camel-case)
+(declare desc->pb-class)
 
-(defn- pb-desc-class-name-raw
-  ^String [^Descriptors$Descriptor desc]
-  (if-some [containing-desc (.getContainingType desc)]
-    (.intern (str (pb-desc-class-name-raw containing-desc) "$" (.getName desc)))
-    (let [file-desc (.getFile desc)
-          file-options (.getOptions file-desc)
-          package-name (.getJavaPackage file-options)
-          class-name (.getName desc)
-
-          ;; The rules around auto-generated outer class names have changed in
-          ;; Protobuf Edition 2024. We might need to revise our fallback code in
-          ;; case we upgrade. Luckily, we specify it explicitly in most cases.
-          ;; See: https://protobuf.dev/reference/java/java-proto-names/
-          outer-class-name
-          (or (not-empty (.getJavaOuterClassname file-options))
-              (-> file-desc .getName FilenameUtils/getBaseName underscores-to-camel-case))]
-
-      (.intern (str package-name "." outer-class-name "$" class-name)))))
-
-(def ^String pb-desc-class-name (fn/memoize pb-desc-class-name-raw))
-
-(defn- pb-desc-class-raw
-  ^Class [^Descriptors$Descriptor desc]
-  (let [class-name (pb-desc-class-name desc)]
-    (Class/forName class-name)))
-
-(def ^Class pb-desc-class (fn/memoize pb-desc-class-raw))
-
-(defn pb-field-desc-class-raw
+(defn pb-field-desc-class
   ^Class [^Descriptors$FieldDescriptor field-desc]
-  ;; TODO(protobuf-maps): We might not be able to call .getDefaultValue on
-  ;; required fields or optional fields without a declared default.
-  (if (= Descriptors$FieldDescriptor$JavaType/MESSAGE (.getJavaType field-desc))
-    (pb-desc-class (.getMessageType field-desc))
-    (class (.getDefaultValue field-desc))))
-
-(def pb-field-desc-class (fn/memoize pb-field-desc-class-raw))
+  (condp = (.getJavaType field-desc)
+    Descriptors$FieldDescriptor$JavaType/INT Integer
+    Descriptors$FieldDescriptor$JavaType/LONG Long
+    Descriptors$FieldDescriptor$JavaType/FLOAT Float
+    Descriptors$FieldDescriptor$JavaType/DOUBLE Double
+    Descriptors$FieldDescriptor$JavaType/BOOLEAN Boolean
+    Descriptors$FieldDescriptor$JavaType/STRING String
+    Descriptors$FieldDescriptor$JavaType/BYTE_STRING ByteString
+    Descriptors$FieldDescriptor$JavaType/ENUM (desc->pb-class (.getEnumType field-desc))
+    Descriptors$FieldDescriptor$JavaType/MESSAGE (desc->pb-class (.getMessageType field-desc))))
 
 (defn- new-builder
   ^Message$Builder [^Class cls]
@@ -287,33 +262,35 @@ Macros currently mean no foreseeable performance gain, however."
           (.getField field-options runtime-only-desc)
           (assoc :runtime-only true)))
 
-(def ^:private pb-field-type->field-type-kw
-  {Descriptors$FieldDescriptor$Type/BOOL :bool
-   Descriptors$FieldDescriptor$Type/BYTES :bytes
-   Descriptors$FieldDescriptor$Type/DOUBLE :double
-   Descriptors$FieldDescriptor$Type/ENUM :enum
-   Descriptors$FieldDescriptor$Type/FIXED32 :fixed-32
-   Descriptors$FieldDescriptor$Type/FIXED64 :fixed-64
-   Descriptors$FieldDescriptor$Type/FLOAT :float
-   Descriptors$FieldDescriptor$Type/GROUP :group
-   Descriptors$FieldDescriptor$Type/INT32 :int-32
-   Descriptors$FieldDescriptor$Type/INT64 :int-64
-   Descriptors$FieldDescriptor$Type/MESSAGE :message
-   Descriptors$FieldDescriptor$Type/SFIXED32 :sfixed-32
-   Descriptors$FieldDescriptor$Type/SFIXED64 :sfixed-64
-   Descriptors$FieldDescriptor$Type/SINT32 :sint-32
-   Descriptors$FieldDescriptor$Type/SINT64 :sint-64
-   Descriptors$FieldDescriptor$Type/STRING :string
-   Descriptors$FieldDescriptor$Type/UINT32 :uint-32
-   Descriptors$FieldDescriptor$Type/UINT64 :uint-64})
+(defn pb-field-type->field-type-kw
+  [pb-field-type]
+  (condp = pb-field-type
+    Descriptors$FieldDescriptor$Type/BOOL :bool
+    Descriptors$FieldDescriptor$Type/BYTES :bytes
+    Descriptors$FieldDescriptor$Type/DOUBLE :double
+    Descriptors$FieldDescriptor$Type/ENUM :enum
+    Descriptors$FieldDescriptor$Type/FIXED32 :fixed-32
+    Descriptors$FieldDescriptor$Type/FIXED64 :fixed-64
+    Descriptors$FieldDescriptor$Type/FLOAT :float
+    Descriptors$FieldDescriptor$Type/GROUP :group
+    Descriptors$FieldDescriptor$Type/INT32 :int-32
+    Descriptors$FieldDescriptor$Type/INT64 :int-64
+    Descriptors$FieldDescriptor$Type/MESSAGE :message
+    Descriptors$FieldDescriptor$Type/SFIXED32 :sfixed-32
+    Descriptors$FieldDescriptor$Type/SFIXED64 :sfixed-64
+    Descriptors$FieldDescriptor$Type/SINT32 :sint-32
+    Descriptors$FieldDescriptor$Type/SINT64 :sint-64
+    Descriptors$FieldDescriptor$Type/STRING :string
+    Descriptors$FieldDescriptor$Type/UINT32 :uint-32
+    Descriptors$FieldDescriptor$Type/UINT64 :uint-64))
 
 (defn field-type-default [field-type-kw]
   (case field-type-kw
     (:bool) Boolean/FALSE
     (:double) (Double/valueOf 0.0)
     (:float) (Float/valueOf (float 0.0))
-    (:int-32 :sfixed-32 :sint-32 :uint-32) (Integer/valueOf 0)
-    (:int-64 :sfixed-64 :sint-64 :uint-64) (Long/valueOf 0)
+    (:fixed-32 :int-32 :sfixed-32 :sint-32 :uint-32) (Integer/valueOf 0)
+    (:fixed-64 :int-64 :sfixed-64 :sint-64 :uint-64) (Long/valueOf 0)
     (:string) ""))
 
 (defn- field-get-method-raw
@@ -415,11 +392,6 @@ Macros currently mean no foreseeable performance gain, however."
     (:pb-field-kind/map)
     false))
 
-(defn map-field? [field-info]
-  (case (:field-kind field-info)
-    (:pb-field-kind/list :pb-field-kind/optional :pb-field-kind/required) false
-    (:pb-field-kind/map) true))
-
 (def field-key-set
   "Returns the set of field keywords applicable to the supplied protobuf Class."
   (fn/memoize (comp set keys field-infos)))
@@ -433,216 +405,78 @@ Macros currently mean no foreseeable performance gain, however."
                     {:pb-class cls
                      :field field}))))
 
-(declare resource-field-path-specs)
+(defn field-value-paths-impl
+  [path pb-map pb-map-field-infos field-info-pred]
+  {:pre [(vector? path)
+         (ifn? field-info-pred)]}
+  ;; This function is called recursively on values that have been through a
+  ;; PbConverter and are thus no longer traversable as pb-maps. It is also
+  ;; sometimes called on malformed data structures. In either case, we won't
+  ;; consider those parts of the tree.
+  (when (map? pb-map)
+    (coll/into-> pb-map-field-infos []
+      (coll/mapcat
+        (fn [[field-key field-info]]
+          (case (:field-kind field-info)
+            :pb-field-kind/list
+            (when-some [values (coll/not-empty (get pb-map field-key))]
+              (if (message-field? field-info)
+                (let [path (conj path field-key)
+                      value-class (:value-class field-info)
+                      value-field-infos (field-infos value-class)]
+                  (coll/into-> values :eduction
+                    (coll/mapcat-indexed
+                      (fn [index value]
+                        (let [path (conj path index)]
+                          (field-value-paths-impl path value value-field-infos field-info-pred))))))
+                (when (field-info-pred field-info)
+                  (let [path (conj path field-key)]
+                    (coll/into-> values :eduction
+                      (map-indexed
+                        (fn [index value]
+                          (let [path (conj path index)]
+                            [path value]))))))))
 
-(defn- resource-field-path-specs-raw
-  "Returns a list of path expressions pointing out all resource fields.
+            :pb-field-kind/map
+            (when (= :message (:value-type-kw field-info))
+              (when-some [entries (coll/not-empty (get pb-map field-key))]
+                (let [path (conj path field-key)
+                      value-class (:value-class field-info)
+                      value-field-infos (field-infos value-class)]
+                  (coll/into-> entries :eduction
+                    (coll/mapcat
+                      (fn [[key value]]
+                        (let [path (conj path key)]
+                          (field-value-paths-impl path value value-field-infos field-info-pred))))))))
 
-  path-expr := '[' elem+ ']'
-  elem := :keyword                  ; index into structure using :keyword
-  elem := '{' :keyword default '}'  ; index into structure using :keyword, with default value to use when not specified
-  elem := '[' :keyword ']'          ; :keyword is a repeated field, use rest of step* (if any) to index into each repetition (a message)
+            (:pb-field-kind/optional :pb-field-kind/required)
+            (if (message-field? field-info)
+              (when-some [value (get pb-map field-key)]
+                (let [path (conj path field-key)
+                      value-class (:value-class field-info)
+                      value-field-infos (field-infos value-class)]
+                  (field-value-paths-impl path value value-field-infos field-info-pred)))
+              (when (field-info-pred field-info)
+                (if-some [default-value (:value-default field-info)]
+                  (let [path (conj path field-key)
+                        field-value (get pb-map field-key)
+                        value (if (nil? field-value)
+                                default-value
+                                field-value)]
+                    [[path value]])
+                  (let [value (get pb-map field-key ::not-found)]
+                    (when (not= ::not-found value)
+                      (let [path (conj path field-key)]
+                        [[path value]]))))))))))))
 
-  message ResourceSimple {
-      optional string image = 1 [(resource) = true];
-  }
+(defn field-value-paths
+  [^Class pb-class pb-map field-info-pred]
+  (let [pb-map-field-infos (field-infos pb-class)]
+    (field-value-paths-impl [] pb-map pb-map-field-infos field-info-pred)))
 
-  message ResourceDefaulted {
-      optional string image = 1 [(resource) = true, default = '/default.png'];
-  }
-
-  message ResourceRepeated {
-      repeated string images = 1 [(resource) = true];
-  }
-
-  message ResourceSimpleNested {
-      optional ResourceSimple simple = 1;
-  }
-
-  message ResourceDefaultedNested {
-      optional ResourceDefaulted defaulted = 1;
-  }
-
-  message ResourceRepeatedNested {
-      optional ResourceRepeated repeated = 1;
-  }
-
-  message ResourceSimpleRepeatedlyNested {
-      repeated ResourceSimple simples = 1;
-  }
-
-  message ResourceDefaultedRepeatedlyNested {
-      repeated ResourceDefaulted defaulteds = 1;
-  }
-
-  message ResourceRepeatedRepeatedlyNested {
-      repeated ResourceRepeated repeateds = 1;
-  }
-
-  message ResourceSimpleMapNested {
-    map<string, ResourceSimple> simples = 1;
-  }
-
-  message ResourceDefaultedMapNested {
-      map<string, ResourceDefaulted> defaulteds = 1;
-  }
-
-  message ResourceRepeatedMapNested {
-      map<string, ResourceRepeated> repeateds = 1;
-  }
-
-  (resource-field-path-specs-raw ResourceSimple)    => [ [:image] ]
-  (resource-field-path-specs-raw ResourceDefaulted) => [ [{:image '/default.png'}] ]
-  (resource-field-path-specs-raw ResourceRepeated)  => [ [[:images]] ]
-
-  (resource-field-path-specs-raw ResourceSimpleNested)    => [ [:simple :image] ]
-  (resource-field-path-specs-raw ResourceDefaultedNested) => [ [:defaulted {:image '/default.png'}] ]
-  (resource-field-path-specs-raw ResourceRepeatedNested)  => [ [:repeated [:images]] ]
-
-  (resource-field-path-specs-raw ResourceSimpleRepeatedlyNested)    => [ [[:simples] :image] ]
-  (resource-field-path-specs-raw ResourceDefaultedRepeatedlyNested) => [ [[:defaulteds] {:image '/default.png'}] ]
-  (resource-field-path-specs-raw ResourceRepeatedRepeatedlyNested)  => [ [[:repeateds] [:images]] ]
-
-  (resource-field-path-specs-raw ResourceSimpleMapNested)    => [ [#{:simples} :image] ]
-  (resource-field-path-specs-raw ResourceDefaultedMapNested) => [ [#{:defaulteds} {:image '/default.png'}] ]
-  (resource-field-path-specs-raw ResourceRepeatedMapNested)  => [ [#{:repeateds} [:images]] ]"
-  [^Class class]
-  (into []
-        (comp
-          (map (fn [[key field-info]]
-                 (cond
-                   (resource-field? field-info)
-                   (case (:field-kind field-info)
-                     :pb-field-kind/list
-                     [[[key]]]
-
-                     :pb-field-kind/map
-                     (assert false "Protobuf map fields cannot be resource fields.")
-
-                     :pb-field-kind/optional
-                     (if-some [field-default (:value-default field-info)]
-                       [[{key field-default}]]
-                       [[key]])
-
-                     :pb-field-kind/required
-                     [[key]])
-
-                   (map-field? field-info)
-                   ;; No need to look at keys since they can't be messages.
-                   (let [sub-paths (resource-field-path-specs (:value-class field-info))]
-                     (when-not (coll/empty? sub-paths)
-                       (let [prefix [#{key}]]
-                         (mapv (partial into prefix) sub-paths))))
-
-                   (message-field? field-info)
-                   (let [sub-paths (resource-field-path-specs (:value-class field-info))]
-                     (when-not (coll/empty? sub-paths)
-                       (let [prefix (if (= :pb-field-kind/list (:field-kind field-info))
-                                      [[key]]
-                                      [key])]
-                         (mapv (partial into prefix) sub-paths)))))))
-          cat
-          (remove nil?))
-        (field-infos class)))
-
-(def resource-field-path-specs (fn/memoize resource-field-path-specs-raw))
-
-(declare get-field-fn)
-
-(defn- get-field-fn-raw [field-path-spec]
-  (if (seq field-path-spec)
-    (let [elem (first field-path-spec)
-          sub-path-fn (get-field-fn (rest field-path-spec))]
-      (cond
-        (keyword? elem)
-        (fn [pb]
-          (sub-path-fn (elem pb)))
-
-        (map? elem)
-        (fn [pb]
-          (let [[key default] (first elem)]
-            (sub-path-fn (get pb key default))))
-
-        (vector? elem)
-        (let [pbs-fn (first elem)]
-          (fn [pb]
-            (into [] (mapcat sub-path-fn) (pbs-fn pb))))))
-    (fn [pb] [pb])))
-
-(def ^:private get-field-fn (fn/memoize get-field-fn-raw))
-
-(defn- get-fields-fn-raw [field-path-specs]
-  (let [get-field-fns (mapv get-field-fn field-path-specs)]
-    (fn [pb]
-      (into []
-            (mapcat (fn [get-fn]
-                      (get-fn pb)))
-            get-field-fns))))
-
-(def get-fields-fn (fn/memoize get-fields-fn-raw))
-
-(declare get-field-value-path-fn)
-
-(defn- get-field-value-path-fn-raw [field-path-spec]
-  (let [field-path-spec-token (first field-path-spec)]
-    (if (nil? field-path-spec-token)
-      (fn [field-path field-value]
-        [(pair field-path field-value)])
-      (let [sub-path-fn (get-field-value-path-fn (rest field-path-spec))]
-        (cond
-          (keyword? field-path-spec-token)
-          (fn [field-path pb-map]
-            (let [field-value (get pb-map field-path-spec-token ::not-found)]
-              (when (not= ::not-found field-value)
-                (let [field-path (conj field-path field-path-spec-token)]
-                  (sub-path-fn field-path field-value)))))
-
-          (map? field-path-spec-token)
-          (fn [field-path pb-map]
-            (let [[field default-value] (first field-path-spec-token)
-                  field-path (conj field-path field)
-                  field-value (or (get pb-map field) default-value)]
-              (sub-path-fn field-path field-value)))
-
-          (vector? field-path-spec-token)
-          (let [field (first field-path-spec-token)]
-            (fn [field-path pb-map]
-              (let [field-path (conj field-path field)
-                    repeated-field-values (get pb-map field)]
-                (into []
-                      (coll/mapcat-indexed
-                        (fn [index repeated-field-value]
-                          (let [field-path (conj field-path index)]
-                            (sub-path-fn field-path repeated-field-value))))
-                      repeated-field-values))))
-
-          (set? field-path-spec-token)
-          (let [field (first field-path-spec-token)]
-            (fn [field-path pb-map]
-              (let [field-path (conj field-path field)
-                    map-entries (get pb-map field)]
-                (into []
-                      (coll/mapcat
-                        (fn [[map-key map-value]]
-                          (let [field-path (conj field-path map-key)]
-                            (sub-path-fn field-path map-value))))
-                      map-entries)))))))))
-
-(def ^:private get-field-value-path-fn (fn/memoize get-field-value-path-fn-raw))
-
-(defn- get-field-value-paths-fn-raw [field-path-specs]
-  (let [get-field-value-path-fns (mapv get-field-value-path-fn field-path-specs)]
-    (fn [pb-map]
-      {:pre [(map? pb-map)]} ;; Protobuf Message in map format.
-      (into []
-            (mapcat (fn [get-fn]
-                      (get-fn [] pb-map)))
-            get-field-value-path-fns))))
-
-(def get-field-value-paths-fn (fn/memoize get-field-value-paths-fn-raw))
-
-(defn get-field-value-paths [pb-map pb-class]
-  ((get-field-value-paths-fn (resource-field-path-specs pb-class)) pb-map))
+(defn resource-field-value-paths
+  [^Class pb-class pb-map]
+  (field-value-paths pb-class pb-map resource-field?))
 
 (defn- make-pb->clj-fn [fields]
   (fn pb->clj [pb]
@@ -714,7 +548,7 @@ Macros currently mean no foreseeable performance gain, however."
                                (let [field-pb-value (.invoke field-get-method pb java/no-args-array)]
                                  (pb-value->clj field-pb-value))))))))))))))
 
-(def ^:private pb->clj-fn (fn/memoize-late-bound pb->clj-fn-raw))
+(def ^:private pb->clj-fn (fn/memoize-late-bound {:timeout-ms 1000} pb->clj-fn-raw))
 
 (def ^:private pb->clj-with-defaults-fn (fn/memoize #(pb->clj-fn % #{:pb-field-kind/optional :pb-field-kind/required})))
 
@@ -856,22 +690,32 @@ Macros currently mean no foreseeable performance gain, however."
                       {:pb-class cls
                        :field field})))))
 
-(defn- desc->proto-cls ^Class [desc]
-  (let [cls-name (if-let [containing (containing-type desc)]
-                   (str (.getName (desc->proto-cls containing)) "$" (desc-name desc))
-                   (let [file (file desc)
-                         options (.getOptions file)
-                         package (if (.hasJavaPackage options)
-                                   (.getJavaPackage options)
-                                   (let [full (full-name desc)
-                                         name (desc-name desc)]
-                                     (subs full 0 (- (count full) (count name) 1))))
-                         outer-cls (if (.hasJavaOuterClassname options)
-                                     (.getJavaOuterClassname options)
-                                     (->CamelCase (FilenameUtils/getBaseName (.getName file))))
-                         inner-cls (desc-name desc)]
-                     (str package "." outer-cls "$" inner-cls)))]
-    (java/load-class! cls-name)))
+(declare desc->pb-class-name)
+
+(defn- desc->pb-class-name-raw
+  ^String [desc]
+  (if-let [containing-desc (containing-type desc)]
+    (.intern (str (desc->pb-class-name containing-desc) "$" (desc-name desc)))
+    (let [file (file desc)
+          options (.getOptions file)
+          package (if (.hasJavaPackage options)
+                    (.getJavaPackage options)
+                    (let [full (full-name desc)
+                          name (desc-name desc)]
+                      (subs full 0 (- (count full) (count name) 1))))
+          outer-class-name (if (.hasJavaOuterClassname options)
+                             (.getJavaOuterClassname options)
+                             (->CamelCase (FilenameUtils/getBaseName (.getName file))))
+          inner-class-name (desc-name desc)]
+      (.intern (str package "." outer-class-name "$" inner-class-name)))))
+
+(def ^:private desc->pb-class-name (fn/memoize desc->pb-class-name-raw))
+
+(defn- desc->pb-class-raw
+  ^Class [desc]
+  (java/load-class! (desc->pb-class-name desc)))
+
+(def ^:private desc->pb-class (fn/memoize desc->pb-class-raw))
 
 (defn val->pb-enum [^Class enum-class val]
   (Enum/valueOf enum-class (keyword->enum-name val)))
@@ -893,18 +737,15 @@ Macros currently mean no foreseeable performance gain, however."
 (def ^:private enum-from-clj-fn (fn/memoize enum-from-clj-fn-raw))
 
 (defn- primitive-builder [^Descriptors$FieldDescriptor desc]
-  (let [type (.getJavaType desc)]
-    (cond
-      (= type Descriptors$FieldDescriptor$JavaType/INT) int-from-clj
-      (= type Descriptors$FieldDescriptor$JavaType/LONG) long
-      (= type Descriptors$FieldDescriptor$JavaType/FLOAT) float
-      (= type Descriptors$FieldDescriptor$JavaType/DOUBLE) double
-      (= type Descriptors$FieldDescriptor$JavaType/STRING) str
-      (= type Descriptors$FieldDescriptor$JavaType/BOOLEAN) boolean-from-clj
-      (= type Descriptors$FieldDescriptor$JavaType/BYTE_STRING) identity
-      (= type Descriptors$FieldDescriptor$JavaType/ENUM) (let [enum-cls (desc->proto-cls (.getEnumType desc))]
-                                                           (enum-from-clj-fn enum-cls))
-      :else nil)))
+  (condp = (.getJavaType desc)
+    Descriptors$FieldDescriptor$JavaType/INT int-from-clj
+    Descriptors$FieldDescriptor$JavaType/LONG long
+    Descriptors$FieldDescriptor$JavaType/FLOAT float
+    Descriptors$FieldDescriptor$JavaType/DOUBLE double
+    Descriptors$FieldDescriptor$JavaType/STRING str
+    Descriptors$FieldDescriptor$JavaType/BOOLEAN boolean-from-clj
+    Descriptors$FieldDescriptor$JavaType/BYTE_STRING identity
+    Descriptors$FieldDescriptor$JavaType/ENUM (-> desc .getEnumType desc->pb-class enum-from-clj-fn)))
 
 (declare ^:private pb-builder ^:private vector-to-map-conversions)
 
@@ -1002,7 +843,7 @@ Macros currently mean no foreseeable performance gain, however."
       (comp builder-fn vector->map)
       builder-fn)))
 
-(def ^:private pb-builder (fn/memoize-late-bound pb-builder-raw))
+(def ^:private pb-builder (fn/memoize-late-bound {:timeout-ms 1000} pb-builder-raw))
 
 (defmacro map->pb [^Class cls m]
   (cond-> `((#'pb-builder ~cls) ~m)
@@ -1604,28 +1445,3 @@ Macros currently mean no foreseeable performance gain, however."
 
               (text-util/string->text-match re-pattern)
               (assoc :value value)))))
-
-;; TODO(protobuf-maps): Remove!
-(comment
-  (let [^Class struct-pb-class
-        com.dynamo.proto.DdfStruct$Struct
-
-        ;; Struct
-        struct-desc (pb-class->descriptor struct-pb-class)
-
-        ;; Struct.fields
-        struct-fields-field-desc (first (.getFields struct-desc))
-
-        ;; Struct$FieldEntry
-        struct-fields-entry-desc (.getMessageType struct-fields-field-desc)
-
-        ;; Struct$FieldEntry.key
-        key-field-desc (.findFieldByName struct-fields-entry-desc "key")
-
-        ;; Struct$FieldEntry.value
-        value-field-desc (.findFieldByName struct-fields-entry-desc "value")
-
-        ;; Struct$Value
-        value-desc (.getMessageType value-field-desc)]
-
-    (pb-field-desc-class value-field-desc)))

--- a/editor/src/clj/editor/protobuf.clj
+++ b/editor/src/clj/editor/protobuf.clj
@@ -30,8 +30,7 @@ Macros currently mean no foreseeable performance gain, however."
             [util.digest :as digest]
             [util.fn :as fn]
             [util.text-util :as text-util])
-  (:import [clojure.lang IPending]
-           [com.dynamo.proto DdfExtensions DdfMath$Matrix4 DdfMath$Point3 DdfMath$Quat DdfMath$Vector3 DdfMath$Vector3One DdfMath$Vector4 DdfMath$Vector4One DdfMath$Vector4WOne]
+  (:import [com.dynamo.proto DdfExtensions DdfMath$Matrix4 DdfMath$Point3 DdfMath$Quat DdfMath$Vector3 DdfMath$Vector3One DdfMath$Vector4 DdfMath$Vector4One DdfMath$Vector4WOne]
            [com.google.protobuf DescriptorProtos$FieldOptions Descriptors$Descriptor Descriptors$EnumDescriptor Descriptors$EnumValueDescriptor Descriptors$FieldDescriptor Descriptors$FieldDescriptor$JavaType Descriptors$FieldDescriptor$Type Descriptors$FileDescriptor Message Message$Builder ProtocolMessageEnum TextFormat]
            [java.io ByteArrayOutputStream StringReader]
            [java.lang.reflect Method]
@@ -62,52 +61,6 @@ Macros currently mean no foreseeable performance gain, however."
 (defonce/protocol PbConverter
   (msg->vecmath [^Message pb v] "Return the javax.vecmath equivalent for the Protocol Buffer message")
   (msg->clj [^Message pb v]))
-
-(defn- as-late-bound-fn [fn-or-promise]
-  (cond
-    (fn? fn-or-promise)
-    fn-or-promise
-
-    (instance? IPending fn-or-promise)
-    (fn late-fn [& args]
-      (let [fn (deref fn-or-promise 1000 ::timeout)]
-        (if (not= ::timeout fn)
-          (apply fn args)
-          (throw
-            (ex-info
-              "Calling late-bound function before its promise could be delivered."
-              {:promise fn-or-promise})))))))
-
-(defn- memoize-late-bound [higher-order-fn]
-  (let [cache-atom (atom {})
-
-        memoized-fn
-        (fn memoized-fn [& args]
-          (let [cache-key (vec args)
-                cache-value (get @cache-atom cache-key)]
-            (or (as-late-bound-fn cache-value)
-                (let [lower-order-fn-promise (promise)
-
-                      cache-value
-                      (-> cache-atom
-                          (swap! update cache-key fn/or lower-order-fn-promise)
-                          (get cache-key))]
-
-                  (if (identical? lower-order-fn-promise cache-value)
-                    ;; We just inserted our promise into the cache, so we're
-                    ;; responsible for delivering the result.
-                    (let [early-fn (apply higher-order-fn args)]
-                      (assert (ifn? early-fn) "The higher-order-fn must return a function.")
-                      (deliver lower-order-fn-promise early-fn)
-                      (swap! cache-atom assoc cache-key early-fn)
-                      early-fn)
-
-                    ;; Found an already-existing promise or function in the cache.
-                    ;; Return the function unaltered, or a function that
-                    ;; dereferences the promise when called.
-                    (as-late-bound-fn cache-value))))))]
-
-    (fn/with-memoize-info memoized-fn higher-order-fn cache-atom -1)))
 
 (def ^:private upper-pattern (re-pattern #"\p{javaUpperCase}"))
 
@@ -761,7 +714,7 @@ Macros currently mean no foreseeable performance gain, however."
                                (let [field-pb-value (.invoke field-get-method pb java/no-args-array)]
                                  (pb-value->clj field-pb-value))))))))))))))
 
-(def ^:private pb->clj-fn (memoize-late-bound pb->clj-fn-raw))
+(def ^:private pb->clj-fn (fn/memoize-late-bound pb->clj-fn-raw))
 
 (def ^:private pb->clj-with-defaults-fn (fn/memoize #(pb->clj-fn % #{:pb-field-kind/optional :pb-field-kind/required})))
 
@@ -1049,7 +1002,7 @@ Macros currently mean no foreseeable performance gain, however."
       (comp builder-fn vector->map)
       builder-fn)))
 
-(def ^:private pb-builder (memoize-late-bound pb-builder-raw))
+(def ^:private pb-builder (fn/memoize-late-bound pb-builder-raw))
 
 (defmacro map->pb [^Class cls m]
   (cond-> `((#'pb-builder ~cls) ~m)
@@ -1676,26 +1629,3 @@ Macros currently mean no foreseeable performance gain, however."
         value-desc (.getMessageType value-field-desc)]
 
     (pb-field-desc-class value-field-desc)))
-
-;; TODO(protobuf-maps): Remove!
-(comment
-  (pb-class->descriptor com.defold.editor.test.TestDdf$SubMsg)
-  (pb-desc-class-name (pb-class->descriptor com.defold.editor.test.TestDdf$SubMsg))
-
-  (slurp "test/resources/save_data_project/checked01.light")
-
-  (let [bad-class com.dynamo.proto.DdfStruct
-        pb-class com.dynamo.proto.DdfStruct$Struct
-        fields-field-info (:fields (field-infos-raw pb-class))
-        content (slurp "test/resources/save_data_project/checked01.light")]
-
-    (str->map-without-defaults com.dynamo.gamesys.proto.GameSystem$LightDesc content)
-
-    (with-open [reader (StringReader. content)]
-      (let [light-desc (read-pb com.dynamo.gamesys.proto.GameSystem$LightDesc reader)
-            struct (.getData light-desc)]
-        (-> (.getFields struct)
-            (coll/into-> {}
-              (map (fn [[key value]]
-                     [(keyword key)
-                      value]))))))))

--- a/editor/src/clj/editor/protobuf.clj
+++ b/editor/src/clj/editor/protobuf.clj
@@ -780,10 +780,10 @@ Macros currently mean no foreseeable performance gain, however."
                       (java/get-declared-methods builder-class))
         field-descs (.getFields desc)
         setters (into {}
-                      (map (fn [^Descriptors$FieldDescriptor fd]
-                             (let [java-name (->CamelCase (.getName fd))
-                                   is-map-field (.isMapField fd)
-                                   is-repeated-field (.isRepeated fd)
+                      (map (fn [^Descriptors$FieldDescriptor field-desc]
+                             (let [java-name (->CamelCase (.getName field-desc))
+                                   is-map-field (.isMapField field-desc)
+                                   is-repeated-field (.isRepeated field-desc)
 
                                    ^Method field-set-method
                                    (get methods
@@ -792,21 +792,23 @@ Macros currently mean no foreseeable performance gain, however."
                                           is-repeated-field (str "addAll" java-name)
                                           :else (str "set" java-name)))
 
-                                   field-builder
-                                   (if (= Descriptors$FieldDescriptor$JavaType/MESSAGE (.getJavaType fd))
-                                     (let [^Method field-get-method
-                                           (get methods
-                                                (if is-map-field
-                                                  (str "get" java-name "OrThrow")
-                                                  (str "get" java-name)))]
-                                       (pb-builder (.getReturnType field-get-method)))
-                                     (primitive-builder fd))
+                                   value-builder
+                                   (let [value-field-desc
+                                         (if is-map-field
+                                           (-> (.getMessageType field-desc)
+                                               (.findFieldByName "value"))
+                                           field-desc)]
+                                     (if (= Descriptors$FieldDescriptor$JavaType/MESSAGE (.getJavaType value-field-desc))
+                                       (let [value-desc (.getMessageType value-field-desc)
+                                             value-class (desc->pb-class value-desc)]
+                                         (pb-builder value-class))
+                                       (primitive-builder value-field-desc)))
 
-                                   field-key (field->key fd)
+                                   field-key (field->key field-desc)
                                    value-fn (cond
-                                              is-map-field #(coll/map-vals field-builder %)
-                                              is-repeated-field #(mapv field-builder %)
-                                              :else field-builder)
+                                              is-map-field #(coll/map-vals value-builder %)
+                                              is-repeated-field #(mapv value-builder %)
+                                              :else value-builder)
                                    value-fn (if-not decorate-protobuf-exceptions
                                               value-fn
                                               (fn decorated-value-fn [clj-value]
@@ -817,7 +819,7 @@ Macros currently mean no foreseeable performance gain, however."
                                                       (ex-info
                                                         (format "Failed to assign protobuf field %s ('%s') from value: %s"
                                                                 field-key
-                                                                (.getFullName fd)
+                                                                (.getFullName field-desc)
                                                                 clj-value)
                                                         {:pb-class class
                                                          :pb-field field-key

--- a/editor/src/clj/editor/protobuf.clj
+++ b/editor/src/clj/editor/protobuf.clj
@@ -35,7 +35,7 @@ Macros currently mean no foreseeable performance gain, however."
            [java.io ByteArrayOutputStream StringReader]
            [java.lang.reflect Method]
            [java.nio.charset StandardCharsets]
-           [java.util Collection]
+           [java.util Collection Map]
            [javax.vecmath Matrix4d Point3d Quat4d Vector3d Vector4d]
            [org.apache.commons.io FilenameUtils]))
 
@@ -79,6 +79,46 @@ Macros currently mean no foreseeable performance gain, however."
   (and (class? value)
        (not= Message value)
        (.isAssignableFrom Message value)))
+
+(declare underscores-to-camel-case)
+
+(defn- pb-desc-class-name-raw
+  ^String [^Descriptors$Descriptor desc]
+  (if-some [containing-desc (.getContainingType desc)]
+    (.intern (str (pb-desc-class-name-raw containing-desc) "$" (.getName desc)))
+    (let [file-desc (.getFile desc)
+          file-options (.getOptions file-desc)
+          package-name (.getJavaPackage file-options)
+          class-name (.getName desc)
+
+          ;; The rules around auto-generated outer class names have changed in
+          ;; Protobuf Edition 2024. We might need to revise our fallback code in
+          ;; case we upgrade. Luckily, we specify it explicitly in most cases.
+          ;; See: https://protobuf.dev/reference/java/java-proto-names/
+          outer-class-name
+          (or (not-empty (.getJavaOuterClassname file-options))
+              (-> file-desc .getName FilenameUtils/getBaseName underscores-to-camel-case))]
+
+      (.intern (str package-name "." outer-class-name "$" class-name)))))
+
+(def ^String pb-desc-class-name (fn/memoize pb-desc-class-name-raw))
+
+(defn- pb-desc-class-raw
+  ^Class [^Descriptors$Descriptor desc]
+  (let [class-name (pb-desc-class-name desc)]
+    (Class/forName class-name)))
+
+(def ^Class pb-desc-class (fn/memoize pb-desc-class-raw))
+
+(defn pb-field-desc-class-raw
+  ^Class [^Descriptors$FieldDescriptor field-desc]
+  ;; TODO(protobuf-maps): We might not be able to call .getDefaultValue on
+  ;; required fields or optional fields without a declared default.
+  (if (= Descriptors$FieldDescriptor$JavaType/MESSAGE (.getJavaType field-desc))
+    (pb-desc-class (.getMessageType field-desc))
+    (class (.getDefaultValue field-desc))))
+
+(def pb-field-desc-class (fn/memoize pb-field-desc-class-raw))
 
 (defn- new-builder
   ^Message$Builder [^Class cls]
@@ -137,29 +177,50 @@ Macros currently mean no foreseeable performance gain, however."
 (defn pb-enum->int ^long [val-or-desc]
   (-> val-or-desc as-enum-desc .getNumber))
 
-(defn- pb-primitive->clj-fn [field-type-key]
-  (case field-type-key
+(defn- pb-primitive->clj-fn [value-type-kw]
+  (case value-type-kw
     :enum pb-enum->val
     :bool boolean ; Java reflection returns unique Boolean instances. We want either Boolean/TRUE or Boolean/FALSE.
     :message (throw (IllegalArgumentException. "Non-primitive protobuf types are not supported."))
     identity))
 
-(defn- pb-primitive->clj [pb-value field-type-key]
-  (let [pb-value->clj (pb-primitive->clj-fn field-type-key)]
+(defn- pb-primitive->clj [pb-value value-type-kw]
+  (let [pb-value->clj (pb-primitive->clj-fn value-type-kw)]
     (pb-value->clj pb-value)))
 
 (declare ^:private pb->clj-fn)
-
-(defn- pb-value->clj-fn [{:keys [field-type-key] :as field-info} default-included-field-rules]
-  (let [pb-value->clj
-        (case field-type-key
-          :message (pb->clj-fn (:type field-info) default-included-field-rules)
-          (pb-primitive->clj-fn field-type-key))]
-    (if (not= :repeated (:field-rule field-info))
-      pb-value->clj
-      (fn repeated-pb-value->clj [^Collection values]
+(defn- pb-value->clj-fn [field-info default-included-field-rules]
+  (case (:field-kind field-info)
+    :pb-field-kind/list
+    (let [{:keys [value-class value-type-kw]} field-info
+          value->clj (case value-type-kw
+                       :message (pb->clj-fn value-class default-included-field-rules)
+                       (pb-primitive->clj-fn value-type-kw))]
+      (fn repeated-pb-value->clj-vector [^Collection values]
         (when-not (.isEmpty values)
-          (mapv pb-value->clj values))))))
+          (mapv value->clj values))))
+
+    :pb-field-kind/map
+    ;; The key type can any scalar type except for floating point types and
+    ;; bytes. Neither enum nor proto messages are valid key types. The value
+    ;; type can be any type except another map. Ordering of map values is
+    ;; undefined but sorted by key in text-based file formats.
+    (let [{:keys [key-type-kw value-class value-type-kw]} field-info
+          key->clj (pb-primitive->clj-fn key-type-kw)
+          value->clj (case value-type-kw
+                       :message (pb->clj-fn value-class default-included-field-rules)
+                       (pb-primitive->clj-fn value-type-kw))
+          entry->clj (coll/pair-fn key->clj value->clj)]
+      (fn map-pb-value->clj-map [^Map entries]
+        (when-not (.isEmpty entries)
+          (coll/into-> entries {}
+            (map entry->clj)))))
+
+    (:pb-field-kind/optional :pb-field-kind/required)
+    (let [{:keys [value-class value-type-kw]} field-info]
+      (case value-type-kw
+        :message (pb->clj-fn value-class default-included-field-rules)
+        (pb-primitive->clj-fn value-type-kw)))))
 
 (def ^:private methods-by-name
   (fn/memoize
@@ -223,12 +284,7 @@ Macros currently mean no foreseeable performance gain, however."
           (.getField field-options runtime-only-desc)
           (assoc :runtime-only true)))
 
-(defn field-value-class [^Class class ^Descriptors$FieldDescriptor field-desc]
-  (let [java-name (underscores-to-camel-case (.getName field-desc))
-        field-accessor-name (str "get" java-name)]
-    (.getReturnType (lookup-method class field-accessor-name))))
-
-(def ^:private field-type->key
+(def ^:private pb-field-type->field-type-kw
   {Descriptors$FieldDescriptor$Type/BOOL :bool
    Descriptors$FieldDescriptor$Type/BYTES :bytes
    Descriptors$FieldDescriptor$Type/DOUBLE :double
@@ -247,6 +303,15 @@ Macros currently mean no foreseeable performance gain, however."
    Descriptors$FieldDescriptor$Type/STRING :string
    Descriptors$FieldDescriptor$Type/UINT32 :uint-32
    Descriptors$FieldDescriptor$Type/UINT64 :uint-64})
+
+(defn field-type-default [field-type-kw]
+  (case field-type-kw
+    (:bool) Boolean/FALSE
+    (:double) (Double/valueOf 0.0)
+    (:float) (Float/valueOf (float 0.0))
+    (:int-32 :sfixed-32 :sint-32 :uint-32) (Integer/valueOf 0)
+    (:int-64 :sfixed-64 :sint-64 :uint-64) (Long/valueOf 0)
+    (:string) ""))
 
 (defn- field-get-method-raw
   ^Method [^Class cls java-name repeated]
@@ -279,33 +344,71 @@ Macros currently mean no foreseeable performance gain, however."
     (into {}
           (map (fn [^Descriptors$FieldDescriptor field-desc]
                  (let [field-key (field->key field-desc)
-                       field-rule (cond (.isRepeated field-desc) :repeated
-                                        (.isRequired field-desc) :required
-                                        (.isOptional field-desc) :optional
+                       is-map-field (.isMapField field-desc)
+                       is-repeated-field (.isRepeated field-desc)
+                       is-optional-field (.isOptional field-desc)
+                       is-required-field (.isRequired field-desc)
+                       field-kind (cond is-map-field :pb-field-kind/map
+                                        is-repeated-field :pb-field-kind/list
+                                        is-optional-field :pb-field-kind/optional
+                                        is-required-field :pb-field-kind/required
                                         :else (assert false))
-                       field-type-key (field-type->key (.getType field-desc))
-                       default (when (not= Descriptors$FieldDescriptor$JavaType/MESSAGE (.getJavaType field-desc))
-                                 (pb-primitive->clj (.getDefaultValue field-desc) field-type-key))
-                       declared-default (when (.hasDefaultValue field-desc)
-                                          default)]
+                       ;; TODO(protobuf-maps): Remove field-rule once everything has been ported to field-kind.
+                       field-rule (cond is-repeated-field :repeated
+                                        is-required-field :required
+                                        is-optional-field :optional
+                                        :else (assert false))
+
+                       [key-info value-info]
+                       (if (.isMapField field-desc)
+                         (let [map-entry-desc (.getMessageType field-desc)
+                               key-field-desc (.findFieldByName map-entry-desc "key")
+                               value-field-desc (.findFieldByName map-entry-desc "value")
+                               key-info {:key-type-kw (pb-field-type->field-type-kw (.getType key-field-desc))
+                                         :key-class (pb-field-desc-class key-field-desc)}
+                               value-info {:value-type-kw (pb-field-type->field-type-kw (.getType value-field-desc))
+                                           :value-class (pb-field-desc-class value-field-desc)}]
+                           (pair key-info value-info))
+                         (let [value-type-kw (pb-field-type->field-type-kw (.getType field-desc))
+                               value-info (cond-> {:value-type-kw value-type-kw
+                                                   :value-class (pb-field-desc-class field-desc)}
+                                                  (.hasDefaultValue field-desc) ; Declared default in .proto file. Optional primitive fields only.
+                                                  (assoc :value-default (pb-primitive->clj (.getDefaultValue field-desc) value-type-kw)))]
+                           (pair nil value-info)))]
+
                    (pair field-key
-                         {:type (field-value-class cls field-desc)
-                          :java-name (underscores-to-camel-case (.getName field-desc))
-                          :field-type-key field-type-key
-                          :field-rule field-rule
-                          :default default
-                          :declared-default declared-default
-                          :options (options (.getOptions field-desc))}))))
+                         (coll/merge
+                           key-info
+                           value-info
+                           {:java-name (underscores-to-camel-case (.getName field-desc))
+                            :field-kind field-kind
+                            :field-rule field-rule
+                            :options (options (.getOptions field-desc))})))))
           (.getFields desc))))
 
 (def field-infos (fn/memoize field-infos-raw))
 
 (defn resource-field? [field-info]
-  (and (= :string (:field-type-key field-info))
-       (true? (:resource (:options field-info)))))
+  (case (:field-kind field-info)
+    (:pb-field-kind/list :pb-field-kind/optional :pb-field-kind/required)
+    (and (= :string (:value-type-kw field-info))
+         (true? (:resource (:options field-info))))
+
+    (:pb-field-kind/map)
+    false))
 
 (defn message-field? [field-info]
-  (= :message (:field-type-key field-info)))
+  (case (:field-kind field-info)
+    (:pb-field-kind/list :pb-field-kind/optional :pb-field-kind/required)
+    (= :message (:value-type-kw field-info))
+
+    (:pb-field-kind/map)
+    false))
+
+(defn map-field? [field-info]
+  (case (:field-kind field-info)
+    (:pb-field-kind/list :pb-field-kind/optional :pb-field-kind/required) false
+    (:pb-field-kind/map) true))
 
 (def field-key-set
   "Returns the set of field keywords applicable to the supplied protobuf Class."
@@ -313,7 +416,7 @@ Macros currently mean no foreseeable performance gain, however."
 
 (defn- declared-default [^Class cls field]
   (if-some [field-info (get (field-infos cls) field)]
-    (:declared-default field-info)
+    (:value-default field-info)
     (throw (ex-info (format "Field '%s' does not exist in protobuf class '%s'."
                             field
                             (.getName cls))
@@ -366,6 +469,18 @@ Macros currently mean no foreseeable performance gain, however."
       repeated ResourceRepeated repeateds = 1;
   }
 
+  message ResourceSimpleMapNested {
+    map<string, ResourceSimple> simples = 1;
+  }
+
+  message ResourceDefaultedMapNested {
+      map<string, ResourceDefaulted> defaulteds = 1;
+  }
+
+  message ResourceRepeatedMapNested {
+      map<string, ResourceRepeated> repeateds = 1;
+  }
+
   (resource-field-path-specs-raw ResourceSimple)    => [ [:image] ]
   (resource-field-path-specs-raw ResourceDefaulted) => [ [{:image '/default.png'}] ]
   (resource-field-path-specs-raw ResourceRepeated)  => [ [[:images]] ]
@@ -376,23 +491,42 @@ Macros currently mean no foreseeable performance gain, however."
 
   (resource-field-path-specs-raw ResourceSimpleRepeatedlyNested)    => [ [[:simples] :image] ]
   (resource-field-path-specs-raw ResourceDefaultedRepeatedlyNested) => [ [[:defaulteds] {:image '/default.png'}] ]
-  (resource-field-path-specs-raw ResourceRepeatedRepeatedlyNested)  => [ [[:repeateds] [:images]] ]"
+  (resource-field-path-specs-raw ResourceRepeatedRepeatedlyNested)  => [ [[:repeateds] [:images]] ]
+
+  (resource-field-path-specs-raw ResourceSimpleMapNested)    => [ [#{:simples} :image] ]
+  (resource-field-path-specs-raw ResourceDefaultedMapNested) => [ [#{:defaulteds} {:image '/default.png'}] ]
+  (resource-field-path-specs-raw ResourceRepeatedMapNested)  => [ [#{:repeateds} [:images]] ]"
   [^Class class]
   (into []
         (comp
           (map (fn [[key field-info]]
                  (cond
                    (resource-field? field-info)
-                   (case (:field-rule field-info)
-                     :repeated [[[key]]]
-                     :required [[key]]
-                     :optional (if-some [field-default (declared-default class key)]
-                                 [[{key field-default}]]
-                                 [[key]]))
+                   (case (:field-kind field-info)
+                     :pb-field-kind/list
+                     [[[key]]]
+
+                     :pb-field-kind/map
+                     (assert false "Protobuf map fields cannot be resource fields.")
+
+                     :pb-field-kind/optional
+                     (if-some [field-default (:value-default field-info)]
+                       [[{key field-default}]]
+                       [[key]])
+
+                     :pb-field-kind/required
+                     [[key]])
+
+                   (map-field? field-info)
+                   ;; No need to look at keys since they can't be messages.
+                   (let [sub-paths (resource-field-path-specs (:value-class field-info))]
+                     (when-not (coll/empty? sub-paths)
+                       (let [prefix [#{key}]]
+                         (mapv (partial into prefix) sub-paths))))
 
                    (message-field? field-info)
-                   (let [sub-paths (resource-field-path-specs (:type field-info))]
-                     (when (seq sub-paths)
+                   (let [sub-paths (resource-field-path-specs (:value-class field-info))]
+                     (when-not (coll/empty? sub-paths)
                        (let [prefix (if (= :repeated (:field-rule field-info))
                                       [[key]]
                                       [key])]
@@ -470,7 +604,19 @@ Macros currently mean no foreseeable performance gain, however."
                         (fn [index repeated-field-value]
                           (let [field-path (conj field-path index)]
                             (sub-path-fn field-path repeated-field-value))))
-                      repeated-field-values)))))))))
+                      repeated-field-values))))
+
+          (set? field-path-spec-token)
+          (let [field (first field-path-spec-token)]
+            (fn [field-path pb-map]
+              (let [field-path (conj field-path field)
+                    map-entries (get pb-map field)]
+                (into []
+                      (coll/mapcat
+                        (fn [[map-key map-value]]
+                          (let [field-path (conj field-path map-key)]
+                            (sub-path-fn field-path map-value))))
+                      map-entries)))))))))
 
 (def ^:private get-field-value-path-fn (fn/memoize get-field-value-path-fn-raw))
 
@@ -508,6 +654,7 @@ Macros currently mean no foreseeable performance gain, however."
 (defn- pb->clj-fn-raw [^Class class default-included-field-rules]
   {:pre [(set? default-included-field-rules)
          (every? #{:optional :required} default-included-field-rules)]}
+  ;; TODO(protobuf-maps): Convert to field-kind and support map fields.
   (make-pb->clj-fn
     (mapv (fn [[field-key {:keys [field-rule java-name] :as field-info}]]
             (let [pb-value->clj (pb-value->clj-fn field-info default-included-field-rules)
@@ -520,7 +667,7 @@ Macros currently mean no foreseeable performance gain, however."
                            (= :optional field-rule)
                            (message-field? field-info))
                       (let [field-has-value? (field-has-value-fn class java-name repeated)
-                            default-field-value (default-message (:type field-info) default-included-field-rules)]
+                            default-field-value (default-message (:value-class field-info) default-included-field-rules)]
                         (fn pb->field-clj-value [pb]
                           (if (field-has-value? pb)
                             (let [field-pb-value (.invoke field-get-method pb java/no-args-array)]
@@ -1259,8 +1406,13 @@ Macros currently mean no foreseeable performance gain, however."
     (keep (fn [[key value :as entry]]
             (when (some? value)
               (let [field-info (key->field-info key)]
-                (case (:field-rule field-info)
-                  :optional
+                (case (:field-kind field-info)
+                  :pb-field-kind/map
+                  (when (and (not (coll/empty? value))
+                             (not= (key->default key) value))
+                    entry)
+
+                  :pb-field-kind/optional
                   (when (if (resource-field? field-info)
                           (if (= "" value)
                             (not= "" (key->default key))
@@ -1270,7 +1422,7 @@ Macros currently mean no foreseeable performance gain, however."
                                    (= (key->default key) value))))
                     entry)
 
-                  :repeated
+                  :pb-field-kind/list
                   (when (and (not (coll/empty? value))
                              (not= (key->default key) value))
                     (let [as-vec (vec value)]
@@ -1278,7 +1430,7 @@ Macros currently mean no foreseeable performance gain, however."
                         entry
                         (pair key as-vec))))
 
-                  :required
+                  :pb-field-kind/required
                   (when-not (and (message-field? field-info)
                                  (coll/empty? value))
                     entry)
@@ -1390,3 +1542,51 @@ Macros currently mean no foreseeable performance gain, however."
 
               (text-util/string->text-match re-pattern)
               (assoc :value value)))))
+
+;; TODO(protobuf-maps): Remove!
+(comment
+  (let [^Class struct-pb-class
+        com.dynamo.proto.DdfStruct$Struct
+
+        ;; Struct
+        struct-desc (pb-class->descriptor struct-pb-class)
+
+        ;; Struct.fields
+        struct-fields-field-desc (first (.getFields struct-desc))
+
+        ;; Struct$FieldEntry
+        struct-fields-entry-desc (.getMessageType struct-fields-field-desc)
+
+        ;; Struct$FieldEntry.key
+        key-field-desc (.findFieldByName struct-fields-entry-desc "key")
+
+        ;; Struct$FieldEntry.value
+        value-field-desc (.findFieldByName struct-fields-entry-desc "value")
+
+        ;; Struct$Value
+        value-desc (.getMessageType value-field-desc)]
+
+    (pb-field-desc-class value-field-desc)))
+
+;; TODO(protobuf-maps): Remove!
+(comment
+  (pb-class->descriptor com.defold.editor.test.TestDdf$SubMsg)
+  (pb-desc-class-name (pb-class->descriptor com.defold.editor.test.TestDdf$SubMsg))
+
+  (slurp "test/resources/save_data_project/checked01.light")
+
+  (let [bad-class com.dynamo.proto.DdfStruct
+        pb-class com.dynamo.proto.DdfStruct$Struct
+        fields-field-info (:fields (field-infos-raw pb-class))
+        content (slurp "test/resources/save_data_project/checked01.light")]
+
+    (str->map-without-defaults com.dynamo.gamesys.proto.GameSystem$LightDesc content)
+
+    (with-open [reader (StringReader. content)]
+      (let [light-desc (read-pb com.dynamo.gamesys.proto.GameSystem$LightDesc reader)
+            struct (.getData light-desc)]
+        (-> (.getFields struct)
+            (coll/into-> {}
+              (map (fn [[key value]]
+                     [(keyword key)
+                      value]))))))))

--- a/editor/src/clj/editor/protobuf.clj
+++ b/editor/src/clj/editor/protobuf.clj
@@ -189,12 +189,13 @@ Macros currently mean no foreseeable performance gain, however."
     (pb-value->clj pb-value)))
 
 (declare ^:private pb->clj-fn)
-(defn- pb-value->clj-fn [field-info default-included-field-rules]
+
+(defn- pb-value->clj-fn [field-info default-included-field-kinds]
   (case (:field-kind field-info)
     :pb-field-kind/list
     (let [{:keys [value-class value-type-kw]} field-info
           value->clj (case value-type-kw
-                       :message (pb->clj-fn value-class default-included-field-rules)
+                       :message (pb->clj-fn value-class default-included-field-kinds)
                        (pb-primitive->clj-fn value-type-kw))]
       (fn repeated-pb-value->clj-vector [^Collection values]
         (when-not (.isEmpty values)
@@ -208,9 +209,11 @@ Macros currently mean no foreseeable performance gain, however."
     (let [{:keys [key-type-kw value-class value-type-kw]} field-info
           key->clj (pb-primitive->clj-fn key-type-kw)
           value->clj (case value-type-kw
-                       :message (pb->clj-fn value-class default-included-field-rules)
+                       :message (pb->clj-fn value-class default-included-field-kinds)
                        (pb-primitive->clj-fn value-type-kw))
-          entry->clj (coll/pair-fn key->clj value->clj)]
+          entry->clj (fn entry->clj [[key value]]
+                       (pair (key->clj key)
+                             (value->clj value)))]
       (fn map-pb-value->clj-map [^Map entries]
         (when-not (.isEmpty entries)
           (coll/into-> entries {}
@@ -219,7 +222,7 @@ Macros currently mean no foreseeable performance gain, however."
     (:pb-field-kind/optional :pb-field-kind/required)
     (let [{:keys [value-class value-type-kw]} field-info]
       (case value-type-kw
-        :message (pb->clj-fn value-class default-included-field-rules)
+        :message (pb->clj-fn value-class default-included-field-kinds)
         (pb-primitive->clj-fn value-type-kw)))))
 
 (def ^:private methods-by-name
@@ -314,21 +317,33 @@ Macros currently mean no foreseeable performance gain, however."
     (:string) ""))
 
 (defn- field-get-method-raw
-  ^Method [^Class cls java-name repeated]
-  (let [get-method-name (str "get" java-name (if repeated "List" ""))]
-    (lookup-method cls get-method-name)))
+  ^Method [^Class pb-class java-name field-kind]
+  (let [get-method-name
+        (case field-kind
+          :pb-field-kind/list
+          (str "get" java-name "List")
+
+          :pb-field-kind/map
+          (str "get" java-name "Map")
+
+          (:pb-field-kind/optional :pb-field-kind/required)
+          (str "get" java-name))]
+    (lookup-method pb-class get-method-name)))
 
 (def ^:private field-get-method (fn/memoize field-get-method-raw))
 
 (defn- field-has-value-fn
-  ^Method [^Class cls java-name repeated]
-  (if repeated
+  ^Method [^Class pb-class java-name field-kind]
+  (case field-kind
+    (:pb-field-kind/list :pb-field-kind/map)
     (let [count-method-name (str "get" java-name "Count")
-          count-method (lookup-method cls count-method-name)]
+          count-method (lookup-method pb-class count-method-name)]
       (fn repeated-field-has-value? [pb]
         (pos? (.invoke count-method pb java/no-args-array))))
+
+    (:pb-field-kind/optional :pb-field-kind/required)
     (let [has-method-name (str "has" java-name)
-          has-method (lookup-method cls has-method-name)]
+          has-method (lookup-method pb-class has-method-name)]
       (fn field-has-value? [pb]
         ;; Wrapped in boolean because reflection will produce unique Boolean
         ;; instances that cannot evaluate to false in if-expressions.
@@ -344,20 +359,14 @@ Macros currently mean no foreseeable performance gain, however."
     (into {}
           (map (fn [^Descriptors$FieldDescriptor field-desc]
                  (let [field-key (field->key field-desc)
-                       is-map-field (.isMapField field-desc)
-                       is-repeated-field (.isRepeated field-desc)
-                       is-optional-field (.isOptional field-desc)
-                       is-required-field (.isRequired field-desc)
-                       field-kind (cond is-map-field :pb-field-kind/map
-                                        is-repeated-field :pb-field-kind/list
-                                        is-optional-field :pb-field-kind/optional
-                                        is-required-field :pb-field-kind/required
-                                        :else (assert false))
-                       ;; TODO(protobuf-maps): Remove field-rule once everything has been ported to field-kind.
-                       field-rule (cond is-repeated-field :repeated
-                                        is-required-field :required
-                                        is-optional-field :optional
-                                        :else (assert false))
+
+                       field-kind
+                       (cond
+                         (.isMapField field-desc) :pb-field-kind/map
+                         (.isRepeated field-desc) :pb-field-kind/list
+                         (.isOptional field-desc) :pb-field-kind/optional
+                         (.isRequired field-desc) :pb-field-kind/required
+                         :else (assert false))
 
                        [key-info value-info]
                        (if (.isMapField field-desc)
@@ -374,16 +383,16 @@ Macros currently mean no foreseeable performance gain, however."
                                                    :value-class (pb-field-desc-class field-desc)}
                                                   (.hasDefaultValue field-desc) ; Declared default in .proto file. Optional primitive fields only.
                                                   (assoc :value-default (pb-primitive->clj (.getDefaultValue field-desc) value-type-kw)))]
-                           (pair nil value-info)))]
+                           (pair nil value-info)))
 
-                   (pair field-key
-                         (coll/merge
-                           key-info
-                           value-info
-                           {:java-name (underscores-to-camel-case (.getName field-desc))
-                            :field-kind field-kind
-                            :field-rule field-rule
-                            :options (options (.getOptions field-desc))})))))
+                       field-info
+                       (coll/merge
+                         key-info
+                         value-info
+                         {:field-kind field-kind
+                          :java-name (underscores-to-camel-case (.getName field-desc))
+                          :options (options (.getOptions field-desc))})]
+                   (pair field-key field-info))))
           (.getFields desc))))
 
 (def field-infos (fn/memoize field-infos-raw))
@@ -527,7 +536,7 @@ Macros currently mean no foreseeable performance gain, however."
                    (message-field? field-info)
                    (let [sub-paths (resource-field-path-specs (:value-class field-info))]
                      (when-not (coll/empty? sub-paths)
-                       (let [prefix (if (= :repeated (:field-rule field-info))
+                       (let [prefix (if (= :pb-field-kind/list (:field-kind field-info))
                                       [[key]]
                                       [key])]
                          (mapv (partial into prefix) sub-paths)))))))
@@ -645,52 +654,67 @@ Macros currently mean no foreseeable performance gain, however."
          (persistent!)
          (msg->clj pb))))
 
-(defn- default-message-raw [^Class class default-included-field-rules]
-  (let [pb->clj (pb->clj-fn class default-included-field-rules)]
+(defn- default-message-raw [^Class class default-included-field-kinds]
+  (let [pb->clj (pb->clj-fn class default-included-field-kinds)]
     (pb->clj (default-instance class))))
 
-(def default-message (fn/memoize default-message-raw))
+(def ^:private default-message (fn/memoize default-message-raw))
 
-(defn- pb->clj-fn-raw [^Class class default-included-field-rules]
-  {:pre [(set? default-included-field-rules)
-         (every? #{:optional :required} default-included-field-rules)]}
-  ;; TODO(protobuf-maps): Convert to field-kind and support map fields.
+(defn- pb->clj-fn-raw [^Class pb-class default-included-field-kinds]
+  {:pre [(set? default-included-field-kinds)
+         (every? #{:pb-field-kind/optional :pb-field-kind/required}
+                 default-included-field-kinds)]}
   (make-pb->clj-fn
-    (mapv (fn [[field-key {:keys [field-rule java-name] :as field-info}]]
-            (let [pb-value->clj (pb-value->clj-fn field-info default-included-field-rules)
-                  repeated (= :repeated field-rule)
-                  ^Method field-get-method (field-get-method class java-name repeated)
-                  include-defaults (contains? default-included-field-rules field-rule)]
-              (pair field-key
-                    (cond
-                      (and include-defaults
-                           (= :optional field-rule)
-                           (message-field? field-info))
-                      (let [field-has-value? (field-has-value-fn class java-name repeated)
-                            default-field-value (default-message (:value-class field-info) default-included-field-rules)]
-                        (fn pb->field-clj-value [pb]
-                          (if (field-has-value? pb)
-                            (let [field-pb-value (.invoke field-get-method pb java/no-args-array)]
-                              (pb-value->clj field-pb-value))
-                            default-field-value)))
+    (coll/into-> (field-infos pb-class) []
+      (map (fn [[field-key {:keys [field-kind java-name] :as field-info}]]
+             (let [pb-value->clj (pb-value->clj-fn field-info default-included-field-kinds)
+                   ^Method field-get-method (field-get-method pb-class java-name field-kind)
+                   include-defaults (contains? default-included-field-kinds field-kind)]
+               (pair field-key
+                     (case field-kind
+                       :pb-field-kind/list
+                       (fn pb->field-clj-value-or-default [pb]
+                         (let [field-pb-value (.invoke field-get-method pb java/no-args-array)]
+                           (pb-value->clj field-pb-value)))
 
-                      (or repeated
-                          include-defaults)
-                      (fn pb->field-clj-value-or-default [pb]
-                        (let [field-pb-value (.invoke field-get-method pb java/no-args-array)]
-                          (pb-value->clj field-pb-value)))
+                       :pb-field-kind/map
+                       (fn pb->field-clj-value-or-default [pb]
+                         (let [field-pb-value (.invoke field-get-method pb java/no-args-array)]
+                           (pb-value->clj field-pb-value)))
 
-                      :else
-                      (let [field-has-value? (field-has-value-fn class java-name repeated)]
-                        (fn pb->field-clj-value [pb]
-                          (when (field-has-value? pb)
-                            (let [field-pb-value (.invoke field-get-method pb java/no-args-array)]
-                              (pb-value->clj field-pb-value)))))))))
-          (field-infos class))))
+                       :pb-field-kind/optional
+                       (if include-defaults
+                         (if (message-field? field-info)
+                           (let [field-has-value? (field-has-value-fn pb-class java-name field-kind)
+                                 default-field-value (default-message (:value-class field-info) default-included-field-kinds)]
+                             (fn pb->field-clj-value [pb]
+                               (if (field-has-value? pb)
+                                 (let [field-pb-value (.invoke field-get-method pb java/no-args-array)]
+                                   (pb-value->clj field-pb-value))
+                                 default-field-value)))
+                           (fn pb->field-clj-value-or-default [pb]
+                             (let [field-pb-value (.invoke field-get-method pb java/no-args-array)]
+                               (pb-value->clj field-pb-value))))
+                         (let [field-has-value? (field-has-value-fn pb-class java-name field-kind)]
+                           (fn pb->field-clj-value [pb]
+                             (when (field-has-value? pb)
+                               (let [field-pb-value (.invoke field-get-method pb java/no-args-array)]
+                                 (pb-value->clj field-pb-value))))))
+
+                       :pb-field-kind/required
+                       (if include-defaults
+                         (fn pb->field-clj-value-or-default [pb]
+                           (let [field-pb-value (.invoke field-get-method pb java/no-args-array)]
+                             (pb-value->clj field-pb-value)))
+                         (let [field-has-value? (field-has-value-fn pb-class java-name field-kind)]
+                           (fn pb->field-clj-value [pb]
+                             (when (field-has-value? pb)
+                               (let [field-pb-value (.invoke field-get-method pb java/no-args-array)]
+                                 (pb-value->clj field-pb-value))))))))))))))
 
 (def ^:private pb->clj-fn (fn/memoize pb->clj-fn-raw))
 
-(def ^:private pb->clj-with-defaults-fn (fn/memoize #(pb->clj-fn % #{:optional :required})))
+(def ^:private pb->clj-with-defaults-fn (fn/memoize #(pb->clj-fn % #{:pb-field-kind/optional :pb-field-kind/required})))
 
 (def ^:private pb->clj-without-defaults-fn (fn/memoize #(pb->clj-fn % #{})))
 
@@ -717,6 +741,23 @@ Macros currently mean no foreseeable performance gain, however."
                       field-is-default (clear-defaults-from-builder! field-builder)]
                   (.setField builder field-desc (.build field-builder))
                   (and is-default field-is-default))
+
+                (.isMapField field-desc)
+                (let [entry-count (.getRepeatedFieldCount builder field-desc)]
+                  (if (zero? entry-count)
+                    is-default
+                    (let [entry-desc (.getMessageType field-desc)
+                          value-field-desc (.findFieldByName entry-desc "value")]
+                      (if (not= Descriptors$FieldDescriptor$JavaType/MESSAGE (.getJavaType value-field-desc))
+                        is-default
+                        (do
+                          (doseq [index (range entry-count)]
+                            (let [entry-builder (.toBuilder ^Message (.getRepeatedField builder field-desc index))
+                                  value-builder (.toBuilder ^Message (.getField entry-builder value-field-desc))]
+                              (clear-defaults-from-builder! value-builder)
+                              (.setField entry-builder value-field-desc (.build value-builder))
+                              (.setRepeatedField builder field-desc index (.build entry-builder))))
+                          false)))))
 
                 (.isRepeated field-desc)
                 (let [item-count (.getRepeatedFieldCount builder field-desc)]
@@ -776,19 +817,19 @@ Macros currently mean no foreseeable performance gain, however."
   (let [pb->clj-without-defaults (pb->clj-without-defaults-fn (.getClass pb))]
     (pb->clj-without-defaults (clear-defaults-from-message pb))))
 
-(defn- default-value-raw [^Class cls]
-  (default-message cls #{:optional}))
+(defn- optional-field-defaults-raw [^Class cls]
+  (default-message cls #{:pb-field-kind/optional}))
 
-(def default-value (fn/memoize default-value-raw))
+(def optional-field-defaults (fn/memoize optional-field-defaults-raw))
 
-(defn- required-default-value-raw [^Class cls]
-  (default-message cls #{:required}))
+(defn- required-field-defaults-raw [^Class cls]
+  (default-message cls #{:pb-field-kind/required}))
 
-(def required-default-value (fn/memoize required-default-value-raw))
+(def required-field-defaults (fn/memoize required-field-defaults-raw))
 
 (defn default
   ([^Class cls field]
-   (let [field-default (get (default-value cls) field ::not-found)]
+   (let [field-default (get (optional-field-defaults cls) field ::not-found)]
      (if (not= ::not-found field-default)
        field-default
        (throw (ex-info (format "Field '%s' does not have a default in protobuf class '%s'."
@@ -797,10 +838,10 @@ Macros currently mean no foreseeable performance gain, however."
                        {:pb-class cls
                         :field field})))))
   ([^Class cls field not-found]
-   (get (default-value cls) field not-found)))
+   (get (optional-field-defaults cls) field not-found)))
 
 (defn required-default [^Class cls field]
-  (let [field-default (get (required-default-value cls) field ::not-found)]
+  (let [field-default (get (required-field-defaults cls) field ::not-found)]
     (if (not= ::not-found field-default)
       field-default
       (throw (ex-info (format "Field '%s' is not required in protobuf class '%s'."
@@ -878,17 +919,32 @@ Macros currently mean no foreseeable performance gain, however."
         field-descs (.getFields desc)
         setters (into {}
                       (map (fn [^Descriptors$FieldDescriptor fd]
-                             (let [j-name (->CamelCase (.getName fd))
-                                   repeated (.isRepeated fd)
-                                   ^Method field-set-method (get methods (str (if repeated "addAll" "set") j-name))
-                                   field-builder (if (= (.getJavaType fd) Descriptors$FieldDescriptor$JavaType/MESSAGE)
-                                                   (let [^Method field-get-method (get methods (str "get" j-name))]
-                                                     (pb-builder (.getReturnType field-get-method)))
-                                                   (primitive-builder fd))
+                             (let [java-name (->CamelCase (.getName fd))
+                                   is-map-field (.isMapField fd)
+                                   is-repeated-field (.isRepeated fd)
+
+                                   ^Method field-set-method
+                                   (get methods
+                                        (cond
+                                          is-map-field (str "putAll" java-name)
+                                          is-repeated-field (str "addAll" java-name)
+                                          :else (str "set" java-name)))
+
+                                   field-builder
+                                   (if (= Descriptors$FieldDescriptor$JavaType/MESSAGE (.getJavaType fd))
+                                     (let [^Method field-get-method
+                                           (get methods
+                                                (if is-map-field
+                                                  (str "get" java-name "OrThrow")
+                                                  (str "get" java-name)))]
+                                       (pb-builder (.getReturnType field-get-method)))
+                                     (primitive-builder fd))
+
                                    field-key (field->key fd)
-                                   value-fn (if repeated
-                                              #(mapv field-builder %)
-                                              field-builder)
+                                   value-fn (cond
+                                              is-map-field #(coll/map-vals field-builder %)
+                                              is-repeated-field #(mapv field-builder %)
+                                              :else field-builder)
                                    value-fn (if-not decorate-protobuf-exceptions
                                               value-fn
                                               (fn decorated-value-fn [clj-value]
@@ -1368,7 +1424,7 @@ Macros currently mean no foreseeable performance gain, however."
                          :m30 :m31 :m32 :m33]}
        (into {}
              (map (fn [[^Class cls component-keys]]
-                    (let [default-values (default-value cls)]
+                    (let [default-values (optional-field-defaults cls)]
                       (pair cls
                             (fn vector->map [component-values]
                               (->> component-keys
@@ -1382,7 +1438,7 @@ Macros currently mean no foreseeable performance gain, however."
                                    (persistent!))))))))))
 
 (defn make-map-with-defaults [^Class cls & kvs]
-  (into (default-value cls)
+  (into (optional-field-defaults cls)
         (comp (partition-all 2)
               (keep (fn [[key value :as entry]]
                       (cond
@@ -1402,7 +1458,7 @@ Macros currently mean no foreseeable performance gain, however."
 
 (defn- without-defaults-xform-raw [^Class cls]
   (let [key->field-info (field-infos cls)
-        key->default (default-value cls)]
+        key->default (optional-field-defaults cls)]
     (keep (fn [[key value :as entry]]
             (when (some? value)
               (let [field-info (key->field-info key)]

--- a/editor/src/clj/editor/protobuf.clj
+++ b/editor/src/clj/editor/protobuf.clj
@@ -70,36 +70,44 @@ Macros currently mean no foreseeable performance gain, however."
 
     (instance? IPending fn-or-promise)
     (fn late-fn [& args]
-      (let [fn (deref fn-or-promise)]
-        (apply fn args)))))
+      (let [fn (deref fn-or-promise 1000 ::timeout)]
+        (if (not= ::timeout fn)
+          (apply fn args)
+          (throw
+            (ex-info
+              "Calling late-bound function before its promise could be delivered."
+              {:promise fn-or-promise})))))))
 
 (defn- memoize-late-bound [higher-order-fn]
-  (let [cache-atom (atom {})]
-    (fn memoized-higher-order-fn [& args]
-      (let [cache-key (vec args)
-            cache-value (get @cache-atom cache-key)]
-        (or (as-late-bound-fn cache-value)
-            (let [late-fn-promise (promise)
+  (let [cache-atom (atom {})
 
-                  cache-value
-                  (-> cache-atom
-                      (swap! update cache-key fn/or late-fn-promise)
-                      (get cache-key))]
+        memoized-fn
+        (fn memoized-fn [& args]
+          (let [cache-key (vec args)
+                cache-value (get @cache-atom cache-key)]
+            (or (as-late-bound-fn cache-value)
+                (let [lower-order-fn-promise (promise)
 
-              (if (identical? late-fn-promise cache-value)
-                ;; We just inserted our promise into the cache, so we're
-                ;; responsible for delivering the result.
-                (let [late-fn (apply higher-order-fn args)]
-                  (assert (ifn? late-fn) "The higher-order-fn must return a function.")
-                  (deliver late-fn-promise late-fn)
-                  (swap! cache-atom assoc cache-key late-fn)
-                  late-fn)
+                      cache-value
+                      (-> cache-atom
+                          (swap! update cache-key fn/or lower-order-fn-promise)
+                          (get cache-key))]
 
-                ;; Found an already-existing promise or function in the cache.
-                ;; Return the function unaltered, or a function that
-                ;; dereferences the promise when called.
-                (or (as-late-bound-fn cache-value)
-                    (assert false "Unexpected value found in cache.")))))))))
+                  (if (identical? lower-order-fn-promise cache-value)
+                    ;; We just inserted our promise into the cache, so we're
+                    ;; responsible for delivering the result.
+                    (let [early-fn (apply higher-order-fn args)]
+                      (assert (ifn? early-fn) "The higher-order-fn must return a function.")
+                      (deliver lower-order-fn-promise early-fn)
+                      (swap! cache-atom assoc cache-key early-fn)
+                      early-fn)
+
+                    ;; Found an already-existing promise or function in the cache.
+                    ;; Return the function unaltered, or a function that
+                    ;; dereferences the promise when called.
+                    (as-late-bound-fn cache-value))))))]
+
+    (fn/with-memoize-info memoized-fn higher-order-fn cache-atom -1)))
 
 (def ^:private upper-pattern (re-pattern #"\p{javaUpperCase}"))
 
@@ -429,6 +437,7 @@ Macros currently mean no foreseeable performance gain, however."
                          key-info
                          value-info
                          {:field-kind field-kind
+                          :is-oneof-field (some? (.getRealContainingOneof field-desc))
                           :java-name (underscores-to-camel-case (.getName field-desc))
                           :options (options (.getOptions field-desc))})]
                    (pair field-key field-info))))
@@ -708,7 +717,8 @@ Macros currently mean no foreseeable performance gain, however."
       (map (fn [[field-key {:keys [field-kind java-name] :as field-info}]]
              (let [pb-value->clj (pb-value->clj-fn field-info default-included-field-kinds)
                    ^Method field-get-method (field-get-method pb-class java-name field-kind)
-                   include-defaults (contains? default-included-field-kinds field-kind)]
+                   include-defaults (and (not (:is-oneof-field field-info))
+                                         (contains? default-included-field-kinds field-kind))]
                (pair field-key
                      (case field-kind
                        :pb-field-kind/list
@@ -725,12 +735,12 @@ Macros currently mean no foreseeable performance gain, however."
                        (if include-defaults
                          (if (message-field? field-info)
                            (let [field-has-value? (field-has-value-fn pb-class java-name field-kind)
-                                 default-field-value (default-message (:value-class field-info) default-included-field-kinds)]
+                                 field-pb-class (:value-class field-info)]
                              (fn pb->field-clj-value [pb]
                                (if (field-has-value? pb)
                                  (let [field-pb-value (.invoke field-get-method pb java/no-args-array)]
                                    (pb-value->clj field-pb-value))
-                                 default-field-value)))
+                                 (default-message field-pb-class default-included-field-kinds)))) ; Call from inside the fn to support self-referential types.
                            (fn pb->field-clj-value-or-default [pb]
                              (let [field-pb-value (.invoke field-get-method pb java/no-args-array)]
                                (pb-value->clj field-pb-value))))
@@ -767,7 +777,8 @@ Macros currently mean no foreseeable performance gain, however."
                   is-default
                   (let [field-builder (.toBuilder ^Message (.getField builder field-desc))
                         field-is-default (clear-defaults-from-builder! field-builder)]
-                    (if field-is-default
+                    (if (and field-is-default
+                             (not (.getRealContainingOneof field-desc)))
                       (do
                         (.clearField builder field-desc)
                         is-default)
@@ -811,6 +822,9 @@ Macros currently mean no foreseeable performance gain, however."
 
               ;; Non-message field.
               (cond
+                (.getRealContainingOneof field-desc)
+                false
+
                 (.isOptional field-desc)
                 (cond
                   (not (.hasField builder field-desc))
@@ -1035,7 +1049,7 @@ Macros currently mean no foreseeable performance gain, however."
       (comp builder-fn vector->map)
       builder-fn)))
 
-(def ^:private pb-builder (fn/memoize pb-builder-raw))
+(def ^:private pb-builder (memoize-late-bound pb-builder-raw))
 
 (defmacro map->pb [^Class cls m]
   (cond-> `((#'pb-builder ~cls) ~m)

--- a/editor/src/clj/editor/render_program_utils.clj
+++ b/editor/src/clj/editor/render_program_utils.clj
@@ -125,7 +125,7 @@
 
 (def ^:private editable-sampler-optional-field-defaults
   (-> Material$MaterialDesc$Sampler
-      (protobuf/default-message #{:optional})
+      (protobuf/optional-field-defaults)
       (dissoc :name-hash :texture))) ; TODO: Support assigning a default :texture for Samplers.
 
 (defn sampler->editable-sampler [sampler]

--- a/editor/src/clj/editor/render_target.clj
+++ b/editor/src/clj/editor/render_target.clj
@@ -172,7 +172,7 @@
         depth-stencil-attachment-format :format
         depth-stencil-attachment-texture-storage :texture-storage))))
 
-(def ^:private default-pb-depth-stencil-attachment (protobuf/default-message RenderTarget$RenderTargetDesc$DepthStencilAttachment #{:required}))
+(def ^:private default-pb-depth-stencil-attachment (protobuf/required-field-defaults RenderTarget$RenderTargetDesc$DepthStencilAttachment))
 
 (defn- sanitize-render-target [render-target-desc]
   {:pre [(map? render-target-desc)]} ; RenderTarget$RenderTargetDesc in map format.

--- a/editor/src/clj/editor/resource_node.clj
+++ b/editor/src/clj/editor/resource_node.clj
@@ -213,14 +213,13 @@
   ([resource-node-id evaluation-context]
    (g/valid-node-value resource-node-id :dirty evaluation-context)))
 
-(defn- make-ddf-dependencies-fn-raw [ddf-type]
-  (let [get-fields (protobuf/get-fields-fn (protobuf/resource-field-path-specs ddf-type))]
-    (fn [source-value]
-      (into []
-            (comp
-              (filter seq)
-              (distinct))
-            (get-fields source-value)))))
+(defn- make-ddf-dependencies-fn-raw [^Class pb-class]
+  (fn ddf-dependencies-fn [source-value]
+    (coll/into->
+      (protobuf/resource-field-value-paths pb-class source-value) []
+      (map second) ; => proj-paths
+      (remove coll/empty?)
+      (distinct))))
 
 (def make-ddf-dependencies-fn (memoize make-ddf-dependencies-fn-raw))
 

--- a/editor/src/clj/editor/tile_source.clj
+++ b/editor/src/clj/editor/tile_source.clj
@@ -220,7 +220,7 @@
 (def ^:private protobuf-animation-defaults
   "Default field values declared in the Tile$Animation protobuf message. Fields
   that match these values will be excluded from the saved project files."
-  (protobuf/default-value Tile$Animation))
+  (protobuf/optional-field-defaults Tile$Animation))
 
 (defn- animation-ddf-errors [tile-count node-id animation-ddf]
   {:pre [(g/node-id? node-id)

--- a/editor/src/clj/util/fn.clj
+++ b/editor/src/clj/util/fn.clj
@@ -40,9 +40,9 @@
                       (merge {:args ~'args}
                              ~context-map-expr))))))
 
-(definline ^:private with-memoize-info [memoized-fn cache arity]
+(definline with-memoize-info [memoized-fn original-fn cache arity]
   `(with-meta ~memoized-fn
-              {::memoize-original ~memoized-fn
+              {::memoize-original ~original-fn
                ::memoize-arity ~arity
                ::memoize-cache ~cache}))
 
@@ -85,7 +85,7 @@
                             (swap! cache encache-fn arg result)
                             result)
                           cached-result)))]
-    (with-memoize-info memoized-fn cache 1)))
+    (with-memoize-info memoized-fn unary-fn cache 1)))
 
 (defn- memoize-two [opts binary-fn]
   (let [[storage encache-fn] (memoize-details opts)
@@ -98,7 +98,7 @@
                             (swap! cache encache-fn key result)
                             result)
                           cached-result)))]
-    (with-memoize-info memoized-fn cache 2)))
+    (with-memoize-info memoized-fn binary-fn cache 2)))
 
 (defn- memoize-any [opts any-fn ^long arity]
   (let [[storage encache-fn] (memoize-details opts)
@@ -111,7 +111,7 @@
                             (swap! cache encache-fn key result)
                             result)
                           cached-result)))]
-    (with-memoize-info memoized-fn cache arity)))
+    (with-memoize-info memoized-fn any-fn cache arity)))
 
 (defn- ifn-class-arities-raw
   [^Class ifn-class]

--- a/editor/src/clj/util/fn.clj
+++ b/editor/src/clj/util/fn.clj
@@ -204,14 +204,14 @@
          (memoize-any opts ifn arity))))))
 
 (defn- as-late-bound-fn
-  [fn-or-promise]
+  [fn-or-promise timeout-ms]
   (cond
     (fn? fn-or-promise)
     fn-or-promise
 
     (instance? IPending fn-or-promise)
     (fn late-fn [& args]
-      (let [fn (deref fn-or-promise 0 ::unrealized)]
+      (let [fn (deref fn-or-promise timeout-ms ::unrealized)]
         (if (not= ::unrealized fn)
           (apply fn args)
           (throw
@@ -223,15 +223,26 @@
   "Given a higher-order function that returns a function, return a memoized
   version of the higher-order function that is able to call itself recursively
   with the same arguments. An exception will be thrown if the returned
-  lower-order function is called before memoize-late-bound returns."
-  [higher-order-fn]
+  lower-order function is called before memoize-late-bound returns.
+
+  Required opts:
+    :timeout-ms <integer>
+      The number of milliseconds to wait for the higher-order-fn to deliver the
+      lower-order function to callers of the late-bound lower-order function. If
+      the late-bound lower-order function is called from within the higher-order
+      function that is responsible for producing the lower-order function, it is
+      a programming error. However, in multithreaded scenarios, other threads
+      may wait for the promise to be fulfilled. With an infinite timeout, we
+      won't be able to detect the programming error in the single-threaded case."
+  [{:keys [timeout-ms] :as _opts} higher-order-fn]
+  {:pre [(nat-int? timeout-ms)]}
   (let [cache-atom (atom {})
 
         memoized-fn
         (fn memoized-fn [& args]
           (let [cache-key (vec args)
                 cache-value (get @cache-atom cache-key)]
-            (or* (as-late-bound-fn cache-value)
+            (or* (as-late-bound-fn cache-value timeout-ms)
                  (let [lower-order-fn-promise (promise)
 
                        cache-value
@@ -251,7 +262,7 @@
                      ;; Found an already-existing promise or function in the
                      ;; cache. Return the function unaltered, or a function that
                      ;; dereferences the promise when called.
-                     (as-late-bound-fn cache-value))))))]
+                     (as-late-bound-fn cache-value timeout-ms))))))]
 
     (with-memoize-info memoized-fn higher-order-fn cache-atom -1)))
 

--- a/editor/src/clj/util/fn.clj
+++ b/editor/src/clj/util/fn.clj
@@ -252,12 +252,59 @@
 
                    (if (identical? lower-order-fn-promise cache-value)
                      ;; We just inserted our promise into the cache, so we're
-                     ;; responsible for delivering the result.
-                     (let [early-fn (apply higher-order-fn args)]
-                       (assert (ifn? early-fn) "The higher-order-fn must return a function.")
-                       (deliver lower-order-fn-promise early-fn)
-                       (swap! cache-atom assoc cache-key early-fn)
-                       early-fn)
+                     ;; responsible for delivering the result. In the event that
+                     ;; the higher-order-fn throws an exception when attempting
+                     ;; to produce the lower-order-fn, we deliver a lower-order
+                     ;; function that rethrows the exception when called to the
+                     ;; lower-order-fn-promise before rethrowing.
+                     (let [[lower-order-fn exception]
+                           (try
+                             (let [lower-order-fn (apply higher-order-fn args)]
+                               (assert (ifn? lower-order-fn) "The higher-order-fn must return a function.")
+                               (pair lower-order-fn nil))
+                             (catch Throwable exception
+                               ;; The higher-order-fn threw an exception before
+                               ;; it could return a lower-order-fn. Deliver a
+                               ;; lower-order function that throws a wrapped
+                               ;; version of the original exception to any
+                               ;; concurrent threads that managed to obtain the
+                               ;; lower-order-fn-promise since we inserted it
+                               ;; into the cache-atom above. We will rethrow
+                               ;; this exception below, so our own thread should
+                               ;; never see this throwing lower-order function.
+                               (letfn [(throwing-lower-order-fn [& _args]
+                                         (throw
+                                           (ex-info
+                                             "An exception was thrown when invoking the higher-order-fn to produce this lower-order-fn."
+                                             {}
+                                             exception)))]
+                                 (pair throwing-lower-order-fn exception))))]
+
+                       ;; We always deliver *something* to this promise.
+                       (deliver lower-order-fn-promise lower-order-fn)
+
+                       ;; Update the cache. If everything went well so far, we
+                       ;; replace the lower-order-fn-promise we inserted into
+                       ;; the cache with the actual lower-order-fn. Otherwise,
+                       ;; if the higher-order-fn threw an exception when
+                       ;; attempting to produce the lower-order-fn, we clear out
+                       ;; the lower-order-fn-promise from the cache so that
+                       ;; later calls to the memoized-fn can retry the process.
+                       (swap! cache-atom
+                              (fn [cache]
+                                (let [cache-value (get cache cache-key)]
+                                  (if-not (identical? lower-order-fn-promise cache-value)
+                                    cache
+                                    (if (nil? exception)
+                                      (assoc cache cache-key lower-order-fn)
+                                      (dissoc cache cache-key))))))
+
+                       ;; We've delivered the promise and updated the cache, so
+                       ;; all that remains is to return the lower-order-fn or
+                       ;; rethrow the exception.
+                       (if (nil? exception)
+                         lower-order-fn
+                         (throw exception)))
 
                      ;; Found an already-existing promise or function in the
                      ;; cache. Return the function unaltered, or a function that

--- a/editor/src/clj/util/fn.clj
+++ b/editor/src/clj/util/fn.clj
@@ -18,7 +18,7 @@
                            or or*})
   (:require [internal.java :as java]
             [util.coll :as coll :refer [pair]])
-  (:import [clojure.lang ArityException Compiler Fn IFn IHashEq MultiFn]
+  (:import [clojure.lang ArityException Compiler Fn IFn IHashEq IPending MultiFn]
            [java.lang.reflect Method]))
 
 (set! *warn-on-reflection* true)
@@ -40,7 +40,23 @@
                       (merge {:args ~'args}
                              ~context-map-expr))))))
 
-(definline with-memoize-info [memoized-fn original-fn cache arity]
+;; Exposed publicly as fn/and at the bottom of this file.
+(defn- and-fn
+  "Like clojure.core/and, but is eager and can be used as a function."
+  ([] true)
+  ([a] a)
+  ([a b] (if a b a))
+  ([a b & more] (if a (reduce and-fn b more) a)))
+
+;; Exposed publicly as fn/or at the bottom of this file.
+(defn- or-fn
+  "Like clojure.core/or, but is eager and can be used as a function."
+  ([] nil)
+  ([a] a)
+  ([a b] (if a a b))
+  ([a b & more] (reduce or-fn (if a a b) more)))
+
+(definline ^:private with-memoize-info [memoized-fn original-fn cache arity]
   `(with-meta ~memoized-fn
               {::memoize-original ~original-fn
                ::memoize-arity ~arity
@@ -186,6 +202,58 @@
          1 (memoize-one opts ifn)
          2 (memoize-two opts ifn)
          (memoize-any opts ifn arity))))))
+
+(defn- as-late-bound-fn
+  [fn-or-promise]
+  (cond
+    (fn? fn-or-promise)
+    fn-or-promise
+
+    (instance? IPending fn-or-promise)
+    (fn late-fn [& args]
+      (let [fn (deref fn-or-promise 0 ::unrealized)]
+        (if (not= ::unrealized fn)
+          (apply fn args)
+          (throw
+            (ex-info
+              "Calling late-bound function before its promise could be realized."
+              {:promise fn-or-promise})))))))
+
+(defn memoize-late-bound
+  "Given a higher-order function that returns a function, return a memoized
+  version of the higher-order function that is able to call itself recursively
+  with the same arguments. An exception will be thrown if the returned
+  lower-order function is called before memoize-late-bound returns."
+  [higher-order-fn]
+  (let [cache-atom (atom {})
+
+        memoized-fn
+        (fn memoized-fn [& args]
+          (let [cache-key (vec args)
+                cache-value (get @cache-atom cache-key)]
+            (or* (as-late-bound-fn cache-value)
+                 (let [lower-order-fn-promise (promise)
+
+                       cache-value
+                       (-> cache-atom
+                           (swap! update cache-key or-fn lower-order-fn-promise)
+                           (get cache-key))]
+
+                   (if (identical? lower-order-fn-promise cache-value)
+                     ;; We just inserted our promise into the cache, so we're
+                     ;; responsible for delivering the result.
+                     (let [early-fn (apply higher-order-fn args)]
+                       (assert (ifn? early-fn) "The higher-order-fn must return a function.")
+                       (deliver lower-order-fn-promise early-fn)
+                       (swap! cache-atom assoc cache-key early-fn)
+                       early-fn)
+
+                     ;; Found an already-existing promise or function in the
+                     ;; cache. Return the function unaltered, or a function that
+                     ;; dereferences the promise when called.
+                     (as-late-bound-fn cache-value))))))]
+
+    (with-memoize-info memoized-fn higher-order-fn cache-atom -1)))
 
 (defn clear-memoized!
   "Clear all previously cached results from the cache of a memoized function
@@ -397,18 +465,16 @@
   `(defn ~name [~'value]
      (among-values-case-expr ~valid-values ~'value)))
 
-;; Keep at the bottom to avoid internal use. Code in this file should use and*.
-(defn and
-  "Like clojure.core/and, but is eager and can be used as a function."
-  ([] true)
-  ([a] a)
-  ([a b] (if a b a))
-  ([a b & more] (if a (reduce and b more) a)))
+;; Expose and-fn to the outside as fn/and. Keep at the bottom to avoid internal
+;; use. Code in this file should use and* for core.and and and-fn for this.
+(def
+  ^{:doc "Like clojure.core/and, but is eager and can be used as a function."
+    :arglists '([] [a] [a b] [a b & more])}
+  and and-fn)
 
-;; Keep at the bottom to avoid internal use. Code in this file should use or*.
-(defn or
-  "Like clojure.core/or, but is eager and can be used as a function."
-  ([] nil)
-  ([a] a)
-  ([a b] (if a a b))
-  ([a b & more] (reduce or (if a a b) more)))
+;; Expose or-fn to the outside as fn/or. Keep at the bottom to avoid internal
+;; use. Code in this file should use or* for core.or and or-fn for this.
+(def
+  ^{:doc "Like clojure.core/or, but is eager and can be used as a function."
+    :arglists '([] [a] [a b] [a b & more])}
+  or or-fn)

--- a/editor/src/dev/dev.clj
+++ b/editor/src/dev/dev.clj
@@ -71,7 +71,7 @@
   (:import [com.defold.util WeakInterner]
            [com.dynamo.bob Platform]
            [com.dynamo.graphics.proto Graphics$TextureImage Graphics$TextureImage$Image]
-           [com.google.protobuf Descriptors$FieldDescriptor Descriptors$FieldDescriptor$JavaType]
+           [com.google.protobuf Descriptors$Descriptor Descriptors$FieldDescriptor Descriptors$FieldDescriptor$JavaType]
            [editor.code.data Cursor CursorRange]
            [editor.gl.pass RenderPass]
            [editor.gl.vertex2 VertexBuffer]
@@ -1323,26 +1323,56 @@
                    (build-output-infos->diff-data bob-build-output-infos)
                    opts))))
 
-(defn pb-class-info
-  ([^Class pb-class]
-   (pb-class-info pb-class fn/constantly-true))
-  ([^Class pb-class field-info-predicate]
-   (into (sorted-map)
-         (keep (fn [^Descriptors$FieldDescriptor field-desc]
-                 (let [field-name (.getName field-desc)
-                       field-value-class (protobuf/field-value-class pb-class field-desc)
-                       field-rule (cond (.isRepeated field-desc) :repeated
-                                        (.isRequired field-desc) :required
-                                        (.isOptional field-desc) :optional
-                                        :else (assert false))
-                       field-info (cond-> {:value-type field-value-class
-                                           :field-rule field-rule}
+(defn- pb-field-rule
+  [^Descriptors$FieldDescriptor field-desc]
+  (cond
+    (.isRepeated field-desc) :repeated
+    (.isRequired field-desc) :required
+    (.isOptional field-desc) :optional
+    :else (assert false)))
 
-                                          (= Descriptors$FieldDescriptor$JavaType/MESSAGE (.getJavaType field-desc))
-                                          (assoc :message (pb-class-info field-value-class field-info-predicate)))]
-                   (when (field-info-predicate field-info)
-                     (pair field-name field-info)))))
-         (.getFields (protobuf/pb-class->descriptor pb-class)))))
+(defn- pb-desc-info-impl
+  [^Descriptors$Descriptor desc seen-descs field-info-predicate]
+  (letfn [(recurse [^Descriptors$FieldDescriptor field-desc]
+            (when (= Descriptors$FieldDescriptor$JavaType/MESSAGE (.getJavaType field-desc))
+              (let [value-desc (.getMessageType field-desc)]
+                (when-not (contains? seen-descs value-desc)
+                  (let [seen-descs (conj seen-descs value-desc)]
+                    (pb-desc-info-impl value-desc seen-descs field-info-predicate))))))]
+    (into (sorted-map)
+          (keep (fn [^Descriptors$FieldDescriptor field-desc]
+                  (let [{:keys [key-info value-info]}
+                        (if (.isMapField field-desc)
+                          (let [map-entry-desc (.getMessageType field-desc)
+                                key-field-desc (.findFieldByName map-entry-desc "key")
+                                value-field-desc (.findFieldByName map-entry-desc "value")
+                                key-class (protobuf/pb-field-desc-class key-field-desc)
+                                value-class (protobuf/pb-field-desc-class value-field-desc)
+                                value-message (recurse value-field-desc)]
+                            {:key-info {:key-class key-class}
+                             :value-info (cond-> {:value-class value-class}
+                                                 value-message (assoc :value-message value-message))})
+                          (let [value-class (protobuf/pb-field-desc-class field-desc)
+                                value-message (recurse field-desc)]
+                            {:value-info (cond-> {:value-class value-class}
+                                                 value-message (assoc :value-message value-message))}))
+
+                        field-name (.getName field-desc)
+                        field-rule (pb-field-rule field-desc)
+                        field-info (coll/merge {:field-rule field-rule}
+                                               key-info
+                                               value-info)]
+                    (when (field-info-predicate field-info)
+                      (pair field-name field-info)))))
+          (.getFields desc))))
+
+(defn pb-desc-info
+  ([^Descriptors$Descriptor desc]
+   (pb-desc-info-impl desc #{} fn/constantly-true))
+  ([^Descriptors$Descriptor desc field-info-predicate]
+   (pb-desc-info-impl desc #{} field-info-predicate)))
+
+(def pb-class-info (comp pb-desc-info protobuf/pb-class->descriptor))
 
 (defn pb-resource-type-info
   ([workspace]
@@ -1354,8 +1384,8 @@
                    (let [read-defaults (:read-defaults test-info)
                          pb-class-info (pb-class-info pb-class field-info-predicate)]
                      (pair ext {:read-defaults read-defaults
-                                :value-type pb-class
-                                :message pb-class-info})))))
+                                :value-class pb-class
+                                :value-message pb-class-info})))))
          (workspace/get-resource-type-map workspace))))
 
 (defn pb-resource-exts-that-read-defaults [workspace]
@@ -1364,11 +1394,11 @@
 (def class-name-comparator #(compare (.getName ^Class %1) (.getName ^Class %2)))
 
 (defn resource-pb-classes [workspace]
-  (letfn [(info->value-types [{:keys [message value-type]}]
-            (cond->> (mapcat info->value-types (vals message))
-                     (and message value-type) (cons value-type)))]
+  (letfn [(info->value-classes [{:keys [value-class value-message]}]
+            (cond->> (mapcat info->value-classes (vals value-message))
+                     (and value-message value-class) (cons value-class)))]
     (into (sorted-set-by class-name-comparator)
-          (mapcat info->value-types)
+          (mapcat info->value-classes)
           (vals (pb-resource-type-info workspace)))))
 
 (defn resource-pb-class-field-types
@@ -1378,9 +1408,9 @@
    (into (sorted-map-by class-name-comparator)
          (keep (fn [^Class pb-class]
                  (some->> (into (sorted-map)
-                                (keep (fn [[field-name {:keys [^Class value-type] :as field-info}]]
+                                (keep (fn [[field-name {:keys [^Class value-class] :as field-info}]]
                                         (when (field-info-predicate field-info)
-                                          (pair field-name value-type))))
+                                          (pair field-name value-class))))
                                 (pb-class-info pb-class))
                           (not-empty)
                           (pair pb-class))))

--- a/editor/src/dev/dev.clj
+++ b/editor/src/dev/dev.clj
@@ -1323,7 +1323,7 @@
                    (build-output-infos->diff-data bob-build-output-infos)
                    opts))))
 
-(defn- pb-field-rule
+(defn- pb-field-kind
   [^Descriptors$FieldDescriptor field-desc]
   (cond
     (.isRepeated field-desc) :repeated
@@ -1358,8 +1358,8 @@
                                                  value-message (assoc :value-message value-message))}))
 
                         field-name (.getName field-desc)
-                        field-rule (pb-field-rule field-desc)
-                        field-info (coll/merge {:field-rule field-rule}
+                        field-kind (pb-field-kind field-desc)
+                        field-info (coll/merge {:field-kind field-kind}
                                                key-info
                                                value-info)]
                     (when (field-info-predicate field-info)

--- a/editor/src/dev/dev.clj
+++ b/editor/src/dev/dev.clj
@@ -1323,14 +1323,6 @@
                    (build-output-infos->diff-data bob-build-output-infos)
                    opts))))
 
-(defn- pb-field-kind
-  [^Descriptors$FieldDescriptor field-desc]
-  (cond
-    (.isRepeated field-desc) :repeated
-    (.isRequired field-desc) :required
-    (.isOptional field-desc) :optional
-    :else (assert false)))
-
 (defn- pb-desc-info-impl
   [^Descriptors$Descriptor desc seen-descs field-info-predicate]
   (letfn [(recurse [^Descriptors$FieldDescriptor field-desc]
@@ -1358,7 +1350,7 @@
                                                  value-message (assoc :value-message value-message))}))
 
                         field-name (.getName field-desc)
-                        field-kind (pb-field-kind field-desc)
+                        field-kind (protobuf/pb-field-desc-field-kind field-desc)
                         field-info (coll/merge {:field-kind field-kind}
                                                key-info
                                                value-info)]

--- a/editor/test/editor/protobuf_test.clj
+++ b/editor/test/editor/protobuf_test.clj
@@ -120,10 +120,17 @@
     (is (= m new-m))))
 
 (deftest map-msgs
-  (let [m {:simples {"a" {:image "/path/1.png"}
-                     "b" {:image "/path/2.png"}}}
-        new-m (round-trip TestDdf$ResourceSimpleMapNested m)]
-    (is (= m new-m))))
+  (testing "Primitive values."
+    (let [m {:string-to-number {"a" 1.0
+                                "b" 2.0}}
+          new-m (round-trip TestDdf$MappedPrimitive m)]
+      (is (= m new-m))))
+
+  (testing "Message values."
+    (let [m {:string-to-message {"a" {:uint-value 1}
+                                 "b" {:uint-value 2}}}
+          new-m (round-trip TestDdf$MappedMessage m)]
+      (is (= m new-m)))))
 
 (deftest repeated-uints
   (let [m {:uint-values (into [] (range 10))}
@@ -2052,7 +2059,9 @@ object {
     (is (false? (#'editor.protobuf/clear-defaults-from-builder!
                   (.putStringToMessage (TestDdf$MappedMessage/newBuilder)
                                        ""
-                                       (TestDdf$DefaultValue/getDefaultInstance)))))))
+                                       (-> (TestDdf$SubMsg/newBuilder)
+                                           (.setUintValue 0)
+                                           (.build))))))))
 
 ;; -----------------------------------------------------------------------------
 ;; self-referencing-types

--- a/editor/test/editor/protobuf_test.clj
+++ b/editor/test/editor/protobuf_test.clj
@@ -16,7 +16,7 @@
   (:require [clojure.string :as string]
             [clojure.test :refer :all]
             [editor.protobuf :as protobuf])
-  (:import [com.defold.editor.test TestDdf$BooleanMsg TestDdf$BytesMsg TestDdf$DefaultValue TestDdf$EmptyMsg TestDdf$JavaCasingMsg TestDdf$JsonObject TestDdf$JsonValue TestDdf$Msg TestDdf$NestedDefaults TestDdf$NestedDefaultsSubMsg TestDdf$NestedMessages TestDdf$NestedMessages$NestedEnum$Enum TestDdf$NestedRequireds TestDdf$NestedRequiredsSubMsg TestDdf$OptionalNoDefaultValue TestDdf$RepeatedUints TestDdf$ResourceDefaulted TestDdf$ResourceDefaultedMapNested TestDdf$ResourceDefaultedNested TestDdf$ResourceDefaultedRepeatedlyNested TestDdf$ResourceFields TestDdf$ResourceRepeated TestDdf$ResourceRepeatedMapNested TestDdf$ResourceRepeatedNested TestDdf$ResourceRepeatedRepeatedlyNested TestDdf$ResourceSelfReferencingDefaulted TestDdf$ResourceSelfReferencingRepeated TestDdf$ResourceSelfReferencingSimple TestDdf$ResourceSimple TestDdf$ResourceSimpleMapNested TestDdf$ResourceSimpleNested TestDdf$ResourceSimpleRepeatedlyNested TestDdf$SubMsg TestDdf$Transform TestDdf$Uint64Msg]
+  (:import [com.defold.editor.test TestDdf$BooleanMsg TestDdf$BytesMsg TestDdf$DefaultValue TestDdf$EmptyMsg TestDdf$JavaCasingMsg TestDdf$JsonArray TestDdf$JsonNull TestDdf$JsonObject TestDdf$JsonValue TestDdf$MappedPrimitive TestDdf$MappedMessage TestDdf$Msg TestDdf$NestedDefaults TestDdf$NestedDefaultsSubMsg TestDdf$NestedMessages TestDdf$NestedMessages$NestedEnum$Enum TestDdf$NestedRequireds TestDdf$NestedRequiredsSubMsg TestDdf$OptionalNoDefaultValue TestDdf$RepeatedUints TestDdf$ResourceDefaulted TestDdf$ResourceDefaultedMapNested TestDdf$ResourceDefaultedNested TestDdf$ResourceDefaultedRepeatedlyNested TestDdf$ResourceFields TestDdf$ResourceOneofDefaulted TestDdf$ResourceOneofDefaultedNested TestDdf$ResourceOneofRepeatedNested TestDdf$ResourceOneofSimple TestDdf$ResourceOneofSimpleNested TestDdf$ResourceRepeated TestDdf$ResourceRepeatedMapNested TestDdf$ResourceRepeatedNested TestDdf$ResourceRepeatedRepeatedlyNested TestDdf$ResourceSelfReferencingDefaulted TestDdf$ResourceSelfReferencingRepeated TestDdf$ResourceSelfReferencingSimple TestDdf$ResourceSimple TestDdf$ResourceSimpleMapNested TestDdf$ResourceSimpleNested TestDdf$ResourceSimpleRepeatedlyNested TestDdf$SubMsg TestDdf$Transform TestDdf$Uint64Msg]
            [com.dynamo.proto DdfMath$Matrix4 DdfMath$Point3 DdfMath$Quat DdfMath$Vector3 DdfMath$Vector3One DdfMath$Vector4 DdfMath$Vector4One DdfMath$Vector4WOne]
            [com.google.protobuf ByteString]
            [java.io StringReader]))
@@ -293,6 +293,16 @@
                                          :m30 zero :m31 zero :m32 zero :m33 one}))))))
 
 (deftest resource-field-value-paths-test
+  (testing "Matches only resource fields"
+    (is (= []
+           (protobuf/resource-field-value-paths
+             TestDdf$DefaultValue
+             {:uint-value 1234
+              :string-value "/image.png"
+              :quat-value [0.1 0.2 0.3 1.4]
+              :enum-value :enum-val0
+              :bool-value false}))))
+
   (testing "Simple"
     (is (= []
            (protobuf/resource-field-value-paths
@@ -557,7 +567,170 @@
              {:repeateds {"a" {:images ["/image00.png"
                                         "/image01.png"]}
                           "b" {:images ["/image10.png"
-                                        "/image11.png"]}}})))))
+                                        "/image11.png"]}}}))))
+
+  (testing "Self-referencing simple"
+    (is (= []
+           (protobuf/resource-field-value-paths
+             TestDdf$ResourceSelfReferencingSimple
+             {})))
+    (is (= [[[:image] nil]]
+           (protobuf/resource-field-value-paths
+             TestDdf$ResourceSelfReferencingSimple
+             {:image nil})))
+    (is (= [[[:image] "/image.png"]]
+           (protobuf/resource-field-value-paths
+             TestDdf$ResourceSelfReferencingSimple
+             {:image "/image.png"})))
+    (is (= []
+           (protobuf/resource-field-value-paths
+             TestDdf$ResourceSelfReferencingSimple
+             {:next {}})))
+    (is (= [[[:next :image] nil]]
+           (protobuf/resource-field-value-paths
+             TestDdf$ResourceSelfReferencingSimple
+             {:next {:image nil}})))
+    (is (= [[[:next :image] "/image.png"]]
+           (protobuf/resource-field-value-paths
+             TestDdf$ResourceSelfReferencingSimple
+             {:next {:image "/image.png"}}))))
+
+  (testing "Self-referencing defaulted"
+    (is (= [[[:image] "/default.png"]]
+           (protobuf/resource-field-value-paths
+             TestDdf$ResourceSelfReferencingDefaulted
+             {})))
+    (is (= [[[:image] "/default.png"]]
+           (protobuf/resource-field-value-paths
+             TestDdf$ResourceSelfReferencingDefaulted
+             {:image nil})))
+    (is (= [[[:image] "/image.png"]]
+           (protobuf/resource-field-value-paths
+             TestDdf$ResourceSelfReferencingDefaulted
+             {:image "/image.png"})))
+    (is (= [[[:image] "/default.png"]
+            [[:next :image] "/default.png"]]
+           (protobuf/resource-field-value-paths
+             TestDdf$ResourceSelfReferencingDefaulted
+             {:next {}})))
+    (is (= [[[:image] "/default.png"]
+            [[:next :image] "/default.png"]]
+           (protobuf/resource-field-value-paths
+             TestDdf$ResourceSelfReferencingDefaulted
+             {:next {:image nil}})))
+    (is (= [[[:image] "/default.png"]
+            [[:next :image] "/image.png"]]
+           (protobuf/resource-field-value-paths
+             TestDdf$ResourceSelfReferencingDefaulted
+             {:next {:image "/image.png"}}))))
+
+  (testing "Self-referencing repeated"
+    (is (= [[[:images 0] nil]
+            [[:images 1] nil]]
+           (protobuf/resource-field-value-paths
+             TestDdf$ResourceSelfReferencingRepeated
+             {:images [nil
+                       nil]})))
+    (is (= [[[:images 0] "/image0.png"]
+            [[:images 1] "/image1.png"]]
+           (protobuf/resource-field-value-paths
+             TestDdf$ResourceSelfReferencingRepeated
+             {:images ["/image0.png"
+                       "/image1.png"]})))
+    (is (= [[[:next :images 0] nil]
+            [[:next :images 1] nil]]
+           (protobuf/resource-field-value-paths
+             TestDdf$ResourceSelfReferencingRepeated
+             {:next {:images [nil
+                              nil]}})))
+    (is (= [[[:next :images 0] "/image0.png"]
+            [[:next :images 1] "/image1.png"]]
+           (protobuf/resource-field-value-paths
+             TestDdf$ResourceSelfReferencingRepeated
+             {:next {:images ["/image0.png"
+                              "/image1.png"]}}))))
+
+  (testing "Oneof simple"
+    (is (= []
+           (protobuf/resource-field-value-paths
+             TestDdf$ResourceOneofSimple
+             {})))
+    (is (= [[[:image] nil]]
+           (protobuf/resource-field-value-paths
+             TestDdf$ResourceOneofSimple
+             {:image nil})))
+    (is (= [[[:image] "/image.png"]]
+           (protobuf/resource-field-value-paths
+             TestDdf$ResourceOneofSimple
+             {:image "/image.png"}))))
+
+  (testing "Oneof defaulted"
+    (is (= []
+           (protobuf/resource-field-value-paths
+             TestDdf$ResourceOneofDefaulted
+             {})))
+    (is (= [[[:image] "/default.png"]]
+           (protobuf/resource-field-value-paths
+             TestDdf$ResourceOneofDefaulted
+             {:image nil})))
+    (is (= [[[:image] "/image.png"]]
+           (protobuf/resource-field-value-paths
+             TestDdf$ResourceOneofDefaulted
+             {:image "/image.png"}))))
+
+  (testing "Oneof simple nested"
+    (is (= []
+           (protobuf/resource-field-value-paths
+             TestDdf$ResourceOneofSimpleNested
+             {})))
+    (is (= []
+           (protobuf/resource-field-value-paths
+             TestDdf$ResourceOneofSimpleNested
+             {:simple {}})))
+    (is (= [[[:simple :image] nil]]
+           (protobuf/resource-field-value-paths
+             TestDdf$ResourceOneofSimpleNested
+             {:simple {:image nil}})))
+    (is (= [[[:simple :image] "/image.png"]]
+           (protobuf/resource-field-value-paths
+             TestDdf$ResourceOneofSimpleNested
+             {:simple {:image "/image.png"}}))))
+
+  (testing "Oneof defaulted nested"
+    (is (= []
+           (protobuf/resource-field-value-paths
+             TestDdf$ResourceOneofDefaultedNested
+             {})))
+    (is (= [[[:defaulted :image] "/default.png"]]
+           (protobuf/resource-field-value-paths
+             TestDdf$ResourceOneofDefaultedNested
+             {:defaulted {}})))
+    (is (= [[[:defaulted :image] "/default.png"]]
+           (protobuf/resource-field-value-paths
+             TestDdf$ResourceOneofDefaultedNested
+             {:defaulted {:image nil}})))
+    (is (= [[[:defaulted :image] "/image.png"]]
+           (protobuf/resource-field-value-paths
+             TestDdf$ResourceOneofDefaultedNested
+             {:defaulted {:image "/image.png"}}))))
+
+  (testing "Oneof repeated nested"
+    (is (= []
+           (protobuf/resource-field-value-paths
+             TestDdf$ResourceOneofRepeatedNested
+             {})))
+    (is (= [[[:repeated :images 0] nil]
+            [[:repeated :images 1] nil]]
+           (protobuf/resource-field-value-paths
+             TestDdf$ResourceOneofRepeatedNested
+             {:repeated {:images [nil
+                                  nil]}})))
+    (is (= [[[:repeated :images 0] "/image0.png"]
+            [[:repeated :images 1] "/image1.png"]]
+           (protobuf/resource-field-value-paths
+             TestDdf$ResourceOneofRepeatedNested
+             {:repeated {:images ["/image0.png"
+                                  "/image1.png"]}})))))
 
 ;; -----------------------------------------------------------------------------
 ;; make-map-with-defaults
@@ -1750,6 +1923,31 @@ mapped_message {
 ;; oneof-fields
 ;; -----------------------------------------------------------------------------
 
+(deftest oneof-field-is-initially-default-test
+  (testing "Reports as already default when cleared from initial state."
+    (is (true? (#'editor.protobuf/clear-defaults-from-builder!
+                 (.toBuilder (TestDdf$JsonValue/getDefaultInstance)))))
+    (is (true? (#'editor.protobuf/clear-defaults-from-builder!
+                 (TestDdf$JsonValue/newBuilder)))))
+
+  (testing "Reports as previously non-default when clearing set primitive fields."
+    (is (false? (#'editor.protobuf/clear-defaults-from-builder!
+                  (.setNull (TestDdf$JsonValue/newBuilder) TestDdf$JsonNull/NULL))))
+    (is (false? (#'editor.protobuf/clear-defaults-from-builder!
+                  (.setBool (TestDdf$JsonValue/newBuilder) false))))
+    (is (false? (#'editor.protobuf/clear-defaults-from-builder!
+                  (.setNumber (TestDdf$JsonValue/newBuilder) 0.0))))
+    (is (false? (#'editor.protobuf/clear-defaults-from-builder!
+                  (.setString (TestDdf$JsonValue/newBuilder) "")))))
+
+  (testing "Reports as previously non-default when clearing set message fields."
+    (is (false? (#'editor.protobuf/clear-defaults-from-builder!
+                  (.setArray (TestDdf$JsonValue/newBuilder)
+                             (TestDdf$JsonArray/getDefaultInstance)))))
+    (is (false? (#'editor.protobuf/clear-defaults-from-builder!
+                  (.setObject (TestDdf$JsonValue/newBuilder)
+                              (TestDdf$JsonObject/getDefaultInstance)))))))
+
 (deftest oneof-field-map-without-defaults-test
   (testing "Returns map with a single field of the selected type."
     (is (= {:null :null}
@@ -1828,6 +2026,33 @@ object {
     }
   }
 }")))))
+
+;; -----------------------------------------------------------------------------
+;; map fields
+;; -----------------------------------------------------------------------------
+
+(deftest map-field-is-initially-default-test
+  (testing "Reports as already default when clearing primitive field from initial state."
+    (is (true? (#'editor.protobuf/clear-defaults-from-builder!
+                 (.toBuilder (TestDdf$MappedPrimitive/getDefaultInstance)))))
+    (is (true? (#'editor.protobuf/clear-defaults-from-builder!
+                 (TestDdf$MappedPrimitive/newBuilder)))))
+
+  (testing "Reports as already default when clearing message field from initial state."
+    (is (true? (#'editor.protobuf/clear-defaults-from-builder!
+                 (.toBuilder (TestDdf$MappedMessage/getDefaultInstance)))))
+    (is (true? (#'editor.protobuf/clear-defaults-from-builder!
+                 (TestDdf$MappedMessage/newBuilder)))))
+
+  (testing "Reports as previously non-default when clearing set primitive fields."
+    (is (false? (#'editor.protobuf/clear-defaults-from-builder!
+                  (.putStringToNumber (TestDdf$MappedPrimitive/newBuilder) "" 0.0)))))
+
+  (testing "Reports as previously non-default when clearing set message fields."
+    (is (false? (#'editor.protobuf/clear-defaults-from-builder!
+                  (.putStringToMessage (TestDdf$MappedMessage/newBuilder)
+                                       ""
+                                       (TestDdf$DefaultValue/getDefaultInstance)))))))
 
 ;; -----------------------------------------------------------------------------
 ;; self-referencing-types

--- a/editor/test/editor/protobuf_test.clj
+++ b/editor/test/editor/protobuf_test.clj
@@ -16,7 +16,7 @@
   (:require [clojure.string :as string]
             [clojure.test :refer :all]
             [editor.protobuf :as protobuf])
-  (:import [com.defold.editor.test TestDdf$BooleanMsg TestDdf$BytesMsg TestDdf$DefaultValue TestDdf$EmptyMsg TestDdf$JavaCasingMsg TestDdf$JsonObject TestDdf$JsonValue TestDdf$Msg TestDdf$NestedDefaults TestDdf$NestedDefaultsSubMsg TestDdf$NestedMessages TestDdf$NestedMessages$NestedEnum$Enum TestDdf$NestedRequireds TestDdf$NestedRequiredsSubMsg TestDdf$OptionalNoDefaultValue TestDdf$RepeatedUints TestDdf$ResourceDefaulted TestDdf$ResourceDefaultedMapNested TestDdf$ResourceDefaultedNested TestDdf$ResourceDefaultedRepeatedlyNested TestDdf$ResourceFields TestDdf$ResourceRepeated TestDdf$ResourceRepeatedMapNested TestDdf$ResourceRepeatedNested TestDdf$ResourceRepeatedRepeatedlyNested TestDdf$ResourceSimple TestDdf$ResourceSimpleMapNested TestDdf$ResourceSimpleNested TestDdf$ResourceSimpleRepeatedlyNested TestDdf$SubMsg TestDdf$Transform TestDdf$Uint64Msg]
+  (:import [com.defold.editor.test TestDdf$BooleanMsg TestDdf$BytesMsg TestDdf$DefaultValue TestDdf$EmptyMsg TestDdf$JavaCasingMsg TestDdf$JsonObject TestDdf$JsonValue TestDdf$Msg TestDdf$NestedDefaults TestDdf$NestedDefaultsSubMsg TestDdf$NestedMessages TestDdf$NestedMessages$NestedEnum$Enum TestDdf$NestedRequireds TestDdf$NestedRequiredsSubMsg TestDdf$OptionalNoDefaultValue TestDdf$RepeatedUints TestDdf$ResourceDefaulted TestDdf$ResourceDefaultedMapNested TestDdf$ResourceDefaultedNested TestDdf$ResourceDefaultedRepeatedlyNested TestDdf$ResourceFields TestDdf$ResourceRepeated TestDdf$ResourceRepeatedMapNested TestDdf$ResourceRepeatedNested TestDdf$ResourceRepeatedRepeatedlyNested TestDdf$ResourceSelfReferencingDefaulted TestDdf$ResourceSelfReferencingRepeated TestDdf$ResourceSelfReferencingSimple TestDdf$ResourceSimple TestDdf$ResourceSimpleMapNested TestDdf$ResourceSimpleNested TestDdf$ResourceSimpleRepeatedlyNested TestDdf$SubMsg TestDdf$Transform TestDdf$Uint64Msg]
            [com.dynamo.proto DdfMath$Matrix4 DdfMath$Point3 DdfMath$Quat DdfMath$Vector3 DdfMath$Vector3One DdfMath$Vector4 DdfMath$Vector4One DdfMath$Vector4WOne]
            [com.google.protobuf ByteString]
            [java.io StringReader]))
@@ -292,240 +292,272 @@
                                          :m20 zero :m21 zero :m22 one :m23 zero
                                          :m30 zero :m31 zero :m32 zero :m33 one}))))))
 
-(deftest resource-field-path-specs-test
-  (is (= [[:image]] (protobuf/resource-field-path-specs TestDdf$ResourceSimple)))
-  (is (= [[{:image "/default.png"}]] (protobuf/resource-field-path-specs TestDdf$ResourceDefaulted)))
-  (is (= [[[:images]]] (protobuf/resource-field-path-specs TestDdf$ResourceRepeated)))
-  (is (= [[:simple :image]] (protobuf/resource-field-path-specs TestDdf$ResourceSimpleNested)))
-  (is (= [[:defaulted {:image "/default.png"}]] (protobuf/resource-field-path-specs TestDdf$ResourceDefaultedNested)))
-  (is (= [[:repeated [:images]]] (protobuf/resource-field-path-specs TestDdf$ResourceRepeatedNested)))
-  (is (= [[[:simples] :image]] (protobuf/resource-field-path-specs TestDdf$ResourceSimpleRepeatedlyNested)))
-  (is (= [[[:defaulteds] {:image "/default.png"}]] (protobuf/resource-field-path-specs TestDdf$ResourceDefaultedRepeatedlyNested)))
-  (is (= [[[:repeateds] [:images]]] (protobuf/resource-field-path-specs TestDdf$ResourceRepeatedRepeatedlyNested)))
-  (is (= [[#{:simples} :image]] (protobuf/resource-field-path-specs TestDdf$ResourceSimpleMapNested)))
-  (is (= [[#{:defaulteds} {:image "/default.png"}]] (protobuf/resource-field-path-specs TestDdf$ResourceDefaultedMapNested)))
-  (is (= [[#{:repeateds} [:images]]] (protobuf/resource-field-path-specs TestDdf$ResourceRepeatedMapNested))))
-
-(deftest get-field-value-paths-fn-test
+(deftest get-field-value-paths-test
   (testing "Simple"
     (is (= []
-           ((protobuf/get-field-value-paths-fn [[:image]])
-            {})))
+           (protobuf/get-field-value-paths
+             TestDdf$ResourceSimple
+             {})))
     (is (= [[[:image] nil]]
-           ((protobuf/get-field-value-paths-fn [[:image]])
-            {:image nil})))
+           (protobuf/get-field-value-paths
+             TestDdf$ResourceSimple
+             {:image nil})))
     (is (= [[[:image] "/image.png"]]
-           ((protobuf/get-field-value-paths-fn [[:image]])
-            {:image "/image.png"}))))
+           (protobuf/get-field-value-paths
+             TestDdf$ResourceSimple
+             {:image "/image.png"}))))
 
   (testing "Defaulted"
     (is (= [[[:image] "/default.png"]]
-           ((protobuf/get-field-value-paths-fn [[{:image "/default.png"}]])
-            {})))
+           (protobuf/get-field-value-paths
+             TestDdf$ResourceDefaulted
+             {})))
     (is (= [[[:image] "/default.png"]]
-           ((protobuf/get-field-value-paths-fn [[{:image "/default.png"}]])
-            {:image nil})))
+           (protobuf/get-field-value-paths
+             TestDdf$ResourceDefaulted
+             {:image nil})))
     (is (= [[[:image] "/image.png"]]
-           ((protobuf/get-field-value-paths-fn [[{:image "/default.png"}]])
-            {:image "/image.png"}))))
+           (protobuf/get-field-value-paths
+             TestDdf$ResourceDefaulted
+             {:image "/image.png"}))))
 
   (testing "Repeated"
     (is (= [[[:images 0] nil]
             [[:images 1] nil]]
-           ((protobuf/get-field-value-paths-fn [[[:images]]])
-            {:images [nil
-                      nil]})))
+           (protobuf/get-field-value-paths
+             TestDdf$ResourceRepeated
+             {:images [nil
+                       nil]})))
     (is (= [[[:images 0] "/image0.png"]
             [[:images 1] "/image1.png"]]
-           ((protobuf/get-field-value-paths-fn [[[:images]]])
-            {:images ["/image0.png"
-                      "/image1.png"]}))))
+           (protobuf/get-field-value-paths
+             TestDdf$ResourceRepeated
+             {:images ["/image0.png"
+                       "/image1.png"]}))))
 
   (testing "Simple nested"
     (is (= []
-           ((protobuf/get-field-value-paths-fn [[:simple :image]])
-            {:simple {}})))
+           (protobuf/get-field-value-paths-fn
+             TestDdf$ResourceSimpleNested
+             {:simple {}})))
     (is (= [[[:simple :image] nil]]
-           ((protobuf/get-field-value-paths-fn [[:simple :image]])
-            {:simple {:image nil}})))
+           (protobuf/get-field-value-paths-fn
+             TestDdf$ResourceSimpleNested
+             {:simple {:image nil}})))
     (is (= [[[:simple :image] "/image.png"]]
-           ((protobuf/get-field-value-paths-fn [[:simple :image]])
-            {:simple {:image "/image.png"}}))))
+           (protobuf/get-field-value-paths-fn
+             TestDdf$ResourceSimpleNested
+             {:simple {:image "/image.png"}}))))
 
   (testing "Defaulted nested"
     (is (= []
-           ((protobuf/get-field-value-paths-fn [[:defaulted {:image "/default.png"}]])
-            {})))
+           (protobuf/get-field-value-paths
+             TestDdf$ResourceDefaultedNested
+             {})))
     (is (= [[[:defaulted :image] "/default.png"]]
-           ((protobuf/get-field-value-paths-fn [[:defaulted {:image "/default.png"}]])
-            {:defaulted {}})))
+           (protobuf/get-field-value-paths
+             TestDdf$ResourceDefaultedNested
+             {:defaulted {}})))
     (is (= [[[:defaulted :image] "/default.png"]]
-           ((protobuf/get-field-value-paths-fn [[:defaulted {:image "/default.png"}]])
-            {:defaulted {:image nil}})))
+           (protobuf/get-field-value-paths
+             TestDdf$ResourceDefaultedNested
+             {:defaulted {:image nil}})))
     (is (= [[[:defaulted :image] "/image.png"]]
-           ((protobuf/get-field-value-paths-fn [[:defaulted {:image "/default.png"}]])
-            {:defaulted {:image "/image.png"}}))))
+           (protobuf/get-field-value-paths
+             TestDdf$ResourceDefaultedNested
+             {:defaulted {:image "/image.png"}}))))
 
   (testing "Repeated nested"
     (is (= [[[:repeated :images 0] nil]
             [[:repeated :images 1] nil]]
-           ((protobuf/get-field-value-paths-fn [[:repeated [:images]]])
-            {:repeated {:images [nil
-                                 nil]}})))
+           (protobuf/get-field-value-paths
+             TestDdf$ResourceRepeatedNested
+             {:repeated {:images [nil
+                                  nil]}})))
     (is (= [[[:repeated :images 0] "/image0.png"]
             [[:repeated :images 1] "/image1.png"]]
-           ((protobuf/get-field-value-paths-fn [[:repeated [:images]]])
-            {:repeated {:images ["/image0.png"
-                                 "/image1.png"]}}))))
+           (protobuf/get-field-value-paths
+             TestDdf$ResourceRepeatedNested
+             {:repeated {:images ["/image0.png"
+                                  "/image1.png"]}}))))
 
   (testing "Simple repeatedly nested"
     (is (= []
-           ((protobuf/get-field-value-paths-fn [[[:simples] :image]])
-            {:simples [{}
-                       {}]})))
+           (protobuf/get-field-value-paths
+             TestDdf$ResourceSimpleRepeatedlyNested
+             {:simples [{}
+                        {}]})))
     (is (= [[[:simples 0 :image] nil]
             [[:simples 1 :image] nil]]
-           ((protobuf/get-field-value-paths-fn [[[:simples] :image]])
-            {:simples [{:image nil}
-                       {:image nil}]})))
+           (protobuf/get-field-value-paths
+             TestDdf$ResourceSimpleRepeatedlyNested
+             {:simples [{:image nil}
+                        {:image nil}]})))
     (is (= [[[:simples 0 :image] "/image0.png"]
             [[:simples 1 :image] "/image1.png"]]
-           ((protobuf/get-field-value-paths-fn [[[:simples] :image]])
-            {:simples [{:image "/image0.png"}
-                       {:image "/image1.png"}]}))))
+           (protobuf/get-field-value-paths
+             TestDdf$ResourceSimpleRepeatedlyNested
+             {:simples [{:image "/image0.png"}
+                        {:image "/image1.png"}]}))))
 
   (testing "Defaulted repeatedly nested"
     (is (= []
-           ((protobuf/get-field-value-paths-fn [[[:defaulteds] {:image "/default.png"}]])
-            {:defaulteds []})))
+           (protobuf/get-field-value-paths
+             TestDdf$ResourceDefaultedRepeatedlyNested
+             {:defaulteds []})))
     (is (= [[[:defaulteds 0 :image] "/default.png"]
             [[:defaulteds 1 :image] "/default.png"]]
-           ((protobuf/get-field-value-paths-fn [[[:defaulteds] {:image "/default.png"}]])
-            {:defaulteds [{}
-                          {}]})))
+           (protobuf/get-field-value-paths
+             TestDdf$ResourceDefaultedRepeatedlyNested
+             {:defaulteds [{}
+                           {}]})))
     (is (= [[[:defaulteds 0 :image] "/default.png"]
             [[:defaulteds 1 :image] "/default.png"]]
-           ((protobuf/get-field-value-paths-fn [[[:defaulteds] {:image "/default.png"}]])
-            {:defaulteds [{:image nil}
-                          {:image nil}]})))
+           (protobuf/get-field-value-paths
+             TestDdf$ResourceDefaultedRepeatedlyNested
+             {:defaulteds [{:image nil}
+                           {:image nil}]})))
     (is (= [[[:defaulteds 0 :image] "/image0.png"]
             [[:defaulteds 1 :image] "/image1.png"]]
-           ((protobuf/get-field-value-paths-fn [[[:defaulteds] {:image "/default.png"}]])
-            {:defaulteds [{:image "/image0.png"}
-                          {:image "/image1.png"}]}))))
+           (protobuf/get-field-value-paths
+             TestDdf$ResourceDefaultedRepeatedlyNested
+             {:defaulteds [{:image "/image0.png"}
+                           {:image "/image1.png"}]}))))
 
   (testing "Repeated repeatedly nested"
     (is (= []
-           ((protobuf/get-field-value-paths-fn [[[:repeateds] [:images]]])
-            {})))
+           (protobuf/get-field-value-paths
+             TestDdf$ResourceRepeatedRepeatedlyNested
+             {})))
     (is (= []
-           ((protobuf/get-field-value-paths-fn [[[:repeateds] [:images]]])
-            {:repeateds []})))
+           (protobuf/get-field-value-paths
+             TestDdf$ResourceRepeatedRepeatedlyNested
+             {:repeateds []})))
     (is (= []
-           ((protobuf/get-field-value-paths-fn [[[:repeateds] [:images]]])
-            {:repeateds [{}
-                         {}]})))
+           (protobuf/get-field-value-paths
+             TestDdf$ResourceRepeatedRepeatedlyNested
+             {:repeateds [{}
+                          {}]})))
     (is (= []
-           ((protobuf/get-field-value-paths-fn [[[:repeateds] [:images]]])
-            {:repeateds [{:images []}
-                         {:images []}]})))
+           (protobuf/get-field-value-paths
+             TestDdf$ResourceRepeatedRepeatedlyNested
+             {:repeateds [{:images []}
+                          {:images []}]})))
     (is (= [[[:repeateds 0 :images 0] nil]
             [[:repeateds 0 :images 1] nil]
             [[:repeateds 1 :images 0] nil]
             [[:repeateds 1 :images 1] nil]]
-           ((protobuf/get-field-value-paths-fn [[[:repeateds] [:images]]])
-            {:repeateds [{:images [nil
-                                   nil]}
-                         {:images [nil
-                                   nil]}]})))
+           (protobuf/get-field-value-paths
+             TestDdf$ResourceRepeatedRepeatedlyNested
+             {:repeateds [{:images [nil
+                                    nil]}
+                          {:images [nil
+                                    nil]}]})))
     (is (= [[[:repeateds 0 :images 0] "/image00.png"]
             [[:repeateds 0 :images 1] "/image01.png"]
             [[:repeateds 1 :images 0] "/image10.png"]
             [[:repeateds 1 :images 1] "/image11.png"]]
-           ((protobuf/get-field-value-paths-fn [[[:repeateds] [:images]]])
-            {:repeateds [{:images ["/image00.png"
-                                   "/image01.png"]}
-                         {:images ["/image10.png"
-                                   "/image11.png"]}]}))))
+           (protobuf/get-field-value-paths
+             TestDdf$ResourceRepeatedRepeatedlyNested
+             {:repeateds [{:images ["/image00.png"
+                                    "/image01.png"]}
+                          {:images ["/image10.png"
+                                    "/image11.png"]}]}))))
 
   (testing "Simple map nested"
     (is (= []
-           ((protobuf/get-field-value-paths-fn [[#{:simples} :image]])
-            {})))
+           (protobuf/get-field-value-paths
+             TestDdf$ResourceSimpleMapNested
+             {})))
     (is (= []
-           ((protobuf/get-field-value-paths-fn [[#{:simples} :image]])
-            {:simples {}})))
+           (protobuf/get-field-value-paths
+             TestDdf$ResourceSimpleMapNested
+             {:simples {}})))
     (is (= []
-           ((protobuf/get-field-value-paths-fn [[#{:simples} :image]])
-            {:simples {"a" {}
-                       "b" {}}})))
+           (protobuf/get-field-value-paths
+             TestDdf$ResourceSimpleMapNested
+             {:simples {"a" {}
+                        "b" {}}})))
     (is (= [[[:simples "a" :image] nil]
             [[:simples "b" :image] nil]]
-           ((protobuf/get-field-value-paths-fn [[#{:simples} :image]])
-            {:simples {"a" {:image nil}
-                       "b" {:image nil}}})))
+           (protobuf/get-field-value-paths
+             TestDdf$ResourceSimpleMapNested
+             {:simples {"a" {:image nil}
+                        "b" {:image nil}}})))
     (is (= [[[:simples "a" :image] "/image0.png"]
             [[:simples "b" :image] "/image1.png"]]
-           ((protobuf/get-field-value-paths-fn [[#{:simples} :image]])
-            {:simples {"a" {:image "/image0.png"}
-                       "b" {:image "/image1.png"}}}))))
+           (protobuf/get-field-value-paths
+             TestDdf$ResourceSimpleMapNested
+             {:simples {"a" {:image "/image0.png"}
+                        "b" {:image "/image1.png"}}}))))
 
   (testing "Defaulted map nested"
     (is (= []
-           ((protobuf/get-field-value-paths-fn [[#{:defaulteds} {:image "/default.png"}]])
-            {})))
+           (protobuf/get-field-value-paths
+             TestDdf$ResourceDefaultedMapNested
+             {})))
     (is (= []
-           ((protobuf/get-field-value-paths-fn [[#{:defaulteds} {:image "/default.png"}]])
-            {:defaulteds {}})))
+           (protobuf/get-field-value-paths
+             TestDdf$ResourceDefaultedMapNested
+             {:defaulteds {}})))
     (is (= [[[:defaulteds "a" :image] "/default.png"]
             [[:defaulteds "b" :image] "/default.png"]]
-           ((protobuf/get-field-value-paths-fn [[#{:defaulteds} {:image "/default.png"}]])
-            {:defaulteds {"a" {}
-                          "b" {}}})))
+           (protobuf/get-field-value-paths
+             TestDdf$ResourceDefaultedMapNested
+             {:defaulteds {"a" {}
+                           "b" {}}})))
     (is (= [[[:defaulteds "a" :image] "/default.png"]
             [[:defaulteds "b" :image] "/default.png"]]
-           ((protobuf/get-field-value-paths-fn [[#{:defaulteds} {:image "/default.png"}]])
-            {:defaulteds {"a" {:image nil}
-                          "b" {:image nil}}})))
+           (protobuf/get-field-value-paths
+             TestDdf$ResourceDefaultedMapNested
+             {:defaulteds {"a" {:image nil}
+                           "b" {:image nil}}})))
     (is (= [[[:defaulteds "a" :image] "/image0.png"]
             [[:defaulteds "b" :image] "/image1.png"]]
-           ((protobuf/get-field-value-paths-fn [[#{:defaulteds} {:image "/default.png"}]])
-            {:defaulteds {"a" {:image "/image0.png"}
-                          "b" {:image "/image1.png"}}}))))
+           (protobuf/get-field-value-paths
+             TestDdf$ResourceDefaultedMapNested
+             {:defaulteds {"a" {:image "/image0.png"}
+                           "b" {:image "/image1.png"}}}))))
 
   (testing "Repeated map nested"
     (is (= []
-           ((protobuf/get-field-value-paths-fn [[#{:repeateds} [:images]]])
-            {})))
+           (protobuf/get-field-value-paths
+             TestDdf$ResourceRepeatedMapNested
+             {})))
     (is (= []
-           ((protobuf/get-field-value-paths-fn [[#{:repeateds} [:images]]])
-            {:repeateds {}})))
+           (protobuf/get-field-value-paths
+             TestDdf$ResourceRepeatedMapNested
+             {:repeateds {}})))
     (is (= []
-           ((protobuf/get-field-value-paths-fn [[#{:repeateds} [:images]]])
-            {:repeateds {"a" {}
-                         "b" {}}})))
+           (protobuf/get-field-value-paths
+             TestDdf$ResourceRepeatedMapNested
+             {:repeateds {"a" {}
+                          "b" {}}})))
     (is (= []
-           ((protobuf/get-field-value-paths-fn [[#{:repeateds} [:images]]])
-            {:repeateds {"a" {:images []}
-                         "b" {:images []}}})))
+           (protobuf/get-field-value-paths
+             TestDdf$ResourceRepeatedMapNested
+             {:repeateds {"a" {:images []}
+                          "b" {:images []}}})))
     (is (= [[[:repeateds "a" :images 0] nil]
             [[:repeateds "a" :images 1] nil]
             [[:repeateds "b" :images 0] nil]
             [[:repeateds "b" :images 1] nil]]
-           ((protobuf/get-field-value-paths-fn [[#{:repeateds} [:images]]])
-            {:repeateds {"a" {:images [nil
-                                       nil]}
-                         "b" {:images [nil
-                                       nil]}}})))
+           (protobuf/get-field-value-paths
+             TestDdf$ResourceRepeatedMapNested
+             {:repeateds {"a" {:images [nil
+                                        nil]}
+                          "b" {:images [nil
+                                        nil]}}})))
     (is (= [[[:repeateds "a" :images 0] "/image00.png"]
             [[:repeateds "a" :images 1] "/image01.png"]
             [[:repeateds "b" :images 0] "/image10.png"]
             [[:repeateds "b" :images 1] "/image11.png"]]
-           ((protobuf/get-field-value-paths-fn [[#{:repeateds} [:images]]])
-            {:repeateds {"a" {:images ["/image00.png"
-                                       "/image01.png"]}
-                         "b" {:images ["/image10.png"
-                                       "/image11.png"]}}})))))
+           (protobuf/get-field-value-paths
+             TestDdf$ResourceRepeatedMapNested
+             {:repeateds {"a" {:images ["/image00.png"
+                                        "/image01.png"]}
+                          "b" {:images ["/image10.png"
+                                        "/image11.png"]}}})))))
 
 ;; -----------------------------------------------------------------------------
 ;; make-map-with-defaults

--- a/editor/test/editor/protobuf_test.clj
+++ b/editor/test/editor/protobuf_test.clj
@@ -1714,10 +1714,9 @@ mapped_message {
          (read-map-without-defaults TestDdf$ResourceFields "optional_resource: '/default'"))
       "Keep non-empty paths even if equal to the default."))
 
-
-;: -----------------------------------------------------------------------------
-;; oneof fields
-;: -----------------------------------------------------------------------------
+;; -----------------------------------------------------------------------------
+;; oneof-fields
+;; -----------------------------------------------------------------------------
 
 (deftest oneof-field-map-without-defaults-test
   (testing "Returns map with a single field of the selected type."
@@ -1798,10 +1797,9 @@ object {
   }
 }")))))
 
-
-;: -----------------------------------------------------------------------------
-;; Self-referencing types
-;: -----------------------------------------------------------------------------
+;; -----------------------------------------------------------------------------
+;; self-referencing-types
+;; -----------------------------------------------------------------------------
 
 (deftest self-referencing-type-test
   (let [expected-map

--- a/editor/test/editor/protobuf_test.clj
+++ b/editor/test/editor/protobuf_test.clj
@@ -292,154 +292,154 @@
                                          :m20 zero :m21 zero :m22 one :m23 zero
                                          :m30 zero :m31 zero :m32 zero :m33 one}))))))
 
-(deftest get-field-value-paths-test
+(deftest resource-field-value-paths-test
   (testing "Simple"
     (is (= []
-           (protobuf/get-field-value-paths
+           (protobuf/resource-field-value-paths
              TestDdf$ResourceSimple
              {})))
     (is (= [[[:image] nil]]
-           (protobuf/get-field-value-paths
+           (protobuf/resource-field-value-paths
              TestDdf$ResourceSimple
              {:image nil})))
     (is (= [[[:image] "/image.png"]]
-           (protobuf/get-field-value-paths
+           (protobuf/resource-field-value-paths
              TestDdf$ResourceSimple
              {:image "/image.png"}))))
 
   (testing "Defaulted"
     (is (= [[[:image] "/default.png"]]
-           (protobuf/get-field-value-paths
+           (protobuf/resource-field-value-paths
              TestDdf$ResourceDefaulted
              {})))
     (is (= [[[:image] "/default.png"]]
-           (protobuf/get-field-value-paths
+           (protobuf/resource-field-value-paths
              TestDdf$ResourceDefaulted
              {:image nil})))
     (is (= [[[:image] "/image.png"]]
-           (protobuf/get-field-value-paths
+           (protobuf/resource-field-value-paths
              TestDdf$ResourceDefaulted
              {:image "/image.png"}))))
 
   (testing "Repeated"
     (is (= [[[:images 0] nil]
             [[:images 1] nil]]
-           (protobuf/get-field-value-paths
+           (protobuf/resource-field-value-paths
              TestDdf$ResourceRepeated
              {:images [nil
                        nil]})))
     (is (= [[[:images 0] "/image0.png"]
             [[:images 1] "/image1.png"]]
-           (protobuf/get-field-value-paths
+           (protobuf/resource-field-value-paths
              TestDdf$ResourceRepeated
              {:images ["/image0.png"
                        "/image1.png"]}))))
 
   (testing "Simple nested"
     (is (= []
-           (protobuf/get-field-value-paths-fn
+           (protobuf/resource-field-value-paths
              TestDdf$ResourceSimpleNested
              {:simple {}})))
     (is (= [[[:simple :image] nil]]
-           (protobuf/get-field-value-paths-fn
+           (protobuf/resource-field-value-paths
              TestDdf$ResourceSimpleNested
              {:simple {:image nil}})))
     (is (= [[[:simple :image] "/image.png"]]
-           (protobuf/get-field-value-paths-fn
+           (protobuf/resource-field-value-paths
              TestDdf$ResourceSimpleNested
              {:simple {:image "/image.png"}}))))
 
   (testing "Defaulted nested"
     (is (= []
-           (protobuf/get-field-value-paths
+           (protobuf/resource-field-value-paths
              TestDdf$ResourceDefaultedNested
              {})))
     (is (= [[[:defaulted :image] "/default.png"]]
-           (protobuf/get-field-value-paths
+           (protobuf/resource-field-value-paths
              TestDdf$ResourceDefaultedNested
              {:defaulted {}})))
     (is (= [[[:defaulted :image] "/default.png"]]
-           (protobuf/get-field-value-paths
+           (protobuf/resource-field-value-paths
              TestDdf$ResourceDefaultedNested
              {:defaulted {:image nil}})))
     (is (= [[[:defaulted :image] "/image.png"]]
-           (protobuf/get-field-value-paths
+           (protobuf/resource-field-value-paths
              TestDdf$ResourceDefaultedNested
              {:defaulted {:image "/image.png"}}))))
 
   (testing "Repeated nested"
     (is (= [[[:repeated :images 0] nil]
             [[:repeated :images 1] nil]]
-           (protobuf/get-field-value-paths
+           (protobuf/resource-field-value-paths
              TestDdf$ResourceRepeatedNested
              {:repeated {:images [nil
                                   nil]}})))
     (is (= [[[:repeated :images 0] "/image0.png"]
             [[:repeated :images 1] "/image1.png"]]
-           (protobuf/get-field-value-paths
+           (protobuf/resource-field-value-paths
              TestDdf$ResourceRepeatedNested
              {:repeated {:images ["/image0.png"
                                   "/image1.png"]}}))))
 
   (testing "Simple repeatedly nested"
     (is (= []
-           (protobuf/get-field-value-paths
+           (protobuf/resource-field-value-paths
              TestDdf$ResourceSimpleRepeatedlyNested
              {:simples [{}
                         {}]})))
     (is (= [[[:simples 0 :image] nil]
             [[:simples 1 :image] nil]]
-           (protobuf/get-field-value-paths
+           (protobuf/resource-field-value-paths
              TestDdf$ResourceSimpleRepeatedlyNested
              {:simples [{:image nil}
                         {:image nil}]})))
     (is (= [[[:simples 0 :image] "/image0.png"]
             [[:simples 1 :image] "/image1.png"]]
-           (protobuf/get-field-value-paths
+           (protobuf/resource-field-value-paths
              TestDdf$ResourceSimpleRepeatedlyNested
              {:simples [{:image "/image0.png"}
                         {:image "/image1.png"}]}))))
 
   (testing "Defaulted repeatedly nested"
     (is (= []
-           (protobuf/get-field-value-paths
+           (protobuf/resource-field-value-paths
              TestDdf$ResourceDefaultedRepeatedlyNested
              {:defaulteds []})))
     (is (= [[[:defaulteds 0 :image] "/default.png"]
             [[:defaulteds 1 :image] "/default.png"]]
-           (protobuf/get-field-value-paths
+           (protobuf/resource-field-value-paths
              TestDdf$ResourceDefaultedRepeatedlyNested
              {:defaulteds [{}
                            {}]})))
     (is (= [[[:defaulteds 0 :image] "/default.png"]
             [[:defaulteds 1 :image] "/default.png"]]
-           (protobuf/get-field-value-paths
+           (protobuf/resource-field-value-paths
              TestDdf$ResourceDefaultedRepeatedlyNested
              {:defaulteds [{:image nil}
                            {:image nil}]})))
     (is (= [[[:defaulteds 0 :image] "/image0.png"]
             [[:defaulteds 1 :image] "/image1.png"]]
-           (protobuf/get-field-value-paths
+           (protobuf/resource-field-value-paths
              TestDdf$ResourceDefaultedRepeatedlyNested
              {:defaulteds [{:image "/image0.png"}
                            {:image "/image1.png"}]}))))
 
   (testing "Repeated repeatedly nested"
     (is (= []
-           (protobuf/get-field-value-paths
+           (protobuf/resource-field-value-paths
              TestDdf$ResourceRepeatedRepeatedlyNested
              {})))
     (is (= []
-           (protobuf/get-field-value-paths
+           (protobuf/resource-field-value-paths
              TestDdf$ResourceRepeatedRepeatedlyNested
              {:repeateds []})))
     (is (= []
-           (protobuf/get-field-value-paths
+           (protobuf/resource-field-value-paths
              TestDdf$ResourceRepeatedRepeatedlyNested
              {:repeateds [{}
                           {}]})))
     (is (= []
-           (protobuf/get-field-value-paths
+           (protobuf/resource-field-value-paths
              TestDdf$ResourceRepeatedRepeatedlyNested
              {:repeateds [{:images []}
                           {:images []}]})))
@@ -447,7 +447,7 @@
             [[:repeateds 0 :images 1] nil]
             [[:repeateds 1 :images 0] nil]
             [[:repeateds 1 :images 1] nil]]
-           (protobuf/get-field-value-paths
+           (protobuf/resource-field-value-paths
              TestDdf$ResourceRepeatedRepeatedlyNested
              {:repeateds [{:images [nil
                                     nil]}
@@ -457,7 +457,7 @@
             [[:repeateds 0 :images 1] "/image01.png"]
             [[:repeateds 1 :images 0] "/image10.png"]
             [[:repeateds 1 :images 1] "/image11.png"]]
-           (protobuf/get-field-value-paths
+           (protobuf/resource-field-value-paths
              TestDdf$ResourceRepeatedRepeatedlyNested
              {:repeateds [{:images ["/image00.png"
                                     "/image01.png"]}
@@ -466,75 +466,75 @@
 
   (testing "Simple map nested"
     (is (= []
-           (protobuf/get-field-value-paths
+           (protobuf/resource-field-value-paths
              TestDdf$ResourceSimpleMapNested
              {})))
     (is (= []
-           (protobuf/get-field-value-paths
+           (protobuf/resource-field-value-paths
              TestDdf$ResourceSimpleMapNested
              {:simples {}})))
     (is (= []
-           (protobuf/get-field-value-paths
+           (protobuf/resource-field-value-paths
              TestDdf$ResourceSimpleMapNested
              {:simples {"a" {}
                         "b" {}}})))
     (is (= [[[:simples "a" :image] nil]
             [[:simples "b" :image] nil]]
-           (protobuf/get-field-value-paths
+           (protobuf/resource-field-value-paths
              TestDdf$ResourceSimpleMapNested
              {:simples {"a" {:image nil}
                         "b" {:image nil}}})))
     (is (= [[[:simples "a" :image] "/image0.png"]
             [[:simples "b" :image] "/image1.png"]]
-           (protobuf/get-field-value-paths
+           (protobuf/resource-field-value-paths
              TestDdf$ResourceSimpleMapNested
              {:simples {"a" {:image "/image0.png"}
                         "b" {:image "/image1.png"}}}))))
 
   (testing "Defaulted map nested"
     (is (= []
-           (protobuf/get-field-value-paths
+           (protobuf/resource-field-value-paths
              TestDdf$ResourceDefaultedMapNested
              {})))
     (is (= []
-           (protobuf/get-field-value-paths
+           (protobuf/resource-field-value-paths
              TestDdf$ResourceDefaultedMapNested
              {:defaulteds {}})))
     (is (= [[[:defaulteds "a" :image] "/default.png"]
             [[:defaulteds "b" :image] "/default.png"]]
-           (protobuf/get-field-value-paths
+           (protobuf/resource-field-value-paths
              TestDdf$ResourceDefaultedMapNested
              {:defaulteds {"a" {}
                            "b" {}}})))
     (is (= [[[:defaulteds "a" :image] "/default.png"]
             [[:defaulteds "b" :image] "/default.png"]]
-           (protobuf/get-field-value-paths
+           (protobuf/resource-field-value-paths
              TestDdf$ResourceDefaultedMapNested
              {:defaulteds {"a" {:image nil}
                            "b" {:image nil}}})))
     (is (= [[[:defaulteds "a" :image] "/image0.png"]
             [[:defaulteds "b" :image] "/image1.png"]]
-           (protobuf/get-field-value-paths
+           (protobuf/resource-field-value-paths
              TestDdf$ResourceDefaultedMapNested
              {:defaulteds {"a" {:image "/image0.png"}
                            "b" {:image "/image1.png"}}}))))
 
   (testing "Repeated map nested"
     (is (= []
-           (protobuf/get-field-value-paths
+           (protobuf/resource-field-value-paths
              TestDdf$ResourceRepeatedMapNested
              {})))
     (is (= []
-           (protobuf/get-field-value-paths
+           (protobuf/resource-field-value-paths
              TestDdf$ResourceRepeatedMapNested
              {:repeateds {}})))
     (is (= []
-           (protobuf/get-field-value-paths
+           (protobuf/resource-field-value-paths
              TestDdf$ResourceRepeatedMapNested
              {:repeateds {"a" {}
                           "b" {}}})))
     (is (= []
-           (protobuf/get-field-value-paths
+           (protobuf/resource-field-value-paths
              TestDdf$ResourceRepeatedMapNested
              {:repeateds {"a" {:images []}
                           "b" {:images []}}})))
@@ -542,7 +542,7 @@
             [[:repeateds "a" :images 1] nil]
             [[:repeateds "b" :images 0] nil]
             [[:repeateds "b" :images 1] nil]]
-           (protobuf/get-field-value-paths
+           (protobuf/resource-field-value-paths
              TestDdf$ResourceRepeatedMapNested
              {:repeateds {"a" {:images [nil
                                         nil]}
@@ -552,7 +552,7 @@
             [[:repeateds "a" :images 1] "/image01.png"]
             [[:repeateds "b" :images 0] "/image10.png"]
             [[:repeateds "b" :images 1] "/image11.png"]]
-           (protobuf/get-field-value-paths
+           (protobuf/resource-field-value-paths
              TestDdf$ResourceRepeatedMapNested
              {:repeateds {"a" {:images ["/image00.png"
                                         "/image01.png"]}

--- a/editor/test/editor/protobuf_test.clj
+++ b/editor/test/editor/protobuf_test.clj
@@ -13,9 +13,10 @@
 ;; specific language governing permissions and limitations under the License.
 
 (ns editor.protobuf-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.string :as string]
+            [clojure.test :refer :all]
             [editor.protobuf :as protobuf])
-  (:import [com.defold.editor.test TestDdf$BooleanMsg TestDdf$BytesMsg TestDdf$DefaultValue TestDdf$EmptyMsg TestDdf$JavaCasingMsg TestDdf$Msg TestDdf$NestedDefaults TestDdf$NestedDefaultsSubMsg TestDdf$NestedMessages TestDdf$NestedMessages$NestedEnum$Enum TestDdf$NestedRequireds TestDdf$NestedRequiredsSubMsg TestDdf$OptionalNoDefaultValue TestDdf$RepeatedUints TestDdf$ResourceDefaulted TestDdf$ResourceDefaultedMapNested TestDdf$ResourceDefaultedNested TestDdf$ResourceDefaultedRepeatedlyNested TestDdf$ResourceFields TestDdf$ResourceRepeated TestDdf$ResourceRepeatedMapNested TestDdf$ResourceRepeatedNested TestDdf$ResourceRepeatedRepeatedlyNested TestDdf$ResourceSimple TestDdf$ResourceSimpleMapNested TestDdf$ResourceSimpleNested TestDdf$ResourceSimpleRepeatedlyNested TestDdf$SubMsg TestDdf$Transform TestDdf$Uint64Msg]
+  (:import [com.defold.editor.test TestDdf$BooleanMsg TestDdf$BytesMsg TestDdf$DefaultValue TestDdf$EmptyMsg TestDdf$JavaCasingMsg TestDdf$JsonObject TestDdf$JsonValue TestDdf$Msg TestDdf$NestedDefaults TestDdf$NestedDefaultsSubMsg TestDdf$NestedMessages TestDdf$NestedMessages$NestedEnum$Enum TestDdf$NestedRequireds TestDdf$NestedRequiredsSubMsg TestDdf$OptionalNoDefaultValue TestDdf$RepeatedUints TestDdf$ResourceDefaulted TestDdf$ResourceDefaultedMapNested TestDdf$ResourceDefaultedNested TestDdf$ResourceDefaultedRepeatedlyNested TestDdf$ResourceFields TestDdf$ResourceRepeated TestDdf$ResourceRepeatedMapNested TestDdf$ResourceRepeatedNested TestDdf$ResourceRepeatedRepeatedlyNested TestDdf$ResourceSimple TestDdf$ResourceSimpleMapNested TestDdf$ResourceSimpleNested TestDdf$ResourceSimpleRepeatedlyNested TestDdf$SubMsg TestDdf$Transform TestDdf$Uint64Msg]
            [com.dynamo.proto DdfMath$Matrix4 DdfMath$Point3 DdfMath$Quat DdfMath$Vector3 DdfMath$Vector3One DdfMath$Vector4 DdfMath$Vector4One DdfMath$Vector4WOne]
            [com.google.protobuf ByteString]
            [java.io StringReader]))
@@ -1712,3 +1713,170 @@ mapped_message {
   (is (= {:optional-resource "/default"}
          (read-map-without-defaults TestDdf$ResourceFields "optional_resource: '/default'"))
       "Keep non-empty paths even if equal to the default."))
+
+
+;: -----------------------------------------------------------------------------
+;; oneof fields
+;: -----------------------------------------------------------------------------
+
+(deftest oneof-field-map-without-defaults-test
+  (testing "Returns map with a single field of the selected type."
+    (is (= {:null :null}
+           (protobuf/str->map-without-defaults TestDdf$JsonValue "null: NULL")))
+    (is (= {:bool true}
+           (protobuf/str->map-without-defaults TestDdf$JsonValue "bool: true")))
+    (is (= {:number 1.0}
+           (protobuf/str->map-without-defaults TestDdf$JsonValue "number: 1.0")))
+    (is (= {:string "a"}
+           (protobuf/str->map-without-defaults TestDdf$JsonValue "string: 'a'")))
+    (is (= {:array {:elements [{:bool true}]}}
+           (protobuf/str->map-without-defaults TestDdf$JsonValue "
+array {
+  elements {
+    bool: true
+  }
+}")))
+    (is (= {:object {:members {"intensity" {:number 1.0}}}}
+           (protobuf/str->map-without-defaults TestDdf$JsonValue "
+object {
+  members {
+    key: 'intensity'
+    value {
+      number: 1.0
+    }
+  }
+}"))))
+  (testing "Protobuf oneof fields retain default-valued fields to preserve type."
+    (is (= {:null :null}
+           (protobuf/str->map-without-defaults TestDdf$JsonValue "null: NULL")))
+    (is (= {:bool false}
+           (protobuf/str->map-without-defaults TestDdf$JsonValue "bool: false")))
+    (is (= {:number 0.0}
+           (protobuf/str->map-without-defaults TestDdf$JsonValue "number: 0.0")))
+    (is (= {:string ""}
+           (protobuf/str->map-without-defaults TestDdf$JsonValue "string: ''")))
+    (is (= {:array {}}
+           (protobuf/str->map-without-defaults TestDdf$JsonValue "array {}")))
+    (is (= {:object {}}
+           (protobuf/str->map-without-defaults TestDdf$JsonValue "object {}")))))
+
+(deftest oneof-field-map-with-defaults-test
+  (testing "Returns map with a single field of the selected type."
+    (is (= {:null :null}
+           (protobuf/str->map-with-defaults TestDdf$JsonValue "null: NULL")))
+    (is (= {:bool false}
+           (protobuf/str->map-with-defaults TestDdf$JsonValue "bool: false")))
+    (is (= {:bool true}
+           (protobuf/str->map-with-defaults TestDdf$JsonValue "bool: true")))
+    (is (= {:number 0.0}
+           (protobuf/str->map-with-defaults TestDdf$JsonValue "number: 0.0")))
+    (is (= {:number 1.0}
+           (protobuf/str->map-with-defaults TestDdf$JsonValue "number: 1.0")))
+    (is (= {:string ""}
+           (protobuf/str->map-with-defaults TestDdf$JsonValue "string: ''")))
+    (is (= {:string "a"}
+           (protobuf/str->map-with-defaults TestDdf$JsonValue "string: 'a'")))
+    (is (= {:array {}}
+           (protobuf/str->map-with-defaults TestDdf$JsonValue "array {}")))
+    (is (= {:array {:elements [{:bool true}]}}
+           (protobuf/str->map-with-defaults TestDdf$JsonValue "
+array {
+  elements {
+    bool: true
+  }
+}")))
+    (is (= {:object {}}
+           (protobuf/str->map-with-defaults TestDdf$JsonValue "object {}")))
+    (is (= {:object {:members {"intensity" {:number 1.0}}}}
+           (protobuf/str->map-with-defaults TestDdf$JsonValue "
+object {
+  members {
+    key: 'intensity'
+    value {
+      number: 1.0
+    }
+  }
+}")))))
+
+
+;: -----------------------------------------------------------------------------
+;; Self-referencing types
+;: -----------------------------------------------------------------------------
+
+(deftest self-referencing-type-test
+  (let [expected-map
+        {:members {"null" {:null :null}
+                   "bool" {:bool false}
+                   "number" {:number 0.0}
+                   "string" {:string ""}
+                   "array" {:array {:elements [{:number 0.0}
+                                               {:string ""}]}}
+                   "object" {:object {:members {"number" {:number 0.0}
+                                                "string" {:string ""}}}}}}
+
+        expected-str
+        (string/triml "
+members {
+  key: \"array\"
+  value {
+    array {
+      elements {
+        number: 0.0
+      }
+      elements {
+        string: \"\"
+      }
+    }
+  }
+}
+members {
+  key: \"bool\"
+  value {
+    bool: false
+  }
+}
+members {
+  key: \"null\"
+  value {
+    null: NULL
+  }
+}
+members {
+  key: \"number\"
+  value {
+    number: 0.0
+  }
+}
+members {
+  key: \"object\"
+  value {
+    object {
+      members {
+        key: \"number\"
+        value {
+          number: 0.0
+        }
+      }
+      members {
+        key: \"string\"
+        value {
+          string: \"\"
+        }
+      }
+    }
+  }
+}
+members {
+  key: \"string\"
+  value {
+    string: \"\"
+  }
+}
+")]
+    (testing "Protobuf text format to Clojure map conversion."
+      (is (= expected-map
+             (protobuf/str->map-without-defaults TestDdf$JsonObject expected-str))))
+
+    (testing "Clojure map to Protobuf text format conversion."
+      (is (= expected-str
+             (protobuf/map->str TestDdf$JsonObject expected-map))))))

--- a/editor/test/editor/protobuf_test.clj
+++ b/editor/test/editor/protobuf_test.clj
@@ -1427,12 +1427,12 @@ repeated_message {
   optional_enum: ENUM_VAL0
   optional_bool: false
 }
-mapped_value {
+mapped_message {
   key: 'a'
   value {
   }
 }
-mapped_value {
+mapped_message {
   key: 'b'
   value {
     optional_string: 'overridden optional_string'

--- a/editor/test/editor/protobuf_test.clj
+++ b/editor/test/editor/protobuf_test.clj
@@ -15,7 +15,7 @@
 (ns editor.protobuf-test
   (:require [clojure.test :refer :all]
             [editor.protobuf :as protobuf])
-  (:import [com.defold.editor.test TestDdf$BooleanMsg TestDdf$BytesMsg TestDdf$DefaultValue TestDdf$EmptyMsg TestDdf$JavaCasingMsg TestDdf$Msg TestDdf$NestedDefaults TestDdf$NestedDefaultsSubMsg TestDdf$NestedMessages TestDdf$NestedMessages$NestedEnum$Enum TestDdf$NestedRequireds TestDdf$NestedRequiredsSubMsg TestDdf$OptionalNoDefaultValue TestDdf$RepeatedUints TestDdf$ResourceDefaulted TestDdf$ResourceDefaultedNested TestDdf$ResourceDefaultedRepeatedlyNested TestDdf$ResourceFields TestDdf$ResourceRepeated TestDdf$ResourceRepeatedNested TestDdf$ResourceRepeatedRepeatedlyNested TestDdf$ResourceSimple TestDdf$ResourceSimpleNested TestDdf$ResourceSimpleRepeatedlyNested TestDdf$SubMsg TestDdf$Transform TestDdf$Uint64Msg]
+  (:import [com.defold.editor.test TestDdf$BooleanMsg TestDdf$BytesMsg TestDdf$DefaultValue TestDdf$EmptyMsg TestDdf$JavaCasingMsg TestDdf$Msg TestDdf$NestedDefaults TestDdf$NestedDefaultsSubMsg TestDdf$NestedMessages TestDdf$NestedMessages$NestedEnum$Enum TestDdf$NestedRequireds TestDdf$NestedRequiredsSubMsg TestDdf$OptionalNoDefaultValue TestDdf$RepeatedUints TestDdf$ResourceDefaulted TestDdf$ResourceDefaultedMapNested TestDdf$ResourceDefaultedNested TestDdf$ResourceDefaultedRepeatedlyNested TestDdf$ResourceFields TestDdf$ResourceRepeated TestDdf$ResourceRepeatedMapNested TestDdf$ResourceRepeatedNested TestDdf$ResourceRepeatedRepeatedlyNested TestDdf$ResourceSimple TestDdf$ResourceSimpleMapNested TestDdf$ResourceSimpleNested TestDdf$ResourceSimpleRepeatedlyNested TestDdf$SubMsg TestDdf$Transform TestDdf$Uint64Msg]
            [com.dynamo.proto DdfMath$Matrix4 DdfMath$Point3 DdfMath$Quat DdfMath$Vector3 DdfMath$Vector3One DdfMath$Vector4 DdfMath$Vector4One DdfMath$Vector4WOne]
            [com.google.protobuf ByteString]
            [java.io StringReader]))
@@ -116,6 +116,12 @@
   (let [m {:simples [{:image "/path/1.png"}
                      {:image "/path/2.png"}]}
         new-m (round-trip TestDdf$ResourceSimpleRepeatedlyNested m)]
+    (is (= m new-m))))
+
+(deftest map-msgs
+  (let [m {:simples {"a" {:image "/path/1.png"}
+                     "b" {:image "/path/2.png"}}}
+        new-m (round-trip TestDdf$ResourceSimpleMapNested m)]
     (is (= m new-m))))
 
 (deftest repeated-uints
@@ -294,7 +300,10 @@
   (is (= [[:repeated [:images]]] (protobuf/resource-field-path-specs TestDdf$ResourceRepeatedNested)))
   (is (= [[[:simples] :image]] (protobuf/resource-field-path-specs TestDdf$ResourceSimpleRepeatedlyNested)))
   (is (= [[[:defaulteds] {:image "/default.png"}]] (protobuf/resource-field-path-specs TestDdf$ResourceDefaultedRepeatedlyNested)))
-  (is (= [[[:repeateds] [:images]]] (protobuf/resource-field-path-specs TestDdf$ResourceRepeatedRepeatedlyNested))))
+  (is (= [[[:repeateds] [:images]]] (protobuf/resource-field-path-specs TestDdf$ResourceRepeatedRepeatedlyNested)))
+  (is (= [[#{:simples} :image]] (protobuf/resource-field-path-specs TestDdf$ResourceSimpleMapNested)))
+  (is (= [[#{:defaulteds} {:image "/default.png"}]] (protobuf/resource-field-path-specs TestDdf$ResourceDefaultedMapNested)))
+  (is (= [[#{:repeateds} [:images]]] (protobuf/resource-field-path-specs TestDdf$ResourceRepeatedMapNested))))
 
 (deftest get-field-value-paths-fn-test
   (testing "Simple"
@@ -436,7 +445,86 @@
             {:repeateds [{:images ["/image00.png"
                                    "/image01.png"]}
                          {:images ["/image10.png"
-                                   "/image11.png"]}]})))))
+                                   "/image11.png"]}]}))))
+
+  (testing "Simple map nested"
+    (is (= []
+           ((protobuf/get-field-value-paths-fn [[#{:simples} :image]])
+            {})))
+    (is (= []
+           ((protobuf/get-field-value-paths-fn [[#{:simples} :image]])
+            {:simples {}})))
+    (is (= []
+           ((protobuf/get-field-value-paths-fn [[#{:simples} :image]])
+            {:simples {"a" {}
+                       "b" {}}})))
+    (is (= [[[:simples "a" :image] nil]
+            [[:simples "b" :image] nil]]
+           ((protobuf/get-field-value-paths-fn [[#{:simples} :image]])
+            {:simples {"a" {:image nil}
+                       "b" {:image nil}}})))
+    (is (= [[[:simples "a" :image] "/image0.png"]
+            [[:simples "b" :image] "/image1.png"]]
+           ((protobuf/get-field-value-paths-fn [[#{:simples} :image]])
+            {:simples {"a" {:image "/image0.png"}
+                       "b" {:image "/image1.png"}}}))))
+
+  (testing "Defaulted map nested"
+    (is (= []
+           ((protobuf/get-field-value-paths-fn [[#{:defaulteds} {:image "/default.png"}]])
+            {})))
+    (is (= []
+           ((protobuf/get-field-value-paths-fn [[#{:defaulteds} {:image "/default.png"}]])
+            {:defaulteds {}})))
+    (is (= [[[:defaulteds "a" :image] "/default.png"]
+            [[:defaulteds "b" :image] "/default.png"]]
+           ((protobuf/get-field-value-paths-fn [[#{:defaulteds} {:image "/default.png"}]])
+            {:defaulteds {"a" {}
+                          "b" {}}})))
+    (is (= [[[:defaulteds "a" :image] "/default.png"]
+            [[:defaulteds "b" :image] "/default.png"]]
+           ((protobuf/get-field-value-paths-fn [[#{:defaulteds} {:image "/default.png"}]])
+            {:defaulteds {"a" {:image nil}
+                          "b" {:image nil}}})))
+    (is (= [[[:defaulteds "a" :image] "/image0.png"]
+            [[:defaulteds "b" :image] "/image1.png"]]
+           ((protobuf/get-field-value-paths-fn [[#{:defaulteds} {:image "/default.png"}]])
+            {:defaulteds {"a" {:image "/image0.png"}
+                          "b" {:image "/image1.png"}}}))))
+
+  (testing "Repeated map nested"
+    (is (= []
+           ((protobuf/get-field-value-paths-fn [[#{:repeateds} [:images]]])
+            {})))
+    (is (= []
+           ((protobuf/get-field-value-paths-fn [[#{:repeateds} [:images]]])
+            {:repeateds {}})))
+    (is (= []
+           ((protobuf/get-field-value-paths-fn [[#{:repeateds} [:images]]])
+            {:repeateds {"a" {}
+                         "b" {}}})))
+    (is (= []
+           ((protobuf/get-field-value-paths-fn [[#{:repeateds} [:images]]])
+            {:repeateds {"a" {:images []}
+                         "b" {:images []}}})))
+    (is (= [[[:repeateds "a" :images 0] nil]
+            [[:repeateds "a" :images 1] nil]
+            [[:repeateds "b" :images 0] nil]
+            [[:repeateds "b" :images 1] nil]]
+           ((protobuf/get-field-value-paths-fn [[#{:repeateds} [:images]]])
+            {:repeateds {"a" {:images [nil
+                                       nil]}
+                         "b" {:images [nil
+                                       nil]}}})))
+    (is (= [[[:repeateds "a" :images 0] "/image00.png"]
+            [[:repeateds "a" :images 1] "/image01.png"]
+            [[:repeateds "b" :images 0] "/image10.png"]
+            [[:repeateds "b" :images 1] "/image11.png"]]
+           ((protobuf/get-field-value-paths-fn [[#{:repeateds} [:images]]])
+            {:repeateds {"a" {:images ["/image00.png"
+                                       "/image01.png"]}
+                         "b" {:images ["/image10.png"
+                                       "/image11.png"]}}})))))
 
 ;; -----------------------------------------------------------------------------
 ;; make-map-with-defaults
@@ -475,8 +563,20 @@
                               :optional-quat [1.0 2.0 3.0 4.0]
                               :optional-enum :enum-val0
                               :optional-bool false}]
+          :mapped-message {"a" {:optional-string "default"
+                                :optional-int 10
+                                :optional-quat [0.0 0.0 0.0 1.0]
+                                :optional-enum :enum-val1
+                                :optional-bool true}
+                           "b" {:optional-string "overridden optional_string"
+                                :optional-int 11
+                                :optional-quat [1.0 2.0 3.0 4.0]
+                                :optional-enum :enum-val0
+                                :optional-bool false}}
           :repeated-int [0
-                         1]}
+                         1]
+          :mapped-int {"a" 0
+                       "b" 1}}
          (protobuf/make-map-with-defaults TestDdf$NestedDefaults
            :required-string "overridden required_string"
            :optional-with-default "overridden with_default"
@@ -494,8 +594,17 @@
                                 :optional-quat [1.0 2.0 3.0 4.0]
                                 :optional-enum :enum-val0
                                 :optional-bool false)]
+           :mapped-message {"a" (protobuf/make-map-with-defaults TestDdf$NestedDefaultsSubMsg)
+                            "b" (protobuf/make-map-with-defaults TestDdf$NestedDefaultsSubMsg
+                                  :optional-string "overridden optional_string"
+                                  :optional-int 11
+                                  :optional-quat [1.0 2.0 3.0 4.0]
+                                  :optional-enum :enum-val0
+                                  :optional-bool false)}
            :repeated-int [0
-                          1])))
+                          1]
+           :mapped-int {"a" 0
+                        "b" 1})))
   (is (= {:required-message {:required-string "overridden required_string"
                              :required-quat [1.0 2.0 3.0 4.0]
                              :required-enum :enum-val1}
@@ -505,7 +614,11 @@
           :repeated-message [{}
                              {:required-string "overridden required_string"
                               :required-quat [1.0 2.0 3.0 4.0]
-                              :required-enum :enum-val1}]}
+                              :required-enum :enum-val1}]
+          :mapped-message {"a" {}
+                           "b" {:required-string "overridden required_string"
+                                :required-quat [1.0 2.0 3.0 4.0]
+                                :required-enum :enum-val1}}}
          (protobuf/make-map-with-defaults TestDdf$NestedRequireds
            :required-message (protobuf/make-map-with-defaults TestDdf$NestedRequiredsSubMsg
                                :required-string "overridden required_string"
@@ -519,7 +632,12 @@
                               (protobuf/make-map-with-defaults TestDdf$NestedRequiredsSubMsg
                                 :required-string "overridden required_string"
                                 :required-quat [1.0 2.0 3.0 4.0]
-                                :required-enum :enum-val1)])))
+                                :required-enum :enum-val1)]
+           :mapped-message {"a" (protobuf/make-map-with-defaults TestDdf$NestedRequiredsSubMsg)
+                            "b" (protobuf/make-map-with-defaults TestDdf$NestedRequiredsSubMsg
+                                  :required-string "overridden required_string"
+                                  :required-quat [1.0 2.0 3.0 4.0]
+                                  :required-enum :enum-val1)})))
   (is (= {:optional-resource "/overridden optional_resource"}
          (protobuf/make-map-with-defaults TestDdf$ResourceFields
            :optional-resource "/overridden optional_resource"))))
@@ -542,7 +660,17 @@
                               :optional-int 11
                               :optional-quat [1.0 2.0 3.0 4.0]
                               :optional-enum :enum-val0
-                              :optional-bool false}]}
+                              :optional-bool false}]
+          :mapped-message {"a" {:optional-string "default"
+                                :optional-int 10
+                                :optional-quat [0.0 0.0 0.0 1.0]
+                                :optional-enum :enum-val1
+                                :optional-bool true}
+                           "b" {:optional-string "overridden optional_string"
+                                :optional-int 11
+                                :optional-quat [1.0 2.0 3.0 4.0]
+                                :optional-enum :enum-val0
+                                :optional-bool false}}}
          (protobuf/make-map-with-defaults TestDdf$NestedDefaults
            :required-string ""
            :optional-with-default "overridden with_default"
@@ -559,7 +687,14 @@
                                 :optional-int 11
                                 :optional-quat [1.0 2.0 3.0 4.0]
                                 :optional-enum :enum-val0
-                                :optional-bool false)])))
+                                :optional-bool false)]
+           :mapped-message {"a" (protobuf/make-map-with-defaults TestDdf$NestedDefaultsSubMsg)
+                            "b" (protobuf/make-map-with-defaults TestDdf$NestedDefaultsSubMsg
+                                  :optional-string "overridden optional_string"
+                                  :optional-int 11
+                                  :optional-quat [1.0 2.0 3.0 4.0]
+                                  :optional-enum :enum-val0
+                                  :optional-bool false)})))
   (is (= {:required-message {:required-string ""
                              :required-quat [0.0 0.0 0.0 1.0]
                              :required-enum :enum-val0}
@@ -569,7 +704,11 @@
           :repeated-message [{}
                              {:required-string ""
                               :required-quat [0.0 0.0 0.0 1.0]
-                              :required-enum :enum-val0}]}
+                              :required-enum :enum-val0}]
+          :mapped-message {"a" {}
+                           "b" {:required-string ""
+                                :required-quat [0.0 0.0 0.0 1.0]
+                                :required-enum :enum-val0}}}
          (protobuf/make-map-with-defaults TestDdf$NestedRequireds
            :required-message (protobuf/make-map-with-defaults TestDdf$NestedRequiredsSubMsg
                                :required-string ""
@@ -583,7 +722,12 @@
                               (protobuf/make-map-with-defaults TestDdf$NestedRequiredsSubMsg
                                 :required-string ""
                                 :required-quat [0.0 0.0 0.0 1.0]
-                                :required-enum :enum-val0)])))
+                                :required-enum :enum-val0)]
+           :mapped-message {"a" (protobuf/make-map-with-defaults TestDdf$NestedRequiredsSubMsg)
+                            "b" (protobuf/make-map-with-defaults TestDdf$NestedRequiredsSubMsg
+                                  :required-string ""
+                                  :required-quat [0.0 0.0 0.0 1.0]
+                                  :required-enum :enum-val0)})))
   (is (= {:optional-resource "/default"}
          (protobuf/make-map-with-defaults TestDdf$ResourceFields
            :optional-resource "/default"))))
@@ -656,8 +800,20 @@ required_message {
                               :optional-quat [1.0 2.0 3.0 4.0]
                               :optional-enum :enum-val0
                               :optional-bool false}]
+          :mapped-message {"a" {:optional-string "default"
+                                :optional-int 10
+                                :optional-quat [0.0 0.0 0.0 1.0]
+                                :optional-enum :enum-val1
+                                :optional-bool true}
+                           "b" {:optional-string "overridden optional_string"
+                                :optional-int 11
+                                :optional-quat [1.0 2.0 3.0 4.0]
+                                :optional-enum :enum-val0
+                                :optional-bool false}}
           :repeated-int [0
-                         1]}
+                         1]
+          :mapped-int {"a" 0
+                       "b" 1}}
          (read-map-with-defaults TestDdf$NestedDefaults "
 required_string: 'overridden required_string'
 optional_with_default: 'overridden with_default'
@@ -688,8 +844,36 @@ repeated_message {
   optional_enum: ENUM_VAL0
   optional_bool: false
 }
+mapped_message {
+  key: 'a'
+  value {
+  }
+}
+mapped_message {
+  key: 'b'
+  value {
+    optional_string: 'overridden optional_string'
+    optional_int: 11
+    optional_quat {
+      x: 1.0
+      y: 2.0
+      z: 3.0
+      w: 4.0
+    }
+    optional_enum: ENUM_VAL0
+    optional_bool: false
+  }
+}
 repeated_int: 0
-repeated_int: 1")))
+repeated_int: 1
+mapped_int {
+  key: 'a'
+  value: 0
+}
+mapped_int {
+  key: 'b'
+  value: 1
+}")))
   (is (= {:optional-message {:required-string "overridden required_string"
                              :required-quat [1.0 2.0 3.0 4.0]
                              :required-enum :enum-val1}
@@ -701,7 +885,13 @@ repeated_int: 1")))
                               :required-enum :enum-val1}
                              {:required-string "overridden required_string"
                               :required-quat [1.0 2.0 3.0 4.0]
-                              :required-enum :enum-val1}]}
+                              :required-enum :enum-val1}]
+          :mapped-message {"a" {:required-string "overridden required_string"
+                                :required-quat [1.0 2.0 3.0 4.0]
+                                :required-enum :enum-val1}
+                           "b" {:required-string "overridden required_string"
+                                :required-quat [1.0 2.0 3.0 4.0]
+                                :required-enum :enum-val1}}}
          (read-map-with-defaults TestDdf$NestedRequireds "
 required_message {
   required_string: 'overridden required_string'
@@ -742,6 +932,32 @@ repeated_message {
     w: 4.0
   }
   required_enum: ENUM_VAL1
+}
+mapped_message {
+  key: 'a'
+  value {
+    required_string: 'overridden required_string'
+    required_quat {
+      x: 1.0
+      y: 2.0
+      z: 3.0
+      w: 4.0
+    }
+    required_enum: ENUM_VAL1
+  }
+}
+mapped_message {
+  key: 'b'
+  value {
+    required_string: 'overridden required_string'
+    required_quat {
+      x: 1.0
+      y: 2.0
+      z: 3.0
+      w: 4.0
+    }
+    required_enum: ENUM_VAL1
+  }
 }")))
   (is (= {:optional-resource "/overridden optional_resource"}
          (read-map-with-defaults TestDdf$ResourceFields "optional_resource: '/overridden optional_resource'"))))
@@ -765,8 +981,20 @@ repeated_message {
                               :optional-quat [0.0 0.0 0.0 1.0]
                               :optional-enum :enum-val1
                               :optional-bool true}]
+          :mapped-message {"a" {:optional-string "default"
+                                :optional-int 10
+                                :optional-quat [0.0 0.0 0.0 1.0]
+                                :optional-enum :enum-val1
+                                :optional-bool true}
+                           "b" {:optional-string "default"
+                                :optional-int 10
+                                :optional-quat [0.0 0.0 0.0 1.0]
+                                :optional-enum :enum-val1
+                                :optional-bool true}}
           :repeated-int [0
-                         0]}
+                         0]
+          :mapped-int {"a" 0
+                       "b" 0}}
          (read-map-with-defaults TestDdf$NestedDefaults "
 required_string: ''
 optional_with_default: 'default'
@@ -797,8 +1025,36 @@ repeated_message {
   optional_enum: ENUM_VAL1
   optional_bool: true
 }
+mapped_message {
+  key: 'a'
+  value {
+  }
+}
+mapped_message {
+  key: 'b'
+  value {
+    optional_string: 'default'
+    optional_int: 10
+    optional_quat {
+      x: 0.0
+      y: 0.0
+      z: 0.0
+      w: 1.0
+    }
+    optional_enum: ENUM_VAL1
+    optional_bool: true
+  }
+}
 repeated_int: 0
-repeated_int: 0")))
+repeated_int: 0
+mapped_int {
+  key: 'a'
+  value: 0
+}
+mapped_int {
+  key: 'b'
+  value: 0
+}")))
   (is (= {:optional-message {:required-string ""
                              :required-quat [0.0 0.0 0.0 1.0]
                              :required-enum :enum-val0}
@@ -810,7 +1066,13 @@ repeated_int: 0")))
                               :required-enum :enum-val0}
                              {:required-string ""
                               :required-quat [0.0 0.0 0.0 1.0]
-                              :required-enum :enum-val0}]}
+                              :required-enum :enum-val0}]
+          :mapped-message {"a" {:required-string ""
+                                :required-quat [0.0 0.0 0.0 1.0]
+                                :required-enum :enum-val0}
+                           "b" {:required-string ""
+                                :required-quat [0.0 0.0 0.0 1.0]
+                                :required-enum :enum-val0}}}
          (read-map-with-defaults TestDdf$NestedRequireds "
 required_message {
   required_string: ''
@@ -851,6 +1113,32 @@ repeated_message {
     w: 1.0
   }
   required_enum: ENUM_VAL0
+}
+mapped_message {
+  key: 'a'
+  value {
+    required_string: ''
+    required_quat {
+      x: 0.0
+      y: 0.0
+      z: 0.0
+      w: 1.0
+    }
+    required_enum: ENUM_VAL0
+  }
+}
+mapped_message {
+  key: 'b'
+  value {
+    required_string: ''
+    required_quat {
+      x: 0.0
+      y: 0.0
+      z: 0.0
+      w: 1.0
+    }
+    required_enum: ENUM_VAL0
+  }
 }")))
   (is (= {:optional-resource "/default"}
          (read-map-with-defaults TestDdf$ResourceFields "optional_resource: '/default'"))))
@@ -895,8 +1183,16 @@ repeated_message {
                               :optional-quat [1.0 2.0 3.0 4.0]
                               :optional-enum :enum-val0
                               :optional-bool false}]
+          :mapped-message {"a" {}
+                           "b" {:optional-string "overridden optional_string"
+                                :optional-int 11
+                                :optional-quat [1.0 2.0 3.0 4.0]
+                                :optional-enum :enum-val0
+                                :optional-bool false}}
           :repeated-int [0
-                         1]}
+                         1]
+          :mapped-int {"a" 0
+                       "b" 1}}
          (protobuf/make-map-without-defaults TestDdf$NestedDefaults
            :required-string "overridden required_string"
            :optional-with-default "overridden with_default"
@@ -914,8 +1210,17 @@ repeated_message {
                                 :optional-quat [1.0 2.0 3.0 4.0]
                                 :optional-enum :enum-val0
                                 :optional-bool false)]
+           :mapped-message {"a" (protobuf/make-map-without-defaults TestDdf$NestedDefaultsSubMsg)
+                            "b" (protobuf/make-map-without-defaults TestDdf$NestedDefaultsSubMsg
+                                  :optional-string "overridden optional_string"
+                                  :optional-int 11
+                                  :optional-quat [1.0 2.0 3.0 4.0]
+                                  :optional-enum :enum-val0
+                                  :optional-bool false)}
            :repeated-int [0
-                          1])))
+                          1]
+           :mapped-int {"a" 0
+                        "b" 1})))
   (is (= {:optional-message {:required-string "overridden required_string"
                              :required-quat [1.0 2.0 3.0 4.0]
                              :required-enum :enum-val1}
@@ -925,7 +1230,11 @@ repeated_message {
           :repeated-message [{}
                              {:required-string "overridden required_string"
                               :required-quat [1.0 2.0 3.0 4.0]
-                              :required-enum :enum-val1}]}
+                              :required-enum :enum-val1}]
+          :mapped-message {"a" {}
+                           "b" {:required-string "overridden required_string"
+                                :required-quat [1.0 2.0 3.0 4.0]
+                                :required-enum :enum-val1}}}
          (protobuf/make-map-without-defaults TestDdf$NestedRequireds
            :optional-message (protobuf/make-map-without-defaults TestDdf$NestedRequiredsSubMsg
                                :required-string "overridden required_string"
@@ -939,7 +1248,12 @@ repeated_message {
                               (protobuf/make-map-without-defaults TestDdf$NestedRequiredsSubMsg
                                 :required-string "overridden required_string"
                                 :required-quat [1.0 2.0 3.0 4.0]
-                                :required-enum :enum-val1)])))
+                                :required-enum :enum-val1)]
+           :mapped-message {"a" (protobuf/make-map-without-defaults TestDdf$NestedRequiredsSubMsg)
+                            "b" (protobuf/make-map-without-defaults TestDdf$NestedRequiredsSubMsg
+                                  :required-string "overridden required_string"
+                                  :required-quat [1.0 2.0 3.0 4.0]
+                                  :required-enum :enum-val1)})))
   (is (= {:optional-resource "/overridden optional_resource"}
          (protobuf/make-map-without-defaults TestDdf$ResourceFields
            :optional-resource "/overridden optional_resource"))))
@@ -948,8 +1262,12 @@ repeated_message {
   (is (= {:required-string ""
           :repeated-message [{}
                              {}]
+          :mapped-message {"a" {}
+                           "b" {}}
           :repeated-int [0
-                         0]}
+                         0]
+          :mapped-int {"a" 0
+                       "b" 0}}
          (protobuf/make-map-without-defaults TestDdf$NestedDefaults
            :required-string ""
            :optional-with-default "default"
@@ -967,8 +1285,17 @@ repeated_message {
                                 :optional-quat [0.0 0.0 0.0 1.0]
                                 :optional-enum :enum-val1
                                 :optional-bool true)]
+           :mapped-message {"a" (protobuf/make-map-without-defaults TestDdf$NestedDefaultsSubMsg)
+                            "b" (protobuf/make-map-without-defaults TestDdf$NestedDefaultsSubMsg
+                                  :optional-string "default"
+                                  :optional-int 10
+                                  :optional-quat [0.0 0.0 0.0 1.0]
+                                  :optional-enum :enum-val1
+                                  :optional-bool true)}
            :repeated-int [0
-                          0])))
+                          0]
+           :mapped-int {"a" 0
+                        "b" 0})))
   (is (= {:optional-message {:required-string ""
                              :required-quat [0.0 0.0 0.0 1.0]
                              :required-enum :enum-val0}
@@ -978,7 +1305,11 @@ repeated_message {
           :repeated-message [{}
                              {:required-string ""
                               :required-quat [0.0 0.0 0.0 1.0]
-                              :required-enum :enum-val0}]}
+                              :required-enum :enum-val0}]
+          :mapped-message {"a" {}
+                           "b" {:required-string ""
+                                :required-quat [0.0 0.0 0.0 1.0]
+                                :required-enum :enum-val0}}}
          (protobuf/make-map-without-defaults TestDdf$NestedRequireds
            :optional-message (protobuf/make-map-without-defaults TestDdf$NestedRequiredsSubMsg
                                :required-string ""
@@ -992,7 +1323,12 @@ repeated_message {
                               (protobuf/make-map-without-defaults TestDdf$NestedRequiredsSubMsg
                                 :required-string ""
                                 :required-quat [0.0 0.0 0.0 1.0]
-                                :required-enum :enum-val0)])))
+                                :required-enum :enum-val0)]
+           :mapped-message {"a" (protobuf/make-map-without-defaults TestDdf$NestedRequiredsSubMsg)
+                            "b" (protobuf/make-map-without-defaults TestDdf$NestedRequiredsSubMsg
+                                  :required-string ""
+                                  :required-quat [0.0 0.0 0.0 1.0]
+                                  :required-enum :enum-val0)})))
   (is (= {:optional-resource "/default"}
          (protobuf/make-map-without-defaults TestDdf$ResourceFields
            :optional-resource "/default"))))
@@ -1051,8 +1387,16 @@ required_message {
                               :optional-quat [1.0 2.0 3.0 4.0]
                               :optional-enum :enum-val0
                               :optional-bool false}]
+          :mapped-message {"a" {}
+                           "b" {:optional-string "overridden optional_string"
+                                :optional-int 11
+                                :optional-quat [1.0 2.0 3.0 4.0]
+                                :optional-enum :enum-val0
+                                :optional-bool false}}
           :repeated-int [0
-                         1]}
+                         1]
+          :mapped-int {"a" 0
+                       "b" 1}}
          (read-map-without-defaults TestDdf$NestedDefaults "
 required_string: 'overridden required_string'
 optional_with_default: 'overridden with_default'
@@ -1083,8 +1427,36 @@ repeated_message {
   optional_enum: ENUM_VAL0
   optional_bool: false
 }
+mapped_value {
+  key: 'a'
+  value {
+  }
+}
+mapped_value {
+  key: 'b'
+  value {
+    optional_string: 'overridden optional_string'
+    optional_int: 11
+    optional_quat {
+      x: 1.0
+      y: 2.0
+      z: 3.0
+      w: 4.0
+    }
+    optional_enum: ENUM_VAL0
+    optional_bool: false
+  }
+}
 repeated_int: 0
-repeated_int: 1")))
+repeated_int: 1
+mapped_int {
+  key: 'a'
+  value: 0
+}
+mapped_int {
+  key: 'b'
+  value: 1
+}")))
   (is (= {:optional-message {:required-string "overridden required_string"
                              :required-quat [1.0 2.0 3.0 4.0]
                              :required-enum :enum-val1}
@@ -1096,7 +1468,13 @@ repeated_int: 1")))
                               :required-enum :enum-val1}
                              {:required-string "overridden required_string"
                               :required-quat [1.0 2.0 3.0 4.0]
-                              :required-enum :enum-val1}]}
+                              :required-enum :enum-val1}]
+          :mapped-message {"a" {:required-string "overridden required_string"
+                                :required-quat [1.0 2.0 3.0 4.0]
+                                :required-enum :enum-val1}
+                           "b" {:required-string "overridden required_string"
+                                :required-quat [1.0 2.0 3.0 4.0]
+                                :required-enum :enum-val1}}}
          (read-map-without-defaults TestDdf$NestedRequireds "
 required_message {
   required_string: 'overridden required_string'
@@ -1137,6 +1515,32 @@ repeated_message {
     w: 4.0
   }
   required_enum: ENUM_VAL1
+}
+mapped_message {
+  key: 'a'
+  value {
+    required_string: 'overridden required_string'
+    required_quat {
+      x: 1.0
+      y: 2.0
+      z: 3.0
+      w: 4.0
+    }
+    required_enum: ENUM_VAL1
+  }
+}
+mapped_message {
+  key: 'b'
+  value {
+    required_string: 'overridden required_string'
+    required_quat {
+      x: 1.0
+      y: 2.0
+      z: 3.0
+      w: 4.0
+    }
+    required_enum: ENUM_VAL1
+  }
 }")))
   (is (= {:optional-resource "/overridden optional_resource"}
          (read-map-without-defaults TestDdf$ResourceFields "optional_resource: '/overridden optional_resource'"))))
@@ -1145,8 +1549,12 @@ repeated_message {
   (is (= {:required-string ""
           :repeated-message [{}
                              {}]
+          :mapped-message {"a" {}
+                           "b" {}}
           :repeated-int [0
-                         0]}
+                         0]
+          :mapped-int {"a" 0
+                       "b" 0}}
          (read-map-without-defaults TestDdf$NestedDefaults "
 required_string: ''
 optional_with_default: 'default'
@@ -1177,8 +1585,36 @@ repeated_message {
   optional_enum: ENUM_VAL1
   optional_bool: true
 }
+mapped_message {
+  key: 'a'
+  value {
+  }
+}
+mapped_message {
+  key: 'b'
+  value {
+    optional_string: 'default'
+    optional_int: 10
+    optional_quat {
+      x: 0.0
+      y: 0.0
+      z: 0.0
+      w: 1.0
+    }
+    optional_enum: ENUM_VAL1
+    optional_bool: true
+  }
+}
 repeated_int: 0
-repeated_int: 0")))
+repeated_int: 0
+mapped_int {
+  key: 'a'
+  value: 0
+}
+mapped_int {
+  key: 'b'
+  value: 0
+}")))
   (is (= {:required-message {:required-string ""
                              :required-quat [0.0 0.0 0.0 1.0]
                              :required-enum :enum-val0}
@@ -1187,7 +1623,13 @@ repeated_int: 0")))
                               :required-enum :enum-val0}
                              {:required-string ""
                               :required-quat [0.0 0.0 0.0 1.0]
-                              :required-enum :enum-val0}]}
+                              :required-enum :enum-val0}]
+          :mapped-message {"a" {:required-string ""
+                                :required-quat [0.0 0.0 0.0 1.0]
+                                :required-enum :enum-val0}
+                           "b" {:required-string ""
+                                :required-quat [0.0 0.0 0.0 1.0]
+                                :required-enum :enum-val0}}}
          (read-map-without-defaults TestDdf$NestedRequireds "
 required_message {
   required_string: ''
@@ -1228,6 +1670,32 @@ repeated_message {
     w: 1.0
   }
   required_enum: ENUM_VAL0
+}
+mapped_message {
+  key: 'a'
+  value {
+    required_string: ''
+    required_quat {
+      x: 0.0
+      y: 0.0
+      z: 0.0
+      w: 1.0
+    }
+    required_enum: ENUM_VAL0
+  }
+}
+mapped_message {
+  key: 'b'
+  value {
+    required_string: ''
+    required_quat {
+      x: 0.0
+      y: 0.0
+      z: 0.0
+      w: 1.0
+    }
+    required_enum: ENUM_VAL0
+  }
 }")))
   (is (= {:optional-resource "/default"}
          (read-map-without-defaults TestDdf$ResourceFields "optional_resource: '/default'"))))

--- a/editor/test/integration/sparse_protobuf_test.clj
+++ b/editor/test/integration/sparse_protobuf_test.clj
@@ -304,40 +304,48 @@
        (class? (resource-type->pb-class resource-type))))
 
 (defn- sparse-pb-map [^Class pb-class pb-path ^long depth-limit]
-  (->> pb-class
-       (protobuf/field-infos)
-       (into {}
-             (keep
-               (fn [[field-key {:keys [default field-rule field-type-key options type]}]]
-                 (let [pb-path (conj pb-path field-key)
+  (let [required-field-defaults (protobuf/required-default-value pb-class)
+        field-infos (protobuf/field-infos pb-class)]
+    (coll/into-> field-infos {}
+      (keep
+        (fn [[field-key field-info]]
+          (let [pb-path (conj pb-path field-key)
+                field-kind (:field-kind field-info)
 
-                       [specific-value is-required]
-                       (unwrap-pb-field-value (get-in pb-field-values pb-path))
+                [specific-value is-required]
+                (unwrap-pb-field-value (get-in pb-field-values pb-path))
 
-                       value
-                       (cond
-                         (exactly? specific-value)
-                         (unwrap-exactly specific-value)
+                value
+                (cond
+                  (exactly? specific-value)
+                  (unwrap-exactly specific-value)
 
-                         (or is-required
-                             (= :required field-rule)
-                             (and (pos? depth-limit)
-                                  (not (:runtime-only options))))
-                         (cond
-                           (= :message field-type-key)
-                           (sparse-pb-map type pb-path (dec depth-limit))
+                  (or is-required
+                      (= :pb-field-kind/required field-kind)
+                      (and (pos? depth-limit)
+                           (not (:runtime-only (:options field-info)))))
+                  (cond
+                    (= :message (:value-type-kw field-info))
+                    (sparse-pb-map (:value-class field-info) pb-path (dec depth-limit))
 
-                           (some? specific-value)
-                           specific-value
+                    (some? specific-value)
+                    specific-value
 
-                           (= :required field-rule)
-                           default))]
+                    (= :pb-field-kind/required field-kind)
+                    (required-field-defaults field-key)))]
 
-                   (when (some? value)
-                     (pair field-key
-                           (case field-rule
-                             :repeated (vector value)
-                             value)))))))))
+            (when (some? value)
+              (pair field-key
+                    (case field-kind
+                      (:pb-field-kind/list)
+                      [value]
+
+                      (:pb-field-kind/map)
+                      (let [key (protobuf/field-type-default (:key-type-kw field-info))]
+                        {key value})
+
+                      (:pb-field-kind/optional :pb-field-kind/required)
+                      value)))))))))
 
 (defn- sparse-protobuf-content-by-proj-path [workspace]
   (into (sorted-map)

--- a/editor/test/integration/sparse_protobuf_test.clj
+++ b/editor/test/integration/sparse_protobuf_test.clj
@@ -304,7 +304,7 @@
        (class? (resource-type->pb-class resource-type))))
 
 (defn- sparse-pb-map [^Class pb-class pb-path ^long depth-limit]
-  (let [required-field-defaults (protobuf/required-default-value pb-class)
+  (let [required-field-defaults (protobuf/required-field-defaults pb-class)
         field-infos (protobuf/field-infos pb-class)]
     (coll/into-> field-infos {}
       (keep

--- a/editor/test/proto/test_ddf.proto
+++ b/editor/test/proto/test_ddf.proto
@@ -176,3 +176,31 @@ message ResourceDefaultedMapNested {
 message ResourceRepeatedMapNested {
     map<string, ResourceRepeated> repeateds = 1;
 }
+
+
+// -----------------------------------------------------------------------------
+// Self-referencing types
+// -----------------------------------------------------------------------------
+
+message JsonValue {
+    oneof kind {
+        JsonNull null = 1;
+        bool bool = 2;
+        double number = 3;
+        string string = 4;
+        JsonArray array = 5;
+        JsonObject object = 6;
+    }
+}
+
+enum JsonNull {
+    NULL = 0;
+}
+
+message JsonArray {
+    repeated JsonValue elements = 1;
+}
+
+message JsonObject {
+    map<string, JsonValue> members = 1;
+}

--- a/editor/test/proto/test_ddf.proto
+++ b/editor/test/proto/test_ddf.proto
@@ -55,7 +55,9 @@ message NestedDefaults {
     optional string optional_without_default = 3;
     optional NestedDefaultsSubMsg optional_message = 4;
     repeated NestedDefaultsSubMsg repeated_message = 5;
-    repeated int32 repeated_int = 6;
+    map<string, NestedDefaultsSubMsg> mapped_message = 6;
+    repeated int32 repeated_int = 7;
+    map<string, int32> mapped_int = 8;
 }
 
 message NestedRequiredsSubMsg {
@@ -68,6 +70,7 @@ message NestedRequireds {
     required NestedRequiredsSubMsg required_message = 1;
     optional NestedRequiredsSubMsg optional_message = 2;
     repeated NestedRequiredsSubMsg repeated_message = 3;
+    map<string, NestedRequiredsSubMsg> mapped_message = 4;
 }
 
 message ResourceFields {
@@ -160,4 +163,16 @@ message ResourceDefaultedRepeatedlyNested {
 
 message ResourceRepeatedRepeatedlyNested {
     repeated ResourceRepeated repeateds = 1;
+}
+
+message ResourceSimpleMapNested {
+    map<string, ResourceSimple> simples = 1;
+}
+
+message ResourceDefaultedMapNested {
+    map<string, ResourceDefaulted> defaulteds = 1;
+}
+
+message ResourceRepeatedMapNested {
+    map<string, ResourceRepeated> repeateds = 1;
 }

--- a/editor/test/proto/test_ddf.proto
+++ b/editor/test/proto/test_ddf.proto
@@ -125,6 +125,18 @@ message JavaCasingMsg {
 }
 
 // -----------------------------------------------------------------------------
+// Map fields
+// -----------------------------------------------------------------------------
+
+message MappedPrimitive {
+    map<string, double> string_to_number = 1;
+}
+
+message MappedMessage {
+    map<string, DefaultValue> string_to_message = 1;
+}
+
+// -----------------------------------------------------------------------------
 // JSON-like structure
 // -----------------------------------------------------------------------------
 
@@ -218,12 +230,37 @@ message ResourceSelfReferencingRepeated {
     optional ResourceSelfReferencingRepeated next = 2;
 }
 
-message ResourceOneof {
+message ResourceOneofSimple {
     oneof kind {
         string image = 1 [(resource) = true];
-        string defaulted_image = 2 [(resource) = true, default = "/default.png"];
-        ResourceSimple simple = 3;
-        ResourceDefaulted defaulted = 4;
-        ResourceRepeated repeated = 5;
+        JsonNull null = 2;
+    }
+}
+
+message ResourceOneofDefaulted {
+    oneof kind {
+        string image = 1 [(resource) = true, default = "/default.png"];
+        JsonNull null = 2;
+    }
+}
+
+message ResourceOneofSimpleNested {
+    oneof kind {
+        ResourceSimple simple = 1;
+        JsonNull null = 2;
+    }
+}
+
+message ResourceOneofDefaultedNested {
+    oneof kind {
+        ResourceDefaulted defaulted = 1;
+        JsonNull null = 2;
+    }
+}
+
+message ResourceOneofRepeatedNested {
+    oneof kind {
+        ResourceRepeated repeated = 1;
+        JsonNull null = 2;
     }
 }

--- a/editor/test/proto/test_ddf.proto
+++ b/editor/test/proto/test_ddf.proto
@@ -133,7 +133,7 @@ message MappedPrimitive {
 }
 
 message MappedMessage {
-    map<string, DefaultValue> string_to_message = 1;
+    map<string, SubMsg> string_to_message = 1;
 }
 
 // -----------------------------------------------------------------------------

--- a/editor/test/proto/test_ddf.proto
+++ b/editor/test/proto/test_ddf.proto
@@ -124,6 +124,32 @@ message JavaCasingMsg {
     required string javaCasing = 1;
 }
 
+// -----------------------------------------------------------------------------
+// JSON-like structure
+// -----------------------------------------------------------------------------
+
+message JsonValue {
+    oneof kind {
+        JsonNull null = 1;
+        bool bool = 2;
+        double number = 3;
+        string string = 4;
+        JsonArray array = 5;
+        JsonObject object = 6;
+    }
+}
+
+enum JsonNull {
+    NULL = 0;
+}
+
+message JsonArray {
+    repeated JsonValue elements = 1;
+}
+
+message JsonObject {
+    map<string, JsonValue> members = 1;
+}
 
 // -----------------------------------------------------------------------------
 // Resource fields
@@ -177,30 +203,27 @@ message ResourceRepeatedMapNested {
     map<string, ResourceRepeated> repeateds = 1;
 }
 
+message ResourceSelfReferencingSimple {
+    optional string image = 1 [(resource) = true];
+    optional ResourceSelfReferencingSimple next = 2;
+}
 
-// -----------------------------------------------------------------------------
-// Self-referencing types
-// -----------------------------------------------------------------------------
+message ResourceSelfReferencingDefaulted {
+    optional string image = 1 [(resource) = true, default = "/default.png"];
+    optional ResourceSelfReferencingDefaulted next = 2;
+}
 
-message JsonValue {
+message ResourceSelfReferencingRepeated {
+    repeated string images = 1 [(resource) = true];
+    optional ResourceSelfReferencingRepeated next = 2;
+}
+
+message ResourceOneof {
     oneof kind {
-        JsonNull null = 1;
-        bool bool = 2;
-        double number = 3;
-        string string = 4;
-        JsonArray array = 5;
-        JsonObject object = 6;
+        string image = 1 [(resource) = true];
+        string defaulted_image = 2 [(resource) = true, default = "/default.png"];
+        ResourceSimple simple = 3;
+        ResourceDefaulted defaulted = 4;
+        ResourceRepeated repeated = 5;
     }
-}
-
-enum JsonNull {
-    NULL = 0;
-}
-
-message JsonArray {
-    repeated JsonValue elements = 1;
-}
-
-message JsonObject {
-    map<string, JsonValue> members = 1;
 }

--- a/editor/test/util/fn_test.clj
+++ b/editor/test/util/fn_test.clj
@@ -15,7 +15,8 @@
 (ns util.fn-test
   (:require [clojure.test :refer :all]
             [util.fn :as fn])
-  (:import [clojure.lang ArityException]))
+  (:import [clojure.lang ArityException ExceptionInfo]
+           [java.util.concurrent ExecutionException]))
 
 (defn- arity-void-test-fn
   ([]))
@@ -430,6 +431,69 @@
       (is (= "2, 3, 4, 5, 6" (memoized-fn 2 3 4 5 6)))
       (is (= 3 @call-count-atom))
       (is (nil? (fn/evict-memoized! memoized-fn 1 2 3 4 5 6 7 8 9))))))
+
+;; region memoize-late-bound
+
+(declare ^:private memoize-late-bound-memoized-fn)
+
+(defn- memoize-late-bound-memoized-fn-raw [arg]
+  (case arg
+    :outer (let [inner-fn (memoize-late-bound-memoized-fn :inner)]
+             (fn outer-fn [^long depth]
+               (case depth
+                 0 (inner-fn 1)
+                 2 "outer -> inner -> outer")))
+    :inner (let [outer-fn (memoize-late-bound-memoized-fn :outer)]
+             (fn inner-fn [^long depth]
+               (case depth
+                 1 (outer-fn 2))))))
+
+;; Calling the resulting function would cause a StackOverflowError
+;; if we were using the basic memoize function.
+(def ^:private memoize-late-bound-memoized-fn (fn/memoize-late-bound {:timeout-ms 0} memoize-late-bound-memoized-fn-raw))
+
+(deftest memoize-late-bound-allows-memoized-fn-to-call-itself
+  (try
+    (let [outer (memoize-late-bound-memoized-fn :outer)]
+      (is (= "outer -> inner -> outer" (outer 0))))
+    (finally
+      (ns-unmap *ns* 'memoize-late-bound-memoized-fn))))
+
+(deftest memoize-late-bound-retries-if-higher-order-fn-throws-test
+  (let [attempt-count-atom (atom 0)
+
+        memoized-fn
+        (fn/memoize-late-bound
+          {:timeout-ms 0}
+          (fn higher-order-fn [arg]
+            (if (= 1 (swap! attempt-count-atom inc))
+              (throw (ex-info "Thrown from higher-order-fn." {:arg arg}))
+              (fn lower-order-fn []
+                arg))))]
+
+    (is (thrown-with-msg? ExceptionInfo #"Thrown from higher-order-fn." (memoized-fn :arg)))
+    (let [lower-order-fn (memoized-fn :arg)]
+      (is (= :arg (lower-order-fn))))
+    (is (= 2 @attempt-count-atom))))
+
+(deftest memoize-late-bound-delivers-throwing-lower-order-fn-if-higher-order-fn-throws-test
+  (let [memoized-fn
+        (fn/memoize-late-bound
+          {:timeout-ms 100}
+          (fn higher-order-fn [arg]
+            (Thread/sleep 20)
+            (throw (ex-info "Thrown from higher-order-fn." {:arg arg}))))
+
+        concurrent-future
+        (future
+          (Thread/sleep 10)
+          (let [lower-order-fn (memoized-fn :arg)]
+            (lower-order-fn)))]
+
+    (is (thrown-with-msg? ExceptionInfo #"Thrown from higher-order-fn." (memoized-fn :arg)))
+    (is (thrown-with-msg? ExecutionException #"An exception was thrown when invoking the higher-order-fn to produce this lower-order-fn." (deref concurrent-future)))))
+
+;; endregion
 
 (def ^:private defined-constant :default)
 (defn- defined-function [_arg])


### PR DESCRIPTION
This PR adds support for missing Protobuf features to the editor. We now support `map<TKey, TValue>` fields and self-referencing message types. Both of these are required for Json-like messages where objects and arrays of objects can be nested inside each other. It also fixes a few uncovered corner cases around `oneof` fields and adds a whole host of tests.

Required for #11724.

### Technical changes
* Protobuf `field-info` no longer specifies a `:field-rule` as `:required`, `:optional`, or `:repeated`. Instead, a we have a `:field-kind` that is considered to be either `required`, `optional`, `list`, or `map`. This was done to distinguish between `list` and `map` fields, which need to be handled differently, but are both `repeated` fields internally. The new values are namespaced keywords under `:pb-field-kind/*`.
* The old method of extracting resource field path has been removed. Previously you would obtain a `resource-field-path-fn` from a Protobuf `Message` subclass that could apply to Clojure map representations of those messages. This is no longer possible when we have self-referencing types. Instead, you now supply the `pb-class` and Clojure map directly to the `protobuf/resource-field-value-paths` function.
* `protobuf/default-value` was renamed to `optional-field-defaults` for clarity.
* `protobuf/required-default-value` was renamed to `required-field-defaults` for clarity.
* `protobuf/default-message` was made private. Callers should call either `optional-field-defaults` or `required-field-defaults`, depending on their needs.
* Added `memoize-late-bound` function to `fn` module.