### PR TITLE
Avoid deadlocks when the profiler stack is unbalanced

### DIFF
--- a/engine/engine/src/test/test_profilerext_lua.cpp
+++ b/engine/engine/src/test/test_profilerext_lua.cpp
@@ -1,0 +1,235 @@
+// Copyright 2020-2026 The Defold Foundation
+// Copyright 2014-2020 King
+// Copyright 2009-2014 Ragnar Svensson, Christian Murray
+// Licensed under the Defold License version 1.0 (the "License"); you may not use
+// this file except in compliance with the License.
+//
+// You may obtain a copy of the License, together with FAQs at
+// https://www.defold.com/license
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#include <dlib/array.h>
+#include <dlib/configfile.h>
+#include <dlib/log.h>
+#include <extension/extension.hpp>
+#include <script/script.h>
+#include <testmain/testmain.h>
+
+#include <string.h>
+
+#define JC_TEST_IMPLEMENTATION
+#include <jc_test/jc_test.h>
+
+namespace
+{
+    class ProfilerExtLuaTest : public jc_test_base_class
+    {
+    public:
+        void SetUp() override
+        {
+            m_ExtensionInitialized = false;
+            m_AppInitialized = false;
+            s_LogCaptureContext = this;
+
+            dmLog::LogParams log_params;
+            dmLog::LogInitialize(&log_params);
+            dmLogRegisterListener(LogListener);
+
+            dmConfigFile::Result config_result = dmConfigFile::LoadFromBuffer(0, 0, 0, 0, &m_ConfigFile);
+            ASSERT_EQ(dmConfigFile::RESULT_OK, config_result);
+
+            dmScript::ContextParams script_context_params = {};
+            script_context_params.m_ConfigFile = m_ConfigFile;
+            m_Context = dmScript::NewContext(script_context_params);
+            ASSERT_NE((dmScript::HContext) 0, m_Context);
+            dmScript::Initialize(m_Context);
+            m_L = dmScript::GetLuaState(m_Context);
+            ASSERT_NE((lua_State*) 0, m_L);
+
+            ExtensionAppParamsInitialize(&m_AppParams);
+            m_AppParams.m_ConfigFile = m_ConfigFile;
+            ASSERT_EQ(dmExtension::RESULT_OK, dmExtension::AppInitialize(&m_AppParams));
+
+            ExtensionParamsInitialize(&m_Params);
+            m_Params.m_L = m_L;
+            m_Params.m_ConfigFile = m_ConfigFile;
+            ASSERT_EQ(dmExtension::RESULT_OK, dmExtension::Initialize(&m_Params));
+            m_ExtensionInitialized = true;
+            m_AppInitialized = true;
+        }
+
+        void TearDown() override
+        {
+            if (m_ExtensionInitialized)
+            {
+                ASSERT_EQ(dmExtension::RESULT_OK, dmExtension::Finalize(&m_Params));
+                m_ExtensionInitialized = false;
+            }
+            if (m_AppInitialized)
+            {
+                ASSERT_EQ(dmExtension::RESULT_OK, dmExtension::AppFinalize(&m_AppParams));
+                m_AppInitialized = false;
+            }
+
+            ExtensionParamsFinalize(&m_Params);
+            ExtensionAppParamsFinalize(&m_AppParams);
+
+            dmScript::Finalize(m_Context);
+            dmScript::DeleteContext(m_Context);
+            dmConfigFile::Delete(m_ConfigFile);
+
+            if (s_LogCaptureContext)
+            {
+                dmLogUnregisterListener(LogListener);
+                dmLog::LogFinalize();
+                s_LogCaptureContext = 0;
+            }
+        }
+
+        bool RunString(const char* script)
+        {
+            if (luaL_dostring(m_L, script) != 0)
+            {
+                dmLogError("%s", lua_tostring(m_L, -1));
+                lua_pop(m_L, 1);
+                return false;
+            }
+            return true;
+        }
+
+        void FinalizeExtension()
+        {
+            ASSERT_TRUE(m_ExtensionInitialized);
+            ASSERT_EQ(dmExtension::RESULT_OK, dmExtension::Finalize(&m_Params));
+            m_ExtensionInitialized = false;
+        }
+
+        char* GetLog()
+        {
+            if (s_LogCaptureContext)
+            {
+                dmLog::LogFinalize();
+                s_LogCaptureContext = 0;
+            }
+
+            m_Log.SetCapacity(m_Log.Size() + 1);
+            m_Log.Push('\0');
+            return m_Log.Begin();
+        }
+
+        static void LogListener(LogSeverity severity, const char* domain, const char* formatted_string)
+        {
+            (void) severity;
+            (void) domain;
+
+            if (s_LogCaptureContext != 0)
+            {
+                s_LogCaptureContext->AppendToLog(formatted_string);
+            }
+        }
+
+        void AppendToLog(const char* log)
+        {
+            uint32_t len = strlen(log);
+            m_Log.SetCapacity(m_Log.Size() + len + 1);
+            m_Log.PushArray(log, len);
+        }
+
+        dmScript::HContext  m_Context;
+        dmConfigFile::HConfig m_ConfigFile;
+        lua_State*          m_L;
+        ExtensionAppParams  m_AppParams;
+        ExtensionParams     m_Params;
+        dmArray<char>       m_Log;
+        bool                m_ExtensionInitialized;
+        bool                m_AppInitialized;
+
+        static ProfilerExtLuaTest* s_LogCaptureContext;
+    };
+
+    ProfilerExtLuaTest* ProfilerExtLuaTest::s_LogCaptureContext = 0;
+}
+
+TEST_F(ProfilerExtLuaTest, ScopeEndWithoutBeginRaisesLuaError)
+{
+    ASSERT_TRUE(RunString(
+        "local ok, err = pcall(function() profiler.scope_end() end)\n"
+        "assert(not ok)\n"
+        "assert(string.find(err, \"profiler.scope_end() called without a matching profiler.scope_begin()\", 1, true))\n"));
+}
+
+TEST_F(ProfilerExtLuaTest, UnclosedScopesAreAutoClosedOnUpdate)
+{
+    ASSERT_TRUE(RunString(
+        "profiler.scope_begin(\"outer\")\n"
+        "profiler.scope_begin(\"inner\")\n"));
+
+    ASSERT_EQ(dmExtension::RESULT_OK, dmExtension::Update(&m_Params));
+
+    ASSERT_TRUE(RunString(
+        "local ok, err = pcall(function() profiler.scope_end() end)\n"
+        "assert(not ok)\n"
+        "assert(string.find(err, \"profiler.scope_end() called without a matching profiler.scope_begin()\", 1, true))\n"));
+
+    char* log = GetLog();
+    ASSERT_NE((char*) 0, strstr(log, "Lua profiler scope 'inner' was not closed before the end of the frame. Auto-closing it."));
+    ASSERT_NE((char*) 0, strstr(log, "Lua profiler scope 'outer' was not closed before the end of the frame. Auto-closing it."));
+}
+
+TEST_F(ProfilerExtLuaTest, CoroutineScopesAreAutoClosedOnUpdate)
+{
+    ASSERT_TRUE(RunString(
+        "co = coroutine.create(function()\n"
+        "    profiler.scope_begin(\"coroutine_outer\")\n"
+        "    profiler.scope_begin(\"coroutine_inner\")\n"
+        "    coroutine.yield()\n"
+        "    profiler.scope_end()\n"
+        "end)\n"
+        "assert(coroutine.resume(co))\n"));
+
+    lua_getglobal(m_L, "co");
+    lua_State* coroutine_state = lua_tothread(m_L, -1);
+    ASSERT_NE((lua_State*) 0, coroutine_state);
+    ASSERT_NE(m_L, coroutine_state);
+    ASSERT_EQ(m_L, dmScript::GetMainThread(coroutine_state));
+    lua_pop(m_L, 1);
+
+    ASSERT_EQ(dmExtension::RESULT_OK, dmExtension::Update(&m_Params));
+
+    ASSERT_TRUE(RunString(
+        "local ok, err = coroutine.resume(co)\n"
+        "assert(not ok)\n"
+        "assert(string.find(err, \"profiler.scope_end() called without a matching profiler.scope_begin()\", 1, true))\n"));
+
+    char* log = GetLog();
+    ASSERT_NE((char*) 0, strstr(log, "Lua profiler scope 'coroutine_inner' was not closed before the end of the frame. Auto-closing it."));
+    ASSERT_NE((char*) 0, strstr(log, "Lua profiler scope 'coroutine_outer' was not closed before the end of the frame. Auto-closing it."));
+}
+
+TEST_F(ProfilerExtLuaTest, CoroutineScopesAreAutoClosedOnFinalize)
+{
+    ASSERT_TRUE(RunString(
+        "co = coroutine.create(function()\n"
+        "    profiler.scope_begin(\"coroutine_finalize\")\n"
+        "end)\n"
+        "assert(coroutine.resume(co))\n"));
+
+    FinalizeExtension();
+
+    char* log = GetLog();
+    ASSERT_NE((char*) 0, strstr(log, "Lua profiler scope 'coroutine_finalize' was not closed before the end of the frame. Auto-closing it."));
+}
+
+extern "C" void dmExportedSymbols();
+
+int main(int argc, char **argv)
+{
+    dmExportedSymbols();
+    TestMainPlatformInit();
+    jc_test_init(&argc, argv);
+    return jc_test_run_all();
+}

