### PR TITLE
Add streaming console endpoint

### DIFF
--- a/editor/src/clj/editor/command_requests.clj
+++ b/editor/src/clj/editor/command_requests.clj
@@ -131,9 +131,9 @@
    {:ui-handler :help.open-issues
     :help "Open the Defold Issue Tracker in a web browser."}
 
-   :rebuild
+   :clean-build
    {:ui-handler :project.clean-build
-    :help "Rebuild and run the project."
+    :help "Clear caches, and then build the project."
     :resource-sync true}
 
    :rebundle

--- a/editor/src/clj/editor/console.clj
+++ b/editor/src/clj/editor/console.clj
@@ -816,7 +816,7 @@
       (connection-write! [_ output-stream]
         (let [writer (io/writer output-stream :encoding "UTF-8")
               queue (ArrayBlockingQueue. 1024)
-              subscriber #(.put queue %)
+              subscriber #(.offer queue %)
               entries (:entries (swap! pending-atom update :stream-subscribers conj subscriber))]
           (try
             (when-not (coll/empty? entries)
@@ -833,8 +833,7 @@
             ;; Suppress warning logs on disconnect:
             (catch IOException _)
             (finally
-              (swap! pending-atom update :stream-subscribers disj subscriber)
-              (.clear queue))))))))
+              (swap! pending-atom update :stream-subscribers disj subscriber))))))))
 
 (defn routes [console-view]
   (let [console-node (g/node-value console-view :resource-node)]

--- a/editor/src/clj/editor/console.clj
+++ b/editor/src/clj/editor/console.clj
@@ -47,6 +47,7 @@
             [util.http-server :as http-server])
   (:import [editor.code.data Cursor CursorRange LayoutInfo Rect]
            [java.io BufferedReader IOException]
+           [java.util.concurrent ArrayBlockingQueue]
            [java.util.regex MatchResult]
            [javafx.beans.property SimpleStringProperty]
            [javafx.scene Node Parent Scene]
@@ -59,8 +60,6 @@
 
 (set! *warn-on-reflection* true)
 (set! *unchecked-math* :warn-on-boxed)
-
-(defonce ^:const url-prefix "/console")
 
 (def ^:const console-filters-prefs-key [:console :filters])
 (def ^:const console-filtering-key [:console :filtering])
@@ -75,7 +74,7 @@
   ;; by resetting the :index to 0, marking the view to :clear while keeping the
   ;; :entries. Hence, from the point of view of the console view, there is no
   ;; such thing as filters, only clearing the output.
-  (atom {:clear false :entries [] :index 0 :filter-set #{} :entry-pred nil}))
+  (atom {:clear false :entries [] :index 0 :filter-set #{} :entry-pred nil :stream-subscribers #{}}))
 
 (def ^:private gutter-bubble-font
   (Font. "Source Sans Pro", 10.5))
@@ -89,14 +88,17 @@
   [type line]
   (assert (or (nil? type) (keyword? type)))
   (assert (string? line))
-  (swap! pending-atom update :entries conj [type line]))
+  (let [message (str line \newline)
+        subscribers (:stream-subscribers (swap! pending-atom update :entries conj [type line]))]
+    (run! #(% message) subscribers)))
 
 (def append-console-line! (partial append-console-entry! nil))
 
 (defn clear-console!
   "Clear the console. Callable from a background thread."
   []
-  (swap! pending-atom assoc :clear true :entries [] :index 0))
+  (let [subscribers (:stream-subscribers (swap! pending-atom assoc :clear true :entries [] :index 0))]
+    (run! #(% "\n") subscribers)))
 
 (def ^:private remote-log-pump-thread (atom nil))
 (def ^:private console-stream (atom nil))
@@ -805,6 +807,35 @@
     (ui/timer-start! repainter)
     view-node))
 
+(defn- stream-console-response []
+  (http-server/response
+    200
+    {"content-type" "text/plain; charset=utf-8"}
+    (reify
+      http-server/ConnectionWrite
+      (connection-write! [_ output-stream]
+        (let [writer (io/writer output-stream :encoding "UTF-8")
+              queue (ArrayBlockingQueue. 1024)
+              subscriber #(.put queue %)
+              entries (:entries (swap! pending-atom update :stream-subscribers conj subscriber))]
+          (try
+            (when-not (coll/empty? entries)
+              (run! (fn [[_ line]]
+                      (.write writer ^String line)
+                      (.write writer "\n"))
+                    entries)
+              (.flush writer))
+            (loop []
+              (do
+                (.write writer ^String (.take queue))
+                (.flush writer)
+                (recur)))
+            ;; Suppress warning logs on disconnect:
+            (catch IOException _)
+            (finally
+              (swap! pending-atom update :stream-subscribers disj subscriber)
+              (.clear queue))))))))
+
 (defn routes [console-view]
   (let [console-node (g/node-value console-view :resource-node)]
     (assert (g/node-instance? ConsoleNode console-node))
@@ -838,4 +869,14 @@
                                               :properties {:row {:type "integer"}
                                                            :col {:type "integer"}}}
                                          :type {:type "string"
-                                                :description "Region type, e.g. extension-output, extension-error, resource-reference, repeat, eval-expression, eval-result, or eval-error."}}}}}}}}}}}})}}))
+                                                :description "Region type, e.g. extension-output, extension-error, resource-reference, repeat, eval-expression, eval-result, or eval-error."}}}}}}}}}}}})}
+     "/console/stream"
+     {"GET" (with-meta
+              (bound-fn [_]
+                (stream-console-response))
+              {:openapi
+               {:summary "Stream console output, use with, e.g., `curl -N`"
+                :responses
+                {"200"
+                 {:description "Chunked text stream; stays open indefinitely"
+                  :content {"text/plain" {:schema {:type "string"}}}}}}})}}))

