### PR TITLE
Fixed crash when calling `model.play_anim()` with an animation that is not present in the model

### DIFF
--- a/engine/gamesys/src/gamesys/scripts/script_model.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_model.cpp
@@ -287,7 +287,10 @@ namespace dmGameSystem
         dmRig::Result result = dmGameSystem::CompModelPlayAnimation(world, component, anim_id, (dmRig::RigPlayback)playback, blend_duration, offset, playback_rate, callback, callback_ctx);
         if (dmRig::RESULT_ANIM_NOT_FOUND == result)
         {
-            dmScript::DestroyCallback(callback_ctx->m_LuaCallback);
+            if (callback_ctx->m_LuaCallback)
+            {
+                dmScript::DestroyCallback(callback_ctx->m_LuaCallback);
+            }
             delete callback_ctx;
             dmLogError("'%s:%s#%s' has no animation named '%s'",
                     dmMessage::GetSocketName(receiver.m_Socket),
@@ -442,7 +445,10 @@ namespace dmGameSystem
         dmRig::Result result = dmGameSystem::CompModelPlayAnimation(world, component, anim_id, (dmRig::RigPlayback)playback, blend_duration, offset, playback_rate, callback, callback_ctx);
         if (dmRig::RESULT_ANIM_NOT_FOUND == result)
         {
-            dmScript::DestroyCallback(callback_ctx->m_LuaCallback);
+            if (callback_ctx->m_LuaCallback)
+            {
+                dmScript::DestroyCallback(callback_ctx->m_LuaCallback);
+            }
             delete callback_ctx;
             dmLogError("'%s:%s#%s' has no animation named '%s'",
                     dmMessage::GetSocketName(receiver.m_Socket),

--- a/engine/gamesys/src/gamesys/test/model/model_anim_missing.script
+++ b/engine/gamesys/src/gamesys/test/model/model_anim_missing.script
@@ -1,0 +1,30 @@
+-- Copyright 2020-2026 The Defold Foundation
+-- Copyright 2014-2020 King
+-- Copyright 2009-2014 Ragnar Svensson, Christian Murray
+-- Licensed under the Defold License version 1.0 (the "License"); you may not use
+-- this file except in compliance with the License.
+--
+-- You may obtain a copy of the License, together with FAQs at
+-- https://www.defold.com/license
+--
+-- Unless required by applicable law or agreed to in writing, software distributed
+-- under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+-- CONDITIONS OF ANY KIND, either express or implied. See the License for the
+-- specific language governing permissions and limitations under the License.
+
+require "lua.test_helpers"
+
+play_anim_missing_done = false
+
+function init(self)
+    play_anim_missing_done = false
+
+    assert_not_error(function()
+        model.play_anim("#fox", "Missing", go.PLAYBACK_LOOP_FORWARD, {
+            blend_duration = 0.1,
+            playback_rate = 1,
+        })
+    end)
+
+    play_anim_missing_done = true
+end

--- a/engine/gamesys/src/gamesys/test/model/script_model_anim_missing.go
+++ b/engine/gamesys/src/gamesys/test/model/script_model_anim_missing.go
@@ -1,0 +1,8 @@
+components {
+	id: "fox"
+	component: "/model/fox.model"
+}
+components {
+	id: "script"
+	component: "/model/model_anim_missing.script"
+}

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -7285,6 +7285,16 @@ TEST_F(ModelTest, PlayAnimMessage)
     ASSERT_TRUE(dmGameObject::Final(m_Collection));
 }
 
+TEST_F(ModelTest, PlayAnimMissingAnimation)
+{
+    dmGameObject::HInstance go = Spawn(m_Factory, m_Collection, "/model/script_model_anim_missing.goc", dmHashString64("/go"), 0, Point3(0, 0, 0), Quat(0, 0, 0, 1), Vector3(1, 1, 1));
+    ASSERT_NE((void*)0, go);
+
+    ASSERT_TRUE(UpdateAndWaitUntilDone(m_Scriptlibcontext, m_Collection, &m_UpdateContext, false, "play_anim_missing_done", 5));
+
+    ASSERT_TRUE(dmGameObject::Final(m_Collection));
+}
+
 // A single mesh with multiple materials that have different coordinate spaces
 // should generate the corresponding batch types. In this case the .gltf file
 // has two sub-meshes (RenderItems) with one world space material and one


### PR DESCRIPTION
Fixed a crash when `model.play_anim()` is called without a callback and attempts to play an animation that doesn't exist in the model.

Fix https://github.com/defold/defold/issues/12141