### PR TITLE
Store frustum has in render items to avoid already calculated culling

### DIFF
--- a/engine/render/src/dmsdk/render/render.h
+++ b/engine/render/src/dmsdk/render/render.h
@@ -239,11 +239,11 @@ namespace dmRender
      * Each callback then represents a draw call, and will register a RenderObject
      * @name RenderListEntry
      * @param m_WorldPosition [type: dmVMath::Point3] the world position of the object
-     * @param m_FrustumHash [type: dmhash_t] The hash of the frustum matrix used for frustum culling
+     * @param m_UserData [type: uint64_t] user data (available in the render dispatch callback)
      * @param m_Order [type: uint32_t] the order to sort on (used if m_MajorOrder != RENDER_ORDER_WORLD)
      * @param m_BatchKey [type: uint32_t] the batch key to sort on (note: only 48 bits are currently used by renderer)
      * @param m_TagListKey [type: uint32_t] the key to the list of material tags
-     * @param m_UserData [type: uint64_t] user data (available in the render dispatch callback)
+     * @param m_FrustumHash [type: uint32_t] Last combined frustum cull key (note: engine internal use only!)
      * @param m_MinorOrder [type: uint32_t:4] used to sort within a batch
      * @param m_MajorOrder [type: uint32_t:2] If RENDER_ORDER_WORLD, then sorting is done based on the world position.
                                               Otherwise the sorting uses the m_Order value directly.
@@ -253,11 +253,11 @@ namespace dmRender
     struct RenderListEntry
     {
         dmVMath::Point3 m_WorldPosition;
-        dmhash_t m_FrustumHash;
         uint64_t m_UserData; // E.g. component type instance pointer
         uint32_t m_Order;
         uint32_t m_BatchKey;
         uint32_t m_TagListKey;
+        uint32_t m_FrustumHash;
         uint32_t m_MinorOrder : 4;
         uint32_t m_MajorOrder : 2;
         uint32_t m_Dispatch   : 8;

--- a/engine/render/src/dmsdk/render/render.h
+++ b/engine/render/src/dmsdk/render/render.h
@@ -239,6 +239,7 @@ namespace dmRender
      * Each callback then represents a draw call, and will register a RenderObject
      * @name RenderListEntry
      * @param m_WorldPosition [type: dmVMath::Point3] the world position of the object
+     * @param m_FrustumHash [type: dmhash_t] The hash of the frustum matrix used for frustum culling
      * @param m_Order [type: uint32_t] the order to sort on (used if m_MajorOrder != RENDER_ORDER_WORLD)
      * @param m_BatchKey [type: uint32_t] the batch key to sort on (note: only 48 bits are currently used by renderer)
      * @param m_TagListKey [type: uint32_t] the key to the list of material tags
@@ -252,6 +253,7 @@ namespace dmRender
     struct RenderListEntry
     {
         dmVMath::Point3 m_WorldPosition;
+        dmhash_t m_FrustumHash;
         uint64_t m_UserData; // E.g. component type instance pointer
         uint32_t m_Order;
         uint32_t m_BatchKey;

--- a/engine/render/src/render/render.cpp
+++ b/engine/render/src/render/render.cpp
@@ -55,6 +55,7 @@ namespace dmRender
     const dmhash_t VERTEX_STREAM_ANIMATION_DATA       = dmHashString64("animation_data");
     const dmhash_t VERTEX_STREAM_TEXTURE_TRANSFORM_2D = dmHashString64("texture_transform_2d");
     const dmhash_t SAMPLER_POSE_MATRIX_CACHE          = dmHashString64("pose_matrix_cache");
+    const dmhash_t FRUSTUM_HASH_UNINITIALIZED         = 0xFFFFFFFF;
 
     StencilTestParams::StencilTestParams() {
         Init();
@@ -207,7 +208,6 @@ namespace dmRender
         render_context->m_RenderListSortIndices.SetSize(0);
         render_context->m_RenderListDispatch.SetSize(0);
         render_context->m_RenderListRanges.SetSize(0);
-        render_context->m_FrustumHash = 0xFFFFFFFF; // trigger a first recalculation each frame
     }
 
     HRenderListDispatch RenderListMakeDispatch(HRenderContext render_context, RenderListDispatchFn dispatch_fn, RenderListVisibilityFn visibility_fn, void* user_data)
@@ -234,6 +234,15 @@ namespace dmRender
         return RenderListMakeDispatch(render_context, dispatch_fn, 0, user_data);
     }
 
+    static void SetVisibility(uint32_t count, RenderListEntry* entries, Visibility visibility, uint64_t frustum_hash)
+    {
+        for (uint32_t i = 0; i < count; ++i)
+        {
+            entries[i].m_Visibility = visibility;
+            entries[i].m_FrustumHash = frustum_hash;
+        }
+    }
+
     // Allocate a buffer (from the array) with room for 'entries' entries.
     //
     // NOTE: Pointer might go invalid after a consecutive call to RenderListAlloc if reallocation
@@ -252,10 +261,11 @@ namespace dmRender
         uint32_t size = render_list.Size();
         render_list.SetSize(size + entries);
 
-        // If we push new items after the last frustum culling, we need to reevaluate it
-        render_context->m_FrustumHash = 0xFFFFFFFF;
+        // If we push new items after the last frustum culling, we need to reevaluate them.
+        RenderListEntry* start = render_list.Begin() + size;
+        SetVisibility(entries, start, dmRender::VISIBILITY_NONE, FRUSTUM_HASH_UNINITIALIZED);
 
-        return (render_list.Begin() + size);
+        return start;
     }
 
     // Submit a range of entries (pointers must be from a range allocated by RenderListAlloc, and not between two alloc calls).
