### PR TITLE
Allow changing zoom even when a camera component uses Fit or Cover mode

### DIFF
--- a/editor/src/clj/editor/camera_editor.clj
+++ b/editor/src/clj/editor/camera_editor.clj
@@ -286,7 +286,7 @@
   (let [vertex-buffer (gen-outline-vertex-buffer render-args renderables renderable-count)
         outline-vertex-binding (vtx/use-with ::frustum-outline vertex-buffer outline-shader)]
     (gl/with-gl-bindings gl render-args [outline-shader outline-vertex-binding]
-      (gl/gl-draw-arrays gl GL/GL_LINES 0 (* renderable-count camera-preview-mesh-vertices-count)))))
+      (gl/gl-draw-arrays gl GL/GL_LINES 0 (count vertex-buffer)))))
 
 (g/defnk produce-camera-scene
   [_node-id fov aspect-ratio near-z far-z orthographic-projection orthographic-zoom orthographic-mode project-display-width project-display-height]

--- a/editor/src/clj/editor/camera_editor.clj
+++ b/editor/src/clj/editor/camera_editor.clj
@@ -244,9 +244,6 @@
         dh (double display-height)]
     (if (true? is-orthographic)
       (let [zoom (double (or orthographic-zoom 1.0))
-            zoom (if (= orthographic-mode :ortho-mode-fixed)
-                   zoom
-                   1.0)
             ow (/ dw zoom)
             oh (/ dh zoom)]
         (camera/simple-orthographic-projection-matrix near far ow oh))
@@ -264,8 +261,8 @@
             {:keys [is-orthographic near-z far-z fov aspect-ratio display-width display-height orthographic-zoom orthographic-mode]} (:user-data renderable)
             world-translation (:world-translation renderable)
             world-rotation (:world-rotation renderable)]
