### PR TITLE
Explicitly add include paths for java_gen tasks

### DIFF
--- a/engine/jni/src/test/wscript
+++ b/engine/jni/src/test/wscript
@@ -23,6 +23,7 @@ def configure(conf):
     dynamo_home = conf.env.DYNAMO_HOME
     includes = [os.getcwd(),
                 os.path.join(dynamo_home, 'sdk', 'include')]
+    includes += conf.env['INCLUDES']
 
     def make_path(path):
         cwd = os.getcwd()

--- a/engine/modelc/src/wscript
+++ b/engine/modelc/src/wscript
@@ -17,6 +17,7 @@ def configure(conf):
     dynamo_home = conf.env.DYNAMO_HOME
     includes = [os.getcwd(),
                 os.path.join(dynamo_home, 'sdk', 'include')]
+    includes += conf.env['INCLUDES']
 
     def make_path(path):
         cwd = os.getcwd()

--- a/engine/shaderc/src/wscript
+++ b/engine/shaderc/src/wscript
@@ -18,6 +18,7 @@ def configure(conf):
     dynamo_home = conf.env.DYNAMO_HOME
     includes = [os.getcwd(),
                 os.path.join(dynamo_home, 'sdk', 'include')]
+    includes += conf.env['INCLUDES']
 
     def make_path(path):
         cwd = os.getcwd()

--- a/engine/texc/src/wscript
+++ b/engine/texc/src/wscript
@@ -11,6 +11,7 @@ def configure(conf):
     dynamo_home = conf.env.DYNAMO_HOME
     includes = [os.getcwd(),
                 os.path.join(dynamo_home, 'sdk', 'include')]
+    includes += conf.env['INCLUDES']
 
     def make_path(path):
         cwd = os.getcwd()


