### PR TITLE
Add API for creating and manipulating lights to dmRender

### DIFF
--- a/engine/gamesys/src/gamesys/test/material/light_buffer.fp
+++ b/engine/gamesys/src/gamesys/test/material/light_buffer.fp
@@ -1,0 +1,31 @@
+#version 140
+
+#define MAX_LIGHTS 32
+
+struct Light
+{
+    vec4 position;        // xyz: position, w:unused
+    vec4 color;           // RGBA (matches LightParams order)
+    vec4 direction_range; // xyz: normalized direction; w: range
+    vec4 params;          // x: type (0 dir, 1 point, 2 spot; matches dmRender::LightType)
+                          // y: intensity
+                          // z: innerConeAngle (radians, spot only)
+                          // w: outerConeAngle (radians, spot only)
+};
+uniform LightBuffer
+{
+    vec4  lights_count; // x: number of active lights
+    Light lights[MAX_LIGHTS];
+};
+
+out vec4 out_fragColor;
+
+void main()
+{
+    vec4 light_accum = vec4(0.0);
+    for (int i=0; i < int(lights_count.x); i++)
+    {
+        light_accum += lights[i].color;
+    }
+    out_fragColor = light_accum;
+}

--- a/engine/gamesys/src/gamesys/test/material/light_buffer.material
+++ b/engine/gamesys/src/gamesys/test/material/light_buffer.material
@@ -1,0 +1,3 @@
+name: "light_buffer"
+vertex_program: "/vertex_program/valid.vp"
+fragment_program: "/material/light_buffer.fp"

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -6005,23 +6005,23 @@ TEST_F(MaterialTest, TestUniformBuffersLayout)
     dmRender::HMaterial material = material_res->m_Material;
     ASSERT_NE((void*)0, material);
 
-    dmGraphics::ShaderResourceMember light_color_members[2];
+    dmGraphics::ShaderResourceMember color_intensity_members[2];
 
     // color : vec3
-    light_color_members[0].m_Name                 = (char*)"color";
-    light_color_members[0].m_NameHash             = dmHashString64("color");
-    light_color_members[0].m_Type.m_ShaderType    = dmGraphics::ShaderDesc::SHADER_TYPE_VEC3;
-    light_color_members[0].m_Type.m_UseTypeIndex  = 0;
-    light_color_members[0].m_ElementCount         = 1;
-    light_color_members[0].m_Offset               = 0;
+    color_intensity_members[0].m_Name                 = (char*)"color";
+    color_intensity_members[0].m_NameHash             = dmHashString64("color");
+    color_intensity_members[0].m_Type.m_ShaderType    = dmGraphics::ShaderDesc::SHADER_TYPE_VEC3;
+    color_intensity_members[0].m_Type.m_UseTypeIndex  = 0;
+    color_intensity_members[0].m_ElementCount         = 1;
+    color_intensity_members[0].m_Offset               = 0;
 
     // intensity : float
-    light_color_members[1].m_Name                 = (char*)"intensity";
-    light_color_members[1].m_NameHash             = dmHashString64("intensity");
-    light_color_members[1].m_Type.m_ShaderType    = dmGraphics::ShaderDesc::SHADER_TYPE_FLOAT;
-    light_color_members[1].m_Type.m_UseTypeIndex  = 0;
-    light_color_members[1].m_ElementCount         = 1;
-    light_color_members[1].m_Offset               = 0;
+    color_intensity_members[1].m_Name                 = (char*)"intensity";
+    color_intensity_members[1].m_NameHash             = dmHashString64("intensity");
+    color_intensity_members[1].m_Type.m_ShaderType    = dmGraphics::ShaderDesc::SHADER_TYPE_FLOAT;
+    color_intensity_members[1].m_Type.m_UseTypeIndex  = 0;
+    color_intensity_members[1].m_ElementCount         = 1;
+    color_intensity_members[1].m_Offset               = 0;
 
     dmGraphics::ShaderResourceMember light_members[2];
 
@@ -6033,7 +6033,7 @@ TEST_F(MaterialTest, TestUniformBuffersLayout)
     light_members[0].m_ElementCount         = 1;
     light_members[0].m_Offset               = 0;
 
-    // color_intensity : LightColor
+    // color_intensity : ColorIntensity (matches uniform_buffers.fp struct name)
     light_members[1].m_Name                 = (char*)"color_intensity";
     light_members[1].m_NameHash             = dmHashString64("color_intensity");
     light_members[1].m_Type.m_TypeIndex     = 2;   // index into ShaderResourceTypeInfo[]
@@ -6075,10 +6075,10 @@ TEST_F(MaterialTest, TestUniformBuffersLayout)
     types[1].m_Members     = light_members;
     types[1].m_MemberCount = 2;
 
-    // LightColor (index 2)
-    types[2].m_Name        = (char*)"LightColor";
-    types[2].m_NameHash    = dmHashString64("LightColor");
-    types[2].m_Members     = light_color_members;
+    // ColorIntensity (index 2) - must match struct name in uniform_buffers.fp
+    types[2].m_Name        = (char*)"ColorIntensity";
+    types[2].m_NameHash    = dmHashString64("ColorIntensity");
+    types[2].m_Members     = color_intensity_members;
     types[2].m_MemberCount = 2;
 
     dmGraphics::UpdateShaderTypesOffsets(types, DM_ARRAY_SIZE(types));
@@ -6094,6 +6094,68 @@ TEST_F(MaterialTest, TestUniformBuffersLayout)
 
     ASSERT_EQ(layout.m_Size, built_layout.m_Size);
     ASSERT_EQ(layout.m_Hash, built_layout.m_Hash);
+
+    dmResource::Release(m_Factory, material_res);
+}
+
+TEST_F(MaterialTest, TestLightBuffer)
+{
+    dmGameSystem::MaterialResource* material_res;
+    dmResource::Result res = dmResource::Get(m_Factory, "/material/light_buffer.materialc", (void**)&material_res);
+    ASSERT_EQ(dmResource::RESULT_OK, res);
+    ASSERT_NE((void*)0, material_res);
+
+    dmRender::HMaterial material = material_res->m_Material;
+    ASSERT_NE((void*)0, material);
+
+    ASSERT_TRUE(material->m_HasLightBuffer);
+    ASSERT_EQ(32, material->m_LightBufferLightsCount);
+    // Set and binding are assigned from the shader's uniform block; ensure they are initialized
+    ASSERT_LT(material->m_LightBufferSet, 8u);
+    ASSERT_LT(material->m_LightBufferBinding, 32u);
+
+    // Verify the material's program declares a LightBuffer with the expected layout
+    dmGraphics::HProgram program = dmRender::GetMaterialProgram(material);
+    ASSERT_NE((dmGraphics::HProgram)0, program);
+    const dmGraphics::ShaderMeta* program_meta = dmGraphics::GetShaderMeta(program);
+    ASSERT_NE((void*)0, program_meta);
+
+    const dmhash_t light_buffer_type = dmHashString64("LightBuffer");
+    const dmhash_t lights_member = dmHashString64("lights");
+    bool found_light_buffer = false;
+    for (uint32_t i = 0; i < program_meta->m_TypeInfos.Size(); ++i)
+    {
+        const dmGraphics::ShaderResourceTypeInfo& type_info = program_meta->m_TypeInfos[i];
+        if (type_info.m_NameHash == light_buffer_type)
+        {
+            found_light_buffer = true;
+            for (uint32_t m = 0; m < type_info.m_MemberCount; ++m)
+            {
+                if (type_info.m_Members[m].m_NameHash == lights_member)
+                {
+                    ASSERT_EQ(32, type_info.m_Members[m].m_ElementCount);
+                    break;
+                }
+            }
+            break;
+        }
+    }
+    ASSERT_TRUE(found_light_buffer);
+
+    dmResource::Release(m_Factory, material_res);
+}
+
+TEST_F(MaterialTest, TestLightBufferAbsent)
+{
+    dmGameSystem::MaterialResource* material_res;
+    dmResource::Result res = dmResource::Get(m_Factory, "/material/valid.materialc", (void**)&material_res);
+    ASSERT_EQ(dmResource::RESULT_OK, res);
+    ASSERT_NE((void*)0, material_res);
+
+    dmRender::HMaterial material = material_res->m_Material;
+    ASSERT_NE((void*)0, material);
+
+    ASSERT_FALSE(material->m_HasLightBuffer);
 
     dmResource::Release(m_Factory, material_res);
 }

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -6109,7 +6109,6 @@ TEST_F(MaterialTest, TestLightBuffer)
     ASSERT_NE((void*)0, material);
 
     ASSERT_TRUE(material->m_HasLightBuffer);
-    ASSERT_EQ(32, material->m_LightBufferLightsCount);
     // Set and binding are assigned from the shader's uniform block; ensure they are initialized
     ASSERT_LT(material->m_LightBufferSet, 8u);
     ASSERT_LT(material->m_LightBufferBinding, 32u);

--- a/engine/gamesys/src/gamesys/test/test_gamesys.h
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.h
@@ -577,6 +577,7 @@ void GamesysTest<T>::SetUp()
     render_params.m_ScriptContext = m_ScriptContext;
     render_params.m_MaxCharacters = 256;
     render_params.m_MaxBatches = 128;
+    render_params.m_MaxLights = 32;
     m_RenderContext = dmRender::NewRenderContext(m_GraphicsContext, render_params);
 
     dmInput::NewContextParams input_params;

--- a/engine/graphics/src/graphics.cpp
+++ b/engine/graphics/src/graphics.cpp
@@ -1353,22 +1353,12 @@ namespace dmGraphics
     void IterateProgramResourceBindings(HProgram prog, ShaderResourceBindingFamily family, IterateProgramResourceBindingsCallback callback, void* user_data)
     {
         Program* program = (Program*) prog;
-        if (!program || !callback)
-        {
-            return;
-        }
-
         ProgramResourceBindingIterator it(program);
 
         const ProgramResourceBinding* binding;
         while ((binding = it.Next()))
         {
-            if (!binding->m_Res)
-            {
-                continue;
-            }
-
-            if (binding->m_Res->m_BindingFamily != family)
+            if (!binding->m_Res || binding->m_Res->m_BindingFamily != family)
             {
                 continue;
             }
@@ -1381,11 +1371,7 @@ namespace dmGraphics
             }
 
             const ShaderResourceTypeInfo* root_type = &type_infos[root_type_index];
-
-            callback(binding->m_Res->m_Set,
-                     binding->m_Res->m_Binding,
-                     root_type,
-                     user_data);
+            callback(binding->m_Res->m_Set, binding->m_Res->m_Binding, root_type, user_data);
         }
     }
 

