### PR TITLE
Add pipeline cache object for the Vulkan adapter

### DIFF
--- a/engine/graphics/src/vulkan/graphics_vulkan.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan.cpp
@@ -1406,6 +1406,20 @@ namespace dmGraphics
     #endif
 
         context->m_PipelineCache.SetCapacity(32,64);
+
+        // Create a Vulkan pipeline cache so the driver can reuse compiled
+        // shader/pipeline state across pipeline creation calls within
+        // the same session. Passing an empty initialData for now — disk
+        // serialization can be added later for cross-session warm starts.
+        {
+            VkPipelineCacheCreateInfo vk_pipeline_cache_info;
+            memset(&vk_pipeline_cache_info, 0, sizeof(vk_pipeline_cache_info));
+            vk_pipeline_cache_info.sType = VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO;
+
+            res = vkCreatePipelineCache(context->m_LogicalDevice.m_Device, &vk_pipeline_cache_info, 0, &context->m_VkPipelineCache);
+            CHECK_VK_ERROR(res);
+        }
+
         context->m_TextureSamplers.SetCapacity(4);
         context->m_FenceResourcesToDestroy.Allocate(8);
 
@@ -1952,7 +1966,7 @@ bail:
         }
     }
 
-    static Pipeline* GetOrCreateComputePipeline(VkDevice vk_device, PipelineCache& pipelineCache, VulkanProgram* program)
+    static Pipeline* GetOrCreateComputePipeline(VkDevice vk_device, VkPipelineCache vk_pipeline_cache, PipelineCache& pipelineCache, VulkanProgram* program)
     {
         HashState64 pipeline_hash_state;
         dmHashInit64(&pipeline_hash_state, false);
@@ -1965,7 +1979,7 @@ bail:
         {
             Pipeline new_pipeline = {};
 
-            VkResult res = CreateComputePipeline(vk_device, program, &new_pipeline);
+            VkResult res = CreateComputePipeline(vk_device, vk_pipeline_cache, program, &new_pipeline);
             CHECK_VK_ERROR(res);
 
             if (pipelineCache.Full())
@@ -1982,7 +1996,7 @@ bail:
         return cached_pipeline;
     }
 
-    static Pipeline* GetOrCreatePipeline(VkDevice vk_device, VkSampleCountFlagBits vk_sample_count,
+    static Pipeline* GetOrCreatePipeline(VkDevice vk_device, VkPipelineCache vk_pipeline_cache, VkSampleCountFlagBits vk_sample_count,
         const PipelineState pipelineState, PipelineCache& pipelineCache,
         VulkanProgram* program, RenderTarget* rt, VertexDeclaration** vertexDeclaration, uint32_t vertexDeclarationCount)
     {
@@ -2013,7 +2027,7 @@ bail:
             vk_scissor.offset.x = 0;
             vk_scissor.offset.y = 0;
 
-            VkResult res = CreateGraphicsPipeline(vk_device, vk_scissor, vk_sample_count, pipelineState, program, vertexDeclaration, vertexDeclarationCount, rt, &new_pipeline);
+            VkResult res = CreateGraphicsPipeline(vk_device, vk_pipeline_cache, vk_scissor, vk_sample_count, pipelineState, program, vertexDeclaration, vertexDeclarationCount, rt, &new_pipeline);
             if (res == VK_ERROR_INITIALIZATION_FAILED)
             {
                 dmLogError("Failed to create VkPipeline");
@@ -2941,7 +2955,7 @@ bail:
         VkResult res               = CommitUniforms(context, vk_command_buffer, vk_device, program_ptr, VK_PIPELINE_BIND_POINT_COMPUTE, scratchBuffer, context->m_DynamicOffsetBuffer, dynamic_alignment);
         CHECK_VK_ERROR(res);
 
-        Pipeline* pipeline = GetOrCreateComputePipeline(vk_device, context->m_PipelineCache, program_ptr);
+        Pipeline* pipeline = GetOrCreateComputePipeline(vk_device, context->m_VkPipelineCache, context->m_PipelineCache, program_ptr);
         vkCmdBindPipeline(vk_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, *pipeline);
     }
 
@@ -3026,7 +3040,7 @@ bail:
             vk_sample_count = context->m_SwapChain->m_SampleCountFlag;
         }
 
-        Pipeline* pipeline = GetOrCreatePipeline(vk_device, vk_sample_count,
+        Pipeline* pipeline = GetOrCreatePipeline(vk_device, context->m_VkPipelineCache, vk_sample_count,
             pipeline_state_draw, context->m_PipelineCache,
             program_ptr, current_rt, vx_declarations, num_vx_buffers);
 
@@ -4795,6 +4809,12 @@ bail:
         VkDevice vk_device = context->m_LogicalDevice.m_Device;
 
         context->m_PipelineCache.Iterate(DestroyPipelineCacheCb, context);
+
+        if (context->m_VkPipelineCache != VK_NULL_HANDLE)
+        {
+            vkDestroyPipelineCache(vk_device, context->m_VkPipelineCache, 0);
+            context->m_VkPipelineCache = VK_NULL_HANDLE;
+        }
 
         DestroyDeviceBuffer(vk_device, &context->m_MainTextureDepthStencil.m_DeviceBuffer.m_Handle);
         DestroyTexture(vk_device, &context->m_MainTextureDepthStencil.m_Handle);

--- a/engine/graphics/src/vulkan/graphics_vulkan_device.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan_device.cpp
@@ -1201,7 +1201,7 @@ bail:
         VK_COMPARE_OP_ALWAYS
     };
 
-    VkResult CreateComputePipeline(VkDevice vk_device, VulkanProgram* program, Pipeline* pipelineOut)
+    VkResult CreateComputePipeline(VkDevice vk_device, VkPipelineCache vk_pipeline_cache, VulkanProgram* program, Pipeline* pipelineOut)
     {
         assert(pipelineOut && *pipelineOut == VK_NULL_HANDLE);
 
@@ -1213,10 +1213,10 @@ bail:
         vk_pipeline_create_info.layout             = program->m_Handle.m_PipelineLayout;
         vk_pipeline_create_info.pNext              = 0;
         vk_pipeline_create_info.stage              = program->m_ComputeModule->m_PipelineStageInfo;
-        return vkCreateComputePipelines(vk_device, 0, 1, &vk_pipeline_create_info, 0, pipelineOut);
+        return vkCreateComputePipelines(vk_device, vk_pipeline_cache, 1, &vk_pipeline_create_info, 0, pipelineOut);
     }
 
-    VkResult CreateGraphicsPipeline(VkDevice vk_device, VkRect2D vk_scissor, VkSampleCountFlagBits vk_sample_count,
+    VkResult CreateGraphicsPipeline(VkDevice vk_device, VkPipelineCache vk_pipeline_cache, VkRect2D vk_scissor, VkSampleCountFlagBits vk_sample_count,
         PipelineState pipelineState, VulkanProgram* program, VertexDeclaration** vertexDeclarations, uint32_t vertexDeclarationCount,
         RenderTarget* render_target, Pipeline* pipelineOut)
     {
@@ -1427,7 +1427,7 @@ bail:
         vk_pipeline_info.basePipelineHandle  = VK_NULL_HANDLE;
         vk_pipeline_info.basePipelineIndex   = -1;
 
-        return vkCreateGraphicsPipelines(vk_device, VK_NULL_HANDLE, 1, &vk_pipeline_info, 0, pipelineOut);
+        return vkCreateGraphicsPipelines(vk_device, vk_pipeline_cache, 1, &vk_pipeline_info, 0, pipelineOut);
     }
 
     void ResetScratchBuffer(VkDevice vk_device, ScratchBuffer* scratchBuffer)

--- a/engine/graphics/src/vulkan/graphics_vulkan_private.h
+++ b/engine/graphics/src/vulkan/graphics_vulkan_private.h
@@ -406,6 +406,7 @@ namespace dmGraphics
         FWindowResizeCallback              m_WindowResizeCallback;
         HTexture                           m_TextureUnits[DM_MAX_TEXTURE_UNITS];
         PipelineCache                      m_PipelineCache;
+        VkPipelineCache                    m_VkPipelineCache;
         PipelineState                      m_PipelineState;
         SwapChain*                         m_SwapChain;
         SwapChainCapabilities              m_SwapChainCapabilities;
@@ -510,8 +511,8 @@ namespace dmGraphics
     VkResult CreateRenderPass(VkDevice vk_device, VkSampleCountFlagBits vk_sample_flags, RenderPassAttachment* colorAttachments, uint8_t numColorAttachments, RenderPassAttachment* depthStencilAttachment, RenderPassAttachment* resolveAttachment, VkRenderPass* renderPassOut);
     VkResult CreateDeviceBuffer(VkPhysicalDevice vk_physical_device, VkDevice vk_device, VkDeviceSize vk_size, VkMemoryPropertyFlags vk_memory_flags, DeviceBuffer* bufferOut);
     VkResult CreateShaderModule(VkDevice vk_device, const void* source, uint32_t sourceSize, VkShaderStageFlagBits stage_flag, ShaderModule* shaderModuleOut);
-    VkResult CreateGraphicsPipeline(VkDevice vk_device, VkRect2D vk_scissor, VkSampleCountFlagBits vk_sample_count, const PipelineState pipelineState, VulkanProgram* program, VertexDeclaration** vertexDeclarations, uint32_t vertexDeclarationCount, RenderTarget* render_target, Pipeline* pipelineOut);
-    VkResult CreateComputePipeline(VkDevice vk_device, VulkanProgram* program, Pipeline* pipelineOut);
+    VkResult CreateGraphicsPipeline(VkDevice vk_device, VkPipelineCache vk_pipeline_cache, VkRect2D vk_scissor, VkSampleCountFlagBits vk_sample_count, const PipelineState pipelineState, VulkanProgram* program, VertexDeclaration** vertexDeclarations, uint32_t vertexDeclarationCount, RenderTarget* render_target, Pipeline* pipelineOut);
+    VkResult CreateComputePipeline(VkDevice vk_device, VkPipelineCache vk_pipeline_cache, VulkanProgram* program, Pipeline* pipelineOut);
 
     // Destroy functions
     void DestroyDeviceBuffer(VkDevice vk_device, DeviceBuffer::VulkanHandle* handle);


### PR DESCRIPTION
### Technical changes

This PR adds a "pipeline cache" for the vulkan pipeline objects. As a first step this doesn't serialize the cache to disk, which should be the next obvious improvement. This just adds the inner adapter plumbing for that to happen.