### PR TITLE
Ensure `UpdateTransforms` runs only after actual transform changes

### DIFF
--- a/engine/gameobject/src/gameobject/comp_anim.cpp
+++ b/engine/gameobject/src/gameobject/comp_anim.cpp
@@ -21,6 +21,7 @@
 #include <script/script.h>
 
 #include "component.h"
+#include "gameobject_private.h"
 #include "gameobject_script.h"
 #include "gameobject_props.h"
 #include "gameobject_props_lua.h"
@@ -66,6 +67,7 @@ namespace dmGameObject
         uint16_t            m_Composite : 1;
         uint16_t            m_Backwards : 1;
         uint16_t            m_FirstUpdate : 1;
+        uint16_t            m_TransformsUpdated : 1;
     };
 
     struct AnimWorld
@@ -184,7 +186,7 @@ namespace dmGameObject
         AnimWorld* world = (AnimWorld*)params.m_World;
         world->m_InUpdate = 1;
         uint32_t size = world->m_Animations.Size();
-        uint32_t orig_size = size;
+        bool transforms_updated = false;
 
         DM_PROPERTY_ADD_U32(rmtp_ComponentsAnim, size);
 
@@ -322,6 +324,11 @@ namespace dmGameObject
                     AddPropertyOptionsIndex(&property_opt, 0);
                     SetProperty(anim.m_Instance, anim.m_ComponentId, anim.m_PropertyId, property_opt, PropertyVar(v));
                 }
+                if (anim.m_TransformsUpdated)
+                {
+                    MarkTransformDirty(anim.m_Instance);
+                    transforms_updated = true;
+                }
             }
             if (completed)
             {
@@ -386,7 +393,7 @@ namespace dmGameObject
             }
         }
         world->m_InUpdate = 0;
-        update_result.m_TransformsUpdated = orig_size != 0;
+        update_result.m_TransformsUpdated = transforms_updated;
         return result;
     }
 
@@ -480,6 +487,7 @@ namespace dmGameObject
         animation.m_Next = INVALID_INDEX;
         animation.m_Playing = 1;
         animation.m_Composite = composite ? 1 : 0;
+        animation.m_TransformsUpdated = IsGameObjectTransformProperty(component_id, property_id) ? 1 : 0;
         if (animation.m_Playback == PLAYBACK_ONCE_BACKWARD || animation.m_Playback == PLAYBACK_LOOP_BACKWARD)
             animation.m_Backwards = 1;
         animation.m_FirstUpdate = 1;

--- a/engine/gameobject/src/gameobject/comp_anim.cpp
+++ b/engine/gameobject/src/gameobject/comp_anim.cpp
@@ -324,11 +324,7 @@ namespace dmGameObject
                     AddPropertyOptionsIndex(&property_opt, 0);
                     SetProperty(anim.m_Instance, anim.m_ComponentId, anim.m_PropertyId, property_opt, PropertyVar(v));
                 }
-                if (anim.m_TransformsUpdated)
-                {
-                    MarkTransformDirty(anim.m_Instance);
-                    transforms_updated = true;
-                }
+                transforms_updated |= anim.m_TransformsUpdated;
             }
             if (completed)
             {
@@ -487,7 +483,7 @@ namespace dmGameObject
         animation.m_Next = INVALID_INDEX;
         animation.m_Playing = 1;
         animation.m_Composite = composite ? 1 : 0;
-        animation.m_TransformsUpdated = IsGameObjectTransformProperty(component_id, property_id) ? 1 : 0;
+        animation.m_TransformsUpdated = component_id == 0 && IsGameObjectTransformProperty(property_id) ? 1 : 0;
         if (animation.m_Playback == PLAYBACK_ONCE_BACKWARD || animation.m_Playback == PLAYBACK_LOOP_BACKWARD)
             animation.m_Backwards = 1;
         animation.m_FirstUpdate = 1;

--- a/engine/gameobject/src/gameobject/comp_anim.cpp
+++ b/engine/gameobject/src/gameobject/comp_anim.cpp
@@ -67,7 +67,7 @@ namespace dmGameObject
         uint16_t            m_Composite : 1;
         uint16_t            m_Backwards : 1;
         uint16_t            m_FirstUpdate : 1;
-        uint16_t            m_TransformsUpdated : 1;
+        uint16_t            m_IsGameObjectTransformProperty : 1;
     };
 
     struct AnimWorld
@@ -324,7 +324,7 @@ namespace dmGameObject
                     AddPropertyOptionsIndex(&property_opt, 0);
                     SetProperty(anim.m_Instance, anim.m_ComponentId, anim.m_PropertyId, property_opt, PropertyVar(v));
                 }
-                transforms_updated |= anim.m_TransformsUpdated;
+                transforms_updated |= anim.m_IsGameObjectTransformProperty;
             }
             if (completed)
             {
@@ -483,7 +483,7 @@ namespace dmGameObject
         animation.m_Next = INVALID_INDEX;
         animation.m_Playing = 1;
         animation.m_Composite = composite ? 1 : 0;
-        animation.m_TransformsUpdated = component_id == 0 && IsGameObjectTransformProperty(property_id) ? 1 : 0;
+        animation.m_IsGameObjectTransformProperty = component_id == 0 && IsGameObjectTransformProperty(property_id) ? 1 : 0;
         if (animation.m_Playback == PLAYBACK_ONCE_BACKWARD || animation.m_Playback == PLAYBACK_LOOP_BACKWARD)
             animation.m_Backwards = 1;
         animation.m_FirstUpdate = 1;

--- a/engine/gameobject/src/gameobject/comp_script.cpp
+++ b/engine/gameobject/src/gameobject/comp_script.cpp
@@ -224,7 +224,7 @@ namespace dmGameObject
     }
 
 
-    static UpdateResult CompScriptUpdateInternal(const ComponentsUpdateParams& params, ScriptFunction function, ComponentsUpdateResult& update_result)
+    static UpdateResult CompScriptUpdateInternal(const ComponentsUpdateParams& params, ScriptFunction function, ComponentsUpdateResult&)
     {
         lua_State* L = GetLuaState(params.m_Context);
         int top = lua_gettop(L);
@@ -246,9 +246,6 @@ namespace dmGameObject
                 }
             }
         }
-
-        // TODO: Find out if the scripts actually sent any transform events
-        update_result.m_TransformsUpdated = true;
 
         assert(top == lua_gettop(L));
         return result;

--- a/engine/gameobject/src/gameobject/gameobject.cpp
+++ b/engine/gameobject/src/gameobject/gameobject.cpp
@@ -84,20 +84,8 @@ namespace dmGameObject
     PROP_VECTOR3(EULER, euler);
     PROP_VECTOR3(SCALE, scale);
 
-    void MarkTransformDirty(HInstance instance)
+    bool IsGameObjectTransformProperty(dmhash_t property_id)
     {
-        instance->m_Collection->m_DirtyTransforms = true;
-    }
-
-    bool IsGameObjectTransformProperty(dmhash_t component_id, dmhash_t property_id)
-    {
-        // Component id 0 targets the game object itself. Non-zero ids target component
-        // properties, which may have overlapping names such as "scale".
-        if (component_id != 0)
-        {
-            return false;
-        }
-
         return property_id == PROP_POSITION ||
                property_id == PROP_POSITION_X ||
                property_id == PROP_POSITION_Y ||
@@ -2285,26 +2273,25 @@ namespace dmGameObject
         return instance->m_Bone;
     }
 
