### PR TITLE
Update editor JGit dependency to version 7.6.0

### DIFF
--- a/editor/project.clj
+++ b/editor/project.clj
@@ -45,7 +45,7 @@
                      [javax.vecmath/vecmath                       "1.5.2"]
                      [org.codehaus.jackson/jackson-core-asl       "1.9.13"]
                      [org.codehaus.jackson/jackson-mapper-asl     "1.9.13"]
-                     [org.eclipse.jgit/org.eclipse.jgit           "4.2.0.201601211800-r"]
+                     [org.eclipse.jgit/org.eclipse.jgit           "7.6.0.202603022253-r"]
                      [org.apache.commons/commons-compress         "1.18"]
 
                      [net.java.dev.jna/jna                        "4.1.0"]

--- a/editor/src/clj/editor/git.clj
+++ b/editor/src/clj/editor/git.clj
@@ -19,7 +19,8 @@
             [editor.fs :as fs]
             [util.fn :as fn]
             [util.text-util :as text-util])
-  (:import [java.io File]
+  (:import [ch.qos.logback.classic Level Logger]
+           [java.io File]
            [java.util Collection]
            [org.eclipse.jgit.api Git]
            [org.eclipse.jgit.diff DiffEntry RenameDetector]
@@ -28,9 +29,23 @@
            [org.eclipse.jgit.revwalk RevCommit RevWalk]
            [org.eclipse.jgit.transport RemoteConfig URIish]
            [org.eclipse.jgit.treewalk FileTreeIterator TreeWalk]
-           [org.eclipse.jgit.treewalk.filter PathFilter PathFilterGroup]))
+           [org.eclipse.jgit.treewalk.filter PathFilter PathFilterGroup]
+           [org.slf4j LoggerFactory]))
 
 (set! *warn-on-reflection* true)
+
+;; Silence log spam.
+(run! (fn [^String class-name]
+        (let [logger (LoggerFactory/getLogger class-name)]
+          (when (instance? Logger logger)
+            (.setLevel ^Logger logger Level/WARN))))
+      ["org.eclipse.jgit.internal.storage.file.FileSnapshot"
+       "org.eclipse.jgit.internal.storage.file.Pack"
+       "org.eclipse.jgit.internal.util.ShutdownHook"
+       "org.eclipse.jgit.transport.PacketLineIn"
+       "org.eclipse.jgit.transport.PacketLineOut"
+       "org.eclipse.jgit.util.FS"
+       "org.eclipse.jgit.util.SystemReader"])
 
 ;; When opening a project, we ensure the .gitignore file contains every entry on this list.
 (defonce required-gitignore-entries ["/.editor_settings"

--- a/editor/test/editor/git_test.clj
+++ b/editor/test/editor/git_test.clj
@@ -20,13 +20,9 @@
             [editor.fs :as fs]
             [editor.git :as git]
             [util.text-util :as text-util])
-  (:import [ch.qos.logback.classic Level Logger]
-           [java.io File]
+  (:import [java.io File]
            [org.eclipse.jgit.api Git]
-           [org.eclipse.jgit.revwalk RevCommit]
-           [org.slf4j LoggerFactory]))
-
-(.setLevel ^Logger (LoggerFactory/getLogger "org.eclipse.jgit.util.FS") Level/ERROR)
+           [org.eclipse.jgit.revwalk RevCommit]))
 
 (defn create-file
   ^File [git path content]


### PR DESCRIPTION
It seems the old version of JGit we were using has trouble with some repositories created by newer Git versions.

See: https://bugs.eclipse.org/bugs/show_bug.cgi?id=581723

Fix https://github.com/defold/defold/issues/3893
Fix https://github.com/defold/defold/issues/12171