### PR TITLE
Optimize sprite culling

### DIFF
--- a/engine/gamesys/src/gamesys/components/comp_sprite.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sprite.cpp
@@ -167,13 +167,19 @@ namespace dmGameSystem
         uint8_t                     m_NumTextures; // cached value from m_Resource->m_NumTextures
     };
 
+    struct SpriteCullingInfo
+    {
+        float m_Position[3];
+        float m_Radius;
+    };
+
     struct SpriteWorld
     {
         AnimationDataCache                  m_AnimationDataCache;
         dmObjectPool<SpriteComponent>       m_Components;
         DynamicAttributePool                m_DynamicVertexAttributePool;
         dmArray<dmRender::RenderObject*>    m_RenderObjects;
-        dmArray<float>                      m_CullingInfo; // array stores sprite center + radius as 4 floats: x,y,z,radius
+        dmArray<SpriteCullingInfo>          m_CullingInfo;
         // We currently assume the vertex format uses 2-tuple UVs
         dmArray<float>                      m_ScratchUVs[MAX_TEXTURE_COUNT];
         dmArray<Vector4>                    m_ScratchPositionWorld;
@@ -251,8 +257,8 @@ namespace dmGameSystem
         SpriteWorld* sprite_world = new SpriteWorld();
         uint32_t comp_count = dmMath::Min(params.m_MaxComponentInstances, sprite_context->m_MaxSpriteCount);
         sprite_world->m_Components.SetCapacity(comp_count);
-        sprite_world->m_CullingInfo.SetCapacity(comp_count * 4);
-        sprite_world->m_CullingInfo.SetSize(comp_count * 4);
+        sprite_world->m_CullingInfo.SetCapacity(comp_count);
+        sprite_world->m_CullingInfo.SetSize(comp_count);
         sprite_world->m_AnimationDataCache.m_Cache.SetCapacity(MINIMUM_CACHE_CAPACITY);
         dmDoubleLinkedList::ListInit(&sprite_world->m_AnimationDataCache.m_LRU);
         memset(sprite_world->m_Components.GetRawObjects().Begin(), 0, sizeof(SpriteComponent) * comp_count);
@@ -2056,10 +2062,10 @@ namespace dmGameSystem
             Point3 pivot_scaled(-component->m_PivotX * size.getX(), -component->m_PivotY * size.getY(), 0.f);
             Vector3 world_pos = (component->m_World * pivot_scaled).getXYZ();
 
-            world->m_CullingInfo[i * 4] = world_pos.getX();
-            world->m_CullingInfo[i * 4 + 1] = world_pos.getY();
-            world->m_CullingInfo[i * 4 + 2] = world_pos.getZ();
-            world->m_CullingInfo[i * 4 + 3] = radius_sq;
+            world->m_CullingInfo[i].m_Position[0] = world_pos.getX();
+            world->m_CullingInfo[i].m_Position[1] = world_pos.getY();
+            world->m_CullingInfo[i].m_Position[2] = world_pos.getZ();
+            world->m_CullingInfo[i].m_Radius = radius_sq;
         }
         return dmGameObject::UPDATE_RESULT_OK;
     }
@@ -2069,16 +2075,16 @@ namespace dmGameSystem
         DM_PROFILE("Sprite");
 
         SpriteWorld* sprite_world = (SpriteWorld*)params.m_UserData;
-        const float* infos = sprite_world->m_CullingInfo.Begin();
+        const SpriteCullingInfo* infos = sprite_world->m_CullingInfo.Begin();
 
         const dmIntersection::Frustum frustum = *params.m_Frustum;
         uint32_t num_entries = params.m_NumEntries;
         for (uint32_t i = 0; i < num_entries; ++i)
         {
             dmRender::RenderListEntry* entry = &params.m_Entries[i];
-            uint32_t component_idx = entry->m_UserData;
-            Vector4 pos(infos[component_idx * 4], infos[component_idx * 4 + 1], infos[component_idx * 4 + 2], 1.0f);
-            bool intersect = dmIntersection::TestFrustumSphereSq(frustum, pos, infos[component_idx * 4 + 3]);
+            const SpriteCullingInfo& culling_info = infos[entry->m_UserData];
+            Vector4 pos(culling_info.m_Position[0], culling_info.m_Position[1], culling_info.m_Position[2], 1.0f);
+            bool intersect = dmIntersection::TestFrustumSphereSq(frustum, pos, culling_info.m_Radius);
             entry->m_Visibility = intersect ? dmRender::VISIBILITY_FULL : dmRender::VISIBILITY_NONE;
         }
     }

