### PR TITLE
Only run culling function if there is items to test

### DIFF
--- a/engine/render/src/render/render.cpp
+++ b/engine/render/src/render/render.cpp
@@ -761,10 +761,13 @@ namespace dmRender
                         i++;
                     }
 
-                    // Execute culling for this sub-batch
+                    // Execute culling for this sub-batch if > 0
                     params.m_Entries = batch_start + sub_batch_start;
                     params.m_NumEntries = i - sub_batch_start;
-                    d->m_VisibilityFn(params);
+                    if (params.m_NumEntries > 0)
+                    {
+                        d->m_VisibilityFn(params);
+                    }
                 }
             }
         }


### PR DESCRIPTION
We currently run the culling function even if there is no culling work to be done. To make sure the amount of culling calls are correct in the profiler, we now skip calling the function in this case.