### PR TITLE
Show a Lua error when attempting to set the render target size <= 0

### DIFF
--- a/engine/render/src/render/render_script.cpp
+++ b/engine/render/src/render/render_script.cpp
@@ -639,6 +639,25 @@ namespace dmRender
         return buffer_type;
     }
 
+    static void CheckRenderTargetSize(lua_State* L, RenderScriptInstance* i, lua_Integer width, lua_Integer height)
+    {
+        int32_t width_i = (int32_t) width;
+        int32_t height_i = (int32_t) height;
+
+        if (width <= 0 || height <= 0)
+        {
+            luaL_error(L, "Invalid render target size: width %d and height %d. Width and height must be greater than 0.",
+                width_i, height_i);
+        }
+
+        uint32_t max_tex_size = dmGraphics::GetMaxTextureSize(i->m_RenderContext->m_GraphicsContext);
+        if ((uint32_t) width > max_tex_size || (uint32_t) height > max_tex_size)
+        {
+            luaL_error(L, "Render target size %d x %d exceeds max supported texture size %u for this platform.",
+                width_i, height_i, max_tex_size);
+        }
+    }
+
     bool InsertCommand(RenderScriptInstance* i, const Command& command)
     {
         if (i->m_CommandBuffer.Full())
@@ -895,7 +914,6 @@ namespace dmRender
         const char* required_keys[] = { "format", "width", "height" };
         const int required_keys_count = sizeof(required_keys) / sizeof(required_keys[0]);
         uint32_t buffer_type_flags = 0;
-        uint32_t max_tex_size = dmGraphics::GetMaxTextureSize(i->m_RenderContext->m_GraphicsContext);
         luaL_checktype(L, table_index, LUA_TTABLE);
 
         dmGraphics::RenderTargetCreationParams params = {};
@@ -907,6 +925,8 @@ namespace dmRender
             buffer_type_flags                    |= (uint32_t) buffer_type;
             dmGraphics::TextureParams* p          = 0;
             dmGraphics::TextureCreationParams* cp = 0;
+            lua_Integer width                     = 0;
+            lua_Integer height                    = 0;
 
             if (dmGraphics::IsColorBufferType(buffer_type))
             {
@@ -981,13 +1001,11 @@ namespace dmRender
                 }
                 else if (strncmp(key, RENDER_SCRIPT_WIDTH_NAME, strlen(RENDER_SCRIPT_WIDTH_NAME)) == 0)
                 {
-                    p->m_Width = luaL_checkinteger(L, -1);
-                    cp->m_Width = p->m_Width;
+                    width = luaL_checkinteger(L, -1);
                 }
                 else if (strncmp(key, RENDER_SCRIPT_HEIGHT_NAME, strlen(RENDER_SCRIPT_HEIGHT_NAME)) == 0)
                 {
-                    p->m_Height = luaL_checkinteger(L, -1);
-                    cp->m_Height = p->m_Height;
+                    height = luaL_checkinteger(L, -1);
                 }
                 else if (strncmp(key, RENDER_SCRIPT_MIN_FILTER_NAME, strlen(RENDER_SCRIPT_MIN_FILTER_NAME)) == 0)
                 {
@@ -1035,12 +1053,12 @@ namespace dmRender
             }
             lua_pop(L, 1);      // [-1,+0 = 1] pop value, keep key for next iteration
 
-            if (cp->m_Width > max_tex_size || cp->m_Height > max_tex_size)
-            {
-                lua_pop(L, 1);  // [-1,+0 = 0] pop key
-                return DM_LUA_ERROR("Render target (type %s) of width %d and height %d is greater than max supported texture size %d for this platform.",
-                    dmGraphics::GetBufferTypeLiteral(buffer_type), cp->m_Width, cp->m_Height, max_tex_size);
-            }
+            CheckRenderTargetSize(L, i, width, height);
+
+            p->m_Width = (uint32_t) width;
+            p->m_Height = (uint32_t) height;
+            cp->m_Width = p->m_Width;
+            cp->m_Height = p->m_Height;
         }
 
         dmGraphics::HRenderTarget render_target = dmGraphics::NewRenderTarget(i->m_RenderContext->m_GraphicsContext, buffer_type_flags, params);
@@ -1348,9 +1366,11 @@ namespace dmRender
     {
         RenderScriptInstance* i = RenderScriptInstance_Check(L);
         dmGraphics::HRenderTarget render_target = CheckRenderTarget(L, 1, i);
-        uint32_t width = luaL_checkinteger(L, 2);
-        uint32_t height = luaL_checkinteger(L, 3);
-        dmGraphics::SetRenderTargetSize(i->m_RenderContext->m_GraphicsContext, render_target, width, height);
+        lua_Integer width = luaL_checkinteger(L, 2);
+        lua_Integer height = luaL_checkinteger(L, 3);
+
+        CheckRenderTargetSize(L, i, width, height);
+        dmGraphics::SetRenderTargetSize(i->m_RenderContext->m_GraphicsContext, render_target, (uint32_t) width, (uint32_t) height);
         return 0;
     }
 