--- a/editor/src/clj/editor/future.clj
+++ b/editor/src/clj/editor/future.clj
@@ -14,7 +14,7 @@
 
 (ns editor.future
   (:refer-clojure :exclude [future])
-  (:import [java.util.concurrent CompletableFuture CompletionException Executors ThreadFactory]
+  (:import [java.util.concurrent CompletableFuture CompletionException Executors]
            [java.util.function Function Supplier]))
 
 (set! *warn-on-reflection* true)
@@ -40,13 +40,7 @@
              ~@body))))))
 
 (def io-executor
-  (let [counter (atom 0)]
-    (Executors/newCachedThreadPool
-      (reify ThreadFactory
-        (newThread [_ r]
-          (doto (Thread. r)
-            (.setDaemon true)
-            (.setName (str "editor.future/io-executor#" (swap! counter inc)))))))))
+  (Executors/newVirtualThreadPerTaskExecutor))
 
 (defmacro io
   "Asynchronously perform an IO-intensive operation (see also: compute)"

--- a/editor/src/clj/util/http_server.clj
+++ b/editor/src/clj/util/http_server.clj
@@ -96,9 +96,10 @@
 (defprotocol ContentType (content-type [body] "static content-type string or nil if unknown; default nil"))
 (defprotocol ContentLength (content-length [body] "static content-length in bytes (long) or nil if unknown; default nil"))
 (defprotocol ->Data (->data [body] "convert body to reusable immutable data"))
-(defprotocol ->Connection (->connection [data] "open connection to HTTP response data that might know it's content-type and content-length when sent, should be io/IOFactory, could be Closeable; default identity"))
+(defprotocol ->Connection (->connection [data] "open connection to HTTP response data before sending; the connection may know its content-type and content-length at send time, is written via connection-write!, and may be Closeable; default identity"))
 (defprotocol ConnectionContentType (connection-content-type [connection] "dynamic content-type string or nil if unknown; default nil"))
 (defprotocol ConnectionContentLength (connection-content-length [connection] "dynamic content-length in bytes (long) or nil if unknown; default nil"))
+(defprotocol ConnectionWrite (connection-write! [connection output-stream] "write HTTP response body directly to output-stream"))
 ;; During response creation, if content-length and content-type weren't
 ;; explicitly provided, we try to infer them. We use `content-type` fn on a
 ;; provided body, and then try it on the data produced using `->data`. We
@@ -156,7 +157,9 @@
     status     HTTP status code, e.g. 200
     headers    HTTP headers map, string->string, lower-case keys
     body       response body, either nil, string (text content) or anything that
-               satisfies io/IOFactory (e.g. InputStream, File, Path, etc.)"
+               the server knows how to write after ->data/->connection
+               normalization, typically an io/IOFactory value such as
+               InputStream, File, or Path"
   ([]
    (response 200 nil nil))
   ([status]
@@ -249,6 +252,12 @@
   Object (->connection [x] x)
   nil (->connection [x] x))
 
+(extend-protocol ConnectionWrite
+  Object (connection-write! [connection output-stream]
+           (with-open [input-stream (io/input-stream connection)]
+             (io/copy input-stream output-stream)))
+  nil (connection-write! [_ _]))
+
 (defn error [response]
   (ex-info "HTTP server error" {::response response}))
 
@@ -270,11 +279,12 @@
                  :headers    optional response headers map, string->string;
                              header names should be lower-case
                  :body       optional response body, could be nil, string
-                             content, or anything that satisfies io/IOFactory
-                             (e.g. InputStream, File, Path etc.). If body is
-                             Closeable, it will be closed even if it's not
-                             written (which might happen when responding to HEAD
-                             requests)
+                             content, or anything the server knows how to write
+                             after ->data/->connection normalization, typically
+                             an io/IOFactory value such as InputStream, File,
+                             or Path. If the opened connection is Closeable, it
+                             will be closed even if it's not written (which
+                             might happen when responding to HEAD requests)
                Use [[response]] fn to produce the response
 
   Kv-args (all optional):
