### PR TITLE
Shader precision options

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/ShaderProgramBuilderTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/ShaderProgramBuilderTest.java
@@ -27,7 +27,6 @@ import org.junit.Test;
 
 import com.dynamo.bob.CompileExceptionError;
 import com.dynamo.bob.Platform;
-import com.dynamo.bob.pipeline.Shaderc;
 import com.dynamo.graphics.proto.Graphics.ShaderDesc;
 
 public class ShaderProgramBuilderTest extends AbstractProtoBuilderTest {
@@ -895,6 +894,32 @@ public class ShaderProgramBuilderTest extends AbstractProtoBuilderTest {
         assertEquals(3, res_position.location);
         assertEquals(4, res_normal.location);
         assertEquals(5, res_tex_coord.location);
+
+        ShadercJni.DeleteShaderContext(ctx);
+    }
+
+    @Test
+    public void testGlslEsPrecisionOptions() throws Exception {
+        byte[] spvReflection = getFile("simple.spv");
+        assertNotNull(spvReflection);
+
+        long ctx = ShadercJni.NewShaderContext(Shaderc.ShaderStage.SHADER_STAGE_FRAGMENT.getValue(), spvReflection);
+        long compiler = ShadercJni.NewShaderCompiler(ctx, Shaderc.ShaderLanguage.SHADER_LANGUAGE_GLSL.getValue());
+
+        Shaderc.ShaderCompilerOptions opts = new Shaderc.ShaderCompilerOptions();
+        opts.version = 100;
+        opts.glslEs = 1;
+        opts.entryPoint = "main";
+        opts.glslEsDefaultFloatPrecision = Shaderc.ShaderPrecision.SHADER_PRECISION_HIGHP;
+        opts.glslEsDefaultIntPrecision = Shaderc.ShaderPrecision.SHADER_PRECISION_MEDIUMP;
+
+        Shaderc.ShaderCompileResult result = ShadercJni.Compile(ctx, compiler, opts);
+        assertNotNull(result);
+        assertNotNull(result.data);
+
+        String src = new String(result.data);
+        assertTrue(src.contains("precision highp float;"));
+        assertTrue(src.contains("precision mediump int;"));
 
         ShadercJni.DeleteShaderContext(ctx);
     }

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/ShaderProgramBuilderTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/ShaderProgramBuilderTest.java
@@ -642,6 +642,64 @@ public class ShaderProgramBuilderTest extends AbstractProtoBuilderTest {
         testOutput(expected, res.output);
     }
 
+    @Test
+    public void testLegacyPipelinePrecisionOptions() throws Exception {
+        String source =
+            "#extension GL_OES_standard_derivatives : enable\n" +
+            "void main() {\n" +
+            "    gl_FragColor = vec4(1.0);\n" +
+            "}";
+
+        // GLES 100 profile with non-default precisions
+        String es100 = ShaderUtil.Common.compileGLSL(
+                source,
+                ShaderDesc.ShaderType.SHADER_TYPE_FRAGMENT,
+                ShaderDesc.Language.LANGUAGE_GLES_SM100,
+                true,
+                false,
+                false,
+                Shaderc.ShaderPrecision.SHADER_PRECISION_HIGHP,
+                Shaderc.ShaderPrecision.SHADER_PRECISION_MEDIUMP);
+
+        String expectedEs100 =
+            "#extension GL_OES_standard_derivatives : enable\n" +
+            "\n" +
+            "precision highp float;\n" +
+            "precision mediump int;\n" +
+            "#line 1\n" +
+            "void main() {\n" +
+            "    gl_FragColor = vec4(1.0);\n" +
+            "}\n";
+
+        testOutput(expectedEs100, es100);
+
+        // GLES 300 es profile (legacy ES2 source goes through ES2ToES3Converter internally)
+        String es300 = ShaderUtil.Common.compileGLSL(
+                source,
+                ShaderDesc.ShaderType.SHADER_TYPE_FRAGMENT,
+                ShaderDesc.Language.LANGUAGE_GLES_SM300,
+                true,
+                false,
+                false,
+                Shaderc.ShaderPrecision.SHADER_PRECISION_HIGHP,
+                Shaderc.ShaderPrecision.SHADER_PRECISION_MEDIUMP);
+
+        String expectedEs300 =
+            "#version 300 es\n" +
+            "#extension GL_OES_standard_derivatives : enable\n" +
+            "\n" +
+            "precision highp float;\n" +
+            "precision mediump int;\n" +
+            "\n" +
+            "out vec4 _DMENGINE_GENERATED_gl_FragColor_0;\n" +
+            "#line 1\n" +
+            "void main() {\n" +
+            "    _DMENGINE_GENERATED_gl_FragColor_0 = vec4(1.0);\n" +
+            "}\n";
+
+        testOutput(expectedEs300, es300);
+    }
+
     private static ShaderDesc.Shader getShaderByLanguage(ShaderDesc shaderDesc, ShaderDesc.Language language) {
         for (ShaderDesc.Shader shader : shaderDesc.getShadersList()) {
             if (shader.getLanguage() == language) {

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/ShaderProgramBuilderTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/ShaderProgramBuilderTest.java
@@ -622,8 +622,8 @@ public class ShaderProgramBuilderTest extends AbstractProtoBuilderTest {
                 140,
                 true,
                 false,
-                "mediump",
-                "highp");
+                Shaderc.ShaderPrecision.SHADER_PRECISION_MEDIUMP,
+                Shaderc.ShaderPrecision.SHADER_PRECISION_HIGHP);
 
         expected =
             "#version 140\n" +
@@ -964,11 +964,12 @@ public class ShaderProgramBuilderTest extends AbstractProtoBuilderTest {
         long ctx = ShadercJni.NewShaderContext(Shaderc.ShaderStage.SHADER_STAGE_FRAGMENT.getValue(), spvReflection);
         long compiler = ShadercJni.NewShaderCompiler(ctx, Shaderc.ShaderLanguage.SHADER_LANGUAGE_GLSL.getValue());
 
+        // Test mediump
         Shaderc.ShaderCompilerOptions opts = new Shaderc.ShaderCompilerOptions();
         opts.version = 100;
         opts.glslEs = 1;
         opts.entryPoint = "main";
-        opts.glslEsDefaultFloatPrecision = Shaderc.ShaderPrecision.SHADER_PRECISION_HIGHP;
+        opts.glslEsDefaultFloatPrecision = Shaderc.ShaderPrecision.SHADER_PRECISION_MEDIUMP;
         opts.glslEsDefaultIntPrecision = Shaderc.ShaderPrecision.SHADER_PRECISION_MEDIUMP;
 
         Shaderc.ShaderCompileResult result = ShadercJni.Compile(ctx, compiler, opts);
@@ -976,8 +977,20 @@ public class ShaderProgramBuilderTest extends AbstractProtoBuilderTest {
         assertNotNull(result.data);
 
         String src = new String(result.data);
-        assertTrue(src.contains("precision highp float;"));
+        assertTrue(src.contains("precision mediump float;"));
         assertTrue(src.contains("precision mediump int;"));
+
+        // Test highp
+        opts.glslEsDefaultFloatPrecision = Shaderc.ShaderPrecision.SHADER_PRECISION_HIGHP;
+        opts.glslEsDefaultIntPrecision = Shaderc.ShaderPrecision.SHADER_PRECISION_HIGHP;
+
+        result = ShadercJni.Compile(ctx, compiler, opts);
+        assertNotNull(result);
+        assertNotNull(result.data);
+
+        src = new String(result.data);
+        assertTrue(src.contains("precision highp float;"));
+        assertTrue(src.contains("precision highp int;"));
 
         ShadercJni.DeleteShaderContext(ctx);
     }

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/ShaderProgramBuilderTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/ShaderProgramBuilderTest.java
@@ -614,7 +614,15 @@ public class ShaderProgramBuilderTest extends AbstractProtoBuilderTest {
             "   gl_FragColor = my_uniform + my_varying;\n" +
             "}\n";
 
-        ShaderUtil.ES2ToES3Converter.Result res = ShaderUtil.ES2ToES3Converter.transform(source, ShaderDesc.ShaderType.SHADER_TYPE_FRAGMENT, "", 140, true, false);
+        ShaderUtil.ES2ToES3Converter.Result res = ShaderUtil.ES2ToES3Converter.transform(
+                source,
+                ShaderDesc.ShaderType.SHADER_TYPE_FRAGMENT,
+                "",
+                140,
+                true,
+                false,
+                "mediump",
+                "highp");
 
         expected =
             "#version 140\n" +

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/ShaderProgramBuilderTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/ShaderProgramBuilderTest.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 
 import com.dynamo.bob.CompileExceptionError;
 import com.dynamo.bob.Platform;
+import com.dynamo.bob.pipeline.Shaderc;
 import com.dynamo.graphics.proto.Graphics.ShaderDesc;
 
 public class ShaderProgramBuilderTest extends AbstractProtoBuilderTest {
@@ -506,7 +507,15 @@ public class ShaderProgramBuilderTest extends AbstractProtoBuilderTest {
         String source;
         String expected;
 
-        source = ShaderUtil.Common.compileGLSL("", ShaderDesc.ShaderType.SHADER_TYPE_VERTEX, ShaderDesc.Language.LANGUAGE_GLSL_SM330, true, false, false);
+        source = ShaderUtil.Common.compileGLSL(
+                "",
+                ShaderDesc.ShaderType.SHADER_TYPE_VERTEX,
+                ShaderDesc.Language.LANGUAGE_GLSL_SM330,
+                true,
+                false,
+                false,
+                Shaderc.ShaderPrecision.SHADER_PRECISION_MEDIUMP,
+                Shaderc.ShaderPrecision.SHADER_PRECISION_HIGHP);
         expected =  "#version 330\n" +
                     "#ifndef GL_ES\n" +
                     "#define lowp\n" +
@@ -519,7 +528,15 @@ public class ShaderProgramBuilderTest extends AbstractProtoBuilderTest {
 
         source = "#extension GL_OES_standard_derivatives : enable\n" +
                  "varying highp vec2 var_texcoord0;";
-        source = ShaderUtil.Common.compileGLSL(source, ShaderDesc.ShaderType.SHADER_TYPE_VERTEX, ShaderDesc.Language.LANGUAGE_GLSL_SM330, true, false, false);
+        source = ShaderUtil.Common.compileGLSL(
+                source,
+                ShaderDesc.ShaderType.SHADER_TYPE_VERTEX,
+                ShaderDesc.Language.LANGUAGE_GLSL_SM330,
+                true,
+                false,
+                false,
+                Shaderc.ShaderPrecision.SHADER_PRECISION_MEDIUMP,
+                Shaderc.ShaderPrecision.SHADER_PRECISION_HIGHP);
         expected =  "#version 330\n" +
                     "#extension GL_OES_standard_derivatives : enable\n" +
                     "\n" +
@@ -537,7 +554,15 @@ public class ShaderProgramBuilderTest extends AbstractProtoBuilderTest {
                  "void main() {\n" +
                  "    gl_FragColor = vec4(1.0);\n" +
                  "}";
-        source = ShaderUtil.Common.compileGLSL(source, ShaderDesc.ShaderType.SHADER_TYPE_FRAGMENT, ShaderDesc.Language.LANGUAGE_GLES_SM100, true, false, false);
+        source = ShaderUtil.Common.compileGLSL(
+                source,
+                ShaderDesc.ShaderType.SHADER_TYPE_FRAGMENT,
+                ShaderDesc.Language.LANGUAGE_GLES_SM100,
+                true,
+                false,
+                false,
+                Shaderc.ShaderPrecision.SHADER_PRECISION_MEDIUMP,
+                Shaderc.ShaderPrecision.SHADER_PRECISION_HIGHP);
         expected =  "#extension GL_OES_standard_derivatives : enable\n" +
                     "\n" +
                     "precision mediump float;\n" +
@@ -551,7 +576,15 @@ public class ShaderProgramBuilderTest extends AbstractProtoBuilderTest {
                  "void main() {\n" +
                  "    gl_FragColor = vec4(1.0);\n" +
                  "}";
-        source = ShaderUtil.Common.compileGLSL(source, ShaderDesc.ShaderType.SHADER_TYPE_FRAGMENT, ShaderDesc.Language.LANGUAGE_GLES_SM300, true, false, false);
+        source = ShaderUtil.Common.compileGLSL(
+                source,
+                ShaderDesc.ShaderType.SHADER_TYPE_FRAGMENT,
+                ShaderDesc.Language.LANGUAGE_GLES_SM300,
+                true,
+                false,
+                false,
+                Shaderc.ShaderPrecision.SHADER_PRECISION_MEDIUMP,
+                Shaderc.ShaderPrecision.SHADER_PRECISION_HIGHP);
         expected =  "#version 300 es\n" +
                     "#extension GL_OES_standard_derivatives : enable\n" +
                     "\n" +

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/ShaderProgramBuilderTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/ShaderProgramBuilderTest.java
@@ -566,6 +566,7 @@ public class ShaderProgramBuilderTest extends AbstractProtoBuilderTest {
         expected =  "#extension GL_OES_standard_derivatives : enable\n" +
                     "\n" +
                     "precision mediump float;\n" +
+                    "precision highp int;\n" +
                     "#line 1\n" +
                     "void main() {\n" +
                     "    gl_FragColor = vec4(1.0);\n" +
@@ -589,6 +590,7 @@ public class ShaderProgramBuilderTest extends AbstractProtoBuilderTest {
                     "#extension GL_OES_standard_derivatives : enable\n" +
                     "\n" +
                     "precision mediump float;\n" +
+                    "precision highp int;\n" +
                     "\n" +
                     "out vec4 _DMENGINE_GENERATED_gl_FragColor_0;\n" +
                     "#line 1\n" +

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
@@ -337,16 +337,14 @@ exclude_gles_sm100.private = 1
 exclude_gles_sm100.label = Exclude GLES 2.0
 
 glsl_es_default_precision_float.type = string
-glsl_es_default_precision_float.help = default float precision for GLSL ES shaders
+glsl_es_default_precision_float.help = Default global precision qualifier for floats (GLSL ES only)
 glsl_es_default_precision_float.default = mediump
-glsl_es_default_precision_float.options = mediump,highp
-glsl_es_default_precision_float.label = GLSL ES float precision
+glsl_es_default_precision_float.options = mediump, highp
 
 glsl_es_default_precision_int.type = string
-glsl_es_default_precision_int.help = default int precision for GLSL ES shaders
+glsl_es_default_precision_int.help = Default global precision qualifier for integers (GLSL ES only)
 glsl_es_default_precision_int.default = highp
-glsl_es_default_precision_int.options = mediump,highp
-glsl_es_default_precision_int.label = GLSL ES int precision
+glsl_es_default_precision_int.options = mediump, highp
 
 [sound]
 help = Sound related settings

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
@@ -336,6 +336,18 @@ exclude_gles_sm100.default = 0
 exclude_gles_sm100.private = 1
 exclude_gles_sm100.label = Exclude GLES 2.0
 
+glsl_es_default_precision_float.type = string
+glsl_es_default_precision_float.help = default float precision for GLSL ES shaders
+glsl_es_default_precision_float.default = mediump
+glsl_es_default_precision_float.options = mediump,highp
+glsl_es_default_precision_float.label = GLSL ES float precision
+
+glsl_es_default_precision_int.type = string
+glsl_es_default_precision_int.help = default int precision for GLSL ES shaders
+glsl_es_default_precision_int.default = highp
+glsl_es_default_precision_int.options = mediump,highp
+glsl_es_default_precision_int.label = GLSL ES int precision
+
 [sound]
 help = Sound related settings
 group = Components

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/IShaderCompiler.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/IShaderCompiler.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import com.dynamo.bob.CompileExceptionError;
 import com.dynamo.bob.pipeline.shader.ShaderCompilePipeline;
 import com.dynamo.graphics.proto.Graphics.ShaderDesc;
+import com.dynamo.bob.pipeline.Shaderc;
 
 public interface IShaderCompiler {
     class CompileOptions implements Serializable {
@@ -28,6 +29,8 @@ public interface IShaderCompiler {
         public int maxPageCount;
         public boolean forceSplitSamplers;
         public boolean excludeGlesSm100;
+        public Shaderc.ShaderPrecision glslEsDefaultFloatPrecision = Shaderc.ShaderPrecision.SHADER_PRECISION_MEDIUMP;
+        public Shaderc.ShaderPrecision glslEsDefaultIntPrecision   = Shaderc.ShaderPrecision.SHADER_PRECISION_HIGHP;
     };
 
     ShaderProgramBuilder.ShaderCompileResult compile(ArrayList<ShaderCompilePipeline.ShaderModuleDesc> shaderModules, String resourceOutputPath, CompileOptions options) throws IOException, CompileExceptionError;

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderCompilers.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderCompilers.java
@@ -164,7 +164,8 @@ public class ShaderCompilers {
 
             ShaderCompilePipeline.Options opts = new ShaderCompilePipeline.Options();
             opts.splitTextureSamplers = compileOptions.forceSplitSamplers;
-
+            opts.glslEsDefaultFloatPrecision = compileOptions.glslEsDefaultFloatPrecision;
+            opts.glslEsDefaultIntPrecision   = compileOptions.glslEsDefaultIntPrecision;
 
             for (ShaderDesc.Language shaderLanguage : compileOptions.forceIncludeShaderLanguages) {
                 boolean isHLSL = shaderLanguage == ShaderDesc.Language.LANGUAGE_HLSL_51 || shaderLanguage == ShaderDesc.Language.LANGUAGE_HLSL_50;

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderCompilers.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderCompilers.java
@@ -165,7 +165,7 @@ public class ShaderCompilers {
             ShaderCompilePipeline.Options opts = new ShaderCompilePipeline.Options();
             opts.splitTextureSamplers = compileOptions.forceSplitSamplers;
             opts.glslEsDefaultFloatPrecision = compileOptions.glslEsDefaultFloatPrecision;
-            opts.glslEsDefaultIntPrecision   = compileOptions.glslEsDefaultIntPrecision;
+            opts.glslEsDefaultIntPrecision = compileOptions.glslEsDefaultIntPrecision;
 
             for (ShaderDesc.Language shaderLanguage : compileOptions.forceIncludeShaderLanguages) {
                 boolean isHLSL = shaderLanguage == ShaderDesc.Language.LANGUAGE_HLSL_51 || shaderLanguage == ShaderDesc.Language.LANGUAGE_HLSL_50;

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderProgramBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderProgramBuilder.java
@@ -119,15 +119,12 @@ public class ShaderProgramBuilder extends Builder {
         }
     }
 
-    static Shaderc.ShaderPrecision shaderPrecisionFromString(String value) {
+    static Shaderc.ShaderPrecision shaderPrecisionFromString(String value) throws CompileExceptionError {
         if (value.equals("highp"))
             return Shaderc.ShaderPrecision.SHADER_PRECISION_HIGHP;
         else if (value.equals("mediump"))
             return Shaderc.ShaderPrecision.SHADER_PRECISION_MEDIUMP;
-        // Not implemented
-        assert false;
-        // Fallback to a sensible default to satisfy the compiler
-        return Shaderc.ShaderPrecision.SHADER_PRECISION_MEDIUMP;
+        throw new CompileExceptionError("Unknown shader precision: " + value);
     }
 
     @Override
@@ -525,10 +522,7 @@ public class ShaderProgramBuilder extends Builder {
 
             ArrayList<ShaderCompilePipeline.ShaderModuleDesc> newDescs = new ArrayList<>(newShaders);
             for (ShaderCompilePipeline.ShaderModuleDesc old : oldShaders) {
-                String floatPrec = options.glslEsDefaultFloatPrecision == Shaderc.ShaderPrecision.SHADER_PRECISION_HIGHP ? "highp" : "mediump";
-                String intPrec = options.glslEsDefaultIntPrecision == null ? "" :
-                        (options.glslEsDefaultIntPrecision == Shaderc.ShaderPrecision.SHADER_PRECISION_HIGHP ? "highp" : "mediump");
-                ShaderUtil.ES2ToES3Converter.Result transformResult = ShaderUtil.ES2ToES3Converter.transform(old.source, old.type, "", 140, true, options.splitTextureSamplers, floatPrec, intPrec);
+                ShaderUtil.ES2ToES3Converter.Result transformResult = ShaderUtil.ES2ToES3Converter.transform(old.source, old.type, "", 140, true, options.splitTextureSamplers, options.glslEsDefaultFloatPrecision, options.glslEsDefaultIntPrecision);
                 ShaderCompilePipeline.ShaderModuleDesc transformedDesc = new ShaderCompilePipeline.ShaderModuleDesc();
                 transformedDesc.type = old.type;
                 transformedDesc.source = transformResult.output;

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderProgramBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderProgramBuilder.java
@@ -119,6 +119,15 @@ public class ShaderProgramBuilder extends Builder {
         }
     }
 
+    static Shaderc.ShaderPrecision shaderPrecisionFromString(String value) {
+        if (value.equals("highp"))
+            return Shaderc.ShaderPrecision.SHADER_PRECISION_HIGHP;
+        else if (value.equals("mediump"))
+            return Shaderc.ShaderPrecision.SHADER_PRECISION_MEDIUMP;
+        // Not implemented
+        assert null;
+    }
+
     @Override
     public void build(Task task) throws IOException, CompileExceptionError {
         String resourceOutputPath = task.getOutputs().get(0).getPath();
@@ -134,6 +143,9 @@ public class ShaderProgramBuilder extends Builder {
         }
 
         compileOptions.excludeGlesSm100 = getExcludeGlesSm100Flag();
+        compileOptions.glslEsDefaultFloatPrecision = shaderPrecisionFromString(this.project.getProjectProperties().getStringValue("shader", "glsl_es_default_precision_float", "mediump"));
+        compileOptions.glslEsDefaultIntPrecision = shaderPrecisionFromString(this.project.getProjectProperties().getStringValue("shader", "glsl_es_default_precision_int", "highp"));
+
         if (getOutputHlslFlag()) {
             addUniqueShaderLanguage(ShaderDesc.Language.LANGUAGE_HLSL_51);
         }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderProgramBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderProgramBuilder.java
@@ -125,7 +125,9 @@ public class ShaderProgramBuilder extends Builder {
         else if (value.equals("mediump"))
             return Shaderc.ShaderPrecision.SHADER_PRECISION_MEDIUMP;
         // Not implemented
-        assert null;
+        assert false;
+        // Fallback to a sensible default to satisfy the compiler
+        return Shaderc.ShaderPrecision.SHADER_PRECISION_MEDIUMP;
     }
 
     @Override
@@ -523,7 +525,10 @@ public class ShaderProgramBuilder extends Builder {
 
             ArrayList<ShaderCompilePipeline.ShaderModuleDesc> newDescs = new ArrayList<>(newShaders);
             for (ShaderCompilePipeline.ShaderModuleDesc old : oldShaders) {
-                ShaderUtil.ES2ToES3Converter.Result transformResult = ShaderUtil.ES2ToES3Converter.transform(old.source, old.type, "", 140, true, options.splitTextureSamplers);
+                String floatPrec = options.glslEsDefaultFloatPrecision == Shaderc.ShaderPrecision.SHADER_PRECISION_HIGHP ? "highp" : "mediump";
+                String intPrec = options.glslEsDefaultIntPrecision == null ? "" :
+                        (options.glslEsDefaultIntPrecision == Shaderc.ShaderPrecision.SHADER_PRECISION_HIGHP ? "highp" : "mediump");
+                ShaderUtil.ES2ToES3Converter.Result transformResult = ShaderUtil.ES2ToES3Converter.transform(old.source, old.type, "", 140, true, options.splitTextureSamplers, floatPrec, intPrec);
                 ShaderCompilePipeline.ShaderModuleDesc transformedDesc = new ShaderCompilePipeline.ShaderModuleDesc();
                 transformedDesc.type = old.type;
                 transformedDesc.source = transformResult.output;

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderProgramBuilderEditor.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderProgramBuilderEditor.java
@@ -27,7 +27,16 @@ import java.util.HashMap;
 import static com.dynamo.bob.pipeline.ShaderProgramBuilder.buildResultsToShaderDescBuildResults;
 
 public class ShaderProgramBuilderEditor {
+    static private void applyEditorShaderPrecision(ShaderCompilePipeline.Options options, Shaderc.ShaderPrecision floatPrecision, Shaderc.ShaderPrecision intPrecision) {
+        options.glslEsDefaultFloatPrecision = floatPrecision;
+        options.glslEsDefaultIntPrecision = intPrecision;
+    }
+
     static public ShaderUtil.Common.GLSLCompileResult buildGLSLVariantTextureArray(String resourcePath, String source, Graphics.ShaderDesc.ShaderType shaderType, Graphics.ShaderDesc.Language shaderLanguage, int maxPageCount) throws IOException, CompileExceptionError {
+        return buildGLSLVariantTextureArray(resourcePath, source, shaderType, shaderLanguage, maxPageCount, Shaderc.ShaderPrecision.SHADER_PRECISION_MEDIUMP, Shaderc.ShaderPrecision.SHADER_PRECISION_HIGHP);
+    }
+
+    static public ShaderUtil.Common.GLSLCompileResult buildGLSLVariantTextureArray(String resourcePath, String source, Graphics.ShaderDesc.ShaderType shaderType, Graphics.ShaderDesc.Language shaderLanguage, int maxPageCount, Shaderc.ShaderPrecision floatPrecision, Shaderc.ShaderPrecision intPrecision) throws IOException, CompileExceptionError {
         ShaderCompilePipeline.ShaderModuleDesc module = new ShaderCompilePipeline.ShaderModuleDesc();
         module.source = source;
         module.type = shaderType;
@@ -37,6 +46,7 @@ public class ShaderProgramBuilderEditor {
 
         ShaderCompilePipeline.Options options = new ShaderCompilePipeline.Options();
         options.defines.add("EDITOR");
+        applyEditorShaderPrecision(options, floatPrecision, intPrecision);
 
         ShaderCompilePipeline pipeline = ShaderProgramBuilder.newShaderPipeline(resourcePath, shaderDescs, options);
         Shaderc.ShaderCompileResult result = pipeline.crossCompile(shaderType, shaderLanguage);
@@ -69,8 +79,15 @@ public class ShaderProgramBuilderEditor {
     static public ShaderProgramBuilder.ShaderDescBuildResult makeShaderDescWithVariants(
             String resourceOutputPath, ShaderCompilePipeline.ShaderModuleDesc[] shaderDescs,
             Graphics.ShaderDesc.Language[] shaderLanguages, int maxPageCount) throws IOException, CompileExceptionError {
+        return makeShaderDescWithVariants(resourceOutputPath, shaderDescs, shaderLanguages, maxPageCount, Shaderc.ShaderPrecision.SHADER_PRECISION_MEDIUMP, Shaderc.ShaderPrecision.SHADER_PRECISION_HIGHP);
+    }
+
+    static public ShaderProgramBuilder.ShaderDescBuildResult makeShaderDescWithVariants(
+            String resourceOutputPath, ShaderCompilePipeline.ShaderModuleDesc[] shaderDescs,
+            Graphics.ShaderDesc.Language[] shaderLanguages, int maxPageCount, Shaderc.ShaderPrecision floatPrecision, Shaderc.ShaderPrecision intPrecision) throws IOException, CompileExceptionError {
 
         ShaderCompilePipeline.Options options = new ShaderCompilePipeline.Options();
+        applyEditorShaderPrecision(options, floatPrecision, intPrecision);
         ShaderCompilePipeline pipeline;
 
         ArrayList<ShaderCompilePipeline.ShaderModuleDesc> shaderModuleDescsArrayList = new ArrayList<>(Arrays.asList(shaderDescs));

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderProgramBuilderEditor.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderProgramBuilderEditor.java
@@ -70,12 +70,6 @@ public class ShaderProgramBuilderEditor {
     // fully transformed from source to context shaders based on a list of languages
     static public ShaderProgramBuilder.ShaderDescBuildResult makeShaderDescWithVariants(
             String resourceOutputPath, ShaderCompilePipeline.ShaderModuleDesc[] shaderDescs,
-            Graphics.ShaderDesc.Language[] shaderLanguages, int maxPageCount) throws IOException, CompileExceptionError {
-        return makeShaderDescWithVariants(resourceOutputPath, shaderDescs, shaderLanguages, maxPageCount, Shaderc.ShaderPrecision.SHADER_PRECISION_MEDIUMP, Shaderc.ShaderPrecision.SHADER_PRECISION_HIGHP);
-    }
-
-    static public ShaderProgramBuilder.ShaderDescBuildResult makeShaderDescWithVariants(
-            String resourceOutputPath, ShaderCompilePipeline.ShaderModuleDesc[] shaderDescs,
             Graphics.ShaderDesc.Language[] shaderLanguages, int maxPageCount, Shaderc.ShaderPrecision floatPrecision, Shaderc.ShaderPrecision intPrecision) throws IOException, CompileExceptionError {
 
         ShaderCompilePipeline.Options options = new ShaderCompilePipeline.Options();

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderProgramBuilderEditor.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderProgramBuilderEditor.java
@@ -27,15 +27,6 @@ import java.util.HashMap;
 import static com.dynamo.bob.pipeline.ShaderProgramBuilder.buildResultsToShaderDescBuildResults;
 
 public class ShaderProgramBuilderEditor {
-    static private void applyEditorShaderPrecision(ShaderCompilePipeline.Options options, Shaderc.ShaderPrecision floatPrecision, Shaderc.ShaderPrecision intPrecision) {
-        options.glslEsDefaultFloatPrecision = floatPrecision;
-        options.glslEsDefaultIntPrecision = intPrecision;
-    }
-
-    static public ShaderUtil.Common.GLSLCompileResult buildGLSLVariantTextureArray(String resourcePath, String source, Graphics.ShaderDesc.ShaderType shaderType, Graphics.ShaderDesc.Language shaderLanguage, int maxPageCount) throws IOException, CompileExceptionError {
-        return buildGLSLVariantTextureArray(resourcePath, source, shaderType, shaderLanguage, maxPageCount, Shaderc.ShaderPrecision.SHADER_PRECISION_MEDIUMP, Shaderc.ShaderPrecision.SHADER_PRECISION_HIGHP);
-    }
-
     static public ShaderUtil.Common.GLSLCompileResult buildGLSLVariantTextureArray(String resourcePath, String source, Graphics.ShaderDesc.ShaderType shaderType, Graphics.ShaderDesc.Language shaderLanguage, int maxPageCount, Shaderc.ShaderPrecision floatPrecision, Shaderc.ShaderPrecision intPrecision) throws IOException, CompileExceptionError {
         ShaderCompilePipeline.ShaderModuleDesc module = new ShaderCompilePipeline.ShaderModuleDesc();
         module.source = source;
@@ -46,7 +37,8 @@ public class ShaderProgramBuilderEditor {
 
         ShaderCompilePipeline.Options options = new ShaderCompilePipeline.Options();
         options.defines.add("EDITOR");
-        applyEditorShaderPrecision(options, floatPrecision, intPrecision);
+        options.glslEsDefaultFloatPrecision = floatPrecision;
+        options.glslEsDefaultIntPrecision = intPrecision;
 
         ShaderCompilePipeline pipeline = ShaderProgramBuilder.newShaderPipeline(resourcePath, shaderDescs, options);
         Shaderc.ShaderCompileResult result = pipeline.crossCompile(shaderType, shaderLanguage);
@@ -87,9 +79,10 @@ public class ShaderProgramBuilderEditor {
             Graphics.ShaderDesc.Language[] shaderLanguages, int maxPageCount, Shaderc.ShaderPrecision floatPrecision, Shaderc.ShaderPrecision intPrecision) throws IOException, CompileExceptionError {
 
         ShaderCompilePipeline.Options options = new ShaderCompilePipeline.Options();
-        applyEditorShaderPrecision(options, floatPrecision, intPrecision);
-        ShaderCompilePipeline pipeline;
+        options.glslEsDefaultFloatPrecision = floatPrecision;
+        options.glslEsDefaultIntPrecision = intPrecision;
 
+        ShaderCompilePipeline pipeline;
         ArrayList<ShaderCompilePipeline.ShaderModuleDesc> shaderModuleDescsArrayList = new ArrayList<>(Arrays.asList(shaderDescs));
 
         try {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderUtil.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderUtil.java
@@ -208,10 +208,7 @@ public class ShaderUtil {
             String source = os.toString().replace("\r", "");
 
             if (gles3Standard) {
-                String floatPrec = defaultFloatPrecision == Shaderc.ShaderPrecision.SHADER_PRECISION_HIGHP ? "highp" : "mediump";
-                String intPrec = defaultIntPrecision == null ? "" :
-                        (defaultIntPrecision == Shaderc.ShaderPrecision.SHADER_PRECISION_HIGHP ? "highp" : "mediump");
-                ES2ToES3Converter.Result es3Result = ES2ToES3Converter.transform(source, shaderType, gles ? "es" : "", version, useLatestFeatures, splitTextureSamplers, floatPrec, intPrec);
+                ES2ToES3Converter.Result es3Result = ES2ToES3Converter.transform(source, shaderType, gles ? "es" : "", version, useLatestFeatures, splitTextureSamplers, defaultFloatPrecision, defaultIntPrecision);
                 source = es3Result.output;
             }
             return source;
@@ -466,7 +463,7 @@ public class ShaderUtil {
 
 
 
-        public static Result transform(String input, ShaderDesc.ShaderType shaderType, String targetProfile, int targetVersion, boolean useLatestFeatures, boolean splitTextureSamplers, String defaultFloatPrecision, String defaultIntPrecision) throws CompileExceptionError {
+        public static Result transform(String input, ShaderDesc.ShaderType shaderType, String targetProfile, int targetVersion, boolean useLatestFeatures, boolean splitTextureSamplers, Shaderc.ShaderPrecision defaultFloatPrecision, Shaderc.ShaderPrecision defaultIntPrecision) throws CompileExceptionError {
             Result result = new Result();
 
             if(input.isEmpty()) {
@@ -650,11 +647,12 @@ public class ShaderUtil {
             if (shaderType == ShaderDesc.ShaderType.SHADER_TYPE_FRAGMENT) {
                 // if we have patched glFragColor
                 if(output_glFragColor || output_glFragData) {
-                    String floatPrecision = defaultFloatPrecision != null ? defaultFloatPrecision : "mediump";
+                    String floatPrecision = defaultFloatPrecision == Shaderc.ShaderPrecision.SHADER_PRECISION_HIGHP ? "highp" : "mediump";
                     String floatPrecisionAttrRep = "precision " + floatPrecision + " float;\n";
                     String intPrecisionAttrRep = null;
-                    if (defaultIntPrecision != null && !defaultIntPrecision.isEmpty()) {
-                        intPrecisionAttrRep = "precision " + defaultIntPrecision + " int;\n";
+                    if (defaultIntPrecision != null) {
+                        String intPrecision = defaultIntPrecision == Shaderc.ShaderPrecision.SHADER_PRECISION_HIGHP ? "highp" : "mediump";
+                        intPrecisionAttrRep = "precision " + intPrecision + " int;\n";
                     }
                     // insert precision if not found, as it is mandatory for out attributes
                     if(floatPrecisionIndex < 0 && targetProfile.equals("es")) {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderUtil.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderUtil.java
@@ -647,18 +647,18 @@ public class ShaderUtil {
             if (shaderType == ShaderDesc.ShaderType.SHADER_TYPE_FRAGMENT) {
                 // if we have patched glFragColor
                 if(output_glFragColor || output_glFragData) {
-                    String floatPrecision = defaultFloatPrecision == Shaderc.ShaderPrecision.SHADER_PRECISION_HIGHP ? "highp" : "mediump";
-                    String floatPrecisionAttrRep = "precision " + floatPrecision + " float;\n";
-                    String intPrecisionAttrRep = null;
-                    if (defaultIntPrecision != null) {
-                        String intPrecision = defaultIntPrecision == Shaderc.ShaderPrecision.SHADER_PRECISION_HIGHP ? "highp" : "mediump";
-                        intPrecisionAttrRep = "precision " + intPrecision + " int;\n";
-                    }
+
+                    boolean isEsTargetProfile = targetProfile.equals("es");
+
                     // insert precision if not found, as it is mandatory for out attributes
-                    if(floatPrecisionIndex < 0 && targetProfile.equals("es")) {
+                    if(floatPrecisionIndex < 0 && isEsTargetProfile) {
+                        String floatPrecision = defaultFloatPrecision == Shaderc.ShaderPrecision.SHADER_PRECISION_HIGHP ? "highp" : "mediump";
+                        String floatPrecisionAttrRep = "precision " + floatPrecision + " float;\n";
                         output.add(patchLineIndex++, floatPrecisionAttrRep);
                     }
-                    if(intPrecisionAttrRep != null && intPrecisionIndex < 0 && targetProfile.equals("es")) {
+                    if(intPrecisionIndex < 0 && isEsTargetProfile) {
+                        String intPrecision = defaultIntPrecision == Shaderc.ShaderPrecision.SHADER_PRECISION_HIGHP ? "highp" : "mediump";
+                        String intPrecisionAttrRep = "precision " + intPrecision + " int;\n";
                         output.add(patchLineIndex++, intPrecisionAttrRep);
                     }
 
@@ -666,7 +666,7 @@ public class ShaderUtil {
                     for (int i = 0; i < maxColorOutputs; i++) {
                         String colorOutputLayoutPrefix = "";
                         // For ES targets we need to add a layout specification for the outputs
-                        if (targetProfile.equals("es") && maxColorOutputs > 1)
+                        if (isEsTargetProfile && maxColorOutputs > 1)
                         {
                             colorOutputLayoutPrefix = String.format(glFragColorAttrLayoutPrefix, i);
                         }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderUtil.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderUtil.java
@@ -165,10 +165,8 @@ public class ShaderUtil {
                     // Normally, the ES2ToES3Converter would do this
                     String floatPrec = defaultFloatPrecision == Shaderc.ShaderPrecision.SHADER_PRECISION_HIGHP ? "highp" : "mediump";
                     writer.println("precision " + floatPrec + " float;");
-                    if (defaultIntPrecision != null) {
-                        String intPrec = defaultIntPrecision == Shaderc.ShaderPrecision.SHADER_PRECISION_HIGHP ? "highp" : "mediump";
-                        writer.println("precision " + intPrec + " int;");
-                    }
+                    String intPrec = defaultIntPrecision == Shaderc.ShaderPrecision.SHADER_PRECISION_HIGHP ? "highp" : "mediump";
+                    writer.println("precision " + intPrec + " int;");
                 }
 
                 if (!gles) {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderUtil.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderUtil.java
@@ -21,6 +21,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import com.dynamo.bob.CompileExceptionError;
+import com.dynamo.bob.pipeline.Shaderc;
 import com.dynamo.bob.pipeline.shader.SPIRVReflector;
 import com.dynamo.graphics.proto.Graphics.ShaderDesc;
 
@@ -106,7 +107,9 @@ public class ShaderUtil {
             return rewriter.getText();
         }
 
-        public static String compileGLSL(String shaderSource, ShaderDesc.ShaderType shaderType, ShaderDesc.Language shaderLanguage, boolean isDebug, boolean useLatestFeatures, boolean splitTextureSamplers) throws CompileExceptionError {
+        public static String compileGLSL(String shaderSource, ShaderDesc.ShaderType shaderType, ShaderDesc.Language shaderLanguage,
+                                         boolean isDebug, boolean useLatestFeatures, boolean splitTextureSamplers,
+                                         Shaderc.ShaderPrecision defaultFloatPrecision, Shaderc.ShaderPrecision defaultIntPrecision) throws CompileExceptionError {
 
             ByteArrayOutputStream os = new ByteArrayOutputStream();
             PrintWriter writer = new PrintWriter(os);
@@ -160,7 +163,12 @@ public class ShaderUtil {
                 // Write our directives.
                 if (shaderLanguage == ShaderDesc.Language.LANGUAGE_GLES_SM100) {
                     // Normally, the ES2ToES3Converter would do this
-                    writer.println("precision mediump float;");
+                    String floatPrec = defaultFloatPrecision == Shaderc.ShaderPrecision.SHADER_PRECISION_HIGHP ? "highp" : "mediump";
+                    writer.println("precision " + floatPrec + " float;");
+                    if (defaultIntPrecision != null) {
+                        String intPrec = defaultIntPrecision == Shaderc.ShaderPrecision.SHADER_PRECISION_HIGHP ? "highp" : "mediump";
+                        writer.println("precision " + intPrec + " int;");
+                    }
                 }
 
                 if (!gles) {
@@ -200,7 +208,10 @@ public class ShaderUtil {
             String source = os.toString().replace("\r", "");
 
             if (gles3Standard) {
-                ES2ToES3Converter.Result es3Result = ES2ToES3Converter.transform(source, shaderType, gles ? "es" : "", version, useLatestFeatures, splitTextureSamplers);
+                String floatPrec = defaultFloatPrecision == Shaderc.ShaderPrecision.SHADER_PRECISION_HIGHP ? "highp" : "mediump";
+                String intPrec = defaultIntPrecision == null ? "" :
+                        (defaultIntPrecision == Shaderc.ShaderPrecision.SHADER_PRECISION_HIGHP ? "highp" : "mediump");
+                ES2ToES3Converter.Result es3Result = ES2ToES3Converter.transform(source, shaderType, gles ? "es" : "", version, useLatestFeatures, splitTextureSamplers, floatPrec, intPrec);
                 source = es3Result.output;
             }
             return source;
@@ -389,8 +400,6 @@ public class ShaderUtil {
         private static final String glFragColorRep              = dmEngineGeneratedRep + glFragColorKeyword;
         private static final String glFragColorAttrRep          = "\n%sout vec4 " + glFragColorRep + "%s;\n";
         private static final String glFragColorAttrLayoutPrefix = "layout(location = %d) ";
-        private static final String floatPrecisionAttrRep       = "precision mediump float;\n";
-
         private static boolean isOpaqueType(String type) {
             for( String opaqueTypePrefix : opaqueUniformTypesPrefix) {
                 if(type.startsWith(opaqueTypePrefix)) {
@@ -457,7 +466,7 @@ public class ShaderUtil {
 
 
 
-        public static Result transform(String input, ShaderDesc.ShaderType shaderType, String targetProfile, int targetVersion, boolean useLatestFeatures, boolean splitTextureSamplers) throws CompileExceptionError {
+        public static Result transform(String input, ShaderDesc.ShaderType shaderType, String targetProfile, int targetVersion, boolean useLatestFeatures, boolean splitTextureSamplers, String defaultFloatPrecision, String defaultIntPrecision) throws CompileExceptionError {
             Result result = new Result();
 
             if(input.isEmpty()) {
@@ -473,6 +482,7 @@ public class ShaderUtil {
 
             // Index to output used for post patching tasks
             int floatPrecisionIndex = -1;
+            int intPrecisionIndex = -1;
 
             Common.GLSLShaderInfo shaderInfo = Common.getShaderInfo(input);
 
@@ -622,8 +632,11 @@ public class ShaderUtil {
                     // Check if precision keyword present and store index if so, for post patch tasks
                     Matcher precisionMatcher = regexPrecisionKeywordPattern.matcher(line);
                     if(precisionMatcher.find()) {
-                        if(precisionMatcher.group("type").equals("float")) {
+                        String type = precisionMatcher.group("type");
+                        if(type.equals("float")) {
                             floatPrecisionIndex = output.size();
+                        } else if (type.equals("int")) {
+                            intPrecisionIndex = output.size();
                         }
                     }
                 }
@@ -637,9 +650,18 @@ public class ShaderUtil {
             if (shaderType == ShaderDesc.ShaderType.SHADER_TYPE_FRAGMENT) {
                 // if we have patched glFragColor
                 if(output_glFragColor || output_glFragData) {
+                    String floatPrecision = defaultFloatPrecision != null ? defaultFloatPrecision : "mediump";
+                    String floatPrecisionAttrRep = "precision " + floatPrecision + " float;\n";
+                    String intPrecisionAttrRep = null;
+                    if (defaultIntPrecision != null && !defaultIntPrecision.isEmpty()) {
+                        intPrecisionAttrRep = "precision " + defaultIntPrecision + " int;\n";
+                    }
                     // insert precision if not found, as it is mandatory for out attributes
                     if(floatPrecisionIndex < 0 && targetProfile.equals("es")) {
                         output.add(patchLineIndex++, floatPrecisionAttrRep);
+                    }
+                    if(intPrecisionAttrRep != null && intPrecisionIndex < 0 && targetProfile.equals("es")) {
+                        output.add(patchLineIndex++, intPrecisionAttrRep);
                     }
 
                     // insert fragcolor out attribute for all output targets

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/shader/ShaderCompilePipeline.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/shader/ShaderCompilePipeline.java
@@ -34,11 +34,14 @@ import com.dynamo.bob.util.MurmurHash;
 import com.dynamo.graphics.proto.Graphics.ShaderDesc;
 
 import org.apache.commons.io.FileUtils;
+import com.dynamo.bob.pipeline.Shaderc;
 
 public class ShaderCompilePipeline {
     public static class Options {
         public boolean splitTextureSamplers;
         public ArrayList<String> defines = new ArrayList<>();
+        public Shaderc.ShaderPrecision glslEsDefaultFloatPrecision = Shaderc.ShaderPrecision.SHADER_PRECISION_MEDIUMP;
+        public Shaderc.ShaderPrecision glslEsDefaultIntPrecision   = Shaderc.ShaderPrecision.SHADER_PRECISION_HIGHP;
     }
 
     public static class ShaderModuleDesc {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/shader/ShaderCompilePipeline.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/shader/ShaderCompilePipeline.java
@@ -240,10 +240,12 @@ public class ShaderCompilePipeline {
         }
 
         Shaderc.ShaderCompilerOptions opts = new Shaderc.ShaderCompilerOptions();
-        opts.version               = versionOut;
-        opts.entryPoint            = "main";
-        opts.removeUnusedVariables = 1;
-        opts.no420PackExtension    = 1;
+        opts.version                       = versionOut;
+        opts.entryPoint                    = "main";
+        opts.removeUnusedVariables         = 1;
+        opts.no420PackExtension            = 1;
+        opts.glslEsDefaultFloatPrecision   = this.options.glslEsDefaultFloatPrecision;
+        opts.glslEsDefaultIntPrecision     = this.options.glslEsDefaultIntPrecision;
 
         if (shaderLanguage == ShaderDesc.Language.LANGUAGE_GLES_SM100 || shaderLanguage == ShaderDesc.Language.LANGUAGE_GLSL_SM120) {
             opts.glslEmitUboAsPlainUniforms = 1;
@@ -514,7 +516,7 @@ public class ShaderCompilePipeline {
     public static ShaderCompilePipeline createShaderPipeline(ShaderCompilePipeline pipeline, ShaderModuleDesc desc, Options options) throws IOException, CompileExceptionError {
         ArrayList<ShaderModuleDesc> descs = new ArrayList<>();
         descs.add(desc);
-        return createShaderPipeline(pipeline, descs, options );
+        return createShaderPipeline(pipeline, descs, options);
     }
 
     public static ShaderCompilePipeline createShaderPipeline(ShaderCompilePipeline pipeline, ArrayList<ShaderModuleDesc> descs, Options options) throws IOException, CompileExceptionError {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/shader/ShaderCompilePipelineLegacy.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/shader/ShaderCompilePipelineLegacy.java
@@ -96,11 +96,15 @@ public class ShaderCompilePipelineLegacy extends ShaderCompilePipeline {
         String shaderSource = moduleLegacy.desc.source;
         ShaderDesc.ShaderType shaderType = moduleLegacy.desc.type;
 
+        String floatPrec = this.options.glslEsDefaultFloatPrecision == Shaderc.ShaderPrecision.SHADER_PRECISION_HIGHP ? "highp" : "mediump";
+        String intPrec = this.options.glslEsDefaultIntPrecision == null ? "" :
+                (this.options.glslEsDefaultIntPrecision == Shaderc.ShaderPrecision.SHADER_PRECISION_HIGHP ? "highp" : "mediump");
+
         if (shaderType == ShaderDesc.ShaderType.SHADER_TYPE_COMPUTE) {
 
             int version = 430;
 
-            ShaderUtil.ES2ToES3Converter.Result es3Result = ShaderUtil.ES2ToES3Converter.transform(shaderSource, shaderType, targetProfile, version, true, splitTextureSamplers);
+            ShaderUtil.ES2ToES3Converter.Result es3Result = ShaderUtil.ES2ToES3Converter.transform(shaderSource, shaderType, targetProfile, version, true, splitTextureSamplers, floatPrec, intPrec);
 
             File file_in_compute = File.createTempFile(FilenameUtils.getName(resourceOutput), ".cp");
             FileUtil.deleteOnExit(file_in_compute);
@@ -130,7 +134,7 @@ public class ShaderCompilePipelineLegacy extends ShaderCompilePipeline {
             // If the shader already has a version, we expect it to be already written in valid GLSL for that version
             if (shaderInfo == null) {
                 // Convert to ES3 (or GL 140+)
-                ShaderUtil.ES2ToES3Converter.Result es3Result = ShaderUtil.ES2ToES3Converter.transform(shaderSource, shaderType, targetProfile, version, true, splitTextureSamplers);
+                ShaderUtil.ES2ToES3Converter.Result es3Result = ShaderUtil.ES2ToES3Converter.transform(shaderSource, shaderType, targetProfile, version, true, splitTextureSamplers, floatPrec, intPrec);
 
                 // Update version for SPIR-V (GLES >= 310, Core >= 140)
                 es3Result.shaderVersion = es3Result.shaderVersion.isEmpty() ? "0" : es3Result.shaderVersion;

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/shader/ShaderCompilePipelineLegacy.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/shader/ShaderCompilePipelineLegacy.java
@@ -261,7 +261,15 @@ public class ShaderCompilePipelineLegacy extends ShaderCompilePipeline {
             }
             return result;
         } else if (CanBeCrossCompiled(shaderLanguage)) {
-            String compileResult = ShaderUtil.Common.compileGLSL(module.desc.source, shaderType, shaderLanguage, false, false, this.options.splitTextureSamplers);
+            String compileResult = ShaderUtil.Common.compileGLSL(
+                    module.desc.source,
+                    shaderType,
+                    shaderLanguage,
+                    false,
+                    false,
+                    this.options.splitTextureSamplers,
+                    this.options.glslEsDefaultFloatPrecision,
+                    this.options.glslEsDefaultIntPrecision);
             Shaderc.ShaderCompileResult result = new Shaderc.ShaderCompileResult();
             result.data = compileResult.getBytes();
             return result;

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/shader/ShaderCompilePipelineLegacy.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/shader/ShaderCompilePipelineLegacy.java
@@ -96,15 +96,11 @@ public class ShaderCompilePipelineLegacy extends ShaderCompilePipeline {
         String shaderSource = moduleLegacy.desc.source;
         ShaderDesc.ShaderType shaderType = moduleLegacy.desc.type;
 
-        String floatPrec = this.options.glslEsDefaultFloatPrecision == Shaderc.ShaderPrecision.SHADER_PRECISION_HIGHP ? "highp" : "mediump";
-        String intPrec = this.options.glslEsDefaultIntPrecision == null ? "" :
-                (this.options.glslEsDefaultIntPrecision == Shaderc.ShaderPrecision.SHADER_PRECISION_HIGHP ? "highp" : "mediump");
-
         if (shaderType == ShaderDesc.ShaderType.SHADER_TYPE_COMPUTE) {
 
             int version = 430;
 
-            ShaderUtil.ES2ToES3Converter.Result es3Result = ShaderUtil.ES2ToES3Converter.transform(shaderSource, shaderType, targetProfile, version, true, splitTextureSamplers, floatPrec, intPrec);
+            ShaderUtil.ES2ToES3Converter.Result es3Result = ShaderUtil.ES2ToES3Converter.transform(shaderSource, shaderType, targetProfile, version, true, splitTextureSamplers, this.options.glslEsDefaultFloatPrecision, this.options.glslEsDefaultIntPrecision);
 
             File file_in_compute = File.createTempFile(FilenameUtils.getName(resourceOutput), ".cp");
             FileUtil.deleteOnExit(file_in_compute);
@@ -134,7 +130,7 @@ public class ShaderCompilePipelineLegacy extends ShaderCompilePipeline {
             // If the shader already has a version, we expect it to be already written in valid GLSL for that version
             if (shaderInfo == null) {
                 // Convert to ES3 (or GL 140+)
-                ShaderUtil.ES2ToES3Converter.Result es3Result = ShaderUtil.ES2ToES3Converter.transform(shaderSource, shaderType, targetProfile, version, true, splitTextureSamplers, floatPrec, intPrec);
+                ShaderUtil.ES2ToES3Converter.Result es3Result = ShaderUtil.ES2ToES3Converter.transform(shaderSource, shaderType, targetProfile, version, true, splitTextureSamplers, this.options.glslEsDefaultFloatPrecision, this.options.glslEsDefaultIntPrecision);
 
                 // Update version for SPIR-V (GLES >= 310, Core >= 140)
                 es3Result.shaderVersion = es3Result.shaderVersion.isEmpty() ? "0" : es3Result.shaderVersion;

--- a/editor/resources/localization/en.editor_localization
+++ b/editor/resources/localization/en.editor_localization
@@ -2007,9 +2007,9 @@ form.help.project.shader.output_spirv = This setting is deprecated. Compile and 
 form.label.project.shader.exclude_gles_sm100 = Exclude GLES 2.0
 form.help.project.shader.exclude_gles_sm100 = Don't compile shaders for devices running OpenGLES 2.0 / WebGL 1.0
 form.label.project.shader.glsl_es_default_precision_float = GLSL ES float precision
-form.help.project.shader.glsl_es_default_precision_float = Default float precision to use in GLSL ES shaders when not explicitly specified
+form.help.project.shader.glsl_es_default_precision_float = Default global precision qualifier for floats (GLSL ES only)
 form.label.project.shader.glsl_es_default_precision_int = GLSL ES int precision
-form.help.project.shader.glsl_es_default_precision_int = Default int precision to use in GLSL ES shaders when not explicitly specified
+form.help.project.shader.glsl_es_default_precision_int = Default global precision qualifier for integers (GLSL ES only)
 
 form.label.project.library = Library
 form.help.project.library = Settings for when this project is used as a library by another project

--- a/editor/resources/localization/en.editor_localization
+++ b/editor/resources/localization/en.editor_localization
@@ -2006,6 +2006,10 @@ form.label.project.shader.output_spirv = Output SPIR-V
 form.help.project.shader.output_spirv = This setting is deprecated. Compile and output SPIR-V shaders for use with Metal or Vulkan
 form.label.project.shader.exclude_gles_sm100 = Exclude GLES 2.0
 form.help.project.shader.exclude_gles_sm100 = Don't compile shaders for devices running OpenGLES 2.0 / WebGL 1.0
+form.label.project.shader.glsl_es_default_precision_float = GLSL ES float precision
+form.help.project.shader.glsl_es_default_precision_float = Default float precision to use in GLSL ES shaders when not explicitly specified
+form.label.project.shader.glsl_es_default_precision_int = GLSL ES int precision
+form.help.project.shader.glsl_es_default_precision_int = Default int precision to use in GLSL ES shaders when not explicitly specified
 
 form.label.project.library = Library
 form.help.project.library = Settings for when this project is used as a library by another project

--- a/editor/src/clj/editor/code/shader_compilation.clj
+++ b/editor/src/clj/editor/code/shader_compilation.clj
@@ -23,7 +23,7 @@
             [editor.workspace :as workspace]
             [util.array :as array]
             [util.eduction :as e])
-  (:import [com.dynamo.bob.pipeline ShaderProgramBuilderEditor]
+  (:import [com.dynamo.bob.pipeline ShaderProgramBuilderEditor Shaderc$ShaderPrecision]
            [com.dynamo.bob.pipeline.shader ShaderCompilePipeline$ShaderModuleDesc]
            [com.dynamo.graphics.proto Graphics$ShaderDesc Graphics$ShaderDesc$Language]))
 
@@ -59,6 +59,13 @@
     (set! (. shader-module-desc type) pb-shader-type)
     shader-module-desc))
 
+(defn- precision-string->enum
+  ^Shaderc$ShaderPrecision [s default-enum]
+  (cond
+    (nil? s) default-enum
+    (= "highp" (str s)) Shaderc$ShaderPrecision/SHADER_PRECISION_HIGHP
+    :else Shaderc$ShaderPrecision/SHADER_PRECISION_MEDIUMP))
+
 (defn- error-string->error-value [^String error-string]
   (g/error-fatal (string/trim error-string)))
 
@@ -70,7 +77,7 @@
       {:resource build-resource
        :content (protobuf/pb->bytes shader-desc)})))
 
-(defn make-shader-build-target [node-id shader-source-infos max-page-count exclude-gles-sm100]
+(defn make-shader-build-target [node-id shader-source-infos max-page-count exclude-gles-sm100 & [settings]]
   {:pre [(g/node-id? node-id)
          (vector? shader-source-infos)
          (pos? (count shader-source-infos))
@@ -97,7 +104,10 @@
                               pb-shader-languages-without-gles-sm100
                               pb-default-shader-languages)
 
-        shader-desc-build-result (ShaderProgramBuilderEditor/makeShaderDescWithVariants build-resource-path shader-module-descs-array pb-shader-languages (int max-page-count))
+        float-precision (precision-string->enum (get-in settings ["shader" "glsl_es_default_precision_float"]) Shaderc$ShaderPrecision/SHADER_PRECISION_MEDIUMP)
+        int-precision (precision-string->enum (get-in settings ["shader" "glsl_es_default_precision_int"]) Shaderc$ShaderPrecision/SHADER_PRECISION_HIGHP)
+
+        shader-desc-build-result (ShaderProgramBuilderEditor/makeShaderDescWithVariants build-resource-path shader-module-descs-array pb-shader-languages (int max-page-count) float-precision int-precision)
         shader-desc (.-shaderDesc shader-desc-build-result)]
     (bt/with-content-hash
       {:node-id node-id

--- a/editor/src/clj/editor/code/shader_compilation.clj
+++ b/editor/src/clj/editor/code/shader_compilation.clj
@@ -59,12 +59,12 @@
     (set! (. shader-module-desc type) pb-shader-type)
     shader-module-desc))
 
-(defn- precision-string->enum
-  ^Shaderc$ShaderPrecision [s default-enum]
-  (cond
-    (nil? s) default-enum
-    (= "highp" (str s)) Shaderc$ShaderPrecision/SHADER_PRECISION_HIGHP
-    :else Shaderc$ShaderPrecision/SHADER_PRECISION_MEDIUMP))
+(defn- glsl-precision-string->enum
+  ^Shaderc$ShaderPrecision [s]
+  (case s
+    "highp" Shaderc$ShaderPrecision/SHADER_PRECISION_HIGHP
+    "mediump" Shaderc$ShaderPrecision/SHADER_PRECISION_MEDIUMP
+    nil))
 
 (defn- error-string->error-value [^String error-string]
   (g/error-fatal (string/trim error-string)))
@@ -77,7 +77,7 @@
       {:resource build-resource
        :content (protobuf/pb->bytes shader-desc)})))
 
-(defn make-shader-build-target [node-id shader-source-infos max-page-count exclude-gles-sm100 & [settings]]
+(defn make-shader-build-target [node-id shader-source-infos max-page-count exclude-gles-sm100 glsl-es-default-precision-float glsl-es-default-precision-int]
   {:pre [(g/node-id? node-id)
          (vector? shader-source-infos)
          (pos? (count shader-source-infos))
@@ -103,8 +103,8 @@
         pb-shader-languages (if exclude-gles-sm100
                               pb-shader-languages-without-gles-sm100
                               pb-default-shader-languages)
-        float-precision (precision-string->enum (get settings ["shader" "glsl_es_default_precision_float"]) Shaderc$ShaderPrecision/SHADER_PRECISION_MEDIUMP)
-        int-precision (precision-string->enum (get settings ["shader" "glsl_es_default_precision_int"]) Shaderc$ShaderPrecision/SHADER_PRECISION_HIGHP)
+        float-precision (glsl-precision-string->enum glsl-es-default-precision-float)
+        int-precision (glsl-precision-string->enum glsl-es-default-precision-int)
         shader-desc-build-result (ShaderProgramBuilderEditor/makeShaderDescWithVariants build-resource-path shader-module-descs-array pb-shader-languages (int max-page-count) float-precision int-precision)
         shader-desc (.-shaderDesc shader-desc-build-result)]
     (bt/with-content-hash

--- a/editor/src/clj/editor/code/shader_compilation.clj
+++ b/editor/src/clj/editor/code/shader_compilation.clj
@@ -64,9 +64,7 @@
   (case s
     "highp" Shaderc$ShaderPrecision/SHADER_PRECISION_HIGHP
     "mediump" Shaderc$ShaderPrecision/SHADER_PRECISION_MEDIUMP
-    (throw (IllegalArgumentException.
-             (format "Invalid shader precision '%s'. Expected \"highp\" or \"mediump\"."
-                     (str s))))))
+    (g/error-fatal (format "Invalid shader precision '%s'. Expected \"highp\" or \"mediump\"." (str s)))))
 
 (defn- error-string->error-value [^String error-string]
   (g/error-fatal (string/trim error-string)))

--- a/editor/src/clj/editor/code/shader_compilation.clj
+++ b/editor/src/clj/editor/code/shader_compilation.clj
@@ -64,7 +64,9 @@
   (case s
     "highp" Shaderc$ShaderPrecision/SHADER_PRECISION_HIGHP
     "mediump" Shaderc$ShaderPrecision/SHADER_PRECISION_MEDIUMP
-    nil))
+    (throw (IllegalArgumentException.
+             (format "Invalid shader precision '%s'. Expected \"highp\" or \"mediump\"."
+                     (str s))))))
 
 (defn- error-string->error-value [^String error-string]
   (g/error-fatal (string/trim error-string)))

--- a/editor/src/clj/editor/code/shader_compilation.clj
+++ b/editor/src/clj/editor/code/shader_compilation.clj
@@ -104,13 +104,21 @@
                               pb-shader-languages-without-gles-sm100
                               pb-default-shader-languages)
         float-precision (glsl-precision-string->enum glsl-es-default-precision-float)
-        int-precision (glsl-precision-string->enum glsl-es-default-precision-int)
-        shader-desc-build-result (ShaderProgramBuilderEditor/makeShaderDescWithVariants build-resource-path shader-module-descs-array pb-shader-languages (int max-page-count) float-precision int-precision)
-        shader-desc (.-shaderDesc shader-desc-build-result)]
-    (bt/with-content-hash
-      {:node-id node-id
-       :resource build-resource
-       :shader-reflection (when shader-desc (.getReflection shader-desc))
-       :build-fn build-shader
-       :user-data {:shader-desc shader-desc
-                   :compile-warning-messages (.buildWarnings shader-desc-build-result)}})))
+        int-precision (glsl-precision-string->enum glsl-es-default-precision-int)]
+    (cond
+      (g/error-value? float-precision)
+      float-precision
+
+      (g/error-value? int-precision)
+      int-precision
+
+      :else
+      (let [shader-desc-build-result (ShaderProgramBuilderEditor/makeShaderDescWithVariants build-resource-path shader-module-descs-array pb-shader-languages (int max-page-count) float-precision int-precision)
+            shader-desc (.-shaderDesc shader-desc-build-result)]
+        (bt/with-content-hash
+          {:node-id node-id
+           :resource build-resource
+           :shader-reflection (when shader-desc (.getReflection shader-desc))
+           :build-fn build-shader
+           :user-data {:shader-desc shader-desc
+                       :compile-warning-messages (.buildWarnings shader-desc-build-result)}})))))

--- a/editor/src/clj/editor/code/shader_compilation.clj
+++ b/editor/src/clj/editor/code/shader_compilation.clj
@@ -103,10 +103,8 @@
         pb-shader-languages (if exclude-gles-sm100
                               pb-shader-languages-without-gles-sm100
                               pb-default-shader-languages)
-
-        float-precision (precision-string->enum (get-in settings ["shader" "glsl_es_default_precision_float"]) Shaderc$ShaderPrecision/SHADER_PRECISION_MEDIUMP)
-        int-precision (precision-string->enum (get-in settings ["shader" "glsl_es_default_precision_int"]) Shaderc$ShaderPrecision/SHADER_PRECISION_HIGHP)
-
+        float-precision (precision-string->enum (get settings ["shader" "glsl_es_default_precision_float"]) Shaderc$ShaderPrecision/SHADER_PRECISION_MEDIUMP)
+        int-precision (precision-string->enum (get settings ["shader" "glsl_es_default_precision_int"]) Shaderc$ShaderPrecision/SHADER_PRECISION_HIGHP)
         shader-desc-build-result (ShaderProgramBuilderEditor/makeShaderDescWithVariants build-resource-path shader-module-descs-array pb-shader-languages (int max-page-count) float-precision int-precision)
         shader-desc (.-shaderDesc shader-desc-build-result)]
     (bt/with-content-hash

--- a/editor/src/clj/editor/defold_project.clj
+++ b/editor/src/clj/editor/defold_project.clj
@@ -1632,6 +1632,8 @@
   (output display-height g/Num (g/fnk [settings]
                                   (double (or (get settings ["display" "height"]) 0))))
   (output exclude-gles-sm100 g/Any (g/fnk [settings] (get settings ["shader" "exclude_gles_sm100"])))
+  (output glsl-es-default-precision-float g/Any (g/fnk [settings] (get settings ["shader" "glsl_es_default_precision_float"])))
+  (output glsl-es-default-precision-int g/Any (g/fnk [settings] (get settings ["shader" "glsl_es_default_precision_int"])))
   (output display-profiles g/Any :cached (gu/passthrough display-profiles))
   (output texture-profiles g/Any :cached (gu/passthrough texture-profiles))
   (output dependencies g/Any (gu/passthrough dependencies))

--- a/editor/src/clj/editor/gl/shader.clj
+++ b/editor/src/clj/editor/gl/shader.clj
@@ -686,7 +686,7 @@ These forms should be quoted, as if they came from a macro."
         (coll/into-> shader-paths []
           (map (fn [^String shader-path]
                  (let [shader-source (shader-path->source shader-path)]
-                   (shader-gen/transpile-shader-source shader-path shader-source max-page-count nil nil)))))]
+                   (shader-gen/transpile-shader-source shader-path shader-source max-page-count "mediump" "highp")))))]
 
     (shader-gen/combined-shader-info augmented-shader-infos)))
 

--- a/editor/src/clj/editor/gl/shader.clj
+++ b/editor/src/clj/editor/gl/shader.clj
@@ -682,12 +682,13 @@ These forms should be quoted, as if they came from a macro."
 
 (defn read-combined-shader-info [shader-paths opts shader-path->source]
   (let [max-page-count (long (or (:max-page-count opts) 0))
+        settings (:settings opts)
 
         augmented-shader-infos
         (coll/into-> shader-paths []
           (map (fn [^String shader-path]
                  (let [shader-source (shader-path->source shader-path)]
-                   (shader-gen/transpile-shader-source shader-path shader-source max-page-count)))))]
+                   (shader-gen/transpile-shader-source shader-path shader-source max-page-count settings)))))]
 
     (shader-gen/combined-shader-info augmented-shader-infos)))
 

--- a/editor/src/clj/editor/gl/shader.clj
+++ b/editor/src/clj/editor/gl/shader.clj
@@ -682,13 +682,11 @@ These forms should be quoted, as if they came from a macro."
 
 (defn read-combined-shader-info [shader-paths opts shader-path->source]
   (let [max-page-count (long (or (:max-page-count opts) 0))
-        settings (:settings opts)
-
         augmented-shader-infos
         (coll/into-> shader-paths []
           (map (fn [^String shader-path]
                  (let [shader-source (shader-path->source shader-path)]
-                   (shader-gen/transpile-shader-source shader-path shader-source max-page-count settings)))))]
+                   (shader-gen/transpile-shader-source shader-path shader-source max-page-count nil nil)))))]
 
     (shader-gen/combined-shader-info augmented-shader-infos)))
 

--- a/editor/src/clj/editor/material.clj
+++ b/editor/src/clj/editor/material.clj
@@ -175,13 +175,13 @@
     :constant-type-worldviewproj :world-view-proj))
 
 (defn- transpile-shader-source
-  [shader-resource-node-id shader-resource ^String shader-source max-page-count settings]
+  [shader-resource-node-id shader-resource ^String shader-source max-page-count glsl-es-default-precision-float glsl-es-default-precision-int]
   ;; TODO(instancing): The shader-source has been preprocessed and will contain
   ;; lines from include directives, so we do not report the correct source paths
   ;; and line numbers here.
   (let [shader-proj-path (resource/proj-path shader-resource)]
     (try
-      (shader-gen/transpile-shader-source shader-proj-path shader-source max-page-count settings)
+      (shader-gen/transpile-shader-source shader-proj-path shader-source max-page-count glsl-es-default-precision-float glsl-es-default-precision-int)
       (catch Exception exception
         (let [ex-data (ex-data exception)]
           (if-not (shader-gen/shader-transpile-ex-data? ex-data)
@@ -202,8 +202,7 @@
       (prop-resource-error _node-id :fragment-program fragment-program fragment-program-message "fp")
       (let [augmented-shader-infos
             (mapv (fn [{:keys [node-id resource shader-source]}]
-                    (transpile-shader-source node-id resource shader-source max-page-count {"shader" {"glsl_es_default_precision_float" glsl-es-default-precision-float
-                                                                                                   "glsl_es_default_precision_int" glsl-es-default-precision-int}}))
+                    (transpile-shader-source node-id resource shader-source max-page-count glsl-es-default-precision-float glsl-es-default-precision-int))
                   [vertex-shader-source-info
                    fragment-shader-source-info])]
         (g/precluding-errors augmented-shader-infos

--- a/editor/src/clj/editor/material.clj
+++ b/editor/src/clj/editor/material.clj
@@ -132,12 +132,12 @@
   (when-some [pbr-parameters-proto (MaterialBuilder/makePbrParametersProtoMessage shader-reflection)]
     (protobuf/pb->map-without-defaults pbr-parameters-proto)))
 
-(g/defnk produce-build-targets [_node-id attribute-infos base-pb-msg fragment-program fragment-shader-source-info max-page-count exclude-gles-sm100 resource settings vertex-program vertex-shader-source-info]
+(g/defnk produce-build-targets [_node-id attribute-infos base-pb-msg fragment-program fragment-shader-source-info max-page-count exclude-gles-sm100 glsl-es-default-precision-float glsl-es-default-precision-int resource vertex-program vertex-shader-source-info]
   (or (g/flatten-errors
         (prop-resource-error _node-id :vertex-program vertex-program vertex-program-message "vp")
         (prop-resource-error _node-id :fragment-program fragment-program fragment-program-message "fp")
         (mapcat #(attribute-info->error-values % _node-id :attributes) attribute-infos))
-      (let [shader-desc-build-target (shader-compilation/make-shader-build-target _node-id [vertex-shader-source-info fragment-shader-source-info] max-page-count exclude-gles-sm100 settings)
+      (let [shader-desc-build-target (shader-compilation/make-shader-build-target _node-id [vertex-shader-source-info fragment-shader-source-info] max-page-count exclude-gles-sm100 glsl-es-default-precision-float glsl-es-default-precision-int)
             build-target-samplers (build-target-samplers (:samplers base-pb-msg) max-page-count)
             build-target-attributes (build-target-attributes attribute-infos)
             build-target-pbr-params (build-target-pbr-params (:shader-reflection shader-desc-build-target))
@@ -197,12 +197,13 @@
                                     error-cursor-range (assoc :cursor-range error-cursor-range))]
               (g/->error shader-resource-node-id :lines :fatal nil message user-data))))))))
 
-(g/defnk produce-combined-shader-info [_node-id vertex-program vertex-shader-source-info fragment-program fragment-shader-source-info max-page-count settings]
+(g/defnk produce-combined-shader-info [_node-id vertex-program vertex-shader-source-info fragment-program fragment-shader-source-info max-page-count glsl-es-default-precision-float glsl-es-default-precision-int]
   (or (prop-resource-error _node-id :vertex-program vertex-program vertex-program-message "vp")
       (prop-resource-error _node-id :fragment-program fragment-program fragment-program-message "fp")
       (let [augmented-shader-infos
             (mapv (fn [{:keys [node-id resource shader-source]}]
-                    (transpile-shader-source node-id resource shader-source max-page-count settings))
+                    (transpile-shader-source node-id resource shader-source max-page-count {"shader" {"glsl_es_default_precision_float" glsl-es-default-precision-float
+                                                                                                   "glsl_es_default_precision_int" glsl-es-default-precision-int}}))
                   [vertex-shader-source-info
                    fragment-shader-source-info])]
         (g/precluding-errors augmented-shader-infos
@@ -572,7 +573,8 @@
   (input fragment-resource resource/Resource)
   (input fragment-shader-source-info g/Any)
   (input exclude-gles-sm100 g/Any)
-  (input settings g/Any)
+  (input glsl-es-default-precision-float g/Any)
+  (input glsl-es-default-precision-int g/Any)
 
   (output base-pb-msg g/Any produce-base-pb-msg)
 
@@ -594,7 +596,8 @@
     (concat
       (g/connect project :default-sampler-filter-modes self :default-sampler-filter-modes)
       (g/connect project :exclude-gles-sm100 self :exclude-gles-sm100)
-      (g/connect project :settings self :settings)
+      (g/connect project :glsl-es-default-precision-float self :glsl-es-default-precision-float)
+      (g/connect project :glsl-es-default-precision-int self :glsl-es-default-precision-int)
       (gu/set-properties-from-pb-map self Material$MaterialDesc material-desc
         vertex-program (resolve-resource :vertex-program)
         fragment-program (resolve-resource :fragment-program)

--- a/editor/src/clj/editor/material.clj
+++ b/editor/src/clj/editor/material.clj
@@ -181,7 +181,7 @@
   ;; and line numbers here.
   (let [shader-proj-path (resource/proj-path shader-resource)]
     (try
-      (shader-gen/transpile-shader-source shader-proj-path shader-source max-page-count glsl-es-default-precision-float glsl-es-default-precision-int)
+      (shader-gen/transpile-shader-source shader-proj-path shader-source ^long max-page-count glsl-es-default-precision-float glsl-es-default-precision-int)
       (catch Exception exception
         (let [ex-data (ex-data exception)]
           (if-not (shader-gen/shader-transpile-ex-data? ex-data)

--- a/editor/src/clj/editor/material.clj
+++ b/editor/src/clj/editor/material.clj
@@ -132,12 +132,12 @@
   (when-some [pbr-parameters-proto (MaterialBuilder/makePbrParametersProtoMessage shader-reflection)]
     (protobuf/pb->map-without-defaults pbr-parameters-proto)))
 
-(g/defnk produce-build-targets [_node-id attribute-infos base-pb-msg fragment-program fragment-shader-source-info max-page-count exclude-gles-sm100 resource vertex-program vertex-shader-source-info]
+(g/defnk produce-build-targets [_node-id attribute-infos base-pb-msg fragment-program fragment-shader-source-info max-page-count exclude-gles-sm100 resource settings vertex-program vertex-shader-source-info]
   (or (g/flatten-errors
         (prop-resource-error _node-id :vertex-program vertex-program vertex-program-message "vp")
         (prop-resource-error _node-id :fragment-program fragment-program fragment-program-message "fp")
         (mapcat #(attribute-info->error-values % _node-id :attributes) attribute-infos))
-      (let [shader-desc-build-target (shader-compilation/make-shader-build-target _node-id [vertex-shader-source-info fragment-shader-source-info] max-page-count exclude-gles-sm100)
+      (let [shader-desc-build-target (shader-compilation/make-shader-build-target _node-id [vertex-shader-source-info fragment-shader-source-info] max-page-count exclude-gles-sm100 settings)
             build-target-samplers (build-target-samplers (:samplers base-pb-msg) max-page-count)
             build-target-attributes (build-target-attributes attribute-infos)
             build-target-pbr-params (build-target-pbr-params (:shader-reflection shader-desc-build-target))
@@ -175,13 +175,13 @@
     :constant-type-worldviewproj :world-view-proj))
 
 (defn- transpile-shader-source
-  [shader-resource-node-id shader-resource ^String shader-source ^long max-page-count]
+  [shader-resource-node-id shader-resource ^String shader-source ^long max-page-count settings]
   ;; TODO(instancing): The shader-source has been preprocessed and will contain
   ;; lines from include directives, so we do not report the correct source paths
   ;; and line numbers here.
   (let [shader-proj-path (resource/proj-path shader-resource)]
     (try
-      (shader-gen/transpile-shader-source shader-proj-path shader-source max-page-count)
+      (shader-gen/transpile-shader-source shader-proj-path shader-source max-page-count settings)
       (catch Exception exception
         (let [ex-data (ex-data exception)]
           (if-not (shader-gen/shader-transpile-ex-data? ex-data)
@@ -197,12 +197,12 @@
                                     error-cursor-range (assoc :cursor-range error-cursor-range))]
               (g/->error shader-resource-node-id :lines :fatal nil message user-data))))))))
 
-(g/defnk produce-combined-shader-info [_node-id vertex-program vertex-shader-source-info fragment-program fragment-shader-source-info max-page-count]
+(g/defnk produce-combined-shader-info [_node-id vertex-program vertex-shader-source-info fragment-program fragment-shader-source-info max-page-count settings]
   (or (prop-resource-error _node-id :vertex-program vertex-program vertex-program-message "vp")
       (prop-resource-error _node-id :fragment-program fragment-program fragment-program-message "fp")
       (let [augmented-shader-infos
             (mapv (fn [{:keys [node-id resource shader-source]}]
-                    (transpile-shader-source node-id resource shader-source max-page-count))
+                    (transpile-shader-source node-id resource shader-source max-page-count settings))
                   [vertex-shader-source-info
                    fragment-shader-source-info])]
         (g/precluding-errors augmented-shader-infos
@@ -572,6 +572,7 @@
   (input fragment-resource resource/Resource)
   (input fragment-shader-source-info g/Any)
   (input exclude-gles-sm100 g/Any)
+  (input settings g/Any)
 
   (output base-pb-msg g/Any produce-base-pb-msg)
 
@@ -593,6 +594,7 @@
     (concat
       (g/connect project :default-sampler-filter-modes self :default-sampler-filter-modes)
       (g/connect project :exclude-gles-sm100 self :exclude-gles-sm100)
+      (g/connect project :settings self :settings)
       (gu/set-properties-from-pb-map self Material$MaterialDesc material-desc
         vertex-program (resolve-resource :vertex-program)
         fragment-program (resolve-resource :fragment-program)

--- a/editor/src/clj/editor/material.clj
+++ b/editor/src/clj/editor/material.clj
@@ -175,7 +175,7 @@
     :constant-type-worldviewproj :world-view-proj))
 
 (defn- transpile-shader-source
-  [shader-resource-node-id shader-resource ^String shader-source ^long max-page-count settings]
+  [shader-resource-node-id shader-resource ^String shader-source max-page-count settings]
   ;; TODO(instancing): The shader-source has been preprocessed and will contain
   ;; lines from include directives, so we do not report the correct source paths
   ;; and line numbers here.

--- a/editor/src/clj/editor/pipeline/shader_gen.clj
+++ b/editor/src/clj/editor/pipeline/shader_gen.clj
@@ -161,8 +161,8 @@
          (pos? (count shader-source))]}
   (let [shader-type (graphics.types/filename-shader-type shader-path)
         pb-shader-type (graphics.types/shader-type-pb-shader-type shader-type)
-        float-precision (precision-string->enum (get-in settings ["shader" "glsl_es_default_precision_float"]) Shaderc$ShaderPrecision/SHADER_PRECISION_MEDIUMP)
-        int-precision (precision-string->enum (get-in settings ["shader" "glsl_es_default_precision_int"]) Shaderc$ShaderPrecision/SHADER_PRECISION_HIGHP)
+        float-precision (precision-string->enum (get settings ["shader" "glsl_es_default_precision_float"]) Shaderc$ShaderPrecision/SHADER_PRECISION_MEDIUMP)
+        int-precision (precision-string->enum (get settings ["shader" "glsl_es_default_precision_int"]) Shaderc$ShaderPrecision/SHADER_PRECISION_HIGHP)
 
         ^ShaderUtil$Common$GLSLCompileResult glsl-compile-result
         (try

--- a/editor/src/clj/editor/pipeline/shader_gen.clj
+++ b/editor/src/clj/editor/pipeline/shader_gen.clj
@@ -136,12 +136,14 @@
     false))
 
 (defn- precision-string->enum
-  "Maps game.project precision string to Shaderc.ShaderPrecision. default-enum used when s is nil."
-  ^Shaderc$ShaderPrecision [s default-enum]
-  (cond
-    (= "highp" (str s)) Shaderc$ShaderPrecision/SHADER_PRECISION_HIGHP
-    (= "mediump" (str s)) Shaderc$ShaderPrecision/SHADER_PRECISION_MEDIUMP
-    :else default-enum))
+  "Maps game.project precision string to Shaderc.ShaderPrecision."
+  ^Shaderc$ShaderPrecision [s]
+  (case s
+    "highp" Shaderc$ShaderPrecision/SHADER_PRECISION_HIGHP
+    "mediump" Shaderc$ShaderPrecision/SHADER_PRECISION_MEDIUMP
+    (throw (IllegalArgumentException.
+             (format "Invalid shader precision '%s'. Expected \"highp\" or \"mediump\"."
+                     (str s))))))
 
 (defonce ^{:private true :tag 'byte} vertex-shader-stage-flag (byte (.getValue Shaderc$ShaderStage/SHADER_STAGE_VERTEX)))
 
@@ -161,8 +163,8 @@
          (pos? (count shader-source))]}
   (let [shader-type (graphics.types/filename-shader-type shader-path)
         pb-shader-type (graphics.types/shader-type-pb-shader-type shader-type)
-        float-precision (precision-string->enum float-precision-str Shaderc$ShaderPrecision/SHADER_PRECISION_MEDIUMP)
-        int-precision (precision-string->enum int-precision-str Shaderc$ShaderPrecision/SHADER_PRECISION_HIGHP)
+        float-precision (precision-string->enum float-precision-str)
+        int-precision (precision-string->enum int-precision-str)
 
         ^ShaderUtil$Common$GLSLCompileResult glsl-compile-result
         (try

--- a/editor/src/clj/editor/pipeline/shader_gen.clj
+++ b/editor/src/clj/editor/pipeline/shader_gen.clj
@@ -154,7 +154,7 @@
   augmented-shader-info map with the transpiled shader source and various
   reflection info. When settings (map) is provided, reads shader.glsl_es_default_precision_float
   and shader.glsl_es_default_precision_int; otherwise uses mediump float and highp int."
-  [^String shader-path ^String shader-source ^long max-page-count & [settings]]
+  [^String shader-path ^String shader-source max-page-count & [settings]]
   {:pre [(string? shader-path)
          (pos? (count shader-path))
          (string? shader-source)

--- a/editor/src/clj/editor/pipeline/shader_gen.clj
+++ b/editor/src/clj/editor/pipeline/shader_gen.clj
@@ -166,18 +166,18 @@
 
         ^ShaderUtil$Common$GLSLCompileResult glsl-compile-result
         (try
-          (ShaderProgramBuilderEditor/buildGLSLVariantTextureArray shader-path shader-source pb-shader-type transpile-target-pb-shader-language max-page-count float-precision int-precision)
+          (ShaderProgramBuilderEditor/buildGLSLVariantTextureArray shader-path shader-source pb-shader-type transpile-target-pb-shader-language ^long max-page-count float-precision int-precision)
           (catch CompileExceptionError cause
             (let [error-line-number (.getLineNumber cause)
                   error-proj-path (or (some-> cause .getResource .getPath (str "/"))
                                       shader-path)]
               (throw (decorate-transpile-error
-                       cause shader-type shader-path shader-source max-page-count
+                       cause shader-type shader-path shader-source ^long max-page-count
                        :error-line-number error-line-number
                        :error-proj-path error-proj-path))))
           (catch Exception cause
             (throw (decorate-transpile-error
-                     cause shader-type shader-path shader-source max-page-count))))
+                     cause shader-type shader-path shader-source ^long max-page-count))))
 
         transpiled-shader-source (.source glsl-compile-result)
         array-sampler-names (vec (.arraySamplers glsl-compile-result))
@@ -190,7 +190,7 @@
           (map make-attribute-reflection-info))]
 
     {:shader-type shader-type
-     :max-page-count max-page-count
+     :max-page-count ^long max-page-count
      :transpiled-shader-source transpiled-shader-source
      :resource-binding-namespaces resource-binding-namespaces
      :array-sampler-names array-sampler-names

--- a/editor/src/clj/editor/pipeline/shader_gen.clj
+++ b/editor/src/clj/editor/pipeline/shader_gen.clj
@@ -19,7 +19,7 @@
             [util.coll :as coll :refer [pair]]
             [util.eduction :as e])
   (:import [com.dynamo.bob CompileExceptionError]
-           [com.dynamo.bob.pipeline ShaderProgramBuilder ShaderProgramBuilderEditor ShaderUtil$Common$GLSLCompileResult Shaderc$ShaderResource Shaderc$ShaderStage]
+           [com.dynamo.bob.pipeline ShaderProgramBuilder ShaderProgramBuilderEditor ShaderUtil$Common$GLSLCompileResult Shaderc$ShaderPrecision Shaderc$ShaderResource Shaderc$ShaderStage]
            [com.dynamo.bob.pipeline.shader SPIRVReflector]
            [com.dynamo.graphics.proto Graphics$ShaderDesc$Language Graphics$ShaderDesc$ShaderDataType]))
 
@@ -135,6 +135,14 @@
     ::shader-transpile-error true
     false))
 
+(defn- precision-string->enum
+  "Maps game.project precision string to Shaderc.ShaderPrecision. default-enum used when s is nil."
+  ^Shaderc$ShaderPrecision [s default-enum]
+  (cond
+    (nil? s) default-enum
+    (= "highp" (str s)) Shaderc$ShaderPrecision/SHADER_PRECISION_HIGHP
+    :else Shaderc$ShaderPrecision/SHADER_PRECISION_MEDIUMP))
+
 (defonce ^{:private true :tag 'byte} vertex-shader-stage-flag (byte (.getValue Shaderc$ShaderStage/SHADER_STAGE_VERTEX)))
 
 (defn- vertex-shader-resource? [^Shaderc$ShaderResource shader-resource]
@@ -144,18 +152,21 @@
 (defn transpile-shader-source
   "Compiles a single shader source file, for example, a .vp or a .fp file into a
   augmented-shader-info map with the transpiled shader source and various
-  reflection info."
-  [^String shader-path ^String shader-source ^long max-page-count]
+  reflection info. When settings (map) is provided, reads shader.glsl_es_default_precision_float
+  and shader.glsl_es_default_precision_int; otherwise uses mediump float and highp int."
+  [^String shader-path ^String shader-source ^long max-page-count & [settings]]
   {:pre [(string? shader-path)
          (pos? (count shader-path))
          (string? shader-source)
          (pos? (count shader-source))]}
   (let [shader-type (graphics.types/filename-shader-type shader-path)
         pb-shader-type (graphics.types/shader-type-pb-shader-type shader-type)
+        float-precision (precision-string->enum (get-in settings ["shader" "glsl_es_default_precision_float"]) Shaderc$ShaderPrecision/SHADER_PRECISION_MEDIUMP)
+        int-precision (precision-string->enum (get-in settings ["shader" "glsl_es_default_precision_int"]) Shaderc$ShaderPrecision/SHADER_PRECISION_HIGHP)
 
         ^ShaderUtil$Common$GLSLCompileResult glsl-compile-result
         (try
-          (ShaderProgramBuilderEditor/buildGLSLVariantTextureArray shader-path shader-source pb-shader-type transpile-target-pb-shader-language max-page-count)
+          (ShaderProgramBuilderEditor/buildGLSLVariantTextureArray shader-path shader-source pb-shader-type transpile-target-pb-shader-language max-page-count float-precision int-precision)
           (catch CompileExceptionError cause
             (let [error-line-number (.getLineNumber cause)
                   error-proj-path (or (some-> cause .getResource .getPath (str "/"))

--- a/editor/src/clj/editor/pipeline/shader_gen.clj
+++ b/editor/src/clj/editor/pipeline/shader_gen.clj
@@ -163,12 +163,10 @@
          (pos? (count shader-source))]}
   (let [shader-type (graphics.types/filename-shader-type shader-path)
         pb-shader-type (graphics.types/shader-type-pb-shader-type shader-type)
-        float-precision (precision-string->enum float-precision-str)
-        int-precision (precision-string->enum int-precision-str)
 
         ^ShaderUtil$Common$GLSLCompileResult glsl-compile-result
         (try
-          (ShaderProgramBuilderEditor/buildGLSLVariantTextureArray shader-path shader-source pb-shader-type transpile-target-pb-shader-language ^long max-page-count float-precision int-precision)
+          (ShaderProgramBuilderEditor/buildGLSLVariantTextureArray shader-path shader-source pb-shader-type transpile-target-pb-shader-language ^long max-page-count (precision-string->enum float-precision-str) (precision-string->enum int-precision-str))
           (catch CompileExceptionError cause
             (let [error-line-number (.getLineNumber cause)
                   error-proj-path (or (some-> cause .getResource .getPath (str "/"))

--- a/editor/src/clj/editor/pipeline/shader_gen.clj
+++ b/editor/src/clj/editor/pipeline/shader_gen.clj
@@ -139,9 +139,9 @@
   "Maps game.project precision string to Shaderc.ShaderPrecision. default-enum used when s is nil."
   ^Shaderc$ShaderPrecision [s default-enum]
   (cond
-    (nil? s) default-enum
     (= "highp" (str s)) Shaderc$ShaderPrecision/SHADER_PRECISION_HIGHP
-    :else Shaderc$ShaderPrecision/SHADER_PRECISION_MEDIUMP))
+    (= "mediump" (str s)) Shaderc$ShaderPrecision/SHADER_PRECISION_MEDIUMP
+    :else default-enum))
 
 (defonce ^{:private true :tag 'byte} vertex-shader-stage-flag (byte (.getValue Shaderc$ShaderStage/SHADER_STAGE_VERTEX)))
 
@@ -150,19 +150,19 @@
                  vertex-shader-stage-flag)))
 
 (defn transpile-shader-source
-  "Compiles a single shader source file, for example, a .vp or a .fp file into a
+  "Compiles a single shader source file, for example, a .vp or a .fp file into an
   augmented-shader-info map with the transpiled shader source and various
-  reflection info. When settings (map) is provided, reads shader.glsl_es_default_precision_float
-  and shader.glsl_es_default_precision_int; otherwise uses mediump float and highp int."
-  [^String shader-path ^String shader-source max-page-count & [settings]]
+  reflection info. The precision strings should be either \"highp\" or \"mediump\";
+  when nil, mediump float and highp int are used."
+  [^String shader-path ^String shader-source max-page-count float-precision-str int-precision-str]
   {:pre [(string? shader-path)
          (pos? (count shader-path))
          (string? shader-source)
          (pos? (count shader-source))]}
   (let [shader-type (graphics.types/filename-shader-type shader-path)
         pb-shader-type (graphics.types/shader-type-pb-shader-type shader-type)
-        float-precision (precision-string->enum (get settings ["shader" "glsl_es_default_precision_float"]) Shaderc$ShaderPrecision/SHADER_PRECISION_MEDIUMP)
-        int-precision (precision-string->enum (get settings ["shader" "glsl_es_default_precision_int"]) Shaderc$ShaderPrecision/SHADER_PRECISION_HIGHP)
+        float-precision (precision-string->enum float-precision-str Shaderc$ShaderPrecision/SHADER_PRECISION_MEDIUMP)
+        int-precision (precision-string->enum int-precision-str Shaderc$ShaderPrecision/SHADER_PRECISION_HIGHP)
 
         ^ShaderUtil$Common$GLSLCompileResult glsl-compile-result
         (try

--- a/editor/test/resources/save_data_project/game.project
+++ b/editor/test/resources/save_data_project/game.project
@@ -282,6 +282,8 @@ player_health = 120
 
 [shader]
 exclude_gles_sm100 = 0
+glsl_es_default_precision_float = highp
+glsl_es_default_precision_int = mediump
 
 [font]
 runtime_generation = 1

--- a/engine/shaderc/src/java/com/dynamo/bob/pipeline/Shaderc.java
+++ b/engine/shaderc/src/java/com/dynamo/bob/pipeline/Shaderc.java
@@ -204,9 +204,30 @@ public class Shaderc {
         }
     };
 
+    public enum ShaderPrecision {
+        SHADER_PRECISION_MEDIUMP(0),
+        SHADER_PRECISION_HIGHP(1);
+        private final int value;
+        private ShaderPrecision(int value) {
+            this.value = value;
+        }
+        public int getValue() {
+            return this.value;
+        }
+        static public ShaderPrecision fromValue(int value) throws IllegalArgumentException {
+            for (ShaderPrecision e : ShaderPrecision.values()) {
+                if (e.value == value)
+                    return e;
+            }
+            throw new IllegalArgumentException(String.format("Invalid value to ShaderPrecision: %d", value) );
+        }
+    };
+
     public static class ShaderCompilerOptions {
         public int version = 0;
         public String entryPoint;
+        public ShaderPrecision glslEsDefaultFloatPrecision = ShaderPrecision.SHADER_PRECISION_MEDIUMP;
+        public ShaderPrecision glslEsDefaultIntPrecision = ShaderPrecision.SHADER_PRECISION_MEDIUMP;
         public byte removeUnusedVariables = 0;
         public byte no420PackExtension = 0;
         public byte glslEmitUboAsPlainUniforms = 0;

--- a/engine/shaderc/src/jni/Shaderc_jni.cpp
+++ b/engine/shaderc/src/jni/Shaderc_jni.cpp
@@ -45,6 +45,8 @@ void InitializeJNITypes(JNIEnv* env, TypeInfos* infos) {
         SETUP_CLASS(ShaderCompilerOptionsJNI, "ShaderCompilerOptions");
         GET_FLD_TYPESTR(version, "I");
         GET_FLD_TYPESTR(entryPoint, "Ljava/lang/String;");
+        GET_FLD(glslEsDefaultFloatPrecision, "ShaderPrecision");
+        GET_FLD(glslEsDefaultIntPrecision, "ShaderPrecision");
         GET_FLD_TYPESTR(removeUnusedVariables, "B");
         GET_FLD_TYPESTR(no420PackExtension, "B");
         GET_FLD_TYPESTR(glslEmitUboAsPlainUniforms, "B");
@@ -147,6 +149,8 @@ jobject C2J_CreateShaderCompilerOptions(JNIEnv* env, TypeInfos* types, const Sha
     jobject obj = env->AllocObject(types->m_ShaderCompilerOptionsJNI.cls);
     dmJNI::SetUInt(env, obj, types->m_ShaderCompilerOptionsJNI.version, src->m_Version);
     dmJNI::SetString(env, obj, types->m_ShaderCompilerOptionsJNI.entryPoint, src->m_EntryPoint);
+    dmJNI::SetEnum(env, obj, types->m_ShaderCompilerOptionsJNI.glslEsDefaultFloatPrecision, src->m_GlslEsDefaultFloatPrecision);
+    dmJNI::SetEnum(env, obj, types->m_ShaderCompilerOptionsJNI.glslEsDefaultIntPrecision, src->m_GlslEsDefaultIntPrecision);
     dmJNI::SetUByte(env, obj, types->m_ShaderCompilerOptionsJNI.removeUnusedVariables, src->m_RemoveUnusedVariables);
     dmJNI::SetUByte(env, obj, types->m_ShaderCompilerOptionsJNI.no420PackExtension, src->m_No420PackExtension);
     dmJNI::SetUByte(env, obj, types->m_ShaderCompilerOptionsJNI.glslEmitUboAsPlainUniforms, src->m_GlslEmitUboAsPlainUniforms);
@@ -436,6 +440,8 @@ bool J2C_CreateShaderCompilerOptions(JNIEnv* env, TypeInfos* types, jobject obj,
     if (out == 0) return false;
     out->m_Version = dmJNI::GetUInt(env, obj, types->m_ShaderCompilerOptionsJNI.version);
     out->m_EntryPoint = dmJNI::GetString(env, obj, types->m_ShaderCompilerOptionsJNI.entryPoint);
+    out->m_GlslEsDefaultFloatPrecision = (ShaderPrecision)dmJNI::GetEnum(env, obj, types->m_ShaderCompilerOptionsJNI.glslEsDefaultFloatPrecision);
+    out->m_GlslEsDefaultIntPrecision = (ShaderPrecision)dmJNI::GetEnum(env, obj, types->m_ShaderCompilerOptionsJNI.glslEsDefaultIntPrecision);
     out->m_RemoveUnusedVariables = dmJNI::GetUByte(env, obj, types->m_ShaderCompilerOptionsJNI.removeUnusedVariables);
     out->m_No420PackExtension = dmJNI::GetUByte(env, obj, types->m_ShaderCompilerOptionsJNI.no420PackExtension);
     out->m_GlslEmitUboAsPlainUniforms = dmJNI::GetUByte(env, obj, types->m_ShaderCompilerOptionsJNI.glslEmitUboAsPlainUniforms);

--- a/engine/shaderc/src/jni/Shaderc_jni.h
+++ b/engine/shaderc/src/jni/Shaderc_jni.h
@@ -26,6 +26,8 @@ struct ShaderCompilerOptionsJNI {
     jclass cls;
     jfieldID version;
     jfieldID entryPoint;
+    jfieldID glslEsDefaultFloatPrecision;
+    jfieldID glslEsDefaultIntPrecision;
     jfieldID removeUnusedVariables;
     jfieldID no420PackExtension;
     jfieldID glslEmitUboAsPlainUniforms;

--- a/engine/shaderc/src/shaderc.h
+++ b/engine/shaderc/src/shaderc.h
@@ -130,6 +130,12 @@ namespace dmShaderc
         IMAGE_ACCESS_QUALIFIER_READ_WRITE,
     };
 
+    enum ShaderPrecision
+    {
+        SHADER_PRECISION_MEDIUMP,
+        SHADER_PRECISION_HIGHP,
+    };
+
     struct ShaderCompilerOptions
     {
         ShaderCompilerOptions()
@@ -139,15 +145,18 @@ namespace dmShaderc
         , m_No420PackExtension(true)
         , m_GlslEmitUboAsPlainUniforms(true)
         , m_GlslEs(false)
+        , m_GlslEsDefaultFloatPrecision(SHADER_PRECISION_MEDIUMP)
+        , m_GlslEsDefaultIntPrecision(SHADER_PRECISION_HIGHP)
         {}
 
-        uint32_t    m_Version;
-        const char* m_EntryPoint;
-
-        uint8_t     m_RemoveUnusedVariables      : 1;
-        uint8_t     m_No420PackExtension         : 1;
-        uint8_t     m_GlslEmitUboAsPlainUniforms : 1;
-        uint8_t     m_GlslEs                     : 1;
+        uint32_t        m_Version;
+        const char*     m_EntryPoint;
+        ShaderPrecision m_GlslEsDefaultFloatPrecision;
+        ShaderPrecision m_GlslEsDefaultIntPrecision;
+        uint8_t         m_RemoveUnusedVariables      : 1;
+        uint8_t         m_No420PackExtension         : 1;
+        uint8_t         m_GlslEmitUboAsPlainUniforms : 1;
+        uint8_t         m_GlslEs                     : 1;
     };
 
     struct ResourceType

--- a/engine/shaderc/src/shaderc.h
+++ b/engine/shaderc/src/shaderc.h
@@ -141,12 +141,12 @@ namespace dmShaderc
         ShaderCompilerOptions()
         : m_Version(330)
         , m_EntryPoint("main")
+        , m_GlslEsDefaultFloatPrecision(SHADER_PRECISION_MEDIUMP)
+        , m_GlslEsDefaultIntPrecision(SHADER_PRECISION_HIGHP)
         , m_RemoveUnusedVariables(true)
         , m_No420PackExtension(true)
         , m_GlslEmitUboAsPlainUniforms(true)
         , m_GlslEs(false)
-        , m_GlslEsDefaultFloatPrecision(SHADER_PRECISION_MEDIUMP)
-        , m_GlslEsDefaultIntPrecision(SHADER_PRECISION_HIGHP)
         {}
 
         uint32_t        m_Version;

--- a/engine/shaderc/src/shaderc_spvc.cpp
+++ b/engine/shaderc/src/shaderc_spvc.cpp
@@ -531,10 +531,11 @@ namespace dmShaderc
             spvc_compiler_options_set_bool(spv_options, SPVC_COMPILER_OPTION_GLSL_ES,                       options.m_GlslEs);
             spvc_compiler_options_set_bool(spv_options, SPVC_COMPILER_OPTION_GLSL_ENABLE_420PACK_EXTENSION, !options.m_No420PackExtension);
 
-            // TODO:
-            // SPVC_COMPILER_OPTION_GLSL_ES_DEFAULT_FLOAT_PRECISION_HIGHP
-            // SPVC_COMPILER_OPTION_GLSL_ES_DEFAULT_INT_PRECISION_HIGHP
-
+            if (options.m_GlslEs)
+            {
+                spvc_compiler_options_set_bool(spv_options, SPVC_COMPILER_OPTION_GLSL_ES_DEFAULT_FLOAT_PRECISION_HIGHP, options.m_GlslEsDefaultFloatPrecision == SHADER_PRECISION_HIGHP);
+                spvc_compiler_options_set_bool(spv_options, SPVC_COMPILER_OPTION_GLSL_ES_DEFAULT_INT_PRECISION_HIGHP, options.m_GlslEsDefaultIntPrecision == SHADER_PRECISION_HIGHP);
+            }
         }
         else if (compiler->m_BaseCompiler.m_Language == SHADER_LANGUAGE_HLSL)
         {

--- a/engine/shaderc/src/shaderc_spvc.cpp
+++ b/engine/shaderc/src/shaderc_spvc.cpp
@@ -527,15 +527,11 @@ namespace dmShaderc
 
         if (compiler->m_BaseCompiler.m_Language == SHADER_LANGUAGE_GLSL)
         {
-            spvc_compiler_options_set_uint(spv_options, SPVC_COMPILER_OPTION_GLSL_VERSION,                  options.m_Version);
-            spvc_compiler_options_set_bool(spv_options, SPVC_COMPILER_OPTION_GLSL_ES,                       options.m_GlslEs);
+            spvc_compiler_options_set_uint(spv_options, SPVC_COMPILER_OPTION_GLSL_VERSION, options.m_Version);
             spvc_compiler_options_set_bool(spv_options, SPVC_COMPILER_OPTION_GLSL_ENABLE_420PACK_EXTENSION, !options.m_No420PackExtension);
-
-            if (options.m_GlslEs)
-            {
-                spvc_compiler_options_set_bool(spv_options, SPVC_COMPILER_OPTION_GLSL_ES_DEFAULT_FLOAT_PRECISION_HIGHP, options.m_GlslEsDefaultFloatPrecision == SHADER_PRECISION_HIGHP);
-                spvc_compiler_options_set_bool(spv_options, SPVC_COMPILER_OPTION_GLSL_ES_DEFAULT_INT_PRECISION_HIGHP, options.m_GlslEsDefaultIntPrecision == SHADER_PRECISION_HIGHP);
-            }
+            spvc_compiler_options_set_bool(spv_options, SPVC_COMPILER_OPTION_GLSL_ES, options.m_GlslEs);
+            spvc_compiler_options_set_bool(spv_options, SPVC_COMPILER_OPTION_GLSL_ES_DEFAULT_FLOAT_PRECISION_HIGHP, options.m_GlslEsDefaultFloatPrecision == SHADER_PRECISION_HIGHP);
+            spvc_compiler_options_set_bool(spv_options, SPVC_COMPILER_OPTION_GLSL_ES_DEFAULT_INT_PRECISION_HIGHP, options.m_GlslEsDefaultIntPrecision == SHADER_PRECISION_HIGHP);
         }
         else if (compiler->m_BaseCompiler.m_Language == SHADER_LANGUAGE_HLSL)
         {

--- a/engine/shaderc/src/test/test_shaderc.cpp
+++ b/engine/shaderc/src/test/test_shaderc.cpp
@@ -516,6 +516,36 @@ TEST(Shaderc, TestMetal)
     free(data);
 }
 
+TEST(Shaderc, GlslEsPrecisionOptions)
+{
+    uint32_t data_size;
+    void* data = ReadFile("./build/src/test/data/reflection.spv", &data_size);
+    ASSERT_NE((void*) 0, data);
+
+    dmShaderc::HShaderContext shader_ctx = dmShaderc::NewShaderContext(dmShaderc::SHADER_STAGE_FRAGMENT, data, data_size);
+    dmShaderc::HShaderCompiler compiler = dmShaderc::NewShaderCompiler(shader_ctx, dmShaderc::SHADER_LANGUAGE_GLSL);
+
+    dmShaderc::ShaderCompilerOptions options;
+    options.m_Version                     = 100;
+    options.m_GlslEs                      = 1;
+    options.m_EntryPoint                  = "main";
+    options.m_GlslEsDefaultFloatPrecision = dmShaderc::SHADER_PRECISION_HIGHP;
+    options.m_GlslEsDefaultIntPrecision   = dmShaderc::SHADER_PRECISION_MEDIUMP;
+
+    dmShaderc::ShaderCompileResult* dst = dmShaderc::Compile(shader_ctx, compiler, options);
+    ASSERT_NE((void*) 0, dst);
+    ASSERT_NE((void*) 0, dst->m_Data.Begin());
+
+    const char* src = (const char*) dst->m_Data.Begin();
+    ASSERT_NE((const char*) 0, FindFirstOccurance(src, "precision highp float;"));
+    ASSERT_NE((const char*) 0, FindFirstOccurance(src, "precision mediump int;"));
+
+    dmShaderc::FreeShaderCompileResult(dst);
+    dmShaderc::DeleteShaderCompiler(compiler);
+    dmShaderc::DeleteShaderContext(shader_ctx);
+    free(data);
+}
+
 TEST(Shaderc, HLSLMergeRootSignatures)
 {
 #if !defined(DM_BINARY_HLSL_SUPPORTED)


### PR DESCRIPTION
Two new game.project options have been added that controls how the default type precision for floats and ints are generated for GLSL ES shaders:

```yaml
shader.glsl_es_default_precision_float = highp | mediump
shader.glsl_es_default_precision_int = highp | mediump
```

These will affect how the global type qualifiers are generated in the cross-compiled shaders:

```glsl
#version 300 es
precision highp float;
precision mediump int;
```

Fixes #6519