### PR TITLE
Fixed an issue where equal hashes could behave as if they were not equal in certain cases

### DIFF
--- a/engine/script/src/script_hash.cpp
+++ b/engine/script/src/script_hash.cpp
@@ -45,6 +45,14 @@ namespace dmScript
     #define SCRIPT_TYPE_NAME_HASH "hash"
     static uint32_t SCRIPT_HASH_TYPE_HASH = 0;
 
+    static inline void PushHashWeakTableKey(lua_State* L, dmhash_t hash)
+    {
+        // The weak table is indexed by full 64-bit hashes. Lua numbers are doubles
+        // and lua_rawgeti() takes an int, so numeric keys can lose
+        // bits and let stale hash userdata erase a live cache entry.
+        lua_pushlstring(L, (const char*)&hash, sizeof(hash));
+    }
+
     bool IsHash(lua_State *L, int index)
     {
         return dmScript::ToUserType(L, index, SCRIPT_HASH_TYPE_HASH) != 0;
@@ -175,7 +183,7 @@ namespace dmScript
         lua_rawgeti(L, LUA_REGISTRYINDEX, context->m_ContextWeakTableRef);
         // [-2] userdata
         // [-1] weak_table
-        lua_pushinteger(L, (lua_Integer)hash);
+        PushHashWeakTableKey(L, hash);
         // [-3] userdata
         // [-2] weak_table
         // [-1] key
@@ -184,7 +192,7 @@ namespace dmScript
         // [-3] weak_table
         // [-2] key
         // [-1] value
-        lua_settable(L, -3); // weak_table[hash] = userdata
+        lua_rawset(L, -3); // weak_table[hash] = userdata
         // [-2] userdata
         // [-1] weak_table
         lua_pop(L, 1);
@@ -206,10 +214,10 @@ namespace dmScript
         {
             lua_rawgeti(L, LUA_REGISTRYINDEX, context->m_ContextWeakTableRef);
             // [-1] weak_table
-            lua_pushinteger(L, (lua_Integer)hash);
+            PushHashWeakTableKey(L, hash);
             // [-2] weak_table
             // [-1] key
-            lua_gettable(L, -2);
+            lua_rawget(L, -2);
             // [-2] weak_table
             // [-1] value or nil
             if (lua_isnil(L, -1))
@@ -397,9 +405,12 @@ namespace dmScript
             {
                 lua_rawgeti(L, LUA_REGISTRYINDEX, context->m_ContextWeakTableRef);
                 // [-1] weak_table
-                lua_rawgeti(L, -1, (lua_Integer)hash);
+                PushHashWeakTableKey(L, hash);
                 // [-2] weak_table
-                // [-1] hash
+                // [-1] key
+                lua_rawget(L, -2);
+                // [-2] weak_table
+                // [-1] value or nil
                 if (lua_isnil(L, -1))
                 {
                     context->m_HashInstances.Erase(hash);

--- a/engine/script/src/test/test_script_hash.cpp
+++ b/engine/script/src/test/test_script_hash.cpp
@@ -103,6 +103,42 @@ TEST_F(ScriptHashTest, TestHashUnknown)
     ASSERT_EQ(top, lua_gettop(L));
 }
 
+TEST_F(ScriptHashTest, TestHashGcDoesNotEraseLiveHashInstance)
+{
+    int top = lua_gettop(L);
+
+    dmhash_t hash = dmHashString64("/collection112/collisionobject");
+
+    dmScript::PushHash(L, hash);
+    void* live_hash = lua_touserdata(L, -1);
+    lua_setglobal(L, "live_hash");
+
+    lua_getglobal(L, "live_hash");
+    ASSERT_TRUE(lua_getmetatable(L, -1));
+
+    dmhash_t* stale_hash = (dmhash_t*)lua_newuserdata(L, sizeof(dmhash_t));
+    *stale_hash = hash;
+    lua_pushvalue(L, -2);
+    lua_setmetatable(L, -2);
+
+    lua_getfield(L, -2, "__gc");
+    lua_pushvalue(L, -2);
+    ASSERT_EQ(0, lua_pcall(L, 1, 0, 0));
+
+    lua_pushnil(L);
+    lua_setmetatable(L, -2);
+    lua_pop(L, 3);
+
+    dmScript::PushHash(L, hash);
+    ASSERT_EQ(live_hash, lua_touserdata(L, -1));
+    lua_pop(L, 1);
+
+    lua_pushnil(L);
+    lua_setglobal(L, "live_hash");
+
+    ASSERT_EQ(top, lua_gettop(L));
+}
+
 
 TEST_F(ScriptHashTest, TestGetStringFromHashOrString)
 {


### PR DESCRIPTION
Fixed an issue where, in certain cases, the Lua garbage collector could cause hashes with the same values to behave as unequal, leading to unexpected bugs that are difficult to debug.

Fix https://github.com/defold/defold/issues/11128
Fix https://github.com/defold/defold/issues/12252