### PR TITLE
Exclude unused code from the HTML5 build to reduce binary size

### DIFF
--- a/engine/dlib/src/dlib/configfile.cpp
+++ b/engine/dlib/src/dlib/configfile.cpp
@@ -23,15 +23,12 @@
 #include "uri.h"
 
 #include "configfile.h"
+#include "configfile_http.h"
 #include "array.h"
 #include "dstrings.h"
 #include "math.h"
 #include "sys.h"
 #include "static_assert.h"
-
-#if !defined(__EMSCRIPTEN__)
-#include "http_client.h"
-#endif
 
 struct ConfigFileEntry
 {
@@ -503,51 +500,6 @@ namespace dmConfigFile
         }
     }
 
-#if !defined(__EMSCRIPTEN__)
-    struct HttpContext
-    {
-        HttpContext()
-        {
-        }
-        dmArray<char> m_Buffer;
-    };
-
-    static void HttpHeader(dmHttpClient::HResponse response, void* user_data, int status_code, const char* key, const char* value)
-    {
-        (void) response;
-        (void) user_data;
-        (void) status_code;
-        (void) key;
-        (void) value;
-    }
-
-    static void HttpContent(dmHttpClient::HResponse response, void* user_data, int status_code, const void* content_data, uint32_t content_data_size, int32_t content_length,
-                            uint32_t range_start, uint32_t range_end, uint32_t document_size,
-                            const char* method)
-    {
-        (void) method; // unused
-        HttpContext* context = (HttpContext*) user_data;
-        if (status_code != 200)
-            return;
-
-        if (!content_data && !content_data_size)
-        {
-            context->m_Buffer.SetSize(0);
-            return;
-        }
-
-        dmArray<char>& buffer = context->m_Buffer;
-        if (buffer.Remaining() < content_data_size)
-        {
-            uint32_t new_capacity = buffer.Capacity() + dmMath::Max(4U * 1024U, content_data_size);
-            context->m_Buffer.SetCapacity(new_capacity);
-        }
-
-        assert(content_data);
-        buffer.PushArray((const char*) content_data, content_data_size);
-    }
-#endif
-
     static Result LoadFromBufferInternal(const char* url, const char* buffer, uint32_t buffer_size, int argc, const char** argv, HConfig* config)
     {
         Context context;
@@ -697,34 +649,6 @@ namespace dmConfigFile
 #endif
     }
 