--- a/engine/graphics/src/graphics.cpp
+++ b/engine/graphics/src/graphics.cpp
@@ -1185,7 +1185,7 @@ namespace dmGraphics
             free(meta.m_TypeInfos[i].m_Name);
             for (int j = 0; j < meta.m_TypeInfos[i].m_MemberCount; ++j)
             {
-                free(meta.m_TypeInfos[i].m_Members[j].m_Name);
+                free((char*) meta.m_TypeInfos[i].m_Members[j].m_Name);
             }
 
             delete[] meta.m_TypeInfos[i].m_Members;

--- a/engine/graphics/src/graphics.cpp
+++ b/engine/graphics/src/graphics.cpp
@@ -1350,7 +1350,7 @@ namespace dmGraphics
         }
     }
 
-    void IterateProgramResourceBindings(HProgram prog, ShaderResourceBindingFamily family, ProgramResourceBindingCallback callback, void* user_data)
+    void IterateProgramResourceBindings(HProgram prog, ShaderResourceBindingFamily family, IterateProgramResourceBindingsCallback callback, void* user_data)
     {
         Program* program = (Program*) prog;
         if (!program || !callback)

--- a/engine/graphics/src/graphics.cpp
+++ b/engine/graphics/src/graphics.cpp
@@ -1350,6 +1350,45 @@ namespace dmGraphics
         }
     }
 
