### PR TITLE
Fixed an issue when using collectionproxy.set_collection() with already loaded collection

### DIFF
--- a/engine/gamesys/src/gamesys/components/comp_collection_proxy.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_collection_proxy.cpp
@@ -419,7 +419,6 @@ namespace dmGameSystem
         return result;
     }
 
-
     static dmGameObject::Result CompCollectionProxyLoadInternal(CollectionProxyContext* context, HCollectionProxyComponent proxy,
                                                             ProxyLoadCallback cbk, void* cbk_ctx,
                                                             dmMessage::URL* sender, dmMessage::URL* receiver,
@@ -445,6 +444,16 @@ namespace dmGameSystem
             if (message)
                 return dmGameObject::RESULT_OK;
             return dmGameObject::RESULT_UNKNOWN_ERROR;
+        }
+
+        char canonical_path[dmResource::RESOURCE_PATH_MAX];
+        uint32_t canonical_path_len = dmResource::GetCanonicalPath(path, canonical_path, sizeof(canonical_path));
+        dmhash_t canonical_path_hash = dmHashBuffer64(canonical_path, canonical_path_len);
+
+        if (dmResource::FindByHash(context->m_Factory, canonical_path_hash) != 0)
+        {
+            LogMessageError(message, "Collection proxy %s: '%s'", "already loaded", path);
+            return dmGameObject::RESULT_ALREADY_REGISTERED;
         }
 
         proxy->m_Unloaded = 0;

--- a/engine/gamesys/src/gamesys/test/collection_factory/collectionfactory_test.script
+++ b/engine/gamesys/src/gamesys/test/collection_factory/collectionfactory_test.script
@@ -17,15 +17,27 @@ local function state(self)
     return self.states[self.state]
 end
 
+local ROOT_ID = hash("/go")
+
 local function next_state(self)
     self.state = self.state + 1
 end
 
-local function delete_gameobjects(self)
-    for _, id in ipairs(self.ids) do
+local function is_root_instance()
+    return go.get_id() == ROOT_ID
+end
+
+local function should_cleanup_recursive_instance()
+    return recursive_cleanup_in_script ~= false
+end
+
+local function delete_gameobjects(ids)
+    for _, id in ipairs(ids) do
         go.delete(id, true)
     end
-    self.ids = {}
+    for i = #ids, 1, -1 do
+        ids[i] = nil
+    end
 end
 
 local function handle_state(self)
@@ -49,12 +61,38 @@ local function handle_state(self)
         collectionfactory.set_prototype("/go#collectionfactory", nil)
         next_state(self)
     elseif state == "delete" then
-        delete_gameobjects(self)
+        delete_gameobjects(self.ids)
+        next_state(self)
+    elseif state == "load_recursive_prototype" then
+        assert(recursive_prototype_path ~= nil)
+        collectionfactory.set_prototype("/go#collectionfactory", recursive_prototype_path)
+        self.loading = true
+        collectionfactory.load("/go#collectionfactory", load_complete)
+    elseif state == "unload_recursive_prototype" then
+        collectionfactory.unload("/go#collectionfactory")
+        collectionfactory.set_prototype("/go#collectionfactory", nil)
+        next_state(self)
+    elseif state == "delete_recursive_gameobjects" then
+        if should_cleanup_recursive_instance() then
+            delete_gameobjects(self.recursive_ids)
+        end
         next_state(self)
     end
 end
 
 function init(self)
+    global_recursive_created = nil
+    recursive_instance = nil
+
+    if recursive_prototype_path ~= nil and not is_root_instance() then
+        self.states = {}
+        self.ids = {}
+        self.recursive_ids = {}
+        self.state = 1
+        self.loading = false
+        return
+    end
+
     self.states = {"load", "unload", "delete"}
     if prototype_path ~= nil then
         table.insert(self.states, "load_prototype")
@@ -62,7 +100,16 @@ function init(self)
         table.insert(self.states, "delete")
     end
 
+    if recursive_prototype_path ~= nil and is_root_instance() then
+        table.insert(self.states, "load_recursive_prototype")
+        table.insert(self.states, "unload_recursive_prototype")
+        if should_cleanup_recursive_instance() then
+            table.insert(self.states, "delete_recursive_gameobjects")
+        end
+    end
+
     self.ids = {}
+    self.recursive_ids = {}
     self.state = 1
     self.loading = false
     handle_state(self)
@@ -70,14 +117,22 @@ end
 
 function load_complete(self, url, result)
     assert(result == true)
-    local ids1 = collectionfactory.create(url)
-    local ids2 = collectionfactory.create(url)
-    -- DEF-3338 Collection factory create() function should accept nil value in place of table
-    local ids3 = collectionfactory.create(url, nil, nil, nil, 1)
-    self.ids = {}
-    for _, id in pairs(ids1) do table.insert(self.ids, id) end
-    for _, id in pairs(ids2) do table.insert(self.ids, id) end
-    for _, id in pairs(ids3) do table.insert(self.ids, id) end
+    if state(self) == "load_recursive_prototype" then
+        self.recursive_ids = {}
+        local ids = collectionfactory.create(url)
+        for _, id in pairs(ids) do table.insert(self.recursive_ids, id) end
+        recursive_instance = self.recursive_ids[1]
+        global_recursive_created = true
+    else
+        local ids1 = collectionfactory.create(url)
+        local ids2 = collectionfactory.create(url)
+        -- DEF-3338 Collection factory create() function should accept nil value in place of table
+        local ids3 = collectionfactory.create(url, nil, nil, nil, 1)
+        self.ids = {}
+        for _, id in pairs(ids1) do table.insert(self.ids, id) end
+        for _, id in pairs(ids2) do table.insert(self.ids, id) end
+        for _, id in pairs(ids3) do table.insert(self.ids, id) end
+    end
     self.loading = false
     next_state(self)
 end
@@ -93,4 +148,7 @@ function update(self, dt)
 end
 
 function final(self)
+    if should_cleanup_recursive_instance() then
+        delete_gameobjects(self.recursive_ids)
+    end
 end

--- a/engine/gamesys/src/gamesys/test/collection_factory/dynamic_collectionfactory_test.script
+++ b/engine/gamesys/src/gamesys/test/collection_factory/dynamic_collectionfactory_test.script
@@ -20,23 +20,35 @@ local function state_prev(self)
     return self.states[self.state_prev]
 end
 
+local ROOT_ID = hash("/go")
+
 local function next_state(self)
     self.state_prev = self.state
     self.state = self.state + 1
 end
 
-local function delete_gameobjects(self)
-    for _, id in ipairs(self.ids) do
-        go.delete(id, true)
-    end
-    self.ids = {}
+local function is_root_instance()
+    return go.get_id() == ROOT_ID
 end
 
-local function create_gameobjects(self, url)
+local function should_cleanup_recursive_instance()
+    return recursive_cleanup_in_script ~= false
+end
+
+local function delete_gameobjects(ids)
+    for _, id in ipairs(ids) do
+        go.delete(id, true)
+    end
+    for i = #ids, 1, -1 do
+        ids[i] = nil
+    end
+end
+
+local function create_gameobjects(ids, url)
     local ids1 = collectionfactory.create(url)
     local ids2 = collectionfactory.create(url)
-    for _, id in pairs(ids1) do table.insert(self.ids, id) end
-    for _, id in pairs(ids2) do table.insert(self.ids, id) end
+    for _, id in pairs(ids1) do table.insert(ids, id) end
+    for _, id in pairs(ids2) do table.insert(ids, id) end
 end
 
 local function handle_state(self)
@@ -61,34 +73,72 @@ local function handle_state(self)
         collectionfactory.set_prototype("/go#collectionfactory", nil)
         next_state(self)
     elseif state == "delete" then
-        delete_gameobjects(self)
+        delete_gameobjects(self.ids)
         next_state(self)
     elseif state == "create" then
-        create_gameobjects(self, self.url)
+        create_gameobjects(self.ids, self.url)
+        next_state(self)
+    elseif state == "load_recursive_prototype" then
+        assert(recursive_prototype_path ~= nil)
+        collectionfactory.set_prototype("/go#collectionfactory", recursive_prototype_path)
+        self.loading = true
+        collectionfactory.load("/go#collectionfactory", load_complete)
+    elseif state == "unload_recursive_prototype" then
+        collectionfactory.unload("/go#collectionfactory")
+        collectionfactory.set_prototype("/go#collectionfactory", nil)
+        next_state(self)
+    elseif state == "delete_recursive_gameobjects" then
+        if should_cleanup_recursive_instance() then
+            delete_gameobjects(self.recursive_ids)
+        end
         next_state(self)
     end
 end
 
 function init(self)
+    global_recursive_created = nil
+    recursive_instance = nil
+
     self.url = "/go#collectionfactory"
     self.ids = {}
+    self.recursive_ids = {}
     self.loading = false
     self.state_prev = 0
     self.state = 1
     self.states = { "load", "unload", "delete", "load", "unload",
-                    "unload", "delete", "create", "delete"}
+                    "unload", "delete", "create", "delete" }
 
     if prototype_path ~= nil then
         table.insert(self.states, "load_prototype")
         table.insert(self.states, "unload_prototype")
         table.insert(self.states, "delete")
     end
+
+    if recursive_prototype_path ~= nil then
+        if is_root_instance() then
+            table.insert(self.states, "load_recursive_prototype")
+            table.insert(self.states, "unload_recursive_prototype")
+            if should_cleanup_recursive_instance() then
+                table.insert(self.states, "delete_recursive_gameobjects")
+            end
+        else
+            self.states = {}
+        end
+    end
 end
 
 function load_complete(self, url, result)
     assert(result == true)
     self.loading = false
-    create_gameobjects(self, url)
+    if state(self) == "load_recursive_prototype" then
+        self.recursive_ids = {}
+        local ids = collectionfactory.create(url)
+        for _, id in pairs(ids) do table.insert(self.recursive_ids, id) end
+        recursive_instance = self.recursive_ids[1]
+        global_recursive_created = true
+    else
+        create_gameobjects(self.ids, url)
+    end
     next_state(self)
 end
 
@@ -101,4 +151,7 @@ function update(self, dt)
 end
 
 function final(self)
+    if should_cleanup_recursive_instance() then
+        delete_gameobjects(self.recursive_ids)
+    end
 end