--- a/engine/gamesys/src/gamesys/components/comp_sprite.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sprite.cpp
@@ -147,6 +147,8 @@ namespace dmGameSystem
         /// Timer in local space: [0,1]
         float                       m_AnimTimer;
         float                       m_PlaybackRate;
+        float                       m_PivotX;
+        float                       m_PivotY;
         uint16_t                    m_AnimationID; // index into array
         uint16_t                    m_DynamicVertexAttributeIndex;
         uint16_t                    m_ComponentIndex;
@@ -171,7 +173,7 @@ namespace dmGameSystem
         dmObjectPool<SpriteComponent>       m_Components;
         DynamicAttributePool                m_DynamicVertexAttributePool;
         dmArray<dmRender::RenderObject*>    m_RenderObjects;
-        dmArray<float>                      m_BoundingVolumes;
+        dmArray<float>                      m_CullingInfo; // array stores sprite center + radius as 4 floats: x,y,z,radius
         // We currently assume the vertex format uses 2-tuple UVs
         dmArray<float>                      m_ScratchUVs[MAX_TEXTURE_COUNT];
         dmArray<Vector4>                    m_ScratchPositionWorld;
@@ -249,8 +251,8 @@ namespace dmGameSystem
         SpriteWorld* sprite_world = new SpriteWorld();
         uint32_t comp_count = dmMath::Min(params.m_MaxComponentInstances, sprite_context->m_MaxSpriteCount);
         sprite_world->m_Components.SetCapacity(comp_count);
-        sprite_world->m_BoundingVolumes.SetCapacity(comp_count);
-        sprite_world->m_BoundingVolumes.SetSize(comp_count);
+        sprite_world->m_CullingInfo.SetCapacity(comp_count * 4);
+        sprite_world->m_CullingInfo.SetSize(comp_count * 4);
         sprite_world->m_AnimationDataCache.m_Cache.SetCapacity(MINIMUM_CACHE_CAPACITY);
         dmDoubleLinkedList::ListInit(&sprite_world->m_AnimationDataCache.m_LRU);
         memset(sprite_world->m_Components.GetRawObjects().Begin(), 0, sizeof(SpriteComponent) * comp_count);
@@ -717,6 +719,8 @@ namespace dmGameSystem
         component->m_AnimationID = 0;
         component->m_AnimationPlayback = dmGameSystemDDF::PLAYBACK_NONE;
         component->m_AnimationFrameCount = 1;
+        component->m_PivotX = 0.5f;
+        component->m_PivotY = 0.5f;
 
         if (component->m_Resource->m_DDF->m_SizeMode == dmGameSystemDDF::SpriteDesc::SIZE_MODE_MANUAL || component->m_NumTextures == 0)
         {
@@ -997,11 +1001,6 @@ namespace dmGameSystem
             (const float**) scratch_tt_ptrs,
             uv_channels_count);
 
-        // We always use the first geometry for the vertices
-        float pivot_x = 0.f;
-        float pivot_y = 0.f;
-        GetPivot(anim_data, &pivot_x, &pivot_y);
-
         uint32_t sp_width = sprite_size.getX();
         uint32_t sp_height = sprite_size.getY();
         uint32_t vertex_index = 0;
@@ -1014,7 +1013,7 @@ namespace dmGameSystem
                     // convert from [0,1] to [-0.5, 0.5]
                     float px = xs[x] - 0.5f;
                     float py = ys[y] - 0.5f;
-                    Point3 p = Point3(px - pivot_x, py - pivot_y, 0);
+                    Point3 p = Point3(px - component->m_PivotX, py - component->m_PivotY, 0);
 
                     // Local space has size applied; world = mtx_world * local (mtx_world has no scale)
                     Vector4 local_pos(p.getX() * sp_width, p.getY() * sp_height, 0.0f, 1.0f);
@@ -1313,10 +1312,6 @@ namespace dmGameSystem
             float center_x = geometry->m_CenterX;
             float center_y = geometry->m_CenterY;
 
-            float pivot_x = 0.f;
-            float pivot_y = 0.f;
-            GetPivot(anim_data, &pivot_x, &pivot_y);
-
             const float* vertices = reverse ? orig_vertices + num_vertices*2 - 2 : orig_vertices;
 
             for (uint32_t j = 0; j < num_vertices; ++j, vertices += step)
@@ -1348,8 +1343,8 @@ namespace dmGameSystem
                 // We grab the geometry as positions from the first texture
                 if (i == 0)
                 {
-                    float vx = px - pivot_x;
-                    float vy = py - pivot_y;
+                    float vx = px - component->m_PivotX;
+                    float vy = py - component->m_PivotY;
                     scratch_pos[j] = Vector4(vx * scale_x, vy * scale_y, 0.0f, 1.0f);
                 }
             }
