### PR TITLE
Cleanup of Vulkan shutdown procedure

### DIFF
--- a/engine/graphics/src/vulkan/graphics_native.cpp
+++ b/engine/graphics/src/vulkan/graphics_native.cpp
@@ -141,7 +141,6 @@ namespace dmGraphics
                 free(context->m_DynamicOffsetBuffer);
             }
 
-            DestroyTexture(vk_device, &context->m_SwapChain->m_ResolveTexture->m_Handle);
             delete context->m_SwapChain;
         }
     }

--- a/engine/graphics/src/vulkan/graphics_vulkan.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan.cpp
@@ -1192,6 +1192,12 @@ namespace dmGraphics
         VkSampleCountFlagBits vk_closest_multisample_flag;
 
         void* device_pNext_chain = 0;
+        VkPhysicalDevicePresentIdFeaturesKHR present_id_feature_support = {};
+        VkPhysicalDevicePresentWaitFeaturesKHR present_wait_feature_support = {};
+        VkPhysicalDevicePresentIdFeaturesKHR device_present_id_features = {};
+        VkPhysicalDevicePresentWaitFeaturesKHR device_present_wait_features = {};
+        VkPhysicalDeviceFeatures2 present_features = {};
+        bool supports_present_wait_extensions = false;
 
         uint16_t validation_layers_count;
         const char** validation_layers = GetValidationLayers(&validation_layers_count, context->m_UseValidationLayers);
@@ -1211,7 +1217,41 @@ namespace dmGraphics
 
         SetupSupportedTextureFormats(context);
 
-    #if defined(__MACH__)
+        present_id_feature_support.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRESENT_ID_FEATURES_KHR;
+        present_wait_feature_support.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRESENT_WAIT_FEATURES_KHR;
+        present_id_feature_support.pNext = &present_wait_feature_support;
+
+        supports_present_wait_extensions =
+            VulkanIsExtensionSupported((HContext) context, VK_KHR_PRESENT_ID_EXTENSION_NAME) &&
+            VulkanIsExtensionSupported((HContext) context, VK_KHR_PRESENT_WAIT_EXTENSION_NAME);
+
+        if (supports_present_wait_extensions)
+        {
+            present_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
+            present_features.pNext = &present_id_feature_support;
+            vkGetPhysicalDeviceFeatures2(context->m_PhysicalDevice.m_Device, &present_features);
+        }
+
+        if (supports_present_wait_extensions &&
+            present_id_feature_support.presentId &&
+            present_wait_feature_support.presentWait)
+        {
+            device_extensions.OffsetCapacity(2);
+            device_extensions.Push(VK_KHR_PRESENT_ID_EXTENSION_NAME);
+            device_extensions.Push(VK_KHR_PRESENT_WAIT_EXTENSION_NAME);
+
+            device_present_wait_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRESENT_WAIT_FEATURES_KHR;
+            device_present_wait_features.pNext = device_pNext_chain;
+            device_present_wait_features.presentWait = VK_TRUE;
+
+            device_present_id_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRESENT_ID_FEATURES_KHR;
+            device_present_id_features.pNext = &device_present_wait_features;
+            device_present_id_features.presentId = VK_TRUE;
+
+            device_pNext_chain = &device_present_id_features;
+        }
+
+#if defined(__MACH__)
         // Check for optional extensions so that we can enable them if they exist
         if (VulkanIsExtensionSupported((HContext) context, VK_IMG_FORMAT_PVRTC_EXTENSION_NAME))
         {
@@ -1224,20 +1264,20 @@ namespace dmGraphics
             device_extensions.OffsetCapacity(1);
             device_extensions.Push(VK_EXT_METAL_OBJECTS_EXTENSION_NAME);
         }
+#endif
 
-        #ifdef DM_VULKAN_VALIDATION
+#if defined(__MACH__) && defined(DM_VULKAN_VALIDATION)
         if (context->m_UseValidationLayers)
         {
             device_extensions.OffsetCapacity(1);
             device_extensions.Push("VK_KHR_portability_subset");
         }
