### PR TITLE
Fix crash in `http_client`

### DIFF
--- a/engine/dlib/scripts/start_http_server.sh
+++ b/engine/dlib/scripts/start_http_server.sh
@@ -32,6 +32,9 @@ CLASSPATH=${CLASSPATH}${PATHSEP}${SCRIPTDIR}/../ext/*
 CLASSPATH=${CLASSPATH}${PATHSEP}${SCRIPTDIR}/../ext/jetty/*
 CLASSPATH=${CLASSPATH}${PATHSEP}${SCRIPTDIR}/../ext/jetty/logging/*
 CLASSPATH=${CLASSPATH}${PATHSEP}${SCRIPTDIR}/../build/src/test/http_server
+SERVER_SOURCE="${SCRIPTDIR}/../src/test/http_server/TestHttpServer.java"
+SERVER_CLASS_DIR="${SCRIPTDIR}/../build/src/test/http_server"
+SERVER_CLASS="${SERVER_CLASS_DIR}/TestHttpServer.class"
 
 LOGFILE="${TEST_HTTP_SERVER_LOG:-test_http_server.log}"
 
@@ -39,6 +42,12 @@ echo $CLASSPATH
 echo "Logging TestHttpServer output to ${LOGFILE}"
 
 #DEBUG="-DDEBUG=true -Dorg.eclipse.jetty.LEVEL=DEBUG -Djavax.net.debug=ssl,handshake,data"
+
+mkdir -p "${SERVER_CLASS_DIR}"
+if [ ! -f "${SERVER_CLASS}" ] || [ "${SERVER_SOURCE}" -nt "${SERVER_CLASS}" ]; then
+    echo "Compiling TestHttpServer.java"
+    javac -g --release 8 -Xlint:-options -cp "$CLASSPATH" -d "${SERVER_CLASS_DIR}" "${SERVER_SOURCE}"
+fi
 
 java -cp $CLASSPATH ${DEBUG} TestHttpServer >> "${LOGFILE}" 2>&1 &
 echo $! > test_http_server.pid

--- a/engine/dlib/src/dlib/http_client.cpp
+++ b/engine/dlib/src/dlib/http_client.cpp
@@ -1204,7 +1204,7 @@ bail:
                     return r;
                 }
             }
-            else if (use_proxy)
+            else if (r == RESULT_OK && use_proxy)
             {
                 if (client->m_Secure)
                 {

--- a/engine/dlib/src/dlib/http_client.cpp
+++ b/engine/dlib/src/dlib/http_client.cpp
@@ -155,6 +155,11 @@ namespace dmHttpClient
         Result Connect(const char* host, uint16_t port, bool secure, int timeout, int* canceled);
         Result CreateSSLSocket(const char* host, int timeout);
         ~Response();
+
+    private:
+        // Forbid assignment operator and copy-constructor. Response owns a pool handle.
+        Response(const Response&);
+        Response& operator=(const Response&);
     };
 
     /*
@@ -1142,28 +1147,29 @@ bail:
         // The assumption holds only for a single-threaded environment though
         // but as network errors will occur in practice the heuristic is probably
         // "good enough".
-        Response response = Response(client);
-        Result r;
         for (uint32_t i = 0; i < MAX_POOL_CONNECTIONS + 1; ++i)
         {
+            // One response owns one pooled connection for one physical attempt.
+            Response response(client);
+
             client->m_Statistics.m_Responses++;
 
             client->m_SocketResult = dmSocket::RESULT_OK;
 
             // host, port, secure, timeout, cancel
-            r = response.Connect(use_proxy ? client->m_ProxyURI.m_Hostname : client->m_HostURI.m_Hostname,
-                                 use_proxy ? client->m_ProxyURI.m_Port : client->m_HostURI.m_Port,
-                                 use_proxy ? false : client->m_Secure,
-                                 client->m_RequestTimeout,
-                                 client->m_CancelFlag);
+            Result r = response.Connect(use_proxy ? client->m_ProxyURI.m_Hostname : client->m_HostURI.m_Hostname,
+                                        use_proxy ? client->m_ProxyURI.m_Port : client->m_HostURI.m_Port,
+                                        use_proxy ? false : client->m_Secure,
+                                        client->m_RequestTimeout,
+                                        client->m_CancelFlag);
             if (r != RESULT_OK)
             {
-                break;
+                return r;
             }
 
             if( HasRequestTimedOut(client) )
             {
-                break;
+                return r;
             }
 
             // client, response, path, method
@@ -1177,7 +1183,7 @@ bail:
 
                 if( HasRequestTimedOut(client) )
                 {
-                    break;
+                    return r;
                 }
 
                 uint32_t count = dmConnectionPool::GetReuseCount(response.m_Pool, response.m_Connection);
@@ -1191,40 +1197,36 @@ bail:
                     // Otherwise, we have to regard this type of connection shutdown as
                     // an error.
 
-                    // implicit continue here
+                    continue;
                 }
                 else
                 {
-                    break;
+                    return r;
                 }
             }
-            else
+            else if (use_proxy)
             {
-                break;
+                if (client->m_Secure)
+                {
+                    r = response.CreateSSLSocket(client->m_HostURI.m_Hostname, client->m_RequestTimeout);
+                }
+
+                if (r == RESULT_OK)
+                {
+                    r = DoDoRequest(client, response, path, method);
+                }
+
+                if (r != RESULT_OK && r != RESULT_NOT_200_OK)
+                {
+                    response.m_CloseConnection = 1;
+                }
             }
-            response = Response(client);
+
+            return r;
         }
 
-
-        if (r == RESULT_OK && use_proxy)
-        {
-            if (client->m_Secure)
-            {
-                r = response.CreateSSLSocket(client->m_HostURI.m_Hostname, client->m_RequestTimeout);
-            }
-            
-            if (r == RESULT_OK)
-            {
-                r = DoDoRequest(client, response, path, method);
-            }
-        }
-
-        if (r != RESULT_OK && r != RESULT_NOT_200_OK)
-        {
-            response.m_CloseConnection = 1;
-        }
-
-        return r;
+        dmLogWarning("All connection attempts to remote host are prematurely closed. This error is very unlikely.");
+        return RESULT_UNKNOWN;
     }
 
 #if !defined(DM_NO_HTTP_CACHE)

--- a/engine/dlib/src/test/http_server/TestHttpServer.java
+++ b/engine/dlib/src/test/http_server/TestHttpServer.java
@@ -23,6 +23,9 @@ import java.util.regex.*;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.io.*;
 import java.nio.file.Files;
@@ -78,6 +81,272 @@ class Range
     }
 }
 
+class TestConnectProxyServer
+{
+    private ServerSocket m_ServerSocket;
+
+    public TestConnectProxyServer() throws IOException
+    {
+        m_ServerSocket = new ServerSocket();
+        m_ServerSocket.setReuseAddress(true);
+        m_ServerSocket.bind(new InetSocketAddress(InetAddress.getByName("127.0.0.1"), 0));
+    }
+
+    public int getLocalPort()
+    {
+        return m_ServerSocket.getLocalPort();
+    }
+
+    public void start()
+    {
+        Thread acceptThread = new Thread(new Runnable() {
+            @Override
+            public void run()
+            {
+                acceptLoop();
+            }
+        }, "TestConnectProxyAccept");
+        acceptThread.setDaemon(true);
+        acceptThread.start();
+    }
+
+    private void acceptLoop()
+    {
+        while (!m_ServerSocket.isClosed())
+        {
+            try
+            {
+                final Socket clientSocket = m_ServerSocket.accept();
+                Thread worker = new Thread(new Runnable() {
+                    @Override
+                    public void run()
+                    {
+                        handleClient(clientSocket);
+                    }
+                }, "TestConnectProxyWorker");
+                worker.setDaemon(true);
+                worker.start();
+            }
+            catch (SocketException e)
+            {
+                if (m_ServerSocket.isClosed())
+                    return;
+                throw new RuntimeException(e);
+            }
+            catch (IOException e)
+            {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    private static void closeQuietly(Socket socket)
+    {
+        if (socket != null)
+        {
+            try
+            {
+                socket.close();
+            }
+            catch (IOException e)
+            {
+            }
+        }
+    }
+
+    private static void writeResponse(OutputStream output, String response) throws IOException
+    {
+        output.write(response.getBytes("ISO-8859-1"));
+        output.flush();
+    }
+
+    private static String readLine(InputStream input) throws IOException
+    {
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        int c = input.read();
+        while (c != -1)
+        {
+            if (c == '\n')
+                break;
+            if (c != '\r')
+                buffer.write(c);
+            c = input.read();
+        }
+
+        if (c == -1 && buffer.size() == 0)
+            return null;
+
+        return buffer.toString("ISO-8859-1");
+    }
+
+    private static int findPortSeparator(String hostAndPort)
+    {
+        if (hostAndPort.startsWith("["))
+        {
+            int closingBracket = hostAndPort.indexOf(']');
+            if (closingBracket != -1 && closingBracket + 1 < hostAndPort.length() && hostAndPort.charAt(closingBracket + 1) == ':')
+                return closingBracket + 1;
+        }
+        return hostAndPort.lastIndexOf(':');
+    }
+
+    private static Socket connectTargetSocket(String host, int port) throws IOException
+    {
+        IOException lastException = null;
+        InetAddress[] addresses = InetAddress.getAllByName(host);
+        for (InetAddress address : addresses)
+        {
+            Socket socket = new Socket();
+            try
+            {
+                socket.setTcpNoDelay(true);
+                socket.connect(new InetSocketAddress(address, port), 5000);
+                return socket;
+            }
+            catch (IOException e)
+            {
+                lastException = e;
+                closeQuietly(socket);
+            }
+        }
+
+        if (lastException != null)
+            throw lastException;
+
+        throw new UnknownHostException(host);
+    }
+
+    private static void tunnel(Socket inputSocket, Socket outputSocket, Socket clientSocket, Socket targetSocket)
+    {
+        try
+        {
+            InputStream input = inputSocket.getInputStream();
+            OutputStream output = outputSocket.getOutputStream();
+            byte[] buffer = new byte[8192];
+            int read = input.read(buffer);
+            while (read != -1)
+            {
+                output.write(buffer, 0, read);
+                output.flush();
+                read = input.read(buffer);
+            }
+        }
+        catch (IOException e)
+        {
+        }
+        finally
+        {
+            closeQuietly(clientSocket);
+            closeQuietly(targetSocket);
+        }
+    }
+
+    private void handleClient(Socket clientSocket)
+    {
+        Socket targetSocket = null;
+        try
+        {
+            clientSocket.setTcpNoDelay(true);
+
+            InputStream clientInput = clientSocket.getInputStream();
+            OutputStream clientOutput = clientSocket.getOutputStream();
+
+            String requestLine = readLine(clientInput);
+            if (requestLine == null)
+                return;
+
+            String headerLine = readLine(clientInput);
+            while (headerLine != null && headerLine.length() > 0)
+            {
+                headerLine = readLine(clientInput);
+            }
+
+            String[] requestParts = requestLine.split(" ");
+            if (requestParts.length != 3 || !"CONNECT".equals(requestParts[0]))
+            {
+                writeResponse(clientOutput, "HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\n\r\n");
+                return;
+            }
+
+            String hostAndPort = requestParts[1];
+            int separator = findPortSeparator(hostAndPort);
+            if (separator <= 0)
+            {
+                writeResponse(clientOutput, "HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\n\r\n");
+                return;
+            }
+
+            String host = hostAndPort.substring(0, separator);
+            if (host.startsWith("[") && host.endsWith("]"))
+                host = host.substring(1, host.length() - 1);
+
+            int port = Integer.parseInt(hostAndPort.substring(separator + 1));
+
+            try
+            {
+                targetSocket = connectTargetSocket(host, port);
+            }
+            catch (IOException e)
+            {
+                writeResponse(clientOutput, "HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\n\r\n");
+                return;
+            }
+
+            writeResponse(clientOutput, "HTTP/1.1 200 Connection established\r\n\r\n");
+
+            final Socket clientSocketFinal = clientSocket;
+            final Socket targetSocketFinal = targetSocket;
+
+            Thread clientToTarget = new Thread(new Runnable() {
+                @Override
+                public void run()
+                {
+                    tunnel(clientSocketFinal, targetSocketFinal, clientSocketFinal, targetSocketFinal);
+                }
+            }, "TestConnectProxyClientToTarget");
+            Thread targetToClient = new Thread(new Runnable() {
+                @Override
+                public void run()
+                {
+                    tunnel(targetSocketFinal, clientSocketFinal, clientSocketFinal, targetSocketFinal);
+                }
+            }, "TestConnectProxyTargetToClient");
+
+            clientToTarget.setDaemon(true);
+            targetToClient.setDaemon(true);
+
+            clientToTarget.start();
+            targetToClient.start();
+
+            clientToTarget.join();
+            targetToClient.join();
+        }
+        catch (NumberFormatException e)
+        {
+            try
+            {
+                OutputStream clientOutput = clientSocket.getOutputStream();
+                writeResponse(clientOutput, "HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\n\r\n");
+            }
+            catch (IOException ioe)
+            {
+            }
+        }
+        catch (IOException e)
+        {
+        }
+        catch (InterruptedException e)
+        {
+            Thread.currentThread().interrupt();
+        }
+        finally
+        {
+            closeQuietly(targetSocket);
+            closeQuietly(clientSocket);
+        }
+    }
+}
+
 public class TestHttpServer extends AbstractHandler
 {
     // Max number of retries when starting the server.
@@ -90,7 +359,9 @@ public class TestHttpServer extends AbstractHandler
     Pattern m_CachedPattern = Pattern.compile("/cached/(\\d+)");
     Pattern m_EchoPattern = Pattern.compile("/echo/(.*)");
     Pattern m_ClosePattern = Pattern.compile("/close");
+    Pattern m_CloseReusedPattern = Pattern.compile("/close-reused");
     Pattern m_SleepPattern = Pattern.compile("/sleep/(\\d+)");
+    Map<Object, Integer> m_CloseReusedConnections = Collections.synchronizedMap(new IdentityHashMap<Object, Integer>());
     public TestHttpServer()
     {
         super();
@@ -502,6 +773,22 @@ public class TestHttpServer extends AbstractHandler
             baseRequest.setHandled(true);
             response.getWriter().print("will close connection now.");
             response.setStatus(HttpServletResponse.SC_OK);
+        } else if (m_CloseReusedPattern.matcher(target).matches()) {
+            Object connection = baseRequest.getHttpChannel().getConnection();
+            int reuse_count;
+            synchronized (m_CloseReusedConnections) {
+                Integer count = m_CloseReusedConnections.get(connection);
+                reuse_count = count == null ? 0 : count.intValue();
+                m_CloseReusedConnections.put(connection, reuse_count + 1);
+            }
+
+            if (reuse_count == 0) {
+                baseRequest.setHandled(true);
+                response.getWriter().print("reused connection is healthy.");
+                response.setStatus(HttpServletResponse.SC_OK);
+            } else {
+                HttpConnection.getCurrentConnection().getHttpChannel().getConnection().close();
+            }
         } else if (closem.matches()) {
             HttpConnection.getCurrentConnection().getHttpChannel().getConnection().close();
         } else if (sleepm.matches()) {
@@ -522,6 +809,8 @@ public class TestHttpServer extends AbstractHandler
         try
         {
             Server server = new Server();
+            TestConnectProxyServer proxyServer = new TestConnectProxyServer();
+            proxyServer.start();
             
             ServerConnector connector = new ServerConnector(server);
             connector.setIdleTimeout(10000); // millis
@@ -603,6 +892,7 @@ public class TestHttpServer extends AbstractHandler
             int port = ((ServerConnector)connectors[0]).getLocalPort();
             int port_ssl = ((ServerConnector)connectors[1]).getLocalPort();
             int port_ssl_test = ((ServerConnector)connectors[2]).getLocalPort();
+            int port_proxy = proxyServer.getLocalPort();
 
             // Early exit if any of the connectors is not opened or closed.
             if ((port == -1) || (port == -2)) {
@@ -617,6 +907,10 @@ public class TestHttpServer extends AbstractHandler
                 System.out.println("ERROR: Connector 2 is not opened or closed!");
                 return;
             }
+            if ((port_proxy == -1) || (port_proxy == -2)) {
+                System.out.println("ERROR: Proxy connector is not opened or closed!");
+                return;
+            }
 
             try {
                 String tempname = "test_http_server.cfg.tmp";
@@ -628,6 +922,7 @@ public class TestHttpServer extends AbstractHandler
                 writer.println(String.format("socket=%d", port));
                 writer.println(String.format("socket_ssl=%d", port_ssl));
                 writer.println(String.format("socket_ssl_test=%d", port_ssl_test));
+                writer.println(String.format("socket_proxy=%d", port_proxy));
                 writer.close();
 
                 File tempfile = new File(tempname);

--- a/engine/dlib/src/test/test_httpclient.cpp
+++ b/engine/dlib/src/test/test_httpclient.cpp
@@ -1562,6 +1562,20 @@ TEST(dmHttpClient, ProxyHttps)
     ProxyAddRequest(true, g_HttpPortSSL);
 }
 
+// Verifies that a non-200 CONNECT response from the proxy is preserved as an HTTP error for HTTPS requests.
+TEST(dmHttpClient, ProxyHttpsConnectFailureReturnsHttpError)
+{
+    char proxy_url[128];
+    MakeLocalProxyUrl(proxy_url, sizeof(proxy_url));
+
+    ProxyRequestHelper helper("https://127.0.0.1:1", proxy_url);
+    ASSERT_TRUE(helper.IsValid());
+
+    dmHttpClient::Result r = helper.Get("/");
+    ASSERT_EQ(dmHttpClient::RESULT_NOT_200_OK, r);
+    ASSERT_EQ(502, helper.m_StatusCode);
+}
+
 // Verifies that reconnecting through a proxy after a reused HTTP connection is closed does not leak pool handles.
 TEST(dmHttpClient, ProxyReusedConnectionCloseDoesNotLeakPoolHandles)
 {

--- a/engine/dlib/src/test/test_httpclient.cpp
+++ b/engine/dlib/src/test/test_httpclient.cpp
@@ -60,6 +60,7 @@ template <> char* jc_test_print_value(char* buffer, size_t buffer_len, dmSocket:
 int g_HttpPort = -1;
 int g_HttpPortSSL = -1;
 int g_HttpPortSSLTest = -1;
+int g_HttpPortProxy = -1;
 char SERVER_IP[64] = "localhost";
 
 #define NAME_SERVER_IP "localhost"
@@ -1366,6 +1367,134 @@ INSTANTIATE_TEST_CASE_P(dmHttpClientTestCache, dmHttpClientTestCache, jc_test_va
 
 #endif // #ifndef DM_DISABLE_HTTPCLIENT_TESTS
 
+class ProxyRequestHelper
+{
+public:
+    ProxyRequestHelper(const char* url, const char* proxy_url)
+    {
+        memset(&m_URI, 0, sizeof(m_URI));
+        memset(&m_ProxyURI, 0, sizeof(m_ProxyURI));
+        m_Client = 0;
+        m_Valid = false;
+        m_StatusCode = -1;
+
+        if (dmURI::Parse(url, &m_URI) != dmURI::RESULT_OK)
+            return;
+
+        if (dmURI::Parse(proxy_url, &m_ProxyURI) != dmURI::RESULT_OK)
+            return;
+
+        dmHttpClient::NewParams params;
+        params.m_Userdata = this;
+        params.m_HttpContent = ProxyRequestHelper::HttpContent;
+        m_Client = dmHttpClient::New(&params, &m_URI, 0, &m_ProxyURI);
+        m_Valid = m_Client != 0;
+    }
+
+    ~ProxyRequestHelper()
+    {
+        if (m_Client)
+            dmHttpClient::Delete(m_Client);
+    }
+
+    bool IsValid() const
+    {
+        return m_Valid;
+    }
+
+    dmHttpClient::HClient GetClient()
+    {
+        return m_Client;
+    }
+
+    dmHttpClient::Result Get(const char* path)
+    {
+        m_StatusCode = -1;
+        m_Content.clear();
+        return dmHttpClient::Get(m_Client, path);
+    }
+
+    static void HttpContent(dmHttpClient::HResponse response, void* user_data, int status_code, const void* content_data, uint32_t content_data_size, int32_t content_length,
+                            uint32_t range_start, uint32_t range_end, uint32_t document_size,
+                            const char* method)
+    {
+        ProxyRequestHelper* self = (ProxyRequestHelper*) user_data;
+        self->m_StatusCode = status_code;
+        self->m_Content.append((const char*) content_data, content_data_size);
+    }
+
+    int m_StatusCode;
+    std::string m_Content;
+
+private:
+    dmHttpClient::HClient m_Client;
+    dmURI::Parts m_URI;
+    dmURI::Parts m_ProxyURI;
+    bool m_Valid;
+};
+
+static void MakeLocalUrl(char* buffer, uint32_t buffer_size, bool secure, int port)
+{
+    // Use IPv4 loopback explicitly so the standalone proxy and Jetty test servers
+    // don't depend on platform-specific localhost address-family resolution.
+    dmSnPrintf(buffer, buffer_size, "%s://127.0.0.1:%d", secure ? "https" : "http", port);
+}
+
+static void MakeLocalProxyUrl(char* buffer, uint32_t buffer_size)
+{
+    dmSnPrintf(buffer, buffer_size, "http://127.0.0.1:%d", g_HttpPortProxy);
+}
+
+static void ProxyAddRequest(bool secure, int port)
+{
+    char url[128];
+    char proxy_url[128];
+    MakeLocalUrl(url, sizeof(url), secure, port);
+    MakeLocalProxyUrl(proxy_url, sizeof(proxy_url));
+
+    ProxyRequestHelper helper(url, proxy_url);
+    ASSERT_TRUE(helper.IsValid());
+
+    dmHttpClient::Result r = helper.Get("/add/10/20");
+    ASSERT_EQ(dmHttpClient::RESULT_OK, r);
+    ASSERT_EQ(200, helper.m_StatusCode);
+    ASSERT_EQ(30, strtol(helper.m_Content.c_str(), 0, 10));
+}
+
+static void ProxyCloseReusedDoesNotLeakPoolHandles(bool secure, int port, uint32_t iterations)
+{
+    dmHttpClient::ShutdownConnectionPool();
+    dmHttpClient::ReopenConnectionPool();
+
+    char url[128];
+    char proxy_url[128];
+    MakeLocalUrl(url, sizeof(url), secure, port);
+    MakeLocalProxyUrl(proxy_url, sizeof(proxy_url));
+
+    ProxyRequestHelper helper(url, proxy_url);
+    ASSERT_TRUE(helper.IsValid());
+
+    dmHttpClient::SetOptionInt(helper.GetClient(), dmHttpClient::OPTION_MAX_GET_RETRIES, 1);
+
+    dmHttpClient::Result r = helper.Get("/close-reused");
+    ASSERT_EQ(dmHttpClient::RESULT_OK, r);
+    ASSERT_EQ(200, helper.m_StatusCode);
+    ASSERT_STREQ("reused connection is healthy.", helper.m_Content.c_str());
+    ASSERT_EQ(0u, dmHttpClient::GetNumPoolConnections());
+
+    for (uint32_t i = 0; i < iterations; ++i)
+    {
+        r = helper.Get("/close-reused");
+        ASSERT_EQ(dmHttpClient::RESULT_OK, r);
+        ASSERT_EQ(200, helper.m_StatusCode);
+        ASSERT_STREQ("reused connection is healthy.", helper.m_Content.c_str());
+        ASSERT_EQ(0u, dmHttpClient::GetNumPoolConnections());
+    }
+
+    dmHttpClient::ShutdownConnectionPool();
+    dmHttpClient::ReopenConnectionPool();
+}
+
 TEST(dmHttpClient, HostNotFound)
 {
     dmURI::Parts uri;
@@ -1427,6 +1556,52 @@ TEST(dmHttpClient, Proxy)
     dmHttpClient::Delete(client);
 }
 
+// Verifies that HTTPS requests still work when the client tunnels through an HTTP CONNECT proxy.
+TEST(dmHttpClient, ProxyHttps)
+{
+    ProxyAddRequest(true, g_HttpPortSSL);
+}
+
+// Verifies that reconnecting through a proxy after a reused HTTP connection is closed does not leak pool handles.
+TEST(dmHttpClient, ProxyReusedConnectionCloseDoesNotLeakPoolHandles)
+{
+    ProxyCloseReusedDoesNotLeakPoolHandles(false, g_HttpPort, 20);
+}
+
+// Verifies the same reused-connection reconnect path for HTTPS traffic tunneled through a proxy.
+TEST(dmHttpClient, ProxySecureReusedConnectionCloseDoesNotLeakPoolHandles)
+{
+    ProxyCloseReusedDoesNotLeakPoolHandles(true, g_HttpPortSSL, 20);
+}
+
+// Verifies the direct retry path: when the server closes a reused keep-alive connection, the client reconnects
+// and does not leave any in-use handles behind in the pool.
+TEST_P(dmHttpClientTest, ReusedConnectionCloseDoesNotLeakPoolHandles)
+{
+    dmHttpClient::ShutdownConnectionPool();
+    dmHttpClient::ReopenConnectionPool();
+
+    dmHttpClient::SetOptionInt(m_Client, dmHttpClient::OPTION_MAX_GET_RETRIES, 1);
+
+    dmHttpClient::Result r = HttpGet("/close-reused");
+    ASSERT_EQ(dmHttpClient::RESULT_OK, r);
+    ASSERT_EQ(200, m_StatusCode);
+    ASSERT_STREQ("reused connection is healthy.", m_Content.c_str());
+    ASSERT_EQ(0u, dmHttpClient::GetNumPoolConnections());
+
+    for (uint32_t i = 0; i < 40; ++i)
+    {
+        r = HttpGet("/close-reused");
+        ASSERT_EQ(dmHttpClient::RESULT_OK, r);
+        ASSERT_EQ(200, m_StatusCode);
+        ASSERT_STREQ("reused connection is healthy.", m_Content.c_str());
+        ASSERT_EQ(0u, dmHttpClient::GetNumPoolConnections());
+    }
+
+    dmHttpClient::ShutdownConnectionPool();
+    dmHttpClient::ReopenConnectionPool();
+}
+
 static void Usage()
 {
     dmLogError("Usage: <exe> <config>");
@@ -1455,6 +1630,7 @@ int main(int argc, char **argv)
         dmStrlCpy(SERVER_IP, ip, sizeof(SERVER_IP));
 
         dmTestUtil::GetSocketsFromConfig(config, &g_HttpPort, &g_HttpPortSSL, &g_HttpPortSSLTest);
+        g_HttpPortProxy = dmConfigFile::GetInt(config, "server.socket_proxy", -1);
         dmConfigFile::Delete(config);
     }
     else

--- a/engine/dlib/wscript
+++ b/engine/dlib/wscript
@@ -144,6 +144,7 @@ def shutdown(sht):
         config.set("server", "socket", server_sockets.getint("server", "socket"))
         config.set("server", "socket_ssl", server_sockets.getint("server", "socket_ssl"))
         config.set("server", "socket_ssl_test", server_sockets.getint("server", "socket_ssl_test"))
+        config.set("server", "socket_proxy", server_sockets.getint("server", "socket_proxy"))
 
         fd, tmp_path = tempfile.mkstemp(suffix=".cfg", prefix="unittest_")
         os.close(fd)
@@ -159,6 +160,7 @@ def shutdown(sht):
         config.set("server", "socket", "0")
         config.set("server", "socket_ssl", "0")
         config.set("server", "socket_ssl_test", "0")
+        config.set("server", "socket_proxy", "0")
 
         fd, tmp_path = tempfile.mkstemp(suffix=".cfg", prefix="unittest_")
         os.close(fd)


### PR DESCRIPTION
Fixes a crash that may happen in `http_client` because connections can't be reused.

Fix https://github.com/defold/defold/issues/12120

### Technical changes

Restore per-attempt dmHttpClient::Response ownership so retries cannot drop pooled connection handles, which could lead to stale pool slot assertions.
Add deterministic proxy coverage for HTTPS-over-CONNECT and reused proxied connections.