### PR TITLE
Fix editor Scene View manipulator preview during drag

### DIFF
--- a/editor/project.clj
+++ b/editor/project.clj
@@ -322,7 +322,7 @@
                                                     "-Ddefold.extension.simpledata.url=https://github.com/defold/extension-simpledata/archive/refs/tags/v1.2.0.zip"
                                                     "-Ddefold.extension.spine.url=https://github.com/defold/extension-spine/archive/refs/tags/4.4.1.zip"
                                                     "-Ddefold.extension.teal.url=https://github.com/defold/extension-teal/archive/refs/tags/v1.4.zip"
-                                                    "-Ddefold.extension.texturepacker.url=https://github.com/defold/extension-texturepacker/archive/refs/tags/2.6.0.zip"
+                                                    "-Ddefold.extension.texturepacker.url=https://github.com/defold/extension-texturepacker/archive/refs/heads/editor-use-pose.zip"
                                                     "-Ddefold.unpack.path=tmp/unpack"
                                                     "-Ddefold.nrepl=true"
                                                     "-Ddefold.log.dir="

--- a/editor/project.clj
+++ b/editor/project.clj
@@ -317,12 +317,12 @@
                                 :repl-options      {:init-ns user}
                                 :proto-paths       ["test/proto"]
                                 :resource-paths    ["test/resources"]
-                                :jvm-opts          ["-Ddefold.extension.lua-preprocessor.url=https://github.com/defold/extension-lua-preprocessor/archive/refs/tags/1.1.3.zip"
-                                                    "-Ddefold.extension.rive.url=https://github.com/defold/extension-rive/archive/refs/heads/editor-plugin-test-fixes.zip"
+                                :jvm-opts          ["-Ddefold.extension.lua-preprocessor.url=https://github.com/defold/extension-lua-preprocessor/archive/refs/tags/1.2.0.zip"
+                                                    "-Ddefold.extension.rive.url=https://github.com/defold/extension-rive/archive/refs/tags/11.0.4.zip"
                                                     "-Ddefold.extension.simpledata.url=https://github.com/defold/extension-simpledata/archive/refs/tags/v1.2.0.zip"
-                                                    "-Ddefold.extension.spine.url=https://github.com/defold/extension-spine/archive/refs/tags/4.4.1.zip"
+                                                    "-Ddefold.extension.spine.url=https://github.com/defold/extension-spine/archive/refs/tags/4.5.1.zip"
                                                     "-Ddefold.extension.teal.url=https://github.com/defold/extension-teal/archive/refs/tags/v1.4.zip"
-                                                    "-Ddefold.extension.texturepacker.url=https://github.com/defold/extension-texturepacker/archive/refs/heads/editor-use-pose.zip"
+                                                    "-Ddefold.extension.texturepacker.url=https://github.com/defold/extension-texturepacker/archive/refs/tags/2.7.0.zip"
                                                     "-Ddefold.unpack.path=tmp/unpack"
                                                     "-Ddefold.nrepl=true"
                                                     "-Ddefold.log.dir="

--- a/editor/src/clj/editor/atlas.clj
+++ b/editor/src/clj/editor/atlas.clj
@@ -36,6 +36,7 @@
             [editor.pipeline :as pipeline]
             [editor.pipeline.tex-gen :as tex-gen]
             [editor.pipeline.texture-set-gen :as texture-set-gen]
+            [editor.pose :as pose]
             [editor.properties :as properties]
             [editor.protobuf :as protobuf]
             [editor.render-util :as render-util]
@@ -80,11 +81,9 @@
   (let [page-margin 32]
     (+ (* page-margin page-index) (* layout-width page-index))))
 
-(defn- get-rect-transform [width page-index]
+(defn- get-rect-pose [width page-index]
   (let [page-offset (get-rect-page-offset width page-index)]
-    (doto (Matrix4d.)
-      (.setIdentity)
-      (.setTranslation (Vector3d. page-offset 0.0 0.0)))))
+    (pose/translation-pose page-offset 0.0 0.0)))
 
 (defn- render-rect
   [^GL2 gl rect color offset-x]
@@ -553,8 +552,8 @@
 
 (defn- make-page-scene
   [layout-width layout-height page-index gpu-texture]
-  (let [page-offset-transform (get-rect-transform layout-width page-index)]
-    (render-util/make-outlined-textured-quad-scene #{:atlas} page-offset-transform layout-width layout-height gpu-texture page-index)))
+  (let [page-offset-pose (get-rect-pose layout-width page-index)]
+    (render-util/make-outlined-textured-quad-scene #{:atlas} page-offset-pose layout-width layout-height gpu-texture page-index)))
 
 (g/defnk produce-scene
   [_node-id layout-rects layout-size gpu-texture child-scenes texture-profile]
@@ -692,11 +691,11 @@
 
 (s/defrecord AtlasRect
   [path     :- s/Any
-   x        :- types/Int32
-   y        :- types/Int32
-   width    :- types/Int32
-   height   :- types/Int32
-   page     :- types/Int32
+   x        :- types/TInt32
+   y        :- types/TInt32
+   width    :- types/TInt32
+   height   :- types/TInt32
+   page     :- types/TInt32
    geometry :- s/Any])
 
 (defn rotate-vertices-90-cw [vertices]

--- a/editor/src/clj/editor/collection.clj
+++ b/editor/src/clj/editor/collection.clj
@@ -277,8 +277,8 @@
   (output node-outline-extras g/Any (g/constantly {}))
   (output build-targets g/Any :abstract)
 
-  (output scene g/Any :cached (g/fnk [_node-id id transform scene child-scenes]
-                                (-> (collection-common/any-instance-scene _node-id id transform scene)
+  (output scene g/Any :cached (g/fnk [_node-id id pose scene child-scenes]
+                                (-> (collection-common/any-instance-scene _node-id id pose scene)
                                     (update :children util/intov child-scenes))))
   (output go-inst-ids g/Any (g/fnk [_node-id id] {id _node-id}))
   (output ddf-properties g/Any (g/fnk [id ddf-component-properties] {:id id :properties ddf-component-properties})))
@@ -674,8 +674,8 @@
                                     :scale3 scale
                                     :instance-properties ddf-properties)
                                   (collection-common/strip-default-scale-from-any-instance-desc))))
-  (output scene g/Any :cached (g/fnk [_node-id id transform scene]
-                                (collection-common/any-instance-scene _node-id id transform scene)))
+  (output scene g/Any :cached (g/fnk [_node-id id pose scene]
+                                (collection-common/any-instance-scene _node-id id pose scene)))
   (output build-targets g/Any produce-coll-inst-build-targets)
   (output sub-ddf-properties g/Any :cached (g/fnk [id ddf-properties]
                                                   (map (fn [m] (update m :id (fn [s] (format "%s/%s" id s)))) ddf-properties)))

--- a/editor/src/clj/editor/collection_common.clj
+++ b/editor/src/clj/editor/collection_common.clj
@@ -28,8 +28,7 @@
             [internal.util :as util]
             [service.log :as log]
             [util.coll :refer [pair]])
-  (:import [com.dynamo.gameobject.proto GameObject$CollectionDesc GameObject$InstanceDesc GameObject$PrototypeDesc]
-           [javax.vecmath Matrix4d]))
+  (:import [com.dynamo.gameobject.proto GameObject$CollectionDesc GameObject$InstanceDesc GameObject$PrototypeDesc]))
 
 (set! *warn-on-reflection* true)
 
@@ -350,13 +349,13 @@
                    collection-instance-build-targets)
        :game-object-instance-datas game-object-instance-datas})))
 