-        #endif
-    #endif
+#endif
 
         if (VulkanIsExtensionSupported((HContext) context, VK_EXT_FRAGMENT_SHADER_INTERLOCK_EXTENSION_NAME))
         {
             context->m_FragmentShaderInterlockFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADER_INTERLOCK_FEATURES_EXT;
-            context->m_FragmentShaderInterlockFeatures.pNext = NULL;
+            context->m_FragmentShaderInterlockFeatures.pNext = device_pNext_chain;
 
             device_extensions.OffsetCapacity(1);
             device_extensions.Push(VK_EXT_FRAGMENT_SHADER_INTERLOCK_EXTENSION_NAME);
@@ -1254,12 +1294,13 @@ namespace dmGraphics
         }
 
         context->m_LogicalDevice    = logical_device;
+        context->m_WaitForPresent   = (PFN_vkWaitForPresentKHR) vkGetDeviceProcAddr(logical_device.m_Device, "vkWaitForPresentKHR");
         vk_closest_multisample_flag = GetClosestSampleCountFlag(selected_device, BUFFER_TYPE_COLOR0_BIT | BUFFER_TYPE_DEPTH_BIT, dmPlatform::GetWindowStateParam(context->m_Window, WINDOW_STATE_SAMPLE_COUNT));
 
         // Create swap chain
         InitializeVulkanTexture(&context->m_ResolveTexture);
         context->m_SwapChainCapabilities.Swap(selected_swap_chain_capabilities);
-        context->m_SwapChain = new SwapChain(context->m_WindowSurface, vk_closest_multisample_flag, context->m_SwapChainCapabilities, selected_queue_family, &context->m_ResolveTexture);
+        context->m_SwapChain = new SwapChain(context->m_WindowSurface, vk_closest_multisample_flag, context->m_SwapChainCapabilities, selected_queue_family, &context->m_ResolveTexture, context->m_WaitForPresent);
 
         res = UpdateSwapChain(&context->m_PhysicalDevice, &context->m_LogicalDevice, &created_width, &created_height, want_vsync, context->m_SwapChainCapabilities, context->m_SwapChain);
         if (res != VK_SUCCESS)
