### PR TITLE
Make sure `shader.exclude_gles_sm100` is taken into account in `AndroidManifest.xml`

### DIFF
--- a/engine/engine/content/builtins/manifests/android/AndroidManifest.xml
+++ b/engine/engine/content/builtins/manifests/android/AndroidManifest.xml
@@ -8,7 +8,12 @@
         android:appCategory="game"
         android:installLocation="auto">
 
+    {{#shader.exclude_gles_sm100}}
+    <uses-feature android:required="true" android:glEsVersion="0x00030000" />
+    {{/shader.exclude_gles_sm100}}
+    {{^shader.exclude_gles_sm100}}
     <uses-feature android:required="true" android:glEsVersion="0x00020000" />
+    {{/shader.exclude_gles_sm100}}
     <uses-sdk android:minSdkVersion="{{android.minimum_sdk_version}}" android:targetSdkVersion="{{android.target_sdk_version}}" />
     <application
         {{#has-icons?}}


### PR DESCRIPTION
The `shader.exclude_gles_sm100` checkbox in `game.project` disables generation of OpenGL ES 2.0 compatible shaders, which makes this API unsupported. This setting should also be reflected in `AndroidManifest.xml`, so Google Play knows that such devices are not supported.

⚠️ If you are using a custom AndroidManifest.xml file, make sure to update it.
Replace
```xml
    <uses-feature android:required="true" android:glEsVersion="0x00020000" />
```
with
```xml
    {{#shader.exclude_gles_sm100}}
    <uses-feature android:required="true" android:glEsVersion="0x00030000" />
    {{/shader.exclude_gles_sm100}}
    {{^shader.exclude_gles_sm100}}
    <uses-feature android:required="true" android:glEsVersion="0x00020000" />
    {{/shader.exclude_gles_sm100}}
```