### PR TITLE
Fix Box2D 3.1 trigger enter/exit when one collision object overlaps several triggers

### DIFF
--- a/engine/physics/src/physics/box2d/box2d_physics.cpp
+++ b/engine/physics/src/physics/box2d/box2d_physics.cpp
@@ -269,19 +269,19 @@ namespace dmPhysics
 
     static dmArray<b2ShapeId>& GetSensorOverlapBuffer(HWorld2D world, b2ShapeId shapeId)
     {
-        int num_overlaps = b2Shape_GetSensorCapacity(shapeId);
+        int capacity = b2Shape_GetSensorCapacity(shapeId);
 
-        if (world->m_GetSensorOverlapsScratchBuffer.Capacity() < num_overlaps)
+        if (world->m_GetSensorOverlapsScratchBuffer.Capacity() < capacity)
         {
-            world->m_GetSensorOverlapsScratchBuffer.SetCapacity(num_overlaps);
+            world->m_GetSensorOverlapsScratchBuffer.SetCapacity(capacity);
         }
 
+        int num_overlaps = 0;
+        if (capacity > 0)
+        {
+            num_overlaps = b2Shape_GetSensorOverlaps(shapeId, world->m_GetSensorOverlapsScratchBuffer.Begin(), capacity);
+        }
         world->m_GetSensorOverlapsScratchBuffer.SetSize(num_overlaps);
-
-        if (num_overlaps > 0)
-        {
-            num_overlaps = b2Shape_GetSensorOverlaps(shapeId, world->m_GetSensorOverlapsScratchBuffer.Begin(), num_overlaps);
-        }
         return world->m_GetSensorOverlapsScratchBuffer;
     }
 
@@ -704,8 +704,6 @@ namespace dmPhysics
             world->m_RayCastRequests.SetSize(0);
         }
 
-        b2SensorEvents sensor_events = b2World_GetSensorEvents(world->m_WorldId);
-
         if (step_context.m_CollisionCallback)
         {
             DM_PROFILE("CollisionCallbacks");
@@ -753,6 +751,8 @@ namespace dmPhysics
         {
             DM_PROFILE("TriggerCallbacks");
 
+            b2SensorEvents sensor_events = b2World_GetSensorEvents(world->m_WorldId);
+
             OverlapCacheAddData add_data;
             add_data.m_TriggerEnteredCallback = step_context.m_TriggerEnteredCallback;
             add_data.m_TriggerEnteredUserData = step_context.m_TriggerEnteredUserData;
@@ -785,8 +785,11 @@ namespace dmPhysics
                 {
                     continue;
                 }
-                OverlapCacheDecreaseCount(&world->m_TriggerOverlaps, ToOpaqueHandle(b2Shape_GetBody(shapeIdA)));
-                OverlapCacheDecreaseCount(&world->m_TriggerOverlaps, ToOpaqueHandle(b2Shape_GetBody(shapeIdB)));
+
+                uint64_t body_a = ToOpaqueHandle(b2Shape_GetBody(shapeIdA));
+                uint64_t body_b = ToOpaqueHandle(b2Shape_GetBody(shapeIdB));
+                OverlapCacheDecreaseCount(&world->m_TriggerOverlaps, body_a, body_b);
+                OverlapCacheDecreaseCount(&world->m_TriggerOverlaps, body_b, body_a);
             }
 
             OverlapCachePruneData prune_data;

--- a/engine/physics/src/physics/physics.cpp
+++ b/engine/physics/src/physics/physics.cpp
@@ -167,14 +167,19 @@ namespace dmPhysics
         }
     }
 
-    void OverlapCacheDecreaseCount(OverlapCache* cache, uint64_t object)
+    void OverlapCacheDecreaseCount(OverlapCache* cache, uint64_t object_a, uint64_t object_b)
     {
-        OverlapEntry* entry = cache->m_OverlapCache.Get(object);
-        if (entry != 0x0)
+        OverlapEntry* entry_a = cache->m_OverlapCache.Get(object_a);
+        if (entry_a != 0x0)
         {
-            for (int i = 0; i < entry->m_OverlapCount; ++i)
+            for (uint32_t i = 0; i < entry_a->m_OverlapCount; ++i)
             {
-                entry->m_Overlaps[i].m_Count--;
+                Overlap& overlap = entry_a->m_Overlaps[i];
+                if (overlap.m_Object == object_b)
+                {
+                    overlap.m_Count--;
+                    break;
+                }
             }
         }
     }

--- a/engine/physics/src/physics/physics_private.h
+++ b/engine/physics/src/physics/physics_private.h
@@ -99,7 +99,11 @@ namespace dmPhysics
         uint16_t                m_GroupB;
     };
 