@@ -708,15 +718,7 @@ namespace dmRender
         return a->m_Dispatch == b->m_Dispatch;
     }
 
-    static void SetVisibility(uint32_t count, RenderListEntry* entries, Visibility visibility)
-    {
-        for (uint32_t i = 0; i < count; ++i)
-        {
-            entries[i].m_Visibility = visibility;
-        }
-    }
-
-    static void FrustumCulling(HRenderContext context, const dmIntersection::Frustum& frustum)
+    static void FrustumCulling(HRenderContext context, const dmIntersection::Frustum& frustum, dmhash_t frustum_hash)
     {
         DM_PROFILE("FrustumCulling");
 
@@ -728,19 +730,42 @@ namespace dmRender
         while(iter.Next())
         {
             RenderListEntry* batch_start = iter.Begin();
+            uint32_t batch_length = iter.Length();
 
             const RenderListDispatch* d = &context->m_RenderListDispatch[batch_start->m_Dispatch];
             if (!d->m_VisibilityFn)
             {
-                SetVisibility(iter.Length(), iter.Begin(), dmRender::VISIBILITY_FULL);
+                SetVisibility(batch_length, batch_start, dmRender::VISIBILITY_FULL, FRUSTUM_HASH_UNINITIALIZED);
             }
-            else {
+            else
+            {
                 RenderListVisibilityParams params;
                 params.m_Frustum = &frustum;
                 params.m_UserData = d->m_UserData;
-                params.m_Entries = batch_start;
-                params.m_NumEntries = iter.Length();
-                d->m_VisibilityFn(params);
+
+                uint32_t i =0;
+                while(i < batch_length)
+                {
+                    // Skip over already calculated entries
+                    while(i < batch_length && batch_start[i].m_FrustumHash == frustum_hash)
+                    {
+                        i++;
+                    }
+
+                    // Calculate start/end of entries to calculate culling for
+                    uint32_t sub_batch_start = i;
+                    while(i < batch_length && batch_start[i].m_FrustumHash != frustum_hash)
+                    {
+                        // Update hash here since we are already looping over the entries
+                        batch_start[i].m_FrustumHash = frustum_hash;
+                        i++;
+                    }
+
+                    // Execute culling for this sub-batch
+                    params.m_Entries = batch_start + sub_batch_start;
+                    params.m_NumEntries = i - sub_batch_start;
+                    d->m_VisibilityFn(params);
+                }
             }
         }
     }
@@ -923,24 +948,24 @@ namespace dmRender
             SortRenderList(context);
         }
 
-        dmhash_t frustum_hash = frustum_matrix ? dmHashBuffer64((const void*) frustum_matrix, 16*sizeof(float)) : 0;
+        dmhash_t frustum_hash = 0;
 
