### PR TITLE
Added support to choose Vulkan api version from game.project 

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
@@ -316,6 +316,14 @@ opengl_core_profile_hint.type = bool
 opengl_core_profile_hint.help = Set the 'core' OpenGL profile hint when creating the context. The core profile removes all deprecated features from OpenGL, such as immediate mode rendering. Does not apply to OpenGL ES.
 opengl_core_profile_hint.default = 1
 
+vulkan_version_major.type = integer
+vulkan_version_major.help = Vulkan context major version hint. Only applies when using the Vulkan graphics backend.
+vulkan_version_major.default = 1
+
+vulkan_version_minor.type = integer
+vulkan_version_minor.help = Vulkan context minor version hint. Only applies when using the Vulkan graphics backend.
+vulkan_version_minor.default = 1
+
 memory_size.type = integer
 memory_size.help = how much memory is the driver allowed to use (MB)
 memory_size.default = 512

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
@@ -322,7 +322,7 @@ vulkan_version_major.default = 1
 
 vulkan_version_minor.type = integer
 vulkan_version_minor.help = Vulkan context minor version hint. Only applies when using the Vulkan graphics backend.
-vulkan_version_minor.default = 1
+vulkan_version_minor.default = 0
 
 memory_size.type = integer
 memory_size.help = how much memory is the driver allowed to use (MB)

--- a/editor/resources/localization/en.editor_localization
+++ b/editor/resources/localization/en.editor_localization
@@ -1899,6 +1899,10 @@ form.label.project.graphics.opengl_version_hint = OpenGL Version Hint
 form.help.project.graphics.opengl_version_hint = OpenGL context version hint. If a specific version is selected, this will be used as the minimum version required (does not apply to OpenGL ES). Defaults to OpenGL 3.3
 form.label.project.graphics.opengl_core_profile_hint = OpenGL Core Profile Hint
 form.help.project.graphics.opengl_core_profile_hint = Set the 'core' OpenGL profile hint when creating the context. The core profile removes deprecated OpenGL features such as immediate mode rendering. Does not apply to OpenGL ES.
+form.label.project.graphics.vulkan_version_major = Vulkan Version Major
+form.help.project.graphics.vulkan_version_major = Vulkan context major version hint. Only applies when using the Vulkan graphics backend.
+form.label.project.graphics.vulkan_version_minor = Vulkan Version Minor
+form.help.project.graphics.vulkan_version_minor = Vulkan context minor version hint. Only applies when using the Vulkan graphics backend.
 form.label.project.graphics.memory_size = Memory Size
 form.help.project.graphics.memory_size = How much memory the driver is allowed to use (MB)
 

--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -1111,7 +1111,7 @@ namespace dmEngine
         if (window_params.m_GraphicsApi == WINDOW_GRAPHICS_API_VULKAN)
         {
             graphics_context_params.m_GraphicsApiVersionMajorHint = dmConfigFile::GetInt(engine->m_Config, "graphics.vulkan_version_major", 1);
-            graphics_context_params.m_GraphicsApiVersionMinorHint = dmConfigFile::GetInt(engine->m_Config, "graphics.vulkan_version_minor", 1);
+            graphics_context_params.m_GraphicsApiVersionMinorHint = dmConfigFile::GetInt(engine->m_Config, "graphics.vulkan_version_minor", 0);
         }
 
         engine->m_GraphicsContext = dmGraphics::NewContext(graphics_context_params);

--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -1108,6 +1108,12 @@ namespace dmEngine
         graphics_context_params.m_JobContext              = engine->m_JobThreadContext;
         graphics_context_params.m_SwapInterval            = swap_interval;
 
