### PR TITLE
Add `parent` property to editor script outline nodes

### DIFF
--- a/editor/AGENTS.md
+++ b/editor/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Coding Style
 
-Don't use defensive coding.
+Use offensive/fail-fast coding style.
 Keep requires sorted.
 Use variables and keywords with "?" suffix only to denote predicate functions, never boolean values.
 Never use lazy sequences, instead use transducers. See src/clj/util/coll.clj for alternatives of core clojure functions that use reduce instead of seq. See src/clj/util/eduction.clj for using eductions instead of unrealized sequences. 

--- a/editor/src/clj/editor/editor_extensions.clj
+++ b/editor/src/clj/editor/editor_extensions.clj
@@ -134,39 +134,39 @@
 
 (defn- make-ext-get-fn [project]
   (rt/lua-fn ext-get [{:keys [rt evaluation-context]} lua-node-id-or-path lua-property]
-    (let [node-id-or-path (rt/->clj rt graph/node-id-or-path-coercer lua-node-id-or-path)
+    (let [unresolved-editor-lookup (rt/->clj rt graph/unresolved-editor-lookup-coercer lua-node-id-or-path)
           property (rt/->clj rt coerce/string lua-property)
-          node-id-or-resource (graph/resolve-node-id-or-path node-id-or-path project evaluation-context)
-          getter (graph/ext-value-getter node-id-or-resource property project evaluation-context)]
+          editor-lookup (graph/resolve-unresolved-editor-lookup unresolved-editor-lookup project evaluation-context)
+          getter (graph/ext-value-getter editor-lookup property project evaluation-context)]
       (if getter
         (getter)
-        (throw (LuaError. (str (if (resource/resource? node-id-or-resource)
-                                 (resource/proj-path node-id-or-resource)
-                                 (name (graph/node-id->type-keyword node-id-or-resource evaluation-context)))
+        (throw (LuaError. (str (if (resource/resource? editor-lookup)
+                                 (resource/proj-path editor-lookup)
+                                 (name (graph/node-id->type-keyword (graph/editor-lookup->node-id editor-lookup) evaluation-context)))
                                " has no \""
                                property
                                "\" property")))))))
 
 (defn- make-ext-can-get-fn [project]
   (rt/lua-fn ext-can-get [{:keys [rt evaluation-context]} lua-node-id-or-path lua-property]
-    (let [node-id-or-path (rt/->clj rt graph/node-id-or-path-coercer lua-node-id-or-path)
+    (let [unresolved-editor-lookup (rt/->clj rt graph/unresolved-editor-lookup-coercer lua-node-id-or-path)
           property (rt/->clj rt coerce/string lua-property)
-          node-id-or-resource (graph/resolve-node-id-or-path node-id-or-path project evaluation-context)]
-      (some? (graph/ext-value-getter node-id-or-resource property project evaluation-context)))))
+          editor-lookup (graph/resolve-unresolved-editor-lookup unresolved-editor-lookup project evaluation-context)]
+      (some? (graph/ext-value-getter editor-lookup property project evaluation-context)))))
 
 (defn- make-ext-properties-fn [project]
   (rt/lua-fn ext-properties [{:keys [rt evaluation-context]} lua-node-id-or-path]
-    (let [node-id-or-path (rt/->clj rt graph/node-id-or-path-coercer lua-node-id-or-path)
-          node-id-or-resource (graph/resolve-node-id-or-path node-id-or-path project evaluation-context)]
-      (graph/ext-readable-properties node-id-or-resource project evaluation-context))))
+    (let [unresolved-editor-lookup (rt/->clj rt graph/unresolved-editor-lookup-coercer lua-node-id-or-path)
+          editor-lookup (graph/resolve-unresolved-editor-lookup unresolved-editor-lookup project evaluation-context)]
+      (graph/ext-readable-properties editor-lookup project evaluation-context))))
 
 (defn- make-ext-can-set-fn [project]
   (rt/lua-fn ext-can-set [{:keys [rt evaluation-context]} lua-node-id-or-path lua-property]
-    (let [node-id-or-path (rt/->clj rt graph/node-id-or-path-coercer lua-node-id-or-path)
+    (let [unresolved-editor-lookup (rt/->clj rt graph/unresolved-editor-lookup-coercer lua-node-id-or-path)
           property (rt/->clj rt coerce/string lua-property)
-          node-id-or-resource (graph/resolve-node-id-or-path node-id-or-path project evaluation-context)]
-      (and (not (resource/resource? node-id-or-resource))
-           (some? (graph/ext-lua-value-setter node-id-or-resource property rt project evaluation-context))))))
+          editor-lookup (graph/resolve-unresolved-editor-lookup unresolved-editor-lookup project evaluation-context)]
+      (and (not (resource/resource? editor-lookup))
+           (some? (graph/ext-lua-value-setter (graph/editor-lookup->node-id editor-lookup) property rt project evaluation-context))))))
 
 (def ^:private created-resources-coercer
   (coerce/vector-of
@@ -414,8 +414,8 @@
 
 (defn- make-ext-tx-set-fn [project]
   (rt/lua-fn ext-tx-set [{:keys [rt evaluation-context]} lua-node-id-or-path lua-property lua-value]
-    (let [node-id (graph/node-id-or-path->node-id
-                    (rt/->clj rt graph/node-id-or-path-coercer lua-node-id-or-path)
+    (let [node-id (graph/unresolved-editor-lookup->node-id
+                    (rt/->clj rt graph/unresolved-editor-lookup-coercer lua-node-id-or-path)
                     project
                     evaluation-context)
           property (rt/->clj rt coerce/string lua-property)

--- a/editor/src/clj/editor/editor_extensions/actions.clj
+++ b/editor/src/clj/editor/editor_extensions/actions.clj
@@ -44,7 +44,7 @@
     f))
 
 (defmethod action->batched-executor+input :set [action rt project evaluation-context]
-  (let [node-id (graph/node-id-or-path->node-id (:node_id action) project evaluation-context)
+  (let [node-id (graph/unresolved-editor-lookup->node-id (:node_id action) project evaluation-context)
         property (:property action)
         setter (graph/ext-lua-value-setter node-id property rt project evaluation-context)]
     (if setter
@@ -112,7 +112,7 @@
   (coerce/vector-of
     (coerce/by-key
       :action
-      {:set (coerce/hash-map :req {:node_id graph/node-id-or-path-coercer
+      {:set (coerce/hash-map :req {:node_id graph/unresolved-editor-lookup-coercer
                                    :property coerce/string
                                    :value coerce/untouched})
        :shell (coerce/hash-map :req {:command (coerce/vector-of coerce/string :min-count 1)})})))

--- a/editor/src/clj/editor/editor_extensions/commands.clj
+++ b/editor/src/clj/editor/editor_extensions/commands.clj
@@ -18,16 +18,17 @@
             [editor.editor-extensions.actions :as actions]
             [editor.editor-extensions.coerce :as coerce]
             [editor.editor-extensions.error-handling :as error-handling]
-            [editor.editor-extensions.localization :as ext.localization]
+            [editor.editor-extensions.graph :as graph]
             [editor.editor-extensions.prefs-docs :as prefs-docs]
             [editor.editor-extensions.runtime :as rt]
             [editor.editor-extensions.ui-docs :as ui-docs]
             [editor.future :as future]
             [editor.handler :as handler]
             [editor.lsp.async :as lsp.async]
-            [editor.outline :as outline]
             [editor.resource :as resource]
-            [editor.scene :as scene]))
+            [editor.scene :as scene]
+            [util.coll :as coll]
+            [util.fn :as fn]))
 
 (set! *warn-on-reflection* true)
 
@@ -51,8 +52,11 @@
       (first selection))
     selection))
 
+(defn- editor-lookup-userdata [editor-lookup]
+  (rt/wrap-userdata editor-lookup (format "<node: 0x%x>" (graph/editor-lookup->node-id editor-lookup))))
+
 (defn- node-ids->lua-selection [selection q]
-  (ensure-selection-cardinality (mapv rt/wrap-userdata selection) q))
+  (ensure-selection-cardinality (mapv editor-lookup-userdata selection) q))
 
 (defmethod gen-selection-query :resource [q acc project]
   (gen-query acc [env cont]
@@ -74,7 +78,7 @@
                                                  (keep
                                                    (fn [resource]
                                                      (if-let [node-id (project/get-resource-node project resource evaluation-context)]
-                                                       (rt/wrap-userdata node-id)
+                                                       (editor-lookup-userdata node-id)
                                                        (resource/proj-path resource))))))
                                           (ensure-selection-cardinality q)))]
                  (when-not (:evaluation-context env)
@@ -85,8 +89,16 @@
   (gen-query acc [env cont]
              (let [evaluation-context (or (:evaluation-context env) (g/make-evaluation-context))]
                (when-let [res (some-> (:selection env)
-                                      (handler/adapt-every outline/OutlineNode evaluation-context)
-                                      (node-ids->lua-selection q))]
+                                      (coll/into-> []
+                                        (halt-when
+                                          (fn [selected-item]
+                                            (not (and (map? selected-item)
+                                                      (contains? selected-item :node-id)
+                                                      (contains? selected-item :node-id-path))))
+                                          fn/constantly-nil)
+                                        (map #(editor-lookup-userdata (graph/node-id-with-ancestors (:node-id %) (pop (:node-id-path %))))))
+                                      coll/not-empty
+                                      (ensure-selection-cardinality q))]
                  (when-not (:evaluation-context env)
                    (g/update-cache-from-evaluation-context! evaluation-context))
                  (cont assoc :selection res)))))

--- a/editor/src/clj/editor/editor_extensions/graph.clj
+++ b/editor/src/clj/editor/editor_extensions/graph.clj
@@ -37,6 +37,7 @@
             [editor.util :as util]
             [editor.workspace :as workspace]
             [util.coll :as coll]
+            [util.defonce :as defonce]
             [util.eduction :as e]
             [util.fn :as fn]
             [util.id-vec :as iv])
@@ -52,34 +53,74 @@
 (set! *warn-on-reflection* true)
 (set! *unchecked-math* :warn-on-boxed)
 
+;; Terminology:
+;; - unresolved-editor-lookup: input value accepted from Lua, either a node id,
+;;   NodeIdWithAncestors, or a resource path string. use to look up properties
+;; - editor-lookup: resolved value used by property APIs, either a node id,
+;;   NodeIdWithAncestors, or a folder resource (files get resolved to node ids)
+
+;; ancestors is a non-empty vector of semantical node id ancestors, with the
+;; nearest ancestor (parent) at the end
+(defonce/type NodeIdWithAncestors [node-id ancestors])
+
+(defn node-id-with-ancestors? [x]
+  (instance? NodeIdWithAncestors x))
+
+(defn node-id-with-ancestors [node-id ancestors]
+  {:pre [(g/node-id? node-id) (vector? ancestors) (coll/every? g/node-id? ancestors)]}
+  (if (coll/empty? ancestors)
+    node-id
+    (->NodeIdWithAncestors node-id ancestors)))
+
+(defn editor-lookup->node-id
+  "Extract node id from editor-lookup known to reference a node.
+
+  Precondition: editor-lookup is not a resource."
+  [editor-lookup]
+  {:pre [(not (resource/resource? editor-lookup))]}
+  (if (node-id-with-ancestors? editor-lookup)
+    (.-node-id ^NodeIdWithAncestors editor-lookup)
+    editor-lookup))
+
+(defn editor-lookup->ancestors
+  "Return ancestors from editor-lookup.
+
+  Returns nil unless editor-lookup is NodeIdWithAncestors."
+  [editor-lookup]
+  (when (node-id-with-ancestors? editor-lookup)
+    (.-ancestors ^NodeIdWithAncestors editor-lookup)))
+
 (def resource-path-coercer
   (coerce/wrap-with-pred coerce/string #(and (string? %) (string/starts-with? % "/")) "is not a resource path"))
 
-(def node-id-or-path-coercer
+(def unresolved-editor-lookup-coercer
   (coerce/one-of
-    (coerce/wrap-with-pred coerce/userdata g/node-id? "is not a node id")
+    (coerce/wrap-with-pred coerce/userdata (some-fn g/node-id? node-id-with-ancestors?) "is not a node id")
     resource-path-coercer))
 
-(defn resolve-node-id-or-path
-  "Resolve node id or proj-path to either a node id or a folder resource
+(defn resolve-unresolved-editor-lookup
+  "Resolve unresolved-editor-lookup to editor-lookup.
 
-  If a path points to a file resource, it will be resolved to node-id"
-  [node-id-or-path project evaluation-context]
-  (if (string? node-id-or-path)
-    (let [resource (workspace/find-resource (project/workspace project evaluation-context) node-id-or-path evaluation-context)]
+  Resource paths are resolved in workspace. A file resource path resolves to
+  node id, while a folder path resolves to folder resource."
+  [unresolved-editor-lookup project evaluation-context]
+  (if (string? unresolved-editor-lookup)
+    (let [resource (workspace/find-resource (project/workspace project evaluation-context) unresolved-editor-lookup evaluation-context)]
       (when-not resource
-        (throw (LuaError. (str node-id-or-path " not found"))))
+        (throw (LuaError. (str unresolved-editor-lookup " not found"))))
       (or (project/get-resource-node project resource evaluation-context)
           resource))
-    node-id-or-path))
+    unresolved-editor-lookup))
 
-(defn node-id-or-path->node-id
-  "Coerce a value that may be node id or proj-path to existing node id"
-  [node-id-or-path project evaluation-context]
-  (let [node-id-or-resource (resolve-node-id-or-path node-id-or-path project evaluation-context)]
-    (when (resource/resource? node-id-or-resource)
-      (throw (LuaError. (str (resource/proj-path node-id-or-resource) " is not a file resource"))))
-    node-id-or-resource))
+(defn unresolved-editor-lookup->node-id
+  "Resolve unresolved-editor-lookup and return existing node id.
+
+  Folder resources are rejected with LuaError."
+  [unresolved-editor-lookup project evaluation-context]
+  (let [editor-lookup (resolve-unresolved-editor-lookup unresolved-editor-lookup project evaluation-context)]
+    (when (resource/resource? editor-lookup)
+      (throw (LuaError. (str (resource/proj-path editor-lookup) " is not a file resource"))))
+    (editor-lookup->node-id editor-lookup)))
 
 (defn node-id->type-keyword [node-id evaluation-context]
   (g/node-type-kw (:basis evaluation-context) node-id))
@@ -90,19 +131,19 @@
   (fn [lua-value rt _edit-type _project _evaluation-context]
     (rt/->clj rt coercer lua-value)))
 
-(def node-id-or-path-or-empty-string-coercer
+(def unresolved-editor-lookup-or-empty-string-coercer
   (coerce/one-of
-    node-id-or-path-coercer
+    unresolved-editor-lookup-coercer
     (coerce/enum "")))
 
 (defn- resource-converter [lua-value rt edit-type project evaluation-context]
-  (let [node-id-or-path (rt/->clj rt node-id-or-path-or-empty-string-coercer lua-value)]
-    (when-not (= node-id-or-path "")
-      (let [resource (if (string? node-id-or-path)
+  (let [unresolved-editor-lookup (rt/->clj rt unresolved-editor-lookup-or-empty-string-coercer lua-value)]
+    (when-not (= unresolved-editor-lookup "")
+      (let [resource (if (string? unresolved-editor-lookup)
                        (-> project
                            (project/workspace evaluation-context)
-                           (workspace/resolve-workspace-resource node-id-or-path evaluation-context))
-                       (g/node-value node-id-or-path :resource evaluation-context))
+                           (workspace/resolve-workspace-resource unresolved-editor-lookup evaluation-context))
+                       (g/node-value (editor-lookup->node-id unresolved-editor-lookup) :resource evaluation-context))
             ext (:ext edit-type)
             ext (if (string? ext) [ext] ext)]
         (when (and (seq ext)
@@ -407,28 +448,34 @@
                 (prop-kw->property prop-kw)))))))
 
 (defn ext-value-getter
-  "Create 0-arg fn that produces node property value
+  "Create 0-arg fn that produces property value for editor-lookup.
 
-  Returns nil if there is no getter for node-id-or-resource+property
+  Returns nil if there is no getter for editor-lookup+property
 
   Args:
-    node-id-or-resource    resolved node id or folder resource
+    editor-lookup          editor lookup
     property               string property name
     project                the project node id
     evaluation-context     used evaluation context"
-  [node-id-or-resource property project evaluation-context]
-  (if (resource/resource? node-id-or-resource)
+  [editor-lookup property project evaluation-context]
+  (if (resource/resource? editor-lookup)
     (case property
-      "path" #(resource/proj-path node-id-or-resource)
-      "children" #(mapv resource/proj-path (resource/children node-id-or-resource))
+      "path" #(resource/proj-path editor-lookup)
+      "children" #(mapv resource/proj-path (resource/children editor-lookup))
       nil)
-    (let [node-id node-id-or-resource
+    (let [node-id (editor-lookup->node-id editor-lookup)
           {:keys [basis]} evaluation-context
           node-type (g/node-type* basis node-id)
           workspace (project/workspace project evaluation-context)]
       (or (coll/some #((ext-property-getter (:k (g/node-type* basis %))) % property evaluation-context)
                      (attachment/alternatives workspace node-id evaluation-context))
           (case property
+            "parent" (when-let [ancestors (editor-lookup->ancestors editor-lookup)]
+                       (fn get-parent []
+                         (let [parent-node-id (peek ancestors)
+                               parent-ancestors (pop ancestors)]
+                           (rt/wrap-userdata
+                             (node-id-with-ancestors parent-node-id parent-ancestors)))))
             "type" (when-let [type-name (node-types/->name node-type)]
                      (constantly type-name))
             (let [list-kw (property->prop-kw property)]
@@ -440,17 +487,17 @@
 ;; region properties list
 
 (defn ext-readable-properties
-  "Return readable property names for a node/resource.
-
-  Work in progress"
-  [node-id-or-resource project evaluation-context]
-  (if (resource/resource? node-id-or-resource)
+  "Return sorted unique readable property names for editor-lookup."
+  [editor-lookup project evaluation-context]
+  (if (resource/resource? editor-lookup)
     ["children" "path"]
-    (let [node-id node-id-or-resource
+    (let [node-id (editor-lookup->node-id editor-lookup)
+          ancestors (editor-lookup->ancestors editor-lookup)
           workspace (project/workspace project evaluation-context)
           explicit-type-name (node-types/->name (g/node-type* (:basis evaluation-context) node-id))]
       (-> (e/distinct
             (e/concat
+              (when ancestors ["parent"])
               (->> (attachment/alternatives workspace node-id evaluation-context)
                    (e/mapcat #(e/cat ((ext-property-lister (node-id->type-keyword % evaluation-context)) % evaluation-context))))
               (e/map prop-kw->property (attachment/list-kws workspace node-id evaluation-context))
@@ -671,23 +718,23 @@
         #(properties/clear-override-uncoalesced property)))))
 
 (def ^:private can-reset-args-coercer
-  (coerce/regex :node node-id-or-path-coercer :property coerce/string))
+  (coerce/regex :node unresolved-editor-lookup-coercer :property coerce/string))
 
 (defn make-ext-can-reset-fn [project]
   (rt/varargs-lua-fn ext-can-reset [{:keys [rt evaluation-context]} varargs]
     (let [{:keys [node property]} (rt/->clj rt can-reset-args-coercer varargs)
-          node-id-or-resource (resolve-node-id-or-path node project evaluation-context)]
-      (and (not (resource/resource? node-id-or-resource))
-           (let [node-id node-id-or-resource]
+          editor-lookup (resolve-unresolved-editor-lookup node project evaluation-context)]
+      (and (not (resource/resource? editor-lookup))
+           (let [node-id (editor-lookup->node-id editor-lookup)]
              (some? ((ext-property-resetter (node-id->type-keyword node-id evaluation-context)) node-id property evaluation-context)))))))
 
 (def ^:private reset-args-coercer
-  (coerce/regex :node node-id-or-path-coercer :property coerce/string))
+  (coerce/regex :node unresolved-editor-lookup-coercer :property coerce/string))
 
 (defn make-ext-reset-fn [project]
   (rt/varargs-lua-fn ext-reset [{:keys [rt evaluation-context]} varargs]
     (let [{:keys [node property]} (rt/->clj rt reset-args-coercer varargs)
-          node-id (node-id-or-path->node-id node project evaluation-context)]
+          node-id (unresolved-editor-lookup->node-id node project evaluation-context)]
       (if-let [resetter ((ext-property-resetter (node-id->type-keyword node-id evaluation-context)) node-id property evaluation-context)]
         (-> (resetter)
             (with-meta {:type :transaction-step})
@@ -968,7 +1015,7 @@
       attachment)))
 
 (def ^:private add-args-coercer
-  (coerce/regex :node node-id-or-path-coercer
+  (coerce/regex :node unresolved-editor-lookup-coercer
                 :property coerce/string
                 :attachment attachment-coercer))
 
@@ -976,7 +1023,7 @@
   (rt/varargs-lua-fn ext-add [{:keys [rt evaluation-context]} varargs]
     (let [{:keys [node property attachment]} (rt/->clj rt add-args-coercer varargs)
           workspace (project/workspace project evaluation-context)
-          node-id (node-id-or-path->node-id node project evaluation-context)
+          node-id (unresolved-editor-lookup->node-id node project evaluation-context)
           list-kw (property->prop-kw property)]
       (when-not (attachment/defined? workspace node-id list-kw evaluation-context)
         (throw (LuaError. (format "\"%s\" is undefined" property))))
@@ -991,25 +1038,25 @@
             (rt/wrap-userdata "editor.tx.add(...)"))))))
 
 (def ^:private can-add-args-coercer
-  (coerce/regex :node node-id-or-path-coercer :property coerce/string))
+  (coerce/regex :node unresolved-editor-lookup-coercer :property coerce/string))
 
 (defn make-ext-can-add-fn [project]
   (rt/varargs-lua-fn ext-can-add [{:keys [rt evaluation-context]} varargs]
     (let [{:keys [node property]} (rt/->clj rt can-add-args-coercer varargs)
-          node-id-or-resource (resolve-node-id-or-path node project evaluation-context)
+          editor-lookup (resolve-unresolved-editor-lookup node project evaluation-context)
           list-kw (property->prop-kw property)
           workspace (project/workspace project evaluation-context)]
-      (and (not (resource/resource? node-id-or-resource))
-           (attachment/editable? workspace node-id-or-resource list-kw evaluation-context)))))
+      (and (not (resource/resource? editor-lookup))
+           (attachment/editable? workspace (editor-lookup->node-id editor-lookup) list-kw evaluation-context)))))
 
 (def ^:private clear-args-coercer
-  (coerce/regex :node node-id-or-path-coercer :property coerce/string))
+  (coerce/regex :node unresolved-editor-lookup-coercer :property coerce/string))
 
 (defn make-ext-clear-fn [project]
   (rt/varargs-lua-fn ext-clear [{:keys [rt evaluation-context]} varargs]
     (let [{:keys [node property]} (rt/->clj rt clear-args-coercer varargs)
           workspace (project/workspace project evaluation-context)
-          node-id (node-id-or-path->node-id node project evaluation-context)
+          node-id (unresolved-editor-lookup->node-id node project evaluation-context)
           list-kw (property->prop-kw property)]
       (when-not (attachment/defined? workspace node-id list-kw evaluation-context)
         (throw (LuaError. (format "\"%s\" is undefined" property))))
@@ -1020,14 +1067,14 @@
           (rt/wrap-userdata "editor.tx.clear(...)")))))
 
 (def ^:private remove-args-coercer
-  (coerce/regex :node node-id-or-path-coercer :property coerce/string :child node-id-or-path-coercer))
+  (coerce/regex :node unresolved-editor-lookup-coercer :property coerce/string :child unresolved-editor-lookup-coercer))
 
 (defn make-ext-remove-fn [project]
   (rt/varargs-lua-fn ext-remove [{:keys [rt evaluation-context]} varargs]
     (let [{:keys [node property child]} (rt/->clj rt remove-args-coercer varargs)
           workspace (project/workspace project evaluation-context)
-          node-id (node-id-or-path->node-id node project evaluation-context)
-          child-node-id (node-id-or-path->node-id child project evaluation-context)
+          node-id (unresolved-editor-lookup->node-id node project evaluation-context)
+          child-node-id (unresolved-editor-lookup->node-id child project evaluation-context)
           list-kw (property->prop-kw property)]
       (when-not (attachment/defined? workspace node-id list-kw evaluation-context)
         (throw (LuaError. (format "\"%s\" is undefined" property))))
@@ -1040,30 +1087,30 @@
           (rt/wrap-userdata "editor.tx.remove(...)")))))
 
 (def ^:private can-reorder-args-coercer
-  (coerce/regex :node node-id-or-path-coercer :property coerce/string))
+  (coerce/regex :node unresolved-editor-lookup-coercer :property coerce/string))
 
 (defn make-ext-can-reorder-fn [project]
   (rt/varargs-lua-fn ext-can-reorder [{:keys [rt evaluation-context]} varargs]
     (let [{:keys [node property]} (rt/->clj rt can-reorder-args-coercer varargs)
-          node-id-or-resource (resolve-node-id-or-path node project evaluation-context)
+          editor-lookup (resolve-unresolved-editor-lookup node project evaluation-context)
           workspace (project/workspace project evaluation-context)
           list-kw (property->prop-kw property)]
-      (and (not (resource/resource? node-id-or-resource))
-           (attachment/editable? workspace node-id-or-resource list-kw evaluation-context)
-           (attachment/reorderable? workspace node-id-or-resource list-kw evaluation-context)))))
+      (and (not (resource/resource? editor-lookup))
+           (attachment/editable? workspace (editor-lookup->node-id editor-lookup) list-kw evaluation-context)
+           (attachment/reorderable? workspace (editor-lookup->node-id editor-lookup) list-kw evaluation-context)))))
 
 (def ^:private reorder-args-coercer
-  (coerce/regex :node node-id-or-path-coercer
+  (coerce/regex :node unresolved-editor-lookup-coercer
                 :property coerce/string
-                :children (coerce/vector-of node-id-or-path-coercer)))
+                :children (coerce/vector-of unresolved-editor-lookup-coercer)))
 
 (defn make-ext-reorder-fn [project]
   (rt/varargs-lua-fn ext-reorder [{:keys [rt evaluation-context]} varargs]
     (let [{:keys [node property children]} (rt/->clj rt reorder-args-coercer varargs)
           workspace (project/workspace project evaluation-context)
-          node-id (node-id-or-path->node-id node project evaluation-context)
+          node-id (unresolved-editor-lookup->node-id node project evaluation-context)
           list-kw (property->prop-kw property)
-          reordered-child-node-ids (mapv #(node-id-or-path->node-id % project evaluation-context) children)]
+          reordered-child-node-ids (mapv #(unresolved-editor-lookup->node-id % project evaluation-context) children)]
       (when-not (attachment/defined? workspace node-id list-kw evaluation-context)
         (throw (LuaError. (format "\"%s\" is undefined" property))))
       (when-not (attachment/editable? workspace node-id list-kw evaluation-context)

--- a/editor/test/integration/editor_extensions_test.clj
+++ b/editor/test/integration/editor_extensions_test.clj
@@ -28,6 +28,7 @@
             [editor.graph-util :as gu]
             [editor.handler :as handler]
             [editor.os :as os]
+            [editor.outline-view :as outline-view]
             [editor.pipeline.bob :as bob]
             [editor.prefs :as prefs]
             [editor.process :as process]
@@ -38,6 +39,7 @@
             [editor.workspace :as workspace]
             [integration.test-util :as test-util]
             [support.test-support :as test-support]
+            [util.coll :as coll]
             [util.diff :as diff]
             [util.http-server :as http-server]
             [util.path :as path])
@@ -309,16 +311,26 @@
     (g/with-auto-evaluation-context evaluation-context
       (handler/eval-contexts [command-context] false evaluation-context))))
 
+(defn- decorated-outline [resource-node outline-path]
+  (let [node-outline (g/node-value resource-node :node-outline)
+        decorated-outline (:outline (outline-view/decorate-outline node-outline #{} #{} @test-util/localization #{}))]
+    (reduce (fn [outline-selection index]
+              (nth (:children outline-selection) index))
+            decorated-outline
+            outline-path)))
+
 (deftest editor-scripts-commands-test
   (test-util/with-loaded-project "test/resources/editor_extensions/commands_project"
-    (let [sprite-outline (:node-id (test-util/outline (test-util/resource-node project "/main/main.collection") [0 0]))]
+    (let [resource-node (test-util/resource-node project "/main/main.collection")
+          sprite-outline (decorated-outline resource-node [0 0])
+          sprite-node-id (:node-id sprite-outline)]
       (reload-editor-scripts! project)
       (let [handler+context (handler/active
                               (:command (first (handler/realize-menu :editor.outline-view/context-menu-end)))
                               (eval-handler-contexts :outline [sprite-outline])
                               {})]
-        (is (= [0.0 0.0 0.0] (test-util/prop sprite-outline :position)))
-        (is (= 1.0 (test-util/prop sprite-outline :playback-rate)))
+        (is (= [0.0 0.0 0.0] (test-util/prop sprite-node-id :position)))
+        (is (= 1.0 (test-util/prop sprite-node-id :playback-rate)))
         (is (some? handler+context))
         (is (handler/enabled? handler+context))
         (is (nil?
@@ -326,13 +338,13 @@
                 @(handler/run handler+context)
                 nil
                 (catch Throwable e e))))
-        (is (= [1.5 1.5 1.5] (test-util/prop sprite-outline :position)))
-        (is (= 2.5 (test-util/prop sprite-outline :playback-rate))))
+        (is (= [1.5 1.5 1.5] (test-util/prop sprite-node-id :position)))
+        (is (= 2.5 (test-util/prop sprite-node-id :playback-rate))))
       (let [handler+context (handler/active
                               (:command (first (handler/realize-menu :editor.scene-selection/context-menu-end)))
-                              (eval-handler-contexts :global [sprite-outline])
+                              (eval-handler-contexts :global [sprite-node-id])
                               {})]
-        (is (= [1.0 1.0 1.0] (test-util/prop sprite-outline :scale)))
+        (is (= [1.0 1.0 1.0] (test-util/prop sprite-node-id :scale)))
         (is (some? handler+context))
         (is (handler/enabled? handler+context))
         (is (nil?
@@ -340,7 +352,7 @@
                 @(handler/run handler+context)
                 nil
                 (catch Throwable e e))))
-        (is (= [2 2 2] (test-util/prop sprite-outline :scale)))))))
+        (is (= [2 2 2] (test-util/prop sprite-node-id :scale)))))))
 
 (deftest refresh-context-after-write-test
   (test-util/with-scratch-project "test/resources/editor_extensions/refresh_context_project"
@@ -388,10 +400,12 @@
   (test-util/with-loaded-project "test/resources/editor_extensions/transact_test"
     (let [output (atom [])
           _ (reload-editor-scripts! project :display-output! #(swap! output conj [%1 %2]))
-          node (:node-id (test-util/outline (test-util/resource-node project "/main/main.collection") [0 0]))
+          resource-node (test-util/resource-node project "/main/main.collection")
+          outline (decorated-outline resource-node [0 0])
+          node (:node-id outline)
           handler+context (handler/active
                             (:command (first (handler/realize-menu :editor.outline-view/context-menu-end)))
-                            (eval-handler-contexts :outline [node])
+                            (eval-handler-contexts :outline [outline])
                             {})
           test-initial-state! (fn test-initial-state! []
                                 (is (= "properties" (test-util/prop node :id)))
@@ -662,6 +676,44 @@
   (let [actual (normalize-pprint-output (str actual))]
     (let [output-matches-expectation (= expected actual)]
       (is output-matches-expectation (when-not output-matches-expectation (string/join "\n" (diff/make-diff-output-lines expected actual 3)))))))
+
+(def ^:private expected-outline-selection-parent-chain-test-output
+  "outline.child.can_get_parent=true
+outline.child.has_parent_property=true
+outline.parent.is_nil=false
+outline.parent.can_get_id=true
+outline.parent.id=go
+outline.parent.has_parent_property=true
+outline.parent.can_get_parent=true
+outline.grandparent.is_nil=false
+outline.grandparent.can_get_parent=false
+scene.node.can_get_parent=false
+scene.node.has_parent_property=false
+scene.node.get_parent_succeeds=false
+")
+
+(deftest outline-selection-parent-chain-test
+  (test-util/with-loaded-project "test/resources/editor_extensions/outline_parent_project"
+    (let [out (StringBuilder.)
+          _ (reload-editor-scripts! project :display-output! #(doto out (.append %2) (.append \newline)))
+          resource-node (test-util/resource-node project "/main/main.collection")
+          sprite-outline (decorated-outline resource-node [0 0])
+          sprite-node-id (:node-id sprite-outline)
+          run-command! (fn run-command! [location context-name selection label]
+                         (let [command-contexts (eval-handler-contexts context-name selection)
+                               menu-items (handler/realize-menu location)
+                               handler+context (coll/some
+                                                 (fn [{:keys [command]}]
+                                                   (let [handler+context (handler/active command command-contexts {})]
+                                                     (when (and handler+context (= label (handler/label handler+context)))
+                                                       handler+context)))
+                                                 menu-items)]
+                           (assert handler+context "Test bug: undefined test command")
+                           (is (handler/enabled? handler+context))
+                           @(handler/run handler+context)))]
+      (run-command! :editor.outline-view/context-menu-end :outline [sprite-outline] "Outline Parent Chain Test")
+      (run-command! :editor.scene-selection/context-menu-end :global [sprite-node-id] "Scene Parent Chain Test")
+      (expect-script-output expected-outline-selection-parent-chain-test-output out))))
 
 (deftest external-file-attributes-test
   (test-util/with-loaded-project "test/resources/editor_extensions/external_file_attributes_project"

--- a/editor/test/resources/editor_extensions/outline_parent_project/.gitignore
+++ b/editor/test/resources/editor_extensions/outline_parent_project/.gitignore
@@ -1,0 +1,11 @@
+/.editor_settings
+/.internal
+/build
+.externalToolBuilders
+.DS_Store
+Thumbs.db
+.lock-wscript
+*.pyc
+.project
+.cproject
+builtins

--- a/editor/test/resources/editor_extensions/outline_parent_project/game.project
+++ b/editor/test/resources/editor_extensions/outline_parent_project/game.project
@@ -1,0 +1,27 @@
+[bootstrap]
+main_collection = /main/main.collectionc
+
+[script]
+shared_state = 1
+
+[display]
+width = 960
+height = 640
+high_dpi = 1
+
+[android]
+input_method = HiddenInputField
+
+[physics]
+gravity_y = -1000.0
+scale = 0.01
+
+[html5]
+scale_mode = stretch
+
+[project]
+title = outline_parent_project
+
+[input]
+game_binding = /builtins/input/all.input_bindingc
+

--- a/editor/test/resources/editor_extensions/outline_parent_project/main/main.collection
+++ b/editor/test/resources/editor_extensions/outline_parent_project/main/main.collection
@@ -1,0 +1,45 @@
+name: "main"
+scale_along_z: 0
+embedded_instances {
+  id: "go"
+  data: "embedded_components {\n"
+  "  id: \"sprite\"\n"
+  "  type: \"sprite\"\n"
+  "  data: \"default_animation: \\\"anim\\\"\\n"
+  "material: \\\"/builtins/materials/sprite.material\\\"\\n"
+  "blend_mode: BLEND_MODE_ALPHA\\n"
+  "textures {\\n"
+  "  sampler: \\\"texture_sampler\\\"\\n"
+  "  texture: \\\"/builtins/graphics/particle_blob.tilesource\\\"\\n"
+  "}\\n"
+  "\"\n"
+  "  position {\n"
+  "    x: 0.0\n"
+  "    y: 0.0\n"
+  "    z: 0.0\n"
+  "  }\n"
+  "  rotation {\n"
+  "    x: 0.0\n"
+  "    y: 0.0\n"
+  "    z: 0.0\n"
+  "    w: 1.0\n"
+  "  }\n"
+  "}\n"
+  ""
+  position {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  scale3 {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+  }
+}

--- a/editor/test/resources/editor_extensions/outline_parent_project/test.editor_script
+++ b/editor/test/resources/editor_extensions/outline_parent_project/test.editor_script
@@ -1,0 +1,70 @@
+local M = {}
+
+local function has_value(values, wanted)
+    for i = 1, #values do
+        if values[i] == wanted then
+            return true
+        end
+    end
+    return false
+end
+
+local function assert_equal(label, expected, actual)
+    if expected ~= actual then
+        error(("%s: expected %s, got %s"):format(label, tostring(expected), tostring(actual)))
+    end
+    print(("%s=%s"):format(label, tostring(actual)))
+end
+
+local function assert_true(label, value)
+    assert_equal(label, true, value)
+end
+
+local function assert_false(label, value)
+    assert_equal(label, false, value)
+end
+
+function M.get_commands()
+    return {
+        {
+            label = "Outline Parent Chain Test",
+            locations = {"Outline"},
+            query = {selection = {type = "outline", cardinality = "one"}},
+            run = function(opts)
+                local node = opts.selection
+                local node_properties = editor.properties(node)
+
+                assert_true("outline.child.can_get_parent", editor.can_get(node, "parent"))
+                assert_true("outline.child.has_parent_property", has_value(node_properties, "parent"))
+
+                local parent = editor.get(node, "parent")
+                assert_false("outline.parent.is_nil", parent == nil)
+                assert_true("outline.parent.can_get_id", editor.can_get(parent, "id"))
+                assert_equal("outline.parent.id", "go", editor.get(parent, "id"))
+
+                local parent_properties = editor.properties(parent)
+                assert_true("outline.parent.has_parent_property", has_value(parent_properties, "parent"))
+                assert_true("outline.parent.can_get_parent", editor.can_get(parent, "parent"))
+
+                local grandparent = editor.get(parent, "parent")
+                assert_false("outline.grandparent.is_nil", grandparent == nil)
+                assert_false("outline.grandparent.can_get_parent", editor.can_get(grandparent, "parent"))
+            end
+        },
+        {
+            label = "Scene Parent Chain Test",
+            locations = {"Scene"},
+            query = {selection = {type = "scene", cardinality = "one"}},
+            run = function(opts)
+                local node = opts.selection
+                local node_properties = editor.properties(node)
+
+                assert_false("scene.node.can_get_parent", editor.can_get(node, "parent"))
+                assert_false("scene.node.has_parent_property", has_value(node_properties, "parent"))
+                assert_false("scene.node.get_parent_succeeds", pcall(editor.get, node, "parent"))
+            end
+        }
+    }
+end
+
+return M


### PR DESCRIPTION
Editor scripts can now access outline parents using `editor.can_get(node, "parent")` and `editor.get(node, "parent")` in commands that query outline selection.

Fix #5370
Fix #11898