-        if (context->m_FrustumHash != frustum_hash)
+        if (frustum_matrix)
         {
-            // We use this to avoid calling the culling functions more than once in a row
-            context->m_FrustumHash = frustum_hash;
+            HashState64 frustum_hash_state;
+            dmHashInit64(&frustum_hash_state, false);
+            dmHashUpdateBuffer64(&frustum_hash_state, frustum_matrix, sizeof(dmVMath::Matrix4));
+            dmHashUpdateBuffer64(&frustum_hash_state, &frustum_num_planes, sizeof(frustum_num_planes));
+            frustum_hash = dmHashFinal64(&frustum_hash_state);
 
-            if (frustum_matrix)
-            {
-                dmIntersection::Frustum frustum;
-                dmIntersection::CreateFrustumFromMatrix(*frustum_matrix, true, (int) frustum_num_planes, frustum);
-                FrustumCulling(context, frustum);
-            }
-            else
-            {
-                // Reset the visibility
-                SetVisibility(context->m_RenderList.Size(), context->m_RenderList.Begin(), dmRender::VISIBILITY_FULL);
-            }
+            dmIntersection::Frustum frustum;
+            dmIntersection::CreateFrustumFromMatrix(*frustum_matrix, true, (int) frustum_num_planes, frustum);
+            FrustumCulling(context, frustum, frustum_hash);
+        }
+        else
+        {
+            // Reset the visibility
+            SetVisibility(context->m_RenderList.Size(), context->m_RenderList.Begin(), dmRender::VISIBILITY_FULL, FRUSTUM_HASH_UNINITIALIZED);
         }
 
         SortOrder effective_sort_order = (sort_order == SORT_UNSPECIFIED) ? SORT_BACK_TO_FRONT : sort_order;

--- a/engine/render/src/render/render.cpp
+++ b/engine/render/src/render/render.cpp
@@ -55,7 +55,7 @@ namespace dmRender
     const dmhash_t VERTEX_STREAM_ANIMATION_DATA       = dmHashString64("animation_data");
     const dmhash_t VERTEX_STREAM_TEXTURE_TRANSFORM_2D = dmHashString64("texture_transform_2d");
     const dmhash_t SAMPLER_POSE_MATRIX_CACHE          = dmHashString64("pose_matrix_cache");
-    const dmhash_t FRUSTUM_HASH_UNINITIALIZED         = 0xFFFFFFFF;
+    const dmhash_t FRUSTUM_HASH_UNINITIALIZED         = 0;
 
     StencilTestParams::StencilTestParams() {
         Init();
@@ -234,15 +234,6 @@ namespace dmRender
         return RenderListMakeDispatch(render_context, dispatch_fn, 0, user_data);
     }
 
-    static void SetVisibility(uint32_t count, RenderListEntry* entries, Visibility visibility, uint64_t frustum_hash)
-    {
-        for (uint32_t i = 0; i < count; ++i)
-        {
-            entries[i].m_Visibility = visibility;
-            entries[i].m_FrustumHash = frustum_hash;
-        }
-    }
-
     // Allocate a buffer (from the array) with room for 'entries' entries.
     //
     // NOTE: Pointer might go invalid after a consecutive call to RenderListAlloc if reallocation
@@ -263,7 +254,7 @@ namespace dmRender
 
         // If we push new items after the last frustum culling, we need to reevaluate them.
         RenderListEntry* start = render_list.Begin() + size;
-        SetVisibility(entries, start, dmRender::VISIBILITY_NONE, FRUSTUM_HASH_UNINITIALIZED);
+        memset(start, 0, entries * sizeof(RenderListEntry));
 
         return start;
     }
@@ -718,7 +709,16 @@ namespace dmRender
         return a->m_Dispatch == b->m_Dispatch;
     }
 
-    static void FrustumCulling(HRenderContext context, const dmIntersection::Frustum& frustum, dmhash_t frustum_hash)
+    static void SetVisibility(uint32_t count, RenderListEntry* entries, Visibility visibility, uint32_t frustum_hash)
+    {
+        for (uint32_t i = 0; i < count; ++i)
+        {
+            entries[i].m_Visibility = visibility;
+            entries[i].m_FrustumHash = frustum_hash;
+        }
+    }
+
+    static void FrustumCulling(HRenderContext context, const dmIntersection::Frustum& frustum, uint32_t frustum_hash)
     {
         DM_PROFILE("FrustumCulling");
 
@@ -948,15 +948,14 @@ namespace dmRender
             SortRenderList(context);
         }
 
