### PR TITLE
Allow go.property() only in .script files

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/LuaBuilderTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/LuaBuilderTest.java
@@ -118,6 +118,30 @@ public class LuaBuilderTest extends AbstractProtoBuilderTest {
     }
 
     @Test
+    public void testGoPropertyOnlyAllowedInScriptFiles() throws Exception {
+        String source = "go.property(\"number\", 1)";
+        String resourceSource = "go.property(\"material\", resource.material(\"/missing.material\"))";
+        String invalidArgsSource = "go.property()";
+        String invalidValueSource = "go.property(\"value\", \"string\")";
+        String invalidLocationSource = "function init() go.property(\"number\", 1) end";
+
+        LuaModule luaModule = getMessage(build("/test.script", source), LuaModule.class);
+        assertEquals(1, luaModule.getProperties().getNumberEntriesCount());
+
+        for (String path : new String[]{"/test.lua", "/test.gui_script", "/test.render_script"}) {
+            for (String invalidSource : new String[]{source, resourceSource, invalidArgsSource, invalidValueSource, invalidLocationSource}) {
+                try {
+                    build(path, invalidSource);
+                    fail("Expected go.property rejection for " + path);
+                } catch (CompileExceptionError e) {
+                    assertEquals("go.property cannot be used in this file type", e.getMessage());
+                    assertEquals(1, e.getLineNumber());
+                }
+            }
+        }
+    }
+
+    @Test
     public void testUseUncompressedLuaSource() throws Exception {
         Project p = getProject();
         p.setOption("use-uncompressed-lua-source", "true");

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/LuaBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/LuaBuilder.java
@@ -80,6 +80,10 @@ public abstract class LuaBuilder extends Builder {
 
     private LuaScanner.Result luaScannerResult;
 
+    protected boolean allowGoProperties() {
+        return false;
+    }
+
     /**
      * Get a LuaScanner instance for a resource
      * This will cache the LuaScanner instance per resource to avoid parsing the
@@ -113,6 +117,9 @@ public abstract class LuaBuilder extends Builder {
             }
 
             luaScannerResult = LuaScanner.parse(script, Bob.VARIANT_DEBUG.equals(variant));
+            if (!allowGoProperties() && !luaScannerResult.properties().isEmpty()) {
+                throw new CompileExceptionError(resource, luaScannerResult.properties().getFirst().startLine() + 1, "go.property cannot be used in this file type");
+            }
             for (LuaScanner.ParseError error : luaScannerResult.errors()) {
                 throw new CompileExceptionError(resource, error.startLine() + 1, error.message());
             }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ScriptBuilders.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ScriptBuilders.java
@@ -26,7 +26,12 @@ public class ScriptBuilders {
 
     @ProtoParams(srcClass = LuaModule.class, messageClass = LuaModule.class)
     @BuilderParams(name = "Script", inExts = ".script", outExt = ".scriptc", paramsForSignature = {"use-uncompressed-lua-source", "use-lua-bytecode-delta", "platform", "architectures", "variant", "prometheus-disabled"})
-    public static class ScriptBuilder extends LuaBuilder {}
+    public static class ScriptBuilder extends LuaBuilder {
+        @Override
+        protected boolean allowGoProperties() {
+            return true;
+        }
+    }
 
     @ProtoParams(srcClass = LuaModule.class, messageClass = LuaModule.class)
     @BuilderParams(name = "GuiScript", inExts = ".gui_script", outExt = ".gui_scriptc", paramsForSignature = {"use-uncompressed-lua-source", "use-lua-bytecode-delta", "platform", "architectures", "variant", "prometheus-disabled"})

--- a/editor/.idea/codeStyles/Project.xml
+++ b/editor/.idea/codeStyles/Project.xml
@@ -88,6 +88,8 @@
           <entry key="editor.yaml/with-error-translation" value="-1" />
           <entry key="integration.build-test/with-build-results" value="-1" />
           <entry key="integration.gui-test/with-visible-layout!" value="-1" />
+          <entry key="integration.lsp-test/await-lsp" value="-1" />
+          <entry key="integration.lsp-test/with-scratch-project" value="-1" />
           <entry key="integration.test-util/set-code-editor-lines" value="-1" />
           <entry key="integration.test-util/set-code-editor-lines!" value="-1" />
           <entry key="integration.test-util/with-changes-reverted" value="-1" />

--- a/editor/AGENTS.md
+++ b/editor/AGENTS.md
@@ -1,12 +1,6 @@
-# Repository Guidelines
-
-## Coding Style
-
-Use offensive/fail-fast coding style.
+Be concise.
+Offensive/fail-fast coding style.
 Keep requires sorted.
 Use variables and keywords with "?" suffix only to denote predicate functions, never boolean values.
-Never use lazy sequences, instead use transducers. See src/clj/util/coll.clj for alternatives of core clojure functions that use reduce instead of seq. See src/clj/util/eduction.clj for using eductions instead of unrealized sequences. 
-
-## Git Guidelines
-
+Use transducers instead of lazy sequences where possible. See src/clj/util/coll.clj for alternatives of core clojure functions that use reduce instead of seq. See src/clj/util/eduction.clj for using eductions instead of unrealized sequences. 
 Use git in read-only mode (e.g., status, diff), never stage/commit anything.

--- a/editor/resources/localization/en.editor_localization
+++ b/editor/resources/localization/en.editor_localization
@@ -2271,6 +2271,7 @@ error.vertex-attribute-normalize-float-data-type = Vertex attribute "{attribute}
 error.atlas-page-count-cannot-exceed = Atlas page count ({count}) cannot exceed {max} pages per atlas. GLES 2.0 support must be excluded in game.project > Runtime > Shader settings
 error.cubemap-image-sizes-differ = Cubemap image sizes differ:\n{right} = {right_size}\n{left} = {left_size}\n{top} = {top_size}\n{bottom} = {bottom_size}\n{front} = {front_size}\n{back} = {back_size}.
 error.lua-preprocessing-failed = Lua preprocessing failed.\n{error}
+error.go-property-disallowed = go.property cannot be used in this file type.
 error.transpiler-compilation-failed = Compilation failed: {error}
 error.animation-set-build-failed = Failed to build {resource}: {error}
 error.blend-mode-add-alpha-replaced = "{old}" has been replaced by "{new}".

--- a/editor/resources/localization/ru.editor_localization
+++ b/editor/resources/localization/ru.editor_localization
@@ -2271,6 +2271,7 @@ error.vertex-attribute-normalize-float-data-type = Вершинный атриб
 error.atlas-page-count-cannot-exceed = Количество страниц атласа ({count}) не может превышать {max} на один атлас. Поддержка GLES 2.0 должна быть отключена в game.project → Среда выполнения → Шейдер
 error.cubemap-image-sizes-differ = Размеры изображений кубической карты различаются\:\n{right} \= {right_size}\n{left} \= {left_size}\n{top} \= {top_size}\n{bottom} \= {bottom_size}\n{front} \= {front_size}\n{back} \= {back_size}.
 error.lua-preprocessing-failed = Ошибка препроцессинга Lua.\n{error}
+error.go-property-disallowed = go.property нельзя использовать в этом типе файла.
 error.transpiler-compilation-failed = Ошибка компиляции\: {error}
 error.animation-set-build-failed = Не удалось собрать {resource}\: {error}
 error.blend-mode-add-alpha-replaced = «{old}» был заменён на «{new}».

--- a/editor/src/clj/editor/code/script.clj
+++ b/editor/src/clj/editor/code/script.clj
@@ -200,33 +200,6 @@
           :script-property-type-boolean
           :script-property-type-resource))
 
-(def script-defs [{:ext "script"
-                   :label (localization/message "resource.type.script")
-                   :icon "icons/32/Icons_12-Script-type.png"
-                   :icon-class :script
-                   :category (localization/message "resource.category.scripts")
-                   :tags #{:component :debuggable :non-embeddable :overridable-properties}
-                   :tag-opts {:component {:transform-properties #{}}}}
-                  {:ext "render_script"
-                   :label (localization/message "resource.type.render-script")
-                   :icon "icons/32/Icons_12-Script-type.png"
-                   :icon-class :script
-                   :category (localization/message "resource.category.scripts")
-                   :tags #{:debuggable}}
-                  {:ext "gui_script"
-                   :label (localization/message "resource.type.gui-script")
-                   :icon "icons/32/Icons_12-Script-type.png"
-                   :icon-class :script
-                   :category (localization/message "resource.category.scripts")
-                   :tags #{:debuggable}}
-                  {:ext "lua"
-                   :label (localization/message "resource.type.lua")
-                   :icon "icons/32/Icons_11-Script-general.png"
-                   :icon-class :script
-                   :category (localization/message "resource.category.scripts")
-                   :annotations true
-                   :tags #{:debuggable}}])
-
 (defn- prop->key [p]
   (-> p :name properties/user-name->key))
 
@@ -405,16 +378,31 @@
               (update :properties into (map (partial lift-error _node-id)) script-property-entries)
               (update :display-order into (map prop->key) script-properties))))
 
-(g/defnk produce-build-targets [^:unsafe _evaluation-context _node-id resource lines lua-preprocessors script-properties original-resource-property-build-targets]
+(g/defnk produce-script-build-targets [^:unsafe _evaluation-context _node-id resource lines lua-preprocessors script-properties original-resource-property-build-targets]
   (let [basis (:basis _evaluation-context)
         project (project/get-project basis _node-id)]
     (script-compilation/build-targets
       _node-id
       resource
       lines
+      true
       lua-preprocessors
       script-properties
       original-resource-property-build-targets
+      #(project/get-resource-node project % _evaluation-context)
+      _evaluation-context)))
+
+(g/defnk produce-lua-build-targets [^:unsafe _evaluation-context _node-id resource lines lua-preprocessors]
+  (let [basis (:basis _evaluation-context)
+        project (project/get-project basis _node-id)]
+    (script-compilation/build-targets
+      _node-id
+      resource
+      lines
+      false
+      lua-preprocessors
+      []
+      []
       #(project/get-resource-node project % _evaluation-context)
       _evaluation-context)))
 
@@ -431,11 +419,29 @@
     (filter data/breakpoint-region?)
     (map (partial region->breakpoint resource))))
 
-(g/defnode ScriptNode
+(g/defnode LuaCodeNode
   (inherits r/CodeEditorResourceNode)
 
   (input lua-preprocessors g/Any)
   (input script-intelligence-completions script-intelligence/ScriptCompletions)
+
+  ;; Breakpoints output only consumed by project (array input of all code files)
+  ;; and already cached there. Changing breakpoints and pulling project breakpoints
+  ;; does imply a pass over all code nodes to produce new breakpoints, but does
+  ;; not seem to be much of a perf issue.
+  (output breakpoints project/Breakpoints produce-breakpoints)
+
+  (output completions g/Any :cached (gu/passthrough script-intelligence-completions))
+  (output resource-with-lines script-annotations/ResourceWithLines (g/fnk [resource lines :as ret] ret)))
+
+(g/defnode LuaNode
+  (inherits LuaCodeNode)
+
+  (output build-targets g/Any :cached produce-lua-build-targets))
+
+(g/defnode ScriptNode
+  (inherits LuaCodeNode)
+
   (input script-property-name+node-ids NameNodeIDPair :array)
   (input script-property-entries ScriptPropertyEntries :array)
 
@@ -473,19 +479,42 @@
                                      evaluation-context project value self
                                      [[:build-targets :original-resource-property-build-targets]]))))))))
 
-  ;; Breakpoints output only consumed by project (array input of all code files)
-  ;; and already cached there. Changing breakpoints and pulling project breakpoints
-  ;; does imply a pass over all ScriptNodes to produce new breakpoints, but does
-  ;; not seem to be much of a perf issue.
-  (output breakpoints project/Breakpoints produce-breakpoints)
-
   (output _properties g/Properties :cached produce-properties)
-  (output build-targets g/Any :cached produce-build-targets)
-  (output completions g/Any :cached (gu/passthrough script-intelligence-completions))
-  (output resource-with-lines script-annotations/ResourceWithLines (g/fnk [resource lines :as ret] ret))
+  (output build-targets g/Any :cached produce-script-build-targets)
   (output resource-property-build-targets g/Any (gu/passthrough resource-property-build-targets))
   (output script-property-entries ScriptPropertyEntries (g/fnk [script-property-entries] (reduce into {} script-property-entries)))
   (output script-property-node-ids-by-name NameNodeIDMap (g/fnk [script-property-name+node-ids] (into {} script-property-name+node-ids))))
+
+(def script-defs [{:ext "script"
+                   :node-type ScriptNode
+                   :label (localization/message "resource.type.script")
+                   :icon "icons/32/Icons_12-Script-type.png"
+                   :icon-class :script
+                   :category (localization/message "resource.category.scripts")
+                   :tags #{:component :debuggable :non-embeddable :overridable-properties}
+                   :tag-opts {:component {:transform-properties #{}}}}
+                  {:ext "render_script"
+                   :node-type LuaNode
+                   :label (localization/message "resource.type.render-script")
+                   :icon "icons/32/Icons_12-Script-type.png"
+                   :icon-class :script
+                   :category (localization/message "resource.category.scripts")
+                   :tags #{:debuggable}}
+                  {:ext "gui_script"
+                   :node-type LuaNode
+                   :label (localization/message "resource.type.gui-script")
+                   :icon "icons/32/Icons_12-Script-type.png"
+                   :icon-class :script
+                   :category (localization/message "resource.category.scripts")
+                   :tags #{:debuggable}}
+                  {:ext "lua"
+                   :node-type LuaNode
+                   :label (localization/message "resource.type.lua")
+                   :icon "icons/32/Icons_11-Script-general.png"
+                   :icon-class :script
+                   :category (localization/message "resource.category.scripts")
+                   :annotations true
+                   :tags #{:debuggable}}])
 
 (defn- additional-load-fn
   [annotations project self resource]
@@ -504,7 +533,6 @@
         :let [args (-> def
                        (dissoc :annotations)
                        (assoc
-                         :node-type ScriptNode
                          :built-pb-class script-compilation/built-pb-class
                          :language "lua"
                          :lazy-loaded false

--- a/editor/src/clj/editor/code/script_compilation.clj
+++ b/editor/src/clj/editor/code/script_compilation.clj
@@ -40,6 +40,9 @@
 
 (def ^Class built-pb-class Lua$LuaModule)
 
+(def ^:const go-property-disallowed-message
+  (localization/message "error.go-property-disallowed"))
+
 (defn script-property-type->go-prop-type
   "Controls how script property values are represented in the file formats."
   [script-property-type]
@@ -163,14 +166,21 @@
     (let [line-number (some-> line-number-string Long/parseLong)]
       (pair proj-path line-number))))
 
-(defn- lua-info-errors [_node-id resource lua-info]
-  (->> lua-info
-       :errors
-       (e/map
-         (fn [{:keys [message cursor-range]}]
-           (g/->error _node-id :modified-lines :fatal resource message {:cursor-range cursor-range})))))
+(defn- lua-info-errors [_node-id resource lua-info allow-go-properties]
+  (e/concat
+    (->> lua-info
+         :errors
+         (e/map
+           (fn [{:keys [message cursor-range]}]
+             (g/->error _node-id :modified-lines :fatal resource message {:cursor-range cursor-range}))))
+    (when-not allow-go-properties
+      (->> lua-info
+           :script-properties
+           (e/map
+             (fn [script-property]
+               (g/->error _node-id :modified-lines :fatal resource go-property-disallowed-message {:cursor-range (:cursor-range (meta script-property))})))))))
 
-(defn build-targets [_node-id resource lines lua-preprocessors script-properties original-resource-property-build-targets proj-path->resource-node evaluation-context]
+(defn build-targets [_node-id resource lines allow-go-properties lua-preprocessors script-properties original-resource-property-build-targets proj-path->resource-node evaluation-context]
   (let [workspace (resource/workspace resource)]
     (if-some [errors
               (not-empty
@@ -201,7 +211,7 @@
           (let [preprocessed-lua-info
                 (with-open [reader (data/lines-reader preprocessed-lines)]
                   (lua-parser/lua-info workspace valid-resource-kind? reader evaluation-context))]
-            (g/precluding-errors (lua-info-errors _node-id resource preprocessed-lua-info)
+            (g/precluding-errors (lua-info-errors _node-id resource preprocessed-lua-info allow-go-properties)
               (let [preprocessed-script-properties (lua-info->script-properties preprocessed-lua-info)
                     preprocessed-modules (lua-info->modules preprocessed-lua-info)
                     preprocessed-go-props-with-source-resources

--- a/editor/src/clj/editor/code/transpilers.clj
+++ b/editor/src/clj/editor/code/transpilers.clj
@@ -105,7 +105,7 @@
                             ;; a build error that points to a lua file that does not exist in the
                             ;; resource tree
                             (let [resource (resource/make-file-resource workspace (str output-dir) file [] fn/constantly-false fn/constantly-false)
-                                  build-targets (script-compilation/build-targets build-file-node-id resource (code.util/split-lines (slurp resource)) lua-preprocessors [] [] proj-path->node-id _evaluation-context)]
+                                  build-targets (script-compilation/build-targets build-file-node-id resource (code.util/split-lines (slurp resource)) false lua-preprocessors [] [] proj-path->node-id _evaluation-context)]
                               (pair (resource/proj-path resource) build-targets)))))
                       (fs/file-walker output-dir false))))
           (catch Exception e

--- a/editor/test/integration/lsp_test.clj
+++ b/editor/test/integration/lsp_test.clj
@@ -24,50 +24,80 @@
             [editor.lsp.base :as lsp.base]
             [editor.lsp.jsonrpc :as lsp.jsonrpc]
             [editor.lsp.server :as lsp.server]
+            [editor.ui :as ui]
             [editor.workspace :as workspace]
             [integration.test-util :as test-util]
             [support.async-support :as async-support]
-            [support.test-support :as test-support])
+            [support.test-support :as test-support]
+            [util.coll :as coll])
   (:import [java.io PipedInputStream PipedOutputStream]))
 
 (set! *warn-on-reflection* true)
 
-(defmacro await-lsp [& forms]
-  `(test-util/with-ui-run-later-rebound
-     (let [result# (do ~@forms)]
-       (Thread/sleep 100)
-       result#)))
+(def ^:private await-lsp-settle-rounds 5)
+(def ^:private await-lsp-settle-sleep-ms 20)
+
+(defmacro await-lsp [lsp & forms]
+  `(let [lsp# ~lsp
+         run-laters# (atom [])]
+     (with-redefs [ui/do-run-later (fn [run-later-fn#]
+                                     (swap! run-laters# conj run-later-fn#))]
+       (let [result# (do ~@forms)]
+         (loop [remaining-settle-rounds# await-lsp-settle-rounds]
+           (lsp/await lsp#)
+           (Thread/sleep (unchecked-long await-lsp-settle-sleep-ms))
+           (let [pending-run-laters# @run-laters#]
+             (reset! run-laters# [])
+             (cond
+               (not (coll/empty? pending-run-laters#))
+               (do
+                 (run! #(%)
+                       pending-run-laters#)
+                 (recur await-lsp-settle-rounds))
+
+               (pos? remaining-settle-rounds#)
+               (recur (dec remaining-settle-rounds#))
+
+               :else
+               result#)))))))
+
+(defmacro with-scratch-project [project-path & forms]
+  `(test-util/with-scratch-project ~project-path
+     (try
+       ~@forms
+       (finally
+         (await-lsp (lsp/get-node-lsp ~'project))))))
 
 (defn- set-servers! [lsp new-servers]
-  (await-lsp
+  (await-lsp lsp
     (lsp/set-servers! lsp new-servers)))
 
 (defn- open-view! [lsp view-node resource lines]
-  (await-lsp
+  (await-lsp lsp
     (lsp/open-view! lsp view-node resource lines)))
 
 (defn- close-view! [lsp view-node]
-  (await-lsp
+  (await-lsp lsp
     (lsp/close-view! lsp view-node)))
 
-(defn- edit-file! [code-resource-node-id lines-or-text]
-  (await-lsp
+(defn- edit-file! [lsp code-resource-node-id lines-or-text]
+  (await-lsp lsp
     (test-util/set-code-editor-source! code-resource-node-id lines-or-text)))
 
-(defn- rename-file! [resource new-file-name]
-  (await-lsp
+(defn- rename-file! [lsp resource new-file-name]
+  (await-lsp lsp
     (asset-browser/rename resource new-file-name test-util/localization)))
 
-(defn- delete-file! [resource]
-  (await-lsp
+(defn- delete-file! [lsp resource]
+  (await-lsp lsp
     (asset-browser/delete [resource])))
 
-(defn- resource-sync! [workspace]
-  (await-lsp
+(defn- resource-sync! [lsp workspace]
+  (await-lsp lsp
     (workspace/resource-sync! workspace)))
 
-(defn- handler-run! [command project]
-  (await-lsp
+(defn- handler-run! [command lsp project]
+  (await-lsp lsp
     (test-util/handler-run command [{:name :global :env {:project-graph (project/graph project)}}] {})))
 
 (def ^:private undo! (partial handler-run! :edit.undo))
@@ -75,28 +105,50 @@
 (def ^:private redo! (partial handler-run! :edit.redo))
 
 (defn- pull-diagnostics! [lsp & args]
-  (await-lsp
+  (await-lsp lsp
     (let [ret (promise)]
       (apply lsp/pull-workspace-diagnostics! lsp ret args)
       @ret)))
 
 (defn- hover! [lsp resource cursor]
-  (await-lsp
+  (await-lsp lsp
     (let [ret (promise)]
       (lsp/hover! lsp resource cursor ret)
       @ret)))
 
 (defn- prepare-rename [lsp resource cursor]
-  (await-lsp
+  (await-lsp lsp
     (let [ret (promise)]
       (lsp/prepare-rename lsp resource cursor ret)
       @ret)))
 
 (defn- rename [lsp prepared-range new-name]
-  (await-lsp
+  (await-lsp lsp
     (let [ret (promise)]
       (lsp/rename lsp prepared-range new-name ret)
       @ret)))
+
+(defn- await-until [pred]
+  (async-support/eventually
+    (a/go-loop []
+      (if-let [value (pred)]
+        value
+        (do
+          (<! (a/timeout 10))
+          (recur))))))
+
+(defn- await-value= [expected f]
+  (await-until
+    (fn []
+      (let [actual (f)]
+        (when (= expected actual)
+          actual)))))
+
+(defmacro await= [expected actual-expr]
+  `(let [expected# ~expected]
+     (await-until
+       (fn []
+         (= expected# ~actual-expr)))))
 
 (defn- make-test-server-launcher [request-handlers]
   (reify lsp.server/Launcher
@@ -144,16 +196,15 @@
 
 (deftest lsp-server-test
   (testing "Initialize + open text document -> should publish diagnostics"
-    (test-util/with-scratch-project "test/resources/lsp_project"
+    (with-scratch-project "test/resources/lsp_project"
       (let [in (a/chan 10)
             out (a/chan 10)]
-        (await-lsp
-          (lsp.server/make
-            project
-            (make-test-server-launcher default-handlers)
-            in out
-            :on-publish-diagnostics #(apply vector :on-publish-diagnostics %&)
-            :on-initialized #(vector :on-initialized %)))
+        (lsp.server/make
+          project
+          (make-test-server-launcher default-handlers)
+          in out
+          :on-publish-diagnostics #(apply vector :on-publish-diagnostics %&)
+          :on-initialized #(vector :on-initialized %))
         (is (= [[:on-initialized
                  {:text-document-sync {:open-close true
                                        :change :incremental}
@@ -167,13 +218,12 @@
                  (test-util/resource workspace "/foo.json")
                  {:items [(assoc (data/->CursorRange (data/->Cursor 0 0) (data/->Cursor 0 1))
                             :message "It's a bad start!" :severity :error)]}]]
-               (await-lsp
-                 (async-support/eventually
-                   (a/go
-                     (>! in (lsp.server/open-text-document (test-util/resource workspace "/foo.json") foo-json-lines))
-                     (<! (a/timeout 10))
-                     (a/close! in)
-                     (<! (a/reduce conj [] out)))))))))))
+               (async-support/eventually
+                 (a/go
+                   (>! in (lsp.server/open-text-document (test-util/resource workspace "/foo.json") foo-json-lines))
+                   (<! (a/timeout 10))
+                   (a/close! in)
+                   (<! (a/reduce conj [] out))))))))))
 
 (g/defnode LSPViewNode
   (property diagnostics g/Any (default []))
@@ -181,7 +231,7 @@
   (property completion-trigger-characters g/Any (default #{})))
 
 (deftest start-open-order-test
-  (test-util/with-scratch-project "test/resources/lsp_project"
+  (with-scratch-project "test/resources/lsp_project"
     (let [lsp (lsp/get-node-lsp project)]
       (testing "Start server + open resource -> should receive diagnostics"
         (let [;; set servers
@@ -190,9 +240,9 @@
               ;; open view
               view-node (g/make-node! (g/node-id->graph-id app-view) LSPViewNode)
               _ (open-view! lsp view-node (test-util/resource workspace "/foo.json") foo-json-lines)]
-          (is (= [(assoc (data/->CursorRange (data/->Cursor 0 0) (data/->Cursor 0 1))
-                    :type :diagnostic :hoverable true :messages ["It's a bad start!"] :severity :error)]
-                 (g/node-value view-node :diagnostics)))
+          (is (await= [(assoc (data/->CursorRange (data/->Cursor 0 0) (data/->Cursor 0 1))
+                         :type :diagnostic :hoverable true :messages ["It's a bad start!"] :severity :error)]
+                      (g/node-value view-node :diagnostics)))
           (close-view! lsp view-node)))
       (testing "Open resource + start server -> should receive diagnostics"
         (let [;; open view
@@ -201,9 +251,9 @@
               ;; set servers
               _ (set-servers! lsp #{{:languages #{"json"}
                                      :launcher (make-test-server-launcher default-handlers)}})]
-          (is (= [(assoc (data/->CursorRange (data/->Cursor 0 0) (data/->Cursor 0 1))
-                    :type :diagnostic :hoverable true :messages ["It's a bad start!"] :severity :error)]
-                 (g/node-value view-node :diagnostics)))
+          (is (await= [(assoc (data/->CursorRange (data/->Cursor 0 0) (data/->Cursor 0 1))
+                         :type :diagnostic :hoverable true :messages ["It's a bad start!"] :severity :error)]
+                      (g/node-value view-node :diagnostics)))
           (close-view! lsp view-node))))))
 
 (deftest text-sync-kind-test
@@ -217,7 +267,7 @@
                                                       (swap! change-notifications conj [sync-kind v]))
                            "shutdown" (constantly nil)
                            "exit" (constantly nil)})]
-      (test-util/with-scratch-project "test/resources/lsp_project"
+      (with-scratch-project "test/resources/lsp_project"
         (let [lsp (lsp/get-node-lsp project)
               _ (set-servers!
                   lsp
@@ -233,27 +283,28 @@
               lines (g/node-value foo-node :lines)
               _ (open-view! lsp view-node (test-util/resource workspace "/foo.json") lines)
               _ (edit-file!
+                  lsp
                   foo-node
                   (data/splice-lines lines {data/document-start-cursor-range ["NEWTEXT"]}))]
-          (is (= #{[lsp.server/lsp-text-document-sync-kind-incremental
-                    {:textDocument {:uri (lsp.server/resource-uri foo-resource)
-                                    :version 1}
-                     :contentChanges [{:range {:start {:line 0
-                                                       :character 0}
-                                               :end {:line 0
-                                                     :character 0}}
-                                       :text "NEWTEXT"}]}]
-                   [lsp.server/lsp-text-document-sync-kind-full
-                    {:textDocument {:uri (lsp.server/resource-uri foo-resource)
-                                    :version 1}
-                     :contentChanges [{:text "NEWTEXT{\"asd\": 1}"}]}]}
-                 @change-notifications))
-          (edit-file! foo-node lines)
+          (is (await= #{[lsp.server/lsp-text-document-sync-kind-incremental
+                         {:textDocument {:uri (lsp.server/resource-uri foo-resource)
+                                         :version 1}
+                          :contentChanges [{:range {:start {:line 0
+                                                            :character 0}
+                                                    :end {:line 0
+                                                          :character 0}}
+                                            :text "NEWTEXT"}]}]
+                        [lsp.server/lsp-text-document-sync-kind-full
+                         {:textDocument {:uri (lsp.server/resource-uri foo-resource)
+                                         :version 1}
+                          :contentChanges [{:text "NEWTEXT{\"asd\": 1}"}]}]}
+                      @change-notifications))
+          (edit-file! lsp foo-node lines)
           (close-view! lsp view-node))))))
 
 (deftest polled-resources-test
   (testing "Modifying resources without any views should make the language servers open the document anyway"
-    (test-util/with-scratch-project "test/resources/lsp_project"
+    (with-scratch-project "test/resources/lsp_project"
       (let [server-opened-docs (atom #{})
             lsp (lsp/get-node-lsp project)
             foo-resource (test-util/resource workspace "/foo.json")
@@ -274,23 +325,25 @@
                                 "exit" (constantly nil)})}})
 
             ;; modify => dirty
-            _ (edit-file! foo-node "{}")
-            _ (is (= #{(lsp.server/resource-uri foo-resource)} @server-opened-docs))
+            _ (edit-file! lsp foo-node "{}")
+            _ (is (await= #{(lsp.server/resource-uri foo-resource)}
+                          @server-opened-docs))
 
             ;; modify to initial => clean
-            _ (edit-file! foo-node initial-source)
-            _ (is (= #{} @server-opened-docs))
+            _ (edit-file! lsp foo-node initial-source)
+            _ (is (await= #{} @server-opened-docs))
 
             ;; undo => dirty again
-            _ (undo! project)
-            _ (is (= #{(lsp.server/resource-uri foo-resource)} @server-opened-docs))
+            _ (undo! lsp project)
+            _ (is (await= #{(lsp.server/resource-uri foo-resource)}
+                          @server-opened-docs))
 
             ;; redo => clean again
-            _ (redo! project)
-            _ (is (= #{} @server-opened-docs))]))))
+            _ (redo! lsp project)
+            _ (is (await= #{} @server-opened-docs))]))))
 
 (deftest open-close-test
-  (test-util/with-scratch-project "test/resources/lsp_project"
+  (with-scratch-project "test/resources/lsp_project"
     (let [lsp (lsp/get-node-lsp project)
           server-opened-docs (atom #{})
           handlers {"initialize" (constantly {:capabilities {:textDocumentSync lsp.server/lsp-text-document-sync-kind-incremental}})
@@ -310,10 +363,10 @@
               foo-resource-uri (lsp.server/resource-uri foo-resource)
               ;; open view
               _ (open-view! lsp view-node foo-resource foo-json-lines)
-              _ (is (= #{foo-resource-uri} @server-opened-docs))
+              _ (is (await= #{foo-resource-uri} @server-opened-docs))
               ;; close view
               _ (close-view! lsp view-node)
-              _ (is (= #{} @server-opened-docs))]))
+              _ (is (await= #{} @server-opened-docs))]))
       (testing "Open view -> notify open, modify lines + close view -> still open"
         (let [_ (set-servers!
                   lsp
@@ -325,15 +378,15 @@
               foo-resource-uri (lsp.server/resource-uri foo-resource)
               ;; open view
               _ (open-view! lsp view-node foo-resource foo-json-lines)
-              _ (is (= #{foo-resource-uri} @server-opened-docs))
+              _ (is (await= #{foo-resource-uri} @server-opened-docs))
               ;; modify lines, close view
-              _ (edit-file! foo-resource-node "{}")
+              _ (edit-file! lsp foo-resource-node "{}")
               _ (close-view! lsp view-node)
-              _ (is (= #{foo-resource-uri} @server-opened-docs))])))))
+              _ (is (await= #{foo-resource-uri} @server-opened-docs))])))))
 
 (deftest resource-changes-test
   (testing "Modify lines -> notify open, rename file -> close + open modified"
-    (test-util/with-scratch-project "test/resources/lsp_project"
+    (with-scratch-project "test/resources/lsp_project"
       (let [lsp (lsp/get-node-lsp project)
             server-opened-docs (atom {})
             handlers {"initialize" (constantly {:capabilities {:textDocumentSync lsp.server/lsp-text-document-sync-kind-incremental}})
@@ -355,18 +408,18 @@
             foo-resource-uri (lsp.server/resource-uri foo-resource)
 
             ;; modify
-            _ (edit-file! foo-resource-node "{}")
-            _ (is (= {foo-resource-uri "{}"} @server-opened-docs))
+            _ (edit-file! lsp foo-resource-node "{}")
+            _ (is (await= {foo-resource-uri "{}"} @server-opened-docs))
 
             ;; rename foo.json to bar.json
-            _ (rename-file! [foo-resource] "bar")
+            _ (rename-file! lsp [foo-resource] "bar")
             bar-resource (test-util/resource workspace "/bar.json")
             bar-resource-uri (lsp.server/resource-uri bar-resource)
-            _ (is (= {bar-resource-uri "{}"} @server-opened-docs))]
-        (edit-file! (test-util/resource-node project "/bar.json") old-foo-content)
-        (rename-file! [bar-resource] "foo"))))
+            _ (is (await= {bar-resource-uri "{}"} @server-opened-docs))]
+        (edit-file! lsp (test-util/resource-node project "/bar.json") old-foo-content)
+        (rename-file! lsp [bar-resource] "foo"))))
   (testing "Open view -> notify open, change on disk + resource sync -> notify changed"
-    (test-util/with-scratch-project "test/resources/lsp_project"
+    (with-scratch-project "test/resources/lsp_project"
       (let [lsp (lsp/get-node-lsp project)
             change-notifications (atom [])
             server-opened-docs (atom #{})
@@ -392,18 +445,18 @@
             lines (g/node-value foo-resource-node :lines)
             ;; open view
             _ (open-view! lsp view-node foo-resource lines)
-            _ (is (= #{foo-resource-uri} @server-opened-docs))
+            _ (is (await= #{foo-resource-uri} @server-opened-docs))
             ;; modify on disk + sync
             _ (test-support/spit-until-new-mtime foo-resource "NEW_CONTENT")
-            _ (resource-sync! workspace)
-            _ (is (= [{:textDocument {:uri foo-resource-uri :version 1}
-                       :contentChanges [{:text "NEW_CONTENT"}]}]
-                     @change-notifications))]
+            _ (resource-sync! lsp workspace)
+            _ (is (await= [{:textDocument {:uri foo-resource-uri :version 1}
+                            :contentChanges [{:text "NEW_CONTENT"}]}]
+                          @change-notifications))]
         (test-support/spit-until-new-mtime foo-resource old-foo-content)
-        (resource-sync! workspace)
+        (resource-sync! lsp workspace)
         (close-view! lsp view-node))))
   (testing "Modify lines -> notify open; delete file + sync -> notify closed"
-    (test-util/with-scratch-project "test/resources/lsp_project"
+    (with-scratch-project "test/resources/lsp_project"
       (let [lsp (lsp/get-node-lsp project)
             server-opened-docs (atom #{})
             handlers {"initialize" (constantly {:capabilities {:textDocumentSync lsp.server/lsp-text-document-sync-kind-incremental}})
@@ -423,17 +476,17 @@
             foo-resource-node (test-util/resource-node project "/foo.json")
             foo-resource-uri (lsp.server/resource-uri foo-resource)
             ;; modify lines
-            _ (edit-file! foo-resource-node "{}")
-            _ (is (= #{foo-resource-uri} @server-opened-docs))
+            _ (edit-file! lsp foo-resource-node "{}")
+            _ (is (await= #{foo-resource-uri} @server-opened-docs))
             ;; delete file
-            _ (delete-file! foo-resource)
-            _ (is (= #{} @server-opened-docs))]
+            _ (delete-file! lsp foo-resource)
+            _ (is (await= #{} @server-opened-docs))]
         (test-support/spit-until-new-mtime foo-resource old-foo-content)
-        (resource-sync! workspace)))))
+        (resource-sync! lsp workspace)))))
 
 (deftest workspace-diagnostics-test
   (testing "Workspace diagnostics with different pull diagnostics kinds"
-    (test-util/with-scratch-project "test/resources/lsp_project"
+    (with-scratch-project "test/resources/lsp_project"
       (let [workspace-lint-exit-promise (promise)
             document-lint-exit-promise (promise)
             no-lint-exit-promise (promise)
@@ -480,26 +533,25 @@
                       "shutdown" (constantly nil)
                       "exit" (fn [_ _]
                                (deliver no-lint-exit-promise true))})}})]
-        (is (= {(workspace/find-resource workspace "/foo.json")
-                (sorted-set
-                  (data/map->CursorRange
-                    {:from (data/->Cursor 0 0)
-                     :to (data/->Cursor 0 1)
-                     :message "Workspace diagnostics error"
-                     :severity :error})
-                  (data/map->CursorRange
-                    {:from (data/->Cursor 0 1)
-                     :to (data/->Cursor 0 2)
-                     :message "Text document diagnostics error"
-                     :severity :error}))}
-               (pull-diagnostics! lsp)))
-        (await-lsp
-          (set-servers! lsp #{})
-          (is (true? (deref workspace-lint-exit-promise 200 false)))
-          (is (true? (deref document-lint-exit-promise 200 false)))
-          (is (true? (deref no-lint-exit-promise 200 false)))))))
+        (is (await= {(workspace/find-resource workspace "/foo.json")
+                     (sorted-set
+                       (data/map->CursorRange
+                         {:from (data/->Cursor 0 0)
+                          :to (data/->Cursor 0 1)
+                          :message "Workspace diagnostics error"
+                          :severity :error})
+                       (data/map->CursorRange
+                         {:from (data/->Cursor 0 1)
+                          :to (data/->Cursor 0 2)
+                          :message "Text document diagnostics error"
+                          :severity :error}))}
+                    (pull-diagnostics! lsp)))
+        (set-servers! lsp #{})
+        (is (true? (deref workspace-lint-exit-promise 200 false)))
+        (is (true? (deref document-lint-exit-promise 200 false)))
+        (is (true? (deref no-lint-exit-promise 200 false))))))
   (testing "Failing server does not block workspace diagnostics"
-    (test-util/with-scratch-project "test/resources/lsp_project"
+    (with-scratch-project "test/resources/lsp_project"
       (let [working-exit-promise (promise)
             broken-exit-promise (promise)
             lsp (lsp/get-node-lsp project)
@@ -531,19 +583,18 @@
                       "shutdown" (constantly nil)
                       "exit" (fn [_ _]
                                (deliver broken-exit-promise true))})}})]
-        (is (= {(workspace/find-resource workspace "/foo.json")
-                (sorted-set (data/map->CursorRange
-                              {:from (data/->Cursor 0 0)
-                               :to (data/->Cursor 0 1)
-                               :message "It's a bad start!"
-                               :severity :error}))}
-               (pull-diagnostics! lsp)))
-        (await-lsp
-          (set-servers! lsp #{})
-          (is (true? (deref working-exit-promise 200 false)))
-          (is (true? (deref broken-exit-promise 200 false)))))))
+        (is (await= {(workspace/find-resource workspace "/foo.json")
+                     (sorted-set (data/map->CursorRange
+                                   {:from (data/->Cursor 0 0)
+                                    :to (data/->Cursor 0 1)
+                                    :message "It's a bad start!"
+                                    :severity :error}))}
+                    (pull-diagnostics! lsp)))
+        (set-servers! lsp #{})
+        (is (true? (deref working-exit-promise 200 false)))
+        (is (true? (deref broken-exit-promise 200 false))))))
   (testing "the LSP client only waits up to a timeout"
-    (test-util/with-scratch-project "test/resources/lsp_project"
+    (with-scratch-project "test/resources/lsp_project"
       (let [exit-promise (promise)
             lsp (lsp/get-node-lsp project)
             _ (set-servers!
@@ -564,12 +615,11 @@
                                 "exit" (fn [_ _]
                                          (deliver exit-promise true))})}})]
         (is (nil? (pull-diagnostics! lsp :timeout-ms 500)))
-        (await-lsp
-          (set-servers! lsp #{})
-          (is (true? (deref exit-promise 1100 false))))))))
+        (set-servers! lsp #{})
+        (is (true? (deref exit-promise 1100 false)))))))
 
 (deftest hover-test
-  (test-util/with-scratch-project "test/resources/lsp_project"
+  (with-scratch-project "test/resources/lsp_project"
     (let [unmatched-promise (promise)
           matched-promise (promise)
           lsp (lsp/get-node-lsp project)
@@ -592,18 +642,18 @@
                                                                      (deliver matched-promise request)
                                                                      {:contents {:kind :markdown :value "hover"}})
                                               "exit" (constantly nil)})}})]
-      (is (= [(data/map->CursorRange {:from (data/->Cursor 0 1)
-                                      :to (data/->Cursor 0 2)
-                                      :type :hover
-                                      :hoverable true
-                                      :content (lsp.server/->MarkupContent :markdown "hover")})]
-             (hover! lsp (test-util/resource workspace "/foo.json") (data/->Cursor 0 1))))
-      (is (realized? matched-promise))
+      (is (await= [(data/map->CursorRange {:from (data/->Cursor 0 1)
+                                           :to (data/->Cursor 0 2)
+                                           :type :hover
+                                           :hoverable true
+                                           :content (lsp.server/->MarkupContent :markdown "hover")})]
+                  (hover! lsp (test-util/resource workspace "/foo.json") (data/->Cursor 0 1))))
+      (is (true? (await-until #(when (realized? matched-promise) true))))
       (is (not (realized? unmatched-promise)))
-      (await-lsp (set-servers! lsp #{})))))
+      (set-servers! lsp #{}))))
 
 (deftest content-modified-errors-are-retried-test
-  (test-util/with-scratch-project "test/resources/lsp_project"
+  (with-scratch-project "test/resources/lsp_project"
     (let [hover-requests (atom 0)
           lsp (lsp/get-node-lsp project)
           _ (set-servers! lsp #{{:languages #{"json"}
@@ -616,17 +666,17 @@
                                                                        (throw (ex-info "Content modified." {:jsonrpc/code -32801}))
                                                                        {:contents {:kind :markdown :value "hover"}}))
                                               "exit" (constantly nil)})}})]
-      (is (= [(data/map->CursorRange {:from (data/->Cursor 0 1)
-                                      :to (data/->Cursor 0 2)
-                                      :type :hover
-                                      :hoverable true
-                                      :content (lsp.server/->MarkupContent :markdown "hover")})]
-             (hover! lsp (test-util/resource workspace "/foo.json") (data/->Cursor 0 1))))
-      (is (= 2 @hover-requests))
-      (await-lsp (set-servers! lsp #{})))))
+      (is (await= [(data/map->CursorRange {:from (data/->Cursor 0 1)
+                                           :to (data/->Cursor 0 2)
+                                           :type :hover
+                                           :hoverable true
+                                           :content (lsp.server/->MarkupContent :markdown "hover")})]
+                  (hover! lsp (test-util/resource workspace "/foo.json") (data/->Cursor 0 1))))
+      (is (await= 2 @hover-requests))
+      (set-servers! lsp #{}))))
 
 (deftest rename-test
-  (test-util/with-scratch-project "test/resources/lsp_project"
+  (with-scratch-project "test/resources/lsp_project"
     (let [lsp (lsp/get-node-lsp project)
           _ (set-servers! lsp #{{:languages #{"json"}
                                  :launcher (make-test-server-launcher
@@ -642,8 +692,10 @@
                                               "shutdown" (constantly nil)
                                               "exit" (constantly nil)})}})]
       (let [resource (test-util/resource workspace "/foo.json")
-            rename-region (prepare-rename lsp resource (data/->Cursor 0 0))]
+            rename-region (await-value=
+                            #code/range[[0 0] [0 1]]
+                            #(prepare-rename lsp resource (data/->Cursor 0 0)))]
         (is (= #code/range[[0 0] [0 1]] rename-region))
-        (is (= {resource [[#code/range [[0 0] [0 1]] ["foo"]]]}
-               (rename lsp rename-region "foo")))
-        (await-lsp (set-servers! lsp #{}))))))
+        (is (await= {resource [[#code/range [[0 0] [0 1]] ["foo"]]]}
+                    (rename lsp rename-region "foo")))
+        (set-servers! lsp #{})))))

--- a/editor/test/integration/script_properties_test.clj
+++ b/editor/test/integration/script_properties_test.clj
@@ -19,6 +19,7 @@
             [clojure.test :refer :all]
             [dynamo.graph :as g]
             [editor.build-errors-view :as build-errors-view]
+            [editor.code.data :as data]
             [editor.code.script :as script]
             [editor.code.script-compilation :as script-compilation]
             [editor.collection :as collection]
@@ -333,6 +334,63 @@
           items)))
 
 (def ^:private error-item-open-info-without-opts (comp pop :args build-errors-view/error-item-open-info))
+
+(deftest go-property-rejected-outside-script-files-test
+  (with-clean-system
+    (let [workspace (tu/setup-scratch-workspace! world "test/resources/empty_project")
+          project (tu/setup-project! workspace)
+          project-graph (g/node-id->graph-id project)
+          resource (partial tu/resource workspace)
+          bad-source "go.property('number', 1)\n"
+          bad-invalid-args-source "go.property()\n"
+          bad-invalid-value-source "go.property('number', 'string')\n"
+          bad-invalid-location-source "function init()\n  go.property('number', 1)\nend\n"
+          two-bad-source "go.property('number', 1)\ngo.property('other', 2)\n"
+          assert-script-only-error!
+          (fn [proj-path expected-node-type source expected-errors]
+            (write-file! workspace proj-path source)
+            (let [node-id (tu/resource-node project (str "/" proj-path))]
+              (is (g/node-instance? expected-node-type node-id))
+              (let [build-error (tu/build-error! node-id)]
+                (when (is (g/error? build-error))
+                  (let [error-tree (build-errors-view/build-resource-tree build-error)
+                        error-item-of-parent-resource (first (:children error-tree))
+                        error-items-of-faulty-node (:children error-item-of-parent-resource)]
+                    (is (= (count expected-errors) (count error-items-of-faulty-node)))
+                    (is (= [(resource (str "/" proj-path)) node-id]
+                           (error-item-open-info-without-opts error-item-of-parent-resource)))
+                    (is (= expected-errors
+                           (mapv (juxt :message :cursor-range) error-items-of-faulty-node)))
+                    (doseq [error-item-of-faulty-node error-items-of-faulty-node]
+                      (is (= [(resource (str "/" proj-path)) node-id]
+                             (error-item-open-info-without-opts error-item-of-faulty-node)))))))))]
+      (with-open [_ (tu/make-graph-reverter project-graph)]
+        (write-file! workspace "ok.script" bad-source)
+        (let [script-node (tu/resource-node project "/ok.script")]
+          (is (g/node-instance? script/ScriptNode script-node))
+          (is (not (g/error? (tu/build-error! script-node)))))
+        (write-file! workspace "bad.script" bad-invalid-value-source)
+        (let [script-node (tu/resource-node project "/bad.script")
+              build-error (tu/build-error! script-node)]
+          (is (g/node-instance? script/ScriptNode script-node))
+          (is (g/error? build-error))
+          (is (not= script-compilation/go-property-disallowed-message (:message (first build-error)))))
+        (assert-script-only-error! "bad.lua" script/LuaNode two-bad-source
+          [[script-compilation/go-property-disallowed-message (data/->CursorRange (data/->Cursor 0 0) (data/->Cursor 0 24))]
+           [script-compilation/go-property-disallowed-message (data/->CursorRange (data/->Cursor 1 0) (data/->Cursor 1 23))]])
+        (assert-script-only-error! "bad_invalid_args.lua" script/LuaNode bad-invalid-args-source
+          [["invalid go.property args" (data/->CursorRange (data/->Cursor 0 0) (data/->Cursor 0 13))]
+           [script-compilation/go-property-disallowed-message (data/->CursorRange (data/->Cursor 0 0) (data/->Cursor 0 13))]])
+        (assert-script-only-error! "bad_invalid_value.lua" script/LuaNode bad-invalid-value-source
+          [["unexpected argument" (data/->CursorRange (data/->Cursor 0 0) (data/->Cursor 0 31))]
+           [script-compilation/go-property-disallowed-message (data/->CursorRange (data/->Cursor 0 0) (data/->Cursor 0 31))]])
+        (assert-script-only-error! "bad_invalid_location.lua" script/LuaNode bad-invalid-location-source
+          [["go.property declaration should be a top-level statement" (data/->CursorRange (data/->Cursor 1 2) (data/->Cursor 1 26))]
+           [script-compilation/go-property-disallowed-message (data/->CursorRange (data/->Cursor 1 2) (data/->Cursor 1 26))]])
+        (assert-script-only-error! "bad.gui_script" script/LuaNode bad-source
+          [[script-compilation/go-property-disallowed-message (data/->CursorRange (data/->Cursor 0 0) (data/->Cursor 0 24))]])
+        (assert-script-only-error! "bad.render_script" script/LuaNode bad-source
+          [[script-compilation/go-property-disallowed-message (data/->CursorRange (data/->Cursor 0 0) (data/->Cursor 0 24))]])))))
 
 (deftest edit-script-resource-properties-test
   (with-clean-system

--- a/editor/test/integration/script_properties_test.clj
+++ b/editor/test/integration/script_properties_test.clj
@@ -364,38 +364,41 @@
                       (is (= [(tu/resource workspace proj-path) node-id]
                              (error-item-open-info-without-opts error-item-of-faulty-node)))))))))]
       (with-open [_ (tu/make-graph-reverter (g/node-id->graph-id project))]
-        (write-file! workspace "ok.script" bad-source)
-        (let [script-node (tu/resource-node project "/ok.script")]
-          (is (g/node-instance? script/ScriptNode script-node))
-          (is (not (g/error? (tu/build-error! script-node)))))
-        (write-file! workspace "bad.script" bad-invalid-value-source)
-        (let [script-node (tu/resource-node project "/bad.script")
-              build-error (tu/build-error! script-node)]
-          (is (g/node-instance? script/ScriptNode script-node))
-          (is (g/error? build-error))
-          (is (not= script-compilation/go-property-disallowed-message (:message (first build-error)))))
-        (assert-script-only-error!
-          "bad.lua" two-bad-source
-          [[script-compilation/go-property-disallowed-message (data/->CursorRange (data/->Cursor 0 0) (data/->Cursor 0 24))]
-           [script-compilation/go-property-disallowed-message (data/->CursorRange (data/->Cursor 1 0) (data/->Cursor 1 23))]])
-        (assert-script-only-error!
-          "bad_invalid_args.lua" bad-invalid-args-source
-          [["invalid go.property args" (data/->CursorRange (data/->Cursor 0 0) (data/->Cursor 0 13))]
-           [script-compilation/go-property-disallowed-message (data/->CursorRange (data/->Cursor 0 0) (data/->Cursor 0 13))]])
-        (assert-script-only-error!
-          "bad_invalid_value.lua" bad-invalid-value-source
-          [["unexpected argument" (data/->CursorRange (data/->Cursor 0 0) (data/->Cursor 0 31))]
-           [script-compilation/go-property-disallowed-message (data/->CursorRange (data/->Cursor 0 0) (data/->Cursor 0 31))]])
-        (assert-script-only-error!
-          "bad_invalid_location.lua" bad-invalid-location-source
-          [["go.property declaration should be a top-level statement" (data/->CursorRange (data/->Cursor 1 2) (data/->Cursor 1 26))]
-           [script-compilation/go-property-disallowed-message (data/->CursorRange (data/->Cursor 1 2) (data/->Cursor 1 26))]])
-        (assert-script-only-error!
-          "bad.gui_script" bad-source
-          [[script-compilation/go-property-disallowed-message (data/->CursorRange (data/->Cursor 0 0) (data/->Cursor 0 24))]])
-        (assert-script-only-error!
-          "bad.render_script" bad-source
-          [[script-compilation/go-property-disallowed-message (data/->CursorRange (data/->Cursor 0 0) (data/->Cursor 0 24))]])))))
+        (testing "Script files allow go.property and keep regular validation"
+          (write-file! workspace "ok.script" bad-source)
+          (let [script-node (tu/resource-node project "/ok.script")]
+            (is (g/node-instance? script/ScriptNode script-node))
+            (is (not (g/error? (tu/build-error! script-node)))))
+          (write-file! workspace "bad.script" bad-invalid-value-source)
+          (let [script-node (tu/resource-node project "/bad.script")
+                build-error (tu/build-error! script-node)]
+            (is (g/node-instance? script/ScriptNode script-node))
+            (is (g/error? build-error))
+            (is (not= script-compilation/go-property-disallowed-message (:message (first build-error))))))
+        (testing "Lua files reject go.property declarations"
+          (assert-script-only-error!
+            "bad.lua" two-bad-source
+            [[script-compilation/go-property-disallowed-message (data/->CursorRange (data/->Cursor 0 0) (data/->Cursor 0 24))]
+             [script-compilation/go-property-disallowed-message (data/->CursorRange (data/->Cursor 1 0) (data/->Cursor 1 23))]])
+          (assert-script-only-error!
+            "bad_invalid_args.lua" bad-invalid-args-source
+            [["invalid go.property args" (data/->CursorRange (data/->Cursor 0 0) (data/->Cursor 0 13))]
+             [script-compilation/go-property-disallowed-message (data/->CursorRange (data/->Cursor 0 0) (data/->Cursor 0 13))]])
+          (assert-script-only-error!
+            "bad_invalid_value.lua" bad-invalid-value-source
+            [["unexpected argument" (data/->CursorRange (data/->Cursor 0 0) (data/->Cursor 0 31))]
+             [script-compilation/go-property-disallowed-message (data/->CursorRange (data/->Cursor 0 0) (data/->Cursor 0 31))]])
+          (assert-script-only-error!
+            "bad_invalid_location.lua" bad-invalid-location-source
+            [["go.property declaration should be a top-level statement" (data/->CursorRange (data/->Cursor 1 2) (data/->Cursor 1 26))]
+             [script-compilation/go-property-disallowed-message (data/->CursorRange (data/->Cursor 1 2) (data/->Cursor 1 26))]]))
+        (testing "Other Lua-based script resource types reject go.property declarations"
+          (assert-script-only-error!
+            "bad.gui_script" bad-source
+            [[script-compilation/go-property-disallowed-message (data/->CursorRange (data/->Cursor 0 0) (data/->Cursor 0 24))]])
+          (assert-script-only-error!
+            "bad.render_script" bad-source
+            [[script-compilation/go-property-disallowed-message (data/->CursorRange (data/->Cursor 0 0) (data/->Cursor 0 24))]]))))))
 
 (deftest edit-script-resource-properties-test
   (with-clean-system

--- a/editor/test/integration/script_properties_test.clj
+++ b/editor/test/integration/script_properties_test.clj
@@ -339,32 +339,31 @@
   (with-clean-system
     (let [workspace (tu/setup-scratch-workspace! world "test/resources/empty_project")
           project (tu/setup-project! workspace)
-          project-graph (g/node-id->graph-id project)
-          resource (partial tu/resource workspace)
           bad-source "go.property('number', 1)\n"
           bad-invalid-args-source "go.property()\n"
           bad-invalid-value-source "go.property('number', 'string')\n"
           bad-invalid-location-source "function init()\n  go.property('number', 1)\nend\n"
           two-bad-source "go.property('number', 1)\ngo.property('other', 2)\n"
           assert-script-only-error!
-          (fn [proj-path expected-node-type source expected-errors]
-            (write-file! workspace proj-path source)
-            (let [node-id (tu/resource-node project (str "/" proj-path))]
-              (is (g/node-instance? expected-node-type node-id))
+          (fn [file-name source expected-errors]
+            (write-file! workspace file-name source)
+            (let [proj-path (str "/" file-name)
+                  node-id (tu/resource-node project proj-path)]
+              (is (g/node-instance? script/LuaNode node-id))
               (let [build-error (tu/build-error! node-id)]
                 (when (is (g/error? build-error))
                   (let [error-tree (build-errors-view/build-resource-tree build-error)
                         error-item-of-parent-resource (first (:children error-tree))
                         error-items-of-faulty-node (:children error-item-of-parent-resource)]
                     (is (= (count expected-errors) (count error-items-of-faulty-node)))
-                    (is (= [(resource (str "/" proj-path)) node-id]
+                    (is (= [(tu/resource workspace proj-path) node-id]
                            (error-item-open-info-without-opts error-item-of-parent-resource)))
                     (is (= expected-errors
                            (mapv (juxt :message :cursor-range) error-items-of-faulty-node)))
                     (doseq [error-item-of-faulty-node error-items-of-faulty-node]
-                      (is (= [(resource (str "/" proj-path)) node-id]
+                      (is (= [(tu/resource workspace proj-path) node-id]
                              (error-item-open-info-without-opts error-item-of-faulty-node)))))))))]
-      (with-open [_ (tu/make-graph-reverter project-graph)]
+      (with-open [_ (tu/make-graph-reverter (g/node-id->graph-id project))]
         (write-file! workspace "ok.script" bad-source)
         (let [script-node (tu/resource-node project "/ok.script")]
           (is (g/node-instance? script/ScriptNode script-node))
@@ -375,21 +374,27 @@
           (is (g/node-instance? script/ScriptNode script-node))
           (is (g/error? build-error))
           (is (not= script-compilation/go-property-disallowed-message (:message (first build-error)))))
-        (assert-script-only-error! "bad.lua" script/LuaNode two-bad-source
+        (assert-script-only-error!
+          "bad.lua" two-bad-source
           [[script-compilation/go-property-disallowed-message (data/->CursorRange (data/->Cursor 0 0) (data/->Cursor 0 24))]
            [script-compilation/go-property-disallowed-message (data/->CursorRange (data/->Cursor 1 0) (data/->Cursor 1 23))]])
-        (assert-script-only-error! "bad_invalid_args.lua" script/LuaNode bad-invalid-args-source
+        (assert-script-only-error!
+          "bad_invalid_args.lua" bad-invalid-args-source
           [["invalid go.property args" (data/->CursorRange (data/->Cursor 0 0) (data/->Cursor 0 13))]
            [script-compilation/go-property-disallowed-message (data/->CursorRange (data/->Cursor 0 0) (data/->Cursor 0 13))]])
-        (assert-script-only-error! "bad_invalid_value.lua" script/LuaNode bad-invalid-value-source
+        (assert-script-only-error!
+          "bad_invalid_value.lua" bad-invalid-value-source
           [["unexpected argument" (data/->CursorRange (data/->Cursor 0 0) (data/->Cursor 0 31))]
            [script-compilation/go-property-disallowed-message (data/->CursorRange (data/->Cursor 0 0) (data/->Cursor 0 31))]])
-        (assert-script-only-error! "bad_invalid_location.lua" script/LuaNode bad-invalid-location-source
+        (assert-script-only-error!
+          "bad_invalid_location.lua" bad-invalid-location-source
           [["go.property declaration should be a top-level statement" (data/->CursorRange (data/->Cursor 1 2) (data/->Cursor 1 26))]
            [script-compilation/go-property-disallowed-message (data/->CursorRange (data/->Cursor 1 2) (data/->Cursor 1 26))]])
-        (assert-script-only-error! "bad.gui_script" script/LuaNode bad-source
+        (assert-script-only-error!
+          "bad.gui_script" bad-source
           [[script-compilation/go-property-disallowed-message (data/->CursorRange (data/->Cursor 0 0) (data/->Cursor 0 24))]])
-        (assert-script-only-error! "bad.render_script" script/LuaNode bad-source
+        (assert-script-only-error!
+          "bad.render_script" bad-source
           [[script-compilation/go-property-disallowed-message (data/->CursorRange (data/->Cursor 0 0) (data/->Cursor 0 24))]])))))
 
 (deftest edit-script-resource-properties-test


### PR DESCRIPTION
Both editor and bob will now only allow `go.property()` in `.script` files. It never worked in `.lua` files, but now it explicitly generates a build error.

As a side effect of this, the editor now loads faster on big proejcts, where it no longer needs to parse all `.lua` files for properties. On an example big project, the observed improvement in load time was 6% (1m31s -> 1m25s).

Technical notes:

Before:

```
2026-03-25 12:46:41.670 INFO  default    editor.boot-open-project - {:line nil, :message "Project loading completed in 1:31"}
2026-03-25 12:46:34.364 INFO  default    editor.defold-project - {:line nil, :message "Project loaded", :allocated "2.48 GB"}
```

<img width="1402" height="896" alt="Screenshot 2026-03-25 at 12 57 45" src="https://github.com/user-attachments/assets/8dd5978e-247e-440d-a555-d057b173f8d3" />


After:
```
2026-03-25 14:55:46.421 INFO  default    editor.boot-open-project - {:line nil, :message "Project loading completed in 1:25"}
2026-03-25 14:55:39.262 INFO  default    editor.defold-project - {:line nil, :message "Project loaded", :allocated "2.44 GB"}
```
<img width="1397" height="904" alt="Screenshot 2026-03-25 at 12 54 24" src="https://github.com/user-attachments/assets/274006ba-0ad4-4ef7-9c16-27dfb906b620" />

As you can see, the "modified lines" setter is halved, with lua parsing basically disappearing.

Related to #11989
