### PR TITLE
Fix particlefx crash when playing effects with emitter overrides

### DIFF
--- a/engine/gamesys/src/gamesys/components/comp_particlefx.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_particlefx.cpp
@@ -112,8 +112,23 @@ namespace dmGameSystem
     };
 
     static void DestroyComponent(ParticleFXWorld* world, ParticleFXComponent* component);
-    static void UpdateComponentUserData(ParticleFXWorld* world, ParticleFXComponent* component);
-    static void UpdateAllComponentUserData(ParticleFXWorld* world);
+
+    static void UpdateComponentUserData(ParticleFXWorld* world, ParticleFXComponent* component)
+    {
+        if (component->m_Overrides && component->m_ParticleInstance != dmParticle::INVALID_INSTANCE)
+        {
+            dmParticle::SetInstanceUserData(world->m_ParticleContext, component->m_ParticleInstance, component);
+        }
+    }
+
+    static void UpdateAllComponentUserData(ParticleFXWorld* world)
+    {
+        uint32_t component_count = world->m_Components.Size();
+        for (uint32_t i = 0; i < component_count; ++i)
+        {
+            UpdateComponentUserData(world, &world->m_Components[i]);
+        }
+    }
 
     dmGameObject::CreateResult CompParticleFXNewWorld(const dmGameObject::ComponentNewWorldParams& params)
     {
@@ -716,23 +731,6 @@ namespace dmGameSystem
 
         world->m_EmitterCount += dmParticle::GetEmitterCount(component->m_ParticlePrototype);
         return component->m_ParticleInstance;
-    }
-
-    static void UpdateComponentUserData(ParticleFXWorld* world, ParticleFXComponent* component)
-    {
-        if (component->m_Overrides && component->m_ParticleInstance != dmParticle::INVALID_INSTANCE)
-        {
-            dmParticle::SetInstanceUserData(world->m_ParticleContext, component->m_ParticleInstance, component);
-        }
-    }
-
-    static void UpdateAllComponentUserData(ParticleFXWorld* world)
-    {
-        uint32_t component_count = world->m_Components.Size();
-        for (uint32_t i = 0; i < component_count; ++i)
-        {
-            UpdateComponentUserData(world, &world->m_Components[i]);
-        }
     }
 
     static void DestroyComponent(ParticleFXWorld* world, ParticleFXComponent* component)

--- a/engine/gamesys/src/gamesys/components/comp_particlefx.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_particlefx.cpp
@@ -112,6 +112,8 @@ namespace dmGameSystem
     };
 
     static void DestroyComponent(ParticleFXWorld* world, ParticleFXComponent* component);
+    static void UpdateComponentUserData(ParticleFXWorld* world, ParticleFXComponent* component);
+    static void UpdateAllComponentUserData(ParticleFXWorld* world);
 
     dmGameObject::CreateResult CompParticleFXNewWorld(const dmGameObject::ComponentNewWorldParams& params)
     {
@@ -301,6 +303,10 @@ namespace dmGameSystem
                 DestroyComponent(w, &c);
                 components.EraseSwap(i);
                 --count;
+                if (i < count)
+                {
+                    UpdateComponentUserData(w, &components[i]);
+                }
             }
             else
             {
@@ -659,6 +665,7 @@ namespace dmGameSystem
         if (world->m_Components.Full())
         {
             world->m_Components.OffsetCapacity(4);
+            UpdateAllComponentUserData(world);
         }
 
         uint32_t count = world->m_Components.Size();
@@ -704,17 +711,39 @@ namespace dmGameSystem
                 component->m_Overrides = component_overrides;
             }
 
-            dmParticle::SetInstanceUserData(world->m_ParticleContext, component->m_ParticleInstance, component);
+            UpdateComponentUserData(world, component);
         }
 
         world->m_EmitterCount += dmParticle::GetEmitterCount(component->m_ParticlePrototype);
         return component->m_ParticleInstance;
     }
 
