### PR TITLE
Increase number of texture units per draw from 8 to 16

### DIFF
--- a/engine/gamesys/src/gamesys/gamesys.cpp
+++ b/engine/gamesys/src/gamesys/gamesys.cpp
@@ -108,7 +108,15 @@ namespace dmGameSystem
         dmHashString64("texture4"),
         dmHashString64("texture5"),
         dmHashString64("texture6"),
-        dmHashString64("texture7")
+        dmHashString64("texture7"),
+        dmHashString64("texture8"),
+        dmHashString64("texture9"),
+        dmHashString64("texture10"),
+        dmHashString64("texture11"),
+        dmHashString64("texture12"),
+        dmHashString64("texture13"),
+        dmHashString64("texture14"),
+        dmHashString64("texture15"),
     };
     const dmhash_t PROP_TEXTURES    = dmHashString64("textures");
     const dmhash_t PROP_TILE_SOURCE = dmHashString64("tile_source");

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -1314,6 +1314,38 @@ TEST_P(ResourcePropTest, ResourceRefCounting)
     }
 }
 
+TEST_F(ComponentTest, ModelTexturePropertyAllTextureSlots)
+{
+    const char* go_path = "/resource/res_getset_prop.goc";
+    const char* tex_path = "/tile/mario_tileset.texturec";
+    dmhash_t tex_hash = dmHashString64(tex_path);
+    dmhash_t comp_name = dmHashString64("model");
+
+    void* tex_res = 0x0;
+    ASSERT_EQ(dmResource::RESULT_OK, dmResource::Get(m_Factory, tex_path, &tex_res));
+
+    dmGameObject::HInstance go = Spawn(m_Factory, m_Collection, go_path, dmHashString64("/go"));
+    ASSERT_NE((void*)0, go);
+
+    char prop_buf[32];
+    dmGameObject::PropertyOptions opt;
+    for (uint32_t i = 0; i < dmRender::RenderObject::MAX_TEXTURE_COUNT; ++i)
+    {
+        dmSnPrintf(prop_buf, sizeof(prop_buf), "texture%u", i);
+        dmhash_t prop = dmHashString64(prop_buf);
+        dmGameObject::PropertyVar v(tex_hash);
+        ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::SetProperty(go, comp_name, prop, opt, v));
+
+        dmGameObject::PropertyDesc desc;
+        ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::GetProperty(go, comp_name, prop, opt, desc));
+        ASSERT_EQ(dmGameObject::PROPERTY_TYPE_HASH, desc.m_Variant.m_Type);
+        ASSERT_EQ(tex_hash, desc.m_Variant.m_Hash);
+    }
+
+    DeleteInstance(m_Collection, go);
+    dmResource::Release(m_Factory, tex_res);
+}
+
 // Test that go.delete() does not influence other sprite animations in progress
 TEST_F(SpriteTest, GoDeletion)
 {

--- a/engine/render/src/dmsdk/render/render.h
+++ b/engine/render/src/dmsdk/render/render.h
@@ -152,7 +152,7 @@ namespace dmRender
 
 
     /*#
-     * The maximum number of textures the render object can hold (currently 8)
+     * The maximum number of textures the render object can hold (16)
      * @constant
      * @name dmRender::RenderObject::MAX_TEXTURE_COUNT
      */
@@ -184,7 +184,7 @@ namespace dmRender
         RenderObject();
         void Init();
 
-        static const uint32_t MAX_TEXTURE_COUNT       = 8;
+        static const uint32_t MAX_TEXTURE_COUNT       = 16;
         static const uint32_t MAX_VERTEX_BUFFER_COUNT = 3;
 
         HNamedConstantBuffer            m_ConstantBuffer;

--- a/engine/render/src/test/test_render.cpp
+++ b/engine/render/src/test/test_render.cpp
@@ -20,6 +20,7 @@
 #include <testmain/testmain.h>
 #include <dlib/hash.h>
 #include <dlib/math.h>
+#include <dlib/dstrings.h>
 #include <script/script.h>
 #include <font/font.h>
 #include <font/fontcollection.h>
@@ -824,6 +825,80 @@ TEST_F(dmRenderTest, TestEnableTextureByHash)
     dmGraphics::DeleteProgram(m_GraphicsContext, program);
     dmRender::DeleteMaterial(m_Context, material);
 
+    dmGraphics::DeleteVertexBuffer(vx_buffer);
+    dmGraphics::DeleteVertexDeclaration(vx_decl);
+}
+
+TEST_F(dmRenderTest, TestRenderObjectMaxTextureBindings)
+{
+    dmGraphics::ShaderDescBuilder shader_desc_builder;
+    dmGraphics::HTexture textures[dmRender::RenderObject::MAX_TEXTURE_COUNT] = {};
+    char tex_names[dmRender::RenderObject::MAX_TEXTURE_COUNT][16] = {}; // Ensure enough space for the longest texture name
+    char fs_buf[2048];
+    size_t off = 0;
+
+    // Generate a fs-shader with MAX_TEXTURE_COUNT samplers
+    for (uint32_t i = 0; i < dmRender::RenderObject::MAX_TEXTURE_COUNT; ++i)
+    {
+        off += dmSnPrintf(fs_buf + off, sizeof(fs_buf) - off, "uniform lowp sampler2D tex%u;\n", i);
+        dmSnPrintf(tex_names[i], sizeof(tex_names[i]), "tex%u", i);
+
+        shader_desc_builder.AddTexture(tex_names[i], i, dmGraphics::ShaderDesc::SHADER_TYPE_SAMPLER2D);
+        textures[i] = MakeDummyTexture(m_GraphicsContext);
+    }
+
+    shader_desc_builder.AddShader(dmGraphics::ShaderDesc::SHADER_TYPE_VERTEX, dmGraphics::ShaderDesc::LANGUAGE_GLSL_SM330, "foo", 3);
+    shader_desc_builder.AddShader(dmGraphics::ShaderDesc::SHADER_TYPE_FRAGMENT, dmGraphics::ShaderDesc::LANGUAGE_GLSL_SM330, fs_buf, (uint32_t) strlen(fs_buf));
+
+    dmGraphics::HProgram program = dmGraphics::NewProgram(m_GraphicsContext, shader_desc_builder.Get(), 0, 0);
+    dmRender::HMaterial material = dmRender::NewMaterial(m_Context, program);
+
+    for (uint32_t i = 0; i < dmRender::RenderObject::MAX_TEXTURE_COUNT; ++i)
+    {
+        ASSERT_TRUE(dmRender::SetMaterialSampler(material, dmHashString64(tex_names[i]), i, dmGraphics::TEXTURE_WRAP_REPEAT, dmGraphics::TEXTURE_WRAP_REPEAT, dmGraphics::TEXTURE_FILTER_LINEAR, dmGraphics::TEXTURE_FILTER_LINEAR, 1.0f));
+    }
+
+    dmhash_t tag = dmHashString64("tag");
+    dmRender::SetMaterialTags(material, 1, &tag);
+
+    dmGraphics::HVertexDeclaration vx_decl = dmGraphics::NewVertexDeclaration(m_GraphicsContext, 0, 0);
+    dmGraphics::HVertexBuffer vx_buffer    = dmGraphics::NewVertexBuffer(m_GraphicsContext, 0, 0, dmGraphics::BUFFER_USAGE_STATIC_DRAW);
+
+    TestEnableTextureByHashDispatchCtx user_ctx;
+    user_ctx.m_Context           = m_Context;
+    user_ctx.m_Material          = material;
+    user_ctx.m_VertexDeclaration = vx_decl;
+    user_ctx.m_VertexBuffer      = vx_buffer;
+    user_ctx.m_Textures          = textures;
+
+    dmRender::RenderListBegin(m_Context);
+    dmRender::RenderListEntry* out   = dmRender::RenderListAlloc(m_Context, 1);
+    dmRender::RenderListEntry& entry = out[0];
+    entry.m_WorldPosition            = Point3(0, 0, 0);
+    entry.m_MajorOrder               = 0;
+    entry.m_MinorOrder               = 0;
+    entry.m_TagListKey               = 0;
+    entry.m_Order                    = 1;
+    entry.m_BatchKey                 = 0;
+    entry.m_Dispatch                 = dmRender::RenderListMakeDispatch(m_Context, TestEnableTextureByHashDispatch, 0, &user_ctx);
+    entry.m_UserData                 = 0;
+
+    dmRender::RenderListSubmit(m_Context, out, out + 1);
+    dmRender::RenderListEnd(m_Context);
+    dmRender::DrawRenderList(m_Context, 0, 0, 0, dmRender::SORT_BACK_TO_FRONT);
+
+    // Note: After a render, the textures are unbound from the context.
+    //       Hence we need to check the last bound unit for each texture.
+    dmGraphics::NullContext* null_context = (dmGraphics::NullContext*) m_GraphicsContext;
+    for (uint32_t i = 0; i < dmRender::RenderObject::MAX_TEXTURE_COUNT; ++i)
+    {
+        dmGraphics::Texture* tex = dmGraphics::GetAssetFromContainer<dmGraphics::Texture>(null_context->m_AssetHandleContainer, textures[i]);
+        ASSERT_EQ((int32_t) i, tex->m_LastBoundUnit[0]);
+        dmGraphics::DeleteTexture(m_GraphicsContext, textures[i]);
+    }
+
+    dmGraphics::DeleteProgram(m_GraphicsContext, program);
+    dmRender::DeleteMaterial(m_Context, material);
     dmGraphics::DeleteVertexBuffer(vx_buffer);
     dmGraphics::DeleteVertexDeclaration(vx_decl);
 }


### PR DESCRIPTION
Max texture units a draw call can reference has been increased from 8 to 16.

Fixes #11750
Fixes #10195