### PR TITLE
Display a warning when a profiler scope overflow occurs

### DIFF
--- a/engine/dlib/src/dlib/profile/profile.cpp
+++ b/engine/dlib/src/dlib/profile/profile.cpp
@@ -186,7 +186,9 @@ void ProfileUnregisterProfiler(const char* name)
             if (p->m_Disabled) continue;                                \
             if (p->m_ ## _FUNC)                                         \
             {                                                           \
-                result = p->m_ ## _FUNC(p->m_Ctx);                      \
+                ProfileResult listener_result = p->m_ ## _FUNC(p->m_Ctx); \
+                if (listener_result != result)                           \
+                    result = listener_result;                           \
             }                                                           \
         }                                                               \
         return result;                                                  \
@@ -201,7 +203,9 @@ void ProfileUnregisterProfiler(const char* name)
             if (p->m_Disabled) continue;                                \
             if (p->m_ ## _FUNC)                                         \
             {                                                           \
-                result = p->m_ ## _FUNC(p->m_Ctx, __VA_ARGS__);         \
+                ProfileResult listener_result = p->m_ ## _FUNC(p->m_Ctx, __VA_ARGS__); \
+                if (listener_result != result)                           \
+                    result = listener_result;                           \
             }                                                           \
         }                                                               \
         return result;                                                  \

--- a/engine/dlib/src/dlib/profile/profile.cpp
+++ b/engine/dlib/src/dlib/profile/profile.cpp
@@ -239,16 +239,34 @@ void ProfileFrameEnd(HProfile profile)
     DO_LOOP_NOARGS(FrameEnd);
 }
 
-void ProfileScopeBegin(const char* name, uint64_t* name_hash)
+ProfileScopeResult ProfileScopeBegin(const char* name, uint64_t* name_hash)
 {
+    if (!IsProfileInitialized())
+        return PROFILE_SCOPE_RESULT_NOT_INITIALIZED;
+
     DM_MUTEX_SCOPED_LOCK(g_ProfileLock);
+
+    ProfileScopeResult result = PROFILE_SCOPE_RESULT_OK;
 
     if (name_hash && !*name_hash)
     {
         *name_hash = dmHashString64(name);
     }
 
-    DO_LOOP(ScopeBegin, name, name_hash ? *name_hash : 0);
+    for (ProfileListener* p = g_ProfileListeners; p != 0; p = p->m_Next)
+    {
+        if (p->m_Disabled) continue;
+        if (p->m_ScopeBegin)
+        {
+            ProfileScopeResult listener_result = p->m_ScopeBegin(p->m_Ctx, name, name_hash ? *name_hash : 0);
+            if (listener_result != PROFILE_SCOPE_RESULT_OK)
+            {
+                result = listener_result;
+            }
+        }
+    }
+
+    return result;
 }
 
 void ProfileScopeEnd(const char* name, uint64_t name_hash)
@@ -552,4 +570,3 @@ void ProfilePropertyReset(ProfileIdx idx)
     GET_PROP_AND_CHECK(idx);
     DO_LOOP(PropertyReset, idx);
 }
-

--- a/engine/dlib/src/dlib/profile/profile.cpp
+++ b/engine/dlib/src/dlib/profile/profile.cpp
@@ -173,6 +173,40 @@ void ProfileUnregisterProfiler(const char* name)
         }                                                               \
     }
 
+#define CHECK_INITIALIZED_RETVAL(_RETVAL)                               \
+    if (!IsProfileInitialized())                                        \
+        return _RETVAL;
+
+#define DO_LOOP_NOARGS_RETVAL(_FUNC)                                    \
+    do                                                                  \
+    {                                                                   \
+        ProfileResult result = PROFILE_RESULT_OK;                       \
+        for (ProfileListener* p = g_ProfileListeners; p != 0; p = p->m_Next) \
+        {                                                               \
+            if (p->m_Disabled) continue;                                \
+            if (p->m_ ## _FUNC)                                         \
+            {                                                           \
+                result = p->m_ ## _FUNC(p->m_Ctx);                      \
+            }                                                           \
+        }                                                               \
+        return result;                                                  \
+    } while (0)
+
+#define DO_LOOP_RETVAL(_FUNC, ...)                                      \
+    do                                                                  \
+    {                                                                   \
+        ProfileResult result = PROFILE_RESULT_OK;                       \
+        for (ProfileListener* p = g_ProfileListeners; p != 0; p = p->m_Next) \
+        {                                                               \
+            if (p->m_Disabled) continue;                                \
+            if (p->m_ ## _FUNC)                                         \
+            {                                                           \
+                result = p->m_ ## _FUNC(p->m_Ctx, __VA_ARGS__);         \
+            }                                                           \
+        }                                                               \
+        return result;                                                  \
+    } while (0)
+
 
 // *****************************************************************************************
 // Initialize / Finalize
@@ -231,56 +265,48 @@ HProfile ProfileFrameBegin()
     return result;
 }
 
-void ProfileFrameEnd(HProfile profile)
+ProfileResult ProfileFrameEnd(HProfile profile)
 {
     if (!profile)
-        return;
+        return PROFILE_RESULT_OK;
 
-    DO_LOOP_NOARGS(FrameEnd);
-}
-
-ProfileScopeResult ProfileScopeBegin(const char* name, uint64_t* name_hash)
-{
-    if (!IsProfileInitialized())
-        return PROFILE_SCOPE_RESULT_NOT_INITIALIZED;
-
+    CHECK_INITIALIZED_RETVAL(PROFILE_RESULT_NOT_INITIALIZED);
     DM_MUTEX_SCOPED_LOCK(g_ProfileLock);
 
-    ProfileScopeResult result = PROFILE_SCOPE_RESULT_OK;
+    DO_LOOP_NOARGS_RETVAL(FrameEnd);
+}
 
+ProfileResult ProfileScopeBegin(const char* name, uint64_t* name_hash)
+{
+    CHECK_INITIALIZED_RETVAL(PROFILE_RESULT_NOT_INITIALIZED);
+    DM_MUTEX_SCOPED_LOCK(g_ProfileLock);
     if (name_hash && !*name_hash)
     {
         *name_hash = dmHashString64(name);
     }
 
-    for (ProfileListener* p = g_ProfileListeners; p != 0; p = p->m_Next)
-    {
-        if (p->m_Disabled) continue;
-        if (p->m_ScopeBegin)
-        {
-            result = p->m_ScopeBegin(p->m_Ctx, name, name_hash ? *name_hash : 0);
-        }
-    }
-
-    return result;
+    DO_LOOP_RETVAL(ScopeBegin, name, name_hash ? *name_hash : 0);
 }
 
-void ProfileScopeEnd(const char* name, uint64_t name_hash)
+ProfileResult ProfileScopeEnd(const char* name, uint64_t name_hash)
 {
+    CHECK_INITIALIZED_RETVAL(PROFILE_RESULT_NOT_INITIALIZED);
     DM_MUTEX_SCOPED_LOCK(g_ProfileLock);
 
-    DO_LOOP(ScopeEnd, name, name_hash);
+    DO_LOOP_RETVAL(ScopeEnd, name, name_hash);
 }
 
-void ProfileSetThreadName(const char* name)
+ProfileResult ProfileSetThreadName(const char* name)
 {
+    CHECK_INITIALIZED_RETVAL(PROFILE_RESULT_NOT_INITIALIZED);
     DM_MUTEX_SCOPED_LOCK(g_ProfileLock);
 
-    DO_LOOP(SetThreadName, name);
+    DO_LOOP_RETVAL(SetThreadName, name);
 }
 
-void ProfileLogText(const char* format, ...)
+ProfileResult ProfileLogText(const char* format, ...)
 {
+    CHECK_INITIALIZED_RETVAL(PROFILE_RESULT_NOT_INITIALIZED);
     DM_MUTEX_SCOPED_LOCK(g_ProfileLock);
 
     char buffer[DM_PROFILE_TEXT_LENGTH];
@@ -294,7 +320,7 @@ void ProfileLogText(const char* format, ...)
     }
     va_end(lst);
 
-    DO_LOOP(LogText, buffer);
+    DO_LOOP_RETVAL(LogText, buffer);
 }
 
 // *****************************************************************************************