-(defn any-instance-scene [node-id node-outline-key ^Matrix4d transform-matrix source-scene]
+(defn any-instance-scene [node-id node-outline-key instance-pose source-scene]
   {:pre [(g/node-id? node-id)
-         (instance? Matrix4d transform-matrix)
+         (pose/pose? instance-pose)
          (or (nil? source-scene) (map? source-scene))]}
   (-> source-scene
       (scene/claim-scene node-id node-outline-key)
-      (assoc :transform transform-matrix
+      (assoc :pose instance-pose
              :aabb geom/empty-bounding-box
              :renderable {:passes [pass/selection]})))
 

--- a/editor/src/clj/editor/collection_non_editable.clj
+++ b/editor/src/clj/editor/collection_non_editable.clj
@@ -33,8 +33,7 @@
             [editor.workspace :as workspace]
             [internal.util :as util]
             [util.coll :as coll :refer [pair]])
-  (:import [com.dynamo.gameobject.proto GameObject$CollectionDesc]
-           [javax.vecmath Matrix4d]))
+  (:import [com.dynamo.gameobject.proto GameObject$CollectionDesc]))
 
 (set! *warn-on-reflection* true)
 
@@ -53,11 +52,6 @@
   ;; GameObject$InstanceDesc, GameObject$EmbeddedInstanceDesc, or GameObject$CollectionInstanceDesc in map format.
   (let [scale (or scale3 scene/default-scale)]
     (pose/make position rotation scale)))
-
-(defn- any-instance-desc->transform-matrix
-  ^Matrix4d [any-instance-desc]
-  ;; GameObject$InstanceDesc, GameObject$EmbeddedInstanceDesc, or GameObject$CollectionInstanceDesc in map format.
-  (pose/matrix (any-instance-desc->pose any-instance-desc)))
 
 (defn- component-property-desc-with-go-props [component-property-desc proj-path->source-resource]
   ;; GameObject$ComponentPropertyDesc in map format.
@@ -276,9 +270,9 @@
          (ifn? child-id->desc)]}
   (letfn [(desc->instance-scene [desc]
             (let [id (:id desc)
-                  transform-matrix (any-instance-desc->transform-matrix desc)
+                  instance-pose (any-instance-desc->pose desc)
                   source-scene (desc->source-scene desc)
-                  instance-scene (collection-common/any-instance-scene node-id id transform-matrix source-scene)
+                  instance-scene (collection-common/any-instance-scene node-id id instance-pose source-scene)
                   child-instance-scenes (map (comp desc->instance-scene child-id->desc)
                                              (:children desc))]
               (cond-> instance-scene

--- a/editor/src/clj/editor/collision_object.clj
+++ b/editor/src/clj/editor/collision_object.clj
@@ -188,7 +188,7 @@
     (pair visibility-aabb user-data)))
 
 (g/defnk produce-sphere-shape-scene
-  [_node-id transform diameter color node-outline-key project-physics-type]
+  [_node-id pose diameter color node-outline-key project-physics-type]
   (let [is-2d (= "2D" project-physics-type)
 
         ;; The preview-fn technically takes and returns a visibility-aabb, but
@@ -201,7 +201,7 @@
 
     {:node-id _node-id
      :node-outline-key node-outline-key
-     :transform transform
+     :pose pose
      :aabb local-aabb
      :renderable {:render-fn render-triangles-uniform-scale
                   :preview-fn preview-sphere-shape-renderable
@@ -252,7 +252,7 @@
     (pair visibility-aabb user-data)))
 
 (g/defnk produce-box-shape-scene
-  [_node-id transform dimensions color node-outline-key project-physics-type]
+  [_node-id pose dimensions color node-outline-key project-physics-type]
   (let [is-2d (= "2D" project-physics-type)
 
         ;; The preview-fn technically takes and returns a visibility-aabb, but
@@ -265,7 +265,7 @@
 
     {:node-id _node-id
      :node-outline-key node-outline-key
-     :transform transform
+     :pose pose
      :aabb local-aabb
      :renderable {:render-fn render-triangles-uniform-scale
                   :preview-fn preview-box-shape-renderable
@@ -331,7 +331,7 @@
     (pair visibility-aabb user-data)))
 
 (g/defnk produce-capsule-shape-scene
-  [_node-id transform diameter height color node-outline-key project-physics-type]
+  [_node-id pose diameter height color node-outline-key project-physics-type]
   ;; NOTE: Capsules are currently only supported when physics type is 3D.
   (let [is-2d (= "2D" project-physics-type)
 
@@ -346,7 +346,7 @@
 
     {:node-id _node-id
      :node-outline-key node-outline-key
-     :transform transform
+     :pose pose
      :aabb local-aabb
      :renderable {:render-fn render-triangles-uniform-scale
                   :preview-fn preview-capsule-shape-renderable

--- a/editor/src/clj/editor/game_object.clj
+++ b/editor/src/clj/editor/game_object.clj
@@ -229,8 +229,8 @@
             (some-> source-resource resource/proj-path) (assoc :link source-resource :outline-reference? true)
             source-id (assoc :alt-outline source-outline))))))
   (output ddf-message g/Any :abstract)
-  (output scene g/Any :cached (g/fnk [_node-id id transform scene]
-                                (game-object-common/component-scene _node-id id transform scene)))
+  (output scene g/Any :cached (g/fnk [_node-id id pose scene]
+                                (game-object-common/component-scene _node-id id pose scene)))
   (output build-targets g/Any :abstract)
   (output resource-property-build-targets g/Any (gu/passthrough resource-property-build-targets))
   (output _properties g/Properties :cached produce-component-properties))

--- a/editor/src/clj/editor/game_object_common.clj
+++ b/editor/src/clj/editor/game_object_common.clj
@@ -28,8 +28,7 @@
             [internal.util :as util]
             [service.log :as log])
   (:import [com.dynamo.gameobject.proto GameObject$PrototypeDesc]
-           [java.io StringReader]
-           [javax.vecmath Matrix4d]))
+           [java.io StringReader]))
 
 (set! *warn-on-reflection* true)
 
@@ -243,20 +242,19 @@
                        (util/distinct-by (comp resource/proj-path :resource)))
                  component-instance-datas)}))
 
-(defn component-scene [node-id node-outline-key ^Matrix4d transform-matrix source-component-resource-scene]
+(defn component-scene [node-id node-outline-key component-pose source-component-resource-scene]
   {:pre [(g/node-id? node-id)
-         (instance? Matrix4d transform-matrix)
+         (pose/pose? component-pose)
          (or (nil? source-component-resource-scene) (map? source-component-resource-scene))]}
   (if source-component-resource-scene
 
     ;; We have a source scene. This is usually the case.
-    (let [transform (if-some [^Matrix4d source-component-resource-transform (:transform source-component-resource-scene)]
-                      (doto (Matrix4d. transform-matrix)
-                        (.mul source-component-resource-transform))
-                      transform-matrix)
+    (let [scene-pose (if-some [source-component-resource-pose (:pose source-component-resource-scene)]
+                       (pose/pre-multiply source-component-resource-pose component-pose)
+                       component-pose)
           scene (-> source-component-resource-scene
                     (scene/claim-scene node-id node-outline-key)
-                    (assoc :transform transform))
+                    (assoc :pose scene-pose))
           updatable (:updatable source-component-resource-scene)]
       (if (nil? updatable)
         scene
@@ -269,7 +267,7 @@
     ;; such as the Script component. The bad data case is covered by for
     ;; instance unknown_components.go in the test project.
     {:node-id node-id
-     :transform transform-matrix
+     :pose component-pose
      :aabb geom/empty-bounding-box
      :renderable {:passes [pass/selection]}}))
 

--- a/editor/src/clj/editor/game_object_non_editable.clj
+++ b/editor/src/clj/editor/game_object_non_editable.clj
@@ -31,8 +31,7 @@
             [internal.graph.types :as gt]
             [internal.util :as util]
             [util.coll :refer [flipped-pair pair]])
-  (:import [com.dynamo.gameobject.proto GameObject$PrototypeDesc]
-           [javax.vecmath Matrix4d]))
+  (:import [com.dynamo.gameobject.proto GameObject$PrototypeDesc]))
 
 (set! *warn-on-reflection* true)
 
@@ -151,11 +150,6 @@
   ;; GameObject$ComponentDesc or GameObject$EmbeddedInstanceDesc in map format.
   (pose/make position rotation scale))
 
