### PR TITLE
Expose engine time to shaders

### DIFF
--- a/editor/src/clj/editor/material.clj
+++ b/editor/src/clj/editor/material.clj
@@ -164,6 +164,7 @@
                                     (.setElement 1 0 y)
                                     (.setElement 2 0 z)
                                     (.setElement 3 0 w)))
+    :constant-type-time (Vector4d. 0.0 0.0 0.0 0.0)
     :constant-type-viewproj :view-proj
     :constant-type-world :world
     :constant-type-texture :texture

--- a/editor/src/clj/editor/render_program_utils.clj
+++ b/editor/src/clj/editor/render_program_utils.clj
@@ -99,6 +99,7 @@
     :constant-type-normal false
     :constant-type-worldview false
     :constant-type-worldviewproj false
+    :constant-type-time false
     :constant-type-user-matrix4 true))
 
 (defn sanitize-constant [constant]

--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -2042,9 +2042,12 @@ bail:
                 dmSound::Update();
 
                 // Don't render while iconified
-                if (!dmGraphics::GetWindowStateParam(engine->m_GraphicsContext, WINDOW_STATE_ICONIFIED)
-                    && do_render)
+                if (!dmGraphics::GetWindowStateParam(engine->m_GraphicsContext, WINDOW_STATE_ICONIFIED) && do_render)
                 {
+                    // Update renderer with current time since engine start and frame delta-time.
+                    // Use the same dt that is passed into script updates and the accumulated engine time.
+                    dmRender::SetFrameTime(engine->m_RenderContext, engine->m_Stats.m_TotalTime + dt, dt);
+
                     // Call pre render functions for extensions, if available.
                     // We do it here before we render rest of the frame
                     // if any extension wants to render on under of the game.

--- a/engine/render/proto/render/material_ddf.proto
+++ b/engine/render/proto/render/material_ddf.proto
@@ -22,6 +22,7 @@ message MaterialDesc
         CONSTANT_TYPE_WORLDVIEW = 7;
         CONSTANT_TYPE_WORLDVIEWPROJ = 8;
         CONSTANT_TYPE_USER_MATRIX4 = 9;
+        CONSTANT_TYPE_TIME = 10;
     }
 
     message Constant

--- a/engine/render/src/render/program_utils.cpp
+++ b/engine/render/src/render/program_utils.cpp
@@ -422,6 +422,12 @@ namespace dmRender
                 }
                 break;
             }
+            case dmRenderDDF::MaterialDesc::CONSTANT_TYPE_TIME:
+            {
+                dmVMath::Vector4 time(render_context->m_Time, render_context->m_Dt, 0.0f, 0.0f);
+                dmGraphics::SetConstantV4(graphics_context, &time, 1, location);
+                break;
+            }
         }
     }
 

--- a/engine/render/src/render/render.cpp
+++ b/engine/render/src/render/render.cpp
@@ -128,6 +128,8 @@ namespace dmRender
         context->m_View = Matrix4::identity();
         context->m_Projection = Matrix4::identity();
         context->m_ViewProj = context->m_Projection * context->m_View;
+        context->m_Time = 0.0f;
+        context->m_Dt = 0.0f;
 
         context->m_ScriptContext = params.m_ScriptContext;
         InitializeRenderScriptContext(context->m_RenderScriptContext, graphics_context, params.m_ScriptContext, params.m_CommandBufferSize);
@@ -345,6 +347,12 @@ namespace dmRender
     {
         render_context->m_Projection = projection;
         render_context->m_ViewProj = projection * render_context->m_View;
+    }
+
+    void SetFrameTime(HRenderContext render_context, float time, float dt)
+    {
+        render_context->m_Time = time;
+        render_context->m_Dt = dt;
     }
 
     Result AddToRender(HRenderContext context, RenderObject* ro)

--- a/engine/render/src/render/render.h
+++ b/engine/render/src/render/render.h
@@ -214,6 +214,9 @@ namespace dmRender
     void SetViewMatrix(HRenderContext render_context, const dmVMath::Matrix4& view);
     void SetProjectionMatrix(HRenderContext render_context, const dmVMath::Matrix4& projection);
 
+    // Set current frame time and delta-time (in seconds) used for built-in material constants.
+    void SetFrameTime(HRenderContext render_context, float time, float dt);
+
     HMaterial GetContextMaterial(HRenderContext render_context);
 
     Result ClearRenderObjects(HRenderContext context);

--- a/engine/render/src/render/render_private.h
+++ b/engine/render/src/render/render_private.h
@@ -296,6 +296,8 @@ namespace dmRender
         Matrix4                     m_View;
         Matrix4                     m_Projection;
         Matrix4                     m_ViewProj;
+        float                       m_Time;
+        float                       m_Dt;
         dmGraphics::HContext        m_GraphicsContext;
         HMaterial                   m_Material;
         HComputeProgram             m_ComputeProgram;

--- a/engine/render/src/test/test_render.cpp
+++ b/engine/render/src/test/test_render.cpp
@@ -1836,7 +1836,72 @@ TEST(Constants, Constant)
     ASSERT_EQ(dmRenderDDF::MaterialDesc::CONSTANT_TYPE_NORMAL, dmRender::GetConstantType(constant));
 
     ////////////////////////////////////////////////////////////
