### PR TITLE
Cache the viewport rectangle to avoid potential performance issues on the HTML5 platform

### DIFF
--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -559,6 +559,10 @@ static void LogFrameBufferError(GLenum status)
         m_GLHandlesData.m_FreeIndexes.SetCapacity(256);
 
         // Default scissor to cover the entire viewport
+        m_ViewportRect[0] = 0;
+        m_ViewportRect[1] = 0;
+        m_ViewportRect[2] = (int32_t) m_Width;
+        m_ViewportRect[3] = (int32_t) m_Height;
         m_ScissorRect[0] = 0;
         m_ScissorRect[1] = 0;
         m_ScissorRect[2] = (int32_t) m_Width;
@@ -1203,11 +1207,23 @@ static void LogFrameBufferError(GLenum status)
             glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, tex_handle, 0);
             if (glCheckFramebufferStatus(GL_FRAMEBUFFER) == GL_FRAMEBUFFER_COMPLETE)
             {
-                GLint vp[4];
-                glGetIntegerv( GL_VIEWPORT, vp );
+                GLint vp[4] = {
+                    context->m_ViewportRect[0],
+                    context->m_ViewportRect[1],
+                    context->m_ViewportRect[2],
+                    context->m_ViewportRect[3]
+                };
+                context->m_ViewportRect[0] = 0;
+                context->m_ViewportRect[1] = 0;
+                context->m_ViewportRect[2] = tcp.m_Width;
+                context->m_ViewportRect[3] = tcp.m_Height;
                 glViewport(0, 0, tcp.m_Width, tcp.m_Height);
                 CHECK_GL_ERROR;
                 glReadPixels(0, 0, tcp.m_Width, tcp.m_Height, GL_RGBA, GL_UNSIGNED_BYTE, gpu_data);
+                context->m_ViewportRect[0] = vp[0];
+                context->m_ViewportRect[1] = vp[1];
+                context->m_ViewportRect[2] = vp[2];
+                context->m_ViewportRect[3] = vp[3];
                 glViewport(vp[0], vp[1], vp[2], vp[3]);
                 CHECK_GL_ERROR;
             }
@@ -3891,6 +3907,10 @@ static void LogFrameBufferError(GLenum status)
         OpenGLContext* context = (OpenGLContext*) _context;
         assert(context);
 
+        context->m_ViewportRect[0] = x;
+        context->m_ViewportRect[1] = y;
+        context->m_ViewportRect[2] = width;
+        context->m_ViewportRect[3] = height;
         glViewport(x, y, width, height);
         CHECK_GL_ERROR;
     }
@@ -5500,9 +5520,10 @@ static void LogFrameBufferError(GLenum status)
     static void OpenGLGetViewport(HContext _context, int32_t* x, int32_t* y, uint32_t* width, uint32_t* height)
     {
         OpenGLContext* context = (OpenGLContext*) _context;
-        GLint vp[4];
-        glGetIntegerv(GL_VIEWPORT, vp);
-        *x = vp[0], *y = vp[1], *width = vp[2], *height = vp[3];
+        *x = context->m_ViewportRect[0];
+        *y = context->m_ViewportRect[1];
+        *width = context->m_ViewportRect[2];
+        *height = context->m_ViewportRect[3];
     }
 
     GLenum TEXTURE_UNIT_NAMES[32] =

--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -3907,12 +3907,12 @@ static void LogFrameBufferError(GLenum status)
         OpenGLContext* context = (OpenGLContext*) _context;
         assert(context);
 
+        glViewport(x, y, width, height);
+        CHECK_GL_ERROR;
         context->m_ViewportRect[0] = x;
         context->m_ViewportRect[1] = y;
         context->m_ViewportRect[2] = width;
         context->m_ViewportRect[3] = height;
-        glViewport(x, y, width, height);
-        CHECK_GL_ERROR;
     }
 
     static void OpenGLSetConstantV4(HContext _context, const Vector4* data, int count, HUniformLocation base_location)

--- a/engine/graphics/src/opengl/graphics_opengl_private.h
+++ b/engine/graphics/src/opengl/graphics_opengl_private.h
@@ -190,6 +190,7 @@ namespace dmGraphics
 
         PipelineState           m_PipelineState;      // Last applied pipeline state
         PipelineState           m_PipelineStateDirty; // Current dirty state
+        int32_t                 m_ViewportRect[4];
         int32_t                 m_ScissorRect[4];
         int32_t                 m_ScissorRectDirty[4];
         HOpenglID               m_GlobalVAO;

