### PR TITLE
Images supported by the engine now open directly in the editor

### DIFF
--- a/editor/src/clj/editor/image.clj
+++ b/editor/src/clj/editor/image.clj
@@ -20,6 +20,8 @@
             [editor.image-util :as image-util]
             [editor.localization :as localization]
             [editor.pipeline.tex-gen :as tex-gen]
+            [editor.pose :as pose]
+            [editor.render-util :as render-util]
             [editor.resource :as resource]
             [editor.resource-io :as resource-io]
             [editor.resource-node :as resource-node]
@@ -89,6 +91,14 @@
                   :compress? (:compress-textures? build-settings false)
                   :texture-profile texture-profile}})])
 
+(g/defnk produce-scene [_node-id size gpu-texture texture-profile]
+  (g/precluding-errors
+    [size gpu-texture]
+    (let [{:keys [width height]} size]
+      (assoc (render-util/make-outlined-textured-quad-scene #{:image} pose/default width height gpu-texture 0)
+        :node-id _node-id
+        :info-text (format "%d x %d (%s profile)" width height (:name texture-profile))))))
+
 (g/defnode ImageNode
   (inherits resource-node/ResourceNode)
 
@@ -125,6 +135,7 @@
                                    :uv-transforms [(TextureSetGenerator$UVTransform.)])}))
 
   (output texture-page-count g/Int (g/constantly texture/non-paged-page-count))
+  (output scene g/Any :cached produce-scene)
   (output build-targets g/Any :cached produce-build-targets))
 
 (defn- load-image
@@ -143,5 +154,5 @@
                                       :node-type ImageNode
                                       :load-fn load-image
                                       :stateless? true
-                                      :view-types [:default])
+                                      :view-types [:scene :default])
     (workspace/register-resource-type workspace :ext "texture")))

--- a/editor/test/editor/image_test.clj
+++ b/editor/test/editor/image_test.clj
@@ -18,9 +18,11 @@
             [clojure.test.check.generators :as gen]
             [clojure.test.check.properties :as prop]
             [clojure.test :refer :all]
+            [editor.gl.texture :as texture]
             [editor.image :refer :all]
             [editor.image-util :refer :all]
             [editor.geom :refer :all]
+            [editor.workspace :as workspace]
             [schema.test])
   (:import [java.awt.image BufferedImage]))
 
@@ -30,3 +32,22 @@
   (let [img (make-image (as-url (file "foo")) (BufferedImage. 128 192 BufferedImage/TYPE_4BYTE_ABGR))]
     (is (= 128 (.width img)))
     (is (= 192 (.height img)))))
+
+(deftest image-resource-type-opens-in-scene-view
+  (let [registrations (atom [])]
+    (with-redefs [workspace/register-resource-type (fn [_workspace & args]
+                                                     (swap! registrations conj (apply hash-map args))
+                                                     [])]
+      (doall (register-resource-types ::workspace)))
+    (is (= ["jpg" "jpeg" "png"] (:ext (first @registrations))))
+    (is (= [:scene :default] (:view-types (first @registrations))))))
+
+(deftest image-scene
+  (let [scene (produce-scene {:_node-id ::image
+                              :size {:width 128 :height 64}
+                              :gpu-texture (texture/empty-texture ::image :rgba 1 1 texture/default-image-texture-params 0)
+                              :texture-profile {:name "Test"}})]
+    (is (= ::image (:node-id scene)))
+    (is (= "128 x 64 (Test profile)" (:info-text scene)))
+    (is (some? (:renderable scene)))
+    (is (seq (:children scene)))))

--- a/editor/test/editor/image_test.clj
+++ b/editor/test/editor/image_test.clj
@@ -18,11 +18,9 @@
             [clojure.test.check.generators :as gen]
             [clojure.test.check.properties :as prop]
             [clojure.test :refer :all]
-            [editor.gl.texture :as texture]
             [editor.image :refer :all]
             [editor.image-util :refer :all]
             [editor.geom :refer :all]
-            [editor.workspace :as workspace]
             [schema.test])
   (:import [java.awt.image BufferedImage]))
 
@@ -32,22 +30,3 @@
   (let [img (make-image (as-url (file "foo")) (BufferedImage. 128 192 BufferedImage/TYPE_4BYTE_ABGR))]
     (is (= 128 (.width img)))
     (is (= 192 (.height img)))))
-
-(deftest image-resource-type-opens-in-scene-view
-  (let [registrations (atom [])]
-    (with-redefs [workspace/register-resource-type (fn [_workspace & args]
-                                                     (swap! registrations conj (apply hash-map args))
-                                                     [])]
-      (doall (register-resource-types ::workspace)))
-    (is (= ["jpg" "jpeg" "png"] (:ext (first @registrations))))
-    (is (= [:scene :default] (:view-types (first @registrations))))))
-
-(deftest image-scene
-  (let [scene (produce-scene {:_node-id ::image
-                              :size {:width 128 :height 64}
-                              :gpu-texture (texture/empty-texture ::image :rgba 1 1 texture/default-image-texture-params 0)
-                              :texture-profile {:name "Test"}})]
-    (is (= ::image (:node-id scene)))
-    (is (= "128 x 64 (Test profile)" (:info-text scene)))
-    (is (some? (:renderable scene)))
-    (is (seq (:children scene)))))


### PR DESCRIPTION
The Editor now opens `jpg`, `jpeg`, and `png` images for preview without using external applications.

Fix https://github.com/defold/defold/issues/11495