-    static uint32_t DoSetBoneTransforms(HCollection hcollection, dmTransform::Transform* component_transform, uint16_t first_index, dmTransform::Transform* transforms, uint32_t transform_count)
+    static uint32_t DoSetBoneTransforms(Collection* collection, dmTransform::Transform* component_transform, uint16_t first_index, dmTransform::Transform* transforms, uint32_t transform_count)
     {
         if (transform_count == 0)
             return 0;
         uint16_t current_index = first_index;
         uint32_t count = 0;
-        Collection* collection = hcollection->m_Collection;
         while (current_index != INVALID_INSTANCE_INDEX)
         {
             HInstance instance = collection->m_Instances[current_index];
             if (instance->m_Bone)
             {
                 instance->m_Transform = transforms[count++];
-                if (component_transform && count == 1) {
+                if (component_transform && count == 1)
+                {
                     instance->m_Transform = dmTransform::Mul(*component_transform, instance->m_Transform);
                 }
-                MarkTransformDirty(instance);
                 if (count < transform_count)
                 {
-                    count += DoSetBoneTransforms(hcollection, 0x0, instance->m_FirstChildIndex, &transforms[count], transform_count - count);
+                    count += DoSetBoneTransforms(collection, 0x0, instance->m_FirstChildIndex, &transforms[count], transform_count - count);
                 }
                 if (transform_count == count)
                 {
@@ -2318,7 +2305,13 @@ namespace dmGameObject
 
     uint32_t SetBoneTransforms(HInstance instance, dmTransform::Transform& component_transform, dmTransform::Transform* transforms, uint32_t transform_count)
     {
-        return DoSetBoneTransforms(instance->m_Collection->m_HCollection, &component_transform, instance->m_Index, transforms, transform_count);
+        Collection* collection = instance->m_Collection;
+        uint32_t count = DoSetBoneTransforms(collection, &component_transform, instance->m_Index, transforms, transform_count);
+        if (count > 0)
+        {
+            collection->m_DirtyTransforms = true;
+        }
+        return count;
     }
 
     static void DeleteBones(Collection* collection, uint16_t first_index) {
@@ -2390,28 +2383,25 @@ namespace dmGameObject
                         dmLogWarning("Could not find parent instance with id '%s'.", dmHashReverseSafe64(sp->m_ParentId));
 
                 }
-                Matrix4 parent_t = Matrix4::identity();
-
-                if (parent)
-                {
-                    parent_t = collection->m_WorldTransforms[parent->m_Index];
-                }
-
-                Matrix4 world_transform = parent_t * dmTransform::ToMatrix4(instance->m_Transform);
-                dmTransform::Transform local_transform = dmTransform::ToTransform(inverse(parent_t) * collection->m_WorldTransforms[instance->m_Index]);
                 uint16_t old_parent = instance->m_Parent;
 
                 dmGameObject::Result result = dmGameObject::SetParent(instance, parent);
 
                 if (result == dmGameObject::RESULT_OK && old_parent != instance->m_Parent)
                 {
+                    Matrix4 parent_t = Matrix4::identity();
+                    if (parent)
+                    {
+                        parent_t = collection->m_WorldTransforms[parent->m_Index];
+                    }
+
                     if (sp->m_KeepWorldTransform == 0)
                     {
-                        collection->m_WorldTransforms[instance->m_Index] = world_transform;
+                        collection->m_WorldTransforms[instance->m_Index] = parent_t * dmTransform::ToMatrix4(instance->m_Transform);
                     }
                     else
                     {
-                        instance->m_Transform = local_transform;
+                        instance->m_Transform = dmTransform::ToTransform(inverse(parent_t) * collection->m_WorldTransforms[instance->m_Index]);
                     }
                 }
 
@@ -2567,7 +2557,7 @@ namespace dmGameObject
         return DispatchMessages(hcollection->m_Collection, sockets, socket_count);
     }
 
-    static void UpdateEulerToRotation(HInstance instance, bool mark_dirty);
+    static void UpdateEulerToRotation(HInstance instance);
 
     static inline bool Vec3Equals(const uint32_t* a, const uint32_t* b)
     {
@@ -2581,11 +2571,11 @@ namespace dmGameObject
         return !Vec3Equals((uint32_t*)(&euler), (uint32_t*)(&prev_euler));
     }
 
-    static void CheckEuler(Instance* instance, bool mark_dirty)
+    static void CheckEuler(Instance* instance)
     {
         if (HasEulerChanged(instance))
         {
-            UpdateEulerToRotation(instance, mark_dirty);
+            UpdateEulerToRotation(instance);
         }
     }
 
@@ -2601,7 +2591,7 @@ namespace dmGameObject
         {
             uint16_t index = root_level[i];
             Instance* instance = collection->m_Instances[index];
-            CheckEuler(instance, false);
+            CheckEuler(instance);
             collection->m_WorldTransforms[index] = dmTransform::ToMatrix4(instance->m_Transform);
             uint16_t parent_index = instance->m_Parent;
             assert(parent_index == INVALID_INSTANCE_INDEX);
@@ -2615,7 +2605,7 @@ namespace dmGameObject
             {
                 uint16_t index = level[i];
                 Instance* instance = collection->m_Instances[index];
-                CheckEuler(instance, false);
+                CheckEuler(instance);
                 Matrix4* trans = &collection->m_WorldTransforms[index];
 
                 uint16_t parent_index = instance->m_Parent;
@@ -2656,7 +2646,7 @@ namespace dmGameObject
         for (int32_t i = (int32_t)count - 1; i >= 0; --i)
         {
             Instance* cur = chain[i];
-            CheckEuler(cur, false);
+            CheckEuler(cur);
 
             Matrix4 own = dmTransform::ToMatrix4(cur->m_Transform);
             if (cur->m_Parent == INVALID_INSTANCE_INDEX)
@@ -3191,7 +3181,7 @@ namespace dmGameObject
     void SetPosition(HInstance instance, Point3 position)
     {
         instance->m_Transform.SetTranslation(Vector3(position));
-        MarkTransformDirty(instance);
+        instance->m_Collection->m_DirtyTransforms = true;
     }
 
     Point3 GetPosition(HInstance instance)
@@ -3202,7 +3192,7 @@ namespace dmGameObject
     void SetRotation(HInstance instance, Quat rotation)
     {
         instance->m_Transform.SetRotation(rotation);
-        MarkTransformDirty(instance);
+        instance->m_Collection->m_DirtyTransforms = true;
     }
 
     Quat GetRotation(HInstance instance)
@@ -3213,19 +3203,19 @@ namespace dmGameObject
     void SetScale(HInstance instance, float scale)
     {
         instance->m_Transform.SetUniformScale(scale);
-        MarkTransformDirty(instance);
+        instance->m_Collection->m_DirtyTransforms = true;
     }
 
     void SetScale(HInstance instance, Vector3 scale)
     {
         instance->m_Transform.SetScale(scale);
-        MarkTransformDirty(instance);
+        instance->m_Collection->m_DirtyTransforms = true;
     }
 
     void SetScaleXY(HInstance instance, float scale_x, float scale_y)
     {
         instance->m_Transform.SetScaleXY(scale_x, scale_y);
-        MarkTransformDirty(instance);
+        instance->m_Collection->m_DirtyTransforms = true;
     }
 
     float GetUniformScale(HInstance instance)
@@ -3369,7 +3359,7 @@ namespace dmGameObject
             }
         }
 
-        MarkTransformDirty(child);
+        collection->m_DirtyTransforms = true;
         return RESULT_OK;
     }
 
@@ -3426,19 +3416,10 @@ namespace dmGameObject
         instance->m_PrevEulerRotation = instance->m_EulerRotation;
     }
 
-    static void UpdateEulerToRotation(HInstance instance, bool mark_dirty)
+    static void UpdateEulerToRotation(HInstance instance)
     {
         instance->m_PrevEulerRotation = instance->m_EulerRotation;
         instance->m_Transform.SetRotation(dmVMath::EulerToQuat(instance->m_EulerRotation));
-        if (mark_dirty)
-        {
-            MarkTransformDirty(instance);
-        }
-    }
-
-    static void UpdateEulerToRotation(HInstance instance)
-    {
-        UpdateEulerToRotation(instance, true);
     }
 
     PropertyResult GetProperty(HInstance instance, dmhash_t component_id, dmhash_t property_id, PropertyOptions options, PropertyDesc& out_value)
@@ -3842,6 +3823,7 @@ namespace dmGameObject
             return PROPERTY_RESULT_INVALID_INSTANCE;
         if (component_id == 0)
         {
+            Collection* collection = instance->m_Collection;
             float* position = instance->m_Transform.GetPositionPtr();
             float* rotation = instance->m_Transform.GetRotationPtr();
             float* scale = instance->m_Transform.GetScalePtr();
@@ -3852,7 +3834,7 @@ namespace dmGameObject
                 position[0] = value.m_V4[0];
                 position[1] = value.m_V4[1];
                 position[2] = value.m_V4[2];
-                MarkTransformDirty(instance);
+                collection->m_DirtyTransforms = true;
                 return PROPERTY_RESULT_OK;
             }
             else if (property_id == PROP_POSITION_X)
@@ -3860,7 +3842,7 @@ namespace dmGameObject
                 if (value.m_Type != PROPERTY_TYPE_NUMBER)
                     return PROPERTY_RESULT_TYPE_MISMATCH;
                 position[0] = (float)value.m_Number;
-                MarkTransformDirty(instance);
+                collection->m_DirtyTransforms = true;
                 return PROPERTY_RESULT_OK;
             }
             else if (property_id == PROP_POSITION_Y)
@@ -3868,7 +3850,7 @@ namespace dmGameObject
                 if (value.m_Type != PROPERTY_TYPE_NUMBER)
                     return PROPERTY_RESULT_TYPE_MISMATCH;
                 position[1] = (float)value.m_Number;
-                MarkTransformDirty(instance);
+                collection->m_DirtyTransforms = true;
                 return PROPERTY_RESULT_OK;
             }
             else if (property_id == PROP_POSITION_Z)
@@ -3876,7 +3858,7 @@ namespace dmGameObject
                 if (value.m_Type != PROPERTY_TYPE_NUMBER)
                     return PROPERTY_RESULT_TYPE_MISMATCH;
                 position[2] = (float)value.m_Number;
-                MarkTransformDirty(instance);
+                collection->m_DirtyTransforms = true;
                 return PROPERTY_RESULT_OK;
             }
             else if (property_id == PROP_SCALE)
@@ -3886,7 +3868,7 @@ namespace dmGameObject
                     scale[0] = (float)value.m_Number;
                     scale[1] = scale[0];
                     scale[2] = scale[0];
-                    MarkTransformDirty(instance);
+                    collection->m_DirtyTransforms = true;
                     return PROPERTY_RESULT_OK;
                 }
                 else if (value.m_Type == PROPERTY_TYPE_VECTOR3)
@@ -3894,7 +3876,7 @@ namespace dmGameObject
                     scale[0] = value.m_V4[0];
                     scale[1] = value.m_V4[1];
                     scale[2] = value.m_V4[2];
-                    MarkTransformDirty(instance);
+                    collection->m_DirtyTransforms = true;
                     return PROPERTY_RESULT_OK;
                 }
                 return PROPERTY_RESULT_TYPE_MISMATCH;
@@ -3905,14 +3887,14 @@ namespace dmGameObject
                 {
                     scale[0] = (float)value.m_Number;
                     scale[1] = scale[0];
-                    MarkTransformDirty(instance);
+                    collection->m_DirtyTransforms = true;
                     return PROPERTY_RESULT_OK;
                 }
                 else if (value.m_Type == PROPERTY_TYPE_VECTOR3)
                 {
                     scale[0] = value.m_V4[0];
                     scale[1] = value.m_V4[1];
-                    MarkTransformDirty(instance);
+                    collection->m_DirtyTransforms = true;
                     return PROPERTY_RESULT_OK;
                 }
                 return PROPERTY_RESULT_TYPE_MISMATCH;
@@ -3922,7 +3904,7 @@ namespace dmGameObject
                 if (value.m_Type != PROPERTY_TYPE_NUMBER)
                     return PROPERTY_RESULT_TYPE_MISMATCH;
                 scale[0] = (float)value.m_Number;
-                MarkTransformDirty(instance);
+                collection->m_DirtyTransforms = true;
                 return PROPERTY_RESULT_OK;
             }
             else if (property_id == PROP_SCALE_Y)
@@ -3930,7 +3912,7 @@ namespace dmGameObject
                 if (value.m_Type != PROPERTY_TYPE_NUMBER)
                     return PROPERTY_RESULT_TYPE_MISMATCH;
                 scale[1] = (float)value.m_Number;
-                MarkTransformDirty(instance);
+                collection->m_DirtyTransforms = true;
                 return PROPERTY_RESULT_OK;
             }
             else if (property_id == PROP_SCALE_Z)
@@ -3938,7 +3920,7 @@ namespace dmGameObject
                 if (value.m_Type != PROPERTY_TYPE_NUMBER)
                     return PROPERTY_RESULT_TYPE_MISMATCH;
                 scale[2] = (float)value.m_Number;
-                MarkTransformDirty(instance);
+                collection->m_DirtyTransforms = true;
                 return PROPERTY_RESULT_OK;
             }
             else if (property_id == PROP_ROTATION)
@@ -3949,7 +3931,7 @@ namespace dmGameObject
                 rotation[1] = value.m_V4[1];
                 rotation[2] = value.m_V4[2];
                 rotation[3] = value.m_V4[3];
-                MarkTransformDirty(instance);
+                collection->m_DirtyTransforms = true;
                 return PROPERTY_RESULT_OK;
             }
             else if (property_id == PROP_ROTATION_X)
@@ -3957,7 +3939,7 @@ namespace dmGameObject
                 if (value.m_Type != PROPERTY_TYPE_NUMBER)
                     return PROPERTY_RESULT_TYPE_MISMATCH;
                 rotation[0] = (float)value.m_Number;
-                MarkTransformDirty(instance);
+                collection->m_DirtyTransforms = true;
                 return PROPERTY_RESULT_OK;
             }
             else if (property_id == PROP_ROTATION_Y)
@@ -3965,7 +3947,7 @@ namespace dmGameObject
                 if (value.m_Type != PROPERTY_TYPE_NUMBER)
                     return PROPERTY_RESULT_TYPE_MISMATCH;
                 rotation[1] = (float)value.m_Number;
-                MarkTransformDirty(instance);
+                collection->m_DirtyTransforms = true;
                 return PROPERTY_RESULT_OK;
             }
             else if (property_id == PROP_ROTATION_Z)
@@ -3973,7 +3955,7 @@ namespace dmGameObject
                 if (value.m_Type != PROPERTY_TYPE_NUMBER)
                     return PROPERTY_RESULT_TYPE_MISMATCH;
                 rotation[2] = (float)value.m_Number;
-                MarkTransformDirty(instance);
+                collection->m_DirtyTransforms = true;
                 return PROPERTY_RESULT_OK;
             }
             else if (property_id == PROP_ROTATION_W)
@@ -3981,7 +3963,7 @@ namespace dmGameObject
                 if (value.m_Type != PROPERTY_TYPE_NUMBER)
                     return PROPERTY_RESULT_TYPE_MISMATCH;
                 rotation[3] = (float)value.m_Number;
-                MarkTransformDirty(instance);
+                collection->m_DirtyTransforms = true;
                 return PROPERTY_RESULT_OK;
             }
             else if (property_id == PROP_EULER)
@@ -3990,6 +3972,7 @@ namespace dmGameObject
                     return PROPERTY_RESULT_TYPE_MISMATCH;
                 instance->m_EulerRotation = Vector3(value.m_V4[0], value.m_V4[1], value.m_V4[2]);
                 UpdateEulerToRotation(instance);
+                collection->m_DirtyTransforms = true;
                 return PROPERTY_RESULT_OK;
             }
             else if (property_id == PROP_EULER_X)
@@ -3998,6 +3981,7 @@ namespace dmGameObject
                     return PROPERTY_RESULT_TYPE_MISMATCH;
                 instance->m_EulerRotation.setX((float)value.m_Number);
                 UpdateEulerToRotation(instance);
+                collection->m_DirtyTransforms = true;
                 return PROPERTY_RESULT_OK;
             }
             else if (property_id == PROP_EULER_Y)
@@ -4006,6 +3990,7 @@ namespace dmGameObject
                     return PROPERTY_RESULT_TYPE_MISMATCH;
                 instance->m_EulerRotation.setY((float)value.m_Number);
                 UpdateEulerToRotation(instance);
+                collection->m_DirtyTransforms = true;
                 return PROPERTY_RESULT_OK;
             }
             else if (property_id == PROP_EULER_Z)