-        ;; Hide frustum preview when orthographic zoom is invalid (<= 0) in fixed mode
-        (if (and is-orthographic (= orthographic-mode :ortho-mode-fixed)
+        ;; Hide frustum preview when orthographic zoom is invalid (<= 0).
+        (if (and is-orthographic
                  (not (> (double (or orthographic-zoom 0.0)) 0.0)))
           (recur (rest renderables) vbuf)
           (let [;; Pixel-stable scale for the small camera mesh at the camera position.
@@ -368,7 +365,8 @@
   (property orthographic-zoom g/Num (default (protobuf/default Camera$CameraDesc :orthographic-zoom))
             (dynamic label (properties/label-dynamic :camera :orthographic-zoom))
             (dynamic tooltip (properties/tooltip-dynamic :camera :orthographic-zoom))
-            (dynamic read-only? (g/fnk [orthographic-projection orthographic-mode] (not (and orthographic-projection (= orthographic-mode :ortho-mode-fixed)))))
+            (dynamic edit-type (g/constantly {:type g/Num :min Double/MIN_NORMAL}))
+            (dynamic read-only? (g/fnk [orthographic-projection] (not orthographic-projection)))
             (dynamic error (g/fnk [_node-id orthographic-zoom]
                              (validation/prop-error :fatal _node-id :orthographic-zoom validation/prop-zero-or-below? orthographic-zoom orthographic-zoom-message))))
 

--- a/engine/gamesys/proto/gamesys/camera_ddf.proto
+++ b/engine/gamesys/proto/gamesys/camera_ddf.proto
@@ -22,8 +22,8 @@ option java_outer_classname = "Camera";
 enum OrthoZoomMode
 {
     ORTHO_MODE_FIXED        = 0[(displayName) = "Fixed"]; // Use orthographic_zoom as-is
-    ORTHO_MODE_AUTO_FIT     = 1[(displayName) = "Auto Fit"]; // Fit original display area (fit)
-    ORTHO_MODE_AUTO_COVER   = 2[(displayName) = "Auto Cover"]; // Fill original display area (cover)
+    ORTHO_MODE_AUTO_FIT     = 1[(displayName) = "Auto Fit"]; // Fit original display area and multiply by orthographic_zoom
+    ORTHO_MODE_AUTO_COVER   = 2[(displayName) = "Auto Cover"]; // Fill original display area and multiply by orthographic_zoom
 }
 
 message CameraDesc
@@ -50,7 +50,7 @@ message CameraDesc
  * @param near_z [type:number] position of the near clipping plane (distance from camera along relative z)
  * @param far_z [type:number] position of the far clipping plane (distance from camera along relative z)
  * @param orthographic_projection [type:boolean] set to use an orthographic projection
- * @param orthographic_zoom [type:number] zoom level when the camera is using an orthographic projection
+ * @param orthographic_zoom [type:number] positive zoom multiplier when the camera is using an orthographic projection
  * @param orthographic_mode [type:number] orthographic zoom behavior when orthographic_projection is enabled
  * @examples
  *
@@ -167,7 +167,8 @@ message ReleaseCameraFocus {}
 
 /*# [type:float] camera orthographic_zoom
  *
- * Zoom level when using an orthographic projection.
+ * Positive zoom multiplier when using an orthographic projection. In auto fit and auto cover
+ * modes, this value is multiplied with the calculated orthographic_auto_zoom value.
  * The type of the property is float.
  *
  * @name orthographic_zoom
@@ -180,6 +181,24 @@ message ReleaseCameraFocus {}
  *   local orthographic_zoom = go.get("#camera", "orthographic_zoom")
  *   go.set("#camera", "orthographic_zoom", 2.0)
  *   go.animate("#camera", "orthographic_zoom", go.PLAYBACK_ONCE_PINGPONG, 0.5, go.EASING_INOUTQUAD, 2)
+ * end
+ * ```
+ */
+
+/*# [type:float] camera orthographic_auto_zoom
+ *
+ * [mark:READ ONLY] The zoom calculated from the current window and project dimensions
+ * in auto fit and auto cover modes. The value is 1.0 in fixed mode.
+ * The type of the property is float.
+ *
+ * @name orthographic_auto_zoom
+ * @property
+ *
+ * @examples
+ *
+ * ```lua
+ * function init(self)
+ *   local orthographic_auto_zoom = go.get("#camera", "orthographic_auto_zoom")
  * end
  * ```
  */

--- a/engine/gamesys/src/gamesys/components/comp_camera.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_camera.cpp
@@ -58,13 +58,14 @@ namespace dmGameSystem
         dmArray<CameraComponent*> m_CameraStack;
     };
 
-    static const dmhash_t CAMERA_PROP_FOV               = dmHashString64("fov");
-    static const dmhash_t CAMERA_PROP_NEAR_Z            = dmHashString64("near_z");
-    static const dmhash_t CAMERA_PROP_FAR_Z             = dmHashString64("far_z");
-    static const dmhash_t CAMERA_PROP_ORTHOGRAPHIC_ZOOM = dmHashString64("orthographic_zoom");
-    static const dmhash_t CAMERA_PROP_PROJECTION        = dmHashString64("projection");
-    static const dmhash_t CAMERA_PROP_VIEW              = dmHashString64("view");
-    static const dmhash_t CAMERA_PROP_ASPECT_RATIO      = dmHashString64("aspect_ratio");
+    static const dmhash_t CAMERA_PROP_FOV                    = dmHashString64("fov");
+    static const dmhash_t CAMERA_PROP_NEAR_Z                 = dmHashString64("near_z");
+    static const dmhash_t CAMERA_PROP_FAR_Z                  = dmHashString64("far_z");
+    static const dmhash_t CAMERA_PROP_ORTHOGRAPHIC_ZOOM      = dmHashString64("orthographic_zoom");
+    static const dmhash_t CAMERA_PROP_ORTHOGRAPHIC_AUTO_ZOOM = dmHashString64("orthographic_auto_zoom");
+    static const dmhash_t CAMERA_PROP_PROJECTION             = dmHashString64("projection");
+    static const dmhash_t CAMERA_PROP_VIEW                   = dmHashString64("view");
+    static const dmhash_t CAMERA_PROP_ASPECT_RATIO           = dmHashString64("aspect_ratio");
 
 
     static void CompCameraUpdateViewProjection(CameraComponent* camera, dmRender::RenderContext* render_context)
@@ -354,6 +355,12 @@ namespace dmGameSystem
             out_value.m_Variant = dmGameObject::PropertyVar(camera_data.m_OrthographicZoom);
             return dmGameObject::PROPERTY_RESULT_OK;
         }
+        else if (CAMERA_PROP_ORTHOGRAPHIC_AUTO_ZOOM == get_property)
+        {
+            float auto_zoom = dmRender::GetRenderCameraOrthographicAutoZoom(render_context, camera->m_RenderCamera);
+            out_value.m_Variant = dmGameObject::PropertyVar(auto_zoom);
+            return dmGameObject::PROPERTY_RESULT_OK;
+        }
         else if (CAMERA_PROP_PROJECTION == get_property)
         {
             out_value.m_Variant = dmGameObject::PropertyVar(camera->m_Projection);
@@ -401,6 +408,10 @@ namespace dmGameSystem
         }
         else if (CAMERA_PROP_ORTHOGRAPHIC_ZOOM == set_property)
         {
+            if (!(params.m_Value.m_Number > 0.0f))
+            {
+                return dmGameObject::PROPERTY_RESULT_UNSUPPORTED_VALUE;
+            }
             camera_data.m_OrthographicZoom = params.m_Value.m_Number;
             dmRender::SetRenderCameraData(render_context, camera->m_RenderCamera, &camera_data);
             return dmGameObject::PROPERTY_RESULT_OK;
@@ -413,6 +424,7 @@ namespace dmGameSystem
         }
         else if (CAMERA_PROP_PROJECTION   == set_property ||
                  CAMERA_PROP_VIEW         == set_property ||
+                 CAMERA_PROP_ORTHOGRAPHIC_AUTO_ZOOM == set_property ||
                  CAMERA_PROP_ASPECT_RATIO == set_property)
         {
             return dmGameObject::PROPERTY_RESULT_READ_ONLY;

--- a/engine/gamesys/src/gamesys/test/camera/camera_info.script
+++ b/engine/gamesys/src/gamesys/test/camera/camera_info.script
@@ -28,6 +28,12 @@ function init(self)
 
 	-- Test new auto aspect ratio APIs
 	local cam = cams[1]
+	local component_auto_zoom = go.get("#camera_1", "orthographic_auto_zoom")
+	assert(math.abs(component_auto_zoom - 1.0) < 0.001, "Fixed mode orthographic auto zoom should be 1.0")
+	local ok = pcall(go.set, "#camera_1", "orthographic_auto_zoom", 2.0)
+	assert(ok == false, "Orthographic auto zoom should be read-only")
+	ok = pcall(go.set, "#camera_1", "orthographic_zoom", 0.0)
+	assert(ok == false, "Orthographic zoom should be positive")
 	
 	-- Test 1: Get initial auto aspect ratio state (should be false by default)
 	local auto_enabled = camera.get_auto_aspect_ratio(cam)

--- a/engine/render/src/render/camera.cpp
+++ b/engine/render/src/render/camera.cpp
@@ -65,6 +65,10 @@ namespace dmRender
         if (c)
         {
             c->m_Data = *data;
+            if (!(c->m_Data.m_OrthographicZoom > 0.0f))
+            {
+                c->m_Data.m_OrthographicZoom = 1.0f;
+            }
         }
     }
 

--- a/engine/render/src/render/camera.cpp
+++ b/engine/render/src/render/camera.cpp
@@ -33,6 +33,7 @@ namespace dmRender
 
         memset(&camera->m_Data, 0, sizeof(camera->m_Data));
         camera->m_Data.m_Viewport = dmVMath::Vector4(0.0f, 0.0f, 1.0f, 1.0f);
+        camera->m_Data.m_OrthographicZoom = 1.0f;
         camera->m_Data.m_OrthographicMode = ORTHO_MODE_FIXED;
 
         return camera->m_Handle;
@@ -101,6 +102,57 @@ namespace dmRender
         }
     }
 
+    static float CalculateOrthographicAutoZoom(dmGraphics::HContext graphics_context, const RenderCameraData* data)
+    {
+        if (!data->m_OrthographicProjection ||
+            (data->m_OrthographicMode != ORTHO_MODE_AUTO_FIT && data->m_OrthographicMode != ORTHO_MODE_AUTO_COVER))
+        {
+            return 1.0f;
+        }
+
+        float display_scale = dmGraphics::GetDisplayScaleFactor(graphics_context);
+        float width         = (float) dmGraphics::GetWindowWidth(graphics_context);
+        float height        = (float) dmGraphics::GetWindowHeight(graphics_context);
+        float proj_width    = (float) dmGraphics::GetWidth(graphics_context);
+        float proj_height   = (float) dmGraphics::GetHeight(graphics_context);
+
+        if (display_scale <= 0.0f)
+        {
+            display_scale = 1.0f;
+        }
+        if (proj_width <= 0.0f)
+        {
+            proj_width = 1.0f;
+        }
+        if (proj_height <= 0.0f)
+        {
+            proj_height = 1.0f;
+        }
+
+        float zx = width / (display_scale * proj_width);
+        float zy = height / (display_scale * proj_height);
+        float zoom = data->m_OrthographicMode == ORTHO_MODE_AUTO_FIT ? ((zx < zy) ? zx : zy) : ((zx > zy) ? zx : zy);
+
+        if (zoom <= 0.0f)
+        {
+            zoom = 1.0f;
+        }
+
+        return zoom;
+    }
+
+    float GetRenderCameraOrthographicAutoZoom(HRenderContext render_context, HRenderCamera camera)
+    {
+        RenderCamera* c = render_context->m_RenderCameras.Get(camera);
+
+        if (c)
+        {
+            return CalculateOrthographicAutoZoom(GetGraphicsContext(render_context), &c->m_Data);
+        }
+
+        return 1.0f;
+    }
+
     void UpdateRenderCamera(HRenderContext render_context, HRenderCamera camera, const dmVMath::Point3* position, const dmVMath::Quat* rotation)
     {
         RenderCamera* c = render_context->m_RenderCameras.Get(camera);
@@ -122,43 +174,18 @@ namespace dmRender
         if (c->m_Data.m_OrthographicProjection)
         {
             float display_scale = dmGraphics::GetDisplayScaleFactor(graphics_context);
+            if (display_scale <= 0.0f)
+            {
+                display_scale = 1.0f;
+            }
 
             // Determine zoom
             float zoom = c->m_Data.m_OrthographicZoom;
 
-            // Project (reference) size from game.project
-            float proj_width = (float) dmGraphics::GetWidth(graphics_context);
-            float proj_height = (float) dmGraphics::GetHeight(graphics_context);
-
-            // Fallbacks to avoid division by zero
-            if (proj_width <= 0.0f)
-            {
-            	proj_width = 1.0f;
-            }
-            if (proj_height <= 0.0f)
-            {
-            	proj_height = 1.0f;
-            }
-
             // Compute auto zoom if requested
             if (c->m_Data.m_OrthographicMode == ORTHO_MODE_AUTO_FIT || c->m_Data.m_OrthographicMode == ORTHO_MODE_AUTO_COVER)
             {
-                float zx = width / (display_scale * proj_width);
-                float zy = height / (display_scale * proj_height);
-
-                if (c->m_Data.m_OrthographicMode == ORTHO_MODE_AUTO_FIT)
-                {
-                    zoom = (zx < zy) ? zx : zy;
-                }
-                else if (c->m_Data.m_OrthographicMode == ORTHO_MODE_AUTO_COVER)
-                {
-                    zoom = (zx > zy) ? zx : zy;
-                }
-
-                if (zoom <= 0.0f)
-                {
-                    zoom = 1.0f;
-                }
+                zoom *= CalculateOrthographicAutoZoom(graphics_context, &c->m_Data);
             }
 
             float zoomed_width = width / display_scale / zoom;

--- a/engine/render/src/render/camera.cpp
+++ b/engine/render/src/render/camera.cpp
@@ -28,8 +28,9 @@ namespace dmRender
         }
 
         RenderCamera* camera = new RenderCamera();
-        camera->m_URL        = dmMessage::URL();
-        camera->m_Handle     = render_context->m_RenderCameras.Put(camera);
+        camera->m_URL                  = dmMessage::URL();
+        camera->m_Handle               = render_context->m_RenderCameras.Put(camera);
+        camera->m_OrthographicAutoZoom = 1.0f;
 
         memset(&camera->m_Data, 0, sizeof(camera->m_Data));
         camera->m_Data.m_Viewport = dmVMath::Vector4(0.0f, 0.0f, 1.0f, 1.0f);
@@ -102,52 +103,13 @@ namespace dmRender
         }
     }
 
