### PR TITLE
Don't apply skinning twice

### DIFF
--- a/engine/gamesys/src/gamesys/components/comp_model.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_model.cpp
@@ -424,13 +424,11 @@ namespace dmGameSystem
         return component->m_RigInstance && render_item->m_Buffers->m_RigModelVertexFormat == RIG_MODEL_VERTEX_FORMAT_SKINNED;
     }
 
-    // GLTF may parent a skinned mesh under a bone (m_BoneId / m_BoneIndex). GPU skinning already applies
-    // bone deformation; multiplying bone_pose.m_World again would double-transform (wrong bind pose when
-    // idle skinning is skipped, and misalignment when animating).
-    static inline bool ShouldApplyBoneParentToWorldTransform(const MeshRenderItem& item)
+    // True for a static mesh hung under a bone: world = bone_pose × node local. Skinned meshes omit the bone here since GPU skinning handles it.
+    // Otherwise static meshes parented under a bone would be transformed twice.
+    static inline bool IsRigidBoneParentedRenderItem(const MeshRenderItem& item)
     {
-        return item.m_BoneIndex != dmRig::INVALID_BONE_INDEX
-            && item.m_Buffers->m_RigModelVertexFormat != RIG_MODEL_VERTEX_FORMAT_SKINNED;
+        return item.m_BoneIndex != dmRig::INVALID_BONE_INDEX && item.m_Buffers->m_RigModelVertexFormat == RIG_MODEL_VERTEX_FORMAT_STATIC;
     }
 
     static inline dmGraphics::CoordinateSpace GetRenderMaterialCoordinateSpace(dmRender::HMaterial material)
@@ -2135,7 +2133,7 @@ namespace dmGameSystem
                 dmArray<dmRig::BonePose>& pose = *dmRig::GetPose(c->m_RigInstance);
 
                 dmVMath::Matrix4 model_matrix;
