### PR TITLE
Windows fix for file operations using Unicode paths

### DIFF
--- a/engine/dlib/src/dlib/sys_internal.h
+++ b/engine/dlib/src/dlib/sys_internal.h
@@ -27,7 +27,11 @@ namespace dmSys {
 
 #if defined(_WIN32)
     // Internal Windows helper used to test the path handling logic separately
-    // from the SHGetFolderPathW lookup and wchar_t-to-UTF-8 conversion.
+    // from the SHGetFolderPathW lookup.
+    Result GetApplicationSupportPath(const wchar_t* application_support_path, const char* application_name, char* path, uint32_t path_len);
+
+    // Internal Windows helper used to test the narrow path handling logic
+    // separately from the SHGetFolderPathW lookup and wchar_t-to-char conversion.
     Result GetApplicationSupportPath(const char* application_support_path, const char* application_name, char* path, uint32_t path_len);
 #endif
 }

--- a/engine/dlib/src/dlib/sys_internal.h
+++ b/engine/dlib/src/dlib/sys_internal.h
@@ -22,4 +22,12 @@ namespace dmSys {
      * @return Result as string
      */
     const char* ResultToString(Result result);
+
+    // For testing
+
+#if defined(_WIN32)
+    // Internal Windows helper used to test the path handling logic separately
+    // from the SHGetFolderPathW lookup and wchar_t-to-UTF-8 conversion.
+    Result GetApplicationSupportPath(const char* application_support_path, const char* application_name, char* path, uint32_t path_len);
+#endif
 }

