### PR TITLE
Fix DX12 texture array upload stack overflow for layer footprints

### DIFF
--- a/engine/graphics/src/dx12/graphics_dx12.cpp
+++ b/engine/graphics/src/dx12/graphics_dx12.cpp
@@ -1270,9 +1270,15 @@ namespace dmGraphics
         const uint16_t tex_layer_count   = dmMath::Max(texture->m_LayerCount, (uint16_t) params.m_LayerCount);
         const uint32_t subresource_count = tex_layer_count; // only one mip, full array
 
-        D3D12_PLACED_SUBRESOURCE_FOOTPRINT fp[16] = {};
-        uint32_t num_rows[16];
-        uint64_t row_size_in_bytes[16];
+        dmArray<D3D12_PLACED_SUBRESOURCE_FOOTPRINT> fp;
+        dmArray<uint32_t> num_rows;
+        dmArray<uint64_t> row_size_in_bytes;
+        fp.SetCapacity(tex_layer_count);
+        fp.SetSize(tex_layer_count);
+        num_rows.SetCapacity(tex_layer_count);
+        num_rows.SetSize(tex_layer_count);
+        row_size_in_bytes.SetCapacity(tex_layer_count);
+        row_size_in_bytes.SetSize(tex_layer_count);
         uint64_t total_upload_size = 0;
 
         // Calculate offset/footprint per array slice


### PR DESCRIPTION
### Motivation
- The DX12 upload path in `TextureBufferUploadHelper` used fixed-size stack arrays (`fp[16]`, `num_rows[16]`, `row_size_in_bytes[16]`) but iterated up to `tex_layer_count`, allowing out-of-bounds writes for texture arrays with more than 16 layers.
- This could corrupt stack memory during `CopyTextureRegion` and lead to crashes or code execution when processing crafted large-array textures.

### Description
- Replaced the fixed-size per-slice buffers with dynamically sized `dmArray` containers for `D3D12_PLACED_SUBRESOURCE_FOOTPRINT`, `uint32_t` rows, and `uint64_t` row sizes.
- The `dmArray` buffers are `SetCapacity`/`SetSize` to `tex_layer_count` so all per-layer accesses are bounds-safe while preserving the existing upload and copy logic.
- No changes were made to the copy semantics or footprint calculation beyond switching storage to variable-sized arrays.

### Testing
- Verified the vulnerable fixed-size patterns are removed by running `rg` for `fp[16]`, `num_rows[16]`, and `row_size_in_bytes[16]`, which returned no matches (success).
- Inspected the modified region with `nl`/`sed` to confirm `dmArray` allocations are sized to `tex_layer_count` and that loops index those arrays (success).
- Attempted a DX12 build in this environment previously failed due to missing DX12 headers (`d3d12.h` not found), so a full compile/test on DX12 could not be executed here (failure due to environment limitations).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69b5d9580708832d89b161994bafb09d)