--- a/engine/engine/src/test/test_profilerext_lua.cpp
+++ b/engine/engine/src/test/test_profilerext_lua.cpp
@@ -162,13 +162,13 @@ TEST_F(ProfilerExtLuaTest, ScopeEndWithoutBeginRaisesLuaError)
         "assert(string.find(err, \"profiler.scope_end() called without a matching profiler.scope_begin()\", 1, true))\n"));
 }
 
-TEST_F(ProfilerExtLuaTest, UnclosedScopesAreAutoClosedOnUpdate)
+TEST_F(ProfilerExtLuaTest, UnclosedScopesAreAutoClosedOnPreRender)
 {
     ASSERT_TRUE(RunString(
         "profiler.scope_begin(\"outer\")\n"
         "profiler.scope_begin(\"inner\")\n"));
 
-    ASSERT_EQ(dmExtension::RESULT_OK, dmExtension::Update(&m_Params));
+    dmExtension::PreRender(&m_Params);
 
     ASSERT_TRUE(RunString(
         "local ok, err = pcall(function() profiler.scope_end() end)\n"
@@ -180,7 +180,7 @@ TEST_F(ProfilerExtLuaTest, UnclosedScopesAreAutoClosedOnUpdate)
     ASSERT_NE((char*) 0, strstr(log, "Lua profiler scope 'outer' was not closed before the end of the frame. Auto-closing it."));
 }
 
-TEST_F(ProfilerExtLuaTest, CoroutineScopesAreAutoClosedOnUpdate)
+TEST_F(ProfilerExtLuaTest, CoroutineScopesAreAutoClosedOnPreRender)
 {
     ASSERT_TRUE(RunString(
         "co = coroutine.create(function()\n"
@@ -198,7 +198,7 @@ TEST_F(ProfilerExtLuaTest, CoroutineScopesAreAutoClosedOnUpdate)
     ASSERT_EQ(m_L, dmScript::GetMainThread(coroutine_state));
     lua_pop(m_L, 1);
 
-    ASSERT_EQ(dmExtension::RESULT_OK, dmExtension::Update(&m_Params));
+    dmExtension::PreRender(&m_Params);
 
     ASSERT_TRUE(RunString(
         "local ok, err = coroutine.resume(co)\n"

--- a/engine/engine/src/test/wscript
+++ b/engine/engine/src/test/wscript
@@ -81,7 +81,7 @@ def build(bld):
         web_libs = ['library_sys.js', 'library_script.js', 'library_render.js'],
         includes = '../../proto .',
         defines = defines,
-        source = bld.path.ant_glob('**/*.cpp'),
+        source = bld.path.ant_glob('**/*.cpp', excl=['test_profilerext_lua.cpp']),
         target = 'test_engine')
 
     # Psapi.lib is needed by ProfilerExt

--- a/engine/engine/src/test/wscript
+++ b/engine/engine/src/test/wscript
@@ -59,6 +59,21 @@ def build(bld):
     exported_symbols = ['ProfilerExt', 'GraphicsAdapterNull', 'ScriptModelExt']
 
     bld.add_group()
+    profiler_exported_symbols = ['ProfilerExt', 'ProfilerBasic', 'GraphicsAdapterNull']
+    profiler_test = bld(
+        features = 'c cxx cprogram test',
+        use = 'TESTMAIN APP RESOURCE DDF FONT GRAPHICS_NULL PLATFORM_NULL RENDER SOCKET SCRIPT LUA EXTENSION DLIB'.split() + additional_libs + ['PROFILE', 'PROFILEREXT'],
+        exported_symbols = profiler_exported_symbols,
+        web_libs = ['library_sys.js', 'library_script.js', 'library_render.js'],
+        includes = '../../proto .',
+        defines = defines,
+        source = ['test_profilerext_lua.cpp'],
+        target = 'test_profilerext_lua')
+
+    if 'win32' in bld.env.PLATFORM:
+        profiler_test.env.append_value('LINKFLAGS', ['Psapi.lib'])
+
+    bld.add_group()
     obj = bld(
         features = 'c cxx cprogram test',
         use = 'TESTMAIN APP RECORD CRASH VPX GAMEOBJECT DDF LIVEUPDATE FONT GAMESYS RESOURCE DMGLFW GRAPHICS_NULL GRAPHICS_UTIL PHYSICS PLATFORM_NULL RENDER SOCKET SCRIPT LUA EXTENSION HID_NULL INPUT PARTICLE RIG GUI SOUND_NULL DLIB APP engine engine_service'.split() + additional_libs + profile_lib,

--- a/engine/modelc/src/modelimporter_gltf.cpp
+++ b/engine/modelc/src/modelimporter_gltf.cpp
@@ -22,6 +22,7 @@
 // when locale LC_NUMERIC use commas instead of periods for decimal points
 #if defined(__APPLE__) || defined(__linux__)
 #ifdef __APPLE__
+#include <stdlib.h>
 #include <xlocale.h>
 #else
 #include <locale.h>

--- a/engine/profiler/src/profiler.cpp
+++ b/engine/profiler/src/profiler.cpp
@@ -14,6 +14,7 @@
 
 #include "profiler.h"
 
+#include <dlib/array.h>
 #include <dlib/dlib.h>
 #include <dlib/hash.h>
 #include <dlib/log.h>
@@ -27,6 +28,7 @@
 #include "profiler_render.h"
 
 #include <algorithm> // std::sort
+#include <string.h>
 
 #include <dmsdk/dlib/vmath.h>
 #include <dmsdk/extension/extension.h>
@@ -60,8 +62,150 @@ static dmMutex::HMutex                  g_ProfilerMutex = 0;
 static dmHashTable64<int>               g_ProfilerThreadSortOrder;
 static bool                             g_ProfilerDumpNextFrame = false;
 
+struct LuaProfilerScope
+{
+    uint32_t    m_NameOffset;
+    uint64_t    m_NameHash;
+};
+
+struct LuaProfilerScopeState
+{
+    lua_State*                   m_L;
+    dmArray<LuaProfilerScope>    m_Scopes;
+    dmArray<char>                m_Names;
+    LuaProfilerScopeState*       m_Next;
+};
+
+static LuaProfilerScopeState*            g_LuaProfilerScopeStates = 0;
+
 static void SampleTreeCallback(void* _ctx, const char* thread_name, dmProfiler::HSample root);
 static void PropertyTreeCallback(void* _ctx, dmProfiler::HProperty root);
+
+static LuaProfilerScopeState* FindLuaProfilerScopeState(lua_State* L)
+{
+    for (LuaProfilerScopeState* state = g_LuaProfilerScopeStates; state != 0; state = state->m_Next)
+    {
+        if (state->m_L == L)
+        {
+            return state;
+        }
+    }
+    return 0;
+}
+
+static LuaProfilerScopeState* GetOrCreateLuaProfilerScopeState(lua_State* L)
+{
+    LuaProfilerScopeState* state = FindLuaProfilerScopeState(L);
+    if (state != 0)
+    {
+        return state;
+    }
+
+    state = new LuaProfilerScopeState;
+    state->m_L = L;
+    state->m_Scopes.SetCapacity(4);
+    state->m_Names.SetCapacity(64);
+    state->m_Next = g_LuaProfilerScopeStates;
+    g_LuaProfilerScopeStates = state;
+    return state;
+}
+
+static void DeleteLuaProfilerScopeState(lua_State* L)
+{
+    LuaProfilerScopeState** state_ptr = &g_LuaProfilerScopeStates;
+    while (*state_ptr != 0)
+    {
+        LuaProfilerScopeState* state = *state_ptr;
+        if (state->m_L == L)
+        {
+            *state_ptr = state->m_Next;
+            delete state;
+            return;
+        }
+        state_ptr = &state->m_Next;
+    }
+}
+
+static void DeleteLuaProfilerScopeStates()
+{
+    while (g_LuaProfilerScopeStates != 0)
+    {
+        DeleteLuaProfilerScopeState(g_LuaProfilerScopeStates->m_L);
+    }
+}
+
+template <typename T>
+static void EnsureLuaProfilerCapacity(dmArray<T>* array, uint32_t additional_count, uint32_t min_capacity)
+{
+    if (array->Remaining() >= additional_count)
+    {
+        return;
+    }
+
+    uint32_t new_capacity = array->Capacity() == 0 ? min_capacity : array->Capacity() * 2;
+    uint32_t required_capacity = array->Size() + additional_count;
+    if (new_capacity < required_capacity)
+    {
+        new_capacity = required_capacity;
+    }
+
+    array->SetCapacity(new_capacity);
+}
+
+static const char* GetLuaProfilerScopeName(LuaProfilerScopeState* state, const LuaProfilerScope* scope)
+{
+    return state->m_Names.Begin() + scope->m_NameOffset;
+}
+
+static void PushLuaProfilerScope(lua_State* L, const char* name, uint32_t name_length)
+{
+    LuaProfilerScopeState* state = GetOrCreateLuaProfilerScopeState(L);
+    EnsureLuaProfilerCapacity(&state->m_Scopes, 1, 4);
+    EnsureLuaProfilerCapacity(&state->m_Names, name_length + 1, 64);
+
+    LuaProfilerScope scope;
+    scope.m_NameOffset = state->m_Names.Size();
+    uint64_t name_hash = 0;
+    ProfileScopeBegin(name, &name_hash);
+    scope.m_NameHash = name_hash;
+
+    uint32_t name_size = name_length + 1;
+    uint32_t names_size = state->m_Names.Size();
+    state->m_Names.SetSize(names_size + name_size);
+    memcpy(state->m_Names.Begin() + scope.m_NameOffset, name, name_length);
+    state->m_Names[scope.m_NameOffset + name_length] = 0;
+    state->m_Scopes.Push(scope);
+}
+
+static LuaProfilerScopeState* PopLuaProfilerScope(lua_State* L, LuaProfilerScope* out_scope)
+{
+    LuaProfilerScopeState* state = FindLuaProfilerScopeState(L);
+    if (state == 0 || state->m_Scopes.Empty())
+    {
+        return 0;
+    }
+
+    *out_scope = state->m_Scopes.Back();
+    state->m_Scopes.Pop();
+    return state;
+}
+
+static void AutoCloseLuaProfilerScopes()
+{
+    for (LuaProfilerScopeState* state = g_LuaProfilerScopeStates; state != 0; state = state->m_Next)
+    {
+        LuaProfilerScope scope = {0};
+        while (!state->m_Scopes.Empty())
+        {
+            scope = state->m_Scopes.Back();
+            state->m_Scopes.Pop();
+            const char* name = GetLuaProfilerScopeName(state, &scope);
+            dmLogError("Lua profiler scope '%s' was not closed before the end of the frame. Auto-closing it.", name);
+            ProfileScopeEnd(name, scope.m_NameHash);
+            state->m_Names.SetSize(scope.m_NameOffset);
+        }
+    }
+}
 
 void SetUpdateFrequency(uint32_t update_frequency)
 {
@@ -557,7 +701,8 @@ static int ProfilerDumpFrame(lua_State* L)
 /*# start a profile scope
  *
  * Starts a profile scope.
- * @note Must be correctly matched with a corresponding call to `profiler.scope_end()`
+ * @note Must be correctly matched with a corresponding call to `profiler.scope_end()` in the same frame.
+ * Any scopes left open at the end of the frame are reported as errors and auto-closed.
  *
  * @name profiler.scope_begin
  * @param name [type:string] The name of the scope
@@ -585,20 +730,30 @@ static int ProfilerScopeBegin(lua_State* L)
         return DM_LUA_ERROR("Expected non-empty string");
     }
 
-    ProfileScopeBegin(name, 0);
+    PushLuaProfilerScope(L, name, len);
     return 0;
 }
 
 /*# end the current profile scope
  *
  * End the current profile scope.
+ * @note Calling this without a matching `profiler.scope_begin()` raises a Lua error.
  * @name profiler.scope_end
  *
  */
 static int ProfilerScopeEnd(lua_State* L)
 {
     DM_LUA_STACK_CHECK(L, 0);
-    ProfileScopeEnd(0, 0);
+    LuaProfilerScope scope = {0};
+    LuaProfilerScopeState* state = PopLuaProfilerScope(L, &scope);
+    if (state == 0)
+    {
+        return DM_LUA_ERROR("profiler.scope_end() called without a matching profiler.scope_begin()");
+    }
+
+    const char* name = GetLuaProfilerScopeName(state, &scope);
+    ProfileScopeEnd(name, scope.m_NameHash);
+    state->m_Names.SetSize(scope.m_NameOffset);
     return 0;
 }
 
@@ -838,12 +993,16 @@ static dmExtension::Result UpdateProfiler(dmExtension::Params* params)
     }
 
     dmProfilerExt::UpdatePlatformProfiler();
+    AutoCloseLuaProfilerScopes();
 
     return dmExtension::RESULT_OK;
 }
 
 static dmExtension::Result FinalizeProfiler(dmExtension::Params* params)
 {
+    AutoCloseLuaProfilerScopes();
+    DeleteLuaProfilerScopeStates();
+
     if (gRenderProfile)
     {
         dmProfileRender::DeleteRenderProfile(gRenderProfile);
@@ -906,6 +1065,7 @@ static dmExtension::Result AppFinalizeProfiler(dmExtension::AppParams* params)
     }
     dmMutex::Delete(g_ProfilerMutex);
     g_ProfilerMutex = 0;
+    DeleteLuaProfilerScopeStates();
 
     return dmExtension::RESULT_OK;
 }

--- a/engine/profiler/src/profiler.cpp
+++ b/engine/profiler/src/profiler.cpp
@@ -151,15 +151,22 @@ void RenderProfiler(HProfile profile, dmGraphics::HContext graphics_context, dmR
         dmGraphics::SetBlendFunc(graphics_context, (dmGraphics::BlendFactor) ps_before.m_BlendSrcFactor, (dmGraphics::BlendFactor) ps_before.m_BlendDstFactor);
     }
 
+    dmProfileRender::ProfilerFrame* dump_frame = 0;
     if (g_ProfilerCurrentFrame)
     {
         DM_MUTEX_SCOPED_LOCK(g_ProfilerMutex);
 
         if (g_ProfilerDumpNextFrame)
-            dmProfileRender::DumpFrame(g_ProfilerCurrentFrame);
+            dump_frame = dmProfileRender::DuplicateProfilerFrame(g_ProfilerCurrentFrame);
         g_ProfilerDumpNextFrame = false;
 
         g_ProfilerCurrentFrame->m_Properties.SetSize(0);
+    }
+
+    if (dump_frame)
+    {
+        dmProfileRender::DumpFrame(dump_frame);
+        dmProfileRender::DeleteProfilerFrame(dump_frame);
     }
 }
 

--- a/engine/profiler/src/profiler.cpp
+++ b/engine/profiler/src/profiler.cpp
@@ -135,6 +135,29 @@ static void DeleteLuaProfilerScopeStates()
     }
 }
 
+static bool ShouldRetainLuaProfilerScopeState(LuaProfilerScopeState* state)
+{
+    return !state->m_Scopes.Empty() || state->m_L == dmScript::GetMainThread(state->m_L);
+}
+
+static void DeleteEmptyLuaProfilerScopeStates()
+{
+    LuaProfilerScopeState** state_ptr = &g_LuaProfilerScopeStates;
+    while (*state_ptr != 0)
+    {
+        LuaProfilerScopeState* state = *state_ptr;
+        if (!ShouldRetainLuaProfilerScopeState(state))
+        {
+            *state_ptr = state->m_Next;
+            delete state;
+        }
+        else
+        {
+            state_ptr = &state->m_Next;
+        }
+    }
+}
+
 template <typename T>
 static void EnsureLuaProfilerCapacity(dmArray<T>* array, uint32_t additional_count, uint32_t min_capacity)
 {
@@ -206,6 +229,8 @@ static void AutoCloseLuaProfilerScopes()
             state->m_Names.SetSize(scope.m_NameOffset);
         }
     }
+
+    DeleteEmptyLuaProfilerScopeStates();
 }
 
 void SetUpdateFrequency(uint32_t update_frequency)

--- a/engine/profiler/src/profiler.cpp
+++ b/engine/profiler/src/profiler.cpp
@@ -64,8 +64,8 @@ static bool                             g_ProfilerDumpNextFrame = false;
 
 struct LuaProfilerScope
 {
-    uint32_t    m_NameOffset;
     uint64_t    m_NameHash;
+    uint32_t    m_NameOffset;
 };
 
 struct LuaProfilerScopeState

--- a/engine/profiler/src/profiler.cpp
+++ b/engine/profiler/src/profiler.cpp
@@ -80,6 +80,7 @@ static LuaProfilerScopeState*            g_LuaProfilerScopeStates = 0;
 
 static void SampleTreeCallback(void* _ctx, const char* thread_name, dmProfiler::HSample root);
 static void PropertyTreeCallback(void* _ctx, dmProfiler::HProperty root);
+static ExtensionResult PreRenderProfiler(dmExtension::Params* params);
 
 static LuaProfilerScopeState* FindLuaProfilerScopeState(lua_State* L)
 {
@@ -993,9 +994,15 @@ static dmExtension::Result UpdateProfiler(dmExtension::Params* params)
     }
 
     dmProfilerExt::UpdatePlatformProfiler();
-    AutoCloseLuaProfilerScopes();
 
     return dmExtension::RESULT_OK;
+}
+
+static ExtensionResult PreRenderProfiler(dmExtension::Params* params)
+{
+    (void) params;
+    AutoCloseLuaProfilerScopes();
+    return EXTENSION_RESULT_OK;
 }
 
 static dmExtension::Result FinalizeProfiler(dmExtension::Params* params)
