### PR TITLE
Fix build error source links for embedded resources

### DIFF
--- a/editor/src/clj/editor/build_errors_view.clj
+++ b/editor/src/clj/editor/build_errors_view.clj
@@ -43,9 +43,8 @@
   (conj PersistentQueue/EMPTY item))
 
 (defn- openable-resource [evaluation-context node-id]
-  (let [basis (:basis evaluation-context)
-        owner-resource-node-id (resource-node/owner-resource-node-id basis node-id)]
-    (when (g/node-instance? basis resource/ResourceNode owner-resource-node-id)
+  (let [basis (:basis evaluation-context)]
+    (when-let [owner-resource-node-id (resource-node/owner-resource-node-id basis node-id)]
       (when-some [resource (g/node-value owner-resource-node-id :resource evaluation-context)]
         (when (resource/openable-resource? resource)
           {:node-id owner-resource-node-id

--- a/editor/src/clj/editor/build_errors_view.clj
+++ b/editor/src/clj/editor/build_errors_view.clj
@@ -25,6 +25,7 @@
             [editor.outline :as outline]
             [editor.resource :as resource]
             [editor.resource-io :as resource-io]
+            [editor.resource-node :as resource-node]
             [editor.ui :as ui]
             [editor.workspace :as workspace]
             [util.coll :as coll]
@@ -42,10 +43,13 @@
   (conj PersistentQueue/EMPTY item))
 
 (defn- openable-resource [evaluation-context node-id]
-  (when (g/node-instance? (:basis evaluation-context) resource/ResourceNode node-id)
-    (when-some [resource (g/node-value node-id :resource evaluation-context)]
-      (when (resource/openable-resource? resource)
-        resource))))
+  (let [basis (:basis evaluation-context)
+        owner-resource-node-id (resource-node/owner-resource-node-id basis node-id)]
+    (when (g/node-instance? basis resource/ResourceNode owner-resource-node-id)
+      (when-some [resource (g/node-value owner-resource-node-id :resource evaluation-context)]
+        (when (resource/openable-resource? resource)
+          {:node-id owner-resource-node-id
+           :resource resource})))))
 
 (defn- node-id-at-override-depth [override-depth node-id]
   (if (and (some? node-id) (pos? override-depth))
@@ -57,9 +61,7 @@
         (let [basis (:basis evaluation-context)]
           (when (or (nil? origin-override-id)
                     (not= origin-override-id (g/override-id basis node-id)))
-            (when-some [resource (openable-resource evaluation-context node-id)]
-              {:node-id (or (g/override-original basis node-id) node-id)
-               :resource resource}))))
+            (openable-resource evaluation-context node-id))))
       (when-some [remaining-errors (next errors)]
         (recur evaluation-context remaining-errors origin-override-depth origin-override-id))))
 

--- a/editor/test/integration/build_errors_test.clj
+++ b/editor/test/integration/build_errors_test.clj
@@ -124,6 +124,22 @@
           "/main/main.collection" ["file_not_found"]
           (partial add-game-object-from-file! workspace main-collection)))
 
+      (testing "Build errors from embedded collection proxies link to the owning resource"
+        (with-open [_ (make-restore-point!)]
+          (let [collection-proxy-resource-type (workspace/get-resource-type workspace "collectionproxy")
+                embedded-component (test-util/add-embedded-component! game-object collection-proxy-resource-type)
+                embedded-resource-node (test-util/to-component-resource-node-id embedded-component)]
+            (test-util/prop! embedded-resource-node :collection (resource "/errors/missing.collection"))
+            (let [old-artifact-map (workspace/artifact-map workspace)
+                  build-results (build/build-project! project main-collection old-artifact-map nil (g/make-evaluation-context))
+                  error-value (:error build-results)]
+              (if (is (some? error-value))
+                (let [error-tree (build-errors-view/build-resource-tree error-value)
+                      error-item-of-parent-resource (first (:children error-tree))]
+                  (is (= [(resource "/main/main.collection") (resource-node "/main/main.collection")]
+                         (error-item-open-info-without-opts error-item-of-parent-resource))))
+                (workspace/artifact-map! workspace (:artifact-map build-results)))))))
+
       (testing "Errors from the same source are not duplicated"
         (with-open [_ (make-restore-point!)]
           (doseq [path ["/errors/button_break_self.gui"


### PR DESCRIPTION
Build errors coming from embedded resources now consistently open the owning file instead of ending up with an unknown or missing source. 

Fix https://github.com/defold/defold/issues/11697

### Technical Changes

The build errors view now resolves the owner resource through `owner-resource-node-id` before building the error tree, instead of assuming the failing node is itself a top-level ResourceNode. I also added an integration test covering an embedded collection proxy with a missing collection reference to verify the parent error item links to /main/main.collection.