### PR TITLE
Update GUI nodes if the texture has been replaced from a script

### DIFF
--- a/engine/gamesys/src/gamesys/test/gui/texture_reload_override.go
+++ b/engine/gamesys/src/gamesys/test/gui/texture_reload_override.go
@@ -1,0 +1,8 @@
+components {
+  id: "gui"
+  component: "/gui/texture_setter_override.gui"
+}
+components {
+  id: "script"
+  component: "/gui/texture_reload_override.script"
+}

--- a/engine/gamesys/src/gamesys/test/gui/texture_reload_override.script
+++ b/engine/gamesys/src/gamesys/test/gui/texture_reload_override.script
@@ -1,0 +1,30 @@
+-- Copyright 2020-2026 The Defold Foundation
+-- Copyright 2014-2020 King
+-- Copyright 2009-2014 Ragnar Svensson, Christian Murray
+-- Licensed under the Defold License version 1.0 (the "License"); you may not use
+-- this file except in compliance with the License.
+--
+-- You may obtain a copy of the License, together with FAQs at
+-- https://www.defold.com/license
+--
+-- Unless required by applicable law or agreed to in writing, software distributed
+-- under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+-- CONDITIONS OF ANY KIND, either express or implied. See the License for the
+-- specific language governing permissions and limitations under the License.
+
+local ATLAS_A = "/gui/texture_setter_override_a.t.texturesetc"
+local ATLAS_B = "/gui/texture_setter_override_b.t.texturesetc"
+
+function init(self)
+    self.updated = false
+end
+
+function update(self, dt)
+    if self.updated then
+        return
+    end
+
+    local atlas_info = resource.get_atlas(ATLAS_B)
+    resource.set_atlas(ATLAS_A, atlas_info)
+    self.updated = true
+end

--- a/engine/gamesys/src/gamesys/test/gui/texture_setter_override.go
+++ b/engine/gamesys/src/gamesys/test/gui/texture_setter_override.go
@@ -1,0 +1,8 @@
+components {
+  id: "gui"
+  component: "/gui/texture_setter_override.gui"
+}
+components {
+  id: "script"
+  component: "/gui/texture_setter_override.script"
+}

