### PR TITLE
Added dmGraphics::VulkanGetImage and dmGraphics::VulkanGetImageView to dmsdk

### DIFF
--- a/engine/graphics/src/dmsdk/graphics/graphics_vulkan.h
+++ b/engine/graphics/src/dmsdk/graphics/graphics_vulkan.h
@@ -123,6 +123,26 @@ namespace dmGraphics
     VkCommandBuffer VulkanGetCurrentFrameCommandBuffer(HContext context);
 
     /*#
+     * Get the native Vulkan image handle from an engine texture handle.
+     * Returns `0` if the texture handle does not resolve to a Vulkan image.
+     * @name VulkanGetImage
+     * @param context [type:dmGraphics::HContext] the Vulkan context
+     * @param texture [type:dmGraphics::HTexture] the texture handle
+     * @return image [type:VkImage] the Vulkan image handle
+     */
+    VkImage VulkanGetImage(HContext context, HTexture texture);
+
+    /*#
+     * Get the native Vulkan image view handle from an engine texture handle.
+     * Returns `0` if the texture handle does not resolve to a Vulkan image view.
+     * @name VulkanGetImageView
+     * @param context [type:dmGraphics::HContext] the Vulkan context
+     * @param texture [type:dmGraphics::HTexture] the texture handle
+     * @return image_view [type:VkImageView] the Vulkan image view handle
+     */
+    VkImageView VulkanGetImageView(HContext context, HTexture texture);
+
+    /*#
      * Create Vulkan descriptor pool. No need to deallocate descripto pool manualy 
      * because it will be deallocated automatically when context will be destroyed.
      * Only available when using Mac/iOS.

--- a/engine/graphics/src/vulkan/graphics_vulkan.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan.cpp
@@ -4979,6 +4979,19 @@ bail:
     {
         VulkanContext* context = (VulkanContext*) _context;
         return context->m_MainCommandBuffers[context->m_SwapChain->m_ImageIndex];
+
+    VkImage VulkanGetImage(HContext _context, HTexture texture)
+    {
+        VulkanContext* context = (VulkanContext*) _context;
+        VulkanTexture* tex = GetAssetFromContainer<VulkanTexture>(g_VulkanContext->m_AssetHandleContainer, texture);
+        return tex ? tex->m_Handle.m_Image : 0;
+    }
+
+    VkImageView VulkanGetImageView(HContext _context, HTexture texture)
+    {
+        VulkanContext* context = (VulkanContext*) _context;
+        VulkanTexture* tex = GetAssetFromContainer<VulkanTexture>(g_VulkanContext->m_AssetHandleContainer, texture);
+        return tex ? tex->m_Handle.m_ImageView : 0;
     }
 
     bool VulkanCreateDescriptorPool(VkDevice vk_device, uint16_t max_descriptors, VkDescriptorPool* vk_descriptor_pool_out)

--- a/engine/graphics/src/vulkan/graphics_vulkan.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan.cpp
@@ -4979,6 +4979,7 @@ bail:
     {
         VulkanContext* context = (VulkanContext*) _context;
         return context->m_MainCommandBuffers[context->m_SwapChain->m_ImageIndex];
+    }
 
     VkImage VulkanGetImage(HContext _context, HTexture texture)
     {

--- a/engine/graphics/src/vulkan/graphics_vulkan.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan.cpp
@@ -4983,6 +4983,7 @@ bail:
     VkImage VulkanGetImage(HContext _context, HTexture texture)
     {
         VulkanContext* context = (VulkanContext*) _context;
+        DM_MUTEX_SCOPED_LOCK(context->m_AssetHandleContainerMutex);
         VulkanTexture* tex = GetAssetFromContainer<VulkanTexture>(g_VulkanContext->m_AssetHandleContainer, texture);
         return tex ? tex->m_Handle.m_Image : 0;
     }
@@ -4990,6 +4991,7 @@ bail:
     VkImageView VulkanGetImageView(HContext _context, HTexture texture)
     {
         VulkanContext* context = (VulkanContext*) _context;
+        DM_MUTEX_SCOPED_LOCK(context->m_AssetHandleContainerMutex);
         VulkanTexture* tex = GetAssetFromContainer<VulkanTexture>(g_VulkanContext->m_AssetHandleContainer, texture);
         return tex ? tex->m_Handle.m_ImageView : 0;
     }


### PR DESCRIPTION
This allows the developer to get a native `VkImage` and `VkImageView` from a `dmGraphics::HTexture`.
It helps when interacting with other 3rd party libraries.

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
