### PR TITLE
Fixed an issue where HTTP requests could stall during app restart

### DIFF
--- a/engine/dlib/src/dlib/connection_pool.cpp
+++ b/engine/dlib/src/dlib/connection_pool.cpp
@@ -251,12 +251,12 @@ namespace dmConnectionPool
         return false;
     }
 
-    static bool PublishInProgressSocket(HPool pool, Connection* connection, dmSocket::Socket socket)
+    static bool PublishInProgressSocket(HPool pool, Connection* connection, dmSocket::Socket* socket)
     {
         DM_MUTEX_SCOPED_LOCK(pool->m_Mutex);
         if (connection->m_State == STATE_INUSE && !connection->m_WasShutdown)
         {
-            connection->m_Socket = socket;
+            connection->m_Socket = *socket;
             return true;
         }
         return false;
@@ -292,7 +292,7 @@ namespace dmConnectionPool
         // an in-flight TCP connect and a subsequent SSL handshake. If shutdown already claimed
         // the slot before we could publish, abort immediately instead of continuing with an
         // untracked socket.
-        if (!PublishInProgressSocket(pool, connection, *socket))
+        if (!PublishInProgressSocket(pool, connection, socket))
         {
             *sr = dmSocket::RESULT_CONNABORTED;
             CloseInProgressSocket(pool, connection, socket);

--- a/engine/dlib/src/dlib/connection_pool.cpp
+++ b/engine/dlib/src/dlib/connection_pool.cpp
@@ -406,7 +406,10 @@ namespace dmConnectionPool
             }
         }
 
