### PR TITLE
Allow the sound system to grow its used memory to increase the sound speed limit and fix possible crashes

### DIFF
--- a/editor/src/clj/editor/sound.clj
+++ b/editor/src/clj/editor/sound.clj
@@ -164,7 +164,7 @@
       speed :speed
       loopcount :loopcount)))
 
-(def prop-sound-speed? (partial validation/prop-outside-range? [0.1 5.0]))
+(def prop-sound-speed? (partial validation/prop-outside-range? [0.0 50.0]))
 
 (g/defnode SoundNode
   (inherits resource-node/ResourceNode)

--- a/engine/gamesys/src/gamesys/scripts/script_sound.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_sound.cpp
@@ -87,7 +87,7 @@ namespace dmGameSystem
     /*# [type:number] sound speed
      *
      * The speed on the sound-component where 1.0 is normal speed, 0.5 is half
-     * speed and 2.0 is double speed.
+     * speed and 2.0 is double speed. Valid range is 0.0 to 50.0.
      *
      * @name speed
      * @property
@@ -439,7 +439,7 @@ namespace dmGameSystem
      * : [type:number] sound pan between -1 and 1, default is 0. The final pan of the sound will be an addition of this pan and the sound pan.
      *
      * `speed`
-     * : [type:number] sound speed where 1.0 is normal speed, 0.5 is half speed and 2.0 is double speed. The final speed of the sound will be a multiplication of this speed and the sound speed.
+     * : [type:number] sound speed where 1.0 is normal speed, 0.5 is half speed and 2.0 is double speed. Valid range is 0.0 to 50.0. The final speed of the sound will be a multiplication of this speed and the sound speed.
 
      * `start_time`
      * : [type:number] start playback offset (seconds). Optional, mutually exclusive with `start_frame`.

--- a/engine/gamesys/src/gamesys/test/sound/set_speed_zero.go
+++ b/engine/gamesys/src/gamesys/test/sound/set_speed_zero.go
@@ -1,0 +1,8 @@
+components {
+  id: "sound"
+  component: "/sound/valid.sound"
+}
+components {
+  id: "script"
+  component: "/sound/set_speed_zero.script"
+}

--- a/engine/gamesys/src/gamesys/test/sound/set_speed_zero.script
+++ b/engine/gamesys/src/gamesys/test/sound/set_speed_zero.script
@@ -1,0 +1,25 @@
+-- Copyright 2020-2026 The Defold Foundation
+-- Copyright 2014-2020 King
+-- Copyright 2009-2014 Ragnar Svensson, Christian Murray
+-- Licensed under the Defold License version 1.0 (the "License"); you may not use
+-- this file except in compliance with the License.
+--
+-- You may obtain a copy of the License, together with FAQs at
+-- https://www.defold.com/license
+--
+-- Unless required by applicable law or agreed to in writing, software distributed
+-- under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+-- CONDITIONS OF ANY KIND, either express or implied. See the License for the
+-- specific language governing permissions and limitations under the License.
+
+tests_done = false
+
+function init(self)
+    assert(go.get("#sound", "speed") == 1.0)
+    go.set("#sound", "speed", 0.0)
+end
+
+function update(self, dt)
+    assert(go.get("#sound", "speed") == 0.0)
+    tests_done = true
+end

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -1222,6 +1222,36 @@ TEST_F(SoundTest, DelayedSoundStoppedBeforePlay)
     dmGameSystem::FinalizeScriptLibs(scriptlibcontext);
 }
 
+TEST_F(SoundTest, LuaSetSpeedToZero)
+{
+    dmGameSystem::ScriptLibContext scriptlibcontext;
+    scriptlibcontext.m_Factory         = m_Factory;
+    scriptlibcontext.m_Register        = m_Register;
+    scriptlibcontext.m_LuaState        = dmScript::GetLuaState(m_ScriptContext);
+    scriptlibcontext.m_GraphicsContext = m_GraphicsContext;
+    scriptlibcontext.m_ScriptContext   = m_ScriptContext;
+    scriptlibcontext.m_JobContext      = m_JobContext;
+
+    dmGameSystem::InitializeScriptLibs(scriptlibcontext);
+
+    const char* go_path = "/sound/set_speed_zero.goc";
+    dmGameObject::HInstance go = Spawn(m_Factory, m_Collection, go_path, dmHashString64("/go"));
+    ASSERT_NE((void*)0, go);
+
+    EXPECT_TRUE(UpdateAndWaitUntilDone(scriptlibcontext, m_Collection, &m_UpdateContext, false, "tests_done"));
+
+    dmGameObject::PropertyDesc property_desc;
+    dmGameObject::PropertyOptions property_opt;
+    ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::GetProperty(go, dmHashString64("sound"), dmHashString64("speed"), property_opt, property_desc));
+    ASSERT_EQ(0.0f, property_desc.m_Variant.m_Number);
+
+    ASSERT_TRUE(dmGameObject::Final(m_Collection));
+
+    DeleteInstance(m_Collection, go);
+
+    dmGameSystem::FinalizeScriptLibs(scriptlibcontext);
+}
+
 
 TEST_P(ResourcePropTest, ResourceRefCounting)
 {

--- a/engine/sound/src/sound.cpp
+++ b/engine/sound/src/sound.cpp
@@ -228,9 +228,6 @@ namespace dmSound
         float*                  m_DecoderOutput[SOUND_MAX_DECODE_CHANNELS];
         uint32_t                m_DecoderBufferFrameCapacity;
         uint32_t                m_DecoderTempOutputCapacity;
-        uint32_t                m_ProfileSoundDataSize;
-        uint32_t                m_ProfileScratchBufferSize;
-        uint32_t                m_ProfileInstanceBufferSize;
 
         void*                   m_OutBuffers[SOUND_OUTBUFFER_MAX_COUNT];
         uint16_t                m_OutBufferCount;
@@ -499,8 +496,6 @@ namespace dmSound
             instance->m_FrameCount = 0;
             instance->m_Speed = 1.0f;
         }
-        sound->m_ProfileInstanceBufferSize = max_instances * initial_instance_frame_capacity * sizeof(float) * SOUND_MAX_DECODE_CHANNELS;
-
         sound->m_SoundData.SetCapacity(max_sound_data);
         sound->m_SoundData.SetSize(max_sound_data);
         sound->m_SoundDataPool.SetCapacity(max_sound_data);
@@ -516,14 +511,12 @@ namespace dmSound
         sound->m_DecoderTempOutput = 0;
         sound->m_DecoderBufferFrameCapacity = 0;
         sound->m_DecoderTempOutputCapacity = 0;
-        sound->m_ProfileSoundDataSize = 0;
-        sound->m_ProfileScratchBufferSize = 0;
 
         DM_PROPERTY_SET_U32(rmtp_InstanceCount, 0);
         DM_PROPERTY_SET_U32(rmtp_SoundDataCount, 0);
-        DM_PROPERTY_SET_U32(rmtp_SoundDataSize, sound->m_ProfileSoundDataSize);
-        DM_PROPERTY_SET_U32(rmtp_ScratchBufferSize, sound->m_ProfileScratchBufferSize);
-        DM_PROPERTY_SET_U32(rmtp_InstanceBufferSize, sound->m_ProfileInstanceBufferSize);
+        DM_PROPERTY_SET_U32(rmtp_SoundDataSize, 0);
+        DM_PROPERTY_SET_U32(rmtp_ScratchBufferSize, 0);
+        DM_PROPERTY_SET_U32(rmtp_InstanceBufferSize, max_instances * initial_instance_frame_capacity * sizeof(float) * SOUND_MAX_DECODE_CHANNELS);
 
         sound->m_UseFloatOutput = device_info.m_UseFloats;
         sound->m_NormalizeFloatOutput = device_info.m_UseNormalized;
@@ -759,8 +752,7 @@ namespace dmSound
             sound->m_DecoderTempOutputCapacity = (uint32_t)required_temp_output_capacity;
         }
 
-        sound->m_ProfileScratchBufferSize = sound->m_DecoderBufferFrameCapacity * sizeof(float) * SOUND_MAX_DECODE_CHANNELS + sound->m_DecoderTempOutputCapacity;
-        DM_PROPERTY_SET_U32(rmtp_ScratchBufferSize, sound->m_ProfileScratchBufferSize);
+        DM_PROPERTY_SET_U32(rmtp_ScratchBufferSize, sound->m_DecoderBufferFrameCapacity * sizeof(float) * SOUND_MAX_DECODE_CHANNELS + sound->m_DecoderTempOutputCapacity);
 
         return RESULT_OK;
     }
@@ -791,8 +783,7 @@ namespace dmSound
             free(instance->m_Frames[c]);
             instance->m_Frames[c] = new_frames[c];
         }
-        g_SoundSystem->m_ProfileInstanceBufferSize += (required_frame_capacity - instance->m_FrameCapacity) * sizeof(float) * SOUND_MAX_DECODE_CHANNELS;
-        DM_PROPERTY_SET_U32(rmtp_InstanceBufferSize, g_SoundSystem->m_ProfileInstanceBufferSize);
+        DM_PROPERTY_ADD_U32(rmtp_InstanceBufferSize, (required_frame_capacity - instance->m_FrameCapacity) * sizeof(float) * SOUND_MAX_DECODE_CHANNELS);
         instance->m_FrameCapacity = required_frame_capacity;
 
         return RESULT_OK;
@@ -813,13 +804,12 @@ namespace dmSound
 
     static Result SetSoundDataNoLock(HSoundData sound_data, const void* sound_buffer, uint32_t sound_buffer_size)
     {
-        g_SoundSystem->m_ProfileSoundDataSize -= sound_data->m_Size;
+        const uint32_t previous_sound_size = sound_data->m_Size;
         free(sound_data->m_Data);
         sound_data->m_Data = malloc(sound_buffer_size);
         sound_data->m_Size = sound_buffer_size;
         memcpy(sound_data->m_Data, sound_buffer, sound_buffer_size);
-        g_SoundSystem->m_ProfileSoundDataSize += sound_data->m_Size;
-        DM_PROPERTY_SET_U32(rmtp_SoundDataSize, g_SoundSystem->m_ProfileSoundDataSize);
+        DM_PROPERTY_ADD_U32(rmtp_SoundDataSize, (int32_t)sound_buffer_size - (int32_t)previous_sound_size);
         return RESULT_OK;
     }
 
@@ -852,8 +842,7 @@ namespace dmSound
         sd->m_DataCallbacks.m_Context = cbk_ctx;
         sd->m_DataCallbacks.m_GetData = cbk;
         sd->m_RefCount = 1;
-        sound->m_ProfileSoundDataSize += sizeof(SoundData);
-        DM_PROPERTY_SET_U32(rmtp_SoundDataSize, sound->m_ProfileSoundDataSize);
+        DM_PROPERTY_ADD_U32(rmtp_SoundDataSize, sizeof(SoundData));
 
         Result result = RESULT_OK;
         if (sound_buffer != 0)
@@ -923,10 +912,9 @@ namespace dmSound
             free((void*) sound_data->m_Data);
 
         SoundSystem* sound = g_SoundSystem;
-        sound->m_ProfileSoundDataSize -= GetSoundResourceSize(sound_data);
+        DM_PROPERTY_ADD_U32(rmtp_SoundDataSize, -((int32_t)sizeof(SoundData) + (int32_t)sound_data->m_Size));
         sound->m_SoundDataPool.Push(sound_data->m_Index);
         DM_PROPERTY_SET_U32(rmtp_SoundDataCount, sound->m_SoundDataPool.Size());
-        DM_PROPERTY_SET_U32(rmtp_SoundDataSize, sound->m_ProfileSoundDataSize);
         sound_data->m_Index = 0xffff;
 
         return RESULT_OK;

--- a/engine/sound/src/sound.cpp
+++ b/engine/sound/src/sound.cpp
@@ -695,59 +695,26 @@ namespace dmSound
         if (!grow_decoder_buffers && !grow_temp_buffer)
             return RESULT_OK;
 
-        float* new_decoder_output[SOUND_MAX_DECODE_CHANNELS];
-        for (uint32_t c = 0; c < SOUND_MAX_DECODE_CHANNELS; ++c)
-        {
-            new_decoder_output[c] = sound->m_DecoderOutput[c];
-        }
-        void* new_decoder_temp_output = sound->m_DecoderTempOutput;
-
         if (grow_decoder_buffers)
         {
             for (uint32_t c = 0; c < SOUND_MAX_DECODE_CHANNELS; ++c)
             {
-                new_decoder_output[c] = (float*)malloc(required_frame_capacity * sizeof(float));
-                if (new_decoder_output[c] == 0)
+                float* new_decoder_output = (float*)realloc(sound->m_DecoderOutput[c], required_frame_capacity * sizeof(float));
+                if (new_decoder_output == 0)
                 {
-                    for (uint32_t j = 0; j < SOUND_MAX_DECODE_CHANNELS; ++j)
-                    {
-                        if (new_decoder_output[j] != sound->m_DecoderOutput[j])
-                            free(new_decoder_output[j]);
-                    }
                     return RESULT_OUT_OF_MEMORY;
                 }
-            }
-        }
-
-        if (grow_temp_buffer)
-        {
-            new_decoder_temp_output = malloc((size_t)required_temp_output_capacity);
-            if (new_decoder_temp_output == 0)
-            {
-                if (grow_decoder_buffers)
-                {
-                    for (uint32_t c = 0; c < SOUND_MAX_DECODE_CHANNELS; ++c)
-                    {
-                        free(new_decoder_output[c]);
-                    }
-                }
-                return RESULT_OUT_OF_MEMORY;
-            }
-        }
-
-        if (grow_decoder_buffers)
-        {
-            for (uint32_t c = 0; c < SOUND_MAX_DECODE_CHANNELS; ++c)
-            {
-                free(sound->m_DecoderOutput[c]);
-                sound->m_DecoderOutput[c] = new_decoder_output[c];
+                sound->m_DecoderOutput[c] = new_decoder_output;
             }
             sound->m_DecoderBufferFrameCapacity = required_frame_capacity;
         }
 
         if (grow_temp_buffer)
         {
-            free(sound->m_DecoderTempOutput);
+            void* new_decoder_temp_output = realloc(sound->m_DecoderTempOutput, (size_t)required_temp_output_capacity);
+            if (new_decoder_temp_output == 0)
+                return RESULT_OUT_OF_MEMORY;
+
             sound->m_DecoderTempOutput = new_decoder_temp_output;
             sound->m_DecoderTempOutputCapacity = (uint32_t)required_temp_output_capacity;
         }
@@ -762,26 +729,13 @@ namespace dmSound
         if (required_frame_capacity <= instance->m_FrameCapacity)
             return RESULT_OK;
 
-        float* new_frames[SOUND_MAX_DECODE_CHANNELS];
         for (uint32_t c = 0; c < SOUND_MAX_DECODE_CHANNELS; ++c)
         {
-            new_frames[c] = (float*)malloc(required_frame_capacity * sizeof(float));
-            if (new_frames[c] == 0)
-            {
-                for (uint32_t j = 0; j < c; ++j)
-                {
-                    free(new_frames[j]);
-                }
+            float* new_frame_buffer = (float*)realloc(instance->m_Frames[c], required_frame_capacity * sizeof(float));
+            if (new_frame_buffer == 0)
                 return RESULT_OUT_OF_MEMORY;
-            }
 
-            memcpy(new_frames[c], instance->m_Frames[c], instance->m_FrameCapacity * sizeof(float));
-        }
-
-        for (uint32_t c = 0; c < SOUND_MAX_DECODE_CHANNELS; ++c)
-        {
-            free(instance->m_Frames[c]);
-            instance->m_Frames[c] = new_frames[c];
+            instance->m_Frames[c] = new_frame_buffer;
         }
         DM_PROPERTY_ADD_U32(rmtp_InstanceBufferSize, (required_frame_capacity - instance->m_FrameCapacity) * sizeof(float) * SOUND_MAX_DECODE_CHANNELS);
         instance->m_FrameCapacity = required_frame_capacity;

--- a/engine/sound/src/sound.cpp
+++ b/engine/sound/src/sound.cpp
@@ -42,6 +42,13 @@ namespace dmSound
 {
     using namespace dmVMath;
 
+    DM_PROPERTY_GROUP(rmtp_SoundSystem, "Sound System", 0);
+    DM_PROPERTY_U32(rmtp_InstanceCount, 0, PROFILE_PROPERTY_NONE, "# sound instances", &rmtp_SoundSystem);
+    DM_PROPERTY_U32(rmtp_SoundDataCount, 0, PROFILE_PROPERTY_NONE, "# sound data", &rmtp_SoundSystem);
+    DM_PROPERTY_U32(rmtp_SoundDataSize, 0, PROFILE_PROPERTY_NONE, "size of sound data in bytes", &rmtp_SoundSystem);
+    DM_PROPERTY_U32(rmtp_ScratchBufferSize, 0, PROFILE_PROPERTY_NONE, "size of decoder scratch buffers in bytes", &rmtp_SoundSystem);
+    DM_PROPERTY_U32(rmtp_InstanceBufferSize, 0, PROFILE_PROPERTY_NONE, "size of instance frame buffers in bytes", &rmtp_SoundSystem);
+
     static void SoundThread(void* ctx);
 
     /**
@@ -155,6 +162,7 @@ namespace dmSound
         dmSoundCodec::HDecoder m_Decoder;
         float*      m_Frames[SOUND_MAX_DECODE_CHANNELS];
         uint32_t    m_FrameCount;
+        uint32_t    m_FrameCapacity;
 
         dmhash_t    m_Group;
 
@@ -218,6 +226,11 @@ namespace dmSound
 
         void*                   m_DecoderTempOutput;
         float*                  m_DecoderOutput[SOUND_MAX_DECODE_CHANNELS];
+        uint32_t                m_DecoderBufferFrameCapacity;
+        uint32_t                m_DecoderTempOutputCapacity;
+        uint32_t                m_ProfileSoundDataSize;
+        uint32_t                m_ProfileScratchBufferSize;
+        uint32_t                m_ProfileInstanceBufferSize;
 
         void*                   m_OutBuffers[SOUND_OUTBUFFER_MAX_COUNT];
         uint16_t                m_OutBufferCount;
@@ -470,6 +483,7 @@ namespace dmSound
         sound->m_Instances.SetCapacity(max_instances);
         sound->m_Instances.SetSize(max_instances);
         sound->m_InstancesPool.SetCapacity(max_instances);
+        const uint32_t initial_instance_frame_capacity = SOUND_MAX_HISTORY + 1 + SOUND_MAX_FUTURE;
         for (uint32_t i = 0; i < max_instances; ++i)
         {
             SoundInstance* instance = &sound->m_Instances[i];
@@ -479,11 +493,13 @@ namespace dmSound
             // memory to keep around history / future sample state
             for (uint32_t c = 0; c < SOUND_MAX_DECODE_CHANNELS; ++c)
             {
-                instance->m_Frames[c] = (float*)malloc(SOUND_INSTANCE_STATEFRAMECOUNT * sizeof(float));
+                instance->m_Frames[c] = (float*)malloc(initial_instance_frame_capacity * sizeof(float));
             }
+            instance->m_FrameCapacity = initial_instance_frame_capacity;
             instance->m_FrameCount = 0;
             instance->m_Speed = 1.0f;
         }
+        sound->m_ProfileInstanceBufferSize = max_instances * initial_instance_frame_capacity * sizeof(float) * SOUND_MAX_DECODE_CHANNELS;
 
         sound->m_SoundData.SetCapacity(max_sound_data);
         sound->m_SoundData.SetSize(max_sound_data);
@@ -495,9 +511,19 @@ namespace dmSound
 
         for (uint32_t i = 0; i < SOUND_MAX_DECODE_CHANNELS; ++i)
         {
-            sound->m_DecoderOutput[i] = (float*)malloc((sound->m_DeviceFrameCount * SOUND_MAX_SPEED + SOUND_MAX_HISTORY + SOUND_MAX_FUTURE) * sizeof(float));;
+            sound->m_DecoderOutput[i] = 0;
         }
-        sound->m_DecoderTempOutput = malloc((sound->m_DeviceFrameCount * SOUND_MAX_SPEED + SOUND_MAX_HISTORY + SOUND_MAX_FUTURE) * sizeof(int16_t) * SOUND_MAX_DECODE_CHANNELS);
+        sound->m_DecoderTempOutput = 0;
+        sound->m_DecoderBufferFrameCapacity = 0;
+        sound->m_DecoderTempOutputCapacity = 0;
+        sound->m_ProfileSoundDataSize = 0;
+        sound->m_ProfileScratchBufferSize = 0;
+
+        DM_PROPERTY_SET_U32(rmtp_InstanceCount, 0);
+        DM_PROPERTY_SET_U32(rmtp_SoundDataCount, 0);
+        DM_PROPERTY_SET_U32(rmtp_SoundDataSize, sound->m_ProfileSoundDataSize);
+        DM_PROPERTY_SET_U32(rmtp_ScratchBufferSize, sound->m_ProfileScratchBufferSize);
+        DM_PROPERTY_SET_U32(rmtp_InstanceBufferSize, sound->m_ProfileInstanceBufferSize);
 
         sound->m_UseFloatOutput = device_info.m_UseFloats;
         sound->m_NormalizeFloatOutput = device_info.m_UseNormalized;
@@ -598,6 +624,12 @@ namespace dmSound
                 sound->m_DeviceType->m_Close(sound->m_Device);
             }
 
+            DM_PROPERTY_SET_U32(rmtp_InstanceCount, 0);
+            DM_PROPERTY_SET_U32(rmtp_SoundDataCount, 0);
+            DM_PROPERTY_SET_U32(rmtp_SoundDataSize, 0);
+            DM_PROPERTY_SET_U32(rmtp_ScratchBufferSize, 0);
+            DM_PROPERTY_SET_U32(rmtp_InstanceBufferSize, 0);
+
             delete sound;
             g_SoundSystem = 0;
         }
@@ -631,13 +663,163 @@ namespace dmSound
         return dmHashReverseSafe64(hash);
     }
 
+    static inline uint64_t GetResampleDelta(const dmSoundCodec::Info& info, uint32_t mix_rate, float speed)
+    {
+        return (uint64_t)(((double)((uint64_t)info.m_Rate << RESAMPLE_FRACTION_BITS) / (double)mix_rate) * (double)speed);
+    }
+
+    static inline uint64_t GetRequiredDecodedFrameCapacity(uint64_t delta, uint32_t output_frame_count)
+    {
+        const uint64_t frac_unit = 1ULL << RESAMPLE_FRACTION_BITS;
+        const uint64_t required_frames = (((uint64_t)output_frame_count * delta) + frac_unit - 1) >> RESAMPLE_FRACTION_BITS;
+        // The mixer includes the current fractional position when computing mixed_instance_frame_count.
+        // That can require one additional decoded frame compared to ceil(output_frames * delta).
+        return required_frames + 1 + SOUND_MAX_HISTORY + SOUND_MAX_FUTURE;
+    }
+
+    static inline uint64_t GetRequiredStateFrameCapacity(uint64_t delta)
+    {
+        const uint64_t frac_unit = 1ULL << RESAMPLE_FRACTION_BITS;
+        return SOUND_MAX_HISTORY + ((delta + frac_unit - 1) >> RESAMPLE_FRACTION_BITS) + SOUND_MAX_FUTURE;
+    }
+
+    static inline uint32_t GetDecoderOutputStrideBytes(const dmSoundCodec::Info& info)
+    {
+        if (info.m_BitsPerSample == 32 && (!info.m_IsInterleaved || info.m_Channels == 1))
+            return (uint32_t)sizeof(float);
+        return (uint32_t)(info.m_Channels * (info.m_BitsPerSample / 8));
+    }
+
+    static Result EnsureDecoderScratchBufferSize(SoundSystem* sound, const dmSoundCodec::Info& info, uint32_t required_frame_capacity)
+    {
+        const uint64_t required_temp_output_capacity = (uint64_t)required_frame_capacity * GetDecoderOutputStrideBytes(info);
+        if (required_temp_output_capacity > 0xffffffffU)
+            return RESULT_OUT_OF_MEMORY;
+
+        const bool grow_decoder_buffers = required_frame_capacity > sound->m_DecoderBufferFrameCapacity;
+        const bool grow_temp_buffer = required_temp_output_capacity > sound->m_DecoderTempOutputCapacity;
+
+        if (!grow_decoder_buffers && !grow_temp_buffer)
+            return RESULT_OK;
+
+        float* new_decoder_output[SOUND_MAX_DECODE_CHANNELS];
+        for (uint32_t c = 0; c < SOUND_MAX_DECODE_CHANNELS; ++c)
+        {
+            new_decoder_output[c] = sound->m_DecoderOutput[c];
+        }
+        void* new_decoder_temp_output = sound->m_DecoderTempOutput;
+
+        if (grow_decoder_buffers)
+        {
+            for (uint32_t c = 0; c < SOUND_MAX_DECODE_CHANNELS; ++c)
+            {
+                new_decoder_output[c] = (float*)malloc(required_frame_capacity * sizeof(float));
+                if (new_decoder_output[c] == 0)
+                {
+                    for (uint32_t j = 0; j < SOUND_MAX_DECODE_CHANNELS; ++j)
+                    {
+                        if (new_decoder_output[j] != sound->m_DecoderOutput[j])
+                            free(new_decoder_output[j]);
+                    }
+                    return RESULT_OUT_OF_MEMORY;
+                }
+            }
+        }
+
+        if (grow_temp_buffer)
+        {
+            new_decoder_temp_output = malloc((size_t)required_temp_output_capacity);
+            if (new_decoder_temp_output == 0)
+            {
+                if (grow_decoder_buffers)
+                {
+                    for (uint32_t c = 0; c < SOUND_MAX_DECODE_CHANNELS; ++c)
+                    {
+                        free(new_decoder_output[c]);
+                    }
+                }
+                return RESULT_OUT_OF_MEMORY;
+            }
+        }
+
+        if (grow_decoder_buffers)
+        {
+            for (uint32_t c = 0; c < SOUND_MAX_DECODE_CHANNELS; ++c)
+            {
+                free(sound->m_DecoderOutput[c]);
+                sound->m_DecoderOutput[c] = new_decoder_output[c];
+            }
+            sound->m_DecoderBufferFrameCapacity = required_frame_capacity;
+        }
+
+        if (grow_temp_buffer)
+        {
+            free(sound->m_DecoderTempOutput);
+            sound->m_DecoderTempOutput = new_decoder_temp_output;
+            sound->m_DecoderTempOutputCapacity = (uint32_t)required_temp_output_capacity;
+        }
+
+        sound->m_ProfileScratchBufferSize = sound->m_DecoderBufferFrameCapacity * sizeof(float) * SOUND_MAX_DECODE_CHANNELS + sound->m_DecoderTempOutputCapacity;
+        DM_PROPERTY_SET_U32(rmtp_ScratchBufferSize, sound->m_ProfileScratchBufferSize);
+
+        return RESULT_OK;
+    }
+
+    static Result EnsureInstanceFrameBufferSize(SoundInstance* instance, uint32_t required_frame_capacity)
+    {
+        if (required_frame_capacity <= instance->m_FrameCapacity)
+            return RESULT_OK;
+
+        float* new_frames[SOUND_MAX_DECODE_CHANNELS];
+        for (uint32_t c = 0; c < SOUND_MAX_DECODE_CHANNELS; ++c)
+        {
+            new_frames[c] = (float*)malloc(required_frame_capacity * sizeof(float));
+            if (new_frames[c] == 0)
+            {
+                for (uint32_t j = 0; j < c; ++j)
+                {
+                    free(new_frames[j]);
+                }
+                return RESULT_OUT_OF_MEMORY;
+            }
+
+            memcpy(new_frames[c], instance->m_Frames[c], instance->m_FrameCapacity * sizeof(float));
+        }
+
+        for (uint32_t c = 0; c < SOUND_MAX_DECODE_CHANNELS; ++c)
+        {
+            free(instance->m_Frames[c]);
+            instance->m_Frames[c] = new_frames[c];
+        }
+        g_SoundSystem->m_ProfileInstanceBufferSize += (required_frame_capacity - instance->m_FrameCapacity) * sizeof(float) * SOUND_MAX_DECODE_CHANNELS;
+        DM_PROPERTY_SET_U32(rmtp_InstanceBufferSize, g_SoundSystem->m_ProfileInstanceBufferSize);
+        instance->m_FrameCapacity = required_frame_capacity;
+
+        return RESULT_OK;
+    }
+
+    static void ResetInstanceMixState(SoundInstance* instance)
+    {
+        instance->m_FrameFraction = 0;
+        instance->m_EndOfStream = 0;
+
+        for (uint32_t c = 0; c < SOUND_MAX_DECODE_CHANNELS; ++c)
+        {
+            memset(instance->m_Frames[c], 0, SOUND_MAX_HISTORY * sizeof(float));
+        }
+        instance->m_FrameCount = SOUND_MAX_HISTORY;
+    }
+
 
     static Result SetSoundDataNoLock(HSoundData sound_data, const void* sound_buffer, uint32_t sound_buffer_size)
     {
+        g_SoundSystem->m_ProfileSoundDataSize -= sound_data->m_Size;
         free(sound_data->m_Data);
         sound_data->m_Data = malloc(sound_buffer_size);
         sound_data->m_Size = sound_buffer_size;
         memcpy(sound_data->m_Data, sound_buffer, sound_buffer_size);
+        g_SoundSystem->m_ProfileSoundDataSize += sound_data->m_Size;
+        DM_PROPERTY_SET_U32(rmtp_SoundDataSize, g_SoundSystem->m_ProfileSoundDataSize);
         return RESULT_OK;
     }
 
@@ -658,6 +840,7 @@ namespace dmSound
             }
 
             index = sound->m_SoundDataPool.Pop();
+            DM_PROPERTY_SET_U32(rmtp_SoundDataCount, sound->m_SoundDataPool.Size());
         }
 
         SoundData* sd = &sound->m_SoundData[index];
@@ -669,6 +852,8 @@ namespace dmSound
         sd->m_DataCallbacks.m_Context = cbk_ctx;
         sd->m_DataCallbacks.m_GetData = cbk;
         sd->m_RefCount = 1;
+        sound->m_ProfileSoundDataSize += sizeof(SoundData);
+        DM_PROPERTY_SET_U32(rmtp_SoundDataSize, sound->m_ProfileSoundDataSize);
 
         Result result = RESULT_OK;
         if (sound_buffer != 0)
@@ -738,7 +923,10 @@ namespace dmSound
             free((void*) sound_data->m_Data);
 
         SoundSystem* sound = g_SoundSystem;
+        sound->m_ProfileSoundDataSize -= GetSoundResourceSize(sound_data);
         sound->m_SoundDataPool.Push(sound_data->m_Index);
+        DM_PROPERTY_SET_U32(rmtp_SoundDataCount, sound->m_SoundDataPool.Size());
+        DM_PROPERTY_SET_U32(rmtp_SoundDataSize, sound->m_ProfileSoundDataSize);
         sound_data->m_Index = 0xffff;
 
         return RESULT_OK;
@@ -816,6 +1004,7 @@ namespace dmSound
             }
 
             index = ss->m_InstancesPool.Pop();
+            DM_PROPERTY_SET_U32(rmtp_InstanceCount, ss->m_InstancesPool.Size());
         }
 
         sound_data->m_RefCount ++;
@@ -846,13 +1035,7 @@ namespace dmSound
         si->m_Playing = 0;
         si->m_Decoder = decoder;
         si->m_Group = MASTER_GROUP_HASH;
-
-        // prep sample history with silence
-        for(uint32_t c=0; c<SOUND_MAX_DECODE_CHANNELS; ++c)
-        {
-            memset(si->m_Frames[c], 0, SOUND_MAX_HISTORY * sizeof(float));
-        }
-        si->m_FrameCount = SOUND_MAX_HISTORY;
+        ResetInstanceMixState(si);
 
         *sound_instance = si;
 
@@ -874,13 +1057,16 @@ namespace dmSound
 
         uint16_t index = sound_instance->m_Index;
         sound->m_InstancesPool.Push(index);
+        DM_PROPERTY_SET_U32(rmtp_InstanceCount, sound->m_InstancesPool.Size());
         sound_instance->m_Index = 0xffff;
         DeleteSoundData(&sound->m_SoundData[sound_instance->m_SoundDataIndex]);
         sound_instance->m_SoundDataIndex = 0xffff;
         dmSoundCodec::DeleteDecoder(sound->m_CodecContext, sound_instance->m_Decoder);
         sound_instance->m_Decoder = 0;
         sound_instance->m_FrameCount = 0;
+        sound_instance->m_FrameFraction = 0;
         sound_instance->m_Speed = 1.0f;
+        sound_instance->m_EndOfStream = 0;
 
         return RESULT_OK;
     }
@@ -1111,6 +1297,7 @@ namespace dmSound
         DM_MUTEX_OPTIONAL_SCOPED_LOCK(g_SoundSystem->m_Mutex);
         sound_instance->m_Playing = 0;
         dmSoundCodec::Reset(sound->m_CodecContext, sound_instance->m_Decoder);
+        ResetInstanceMixState(sound_instance);
     }
 
     Result Stop(HSoundInstance sound_instance)
@@ -1195,12 +1382,7 @@ namespace dmSound
 
     static inline uint32_t GetSkipStrideBytes(const dmSoundCodec::Info& info)
     {
-        // Match stride logic used in mixing when calling Decode/Skip
-        // If decoder delivers float non-interleaved (or mono), use sizeof(float) per frame
-        // Otherwise use interleaved stride: channels * (bits/8)
-        if (info.m_BitsPerSample == 32 && (!info.m_IsInterleaved || info.m_Channels == 1))
-            return (uint32_t)sizeof(float);
-        return (uint32_t)(info.m_Channels * (info.m_BitsPerSample / 8));
+        return GetDecoderOutputStrideBytes(info);
     }
 
     static Result SkipToStartFrameNoLock(HSoundInstance sound_instance, uint64_t start_frame)
@@ -1273,7 +1455,7 @@ namespace dmSound
     {
         // Copy any leftover sample, the last 4 (note: always available in front of the decoder buffer even if nothing new was added) & the next 4 (also always there)...
         instance->m_FrameCount = SOUND_MAX_HISTORY + (avail_framecount - used_framecount) + SOUND_MAX_FUTURE;
-        assert(instance->m_FrameCount <= SOUND_INSTANCE_STATEFRAMECOUNT);
+        assert(instance->m_FrameCount <= instance->m_FrameCapacity);
         uint32_t state_bytes = instance->m_FrameCount * sizeof(float);
         // note: offset can be negative without exceeding allocate memory - we hence need to ensure proper, signed extension to 64-bit on system using 64-bit pointers
         int32_t state_offset = (int32_t)(used_framecount - SOUND_MAX_HISTORY);
@@ -1438,7 +1620,7 @@ namespace dmSound
         bool correct_bit_depth = info.m_BitsPerSample == 32 || info.m_BitsPerSample == 16 || info.m_BitsPerSample == 8;
         bool correct_num_channels = info.m_Channels == 1 || info.m_Channels == 2;
         if (!correct_bit_depth || !correct_num_channels) {
-            dmLogError("Only mono/stereo with 8/16 bits per sample is supported (%s): %u bpp %u ch", GetSoundName(sound, instance), (uint32_t)info.m_BitsPerSample, (uint32_t)info.m_Channels);
+            dmLogError("Only mono/stereo with 8/16/32 bits per sample is supported (%s): %u bpp %u ch", GetSoundName(sound, instance), (uint32_t)info.m_BitsPerSample, (uint32_t)info.m_Channels);
             instance->m_Playing = 0;
             return;
         }
@@ -1457,11 +1639,44 @@ namespace dmSound
         dmSoundCodec::Result r = dmSoundCodec::RESULT_OK;
 
         // Compute how many input samples we will need to produce the requested output samples
-        uint64_t delta = (uint64_t)(((float)(info.m_Rate << RESAMPLE_FRACTION_BITS) / sound->m_MixRate) * instance->m_Speed);
+        uint64_t delta = GetResampleDelta(info, sound->m_MixRate, instance->m_Speed);
         if (delta == 0) {
             // very low speed settings can get the delta to be zero due to precision limits - we skip the mixing as resulting rates are also (alsmost) inaudibly low as a result
             return;
         }
+
+        uint64_t required_decoder_frame_capacity = GetRequiredDecodedFrameCapacity(delta, mix_context->m_FrameCount);
+        if (required_decoder_frame_capacity > 0xffffffffU)
+        {
+            dmLogError("Decoder scratch buffer too large for '%s'", GetSoundName(sound, instance));
+            instance->m_Playing = 0;
+            return;
+        }
+
+        Result capacity_result = EnsureDecoderScratchBufferSize(sound, info, (uint32_t)required_decoder_frame_capacity);
+        if (capacity_result != RESULT_OK)
+        {
+            dmLogError("Failed to grow decoder scratch buffer for '%s': %d", GetSoundName(sound, instance), capacity_result);
+            instance->m_Playing = 0;
+            return;
+        }
+
+        uint64_t required_state_frame_capacity = GetRequiredStateFrameCapacity(delta);
+        if (required_state_frame_capacity > 0xffffffffU)
+        {
+            dmLogError("Instance frame buffer too large for '%s'", GetSoundName(sound, instance));
+            instance->m_Playing = 0;
+            return;
+        }
+
+        capacity_result = EnsureInstanceFrameBufferSize(instance, (uint32_t)required_state_frame_capacity);
+        if (capacity_result != RESULT_OK)
+        {
+            dmLogError("Failed to grow instance frame buffer for '%s': %d", GetSoundName(sound, instance), capacity_result);
+            instance->m_Playing = 0;
+            return;
+        }
+
         uint32_t mixed_instance_frame_count = (uint32_t)((instance->m_FrameFraction + mix_context->m_FrameCount * delta + ((1UL << RESAMPLE_FRACTION_BITS) - 1)) >> RESAMPLE_FRACTION_BITS) + SOUND_MAX_FUTURE;
 
         // Compute initial amount of samples in temp buffer once we restore per instance state prior to actual mixing
@@ -1478,7 +1693,7 @@ namespace dmSound
 
             bool is_direct_delivery = (info.m_BitsPerSample == 32 && (!info.m_IsInterleaved || info.m_Channels == 1));
 
-            const uint32_t stride = !is_direct_delivery ? (info.m_Channels * (info.m_BitsPerSample / 8)) : sizeof(float);
+            const uint32_t stride = !is_direct_delivery ? GetDecoderOutputStrideBytes(info) : (uint32_t)sizeof(float);
 
             while(frame_count < mixed_instance_frame_count)
             {
@@ -1952,7 +2167,9 @@ namespace dmSound
         DM_PROFILE("Sound");
         SoundSystem* sound = g_SoundSystem;
         if (!sound)
+        {
             return RESULT_OK;
+        }
 
         if (!sound->m_Thread)
             return UpdateInternal(sound);

--- a/engine/sound/src/sound_private.h
+++ b/engine/sound/src/sound_private.h
@@ -51,10 +51,9 @@ namespace dmSound
     #define SOUND_OUTBUFFER_COUNT (3)
     #define SOUND_OUTBUFFER_COUNT_NO_THREADS (4)
     #define SOUND_OUTBUFFER_MAX_COUNT (6)
-    #define SOUND_MAX_SPEED (5)
+    #define SOUND_MAX_SPEED (50)
     #define SOUND_MAX_HISTORY (4)
     #define SOUND_MAX_FUTURE (4)
-    #define SOUND_INSTANCE_STATEFRAMECOUNT (SOUND_MAX_HISTORY + SOUND_MAX_SPEED + SOUND_MAX_FUTURE)         // "max speed" is used as "extra sample count" as we can at most leave these many samples in the buffers due to fractional positions etc.
 
     const uint32_t RESAMPLE_FRACTION_BITS = 11; // matches number of polyphase filter bank entries (2048)
 

--- a/engine/sound/src/test/test_sound.cpp
+++ b/engine/sound/src/test/test_sound.cpp
@@ -67,6 +67,7 @@
 #include "test/stereo_tone_440_44100_11025.wav.embed.h"
 #include "test/stereo_tone_440_44100_88200.wav.embed.h"
 #include "test/stereo_tone_440_48000_12000.wav.embed.h"
+#include "test/stereo_tone_440_96000_24000.wav.embed.h"
 #include "test/stereo_tone_2000_48000_12000.wav.embed.h"
 
 #include "test/mono_tone_440_22050_44100.wav.embed.h"
@@ -2359,6 +2360,36 @@ static int PlaySound(const char* path, dmSound::SoundDataType type)
 
     dmMemory::AlignedFree(sound_data);
     return 0;
+}
+
+TEST(SoundSdk, HighSpeedPlaybackCompletes)
+{
+    dmSound::InitializeParams params;
+    params.m_MaxBuffers = MAX_BUFFERS;
+    params.m_MaxSources = MAX_SOURCES;
+    params.m_OutputDevice = "loopback";
+    params.m_FrameCount = 2048;
+    params.m_UseThread = false;
+
+    ASSERT_EQ(dmSound::RESULT_OK, dmSound::Initialize(0, &params));
+
+    dmSound::HSoundData sd = 0;
+    ASSERT_EQ(dmSound::RESULT_OK, dmSound::NewSoundData(STEREO_TONE_440_96000_24000_WAV, STEREO_TONE_440_96000_24000_WAV_SIZE, dmSound::SOUND_DATA_TYPE_WAV, &sd, dmHashString64("high_speed_wav")));
+
+    dmSound::HSoundInstance instance = 0;
+    ASSERT_EQ(dmSound::RESULT_OK, dmSound::NewSoundInstance(sd, &instance));
+    ASSERT_EQ(dmSound::RESULT_OK, dmSound::SetParameter(instance, dmSound::PARAMETER_SPEED, dmVMath::Vector4(5.0f, 0.0f, 0.0f, 0.0f)));
+    ASSERT_EQ(dmSound::RESULT_OK, dmSound::Play(instance));
+
+    for (uint32_t i = 0; i < 256 && dmSound::IsPlaying(instance); ++i)
+    {
+        ASSERT_EQ(dmSound::RESULT_OK, dmSound::Update());
+    }
+    ASSERT_FALSE(dmSound::IsPlaying(instance));
+
+    ASSERT_EQ(dmSound::RESULT_OK, dmSound::DeleteSoundInstance(instance));
+    ASSERT_EQ(dmSound::RESULT_OK, dmSound::DeleteSoundData(sd));
+    ASSERT_EQ(dmSound::RESULT_OK, dmSound::Finalize());
 }
 
 // New tests for start_time/start_frame offset support

--- a/engine/sound/src/test/wscript
+++ b/engine/sound/src/test/wscript
@@ -123,6 +123,15 @@ def build(bld):
             ramp = True,
             rule = gen_dc)
 
+    bld(target = 'stereo_tone_440_96000_24000.wav',
+        tone = 440,
+        rate = 96000,
+        frames = 24000,
+        channels = 2,
+        ramp = False,
+        rule = gen_tone)
+    wavs.append('stereo_tone_440_96000_24000.wav')
+
     bld.add_group()
 
     embedded_wavs = bld.stlib(features = 'cxx embed test',


### PR DESCRIPTION
Compile-time assumptions about how large audio buffers need to be for all sounds created limitations on the playback speed that could be applied and on the sound quality that could be played safely. For example, playing a `384 kHz` sound could crash on a device with a `44 kHz` output rate. A similar issue existed for playback speed: increasing the speed requires more decoded data to be fed into the resampler, and the sound system could end up with a buffer that was too small, which could also cause a crash.

To fix this, the sound system can now grow its scratch buffers dynamically to ensure that enough data fits when needed. This fixes crashes in those situations and also allows the maximum speed limit to be increased from `5` to `50`. It still makes sense to use reasonable sound sample rates, such as `44 kHz`, since higher rates increase runtime memory usage as well as using high speed sounds. To help track that memory usage, a new `Sound System` section has been added to the profiler.

Fix https://github.com/defold/defold/issues/12031
Fix https://github.com/defold/defold/issues/9045
Fix https://github.com/defold/defold/issues/10327


## Technical changes

- Raises the supported `sound.speed` range from `0.1-5.0` to `0.0-50.0` 
- Reworks sound mixing buffer management to size decoder scratch buffers and per-instance frame state dynamically from the actual resampling delta, instead of relying on fixed allocations derived from a compile-time max speed.
- Adds explicit capacity/overflow checks before growing decode and state buffers. If the required allocation cannot be satisfied, the engine now logs the failure and stops the affected sound instance instead of risking buffer overruns and crashes.
- Consolidates resampling and decoder stride calculations into shared helpers, which removes duplicated sizing logic and keeps skip/decode paths consistent.
- Adds sound-system profiling counters for instance count, sound-data size, decoder scratch buffer size, and instance buffer size to make the new memory behavior observable at runtime.
- Adds a high-speed playback regression test plus a dedicated 96 kHz stereo WAV fixture to verify that fast playback completes correctly without hanging or crashing.