### PR TITLE
Remove unsupported luasocket functionality from HTML5 build

### DIFF
--- a/README_EMSCRIPTEN.md
+++ b/README_EMSCRIPTEN.md
@@ -130,3 +130,5 @@ To debug memory and alignment issues the following parameters should be added bo
 - `-s STACK_OVERFLOW_CHECK=2` should be **added** to enable additional stack checks.
 - `-s AGGRESSIVE_VARIABLE_ELIMINATION=1` should be **removed**, otherwise errors might be ignored.
 - `-s DISABLE_EXCEPTION_CATCHING=1` should be **removed**, otherwise errors might be ignored.
+
+For size analysis of `wasm-web` builds, add `--wasm-size-analysis` to the build. This keeps the normal `--emit-symbol-map` flow and also adds line-table debug info plus `.wasm.map` and separate DWARF sidecars, which makes it easier to attribute wasm functions back to source without changing the optimized code generation.

--- a/README_EMSCRIPTEN.md
+++ b/README_EMSCRIPTEN.md
@@ -131,4 +131,4 @@ To debug memory and alignment issues the following parameters should be added bo
 - `-s AGGRESSIVE_VARIABLE_ELIMINATION=1` should be **removed**, otherwise errors might be ignored.
 - `-s DISABLE_EXCEPTION_CATCHING=1` should be **removed**, otherwise errors might be ignored.
 
-For size analysis of `wasm-web` builds, add `--wasm-size-analysis` to the build. This keeps the normal `--emit-symbol-map` flow and also adds line-table debug info plus `.wasm.map` and separate DWARF sidecars, which makes it easier to attribute wasm functions back to source without changing the optimized code generation.
+For size analysis of `wasm-web` builds, add `--size-analyze` to the build. This keeps the normal `--emit-symbol-map` flow and also adds line-table debug info plus `.wasm.map` and separate DWARF sidecars, which makes it easier to attribute wasm functions back to source without changing the optimized code generation.

--- a/build_tools/waf_dynamo.py
+++ b/build_tools/waf_dynamo.py
@@ -546,6 +546,13 @@ def default_flags(self):
             if int(opt_level) < 2:
                 flags += ['-gseparate-dwarf', '-gsource-map']
                 linkflags += ['-gseparate-dwarf', '-gsource-map']
+            if Options.options.wasm_size_analysis:
+                # Keep source attribution outside the main wasm so size measurements
+                # still reflect the optimized binary while enabling deeper analysis.
+                flags += ['-gline-tables-only']
+                for flag in ['-gsource-map', '-gseparate-dwarf']:
+                    if flag not in linkflags:
+                        linkflags += [flag]
         else:
             emflags_link += ['WASM=0', 'LEGACY_VM_SUPPORT=1']
 
@@ -2138,6 +2145,7 @@ def options(opt):
     opt.add_option('--with-dx12', action='store_true', default=False, dest='with_dx12', help='Enables DX12 as a graphics backend')
     opt.add_option('--with-opus', action='store_true', default=False, dest='with_opus', help='Enable Opus audio codec support in runtime')
     opt.add_option('--with-webgpu', action='store_true', default=False, dest='with_webgpu', help='Enables WebGPU as graphics backend')
+    opt.add_option('--wasm-size-analysis', action='store_true', default=False, dest='wasm_size_analysis', help='Emit extra wasm-web analysis artifacts such as source maps and separate DWARF')
 
     # Currently supported features: physics
     opt.add_option('--disable-feature', action='append', default=[], dest='disable_features', help='disable feature, --disable-feature=foo')

--- a/build_tools/waf_dynamo.py
+++ b/build_tools/waf_dynamo.py
@@ -546,7 +546,7 @@ def default_flags(self):
             if int(opt_level) < 2:
                 flags += ['-gseparate-dwarf', '-gsource-map']
                 linkflags += ['-gseparate-dwarf', '-gsource-map']
-            if Options.options.wasm_size_analysis:
+            if Options.options.size_analyze:
                 # Keep source attribution outside the main wasm so size measurements
                 # still reflect the optimized binary while enabling deeper analysis.
                 flags += ['-gline-tables-only']