@@ -4014,6 +3999,7 @@ namespace dmGameObject
                     return PROPERTY_RESULT_TYPE_MISMATCH;
                 instance->m_EulerRotation.setZ((float)value.m_Number);
                 UpdateEulerToRotation(instance);
+                collection->m_DirtyTransforms = true;
                 return PROPERTY_RESULT_OK;
             }
             else

--- a/engine/gameobject/src/gameobject/gameobject.cpp
+++ b/engine/gameobject/src/gameobject/gameobject.cpp
@@ -2066,7 +2066,7 @@ namespace dmGameObject
 
         if (instance->m_FirstChildIndex != INVALID_INSTANCE_INDEX)
         {
-            collection->m_DirtyTransforms = true;
+            collection->m_DirtyTransforms = 1;
         }
 
         if (prototype != &EMPTY_PROTOTYPE)
@@ -2307,10 +2307,7 @@ namespace dmGameObject
     {
         Collection* collection = instance->m_Collection;
         uint32_t count = DoSetBoneTransforms(collection, &component_transform, instance->m_Index, transforms, transform_count);
-        if (count > 0)
-        {
-            collection->m_DirtyTransforms = true;
-        }
+        collection->m_DirtyTransforms |= count > 0 ? 1 : 0;
         return count;
     }
 
@@ -2720,7 +2717,7 @@ namespace dmGameObject
                 // them in its update function.
                 if (update_result.m_TransformsUpdated)
                 {
-                    collection->m_DirtyTransforms = true;
+                    collection->m_DirtyTransforms = 1;
                 }
             }
 
@@ -3181,7 +3178,7 @@ namespace dmGameObject
     void SetPosition(HInstance instance, Point3 position)
     {
         instance->m_Transform.SetTranslation(Vector3(position));
-        instance->m_Collection->m_DirtyTransforms = true;
+        instance->m_Collection->m_DirtyTransforms = 1;
     }
 
     Point3 GetPosition(HInstance instance)
@@ -3192,7 +3189,7 @@ namespace dmGameObject
     void SetRotation(HInstance instance, Quat rotation)
     {
         instance->m_Transform.SetRotation(rotation);
-        instance->m_Collection->m_DirtyTransforms = true;
+        instance->m_Collection->m_DirtyTransforms = 1;
     }
 
     Quat GetRotation(HInstance instance)
@@ -3203,19 +3200,19 @@ namespace dmGameObject
     void SetScale(HInstance instance, float scale)
     {
         instance->m_Transform.SetUniformScale(scale);
-        instance->m_Collection->m_DirtyTransforms = true;
+        instance->m_Collection->m_DirtyTransforms = 1;
     }
 
     void SetScale(HInstance instance, Vector3 scale)
     {
         instance->m_Transform.SetScale(scale);
-        instance->m_Collection->m_DirtyTransforms = true;
+        instance->m_Collection->m_DirtyTransforms = 1;
     }
 
     void SetScaleXY(HInstance instance, float scale_x, float scale_y)
     {
         instance->m_Transform.SetScaleXY(scale_x, scale_y);
-        instance->m_Collection->m_DirtyTransforms = true;
+        instance->m_Collection->m_DirtyTransforms = 1;
     }
 
     float GetUniformScale(HInstance instance)
@@ -3359,7 +3356,7 @@ namespace dmGameObject
             }
         }
 
-        collection->m_DirtyTransforms = true;
+        collection->m_DirtyTransforms = 1;
         return RESULT_OK;
     }
 
@@ -3834,7 +3831,7 @@ namespace dmGameObject
                 position[0] = value.m_V4[0];
                 position[1] = value.m_V4[1];
                 position[2] = value.m_V4[2];
-                collection->m_DirtyTransforms = true;
+                collection->m_DirtyTransforms = 1;
                 return PROPERTY_RESULT_OK;
             }
             else if (property_id == PROP_POSITION_X)
@@ -3842,7 +3839,7 @@ namespace dmGameObject
                 if (value.m_Type != PROPERTY_TYPE_NUMBER)
                     return PROPERTY_RESULT_TYPE_MISMATCH;
                 position[0] = (float)value.m_Number;
-                collection->m_DirtyTransforms = true;
+                collection->m_DirtyTransforms = 1;
                 return PROPERTY_RESULT_OK;
             }
             else if (property_id == PROP_POSITION_Y)
@@ -3850,7 +3847,7 @@ namespace dmGameObject
                 if (value.m_Type != PROPERTY_TYPE_NUMBER)
                     return PROPERTY_RESULT_TYPE_MISMATCH;
                 position[1] = (float)value.m_Number;
-                collection->m_DirtyTransforms = true;
+                collection->m_DirtyTransforms = 1;
                 return PROPERTY_RESULT_OK;
             }
             else if (property_id == PROP_POSITION_Z)
@@ -3858,7 +3855,7 @@ namespace dmGameObject
                 if (value.m_Type != PROPERTY_TYPE_NUMBER)
                     return PROPERTY_RESULT_TYPE_MISMATCH;
                 position[2] = (float)value.m_Number;
-                collection->m_DirtyTransforms = true;
+                collection->m_DirtyTransforms = 1;
                 return PROPERTY_RESULT_OK;
             }
             else if (property_id == PROP_SCALE)
@@ -3868,7 +3865,7 @@ namespace dmGameObject
                     scale[0] = (float)value.m_Number;
                     scale[1] = scale[0];
                     scale[2] = scale[0];
-                    collection->m_DirtyTransforms = true;
+                    collection->m_DirtyTransforms = 1;
                     return PROPERTY_RESULT_OK;
                 }
                 else if (value.m_Type == PROPERTY_TYPE_VECTOR3)
@@ -3876,7 +3873,7 @@ namespace dmGameObject
                     scale[0] = value.m_V4[0];
                     scale[1] = value.m_V4[1];
                     scale[2] = value.m_V4[2];
-                    collection->m_DirtyTransforms = true;
+                    collection->m_DirtyTransforms = 1;
                     return PROPERTY_RESULT_OK;
                 }
                 return PROPERTY_RESULT_TYPE_MISMATCH;
@@ -3887,14 +3884,14 @@ namespace dmGameObject
                 {
                     scale[0] = (float)value.m_Number;
                     scale[1] = scale[0];
-                    collection->m_DirtyTransforms = true;
+                    collection->m_DirtyTransforms = 1;
                     return PROPERTY_RESULT_OK;
                 }
                 else if (value.m_Type == PROPERTY_TYPE_VECTOR3)
                 {
                     scale[0] = value.m_V4[0];
                     scale[1] = value.m_V4[1];
-                    collection->m_DirtyTransforms = true;
+                    collection->m_DirtyTransforms = 1;
                     return PROPERTY_RESULT_OK;
                 }
                 return PROPERTY_RESULT_TYPE_MISMATCH;
@@ -3904,7 +3901,7 @@ namespace dmGameObject
                 if (value.m_Type != PROPERTY_TYPE_NUMBER)
                     return PROPERTY_RESULT_TYPE_MISMATCH;
                 scale[0] = (float)value.m_Number;
-                collection->m_DirtyTransforms = true;
+                collection->m_DirtyTransforms = 1;
                 return PROPERTY_RESULT_OK;
             }
             else if (property_id == PROP_SCALE_Y)
@@ -3912,7 +3909,7 @@ namespace dmGameObject
                 if (value.m_Type != PROPERTY_TYPE_NUMBER)
                     return PROPERTY_RESULT_TYPE_MISMATCH;
                 scale[1] = (float)value.m_Number;
-                collection->m_DirtyTransforms = true;
+                collection->m_DirtyTransforms = 1;
                 return PROPERTY_RESULT_OK;
             }
             else if (property_id == PROP_SCALE_Z)
@@ -3920,7 +3917,7 @@ namespace dmGameObject
                 if (value.m_Type != PROPERTY_TYPE_NUMBER)
                     return PROPERTY_RESULT_TYPE_MISMATCH;
                 scale[2] = (float)value.m_Number;
-                collection->m_DirtyTransforms = true;
+                collection->m_DirtyTransforms = 1;
                 return PROPERTY_RESULT_OK;
             }
             else if (property_id == PROP_ROTATION)
@@ -3931,7 +3928,7 @@ namespace dmGameObject
                 rotation[1] = value.m_V4[1];
                 rotation[2] = value.m_V4[2];
                 rotation[3] = value.m_V4[3];
-                collection->m_DirtyTransforms = true;
+                collection->m_DirtyTransforms = 1;
                 return PROPERTY_RESULT_OK;
             }
             else if (property_id == PROP_ROTATION_X)
@@ -3939,7 +3936,7 @@ namespace dmGameObject
                 if (value.m_Type != PROPERTY_TYPE_NUMBER)
                     return PROPERTY_RESULT_TYPE_MISMATCH;
                 rotation[0] = (float)value.m_Number;
-                collection->m_DirtyTransforms = true;
+                collection->m_DirtyTransforms = 1;
                 return PROPERTY_RESULT_OK;
             }
             else if (property_id == PROP_ROTATION_Y)
@@ -3947,7 +3944,7 @@ namespace dmGameObject
                 if (value.m_Type != PROPERTY_TYPE_NUMBER)
                     return PROPERTY_RESULT_TYPE_MISMATCH;
                 rotation[1] = (float)value.m_Number;
-                collection->m_DirtyTransforms = true;
+                collection->m_DirtyTransforms = 1;
                 return PROPERTY_RESULT_OK;
             }
             else if (property_id == PROP_ROTATION_Z)
@@ -3955,7 +3952,7 @@ namespace dmGameObject
                 if (value.m_Type != PROPERTY_TYPE_NUMBER)
                     return PROPERTY_RESULT_TYPE_MISMATCH;
                 rotation[2] = (float)value.m_Number;
-                collection->m_DirtyTransforms = true;
+                collection->m_DirtyTransforms = 1;
                 return PROPERTY_RESULT_OK;
             }
             else if (property_id == PROP_ROTATION_W)
@@ -3963,7 +3960,7 @@ namespace dmGameObject
                 if (value.m_Type != PROPERTY_TYPE_NUMBER)
                     return PROPERTY_RESULT_TYPE_MISMATCH;
                 rotation[3] = (float)value.m_Number;
-                collection->m_DirtyTransforms = true;
+                collection->m_DirtyTransforms = 1;
                 return PROPERTY_RESULT_OK;
             }
             else if (property_id == PROP_EULER)
@@ -3972,7 +3969,7 @@ namespace dmGameObject
                     return PROPERTY_RESULT_TYPE_MISMATCH;
                 instance->m_EulerRotation = Vector3(value.m_V4[0], value.m_V4[1], value.m_V4[2]);
                 UpdateEulerToRotation(instance);
-                collection->m_DirtyTransforms = true;
+                collection->m_DirtyTransforms = 1;
                 return PROPERTY_RESULT_OK;
             }
             else if (property_id == PROP_EULER_X)
@@ -3981,7 +3978,7 @@ namespace dmGameObject
                     return PROPERTY_RESULT_TYPE_MISMATCH;
                 instance->m_EulerRotation.setX((float)value.m_Number);
                 UpdateEulerToRotation(instance);
-                collection->m_DirtyTransforms = true;
+                collection->m_DirtyTransforms = 1;
                 return PROPERTY_RESULT_OK;
             }
             else if (property_id == PROP_EULER_Y)
@@ -3990,7 +3987,7 @@ namespace dmGameObject
                     return PROPERTY_RESULT_TYPE_MISMATCH;
                 instance->m_EulerRotation.setY((float)value.m_Number);
                 UpdateEulerToRotation(instance);
-                collection->m_DirtyTransforms = true;
+                collection->m_DirtyTransforms = 1;
                 return PROPERTY_RESULT_OK;
             }
             else if (property_id == PROP_EULER_Z)
@@ -3999,7 +3996,7 @@ namespace dmGameObject
                     return PROPERTY_RESULT_TYPE_MISMATCH;
                 instance->m_EulerRotation.setZ((float)value.m_Number);
                 UpdateEulerToRotation(instance);
