### PR TITLE
Add `/eval` endpoint to editor server

### DIFF
--- a/editor/src/clj/editor/boot_open_project.clj
+++ b/editor/src/clj/editor/boot_open_project.clj
@@ -31,6 +31,7 @@
             [editor.dialogs :as dialogs]
             [editor.disk :as disk]
             [editor.editor-extensions :as extensions]
+            [editor.editor-extensions.server :as ext.server]
             [editor.engine-profiler :as engine-profiler]
             [editor.git :as git]
             [editor.hot-reload :as hot-reload]
@@ -210,10 +211,12 @@
                                                       localization)
 
           breakpoints-view (breakpoints-view/make-breakpoints-view workspace project open-resource *view-graph* prefs (.lookup root "#breakpoints-container"))
+          token (web-server/make-token)
           server-handler (web-server/make-dynamic-handler
                            (into []
                                  cat
                                  [(web-server/built-in-routes project)
+                                  (ext.server/routes project token)
                                   (engine-profiler/routes)
                                   (console/routes console-view)
                                   (hot-reload/routes workspace)
@@ -237,7 +240,10 @@
           port-file-content (str (http-server/port web-server))
           port-file (doto (io/file project-path ".internal" "editor.port")
                       (io/make-parents)
-                      (spit port-file-content))]
+                      (spit port-file-content))
+          token-file (doto (io/file project-path ".internal" "editor.token")
+                       (io/make-parents)
+                       (spit token))]
       (localization/localize! (.lookup root "#assets-pane") localization (localization/message "pane.assets"))
       (localization/localize! (.lookup root "#changed-files-titled-pane") localization (localization/message "pane.changed-files"))
       (localization/localize! (.lookup root "#status-label") localization (localization/message "progress.ready"))
@@ -252,9 +258,11 @@
         (Thread.
           (fn []
             ;; Content might change if another editor is open in the same project
-            ;; In that case, we let the other instance to clean up the file
+            ;; In that case, we let the other instance to clean up the files
             (when (and (.exists port-file) (= port-file-content (slurp port-file)))
-              (.delete port-file)))))
+              (.delete port-file))
+            (when (and (.exists token-file) (= token (slurp token-file)))
+              (.delete token-file)))))
       (.addEventFilter ^StackPane (.lookup root "#overlay") MouseEvent/ANY ui/ignore-event-filter)
       (ui/add-application-focused-callback! :main-stage app-view/handle-application-focused! app-view changes-view workspace prefs)
       (ui/add-application-unfocused-callback! :main-stage-unfocused app-view/handle-application-unfocused! app-view changes-view project prefs)

--- a/editor/src/clj/editor/console.clj
+++ b/editor/src/clj/editor/console.clj
@@ -877,5 +877,4 @@
                {:summary "Stream console output, use with, e.g., `curl -N`"
                 :responses
                 {"200"
-                 {:description "Chunked text stream; stays open indefinitely"
-                  :content {"text/plain" {:schema {:type "string"}}}}}}})}}))
+                 {:description "Chunked text stream; stays open indefinitely"}}}})}}))

--- a/editor/src/clj/editor/editor_extensions.clj
+++ b/editor/src/clj/editor/editor_extensions.clj
@@ -104,16 +104,16 @@
     path    a proj-path of the editor script, string
     ret     a Lua data structure returned from function in that file"
   [state fn-keyword opts evaluation-context]
-  (let [{:keys [rt all display-output!]} state
+  (let [{:keys [rt all]} state
         lua-opts (rt/->lua opts)
         label (name fn-keyword)]
     (eduction
       (keep (fn [[path lua-fn]]
               (when-let [lua-ret (error-handling/try-with-extension-exceptions
-                                   :display-output! display-output!
+                                   :rt rt
                                    :label (str label " in " path)
                                    :catch nil
-                                   (rt/invoke-immediate-1 rt lua-fn lua-opts evaluation-context))]
+                                   (rt/invoke-immediate-1 rt {:evaluation-context evaluation-context} lua-fn lua-opts))]
                 (when-not (rt/coerces-to? rt coerce/null lua-ret)
                   [path lua-ret]))))
       (get all fn-keyword))))
@@ -314,7 +314,7 @@
                            :out (coerce/enum :capture :discard :pipe)
                            :err (coerce/enum :stdout :discard :pipe)})))
 