+    dmRender::SetConstantType(constant, dmRenderDDF::MaterialDesc::CONSTANT_TYPE_TIME);
+    ASSERT_EQ(dmRenderDDF::MaterialDesc::CONSTANT_TYPE_TIME, dmRender::GetConstantType(constant));
+
+    ////////////////////////////////////////////////////////////
+    dmRender::SetConstantType(constant, dmRenderDDF::MaterialDesc::CONSTANT_TYPE_TIME);
+    ASSERT_EQ(dmRenderDDF::MaterialDesc::CONSTANT_TYPE_TIME, dmRender::GetConstantType(constant));
+
+    ////////////////////////////////////////////////////////////
     dmRender::DeleteConstant(constant);
+}
+
+TEST_F(dmRenderTest, ConstantTypeTimeSetsTimeAndDt)
+{
+    // Build a simple shader with a single vec4 uniform "time" backed by a uniform buffer.
+    dmGraphics::ShaderDescBuilder shader_desc_builder;
+    shader_desc_builder.AddTypeMember("time", dmGraphics::ShaderDesc::SHADER_TYPE_VEC4);
+    shader_desc_builder.AddUniformBuffer("time", 0, 0, dmGraphics::GetShaderTypeSize(dmGraphics::ShaderDesc::SHADER_TYPE_VEC4));
+
+    const char* vertex_data   = "";
+    const char* fragment_data = "";
+    shader_desc_builder.AddShader(dmGraphics::ShaderDesc::SHADER_TYPE_VERTEX, dmGraphics::ShaderDesc::LANGUAGE_GLSL_SM330, vertex_data, (uint32_t) strlen(vertex_data));
+    shader_desc_builder.AddShader(dmGraphics::ShaderDesc::SHADER_TYPE_FRAGMENT, dmGraphics::ShaderDesc::LANGUAGE_GLSL_SM330, fragment_data, (uint32_t) strlen(fragment_data));
+
+    dmGraphics::ShaderDesc* shader = shader_desc_builder.Get();
+    dmGraphics::HProgram program = dmGraphics::NewProgram(m_GraphicsContext, shader, 0, 0);
+
+    const dmGraphics::Uniform* time_uniform = dmGraphics::GetUniform(program, dmHashString64("time"));
+    ASSERT_NE(dmGraphics::INVALID_UNIFORM_LOCATION, time_uniform->m_Location);
+
+    dmGraphics::NullProgram* null_program = (dmGraphics::NullProgram*) program;
+
+    uint32_t set           = UNIFORM_LOCATION_GET_OP0(time_uniform->m_Location);
+    uint32_t binding       = UNIFORM_LOCATION_GET_OP1(time_uniform->m_Location);
+    uint32_t buffer_offset = UNIFORM_LOCATION_GET_OP2(time_uniform->m_Location);
+
+    dmGraphics::ProgramResourceBinding& pgm_res = null_program->m_BaseProgram.m_ResourceBindings[set][binding];
+    uint32_t uniform_offset = pgm_res.m_UniformBufferOffset + buffer_offset;
+
+    // Set frame time values on the render context.
+    float time = 123.0f;
+    float dt   = 1.0f / 60.0f;
+    dmRender::SetFrameTime(m_Context, time, dt);
+
+    // Enable the program so constants can be written to its uniform buffer.
+    dmGraphics::EnableProgram(m_GraphicsContext, program);
+
+    dmVMath::Matrix4 identity = dmVMath::Matrix4::identity();
+    dmRender::SetProgramConstant(m_Context,
+                                 m_GraphicsContext,
+                                 identity,
+                                 identity,
+                                 dmGraphics::ShaderDesc::LANGUAGE_GLSL_SM330,
+                                 dmRenderDDF::MaterialDesc::CONSTANT_TYPE_TIME,
+                                 program,
+                                 time_uniform->m_Location,
+                                 0);
+
+    // Verify that the written uniform data matches (time, dt, 0, 0).
+    float* written = (float*) (null_program->m_UniformData + uniform_offset);
+    ASSERT_NEAR(time, written[0], EPSILON);
+    ASSERT_NEAR(dt,   written[1], EPSILON);
+    ASSERT_NEAR(0.0f, written[2], EPSILON);
+    ASSERT_NEAR(0.0f, written[3], EPSILON);
+
+    dmGraphics::DisableProgram(m_GraphicsContext);
+    dmGraphics::DeleteProgram(m_GraphicsContext, program);
 }
 
 struct IterConstantContext


### PR DESCRIPTION
There is now a new constant type added `CONSTANT_TYPE_TIME` that can be used by shaders to automatically recieve time data from the engine:

```glsl
uniform my_uniforms
{
    vec4 my_time; // Set to constant type "Time" in the material editor!
};
```

The current data is exposed:
my_time.x : time since engine start
my_time.y : delta time from last frame (same as being passed into script updates)

This change means that you don't need to keep track of these values manually for certain effects like scrolling textures or other shader based animations!

Fixes #11987