### PR TITLE
Avoid building of the engine during `waf install` process

### DIFF
--- a/build_tools/waf_dynamo.py
+++ b/build_tools/waf_dynamo.py
@@ -17,7 +17,6 @@ from waflib.Configure import conf
 from waflib import Utils, Build, Options, Task, Logs
 from waflib.TaskGen import extension, feature, after, before, task_gen
 from waflib.Logs import error
-from waflib.Task import RUN_ME
 from BuildUtility import BuildUtility, BuildUtilityException, create_build_utility
 from waf_tests import get_test_harness
 from build_constants import TargetOS
@@ -945,7 +944,11 @@ task = Task.task_factory('create_export_symbols',
                          color = 'PINK',
                          before  = 'c cxx')
 
-task.runnable_status = lambda self: RUN_ME
+create_export_symbols_sig_explicit_deps = task.sig_explicit_deps
+def sig_export_symbols(self):
+    create_export_symbols_sig_explicit_deps(self)
+    self.m.update(Utils.h_list(Utils.to_list(getattr(self, 'exported_symbols', []))))
+task.sig_explicit_deps = sig_export_symbols
 
 @task_gen
 @feature('cprogram', 'cxxprogram')
@@ -1248,7 +1251,11 @@ task = Task.task_factory('copy_stub',
                                 color = 'PINK',
                                 before  = 'c cxx')
 
