### PR TITLE
Invalidate all successors on project load

### DIFF
--- a/editor/src/clj/dynamo/graph.clj
+++ b/editor/src/clj/dynamo/graph.clj
@@ -304,21 +304,57 @@
   (when (and (not (:dry-run transact-opts))
              (= :ok (:status tx-result)))
     (swap! *the-system* is/merge-graphs (get-in tx-result [:basis :graphs]) (:graphs-modified tx-result) (:outputs-modified tx-result) (:nodes-deleted tx-result))
+    (when-not (:track-changes transact-opts true)
+      (clear-system-cache!))
     nil))
 
 (defn transact
-  "Provides a way to run a transaction against the graph system.  It takes a list of transaction steps.
+  "Runs a transaction against the graph system.
+
+  Args:
+    opts    optional map with transaction settings:
+              :dry-run
+                Returns the tx report without committing to *the-system*.
+
+              :metrics
+                The metrics collector; results are returned in :metrics.
+
+              :track-changes
+                Defaults to true. When false, disables precise change tracking
+                and uses coarse cache invalidation instead of incremental
+                updates. The system cache is cleared automatically after
+                commit, but older evaluation contexts may still be stale and
+                must not be written back into the cache. Undo history is not
+                tracked accurately in this mode, so callers that need
+                consistent undo semantics must reset or otherwise manage
+                history explicitly.
+
+              :tx-data-context-map
+                Initial transaction data context map. The final value is
+                returned as :tx-data-context-map.
+    txs     sequence of transaction steps
 
   Example:
 
       (g/transact
-         [(g/connect n1 output-name n :xs)
+        [(g/connect n1 output-name n :xs)
          (g/connect n2 output-name n :xs)])
 
-  It returns the transaction result, (tx-result),  which is a map containing keys about the transaction.
-  Transaction result-keys:
-  `[:status :basis :graphs-modified :nodes-added :nodes-modified :nodes-deleted :outputs-modified :label :sequence-label]`
-  "
+  Returns a transaction result, a map with the following keys:
+    :status                :empty if no transaction steps completed, otherwise
+                           :ok
+    :basis                 transaction basis after applying the transaction
+    :graphs-modified       modified graph ids, most useful when change tracking
+                           is enabled
+    :nodes-added           added node ids
+    :nodes-modified        modified node ids when change tracking is enabled
+    :nodes-deleted         deleted nodes by node id
+    :outputs-modified      modified endpoints when change tracking is enabled
+    :label                 transaction label, if any
+    :sequence-label        transaction sequence label, if any
+    :tx-data-context-map   final transaction context map
+    :metrics               transaction metrics, when metrics collection is
+                           enabled"
   ([txs]
    (transact nil txs))
   ([opts txs]

--- a/editor/src/clj/dynamo/graph.clj
+++ b/editor/src/clj/dynamo/graph.clj
@@ -296,15 +296,15 @@
         override-id-generator (is/override-id-generator system)
         tx-data-context-map (or (:tx-data-context-map opts) {})
         metrics-collector (:metrics opts)
-        track-changes (:track-changes opts true)]
-    (it/new-transaction-context basis id-generators override-id-generator tx-data-context-map metrics-collector track-changes)))
+        full-invalidation (:full-invalidation opts)]
+    (it/new-transaction-context basis id-generators override-id-generator tx-data-context-map metrics-collector full-invalidation)))
 
 (defn commit-tx-result!
   [tx-result transact-opts]
   (when (and (not (:dry-run transact-opts))
              (= :ok (:status tx-result)))
     (swap! *the-system* is/merge-graphs (get-in tx-result [:basis :graphs]) (:graphs-modified tx-result) (:outputs-modified tx-result) (:nodes-deleted tx-result))
-    (when-not (:track-changes transact-opts true)
+    (when (:full-invalidation transact-opts)
       (clear-system-cache!))
     nil))
 
@@ -319,9 +319,9 @@
               :metrics
                 The metrics collector; results are returned in :metrics.
 
-              :track-changes
-                Defaults to true. When false, disables precise change tracking
-                and uses coarse cache invalidation instead of incremental
+              :full-invalidation
+                Defaults to false. When true, disables precise change
+                tracking and uses full invalidation instead of incremental
                 updates. The system cache is cleared automatically after
                 commit, but older evaluation contexts may still be stale and
                 must not be written back into the cache. Undo history is not
@@ -344,12 +344,14 @@
     :status                :empty if no transaction steps completed, otherwise
                            :ok
     :basis                 transaction basis after applying the transaction
-    :graphs-modified       modified graph ids, most useful when change tracking
-                           is enabled
+    :graphs-modified       modified graph ids, most useful when full
+                           invalidation is disabled
     :nodes-added           added node ids
-    :nodes-modified        modified node ids when change tracking is enabled
+    :nodes-modified        modified node ids when full invalidation is
+                           disabled
     :nodes-deleted         deleted nodes by node id
-    :outputs-modified      modified endpoints when change tracking is enabled
+    :outputs-modified      modified endpoints when full invalidation is
+                           disabled
     :label                 transaction label, if any
     :sequence-label        transaction sequence label, if any
     :tx-data-context-map   final transaction context map

--- a/editor/src/clj/editor/defold_project.clj
+++ b/editor/src/clj/editor/defold_project.clj
@@ -996,12 +996,12 @@
 
          total-progress (progress/advance total-progress read-progress-span)
 
-         ;; We can disable change tracking on the initial load since we have
+         ;; We can use full invalidation on the initial load since we have
          ;; nothing in the cache and will reset the undo history afterward.
-         change-tracked-transact false
+         full-invalidation-transact true
 
          transact-opts {:metrics transaction-metrics
-                        :track-changes change-tracked-transact}
+                        :full-invalidation full-invalidation-transact}
 
          prelude-tx-data
          (e/concat

--- a/editor/src/clj/editor/defold_project.clj
+++ b/editor/src/clj/editor/defold_project.clj
@@ -1026,14 +1026,6 @@
            (du/measuring process-metrics :load-new-nodes
              (load-nodes! project prelude-tx-data node-load-infos render-progress! resource-metrics transact-opts)))]
 