-        dmhash_t frustum_hash = 0;
+        uint32_t frustum_hash = 0;
 
         if (frustum_matrix)
         {
-            HashState64 frustum_hash_state;
-            dmHashInit64(&frustum_hash_state, false);
-            dmHashUpdateBuffer64(&frustum_hash_state, frustum_matrix, sizeof(dmVMath::Matrix4));
-            dmHashUpdateBuffer64(&frustum_hash_state, &frustum_num_planes, sizeof(frustum_num_planes));
-            frustum_hash = dmHashFinal64(&frustum_hash_state);
+            uint8_t frustum_key_buffer[sizeof(Matrix4) + sizeof(FrustumPlanes)];
+            memcpy(frustum_key_buffer, frustum_matrix, sizeof(Matrix4));
+            memcpy(frustum_key_buffer + sizeof(Matrix4), &frustum_num_planes, sizeof(frustum_num_planes));
+            frustum_hash = dmHashBuffer32(frustum_key_buffer, (uint32_t)sizeof(frustum_key_buffer));
 
             dmIntersection::Frustum frustum;
             dmIntersection::CreateFrustumFromMatrix(*frustum_matrix, true, (int) frustum_num_planes, frustum);

--- a/engine/render/src/render/render_private.h
+++ b/engine/render/src/render/render_private.h
@@ -317,7 +317,7 @@ namespace dmRender
         dmArray<uint32_t>           m_RenderListSortIndices;
         dmArray<RenderListRange>    m_RenderListRanges;         // Maps tagmask to a range in the (sorted) render list
         dmArray<TextureBinding>     m_TextureBindTable;
-        dmhash_t                    m_FrustumHash;
+        //dmhash_t                    m_FrustumHash;
 
         dmHashTable32<MaterialTagList>  m_MaterialTagLists;
 

--- a/engine/render/src/test/test_render.cpp
+++ b/engine/render/src/test/test_render.cpp
@@ -1155,6 +1155,11 @@ TEST_F(dmRenderTest, TestDefaultSamplerFilters)
 }
 
 