-#if !defined(__EMSCRIPTEN__)
-    static Result LoadFromHttpInternal(const char* url, const dmURI::Parts& uri_parts, int argc, const char** argv, HConfig* config)
-    {
-        HttpContext context;
-
-        dmHttpClient::NewParams params;
-        params.m_Userdata = &context;
-        params.m_HttpContent = &HttpContent;
-        params.m_HttpHeader = &HttpHeader;
-        dmHttpClient::HClient client = dmHttpClient::New(&params, &uri_parts, 0);
-        if (client == 0x0)
-        {
-            return RESULT_FILE_NOT_FOUND;
-        }
-
-        dmHttpClient::Result http_result = dmHttpClient::Get(client, uri_parts.m_Path);
-        dmHttpClient::Delete(client);
-
-        if (http_result != dmHttpClient::RESULT_OK)
-        {
-            return RESULT_FILE_NOT_FOUND;
-        }
-
-        Result r = LoadFromBufferInternal(url, (const char*) &context.m_Buffer.Front(), context.m_Buffer.Size(), argc, argv, config);
-        return r;
-    }
-#endif
-
     Result LoadFromBuffer(const char* buffer, uint32_t buffer_size, int argc, const char** argv, HConfig* config)
     {
         Result r = LoadFromBufferInternal("<buffer>", buffer, buffer_size, argc, argv, config);
@@ -748,12 +672,7 @@ namespace dmConfigFile
         {
             if (strcmp(uri_parts.m_Scheme, "http") == 0 || strcmp(uri_parts.m_Scheme, "https") == 0)
             {
-#if defined(__EMSCRIPTEN__)
-                dmLogError("HTTP(S) config loading is not supported on HTML5: %s", url);
-                return RESULT_INVALID_URI;
-#else
-                return LoadFromHttpInternal(url, uri_parts, argc, argv, config);
-#endif
+                return LoadFromHttpInternal(url, uri_parts, argc, argv, config, LoadFromBufferInternal);
             }
             else if (strcmp(uri_parts.m_Scheme, "file") == 0)
             {

--- a/engine/dlib/src/dlib/configfile.cpp
+++ b/engine/dlib/src/dlib/configfile.cpp
@@ -20,7 +20,6 @@
 #include <assert.h>
 #include "hash.h"
 #include "log.h"
-#include "http_client.h"
 #include "uri.h"
 
 #include "configfile.h"
@@ -29,6 +28,10 @@
 #include "math.h"
 #include "sys.h"
 #include "static_assert.h"
+
+#if !defined(__EMSCRIPTEN__)
+#include "http_client.h"
+#endif
 
 struct ConfigFileEntry
 {
@@ -500,6 +503,7 @@ namespace dmConfigFile
         }
     }
 
+#if !defined(__EMSCRIPTEN__)
     struct HttpContext
     {
         HttpContext()
@@ -542,6 +546,7 @@ namespace dmConfigFile
         assert(content_data);
         buffer.PushArray((const char*) content_data, content_data_size);
     }
+#endif
 
     static Result LoadFromBufferInternal(const char* url, const char* buffer, uint32_t buffer_size, int argc, const char** argv, HConfig* config)
     {
@@ -692,6 +697,7 @@ namespace dmConfigFile
 #endif
     }
 
+#if !defined(__EMSCRIPTEN__)
     static Result LoadFromHttpInternal(const char* url, const dmURI::Parts& uri_parts, int argc, const char** argv, HConfig* config)
     {
         HttpContext context;
@@ -717,6 +723,7 @@ namespace dmConfigFile
         Result r = LoadFromBufferInternal(url, (const char*) &context.m_Buffer.Front(), context.m_Buffer.Size(), argc, argv, config);
         return r;
     }
+#endif
 
     Result LoadFromBuffer(const char* buffer, uint32_t buffer_size, int argc, const char** argv, HConfig* config)
     {
@@ -741,7 +748,12 @@ namespace dmConfigFile
         {
             if (strcmp(uri_parts.m_Scheme, "http") == 0 || strcmp(uri_parts.m_Scheme, "https") == 0)
             {
+#if defined(__EMSCRIPTEN__)
+                dmLogError("HTTP(S) config loading is not supported on HTML5: %s", url);
+                return RESULT_INVALID_URI;
+#else
                 return LoadFromHttpInternal(url, uri_parts, argc, argv, config);
+#endif
             }
             else if (strcmp(uri_parts.m_Scheme, "file") == 0)
             {

--- a/engine/dlib/src/dlib/configfile_http.cpp
+++ b/engine/dlib/src/dlib/configfile_http.cpp
@@ -1,0 +1,95 @@
+// Copyright 2020-2026 The Defold Foundation
+// Copyright 2014-2020 King
+// Copyright 2009-2014 Ragnar Svensson, Christian Murray
+// Licensed under the Defold License version 1.0 (the "License"); you may not use
+// this file except in compliance with the License.
+//
+// You may obtain a copy of the License, together with FAQs at
+// https://www.defold.com/license
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#include <assert.h>
+
+#include "array.h"
+#include "configfile_http.h"
+#include "http_client.h"
+#include "math.h"
+
+namespace dmConfigFile
+{
+    struct HttpContext
+    {
+        dmArray<char> m_Buffer;
+    };
+
+    static void HttpHeader(dmHttpClient::HResponse response, void* user_data, int status_code, const char* key, const char* value)
+    {
+        (void) response;
+        (void) user_data;
+        (void) status_code;
+        (void) key;
+        (void) value;
+    }
+
+    static void HttpContent(dmHttpClient::HResponse response, void* user_data, int status_code, const void* content_data, uint32_t content_data_size, int32_t content_length,
+                            uint32_t range_start, uint32_t range_end, uint32_t document_size,
+                            const char* method)
+    {
+        (void) response;
+        (void) content_length;
+        (void) range_start;
+        (void) range_end;
+        (void) document_size;
+        (void) method;
+
+        HttpContext* context = (HttpContext*) user_data;
+        if (status_code != 200)
+            return;
+
+        if (!content_data && !content_data_size)
+        {
+            context->m_Buffer.SetSize(0);
+            return;
+        }
+
+        dmArray<char>& buffer = context->m_Buffer;
+        if (buffer.Remaining() < content_data_size)
+        {
+            uint32_t new_capacity = buffer.Capacity() + dmMath::Max(4U * 1024U, content_data_size);
+            context->m_Buffer.SetCapacity(new_capacity);
+        }
+
+        assert(content_data);
+        buffer.PushArray((const char*) content_data, content_data_size);
+    }
+
+    Result LoadFromHttpInternal(const char* url, const dmURI::Parts& uri_parts, int argc, const char** argv, HConfig* config, FLoadFromBufferInternal load_from_buffer)
+    {
+        HttpContext context;
+
+        dmHttpClient::NewParams params;
+        params.m_Userdata = &context;
+        params.m_HttpContent = &HttpContent;
+        params.m_HttpHeader = &HttpHeader;
+        dmHttpClient::HClient client = dmHttpClient::New(&params, &uri_parts, 0);
+        if (client == 0x0)
+        {
+            return RESULT_FILE_NOT_FOUND;
+        }
+
+        dmHttpClient::Result http_result = dmHttpClient::Get(client, uri_parts.m_Path);
+        dmHttpClient::Delete(client);
+
+        if (http_result != dmHttpClient::RESULT_OK)
+        {
+            return RESULT_FILE_NOT_FOUND;
+        }
+
+        const char* buffer = context.m_Buffer.Size() > 0 ? (const char*) &context.m_Buffer.Front() : "";
+        return load_from_buffer(url, buffer, context.m_Buffer.Size(), argc, argv, config);
+    }
+}

--- a/engine/dlib/src/dlib/configfile_http.h
+++ b/engine/dlib/src/dlib/configfile_http.h
@@ -1,0 +1,30 @@
+// Copyright 2020-2026 The Defold Foundation
+// Copyright 2014-2020 King
+// Copyright 2009-2014 Ragnar Svensson, Christian Murray
+// Licensed under the Defold License version 1.0 (the "License"); you may not use
+// this file except in compliance with the License.
+//
+// You may obtain a copy of the License, together with FAQs at
+// https://www.defold.com/license
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#ifndef DM_CONFIGFILE_HTTP_H
+#define DM_CONFIGFILE_HTTP_H
+
+#include <stdint.h>
+
+#include "configfile.h"
+#include "uri.h"
+
+namespace dmConfigFile
+{
+    typedef Result (*FLoadFromBufferInternal)(const char* url, const char* buffer, uint32_t buffer_size, int argc, const char** argv, HConfig* config);
+
+    Result LoadFromHttpInternal(const char* url, const dmURI::Parts& uri_parts, int argc, const char** argv, HConfig* config, FLoadFromBufferInternal load_from_buffer);
+}
+
+#endif // DM_CONFIGFILE_HTTP_H

--- a/engine/dlib/src/dlib/configfile_http_null.cpp
+++ b/engine/dlib/src/dlib/configfile_http_null.cpp
@@ -25,7 +25,6 @@ namespace dmConfigFile
         (void) config;
         (void) load_from_buffer;
 
-        dmLogError("HTTP(S) config loading is not supported on HTML5: %s", url);
         return RESULT_INVALID_URI;
     }
 }

--- a/engine/dlib/src/dlib/configfile_http_null.cpp
+++ b/engine/dlib/src/dlib/configfile_http_null.cpp
@@ -1,0 +1,31 @@
+// Copyright 2020-2026 The Defold Foundation
+// Copyright 2014-2020 King
+// Copyright 2009-2014 Ragnar Svensson, Christian Murray
+// Licensed under the Defold License version 1.0 (the "License"); you may not use
+// this file except in compliance with the License.
+//
+// You may obtain a copy of the License, together with FAQs at
+// https://www.defold.com/license
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#include "configfile_http.h"
+#include "log.h"
+
+namespace dmConfigFile
+{
+    Result LoadFromHttpInternal(const char* url, const dmURI::Parts& uri_parts, int argc, const char** argv, HConfig* config, FLoadFromBufferInternal load_from_buffer)
+    {
+        (void) uri_parts;
+        (void) argc;
+        (void) argv;
+        (void) config;
+        (void) load_from_buffer;
+
+        dmLogError("HTTP(S) config loading is not supported on HTML5: %s", url);
+        return RESULT_INVALID_URI;
+    }
+}

--- a/engine/dlib/src/dlib/http_cache_null.cpp
+++ b/engine/dlib/src/dlib/http_cache_null.cpp
@@ -1,0 +1,182 @@
+// Copyright 2020-2026 The Defold Foundation
+// Copyright 2014-2020 King
+// Copyright 2009-2014 Ragnar Svensson, Christian Murray
+// Licensed under the Defold License version 1.0 (the "License"); you may not use
+// this file except in compliance with the License.
+//
+// You may obtain a copy of the License, together with FAQs at
+// https://www.defold.com/license
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#include <string.h>
+
+#include "http_cache.h"
+#include "http_cache_verify.h"
+#include "log.h"
+
+namespace dmHttpCache
+{
+    void SetDefaultParams(NewParams* params)
+    {
+        if (params == 0)
+        {
+            return;
+        }
+
+        memset(params, 0, sizeof(*params));
+        params->m_MaxCacheEntryAge = 60 * 60 * 24 * 5;
+    }
+
+    Result Open(NewParams* params, HCache* cache)
+    {
+        (void) params;
+
+        if (cache)
+        {
+            *cache = 0;
+        }
+
+        dmLogError("HTTP cache is not supported on HTML5");
+        return RESULT_INVAL;
+    }
+
+    Result Close(HCache cache)
+    {
+        (void) cache;
+        return RESULT_OK;
+    }
+
+    Result Flush(HCache cache)
+    {
+        (void) cache;
+        return RESULT_OK;
+    }
+
+    Result Begin(HCache cache, const char* uri, const char* etag, uint32_t max_age, uint32_t range_start, uint32_t range_end, uint32_t document_size, HCacheCreator* cache_creator)
+    {
+        (void) cache;
+        (void) uri;
+        (void) etag;
+        (void) max_age;
+        (void) range_start;
+        (void) range_end;
+        (void) document_size;
+        if (cache_creator)
+        {
+            *cache_creator = 0;
+        }
+        return RESULT_INVAL;
+    }
+
+    Result Add(HCache cache, HCacheCreator cache_creator, const void* content, uint32_t content_len)
+    {
+        (void) cache;
+        (void) cache_creator;
+        (void) content;
+        (void) content_len;
+        return RESULT_INVAL;
+    }
+
+    void SetError(HCache cache, HCacheCreator cache_creator)
+    {
+        (void) cache;
+        (void) cache_creator;
+    }
+
+    Result End(HCache cache, HCacheCreator cache_creator)
+    {
+        (void) cache;
+        (void) cache_creator;
+        return RESULT_INVAL;
+    }
+
+    Result GetETag(HCache cache, const char* uri, char* tag_buffer, uint32_t tag_buffer_len)
+    {
+        (void) cache;
+        (void) uri;
+        (void) tag_buffer;
+        (void) tag_buffer_len;
+        return RESULT_INVAL;
+    }
+
+    Result GetInfo(HCache cache, const char* uri, EntryInfo* info)
+    {
+        (void) cache;
+        (void) uri;
+        (void) info;
+        return RESULT_INVAL;
+    }
+
+    Result Get(HCache cache, const char* uri, const char* etag, FILE** file, uint32_t* file_size, uint64_t* checksum,
+                    uint32_t* range_start, uint32_t* range_end, uint32_t* document_size)
+    {
+        (void) cache;
+        (void) uri;
+        (void) etag;
+        (void) file;
+        (void) file_size;
+        (void) checksum;
+        (void) range_start;
+        (void) range_end;
+        (void) document_size;
+        return RESULT_INVAL;
+    }
+
+    Result SetVerified(HCache cache, const char* uri, bool verified)
+    {
+        (void) cache;
+        (void) uri;
+        (void) verified;
+        return RESULT_INVAL;
+    }
+
+    Result Release(HCache cache, const char* uri, const char* etag, FILE* file)
+    {
+        (void) cache;
+        (void) uri;
+        (void) etag;
+        (void) file;
+        return RESULT_INVAL;
+    }
+
+    uint32_t GetEntryCount(HCache cache)
+    {
+        (void) cache;
+        return 0;
+    }
+
+    void SetConsistencyPolicy(HCache cache, ConsistencyPolicy policy)
+    {
+        (void) cache;
+        (void) policy;
+    }
+
+    ConsistencyPolicy GetConsistencyPolicy(HCache cache)
+    {
+        (void) cache;
+        return CONSISTENCY_POLICY_VERIFY;
+    }
+
+    void Iterate(HCache cache, void* context, void (*call_back)(void* context, const EntryInfo* entry_info))
+    {
+        (void) cache;
+        (void) context;
+        (void) call_back;
+    }
+}
+
+namespace dmHttpCacheVerify
+{
+    Result VerifyCache(dmHttpCache::HCache cache, dmURI::Parts* uri, uint64_t max_age)
+    {
+        (void) cache;
+        (void) uri;
+        (void) max_age;
+        dmLogError("HTTP cache verification is not supported on HTML5");
+        return RESULT_UNSUPPORTED;
+    }
+}

--- a/engine/dlib/src/dlib/http_client.cpp
+++ b/engine/dlib/src/dlib/http_client.cpp
@@ -299,10 +299,16 @@ namespace dmHttpClient
         client->m_MaxGetRetries = params->m_MaxGetRetries;
         client->m_RequestTimeout = params->m_RequestTimeout;
         client->m_RequestStart = 0;
-        client->m_HttpCache = params->m_HttpCache;
         client->m_Secure = (strcmp(hostURI->m_Scheme, "https") == 0) || (strcmp(hostURI->m_Scheme, "wss") == 0);
-        client->m_IgnoreCache = params->m_HttpCache != 0 ? 0 : 1;
         client->m_CancelFlag = cancelflag;
+
+#if defined(DM_NO_HTTP_CACHE)
+        client->m_HttpCache = 0;
+        client->m_IgnoreCache = 1;
+#else
+        client->m_HttpCache = params->m_HttpCache;
+        client->m_IgnoreCache = params->m_HttpCache != 0 ? 0 : 1;
+#endif
 
         memcpy(&client->m_HostURI, hostURI, sizeof(*hostURI));
         if (proxyURI)
@@ -335,7 +341,11 @@ namespace dmHttpClient
                 client->m_RequestTimeout = (int) value;
                 break;
             case OPTION_REQUEST_IGNORE_CACHE:
+#if defined(DM_NO_HTTP_CACHE)
+                client->m_IgnoreCache = 1;
+#else
                 client->m_IgnoreCache = value != 0 ? 1 : 0;
+#endif
                 break;
             case OPTION_REQUEST_CHUNKED_TRANSFER:
                 client->m_ChunkedTransfer = value != 0 ? 1 : 0;
@@ -611,6 +621,7 @@ if (sock_res != dmSocket::RESULT_OK)\
             }
         }
 
+#if !defined(DM_NO_HTTP_CACHE)
         if (!client->m_IgnoreCache && client->m_HttpCache)
         {
             char etag[dmHttpCache::MAX_TAG_LEN] = "";
@@ -622,6 +633,7 @@ if (sock_res != dmSocket::RESULT_OK)\
                 HTTP_CLIENT_SENDALL_AND_BAIL("\r\n");
             }
         }
