### PR TITLE
Reject loading of glTF files that have more than one joint or weight channels

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/ModelUtilTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/ModelUtilTest.java
@@ -14,6 +14,12 @@
 
 package com.dynamo.bob.pipeline;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -39,8 +45,6 @@ import com.dynamo.bob.util.MurmurHash;
 
 import com.dynamo.proto.DdfMath.Vector3;
 import com.dynamo.rig.proto.Rig;
-
-import static org.junit.Assert.*;
 
 public class ModelUtilTest {
 

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/ModelUtilTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/ModelUtilTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
 import java.io.File;

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/ModelUtilTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/ModelUtilTest.java
@@ -14,12 +14,6 @@
 
 package com.dynamo.bob.pipeline;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -45,6 +39,8 @@ import com.dynamo.bob.util.MurmurHash;
 
 import com.dynamo.proto.DdfMath.Vector3;
 import com.dynamo.rig.proto.Rig;
+
+import static org.junit.Assert.*;
 
 public class ModelUtilTest {
 
@@ -209,14 +205,14 @@ public class ModelUtilTest {
         }
     }
 
-    Modelimporter.Scene loadSceneNoException(String path) throws IOException {
+    Modelimporter.Scene loadScene(String path) throws IOException {
         File cwd = new File(".");
         return ModelUtil.loadScene(getClass().getResourceAsStream(path), path, new Modelimporter.Options(), new ModelImporterJni.FileDataResolver(cwd));
     }
 
-   Modelimporter.Scene loadScene(String path) {
+   Modelimporter.Scene loadSceneNoException(String path) {
         try {
-            return loadSceneNoException(path);
+            return loadScene(path);
         } catch (IOException e) {
             e.printStackTrace();
             return null;
@@ -227,7 +223,7 @@ public class ModelUtilTest {
                                          Rig.MeshSet.Builder meshSetBuilder,
                                          Rig.AnimationSet.Builder animSetBuilder,
                                          Rig.Skeleton.Builder skeletonBuilder) {
-        Modelimporter.Scene scene = loadScene(path);
+        Modelimporter.Scene scene = loadSceneNoException(path);
         if (scene != null)
         {
             ModelUtil.loadModels(scene, meshSetBuilder);
@@ -241,14 +237,14 @@ public class ModelUtilTest {
 
     private Modelimporter.Scene loadBuiltScene(String path,
                                          Rig.MeshSet.Builder meshSetBuilder) {
-        Modelimporter.Scene scene = loadScene(path);
+        Modelimporter.Scene scene = loadSceneNoException(path);
         ModelUtil.loadModels(scene, meshSetBuilder);
         return scene;
     }
 
     private Modelimporter.Scene loadBuiltScene(String path,
                                          Rig.Skeleton.Builder skeletonBuilder) {
-        Modelimporter.Scene scene = loadScene(path);
+        Modelimporter.Scene scene = loadSceneNoException(path);
         ModelUtil.loadSkeleton(scene, skeletonBuilder);
         return scene;
     }
@@ -488,7 +484,7 @@ public class ModelUtilTest {
         Rig.AnimationSet.Builder animSetBuilder = Rig.AnimationSet.newBuilder();
         Rig.Skeleton.Builder skeletonBuilder = Rig.Skeleton.newBuilder();
         Modelimporter.Scene scene = loadBuiltScene("broken.gltf", meshSetBuilder, animSetBuilder, skeletonBuilder);
-        assertTrue(scene == null);
+        assertNull(scene);
     }
 
     /**
@@ -498,7 +494,7 @@ public class ModelUtilTest {
     @Test
     public void testMultipleJointWeightAttributeSetsRejected() {
         try {
-            loadSceneNoException("multiple_joint_weight_sets.gltf");
+            loadScene("multiple_joint_weight_sets.gltf");
         } catch (IOException e) {
             assertTrue(e.getMessage().contains("multiple joint/weight attribute sets"));
         }
@@ -532,6 +528,6 @@ public class ModelUtilTest {
         }
 
         // Validate we have a reasonable number of models (not duplicated)
-        assertTrue("Should have at least 1 model", models.size() >= 1);
+        assertFalse("Should have at least 1 model", models.isEmpty());
     }
 }

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/ModelUtilTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/ModelUtilTest.java
@@ -209,10 +209,14 @@ public class ModelUtilTest {
         }
     }
 
+    Modelimporter.Scene loadSceneNoException(String path) throws IOException {
+        File cwd = new File(".");
+        return ModelUtil.loadScene(getClass().getResourceAsStream(path), path, new Modelimporter.Options(), new ModelImporterJni.FileDataResolver(cwd));
+    }
+
    Modelimporter.Scene loadScene(String path) {
         try {
-            File cwd = new File(".");
-            return ModelUtil.loadScene(getClass().getResourceAsStream(path), path, new Modelimporter.Options(), new ModelImporterJni.FileDataResolver(cwd));
+            return loadSceneNoException(path);
         } catch (IOException e) {
             e.printStackTrace();
             return null;
@@ -287,7 +291,7 @@ public class ModelUtilTest {
      * Tests a collada file with fewer, and more, than 4 bone influences per vertex.
      */
     @Test
-    public void testBoneInfluences() throws Exception {
+    public void testBoneInfluences() {
         Rig.MeshSet.Builder meshSetBuilder = Rig.MeshSet.newBuilder();
         Rig.AnimationSet.Builder animSetBuilder = Rig.AnimationSet.newBuilder();
         Rig.Skeleton.Builder skeletonBuilder = Rig.Skeleton.newBuilder();
@@ -325,7 +329,7 @@ public class ModelUtilTest {
     }
 
     @Test
-    public void testSkeleton() throws Exception {
+    public void testSkeleton() {
 
         String[] boneIds   = {"root", "Middle", "Top"};
         String[] parentIds = {null,   "root", "Middle"};
@@ -352,7 +356,7 @@ public class ModelUtilTest {
      *  Tests a collada with two connected bones, each with their own animation track.
      */
     @Test
-    public void testTwoBoneAnimation() throws Exception {
+    public void testTwoBoneAnimation() {
         Rig.MeshSet.Builder meshSetBuilder = Rig.MeshSet.newBuilder();
         Rig.AnimationSet.Builder animSetBuilder = Rig.AnimationSet.newBuilder();
         Rig.Skeleton.Builder skeletonBuilder = Rig.Skeleton.newBuilder();
@@ -426,7 +430,7 @@ public class ModelUtilTest {
      * Collada file with a asset unit scale set to 0.01.
      */
     @Test
-    public void testAssetUnit() throws Exception {
+    public void testAssetUnit() {
         Rig.MeshSet.Builder meshSetBuilder = Rig.MeshSet.newBuilder();
         Rig.AnimationSet.Builder animSetBuilder = Rig.AnimationSet.newBuilder();
         Rig.Skeleton.Builder skeletonBuilder = Rig.Skeleton.newBuilder();
@@ -479,7 +483,7 @@ public class ModelUtilTest {
      * Tests that an invalid gltf file is handled
      */
     @Test
-    public void testInvalidFile() throws Exception {
+    public void testInvalidFile() {
         Rig.MeshSet.Builder meshSetBuilder = Rig.MeshSet.newBuilder();
         Rig.AnimationSet.Builder animSetBuilder = Rig.AnimationSet.newBuilder();
         Rig.Skeleton.Builder skeletonBuilder = Rig.Skeleton.newBuilder();
@@ -487,33 +491,46 @@ public class ModelUtilTest {
         assertTrue(scene == null);
     }
 
+    /**
+     * glTF allows multiple joint/weight attribute sets (JOINTS_0/WEIGHTS_0, JOINTS_1/WEIGHTS_1, ...).
+     * Defold only supports a single set; the native loader must fail with a clear error.
+     */
     @Test
-    public void testVehicleGltfHierarchy() throws Exception {
+    public void testMultipleJointWeightAttributeSetsRejected() {
+        try {
+            loadSceneNoException("multiple_joint_weight_sets.gltf");
+        } catch (IOException e) {
+            assertTrue(e.getMessage().contains("multiple joint/weight attribute sets"));
+        }
+    }
+
+    @Test
+    public void testVehicleGltfHierarchy() {
         Rig.MeshSet.Builder meshSetBuilder = Rig.MeshSet.newBuilder();
         Modelimporter.Scene scene = loadBuiltScene("vehicle.glb", meshSetBuilder);
-        
+
         // Validate scene loaded successfully
         assertNotNull("Vehicle scene should load", scene);
-        
+
         // Get all models from the meshset
         List<Rig.Model> models = meshSetBuilder.getModelsList();
-        
+
         // Check for duplicate models by collecting IDs
         Set<Long> modelIds = new HashSet<>();
-        
+
         for (Rig.Model model : models) {
             long id = model.getId();
             String name = "Model_" + id; // Since we hash the node name
-            
-            assertFalse("Model ID " + id + " should be unique (no duplicates)", 
+
+            assertFalse("Model ID " + id + " should be unique (no duplicates)",
                        modelIds.contains(id));
             modelIds.add(id);
-            
+
             // Validate model has meshes
-            assertTrue("Model should have at least one mesh", 
+            assertTrue("Model should have at least one mesh",
                       model.getMeshesCount() > 0);
         }
-        
+
         // Validate we have a reasonable number of models (not duplicated)
         assertTrue("Should have at least 1 model", models.size() >= 1);
     }

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/multiple_joint_weight_sets.gltf
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/multiple_joint_weight_sets.gltf
@@ -1,0 +1,157 @@
+{
+    "asset": {
+        "version": "2.0"
+    },
+    "scene": 0,
+    "scenes": [
+        {
+            "nodes": [
+                2,
+                0
+            ]
+        }
+    ],
+    "nodes": [
+        {
+            "name": "Bone",
+            "children": [
+                1
+            ]
+        },
+        {
+            "name": "Bone_001"
+        },
+        {
+            "name": "SkinnedMesh",
+            "mesh": 0,
+            "skin": 0
+        }
+    ],
+    "meshes": [
+        {
+            "name": "Mesh",
+            "primitives": [
+                {
+                    "attributes": {
+                        "POSITION": 1,
+                        "JOINTS_0": 2,
+                        "WEIGHTS_0": 3,
+                        "JOINTS_1": 4,
+                        "WEIGHTS_1": 5
+                    },
+                    "indices": 0,
+                    "material": 0
+                }
+            ]
+        }
+    ],
+    "materials": [
+        {}
+    ],
+    "skins": [
+        {
+            "inverseBindMatrices": 6,
+            "joints": [
+                0,
+                1
+            ]
+        }
+    ],
+    "accessors": [
+        {
+            "bufferView": 0,
+            "componentType": 5123,
+            "count": 3,
+            "type": "SCALAR"
+        },
+        {
+            "bufferView": 1,
+            "componentType": 5126,
+            "count": 3,
+            "max": [
+                1.0,
+                1.0,
+                0.0
+            ],
+            "min": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "type": "VEC3"
+        },
+        {
+            "bufferView": 2,
+            "componentType": 5123,
+            "count": 3,
+            "type": "VEC4"
+        },
+        {
+            "bufferView": 3,
+            "componentType": 5126,
+            "count": 3,
+            "type": "VEC4"
+        },
+        {
+            "bufferView": 4,
+            "componentType": 5123,
+            "count": 3,
+            "type": "VEC4"
+        },
+        {
+            "bufferView": 5,
+            "componentType": 5126,
+            "count": 3,
+            "type": "VEC4"
+        },
+        {
+            "bufferView": 6,
+            "componentType": 5126,
+            "count": 2,
+            "type": "MAT4"
+        }
+    ],
+    "bufferViews": [
+        {
+            "buffer": 0,
+            "byteOffset": 0,
+            "byteLength": 6
+        },
+        {
+            "buffer": 0,
+            "byteOffset": 8,
+            "byteLength": 36
+        },
+        {
+            "buffer": 0,
+            "byteOffset": 44,
+            "byteLength": 24
+        },
+        {
+            "buffer": 0,
+            "byteOffset": 68,
+            "byteLength": 48
+        },
+        {
+            "buffer": 0,
+            "byteOffset": 116,
+            "byteLength": 24
+        },
+        {
+            "buffer": 0,
+            "byteOffset": 140,
+            "byteLength": 48
+        },
+        {
+            "buffer": 0,
+            "byteOffset": 188,
+            "byteLength": 128
+        }
+    ],
+    "buffers": [
+        {
+            "byteLength": 316,
+            "uri": "data:application/octet-stream;base64,AAABAAIAAAAAAAAAAAAAAAAAAAAAAIA/AAAAAAAAAAAAAAAAAACAPwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIA/AAAAAAAAAAAAAAAAAACAPwAAAAAAAAAAAAAAAAAAgD8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIA/AAAAAAAAAAAAAAAAAAAAAAAAgD8AAAAAAAAAAAAAAAAAAAAAAACAPwAAAAAAAAAAAAAAAAAAAAAAAIA/AACAPwAAAAAAAAAAAAAAAAAAAAAAAIA/AAAAAAAAAAAAAAAAAAAAAAAAgD8AAAAAAAAAAAAAAAAAAAAAAACAPw=="
+        }
+    ]
+}

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/AnimationSetBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/AnimationSetBuilder.java
@@ -128,6 +128,8 @@ public class AnimationSetBuilder extends Builder  {
                 throw new CompileExceptionError(animFile, e.getLocation().getLineNumber(), "Failed to load animation: " + e.getLocalizedMessage(), e);
             } catch (LoaderException e) {
                 throw new CompileExceptionError(animFile, -1, "Failed to load animation: " + e.getLocalizedMessage(), e);
+            } catch (IOException e) {
+                throw new CompileExceptionError(animFile, -1, e.getMessage(), e);
             }
 
             animationSetBuilder.addAllAnimations(animBuilder.getAnimationsList());

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/MeshsetBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/MeshsetBuilder.java
@@ -145,9 +145,11 @@ public class MeshsetBuilder extends Builder  {
 
         Modelimporter.Options options = new Modelimporter.Options();
         ResourceDataResolver dataResolver = new ResourceDataResolver(this.project);
-        Modelimporter.Scene scene = ModelUtil.loadScene(task.input(0).getContent(), task.input(0).getPath(), options, dataResolver);
-        if (scene == null) {
-            throw new CompileExceptionError(task.input(0), -1, "Error loading model");
+        Modelimporter.Scene scene;
+        try {
+            scene = ModelUtil.loadScene(task.input(0).getContent(), task.input(0).getPath(), options, dataResolver);
+        } catch (IOException e) {
+            throw new CompileExceptionError(task.input(0), -1, e.getMessage(), e);
         }
 
         // MeshSet

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ModelUtil.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ModelUtil.java
@@ -75,8 +75,9 @@ public class ModelUtil {
 
         Scene scene = ModelImporterJni.LoadFromBuffer(options, path, content, dataResolver);
 
-        if (scene == null)
-            return null;
+        if (scene == null) {
+            throw new IOException(ModelImporterJni.getLoadError());
+        }
 
         for (Modelimporter.Buffer buffer : scene.buffers)
         {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ModelUtil.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ModelUtil.java
@@ -76,7 +76,7 @@ public class ModelUtil {
         Scene scene = ModelImporterJni.LoadFromBuffer(options, path, content, dataResolver);
 
         if (scene == null) {
-            throw new IOException(ModelImporterJni.getLoadError());
+            throw new IOException("Model load returned null");
         }
 
         for (Modelimporter.Buffer buffer : scene.buffers)

--- a/engine/jni/scripts/external/gen_util.py
+++ b/engine/jni/scripts/external/gen_util.py
@@ -43,7 +43,9 @@ def extract_array_sizes(s):
     return s[s.index('['):].replace('[', ' ').replace(']', ' ').split()
 
 def is_string_ptr(s):
-    return s == "const char *"
+    # Normalize spacing (header may use "char*" or "char *"). Treat mutable char* like const char* for JNI String.
+    t = s.replace(" ", "")
+    return t in ("char*", "constchar*")
 
 def is_const_void_ptr(s):
     return s == "const void *"

--- a/engine/modelc/src/java/com/dynamo/bob/pipeline/ModelImporterJni.java
+++ b/engine/modelc/src/java/com/dynamo/bob/pipeline/ModelImporterJni.java
@@ -75,11 +75,12 @@ public class ModelImporterJni {
 
     private static native String getLoadErrorInternal();
 
-    /** Last native model load error; meaningful after {@link #LoadFromBufferInternal} returns null. */
+    // Last native model load error, meaningful after LoadFromBufferInternal returns null.
     public static String getLoadError() {
         String s = getLoadErrorInternal();
         return s != null ? s : "";
     }
+
     //public static native int AddressOf(Object o);
     public static native void TestException(String message);
 

--- a/engine/modelc/src/java/com/dynamo/bob/pipeline/ModelImporterJni.java
+++ b/engine/modelc/src/java/com/dynamo/bob/pipeline/ModelImporterJni.java
@@ -72,6 +72,14 @@ public class ModelImporterJni {
 
     // The suffix of the path dictates which loader it will use
     public static native Modelimporter.Scene LoadFromBufferInternal(String path, byte[] buffer, Object data_resolver);
+
+    private static native String getLoadErrorInternal();
+
+    /** Last native model load error; meaningful after {@link #LoadFromBufferInternal} returns null. */
+    public static String getLoadError() {
+        String s = getLoadErrorInternal();
+        return s != null ? s : "";
+    }
     //public static native int AddressOf(Object o);
     public static native void TestException(String message);
 

--- a/engine/modelc/src/java/com/dynamo/bob/pipeline/ModelImporterJni.java
+++ b/engine/modelc/src/java/com/dynamo/bob/pipeline/ModelImporterJni.java
@@ -73,18 +73,11 @@ public class ModelImporterJni {
     // The suffix of the path dictates which loader it will use
     public static native Modelimporter.Scene LoadFromBufferInternal(String path, byte[] buffer, Object data_resolver);
 
-    private static native String getLoadErrorInternal();
-
-    // Last native model load error, meaningful after LoadFromBufferInternal returns null.
-    public static String getLoadError() {
-        String s = getLoadErrorInternal();
-        return s != null ? s : "";
-    }
-
     //public static native int AddressOf(Object o);
     public static native void TestException(String message);
 
-    public static class ModelException extends Exception {
+    /** Thrown from native code when model loading fails (also extends IOException for API compatibility). */
+    public static class ModelException extends IOException {
         public ModelException(String errorMessage) {
             super(errorMessage);
         }

--- a/engine/modelc/src/java/com/dynamo/bob/pipeline/Modelimporter.java
+++ b/engine/modelc/src/java/com/dynamo/bob/pipeline/Modelimporter.java
@@ -262,6 +262,7 @@ public class Modelimporter {
         public Texture[] textures;
         public Buffer[] buffers;
         public Material[] dynamicMaterials;
+        public boolean hasFatalLoadError = false;
     };
     public static class Options {
         public int dummy = 0;

--- a/engine/modelc/src/java/com/dynamo/bob/pipeline/Modelimporter.java
+++ b/engine/modelc/src/java/com/dynamo/bob/pipeline/Modelimporter.java
@@ -262,7 +262,7 @@ public class Modelimporter {
         public Texture[] textures;
         public Buffer[] buffers;
         public Material[] dynamicMaterials;
-        public boolean hasFatalLoadError = false;
+        public char loadError;
     };
     public static class Options {
         public int dummy = 0;

--- a/engine/modelc/src/java/com/dynamo/bob/pipeline/Modelimporter.java
+++ b/engine/modelc/src/java/com/dynamo/bob/pipeline/Modelimporter.java
@@ -262,7 +262,7 @@ public class Modelimporter {
         public Texture[] textures;
         public Buffer[] buffers;
         public Material[] dynamicMaterials;
-        public char loadError;
+        public String loadError;
     };
     public static class Options {
         public int dummy = 0;

--- a/engine/modelc/src/jni/Modelimporter_jni.cpp
+++ b/engine/modelc/src/jni/Modelimporter_jni.cpp
@@ -289,7 +289,7 @@ void InitializeJNITypes(JNIEnv* env, TypeInfos* infos) {
         GET_FLD_ARRAY(textures, "Texture");
         GET_FLD_ARRAY(buffers, "Buffer");
         GET_FLD_ARRAY(dynamicMaterials, "Material");
-        GET_FLD_TYPESTR(loadError, "[None");
+        GET_FLD_TYPESTR(loadError, "Ljava/lang/String;");
     }
     {
         SETUP_CLASS(OptionsJNI, "Options");
@@ -674,6 +674,7 @@ jobject C2J_CreateScene(JNIEnv* env, TypeInfos* types, const Scene* src) {
     dmJNI::SetObjectDeref(env, obj, types->m_SceneJNI.textures, C2J_CreateTextureArray(env, types, src->m_Textures.Begin(), src->m_Textures.Size()));
     dmJNI::SetObjectDeref(env, obj, types->m_SceneJNI.buffers, C2J_CreateBufferArray(env, types, src->m_Buffers.Begin(), src->m_Buffers.Size()));
     dmJNI::SetObjectDeref(env, obj, types->m_SceneJNI.dynamicMaterials, C2J_CreateMaterialPtrArray(env, types, src->m_DynamicMaterials.Begin(), src->m_DynamicMaterials.Size()));
+    dmJNI::SetString(env, obj, types->m_SceneJNI.loadError, src->m_LoadError);
     return obj;
 }
 
@@ -2240,6 +2241,7 @@ bool J2C_CreateScene(JNIEnv* env, TypeInfos* types, jobject obj, Scene* out) {
             env->DeleteLocalRef(field_object);
         }
     }
+    out->m_LoadError = dmJNI::GetString(env, obj, types->m_SceneJNI.loadError);
     return true;
 }
 

--- a/engine/modelc/src/jni/Modelimporter_jni.cpp
+++ b/engine/modelc/src/jni/Modelimporter_jni.cpp
@@ -289,6 +289,7 @@ void InitializeJNITypes(JNIEnv* env, TypeInfos* infos) {
         GET_FLD_ARRAY(textures, "Texture");
         GET_FLD_ARRAY(buffers, "Buffer");
         GET_FLD_ARRAY(dynamicMaterials, "Material");
+        GET_FLD_TYPESTR(hasFatalLoadError, "Z");
     }
     {
         SETUP_CLASS(OptionsJNI, "Options");
@@ -673,6 +674,7 @@ jobject C2J_CreateScene(JNIEnv* env, TypeInfos* types, const Scene* src) {
     dmJNI::SetObjectDeref(env, obj, types->m_SceneJNI.textures, C2J_CreateTextureArray(env, types, src->m_Textures.Begin(), src->m_Textures.Size()));
     dmJNI::SetObjectDeref(env, obj, types->m_SceneJNI.buffers, C2J_CreateBufferArray(env, types, src->m_Buffers.Begin(), src->m_Buffers.Size()));
     dmJNI::SetObjectDeref(env, obj, types->m_SceneJNI.dynamicMaterials, C2J_CreateMaterialPtrArray(env, types, src->m_DynamicMaterials.Begin(), src->m_DynamicMaterials.Size()));
+    dmJNI::SetBoolean(env, obj, types->m_SceneJNI.hasFatalLoadError, src->m_HasFatalLoadError);
     return obj;
 }
 
@@ -2239,6 +2241,7 @@ bool J2C_CreateScene(JNIEnv* env, TypeInfos* types, jobject obj, Scene* out) {
             env->DeleteLocalRef(field_object);
         }
     }
+    out->m_HasFatalLoadError = dmJNI::GetBoolean(env, obj, types->m_SceneJNI.hasFatalLoadError);
     return true;
 }
 

--- a/engine/modelc/src/jni/Modelimporter_jni.cpp
+++ b/engine/modelc/src/jni/Modelimporter_jni.cpp
@@ -289,7 +289,7 @@ void InitializeJNITypes(JNIEnv* env, TypeInfos* infos) {
         GET_FLD_ARRAY(textures, "Texture");
         GET_FLD_ARRAY(buffers, "Buffer");
         GET_FLD_ARRAY(dynamicMaterials, "Material");
-        GET_FLD_TYPESTR(hasFatalLoadError, "Z");
+        GET_FLD_TYPESTR(loadError, "[None");
     }
     {
         SETUP_CLASS(OptionsJNI, "Options");
@@ -674,7 +674,6 @@ jobject C2J_CreateScene(JNIEnv* env, TypeInfos* types, const Scene* src) {
     dmJNI::SetObjectDeref(env, obj, types->m_SceneJNI.textures, C2J_CreateTextureArray(env, types, src->m_Textures.Begin(), src->m_Textures.Size()));
     dmJNI::SetObjectDeref(env, obj, types->m_SceneJNI.buffers, C2J_CreateBufferArray(env, types, src->m_Buffers.Begin(), src->m_Buffers.Size()));
     dmJNI::SetObjectDeref(env, obj, types->m_SceneJNI.dynamicMaterials, C2J_CreateMaterialPtrArray(env, types, src->m_DynamicMaterials.Begin(), src->m_DynamicMaterials.Size()));
-    dmJNI::SetBoolean(env, obj, types->m_SceneJNI.hasFatalLoadError, src->m_HasFatalLoadError);
     return obj;
 }
 
@@ -2241,7 +2240,6 @@ bool J2C_CreateScene(JNIEnv* env, TypeInfos* types, jobject obj, Scene* out) {
             env->DeleteLocalRef(field_object);
         }
     }
-    out->m_HasFatalLoadError = dmJNI::GetBoolean(env, obj, types->m_SceneJNI.hasFatalLoadError);
     return true;
 }
 

--- a/engine/modelc/src/jni/Modelimporter_jni.h
+++ b/engine/modelc/src/jni/Modelimporter_jni.h
@@ -273,7 +273,7 @@ struct SceneJNI {
     jfieldID textures;
     jfieldID buffers;
     jfieldID dynamicMaterials;
-    jfieldID hasFatalLoadError;
+    jfieldID loadError;
 };
 struct OptionsJNI {
     jclass cls;

--- a/engine/modelc/src/jni/Modelimporter_jni.h
+++ b/engine/modelc/src/jni/Modelimporter_jni.h
@@ -273,6 +273,7 @@ struct SceneJNI {
     jfieldID textures;
     jfieldID buffers;
     jfieldID dynamicMaterials;
+    jfieldID hasFatalLoadError;
 };
 struct OptionsJNI {
     jclass cls;

--- a/engine/modelc/src/modelimporter.cpp
+++ b/engine/modelc/src/modelimporter.cpp
@@ -53,6 +53,10 @@ namespace dmModelImporter
 
 static char g_ModelLoadError[512];
 
+Options::Options()
+{
+}
+
 void ClearLoadError()
 {
     g_ModelLoadError[0] = 0;
@@ -69,10 +73,6 @@ void SetLoadError(const char* message)
 const char* GetLoadError()
 {
     return g_ModelLoadError[0] ? g_ModelLoadError : 0;
-}
-
-Options::Options()
-{
 }
 
 static void DestroySampler(Sampler* sampler)
@@ -323,10 +323,13 @@ Scene* LoadFromPath(Options* options, const char* path)
     if (!dmModelImporter::LoadFinalize(scene))
     {
         const char* err = GetLoadError();
-        if (err)
-            dmLogError("%s", err);
+
         DestroyScene(scene);
         printf("Failed to load '%s'\n", path);
+
+        if (err)
+            dmLogError("%s", err);
+
         return 0;
     }
 

--- a/engine/modelc/src/modelimporter.cpp
+++ b/engine/modelc/src/modelimporter.cpp
@@ -48,9 +48,28 @@ struct ModelImporterInitializer
     }
 } g_ModelImporterInitializer;
 
-
 namespace dmModelImporter
 {
+
+static char g_ModelLoadError[512];
+
+void ClearLoadError()
+{
+    g_ModelLoadError[0] = 0;
+}
+
+void SetLoadError(const char* message)
+{
+    if (message)
+        dmStrlCpy(g_ModelLoadError, message, sizeof(g_ModelLoadError));
+    else
+        g_ModelLoadError[0] = 0;
+}
+
+const char* GetLoadError()
+{
+    return g_ModelLoadError[0] ? g_ModelLoadError : 0;
+}
 
 Options::Options()
 {
@@ -234,9 +253,12 @@ void DestroyScene(Scene* scene)
 
 Scene* LoadFromBuffer(Options* options, const char* suffix, void* data, uint32_t file_size)
 {
+    ClearLoadError();
+
     if (suffix == 0)
     {
         printf("ModelImporter: No suffix specified!\n");
+        SetLoadError("No file suffix specified");
         return 0;
     }
 
@@ -244,6 +266,7 @@ Scene* LoadFromBuffer(Options* options, const char* suffix, void* data, uint32_t
         return LoadGltfFromBuffer(options, data, file_size);
 
     printf("ModelImporter: File type not supported: %s\n", suffix);
+    SetLoadError("Model file type not supported");
     return 0;
 }
 
@@ -299,6 +322,9 @@ Scene* LoadFromPath(Options* options, const char* path)
 
     if (!dmModelImporter::LoadFinalize(scene))
     {
+        const char* err = GetLoadError();
+        if (err)
+            dmLogError("%s", err);
         DestroyScene(scene);
         printf("Failed to load '%s'\n", path);
         return 0;

--- a/engine/modelc/src/modelimporter.cpp
+++ b/engine/modelc/src/modelimporter.cpp
@@ -16,7 +16,7 @@
 #include <dmsdk/dlib/log.h>
 #include <dmsdk/dlib/dstrings.h>
 #include <stdio.h>
-#include <stdlib.h> // getenv
+#include <stdlib.h> // getenv, free, strdup
 #include <string.h>
 
 
@@ -51,28 +51,20 @@ struct ModelImporterInitializer
 namespace dmModelImporter
 {
 
-static char g_ModelLoadError[512];
-
 Options::Options()
 {
 }
 
-void ClearLoadError()
+void SetLoadError(Scene* scene, const char* message)
 {
-    g_ModelLoadError[0] = 0;
-}
-
-void SetLoadError(const char* message)
-{
-    if (message)
-        dmStrlCpy(g_ModelLoadError, message, sizeof(g_ModelLoadError));
-    else
-        g_ModelLoadError[0] = 0;
-}
-
-const char* GetLoadError()
-{
-    return g_ModelLoadError[0] ? g_ModelLoadError : 0;
+    if (!scene)
+        return;
+    free(scene->m_LoadError);
+    scene->m_LoadError = 0;
+    if (message && message[0])
+    {
+        scene->m_LoadError = strdup(message);
+    }
 }
 
 static void DestroySampler(Sampler* sampler)
@@ -200,6 +192,9 @@ void DestroyScene(Scene* scene)
         return;
     }
 
+    free(scene->m_LoadError);
+    scene->m_LoadError = 0;
+
     scene->m_DestroyFn(scene);
     scene->m_OpaqueSceneData = 0;
 
@@ -253,12 +248,9 @@ void DestroyScene(Scene* scene)
 
 Scene* LoadFromBuffer(Options* options, const char* suffix, void* data, uint32_t file_size)
 {
-    ClearLoadError();
-
     if (suffix == 0)
     {
         printf("ModelImporter: No suffix specified!\n");
-        SetLoadError("No file suffix specified");
         return 0;
     }
 
@@ -266,7 +258,6 @@ Scene* LoadFromBuffer(Options* options, const char* suffix, void* data, uint32_t
         return LoadGltfFromBuffer(options, data, file_size);
 
     printf("ModelImporter: File type not supported: %s\n", suffix);
-    SetLoadError("Model file type not supported");
     return 0;
 }
 
@@ -296,6 +287,7 @@ Scene* LoadFromPath(Options* options, const char* path)
     if (!scene)
     {
         dmLogError("Failed to create scene from path '%s'", path);
+        free(data);
         return 0;
     }
 
@@ -322,14 +314,15 @@ Scene* LoadFromPath(Options* options, const char* path)
 
     if (!dmModelImporter::LoadFinalize(scene))
     {
-        const char* err = GetLoadError();
-
+        char errbuf[512];
+        errbuf[0] = 0;
+        if (scene->m_LoadError && scene->m_LoadError[0])
+            dmStrlCpy(errbuf, scene->m_LoadError, sizeof(errbuf));
         DestroyScene(scene);
         printf("Failed to load '%s'\n", path);
-
-        if (err)
-            dmLogError("%s", err);
-
+        if (errbuf[0])
+            dmLogError("%s", errbuf);
+        free(data);
         return 0;
     }
 

--- a/engine/modelc/src/modelimporter.cpp
+++ b/engine/modelc/src/modelimporter.cpp
@@ -179,21 +179,12 @@ bool LoadFinalize(Scene* scene)
     return true;
 }
 
-void DestroyScene(Scene* scene)
+void ClearScene(Scene* scene)
 {
     if (!scene)
-    {
         return;
-    }
-
     if (!scene->m_OpaqueSceneData)
-    {
-        printf("Already deleted!\n");
         return;
-    }
-
-    free(scene->m_LoadError);
-    scene->m_LoadError = 0;
 
     scene->m_DestroyFn(scene);
     scene->m_OpaqueSceneData = 0;
@@ -243,6 +234,20 @@ void DestroyScene(Scene* scene)
         DestroySampler(&scene->m_Samplers[i]);
     scene->m_Samplers.SetCapacity(0);
 
+    scene->m_LoadFinalizeFn = 0;
+    scene->m_ValidateFn = 0;
+    scene->m_DestroyFn = 0;
+}
+
+void DestroyScene(Scene* scene)
+{
+    if (!scene)
+        return;
+
+    free(scene->m_LoadError);
+    scene->m_LoadError = 0;
+
+    ClearScene(scene);
     delete scene;
 }
 
@@ -287,6 +292,19 @@ Scene* LoadFromPath(Options* options, const char* path)
     if (!scene)
     {
         dmLogError("Failed to create scene from path '%s'", path);
+        free(data);
+        return 0;
+    }
+
+    if (scene->m_LoadError && scene->m_LoadError[0])
+    {
+        char errbuf[512];
+        errbuf[0] = 0;
+        dmStrlCpy(errbuf, scene->m_LoadError, sizeof(errbuf));
+        DestroyScene(scene);
+        printf("Failed to load '%s'\n", path);
+        if (errbuf[0])
+            dmLogError("%s", errbuf);
         free(data);
         return 0;
     }

--- a/engine/modelc/src/modelimporter.h
+++ b/engine/modelc/src/modelimporter.h
@@ -341,7 +341,7 @@ namespace dmModelImporter
         // When we need to dynamically create materials
         dmArray<Material*>  m_DynamicMaterials;
 
-        // Last load error for this scene (heap-allocated; freed in DestroyScene). Non-null means load failed fatally.
+        // Last load error for this scene (heap-allocated; freed in DestroyScene). ClearScene does not free it. Non-null means load failed fatally.
         char*               m_LoadError;
     };
 
@@ -382,6 +382,8 @@ namespace dmModelImporter
     // Switches between warning and debug level
     extern "C" DM_DLLEXPORT void EnableDebugLogging(bool enable);
 
+    // Frees all scene resources except m_LoadError (caller may read it first, then call DestroyScene).
+    void ClearScene(Scene* scene);
     void SetLoadError(Scene* scene, const char* message);
 
     void DebugScene(Scene* scene);

--- a/engine/modelc/src/modelimporter.h
+++ b/engine/modelc/src/modelimporter.h
@@ -343,6 +343,9 @@ namespace dmModelImporter
 
         // GLTF: set when the file uses unsupported mesh features (e.g. multi-set skinning)
         bool                m_HasFatalLoadError;
+
+        // Last load error for this scene (heap-allocated; freed in DestroyScene).
+        char*               m_LoadError;
     };
 
     struct Options
@@ -382,9 +385,7 @@ namespace dmModelImporter
     // Switches between warning and debug level
     extern "C" DM_DLLEXPORT void EnableDebugLogging(bool enable);
 
-    void ClearLoadError();
-    void SetLoadError(const char* message);
-    const char* GetLoadError();
+    void SetLoadError(Scene* scene, const char* message);
 
     void DebugScene(Scene* scene);
     void DebugStructScene(Scene* scene);

--- a/engine/modelc/src/modelimporter.h
+++ b/engine/modelc/src/modelimporter.h
@@ -340,6 +340,9 @@ namespace dmModelImporter
 
         // When we need to dynamically create materials
         dmArray<Material*>  m_DynamicMaterials;
+
+        // GLTF: set when the file uses unsupported mesh features (e.g. multi-set skinning)
+        bool                m_HasFatalLoadError;
     };
 
     struct Options
@@ -378,6 +381,10 @@ namespace dmModelImporter
 
     // Switches between warning and debug level
     extern "C" DM_DLLEXPORT void EnableDebugLogging(bool enable);
+
+    void ClearLoadError();
+    void SetLoadError(const char* message);
+    const char* GetLoadError();
 
     void DebugScene(Scene* scene);
     void DebugStructScene(Scene* scene);

--- a/engine/modelc/src/modelimporter.h
+++ b/engine/modelc/src/modelimporter.h
@@ -341,10 +341,7 @@ namespace dmModelImporter
         // When we need to dynamically create materials
         dmArray<Material*>  m_DynamicMaterials;
 
-        // GLTF: set when the file uses unsupported mesh features (e.g. multi-set skinning)
-        bool                m_HasFatalLoadError;
-
-        // Last load error for this scene (heap-allocated; freed in DestroyScene).
+        // Last load error for this scene (heap-allocated; freed in DestroyScene). Non-null means load failed fatally.
         char*               m_LoadError;
     };
 

--- a/engine/modelc/src/modelimporter_gltf.cpp
+++ b/engine/modelc/src/modelimporter_gltf.cpp
@@ -796,7 +796,7 @@ static void LoadPrimitives(Scene* scene, Model* model, cgltf_data* gltf_data, cg
                     "GLTF mesh '%s', primitive %zu: multiple joint/weight attribute sets (e.g. JOINTS_%u) are not supported. Defold supports a single set of up to 4 bone influences per vertex, to use this content you need to fix the issues in an external tool.",
                     model->m_Name, i, (unsigned)attr->index);
                 dmLogError("%s", buf);
-                SetLoadError(buf);
+                SetLoadError(scene, buf);
                 scene->m_HasFatalLoadError = true;
                 return;
             }
@@ -807,7 +807,7 @@ static void LoadPrimitives(Scene* scene, Model* model, cgltf_data* gltf_data, cg
                     "GLTF mesh '%s', primitive %zu: multiple joint/weight attribute sets (e.g. WEIGHTS_%u) are not supported. Defold supports a single set of up to 4 bone influences per vertex, to use this content you need to fix the issues in an external tool.",
                     model->m_Name, i, (unsigned)attr->index);
                 dmLogError("%s", buf);
-                SetLoadError(buf);
+                SetLoadError(scene, buf);
                 scene->m_HasFatalLoadError = true;
                 return;
             }
@@ -1770,7 +1770,6 @@ Scene* LoadGltfFromBuffer(Options* importeroptions, void* mem, uint32_t file_siz
     if (result != cgltf_result_success)
     {
         printf("Failed to load gltf file: %s (%d)\n", GetResultStr(result), result);
-        SetLoadError("Failed to parse GLTF/GLB file");
         return 0;
     }
 
@@ -1781,7 +1780,6 @@ Scene* LoadGltfFromBuffer(Options* importeroptions, void* mem, uint32_t file_siz
     if (result != cgltf_result_success)
     {
         printf("Failed to load gltf buffers: %s (%d)\n", GetResultStr(result), result);
-        SetLoadError("Failed to load GLTF external buffers");
         return 0;
     }
 

--- a/engine/modelc/src/modelimporter_gltf.cpp
+++ b/engine/modelc/src/modelimporter_gltf.cpp
@@ -779,7 +779,38 @@ static void LoadPrimitives(Scene* scene, Model* model, cgltf_data* gltf_data, cg
 
     for (size_t i = 0; i < gltf_mesh->primitives_count; ++i)
     {
+        if (scene->m_HasFatalLoadError)
+            return;
+
         cgltf_primitive* prim = &gltf_mesh->primitives[i];
+
+        for (cgltf_size ai = 0; ai < prim->attributes_count; ++ai)
+        {
+            cgltf_attribute* attr = &prim->attributes[ai];
+            if (attr->type == cgltf_attribute_type_joints && attr->index > 0)
+            {
+                char buf[512];
+                dmSnPrintf(buf, sizeof(buf),
+                    "GLTF mesh '%s', primitive %zu: multiple joint/weight attribute sets (e.g. JOINTS_%u) are not supported. Defold supports a single set of up to 4 bone influences per vertex; reduce influences in your export settings or merge skin sets in your DCC tool.",
+                    model->m_Name, i, (unsigned)attr->index);
+                dmLogError("%s", buf);
+                SetLoadError(buf);
+                scene->m_HasFatalLoadError = true;
+                return;
+            }
+            if (attr->type == cgltf_attribute_type_weights && attr->index > 0)
+            {
+                char buf[512];
+                dmSnPrintf(buf, sizeof(buf),
+                    "GLTF mesh '%s', primitive %zu: multiple joint/weight attribute sets (e.g. WEIGHTS_%u) are not supported. Defold supports a single set of up to 4 bone influences per vertex; reduce influences in your export settings or merge skin sets in your DCC tool.",
+                    model->m_Name, i, (unsigned)attr->index);
+                dmLogError("%s", buf);
+                SetLoadError(buf);
+                scene->m_HasFatalLoadError = true;
+                return;
+            }
+        }
+
         Mesh* mesh = &model->m_Meshes[i];
         mesh->m_Name = CreateNameFromHash("mesh", i);
 
@@ -1699,7 +1730,7 @@ static bool LoadFinalizeGltf(Scene* scene)
 {
     GltfData* data = (GltfData*)scene->m_OpaqueSceneData;
     LoadScene(scene, data->m_Data);
-    return true;
+    return !scene->m_HasFatalLoadError;
 }
 
 static bool ValidateGltf(Scene* scene)
@@ -1731,6 +1762,7 @@ Scene* LoadGltfFromBuffer(Options* importeroptions, void* mem, uint32_t file_siz
     if (result != cgltf_result_success)
     {
         printf("Failed to load gltf file: %s (%d)\n", GetResultStr(result), result);
+        SetLoadError("Failed to parse GLTF/GLB file");
         return 0;
     }
 
@@ -1741,6 +1773,7 @@ Scene* LoadGltfFromBuffer(Options* importeroptions, void* mem, uint32_t file_siz
     if (result != cgltf_result_success)
     {
         printf("Failed to load gltf buffers: %s (%d)\n", GetResultStr(result), result);
+        SetLoadError("Failed to load GLTF external buffers");
         return 0;
     }
 
@@ -1766,7 +1799,12 @@ Scene* LoadGltfFromBuffer(Options* importeroptions, void* mem, uint32_t file_siz
     if (!NeedsResolve(scene))
     {
         scene->m_LoadFinalizeFn = 0;
-        LoadFinalizeGltf(scene);
+        if (!LoadFinalizeGltf(scene))
+        {
+            DestroyGltf(scene);
+            delete scene;
+            return 0;
+        }
         ValidateGltf(scene);
     }
 

--- a/engine/modelc/src/modelimporter_gltf.cpp
+++ b/engine/modelc/src/modelimporter_gltf.cpp
@@ -1778,6 +1778,7 @@ Scene* LoadGltfFromBuffer(Options* importeroptions, void* mem, uint32_t file_siz
     if (result != cgltf_result_success)
     {
         printf("Failed to load gltf buffers: %s (%d)\n", GetResultStr(result), result);
+        cgltf_free(data);
         return 0;
     }
 
@@ -1805,8 +1806,8 @@ Scene* LoadGltfFromBuffer(Options* importeroptions, void* mem, uint32_t file_siz
         scene->m_LoadFinalizeFn = 0;
         if (!LoadFinalizeGltf(scene))
         {
-            DestroyScene(scene);
-            return 0;
+            ClearScene(scene);
+            return scene;
         }
         ValidateGltf(scene);
     }

--- a/engine/modelc/src/modelimporter_gltf.cpp
+++ b/engine/modelc/src/modelimporter_gltf.cpp
@@ -779,7 +779,7 @@ static void LoadPrimitives(Scene* scene, Model* model, cgltf_data* gltf_data, cg
 
     for (size_t i = 0; i < gltf_mesh->primitives_count; ++i)
     {
-        if (scene->m_HasFatalLoadError)
+        if (scene->m_LoadError)
             return;
 
         cgltf_primitive* prim = &gltf_mesh->primitives[i];
@@ -797,7 +797,6 @@ static void LoadPrimitives(Scene* scene, Model* model, cgltf_data* gltf_data, cg
                     model->m_Name, i, (unsigned)attr->index);
                 dmLogError("%s", buf);
                 SetLoadError(scene, buf);
-                scene->m_HasFatalLoadError = true;
                 return;
             }
             if (attr->type == cgltf_attribute_type_weights && attr->index > 0)
@@ -808,7 +807,6 @@ static void LoadPrimitives(Scene* scene, Model* model, cgltf_data* gltf_data, cg
                     model->m_Name, i, (unsigned)attr->index);
                 dmLogError("%s", buf);
                 SetLoadError(scene, buf);
-                scene->m_HasFatalLoadError = true;
                 return;
             }
         }
@@ -1719,7 +1717,7 @@ static void LoadScene(Scene* scene, cgltf_data* data)
     LoadMeshes(scene, data);
 
     // Make sure we early-out so we don't touch uninitialized data
-    if (scene->m_HasFatalLoadError)
+    if (scene->m_LoadError)
         return;
 
     LinkNodesWithBones(scene, data);
@@ -1738,7 +1736,7 @@ static bool LoadFinalizeGltf(Scene* scene)
 {
     GltfData* data = (GltfData*)scene->m_OpaqueSceneData;
     LoadScene(scene, data->m_Data);
-    return !scene->m_HasFatalLoadError;
+    return scene->m_LoadError == 0;
 }
 
 static bool ValidateGltf(Scene* scene)

--- a/engine/modelc/src/modelimporter_gltf.cpp
+++ b/engine/modelc/src/modelimporter_gltf.cpp
@@ -787,11 +787,13 @@ static void LoadPrimitives(Scene* scene, Model* model, cgltf_data* gltf_data, cg
         for (cgltf_size ai = 0; ai < prim->attributes_count; ++ai)
         {
             cgltf_attribute* attr = &prim->attributes[ai];
+
+            // we only support JOINTS_0 and WEIGHTS_0, so we need to emit an error if any of these cases are true.
             if (attr->type == cgltf_attribute_type_joints && attr->index > 0)
             {
                 char buf[512];
                 dmSnPrintf(buf, sizeof(buf),
-                    "GLTF mesh '%s', primitive %zu: multiple joint/weight attribute sets (e.g. JOINTS_%u) are not supported. Defold supports a single set of up to 4 bone influences per vertex; reduce influences in your export settings or merge skin sets in your DCC tool.",
+                    "GLTF mesh '%s', primitive %zu: multiple joint/weight attribute sets (e.g. JOINTS_%u) are not supported. Defold supports a single set of up to 4 bone influences per vertex, to use this content you need to fix the issues in an external tool.",
                     model->m_Name, i, (unsigned)attr->index);
                 dmLogError("%s", buf);
                 SetLoadError(buf);
@@ -802,7 +804,7 @@ static void LoadPrimitives(Scene* scene, Model* model, cgltf_data* gltf_data, cg
             {
                 char buf[512];
                 dmSnPrintf(buf, sizeof(buf),
-                    "GLTF mesh '%s', primitive %zu: multiple joint/weight attribute sets (e.g. WEIGHTS_%u) are not supported. Defold supports a single set of up to 4 bone influences per vertex; reduce influences in your export settings or merge skin sets in your DCC tool.",
+                    "GLTF mesh '%s', primitive %zu: multiple joint/weight attribute sets (e.g. WEIGHTS_%u) are not supported. Defold supports a single set of up to 4 bone influences per vertex, to use this content you need to fix the issues in an external tool.",
                     model->m_Name, i, (unsigned)attr->index);
                 dmLogError("%s", buf);
                 SetLoadError(buf);
@@ -984,7 +986,8 @@ static void FixupNonSkinnedModels(Scene* scene, Bone* parent, Node* node)
         if (!mesh->m_Weights.Empty())
             continue;
 
-        if (!mesh->m_Material->m_IsSkinned)
+        // Skips uninitialized mesh slots (e.g. fatal error mid-LoadPrimitives) and non-skinned materials.
+        if (!mesh->m_Material || !mesh->m_Material->m_IsSkinned)
             continue;
 
         // We duplicate the material, and create a non skinned version
@@ -1714,6 +1717,11 @@ static void LoadScene(Scene* scene, cgltf_data* data)
     LoadTextures(scene, data, &cache);
     LoadMaterials(scene, data, &cache);
     LoadMeshes(scene, data);
+
+    // Make sure we early-out so we don't touch uninitialized data
+    if (scene->m_HasFatalLoadError)
+        return;
+
     LinkNodesWithBones(scene, data);
     LinkMeshesWithNodes(scene, data);
     LoadAnimations(scene, data);
@@ -1801,8 +1809,7 @@ Scene* LoadGltfFromBuffer(Options* importeroptions, void* mem, uint32_t file_siz
         scene->m_LoadFinalizeFn = 0;
         if (!LoadFinalizeGltf(scene))
         {
-            DestroyGltf(scene);
-            delete scene;
+            DestroyScene(scene);
             return 0;
         }
         ValidateGltf(scene);

--- a/engine/modelc/src/modelimporter_jni.cpp
+++ b/engine/modelc/src/modelimporter_jni.cpp
@@ -590,6 +590,14 @@ static jobject LoadFromBufferInternal(JNIEnv* env, jclass cls, jstring _path, jb
         return 0;
     }
 
+    if (scene->m_LoadError && scene->m_LoadError[0])
+    {
+        ThrowModelLoadExceptionFromScene(env, scene, "Failed to load model");
+        dmModelImporter::DestroyScene(scene);
+        env->ReleaseByteArrayElements(array, file_data, JNI_ABORT);
+        return 0;
+    }
+
     bool resolved = false;
     if (data_resolver != 0 && dmModelImporter::NeedsResolve(scene))
     {

--- a/engine/modelc/src/modelimporter_jni.cpp
+++ b/engine/modelc/src/modelimporter_jni.cpp
@@ -541,6 +541,26 @@ static jobject CreateJavaScene(JNIEnv* env, const dmModelImporter::Scene* scene)
 
 } // namespace
 
+static void ThrowModelLoadException(JNIEnv* env, const char* message)
+{
+    const char* msg = (message && message[0]) ? message : "Failed to load model";
+    jclass jcls = env->FindClass(JAVA_PACKAGE_NAME "/ModelImporterJni$ModelException");
+    if (!jcls)
+    {
+        env->ExceptionClear();
+        dmLogError("Failed to find ModelImporterJni.ModelException class");
+        return;
+    }
+    env->ThrowNew(jcls, msg);
+    env->DeleteLocalRef(jcls);
+}
+
+static void ThrowModelLoadExceptionFromScene(JNIEnv* env, dmModelImporter::Scene* scene, const char* fallback_message)
+{
+    const char* err = (scene && scene->m_LoadError && scene->m_LoadError[0]) ? scene->m_LoadError : fallback_message;
+    ThrowModelLoadException(env, err);
+}
+
 static jobject LoadFromBufferInternal(JNIEnv* env, jclass cls, jstring _path, jbyteArray array, jobject data_resolver)
 {
     dmLogDebug("CreateJavaScene: env = %p\n", env);
@@ -551,10 +571,10 @@ static jobject LoadFromBufferInternal(JNIEnv* env, jclass cls, jstring _path, jb
     const char* suffix = strrchr(path, '.');
     if (!suffix) {
         dmLogError("No suffix found in path: %s", path);
+        ThrowModelLoadException(env, "No file suffix in path");
         return 0;
-    } else {
-        suffix++; // skip the '.'
     }
+    suffix++; // skip the '.'
 
     jsize file_size = env->GetArrayLength(array);
     jbyte* file_data = env->GetByteArrayElements(array, 0);
@@ -565,6 +585,8 @@ static jobject LoadFromBufferInternal(JNIEnv* env, jclass cls, jstring _path, jb
     if (!scene)
     {
         dmLogError("Failed to load %s", path);
+        env->ReleaseByteArrayElements(array, file_data, JNI_ABORT);
+        ThrowModelLoadException(env, "Failed to load model");
         return 0;
     }
 
@@ -587,6 +609,9 @@ static jobject LoadFromBufferInternal(JNIEnv* env, jclass cls, jstring _path, jb
                 dmLogError("JNI ExceptionCheck failed:");
                 env->ExceptionDescribe();
                 env->ExceptionClear();
+                dmModelImporter::DestroyScene(scene);
+                env->ReleaseByteArrayElements(array, file_data, JNI_ABORT);
+                ThrowModelLoadException(env, "Exception while resolving external buffers");
                 return 0;
             }
             if (bytes)
@@ -616,6 +641,7 @@ static jobject LoadFromBufferInternal(JNIEnv* env, jclass cls, jstring _path, jb
     {
         if (!dmModelImporter::LoadFinalize(scene))
         {
+            ThrowModelLoadExceptionFromScene(env, scene, "Failed to finalize model load");
             dmModelImporter::DestroyScene(scene);
             env->ReleaseByteArrayElements(array, file_data, JNI_ABORT);
             return 0;
@@ -623,16 +649,20 @@ static jobject LoadFromBufferInternal(JNIEnv* env, jclass cls, jstring _path, jb
         dmModelImporter::Validate(scene);
     }
 
+    if (dmModelImporter::NeedsResolve(scene))
+    {
+        dmModelImporter::DestroyScene(scene);
+        env->ReleaseByteArrayElements(array, file_data, JNI_ABORT);
+        ThrowModelLoadException(env, "Missing external buffer data for glTF");
+        return 0;
+    }
+
     if (dmLogGetLevel() == LOG_SEVERITY_DEBUG) // verbose mode
     {
         dmModelImporter::DebugScene(scene);
     }
 
-    jobject jscene = 0;
-    if (!dmModelImporter::NeedsResolve(scene))
-    {
-        jscene = dmModelImporter::CreateJavaScene(env, scene);
-    }
+    jobject jscene = dmModelImporter::CreateJavaScene(env, scene);
 
     dmModelImporter::DestroyScene(scene);
 
@@ -651,23 +681,6 @@ JNIEXPORT jobject JNICALL Java_ModelImporterJni_LoadFromBufferInternal(JNIEnv* e
         jscene = LoadFromBufferInternal(env, cls, _path, array, data_resolver);
     DM_JNI_GUARD_SCOPE_END(return 0;);
     return jscene;
-}
-
-static jstring GetLoadErrorInternal(JNIEnv* env, jclass /*cls*/)
-{
-    const char* msg = dmModelImporter::GetLoadError();
-    if (!msg || !msg[0])
-        return 0;
-    return env->NewStringUTF(msg);
-}
-
-JNIEXPORT jstring JNICALL Java_ModelImporterJni_getLoadErrorInternal(JNIEnv* env, jclass cls)
-{
-    jstring out;
-    DM_JNI_GUARD_SCOPE_BEGIN();
-        out = GetLoadErrorInternal(env, cls);
-    DM_JNI_GUARD_SCOPE_END(return 0;);
-    return out;
 }
 
 // JNIEXPORT jint JNICALL Java_ModelImporterJni_AddressOf(JNIEnv* env, jclass cls, jobject object)
@@ -705,7 +718,6 @@ JNIEXPORT jint JNI_OnLoad(JavaVM* vm, void* reserved)
     // Don't forget to add them to the corresponding java file (e.g. ModelImporter.java)
     static const JNINativeMethod methods[] = {
         {(char*)"LoadFromBufferInternal", (char*)"(Ljava/lang/String;[BLjava/lang/Object;)L" CLASS_NAME "$Scene;", reinterpret_cast<void*>(Java_ModelImporterJni_LoadFromBufferInternal)},
-        {(char*)"getLoadErrorInternal", (char*)"()Ljava/lang/String;", reinterpret_cast<void*>(Java_ModelImporterJni_getLoadErrorInternal)},
         //{"AddressOf", "(Ljava/lang/Object;)I", reinterpret_cast<void*>(Java_ModelImporterJni_AddressOf)},
         {(char*)"TestException", (char*)"(Ljava/lang/String;)V", reinterpret_cast<void*>(Java_ModelImporterJni_TestException)},
     };

--- a/engine/modelc/src/modelimporter_jni.cpp
+++ b/engine/modelc/src/modelimporter_jni.cpp
@@ -614,7 +614,12 @@ static jobject LoadFromBufferInternal(JNIEnv* env, jclass cls, jstring _path, jb
 
     if (resolved && !dmModelImporter::NeedsResolve(scene))
     {
-        dmModelImporter::LoadFinalize(scene);
+        if (!dmModelImporter::LoadFinalize(scene))
+        {
+            dmModelImporter::DestroyScene(scene);
+            env->ReleaseByteArrayElements(array, file_data, JNI_ABORT);
+            return 0;
+        }
         dmModelImporter::Validate(scene);
     }
 
@@ -646,6 +651,23 @@ JNIEXPORT jobject JNICALL Java_ModelImporterJni_LoadFromBufferInternal(JNIEnv* e
         jscene = LoadFromBufferInternal(env, cls, _path, array, data_resolver);
     DM_JNI_GUARD_SCOPE_END(return 0;);
     return jscene;
+}
+
+static jstring GetLoadErrorInternal(JNIEnv* env, jclass /*cls*/)
+{
+    const char* msg = dmModelImporter::GetLoadError();
+    if (!msg || !msg[0])
+        return 0;
+    return env->NewStringUTF(msg);
+}
+
+JNIEXPORT jstring JNICALL Java_ModelImporterJni_getLoadErrorInternal(JNIEnv* env, jclass cls)
+{
+    jstring out;
+    DM_JNI_GUARD_SCOPE_BEGIN();
+        out = GetLoadErrorInternal(env, cls);
+    DM_JNI_GUARD_SCOPE_END(return 0;);
+    return out;
 }
 
 // JNIEXPORT jint JNICALL Java_ModelImporterJni_AddressOf(JNIEnv* env, jclass cls, jobject object)
@@ -683,6 +705,7 @@ JNIEXPORT jint JNI_OnLoad(JavaVM* vm, void* reserved)
     // Don't forget to add them to the corresponding java file (e.g. ModelImporter.java)
     static const JNINativeMethod methods[] = {
         {(char*)"LoadFromBufferInternal", (char*)"(Ljava/lang/String;[BLjava/lang/Object;)L" CLASS_NAME "$Scene;", reinterpret_cast<void*>(Java_ModelImporterJni_LoadFromBufferInternal)},
+        {(char*)"getLoadErrorInternal", (char*)"()Ljava/lang/String;", reinterpret_cast<void*>(Java_ModelImporterJni_getLoadErrorInternal)},
         //{"AddressOf", "(Ljava/lang/Object;)I", reinterpret_cast<void*>(Java_ModelImporterJni_AddressOf)},
         {(char*)"TestException", (char*)"(Ljava/lang/String;)V", reinterpret_cast<void*>(Java_ModelImporterJni_TestException)},
     };

--- a/engine/modelc/src/test/test_model.cpp
+++ b/engine/modelc/src/test/test_model.cpp
@@ -58,6 +58,14 @@ static dmModelImporter::Scene* LoadScene(const char* path, dmModelImporter::Opti
         return 0;
     }
 
+    if (scene->m_LoadError && scene->m_LoadError[0])
+    {
+        dmLogError("%s", scene->m_LoadError);
+        dmModelImporter::DestroyScene(scene);
+        free(mem);
+        return 0;
+    }
+
     if (dmModelImporter::NeedsResolve(scene))
     {
         for (uint32_t i = 0; i < scene->m_Buffers.Size(); ++i)


### PR DESCRIPTION
Defold currently only supports one weight and one joint channel (maps to attributes/inputs to vertex shaders) with four components each. Using .gltf content that has more than one of these channels will cause the rendering to be incorrect. In the future we might support the generic case of unlimited such channels, but in the meantime the editor (and bob) will raise an error when trying to load the content. Currently, the simplest fix is to re-export the offending files via Blender.

Fixes #11420