-    static float CalculateOrthographicAutoZoom(dmGraphics::HContext graphics_context, const RenderCameraData* data)
-    {
-        if (!data->m_OrthographicProjection ||
-            (data->m_OrthographicMode != ORTHO_MODE_AUTO_FIT && data->m_OrthographicMode != ORTHO_MODE_AUTO_COVER))
-        {
-            return 1.0f;
-        }
-
-        float display_scale = dmGraphics::GetDisplayScaleFactor(graphics_context);
-        float width         = (float) dmGraphics::GetWindowWidth(graphics_context);
-        float height        = (float) dmGraphics::GetWindowHeight(graphics_context);
-        float proj_width    = (float) dmGraphics::GetWidth(graphics_context);
-        float proj_height   = (float) dmGraphics::GetHeight(graphics_context);
-
-        if (display_scale <= 0.0f)
-        {
-            display_scale = 1.0f;
-        }
-        if (proj_width <= 0.0f)
-        {
-            proj_width = 1.0f;
-        }
-        if (proj_height <= 0.0f)
-        {
-            proj_height = 1.0f;
-        }
-
-        float zx = width / (display_scale * proj_width);
-        float zy = height / (display_scale * proj_height);
-        float zoom = data->m_OrthographicMode == ORTHO_MODE_AUTO_FIT ? ((zx < zy) ? zx : zy) : ((zx > zy) ? zx : zy);
-
-        if (zoom <= 0.0f)
-        {
-            zoom = 1.0f;
-        }
-
-        return zoom;
-    }
-
     float GetRenderCameraOrthographicAutoZoom(HRenderContext render_context, HRenderCamera camera)
     {
         RenderCamera* c = render_context->m_RenderCameras.Get(camera);
 
         if (c)
         {
-            return CalculateOrthographicAutoZoom(GetGraphicsContext(render_context), &c->m_Data);
+            return c->m_OrthographicAutoZoom;
         }
 
         return 1.0f;
@@ -171,21 +133,50 @@ namespace dmRender
             aspect_ratio = width / height;
         }
 