--- a/engine/render/src/render/font/font_renderer.cpp
+++ b/engine/render/src/render/font/font_renderer.cpp
@@ -318,7 +318,6 @@ namespace dmRender
 
         if (font_map->m_Texture)
         {
-            DM_PROFILE("FontRenderBatch_GetTextureSize");
             dmGraphics::HContext graphics_context = dmRender::GetGraphicsContext(render_context);
             float cache_width  = (float) dmGraphics::GetTextureWidth(graphics_context, font_map->m_Texture);
             float cache_height = (float) dmGraphics::GetTextureHeight(graphics_context, font_map->m_Texture);
@@ -353,20 +352,14 @@ namespace dmRender
 
         Vector4 texture_size_recip(im_recip, ih_recip, cache_cell_width_ratio, cache_cell_height_ratio);
 
-        {
-            DM_PROFILE("FontRenderBatch_Constants");
-            dmRender::ClearNamedConstantBuffer(constants_buffer);
-            dmRender::SetNamedConstants(constants_buffer, (HConstant*)first_te.m_RenderConstants, first_te.m_NumRenderConstants);
-            dmRender::SetNamedConstant(constants_buffer, g_TextureSizeRecipHash, &texture_size_recip, 1);
-        }
+        dmRender::ClearNamedConstantBuffer(constants_buffer);
+        dmRender::SetNamedConstants(constants_buffer, (HConstant*)first_te.m_RenderConstants, first_te.m_NumRenderConstants);
+        dmRender::SetNamedConstant(constants_buffer, g_TextureSizeRecipHash, &texture_size_recip, 1);
 
         ro->m_ConstantBuffer = constants_buffer;
 
         // The cache size may have changed, and we need to update the font map glyph texture
-        {
-            DM_PROFILE("FontRenderBatch_UpdateCacheTexture");
-            UpdateCacheTexture(font_map);
-        }
+        UpdateCacheTexture(font_map);
 
         bool calc_sdf_scale = font_map->m_IsSdf;
         Matrix4 sdf_view_proj;
@@ -379,10 +372,7 @@ namespace dmRender
             int32_t vp_y = 0;
             uint32_t vp_w = 0;
             uint32_t vp_h = 0;
-            {
-                DM_PROFILE("FontRenderBatch_GetViewport");
-                dmGraphics::GetViewport(gc, &vp_x, &vp_y, &vp_w, &vp_h);
-            }
+            dmGraphics::GetViewport(gc, &vp_x, &vp_y, &vp_w, &vp_h);
             (void)vp_x;
             (void)vp_y;
 
@@ -398,29 +388,23 @@ namespace dmRender
             }
         }
 
+        for (uint32_t *i = begin;i != end; ++i)
         {
-            DM_PROFILE("FontRenderBatch_CreateVertices");
-            for (uint32_t *i = begin;i != end; ++i)
-            {
-                const TextEntry& te = *(TextEntry*) buf[*i].m_UserData;
-                const char* text = &text_context.m_TextBuffer[te.m_StringOffset];
+            const TextEntry& te = *(TextEntry*) buf[*i].m_UserData;
+            const char* text = &text_context.m_TextBuffer[te.m_StringOffset];
 
-                float sdf_scale = 0.0f;
-                if (calc_sdf_scale)
-                {
-                    sdf_scale = CalcSdfScale(sdf_view_proj, sdf_half_w, sdf_half_h, te.m_Transform);
-                }
-                uint32_t num_vertices = CreateFontVertexData(text_context.m_FontRenderBackend, font_map, text_context.m_Frame, text, te, sdf_scale, im_recip, ih_recip, vertices + text_context.m_VertexIndex * vertex_stride, text_context.m_MaxVertexCount - text_context.m_VertexIndex);
-                text_context.m_VertexIndex += num_vertices;
+            float sdf_scale = 0.0f;
+            if (calc_sdf_scale)
+            {
+                sdf_scale = CalcSdfScale(sdf_view_proj, sdf_half_w, sdf_half_h, te.m_Transform);
             }
+            uint32_t num_vertices = CreateFontVertexData(text_context.m_FontRenderBackend, font_map, text_context.m_Frame, text, te, sdf_scale, im_recip, ih_recip, vertices + text_context.m_VertexIndex * vertex_stride, text_context.m_MaxVertexCount - text_context.m_VertexIndex);
+            text_context.m_VertexIndex += num_vertices;
         }
 
         ro->m_VertexCount = text_context.m_VertexIndex - ro->m_VertexStart;
 
-        {
-            DM_PROFILE("FontRenderBatch_AddToRender");
-            dmRender::AddToRender(render_context, ro);
-        }
+        dmRender::AddToRender(render_context, ro);
     }
 
     static void FontRenderListDispatch(dmRender::RenderListDispatchParams const &params)

