### PR TITLE
Ensure there is no menu bar in the Search and About dialogs

### DIFF
--- a/editor/src/clj/editor/ui.clj
+++ b/editor/src/clj/editor/ui.clj
@@ -1639,38 +1639,45 @@
 
 (declare make-menu-items)
 
-(defn- make-menu-item [^Scene scene item command-contexts keymap localization evaluation-context]
-  (let [{:keys [id icon style children label command user-data check on-submenu-open]} item]
-    (cond
-      (= label :separator)
-      (SeparatorMenuItem.)
+(defn- make-menu-item
+  ([^Scene scene item command-contexts keymap localization evaluation-context]
+   (make-menu-item scene item command-contexts keymap localization evaluation-context true))
+  ([^Scene scene item command-contexts keymap localization evaluation-context allow-custom-menu-items?]
+   (let [{:keys [id icon style children label command user-data check on-submenu-open]} item]
+     (cond
+       (= label :separator)
+       (SeparatorMenuItem.)
 
-      children
-      (let [items (make-menu-items scene children command-contexts keymap localization evaluation-context)]
-        (make-submenu id label localization icon style items on-submenu-open))
+       children
+       (let [items (make-menu-items scene children command-contexts keymap localization evaluation-context allow-custom-menu-items?)]
+         (make-submenu id label localization icon style items on-submenu-open))
 
-      :else
-      (when-let [handler-ctx (handler/active command command-contexts user-data evaluation-context)]
-        ;; NOTE: This label is *not* updated on every menu refresh. Can't do "Show X" <-> "Hide X".
-        (let [label (or (handler/label handler-ctx evaluation-context) label)
-              enabled? (handler/enabled? handler-ctx evaluation-context)
-              key-combo (first (keymap/shortcuts keymap command))
-              options (handler/options handler-ctx evaluation-context)]
-          (if (or (nil? options)
-                  (and key-combo (not (:expand item))))
-            (make-menu-command scene id label localization icon style key-combo user-data command enabled? check)
-            (if (some-> options meta :layout (= :grid))
-              (let [grid-menu (make-grid-menu scene localization options command-contexts evaluation-context)]
-                (make-submenu id label localization icon style [grid-menu] #(focus-first-grid-menu-item grid-menu)))
-              (make-submenu id label localization icon style
-                            (make-menu-items scene (localization/sort-if-annotated @localization options)
-                                             command-contexts keymap localization evaluation-context)
-                            on-submenu-open))))))))
+       :else
+       (when-let [handler-ctx (handler/active command command-contexts user-data evaluation-context)]
+         ;; NOTE: This label is *not* updated on every menu refresh. Can't do "Show X" <-> "Hide X".
+         (let [label (or (handler/label handler-ctx evaluation-context) label)
+               enabled? (handler/enabled? handler-ctx evaluation-context)
+               key-combo (first (keymap/shortcuts keymap command))
+               options (handler/options handler-ctx evaluation-context)]
+           (if (or (nil? options)
+                   (and key-combo (not (:expand item))))
+             (make-menu-command scene id label localization icon style key-combo user-data command enabled? check)
+             (if (and allow-custom-menu-items?
+                      (some-> options meta :layout (= :grid)))
+               (let [grid-menu (make-grid-menu scene localization options command-contexts evaluation-context)]
+                 (make-submenu id label localization icon style [grid-menu] #(focus-first-grid-menu-item grid-menu)))
+               (make-submenu id label localization icon style
+                             (make-menu-items scene (localization/sort-if-annotated @localization options)
+                                              command-contexts keymap localization evaluation-context allow-custom-menu-items?)
+                             on-submenu-open)))))))))
 
-(defn- make-menu-items [^Scene scene menu command-contexts keymap localization evaluation-context]
-  (into []
-        (keep #(make-menu-item scene % command-contexts keymap localization evaluation-context))
-        menu))
+(defn- make-menu-items
+  ([^Scene scene menu command-contexts keymap localization evaluation-context]
+   (make-menu-items scene menu command-contexts keymap localization evaluation-context true))
+  ([^Scene scene menu command-contexts keymap localization evaluation-context allow-custom-menu-items?]
+   (into []
+         (keep #(make-menu-item scene % command-contexts keymap localization evaluation-context allow-custom-menu-items?))
+         menu)))
 
 (defn- make-context-menu ^ContextMenu [menu-items]
   (let [context-menu (doto (ContextMenu.)
@@ -1919,7 +1926,8 @@
                                         visible-command-contexts
                                         keymap
                                         localization
-                                        evaluation-context))
+                                        evaluation-context
+                                        (not (.isUseSystemMenuBar menu-bar))))
   (user-data! menu-bar ::menu menu)
   (user-data! menu-bar ::visible-command-contexts visible-command-contexts)
   (user-data! menu-bar ::keymap keymap)
@@ -1967,7 +1975,8 @@
                                               visible-command-contexts
                                               keymap
                                               localization
-                                              evaluation-context)]
+                                              evaluation-context
+                                              (not (.isUseSystemMenuBar menu-bar)))]
             (replace-menu! menu-bar menu-item new-menu-item)))))
     (clear-invalidated-menubar-items!)))
 