@@ -1586,15 +1581,10 @@ namespace dmGameSystem
                     //    for any subsequent geometry would yield a quad anyways.
                     ResolveUVDataFromQuads(component, animations, sprite_world->m_ScratchUVs, scratch_uv_ptrs, scratch_pi_ptrs, scratch_tt_ptrs);
 
-                    // We always use the first geometry for the vertices
-                    float pivot_x = 0.f;
-                    float pivot_y = 0.f;
-                    GetPivot(animations, &pivot_x, &pivot_y);
-
-                    float x0 = -0.5f - pivot_x;
-                    float x1 =  0.5f - pivot_x;
-                    float y0 = -0.5f - pivot_y;
-                    float y1 =  0.5f - pivot_y;
+                    float x0 = -0.5f - component->m_PivotX;
+                    float x1 =  0.5f - component->m_PivotX;
+                    float y0 = -0.5f - component->m_PivotY;
+                    float y1 =  0.5f - component->m_PivotY;
 
                     Vector4 positions_local[4];
                     Vector4 positions_world[4];
@@ -1892,43 +1882,6 @@ namespace dmGameSystem
         }
     }
 
-    static void UpdateVertexAndIndexCount(SpriteWorld* sprite_world, const SpriteComponent* component, dmRender::HRenderContext render_context, uint32_t& num_vertices,
-        uint32_t& num_indices, uint32_t& vertex_memsize)
-    {
-        dmRender::HMaterial material           = GetRenderMaterial(render_context, component);
-        dmGraphics::HVertexDeclaration vx_decl = dmRender::GetVertexDeclaration(material);
-        uint32_t vertex_stride                 = dmGraphics::GetVertexDeclarationStride(vx_decl);
-        uint8_t textures_num                   = component->m_NumTextures;
-
-        // We need to pad the buffer if the vertex stride doesn't start at an even byte offset from the start
-        vertex_memsize += vertex_stride - vertex_memsize % vertex_stride;
-
-        // Get the correct animation frames, and other meta data
-        AnimationData* anim_data = GetOrCreateAnimationData(sprite_world, component);
-
-        if (textures_num == 0 || anim_data->m_CanUseQuads)
-        {
-            if (component->m_UseSlice9)
-            {
-                num_vertices   += SPRITE_VERTEX_COUNT_SLICE9;
-                num_indices    += SPRITE_INDEX_COUNT_SLICE9;
-                vertex_memsize += SPRITE_VERTEX_COUNT_SLICE9 * vertex_stride;
-            }
-            else
-            {
-                num_vertices   += SPRITE_VERTEX_COUNT_LEGACY;
-                num_indices    += SPRITE_INDEX_COUNT_LEGACY;
-                vertex_memsize += SPRITE_VERTEX_COUNT_LEGACY * vertex_stride;
-            }
-        }
-        else
-        {
-            num_vertices += anim_data->m_VertexCount;
-            num_indices += anim_data->m_IndicesCount;
-            vertex_memsize += anim_data->m_VertexCount * vertex_stride;
-        }
-    }
-
     dmGameObject::CreateResult CompSpriteAddToUpdate(const dmGameObject::ComponentAddToUpdateParams& params)
     {
         SpriteWorld* sprite_world = (SpriteWorld*)params.m_World;
@@ -2004,6 +1957,7 @@ namespace dmGameSystem
             Animate(component, params.m_UpdateContext->m_DT);
 
             HComponentRenderConstants constants = GetRenderConstants(component);
+            bool is_component_changed = component->m_ReHash || component->m_AnimationReHash;
             if (component->m_ReHash || (constants && dmGameSystem::AreRenderConstantsUpdated(constants)))
             {
                 ReHash(component);
@@ -2013,7 +1967,42 @@ namespace dmGameSystem
                 AnimationReHash(component);
             }
 
-            UpdateVertexAndIndexCount(world, component, render_context, num_vertices, num_indices, vertex_memsize);
+            dmRender::HMaterial material           = GetRenderMaterial(render_context, component);
+            dmGraphics::HVertexDeclaration vx_decl = dmRender::GetVertexDeclaration(material);
+            uint32_t vertex_stride                 = dmGraphics::GetVertexDeclarationStride(vx_decl);
+            uint8_t textures_num                   = component->m_NumTextures;
+
+            // We need to pad the buffer if the vertex stride doesn't start at an even byte offset from the start
+            vertex_memsize += vertex_stride - vertex_memsize % vertex_stride;
+
+            // Get the correct animation frames, and other meta data
+            AnimationData* anim_data = GetOrCreateAnimationData(world, component);
+            // update cached pivot
+            if (is_component_changed)
+            {
+                GetPivot(anim_data, &component->m_PivotX, &component->m_PivotY);
+            }
+            if (textures_num == 0 || anim_data->m_CanUseQuads)
+            {
+                if (component->m_UseSlice9)
+                {
+                    num_vertices   += SPRITE_VERTEX_COUNT_SLICE9;
+                    num_indices    += SPRITE_INDEX_COUNT_SLICE9;
+                    vertex_memsize += SPRITE_VERTEX_COUNT_SLICE9 * vertex_stride;
+                }
+                else
+                {
+                    num_vertices   += SPRITE_VERTEX_COUNT_LEGACY;
+                    num_indices    += SPRITE_INDEX_COUNT_LEGACY;
+                    vertex_memsize += SPRITE_VERTEX_COUNT_LEGACY * vertex_stride;
+                }
+            }
+            else
+            {
+                num_vertices += anim_data->m_VertexCount;
+                num_indices += anim_data->m_IndicesCount;
+                vertex_memsize += anim_data->m_VertexCount * vertex_stride;
+            }
 
             // TODO: check when we need send messages
             if (!component->m_IsPlaying)
@@ -2063,7 +2052,14 @@ namespace dmGameSystem
             Vector3 size = component->m_Size;
             Vector3 half_diagonal = (component->m_World.getCol(0).getXYZ() * size.getX() + component->m_World.getCol(1).getXYZ() * size.getY()) * 0.5f;
             float radius_sq = dmVMath::LengthSqr(half_diagonal);
-            world->m_BoundingVolumes[i] = radius_sq;
+
+            Point3 pivot_scaled(-component->m_PivotX * size.getX(), -component->m_PivotY * size.getY(), 0.f);
+            Vector3 world_pos = (component->m_World * pivot_scaled).getXYZ();
+
+            world->m_CullingInfo[i * 4] = world_pos.getX();
+            world->m_CullingInfo[i * 4 + 1] = world_pos.getY();
+            world->m_CullingInfo[i * 4 + 2] = world_pos.getZ();
+            world->m_CullingInfo[i * 4 + 3] = radius_sq;
         }
         return dmGameObject::UPDATE_RESULT_OK;
     }
