### PR TITLE
Fixed line height calculations for the Skribidi text layout

### DIFF
--- a/engine/font/src/test/test_font.cpp
+++ b/engine/font/src/test/test_font.cpp
@@ -944,6 +944,35 @@ TEST_F(FontTest, Layout)
 #endif // !defined(FONT_USE_SKRIBIDI)
 
 #if defined(FONT_USE_SKRIBIDI)
+TEST_F(FontTest, SkribidiLayoutHeightMatchesLegacyLineHeight)
+{
+    dmArray<uint32_t> codepoints;
+    TextToCodePoints("A\nA\nA\nA\nA\nA\nA\nA\nA\nA", codepoints);
+
+    TextLayoutSettings settings = {0};
+    settings.m_LineBreak = false;
+    settings.m_Width = 0.0f;
+    settings.m_Size = 40.0f;
+    settings.m_Leading = 1.0f;
+
+    HTextLayout legacy_layout = 0;
+    TextResult r = TextLayoutLegacyCreate(m_FontCollection, codepoints.Begin(), codepoints.Size(), &settings, &legacy_layout);
+    ASSERT_EQ(TEXT_RESULT_OK, r);
+    ASSERT_NE((HTextLayout)0, legacy_layout);
+
+    HTextLayout skribidi_layout = 0;
+    r = TestLayout(m_FontCollection, codepoints, &settings, &skribidi_layout);
+    ASSERT_EQ(TEXT_RESULT_OK, r);
+    ASSERT_NE((HTextLayout)0, skribidi_layout);
+
+    ASSERT_EQ(10u, skribidi_layout->m_Lines.Size());
+    ASSERT_EQ(legacy_layout->m_Lines.Size(), skribidi_layout->m_Lines.Size());
+    ASSERT_NEAR(legacy_layout->m_Height, skribidi_layout->m_Height, 0.01f);
+
+    TextLayoutRelease(skribidi_layout);
+    TextLayoutRelease(legacy_layout);
+}
+
 TEST_F(FontTest, TextArabic)
 {
     HFont font;

--- a/engine/font/src/text_layout_skribidi.cpp
+++ b/engine/font/src/text_layout_skribidi.cpp
@@ -199,7 +199,7 @@ static bool LayoutText(LayoutContext* ctx,
 
     skb_rect2_t layout_bounds = skb_layout_get_bounds(skblayout);
     layout->m_Width = layout_bounds.width - (tracking > 0 ? tracking : 0);
-    layout->m_Height = lines_count * (line_height * settings->m_Leading) - line_height * (settings->m_Leading - 1.0f);
+    layout->m_Height = lines_count * (line_height_scaled * settings->m_Leading) - line_height_scaled * (settings->m_Leading - 1.0f);
 
     return true;
 }

--- a/engine/font/src/text_layout_skribidi.cpp
+++ b/engine/font/src/text_layout_skribidi.cpp
@@ -17,13 +17,8 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <stdio.h>
-#include <limits.h> // INT_MAX
+#include <math.h>
 
-#include <dlib/array.h>
-#include <dlib/log.h>
-#include <dlib/profile.h>
-#include <dlib/math.h>
-#include <dlib/time.h>
 #include <dlib/utf8.h>
 
 #include "font.h"
@@ -85,6 +80,11 @@ static bool LayoutText(LayoutContext* ctx,
     params.flags              = 0;
 
     float tracking = settings->m_Tracking * settings->m_Size;
+    HFont default_font = FontCollectionGetFont(font_collection, 0);
+    float font_scale = FontGetScaleFromSize(default_font, settings->m_Size);
+    uint32_t ascent = (uint32_t)FontGetAscent(default_font, 1.0f);
+    uint32_t descent = (uint32_t)fabsf(FontGetDescent(default_font, 1.0f));
+    float line_height_scaled = (ascent + descent) * font_scale;
 
     // TODO: Allo setting default as italic etc
     const skb_attribute_t attributes[] = {
@@ -105,7 +105,6 @@ static bool LayoutText(LayoutContext* ctx,
     const int32_t glyphs_count = skb_layout_get_glyphs_count(skblayout);
     const skb_glyph_t* glyphs = skb_layout_get_glyphs(skblayout);
     const skb_glyph_run_t* glyph_runs = skb_layout_get_glyph_runs(skblayout);
-    const skb_layout_params_t* layout_params = skb_layout_get_params(skblayout);
     const skb_text_attributes_span_t* attrib_spans = skb_layout_get_attribute_spans(skblayout);
     const skb_layout_line_t* layout_lines = skb_layout_get_lines(skblayout);
     int32_t lines_count = skb_layout_get_lines_count(skblayout);
@@ -123,29 +122,14 @@ static bool LayoutText(LayoutContext* ctx,
         layout->m_Lines.OffsetCapacity(lines_count - remaining_lines);
     }
 
-    const float edit_layout_y = 0.0f;
     uint32_t num_whitespaces = 0;
-
-    float ox = 0.0f;
-    float oy = 0.0f;
-
-    float max_ascender = 0.0f;
-    float max_descender = 0.0f;
 
     // From example_testbed.c
     for (int li = 0; li < lines_count; li++)
     {
         const skb_layout_line_t* line = &layout_lines[li];
 
-        max_ascender = dmMath::Max(max_ascender, -line->ascender); // make it positive
-        max_descender = dmMath::Max(max_descender, line->descender);
-
         uint32_t prev_glyph_index = layout->m_Glyphs.Size();
-
-        skb_font_handle_t font_handle = 0;
-
-        float max_glyph_bounds_width = 0.0f;
-        float max_glyph_bounds_height = 0.0f;
 
         for (int32_t ri = line->glyph_run_range.start; ri < line->glyph_run_range.end; ri++)
         {
@@ -156,13 +140,10 @@ static bool LayoutText(LayoutContext* ctx,
             {
                 const skb_glyph_t* skbglyph = &glyphs[gi];
 
-                float gx = ox + skbglyph->offset_x;
-                float gy = oy + edit_layout_y + -skbglyph->offset_y;
+                float gx = skbglyph->offset_x;
+                float gy = -skbglyph->offset_y;
 
-                skb_rect2_t bounds = skb_font_get_glyph_bounds(layout_params->font_collection, font_handle, skbglyph->gid, attr_font.size);
-
-                max_glyph_bounds_width = dmMath::Max(max_glyph_bounds_width, bounds.width);
-                max_glyph_bounds_height = dmMath::Max(max_glyph_bounds_height, -bounds.height);
+                skb_rect2_t bounds = skb_font_get_glyph_bounds(params.font_collection, skbglyph->font_handle, skbglyph->gid, attr_font.size);
 
                 uint32_t codepoint_index = skbglyph->text_range.start;
                 uint32_t cp = codepoints[codepoint_index];
@@ -218,13 +199,7 @@ static bool LayoutText(LayoutContext* ctx,
 
     skb_rect2_t layout_bounds = skb_layout_get_bounds(skblayout);
     layout->m_Width = layout_bounds.width - (tracking > 0 ? tracking : 0);
-    layout->m_Height = layout_bounds.height;
-    if (lines_count > 0 && settings->m_Leading > 0.0f)
-    {
-        // Normalize Skribidi line height so leading affects only inter-line spacing.
-        float base_line_height = layout_bounds.height / ((float)lines_count * settings->m_Leading);
-        layout->m_Height = layout_bounds.height - base_line_height * (settings->m_Leading - 1.0f);
-    }
+    layout->m_Height = lines_count * (line_height * settings->m_Leading) - line_height * (settings->m_Leading - 1.0f);
 
     return true;
 }
@@ -250,6 +225,10 @@ TextResult TextLayoutSkribidiCreate(HFontCollection collection,
     layout->m_FontCollection = collection;
     layout->m_Direction = TEXT_DIRECTION_LTR;
     layout->m_NumValidGlyphs = 0;
+    layout->m_MaxGlyphWidth = 0.0f;
+    layout->m_MaxGlyphHeight = 0.0f;
+    layout->m_Width = 0.0f;
+    layout->m_Height = 0.0f;
 
     if (num_codepoints == 0) // empty string
     {


### PR DESCRIPTION
This fixes an issue with `resource.get_text_metrics()` where it previously didn't return the correct bounding box of the text.

Fixes https://github.com/defold/defold/issues/12302

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
