### PR TITLE
Avoid using `std::sort` template in non-performance-critical areas to reduce build size

### DIFF
--- a/engine/gamesys/src/dmsdk/gamesys/resources/res_model.h
+++ b/engine/gamesys/src/dmsdk/gamesys/resources/res_model.h
@@ -81,6 +81,7 @@ namespace dmGameSystem
         uint32_t                     m_AttributeCount;
         MaterialTextureInfo*         m_Textures;
         uint32_t                     m_TexturesCount;
+        int32_t                      m_SortOrder; // MeshSet material index used for resource load sorting
     };
 
     struct ModelResource

--- a/engine/gamesys/src/gamesys/resources/res_model.cpp
+++ b/engine/gamesys/src/gamesys/resources/res_model.cpp
@@ -31,43 +31,48 @@
 #include <render/render.h>
 #include <dmsdk/dlib/transform.h>
 #include <rig/rig.h>
-#include <algorithm> // std::sort
+#include <stdlib.h> // qsort
 
 namespace dmGameSystem
 {
     static void ReleaseResources(dmGraphics::HContext context, dmResource::HFactory factory, ModelResource* resource);
 
     // TODO: Sorting+flattening the structure could be done in the pipeline
-    struct MeshSortPred
+    static int MeshSortCompare(const void* a, const void* b)
     {
-        inline bool operator() (const MeshInfo& p1, const MeshInfo& p2)
+        const MeshInfo* mesh_a = (const MeshInfo*) a;
+        const MeshInfo* mesh_b = (const MeshInfo*) b;
+        uint32_t material_a = mesh_a->m_Mesh->m_MaterialIndex;
+        uint32_t material_b = mesh_b->m_Mesh->m_MaterialIndex;
+        if (material_a != material_b)
         {
-            return p1.m_Mesh->m_MaterialIndex < p2.m_Mesh->m_MaterialIndex;
+            return material_a < material_b ? -1 : 1;
         }
-    };
+        return 0;
+    }
 
     // We could sort them in the pipeline, but then we'd have to read the mesh data
     // for compiling each model which we might not want
-    struct MaterialSortPred
+    static int FindMaterialIndex(dmRigDDF::MeshSet* mesh_set, const char* name)
     {
-        dmRigDDF::MeshSet* m_MeshSet;
-        MaterialSortPred(dmRigDDF::MeshSet* mesh_set) : m_MeshSet(mesh_set) {}
-        int FindMaterial(const char* s)
+        for (int i = 0; i < mesh_set->m_Materials.m_Count; ++i)
         {
-            for (int i = 0; i < m_MeshSet->m_Materials.m_Count; ++i)
-            {
-                if (strcmp(s, m_MeshSet->m_Materials.m_Data[i].m_Name) == 0)
-                    return i;
-            }
-            return -1;
+            if (strcmp(name, mesh_set->m_Materials.m_Data[i].m_Name) == 0)
+                return i;
         }
-        inline bool operator() (const MaterialInfo& mat1, const MaterialInfo& mat2)
+        return -1;
+    }
+
+    static int MaterialSortCompare(const void* a, const void* b)
+    {
+        const MaterialInfo* mat_a = (const MaterialInfo*) a;
+        const MaterialInfo* mat_b = (const MaterialInfo*) b;
+        if (mat_a->m_SortOrder != mat_b->m_SortOrder)
         {
-            int i1 = FindMaterial(mat1.m_Name);
-            int i2 = FindMaterial(mat2.m_Name);
-            return i1 < i2;
+            return mat_a->m_SortOrder < mat_b->m_SortOrder ? -1 : 1;
         }
-    };
+        return 0;
+    }
 
     // Flattens the meshes into a list, sorted on material
     static void FlattenMeshes(ModelResource* resource, dmRigDDF::MeshSet* mesh_set)
@@ -96,7 +101,7 @@ namespace dmGameSystem
         }
 
         // Sort the meshes by material
-        std::sort(resource->m_Meshes.Begin(), resource->m_Meshes.End(), MeshSortPred());
+        qsort(resource->m_Meshes.Begin(), resource->m_Meshes.Size(), sizeof(MeshInfo), MeshSortCompare);
     }
 
     static inline uint32_t GetRigModelVertexFormatSize(RigModelVertexFormat format)
@@ -416,25 +421,34 @@ namespace dmGameSystem
         return true; // All materials are currently world space
     }
 