--- a/engine/dlib/src/dlib/sys_win32.cpp
+++ b/engine/dlib/src/dlib/sys_win32.cpp
@@ -54,6 +54,15 @@
 
 namespace dmSys
 {
+    static bool Utf8ToWide(const char* path, wchar_t* out, uint32_t out_len)
+    {
+        int required = MultiByteToWideChar(CP_UTF8, 0, path, -1, NULL, 0);
+        if (required == 0 || required > (int)out_len)
+            return false;
+
+        return MultiByteToWideChar(CP_UTF8, 0, path, -1, out, required) != 0;
+    }
+
     char* GetEnv(const char* name)
     {
         return getenv(name);
@@ -71,7 +80,12 @@ namespace dmSys
 
     Result Rename(const char* dst_filename, const char* src_filename)
     {
-        bool rename_result = MoveFileExA(src_filename, dst_filename, MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH) != 0;
+        wchar_t wdst_filename[MAX_PATH];
+        wchar_t wsrc_filename[MAX_PATH];
+        if (!Utf8ToWide(dst_filename, wdst_filename, MAX_PATH) || !Utf8ToWide(src_filename, wsrc_filename, MAX_PATH))
+            return RESULT_UNKNOWN;
+
+        bool rename_result = MoveFileExW(wsrc_filename, wdst_filename, MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH) != 0;
         if (rename_result)
         {
             return RESULT_OK;
@@ -93,88 +107,7 @@ namespace dmSys
         return RESULT_NOENT;
     }
 
-
 #if !defined(DM_PLATFORM_VENDOR)
-
-    static const wchar_t* SkipSlashesW(const wchar_t* path)
-    {
-        while (*path && (*path == L'/' || *path == L'\\'))
-        {
-            ++path;
-        }
-        return path;
-    }
-
-    // If a path contains unicode characters, we need to make it 8.3 in order to properly use char* functions
-    static bool MakePath_8_3(const wchar_t* wpath, wchar_t* out)
-    {
-        wchar_t tmp[MAX_PATH] = { 0 };
-        dmPath::NormalizeW(wpath, tmp, MAX_PATH);
-        out[0] = L'\0';
-
-        int has_drive = 0;
-        wchar_t* cursor = tmp;
-        while (*cursor != L'\0')
-        {
-            if (!has_drive)
-            {
-                cursor = wcschr(cursor, L':');
-                if (!cursor)
-                {
-                    dmLogError("Failed to find drive in path: '%ls'\n", wpath);
-                    return false;
-                }
-                has_drive = 1;
-                cursor++; // Skip past the ':'"
-
-                // Copy the drive "C:"
-                wchar_t c = *cursor;
-                *cursor = L'\0';
-                wcscpy(out, tmp);
-
-                *cursor = c;
-                cursor = (wchar_t*)SkipSlashesW(cursor+1);
-                continue;
-            }
-
-            wchar_t* sep = wcschr(cursor, L'\\');
-            if (!sep)
-                sep = wcschr(cursor, L'/');
-
-            // Temporarily null terminate the string
-            if (sep)
-                *sep = L'\0';
-
-            // Create a version of the previously parsed path, and the latest (untransformed) directory name
-            wchar_t testpath[MAX_PATH] = { 0 };
-            wcscpy(testpath, out); // The previously path with 8.3 names
-            wcscat(testpath, L"/");
-            wcscat(testpath, cursor); // The last folder to test
-
-            WIN32_FIND_DATAW fd{0};
-            HANDLE h = FindFirstFileW( tmp, &fd );
-            if (h == INVALID_HANDLE_VALUE)
-            {
-                dmLogError("FindFirstFileW failed\n");
-                return false;
-            }
-
-            wcscat(out, L"/");
-            if (fd.cAlternateFileName[0] == L'\0')
-                wcscat(out, fd.cFileName);
-            else
-                wcscat(out, fd.cAlternateFileName);
-
-            if (sep)
-                *sep = L'/';
-            else
-                break;
-
-            cursor = sep + 1;
-        }
-
-        return true;
-    }
 
     Result GetApplicationSavePath(const char* application_name, char* path, uint32_t path_len)
     {
@@ -207,12 +140,7 @@ namespace dmSys
                                      0,
                                      tmp_wpath)))
         {
-            // Make any unicode directories into 8.3 format if necessary
-            wchar_t short_path[MAX_PATH] = { 0 };
-            if (!MakePath_8_3(tmp_wpath, short_path))
-                return RESULT_UNKNOWN;
-
-            int size_needed = WideCharToMultiByte(CP_UTF8, 0, short_path, -1, NULL, 0, NULL, NULL);
+            int size_needed = WideCharToMultiByte(CP_UTF8, 0, tmp_wpath, -1, NULL, 0, NULL, NULL);
             if (size_needed == 0)
             {
                 dmLogError("Failed converting wchar_t -> char\n");
@@ -220,7 +148,13 @@ namespace dmSys
             }
 
             char* tmp_path = (char*)_alloca(size_needed);
-            if (WideCharToMultiByte(CP_UTF8, 0, short_path, -1, tmp_path, size_needed, NULL, NULL) == 0)
+            if (!tmp_path)
+            {
+                dmLogError("Failed to allocate %d bytes for strinc copy\n", size_needed);
+                return RESULT_UNKNOWN;
+            }
+
+            if (WideCharToMultiByte(CP_UTF8, 0, tmp_wpath, -1, tmp_path, size_needed, NULL, NULL) == 0)
             {
                 dmLogError("Failed converting wchar_t -> char\n");
                 return RESULT_UNKNOWN;
@@ -354,14 +288,22 @@ namespace dmSys
 
     bool ResourceExists(const char* path)
     {
+        wchar_t wpath[MAX_PATH];
+        if (!Utf8ToWide(path, wpath, MAX_PATH))
+            return false;
+
         struct __stat64 file_stat;
-        return _stat64(path, &file_stat) == 0;
+        return _wstat64(wpath, &file_stat) == 0;
     }
 
     Result ResourceSize(const char* path, uint32_t* resource_size)
     {
+        wchar_t wpath[MAX_PATH];
+        if (!Utf8ToWide(path, wpath, MAX_PATH))
+            return RESULT_UNKNOWN;
+
         struct __stat64 file_stat;
-        if (_stat64(path, &file_stat) == 0) {
+        if (_wstat64(wpath, &file_stat) == 0) {
             if (!S_ISREG(file_stat.st_mode)) {
                 return RESULT_NOENT;
             }
@@ -381,8 +323,12 @@ namespace dmSys
     Result LoadResource(const char* path, void* buffer, uint32_t buffer_size, uint32_t* resource_size)
     {
         *resource_size = 0;
+        wchar_t wpath[MAX_PATH];
+        if (!Utf8ToWide(path, wpath, MAX_PATH))
+            return RESULT_UNKNOWN;
+
         struct __stat64 file_stat;
-        if (_stat64(path, &file_stat) == 0) {
+        if (_wstat64(wpath, &file_stat) == 0) {
             if (!S_ISREG(file_stat.st_mode)) {
                 return RESULT_NOENT;
             }
@@ -397,7 +343,10 @@ namespace dmSys
                 return RESULT_INVAL;
             }
 
-            FILE* f = fopen(path, "rb");
+            FILE* f = _wfopen(wpath, L"rb");
+            if (!f)
+                return RESULT_NOENT;
+
             size_t nread = fread(buffer, 1, size_as_32b, f);
             fclose(f);
 
@@ -419,13 +368,17 @@ namespace dmSys
         if (buffer == 0 || size == 0)
             return RESULT_INVAL;
 
+        wchar_t wpath[MAX_PATH];
+        if (!Utf8ToWide(path, wpath, MAX_PATH))
+            return RESULT_UNKNOWN;
+
         struct __stat64 file_stat;
-        if (_stat64(path, &file_stat) == 0) {
+        if (_wstat64(wpath, &file_stat) == 0) {
             if (!S_ISREG(file_stat.st_mode)) {
                 return RESULT_NOENT;
             }
 
-            FILE* f = fopen(path, "rb");
+            FILE* f = _wfopen(wpath, L"rb");
             if (!f)
             {
                 return RESULT_NOENT;
@@ -455,7 +408,11 @@ namespace dmSys
 
     Result Rmdir(const char* path)
     {
-        int ret = _rmdir(path);
+        wchar_t wpath[MAX_PATH];
+        if (!Utf8ToWide(path, wpath, MAX_PATH))
+            return RESULT_UNKNOWN;
+
+        int ret = _wrmdir(wpath);
         if (ret == 0)
             return RESULT_OK;
         else
@@ -464,7 +421,11 @@ namespace dmSys
 
     Result Mkdir(const char* path, uint32_t mode)
     {
-        int ret = _mkdir(path);
+        wchar_t wpath[MAX_PATH];
+        if (!Utf8ToWide(path, wpath, MAX_PATH))
+            return RESULT_UNKNOWN;
+
+        int ret = _wmkdir(wpath);
         if (ret == 0)
             return RESULT_OK;
         else
@@ -473,8 +434,12 @@ namespace dmSys
 
     Result IsDir(const char* path)
     {
+        wchar_t wpath[MAX_PATH];
+        if (!Utf8ToWide(path, wpath, MAX_PATH))
+            return RESULT_UNKNOWN;
+
         struct __stat64 path_stat;
-        int ret = _stat64(path, &path_stat);
+        int ret = _wstat64(wpath, &path_stat);
         if (ret != 0)
             return ErrnoToResult(errno);
         return path_stat.st_mode & S_IFDIR ? RESULT_OK : RESULT_UNKNOWN;
@@ -482,8 +447,12 @@ namespace dmSys
 
     bool Exists(const char* path)
     {
+        wchar_t wpath[MAX_PATH];
+        if (!Utf8ToWide(path, wpath, MAX_PATH))
+            return false;
+
         struct __stat64 path_stat;
-        int ret = _stat64(path, &path_stat);
+        int ret = _wstat64(wpath, &path_stat);
         return ret == 0;
     }
 
@@ -547,7 +516,11 @@ namespace dmSys
 
     Result Unlink(const char* path)
     {
-        int ret = _unlink(path);
+        wchar_t wpath[MAX_PATH];
+        if (!Utf8ToWide(path, wpath, MAX_PATH))
+            return RESULT_UNKNOWN;
+
+        int ret = _wunlink(wpath);
         if (ret == 0)
             return RESULT_OK;
         else
@@ -556,8 +529,12 @@ namespace dmSys
 
     Result Stat(const char* path, StatInfo* stat_info)
     {
+        wchar_t wpath[MAX_PATH];
+        if (!Utf8ToWide(path, wpath, MAX_PATH))
+            return RESULT_NOENT;
+
         struct __stat64 info;
-        int ret = _stat64(path, &info);
+        int ret = _wstat64(wpath, &info);
         if (ret != 0)
             return RESULT_NOENT;
         stat_info->m_Size = info.st_size;

--- a/engine/dlib/src/dlib/sys_win32.cpp
+++ b/engine/dlib/src/dlib/sys_win32.cpp
@@ -114,6 +114,31 @@ namespace dmSys
         return GetApplicationSupportPath(application_name, path, path_len);
     }
 
+    Result GetApplicationSupportPath(const wchar_t* application_support_path, const char* application_name, char* path, uint32_t path_len)
+    {
+        int size_needed = WideCharToMultiByte(CP_UTF8, 0, application_support_path, -1, NULL, 0, NULL, NULL);
+        if (size_needed == 0)
+        {
+            dmLogError("Failed converting wchar_t -> char\n");
+            return RESULT_UNKNOWN;
+        }
+
+        char* tmp_path = (char*)_alloca(size_needed);
+        if (!tmp_path)
+        {
+            dmLogError("Failed to allocate %d bytes for string copy\n", size_needed);
+            return RESULT_UNKNOWN;
+        }
+
+        if (WideCharToMultiByte(CP_UTF8, 0, application_support_path, -1, tmp_path, size_needed, NULL, NULL) == 0)
+        {
+            dmLogError("Failed converting wchar_t -> char\n");
+            return RESULT_UNKNOWN;
+        }
+
+        return GetApplicationSupportPath(tmp_path, application_name, path, path_len);
+    }
+
     Result GetApplicationSupportPath(const char* application_support_path, const char* application_name, char* path, uint32_t path_len)
     {
         if (dmStrlCpy(path, application_support_path, path_len) >= path_len)
@@ -140,27 +165,7 @@ namespace dmSys
                                      0,
                                      tmp_wpath)))
         {
-            int size_needed = WideCharToMultiByte(CP_UTF8, 0, tmp_wpath, -1, NULL, 0, NULL, NULL);
-            if (size_needed == 0)
-            {
-                dmLogError("Failed converting wchar_t -> char\n");
-                return RESULT_UNKNOWN;
-            }
-
-            char* tmp_path = (char*)_alloca(size_needed);
-            if (!tmp_path)
-            {
-                dmLogError("Failed to allocate %d bytes for strinc copy\n", size_needed);
-                return RESULT_UNKNOWN;
-            }
-
-            if (WideCharToMultiByte(CP_UTF8, 0, tmp_wpath, -1, tmp_path, size_needed, NULL, NULL) == 0)
-            {
-                dmLogError("Failed converting wchar_t -> char\n");
-                return RESULT_UNKNOWN;
-            }
-
-            return GetApplicationSupportPath(tmp_path, application_name, path, path_len);
+            return GetApplicationSupportPath(tmp_wpath, application_name, path, path_len);
         }
         else
         {

--- a/engine/dlib/src/dlib/sys_win32.cpp
+++ b/engine/dlib/src/dlib/sys_win32.cpp
@@ -54,15 +54,6 @@
 
 namespace dmSys
 {
-    static bool Utf8ToWide(const char* path, wchar_t* out, uint32_t out_len)
-    {
-        int required = MultiByteToWideChar(CP_UTF8, 0, path, -1, NULL, 0);
-        if (required == 0 || required > (int)out_len)
-            return false;
-
-        return MultiByteToWideChar(CP_UTF8, 0, path, -1, out, required) != 0;
-    }
-
     char* GetEnv(const char* name)
     {
         return getenv(name);
@@ -80,12 +71,7 @@ namespace dmSys
 
     Result Rename(const char* dst_filename, const char* src_filename)
     {
-        wchar_t wdst_filename[MAX_PATH];
-        wchar_t wsrc_filename[MAX_PATH];
-        if (!Utf8ToWide(dst_filename, wdst_filename, MAX_PATH) || !Utf8ToWide(src_filename, wsrc_filename, MAX_PATH))
-            return RESULT_UNKNOWN;
-
-        bool rename_result = MoveFileExW(wsrc_filename, wdst_filename, MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH) != 0;
+        bool rename_result = MoveFileExA(src_filename, dst_filename, MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH) != 0;
         if (rename_result)
         {
             return RESULT_OK;
@@ -109,6 +95,26 @@ namespace dmSys
 
 #if !defined(DM_PLATFORM_VENDOR)
 
+    static bool WideToACP(const wchar_t* path, char* out, uint32_t out_len)
+    {
+        BOOL used_default = FALSE;
+        int written = WideCharToMultiByte(CP_ACP, WC_NO_BEST_FIT_CHARS, path, -1, out, out_len, NULL, &used_default);
+        return written > 0 && !used_default;
+    }
+
+    static bool WidePathToHostPath(const wchar_t* path, char* out, uint32_t out_len)
+    {
+        if (WideToACP(path, out, out_len))
+            return true;
+
+        wchar_t short_path[MAX_PATH];
+        DWORD short_path_len = GetShortPathNameW(path, short_path, MAX_PATH);
+        if (short_path_len == 0 || short_path_len >= MAX_PATH)
+            return false;
+
+        return WideToACP(short_path, out, out_len);
+    }
+
     Result GetApplicationSavePath(const char* application_name, char* path, uint32_t path_len)
     {
         return GetApplicationSupportPath(application_name, path, path_len);
@@ -116,23 +122,10 @@ namespace dmSys
 
     Result GetApplicationSupportPath(const wchar_t* application_support_path, const char* application_name, char* path, uint32_t path_len)
     {
-        int size_needed = WideCharToMultiByte(CP_UTF8, 0, application_support_path, -1, NULL, 0, NULL, NULL);
-        if (size_needed == 0)
+        char tmp_path[MAX_PATH];
+        if (!WidePathToHostPath(application_support_path, tmp_path, sizeof(tmp_path)))
         {
-            dmLogError("Failed converting wchar_t -> char\n");
-            return RESULT_UNKNOWN;
-        }
-
-        char* tmp_path = (char*)_alloca(size_needed);
-        if (!tmp_path)
-        {
-            dmLogError("Failed to allocate %d bytes for string copy\n", size_needed);
-            return RESULT_UNKNOWN;
-        }
-
-        if (WideCharToMultiByte(CP_UTF8, 0, application_support_path, -1, tmp_path, size_needed, NULL, NULL) == 0)
-        {
-            dmLogError("Failed converting wchar_t -> char\n");
+            dmLogError("Failed converting wchar_t path to host path\n");
             return RESULT_UNKNOWN;
         }
 
@@ -293,22 +286,14 @@ namespace dmSys
 
     bool ResourceExists(const char* path)
     {
-        wchar_t wpath[MAX_PATH];
-        if (!Utf8ToWide(path, wpath, MAX_PATH))
-            return false;
-
         struct __stat64 file_stat;
-        return _wstat64(wpath, &file_stat) == 0;
+        return _stat64(path, &file_stat) == 0;
     }
 
     Result ResourceSize(const char* path, uint32_t* resource_size)
     {
-        wchar_t wpath[MAX_PATH];
-        if (!Utf8ToWide(path, wpath, MAX_PATH))
-            return RESULT_UNKNOWN;
-
         struct __stat64 file_stat;
-        if (_wstat64(wpath, &file_stat) == 0) {
+        if (_stat64(path, &file_stat) == 0) {
             if (!S_ISREG(file_stat.st_mode)) {
                 return RESULT_NOENT;
             }
@@ -328,12 +313,8 @@ namespace dmSys
     Result LoadResource(const char* path, void* buffer, uint32_t buffer_size, uint32_t* resource_size)
     {
         *resource_size = 0;
-        wchar_t wpath[MAX_PATH];
-        if (!Utf8ToWide(path, wpath, MAX_PATH))
-            return RESULT_UNKNOWN;
-
         struct __stat64 file_stat;
-        if (_wstat64(wpath, &file_stat) == 0) {
+        if (_stat64(path, &file_stat) == 0) {
             if (!S_ISREG(file_stat.st_mode)) {
                 return RESULT_NOENT;
             }
@@ -348,10 +329,7 @@ namespace dmSys
                 return RESULT_INVAL;
             }
 
-            FILE* f = _wfopen(wpath, L"rb");
-            if (!f)
-                return RESULT_NOENT;
-
+            FILE* f = fopen(path, "rb");
             size_t nread = fread(buffer, 1, size_as_32b, f);
             fclose(f);
 
@@ -373,17 +351,13 @@ namespace dmSys
         if (buffer == 0 || size == 0)
             return RESULT_INVAL;
 
-        wchar_t wpath[MAX_PATH];
-        if (!Utf8ToWide(path, wpath, MAX_PATH))
-            return RESULT_UNKNOWN;
-
         struct __stat64 file_stat;
-        if (_wstat64(wpath, &file_stat) == 0) {
+        if (_stat64(path, &file_stat) == 0) {
             if (!S_ISREG(file_stat.st_mode)) {
                 return RESULT_NOENT;
             }
 
-            FILE* f = _wfopen(wpath, L"rb");
+            FILE* f = fopen(path, "rb");
             if (!f)
             {
                 return RESULT_NOENT;
@@ -413,11 +387,7 @@ namespace dmSys
 
     Result Rmdir(const char* path)
     {
-        wchar_t wpath[MAX_PATH];
-        if (!Utf8ToWide(path, wpath, MAX_PATH))
-            return RESULT_UNKNOWN;
-
-        int ret = _wrmdir(wpath);
+        int ret = _rmdir(path);
         if (ret == 0)
             return RESULT_OK;
         else
@@ -426,11 +396,7 @@ namespace dmSys
 
     Result Mkdir(const char* path, uint32_t mode)
     {
-        wchar_t wpath[MAX_PATH];
-        if (!Utf8ToWide(path, wpath, MAX_PATH))
-            return RESULT_UNKNOWN;
-
-        int ret = _wmkdir(wpath);
+        int ret = _mkdir(path);
         if (ret == 0)
             return RESULT_OK;
         else
@@ -439,12 +405,8 @@ namespace dmSys
 
     Result IsDir(const char* path)
     {
-        wchar_t wpath[MAX_PATH];
-        if (!Utf8ToWide(path, wpath, MAX_PATH))
-            return RESULT_UNKNOWN;
-
         struct __stat64 path_stat;
-        int ret = _wstat64(wpath, &path_stat);
+        int ret = _stat64(path, &path_stat);
         if (ret != 0)
             return ErrnoToResult(errno);
         return path_stat.st_mode & S_IFDIR ? RESULT_OK : RESULT_UNKNOWN;
@@ -452,12 +414,8 @@ namespace dmSys
 
     bool Exists(const char* path)
     {
-        wchar_t wpath[MAX_PATH];
-        if (!Utf8ToWide(path, wpath, MAX_PATH))
-            return false;
-
         struct __stat64 path_stat;
-        int ret = _wstat64(wpath, &path_stat);
+        int ret = _stat64(path, &path_stat);
         return ret == 0;
     }
 
@@ -521,11 +479,7 @@ namespace dmSys
 
     Result Unlink(const char* path)
     {
-        wchar_t wpath[MAX_PATH];
-        if (!Utf8ToWide(path, wpath, MAX_PATH))
-            return RESULT_UNKNOWN;
-
-        int ret = _wunlink(wpath);
+        int ret = _unlink(path);
         if (ret == 0)
             return RESULT_OK;
         else
@@ -534,12 +488,8 @@ namespace dmSys
 
     Result Stat(const char* path, StatInfo* stat_info)
     {
-        wchar_t wpath[MAX_PATH];
-        if (!Utf8ToWide(path, wpath, MAX_PATH))
-            return RESULT_NOENT;
-
         struct __stat64 info;
-        int ret = _wstat64(wpath, &info);
+        int ret = _stat64(path, &info);
         if (ret != 0)
             return RESULT_NOENT;
         stat_info->m_Size = info.st_size;

--- a/engine/dlib/src/dlib/sys_win32.cpp
+++ b/engine/dlib/src/dlib/sys_win32.cpp
@@ -26,6 +26,7 @@
 #include <limits.h> // UINT_MAX
 
 #include "sys.h"
+#include "sys_internal.h"
 #include "log.h"
 #include "dstrings.h"
 #include "hash.h"
@@ -104,7 +105,7 @@ namespace dmSys
         return path;
     }
 
-    // Is a path contains unicode characters, we need to make it 8.3 in order to properly use char* functions
+    // If a path contains unicode characters, we need to make it 8.3 in order to properly use char* functions
     static bool MakePath_8_3(const wchar_t* wpath, wchar_t* out)
     {
         wchar_t tmp[MAX_PATH] = { 0 };
@@ -180,6 +181,22 @@ namespace dmSys
         return GetApplicationSupportPath(application_name, path, path_len);
     }
 
+    Result GetApplicationSupportPath(const char* application_support_path, const char* application_name, char* path, uint32_t path_len)
+    {
+        if (dmStrlCpy(path, application_support_path, path_len) >= path_len)
+            return RESULT_INVAL;
+        if (dmStrlCat(path, "/", path_len) >= path_len)
+            return RESULT_INVAL;
+        if (dmStrlCat(path, application_name, path_len) >= path_len)
+            return RESULT_INVAL;
+
+        Result r =  Mkdir(path, 0755);
+        if (r == RESULT_EXIST)
+            return RESULT_OK;
+        else
+            return r;
+    }
+
     Result GetApplicationSupportPath(const char* application_name, char* path, uint32_t path_len)
     {
         wchar_t tmp_wpath[MAX_PATH];
@@ -191,33 +208,25 @@ namespace dmSys
                                      tmp_wpath)))
         {
             // Make any unicode directories into 8.3 format if necessary
-            wchar_t short_path[MAX_PATH];
-            MakePath_8_3(tmp_wpath, short_path);
+            wchar_t short_path[MAX_PATH] = { 0 };
+            if (!MakePath_8_3(tmp_wpath, short_path))
+                return RESULT_UNKNOWN;
 
-            int wlength = (int)wcslen(short_path);
-            int size_needed = WideCharToMultiByte(CP_UTF8, 0, short_path, wlength, NULL, 0, NULL, NULL);
+            int size_needed = WideCharToMultiByte(CP_UTF8, 0, short_path, -1, NULL, 0, NULL, NULL);
             if (size_needed == 0)
             {
                 dmLogError("Failed converting wchar_t -> char\n");
                 return RESULT_UNKNOWN;
             }
 
-            char* tmp_path = (char*)_alloca(size_needed + 1);
-            WideCharToMultiByte(CP_UTF8, 0, short_path, wlength, tmp_path, size_needed, NULL, NULL);
-            tmp_path[size_needed] = 0;
+            char* tmp_path = (char*)_alloca(size_needed);
+            if (WideCharToMultiByte(CP_UTF8, 0, short_path, -1, tmp_path, size_needed, NULL, NULL) == 0)
+            {
+                dmLogError("Failed converting wchar_t -> char\n");
+                return RESULT_UNKNOWN;
+            }
 
-            if (dmStrlCpy(path, tmp_path, path_len) >= path_len)
-                return RESULT_INVAL;
-            if (dmStrlCat(path, "/", path_len) >= path_len)
-                return RESULT_INVAL;
-            if (dmStrlCat(path, application_name, path_len) >= path_len)
-                return RESULT_INVAL;
-
-            Result r =  Mkdir(path, 0755);
-            if (r == RESULT_EXIST)
-                return RESULT_OK;
-            else
-                return r;
+            return GetApplicationSupportPath(tmp_path, application_name, path, path_len);
         }
         else
         {

--- a/engine/dlib/src/test/test_sys.cpp
+++ b/engine/dlib/src/test/test_sys.cpp
@@ -45,6 +45,54 @@ static bool WidePathToUtf8(const wchar_t* src, char* dst, int dst_len)
     return WideCharToMultiByte(CP_UTF8, 0, src, -1, dst, dst_len, NULL, NULL) > 0;
 }
 
+static bool WideToCodePage(UINT code_page, const wchar_t* src, char* dst, int dst_len)
+{
+    BOOL used_default = FALSE;
+    return WideCharToMultiByte(code_page, WC_NO_BEST_FIT_CHARS, src, -1, dst, dst_len, NULL, &used_default) > 0 && !used_default;
+}
+
+static bool CodePageToWide(UINT code_page, const char* src, wchar_t* dst, int dst_len)
+{
+    return MultiByteToWideChar(code_page, 0, src, -1, dst, dst_len) > 0;
+}
+
+static bool FindAnsiRoundtripSample(wchar_t* sample, uint32_t sample_len)
+{
+    const wchar_t* candidates[] =
+    {
+        L"\x00E9", // e acute
+        L"\x00F6", // o diaeresis
+        L"\x00DF", // sharp s
+        L"\x0416", // Cyrillic
+        L"\x3042", // Japanese Hiragana
+        L"\x65E5", // CJK
+        L"\xD55C", // Korean
+    };
+
+    char acp[16];
+    char utf8[16];
+    wchar_t roundtrip[16];
+
+    for (uint32_t i = 0; i < sizeof(candidates) / sizeof(candidates[0]); ++i)
+    {
+        if (!WideToCodePage(CP_ACP, candidates[i], acp, sizeof(acp)))
+            continue;
+        if (!WidePathToUtf8(candidates[i], utf8, sizeof(utf8)))
+            continue;
+        if (strcmp(acp, utf8) == 0)
+            continue;
+        if (!CodePageToWide(CP_ACP, acp, roundtrip, sizeof(roundtrip) / sizeof(roundtrip[0])))
+            continue;
+        if (wcscmp(roundtrip, candidates[i]) != 0)
+            continue;
+
+        wcscpy_s(sample, sample_len, candidates[i]);
+        return true;
+    }
+
+    return false;
+}
+
 static void WriteWideDebugLine(const wchar_t* prefix, const wchar_t* value)
 {
     HANDLE handle = GetStdHandle(STD_OUTPUT_HANDLE);
@@ -184,18 +232,23 @@ TEST(dmSys, GetApplicationSupportPath)
 }
 
 #if defined(_WIN32)
-TEST(dmSys, GetApplicationSupportPathInternalUnicodeParentPath)
+TEST(dmSys, GetApplicationSupportPathInternalWideRootSupportsNarrowStdio)
 {
     // Skip on systems where the ANSI code page is already UTF-8, since the
     // narrow-path CRT calls may succeed there and not expose the bug.
     if (GetACP() == CP_UTF8)
     {
-        dmLogWarning("Skipping GetApplicationSupportPathInternalUnicodeParentPath because the active ANSI code page is UTF-8 (CP_UTF8), which can mask the narrow Windows path conversion bug.");
+        dmLogWarning("Skipping GetApplicationSupportPathInternalWideRootSupportsNarrowStdio because the active ANSI code page is UTF-8 (CP_UTF8), which masks the ANSI/UTF-8 path mismatch regression.");
         SKIP();
     }
 
-    // Create a unique temporary root directory using wide Win32 APIs so the
-    // test setup itself does not depend on ANSI code page behavior.
+    wchar_t sample[16];
+    if (!FindAnsiRoundtripSample(sample, sizeof(sample) / sizeof(sample[0])))
+    {
+        dmLogWarning("Skipping GetApplicationSupportPathInternalWideRootSupportsNarrowStdio because no non-ASCII sample character roundtrips through the active ANSI code page.");
+        SKIP();
+    }
+
     wchar_t temp_path[MAX_PATH];
     DWORD temp_path_len = GetTempPathW(MAX_PATH, temp_path);
     ASSERT_GT(temp_path_len, 0u);
@@ -207,59 +260,127 @@ TEST(dmSys, GetApplicationSupportPathInternalUnicodeParentPath)
     ASSERT_TRUE(DeleteFileW(test_root) != 0);
     ASSERT_TRUE(CreateDirectoryW(test_root, NULL) != 0);
 
-    // Add a Korean path component to simulate a Unicode username/AppData
-    // segment in the application support path.
     wchar_t unicode_parent[MAX_PATH];
     wcscpy_s(unicode_parent, MAX_PATH, test_root);
     wcscat_s(unicode_parent, MAX_PATH, L"\\");
-    wcscat_s(unicode_parent, MAX_PATH, L"\xD64D\xAE38\xB3D9");
+    wcscat_s(unicode_parent, MAX_PATH, L"support_");
+    wcscat_s(unicode_parent, MAX_PATH, sample);
+    wcscat_s(unicode_parent, MAX_PATH, L"_root");
     ASSERT_TRUE(CreateDirectoryW(unicode_parent, NULL) != 0);
     WriteWideDebugLine(L"Created unicode parent (wchar_t): '", unicode_parent);
 
     wchar_t short_parent[MAX_PATH];
     DWORD short_parent_len = GetShortPathNameW(unicode_parent, short_parent, MAX_PATH);
-    ASSERT_GT(short_parent_len, 0u);
-    ASSERT_LT(short_parent_len, (DWORD)MAX_PATH);
-    WriteWideDebugLine(L"Expected 8.3 parent (wchar_t): '", short_parent);
+    if (short_parent_len > 0 && short_parent_len < (DWORD)MAX_PATH)
+    {
+        WriteWideDebugLine(L"Expected 8.3 parent (wchar_t): '", short_parent);
 
-    // Convert the Unicode parent path to UTF-8 to match the internal value
-    // returned from the public GetApplicationSupportPath() implementation.
-    char utf8_parent[1024];
-    ASSERT_TRUE(WidePathToUtf8(unicode_parent, utf8_parent, sizeof(utf8_parent)));
-    dmLogWarning("Converted to utf8 (char): '%s'", utf8_parent);
-
-    char utf8_short_parent[1024];
-    ASSERT_TRUE(WidePathToUtf8(short_parent, utf8_short_parent, sizeof(utf8_short_parent)));
-    dmLogWarning("Expected 8.3 parent (char): '%s'", utf8_short_parent);
-
-    EXPECT_EQ(dmSys::RESULT_OK, dmSys::IsDir(utf8_short_parent));
-
-    // Call the extracted internal helper directly so the test covers the
-    // narrow-path application support logic without depending on
-    // SHGetFolderPathW.
-    char expected_path[1024];
-    ASSERT_LT(dmStrlCpy(expected_path, utf8_parent, sizeof(expected_path)), sizeof(expected_path));
-    ASSERT_LT(dmStrlCat(expected_path, "/", sizeof(expected_path)), sizeof(expected_path));
-    ASSERT_LT(dmStrlCat(expected_path, "testing", sizeof(expected_path)), sizeof(expected_path));
-    dmLogWarning("Expected application support path (char): '%s'", expected_path);
+        char utf8_short_parent[1024];
+        ASSERT_TRUE(WidePathToUtf8(short_parent, utf8_short_parent, sizeof(utf8_short_parent)));
+        dmLogWarning("Expected 8.3 parent (char): '%s'", utf8_short_parent);
+    }
+    else
+    {
+        dmLogWarning("GetShortPathNameW did not return a short path for the synthetic application-support directory.");
+    }
 
     char path[1024];
-    dmSys::Result result = dmSys::GetApplicationSupportPath(utf8_parent, "testing", path, sizeof(path));
+    dmSys::Result result = dmSys::GetApplicationSupportPath(unicode_parent, "testing", path, sizeof(path));
     EXPECT_EQ(dmSys::RESULT_OK, result);
     if (result == dmSys::RESULT_OK)
     {
         dmLogWarning("Application support path (char): '%s'", path);
 
-        EXPECT_EQ(dmSys::RESULT_OK, dmSys::IsDir(path));
-        EXPECT_STREQ(expected_path, path);
+        char file_path[1024];
+        ASSERT_LT(dmStrlCpy(file_path, path, sizeof(file_path)), sizeof(file_path));
+        ASSERT_LT(dmStrlCat(file_path, "/narrow_stdio.bin", sizeof(file_path)), sizeof(file_path));
+        dmLogWarning("Attempting narrow fopen on: '%s'", file_path);
+
+        FILE* f = fopen(file_path, "wb");
+        EXPECT_NE((FILE*)0, f);
+        if (f)
+        {
+            const char payload[] = "ok";
+            fwrite(payload, 1, sizeof(payload), f);
+            fclose(f);
+        }
     }
 
-    // Clean up with wide Win32 APIs so teardown still works even when the
-    // narrow dmSys path handling is broken.
+    wchar_t unicode_file[MAX_PATH];
+    wcscpy_s(unicode_file, MAX_PATH, unicode_parent);
+    wcscat_s(unicode_file, MAX_PATH, L"\\testing\\narrow_stdio.bin");
+    DeleteFileW(unicode_file);
+
     wchar_t unicode_child[MAX_PATH];
     wcscpy_s(unicode_child, MAX_PATH, unicode_parent);
     wcscat_s(unicode_child, MAX_PATH, L"\\testing");
     RemoveDirectoryW(unicode_child);
+    RemoveDirectoryW(unicode_parent);
+    RemoveDirectoryW(test_root);
+}
+
+TEST(dmSys, ResourceFunctionsAcceptAnsiCodePagePaths)
+{
+    if (GetACP() == CP_UTF8)
+    {
+        dmLogWarning("Skipping ResourceFunctionsAcceptAnsiCodePagePaths because the active ANSI code page is UTF-8 (CP_UTF8), which masks the ANSI/UTF-8 path mismatch regression.");
+        SKIP();
+    }
+
+    wchar_t sample[16];
+    if (!FindAnsiRoundtripSample(sample, sizeof(sample) / sizeof(sample[0])))
+    {
+        dmLogWarning("Skipping ResourceFunctionsAcceptAnsiCodePagePaths because no non-ASCII sample character roundtrips through the active ANSI code page.");
+        SKIP();
+    }
+
+    wchar_t temp_path[MAX_PATH];
+    DWORD temp_path_len = GetTempPathW(MAX_PATH, temp_path);
+    ASSERT_GT(temp_path_len, 0u);
+    ASSERT_LT(temp_path_len, (DWORD)MAX_PATH);
+
+    wchar_t test_root[MAX_PATH];
+    UINT unique_name_result = GetTempFileNameW(temp_path, L"dfs", 0, test_root);
+    ASSERT_NE(0u, unique_name_result);
+    ASSERT_TRUE(DeleteFileW(test_root) != 0);
+    ASSERT_TRUE(CreateDirectoryW(test_root, NULL) != 0);
+
+    wchar_t unicode_parent[MAX_PATH];
+    wcscpy_s(unicode_parent, MAX_PATH, test_root);
+    wcscat_s(unicode_parent, MAX_PATH, L"\\");
+    wcscat_s(unicode_parent, MAX_PATH, L"resource_");
+    wcscat_s(unicode_parent, MAX_PATH, sample);
+    ASSERT_TRUE(CreateDirectoryW(unicode_parent, NULL) != 0);
+    WriteWideDebugLine(L"Created resource parent (wchar_t): '", unicode_parent);
+
+    wchar_t unicode_file[MAX_PATH];
+    wcscpy_s(unicode_file, MAX_PATH, unicode_parent);
+    wcscat_s(unicode_file, MAX_PATH, L"\\payload.bin");
+
+    const char payload[] = "payload";
+    FILE* wf = _wfopen(unicode_file, L"wb");
+    ASSERT_NE((FILE*)0, wf);
+    fwrite(payload, 1, sizeof(payload), wf);
+    fclose(wf);
+
+    char acp_file_path[1024];
+    ASSERT_TRUE(WideToCodePage(CP_ACP, unicode_file, acp_file_path, sizeof(acp_file_path)));
+    dmLogWarning("ACP resource path (char): '%s'", acp_file_path);
+
+    EXPECT_TRUE(dmSys::ResourceExists(acp_file_path));
+
+    uint32_t resource_size = 0;
+    EXPECT_EQ(dmSys::RESULT_OK, dmSys::ResourceSize(acp_file_path, &resource_size));
+    EXPECT_EQ((uint32_t)sizeof(payload), resource_size);
+
+    char buffer[32];
+    memset(buffer, 0, sizeof(buffer));
+    uint32_t loaded_size = 0;
+    EXPECT_EQ(dmSys::RESULT_OK, dmSys::LoadResource(acp_file_path, buffer, sizeof(buffer), &loaded_size));
+    EXPECT_EQ((uint32_t)sizeof(payload), loaded_size);
+    EXPECT_EQ(0, memcmp(payload, buffer, sizeof(payload)));
+
+    DeleteFileW(unicode_file);
     RemoveDirectoryW(unicode_parent);
     RemoveDirectoryW(test_root);
 }

--- a/engine/dlib/src/test/test_sys.cpp
+++ b/engine/dlib/src/test/test_sys.cpp
@@ -18,6 +18,11 @@
 #define JC_TEST_IMPLEMENTATION
 #include <jc_test/jc_test.h>
 
+#if defined(_WIN32)
+    #include <windows.h>
+    #include <wchar.h>
+#endif
+
 #include <dlib/dstrings.h>
 #include <dlib/sys.h>
 #include <dlib/sys_internal.h>
@@ -33,6 +38,25 @@
 template <> char* jc_test_print_value(char* buffer, size_t buffer_len, dmSys::Result r) {
     return buffer + dmSnPrintf(buffer, buffer_len, "%s", dmSys::ResultToString(r));
 }
+
+#if defined(_WIN32)
+static bool WidePathToUtf8(const wchar_t* src, char* dst, int dst_len)
+{
+    return WideCharToMultiByte(CP_UTF8, 0, src, -1, dst, dst_len, NULL, NULL) > 0;
+}
+
+static void WriteWideDebugLine(const wchar_t* prefix, const wchar_t* value)
+{
+    HANDLE handle = GetStdHandle(STD_OUTPUT_HANDLE);
+    if (handle == INVALID_HANDLE_VALUE || handle == NULL)
+        return;
+
+    DWORD ignored = 0;
+    WriteConsoleW(handle, prefix, (DWORD)wcslen(prefix), &ignored, NULL);
+    WriteConsoleW(handle, value, (DWORD)wcslen(value), &ignored, NULL);
+    WriteConsoleW(handle, L"'\n", 2, &ignored, NULL);
+}
+#endif
 
 
 // Unit test helpers
@@ -158,6 +182,142 @@ TEST(dmSys, GetApplicationSupportPath)
     ASSERT_EQ(dmSys::RESULT_OK, result);
     ASSERT_EQ(dmSys::RESULT_OK, dmSys::IsDir(path));
 }
+
+#if 0
+TEST(dmSys, UnicodeParentPath)
+{
+    // Skip on systems where the ANSI code page is already UTF-8, since the
+    // narrow-path CRT calls may succeed there and not expose the bug.
+    if (GetACP() == CP_UTF8)
+    {
+        dmLogWarning("Skipping UnicodeParentPath test because the active ANSI code page is UTF-8 (CP_UTF8), which can mask the narrow Windows path conversion bug.");
+        SKIP();
+    }
+
+    // Create a unique temporary root directory using wide Win32 APIs so the
+    // test setup itself does not depend on ANSI code page behavior.
+    wchar_t temp_path[MAX_PATH];
+    DWORD temp_path_len = GetTempPathW(MAX_PATH, temp_path);
+    ASSERT_GT(temp_path_len, 0u);
+    ASSERT_LT(temp_path_len, (DWORD)MAX_PATH);
+
+    wchar_t test_root[MAX_PATH];
+    UINT unique_name_result = GetTempFileNameW(temp_path, L"dfs", 0, test_root);
+    ASSERT_NE(0u, unique_name_result);
+    ASSERT_TRUE(DeleteFileW(test_root) != 0);
+    ASSERT_TRUE(CreateDirectoryW(test_root, NULL) != 0);
+
+    // Add a Korean path component to simulate a Unicode username/AppData
+    // segment in the application support path.
+    wchar_t unicode_parent[MAX_PATH];
+    wcscpy_s(unicode_parent, MAX_PATH, test_root);
+    wcscat_s(unicode_parent, MAX_PATH, L"\\");
+    wcscat_s(unicode_parent, MAX_PATH, L"\xD64D\xAE38\xB3D9");
+    ASSERT_TRUE(CreateDirectoryW(unicode_parent, NULL) != 0);
+
+    // This is the child directory that dmSys::Mkdir() will try to create.
+    wchar_t unicode_child[MAX_PATH];
+    wcscpy_s(unicode_child, MAX_PATH, unicode_parent);
+    wcscat_s(unicode_child, MAX_PATH, L"\\testing");
+
+    // Convert the wide paths to UTF-8 to match what GetApplicationSupportPath()
+    // returns before the path is passed into the narrow dmSys filesystem APIs.
+    char utf8_parent[1024];
+    char utf8_child[1024];
+    ASSERT_TRUE(WidePathToUtf8(unicode_parent, utf8_parent, sizeof(utf8_parent)));
+    ASSERT_TRUE(WidePathToUtf8(unicode_child, utf8_child, sizeof(utf8_child)));
+
+    // These calls currently go through narrow CRT/Win32 APIs on Windows and
+    // are expected to fail before the Unicode path handling is fixed.
+    EXPECT_EQ(dmSys::RESULT_OK, dmSys::IsDir(utf8_parent));
+    EXPECT_EQ(dmSys::RESULT_OK, dmSys::Mkdir(utf8_child, 0777));
+    EXPECT_EQ(dmSys::RESULT_OK, dmSys::IsDir(utf8_child));
+
+    // Clean up with wide Win32 APIs so teardown still works even when the
+    // narrow dmSys path handling is broken.
+    RemoveDirectoryW(unicode_child);
+    RemoveDirectoryW(unicode_parent);
+    RemoveDirectoryW(test_root);
+}
+#endif
+
+#if defined(_WIN32)
+TEST(dmSys, GetApplicationSupportPathInternalUnicodeParentPath)
+{
+    // Skip on systems where the ANSI code page is already UTF-8, since the
+    // narrow-path CRT calls may succeed there and not expose the bug.
+    if (GetACP() == CP_UTF8)
+    {
+        dmLogWarning("Skipping GetApplicationSupportPathInternalUnicodeParentPath because the active ANSI code page is UTF-8 (CP_UTF8), which can mask the narrow Windows path conversion bug.");
+        SKIP();
+    }
+
+    // Create a unique temporary root directory using wide Win32 APIs so the
+    // test setup itself does not depend on ANSI code page behavior.
+    wchar_t temp_path[MAX_PATH];
+    DWORD temp_path_len = GetTempPathW(MAX_PATH, temp_path);
+    ASSERT_GT(temp_path_len, 0u);
+    ASSERT_LT(temp_path_len, (DWORD)MAX_PATH);
+
+    wchar_t test_root[MAX_PATH];
+    UINT unique_name_result = GetTempFileNameW(temp_path, L"dfs", 0, test_root);
+    ASSERT_NE(0u, unique_name_result);
+    ASSERT_TRUE(DeleteFileW(test_root) != 0);
+    ASSERT_TRUE(CreateDirectoryW(test_root, NULL) != 0);
+
+    // Add a Korean path component to simulate a Unicode username/AppData
+    // segment in the application support path.
+    wchar_t unicode_parent[MAX_PATH];
+    wcscpy_s(unicode_parent, MAX_PATH, test_root);
+    wcscat_s(unicode_parent, MAX_PATH, L"\\");
+    wcscat_s(unicode_parent, MAX_PATH, L"\xD64D\xAE38\xB3D9");
+    ASSERT_TRUE(CreateDirectoryW(unicode_parent, NULL) != 0);
+    WriteWideDebugLine(L"Created unicode parent (wchar_t): '", unicode_parent);
+
+    wchar_t short_parent[MAX_PATH];
+    DWORD short_parent_len = GetShortPathNameW(unicode_parent, short_parent, MAX_PATH);
+    ASSERT_GT(short_parent_len, 0u);
+    ASSERT_LT(short_parent_len, (DWORD)MAX_PATH);
+    WriteWideDebugLine(L"Expected 8.3 parent (wchar_t): '", short_parent);
+
+    // Convert the Unicode parent path to UTF-8 to match the internal value
+    // returned from the public GetApplicationSupportPath() implementation.
+    char utf8_parent[1024];
+    ASSERT_TRUE(WidePathToUtf8(unicode_parent, utf8_parent, sizeof(utf8_parent)));
+    dmLogWarning("Converted to utf8 (char): '%s'", utf8_parent);
+
+    char utf8_short_parent[1024];
+    ASSERT_TRUE(WidePathToUtf8(short_parent, utf8_short_parent, sizeof(utf8_short_parent)));
+    dmLogWarning("Expected 8.3 parent (char): '%s'", utf8_short_parent);
+
+    // Call the extracted internal helper directly so the test covers the
+    // narrow-path application support logic without depending on
+    // SHGetFolderPathW or 8.3 alias generation.
+    char expected_path[1024];
+    ASSERT_LT(dmStrlCpy(expected_path, utf8_short_parent, sizeof(expected_path)), sizeof(expected_path));
+    ASSERT_LT(dmStrlCat(expected_path, "/", sizeof(expected_path)), sizeof(expected_path));
+    ASSERT_LT(dmStrlCat(expected_path, "testing", sizeof(expected_path)), sizeof(expected_path));
+    dmLogWarning("Expected application support path (char): '%s'", expected_path);
+
+    char path[1024];
+    dmSys::Result result = dmSys::GetApplicationSupportPath(utf8_parent, "testing", path, sizeof(path));
+    EXPECT_EQ(dmSys::RESULT_OK, result);
+    if (result == dmSys::RESULT_OK)
+    {
+        EXPECT_EQ(dmSys::RESULT_OK, dmSys::IsDir(path));
+        EXPECT_STREQ(expected_path, path);
+    }
+
+    // Clean up with wide Win32 APIs so teardown still works even when the
+    // narrow dmSys path handling is broken.
+    wchar_t unicode_child[MAX_PATH];
+    wcscpy_s(unicode_child, MAX_PATH, unicode_parent);
+    wcscat_s(unicode_child, MAX_PATH, L"\\testing");
+    RemoveDirectoryW(unicode_child);
+    RemoveDirectoryW(unicode_parent);
+    RemoveDirectoryW(test_root);
+}
+#endif
 
 #endif
 

--- a/engine/dlib/src/test/test_sys.cpp
+++ b/engine/dlib/src/test/test_sys.cpp
@@ -183,64 +183,6 @@ TEST(dmSys, GetApplicationSupportPath)
     ASSERT_EQ(dmSys::RESULT_OK, dmSys::IsDir(path));
 }
 
-#if 0
-TEST(dmSys, UnicodeParentPath)
-{
-    // Skip on systems where the ANSI code page is already UTF-8, since the
-    // narrow-path CRT calls may succeed there and not expose the bug.
-    if (GetACP() == CP_UTF8)
-    {
-        dmLogWarning("Skipping UnicodeParentPath test because the active ANSI code page is UTF-8 (CP_UTF8), which can mask the narrow Windows path conversion bug.");
-        SKIP();
-    }
-
-    // Create a unique temporary root directory using wide Win32 APIs so the
-    // test setup itself does not depend on ANSI code page behavior.
-    wchar_t temp_path[MAX_PATH];
-    DWORD temp_path_len = GetTempPathW(MAX_PATH, temp_path);
-    ASSERT_GT(temp_path_len, 0u);
-    ASSERT_LT(temp_path_len, (DWORD)MAX_PATH);
-
-    wchar_t test_root[MAX_PATH];
-    UINT unique_name_result = GetTempFileNameW(temp_path, L"dfs", 0, test_root);
-    ASSERT_NE(0u, unique_name_result);
-    ASSERT_TRUE(DeleteFileW(test_root) != 0);
-    ASSERT_TRUE(CreateDirectoryW(test_root, NULL) != 0);
-
-    // Add a Korean path component to simulate a Unicode username/AppData
-    // segment in the application support path.
-    wchar_t unicode_parent[MAX_PATH];
-    wcscpy_s(unicode_parent, MAX_PATH, test_root);
-    wcscat_s(unicode_parent, MAX_PATH, L"\\");
-    wcscat_s(unicode_parent, MAX_PATH, L"\xD64D\xAE38\xB3D9");
-    ASSERT_TRUE(CreateDirectoryW(unicode_parent, NULL) != 0);
-
-    // This is the child directory that dmSys::Mkdir() will try to create.
-    wchar_t unicode_child[MAX_PATH];
-    wcscpy_s(unicode_child, MAX_PATH, unicode_parent);
-    wcscat_s(unicode_child, MAX_PATH, L"\\testing");
-
-    // Convert the wide paths to UTF-8 to match what GetApplicationSupportPath()
-    // returns before the path is passed into the narrow dmSys filesystem APIs.
-    char utf8_parent[1024];
-    char utf8_child[1024];
-    ASSERT_TRUE(WidePathToUtf8(unicode_parent, utf8_parent, sizeof(utf8_parent)));
-    ASSERT_TRUE(WidePathToUtf8(unicode_child, utf8_child, sizeof(utf8_child)));
-
-    // These calls currently go through narrow CRT/Win32 APIs on Windows and
-    // are expected to fail before the Unicode path handling is fixed.
-    EXPECT_EQ(dmSys::RESULT_OK, dmSys::IsDir(utf8_parent));
-    EXPECT_EQ(dmSys::RESULT_OK, dmSys::Mkdir(utf8_child, 0777));
-    EXPECT_EQ(dmSys::RESULT_OK, dmSys::IsDir(utf8_child));
-
-    // Clean up with wide Win32 APIs so teardown still works even when the
-    // narrow dmSys path handling is broken.
-    RemoveDirectoryW(unicode_child);
-    RemoveDirectoryW(unicode_parent);
-    RemoveDirectoryW(test_root);
-}
-#endif
-
 #if defined(_WIN32)
 TEST(dmSys, GetApplicationSupportPathInternalUnicodeParentPath)
 {
@@ -290,11 +232,13 @@ TEST(dmSys, GetApplicationSupportPathInternalUnicodeParentPath)
     ASSERT_TRUE(WidePathToUtf8(short_parent, utf8_short_parent, sizeof(utf8_short_parent)));
     dmLogWarning("Expected 8.3 parent (char): '%s'", utf8_short_parent);
 
+    EXPECT_EQ(dmSys::RESULT_OK, dmSys::IsDir(utf8_short_parent));
+
     // Call the extracted internal helper directly so the test covers the
     // narrow-path application support logic without depending on
-    // SHGetFolderPathW or 8.3 alias generation.
+    // SHGetFolderPathW.
     char expected_path[1024];
-    ASSERT_LT(dmStrlCpy(expected_path, utf8_short_parent, sizeof(expected_path)), sizeof(expected_path));
+    ASSERT_LT(dmStrlCpy(expected_path, utf8_parent, sizeof(expected_path)), sizeof(expected_path));
     ASSERT_LT(dmStrlCat(expected_path, "/", sizeof(expected_path)), sizeof(expected_path));
     ASSERT_LT(dmStrlCat(expected_path, "testing", sizeof(expected_path)), sizeof(expected_path));
     dmLogWarning("Expected application support path (char): '%s'", expected_path);
@@ -304,6 +248,8 @@ TEST(dmSys, GetApplicationSupportPathInternalUnicodeParentPath)
     EXPECT_EQ(dmSys::RESULT_OK, result);
     if (result == dmSys::RESULT_OK)
     {
+        dmLogWarning("Application support path (char): '%s'", path);
+
         EXPECT_EQ(dmSys::RESULT_OK, dmSys::IsDir(path));
         EXPECT_STREQ(expected_path, path);
     }


### PR DESCRIPTION
This fixes issues when a folder or a filename contain Unicode characters.
E.g. you could see `Failed get application support path` due to invalid conversions.

Fixes https://github.com/defold/defold/issues/12191

### Technical changes

Instead of keeping all strings as `char`, we use Windows functions to convert to `wchar_t` and use the `W` (wide) variants of the file operation functions.


## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
