### PR TITLE
Fix for calculating multiline text height

### DIFF
--- a/engine/font/src/text_layout_legacy.cpp
+++ b/engine/font/src/text_layout_legacy.cpp
@@ -224,7 +224,7 @@ TextResult TextLayoutLegacyCreate(HFontCollection collection,
     float scale = FontGetScaleFromSize(font, settings->m_Size);
 
     uint32_t ascent = (uint32_t)FontGetAscent(font, 1.0f);
-    uint32_t descent = (uint32_t)FontGetDescent(font, 1.0f); // positive value
+    uint32_t descent = (uint32_t)fabsf(FontGetDescent(font, 1.0f)); // positive value
     uint32_t line_height = ascent + descent;
     float line_height_scaled = line_height * scale;
     float tracking = line_height_scaled * settings->m_Tracking;


### PR DESCRIPTION
Legacy text metrics calculation is now using the correct descent value.
It fixes wrongly spaced lines.