--- a/engine/gamesys/src/gamesys/test/collection_factory/recursive_collectionfactory_test.collection
+++ b/engine/gamesys/src/gamesys/test/collection_factory/recursive_collectionfactory_test.collection
@@ -1,0 +1,16 @@
+name: "recursive_collectionfactory_test"
+instances {
+  id: "go"
+  prototype: "/collection_factory/collectionfactory_test.go"
+  position {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+}

--- a/engine/gamesys/src/gamesys/test/collection_factory/recursive_dynamic_collectionfactory_test.collection
+++ b/engine/gamesys/src/gamesys/test/collection_factory/recursive_dynamic_collectionfactory_test.collection
@@ -1,0 +1,16 @@
+name: "recursive_dynamic_collectionfactory_test"
+instances {
+  id: "go"
+  prototype: "/collection_factory/dynamic_collectionfactory_test.go"
+  position {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+}

--- a/engine/gamesys/src/gamesys/test/collection_proxy/set_collection_chain_level1.collection
+++ b/engine/gamesys/src/gamesys/test/collection_proxy/set_collection_chain_level1.collection
@@ -1,0 +1,16 @@
+name: "set_collection_chain_level1"
+instances {
+  id: "go"
+  prototype: "/collection_proxy/set_collection_chain_level1.go"
+  position {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+}

--- a/engine/gamesys/src/gamesys/test/collection_proxy/set_collection_chain_level1.go
+++ b/engine/gamesys/src/gamesys/test/collection_proxy/set_collection_chain_level1.go
@@ -1,0 +1,8 @@
+components {
+  id: "script"
+  component: "/collection_proxy/set_collection_chain_level1.script"
+}
+components {
+  id: "collectionproxy"
+  component: "/collection_proxy/set_collection_override.collectionproxy"
+}

--- a/engine/gamesys/src/gamesys/test/collection_proxy/set_collection_chain_level1.script
+++ b/engine/gamesys/src/gamesys/test/collection_proxy/set_collection_chain_level1.script
@@ -1,0 +1,52 @@
+local function append_status(message)
+    print(message)
+    cp_status_log = cp_status_log or {}
+    table.insert(cp_status_log, message)
+end
+
+function init(self)
+    self.collection = "/collection_proxy/set_collection_chain_level2.collectionc"
+    self.state = "set_collection"
+
+    append_status("collectionproxy chain level1 init")
+    cp_chain_level1_initialized = true
+end
+
+function update(self, dt)
+    if self.state == "set_collection" then
+        append_status("collectionproxy chain level1 set_collection " .. self.collection)
+        local ok, result = collectionproxy.set_collection("#collectionproxy", self.collection)
+        cp_chain_level1_set_ok = ok
+        cp_chain_level1_set_result = result
+        if ok then
+            append_status("collectionproxy chain level1 set_collection_ok")
+            self.state = "load"
+        else
+            append_status("collectionproxy chain level1 set_collection_failed " .. tostring(result))
+            cp_chain_cycle_rejected = true
+            self.state = "done"
+        end
+    elseif self.state == "load" then
+        msg.post("#collectionproxy", "load")
+        self.state = "wait_loaded"
+    elseif self.state == "init_enable" then
+        msg.post("#collectionproxy", "init")
+        msg.post("#collectionproxy", "enable")
+        self.state = "done"
+    end
+end
+
+function on_message(self, message_id, message, sender)
+    if message_id == hash("proxy_loaded") then
+        append_status("collectionproxy chain level1 proxy_loaded")
+        cp_chain_level1_proxy_loaded = true
+        self.state = "init_enable"
+    elseif message_id == hash("proxy_unloaded") then
+        append_status("collectionproxy chain level1 proxy_unloaded")
+    end
+end
+
+function final(self)
+    append_status("collectionproxy chain level1 final")
+    cp_chain_level1_finalized = true
+end

--- a/engine/gamesys/src/gamesys/test/collection_proxy/set_collection_chain_level2.collection
+++ b/engine/gamesys/src/gamesys/test/collection_proxy/set_collection_chain_level2.collection
@@ -1,0 +1,16 @@
+name: "set_collection_chain_level2"
+instances {
+  id: "go"
+  prototype: "/collection_proxy/set_collection_chain_level2.go"
+  position {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+}

--- a/engine/gamesys/src/gamesys/test/collection_proxy/set_collection_chain_level2.go
+++ b/engine/gamesys/src/gamesys/test/collection_proxy/set_collection_chain_level2.go
@@ -1,0 +1,8 @@
+components {
+  id: "script"
+  component: "/collection_proxy/set_collection_chain_level2.script"
+}
+components {
+  id: "collectionproxy"
+  component: "/collection_proxy/set_collection_override.collectionproxy"
+}

--- a/engine/gamesys/src/gamesys/test/collection_proxy/set_collection_chain_level2.script
+++ b/engine/gamesys/src/gamesys/test/collection_proxy/set_collection_chain_level2.script
@@ -1,0 +1,54 @@
+local function append_status(message)
+    print(message)
+    cp_status_log = cp_status_log or {}
+    table.insert(cp_status_log, message)
+end
+
+function init(self)
+    self.collection = "/collection_proxy/set_collection_chain_level1.collectionc"
+    self.state = "set_collection"
+
+    append_status("collectionproxy chain level2 init")
+    cp_chain_level2_initialized = true
+end
+
+function update(self, dt)
+    cp_chain_level2_update_count = (cp_chain_level2_update_count or 0) + 1
+
+    if self.state == "set_collection" then
+        append_status("collectionproxy chain level2 set_collection " .. self.collection)
+        local ok, result = collectionproxy.set_collection("#collectionproxy", self.collection)
+        cp_chain_level2_set_ok = ok
+        cp_chain_level2_set_result = result
+        if ok then
+            append_status("collectionproxy chain level2 set_collection_ok")
+            self.state = "load"
+        else
+            append_status("collectionproxy chain level2 set_collection_failed " .. tostring(result))
+            cp_chain_cycle_rejected = true
+            self.state = "done"
+        end
+    elseif self.state == "load" then
+        msg.post("#collectionproxy", "load")
+        self.state = "wait_loaded"
+    elseif self.state == "init_enable" then
+        msg.post("#collectionproxy", "init")
+        msg.post("#collectionproxy", "enable")
+        self.state = "done"
+    end
+end
+
+function on_message(self, message_id, message, sender)
+    if message_id == hash("proxy_loaded") then
+        append_status("collectionproxy chain level2 proxy_loaded")
+        cp_chain_level2_proxy_loaded = true
+        self.state = "init_enable"
+    elseif message_id == hash("proxy_unloaded") then
+        append_status("collectionproxy chain level2 proxy_unloaded")
+    end
+end
+
+function final(self)
+    append_status("collectionproxy chain level2 final")
+    cp_chain_level2_finalized = true
+end

--- a/engine/gamesys/src/gamesys/test/collection_proxy/set_collection_chain_root.go
+++ b/engine/gamesys/src/gamesys/test/collection_proxy/set_collection_chain_root.go
@@ -1,0 +1,8 @@
+components {
+  id: "script"
+  component: "/collection_proxy/set_collection_chain_root.script"
+}
+components {
+  id: "collectionproxy"
+  component: "/collection_proxy/set_collection_override.collectionproxy"
+}

--- a/engine/gamesys/src/gamesys/test/collection_proxy/set_collection_chain_root.script
+++ b/engine/gamesys/src/gamesys/test/collection_proxy/set_collection_chain_root.script
@@ -1,0 +1,52 @@
+local function append_status(message)
+    print(message)
+    cp_status_log = cp_status_log or {}
+    table.insert(cp_status_log, message)
+end
+
+function init(self)
+    self.collection = "/collection_proxy/set_collection_chain_level1.collectionc"
+    self.state = "set_collection"
+
+    append_status("collectionproxy chain root init")
+    cp_chain_root_initialized = true
+end
+
+function update(self, dt)
+    if self.state == "set_collection" then
+        append_status("collectionproxy chain root set_collection " .. self.collection)
+        local ok, result = collectionproxy.set_collection("#collectionproxy", self.collection)
+        cp_chain_root_set_ok = ok
+        cp_chain_root_set_result = result
+        if ok then
+            append_status("collectionproxy chain root set_collection_ok")
+            self.state = "load"
+        else
+            append_status("collectionproxy chain root set_collection_failed " .. tostring(result))
+            cp_chain_cycle_rejected = true
+            self.state = "done"
+        end
+    elseif self.state == "load" then
+        msg.post("#collectionproxy", "load")
+        self.state = "wait_loaded"
+    elseif self.state == "init_enable" then
+        msg.post("#collectionproxy", "init")
+        msg.post("#collectionproxy", "enable")
+        self.state = "done"
+    end
+end
+
+function on_message(self, message_id, message, sender)
+    if message_id == hash("proxy_loaded") then
+        append_status("collectionproxy chain root proxy_loaded")
+        cp_chain_root_proxy_loaded = true
+        self.state = "init_enable"
+    elseif message_id == hash("proxy_unloaded") then
+        append_status("collectionproxy chain root proxy_unloaded")
+    end
+end
+
+function final(self)
+    append_status("collectionproxy chain root final")
+    cp_chain_root_finalized = true
+end

--- a/engine/gamesys/src/gamesys/test/collection_proxy/set_collection_cpp_cycle_level1.collection
+++ b/engine/gamesys/src/gamesys/test/collection_proxy/set_collection_cpp_cycle_level1.collection
@@ -1,0 +1,16 @@
+name: "set_collection_cpp_cycle_level1"
+instances {
+  id: "go"
+  prototype: "/collection_proxy/set_collection_cpp_cycle_proxy.go"
+  position {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+}

--- a/engine/gamesys/src/gamesys/test/collection_proxy/set_collection_cpp_cycle_level2.collection
+++ b/engine/gamesys/src/gamesys/test/collection_proxy/set_collection_cpp_cycle_level2.collection
@@ -1,0 +1,16 @@
+name: "set_collection_cpp_cycle_level2"
+instances {
+  id: "go"
+  prototype: "/collection_proxy/set_collection_cpp_cycle_proxy.go"
+  position {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+}

--- a/engine/gamesys/src/gamesys/test/collection_proxy/set_collection_cpp_cycle_level3.collection
+++ b/engine/gamesys/src/gamesys/test/collection_proxy/set_collection_cpp_cycle_level3.collection
@@ -1,0 +1,16 @@
+name: "set_collection_cpp_cycle_level3"
+instances {
+  id: "go"
+  prototype: "/collection_proxy/set_collection_cpp_cycle_proxy.go"
+  position {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+}

--- a/engine/gamesys/src/gamesys/test/collection_proxy/set_collection_cpp_cycle_proxy.go
+++ b/engine/gamesys/src/gamesys/test/collection_proxy/set_collection_cpp_cycle_proxy.go
@@ -1,0 +1,4 @@
+components {
+  id: "collectionproxy"
+  component: "/collection_proxy/set_collection_override.collectionproxy"
+}

--- a/engine/gamesys/src/gamesys/test/collection_proxy/set_collection_override.collectionproxy
+++ b/engine/gamesys/src/gamesys/test/collection_proxy/set_collection_override.collectionproxy
@@ -1,0 +1,2 @@
+collection: "/collection_proxy/valid.collection"
+exclude: true

--- a/engine/gamesys/src/gamesys/test/collection_proxy/set_collection_single_root.go
+++ b/engine/gamesys/src/gamesys/test/collection_proxy/set_collection_single_root.go
@@ -1,0 +1,8 @@
+components {
+  id: "script"
+  component: "/collection_proxy/set_collection_single_root.script"
+}
+components {
+  id: "collectionproxy"
+  component: "/collection_proxy/set_collection_override.collectionproxy"
+}

--- a/engine/gamesys/src/gamesys/test/collection_proxy/set_collection_single_root.script
+++ b/engine/gamesys/src/gamesys/test/collection_proxy/set_collection_single_root.script
@@ -1,0 +1,36 @@
+local function append_status(message)
+    print(message)
+    cp_status_log = cp_status_log or {}
+    table.insert(cp_status_log, message)
+end
+
+function init(self)
+    local collection = "/collection_proxy/set_collection_single_target.collectionc"
+
+    append_status("collectionproxy single root init")
+    cp_single_root_initialized = true
+
+    append_status("collectionproxy single root set_collection " .. collection)
+    local ok, result = collectionproxy.set_collection("#collectionproxy", collection)
+    cp_single_root_set_ok = ok
+    cp_single_root_set_result = result
+    assert(ok)
+
+    msg.post("#collectionproxy", "load")
+end
+
+function on_message(self, message_id, message, sender)
+    if message_id == hash("proxy_loaded") then
+        append_status("collectionproxy single root proxy_loaded")
+        cp_single_root_proxy_loaded = true
+        msg.post("#collectionproxy", "init")
+        msg.post("#collectionproxy", "enable")
+    elseif message_id == hash("proxy_unloaded") then
+        append_status("collectionproxy single root proxy_unloaded")
+    end
+end
+
+function final(self)
+    append_status("collectionproxy single root final")
+    cp_single_root_finalized = true
+end

--- a/engine/gamesys/src/gamesys/test/collection_proxy/set_collection_single_target.collection
+++ b/engine/gamesys/src/gamesys/test/collection_proxy/set_collection_single_target.collection
@@ -1,0 +1,16 @@
+name: "set_collection_single_target"
+instances {
+  id: "go"
+  prototype: "/collection_proxy/set_collection_single_target.go"
+  position {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+}

--- a/engine/gamesys/src/gamesys/test/collection_proxy/set_collection_single_target.go
+++ b/engine/gamesys/src/gamesys/test/collection_proxy/set_collection_single_target.go
@@ -1,0 +1,4 @@
+components {
+  id: "script"
+  component: "/collection_proxy/set_collection_single_target.script"
+}

--- a/engine/gamesys/src/gamesys/test/collection_proxy/set_collection_single_target.script
+++ b/engine/gamesys/src/gamesys/test/collection_proxy/set_collection_single_target.script
@@ -1,0 +1,19 @@
+local function append_status(message)
+    print(message)
+    cp_status_log = cp_status_log or {}
+    table.insert(cp_status_log, message)
+end
+
+function init(self)
+    append_status("collectionproxy single target init")
+    cp_single_target_initialized = true
+end
+
+function update(self, dt)
+    cp_single_target_update_count = (cp_single_target_update_count or 0) + 1
+end
+
+function final(self)
+    append_status("collectionproxy single target final")
+    cp_single_target_finalized = true
+end

--- a/engine/gamesys/src/gamesys/test/factory/dynamic_factory_test.factory
+++ b/engine/gamesys/src/gamesys/test/factory/dynamic_factory_test.factory
@@ -1,2 +1,3 @@
 prototype: "/factory/factory_resource.go"
 load_dynamically: true
+dynamic_prototype: true

--- a/engine/gamesys/src/gamesys/test/factory/dynamic_factory_test.script
+++ b/engine/gamesys/src/gamesys/test/factory/dynamic_factory_test.script
@@ -12,84 +12,101 @@
 -- CONDITIONS OF ANY KIND, either express or implied. See the License for the
 -- specific language governing permissions and limitations under the License.
 
+local function state(self)
+    return self.states[self.state]
+end
+
+local function next_state(self)
+    self.state = self.state + 1
+end
+
+local function delete_gameobjects()
+    if first_instance ~= nil then
+        go.delete(first_instance, true)
+        first_instance = nil
+    end
+
+    if second_instance ~= nil then
+        go.delete(second_instance, true)
+        second_instance = nil
+    end
+
+    global_created = nil
+end
+
+local function create_gameobjects(url)
+    first_instance = factory.create(url)
+    second_instance = factory.create(url)
+    global_created = true
+end
+
+local function handle_state(self)
+    local current_state = state(self)
+
+    if current_state == "load" then
+        assert(factory.get_status("/go#factory") == factory.STATUS_UNLOADED)
+        self.loading = true
+        factory.load("/go#factory", load_complete)
+        assert(factory.get_status("/go#factory") == factory.STATUS_LOADING)
+    elseif current_state == "unload_delete" then
+        assert(factory.get_status("/go#factory") == factory.STATUS_LOADED)
+        factory.unload("/go#factory")
+        delete_gameobjects()
+        next_state(self)
+    elseif current_state == "unload_keep" then
+        assert(factory.get_status("/go#factory") == factory.STATUS_LOADED)
+        factory.unload("/go#factory")
+        next_state(self)
+    elseif current_state == "unload" then
+        factory.unload("/go#factory")
+        next_state(self)
+    elseif current_state == "delete" then
+        delete_gameobjects()
+        next_state(self)
+    elseif current_state == "create" then
+        create_gameobjects("/go#factory")
+        next_state(self)
+    elseif current_state == "load_prototype" then
+        assert(prototype_path ~= nil)
+        factory.set_prototype("/go#factory", prototype_path)
+        self.loading = true
+        factory.load("/go#factory", load_complete)
+    elseif current_state == "unload_prototype" then
+        factory.unload("/go#factory")
+        factory.set_prototype("/go#factory", nil)
+        next_state(self)
+    end
+end
 
 function init(self)
-    self.load = true
-    self.loaded = false
-    self.repeatloadunload = true
-    self.testunloadtwice = false
-    self.delete = false
-    self.create = false
+    self.loading = false
+    self.state = 1
+    self.states = { "load", "unload_delete", "load", "unload_keep", "unload", "delete", "create" }
+
+    if prototype_path ~= nil then
+        table.insert(self.states, "unload")
+        table.insert(self.states, "delete")
+        table.insert(self.states, "load_prototype")
+        table.insert(self.states, "unload_prototype")
+        table.insert(self.states, "delete")
+    end
 end
 
 function load_complete(self, url, result)
     assert(result == true)
-    first_instance = factory.create(url)
-    second_instance = factory.create(url)
-    self.loaded = true
-    global_created = true
+    create_gameobjects(url)
+    self.loading = false
+    next_state(self)
 end
 
 function update(self, dt)
-
-    --- step 1 ---
-    if self.load == true then
-        self.load = false
-        assert(factory.get_status("/go#factory") == factory.STATUS_UNLOADED)
-        factory.load("/go#factory", load_complete)
-        assert(factory.get_status("/go#factory") == factory.STATUS_LOADING)
+    if self.loading then
         return
     end
 
-    --- step 2 ---
-    if self.loaded == true then
-        self.loaded = false
-        assert(factory.get_status("/go#factory") == factory.STATUS_LOADED)
-        factory.unload("/go#factory")
-        if self.repeatloadunload == true then
-           self.repeatloadunload = false
-           self.load = true
-            go.delete(first_instance, true)
-            go.delete(second_instance, true)
-            global_created = nil
-        else
-            self.testunloadtwice = true
-        end
-        return
-    end
-
-    --- step 3 ---
-    if self.testunloadtwice == true then
-        self.testunloadtwice = false
-        self.delete = true
-        factory.unload("/go#factory")
-        return
-    end
-
-    --- step 4 ---
-    if self.delete == true then
-        self.delete = false
-        self.create = true
-        go.delete(first_instance, true)
-        go.delete(second_instance, true)
-        global_created = nil
-        return
-    end
-
-    --- step 5 ---
-    if self.create == true then
-        self.create = false
-        first_instance = factory.create("/go#factory")
-        second_instance = factory.create("/go#factory")
-        global_created = true
-        return
-    end
+    handle_state(self)
 end
 
 function final(self)
-    go.delete(first_instance, true)
-    go.delete(second_instance, true)
-    global_created = nil
-    first_instance = nil
-    second_instance = nil
+    delete_gameobjects()
 end

--- a/engine/gamesys/src/gamesys/test/factory/dynamic_factory_test.script
+++ b/engine/gamesys/src/gamesys/test/factory/dynamic_factory_test.script
@@ -16,6 +16,12 @@ local function state(self)
     return self.states[self.state]
 end
 
+local ROOT_ID = hash("/go")
+
+local function should_cleanup_recursive_instance()
+    return recursive_cleanup_in_script ~= false
+end
+
 local function next_state(self)
     self.state = self.state + 1
 end
@@ -38,6 +44,15 @@ local function create_gameobjects(url)
     first_instance = factory.create(url)
     second_instance = factory.create(url)
     global_created = true
+end
+
+local function delete_recursive_instance()
+    if recursive_instance ~= nil then
+        go.delete(recursive_instance, true)
+        recursive_instance = nil
+    end
+
+    global_recursive_created = nil
 end
 
 local function handle_state(self)
@@ -75,10 +90,30 @@ local function handle_state(self)
         factory.unload("/go#factory")
         factory.set_prototype("/go#factory", nil)
         next_state(self)
+    elseif current_state == "recursive_prototype" then
+        assert(recursive_prototype_path ~= nil)
+        factory.set_prototype("/go#factory", recursive_prototype_path)
+        recursive_instance = factory.create("/go#factory")
+        assert(recursive_instance ~= nil)
+        global_recursive_created = true
+        next_state(self)
+    elseif current_state == "reset_recursive_prototype" then
+        factory.unload("/go#factory")
+        factory.set_prototype("/go#factory", nil)
+        next_state(self)
+    elseif current_state == "delete_recursive_instance" then
+        delete_recursive_instance()
+        next_state(self)
     end
 end
 
 function init(self)
+    if recursive_prototype_path ~= nil and go.get_id() ~= ROOT_ID then
+        self.disabled = true
+        return
+    end
+
+    self.disabled = false
     self.loading = false
     self.state = 1
     self.states = { "load", "unload_delete", "load", "unload_keep", "unload", "delete", "create" }
@@ -90,6 +125,14 @@ function init(self)
         table.insert(self.states, "unload_prototype")
         table.insert(self.states, "delete")
     end
+
+    if recursive_prototype_path ~= nil then
+        table.insert(self.states, "recursive_prototype")
+        table.insert(self.states, "reset_recursive_prototype")
+        if should_cleanup_recursive_instance() then
+            table.insert(self.states, "delete_recursive_instance")
+        end
+    end
 end
 
 function load_complete(self, url, result)
@@ -100,6 +143,10 @@ function load_complete(self, url, result)
 end
 
 function update(self, dt)
+    if self.disabled then
+        return
+    end
+
     if self.loading then
         return
     end
@@ -108,5 +155,12 @@ function update(self, dt)
 end
 
 function final(self)
+    if self.disabled then
+        return
+    end
+
     delete_gameobjects()
+    if should_cleanup_recursive_instance() then
+        delete_recursive_instance()
+    end
 end

--- a/engine/gamesys/src/gamesys/test/factory/dynamic_prototype_sprite.go
+++ b/engine/gamesys/src/gamesys/test/factory/dynamic_prototype_sprite.go
@@ -1,0 +1,4 @@
+components {
+  id: "sprite"
+  component: "/sprite/valid.sprite"
+}

--- a/engine/gamesys/src/gamesys/test/factory/factory_test.factory
+++ b/engine/gamesys/src/gamesys/test/factory/factory_test.factory
@@ -1,2 +1,2 @@
 prototype: "/factory/factory_resource.go"
-
+dynamic_prototype: true

--- a/engine/gamesys/src/gamesys/test/factory/factory_test.script
+++ b/engine/gamesys/src/gamesys/test/factory/factory_test.script
@@ -30,12 +30,16 @@ local function delete_gameobjects(self)
     if self.first_instance ~= nil then
         go.delete(self.first_instance, true)
         self.first_instance = nil
+        first_instance = nil
     end
 
     if self.second_instance ~= nil then
         go.delete(self.second_instance, true)
         self.second_instance = nil
+        second_instance = nil
     end
+
+    global_created = nil
 end
 
 local function delete_recursive_instance(self)
@@ -97,6 +101,9 @@ function init(self)
     self.first_instance = nil
     self.second_instance = nil
     self.recursive_instance = nil
+    first_instance = nil
+    second_instance = nil
+    global_created = nil
     self.loading = false
     self.state = 1
     self.states = { "load", "unload", "delete" }
@@ -120,6 +127,9 @@ function load_complete(self, url, result)
     assert(result == true)
     self.first_instance = factory.create(url)
     self.second_instance = factory.create(url)
+    first_instance = self.first_instance
+    second_instance = self.second_instance
+    global_created = true
     self.loading = false
     next_state(self)
 end

--- a/engine/gamesys/src/gamesys/test/factory/factory_test.script
+++ b/engine/gamesys/src/gamesys/test/factory/factory_test.script
@@ -12,30 +12,81 @@
 -- CONDITIONS OF ANY KIND, either express or implied. See the License for the
 -- specific language governing permissions and limitations under the License.
 
+local function state(self)
+    return self.states[self.state]
+end
+
+local function next_state(self)
+    self.state = self.state + 1
+end
+
+local function delete_gameobjects(self)
+    if self.first_instance ~= nil then
+        go.delete(self.first_instance, true)
+        self.first_instance = nil
+    end
+
+    if self.second_instance ~= nil then
+        go.delete(self.second_instance, true)
+        self.second_instance = nil
+    end
+end
+
+local function handle_state(self)
+    local current_state = state(self)
+
+    if current_state == "load" then
+        assert(factory.get_status("/go#factory") == factory.STATUS_LOADED)
+        self.loading = true
+        factory.load("/go#factory", load_complete)
+    elseif current_state == "unload" then
+        factory.unload("/go#factory")
+        next_state(self)
+    elseif current_state == "load_prototype" then
+        assert(prototype_path ~= nil)
+        factory.set_prototype("/go#factory", prototype_path)
+        self.loading = true
+        factory.load("/go#factory", load_complete)
+    elseif current_state == "unload_prototype" then
+        factory.unload("/go#factory")
+        factory.set_prototype("/go#factory", nil)
+        next_state(self)
+    elseif current_state == "delete" then
+        delete_gameobjects(self)
+        next_state(self)
+    end
+end
 
 function init(self)
-    self.unload = false
-    --- step 2 ---
-    assert(factory.get_status("/go#factory") == factory.STATUS_LOADED)
-    factory.load("/go#factory", load_complete)
+    self.first_instance = nil
+    self.second_instance = nil
+    self.loading = false
+    self.state = 1
+    self.states = { "load", "unload", "delete" }
+
+    if prototype_path ~= nil then
+        table.insert(self.states, "load_prototype")
+        table.insert(self.states, "unload_prototype")
+        table.insert(self.states, "delete")
+    end
 end
 
 function load_complete(self, url, result)
     assert(result == true)
     self.first_instance = factory.create(url)
     self.second_instance = factory.create(url)
-    self.unload = true
+    self.loading = false
+    next_state(self)
 end
 
 function update(self, dt)
-    --- step 2 ---
-    if self.unload == true then
-        factory.unload("/go#factory")
-        self.unload = false
+    if self.loading then
+        return
     end
+
+    handle_state(self)
 end
 
 function final(self)
-    go.delete(self.first_instance, true)
-    go.delete(self.second_instance, true)
+    delete_gameobjects(self)
 end

--- a/engine/gamesys/src/gamesys/test/factory/factory_test.script
+++ b/engine/gamesys/src/gamesys/test/factory/factory_test.script
@@ -16,6 +16,12 @@ local function state(self)
     return self.states[self.state]
 end
 
+local ROOT_ID = hash("/go")
+
+local function should_cleanup_recursive_instance()
+    return recursive_cleanup_in_script ~= false
+end
+
 local function next_state(self)
     self.state = self.state + 1
 end
@@ -30,6 +36,15 @@ local function delete_gameobjects(self)
         go.delete(self.second_instance, true)
         self.second_instance = nil
     end
+end
+
+local function delete_recursive_instance(self)
+    if self.recursive_instance ~= nil then
+        go.delete(self.recursive_instance, true)
+        self.recursive_instance = nil
+    end
+
+    global_recursive_created = nil
 end
 
 local function handle_state(self)
@@ -54,12 +69,34 @@ local function handle_state(self)
     elseif current_state == "delete" then
         delete_gameobjects(self)
         next_state(self)
+    elseif current_state == "recursive_prototype" then
+        assert(recursive_prototype_path ~= nil)
+        factory.set_prototype("/go#factory", recursive_prototype_path)
+        self.recursive_instance = factory.create("/go#factory")
+        assert(self.recursive_instance ~= nil)
+        recursive_instance = self.recursive_instance
+        global_recursive_created = true
+        next_state(self)
+    elseif current_state == "reset_recursive_prototype" then
+        factory.unload("/go#factory")
+        factory.set_prototype("/go#factory", nil)
+        next_state(self)
+    elseif current_state == "delete_recursive_instance" then
+        delete_recursive_instance(self)
+        next_state(self)
     end
 end
 
 function init(self)
+    if recursive_prototype_path ~= nil and go.get_id() ~= ROOT_ID then
+        self.disabled = true
+        return
+    end
+
+    self.disabled = false
     self.first_instance = nil
     self.second_instance = nil
+    self.recursive_instance = nil
     self.loading = false
     self.state = 1
     self.states = { "load", "unload", "delete" }
@@ -68,6 +105,14 @@ function init(self)
         table.insert(self.states, "load_prototype")
         table.insert(self.states, "unload_prototype")
         table.insert(self.states, "delete")
+    end
+
+    if recursive_prototype_path ~= nil then
+        table.insert(self.states, "recursive_prototype")
+        table.insert(self.states, "reset_recursive_prototype")
+        if should_cleanup_recursive_instance() then
+            table.insert(self.states, "delete_recursive_instance")
+        end
     end
 end
 
@@ -80,6 +125,10 @@ function load_complete(self, url, result)
 end
 
 function update(self, dt)
+    if self.disabled then
+        return
+    end
+
     if self.loading then
         return
     end
@@ -88,5 +137,12 @@ function update(self, dt)
 end
 
 function final(self)
-    delete_gameobjects(self)
+    if self.disabled then
+        return
+    end
+
+    if should_cleanup_recursive_instance() then
+        delete_gameobjects(self)
+        delete_recursive_instance(self)
+    end
 end

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -3366,9 +3366,23 @@ TEST_P(FactoryTest, Test)
 
             // --- step 4 ---
             // set and load a custom prototype, then create two instances
-            ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
-            ASSERT_TRUE(dmGameObject::PostUpdate(m_Collection));
-            dmGameObject::PostUpdate(m_Register);
+            for (;;)
+            {
+                lua_getglobal(L, "global_created");
+                bool ready = !lua_isnil(L, -1);
+                lua_pop(L, 1);
+                if (ready)
+                {
+                    lua_getglobal(L, "second_instance");
+                    dmhash_t second_instance = dmScript::CheckHash(L, -1);
+                    lua_pop(L, 1);
+                    if (dmGameObject::GetInstanceFromIdentifier(m_Collection, second_instance) != 0x0)
+                        break;
+                }
+                ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+                ASSERT_TRUE(dmGameObject::PostUpdate(m_Collection));
+                dmGameObject::PostUpdate(m_Register);
+            }
             ASSERT_EQ(3, dmResource::GetRefCount(m_Factory, dmHashString64(dyn_prototype_resource_path[0])));
             if (custom_prototype_has_subresources)
             {
@@ -7259,13 +7273,11 @@ TEST_F(MaterialTest, TextureTransform2DAttribute)
     ASSERT_EQ(5u, attribute_count);
 
     const dmGraphics::VertexAttributeInfo* tt_attr = 0;
-    uint32_t tt_ix = -1;
     for (uint32_t i = 0; i < attribute_count; ++i)
     {
         if (attributes[i].m_NameHash == dmHashString64("texture_transform_2d"))
         {
             tt_attr = &attributes[i];
-            tt_ix = i;
             break;
         }
     }

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -2886,6 +2886,18 @@ TEST_P(FactoryTest, Test)
             "/tile/valid.t.texturesetc",
             "/sprite/sprite.materialc",
     };
+    const char* dyn_prototype_empty_resource_path[] = {
+            "/factory/empty.goc",
+    };
+    const char* dyn_prototype_sprite_resource_path[] = {
+            "/factory/dynamic_prototype_sprite.goc",
+            "/sprite/valid.spritec",
+            "/tile/valid.t.texturesetc",
+            "/sprite/sprite.materialc",
+    };
+    const char** dyn_prototype_resource_path = 0;
+    uint32_t num_dyn_prototype_resources = 0;
+    bool custom_prototype_has_subresources = false;
     dmHashEnableReverseHash(true);
     lua_State* L = dmScript::GetLuaState(m_ScriptContext);
 
@@ -2898,6 +2910,29 @@ TEST_P(FactoryTest, Test)
 
     dmGameSystem::InitializeScriptLibs(scriptlibcontext);
     const FactoryTestParams& param = GetParam();
+
+    if (param.m_PrototypePath)
+    {
+        char buffer[256];
+        dmSnPrintf(buffer, sizeof(buffer), "prototype_path = '%s'", param.m_PrototypePath);
+        RunString(L, buffer);
+
+        if (strcmp(param.m_PrototypePath, "/factory/empty.goc") == 0)
+        {
+            dyn_prototype_resource_path = dyn_prototype_empty_resource_path;
+            num_dyn_prototype_resources = DM_ARRAY_SIZE(dyn_prototype_empty_resource_path);
+        }
+        else if (strcmp(param.m_PrototypePath, "/factory/dynamic_prototype_sprite.goc") == 0)
+        {
+            dyn_prototype_resource_path = dyn_prototype_sprite_resource_path;
+            num_dyn_prototype_resources = DM_ARRAY_SIZE(dyn_prototype_sprite_resource_path);
+            custom_prototype_has_subresources = true;
+        }
+        else
+        {
+            ASSERT_TRUE(false);
+        }
+    }
 
     // Conditional preload. This is essentially testing async loading vs sync loading of parent collection
     // This only affects non-dynamic factories.
@@ -3012,6 +3047,85 @@ TEST_P(FactoryTest, Test)
         ASSERT_EQ(1, dmResource::GetRefCount(m_Factory, dmHashString64(resource_path[2])));
         ASSERT_EQ(1, dmResource::GetRefCount(m_Factory, dmHashString64(resource_path[3])));
 
+        if (param.m_PrototypePath)
+        {
+            // --- step 6 ---
+            // unload the factory after the sync create so only the live instances keep the default prototype
+            ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+            ASSERT_TRUE(dmGameObject::PostUpdate(m_Collection));
+            dmGameObject::PostUpdate(m_Register);
+            ASSERT_EQ(2, dmResource::GetRefCount(m_Factory, dmHashString64(resource_path[0])));
+            ASSERT_EQ(1, dmResource::GetRefCount(m_Factory, dmHashString64(resource_path[1])));
+            ASSERT_EQ(1, dmResource::GetRefCount(m_Factory, dmHashString64(resource_path[2])));
+            ASSERT_EQ(1, dmResource::GetRefCount(m_Factory, dmHashString64(resource_path[3])));
+
+            // --- step 7 ---
+            // delete the instances created in the previous step so the new prototype starts from zero refs
+            ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+            ASSERT_TRUE(dmGameObject::PostUpdate(m_Collection));
+            dmGameObject::PostUpdate(m_Register);
+            ASSERT_EQ(0, dmResource::GetRefCount(m_Factory, dmHashString64(resource_path[0])));
+            ASSERT_EQ(0, dmResource::GetRefCount(m_Factory, dmHashString64(resource_path[1])));
+            ASSERT_EQ(0, dmResource::GetRefCount(m_Factory, dmHashString64(resource_path[2])));
+            ASSERT_EQ(0, dmResource::GetRefCount(m_Factory, dmHashString64(resource_path[3])));
+
+            for (uint32_t i = 0; i < num_dyn_prototype_resources; ++i)
+            {
+                ASSERT_EQ(0, dmResource::GetRefCount(m_Factory, dmHashString64(dyn_prototype_resource_path[i])));
+            }
+
+            // --- step 8 ---
+            // set and load a custom prototype, then create two instances
+            for(;;)
+            {
+                lua_getglobal(L, "global_created");
+                bool ready = !lua_isnil(L, -1);
+                lua_pop(L, 1);
+                if(ready)
+                {
+                    lua_getglobal(L, "second_instance");
+                    dmhash_t second_instance = dmScript::CheckHash(L, -1);
+                    lua_pop(L, 1);
+                    if (dmGameObject::GetInstanceFromIdentifier(m_Collection, second_instance) != 0x0)
+                        break;
+                }
+                ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+                ASSERT_TRUE(dmGameObject::PostUpdate(m_Collection));
+                dmGameObject::PostUpdate(m_Register);
+            }
+
+            ASSERT_EQ(3, dmResource::GetRefCount(m_Factory, dmHashString64(dyn_prototype_resource_path[0])));
+            if (custom_prototype_has_subresources)
+            {
+                ASSERT_EQ(1, dmResource::GetRefCount(m_Factory, dmHashString64(dyn_prototype_resource_path[1])));
+                ASSERT_EQ(1, dmResource::GetRefCount(m_Factory, dmHashString64(dyn_prototype_resource_path[2])));
+                ASSERT_EQ(1, dmResource::GetRefCount(m_Factory, dmHashString64(dyn_prototype_resource_path[3])));
+            }
+
+            // --- step 9 ---
+            // unload and reset the prototype; only the created instances should keep the resource alive
+            ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+            ASSERT_TRUE(dmGameObject::PostUpdate(m_Collection));
+            dmGameObject::PostUpdate(m_Register);
+            ASSERT_EQ(2, dmResource::GetRefCount(m_Factory, dmHashString64(dyn_prototype_resource_path[0])));
+            if (custom_prototype_has_subresources)
+            {
+                ASSERT_EQ(1, dmResource::GetRefCount(m_Factory, dmHashString64(dyn_prototype_resource_path[1])));
+                ASSERT_EQ(1, dmResource::GetRefCount(m_Factory, dmHashString64(dyn_prototype_resource_path[2])));
+                ASSERT_EQ(1, dmResource::GetRefCount(m_Factory, dmHashString64(dyn_prototype_resource_path[3])));
+            }
+
+            // --- step 10 ---
+            // delete the created instances and release the custom prototype resource
+            ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+            ASSERT_TRUE(dmGameObject::PostUpdate(m_Collection));
+            dmGameObject::PostUpdate(m_Register);
+            for (uint32_t i = 0; i < num_dyn_prototype_resources; ++i)
+            {
+                ASSERT_EQ(0, dmResource::GetRefCount(m_Factory, dmHashString64(dyn_prototype_resource_path[i])));
+            }
+        }
+
         // delete the root go and update so deferred deletes will be executed.
         dmGameObject::Delete(m_Collection, go, true);
         dmGameObject::Final(m_Collection);
@@ -3054,6 +3168,80 @@ TEST_P(FactoryTest, Test)
         ASSERT_EQ(1, dmResource::GetRefCount(m_Factory, dmHashString64(resource_path[2])));
         ASSERT_EQ(1, dmResource::GetRefCount(m_Factory, dmHashString64(resource_path[3])));
 
+        if (param.m_PrototypePath)
+        {
+            // --- step 3 ---
+            // delete the current instances before switching to a custom prototype
+            ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+            ASSERT_TRUE(dmGameObject::PostUpdate(m_Collection));
+            dmGameObject::PostUpdate(m_Register);
+            ASSERT_EQ(1, dmResource::GetRefCount(m_Factory, dmHashString64(resource_path[0])));
+            ASSERT_EQ(1, dmResource::GetRefCount(m_Factory, dmHashString64(resource_path[1])));
+            ASSERT_EQ(1, dmResource::GetRefCount(m_Factory, dmHashString64(resource_path[2])));
+            ASSERT_EQ(1, dmResource::GetRefCount(m_Factory, dmHashString64(resource_path[3])));
+
+            ASSERT_EQ(0, dmResource::GetRefCount(m_Factory, dmHashString64(dyn_prototype_resource_path[0])));
+            if (custom_prototype_has_subresources)
+            {
+                ASSERT_EQ(1, dmResource::GetRefCount(m_Factory, dmHashString64(dyn_prototype_resource_path[1])));
+                ASSERT_EQ(1, dmResource::GetRefCount(m_Factory, dmHashString64(dyn_prototype_resource_path[2])));
+                ASSERT_EQ(1, dmResource::GetRefCount(m_Factory, dmHashString64(dyn_prototype_resource_path[3])));
+            }
+            else
+            {
+                for (uint32_t i = 1; i < num_dyn_prototype_resources; ++i)
+                {
+                    ASSERT_EQ(0, dmResource::GetRefCount(m_Factory, dmHashString64(dyn_prototype_resource_path[i])));
+                }
+            }
+
+            // --- step 4 ---
+            // set and load a custom prototype, then create two instances
+            ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+            ASSERT_TRUE(dmGameObject::PostUpdate(m_Collection));
+            dmGameObject::PostUpdate(m_Register);
+            ASSERT_EQ(3, dmResource::GetRefCount(m_Factory, dmHashString64(dyn_prototype_resource_path[0])));
+            if (custom_prototype_has_subresources)
+            {
+                ASSERT_EQ(2, dmResource::GetRefCount(m_Factory, dmHashString64(dyn_prototype_resource_path[1])));
+                ASSERT_EQ(1, dmResource::GetRefCount(m_Factory, dmHashString64(dyn_prototype_resource_path[2])));
+                ASSERT_EQ(1, dmResource::GetRefCount(m_Factory, dmHashString64(dyn_prototype_resource_path[3])));
+            }
+
+            // --- step 5 ---
+            // unload and reset the prototype; only the created instances should keep the resource alive
+            ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+            ASSERT_TRUE(dmGameObject::PostUpdate(m_Collection));
+            dmGameObject::PostUpdate(m_Register);
+            ASSERT_EQ(2, dmResource::GetRefCount(m_Factory, dmHashString64(dyn_prototype_resource_path[0])));
+            if (custom_prototype_has_subresources)
+            {
+                ASSERT_EQ(2, dmResource::GetRefCount(m_Factory, dmHashString64(dyn_prototype_resource_path[1])));
+                ASSERT_EQ(1, dmResource::GetRefCount(m_Factory, dmHashString64(dyn_prototype_resource_path[2])));
+                ASSERT_EQ(1, dmResource::GetRefCount(m_Factory, dmHashString64(dyn_prototype_resource_path[3])));
+            }
+
+            // --- step 6 ---
+            // delete the created instances and release the custom prototype resource
+            ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+            ASSERT_TRUE(dmGameObject::PostUpdate(m_Collection));
+            dmGameObject::PostUpdate(m_Register);
+            ASSERT_EQ(0, dmResource::GetRefCount(m_Factory, dmHashString64(dyn_prototype_resource_path[0])));
+            if (custom_prototype_has_subresources)
+            {
+                ASSERT_EQ(1, dmResource::GetRefCount(m_Factory, dmHashString64(dyn_prototype_resource_path[1])));
+                ASSERT_EQ(1, dmResource::GetRefCount(m_Factory, dmHashString64(dyn_prototype_resource_path[2])));
+                ASSERT_EQ(1, dmResource::GetRefCount(m_Factory, dmHashString64(dyn_prototype_resource_path[3])));
+            }
+            else
+            {
+                for (uint32_t i = 1; i < num_dyn_prototype_resources; ++i)
+                {
+                    ASSERT_EQ(0, dmResource::GetRefCount(m_Factory, dmHashString64(dyn_prototype_resource_path[i])));
+                }
+            }
+        }
+
         // Delete the root go and update so deferred deletes will be executed.
         dmGameObject::Delete(m_Collection, go, true);
         ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
@@ -3094,6 +3282,11 @@ TEST_P(FactoryTest, IdHashTest)
     ASSERT_TRUE(dmGameObject::PostUpdate(m_Collection));
     dmGameObject::PostUpdate(m_Register);
 
+    dmGameObject::Delete(m_Collection, go, true);
+    ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+    ASSERT_TRUE(dmGameObject::PostUpdate(m_Collection));
+    dmGameObject::PostUpdate(m_Register);
+
     dmGameSystem::FinalizeScriptLibs(scriptlibcontext);
 }
 
@@ -3119,6 +3312,11 @@ TEST_P(FactoryTest, Create)
     dmGameObject::HInstance go = Spawn(m_Factory, m_Collection, "/factory/factory_create_test.goc", go_hash, 0, Point3(0, 0, 0), Quat(0, 0, 0, 1), Vector3(1, 1, 1));
     ASSERT_NE((void*)0, go);
 
+    ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+    ASSERT_TRUE(dmGameObject::PostUpdate(m_Collection));
+    dmGameObject::PostUpdate(m_Register);
+
+    dmGameObject::Delete(m_Collection, go, true);
     ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
     ASSERT_TRUE(dmGameObject::PostUpdate(m_Collection));
     dmGameObject::PostUpdate(m_Register);
@@ -5230,10 +5428,18 @@ INSTANTIATE_TEST_CASE_P(ResourceProperty, ResourcePropTest, jc_test_values_in(re
 
 FactoryTestParams factory_testparams [] =
 {
-    {"/factory/dynamic_factory_test.goc", true, true},
-    {"/factory/dynamic_factory_test.goc", true, false},
-    {"/factory/factory_test.goc", false, true},
-    {"/factory/factory_test.goc", false, false},
+    {"/factory/dynamic_factory_test.goc", 0, true, true},
+    {"/factory/dynamic_factory_test.goc", 0, true, false},
+    {"/factory/factory_test.goc", 0, false, true},
+    {"/factory/factory_test.goc", 0, false, false},
+    {"/factory/dynamic_factory_test.goc", "/factory/empty.goc", true, true},
+    {"/factory/dynamic_factory_test.goc", "/factory/empty.goc", true, false},
+    {"/factory/factory_test.goc", "/factory/empty.goc", false, true},
+    {"/factory/factory_test.goc", "/factory/empty.goc", false, false},
+    {"/factory/dynamic_factory_test.goc", "/factory/dynamic_prototype_sprite.goc", true, true},
+    {"/factory/dynamic_factory_test.goc", "/factory/dynamic_prototype_sprite.goc", true, false},
+    {"/factory/factory_test.goc", "/factory/dynamic_prototype_sprite.goc", false, true},
+    {"/factory/factory_test.goc", "/factory/dynamic_prototype_sprite.goc", false, false},
 };
 INSTANTIATE_TEST_CASE_P(Factory, FactoryTest, jc_test_values_in(factory_testparams));
 

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -56,6 +56,7 @@
 #include <gamesys/label_ddf.h>
 #include <gamesys/sprite_ddf.h>
 #include "../components/comp_label.h"
+#include "../components/comp_collection_proxy.h"
 #include "../scripts/script_sys_gamesys.h"
 #include "../scripts/script_resource.h"
 
@@ -73,6 +74,16 @@
 #include <jc_test/jc_test.h>
 
 using namespace dmVMath;
+
+namespace dmGameObject
+{
+    HCollection GetCollectionByHash(HRegister regist, dmhash_t socket_name);
+}
+
+namespace dmGameSystem
+{
+    dmGameObject::Result CompCollectionProxyUnloadAsync(HCollectionProxyWorld world, HCollectionProxyComponent proxy, ProxyLoadCallback cbk, void* cbk_ctx);
+}
 
 #if !defined(DM_TEST_EXTERN_INIT_FUNCTIONS)
     bool GameSystemTest_PlatformInit()
@@ -230,6 +241,52 @@ static void DeleteInstance(dmGameObject::HCollection collection, dmGameObject::H
     dmGameObject::Update(collection, &ctx);
     dmGameObject::Delete(collection, instance, false);
     dmGameObject::PostUpdate(collection);
+}
+
+struct CollectionProxyComponentRef
+{
+    dmGameSystem::HCollectionProxyWorld m_World;
+    dmGameSystem::HCollectionProxyComponent m_Component;
+};
+
+static CollectionProxyComponentRef GetCollectionProxyComponentRef(dmGameObject::HInstance instance, dmhash_t component_id)
+{
+    uint32_t component_type = 0;
+    dmGameObject::HComponent component = 0;
+    dmGameObject::HComponentWorld world = 0;
+    EXPECT_EQ(dmGameObject::RESULT_OK, dmGameObject::GetComponent(instance, component_id, &component_type, &component, &world));
+    EXPECT_NE((void*)0, component);
+    EXPECT_NE((void*)0, world);
+
+    CollectionProxyComponentRef proxy_ref;
+    proxy_ref.m_World = (dmGameSystem::HCollectionProxyWorld) world;
+    proxy_ref.m_Component = (dmGameSystem::HCollectionProxyComponent) component;
+    return proxy_ref;
+}
+
+static dmGameObject::HCollection GetCollectionByName(dmGameObject::HRegister regist, const char* name)
+{
+    dmGameObject::HCollection collection = dmGameObject::GetCollectionByHash(regist, dmHashString64(name));
+    EXPECT_NE((void*)0, collection);
+    return collection;
+}
+
+static void ConfigureCollectionProxy(CollectionProxyComponentRef proxy, const char* collection_path, dmGameObject::Result expected_load_result = dmGameObject::RESULT_OK)
+{
+    ASSERT_EQ(dmGameSystem::SET_COLLECTION_PATH_RESULT_OK, dmGameSystem::CollectionProxySetCollectionPath(proxy.m_World, proxy.m_Component, collection_path));
+    ASSERT_EQ(expected_load_result, dmGameSystem::CompCollectionProxyLoad(proxy.m_World, proxy.m_Component, 0, 0));
+    if (expected_load_result != dmGameObject::RESULT_OK)
+        return;
+
+    ASSERT_EQ(dmGameObject::RESULT_OK, dmGameSystem::CompCollectionProxyInitialize(proxy.m_World, proxy.m_Component));
+    ASSERT_EQ(dmGameObject::RESULT_OK, dmGameSystem::CompCollectionProxyEnable(proxy.m_World, proxy.m_Component));
+}
+
+static void UpdateAndPostUpdateCollection(dmGameObject::HCollection collection, dmGameObject::UpdateContext* update_context, dmGameObject::HRegister regist)
+{
+    ASSERT_TRUE(dmGameObject::Update(collection, update_context));
+    ASSERT_TRUE(dmGameObject::PostUpdate(collection));
+    dmGameObject::PostUpdate(regist);
 }
 
 TEST_P(ResourceTest, Test)
@@ -1163,6 +1220,118 @@ TEST_F(ComponentTest, ConsumeInputInCollectionProxy)
     ASSERT_INPUT_OBJECT_EQUALS(hash_go_consume_proxy)
 
     #undef ASSERT_INPUT_OBJECT_EQUALS
+}
+
+TEST_F(ComponentTest, CollectionProxySetCollectionLoadInitialize)
+{
+    lua_State* L = dmScript::GetLuaState(m_ScriptContext);
+    const char* go_path = "/collection_proxy/set_collection_single_root.goc";
+    dmhash_t go_hash = dmHashString64("/go");
+
+    dmGameObject::HInstance go = Spawn(m_Factory, m_Collection, go_path, go_hash, 0, Point3(0, 0, 0), Quat(0, 0, 0, 1), Vector3(1, 1, 1));
+    ASSERT_NE((void*)0, go);
+
+    for (;;)
+    {
+        lua_getglobal(L, "cp_single_target_initialized");
+        bool ready = lua_toboolean(L, -1) != 0;
+        lua_pop(L, 1);
+        if (ready)
+            break;
+
+        ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+        ASSERT_TRUE(dmGameObject::PostUpdate(m_Collection));
+        dmGameObject::PostUpdate(m_Register);
+    }
+
+    ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+    ASSERT_TRUE(dmGameObject::PostUpdate(m_Collection));
+    dmGameObject::PostUpdate(m_Register);
+
+    lua_getglobal(L, "cp_single_root_set_ok");
+    ASSERT_TRUE(lua_toboolean(L, -1) != 0);
+    lua_pop(L, 1);
+
+    lua_getglobal(L, "cp_single_root_proxy_loaded");
+    ASSERT_TRUE(lua_toboolean(L, -1) != 0);
+    lua_pop(L, 1);
+
+    lua_getglobal(L, "cp_single_target_update_count");
+    ASSERT_GE((int)lua_tointeger(L, -1), 1);
+    lua_pop(L, 1);
+
+    dmGameObject::Delete(m_Collection, go, true);
+    ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+    ASSERT_TRUE(dmGameObject::PostUpdate(m_Collection));
+    dmGameObject::PostUpdate(m_Register);
+
+    lua_getglobal(L, "cp_single_root_finalized");
+    ASSERT_TRUE(lua_toboolean(L, -1) != 0);
+    lua_pop(L, 1);
+
+    lua_getglobal(L, "cp_single_target_finalized");
+    ASSERT_TRUE(lua_toboolean(L, -1) != 0);
+    lua_pop(L, 1);
+}
+
+TEST_F(ComponentTest, CollectionProxySetCollectionRecursiveLoadInitialize)
+{
+    const char* go_path = "/collection_proxy/set_collection_cpp_cycle_proxy.goc";
+    dmhash_t go_hash = dmHashString64("/go");
+    dmhash_t proxy_component_hash = dmHashString64("collectionproxy");
+
+    dmGameObject::HInstance go = Spawn(m_Factory, m_Collection, go_path, go_hash, 0, Point3(0, 0, 0), Quat(0, 0, 0, 1), Vector3(1, 1, 1));
+    ASSERT_NE((void*)0, go);
+
+    dmLogInfo("collectionproxy cpp cycle root spawned");
+    UpdateAndPostUpdateCollection(m_Collection, &m_UpdateContext, m_Register);
+
+    CollectionProxyComponentRef root_proxy = GetCollectionProxyComponentRef(go, proxy_component_hash);
+    dmLogInfo("collectionproxy cpp cycle root set_collection /collection_proxy/set_collection_cpp_cycle_level1.collectionc");
+    ConfigureCollectionProxy(root_proxy, "/collection_proxy/set_collection_cpp_cycle_level1.collectionc");
+    UpdateAndPostUpdateCollection(m_Collection, &m_UpdateContext, m_Register);
+
+    dmGameObject::HCollection level1_collection = GetCollectionByName(m_Register, "set_collection_cpp_cycle_level1");
+    dmLogInfo("collectionproxy cpp cycle level1 loaded and initialized");
+    dmGameObject::HInstance level1_go = dmGameObject::GetInstanceFromIdentifier(level1_collection, dmHashString64("/go"));
+    ASSERT_NE((void*)0, level1_go);
+    CollectionProxyComponentRef level1_proxy = GetCollectionProxyComponentRef(level1_go, proxy_component_hash);
+    dmLogInfo("collectionproxy cpp cycle level1 set_collection /collection_proxy/set_collection_cpp_cycle_level2.collectionc");
+    ConfigureCollectionProxy(level1_proxy, "/collection_proxy/set_collection_cpp_cycle_level2.collectionc");
+    UpdateAndPostUpdateCollection(level1_collection, &m_UpdateContext, m_Register);
+
+    dmGameObject::HCollection level2_collection = GetCollectionByName(m_Register, "set_collection_cpp_cycle_level2");
+    dmLogInfo("collectionproxy cpp cycle level2 loaded and initialized");
+    dmGameObject::HInstance level2_go = dmGameObject::GetInstanceFromIdentifier(level2_collection, dmHashString64("/go"));
+    ASSERT_NE((void*)0, level2_go);
+    CollectionProxyComponentRef level2_proxy = GetCollectionProxyComponentRef(level2_go, proxy_component_hash);
+    dmLogInfo("collectionproxy cpp cycle level2 set_collection /collection_proxy/set_collection_cpp_cycle_level3.collectionc");
+    ConfigureCollectionProxy(level2_proxy, "/collection_proxy/set_collection_cpp_cycle_level3.collectionc");
+    UpdateAndPostUpdateCollection(level2_collection, &m_UpdateContext, m_Register);
+
+    dmGameObject::HCollection level3_collection = GetCollectionByName(m_Register, "set_collection_cpp_cycle_level3");
+    dmLogInfo("collectionproxy cpp cycle level3 loaded and initialized");
+    dmGameObject::HInstance level3_go = dmGameObject::GetInstanceFromIdentifier(level3_collection, dmHashString64("/go"));
+    ASSERT_NE((void*)0, level3_go);
+    CollectionProxyComponentRef level3_proxy = GetCollectionProxyComponentRef(level3_go, proxy_component_hash);
+
+    // Establish the back-edge in C++ without loading it.
+    // Loading/enabling this final edge is what drives the recursion scenario.
+    dmLogInfo("collectionproxy cpp cycle level3 set_collection /collection_proxy/set_collection_cpp_cycle_level1.collectionc");
+    // Try to create a cyclic graph
+    ConfigureCollectionProxy(level3_proxy, "/collection_proxy/set_collection_cpp_cycle_level1.collectionc", dmGameObject::RESULT_ALREADY_REGISTERED);
+
+    ASSERT_NE((void*)0, GetCollectionByName(m_Register, "set_collection_cpp_cycle_level1"));
+    ASSERT_NE((void*)0, GetCollectionByName(m_Register, "set_collection_cpp_cycle_level2"));
+    ASSERT_NE((void*)0, GetCollectionByName(m_Register, "set_collection_cpp_cycle_level3"));
+
+    ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+    ASSERT_TRUE(dmGameObject::PostUpdate(m_Collection));
+
+    dmGameObject::Delete(m_Collection, go, true);
+    ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+    ASSERT_TRUE(dmGameObject::PostUpdate(m_Collection));
+    dmGameObject::PostUpdate(m_Register);
 }
 
 TEST_P(ComponentFailTest, Test)
@@ -3324,6 +3493,174 @@ TEST_P(FactoryTest, Create)
     dmGameSystem::FinalizeScriptLibs(scriptlibcontext);
 }
 
+TEST_P(FactoryRecursivePrototypeTest, RecursivePrototype)
+{
+    lua_State* L = dmScript::GetLuaState(m_ScriptContext);
+
+    dmGameSystem::ScriptLibContext scriptlibcontext;
+    scriptlibcontext.m_Factory         = m_Factory;
+    scriptlibcontext.m_Register        = m_Register;
+    scriptlibcontext.m_LuaState        = L;
+    scriptlibcontext.m_GraphicsContext = m_GraphicsContext;
+    scriptlibcontext.m_ScriptContext   = m_ScriptContext;
+
+    dmGameSystem::InitializeScriptLibs(scriptlibcontext);
+    const FactoryTestParams& param = GetParam();
+
+    char buffer[256];
+    dmSnPrintf(buffer, sizeof(buffer), "recursive_prototype_path = '%s'", param.m_GOPath);
+    RunString(L, buffer);
+
+    dmResource::HPreloader go_pr = 0;
+    if(param.m_IsPreloaded)
+    {
+        go_pr = dmResource::NewPreloader(m_Factory, param.m_GOPath);
+        dmResource::Result r;
+        uint64_t stop_time = dmTime::GetMonotonicTime() + 30*10e6;
+        while (dmTime::GetMonotonicTime() < stop_time)
+        {
+            r = dmResource::UpdatePreloader(go_pr, 0, 0, 16*1000);
+            if (r != dmResource::RESULT_PENDING)
+                break;
+            dmTime::Sleep(16*1000);
+        }
+        ASSERT_EQ(dmResource::RESULT_OK, r);
+    }
+
+    ASSERT_TRUE(dmGameObject::Init(m_Collection));
+    dmhash_t go_hash = dmHashString64("/go");
+    dmGameObject::HInstance go = Spawn(m_Factory, m_Collection, param.m_GOPath, go_hash, 0, Point3(0, 0, 0), Quat(0, 0, 0, 1), Vector3(1, 1, 1));
+    ASSERT_NE((void*)0, go);
+    go = dmGameObject::GetInstanceFromIdentifier(m_Collection, go_hash);
+    ASSERT_NE((void*)0, go);
+
+    if(go_pr)
+    {
+        dmResource::DeletePreloader(go_pr);
+    }
+
+    dmhash_t recursive_instance = 0;
+    for(;;)
+    {
+        lua_getglobal(L, "global_recursive_created");
+        bool ready = !lua_isnil(L, -1);
+        lua_pop(L, 1);
+        if(ready)
+        {
+            lua_getglobal(L, "recursive_instance");
+            recursive_instance = dmScript::CheckHash(L, -1);
+            lua_pop(L, 1);
+            if (dmGameObject::GetInstanceFromIdentifier(m_Collection, recursive_instance) != 0x0)
+                break;
+        }
+        ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+        ASSERT_TRUE(dmGameObject::PostUpdate(m_Collection));
+        dmGameObject::PostUpdate(m_Register);
+    }
+
+    ASSERT_NE((dmhash_t)0, recursive_instance);
+
+    ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+    ASSERT_TRUE(dmGameObject::PostUpdate(m_Collection));
+    dmGameObject::PostUpdate(m_Register);
+
+    ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+    ASSERT_TRUE(dmGameObject::PostUpdate(m_Collection));
+    dmGameObject::PostUpdate(m_Register);
+
+    ASSERT_EQ((dmGameObject::HInstance)0x0, dmGameObject::GetInstanceFromIdentifier(m_Collection, recursive_instance));
+
+    dmGameObject::Delete(m_Collection, go, true);
+    ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+    ASSERT_TRUE(dmGameObject::PostUpdate(m_Collection));
+    dmGameObject::PostUpdate(m_Register);
+
+    dmGameSystem::FinalizeScriptLibs(scriptlibcontext);
+}
+
+TEST_P(FactoryRecursivePrototypeTest, RecursivePrototypeCppCleanup)
+{
+    lua_State* L = dmScript::GetLuaState(m_ScriptContext);
+
+    dmGameSystem::ScriptLibContext scriptlibcontext;
+    scriptlibcontext.m_Factory         = m_Factory;
+    scriptlibcontext.m_Register        = m_Register;
+    scriptlibcontext.m_LuaState        = L;
+    scriptlibcontext.m_GraphicsContext = m_GraphicsContext;
+    scriptlibcontext.m_ScriptContext   = m_ScriptContext;
+
+    dmGameSystem::InitializeScriptLibs(scriptlibcontext);
+    const FactoryTestParams& param = GetParam();
+
+    char buffer[256];
+    dmSnPrintf(buffer, sizeof(buffer), "recursive_prototype_path = '%s'", param.m_GOPath);
+    RunString(L, buffer);
+    RunString(L, "recursive_cleanup_in_script = false");
+
+    dmResource::HPreloader go_pr = 0;
+    if(param.m_IsPreloaded)
+    {
+        go_pr = dmResource::NewPreloader(m_Factory, param.m_GOPath);
+        dmResource::Result r;
+        uint64_t stop_time = dmTime::GetMonotonicTime() + 30*10e6;
+        while (dmTime::GetMonotonicTime() < stop_time)
+        {
+            r = dmResource::UpdatePreloader(go_pr, 0, 0, 16*1000);
+            if (r != dmResource::RESULT_PENDING)
+                break;
+            dmTime::Sleep(16*1000);
+        }
+        ASSERT_EQ(dmResource::RESULT_OK, r);
+    }
+
+    ASSERT_TRUE(dmGameObject::Init(m_Collection));
+    dmhash_t go_hash = dmHashString64("/go");
+    dmGameObject::HInstance go = Spawn(m_Factory, m_Collection, param.m_GOPath, go_hash, 0, Point3(0, 0, 0), Quat(0, 0, 0, 1), Vector3(1, 1, 1));
+    ASSERT_NE((void*)0, go);
+    go = dmGameObject::GetInstanceFromIdentifier(m_Collection, go_hash);
+    ASSERT_NE((void*)0, go);
+
+    if(go_pr)
+    {
+        dmResource::DeletePreloader(go_pr);
+    }
+
+    dmhash_t recursive_instance = 0;
+    for(;;)
+    {
+        lua_getglobal(L, "global_recursive_created");
+        bool ready = !lua_isnil(L, -1);
+        lua_pop(L, 1);
+        if(ready)
+        {
+            lua_getglobal(L, "recursive_instance");
+            recursive_instance = dmScript::CheckHash(L, -1);
+            lua_pop(L, 1);
+            if (dmGameObject::GetInstanceFromIdentifier(m_Collection, recursive_instance) != 0x0)
+                break;
+        }
+        ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+        ASSERT_TRUE(dmGameObject::PostUpdate(m_Collection));
+        dmGameObject::PostUpdate(m_Register);
+    }
+
+    ASSERT_NE((dmhash_t)0, recursive_instance);
+
+    ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+    ASSERT_TRUE(dmGameObject::PostUpdate(m_Collection));
+    dmGameObject::PostUpdate(m_Register);
+
+    dmGameObject::Delete(m_Collection, go, true);
+    ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+    ASSERT_TRUE(dmGameObject::PostUpdate(m_Collection));
+    dmGameObject::PostUpdate(m_Register);
+
+    ASSERT_EQ((dmGameObject::HInstance)0x0, dmGameObject::GetInstanceFromIdentifier(m_Collection, go_hash));
+    ASSERT_NE((dmGameObject::HInstance)0x0, dmGameObject::GetInstanceFromIdentifier(m_Collection, recursive_instance));
+
+    dmGameSystem::FinalizeScriptLibs(scriptlibcontext);
+}
+
 /* Collection factory dynamic and static loading */
 
 TEST_P(CollectionFactoryTest, Test)
@@ -3638,6 +3975,180 @@ TEST_P(CollectionFactoryTest, Test)
             ASSERT_EQ(0, dmResource::GetRefCount(m_Factory, dmHashString64(resource_path[i])));
         }
     }
+
+    dmGameSystem::FinalizeScriptLibs(scriptlibcontext);
+}
+
+TEST_P(CollectionFactoryRecursivePrototypeTest, RecursivePrototype)
+{
+    lua_State* L = dmScript::GetLuaState(m_ScriptContext);
+
+    dmGameSystem::ScriptLibContext scriptlibcontext;
+    scriptlibcontext.m_Factory         = m_Factory;
+    scriptlibcontext.m_Register        = m_Register;
+    scriptlibcontext.m_LuaState        = L;
+    scriptlibcontext.m_GraphicsContext = m_GraphicsContext;
+    scriptlibcontext.m_ScriptContext   = m_ScriptContext;
+
+    dmGameSystem::InitializeScriptLibs(scriptlibcontext);
+    const CollectionFactoryTestParams& param = GetParam();
+    const char* recursive_prototype_path = param.m_IsDynamic
+        ? "/collection_factory/recursive_dynamic_collectionfactory_test.collectionc"
+        : "/collection_factory/recursive_collectionfactory_test.collectionc";
+
+    char buffer[256];
+    dmSnPrintf(buffer, sizeof(buffer), "recursive_prototype_path = '%s'", recursive_prototype_path);
+    RunString(L, buffer);
+
+    dmResource::HPreloader go_pr = 0;
+    if(param.m_IsPreloaded)
+    {
+        go_pr = dmResource::NewPreloader(m_Factory, param.m_GOPath);
+        dmResource::Result r;
+        uint64_t stop_time = dmTime::GetMonotonicTime() + 30*10e6;
+        while (dmTime::GetMonotonicTime() < stop_time)
+        {
+            r = dmResource::UpdatePreloader(go_pr, 0, 0, 16*1000);
+            if (r != dmResource::RESULT_PENDING)
+                break;
+            dmTime::Sleep(16*1000);
+        }
+        ASSERT_EQ(dmResource::RESULT_OK, r);
+    }
+
+    ASSERT_TRUE(dmGameObject::Init(m_Collection));
+    dmhash_t go_hash = dmHashString64("/go");
+    dmGameObject::HInstance go = Spawn(m_Factory, m_Collection, param.m_GOPath, go_hash, 0, Point3(0, 0, 0), Quat(0, 0, 0, 1), Vector3(1, 1, 1));
+    ASSERT_NE((void*)0, go);
+    go = dmGameObject::GetInstanceFromIdentifier(m_Collection, go_hash);
+    ASSERT_NE((void*)0, go);
+
+    if(go_pr)
+    {
+        dmResource::DeletePreloader(go_pr);
+    }
+
+    dmhash_t recursive_instance = 0;
+    for(;;)
+    {
+        lua_getglobal(L, "global_recursive_created");
+        bool ready = !lua_isnil(L, -1);
+        lua_pop(L, 1);
+        if(ready)
+        {
+            lua_getglobal(L, "recursive_instance");
+            recursive_instance = dmScript::CheckHash(L, -1);
+            lua_pop(L, 1);
+            if (dmGameObject::GetInstanceFromIdentifier(m_Collection, recursive_instance) != 0x0)
+                break;
+        }
+        ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+        ASSERT_TRUE(dmGameObject::PostUpdate(m_Collection));
+        dmGameObject::PostUpdate(m_Register);
+    }
+
+    ASSERT_NE((dmhash_t)0, recursive_instance);
+
+    ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+    ASSERT_TRUE(dmGameObject::PostUpdate(m_Collection));
+    dmGameObject::PostUpdate(m_Register);
+
+    ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+    ASSERT_TRUE(dmGameObject::PostUpdate(m_Collection));
+    dmGameObject::PostUpdate(m_Register);
+
+    ASSERT_EQ((dmGameObject::HInstance)0x0, dmGameObject::GetInstanceFromIdentifier(m_Collection, recursive_instance));
+
+    dmGameObject::Delete(m_Collection, go, true);
+    ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+    ASSERT_TRUE(dmGameObject::PostUpdate(m_Collection));
+    dmGameObject::PostUpdate(m_Register);
+
+    dmGameSystem::FinalizeScriptLibs(scriptlibcontext);
+}
+
+TEST_P(CollectionFactoryRecursivePrototypeTest, RecursivePrototypeCppCleanup)
+{
+    lua_State* L = dmScript::GetLuaState(m_ScriptContext);
+
+    dmGameSystem::ScriptLibContext scriptlibcontext;
+    scriptlibcontext.m_Factory         = m_Factory;
+    scriptlibcontext.m_Register        = m_Register;
+    scriptlibcontext.m_LuaState        = L;
+    scriptlibcontext.m_GraphicsContext = m_GraphicsContext;
+    scriptlibcontext.m_ScriptContext   = m_ScriptContext;
+
+    dmGameSystem::InitializeScriptLibs(scriptlibcontext);
+    const CollectionFactoryTestParams& param = GetParam();
+    const char* recursive_prototype_path = param.m_IsDynamic
+        ? "/collection_factory/recursive_dynamic_collectionfactory_test.collectionc"
+        : "/collection_factory/recursive_collectionfactory_test.collectionc";
+
+    char buffer[256];
+    dmSnPrintf(buffer, sizeof(buffer), "recursive_prototype_path = '%s'", recursive_prototype_path);
+    RunString(L, buffer);
+    RunString(L, "recursive_cleanup_in_script = false");
+
+    dmResource::HPreloader go_pr = 0;
+    if(param.m_IsPreloaded)
+    {
+        go_pr = dmResource::NewPreloader(m_Factory, param.m_GOPath);
+        dmResource::Result r;
+        uint64_t stop_time = dmTime::GetMonotonicTime() + 30*10e6;
+        while (dmTime::GetMonotonicTime() < stop_time)
+        {
+            r = dmResource::UpdatePreloader(go_pr, 0, 0, 16*1000);
+            if (r != dmResource::RESULT_PENDING)
+                break;
+            dmTime::Sleep(16*1000);
+        }
+        ASSERT_EQ(dmResource::RESULT_OK, r);
+    }
+
+    ASSERT_TRUE(dmGameObject::Init(m_Collection));
+    dmhash_t go_hash = dmHashString64("/go");
+    dmGameObject::HInstance go = Spawn(m_Factory, m_Collection, param.m_GOPath, go_hash, 0, Point3(0, 0, 0), Quat(0, 0, 0, 1), Vector3(1, 1, 1));
+    ASSERT_NE((void*)0, go);
+    go = dmGameObject::GetInstanceFromIdentifier(m_Collection, go_hash);
+    ASSERT_NE((void*)0, go);
+
+    if(go_pr)
+    {
+        dmResource::DeletePreloader(go_pr);
+    }
+
+    dmhash_t recursive_instance = 0;
+    for(;;)
+    {
+        lua_getglobal(L, "global_recursive_created");
+        bool ready = !lua_isnil(L, -1);
+        lua_pop(L, 1);
+        if(ready)
+        {
+            lua_getglobal(L, "recursive_instance");
+            recursive_instance = dmScript::CheckHash(L, -1);
+            lua_pop(L, 1);
+            if (dmGameObject::GetInstanceFromIdentifier(m_Collection, recursive_instance) != 0x0)
+                break;
+        }
+        ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+        ASSERT_TRUE(dmGameObject::PostUpdate(m_Collection));
+        dmGameObject::PostUpdate(m_Register);
+    }
+
+    ASSERT_NE((dmhash_t)0, recursive_instance);
+
+    ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+    ASSERT_TRUE(dmGameObject::PostUpdate(m_Collection));
+    dmGameObject::PostUpdate(m_Register);
+
+    dmGameObject::Delete(m_Collection, go, true);
+    ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+    ASSERT_TRUE(dmGameObject::PostUpdate(m_Collection));
+    dmGameObject::PostUpdate(m_Register);
+
+    ASSERT_EQ((dmGameObject::HInstance)0x0, dmGameObject::GetInstanceFromIdentifier(m_Collection, go_hash));
+    ASSERT_NE((dmGameObject::HInstance)0x0, dmGameObject::GetInstanceFromIdentifier(m_Collection, recursive_instance));
 
     dmGameSystem::FinalizeScriptLibs(scriptlibcontext);
 }
@@ -5443,6 +5954,15 @@ FactoryTestParams factory_testparams [] =
 };
 INSTANTIATE_TEST_CASE_P(Factory, FactoryTest, jc_test_values_in(factory_testparams));
 
+FactoryTestParams factory_recursive_testparams [] =
+{
+    {"/factory/dynamic_factory_test.goc", 0, true, true},
+    {"/factory/dynamic_factory_test.goc", 0, true, false},
+    {"/factory/factory_test.goc", 0, false, true},
+    {"/factory/factory_test.goc", 0, false, false},
+};
+INSTANTIATE_TEST_CASE_P(FactoryRecursivePrototype, FactoryRecursivePrototypeTest, jc_test_values_in(factory_recursive_testparams));
+
 /* Validate default and dynamic collection factories */
 
 CollectionFactoryTestParams collection_factory_testparams [] =
@@ -5457,6 +5977,15 @@ CollectionFactoryTestParams collection_factory_testparams [] =
     {"/collection_factory/collectionfactory_test.goc", "/collection_factory/dynamic_prototype.collectionc", false, false},
 };
 INSTANTIATE_TEST_CASE_P(CollectionFactory, CollectionFactoryTest, jc_test_values_in(collection_factory_testparams));
+
+CollectionFactoryTestParams collection_factory_recursive_testparams [] =
+{
+    {"/collection_factory/dynamic_collectionfactory_test.goc", 0, true, true},
+    {"/collection_factory/dynamic_collectionfactory_test.goc", 0, true, false},
+    {"/collection_factory/collectionfactory_test.goc", 0, false, true},
+    {"/collection_factory/collectionfactory_test.goc", 0, false, false},
+};
+INSTANTIATE_TEST_CASE_P(CollectionFactoryRecursivePrototype, CollectionFactoryRecursivePrototypeTest, jc_test_values_in(collection_factory_recursive_testparams));
 
 /* Validate draw count for different GOs */
 

--- a/engine/gamesys/src/gamesys/test/test_gamesys.h
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.h
@@ -302,6 +302,12 @@ public:
     ~FactoryTest() override = default;
 };
 
+class FactoryRecursivePrototypeTest : public GamesysTest<FactoryTestParams>
+{
+public:
+    ~FactoryRecursivePrototypeTest() override = default;
+};
+
 struct CollectionFactoryTestParams
 {
     const char* m_GOPath;
@@ -314,6 +320,12 @@ class CollectionFactoryTest : public GamesysTest<CollectionFactoryTestParams>
 {
 public:
     ~CollectionFactoryTest() override = default;
+};
+
+class CollectionFactoryRecursivePrototypeTest : public GamesysTest<CollectionFactoryTestParams>
+{
+public:
+    ~CollectionFactoryRecursivePrototypeTest() override = default;
 };
 
 class SpriteTest : public ScriptBaseTest
@@ -706,37 +718,40 @@ void GamesysTest<T>::SetUp()
 template<typename T>
 void GamesysTest<T>::TearDown()
 {
-    dmGameObject::DeleteCollection(m_Collection);
     dmGameObject::PostUpdate(m_Register);
+    dmGameObject::DeleteCollections(m_Register);
+    m_Collection = 0;
+
     dmResource::Release(m_Factory, m_GamepadMapsDDF);
+
+    dmResource::DeregisterTypes(m_Factory, &m_Contexts);
 
     dmGameObject::ComponentTypeCreateCtx component_create_ctx;
     SetupComponentCreateContext(component_create_ctx);
     dmGameObject::DestroyRegisteredComponentTypes(&component_create_ctx);
 
-    dmResource::DeregisterTypes(m_Factory, &m_Contexts);
+    dmGameObject::DeleteRegister(m_Register);
+
+    dmSound::Finalize();
+    dmInput::DeleteContext(m_InputContext);
+    dmRender::DeleteRenderContext(m_RenderContext, m_ScriptContext);
+    dmHID::Final(m_HidContext);
+    dmHID::DeleteContext(m_HidContext);
+    dmGui::DeleteContext(m_GuiContext, m_ScriptContext);
 
     dmExtension::Finalize(&m_Params);
-    dmExtension::AppFinalize(&m_AppParams);
 
     ExtensionParamsFinalize(&m_Params);
-    ExtensionAppParamsFinalize(&m_AppParams);
 
-    dmGui::DeleteContext(m_GuiContext, m_ScriptContext);
-    dmRender::DeleteRenderContext(m_RenderContext, m_ScriptContext);
+    dmScript::Finalize(m_ScriptContext);
+    dmScript::DeleteContext(m_ScriptContext);
+    dmResource::DeleteFactory(m_Factory);
+
     JobSystemDestroy(m_JobContext);
     dmGraphics::CloseWindow(m_GraphicsContext);
     dmGraphics::DeleteContext(m_GraphicsContext);
     dmPlatform::CloseWindow(m_Window);
     dmPlatform::DeleteWindow(m_Window);
-    dmScript::Finalize(m_ScriptContext);
-    dmScript::DeleteContext(m_ScriptContext);
-    dmResource::DeleteFactory(m_Factory);
-    dmGameObject::DeleteRegister(m_Register);
-    dmSound::Finalize();
-    dmInput::DeleteContext(m_InputContext);
-    dmHID::Final(m_HidContext);
-    dmHID::DeleteContext(m_HidContext);
 
     if (m_PhysicsContextBullet3D.m_Context)
     {
@@ -747,6 +762,10 @@ void GamesysTest<T>::TearDown()
     {
         dmPhysics::DeleteContext2D(m_PhysicsContextBox2D.m_Context);
     }
+
+    dmExtension::AppFinalize(&m_AppParams);
+    ExtensionAppParamsFinalize(&m_AppParams);
+
     dmBuffer::DeleteContext();
     dmConfigFile::Delete(m_Config);
 }

--- a/engine/gamesys/src/gamesys/test/test_gamesys.h
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.h
@@ -291,6 +291,7 @@ public:
 struct FactoryTestParams
 {
     const char* m_GOPath;
+    const char* m_PrototypePath; // If set, then it uses "Dynamic Prototype"
     bool m_IsDynamic;
     bool m_IsPreloaded;
 };


### PR DESCRIPTION
This fixes an issue when trying to use collectionproxy.set_collection() to load a collection that is already loaded.
It will now fail with an error, whereas previously it would accidentally create a cyclic chain of dependencies.

### Technical changes

Added unit test for
* `factory.set_prototype()`
* `collectionfactory.set_prototype()`
* `collectionproxy.set_collection()`

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
