### PR TITLE
Fix for custom vertex attribute with overridden render material

### DIFF
--- a/engine/gamesys/src/gamesys/gamesys_private.cpp
+++ b/engine/gamesys/src/gamesys/gamesys_private.cpp
@@ -359,8 +359,12 @@ namespace dmGameSystem
             int component_attribute_index = FindAttributeIndex(component_attributes, num_component_attributes, name_hash);
             if (component_attribute_index >= 0)
             {
+                // Keep the destination layout from the material info, but preserve the overridden
+                // attribute's source vector shape so WriteAttributes can safely convert the value.
+                component_info.m_ValueVectorType = component_attributes[component_attribute_index].m_VectorType;
+
                 // We don't use the byte size from the overridden attribute here, since we still need to match
-                // the stride of the materials vertex declaration
+                // the stride of the material's vertex declaration.
                 uint32_t value_byte_size_tmp;
                 dmGraphics::GetAttributeValues(component_attributes[component_attribute_index],
                     &component_info.m_ValuePtr, &value_byte_size_tmp);

--- a/engine/gamesys/src/gamesys/test/particlefx/attribute_mismatch.go
+++ b/engine/gamesys/src/gamesys/test/particlefx/attribute_mismatch.go
@@ -1,0 +1,4 @@
+components {
+  id: "particlefx"
+  component: "/particlefx/attribute_mismatch.particlefx"
+}

--- a/engine/gamesys/src/gamesys/test/particlefx/attribute_mismatch.particlefx
+++ b/engine/gamesys/src/gamesys/test/particlefx/attribute_mismatch.particlefx
@@ -1,0 +1,72 @@
+emitters {
+  id: "emitter"
+  mode: PLAY_MODE_ONCE
+  duration: 1.0
+  space: EMISSION_SPACE_WORLD
+  position {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  tile_source: "/tile/valid.tileset"
+  animation: "anim"
+  material: "/particlefx/attribute_mismatch_scalar.material"
+  blend_mode: BLEND_MODE_ADD
+  particle_orientation: PARTICLE_ORIENTATION_DEFAULT
+  inherit_velocity: 0.0
+  max_particle_count: 1
+  type: EMITTER_TYPE_2DCONE
+  start_delay: 0.0
+  properties {
+    key: EMITTER_KEY_SPAWN_RATE
+    points {
+      x: 0.0
+      y: 32.0
+      t_x: 1.0
+      t_y: 0.0
+    }
+    spread: 0.0
+  }
+  properties {
+    key: EMITTER_KEY_PARTICLE_SIZE
+    points {
+      x: 0.0
+      y: 20.0
+      t_x: 1.0
+      t_y: 0.0
+    }
+    spread: 0.0
+  }
+  particle_properties {
+    key: PARTICLE_KEY_SCALE
+    points {
+      x: 0.0
+      y: 1.0
+      t_x: 1.0
+      t_y: 0.0
+    }
+  }
+  size_mode: SIZE_MODE_AUTO
+  start_delay_spread: 0.0
+  duration_spread: 0.0
+  stretch_with_velocity: false
+  start_offset: 0.0
+  pivot {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+  }
+  attributes {
+    name: "crash_attr"
+    semantic_type: SEMANTIC_TYPE_NONE
+    data_type: TYPE_FLOAT
+    vector_type: VECTOR_TYPE_SCALAR
+    binary_values: "\000\000\200?"
+  }
+}

--- a/engine/gamesys/src/gamesys/test/particlefx/attribute_mismatch_mat4.material
+++ b/engine/gamesys/src/gamesys/test/particlefx/attribute_mismatch_mat4.material
@@ -1,0 +1,29 @@
+name: "attribute_mismatch_mat4"
+tags: "particle"
+vertex_program: "/particlefx/attribute_mismatch_mat4_repro.vp"
+fragment_program: "/particlefx/attribute_mismatch_repro.fp"
+vertex_space: VERTEX_SPACE_WORLD
+attributes {
+  name: "crash_attr"
+  semantic_type: SEMANTIC_TYPE_NONE
+  data_type: TYPE_FLOAT
+  vector_type: VECTOR_TYPE_MAT4
+  double_values {
+    v: 1.0
+    v: 0.0
+    v: 0.0
+    v: 0.0
+    v: 0.0
+    v: 1.0
+    v: 0.0
+    v: 0.0
+    v: 0.0
+    v: 0.0
+    v: 1.0
+    v: 0.0
+    v: 0.0
+    v: 0.0
+    v: 0.0
+    v: 1.0
+  }
+}

--- a/engine/gamesys/src/gamesys/test/particlefx/attribute_mismatch_mat4_repro.vp
+++ b/engine/gamesys/src/gamesys/test/particlefx/attribute_mismatch_mat4_repro.vp
@@ -1,0 +1,10 @@
+attribute vec4 position;
+attribute mat4 crash_attr;
+
+varying vec4 var_crash_attr;
+
+void main()
+{
+    gl_Position = position;
+    var_crash_attr = crash_attr[0];
+}

--- a/engine/gamesys/src/gamesys/test/particlefx/attribute_mismatch_repro.fp
+++ b/engine/gamesys/src/gamesys/test/particlefx/attribute_mismatch_repro.fp
@@ -1,0 +1,6 @@
+varying vec4 var_crash_attr;
+
+void main()
+{
+    gl_FragColor = var_crash_attr;
+}

--- a/engine/gamesys/src/gamesys/test/particlefx/attribute_mismatch_scalar.material
+++ b/engine/gamesys/src/gamesys/test/particlefx/attribute_mismatch_scalar.material
@@ -1,0 +1,14 @@
+name: "attribute_mismatch_scalar"
+tags: "particle"
+vertex_program: "/particlefx/attribute_mismatch_scalar_repro.vp"
+fragment_program: "/particlefx/attribute_mismatch_repro.fp"
+vertex_space: VERTEX_SPACE_WORLD
+attributes {
+  name: "crash_attr"
+  semantic_type: SEMANTIC_TYPE_NONE
+  data_type: TYPE_FLOAT
+  vector_type: VECTOR_TYPE_SCALAR
+  double_values {
+    v: 1.0
+  }
+}

--- a/engine/gamesys/src/gamesys/test/particlefx/attribute_mismatch_scalar_repro.vp
+++ b/engine/gamesys/src/gamesys/test/particlefx/attribute_mismatch_scalar_repro.vp
@@ -1,0 +1,10 @@
+attribute vec4 position;
+attribute float crash_attr;
+
+varying vec4 var_crash_attr;
+
+void main()
+{
+    gl_Position = position;
+    var_crash_attr = vec4(crash_attr, 0.0, 0.0, 1.0);
+}

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -17,6 +17,7 @@
 
 #include "../../../../graphics/src/graphics_private.h"
 #include "../../../../graphics/src/null/graphics_null_private.h"
+#include "../../../../particle/src/particle_private.h"
 #include "../../../../render/src/render/render_private.h"
 #include "../../../../resource/src/resource_private.h"
 #include "../../../../gui/src/gui_private.h"
@@ -5448,6 +5449,101 @@ TEST_F(ComponentTest, DispatchBuffersTest)
     #undef SET_VTX_B
     #undef ASSERT_VTX_A_EQ
     #undef ASSERT_VTX_B_EQ
+
+    ASSERT_TRUE(dmGameObject::Final(m_Collection));
+}
+
+TEST_F(ComponentTest, ParticleFXRenderScriptMaterialOverrideAttributeSizeMismatch)
+{
+    dmHashEnableReverseHash(true);
+
+    dmRender::RenderContext* render_context_ptr  = (dmRender::RenderContext*) m_RenderContext;
+    render_context_ptr->m_MultiBufferingRequired = 1;
+
+    void* particlefx_world = dmGameObject::GetWorld(m_Collection, dmGameObject::GetComponentTypeIndex(m_Collection, dmHashString64("particlefxc")));
+    ASSERT_NE((void*) 0, particlefx_world);
+
+    dmParticle::Prototype* particlefx_prototype = 0;
+    ASSERT_EQ(dmResource::RESULT_OK, dmResource::Get(m_Factory, "/particlefx/attribute_mismatch.particlefxc", (void**) &particlefx_prototype));
+    ASSERT_EQ(1u, particlefx_prototype->m_DDF->m_Emitters.m_Count);
+    ASSERT_EQ(1u, particlefx_prototype->m_DDF->m_Emitters[0].m_Attributes.m_Count);
+
+    dmGraphics::VertexAttribute& scalar_attribute = particlefx_prototype->m_DDF->m_Emitters[0].m_Attributes[0];
+
+    // The waf test compiler does not run Bob's particlefx attribute packing/name-hash step.
+    // Patch the runtime fields here, and keep the scalar backing allocation to one float
+    // so ASan catches the mat4 read performed after the material override below.
+    scalar_attribute.m_NameHash = dmHashString64("crash_attr");
+    ASSERT_EQ((uint32_t) sizeof(float), scalar_attribute.m_Values.m_BinaryValues.m_Count);
+    uint8_t* original_scalar_values = scalar_attribute.m_Values.m_BinaryValues.m_Data;
+    float* scalar_value = new float(1.0f);
+    scalar_attribute.m_Values.m_BinaryValues.m_Data = (uint8_t*) scalar_value;
+
+    dmGameSystem::MaterialResource* mat4_material_resource = 0;
+    ASSERT_EQ(dmResource::RESULT_OK, dmResource::Get(m_Factory, "/particlefx/attribute_mismatch_mat4.materialc", (void**) &mat4_material_resource));
+
+    const char* render_script_source =
+        "function init(self)\n"
+        "    self.predicate = render.predicate({\"particle\"})\n"
+        "end\n"
+        "function update(self)\n"
+        "    render.enable_material(\"attribute_mismatch_mat4\")\n"
+        "    render.draw(self.predicate)\n"
+        "    render.disable_material()\n"
+        "end\n";
+    dmLuaDDF::LuaSource lua_source;
+    memset(&lua_source, 0, sizeof(lua_source));
+    lua_source.m_Script.m_Data = (uint8_t*) render_script_source;
+    lua_source.m_Script.m_Count = strlen(render_script_source);
+    lua_source.m_Bytecode.m_Data = (uint8_t*) render_script_source;
+    lua_source.m_Bytecode.m_Count = strlen(render_script_source);
+    lua_source.m_Bytecode64.m_Data = (uint8_t*) render_script_source;
+    lua_source.m_Bytecode64.m_Count = strlen(render_script_source);
+    lua_source.m_Filename = "particlefx-attribute-mismatch-render-script";
+
+    dmRender::HRenderScript render_script = dmRender::NewRenderScript(m_RenderContext, &lua_source);
+    ASSERT_NE((dmRender::HRenderScript) 0, render_script);
+    dmRender::HRenderScriptInstance render_script_instance = dmRender::NewRenderScriptInstance(m_RenderContext, render_script);
+    ASSERT_NE((dmRender::HRenderScriptInstance) 0, render_script_instance);
+    dmRender::AddRenderScriptInstanceRenderResource(render_script_instance, "attribute_mismatch_mat4", (uint64_t) mat4_material_resource->m_Material, dmRender::RENDER_RESOURCE_TYPE_MATERIAL);
+    ASSERT_EQ(dmRender::RENDER_SCRIPT_RESULT_OK, dmRender::InitRenderScriptInstance(render_script_instance));
+
+    ASSERT_TRUE(dmGameObject::Init(m_Collection));
+    dmGameObject::HInstance go = Spawn(m_Factory, m_Collection, "/particlefx/attribute_mismatch.goc", dmHashString64("/go"), 0, Point3(0, 0, 0), Quat(0, 0, 0, 1), Vector3(1, 1, 1));
+    ASSERT_NE((void*)0, go);
+
+    dmMessage::URL receiver;
+    receiver.m_Socket   = dmGameObject::GetMessageSocket(m_Collection);
+    receiver.m_Path     = dmGameObject::GetIdentifier(go);
+    receiver.m_Fragment = 0;
+    dmMessage::Post(
+            0, &receiver,
+            dmGameSystemDDF::PlayParticleFX::m_DDFDescriptor->m_NameHash,
+            (uintptr_t) go,
+            (uintptr_t) dmGameSystemDDF::PlayParticleFX::m_DDFDescriptor,
+            0, 0, 0);
+
+    ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+    dmTime::Sleep(16*1000);
+    ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+
+    dmRender::RenderListBegin(m_RenderContext);
+    dmGameObject::Render(m_Collection);
+    ASSERT_EQ(dmRender::RENDER_SCRIPT_RESULT_OK, dmRender::DispatchRenderScriptInstance(render_script_instance));
+    dmRender::RenderListEnd(m_RenderContext);
+    dmGraphics::BeginFrame(m_GraphicsContext);
+    ASSERT_EQ(dmRender::RENDER_SCRIPT_RESULT_OK, dmRender::UpdateRenderScriptInstance(render_script_instance, m_UpdateContext.m_DT));
+
+    dmRender::BufferedRenderBuffer* vx_buffer;
+    dmGameSystem::GetParticleFXWorldRenderBuffers(particlefx_world, &vx_buffer);
+    ASSERT_EQ(1u, vx_buffer->m_Buffers.Size());
+
+    scalar_attribute.m_Values.m_BinaryValues.m_Data = original_scalar_values;
+    delete scalar_value;
+    dmResource::Release(m_Factory, particlefx_prototype);
+    dmRender::DeleteRenderScriptInstance(render_script_instance);
+    dmRender::DeleteRenderScript(m_RenderContext, render_script);
+    dmResource::Release(m_Factory, mat4_material_resource);
 
     ASSERT_TRUE(dmGameObject::Final(m_Collection));
 }


### PR DESCRIPTION
Fixed a memory out-of-bounds issue where setting a material from a render script containing custom vertex attributes did not factor in the source material attribute size.

Fixes #12243 