### PR TITLE
Add a LUA reference for constant buffers involved in a render.draw command

### DIFF
--- a/engine/render/src/render/render_script.cpp
+++ b/engine/render/src/render/render_script.cpp
@@ -1885,11 +1885,7 @@ namespace dmRender
                 {
                     AddConstantBufferRef(L, i);
                 }
-                else
-                {
-                    lua_pop(L, 1);
-                }
-                lua_pop(L, 1);
+                lua_pop(L, 2);
             }
             else if (lua_isuserdata(L, 2)) // Deprecated
             {
@@ -3110,11 +3106,7 @@ namespace dmRender
                 {
                     AddConstantBufferRef(L, i);
                 }
-                else
-                {
-                    lua_pop(L, 1);
-                }
-                lua_pop(L, 1);
+                lua_pop(L, 2);
             }
             return 0;
         }

--- a/engine/render/src/render/render_script.cpp
+++ b/engine/render/src/render/render_script.cpp
@@ -1830,7 +1830,20 @@ namespace dmRender
             lua_pop(L, 1);
 
             lua_getfield(L, -1, "constants");
-            constant_buffer = lua_isnil(L, -1) ? 0 : *RenderScriptConstantBuffer_Check(L, -1);
+            if (!lua_isnil(L, -1))
+            {
+                constant_buffer = *RenderScriptConstantBuffer_Check(L, -1);
+                // Take a Lua registry reference to prevent the constant buffer
+                // userdata from being garbage collected while the draw command
+                // is queued. The reference is released after ParseCommands.
+                lua_pushvalue(L, -1);
+                int ref = dmScript::Ref(L, LUA_REGISTRYINDEX);
+                if (i->m_ConstantBufferLuaRefs.Full())
+                {
+                    i->m_ConstantBufferLuaRefs.OffsetCapacity(16);
+                }
+                i->m_ConstantBufferLuaRefs.Push(ref);
+            }
             lua_pop(L, 1);
 
             lua_getfield(L, -1, "sort_order");
@@ -1847,6 +1860,14 @@ namespace dmRender
             dmLogOnceWarning("This interface for render.draw() is deprecated. Please see documentation at https://defold.com/ref/stable/render/#render.draw:predicate-[constants]")
             HNamedConstantBuffer* tmp = RenderScriptConstantBuffer_Check(L, 2);
             constant_buffer = *tmp;
+            // Take a Lua registry reference (same reason as the options table path above).
+            lua_pushvalue(L, 2);
+            int ref = dmScript::Ref(L, LUA_REGISTRYINDEX);
+            if (i->m_ConstantBufferLuaRefs.Full())
+            {
+                i->m_ConstantBufferLuaRefs.OffsetCapacity(16);
+            }
+            i->m_ConstantBufferLuaRefs.Push(ref);
         }
 
         // we need to pass ownership to the command queue
@@ -3048,7 +3069,17 @@ namespace dmRender
             lua_pushvalue(L, 4);
 
             lua_getfield(L, -1, "constants");
-            constant_buffer = lua_isnil(L, -1) ? 0 : *RenderScriptConstantBuffer_Check(L, -1);
+            if (!lua_isnil(L, -1))
+            {
+                constant_buffer = *RenderScriptConstantBuffer_Check(L, -1);
+                lua_pushvalue(L, -1);
+                int ref = dmScript::Ref(L, LUA_REGISTRYINDEX);
+                if (i->m_ConstantBufferLuaRefs.Full())
+                {
+                    i->m_ConstantBufferLuaRefs.OffsetCapacity(16);
+                }
+                i->m_ConstantBufferLuaRefs.Push(ref);
+            }
             lua_pop(L, 1);
 
             lua_pop(L, 1);
@@ -3572,6 +3603,19 @@ bail:
         return i;
     }
 