-     ;; When we're not tracking changes, we will not evict stale values from the
-     ;; system cache. This means subsequent graph queries won't see the changes
-     ;; from the transaction if a value was previously cached. To be on the safe
-     ;; side, we clear the cache after each transaction we perform with change
-     ;; tracking disabled.
-     (when-not change-tracked-transact
-       (g/clear-system-cache!))
-
      (cache-loaded-save-data! node-load-infos project migrated-resource-node-ids)
      (render-progress! progress/done)
 

--- a/editor/src/clj/internal/graph.clj
+++ b/editor/src/clj/internal/graph.clj
@@ -1262,8 +1262,8 @@
           basis
           (util/group-into (comp gt/node-id->graph-id first) changes)))
 
-(defn invalidate-all-successors
-  [basis]
-  (update basis :graphs #(coll/map-vals (fn [graph]
-                                          (assoc graph :successors (make-successors)))
-                                        %)))
+(defn- invalidate-graph-all-successors [graph]
+  (assoc graph :successors (make-successors)))
+
+(defn invalidate-all-successors [basis]
+  (update basis :graphs coll/update-vals invalidate-graph-all-successors))

--- a/editor/src/clj/internal/graph.clj
+++ b/editor/src/clj/internal/graph.clj
@@ -1261,3 +1261,9 @@
               basis))
           basis
           (util/group-into (comp gt/node-id->graph-id first) changes)))
+
+(defn invalidate-all-successors
+  [basis]
+  (update basis :graphs #(coll/map-vals (fn [graph]
+                                          (assoc graph :successors (make-successors)))
+                                        %)))