+    void IterateProgramResourceBindings(HProgram prog, ShaderResourceBindingFamily family, ProgramResourceBindingCallback callback, void* user_data)
+    {
+        Program* program = (Program*) prog;
+        if (!program || !callback)
+        {
+            return;
+        }
+
+        ProgramResourceBindingIterator it(program);
+
+        const ProgramResourceBinding* binding;
+        while ((binding = it.Next()))
+        {
+            if (!binding->m_Res)
+            {
+                continue;
+            }
+
+            if (binding->m_Res->m_BindingFamily != family)
+            {
+                continue;
+            }
+
+            const dmArray<ShaderResourceTypeInfo>& type_infos = *binding->m_TypeInfos;
+            uint32_t root_type_index = binding->m_Res->m_Type.m_TypeIndex;
+            if (root_type_index >= (uint32_t) type_infos.Size())
+            {
+                continue;
+            }
+
+            const ShaderResourceTypeInfo* root_type = &type_infos[root_type_index];
+
+            callback(binding->m_Res->m_Set,
+                     binding->m_Res->m_Binding,
+                     root_type,
+                     user_data);
+        }
+    }
+
     void BuildUniforms(Program* program)
     {
         uint32_t uniform_count = 0;
@@ -1594,7 +1633,10 @@ namespace dmGraphics
             if (use_type_index)
             {
                 uint32_t child_type = member.m_Type.m_TypeIndex;
-                dmHashUpdateBuffer32(hash_state, &child_type, sizeof(child_type));
+                // Hash the type's name so the layout hash is independent of type array order
+                // (shader reflection may order types differently than manually built layouts).
+                dmhash_t child_name_hash = types[child_type].m_NameHash;
+                dmHashUpdateBuffer32(hash_state, &child_name_hash, sizeof(child_name_hash));
 
                 // Recurse into referenced type
                 HashTypeRecursive(child_type, types, num_types, hash_state, visited);

--- a/engine/graphics/src/graphics.h
+++ b/engine/graphics/src/graphics.h
@@ -271,17 +271,11 @@ namespace dmGraphics
     };
 
     // Callback invoked for each resource binding in a program that matches the specified family.
-    // The callback receives the descriptor set and binding indices for the resource, and the
-    // root type description for the bound resource.
-    typedef void (*ProgramResourceBindingCallback)(
-        uint16_t                      set,
-        uint16_t                      binding,
-        const ShaderResourceTypeInfo* root_type,
-        void*                         user_data);
+    typedef void (*IterateProgramResourceBindingsCallback)(uint16_t set, uint16_t binding, const ShaderResourceTypeInfo* root_type, void* user_data);
 
     // Iterate over all resource bindings for the given program that belong to the specified
     // binding family and invoke the supplied callback for each binding.
-    void IterateProgramResourceBindings(HProgram program, ShaderResourceBindingFamily family, ProgramResourceBindingCallback callback, void* user_data);
+    void IterateProgramResourceBindings(HProgram program, ShaderResourceBindingFamily family, IterateProgramResourceBindingsCallback callback, void* user_data);
 
     /**
      * Starts the app that needs to control the update loop (iOS only)

--- a/engine/graphics/src/graphics.h
+++ b/engine/graphics/src/graphics.h
@@ -246,11 +246,11 @@ namespace dmGraphics
 
     struct ShaderResourceMember
     {
-        char*                       m_Name;
-        dmhash_t                    m_NameHash;
-        ShaderResourceType          m_Type;
-        uint32_t                    m_ElementCount;
-        uint32_t                    m_Offset;
+        char*              m_Name;
+        dmhash_t           m_NameHash;
+        ShaderResourceType m_Type;
+        uint32_t           m_ElementCount;
+        uint32_t           m_Offset;
     };
 
     struct ShaderResourceTypeInfo

--- a/engine/graphics/src/graphics.h
+++ b/engine/graphics/src/graphics.h
@@ -246,7 +246,7 @@ namespace dmGraphics
 
     struct ShaderResourceMember
     {
-        char*              m_Name;
+        const char*        m_Name;
         dmhash_t           m_NameHash;
         ShaderResourceType m_Type;
         uint32_t           m_ElementCount;

--- a/engine/graphics/src/graphics.h
+++ b/engine/graphics/src/graphics.h
@@ -234,7 +234,54 @@ namespace dmGraphics
         uint32_t m_Hash;
     };
 
+    struct ShaderResourceType
+    {
+        union
+        {
+            ShaderDesc::ShaderDataType m_ShaderType;
+            uint32_t                   m_TypeIndex;
+        };
+        uint8_t m_UseTypeIndex : 1;
+    };
 
+    struct ShaderResourceMember
+    {
+        char*                       m_Name;
+        dmhash_t                    m_NameHash;
+        ShaderResourceType          m_Type;
+        uint32_t                    m_ElementCount;
+        uint32_t                    m_Offset;
+    };
+
+    struct ShaderResourceTypeInfo
+    {
+        char*                 m_Name;
+        dmhash_t              m_NameHash;
+        ShaderResourceMember* m_Members;
+        uint32_t              m_MemberCount;
+    };
+
+    // Binding family for shader resources in a program.
+    enum ShaderResourceBindingFamily
+    {
+        BINDING_FAMILY_GENERIC        = 0,
+        BINDING_FAMILY_UNIFORM_BUFFER = 1,
+        BINDING_FAMILY_STORAGE_BUFFER = 2,
+        BINDING_FAMILY_TEXTURE        = 3,
+    };
+
+    // Callback invoked for each resource binding in a program that matches the specified family.
+    // The callback receives the descriptor set and binding indices for the resource, and the
+    // root type description for the bound resource.
+    typedef void (*ProgramResourceBindingCallback)(
+        uint16_t                      set,
+        uint16_t                      binding,
+        const ShaderResourceTypeInfo* root_type,
+        void*                         user_data);
+
+    // Iterate over all resource bindings for the given program that belong to the specified
+    // binding family and invoke the supplied callback for each binding.
+    void IterateProgramResourceBindings(HProgram program, ShaderResourceBindingFamily family, ProgramResourceBindingCallback callback, void* user_data);
 
     /**
      * Starts the app that needs to control the update loop (iOS only)
@@ -361,6 +408,8 @@ namespace dmGraphics
     void             GetUniform(HProgram prog, uint32_t index, Uniform* uniform);
 
     // Uniform buffers
+    void                UpdateShaderTypesOffsets(ShaderResourceTypeInfo* type_infos, uint32_t num_type_infos);
+    void                GetUniformBufferLayout(uint32_t root_type_index, const ShaderResourceTypeInfo* types, uint32_t num_types, UniformBufferLayout* layout_desc);
     HUniformBuffer      NewUniformBuffer(HContext context, const UniformBufferLayout& layout);
     void                DeleteUniformBuffer(HContext context, HUniformBuffer uniform_buffer);
     void                SetUniformBuffer(HContext context, HUniformBuffer uniform_buffer, uint32_t offset, uint32_t size, const void* data);

--- a/engine/graphics/src/graphics_private.h
+++ b/engine/graphics/src/graphics_private.h
@@ -72,14 +72,6 @@ namespace dmGraphics
         SHADER_STAGE_FLAG_COMPUTE  = 0x4,
     };
 
-    enum ShaderResourceBindingFamily
-    {
-        BINDING_FAMILY_GENERIC        = 0,
-        BINDING_FAMILY_UNIFORM_BUFFER = 1,
-        BINDING_FAMILY_STORAGE_BUFFER = 2,
-        BINDING_FAMILY_TEXTURE        = 3,
-    };
-
     struct VertexStream
     {
         dmhash_t m_NameHash;
@@ -93,33 +85,6 @@ namespace dmGraphics
     {
         dmArray<VertexStream> m_Streams;
         VertexStepFunction    m_StepFunction;
-    };
-
-    struct ShaderResourceType
-    {
-        union
-        {
-            ShaderDesc::ShaderDataType m_ShaderType;
-            uint32_t                   m_TypeIndex;
-        };
-        uint8_t m_UseTypeIndex : 1;
-    };
-
-    struct ShaderResourceMember
-    {
-        char*                       m_Name;
-        dmhash_t                    m_NameHash;
-        ShaderResourceType          m_Type;
-        uint32_t                    m_ElementCount;
-        uint32_t                    m_Offset;
-    };
-
-    struct ShaderResourceTypeInfo
-    {
-        char*                 m_Name;
-        dmhash_t              m_NameHash;
-        ShaderResourceMember* m_Members;
-        uint32_t              m_MemberCount;
     };
 
     struct ShaderResourceBinding
@@ -279,7 +244,6 @@ namespace dmGraphics
     uint32_t                   CountShaderResourceLeafMembers(const dmArray<ShaderResourceTypeInfo>& type_infos, ShaderResourceType type, uint32_t count = 0);
     void                       BuildUniforms(Program* program);
     void                       IterateUniforms(Program* program, bool prepend_instance_name, IterateUniformsCallback callback, void* user_data);
-    void                       GetUniformBufferLayout(uint32_t root_type_index, const ShaderResourceTypeInfo* types, uint32_t num_types, UniformBufferLayout* layout_desc);
     UniformBufferLayout*       AddUniformBufferLayout(Program* program, const ShaderResourceBinding* res, const ShaderResourceTypeInfo* type_infos, uint32_t num_type_infos);
 
     void FillProgramResourceBindings(Program& program,
@@ -370,7 +334,6 @@ namespace dmGraphics
     void                SetOverrideShaderLanguage(HContext context, ShaderDesc::ShaderType shader_class, ShaderDesc::Language language);
     const Uniform*      GetUniform(HProgram prog, dmhash_t name_hash);
     const ShaderMeta*   GetShaderMeta(HProgram prog);
-    void                UpdateShaderTypesOffsets(ShaderResourceTypeInfo* type_infos, uint32_t num_type_infos);
 }
 
 #endif // #ifndef DM_GRAPHICS_PRIVATE_H

--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -2033,6 +2033,9 @@ static void LogFrameBufferError(GLenum status)
         ubo->m_Id = AddNewGLHandle(context, buffer_handle);
         CHECK_GL_ERROR;
 
+        // Clear out UBO first
+        SetUniformBuffer(_context, (HUniformBuffer) ubo, 0, layout.m_Size, 0);
+
         return (HUniformBuffer) ubo;
     }
 
@@ -2045,11 +2048,15 @@ static void LogFrameBufferError(GLenum status)
         GLuint handle = GetGLHandle(context, ubo->m_Id);
 
         glBindBuffer(GL_UNIFORM_BUFFER, handle);
-        if (offset != 0)
+        if (size < ubo->m_BaseUniformBuffer.m_Layout.m_Size)
         {
             glBufferSubDataARB(GL_UNIFORM_BUFFER, offset, size, data);
+            CHECK_GL_ERROR;
         }
-        glBufferData(GL_UNIFORM_BUFFER, size, data, GL_STATIC_DRAW);
+        else
+        {
+            glBufferData(GL_UNIFORM_BUFFER, size, data, GL_STATIC_DRAW);
+        }
         glBindBuffer(GL_UNIFORM_BUFFER, 0);
     }
 

--- a/engine/graphics/src/vulkan/graphics_vulkan.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan.cpp
@@ -1797,11 +1797,16 @@ bail:
 
     static HUniformBuffer VulkanNewUniformBuffer(HContext _context, const UniformBufferLayout& layout)
     {
+        VulkanContext* context      = (VulkanContext*) _context;
         VulkanUniformBuffer* ubo    = new VulkanUniformBuffer();
         ubo->m_DeviceBuffer.m_Usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
         ubo->m_BaseUniformBuffer.m_Layout       = layout;
         ubo->m_BaseUniformBuffer.m_BoundSet     = UNUSED_BINDING_OR_SET;
         ubo->m_BaseUniformBuffer.m_BoundBinding = UNUSED_BINDING_OR_SET;
+
+        VkResult res = CreateDeviceBuffer(context->m_PhysicalDevice.m_Device, context->m_LogicalDevice.m_Device,
+            layout.m_Size, VK_MEMORY_PROPERTY_HOST_COHERENT_BIT | VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT, &ubo->m_DeviceBuffer);
+        CHECK_VK_ERROR(res);
 
         return (HUniformBuffer) ubo;
     }
@@ -1811,7 +1816,7 @@ bail:
         VulkanContext* context   = (VulkanContext*)_context;
         VulkanUniformBuffer* ubo = (VulkanUniformBuffer*) uniform_buffer;
         assert(offset + size <= ubo->m_BaseUniformBuffer.m_Layout.m_Size);
-        SetDeviceBuffer(context, &ubo->m_DeviceBuffer, size, offset, data);
+        DeviceBufferUploadHelper(context, data, size, offset, &ubo->m_DeviceBuffer);
     }
 
     static void VulkanDisableUniformBuffer(HContext _context, HUniformBuffer uniform_buffer)

--- a/engine/render/src/render/light.cpp
+++ b/engine/render/src/render/light.cpp
@@ -12,12 +12,13 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
+#include <math.h>
+
 #include "render.h"
 #include "render_private.h"
 
 namespace dmRender
 {
-
     static void CommitLightInstance(HRenderContext render_context, LightInstance* instance);
     static void CommitLightCount(HRenderContext render_context);
 
@@ -32,7 +33,7 @@ namespace dmRender
     , m_Intensity(1.0f)
     , m_Range(10.0f)
     , m_InnerConeAngle(0.0f)
-    , m_OuterConeAngle(3.1415926535f / 4.0f)
+    , m_OuterConeAngle(M_PI_4)
     {
     }
 

--- a/engine/render/src/render/light.cpp
+++ b/engine/render/src/render/light.cpp
@@ -222,17 +222,38 @@ namespace dmRender
 
     static inline void CommitLightInstance(HRenderContext render_context, LightInstance* instance)
     {
+        const LightPrototype* prototype = instance->m_LightPrototype;
+
         LightSTD140& light_std140 = render_context->m_LightBufferScratch[instance->m_LightBufferIndex];
         light_std140.m_Position = dmVMath::Vector4(instance->m_Position);
-        light_std140.m_Color = instance->m_LightPrototype->m_Color;
-        light_std140.m_DirectionRange = dmVMath::Vector4(
-            instance->m_Direction,
-            instance->m_LightPrototype->m_Range);
-        light_std140.m_Params = dmVMath::Vector4(
-            instance->m_LightPrototype->m_Type,
-            instance->m_LightPrototype->m_Intensity,
-            instance->m_LightPrototype->m_InnerConeAngle,
-            instance->m_LightPrototype->m_OuterConeAngle);
+        light_std140.m_Color    = prototype->m_Color;
+
+        dmVMath::Vector3 direction(0.0f, 0.0f, 0.0f);
+        float range      = 0.0f;
+        float inner_cone = 0.0f;
+        float outer_cone = 0.0f;
+
+        switch (prototype->m_Type)
+        {
+        case LIGHT_TYPE_DIRECTIONAL:
+            direction = instance->m_Direction;
+            break;
+        case LIGHT_TYPE_POINT:
+            range = prototype->m_Range;
+            break;
+        case LIGHT_TYPE_SPOT:
+            direction  = instance->m_Direction;
+            range      = prototype->m_Range;
+            inner_cone = prototype->m_InnerConeAngle;
+            outer_cone = prototype->m_OuterConeAngle;
+            break;
+        default:
+            assert("Light type not supported!");
+            break;
+        }
+
+        light_std140.m_DirectionRange = dmVMath::Vector4(direction, range);
+        light_std140.m_Params = dmVMath::Vector4((float) prototype->m_Type, prototype->m_Intensity, inner_cone, outer_cone);
 
         // Mark dirty range
         render_context->m_LightBufferDirtyStart = dmMath::Min(render_context->m_LightBufferDirtyStart, (uint32_t) instance->m_LightBufferIndex);

--- a/engine/render/src/render/light.cpp
+++ b/engine/render/src/render/light.cpp
@@ -17,15 +17,7 @@
 
 namespace dmRender
 {
-    static struct
-    {
-        dmGraphics::UniformBufferLayout m_LightBufferLayout;
-        uint32_t                        m_LightBufferDataWriteStart;
-        uint32_t                        m_MaxLightCount;
-        bool                            m_Initialized;
-    } g_LightBufferContext;
 
-    static void ResizeLightBuffer(HRenderContext render_context, uint32_t max_light_count);
     static void CommitLightInstance(HRenderContext render_context, LightInstance* instance);
     static void CommitLightCount(HRenderContext render_context);
 
@@ -69,21 +61,15 @@ namespace dmRender
 
     HLightInstance NewLightInstance(HRenderContext render_context, HLightPrototype light_prototype)
     {
-        const uint32_t lights_to_add = 32;
-
+        // Reached max count.
         if (render_context->m_RenderLightsIndices.Remaining() == 0)
         {
-            render_context->m_RenderLightsIndices.SetCapacity(render_context->m_RenderLightsIndices.Capacity() + lights_to_add);
+            return 0;
         }
+
         if (render_context->m_RenderLights.Full())
         {
-            render_context->m_RenderLights.Allocate(lights_to_add);
-        }
-        uint32_t scratch_size = render_context->m_RenderLightsIndices.Capacity();
-        if (render_context->m_LightBufferScratch.Capacity() < scratch_size)
-        {
-            render_context->m_LightBufferScratch.SetCapacity(scratch_size);
-            render_context->m_LightBufferScratch.SetSize(scratch_size);
+            render_context->m_RenderLights.Allocate(32);
         }
 
         LightInstance* light_instance      = new LightInstance;
@@ -91,6 +77,11 @@ namespace dmRender
         light_instance->m_Direction        = light_prototype->m_Direction;
         light_instance->m_LightPrototype   = light_prototype;
         light_instance->m_LightBufferIndex = render_context->m_RenderLightsIndices.Pop();
+
+        if (light_instance->m_LightBufferIndex >= render_context->m_LightBufferScratch.Size())
+        {
+            render_context->m_LightBufferScratch.SetSize(light_instance->m_LightBufferIndex+1);
+        }
 
         CommitLightInstance(render_context, light_instance);
         CommitLightCount(render_context);
@@ -122,7 +113,9 @@ namespace dmRender
     {
         LightInstance* light_instance = render_context->m_RenderLights.Get(instance);
         if (!light_instance)
+        {
             return;
+        }
 
         dmVMath::Vector3 direction = dmVMath::Rotate(rotation, light_instance->m_LightPrototype->m_Direction);
         bool needs_commit = !Vector3Equals(dmVMath::Vector3(position), dmVMath::Vector3(light_instance->m_Position)) || !Vector3Equals(direction, light_instance->m_Direction);
@@ -140,7 +133,7 @@ namespace dmRender
     // Light buffer
     ////////////////////////////////
 
-    static void GenerateDefaultUniformBufferLayout(int max_lights)
+    static void GenerateUniformBuffer(HRenderContext render_context, int max_lights)
     {
         /*
         struct Light
@@ -219,13 +212,12 @@ namespace dmRender
         light_types[1].m_Members     = light_members;
         light_types[1].m_MemberCount = DM_ARRAY_SIZE(light_members);
 
-        // Generate a new layout for the light buffer
+        dmGraphics::UniformBufferLayout layout;
         dmGraphics::UpdateShaderTypesOffsets(light_types, DM_ARRAY_SIZE(light_types));
-        dmGraphics::GetUniformBufferLayout(0, light_types, DM_ARRAY_SIZE(light_types), &g_LightBufferContext.m_LightBufferLayout);
+        dmGraphics::GetUniformBufferLayout(0, light_types, DM_ARRAY_SIZE(light_types), &layout);
 
-        g_LightBufferContext.m_Initialized = true;
-        g_LightBufferContext.m_MaxLightCount = max_lights;
-        g_LightBufferContext.m_LightBufferDataWriteStart = light_buffer_members[1].m_Offset;
+        render_context->m_LightUniformBuffer = dmGraphics::NewUniformBuffer(render_context->m_GraphicsContext, layout);
+        render_context->m_LightBufferDataWriteStart = light_buffer_members[1].m_Offset;
     }
 
     static inline void CommitLightInstance(HRenderContext render_context, LightInstance* instance)
@@ -243,8 +235,8 @@ namespace dmRender
             instance->m_LightPrototype->m_OuterConeAngle);
 
         // Mark dirty range
-        render_context->m_LightBufferDirtyStart = dmMath::Min(render_context->m_LightBufferDirtyStart, instance->m_LightBufferIndex);
-        render_context->m_LightBufferDirtyEnd = dmMath::Max(render_context->m_LightBufferDirtyEnd, (uint16_t) (instance->m_LightBufferIndex + 1));
+        render_context->m_LightBufferDirtyStart = dmMath::Min(render_context->m_LightBufferDirtyStart, (uint32_t) instance->m_LightBufferIndex);
+        render_context->m_LightBufferDirtyEnd = dmMath::Max(render_context->m_LightBufferDirtyEnd, (uint32_t) (instance->m_LightBufferIndex + 1));
     }
 
     static inline void CommitLightCount(HRenderContext render_context)
@@ -254,24 +246,23 @@ namespace dmRender
 
     static void WriteLightInstanceData(HRenderContext render_context)
     {
-        if (!render_context->m_LightUniformBuffer)
-        {
-            uint32_t min_size = dmMath::Max(1u, render_context->m_LightBufferScratch.Size());
-            ResizeLightBuffer(render_context, min_size);
-        }
-
         // The light count has changed, we need to write that separately
         if (render_context->m_LightBufferDirtyCount)
         {
+            // ... but only if it is actually different from last write.
             float count = (float) render_context->m_RenderLightsIndices.Size();
-            dmGraphics::SetUniformBuffer(render_context->m_GraphicsContext, render_context->m_LightUniformBuffer, 0, sizeof(float), &count);
+            if (count != render_context->m_LightBufferLastWrittenCount)
+            {
+                dmGraphics::SetUniformBuffer(render_context->m_GraphicsContext, render_context->m_LightUniformBuffer, 0, sizeof(float), &count);
+            }
+            render_context->m_LightBufferLastWrittenCount = count;
         }
 
         // Write the light data from the scratch buffer
         if (render_context->m_LightBufferDirtyEnd > render_context->m_LightBufferDirtyStart)
         {
             // Convert indices to byte offsets
-            uint32_t write_light_data_start = g_LightBufferContext.m_LightBufferDataWriteStart;
+            uint32_t write_light_data_start = render_context->m_LightBufferDataWriteStart;
             uint32_t write_start            = write_light_data_start + render_context->m_LightBufferDirtyStart * sizeof(LightSTD140);
             uint32_t write_end              = write_light_data_start + render_context->m_LightBufferDirtyEnd * sizeof(LightSTD140);
             uint32_t write_size             = write_end - write_start;
@@ -291,49 +282,31 @@ namespace dmRender
         return render_context->m_LightBufferDirtyEnd > render_context->m_LightBufferDirtyStart || render_context->m_LightBufferDirtyCount;
     }
 
-    static void ResizeLightBuffer(HRenderContext render_context, uint32_t max_light_count)
+    void InitializeLightData(HRenderContext render_context, uint32_t max_light_count)
     {
-        if (render_context->m_LightBufferScratch.Capacity() < max_light_count)
+        render_context->m_MaxLightCount = max_light_count;
+        render_context->m_LightUniformBuffer = 0;
+
+        if (max_light_count > 0)
         {
+            render_context->m_RenderLightsIndices.SetCapacity(max_light_count);
             render_context->m_LightBufferScratch.SetCapacity(max_light_count);
-            render_context->m_LightBufferScratch.SetSize(max_light_count);
+            GenerateUniformBuffer(render_context, max_light_count);
         }
+    }
 
-        if (!g_LightBufferContext.m_Initialized)
-        {
-            GenerateDefaultUniformBufferLayout(max_light_count);
-        }
-        else if (max_light_count != g_LightBufferContext.m_MaxLightCount)
-        {
-            dmLogOnceWarning("Using different sizes of light buffers is not supported. You should use the same size everywhere for the uniform buffer!");
-        }
-
+    void FinalizeLightData(HRenderContext render_context)
+    {
         if (render_context->m_LightUniformBuffer)
         {
             dmGraphics::DeleteUniformBuffer(render_context->m_GraphicsContext, render_context->m_LightUniformBuffer);
         }
-        render_context->m_LightUniformBuffer = dmGraphics::NewUniformBuffer(render_context->m_GraphicsContext, g_LightBufferContext.m_LightBufferLayout);
-
-        // Dirty the entire range of lights
-        render_context->m_LightBufferDirtyStart = 0;
-        render_context->m_LightBufferDirtyEnd   = render_context->m_LightBufferScratch.Size();
-    }
-
-    void InitializeLightData(HRenderContext render_context)
-    {
-        render_context->m_RenderLightsIndices.SetCapacity(4);
     }
 
     void ApplyMaterialProgramLightBuffers(HRenderContext render_context, HMaterial material)
     {
         if (material->m_HasLightBuffer)
         {
-            // The lightbuffer needs to match the material
-            if (material->m_LightBufferLightsCount != render_context->m_LightBufferScratch.Size())
-            {
-                ResizeLightBuffer(render_context, material->m_LightBufferLightsCount);
-            }
-
             if (IsLightBufferDirty(render_context))
             {
                 WriteLightInstanceData(render_context);

--- a/engine/render/src/render/light.cpp
+++ b/engine/render/src/render/light.cpp
@@ -1,0 +1,348 @@
+// Copyright 2020-2026 The Defold Foundation
+// Copyright 2014-2020 King
+// Copyright 2009-2014 Ragnar Svensson, Christian Murray
+// Licensed under the Defold License version 1.0 (the "License"); you may not use
+// this file except in compliance with the License.
+//
+// You may obtain a copy of the License, together with FAQs at
+// https://www.defold.com/license
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#include "render.h"
+#include "render_private.h"
+
+namespace dmRender
+{
+    static struct
+    {
+        dmGraphics::UniformBufferLayout m_LightBufferLayout;
+        uint32_t                        m_LightBufferDataWriteStart;
+        uint32_t                        m_MaxLightCount;
+        bool                            m_Initialized;
+    } g_LightBufferContext;
+
+    static void ResizeLightBuffer(HRenderContext render_context, uint32_t max_light_count);
+    static void CommitLightInstance(HRenderContext render_context, LightInstance* instance);
+    static void CommitLightCount(HRenderContext render_context);
+
+    ////////////////////////////////
+    // Light prototype
+    ////////////////////////////////
+
+    LightPrototypeParams::LightPrototypeParams()
+    : m_Type(LIGHT_TYPE_POINT)
+    , m_Color(1.0f, 1.0f, 1.0f, 1.0f)
+    , m_Direction(0.0f, 0.0f, -1.0f)
+    , m_Intensity(1.0f)
+    , m_Range(10.0f)
+    , m_InnerConeAngle(0.0f)
+    , m_OuterConeAngle(3.1415926535f / 4.0f)
+    {
+    }
+
+    HLightPrototype NewLightPrototype(HRenderContext render_context, const LightPrototypeParams& params)
+    {
+        LightPrototype* lp = new LightPrototype;
+        memset(lp, 0, sizeof(LightPrototype));
+        lp->m_Type = params.m_Type;
+        lp->m_Color = params.m_Color;
+        lp->m_Intensity = params.m_Intensity;
+        lp->m_Direction = params.m_Direction;
+        lp->m_Range = params.m_Range;
+        lp->m_InnerConeAngle = params.m_InnerConeAngle;
+        lp->m_OuterConeAngle = params.m_OuterConeAngle;
+        return lp;
+    }
+
+    void DeleteLightPrototype(HRenderContext render_context, HLightPrototype light_prototype)
+    {
+        delete light_prototype;
+    }
+
+    ////////////////////////////////
+    // Light instance
+    ////////////////////////////////
+
+    HLightInstance NewLightInstance(HRenderContext render_context, HLightPrototype light_prototype)
+    {
+        const uint32_t lights_to_add = 32;
+
+        if (render_context->m_RenderLightsIndices.Remaining() == 0)
+        {
+            render_context->m_RenderLightsIndices.SetCapacity(render_context->m_RenderLightsIndices.Capacity() + lights_to_add);
+        }
+        if (render_context->m_RenderLights.Full())
+        {
+            render_context->m_RenderLights.Allocate(lights_to_add);
+        }
+        uint32_t scratch_size = render_context->m_RenderLightsIndices.Capacity();
+        if (render_context->m_LightBufferScratch.Capacity() < scratch_size)
+        {
+            render_context->m_LightBufferScratch.SetCapacity(scratch_size);
+            render_context->m_LightBufferScratch.SetSize(scratch_size);
+        }
+
+        LightInstance* light_instance      = new LightInstance;
+        light_instance->m_Position         = dmVMath::Point3();
+        light_instance->m_Direction        = light_prototype->m_Direction;
+        light_instance->m_LightPrototype   = light_prototype;
+        light_instance->m_LightBufferIndex = render_context->m_RenderLightsIndices.Pop();
+
+        CommitLightInstance(render_context, light_instance);
+        CommitLightCount(render_context);
+
+        return render_context->m_RenderLights.Put(light_instance);
+    }
+
+    void DeleteLightInstance(HRenderContext render_context, HLightInstance instance)
+    {
+        LightInstance* light_instance = render_context->m_RenderLights.Get(instance);
+        if (light_instance)
+        {
+            render_context->m_RenderLightsIndices.Push(light_instance->m_LightBufferIndex);
+            render_context->m_RenderLights.Release(instance);
+            delete light_instance;
+            CommitLightCount(render_context);
+        }
+    }
+
+    static inline bool Vector3Equals(const dmVMath::Vector3& a, const dmVMath::Vector3& b)
+    {
+        const float eps = 1e-4f;
+        dmVMath::Vector3 diff = a - b;
+        float dist2 = dmVMath::LengthSqr(diff);
+        return dist2 <= eps * eps;
+    }
+
+    void SetLightInstance(HRenderContext render_context, HLightInstance instance, dmVMath::Point3 position, dmVMath::Quat rotation)
+    {
+        LightInstance* light_instance = render_context->m_RenderLights.Get(instance);
+        if (!light_instance)
+            return;
+
+        dmVMath::Vector3 direction = dmVMath::Rotate(rotation, light_instance->m_LightPrototype->m_Direction);
+        bool needs_commit = !Vector3Equals(dmVMath::Vector3(position), dmVMath::Vector3(light_instance->m_Position)) || !Vector3Equals(direction, light_instance->m_Direction);
+
+        light_instance->m_Position = position;
+        light_instance->m_Direction = direction;
+
+        if (needs_commit)
+        {
+            CommitLightInstance(render_context, light_instance);
+        }
+    }
+
+    ////////////////////////////////
+    // Light buffer
+    ////////////////////////////////
+
+    static void GenerateDefaultUniformBufferLayout(int max_lights)
+    {
+        /*
+        struct Light
+        {
+            vec4 position;        // xyz: position, w: unused
+            vec4 color;           // RGBA (matches LightParams order)
+            vec4 direction_range; // xyz: normalized direction; w: range
+            vec4 params;          // x: type (0 dir, 1 point, 2 spot; matches dmRender::LightType)
+                                  // y: intensity
+                                  // z: innerConeAngle (radians, spot only)
+                                  // w: outerConeAngle (radians, spot only)
+        };
+        uniform LightBuffer
+        {
+            vec4  lights_count;   // x: number of active lights
+            Light lights[MAX_LIGHTS];
+        };
+        */
+
+        dmGraphics::ShaderResourceMember   light_buffer_members[2];
+        dmGraphics::ShaderResourceMember   light_members[4];
+        dmGraphics::ShaderResourceTypeInfo light_types[2];
+
+        // Ensure all fields (including bitfields) are initialized
+        memset(light_buffer_members, 0, sizeof(light_buffer_members));
+        memset(light_members, 0, sizeof(light_members));
+        memset(light_types, 0, sizeof(light_types));
+
+        // lights_count (vec4)
+        light_buffer_members[0].m_Name                 = (char*)"lights_count";
+        light_buffer_members[0].m_NameHash             = dmHashString64("lights_count");
+        light_buffer_members[0].m_Type.m_ShaderType    = dmGraphics::ShaderDesc::SHADER_TYPE_VEC4;
+        light_buffer_members[0].m_Type.m_UseTypeIndex  = 0;
+        light_buffer_members[0].m_ElementCount         = 1;
+        // lights
+        light_buffer_members[1].m_Name                 = (char*)"lights";
+        light_buffer_members[1].m_NameHash             = dmHashString64("lights");
+        light_buffer_members[1].m_Type.m_ShaderType    = dmGraphics::ShaderDesc::SHADER_TYPE_FLOAT;
+        light_buffer_members[1].m_ElementCount         = max_lights;
+        light_buffer_members[1].m_Type.m_TypeIndex     = 1; // index into ShaderResourceTypeInfo[]
+        light_buffer_members[1].m_Type.m_UseTypeIndex  = 1;
+
+        // vec4 position
+        light_members[0].m_Name                 = (char*)"position";
+        light_members[0].m_NameHash             = dmHashString64("position");
+        light_members[0].m_Type.m_ShaderType    = dmGraphics::ShaderDesc::SHADER_TYPE_VEC4;
+        light_members[0].m_Type.m_UseTypeIndex  = 0;
+        light_members[0].m_ElementCount         = 1;
+        // vec4 color
+        light_members[1].m_Name                 = (char*)"color";
+        light_members[1].m_NameHash             = dmHashString64("color");
+        light_members[1].m_Type.m_ShaderType    = dmGraphics::ShaderDesc::SHADER_TYPE_VEC4;
+        light_members[1].m_Type.m_UseTypeIndex  = 0;
+        light_members[1].m_ElementCount         = 1;
+        // vec4 direction (xyz: direction, w: range)
+        light_members[2].m_Name                 = (char*)"direction_range";
+        light_members[2].m_NameHash             = dmHashString64("direction_range");
+        light_members[2].m_Type.m_ShaderType    = dmGraphics::ShaderDesc::SHADER_TYPE_VEC4;
+        light_members[2].m_Type.m_UseTypeIndex  = 0;
+        light_members[2].m_ElementCount         = 1;
+        // vec4 params (x: type, y: intensity, z: innerConeAngle, w: outerConeAngle)
+        light_members[3].m_Name                 = (char*)"params";
+        light_members[3].m_NameHash             = dmHashString64("params");
+        light_members[3].m_Type.m_ShaderType    = dmGraphics::ShaderDesc::SHADER_TYPE_VEC4;
+        light_members[3].m_Type.m_UseTypeIndex  = 0;
+        light_members[3].m_ElementCount         = 1;
+
+        // LightBuffer (index 1)
+        light_types[0].m_Name        = (char*)"LightBuffer";
+        light_types[0].m_NameHash    = dmHashString64("LightBuffer");
+        light_types[0].m_Members     = light_buffer_members;
+        light_types[0].m_MemberCount = DM_ARRAY_SIZE(light_buffer_members);
+        // Light (index 0)
+        light_types[1].m_Name        = (char*)"Light";
+        light_types[1].m_NameHash    = dmHashString64("Light");
+        light_types[1].m_Members     = light_members;
+        light_types[1].m_MemberCount = DM_ARRAY_SIZE(light_members);
+
+        // Generate a new layout for the light buffer
+        dmGraphics::UpdateShaderTypesOffsets(light_types, DM_ARRAY_SIZE(light_types));
+        dmGraphics::GetUniformBufferLayout(0, light_types, DM_ARRAY_SIZE(light_types), &g_LightBufferContext.m_LightBufferLayout);
+
+        g_LightBufferContext.m_Initialized = true;
+        g_LightBufferContext.m_MaxLightCount = max_lights;
+        g_LightBufferContext.m_LightBufferDataWriteStart = light_buffer_members[1].m_Offset;
+    }
+
+    static inline void CommitLightInstance(HRenderContext render_context, LightInstance* instance)
+    {
+        LightSTD140& light_std140 = render_context->m_LightBufferScratch[instance->m_LightBufferIndex];
+        light_std140.m_Position = dmVMath::Vector4(instance->m_Position);
+        light_std140.m_Color = instance->m_LightPrototype->m_Color;
+        light_std140.m_DirectionRange = dmVMath::Vector4(
+            instance->m_Direction,
+            instance->m_LightPrototype->m_Range);
+        light_std140.m_Params = dmVMath::Vector4(
+            instance->m_LightPrototype->m_Type,
+            instance->m_LightPrototype->m_Intensity,
+            instance->m_LightPrototype->m_InnerConeAngle,
+            instance->m_LightPrototype->m_OuterConeAngle);
+
+        // Mark dirty range
+        render_context->m_LightBufferDirtyStart = dmMath::Min(render_context->m_LightBufferDirtyStart, instance->m_LightBufferIndex);
+        render_context->m_LightBufferDirtyEnd = dmMath::Max(render_context->m_LightBufferDirtyEnd, (uint16_t) (instance->m_LightBufferIndex + 1));
+    }
+
+    static inline void CommitLightCount(HRenderContext render_context)
+    {
+        render_context->m_LightBufferDirtyCount = 1;
+    }
+
+    static void WriteLightInstanceData(HRenderContext render_context)
+    {
+        if (!render_context->m_LightUniformBuffer)
+        {
+            uint32_t min_size = dmMath::Max(1u, render_context->m_LightBufferScratch.Size());
+            ResizeLightBuffer(render_context, min_size);
+        }
+
+        // The light count has changed, we need to write that separately
+        if (render_context->m_LightBufferDirtyCount)
+        {
+            float count = (float) render_context->m_RenderLightsIndices.Size();
+            dmGraphics::SetUniformBuffer(render_context->m_GraphicsContext, render_context->m_LightUniformBuffer, 0, sizeof(float), &count);
+        }
+
+        // Write the light data from the scratch buffer
+        if (render_context->m_LightBufferDirtyEnd > render_context->m_LightBufferDirtyStart)
+        {
+            // Convert indices to byte offsets
+            uint32_t write_light_data_start = g_LightBufferContext.m_LightBufferDataWriteStart;
+            uint32_t write_start            = write_light_data_start + render_context->m_LightBufferDirtyStart * sizeof(LightSTD140);
+            uint32_t write_end              = write_light_data_start + render_context->m_LightBufferDirtyEnd * sizeof(LightSTD140);
+            uint32_t write_size             = write_end - write_start;
+            LightSTD140* write_ptr_start    = &render_context->m_LightBufferScratch[render_context->m_LightBufferDirtyStart];
+
+            dmGraphics::SetUniformBuffer(render_context->m_GraphicsContext, render_context->m_LightUniformBuffer, write_start, write_size, (void*) write_ptr_start);
+        }
+
+        // Reset all dirty flags
+        render_context->m_LightBufferDirtyStart = render_context->m_LightBufferScratch.Size();
+        render_context->m_LightBufferDirtyEnd   = 0;
+        render_context->m_LightBufferDirtyCount = 0;
+    }
+
+    static inline bool IsLightBufferDirty(HRenderContext render_context)
+    {
+        return render_context->m_LightBufferDirtyEnd > render_context->m_LightBufferDirtyStart || render_context->m_LightBufferDirtyCount;
+    }
+
+    static void ResizeLightBuffer(HRenderContext render_context, uint32_t max_light_count)
+    {
+        if (render_context->m_LightBufferScratch.Capacity() < max_light_count)
+        {
+            render_context->m_LightBufferScratch.SetCapacity(max_light_count);
+            render_context->m_LightBufferScratch.SetSize(max_light_count);
+        }
+
+        if (!g_LightBufferContext.m_Initialized)
+        {
+            GenerateDefaultUniformBufferLayout(max_light_count);
+        }
+        else if (max_light_count != g_LightBufferContext.m_MaxLightCount)
+        {
+            dmLogOnceWarning("Using different sizes of light buffers is not supported. You should use the same size everywhere for the uniform buffer!");
+        }
+
+        if (render_context->m_LightUniformBuffer)
+        {
+            dmGraphics::DeleteUniformBuffer(render_context->m_GraphicsContext, render_context->m_LightUniformBuffer);
+        }
+        render_context->m_LightUniformBuffer = dmGraphics::NewUniformBuffer(render_context->m_GraphicsContext, g_LightBufferContext.m_LightBufferLayout);
+
+        // Dirty the entire range of lights
+        render_context->m_LightBufferDirtyStart = 0;
+        render_context->m_LightBufferDirtyEnd   = render_context->m_LightBufferScratch.Size();
+    }
+
+    void InitializeLightData(HRenderContext render_context)
+    {
+        render_context->m_RenderLightsIndices.SetCapacity(4);
+    }
+
+    void ApplyMaterialProgramLightBuffers(HRenderContext render_context, HMaterial material)
+    {
+        if (material->m_HasLightBuffer)
+        {
+            // The lightbuffer needs to match the material
+            if (material->m_LightBufferLightsCount != render_context->m_LightBufferScratch.Size())
+            {
+                ResizeLightBuffer(render_context, material->m_LightBufferLightsCount);
+            }
+
+            if (IsLightBufferDirty(render_context))
+            {
+                WriteLightInstanceData(render_context);
+            }
+
+            dmGraphics::EnableUniformBuffer(render_context->m_GraphicsContext,
+                                            render_context->m_LightUniformBuffer,
+                                            material->m_LightBufferSet,
+                                            material->m_LightBufferBinding);
+        }
+    }
+}

