### PR TITLE
Speedup Bob.jar pre-creation stage

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/ProjectBuildTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/ProjectBuildTest.java
@@ -21,11 +21,12 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.text.ParseException;
+import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
-
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import javax.imageio.ImageIO;
 
@@ -202,6 +203,40 @@ public class ProjectBuildTest {
         outputProps.load(new FileInputStream(new File(contentRoot + "/build/game.projectc")));
 
         checkProjectSettingArray(outputProps, "project", "custom_string_list", new String[]{"http://test.com/test.zip", "http://test.com/test1.zip", "http://test.com/test2.zip"});
+    }
+
+    @Test
+    public void testFindResourcePathsRespectsDefignore() throws IOException {
+        createFile(contentRoot, ".defignore", "ignored-without-leading-slash.txt\n/ignored-dir/\n/ignored-file.txt\n");
+        createFile(contentRoot, "visible/keep.txt", "");
+        createFile(contentRoot, "ignored-dir/skip.txt", "");
+        createFile(contentRoot, "ignored-dir-sibling.txt", "");
+        createFile(contentRoot, "sub/ignored-dir/keep.txt", "");
+        createFile(contentRoot, "ignored-file.txt", "");
+        createFile(contentRoot, "ignored-without-leading-slash.txt", "");
+
+        Project project = new Project(new DefaultFileSystem(), contentRoot, "build");
+        try {
+            List<String> paths = new ArrayList<>();
+            project.findResourcePaths("", paths);
+            assertTrue(paths.contains("visible/keep.txt"));
+            assertTrue(paths.contains("ignored-dir-sibling.txt"));
+            assertTrue(paths.contains("sub/ignored-dir/keep.txt"));
+            assertTrue(paths.contains("ignored-without-leading-slash.txt"));
+            assertFalse(paths.contains("ignored-dir/skip.txt"));
+            assertFalse(paths.contains("ignored-file.txt"));
+
+            List<String> ignoredPaths = new ArrayList<>();
+            project.findResourcePaths("ignored-dir", ignoredPaths);
+            assertTrue(ignoredPaths.isEmpty());
+
+            List<String> dirs = new ArrayList<>();
+            project.findResourceDirs("", dirs);
+            assertTrue(dirs.contains("visible"));
+            assertFalse(dirs.contains("ignored-dir"));
+        } finally {
+            project.dispose();
+        }
     }
 
     @Test

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/ProjectBuildTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/ProjectBuildTest.java
@@ -22,6 +22,8 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.text.ParseException;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -219,12 +221,16 @@ public class ProjectBuildTest {
         try {
             List<String> paths = new ArrayList<>();
             project.findResourcePaths("", paths);
-            assertTrue(paths.contains("visible/keep.txt"));
-            assertTrue(paths.contains("ignored-dir-sibling.txt"));
-            assertTrue(paths.contains("sub/ignored-dir/keep.txt"));
-            assertTrue(paths.contains("ignored-without-leading-slash.txt"));
-            assertFalse(paths.contains("ignored-dir/skip.txt"));
-            assertFalse(paths.contains("ignored-file.txt"));
+            assertEquals(7, paths.size());
+            assertEquals(new HashSet<>(Arrays.asList(
+                    ".defignore",
+                    "game.project",
+                    "ignored-dir-sibling.txt",
+                    "ignored-without-leading-slash.txt",
+                    "sub/ignored-dir/keep.txt",
+                    "test.png",
+                    "visible/keep.txt")),
+                    new HashSet<>(paths));
 
             List<String> ignoredPaths = new ArrayList<>();
             project.findResourcePaths("ignored-dir", ignoredPaths);
@@ -232,8 +238,8 @@ public class ProjectBuildTest {
 
             List<String> dirs = new ArrayList<>();
             project.findResourceDirs("", dirs);
-            assertTrue(dirs.contains("visible"));
-            assertFalse(dirs.contains("ignored-dir"));
+            assertEquals(2, dirs.size());
+            assertEquals(new HashSet<>(Arrays.asList("sub", "visible")), new HashSet<>(dirs));
         } finally {
             project.dispose();
         }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
@@ -14,46 +14,25 @@
 
 package com.dynamo.bob;
 
-import static org.apache.commons.io.FilenameUtils.normalizeNoEndSeparator;
-
-import java.io.BufferedInputStream;
-import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.net.ConnectException;
-import java.net.HttpURLConnection;
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.net.URI;
-import java.nio.file.attribute.FileTime;
-import java.text.ParseException;
-import java.util.*;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Callable;
-import java.util.concurrent.Future;
-import java.util.concurrent.ExecutionException;
-import java.util.jar.Attributes;
-import java.util.jar.JarFile;
-import java.util.jar.Manifest;
-import java.util.logging.Level;
-import java.util.stream.Collectors;
-import java.util.zip.ZipException;
-import java.util.zip.ZipFile;
-import java.util.zip.ZipOutputStream;
-
+import com.defold.extender.client.ExtenderClient;
+import com.defold.extender.client.ExtenderClientException;
+import com.defold.extender.client.ExtenderResource;
 import com.defold.extension.pipeline.ILuaTranspiler;
+import com.defold.extension.pipeline.texture.ITextureCompressor;
+import com.defold.extension.pipeline.texture.TextureCompression;
 import com.defold.extension.pipeline.texture.TextureCompressorPreset;
 import com.dynamo.bob.archive.ArchiveBuilder;
+import com.dynamo.bob.archive.EngineVersion;
+import com.dynamo.bob.archive.publisher.AWSPublisher;
 import com.dynamo.bob.archive.publisher.FolderPublisher;
+import com.dynamo.bob.archive.publisher.NullPublisher;
+import com.dynamo.bob.archive.publisher.Publisher;
+import com.dynamo.bob.archive.publisher.PublisherSettings;
+import com.dynamo.bob.archive.publisher.ZipPublisher;
+import com.dynamo.bob.bundle.BundleHelper;
+import com.dynamo.bob.bundle.BundlerParams;
+import com.dynamo.bob.bundle.IBundler;
+import com.dynamo.bob.cache.ResourceCache;
 import com.dynamo.bob.fs.ClassLoaderMountPoint;
 import com.dynamo.bob.fs.DefaultFileSystem;
 import com.dynamo.bob.fs.DefaultResource;
@@ -63,46 +42,75 @@ import com.dynamo.bob.fs.IFileSystem;
 import com.dynamo.bob.fs.IResource;
 import com.dynamo.bob.fs.ResourceUtil;
 import com.dynamo.bob.fs.ZipMountPoint;
-import com.dynamo.bob.plugin.PluginScanner;
-import com.dynamo.bob.util.BuildInputDataCollector;
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.io.IOUtils;
-import org.apache.commons.codec.binary.Base64;
-
-import com.defold.extender.client.ExtenderClient;
-import com.defold.extender.client.ExtenderClientException;
-import com.defold.extender.client.ExtenderResource;
-
-import com.dynamo.bob.archive.EngineVersion;
-import com.dynamo.bob.archive.publisher.AWSPublisher;
-import com.dynamo.bob.archive.publisher.NullPublisher;
-import com.dynamo.bob.archive.publisher.Publisher;
-import com.dynamo.bob.archive.publisher.PublisherSettings;
-import com.dynamo.bob.archive.publisher.ZipPublisher;
-
-import com.dynamo.bob.bundle.BundleHelper;
-import com.dynamo.bob.bundle.IBundler;
-import com.dynamo.bob.bundle.BundlerParams;
+import com.dynamo.bob.logging.Logger;
 import com.dynamo.bob.pipeline.ExtenderUtil;
 import com.dynamo.bob.pipeline.IShaderCompiler;
 import com.dynamo.bob.pipeline.ShaderCompilers;
 import com.dynamo.bob.pipeline.TextureGenerator;
-import com.defold.extension.pipeline.texture.TextureCompression;
-import com.defold.extension.pipeline.texture.ITextureCompressor;
 import com.dynamo.bob.plugin.IPlugin;
-import com.dynamo.bob.logging.Logger;
+import com.dynamo.bob.plugin.PluginScanner;
 import com.dynamo.bob.util.BobProjectProperties;
+import com.dynamo.bob.util.BuildInputDataCollector;
 import com.dynamo.bob.util.LibraryUtil;
-import com.dynamo.bob.util.ReportGenerator;
-import com.dynamo.bob.util.TimeProfiler;
-import com.dynamo.bob.util.StringUtil;
 import com.dynamo.bob.util.MinifyPathCollector;
+import com.dynamo.bob.util.ReportGenerator;
+import com.dynamo.bob.util.StringUtil;
+import com.dynamo.bob.util.TimeProfiler;
 import com.dynamo.graphics.proto.Graphics.TextureProfiles;
-
-import com.dynamo.bob.cache.ResourceCache;
+import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.io.IOUtils;
 import org.codehaus.jackson.JsonNode;
 import org.codehaus.jackson.map.ObjectMapper;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.ConnectException;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.FileTime;
+import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.jar.Attributes;
+import java.util.jar.JarFile;
+import java.util.jar.Manifest;
+import java.util.logging.Level;
+import java.util.stream.Collectors;
+import java.util.zip.ZipException;
+import java.util.zip.ZipFile;
+import java.util.zip.ZipOutputStream;
+
+import static org.apache.commons.io.FilenameUtils.normalizeNoEndSeparator;
 
 /**
  * Project abstraction. Contains input files, builder, tasks, etc
@@ -127,6 +135,7 @@ public class Project {
     private ExecutorService executor = Executors.newCachedThreadPool();
     private ResourceCache resourceCache = new ResourceCache();
     private IFileSystem fileSystem;
+    private final ProjectResourceWalker resourceWalker;
     private Map<String, Class<? extends Builder>> extToBuilder = new HashMap<String, Class<? extends Builder>>();
     private List<String> inputs = new ArrayList<String>();
     private HashMap<String, EnumSet<OutputFlags>> outputs = new HashMap<String, EnumSet<OutputFlags>>();
@@ -140,7 +149,6 @@ public class Project {
     private List<String> propertyFiles = new ArrayList<>();
     private List<String> buildServerHeaders = new ArrayList<>();
     private List<String> engineBuildDirs = new ArrayList<>();
-    private List<String> allResourcePathsCache; // Cache for all resource paths, since Bob doesn't change project files during build
     private BobProjectProperties projectProperties;
     private Publisher publisher;
     private Map<String, Map<Long, IResource>> hashToResource = new HashMap<>();
@@ -165,9 +173,9 @@ public class Project {
 
     public Project(IFileSystem fileSystem) {
         this.fileSystem = fileSystem;
+        this.resourceWalker = new ProjectResourceWalker(this, fileSystem);
         this.fileSystem.setRootDirectory(rootDirectory);
         this.fileSystem.setBuildDirectory(buildDirectory);
-        this.allResourcePathsCache = null;
         clearProjectProperties();
     }
 
@@ -175,9 +183,9 @@ public class Project {
         this.rootDirectory = normalizeNoEndSeparator(new File(sourceRootDirectory).getAbsolutePath(), true);
         this.buildDirectory = normalizeNoEndSeparator(buildDirectory, true);
         this.fileSystem = fileSystem;
+        this.resourceWalker = new ProjectResourceWalker(this, fileSystem);
         this.fileSystem.setRootDirectory(this.rootDirectory);
         this.fileSystem.setBuildDirectory(this.buildDirectory);
-        this.allResourcePathsCache = null;
         clearProjectProperties();
     }
 
@@ -187,15 +195,15 @@ public class Project {
         this.rootDirectory = normalizeNoEndSeparator(new File(sourceRootDirectory).getAbsolutePath(), true);
         this.buildDirectory = normalizeNoEndSeparator(buildDirectory, true);
         this.fileSystem = fileSystem;
+        this.resourceWalker = new ProjectResourceWalker(this, fileSystem);
         this.fileSystem.setRootDirectory(this.rootDirectory);
         this.fileSystem.setBuildDirectory(this.buildDirectory);
-        this.allResourcePathsCache = null;
         clearProjectProperties();
     }
 
     // For tests
     public void cleanupResourcePathsCache() {
-        allResourcePathsCache = null;
+        resourceWalker.clearCaches();
     }
 
     public void dispose() {
@@ -1491,7 +1499,7 @@ public class Project {
     // the texture compressor handler.
     private void installTextureCompressorPresets() throws IOException, CompileExceptionError {
         ArrayList<String> paths = new ArrayList<>();
-        findResourcePathsByExtension("", ".texc_json", paths);
+        resourceWalker.findResourcePathsByExtension("", ".texc_json", paths);
 
         for (String p : paths) {
             IResource r = getResource(p);
@@ -1515,15 +1523,12 @@ public class Project {
                 IResource buildFileResource = getResource(transpiler.getBuildFileResourcePath());
                 if (buildFileResource.exists()) {
                     String ext = "." + transpiler.getSourceExt();
-                    ArrayList<IResource> sources = new ArrayList<>();
-                    fileSystem.walk("", new FileSystemWalker() {
-                        @Override
-                        public void handleFile(String path, Collection<String> results) {
-                            if (path.endsWith(ext)) {
-                                sources.add(fileSystem.get(path));
-                            }
-                        }
-                    }, new ArrayList<>());
+                    ArrayList<String> sourcePaths = new ArrayList<>();
+                    resourceWalker.findResourcePathsByExtension("", ext, sourcePaths);
+                    ArrayList<IResource> sources = new ArrayList<>(sourcePaths.size());
+                    for (String sourcePath : sourcePaths) {
+                        sources.add(fileSystem.get(sourcePath));
+                    }
                     if (!sources.isEmpty()) {
                         // We transpile to lua from the project dir only if all the source code files exist on disc. Since
                         // some source file may come as dependencies in zip archives, the transpiler will not be able to
@@ -1728,6 +1733,7 @@ public class Project {
         monitor.beginTask(IProgress.Task.WORKING, 100);
         // it should be done before scanJavaClasses to have updated options
         configurePreBuildProjectOptions();
+        resourceWalker.primeIgnorePatterns();
         {
             TimeProfiler.start("scanJavaClasses");
             IProgress mrep = monitor.subProgress(1);
@@ -2253,69 +2259,13 @@ public class Project {
         return maxThreads;
     }
 
-    private void findResourcePathsByExtension(String _path, String ext, Collection<String> result) {
-        TimeProfiler.start("findResourcePathsByExtension");
-        TimeProfiler.addData("path", _path);
-        TimeProfiler.addData("ext", ext);
-        // Initialize and cache all paths only once
-        if (allResourcePathsCache == null) {
-            List<String> allPaths = new ArrayList<>();
-            fileSystem.walk("", new FileSystemWalker() {
-                public void handleFile(String filePath, Collection<String> results) {
-                    results.add(FilenameUtils.normalize(filePath, true));
-                }
-            }, allPaths);
-            allResourcePathsCache = allPaths;
-        }
-        _path = FilenameUtils.normalize(_path, true);
-        _path = stripLeadingSlash(_path);
-        // Fast path: if no filter, return everything
-        if ((ext == null || ext.isEmpty()) && (_path == null || _path.isEmpty())) {
-            result.addAll(allResourcePathsCache);
-            TimeProfiler.stop();
-            return;
-        }
-        IResource res = fileSystem.get(_path);
-        try {
-            if ( (_path != null && !_path.isEmpty()) && (!res.isFile() || res.getContent() == null)) {
-                if (!_path.endsWith("/")) {
-                    _path += "/";
-                }
-            }
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-        final String path =_path;
-
-        // Filter the cached list in parallel, collect safely, then add to result
-        List<String> filteredPaths = allResourcePathsCache.parallelStream()
-            .filter(p -> (ext == null || p.endsWith(ext)) &&
-                         (path == null || path.isEmpty() || p.startsWith(path)))
-            .collect(Collectors.toList());
-        result.addAll(filteredPaths);
-        TimeProfiler.stop();
-    }
-
     public void findResourcePaths(String _path, Collection<String> result) {
-        findResourcePathsByExtension(_path, null, result);
+        resourceWalker.findResourcePathsByExtension(_path, null, result);
     }
 
     // Finds the first level of directories in a path
     public void findResourceDirs(String _path, Collection<String> result) {
-        // Make sure the path has Unix separators, since this is how
-        // paths are specified game project relative internally.
-        final String path = Project.stripLeadingSlash(FilenameUtils.separatorsToUnix(_path));
-        fileSystem.walk(path, new FileSystemWalker() {
-            public boolean handleDirectory(String dir, Collection<String> results) {
-                if (path.equals(dir)) {
-                    return true;
-                }
-                results.add(FilenameUtils.getName(FilenameUtils.normalizeNoEndSeparator(dir)));
-                return false; // skip recursion
-            }
-            public void handleFile(String path, Collection<String> results) { // skip any files
-            }
-        }, result);
+        resourceWalker.findResourceDirs(_path, result);
     }
 
     public List<Task> getTasks() {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
@@ -1733,7 +1733,7 @@ public class Project {
         monitor.beginTask(IProgress.Task.WORKING, 100);
         // it should be done before scanJavaClasses to have updated options
         configurePreBuildProjectOptions();
-        resourceWalker.primeIgnorePatterns();
+        resourceWalker.initIgnorePatterns();
         {
             TimeProfiler.start("scanJavaClasses");
             IProgress mrep = monitor.subProgress(1);
@@ -2245,6 +2245,20 @@ public class Project {
             path = path.substring(1);
         }
         return path;
+    }
+
+    public static String stripLeadingAndTrailingSlashes(String path) {
+        int start = 0;
+        int end = path.length();
+
+        while (start < end && path.charAt(start) == '/') {
+            start++;
+        }
+        while (end > start && path.charAt(end - 1) == '/') {
+            end--;
+        }
+
+        return start == 0 && end == path.length() ? path : path.substring(start, end);
     }
 
     public static int getDefaultMaxCpuThreads() {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/ProjectResourceWalker.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/ProjectResourceWalker.java
@@ -49,7 +49,7 @@ class ProjectResourceWalker {
         ignoredResourcePathPatterns = null;
     }
 
-    public void primeIgnorePatterns() throws CompileExceptionError {
+    public void initIgnorePatterns() throws CompileExceptionError {
         loadIgnoredResourcePathPatterns();
     }
 
@@ -206,8 +206,7 @@ class ProjectResourceWalker {
 
     private static String normalizeIgnoredPathPattern(String path) {
         path = FilenameUtils.separatorsToUnix(path);
-        path = Project.stripLeadingSlash(path);
-        return stripTrailingSlash(path);
+        return Project.stripLeadingAndTrailingSlashes(path);
     }
 
     private static String normalizeResourcePathForMatching(String path) {
@@ -215,14 +214,6 @@ class ProjectResourceWalker {
         if (path.startsWith("./")) {
             path = path.substring(2);
         }
-        path = Project.stripLeadingSlash(path);
-        return stripTrailingSlash(path);
-    }
-
-    private static String stripTrailingSlash(String path) {
-        while (path.length() > 0 && path.charAt(path.length() - 1) == '/') {
-            path = path.substring(0, path.length() - 1);
-        }
-        return path;
+        return Project.stripLeadingAndTrailingSlashes(path);
     }
 }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/ProjectResourceWalker.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/ProjectResourceWalker.java
@@ -1,0 +1,228 @@
+// Copyright 2020-2026 The Defold Foundation
+// Copyright 2014-2020 King
+// Copyright 2009-2014 Ragnar Svensson, Christian Murray
+// Licensed under the Defold License version 1.0 (the "License"); you may not use
+// this file except in compliance with the License.
+//
+// You may obtain a copy of the License, together with FAQs at
+// https://www.defold.com/license
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package com.dynamo.bob;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.FilenameUtils;
+
+import com.dynamo.bob.bundle.BundleHelper;
+import com.dynamo.bob.fs.FileSystemWalker;
+import com.dynamo.bob.fs.IFileSystem;
+import com.dynamo.bob.fs.IResource;
+import com.dynamo.bob.util.TimeProfiler;
+
+// Owns project-local resource walking, ignore rules, and the cached resource path list.
+class ProjectResourceWalker {
+
+    private final Project project;
+    private final IFileSystem fileSystem;
+    private List<String> allResourcePathsCache; // Cache for all resource paths, since Bob doesn't change project files during build
+    private List<String> ignoredResourcePathPatterns;
+
+    ProjectResourceWalker(Project project, IFileSystem fileSystem) {
+        this.project = project;
+        this.fileSystem = fileSystem;
+    }
+
+    public void clearCaches() {
+        allResourcePathsCache = null;
+        ignoredResourcePathPatterns = null;
+    }
+
+    public void primeIgnorePatterns() throws CompileExceptionError {
+        loadIgnoredResourcePathPatterns();
+    }
+
+    public void findResourcePathsByExtension(String path, String ext, Collection<String> result) {
+        TimeProfiler.start("findResourcePathsByExtension");
+        TimeProfiler.addData("path", path);
+        TimeProfiler.addData("ext", ext);
+
+        // Initialize and cache all paths only once.
+        if (allResourcePathsCache == null) {
+            List<String> allPaths = new ArrayList<>();
+            walkResources("", new FileSystemWalker() {
+                @Override
+                public void handleFile(String filePath, Collection<String> results) {
+                    results.add(FilenameUtils.normalize(filePath, true));
+                }
+            }, allPaths);
+            allResourcePathsCache = allPaths;
+        }
+
+        path = FilenameUtils.normalize(path, true);
+        path = Project.stripLeadingSlash(path);
+
+        if ((ext == null || ext.isEmpty()) && (path == null || path.isEmpty())) {
+            result.addAll(allResourcePathsCache);
+            TimeProfiler.stop();
+            return;
+        }
+
+        IResource resource = fileSystem.get(path);
+        try {
+            // Normalize directory lookups so prefix matching stays within that subtree.
+            if ((path != null && !path.isEmpty()) && (!resource.isFile() || resource.getContent() == null)) {
+                if (!path.endsWith("/")) {
+                    path += "/";
+                }
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        final String normalizedPath = path;
+        // Filter the cached list in parallel, collect safely, then add to result.
+        List<String> filteredPaths = allResourcePathsCache.parallelStream()
+                .filter(p -> (ext == null || p.endsWith(ext))
+                        && (normalizedPath == null || normalizedPath.isEmpty() || p.startsWith(normalizedPath)))
+                .collect(Collectors.toList());
+        result.addAll(filteredPaths);
+        TimeProfiler.stop();
+    }
+
+    public void findResourceDirs(String path, Collection<String> result) {
+        // Make sure the path has Unix separators, since this is how
+        // paths are specified game project relative internally.
+        final String normalizedPath = Project.stripLeadingSlash(FilenameUtils.separatorsToUnix(path));
+        walkResources(normalizedPath, new FileSystemWalker() {
+            @Override
+            public boolean handleDirectory(String dir, Collection<String> results) {
+                if (normalizedPath.equals(dir)) {
+                    return true;
+                }
+                results.add(FilenameUtils.getName(FilenameUtils.normalizeNoEndSeparator(dir)));
+                return false; // skip recursion
+            }
+
+            @Override
+            public void handleFile(String path, Collection<String> results) {
+            }
+        }, result);
+    }
+
+    // Centralized project walk that applies .defignore filtering before delegating.
+    private void walkResources(String path, IFileSystem.IWalker walker, Collection<String> results) {
+        fileSystem.walk(path, new FileSystemWalker() {
+            @Override
+            public boolean handleDirectory(String dir, Collection<String> results) {
+                if (isIgnoredResourcePath(dir)) {
+                    return false;
+                }
+                return walker.handleDirectory(dir, results);
+            }
+
+            @Override
+            public void handleFile(String filePath, Collection<String> results) {
+                if (!isIgnoredResourcePath(filePath)) {
+                    walker.handleFile(filePath, results);
+                }
+            }
+        }, results);
+    }
+
+    /*
+        The same `.defignore` matching logic is implemented in the Editor.
+        If you change something here, make sure you change it in resource.clj
+        (defignore-pred).
+    */
+    private List<String> loadIgnoredResourcePathPatterns() throws CompileExceptionError {
+        if (ignoredResourcePathPatterns != null) {
+            return ignoredResourcePathPatterns;
+        }
+
+        LinkedHashSet<String> patterns = new LinkedHashSet<>();
+        for (String excludeFolder : BundleHelper.createArrayFromString(project.option("exclude-build-folder", ""))) {
+            String normalizedPath = normalizeIgnoredPathPattern(excludeFolder);
+            if (!normalizedPath.isEmpty()) {
+                patterns.add(normalizedPath);
+            }
+        }
+
+        File defIgnoreFile = new File(project.getRootDirectory(), ".defignore");
+        if (defIgnoreFile.isFile()) {
+            try {
+                for (String entry : FileUtils.readLines(defIgnoreFile, "UTF-8")) {
+                    if (!entry.startsWith("/")) {
+                        continue;
+                    }
+
+                    String normalizedPath = normalizeIgnoredPathPattern(entry);
+                    if (!normalizedPath.isEmpty()) {
+                        patterns.add(normalizedPath);
+                    }
+                }
+            } catch (IOException e) {
+                throw new CompileExceptionError("Unable to read .defignore", e);
+            }
+        }
+
+        ignoredResourcePathPatterns = new ArrayList<>(patterns);
+        return ignoredResourcePathPatterns;
+    }
+
+    private List<String> getIgnoredResourcePathPatterns() {
+        try {
+            return loadIgnoredResourcePathPatterns();
+        } catch (CompileExceptionError e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private boolean isIgnoredResourcePath(String path) {
+        String normalizedPath = normalizeResourcePathForMatching(path);
+        if (normalizedPath.isEmpty()) {
+            return false;
+        }
+
+        for (String ignoredPathPattern : getIgnoredResourcePathPatterns()) {
+            if (normalizedPath.equals(ignoredPathPattern) || normalizedPath.startsWith(ignoredPathPattern + "/")) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static String normalizeIgnoredPathPattern(String path) {
+        path = FilenameUtils.separatorsToUnix(path);
+        path = Project.stripLeadingSlash(path);
+        return stripTrailingSlash(path);
+    }
+
+    private static String normalizeResourcePathForMatching(String path) {
+        path = FilenameUtils.separatorsToUnix(path);
+        if (path.startsWith("./")) {
+            path = path.substring(2);
+        }
+        path = Project.stripLeadingSlash(path);
+        return stripTrailingSlash(path);
+    }
+
+    private static String stripTrailingSlash(String path) {
+        while (path.length() > 0 && path.charAt(path.length() - 1) == '/') {
+            path = path.substring(0, path.length() - 1);
+        }
+        return path;
+    }
+}

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ExtenderUtil.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ExtenderUtil.java
@@ -20,6 +20,7 @@ import com.dynamo.bob.fs.DefaultFileSystem;
 import com.dynamo.bob.fs.FileSystemWalker;
 import com.dynamo.bob.fs.ZipMountPoint;
 import com.dynamo.bob.util.MiscUtil;
+import com.dynamo.bob.util.TimeProfiler;
 import org.apache.commons.io.filefilter.DirectoryFileFilter;
 import org.apache.commons.io.filefilter.RegexFileFilter;
 
@@ -497,16 +498,20 @@ public class ExtenderUtil {
      * @return True if it contains native extension code
      */
     public static boolean hasNativeExtensions(Project project) {
+        TimeProfiler.start("hasNativeExtensions");
         BobProjectProperties projectProperties = project.getProjectProperties();
         if (hasPropertyResource(project, projectProperties, "native_extension", "app_manifest") ||
             hasPropertyResource(project, projectProperties, "android", "proguard") &&
             !projectProperties.getStringValue("android", "proguard", "").startsWith("/builtins/")) {
+            TimeProfiler.stop();
             return true;
         }
 
         ArrayList<String> paths = new ArrayList<>();
         project.findResourcePaths("", paths);
-        return paths.stream().anyMatch(v -> isEngineExtensionManifest(project, v));
+        boolean hasNativeExtensions = paths.stream().anyMatch(v -> isEngineExtensionManifest(project, v));
+        TimeProfiler.stop();
+        return hasNativeExtensions;
     }
 
     private static IResource getProjectResource(Project project, String section, String key) throws CompileExceptionError, IOException {
@@ -674,6 +679,7 @@ public class ExtenderUtil {
      * @return Doesn't return anything. It throws CompileExceptionError if the check fails.
      */
     public static void checkProjectForDuplicates(Project project) throws CompileExceptionError {
+        TimeProfiler.start("checkProjectForDuplicates");
         Map<String, IResource> files = new HashMap<String, IResource>();
 
         ArrayList<String> paths = new ArrayList<>();
@@ -685,10 +691,12 @@ public class ExtenderUtil {
 
             if (files.containsKey(r.getPath())) {
                 IResource previous = files.get(r.getPath());
+                TimeProfiler.stop();
                 throw new CompileExceptionError(r, 0, String.format("The files' relative path conflict:\n'%s' and\n'%s", r.getAbsPath(), previous.getAbsPath()));
             }
             files.put(r.getPath(), r);
         }
+        TimeProfiler.stop();
     }
 
     /** Get the platform manifests from the extensions


### PR DESCRIPTION
Make sure the `.defignore` file is taken into account when caching all project paths in `findResourcePathsByExtension`.

# Technical changes

Mostly restored logic from old code path when we used to use `.defignore`  + small refactoring
On a test project **10m -> 35s** for pre-creation stage
I want this fix to be included in 1.12.3 beta