--- a/engine/gamesys/src/gamesys/test/gui/texture_setter_override.gui
+++ b/engine/gamesys/src/gamesys/test/gui/texture_setter_override.gui
@@ -1,0 +1,72 @@
+script: "/gui/valid.gui_script"
+textures {
+  name: "atlas"
+  texture: "/gui/texture_setter_override_a.atlas"
+}
+textures {
+  name: "atlas_reload_source"
+  texture: "/gui/texture_setter_override_b.atlas"
+}
+background_color {
+  x: 0.0
+  y: 0.0
+  z: 0.0
+  w: 0.0
+}
+nodes {
+  position {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  scale {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  size {
+    x: 128.0
+    y: 128.0
+    z: 0.0
+    w: 1.0
+  }
+  color {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  type: TYPE_BOX
+  blend_mode: BLEND_MODE_ALPHA
+  texture: "atlas/frame"
+  id: "box"
+  xanchor: XANCHOR_NONE
+  yanchor: YANCHOR_NONE
+  pivot: PIVOT_CENTER
+  adjust_mode: ADJUST_MODE_FIT
+  layer: ""
+  inherit_alpha: true
+  slice9 {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 0.0
+  }
+  clipping_mode: CLIPPING_MODE_NONE
+  clipping_visible: true
+  clipping_inverted: false
+  alpha: 1.0
+  template_node_child: false
+  size_mode: SIZE_MODE_AUTO
+}
+material: "/gui/gui.material"
+adjust_reference: ADJUST_REFERENCE_PARENT
+max_nodes: 512

--- a/engine/gamesys/src/gamesys/test/gui/texture_setter_override.gui
+++ b/engine/gamesys/src/gamesys/test/gui/texture_setter_override.gui
@@ -1,4 +1,4 @@
-script: "/gui/valid.gui_script"
+script: "/gui/goscript.gui_script"
 textures {
   name: "atlas"
   texture: "/gui/texture_setter_override_a.atlas"

--- a/engine/gamesys/src/gamesys/test/gui/texture_setter_override.script
+++ b/engine/gamesys/src/gamesys/test/gui/texture_setter_override.script
@@ -14,15 +14,6 @@
 
 local ATLAS_B = hash("/gui/texture_setter_override_b.t.texturesetc")
 
-function init(self)
-    self.updated = false
-end
-
 function update(self, dt)
-    if self.updated then
-        return
-    end
-
     go.set("#gui", "textures", ATLAS_B, { key = "atlas" })
-    self.updated = true
 end

--- a/engine/gamesys/src/gamesys/test/gui/texture_setter_override.script
+++ b/engine/gamesys/src/gamesys/test/gui/texture_setter_override.script
@@ -1,0 +1,28 @@
+-- Copyright 2020-2026 The Defold Foundation
+-- Copyright 2014-2020 King
+-- Copyright 2009-2014 Ragnar Svensson, Christian Murray
+-- Licensed under the Defold License version 1.0 (the "License"); you may not use
+-- this file except in compliance with the License.
+--
+-- You may obtain a copy of the License, together with FAQs at
+-- https://www.defold.com/license
+--
+-- Unless required by applicable law or agreed to in writing, software distributed
+-- under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+-- CONDITIONS OF ANY KIND, either express or implied. See the License for the
+-- specific language governing permissions and limitations under the License.
+
+local ATLAS_B = hash("/gui/texture_setter_override_b.t.texturesetc")
+
+function init(self)
+    self.updated = false
+end
+
+function update(self, dt)
+    if self.updated then
+        return
+    end
+
+    go.set("#gui", "textures", ATLAS_B, { key = "atlas" })
+    self.updated = true
+end

--- a/engine/gamesys/src/gamesys/test/gui/texture_setter_override_a.atlas
+++ b/engine/gamesys/src/gamesys/test/gui/texture_setter_override_a.atlas
@@ -1,0 +1,13 @@
+animations {
+  id: "frame"
+  images {
+    image: "/texture/valid_png_128.png"
+    sprite_trim_mode: SPRITE_TRIM_MODE_OFF
+  }
+}
+margin: 0
+extrude_borders: 0
+inner_padding: 0
+max_page_width: 0
+max_page_height: 0
+rename_patterns: ""

--- a/engine/gamesys/src/gamesys/test/gui/texture_setter_override_b.atlas
+++ b/engine/gamesys/src/gamesys/test/gui/texture_setter_override_b.atlas
@@ -1,0 +1,13 @@
+animations {
+  id: "frame"
+  images {
+    image: "/texture/valid_png.png"
+    sprite_trim_mode: SPRITE_TRIM_MODE_OFF
+  }
+}
+margin: 0
+extrude_borders: 0
+inner_padding: 0
+max_page_width: 0
+max_page_height: 0
+rename_patterns: ""

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -2074,6 +2074,95 @@ TEST_F(GuiTest, TextureResources)
     ASSERT_TRUE(dmGameObject::Final(m_Collection));
 }
 
+TEST_F(GuiTest, TextureSetterOverrideRefreshesAtlasState)
+{
+    dmGameSystem::TextureSetResource* expected_atlas = 0;
+    ASSERT_EQ(dmResource::RESULT_OK, dmResource::Get(m_Factory, "/gui/texture_setter_override_b.t.texturesetc", (void**)&expected_atlas));
+    ASSERT_NE((void*)0x0, expected_atlas);
+
+    dmGameObject::HInstance go = Spawn(m_Factory, m_Collection, "/gui/texture_setter_override.goc", dmHashString64("/go"), 0, Point3(0, 0, 0), Quat(0, 0, 0, 1), Vector3(1, 1, 1));
+    ASSERT_NE((void*)0x0, go);
+
+    ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+
+    dmRender::RenderListBegin(m_RenderContext);
+    dmGameObject::Render(m_Collection);
+
+    dmRender::RenderListEnd(m_RenderContext);
+    dmRender::DrawRenderList(m_RenderContext, 0x0, 0x0, 0x0, dmRender::SORT_BACK_TO_FRONT);
+
+    uint32_t component_type_index        = dmGameObject::GetComponentTypeIndex(m_Collection, dmHashString64("guic"));
+    dmGameSystem::GuiWorld* gui_world    = (dmGameSystem::GuiWorld*) dmGameObject::GetWorld(m_Collection, component_type_index);
+    dmGameSystem::GuiComponent* gui_comp = gui_world->m_Components[0];
+
+    dmGui::HNode box = dmGui::GetNodeById(gui_comp->m_Scene, "box");
+    ASSERT_NE(0, box);
+
+    dmGui::NodeTextureType texture_type;
+    dmGui::HTextureSource texture_source = dmGui::GetNodeTexture(gui_comp->m_Scene, box, &texture_type);
+    ASSERT_EQ(dmGui::NODE_TEXTURE_TYPE_TEXTURE_SET, texture_type);
+    ASSERT_EQ((dmGui::HTextureSource) expected_atlas, texture_source);
+
+    dmGui::TextureSetAnimDesc* anim_desc = dmGui::GetNodeTextureSet(gui_comp->m_Scene, box);
+    ASSERT_NE((void*)0x0, anim_desc);
+    ASSERT_EQ((const void*) expected_atlas, anim_desc->m_TextureSet);
+    ASSERT_EQ(64, anim_desc->m_State.m_OriginalTextureWidth);
+    ASSERT_EQ(64, anim_desc->m_State.m_OriginalTextureHeight);
+
+    Point3 size = dmGui::GetNodeSize(gui_comp->m_Scene, box);
+    ASSERT_EQ(64.0f, size.getX());
+    ASSERT_EQ(64.0f, size.getY());
+
+    dmResource::Release(m_Factory, expected_atlas);
+    ASSERT_TRUE(dmGameObject::Final(m_Collection));
+}
+
+TEST_F(GuiTest, TextureReloadRefreshesAtlasState)
+{
+    dmGameSystem::TextureSetResource* expected_atlas = 0;
+    ASSERT_EQ(dmResource::RESULT_OK, dmResource::Get(m_Factory, "/gui/texture_setter_override_a.t.texturesetc", (void**)&expected_atlas));
+    ASSERT_NE((void*)0x0, expected_atlas);
+
+    dmGameObject::HInstance go = Spawn(m_Factory, m_Collection, "/gui/texture_reload_override.goc", dmHashString64("/go"), 0, Point3(0, 0, 0), Quat(0, 0, 0, 1), Vector3(1, 1, 1));
+    ASSERT_NE((void*)0x0, go);
+
+    ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+    // The atlas swap happens from script update(), so step one more frame to
+    // exercise the GUI scene refresh in UpdateScene().
+    ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+
+    dmRender::RenderListBegin(m_RenderContext);
+    dmGameObject::Render(m_Collection);
+
+    dmRender::RenderListEnd(m_RenderContext);
+    dmRender::DrawRenderList(m_RenderContext, 0x0, 0x0, 0x0, dmRender::SORT_BACK_TO_FRONT);
+
+    uint32_t component_type_index        = dmGameObject::GetComponentTypeIndex(m_Collection, dmHashString64("guic"));
+    dmGameSystem::GuiWorld* gui_world    = (dmGameSystem::GuiWorld*) dmGameObject::GetWorld(m_Collection, component_type_index);
+    dmGameSystem::GuiComponent* gui_comp = gui_world->m_Components[0];
+
+    dmGui::HNode box = dmGui::GetNodeById(gui_comp->m_Scene, "box");
+    ASSERT_NE(0, box);
+
+    dmGui::NodeTextureType texture_type;
+    dmGui::HTextureSource texture_source = dmGui::GetNodeTexture(gui_comp->m_Scene, box, &texture_type);
+    ASSERT_EQ(dmGui::NODE_TEXTURE_TYPE_TEXTURE_SET, texture_type);
+    ASSERT_EQ((dmGui::HTextureSource) expected_atlas, texture_source);
+
+    dmGui::TextureSetAnimDesc* anim_desc = dmGui::GetNodeTextureSet(gui_comp->m_Scene, box);
+    ASSERT_NE((void*)0x0, anim_desc);
+    ASSERT_EQ((const void*) expected_atlas, anim_desc->m_TextureSet);
+    ASSERT_EQ(64, anim_desc->m_State.m_OriginalTextureWidth);
+    ASSERT_EQ(64, anim_desc->m_State.m_OriginalTextureHeight);
+
+    Point3 size = dmGui::GetNodeSize(gui_comp->m_Scene, box);
+    ASSERT_EQ(64.0f, size.getX());
+    ASSERT_EQ(64.0f, size.getY());
+
+    dmResource::Release(m_Factory, expected_atlas);
+    ASSERT_TRUE(dmGameObject::Final(m_Collection));
+}
+
 // Tests creating and deleting dynamic textures
 TEST_F(GuiTest, MaxDynamictextures)
 {

--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -78,6 +78,7 @@ namespace dmGui
     static uint32_t g_ClonedNodeCount = 0;
 
     static inline void UpdateTextureSetAnimData(HScene scene, InternalNode* n);
+    inline void CalculateNodeSize(InternalNode* in);
     static void SetSceneSafeAreaAdjust(Scene* scene, bool enabled, uint32_t width, uint32_t height, float offset_x, float offset_y);
     static void ComputeSafeAreaAdjust(SafeAreaMode mode, uint32_t window_width, uint32_t window_height,
                                       int32_t inset_left, int32_t inset_top, int32_t inset_right, int32_t inset_bottom,
@@ -732,6 +733,12 @@ namespace dmGui
             {
                 nodes[i].m_Node.m_Texture     = texture_source;
                 nodes[i].m_Node.m_TextureType = texture_type;
+
+                if (texture_type == NODE_TEXTURE_TYPE_TEXTURE_SET)
+                {
+                    UpdateTextureSetAnimData(scene, &nodes[i]);
+                    CalculateNodeSize(&nodes[i]);
+                }
             }
         }
     }
@@ -2401,8 +2408,11 @@ namespace dmGui
         uint32_t node_count = scene->m_Nodes.Size();
         InternalNode* nodes = scene->m_Nodes.Begin();
 
+		// It's needed in cases when texture reloaded using hot reload
+		// There is no way to notify nodes about it
         if (dLib::IsDebugMode())
         {
+            DM_PROFILE("DebugUpdateTextureSetAnimData");
             for (uint32_t i = 0; i < node_count; ++i)
             {
                 InternalNode* node = &nodes[i];


### PR DESCRIPTION
Fixed an issue where, when updating a texture in GUI, `go.set()` updates node parameters in debug builds but doesn't update them in release builds.

Fix https://github.com/defold/defold/issues/11572