+    static void ReleaseConstantBufferLuaRefs(HRenderScriptInstance instance)
+    {
+        if (instance->m_ConstantBufferLuaRefs.Size() > 0)
+        {
+            lua_State* L = instance->m_RenderContext->m_RenderScriptContext.m_LuaState;
+            for (uint32_t i = 0; i < instance->m_ConstantBufferLuaRefs.Size(); ++i)
+            {
+                dmScript::Unref(L, LUA_REGISTRYINDEX, instance->m_ConstantBufferLuaRefs[i]);
+            }
+            instance->m_ConstantBufferLuaRefs.SetSize(0);
+        }
+    }
+
     void DeleteRenderScriptInstance(HRenderScriptInstance render_script_instance)
     {
         lua_State* L = render_script_instance->m_RenderContext->m_RenderScriptContext.m_LuaState;
@@ -3588,6 +3632,8 @@ bail:
         dmScript::Unref(L, LUA_REGISTRYINDEX, render_script_instance->m_InstanceReference);
         dmScript::Unref(L, LUA_REGISTRYINDEX, render_script_instance->m_RenderScriptDataReference);
         dmScript::Unref(L, LUA_REGISTRYINDEX, render_script_instance->m_ContextTableReference);
+
+        ReleaseConstantBufferLuaRefs(render_script_instance);
 
         assert(top == lua_gettop(L));
 
@@ -3780,6 +3826,7 @@ bail:
     {
         DM_PROFILE("UpdateRSI");
         instance->m_CommandBuffer.SetSize(0);
+        ReleaseConstantBufferLuaRefs(instance);
 
         dmScript::UpdateScriptWorld(instance->m_ScriptWorld, dt);
 

--- a/engine/render/src/render/render_script.cpp
+++ b/engine/render/src/render/render_script.cpp
@@ -1830,34 +1830,35 @@ namespace dmRender
         HNamedConstantBuffer constant_buffer = 0;
         dmRender::SortOrder sort_order = dmRender::SORT_UNSPECIFIED;
 
-        if (lua_istable(L, 2))
+        bool has_options_table = lua_istable(L, 2);
+        bool has_constant_buffer_value = false;
+
+        if (has_options_table)
         {
             luaL_checktype(L, 2, LUA_TTABLE);
             lua_pushvalue(L, 2);
+            int options_index = lua_gettop(L);
 
-            lua_getfield(L, -1, "frustum");
+            lua_getfield(L, options_index, "frustum");
             frustum_matrix = lua_isnil(L, -1) ? 0 : dmScript::CheckMatrix4(L, -1);
             lua_pop(L, 1);
 
-            lua_getfield(L, -1, "frustum_planes");
+            lua_getfield(L, options_index, "frustum_planes");
             frustum_num_planes = lua_isnil(L, -1) ? frustum_num_planes : (dmRender::FrustumPlanes)luaL_checkinteger(L, -1);
             lua_pop(L, 1);
 
-            lua_getfield(L, -1, "constants");
+            lua_getfield(L, options_index, "constants");
             if (!lua_isnil(L, -1))
             {
                 constant_buffer = *RenderScriptConstantBuffer_Check(L, -1);
-                AddConstantBufferRef(L, i);
+                has_constant_buffer_value = true;
             }
-            lua_pop(L, 1);
 
-            lua_getfield(L, -1, "sort_order");
+            lua_getfield(L, options_index, "sort_order");
             if (!lua_isnil(L, -1))
             {
                 sort_order = (dmRender::SortOrder) luaL_checkinteger(L, -1);
             }
-            lua_pop(L, 1);
-
             lua_pop(L, 1);
         }
         else if (lua_isuserdata(L, 2)) // Deprecated
@@ -1865,9 +1866,6 @@ namespace dmRender
             dmLogOnceWarning("This interface for render.draw() is deprecated. Please see documentation at https://defold.com/ref/stable/render/#render.draw:predicate-[constants]")
             HNamedConstantBuffer* tmp = RenderScriptConstantBuffer_Check(L, 2);
             constant_buffer = *tmp;
-            // Take a Lua registry reference (same reason as the options table path above).
-            lua_pushvalue(L, 2);
-            AddConstantBufferRef(L, i);
         }
 
         // we need to pass ownership to the command queue
@@ -1880,9 +1878,34 @@ namespace dmRender
         }
 
         if (InsertCommand(i, Command(COMMAND_TYPE_DRAW, (uint64_t)predicate, (uint64_t) constant_buffer, (uint64_t) frustum_options, (uint64_t) sort_order)))