--- a/engine/dlib/src/dlib/profile/profile.cpp
+++ b/engine/dlib/src/dlib/profile/profile.cpp
@@ -258,11 +258,7 @@ ProfileScopeResult ProfileScopeBegin(const char* name, uint64_t* name_hash)
         if (p->m_Disabled) continue;
         if (p->m_ScopeBegin)
         {
-            ProfileScopeResult listener_result = p->m_ScopeBegin(p->m_Ctx, name, name_hash ? *name_hash : 0);
-            if (listener_result != PROFILE_SCOPE_RESULT_OK)
-            {
-                result = listener_result;
-            }
+            result = p->m_ScopeBegin(p->m_Ctx, name, name_hash ? *name_hash : 0);
         }
     }
 

--- a/engine/dlib/src/dlib/profile/profile_null.cpp
+++ b/engine/dlib/src/dlib/profile/profile_null.cpp
@@ -27,8 +27,10 @@ bool ProfileIsInitialized()
     return false;
 }
 
-void ProfileSetThreadName(const char* name)
+ProfileResult ProfileSetThreadName(const char* name)
 {
+    (void)name;
+    return PROFILE_RESULT_NOT_INITIALIZED;
 }
 
 HProfile ProfileFrameBegin()
@@ -36,21 +38,30 @@ HProfile ProfileFrameBegin()
     return 0;
 }
 
-void ProfileFrameEnd(HProfile profile)
+ProfileResult ProfileFrameEnd(HProfile profile)
 {
+    (void)profile;
+    return PROFILE_RESULT_NOT_INITIALIZED;
 }
 
-ProfileScopeResult ProfileScopeBegin(const char* name, uint64_t* name_hash)
+ProfileResult ProfileScopeBegin(const char* name, uint64_t* name_hash)
 {
-    return PROFILE_SCOPE_RESULT_NOT_INITIALIZED;
+    (void)name;
+    (void)name_hash;
+    return PROFILE_RESULT_NOT_INITIALIZED;
 }
 
-void ProfileScopeEnd(const char* name, uint64_t name_hash)
+ProfileResult ProfileScopeEnd(const char* name, uint64_t name_hash)
 {
+    (void)name;
+    (void)name_hash;
+    return PROFILE_RESULT_NOT_INITIALIZED;
 }
 
-void ProfileLogText(const char* text, ...)
+ProfileResult ProfileLogText(const char* text, ...)
 {
+    (void)text;
+    return PROFILE_RESULT_NOT_INITIALIZED;
 }
 
 void ProfilePropertySetBool(ProfileIdx idx, int v)

--- a/engine/dlib/src/dlib/profile/profile_null.cpp
+++ b/engine/dlib/src/dlib/profile/profile_null.cpp
@@ -40,8 +40,9 @@ void ProfileFrameEnd(HProfile profile)
 {
 }
 
-void ProfileScopeBegin(const char* name, uint64_t* name_hash)
+ProfileScopeResult ProfileScopeBegin(const char* name, uint64_t* name_hash)
 {
+    return PROFILE_SCOPE_RESULT_NOT_INITIALIZED;
 }
 
 void ProfileScopeEnd(const char* name, uint64_t name_hash)

--- a/engine/dlib/src/dmsdk/dlib/profile.h
+++ b/engine/dlib/src/dmsdk/dlib/profile.h
@@ -89,6 +89,20 @@ enum ProfilePropertyFlags
     PROFILE_PROPERTY_FRAME_RESET = 1  // reset the property each frame
 };
 
