### PR TITLE
Add the ability to increase the maximum sample count in the profiler

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
@@ -1062,7 +1062,7 @@ performance_timeline_enabled.default = 0
 max_sample_count.type = integer
 max_sample_count.help = Maximum number of profiler samples recorded per thread and frame
 max_sample_count.default = 4096
-max_sample_count.minimum = 1
+max_sample_count.minimum = 128
 
 [liveupdate]
 help = Liveupdate settings

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
@@ -1059,6 +1059,11 @@ performance_timeline_enabled.type = bool
 performance_timeline_enabled.help = enable in browser performance timeline
 performance_timeline_enabled.default = 0
 
+max_sample_count.type = integer
+max_sample_count.help = Maximum number of profiler samples recorded per thread and frame
+max_sample_count.default = 4096
+max_sample_count.minimum = 1
+
 [liveupdate]
 help = Liveupdate settings
 group = Distribution

--- a/editor/resources/localization/en.editor_localization
+++ b/editor/resources/localization/en.editor_localization
@@ -1994,6 +1994,8 @@ form.label.project.profiler.sleep_between_server_updates = Server Sleep (ms)
 form.help.project.profiler.sleep_between_server_updates = Number of milliseconds to sleep between server updates
 form.label.project.profiler.performance_timeline_enabled = Performance Timeline
 form.help.project.profiler.performance_timeline_enabled = Enable reporting to the browser performance timeline
+form.label.project.profiler.max_sample_count = Max Sample Count
+form.help.project.profiler.max_sample_count = Maximum number of profiler samples recorded per thread and frame
 
 form.label.project.render = Render
 form.help.project.render = Render related settings

--- a/editor/resources/localization/ru.editor_localization
+++ b/editor/resources/localization/ru.editor_localization
@@ -1982,6 +1982,8 @@ form.label.project.profiler.sleep_between_server_updates = Пауза серве
 form.help.project.profiler.sleep_between_server_updates = Пауза в миллисекундах между обновлениями сервера профайлера
 form.label.project.profiler.performance_timeline_enabled = Веб-таймлайн
 form.help.project.profiler.performance_timeline_enabled = Включить вывод данных в браузерный Performance Timeline
+form.label.project.profiler.max_sample_count = Макс. число сэмплов
+form.help.project.profiler.max_sample_count = Максимальное число сэмплов профайлера, записываемых на поток и кадр
 
 form.label.project.render = Рендер
 form.help.project.render = Настройки рендера

--- a/editor/test/resources/save_data_project/game.project
+++ b/editor/test/resources/save_data_project/game.project
@@ -256,6 +256,7 @@ sub_step_count = 3
 track_cpu = 1
 sleep_between_server_updates = 10
 performance_timeline_enabled = 0
+max_sample_count = 8192
 enabled = 1
 
 [render]

--- a/engine/profiler/src/basic/profiler_basic.cpp
+++ b/engine/profiler/src/basic/profiler_basic.cpp
@@ -69,8 +69,7 @@ struct Sample
 // to avoid dynamic allocations or other setup issues
 static int32_atomic_t g_PropertyInitialized = 0;
 static const uint32_t g_MaxPropertyCount = 256;
-static const uint32_t g_DefaultMaxSampleCount = 4096;
-static uint32_t       g_MaxSampleCount = g_DefaultMaxSampleCount;
+static uint32_t       g_MaxSampleCount = 4096;
 static Property       g_Properties[g_MaxPropertyCount];
 static PropertyData   g_PropertyData[g_MaxPropertyCount];
 
@@ -981,8 +980,7 @@ static ProfileListener g_Listener = {};
 
 static dmExtension::Result ProfilerBasic_AppInitialize(dmExtension::AppParams* params)
 {
-    int32_t max_sample_count = dmConfigFile::GetInt(params->m_ConfigFile, "profiler.max_sample_count", g_DefaultMaxSampleCount);
-    g_MaxSampleCount = (uint32_t) max_sample_count;
+    g_MaxSampleCount = dmConfigFile::GetInt(params->m_ConfigFile, "profiler.max_sample_count", g_MaxSampleCount);
 
     g_Listener.m_Create = CreateListener;
     g_Listener.m_Destroy = DestroyListener;

--- a/engine/profiler/src/basic/profiler_basic.cpp
+++ b/engine/profiler/src/basic/profiler_basic.cpp
@@ -12,6 +12,7 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
+#include <dmsdk/dlib/configfile.h>
 #include <dmsdk/extension/extension.h>
 #include "../profiler_private.h"
 
@@ -68,7 +69,8 @@ struct Sample
 // to avoid dynamic allocations or other setup issues
 static int32_atomic_t g_PropertyInitialized = 0;
 static const uint32_t g_MaxPropertyCount = 256;
-static const uint32_t g_MaxSampleCount = 4096;
+static const uint32_t g_DefaultMaxSampleCount = 4096;
+static uint32_t       g_MaxSampleCount = g_DefaultMaxSampleCount;
 static Property       g_Properties[g_MaxPropertyCount];
 static PropertyData   g_PropertyData[g_MaxPropertyCount];
 
@@ -979,6 +981,9 @@ static ProfileListener g_Listener = {};
 
 static dmExtension::Result ProfilerBasic_AppInitialize(dmExtension::AppParams* params)
 {
+    int32_t max_sample_count = dmConfigFile::GetInt(params->m_ConfigFile, "profiler.max_sample_count", g_DefaultMaxSampleCount);
+    g_MaxSampleCount = (uint32_t) max_sample_count;
+
     g_Listener.m_Create = CreateListener;
     g_Listener.m_Destroy = DestroyListener;
     g_Listener.m_SetThreadName = SetThreadName;


### PR DESCRIPTION
Added `profiler.max_sample_count` to `game.project` to allow using more than the default 4096 samples, which can be useful in rare cases.