--- a/engine/render/src/render/font/font_renderer.cpp
+++ b/engine/render/src/render/font/font_renderer.cpp
@@ -318,6 +318,7 @@ namespace dmRender
 
         if (font_map->m_Texture)
         {
+            DM_PROFILE("FontRenderBatch_GetTextureSize");
             dmGraphics::HContext graphics_context = dmRender::GetGraphicsContext(render_context);
             float cache_width  = (float) dmGraphics::GetTextureWidth(graphics_context, font_map->m_Texture);
             float cache_height = (float) dmGraphics::GetTextureHeight(graphics_context, font_map->m_Texture);
@@ -352,14 +353,20 @@ namespace dmRender
 
         Vector4 texture_size_recip(im_recip, ih_recip, cache_cell_width_ratio, cache_cell_height_ratio);
 
-        dmRender::ClearNamedConstantBuffer(constants_buffer);
-        dmRender::SetNamedConstants(constants_buffer, (HConstant*)first_te.m_RenderConstants, first_te.m_NumRenderConstants);
-        dmRender::SetNamedConstant(constants_buffer, g_TextureSizeRecipHash, &texture_size_recip, 1);
+        {
+            DM_PROFILE("FontRenderBatch_Constants");
+            dmRender::ClearNamedConstantBuffer(constants_buffer);
+            dmRender::SetNamedConstants(constants_buffer, (HConstant*)first_te.m_RenderConstants, first_te.m_NumRenderConstants);
+            dmRender::SetNamedConstant(constants_buffer, g_TextureSizeRecipHash, &texture_size_recip, 1);
+        }
 
         ro->m_ConstantBuffer = constants_buffer;
 
         // The cache size may have changed, and we need to update the font map glyph texture
-        UpdateCacheTexture(font_map);
+        {
+            DM_PROFILE("FontRenderBatch_UpdateCacheTexture");
+            UpdateCacheTexture(font_map);
+        }
 
         bool calc_sdf_scale = font_map->m_IsSdf;
         Matrix4 sdf_view_proj;
@@ -372,7 +379,10 @@ namespace dmRender
             int32_t vp_y = 0;
             uint32_t vp_w = 0;
             uint32_t vp_h = 0;
-            dmGraphics::GetViewport(gc, &vp_x, &vp_y, &vp_w, &vp_h);
+            {
+                DM_PROFILE("FontRenderBatch_GetViewport");
+                dmGraphics::GetViewport(gc, &vp_x, &vp_y, &vp_w, &vp_h);
+            }
             (void)vp_x;
             (void)vp_y;
 
@@ -388,23 +398,29 @@ namespace dmRender
             }
         }
 
-        for (uint32_t *i = begin;i != end; ++i)
         {
-            const TextEntry& te = *(TextEntry*) buf[*i].m_UserData;
-            const char* text = &text_context.m_TextBuffer[te.m_StringOffset];
-
-            float sdf_scale = 0.0f;
-            if (calc_sdf_scale)
+            DM_PROFILE("FontRenderBatch_CreateVertices");
+            for (uint32_t *i = begin;i != end; ++i)
             {
-                sdf_scale = CalcSdfScale(sdf_view_proj, sdf_half_w, sdf_half_h, te.m_Transform);
+                const TextEntry& te = *(TextEntry*) buf[*i].m_UserData;
+                const char* text = &text_context.m_TextBuffer[te.m_StringOffset];
+
+                float sdf_scale = 0.0f;
+                if (calc_sdf_scale)
+                {
+                    sdf_scale = CalcSdfScale(sdf_view_proj, sdf_half_w, sdf_half_h, te.m_Transform);
+                }
+                uint32_t num_vertices = CreateFontVertexData(text_context.m_FontRenderBackend, font_map, text_context.m_Frame, text, te, sdf_scale, im_recip, ih_recip, vertices + text_context.m_VertexIndex * vertex_stride, text_context.m_MaxVertexCount - text_context.m_VertexIndex);
+                text_context.m_VertexIndex += num_vertices;
             }
-            uint32_t num_vertices = CreateFontVertexData(text_context.m_FontRenderBackend, font_map, text_context.m_Frame, text, te, sdf_scale, im_recip, ih_recip, vertices + text_context.m_VertexIndex * vertex_stride, text_context.m_MaxVertexCount - text_context.m_VertexIndex);
-            text_context.m_VertexIndex += num_vertices;
         }
 
         ro->m_VertexCount = text_context.m_VertexIndex - ro->m_VertexStart;
 
-        dmRender::AddToRender(render_context, ro);
+        {
+            DM_PROFILE("FontRenderBatch_AddToRender");
+            dmRender::AddToRender(render_context, ro);
+        }
     }
 
     static void FontRenderListDispatch(dmRender::RenderListDispatchParams const &params)


### PR DESCRIPTION
Cache the viewport rectangle to avoid unnecessary OpenGL calls. In some cases, it may be the cause of performance issues.

Fix https://github.com/defold/defold/issues/12052