+/*# Enum to describe the result of starting a profile scope
+ * @enum
+ * @name ProfileScopeResult
+ * @member PROFILE_SCOPE_RESULT_OK
+ * @member PROFILE_SCOPE_RESULT_NOT_INITIALIZED
+ * @member PROFILE_SCOPE_RESULT_OUT_OF_SAMPLES
+ */
+enum ProfileScopeResult
+{
+    PROFILE_SCOPE_RESULT_OK = 0,
+    PROFILE_SCOPE_RESULT_NOT_INITIALIZED = 1,
+    PROFILE_SCOPE_RESULT_OUT_OF_SAMPLES = 2,
+};
+
 /*# Index constant to mark a a property as invalid
  * @enum
  * @name PROFILE_PROPERTY_INVALID_IDX
@@ -216,7 +230,7 @@ typedef void (*ProfileDestroyListenerFn)(void* ctx);
 
 typedef void (*ProfileFrameBeginFn)(void* ctx);
 typedef void (*ProfileFrameEndFn)(void* ctx);
-typedef void (*ProfileScopeBeginFn)(void* ctx, const char* name, uint64_t name_hash);
+typedef ProfileScopeResult (*ProfileScopeBeginFn)(void* ctx, const char* name, uint64_t name_hash);
 typedef void (*ProfileScopeEndFn)(void* ctx, const char* name, uint64_t name_hash);
 typedef void (*ProfileSetThreadNameFn)(void* ctx, const char* name);
 typedef void (*ProfileLogTextFn)(void* ctx, const char* text);
@@ -352,8 +366,9 @@ void ProfileFrameEnd(HProfile profile);
  * @name ProfileScopeBegin
  * @param name [type:const char*] Name of the scope
  * @param name_hash [type:uint64_t] Hashed name of the scope
+ * @return result [type:ProfileScopeResult] Status for the scope begin operation
  */
-void ProfileScopeBegin(const char* name, uint64_t* name_hash);
+ProfileScopeResult ProfileScopeBegin(const char* name, uint64_t* name_hash);
 
 /*#
  * End the last added scope

--- a/engine/dlib/src/dmsdk/dlib/profile.h
+++ b/engine/dlib/src/dmsdk/dlib/profile.h
@@ -89,18 +89,18 @@ enum ProfilePropertyFlags
     PROFILE_PROPERTY_FRAME_RESET = 1  // reset the property each frame
 };
 
-/*# Enum to describe the result of starting a profile scope
+/*# Enum to describe the result of a profiler operation
  * @enum
- * @name ProfileScopeResult
- * @member PROFILE_SCOPE_RESULT_OK
- * @member PROFILE_SCOPE_RESULT_NOT_INITIALIZED
- * @member PROFILE_SCOPE_RESULT_OUT_OF_SAMPLES
+ * @name ProfileResult
+ * @member PROFILE_RESULT_OK
+ * @member PROFILE_RESULT_NOT_INITIALIZED
+ * @member PROFILE_RESULT_OUT_OF_SAMPLES
  */
-enum ProfileScopeResult
+enum ProfileResult
 {
-    PROFILE_SCOPE_RESULT_OK = 0,
-    PROFILE_SCOPE_RESULT_NOT_INITIALIZED = 1,
-    PROFILE_SCOPE_RESULT_OUT_OF_SAMPLES = 2,
+    PROFILE_RESULT_OK = 0,
+    PROFILE_RESULT_NOT_INITIALIZED = 1,
+    PROFILE_RESULT_OUT_OF_SAMPLES = 2,
 };
 
 /*# Index constant to mark a a property as invalid
@@ -228,12 +228,12 @@ const uint32_t PROFILE_PROPERTY_INVALID_IDX = 0xFFFFFFFF;
 typedef void* (*ProfileCreateListenerFn)();
 typedef void (*ProfileDestroyListenerFn)(void* ctx);
 
-typedef void (*ProfileFrameBeginFn)(void* ctx);
-typedef void (*ProfileFrameEndFn)(void* ctx);
-typedef ProfileScopeResult (*ProfileScopeBeginFn)(void* ctx, const char* name, uint64_t name_hash);
-typedef void (*ProfileScopeEndFn)(void* ctx, const char* name, uint64_t name_hash);
-typedef void (*ProfileSetThreadNameFn)(void* ctx, const char* name);
-typedef void (*ProfileLogTextFn)(void* ctx, const char* text);
+typedef ProfileResult (*ProfileFrameBeginFn)(void* ctx);
+typedef ProfileResult (*ProfileFrameEndFn)(void* ctx);
+typedef ProfileResult (*ProfileScopeBeginFn)(void* ctx, const char* name, uint64_t name_hash);
+typedef ProfileResult (*ProfileScopeEndFn)(void* ctx, const char* name, uint64_t name_hash);
+typedef ProfileResult (*ProfileSetThreadNameFn)(void* ctx, const char* name);
+typedef ProfileResult (*ProfileLogTextFn)(void* ctx, const char* text);
 
 typedef void (*ProfilePropertyCreateGroupFn)(void* ctx, const char* name, const char* desc, ProfileIdx idx, ProfileIdx parent);
 typedef void (*ProfilePropertyCreateBoolFn)(void* ctx, const char* name, const char* desc, int value, uint32_t flags, ProfileIdx idx, ProfileIdx parent);
@@ -343,8 +343,9 @@ bool ProfileIsInitialized();
  * Set the current thread name to each registered profiler
  * @name ProfileSetThreadName
  * @param name [type:const char*] Name of the thread
+ * @return result [type:ProfileResult] Status for the thread name operation
  */