+        {
+            if (has_options_table)
+            {
+                if (has_constant_buffer_value)
+                {
+                    AddConstantBufferRef(L, i);
+                }
+                else
+                {
+                    lua_pop(L, 1);
+                }
+                lua_pop(L, 1);
+            }
+            else if (lua_isuserdata(L, 2)) // Deprecated
+            {
+                // Take a Lua registry reference (same reason as the options table path above).
+                lua_pushvalue(L, 2);
+                AddConstantBufferRef(L, i);
+            }
             return 0;
-        else
-            return luaL_error(L, "Command buffer is full (%d).", i->m_CommandBuffer.Capacity());
+        }
+
+        delete frustum_options;
+        if (has_options_table)
+        {
+            lua_pop(L, 2);
+        }
+        return luaL_error(L, "Command buffer is full (%d).", i->m_CommandBuffer.Capacity());
     }
 
     /*# draws all 3d debug graphics
@@ -3062,26 +3085,42 @@ namespace dmRender
         int p_z = luaL_checkinteger(L, 3);
 
         HNamedConstantBuffer constant_buffer = 0;
+        bool has_options_table = lua_istable(L, 4);
+        bool has_constant_buffer_value = false;
 
-        if (lua_istable(L, 4))
+        if (has_options_table)
         {
             luaL_checktype(L, 4, LUA_TTABLE);
             lua_pushvalue(L, 4);
+            int options_index = lua_gettop(L);
 
-            lua_getfield(L, -1, "constants");
+            lua_getfield(L, options_index, "constants");
             if (!lua_isnil(L, -1))
             {
                 constant_buffer = *RenderScriptConstantBuffer_Check(L, -1);
-                AddConstantBufferRef(L, i);
+                has_constant_buffer_value = true;
             }
-            lua_pop(L, 1);
-
-            lua_pop(L, 1);
         }
 
         if (InsertCommand(i, Command(COMMAND_TYPE_DISPATCH_COMPUTE, p_x, p_y, p_z, (uint64_t) constant_buffer)))
         {
+            if (has_options_table)
+            {
+                if (has_constant_buffer_value)
+                {
+                    AddConstantBufferRef(L, i);
+                }
+                else
+                {
+                    lua_pop(L, 1);
+                }
+                lua_pop(L, 1);
+            }
             return 0;
+        }
+        if (has_options_table)
+        {
+            lua_pop(L, 2);
         }
         return DM_LUA_ERROR("Command buffer is full (%d).", i->m_CommandBuffer.Capacity());
     }

--- a/engine/render/src/render/render_script.cpp
+++ b/engine/render/src/render/render_script.cpp
@@ -1736,6 +1736,20 @@ namespace dmRender
             return luaL_error(L, "Command buffer is full (%d).", i->m_CommandBuffer.Capacity());
     }
 
+    // Take a Lua registry reference to prevent the constant buffer
+    // userdata from being garbage collected while the draw command
+    // is queued. The reference is released after ParseCommands.
+    static void AddConstantBufferRef(lua_State* L, RenderScriptInstance* instance)
+    {
+        lua_pushvalue(L, -1);
+        int ref = dmScript::Ref(L, LUA_REGISTRYINDEX);
+        if (instance->m_ConstantBufferLuaRefs.Full())
+        {
+            instance->m_ConstantBufferLuaRefs.OffsetCapacity(16);
+        }
+        instance->m_ConstantBufferLuaRefs.Push(ref);
+    }
+
     /*# draws all objects matching a predicate
      * Draws all objects that match a specified predicate. An optional constant buffer can be
      * provided to override the default constants. If no constants buffer is provided, a default
@@ -1833,16 +1847,7 @@ namespace dmRender
             if (!lua_isnil(L, -1))
             {
                 constant_buffer = *RenderScriptConstantBuffer_Check(L, -1);
-                // Take a Lua registry reference to prevent the constant buffer
-                // userdata from being garbage collected while the draw command
-                // is queued. The reference is released after ParseCommands.
-                lua_pushvalue(L, -1);
-                int ref = dmScript::Ref(L, LUA_REGISTRYINDEX);
-                if (i->m_ConstantBufferLuaRefs.Full())
-                {
-                    i->m_ConstantBufferLuaRefs.OffsetCapacity(16);
-                }
-                i->m_ConstantBufferLuaRefs.Push(ref);
+                AddConstantBufferRef(L, i);
             }
             lua_pop(L, 1);
 
@@ -1862,12 +1867,7 @@ namespace dmRender
             constant_buffer = *tmp;
             // Take a Lua registry reference (same reason as the options table path above).
             lua_pushvalue(L, 2);
-            int ref = dmScript::Ref(L, LUA_REGISTRYINDEX);
-            if (i->m_ConstantBufferLuaRefs.Full())
-            {
-                i->m_ConstantBufferLuaRefs.OffsetCapacity(16);
-            }
-            i->m_ConstantBufferLuaRefs.Push(ref);
+            AddConstantBufferRef(L, i);
         }
 
         // we need to pass ownership to the command queue
@@ -3072,13 +3072,7 @@ namespace dmRender
             if (!lua_isnil(L, -1))
             {
                 constant_buffer = *RenderScriptConstantBuffer_Check(L, -1);
-                lua_pushvalue(L, -1);
-                int ref = dmScript::Ref(L, LUA_REGISTRYINDEX);
-                if (i->m_ConstantBufferLuaRefs.Full())
-                {
-                    i->m_ConstantBufferLuaRefs.OffsetCapacity(16);
-                }
-                i->m_ConstantBufferLuaRefs.Push(ref);
+                AddConstantBufferRef(L, i);
             }
             lua_pop(L, 1);
 
@@ -3603,12 +3597,12 @@ bail:
         return i;
     }
 
-    static void ReleaseConstantBufferLuaRefs(HRenderScriptInstance instance)
+    static void ReleaseConstantBufferLuaRefs(lua_State* L, HRenderScriptInstance instance)
     {
-        if (instance->m_ConstantBufferLuaRefs.Size() > 0)
+        uint32_t num_refs = instance->m_ConstantBufferLuaRefs.Size();
+        if (num_refs > 0)
         {
-            lua_State* L = instance->m_RenderContext->m_RenderScriptContext.m_LuaState;
-            for (uint32_t i = 0; i < instance->m_ConstantBufferLuaRefs.Size(); ++i)
+            for (uint32_t i = 0; i < num_refs; ++i)
             {
                 dmScript::Unref(L, LUA_REGISTRYINDEX, instance->m_ConstantBufferLuaRefs[i]);
             }
@@ -3633,7 +3627,7 @@ bail:
         dmScript::Unref(L, LUA_REGISTRYINDEX, render_script_instance->m_RenderScriptDataReference);
         dmScript::Unref(L, LUA_REGISTRYINDEX, render_script_instance->m_ContextTableReference);
 
-        ReleaseConstantBufferLuaRefs(render_script_instance);
+        ReleaseConstantBufferLuaRefs(L, render_script_instance);
 
         assert(top == lua_gettop(L));
 
@@ -3826,7 +3820,8 @@ bail:
     {
         DM_PROFILE("UpdateRSI");
         instance->m_CommandBuffer.SetSize(0);
-        ReleaseConstantBufferLuaRefs(instance);
+
+        ReleaseConstantBufferLuaRefs(instance->m_RenderContext->m_RenderScriptContext.m_LuaState, instance);
 
         dmScript::UpdateScriptWorld(instance->m_ScriptWorld, dt);
 

--- a/engine/render/src/render/render_script.h
+++ b/engine/render/src/render/render_script.h
@@ -57,6 +57,7 @@ namespace dmRender
     struct RenderScriptInstance
     {
         dmArray<Command>              m_CommandBuffer;
+        dmArray<int>                  m_ConstantBufferLuaRefs; // Lua registry refs keeping constant buffers alive while queued in m_CommandBuffer
         dmHashTable64<RenderResource> m_RenderResources;
         Predicate*                    m_Predicates[MAX_PREDICATE_COUNT];
         RenderContext*                m_RenderContext;

--- a/engine/render/src/test/test_render_script.cpp
+++ b/engine/render/src/test/test_render_script.cpp
@@ -1456,6 +1456,50 @@ TEST_F(dmRenderScriptTest, TestLuaConstantBuffers_InvalidUsage)
     dmRender::DeleteRenderScript(m_Context, render_script);
 }
 
+// Test that constant buffers passed to render.draw() as locals survive garbage
+// collection between command creation and command parsing.
+TEST_F(dmRenderScriptTest, TestLuaConstantBuffers_GCBeforeCommandParse)
+{
+    // Create multiple constant buffers as locals only — no reference
+        // from self, so they become eligible for GC after the loop.
+    const char* script =
+        "function init(self)\n"
+        "    self.pred = render.predicate({\"tag\"})\n"
+        "    for i = 1, 5 do\n"
+        "        local cb = render.constant_buffer()\n"
+        "        cb.tint = vmath.vector4(i, 0, 0, 1)\n"
+        "        render.draw(self.pred, { constants = cb })\n"
+        "    end\n"
+        "end\n";
+
+    dmRender::HRenderScript render_script = dmRender::NewRenderScript(m_Context, LuaSourceFromString(script));
+    dmRender::HRenderScriptInstance render_script_instance = dmRender::NewRenderScriptInstance(m_Context, render_script);
+
+    // init() creates the draw commands but does NOT call ParseCommands.
+    ASSERT_EQ(dmRender::RENDER_SCRIPT_RESULT_OK, dmRender::InitRenderScriptInstance(render_script_instance));
+
+    dmArray<dmRender::Command>& commands = render_script_instance->m_CommandBuffer;
+    ASSERT_EQ(5u, commands.Size());
+
+    // Force a full garbage collection cycle from C++
+    lua_State* L = m_Context->m_RenderScriptContext.m_LuaState;
+    lua_gc(L, LUA_GCCOLLECT, 0);
+    lua_gc(L, LUA_GCCOLLECT, 0);
+
+    for (uint32_t i = 0; i < commands.Size(); ++i)
+    {
+        ASSERT_EQ(dmRender::COMMAND_TYPE_DRAW, commands[i].m_Type);
+        dmRender::HNamedConstantBuffer cb = (dmRender::HNamedConstantBuffer)commands[i].m_Operands[1];
+        ASSERT_NE((dmRender::HNamedConstantBuffer)0, cb);
+        ASSERT_EQ(1u, dmRender::GetNamedConstantCount(cb));
+    }
+
+    dmRender::ParseCommands(m_Context, &commands[0], commands.Size());
+
+    dmRender::DeleteRenderScriptInstance(render_script_instance);
+    dmRender::DeleteRenderScript(m_Context, render_script);
+}
+
 TEST_F(dmRenderScriptTest, TestAssetHandlesValidRenderTarget)
 {
     const char* script =


### PR DESCRIPTION
Constant buffers created by render scripts are more robust in terms of garbage collection. Previously, a constant buffer could be deallocated between the `render.draw` call and its consumption by the renderer.

Fixes #3557 