--- a/engine/render/src/render/material.cpp
+++ b/engine/render/src/render/material.cpp
@@ -303,22 +303,36 @@ namespace dmRender
         material->m_HasSkinnedMatrixCache = material->m_NameHashToLocation.Get(SAMPLER_POSE_MATRIX_CACHE) != 0x0;
     }
 
+    struct LightBufferConfigurationCallbackContext
+    {
+        RenderContext* m_Context;
+        Material* m_Material;
+    };
+
     static void LightBufferConfigurationCallback(uint16_t set, uint16_t binding, const dmGraphics::ShaderResourceTypeInfo* root_type, void* user_data)
     {
-        Material* material = (Material*) user_data;
+        LightBufferConfigurationCallbackContext* cb_ctx = (LightBufferConfigurationCallbackContext*) user_data;
+        Material* material = cb_ctx->m_Material;
 
         if (material->m_HasLightBuffer || root_type->m_NameHash != LIGHT_BUFFER_TYPE)
         {
             return;
         }
 
+        uint32_t ubo_light_count = 0;
         for (uint32_t i = 0; i < root_type->m_MemberCount; ++i)
         {
             if (root_type->m_Members[i].m_NameHash == LIGHT_MEMBER_TYPE)
             {
-                material->m_LightBufferLightsCount = root_type->m_Members[i].m_ElementCount;
+                ubo_light_count = root_type->m_Members[i].m_ElementCount;
                 break;
             }
+        }
+
+        if (cb_ctx->m_Context->m_MaxLightCount != ubo_light_count)
+        {
+            dmLogOnceWarning("The size of the light buffer must match the project configuration. You should use the same size everywhere for the uniform buffer!");
+            return;
         }
 
         // Only one light buffer binding is currently supported.
@@ -348,7 +362,10 @@ namespace dmRender
         CreateConstants(graphics_context, m);
 
         // Loop over the uniform buffers resources to check if there is a light uniform buffer present.
-        dmGraphics::IterateProgramResourceBindings(m->m_Program, dmGraphics::BINDING_FAMILY_UNIFORM_BUFFER, LightBufferConfigurationCallback, m);
+        LightBufferConfigurationCallbackContext cb_ctx;
+        cb_ctx.m_Context = render_context;
+        cb_ctx.m_Material = m;
+        dmGraphics::IterateProgramResourceBindings(m->m_Program, dmGraphics::BINDING_FAMILY_UNIFORM_BUFFER, LightBufferConfigurationCallback, &cb_ctx);
 
         return (HMaterial)m;
     }

