### PR TITLE
Add check for ES2/WebGL1 shaders that highp is supported in shaders

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/ShaderCompilePipelineTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/ShaderCompilePipelineTest.java
@@ -550,4 +550,49 @@ public class ShaderCompilePipelineTest {
 
         ShaderCompilePipeline.destroyShaderPipeline(pipelineFragmentLegacy);
     }
+
+    @Test
+    public void testLegacyPipelineGlesSm100HighpPrecisionWorkaround() throws Exception {
+        String fsShaderLegacy =
+                """
+                varying vec4 frag_color;
+                void main() {
+                    gl_FragColor = frag_color;
+                }
+                """;
+
+        ShaderCompilePipeline.ShaderModuleDesc fsDescLegacy = new ShaderCompilePipeline.ShaderModuleDesc();
+        fsDescLegacy.source = fsShaderLegacy;
+        fsDescLegacy.type = ShaderDesc.ShaderType.SHADER_TYPE_FRAGMENT;
+
+        ShaderCompilePipeline.Options options = new ShaderCompilePipeline.Options();
+        options.glslEsDefaultFloatPrecision = Shaderc.ShaderPrecision.SHADER_PRECISION_HIGHP;
+        options.glslEsDefaultIntPrecision = Shaderc.ShaderPrecision.SHADER_PRECISION_HIGHP;
+
+        ShaderCompilePipelineLegacy pipelineFragmentLegacy = new ShaderCompilePipelineLegacy("testLegacyPrecisionWorkaround");
+        ShaderCompilePipeline.createShaderPipeline(pipelineFragmentLegacy, fsDescLegacy, options);
+
+        Shaderc.ShaderCompileResult compileResult = pipelineFragmentLegacy.crossCompile(
+                ShaderDesc.ShaderType.SHADER_TYPE_FRAGMENT,
+                ShaderDesc.Language.LANGUAGE_GLES_SM100);
+        String src = new String(compileResult.data);
+
+        String expectedFloatHighpPrecision =
+                "#ifdef GL_FRAGMENT_PRECISION_HIGH\n" +
+                "    precision highp float;\n" +
+                "#else\n" +
+                "    precision mediump float;\n" +
+                "#endif";
+        String expectedIntHighpPrecision =
+                "#ifdef GL_FRAGMENT_PRECISION_HIGH\n" +
+                "    precision highp int;\n" +
+                "#else\n" +
+                "    precision mediump int;\n" +
+                "#endif";
+
+        assertTrue(src.contains(expectedFloatHighpPrecision));
+        assertTrue(src.contains(expectedIntHighpPrecision));
+
+        ShaderCompilePipeline.destroyShaderPipeline(pipelineFragmentLegacy);
+    }
 }

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/ShaderProgramBuilderTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/ShaderProgramBuilderTest.java
@@ -565,7 +565,11 @@ public class ShaderProgramBuilderTest extends AbstractProtoBuilderTest {
         expected =  "#extension GL_OES_standard_derivatives : enable\n" +
                     "\n" +
                     "precision mediump float;\n" +
-                    "precision highp int;\n" +
+                    "#ifdef GL_FRAGMENT_PRECISION_HIGH\n" +
+                    "    precision highp int;\n" +
+                    "#else\n" +
+                    "    precision mediump int;\n" +
+                    "#endif\n" +
                     "#line 1\n" +
                     "void main() {\n" +
                     "    gl_FragColor = vec4(1.0);\n" +
@@ -664,7 +668,11 @@ public class ShaderProgramBuilderTest extends AbstractProtoBuilderTest {
         String expectedEs100 =
             "#extension GL_OES_standard_derivatives : enable\n" +
             "\n" +
-            "precision highp float;\n" +
+            "#ifdef GL_FRAGMENT_PRECISION_HIGH\n" +
+            "    precision highp float;\n" +
+            "#else\n" +
+            "    precision mediump float;\n" +
+            "#endif\n" +
             "precision mediump int;\n" +
             "#line 1\n" +
             "void main() {\n" +
@@ -979,6 +987,7 @@ public class ShaderProgramBuilderTest extends AbstractProtoBuilderTest {
         String src = new String(result.data);
         assertTrue(src.contains("precision mediump float;"));
         assertTrue(src.contains("precision mediump int;"));
+        assertFalse(src.contains("GL_FRAGMENT_PRECISION_HIGH"));
 
         // Test highp
         opts.glslEsDefaultFloatPrecision = Shaderc.ShaderPrecision.SHADER_PRECISION_HIGHP;
@@ -989,6 +998,7 @@ public class ShaderProgramBuilderTest extends AbstractProtoBuilderTest {
         assertNotNull(result.data);
 
         src = new String(result.data);
+        assertTrue(src.contains("#ifdef GL_FRAGMENT_PRECISION_HIGH"));
         assertTrue(src.contains("precision highp float;"));
         assertTrue(src.contains("precision highp int;"));
 

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/ShaderProgramBuilderTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/ShaderProgramBuilderTest.java
@@ -985,9 +985,10 @@ public class ShaderProgramBuilderTest extends AbstractProtoBuilderTest {
         assertNotNull(result.data);
 
         String src = new String(result.data);
-        assertTrue(src.contains("precision mediump float;"));
-        assertTrue(src.contains("precision mediump int;"));
-        assertFalse(src.contains("GL_FRAGMENT_PRECISION_HIGH"));
+        String expectedMediumpPrecision =
+                "precision mediump float;\n" +
+                "precision mediump int;";
+        assertTrue(src.contains(expectedMediumpPrecision));
 
         // Test highp
         opts.glslEsDefaultFloatPrecision = Shaderc.ShaderPrecision.SHADER_PRECISION_HIGHP;
@@ -998,9 +999,20 @@ public class ShaderProgramBuilderTest extends AbstractProtoBuilderTest {
         assertNotNull(result.data);
 
         src = new String(result.data);
-        assertTrue(src.contains("#ifdef GL_FRAGMENT_PRECISION_HIGH"));
-        assertTrue(src.contains("precision highp float;"));
-        assertTrue(src.contains("precision highp int;"));
+        String expectedFloatHighpPrecision =
+                "#ifdef GL_FRAGMENT_PRECISION_HIGH\n" +
+                "    precision highp float;\n" +
+                "#else\n" +
+                "    precision mediump float;\n" +
+                "#endif";
+        String expectedIntHighpPrecision =
+                "#ifdef GL_FRAGMENT_PRECISION_HIGH\n" +
+                "    precision highp int;\n" +
+                "#else\n" +
+                "    precision mediump int;\n" +
+                "#endif";
+        assertTrue(src.contains(expectedFloatHighpPrecision));
+        assertTrue(src.contains(expectedIntHighpPrecision));
 
         ShadercJni.DeleteShaderContext(ctx);
     }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderUtil.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderUtil.java
@@ -107,6 +107,21 @@ public class ShaderUtil {
             return rewriter.getText();
         }
 
+        private static void writeGlesSM100PrecisionDirective(PrintWriter writer, ShaderDesc.ShaderType shaderType, Shaderc.ShaderPrecision defaultPrecision, String typeKeyword) {
+            String prec = defaultPrecision == Shaderc.ShaderPrecision.SHADER_PRECISION_HIGHP ? "highp" : "mediump";
+
+            // GLSL ES 2.0 might not support highp/mediump precision for fragment shaders, so we need to guard for that.
+            if (shaderType == ShaderDesc.ShaderType.SHADER_TYPE_FRAGMENT && defaultPrecision == Shaderc.ShaderPrecision.SHADER_PRECISION_HIGHP) {
+                writer.println("#ifdef GL_FRAGMENT_PRECISION_HIGH");
+                writer.println("    precision highp " + typeKeyword + ";");
+                writer.println("#else");
+                writer.println("    precision mediump " + typeKeyword + ";");
+                writer.println("#endif");
+            } else {
+                writer.println("precision " + prec + " " + typeKeyword + ";");
+            }
+        }
+
         public static String compileGLSL(String shaderSource, ShaderDesc.ShaderType shaderType, ShaderDesc.Language shaderLanguage,
                                          boolean isDebug, boolean useLatestFeatures, boolean splitTextureSamplers,
                                          Shaderc.ShaderPrecision defaultFloatPrecision, Shaderc.ShaderPrecision defaultIntPrecision) throws CompileExceptionError {
@@ -162,11 +177,8 @@ public class ShaderUtil {
 
                 // Write our directives.
                 if (shaderLanguage == ShaderDesc.Language.LANGUAGE_GLES_SM100) {
-                    // Normally, the ES2ToES3Converter would do this
-                    String floatPrec = defaultFloatPrecision == Shaderc.ShaderPrecision.SHADER_PRECISION_HIGHP ? "highp" : "mediump";
-                    writer.println("precision " + floatPrec + " float;");
-                    String intPrec = defaultIntPrecision == Shaderc.ShaderPrecision.SHADER_PRECISION_HIGHP ? "highp" : "mediump";
-                    writer.println("precision " + intPrec + " int;");
+                    writeGlesSM100PrecisionDirective(writer, shaderType, defaultFloatPrecision, "float");
+                    writeGlesSM100PrecisionDirective(writer, shaderType, defaultIntPrecision, "int");
                 }
 
                 if (!gles) {

--- a/engine/shaderc/src/shaderc_spvc.cpp
+++ b/engine/shaderc/src/shaderc_spvc.cpp
@@ -14,10 +14,10 @@
 
 #include <stdlib.h>
 #include <string.h>
-
 #include <spirv/spirv_cross_c.h>
 
 #include <dmsdk/dlib/log.h>
+#include <dmsdk/dlib/dstrings.h>
 
 #include "shaderc_private.h"
 
@@ -514,6 +514,65 @@ namespace dmShaderc
     }
     #undef MAX_BINDINGS
 
+    template <typename T>
+    static void EnsureSize(dmArray<T>& array, uint32_t size)
+    {
+        if (array.Capacity() < size) {
+            array.OffsetCapacity(size - array.Capacity());
+        }
+        array.SetSize(size);
+    }
+
+    static bool ReplaceString(const char *src, const char* search_str, const char *replacement, dmArray<char>* result_buf)
+    {
+        const char* found = strstr(src, search_str);
+        if (!found)
+        {
+            return false;
+        }
+
+        const char *line_end = found + strlen(search_str);
+        while (*line_end != '\n' && *line_end != '\0')
+        {
+            line_end++;
+        }
+
+        uint32_t prefix_len      = found - src;
+        uint32_t replacement_len = strlen(replacement);
+        uint32_t suffix_len      = strlen(line_end);
+        uint32_t total           = prefix_len + replacement_len + suffix_len + 1;
+
+        EnsureSize(*result_buf, total);
+
+        char* dst = result_buf->Begin();
+        memcpy(dst, src, prefix_len);
+        memcpy(dst + prefix_len, replacement, replacement_len);
+        memcpy(dst + prefix_len + replacement_len, line_end, suffix_len);
+        dst[total - 1] = '\0';
+
+        return true;
+    }
+
+    static bool ApplyHighpWorkaround(const char* src, dmArray<char>* result_buf, bool is_float_type)
+    {
+        const char* type_str = is_float_type ? "float" : "int";
+
+        char precision_buf[32] = {};
+        dmSnPrintf(precision_buf, sizeof(precision_buf), "precision highp %s;", type_str);
+
+        const char* replace_template =
+            "#ifdef GL_FRAGMENT_PRECISION_HIGH\n"
+            "    precision highp %s;\n"
+            "#else\n"
+            "    precision mediump %s;\n"
+            "#endif";
+
+        char replace_buf[256] = {};
+        dmSnPrintf(replace_buf, sizeof(replace_buf), replace_template, type_str, type_str);
+
+        return ReplaceString(src, precision_buf, replace_buf, result_buf);
+    }
+
     ShaderCompileResult* CompileSPVC(HShaderContext context, ShaderCompilerSPVC* compiler, const ShaderCompilerOptions& options)
     {
         spvc_compiler_options spv_options = NULL;
@@ -618,16 +677,46 @@ namespace dmShaderc
             compile_result_size = strlen(compile_result);
         }
 
+        const char* final_compile_result = compile_result;
+        uint32_t final_compile_result_size = compile_result_size;
+
+        dmArray<char> transform_buffer;
+
+        // highp qualifier might not be supported on ES2, so we need to apply a workaround.
+        if (compile_result && options.m_GlslEs && options.m_Version == 100 && context->m_Stage == SHADER_STAGE_FRAGMENT)
+        {
+            EnsureSize(transform_buffer, compile_result_size);
+            memcpy(transform_buffer.Begin(), compile_result, compile_result_size);
+
+            dmArray<char> tmp_buffer;
+
+            if (options.m_GlslEsDefaultFloatPrecision == SHADER_PRECISION_HIGHP &&
+                ApplyHighpWorkaround(transform_buffer.Begin(), &tmp_buffer, true))
+            {
+                EnsureSize(transform_buffer, tmp_buffer.Size());
+                memcpy(transform_buffer.Begin(), tmp_buffer.Begin(), tmp_buffer.Size());
+            }
+            if (options.m_GlslEsDefaultIntPrecision == SHADER_PRECISION_HIGHP &&
+                ApplyHighpWorkaround(transform_buffer.Begin(), &tmp_buffer, false))
+            {
+                EnsureSize(transform_buffer, tmp_buffer.Size());
+                memcpy(transform_buffer.Begin(), tmp_buffer.Begin(), tmp_buffer.Size());
+            }
+
+            final_compile_result = transform_buffer.Begin();
+            final_compile_result_size = transform_buffer.Size();
+        }
+
         ShaderCompileResult* result = (ShaderCompileResult*) malloc(sizeof(ShaderCompileResult));
         memset(result, 0, sizeof(ShaderCompileResult));
-        result->m_Data.SetCapacity(compile_result_size);
-        result->m_Data.SetSize(compile_result_size);
+        result->m_Data.SetCapacity(final_compile_result_size);
+        result->m_Data.SetSize(final_compile_result_size);
         result->m_LastError = "";
         result->m_HLSLNumWorkGroupsId = hlsl_num_workgroups_id_binding;
 
-        if (compile_result)
+        if (final_compile_result)
         {
-            memcpy(result->m_Data.Begin(), compile_result, result->m_Data.Size());
+            memcpy(result->m_Data.Begin(), final_compile_result, result->m_Data.Size());
         }
         else
         {

--- a/engine/shaderc/src/shaderc_spvc.cpp
+++ b/engine/shaderc/src/shaderc_spvc.cpp
@@ -685,9 +685,11 @@ namespace dmShaderc
         // highp qualifier might not be supported on ES2, so we need to apply a workaround.
         if (compile_result && options.m_GlslEs && options.m_Version == 100 && context->m_Stage == SHADER_STAGE_FRAGMENT)
         {
-            EnsureSize(transform_buffer, compile_result_size);
+            EnsureSize(transform_buffer, compile_result_size + 1);
             memcpy(transform_buffer.Begin(), compile_result, compile_result_size);
+            transform_buffer.Begin()[compile_result_size] = '\0';
 
+            uint32_t transform_content_size = compile_result_size;
             dmArray<char> tmp_buffer;
 
             if (options.m_GlslEsDefaultFloatPrecision == SHADER_PRECISION_HIGHP &&
@@ -695,16 +697,18 @@ namespace dmShaderc
             {
                 EnsureSize(transform_buffer, tmp_buffer.Size());
                 memcpy(transform_buffer.Begin(), tmp_buffer.Begin(), tmp_buffer.Size());
+                transform_content_size = tmp_buffer.Size() - 1;
             }
             if (options.m_GlslEsDefaultIntPrecision == SHADER_PRECISION_HIGHP &&
                 ApplyHighpWorkaround(transform_buffer.Begin(), &tmp_buffer, false))
             {
                 EnsureSize(transform_buffer, tmp_buffer.Size());
                 memcpy(transform_buffer.Begin(), tmp_buffer.Begin(), tmp_buffer.Size());
+                transform_content_size = tmp_buffer.Size() - 1;
             }
 
             final_compile_result = transform_buffer.Begin();
-            final_compile_result_size = transform_buffer.Size();
+            final_compile_result_size = transform_content_size;
         }
 
         ShaderCompileResult* result = (ShaderCompileResult*) malloc(sizeof(ShaderCompileResult));

--- a/engine/shaderc/src/test/test_shaderc.cpp
+++ b/engine/shaderc/src/test/test_shaderc.cpp
@@ -529,6 +529,8 @@ TEST(Shaderc, GlslEsPrecisionOptions)
     options.m_Version                     = 100;
     options.m_GlslEs                      = 1;
     options.m_EntryPoint                  = "main";
+
+    // Case 1: highp float, mediump int
     options.m_GlslEsDefaultFloatPrecision = dmShaderc::SHADER_PRECISION_HIGHP;
     options.m_GlslEsDefaultIntPrecision   = dmShaderc::SHADER_PRECISION_MEDIUMP;
 
@@ -537,8 +539,36 @@ TEST(Shaderc, GlslEsPrecisionOptions)
     ASSERT_NE((void*) 0, dst->m_Data.Begin());
 
     const char* src = (const char*) dst->m_Data.Begin();
-    ASSERT_NE((const char*) 0, FindFirstOccurance(src, "precision highp float;"));
+    const char* float_highp_block =
+        "#ifdef GL_FRAGMENT_PRECISION_HIGH\n"
+        "    precision highp float;\n"
+        "#else\n"
+        "    precision mediump float;\n"
+        "#endif";
+
+    ASSERT_NE((const char*) 0, FindFirstOccurance(src, float_highp_block));
     ASSERT_NE((const char*) 0, FindFirstOccurance(src, "precision mediump int;"));
+
+    dmShaderc::FreeShaderCompileResult(dst);
+
+    // Case 2: mediump float, highp int
+    options.m_GlslEsDefaultFloatPrecision = dmShaderc::SHADER_PRECISION_MEDIUMP;
+    options.m_GlslEsDefaultIntPrecision   = dmShaderc::SHADER_PRECISION_HIGHP;
+
+    dst = dmShaderc::Compile(shader_ctx, compiler, options);
+    ASSERT_NE((void*) 0, dst);
+    ASSERT_NE((void*) 0, dst->m_Data.Begin());
+
+    src = (const char*) dst->m_Data.Begin();
+    const char* int_highp_block =
+        "#ifdef GL_FRAGMENT_PRECISION_HIGH\n"
+        "    precision highp int;\n"
+        "#else\n"
+        "    precision mediump int;\n"
+        "#endif";
+
+    ASSERT_NE((const char*) 0, FindFirstOccurance(src, "precision mediump float;"));
+    ASSERT_NE((const char*) 0, FindFirstOccurance(src, int_highp_block));
 
     dmShaderc::FreeShaderCompileResult(dst);
     dmShaderc::DeleteShaderCompiler(compiler);


### PR DESCRIPTION
ES2/WebGL1 shaders that have specified highp as the default precision qualifier might not work on all devices since `highp` for fragment shaders is not guaranteed to work on ES2.

To fix this, the shader build pipeline now patches the cross-compiled ES2 shaders with the following snippet:

```glsl
#version 100 es

// If highp is specified as the default precision for floats:
#ifdef GL_FRAGMENT_PRECISION_HIGH
    precision highp float;
#else
    precision mediump float;
#endif

// If highp is specified as the default precision for ints:
#ifdef GL_FRAGMENT_PRECISION_HIGH
    precision highp int;
#else
    precision mediump int;
#endif
```

Fixes #10552 