--- a/editor/test/editor/ui_test.clj
+++ b/editor/test/editor/ui_test.clj
@@ -22,7 +22,7 @@
             [integration.test-util :as test-util]
             [support.test-support :as test-support])
   (:import [javafx.scene Scene]
-           [javafx.scene.control ComboBox ListView Menu MenuBar MenuItem SelectionMode Tab TabPane TreeItem TreeView]
+           [javafx.scene.control ComboBox CustomMenuItem ListView Menu MenuBar MenuItem SelectionMode Tab TabPane TreeItem TreeView]
            [javafx.scene.control.skin TabPaneSkin]
            [javafx.scene.layout Pane VBox]))
 
@@ -113,6 +113,42 @@
       (let [menu-items (make-menu-items nil ::my-menu command-context)]
         (is (= 1 (count menu-items)))
         (is (= 1 (count (.getItems (first menu-items)))))))))
+
+(deftest system-menubar-does-not-use-custom-menu-items-test
+  @(fx/on-fx-thread
+     (test-support/with-clean-system
+       (handler/register-menu! ::my-menu
+         [{:label (localization/message "command.file")
+           :children [{:label (localization/message "command.file.new")
+                       :command :file.new
+                       :expand true}]}])
+
+       (handler/defhandler :file.new :global
+         (run [user-data] user-data)
+         (options [user-data]
+           (when-not user-data
+             (with-meta
+               [{:label (localization/message "command.file.new.any-file")
+                 :command :file.new
+                 :user-data {:any-file true}}]
+               {:layout :grid
+                :columns [[(localization/message "resource.category.other")]]}))))
+
+       (let [root (Pane.)
+             scene (Scene. root)
+             selection-provider (TestSelectionProvider. [])
+             menubar (doto (MenuBar.)
+                       (.setUseSystemMenuBar true))]
+         (ui/user-data! scene :localization test-util/localization)
+         (ui/context! root :global {} selection-provider)
+         (.add (.getChildren root) menubar)
+         (ui/register-menubar scene menubar ::my-menu)
+         (ui/refresh scene)
+         (let [menu-items (tree-seq #(and (instance? Menu %)
+                                          (seq (.getItems ^Menu %)))
+                                    #(.getItems ^Menu %)
+                                    (first (.getMenus menubar)))]
+           (is (not-any? #(instance? CustomMenuItem %) menu-items)))))))
 
 (g/defnode FakeAppView
   (property active-tab g/Any))


### PR DESCRIPTION
Fixes macOS dialog windows showing an in-window menu bar when the main menu contains grid-backed items.

Fix https://github.com/defold/defold/issues/12156

### Technical changes

System menu bars now avoid `CustomMenuItem` fallback rendering, while context menus keep the existing grid layout. Added a regression test for grid-backed commands in system menu bars.

Joe, I have a feeling I'm fixing a symptom here, not the root cause, since I don't fully understand why this was implemented based on having or not having a grid. So I’ll leave it for you to decide if this approach is okay, or if you have a better idea. I know you mentioned it's a macOS-only issue, and without access to a Mac it might be hard to fix, so I'm suggesting this PR as a possible fix, or at least as additional information about what’s wrong (with this fix, there are no menus in the Search and About windows - so technically it is a fix). But if you think there is a better way to fix it, feel free to close this one and open a new one.