--- a/engine/render/src/render/material.cpp
+++ b/engine/render/src/render/material.cpp
@@ -29,6 +29,9 @@ namespace dmRender
 {
     using namespace dmVMath;
 
+    static const dmhash_t LIGHT_BUFFER_TYPE = dmHashString64("LightBuffer");
+    static const dmhash_t LIGHT_MEMBER_TYPE = dmHashString64("lights");
+
     static inline dmGraphics::VertexAttribute::VectorType GetAttributeVectorType(dmGraphics::Type from_type)
     {
         switch(from_type)
@@ -300,6 +303,35 @@ namespace dmRender
         material->m_HasSkinnedMatrixCache = material->m_NameHashToLocation.Get(SAMPLER_POSE_MATRIX_CACHE) != 0x0;
     }
 
+    static void LightBufferConfigurationCallback(uint16_t set, uint16_t binding, const dmGraphics::ShaderResourceTypeInfo* root_type, void* user_data)
+    {
+        Material* material = (Material*) user_data;
+
+        if (material->m_HasLightBuffer)
+        {
+            return;
+        }
+
+        if (!root_type || root_type->m_NameHash != LIGHT_BUFFER_TYPE)
+        {
+            return;
+        }
+
+        for (uint32_t i = 0; i < root_type->m_MemberCount; ++i)
+        {
+            if (root_type->m_Members[i].m_NameHash == LIGHT_MEMBER_TYPE)
+            {
+                material->m_LightBufferLightsCount = root_type->m_Members[i].m_ElementCount;
+                break;
+            }
+        }
+
+        // Only one light buffer binding is currently supported.
+        material->m_HasLightBuffer     = true;
+        material->m_LightBufferSet     = (uint8_t) set;
+        material->m_LightBufferBinding = (uint8_t) binding;
+    }
+
     HMaterial NewMaterial(dmRender::HRenderContext render_context, dmGraphics::HProgram program)
     {
         dmGraphics::HContext graphics_context = dmRender::GetGraphicsContext(render_context);
@@ -319,6 +351,8 @@ namespace dmRender
         CreateAttributes(graphics_context, m);
         CreateVertexDeclarations(graphics_context, m);
         CreateConstants(graphics_context, m);
+
+        dmGraphics::IterateProgramResourceBindings(m->m_Program, dmGraphics::BINDING_FAMILY_UNIFORM_BUFFER, LightBufferConfigurationCallback, m);
 
         return (HMaterial)m;
     }

--- a/engine/render/src/render/material.cpp
+++ b/engine/render/src/render/material.cpp
@@ -307,12 +307,7 @@ namespace dmRender
     {
         Material* material = (Material*) user_data;
 
-        if (material->m_HasLightBuffer)
-        {
-            return;
-        }
-
-        if (!root_type || root_type->m_NameHash != LIGHT_BUFFER_TYPE)
+        if (material->m_HasLightBuffer || root_type->m_NameHash != LIGHT_BUFFER_TYPE)
         {
             return;
         }
@@ -352,6 +347,7 @@ namespace dmRender
         CreateVertexDeclarations(graphics_context, m);
         CreateConstants(graphics_context, m);
 
+        // Loop over the uniform buffers resources to check if there is a light uniform buffer present.
         dmGraphics::IterateProgramResourceBindings(m->m_Program, dmGraphics::BINDING_FAMILY_UNIFORM_BUFFER, LightBufferConfigurationCallback, m);
 
         return (HMaterial)m;

--- a/engine/render/src/render/render.cpp
+++ b/engine/render/src/render/render.cpp
@@ -100,6 +100,7 @@ namespace dmRender
     , m_MaxCharacters(0)
     , m_CommandBufferSize(1024)
     , m_MaxDebugVertexCount(0)
+    , m_MaxLights(0)
     {
 
     }
@@ -166,7 +167,7 @@ namespace dmRender
 
         SetupContextEventCallback(context, &OnContextEvent);
 
-        InitializeLightData(context);
+        InitializeLightData(context, params.m_MaxLights);
 
         dmMessage::Result r = dmMessage::NewSocket(RENDER_SOCKET_NAME, &context->m_Socket);
         assert(r == dmMessage::RESULT_OK);
@@ -187,6 +188,7 @@ namespace dmRender
         dmScript::DeleteScriptWorld(render_context->m_ScriptWorld);
         FinalizeDebugRenderer(render_context);
         FinalizeTextContext(render_context);
+        FinalizeLightData(render_context);
         dmMessage::DeleteSocket(render_context->m_Socket);
         delete render_context;
 

--- a/engine/render/src/render/render.cpp
+++ b/engine/render/src/render/render.cpp
@@ -166,6 +166,8 @@ namespace dmRender
 
         SetupContextEventCallback(context, &OnContextEvent);
 
+        InitializeLightData(context);
+
         dmMessage::Result r = dmMessage::NewSocket(RENDER_SOCKET_NAME, &context->m_Socket);
         assert(r == dmMessage::RESULT_OK);
         return context;
@@ -1178,6 +1180,8 @@ namespace dmRender
                     }
                 }
             }