@@ -2145,7 +2145,7 @@ def options(opt):
     opt.add_option('--with-dx12', action='store_true', default=False, dest='with_dx12', help='Enables DX12 as a graphics backend')
     opt.add_option('--with-opus', action='store_true', default=False, dest='with_opus', help='Enable Opus audio codec support in runtime')
     opt.add_option('--with-webgpu', action='store_true', default=False, dest='with_webgpu', help='Enables WebGPU as graphics backend')
-    opt.add_option('--wasm-size-analysis', action='store_true', default=False, dest='wasm_size_analysis', help='Emit extra wasm-web analysis artifacts such as source maps and separate DWARF')
+    opt.add_option('--size-analyze', action='store_true', default=False, dest='size_analyze', help='Emit extra wasm-web analysis artifacts such as source maps and separate DWARF')
 
     # Currently supported features: physics
     opt.add_option('--disable-feature', action='append', default=[], dest='disable_features', help='disable feature, --disable-feature=foo')

--- a/engine/script/src/luasocket/luasocket.doc_h
+++ b/engine/script/src/luasocket/luasocket.doc_h
@@ -6,6 +6,9 @@
  * SMTP, HTTP, FTP etc are not part of the core included, but can be easily added to a project
  * and used.
  *
+ * [icon:html5] On HTML5, the non-network helpers remain available, but TCP, UDP and
+ * `socket.select()` are not supported.
+ *
  * Note the included helper module "socket.lua" in "builtins/scripts/socket.lua". Require this
  * module to add some additional functions and shortcuts to the namespace:
  *

