### PR TITLE
Fix GUI auto size for async-created texture atlases

### DIFF
--- a/engine/gamesys/src/gamesys/scripts/script_resource.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_resource.cpp
@@ -695,6 +695,14 @@ static void HandleRequestCompleted(dmGraphics::HTexture texture, void* user_data
     // Swap out the texture
     dmGraphics::DeleteTexture(g_ResourceModule.m_GraphicsContext, request->m_TextureResource->m_Texture);
     request->m_TextureResource->m_Texture = texture;
+    request->m_TextureResource->m_OriginalWidth = dmGraphics::GetOriginalTextureWidth(g_ResourceModule.m_GraphicsContext, texture);
+    request->m_TextureResource->m_OriginalHeight = dmGraphics::GetOriginalTextureHeight(g_ResourceModule.m_GraphicsContext, texture);
+
+    HResourceDescriptor rd = dmResource::FindByHash(g_ResourceModule.m_Factory, request->m_PathHash);
+    if (rd)
+    {
+        dmResource::SetResourceSize(rd, dmGraphics::GetTextureResourceSize(g_ResourceModule.m_GraphicsContext, texture));
+    }
 
     if (dmScript::IsCallbackValid(request->m_CallbackInfo))
     {

--- a/engine/gamesys/src/gamesys/test/gui/async_texture_auto_size.go
+++ b/engine/gamesys/src/gamesys/test/gui/async_texture_auto_size.go
@@ -1,0 +1,8 @@
+components {
+  id: "gui"
+  component: "/gui/async_texture_auto_size.gui"
+}
+components {
+  id: "script"
+  component: "/gui/async_texture_auto_size.script"
+}

--- a/engine/gamesys/src/gamesys/test/gui/async_texture_auto_size.gui
+++ b/engine/gamesys/src/gamesys/test/gui/async_texture_auto_size.gui
@@ -1,0 +1,68 @@
+script: "/gui/async_texture_auto_size.gui_script"
+textures {
+  name: "atlas"
+  texture: "/gui/texture_setter_override_a.atlas"
+}
+background_color {
+  x: 0.0
+  y: 0.0
+  z: 0.0
+  w: 0.0
+}
+nodes {
+  position {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  scale {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  size {
+    x: 128.0
+    y: 128.0
+    z: 0.0
+    w: 1.0
+  }
+  color {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  type: TYPE_BOX
+  blend_mode: BLEND_MODE_ALPHA
+  texture: "atlas/frame"
+  id: "box"
+  xanchor: XANCHOR_NONE
+  yanchor: YANCHOR_NONE
+  pivot: PIVOT_CENTER
+  adjust_mode: ADJUST_MODE_FIT
+  layer: ""
+  inherit_alpha: true
+  slice9 {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 0.0
+  }
+  clipping_mode: CLIPPING_MODE_NONE
+  clipping_visible: true
+  clipping_inverted: false
+  alpha: 1.0
+  template_node_child: false
+  size_mode: SIZE_MODE_AUTO
+}
+material: "/gui/gui.material"
+adjust_reference: ADJUST_REFERENCE_PARENT
+max_nodes: 512

--- a/engine/gamesys/src/gamesys/test/gui/async_texture_auto_size.gui_script
+++ b/engine/gamesys/src/gamesys/test/gui/async_texture_auto_size.gui_script
@@ -1,0 +1,23 @@
+local WIDTH = 8
+local HEIGHT = 8
+
+function init(self)
+    tests_done = false
+    self.applied_async_atlas = false
+end
+
+function update(self, dt)
+    if async_texture_auto_size_ready and not self.applied_async_atlas then
+        async_texture_auto_size_ready = false
+        self.applied_async_atlas = true
+
+        local node = gui.get_node("box")
+        gui.set_texture(node, "dynamic_atlas")
+        gui.play_flipbook(node, "frame")
+
+        local size = gui.get_size(node)
+        assert(size == vmath.vector3(WIDTH, HEIGHT, 0))
+
+        tests_done = true
+    end
+end

--- a/engine/gamesys/src/gamesys/test/gui/async_texture_auto_size.gui_script
+++ b/engine/gamesys/src/gamesys/test/gui/async_texture_auto_size.gui_script
@@ -1,5 +1,9 @@
-local WIDTH = 8
-local HEIGHT = 8
+local SPRITES = {
+    {id = "sprite_8x8", w = 8, h = 8},
+    {id = "sprite_12x6", w = 12, h = 6},
+    {id = "sprite_5x11", w = 5, h = 11},
+    {id = "sprite_16x9", w = 16, h = 9},
+}
 
 function init(self)
     tests_done = false
@@ -13,10 +17,12 @@ function update(self, dt)
 
         local node = gui.get_node("box")
         gui.set_texture(node, "dynamic_atlas")
-        gui.play_flipbook(node, "frame")
 
-        local size = gui.get_size(node)
-        assert(size == vmath.vector3(WIDTH, HEIGHT, 0))
+        for _, sprite in ipairs(SPRITES) do
+            gui.play_flipbook(node, sprite.id)
+            local size = gui.get_size(node)
+            assert(size == vmath.vector3(sprite.w, sprite.h, 0))
+        end
 
         tests_done = true
     end

--- a/engine/gamesys/src/gamesys/test/gui/async_texture_auto_size.script
+++ b/engine/gamesys/src/gamesys/test/gui/async_texture_auto_size.script
@@ -1,10 +1,22 @@
-local WIDTH = 8
-local HEIGHT = 8
+local TEXTURE_WIDTH = 32
+local TEXTURE_HEIGHT = 32
 
-local function make_quad(w, h)
+local SPRITES = {
+    {id = "sprite_8x8", x = 0, y = 0, w = 8, h = 8},
+    {id = "sprite_12x6", x = 8, y = 0, w = 12, h = 6},
+    {id = "sprite_5x11", x = 0, y = 8, w = 5, h = 11},
+    {id = "sprite_16x9", x = 5, y = 8, w = 16, h = 9},
+}
+
+local function make_quad(sprite)
     return {
-        vertices = {0, 0, 0, h, w, h, w, 0},
-        uvs = {0, 0, 0, h, w, h, w, 0},
+        vertices = {0, 0, 0, sprite.h, sprite.w, sprite.h, sprite.w, 0},
+        uvs = {
+            sprite.x, sprite.y,
+            sprite.x, sprite.y + sprite.h,
+            sprite.x + sprite.w, sprite.y + sprite.h,
+            sprite.x + sprite.w, sprite.y,
+        },
         indices = {0, 1, 2, 0, 2, 3}
     }
 end
@@ -22,25 +34,32 @@ function init(self)
     async_texture_auto_size_ready = false
 
     local tparams = {
-        width = WIDTH,
-        height = HEIGHT,
+        width = TEXTURE_WIDTH,
+        height = TEXTURE_HEIGHT,
         type = graphics.TEXTURE_TYPE_2D,
         format = graphics.TEXTURE_FORMAT_RGBA,
     }
 
-    resource.create_texture_async("/gui/async_texture_auto_size.texturec", tparams, make_texture_buffer(WIDTH, HEIGHT),
+    resource.create_texture_async("/gui/async_texture_auto_size.texturec", tparams, make_texture_buffer(TEXTURE_WIDTH, TEXTURE_HEIGHT),
         function(self, request_id, result)
-            local atlas_id = resource.create_atlas("/gui/async_texture_auto_size.texturesetc", {
-                texture = result.path,
-                animations = {{
-                    id = "frame",
-                    width = WIDTH,
-                    height = HEIGHT,
-                    frames = {1},
+            local animations = {}
+            local geometries = {}
+            for i, sprite in ipairs(SPRITES) do
+                animations[i] = {
+                    id = sprite.id,
+                    width = sprite.w,
+                    height = sprite.h,
+                    frames = {i},
                     fps = 60,
                     playback = go.PLAYBACK_ONCE_FORWARD,
-                }},
-                geometries = {make_quad(WIDTH, HEIGHT)}
+                }
+                geometries[i] = make_quad(sprite)
+            end
+
+            local atlas_id = resource.create_atlas("/gui/async_texture_auto_size.texturesetc", {
+                texture = result.path,
+                animations = animations,
+                geometries = geometries
             })
             go.set("#gui", "textures", atlas_id, {key = "dynamic_atlas"})
             async_texture_auto_size_ready = true

--- a/engine/gamesys/src/gamesys/test/gui/async_texture_auto_size.script
+++ b/engine/gamesys/src/gamesys/test/gui/async_texture_auto_size.script
@@ -1,0 +1,48 @@
+local WIDTH = 8
+local HEIGHT = 8
+
+local function make_quad(w, h)
+    return {
+        vertices = {0, 0, 0, h, w, h, w, 0},
+        uvs = {0, 0, 0, h, w, h, w, 0},
+        indices = {0, 1, 2, 0, 2, 3}
+    }
+end
+
+local function make_texture_buffer(w, h)
+    local tex_buffer = buffer.create(w * h, {{name = hash("rgba"), type = buffer.VALUE_TYPE_UINT8, count = 4}})
+    local stream = buffer.get_stream(tex_buffer, hash("rgba"))
+    for i = 1, w * h * 4 do
+        stream[i] = 0xff
+    end
+    return tex_buffer
+end
+
+function init(self)
+    async_texture_auto_size_ready = false
+
+    local tparams = {
+        width = WIDTH,
+        height = HEIGHT,
+        type = graphics.TEXTURE_TYPE_2D,
+        format = graphics.TEXTURE_FORMAT_RGBA,
+    }
+
+    resource.create_texture_async("/gui/async_texture_auto_size.texturec", tparams, make_texture_buffer(WIDTH, HEIGHT),
+        function(self, request_id, result)
+            local atlas_id = resource.create_atlas("/gui/async_texture_auto_size.texturesetc", {
+                texture = result.path,
+                animations = {{
+                    id = "frame",
+                    width = WIDTH,
+                    height = HEIGHT,
+                    frames = {1},
+                    fps = 60,
+                    playback = go.PLAYBACK_ONCE_FORWARD,
+                }},
+                geometries = {make_quad(WIDTH, HEIGHT)}
+            })
+            go.set("#gui", "textures", atlas_id, {key = "dynamic_atlas"})
+            async_texture_auto_size_ready = true
+        end)
+end

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -2730,6 +2730,19 @@ TEST_F(GuiTest, TextureReloadRefreshesAtlasState)
     ASSERT_TRUE(dmGameObject::Final(m_Collection));
 }
 
+TEST_F(GuiTest, AsyncTextureAutoSize)
+{
+    dmGraphics::NullContext* null_context = (dmGraphics::NullContext*) m_GraphicsContext;
+    null_context->m_UseAsyncTextureLoad = 1;
+
+    dmGameObject::HInstance go = Spawn(m_Factory, m_Collection, "/gui/async_texture_auto_size.goc", dmHashString64("/go"), 0, Point3(0, 0, 0), Quat(0, 0, 0, 1), Vector3(1, 1, 1));
+    ASSERT_NE((void*)0x0, go);
+
+    ASSERT_TRUE(UpdateAndWaitUntilDone(m_Scriptlibcontext, m_Collection, &m_UpdateContext, false, "tests_done"));
+
+    ASSERT_TRUE(dmGameObject::Final(m_Collection));
+}
+
 // Tests creating and deleting dynamic textures
 TEST_F(GuiTest, MaxDynamictextures)
 {


### PR DESCRIPTION
GUI nodes using `SIZE_MODE_AUTO` now report the correct size when their atlas is created from a texture uploaded with resource.create_texture_async().

Fix https://github.com/defold/defold/issues/12319