-                collection->m_DirtyTransforms = true;
+                collection->m_DirtyTransforms = 1;
                 return PROPERTY_RESULT_OK;
             }
             else

--- a/engine/gameobject/src/gameobject/gameobject.cpp
+++ b/engine/gameobject/src/gameobject/gameobject.cpp
@@ -84,6 +84,40 @@ namespace dmGameObject
     PROP_VECTOR3(EULER, euler);
     PROP_VECTOR3(SCALE, scale);
 
+    void MarkTransformDirty(HInstance instance)
+    {
+        instance->m_Collection->m_DirtyTransforms = true;
+    }
+
+    bool IsGameObjectTransformProperty(dmhash_t component_id, dmhash_t property_id)
+    {
+        // Component id 0 targets the game object itself. Non-zero ids target component
+        // properties, which may have overlapping names such as "scale".
+        if (component_id != 0)
+        {
+            return false;
+        }
+
+        return property_id == PROP_POSITION ||
+               property_id == PROP_POSITION_X ||
+               property_id == PROP_POSITION_Y ||
+               property_id == PROP_POSITION_Z ||
+               property_id == PROP_ROTATION ||
+               property_id == PROP_ROTATION_X ||
+               property_id == PROP_ROTATION_Y ||
+               property_id == PROP_ROTATION_Z ||
+               property_id == PROP_ROTATION_W ||
+               property_id == PROP_EULER ||
+               property_id == PROP_EULER_X ||
+               property_id == PROP_EULER_Y ||
+               property_id == PROP_EULER_Z ||
+               property_id == PROP_SCALE ||
+               property_id == PROP_SCALE_XY ||
+               property_id == PROP_SCALE_X ||
+               property_id == PROP_SCALE_Y ||
+               property_id == PROP_SCALE_Z;
+    }
+
     static void ResourceReloadedCallback(const ResourceReloadedParams* params);
     static void DoDeleteInstance(Collection* collection, HInstance instance);
     static bool InitInstance(Collection* collection, HInstance instance);
@@ -2042,6 +2076,11 @@ namespace dmGameObject
         EraseSwapLevelIndex(collection, instance);
         MoveAllUp(collection, instance);
 
+        if (instance->m_FirstChildIndex != INVALID_INSTANCE_INDEX)
+        {
+            collection->m_DirtyTransforms = true;
+        }
+
         if (prototype != &EMPTY_PROTOTYPE)
             dmResource::Release(factory, prototype);
         collection->m_InstanceIndices.Push(instance->m_Index);
@@ -2262,6 +2301,7 @@ namespace dmGameObject
                 if (component_transform && count == 1) {
                     instance->m_Transform = dmTransform::Mul(*component_transform, instance->m_Transform);
                 }
+                MarkTransformDirty(instance);
                 if (count < transform_count)
                 {
                     count += DoSetBoneTransforms(hcollection, 0x0, instance->m_FirstChildIndex, &transforms[count], transform_count - count);
@@ -2357,17 +2397,23 @@ namespace dmGameObject
                     parent_t = collection->m_WorldTransforms[parent->m_Index];
                 }
 
-                if (sp->m_KeepWorldTransform == 0)
-                {
-                    Matrix4& world = collection->m_WorldTransforms[instance->m_Index];
-                    world = parent_t * dmTransform::ToMatrix4(instance->m_Transform);
-                }
-                else
-                {
-                    instance->m_Transform = dmTransform::ToTransform(inverse(parent_t) * collection->m_WorldTransforms[instance->m_Index]);
-                }
+                Matrix4 world_transform = parent_t * dmTransform::ToMatrix4(instance->m_Transform);
+                dmTransform::Transform local_transform = dmTransform::ToTransform(inverse(parent_t) * collection->m_WorldTransforms[instance->m_Index]);
+                uint16_t old_parent = instance->m_Parent;
 
                 dmGameObject::Result result = dmGameObject::SetParent(instance, parent);
+
+                if (result == dmGameObject::RESULT_OK && old_parent != instance->m_Parent)
+                {
+                    if (sp->m_KeepWorldTransform == 0)
+                    {
+                        collection->m_WorldTransforms[instance->m_Index] = world_transform;
+                    }
+                    else
+                    {
+                        instance->m_Transform = local_transform;
+                    }
+                }
 
                 if (result != dmGameObject::RESULT_OK)
                     dmLogWarning("Error when setting parent of '%s' to '%s', error: %i.",
@@ -2507,7 +2553,6 @@ namespace dmGameObject
                 uint32_t message_count = dmMessage::Dispatch(sockets[i], &DispatchMessagesFunction, (void*) &ctx);
                 if (message_count)
                 {
-                    collection->m_DirtyTransforms = true;
                     iterate = true;
                 }
             }
@@ -2522,7 +2567,7 @@ namespace dmGameObject
         return DispatchMessages(hcollection->m_Collection, sockets, socket_count);
     }
 
-    static void UpdateEulerToRotation(HInstance instance);
+    static void UpdateEulerToRotation(HInstance instance, bool mark_dirty);
 
     static inline bool Vec3Equals(const uint32_t* a, const uint32_t* b)
     {
@@ -2536,11 +2581,11 @@ namespace dmGameObject
         return !Vec3Equals((uint32_t*)(&euler), (uint32_t*)(&prev_euler));
     }
 
-    static void CheckEuler(Instance* instance)
+    static void CheckEuler(Instance* instance, bool mark_dirty)
     {
         if (HasEulerChanged(instance))
         {
-            UpdateEulerToRotation(instance);
+            UpdateEulerToRotation(instance, mark_dirty);
         }
     }
 
@@ -2556,7 +2601,7 @@ namespace dmGameObject
         {
             uint16_t index = root_level[i];
             Instance* instance = collection->m_Instances[index];
-            CheckEuler(instance);
+            CheckEuler(instance, false);
             collection->m_WorldTransforms[index] = dmTransform::ToMatrix4(instance->m_Transform);
             uint16_t parent_index = instance->m_Parent;
             assert(parent_index == INVALID_INSTANCE_INDEX);
@@ -2570,7 +2615,7 @@ namespace dmGameObject
             {
                 uint16_t index = level[i];
                 Instance* instance = collection->m_Instances[index];
-                CheckEuler(instance);
+                CheckEuler(instance, false);
                 Matrix4* trans = &collection->m_WorldTransforms[index];
 
                 uint16_t parent_index = instance->m_Parent;
@@ -2611,7 +2656,7 @@ namespace dmGameObject
         for (int32_t i = (int32_t)count - 1; i >= 0; --i)
         {
             Instance* cur = chain[i];
-            CheckEuler(cur);
+            CheckEuler(cur, false);
 
             Matrix4 own = dmTransform::ToMatrix4(cur->m_Transform);
             if (cur->m_Parent == INVALID_INSTANCE_INDEX)
@@ -2683,7 +2728,10 @@ namespace dmGameObject
 
                 // Mark the collections transforms as dirty if this component has updated
                 // them in its update function.
-                collection->m_DirtyTransforms |= update_result.m_TransformsUpdated;
+                if (update_result.m_TransformsUpdated)
+                {
+                    collection->m_DirtyTransforms = true;
+                }
             }
 
             if (!DispatchMessages(collection, &collection->m_ComponentSocket, 1))
@@ -3143,6 +3191,7 @@ namespace dmGameObject
     void SetPosition(HInstance instance, Point3 position)
     {
         instance->m_Transform.SetTranslation(Vector3(position));
+        MarkTransformDirty(instance);
     }
 
     Point3 GetPosition(HInstance instance)
@@ -3153,6 +3202,7 @@ namespace dmGameObject
     void SetRotation(HInstance instance, Quat rotation)
     {
         instance->m_Transform.SetRotation(rotation);
+        MarkTransformDirty(instance);
     }
 
     Quat GetRotation(HInstance instance)
@@ -3163,16 +3213,19 @@ namespace dmGameObject
     void SetScale(HInstance instance, float scale)
     {
         instance->m_Transform.SetUniformScale(scale);
+        MarkTransformDirty(instance);
     }
 
     void SetScale(HInstance instance, Vector3 scale)
     {
         instance->m_Transform.SetScale(scale);
+        MarkTransformDirty(instance);
     }
 
     void SetScaleXY(HInstance instance, float scale_x, float scale_y)
     {
         instance->m_Transform.SetScaleXY(scale_x, scale_y);
+        MarkTransformDirty(instance);
     }
 
     float GetUniformScale(HInstance instance)
@@ -3316,6 +3369,7 @@ namespace dmGameObject
             }
         }
 
+        MarkTransformDirty(child);
         return RESULT_OK;
     }
 
@@ -3372,10 +3426,19 @@ namespace dmGameObject
         instance->m_PrevEulerRotation = instance->m_EulerRotation;
     }
 
-    static void UpdateEulerToRotation(HInstance instance)
+    static void UpdateEulerToRotation(HInstance instance, bool mark_dirty)
     {
         instance->m_PrevEulerRotation = instance->m_EulerRotation;
         instance->m_Transform.SetRotation(dmVMath::EulerToQuat(instance->m_EulerRotation));
+        if (mark_dirty)
+        {
+            MarkTransformDirty(instance);
+        }
+    }
+
+    static void UpdateEulerToRotation(HInstance instance)
+    {
+        UpdateEulerToRotation(instance, true);
     }
 
     PropertyResult GetProperty(HInstance instance, dmhash_t component_id, dmhash_t property_id, PropertyOptions options, PropertyDesc& out_value)
@@ -3789,6 +3852,7 @@ namespace dmGameObject
                 position[0] = value.m_V4[0];
                 position[1] = value.m_V4[1];
                 position[2] = value.m_V4[2];
+                MarkTransformDirty(instance);
                 return PROPERTY_RESULT_OK;
             }
             else if (property_id == PROP_POSITION_X)
@@ -3796,6 +3860,7 @@ namespace dmGameObject
                 if (value.m_Type != PROPERTY_TYPE_NUMBER)
                     return PROPERTY_RESULT_TYPE_MISMATCH;
                 position[0] = (float)value.m_Number;
+                MarkTransformDirty(instance);
                 return PROPERTY_RESULT_OK;
             }
             else if (property_id == PROP_POSITION_Y)
@@ -3803,6 +3868,7 @@ namespace dmGameObject
                 if (value.m_Type != PROPERTY_TYPE_NUMBER)
                     return PROPERTY_RESULT_TYPE_MISMATCH;
                 position[1] = (float)value.m_Number;
+                MarkTransformDirty(instance);
                 return PROPERTY_RESULT_OK;
             }
             else if (property_id == PROP_POSITION_Z)
@@ -3810,6 +3876,7 @@ namespace dmGameObject
                 if (value.m_Type != PROPERTY_TYPE_NUMBER)
                     return PROPERTY_RESULT_TYPE_MISMATCH;
                 position[2] = (float)value.m_Number;
+                MarkTransformDirty(instance);
                 return PROPERTY_RESULT_OK;
             }
             else if (property_id == PROP_SCALE)
@@ -3819,6 +3886,7 @@ namespace dmGameObject
                     scale[0] = (float)value.m_Number;
                     scale[1] = scale[0];
                     scale[2] = scale[0];
+                    MarkTransformDirty(instance);
                     return PROPERTY_RESULT_OK;
                 }
                 else if (value.m_Type == PROPERTY_TYPE_VECTOR3)
@@ -3826,6 +3894,7 @@ namespace dmGameObject
                     scale[0] = value.m_V4[0];
                     scale[1] = value.m_V4[1];
                     scale[2] = value.m_V4[2];
+                    MarkTransformDirty(instance);
                     return PROPERTY_RESULT_OK;
                 }
                 return PROPERTY_RESULT_TYPE_MISMATCH;
@@ -3836,12 +3905,14 @@ namespace dmGameObject
                 {
                     scale[0] = (float)value.m_Number;
                     scale[1] = scale[0];
+                    MarkTransformDirty(instance);
                     return PROPERTY_RESULT_OK;
                 }
                 else if (value.m_Type == PROPERTY_TYPE_VECTOR3)
                 {
                     scale[0] = value.m_V4[0];
                     scale[1] = value.m_V4[1];
+                    MarkTransformDirty(instance);
                     return PROPERTY_RESULT_OK;
                 }
                 return PROPERTY_RESULT_TYPE_MISMATCH;