+#endif
 
         if (strcmp(method, "POST") == 0 || strcmp(method, "PUT") == 0 || strcmp(method, "PATCH") == 0) {
             send_content_length = client->m_HttpSendContentLength(response, client->m_Userdata);
@@ -696,6 +708,10 @@ bail:
         // to_transfer can be set to -1 when the "Content-Length" is unknown
         int total_transferred = 0;
 
+#if defined(DM_NO_HTTP_CACHE)
+        (void) add_to_cache;
+#endif
+
         while (true)
         {
             int n;
@@ -709,10 +725,12 @@ bail:
                         response->m_RangeStart, response->m_RangeEnd, response->m_DocumentSize,
                         method);
 
+#if !defined(DM_NO_HTTP_CACHE)
             if (response->m_CacheCreator && add_to_cache)
             {
                 dmHttpCache::Add(client->m_HttpCache, response->m_CacheCreator, client->m_Buffer + response->m_ContentOffset, n);
             }
+#endif
 
             total_transferred += n;
             assert(total_transferred <= to_transfer || to_transfer == -1);
@@ -795,6 +813,7 @@ bail:
         (void) method;
     }
 
+#if !defined(DM_NO_HTTP_CACHE)
     static Result HandleCached(HClient client, const char* path, Response* response, bool method_is_head)
     {
         client->m_Statistics.m_CachedResponses++;
@@ -879,6 +898,7 @@ bail:
 
         return RESULT_OK;
     }
+#endif
 
     static Result HandleResponse(HClient client, const char* path, const char* method, Response* response)
     {
@@ -986,6 +1006,11 @@ bail:
         bool method_is_head = strcmp(method, "HEAD") == 0;
         bool method_is_connect = strcmp(method, "CONNECT") == 0;
 
+#if defined(DM_NO_HTTP_CACHE)
+        (void) method_is_head;
+        (void) method_is_connect;
+#endif
+
         if (sock_res != dmSocket::RESULT_OK)
         {
             return RESULT_SOCKET_ERROR;
@@ -1021,10 +1046,12 @@ bail:
             // Use cached version
             if (response.m_ContentLength == 0 || response.m_ContentLength == -1)
             {
+#if !defined(DM_NO_HTTP_CACHE)
                 if (!client->m_IgnoreCache && client->m_HttpCache)
                 {
                     r = HandleCached(client, path, &response, method_is_head);
                 }
+#endif
                 response.m_TotalReceived = 0;
             }
             else
@@ -1045,6 +1072,7 @@ bail:
                 response.m_RangeEnd = response.m_DocumentSize-1;
             }
 
+#if !defined(DM_NO_HTTP_CACHE)
             // Non-cached response
             bool is_ok = response.m_Status == 200 || response.m_Status == 206;
             if (!client->m_IgnoreCache && client->m_HttpCache && !method_is_head && !method_is_connect && is_ok)
@@ -1056,9 +1084,11 @@ bail:
                 dmHttpCache::Begin(client->m_HttpCache, client->m_CacheKey, response.m_ETag, response.m_MaxAge,
                                     range_start, range_end, document_size, &response.m_CacheCreator);
             }
+#endif
 
             r = HandleResponse(client, path, method, &response);
 
+#if !defined(DM_NO_HTTP_CACHE)
             if (response.m_CacheCreator)
             {
                 if (r != RESULT_OK)
@@ -1068,6 +1098,7 @@ bail:
                 dmHttpCache::End(client->m_HttpCache, response.m_CacheCreator);
                 response.m_CacheCreator = 0;
             }
