### PR TITLE
Fix custom resources not rebuilding after changes in the editor

### DIFF
--- a/editor/src/clj/editor/defold_project.clj
+++ b/editor/src/clj/editor/defold_project.clj
@@ -1074,7 +1074,8 @@
      (if-not include-non-editable-directories
        upgraded-editable-save-data
        (let [live-run-evaluation-context (dissoc evaluation-context :dry-run)
-             resources-by-proj-path (g/valid-node-value project :resource-map live-run-evaluation-context)
+             workspace (g/valid-node-value project :workspace live-run-evaluation-context)
+             resources-by-proj-path (g/valid-node-value workspace :resource-map live-run-evaluation-context)
              resource-nodes-by-proj-path (g/valid-node-value project :nodes-by-resource-path live-run-evaluation-context)]
          (into upgraded-editable-save-data
                (keep (fn [[proj-path node-id]]
@@ -1594,7 +1595,6 @@
   (input all-selected-node-ids g/Any :array)
   (input all-selected-node-properties g/Any :array)
   (input resources g/Any)
-  (input resource-map g/Any)
   (input save-data g/Any :array :substitute gu/array-subst-remove-errors)
   (input node-id+resources g/Any :array)
   (input settings g/Any :substitute nil)
@@ -1623,7 +1623,6 @@
                                                                  (->> all-sub-selections
                                                                    (map (fn [[key vals]] [key (filterv (comp selected-node-id-set first) vals)]))
                                                                    (into {})))))
-  (output resource-map g/Any (gu/passthrough resource-map))
   (output nodes-by-resource-path g/Any :cached (g/fnk [node-id+resources] (make-resource-nodes-by-path-map node-id+resources)))
   (output save-data g/Any :cached (g/fnk [save-data] (filterv :save-value save-data)))
   (output dirty-save-data g/Any :cached (g/fnk [save-data]
@@ -1813,7 +1812,6 @@
                 (g/connect workspace-id :build-settings project :build-settings)
                 (g/connect workspace-id :dependencies project :dependencies)
                 (g/connect workspace-id :resource-list project :resources)
-                (g/connect workspace-id :resource-map project :resource-map)
                 (g/set-graph-value graph :project-id project)
                 (g/set-graph-value graph :lsp (lsp/make project get-resource-node))
                 (g/set-graph-value graph :code-transpilers transpilers-id)))))]

--- a/editor/src/clj/editor/game_project.clj
+++ b/editor/src/clj/editor/game_project.clj
@@ -29,6 +29,7 @@
             [editor.settings :as settings]
             [editor.settings-core :as settings-core]
             [editor.workspace :as workspace]
+            [util.coll :as coll :refer [pair]]
             [util.defonce :as defonce]))
 
 (set! *warn-on-reflection* true)
@@ -106,17 +107,6 @@
 (defn- file-resource? [resource]
   (= (resource/source-type resource) :file))
 
