### PR TITLE
Fix `gui.set_screen_position()` when Adjust Reference is Disabled

### DIFF
--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -4387,6 +4387,18 @@ namespace dmGui
     {
         Matrix4 parent_m;
 
+        if (scene->m_AdjustReference == ADJUST_REFERENCE_DISABLED)
+        {
+            if (parent_node == 0x0)
+            {
+                return screen_position;
+            }
+
+            CalculateNodeTransform(scene, parent_node, CalculateNodeTransformFlags(), parent_m);
+            Vector4 local_position = inverse(parent_m) * Vector4(screen_position, 1.0f);
+            return local_position.getXYZ();
+        }
+
         Vector4 reference_scale;
         Vector4 adjust_scale;
         Vector4 offset(0.0f);

--- a/engine/gui/src/test/test_gui.cpp
+++ b/engine/gui/src/test/test_gui.cpp
@@ -5506,6 +5506,56 @@ TEST_F(dmGuiTest, SetGetScreenPositionSafeArea)
     ASSERT_NEAR(local_after.getY(), local_from_after.getY(), EPSILON);
 }
 
+TEST_F(dmGuiTest, SetGetScreenPositionAdjustDisabledRoot)
+{
+    dmGui::SetPhysicalResolution(m_Context, 200, 100);
+    dmGui::SetDefaultResolution(m_Context, 100, 50);
+    dmGui::SetSceneResolution(m_Scene, 100, 50);
+    dmGui::SetSceneAdjustReference(m_Scene, dmGui::ADJUST_REFERENCE_DISABLED);
+
+    dmGui::HNode root = dmGui::NewNode(m_Scene, Point3(20, 15, 0), Vector3(20, 20, 0), dmGui::NODE_TYPE_BOX, 0);
+
+    Vector4 before_set = _GET_NODE_SCENE_POSITION(m_Scene, root);
+    Point3 local_before = dmGui::GetNodePosition(m_Scene, root);
+    Point3 local_from_screen = dmGui::ScreenToLocalPosition(m_Scene, root, Point3(before_set.getXYZ()));
+    ASSERT_NEAR(local_before.getX(), local_from_screen.getX(), EPSILON);
+    ASSERT_NEAR(local_before.getY(), local_from_screen.getY(), EPSILON);
+
+    Point3 target_screen(before_set.getX() + 13.0f, before_set.getY() + 9.0f, 0.0f);
+    dmGui::SetScreenPosition(m_Scene, root, target_screen);
+
+    Vector4 after_set = _GET_NODE_SCENE_POSITION(m_Scene, root);
+    ASSERT_NEAR(target_screen.getX(), after_set.getX(), EPSILON);
+    ASSERT_NEAR(target_screen.getY(), after_set.getY(), EPSILON);
+}
+
+TEST_F(dmGuiTest, SetGetScreenPositionAdjustDisabledScaledParent)
+{
+    dmGui::SetPhysicalResolution(m_Context, 100, 100);
+    dmGui::SetDefaultResolution(m_Context, 100, 100);
+    dmGui::SetSceneResolution(m_Scene, 100, 100);
+    dmGui::SetSceneAdjustReference(m_Scene, dmGui::ADJUST_REFERENCE_DISABLED);
+
+    dmGui::HNode parent = dmGui::NewNode(m_Scene, Point3(30, 20, 0), Vector3(40, 40, 0), dmGui::NODE_TYPE_BOX, 0);
+    dmGui::SetNodeProperty(m_Scene, parent, dmGui::PROPERTY_SCALE, Vector4(2.0f, 0.5f, 1.0f, 1.0f));
+
+    dmGui::HNode child = dmGui::NewNode(m_Scene, Point3(10, 8, 0), Vector3(10, 10, 0), dmGui::NODE_TYPE_BOX, 0);
+    dmGui::SetNodeParent(m_Scene, child, parent, false);
+
+    Vector4 before_set = _GET_NODE_SCENE_POSITION(m_Scene, child);
+    Point3 target_screen(before_set.getX() + 14.0f, before_set.getY() - 6.0f, 0.0f);
+    dmGui::SetScreenPosition(m_Scene, child, target_screen);
+
+    Vector4 after_set = _GET_NODE_SCENE_POSITION(m_Scene, child);
+    ASSERT_NEAR(target_screen.getX(), after_set.getX(), EPSILON);
+    ASSERT_NEAR(target_screen.getY(), after_set.getY(), EPSILON);
+
+    Point3 local_after = dmGui::GetNodePosition(m_Scene, child);
+    Point3 local_from_after = dmGui::ScreenToLocalPosition(m_Scene, child, Point3(after_set.getXYZ()));
+    ASSERT_NEAR(local_after.getX(), local_from_after.getX(), EPSILON);
+    ASSERT_NEAR(local_after.getY(), local_from_after.getY(), EPSILON);
+}
+
 TEST_F(dmGuiTest, ZeroMaxDynamicTextures)
 {
     dmGui::NewSceneParams params;


### PR DESCRIPTION
Fixed an issue where `gui.set_screen_position()` did not work correctly for root nodes when `Adjust Reference` was set to Disabled in a GUI component.

Fix https://github.com/defold/defold/issues/11953