### PR TITLE
Fixed Vulkan swap chain synchronization

### DIFF
--- a/engine/graphics/src/vulkan/graphics_vulkan.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan.cpp
@@ -223,7 +223,6 @@ namespace dmGraphics
         for(uint8_t i=0; i < frame_resource_count; i++)
         {
             if (vkCreateSemaphore(vk_device, &vk_create_semaphore_info, 0, &frame_resources_out[i].m_ImageAvailable) != VK_SUCCESS ||
-                vkCreateSemaphore(vk_device, &vk_create_semaphore_info, 0, &frame_resources_out[i].m_RenderFinished) != VK_SUCCESS ||
                 vkCreateFence(vk_device, &vk_create_fence_info, 0, &frame_resources_out[i].m_SubmitFence) != VK_SUCCESS)
             {
                 return VK_ERROR_INITIALIZATION_FAILED;
@@ -1484,6 +1483,7 @@ bail:
 
         // Determine the swapchain image we rendered to
         uint32_t swapchainImageIndex = context->m_SwapChain->m_ImageIndex;
+        VkSemaphore renderFinishedSemaphore = context->m_SwapChain->m_RenderFinishedSemaphores[swapchainImageIndex];
 
         // End the current render pass
         EndRenderPass(context);
@@ -1503,7 +1503,7 @@ bail:
         submitInfo.commandBufferCount   = 1;
         submitInfo.pCommandBuffers      = &cmd;
         submitInfo.signalSemaphoreCount = 1;
-        submitInfo.pSignalSemaphores    = &currentFrame.m_RenderFinished;
+        submitInfo.pSignalSemaphores    = &renderFinishedSemaphore;
 
         res = vkQueueSubmit(context->m_LogicalDevice.m_GraphicsQueue, 1, &submitInfo, currentFrame.m_SubmitFence);
         CHECK_VK_ERROR(res);
@@ -1512,7 +1512,7 @@ bail:
         VkPresentInfoKHR presentInfo = {};
         presentInfo.sType              = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR;
         presentInfo.waitSemaphoreCount = 1;
-        presentInfo.pWaitSemaphores    = &currentFrame.m_RenderFinished;
+        presentInfo.pWaitSemaphores    = &renderFinishedSemaphore;
         presentInfo.swapchainCount     = 1;
         presentInfo.pSwapchains        = &context->m_SwapChain->m_SwapChain;
         presentInfo.pImageIndices      = &swapchainImageIndex;
@@ -4348,7 +4348,6 @@ bail:
 
         for (size_t i = 0; i < DM_MAX_FRAMES_IN_FLIGHT; i++) {
             FrameResource& frame_resource = context->m_FrameResources[i];
-            vkDestroySemaphore(vk_device, frame_resource.m_RenderFinished, 0);
             vkDestroySemaphore(vk_device, frame_resource.m_ImageAvailable, 0);
             vkDestroyFence(vk_device, frame_resource.m_SubmitFence, 0);
         }
@@ -4978,7 +4977,7 @@ bail:
     VkCommandBuffer VulkanGetCurrentFrameCommandBuffer(HContext _context)
     {
         VulkanContext* context = (VulkanContext*) _context;
-        return context->m_MainCommandBuffers[context->m_SwapChain->m_ImageIndex];
+        return context->m_MainCommandBuffers[context->m_CurrentFrameInFlight];
     }
 
     VkImage VulkanGetImage(HContext _context, HTexture texture)

--- a/engine/graphics/src/vulkan/graphics_vulkan.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan.cpp
@@ -1356,6 +1356,9 @@ bail:
         {
             dmAtomicStore32(&context->m_DeleteContextRequested, 1);
 
+            DeleteRenderTarget(_context, context->m_MainRenderTarget);
+            DeleteTexture(_context, context->m_CurrentSwapchainTexture);
+
             if (context->m_Instance != VK_NULL_HANDLE)
             {
                 vkDestroyInstance(context->m_Instance, 0);
@@ -1368,6 +1371,12 @@ bail:
             }
 
             ResetSetTextureAsyncState(context->m_SetTextureAsyncState);
+
+            for (uint32_t i = 0; i < DM_MAX_FRAMES_IN_FLIGHT; ++i)
+            {
+                FlushResourcesToDestroy(context, context->m_MainResourcesToDestroy[i]);
+                delete context->m_MainResourcesToDestroy[i];
+            }
 
             delete context;
             g_VulkanContext = 0x0;
@@ -3017,6 +3026,9 @@ bail:
         DestroyShader(context, program_ptr->m_VertexModule);
         DestroyShader(context, program_ptr->m_FragmentModule);
         DestroyShader(context, program_ptr->m_ComputeModule);
+        delete program_ptr->m_VertexModule;
+        delete program_ptr->m_FragmentModule;
+        delete program_ptr->m_ComputeModule;
 
         delete program_ptr;
     }
@@ -4305,14 +4317,19 @@ bail:
         DestroyTexture(vk_device, &context->m_MainTextureDepthStencil.m_Handle);
         DestroyDeviceBuffer(vk_device, &context->m_DefaultTexture2D->m_DeviceBuffer.m_Handle);
         DestroyTexture(vk_device, &context->m_DefaultTexture2D->m_Handle);
+        delete context->m_DefaultTexture2D;
         DestroyDeviceBuffer(vk_device, &context->m_DefaultTexture2DArray->m_DeviceBuffer.m_Handle);
         DestroyTexture(vk_device, &context->m_DefaultTexture2DArray->m_Handle);
+        delete context->m_DefaultTexture2DArray;
         DestroyDeviceBuffer(vk_device, &context->m_DefaultTextureCubeMap->m_DeviceBuffer.m_Handle);
         DestroyTexture(vk_device, &context->m_DefaultTextureCubeMap->m_Handle);
+        delete context->m_DefaultTextureCubeMap;
         DestroyDeviceBuffer(vk_device, &context->m_DefaultTexture2D32UI->m_DeviceBuffer.m_Handle);
         DestroyTexture(vk_device, &context->m_DefaultTexture2D32UI->m_Handle);
+        delete context->m_DefaultTexture2D32UI;
         DestroyDeviceBuffer(vk_device, &context->m_DefaultStorageImage2D->m_DeviceBuffer.m_Handle);
         DestroyTexture(vk_device, &context->m_DefaultStorageImage2D->m_Handle);
+        delete context->m_DefaultStorageImage2D;
 
         vkDestroyRenderPass(vk_device, context->m_MainRenderPass, 0);
 

--- a/engine/graphics/src/vulkan/graphics_vulkan_device.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan_device.cpp
@@ -1462,7 +1462,7 @@ bail:
     void DestroyDescriptorAllocator(VkDevice vk_device, DescriptorAllocator* allocator)
     {
         assert(allocator);
-        delete[] allocator->m_DescriptorSets;
+        free(allocator->m_DescriptorSets);
         allocator->m_DescriptorSets = 0x0;
 
         for (int i = 0; i < allocator->m_DescriptorPools.Size(); ++i)

--- a/engine/graphics/src/vulkan/graphics_vulkan_private.h
+++ b/engine/graphics/src/vulkan/graphics_vulkan_private.h
@@ -219,7 +219,6 @@ namespace dmGraphics
     struct FrameResource
     {
         VkSemaphore m_ImageAvailable;
-        VkSemaphore m_RenderFinished;
         VkFence     m_SubmitFence;
     };
 
@@ -367,6 +366,7 @@ namespace dmGraphics
 
         dmArray<VkImage>      m_Images;
         dmArray<VkImageView>  m_ImageViews;
+        dmArray<VkSemaphore>  m_RenderFinishedSemaphores;
         VulkanTexture*        m_ResolveTexture;
         const VkSurfaceKHR    m_Surface;
         const QueueFamily     m_QueueFamily;

--- a/engine/graphics/src/vulkan/graphics_vulkan_swap_chain.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan_swap_chain.cpp
@@ -221,6 +221,11 @@ namespace dmGraphics
         if (vk_old_swap_chain != VK_NULL_HANDLE)
         {
             DestroyVkSwapChain(vk_device, vk_old_swap_chain, swapChain->m_ImageViews);
+            for (uint32_t i = 0; i < swapChain->m_RenderFinishedSemaphores.Size(); ++i)
+            {
+                vkDestroySemaphore(vk_device, swapChain->m_RenderFinishedSemaphores[i], 0);
+            }
+            swapChain->m_RenderFinishedSemaphores.SetSize(0);
             DestroyTexture(vk_device, &swapChain->m_ResolveTexture->m_Handle);
         }
 
@@ -236,6 +241,8 @@ namespace dmGraphics
 
         swapChain->m_ImageViews.SetCapacity(swap_chain_image_count);
         swapChain->m_ImageViews.SetSize(swap_chain_image_count);
+        swapChain->m_RenderFinishedSemaphores.SetCapacity(swap_chain_image_count);
+        swapChain->m_RenderFinishedSemaphores.SetSize(swap_chain_image_count);
 
         if (swapChain->HasMultiSampling())
         {
@@ -292,6 +299,14 @@ namespace dmGraphics
             {
                 return res;
             }
+
+            VkSemaphoreCreateInfo semaphore_create_info = {};
+            semaphore_create_info.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
+            res = vkCreateSemaphore(vk_device, &semaphore_create_info, 0, &swapChain->m_RenderFinishedSemaphores[i]);
+            if (res != VK_SUCCESS)
+            {
+                return res;
+            }
         }
 
         return VK_SUCCESS;
@@ -301,6 +316,11 @@ namespace dmGraphics
     {
         assert(swapChain);
         DestroyVkSwapChain(vk_device, swapChain->m_SwapChain, swapChain->m_ImageViews);
+        for (uint32_t i = 0; i < swapChain->m_RenderFinishedSemaphores.Size(); ++i)
+        {
+            vkDestroySemaphore(vk_device, swapChain->m_RenderFinishedSemaphores[i], 0);
+        }
+        swapChain->m_RenderFinishedSemaphores.SetSize(0);
         DestroyTexture(vk_device, &swapChain->m_ResolveTexture->m_Handle);
 
         swapChain->m_SwapChain = VK_NULL_HANDLE;


### PR DESCRIPTION
Using the per-image m_RenderFinishedSemaphores from SwapChain instead of a per-frame semaphore, matching the logic already in graphics_vulkan_swap_chain.cpp and avoiding redundant semaphore creation/destruction.

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