-    void OverlapCacheDecreaseCount(OverlapCache* cache, uint64_t object);
+    /**
+     * Decrements overlap count for the pair (object_a, object_b) on object_a's side only.
+     * Call twice with arguments swapped to update both directions after a touch ends.
+     */
+    void OverlapCacheDecreaseCount(OverlapCache* cache, uint64_t object_a, uint64_t object_b);
 
     /**
      * Adds an overlap to the cache and potentially calls the trigger entered callback

--- a/engine/physics/src/physics/test/test_physics.cpp
+++ b/engine/physics/src/physics/test/test_physics.cpp
@@ -2051,6 +2051,65 @@ TYPED_TEST(PhysicsTest, TriggerEnterExit)
     (*TestFixture::m_Test.m_DeleteCollisionShapeFunc)(shape_b);
 }
 
+// Three triggers: two overlap from creation (one enter pair), a third moves into both (two enters),
+// then leaves (two exits). Exercises trigger–trigger overlaps and a third body overlapping two triggers.
+TYPED_TEST(PhysicsTest, TriggerThreeOverlapping)
+{
+    float radius = 0.5f;
+
+    VisualObject vo_t1;
+    vo_t1.m_Position = Point3(0.0f, 0.0f, 0.0f);
+    VisualObject vo_t2;
+    vo_t2.m_Position = Point3(0.4f, 0.0f, 0.0f);
+    VisualObject vo_t3;
+    vo_t3.m_Position = Point3(10.0f, 0.0f, 0.0f);
+
+    dmPhysics::CollisionObjectData data_t;
+    typename TypeParam::CollisionShapeType shape_t1 = (*TestFixture::m_Test.m_NewSphereShapeFunc)(TestFixture::m_Context, radius);
+    typename TypeParam::CollisionShapeType shape_t2 = (*TestFixture::m_Test.m_NewSphereShapeFunc)(TestFixture::m_Context, radius);
+    typename TypeParam::CollisionShapeType shape_t3 = (*TestFixture::m_Test.m_NewSphereShapeFunc)(TestFixture::m_Context, radius);
+    data_t.m_Group = 1;
+    data_t.m_Mask = 1;
+    data_t.m_Type = dmPhysics::COLLISION_OBJECT_TYPE_TRIGGER;
+    data_t.m_Mass = 0.0f;
+    data_t.m_Restitution = 1.0f;
+
+    data_t.m_UserData = &vo_t1;
+    typename TypeParam::CollisionObjectType co_t1 = (*TestFixture::m_Test.m_NewCollisionObjectFunc)(TestFixture::m_World, data_t, &shape_t1, 1u);
+    data_t.m_UserData = &vo_t2;
+    typename TypeParam::CollisionObjectType co_t2 = (*TestFixture::m_Test.m_NewCollisionObjectFunc)(TestFixture::m_World, data_t, &shape_t2, 1u);
+
+    TriggerUserData ud = {0, 0, 0};
+    TestFixture::m_StepWorldContext.m_TriggerEnteredCallback = TriggerEntered;
+    TestFixture::m_StepWorldContext.m_TriggerEnteredUserData = &ud;
+    TestFixture::m_StepWorldContext.m_TriggerExitedCallback = TriggerExited;
+    TestFixture::m_StepWorldContext.m_TriggerExitedUserData = &ud;
+
+    (*TestFixture::m_Test.m_StepWorldFunc)(TestFixture::m_World, TestFixture::m_StepWorldContext);
+    ASSERT_EQ(1, ud.m_Count);
+
+    data_t.m_UserData = &vo_t3;
+    typename TypeParam::CollisionObjectType co_t3 = (*TestFixture::m_Test.m_NewCollisionObjectFunc)(TestFixture::m_World, data_t, &shape_t3, 1u);
+    (*TestFixture::m_Test.m_StepWorldFunc)(TestFixture::m_World, TestFixture::m_StepWorldContext);
+    ASSERT_EQ(1, ud.m_Count);
+
+    // Inside both t1 and t2 (overlap region of the two circles)
+    vo_t3.m_Position = Point3(0.2f, 0.0f, 0.0f);
+    (*TestFixture::m_Test.m_StepWorldFunc)(TestFixture::m_World, TestFixture::m_StepWorldContext);
+    ASSERT_EQ(3, ud.m_Count);
+
+    vo_t3.m_Position = Point3(10.0f, 0.0f, 0.0f);
+    (*TestFixture::m_Test.m_StepWorldFunc)(TestFixture::m_World, TestFixture::m_StepWorldContext);
+    ASSERT_EQ(1, ud.m_Count);
+
+    (*TestFixture::m_Test.m_DeleteCollisionObjectFunc)(TestFixture::m_World, co_t3);
+    (*TestFixture::m_Test.m_DeleteCollisionObjectFunc)(TestFixture::m_World, co_t2);
+    (*TestFixture::m_Test.m_DeleteCollisionObjectFunc)(TestFixture::m_World, co_t1);
+    (*TestFixture::m_Test.m_DeleteCollisionShapeFunc)(shape_t3);
+    (*TestFixture::m_Test.m_DeleteCollisionShapeFunc)(shape_t2);
+    (*TestFixture::m_Test.m_DeleteCollisionShapeFunc)(shape_t1);
+}
+
 // Verify that enter/exit callbacks are used correctly when objects are deleted inside a trigger.
 TYPED_TEST(PhysicsTest, TriggerEnterExitDelete)
 {


### PR DESCRIPTION
2D physics with Box2D 3.1 could report wrong trigger enter/exit when one object overlapped more than one trigger at the same time. Exits were applied incorrectly to all overlaps of a body instead of only the pair that ended. This change fixes that tracking and adds a regression test. Sensor overlap queries used for collision callbacks also read overlap counts from Box2D correctly.

Fixes https://github.com/defold/defold/issues/12093

### Technical changes

* `GetSensorOverlapBuffer`: treat `b2Shape_GetSensorCapacity` as capacity only; call `b2Shape_GetSensorOverlaps`, then set scratch buffer size to the returned overlap count.  
* `OverlapCacheDecreaseCount` now takes `(object_a, object_b)` and decrements the overlap from **a -> b** only; We call it twice with arguments swapped so both directed edges stay consistent.  
* New test: `TriggerThreeOverlapping` (two overlapping triggers + third body entering/leaving both - the same as the re-pro case from the issue).