### PR TITLE
Fix editor performance regression introduced by symlink support

### DIFF
--- a/editor/src/clj/editor/animation_set.clj
+++ b/editor/src/clj/editor/animation_set.clj
@@ -175,7 +175,8 @@
 
 (defn- load-animation-set [_project self resource animation-set-desc]
   {:pre [(map? animation-set-desc)]} ; Rig$AnimationSetDesc in map format
-  (let [resolve-resource #(workspace/resolve-resource resource %)
+  (let [basis (g/now)
+        resolve-resource #(workspace/resolve-resource basis resource %)
         animation-instance-descs->animation-resources #(mapv (comp resolve-resource :animation) %)]
     (gu/set-properties-from-pb-map self Rig$AnimationSetDesc animation-set-desc
       animations (animation-instance-descs->animation-resources :animations))))

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -2502,7 +2502,8 @@
        (perform-open-resource-plan! localization))))
 
 (defn- open-resource-plans-from-prefs [app-view prefs workspace project evaluation-context]
-  (let [prefs-data-per-tab-per-tab-pane (prefs/get prefs [:workflow :open-tabs])
+  (let [basis (:basis evaluation-context)
+        prefs-data-per-tab-per-tab-pane (prefs/get prefs [:workflow :open-tabs])
         selected-tab-index-by-tab-pane-index (prefs/get prefs [:workflow :last-selected-tabs :tab-selection-by-pane])]
     (coll/into-> prefs-data-per-tab-per-tab-pane []
       (coll/mapcat-indexed
@@ -2511,7 +2512,7 @@
             (coll/into-> prefs-data-per-tab :eduction
               (keep-indexed
                 (fn [tab-index [proj-path view-type-id]]
-                  (let [resource (workspace/find-resource workspace proj-path evaluation-context)]
+                  (let [resource (workspace/find-resource basis workspace proj-path)]
                     (when (and (resource/openable-resource? resource)
                                (resource/exists? resource))
                       (let [view-type (workspace/get-view-type workspace view-type-id evaluation-context)
@@ -3044,13 +3045,12 @@
 
 (defn file-open-user-data->openable-resources
   ([workspace x]
-   (g/with-auto-evaluation-context evaluation-context
-     (file-open-user-data->openable-resources workspace x evaluation-context)))
-  ([workspace x evaluation-context]
+   (file-open-user-data->openable-resources (g/now) workspace x))
+  ([basis workspace x]
    (cond
      (string? x)
-     (when-let [resource (workspace/find-resource workspace x evaluation-context)]
-       (recur workspace resource evaluation-context))
+     (when-let [resource (workspace/find-resource basis workspace x)]
+       (recur basis workspace resource))
 
      (resource/resource? x)
      (when (and (resource/openable? x)
@@ -3058,7 +3058,7 @@
        [x])
 
      (sequential? x)
-     (e/mapcat #(file-open-user-data->openable-resources workspace % evaluation-context) x)
+     (e/mapcat #(file-open-user-data->openable-resources basis workspace %) x)
 
      :else
      (throw (IllegalArgumentException. (str "Didn't expect file.open argument to be " x))))))
@@ -3246,7 +3246,7 @@
         (disk/async-reload! render-reload-progress! workspace [] changes-view
                             (fn [successful?]
                               (when successful?
-                                (when-some [created-resource (workspace/find-resource workspace proj-path)]
+                                (when-some [created-resource (workspace/find-resource (g/now) workspace proj-path)]
                                   (open-resource! app-view prefs localization project created-resource))))))
 
       (= :folder (resource/source-type resource))

--- a/editor/src/clj/editor/asset_browser.clj
+++ b/editor/src/clj/editor/asset_browser.clj
@@ -577,7 +577,7 @@
                 template (or (workspace/template workspace rt) "")]
             (create-template-file! template new-file))
           (workspace/resource-sync! workspace)
-          (let [resource-map (g/node-value workspace :resource-map)
+          (let [resource-map (g/raw-property-value (g/now) workspace :resource-map)
                 new-resource-path (resource/file->proj-path project-directory new-file)
                 resource (resource-map new-resource-path)]
             (when (resource/loaded? resource)
@@ -585,18 +585,21 @@
             (select-resource! asset-browser resource))))))
   (options [workspace user-data localization evaluation-context]
     (when (not user-data)
-      (let [base-columns
+      (let [basis (:basis evaluation-context)
+
+            base-columns
             (mapv #(mapv localization/message %)
                   [["resource.category.objects" "resource.category.scripts" "resource.category.shaders"]
                    ["resource.category.components"]
                    ["resource.category.resources"]
                    ["resource.category.editor" "resource.category.project_settings" "resource.category.other"]])
+
             predefined-categories (into #{} cat base-columns)
             all-items (coll/into->
-                        (resource/resource-types-by-type-ext (:basis evaluation-context) workspace :editable)
+                        (resource/resource-types-by-type-ext basis workspace :editable)
                         []
                         (keep (fn [[_ext resource-type]]
-                                (when (workspace/has-template? workspace resource-type evaluation-context)
+                                (when (workspace/has-template? basis workspace resource-type)
                                   {:label (or (:label resource-type) (:ext resource-type))
                                    :icon (:icon resource-type)
                                    :category (or (:category resource-type)

--- a/editor/src/clj/editor/atlas.clj
+++ b/editor/src/clj/editor/atlas.clj
@@ -873,7 +873,7 @@
     (make-image-nodes-in-atlas atlas-node image-msgs)))
 
 (defn- resolve-image-msgs [workspace image-msgs remove-duplicates]
-  (let [resolve-workspace-resource (partial workspace/resolve-workspace-resource workspace)]
+  (let [resolve-workspace-resource (partial workspace/resolve-workspace-resource (g/now) workspace)]
     (into []
           (comp (remove (comp empty? :image))
                 (if remove-duplicates

--- a/editor/src/clj/editor/boot_open_project.clj
+++ b/editor/src/clj/editor/boot_open_project.clj
@@ -401,7 +401,7 @@
 
           ;; If the project was just created, we automatically open the readme.
           (if newly-created?
-            (when-some [readme-resource (workspace/find-resource workspace "/README.md")]
+            (when-some [readme-resource (workspace/find-resource (g/now) workspace "/README.md")]
               (open-resource readme-resource))
             (app-view/restore-tabs-from-prefs! app-view prefs localization workspace project))
 

--- a/editor/src/clj/editor/breakpoints_view.clj
+++ b/editor/src/clj/editor/breakpoints_view.clj
@@ -121,10 +121,11 @@
 
 (defn restore-breakpoints! [project prefs]
   (g/with-auto-evaluation-context evaluation-context
-    (let [breakpoints (keep #(when-some [resource (workspace/find-resource (project/workspace project)
-                                                                           (:proj-path %)
-                                                                           evaluation-context)]
-                               (assoc % :resource resource))
+    (let [basis (:basis evaluation-context)
+          workspace (project/workspace project evaluation-context)
+          breakpoints (keep (fn [breakpoint]
+                              (when-some [resource (workspace/find-resource basis workspace (:proj-path breakpoint))]
+                                (assoc breakpoint :resource resource)))
                             (prefs/get prefs [:code :breakpoints]))
           script-bps (collect-script-nodes-from-breakpoints project breakpoints evaluation-context)]
       (g/transact

--- a/editor/src/clj/editor/cljfx_form_view.clj
+++ b/editor/src/clj/editor/cljfx_form_view.clj
@@ -141,7 +141,7 @@
   (DefoldStringConverter.
     resource/resource->proj-path
     #(some->> (when-not (string/blank? %) %)
-              (workspace/to-absolute-path)
+              (workspace/to-absolute-proj-path)
               (workspace/resolve-workspace-resource workspace))))
 
 (defn- text-field [props]

--- a/editor/src/clj/editor/code/script.clj
+++ b/editor/src/clj/editor/code/script.clj
@@ -453,7 +453,7 @@
                          lsp (lsp/get-node-lsp basis self)
                          workspace (resource/workspace resource)
                          lua-info (with-open [reader (data/lines-reader new-value)]
-                                    (lua-parser/lua-info workspace script-compilation/valid-resource-kind? reader evaluation-context))
+                                    (lua-parser/lua-info basis workspace script-compilation/valid-resource-kind? reader))
                          script-properties (script-compilation/lua-info->script-properties lua-info)]
                      (lsp/notify-lines-modified! lsp resource source-value new-value)
                      (g/set-property self :script-properties script-properties)))))

--- a/editor/src/clj/editor/code/script_compilation.clj
+++ b/editor/src/clj/editor/code/script_compilation.clj
@@ -171,7 +171,8 @@
            (g/->error _node-id :modified-lines :fatal resource message {:cursor-range cursor-range})))))
 
 (defn build-targets [_node-id resource lines lua-preprocessors script-properties original-resource-property-build-targets proj-path->resource-node evaluation-context]
-  (let [workspace (resource/workspace resource)]
+  (let [basis (:basis evaluation-context)
+        workspace (resource/workspace resource)]
     (if-some [errors
               (not-empty
                 (keep (fn [{:keys [name resource-kind type value]}]
@@ -191,7 +192,7 @@
                 log-error-message (format "Lua preprocessing failed for file '%s'." (resource/proj-path resource))]
             (log/error :message log-error-message :exception exception)
             (if-some [[proj-path line-number] (try-parse-file-line exception-message)]
-              (let [exception-resource (workspace/resolve-resource resource proj-path evaluation-context)
+              (let [exception-resource (workspace/resolve-resource basis resource proj-path)
                     exception-node-id (proj-path->resource-node proj-path)
                     error-node-id (or exception-node-id _node-id)
                     error-resource (if (nil? exception-node-id) resource exception-resource)
@@ -200,7 +201,7 @@
               (g/->error _node-id :modified-lines :fatal resource build-error-message)))
           (let [preprocessed-lua-info
                 (with-open [reader (data/lines-reader preprocessed-lines)]
-                  (lua-parser/lua-info workspace valid-resource-kind? reader evaluation-context))]
+                  (lua-parser/lua-info basis workspace valid-resource-kind? reader))]
             (g/precluding-errors (lua-info-errors _node-id resource preprocessed-lua-info)
               (let [preprocessed-script-properties (lua-info->script-properties preprocessed-lua-info)
                     preprocessed-modules (lua-info->modules preprocessed-lua-info)

--- a/editor/src/clj/editor/code/shader.clj
+++ b/editor/src/clj/editor/code/shader.clj
@@ -164,7 +164,7 @@
                      (concat
                        (g/disconnect-sources basis self :included-proj-paths+full-lines)
                        (map (fn [include]
-                              (let [included-resource (workspace/resolve-resource resource include evaluation-context)]
+                              (let [included-resource (workspace/resolve-resource basis resource include)]
                                 (:tx-data (project/connect-resource-node evaluation-context project included-resource self connections))))
                             new-value))))))
 

--- a/editor/src/clj/editor/collection.clj
+++ b/editor/src/clj/editor/collection.clj
@@ -859,52 +859,54 @@
 
 (defn load-collection [project self resource collection]
   {:pre [(map? collection)]} ; GameObject$CollectionDesc in map format.
-  (concat
-    (gu/set-properties-from-pb-map self GameObject$CollectionDesc collection
-      name :name
-      scale-along-z (protobuf/int->boolean :scale-along-z))
-    (let [tx-go-creation (flatten
-                           (concat
-                             (for [game-object (:instances collection)
-                                   :let [source-resource (workspace/resolve-resource resource (:prototype game-object))]]
-                               (make-ref-go self source-resource (:id game-object) game-object nil (:component-properties game-object) nil))
-                             (for [embedded (:embedded-instances collection)]
-                               (do
-                                 ;; Note: We only need to check that the
-                                 ;; EmbeddedInstanceDesc has been string-decoded
-                                 ;; here. Any EmbeddedComponentDescs inside will
-                                 ;; be validated by the game-object :load-fn.
-                                 (collection-string-data/verify-string-decoded-embedded-instance-desc! embedded resource)
-                                 (make-embedded-go self project (:data embedded) (:id embedded) embedded nil nil)))))
-          id->nid (-> tx-go-creation
-                      (g/tx-data-added-nodes)
-                      (coll/into-> {}
-                        (filter #(g/node-instance*? GameObjectInstanceNode %))
-                        (map (fn [node]
-                               (pair (:id node)
-                                     (g/node-id node))))))
-          child->parent (-> {}
-                            (into (map #(pair (key %) nil))
-                                  id->nid)
-                            (into
-                              (comp cat
-                                    (mapcat (fn [{:keys [children id]}]
-                                              (map #(pair % id)
-                                                   children))))
-                              (pair (:instances collection)
-                                    (:embedded-instances collection))))]
-      (validate-child-references! id->nid child->parent)
-      (concat
-        tx-go-creation
-        (for [[child parent] child->parent
-              :let [child-id (id->nid child)
-                    parent-id (if parent (id->nid parent) self)]]
-          (if parent
-            (child-go-go parent-id child-id)
-            (child-coll-any self child-id)))))
-    (for [coll-instance (:collection-instances collection)
-          :let [source-resource (workspace/resolve-resource resource (:collection coll-instance))]]
-      (make-collection-instance self source-resource (:id coll-instance) coll-instance (:instance-properties coll-instance) nil))))
+  (let [basis (g/now)
+        resolve-resource #(workspace/resolve-resource basis resource %)]
+    (concat
+      (gu/set-properties-from-pb-map self GameObject$CollectionDesc collection
+        name :name
+        scale-along-z (protobuf/int->boolean :scale-along-z))
+      (let [tx-go-creation (flatten
+                             (concat
+                               (for [game-object (:instances collection)
+                                     :let [source-resource (resolve-resource (:prototype game-object))]]
+                                 (make-ref-go self source-resource (:id game-object) game-object nil (:component-properties game-object) nil))
+                               (for [embedded (:embedded-instances collection)]
+                                 (do
+                                   ;; Note: We only need to check that the
+                                   ;; EmbeddedInstanceDesc has been string-decoded
+                                   ;; here. Any EmbeddedComponentDescs inside will
+                                   ;; be validated by the game-object :load-fn.
+                                   (collection-string-data/verify-string-decoded-embedded-instance-desc! embedded resource)
+                                   (make-embedded-go self project (:data embedded) (:id embedded) embedded nil nil)))))
+            id->nid (-> tx-go-creation
+                        (g/tx-data-added-nodes)
+                        (coll/into-> {}
+                          (filter #(g/node-instance*? GameObjectInstanceNode %))
+                          (map (fn [node]
+                                 (pair (:id node)
+                                       (g/node-id node))))))
+            child->parent (-> {}
+                              (into (map #(pair (key %) nil))
+                                    id->nid)
+                              (into
+                                (comp cat
+                                      (mapcat (fn [{:keys [children id]}]
+                                                (map #(pair % id)
+                                                     children))))
+                                (pair (:instances collection)
+                                      (:embedded-instances collection))))]
+        (validate-child-references! id->nid child->parent)
+        (concat
+          tx-go-creation
+          (for [[child parent] child->parent
+                :let [child-id (id->nid child)
+                      parent-id (if parent (id->nid parent) self)]]
+            (if parent
+              (child-go-go parent-id child-id)
+              (child-coll-any self child-id)))))
+      (for [coll-instance (:collection-instances collection)
+            :let [source-resource (resolve-resource (:collection coll-instance))]]
+        (make-collection-instance self source-resource (:id coll-instance) coll-instance (:instance-properties coll-instance) nil)))))
 
 (defn- sanitize-collection [workspace collection-desc]
   (let [ext->embedded-component-resource-type (workspace/get-resource-type-map workspace)]
@@ -940,8 +942,9 @@
            (mapv #(add-dropped-resource root-id transform-props % evaluation-context))))))
 
 (defmethod ext-graph/create-extra-nodes ::EmbeddedGOInstanceNode [evaluation-context _rt project workspace _attachment node-id]
-  (let [resource-type ((resource/resource-types-by-type-ext (:basis evaluation-context) workspace :editable) "go")
-        pb-map (game-object-common/template-pb-map workspace resource-type evaluation-context)
+  (let [basis (:basis evaluation-context)
+        resource-type (get (resource/resource-types-by-type-ext basis workspace :editable) "go")
+        pb-map (game-object-common/template-pb-map basis workspace resource-type)
         resource (resource/make-memory-resource workspace resource-type pb-map)
         graph (g/node-id->graph-id node-id)
         node-type (:node-type resource-type)]

--- a/editor/src/clj/editor/collection_proxy.clj
+++ b/editor/src/clj/editor/collection_proxy.clj
@@ -80,7 +80,8 @@
 
 (defn load-collection-proxy [_project self resource collection-proxy-desc]
   {:pre [(map? collection-proxy-desc)]} ; GameSystem$CollectionProxyDesc in map format.
-  (let [resolve-resource #(workspace/resolve-resource resource %)]
+  (let [basis (g/now)
+        resolve-resource #(workspace/resolve-resource basis resource %)]
     (gu/set-properties-from-pb-map self GameSystem$CollectionProxyDesc collection-proxy-desc
       collection (resolve-resource :collection)
       exclude :exclude)))

--- a/editor/src/clj/editor/collision_object.clj
+++ b/editor/src/clj/editor/collision_object.clj
@@ -426,7 +426,8 @@
 (defn load-collision-object
   [project self resource collision-object-desc]
   {:pre [(map? collision-object-desc)]} ; Physics$CollisionObjectDesc in map format.
-  (let [resolve-resource #(workspace/resolve-resource resource %)
+  (let [basis (g/now)
+        resolve-resource #(workspace/resolve-resource basis resource %)
         to-comma-separated-string #(some->> % (string/join ", "))]
     (concat
       (gu/set-properties-from-pb-map self Physics$CollisionObjectDesc collision-object-desc

--- a/editor/src/clj/editor/compute.clj
+++ b/editor/src/clj/editor/compute.clj
@@ -122,7 +122,8 @@
 
 (defn load-compute [_project self resource compute-desc]
   {:pre [(map? compute-desc)]} ; Compute$ComputeDesc in map format.
-  (let [resolve-resource #(workspace/resolve-resource resource %)]
+  (let [basis (g/now)
+        resolve-resource #(workspace/resolve-resource basis resource %)]
     (gu/set-properties-from-pb-map self Compute$ComputeDesc compute-desc
       compute-program (resolve-resource :compute-program)
       constants (render-program-utils/constants->editable-constants :constants)

--- a/editor/src/clj/editor/console.clj
+++ b/editor/src/clj/editor/console.clj
@@ -656,7 +656,8 @@
 (defn- repaint-console-view! [view-node workspace on-region-click! elapsed-time]
   (let [{:keys [clear entries]} (dequeue-pending! 1024)]
     (when (or clear (seq entries))
-      (g/let-ec [resource-map (g/node-value workspace :resource-map evaluation-context)
+      (g/let-ec [basis (:basis evaluation-context)
+                 resource-map (g/raw-property-value basis workspace :resource-map)
                  ^LayoutInfo prev-layout (g/node-value view-node :layout evaluation-context)
                  prev-lines (g/node-value view-node :lines evaluation-context)
                  prev-regions (g/node-value view-node :regions evaluation-context)
@@ -746,7 +747,7 @@
                                                                    {:cursor-range (data/Cursor->CursorRange (data/->Cursor row 0))})]
                                                         (open-resource-fn resource opts))))
                                    resource-candidates (into []
-                                                             (comp (keep (partial workspace/find-resource workspace))
+                                                             (comp (keep (partial workspace/find-resource (g/now) workspace))
                                                                    (filter openable-resource?))
                                                              (:proj-path-candidates region))]
                                (case (count resource-candidates)

--- a/editor/src/clj/editor/cubemap.clj
+++ b/editor/src/clj/editor/cubemap.clj
@@ -306,7 +306,8 @@
 
 (defn load-cubemap [project self resource cubemap]
   {:pre [(map? cubemap)]} ; Graphics$Cubemap in map format.
-  (let [resolve-resource #(workspace/resolve-resource resource %)]
+  (let [basis (g/now)
+        resolve-resource #(workspace/resolve-resource basis resource %)]
     (concat
       (g/connect project :build-settings self :build-settings)
       (g/connect project :texture-profiles self :texture-profiles)

--- a/editor/src/clj/editor/debug_view.clj
+++ b/editor/src/clj/editor/debug_view.clj
@@ -394,7 +394,9 @@
 
 (defn- file-or-module->resource
   [workspace file]
-  (some (partial workspace/find-resource workspace) [file (lua/lua-module->path file)]))
+  (let [basis (g/now)]
+    (or (workspace/find-resource basis workspace file)
+        (workspace/find-resource basis workspace (lua/lua-module->path file)))))
 
 (defn- make-open-resource-fn
   [project open-resource-fn]

--- a/editor/src/clj/editor/defold_project.clj
+++ b/editor/src/clj/editor/defold_project.clj
@@ -865,7 +865,7 @@
      (get-resource-node project path-or-resource evaluation-context)))
   ([project path-or-resource evaluation-context]
    (when-let [resource (cond
-                         (string? path-or-resource) (workspace/find-resource (g/node-value project :workspace evaluation-context) path-or-resource evaluation-context)
+                         (string? path-or-resource) (workspace/find-resource (:basis evaluation-context) (g/node-value project :workspace evaluation-context) path-or-resource)
                          (resource/resource? path-or-resource) path-or-resource
                          :else (assert false (str (type path-or-resource) " is neither a path nor a resource: " (pr-str path-or-resource))))]
      ;; This is frequently called from property setters, where we don't have a
@@ -970,10 +970,9 @@
          node-id+resource-pairs (make-node-id+resource-pairs project-graph resources)
 
          game-project-resource
-         (g/with-auto-evaluation-context evaluation-context
-           (-> project
-               (workspace evaluation-context)
-               (workspace/find-resource "/game.project" evaluation-context)))
+         (g/let-ec [basis (:basis evaluation-context)
+                    workspace (workspace project evaluation-context)]
+           (workspace/find-resource basis workspace "/game.project"))
 
          game-project-node-id
          (when game-project-resource
@@ -1460,7 +1459,7 @@
              localization (workspace/localization workspace evaluation-context)
              code-preprocessors (workspace/code-preprocessors workspace evaluation-context)
              code-transpilers (code-transpilers basis project)]
-    (workspace/unpack-editor-plugins! workspace touched-resources)
+    (workspace/unpack-editor-plugins! basis workspace touched-resources)
     (code.preprocessors/reload-lua-preprocessors! code-preprocessors java/class-loader localization)
     (code.transpilers/reload-lua-transpilers! code-transpilers workspace java/class-loader localization)
     (texture.engine/reload-texture-compressors! java/class-loader localization)
@@ -1691,7 +1690,7 @@
 
 (defn resolve-path-or-resource [project path-or-resource evaluation-context]
   (if (string? path-or-resource)
-    (workspace/resolve-workspace-resource (workspace project evaluation-context) path-or-resource evaluation-context)
+    (workspace/resolve-workspace-resource (:basis evaluation-context) (workspace project evaluation-context) path-or-resource)
     path-or-resource))
 
 (defn disconnect-resource-node [evaluation-context project path-or-resource consumer-node connections]

--- a/editor/src/clj/editor/editor_extensions.clj
+++ b/editor/src/clj/editor/editor_extensions.clj
@@ -190,7 +190,7 @@
           resource-types (resource/resource-types-by-type-ext basis workspace :editable)
           type-ext->template (fn/memoize
                                (fn type-ext->template [ext]
-                                 (or (workspace/template workspace (get resource-types ext) evaluation-context) "")))]
+                                 (or (workspace/template basis workspace (get resource-types ext)) "")))]
       (-> (future/io
             (let [root-path (path/real project-dir)
                   path+contents (mapv (fn [{proj-path 1 content 2}]
@@ -292,10 +292,10 @@
 
 (defn- make-ext-resource-attributes-fn [project]
   (rt/lua-fn ext-resource-attributes [{:keys [rt evaluation-context]} lua-resource-path]
-    (let [proj-path (rt/->clj rt graph/resource-path-coercer lua-resource-path)]
-      (if-let [resource (-> project
-                            (project/workspace evaluation-context)
-                            (workspace/find-resource proj-path evaluation-context))]
+    (let [basis (:basis evaluation-context)
+          proj-path (rt/->clj rt graph/resource-path-coercer lua-resource-path)
+          workspace (project/workspace project evaluation-context)]
+      (if-let [resource (workspace/find-resource basis workspace proj-path)]
         (let [source-type (resource/source-type resource)]
           {:exists true
            :is_file (= :file source-type)
@@ -434,8 +434,9 @@
 
 (defn- make-open-resource-fn [workspace open-resource!]
   (rt/suspendable-lua-fn open-resource [{:keys [rt evaluation-context]} lua-resource-path]
-    (let [resource-path (rt/->clj rt graph/resource-path-coercer lua-resource-path)
-          resource (workspace/find-resource workspace resource-path evaluation-context)]
+    (let [basis (:basis evaluation-context)
+          resource-path (rt/->clj rt graph/resource-path-coercer lua-resource-path)
+          resource (workspace/find-resource basis workspace resource-path)]
       (when (and resource (resource/exists? resource) (resource/openable? resource))
         (open-resource! resource)))))
 

--- a/editor/src/clj/editor/editor_extensions/graph.clj
+++ b/editor/src/clj/editor/editor_extensions/graph.clj
@@ -105,7 +105,9 @@
   node id, while a folder path resolves to folder resource."
   [unresolved-editor-lookup project evaluation-context]
   (if (string? unresolved-editor-lookup)
-    (let [resource (workspace/find-resource (project/workspace project evaluation-context) unresolved-editor-lookup evaluation-context)]
+    (let [basis (:basis evaluation-context)
+          workspace (project/workspace project evaluation-context)
+          resource (workspace/find-resource basis workspace unresolved-editor-lookup)]
       (when-not resource
         (throw (LuaError. (str unresolved-editor-lookup " not found"))))
       (or (project/get-resource-node project resource evaluation-context)
@@ -140,9 +142,9 @@
   (let [unresolved-editor-lookup (rt/->clj rt unresolved-editor-lookup-or-empty-string-coercer lua-value)]
     (when-not (= unresolved-editor-lookup "")
       (let [resource (if (string? unresolved-editor-lookup)
-                       (-> project
-                           (project/workspace evaluation-context)
-                           (workspace/resolve-workspace-resource unresolved-editor-lookup evaluation-context))
+                       (let [basis (:basis evaluation-context)
+                             workspace (project/workspace project evaluation-context)]
+                         (workspace/resolve-workspace-resource basis workspace unresolved-editor-lookup))
                        (g/node-value (editor-lookup->node-id unresolved-editor-lookup) :resource evaluation-context))
             ext (:ext edit-type)
             ext (if (string? ext) [ext] ext)]

--- a/editor/src/clj/editor/editor_extensions/http_server.clj
+++ b/editor/src/clj/editor/editor_extensions/http_server.clj
@@ -113,8 +113,9 @@
 
 (defn- make-ext-resource-response-fn [workspace]
   (rt/varargs-lua-fn ext-resource-response [{:keys [rt evaluation-context]} varargs]
-    (let [{:keys [status headers resource-path] :or {status 200}} (rt/->clj rt resource-response-args-coercer varargs)]
-      (let [resource (workspace/resolve-workspace-resource workspace resource-path evaluation-context)]
+    (let [basis (:basis evaluation-context)
+          {:keys [status headers resource-path] :or {status 200}} (rt/->clj rt resource-response-args-coercer varargs)]
+      (let [resource (workspace/resolve-workspace-resource basis workspace resource-path)]
         (-> (http-server/response status headers resource)
             (with-meta {:type :response})
             (rt/wrap-userdata "http.server.resource_response(...)"))))))

--- a/editor/src/clj/editor/editor_extensions/ui_components.clj
+++ b/editor/src/clj/editor/editor_extensions/ui_components.clj
@@ -314,7 +314,7 @@
 
 (defn- construct-image [s workspace]
   (if (string/starts-with? s "/")
-    (when-let [resource (workspace/find-resource workspace s (lifecycle-evaluation-context))]
+    (when-let [resource (workspace/find-resource (:basis (lifecycle-evaluation-context)) workspace s)]
       (when (resource/exists? resource)
         (with-open [is (io/input-stream resource)]
           (Image. is))))

--- a/editor/src/clj/editor/factory.clj
+++ b/editor/src/clj/editor/factory.clj
@@ -91,7 +91,8 @@
   {:pre [(contains? factory-types factory-type)
          (map? any-factory-desc)]} ; GameSystem$FactoryDesc or GameSystem$CollectionFactoryDesc in map format.
   (let [pb-class (:pb-type (get factory-types factory-type))
-        resolve-resource #(workspace/resolve-resource resource %)]
+        basis (g/now)
+        resolve-resource #(workspace/resolve-resource basis resource %)]
     (into [(g/set-property self :factory-type factory-type)]
           (gu/set-properties-from-pb-map self pb-class any-factory-desc
             prototype (resolve-resource :prototype)

--- a/editor/src/clj/editor/font.clj
+++ b/editor/src/clj/editor/font.clj
@@ -960,7 +960,8 @@
 
 (defn load-font [_project self resource font-desc]
   {:pre [(map? font-desc)]} ; Font$FontDesc in map format.
-  (let [resolve-resource #(workspace/resolve-resource resource %)]
+  (let [basis (g/now)
+        resolve-resource #(workspace/resolve-resource basis resource %)]
     (gu/set-properties-from-pb-map self Font$FontDesc font-desc
       font (resolve-resource :font)
       material (resolve-resource :material)

--- a/editor/src/clj/editor/fs.clj
+++ b/editor/src/clj/editor/fs.clj
@@ -248,7 +248,7 @@
   (^File [] (create-temp-file! nil nil))
   (^File [prefix] (create-temp-file! prefix nil))
   (^File [prefix suffix]
-   (doto (.toFile (Files/createTempFile prefix suffix empty-file-attrs))
+   (doto (.getCanonicalFile (.toFile (Files/createTempFile prefix suffix empty-file-attrs)))
      (delete-on-exit!))))
 
 (defn create-temp-directory!
@@ -256,7 +256,7 @@
   The directory will be deleted on exit."
   (^File [] (create-temp-directory! nil))
   (^File [hint]
-   (doto (.toFile (Files/createTempDirectory hint empty-file-attrs))
+   (doto (.getCanonicalFile (.toFile (Files/createTempDirectory hint empty-file-attrs)))
      (delete-on-exit!))))
 
 ;; create directories, files
@@ -313,7 +313,7 @@
 
 (def ^:private fs-temp-dir (create-temp-directory! "moved"))
 
-(def case-sensitive?
+(def is-case-sensitive
   "Whether we're running on a case sensitive file system or not."
   (let [lower-file (io/file (io/file fs-temp-dir "casetest"))
         upper-file (io/file (io/file fs-temp-dir "CASETEST"))]
@@ -323,7 +323,7 @@
 (defn- comparable-path
   ^String [entry]
   (cond-> (-> entry io/as-file .toPath .normalize .toAbsolutePath .toString)
-          (not case-sensitive?) .toLowerCase))
+          (not is-case-sensitive) .toLowerCase))
 
 (def separator-char File/separatorChar)
 

--- a/editor/src/clj/editor/game_object.clj
+++ b/editor/src/clj/editor/game_object.clj
@@ -588,25 +588,24 @@
         resource-type (:resource-type user-data)]
     (add-embedded-component! go-id resource-type select-fn)))
 
-(defn- embeddable-component-resource-type? [resource-type workspace evaluation-context]
+(defn- embeddable-component-resource-type? [basis resource-type workspace]
   (let [{:keys [tags] :as resource-type} resource-type]
     (and (contains? tags :component)
          (not (contains? tags :non-embeddable))
-         (workspace/has-template? workspace resource-type evaluation-context))))
+         (workspace/has-template? basis workspace resource-type))))
 
 (defn embeddable-component-resource-types
   ([workspace]
-   (g/with-auto-evaluation-context evaluation-context
-     (embeddable-component-resource-types workspace evaluation-context)))
-  ([workspace evaluation-context]
+   (embeddable-component-resource-types (g/now) workspace))
+  ([basis workspace]
    (keep (fn [[_ext resource-type]]
-           (when (embeddable-component-resource-type? resource-type workspace evaluation-context)
+           (when (embeddable-component-resource-type? basis resource-type workspace)
              resource-type))
-         (resource/resource-types-by-type-ext (:basis evaluation-context) workspace :editable))))
+         (resource/resource-types-by-type-ext basis workspace :editable))))
 
-(defn- add-embedded-component-options [self workspace user-data evaluation-context]
+(defn- add-embedded-component-options [basis self workspace user-data]
   (when (not user-data)
-    (->> (embeddable-component-resource-types workspace evaluation-context)
+    (->> (embeddable-component-resource-types basis workspace)
          (mapv (fn [res-type]
                  {:label (or (:label res-type) (:ext res-type))
                   :icon (:icon res-type)
@@ -623,18 +622,21 @@
   (active? [selection evaluation-context] (selection->game-object selection evaluation-context))
   (run [user-data app-view] (add-embedded-component-handler user-data (fn [node-ids] (app-view/select app-view node-ids))))
   (options [selection user-data evaluation-context]
-    (let [self (selection->game-object selection evaluation-context)
+    (let [basis (:basis evaluation-context)
+          self (selection->game-object selection evaluation-context)
           workspace (:workspace (g/node-value self :resource evaluation-context))]
-      (add-embedded-component-options self workspace user-data evaluation-context))))
+      (add-embedded-component-options basis self workspace user-data))))
 
 (defn load-game-object [project self resource prototype-desc]
   {:pre [(map? prototype-desc)]} ; GameObject$PrototypeDesc in map format.
-  (let [workspace (project/workspace project)
+  (let [basis (g/now)
+        resolve-resource #(workspace/resolve-resource basis resource %)
+        workspace (project/workspace project)
         ext->embedded-component-resource-type (workspace/get-resource-type-map workspace)]
     (concat
       (for [component (:components prototype-desc)
             :let [source-path (:component component)
-                  source-resource (workspace/resolve-resource resource source-path)
+                  source-resource (resolve-resource source-path)
                   resource-type (some-> source-resource resource/resource-type)
                   transform-properties (select-transform-properties resource-type component)
                   properties (:properties component)]]
@@ -693,25 +695,27 @@
     (let [type-name (rt/->clj rt coerce/string lua-type)]
       (if (= ext-referenced-component-type type-name)
         [(dissoc attachment "type") ReferencedComponent]
-        (let [resource-types (resource/resource-types-by-type-ext (:basis evaluation-context) workspace :editable)
+        (let [basis (:basis evaluation-context)
+              resource-types (resource/resource-types-by-type-ext basis workspace :editable)
               resource-type (resource-types type-name)]
-          (if (and resource-type (embeddable-component-resource-type? resource-type workspace evaluation-context))
+          (if (and resource-type (embeddable-component-resource-type? basis resource-type workspace))
             [attachment EmbeddedComponent]
             (throw (LuaError. (str "type is not "
-                                   (->> (embeddable-component-resource-types workspace evaluation-context)
+                                   (->> (embeddable-component-resource-types basis workspace)
                                         (map :ext)
                                         (cons ext-referenced-component-type)
                                         (eutil/join-words ", " " or ")))))))))
     (throw (LuaError. "type is required"))))
 
 (defmethod ext-graph/create-extra-nodes ::EmbeddedComponent [evaluation-context rt project workspace attachment node-id]
-  (let [component-ext (rt/->clj rt coerce/string (attachment "type"))
-        resource-types (resource/resource-types-by-type-ext (:basis evaluation-context) workspace :editable)
+  (let [basis (:basis evaluation-context)
+        component-ext (rt/->clj rt coerce/string (attachment "type"))
+        resource-types (resource/resource-types-by-type-ext basis workspace :editable)
         resource-type (resource-types component-ext)]
     (assert resource-type)
-    (assert (embeddable-component-resource-type? resource-type workspace evaluation-context))
+    (assert (embeddable-component-resource-type? basis resource-type workspace))
     (let [graph (g/node-id->graph-id node-id)
-          pb-map (game-object-common/template-pb-map workspace resource-type evaluation-context)
+          pb-map (game-object-common/template-pb-map basis workspace resource-type)
           resource (resource/make-memory-resource workspace resource-type pb-map)
           node-type (:node-type resource-type)]
       (g/make-nodes graph [resource-node [node-type :resource resource]]

--- a/editor/src/clj/editor/game_object_common.clj
+++ b/editor/src/clj/editor/game_object_common.clj
@@ -39,10 +39,9 @@
 
 (defn template-pb-map
   ([workspace resource-type]
-   (g/with-auto-evaluation-context evaluation-context
-     (template-pb-map workspace resource-type evaluation-context)))
-  ([workspace resource-type evaluation-context]
-   (let [template (workspace/template workspace resource-type evaluation-context)
+   (template-pb-map (g/now) workspace resource-type))
+  ([basis workspace resource-type]
+   (let [template (workspace/template basis workspace resource-type)
          read-fn (:read-fn resource-type)]
      (with-open [reader (StringReader. template)]
        (read-fn reader)))))

--- a/editor/src/clj/editor/graph_util.clj
+++ b/editor/src/clj/editor/graph_util.clj
@@ -16,14 +16,10 @@
   (:require [clojure.set :as set]
             [clojure.string :as string]
             [dynamo.graph :as g]
-            [editor.core :as core]
-            [editor.outline :as outline]
             [editor.protobuf :as protobuf]
-            [editor.resource :as resource]
-            [editor.resource-node :as resource-node]
-            [internal.graph.types :as gt]
             [internal.node :as in]
-            [util.coll :as coll]))
+            [util.coll :as coll]
+            [util.fn :as fn]))
 
 (set! *warn-on-reflection* true)
 (set! *unchecked-math* :warn-on-boxed)
@@ -32,6 +28,30 @@
 
 (defmacro passthrough [field]
   `(g/fnk [~field] ~field))
+
+(defn- make-immutable-property-set-fn-raw [prop-kw]
+  {:pre [(keyword? prop-kw)]}
+  (fn immutable-property-set-fn [evaluation-context node-id old-value new-value]
+    (when (some? old-value)
+      (let [basis (:basis evaluation-context)
+            node-type-kw (g/node-type-kw basis node-id)]
+        (throw (ex-info (format "Unable to reassign immutable property %s on %s %d."
+                                prop-kw
+                                node-type-kw
+                                node-id)
+                        {:node-id node-id
+                         :node-type-kw node-type-kw
+                         :prop-kw prop-kw
+                         :old-value old-value
+                         :new-value new-value}))))))
+
+(def make-immutable-property-set-fn (fn/memoize make-immutable-property-set-fn-raw))
+
+(defmacro immutable-property-setter [prop-sym]
+  {:pre [(symbol? prop-sym)
+         (not (qualified-symbol? prop-sym))]}
+  (let [prop-kw (keyword prop-sym)]
+    (make-immutable-property-set-fn prop-kw)))
 
 (defn array-subst-remove-errors [arr]
   (filterv (complement g/error?) arr))
@@ -50,91 +70,6 @@
     (for [[source-output-label target-output-label] connections
           :when (contains? existing-source-output-labels source-output-label)]
       (g/connect source-node-id source-output-label target-node-id target-output-label))))
-
-(defn node-qualifier-label
-  "Given a node-id, returns a string that identifies the node for the user.
-  Typically, this will be the URL that uniquely identifies the node inside its
-  owner resource, or the id that the user has specified for the node. Returns
-  nil if there is no suitable qualifier for the given node."
-  ([node-id]
-   (g/with-auto-evaluation-context evaluation-context
-     (node-qualifier-label node-id evaluation-context)))
-  ([node-id {:keys [basis] :as evaluation-context}]
-   (when-some [node (g/node-by-id-at basis node-id)]
-     (let [node-type (g/node-type node)]
-       (or (when (in/behavior node-type :url)
-             (let [value (in/node-value node :url evaluation-context)]
-               (when (and (string? value)
-                          (coll/not-empty value))
-                 ;; Convert urls to a more readable representation.
-                 ;;   "#book_script" -> "book_script"
-                 ;;   "/referenced_book#book_script" -> "referenced_book/book_script"
-                 (-> value
-                     (subs 1)
-                     (string/replace "#" "/")))))
-           (when (in/behavior node-type :id)
-             (let [value (in/node-value node :id evaluation-context)]
-               (when (string? value)
-                 (coll/not-empty value)))))))))
-
-(defn node-debug-label
-  ([node-id]
-   (g/with-auto-evaluation-context evaluation-context
-     (node-debug-label node-id evaluation-context)))
-  ([node-id {:keys [basis] :as evaluation-context}]
-   (let [node (g/node-by-id basis node-id)
-         node-type (g/node-type node)]
-     (or (when (in/inherits? node-type resource/ResourceNode)
-           (let [resource (resource-node/resource basis node-id)]
-             (cond
-               (resource/memory-resource? resource)
-               (str "embedded." (resource/ext resource))
-
-               (some? (gt/original node))
-               (let [proj-path (resource/proj-path resource)]
-                 (if-let [owner-resource (resource-node/owner-resource basis node-id)]
-                   (str proj-path " override in " (resource/proj-path owner-resource))
-                   (str proj-path " override")))
-
-               :else
-               (resource/proj-path resource))))
-         (node-qualifier-label node-id evaluation-context)
-         (when (in/inherits? node-type outline/OutlineNode)
-           (coll/not-empty (:label (g/maybe-node-value node-id :node-outline evaluation-context))))
-         (let [name (g/maybe-node-value node-id :name evaluation-context)]
-           (when (string? name)
-             (coll/not-empty name)))
-         (str (name (:k node-type)) \# node-id)))))
-
-(defn node-debug-label-path
-  ([node-id]
-   (g/with-auto-evaluation-context evaluation-context
-     (node-debug-label-path node-id evaluation-context)))
-  ([node-id {:keys [basis] :as evaluation-context}]
-   (let [graph-id (g/node-id->graph-id node-id)
-         project-node-id (g/graph-value basis graph-id :project-id)]
-     (->> node-id
-          (iterate #(core/owner-node-id basis %))
-          (take-while #(some-> % (not= project-node-id)))
-          (reverse)
-          (mapv #(node-debug-label % evaluation-context))))))
-
-(defn node-debug-info
-  ([node-id]
-   (g/with-auto-evaluation-context evaluation-context
-     (node-debug-info node-id evaluation-context)))
-  ([node-id {:keys [basis] :as evaluation-context}]
-   (let [node-type-kw (g/node-type-kw basis node-id)
-         node-debug-label-path (node-debug-label-path node-id evaluation-context)
-         owner-resource-node-id (try
-                                  (resource-node/owner-resource-node-id basis node-id)
-                                  (catch Exception _
-                                    nil))
-         owner-resource-node-type-kw (some->> owner-resource-node-id (g/node-type-kw basis))]
-     {:node-type-kw node-type-kw
-      :node-debug-label-path node-debug-label-path
-      :owner-resource-node-id owner-resource-node-id
-      :owner-resource-node-type-kw owner-resource-node-type-kw})))
 
 ;; -----------------------------------------------------------------------------
 ;; set-properties-from-pb-map macro

--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -2227,11 +2227,12 @@
 
 (defn- contains-resource?
   [project gui-scene resource evaluation-context]
-  (let [workspace (project/workspace project evaluation-context)
+  (let [basis (:basis evaluation-context)
+        workspace (project/workspace project evaluation-context)
         acc-fn (fn [target-node]
                  (->> (g/node-value target-node :node-msgs evaluation-context)
                       (filter #(= :type-template (:type %)))
-                      (keep #(workspace/resolve-workspace-resource workspace (:template %) evaluation-context))))]
+                      (keep #(workspace/resolve-workspace-resource basis workspace (:template %)))))]
     (project/node-refers-to-resource? project gui-scene resource acc-fn)))
 
 (g/defnode TemplateNode
@@ -4033,7 +4034,8 @@
         custom-data        (for [loader-fn custom-loader-fns
                                  :let [result (loader-fn project self scene graph-id resource)]]
                              result)
-        resolve-resource #(workspace/resolve-resource resource %)]
+        basis (g/now)
+        resolve-resource #(workspace/resolve-resource basis resource %)]
     (concat
       ;; TODO(save-value-cleanup): We could use set-properties-from-pb-map when setting Gui$NodeDesc properties as well.
       (gu/set-properties-from-pb-map self Gui$SceneDesc scene
@@ -4082,7 +4084,7 @@
         (g/connect materials-node :node-outline self :child-outlines)
         (g/connect materials-node :add-handler-info self :handler-infos)
         (for [materials-desc (:materials scene)
-              :let [resource (workspace/resolve-resource resource (:material materials-desc))]]
+              :let [resource (resolve-resource (:material materials-desc))]]
           (g/make-nodes graph-id [material [MaterialNode :name (:name materials-desc) :material resource]]
             (attach-material self materials-node material))))
 

--- a/editor/src/clj/editor/icons.clj
+++ b/editor/src/clj/editor/icons.clj
@@ -48,10 +48,10 @@
 
 (defn- find-resource
   ([workspace proj-path]
-   (g/with-auto-evaluation-context evaluation-context
-     (find-resource workspace proj-path evaluation-context)))
-  ([workspace proj-path evaluation-context]
-   (get (g/node-value workspace :resource-map evaluation-context) proj-path)))
+   (find-resource (g/now) workspace proj-path))
+  ([basis workspace proj-path]
+   (let [resources-by-proj-path (g/raw-property-value basis workspace :resource-map)]
+     (get resources-by-proj-path proj-path))))
 
 (defn- load-icon-image
   ^Image [^String name ^Double size]

--- a/editor/src/clj/editor/label.clj
+++ b/editor/src/clj/editor/label.clj
@@ -360,7 +360,8 @@
 
 (defn load-label [_project self resource label]
   {:pre [(map? label)]} ; Label$LabelDesc in map format.
-  (let [resolve-resource #(workspace/resolve-resource resource %)]
+  (let [basis (g/now)
+        resolve-resource #(workspace/resolve-resource basis resource %)]
     (gu/set-properties-from-pb-map self Label$LabelDesc label
       text :text
       size (protobuf/vector4->vector3 :size)

--- a/editor/src/clj/editor/lsp/server.clj
+++ b/editor/src/clj/editor/lsp/server.clj
@@ -134,7 +134,7 @@
   (let [basis (:basis evaluation-context)
         workspace (g/node-value project :workspace evaluation-context)]
     (when-let [proj-path (workspace/as-proj-path basis workspace (.getPath (URI. uri)))]
-      (workspace/find-resource workspace proj-path evaluation-context))))
+      (workspace/find-resource basis workspace proj-path))))
 
 ;; diagnostics
 (s/def ::severity #{:error :warning :information :hint})

--- a/editor/src/clj/editor/lua_parser.clj
+++ b/editor/src/clj/editor/lua_parser.clj
@@ -26,7 +26,7 @@
 (set! *warn-on-reflection* true)
 (set! *unchecked-math* :warn-on-boxed)
 
-(defn lua-info [workspace valid-resource-kind? code evaluation-context]
+(defn lua-info [basis workspace valid-resource-kind? code]
   (let [^LuaScanner$Result result (if (string? code)
                                     (^[String boolean Predicate] LuaScanner/parse code true valid-resource-kind?)
                                     (^[Reader boolean Predicate] LuaScanner/parse (io/reader code) true valid-resource-kind?))]
@@ -66,7 +66,7 @@
 
                        (some? value)
                        (assoc :value (if (and is-resource value)
-                                       (workspace/resolve-workspace-resource workspace value evaluation-context)
+                                       (workspace/resolve-workspace-resource basis workspace value)
                                        (condp instance? value
                                          Vector3d (math/vecmath->clj value)
                                          Vector4d (math/vecmath->clj value)

--- a/editor/src/clj/editor/markdown.clj
+++ b/editor/src/clj/editor/markdown.clj
@@ -116,7 +116,7 @@
                               (let [basis (:basis evaluation-context)
                                     workspace (project/workspace project evaluation-context)]
                                 (when-let [proj-path (workspace/as-proj-path basis workspace resolved-url)]
-                                  (workspace/find-resource workspace proj-path))))]
+                                  (workspace/find-resource basis workspace proj-path))))]
             (ui/execute-command (ui/contexts (ui/main-scene) true) :file.open resource)
             (ui/open-url resolved-url))
 

--- a/editor/src/clj/editor/material.clj
+++ b/editor/src/clj/editor/material.clj
@@ -588,7 +588,8 @@
 
 (defn load-material [project self resource material-desc]
   {:pre [(map? material-desc)]} ; Material$MaterialDesc in map format.
-  (let [resolve-resource #(workspace/resolve-resource resource %)
+  (let [basis (g/now)
+        resolve-resource #(workspace/resolve-resource basis resource %)
         attributes->editable-attributes #(mapv attribute->editable-attribute %)]
     (concat
       (g/connect project :default-sampler-filter-modes self :default-sampler-filter-modes)

--- a/editor/src/clj/editor/mesh.clj
+++ b/editor/src/clj/editor/mesh.clj
@@ -512,7 +512,8 @@
 
 (defn- load-mesh [_project self resource pb]
   {:pre [(map? pb)]} ; MeshProto$MeshDesc in map format.
-  (let [resolve-resource #(workspace/resolve-resource resource %)
+  (let [basis (g/now)
+        resolve-resource #(workspace/resolve-resource basis resource %)
         resolve-resources #(mapv resolve-resource %)]
     (gu/set-properties-from-pb-map self MeshProto$MeshDesc pb
       primitive-type :primitive-type

--- a/editor/src/clj/editor/model.clj
+++ b/editor/src/clj/editor/model.clj
@@ -550,25 +550,26 @@
     (g/flag-nodes-as-migrated! evaluation-context [model-node-id])))
 
 (defn load-model [_project self resource {:keys [materials] :as model-desc}]
-  (concat
-    (let [resolve-resource #(workspace/resolve-resource resource %)]
+  (let [basis (g/now)
+        resolve-resource #(workspace/resolve-resource basis resource %)]
+    (concat
       (gu/set-properties-from-pb-map self ModelProto$ModelDesc model-desc
         name :name
         default-animation :default-animation
         mesh (resolve-resource :mesh)
         skeleton (resolve-resource :skeleton)
         animations (resolve-resource :animations)
-        create-go-bones :create-go-bones))
-    (map-indexed
-      (fn [material-index {:keys [name material textures attributes]}]
-        (let [material (workspace/resolve-resource resource material)
-              textures (mapv (fn [{:keys [texture] :as texture-desc}]
-                               (assoc texture-desc :texture (workspace/resolve-resource resource texture)))
-                             textures)
-              vertex-attribute-overrides (graphics/override-attributes->vertex-attribute-overrides attributes)]
-          (create-material-binding-tx self name material material-index textures vertex-attribute-overrides)))
-      materials)
-    (g/callback-ec detect-and-flag-migrated! self model-desc)))
+        create-go-bones :create-go-bones)
+      (map-indexed
+        (fn [material-index {:keys [name material textures attributes]}]
+          (let [material (resolve-resource material)
+                textures (mapv (fn [{:keys [texture] :as texture-desc}]
+                                 (assoc texture-desc :texture (resolve-resource texture)))
+                               textures)
+                vertex-attribute-overrides (graphics/override-attributes->vertex-attribute-overrides attributes)]
+            (create-material-binding-tx self name material material-index textures vertex-attribute-overrides)))
+        materials)
+      (g/callback-ec detect-and-flag-migrated! self model-desc))))
 
 (defn- sanitize-model [{:keys [material textures materials] :as model-desc}]
   {:pre [(map? model-desc)]} ; ModelProto$ModelDesc in map format.

--- a/editor/src/clj/editor/node_util.clj
+++ b/editor/src/clj/editor/node_util.clj
@@ -1,0 +1,112 @@
+;; Copyright 2020-2026 The Defold Foundation
+;; Copyright 2014-2020 King
+;; Copyright 2009-2014 Ragnar Svensson, Christian Murray
+;; Licensed under the Defold License version 1.0 (the "License"); you may not use
+;; this file except in compliance with the License.
+;;
+;; You may obtain a copy of the License, together with FAQs at
+;; https://www.defold.com/license
+;;
+;; Unless required by applicable law or agreed to in writing, software distributed
+;; under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+;; CONDITIONS OF ANY KIND, either express or implied. See the License for the
+;; specific language governing permissions and limitations under the License.
+
+(ns editor.node-util
+  (:require [clojure.string :as string]
+            [dynamo.graph :as g]
+            [editor.core :as core]
+            [editor.outline :as outline]
+            [editor.resource :as resource]
+            [editor.resource-node :as resource-node]
+            [internal.graph.types :as gt]
+            [internal.node :as in]
+            [util.coll :as coll]))
+
+(set! *warn-on-reflection* true)
+(set! *unchecked-math* :warn-on-boxed)
+
+(defn node-qualifier-label
+  "Given a node-id, returns a string that identifies the node for the user.
+  Typically, this will be the URL that uniquely identifies the node inside its
+  owner resource, or the id that the user has specified for the node. Returns
+  nil if there is no suitable qualifier for the given node."
+  ([node-id]
+   (g/with-auto-evaluation-context evaluation-context
+     (node-qualifier-label node-id evaluation-context)))
+  ([node-id {:keys [basis] :as evaluation-context}]
+   (when-some [node (g/node-by-id-at basis node-id)]
+     (let [node-type (g/node-type node)]
+       (or (when (in/behavior node-type :url)
+             (let [value (in/node-value node :url evaluation-context)]
+               (when (and (string? value)
+                          (coll/not-empty value))
+                 ;; Convert urls to a more readable representation.
+                 ;;   "#book_script" -> "book_script"
+                 ;;   "/referenced_book#book_script" -> "referenced_book/book_script"
+                 (-> value
+                     (subs 1)
+                     (string/replace "#" "/")))))
+           (when (in/behavior node-type :id)
+             (let [value (in/node-value node :id evaluation-context)]
+               (when (string? value)
+                 (coll/not-empty value)))))))))
+
+(defn node-debug-label
+  ([node-id]
+   (g/with-auto-evaluation-context evaluation-context
+     (node-debug-label node-id evaluation-context)))
+  ([node-id {:keys [basis] :as evaluation-context}]
+   (let [node (g/node-by-id basis node-id)
+         node-type (g/node-type node)]
+     (or (when (in/inherits? node-type resource/ResourceNode)
+           (let [resource (resource-node/resource basis node-id)]
+             (cond
+               (resource/memory-resource? resource)
+               (str "embedded." (resource/ext resource))
+
+               (some? (gt/original node))
+               (let [proj-path (resource/proj-path resource)]
+                 (if-let [owner-resource (resource-node/owner-resource basis node-id)]
+                   (str proj-path " override in " (resource/proj-path owner-resource))
+                   (str proj-path " override")))
+
+               :else
+               (resource/proj-path resource))))
+         (node-qualifier-label node-id evaluation-context)
+         (when (in/inherits? node-type outline/OutlineNode)
+           (coll/not-empty (:label (g/maybe-node-value node-id :node-outline evaluation-context))))
+         (let [name (g/maybe-node-value node-id :name evaluation-context)]
+           (when (string? name)
+             (coll/not-empty name)))
+         (str (name (:k node-type)) \# node-id)))))
+
+(defn node-debug-label-path
+  ([node-id]
+   (g/with-auto-evaluation-context evaluation-context
+     (node-debug-label-path node-id evaluation-context)))
+  ([node-id {:keys [basis] :as evaluation-context}]
+   (let [graph-id (g/node-id->graph-id node-id)
+         project-node-id (g/graph-value basis graph-id :project-id)]
+     (->> node-id
+          (iterate #(core/owner-node-id basis %))
+          (take-while #(some-> % (not= project-node-id)))
+          (reverse)
+          (mapv #(node-debug-label % evaluation-context))))))
+
+(defn node-debug-info
+  ([node-id]
+   (g/with-auto-evaluation-context evaluation-context
+     (node-debug-info node-id evaluation-context)))
+  ([node-id {:keys [basis] :as evaluation-context}]
+   (let [node-type-kw (g/node-type-kw basis node-id)
+         node-debug-label-path (node-debug-label-path node-id evaluation-context)
+         owner-resource-node-id (try
+                                  (resource-node/owner-resource-node-id basis node-id)
+                                  (catch Exception _
+                                    nil))
+         owner-resource-node-type-kw (some->> owner-resource-node-id (g/node-type-kw basis))]
+     {:node-type-kw node-type-kw
+      :node-debug-label-path node-debug-label-path
+      :owner-resource-node-id owner-resource-node-id
+      :owner-resource-node-type-kw owner-resource-node-type-kw})))

--- a/editor/src/clj/editor/pipeline.clj
+++ b/editor/src/clj/editor/pipeline.clj
@@ -18,8 +18,8 @@
             [dynamo.graph :as g]
             [editor.build-target :as bt]
             [editor.fs :as fs]
-            [editor.graph-util :as gu]
             [editor.localization :as localization]
+            [editor.node-util :as node-util]
             [editor.progress :as progress]
             [editor.protobuf :as protobuf]
             [editor.resource :as resource]
@@ -202,7 +202,7 @@
 (defn decorate-build-exception [exception stage node-id resource-path {:keys [basis] :as evaluation-context}]
   (try
     (let [{:keys [owner-resource-node-id node-debug-label-path] :as node-debug-info}
-          (gu/node-debug-info node-id evaluation-context)]
+          (node-util/node-debug-info node-id evaluation-context)]
       (ex-info (format "Failed to %s %s %s."
                        (name stage)
                        (if (= owner-resource-node-id node-id)

--- a/editor/src/clj/editor/properties.clj
+++ b/editor/src/clj/editor/properties.clj
@@ -19,9 +19,9 @@
             [cognitect.transit :as transit]
             [dynamo.graph :as g]
             [editor.core :as core]
-            [editor.graph-util :as gu]
             [editor.localization :as localization]
             [editor.math :as math]
+            [editor.node-util :as node-util]
             [editor.protobuf :as protobuf]
             [editor.resource :as resource]
             [editor.resource-node :as resource-node]
@@ -35,8 +35,7 @@
             [util.eduction :as e]
             [util.fn :as fn]
             [util.id-vec :as iv]
-            [util.murmur :as murmur]
-            [util.text-util :as text-util])
+            [util.murmur :as murmur])
   (:import [java.util StringTokenizer]
            [javax.vecmath Matrix4d Point3d Quat4d]))
 
@@ -1211,7 +1210,7 @@
                 (as-> property-transfer property-transfer
                       (merge (sorted-map
                                :source-node-type-kw (g/node-type-kw basis source-node-id)
-                               :source-node-path (gu/node-debug-label-path source-node-id evaluation-context))
+                               :source-node-path (node-util/node-debug-label-path source-node-id evaluation-context))
                              property-transfer)
                       (update property-transfer :targets
                               (fn [property-transfer-targets]
@@ -1221,9 +1220,9 @@
                                                 (g/node-id? target-prop-node-id)]}
                                          (merge (sorted-map
                                                   :target-node-type-kw (g/node-type-kw basis target-node-id)
-                                                  :target-node-path (gu/node-debug-label-path target-node-id evaluation-context)
+                                                  :target-node-path (node-util/node-debug-label-path target-node-id evaluation-context)
                                                   :target-prop-node-type-kw (g/node-type-kw basis target-prop-node-id)
-                                                  :target-prop-node-path (gu/node-debug-label-path target-prop-node-id evaluation-context))
+                                                  :target-prop-node-path (node-util/node-debug-label-path target-prop-node-id evaluation-context))
                                                 property-transfer-target))))))))))))))
 
 (defn transfer-overrides-status
@@ -1288,7 +1287,7 @@
           {"property_count" (count property-transfers)
            "property" (:source-prop-label (first property-transfers))
            "target_count" (count target-node-ids)
-           "target" (or (gu/node-qualifier-label (first target-node-ids) evaluation-context) "undefined")
+           "target" (or (node-util/node-qualifier-label (first target-node-ids) evaluation-context) "undefined")
            "aspect_count" target-aspect-count
            "aspect" (if (= 1 target-aspect-count)
                       (first (first target-aspects))

--- a/editor/src/clj/editor/recent_files.clj
+++ b/editor/src/clj/editor/recent_files.clj
@@ -48,7 +48,7 @@
     (prefs/set! prefs k (conj-history-item (prefs/get prefs k) item))))
 
 (defn- project-path+view-type-id->resource+view-type [workspace evaluation-context [project-path view-type-id]]
-  (when-let [res (workspace/find-resource workspace project-path evaluation-context)]
+  (when-let [res (workspace/find-resource (:basis evaluation-context) workspace project-path)]
     (when (resource/openable? res)
       (when-let [view-type (workspace/get-view-type workspace view-type-id evaluation-context)]
         [res view-type]))))

--- a/editor/src/clj/editor/render_pb.clj
+++ b/editor/src/clj/editor/render_pb.clj
@@ -168,13 +168,15 @@
   (output save-value g/Any :cached produce-save-value)
   (output build-targets g/Any :cached produce-build-targets))
 
-(defn- load-render [project self resource render-ddf]
-  (let [graph-id (g/node-id->graph-id self)
+(defn- load-render [_project self resource render-ddf]
+  (let [basis (g/now)
+        resolve-resource #(workspace/resolve-resource basis resource %)
+        graph-id (g/node-id->graph-id self)
         {script-path :script render-resources :render-resources} render-ddf]
     (concat
-      (g/set-property self :script (workspace/resolve-resource resource script-path))
+      (g/set-property self :script (resolve-resource script-path))
       (for [{:keys [name path]} render-resources]
-        (let [render-resource (workspace/resolve-resource resource path)]
+        (let [render-resource (resolve-resource path)]
           (make-named-render-resource-node graph-id self name render-resource))))))
 
 (defn- sanitize-render [render-ddf]

--- a/editor/src/clj/editor/resource.clj
+++ b/editor/src/clj/editor/resource.clj
@@ -104,6 +104,10 @@
     (or (resource-types ext)
         (resource-types placeholder-resource-type-ext))))
 
+(defn- proj-path-exists? [basis workspace proj-path]
+  (let [resources-by-proj-path (g/raw-property-value basis workspace :resource-map)]
+    (contains? resources-by-proj-path proj-path)))
+
 (defn overridable-resource-type?
   "Returns whether the supplied value is a resource-type that hosts properties
   that may be overridden."
@@ -168,11 +172,11 @@
     (subs proj-path 0 last-slash)))
 
 (defn project-directory? [^File value]
-  ;; The project directory must exist on disk and exactly match the real casing.
+  ;; The project directory must be a real and existing path on disk.
   (and (instance? File value)
        (.isDirectory value)
        (= (.getPath value)
-          (str (path/actual-cased value)))))
+          (str (path/real value)))))
 
 (defn proj-path-patterns-file? [^File value]
   ;; These files may or may not exist in the project, but it is important for
@@ -441,22 +445,10 @@
   (resource-type [this] (lookup-resource-type (g/unsafe-basis) workspace this))
   (source-type [this] source-type)
   (exists? [this]
-    (try
-      ;; The path must match the casing of the file on disk exactly. We treat
-      ;; this as an error to make the user manually fix mismatches. We could fix
-      ;; such references automatically by using the canonical path to create the
-      ;; FileResource. However, some ids used by the engine are derived from the
-      ;; file names, most notably AtlasImage ids. Since these can be referenced
-      ;; from scripts, we make the user aware of the bad reference so she can
-      ;; fix it manually and hopefully remember to update the scripts too.
-      (let [file (io/file this)]
-        (and (.exists file)
-             (not (ignored-project-path? (io/file root) project-path))
-             (string/ends-with? (->unix-seps (str (path/actual-cased file))) project-path)))
-      (catch IOException _
-        false)
-      (catch SecurityException _
-        false)))
+    (and (proj-path-exists? (g/unsafe-basis) workspace project-path)
+         (if (path/symlink? this)
+           (.exists (io/file this))
+           true)))
   (read-only? [this]
     (try
       (not (.canWrite (io/file this)))
@@ -468,7 +460,7 @@
   (proj-path [this] project-path)
   (resource-name [this] name)
   (workspace [this] workspace)
-  (resource-hash [this] (hash (proj-path this)))
+  (resource-hash [this] (hash project-path))
   (openable? [this]
     (and (= :file source-type)
          (if (:editor-openable (resource-type this))

--- a/editor/src/clj/editor/scene_selection.clj
+++ b/editor/src/clj/editor/scene_selection.clj
@@ -139,11 +139,12 @@
   [drop-fn root-id select-fn action]
   (let [{:keys [^DragEvent event string gesture-target world-pos world-dir]} action]
     (ui/request-focus! gesture-target)
-    (g/let-ec [op-seq (gensym)
+    (g/let-ec [basis (:basis evaluation-context)
+               op-seq (gensym)
                env (-> gesture-target (ui/node-contexts false evaluation-context) first :env)
                {:keys [selection workspace]} env
                resource-strings (some-> string string/split-lines sort)
-               resources (e/keep #(workspace/resolve-workspace-resource workspace % evaluation-context) resource-strings)
+               resources (e/keep #(workspace/resolve-workspace-resource basis workspace %) resource-strings)
                z-plane-pos (math/line-plane-intersection world-pos world-dir (Point3d. 0.0 0.0 0.0) (Vector3d. 0.0 0.0 1.0))
                drop-fn (partial drop-fn root-id selection workspace z-plane-pos)]
       (.consume event)

--- a/editor/src/clj/editor/search_results_view.clj
+++ b/editor/src/clj/editor/search_results_view.clj
@@ -41,9 +41,9 @@
             [editor.error-reporting :as error-reporting]
             [editor.field-expression :as field-expression]
             [editor.fxui :as fxui]
-            [editor.graph-util :as gu]
             [editor.localization :as localization]
             [editor.menu-items :as menu-items]
+            [editor.node-util :as node-util]
             [editor.outline :as outline]
             [editor.prefs :as prefs]
             [editor.properties :as properties]
@@ -52,7 +52,6 @@
             [editor.resource-node :as resource-node]
             [editor.types :as types]
             [editor.ui :as ui]
-            [editor.util :as util]
             [editor.workspace :as workspace]
             [util.coll :as coll :refer [flipped-pair pair]]
             [util.fn :as fn]
@@ -758,7 +757,7 @@
                                                 (outline-ids node-id) node-id
                                                 :else (recur (core/owner-node-id basis node-id)))))
                                           node-id)
-                       qualifier (gu/node-qualifier-label select-node-id evaluation-context)]
+                       qualifier (node-util/node-qualifier-label select-node-id evaluation-context)]
                    {:node-id select-node-id
                     :qualifier qualifier
                     :resource resource

--- a/editor/src/clj/editor/settings.clj
+++ b/editor/src/clj/editor/settings.clj
@@ -46,10 +46,11 @@
   ;; resource-setting-reference only consumed by SettingsNode and already cached there.
   (output resource-setting-reference g/Any (g/fnk [_node-id path value] {:path path :node-id _node-id :value value})))
 
-(defn- resolve-resource-settings-from-raw [raw-settings meta-settings owner-resource evaluation-context]
+(defn- resolve-resource-settings-from-raw [basis raw-settings meta-settings owner-resource]
   ;; evaluation context is an `^:unsafe` part of the output: can be used only
   ;; for resource resolution (that are then only needed for paths)
-  (let [meta-settings-map (settings-core/make-meta-settings-map meta-settings)]
+  (let [resolve-resource #(workspace/resolve-resource basis owner-resource %)
+        meta-settings-map (settings-core/make-meta-settings-map meta-settings)]
     (->> raw-settings
          (settings-core/settings-with-value)
          (settings-core/sanitize-settings meta-settings)
@@ -60,13 +61,14 @@
                  ;; ResourceSettingNode in the graph.
                  (cond-> setting
                          (and (string? value) (= :resource (:type (meta-settings-map path))))
-                         (assoc :value (workspace/resolve-resource owner-resource value evaluation-context))))))))
+                         (assoc :value (resolve-resource value))))))))
 
 (g/defnk produce-settings-map [^:unsafe _evaluation-context owner-resource meta-info raw-settings resource-settings]
   ;; we use evaluation context to resolve a resource; we only need the resource
   ;; for its path, so it's safe to use it here
-  (let [meta-settings (:settings meta-info)
-        sanitized-settings (resolve-resource-settings-from-raw raw-settings meta-settings owner-resource _evaluation-context)
+  (let [basis (:basis _evaluation-context)
+        meta-settings (:settings meta-info)
+        sanitized-settings (resolve-resource-settings-from-raw basis raw-settings meta-settings owner-resource)
         all-settings (concat (settings-core/make-default-settings meta-settings) sanitized-settings resource-settings)
         settings-map (settings-core/make-settings-map all-settings)]
     settings-map))
@@ -210,8 +212,9 @@
 (g/defnk produce-form-data [^:unsafe _evaluation-context _node-id project owner-resource meta-info raw-settings resource-setting-nodes resource-settings resource-setting-connections]
   ;; we use evaluation context to resolve a resource; we only need the resource
   ;; for its path, so it's safe to use it here
-  (let [meta-settings (:settings meta-info)
-        sanitized-settings (resolve-resource-settings-from-raw raw-settings meta-settings owner-resource _evaluation-context)
+  (let [basis (:basis _evaluation-context)
+        meta-settings (:settings meta-info)
+        sanitized-settings (resolve-resource-settings-from-raw basis raw-settings meta-settings owner-resource)
         non-defaulted-setting-paths (into #{}
                                           (comp
                                             (filter :value)
@@ -292,10 +295,10 @@
                       project-meta-info (settings-core/merge-meta-infos project-meta-info)
                       (and ext-meta-info (= "project" (resource/type-ext owner-resource))) (settings-core/merge-meta-infos ext-meta-info))))))
 
-(defn- resolve-resource-settings [settings base-resource value-field]
+(defn- resolve-resource-settings [settings value-field resolve-resource-fn]
   (mapv (fn [setting]
           (if (= :resource (:type setting))
-            (update setting value-field #(workspace/resolve-resource base-resource %))
+            (update setting value-field resolve-resource-fn)
             setting))
         settings))
 
@@ -304,12 +307,14 @@
     (mapv #(assoc % :type (:type (meta-settings-map (:path %)))) settings)))
 
 (defn load-settings-node [project owner-resource-node self resource raw-settings initial-meta-info resource-setting-connections]
-  (let [meta-info (-> (settings-core/add-meta-info-for-unknown-settings initial-meta-info raw-settings)
-                      (update :settings resolve-resource-settings resource :default))
+  (let [basis (g/now)
+        resolve-resource #(workspace/resolve-resource basis resource %)
+        meta-info (-> (settings-core/add-meta-info-for-unknown-settings initial-meta-info raw-settings)
+                      (update :settings resolve-resource-settings :default resolve-resource))
         meta-settings (:settings meta-info)
         settings (-> (settings-core/sanitize-settings meta-settings raw-settings) ; this provokes parse errors if any
                      (type-annotate-settings meta-settings)
-                     (resolve-resource-settings resource :value))
+                     (resolve-resource-settings :value resolve-resource))
         resource-setting-paths (set (map :path (filter #(= :resource (:type %)) meta-settings)))]
     (concat
       ;; We retain the actual raw string settings and update these when/if the user changes a setting,

--- a/editor/src/clj/editor/sound.clj
+++ b/editor/src/clj/editor/sound.clj
@@ -154,7 +154,8 @@
 
 (defn load-sound [_project self resource sound-desc]
   {:pre [(map? sound-desc)]} ; Sound$SoundDesc in map format.
-  (let [resolve-resource #(workspace/resolve-resource resource %)]
+  (let [basis (g/now)
+        resolve-resource #(workspace/resolve-resource basis resource %)]
     (gu/set-properties-from-pb-map self Sound$SoundDesc sound-desc
       sound (resolve-resource :sound)
       looping (protobuf/int->boolean :looping)

--- a/editor/src/clj/editor/sprite.clj
+++ b/editor/src/clj/editor/sprite.clj
@@ -665,7 +665,8 @@
 
 (defn- load-sprite [project self resource sprite-desc]
   {:pre [(map? sprite-desc)]} ; Sprite$SpriteDesc in map format.
-  (let [resolve-resource #(workspace/resolve-resource resource %)]
+  (let [basis (g/now)
+        resolve-resource #(workspace/resolve-resource basis resource %)]
     (concat
       (g/connect project :default-tex-params self :default-tex-params)
       (g/connect project :exclude-gles-sm100 self :exclude-gles-sm100)

--- a/editor/src/clj/editor/tile_map.clj
+++ b/editor/src/clj/editor/tile_map.clj
@@ -580,9 +580,8 @@
 (defn- load-tile-map
   [project self resource tile-grid]
   {:pre [(map? tile-grid)]} ; Tile$TileGrid in map format.
-  (let [tile-source (workspace/resolve-resource resource (:tile-set tile-grid))
-        material (workspace/resolve-resource resource (:material tile-grid))
-        resolve-resource #(workspace/resolve-resource resource %)]
+  (let [basis (g/now)
+        resolve-resource #(workspace/resolve-resource basis resource %)]
     (concat
       (g/connect project :default-tex-params self :default-tex-params)
       (gu/set-properties-from-pb-map self Tile$TileGrid tile-grid

--- a/editor/src/clj/editor/tile_source.clj
+++ b/editor/src/clj/editor/tile_source.clj
@@ -1035,7 +1035,8 @@
 
 (defn- load-tile-source [project self resource tile-set]
   {:pre [(map? tile-set)]} ; Tile$TileSet in map format.
-  (let [resolve-resource #(workspace/resolve-resource resource %)
+  (let [basis (g/now)
+        resolve-resource #(workspace/resolve-resource basis resource %)
 
         animation-nodes-tx-data
         (mapv (partial make-animation-node self project nil)

--- a/editor/src/clj/editor/workspace.clj
+++ b/editor/src/clj/editor/workspace.clj
@@ -23,6 +23,7 @@ ordinary paths."
             [editor.code.preprocessors :as code.preprocessors]
             [editor.dialogs :as dialogs]
             [editor.fs :as fs]
+            [editor.graph-util :as gu]
             [editor.library :as library]
             [editor.localization :as localization]
             [editor.notifications :as notifications]
@@ -197,18 +198,6 @@ ordinary paths."
                                  (util/comparator-on util/natural-order editor.resource/resource-name)))
                              vec)]
     (assoc tree :children sorted-children)))
-
-(g/defnk produce-resource-tree [_node-id root resource-snapshot editable-proj-path? unloaded-proj-path?]
-  (sort-resource-tree
-    (resource/make-file-resource _node-id root (io/as-file root) (:resources resource-snapshot) editable-proj-path? unloaded-proj-path?)))
-
-(g/defnk produce-resource-list [resource-tree]
-  (vec (sort-by resource/proj-path util/natural-order (resource/resource-seq resource-tree))))
-
-(g/defnk produce-resource-map [resource-list]
-  (into {}
-        (map #(pair (resource/proj-path %) %))
-        resource-list))
 
 (defn get-view-type
   ([workspace id]
@@ -436,40 +425,30 @@ ordinary paths."
 (defn file-resource
   ([workspace path-or-file]
    (file-resource (g/now) workspace path-or-file))
-  ([basis workspace path-or-file]
+  ([basis workspace proj-path-or-file]
    (let [workspace-node (g/node-by-id basis workspace)
-         project-path (g/raw-property-value* basis workspace-node :root)
+         project-directory-pathname (g/raw-property-value* basis workspace-node :root)
          editable-proj-path? (g/raw-property-value* basis workspace-node :editable-proj-path?)
          unloaded-proj-path? (g/raw-property-value* basis workspace-node :unloaded-proj-path?)
-         file (if (instance? File path-or-file)
-                path-or-file
-                (File. (str project-path path-or-file)))]
-     (resource/make-file-resource workspace project-path file [] editable-proj-path? unloaded-proj-path?))))
+         file (if (instance? File proj-path-or-file)
+                proj-path-or-file
+                (File. (str project-directory-pathname proj-path-or-file)))]
+     (resource/make-file-resource workspace project-directory-pathname file [] editable-proj-path? unloaded-proj-path?))))
 
 (defn find-resource
   ([workspace proj-path]
-   (g/with-auto-evaluation-context evaluation-context
-     (find-resource workspace proj-path evaluation-context)))
-  ([workspace proj-path evaluation-context]
-   ;; This is frequently called from property setters, where we don't have a
-   ;; cache. In that case, manually cache the evaluated value in the
-   ;; :tx-data-context atom of the evaluation-context, since this persists
-   ;; throughout the transaction.
-   (let [resources-by-proj-path (g/tx-cached-node-value! workspace :resource-map evaluation-context)]
+   (find-resource (g/now) workspace proj-path))
+  ([basis workspace proj-path]
+   (let [resources-by-proj-path (g/raw-property-value basis workspace :resource-map)]
      (get resources-by-proj-path proj-path))))
 
 (defn resolve-workspace-resource
-  ([workspace path]
-   (when (not-empty path)
-     (g/with-auto-evaluation-context evaluation-context
-       (or
-         (find-resource workspace path evaluation-context)
-         (file-resource (:basis evaluation-context) workspace path)))))
-  ([workspace path evaluation-context]
-   (when (not-empty path)
-     (or
-       (find-resource workspace path evaluation-context)
-       (file-resource (:basis evaluation-context) workspace path)))))
+  ([workspace proj-path]
+   (resolve-workspace-resource (g/now) workspace proj-path))
+  ([basis workspace proj-path]
+   (when (not-empty proj-path)
+     (or (find-resource basis workspace proj-path)
+         (file-resource basis workspace proj-path)))))
 
 (defn make-proj-path->resource-fn [workspace evaluation-context]
   (let [basis (:basis evaluation-context)
@@ -477,7 +456,7 @@ ordinary paths."
         project-path (g/raw-property-value* basis workspace-node :root)
         editable-proj-path? (g/raw-property-value* basis workspace-node :editable-proj-path?)
         unloaded-proj-path? (g/raw-property-value* basis workspace-node :unloaded-proj-path?)
-        resources-by-proj-path (g/tx-cached-node-value! workspace :resource-map evaluation-context)
+        resources-by-proj-path (g/raw-property-value* basis workspace-node :resource-map)
 
         make-missing-file-resource
         (fn/memoize
@@ -492,59 +471,55 @@ ordinary paths."
         (or (resources-by-proj-path proj-path)
             (make-missing-file-resource proj-path))))))
 
-(defn- absolute-path [^String path]
+(defn- absolute-proj-path? [^String path]
   (.startsWith path "/"))
 
-(defn to-absolute-path
-  ([rel-path] (to-absolute-path "" rel-path))
+(defn to-absolute-proj-path
+  ([rel-path] (to-absolute-proj-path "" rel-path))
   ([base rel-path]
-   (if (absolute-path rel-path)
+   (if (absolute-proj-path? rel-path)
      rel-path
      (str base "/" rel-path))))
 
 (defn resolve-resource
   ([base-resource path]
-   (g/with-auto-evaluation-context evaluation-context
-     (resolve-resource base-resource path evaluation-context)))
-  ([base-resource path evaluation-context]
+   (resolve-resource (g/now) base-resource path))
+  ([basis base-resource path]
    (when-not (empty? path)
-     (let [basis (:basis evaluation-context)
-           workspace (:workspace base-resource)
-           path  (if (absolute-path path)
-                   path
-                   (resource/file->proj-path (project-directory basis workspace)
-                                             (.getCanonicalFile (io/file (.getParentFile (io/file base-resource))
-                                                                         path))))]
-       (resolve-workspace-resource workspace path evaluation-context)))))
+     (let [workspace (resource/workspace base-resource)
+           path (if (absolute-proj-path? path)
+                  path
+                  (resource/file->proj-path (project-directory basis workspace)
+                                            (.getCanonicalFile (io/file (.getParentFile (io/file base-resource))
+                                                                        path))))]
+       (resolve-workspace-resource basis workspace path)))))
 
 (def ^:private default-user-resource-path "/templates/default.")
 (def ^:private java-resource-path "templates/template.")
 
-(defn- get-template-resource [workspace resource-type evaluation-context]
+(defn- get-template-resource [basis workspace resource-type]
   (when resource-type
     (let [resource-path (:template resource-type)
           ext (:ext resource-type)]
       (or
         ;; default user resource
-        (find-resource workspace (str default-user-resource-path ext) evaluation-context)
+        (find-resource basis workspace (str default-user-resource-path ext))
         ;; editor resource provided from extensions
-        (when resource-path (find-resource workspace resource-path evaluation-context))
+        (when resource-path (find-resource basis workspace resource-path))
         ;; java resource
         (io/resource (str java-resource-path ext))))))
 
 (defn has-template?
   ([workspace resource-type]
-   (g/with-auto-evaluation-context evaluation-context
-     (has-template? workspace resource-type evaluation-context)))
-  ([workspace resource-type evaluation-context]
-   (some? (get-template-resource workspace resource-type evaluation-context))))
+   (has-template? (g/now) workspace resource-type))
+  ([basis workspace resource-type]
+   (some? (get-template-resource basis workspace resource-type))))
 
 (defn template
   ([workspace resource-type]
-   (g/with-auto-evaluation-context evaluation-context
-     (template workspace resource-type evaluation-context)))
-  ([workspace resource-type evaluation-context]
-   (when-let [resource (get-template-resource workspace resource-type evaluation-context)]
+   (template (g/now) workspace resource-type))
+  ([basis workspace resource-type]
+   (when-let [resource (get-template-resource basis workspace resource-type)]
      (let [{:keys [read-fn write-fn]} resource-type]
        (if (and read-fn write-fn)
          ;; Sanitize the template.
@@ -689,20 +664,23 @@ ordinary paths."
   [resource]
   (some #(= "ext.manifest" (resource/resource-name %)) (resource/children resource)))
 
-(defn- find-parent [resource evaluation-context]
-  (let [parent-path (resource/parent-proj-path (resource/proj-path resource))]
-    (find-resource (resource/workspace resource) (str parent-path) evaluation-context)))
+(defn- find-parent [basis resource]
+  (let [workspace (resource/workspace resource)
+        proj-path (resource/proj-path resource)]
+    (some->> (resource/parent-proj-path proj-path)
+             (find-resource basis workspace))))
 
-(defn- is-extension-file? [resource evaluation-context]
+(defn- is-extension-file? [basis resource]
   (or (extension-root? resource)
-      (some-> (find-parent resource evaluation-context)
-              (recur evaluation-context))))
+      (if-some [parent-resource (find-parent basis resource)]
+        (recur basis parent-resource)
+        false)))
 
-(defn- is-plugin-file? [resource evaluation-context]
+(defn- is-plugin-file? [basis resource]
   (and
     (= :file (resource/source-type resource))
     (string/includes? (resource/proj-path resource) "/plugins/")
-    (is-extension-file? resource evaluation-context)))
+    (is-extension-file? basis resource)))
 
 (defn- shared-library? [resource]
   (contains? #{"dylib" "dll" "so"} (resource/ext resource)))
@@ -794,23 +772,24 @@ ordinary paths."
             (filter #(= :file (resource/source-type %)))
             (:tree (resource/load-zip-resources workspace plugin-file))))))
 
-(defn unpack-editor-plugins! [workspace changed]
-  ; Used for unpacking the .jar files and shared libraries (.so, .dylib, .dll) to disc
-  ; TODO: Handle removed plugins (e.g. a dependency was removed)
-  (g/let-ec [[plugin-zips resources]
-             (->> changed
-                  (filter #(is-plugin-file? % evaluation-context))
-                  (coll/separate-by plugin-zip?))
+(defn unpack-editor-plugins! [basis workspace changed]
+  ;; Used for unpacking the .jar files and shared libraries (.so, .dylib, .dll).
+  ;; TODO: Handle removed plugins (e.g. a dependency was removed).
+  (let [[plugin-zips resources]
+        (->> changed
+             (filter #(is-plugin-file? basis %))
+             (coll/separate-by plugin-zip?))
 
-             plugin-zips
-             (->> plugin-zips
-                  (into []
-                        (comp
-                          (map #(find-parent % evaluation-context))
-                          (distinct)
-                          (mapcat resource/children)
-                          (filter plugin-zip?)))
-                  (sort-by plugin-zip-priority))]
+        plugin-zips
+        (->> plugin-zips
+             (into []
+                   (comp
+                     (map #(find-parent basis %))
+                     (distinct)
+                     (mapcat resource/children)
+                     (filter plugin-zip?)))
+             (sort-by plugin-zip-priority))]
+
     (run! #(unpack-plugin-zip! workspace %) plugin-zips)
     (run! #(unpack-resource! workspace %) resources)))
 
@@ -955,10 +934,37 @@ ordinary paths."
     s/Keyword s/Any}])
 
 (g/defnode Workspace
-  (property root g/Str)
+  (property root g/Str
+            (set (gu/immutable-property-setter root)))
   (property dependencies Dependencies)
   (property opened-files g/Any)
-  (property resource-snapshot g/Any (default resource-watch/empty-snapshot))
+  (property resource-snapshot g/Any (default resource-watch/empty-snapshot)
+            (set (fn [evaluation-context self _old-value new-value]
+                   (let [basis (:basis evaluation-context)
+                         editable-proj-path? (g/raw-property-value basis self :editable-proj-path?)
+                         unloaded-proj-path? (g/raw-property-value basis self :unloaded-proj-path?)
+                         project-directory-pathname (g/raw-property-value basis self :root)]
+                     (when-not (and (ifn? editable-proj-path?)
+                                    (ifn? unloaded-proj-path?)
+                                    (string? project-directory-pathname))
+                       (throw
+                         (ex-info "The Workspace must be fully initialized before the :resource-snapshot property can be set."
+                                  {:editable-proj-path? editable-proj-path?
+                                   :unloaded-proj-path? unloaded-proj-path?
+                                   :project-directory-pathname project-directory-pathname})))
+                     (let [project-directory (io/as-file project-directory-pathname)
+                           resources (:resources new-value)
+                           root-file-resource (resource/make-file-resource self project-directory-pathname project-directory resources editable-proj-path? unloaded-proj-path?)
+                           resource-tree (sort-resource-tree root-file-resource)
+                           resource-list (vec (sort-by resource/proj-path util/natural-order (resource/resource-seq resource-tree)))
+                           resource-map (coll/pair-map-by resource/proj-path resource-list)]
+                       (g/set-properties self
+                         :resource-tree resource-tree
+                         :resource-list resource-list
+                         :resource-map resource-map))))))
+  (property resource-tree FileResource) ; Assigned from resource-snapshot property setter.
+  (property resource-list g/Any) ; Assigned from resource-snapshot property setter.
+  (property resource-map g/Any) ; Assigned from resource-snapshot property setter.
   (property resource-listeners g/Any)
   (property disk-sha256s-by-node-id g/Any (default {}))
   (property view-types g/Any (default {:default {:id :default}}))
@@ -966,8 +972,10 @@ ordinary paths."
   (property resource-types-non-editable g/Any)
   (property snapshot-cache g/Any (default {}))
   (property build-settings g/Any)
-  (property editable-proj-path? g/Any)
-  (property unloaded-proj-path? g/Any)
+  (property editable-proj-path? g/Any
+            (set (gu/immutable-property-setter editable-proj-path?)))
+  (property unloaded-proj-path? g/Any
+            (set (gu/immutable-property-setter unloaded-proj-path?)))
   (property resource-kind-extensions g/Any (default {:atlas ["atlas" "tilesource"]}))
   (property node-attachments g/Any (default {}))
   (property localization g/Any)
@@ -975,11 +983,7 @@ ordinary paths."
   (input code-preprocessors g/NodeID :cascade-delete)
   (input notifications g/NodeID :cascade-delete)
 
-  (output dependency-uris g/Any (g/fnk [dependencies] (mapv :uri dependencies)))
-  (output dependencies g/Any (g/fnk [dependencies] dependencies))
-  (output resource-tree FileResource :cached produce-resource-tree)
-  (output resource-list g/Any :cached produce-resource-list)
-  (output resource-map g/Any :cached produce-resource-map))
+  (output dependency-uris g/Any (g/fnk [dependencies] (mapv :uri dependencies))))
 
 (defn node-attachments [basis workspace]
   (g/raw-property-value basis workspace :node-attachments))

--- a/editor/src/clj/util/path.clj
+++ b/editor/src/clj/util/path.clj
@@ -145,7 +145,10 @@
   system entry. Throws an IOException if there was no matching entry in the file
   system. Contrary to the `real` function, `actual-cased` does not resolve
   symbolic links in the returned Path. Beware that this operation can be
-  surprisingly slow on certain file systems."
+  surprisingly slow on certain file systems.
+
+  See: https://bugs.openjdk.org/browse/JDK-8368633, which was resolved after the
+  performance improved a bit, but unfortunately, it is still very slow."
   (^Path [x]
    (.toRealPath (to-path x) no-follow-links-link-options))
   (^Path [x & xs]
@@ -154,8 +157,7 @@
 (defn real
   "Returns the canonical, real path to an existing file system entry. Throws an
   IOException if there was no matching entry in the file system. Follows
-  symbolic links and queries their target. Beware that this operation can be
-  surprisingly slow on certain file systems."
+  symbolic links and queries their target."
   (^Path [x]
    (.toRealPath (to-path x) follow-links-link-options))
   (^Path [x & xs]

--- a/editor/src/dev/dev.clj
+++ b/editor/src/dev/dev.clj
@@ -32,11 +32,11 @@
             [editor.dialogs :as dialogs]
             [editor.fxui :as fxui]
             [editor.game-object :as game-object]
-            [editor.graph-util :as gu]
             [editor.graphics.types :as graphics.types]
             [editor.handler :as handler]
             [editor.localization :as localization]
             [editor.math :as math]
+            [editor.node-util :as node-util]
             [editor.outline-view :as outline-view]
             [editor.pipeline.bob :as bob]
             [editor.prefs :as prefs]
@@ -150,7 +150,7 @@
          original-node-id (g/override-original basis node-id)
          override-node-ids (g/overrides basis node-id)]
      (cond-> (into (array-map :node-id node-id)
-                   (gu/node-debug-info node-id evaluation-context))
+                   (node-util/node-debug-info node-id evaluation-context))
 
              (some? original-node-id)
              (assoc :original-node-id original-node-id)

--- a/editor/test/editor/fs_test.clj
+++ b/editor/test/editor/fs_test.clj
@@ -468,7 +468,7 @@
       (test-util/make-file-tree! dir ["name.txt"])
       (let [src (io/file dir "name.txt")
             tgt (io/file dir "Name.txt")]
-        (if fs/case-sensitive?
+        (if fs/is-case-sensitive
           (do
             (is (= [[src tgt]] (fs/copy-file! src tgt)))
             (is (= ["Name.txt" "name.txt"] (test-util/file-tree dir))))
@@ -550,7 +550,7 @@
       (test-util/make-file-tree! dir [{"directory" ["name.txt"]}])
       (let [src (io/file dir "directory")
             tgt (io/file dir "Directory")]
-        (if fs/case-sensitive?
+        (if fs/is-case-sensitive
           (do
             (is (= [[src tgt]] (fs/copy-directory! src tgt)))
             (is (= [{"Directory" ["name.txt"]} {"directory" ["name.txt"]}] (test-util/file-tree dir))))
@@ -678,7 +678,7 @@
     (is (false? (fs/below-directory? (io/file project-dir "subdirectory") (io/file project-dir "subdir"))))
     (is (false? (fs/below-directory? project-dir project-dir)))
 
-    (if fs/case-sensitive?
+    (if fs/is-case-sensitive
       (is (false? (fs/below-directory? (io/file project-dir "SUBDIRECTORY" "file.txt") (io/file project-dir "subdirectory"))))
       (is (true? (fs/below-directory? (io/file project-dir "SUBDIRECTORY" "file.txt") (io/file project-dir "subdirectory")))))))
 

--- a/editor/test/editor/lua_parser_test.clj
+++ b/editor/test/editor/lua_parser_test.clj
@@ -27,10 +27,10 @@
 (defn- lua-info
   ([code]
    (g/with-auto-or-fake-evaluation-context evaluation-context
-     (lp/lua-info nil fn/constantly-true code evaluation-context)))
+     (lp/lua-info (:basis evaluation-context) nil fn/constantly-true code)))
   ([workspace valid-resource-kind? code]
    (g/with-auto-or-fake-evaluation-context evaluation-context
-     (lp/lua-info workspace valid-resource-kind? code evaluation-context))))
+     (lp/lua-info (:basis evaluation-context) workspace valid-resource-kind? code))))
 
 (deftest test-require
   (testing "bare require function call"

--- a/editor/test/integration/asset_browser_test.clj
+++ b/editor/test/integration/asset_browser_test.clj
@@ -242,14 +242,14 @@
     (let [workspace (test-util/setup-scratch-workspace! world)
           root-dir (workspace/project-directory workspace)
           make-file (partial io/file root-dir)
-          resource-map (g/node-value workspace :resource-map)]
+          resource-map (g/raw-property-value (g/now) workspace :resource-map)]
       (testing "drag-moving game.project becomes copy"
         ;; moving /game.project and /car/car.script into the /collection directory
         (let [moved (asset-browser/drop-files! workspace [[(io/as-file (resource-map "/game.project")) (make-file "collection/game.project")]
                                                           [(io/as-file (resource-map "/car/car.script")) (make-file "collection/car.script")]]
                                                :move)]
           (workspace/resource-sync! workspace moved)
-          (let [resource-map (g/node-value workspace :resource-map)]
+          (let [resource-map (g/raw-property-value (g/now) workspace :resource-map)]
             (is (some? (resource-map "/game.project")))
             (is (some? (resource-map "/collection/game.project")))
             (is (not (some? (resource-map "/car/car.script"))))

--- a/editor/test/integration/symlink_test.clj
+++ b/editor/test/integration/symlink_test.clj
@@ -40,14 +40,12 @@
                         :project-directory-path project-directory-path}))
        (str \/ relative-path)))))
 
-(defn path->resource
+(defn- path->resource
   ([workspace path]
-   (g/with-auto-evaluation-context evaluation-context
-     (path->resource workspace path evaluation-context)))
-  ([workspace path evaluation-context]
-   (let [basis (:basis evaluation-context)
-         proj-path (path->proj-path basis workspace path)]
-     (or (workspace/find-resource workspace proj-path evaluation-context)
+   (path->resource (g/now) workspace path))
+  ([basis workspace path]
+   (let [proj-path (path->proj-path basis workspace path)]
+     (or (workspace/find-resource basis workspace proj-path)
          (throw (ex-info "The path does not refer to a resource in the workspace."
                          {:path path}))))))
 

--- a/editor/test/integration/unload_test.clj
+++ b/editor/test/integration/unload_test.clj
@@ -97,7 +97,7 @@
               (g/with-auto-evaluation-context evaluation-context
                 (let [basis (:basis evaluation-context)]
                   (doseq [proj-path loadable-resource-proj-paths]
-                    (let [resource (workspace/find-resource workspace proj-path evaluation-context)
+                    (let [resource (workspace/find-resource basis workspace proj-path)
                           resource-node (project/get-resource-node project resource evaluation-context)
                           resource-type (resource/resource-type resource)]
                       (testing proj-path

--- a/editor/test/util/path_test.clj
+++ b/editor/test/util/path_test.clj
@@ -1,0 +1,82 @@
+;; Copyright 2020-2026 The Defold Foundation
+;; Copyright 2014-2020 King
+;; Copyright 2009-2014 Ragnar Svensson, Christian Murray
+;; Licensed under the Defold License version 1.0 (the "License"); you may not use
+;; this file except in compliance with the License.
+;;
+;; You may obtain a copy of the License, together with FAQs at
+;; https://www.defold.com/license
+;;
+;; Unless required by applicable law or agreed to in writing, software distributed
+;; under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+;; CONDITIONS OF ANY KIND, either express or implied. See the License for the
+;; specific language governing permissions and limitations under the License.
+
+(ns util.path-test
+  (:require [clojure.test :refer :all]
+            [editor.fs :as fs]
+            [integration.test-util :as test-util]
+            [util.path :as path])
+  (:import [java.nio.file NoSuchFileException]))
+
+(set! *warn-on-reflection* true)
+
+(deftest actual-cased-test
+  (test-util/with-temp-dir! dir
+    (testing "Throws for a missing file system entry."
+      (is (thrown? NoSuchFileException (path/actual-cased dir "MissingFile.txt")))
+      (is (thrown? NoSuchFileException (path/actual-cased dir "MissingDirectory" "MissingFile.txt"))))
+
+    (testing "Returns a Path with the actual casing for existing file system entries."
+      (test-util/make-file-tree! dir [{"ExistingDirectory" ["ExistingFile.txt"]}])
+      (let [expected (path/absolute dir "ExistingDirectory" "ExistingFile.txt")]
+        (is (= expected (path/actual-cased (path/of dir "ExistingDirectory" "ExistingFile.txt"))))
+        (is (= expected (path/actual-cased dir "ExistingDirectory" "ExistingFile.txt")))
+        (when-not fs/is-case-sensitive
+          (is (= expected (path/actual-cased dir "existingDIRECTORY" "existingFILE.txt"))))))
+
+    (testing "Does not follow file symlinks."
+      (path/create-symlink! (path/of dir "ExistingDirectory" "SymlinkFile.txt")
+                            (path/of dir "ExistingDirectory" "ExistingFile.txt"))
+      (let [expected (path/absolute dir "ExistingDirectory" "SymlinkFile.txt")]
+        (is (= expected (path/actual-cased dir "ExistingDirectory" "SymlinkFile.txt")))
+        (when-not fs/is-case-sensitive
+          (is (= expected (path/actual-cased dir "existingDIRECTORY" "symlinkFILE.txt"))))))
+
+    (testing "Does not follow directory symlinks."
+      (path/create-symlink! (path/of dir "SymlinkDirectory")
+                            (path/of dir "ExistingDirectory"))
+      (let [expected (path/absolute dir "SymlinkDirectory" "ExistingFile.txt")]
+        (is (= expected (path/actual-cased dir "SymlinkDirectory" "ExistingFile.txt")))
+        (when-not fs/is-case-sensitive
+          (is (= expected (path/actual-cased dir "symlinkDIRECTORY" "existingFILE.txt"))))))))
+
+(deftest real-test
+  (test-util/with-temp-dir! dir
+    (testing "Throws for a missing file system entry."
+      (is (thrown? NoSuchFileException (path/real dir "MissingFile.txt")))
+      (is (thrown? NoSuchFileException (path/real dir "MissingDirectory" "MissingFile.txt"))))
+
+    (testing "Returns the real Path for existing file system entries."
+      (test-util/make-file-tree! dir [{"ExistingDirectory" ["ExistingFile.txt"]}])
+      (let [expected (path/absolute dir "ExistingDirectory" "ExistingFile.txt")]
+        (is (= expected (path/real (path/of dir "ExistingDirectory" "ExistingFile.txt"))))
+        (is (= expected (path/real dir "ExistingDirectory" "ExistingFile.txt")))
+        (when-not fs/is-case-sensitive
+          (is (= expected (path/real dir "existingDIRECTORY" "existingFILE.txt"))))))
+
+    (testing "Follows file symlinks."
+      (path/create-symlink! (path/of dir "ExistingDirectory" "SymlinkFile.txt")
+                            (path/of dir "ExistingDirectory" "ExistingFile.txt"))
+      (let [expected (path/absolute dir "ExistingDirectory" "ExistingFile.txt")]
+        (is (= expected (path/real dir "ExistingDirectory" "SymlinkFile.txt")))
+        (when-not fs/is-case-sensitive
+          (is (= expected (path/real dir "existingDIRECTORY" "symlinkFILE.txt"))))))
+
+    (testing "Follows directory symlinks."
+      (path/create-symlink! (path/of dir "SymlinkDirectory")
+                            (path/of dir "ExistingDirectory"))
+      (let [expected (path/absolute dir "ExistingDirectory" "ExistingFile.txt")]
+        (is (= expected (path/real dir "SymlinkDirectory" "ExistingFile.txt")))
+        (when-not fs/is-case-sensitive
+          (is (= expected (path/real dir "symlinkDIRECTORY" "existingFILE.txt"))))))))


### PR DESCRIPTION
The recent addition of better support for symlinks introduced a performance regression in file existence checks. This had a significant impact on build times in larger projects.

### Technical changes
* We now validate `FileResource` `proj-paths` against the `resource-map` in the `Workspace`. To facilitate this, The `resource-map` was converted from an `output` to a `property`, along with all other outputs that are downstream of the `resource-snapshot` property. During `resource-sync`, we eagerly evaluate the resulting collections and assign them to the corresponding `Workspace` properties. This lets us cheaply access the `resource-map` - which is a map of canonical `proj-path` to `Resource` - from the `FileResource` `resource/exists?` implementation using `g/raw-property-value`.
* The various resource-resolving functions in the `workspace` module now take a `basis` instead of an `evaluation-context`.
* Added tests for `path/actual-cased` and `path/real`.
* Avoid calling the expensive `path/actual-cased` function whenever possible.

Same as #12108, but targeting the `beta` branch. The changes have been reviewed in #12108.