### PR TITLE
Use more efficient parallelization for reading resources

### DIFF
--- a/editor/src/clj/editor/defold_project.clj
+++ b/editor/src/clj/editor/defold_project.clj
@@ -54,6 +54,7 @@
             [service.log :as log]
             [util.coll :as coll :refer [pair]]
             [util.debug-util :as du]
+            [util.defonce :as defonce]
             [util.eduction :as e]
             [util.fn :as fn]
             [util.thread-util :as thread-util])
@@ -352,16 +353,17 @@
           (fn progress-fn [progress-message ^long node-index]
             (progress/make progress-message progress-size (inc node-index)))
           (fn indeterminate-progress-fn [progress-message ^long _node-index]
-            (progress/make-indeterminate progress-message)))]
-    (->> node-id+resource-pairs
-         (map-indexed vector)
-         (pmap (fn [[node-index [node-id resource]]]
-                 (let [proj-path (resource/proj-path resource)
-                       progress-message (localization/message "progress.reading-resource" {"resource" proj-path})
-                       progress (progress-fn progress-message node-index)]
-                   (render-progress! progress)
-                   (read-node-load-info node-id resource resource-metrics))))
-         (into []))))
+            (progress/make-indeterminate progress-message)))
+        progress-counter-atom (atom 0)]
+    (coll/pmapv
+      (fn [[node-id resource]]
+        (let [proj-path (resource/proj-path resource)
+              progress-message (localization/message "progress.reading-resource" {"resource" proj-path})
+              progress-index (dec (swap! progress-counter-atom inc))
+              progress (progress-fn progress-message progress-index)]
+          (render-progress! progress)
+          (read-node-load-info node-id resource resource-metrics)))
+      node-id+resource-pairs)))
 
 (defn node-load-infos->stored-disk-state [node-load-infos]
   (let [[disk-sha256s-by-node-id
@@ -1774,7 +1776,7 @@
                     load-tx-data
                     (gu/connect-existing-outputs node-type node-id consumer-node connections)))})))
 