-                if (ShouldApplyBoneParentToWorldTransform(*render_item))
+                if (IsRigidBoneParentedRenderItem(*render_item))
                 {
                     dmRig::BonePose bone_pose = pose[render_item->m_BoneIndex];
                     model_matrix = dmTransform::ToMatrix4(bone_pose.m_World) * dmTransform::ToMatrix4(render_item->m_Model->m_Local);
@@ -2301,7 +2299,7 @@ namespace dmGameSystem
             // For skinned models: bone hierarchy is applied in the vertex shader, not via bone_pose here.
             // For rigid meshes parented to a bone: apply bone_pose.m_World * node.local.
             // For non-skinned models without bone parent: m_Local contains node.world (flattened hierarchy).
-            if (ShouldApplyBoneParentToWorldTransform(item))
+            if (IsRigidBoneParentedRenderItem(item))
             {
                 dmRig::BonePose bone_pose = (*pose)[item.m_BoneIndex];
                 item.m_World = world * (dmTransform::ToMatrix4(bone_pose.m_World) * dmTransform::ToMatrix4(model->m_Local));

--- a/engine/gamesys/src/gamesys/components/comp_model.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_model.cpp
@@ -424,6 +424,15 @@ namespace dmGameSystem
         return component->m_RigInstance && render_item->m_Buffers->m_RigModelVertexFormat == RIG_MODEL_VERTEX_FORMAT_SKINNED;
     }
 
+    // GLTF may parent a skinned mesh under a bone (m_BoneId / m_BoneIndex). GPU skinning already applies
+    // bone deformation; multiplying bone_pose.m_World again would double-transform (wrong bind pose when
+    // idle skinning is skipped, and misalignment when animating).
+    static inline bool ShouldApplyBoneParentToWorldTransform(const MeshRenderItem& item)
+    {
+        return item.m_BoneIndex != dmRig::INVALID_BONE_INDEX
+            && item.m_Buffers->m_RigModelVertexFormat != RIG_MODEL_VERTEX_FORMAT_SKINNED;
+    }
+
     static inline dmGraphics::CoordinateSpace GetRenderMaterialCoordinateSpace(dmRender::HMaterial material)
     {
         return dmRender::GetMaterialVertexSpace(material) == dmRenderDDF::MaterialDesc::VERTEX_SPACE_LOCAL ? dmGraphics::COORDINATE_SPACE_LOCAL : dmGraphics::COORDINATE_SPACE_WORLD;
@@ -1709,7 +1718,9 @@ namespace dmGameSystem
                 instance_data->m_InstanceData.m_WorldTransform  = instance_render_item->m_World;
                 instance_data->m_InstanceData.m_NormalTransform = dmRender::GetNormalMatrix(render_context, instance_data->m_InstanceData.m_WorldTransform);
 
-                if (dmRig::IsAnimating(instance_component->m_RigInstance))
+                // Skinning must run whenever the mesh is skinned: bind pose matrices are written every frame
+                // (see dmRig::DoAnimate when not playing an animation) so idle pose matches animated pose.
+                if (dmRig::GetPoseMatrixCacheDataOffset(world->m_RigContext, instance_component->m_RigInstance) != dmRig::INVALID_POSE_MATRIX_CACHE_ENTRY)
                 {
                     // *3 = 3 vectors per matrix (we store only first 3 columns, 4th is always 0,0,0,1)
                     uint32_t cache_offset = 3 * dmRig::GetPoseMatrixCacheDataOffset(world->m_RigContext, instance_component->m_RigInstance);
@@ -1889,10 +1900,9 @@ namespace dmGameSystem
                     constants = GetScratchConstantBuffer(world);
                 }
 
-                // Initialize to no animation
                 dmVMath::Vector4 animation_data(0.0f, 0.0f, 0.0f, 0.0f);
 
-                if (dmRig::IsAnimating(component->m_RigInstance))
+                if (dmRig::GetPoseMatrixCacheDataOffset(world->m_RigContext, component->m_RigInstance) != dmRig::INVALID_POSE_MATRIX_CACHE_ENTRY)
                 {
                     // *3 = 3 vectors per matrix (we store only first 3 columns, 4th is always 0,0,0,1)
                     uint32_t cache_offset = 3 * dmRig::GetPoseMatrixCacheDataOffset(world->m_RigContext, component->m_RigInstance);
@@ -2125,7 +2135,7 @@ namespace dmGameSystem
                 dmArray<dmRig::BonePose>& pose = *dmRig::GetPose(c->m_RigInstance);
 
                 dmVMath::Matrix4 model_matrix;
-                if (render_item->m_BoneIndex != dmRig::INVALID_BONE_INDEX)
+                if (ShouldApplyBoneParentToWorldTransform(*render_item))
                 {
                     dmRig::BonePose bone_pose = pose[render_item->m_BoneIndex];
                     model_matrix = dmTransform::ToMatrix4(bone_pose.m_World) * dmTransform::ToMatrix4(render_item->m_Model->m_Local);
@@ -2287,10 +2297,11 @@ namespace dmGameSystem
             if (!item.m_Enabled)
                 continue;
             dmRigDDF::Model* model = item.m_Model;
-            // Hierarchy handling: See ModelUtil.java:loadModel() for how model->m_Local is set
-            // For skinned models: m_Local contains node.local, hierarchy applied via bone_pose.m_World
-            // For non-skinned models: m_Local contains node.world, hierarchy already flattened
-            if (item.m_BoneIndex != dmRig::INVALID_BONE_INDEX)
+            // Hierarchy handling: See ModelUtil.java:loadModel() for how model->m_Local is set.
+            // For skinned models: bone hierarchy is applied in the vertex shader, not via bone_pose here.
+            // For rigid meshes parented to a bone: apply bone_pose.m_World * node.local.
+            // For non-skinned models without bone parent: m_Local contains node.world (flattened hierarchy).
+            if (ShouldApplyBoneParentToWorldTransform(item))
             {
                 dmRig::BonePose bone_pose = (*pose)[item.m_BoneIndex];
                 item.m_World = world * (dmTransform::ToMatrix4(bone_pose.m_World) * dmTransform::ToMatrix4(model->m_Local));

--- a/engine/rig/src/rig.cpp
+++ b/engine/rig/src/rig.cpp
@@ -577,6 +577,18 @@ namespace dmRig
         // NOTE we previously checked for (!instance->m_Enabled || !instance->m_AddedToUpdate) here also
         if (!IsAnimating(instance))
         {
+            // Skinned meshes sample the pose matrix cache every frame. If we skip the cache write while
+            // idle, the vertex shader falls back to non-skinned positions which can cause a disparity
+            // between authoring tools and animated result. Instead, we write the non-animated
+            // skeleton bind pose whenever this instance owns cache space.
+            if (instance->m_Skeleton && instance->m_PoseMatrixCacheIndex != INVALID_POSE_MATRIX_CACHE_ENTRY)
+            {
+                dmArray<BonePose>& pose = instance->m_Pose;
+                const dmRigDDF::Skeleton* skeleton = instance->m_Skeleton;
+                ResetPose(skeleton, pose);
+                UpdatePoseTransforms(skeleton, pose);
+                CommitPoseMatrixToCache(context, instance);
+            }
             return;
         }
 


### PR DESCRIPTION
An issue has been fixed where world transforms are applied twice for static non-skinned meshes that are anchored to skeletal bones. Essentially, in some cases meshes would render in an incorrect position when playing an animation as opposed to the bind pose (i.e when no animation is playing). 

Fixes #11196