@@ -2073,26 +2069,16 @@ namespace dmGameSystem
         DM_PROFILE("Sprite");
 
         SpriteWorld* sprite_world = (SpriteWorld*)params.m_UserData;
-        const float* radiuses = sprite_world->m_BoundingVolumes.Begin();
+        const float* infos = sprite_world->m_CullingInfo.Begin();
 
         const dmIntersection::Frustum frustum = *params.m_Frustum;
         uint32_t num_entries = params.m_NumEntries;
-        dmArray<SpriteComponent>& components = sprite_world->m_Components.GetRawObjects();
         for (uint32_t i = 0; i < num_entries; ++i)
         {
             dmRender::RenderListEntry* entry = &params.m_Entries[i];
-
-            float radius_sq = radiuses[entry->m_UserData];
-
-            SpriteComponent* component = &components[entry->m_UserData];
-            const AnimationData* anim_data = GetOrCreateAnimationData(sprite_world, component);
-            float pivot_x = 0.f, pivot_y = 0.f;
-            GetPivot(anim_data, &pivot_x, &pivot_y);
-            Vector3 size = component->m_Size;
-            Point3 pivot_scaled(-pivot_x * size.getX(), -pivot_y * size.getY(), 0.f);
-            Vector3 world_pos = (component->m_World * pivot_scaled).getXYZ();
-
-            bool intersect = dmIntersection::TestFrustumSphereSq(frustum, Point3(world_pos), radius_sq);
+            uint32_t component_idx = entry->m_UserData;
+            Vector4 pos(infos[component_idx * 4], infos[component_idx * 4 + 1], infos[component_idx * 4 + 2], 1.0f);
+            bool intersect = dmIntersection::TestFrustumSphereSq(frustum, pos, infos[component_idx * 4 + 3]);
             entry->m_Visibility = intersect ? dmRender::VISIBILITY_FULL : dmRender::VISIBILITY_NONE;
         }
     }


### PR DESCRIPTION
Sprite culling spends less time calculating visibility now. But memory footprint grows by 20 bytes per every sprite component.

### Technical changes
* Added pivot cache in sprite component.
* Store sprite center position together with sprite radius to optimize culling calls. Accessing sprite components array in culling was pretty expensive so solution is store all culling-related information in one array (`m_CullingInfo`)

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