--- a/engine/script/src/luasocket/luasocket_html5.c
+++ b/engine/script/src/luasocket/luasocket_html5.c
@@ -70,14 +70,12 @@ static int global_unload(lua_State *L) {
 }
 
 static int global_unsupported(lua_State *L) {
-    (void) L;
     lua_pushnil(L);
     lua_pushliteral(L, "LuaSocket networking is not supported on HTML5");
     return 2;
 }
 
 static int global_dns_unsupported(lua_State *L) {
-    (void) L;
     lua_pushnil(L);
     lua_pushliteral(L, "LuaSocket DNS is not supported on HTML5");
     return 2;

--- a/engine/script/src/luasocket/luasocket_html5.c
+++ b/engine/script/src/luasocket/luasocket_html5.c
@@ -1,0 +1,157 @@
+/*=========================================================================*\
+* LuaSocket toolkit
+* HTML5 registration for Defold
+\*=========================================================================*/
+
+// Copyright 2020-2026 The Defold Foundation
+// Copyright 2014-2020 King
+// Copyright 2009-2014 Ragnar Svensson, Christian Murray
+// Licensed under the Defold License version 1.0 (the "License"); you may not use
+// this file except in compliance with the License.
+//
+// You may obtain a copy of the License, together with FAQs at
+// https://www.defold.com/license
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#include "lua.h"
+#include "lauxlib.h"
+
+#include "luasocket.h"
+#include "except.h"
+#include "timeout.h"
+
+/*-------------------------------------------------------------------------*\
+* Internal function prototypes
+\*-------------------------------------------------------------------------*/
+static int global_skip(lua_State *L);
+static int global_unload(lua_State *L);
+static int global_unsupported(lua_State *L);
+static int global_dns_unsupported(lua_State *L);
+static int base_open(lua_State *L);
+static int html5_unsupported_open(lua_State *L);
+static int html5_dns_open(lua_State *L);
+
+/*-------------------------------------------------------------------------*\
+* Modules and functions
+\*-------------------------------------------------------------------------*/
+static const luaL_Reg mod[] = {
+    {"except", except_open},
+    {"timeout", timeout_open},
+    {"html5_dns", html5_dns_open},
+    {"html5_unsupported", html5_unsupported_open},
+    {NULL, NULL}
+};
+
+static luaL_Reg func[] = {
+    {"skip",      global_skip},
+    {"__unload",  global_unload},
+    {NULL,        NULL}
+};
+
+/*-------------------------------------------------------------------------*\
+* Skip a few arguments
+\*-------------------------------------------------------------------------*/
+static int global_skip(lua_State *L) {
+    int amount = luaL_checkint(L, 1);
+    int ret = lua_gettop(L) - amount - 1;
+    return ret >= 0 ? ret : 0;
+}
+
+/*-------------------------------------------------------------------------*\
+* Unloads the library
+\*-------------------------------------------------------------------------*/
+static int global_unload(lua_State *L) {
+    (void) L;
+    return 0;
+}
+
+static int global_unsupported(lua_State *L) {
+    (void) L;
+    lua_pushnil(L);
+    lua_pushliteral(L, "LuaSocket networking is not supported on HTML5");
+    return 2;
+}
+
+static int global_dns_unsupported(lua_State *L) {
+    (void) L;
+    lua_pushnil(L);
+    lua_pushliteral(L, "LuaSocket DNS is not supported on HTML5");
+    return 2;
+}
+
+static int html5_unsupported_open(lua_State *L) {
+    static const luaL_Reg unsupported[] = {
+        {"connect", global_unsupported},
+        {"tcp", global_unsupported},
+        {"tcp6", global_unsupported},
+        {"udp", global_unsupported},
+        {"udp6", global_unsupported},
+        {"select", global_unsupported},
+        {NULL, NULL}
+    };
+#if LUA_VERSION_NUM > 501 && !defined(LUA_COMPAT_MODULE)
+    luaL_setfuncs(L, unsupported, 0);
+#else
+    luaL_openlib(L, NULL, unsupported, 0);
+#endif
+    return 0;
+}
+
+static int html5_dns_open(lua_State *L) {
+    static const luaL_Reg dns[] = {
+        {"toip", global_dns_unsupported},
+        {"getaddrinfo", global_dns_unsupported},
+        {"tohostname", global_dns_unsupported},
+        {"getnameinfo", global_dns_unsupported},
+        {"gethostname", global_dns_unsupported},
+        {NULL, NULL}
+    };
+
+    lua_pushliteral(L, "dns");
+    lua_newtable(L);
+#if LUA_VERSION_NUM > 501 && !defined(LUA_COMPAT_MODULE)
+    luaL_setfuncs(L, dns, 0);
+#else
+    luaL_openlib(L, NULL, dns, 0);
+#endif
+    lua_settable(L, -3);
+    return 0;
+}
+
+/*-------------------------------------------------------------------------*\
+* Setup basic stuff.
+\*-------------------------------------------------------------------------*/
+static int base_open(lua_State *L) {
+    {
+        /* export functions (and leave namespace table on top of stack) */
+#if LUA_VERSION_NUM > 501 && !defined(LUA_COMPAT_MODULE)
+        lua_newtable(L);
+        luaL_setfuncs(L, func, 0);
+#else
+        luaL_openlib(L, "socket", func, 0);
+#endif
+#ifdef LUASOCKET_DEBUG
+        lua_pushliteral(L, "_DEBUG");
+        lua_pushboolean(L, 1);
+        lua_rawset(L, -3);
+#endif
+        lua_pushliteral(L, "_VERSION");
+        lua_pushstring(L, LUASOCKET_VERSION);
+        lua_rawset(L, -3);
+        return 1;
+    }
+}
+
+/*-------------------------------------------------------------------------*\
+* Initializes the HTML5-safe library modules.
+\*-------------------------------------------------------------------------*/
+LUASOCKET_API int luaopen_socket_core(lua_State *L) {
+    int i;
+    base_open(L);
+    for (i = 0; mod[i].name; i++) mod[i].func(L);
+    return 1;
+}

--- a/engine/script/src/test/test_luasocket.lua
+++ b/engine/script/src/test/test_luasocket.lua
@@ -14,6 +14,25 @@
 
 -- Tests adopted from luasocket library provided tests
 
+function test_html5_minimal()
+    local socket = require "socket"
+
+    local t = socket.gettime()
+    assert(type(t) == "number")
+
+    local tcp, tcp_err = socket.tcp()
+    assert(tcp == nil)
+    assert(type(tcp_err) == "string")
+
+    local udp, udp_err = socket.udp()
+    assert(udp == nil)
+    assert(type(udp_err) == "string")
+
+    local readable, select_err = socket.select({}, {}, 0)
+    assert(readable == nil)
+    assert(type(select_err) == "string")
+end
+
 function test_bind()
     local socket = require "socket"
     local u = socket.udp()
@@ -237,6 +256,6 @@ function test_bind_error()
 end
 
 
-functions = { test_getaddr = test_getaddr, test_bind = test_bind,
+functions = { test_html5_minimal = test_html5_minimal, test_getaddr = test_getaddr, test_bind = test_bind,
     test_udp = test_udp, test_tcp_clientserver = test_tcp_clientserver,
     test_udp_clientserver = test_udp_clientserver, test_bind_error = test_bind_error }

--- a/engine/script/src/test/test_script_luasocket.cpp
+++ b/engine/script/src/test/test_script_luasocket.cpp
@@ -34,11 +34,17 @@ TEST_F(ScriptLuasocketTest, TestLuasocket)
 
     ASSERT_TRUE(RunFile(L, "test_luasocket.luac"));
 
+#if defined(__EMSCRIPTEN__)
+    const char *funcs[] = {
+        "test_html5_minimal", 0
+    };
+#else
     const char *funcs[] = {
         "test_bind", "test_getaddr",
         "test_udp", "test_tcp_clientserver",
         "test_udp_clientserver", "test_bind_error", 0
     };
+#endif
 
     for (int i=0;funcs[i];i++)
     {

--- a/engine/script/src/wscript
+++ b/engine/script/src/wscript
@@ -37,6 +37,20 @@ def build(bld):
         script.source = remove_from_node_list(script.source, os.path.join('luasocket', 'serial.c'))
         script.source = remove_from_node_list(script.source, os.path.join('luasocket', 'unix.c'))
 
+        if 'web' in bld.env.PLATFORM:
+            script.source = remove_from_node_list(script.source, os.path.join('luasocket', 'luasocket.c'))
+            script.source = remove_from_node_list(script.source, os.path.join('luasocket', 'tcp.c'))
+            script.source = remove_from_node_list(script.source, os.path.join('luasocket', 'udp.c'))
+            script.source = remove_from_node_list(script.source, os.path.join('luasocket', 'select.c'))
+            script.source = remove_from_node_list(script.source, os.path.join('luasocket', 'inet.c'))
+            script.source = remove_from_node_list(script.source, os.path.join('luasocket', 'buffer.c'))
+            script.source = remove_from_node_list(script.source, os.path.join('luasocket', 'options.c'))
+            script.source = remove_from_node_list(script.source, os.path.join('luasocket', 'io.c'))
+            script.source = remove_from_node_list(script.source, os.path.join('luasocket', 'usocket.c'))
+            script.source = remove_from_node_list(script.source, os.path.join('luasocket', 'auxiliar.c'))
+        else:
+            script.source = remove_from_node_list(script.source, os.path.join('luasocket', 'luasocket_html5.c'))
+
         script.cflags = ['-DLUASOCKET_API=']
         if bld.env.PLATFORM in ['win32', 'x86_64-win32', 'x86_64-xbone']:
             script.source = remove_from_node_list(script.source, os.path.join('luasocket', 'usocket.c'))

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -3050,10 +3050,17 @@ To pass on arbitrary options to waf: build.py OPTIONS COMMANDS -- WAF_OPTIONS
                       default = False,
                       help = 'If used, outputs verbose logging')
 
+    parser.add_option('--wasm-size-analysis', dest='wasm_size_analysis',
+                      action = 'store_true',
+                      default = False,
+                      help = 'Emit extra wasm-web analysis artifacts such as source maps and separate DWARF')
+
     options, all_args = parser.parse_args()
 
     args = list(filter(lambda x: x[:2] != '--', all_args))
     waf_options = list(filter(lambda x: x[:2] == '--', all_args))
+    if options.wasm_size_analysis:
+        waf_options.append('--wasm-size-analysis')
 
     if len(args) == 0:
         parser.error('No command specified')

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -3050,7 +3050,7 @@ To pass on arbitrary options to waf: build.py OPTIONS COMMANDS -- WAF_OPTIONS
                       default = False,
                       help = 'If used, outputs verbose logging')
 
-    parser.add_option('--wasm-size-analysis', dest='wasm_size_analysis',
+    parser.add_option('--size-analyze', dest='size_analyze',
                       action = 'store_true',
                       default = False,
                       help = 'Emit extra wasm-web analysis artifacts such as source maps and separate DWARF')
@@ -3059,8 +3059,8 @@ To pass on arbitrary options to waf: build.py OPTIONS COMMANDS -- WAF_OPTIONS
 
     args = list(filter(lambda x: x[:2] != '--', all_args))
     waf_options = list(filter(lambda x: x[:2] == '--', all_args))
-    if options.wasm_size_analysis:
-        waf_options.append('--wasm-size-analysis')
+    if options.size_analyze:
+        waf_options.append('--size-analyze')
 
     if len(args) == 0:
         parser.error('No command specified')

--- a/scripts/web/wasm_symbol_sizes.py
+++ b/scripts/web/wasm_symbol_sizes.py
@@ -39,6 +39,10 @@ def infer_output_path(wasm_path):
     return pathlib.Path(str(wasm_path) + ".symbol-sizes.tsv")
 
 
+def infer_wasm_map_path(wasm_path):
+    return pathlib.Path(str(wasm_path) + ".map")
+
+
 def find_default_wasm(dynamo_home, platform, engine):
     bin_dir = pathlib.Path(dynamo_home).resolve() / "bin" / platform
 
@@ -103,21 +107,32 @@ def run_bloaty(wasm_path, bloaty):
 
 
 def extract_function_rows(bloaty_tsv, symbol_map):
+    reverse_symbol_map = {}
+    for func_index, name in symbol_map.items():
+        reverse_symbol_map.setdefault(name, []).append(func_index)
+
     rows = []
     lines = bloaty_tsv.splitlines()
     for line in lines[1:]:
         columns = line.split("\t")
         if len(columns) != 3:
             continue
-        match = FUNC_RE.match(columns[0])
-        if not match:
+        symbol = columns[0]
+        if symbol.startswith("[section "):
             continue
-        func_index = int(match.group(1))
+
         file_size_bytes = int(columns[2])
-        name = symbol_map.get(func_index, columns[0])
+        match = FUNC_RE.match(symbol)
+        if match:
+            func_index = int(match.group(1))
+            name = symbol_map.get(func_index, symbol)
+        else:
+            indices = reverse_symbol_map.get(symbol, [])
+            func_index = indices[0] if len(indices) == 1 else -1
+            name = symbol
         rows.append((file_size_bytes, func_index, name))
 
-    rows.sort(key=lambda row: (-row[0], row[1]))
+    rows.sort(key=lambda row: (-row[0], row[1], row[2]))
     return rows
 
 
@@ -125,7 +140,7 @@ def write_output(rows, output_path):
     with output_path.open("w", encoding="utf-8", newline="") as output_file:
         output_file.write("file_size_bytes\tfunc_index\tname\n")
         for file_size_bytes, func_index, name in rows:
-            output_file.write(f"{file_size_bytes}\t{func_index}\t{name}\n")
+            output_file.write(f"{file_size_bytes}\t{'' if func_index < 0 else func_index}\t{name}\n")
 
 
 def print_top_rows(rows, top_count):
@@ -194,12 +209,20 @@ def main():
 
     symbols_path = pathlib.Path(args.symbols).resolve() if args.symbols else infer_symbols_path(wasm_path)
     output_path = pathlib.Path(args.output).resolve() if args.output else infer_output_path(wasm_path)
+    wasm_map_path = infer_wasm_map_path(wasm_path)
 
     symbol_map = {}
     if symbols_path.is_file():
         symbol_map = load_symbol_map(symbols_path)
     else:
         print(f"warning: symbol map not found, using raw func[N] names: {symbols_path}", file=sys.stderr)
+
+    if not wasm_map_path.is_file():
+        print(
+            f"note: source map not found: {wasm_map_path}. "
+            f"Rebuild with --wasm-size-analysis if you want source-level attribution.",
+            file=sys.stderr,
+        )
 
     bloaty_tsv = run_bloaty(wasm_path, args.bloaty)
     if bloaty_tsv is None:

--- a/scripts/web/wasm_symbol_sizes.py
+++ b/scripts/web/wasm_symbol_sizes.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+# Copyright 2020-2026 The Defold Foundation
+# Copyright 2014-2020 King
+# Copyright 2009-2014 Ragnar Svensson, Christian Murray
+# Licensed under the Defold License version 1.0 (the "License"); you may not use
+# this file except in compliance with the License.
+#
+# You may obtain a copy of the License, together with FAQs at
+# https://www.defold.com/license
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+import argparse
+import os
+import pathlib
+import re
+import subprocess
+import sys
+
+
+SYMBOL_ESCAPE_RE = re.compile(r"\\([0-9A-Fa-f]{2})")
+FUNC_RE = re.compile(r"^func\[(\d+)\]$")
+
+
+def decode_symbol_name(name):
+    return SYMBOL_ESCAPE_RE.sub(lambda match: chr(int(match.group(1), 16)), name)
+
+
+def infer_symbols_path(wasm_path):
+    if wasm_path.suffix == ".wasm":
+        return wasm_path.with_suffix(".js.symbols")
+    return wasm_path.parent / (wasm_path.name + ".js.symbols")
+
+
+def infer_output_path(wasm_path):
+    return pathlib.Path(str(wasm_path) + ".symbol-sizes.tsv")
+
+
+def find_default_wasm(dynamo_home, platform, engine):
+    bin_dir = pathlib.Path(dynamo_home).resolve() / "bin" / platform
+
+    if engine:
+        wasm_path = bin_dir / f"{engine}.wasm"
+        if not wasm_path.is_file():
+            raise FileNotFoundError(f"wasm file not found: {wasm_path}")
+        return wasm_path
+
+    preferred_names = [
+        "dmengine_release.wasm",
+        "dmengine.wasm",
+        "dmengine_headless.wasm",
+    ]
+
+    for name in preferred_names:
+        wasm_path = bin_dir / name
+        if wasm_path.is_file():
+            return wasm_path
+
+    candidates = sorted(bin_dir.glob("*.wasm"))
+    if len(candidates) == 1:
+        return candidates[0]
+    if len(candidates) > 1:
+        candidate_list = ", ".join(candidate.name for candidate in candidates)
+        raise FileNotFoundError(
+            f"multiple wasm files found in {bin_dir}, specify --engine or a wasm path: {candidate_list}"
+        )
+    raise FileNotFoundError(f"no wasm files found in {bin_dir}")
+
+
+def load_symbol_map(symbols_path):
+    symbol_map = {}
+    with symbols_path.open("r", encoding="utf-8") as symbols_file:
+        for line in symbols_file:
+            line = line.rstrip("\n")
+            if not line:
+                continue
+            index_text, name = line.split(":", 1)
+            symbol_map[int(index_text)] = decode_symbol_name(name)
+    return symbol_map
+
+
+def run_bloaty(wasm_path, bloaty):
+    try:
+        result = subprocess.run(
+            [bloaty, "--tsv", "-n", "0", "-d", "symbols", str(wasm_path)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        print(f"error: '{bloaty}' was not found in PATH", file=sys.stderr)
+        return None
+    except subprocess.CalledProcessError as error:
+        if error.stderr:
+            print(error.stderr.strip(), file=sys.stderr)
+        else:
+            print("error: bloaty failed", file=sys.stderr)
+        return None
+    return result.stdout
+
+
+def extract_function_rows(bloaty_tsv, symbol_map):
+    rows = []
+    lines = bloaty_tsv.splitlines()
+    for line in lines[1:]:
+        columns = line.split("\t")
+        if len(columns) != 3:
+            continue
+        match = FUNC_RE.match(columns[0])
+        if not match:
+            continue
+        func_index = int(match.group(1))
+        file_size_bytes = int(columns[2])
+        name = symbol_map.get(func_index, columns[0])
+        rows.append((file_size_bytes, func_index, name))
+
+    rows.sort(key=lambda row: (-row[0], row[1]))
+    return rows
+
+
+def write_output(rows, output_path):
+    with output_path.open("w", encoding="utf-8", newline="") as output_file:
+        output_file.write("file_size_bytes\tfunc_index\tname\n")
+        for file_size_bytes, func_index, name in rows:
+            output_file.write(f"{file_size_bytes}\t{func_index}\t{name}\n")
+
+
+def print_top_rows(rows, top_count):
+    if top_count <= 0 or not rows:
+        return
+
+    print(f"Top {min(top_count, len(rows))} functions:")
+    for file_size_bytes, func_index, name in rows[:top_count]:
+        print(f"{file_size_bytes:>8}  func[{func_index}]  {name}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate a size-sorted TSV for functions in a WebAssembly binary."
+    )
+    parser.add_argument(
+        "wasm",
+        nargs="?",
+        help="Path to the .wasm file. If omitted, resolve it from $DYNAMO_HOME/bin/<platform>/.",
+    )
+    parser.add_argument(
+        "--symbols",
+        help="Path to the matching .js.symbols file. Defaults to <wasm>.with_suffix('.js.symbols').",
+    )
+    parser.add_argument(
+        "--output",
+        help="Path to the output TSV. Defaults to <wasm>.symbol-sizes.tsv.",
+    )
+    parser.add_argument(
+        "--bloaty",
+        default="bloaty",
+        help="Bloaty executable to use. Defaults to 'bloaty'.",
+    )
+    parser.add_argument(
+        "--platform",
+        default="wasm-web",
+        help="Platform subdirectory under $DYNAMO_HOME/bin when wasm is omitted. Defaults to 'wasm-web'.",
+    )
+    parser.add_argument(
+        "--engine",
+        help="Engine basename under $DYNAMO_HOME/bin/<platform>/, for example 'dmengine_release'.",
+    )
+    parser.add_argument(
+        "--top",
+        type=int,
+        default=0,
+        help="Print the N biggest functions after writing the TSV. Defaults to 0.",
+    )
+    args = parser.parse_args()
+
+    if args.wasm:
+        wasm_path = pathlib.Path(args.wasm).resolve()
+        if not wasm_path.is_file():
+            print(f"error: wasm file not found: {wasm_path}", file=sys.stderr)
+            return 1
+    else:
+        dynamo_home = os.environ.get("DYNAMO_HOME")
+        if not dynamo_home:
+            print("error: either pass a wasm path or set DYNAMO_HOME", file=sys.stderr)
+            return 1
+        try:
+            wasm_path = find_default_wasm(dynamo_home, args.platform, args.engine)
+        except FileNotFoundError as error:
+            print(f"error: {error}", file=sys.stderr)
+            return 1
+
+    symbols_path = pathlib.Path(args.symbols).resolve() if args.symbols else infer_symbols_path(wasm_path)
+    output_path = pathlib.Path(args.output).resolve() if args.output else infer_output_path(wasm_path)
+
+    symbol_map = {}
+    if symbols_path.is_file():
+        symbol_map = load_symbol_map(symbols_path)
+    else:
+        print(f"warning: symbol map not found, using raw func[N] names: {symbols_path}", file=sys.stderr)
+
+    bloaty_tsv = run_bloaty(wasm_path, args.bloaty)
+    if bloaty_tsv is None:
+        return 1
+
+    rows = extract_function_rows(bloaty_tsv, symbol_map)
+    write_output(rows, output_path)
+
+    print(f"Wrote {len(rows)} function rows to {output_path}")
+    print_top_rows(rows, args.top)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/web/wasm_symbol_sizes.py
+++ b/scripts/web/wasm_symbol_sizes.py
@@ -220,7 +220,7 @@ def main():
     if not wasm_map_path.is_file():
         print(
             f"note: source map not found: {wasm_map_path}. "
-            f"Rebuild with --wasm-size-analysis if you want source-level attribution.",
+            f"Rebuild with --size-analyze if you want source-level attribution.",
             file=sys.stderr,
         )
 


### PR DESCRIPTION
TCP/UDP isn't supported on the HTML5 platform with luasockets. Removing this functionality from the binary helps reduce the WASM binary size slightly (~1%)

### Technical changes
Removing unused code helps to reduce dmengine_release.wasm from 2445043 bytes to 2420425 bytes
