### PR TITLE
Ensure the Editor loads only bundled libraries, ignoring those installed on the system

### DIFF
--- a/editor/src/java/com/defold/editor/Start.java
+++ b/editor/src/java/com/defold/editor/Start.java
@@ -89,7 +89,7 @@ public class Start extends Application {
                 }
             } catch (Throwable t) {
                 t.printStackTrace();
-                logger.error("failed to extract native libs", t);
+                logger.error("failed to initialize bundled native libraries", t);
             }
         });
         kickThread.start();

--- a/editor/src/java/com/defold/libs/MouseCapture.java
+++ b/editor/src/java/com/defold/libs/MouseCapture.java
@@ -33,8 +33,8 @@ public class MouseCapture {
         try {
             ResourceUnpacker.unpackResources();
             Native.register(MouseCapture.class, NativeLibrary.getInstance(ResourceUnpacker.getPreloadedLibraryPath("mouse_capture_shared").toString()));
-        } catch (Throwable t) {
-            logger.error("Failed to register bundled mouse_capture_shared", t);
+        } catch (Exception e) {
+            logger.error("Failed to register bundled mouse_capture_shared", e);
         }
     }
 

--- a/editor/src/java/com/defold/libs/MouseCapture.java
+++ b/editor/src/java/com/defold/libs/MouseCapture.java
@@ -16,6 +16,7 @@ package com.defold.libs;
 
 import com.sun.jna.Callback;
 import com.sun.jna.Native;
+import com.sun.jna.NativeLibrary;
 import com.sun.jna.Pointer;
 import com.sun.jna.Structure;
 
