### PR TITLE
Use stat64 on windows

### DIFF
--- a/engine/dlib/src/dlib/sys_win32.cpp
+++ b/engine/dlib/src/dlib/sys_win32.cpp
@@ -50,10 +50,10 @@
 #warning "S_ISREG WAS ADDED AS A DEFINE! /MAWE"
 #endif
 
-
-
 namespace dmSys
 {
+    static const uint64_t UINT32_MAX_VALUE = 0xFFFFFFFFu;
+
     char* GetEnv(const char* name)
     {
         return getenv(name);
@@ -346,17 +346,23 @@ namespace dmSys
 
     bool ResourceExists(const char* path)
     {
-        struct stat file_stat;
-        return stat(path, &file_stat) == 0;
+        struct __stat64 file_stat;
+        return _stat64(path, &file_stat) == 0;
     }
 
     Result ResourceSize(const char* path, uint32_t* resource_size)
     {
-        struct stat file_stat;
-        if (stat(path, &file_stat) == 0) {
+        struct __stat64 file_stat;
+        if (_stat64(path, &file_stat) == 0) {
             if (!S_ISREG(file_stat.st_mode)) {
                 return RESULT_NOENT;
             }
+
+            if (file_stat.st_size > UINT32_MAX_VALUE)
+            {
+                return RESULT_FBIG;
+            }
+
             *resource_size = (uint32_t) file_stat.st_size;
             return RESULT_OK;
         } else {
@@ -367,23 +373,35 @@ namespace dmSys
     Result LoadResource(const char* path, void* buffer, uint32_t buffer_size, uint32_t* resource_size)
     {
         *resource_size = 0;
-        struct stat file_stat;
-        if (stat(path, &file_stat) == 0) {
+        struct __stat64 file_stat;
+        if (_stat64(path, &file_stat) == 0) {
             if (!S_ISREG(file_stat.st_mode)) {
                 return RESULT_NOENT;
             }
-            if ((uint32_t) file_stat.st_size > buffer_size) {
+
+            if (file_stat.st_size > UINT32_MAX_VALUE)
+            {
+                return RESULT_FBIG;
+            }
+
+            uint32_t size_as_32b = (uint32_t) file_stat.st_size;
+            if (size_as_32b > buffer_size) {
                 return RESULT_INVAL;
             }
+
             FILE* f = fopen(path, "rb");
-            size_t nread = fread(buffer, 1, file_stat.st_size, f);
+            size_t nread = fread(buffer, 1, size_as_32b, f);
             fclose(f);
-            if (nread != (size_t) file_stat.st_size) {
+
+            if (nread != size_as_32b)
+            {
                 return RESULT_IO;
             }
-            *resource_size = file_stat.st_size;
+            *resource_size = size_as_32b;
             return RESULT_OK;
-        } else {
+        }
+        else
+        {
             return ErrnoToResult(errno);
         }
     }
@@ -393,8 +411,8 @@ namespace dmSys
         if (buffer == 0 || size == 0)
             return RESULT_INVAL;
 
-        struct stat file_stat;
-        if (stat(path, &file_stat) == 0) {
+        struct __stat64 file_stat;
+        if (_stat64(path, &file_stat) == 0) {
             if (!S_ISREG(file_stat.st_mode)) {
                 return RESULT_NOENT;
             }
@@ -447,8 +465,8 @@ namespace dmSys
 
     Result IsDir(const char* path)
     {
-        struct stat path_stat;
-        int ret = stat(path, &path_stat);
+        struct __stat64 path_stat;
+        int ret = _stat64(path, &path_stat);
         if (ret != 0)
             return ErrnoToResult(errno);
         return path_stat.st_mode & S_IFDIR ? RESULT_OK : RESULT_UNKNOWN;
@@ -456,8 +474,8 @@ namespace dmSys
 
     bool Exists(const char* path)
     {
-        struct stat path_stat;
-        int ret = stat(path, &path_stat);
+        struct __stat64 path_stat;
+        int ret = _stat64(path, &path_stat);
         return ret == 0;
     }
 
@@ -530,14 +548,14 @@ namespace dmSys
 
     Result Stat(const char* path, StatInfo* stat_info)
     {
-        struct stat info;
-        int ret = stat(path, &info);
+        struct __stat64 info;
+        int ret = _stat64(path, &info);
         if (ret != 0)
             return RESULT_NOENT;
-        stat_info->m_Size = (uint64_t)info.st_size;
+        stat_info->m_Size = info.st_size;
         stat_info->m_Mode = info.st_mode;
-        stat_info->m_AccessTime = info.st_atime;
-        stat_info->m_ModifiedTime = info.st_mtime;
+        stat_info->m_AccessTime = (uint32_t)info.st_atime;
+        stat_info->m_ModifiedTime = (uint32_t)info.st_mtime;
         return RESULT_OK;
     }
 

--- a/engine/dlib/src/dlib/sys_win32.cpp
+++ b/engine/dlib/src/dlib/sys_win32.cpp
@@ -23,6 +23,7 @@
 #include <string.h>
 #include <errno.h>
 #include <time.h>
+#include <limits.h> // UINT_MAX
 
 #include "sys.h"
 #include "log.h"
@@ -52,8 +53,6 @@
 
 namespace dmSys
 {
-    static const uint64_t UINT32_MAX_VALUE = 0xFFFFFFFFu;
-
     char* GetEnv(const char* name)
     {
         return getenv(name);
@@ -358,7 +357,7 @@ namespace dmSys
                 return RESULT_NOENT;
             }
 
-            if (file_stat.st_size > UINT32_MAX_VALUE)
+            if (file_stat.st_size > UINT_MAX)
             {
                 return RESULT_FBIG;
             }
@@ -379,7 +378,7 @@ namespace dmSys
                 return RESULT_NOENT;
             }
 
-            if (file_stat.st_size > UINT32_MAX_VALUE)
+            if (file_stat.st_size > UINT_MAX)
             {
                 return RESULT_FBIG;
             }


### PR DESCRIPTION
We now use the 64-bit version of stat in the engine on windows. This means that we can load resources larger than 2gb.

Fixes #11923 