-        dmSSLSocket::Delete(sslsocket);
+        if (sslsocket != dmSSLSocket::INVALID_SOCKET_HANDLE)
+        {
+            dmSSLSocket::Delete(sslsocket);
+        }
         if (delete_socket)
         {
             dmSocket::Delete(socket);
@@ -531,7 +534,10 @@ namespace dmConnectionPool
 
         // If commit succeeded, ownership was transferred to the pool slot and these locals were
         // invalidated above. Otherwise they still own the uncommitted handles and must clean up.
-        dmSSLSocket::Delete(sslsocket);
+        if (sslsocket != dmSSLSocket::INVALID_SOCKET_HANDLE)
+        {
+            dmSSLSocket::Delete(sslsocket);
+        }
         if (socket != dmSocket::INVALID_SOCKET_HANDLE)
         {
             dmSocket::Delete(socket);

--- a/engine/dlib/src/dlib/connection_pool.cpp
+++ b/engine/dlib/src/dlib/connection_pool.cpp
@@ -251,24 +251,65 @@ namespace dmConnectionPool
         return false;
     }
 
-    static Result ConnectSocket(HPool pool, dmSocket::Address address, uint16_t port, int timeout, dmSocket::Socket* socket, dmSocket::Result* sr)
+    static bool PublishInProgressSocket(HPool pool, Connection* connection, dmSocket::Socket socket)
+    {
+        DM_MUTEX_SCOPED_LOCK(pool->m_Mutex);
+        if (connection->m_State == STATE_INUSE && !connection->m_WasShutdown)
+        {
+            connection->m_Socket = socket;
+            return true;
+        }
+        return false;
+    }
+
+    static void UnpublishInProgressSocket(HPool pool, Connection* connection, dmSocket::Socket socket)
+    {
+        DM_MUTEX_SCOPED_LOCK(pool->m_Mutex);
+        if (connection->m_Socket == socket)
+        {
+            connection->m_Socket = dmSocket::INVALID_SOCKET_HANDLE;
+        }
+    }
+
+    static void CloseInProgressSocket(HPool pool, Connection* connection, dmSocket::Socket* socket)
+    {
+        if (*socket != dmSocket::INVALID_SOCKET_HANDLE)
+        {
+            UnpublishInProgressSocket(pool, connection, *socket);
+            dmSocket::Delete(*socket);
+            *socket = dmSocket::INVALID_SOCKET_HANDLE;
+        }
+    }
+
+    static Result ConnectSocket(HPool pool, Connection* connection, dmSocket::Address address, uint16_t port, int timeout, dmSocket::Socket* socket, dmSocket::Result* sr)
     {
         *sr = dmSocket::New(address.m_family, dmSocket::TYPE_STREAM, dmSocket::PROTOCOL_TCP, socket);
         if (*sr != dmSocket::RESULT_OK) {
             return RESULT_SOCKET_ERROR;
         }
 
+        // Publish the raw socket as soon as it exists so pool shutdown can interrupt both
+        // an in-flight TCP connect and a subsequent SSL handshake. If shutdown already claimed
+        // the slot before we could publish, abort immediately instead of continuing with an
+        // untracked socket.
+        if (!PublishInProgressSocket(pool, connection, *socket))
+        {
+            *sr = dmSocket::RESULT_CONNABORTED;
+            CloseInProgressSocket(pool, connection, socket);
+            return RESULT_SHUT_DOWN;
+        }
+
         if( timeout > 0 )
         {
             *sr = dmSocket::SetBlocking(*socket, false);
             if (*sr != dmSocket::RESULT_OK) {
-                dmSocket::Delete(*socket);
+                CloseInProgressSocket(pool, connection, socket);
                 return RESULT_SOCKET_ERROR;
             }
 
             *sr = dmSocket::Connect(*socket, address, port);
             if (*sr != dmSocket::RESULT_OK) {
-                dmSocket::Delete(*socket);
+                CloseInProgressSocket(pool, connection, socket);
                 return RESULT_SOCKET_ERROR;
             }
 
@@ -279,13 +320,13 @@ namespace dmConnectionPool
             *sr = dmSocket::Select(&selector, timeout);
             if( *sr == dmSocket::RESULT_WOULDBLOCK )
             {
-                dmSocket::Delete(*socket);
+                CloseInProgressSocket(pool, connection, socket);
                 return RESULT_SOCKET_ERROR;
             }
 
             *sr = dmSocket::SetBlocking(*socket, true);
             if (*sr != dmSocket::RESULT_OK) {
-                dmSocket::Delete(*socket);
+                CloseInProgressSocket(pool, connection, socket);
                 return RESULT_SOCKET_ERROR;
             }
         }
@@ -293,7 +334,7 @@ namespace dmConnectionPool
         {
             *sr = dmSocket::Connect(*socket, address, port);
             if (*sr != dmSocket::RESULT_OK) {
-                dmSocket::Delete(*socket);
+                CloseInProgressSocket(pool, connection, socket);
                 return RESULT_SOCKET_ERROR;
             }
         }
@@ -323,19 +364,62 @@ namespace dmConnectionPool
 
     Result CreateSSLSocket(HPool pool, HConnection connection, const char* host, int timeout, dmSocket::Result* sock_res)
     {
-        DM_MUTEX_SCOPED_LOCK(pool->m_Mutex);
+        dmSocket::Socket socket = dmSocket::INVALID_SOCKET_HANDLE;
+        dmSSLSocket::Socket sslsocket = dmSSLSocket::INVALID_SOCKET_HANDLE;
+        bool delete_socket = false;
 
-        Connection* c = GetConnection(pool, connection);
+        {
+            DM_MUTEX_SCOPED_LOCK(pool->m_Mutex);
 
-        return CreateSSLSocket(c->m_Socket, host, timeout, &c->m_SSLSocket, sock_res);
+            Connection* c = GetConnection(pool, connection);
+            if (!pool->m_AllowNewConnections || c->m_WasShutdown || c->m_Socket == dmSocket::INVALID_SOCKET_HANDLE)
+            {
+                *sock_res = dmSocket::RESULT_CONNABORTED;
+                return RESULT_SHUT_DOWN;
+            }
+            socket = c->m_Socket;
+        }
+
+        Result r = CreateSSLSocket(socket, host, timeout, &sslsocket, sock_res);
+
+        {
+            DM_MUTEX_SCOPED_LOCK(pool->m_Mutex);
+
+            Connection* c = GetConnection(pool, connection);
+            if (r == RESULT_OK && pool->m_AllowNewConnections && !c->m_WasShutdown && c->m_Socket == socket)
+            {
+                c->m_SSLSocket = sslsocket;
+                sslsocket = dmSSLSocket::INVALID_SOCKET_HANDLE;
+            }
+            else if (r == RESULT_OK)
+            {
+                r = RESULT_SHUT_DOWN;
+                *sock_res = dmSocket::RESULT_CONNABORTED;
+            }
+
+            if (c->m_Socket != socket)
+            {
+                // The slot no longer owns the raw socket (typically because Shutdown()
+                // interrupted the in-flight handshake), so the borrowed local handle
+                // must delete it after we leave the mutex.
+                delete_socket = true;
+            }
+        }
+
+        dmSSLSocket::Delete(sslsocket);
+        if (delete_socket)
+        {
+            dmSocket::Delete(socket);
+        }
+        return r;
     }
 
-    static Result Connect(HPool pool, const char* host, dmSocket::Address address, uint16_t port, int timeout,
+    static Result Connect(HPool pool, Connection* connection, const char* host, dmSocket::Address address, uint16_t port, int timeout,
                                     dmSocket::Socket* socket, dmSocket::Result* sr)
     {
         uint64_t connectstart = dmTime::GetMonotonicTime();
 
-        Result r = ConnectSocket(pool, address, port, timeout, socket, sr);
+        Result r = ConnectSocket(pool, connection, address, port, timeout, socket, sr);
         if( r != RESULT_OK )
         {
             *socket = dmSocket::INVALID_SOCKET_HANDLE;
@@ -345,8 +429,7 @@ namespace dmConnectionPool
         uint64_t now = dmTime::GetMonotonicTime();
         if( timeout > 0 && (now - connectstart) > (uint64_t)timeout )
         {
-            dmSocket::Delete(*socket);
-            *socket = dmSocket::INVALID_SOCKET_HANDLE;
+            CloseInProgressSocket(pool, connection, socket);
             return RESULT_SOCKET_ERROR;
         }
         return r;
@@ -387,6 +470,11 @@ namespace dmConnectionPool
 
             PurgeExpired(pool);
 
+            if (!pool->m_AllowNewConnections) {
+                *sock_res = dmSocket::RESULT_CONNABORTED;
+                return RESULT_SHUT_DOWN;
+            }
+
             if (FindConnection(pool, conn_id, address, port, ssl, connection)) {
                 return RESULT_OK;
             }
@@ -404,7 +492,7 @@ namespace dmConnectionPool
         dmSocket::Socket socket = dmSocket::INVALID_SOCKET_HANDLE;
         dmSSLSocket::Socket sslsocket = dmSSLSocket::INVALID_SOCKET_HANDLE;
 
-        Result r = Connect(pool, host, address, port, timeout, &socket, sock_res);
+        Result r = Connect(pool, c, host, address, port, timeout, &socket, sock_res);
         if ((r == RESULT_OK) && ssl)
         {
             r = CreateSSLSocket(socket, host, timeout, &sslsocket, sock_res);
@@ -413,10 +501,9 @@ namespace dmConnectionPool
         {
             DM_MUTEX_SCOPED_LOCK(pool->m_Mutex);
 
-            if (r == RESULT_OK)
+            if (r == RESULT_OK && pool->m_AllowNewConnections && !c->m_WasShutdown)
             {
                 *connection = MakeHandle(pool, index, c);
-                c->m_Socket = socket;
                 c->m_SSLSocket = sslsocket;
                 c->m_ID = conn_id;
                 c->m_ReuseCount = 0;
@@ -425,12 +512,29 @@ namespace dmConnectionPool
                 c->m_Address = address;
                 c->m_Port = port;
                 c->m_WasShutdown = 0;
+                socket = dmSocket::INVALID_SOCKET_HANDLE;
+                sslsocket = dmSSLSocket::INVALID_SOCKET_HANDLE;
             }
             else
             {
-                c->m_State = STATE_FREE;
-                DoClose(pool, c);
+                // The raw socket is published into the slot before connect/handshake completes
+                // so Shutdown() can interrupt it. If we never commit the connection, ownership
+                // stays with these local variables and the slot is only reset here.
+                if (r == RESULT_OK)
+                {
+                    r = RESULT_SHUT_DOWN;
+                    *sock_res = dmSocket::RESULT_CONNABORTED;
+                }
+                c->Clear();
             }
+        }
+
+        // If commit succeeded, ownership was transferred to the pool slot and these locals were
+        // invalidated above. Otherwise they still own the uncommitted handles and must clean up.
+        dmSSLSocket::Delete(sslsocket);
+        if (socket != dmSocket::INVALID_SOCKET_HANDLE)
+        {
+            dmSocket::Delete(socket);
         }
 
         return r;
@@ -543,15 +647,17 @@ namespace dmConnectionPool
     void Reopen(HPool pool)
     {
         // This function is used by tests to restore usage of a pool
-        // We purge any live connections so the test does not run out
-        // of connection pool items
+        // We purge idle pooled connections so the test does not run out
+        // of connection pool items. In-use slots keep their handles until
+        // their owners unwind, otherwise a concurrent request can observe an
+        // invalidated connection handle during shutdown.
         DM_MUTEX_SCOPED_LOCK(pool->m_Mutex);
         uint32_t n = pool->m_Connections.Size();
         for (uint32_t i=0; i != n; i++) {
             Connection* c = &pool->m_Connections[i];
-            dmSSLSocket::Delete(c->m_SSLSocket);
-            dmSocket::Delete(c->m_Socket);
-            c->Clear();
+            if (c->m_State == STATE_CONNECTED) {
+                DoClose(pool, c);
+            }
         }
         pool->m_AllowNewConnections = 1;
     }

--- a/engine/dlib/src/test/test_httpclient.cpp
+++ b/engine/dlib/src/test/test_httpclient.cpp
@@ -1559,6 +1559,34 @@ static void ProxyCloseReusedDoesNotLeakPoolHandles(bool secure, int port, uint32
     dmHttpClient::ReopenConnectionPool();
 }
 
+struct ProxyShutdownThreadContext
+{
+    int32_atomic_t m_GotIt;
+};
+
+static void ProxyHandshakeShutdownThreadLocal(void *args)
+{
+    ProxyShutdownThreadContext* ctx = (ProxyShutdownThreadContext*)args;
+    while (!dmAtomicGet32(&ctx->m_GotIt))
+    {
+        if (dmHttpClient::GetNumPoolConnections() == 0)
+        {
+            dmTime::Sleep(1000);
+            continue;
+        }
+
+        // The proxy socket is published before the CONNECT tunnel is upgraded to TLS.
+        // Wait a bit so shutdown lands during the delayed SSL handshake on the test port.
+        dmTime::Sleep(200 * 1000);
+
+        if (dmHttpClient::ShutdownConnectionPool() > 0) {
+            dmAtomicStore32(&ctx->m_GotIt, 1);
+        } else {
+            break;
+        }
+    }
+}
+
 static void ProxyThreadedShutdownDuringHandshake(int port)
 {
     dmHttpClient::ShutdownConnectionPool();
@@ -1572,7 +1600,7 @@ static void ProxyThreadedShutdownDuringHandshake(int port)
     ProxyRequestHelper helper(url, proxy_url);
     ASSERT_TRUE(helper.IsValid());
 
-    ShutdownThreadContext ctx;
+    ProxyShutdownThreadContext ctx;
     ctx.m_GotIt = 0;
 
     dmHttpClient::SetOptionInt(helper.GetClient(), dmHttpClient::OPTION_REQUEST_TIMEOUT, 15 * 1000000);
@@ -1581,7 +1609,7 @@ static void ProxyThreadedShutdownDuringHandshake(int port)
     dmHttpClient::Result r = dmHttpClient::RESULT_OK;
     for (int i = 0; i < 3; ++i)
     {
-        dmThread::Thread thr = dmThread::New(&ProxyHandshakeShutdownThread, 65536, &ctx, "cts-proxy-ssl");
+        dmThread::Thread thr = dmThread::New(&ProxyHandshakeShutdownThreadLocal, 65536, &ctx, "cts-proxy-ssl");
 
         uint64_t timestart = dmTime::GetMonotonicTime();
         r = helper.Get("/sleep/5000");

--- a/engine/dlib/src/test/test_httpclient.cpp
+++ b/engine/dlib/src/test/test_httpclient.cpp
@@ -736,6 +736,29 @@ static void ShutdownThread(void *args)
     }
 }
 
+static void ProxyHandshakeShutdownThread(void *args)
+{
+    ShutdownThreadContext* ctx = (ShutdownThreadContext*)args;
+    while (!dmAtomicGet32(&ctx->m_GotIt))
+    {
+        if (dmHttpClient::GetNumPoolConnections() == 0)
+        {
+            dmTime::Sleep(1000);
+            continue;
+        }
+
+        // The proxy socket is published before the CONNECT tunnel is upgraded to TLS.
+        // Wait a bit so shutdown lands during the delayed SSL handshake on the test port.
+        dmTime::Sleep(200 * 1000);
+
+        if (dmHttpClient::ShutdownConnectionPool() > 0) {
+            dmAtomicStore32(&ctx->m_GotIt, 1);
+        } else {
+            break;
+        }
+    }
+}
+
 TEST_P(dmHttpClientTest, ClientThreadedShutdown)
 {
     dmHttpClient::ShutdownConnectionPool();
@@ -1061,6 +1084,47 @@ TEST_P(dmHttpClientTestSSL, FailedSSLHandshake)
             ASSERT_TRUE(0);
         }
     }
+}
+
+// Covers the shutdown gap where the raw socket exists but the connection has not yet been
+// committed back into the pool. The same publication path is used for plain TCP connect and
+// the subsequent SSL handshake, but the handshake stall is easy to reproduce locally.
+TEST_P(dmHttpClientTestSSL, ClientThreadedShutdownDuringHandshake)
+{
+    dmHttpClient::ShutdownConnectionPool();
+    dmHttpClient::ReopenConnectionPool();
+
+    ShutdownThreadContext ctx;
+    ctx.m_GotIt = 0;
+
+    dmHttpClient::SetOptionInt(m_Client, dmHttpClient::OPTION_REQUEST_TIMEOUT, 10 * 1000000);
+
+    uint64_t elapsed = 0;
+    dmHttpClient::Result r = dmHttpClient::RESULT_OK;
+    for (int i = 0; i < 3; ++i)
+    {
+        dmThread::Thread thr = dmThread::New(&ShutdownThread, 65536, &ctx, "cts-ssl");
+
+        uint64_t timestart = dmTime::GetMonotonicTime();
+        r = HttpGet("/sleep/5000");
+        elapsed = dmTime::GetMonotonicTime() - timestart;
+
+        ASSERT_NE(dmHttpClient::RESULT_OK, r);
+        ASSERT_NE(dmHttpClient::RESULT_NOT_200_OK, r);
+
+        dmThread::Join(thr);
+
+        if (dmAtomicGet32(&ctx.m_GotIt))
+            break;
+
+        dmHttpClient::ReopenConnectionPool();
+    }
+
+    ASSERT_EQ(1, dmAtomicGet32(&ctx.m_GotIt));
+    ASSERT_LT(elapsed, 3 * 1000000ULL);
+    ASSERT_EQ(0u, dmHttpClient::GetNumPoolConnections());
+
+    dmHttpClient::ReopenConnectionPool();
 }
 
 // Until we've figured out how to access the local server on windows from the device
@@ -1495,6 +1559,54 @@ static void ProxyCloseReusedDoesNotLeakPoolHandles(bool secure, int port, uint32
     dmHttpClient::ReopenConnectionPool();
 }
 
+static void ProxyThreadedShutdownDuringHandshake(int port)
+{
+    dmHttpClient::ShutdownConnectionPool();
+    dmHttpClient::ReopenConnectionPool();
+
+    char url[128];
+    char proxy_url[128];
+    MakeLocalUrl(url, sizeof(url), true, port);
+    MakeLocalProxyUrl(proxy_url, sizeof(proxy_url));
+
+    ProxyRequestHelper helper(url, proxy_url);
+    ASSERT_TRUE(helper.IsValid());
+
+    ShutdownThreadContext ctx;
+    ctx.m_GotIt = 0;
+
+    dmHttpClient::SetOptionInt(helper.GetClient(), dmHttpClient::OPTION_REQUEST_TIMEOUT, 15 * 1000000);
+
+    uint64_t elapsed = 0;
+    dmHttpClient::Result r = dmHttpClient::RESULT_OK;
+    for (int i = 0; i < 3; ++i)
+    {
+        dmThread::Thread thr = dmThread::New(&ProxyHandshakeShutdownThread, 65536, &ctx, "cts-proxy-ssl");
+
+        uint64_t timestart = dmTime::GetMonotonicTime();
+        r = helper.Get("/sleep/5000");
+        elapsed = dmTime::GetMonotonicTime() - timestart;
+
+        ASSERT_NE(dmHttpClient::RESULT_OK, r);
+        ASSERT_NE(dmHttpClient::RESULT_NOT_200_OK, r);
+        ASSERT_NE(dmSocket::RESULT_OK, dmHttpClient::GetLastSocketResult(helper.GetClient()));
+
+        dmThread::Join(thr);
+
+        if (dmAtomicGet32(&ctx.m_GotIt))
+            break;
+
+        dmHttpClient::ReopenConnectionPool();
+    }
+
+    ASSERT_EQ(1, dmAtomicGet32(&ctx.m_GotIt));
+    ASSERT_GT(elapsed, 100 * 1000ULL);
+    ASSERT_LT(elapsed, 3 * 1000000ULL);
+    ASSERT_EQ(0u, dmHttpClient::GetNumPoolConnections());
+
+    dmHttpClient::ReopenConnectionPool();
+}
+
 TEST(dmHttpClient, HostNotFound)
 {
     dmURI::Parts uri;
@@ -1560,6 +1672,12 @@ TEST(dmHttpClient, Proxy)
 TEST(dmHttpClient, ProxyHttps)
 {
     ProxyAddRequest(true, g_HttpPortSSL);
+}
+
+// Verifies that shutting down the pool interrupts the TLS handshake performed after an HTTP CONNECT proxy tunnel is established.
+TEST(dmHttpClient, ProxyHttpsThreadedShutdownDuringHandshake)
+{
+    ProxyThreadedShutdownDuringHandshake(g_HttpPortSSLTest);
 }
 
 // Verifies that a non-200 CONNECT response from the proxy is preserved as an HTTP error for HTTPS requests.


### PR DESCRIPTION
In some cases, an application restart could not complete an ongoing HTTP request, which could result in the app freezing.

### Technical changes

#### Issue explanatiion

The old DoDial() flow reserved a pool slot as STATE_INUSE, but kept the raw socket only in a local variable until connect and optional SSL handshake had already succeeded. 
That means shutdown did this:
- saw an in-use slot
- found c->m_Socket == INVALID
- set m_WasShutdown
- could not actually call shutdown() on the real fd
- returned, while the worker was still blocked in poll()

#### Fix

Publish the socket into the pool slot immediately after dmSocket::New(), before blocking connect or TLS handshake continues.
In this case `Shutdown()` can hit the real fd and interrupt the wait.

```mermaid
sequenceDiagram
    participant E as Engine restart
    participant H as HttpService::Delete
    participant P as ConnectionPool slot
    participant W as HTTP worker
    participant S as OS socket

    alt Before fix
        W->>P: reserve slot (STATE_INUSE)
        W->>S: create socket, connect, poll()
        Note over P: c->m_Socket still INVALID
        E->>H: finalize/restart
        H->>P: ShutdownConnectionPool()
        P-->>H: slot is in use, but no fd to shut down
        H->>W: pthread_join()
        S-->>W: wakes only on timeout/network result
        W-->>H: exits late
    else With staged change
        W->>S: create socket
        W->>P: publish fd immediately
        W->>S: connect / poll / SSL handshake
        E->>H: finalize/restart
        H->>P: ShutdownConnectionPool()
        P->>S: shutdown(fd)
        S-->>W: poll/handshake wakes
        W->>P: sees shutdown, aborts
        W-->>H: exits quickly
        H-->>E: join returns
    end

```