### PR TITLE
Added missing html5.performance_timeline_enabled option to game.project

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
@@ -939,6 +939,10 @@ transparent_graphics_context.type = bool
 transparent_graphics_context.default = 0
 transparent_graphics_context.help = set to true if you want graphics context has transparent backdrop
 
+performance_timeline_enabled.type = bool
+performance_timeline_enabled.help = enable profiling capabilities in Chrome Developer Tools
+performance_timeline_enabled.default = 0
+
 [particle_fx]
 help = Particle FX related settings
 group = Components

--- a/editor/resources/localization/en.editor_localization
+++ b/editor/resources/localization/en.editor_localization
@@ -1650,6 +1650,8 @@ form.label.project.html5.retry_time = Retry Time
 form.help.project.html5.retry_time = Pause in seconds before retrying file downloads after an error
 form.label.project.html5.transparent_graphics_context = Transparent Context
 form.help.project.html5.transparent_graphics_context = Make the graphics context backdrop transparent
+form.label.project.html5.performance_timeline_enabled = Performance API
+form.help.project.html5.performance_timeline_enabled = Enable profiling capabilities in Chrome Developer Tools
 
 form.label.project.ios = iOS
 form.help.project.ios = iOS related settings

--- a/editor/test/resources/save_data_project/game.project
+++ b/editor/test/resources/save_data_project/game.project
@@ -96,6 +96,7 @@ scale_mode = no_scale
 retry_count = 11
 retry_time = 1.5
 transparent_graphics_context = 1
+performance_timeline_enabled = 1
 
 [ios]
 app_icon_76x76 = /referenced/images/diamond.png


### PR DESCRIPTION
This change adds the `html5.performance_timeline_enabled` option from https://github.com/defold/defold/pull/10980 to game.project.