+        c->m_OrthographicAutoZoom = 1.0f;
+
         if (c->m_Data.m_OrthographicProjection)
         {
             float display_scale = dmGraphics::GetDisplayScaleFactor(graphics_context);
-            if (display_scale <= 0.0f)
-            {
-                display_scale = 1.0f;
-            }
 
             // Determine zoom
             float zoom = c->m_Data.m_OrthographicZoom;
 
+            // Project (reference) size from game.project
+            float proj_width = (float) dmGraphics::GetWidth(graphics_context);
+            float proj_height = (float) dmGraphics::GetHeight(graphics_context);
+
+            // Fallbacks to avoid division by zero
+            if (proj_width <= 0.0f)
+            {
+                proj_width = 1.0f;
+            }
+            if (proj_height <= 0.0f)
+            {
+                proj_height = 1.0f;
+            }
+
             // Compute auto zoom if requested
             if (c->m_Data.m_OrthographicMode == ORTHO_MODE_AUTO_FIT || c->m_Data.m_OrthographicMode == ORTHO_MODE_AUTO_COVER)
             {
-                zoom *= CalculateOrthographicAutoZoom(graphics_context, &c->m_Data);
+                float zx = width / (display_scale * proj_width);
+                float zy = height / (display_scale * proj_height);
+
+                if (c->m_Data.m_OrthographicMode == ORTHO_MODE_AUTO_FIT)
+                {
+                    c->m_OrthographicAutoZoom = (zx < zy) ? zx : zy;
+                }
+                else if (c->m_Data.m_OrthographicMode == ORTHO_MODE_AUTO_COVER)
+                {
+                    c->m_OrthographicAutoZoom = (zx > zy) ? zx : zy;
+                }
+
+                if (c->m_OrthographicAutoZoom <= 0.0f)
+                {
+                    c->m_OrthographicAutoZoom = 1.0f;
+                }
+
+                zoom *= c->m_OrthographicAutoZoom;
             }
 
             float zoomed_width = width / display_scale / zoom;

--- a/engine/render/src/render/render.h
+++ b/engine/render/src/render/render.h
@@ -464,6 +464,7 @@ namespace dmRender
     void                            SetRenderCameraEnabled(HRenderContext render_context, HRenderCamera camera, bool value);
     void                            UpdateRenderCamera(HRenderContext render_context, HRenderCamera camera, const dmVMath::Point3* position, const dmVMath::Quat* rotation);
     float                           GetRenderCameraEffectiveAspectRatio(HRenderContext render_context, HRenderCamera camera);
+    float                           GetRenderCameraOrthographicAutoZoom(HRenderContext render_context, HRenderCamera camera);
 
     /** Lights
      * A light prototype is essentially the data that represents the light and has a set of basic parameters,

--- a/engine/render/src/render/render_private.h
+++ b/engine/render/src/render/render_private.h
@@ -271,6 +271,7 @@ namespace dmRender
         // based on the new parameters
         dmVMath::Point3  m_LastPosition;
         dmVMath::Quat    m_LastRotation;
+        float            m_OrthographicAutoZoom;
 
         RenderCameraData m_Data;
         uint8_t          m_UseFrustum : 1;

--- a/engine/render/src/render/render_script_camera.cpp
+++ b/engine/render/src/render/render_script_camera.cpp
@@ -40,6 +40,7 @@ namespace dmRender
     /*# auto-fit orthographic zoom mode
      * Computes zoom so the original display area (game.project width/height) fits inside the window
      * while preserving aspect ratio. Equivalent to using min(window_width/width, window_height/height).
+     * The result is multiplied by the user-controlled orthographic zoom.
      *
      * @name camera.ORTHO_MODE_AUTO_FIT
      * @constant
@@ -48,6 +49,7 @@ namespace dmRender
     /*# auto-cover orthographic zoom mode
      * Computes zoom so the original display area covers the entire window while preserving aspect ratio.
      * Equivalent to using max(window_width/width, window_height/height).
+     * The result is multiplied by the user-controlled orthographic zoom.
      *
      * @name camera.ORTHO_MODE_AUTO_COVER
      * @constant
@@ -392,12 +394,31 @@ namespace dmRender
     GET_CAMERA_DATA_PROPERTY_FN(NearZ, lua_pushnumber);
 
     /*# get orthographic zoom
+    * Gets the positive user-controlled orthographic zoom multiplier. In auto-fit and auto-cover
+    * modes, this value is multiplied with camera.get_orthographic_auto_zoom(camera).
     *
     * @name camera.get_orthographic_zoom
     * @param camera [type:url|number|nil] camera id
-    * @return orthographic_zoom [type:number] the zoom level when the camera uses orthographic projection.
+    * @return orthographic_zoom [type:number] the positive zoom multiplier when the camera uses orthographic projection.
     */
     GET_CAMERA_DATA_PROPERTY_FN(OrthographicZoom, lua_pushnumber);
+
+    /*# get orthographic auto zoom
+    * Gets the orthographic zoom calculated from the current window and project dimensions
+    * in auto-fit and auto-cover modes. Returns 1.0 in fixed mode.
+    *
+    * @name camera.get_orthographic_auto_zoom
+    * @param camera [type:url|number|nil] camera id
+    * @return orthographic_auto_zoom [type:number] the calculated orthographic auto zoom.
+    */
+    static int RenderScriptCamera_GetOrthographicAutoZoom(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        RenderCamera* camera = CheckRenderCamera(L, 1, g_RenderScriptCameraModule.m_RenderContext);
+        float auto_zoom = GetRenderCameraOrthographicAutoZoom(g_RenderScriptCameraModule.m_RenderContext, camera->m_Handle);
+        lua_pushnumber(L, auto_zoom);
+        return 1;
+    }
 
     /*# set aspect ratio
     * Sets the manual aspect ratio for the camera. This value is only used when
@@ -435,12 +456,26 @@ namespace dmRender
     SET_CAMERA_DATA_PROPERTY_FN(NearZ, lua_tonumber);
 
     /*# set orthographic zoom
+    * Sets the positive user-controlled orthographic zoom multiplier. In auto-fit and auto-cover
+    * modes, this value is multiplied with camera.get_orthographic_auto_zoom(camera).
     *
     * @name camera.set_orthographic_zoom
     * @param camera [type:url|number|nil] camera id
-    * @param orthographic_zoom [type:number] the zoom level when the camera uses orthographic projection.
+    * @param orthographic_zoom [type:number] the positive zoom multiplier when the camera uses orthographic projection.
     */
-    SET_CAMERA_DATA_PROPERTY_FN(OrthographicZoom, lua_tonumber);
+    static int RenderScriptCamera_SetOrthographicZoom(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        RenderCamera* camera = CheckRenderCamera(L, 1, g_RenderScriptCameraModule.m_RenderContext);
+        float orthographic_zoom = (float) luaL_checknumber(L, 2);
+        if (!(orthographic_zoom > 0.0f))
+        {
+            return luaL_error(L, "Orthographic zoom must be greater than 0.");
+        }
+        camera->m_Data.m_OrthographicZoom = orthographic_zoom;
+        camera->m_Dirty = 1;
+        return 0;
+    }
 
     /*# get orthographic zoom mode
     *
@@ -536,10 +571,11 @@ namespace dmRender
         {"set_far_z",               RenderScriptCamera_SetFarZ},
         {"get_orthographic_zoom",   RenderScriptCamera_GetOrthographicZoom},
         {"set_orthographic_zoom",   RenderScriptCamera_SetOrthographicZoom},
-        {"get_auto_aspect_ratio",   RenderScriptCamera_GetAutoAspectRatio},
-        {"set_auto_aspect_ratio",   RenderScriptCamera_SetAutoAspectRatio},
-        {"get_orthographic_mode",   RenderScriptCamera_GetOrthographicMode},
-        {"set_orthographic_mode",   RenderScriptCamera_SetOrthographicMode},
+        {"get_orthographic_auto_zoom", RenderScriptCamera_GetOrthographicAutoZoom},
+        {"get_auto_aspect_ratio",      RenderScriptCamera_GetAutoAspectRatio},
+        {"set_auto_aspect_ratio",      RenderScriptCamera_SetAutoAspectRatio},
+        {"get_orthographic_mode",      RenderScriptCamera_GetOrthographicMode},
+        {"set_orthographic_mode",      RenderScriptCamera_SetOrthographicMode},
         {0, 0}
     };
 

--- a/engine/render/src/test/test_render.cpp
+++ b/engine/render/src/test/test_render.cpp
@@ -353,6 +353,76 @@ TEST_F(dmRenderTest, TestRenderCameraEffectiveAspectRatio)
     dmRender::DeleteRenderCamera(m_Context, camera);
 }
 
+TEST_F(dmRenderTest, TestRenderCameraOrthographicAutoZoom)
+{
+    dmRender::HRenderCamera camera = dmRender::NewRenderCamera(m_Context);
+
+    dmGraphics::NullContext* null_context = (dmGraphics::NullContext*) m_GraphicsContext;
+    null_context->m_BaseContext.m_Width = 10;
+    null_context->m_BaseContext.m_Height = 10;
+
+    dmRender::RenderCameraData data = {};
+    data.m_Viewport               = dmVMath::Vector4(0.0f, 0.0f, 1.0f, 1.0f);
+    data.m_AspectRatio            = 1.0f;
+    data.m_Fov                    = M_PI / 4.0f;
+    data.m_NearZ                  = 0.1f;
+    data.m_FarZ                   = 100.0f;
+    data.m_OrthographicZoom       = 3.0f;
+    data.m_OrthographicProjection = true;
+    data.m_OrthographicMode       = dmRender::ORTHO_MODE_AUTO_COVER;
+
+    dmRender::SetRenderCameraData(m_Context, camera, &data);
+
+    float display_scale = dmGraphics::GetDisplayScaleFactor(m_GraphicsContext);
+    if (display_scale <= 0.0f)
+    {
+        display_scale = 1.0f;
+    }
+    float width         = (float) dmGraphics::GetWindowWidth(m_GraphicsContext);
+    float height        = (float) dmGraphics::GetWindowHeight(m_GraphicsContext);
+    float proj_width    = (float) dmGraphics::GetWidth(m_GraphicsContext);
+    float proj_height   = (float) dmGraphics::GetHeight(m_GraphicsContext);
+    float zx            = width / (display_scale * proj_width);
+    float zy            = height / (display_scale * proj_height);
+    float auto_cover    = zx > zy ? zx : zy;
+    float auto_fit      = zx < zy ? zx : zy;
+
+    ASSERT_NEAR(auto_cover, dmRender::GetRenderCameraOrthographicAutoZoom(m_Context, camera), EPSILON);
+
+    dmVMath::Point3 position(0.0f, 0.0f, 0.0f);
+    dmVMath::Quat rotation(0.0f, 0.0f, 0.0f, 1.0f);
+    dmRender::UpdateRenderCamera(m_Context, camera, &position, &rotation);
+
+    dmVMath::Matrix4 projection;
+    dmRender::GetRenderCameraProjection(m_Context, camera, &projection);
+
+    float effective_zoom = auto_cover * data.m_OrthographicZoom;
+    float zoomed_width   = width / display_scale / effective_zoom;
+    float zoomed_height  = height / display_scale / effective_zoom;
+    dmVMath::Matrix4 expected_projection = dmVMath::Matrix4::orthographic(
+        -zoomed_width / 2.0f, zoomed_width / 2.0f,
+        -zoomed_height / 2.0f, zoomed_height / 2.0f,
+        data.m_NearZ, data.m_FarZ);
+
+    for (int row = 0; row < 4; ++row)
+    {
+        for (int col = 0; col < 4; ++col)
+        {
+            ASSERT_NEAR(expected_projection.getElem(row, col), projection.getElem(row, col), EPSILON);
+        }
+    }
+
+    data.m_OrthographicMode = dmRender::ORTHO_MODE_AUTO_FIT;
+    dmRender::SetRenderCameraData(m_Context, camera, &data);
+    ASSERT_NEAR(auto_fit, dmRender::GetRenderCameraOrthographicAutoZoom(m_Context, camera), EPSILON);
+
+    data.m_OrthographicMode = dmRender::ORTHO_MODE_FIXED;
+    dmRender::SetRenderCameraData(m_Context, camera, &data);
+    ASSERT_NEAR(1.0f, dmRender::GetRenderCameraOrthographicAutoZoom(m_Context, camera), EPSILON);
+
+    dmRender::DeleteRenderCamera(m_Context, camera);
+}
+
 TEST_F(dmRenderTest, TestSquare2d)
 {
     Square2d(m_Context, 10.0f, 20.0f, 30.0f, 40.0f, Vector4(0.1f, 0.2f, 0.3f, 0.4f));

--- a/engine/render/src/test/test_render.cpp
+++ b/engine/render/src/test/test_render.cpp
@@ -371,6 +371,18 @@ TEST_F(dmRenderTest, TestRenderCameraOrthographicAutoZoom)
     data.m_OrthographicProjection = true;
     data.m_OrthographicMode       = dmRender::ORTHO_MODE_AUTO_COVER;
 
+    dmRender::RenderCameraData invalid_data = data;
+    invalid_data.m_OrthographicZoom = 0.0f;
+    dmRender::SetRenderCameraData(m_Context, camera, &invalid_data);
+    dmRender::RenderCameraData sanitized_data = {};
+    dmRender::GetRenderCameraData(m_Context, camera, &sanitized_data);
+    ASSERT_NEAR(1.0f, sanitized_data.m_OrthographicZoom, EPSILON);
+
+    invalid_data.m_OrthographicZoom = -1.0f;
+    dmRender::SetRenderCameraData(m_Context, camera, &invalid_data);
+    dmRender::GetRenderCameraData(m_Context, camera, &sanitized_data);
+    ASSERT_NEAR(1.0f, sanitized_data.m_OrthographicZoom, EPSILON);
+
     dmRender::SetRenderCameraData(m_Context, camera, &data);
     ASSERT_NEAR(1.0f, dmRender::GetRenderCameraOrthographicAutoZoom(m_Context, camera), EPSILON);
 

--- a/engine/render/src/test/test_render.cpp
+++ b/engine/render/src/test/test_render.cpp
@@ -372,6 +372,7 @@ TEST_F(dmRenderTest, TestRenderCameraOrthographicAutoZoom)
     data.m_OrthographicMode       = dmRender::ORTHO_MODE_AUTO_COVER;
 
     dmRender::SetRenderCameraData(m_Context, camera, &data);
+    ASSERT_NEAR(1.0f, dmRender::GetRenderCameraOrthographicAutoZoom(m_Context, camera), EPSILON);
 
     float display_scale = dmGraphics::GetDisplayScaleFactor(m_GraphicsContext);
     if (display_scale <= 0.0f)
@@ -387,11 +388,10 @@ TEST_F(dmRenderTest, TestRenderCameraOrthographicAutoZoom)
     float auto_cover    = zx > zy ? zx : zy;
     float auto_fit      = zx < zy ? zx : zy;
 
-    ASSERT_NEAR(auto_cover, dmRender::GetRenderCameraOrthographicAutoZoom(m_Context, camera), EPSILON);
-
     dmVMath::Point3 position(0.0f, 0.0f, 0.0f);
     dmVMath::Quat rotation(0.0f, 0.0f, 0.0f, 1.0f);
     dmRender::UpdateRenderCamera(m_Context, camera, &position, &rotation);
+    ASSERT_NEAR(auto_cover, dmRender::GetRenderCameraOrthographicAutoZoom(m_Context, camera), EPSILON);
 
     dmVMath::Matrix4 projection;
     dmRender::GetRenderCameraProjection(m_Context, camera, &projection);
@@ -414,10 +414,12 @@ TEST_F(dmRenderTest, TestRenderCameraOrthographicAutoZoom)
 
     data.m_OrthographicMode = dmRender::ORTHO_MODE_AUTO_FIT;
     dmRender::SetRenderCameraData(m_Context, camera, &data);
+    dmRender::UpdateRenderCamera(m_Context, camera, &position, &rotation);
     ASSERT_NEAR(auto_fit, dmRender::GetRenderCameraOrthographicAutoZoom(m_Context, camera), EPSILON);
 
     data.m_OrthographicMode = dmRender::ORTHO_MODE_FIXED;
     dmRender::SetRenderCameraData(m_Context, camera, &data);
+    dmRender::UpdateRenderCamera(m_Context, camera, &position, &rotation);
     ASSERT_NEAR(1.0f, dmRender::GetRenderCameraOrthographicAutoZoom(m_Context, camera), EPSILON);
 
     dmRender::DeleteRenderCamera(m_Context, camera);

--- a/engine/render/src/test/test_render_script.cpp
+++ b/engine/render/src/test/test_render_script.cpp
@@ -1741,6 +1741,7 @@ TEST_F(dmRenderScriptTest, TestRenderCameraGetSetInfo)
         "    assert_near(camera.get_far_z(cams[1]), 100)\n"
         "    assert_near(camera.get_fov(cams[1]), 90)\n"
         "    assert_near(camera.get_orthographic_zoom(cams[1]), 1)\n"
+        "    assert_near(camera.get_orthographic_auto_zoom(cams[1]), 1)\n"
         // Test "set"
         "    camera.set_near_z(cams[1], -1)\n"
         "    assert_near(camera.get_near_z(cams[1]), -1)\n"
@@ -1749,6 +1750,9 @@ TEST_F(dmRenderScriptTest, TestRenderCameraGetSetInfo)
         "    camera.set_fov(cams[1], 45)\n"
         "    assert_near(camera.get_fov(cams[1]), 45)\n"
         "    camera.set_orthographic_zoom(cams[1], 2)\n"
+        "    assert_near(camera.get_orthographic_zoom(cams[1]), 2)\n"
+        "    assert(pcall(camera.set_orthographic_zoom, cams[1], 0) == false)\n"
+        "    assert(pcall(camera.set_orthographic_zoom, cams[1], -1) == false)\n"
         "    assert_near(camera.get_orthographic_zoom(cams[1]), 2)\n"
         // Test set_camera()
         "    render.set_camera(cams[1])\n"


### PR DESCRIPTION
Now the orthographic zoom set by the user in the editor or via code is applied on top of the automatically calculated zoom, giving more control over the camera. Additionally, a new function `get_orthographic_auto_zoom()` and a read-only property `orthographic_auto_zoom` have been added. They return the automatically calculated zoom for Fit or Cover mode.

Fix https://github.com/defold/defold/issues/12158