### PR TITLE
Eliminate unnecessary code editor redraws

### DIFF
--- a/editor/src/clj/editor/code/data.clj
+++ b/editor/src/clj/editor/code/data.clj
@@ -41,6 +41,9 @@
   (line-height [this] "A rounded double representing the line height.")
   (char-width [this character] "A rounded double representing the width of the specified character."))
 
+(defmacro clamp [value minimum maximum]
+  `(max ~minimum (min ~value ~maximum)))
+
 (defn- identifier-character-at-index? [line ^long index]
   (if-some [^char character (get line index)]
     (case character
@@ -467,6 +470,27 @@
           (- (.y r) y)
           (+ (.w r) (* 2.0 x))
           (+ (.h r) (* 2.0 y))))
+
+(defn rect-intersection
+  "Returns either nil if no intersection or a Rect of some area where the two
+  input rectangles intersect. See also cursor-range-intersection."
+  ^Rect [^Rect a ^Rect b]
+  (let [al (.x a)
+        at (.y a)
+        ar (+ al (.w a))
+        ab (+ at (.h a))
+        bl (.x b)
+        bt (.y b)
+        br (+ bl (.w b))
+        bb (+ bt (.h b))
+        l (clamp al bl br)
+        r (clamp ar bl br)
+        t (clamp at bt bb)
+        b (clamp ab bt bb)
+        w (- r l)
+        h (- b t)]
+    (when (and (pos? w) (pos? h))
+      (->Rect l t w h))))
 
 (defn- outer-bounds
   ^Rect [^Rect a ^Rect b]

--- a/editor/src/clj/editor/code/data.clj
+++ b/editor/src/clj/editor/code/data.clj
@@ -2912,7 +2912,8 @@
         {:type :ui-element :ui-element :minimap}))
 
     (in-gutter? layout x)
-    {:type :ui-element :ui-element :gutter}
+    (when-some [hovered-row (y->existing-row layout lines y)]
+      {:type :gutter-row :row hovered-row})
 
     :else
     (when-some [clickable-region (some (fn [region]
@@ -2923,24 +2924,19 @@
                                        visible-regions)]
       {:type :region :region clickable-region})))
 
-(defn- mouse-hover [lines visible-regions ^LayoutInfo layout ^LayoutInfo minimap-layout hovered-element hovered-row x y]
-  (let [new-hovered-element (element-at-position lines visible-regions layout minimap-layout x y)
-        new-hovered-row (y->row layout y)
-        row-changed (not= hovered-row new-hovered-row)
-        element-changed (not= hovered-element new-hovered-element)]
-    (when (or row-changed element-changed)
-      (cond-> {}
-        row-changed (assoc :hovered-row new-hovered-row)
-        element-changed (assoc :hovered-element new-hovered-element)))))
+(defn- mouse-hover [lines visible-regions ^LayoutInfo layout ^LayoutInfo minimap-layout hovered-element x y]
+  (let [new-hovered-element (element-at-position lines visible-regions layout minimap-layout x y)]
+    (when (not= hovered-element new-hovered-element)
+      {:hovered-element new-hovered-element})))
 
-(defn mouse-moved [lines cursor-ranges visible-regions ^LayoutInfo layout ^LayoutInfo minimap-layout ^GestureInfo gesture-start hovered-element hovered-row x y]
+(defn mouse-moved [lines cursor-ranges visible-regions ^LayoutInfo layout ^LayoutInfo minimap-layout ^GestureInfo gesture-start hovered-element x y]
   (if (some? gesture-start)
     (mouse-gesture lines cursor-ranges layout minimap-layout gesture-start x y)
-    (mouse-hover lines visible-regions layout minimap-layout hovered-element hovered-row x y)))
+    (mouse-hover lines visible-regions layout minimap-layout hovered-element x y)))
 
-(defn mouse-released [lines cursor-ranges visible-regions ^LayoutInfo layout ^LayoutInfo minimap-layout ^GestureInfo gesture-start button hovered-row x y]
+(defn mouse-released [lines cursor-ranges visible-regions ^LayoutInfo layout ^LayoutInfo minimap-layout ^GestureInfo gesture-start button x y]
   (when (= button (some-> gesture-start :button))
-    (assoc (mouse-hover lines visible-regions layout minimap-layout ::force-evaluation hovered-row x y)
+    (assoc (mouse-hover lines visible-regions layout minimap-layout ::force-evaluation x y)
       :cursor-ranges (mapv #(dissoc % :dragged) cursor-ranges)
       :gesture-start nil)))
 

--- a/editor/src/clj/editor/code/view.clj
+++ b/editor/src/clj/editor/code/view.clj
@@ -103,7 +103,7 @@
 
 (defonce/protocol GutterView
   (gutter-metrics [this lines regions glyph-metrics] "A two-element vector with a rounded double representing the width of the gutter and another representing the margin on each side within the gutter.")
-  (draw-gutter! [this gc gutter-rect layout hovered-ui-element font color-scheme lines regions visible-cursor-ranges focus-state hovered-row] "Draws the gutter into the specified Rect."))
+  (draw-gutter! [this gc gutter-rect layout hovered-element font color-scheme lines regions visible-cursor-ranges focus-state] "Draws the gutter into the specified Rect."))
 
 (defonce/record CursorRangeDrawInfo [type fill stroke cursor-range])
 
@@ -564,7 +564,7 @@
           (recur (inc drawn-line-index)
                  (inc source-line-index)))))))
 
-(defn- draw! [^GraphicsContext gc ^Font font gutter-view hovered-element hovered-row ^LayoutInfo layout ^LayoutInfo minimap-layout color-scheme lines regions syntax-info cursor-range-draw-infos minimap-cursor-range-draw-infos indent-type visible-cursor-ranges focus-state visible-indentation-guides? visible-minimap? visible-whitespace]
+(defn- draw! [^GraphicsContext gc ^Font font gutter-view hovered-element ^LayoutInfo layout ^LayoutInfo minimap-layout color-scheme lines regions syntax-info cursor-range-draw-infos minimap-cursor-range-draw-infos indent-type visible-cursor-ranges focus-state visible-indentation-guides? visible-minimap? visible-whitespace]
   (let [^Rect canvas-rect (.canvas layout)
         source-line-count (count lines)
         dropped-line-count (.dropped-line-count layout)
@@ -573,7 +573,9 @@
         background-color (color-lookup color-scheme "editor.background")
         scroll-tab-color (color-lookup color-scheme "editor.scroll.tab")
         scroll-tab-hovered-color (color-lookup color-scheme "editor.scroll.tab.hovered")
-        hovered-ui-element (:ui-element hovered-element)]
+        hovered-ui-element (case (:type hovered-element)
+                             :ui-element (:ui-element hovered-element)
+                             nil)]
     (.setFill gc background-color)
     (.fillRect gc 0 0 (.. gc getCanvas getWidth) (.. gc getCanvas getHeight))
     (.setFontSmoothingType gc FontSmoothingType/GRAY) ; FontSmoothingType/LCD is very slow.
@@ -672,7 +674,7 @@
     ;; Draw gutter.
     (let [^Rect gutter-rect (data/->Rect 0.0 (.y canvas-rect) (.x canvas-rect) (.h canvas-rect))]
       (when (< 0.0 (.w gutter-rect))
-        (draw-gutter! gutter-view gc gutter-rect layout hovered-ui-element font color-scheme lines regions visible-cursor-ranges focus-state hovered-row)))))
+        (draw-gutter! gutter-view gc gutter-rect layout hovered-element font color-scheme lines regions visible-cursor-ranges focus-state)))))
 
 ;; -----------------------------------------------------------------------------
 
@@ -852,12 +854,12 @@
                        (data/execution-marker lines (dec line) type))))
           debugger-execution-locations)))
 
-(g/defnk produce-canvas-repaint-info [canvas color-scheme cursor-range-draw-infos execution-markers focus-state font grammar gutter-view hovered-element hovered-row indent-type invalidated-rows layout lines minimap-cursor-range-draw-infos minimap-layout regions repaint-trigger visible-cursor-ranges visible-indentation-guides? visible-minimap? visible-whitespace :as canvas-repaint-info]
+(g/defnk produce-canvas-repaint-info [canvas color-scheme cursor-range-draw-infos execution-markers focus-state font grammar gutter-view hovered-element indent-type invalidated-rows layout lines minimap-cursor-range-draw-infos minimap-layout regions repaint-trigger visible-cursor-ranges visible-indentation-guides? visible-minimap? visible-whitespace :as canvas-repaint-info]
   canvas-repaint-info)
 
-(defn- repaint-canvas! [{:keys [^Canvas canvas execution-markers focus-state font gutter-view hovered-element hovered-row layout minimap-layout color-scheme lines regions cursor-range-draw-infos minimap-cursor-range-draw-infos indent-type visible-cursor-ranges visible-indentation-guides? visible-minimap? visible-whitespace] :as _canvas-repaint-info} syntax-info]
+(defn- repaint-canvas! [{:keys [^Canvas canvas execution-markers focus-state font gutter-view hovered-element layout minimap-layout color-scheme lines regions cursor-range-draw-infos minimap-cursor-range-draw-infos indent-type visible-cursor-ranges visible-indentation-guides? visible-minimap? visible-whitespace] :as _canvas-repaint-info} syntax-info]
   (let [regions (into [] cat [regions execution-markers])]
-    (draw! (.getGraphicsContext2D canvas) font gutter-view hovered-element hovered-row layout minimap-layout color-scheme lines regions syntax-info cursor-range-draw-infos minimap-cursor-range-draw-infos indent-type visible-cursor-ranges focus-state visible-indentation-guides? visible-minimap? visible-whitespace))
+    (draw! (.getGraphicsContext2D canvas) font gutter-view hovered-element layout minimap-layout color-scheme lines regions syntax-info cursor-range-draw-infos minimap-cursor-range-draw-infos indent-type visible-cursor-ranges focus-state visible-indentation-guides? visible-minimap? visible-whitespace))
   nil)
 
 (g/defnk produce-cursor-repaint-info [canvas color-scheme cursor-opacity layout lines repaint-trigger visible-cursors :as cursor-repaint-info]
@@ -1494,7 +1496,6 @@
   (property gesture-start GestureInfo (dynamic visible (g/constantly false)))
   (property highlighted-find-term g/Str (default "") (dynamic visible (g/constantly false)))
   (property hovered-element HoveredElement (dynamic visible (g/constantly false)))
-  (property hovered-row g/Num (default 0) (dynamic visible (g/constantly false)))
   (property edited-breakpoint r/Region (dynamic visible (g/constantly false)))
   (property find-case-sensitive? g/Bool (dynamic visible (g/constantly false)))
   (property find-whole-word? g/Bool (dynamic visible (g/constantly false)))
@@ -2753,7 +2754,6 @@
                               (get-property view-node :minimap-layout evaluation-context)
                               (get-property view-node :gesture-start evaluation-context)
                               (get-property view-node :hovered-element evaluation-context)
-                              (get-property view-node :hovered-row evaluation-context)
                               x
                               y)
             (cond->
@@ -2771,17 +2771,18 @@
     (when-some [on-click! (:on-click! hovered-region)]
       (on-click! hovered-region event)))
   (refresh-mouse-cursor! view-node event)
-  (set-properties! view-node :selection
-                   (data/mouse-released (get-property view-node :lines)
-                                        (get-property view-node :cursor-ranges)
-                                        (get-property view-node :visible-regions)
-                                        (get-property view-node :layout)
-                                        (get-property view-node :minimap-layout)
-                                        (get-property view-node :gesture-start)
-                                        (mouse-button event)
-                                        (get-property view-node :hovered-row)
-                                        (.getX event)
-                                        (.getY event))))
+  (g/let-ec [values-by-prop-kw
+             (data/mouse-released
+               (get-property view-node :lines evaluation-context)
+               (get-property view-node :cursor-ranges evaluation-context)
+               (get-property view-node :visible-regions evaluation-context)
+               (get-property view-node :layout evaluation-context)
+               (get-property view-node :minimap-layout evaluation-context)
+               (get-property view-node :gesture-start evaluation-context)
+               (mouse-button event)
+               (.getX event)
+               (.getY event))]
+    (set-properties! view-node :selection values-by-prop-kw)))
 
 (defn handle-mouse-exited! [view-node ^MouseEvent event]
   (.consume event)
@@ -3688,7 +3689,7 @@
              cursor-repaint-info (g/node-value view-node :cursor-repaint-info evaluation-context)]
 
     ;; Repaint canvas if needed.
-    (when-not (identical? prev-canvas-repaint-info canvas-repaint-info)
+    (when (not= prev-canvas-repaint-info canvas-repaint-info)
       (g/user-data! view-node :canvas-repaint-info canvas-repaint-info)
       (let [row (data/last-visible-row (:minimap-layout canvas-repaint-info))]
         (repaint-canvas! canvas-repaint-info (get-valid-syntax-info resource-node canvas-repaint-info row))))
@@ -3795,7 +3796,7 @@
     (let [gutter-margin (data/line-height glyph-metrics)]
       (data/gutter-metrics glyph-metrics gutter-margin (count lines))))
 
-  (draw-gutter! [this gc gutter-rect layout hovered-ui-element font color-scheme lines regions visible-cursor-ranges focus-state hovered-row]
+  (draw-gutter! [this gc gutter-rect layout hovered-element font color-scheme lines regions visible-cursor-ranges focus-state]
     (let [^GraphicsContext gc gc
           ^Rect gutter-rect gutter-rect
           ^LayoutInfo layout layout
@@ -3844,16 +3845,18 @@
                                                          :enabled (:enabled %)}))))
             execution-markers-by-type (group-by :location-type (filter data/execution-marker? regions))
             execution-marker-current-rows (data/cursor-ranges->start-rows lines (:current-line execution-markers-by-type))
-            execution-marker-frame-rows (data/cursor-ranges->start-rows lines (:current-frame execution-markers-by-type))]
+            execution-marker-frame-rows (data/cursor-ranges->start-rows lines (:current-frame execution-markers-by-type))
+            hovered-row (long (case (:type hovered-element)
+                                :gutter-row (:row hovered-element)
+                                -1))]
         (loop [drawn-line-index 0
                source-line-index dropped-line-count]
           (when (and (< drawn-line-index drawn-line-count)
                      (< source-line-index source-line-count))
             (let [y (data/row->y layout source-line-index)
-                  breakpoint (breakpoint-row->condition source-line-index)
-                  hovered? (and (= hovered-ui-element :gutter)
-                                (= hovered-row source-line-index))]
-              (when (and hovered? (nil? breakpoint))
+                  breakpoint (breakpoint-row->condition source-line-index)]
+              (when (and (nil? breakpoint)
+                         (= hovered-row source-line-index))
                 (.setFill gc ^Color (.deriveColor ^Color gutter-breakpoint-color 0.0 1.0 1.0 0.3))
                 (.fillOval gc
                            (+ (.x line-numbers-rect) (.w line-numbers-rect) indicator-offset)

--- a/editor/src/clj/editor/code/view.clj
+++ b/editor/src/clj/editor/code/view.clj
@@ -318,7 +318,7 @@
     (.setStroke gc stroke)
     (.setLineWidth gc 1.0)
     (case type
-      :word (let [^Rect r (data/expand-rect (first rects) 1.5 0.5)]
+      :word (let [^Rect r (data/expand-rect (first rects) 1.5 0.0)]
               (assert (= 1 (count rects)))
               (.strokeRoundRect gc (.x r) (.y r) (.w r) (.h r) 5.0 5.0))
       :range (doseq [polyline (cursor-range-outline rects)]

--- a/editor/src/clj/editor/code/view.clj
+++ b/editor/src/clj/editor/code/view.clj
@@ -876,16 +876,19 @@
   (let [^Pane canvas-pane (.getParent canvas)
         ^Rect canvas-rect (.canvas layout)
         ^Rect minimap-rect (.minimap layout)
-        gutter-end (dec (.x canvas-rect))
-        canvas-end (.x minimap-rect)
+        view-x (if (neg? (.scroll-x layout))
+                 (.x canvas-rect) ; We're scrolled in a bit. The gutter covers the code.
+                 0.0)
+        view-y (.y canvas-rect)
+        view-w (- (.x minimap-rect) view-x)
+        view-h (.h canvas-rect)
+        view-rect (data/->Rect view-x view-y view-w view-h)
         children (.getChildren canvas-pane)
         cursor-color (color-lookup color-scheme "editor.cursor")
-        cursor-rectangles (into []
-                                (comp (map (partial data/cursor-rect layout lines))
-                                      (remove (fn [^Rect cursor-rect] (< (.x cursor-rect) gutter-end)))
-                                      (remove (fn [^Rect cursor-rect] (> (.x cursor-rect) canvas-end)))
-                                      (map (partial make-cursor-rectangle cursor-color cursor-opacity)))
-                                visible-cursors)]
+        cursor-rectangles (coll/into-> visible-cursors []
+                            (map (partial data/cursor-rect layout lines))
+                            (keep (partial data/rect-intersection view-rect))
+                            (map (partial make-cursor-rectangle cursor-color cursor-opacity)))]
     (assert (identical? canvas (first children)))
     (.remove children 1 (count children))
     (.addAll children ^Collection cursor-rectangles)

--- a/editor/src/clj/editor/console.clj
+++ b/editor/src/clj/editor/console.clj
@@ -527,7 +527,7 @@
   (gutter-metrics [_this _lines _regions _glyph-metrics]
     (gutter-metrics))
 
-  (draw-gutter! [_this gc gutter-rect layout _hovered-ui-element font color-scheme lines regions _visible-cursor-ranges _focus-state _hovered-row]
+  (draw-gutter! [_this gc gutter-rect layout _hovered-element font color-scheme lines regions _visible-cursor-ranges _focus-state]
     (draw-gutter! gc gutter-rect layout font color-scheme lines regions)))
 
 (defn- setup-view! [console-node view-node]

--- a/editor/src/dev/jfx.clj
+++ b/editor/src/dev/jfx.clj
@@ -19,6 +19,7 @@
            [javafx.scene Node Parent Scene]
            [javafx.scene.control ChoiceBox ChoiceDialog ComboBox ContextMenu Control CustomMenuItem Dialog Labeled ListView Menu MenuButton MenuItem ScrollPane SplitPane Tab TabPane TableColumnBase TableView TextInputControl TitledPane ToolBar Tooltip TreeItem]
            [javafx.scene.control.cell ChoiceBoxListCell ChoiceBoxTableCell ChoiceBoxTreeCell ChoiceBoxTreeTableCell ComboBoxListCell ComboBoxTableCell ComboBoxTreeCell ComboBoxTreeTableCell]
+           [javafx.scene.layout Region]
            [javafx.scene.text Text]
            [javafx.stage Popup Window]))
 
@@ -246,6 +247,9 @@
             (not (.isManaged node)) (assoc :managed false)
             (not (.isVisible node)) (assoc :visible false))))
 
+(defn- region-props [^Region region]
+  {:is-snap-to-pixel (.isSnapToPixel region)})
+
 (defn- to-coll [items]
   (cond
     (or (nil? items)
@@ -272,6 +276,9 @@
 
           (instance? Node obj)
           (into (node-props obj))
+
+          (instance? Region obj)
+          (into (region-props obj))
 
           (satisfies? InfoProps obj)
           (into (info-props obj))

--- a/editor/test/editor/code/data_test.clj
+++ b/editor/test/editor/code/data_test.clj
@@ -15,7 +15,7 @@
 (ns editor.code.data-test
   (:require [clojure.string :as string]
             [clojure.test :refer :all]
-            [editor.code.data :as data :refer [->Cursor ->CursorRange]]
+            [editor.code.data :as data :refer [->Cursor ->CursorRange ->Rect]]
             [editor.code.script :as script])
   (:import (java.io IOException)
            (java.nio CharBuffer)))
@@ -1587,6 +1587,52 @@
       (is (nil? (data/cursor-range-intersection (cr [0 0] [0 0])
                                                 (cr [0 0] [0 0])))))))
 
+(deftest rect-intersection-test
+  (testing "no intersection => nil"
+    (testing "not touching"
+      (is (nil? (data/rect-intersection (->Rect 0 0 1 1)
+                                        (->Rect 2 0 1 1))))
+      (is (nil? (data/rect-intersection (->Rect 2 0 1 1)
+                                        (->Rect 0 0 1 1)))))
+    (testing "touching"
+      (is (nil? (data/rect-intersection (->Rect 0 0 1 1)
+                                        (->Rect 1 0 1 1))))
+      (is (nil? (data/rect-intersection (->Rect 1 0 1 1)
+                                        (->Rect 0 0 1 1))))
+      (testing "one is empty"
+        (is (nil? (data/rect-intersection (->Rect 0 0 1 1)
+                                          (->Rect 1 0 0 0))))
+        (is (nil? (data/rect-intersection (->Rect 1 0 0 0)
+                                          (->Rect 0 0 1 1))))
+        (is (nil? (data/rect-intersection (->Rect 0 0 0 0)
+                                          (->Rect 0 0 1 1))))
+        (is (nil? (data/rect-intersection (->Rect 0 0 1 1)
+                                          (->Rect 0 0 0 0)))))))
+  (testing "one within another"
+    (is (= (->Rect 1 0 1 1)
+           (data/rect-intersection (->Rect 0 0 3 1)
+                                   (->Rect 1 0 1 1))))
+    (is (= (->Rect 1 0 1 1)
+           (data/rect-intersection (->Rect 1 0 1 1)
+                                   (->Rect 0 0 3 1))))
+    (testing "empty is still nil"
+      (is (nil? (data/rect-intersection (->Rect 0 0 2 1)
+                                        (->Rect 1 0 0 0))))))
+  (testing "partial intersection"
+    (is (= (->Rect 1 0 1 1)
+           (data/rect-intersection (->Rect 0 0 2 1)
+                                   (->Rect 1 0 2 1))))
+    (is (= (->Rect 1 0 1 1)
+           (data/rect-intersection (->Rect 1 0 2 1)
+                                   (->Rect 0 0 2 1)))))
+  (testing "full overlap"
+    (is (= (->Rect 0 0 1 1)
+           (data/rect-intersection (->Rect 0 0 1 1)
+                                   (->Rect 0 0 1 1))))
+    (testing "empty is still nil"
+      (is (nil? (data/rect-intersection (->Rect 0 0 0 0)
+                                        (->Rect 0 0 0 0)))))))
+
 (deftest syntax-scope-before-cursor-test
   (let [syntax-scope-before-cursor (fn syntax-scope-before-cursor [lines cursor]
                                      (data/syntax-scope-before-cursor
@@ -1605,7 +1651,6 @@
            (syntax-scope-before-cursor ["'bar'"] (->Cursor 0 5))))
     (is (= "comment.block.lua"
            (syntax-scope-before-cursor ["--[[" "inside a comment" "]]"] (->Cursor 1 1))))))
-
 
 (deftest auto-insert-test
   (let [key-typed (fn key-typed [lines cursor-ranges typed]


### PR DESCRIPTION
* Fixed an issue where the code editor would redraw unnecessarily when moving the mouse cursor across the view.
* Fixed an issue where the blinking cursor could cause the code editor height to oscillate by half a pixel when placed on the first row of a file.

Fixes #11985

### Technical changes
* The `hovered-row` `CodeEditorView` state has been moved to `hovered-element` state.
* The `draw-gutter!` method of the `GutterView` protocol now takes the full `hovered-element` instead of the `hovered-ui-element`, and no longer takes the `hovered-row`.
* We now perform a full equality test to determine if we need to repaint the code editor view from updated `canvas-repaint-info`.
* `Rectangles` that represent code editor cursors are now clipped to the view rect.
* The `jfx/info-map` dev function will now show the state of the `isSnapToPixel` property for `Region` subclasses.