### PR TITLE
Set the Android app state struct to dlib before starting the engine

### DIFF
--- a/build_tools/waf_dynamo.py
+++ b/build_tools/waf_dynamo.py
@@ -1088,9 +1088,15 @@ def create_app_bundle(self):
         codesign.signed_exe = signed_exe
 
 
+# Keep this as close as possible to the stub in build_input.yml
 ANDROID_STUB = """
-struct android_app;
+#include <dmsdk/dlib/android.h>
 
+#if __cplusplus
+extern "C" {
+#endif
+
+struct android_app;
 extern void _glfwPreMain(struct android_app* state);
 extern void app_dummy();
 
@@ -1098,8 +1104,13 @@ void android_main(struct android_app* state)
 {
     // Make sure glue isn't stripped.
     app_dummy();
-    _glfwPreMain(state);
+    dmAndroid::SetAndroidApp(state);
+    _glfwPreMain(state); // calls engine_main()
 }
+
+#if __cplusplus
+}
+#endif
 """
 
 def android_package(task):
@@ -1260,7 +1271,7 @@ def create_copy_glue(self):
     if not re.match('arm.*?android', self.env['PLATFORM']):
         return
 
-    stub = self.path.get_bld().find_or_declare('android_stub.c')
+    stub = self.path.get_bld().find_or_declare('android_stub.cpp')
     self.source.append(stub)
     task = self.create_task('copy_stub')
     task.set_outputs([stub])

--- a/scripts/mobile/android_emulator.sh
+++ b/scripts/mobile/android_emulator.sh
@@ -4,9 +4,9 @@ set -euo pipefail
 
 usage() {
     cat <<'EOF'
-usage: ci/rendertest/android/emulator_start.sh --avd NAME [options]
+usage: ci/rendertest/android/emulator_start.sh (--avd NAME [options] | --stop)
 
-Start an Android emulator and wait until adb can see it.
+Start an Android emulator and wait until adb can see it, or stop a running emulator.
 
 To list installed avd's:
 
@@ -18,6 +18,7 @@ Options:
   --gpu MODE            GPU emulation mode passed to the emulator. Default: auto
   --output DIR          Output directory for emulator logs. Default: build/render-tests/android
   --emulator-arg ARG    Extra argument passed to the emulator binary. Repeatable.
+  --stop                Stop the currently running emulator.
   -h, --help            Show this help
 EOF
 }
@@ -26,6 +27,7 @@ AVD_NAME=""
 GPU_MODE="auto"
 OUTPUT_DIR="build/render-tests/android"
 EMULATOR_ARGS=()
+STOP_EMULATOR="0"
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -45,6 +47,10 @@ while [[ $# -gt 0 ]]; do
             EMULATOR_ARGS+=("${2:-}")
             shift 2
             ;;
+        --stop)
+            STOP_EMULATOR="1"
+            shift
+            ;;
         -h|--help)
             usage
             exit 0
@@ -57,7 +63,7 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-if [[ -z "${AVD_NAME}" ]]; then
+if [[ "${STOP_EMULATOR}" == "0" ]] && [[ -z "${AVD_NAME}" ]]; then
     echo "--avd is required" >&2
     exit 1
 fi
@@ -78,6 +84,10 @@ if ! [[ "${TIMEOUT_SECONDS}" =~ ^[0-9]+$ ]] || [[ "${TIMEOUT_SECONDS}" -le 0 ]];
     echo "internal timeout must be a positive integer" >&2
     exit 1
 fi
+
+list_running_emulators() {
+    "${ADB_BIN}" devices | awk 'NR > 1 && $2 != "offline" && $1 ~ /^emulator-/ { print $1 }'
+}
 
 find_emulator_binary() {
     local candidate
@@ -109,6 +119,48 @@ find_emulator_binary() {
 
     return 1
 }
+
+stop_running_emulator() {
+    local running_serials
+    local running_count
+    local adb_serial
+    local deadline_epoch
+
+    running_serials="$(list_running_emulators)"
+    running_count="$(printf '%s\n' "${running_serials}" | awk 'NF { count++ } END { print count + 0 }')"
+
+    if [[ "${running_count}" -eq 0 ]]; then
+        echo "No running emulator found in adb devices." >&2
+        exit 1
+    fi
+
+    if [[ "${running_count}" -gt 1 ]]; then
+        echo "More than one running emulator found; refusing to guess which one to stop." >&2
+        printf 'Running emulators:\n%s\n' "${running_serials}" >&2
+        exit 1
+    fi
+
+    adb_serial="${running_serials}"
+    "${ADB_BIN}" -s "${adb_serial}" emu kill >/dev/null
+
+    deadline_epoch="$(( $(date +%s) + TIMEOUT_SECONDS ))"
+    while [[ "$(date +%s)" -le "${deadline_epoch}" ]]; do
+        if ! list_running_emulators | grep -qx -- "${adb_serial}"; then
+            echo "${adb_serial}"
+            return 0
+        fi
+
+        sleep 1
+    done
+
+    echo "Timed out waiting for emulator ${adb_serial} to stop." >&2
+    exit 1
+}
+
+if [[ "${STOP_EMULATOR}" == "1" ]]; then
+    stop_running_emulator
+    exit 0
+fi
 
 list_avds() {
     "${EMULATOR_BIN}" -list-avds 2>/dev/null | awk 'NF { print }'
@@ -144,7 +196,7 @@ OUTPUT_DIR_ABS="${OUTPUT_DIR}"
 mkdir -p "${OUTPUT_DIR_ABS}"
 
 LOG_PATH="${OUTPUT_DIR_ABS}/emulator.log"
-START_SERIALS_TEXT="$("${ADB_BIN}" devices | awk 'NR > 1 && $2 != "offline" && $1 ~ /^emulator-/ { print $1 }')"
+START_SERIALS_TEXT="$(list_running_emulators)"
 
 EMULATOR_CMD=(
     "${EMULATOR_BIN}"
@@ -169,7 +221,7 @@ deadline_epoch="$(( $(date +%s) + TIMEOUT_SECONDS ))"
 ADB_SERIAL=""
 
 while [[ "$(date +%s)" -le "${deadline_epoch}" ]]; do
-    CURRENT_SERIALS_TEXT="$("${ADB_BIN}" devices | awk 'NR > 1 && $2 != "offline" && $1 ~ /^emulator-/ { print $1 }')"
+    CURRENT_SERIALS_TEXT="$(list_running_emulators)"
 
     while IFS= read -r serial; do
         [[ -n "${serial}" ]] || continue

--- a/share/extender/build_input.yml
+++ b/share/extender/build_input.yml
@@ -220,8 +220,8 @@ main: |
     {
         // Make sure glue isn't stripped.
         app_dummy();
-        _glfwPreMain(state);
         dmAndroid::SetAndroidApp(state);
+        _glfwPreMain(state);
     }
 
     #if __cplusplus


### PR DESCRIPTION
## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