@@ -1408,27 +1449,43 @@ bail:
         {
             dmAtomicStore32(&context->m_DeleteContextRequested, 1);
 
-            // context->m_MainRenderTarget is part of this
+            {
+                DM_MUTEX_OPTIONAL_SCOPED_LOCK(context->m_AssetHandleContainerMutex);
+
+                RenderTarget* main_render_target = GetAssetFromContainer<RenderTarget>(context->m_AssetHandleContainer, context->m_MainRenderTarget);
+                if (main_render_target)
+                {
+                    context->m_AssetHandleContainer.Release(context->m_MainRenderTarget);
+                    delete main_render_target;
+                    context->m_MainRenderTarget    = 0x0;
+                    context->m_CurrentRenderTarget = 0x0;
+                }
+
+                VulkanTexture* current_swapchain_texture = GetAssetFromContainer<VulkanTexture>(context->m_AssetHandleContainer, context->m_CurrentSwapchainTexture);
+                if (current_swapchain_texture)
+                {
+                    context->m_AssetHandleContainer.Release(context->m_CurrentSwapchainTexture);
+                    delete current_swapchain_texture;
+                    context->m_CurrentSwapchainTexture = 0x0;
+                }
+            }
+
             for (uint32_t i = 0; i < DM_MAX_FRAMES_IN_FLIGHT; ++i)
             {
-                FlushResourcesToDestroy(context, context->m_MainResourcesToDestroy[i]);
                 delete context->m_MainResourcesToDestroy[i];
             }
 
-            DeleteTexture(_context, context->m_CurrentSwapchainTexture);
-
             if (context->m_Instance != VK_NULL_HANDLE)
             {
-                vkDestroyInstance(context->m_Instance, 0);
-                context->m_Instance = VK_NULL_HANDLE;
+                DestroyInstance(&context->m_Instance);
             }
+
+            ResetSetTextureAsyncState(context->m_SetTextureAsyncState);
 
             if (context->m_AssetHandleContainerMutex)
             {
                 dmMutex::Delete(context->m_AssetHandleContainerMutex);
             }
-
-            ResetSetTextureAsyncState(context->m_SetTextureAsyncState);
 
             delete context;
             g_VulkanContext = 0x0;
@@ -1578,6 +1635,17 @@ bail:
         presentInfo.pSwapchains        = &context->m_SwapChain->m_SwapChain;
         presentInfo.pImageIndices      = &swapchainImageIndex;
         presentInfo.pResults           = nullptr;
+
+        VkPresentIdKHR present_id_info = {};
+        uint64_t present_id = 0;
+        if (context->m_WaitForPresent)
+        {
+            present_id = ++context->m_SwapChain->m_LastPresentId;
+            present_id_info.sType = VK_STRUCTURE_TYPE_PRESENT_ID_KHR;
+            present_id_info.swapchainCount = 1;
+            present_id_info.pPresentIds = &present_id;
+            presentInfo.pNext = &present_id_info;
+        }
 
         res = vkQueuePresentKHR(context->m_LogicalDevice.m_PresentQueue, &presentInfo);
         if (res != VK_SUCCESS && res != VK_SUBOPTIMAL_KHR)

--- a/engine/graphics/src/vulkan/graphics_vulkan.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan.cpp
@@ -1619,7 +1619,7 @@ bail:
         uint64_t present_id = 0;
         if (context->m_WaitForPresent)
         {
-            present_id = ++context->m_SwapChain->m_LastPresentId;
+            present_id = context->m_SwapChain->m_LastPresentId + 1;
             present_id_info.sType = VK_STRUCTURE_TYPE_PRESENT_ID_KHR;
             present_id_info.swapchainCount = 1;
             present_id_info.pPresentIds = &present_id;
@@ -1627,6 +1627,11 @@ bail:
         }
 
         res = vkQueuePresentKHR(context->m_LogicalDevice.m_PresentQueue, &presentInfo);
+        if ((res == VK_SUCCESS || res == VK_SUBOPTIMAL_KHR) && present_id != 0)
+        {
+            context->m_SwapChain->m_LastPresentId = present_id;
+        }
+
         if (res != VK_SUCCESS && res != VK_SUBOPTIMAL_KHR)
         {
             CHECK_VK_ERROR(res);

--- a/engine/graphics/src/vulkan/graphics_vulkan.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan.cpp
@@ -1449,27 +1449,6 @@ bail:
         {
             dmAtomicStore32(&context->m_DeleteContextRequested, 1);
 
-            {
-                DM_MUTEX_OPTIONAL_SCOPED_LOCK(context->m_AssetHandleContainerMutex);
-
-                RenderTarget* main_render_target = GetAssetFromContainer<RenderTarget>(context->m_AssetHandleContainer, context->m_MainRenderTarget);
-                if (main_render_target)
-                {
-                    context->m_AssetHandleContainer.Release(context->m_MainRenderTarget);
-                    delete main_render_target;
-                    context->m_MainRenderTarget    = 0x0;
-                    context->m_CurrentRenderTarget = 0x0;
-                }
-
-                VulkanTexture* current_swapchain_texture = GetAssetFromContainer<VulkanTexture>(context->m_AssetHandleContainer, context->m_CurrentSwapchainTexture);
-                if (current_swapchain_texture)
-                {
-                    context->m_AssetHandleContainer.Release(context->m_CurrentSwapchainTexture);
-                    delete current_swapchain_texture;
-                    context->m_CurrentSwapchainTexture = 0x0;
-                }
-            }
-
             for (uint32_t i = 0; i < DM_MAX_FRAMES_IN_FLIGHT; ++i)
             {
                 delete context->m_MainResourcesToDestroy[i];
@@ -4483,6 +4462,18 @@ bail:
 
         FlushFenceResourcesToDestroy(context);
 
+        {
+            DM_MUTEX_OPTIONAL_SCOPED_LOCK(context->m_AssetHandleContainerMutex);
+            RenderTarget* main_render_target = GetAssetFromContainer<RenderTarget>(context->m_AssetHandleContainer, context->m_MainRenderTarget);
+            if (main_render_target)
+            {
+                context->m_AssetHandleContainer.Release(context->m_MainRenderTarget);
+                delete main_render_target;
+                context->m_MainRenderTarget    = 0x0;
+                context->m_CurrentRenderTarget = 0x0;
+            }
+        }
+
         for (size_t i = 0; i < DM_MAX_FRAMES_IN_FLIGHT; i++) {
             FrameResource& frame_resource = context->m_FrameResources[i];
             vkDestroySemaphore(vk_device, frame_resource.m_ImageAvailable, 0);
@@ -4490,6 +4481,18 @@ bail:
         }
 
         DestroySwapChain(vk_device, context->m_SwapChain);
+
+        {
+            DM_MUTEX_OPTIONAL_SCOPED_LOCK(context->m_AssetHandleContainerMutex);
+            VulkanTexture* current_swapchain_texture = GetAssetFromContainer<VulkanTexture>(context->m_AssetHandleContainer, context->m_CurrentSwapchainTexture);
+            if (current_swapchain_texture)
+            {
+                context->m_AssetHandleContainer.Release(context->m_CurrentSwapchainTexture);
+                delete current_swapchain_texture;
+                context->m_CurrentSwapchainTexture = 0x0;
+            }
+        }
+
         DestroyLogicalDevice(&context->m_LogicalDevice);
         DestroyPhysicalDevice(&context->m_PhysicalDevice);
     }

--- a/engine/graphics/src/vulkan/graphics_vulkan_private.h
+++ b/engine/graphics/src/vulkan/graphics_vulkan_private.h
@@ -362,7 +362,8 @@ namespace dmGraphics
             VkSampleCountFlagBits        vk_sample_flag,
             const SwapChainCapabilities& capabilities,
             const QueueFamily            queueFamily,
-            VulkanTexture*               resolveTexture);
+            VulkanTexture*               resolveTexture,
+            PFN_vkWaitForPresentKHR      wait_for_present);
 
         dmArray<VkImage>      m_Images;
         dmArray<VkImageView>  m_ImageViews;
@@ -374,6 +375,8 @@ namespace dmGraphics
         VkSwapchainKHR        m_SwapChain;
         VkExtent2D            m_ImageExtent;
         VkSampleCountFlagBits m_SampleCountFlag;
+        PFN_vkWaitForPresentKHR m_WaitForPresent;
+        uint64_t              m_LastPresentId;
         uint8_t               m_ImageIndex;
 
         VkResult Advance(VkDevice vk_device, VkSemaphore);
@@ -450,6 +453,7 @@ namespace dmGraphics
         VulkanTexture                   m_ResolveTexture;
         uint64_t                        m_TextureFormatSupport;
         int32_atomic_t                  m_DeleteContextRequested;
+        PFN_vkWaitForPresentKHR         m_WaitForPresent;
 
         uint32_t                        m_Width;
         uint32_t                        m_Height;

--- a/engine/graphics/src/vulkan/graphics_vulkan_swap_chain.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan_swap_chain.cpp
@@ -81,14 +81,14 @@ namespace dmGraphics
     {
     }
 
-    static void WaitForLastPresent(const VkDevice vk_device, const SwapChain* swapChain)
+    static void WaitForLastPresent(const VkDevice vk_device, PFN_vkWaitForPresentKHR wait_for_present, VkSwapchainKHR vk_swap_chain, uint64_t last_present_id)
     {
-        if (swapChain->m_WaitForPresent == 0 || swapChain->m_SwapChain == VK_NULL_HANDLE || swapChain->m_LastPresentId == 0)
+        if (wait_for_present == 0 || vk_swap_chain == VK_NULL_HANDLE || last_present_id == 0)
         {
             return;
         }
 
-        VkResult res = swapChain->m_WaitForPresent(vk_device, swapChain->m_SwapChain, swapChain->m_LastPresentId, UINT64_MAX);
+        VkResult res = wait_for_present(vk_device, vk_swap_chain, last_present_id, UINT64_MAX);
         if (res != VK_SUCCESS)
         {
             dmLogWarning("vkWaitForPresentKHR failed while waiting for swapchain present completion: %d", res);
@@ -114,6 +114,7 @@ namespace dmGraphics
         bool wantVSync, SwapChainCapabilities& capabilities, SwapChain* swapChain)
     {
         VkSwapchainKHR vk_old_swap_chain    = swapChain->m_SwapChain;
+        uint64_t old_last_present_id        = swapChain->m_LastPresentId;
         VkDevice vk_device                  = logicalDevice->m_Device;
         VkPhysicalDevice vk_physical_device = physicalDevice->m_Device;
         VkPresentModeKHR vk_present_mode    = VK_PRESENT_MODE_FIFO_KHR;
@@ -238,7 +239,7 @@ namespace dmGraphics
 
         if (vk_old_swap_chain != VK_NULL_HANDLE)
         {
-            WaitForLastPresent(vk_device, swapChain);
+            WaitForLastPresent(vk_device, swapChain->m_WaitForPresent, vk_old_swap_chain, old_last_present_id);
             DestroyVkSwapChain(vk_device, vk_old_swap_chain, swapChain->m_ImageViews);
             for (uint32_t i = 0; i < swapChain->m_RenderFinishedSemaphores.Size(); ++i)
             {
@@ -335,7 +336,7 @@ namespace dmGraphics
     void DestroySwapChain(VkDevice vk_device, SwapChain* swapChain)
     {
         assert(swapChain);
-        WaitForLastPresent(vk_device, swapChain);
+        WaitForLastPresent(vk_device, swapChain->m_WaitForPresent, swapChain->m_SwapChain, swapChain->m_LastPresentId);
         DestroyVkSwapChain(vk_device, swapChain->m_SwapChain, swapChain->m_ImageViews);
         for (uint32_t i = 0; i < swapChain->m_RenderFinishedSemaphores.Size(); ++i)
         {

--- a/engine/graphics/src/vulkan/graphics_vulkan_swap_chain.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan_swap_chain.cpp
@@ -14,6 +14,7 @@
 
 #include <dlib/math.h>
 #include <dlib/array.h>
+#include <dlib/log.h>
 
 #include "graphics_vulkan_defines.h"
 #include "graphics_vulkan_private.h"
@@ -67,14 +68,31 @@ namespace dmGraphics
     }
 
     SwapChain::SwapChain(const VkSurfaceKHR surface, VkSampleCountFlagBits vk_sample_flag,
-        const SwapChainCapabilities& capabilities, const QueueFamily queueFamily, VulkanTexture* resolveTexture)
+        const SwapChainCapabilities& capabilities, const QueueFamily queueFamily, VulkanTexture* resolveTexture,
+        PFN_vkWaitForPresentKHR wait_for_present)
         : m_ResolveTexture(resolveTexture)
         , m_Surface(surface)
         , m_QueueFamily(queueFamily)
         , m_SurfaceFormat(SwapChainFindSurfaceFormat(capabilities))
         , m_SwapChain(VK_NULL_HANDLE)
         , m_SampleCountFlag(vk_sample_flag)
+        , m_WaitForPresent(wait_for_present)
+        , m_LastPresentId(0)
     {
+    }
+
+    static void WaitForLastPresent(const VkDevice vk_device, const SwapChain* swapChain)
+    {
+        if (swapChain->m_WaitForPresent == 0 || swapChain->m_SwapChain == VK_NULL_HANDLE || swapChain->m_LastPresentId == 0)
+        {
+            return;
+        }
+
+        VkResult res = swapChain->m_WaitForPresent(vk_device, swapChain->m_SwapChain, swapChain->m_LastPresentId, UINT64_MAX);
+        if (res != VK_SUCCESS)
+        {
+            dmLogWarning("vkWaitForPresentKHR failed while waiting for swapchain present completion: %d", res);
+        }
     }
 
     VkResult SwapChain::Advance(VkDevice vk_device, VkSemaphore vk_image_available)
@@ -220,6 +238,7 @@ namespace dmGraphics
 
         if (vk_old_swap_chain != VK_NULL_HANDLE)
         {
+            WaitForLastPresent(vk_device, swapChain);
             DestroyVkSwapChain(vk_device, vk_old_swap_chain, swapChain->m_ImageViews);
             for (uint32_t i = 0; i < swapChain->m_RenderFinishedSemaphores.Size(); ++i)
             {
@@ -238,6 +257,7 @@ namespace dmGraphics
 
         swapChain->m_ImageExtent = vk_extent;
         swapChain->m_ImageIndex  = 0;
+        swapChain->m_LastPresentId = 0;
 
         swapChain->m_ImageViews.SetCapacity(swap_chain_image_count);
         swapChain->m_ImageViews.SetSize(swap_chain_image_count);
@@ -315,6 +335,7 @@ namespace dmGraphics
     void DestroySwapChain(VkDevice vk_device, SwapChain* swapChain)
     {
         assert(swapChain);
+        WaitForLastPresent(vk_device, swapChain);
         DestroyVkSwapChain(vk_device, swapChain->m_SwapChain, swapChain->m_ImageViews);
         for (uint32_t i = 0; i < swapChain->m_RenderFinishedSemaphores.Size(); ++i)
         {
@@ -324,6 +345,7 @@ namespace dmGraphics
         DestroyTexture(vk_device, &swapChain->m_ResolveTexture->m_Handle);
 
         swapChain->m_SwapChain = VK_NULL_HANDLE;
+        swapChain->m_LastPresentId = 0;
     }
 
     void GetSwapChainCapabilities(VkPhysicalDevice vk_device, const VkSurfaceKHR surface, SwapChainCapabilities& capabilities)


### PR DESCRIPTION
This fixes an accidental hang upon shutting down the Vulkan context and its resources.

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