@@ -3851,6 +3922,7 @@ namespace dmGameObject
                 if (value.m_Type != PROPERTY_TYPE_NUMBER)
                     return PROPERTY_RESULT_TYPE_MISMATCH;
                 scale[0] = (float)value.m_Number;
+                MarkTransformDirty(instance);
                 return PROPERTY_RESULT_OK;
             }
             else if (property_id == PROP_SCALE_Y)
@@ -3858,6 +3930,7 @@ namespace dmGameObject
                 if (value.m_Type != PROPERTY_TYPE_NUMBER)
                     return PROPERTY_RESULT_TYPE_MISMATCH;
                 scale[1] = (float)value.m_Number;
+                MarkTransformDirty(instance);
                 return PROPERTY_RESULT_OK;
             }
             else if (property_id == PROP_SCALE_Z)
@@ -3865,6 +3938,7 @@ namespace dmGameObject
                 if (value.m_Type != PROPERTY_TYPE_NUMBER)
                     return PROPERTY_RESULT_TYPE_MISMATCH;
                 scale[2] = (float)value.m_Number;
+                MarkTransformDirty(instance);
                 return PROPERTY_RESULT_OK;
             }
             else if (property_id == PROP_ROTATION)
@@ -3875,6 +3949,7 @@ namespace dmGameObject
                 rotation[1] = value.m_V4[1];
                 rotation[2] = value.m_V4[2];
                 rotation[3] = value.m_V4[3];
+                MarkTransformDirty(instance);
                 return PROPERTY_RESULT_OK;
             }
             else if (property_id == PROP_ROTATION_X)
@@ -3882,6 +3957,7 @@ namespace dmGameObject
                 if (value.m_Type != PROPERTY_TYPE_NUMBER)
                     return PROPERTY_RESULT_TYPE_MISMATCH;
                 rotation[0] = (float)value.m_Number;
+                MarkTransformDirty(instance);
                 return PROPERTY_RESULT_OK;
             }
             else if (property_id == PROP_ROTATION_Y)
@@ -3889,6 +3965,7 @@ namespace dmGameObject
                 if (value.m_Type != PROPERTY_TYPE_NUMBER)
                     return PROPERTY_RESULT_TYPE_MISMATCH;
                 rotation[1] = (float)value.m_Number;
+                MarkTransformDirty(instance);
                 return PROPERTY_RESULT_OK;
             }
             else if (property_id == PROP_ROTATION_Z)
@@ -3896,6 +3973,7 @@ namespace dmGameObject
                 if (value.m_Type != PROPERTY_TYPE_NUMBER)
                     return PROPERTY_RESULT_TYPE_MISMATCH;
                 rotation[2] = (float)value.m_Number;
+                MarkTransformDirty(instance);
                 return PROPERTY_RESULT_OK;
             }
             else if (property_id == PROP_ROTATION_W)
@@ -3903,6 +3981,7 @@ namespace dmGameObject
                 if (value.m_Type != PROPERTY_TYPE_NUMBER)
                     return PROPERTY_RESULT_TYPE_MISMATCH;
                 rotation[3] = (float)value.m_Number;
+                MarkTransformDirty(instance);
                 return PROPERTY_RESULT_OK;
             }
             else if (property_id == PROP_EULER)

--- a/engine/gameobject/src/gameobject/gameobject_private.h
+++ b/engine/gameobject/src/gameobject/gameobject_private.h
@@ -308,10 +308,9 @@ namespace dmGameObject
     void UndoNewInstance(Collection* collection, HInstance instance);
     bool CreateComponents(Collection* collection, HInstance instance);
     void Delete(Collection* collection, HInstance instance, bool recursive);
-    void MarkTransformDirty(HInstance instance);
     void UpdateTransforms(Collection* collection);
     void UpdateTransformsForInstance(Collection* collection, Instance* instance);
-    bool IsGameObjectTransformProperty(dmhash_t component_id, dmhash_t property_id);
+    bool IsGameObjectTransformProperty(dmhash_t property_id);
     void DeleteCollection(Collection* collection);
     bool IsCollectionInitialized(Collection* collection);
     Result AttachCollection(Collection* collection, const char* name, dmResource::HFactory factory, HRegister regist, HCollection hcollection);

--- a/engine/gameobject/src/gameobject/gameobject_private.h
+++ b/engine/gameobject/src/gameobject/gameobject_private.h
@@ -308,8 +308,10 @@ namespace dmGameObject
     void UndoNewInstance(Collection* collection, HInstance instance);
     bool CreateComponents(Collection* collection, HInstance instance);
     void Delete(Collection* collection, HInstance instance, bool recursive);
+    void MarkTransformDirty(HInstance instance);
     void UpdateTransforms(Collection* collection);
     void UpdateTransformsForInstance(Collection* collection, Instance* instance);
+    bool IsGameObjectTransformProperty(dmhash_t component_id, dmhash_t property_id);
     void DeleteCollection(Collection* collection);
     bool IsCollectionInitialized(Collection* collection);
     Result AttachCollection(Collection* collection, const char* name, dmResource::HFactory factory, HRegister regist, HCollection hcollection);

--- a/engine/gameobject/src/gameobject/test/anim/test_gameobject_anim.cpp
+++ b/engine/gameobject/src/gameobject/test/anim/test_gameobject_anim.cpp
@@ -120,8 +120,10 @@ TEST_F(AnimTest, AnimateAndStop)
     ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, result);
     ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
     ASSERT_NEAR(2.5f, X(go), EPSILON);
+    ASSERT_NEAR(2.5f, dmGameObject::GetWorldPosition(go).getX(), EPSILON);
     ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
     ASSERT_NEAR(5.0f, X(go), EPSILON);
+    ASSERT_NEAR(5.0f, dmGameObject::GetWorldPosition(go).getX(), EPSILON);
     ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
     ASSERT_NEAR(7.5f, X(go), EPSILON);
     ASSERT_EQ(0u, this->m_FinishCount);

--- a/engine/gameobject/src/gameobject/test/hierarchy/test_gameobject_hierarchy.cpp
+++ b/engine/gameobject/src/gameobject/test/hierarchy/test_gameobject_hierarchy.cpp
@@ -87,6 +87,44 @@ public:
     dmHashTable64<void*> m_Contexts;
 };
 
