### PR TITLE
Apply skeleton transforms for orphaned joints

### DIFF
--- a/engine/rig/src/rig.cpp
+++ b/engine/rig/src/rig.cpp
@@ -507,7 +507,7 @@ namespace dmRig
         }
     }
 
-    static void UpdatePoseTransforms(dmArray<BonePose>& pose)
+    static void UpdatePoseTransforms(const dmRigDDF::Skeleton* skeleton, dmArray<BonePose>& pose)
     {
         uint32_t bone_count = pose.Size();
         for (uint32_t bi = 0; bi < bone_count; ++bi)
@@ -515,9 +515,19 @@ namespace dmRig
             BonePose& bp = pose[bi];
 
             if (bp.m_ParentIndex != INVALID_BONE_INDEX)
+            {
                 bp.m_World = dmTransform::Mul(pose[bp.m_ParentIndex].m_World, bp.m_Local);
+            }
             else
-                bp.m_World = bp.m_Local;
+            {
+                // Apply the skeleton bone transform when the there is no parent.
+                const dmRigDDF::Bone* sk_bone = &skeleton->m_Bones[bi];
+                // Separate the anscestor (everything "above" this joint hierarchy-wise) from the local transform of this joint.
+                const Matrix4 world_bind = dmTransform::ToMatrix4(sk_bone->m_World);
+                const Matrix4 local_bind = dmTransform::ToMatrix4(sk_bone->m_Local);
+                const Matrix4 ancestor = world_bind * dmVMath::Inverse(local_bind);
+                bp.m_World = dmTransform::ToTransform(ancestor * dmTransform::ToMatrix4(bp.m_Local));
+            }
         }
     }
 
@@ -636,7 +646,7 @@ namespace dmRig
             }
         }
 
-        UpdatePoseTransforms(pose);
+        UpdatePoseTransforms(skeleton, pose);
 
         CommitPoseMatrixToCache(context, instance);
     }


### PR DESCRIPTION
In the cases where animations coming from a .gltf file where the root node of a skeleton has non-identity transform, the skinned objects in the engine would not be correctly placed when animating. 

NOTE: This could mean that your projects with skinned characters might be rotated, scaled or positioned differently now when animating. If this happens, you need to fix this in your authoring package (e.g Blender) and re-export the offending .gltf files!

Fixes #11054 