+#endif
         }
 
         // Removed an assert here, in favor of returning an error instead
@@ -1196,6 +1227,7 @@ bail:
         return r;
     }
 
+#if !defined(DM_NO_HTTP_CACHE)
     static Result HandleCachedVerified(HClient client, const dmHttpCache::EntryInfo* info)
     {
         Response response(client);
@@ -1231,6 +1263,7 @@ bail:
             return RESULT_IO_ERROR;
         }
     }
+#endif
 
     Result SetCacheKey(HClient client, const char* key)
     {
@@ -1254,6 +1287,7 @@ bail:
 
         Result r;
 
+#if !defined(DM_NO_HTTP_CACHE)
         if (!client->m_IgnoreCache && client->m_HttpCache)
         {
             dmHttpCache::ConsistencyPolicy policy = dmHttpCache::GetConsistencyPolicy(client->m_HttpCache);
@@ -1273,6 +1307,7 @@ bail:
                 }
             }
         }
+#endif
 
         for (int i = 0; i < client->m_MaxGetRetries; ++i)
         {

--- a/engine/dlib/src/dlib/sslsocket_null.cpp
+++ b/engine/dlib/src/dlib/sslsocket_null.cpp
@@ -1,0 +1,78 @@
+// Copyright 2020-2026 The Defold Foundation
+// Copyright 2014-2020 King
+// Copyright 2009-2014 Ragnar Svensson, Christian Murray
+// Licensed under the Defold License version 1.0 (the "License"); you may not use
+// this file except in compliance with the License.
+//
+// You may obtain a copy of the License, together with FAQs at
+// https://www.defold.com/license
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#include "sslsocket.h"
+
+namespace dmSSLSocket
+{
+    Result Initialize()
+    {
+        return RESULT_OK;
+    }
+
+    Result Finalize()
+    {
+        return RESULT_OK;
+    }
+
+    Result SetSslPublicKeys(const uint8_t* key, uint32_t keylen)
+    {
+        (void) key;
+        (void) keylen;
+        return RESULT_SSL_INIT_FAILED;
+    }
+
+    Result New(dmSocket::Socket socket, const char* host, uint64_t timeout, Socket* sslsocket)
+    {
+        (void) socket;
+        (void) host;
+        (void) timeout;
+        if (sslsocket)
+            *sslsocket = INVALID_SOCKET_HANDLE;
+        return RESULT_SSL_INIT_FAILED;
+    }
+
+    Result Delete(Socket socket)
+    {
+        (void) socket;
+        return RESULT_OK;
+    }
+
+    dmSocket::Result Send(Socket socket, const void* buffer, int length, int* sent_bytes)
+    {
+        (void) socket;
+        (void) buffer;
+        (void) length;
+        if (sent_bytes)
+            *sent_bytes = 0;
+        return dmSocket::RESULT_OPNOTSUPP;
+    }
+
+    dmSocket::Result Receive(Socket socket, void* buffer, int length, int* received_bytes)
+    {
+        (void) socket;
+        (void) buffer;
+        (void) length;
+        if (received_bytes)
+            *received_bytes = 0;
+        return dmSocket::RESULT_OPNOTSUPP;
+    }
+
+    dmSocket::Result SetReceiveTimeout(Socket socket, uint64_t timeout)
+    {
+        (void) socket;
+        (void) timeout;
+        return dmSocket::RESULT_OPNOTSUPP;
+    }
+}

--- a/engine/dlib/src/test/test_configfile.cpp
+++ b/engine/dlib/src/test/test_configfile.cpp
@@ -425,6 +425,16 @@ const TestParam params_extension[] = {
 INSTANTIATE_TEST_CASE_P(ConfigfileExtension, ConfigfileExtension, jc_test_values_in(params_extension));
 
 
+#if defined(__EMSCRIPTEN__)
+TEST(ConfigFile, HttpLoadUnsupportedOnHtml5)
+{
+    dmConfigFile::HConfig config = 0;
+    dmConfigFile::Result result = dmConfigFile::Load("https://example.com/game.projectc", 1, DEFAULT_ARGV, &config);
+    ASSERT_EQ(dmConfigFile::RESULT_INVALID_URI, result);
+    ASSERT_EQ((dmConfigFile::HConfig)0, config);
+}
+#endif
+
 
 static void Usage()
 {

--- a/engine/dlib/src/test/test_configfile.cpp
+++ b/engine/dlib/src/test/test_configfile.cpp
@@ -424,18 +424,6 @@ const TestParam params_extension[] = {
 
 INSTANTIATE_TEST_CASE_P(ConfigfileExtension, ConfigfileExtension, jc_test_values_in(params_extension));
 
-
-#if defined(__EMSCRIPTEN__)
-TEST(ConfigFile, HttpLoadUnsupportedOnHtml5)
-{
-    dmConfigFile::HConfig config = 0;
-    dmConfigFile::Result result = dmConfigFile::Load("https://example.com/game.projectc", 1, DEFAULT_ARGV, &config);
-    ASSERT_EQ(dmConfigFile::RESULT_INVALID_URI, result);
-    ASSERT_EQ((dmConfigFile::HConfig)0, config);
-}
-#endif
-
-
 static void Usage()
 {
     dmLogError("Usage: <exe> <config>");

--- a/engine/dlib/src/wscript
+++ b/engine/dlib/src/wscript
@@ -139,7 +139,7 @@ def build(bld):
     # remove all null implementations
     dlib.source = remove_files(dlib.source, ['_null.cpp'])
     if 'web' in bld.env.PLATFORM:
-        dlib.source += bld.path.ant_glob(['dlib/sslsocket_null.cpp', 'dlib/configfile_http_null.cpp'])
+        dlib.source += bld.path.ant_glob(['dlib/http_cache_null.cpp', 'dlib/sslsocket_null.cpp', 'dlib/configfile_http_null.cpp'])
 
     if 'macos' in bld.env.BUILD_PLATFORM and build_util.get_target_os() not in ['macos', 'ios']:
         # NOTE: This is a hack required when cross compiling on darwin to linux platform(s)

--- a/engine/dlib/src/wscript
+++ b/engine/dlib/src/wscript
@@ -126,6 +126,10 @@ def build(bld):
     if build_util.get_target_os() in ['macos', 'ios']:
         source_files = remove_files(source_files, ['time_posix.cpp'])
 
+    if 'web' in bld.env.PLATFORM:
+        source_files = remove_files(source_files, ['http_cache.cpp', 'http_cache_verify.cpp', 'sslsocket.cpp', 'configfile_http.cpp'])
+        extra_defines.append('DM_NO_HTTP_CACHE')
+
     dlib = bld.stlib(features = 'c cxx',
                      source   = source_files + platform_source_files,
                      includes = ['.', './mbedtls/include', './mbedtls/crypto/include'],
@@ -134,6 +138,8 @@ def build(bld):
 
     # remove all null implementations
     dlib.source = remove_files(dlib.source, ['_null.cpp'])
+    if 'web' in bld.env.PLATFORM:
+        dlib.source += bld.path.ant_glob(['dlib/sslsocket_null.cpp', 'dlib/configfile_http_null.cpp'])
 
     if 'macos' in bld.env.BUILD_PLATFORM and build_util.get_target_os() not in ['macos', 'ios']:
         # NOTE: This is a hack required when cross compiling on darwin to linux platform(s)

--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -28,14 +28,12 @@
 #include <dlib/dlib.h>
 #include <dlib/dstrings.h>
 #include <dlib/hash.h>
-#include <dlib/http_client.h>
 #include <dlib/log.h>
 #include <dlib/math.h>
 #include <dlib/memprofile.h>
 #include <dlib/path.h>
 #include <dlib/profile.h>
 #include <dlib/socket.h>
-#include <dlib/sslsocket.h>
 #include <dlib/sys.h>
 #include <dlib/thread.h>
 #include <platform/window.hpp>
@@ -71,6 +69,9 @@
 
 #if defined(__EMSCRIPTEN__)
     #include "engine_web.h"
+#else
+	#include <dlib/http_client.h>
+	#include <dlib/sslsocket.h>
 #endif
 
 // Embedded resources
@@ -398,7 +399,9 @@ namespace dmEngine
 
         dmGameObject::DeleteCollections(engine->m_Register); // Delete all collections and game objects
 
+#if !defined(__EMSCRIPTEN__)
         dmHttpClient::ShutdownConnectionPool();
+#endif
 
         // Reregister the types before the rest of the contexts are deleted
         if (engine->m_Factory && engine->m_ResourceTypeContexts.Size() > 0) {
@@ -426,7 +429,9 @@ namespace dmEngine
             dmEngine::ScriptSysEngineFinalize(script_lib_context.m_LuaState, engine);
         }
 
+#if !defined(__EMSCRIPTEN__)
         dmHttpClient::ReopenConnectionPool();
+#endif
 
         dmGameObject::DeleteRegister(engine->m_Register);
 
@@ -616,6 +621,7 @@ namespace dmEngine
         return false;
     }
 
+#if !defined(__EMSCRIPTEN__)
     static bool LoadAndSetSslKeys(const char* ssl_keys_path)
     {
         if (!dmSys::ResourceExists(ssl_keys_path))
@@ -646,6 +652,7 @@ namespace dmEngine
         free(ssl_keys_buf);
         return loadind_key_result == dmSSLSocket::RESULT_OK;
     }
+#endif
 
     static void SetSwapInterval(HEngine engine, int swap_interval)
     {
@@ -855,6 +862,7 @@ namespace dmEngine
         int32_t minimum_log_level = dmConfigFile::GetInt(engine->m_Config, "project.minimum_log_level", LOG_SEVERITY_INFO);
         dmLogSetLevel((LogSeverity)minimum_log_level);
 
+#if !defined(__EMSCRIPTEN__)
         // Try loading SSL keys
         char engine_ssl_keys_path[DMPATH_MAX_PATH];
         dmPath::Concat(resources_path, "/ssl_keys.pem", engine_ssl_keys_path, sizeof(engine_ssl_keys_path));
@@ -874,6 +882,7 @@ namespace dmEngine
                 break;
             }
         }
+#endif
 
         // Set HTML5 console banner "MadeWithDefold"
         #if defined(__EMSCRIPTEN__)
@@ -1140,7 +1149,7 @@ namespace dmEngine
         SetUpdateFrequency(engine, dmConfigFile::GetInt(engine->m_Config, "display.update_frequency", 0));
 
         engine->m_HttpCache = 0;
-#if !defined(DM_NO_HTTP_CACHE)
+#if !defined(DM_NO_HTTP_CACHE) && !defined(__EMSCRIPTEN__)
         int http_cache_enabled = dmConfigFile::GetInt(engine->m_Config, "network.http_cache_enabled", 1);
         if (http_cache_enabled)
         {
@@ -2524,7 +2533,9 @@ void dmEngineInitialize()
     dmCrash::Init(dmEngineVersion::VERSION, dmEngineVersion::VERSION_SHA1);
     dmDDF::RegisterAllTypes();
     dmSocket::Initialize();
+#if !defined(__EMSCRIPTEN__)
     dmSSLSocket::Initialize();
+#endif
     dmMemProfile::Initialize();
     dmLog::LogParams params;
     dmLog::LogInitialize(&params);
@@ -2545,7 +2556,9 @@ void dmEngineFinalize()
     dmGraphics::Finalize();
     dmLog::LogFinalize();
     dmMemProfile::Finalize();
+#if !defined(__EMSCRIPTEN__)
     dmSSLSocket::Finalize();
+#endif
     dmSocket::Finalize();
 
     dmEngine::PlatformFinalize();

--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -69,10 +69,10 @@
 
 #if defined(__EMSCRIPTEN__)
     #include "engine_web.h"
-#else
-	#include <dlib/http_client.h>
-	#include <dlib/sslsocket.h>
 #endif
+
+#include <dlib/http_client.h>
+#include <dlib/sslsocket.h>
 
 // Embedded resources
 // Unfortunately, the draw_line et. al are used in production code
@@ -399,9 +399,7 @@ namespace dmEngine
 
         dmGameObject::DeleteCollections(engine->m_Register); // Delete all collections and game objects
 
-#if !defined(__EMSCRIPTEN__)
         dmHttpClient::ShutdownConnectionPool();
-#endif
 
         // Reregister the types before the rest of the contexts are deleted
         if (engine->m_Factory && engine->m_ResourceTypeContexts.Size() > 0) {
@@ -429,9 +427,7 @@ namespace dmEngine
             dmEngine::ScriptSysEngineFinalize(script_lib_context.m_LuaState, engine);
         }
 
-#if !defined(__EMSCRIPTEN__)
         dmHttpClient::ReopenConnectionPool();
-#endif
 
         dmGameObject::DeleteRegister(engine->m_Register);
 
@@ -519,8 +515,10 @@ namespace dmEngine
         ScopedExtensionAppParams app_params(engine);
         dmExtension::AppFinalize(app_params);
 
+#if !defined(DM_NO_HTTP_CACHE)
         if (engine->m_HttpCache)
             dmHttpCache::Close(engine->m_HttpCache);
+#endif
 
         dmBuffer::DeleteContext();
 
@@ -621,7 +619,6 @@ namespace dmEngine
         return false;
     }
 
-#if !defined(__EMSCRIPTEN__)
     static bool LoadAndSetSslKeys(const char* ssl_keys_path)
     {
         if (!dmSys::ResourceExists(ssl_keys_path))
@@ -652,7 +649,6 @@ namespace dmEngine
         free(ssl_keys_buf);
         return loadind_key_result == dmSSLSocket::RESULT_OK;
     }
-#endif
 
     static void SetSwapInterval(HEngine engine, int swap_interval)
     {
@@ -862,7 +858,6 @@ namespace dmEngine
         int32_t minimum_log_level = dmConfigFile::GetInt(engine->m_Config, "project.minimum_log_level", LOG_SEVERITY_INFO);
         dmLogSetLevel((LogSeverity)minimum_log_level);
 
-#if !defined(__EMSCRIPTEN__)
         // Try loading SSL keys
         char engine_ssl_keys_path[DMPATH_MAX_PATH];
         dmPath::Concat(resources_path, "/ssl_keys.pem", engine_ssl_keys_path, sizeof(engine_ssl_keys_path));
@@ -882,7 +877,6 @@ namespace dmEngine
                 break;
             }
         }
-#endif
 
         // Set HTML5 console banner "MadeWithDefold"
         #if defined(__EMSCRIPTEN__)
@@ -1149,7 +1143,7 @@ namespace dmEngine
         SetUpdateFrequency(engine, dmConfigFile::GetInt(engine->m_Config, "display.update_frequency", 0));
 
         engine->m_HttpCache = 0;
-#if !defined(DM_NO_HTTP_CACHE) && !defined(__EMSCRIPTEN__)
+#if !defined(DM_NO_HTTP_CACHE)
         int http_cache_enabled = dmConfigFile::GetInt(engine->m_Config, "network.http_cache_enabled", 1);
         if (http_cache_enabled)
         {
@@ -2533,9 +2527,7 @@ void dmEngineInitialize()
     dmCrash::Init(dmEngineVersion::VERSION, dmEngineVersion::VERSION_SHA1);
     dmDDF::RegisterAllTypes();
     dmSocket::Initialize();
-#if !defined(__EMSCRIPTEN__)
     dmSSLSocket::Initialize();
-#endif
     dmMemProfile::Initialize();
     dmLog::LogParams params;
     dmLog::LogInitialize(&params);
@@ -2556,9 +2548,7 @@ void dmEngineFinalize()
     dmGraphics::Finalize();
     dmLog::LogFinalize();
     dmMemProfile::Finalize();
-#if !defined(__EMSCRIPTEN__)
     dmSSLSocket::Finalize();
-#endif
     dmSocket::Finalize();
 
     dmEngine::PlatformFinalize();

--- a/engine/engine/src/wscript
+++ b/engine/engine/src/wscript
@@ -152,11 +152,15 @@ def build(bld):
 
     additional_libs.extend(font_lib)
 
+    resource_provider_symbols = []
+    if bld.env['PLATFORM'] not in ('js-web', 'wasm-web', 'wasm_pthread-web'):
+        resource_provider_symbols.append('ResourceProviderHttp')
+
     obj = bld(
         features = 'c cxx cprogram apk web extract_symbols',
         use = 'engine_rs PROFILEREXT GAMEOBJECT DDF LIVEUPDATE RESOURCE GAMESYS PHYSICS RECORD RENDER SOCKET SCRIPT LUA EXTENSION HID INPUT PARTICLE RIG DLIB GUI CRASH engine engine_service'.split() + graphics_lib + sound_lib + profile_lib + platform_lib + additional_libs,
         web_libs = web_libs,
-        exported_symbols = exported_symbols + profile_symbols + resource_type_symbols + ['ResourceProviderHttp'] + component_type_symbols,
+        exported_symbols = exported_symbols + profile_symbols + resource_type_symbols + resource_provider_symbols + component_type_symbols,
         includes = '../build ../proto . ..',
         #NOTE: _XBOX to get static lib and avoid dllimport/dllexport stuff
         defines = '_XBOX',

--- a/engine/engine/src/wscript
+++ b/engine/engine/src/wscript
@@ -42,9 +42,14 @@ def build(bld):
     elif bld.env.PLATFORM in ('x86_64-xbone'):
         source.append('engine_xbox.cpp')
 
+    engine_defines = []
+    if bld.env['PLATFORM'] in ('js-web', 'wasm-web', 'wasm_pthread-web'):
+        engine_defines.append('DM_NO_HTTP_CACHE')
+
     bld.stlib(features = 'cxx ddf embed',
                     includes = '../proto . ..',
                     target = 'engine',
+                    defines = engine_defines,
                     proto_gen_py = True,
                     protoc_includes = ['../proto', bld.env['PREFIX'] + '/share'],
                     embed_source='../content/materials/debug.spc ../content/builtins/connect/game.project ../content/builtins.arci ../content/builtins.arcd ../content/builtins.dmanifest',
@@ -57,7 +62,7 @@ def build(bld):
     bld.stlib(features = 'cxx ddf',
                     includes = '../proto . ..',
                     target = 'engine_release',
-                    defines = 'DM_RELEASE=1',
+                    defines = ['DM_RELEASE=1'] + engine_defines,
                     proto_gen_py = True,
                     protoc_includes = ['../proto', bld.env['PREFIX'] + '/share'],
                     source = source,
@@ -152,9 +157,7 @@ def build(bld):
 
     additional_libs.extend(font_lib)
 
-    resource_provider_symbols = []
-    if bld.env['PLATFORM'] not in ('js-web', 'wasm-web', 'wasm_pthread-web'):
-        resource_provider_symbols.append('ResourceProviderHttp')
+    resource_provider_symbols = ['ResourceProviderHttp']
 
     obj = bld(
         features = 'c cxx cprogram apk web extract_symbols',

--- a/engine/gamesys/src/gamesys/scripts/script_http_js.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_http_js.cpp
@@ -31,7 +31,6 @@
 #include <script/http_ddf.h>
 
 #include "script_http.h"
-#include <script/http_service.h>
 
 #include <extension/extension.hpp>
 

--- a/engine/resource/src/providers/provider_http_null.cpp
+++ b/engine/resource/src/providers/provider_http_null.cpp
@@ -1,0 +1,109 @@
+// Copyright 2020-2026 The Defold Foundation
+// Copyright 2014-2020 King
+// Copyright 2009-2014 Ragnar Svensson, Christian Murray
+// Licensed under the Defold License version 1.0 (the "License"); you may not use
+// this file except in compliance with the License.
+//
+// You may obtain a copy of the License, together with FAQs at
+// https://www.defold.com/license
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#include <string.h>
+
+#include <dlib/log.h>
+
+#include "provider.h"
+#include "provider_private.h"
+
+namespace dmResourceProviderHttp
+{
+    static const char* SafeString(const char* value)
+    {
+        return value ? value : "";
+    }
+
+    static bool MatchesUri(const dmURI::Parts* uri)
+    {
+        return strcmp(uri->m_Scheme, "http") == 0 || strcmp(uri->m_Scheme, "https") == 0;
+    }
+
+    static dmResourceProvider::Result Mount(const dmURI::Parts* uri, dmResourceProvider::HArchive base_archive, dmResourceProvider::HArchiveInternal* out_archive)
+    {
+        (void) base_archive;
+        (void) out_archive;
+
+        if (!MatchesUri(uri))
+            return dmResourceProvider::RESULT_NOT_SUPPORTED;
+
+        dmLogError("Remote resource roots via HTTP(S) are not supported on HTML5: %s://%s%s",
+            SafeString(uri->m_Scheme), SafeString(uri->m_Location), SafeString(uri->m_Path));
+        return dmResourceProvider::RESULT_NOT_SUPPORTED;
+    }
+
+    static dmResourceProvider::Result Unmount(dmResourceProvider::HArchiveInternal archive)
+    {
+        (void) archive;
+        return dmResourceProvider::RESULT_OK;
+    }
+
+    static dmResourceProvider::Result GetFileSize(dmResourceProvider::HArchiveInternal archive, dmhash_t path_hash, const char* path, uint32_t* file_size)
+    {
+        (void) archive;
+        (void) path_hash;
+        (void) path;
+        (void) file_size;
+        return dmResourceProvider::RESULT_NOT_SUPPORTED;
+    }
+
+    static dmResourceProvider::Result ReadFile(dmResourceProvider::HArchiveInternal archive, dmhash_t path_hash, const char* path, uint8_t* buffer, uint32_t buffer_len)
+    {
+        (void) archive;
+        (void) path_hash;
+        (void) path;
+        (void) buffer;
+        (void) buffer_len;
+        return dmResourceProvider::RESULT_NOT_SUPPORTED;
+    }
+
+    static dmResourceProvider::Result ReadFilePartial(dmResourceProvider::HArchiveInternal archive, dmhash_t path_hash, const char* path, uint32_t offset, uint32_t size, uint8_t* buffer, uint32_t* nread)
+    {
+        (void) archive;
+        (void) path_hash;
+        (void) path;
+        (void) offset;
+        (void) size;
+        (void) buffer;
+        (void) nread;
+        return dmResourceProvider::RESULT_NOT_SUPPORTED;
+    }
+
+    static dmResourceProvider::Result InitializeArchiveLoaderHttp(dmResourceProvider::ArchiveLoaderParams* params, dmResourceProvider::ArchiveLoader* loader)
+    {
+        (void) params;
+        (void) loader;
+        return dmResourceProvider::RESULT_OK;
+    }
+
+    static dmResourceProvider::Result FinalizeArchiveLoaderHttp(dmResourceProvider::ArchiveLoaderParams* params, dmResourceProvider::ArchiveLoader* loader)
+    {
+        (void) params;
+        (void) loader;
+        return dmResourceProvider::RESULT_OK;
+    }
+
+    static void SetupArchiveLoaderHttp(dmResourceProvider::ArchiveLoader* loader)
+    {
+        loader->m_CanMount        = MatchesUri;
+        loader->m_Mount           = Mount;
+        loader->m_Unmount         = Unmount;
+        loader->m_GetFileSize     = GetFileSize;
+        loader->m_ReadFile        = ReadFile;
+        loader->m_ReadFilePartial = ReadFilePartial;
+    }
+
+    DM_DECLARE_ARCHIVE_LOADER(ResourceProviderHttp, "http", SetupArchiveLoaderHttp, InitializeArchiveLoaderHttp, FinalizeArchiveLoaderHttp);
+}

--- a/engine/resource/src/providers/provider_http_null.cpp
+++ b/engine/resource/src/providers/provider_http_null.cpp
@@ -12,35 +12,22 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
-#include <string.h>
-
-#include <dlib/log.h>
-
 #include "provider.h"
 #include "provider_private.h"
 
 namespace dmResourceProviderHttp
 {
-    static const char* SafeString(const char* value)
-    {
-        return value ? value : "";
-    }
-
     static bool MatchesUri(const dmURI::Parts* uri)
     {
-        return strcmp(uri->m_Scheme, "http") == 0 || strcmp(uri->m_Scheme, "https") == 0;
+        (void) uri;
+        return false;
     }
 
     static dmResourceProvider::Result Mount(const dmURI::Parts* uri, dmResourceProvider::HArchive base_archive, dmResourceProvider::HArchiveInternal* out_archive)
     {
+        (void) uri;
         (void) base_archive;
         (void) out_archive;
-
-        if (!MatchesUri(uri))
-            return dmResourceProvider::RESULT_NOT_SUPPORTED;
-
-        dmLogError("Remote resource roots via HTTP(S) are not supported on HTML5: %s://%s%s",
-            SafeString(uri->m_Scheme), SafeString(uri->m_Location), SafeString(uri->m_Path));
         return dmResourceProvider::RESULT_NOT_SUPPORTED;
     }
 

--- a/engine/resource/src/resource.cpp
+++ b/engine/resource/src/resource.cpp
@@ -228,6 +228,16 @@ HFactory NewFactory(NewFactoryParams* params, const char* uri)
         return 0;
     }
 
+#if defined(__EMSCRIPTEN__)
+    if (strcmp(factory->m_UriParts.m_Scheme, "http") == 0 || strcmp(factory->m_UriParts.m_Scheme, "https") == 0)
+    {
+        dmLogError("Remote resource roots via HTTP(S) are not supported on HTML5: %s", uri);
+        dmMessage::DeleteSocket(socket);
+        delete factory;
+        return 0;
+    }
+#endif
+
     factory->m_HttpCache = params->m_HttpCache;
 
     factory->m_Mounts = 0;

--- a/engine/resource/src/resource.cpp
+++ b/engine/resource/src/resource.cpp
@@ -228,16 +228,6 @@ HFactory NewFactory(NewFactoryParams* params, const char* uri)
         return 0;
     }
 
-#if defined(__EMSCRIPTEN__)
-    if (strcmp(factory->m_UriParts.m_Scheme, "http") == 0 || strcmp(factory->m_UriParts.m_Scheme, "https") == 0)
-    {
-        dmLogError("Remote resource roots via HTTP(S) are not supported on HTML5: %s", uri);
-        dmMessage::DeleteSocket(socket);
-        delete factory;
-        return 0;
-    }
-#endif
-
     factory->m_HttpCache = params->m_HttpCache;
 
     factory->m_Mounts = 0;
@@ -264,6 +254,7 @@ HFactory NewFactory(NewFactoryParams* params, const char* uri)
     factory->m_JobThreadContext = params->m_JobThreadContext;
 
     int num_mounted = 0;
+    bool mount_unsupported = false;
     for (uint32_t i = 0; i < DM_ARRAY_SIZE(type_pairs); ++i)
     {
         if (strcmp(factory->m_UriParts.m_Scheme, type_pairs[i].m_Scheme) != 0)
@@ -278,6 +269,11 @@ HFactory NewFactory(NewFactoryParams* params, const char* uri)
             dmResourceProvider::Result provider_result = dmResourceProvider::CreateMount(loader, &factory->m_UriParts, 0, &archive);
             if (dmResourceProvider::RESULT_OK != provider_result)
             {
+                if (provider_result == dmResourceProvider::RESULT_NOT_SUPPORTED)
+                {
+                    mount_unsupported = true;
+                    continue;
+                }
                 dmLogError("Failed to mount base archive: %d for mount %s://%s%s", provider_result, factory->m_UriParts.m_Scheme, factory->m_UriParts.m_Location, factory->m_UriParts.m_Path);
                 continue;
             }
@@ -322,7 +318,10 @@ HFactory NewFactory(NewFactoryParams* params, const char* uri)
 
     if (!num_mounted)
     {
-        dmLogWarning("No resource loaders mounted that could match uri %s", uri);
+        if (!mount_unsupported)
+        {
+            dmLogWarning("No resource loaders mounted that could match uri %s", uri);
+        }
         DeleteFactory(factory);
         dmMessage::DeleteSocket(socket);
         return 0;

--- a/engine/resource/src/test/test_resource.cpp
+++ b/engine/resource/src/test/test_resource.cpp
@@ -991,6 +991,17 @@ TEST(dmResource, InvalidUri)
 }
 #endif
 
+#if defined(__EMSCRIPTEN__)
+TEST(dmResource, HttpResourceRootUnsupportedOnHtml5)
+{
+    dmResource::NewFactoryParams params;
+    params.m_MaxResources = 16;
+    params.m_Flags = RESOURCE_FACTORY_FLAGS_RELOAD_SUPPORT;
+    dmResource::HFactory factory = dmResource::NewFactory(&params, "https://example.com/liveupdate");
+    ASSERT_EQ((void*) 0, factory);
+}
+#endif
+
 dmResource::Result AdResourceCreate(const dmResource::ResourceCreateParams* params)
 {
     uint32_t data_size = params->m_BufferSize;

--- a/engine/resource/src/test/test_resource.cpp
+++ b/engine/resource/src/test/test_resource.cpp
@@ -991,17 +991,6 @@ TEST(dmResource, InvalidUri)
 }
 #endif
 
-#if defined(__EMSCRIPTEN__)
-TEST(dmResource, HttpResourceRootUnsupportedOnHtml5)
-{
-    dmResource::NewFactoryParams params;
-    params.m_MaxResources = 16;
-    params.m_Flags = RESOURCE_FACTORY_FLAGS_RELOAD_SUPPORT;
-    dmResource::HFactory factory = dmResource::NewFactory(&params, "https://example.com/liveupdate");
-    ASSERT_EQ((void*) 0, factory);
-}
-#endif
-
 dmResource::Result AdResourceCreate(const dmResource::ResourceCreateParams* params)
 {
     uint32_t data_size = params->m_BufferSize;

--- a/engine/resource/src/test/wscript
+++ b/engine/resource/src/test/wscript
@@ -129,9 +129,7 @@ def build(bld):
     if is_web:
         skip_http_test = ['skip_test']
 
-    resource_http_provider_symbols = []
-    if not is_web:
-        resource_http_provider_symbols.append('ResourceProviderHttp')
+    resource_http_provider_symbols = ['ResourceProviderHttp']
 
     bld.program(features     = 'cxx test',
                 includes     = '.. ../../proto',

--- a/engine/resource/src/test/wscript
+++ b/engine/resource/src/test/wscript
@@ -107,8 +107,10 @@ def build(bld):
 
     bld.add_group()
 
+    is_web = bld.env.PLATFORM in ['wasm-web', 'wasm_pthread-web', 'js-web']
+
     defines = []
-    if not ('GITHUB_CI' in bld.env.DEFINES and sys.platform == 'darwin'):
+    if not is_web and not ('GITHUB_CI' in bld.env.DEFINES and sys.platform == 'darwin'):
         defines = ['DM_TEST_HTTP_SUPPORTED']
     if bld.env.PLATFORM in ['arm64-nx64']:
         defines = []
@@ -124,8 +126,12 @@ def build(bld):
     # ******************************************************************************************************************************
     # Resource providers
     skip_http_test = []
-    if bld.env.PLATFORM in ['wasm-web','wasm_pthread-web','js-web']:
+    if is_web:
         skip_http_test = ['skip_test']
+
+    resource_http_provider_symbols = []
+    if not is_web:
+        resource_http_provider_symbols.append('ResourceProviderHttp')
 
     bld.program(features     = 'cxx test',
                 includes     = '.. ../../proto',
@@ -160,7 +166,7 @@ def build(bld):
                 includes     = '.. ../../proto',
                 defines      = defines,
                 use          = 'TESTMAIN DDF DLIB PROFILE_NULL SOCKET THREAD LUA resource',
-                exported_symbols = ['ResourceProviderHttp'],
+                exported_symbols = resource_http_provider_symbols,
                 target       = 'test_provider_http',
                 source       = 'test_provider_http.cpp')
 
@@ -213,7 +219,7 @@ def build(bld):
                 use          = 'TESTMAIN DDF DLIB PROFILE_NULL SOCKET THREAD LUA APP resource',
                 web_libs     = ['library_sys.js'],
                 proto_gen_py = True,
-                exported_symbols = ['ResourceProviderFile', 'ResourceProviderHttp', 'ResourceProviderArchive'],
+                exported_symbols = ['ResourceProviderFile', 'ResourceProviderArchive'] + resource_http_provider_symbols,
                 target       = 'test_resource',
                 source       = 'test_resource.cpp test_resource_ddf.proto test.cont_pb test01.foo_pb test02.foo_pb self_referring.cont_pb root_loop.cont_pb child_loop.cont_pb many_refs.cont_pb',
                 embed_source = 'resources.arci resources.arcd resources.dmanifest')

--- a/engine/resource/src/wscript
+++ b/engine/resource/src/wscript
@@ -5,6 +5,9 @@ from waf_dynamo import dmsdk_add_files
 def configure(conf):
     pass
 
+def remove_from_node_list(lst, name):
+    return [x for x in lst if not x.abspath().endswith(name)]
+
 def build(bld):
     resource = bld.stlib(features = 'cxx ddf',
                          includes = '. ../proto',
@@ -12,6 +15,9 @@ def build(bld):
                          protoc_includes = '../proto',
                          proto_gen_py = True,
                          target = 'resource')
+
+    if 'web' in bld.env.PLATFORM:
+        resource.source = remove_from_node_list(resource.source, 'provider_http.cpp')
 
     resource.source.append('async/load_queue.cpp');
     if 'web' in bld.env.PLATFORM:
@@ -47,4 +53,3 @@ def build(bld):
     bld.install_files('${PREFIX}/include/resource/providers', 'providers/provider.h')
     bld.install_files('${PREFIX}/lib/python', 'waf_resource.py')
     bld.install_files('${PREFIX}/bin', 'arcc.py')
-

--- a/engine/resource/src/wscript
+++ b/engine/resource/src/wscript
@@ -18,6 +18,8 @@ def build(bld):
 
     if 'web' in bld.env.PLATFORM:
         resource.source = remove_from_node_list(resource.source, 'provider_http.cpp')
+    else:
+        resource.source = remove_from_node_list(resource.source, 'provider_http_null.cpp')
 
     resource.source.append('async/load_queue.cpp');
     if 'web' in bld.env.PLATFORM:

--- a/engine/script/src/http_service_null.cpp
+++ b/engine/script/src/http_service_null.cpp
@@ -1,0 +1,62 @@
+// Copyright 2020-2026 The Defold Foundation
+// Copyright 2014-2020 King
+// Copyright 2009-2014 Ragnar Svensson, Christian Murray
+// Licensed under the Defold License version 1.0 (the "License"); you may not use
+// this file except in compliance with the License.
+//
+// You may obtain a copy of the License, together with FAQs at
+// https://www.defold.com/license
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#include <dlib/log.h>
+#include <dlib/message.h>
+
+#include "http_ddf.h"
+#include "http_service.h"
+
+namespace dmHttpService
+{
+    #define HTTP_SOCKET_NAME "@http"
+
+    struct HttpService
+    {
+        dmMessage::HSocket m_Socket;
+    };
+
+    HHttpService New(const Params* params)
+    {
+        (void) params;
+
+        HttpService* service = new HttpService;
+        service->m_Socket = 0;
+
+        dmMessage::Result result = dmMessage::NewSocket(HTTP_SOCKET_NAME, &service->m_Socket);
+        if (result != dmMessage::RESULT_OK)
+        {
+            dmLogError("Unable to create HTTP service socket: %d", result);
+            delete service;
+            return 0;
+        }
+
+        return service;
+    }
+
+    dmMessage::HSocket GetSocket(HHttpService http_service)
+    {
+        return http_service ? http_service->m_Socket : 0;
+    }
+
+    void Delete(HHttpService http_service)
+    {
+        if (!http_service)
+            return;
+
+        if (http_service->m_Socket)
+            dmMessage::DeleteSocket(http_service->m_Socket);
+        delete http_service;
+    }
+}

--- a/engine/script/src/http_service_null.cpp
+++ b/engine/script/src/http_service_null.cpp
@@ -20,43 +20,21 @@
 
 namespace dmHttpService
 {
-    #define HTTP_SOCKET_NAME "@http"
-
-    struct HttpService
-    {
-        dmMessage::HSocket m_Socket;
-    };
-
     HHttpService New(const Params* params)
     {
         (void) params;
-
-        HttpService* service = new HttpService;
-        service->m_Socket = 0;
-
-        dmMessage::Result result = dmMessage::NewSocket(HTTP_SOCKET_NAME, &service->m_Socket);
-        if (result != dmMessage::RESULT_OK)
-        {
-            dmLogError("Unable to create HTTP service socket: %d", result);
-            delete service;
-            return 0;
-        }
-
-        return service;
+        dmLogError("HTTP service is not supported on HTML5.");
+        return 0;
     }
 
     dmMessage::HSocket GetSocket(HHttpService http_service)
     {
-        return http_service ? http_service->m_Socket : 0;
+        (void) http_service;
+        return 0;
     }
 
     void Delete(HHttpService http_service)
     {
-        if (!http_service)
-            return;
-
-        if (http_service->m_Socket)
-            dmMessage::DeleteSocket(http_service->m_Socket);
-        delete http_service;
+        (void) http_service;
     }
 }

--- a/engine/script/src/wscript
+++ b/engine/script/src/wscript
@@ -24,6 +24,7 @@ def build(bld):
         script.source = remove_from_node_list(script.source, 'http_service.cpp')
     else:
         script.source = remove_from_node_list(script.source, 'script_html5_js.cpp')
+        script.source = remove_from_node_list(script.source, 'http_service_null.cpp')
 
     # luabitop
     if 'lua' in waflib.Utils.to_list(script.env['STLIB_LUA']):

--- a/engine/script/src/wscript
+++ b/engine/script/src/wscript
@@ -21,6 +21,7 @@ def build(bld):
 
     if 'web' in bld.env.PLATFORM:
         script.source = remove_from_node_list(script.source, 'script_html5.cpp')
+        script.source = remove_from_node_list(script.source, 'http_service.cpp')
     else:
         script.source = remove_from_node_list(script.source, 'script_html5_js.cpp')
 


### PR DESCRIPTION
Even though `http_service.cpp` and `provider_http.cpp` were unused in HTML5, they were accidentally included in the HTML5 binary. 

Excluding them reduces the HTML5 release build from 2 604 862 bytes to 2 469 942 bytes, saving 134 920 bytes (~5.2%)