-(deftype ProjectResourceListener [project-id]
+(defonce/type ProjectResourceListener [project-id]
   resource/ResourceListener
   (handle-changes [this changes render-progress!]
     (handle-resource-changes project-id changes render-progress!)))

--- a/editor/src/clj/util/coll.clj
+++ b/editor/src/clj/util/coll.clj
@@ -1047,20 +1047,35 @@
    (mapv #(apply f % args) coll)))
 
 (defn pmapv
-  "Like core.pmap, but eagerly returns a vector and uses virtual threads. Fails
-  fast by cancelling remaining tasks on the first error."
+  "Like core.pmap, but eagerly returns a vector, uses virtual threads, and
+  keeps a bounded number of tasks in flight. Fails fast by cancelling
+  remaining tasks on the first error."
   ([f coll]
    (let [items (if (vector? coll) coll (vec coll))
          item-count (count items)]
      (if (zero? item-count)
        []
        (let [binding-frame (Var/cloneThreadBindingFrame)
-             results (object-array item-count)]
+             results (object-array item-count)
+             next-index (AtomicInteger. 0)
+             worker-count (-> (.availableProcessors (Runtime/getRuntime))
+                              (* 2)
+                              (min (long item-count))
+                              (max 4))]
          (with-open [scope (StructuredTaskScope/open (StructuredTaskScope$Joiner/awaitAllSuccessfulOrThrow))]
-           (dotimes [index item-count]
-             (.fork scope ^Runnable #(do
-                                       (Var/resetThreadBindingFrame binding-frame)
-                                       (aset results index (f (nth items index))))))
+           (dotimes [_ worker-count]
+             (.fork
+               scope
+               ^Runnable
+               (fn []
+                 (do
+                   (Var/resetThreadBindingFrame binding-frame)
+                   (loop []
+                     (when-not (.isInterrupted (Thread/currentThread))
+                       (let [index (.getAndIncrement next-index)]
+                         (when (< index item-count)
+                           (aset results index (f (nth items index)))
+                           (recur)))))))))
            (try
              (.join scope)
              (catch StructuredTaskScope$FailedException e (throw (.getCause e))))

--- a/editor/src/clj/util/coll.clj
+++ b/editor/src/clj/util/coll.clj
@@ -1053,15 +1053,16 @@
   ([f coll]
    (let [items (if (vector? coll) coll (vec coll))
          item-count (count items)]
-     (if (zero? item-count)
-       []
+     (case item-count
+       0 []
+       1 [(f (items 0))]
        (let [binding-frame (Var/cloneThreadBindingFrame)
              results (object-array item-count)
              next-index (AtomicInteger. 0)
              worker-count (-> (.availableProcessors (Runtime/getRuntime))
                               (* 2)
-                              (min (long item-count))
-                              (max 4))]
+                              (max 4)
+                              (min item-count))]
          (with-open [scope (StructuredTaskScope/open (StructuredTaskScope$Joiner/awaitAllSuccessfulOrThrow))]
            (dotimes [_ worker-count]
              (.fork
@@ -1074,7 +1075,7 @@
                      (when-not (.isInterrupted (Thread/currentThread))
                        (let [index (.getAndIncrement next-index)]
                          (when (< index item-count)
-                           (aset results index (f (nth items index)))
+                           (aset results index (f (items index)))
                            (recur)))))))))
            (try
              (.join scope)

--- a/editor/src/clj/util/coll.clj
+++ b/editor/src/clj/util/coll.clj
@@ -15,8 +15,9 @@
 (ns util.coll
   (:refer-clojure :exclude [any? bounded-count empty? every? mapcat merge merge-with not-any? not-empty not-every? some update-vals])
   (:import [clojure.core Eduction Vec]
-           [clojure.lang Cons Cycle IEditableCollection LazySeq MapEntry Repeat]
+           [clojure.lang Cons Cycle IEditableCollection LazilyPersistentVector LazySeq MapEntry Repeat Var]
            [java.util ArrayList Arrays List]
+           [java.util.concurrent StructuredTaskScope StructuredTaskScope$FailedException StructuredTaskScope$Joiner]
            [java.util.concurrent.atomic AtomicInteger]))
 
 (set! *warn-on-reflection* true)
@@ -1044,3 +1045,25 @@
    (mapv f coll))
   ([coll f & args]
    (mapv #(apply f % args) coll)))
+
+(defn pmapv
+  "Like core.pmap, but eagerly returns a vector and uses virtual threads. Fails
+  fast by cancelling remaining tasks on the first error."
+  ([f coll]
+   (let [items (if (vector? coll) coll (vec coll))
+         item-count (count items)]
+     (if (zero? item-count)
+       []
+       (let [binding-frame (Var/cloneThreadBindingFrame)
+             results (object-array item-count)]
+         (with-open [scope (StructuredTaskScope/open (StructuredTaskScope$Joiner/awaitAllSuccessfulOrThrow))]
+           (dotimes [index item-count]
+             (.fork scope ^Runnable #(do
+                                       (Var/resetThreadBindingFrame binding-frame)
+                                       (aset results index (f (nth items index))))))
+           (try
+             (.join scope)
+             (catch StructuredTaskScope$FailedException e (throw (.getCause e))))
+           (LazilyPersistentVector/createOwning results))))))
+  ([f coll & colls]
+   (pmapv #(apply f %) (apply mapv vector coll colls))))

--- a/editor/test/util/coll_test.clj
+++ b/editor/test/util/coll_test.clj
@@ -1958,12 +1958,12 @@
                           (.await all-started)
                           (if (zero? value)
                             (throw (ex-info "boom" {}))
-                            (try
-                              (Thread/sleep 10000)
-                              value
-                              (catch InterruptedException _
-                                (swap! cancellation-count inc)
-                                :interrupted))))
+                            (loop []
+                              (if (.isInterrupted (Thread/currentThread))
+                                (do
+                                  (swap! cancellation-count inc)
+                                  :interrupted)
+                                (recur)))))
                         (range task-count))))
       (is (= true (.await all-started 1 TimeUnit/SECONDS)))
       (dotimes [_ 100]

--- a/editor/test/util/coll_test.clj
+++ b/editor/test/util/coll_test.clj
@@ -18,8 +18,9 @@
             [util.coll :as coll]
             [util.defonce :as defonce]
             [util.fn :as fn])
-  (:import [clojure.lang IPersistentVector PersistentArrayMap PersistentHashMap PersistentHashSet PersistentTreeMap PersistentTreeSet]
-           [java.util Hashtable]))
+  (:import [clojure.lang ExceptionInfo IPersistentVector PersistentArrayMap PersistentHashMap PersistentHashSet PersistentTreeMap PersistentTreeSet]
+           [java.util Hashtable]
+           [java.util.concurrent CountDownLatch TimeUnit]))
 
 (set! *warn-on-reflection* true)
 (set! *unchecked-math* :warn-on-boxed)
@@ -27,6 +28,8 @@
 (defonce/record Nothing [])
 (defonce/record JustA [a])
 (defonce/record PairAB [a b])
+
+(def ^:dynamic *pmapv-binding-test-value* nil)
 
 (defn- java-map
   ^Hashtable [& key-vals]
@@ -1905,3 +1908,65 @@
   (is (nil? (coll/primitive-vector-type (Object.))))
   (doseq [primitive-type [:boolean :char :byte :short :int :long :float :double]]
     (is (= primitive-type (coll/primitive-vector-type (vector-of primitive-type))))))
+
+(deftest pmapv-test
+  (testing "Single collection."
+    (is (= [] (coll/pmapv inc nil)))
+    (is (= [] (coll/pmapv inc [])))
+    (is (= [1 2 3] (coll/pmapv inc [0 1 2])))
+    (is (= [1 2 3] (coll/pmapv inc '(0 1 2)))))
+
+  (testing "Multiple collections."
+    (is (= [11 22 33]
+           (coll/pmapv + [1 2 3] [10 20 30])))
+    (is (= [11 22]
+           (coll/pmapv + [1 2 3] [10 20]))))
+
+  (testing "Preserves order."
+    (is (= (range 32)
+           (coll/pmapv (fn [^long value]
+                         (Thread/sleep ^long (- 31 value))
+                         value)
+                       (range 32)))))
+
+  (testing "Propagates thread bindings."
+    (binding [*pmapv-binding-test-value* :bound]
+      (is (= [[:bound 0] [:bound 1] [:bound 2] [:bound 3]]
+             (coll/pmapv (fn [value]
+                           [*pmapv-binding-test-value* value])
+                         (range 4))))))
+
+  (testing "Rethrows task failure."
+    (is (thrown-with-msg?
+          ExceptionInfo
+          #"boom 2"
+          (coll/pmapv (fn [value]
+                        (if (= 2 value)
+                          (throw (ex-info (str "boom " value) {:value value}))
+                          value))
+                      (range 4)))))
+
+  (testing "Cancels remaining tasks on failure."
+    (let [task-count 4
+          all-started (CountDownLatch. task-count)
+          cancellation-count (atom 0)]
+      (is (thrown-with-msg?
+            ExceptionInfo
+            #"boom"
+            (coll/pmapv (fn [^long value]
+                          (.countDown all-started)
+                          (.await all-started)
+                          (if (zero? value)
+                            (throw (ex-info "boom" {}))
+                            (try
+                              (Thread/sleep 10000)
+                              value
+                              (catch InterruptedException _
+                                (swap! cancellation-count inc)
+                                :interrupted))))
+                        (range task-count))))
+      (is (= true (.await all-started 1 TimeUnit/SECONDS)))
+      (dotimes [_ 100]
+        (when (< ^long @cancellation-count (dec task-count))
+          (Thread/sleep 10)))
+      (is (= (dec task-count) @cancellation-count)))))


### PR DESCRIPTION
This change improves project open performance on large projects by 4% (1m32s -> 1m28s).

Related to #11989