+static void SetCachedWorldPosition(dmGameObject::HCollection collection, dmGameObject::HInstance instance, const Point3& position)
+{
+    Matrix4 world = Matrix4::identity();
+    world.setCol3(Vector4(position.getX(), position.getY(), position.getZ(), 1.0f));
+    collection->m_Collection->m_WorldTransforms[instance->m_Index] = world;
+}
+
+static void AssertWorldPosition(dmGameObject::HInstance instance, const Point3& expected)
+{
+    Point3 actual = dmGameObject::GetWorldPosition(instance);
+    ASSERT_NEAR(expected.getX(), actual.getX(), EPSILON);
+    ASSERT_NEAR(expected.getY(), actual.getY(), EPSILON);
+    ASSERT_NEAR(expected.getZ(), actual.getZ(), EPSILON);
+}
+
+static void AssertPosition(dmGameObject::HInstance instance, const Point3& expected)
+{
+    Point3 actual = dmGameObject::GetPosition(instance);
+    ASSERT_NEAR(expected.getX(), actual.getX(), EPSILON);
+    ASSERT_NEAR(expected.getY(), actual.getY(), EPSILON);
+    ASSERT_NEAR(expected.getZ(), actual.getZ(), EPSILON);
+}
+
+static void PostSetParentMessage(dmGameObject::HCollection collection, dmGameObject::HInstance child, dmGameObject::HInstance parent, bool keep_world_transform)
+{
+    dmGameObjectDDF::SetParent ddf = {};
+    ddf.m_ParentId = parent ? dmGameObject::GetIdentifier(parent) : 0;
+    ddf.m_KeepWorldTransform = keep_world_transform ? 1 : 0;
+
+    dmMessage::URL receiver = {};
+    receiver.m_Socket = dmGameObject::GetMessageSocket(collection);
+    receiver.m_Path = dmGameObject::GetIdentifier(child);
+    receiver.m_Fragment = 0;
+
+    ASSERT_EQ(dmMessage::RESULT_OK, dmMessage::Post(0x0, &receiver, dmGameObjectDDF::SetParent::m_DDFDescriptor->m_NameHash,
+        0, (uintptr_t)dmGameObjectDDF::SetParent::m_DDFDescriptor, &ddf, sizeof(dmGameObjectDDF::SetParent), 0));
+}
+
 TEST_F(HierarchyTest, TestHierarchy1)
 {
     for (int i = 0; i < 2; ++i)
@@ -351,7 +389,6 @@ TEST_F(HierarchyTest, TestUpdateTransformsForInstance)
     ASSERT_TRUE(ret);
 
     // Capture original world positions
-    Point3 child_world_before       = dmGameObject::GetWorldPosition(child);
     Point3 grandchild_world_before  = dmGameObject::GetWorldPosition(grandchild);
 
     // Modify parent local transform mid-frame
@@ -385,6 +422,171 @@ TEST_F(HierarchyTest, TestUpdateTransformsForInstance)
     dmGameObject::Delete(m_Collection, parent, true);
     ret = dmGameObject::PostUpdate(m_Collection);
     ASSERT_TRUE(ret);
+}
+
+TEST_F(HierarchyTest, TransformChangesMarkCollectionDirty)
+{
+    dmGameObject::HInstance parent = dmGameObject::New(m_Collection, "/go.goc");
+    dmGameObject::HInstance child = dmGameObject::New(m_Collection, "/go.goc");
+
+    ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+    ASSERT_FALSE(m_Collection->m_Collection->m_DirtyTransforms);
+
+    dmGameObject::SetPosition(parent, Point3(1, 2, 3));
+    ASSERT_TRUE(m_Collection->m_Collection->m_DirtyTransforms);
+    dmGameObject::UpdateTransforms(m_Collection->m_Collection);
+    ASSERT_FALSE(m_Collection->m_Collection->m_DirtyTransforms);
+
+    dmGameObject::SetRotation(parent, Quat::rotationZ(0.5f));
+    ASSERT_TRUE(m_Collection->m_Collection->m_DirtyTransforms);
+    dmGameObject::UpdateTransforms(m_Collection->m_Collection);
+    ASSERT_FALSE(m_Collection->m_Collection->m_DirtyTransforms);
+
+    dmGameObject::SetScale(parent, Vector3(2, 3, 4));
+    ASSERT_TRUE(m_Collection->m_Collection->m_DirtyTransforms);
+    dmGameObject::UpdateTransforms(m_Collection->m_Collection);
+    ASSERT_FALSE(m_Collection->m_Collection->m_DirtyTransforms);
+
+    ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::SetPropertyFromVector3(parent, 0, dmHashString64("position"), Vector3(4, 5, 6)));
+    ASSERT_TRUE(m_Collection->m_Collection->m_DirtyTransforms);
+    dmGameObject::UpdateTransforms(m_Collection->m_Collection);
+    ASSERT_FALSE(m_Collection->m_Collection->m_DirtyTransforms);
+
+    ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::SetPropertyFromQuat(parent, 0, dmHashString64("rotation"), Quat::rotationZ(0.25f)));
+    ASSERT_TRUE(m_Collection->m_Collection->m_DirtyTransforms);
+    dmGameObject::UpdateTransforms(m_Collection->m_Collection);
+    ASSERT_FALSE(m_Collection->m_Collection->m_DirtyTransforms);
+
+    ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::SetPropertyFromVector3(parent, 0, dmHashString64("euler"), Vector3(0, 0, 45)));
+    ASSERT_TRUE(m_Collection->m_Collection->m_DirtyTransforms);
+    dmGameObject::UpdateTransforms(m_Collection->m_Collection);
+    ASSERT_FALSE(m_Collection->m_Collection->m_DirtyTransforms);
+
+    ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::SetPropertyFromVector3(parent, 0, dmHashString64("scale"), Vector3(2, 2, 2)));
+    ASSERT_TRUE(m_Collection->m_Collection->m_DirtyTransforms);
+    dmGameObject::UpdateTransforms(m_Collection->m_Collection);
+    ASSERT_FALSE(m_Collection->m_Collection->m_DirtyTransforms);
+
+    ASSERT_EQ(dmGameObject::RESULT_OK, dmGameObject::SetParent(child, parent));
+    ASSERT_TRUE(m_Collection->m_Collection->m_DirtyTransforms);
+    dmGameObject::UpdateTransforms(m_Collection->m_Collection);
+    ASSERT_FALSE(m_Collection->m_Collection->m_DirtyTransforms);
+
+    dmGameObject::SetBone(child, true);
+    dmTransform::Transform component_transform;
+    component_transform.SetIdentity();
+    dmTransform::Transform bone_transform;
+    bone_transform.SetIdentity();
+    bone_transform.SetTranslation(Vector3(7, 8, 9));
+    ASSERT_EQ(1u, dmGameObject::SetBoneTransforms(child, component_transform, &bone_transform, 1));
+    ASSERT_TRUE(m_Collection->m_Collection->m_DirtyTransforms);
+
+    dmGameObject::Delete(m_Collection, parent, true);
+    ASSERT_TRUE(dmGameObject::PostUpdate(m_Collection));
+}
+
+TEST_F(HierarchyTest, DeleteWithReparentMarksCollectionDirty)
+{
+    dmGameObject::HInstance parent = dmGameObject::New(m_Collection, "/go.goc");
+    dmGameObject::HInstance child = dmGameObject::New(m_Collection, "/go.goc");
+    dmGameObject::SetParent(child, parent);
+
+    ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+    ASSERT_FALSE(m_Collection->m_Collection->m_DirtyTransforms);
+
+    dmGameObject::Delete(m_Collection, parent, false);
+    ASSERT_TRUE(dmGameObject::PostUpdate(m_Collection));
+    ASSERT_TRUE(m_Collection->m_Collection->m_DirtyTransforms);
+    ASSERT_EQ((dmGameObject::HInstance) 0, dmGameObject::GetParent(child));
+
+    dmGameObject::Delete(m_Collection, child, false);
+}
+
+TEST_F(HierarchyTest, DeleteWithReparentUpdatesPromotedSubtree)
+{
+    dmGameObject::HInstance parent = dmGameObject::New(m_Collection, "/go.goc");
+    dmGameObject::HInstance child = dmGameObject::New(m_Collection, "/go.goc");
+    dmGameObject::HInstance grandchild = dmGameObject::New(m_Collection, "/go.goc");
+
+    dmGameObject::SetPosition(parent, Point3(10, 0, 0));
+    dmGameObject::SetPosition(child, Point3(1, 0, 0));
+    dmGameObject::SetPosition(grandchild, Point3(2, 0, 0));
+    ASSERT_EQ(dmGameObject::RESULT_OK, dmGameObject::SetParent(child, parent));
+    ASSERT_EQ(dmGameObject::RESULT_OK, dmGameObject::SetParent(grandchild, child));
+
+    ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+    SetCachedWorldPosition(m_Collection, child, Point3(100, 100, 100));
+    SetCachedWorldPosition(m_Collection, grandchild, Point3(200, 200, 200));
+
+    dmGameObject::Delete(m_Collection, parent, false);
+    ASSERT_TRUE(dmGameObject::PostUpdate(m_Collection));
+    ASSERT_TRUE(m_Collection->m_Collection->m_DirtyTransforms);
+    ASSERT_EQ((dmGameObject::HInstance) 0, dmGameObject::GetParent(child));
+
+    dmGameObject::UpdateTransforms(m_Collection->m_Collection);
+    AssertWorldPosition(child, Point3(1, 0, 0));
+    AssertWorldPosition(grandchild, Point3(3, 0, 0));
+
+    dmGameObject::Delete(m_Collection, child, true);
+}
+
+TEST_F(HierarchyTest, DirtyCollectionRefreshesAllWorldTransforms)
+{
+    dmGameObject::HInstance parent = dmGameObject::New(m_Collection, "/go.goc");
+    dmGameObject::HInstance child = dmGameObject::New(m_Collection, "/go.goc");
+
+    dmGameObject::SetPosition(parent, Point3(10, 0, 0));
+    dmGameObject::SetPosition(child, Point3(1, 0, 0));
+    ASSERT_EQ(dmGameObject::RESULT_OK, dmGameObject::SetParent(child, parent));
+
+    ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+
+    SetCachedWorldPosition(m_Collection, parent, Point3(100, 100, 100));
+    SetCachedWorldPosition(m_Collection, child, Point3(200, 200, 200));
+    m_Collection->m_Collection->m_DirtyTransforms = true;
+
+    dmGameObject::UpdateTransforms(m_Collection->m_Collection);
+    AssertWorldPosition(parent, Point3(10, 0, 0));
+    AssertWorldPosition(child, Point3(11, 0, 0));
+}
+
+TEST_F(HierarchyTest, FailedSetParentMessageDoesNotModifyTransform)
+{
+    dmGameObject::HInstance parent = dmGameObject::New(m_Collection, "/go.goc");
+    dmGameObject::HInstance child = dmGameObject::New(m_Collection, "/go.goc");
+    ASSERT_EQ(dmGameObject::RESULT_OK, dmGameObject::SetIdentifier(m_Collection, parent, "parent"));
+    ASSERT_EQ(dmGameObject::RESULT_OK, dmGameObject::SetIdentifier(m_Collection, child, "child"));
+
+    dmGameObject::SetPosition(parent, Point3(10, 0, 0));
+    dmGameObject::SetPosition(child, Point3(1, 0, 0));
+    ASSERT_EQ(dmGameObject::RESULT_OK, dmGameObject::SetParent(child, parent));
+
+    ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+    ASSERT_FALSE(m_Collection->m_Collection->m_DirtyTransforms);
+
+    Point3 parent_position_before = dmGameObject::GetPosition(parent);
+    Point3 parent_world_before = dmGameObject::GetWorldPosition(parent);
+    Point3 child_world_before = dmGameObject::GetWorldPosition(child);
+
+    PostSetParentMessage(m_Collection, parent, child, false);
+    ASSERT_TRUE(dmGameObject::PostUpdate(m_Collection));
+    ASSERT_EQ((dmGameObject::HInstance) 0, dmGameObject::GetParent(parent));
+    ASSERT_EQ(parent, dmGameObject::GetParent(child));
+    AssertPosition(parent, parent_position_before);
+    AssertWorldPosition(parent, parent_world_before);
+    AssertWorldPosition(child, child_world_before);
+    ASSERT_FALSE(m_Collection->m_Collection->m_DirtyTransforms);
+
+    PostSetParentMessage(m_Collection, parent, child, true);
+    ASSERT_TRUE(dmGameObject::PostUpdate(m_Collection));
+    ASSERT_EQ((dmGameObject::HInstance) 0, dmGameObject::GetParent(parent));
+    ASSERT_EQ(parent, dmGameObject::GetParent(child));
+    AssertPosition(parent, parent_position_before);
+    AssertWorldPosition(parent, parent_world_before);
+    AssertWorldPosition(child, child_world_before);
+    ASSERT_FALSE(m_Collection->m_Collection->m_DirtyTransforms);
+
+    dmGameObject::Delete(m_Collection, parent, true);
 }
 
 TEST_F(HierarchyTest, TestHierarchy4)

--- a/engine/gameobject/src/gameobject/test/hierarchy/test_gameobject_hierarchy.cpp
+++ b/engine/gameobject/src/gameobject/test/hierarchy/test_gameobject_hierarchy.cpp
@@ -87,11 +87,9 @@ public:
     dmHashTable64<void*> m_Contexts;
 };
 
-static void SetCachedWorldPosition(dmGameObject::HCollection collection, dmGameObject::HInstance instance, const Point3& position)
+static void SetCachedWorldTransform(dmGameObject::HCollection collection, dmGameObject::HInstance instance, const Matrix4& transform)
 {
-    Matrix4 world = Matrix4::identity();
-    world.setCol3(Vector4(position.getX(), position.getY(), position.getZ(), 1.0f));
-    collection->m_Collection->m_WorldTransforms[instance->m_Index] = world;
+    collection->m_Collection->m_WorldTransforms[instance->m_Index] = transform;
 }
 
 static void AssertWorldPosition(dmGameObject::HInstance instance, const Point3& expected)
@@ -515,8 +513,8 @@ TEST_F(HierarchyTest, DeleteWithReparentUpdatesPromotedSubtree)
     ASSERT_EQ(dmGameObject::RESULT_OK, dmGameObject::SetParent(grandchild, child));
 
     ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
-    SetCachedWorldPosition(m_Collection, child, Point3(100, 100, 100));
-    SetCachedWorldPosition(m_Collection, grandchild, Point3(200, 200, 200));
+    SetCachedWorldTransform(m_Collection, child, Matrix4::translation(Vector3(100, 100, 100)));
+    SetCachedWorldTransform(m_Collection, grandchild, Matrix4::translation(Vector3(200, 200, 200)));
 
     dmGameObject::Delete(m_Collection, parent, false);
     ASSERT_TRUE(dmGameObject::PostUpdate(m_Collection));
@@ -541,8 +539,8 @@ TEST_F(HierarchyTest, DirtyCollectionRefreshesAllWorldTransforms)
 
     ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
 
-    SetCachedWorldPosition(m_Collection, parent, Point3(100, 100, 100));
-    SetCachedWorldPosition(m_Collection, child, Point3(200, 200, 200));
+    SetCachedWorldTransform(m_Collection, parent, Matrix4::translation(Vector3(100, 100, 100)));
+    SetCachedWorldTransform(m_Collection, child, Matrix4::translation(Vector3(200, 200, 200)));
     m_Collection->m_Collection->m_DirtyTransforms = true;
 
     dmGameObject::UpdateTransforms(m_Collection->m_Collection);

--- a/engine/gameobject/src/gameobject/test/hierarchy/test_gameobject_hierarchy.cpp
+++ b/engine/gameobject/src/gameobject/test/hierarchy/test_gameobject_hierarchy.cpp
@@ -541,7 +541,7 @@ TEST_F(HierarchyTest, DirtyCollectionRefreshesAllWorldTransforms)
 
     SetCachedWorldTransform(m_Collection, parent, Matrix4::translation(Vector3(100, 100, 100)));
     SetCachedWorldTransform(m_Collection, child, Matrix4::translation(Vector3(200, 200, 200)));
-    m_Collection->m_Collection->m_DirtyTransforms = true;
+    m_Collection->m_Collection->m_DirtyTransforms = 1;
 
     dmGameObject::UpdateTransforms(m_Collection->m_Collection);
     AssertWorldPosition(parent, Point3(10, 0, 0));

--- a/engine/gameobject/src/gameobject/test/script/message_transform_cache_change.go_pb
+++ b/engine/gameobject/src/gameobject/test/script/message_transform_cache_change.go_pb
@@ -1,0 +1,4 @@
+components {
+  id: "script"
+  component: "/message_transform_cache_change.scriptc"
+}

--- a/engine/gameobject/src/gameobject/test/script/message_transform_cache_change.script
+++ b/engine/gameobject/src/gameobject/test/script/message_transform_cache_change.script
@@ -1,0 +1,17 @@
+-- Copyright 2020-2026 The Defold Foundation
+-- Copyright 2014-2020 King
+-- Copyright 2009-2014 Ragnar Svensson, Christian Murray
+-- Licensed under the Defold License version 1.0 (the "License"); you may not use
+-- this file except in compliance with the License.
+--
+-- You may obtain a copy of the License, together with FAQs at
+-- https://www.defold.com/license
+--
+-- Unless required by applicable law or agreed to in writing, software distributed
+-- under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+-- CONDITIONS OF ANY KIND, either express or implied. See the License for the
+-- specific language governing permissions and limitations under the License.
+
+function on_message(self, message_id, message, sender)
+    go.set_position(vmath.vector3(1, 2, 3))
+end