-void ProfileSetThreadName(const char* name);
+ProfileResult ProfileSetThreadName(const char* name);
 
 /*#
  * Begin profiling, eg start of frame
@@ -358,36 +359,39 @@ HProfile ProfileFrameBegin();
  * Release profile returned by #ProfileFrameBegin
  * @name ProfileFrameEnd
  * @param profile [type: HProfile] Profile to release
+ * @return result [type:ProfileResult] Status for the frame end operation
  */
-void ProfileFrameEnd(HProfile profile);
+ProfileResult ProfileFrameEnd(HProfile profile);
 
 /*#
  * Start a new profile scope
  * @name ProfileScopeBegin
  * @param name [type:const char*] Name of the scope
  * @param name_hash [type:uint64_t] Hashed name of the scope
- * @return result [type:ProfileScopeResult] Status for the scope begin operation
+ * @return result [type:ProfileResult] Status for the scope begin operation
  */
-ProfileScopeResult ProfileScopeBegin(const char* name, uint64_t* name_hash);
+ProfileResult ProfileScopeBegin(const char* name, uint64_t* name_hash);
 
 /*#
  * End the last added scope
  * @name ProfileScopeEnd
  * @param name [type:const char*] Name of the scope
  * @param name_hash [type:uint64_t] Hashed name of the scope
+ * @return result [type:ProfileResult] Status for the scope end operation
  */
-void ProfileScopeEnd(const char* name, uint64_t name_hash);
+ProfileResult ProfileScopeEnd(const char* name, uint64_t name_hash);
 
 /*#
  * Log text via the registered profilers
  * @name ProfileLogText
  * @param name [type:const char*] Name of the scope
  * @param ... [type: va_list] Arguments for internal logging function
+ * @return result [type:ProfileResult] Status for the log text operation
  */
 #ifdef __GNUC__
-    void ProfileLogText(const char* text, ...) __attribute__ ((format (printf, 1, 2)));
+    ProfileResult ProfileLogText(const char* text, ...) __attribute__ ((format (printf, 1, 2)));
 #else
-    void ProfileLogText(const char* text, ...);
+    ProfileResult ProfileLogText(const char* text, ...);
 #endif
 
 /// Internal, do not use. Use DM_PROFILE() instead

--- a/engine/dlib/src/test/test_profiler_dummy.cpp
+++ b/engine/dlib/src/test/test_profiler_dummy.cpp
@@ -33,10 +33,11 @@ static const char*              g_ProfilerName = "ProfilerDummy";
 static ProfileListener          g_Listener = {};
 
 
-static void LogText(void* _ctx, const char* text)
+static ProfileResult LogText(void* _ctx, const char* text)
 {
     ProfilerDummyContext* ctx = (ProfilerDummyContext*)_ctx;
     dmStrlCat(ctx->m_TextBuffer, text, sizeof(ctx->m_TextBuffer));
+    return PROFILE_RESULT_OK;
 }
 
 static void* CreateListener()
@@ -265,12 +266,13 @@ static void ProfilePropertyReset(void* _ctx, ProfileIdx idx)
     prop->m_Value = prop->m_DefaultValue;
 }
 
-static void FrameBegin(void* ctx)
+static ProfileResult FrameBegin(void* ctx)
 {
     (void)ctx;
+    return PROFILE_RESULT_OK;
 }
 
-static void FrameEnd(void* ctx)
+static ProfileResult FrameEnd(void* ctx)
 {
     (void)ctx;
 
@@ -279,6 +281,7 @@ static void FrameEnd(void* ctx)
     g_Context->m_NumProperties = 0;
     g_Context->m_NumSamples = 1;
     g_Context->m_CurrentSample = &g_Context->m_Samples[0];
+    return PROFILE_RESULT_OK;
 }
 
 static ProfilerDummySample* AllocateSample(ProfilerDummyContext* ctx, uint64_t name_hash)
@@ -324,7 +327,7 @@ static ProfilerDummySample* AllocateSample(ProfilerDummyContext* ctx, uint64_t n
     return sample;
 }
 
-static ProfileScopeResult ScopeBegin(void* ctx, const char* name, uint64_t name_hash)
+static ProfileResult ScopeBegin(void* ctx, const char* name, uint64_t name_hash)
 {
     (void)ctx;
 
@@ -340,10 +343,10 @@ static ProfileScopeResult ScopeBegin(void* ctx, const char* name, uint64_t name_
     else
         sample->m_Start = tstart;
 
-    return PROFILE_SCOPE_RESULT_OK;
+    return PROFILE_RESULT_OK;
 }
 
-static void ScopeEnd(void* _ctx, const char* name, uint64_t name_hash)
+static ProfileResult ScopeEnd(void* _ctx, const char* name, uint64_t name_hash)
 {
     ProfilerDummyContext* ctx = (ProfilerDummyContext*)_ctx;
 
@@ -366,6 +369,7 @@ static void ScopeEnd(void* _ctx, const char* name, uint64_t name_hash)
 
     ctx->m_CurrentSample = sample->m_Parent;
     assert(ctx->m_CurrentSample != 0);
+    return PROFILE_RESULT_OK;
 }
 
 void DummyProfilerRegister()

--- a/engine/dlib/src/test/test_profiler_dummy.cpp
+++ b/engine/dlib/src/test/test_profiler_dummy.cpp
@@ -324,7 +324,7 @@ static ProfilerDummySample* AllocateSample(ProfilerDummyContext* ctx, uint64_t n
     return sample;
 }
 
-static void ScopeBegin(void* ctx, const char* name, uint64_t name_hash)
+static ProfileScopeResult ScopeBegin(void* ctx, const char* name, uint64_t name_hash)
 {
     (void)ctx;
 
@@ -339,6 +339,8 @@ static void ScopeBegin(void* ctx, const char* name, uint64_t name_hash)
         sample->m_TempStart = tstart;
     else
         sample->m_Start = tstart;
+
+    return PROFILE_SCOPE_RESULT_OK;
 }
 
 static void ScopeEnd(void* _ctx, const char* name, uint64_t name_hash)

--- a/engine/engine/src/test/test_profilerext_lua.cpp
+++ b/engine/engine/src/test/test_profilerext_lua.cpp
@@ -224,6 +224,19 @@ TEST_F(ProfilerExtLuaTest, CoroutineScopesAreAutoClosedOnFinalize)
     ASSERT_NE((char*) 0, strstr(log, "Lua profiler scope 'coroutine_finalize' was not closed before the end of the frame. Auto-closing it."));
 }
 