--- a/editor/src/clj/internal/transaction.clj
+++ b/editor/src/clj/internal/transaction.clj
@@ -29,6 +29,7 @@
            [java.util.concurrent.atomic AtomicInteger]))
 
 (set! *warn-on-reflection* true)
+(set! *unchecked-math* :warn-on-boxed)
 
 (defonce/interface TransactionStep
   (step_type []) ; Returns a keyword uniquely identifying the type of transaction step.
@@ -52,7 +53,7 @@
 (defn- mark-input-activated
   [ctx node-id input-label]
   ;; This gets called a lot, so we're trying to keep allocations to a minimum.
-  (if-not (:track-changes ctx)
+  (if (:full-invalidation ctx)
     ctx
     (let [basis (:basis ctx)
           dirty-deps (-> (gt/node-by-id-at basis node-id)
@@ -69,7 +70,7 @@
 (defn- mark-output-activated
   [ctx node-id output-label]
   ;; This gets called a lot, so we're trying to keep allocations to a minimum.
-  (if-not (:track-changes ctx)
+  (if (:full-invalidation ctx)
     ctx
     (let [nodes-affected (:nodes-affected ctx)]
       (assoc ctx
@@ -79,7 +80,7 @@
 (defn- mark-outputs-activated
   [ctx node-id output-labels]
   ;; This gets called a lot, so we're trying to keep allocations to a minimum.
-  (if-not (:track-changes ctx)
+  (if (:full-invalidation ctx)
     ctx
     (let [nodes-affected (:nodes-affected ctx)]
       (assoc ctx
@@ -91,7 +92,7 @@
 (defn- mark-all-outputs-activated
   [ctx node-id]
   ;; This gets called a lot, so we're trying to keep allocations to a minimum.
-  (if-not (:track-changes ctx)
+  (if (:full-invalidation ctx)
     ctx
     (let [basis (:basis ctx)
           output-labels (-> (gt/node-by-id-at basis node-id)
@@ -214,7 +215,7 @@
           "Override nodes must belong to the same graph as the original")
   (let [basis (:basis ctx)
         ctx (assoc ctx :basis (gt/override-node basis original-node-id override-node-id))]
-    (if (:track-changes ctx)
+    (if-not (:full-invalidation ctx)
       (let [all-originals (ig/override-originals basis original-node-id)]
         (-> ctx
             ;; Any property, input or output on any original nodes must now take the
@@ -665,7 +666,7 @@
             (mark-input-activated target-id target-label)
             (update :basis gt/connect source-id source-label target-id target-label)
             (cond->
-              (:track-changes ctx)
+              (not (:full-invalidation ctx))
               ;; When updating the successors, we must also consider any override
               ;; nodes of the source node, since these will inherit an implicit
               ;; connection between them and the corresponding override nodes of
@@ -708,20 +709,21 @@
   (-> ctx
       (mark-input-activated target-id target-label)
       (update :basis gt/disconnect source-id source-label target-id target-label)
-      (cond-> (:track-changes ctx)
+      (cond-> (not (:full-invalidation ctx))
         ;; When updating the successors, we must also consider any override nodes
         ;; of the source node, since these will inherit an implicit connection
         ;; between them and the corresponding override nodes of the target node.
-        (flag-successors-changed (e/cons
-                                   (pair source-id source-label)
-                                   (e/map #(pair % source-label)
-                                          (ig/get-overrides (:basis ctx) source-id)))))
+        (flag-successors-changed
+          (e/cons
+            (pair source-id source-label)
+            (e/map #(pair % source-label)
+                   (ig/get-overrides (:basis ctx) source-id)))))
       (ctx-remove-overrides source-id source-label target-id target-label)))
 
 (defn- ctx-update-graph-value
   [ctx graph-id fn args]
   (cond-> (update-in ctx [:basis :graphs graph-id :graph-values] #(apply fn % args))
-          (:track-changes ctx) (update :graphs-modified conj graph-id)))
+          (not (:full-invalidation ctx)) (update :graphs-modified conj graph-id)))
 
 ;; ---------------------------------------------------------------------------
 ;; Transaction steps
@@ -1080,12 +1082,12 @@
 (defn finalize-update
   [{:keys [nodes-modified graphs-modified tx-data-context] :as ctx}]
   (-> (select-keys ctx tx-report-keys)
-      (assoc :status (if (zero? (:completed-action-count ctx)) :empty :ok)
+      (assoc :status (if (zero? (long (:completed-action-count ctx))) :empty :ok)
              :graphs-modified (into graphs-modified (map gt/node-id->graph-id) nodes-modified)
              :tx-data-context-map (deref tx-data-context))))
 
 (defn new-transaction-context
-  [basis node-id-generators override-id-generator tx-data-context-map metrics-collector track-changes]
+  [basis node-id-generators override-id-generator tx-data-context-map metrics-collector full-invalidation]
   {:pre [(map? tx-data-context-map)]}
   {:basis basis
    :nodes-affected #{}
@@ -1103,7 +1105,7 @@
    :txid (new-txid)
    :tx-data-context (atom tx-data-context-map)
    :metrics metrics-collector
-   :track-changes track-changes})
+   :full-invalidation full-invalidation})
 
 (defn update-overrides
   [{:keys [override-nodes-affected-ordered] :as ctx}]
@@ -1113,17 +1115,17 @@
             override-nodes-affected-ordered)))
 
 (defn update-successors
-  [{:keys [completed-action-count successors-changed] :as ctx}]
+  [{:keys [^long completed-action-count successors-changed] :as ctx}]
   (du/measuring (:metrics ctx) :update-successors
     (cond
       (zero? completed-action-count)
       ctx
 
-      (:track-changes ctx)
-      (update ctx :basis ig/update-successors successors-changed)
+      (:full-invalidation ctx)
+      (update ctx :basis ig/invalidate-all-successors)
 
       :else
-      (update ctx :basis ig/invalidate-all-successors))))
+      (update ctx :basis ig/update-successors successors-changed))))
 
 (defn trace-dependencies
   [ctx]

--- a/editor/src/clj/internal/transaction.clj
+++ b/editor/src/clj/internal/transaction.clj
@@ -215,7 +215,8 @@
           "Override nodes must belong to the same graph as the original")
   (let [basis (:basis ctx)
         ctx (assoc ctx :basis (gt/override-node basis original-node-id override-node-id))]
-    (if-not (:full-invalidation ctx)
+    (if (:full-invalidation ctx)
+      ctx
       (let [all-originals (ig/override-originals basis original-node-id)]
         (-> ctx
             ;; Any property, input or output on any original nodes must now take the
@@ -224,8 +225,7 @@
 
             ;; Similarly, so must the source outputs of any arcs that target any of
             ;; the original nodes.
-            (flag-successors-changed (e/mapcat #(gt/sources basis %) all-originals))))
-      ctx)))
+            (flag-successors-changed (e/mapcat #(gt/sources basis %) all-originals)))))))
 
 (defonce/type NewOverrideTXS [override-id root-id traverse-fn init-props-fn]
   TransactionStep

--- a/editor/src/clj/internal/transaction.clj
+++ b/editor/src/clj/internal/transaction.clj
@@ -213,17 +213,18 @@
   (assert (= (gt/node-id->graph-id original-node-id) (gt/node-id->graph-id override-node-id))
           "Override nodes must belong to the same graph as the original")
   (let [basis (:basis ctx)
-        all-originals (ig/override-originals basis original-node-id)]
-    (-> ctx
-        (assoc :basis (gt/override-node basis original-node-id override-node-id))
+        ctx (assoc ctx :basis (gt/override-node basis original-node-id override-node-id))]
+    (if (:track-changes ctx)
+      (let [all-originals (ig/override-originals basis original-node-id)]
+        (-> ctx
+            ;; Any property, input or output on any original nodes must now take the
+            ;; new override node into account.
+            (flag-all-successors-changed all-originals)
 
-        ;; Any property, input or output on any original nodes must now take the
-        ;; new override node into account.
-        (flag-all-successors-changed all-originals)
-
-        ;; Similarly, so must the source outputs of any arcs that target any of
-        ;; the original nodes.
-        (flag-successors-changed (e/mapcat #(gt/sources basis %) all-originals)))))
+            ;; Similarly, so must the source outputs of any arcs that target any of
+            ;; the original nodes.
+            (flag-successors-changed (e/mapcat #(gt/sources basis %) all-originals))))
+      ctx)))
 
 (defonce/type NewOverrideTXS [override-id root-id traverse-fn init-props-fn]
   TransactionStep
@@ -663,20 +664,23 @@
             (ctx-disconnect-single target target-id target-label)
             (mark-input-activated target-id target-label)
             (update :basis gt/connect source-id source-label target-id target-label)
-            ;; When updating the successors, we must also consider any override
-            ;; nodes of the source node, since these will inherit an implicit
-            ;; connection between them and the corresponding override nodes of
-            ;; the target node.
-            (flag-successors-changed (e/cons
-                                       (pair source-id source-label)
-                                       (e/map #(pair % source-label)
-                                              (ig/get-overrides basis source-id))))
-            ;; If we're connecting to a :cascade-delete input, we will need to
-            ;; re-traverse the :cascade-delete inputs of the connected sub-graph
-            ;; and create override nodes for each node. This happens in the
-            ;; update-overrides function once the transaction concludes.
             (cond->
+              (:track-changes ctx)
+              ;; When updating the successors, we must also consider any override
+              ;; nodes of the source node, since these will inherit an implicit
+              ;; connection between them and the corresponding override nodes of
+              ;; the target node.
+              (flag-successors-changed
+                (e/cons
+                  (pair source-id source-label)
+                  (e/map #(pair % source-label)
+                         (ig/get-overrides basis source-id))))
+
               (contains? target-cascade-deletes target-label)
+              ;; If we're connecting to a :cascade-delete input, we will need to
+              ;; re-traverse the :cascade-delete inputs of the connected sub-graph
+              ;; and create override nodes for each node. This happens in the
+              ;; update-overrides function once the transaction concludes.
               (flag-override-nodes-affected target-id))))
       ctx)
     ctx))
@@ -704,13 +708,14 @@
   (-> ctx
       (mark-input-activated target-id target-label)
       (update :basis gt/disconnect source-id source-label target-id target-label)
-      ;; When updating the successors, we must also consider any override nodes
-      ;; of the source node, since these will inherit an implicit connection
-      ;; between them and the corresponding override nodes of the target node.
-      (flag-successors-changed (e/cons
-                                 (pair source-id source-label)
-                                 (e/map #(pair % source-label)
-                                        (ig/get-overrides (:basis ctx) source-id))))
+      (cond-> (:track-changes ctx)
+        ;; When updating the successors, we must also consider any override nodes
+        ;; of the source node, since these will inherit an implicit connection
+        ;; between them and the corresponding override nodes of the target node.
+        (flag-successors-changed (e/cons
+                                   (pair source-id source-label)
+                                   (e/map #(pair % source-label)
+                                          (ig/get-overrides (:basis ctx) source-id)))))
       (ctx-remove-overrides source-id source-label target-id target-label)))
 
 (defn- ctx-update-graph-value
@@ -1108,9 +1113,17 @@
             override-nodes-affected-ordered)))
 
 (defn update-successors
-  [{:keys [successors-changed] :as ctx}]
+  [{:keys [completed-action-count successors-changed] :as ctx}]
   (du/measuring (:metrics ctx) :update-successors
-    (update ctx :basis ig/update-successors successors-changed)))
+    (cond
+      (zero? completed-action-count)
+      ctx
+
+      (:track-changes ctx)
+      (update ctx :basis ig/update-successors successors-changed)
+
+      :else
+      (update ctx :basis ig/invalidate-all-successors))))
 
 (defn trace-dependencies
   [ctx]

--- a/editor/src/dev/load_project.clj
+++ b/editor/src/dev/load_project.clj
@@ -96,11 +96,11 @@
 (defonce ^:private resource-metrics (du/make-metrics-collector))
 (defonce ^:private transaction-metrics (du/make-metrics-collector))
 
-(defonce ^:private change-tracked-transact false)
+(defonce ^:private full-invalidation-transact true)
 
 (defonce ^:private transact-opts
   {:metrics transaction-metrics
-   :track-changes change-tracked-transact})
+   :full-invalidation full-invalidation-transact})
 
 (defn- measure-task-impl! [task-key task-fn]
   (let [task-label (name task-key)]
@@ -235,8 +235,6 @@
                 (keep #(resource-node/owner-resource-node-id basis %))
                 (g/migrated-node-ids tx-result)))]
 
-    (when-not change-tracked-transact
-      (g/clear-system-cache!))
     (run-and-measure-task!
       :cache-save-data
       (project/cache-loaded-save-data! node-load-infos project migrated-resource-node-ids))

--- a/editor/test/internal/transaction_test.clj
+++ b/editor/test/internal/transaction_test.clj
@@ -202,6 +202,70 @@
         (is (= #{:_declared-properties :_properties :a-property :ordinary :self-dependent}
                (into #{} (map gt/endpoint-label) outputs-modified)))))))
 
+(defn- graph-successors-cache
+  [graph-id]
+  (get-in @g/*the-system* [:graphs graph-id :successors]))
+
+(deftest transact-without-change-tracking-test
+  (testing "invalidates all successors after a property update"
+    (ts/with-clean-system
+      (let [graph-a (g/make-graph! :history false)
+            graph-b (g/make-graph! :history false)
+            [resource-a receiver-a resource-b receiver-b] (ts/tx-nodes
+                                                            (g/make-node graph-a Resource)
+                                                            (g/make-node graph-a Receiver)
+                                                            (g/make-node graph-b Resource)
+                                                            (g/make-node graph-b Receiver))]
+        (g/transact
+          [(g/connect resource-a :b receiver-a :generic-input)
+           (g/connect resource-b :b receiver-b :generic-input)])
+
+        (is (= #{(g/endpoint receiver-a :passthrough)}
+               (set (g/successors (g/now) resource-a :b))))
+        (is (= #{(g/endpoint receiver-b :passthrough)}
+               (set (g/successors (g/now) resource-b :b))))
+
+        (let [graph-a-successors-before (graph-successors-cache graph-a)
+              graph-b-successors-before (graph-successors-cache graph-b)]
+          (g/transact {:track-changes false}
+            (g/set-property resource-a :marker (int 1)))
+
+          (let [graph-a-successors-after (graph-successors-cache graph-a)
+                graph-b-successors-after (graph-successors-cache graph-b)]
+            (is (not (identical? graph-a-successors-before graph-a-successors-after)))
+            (is (not (identical? graph-b-successors-before graph-b-successors-after)))
+            (is (= #{(g/endpoint receiver-b :passthrough)}
+                   (set (g/successors (g/now) resource-b :b)))))))))
+
+  (testing "does not invalidate successors for a no-op transaction"
+    (ts/with-clean-system
+      (let [graph (g/make-graph! :history false)
+            [resource receiver] (ts/tx-nodes
+                                  (g/make-node graph Resource)
+                                  (g/make-node graph Receiver))]
+        (g/transact
+          (g/connect resource :b receiver :generic-input))
+
+        (let [successors-before (graph-successors-cache graph)]
+          (g/transact {:track-changes false} [])
+          (is (identical? successors-before (graph-successors-cache graph)))))))
+
+  (testing "recomputes topology changes after connect and disconnect"
+    (ts/with-clean-system
+      (let [graph (g/make-graph! :history false)
+            [resource receiver] (ts/tx-nodes
+                                  (g/make-node graph Resource)
+                                  (g/make-node graph Receiver))]
+        (g/transact {:track-changes false}
+          (g/connect resource :b receiver :generic-input))
+        (is (= #{(g/endpoint receiver :passthrough)}
+               (set (g/successors (g/now) resource :b))))
+
+        (g/transact {:track-changes false}
+          (g/disconnect resource :b receiver :generic-input))
+        (is (= #{}
+               (set (g/successors (g/now) resource :b))))))))
+
 (g/defnode CachedValueNode
   (output cached-output g/Str :cached (g/fnk [] "an-output-value")))
 

--- a/editor/test/internal/transaction_test.clj
+++ b/editor/test/internal/transaction_test.clj
@@ -206,8 +206,8 @@
   [graph-id]
   (get-in @g/*the-system* [:graphs graph-id :successors]))
 
-(deftest transact-without-change-tracking-test
-  (testing "invalidates all successors after a property update"
+(deftest transact-with-full-invalidation-test
+  (testing "Invalidates all graph successor caches after a property update."
     (ts/with-clean-system
       (let [graph-a (g/make-graph! :history false)
             graph-b (g/make-graph! :history false)
@@ -227,17 +227,22 @@
 
         (let [graph-a-successors-before (graph-successors-cache graph-a)
               graph-b-successors-before (graph-successors-cache graph-b)]
-          (g/transact {:track-changes false}
+          (g/transact {:full-invalidation true}
             (g/set-property resource-a :marker (int 1)))
 
           (let [graph-a-successors-after (graph-successors-cache graph-a)
                 graph-b-successors-after (graph-successors-cache graph-b)]
+            ;; :successors is a mutable cache object stored per graph. With full
+            ;; invalidation, we conservatively replace that cache for every
+            ;; graph. This ensures later successor queries are recomputed from
+            ;; the current topology instead of using stale cached data from
+            ;; before the transaction.
             (is (not (identical? graph-a-successors-before graph-a-successors-after)))
             (is (not (identical? graph-b-successors-before graph-b-successors-after)))
             (is (= #{(g/endpoint receiver-b :passthrough)}
                    (set (g/successors (g/now) resource-b :b)))))))))
 
-  (testing "does not invalidate successors for a no-op transaction"
+  (testing "Does not invalidate successors for a no-op transaction."
     (ts/with-clean-system
       (let [graph (g/make-graph! :history false)
             [resource receiver] (ts/tx-nodes
@@ -247,21 +252,21 @@
           (g/connect resource :b receiver :generic-input))
 
         (let [successors-before (graph-successors-cache graph)]
-          (g/transact {:track-changes false} [])
+          (g/transact {:full-invalidation true} [])
           (is (identical? successors-before (graph-successors-cache graph)))))))
 
-  (testing "recomputes topology changes after connect and disconnect"
+  (testing "Recomputes topology changes after connect and disconnect."
     (ts/with-clean-system
       (let [graph (g/make-graph! :history false)
             [resource receiver] (ts/tx-nodes
                                   (g/make-node graph Resource)
                                   (g/make-node graph Receiver))]
-        (g/transact {:track-changes false}
+        (g/transact {:full-invalidation true}
           (g/connect resource :b receiver :generic-input))
         (is (= #{(g/endpoint receiver :passthrough)}
                (set (g/successors (g/now) resource :b))))
 
-        (g/transact {:track-changes false}
+        (g/transact {:full-invalidation true}
           (g/disconnect resource :b receiver :generic-input))
         (is (= #{}
                (set (g/successors (g/now) resource :b))))))))


### PR DESCRIPTION
This change improves project load time on big projects by 13% (on a tested project: 1m46s -> 1m32s).

Related to #11989