+
+            ApplyMaterialProgramLightBuffers(render_context, material);
 
             dmGraphics::HProgram material_program = GetMaterialProgram(material);
 

--- a/engine/render/src/render/render.h
+++ b/engine/render/src/render/render.h
@@ -177,6 +177,7 @@ namespace dmRender
         uint32_t                        m_MaxCharacters;
         uint32_t                        m_MaxBatches;
         uint32_t                        m_CommandBufferSize;
+        uint32_t                        m_MaxLights;
         /// Max debug vertex count
         /// NOTE: This is per debug-type and not the total sum
         uint32_t                        m_MaxDebugVertexCount;

--- a/engine/render/src/render/render.h
+++ b/engine/render/src/render/render.h
@@ -59,6 +59,8 @@ namespace dmRender
     typedef uintptr_t                       HRenderBuffer;
     typedef struct BufferedRenderBuffer*    HBufferedRenderBuffer;
     typedef HOpaqueHandle                   HRenderCamera;
+    typedef struct LightPrototype*          HLightPrototype;
+    typedef HOpaqueHandle                   HLightInstance;
 
     static const uint8_t RENDERLIST_INVALID_DISPATCH       = 0xff;
     static const HRenderType INVALID_RENDER_TYPE_HANDLE    = ~0ULL;