+TEST_F(ProfilerExtLuaTest, ExcessiveUniqueScopesDoNotHangProfiler)
+{
+    ASSERT_TRUE(RunString(
+        "profiler.scope_begin(\"overflow_root\")\n"
+        "for i = 1, 4200 do\n"
+        "    profiler.scope_begin(\"overflow_child_\" .. i)\n"
+        "    profiler.scope_end()\n"
+        "end\n"
+        "profiler.scope_end()\n"
+        "profiler.scope_begin(\"after_overflow\")\n"
+        "profiler.scope_end()\n"));
+}
+
 TEST_F(ProfilerExtLuaTest, GarbageCollectedCoroutineScopeStateIsReleasedOnPreRender)
 {
     ASSERT_TRUE(RunString(

--- a/engine/engine/src/test/test_profilerext_lua.cpp
+++ b/engine/engine/src/test/test_profilerext_lua.cpp
@@ -235,6 +235,10 @@ TEST_F(ProfilerExtLuaTest, ExcessiveUniqueScopesDoNotHangProfiler)
         "profiler.scope_end()\n"
         "profiler.scope_begin(\"after_overflow\")\n"
         "profiler.scope_end()\n"));
+
+    char* log = GetLog();
+    ASSERT_NE((char*) 0, strstr(log, "Lua profiler scope 'overflow_child_"));
+    ASSERT_NE((char*) 0, strstr(log, "exceeded the profiler sample limit"));
 }
 
 TEST_F(ProfilerExtLuaTest, GarbageCollectedCoroutineScopeStateIsReleasedOnPreRender)

--- a/engine/profiler/src/basic/profiler_basic.cpp
+++ b/engine/profiler/src/basic/profiler_basic.cpp
@@ -644,17 +644,18 @@ static void FrameEnd(void* ctx)
     ResetProperties(g_ProfileContext);
 }
 
-static void ScopeBegin(void* ctx, const char* name, uint64_t name_hash)
+static ProfileScopeResult ScopeBegin(void* ctx, const char* name, uint64_t name_hash)
 {
     (void)ctx;
-    CHECK_INITIALIZED();
+    if (!IsProfileInitialized())
+        return PROFILE_SCOPE_RESULT_NOT_INITIALIZED;
     DM_MUTEX_SCOPED_LOCK(g_Lock);
 
     ThreadData* td = GetOrCreateThreadData(g_ProfileContext, GetThreadId());
     if (td->m_OverflowDepth != 0)
     {
         td->m_OverflowDepth++;
-        return;
+        return PROFILE_SCOPE_RESULT_OUT_OF_SAMPLES;
     }
 
     uint64_t tstart = dmTime::GetMonotonicTime();
@@ -665,7 +666,7 @@ static void ScopeBegin(void* ctx, const char* name, uint64_t name_hash)
         // Once the sample pool is exhausted we skip nested scopes until the stack is balanced
         // again, instead of linking a shared sentinel node into the sample tree.
         td->m_OverflowDepth = 1;
-        return;
+        return PROFILE_SCOPE_RESULT_OUT_OF_SAMPLES;
     }
 
     InternalizeName(name, &sample_name_hash);
@@ -674,6 +675,8 @@ static void ScopeBegin(void* ctx, const char* name, uint64_t name_hash)
         sample->m_TempStart = tstart;
     else
         sample->m_Start = tstart;
+
+    return PROFILE_SCOPE_RESULT_OK;
 }
 
 static void ScopeEnd(void* ctx, const char* name, uint64_t name_hash)

--- a/engine/profiler/src/basic/profiler_basic.cpp
+++ b/engine/profiler/src/basic/profiler_basic.cpp
@@ -111,6 +111,7 @@ struct ThreadData
     Sample*         m_CurrentSample;
     dmArray<Sample> m_SamplePool;
     int32_t         m_ThreadId;
+    uint32_t        m_OverflowDepth;
 
     ThreadData(int32_t thread_id)
         : m_ThreadId(thread_id)
