### PR TITLE
Fix teal issue

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/fs/test/FileSystemMountPointTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/fs/test/FileSystemMountPointTest.java
@@ -1,0 +1,46 @@
+// Copyright 2020-2026 The Defold Foundation
+// Copyright 2014-2020 King
+// Copyright 2009-2014 Ragnar Svensson, Christian Murray
+// Licensed under the Defold License version 1.0 (the "License"); you may not use
+// this file except in compliance with the License.
+//
+// You may obtain a copy of the License, together with FAQs at
+// https://www.defold.com/license
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package com.dynamo.bob.fs.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+import com.dynamo.bob.fs.FileSystemMountPoint;
+import com.dynamo.bob.fs.IResource;
+import com.dynamo.bob.test.util.MockFileSystem;
+
+public class FileSystemMountPointTest {
+
+    @Test
+    public void testDisableMinifyPathPreservesMountedWrapperForChangeExt() throws IOException {
+        MockFileSystem rootFileSystem = new MockFileSystem();
+        rootFileSystem.setBuildDirectory("build/default");
+
+        MockFileSystem mountedFileSystem = new MockFileSystem();
+        mountedFileSystem.addFile("/main/test.lua", "".getBytes());
+
+        rootFileSystem.addMountPoint(new FileSystemMountPoint(rootFileSystem, mountedFileSystem));
+
+        IResource input = rootFileSystem.get("/main/test.lua");
+        IResource output = input.disableMinifyPath().changeExt(".luac");
+
+        assertEquals("build/default/main/test.luac", output.getPath());
+        assertTrue(output.isOutput());
+    }
+}

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/fs/FileSystemMountPoint.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/fs/FileSystemMountPoint.java
@@ -151,7 +151,13 @@ public class FileSystemMountPoint implements IMountPoint {
         }
 
         @Override
-        public IResource disableMinifyPath() { return resource.disableMinifyPath(); }
+        public IResource disableMinifyPath() {
+            // Preserve the mounted wrapper for fluent chains like
+            // disableMinifyPath().changeExt(...), otherwise changeExt() runs on
+            // the mounted filesystem resource and loses the root-fs output mapping.
+            resource.disableMinifyPath();
+            return this;
+        }
 
         @Override
         public boolean isMinifyPath() { return resource.isMinifyPath(); }


### PR DESCRIPTION
`/main/test.lua` is not a real project file. `extension-teal` generated it from `/main/test.tl`, and Bob mounted that generated output as a virtual filesystem, so the failing input is a wrapped, mounted resource, not a normal file.