@@ -119,6 +121,22 @@ namespace dmRender
         SORT_NONE          = 3
     };
 
+    enum LightType
+    {
+        LIGHT_TYPE_DIRECTIONAL = 0,
+        LIGHT_TYPE_POINT       = 1,
+        LIGHT_TYPE_SPOT        = 2,
+    };
+
+    // NOTE: These enum values are duplicated in gamesys camera DDF (camera_ddf.proto)
+    // Don't forget to change dmGamesysDDF::OrthoZoomMode if you change here
+    enum OrthoZoomMode
+    {
+        ORTHO_MODE_FIXED        = 0,
+        ORTHO_MODE_AUTO_FIT     = 1,
+        ORTHO_MODE_AUTO_COVER   = 2,
+    };
+
     struct Predicate
     {
         static const uint32_t MAX_TAG_COUNT = 32;
@@ -164,15 +182,6 @@ namespace dmRender
         uint32_t                        m_MaxDebugVertexCount;
     };
 
-    // NOTE: These enum values are duplicated in gamesys camera DDF (camera_ddf.proto)
-    // Don't forget to change dmGamesysDDF::OrthoZoomMode if you change here
-    enum OrthoZoomMode
-    {
-        ORTHO_MODE_FIXED        = 0,
-        ORTHO_MODE_AUTO_FIT     = 1,
-        ORTHO_MODE_AUTO_COVER   = 2,
-    };
-
     struct RenderCameraData
     {
         dmVMath::Vector4 m_Viewport;
@@ -194,6 +203,19 @@ namespace dmRender
         const uint8_t*                         m_ValuePtr;
         dmhash_t                               m_ElementIds[4];
         uint32_t                               m_ElementIndex;
+    };
+
+    struct LightPrototypeParams
+    {
+        LightPrototypeParams();
+
+        LightType        m_Type;
+        dmVMath::Vector4 m_Color;
+        dmVMath::Vector3 m_Direction;
+        float            m_Intensity;
+        float            m_Range;
+        float            m_InnerConeAngle;
+        float            m_OuterConeAngle;
     };
 
     HRenderContext NewRenderContext(dmGraphics::HContext graphics_context, const RenderContextParams& params);
@@ -439,6 +461,19 @@ namespace dmRender
     void                            SetRenderCameraEnabled(HRenderContext render_context, HRenderCamera camera, bool value);
     void                            UpdateRenderCamera(HRenderContext render_context, HRenderCamera camera, const dmVMath::Point3* position, const dmVMath::Quat* rotation);
     float                           GetRenderCameraEffectiveAspectRatio(HRenderContext render_context, HRenderCamera camera);
+
+    /** Lights
+     * A light prototype is essentially the data that represents the light and has a set of basic parameters,
+     * such as color, range and whatnot. A light 'instance' on the other hand is what exists in the game world,
+     * and is the basis for what's being written into the light buffer. It has a position and a rotation (direction),
+     * and in the future it is likely that a light instance can override certain parameters of the light prototype.
+     * A light prototype can be used across many light instances, and must live as long as the lights live.
+     */
+    HLightPrototype NewLightPrototype(HRenderContext render_context, const LightPrototypeParams& params);
+    void            DeleteLightPrototype(HRenderContext render_context, HLightPrototype light_prototype);
+    HLightInstance  NewLightInstance(HRenderContext render_context, HLightPrototype light_prototype);
+    void            DeleteLightInstance(HRenderContext render_context, HLightInstance light_instance);
+    void            SetLightInstance(HRenderContext render_context, HLightInstance light_instance, dmVMath::Point3 position, dmVMath::Quat rotation);
 
     static inline dmGraphics::TextureWrap WrapFromDDF(dmRenderDDF::MaterialDesc::WrapMode wrap_mode)
     {

--- a/engine/render/src/render/render_private.h
+++ b/engine/render/src/render/render_private.h
@@ -101,7 +101,6 @@ namespace dmRender
         dmRenderDDF::MaterialDesc::PbrParameters    m_PbrParameters;
         uint32_t                                    m_TagListKey; // the key to use with GetMaterialTagList()
         dmRenderDDF::MaterialDesc::VertexSpace      m_VertexSpace;
-        uint16_t                                    m_LightBufferLightsCount;
         uint8_t                                     m_LightBufferSet;
         uint8_t                                     m_LightBufferBinding;
         uint8_t                                     m_HasLightBuffer : 1;
@@ -275,9 +274,9 @@ namespace dmRender
 
     struct LightPrototype
     {
-        LightType        m_Type;
         dmVMath::Vector4 m_Color;
         dmVMath::Vector3 m_Direction;
+        LightType        m_Type;
         float            m_Intensity;
         float            m_Range;
         float            m_InnerConeAngle;
@@ -327,7 +326,9 @@ namespace dmRender
 
         dmOpaqueHandleContainer<LightInstance> m_RenderLights;
         dmIndexPool16                          m_RenderLightsIndices;
+
         dmArray<LightSTD140>                   m_LightBufferScratch;
+        dmGraphics::UniformBufferLayout        m_LightBufferLayout;
         dmGraphics::HUniformBuffer             m_LightUniformBuffer;
 
         HFontMap                    m_SystemFontMap;
@@ -340,14 +341,18 @@ namespace dmRender
         HMaterial                   m_Material;
         HComputeProgram             m_ComputeProgram;
         dmMessage::HSocket          m_Socket;
-        uint16_t                    m_LightBufferDirtyStart;
-        uint16_t                    m_LightBufferDirtyEnd;
-        uint32_t                    m_LightBufferDirtyCount         : 1;
-        uint32_t                    m_OutOfResources                : 1;
-        uint32_t                    m_StencilBufferCleared          : 1;
-        uint32_t                    m_MultiBufferingRequired        : 1;
-        uint32_t                    m_CurrentRenderCameraUseFrustum : 1;
-        uint32_t                    m_IsRenderPaused                : 1;
+
+        uint32_t                    m_LightBufferDirtyStart;
+        uint32_t                    m_LightBufferDirtyEnd;
+        uint32_t                    m_LightBufferDataWriteStart;
+        uint32_t                    m_LightBufferLastWrittenCount;
+        uint16_t                    m_MaxLightCount;
+        uint16_t                    m_LightBufferDirtyCount         : 1;
+        uint16_t                    m_OutOfResources                : 1;
+        uint16_t                    m_StencilBufferCleared          : 1;
+        uint16_t                    m_MultiBufferingRequired        : 1;
+        uint16_t                    m_CurrentRenderCameraUseFrustum : 1;
+        uint16_t                    m_IsRenderPaused                : 1;
     };
 
     struct BufferedRenderBuffer
@@ -400,7 +405,8 @@ namespace dmRender
     RenderCamera* CheckRenderCamera(lua_State* L, int index, HRenderContext render_context);
 
     // Lights
-    void InitializeLightData(HRenderContext render_context);
+    void InitializeLightData(HRenderContext render_context, uint32_t max_light_count);
+    void FinalizeLightData(HRenderContext render_context);
     void ApplyMaterialProgramLightBuffers(HRenderContext render_context, HMaterial material);
 
     // Exposed here for unit testing

--- a/engine/render/src/render/render_private.h
+++ b/engine/render/src/render/render_private.h
@@ -18,11 +18,12 @@
 #include <string.h> // For memset
 
 #include <dmsdk/dlib/vmath.h>
-#include <dlib/opaque_handle_container.h>
 
+#include <dlib/opaque_handle_container.h>
 #include <dlib/array.h>
 #include <dlib/message.h>
 #include <dlib/hashtable.h>
+#include <dlib/index_pool.h>
 
 #include "render.h"
 
@@ -100,6 +101,10 @@ namespace dmRender
         dmRenderDDF::MaterialDesc::PbrParameters    m_PbrParameters;
         uint32_t                                    m_TagListKey; // the key to use with GetMaterialTagList()
         dmRenderDDF::MaterialDesc::VertexSpace      m_VertexSpace;
+        uint16_t                                    m_LightBufferLightsCount;
+        uint8_t                                     m_LightBufferSet;
+        uint8_t                                     m_LightBufferBinding;
+        uint8_t                                     m_HasLightBuffer : 1;
         uint8_t                                     m_InstancingSupported : 1;
         uint8_t                                     m_HasSkinnedAttributes : 1;
         uint8_t                                     m_HasSkinnedMatrixCache : 1;
@@ -268,6 +273,34 @@ namespace dmRender
         uint8_t          m_Enabled    : 1;
     };
 
+    struct LightPrototype
+    {
+        LightType        m_Type;
+        dmVMath::Vector4 m_Color;
+        dmVMath::Vector3 m_Direction;
+        float            m_Intensity;
+        float            m_Range;
+        float            m_InnerConeAngle;
+        float            m_OuterConeAngle;
+    };
+
+    struct LightInstance
+    {
+        dmVMath::Point3       m_Position;
+        dmVMath::Vector3      m_Direction;
+        const LightPrototype* m_LightPrototype;
+        uint16_t              m_LightBufferIndex;
+    };
+
+    // CPU-mapped representation of a light in STD140 layout
+    struct LightSTD140
+    {
+        dmVMath::Vector4 m_Position;
+        dmVMath::Vector4 m_Color;
+        dmVMath::Vector4 m_DirectionRange;
+        dmVMath::Vector4 m_Params;
+    };
+
     struct RenderContext
     {
         DebugRenderer               m_DebugRenderer;
@@ -292,6 +325,11 @@ namespace dmRender
         dmOpaqueHandleContainer<RenderCamera> m_RenderCameras;
         HRenderCamera                         m_CurrentRenderCamera; // When != 0, the renderer will use the matrices from this camera.
 
+        dmOpaqueHandleContainer<LightInstance> m_RenderLights;
+        dmIndexPool16                          m_RenderLightsIndices;
+        dmArray<LightSTD140>                   m_LightBufferScratch;
+        dmGraphics::HUniformBuffer             m_LightUniformBuffer;
+
         HFontMap                    m_SystemFontMap;
         Matrix4                     m_View;
         Matrix4                     m_Projection;
@@ -302,6 +340,9 @@ namespace dmRender
         HMaterial                   m_Material;
         HComputeProgram             m_ComputeProgram;
         dmMessage::HSocket          m_Socket;
+        uint16_t                    m_LightBufferDirtyStart;
+        uint16_t                    m_LightBufferDirtyEnd;
+        uint32_t                    m_LightBufferDirtyCount         : 1;
         uint32_t                    m_OutOfResources                : 1;
         uint32_t                    m_StencilBufferCleared          : 1;
         uint32_t                    m_MultiBufferingRequired        : 1;
@@ -357,6 +398,10 @@ namespace dmRender
     // Render camera
     RenderCamera* GetRenderCameraByUrl(HRenderContext render_context, const dmMessage::URL& camera_url);
     RenderCamera* CheckRenderCamera(lua_State* L, int index, HRenderContext render_context);
+
+    // Lights
+    void InitializeLightData(HRenderContext render_context);
+    void ApplyMaterialProgramLightBuffers(HRenderContext render_context, HMaterial material);
 
     // Exposed here for unit testing
     struct RenderListEntrySorter

--- a/engine/render/src/test/test_render.cpp
+++ b/engine/render/src/test/test_render.cpp
@@ -1806,6 +1806,140 @@ TEST_F(dmRenderTest, FontMapSetup)
     dmRender::DeleteFontMap(font);
 }
 