@@ -128,11 +129,9 @@ struct ThreadData
 
 static Sample* AllocateNewSample(ThreadData* td)
 {
-    static Sample g_DummySample = { 0 };
-
     if (td->m_SamplePool.Full())
     {
-        return &g_DummySample;
+        return 0;
     }
 
     td->m_SamplePool.SetSize(td->m_SamplePool.Size() + 1);
@@ -145,6 +144,7 @@ static void ResetThreadData(ThreadData* td)
     td->m_Root.m_FirstChild = 0;
     td->m_Root.m_LastChild = 0;
     td->m_CurrentSample = &td->m_Root;
+    td->m_OverflowDepth = 0;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////
@@ -382,6 +382,10 @@ static Sample* AllocateSample(ThreadData* td, uint32_t name_hash)
     if (!sample)
     {
         sample = AllocateNewSample(td);
+        if (!sample)
+        {
+            return 0;
+        }
         memset(sample, 0, sizeof(Sample));
 
         sample->m_NameHash = name_hash;
@@ -646,12 +650,25 @@ static void ScopeBegin(void* ctx, const char* name, uint64_t name_hash)
     CHECK_INITIALIZED();
     DM_MUTEX_SCOPED_LOCK(g_Lock);
 
-    uint64_t    tstart = dmTime::GetMonotonicTime();
-
-    InternalizeName(name, (uint32_t*)&name_hash);
-
     ThreadData* td = GetOrCreateThreadData(g_ProfileContext, GetThreadId());
-    Sample*     sample = AllocateSample(td, name_hash); // Adds it to the thread data
+    if (td->m_OverflowDepth != 0)
+    {
+        td->m_OverflowDepth++;
+        return;
+    }
+
+    uint64_t tstart = dmTime::GetMonotonicTime();
+    uint32_t sample_name_hash = GetOrCacheNameHash(name, (uint32_t*)&name_hash);
+    Sample* sample = AllocateSample(td, sample_name_hash); // Adds it to the thread data
+    if (!sample)
+    {
+        // Once the sample pool is exhausted we skip nested scopes until the stack is balanced
+        // again, instead of linking a shared sentinel node into the sample tree.
+        td->m_OverflowDepth = 1;
+        return;
+    }
+
+    InternalizeName(name, &sample_name_hash);
 
     if (sample->m_CallCount > 1) // we want to preserve the real start of this sample
         sample->m_TempStart = tstart;
@@ -665,9 +682,15 @@ static void ScopeEnd(void* ctx, const char* name, uint64_t name_hash)
     CHECK_INITIALIZED();
     DM_MUTEX_SCOPED_LOCK(g_Lock);
 
+    ThreadData* td = GetOrCreateThreadData(g_ProfileContext, GetThreadId());
+    if (td->m_OverflowDepth != 0)
+    {
+        td->m_OverflowDepth--;
+        return;
+    }
+
     uint64_t    end = dmTime::GetMonotonicTime();
 
-    ThreadData* td = GetOrCreateThreadData(g_ProfileContext, GetThreadId());
     Sample*     sample = td->m_CurrentSample;
 
     uint64_t    length = 0;

--- a/engine/profiler/src/basic/profiler_basic.cpp
+++ b/engine/profiler/src/basic/profiler_basic.cpp
@@ -577,11 +577,11 @@ namespace dmProfiler
 // ***************************************************************************************************************
 // Listener api
 
-static void SetThreadName(void* ctx, const char* name)
+static ProfileResult SetThreadName(void* ctx, const char* name)
 {
     (void)ctx;
     PropertyInitialize();
-    CHECK_INITIALIZED();
+    CHECK_INITIALIZED_RETVAL(PROFILE_RESULT_NOT_INITIALIZED);
     DM_MUTEX_SCOPED_LOCK(g_Lock);
     int32_t      thread_id = GetThreadId();
     const char** existing = g_ProfileContext->m_ThreadNames.Get(thread_id);
@@ -596,6 +596,7 @@ static void SetThreadName(void* ctx, const char* name)
         g_ProfileContext->m_ThreadNames.SetCapacity((cap * 2) / 3, cap);
     }
     g_ProfileContext->m_ThreadNames.Put(thread_id, strdup(name));
+    return PROFILE_RESULT_OK;
 }
 
 static void* CreateListener()
@@ -624,17 +625,18 @@ static void DestroyListener(void* listener)
     g_Lock = 0;
 }
 
-static void FrameBegin(void* ctx)
+static ProfileResult FrameBegin(void* ctx)
 {
     (void)ctx;
-    CHECK_INITIALIZED();
+    CHECK_INITIALIZED_RETVAL(PROFILE_RESULT_NOT_INITIALIZED);
     DM_MUTEX_SCOPED_LOCK(g_Lock);
+    return PROFILE_RESULT_OK;
 }
 
-static void FrameEnd(void* ctx)
+static ProfileResult FrameEnd(void* ctx)
 {
     (void)ctx;
-    CHECK_INITIALIZED();
+    CHECK_INITIALIZED_RETVAL(PROFILE_RESULT_NOT_INITIALIZED);
     DM_MUTEX_SCOPED_LOCK(g_Lock);
 
     // For each top property
@@ -642,20 +644,20 @@ static void FrameEnd(void* ctx)
         g_PropertyTreeCallback(g_PropertyTreeCallbackCtx, 0); // 0 being the root index
 
     ResetProperties(g_ProfileContext);
+    return PROFILE_RESULT_OK;
 }
 
-static ProfileScopeResult ScopeBegin(void* ctx, const char* name, uint64_t name_hash)
+static ProfileResult ScopeBegin(void* ctx, const char* name, uint64_t name_hash)
 {
     (void)ctx;
-    if (!IsProfileInitialized())
-        return PROFILE_SCOPE_RESULT_NOT_INITIALIZED;
+    CHECK_INITIALIZED_RETVAL(PROFILE_RESULT_NOT_INITIALIZED);
     DM_MUTEX_SCOPED_LOCK(g_Lock);
 
     ThreadData* td = GetOrCreateThreadData(g_ProfileContext, GetThreadId());
     if (td->m_OverflowDepth != 0)
     {
         td->m_OverflowDepth++;
-        return PROFILE_SCOPE_RESULT_OUT_OF_SAMPLES;
+        return PROFILE_RESULT_OUT_OF_SAMPLES;
     }
 
     uint64_t tstart = dmTime::GetMonotonicTime();
@@ -666,7 +668,7 @@ static ProfileScopeResult ScopeBegin(void* ctx, const char* name, uint64_t name_
         // Once the sample pool is exhausted we skip nested scopes until the stack is balanced
         // again, instead of linking a shared sentinel node into the sample tree.
         td->m_OverflowDepth = 1;
-        return PROFILE_SCOPE_RESULT_OUT_OF_SAMPLES;
+        return PROFILE_RESULT_OUT_OF_SAMPLES;
     }
 
     InternalizeName(name, &sample_name_hash);
@@ -676,20 +678,20 @@ static ProfileScopeResult ScopeBegin(void* ctx, const char* name, uint64_t name_
     else
         sample->m_Start = tstart;
 
-    return PROFILE_SCOPE_RESULT_OK;
+    return PROFILE_RESULT_OK;
 }
 
-static void ScopeEnd(void* ctx, const char* name, uint64_t name_hash)
+static ProfileResult ScopeEnd(void* ctx, const char* name, uint64_t name_hash)
 {
     (void)ctx;
-    CHECK_INITIALIZED();
+    CHECK_INITIALIZED_RETVAL(PROFILE_RESULT_NOT_INITIALIZED);
     DM_MUTEX_SCOPED_LOCK(g_Lock);
 
     ThreadData* td = GetOrCreateThreadData(g_ProfileContext, GetThreadId());
     if (td->m_OverflowDepth != 0)
     {
         td->m_OverflowDepth--;
-        return;
+        return PROFILE_RESULT_OK;
     }
 
     uint64_t    end = dmTime::GetMonotonicTime();
@@ -732,6 +734,8 @@ static void ScopeEnd(void* ctx, const char* name, uint64_t name_hash)
 
         ResetThreadData(td);
     }
+
+    return PROFILE_RESULT_OK;
 }
 
 // ***************************************************************************************************************

