### PR TITLE
Parallelize directory traversal when syncing resources

### DIFF
--- a/editor/src/clj/editor/resource_watch.clj
+++ b/editor/src/clj/editor/resource_watch.clj
@@ -109,11 +109,13 @@
          unloaded-proj-path? (g/raw-property-value basis workspace :unloaded-proj-path?)]
      (make-file-tree workspace project-directory file editable-proj-path? unloaded-proj-path?)))
   ([workspace ^File root ^File file editable-proj-path? unloaded-proj-path?]
-   (let [children (into []
-                        (comp (filter (partial file-resource-filter root))
-                              (map #(make-file-tree workspace root % editable-proj-path? unloaded-proj-path?)))
-                        (.listFiles file))]
-     (resource/make-file-resource workspace (.getPath root) file children editable-proj-path? unloaded-proj-path?))))
+   (coll/ptree
+     (fn file-tree-children [^File file]
+       (when (.isDirectory file)
+         (filterv #(file-resource-filter root %) (.listFiles file))))
+     (fn file-tree-node [^File file children]
+       (resource/make-file-resource workspace (.getPath root) file children editable-proj-path? unloaded-proj-path?))
+     file)))
 
 (defn- file-resource-status [resource]
   (assert (resource/file-resource? resource))

--- a/editor/src/clj/util/coll.clj
+++ b/editor/src/clj/util/coll.clj
@@ -1088,9 +1088,17 @@
    (pmapv #(apply f %) (apply mapv vector coll colls))))
 
 (defn ptree
-  "Builds a tree in parallel. `children-fn` returns the ordered children for a
-  node, while `build-fn` combines the node with the vector of built child
-  results."
+  "Build a tree in parallel
+
+  Args:
+    children-fn    a function that returns the ordered child nodes for a node;
+                   will receive 1 arg: node; should return a collection of
+                   child nodes or nil
+    build-fn       a function that builds the result for a node; will receive 2
+                   args: node and built-children (vector of results returned by
+                   build-fn for the node's children, in child order); should
+                   return the built result for the node
+    root           the root node to build from"
   [children-fn build-fn root]
   (let [budget (Semaphore. (default-parallelism))]
     (letfn [(parallel-child-results [child-nodes]
@@ -1099,13 +1107,17 @@
                     results (object-array child-count)]
                 (with-open [scope (StructuredTaskScope/open (StructuredTaskScope$Joiner/awaitAllSuccessfulOrThrow))]
                   (dotimes [index child-count]
-                    (let [index index
-                          child-node (child-nodes index)]
-                      (.fork scope
-                             ^Runnable
-                             (fn []
-                               (Var/resetThreadBindingFrame binding-frame)
-                               (aset results index (visit child-node))))))
+                    (let [child-node (child-nodes index)]
+                      (if (.tryAcquire budget)
+                        (.fork scope
+                               ^Runnable
+                               (fn []
+                                 (try
+                                   (Var/resetThreadBindingFrame binding-frame)
+                                   (aset results index (visit child-node))
+                                   (finally
+                                     (.release budget)))))
+                        (aset results index (visit child-node)))))
                   (try
                     (.join scope)
                     (catch StructuredTaskScope$FailedException e
@@ -1116,11 +1128,6 @@
                     child-results (case (count child-nodes)
                                     0 []
                                     1 [(visit (child-nodes 0))]
-                                    (if (.tryAcquire budget)
-                                      (try
-                                        (parallel-child-results child-nodes)
-                                        (finally
-                                          (.release budget)))
-                                      (mapv visit child-nodes)))]
+                                    (parallel-child-results child-nodes))]
                 (build-fn node child-results)))]
       (visit root))))

--- a/editor/src/clj/util/coll.clj
+++ b/editor/src/clj/util/coll.clj
@@ -17,7 +17,7 @@
   (:import [clojure.core Eduction Vec]
            [clojure.lang Cons Cycle IEditableCollection LazilyPersistentVector LazySeq MapEntry Repeat Var]
            [java.util ArrayList Arrays List]
-           [java.util.concurrent StructuredTaskScope StructuredTaskScope$FailedException StructuredTaskScope$Joiner]
+           [java.util.concurrent Semaphore StructuredTaskScope StructuredTaskScope$FailedException StructuredTaskScope$Joiner]
            [java.util.concurrent.atomic AtomicInteger]))
 
 (set! *warn-on-reflection* true)
@@ -1046,6 +1046,12 @@
   ([coll f & args]
    (mapv #(apply f % args) coll)))
 
+(defn- default-parallelism
+  ^long []
+  (-> (.availableProcessors (Runtime/getRuntime))
+      (* 2)
+      (max 4)))
+
 (defn pmapv
   "Like core.pmap, but eagerly returns a vector, uses virtual threads, and
   keeps a bounded number of tasks in flight. Fails fast by cancelling
@@ -1059,10 +1065,7 @@
        (let [binding-frame (Var/cloneThreadBindingFrame)
              results (object-array item-count)
              next-index (AtomicInteger. 0)
-             worker-count (-> (.availableProcessors (Runtime/getRuntime))
-                              (* 2)
-                              (max 4)
-                              (min item-count))]
+             worker-count (min item-count (default-parallelism))]
          (with-open [scope (StructuredTaskScope/open (StructuredTaskScope$Joiner/awaitAllSuccessfulOrThrow))]
            (dotimes [_ worker-count]
              (.fork
@@ -1083,3 +1086,41 @@
            (LazilyPersistentVector/createOwning results))))))
   ([f coll & colls]
    (pmapv #(apply f %) (apply mapv vector coll colls))))
+
+(defn ptree
+  "Builds a tree in parallel. `children-fn` returns the ordered children for a
+  node, while `build-fn` combines the node with the vector of built child
+  results."
+  [children-fn build-fn root]
+  (let [budget (Semaphore. (default-parallelism))]
+    (letfn [(parallel-child-results [child-nodes]
+              (let [binding-frame (Var/cloneThreadBindingFrame)
+                    child-count (count child-nodes)
+                    results (object-array child-count)]
+                (with-open [scope (StructuredTaskScope/open (StructuredTaskScope$Joiner/awaitAllSuccessfulOrThrow))]
+                  (dotimes [index child-count]
+                    (let [index index
+                          child-node (child-nodes index)]
+                      (.fork scope
+                             ^Runnable
+                             (fn []
+                               (Var/resetThreadBindingFrame binding-frame)
+                               (aset results index (visit child-node))))))
+                  (try
+                    (.join scope)
+                    (catch StructuredTaskScope$FailedException e
+                      (throw (.getCause e)))))
+                (LazilyPersistentVector/createOwning results)))
+            (visit [node]
+              (let [child-nodes (vec (or (children-fn node) []))
+                    child-results (case (count child-nodes)
+                                    0 []
+                                    1 [(visit (child-nodes 0))]
+                                    (if (.tryAcquire budget)
+                                      (try
+                                        (parallel-child-results child-nodes)
+                                        (finally
+                                          (.release budget)))
+                                      (mapv visit child-nodes)))]
+                (build-fn node child-results)))]
+      (visit root))))

--- a/editor/test/util/coll_test.clj
+++ b/editor/test/util/coll_test.clj
@@ -1975,3 +1975,50 @@
           (Thread/sleep 10)))
       (is (empty? @completed-values))
       (is (= (dec task-count) @cancellation-count)))))
