### PR TITLE
using a scaled (pixel-converted) height instead of font units

### DIFF
--- a/engine/font/src/text_layout_legacy.cpp
+++ b/engine/font/src/text_layout_legacy.cpp
@@ -292,7 +292,7 @@ TextResult TextLayoutLegacyCreate(HFontCollection collection,
     // metrics->m_MaxDescent = descent;
     uint32_t num_lines = layout->m_Lines.Size();
     layout->m_Width = max_line_width;
-    layout->m_Height = num_lines * (line_height * settings->m_Leading) - line_height * (settings->m_Leading - 1.0f);
+    layout->m_Height = num_lines * (line_height_scaled * settings->m_Leading) - line_height_scaled * (settings->m_Leading - 1.0f);
 
     *outlayout = layout;
     return TEXT_RESULT_OK;


### PR DESCRIPTION
It looks like, for dynamic fonts, the text layout calculation was using font-units instead of pixels, when returning the result of resource.get_text_metrics(font, ...).
This PR makes sure a scaled (pixel-converted) height gets returned, instead of font units, for the font resource metrics calculation output.

a demo project that reproduces the issue: 
[text_metrics_demo.zip](https://github.com/user-attachments/files/26932899/text_metrics_demo.zip)