--- a/engine/gameobject/src/gameobject/test/script/message_transform_cache_no_change.go_pb
+++ b/engine/gameobject/src/gameobject/test/script/message_transform_cache_no_change.go_pb
@@ -1,0 +1,4 @@
+components {
+  id: "script"
+  component: "/message_transform_cache_no_change.scriptc"
+}

--- a/engine/gameobject/src/gameobject/test/script/message_transform_cache_no_change.script
+++ b/engine/gameobject/src/gameobject/test/script/message_transform_cache_no_change.script
@@ -1,0 +1,17 @@
+-- Copyright 2020-2026 The Defold Foundation
+-- Copyright 2014-2020 King
+-- Copyright 2009-2014 Ragnar Svensson, Christian Murray
+-- Licensed under the Defold License version 1.0 (the "License"); you may not use
+-- this file except in compliance with the License.
+--
+-- You may obtain a copy of the License, together with FAQs at
+-- https://www.defold.com/license
+--
+-- Unless required by applicable law or agreed to in writing, software distributed
+-- under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+-- CONDITIONS OF ANY KIND, either express or implied. See the License for the
+-- specific language governing permissions and limitations under the License.
+
+function on_message(self, message_id, message, sender)
+    self.counter = (self.counter or 0) + 1
+end

--- a/engine/gameobject/src/gameobject/test/script/test_gameobject_script.cpp
+++ b/engine/gameobject/src/gameobject/test/script/test_gameobject_script.cpp
@@ -228,6 +228,189 @@ static void CreateScriptFile(const char* file_name, const char* contents)
     assert(r == dmDDF::RESULT_OK);
 }
 
+static void CreateGoFile(const char* file_name, const char* script_resource_name)
+{
+    dmGameObjectDDF::PrototypeDesc prototype;
+    memset(&prototype, 0, sizeof(prototype));
+    prototype.m_Components.m_Count = 1;
+    dmGameObjectDDF::ComponentDesc component_desc;
+    memset(&component_desc, 0, sizeof(component_desc));
+    component_desc.m_Id = "script";
+    component_desc.m_Component = script_resource_name;
+    prototype.m_Components.m_Data = &component_desc;
+
+    dmDDF::Result r = dmDDF::SaveMessageToFile(&prototype, dmGameObjectDDF::PrototypeDesc::m_DDFDescriptor, file_name);
+    assert(r == dmDDF::RESULT_OK);
+}
+
+TEST_F(ScriptTest, UpdateWithoutTransformChangeDoesNotRefreshWorldTransform)
+{
+    const char* script_resource_name = "/__no_transform_update__.scriptc";
+    char script_file_name[512];
+    dmTestUtil::MakeHostPathf(script_file_name, sizeof(script_file_name), "%s%s", m_Path, script_resource_name);
+
+    const char* go_resource_name = "/__no_transform_update__.goc";
+    char go_file_name[512];
+    dmTestUtil::MakeHostPathf(go_file_name, sizeof(go_file_name), "%s%s", m_Path, go_resource_name);
+
+    CreateScriptFile(script_file_name,
+               "function update(self)\n"
+               "    self.counter = (self.counter or 0) + 1\n"
+               "end\n");
+    CreateGoFile(go_file_name, script_resource_name);
+
+    dmGameObject::HInstance go = dmGameObject::New(m_Collection, go_resource_name);
+    ASSERT_NE((dmGameObject::HInstance) 0, go);
+
+    ASSERT_TRUE(dmGameObject::Init(m_Collection));
+    ASSERT_FALSE(m_Collection->m_Collection->m_DirtyTransforms);
+
+    Matrix4 sentinel = Matrix4::identity();
+    sentinel.setCol3(Vector4(42, 43, 44, 1));
+    m_Collection->m_Collection->m_WorldTransforms[go->m_Index] = sentinel;
+
+    ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+
+    Point3 world_position = dmGameObject::GetWorldPosition(go);
+    ASSERT_EQ(42, world_position.getX());
+    ASSERT_EQ(43, world_position.getY());
+    ASSERT_EQ(44, world_position.getZ());
+
+    ASSERT_TRUE(dmGameObject::Final(m_Collection));
+    dmGameObject::Delete(m_Collection, go, false);
+    dmSys::Unlink(script_file_name);
+    dmSys::Unlink(go_file_name);
+}
+
+TEST_F(ScriptTest, UpdateWithTransformChangeRefreshesWorldTransform)
+{
+    const char* script_resource_name = "/__transform_update__.scriptc";
+    char script_file_name[512];
+    dmTestUtil::MakeHostPathf(script_file_name, sizeof(script_file_name), "%s%s", m_Path, script_resource_name);
+
+    const char* go_resource_name = "/__transform_update__.goc";
+    char go_file_name[512];
+    dmTestUtil::MakeHostPathf(go_file_name, sizeof(go_file_name), "%s%s", m_Path, go_resource_name);
+
+    CreateScriptFile(script_file_name,
+               "function update(self)\n"
+               "    go.set_position(vmath.vector3(1, 2, 3))\n"
+               "end\n");
+    CreateGoFile(go_file_name, script_resource_name);
+
+    dmGameObject::HInstance go = dmGameObject::New(m_Collection, go_resource_name);
+    ASSERT_NE((dmGameObject::HInstance) 0, go);
+
+    ASSERT_TRUE(dmGameObject::Init(m_Collection));
+
+    Matrix4 sentinel = Matrix4::identity();
+    sentinel.setCol3(Vector4(42, 43, 44, 1));
+    m_Collection->m_Collection->m_WorldTransforms[go->m_Index] = sentinel;
+
+    ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+
+    Point3 world_position = dmGameObject::GetWorldPosition(go);
+    ASSERT_EQ(1, world_position.getX());
+    ASSERT_EQ(2, world_position.getY());
+    ASSERT_EQ(3, world_position.getZ());
+
+    ASSERT_TRUE(dmGameObject::Final(m_Collection));
+    dmGameObject::Delete(m_Collection, go, false);
+    dmSys::Unlink(script_file_name);
+    dmSys::Unlink(go_file_name);
+}
+
+TEST_F(ScriptTest, MessageWithoutTransformChangeDoesNotRefreshWorldTransform)
+{
+    const char* script_resource_name = "/__no_transform_message__.scriptc";
+    char script_file_name[512];
+    dmTestUtil::MakeHostPathf(script_file_name, sizeof(script_file_name), "%s%s", m_Path, script_resource_name);
+
+    const char* go_resource_name = "/__no_transform_message__.goc";
+    char go_file_name[512];
+    dmTestUtil::MakeHostPathf(go_file_name, sizeof(go_file_name), "%s%s", m_Path, go_resource_name);
+
+    CreateScriptFile(script_file_name,
+               "function on_message(self, message_id, message, sender)\n"
+               "    self.counter = (self.counter or 0) + 1\n"
+               "end\n");
+    CreateGoFile(go_file_name, script_resource_name);
+
+    dmGameObject::HInstance go = dmGameObject::New(m_Collection, go_resource_name);
+    ASSERT_NE((dmGameObject::HInstance) 0, go);
+    ASSERT_EQ(dmGameObject::RESULT_OK, dmGameObject::SetIdentifier(m_Collection, go, "message_go"));
+
+    ASSERT_TRUE(dmGameObject::Init(m_Collection));
+    ASSERT_FALSE(m_Collection->m_Collection->m_DirtyTransforms);
+
+    Matrix4 sentinel = Matrix4::identity();
+    sentinel.setCol3(Vector4(42, 43, 44, 1));
+    m_Collection->m_Collection->m_WorldTransforms[go->m_Index] = sentinel;
+
+    dmMessage::URL receiver;
+    receiver.m_Socket = dmGameObject::GetMessageSocket(m_Collection);
+    receiver.m_Path = dmGameObject::GetIdentifier(go);
+    receiver.m_Fragment = dmHashString64("script");
+    ASSERT_EQ(dmMessage::RESULT_OK, dmMessage::Post(0x0, &receiver, dmHashString64("message"), 0, 0, 0x0, 0, 0));
+
+    ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+
+    Point3 world_position = dmGameObject::GetWorldPosition(go);
+    ASSERT_EQ(42, world_position.getX());
+    ASSERT_EQ(43, world_position.getY());
+    ASSERT_EQ(44, world_position.getZ());
+
+    ASSERT_TRUE(dmGameObject::Final(m_Collection));
+    dmGameObject::Delete(m_Collection, go, false);
+    dmSys::Unlink(script_file_name);
+    dmSys::Unlink(go_file_name);
+}
+
+TEST_F(ScriptTest, MessageWithTransformChangeRefreshesWorldTransform)
+{
+    const char* script_resource_name = "/__transform_message__.scriptc";
+    char script_file_name[512];
+    dmTestUtil::MakeHostPathf(script_file_name, sizeof(script_file_name), "%s%s", m_Path, script_resource_name);
+
+    const char* go_resource_name = "/__transform_message__.goc";
+    char go_file_name[512];
+    dmTestUtil::MakeHostPathf(go_file_name, sizeof(go_file_name), "%s%s", m_Path, go_resource_name);
+
+    CreateScriptFile(script_file_name,
+               "function on_message(self, message_id, message, sender)\n"
+               "    go.set_position(vmath.vector3(1, 2, 3))\n"
+               "end\n");
+    CreateGoFile(go_file_name, script_resource_name);
+
+    dmGameObject::HInstance go = dmGameObject::New(m_Collection, go_resource_name);
+    ASSERT_NE((dmGameObject::HInstance) 0, go);
+    ASSERT_EQ(dmGameObject::RESULT_OK, dmGameObject::SetIdentifier(m_Collection, go, "message_transform_go"));
+
+    ASSERT_TRUE(dmGameObject::Init(m_Collection));
+
+    Matrix4 sentinel = Matrix4::identity();
+    sentinel.setCol3(Vector4(42, 43, 44, 1));
+    m_Collection->m_Collection->m_WorldTransforms[go->m_Index] = sentinel;
+
+    dmMessage::URL receiver;
+    receiver.m_Socket = dmGameObject::GetMessageSocket(m_Collection);
+    receiver.m_Path = dmGameObject::GetIdentifier(go);
+    receiver.m_Fragment = dmHashString64("script");
+    ASSERT_EQ(dmMessage::RESULT_OK, dmMessage::Post(0x0, &receiver, dmHashString64("message"), 0, 0, 0x0, 0, 0));
+
+    ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+
+    Point3 world_position = dmGameObject::GetWorldPosition(go);
+    ASSERT_EQ(1, world_position.getX());
+    ASSERT_EQ(2, world_position.getY());
+    ASSERT_EQ(3, world_position.getZ());
+
+    ASSERT_TRUE(dmGameObject::Final(m_Collection));
+    dmGameObject::Delete(m_Collection, go, false);
+    dmSys::Unlink(script_file_name);
+    dmSys::Unlink(go_file_name);
+}
+
 TEST_F(ScriptTest, TestReload)
 {
     const char* script_resource_name = "/__test__.scriptc";

--- a/engine/gameobject/src/gameobject/test/script/test_gameobject_script.cpp
+++ b/engine/gameobject/src/gameobject/test/script/test_gameobject_script.cpp
@@ -228,36 +228,9 @@ static void CreateScriptFile(const char* file_name, const char* contents)
     assert(r == dmDDF::RESULT_OK);
 }
 