--- a/engine/profiler/src/js/profiler_js.cpp
+++ b/engine/profiler/src/js/profiler_js.cpp
@@ -204,9 +204,9 @@ static void DestroyListener(void*)
     g_Lock = 0;
 }
 
-static void SetThreadName(void*, const char* name)
+static ProfileResult SetThreadName(void*, const char* name)
 {
-    CHECK_INITIALIZED();
+    CHECK_INITIALIZED_RETVAL(PROFILE_RESULT_NOT_INITIALIZED);
     DM_MUTEX_SCOPED_LOCK(g_Lock);
     if (g_ProfileContext->m_ThreadNames.Full())
     {
@@ -214,40 +214,43 @@ static void SetThreadName(void*, const char* name)
         g_ProfileContext->m_ThreadNames.SetCapacity((cap*2)/3, cap);
     }
     g_ProfileContext->m_ThreadNames.Put(GetThreadId(), strdup(name));
+    return PROFILE_RESULT_OK;
 }
 
-static void FrameBegin(void*)
+static ProfileResult FrameBegin(void*)
 {
+    return PROFILE_RESULT_OK;
 }
 
-static void FrameEnd(void*)
+static ProfileResult FrameEnd(void*)
 {
-    CHECK_INITIALIZED();
+    CHECK_INITIALIZED_RETVAL(PROFILE_RESULT_NOT_INITIALIZED);
     DM_MUTEX_SCOPED_LOCK(g_Lock);
 
     dmProfileJSEndFrame(GetThreadId());
+    return PROFILE_RESULT_OK;
 }
 
-static ProfileScopeResult ScopeBegin(void*, const char* name, uint64_t name_hash)
+static ProfileResult ScopeBegin(void*, const char* name, uint64_t name_hash)
 {
     (void)name_hash;
-    if (!IsProfileInitialized())
-        return PROFILE_SCOPE_RESULT_NOT_INITIALIZED;
+    CHECK_INITIALIZED_RETVAL(PROFILE_RESULT_NOT_INITIALIZED);
     DM_MUTEX_SCOPED_LOCK(g_Lock);
     dmProfileJSBeginMark(GetThreadId(), name);
-    return PROFILE_SCOPE_RESULT_OK;
+    return PROFILE_RESULT_OK;
 }
 
-static void ScopeEnd(void*, const char* name, uint64_t name_hash)
+static ProfileResult ScopeEnd(void*, const char* name, uint64_t name_hash)
 {
     (void)name_hash;
-    CHECK_INITIALIZED();
+    CHECK_INITIALIZED_RETVAL(PROFILE_RESULT_NOT_INITIALIZED);
     DM_MUTEX_SCOPED_LOCK(g_Lock);
     const int32_t thread_id = GetThreadId();
 
     if (dmProfileJSEndMark(thread_id)) {
         dmProfileJSReset(thread_id);
     }
+    return PROFILE_RESULT_OK;
 }
 
 // *******************************************************************

--- a/engine/profiler/src/js/profiler_js.cpp
+++ b/engine/profiler/src/js/profiler_js.cpp
@@ -228,12 +228,14 @@ static void FrameEnd(void*)
     dmProfileJSEndFrame(GetThreadId());
 }
 
-static void ScopeBegin(void*, const char* name, uint64_t name_hash)
+static ProfileScopeResult ScopeBegin(void*, const char* name, uint64_t name_hash)
 {
     (void)name_hash;
-    CHECK_INITIALIZED();
+    if (!IsProfileInitialized())
+        return PROFILE_SCOPE_RESULT_NOT_INITIALIZED;
     DM_MUTEX_SCOPED_LOCK(g_Lock);
     dmProfileJSBeginMark(GetThreadId(), name);
+    return PROFILE_SCOPE_RESULT_OK;
 }
 
 static void ScopeEnd(void*, const char* name, uint64_t name_hash)