### PR DESCRIPTION
On Windows if prepackaged sdks are used I faced problem that clang can't find `assert.h` when was run as part of `java_gen.generate` task.
Was following stack
```
Building jni for x86_64-win32
[exec] C:\Python313\python.exe D:\work\defold\tmp\dynamo_home/ext/bin/waf --prefix=D:\work\defold\tmp\dynamo_home --skip-tests distclean configure build install --platform=x86_64-win32
'distclean' finished successfully (0.001s)
Setting top to                           : D:\work\defold\engine\jni
Setting out to                           : D:\work\defold\engine\jni\build
Checking for program 'ccache'            : not found
Checking for program 'glslang'           : D:\work\defold\tmp\dynamo_home\ext\bin\x86_64-win32\glslang.exe
Checking for program 'protoc'            : D:\work\defold\tmp\dynamo_home\ext\bin\x86_64-win32\protoc.exe
Checking for program 'signtool'          : D:\work\defold\tmp\dynamo_home\ext\SDKs\Win32\WindowsKits\10\bin\10.0.20348.0\x64\signtool.exe
Checking for program 'CL'                : D:\work\defold\tmp\dynamo_home\ext\SDKs\Win32\MicrosoftVisualStudio14.0\VC\Tools\MSVC\14.37.32822\bin\Hostx64\x64\CL.exe
Checking for program 'LINK'              : D:\work\defold\tmp\dynamo_home\ext\SDKs\Win32\MicrosoftVisualStudio14.0\VC\Tools\MSVC\14.37.32822\bin\Hostx64\x64\LINK.exe
Checking for program 'LIB'               : D:\work\defold\tmp\dynamo_home\ext\SDKs\Win32\MicrosoftVisualStudio14.0\VC\Tools\MSVC\14.37.32822\bin\Hostx64\x64\LIB.exe
Checking for program 'RC'                : D:\work\defold\tmp\dynamo_home\ext\SDKs\Win32\WindowsKits\10\bin\10.0.20348.0\x64\RC.exe
Checking for program 'signtool'          : D:\work\defold\tmp\dynamo_home\ext\SDKs\Win32\WindowsKits\10\bin\10.0.20348.0\x64\signtool.exe
Checking for program 'clang'             : C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\Llvm\bin\clang.exe
Checking for program 'clang++'           : C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\Llvm\bin\clang++.exe
Checking for program 'javac'             : C:\Program Files\Eclipse Adoptium\jdk-25.0.1.8-hotspot\bin\javac.exe
Checking for program 'java'              : C:\Program Files\Eclipse Adoptium\jdk-25.0.1.8-hotspot\bin\java.exe
Checking for program 'jar'               : C:\Program Files\Eclipse Adoptium\jdk-25.0.1.8-hotspot\bin\jar.exe
Checking for program 'javadoc'           : C:\Program Files\Eclipse Adoptium\jdk-25.0.1.8-hotspot\bin\javadoc.exe
  src\test\jni/Testapi.empty.cpp => Testapi
[exec] ['C:\\Program Files (x86)\\Microsoft Visual Studio\\2022\\BuildTools\\VC\\Tools\\Llvm\\bin\\clang++.exe', '-Xclang', '-ast-dump=json', '-c', '-ID:\\work\\defold\\engine\\jni', '-ID:\\work\\defold\\tmp\\dynamo_home\\sdk\\include', 'src\\test\\jni/Testapi.empty.cpp']
In file included from src\test\jni/Testapi.empty.cpp:1:
In file included from D:\work\defold\engine\jni\src\test\testapi.h:19:
D:\work\defold\tmp\dynamo_home\sdk\include\dmsdk/dlib/array.h:18:10: fatal error: 'assert.h' file not found
   18 | #include <assert.h>
      |          ^~~~~~~~~~
1 error generated.
Traceback (most recent call last):
  File "D:\work\defold\tmp\dynamo_home\ext\bin\waf3-2.1.9-beba77c244731800bf15a003232e7040\waflib\Scripting.py", line 122, in waf_entry_point
    run_commands()
    ~~~~~~~~~~~~^^
  File "D:\work\defold\tmp\dynamo_home\ext\bin\waf3-2.1.9-beba77c244731800bf15a003232e7040\waflib\Scripting.py", line 185, in run_commands
    ctx=run_command(cmd_name)
  File "D:\work\defold\tmp\dynamo_home\ext\bin\waf3-2.1.9-beba77c244731800bf15a003232e7040\waflib\Scripting.py", line 176, in run_command
    ctx.execute()
    ~~~~~~~~~~~^^
  File "D:\work\defold\tmp\dynamo_home\ext\bin\waf3-2.1.9-beba77c244731800bf15a003232e7040\waflib\Configure.py", line 86, in execute
    super(ConfigurationContext,self).execute()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "D:\work\defold\tmp\dynamo_home\ext\bin\waf3-2.1.9-beba77c244731800bf15a003232e7040\waflib\Context.py", line 92, in execute
    self.recurse([os.path.dirname(g_module.root_path)])
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\work\defold\tmp\dynamo_home\ext\bin\waf3-2.1.9-beba77c244731800bf15a003232e7040\waflib\Context.py", line 133, in recurse
    user_function(self)
    ~~~~~~~~~~~~~^^^^^^
  File "D:\work\defold\engine\jni\wscript", line 25, in configure
    conf.recurse('src')
    ~~~~~~~~~~~~^^^^^^^
  File "D:\work\defold\tmp\dynamo_home\ext\bin\waf3-2.1.9-beba77c244731800bf15a003232e7040\waflib\Context.py", line 133, in recurse
    user_function(self)
    ~~~~~~~~~~~~~^^^^^^
  File "D:\work\defold\engine\jni\src\wscript", line 8, in configure
    conf.recurse('test')
    ~~~~~~~~~~~~^^^^^^^^
  File "D:\work\defold\tmp\dynamo_home\ext\bin\waf3-2.1.9-beba77c244731800bf15a003232e7040\waflib\Context.py", line 133, in recurse
    user_function(self)
    ~~~~~~~~~~~~~^^^^^^
  File "D:\work\defold\engine\jni\src\test\wscript", line 32, in configure
    gen_java.generate(header_path   = make_path('./testapi.h'),
    ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                     namespace      = 'dmJniTest',
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<2 lines>...
                     java_outdir    = make_path('./java'),
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                     jni_outdir     = make_path('./jni'))
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\work\defold\engine\jni\scripts\gen_java.py", line 1233, in generate
    ir = gen_ir.gen(source_path, includes, module_name, namespace, [])
  File "D:\work\defold\engine\jni\scripts\external\gen_ir.py", line 229, in gen
    ast = clang_cpp(source_path, includes)
  File "D:\work\defold\engine\jni\scripts\external\gen_ir.py", line 226, in clang_cpp
    return subprocess.check_output(cmd)
           ~~~~~~~~~~~~~~~~~~~~~~~^^^^^
  File "C:\Python313\Lib\subprocess.py", line 472, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
           ~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
               **kwargs).stdout
               ^^^^^^^^^
  File "C:\Python313\Lib\subprocess.py", line 577, in run
    raise CalledProcessError(retcode, process.args,
                             output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command '['C:\\Program Files (x86)\\Microsoft Visual Studio\\2022\\BuildTools\\VC\\Tools\\Llvm\\bin\\clang++.exe', '-Xclang', '-ast-dump=json', '-c', '-ID:\\work\\defold\\engine\\jni', '-ID:\\work\\defold\\tmp\\dynamo_home\\sdk\\include', 'src\\test\\jni/Testapi.empty.cpp']' returned non-zero exit status 1.

[exec] C:\Python313\python.exe D:\work\defold\tmp\dynamo_home/ext/bin/waf --prefix=D:\work\defold\tmp\dynamo_home --skip-tests distclean configure build install --platform=x86_64-win32
Error:
Traceback (most recent call last):
  File "D:\work\defold\scripts\build.py", line 3084, in <module>
    f()
    ~^^
  File "D:\work\defold\scripts\build.py", line 1731, in build_engine
    self._build_engine_lib(args, lib, host, skip_tests = host_lib_skip_tests)
    ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\work\defold\scripts\build.py", line 1676, in _build_engine_lib
    self._build_engine_lib_waf(args, lib, platform, skip_tests, directory)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\work\defold\scripts\build.py", line 1582, in _build_engine_lib_waf
    run.env_command(self._form_env(), args + plf_args + self.waf_options + skip_build_tests, cwd = cwd)
    ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\work\defold\build_tools\run.py", line 161, in env_command
    return _exec_command(args, shell = False, stdout = None, env = env, **kwargs)
  File "D:\work\defold\build_tools\run.py", line 138, in _exec_command
    raise e
run.ExecException: 2
```

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