+    static void UpdateComponentUserData(ParticleFXWorld* world, ParticleFXComponent* component)
+    {
+        if (component->m_Overrides && component->m_ParticleInstance != dmParticle::INVALID_INSTANCE)
+        {
+            dmParticle::SetInstanceUserData(world->m_ParticleContext, component->m_ParticleInstance, component);
+        }
+    }
+
+    static void UpdateAllComponentUserData(ParticleFXWorld* world)
+    {
+        uint32_t component_count = world->m_Components.Size();
+        for (uint32_t i = 0; i < component_count; ++i)
+        {
+            UpdateComponentUserData(world, &world->m_Components[i]);
+        }
+    }
+
     static void DestroyComponent(ParticleFXWorld* world, ParticleFXComponent* component)
     {
         if (component->m_Overrides)
         {
+            if (component->m_ParticleInstance != dmParticle::INVALID_INSTANCE)
+            {
+                dmParticle::SetInstanceUserData(world->m_ParticleContext, component->m_ParticleInstance, 0);
+            }
+
             uint32_t num_overrides = component->m_Overrides->m_EmitterOverrides.Size();
             for (int i = 0; i < num_overrides; ++i)
             {

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -2359,6 +2359,53 @@ TEST_F(ParticleFxTest, GetSetProperties)
     dmResource::Release(m_Factory, material);
 }
 
+TEST_F(ParticleFxTest, PlayWithOverridesAfterComponentStorageGrowth)
+{
+    dmGameObject::DeleteCollections(m_Register);
+
+    dmGameObjectDDF::ComponenTypeDesc component_types[2] = {};
+    component_types[0].m_NameHash = dmHashString64("goc");
+    component_types[0].m_MaxCount = 32;
+    component_types[1].m_NameHash = dmHashString64("particlefxc");
+    component_types[1].m_MaxCount = 1;
+
+    dmGameObjectDDF::CollectionDesc collection_desc = {};
+    collection_desc.m_Name = "particlefx_low_component_capacity";
+    collection_desc.m_ComponentTypes.m_Data = component_types;
+    collection_desc.m_ComponentTypes.m_Count = sizeof(component_types) / sizeof(component_types[0]);
+
+    m_Collection = dmGameObject::NewCollection(collection_desc.m_Name, m_Factory, m_Register, m_projectOptions.m_MaxInstances, &collection_desc);
+    ASSERT_NE((void*)0, m_Collection);
+    ASSERT_TRUE(dmGameObject::Init(m_Collection));
+
+    dmGameObject::HInstance go = Spawn(m_Factory, m_Collection, "/particlefx/valid_particlefx.goc", dmHashString64("/go"), 0, Point3(0, 0, 0), Quat(0, 0, 0, 1), Vector3(1, 1, 1));
+    ASSERT_NE((void*)0, go);
+
+    dmGameObject::PropertyOptions options;
+    ASSERT_TRUE(dmGameObject::AddPropertyOptionsKey(&options, dmHashString64("emitter")));
+    ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::SetProperty(go, dmHashString64("particlefx"), dmHashString64("animation"), options, dmGameObject::PropertyVar(dmHashString64("anim"))));
+
+    dmMessage::URL receiver;
+    receiver.m_Socket   = dmGameObject::GetMessageSocket(m_Collection);
+    receiver.m_Path     = dmGameObject::GetIdentifier(go);
+    receiver.m_Fragment = dmHashString64("particlefx");
+
+    for (uint32_t i = 0; i < 16; ++i)
+    {
+        dmMessage::Post(
+            0, &receiver,
+            dmGameSystemDDF::PlayParticleFX::m_DDFDescriptor->m_NameHash,
+            (uintptr_t)go,
+            (uintptr_t)dmGameSystemDDF::PlayParticleFX::m_DDFDescriptor,
+            0, 0, 0);
+    }
+
+    ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+    ASSERT_TRUE(dmGameObject::PostUpdate(m_Collection));
+
+    ASSERT_TRUE(dmGameObject::Final(m_Collection));
+}
+
 TEST_F(ParticleFxTest, FrustumCullsParticleEmitters)
 {
     ASSERT_TRUE(dmGameObject::Init(m_Collection));


### PR DESCRIPTION
Fixes a crash that could happen when playing particle effects that use runtime emitter overrides for material, image, or animation. Games using overlapping overridden particlefx instances should now continue updating safely.

### Technical details
Particlefx instances with emitter overrides store a pointer to their ParticleFX component as particle instance userdata. That pointer could become stale when the component array grew or when entries were moved with EraseSwap(), causing FetchResourcesCallback() to dereference invalid memory.

The fix refreshes particle instance userdata after component storage growth and swapped removal, and clears it before destroying overridden components. Added a regression test that forces component storage growth while overridden particlefx instances are alive.