-    // We could sort them in the pipeline, but then we'd have to read the material data
-    // for compiling each model which we might not want
-    struct TextureSortPred
+    static uintptr_t GetTextureSortOrder(dmRender::HMaterial material, const MaterialTextureInfo* texture)
     {
-        dmRender::HMaterial m_Material;
-        TextureSortPred(dmRender::HMaterial material) : m_Material(material) {}
+        return dmRender::GetMaterialConstantLocation(material, texture->m_SamplerNameHash);
+    }
 
-        bool operator ()(MaterialTextureInfo& a, MaterialTextureInfo& b) const
+    static void SortTextures(dmRender::HMaterial material, uint32_t num_textures, MaterialTextureInfo* textures)
+    {
+        for (uint32_t i = 0; i < num_textures; ++i)
         {
-            uintptr_t ia = dmRender::GetMaterialConstantLocation(m_Material, a.m_SamplerNameHash);
-            uintptr_t ib = dmRender::GetMaterialConstantLocation(m_Material, b.m_SamplerNameHash);
-            return ia < ib;
-        }
-    };
+            uint32_t best_index = i;
+            uintptr_t best_order = GetTextureSortOrder(material, &textures[i]);
+            for (uint32_t j = i + 1; j < num_textures; ++j)
+            {
+                uintptr_t order = GetTextureSortOrder(material, &textures[j]);
+                if (order < best_order)
+                {
+                    best_index = j;
+                    best_order = order;
+                }
+            }
 
-    void SortTextures(dmRender::HMaterial material, uint32_t num_textures, MaterialTextureInfo* textures)
-    {
-        TextureSortPred pred(material);
-        std::sort(textures, textures + num_textures, pred);
+            if (best_index != i)
+            {
+                MaterialTextureInfo tmp = textures[i];
+                textures[i] = textures[best_index];
+                textures[best_index] = tmp;
+            }
+        }
     }
 
     dmResource::Result AcquireResources(dmGraphics::HContext context, dmResource::HFactory factory, ModelResource* resource, const char* filename,
@@ -475,6 +489,7 @@ namespace dmGameSystem
             }
 
             info.m_Name = strdup(model_material->m_Name);
+            info.m_SortOrder = FindMaterialIndex(mesh_set, info.m_Name);
 
             info.m_Attributes = model_material->m_Attributes.m_Data;
             info.m_AttributeCount = model_material->m_Attributes.m_Count;
@@ -527,7 +542,7 @@ namespace dmGameSystem
         }
 
         // Sort the materials so that they have the same indices as specified in the MeshSet list of materials
-        std::sort(resource->m_Materials.Begin(), resource->m_Materials.End(), MaterialSortPred(mesh_set));
+        qsort(resource->m_Materials.Begin(), resource->m_Materials.Size(), sizeof(MaterialInfo), MaterialSortCompare);
 
         if (result != dmResource::RESULT_OK)
         {

--- a/engine/resource/src/resource_mounts.cpp
+++ b/engine/resource/src/resource_mounts.cpp
@@ -25,7 +25,7 @@
 #include <dlib/math.h>
 #include <dlib/mutex.h>
 #include <dlib/sys.h>
-#include <algorithm> // std::sort
+#include <stdlib.h> // qsort
 
 namespace dmResourceMounts
 {
@@ -93,17 +93,20 @@ void Destroy(HContext ctx)
     delete ctx;
 }
 
-struct MountSortPred
+static int MountSortCompare(const void* a, const void* b)
 {
-    bool operator ()(const ArchiveMount& a, const ArchiveMount& b) const
+    const ArchiveMount* mount_a = (const ArchiveMount*) a;
+    const ArchiveMount* mount_b = (const ArchiveMount*) b;
+    if (mount_a->m_Priority != mount_b->m_Priority)
     {
-        return a.m_Priority > b.m_Priority; // largest priority first
+        return mount_a->m_Priority > mount_b->m_Priority ? -1 : 1; // largest priority first
     }
-};
+    return 0;
+}
 
 static void SortMounts(dmArray<ArchiveMount>& mounts)
 {
-    std::sort(mounts.Begin(), mounts.End(), MountSortPred());
+    qsort(mounts.Begin(), mounts.Size(), sizeof(ArchiveMount), MountSortCompare);
 }
 
 static void AddMountInternal(HContext ctx, const ArchiveMount& mount)


### PR DESCRIPTION
These four sorting locations are not performance-critical (they run once during load) and handle a small number of items. Replacing them with non-templated sorting reduces the WASM build size by about 31 KB.