### PR TITLE
Add `"text"` property to textual resources in editor scripts

### DIFF
--- a/editor/AGENTS.md
+++ b/editor/AGENTS.md
@@ -2,8 +2,7 @@
 
 ## Coding Style
 
-Don't introduce let bindings unless the variable will be used in many places.
-If a let binding may be used inside multiple places, but otherwise it's nilable in other branches, prefer duplicating code instead of introducing bindings.
+Don't use defensive coding.
 Keep requires sorted.
 Use variables and keywords with "?" suffix only to denote predicate functions, never boolean values.
 Never use lazy sequences, instead use transducers. See src/clj/util/coll.clj for alternatives of core clojure functions that use reduce instead of seq. See src/clj/util/eduction.clj for using eductions instead of unrealized sequences. 

--- a/editor/src/clj/editor/editor_extensions/graph.clj
+++ b/editor/src/clj/editor/editor_extensions/graph.clj
@@ -328,23 +328,24 @@
    (ext-property-getter node-type-kw getter-fn)
    (when lister-fn (ext-property-lister node-type-kw lister-fn))))
 
-(register-property-getter!
-  :editor.code.resource/CodeEditorResourceNode
-  (fn CodeEditorResourceNode-getter [node-id property evaluation-context]
-    (case property
-      "text" #(coll/join-to-string \newline (g/node-value node-id :lines evaluation-context))
-      nil))
-  (fn CodeEditorResourceNode-lister [_ _]
-    ["text"]))
+(defn- textual-resource-node? [node-id evaluation-context]
+  (let [resource (g/node-value node-id :resource evaluation-context)]
+    (and (some? resource)
+         (-> evaluation-context
+             :basis
+             (resource/lookup-resource-type (resource/workspace resource) resource)
+             :textual?))))
 
 (register-property-getter!
   :editor.resource/ResourceNode
   (fn ResourceNode-getter [node-id property evaluation-context]
     (case property
+      "text" (when (textual-resource-node? node-id evaluation-context)
+               #(coll/join-to-string \newline (g/node-value node-id :lines evaluation-context)))
       "path" #(resource/resource->proj-path (g/node-value node-id :resource evaluation-context))
       nil))
-  (fn ResourceNode-lister [_ _]
-    ["path"]))
+  (fn ResourceNode-lister [node-id evaluation-context]
+    (cond-> ["path"] (textual-resource-node? node-id evaluation-context) (conj "text"))))
 
 (register-property-getter!
   :editor.tile-source/TileSourceNode

--- a/editor/test/integration/editor_extensions_test.clj
+++ b/editor/test/integration/editor_extensions_test.clj
@@ -1269,6 +1269,16 @@ openapi route has 200 => true
                        (when-not (properties/read-only? p)
                          (is (some? (graph/ext-lua-value-setter node-id ext-key rt project ec))))))))))))
 
+(deftest textual-resource-text-property-test
+  (test-util/with-loaded-project "test/resources/editor_extensions/property_availability_project"
+    (g/with-auto-evaluation-context ec
+      (let [resource-node-id (project/get-resource-node project "/input/game.input_binding" ec)
+            text-property-getter (graph/ext-value-getter resource-node-id "text" project ec)
+            text (text-property-getter)]
+        (is (some #{"text"} (graph/ext-readable-properties resource-node-id project ec)))
+        (is (string/includes? text "mouse_trigger"))
+        (is (string/includes? text "action: \"touch\""))))))
+
 (def ^:private expected-tilemap-test-output
   "new => {
 }
@@ -2229,6 +2239,11 @@ test.tilesource targeted checks:
   contains animation nodes = ok
   animation has id = ok
   animation is readable = ok
+test.input_binding targeted checks:
+  sorted_and_unique = ok
+  contains path = ok
+  contains text = ok
+  all listed are readable = ok
 test.editor_script targeted checks:
   sorted_and_unique = ok
   contains path = ok

--- a/editor/test/resources/editor_extensions/properties_project/test.editor_script
+++ b/editor/test/resources/editor_extensions/properties_project/test.editor_script
@@ -195,6 +195,12 @@ local function print_targeted_editor_script_resource_checks()
                                {"path", "text"})
 end
 
+local function print_targeted_test_input_binding_checks()
+    print_targeted_node_checks("test.input_binding targeted checks:",
+                               "/test.input_binding",
+                               {"path", "text"})
+end
+
 function M.get_commands()
     return {
         editor.command({
@@ -209,6 +215,7 @@ function M.get_commands()
                 print_targeted_test_particlefx_checks()
                 print_targeted_test_tilemap_checks()
                 print_targeted_test_tilesource_checks()
+                print_targeted_test_input_binding_checks()
                 print_targeted_editor_script_resource_checks()
             end
         })

--- a/editor/test/resources/editor_extensions/properties_project/test.input_binding
+++ b/editor/test/resources/editor_extensions/properties_project/test.input_binding
@@ -1,0 +1,4 @@
+mouse_trigger {
+  input: MOUSE_BUTTON_1
+  action: "touch"
+}


### PR DESCRIPTION
We added `"text"` properties to textual resources besides code resources, e.g.:
```lua
print(editor.get("/builtins/render/default.render", "text"))
-- script: "/builtins/render/default.render_script"
```

Fix #11969