-(defn- any-component-desc->transform-matrix
-  ^Matrix4d [any-component-desc]
-  ;; GameObject$ComponentDesc or GameObject$EmbeddedInstanceDesc in map format.
-  (pose/matrix (any-component-desc->pose any-component-desc)))
-
 (defn prototype-desc->referenced-component-proj-paths [prototype-desc]
   (eduction
     (keep (comp not-empty :component))
@@ -265,12 +259,12 @@
   {:pre [(ifn? any-component-desc->source-scene)]}
   (fn any-component-desc->component-scene [any-component-desc node-id]
     (let [node-outline-key (:id any-component-desc)
-          transform-matrix (any-component-desc->transform-matrix any-component-desc)
+          component-pose (any-component-desc->pose any-component-desc)
           source-scene (any-component-desc->source-scene any-component-desc)]
       ;; TODO: Currently we return an empty scene for components that do not
       ;; have a scene output. Can we exclude these or is it necessary for
       ;; selection to work, or something like that?
-      (game-object-common/component-scene node-id node-outline-key transform-matrix source-scene))))
+      (game-object-common/component-scene node-id node-outline-key component-pose source-scene))))
 
 (defn make-prototype-desc->scene [embedded-component-resource-data->scene-index embedded-component-scenes referenced-component-proj-path->scene-index referenced-component-scenes]
   (let [any-component-desc->source-scene

--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -1249,11 +1249,11 @@
   (output scene-renderable g/Any (g/constantly nil))
   (output scene-outline-renderable g/Any (g/constantly nil))
   (output color+alpha types/Color (g/fnk [color alpha] (assoc color 3 alpha)))
-  (output scene g/Any :cached (g/fnk [_node-id id aabb transform scene-children scene-renderable scene-outline-renderable scene-updatable]
+  (output scene g/Any :cached (g/fnk [_node-id id aabb pose scene-children scene-renderable scene-outline-renderable scene-updatable]
                                      (cond-> {:node-id _node-id
                                               :node-outline-key id
                                               :aabb aabb
-                                              :transform transform
+                                              :pose pose
                                               :renderable scene-renderable}
 
                                        scene-outline-renderable
@@ -2462,7 +2462,7 @@
                        (if (some? source-scene)
                          (:aabb source-scene)
                          geom/empty-bounding-box)))
-  (output scene g/Any :cached (g/fnk [_node-id aabb transform source-scene scene-children color+alpha inherit-alpha visible enabled]
+  (output scene g/Any :cached (g/fnk [_node-id aabb pose source-scene scene-children color+alpha inherit-alpha visible enabled]
                                 (let [scene (if source-scene
                                               (if-some [updatable (some-> source-scene :updatable (assoc :node-id _node-id))]
                                                 (scene/map-scene #(assoc % :updatable updatable) source-scene)
@@ -2473,7 +2473,7 @@
                                       (assoc
                                         :node-id _node-id
                                         :aabb aabb
-                                        :transform transform
+                                        :pose pose
                                         :visible-self? (and visible enabled)
                                         :visible-children? enabled)
                                       (update :children coll/into-vector scene-children)))))

--- a/editor/src/clj/editor/gui_clipping.clj
+++ b/editor/src/clj/editor/gui_clipping.clj
@@ -472,7 +472,7 @@
   (-> scene
       (update-in [:renderable :user-data] dissoc :clipping) ; don't want to treat this node as a clipper
       (assoc-in [:renderable :user-data :visible-clipper-scene?] true) ; tag it
-      (dissoc :children :transform :aabb)))
+      (dissoc :aabb :children :pose :transform)))
 
 (defn- visible-clipper-scene? [scene]
   (get-in scene [:renderable :user-data :visible-clipper-scene?]))

--- a/editor/src/clj/editor/model_scene.clj
+++ b/editor/src/clj/editor/model_scene.clj
@@ -28,6 +28,7 @@
             [editor.math :as math]
             [editor.model-loader :as model-loader]
             [editor.model-util :as model-util]
+            [editor.pose :as pose]
             [editor.render-util :as render-util]
             [editor.resource :as resource]
             [editor.resource-node :as resource-node]
@@ -471,7 +472,7 @@
 
 (defn- make-renderable-model [model model-request-id mesh-set mesh-material-index->material-name]
   (let [{:keys [translation rotation scale]} (:local model)
-        model-transform (math/clj->mat4 translation rotation scale)
+        model-pose (pose/make translation rotation scale)
 
         renderable-meshes
         (coll/into-> (:meshes model) []
@@ -486,7 +487,7 @@
                          geom/aabb-union
                          geom/null-aabb
                          renderable-meshes)]
-        {:transform model-transform
+        {:pose model-pose
          :aabb model-aabb
          :renderable-meshes renderable-meshes}))))
 
@@ -499,8 +500,8 @@
 
     (g/precluding-errors renderable-models
       (let [mesh-set-aabb (transduce
-                            (map (fn [{:keys [aabb transform]}]
-                                   (geom/aabb-transform aabb transform)))
+                            (map (fn [{:keys [aabb pose]}]
+                                   (geom/aabb-transform aabb (pose/matrix pose))))
                             geom/aabb-union
                             geom/null-aabb
                             renderable-models)]
@@ -556,10 +557,10 @@
      :renderable renderable}))
 
 (defn- make-model-scene [scene-node-id renderable-model]
-  (let [{:keys [transform aabb renderable-meshes]} renderable-model
+  (let [{:keys [pose aabb renderable-meshes]} renderable-model
         mesh-scenes (mapv #(make-mesh-scene scene-node-id %)
                           renderable-meshes)]
-    {:transform transform
+    {:pose pose
      :aabb aabb
      :children mesh-scenes}))
 

--- a/editor/src/clj/editor/particlefx.clj
+++ b/editor/src/clj/editor/particlefx.clj
@@ -372,13 +372,13 @@
                      [2500.0 2500.0 2500.0]))
 
 (g/defnk produce-modifier-scene
-  [_node-id transform type magnitude max-distance node-outline-key]
+  [_node-id pose type magnitude max-distance node-outline-key]
   (let [mod-type (mod-types type)
         magnitude (properties/sample magnitude)
         max-distance (properties/sample max-distance)]
     {:node-id _node-id
      :node-outline-key node-outline-key
-     :transform transform
+     :pose pose
      :aabb geom/empty-bounding-box
      :visibility-aabb modifier-visibility-aabb
      :renderable {:render-fn render-lines
@@ -582,7 +582,7 @@
                            [+bx +bx (case type :emitter-type-circle 0.0 +bx)])))))
 
 (g/defnk produce-emitter-scene
-  [_node-id id transform aabb visibility-aabb type emitter-sim-data emitter-index emitter-key-size-x emitter-key-size-y emitter-key-size-z child-scenes material-attribute-infos max-particle-count vertex-attribute-bytes]
+  [_node-id id pose aabb visibility-aabb type emitter-sim-data emitter-index emitter-key-size-x emitter-key-size-y emitter-key-size-z child-scenes material-attribute-infos max-particle-count vertex-attribute-bytes]
   (let [emitter-type (emitter-types type)
         user-data {:type type
                    :emitter-sim-data emitter-sim-data
@@ -595,7 +595,7 @@
                                            (mapv properties/sample [emitter-key-size-x emitter-key-size-y emitter-key-size-z]))}]
     {:node-id _node-id
      :node-outline-key id
-     :transform transform
+     :pose pose
      :aabb aabb
      :visibility-aabb visibility-aabb
      :renderable {:render-fn render-emitters

--- a/editor/src/clj/editor/pose.clj
+++ b/editor/src/clj/editor/pose.clj
@@ -16,7 +16,7 @@
   (:require [clojure.spec.alpha :as s]
             [editor.math :as math]
             [util.defonce :as defonce])
-  (:import [javax.vecmath Matrix4d]))
+  (:import [javax.vecmath Matrix4d Quat4d Tuple3d]))
 
 (set! *warn-on-reflection* true)
 (set! *unchecked-math* :warn-on-boxed)
@@ -39,7 +39,6 @@
 (def default-scale (vector-of :double 1.0 1.0 1.0))
 (def ^Pose default (->Pose default-translation default-rotation default-scale))
 
-(def ^:private mat4-identity (doto (Matrix4d.) (.setIdentity)))
 (def ^:private num4-zero (vector-of :double 0.0 0.0 0.0 0.0))
 
 (defn- add-vector [[^double ax ^double ay ^double az] [^double bx ^double by ^double bz]]
@@ -296,7 +295,7 @@
   ^Matrix4d [^Pose pose]
   {:pre [(pose? pose)]}
   (if (identical? default pose)
-    mat4-identity
+    math/identity-mat4
     (math/clj->mat4 (.-translation pose) (.-rotation pose) (.-scale pose))))
 
 (defmacro translation-v3 [pose-expr]
@@ -328,3 +327,14 @@
 
 (defmacro scaled? [pose-expr]
   `(not= default-scale (scale-v3 ~pose-expr)))
+
+(defn assign-to-vecmath! [^Pose pose ^Tuple3d out-translation ^Quat4d out-rotation ^Tuple3d out-scale]
+  (if-let [[^double x ^double y ^double z] (translation-v3 pose)]
+    (.set out-translation x y z)
+    (.set out-translation math/zero-v3))
+  (if-let [[^double x ^double y ^double z ^double w] (rotation-q4 pose)]
+    (.set out-rotation x y z w)
+    (.set out-rotation math/identity-quat))
+  (if-let [[^double x ^double y ^double z] (scale-v3 pose)]
+    (.set out-scale x y z)
+    (.set out-scale math/one-v3)))

--- a/editor/src/clj/editor/pose.clj
+++ b/editor/src/clj/editor/pose.clj
@@ -16,7 +16,7 @@
   (:require [clojure.spec.alpha :as s]
             [editor.math :as math]
             [util.defonce :as defonce])
-  (:import [javax.vecmath Matrix4d Quat4d Tuple3d]))
+  (:import [javax.vecmath Matrix4d Quat4d Tuple3d Vector3d]))
 
 (set! *warn-on-reflection* true)
 (set! *unchecked-math* :warn-on-boxed)
@@ -263,6 +263,18 @@
     (apply scale-pose scale)
     default))
 
+(defn from-matrix
+  ^Pose [^Matrix4d matrix]
+  (if (nil? matrix)
+    default
+    (let [translation (Vector3d.)
+          rotation (Quat4d.)
+          scale (Vector3d.)]
+      (math/split-mat4 matrix translation rotation scale)
+      (make (math/vecmath->clj translation)
+            (math/vecmath->clj rotation)
+            (math/vecmath->clj scale)))))
+
 (defn pre-multiply
   ^Pose [^Pose child-pose ^Pose parent-pose]
   {:pre [(pose? child-pose)
@@ -302,7 +314,7 @@
   `(.-translation ~(with-meta pose-expr {:tag `Pose})))
 
 (defmacro translation-v4 [pose-expr w-expr]
-  `(conj (translation-v3 ~pose-expr) (float ~w-expr)))
+  `(conj (translation-v3 ~pose-expr) ~w-expr))
 
 (defmacro rotation-q4 [pose-expr]
   `(.-rotation ~(with-meta pose-expr {:tag `Pose})))

--- a/editor/src/clj/editor/render_util.clj
+++ b/editor/src/clj/editor/render_util.clj
@@ -21,6 +21,7 @@
             [editor.gl.vertex2 :as vtx]
             [editor.graphics.types :as graphics.types]
             [editor.math :as math]
+            [editor.pose :as pose]
             [editor.shaders :as shaders]
             [editor.types :as types]
             [util.array :as array]
@@ -193,13 +194,25 @@
 
 ;; SDK api
 (defn make-outlined-textured-quad-scene
-  [tags transform width height gpu-texture page-index]
-  {:pre [(instance? Matrix4d transform)]}
+  [tags pose-or-transform width height gpu-texture page-index]
   (let [min (Point3d. 0.0 0.0 0.0)
         max (Point3d. (double width) (double height) 0.0)
-        aabb (types/->AABB min max)]
+        aabb (types/->AABB min max)
+        pose (cond
+               (pose/pose? pose-or-transform)
+               pose-or-transform
+
+               ;; Compatibility with legacy editor plugins.
+               ;; Remove once plugins have been updated.
+               (instance? Matrix4d pose-or-transform)
+               (pose/from-matrix pose-or-transform)
+
+               :else
+               (throw
+                 (ex-info "Expected Pose or Matrix4d."
+                          {:value pose-or-transform})))]
     {:aabb aabb
-     :transform transform
+     :pose pose
      :renderable (make-textured-quad-renderable tags 0.0 0.0 width height gpu-texture page-index)
      :children [{:aabb aabb
                  :renderable (make-aabb-outline-renderable tags)}]}))

--- a/editor/src/clj/editor/scene.clj
+++ b/editor/src/clj/editor/scene.clj
@@ -382,11 +382,14 @@
           pass-renderables
           passes))
 
-(defn- assign-transform-to-vecmath! [scene ^Tuple3d translation ^Quat4d rotation ^Tuple3d scale]
-  (if-some [pose (:pose scene)]
-    (pose/assign-to-vecmath! pose translation rotation scale)
-    (when-some [local-transform (:transform scene)]
-      (math/split-mat4 local-transform translation rotation scale))))
+(defn- reject-transform! [scene]
+  (when (contains? scene :transform)
+    (throw (ex-info "Scene maps must use :pose instead of :transform."
+                    {:node-id (:node-id scene)}))))
+
+(defn- assign-pose-to-vecmath! [scene ^Tuple3d translation ^Quat4d rotation ^Tuple3d scale]
+  (when-some [pose (:pose scene)]
+    (pose/assign-to-vecmath! pose translation rotation scale)))
 
 (defn- flatten-scene-renderables! [flattened-scene
                                    parent-shows-children
@@ -409,6 +412,7 @@
         local-translation (Vector3d. 0.0 0.0 0.0)
         local-rotation (Quat4d. 0.0 0.0 0.0 1.0)
         local-scale (Vector3d. 1.0 1.0 1.0)
+        _ (reject-transform! scene)
 
         prop-kw->override-value
         (let [prop-kw->override-value (get preview-overrides node-id)]
@@ -422,7 +426,7 @@
               ;; No need to extract non-overridden values from the local
               ;; transform if all the transform properties are overridden.
               (when-not (and position-override rotation-override scale-override)
-                (assign-transform-to-vecmath! scene local-translation local-rotation local-scale))
+                (assign-pose-to-vecmath! scene local-translation local-rotation local-scale))
 
               ;; Apply transform property overrides. The clj->vecmath function
               ;; writes directly to the supplied vecmath object.
@@ -435,7 +439,7 @@
 
             ;; We're not applying transform property preview overrides. Simply
             ;; use the local transform, if present.
-            (assign-transform-to-vecmath! scene local-translation local-rotation local-scale))
+            (assign-pose-to-vecmath! scene local-translation local-rotation local-scale))
 
           ;; Consume the transform properties to determine if there are
           ;; additional non-transform preview overrides, and we need to invoke
@@ -475,7 +479,7 @@
                      (geom/aabb-transform local-aabb world-transform)
                      geom/null-aabb)
         flat-renderable (-> scene
-                            (dissoc :children :renderable)
+                            (dissoc :children :pose :renderable :transform)
                             (assoc :node-id-path node-id-path
                                    :node-outline-key-path node-outline-key-path
                                    :picking-node-id picking-node-id
@@ -1986,7 +1990,7 @@
   (output transform-properties g/Any :abstract)
   (output transform Matrix4d :cached produce-transform)
   (output pose Pose produce-pose)
-  (output scene g/Any :cached (g/fnk [^g/NodeID _node-id ^Matrix4d transform] {:node-id _node-id :transform transform})))
+  (output scene g/Any :cached (g/fnk [^g/NodeID _node-id ^Pose pose] {:node-id _node-id :pose pose})))
 
 (defmethod scene-tools/manip-movable? ::SceneNode [node-id]
   (contains? (g/node-value node-id :transform-properties) :position))

--- a/editor/src/clj/editor/scene.clj
+++ b/editor/src/clj/editor/scene.clj
@@ -76,7 +76,7 @@
            [javafx.scene.input KeyCode KeyEvent]
            [javafx.scene.layout AnchorPane Pane]
            [javafx.stage Window]
-           [javax.vecmath Matrix4d Point3d Quat4d Vector3d]
+           [javax.vecmath Matrix4d Point3d Quat4d Tuple3d Vector3d]
            [sun.awt.image IntegerComponentRaster]))
 
 (set! *warn-on-reflection* true)
@@ -382,6 +382,12 @@
           pass-renderables
           passes))
 
+(defn- assign-transform-to-vecmath! [scene ^Tuple3d translation ^Quat4d rotation ^Tuple3d scale]
+  (if-some [pose (:pose scene)]
+    (pose/assign-to-vecmath! pose translation rotation scale)
+    (when-some [local-transform (:transform scene)]
+      (math/split-mat4 local-transform translation rotation scale))))
+
 (defn- flatten-scene-renderables! [flattened-scene
                                    parent-shows-children
                                    apply-transform-preview-overrides
@@ -416,8 +422,7 @@
               ;; No need to extract non-overridden values from the local
               ;; transform if all the transform properties are overridden.
               (when-not (and position-override rotation-override scale-override)
-                (when-some [local-transform (:transform scene)]
-                  (math/split-mat4 local-transform local-translation local-rotation local-scale)))
+                (assign-transform-to-vecmath! scene local-translation local-rotation local-scale))
 
               ;; Apply transform property overrides. The clj->vecmath function
               ;; writes directly to the supplied vecmath object.
@@ -430,8 +435,7 @@
 
             ;; We're not applying transform property preview overrides. Simply
             ;; use the local transform, if present.
-            (when-some [local-transform (:transform scene)]
-              (math/split-mat4 local-transform local-translation local-rotation local-scale)))
+            (assign-transform-to-vecmath! scene local-translation local-rotation local-scale))
 
           ;; Consume the transform properties to determine if there are
           ;; additional non-transform preview overrides, and we need to invoke

--- a/editor/src/clj/editor/tile_map.clj
+++ b/editor/src/clj/editor/tile_map.clj
@@ -33,6 +33,7 @@
             [editor.material :as material]
             [editor.math :as math]
             [editor.outline :as outline]
+            [editor.pose :as pose]
             [editor.properties :as properties]
             [editor.protobuf :as protobuf]
             [editor.resource :as resource]
@@ -459,7 +460,7 @@
   [_node-id id cell-map texture-set-data z gpu-texture shader blend-mode visible]
   (when visible
     (let [{:keys [aabb vbuf]} (gen-layer-render-data cell-map texture-set-data)
-          transform (doto (Matrix4d.) (.set (Vector3d. 0.0 0.0 z)))
+          layer-pose (pose/translation-pose 0.0 0.0 z)
 
           ;; The visibility-aabb is used to determine the scene extents. We use
           ;; it to adjust the camera near and far clip planes to encompass the
@@ -474,7 +475,7 @@
             aabb)]
       {:node-id _node-id
        :node-outline-key id
-       :transform transform
+       :pose layer-pose
        :aabb aabb
        :visibility-aabb visibility-aabb
        :renderable {:render-fn render-layer

--- a/editor/src/clj/editor/types.clj
+++ b/editor/src/clj/editor/types.clj
@@ -355,8 +355,8 @@
 
 ;; SDK api
 (def TSceneUpdatable
-  {:initial-state s/Any
-   :update-fn (s/pred fn?)
+  {:update-fn (s/pred fn?)
+   (s/optional-key :initial-state) s/Any
    (s/optional-key :name) s/Str
    (s/optional-key :node-id) TNodeID
    s/Keyword s/Any})

--- a/editor/src/clj/editor/types.clj
+++ b/editor/src/clj/editor/types.clj
@@ -14,9 +14,11 @@
 
 (ns editor.types
   (:require [dynamo.graph :as g]
+            [editor.pose]
             [schema.core :as s]
             [util.defonce :as defonce])
   (:import [com.dynamo.graphics.proto Graphics$TextureImage$TextureFormat]
+           [editor.pose Pose]
            [java.awt.image BufferedImage]
            [java.nio ByteBuffer]
            [javax.vecmath Matrix4d Point3d Quat4d Vector3d Vector4d]))
@@ -28,10 +30,10 @@
 ;; ----------------------------------------
 
 (defprotocol R3Min
-  (min-p ^Point3d  [this]))
+  (min-p ^Point3d [this]))
 
 (defprotocol R3Max
-  (max-p ^Point3d  [this]))
+  (max-p ^Point3d [this]))
 
 (defprotocol Rotation
   (rotation ^Quat4d [this]))
@@ -67,9 +69,9 @@
 ;;; Functions to create basic value types
 ;;; ----------------------------------------
 
-;; note - Int32 is a schema, not a value type
-(def Int32   (s/both s/Int (s/pred #(< Integer/MIN_VALUE % Integer/MAX_VALUE) 'int32?)))
-(def Float32 (s/pred #(instance? Float %) "float"))
+(def TInt32 (s/both s/Int (s/pred #(< Integer/MIN_VALUE % Integer/MAX_VALUE) 'int32?)))
+(def TFloat32 (s/pred #(instance? Float %) "float"))
+(def TNodeID (s/named s/Int "node-id"))
 
 (g/deftype Icon    s/Str)
 
@@ -208,10 +210,10 @@
 (s/defrecord Image
   [path     :- s/Any
    contents :- (s/maybe BufferedImage)
-   width    :- Int32
-   height   :- Int32
-   pivot-x  :- Float32
-   pivot-y  :- Float32
+   width    :- TInt32
+   height   :- TInt32
+   pivot-x  :- TFloat32
+   pivot-y  :- TFloat32
    sprite-trim-mode :- sprite-trim-modes]
   ImageHolder
   (contents [this] contents))
@@ -224,7 +226,7 @@
 (s/defrecord Animation
   [id              :- s/Str
    images          :- [Image]
-   fps             :- Int32
+   fps             :- TInt32
    flip-horizontal :- s/Bool
    flip-vertical   :- s/Bool
    playback        :- playback-modes])
@@ -237,19 +239,19 @@
    animations   :- [Animation]])
 
 (s/defrecord Vertices
-  [counts   :- [Int32]
-   starts   :- [Int32]
+  [counts   :- [TInt32]
+   starts   :- [TInt32]
    vertices :- [s/Num]])
 
 (s/defrecord EngineFormatTexture
-  [width           :- Int32
-   height          :- Int32
-   original-width  :- Int32
-   original-height :- Int32
+  [width           :- TInt32
+   height          :- TInt32
+   original-width  :- TInt32
+   original-height :- TInt32
    format          :- Graphics$TextureImage$TextureFormat
    data            :- ByteBuffer
-   mipmap-sizes    :- [Int32]
-   mipmap-offsets  :- [Int32]])
+   mipmap-sizes    :- [TInt32]
+   mipmap-offsets  :- [TInt32]])
 
 (s/defrecord TextureSetAnimationFrame
   [image                :- Image ; TODO: is this necessary?
@@ -262,9 +264,9 @@
 
 (s/defrecord TextureSetAnimation
   [id              :- s/Str
-   width           :- Int32
-   height          :- Int32
-   fps             :- Int32
+   width           :- TInt32
+   height          :- TInt32
+   fps             :- TInt32
    flip-horizontal :- s/Int
    flip-vertical   :- s/Int
    playback        :- playback-modes
@@ -338,3 +340,40 @@
 
 (g/deftype NodeOutlineKeyPaths #{(s/pred node-outline-key-path?)})
 (g/deftype RenderableTags #{s/Keyword})
+
+;; SDK api
+(def TSceneRenderable
+  {:passes [(s/protocol Pass)]
+   (s/optional-key :batch-key) s/Any
+   (s/optional-key :preview-fn) (s/pred fn?)
+   (s/optional-key :render-fn) (s/pred fn?)
+   (s/optional-key :select-batch-key) s/Any
+   (s/optional-key :tags) #{s/Keyword}
+   (s/optional-key :topmost?) s/Bool
+   (s/optional-key :user-data) s/Any
+   s/Keyword s/Any})
+
+;; SDK api
+(def TSceneUpdatable
+  {:initial-state s/Any
+   :update-fn (s/pred fn?)
+   (s/optional-key :name) s/Str
+   (s/optional-key :node-id) TNodeID
+   s/Keyword s/Any})
+
+;; SDK api
+(def TScene
+  {(s/optional-key :aabb) AABB
+   (s/optional-key :children) [(s/recursive #'TScene)]
+   (s/optional-key :info-text) s/Str
+   (s/optional-key :node-id) TNodeID
+   (s/optional-key :pose) Pose
+   (s/optional-key :renderable) TSceneRenderable
+   (s/optional-key :updatable) (s/maybe TSceneUpdatable)
+   s/Keyword s/Any})
+
+;; SDK api
+(g/deftype SceneRenderable TSceneRenderable)
+(g/deftype SceneUpdatable TSceneUpdatable)
+(g/deftype Scene TScene)
+(g/deftype SceneVec [TScene])

--- a/editor/test/editor/pose_test.clj
+++ b/editor/test/editor/pose_test.clj
@@ -163,6 +163,23 @@
     (is (identical? pose/default-rotation (:rotation pose)))
     (is (= [1.0 2.0 3.0] (:scale pose)))))
 
+(deftest from-matrix-test
+  (is (thrown? Throwable (pose/from-matrix [1.0 2.0 3.0 4.0])))
+  (is (identical? pose/default (pose/from-matrix nil)))
+  (is (identical? pose/default (pose/from-matrix (doto (Matrix4d.) (.setIdentity)))))
+  (let [pose (pose/from-matrix (doto (Matrix4d.) (.setIdentity) (.setTranslation (Vector3d. 1.0 2.0 3.0))))]
+    (is (= [1.0 2.0 3.0] (:translation pose)))
+    (is (identical? pose/default-rotation (:rotation pose)))
+    (is (identical? pose/default-scale (:scale pose))))
+  (let [pose (pose/from-matrix (doto (Matrix4d.) (.setIdentity) (.setRotation (Quat4d. 0.5 0.5 0.5 0.5))))]
+    (is (identical? pose/default-translation (:translation pose)))
+    (is (= [0.5 0.5 0.5 0.5] (:rotation pose)))
+    (is (identical? pose/default-scale (:scale pose))))
+  (let [pose (pose/from-matrix (doto (Matrix4d.) (.setIdentity) (.setScale 10.0)))]
+    (is (identical? pose/default-translation (:translation pose)))
+    (is (identical? pose/default-rotation (:rotation pose)))
+    (is (= [10.0 10.0 10.0] (:scale pose)))))
+
 (deftest translation-pose-test
   (is (thrown? Throwable (pose/translation-pose nil nil nil)))
   (is (identical? pose/default (pose/translation-pose 0.0 0.0 0.0)))
@@ -284,3 +301,43 @@
   (is (= [0.0 180.0 90.0 0.0] (pose/euler-rotation-v4 (pose/euler-rotation-pose 0.0 180.0 90.0))))
   (is (= [1.0 2.0 3.0] (pose/scale-v3 (pose/scale-pose 1.0 2.0 3.0))))
   (is (= [1.0 2.0 3.0 1.0] (pose/scale-v4 (pose/scale-pose 1.0 2.0 3.0)))))
+
+(deftest assign-to-vecmath!-test
+  (testing "Identity"
+    (let [translation (Vector3d. -99.9 -99.9 -99.9)
+          rotation (Quat4d. -99.9 -99.9 -99.9 -99.9)
+          scale (Vector3d. -99.9 -99.9 -99.9)]
+      (pose/assign-to-vecmath! pose/default translation rotation scale)
+      (is (= math/zero-v3 translation))
+      (is (= math/identity-quat rotation))
+      (is (= math/one-v3 scale))))
+
+  (testing "Translation"
+    (let [translation (Vector3d. -99.9 -99.9 -99.9)
+          rotation (Quat4d. -99.9 -99.9 -99.9 -99.9)
+          scale (Vector3d. -99.9 -99.9 -99.9)
+          pose (pose/translation-pose 1.0 2.0 3.0)]
+      (pose/assign-to-vecmath! pose translation rotation scale)
+      (is (= (Vector3d. 1.0 2.0 3.0) translation))
+      (is (= math/identity-quat rotation))
+      (is (= math/one-v3 scale))))
+
+  (testing "Rotation"
+    (let [translation (Vector3d. -99.9 -99.9 -99.9)
+          rotation (Quat4d. -99.9 -99.9 -99.9 -99.9)
+          scale (Vector3d. -99.9 -99.9 -99.9)
+          pose (pose/rotation-pose 0.5 0.5 0.5 0.5)]
+      (pose/assign-to-vecmath! pose translation rotation scale)
+      (is (= math/zero-v3 translation))
+      (is (= (Quat4d. 0.5 0.5 0.5 0.5) rotation))
+      (is (= math/one-v3 scale))))
+
+  (testing "Scale"
+    (let [translation (Vector3d. -99.9 -99.9 -99.9)
+          rotation (Quat4d. -99.9 -99.9 -99.9 -99.9)
+          scale (Vector3d. -99.9 -99.9 -99.9)
+          pose (pose/scale-pose 10.0 20.0 30.0)]
+      (pose/assign-to-vecmath! pose translation rotation scale)
+      (is (= math/zero-v3 translation))
+      (is (= math/identity-quat rotation))
+      (is (= (Vector3d. 10.0 20.0 30.0) scale)))))

--- a/editor/test/editor/render_util_test.clj
+++ b/editor/test/editor/render_util_test.clj
@@ -1,0 +1,40 @@
+;; Copyright 2020-2026 The Defold Foundation
+;; Copyright 2014-2020 King
+;; Copyright 2009-2014 Ragnar Svensson, Christian Murray
+;; Licensed under the Defold License version 1.0 (the "License"); you may not use
+;; this file except in compliance with the License.
+;;
+;; You may obtain a copy of the License, together with FAQs at
+;; https://www.defold.com/license
+;;
+;; Unless required by applicable law or agreed to in writing, software distributed
+;; under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+;; CONDITIONS OF ANY KIND, either express or implied. See the License for the
+;; specific language governing permissions and limitations under the License.
+
+(ns editor.render-util-test
+  (:require [clojure.test :refer :all]
+            [editor.gl.texture :as texture]
+            [editor.pose :as pose]
+            [editor.render-util :as render-util])
+  (:import [clojure.lang ExceptionInfo]
+           [javax.vecmath Matrix4d Vector3d]))
+
+(set! *warn-on-reflection* true)
+(set! *unchecked-math* :warn-on-boxed)
+
+(deftest make-outlined-textured-quad-scene-accepts-pose-or-matrix-test
+  (let [quad-pose (pose/translation-pose 1.0 2.0 3.0)
+        transform (doto (Matrix4d.)
+                    (.setIdentity)
+                    (.setTranslation (Vector3d. 1.0 2.0 3.0)))]
+    (is (= quad-pose
+           (:pose (render-util/make-outlined-textured-quad-scene #{} quad-pose 10 20 @texture/white-pixel 0))))
+    (is (= quad-pose
+           (:pose (render-util/make-outlined-textured-quad-scene #{} transform 10 20 @texture/white-pixel 0))))))
+
+(deftest make-outlined-textured-quad-scene-rejects-unsupported-transform-test
+  (is (thrown-with-msg?
+        ExceptionInfo
+        #"Expected Pose or Matrix4d"
+        (render-util/make-outlined-textured-quad-scene #{} ::invalid 10 20 @texture/white-pixel 0))))

--- a/editor/test/editor/scene_test.clj
+++ b/editor/test/editor/scene_test.clj
@@ -18,9 +18,10 @@
             [editor.geom :as geom]
             [editor.gl.pass :as pass]
             [editor.math :as math]
+            [editor.pose :as pose]
             [editor.scene :as scene]
             [util.coll :refer [pair]])
-  (:import [javax.vecmath Matrix4d Vector3d]))
+  (:import [javax.vecmath Vector3d]))
 
 (set! *warn-on-reflection* true)
 (set! *unchecked-math* :warn-on-boxed)
@@ -118,7 +119,7 @@
 (deftest flatten-scene-preview-overrides-test
   (let [scene {:node-id :root
                :children [{:node-id :child
-                           :transform (doto (Matrix4d.) (.setIdentity) (.setTranslation (Vector3d. 1.0 2.0 3.0)))
+                           :pose (pose/translation-pose 1.0 2.0 3.0)
                            :aabb (geom/coords->aabb [10.0 10.0 10.0] [100.0 100.0 100.0])}]}]
 
     (testing "Without preview overrides."
@@ -151,7 +152,7 @@
                                         :user-data renderable-user-data}}]}
         preview-position [2.0 3.0 4.0]
         preview-translation (doto (Vector3d.) (math/clj->vecmath preview-position))
-        preview-transform-matrix (doto (Matrix4d.) (.setIdentity) (.setTranslation preview-translation))
+        preview-transform-matrix (pose/matrix (pose/translation-pose 2.0 3.0 4.0))
         preview-aabb-transformed (geom/aabb-transform preview-aabb preview-transform-matrix)
         preview-overrides {:child {:position preview-position
                                    :custom :custom-value}}
@@ -203,16 +204,37 @@
     (testing "Child :preview-fn still receives non-transform overrides."
       (is (= [{:custom :value}] @preview-fn-overrides-atom)))))
 
+(deftest flatten-scene-preserves-negative-scale-test
+  (let [local-pose (pose/make [1.0 2.0 3.0]
+                              pose/default-rotation
+                              [-2.0 3.0 -4.0])
+        scene {:node-id :root
+               :children [{:node-id :child
+                           :pose local-pose
+                           :renderable {:passes [pass/transparent]}}]}
+        renderable (get-in (flatten-scene scene nil) [:renderables pass/transparent 0])]
+    (is (= (Vector3d. 1.0 2.0 3.0) (:world-translation renderable)))
+    (is (= (Vector3d. -2.0 3.0 -4.0) (:world-scale renderable)))
+    (is (= (pose/matrix local-pose) (:world-transform renderable)))
+    (is (not (contains? renderable :pose)))
+    (is (not (contains? renderable :transform)))))
+
+(deftest flatten-scene-rejects-transform-test
+  (let [scene {:node-id :root
+               :children [{:node-id :child
+                           :transform math/identity-mat4}]}]
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                          #"Scene maps must use :pose instead of :transform"
+                          (flatten-scene scene nil)))))
+
 (deftest renderables-sort-back-to-front-test
   (let [camera (camera/make-camera)
-        near-world-transform (doto (Matrix4d.) (.setIdentity) (.setTranslation (Vector3d. 0.0 0.0 -1.0)))
-        far-world-transform (doto (Matrix4d.) (.setIdentity) (.setTranslation (Vector3d. 0.0 0.0 -100.0)))
         scene {:node-id :root
                :children [{:node-id :near
-                           :transform near-world-transform
+                           :pose (pose/translation-pose 0.0 0.0 -1.0)
                            :renderable {:passes [pass/transparent]}}
                           {:node-id :far
-                           :transform far-world-transform
+                           :pose (pose/translation-pose 0.0 0.0 -100.0)
                            :renderable {:passes [pass/transparent]}}]}
         renderables-by-pass (scene-renderables-by-pass scene camera)]
     (is (= [:far :near]

--- a/editor/test/integration/non_editable_resources_test.clj
+++ b/editor/test/integration/non_editable_resources_test.clj
@@ -24,7 +24,6 @@
             [editor.protobuf :as protobuf]
             [editor.resource :as resource]
             [editor.resource-node :as resource-node]
-            [editor.shared-editor-settings :as shared-editor-settings]
             [editor.workspace :as workspace]
             [integration.test-util :as tu]
             [internal.util :as util]
@@ -370,9 +369,9 @@
 
       (doto chair-embedded-sprite
         (tu/prop! :id "chair-embedded-sprite")
-        (tu/prop! :position [1.1 1.2 1.3])
-        (tu/prop! :rotation (math/vecmath->clj (math/euler-z->quat 1.0)))
-        (tu/prop! :scale [1.4 1.5 1.6])
+        (tu/prop! :position (vector-of :float 1.1 1.2 1.3))
+        (tu/prop! :rotation (into (vector-of :float) (math/vecmath->clj (math/euler-z->quat 1.0))))
+        (tu/prop! :scale (vector-of :float 1.4 1.5 1.6))
         (tu/prop! :__sampler__texture_sampler__0 (tu/resource workspace "/assets/from-chair-embedded-sprite.atlas"))
         (tu/prop! :default-animation "from-chair-embedded-sprite"))
 
@@ -381,21 +380,21 @@
 
       (doto chair-referenced-sprite
         (tu/prop! :id "chair-referenced-sprite")
-        (tu/prop! :position [2.1 2.2 2.3])
-        (tu/prop! :rotation (math/vecmath->clj (math/euler-z->quat 2.0)))
-        (tu/prop! :scale [2.4 2.5 2.6]))
+        (tu/prop! :position (vector-of :float 2.1 2.2 2.3))
+        (tu/prop! :rotation (into (vector-of :float) (math/vecmath->clj (math/euler-z->quat 2.0))))
+        (tu/prop! :scale (vector-of :float 2.4 2.5 2.6)))
 
       (doto room-embedded-chair
         (tu/prop! :id "room-embedded-chair")
-        (tu/prop! :position [3.1 3.2 3.3])
-        (tu/prop! :rotation (math/vecmath->clj (math/euler-z->quat 3.0)))
-        (tu/prop! :scale [3.4 3.5 3.6]))
+        (tu/prop! :position (vector-of :float 3.1 3.2 3.3))
+        (tu/prop! :rotation (into (vector-of :float) (math/vecmath->clj (math/euler-z->quat 3.0))))
+        (tu/prop! :scale (vector-of :float 3.4 3.5 3.6)))
 
       (doto room-embedded-chair-embedded-sprite
         (tu/prop! :id "room-embedded-chair-embedded-sprite")
-        (tu/prop! :position [4.1 4.2 4.3])
-        (tu/prop! :rotation (math/vecmath->clj (math/euler-z->quat 4.0)))
-        (tu/prop! :scale [4.4 4.5 4.6])
+        (tu/prop! :position (vector-of :float 4.1 4.2 4.3))
+        (tu/prop! :rotation (into (vector-of :float) (math/vecmath->clj (math/euler-z->quat 4.0))))
+        (tu/prop! :scale (vector-of :float 4.4 4.5 4.6))
         (tu/prop! :__sampler__texture_sampler__0 (tu/resource workspace "/assets/from-room-embedded-chair-embedded-sprite.atlas"))
         (tu/prop! :default-animation "from-room-embedded-chair-embedded-sprite"))
 
@@ -404,21 +403,21 @@
 
       (doto room-embedded-chair-referenced-sprite
         (tu/prop! :id "room-embedded-chair-referenced-sprite")
-        (tu/prop! :position [5.1 5.2 5.3])
-        (tu/prop! :rotation (math/vecmath->clj (math/euler-z->quat 5.0)))
-        (tu/prop! :scale [5.4 5.5 5.6]))
+        (tu/prop! :position (vector-of :float 5.1 5.2 5.3))
+        (tu/prop! :rotation (into (vector-of :float) (math/vecmath->clj (math/euler-z->quat 5.0))))
+        (tu/prop! :scale (vector-of :float 5.4 5.5 5.6)))
 
       (doto room-referenced-chair
         (tu/prop! :id "room-referenced-chair")
-        (tu/prop! :position [6.1 6.2 6.3])
-        (tu/prop! :rotation (math/vecmath->clj (math/euler-z->quat 6.0)))
-        (tu/prop! :scale [6.4 6.5 6.6]))
+        (tu/prop! :position (vector-of :float 6.1 6.2 6.3))
+        (tu/prop! :rotation (into (vector-of :float) (math/vecmath->clj (math/euler-z->quat 6.0))))
+        (tu/prop! :scale (vector-of :float 6.4 6.5 6.6)))
 
       (doto house-referenced-room
         (tu/prop! :id "house-referenced-room")
-        (tu/prop! :position [7.1 7.2 7.3])
-        (tu/prop! :rotation (math/vecmath->clj (math/euler-z->quat 7.0)))
-        (tu/prop! :scale [7.4 7.5 7.6]))
+        (tu/prop! :position (vector-of :float 7.1 7.2 7.3))
+        (tu/prop! :rotation (into (vector-of :float) (math/vecmath->clj (math/euler-z->quat 7.0))))
+        (tu/prop! :scale (vector-of :float 7.4 7.5 7.6)))
 
       {:chair chair
        :house house

--- a/editor/test/integration/test_util.clj
+++ b/editor/test/integration/test_util.clj
@@ -60,6 +60,7 @@
             [internal.system :as is]
             [internal.util :as util]
             [lambdaisland.deep-diff2 :as deep-diff]
+            [local-extensions :as local-extensions]
             [service.log :as log]
             [support.test-support :as test-support]
             [util.coll :refer [pair]]
@@ -122,11 +123,11 @@
 ;; These extensions register additional protobuf resource types that we want to
 ;; cover in our tests.
 (def sanctioned-extension-urls
-  (mapv #(System/getProperty %)
-        ["defold.extension.rive.url"
-         "defold.extension.simpledata.url"
-         "defold.extension.spine.url"
-         "defold.extension.texturepacker.url"]))
+  (mapv local-extensions/inject-jvm-properties
+        ["{{defold.extension.rive.url}}"
+         "{{defold.extension.simpledata.url}}"
+         "{{defold.extension.spine.url}}"
+         "{{defold.extension.texturepacker.url}}"]))
 
 (defn number-type-preserving? [a b]
   (assert (or (number? a) (vector? a) (instance? Curve a) (instance? CurveSpread a)))


### PR DESCRIPTION
Fixed visual discrepancies during Scene View manipulator operations caused by faster drag preview code path.

Fixes #12295

### Technical changes
* Scene transforms are now propagates as Pose records that retain separated translation, rotation, and scale instead of trying to derive these from `Matrix4d` objects.
* Renderables are now expected to specify a `:pose` for the scene rather than a `Matrix4d` `:transform`.
* When flattening the scene, we now use the local transform properties from the `:pose`, and we throw an exception in case we encounter a `scene` with a `:transform` to catch anything that hasn't been ported yet.
* Added pose helpers for matrix conversion and assignment to vecmath objects like `Vector3d`.
* Updated `make-outlined-textured-quad-scene` to take a `Pose`. Since it was also used in `extension-texturepacker`, we still accept a `Matrix4d` and convert it to a `Pose` for the time being.
* Moved scene-related schema types from `extension-texturepacker` to `editor.types`.

See counterpart PR in defold/extension-texturepacker#25.