### PR TITLE
Shut down the engine gracefully when creating a model component with model and rig are excluded

### DIFF
--- a/engine/gamesys/src/gamesys/resources/res_model_null.cpp
+++ b/engine/gamesys/src/gamesys/resources/res_model_null.cpp
@@ -18,21 +18,21 @@ namespace dmGameSystem
 {
     dmResource::Result ResModelPreload(const dmResource::ResourcePreloadParams* params)
     {
-        return dmResource::RESULT_OK;
+        return dmResource::RESULT_NOT_SUPPORTED;
     }
 
     dmResource::Result ResModelCreate(const dmResource::ResourceCreateParams* params)
     {
-        return dmResource::RESULT_OK;
+        return dmResource::RESULT_NOT_SUPPORTED;
     }
 
     dmResource::Result ResModelDestroy(const dmResource::ResourceDestroyParams* params)
     {
-        return dmResource::RESULT_OK;
+        return dmResource::RESULT_NOT_SUPPORTED;
     }
 
     dmResource::Result ResModelRecreate(const dmResource::ResourceRecreateParams* params)
     {
-        return dmResource::RESULT_OK;
+        return dmResource::RESULT_NOT_SUPPORTED;
     }
 }


### PR DESCRIPTION
This fixes a crash when trying to create a model component with model and rig excluded using an app manifest. The engine will now shut down gracefully and the log will show that the operation is not supported:

```
WARNING:RESOURCE: Unable to create resource: /_generated_90739376.modelc: NOT_SUPPORTED
WARNING:RESOURCE: Unable to create resource: /_generated_1f27f107.goc: NOT_SUPPORTED
ERROR:GAMEOBJECT: Could not instantiate game object from prototype /_generated_1f27f107.goc.
WARNING:RESOURCE: Unable to create resource: /main/game/game.collectionc: FORMAT_ERROR
```

## Technical changes

`res_model_null.cpp` will now return dmResource::NOT_SUPPORTED instead of dmResource::RESULT_OK.

Fixes #11845 