--- a/engine/render/src/test/test_render_script.cpp
+++ b/engine/render/src/test/test_render_script.cpp
@@ -481,6 +481,68 @@ TEST_F(dmRenderScriptTest, TestLuaRenderTargetTooLarge)
     dmRender::DeleteRenderScript(m_Context, render_script);
 }
 
+TEST_F(dmRenderScriptTest, TestLuaRenderTargetNonPositiveSize)
+{
+    const char* script_template =
+    "function init(self)\n"
+    "    local params_color = {\n"
+    "        format = graphics.TEXTURE_FORMAT_RGBA,\n"
+    "        width = %s,\n"
+    "        height = 2,\n"
+    "        min_filter = graphics.TEXTURE_FILTER_NEAREST,\n"
+    "        mag_filter = graphics.TEXTURE_FILTER_LINEAR,\n"
+    "        u_wrap = graphics.TEXTURE_WRAP_REPEAT,\n"
+    "        v_wrap = graphics.TEXTURE_WRAP_MIRRORED_REPEAT\n"
+    "    }\n"
+    "    self.rt = render.render_target({[graphics.BUFFER_TYPE_COLOR0_BIT] = params_color})\n"
+    "end\n";
+
+    const char* invalid_widths[] = { "0", "-1" };
+    for (uint32_t i = 0; i < DM_ARRAY_SIZE(invalid_widths); ++i)
+    {
+        char script[1024];
+        dmSnPrintf(script, sizeof(script), script_template, invalid_widths[i]);
+
+        dmRender::HRenderScript render_script = dmRender::NewRenderScript(m_Context, LuaSourceFromString(script));
+        dmRender::HRenderScriptInstance render_script_instance = dmRender::NewRenderScriptInstance(m_Context, render_script);
+        ASSERT_EQ(dmRender::RENDER_SCRIPT_RESULT_FAILED, dmRender::InitRenderScriptInstance(render_script_instance));
+        dmRender::DeleteRenderScriptInstance(render_script_instance);
+        dmRender::DeleteRenderScript(m_Context, render_script);
+    }
+}
+
+TEST_F(dmRenderScriptTest, TestLuaRenderTargetSetSizeInvalid)
+{
+    const char* script_template =
+    "function update(self)\n"
+    "    local params_color = {\n"
+    "        format = graphics.TEXTURE_FORMAT_RGBA,\n"
+    "        width = 1,\n"
+    "        height = 2,\n"
+    "        min_filter = graphics.TEXTURE_FILTER_NEAREST,\n"
+    "        mag_filter = graphics.TEXTURE_FILTER_LINEAR,\n"
+    "        u_wrap = graphics.TEXTURE_WRAP_REPEAT,\n"
+    "        v_wrap = graphics.TEXTURE_WRAP_MIRRORED_REPEAT\n"
+    "    }\n"
+    "    self.rt = render.render_target({[graphics.BUFFER_TYPE_COLOR0_BIT] = params_color})\n"
+    "    render.set_render_target_size(self.rt, %s, 4)\n"
+    "end\n";
+
+    const char* invalid_widths[] = { "0", "-1", "1000000000" };
+    for (uint32_t i = 0; i < DM_ARRAY_SIZE(invalid_widths); ++i)
+    {
+        char script[1024];
+        dmSnPrintf(script, sizeof(script), script_template, invalid_widths[i]);
+
+        dmRender::HRenderScript render_script = dmRender::NewRenderScript(m_Context, LuaSourceFromString(script));
+        dmRender::HRenderScriptInstance render_script_instance = dmRender::NewRenderScriptInstance(m_Context, render_script);
+        ASSERT_EQ(dmRender::RENDER_SCRIPT_RESULT_OK, dmRender::DispatchRenderScriptInstance(render_script_instance));
+        ASSERT_EQ(dmRender::RENDER_SCRIPT_RESULT_FAILED, dmRender::UpdateRenderScriptInstance(render_script_instance, 0.0f));
+        dmRender::DeleteRenderScriptInstance(render_script_instance);
+        dmRender::DeleteRenderScript(m_Context, render_script);
+    }
+}
+
 TEST_F(dmRenderScriptTest, TestLuaRenderTarget)
 {
     const char* script =


### PR DESCRIPTION
An attempt to set the render target size less than or equal to zero crashes the engine. This fix prevents it by showing a Lua error instead.

Fix https://github.com/defold/defold/issues/12134