-(defn- find-custom-resources [resource-map custom-paths]
-  (->> (flatten (keep (fn [custom-path]
-                        (let [base-resource (resource-map custom-path)]
-                          (if base-resource
-                            (resource/resource-seq base-resource)
-                            (throw (ex-info (format "Custom resource not found: '%s'" custom-path)
-                                            {})))))
-                      custom-paths))
-       (distinct)
-       (filter file-resource?)))
-
 (defn- parse-custom-resource-paths [cr-setting]
   (let [paths (remove string/blank? (map string/trim (string/split (or cr-setting "")  #",")))]
     (map (comp strip-trailing-slash fs/with-leading-slash) paths)))
@@ -174,27 +164,80 @@
   (input resource-settings g/Any)
 
   (input resource-map g/Any)
+  (input resource-snapshot g/Any)
   (input dep-build-targets g/Any :array)
   (input meta-info g/Any)
 
   (input build-errors g/Any :array)
 
-  (output custom-build-targets g/Any :cached
+  (output ssl-certificates-directory-resource g/Any
+          (g/fnk [_node-id settings-map]
+            (let [directory-resource (get settings-map ["network" "ssl_certificates"])]
+              (if (or (nil? directory-resource)
+                      (resource/exists? directory-resource))
+                directory-resource
+                (g/map->error
+                  {:_node-id _node-id
+                   :severity :fatal
+                   :message (format "SSL certificates directory not found: '%s'" (resource/proj-path directory-resource))})))))
+
+  (output custom-resources-directory-resources g/Any
           (g/fnk [_node-id resource-map settings-map]
-                 (let [custom-resources (parse-custom-resource-paths (get settings-map ["project" "custom_resources"]))
-                       ssl-certificates (get settings-map ["network" "ssl_certificates"])
-                       custom-paths (if (some? ssl-certificates)
-                                      (conj custom-resources (resource/proj-path ssl-certificates))
-                                      custom-resources)]
-                   (try
-                     (map #(pipeline/make-source-bytes-build-target _node-id (->CustomResource %))
-                          (find-custom-resources resource-map custom-paths))
-                     (catch Throwable error
-                       (g/map->error
-                        {:_node-id _node-id
-                         :_label :custom-build-targets
-                         :message (ex-message error)
-                         :severity :fatal}))))))
+            (let [custom-resources-setting (get settings-map ["project" "custom_resources"])
+                  directory-proj-paths (parse-custom-resource-paths custom-resources-setting)
+
+                  directory-resources
+                  (coll/into-> directory-proj-paths []
+                    (map (fn [directory-proj-path]
+                           (or (get resource-map directory-proj-path)
+                               (g/map->error
+                                 {:_node-id _node-id
+                                  :severity :fatal
+                                  :message (format "Custom resources directory not found: '%s'" directory-proj-path)})))))]
+
+              (g/precluding-errors directory-resources
+                directory-resources))))
+
+  (output custom-resource+versions g/Any :cached
+          (g/fnk [custom-resources-directory-resources resource-snapshot ssl-certificates-directory-resource]
+            ;; We depend on the resource-snapshot to ensure this output reflects
+            ;; the on-disk state of all the involved resources.
+            (let [status-map (:status-map resource-snapshot)
+
+                  directory-resources
+                  (cond-> custom-resources-directory-resources
+                          ssl-certificates-directory-resource (conj ssl-certificates-directory-resource))
+
+                  custom-resources
+                  (coll/into-> directory-resources []
+                    (map resource/resource-seq)
+                    coll/flatten-xf
+                    (distinct)
+                    (filter file-resource?))]
+
+              ;; We include the version only to ensure this output is
+              ;; invalidated if any of the included files change on disk.
+              (coll/into-> custom-resources []
+                (map (fn [resource]
+                       (let [proj-path (resource/proj-path resource)
+                             resource-status (status-map proj-path)
+                             version (:version resource-status)]
+                         (pair resource version))))))))
+
+  (output custom-build-targets g/Any :cached
+          (g/fnk [_node-id custom-resource+versions]
+            (try
+              (mapv (fn [[source-resource _version]]
+                      ;; We don't actually need the version here, since we will
+                      ;; generate a hash from the contents of each file.
+                      (pipeline/make-source-bytes-build-target _node-id (->CustomResource source-resource)))
+                    custom-resource+versions)
+              (catch Throwable error
+                (g/map->error
+                  {:_node-id _node-id
+                   :_label :custom-build-targets
+                   :message (ex-message error)
+                   :severity :fatal})))))
 
   (input save-value g/Any)
   (output save-value g/Any (gu/passthrough save-value))
@@ -205,19 +248,21 @@
 
 (defn- load-game-project [project self resource source-value]
   (let [graph-id (g/node-id->graph-id self)
+        workspace (resource/workspace resource)
         resource-setting-connections (reduce-kv (fn [m k v] (assoc m k [self v])) {} resource-setting-connections-template)]
     (concat
+      (g/connect workspace :resource-map self :resource-map)
+      (g/connect workspace :resource-snapshot self :resource-snapshot)
       (g/make-nodes graph-id [settings-node settings/SettingsNode]
-                    (g/connect settings-node :_node-id self :nodes)
-                    (g/connect settings-node :settings-map self :settings-map)
-                    (g/connect settings-node :save-value self :save-value)
-                    (g/connect settings-node :form-data self :form-data)
-                    (g/connect settings-node :raw-settings self :raw-settings)
-                    (g/connect settings-node :meta-info self :meta-info)
-                    (g/connect settings-node :resource-settings self :resource-settings)
-                    (g/connect settings-node :setting-errors self :build-errors)
-                    (settings/load-settings-node project self settings-node resource source-value gpcore/basic-meta-info resource-setting-connections))
-      (g/connect project :resource-map self :resource-map))))
+        (g/connect settings-node :_node-id self :nodes)
+        (g/connect settings-node :settings-map self :settings-map)
+        (g/connect settings-node :save-value self :save-value)
+        (g/connect settings-node :form-data self :form-data)
+        (g/connect settings-node :raw-settings self :raw-settings)
+        (g/connect settings-node :meta-info self :meta-info)
+        (g/connect settings-node :resource-settings self :resource-settings)
+        (g/connect settings-node :setting-errors self :build-errors)
+        (settings/load-settings-node project self settings-node resource source-value gpcore/basic-meta-info resource-setting-connections)))))
 
 ;; Test support
 