-static void CreateGoFile(const char* file_name, const char* script_resource_name)
-{
-    dmGameObjectDDF::PrototypeDesc prototype;
-    memset(&prototype, 0, sizeof(prototype));
-    prototype.m_Components.m_Count = 1;
-    dmGameObjectDDF::ComponentDesc component_desc;
-    memset(&component_desc, 0, sizeof(component_desc));
-    component_desc.m_Id = "script";
-    component_desc.m_Component = script_resource_name;
-    prototype.m_Components.m_Data = &component_desc;
-
-    dmDDF::Result r = dmDDF::SaveMessageToFile(&prototype, dmGameObjectDDF::PrototypeDesc::m_DDFDescriptor, file_name);
-    assert(r == dmDDF::RESULT_OK);
-}
-
 TEST_F(ScriptTest, UpdateWithoutTransformChangeDoesNotRefreshWorldTransform)
 {
-    const char* script_resource_name = "/__no_transform_update__.scriptc";
-    char script_file_name[512];
-    dmTestUtil::MakeHostPathf(script_file_name, sizeof(script_file_name), "%s%s", m_Path, script_resource_name);
-
-    const char* go_resource_name = "/__no_transform_update__.goc";
-    char go_file_name[512];
-    dmTestUtil::MakeHostPathf(go_file_name, sizeof(go_file_name), "%s%s", m_Path, go_resource_name);
-
-    CreateScriptFile(script_file_name,
-               "function update(self)\n"
-               "    self.counter = (self.counter or 0) + 1\n"
-               "end\n");
-    CreateGoFile(go_file_name, script_resource_name);
+    const char* go_resource_name = "/update_transform_cache_no_change.goc";
 
     dmGameObject::HInstance go = dmGameObject::New(m_Collection, go_resource_name);
     ASSERT_NE((dmGameObject::HInstance) 0, go);
@@ -265,9 +238,7 @@ TEST_F(ScriptTest, UpdateWithoutTransformChangeDoesNotRefreshWorldTransform)
     ASSERT_TRUE(dmGameObject::Init(m_Collection));
     ASSERT_FALSE(m_Collection->m_Collection->m_DirtyTransforms);
 
-    Matrix4 sentinel = Matrix4::identity();
-    sentinel.setCol3(Vector4(42, 43, 44, 1));
-    m_Collection->m_Collection->m_WorldTransforms[go->m_Index] = sentinel;
+    m_Collection->m_Collection->m_WorldTransforms[go->m_Index] = Matrix4::translation(Vector3(42, 43, 44));
 
     ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
 
@@ -278,34 +249,18 @@ TEST_F(ScriptTest, UpdateWithoutTransformChangeDoesNotRefreshWorldTransform)
 
     ASSERT_TRUE(dmGameObject::Final(m_Collection));
     dmGameObject::Delete(m_Collection, go, false);
-    dmSys::Unlink(script_file_name);
-    dmSys::Unlink(go_file_name);
 }
 
 TEST_F(ScriptTest, UpdateWithTransformChangeRefreshesWorldTransform)
 {
-    const char* script_resource_name = "/__transform_update__.scriptc";
-    char script_file_name[512];
-    dmTestUtil::MakeHostPathf(script_file_name, sizeof(script_file_name), "%s%s", m_Path, script_resource_name);
-
-    const char* go_resource_name = "/__transform_update__.goc";
-    char go_file_name[512];
-    dmTestUtil::MakeHostPathf(go_file_name, sizeof(go_file_name), "%s%s", m_Path, go_resource_name);
-
-    CreateScriptFile(script_file_name,
-               "function update(self)\n"
-               "    go.set_position(vmath.vector3(1, 2, 3))\n"
-               "end\n");
-    CreateGoFile(go_file_name, script_resource_name);
+    const char* go_resource_name = "/update_transform_cache_change.goc";
 
     dmGameObject::HInstance go = dmGameObject::New(m_Collection, go_resource_name);
     ASSERT_NE((dmGameObject::HInstance) 0, go);
 
     ASSERT_TRUE(dmGameObject::Init(m_Collection));
 
-    Matrix4 sentinel = Matrix4::identity();
-    sentinel.setCol3(Vector4(42, 43, 44, 1));
-    m_Collection->m_Collection->m_WorldTransforms[go->m_Index] = sentinel;
+    m_Collection->m_Collection->m_WorldTransforms[go->m_Index] = Matrix4::translation(Vector3(42, 43, 44));
 
     ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
 
@@ -316,25 +271,11 @@ TEST_F(ScriptTest, UpdateWithTransformChangeRefreshesWorldTransform)
 
     ASSERT_TRUE(dmGameObject::Final(m_Collection));
     dmGameObject::Delete(m_Collection, go, false);
-    dmSys::Unlink(script_file_name);
-    dmSys::Unlink(go_file_name);
 }
 
 TEST_F(ScriptTest, MessageWithoutTransformChangeDoesNotRefreshWorldTransform)
 {
-    const char* script_resource_name = "/__no_transform_message__.scriptc";
-    char script_file_name[512];
-    dmTestUtil::MakeHostPathf(script_file_name, sizeof(script_file_name), "%s%s", m_Path, script_resource_name);
-
-    const char* go_resource_name = "/__no_transform_message__.goc";
-    char go_file_name[512];
-    dmTestUtil::MakeHostPathf(go_file_name, sizeof(go_file_name), "%s%s", m_Path, go_resource_name);
-
-    CreateScriptFile(script_file_name,
-               "function on_message(self, message_id, message, sender)\n"
-               "    self.counter = (self.counter or 0) + 1\n"
-               "end\n");
-    CreateGoFile(go_file_name, script_resource_name);
+    const char* go_resource_name = "/message_transform_cache_no_change.goc";
 
     dmGameObject::HInstance go = dmGameObject::New(m_Collection, go_resource_name);
     ASSERT_NE((dmGameObject::HInstance) 0, go);
@@ -343,9 +284,7 @@ TEST_F(ScriptTest, MessageWithoutTransformChangeDoesNotRefreshWorldTransform)
     ASSERT_TRUE(dmGameObject::Init(m_Collection));
     ASSERT_FALSE(m_Collection->m_Collection->m_DirtyTransforms);
 
-    Matrix4 sentinel = Matrix4::identity();
-    sentinel.setCol3(Vector4(42, 43, 44, 1));
-    m_Collection->m_Collection->m_WorldTransforms[go->m_Index] = sentinel;
+    m_Collection->m_Collection->m_WorldTransforms[go->m_Index] = Matrix4::translation(Vector3(42, 43, 44));
 
     dmMessage::URL receiver;
     receiver.m_Socket = dmGameObject::GetMessageSocket(m_Collection);
@@ -362,25 +301,11 @@ TEST_F(ScriptTest, MessageWithoutTransformChangeDoesNotRefreshWorldTransform)
 
     ASSERT_TRUE(dmGameObject::Final(m_Collection));
     dmGameObject::Delete(m_Collection, go, false);
-    dmSys::Unlink(script_file_name);
-    dmSys::Unlink(go_file_name);
 }
 
 TEST_F(ScriptTest, MessageWithTransformChangeRefreshesWorldTransform)
 {
-    const char* script_resource_name = "/__transform_message__.scriptc";
-    char script_file_name[512];
-    dmTestUtil::MakeHostPathf(script_file_name, sizeof(script_file_name), "%s%s", m_Path, script_resource_name);
-
-    const char* go_resource_name = "/__transform_message__.goc";
-    char go_file_name[512];
-    dmTestUtil::MakeHostPathf(go_file_name, sizeof(go_file_name), "%s%s", m_Path, go_resource_name);
-
-    CreateScriptFile(script_file_name,
-               "function on_message(self, message_id, message, sender)\n"
-               "    go.set_position(vmath.vector3(1, 2, 3))\n"
-               "end\n");
-    CreateGoFile(go_file_name, script_resource_name);
+    const char* go_resource_name = "/message_transform_cache_change.goc";
 
     dmGameObject::HInstance go = dmGameObject::New(m_Collection, go_resource_name);
     ASSERT_NE((dmGameObject::HInstance) 0, go);
@@ -388,9 +313,7 @@ TEST_F(ScriptTest, MessageWithTransformChangeRefreshesWorldTransform)
 
     ASSERT_TRUE(dmGameObject::Init(m_Collection));
 
-    Matrix4 sentinel = Matrix4::identity();
-    sentinel.setCol3(Vector4(42, 43, 44, 1));
-    m_Collection->m_Collection->m_WorldTransforms[go->m_Index] = sentinel;
+    m_Collection->m_Collection->m_WorldTransforms[go->m_Index] = Matrix4::translation(Vector3(42, 43, 44));
 
     dmMessage::URL receiver;
     receiver.m_Socket = dmGameObject::GetMessageSocket(m_Collection);
@@ -407,8 +330,6 @@ TEST_F(ScriptTest, MessageWithTransformChangeRefreshesWorldTransform)
 
     ASSERT_TRUE(dmGameObject::Final(m_Collection));
     dmGameObject::Delete(m_Collection, go, false);
-    dmSys::Unlink(script_file_name);
-    dmSys::Unlink(go_file_name);
 }
 
 TEST_F(ScriptTest, TestReload)

--- a/engine/gameobject/src/gameobject/test/script/update_transform_cache_change.go_pb
+++ b/engine/gameobject/src/gameobject/test/script/update_transform_cache_change.go_pb
@@ -1,0 +1,4 @@
+components {
+  id: "script"
+  component: "/update_transform_cache_change.scriptc"
+}

--- a/engine/gameobject/src/gameobject/test/script/update_transform_cache_change.script
+++ b/engine/gameobject/src/gameobject/test/script/update_transform_cache_change.script
@@ -1,0 +1,17 @@
+-- Copyright 2020-2026 The Defold Foundation
+-- Copyright 2014-2020 King
+-- Copyright 2009-2014 Ragnar Svensson, Christian Murray
+-- Licensed under the Defold License version 1.0 (the "License"); you may not use
+-- this file except in compliance with the License.
+--
+-- You may obtain a copy of the License, together with FAQs at
+-- https://www.defold.com/license
+--
+-- Unless required by applicable law or agreed to in writing, software distributed
+-- under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+-- CONDITIONS OF ANY KIND, either express or implied. See the License for the
+-- specific language governing permissions and limitations under the License.
+
+function update(self)
+    go.set_position(vmath.vector3(1, 2, 3))
+end

--- a/engine/gameobject/src/gameobject/test/script/update_transform_cache_no_change.go_pb
+++ b/engine/gameobject/src/gameobject/test/script/update_transform_cache_no_change.go_pb
@@ -1,0 +1,4 @@
+components {
+  id: "script"
+  component: "/update_transform_cache_no_change.scriptc"
+}

--- a/engine/gameobject/src/gameobject/test/script/update_transform_cache_no_change.script
+++ b/engine/gameobject/src/gameobject/test/script/update_transform_cache_no_change.script
@@ -1,0 +1,17 @@
+-- Copyright 2020-2026 The Defold Foundation
+-- Copyright 2014-2020 King
+-- Copyright 2009-2014 Ragnar Svensson, Christian Murray
+-- Licensed under the Defold License version 1.0 (the "License"); you may not use
+-- this file except in compliance with the License.
+--
+-- You may obtain a copy of the License, together with FAQs at
+-- https://www.defold.com/license
+--
+-- Unless required by applicable law or agreed to in writing, software distributed
+-- under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+-- CONDITIONS OF ANY KIND, either express or implied. See the License for the
+-- specific language governing permissions and limitations under the License.
+
+function update(self)
+    self.counter = (self.counter or 0) + 1
+end


### PR DESCRIPTION
Improve game object transform dirty tracking.

Previously script/message updates conservatively marked collection transforms dirty every frame. This changes transform invalidation to happen only when game object transform state actually changes, including direct setters, property writes, animations, parenting changes, bone transforms, and delete/reparent paths.

### Technical changes

1. I'm testing inexample which creates 65530 objects splited into trees by 5 objects.
2. Update sends a message
3. This message just prints in `on_message`
4. As result this creates up to 4 `UpdateTransforms` which take about 6.5ms on M1 Max
<img width="2944" height="2166" alt="CleanShot 2026-05-02 at 22 57 40@2x" src="https://github.com/user-attachments/assets/750efab4-886e-47bb-9273-98e6ae6c791a" />

After optimisation the same exact example shows only one `UpdateTransforms` call which takes  1.5ms
<img width="2654" height="2208" alt="CleanShot 2026-05-02 at 23 01 53@2x" src="https://github.com/user-attachments/assets/dcfa162a-40c2-434e-b42f-383bec401be9" />

Example: 
[PerfTestForTransforms.zip](https://github.com/user-attachments/files/27308472/PerfTestForTransforms.zip)