+TEST_F(dmRenderTest, LightBufferTestSimple)
+{
+    // Default params (point light, white, intensity 1, range 10, etc.)
+    dmRender::LightPrototypeParams light_params;
+    dmRender::HLightPrototype light_prototype = dmRender::NewLightPrototype(m_Context, light_params);
+    ASSERT_NE((dmRender::HLightPrototype)0, light_prototype);
+
+    {
+        dmRender::HLightInstance light0 = dmRender::NewLightInstance(m_Context, light_prototype);
+        ASSERT_NE((dmRender::HLightInstance)0, light0);
+
+        dmVMath::Point3 p0;
+        dmVMath::Quat r0;
+        dmRender::SetLightInstance(m_Context, light0, p0, r0);
+        dmRender::DeleteLightInstance(m_Context, light0);
+    }
+
+    dmRender::DeleteLightPrototype(m_Context, light_prototype);
+}
+
+TEST_F(dmRenderTest, LightBufferTestAllTypes)
+{
+    dmRender::LightPrototypeParams params;
+
+    params.m_Type = dmRender::LIGHT_TYPE_DIRECTIONAL;
+    params.m_Color = dmVMath::Vector4(1.0f, 0.0f, 0.0f, 1.0f);
+    params.m_Direction = dmVMath::Vector3(0.0f, -1.0f, 0.0f);
+    params.m_Intensity = 2.0f;
+    dmRender::HLightPrototype proto_dir = dmRender::NewLightPrototype(m_Context, params);
+    ASSERT_NE((dmRender::HLightPrototype)0, proto_dir);
+    dmRender::HLightInstance inst_dir = dmRender::NewLightInstance(m_Context, proto_dir);
+    ASSERT_NE((dmRender::HLightInstance)0, inst_dir);
+    dmRender::SetLightInstance(m_Context, inst_dir, dmVMath::Point3(0, 10, 0), dmVMath::Quat::identity());
+    dmRender::DeleteLightInstance(m_Context, inst_dir);
+    dmRender::DeleteLightPrototype(m_Context, proto_dir);
+
+    params.m_Type = dmRender::LIGHT_TYPE_POINT;
+    params.m_Color = dmVMath::Vector4(0.0f, 1.0f, 0.0f, 1.0f);
+    params.m_Range = 25.0f;
+    params.m_Intensity = 0.5f;
+    dmRender::HLightPrototype proto_point = dmRender::NewLightPrototype(m_Context, params);
+    ASSERT_NE((dmRender::HLightPrototype)0, proto_point);
+    dmRender::HLightInstance inst_point = dmRender::NewLightInstance(m_Context, proto_point);
+    ASSERT_NE((dmRender::HLightInstance)0, inst_point);
+    dmRender::SetLightInstance(m_Context, inst_point, dmVMath::Point3(5.0f, 0.0f, -3.0f), dmVMath::Quat::identity());
+    dmRender::DeleteLightInstance(m_Context, inst_point);
+    dmRender::DeleteLightPrototype(m_Context, proto_point);
+
+    params.m_Type = dmRender::LIGHT_TYPE_SPOT;
+    params.m_Color = dmVMath::Vector4(0.0f, 0.0f, 1.0f, 1.0f);
+    params.m_Direction = dmVMath::Vector3(0.0f, 0.0f, -1.0f);
+    params.m_InnerConeAngle = 0.2f;
+    params.m_OuterConeAngle = 0.8f;
+    params.m_Range = 15.0f;
+    dmRender::HLightPrototype proto_spot = dmRender::NewLightPrototype(m_Context, params);
+    ASSERT_NE((dmRender::HLightPrototype)0, proto_spot);
+    dmRender::HLightInstance inst_spot = dmRender::NewLightInstance(m_Context, proto_spot);
+    ASSERT_NE((dmRender::HLightInstance)0, inst_spot);
+    dmRender::SetLightInstance(m_Context, inst_spot, dmVMath::Point3(0, 0, 10), dmVMath::Quat::identity());
+    dmRender::DeleteLightInstance(m_Context, inst_spot);
+    dmRender::DeleteLightPrototype(m_Context, proto_spot);
+}
+
+TEST_F(dmRenderTest, LightBufferTestMultipleInstances)
+{
+    dmRender::LightPrototypeParams params;
+    params.m_Type = dmRender::LIGHT_TYPE_POINT;
+    params.m_Intensity = 1.0f;
+    params.m_Range = 10.0f;
+
+    dmRender::HLightPrototype prototype = dmRender::NewLightPrototype(m_Context, params);
+    ASSERT_NE((dmRender::HLightPrototype)0, prototype);
+
+    dmRender::HLightInstance lights[4];
+    for (uint32_t i = 0; i < 4; ++i)
+    {
+        lights[i] = dmRender::NewLightInstance(m_Context, prototype);
+        ASSERT_NE((dmRender::HLightInstance)0, lights[i]);
+        dmRender::SetLightInstance(m_Context, lights[i], dmVMath::Point3((float)i, (float)i * 2.0f, (float)i * -1.0f), dmVMath::Quat::identity());
+    }
+
+    for (uint32_t i = 0; i < 4; ++i)
+    {
+        dmRender::DeleteLightInstance(m_Context, lights[i]);
+    }
+    dmRender::DeleteLightPrototype(m_Context, prototype);
+}
+
+TEST_F(dmRenderTest, LightBufferTestIndexReuse)
+{
+    dmRender::LightPrototypeParams params;
+    params.m_Type = dmRender::LIGHT_TYPE_POINT;
+    dmRender::HLightPrototype prototype = dmRender::NewLightPrototype(m_Context, params);
+    ASSERT_NE((dmRender::HLightPrototype)0, prototype);
+
+    dmRender::HLightInstance a = dmRender::NewLightInstance(m_Context, prototype);
+    dmRender::HLightInstance b = dmRender::NewLightInstance(m_Context, prototype);
+    ASSERT_NE((dmRender::HLightInstance)0, a);
+    ASSERT_NE((dmRender::HLightInstance)0, b);
+
+    dmRender::DeleteLightInstance(m_Context, a);
+    dmRender::HLightInstance c = dmRender::NewLightInstance(m_Context, prototype);
+    ASSERT_NE((dmRender::HLightInstance)0, c);
+
+    dmRender::SetLightInstance(m_Context, b, dmVMath::Point3(1, 0, 0), dmVMath::Quat::identity());
+    dmRender::SetLightInstance(m_Context, c, dmVMath::Point3(2, 0, 0), dmVMath::Quat::identity());
+
+    dmRender::DeleteLightInstance(m_Context, b);
+    dmRender::DeleteLightInstance(m_Context, c);
+    dmRender::DeleteLightPrototype(m_Context, prototype);
+}
+
+TEST_F(dmRenderTest, LightBufferTestSetLightInstanceUpdates)
+{
+    dmRender::LightPrototypeParams params;
+    params.m_Type = dmRender::LIGHT_TYPE_SPOT;
+    params.m_Direction = dmVMath::Vector3(0.0f, 0.0f, -1.0f);
+    dmRender::HLightPrototype prototype = dmRender::NewLightPrototype(m_Context, params);
+    ASSERT_NE((dmRender::HLightPrototype)0, prototype);
+
+    dmRender::HLightInstance instance = dmRender::NewLightInstance(m_Context, prototype);
+    ASSERT_NE((dmRender::HLightInstance)0, instance);
+
+    dmRender::SetLightInstance(m_Context, instance, dmVMath::Point3(0, 0, 0), dmVMath::Quat::identity());
+    dmRender::SetLightInstance(m_Context, instance, dmVMath::Point3(1, 2, 3), dmVMath::Quat::identity());
+    // Z rotation by 45 degrees: quat (0, 0, sin(θ/2), cos(θ/2))
+    const float half = 3.14159265f / 8.0f;
+    dmVMath::Quat rot_z(0.0f, 0.0f, sinf(half), cosf(half));
+    dmRender::SetLightInstance(m_Context, instance, dmVMath::Point3(1, 2, 3), rot_z);
+
+    dmRender::DeleteLightInstance(m_Context, instance);
+    dmRender::DeleteLightPrototype(m_Context, prototype);
+}
+
 TEST(Constants, Constant)
 {
     dmhash_t original_name_hash = dmHashString64("test_constant");

--- a/engine/render/src/test/test_render.cpp
+++ b/engine/render/src/test/test_render.cpp
@@ -126,6 +126,7 @@ protected:
         params.m_MaxDebugVertexCount = 256;
         params.m_MaxCharacters = 256;
         params.m_MaxBatches = 128;
+        params.m_MaxLights = 32;
         m_Context = dmRender::NewRenderContext(m_GraphicsContext, params);
 
         m_GlyphBank = CreateGlyphBank(2, 1, 128);


### PR DESCRIPTION
This adds a new (private for now) API for creating and manipulating light sources in the renderer. There are no user facing changes involved here, but this is needed for the new light component to create a glue between components and shaders.

Partial fix for #11724


### Technical changes

These changes are essentially the same as in the previous PR #11849 but with all the component level code stripped. 