@@ -1039,6 +1046,8 @@ static dmExtension::Result AppInitializeProfiler(dmExtension::AppParams* params)
     g_ProfilerThreadSortOrder.Put(dmHashString64("Main"), 0);
     g_ProfilerThreadSortOrder.Put(dmHashString64("sound"), 1);
     g_ProfilerThreadSortOrder.Put(dmHashString64("liveupdate"), 2);
+
+    dmExtension::RegisterCallback(dmExtension::CALLBACK_PRE_RENDER, PreRenderProfiler);
 
     return dmExtension::RESULT_OK;
 }

--- a/engine/profiler/src/profiler_render.cpp
+++ b/engine/profiler/src/profiler_render.cpp
@@ -101,7 +101,6 @@ namespace dmProfileRender
     static const Vector4 TITLE_SHADOW_COLOR = Vector4(0.0f, 0.0f, 0.0f, 1.0f);
     static const Vector4 SAMPLES_BG_COLOR   = Vector4(0.15f, 0.15f, 0.15f, 0.2f);
 
-    static ProfilerFrame* DuplicateProfilerFrame(const ProfilerFrame* frame);
     static ProfilerThread* GetSelectedThread(HRenderProfile render_profile, ProfilerFrame* frame);
 
     ProfilerThread::ProfilerThread()
@@ -814,7 +813,7 @@ namespace dmProfileRender
         return cpy;
     }
 
-    static ProfilerFrame* DuplicateProfilerFrame(const ProfilerFrame* frame)
+    ProfilerFrame* DuplicateProfilerFrame(const ProfilerFrame* frame)
     {
         ProfilerFrame* cpy = new ProfilerFrame;
         cpy->m_Time = frame->m_Time;

--- a/engine/profiler/src/profiler_render.h
+++ b/engine/profiler/src/profiler_render.h
@@ -94,6 +94,7 @@ namespace dmProfileRender
 
     void Draw(HRenderProfile render_profile, dmRender::HRenderContext render_context, dmRender::HFontMap font_map);
 
+    ProfilerFrame* DuplicateProfilerFrame(const ProfilerFrame* frame);
     void DumpFrame(ProfilerFrame* frame);
 
     //


### PR DESCRIPTION
Fixes an issue where the engine may freeze if a user calls `profiler.scope_begin("my_scope")` without later closing it with `profiler.scope_end()`, or vice versa: closing without opening. In such cases, an error will be shown and scopes will be auto-closed at the moment of detection.

Also fixes occasional freezes when using `profiler.dump_frame()`.

Fix https://github.com/defold/defold/issues/8899