@@ -31,9 +32,9 @@ public class MouseCapture {
     static {
         try {
             ResourceUnpacker.unpackResources();
-            Native.register("mouse_capture_shared");
-        } catch (Exception e) {
-            logger.error("Failed to extract/register mousecapture so/dll", e);
+            Native.register(MouseCapture.class, NativeLibrary.getInstance(ResourceUnpacker.getPreloadedLibraryPath("mouse_capture_shared").toString()));
+        } catch (Throwable t) {
+            logger.error("Failed to register bundled mouse_capture_shared", t);
         }
     }
 

--- a/editor/src/java/com/defold/libs/ParticleLibrary.java
+++ b/editor/src/java/com/defold/libs/ParticleLibrary.java
@@ -29,6 +29,7 @@ import org.slf4j.LoggerFactory;
 
 import com.sun.jna.Callback;
 import com.sun.jna.Native;
+import com.sun.jna.NativeLibrary;
 import com.sun.jna.Pointer;
 import com.sun.jna.Structure;
 import com.sun.jna.ptr.FloatByReference;
@@ -40,9 +41,9 @@ public class ParticleLibrary {
     static {
         try {
             ResourceUnpacker.unpackResources();
-            Native.register("particle_shared");
-        } catch (Exception e) {
-            logger.error("Failed to extract/register particle_shared", e);
+            Native.register(ParticleLibrary.class, NativeLibrary.getInstance(ResourceUnpacker.getPreloadedLibraryPath("particle_shared").toString()));
+        } catch (Throwable t) {
+            logger.error("Failed to register bundled particle_shared", t);
         }
     }
 

--- a/editor/src/java/com/defold/libs/ParticleLibrary.java
+++ b/editor/src/java/com/defold/libs/ParticleLibrary.java
@@ -42,8 +42,8 @@ public class ParticleLibrary {
         try {
             ResourceUnpacker.unpackResources();
             Native.register(ParticleLibrary.class, NativeLibrary.getInstance(ResourceUnpacker.getPreloadedLibraryPath("particle_shared").toString()));
-        } catch (Throwable t) {
-            logger.error("Failed to register bundled particle_shared", t);
+        } catch (Exception e) {
+            logger.error("Failed to register bundled particle_shared", e);
         }
     }
 

--- a/editor/src/java/com/defold/libs/ResourceUnpacker.java
+++ b/editor/src/java/com/defold/libs/ResourceUnpacker.java
@@ -160,19 +160,11 @@ public class ResourceUnpacker {
                         Files.writeString(unpackShaPath, sha1);
                     }
                 }
-                if (unpackPath.getParent().startsWith(Editor.getSupportPath())) {
-                    // Prevent from deletion by deleteOldUnpackDirs
-                    Executors.newSingleThreadScheduledExecutor().scheduleAtFixedRate(() -> {
-                        try {
-                            Files.setLastModifiedTime(unpackPath, FileTime.from(Instant.now()));
-                        } catch (IOException e) {
-                            logger.warn("Couldn't set lastModifiedTime for {}", unpackPath, e);
-                        }
-                    }, 0, 1, TimeUnit.DAYS);
-                }
 
                 Path unpackedLibDir = unpackPath.resolve(platform.getPair() + "/lib").toAbsolutePath();
                 System.setProperty("jna.nosys", "true");
+                // Exact-path preloading is authoritative, but JOGL still resolves some bundled
+                // natives by logical name, and JNA-by-name callers still expect these paths.
                 System.setProperty("java.library.path", unpackedLibDir.toString());
                 System.setProperty("jna.library.path", unpackedLibDir.toString());
 
@@ -186,6 +178,9 @@ public class ResourceUnpacker {
                 Map<String, Path> discoveredLibraries = discoverBundledNativeLibraries(unpackedLibDir, platform);
                 preloadedLibraryPaths = preloadNativeLibraries(discoveredLibraries, SYSTEM_NATIVE_LIBRARY_LOADER);
                 logger.info("preloaded {} bundled native libraries from {}", preloadedLibraryPaths.size(), unpackedLibDir);
+                if (unpackPath.getParent().startsWith(Editor.getSupportPath())) {
+                    startUnpackDirTouchScheduler(unpackPath);
+                }
                 isInitialized = true;
             } finally {
                 if (!isInitialized) {
@@ -345,6 +340,21 @@ public class ResourceUnpacker {
 
     private static Map<String, Path> immutableLinkedHashMap(Map<String, Path> libraries) {
         return Collections.unmodifiableMap(new LinkedHashMap<>(libraries));
+    }
+
+    private static void startUnpackDirTouchScheduler(Path unpackPath) {
+        try {
+            // Prevent deletion by deleteOldUnpackDirs once initialization has succeeded.
+            Executors.newSingleThreadScheduledExecutor().scheduleAtFixedRate(() -> {
+                try {
+                    Files.setLastModifiedTime(unpackPath, FileTime.from(Instant.now()));
+                } catch (IOException e) {
+                    logger.warn("Couldn't set lastModifiedTime for {}", unpackPath, e);
+                }
+            }, 0, 1, TimeUnit.DAYS);
+        } catch (RuntimeException e) {
+            logger.warn("Couldn't start unpack dir touch scheduler for {}", unpackPath, e);
+        }
     }
 
     private static void unpackResourceFile(String resourceFileName, Path target) throws IOException {

--- a/editor/src/java/com/defold/libs/ResourceUnpacker.java
+++ b/editor/src/java/com/defold/libs/ResourceUnpacker.java
@@ -14,39 +14,69 @@
 
 package com.defold.libs;
 
-import java.io.*;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.nio.file.*;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.FileTime;
 import java.time.Instant;
-import java.util.Date;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
+import java.util.Date;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.Future;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
 import com.defold.editor.Editor;
+import com.dynamo.bob.Platform;
 import com.dynamo.bob.util.FileUtil;
-
-import com.dynamo.graphics.proto.Graphics.PlatformProfile.OS;
+import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.apache.commons.io.FileUtils;
-
-import com.dynamo.bob.Platform;
 
 public class ResourceUnpacker {
+
+    @FunctionalInterface
+    public interface NativeLibraryLoader {
+        void load(Path libraryPath) throws Throwable;
+    }
+
+    private static final class NativeLibraryLoadFailure {
+        private final String logicalName;
+        private final Path libraryPath;
+        private final Throwable cause;
+
+        private NativeLibraryLoadFailure(String logicalName, Path libraryPath, Throwable cause) {
+            this.logicalName = logicalName;
+            this.libraryPath = libraryPath;
+            this.cause = cause;
+        }
+    }
 
     public static final String DEFOLD_UNPACK_PATH_KEY = "defold.unpack.path";
     public static final String DEFOLD_UNPACK_PATH_ENV_VAR = "DEFOLD_UNPACK_PATH";
     public static final String DEFOLD_EDITOR_SHA1_KEY = "defold.editor.sha1";
 
     private static volatile boolean isInitialized = false;
-    private static Object lock = new Object();
-    private static Logger logger = LoggerFactory.getLogger(ResourceUnpacker.class);
+    private static volatile Map<String, Path> preloadedLibraryPaths = Collections.emptyMap();
+    private static final Object lock = new Object();
+    private static final Logger logger = LoggerFactory.getLogger(ResourceUnpacker.class);
+    private static final NativeLibraryLoader SYSTEM_NATIVE_LIBRARY_LOADER = libraryPath -> System.load(libraryPath.toString());
 
     // unpack dirs should be automatically deleted using a shutdown hook but
     // the shutdown hook will not run if the editor doesn't shut down gracefully
@@ -64,19 +94,21 @@ public class ResourceUnpacker {
         logger.info("deleting old unpack dirs from {}", unpackRoot);
         final long now = new Date().getTime();
         final long oneWeekAgo = now - (7 * 24 * 60 * 60 * 1000);
-        Files.list(unpackRoot)
-                .filter(path -> Files.isDirectory(path) && !path.equals(unpackPath))
-                .forEach(unpackDir -> {
-                    try {
-                        long creationTime = Files.getLastModifiedTime(unpackDir).toMillis();
-                        if (creationTime < oneWeekAgo) {
-                            logger.info("deleting unpack dir {}", unpackDir);
-                            FileUtils.deleteQuietly(unpackDir.toFile());
+        try (Stream<Path> unpackDirs = Files.list(unpackRoot)) {
+            unpackDirs
+                    .filter(path -> Files.isDirectory(path) && !path.equals(unpackPath))
+                    .forEach(unpackDir -> {
+                        try {
+                            long creationTime = Files.getLastModifiedTime(unpackDir).toMillis();
+                            if (creationTime < oneWeekAgo) {
+                                logger.info("deleting unpack dir {}", unpackDir);
+                                FileUtils.deleteQuietly(unpackDir.toFile());
+                            }
+                        } catch (IOException e) {
+                            logger.warn("Couldn't get lastModifiedTime of {}", unpackDir, e);
                         }
-                    } catch (IOException e) {
-                        logger.warn("Couldn't get lastModifiedTime of {}", unpackDir, e);
-                    }
-                });
+                    });
+        }
     }
 
     public static void unpackResources() throws IOException, URISyntaxException {
@@ -93,15 +125,15 @@ public class ResourceUnpacker {
                 return;
             }
 
+            Path unpackPath = getUnpackPath();
+            Platform platform = Platform.getHostPlatform();
             try {
-                Path unpackPath  = getUnpackPath();
                 deleteOldUnpackDirs(unpackPath);
                 String sha1 = System.getProperty(DEFOLD_EDITOR_SHA1_KEY);
                 Path unpackShaPath = unpackPath.resolve("editor-sha.txt");
                 boolean alreadyUnpacked = sha1 != null
                         && Files.exists(unpackShaPath)
                         && sha1.equals(Files.readString(unpackShaPath));
-                Platform platform = Platform.getHostPlatform();
                 if (alreadyUnpacked) {
                     logger.info("Already unpacked for the editor version {}", sha1);
                 } else {
@@ -114,14 +146,15 @@ public class ResourceUnpacker {
                     if (platform.isWindows()) {
                         unpackResourceFile("libexec/" + platform.getPair() + "/dmengine.exe", unpackPath.resolve(platform.getPair()).resolve("bin"), true, true);
                         unpackResourceFile("libexec/" + platform.getPair() + "/luajit-64.exe", unpackPath.resolve(platform.getPair()).resolve("bin"), true, true);
-                    }
-                    else {
+                    } else {
                         unpackResourceFile("libexec/" + platform.getPair() + "/luajit-64", unpackPath.resolve(platform.getPair()).resolve("bin"), true, true);
                     }
 
                     Path binDir = unpackPath.resolve(platform.getPair() + "/bin").toAbsolutePath();
                     if (Files.exists(binDir)) {
-                        Files.walk(binDir).forEach(path -> path.toFile().setExecutable(true));
+                        try (Stream<Path> binPaths = Files.walk(binDir)) {
+                            binPaths.forEach(path -> path.toFile().setExecutable(true));
+                        }
                     }
                     if (sha1 != null) {
                         Files.writeString(unpackShaPath, sha1);
@@ -139,6 +172,7 @@ public class ResourceUnpacker {
                 }
 
                 Path unpackedLibDir = unpackPath.resolve(platform.getPair() + "/lib").toAbsolutePath();
+                System.setProperty("jna.nosys", "true");
                 System.setProperty("java.library.path", unpackedLibDir.toString());
                 System.setProperty("jna.library.path", unpackedLibDir.toString());
 
@@ -148,10 +182,169 @@ public class ResourceUnpacker {
 
                 System.setProperty(DEFOLD_UNPACK_PATH_KEY, unpackPath.toAbsolutePath().toString());
                 logger.info("defold.unpack.path={}", System.getProperty(DEFOLD_UNPACK_PATH_KEY));
-            } finally {
+
+                Map<String, Path> discoveredLibraries = discoverBundledNativeLibraries(unpackedLibDir, platform);
+                preloadedLibraryPaths = preloadNativeLibraries(discoveredLibraries, SYSTEM_NATIVE_LIBRARY_LOADER);
+                logger.info("preloaded {} bundled native libraries from {}", preloadedLibraryPaths.size(), unpackedLibDir);
                 isInitialized = true;
+            } finally {
+                if (!isInitialized) {
+                    preloadedLibraryPaths = Collections.emptyMap();
+                }
             }
         }
+    }
+
+    public static Map<String, Path> getPreloadedLibraries() {
+        return preloadedLibraryPaths;
+    }
+
+    public static Path getPreloadedLibraryPath(String logicalName) {
+        Objects.requireNonNull(logicalName, "logicalName");
+        Path libraryPath = preloadedLibraryPaths.get(logicalName);
+        if (libraryPath == null) {
+            throw new IllegalStateException("Bundled native library '" + logicalName + "' has not been preloaded");
+        }
+        return libraryPath;
+    }
+
+    public static Map<String, Path> discoverBundledNativeLibraries(Path libDir, Platform platform) throws IOException {
+        Objects.requireNonNull(libDir, "libDir");
+        Objects.requireNonNull(platform, "platform");
+
+        if (!Files.isDirectory(libDir)) {
+            throw new IOException("Bundled native library directory does not exist: " + libDir);
+        }
+
+        List<Path> libraryFiles;
+        try (Stream<Path> stream = Files.list(libDir)) {
+            libraryFiles = stream
+                    .filter(Files::isRegularFile)
+                    .map(path -> path.toAbsolutePath().normalize())
+                    .filter(path -> hasBundledNativeLibrarySuffix(path.getFileName().toString(), platform))
+                    .sorted(Comparator.comparing(path -> path.getFileName().toString()))
+                    .toList();
+        }
+
+        if (libraryFiles.isEmpty()) {
+            throw new IOException("No bundled native libraries found in " + libDir);
+        }
+
+        LinkedHashMap<String, Path> discoveredLibraries = new LinkedHashMap<>(libraryFiles.size());
+        for (Path libraryPath : libraryFiles) {
+            String logicalName = toBundledNativeLibraryLogicalName(libraryPath.getFileName().toString(), platform);
+            Path previousPath = discoveredLibraries.putIfAbsent(logicalName, libraryPath);
+            if (previousPath != null) {
+                throw new IOException("Duplicate bundled native library logical name '" + logicalName + "' in " + libDir
+                                      + ": " + previousPath + " and " + libraryPath);
+            }
+        }
+
+        return immutableLinkedHashMap(discoveredLibraries);
+    }
+
+    public static Map<String, Path> preloadNativeLibraries(Map<String, Path> discoveredLibraries, NativeLibraryLoader loader) {
+        Objects.requireNonNull(discoveredLibraries, "discoveredLibraries");
+        Objects.requireNonNull(loader, "loader");
+
+        if (discoveredLibraries.isEmpty()) {
+            throw new IllegalArgumentException("No bundled native libraries were discovered for preload");
+        }
+
+        List<Map.Entry<String, Path>> libraryEntries = new ArrayList<>(discoveredLibraries.entrySet());
+        List<Future<NativeLibraryLoadFailure>> futures = new ArrayList<>(libraryEntries.size());
+        List<NativeLibraryLoadFailure> failures = new ArrayList<>();
+
+        try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+            for (Map.Entry<String, Path> libraryEntry : libraryEntries) {
+                String logicalName = libraryEntry.getKey();
+                Path libraryPath = libraryEntry.getValue();
+                futures.add(executor.submit(() -> preloadNativeLibrary(logicalName, libraryPath, loader)));
+            }
+
+            for (Future<NativeLibraryLoadFailure> future : futures) {
+                try {
+                    NativeLibraryLoadFailure failure = future.get();
+                    if (failure != null) {
+                        failures.add(failure);
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new IllegalStateException("Interrupted while preloading bundled native libraries", e);
+                } catch (Exception e) {
+                    throw new IllegalStateException("Unexpected failure while waiting for bundled native library preload", e);
+                }
+            }
+        }
+
+        if (!failures.isEmpty()) {
+            IllegalStateException aggregatedException = new IllegalStateException(buildPreloadFailureMessage(failures));
+            for (NativeLibraryLoadFailure failure : failures) {
+                aggregatedException.addSuppressed(failure.cause);
+            }
+            throw aggregatedException;
+        }
+
+        return immutableLinkedHashMap(discoveredLibraries);
+    }
+
+    private static NativeLibraryLoadFailure preloadNativeLibrary(String logicalName, Path libraryPath, NativeLibraryLoader loader) {
+        try {
+            loader.load(libraryPath);
+            logger.info("preloaded bundled native library '{}' from {}", logicalName, libraryPath);
+            return null;
+        } catch (Throwable t) {
+            return new NativeLibraryLoadFailure(logicalName, libraryPath, t);
+        }
+    }
+
+    private static String buildPreloadFailureMessage(List<NativeLibraryLoadFailure> failures) {
+        StringBuilder message = new StringBuilder("Failed to preload bundled native libraries:");
+        for (NativeLibraryLoadFailure failure : failures) {
+            message.append(System.lineSeparator())
+                    .append(" - ")
+                    .append(failure.logicalName)
+                    .append(" from ")
+                    .append(failure.libraryPath);
+            if (failure.cause.getMessage() != null && !failure.cause.getMessage().isEmpty()) {
+                message.append(" (").append(failure.cause.getMessage()).append(')');
+            }
+        }
+        return message.toString();
+    }
+
+    private static boolean hasBundledNativeLibrarySuffix(String fileName, Platform platform) {
+        if (platform.isMacOS()) {
+            return fileName.endsWith(".dylib") || fileName.endsWith(".jnilib");
+        }
+        return fileName.endsWith(platform.getLibSuffix());
+    }
+
+    private static String toBundledNativeLibraryLogicalName(String fileName, Platform platform) {
+        String suffix = bundledNativeLibrarySuffix(fileName, platform);
+        String baseName = fileName.substring(0, fileName.length() - suffix.length());
+        String libPrefix = platform.getLibPrefix();
+        if (!libPrefix.isEmpty() && baseName.startsWith(libPrefix)) {
+            baseName = baseName.substring(libPrefix.length());
+        }
+        if (baseName.isEmpty()) {
+            throw new IllegalArgumentException("Unable to derive bundled native library logical name from " + fileName);
+        }
+        return baseName;
+    }
+
+    private static String bundledNativeLibrarySuffix(String fileName, Platform platform) {
+        if (platform.isMacOS() && fileName.endsWith(".jnilib")) {
+            return ".jnilib";
+        }
+        if (fileName.endsWith(platform.getLibSuffix())) {
+            return platform.getLibSuffix();
+        }
+        throw new IllegalArgumentException("Unsupported bundled native library filename: " + fileName);
+    }
+
+    private static Map<String, Path> immutableLinkedHashMap(Map<String, Path> libraries) {
+        return Collections.unmodifiableMap(new LinkedHashMap<>(libraries));
     }
 
     private static void unpackResourceFile(String resourceFileName, Path target) throws IOException {
@@ -169,7 +362,7 @@ public class ResourceUnpacker {
 
             Path outputPath = target.resolve(resourceFileName);
             if (ignoreInputFilePath) {
-                outputPath =  target.resolve(outputPath.getFileName());
+                outputPath = target.resolve(outputPath.getFileName());
             }
             File outputFile = outputPath.toFile();
 
@@ -223,8 +416,7 @@ public class ResourceUnpacker {
                     }
                     try {
                         Files.copy(source, dest, StandardCopyOption.REPLACE_EXISTING);
-                    }
-                    catch (IOException e) {
+                    } catch (IOException e) {
                         logger.warn("unpacking '{}' to '{}' failed", source, dest, e);
                     }
                 }

--- a/editor/src/java/com/defold/libs/ResourceUnpacker.java
+++ b/editor/src/java/com/defold/libs/ResourceUnpacker.java
@@ -37,8 +37,9 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.Future;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
@@ -56,15 +57,14 @@ public class ResourceUnpacker {
         void load(Path libraryPath) throws Throwable;
     }
 
-    private static final class NativeLibraryLoadFailure {
+    private static final class NativeLibraryLoadException extends RuntimeException {
         private final String logicalName;
         private final Path libraryPath;
-        private final Throwable cause;
 
-        private NativeLibraryLoadFailure(String logicalName, Path libraryPath, Throwable cause) {
+        private NativeLibraryLoadException(String logicalName, Path libraryPath, Throwable cause) {
+            super("Failed to preload bundled native library '" + logicalName + "' from " + libraryPath, cause);
             this.logicalName = logicalName;
             this.libraryPath = libraryPath;
-            this.cause = cause;
         }
     }
 
@@ -247,8 +247,8 @@ public class ResourceUnpacker {
         }
 
         List<Map.Entry<String, Path>> libraryEntries = new ArrayList<>(discoveredLibraries.entrySet());
-        List<Future<NativeLibraryLoadFailure>> futures = new ArrayList<>(libraryEntries.size());
-        List<NativeLibraryLoadFailure> failures = new ArrayList<>();
+        List<Future<?>> futures = new ArrayList<>(libraryEntries.size());
+        List<NativeLibraryLoadException> failures = new ArrayList<>();
 
         try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
             for (Map.Entry<String, Path> libraryEntry : libraryEntries) {
@@ -257,25 +257,27 @@ public class ResourceUnpacker {
                 futures.add(executor.submit(() -> preloadNativeLibrary(logicalName, libraryPath, loader)));
             }
 
-            for (Future<NativeLibraryLoadFailure> future : futures) {
+            for (Future<?> future : futures) {
                 try {
-                    NativeLibraryLoadFailure failure = future.get();
-                    if (failure != null) {
+                    future.get();
+                } catch (ExecutionException e) {
+                    Throwable cause = e.getCause();
+                    if (cause instanceof NativeLibraryLoadException failure) {
                         failures.add(failure);
+                    } else {
+                        throw new IllegalStateException("Unexpected failure while preloading bundled native libraries", cause);
                     }
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
                     throw new IllegalStateException("Interrupted while preloading bundled native libraries", e);
-                } catch (Exception e) {
-                    throw new IllegalStateException("Unexpected failure while waiting for bundled native library preload", e);
                 }
             }
         }
 
         if (!failures.isEmpty()) {
             IllegalStateException aggregatedException = new IllegalStateException(buildPreloadFailureMessage(failures));
-            for (NativeLibraryLoadFailure failure : failures) {
-                aggregatedException.addSuppressed(failure.cause);
+            for (NativeLibraryLoadException failure : failures) {
+                aggregatedException.addSuppressed(failure.getCause());
             }
             throw aggregatedException;
         }
@@ -283,26 +285,26 @@ public class ResourceUnpacker {
         return immutableLinkedHashMap(discoveredLibraries);
     }
 
-    private static NativeLibraryLoadFailure preloadNativeLibrary(String logicalName, Path libraryPath, NativeLibraryLoader loader) {
+    private static void preloadNativeLibrary(String logicalName, Path libraryPath, NativeLibraryLoader loader) {
         try {
             loader.load(libraryPath);
             logger.info("preloaded bundled native library '{}' from {}", logicalName, libraryPath);
-            return null;
         } catch (Throwable t) {
-            return new NativeLibraryLoadFailure(logicalName, libraryPath, t);
+            throw new NativeLibraryLoadException(logicalName, libraryPath, t);
         }
     }
 
-    private static String buildPreloadFailureMessage(List<NativeLibraryLoadFailure> failures) {
+    private static String buildPreloadFailureMessage(List<NativeLibraryLoadException> failures) {
         StringBuilder message = new StringBuilder("Failed to preload bundled native libraries:");
-        for (NativeLibraryLoadFailure failure : failures) {
+        for (NativeLibraryLoadException failure : failures) {
             message.append(System.lineSeparator())
                     .append(" - ")
                     .append(failure.logicalName)
                     .append(" from ")
                     .append(failure.libraryPath);
-            if (failure.cause.getMessage() != null && !failure.cause.getMessage().isEmpty()) {
-                message.append(" (").append(failure.cause.getMessage()).append(')');
+            Throwable cause = failure.getCause();
+            if (cause.getMessage() != null && !cause.getMessage().isEmpty()) {
+                message.append(" (").append(cause.getMessage()).append(')');
             }
         }
         return message.toString();

--- a/editor/test/editor/resource_unpacker_test.clj
+++ b/editor/test/editor/resource_unpacker_test.clj
@@ -1,0 +1,151 @@
+;; Copyright 2020-2026 The Defold Foundation
+;; Copyright 2014-2020 King
+;; Copyright 2009-2014 Ragnar Svensson, Christian Murray
+;; Licensed under the Defold License version 1.0 (the "License"); you may not use
+;; this file except in compliance with the License.
+;;
+;; You may obtain a copy of the License, together with FAQs at
+;; https://www.defold.com/license
+;;
+;; Unless required by applicable law or agreed to in writing, software distributed
+;; under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+;; CONDITIONS OF ANY KIND, either express or implied. See the License for the
+;; specific language governing permissions and limitations under the License.
+
+(ns editor.resource-unpacker-test
+  (:require [clojure.java.io :as io]
+            [clojure.test :refer :all]
+            [editor.fs :as fs])
+  (:import [com.defold.libs ResourceUnpacker ResourceUnpacker$NativeLibraryLoader]
+           [com.dynamo.bob Platform]
+           [java.nio.file Path]
+           [java.util LinkedHashMap Map$Entry]
+           [java.util.concurrent CountDownLatch TimeUnit]))
+
+(defn- make-temp-library! ^Path [dir name]
+  (let [file (io/file dir name)]
+    (fs/create-parent-directories! file)
+    (spit file "")
+    (.toPath file)))
+
+(defn- ordered-library-pairs [libraries]
+  (mapv (fn [^Map$Entry entry]
+          [(.getKey entry) (.. entry getValue getFileName toString)])
+        (.entrySet libraries)))
+
+(defn- linked-library-map [& entries]
+  (let [libraries (LinkedHashMap.)]
+    (doseq [[logical-name path] entries]
+      (.put libraries logical-name path))
+    libraries))
+
+(deftest discover-bundled-native-libraries-filters-and-sorts-linux-libs
+  (let [lib-dir (fs/create-temp-directory! "resource-unpacker-linux")]
+    (make-temp-library! lib-dir "libzeta.so")
+    (make-temp-library! lib-dir "libalpha.so")
+    (make-temp-library! lib-dir "ignore.txt")
+    ;; Discovery only scans the top-level host lib directory.
+    (.mkdirs (io/file lib-dir "nested"))
+    (make-temp-library! (io/file lib-dir "nested") "libhidden.so")
+    (is (= [["alpha" "libalpha.so"]
+            ["zeta" "libzeta.so"]]
+           (ordered-library-pairs
+             (ResourceUnpacker/discoverBundledNativeLibraries (.toPath lib-dir) Platform/X86_64Linux))))))
+
+(deftest discover-bundled-native-libraries-accepts-macos-jnilibs
+  (let [lib-dir (fs/create-temp-directory! "resource-unpacker-macos")]
+    (make-temp-library! lib-dir "libbeta.dylib")
+    (make-temp-library! lib-dir "libalpha.jnilib")
+    (make-temp-library! lib-dir "libgamma.so")
+    (is (= [["alpha" "libalpha.jnilib"]
+            ["beta" "libbeta.dylib"]]
+           (ordered-library-pairs
+             (ResourceUnpacker/discoverBundledNativeLibraries (.toPath lib-dir) Platform/Arm64MacOS))))))
+
+(deftest discover-bundled-native-libraries-fails-for-missing-empty-and-duplicate-libs
+  (let [root-dir (fs/create-temp-directory! "resource-unpacker-errors")
+        missing-lib-dir (.toPath (io/file root-dir "missing"))
+        empty-lib-dir (fs/create-temp-directory! "resource-unpacker-empty")
+        duplicate-lib-dir (fs/create-temp-directory! "resource-unpacker-duplicate")]
+    (is (thrown-with-msg? java.io.IOException
+                          #"does not exist"
+                          (ResourceUnpacker/discoverBundledNativeLibraries missing-lib-dir Platform/X86_64Linux)))
+    (is (thrown-with-msg? java.io.IOException
+                          #"No bundled native libraries found"
+                          (ResourceUnpacker/discoverBundledNativeLibraries (.toPath empty-lib-dir) Platform/X86_64Linux)))
+    ;; Different macOS suffixes still collapse to the same logical name.
+    (make-temp-library! duplicate-lib-dir "libparticle_shared.dylib")
+    (make-temp-library! duplicate-lib-dir "libparticle_shared.jnilib")
+    (is (thrown-with-msg? java.io.IOException
+                          #"Duplicate bundled native library logical name 'particle_shared'"
+                          (ResourceUnpacker/discoverBundledNativeLibraries (.toPath duplicate-lib-dir) Platform/Arm64MacOS)))))
+
+(deftest preload-native-libraries-loads-all-paths-in-parallel
+  (let [lib-dir (fs/create-temp-directory! "resource-unpacker-preload")
+        alpha-path (make-temp-library! lib-dir "libalpha.so")
+        beta-path (make-temp-library! lib-dir "libbeta.so")
+        gamma-path (make-temp-library! lib-dir "libgamma.so")
+        libraries (linked-library-map ["alpha" alpha-path]
+                                      ["beta" beta-path]
+                                      ["gamma" gamma-path])
+        ;; The latch forces all worker threads to overlap before any load returns.
+        started (CountDownLatch. 3)
+        loaded-paths (atom [])
+        thread-ids (atom #{})
+        preloaded (ResourceUnpacker/preloadNativeLibraries
+                    libraries
+                    (reify ResourceUnpacker$NativeLibraryLoader
+                      (^void load [_ ^Path library-path]
+                        (swap! loaded-paths conj (.toString library-path))
+                        (swap! thread-ids conj (.threadId (Thread/currentThread)))
+                        (.countDown started)
+                        (when-not (.await started 5 TimeUnit/SECONDS)
+                          (throw (RuntimeException. (str "Timed out waiting for parallel preload of " library-path))))
+                        nil)))]
+    (is (= #{"alpha" "beta" "gamma"} (set (map first (ordered-library-pairs preloaded)))))
+    (is (= #{(.toString alpha-path) (.toString beta-path) (.toString gamma-path)}
+           (set @loaded-paths)))
+    (is (= 3 (count @thread-ids)))))
+
+(deftest preload-native-libraries-aggregates-failures
+  (let [lib-dir (fs/create-temp-directory! "resource-unpacker-failures")
+        alpha-path (make-temp-library! lib-dir "libalpha.so")
+        beta-path (make-temp-library! lib-dir "libbeta.so")
+        gamma-path (make-temp-library! lib-dir "libgamma.so")
+        libraries (linked-library-map ["alpha" alpha-path]
+                                      ["beta" beta-path]
+                                      ["gamma" gamma-path])]
+    (try
+      ;; Only one library succeeds so we can assert that failures are aggregated.
+      (ResourceUnpacker/preloadNativeLibraries
+        libraries
+        (reify ResourceUnpacker$NativeLibraryLoader
+          (^void load [_ ^Path library-path]
+            (when-not (= "libgamma.so" (.. library-path getFileName toString))
+              (throw (RuntimeException. (str "boom:" library-path))))
+            nil)))
+      (is false "Expected aggregated native preload failure")
+      (catch IllegalStateException e
+        (let [message (.getMessage e)]
+          (is (.contains message (.toString alpha-path)))
+          (is (.contains message (.toString beta-path)))
+          (is (not (.contains message (.toString gamma-path))))
+          (is (= 2 (count (.getSuppressed e)))))))))
+
+(deftest unpack-resources-preloads-host-bundled-native-libraries
+  (ResourceUnpacker/unpackResources)
+  (let [platform (Platform/getHostPlatform)
+        unpack-path (System/getProperty ResourceUnpacker/DEFOLD_UNPACK_PATH_KEY)
+        lib-dir (.toPath (io/file unpack-path (str (.getPair platform) "/lib")))
+        discovered (ResourceUnpacker/discoverBundledNativeLibraries lib-dir platform)
+        preloaded (ResourceUnpacker/getPreloadedLibraries)]
+    (is (= (ordered-library-pairs discovered)
+           (ordered-library-pairs preloaded)))
+    (doseq [^Map$Entry entry (.entrySet discovered)]
+      (is (= (.getValue entry)
+             (ResourceUnpacker/getPreloadedLibraryPath (.getKey entry)))))
+    (doseq [logical-name ["particle_shared" "mouse_capture_shared"]]
+      (when-let [^Path library-path (.get preloaded logical-name)]
+        (is (.startsWith library-path lib-dir))
+        (is (= library-path
+               (ResourceUnpacker/getPreloadedLibraryPath logical-name)))))))

--- a/editor/test/editor/resource_unpacker_test.clj
+++ b/editor/test/editor/resource_unpacker_test.clj
@@ -14,10 +14,15 @@
 
 (ns editor.resource-unpacker-test
   (:require [clojure.java.io :as io]
+            [clojure.string :as string]
             [clojure.test :refer :all]
             [editor.fs :as fs])
   (:import [com.defold.libs ResourceUnpacker ResourceUnpacker$NativeLibraryLoader]
            [com.dynamo.bob Platform]
+           [com.jogamp.common.jvm JNILibLoaderBase]
+           [com.jogamp.common.os DynamicLibraryBundle NativeLibrary]
+           [com.jogamp.opengl GLProfile]
+           [jogamp.opengl GLDrawableFactoryImpl]
            [java.nio.file Path]
            [java.util LinkedHashMap Map$Entry]
            [java.util.concurrent CountDownLatch TimeUnit]))
@@ -38,6 +43,30 @@
     (doseq [[logical-name path] entries]
       (.put libraries logical-name path))
     libraries))
+
+(defn- jogl-tool-native-library-paths []
+  (let [profile (GLProfile/getDefault)
+        factory ^GLDrawableFactoryImpl (GLDrawableFactoryImpl/getFactoryImpl profile)
+        helper (.getGLDynamicLookupHelper factory 0 0)]
+    (mapv (fn [^NativeLibrary lib]
+            (-> (.getNativeLibraryPath lib)
+                io/file
+                .toPath
+                .toAbsolutePath
+                .normalize))
+          (.getToolLibraries ^DynamicLibraryBundle helper))))
+
+(defn- bundled-jogl-library-names [libraries]
+  (->> (keys libraries)
+       (filter #(or (= "gluegen_rt" %)
+                    (string/starts-with? % "jogl_")
+                    (string/starts-with? % "nativewindow_")))
+       set))
+
+(defn- loaded-jogl-library-names [candidate-names]
+  (->> candidate-names
+       (filter JNILibLoaderBase/isLoaded)
+       set))
 
 (deftest discover-bundled-native-libraries-filters-and-sorts-linux-libs
   (let [lib-dir (fs/create-temp-directory! "resource-unpacker-linux")]
@@ -149,3 +178,30 @@
         (is (.startsWith library-path lib-dir))
         (is (= library-path
                (ResourceUnpacker/getPreloadedLibraryPath logical-name)))))))
+
+(deftest unpack-resources-supports-jogl-glprofile-init-singleton
+  (ResourceUnpacker/unpackResources)
+  ;; Match the startup path in Start.java: preload first, then let JOGL initialize itself.
+  (GLProfile/initSingleton)
+  (is (GLProfile/isInitialized))
+  (let [platform (Platform/getHostPlatform)
+        unpack-path (System/getProperty ResourceUnpacker/DEFOLD_UNPACK_PATH_KEY)
+        lib-dir (-> (io/file unpack-path (str (.getPair platform) "/lib"))
+                    .toPath
+                    .toAbsolutePath
+                    .normalize)
+        preloaded (ResourceUnpacker/getPreloadedLibraries)
+        bundled-jogl-library-names (bundled-jogl-library-names preloaded)
+        loaded-jogl-library-names (loaded-jogl-library-names bundled-jogl-library-names)
+        tool-library-paths (jogl-tool-native-library-paths)]
+    ;; JOGL exposes exact paths for its GL tool bundle and logical names for the other
+    ;; native libraries it requests to load. Since unpackResources pins java.library.path
+    ;; to the unpacked lib directory, these names resolve back to the bundled copies.
+    (is (= (.toString lib-dir) (System/getProperty "java.library.path")))
+    (is (seq tool-library-paths))
+    (doseq [^Path tool-library-path tool-library-paths]
+      (is (.isAbsolute tool-library-path)))
+    (is (contains? loaded-jogl-library-names "gluegen_rt"))
+    (is (some loaded-jogl-library-names ["jogl_desktop" "jogl_mobile"]))
+    (is (seq (filter #(string/starts-with? % "nativewindow_") loaded-jogl-library-names)))
+    (is (every? #(contains? bundled-jogl-library-names %) loaded-jogl-library-names))))


### PR DESCRIPTION
Fix an issue where the editor could load libraries from `/Library/Java/Extensions` instead of the bundled ones, which could break loading or otherwise affect the editor.

Fix https://github.com/defold/defold/issues/11695

### Technical changes

The editor now loads native libraries directly from Defold’s unpacked lib folder, not from system library paths.

It finds the libs automatically, loads them by exact path in parallel, fails fast if one is broken, and uses the same exact-path lookup for JNA too. Also, tests added for discovery, loading, and failure cases.