### PR TITLE
Remove unnecessary resource sync on project open

### DIFF
--- a/editor/src/clj/editor/boot_open_project.clj
+++ b/editor/src/clj/editor/boot_open_project.clj
@@ -96,7 +96,6 @@
 
     (workspace/clean-editor-plugins! workspace)
     (resource-types/register-resource-types! workspace)
-    (workspace/resource-sync! workspace)
     (workspace/load-build-cache! workspace)
     workspace))
 
@@ -436,7 +435,7 @@
           build-settings (workspace/make-build-settings prefs)
           workspace-config (shared-editor-settings/load-project-workspace-config project-path localization)
           workspace (setup-workspace! project-path build-settings workspace-config localization)
-          game-project-res (workspace/resolve-workspace-resource workspace "/game.project")
+          game-project-res (workspace/file-resource workspace "/game.project")
           extensions (extensions/make *project-graph*)
           project (project/open-project! *project-graph* extensions workspace game-project-res render-progress!)]
       (ui/run-now

--- a/editor/src/dev/load_project.clj
+++ b/editor/src/dev/load_project.clj
@@ -22,9 +22,10 @@
             [editor.progress :as progress]
             [editor.resource :as resource]
             [editor.resource-node :as resource-node]
+            [editor.resource-types :as resource-types]
+            [editor.scene :as scene]
             [editor.shared-editor-settings :as shared-editor-settings]
             [editor.workspace :as workspace]
-            [integration.test-util :as test-util]
             [internal.graph.types]
             [internal.system :as is]
             [internal.transaction :as it]
@@ -130,13 +131,22 @@
 (defonce ^:private -set-system- (do (reset! g/*the-system* (is/make-system system-config)) nil))
 (defonce workspace-graph-id (g/last-graph-added))
 
+(defn- setup-workspace! [workspace-graph-id project-path]
+  (let [workspace-config (shared-editor-settings/load-project-workspace-config project-path localization)
+        workspace (workspace/make-workspace workspace-graph-id project-path {} workspace-config localization)]
+    (g/transact
+      (concat
+        (scene/register-view-types workspace)))
+    (resource-types/register-resource-types! workspace)
+    workspace))
+
 (defonce workspace
   (run-and-measure-task!
     :setup-workspace
-    (test-util/setup-workspace! workspace-graph-id project-path)))
+    (setup-workspace! workspace-graph-id project-path)))
 
 (defonce game-project-resource
-  (workspace/find-resource workspace "/game.project"))
+  (workspace/file-resource workspace "/game.project"))
 
 (defonce up-to-date-lib-states
   (run-and-measure-task!


### PR DESCRIPTION
We had a useless resource sync before the real resource sync when opening a project. Removing it improves the open project time by 5% on big projects (on an example project: 1m51s -> 1m45s)

Related to https://github.com/defold/defold/issues/11989