--- a/engine/profiler/src/profiler.cpp
+++ b/engine/profiler/src/profiler.cpp
@@ -192,10 +192,10 @@ static void PushLuaProfilerScope(lua_State* L, const char* name, uint32_t name_l
     LuaProfilerScope scope;
     scope.m_NameOffset = state->m_Names.Size();
     uint64_t name_hash = 0;
-    ProfileScopeResult result = ProfileScopeBegin(name, &name_hash);
+    ProfileResult result = ProfileScopeBegin(name, &name_hash);
     scope.m_NameHash = name_hash;
 
-    if (result == PROFILE_SCOPE_RESULT_OUT_OF_SAMPLES)
+    if (result == PROFILE_RESULT_OUT_OF_SAMPLES)
     {
         dmLogWarning("Lua profiler scope '%s' exceeded the profiler sample limit for the current thread/frame. Additional Lua profiler scopes will be dropped until the stack unwinds.", name);
     }

--- a/engine/profiler/src/profiler.cpp
+++ b/engine/profiler/src/profiler.cpp
@@ -192,8 +192,13 @@ static void PushLuaProfilerScope(lua_State* L, const char* name, uint32_t name_l
     LuaProfilerScope scope;
     scope.m_NameOffset = state->m_Names.Size();
     uint64_t name_hash = 0;
-    ProfileScopeBegin(name, &name_hash);
+    ProfileScopeResult result = ProfileScopeBegin(name, &name_hash);
     scope.m_NameHash = name_hash;
+
+    if (result == PROFILE_SCOPE_RESULT_OUT_OF_SAMPLES)
+    {
+        dmLogWarning("Lua profiler scope '%s' exceeded the profiler sample limit for the current thread/frame. Additional Lua profiler scopes will be dropped until the stack unwinds.", name);
+    }
 
     uint32_t name_size = name_length + 1;
     uint32_t names_size = state->m_Names.Size();

--- a/engine/profiler/src/remotery/profiler_remotery.cpp
+++ b/engine/profiler/src/remotery/profiler_remotery.cpp
@@ -124,14 +124,15 @@ namespace dmProfilerRemotery
         rmt_LogText(text);
     }
 
-    static void ScopeBegin(void* ctx, const char* name, uint64_t name_hash)
+    static ProfileScopeResult ScopeBegin(void* ctx, const char* name, uint64_t name_hash)
     {
         if (!IsInitialized())
         {
-            return;
+            return PROFILE_SCOPE_RESULT_NOT_INITIALIZED;
         }
         // By passing in 0 here, it will have to hash the string each time
         _rmt_BeginCPUSample(name, RMTSF_Aggregate, 0);
+        return PROFILE_SCOPE_RESULT_OK;
     }
 
     static void ScopeEnd(void* ctx, const char* name, uint64_t name_hash)

--- a/engine/profiler/src/remotery/profiler_remotery.cpp
+++ b/engine/profiler/src/remotery/profiler_remotery.cpp
@@ -91,57 +91,62 @@ namespace dmProfilerRemotery
         dmSpinlock::Destroy(&g_ProfilerLock);
     }
 
-    static void SetThreadName(void*, const char* name)
+    static ProfileResult SetThreadName(void*, const char* name)
     {
         if (!IsInitialized())
-            return;
+            return PROFILE_RESULT_NOT_INITIALIZED;
         DM_SPINLOCK_SCOPED_LOCK(g_ProfilerLock);
         rmt_SetCurrentThreadName(name);
+        return PROFILE_RESULT_OK;
     }
 
-    static void FrameBegin(void*)
+    static ProfileResult FrameBegin(void*)
     {
+        return PROFILE_RESULT_OK;
     }
 
-    static void FrameEnd(void*)
+    static ProfileResult FrameEnd(void*)
     {
         if (!IsInitialized())
         {
-            return;
+            return PROFILE_RESULT_NOT_INITIALIZED;
         }
 
         rmt_PropertySnapshotAll();
         rmt_PropertyFrameResetAll();
+        return PROFILE_RESULT_OK;
     }
 
-    static void LogText(void*, const char* text)
+    static ProfileResult LogText(void*, const char* text)
     {
         if (!IsInitialized())
         {
-            return;
+            return PROFILE_RESULT_NOT_INITIALIZED;
         }
 
         rmt_LogText(text);
+        return PROFILE_RESULT_OK;
     }
 
-    static ProfileScopeResult ScopeBegin(void* ctx, const char* name, uint64_t name_hash)
+    static ProfileResult ScopeBegin(void* ctx, const char* name, uint64_t name_hash)
     {
         if (!IsInitialized())
         {
-            return PROFILE_SCOPE_RESULT_NOT_INITIALIZED;
+            return PROFILE_RESULT_NOT_INITIALIZED;
         }
         // By passing in 0 here, it will have to hash the string each time
         _rmt_BeginCPUSample(name, RMTSF_Aggregate, 0);
-        return PROFILE_SCOPE_RESULT_OK;
+        return PROFILE_RESULT_OK;
     }
 
-    static void ScopeEnd(void* ctx, const char* name, uint64_t name_hash)
+    static ProfileResult ScopeEnd(void* ctx, const char* name, uint64_t name_hash)
     {
         if (!IsInitialized())
         {
-            return;
+            return PROFILE_RESULT_NOT_INITIALIZED;
         }
         rmt_EndCPUSample();
+        return PROFILE_RESULT_OK;
     }
 
 } // namespace dmProfilerRemotery


### PR DESCRIPTION
The app used to hang if the user made a mistake and created too many scopes. That made it hard to debug. Now the profiler warns the user about the problem.

⚠️ This introduces a breaking change to the DMSDK API:
```cpp
void ProfileSetThreadName(const char* name);
void ProfileScopeBegin(const char* name, uint64_t name_hash);
void ProfileFrameEnd(HProfile profile);
void ProfileScopeEnd(const char* name, uint64_t name_hash);
void ProfileLogText(const char* text, ...);
```
replaced with 
```cpp
ProfileResult ProfileSetThreadName(const char* name);
ProfileResult ProfileScopeBegin(const char* name, uint64_t name_hash);
ProfileResult ProfileFrameEnd(HProfile profile);
ProfileResult ProfileScopeEnd(const char* name, uint64_t name_hash);
ProfileResult ProfileLogText(const char* text, ...);
// The result can be one of the following values:
// PROFILE_RESULT_OK
// PROFILE_RESULT_NOT_INITIALIZED
// PROFILE_RESULT_OUT_OF_SAMPLES
```