### PR TITLE
Asan fix for stale http worker progress reporting

### DIFF
--- a/engine/lua/src/lua/wscript_build
+++ b/engine/lua/src/lua/wscript_build
@@ -1,4 +1,5 @@
 #! /usr/bin/env python
+from waflib import Options
 
 EXTRA_DEFINES = []
 
@@ -24,17 +25,21 @@ lua_lib = bld.stlib(features = 'c cxx',
                     source = lua_lib_source,
                     defines = LUA_DEFINES)
 
+lua_asan_source = []
+if Options.options.with_asan:
+    lua_asan_source = ['../lua_asan.cpp']
+
 if bld.env.IS_TARGET_DESKTOP:
     lua = bld.program(features = 'c cxx',
                       includes = '. ../',
-                      source = 'lua.c',
+                      source = ['lua.c'] + lua_asan_source,
                       target = 'lua',
                       use = 'lua_static',
                       defines = LUA_DEFINES)
 
     luac = bld.program(features = 'c cxx',
                        includes = '. ../',
-                       source = 'luac.c print.c',
+                       source = ['luac.c', 'print.c'] + lua_asan_source,
                        target = 'luac',
                        use = 'lua_static',
                        defines = LUA_DEFINES)

--- a/engine/lua/src/lua_asan.cpp
+++ b/engine/lua/src/lua_asan.cpp
@@ -1,0 +1,47 @@
+// Copyright 2020-2026 The Defold Foundation
+// Copyright 2014-2020 King
+// Copyright 2009-2014 Ragnar Svensson, Christian Murray
+// Licensed under the Defold License version 1.0 (the "License"); you may not use
+// this file except in compliance with the License.
+//
+// You may obtain a copy of the License, together with FAQs at
+// https://www.defold.com/license
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+extern "C"
+{
+#ifdef LUA_ANSI
+#undef LUA_ANSI
+#define LUA_ANSI
+#endif
+#include <lua/lua.h>
+#include <lua/lauxlib.h>
+}
+
+#if defined(DM_SANITIZE_ADDRESS) && !defined(_MSC_VER)
+#undef lua_error
+#undef luaL_error
+
+extern "C" void __asan_handle_no_return();
+
+extern "C" int dm_lua_error_asan(lua_State* L)
+{
+    __asan_handle_no_return();
+    return DM_LUA_RENAME(lua_error)(L);
+}
+
+extern "C" int dm_luaL_error_asan(lua_State* L, const char* fmt, ...)
+{
+    va_list argp;
+    va_start(argp, fmt);
+    luaL_where(L, 1);
+    lua_pushvfstring(L, fmt, argp);
+    va_end(argp);
+    lua_concat(L, 2);
+    return dm_lua_error_asan(L);
+}
+#endif

--- a/engine/script/src/http_service.cpp
+++ b/engine/script/src/http_service.cpp
@@ -340,6 +340,7 @@ namespace dmHttpService
         worker->m_RangeStart = 0;
         worker->m_RangeEnd = 0;
         worker->m_DocumentSize = 0;
+        worker->m_ReportProgress = false;
 
         if (request->m_ReportProgress)
         {
@@ -511,6 +512,7 @@ namespace dmHttpService
             worker->m_CacheFlusher = i == 0 && worker->m_Service->m_HttpCache != 0;
             worker->m_Run = true;
             worker->m_Canceled = 0;
+            worker->m_ReportProgress = false;
             service->m_Workers.Push(worker);
 
             dmThread::Thread t = dmThread::New(&Loop, THREAD_STACK_SIZE, worker, "http");


### PR DESCRIPTION
## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