@@ -359,8 +369,7 @@
                                         (if (zero? n) -1 n))
                                       0)))
                                 (when connection
-                                  (with-open [is (io/input-stream connection)]
-                                    (io/copy is (.getResponseBody exchange)))))
+                                  (connection-write! connection (.getResponseBody exchange))))
                               ;; A browser or remote http client can close the
                               ;; connection before we finished sending the response
                               ;; headers/body: we only log such exceptions since
@@ -432,10 +441,11 @@
     :headers    optional response headers map, string->string;
                 header names should be lower-case
     :body       optional response body, could be nil, string
-                content, or anything that satisfies io/IOFactory
-                (e.g. InputStream, File, Path etc.). If body is AutoCloseable,
-                it will be closed even if it's not written (which might happen
-                when responding to HEAD requests)
+                content, or anything the server knows how to write after
+                ->data/->connection normalization, typically an io/IOFactory
+                value such as InputStream, File, or Path. If the opened
+                connection is AutoCloseable, it will be closed even if it's not
+                written (which might happen when responding to HEAD requests)
   See also:
     https://cljdoc.org/d/metosin/reitit-core/0.8.0-alpha1/doc/introduction"
   [routes]

--- a/editor/test/integration/web_server_test.clj
+++ b/editor/test/integration/web_server_test.clj
@@ -39,7 +39,7 @@
             [util.http-client :as http]
             [util.http-server :as http-server]
             [util.path :as path])
-  (:import [java.io ByteArrayInputStream ByteArrayOutputStream]
+  (:import [java.io BufferedReader ByteArrayInputStream ByteArrayOutputStream InputStreamReader OutputStream]
            [java.nio.charset StandardCharsets]
            [javafx.scene Scene]
            [javafx.scene.layout Region]
@@ -170,6 +170,16 @@
            (http-server/response
              200
              (ByteArrayInputStream. (.getBytes "input stream" StandardCharsets/UTF_8)))
+           :as :string)))
+  (is (= {:status 200
+          :headers {"transfer-encoding" "chunked"}
+          :body "connection write"}
+         (get-written-response
+           (http-server/response
+             200
+             (reify http-server/ConnectionWrite
+               (connection-write! [_ output-stream]
+                 (.write ^OutputStream output-stream (.getBytes "connection write" StandardCharsets/UTF_8)))))
            :as :string))))
 
 (defn- schema-leaves
@@ -298,6 +308,7 @@
               (let [json-body (json/read-str body)]
                 (is (= "3.0.3" (get json-body "openapi")))
                 (is (contains? (get json-body "paths") "/console"))
+                (is (contains? (get json-body "paths") "/console/stream"))
                 (let [post-command (get-in json-body ["paths" "/command/{command}" "post"])]
                   (is (= "Execute an editor command" (get post-command "summary")))
                   (is (string/includes? (get post-command "description") "`build-html5`"))
@@ -314,6 +325,19 @@
               (is (= 200 status))
               (is (= "application/json" (get headers "content-type")))
               (is (string/includes? body "\"lines\":")))
+            (testing "Console streaming"
+              (console/clear-console!)
+              (console/append-console-line! "before")
+              (let [{:keys [status headers body]} @(http/request (str url "/console/stream") :as :input-stream)]
+                (is (= 200 status))
+                (is (= "text/plain; charset=utf-8" (get headers "content-type")))
+                (with-open [^java.io.InputStream body body
+                            ^BufferedReader reader (BufferedReader. (InputStreamReader. body StandardCharsets/UTF_8))]
+                  (is (= "before" (deref (future (.readLine reader)) 2000 ::timeout)))
+                  (console/append-console-line! "after")
+                  (is (= "after" (deref (future (.readLine reader)) 2000 ::timeout)))
+                  (console/clear-console!)
+                  (is (= "" (deref (future (.readLine reader)) 2000 ::timeout))))))
             (let [{:keys [status]} @(http/request (str url "/command/") :as :string)]
               (is (= 404 status)))
             (let [{:keys [status headers body]} @(http/request (str url "/command/build-html5") :as :string)]


### PR DESCRIPTION
Now, the editor supports streaming editor logs using its new `/console/stream` endpoint. This can be used by third-party IDEs or coding agents that can run background processes. Example use:
```sh
$ curl -N http://localhost:$(cat .internal/editor.port)/console/stream
INFO:DLIB: Log server started on port 51990
INFO:ENGINE: Engine service started on port 51991
...streams logs until you press Ctrl+C
```

Fix #11903