+static void NoopDrawDispatch(dmRender::RenderListDispatchParams const & params)
+{
+    (void) params;
+}
+
 static void TestDrawVisibilityDispatch(dmRender::RenderListDispatchParams const & params)
 {
     TestDrawDispatchCtx *ctx = (TestDrawDispatchCtx*) params.m_UserData;
@@ -1307,6 +1312,101 @@ TEST_F(dmRenderTest, TestRenderListCulling)
         ASSERT_GT(ctx.m_BatchCalls, 2);
         ASSERT_EQ(ctx.m_EntriesRendered, num_rendered[c]);
         ASSERT_EQ(ctx.m_EndCalls, 2);
+    }
+}
+
+struct FrustumCullDedupTestCtx
+{
+    uint32_t m_VisibilityEntryProcessCount;
+};
+
+static void CountingTestDrawVisibility(dmRender::RenderListVisibilityParams const &params)
+{
+    FrustumCullDedupTestCtx* ctx = (FrustumCullDedupTestCtx*)params.m_UserData;
+    ASSERT_NE(ctx, (FrustumCullDedupTestCtx*)0);
+    ctx->m_VisibilityEntryProcessCount += params.m_NumEntries;
+    TestDrawVisibility(params);
+}
+
+TEST_F(dmRenderTest, TestRenderListFrustumCullDeduplication)
+{
+    dmVMath::Matrix4 view = dmVMath::Matrix4::identity();
+    dmVMath::Matrix4 proj = dmVMath::Matrix4::orthographic(0.0f, WIDTH, 0.0f, HEIGHT, -1.0f, 1.0f);
+    dmRender::SetViewMatrix(m_Context, view);
+    dmRender::SetProjectionMatrix(m_Context, proj);
+
+    dmVMath::Matrix4 view_proj = proj * view;
+    dmRender::FrustumOptions frustum_options;
+    frustum_options.m_Matrix = view_proj;
+    frustum_options.m_NumPlanes = dmRender::FRUSTUM_PLANES_SIDES;
+
+    FrustumCullDedupTestCtx test_ctx;
+    memset(&test_ctx, 0, sizeof(test_ctx));
+
+    const uint32_t n = 16;
+    dmRender::RenderListBegin(m_Context);
+    uint8_t dispatch = dmRender::RenderListMakeDispatch(m_Context, NoopDrawDispatch, CountingTestDrawVisibility, &test_ctx);
+    dmRender::RenderListEntry* out = dmRender::RenderListAlloc(m_Context, n);
+    for (uint32_t i = 0; i < n; ++i)
+    {
+        dmRender::RenderListEntry& entry = out[i];
+        entry.m_WorldPosition = Point3((float)i * 10.f, 0.f, (float)(i + 1));
+        entry.m_MajorOrder = dmRender::RENDER_ORDER_WORLD;
+        entry.m_MinorOrder = 0;
+        entry.m_TagListKey = 0;
+        entry.m_Order = i + 1;
+        entry.m_BatchKey = 1;
+        entry.m_Dispatch = dispatch;
+        entry.m_UserData = 0;
+    }
+
+    dmRender::RenderListSubmit(m_Context, out, out + n);
+    dmRender::RenderListEnd(m_Context);
+
+    // First frustum draw: every entry is uncached, visibility runs for all n entries.
+    dmRender::DrawRenderList(m_Context, 0, 0, &frustum_options, dmRender::SORT_BACK_TO_FRONT);
+    const uint32_t after_first = test_ctx.m_VisibilityEntryProcessCount;
+    ASSERT_EQ(after_first, n);
+
+    // Same frustum and list size: culling is skipped for existing entries (counter unchanged).
+    dmRender::DrawRenderList(m_Context, 0, 0, &frustum_options, dmRender::SORT_BACK_TO_FRONT);
+    ASSERT_EQ(test_ctx.m_VisibilityEntryProcessCount, after_first);
+
+    const uint32_t k = 4;
+    dmRender::RenderListEntry* extra = dmRender::RenderListAlloc(m_Context, k);
+    for (uint32_t i = 0; i < k; ++i)
+    {
+        dmRender::RenderListEntry& entry = extra[i];
+        entry.m_WorldPosition = Point3((float)(n + i) * 10.f, 100.f, (float)(n + i + 1));
+        entry.m_MajorOrder = dmRender::RENDER_ORDER_WORLD;
+        entry.m_MinorOrder = 0;
+        entry.m_TagListKey = 0;
+        entry.m_Order = n + i + 1;
+        entry.m_BatchKey = 1;
+        entry.m_Dispatch = dispatch;
+        entry.m_UserData = 0;
+    }
+    dmRender::RenderListSubmit(m_Context, extra, extra + k);
+
+    // List grew: only the k new entries run visibility; original n stay skipped (counter += k).
+    dmRender::DrawRenderList(m_Context, 0, 0, &frustum_options, dmRender::SORT_BACK_TO_FRONT);
+    ASSERT_EQ(test_ctx.m_VisibilityEntryProcessCount, after_first + k);
+
+    frustum_options.m_NumPlanes = dmRender::FRUSTUM_PLANES_ALL;
+    // Different frustum key (plane count): all n+k entries must be culled again.
+    dmRender::DrawRenderList(m_Context, 0, 0, &frustum_options, dmRender::SORT_BACK_TO_FRONT);
+    const uint32_t total_after_plane_change = (n + k) * 2;
+    ASSERT_EQ(test_ctx.m_VisibilityEntryProcessCount, total_after_plane_change);
+
+    // No frustum: every render list entry is forced to VISIBILITY_FULL (asserted below).
+    dmRender::DrawRenderList(m_Context, 0, 0, 0, dmRender::SORT_BACK_TO_FRONT);
+
+    dmRender::RenderContext* rc = (dmRender::RenderContext*)m_Context;
+    const uint32_t total_entries = n + k;
+    ASSERT_EQ(rc->m_RenderList.Size(), total_entries);
+    for (uint32_t i = 0; i < total_entries; ++i)
+    {
+        ASSERT_EQ(rc->m_RenderList[i].m_Visibility, dmRender::VISIBILITY_FULL);
     }
 }
 


### PR DESCRIPTION
The amount of time spent on frustum culling has been reduced when issuing multiple `render.draw` calls during a single frame. 

Fixes #8088