### PR TITLE
Avoid surprisingly expensive file system access during project read

### DIFF
--- a/editor/src/clj/editor/defold_project.clj
+++ b/editor/src/clj/editor/defold_project.clj
@@ -168,6 +168,7 @@
           ;; FileNotFoundException being thrown by the read attempt. Instead, we
           ;; explicitly check that the file exists, which will follow symlinks.
           (when (and (resource/stateful-resource-type? resource-type)
+                     (resource/symlink? resource)
                      (not (resource/exists? resource)))
             (make-file-not-found-error node-id resource)))
 

--- a/editor/src/clj/util/path.clj
+++ b/editor/src/clj/util/path.clj
@@ -144,7 +144,8 @@
   "Returns an absolute java.nio.file.Path whose casing matches an existing file
   system entry. Throws an IOException if there was no matching entry in the file
   system. Contrary to the `real` function, `actual-cased` does not resolve
-  symbolic links in the returned Path."
+  symbolic links in the returned Path. Beware that this operation can be
+  surprisingly slow on certain file systems."
   (^Path [x]
    (.toRealPath (to-path x) no-follow-links-link-options))
   (^Path [x & xs]
@@ -153,7 +154,8 @@
 (defn real
   "Returns the canonical, real path to an existing file system entry. Throws an
   IOException if there was no matching entry in the file system. Follows
-  symbolic links and queries their target."
+  symbolic links and queries their target. Beware that this operation can be
+  surprisingly slow on certain file systems."
   (^Path [x]
    (.toRealPath (to-path x) follow-links-link-options))
   (^Path [x & xs]


### PR DESCRIPTION
Avoid calling `Path.toRealPath` on stateless resources when reading project data. This method appears to be surprisingly slow on certain file systems. We now only call this method for symlinks to stateless resources, where the existence of the file is important to determine at read-time.

This change resulted in a 24% project load time improvement in the large project we were testing in, but it will vary depending on the project.