### PR TITLE
Fix `liveupdate.is_built_with_excluded_files()` were broken by old liveupdate functions deprecation

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/archive/test/ManifestTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/archive/test/ManifestTest.java
@@ -372,8 +372,10 @@ public class ManifestTest {
 
         assertEquals(instance.resources.length, fullData.getResourcesCount());
         assertEquals(7, countExcludedResources(fullData));
+        assertTrue(fullData.getHasExcludedResources());
         assertEquals(6, strippedData.getResourcesCount());
         assertEquals(0, countExcludedResources(strippedData));
+        assertTrue(strippedData.getHasExcludedResources());
 
         assertFalse(findResource(strippedData, "/main/level1.collectionc") != null);
         assertFalse(findResource(strippedData, "/main/level1.goc") != null);

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/ProjectBuildTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/ProjectBuildTest.java
@@ -288,6 +288,8 @@ public class ProjectBuildTest {
 
         assertEquals(0, countExcludedEntries(bundledManifestData));
         assertTrue(countExcludedEntries(publishedManifestData) > 0);
+        assertTrue(bundledManifestData.getHasExcludedResources());
+        assertTrue(publishedManifestData.getHasExcludedResources());
 
         assertFalse(hasResource(bundledManifestData, "/logic/level.collectionc"));
         assertFalse(hasResource(bundledManifestData, "/logic/level.goc"));
@@ -308,6 +310,8 @@ public class ProjectBuildTest {
         Manifest.ManifestData publishedManifestData = readManifestData(getPublishedManifestFile());
 
         assertTrue(countExcludedEntries(bundledManifestData) > 0);
+        assertTrue(bundledManifestData.getHasExcludedResources());
+        assertTrue(publishedManifestData.getHasExcludedResources());
         assertEquals(publishedManifestData, bundledManifestData);
     }
 
@@ -320,6 +324,7 @@ public class ProjectBuildTest {
         Manifest.ManifestData bundledManifestData = readManifestData(getBundledManifestFile());
 
         assertEquals(0, countExcludedEntries(bundledManifestData));
+        assertFalse(bundledManifestData.getHasExcludedResources());
         assertTrue(hasResource(bundledManifestData, "/logic/level.collectionc"));
         assertTrue(hasResource(bundledManifestData, "/logic/level.goc"));
         assertTrue(hasResource(bundledManifestData, "/logic/level.scriptc"));
@@ -338,6 +343,8 @@ public class ProjectBuildTest {
 
         assertEquals(0, countExcludedEntries(bundledManifestData));
         assertEquals(0, countExcludedEntries(publishedManifestData));
+        assertFalse(bundledManifestData.getHasExcludedResources());
+        assertFalse(publishedManifestData.getHasExcludedResources());
         assertEquals(publishedManifestData, bundledManifestData);
     }
 

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/archive/ManifestBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/archive/ManifestBuilder.java
@@ -281,6 +281,15 @@ public class ManifestBuilder {
         return manifestEntries;
     }
 
+    private boolean hasExcludedResources() {
+        for (ResourceEntry entry : this.resourceEntries) {
+            if ((entry.getFlags() & ResourceEntryFlag.EXCLUDED.getNumber()) != 0) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     private void buildUrlToResourceMap(List<ResourceEntry> entries) throws IOException {
         urlToResource.clear();
         for (ResourceEntry entry : entries) {
@@ -305,6 +314,7 @@ public class ManifestBuilder {
 
         ManifestHeader manifestHeader = this.buildManifestHeader();
         builder.setHeader(manifestHeader);
+        builder.setHasExcludedResources(hasExcludedResources());
 
         List<ResourceEntry> manifestEntries = getManifestEntries(stripExcludedEntries);
         buildUrlToResourceMap(manifestEntries);

--- a/engine/liveupdate/src/liveupdate.cpp
+++ b/engine/liveupdate/src/liveupdate.cpp
@@ -114,7 +114,7 @@ namespace dmLiveUpdate
         dmResourceProvider::HArchive    m_LiveupdateArchive;
         dmResource::HManifest           m_LiveupdateArchiveManifest;
         bool                            m_IsEnabled;
-        bool                            m_MainConttextHasExcludedEntries;
+        bool                            m_MainContextHasExcludedResources;
 
     } g_LiveUpdate;
 
@@ -890,7 +890,7 @@ namespace dmLiveUpdate
 
     bool IsBuiltWithExcludedFiles()
     {
-        return g_LiveUpdate.m_MainConttextHasExcludedEntries;
+        return g_LiveUpdate.m_MainContextHasExcludedResources;
     }
 
     // ******************************************************************
@@ -951,7 +951,7 @@ namespace dmLiveUpdate
         g_LiveUpdate.m_ResourceFactory = factory;
         g_LiveUpdate.m_ResourceMounts = dmResource::GetMountsContext(factory);
         g_LiveUpdate.m_ResourceBaseArchive = dmResource::GetBaseArchive(factory);
-        g_LiveUpdate.m_MainConttextHasExcludedEntries = false;
+        g_LiveUpdate.m_MainContextHasExcludedResources = false;
 
         if (g_LiveUpdate.m_ResourceBaseArchive)
         {
@@ -970,9 +970,9 @@ namespace dmLiveUpdate
                 return dmExtension::RESULT_OK;
             }
 
-            g_LiveUpdate.m_MainConttextHasExcludedEntries = dmResource::HasManifestExcludedEntries(manifest);
+            g_LiveUpdate.m_MainContextHasExcludedResources = dmResource::HasManifestExcludedEntries(manifest);
 
-            if (g_LiveUpdate.m_MainConttextHasExcludedEntries)
+            if (g_LiveUpdate.m_MainContextHasExcludedResources)
             {
                 dmLogInfo("Liveupdate folder located at: %s", g_LiveUpdate.m_AppSupportPath);
             }

--- a/engine/resource/proto/resource/liveupdate_ddf.proto
+++ b/engine/resource/proto/resource/liveupdate_ddf.proto
@@ -114,11 +114,15 @@ message ResourceEntry {
  *                              that version of the engine listed as a
  *                              supported engine.
  * - resources                : The resources that are part of the manifest.
+ * - has_excluded_resources   : True when the build produced one or more
+ *                              resources marked EXCLUDED, regardless of whether
+ *                              those entries are present in this manifest.
  */
 message ManifestData {
     required ManifestHeader     header = 1;
     repeated HashDigest         engine_versions = 2;
     repeated ResourceEntry      resources = 3;
+    optional bool               has_excluded_resources = 4 [default = false];
 }
 
 /*

--- a/engine/resource/src/resource_manifest.cpp
+++ b/engine/resource/src/resource_manifest.cpp
@@ -191,16 +191,7 @@ dmResource::Result GetApplicationSupportPath(dmResource::HManifest manifest, cha
 
 bool HasManifestExcludedEntries(dmResource::HManifest manifest)
 {
-    uint32_t entry_count = manifest->m_DDFData->m_Resources.m_Count;
-    dmLiveUpdateDDF::ResourceEntry* entries = manifest->m_DDFData->m_Resources.m_Data;
-
-    for(uint32_t i = 0; i < entry_count; ++i)
-    {
-        dmLiveUpdateDDF::ResourceEntry* entry = &entries[i];
-        if (entry->m_Flags & dmLiveUpdateDDF::EXCLUDED)
-            return true;
-    }
-    return false;
+    return manifest->m_DDFData->m_HasExcludedResources;
 }
 
 dmLiveUpdateDDF::ResourceEntry* FindEntry(dmResource::HManifest manifest, dmhash_t url_hash)
@@ -303,5 +294,3 @@ void DebugPrintManifest(dmResource::HManifest manifest)
 }
 
 } // namespace
-
-

--- a/engine/resource/src/resource_manifest.h
+++ b/engine/resource/src/resource_manifest.h
@@ -55,7 +55,7 @@ namespace dmResource
     dmResource::Result  LoadManifest(const char* path, dmResource::HManifest* out);
     dmResource::Result  LoadManifestFromBuffer(const uint8_t* buffer, uint32_t buffer_len, dmResource::HManifest* out);
 
-    // If it has excluded entries, we have built the game using the liveupdate setting
+    // If it was built with excluded resources, we have built the game using the liveupdate setting
     bool                HasManifestExcludedEntries(dmResource::HManifest manifest);
 
     dmResource::Result  WriteManifest(const char* path, dmResource::HManifest manifest);

--- a/engine/resource/src/test/test_resource_archive.cpp
+++ b/engine/resource/src/test/test_resource_archive.cpp
@@ -376,14 +376,14 @@ TEST(dmResourceArchive, ManifestHeader)
     dmResource::DeleteManifest(manifest);
 }
 
-TEST(dmResourceArchive, HasLiveupdateContent_FalseWithoutManifestFlagInArchive)
+TEST(dmResourceArchive, HasLiveupdateContent_MatchesArchiveManifestFlag)
 {
     dmResource::HManifest manifest = 0;
     dmResource::Result result = dmResource::LoadManifestFromBuffer(RESOURCES_DMANIFEST, RESOURCES_DMANIFEST_SIZE, &manifest);
     ASSERT_EQ(dmResource::RESULT_OK, result);
     ASSERT_EQ(dmResource::MANIFEST_VERSION, manifest->m_DDF->m_Version);
 
-    ASSERT_FALSE(dmResource::HasManifestExcludedEntries(manifest));
+    ASSERT_EQ(manifest->m_DDFData->m_HasExcludedResources, dmResource::HasManifestExcludedEntries(manifest));
 
     dmResource::DeleteManifest(manifest);
 }

--- a/engine/resource/src/test/test_resource_archive.cpp
+++ b/engine/resource/src/test/test_resource_archive.cpp
@@ -376,14 +376,14 @@ TEST(dmResourceArchive, ManifestHeader)
     dmResource::DeleteManifest(manifest);
 }
 
-TEST(dmResourceArchive, HasLiveupdateContent_True)
+TEST(dmResourceArchive, HasLiveupdateContent_FalseWithoutManifestFlagInArchive)
 {
     dmResource::HManifest manifest = 0;
     dmResource::Result result = dmResource::LoadManifestFromBuffer(RESOURCES_DMANIFEST, RESOURCES_DMANIFEST_SIZE, &manifest);
     ASSERT_EQ(dmResource::RESULT_OK, result);
     ASSERT_EQ(dmResource::MANIFEST_VERSION, manifest->m_DDF->m_Version);
 
-    ASSERT_TRUE(dmResource::HasManifestExcludedEntries(manifest));
+    ASSERT_FALSE(dmResource::HasManifestExcludedEntries(manifest));
 
     dmResource::DeleteManifest(manifest);
 }
@@ -398,6 +398,30 @@ TEST(dmResourceArchive, HasLiveupdateContent_False)
     ASSERT_FALSE(dmResource::HasManifestExcludedEntries(manifest));
 
     dmResource::DeleteManifest(manifest);
+}
+
+TEST(dmResourceArchive, HasLiveupdateContent_TrueFromManifestFlag)
+{
+    dmResource::Manifest manifest;
+    dmLiveUpdateDDF::ManifestData manifest_data;
+    manifest.m_DDFData = &manifest_data;
+    manifest_data.m_HasExcludedResources = true;
+
+    ASSERT_TRUE(dmResource::HasManifestExcludedEntries(&manifest));
+}
+
+TEST(dmResourceArchive, HasLiveupdateContent_FalseWithoutManifestFlag)
+{
+    dmResource::Manifest manifest;
+    dmLiveUpdateDDF::ManifestData manifest_data;
+    dmLiveUpdateDDF::ResourceEntry entries[1];
+    manifest.m_DDFData = &manifest_data;
+    manifest_data.m_HasExcludedResources = false;
+    manifest_data.m_Resources.m_Count = 1;
+    manifest_data.m_Resources.m_Data = entries;
+    entries[0].m_Flags = dmLiveUpdateDDF::EXCLUDED;
+
+    ASSERT_FALSE(dmResource::HasManifestExcludedEntries(&manifest));
 }
 
 TEST(dmResourceArchive, ResourceEntries)


### PR DESCRIPTION
`liveupdate.is_built_with_excluded_files()` should work even if user decided to exclude liveupdate entries from manifest