### PR TITLE
Contain the html5 splash image to the canvas 

### DIFF
--- a/engine/engine/content/builtins/manifests/web/dark_theme.css
+++ b/engine/engine/content/builtins/manifests/web/dark_theme.css
@@ -76,9 +76,10 @@
 	}
 
 	.canvas-app-canvas {
-		background-repeat:no-repeat;
+		background-repeat: no-repeat;
 		background-position: center center;
 {{#DEFOLD_SPLASH_IMAGE}}
+		background-size: contain;
 		background-image: url("{{DEFOLD_SPLASH_IMAGE}}");
 {{/DEFOLD_SPLASH_IMAGE}}
 {{^DEFOLD_SPLASH_IMAGE}}

--- a/engine/engine/content/builtins/manifests/web/light_theme.css
+++ b/engine/engine/content/builtins/manifests/web/light_theme.css
@@ -76,9 +76,10 @@
 	}
 
 	.canvas-app-canvas {
-		background-repeat:no-repeat;
+		background-repeat: no-repeat;
 		background-position: center center;
 {{#DEFOLD_SPLASH_IMAGE}}
+		background-size: contain;
 		background-image: url("{{DEFOLD_SPLASH_IMAGE}}");
 {{/DEFOLD_SPLASH_IMAGE}}
 {{^DEFOLD_SPLASH_IMAGE}}


### PR DESCRIPTION
The default behaviour of the HTML5 splash image has changed to be contained within the canvas area. It was already configured to be centered in the canvas and set to not repeat, and containing it will likely make sense in the majority of use cases. Should this not be the case it is possible to change by copying the css file from builtins.

Fixes #7882 