--- a/editor/src/dev/dev.clj
+++ b/editor/src/dev/dev.clj
@@ -101,7 +101,7 @@
   0)
 
 (defn project []
-  (ffirst (g/targets-of (workspace) :resource-map)))
+  (ffirst (g/targets-of (workspace) :resource-list)))
 
 (defn app-view []
   (ffirst (g/targets-of (project) :selected-node-ids-by-resource-node)))

--- a/editor/src/portal/editor/portal.clj
+++ b/editor/src/portal/editor/portal.clj
@@ -59,7 +59,7 @@
   0)
 
 (defn- project [basis]
-  (some-> (ig/explicit-arcs-by-source basis (workspace) :resource-map)
+  (some-> (ig/explicit-arcs-by-source basis (workspace) :resource-list)
           (first)
           (gt/target-id)))
 

--- a/editor/test/integration/build_test.clj
+++ b/editor/test/integration/build_test.clj
@@ -280,8 +280,8 @@
 (defn- count-exts [paths ext]
   (count (filter #(.endsWith % ext) paths)))
 
-(defn- project-build [project resource-node evaluation-context]
-  (let [workspace (project/workspace project)
+(defn- project-build-impl! [project resource-node evaluation-context]
+  (let [workspace (project/workspace project evaluation-context)
         old-artifact-map (workspace/artifact-map workspace)
         build-results (build/build-project! project resource-node old-artifact-map nil evaluation-context)]
     (when-not (contains? build-results :error)
@@ -289,8 +289,12 @@
       (workspace/etags! workspace (:etags build-results)))
     build-results))
 
-(defn- project-build-artifacts [project resource-node evaluation-context]
-  (let [build-results (project-build project resource-node evaluation-context)
+(defn- project-build! [project resource-node]
+  (g/with-auto-evaluation-context evaluation-context
+    (project-build-impl! project resource-node evaluation-context)))
+
+(defn- project-build-artifacts-impl! [project resource-node evaluation-context]
+  (let [build-results (project-build-impl! project resource-node evaluation-context)
         error-value (:error build-results)]
     (if (nil? error-value)
       (:artifacts build-results)
@@ -306,13 +310,17 @@
              :resource resource
              :error-value error-value}))))))
 
+(defn- project-build-artifacts! [project resource-node]
+  (g/with-auto-evaluation-context evaluation-context
+    (project-build-artifacts-impl! project resource-node evaluation-context)))
+
 (deftest merge-gos
   (testing "Verify equivalent game objects are merged"
     (with-loaded-project project-path
       (doseq [path ["/merge/merge_embed.collection"
                     "/merge/merge_refs.collection"]
               :let [resource-node (test-util/resource-node project path)
-                    build-artifacts (project-build-artifacts project resource-node (g/make-evaluation-context))
+                    build-artifacts (project-build-artifacts! project resource-node)
                     content-by-source (into {} (map #(do [(resource/proj-path (:resource (:resource %))) (content-bytes %)])
                                                     build-artifacts))
                     content-by-target (into {} (map #(do [(resource/proj-path (:resource %)) (content-bytes %)])
@@ -334,7 +342,7 @@
 (deftest merge-textures
   (with-loaded-project "test/resources/build_resource_merging"
     (let [main-collection (test-util/resource-node project "/main/main.collection")
-          build-artifacts (project-build-artifacts project main-collection (g/make-evaluation-context))
+          build-artifacts (project-build-artifacts! project main-collection)
           textures-by-texture-set (into {}
                                         (keep (fn [{:keys [resource] :as artifact}]
                                                 (when (or (= "t.texturesetc" (resource/ext resource)) (= "a.texturesetc" (resource/ext resource)))
@@ -426,7 +434,7 @@
           comp-node (first-source go-node :child-scenes)]
       (testing "Verify equivalent game objects are not merged after being changed in memory"
         (g/transact (g/delete-node comp-node))
-        (let [build-artifacts   (project-build-artifacts project resource-node (g/make-evaluation-context))
+        (let [build-artifacts (project-build-artifacts! project resource-node)
               content-by-target (into {} (map #(do [(resource/proj-path (:resource %)) (content-bytes %)])
                                               build-artifacts))]
           (is (= 2 (count-exts (keys content-by-target) "goc")))
@@ -434,7 +442,7 @@
       (g/undo! (g/node-id->graph-id project))
       (testing "Verify equivalent sprites are not merged after being changed in memory"
         (test-util/prop! comp-node :blend-mode :blend-mode-add)
-        (let [build-artifacts   (project-build-artifacts project resource-node (g/make-evaluation-context))
+        (let [build-artifacts (project-build-artifacts! project resource-node)
               content-by-target (into {} (map #(do [(resource/proj-path (:resource %)) (content-bytes %)])
                                               build-artifacts))]
           (is (= 2 (count-exts (keys content-by-target) "goc")))
@@ -448,17 +456,17 @@
 (deftest build-cached
   (testing "Verify the build cache works as expected"
     (with-loaded-project project-path
-      (let [path          "/game.project"
+      (let [path "/game.project"
             resource-node (test-util/resource-node project path)
             evaluation-context (g/make-evaluation-context)
-            first-time    (measure (project-build-artifacts project resource-node evaluation-context))
+            first-time (measure (project-build-artifacts-impl! project resource-node evaluation-context))
             _ (g/update-cache-from-evaluation-context! evaluation-context)
             evaluation-context (g/make-evaluation-context)
-            second-time   (measure (project-build-artifacts project resource-node evaluation-context))]
+            second-time (measure (project-build-artifacts-impl! project resource-node evaluation-context))]
         (is (< (* 20 second-time) first-time))
         (let [atlas (test-util/resource-node project "/background/background.atlas")]
           (g/transact (g/set-property atlas :margin 10))
-          (let [third-time (measure (project-build-artifacts project resource-node (g/make-evaluation-context)))]
+          (let [third-time (measure (project-build-artifacts-impl! project resource-node (g/make-evaluation-context)))]
             (is (< (* 2 second-time) third-time))))))))
 
 (defn- build-path [workspace proj-path]
@@ -512,11 +520,11 @@
 (deftest build-atlas-with-error
   (testing "Building atlas with error"
     (with-loaded-project project-path
-      (let [path              "/background/background.atlas"
-            resource-node     (test-util/resource-node project path)
-            _                 (g/set-property! resource-node :margin -42)
-            build-results     (project-build project resource-node (g/make-evaluation-context))]
-        (is (instance? internal.graph.error_values.ErrorValue (:error build-results)))))))
+      (let [path "/background/background.atlas"
+            resource-node (test-util/resource-node project path)
+            _ (g/set-property! resource-node :margin -42)
+            build-results (project-build! project resource-node)]
+        (is (g/error-value? (:error build-results)))))))
 
 (deftest build-cubemap
   (testing "Building cubemap"
@@ -654,7 +662,7 @@
   (with-loaded-project
     (let [path              "/gui/scene.gui"
           resource-node     (test-util/resource-node project path)
-          build-artifacts   (project-build-artifacts project resource-node (g/make-evaluation-context))
+          build-artifacts   (project-build-artifacts! project resource-node)
           content-by-source (into {} (map #(do [(resource/proj-path (:resource (:resource %))) (content-bytes %)]) build-artifacts))
           content-by-target (into {} (map #(do [(resource/proj-path (:resource %)) (content-bytes %)]) build-artifacts))
           content           (get content-by-source path)
@@ -712,8 +720,8 @@
           atlas-path          "/background/background.atlas"
           atlas-resource-node (test-util/resource-node project atlas-path)
           _                   (g/set-property! atlas-resource-node :inner-padding -42)
-          build-results       (project-build project resource-node (g/make-evaluation-context))]
-      (is (instance? internal.graph.error_values.ErrorValue (:error build-results))))))
+          build-results       (project-build! project resource-node)]
+      (is (g/error-value? (:error build-results))))))
 
 (defn- check-project-setting [properties path expected-value]
   (let [value (settings-core/get-setting properties path)]
@@ -722,7 +730,7 @@
 (deftest build-game-project-with-buildtime-conversion
   (with-loaded-project "test/resources/buildtime_conversion"
     (let [game-project (test-util/resource-node project "/game.project")]
-     (let [br (project-build project game-project (g/make-evaluation-context))]
+     (let [br (project-build! project game-project)]
        (is (not (contains? br :error)))
        (with-open [r (io/reader (build-path workspace "game.projectc"))]
          (let [built-properties (settings-core/parse-settings r)]
@@ -736,7 +744,7 @@
 (deftest build-game-project-properties
   (with-loaded-project "test/resources/game_project_properties"
                        (let [game-project (test-util/resource-node project "/game.project")]
-                         (let [br (project-build project game-project (g/make-evaluation-context))]
+                         (let [br (project-build! project game-project)]
                            (is (not (contains? br :error)))
                            (with-open [r (io/reader (build-path workspace "game.projectc"))]
                              (let [built-properties (settings-core/parse-settings r)]
@@ -776,10 +784,10 @@
   (let [path-list (string/split path #"/")]
     `(let [old-value# (game-project/get-setting ~'game-project ~path-list)]
        (game-project/set-setting! ~'game-project ~path-list ~value)
-           (try
-             ~@body
-             (finally
-               (game-project/set-setting! ~'game-project ~path-list old-value#))))))
+       (try
+         ~@body
+         (finally
+           (game-project/set-setting! ~'game-project ~path-list old-value#))))))
 
 (defn- check-file-contents [workspace specs]
   (doseq [[path content] specs]
@@ -791,29 +799,29 @@
   (with-loaded-project "test/resources/custom_resources_project"
     (let [game-project (test-util/resource-node project "/game.project")]
       (with-setting "project/custom_resources" "root.stuff"
-        (project-build project game-project (g/make-evaluation-context))
+        (project-build! project game-project)
         (check-file-contents workspace [["root.stuff" "root.stuff"]])
       (with-setting "project/custom_resources" "/root.stuff"
-        (project-build project game-project (g/make-evaluation-context))
+        (project-build! project game-project)
         (check-file-contents workspace [["root.stuff" "root.stuff"]])
       (with-setting "project/custom_resources" "assets"
-        (project-build project game-project (g/make-evaluation-context))
+        (project-build! project game-project)
         (check-file-contents workspace
                              [["assets/some.stuff" "some.stuff"]
                               ["assets/some2.stuff" "some2.stuff"]]))
       (with-setting "project/custom_resources" "/assets"
-        (project-build project game-project (g/make-evaluation-context))
+        (project-build! project game-project)
         (check-file-contents workspace
                              [["assets/some.stuff" "some.stuff"]
                               ["assets/some2.stuff" "some2.stuff"]]))
       (with-setting "project/custom_resources" "assets, root.stuff"
-        (project-build project game-project (g/make-evaluation-context))
+        (project-build! project game-project)
         (check-file-contents workspace
                              [["assets/some.stuff" "some.stuff"]
                               ["assets/some2.stuff" "some2.stuff"]
                               ["root.stuff" "root.stuff"]]))
       (with-setting "project/custom_resources" "assets, root.stuff, /more_assets/"
-        (project-build project game-project (g/make-evaluation-context))
+        (project-build! project game-project)
         (check-file-contents workspace
                              [["assets/some.stuff" "some.stuff"]
                               ["assets/some2.stuff" "some2.stuff"]
@@ -821,16 +829,34 @@
                               ["more_assets/some_more.stuff" "some_more.stuff"]
                               ["more_assets/some_more2.stuff" "some_more2.stuff"]]))
       (with-setting "project/custom_resources" ""
-        (project-build project game-project (g/make-evaluation-context))
+        (project-build! project game-project)
         (doseq [path ["assets/some.stuff" "assets/some2.stuff"
                       "root.stuff"
                       "more_assets/some_more.stuff" "more_assets/some_more2.stuff"]]
           (is (false? (.exists (build-path workspace path))))))
       (with-setting "project/custom_resources" "nonexistent_path"
-        (let [build-error (:error (project-build project game-project (g/make-evaluation-context)))
+        (let [build-error (:error (project-build! project game-project))
               error-message (some :message (tree-seq :causes :causes build-error))]
           (is (g/error? build-error))
-          (is (= "Custom resource not found: '/nonexistent_path'" error-message)))))))))
+          (is (= "Custom resources directory not found: '/nonexistent_path'" error-message)))))))))
+
+(deftest build-with-ssl-certificates
+  (with-loaded-project "test/resources/custom_resources_project"
+    (let [game-project (test-util/resource-node project "/game.project")]
+      (with-setting "network/ssl_certificates" nil
+        (project-build! project game-project)
+        (is (false? (.exists (build-path workspace "assets/some.stuff"))))
+        (is (false? (.exists (build-path workspace "assets/some2.stuff")))))
+      (with-setting "network/ssl_certificates" (workspace/find-resource workspace "/assets")
+        (project-build! project game-project)
+        (check-file-contents workspace
+                             [["assets/some.stuff" "some.stuff"]
+                              ["assets/some2.stuff" "some2.stuff"]]))
+      (with-setting "network/ssl_certificates" (workspace/file-resource workspace "/nonexistent_path")
+        (let [build-error (:error (project-build! project game-project))
+              error-message (some :message (tree-seq :causes :causes build-error))]
+          (is (g/error? build-error))
+          (is (= "SSL certificates directory not found: '/nonexistent_path'" error-message)))))))
 
 (deftest custom-resources-cached
   (testing "Check custom resources are only rebuilt when source has changed"
@@ -839,13 +865,30 @@
             project (test-util/setup-project! workspace)
             game-project (test-util/resource-node project "/game.project")]
         (with-setting "project/custom_resources" "assets"
-          (project-build project game-project (g/make-evaluation-context))
+          (project-build! project game-project)
           (let [initial-some-mtime (mtime (build-path workspace "assets/some.stuff"))
                 initial-some2-mtime (mtime (build-path workspace "assets/some2.stuff"))]
             (Thread/sleep 1000)
             (spit (abs-project-path workspace "assets/some.stuff") "new stuff")
             (workspace/resource-sync! workspace)
-            (project-build project game-project (g/make-evaluation-context))
+            (project-build! project game-project)
+            (is (not (= initial-some-mtime (mtime (build-path workspace "assets/some.stuff")))))
+            (is (= initial-some2-mtime (mtime (build-path workspace "assets/some2.stuff"))))))))))
+
+(deftest ssl-certificates-cached
+  (testing "Check SSL certificates are only rebuilt when source has changed"
+    (with-clean-system
+      (let [workspace (test-util/setup-scratch-workspace! world "test/resources/custom_resources_project")
+            project (test-util/setup-project! workspace)
+            game-project (test-util/resource-node project "/game.project")]
+        (with-setting "network/ssl_certificates" (workspace/find-resource workspace "/assets")
+          (project-build! project game-project)
+          (let [initial-some-mtime (mtime (build-path workspace "assets/some.stuff"))
+                initial-some2-mtime (mtime (build-path workspace "assets/some2.stuff"))]
+            (Thread/sleep 1000)
+            (spit (abs-project-path workspace "assets/some.stuff") "new stuff")
+            (workspace/resource-sync! workspace)
+            (project-build! project game-project)
             (is (not (= initial-some-mtime (mtime (build-path workspace "assets/some.stuff")))))
             (is (= initial-some2-mtime (mtime (build-path workspace "assets/some2.stuff"))))))))))
 
@@ -855,7 +898,7 @@
           game-project   (test-util/resource-node project path)
           dependency-url "http://localhost:1234/dependency.zip"]
       (game-project/set-setting! game-project ["project" "dependencies"] dependency-url)
-      (let [build-artifacts      (project-build-artifacts project game-project (g/make-evaluation-context))
+      (let [build-artifacts      (project-build-artifacts! project game-project)
             content-by-source    (into {} (keep #(when-let [r (:resource (:resource %))]
                                                    [(resource/proj-path r) (content-bytes %)]))
                                        build-artifacts)
@@ -868,19 +911,19 @@
     (let [workspace (test-util/setup-scratch-workspace! world "test/resources/collision_project")
           project (test-util/setup-project! workspace)
           game-project (test-util/resource-node project "/game.project")]
-      (let [br (project-build project game-project (g/make-evaluation-context))]
+      (let [br (project-build! project game-project)]
         (is (not (contains? br :error))))
       (testing "Removing an unreferenced collisionobject should not break the build"
         (let [f (File. (workspace/project-directory workspace) "knight.collisionobject")]
           (fs/delete-file! f)
           (workspace/resource-sync! workspace))
-        (let [br (project-build project game-project (g/make-evaluation-context))]
+        (let [br (project-build! project game-project)]
           (is (not (contains? br :error))))))))
 
 (deftest inexact-path-casing-produces-build-error
   (with-loaded-project "test/resources/inexact_path_casing_project"
     (let [game-project-node (test-util/resource-node project "/game.project")
-          build-error (:error (project-build project game-project-node (g/make-evaluation-context)))
+          build-error (:error (project-build! project game-project-node))
           error-message (some :message (tree-seq :causes :causes build-error))]
       (is (g/error? build-error))
       (is (= (localization/message "error.resource-not-found" {"resource" "/MAIN/BUTTON_CLOUDY.png"}) error-message)))))
@@ -904,9 +947,9 @@
     (let [game-project (test-util/resource-node project "/game.project")]
       (testing "paged atlas with 9 pages fails build when exclude_gles_sm100 is false"
         (with-setting "shader/exclude_gles_sm100" false
-          (let [build-results (project-build project game-project (g/make-evaluation-context))]
+          (let [build-results (project-build! project game-project)]
             (is (g/error? (:error build-results))))))
       (testing "paged atlas with 9 pages passes build when exclude_gles_sm100 is true"
         (with-setting "shader/exclude_gles_sm100" true
-          (let [build-results (project-build project game-project (g/make-evaluation-context))]
+          (let [build-results (project-build! project game-project)]
             (is (not (g/error? (:error build-results))))))))))

--- a/editor/test/integration/override_transfer_test.clj
+++ b/editor/test/integration/override_transfer_test.clj
@@ -45,7 +45,8 @@
    (g/with-auto-evaluation-context evaluation-context
      (select-save-values project proj-path-predicate evaluation-context)))
   ([project proj-path-predicate evaluation-context]
-   (let [resources-by-proj-path (g/valid-node-value project :resource-map evaluation-context)
+   (let [workspace (g/valid-node-value project :workspace evaluation-context)
+         resources-by-proj-path (g/valid-node-value workspace :resource-map evaluation-context)
          resource-nodes-by-proj-path (g/valid-node-value project :nodes-by-resource-path evaluation-context)]
      (coll/into-> resource-nodes-by-proj-path (sorted-map)
        (keep (fn [[proj-path resource-node-id]]


### PR DESCRIPTION
A regression was introduced in #12116 that caused custom resources to not refresh between builds in the editor. This PR addresses the issue and updates the build tests that failed to catch the problem.

Fixes #12126.

### Technical changes
* The build tests have been updated to cache graph evaluations in the system cache, just like the editor does. The fact that we were bypassing the system cache made it possible for this regression to slip through in the first place.
* There is now an explicit connection between the `Workspace` `resource-snapshot` and the `GameProjectNode` that emits `build-targets` for the custom resources. This data dependency already existed in the graph before the regression was introduced in #12116. In the old code, the `Workspace` `resource-map` output (used by the `custom-build-targets` output of `GameProjectNode`) depended on `resource-snapshot`. The new code introduced in #12116 only invalidates the `resource-map` output if there are actual changes to the produced `resource-map` resulting from changes to the `resource-snapshot`. With this PR, the data dependency on the `resource-snapshot` is made explicit.
* The `resource-map` `passthrough` output on `Project` has been removed, and all use sites have been updated to use the `Workspace` `resource-map` output instead. This was done to avoid having the `Project` node also having to `passthrough` the `resource-snapshot` from the `Workspace`.
* The `ErrorValue` messages resulting from a faulty `network.ssl_certificates` setting now differs from the messages resulting from faulty `project.custom_resources`.