+        if (window_params.m_GraphicsApi == WINDOW_GRAPHICS_API_VULKAN)
+        {
+            graphics_context_params.m_GraphicsApiVersionMajorHint = dmConfigFile::GetInt(engine->m_Config, "graphics.vulkan_version_major", 1);
+            graphics_context_params.m_GraphicsApiVersionMinorHint = dmConfigFile::GetInt(engine->m_Config, "graphics.vulkan_version_minor", 1);
+        }
+
         engine->m_GraphicsContext = dmGraphics::NewContext(graphics_context_params);
         if (engine->m_GraphicsContext == 0x0)
         {

--- a/engine/graphics/src/dmsdk/graphics/graphics.h
+++ b/engine/graphics/src/dmsdk/graphics/graphics.h
@@ -1569,6 +1569,8 @@ namespace dmGraphics
      * @member m_Height [type:uint32_t] Initial height of the rendering surface
      * @member m_GraphicsMemorySize [type:uint32_t] Maximum allowed graphics memory in bytes (0 for default/unlimited) (Switch)
      * @member m_SwapInterval [type:uint32_t] Vertical synchronization interval (1 for 60Hz, 2 for 30Hz, etc.) (Default = 1)
+     * @member m_GraphicsApiVersionMajorHint [type:uint16_t] Requested graphics API major version hint. A value of 0 lets the platform use its default.
+     * @member m_GraphicsApiVersionMinorHint [type:uint16_t] Requested graphics API minor version hint.
      * @member m_VerifyGraphicsCalls [type:bool] Enable API call verification for debugging
      * @member m_PrintDeviceInfo [type:bool] Print graphics device information at startup
      * @member m_UseValidationLayers [type:bool] Enable validation layers for debugging (Vulkan/DirectX 12 only)
@@ -1585,6 +1587,8 @@ namespace dmGraphics
         uint32_t              m_Height;
         uint32_t              m_GraphicsMemorySize;
         uint32_t              m_SwapInterval;
+        uint16_t              m_GraphicsApiVersionMajorHint;
+        uint16_t              m_GraphicsApiVersionMinorHint;
         uint8_t               m_VerifyGraphicsCalls : 1;
         uint8_t               m_PrintDeviceInfo : 1;
         uint8_t               m_UseValidationLayers : 1;

--- a/engine/graphics/src/graphics.cpp
+++ b/engine/graphics/src/graphics.cpp
@@ -305,6 +305,8 @@ namespace dmGraphics
     , m_Height(0)
     , m_GraphicsMemorySize(0)
     , m_SwapInterval(1)
+    , m_GraphicsApiVersionMajorHint(0)
+    , m_GraphicsApiVersionMinorHint(0)
     , m_VerifyGraphicsCalls(0)
     , m_PrintDeviceInfo(0)
     , m_UseValidationLayers(0)

--- a/engine/graphics/src/vulkan/graphics_vulkan.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan.cpp
@@ -1408,13 +1408,13 @@ bail:
         {
             dmAtomicStore32(&context->m_DeleteContextRequested, 1);
 
+            // context->m_MainRenderTarget is part of this
             for (uint32_t i = 0; i < DM_MAX_FRAMES_IN_FLIGHT; ++i)
             {
                 FlushResourcesToDestroy(context, context->m_MainResourcesToDestroy[i]);
                 delete context->m_MainResourcesToDestroy[i];
             }
 
-            DeleteRenderTarget(_context, context->m_MainRenderTarget);
             DeleteTexture(_context, context->m_CurrentSwapchainTexture);
 
             if (context->m_Instance != VK_NULL_HANDLE)

--- a/engine/graphics/src/vulkan/graphics_vulkan.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan.cpp
@@ -109,6 +109,47 @@ namespace dmGraphics
     }
     #undef DM_VK_RESULT_TO_STR_CASE
 
+    static const char* VkPhysicalDeviceTypeToStr(VkPhysicalDeviceType device_type)
+    {
+        switch (device_type)
+        {
+            case VK_PHYSICAL_DEVICE_TYPE_OTHER:          return "other";
+            case VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU: return "integrated_gpu";
+            case VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU:   return "discrete_gpu";
+            case VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU:    return "virtual_gpu";
+            case VK_PHYSICAL_DEVICE_TYPE_CPU:            return "cpu";
+            default:                                     return "unknown";
+        }
+    }
+
+    static const char* VkVendorIdToStr(uint32_t vendor_id)
+    {
+        switch (vendor_id)
+        {
+            case 0x1002: return "AMD";
+            case 0x1010: return "Imagination Technologies";
+            case 0x10DE: return "NVIDIA";
+            case 0x13B5: return "ARM";
+            case 0x5143: return "Qualcomm";
+            case 0x8086: return "Intel";
+            default:     return "Unknown";
+        }
+    }
+
+    static void VulkanPrintDeviceInfo(HContext _context)
+    {
+        VulkanContext* context = (VulkanContext*) _context;
+        const VkPhysicalDeviceProperties& properties = context->m_PhysicalDevice.m_Properties;
+
+        dmLogInfo("Device: Vulkan %u.%u.%u  %s",
+            VK_VERSION_MAJOR(properties.apiVersion),
+            VK_VERSION_MINOR(properties.apiVersion),
+            VK_VERSION_PATCH(properties.apiVersion),
+            properties.deviceName);
+        dmLogInfo("Device ID: 0x%04x  Type: %s", properties.deviceID, VkPhysicalDeviceTypeToStr(properties.deviceType));
+        dmLogInfo("Vendor: %s (0x%04x) driver version: 0x%08x", VkVendorIdToStr(properties.vendorID), properties.vendorID, properties.driverVersion);
+    }
+
     VulkanContext::VulkanContext(const ContextParams& params, const VkInstance vk_instance)
     {
         memset(this, 0, sizeof(*this));
@@ -117,6 +158,7 @@ namespace dmGraphics
         m_DefaultTextureMinFilter = params.m_DefaultTextureMinFilter;
         m_DefaultTextureMagFilter = params.m_DefaultTextureMagFilter;
         m_VerifyGraphicsCalls     = params.m_VerifyGraphicsCalls;
+        m_PrintDeviceInfo         = params.m_PrintDeviceInfo;
         m_UseValidationLayers     = params.m_UseValidationLayers;
         m_Window                  = params.m_Window;
         m_Width                   = params.m_Width;
@@ -1162,6 +1204,11 @@ namespace dmGraphics
 
         context->m_PhysicalDevice = *selected_device;
 
+        if (context->m_PrintDeviceInfo)
+        {
+            VulkanPrintDeviceInfo(context);
+        }
+
         SetupSupportedTextureFormats(context);
 
     #if defined(__MACH__)
@@ -1356,6 +1403,12 @@ bail:
         {
             dmAtomicStore32(&context->m_DeleteContextRequested, 1);
 
+            for (uint32_t i = 0; i < DM_MAX_FRAMES_IN_FLIGHT; ++i)
+            {
+                FlushResourcesToDestroy(context, context->m_MainResourcesToDestroy[i]);
+                delete context->m_MainResourcesToDestroy[i];
+            }
+
             DeleteRenderTarget(_context, context->m_MainRenderTarget);
             DeleteTexture(_context, context->m_CurrentSwapchainTexture);
 
@@ -1371,12 +1424,6 @@ bail:
             }
 
             ResetSetTextureAsyncState(context->m_SetTextureAsyncState);
-
-            for (uint32_t i = 0; i < DM_MAX_FRAMES_IN_FLIGHT; ++i)
-            {
-                FlushResourcesToDestroy(context, context->m_MainResourcesToDestroy[i]);
-                delete context->m_MainResourcesToDestroy[i];
-            }
 
             delete context;
             g_VulkanContext = 0x0;

--- a/engine/graphics/src/vulkan/graphics_vulkan.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan.cpp
@@ -1341,8 +1341,10 @@ bail:
         extensionNameCount         = 1;
     #endif
 
+        uint32_t vk_api_version = VK_MAKE_API_VERSION(0, 1, 0, 0);
+
         VkInstance inst;
-        VkResult res = CreateInstance(&inst, extensionNames, extensionNameCount, 0, 0, 0, 0);
+        VkResult res = CreateInstance(&inst, vk_api_version, extensionNames, extensionNameCount, 0, 0, 0, 0);
 
         if (res == VK_SUCCESS)
         {
@@ -1372,8 +1374,11 @@ bail:
             uint16_t validation_layers_ext_count;
             const char** validation_layers_ext = GetValidationLayersExt(&validation_layers_ext_count);
 
+            uint32_t vk_api_version = VK_MAKE_API_VERSION(0, params.m_GraphicsApiVersionMajorHint, params.m_GraphicsApiVersionMinorHint, 0);
+
             VkInstance vk_instance;
             if (CreateInstance(&vk_instance,
+                                vk_api_version,
                                 extension_names, extension_names_count,
                                 validation_layers, validation_layers_count,
                                 validation_layers_ext, validation_layers_ext_count) != VK_SUCCESS)

--- a/engine/graphics/src/vulkan/graphics_vulkan_context.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan_context.cpp
@@ -183,6 +183,7 @@ namespace dmGraphics
     }
 
     VkResult CreateInstance(VkInstance* vkInstanceOut,
+                            uint32_t api_version,
                             const char** extensionNames, uint16_t extensionNameCount,
                             const char** validationLayers, uint16_t validationLayerCount,
                             const char** validationLayerExtensions, uint16_t validationLayerExtensionCount)
@@ -194,9 +195,9 @@ namespace dmGraphics
         vk_application_info.sType              = VK_STRUCTURE_TYPE_APPLICATION_INFO;
         vk_application_info.pApplicationName   = "Defold";
         vk_application_info.pEngineName        = "Defold Engine";
-        vk_application_info.applicationVersion = VK_MAKE_VERSION(1, 0, 0);
-        vk_application_info.engineVersion      = VK_MAKE_VERSION(1, 0, 0);
-        vk_application_info.apiVersion         = VK_API_VERSION_1_0;
+        vk_application_info.applicationVersion = api_version;
+        vk_application_info.engineVersion      = api_version;
+        vk_application_info.apiVersion         = api_version;
 
         vk_required_extensions.SetCapacity(extensionNameCount + validationLayerExtensionCount);
 

--- a/engine/graphics/src/vulkan/graphics_vulkan_private.h
+++ b/engine/graphics/src/vulkan/graphics_vulkan_private.h
@@ -460,6 +460,7 @@ namespace dmGraphics
         uint32_t                        m_CurrentFrameInFlight : 1;
         uint32_t                        m_NumFramesInFlight    : 2;
         uint32_t                        m_VerifyGraphicsCalls  : 1;
+        uint32_t                        m_PrintDeviceInfo      : 1;
         uint32_t                        m_ViewportChanged      : 1;
         uint32_t                        m_CullFaceChanged      : 1;
         uint32_t                        m_UseValidationLayers  : 1;

--- a/engine/graphics/src/vulkan/graphics_vulkan_private.h
+++ b/engine/graphics/src/vulkan/graphics_vulkan_private.h
@@ -472,6 +472,7 @@ namespace dmGraphics
 
     // Implemented in graphics_vulkan_context.cpp
     VkResult CreateInstance(VkInstance* vkInstanceOut,
+        uint32_t api_version,
         // Extension names, e.g. "VK_KHR_SURFACE_EXTENSION_NAME"
         const char** extensionNames, uint16_t extensionNameCount,
         // Validation Layer Names, i.e "VK_LAYER_LUNARG_standard_validation"


### PR DESCRIPTION
This feature allows you to configure a specific Vulkan api version.
Game.project now has two settings:
* `graphics.vulkan_version_major` (default =1)
* `graphics.vulkan_version_minor` (default = 0)

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
