### PR TITLE
Insert call arguments for LSP completions

### DIFF
--- a/editor/src/clj/editor/lsp/server.clj
+++ b/editor/src/clj/editor/lsp/server.clj
@@ -274,7 +274,8 @@
                   workspace (g/node-value project :workspace evaluation-context)
                   root (g/raw-property-value (:basis evaluation-context) workspace :root)]
               {:runtime {:version "Lua 5.1" :pathStrict true}
-               :completion {:workspaceWord false}
+               :completion {:workspaceWord false
+                            :callSnippet "Replace"}
                :diagnostics {:globals (-> lua/defined-globals
                                           (into (lua/extract-globals-from-completions completions))
                                           (into (lua/extract-globals-from-completions lua/editor-completions)))}


### PR DESCRIPTION
Accepting Lua function completions from the Lua language server now inserts the call with parentheses and arguments instead of only the function name.

Fix #12025