+
+(deftest ptree-test
+  (testing "Builds a tree."
+    (let [tree {:value :root
+                :children [{:value :left}
+                           {:value :branch
+                            :children [{:value :leaf}]}]}]
+      (is (= [:root [[:left []]
+                     [:branch [[:leaf []]]]]]
+             (coll/ptree :children
+                         (fn [node children]
+                           [(:value node) children])
+                         tree)))))
+
+  (testing "Preserves child order."
+    (is (= (vec (range 32))
+           (coll/ptree :children
+                       (fn [node children]
+                         (if-let [value (:value node)]
+                           (do
+                             (Thread/sleep ^long (- 31 (long value)))
+                             value)
+                           children))
+                       {:children (mapv (fn [value] {:value value}) (range 32))}))))
+
+  (testing "Propagates thread bindings."
+    (binding [*pmapv-binding-test-value* :bound]
+      (is (= [[:bound 0] [:bound 1] [:bound 2] [:bound 3]]
+             (coll/ptree :children
+                         (fn [node children]
+                           (if-let [value (:value node)]
+                             [*pmapv-binding-test-value* value]
+                             children))
+                         {:children (mapv (fn [value] {:value value}) (range 4))})))))
+
+  (testing "Rethrows task failure."
+    (is (thrown-with-msg?
+          ExceptionInfo
+          #"boom 2"
+          (coll/ptree :children
+                      (fn [node children]
+                        (if-let [value (:value node)]
+                          (if (= 2 value)
+                            (throw (ex-info (str "boom " value) {:value value}))
+                            value)
+                          children))
+                      {:children (mapv (fn [value] {:value value}) (range 4))})))))


### PR DESCRIPTION
This change improves open load time in big projects by 5% (1m12s -> 1m08s)

Fix #11989