-task.runnable_status = lambda self: RUN_ME
+copy_stub_sig_explicit_deps = task.sig_explicit_deps
+def sig_copy_stub(self):
+    copy_stub_sig_explicit_deps(self)
+    self.m.update(ANDROID_STUB.encode('utf-8'))
+task.sig_explicit_deps = sig_copy_stub
 
 @task_gen
 @before('process_source')

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/archive/ArchiveBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/archive/ArchiveBuilder.java
@@ -445,6 +445,8 @@ public class ArchiveBuilder {
         manifestBuilder.setSignatureSignAlgorithm(SignAlgorithm.SIGN_RSA);
 
         Project project = new Project(new DefaultFileSystem());
+        // Keep builtins archives deterministic; parallel writes make .arcd offsets depend on thread scheduling.
+        project.setOption("max-cpu-threads", "1");
         ResourceGraph resourceGraph = new ResourceGraph(project);
         manifestBuilder.setResourceGraph(resourceGraph);
 

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/archive/publisher/ZipPublisher.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/archive/publisher/ZipPublisher.java
@@ -34,6 +34,7 @@ import java.util.zip.ZipOutputStream;
 public class ZipPublisher extends Publisher {
 
     private static Logger logger = Logger.getLogger(ZipPublisher.class.getName());
+    private static final long DETERMINISTIC_ZIP_ENTRY_TIME = 0L;
 
     private File tempZipFile = null;
     private File destZipFile = null;
@@ -126,6 +127,7 @@ public class ZipPublisher extends Publisher {
         }
         try {
             ZipEntry currentEntry = new ZipEntry(zipEntryName);
+            currentEntry.setTime(DETERMINISTIC_ZIP_ENTRY_TIME);
             synchronized (zipOutputStream) {
                 zipOutputStream.putNextEntry(currentEntry);
                 zipOutputStream.write(entry.getHeader());
@@ -151,6 +153,7 @@ public class ZipPublisher extends Publisher {
         }
         try {
             ZipEntry currentEntry = new ZipEntry(zipEntryName);
+            currentEntry.setTime(DETERMINISTIC_ZIP_ENTRY_TIME);
             synchronized (zipOutputStream) {
                 zipOutputStream.putNextEntry(currentEntry);
                 zipOutputStream.write(entry.getHeader());

--- a/engine/engine/content/wscript
+++ b/engine/engine/content/wscript
@@ -8,7 +8,7 @@ def options(opt):
 
 def package_bob(self):
     bob = self.outputs[0].abspath()
-    bob_light = os.path.join(self.env['DYNAMO_HOME'], 'share/java/bob-light.jar')
+    bob_light = self.env['BOB_LIGHT_JAR']
     shutil.copyfile(bob_light, bob)
     zip = zipfile.ZipFile(bob, 'a')
     for input in self.inputs:
@@ -77,12 +77,13 @@ def build(bld):
         bob_deps = [find_required_node(bld, bob_light, 'bob-light.jar')]
         for plugin in bld.env['PLATFORM_SHADER_COMPILER_PLUGIN_JAR']:
             bob_deps.append(find_required_node(bld, plugin, 'shader compiler plugin jar'))
-        bld(name = 'bob-engine',
-            source = bld.path.ant_glob('builtins/**'),
-            deps = bob_deps,
-            target = 'bob-engine.jar',
-            vars = ['PLATFORM_SHADER_COMPILER_PLUGIN_JAR'],
-            rule = package_bob)
+        b = bld(name = 'bob-engine',
+                source = bld.path.ant_glob('builtins/**'),
+                deps = bob_deps,
+                target = 'bob-engine.jar',
+                vars = ['BOB_LIGHT_JAR', 'PLATFORM_SHADER_COMPILER_PLUGIN_JAR'],
+                rule = package_bob)
+        b.env['BOB_LIGHT_JAR'] = bob_light
         bld.install_files('${PREFIX}/share/java', 'bob-engine.jar')
 
 

--- a/engine/engine/content/wscript
+++ b/engine/engine/content/wscript
@@ -39,6 +39,12 @@ def remap_material_output(msg):
         return "debug.spc"
     return None
 
+def find_required_node(bld, path, name):
+    node = bld.root.find_node(path)
+    if not node:
+        bld.fatal('%s not found: %s' % (name, path))
+    return node
+
 def build(bld):
     obj = bld(source = bld.path.ant_glob('materials/*', excl = ['materials/*.fp', 'materials/*.vp']),
               remap_material_output = remap_material_output)
@@ -67,11 +73,16 @@ def build(bld):
     bld.install_files('${PREFIX}/content/builtins', start_dir.ant_glob('fonts/**/*'), cwd = start_dir, relative_trick = True)
 
     if not waflib.Options.options.skip_build_tests:
+        bob_light = os.path.join(bld.env['DYNAMO_HOME'], 'share/java/bob-light.jar')
+        bob_deps = [find_required_node(bld, bob_light, 'bob-light.jar')]
+        for plugin in bld.env['PLATFORM_SHADER_COMPILER_PLUGIN_JAR']:
+            bob_deps.append(find_required_node(bld, plugin, 'shader compiler plugin jar'))
         bld(name = 'bob-engine',
             source = bld.path.ant_glob('builtins/**'),
+            deps = bob_deps,
             target = 'bob-engine.jar',
-            rule = package_bob,
-            always = True)
+            vars = ['PLATFORM_SHADER_COMPILER_PLUGIN_JAR'],
+            rule = package_bob)
         bld.install_files('${PREFIX}/share/java', 'bob-engine.jar')
 
 

--- a/engine/engine/src/wscript
+++ b/engine/engine/src/wscript
@@ -250,7 +250,7 @@ def build(bld):
         bld.install_files('${PREFIX}/bin/${PLATFORM}', 'dmengine_release.nso')
         bld.install_files('${PREFIX}/bin/${PLATFORM}', 'dmengine_headless.nso')
 
-    if not waflib.Options.options.skip_build_tests:
+    if not bld.is_install and not waflib.Options.options.skip_build_tests:
         bld.recurse('test')
 
     dmsdk_add_files(bld, '${PREFIX}/sdk/include/dmsdk', 'dmsdk')

--- a/engine/engine/wscript
+++ b/engine/engine/wscript
@@ -193,7 +193,9 @@ def build(bld):
 
     bld.recurse('content')
 
-    b = bld(rule = create_engine_version, target = 'engine_version.h', always = True)
+    b = bld(rule = create_engine_version,
+            target = 'engine_version.h',
+            vars = ['ENGINE_SHA1', 'ENGINE_PLATFORM', 'ENGINE_VERSION'])
     b.env['ENGINE_SHA1'] = build_util.git_sha1()
     b.env['ENGINE_PLATFORM'] = build_util.get_target_platform()
     b.env['ENGINE_VERSION'] = build_util.get_defold_version()

--- a/engine/render/src/waf_render.py
+++ b/engine/render/src/waf_render.py
@@ -32,13 +32,8 @@ waflib.Task.task_factory('material_shaderbuilder', '${JAVA} ${JAVA_RUNTIME_FLAGS
                       before='c cxx',
                       shell=False)
 
-GENERATOR_ID = 0
-
 @extension('.material')
 def material_file(self, node):
-    global GENERATOR_ID
-    GENERATOR_ID = GENERATOR_ID + 1
-
     import google.protobuf.text_format
     import render.material_ddf_pb2
     import dlib
@@ -59,8 +54,10 @@ def material_file(self, node):
 
     if shader_name == None:
         shader_hash = dlib.dmHashBuffer64(msg.vertex_program + msg.fragment_program)
-        # make sure the name is unique, as each task requires unique outputs
-        shader_name = 'shader_%d_%d_%s' % (shader_hash, GENERATOR_ID, '.spc')
+        material_path = node.path_from(self.path).replace(os.sep, '/')
+        material_hash = dlib.dmHashBuffer64(material_path)
+        # Make sure the name is unique and deterministic, as each task requires unique outputs.
+        shader_name = 'shader_%d_%d%s' % (shader_hash, material_hash, '.spc')
 
     material.env['CLASSPATH']    = os.pathsep.join(classpath)
     material.env['CONTENT_ROOT'] = material.generator.content_root


### PR DESCRIPTION
Submodules building and re-building of separate modules should be much faster now

Fix https://github.com/defold/defold/issues/10799

### Technical changes

* Force standalone builtins archive generation to use one Bob thread to avoid .arcd offset races.
* Set deterministic ZIP entry timestamps for generated archives.
* Replace non-deterministic shader GENERATOR_ID with a stable material-path hash.
* Make Waf-generated helper files signature-based instead of always-running.
* Make bob-engine.jar incremental with explicit bob-light.jar and shader plugin jar dependencies.
* Avoid rebuilding engine test setup during the install pass.