-(defn- make-ext-execute-fn [^Path project-path display-output! reload-resources!]
+(defn- make-ext-execute-fn [^Path project-path reload-resources!]
   (rt/suspendable-lua-fn ext-execute [{:keys [rt]} & lua-args]
     (when (empty? lua-args)
       (throw (LuaError. "No arguments provided to editor.execute()")))
@@ -334,12 +334,14 @@
           maybe-output-future (when (= :capture out)
                                 (future/io
                                   (or (process/capture! (process/out p))
-                                      empty-lua-string)))]
-      (when (= :pipe out)
-        (actions/input-stream->console (process/out p) display-output! :out))
-      (when (= :pipe err)
-        (actions/input-stream->console (process/err p) display-output! :err))
+                                      empty-lua-string)))
+          out-future (when (= :pipe out)
+                       (actions/input-stream->console (process/out p) (rt/stdout rt)))
+          err-future (when (= :pipe err)
+                       (actions/input-stream->console (process/err p) (rt/stderr rt)))]
       (-> (.onExit p)
+          (cond-> out-future (future/then (fn [_] out-future))
+                  err-future (future/then (fn [_] err-future)))
           (future/then
             (fn [_]
               (let [exit-code (.exitValue p)]
@@ -628,14 +630,14 @@
       :opt {:watched_files (coerce/vector-of (coerce/hash-map :req {:pattern coerce/string}) :min-count 1)})))
 
 (defn- ext-language-servers [state evaluation-context]
-  (let [{:keys [display-output! rt]} state]
+  (let [{:keys [rt]} state]
     (into
       #{}
       (comp
         (mapcat
           (fn [[path lua-language-servers]]
             (error-handling/try-with-extension-exceptions
-              :display-output! display-output!
+              :rt rt
               :label (str "Reloading language servers in " path)
               :catch []
               (rt/->clj rt language-servers-coercer lua-language-servers))))
@@ -664,18 +666,18 @@
   (coerce/vector-of commands/command-coercer))
 
 (defn- command-handlers [project state evaluation-context]
-  (let [{:keys [display-output! rt]} state]
+  (let [{:keys [rt]} state]
     (into []
           (mapcat
             (fn [[path lua-ret]]
               (error-handling/try-with-extension-exceptions
-                :display-output! display-output!
+                :rt rt
                 :label (str "Reloading commands in " path)
                 :catch nil
                 (eduction
                   (keep (fn [command]
                           (error-handling/try-with-extension-exceptions
-                            :display-output! display-output!
+                            :rt rt
                             :label (str (:label command) " in " path)
                             :catch nil
                             (commands/command->dynamic-handler command path project state))))
@@ -686,9 +688,9 @@
   (handler/register! ::commands :handlers command-handlers))
 
 (defn- prefs-schema [state evaluation-context]
-  (let [{:keys [display-output! rt]} state
+  (let [{:keys [rt]} state
         report-omitted-schema! (fn report-omitted-schema! [path reason]
-                                 (display-output! :err (str "Omitting prefs schema definition for path '" (string/join "." (map name path)) "': " reason)))
+                                 (.println (rt/stderr rt) (str "Omitting prefs schema definition for path '" (string/join "." (map name path)) "': " reason)))
         omit-on-conflict (fn omit-on-conflict [a b path]
                            (if (= a b)
                              a
@@ -698,7 +700,7 @@
          (e/keep
            (fn [[proj-path lua-ret]]
              (error-handling/try-with-extension-exceptions
-               :display-output! display-output!
+               :rt rt
                :label (str "Reloading prefs schema in " proj-path)
                :catch nil
                (prefs/subtract-schemas
@@ -718,12 +720,12 @@
     (prefs/register-project-schema! project-path prefs-schema)))
 
 (defn- dynamic-routes [state evaluation-context]
-  (let [{:keys [display-output! rt]} state]
+  (let [{:keys [rt]} state]
     (->> (execute-all-top-level-functions state :get_http_server_routes nil evaluation-context)
          (e/mapcat
            (fn [[proj-path lua-ret]]
              (error-handling/try-with-extension-exceptions
-               :display-output! display-output!
+               :rt rt
                :label (str "Reloading server routes in " proj-path)
                :catch nil
                (e/map
@@ -736,18 +738,20 @@
                (let [{:keys [handler proj-path]} (routes 0)]
                  (assoc-in acc path+method (vary-meta handler assoc :proj-path proj-path)))
                (do
-                 (display-output! :err (str "Omitting conflicting routes for '"
-                                            method " " path "' defined in "
-                                            (->> routes
-                                                 (map :proj-path)
-                                                 (distinct)
-                                                 sort
-                                                 (util/join-words ", " " and "))))
+                 (-> rt
+                     rt/stderr
+                     (.println
+                       (str "Omitting conflicting routes for '" method " " path "' defined in "
+                            (->> routes
+                                 (map :proj-path)
+                                 (distinct)
+                                 sort
+                                 (util/join-words ", " " and ")))))
                  acc)))
            {}))))
 
 (defn- reload-server-routes! [state dynamic-routes]
-  (let [{:keys [display-output! web-server]} state
+  (let [{:keys [rt web-server]} state
         handler (http-server/handler web-server)]
     (try
       (web-server/set-dynamic-routes! handler dynamic-routes)
@@ -776,8 +780,8 @@
                                                     a-is-dynamic [a-path]
                                                     b-is-dynamic [b-path]
                                                     :else (throw (ex-info "Didn't expect 2 built-in routes to conflict" {:a a-path :b b-path})))]
-                               (display-output!
-                                 :err
+                               (.println
+                                 (rt/stderr rt)
                                  (str "Omitting conflicting routes for "
                                       (util/join-words ", " " and " (map #(str "'" % "'") excluded-paths))
                                       " defined in "
@@ -820,7 +824,7 @@
     (reduced (read-bundle-editor-script))))
 
 (defn- re-create-ext-state [initial-state evaluation-context]
-  (let [{:keys [rt display-output!]} initial-state]
+  (let [{:keys [rt]} initial-state]
     (->> (e/concat
            [@bundle-editor-script-prototype]
            (:library-prototypes initial-state)
@@ -830,16 +834,16 @@
              (cond
                (instance? LuaError x)
                (do
-                 (display-output! :err (str "Compilation failed" (some->> (ex-message x) (str ": "))))
+                 (.println (rt/stderr rt) (str "Compilation failed" (some->> (ex-message x) (str ": "))))
                  acc)
 
                (instance? Prototype x)
                (let [proto-path (.tojstring (.-source ^Prototype x))]
                  (if-let [module (error-handling/try-with-extension-exceptions
-                                   :display-output! display-output!
+                                   :rt rt
                                    :label (str "Loading " proto-path)
                                    :catch nil
-                                   (rt/->clj rt module-coercer (rt/invoke-immediate-1 rt (rt/bind rt x) evaluation-context)))]
+                                   (rt/->clj rt module-coercer (rt/invoke-immediate-1 rt {:evaluation-context evaluation-context} (rt/bind rt x))))]
                    (-> acc
                        (update :all add-all-entry proto-path module)
                        (cond-> (= hooks-file-path proto-path)
@@ -948,7 +952,7 @@
                                   "delete_directory" (make-ext-delete-directory-fn project reload-resources!)
                                   "resource_attributes" (make-ext-resource-attributes-fn project)
                                   "external_file_attributes" (make-ext-external-file-attributes-fn project-path)
-                                  "execute" (make-ext-execute-fn project-path display-output! reload-resources!)
+                                  "execute" (make-ext-execute-fn project-path reload-resources!)
                                   "bob" (make-ext-bob-fn invoke-bob!)
                                   "browse" ext-browse-fn
                                   "open_external_file" ext-open-external-file-fn
@@ -984,7 +988,7 @@
                         "tilemap" tile-map/env
                         "zip" (zip/env project-path reload-resources!)
                         "zlib" zlib/env})
-             _ (rt/invoke-immediate rt (rt/bind rt @prelude-prototype) evaluation-context)
+             _ (rt/invoke-immediate rt {:evaluation-context evaluation-context} (rt/bind rt @prelude-prototype))
              new-state (re-create-ext-state
                          (assoc opts
                            :rt rt
@@ -1041,7 +1045,7 @@
                            :ignore      return nil
                          When not provided, the exception will be re-thrown"
   [project hook-keyword opts & {:keys [exception-policy]}]
-  (g/let-ec [{:keys [rt display-output! hooks] :as state} (ext-state project evaluation-context)]
+  (g/let-ec [{:keys [rt hooks] :as state} (ext-state project evaluation-context)]
     (if-let [lua-fn (get hooks hook-keyword)]
       (-> (rt/invoke-suspending-1 rt lua-fn (rt/->lua opts))
           (future/then
@@ -1051,7 +1055,7 @@
                   (actions/perform! lua-result project state evaluation-context)))))
           (future/catch
             (fn [ex]
-              (error-handling/display-script-error! display-output! (str "hook " (name hook-keyword)) ex)
+              (error-handling/display-script-error! rt (str "hook " (name hook-keyword)) ex)
               (case exception-policy
                 :as-error (hook-exception->error ex project hook-keyword)
                 :ignore nil

--- a/editor/src/clj/editor/editor_extensions/actions.clj
+++ b/editor/src/clj/editor/editor_extensions/actions.clj
@@ -26,7 +26,8 @@
             [editor.lsp.async :as lsp.async]
             [editor.process :as process]
             [editor.workspace :as workspace])
-  (:import [org.luaj.vm2 LuaError]))
+  (:import [java.io PrintStream]
+           [org.luaj.vm2 LuaError]))
 
 (set! *warn-on-reflection* true)
 
@@ -70,18 +71,16 @@
 
   Args
     input-stream       the InputStream to consume
-    display-output!    2-arg function used to display extension-related output
-                       to the user
-    type               display-output!'s type argument, either :err or :out"
-  [input-stream display-output! type]
-  (future
+    out                the PrintStream to write lines to"
+  [input-stream ^PrintStream out]
+  (future/io
     (error-reporting/catch-all!
       (with-open [reader (io/reader input-stream)]
         (doseq [line (line-seq reader)]
-          (display-output! type line))))))
+          (.println out line))))))
 
 (defn- shell! [commands project state]
-  (let [{:keys [reload-resources! display-output!]} state
+  (let [{:keys [reload-resources! rt]} state
         root (lsp.async/with-auto-evaluation-context evaluation-context
                (let [basis (:basis evaluation-context)
                      workspace (project/workspace project evaluation-context)]
@@ -92,8 +91,8 @@
               (fn [cmd+args]
                 (fn start-async-shell-command! []
                   (let [process (doto (apply process/start! {:dir root} cmd+args)
-                                  (-> process/out (input-stream->console display-output! :out))
-                                  (-> process/err (input-stream->console display-output! :err)))]
+                                  (-> process/out (input-stream->console (rt/stdout rt)))
+                                  (-> process/err (input-stream->console (rt/stderr rt))))]
                     (let [exit-code (process/await-exit-code process)]
                       (when-not (zero? exit-code)
                         (throw (ex-info (str "Command \""

--- a/editor/src/clj/editor/editor_extensions/commands.clj
+++ b/editor/src/clj/editor/editor_extensions/commands.clj
@@ -159,7 +159,7 @@
           (rt/wrap-userdata "editor.command(...)")))))
 
 (defn command->dynamic-handler [{:keys [label query active id run locations]} path project state]
-  (let [{:keys [rt display-output!]} state
+  (let [{:keys [rt]} state
         lua-fn->env-fn (compile-query query project)
         contexts (into #{}
                        (map {"Assets" :asset-browser
@@ -195,10 +195,10 @@
                    (lua-fn->env-fn
                      (fn [env opts]
                        (error-handling/try-with-extension-exceptions
-                         :display-output! display-output!
+                         :rt rt
                          :label (str label "'s \"active\" in " path)
                          :catch false
-                         (rt/->clj rt coerce/to-boolean (rt/invoke-immediate-1 (:rt state) active (rt/->lua opts) (:evaluation-context env)))))))
+                         (rt/->clj rt coerce/to-boolean (rt/invoke-immediate-1 (:rt state) {:evaluation-context (:evaluation-context env)} active (rt/->lua opts)))))))
 
             (and (not active) query)
             (assoc :active? (lua-fn->env-fn (constantly true)))
@@ -214,4 +214,4 @@
                                  (when-not (rt/coerces-to? rt coerce/null lua-result)
                                    (lsp.async/with-auto-evaluation-context evaluation-context
                                      (actions/perform! lua-result project state evaluation-context)))))
-                             (future/catch #(error-handling/display-script-error! display-output! error-label %))))))))))
+                             (future/catch #(error-handling/display-script-error! rt error-label %))))))))))

--- a/editor/src/clj/editor/editor_extensions/error_handling.clj
+++ b/editor/src/clj/editor/editor_extensions/error_handling.clj
@@ -13,24 +13,25 @@
 ;; specific language governing permissions and limitations under the License.
 
 (ns editor.editor-extensions.error-handling
-  (:require [clojure.spec.alpha :as s])
+  (:require [clojure.spec.alpha :as s]
+            [editor.editor-extensions.runtime :as rt])
   (:import [org.luaj.vm2 OrphanedThread]))
 
 (set! *warn-on-reflection* true)
 
 (defn display-script-error!
   "Submit labeled error message from the exception to the display output"
-  [display-output! label ex]
-  (display-output! :err (str label " failed: " (or (ex-message ex) (.getSimpleName (class ex))))))
+  [rt label ex]
+  (.println (rt/stderr rt) (str label " failed: " (or (ex-message ex) (.getSimpleName (class ex))))))
 
 (s/fdef try-with-extension-exceptions
-        :args (s/cat :kv-args (s/+ (s/cat :k #{:display-output! :label :catch} :v any?)) :expr any?))
+        :args (s/cat :kv-args (s/+ (s/cat :k #{:rt :label :catch} :v any?)) :expr any?))
 (defmacro try-with-extension-exceptions
   "Convenience macro for executing an expression and reporting extension errors
   to the console
 
   Leading kv-args:
-    :display-output!    required, 2-arg fn to display error output
+    :rt                 required, runtime used to print error output
     :label              optional, string error prefix, defaults to \"Extension\"
     :catch              optional, result value in case of exceptions (otherwise
                         the Exception is re-thrown)"
@@ -38,11 +39,11 @@
   (let [opts (apply hash-map (butlast kv-args+expr))
         expr (last kv-args+expr)
         ex-sym (gensym "ex")]
-    (when-not (:display-output! opts)
-      (throw (Exception. ":display-output! is required")))
+    (when-not (:rt opts)
+      (throw (Exception. ":rt is required")))
     `(try
        ~expr
        (catch OrphanedThread ~ex-sym (throw ~ex-sym))
        (catch Throwable ~ex-sym
-         (display-script-error! ~(:display-output! opts) ~(:label opts "Extension") ~ex-sym)
+         (display-script-error! ~(:rt opts) ~(:label opts "Extension") ~ex-sym)
          ~(:catch opts `(throw ~ex-sym))))))

--- a/editor/src/clj/editor/editor_extensions/runtime.clj
+++ b/editor/src/clj/editor/editor_extensions/runtime.clj
@@ -47,16 +47,17 @@
   (:refer-clojure :exclude [read])
   (:require [cljfx.api :as fx]
             [clojure.java.io :as io]
+            [clojure.string :as string]
             [dynamo.graph :as g]
             [editor.editor-extensions.coerce :as coerce]
             [editor.editor-extensions.vm :as vm]
             [editor.future :as future]
             [editor.resource :as resource]
             editor.workspace)
-  (:import [com.defold.editor.luart DefoldBaseLib DefoldCoroutine$Create DefoldCoroutine$Yield DefoldIoLib DefoldUserdata DefoldLuaFn DefoldVarargsLuaFn SearchPath]
-           [editor.resource FileResource ZipResource MemoryResource]
+  (:import [com.defold.editor.luart DefoldBaseLib DefoldCoroutine$Create DefoldCoroutine$Yield DefoldIoLib DefoldLuaFn DefoldUserdata DefoldVarargsLuaFn DynamicWriter SearchPath]
+           [editor.resource FileResource MemoryResource ZipResource]
            [editor.workspace BuildResource]
-           [java.io File PrintStream Writer]
+           [java.io File PrintStream]
            [java.nio.charset StandardCharsets]
            [org.apache.commons.io.output WriterOutputStream]
            [org.luaj.vm2 LoadState LuaError LuaFunction LuaString LuaTable LuaValue OrphanedThread Varargs]
@@ -294,8 +295,8 @@
   ([x string-representation]
    (DefoldUserdata. x string-representation)))
 
-(defn- writer->print-stream [^Writer writer]
-  (-> writer
+(defn- writer->print-stream [override-key default-writer]
+  (-> (DynamicWriter. #(get *execution-context* override-key default-writer))
       (WriterOutputStream. StandardCharsets/UTF_8)
       (PrintStream. true StandardCharsets/UTF_8)))
 
@@ -365,8 +366,8 @@
                   (.load (JseOsLib.))
                   (LoadState/install)
                   (LuaC/install)
-                  (-> .-STDOUT (set! (writer->print-stream out)))
-                  (-> .-STDERR (set! (writer->print-stream err))))
+                  (-> .-STDOUT (set! (writer->print-stream :override-out out)))
+                  (-> .-STDERR (set! (writer->print-stream :override-err err))))
         package (.get globals "package")
         ;; Before splitting the coroutine module into 2 contexts (user and
         ;; system), we override the coroutine.create() function with a one that
@@ -427,9 +428,7 @@
                   (fn [result]
                     (if (refresh-context? result)
                       (let [update-cache! (bound-fn* g/update-cache-from-evaluation-context!)
-                            new-context {:evaluation-context (g/make-evaluation-context)
-                                         :rt runtime
-                                         :mode :suspendable}]
+                            new-context (assoc execution-context :evaluation-context (g/make-evaluation-context))]
                         (fx/on-fx-thread (update-cache! (:evaluation-context execution-context)))
                         (invoke-suspending-impl new-context runtime co (vm/wrap-userdata result)))
                       (invoke-suspending-impl execution-context runtime co (vm/wrap-userdata result))))))))
@@ -445,6 +444,23 @@
   ^PrintStream [^EditorExtensionsRuntime rt]
   (.-STDERR (vm/env (.-lua-vm rt))))
 
+(defn- parse-invoke-args [args]
+  (let [first-arg (first args)
+        has-opts (map? first-arg)
+        opts (if has-opts first-arg {})
+        args (if has-opts (next args) args)]
+    (when (empty? args)
+      (throw (IllegalArgumentException. "Lua function is required")))
+    {:opts opts
+     :lua-fn (first args)
+     :lua-args (next args)}))
+
+(defn- execution-context [runtime mode opts]
+  (-> opts
+      (assoc :rt runtime :mode mode)
+      (cond-> (not (contains? opts :evaluation-context))
+              (assoc :evaluation-context (g/make-evaluation-context)))))
+
 (defn invoke-suspending
   "Invoke a potentially long-running LuaFunction
 
@@ -454,11 +470,11 @@
   Runtime will start invoking the LuaFunction on the calling thread, then will
   move the execution to background threads if necessary. This means that
   invoke-suspending might return a completed CompletableFuture"
-  [^EditorExtensionsRuntime runtime lua-fn & lua-args]
-  (let [co (vm/invoke-1 (.-lua-vm runtime) (.-create runtime) lua-fn)
-        execution-context {:evaluation-context (g/make-evaluation-context)
-                           :rt runtime
-                           :mode :suspendable}]
+  {:arglists '([rt opts? lua-fn & lua-args])}
+  [^EditorExtensionsRuntime runtime & args]
+  (let [{:keys [opts lua-fn lua-args]} (parse-invoke-args args)
+        co (vm/invoke-1 (.-lua-vm runtime) (.-create runtime) lua-fn)
+        execution-context (execution-context runtime :suspendable opts)]
     (apply invoke-suspending-impl execution-context runtime co lua-args)))
 
 (defn invoke-suspending-1
@@ -470,20 +486,19 @@
   Runtime will start invoking the LuaFunction on the calling thread, then will
   move the execution to background threads if necessary. This means that
   invoke-suspending might return a completed CompletableFuture"
-  [^EditorExtensionsRuntime runtime lua-fn & lua-args]
+  {:arglists '([rt opts? lua-fn & lua-args])}
+  [^EditorExtensionsRuntime runtime & args]
   (future/then
-    (apply invoke-suspending runtime lua-fn lua-args)
+    (apply invoke-suspending runtime args)
     #(.arg1 ^Varargs %)))
 
-(defn- invoke-immediate-impl [^EditorExtensionsRuntime runtime vm-invoke-fn lua-fn lua-args evaluation-context]
-  (let [context-provided (some? evaluation-context)
-        evaluation-context (or evaluation-context (g/make-evaluation-context))
-        result (binding [*execution-context* {:evaluation-context evaluation-context
-                                              :rt runtime
-                                              :mode :immediate}]
+(defn- invoke-immediate-impl [^EditorExtensionsRuntime runtime opts vm-invoke-fn lua-fn lua-args]
+  (let [context-provided (contains? opts :evaluation-context)
+        execution-context (execution-context runtime :immediate opts)
+        result (binding [*execution-context* execution-context]
                  (apply vm-invoke-fn (.-lua-vm runtime) lua-fn lua-args))]
     (when-not context-provided
-      (g/update-cache-from-evaluation-context! evaluation-context))
+      (g/update-cache-from-evaluation-context! (:evaluation-context execution-context)))
     result))
 
 (defn invoke-immediate-1
@@ -494,16 +509,14 @@
 
   Args:
     runtime                the editor Lua runtime
+    opts                   optional map with :evaluation-context, :override-out
+                           and/or :override-err
     lua-fn                 LuaFunction to invoke
-    lua-args*              0 or more LuaValue arguments
-    evaluation-context?    optional evaluation context for the execution"
-  {:arglists '([runtime lua-fn lua-args* evaluation-context?])}
-  [runtime lua-fn & rest-args]
-  (let [last-arg (last rest-args)
-        context-provided (g/evaluation-context? last-arg)
-        evaluation-context (when context-provided last-arg)
-        lua-args (if context-provided (butlast rest-args) rest-args)]
-    (invoke-immediate-impl runtime vm/invoke-1 lua-fn lua-args evaluation-context)))
+    lua-args*              0 or more LuaValue arguments"
+  {:arglists '([rt opts? lua-fn & lua-args])}
+  [runtime & args]
+  (let [{:keys [opts lua-fn lua-args]} (parse-invoke-args args)]
+    (invoke-immediate-impl runtime opts vm/invoke-1 lua-fn lua-args)))
 
 (defn invoke-immediate
   "Invoke a short-running LuaFunction
@@ -513,16 +526,14 @@
 
   Args:
     runtime                the editor Lua runtime
+    opts                   optional map with :evaluation-context, :override-out
+                           and/or :override-err
     lua-fn                 LuaFunction to invoke
-    lua-args*              0 or more LuaValue arguments
-    evaluation-context?    optional evaluation context for the execution"
-  {:arglists '([runtime lua-fn lua-args* evaluation-context?])}
-  [^EditorExtensionsRuntime runtime lua-fn & rest-args]
-  (let [last-arg (last rest-args)
-        context-provided (g/evaluation-context? last-arg)
-        evaluation-context (when context-provided last-arg)
-        lua-args (if context-provided (butlast rest-args) rest-args)]
-    (invoke-immediate-impl runtime vm/invoke lua-fn lua-args evaluation-context)))
+    lua-args*              0 or more LuaValue arguments"
+  {:arglists '([rt opts? lua-fn & lua-args])}
+  [^EditorExtensionsRuntime runtime & args]
+  (let [{:keys [opts lua-fn lua-args]} (parse-invoke-args args)]
+    (invoke-immediate-impl runtime opts vm/invoke lua-fn lua-args)))
 
 (defn eq?
   "Checks 2 lua values for equality, with metadata processing"

--- a/editor/src/clj/editor/editor_extensions/server.clj
+++ b/editor/src/clj/editor/editor_extensions/server.clj
@@ -36,6 +36,8 @@
         output (StringWriter.)
         rt (:rt (g/with-auto-evaluation-context evaluation-context
                   (extensions/ext-state project evaluation-context)))]
+    (when-not rt
+      (throw (http-server/error (http-server/response 503 "Editor extension runtime is not ready\n"))))
     (-> rt
         (rt/invoke-suspending {:override-out output :override-err output} (rt/bind rt prototype))
         (future/then

--- a/editor/src/clj/editor/editor_extensions/server.clj
+++ b/editor/src/clj/editor/editor_extensions/server.clj
@@ -1,0 +1,65 @@
+;; Copyright 2020-2026 The Defold Foundation
+;; Copyright 2014-2020 King
+;; Copyright 2009-2014 Ragnar Svensson, Christian Murray
+;; Licensed under the Defold License version 1.0 (the "License"); you may not use
+;; this file except in compliance with the License.
+;;
+;; You may obtain a copy of the License, together with FAQs at
+;; https://www.defold.com/license
+;;
+;; Unless required by applicable law or agreed to in writing, software distributed
+;; under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+;; CONDITIONS OF ANY KIND, either express or implied. See the License for the
+;; specific language governing permissions and limitations under the License.
+
+(ns editor.editor-extensions.server
+  (:require [dynamo.graph :as g]
+            [editor.editor-extensions :as extensions]
+            [editor.editor-extensions.runtime :as rt]
+            [editor.future :as future]
+            [editor.web-server :as web-server]
+            [util.http-server :as http-server])
+  (:import [java.io StringWriter]
+           [org.luaj.vm2 LuaError Varargs]))
+
+(set! *warn-on-reflection* true)
+
+(defn- error-text [e]
+  (or (ex-message e) (.getSimpleName (class e))))
+
+(defn- eval-request [request project token]
+  (web-server/require-authorized! request token)
+  (let [prototype (try
+                    (-> request :body slurp (rt/read "eval"))
+                    (catch LuaError e
+                      (throw (http-server/error (http-server/response 422 (error-text e))))))
+        output (StringWriter.)
+        rt (:rt (g/with-auto-evaluation-context evaluation-context
+                  (extensions/ext-state project evaluation-context)))]
+    (-> rt
+        (rt/invoke-suspending {:override-out output :override-err output} (rt/bind rt prototype))
+        (future/then
+          (fn [^Varargs varargs]
+            (dotimes [i (.narg varargs)]
+              (doto output
+                (.append "=> ")
+                (.append (str (.arg varargs (inc i))))
+                (.append \newline)))
+            (http-server/response 200 (str output))))
+        (future/catch
+          (fn [e]
+            (if (instance? LuaError e)
+              (http-server/response 422 (str output (error-text e)))
+              (throw e)))))))
+
+(defn routes [project token]
+  {"/eval" {"POST" (with-meta
+                     (bound-fn [request] (eval-request request project token))
+                     {:openapi {:summary "Evaluate Lua code in the editor extension runtime"
+                                :security [{"token" []}]
+                                :requestBody {:required true
+                                              :content {"text/plain" {:example "print('hi') return 1, 2"}}}
+                                :responses {"200" {:description "Printed output + returned values"
+                                                   :content {"text/plain" {:example "hi\n=> 1\n=> 2"}}}
+                                            "401" {:description "Missing or invalid bearer token"}
+                                            "422" {:description "Printed output + error"}}}})}})

--- a/editor/src/clj/editor/editor_extensions/ui_components.clj
+++ b/editor/src/clj/editor/editor_extensions/ui_components.clj
@@ -1039,7 +1039,7 @@
 
 (defn- invoke-with-hooks [component-atom rt lua-fn lua-props]
   (binding [*current-component-atom* component-atom]
-    (let [ret (rt/invoke-immediate-1 rt lua-fn lua-props (lifecycle-evaluation-context))
+    (let [ret (rt/invoke-immediate-1 rt {:evaluation-context (lifecycle-evaluation-context)} lua-fn lua-props)
           {:keys [hooks current-hook-index]} @component-atom]
       (swap! component-atom assoc :current-hook-index 0)
       (when (< current-hook-index (count hooks))
@@ -1164,7 +1164,7 @@
               (case (key type+dependencies)
                 :value (val type+dependencies)
                 :function (let [lua-fn+lua-args (val type+dependencies)]
-                            (apply rt/invoke-immediate-1 rt (lua-fn+lua-args 0) (conj (subvec lua-fn+lua-args 1) evaluation-context)))))
+                            (apply rt/invoke-immediate-1 rt {:evaluation-context evaluation-context} (lua-fn+lua-args 0) (subvec lua-fn+lua-args 1)))))
             (eq-type+dependencies? [rt a b]
               (let [t (key a)]
                 (and (= t (key b))
@@ -1185,8 +1185,8 @@
                             lua-args (subvec lua-fn+lua-args 1)]
                         (update-hook-state! component-atom hook-index true update :current
                                             (fn [old-lua-value]
-                                              (apply rt/invoke-immediate-1 rt lua-fn
-                                                     (conj (into [old-lua-value] lua-args) evaluation-context))))))))))]
+                                              (apply rt/invoke-immediate-1 rt {:evaluation-context evaluation-context} lua-fn
+                                                     (into [old-lua-value] lua-args))))))))))]
       (make-hook
         (:name ui-docs/use-state-doc)
         :create (fn create-use-hook-state [component-atom {:keys [rt current-hook-index]} evaluation-context & lua-args]
@@ -1213,13 +1213,13 @@
     :create (fn create-use-memo-state [_ {:keys [rt]} evaluation-context & lua-args]
               (let [deps (vec lua-args)]
                 {:dependencies deps
-                 :value (apply rt/invoke-immediate rt (conj deps evaluation-context))}))
+                 :value (apply rt/invoke-immediate rt {:evaluation-context evaluation-context} deps)}))
     :advance (fn advance-use-memo-state [{:keys [rt]} hook-state evaluation-context & lua-args]
                (let [new-dependencies (vec lua-args)]
                  (if (vectors-with-eq-lua-values? rt new-dependencies (:dependencies hook-state))
                    hook-state
                    {:dependencies new-dependencies
-                    :value (apply rt/invoke-immediate rt (conj new-dependencies evaluation-context))})))
+                    :value (apply rt/invoke-immediate rt {:evaluation-context evaluation-context} new-dependencies)})))
     :return :value))
 
 ;; endregion

--- a/editor/src/clj/editor/web_server.clj
+++ b/editor/src/clj/editor/web_server.clj
@@ -20,9 +20,27 @@
             [reitit.core :as reitit]
             [util.coll :as coll]
             [util.http-server :as http-server])
-  (:import [org.apache.commons.io FilenameUtils]))
+  (:import [java.nio.charset StandardCharsets]
+           [java.security MessageDigest SecureRandom]
+           [java.util Base64]
+           [org.apache.commons.io FilenameUtils]))
 
 (set! *warn-on-reflection* true)
+
+(defn make-token []
+  (let [bytes (byte-array 32)]
+    (.nextBytes (SecureRandom.) bytes)
+    (-> (Base64/getUrlEncoder)
+        (.withoutPadding)
+        (.encodeToString bytes))))
+
+(defn require-authorized! [request token]
+  (let [^String authorization (get-in request [:headers "authorization"])]
+    (when-not (and authorization
+                   (MessageDigest/isEqual
+                     (.getBytes (str "Bearer " token) StandardCharsets/UTF_8)
+                     (.getBytes authorization StandardCharsets/UTF_8)))
+      (throw (http-server/error (http-server/response 401 {"www-authenticate" "Bearer"} "Unauthorized\n"))))))
 
 (defn- openapi-paths [router]
   (coll/into-> (reitit/routes router) {}
@@ -41,6 +59,10 @@
     {:openapi "3.0.3"
      :info {:title "Defold Editor HTTP API"
             :version "1.0"}
+     :components {:securitySchemes {"token" {:type "http"
+                                             :scheme "bearer"
+                                             :bearerFormat "opaque"
+                                             :description "Read per-session token from `.internal/editor.token`, then send it as `Authorization: Bearer <token>`."}}}
      :paths (openapi-paths (:router request))}))
 
 (defn- html-escape [s]

--- a/editor/src/clj/editor/web_server.clj
+++ b/editor/src/clj/editor/web_server.clj
@@ -35,11 +35,11 @@
         (.encodeToString bytes))))
 
 (defn require-authorized! [request token]
-  (let [^String authorization (get-in request [:headers "authorization"])]
-    (when-not (and authorization
+  (let [authorization (get-in request [:headers "authorization"])]
+    (when-not (and (string? authorization)
                    (MessageDigest/isEqual
                      (.getBytes (str "Bearer " token) StandardCharsets/UTF_8)
-                     (.getBytes authorization StandardCharsets/UTF_8)))
+                     (.getBytes ^String authorization StandardCharsets/UTF_8)))
       (throw (http-server/error (http-server/response 401 {"www-authenticate" "Bearer"} "Unauthorized\n"))))))
 
 (defn- openapi-paths [router]

--- a/editor/src/java/com/defold/editor/luart/DynamicWriter.java
+++ b/editor/src/java/com/defold/editor/luart/DynamicWriter.java
@@ -1,0 +1,44 @@
+// Copyright 2020-2026 The Defold Foundation
+// Copyright 2014-2020 King
+// Copyright 2009-2014 Ragnar Svensson, Christian Murray
+// Licensed under the Defold License version 1.0 (the "License"); you may not use
+// this file except in compliance with the License.
+//
+// You may obtain a copy of the License, together with FAQs at
+// https://www.defold.com/license
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package com.defold.editor.luart;
+
+import clojure.lang.IFn;
+
+import java.io.IOException;
+import java.io.Writer;
+
+public final class DynamicWriter extends Writer {
+
+    private final IFn writerFn;
+
+    public DynamicWriter(IFn writerFn) {
+        this.writerFn = writerFn;
+    }
+
+    @Override
+    public void write(char[] cbuf, int off, int len) throws IOException {
+        ((Writer) writerFn.invoke()).write(cbuf, off, len);
+    }
+
+    @Override
+    public void flush() throws IOException {
+        ((Writer) writerFn.invoke()).flush();
+    }
+
+    @Override
+    public void close() throws IOException {
+        ((Writer) writerFn.invoke()).flush();
+    }
+}

--- a/editor/test/integration/editor_extensions_test.clj
+++ b/editor/test/integration/editor_extensions_test.clj
@@ -23,6 +23,7 @@
             [editor.editor-extensions.graph :as graph]
             [editor.editor-extensions.prefs-functions :as prefs-functions]
             [editor.editor-extensions.runtime :as rt]
+            [editor.editor-extensions.server :as ext.server]
             [editor.editor-extensions.vm :as vm]
             [editor.future :as future]
             [editor.graph-util :as gu]
@@ -42,9 +43,11 @@
             [util.coll :as coll]
             [util.diff :as diff]
             [util.eduction :as e]
+            [util.http-client :as http]
             [util.http-server :as http-server]
             [util.path :as path])
-  (:import [java.nio.file.attribute PosixFilePermission]
+  (:import [java.io StringWriter]
+           [java.nio.file.attribute PosixFilePermission]
            [java.util.zip ZipEntry]
            [org.apache.commons.compress.archivers.zip ZipArchiveInputStream]
            [org.luaj.vm2 LuaError]))
@@ -70,7 +73,7 @@
       (dotimes [i iterations]
         (let [results (->> (fn []
                              (future
-                               (->> #(rt/invoke-immediate-1 rt lua-inc-and-get ec)
+                               (->> #(rt/invoke-immediate-1 rt {:evaluation-context ec} lua-inc-and-get)
                                     (repeatedly per-thread-calls)
                                     (vec))))
                            (repeatedly threads)
@@ -227,6 +230,40 @@
               ;; updated value
               2]
              (rt/->clj rt @(rt/invoke-suspending-1 rt lua-fn)))))))
+
+(deftest output-overrides-route-to-the-current-suspending-execution
+  (test-support/with-clean-system
+    (let [default-out (StringWriter.)
+          default-err (StringWriter.)
+          override-out (StringWriter.)
+          override-err (StringWriter.)
+            rt (rt/make
+                 :out default-out
+                 :err default-err
+                 :env {"suspend" (rt/suspendable-lua-fn [_]
+                                    (future/io (Thread/sleep 10)))
+                       "with_output_override" (rt/suspendable-lua-fn [{:keys [rt]} f]
+                                                (rt/invoke-suspending-1 rt {:override-out override-out
+                                                                            :override-err override-err}
+                                                                        f))})]
+        (->> (rt/read "print('default before')
+	                     io.stderr:write('default err before\\n')
+	                     with_output_override(function()
+	                       print('override')
+	                       io.stderr:write('override err\\n')
+	                       suspend()
+	                       print('override after')
+	                       io.stderr:write('override err after\\n')
+	                     end)
+	                     print('default after')
+	                     io.stderr:write('default err after\\n')")
+             (rt/bind rt)
+             (rt/invoke-suspending-1 rt)
+             (deref))
+        (is (= "default before\ndefault after\n" (.toString default-out)))
+        (is (= "default err before\ndefault err after\n" (.toString default-err)))
+        (is (= "override\noverride after\n" (.toString override-out)))
+        (is (= "override err\noverride err after\n" (.toString override-err))))))
 
 
 (deftest suspending-lua-failure-test
@@ -1324,6 +1361,65 @@ openapi route has 200 => true
                                 :web-server server)
         (run-edit-menu-test-command!)
         (expect-script-output expected-http-server-test-output out)))))
+
+(deftest eval-route-test
+  (test-util/with-loaded-project
+    (let [token "test-token"
+          handler (web-server/make-dynamic-handler (ext.server/routes project token))
+          displayed-output (atom [])]
+      (with-open [server (http-server/start! handler)]
+        (let [eval-lua! (fn eval-lua! [body]
+                          @(http/request (str (http-server/local-url server) "/eval")
+                                         :method "POST"
+                                         :headers {"authorization" (str "Bearer " token)}
+                                         :body body
+                                         :as :string))]
+          (reload-editor-scripts! project
+                                  :display-output! #(swap! displayed-output conj [%1 %2])
+                                  :web-server server)
+          (testing "Requires bearer token."
+            (let [{:keys [status headers body]} @(http/request (str (http-server/local-url server) "/eval") :method "POST" :body "return 1" :as :string)]
+              (is (= 401 status))
+              (is (= "Bearer" (get headers "www-authenticate")))
+              (is (= "Unauthorized\n" body)))
+            (let [{:keys [status]} @(http/request (str (http-server/local-url server) "/eval")
+                                                  :method "POST"
+                                                  :headers {"authorization" "Bearer wrong-token"}
+                                                  :body "return 1"
+                                                  :as :string)]
+              (is (= 401 status))))
+          (testing "Prints and returned values."
+            (let [{:keys [status headers body]} (eval-lua! "print('hello')\nio.stderr:write('err\\n')\nreturn 1, 'x', true")]
+              (is (= 200 status))
+              (is (= "text/plain; charset=utf-8" (get headers "content-type")))
+              (is (= "hello\nerr\n=> 1\n=> x\n=> true\n" body))))
+          (testing "Return with no values."
+            (let [{:keys [status body]} (eval-lua! "return")]
+              (is (= 200 status))
+              (is (= "" body))))
+          (testing "Return nil."
+            (let [{:keys [status body]} (eval-lua! "return nil")]
+              (is (= 200 status))
+              (is (= "=> nil\n" body))))
+          (testing "Compile errors."
+            (let [{:keys [status body]} (eval-lua! "return function(")]
+              (is (= 422 status))
+              (is (not (string/blank? body)))))
+          (testing "Runtime errors include previous output."
+            (let [{:keys [status body]} (eval-lua! "print('before')\nerror('boom')")]
+              (is (= 422 status))
+              (is (string/starts-with? body "before\n"))
+              (is (string/includes? body "boom"))))
+          (testing "Suspending editor functions retain output capture."
+            (let [{:keys [status body]} (eval-lua! "return editor.execute('git', 'status', {out = 'capture'})")]
+              (is (= 200 status))
+              (is (string/starts-with? body "=> "))))
+          (testing "Output is captured in the response only."
+            (reset! displayed-output [])
+            (let [{:keys [status body]} (eval-lua! "print('captured')")]
+              (is (= 200 status))
+              (is (= "captured\n" body))
+              (is (= [] @displayed-output)))))))))
 
 (deftest property-availability-test
   (test-util/with-loaded-project "test/resources/editor_extensions/property_availability_project"

--- a/editor/test/integration/editor_extensions_test.clj
+++ b/editor/test/integration/editor_extensions_test.clj
@@ -1374,6 +1374,10 @@ openapi route has 200 => true
                                          :headers {"authorization" (str "Bearer " token)}
                                          :body body
                                          :as :string))]
+          (testing "Requires initialized editor extension runtime."
+            (let [{:keys [status body]} (eval-lua! "return 1")]
+              (is (= 503 status))
+              (is (= "Editor extension runtime is not ready\n" body))))
           (reload-editor-scripts! project
                                   :display-output! #(swap! displayed-output conj [%1 %2])
                                   :web-server server)

--- a/editor/test/integration/web_server_test.clj
+++ b/editor/test/integration/web_server_test.clj
@@ -307,6 +307,8 @@
               (is (= "application/json" (get headers "content-type")))
               (let [json-body (json/read-str body)]
                 (is (= "3.0.3" (get json-body "openapi")))
+                (is (= "Read per-session token from `.internal/editor.token`, then send it as `Authorization: Bearer <token>`."
+                       (get-in json-body ["components" "securitySchemes" "token" "description"])))
                 (is (contains? (get json-body "paths") "/console"))
                 (is (contains? (get json-body "paths") "/console/stream"))
                 (let [post-command (get-in json-body ["paths" "/command/{command}" "post"])]


### PR DESCRIPTION
Now, the editor exposes a local, authenticated `/eval` endpoint for evaluating Lua code in the editor Lua runtime.

Simplest example:

```sh
curl \
  "http://localhost:$(cat .internal/editor.port)/eval" \
  -H "Authorization: Bearer $(cat .internal/editor.token)" \
  --data "print('Hello from Lua') return 1, 'two', true"
# Hello from Lua
# => 1
# => two
# => true
```

Because `/eval` can run commands through `editor.execute`, requests must include the token from `.internal/editor.token`. This limits access to clients that also have filesystem access.

```sh
curl \
  "http://localhost:$(cat .internal/editor.port)/eval" \
  -H "Authorization: Bearer $(cat .internal/editor.token)" \
  --data "editor.execute('git', 'status', '--short', { reload_resources = false })"
#  M game.project
```

Security is documented in `openapi.json`, so the only URL your coding agent needs is still `http://localhost:$(cat .internal/editor.port)/openapi.json`. For example:
```md
› use /eval endpoint and make a short report about the available functionality
• Thinking...
• Short Report

  `/eval` evaluates raw Lua in the Defold editor extension runtime.

  Available runtime functionality includes:

  - Standard Lua globals: `assert`, `pcall`, `load`, `require`, `io`, `os`, 
    `math`, `string`, `table`, `coroutine`, etc.
  - Defold editor API via `editor`, including:
      - resource inspection: `editor.resource_attributes`,
        `editor.properties`, `editor.get`
      - resource/project mutation APIs: `editor.transact`, 
        `editor.tx.set`/`add`/`remove`/`reorder`/`reset`/`clear`, `editor.save`
      - filesystem helpers: `editor.create_directory`, `editor.delete_directory`, 
       `editor.create_resources`
      - external command execution: `editor.execute`
      - browser/file helpers: `editor.browse`, `editor.open_external_file`,
        `editor.external_file_attributes`
      - UI construction/dialog APIs under `editor.ui`
      - preferences via `editor.prefs.get`/`set`/`is_set`
  - HTTP APIs via `http`, including `http.request` and `http.server.route`/`response`
  - Utility modules: `json.encode`/`decode`, `zip.pack`/`unpack`, 
    `zlib.deflate`/`inflate`, `localization`.
```

Fix #11995