### PR TITLE
Better message when collada model still used

### DIFF
--- a/editor/resources/localization/en.editor_localization
+++ b/editor/resources/localization/en.editor_localization
@@ -2318,6 +2318,7 @@ error.material-not-defined-in-mesh = "{material}" is not defined in the Mesh. Us
 error.material-expects-paged-atlas = The Material expects a paged Atlas, but the selected {property} is not paged.
 error.material-does-not-support-paged-atlases = The Material does not support paged Atlases, but the selected {property} is paged.
 error.material-max-page-count-insufficient = The Material's "Max Page Count" is not sufficient for the number of pages in the selected {property}.
+error.model-unsupported-file-format = {property} "{resource}" has unsupported format {format}. Defold supports only {supported_formats} files for {property}.
 error.model-load-failed = The file "{file}" failed to load:\n{error}
 error.animation-not-found = "{animation}" could not be found in "{property}".
 error.buffer-syntax-error = Syntax error in buffer file.

--- a/editor/resources/localization/en.editor_localization
+++ b/editor/resources/localization/en.editor_localization
@@ -2314,6 +2314,7 @@ error.resource-is-a-broken-symlink = Symlink "{resource}" refers to missing path
 error.resource-not-loaded = The file "{resource}" could not be loaded.
 error.resource-not-loaded-with-error = The file "{resource}" could not be loaded: {error}
 error.resource-assignment-not-of-type = {property} "{resource}" is not of type {type}.
+error.no-file-extension = no file extension
 error.material-not-defined-in-mesh = "{material}" is not defined in the Mesh. Use the "Clear Override" command from the label's context menu to remove the property.
 error.material-expects-paged-atlas = The Material expects a paged Atlas, but the selected {property} is not paged.
 error.material-does-not-support-paged-atlases = The Material does not support paged Atlases, but the selected {property} is paged.

--- a/editor/resources/localization/ru.editor_localization
+++ b/editor/resources/localization/ru.editor_localization
@@ -2318,6 +2318,7 @@ error.material-not-defined-in-mesh = Материал «{material}» не опр
 error.material-expects-paged-atlas = Материал ожидает постраничный атлас, но значение свойства {property} не является постраничным.
 error.material-does-not-support-paged-atlases = Материал не поддерживает постраничные атласы, но значение свойства {property} является постраничным.
 error.material-max-page-count-insufficient = Значение «Макс. страницы атласа» в материале недостаточно для количества страниц в выбранном свойстве {property}.
+error.model-unsupported-file-format = Значение свойства {property} «{resource}» имеет неподдерживаемый формат {format}. Defold поддерживает только файлы {supported_formats} для свойства {property}.
 error.model-load-failed = Не удалось загрузить файл «{file}»\:\n{error}
 error.animation-not-found = В значении свойства «{property}» не найдена анимация «{animation}».
 error.buffer-syntax-error = Синтаксическая ошибка в файле буфера.

--- a/editor/resources/localization/ru.editor_localization
+++ b/editor/resources/localization/ru.editor_localization
@@ -2314,6 +2314,7 @@ error.resource-is-a-broken-symlink = Символическая ссылка «{
 error.resource-not-loaded = Не удалось загрузить файл «{resource}».
 error.resource-not-loaded-with-error = Не удалось загрузить файл «{resource}»\: {error}
 error.resource-assignment-not-of-type = Значение свойства {property} «{resource}» имеет неподходящий тип\: ожидается {type}.
+error.no-file-extension = без расширения файла
 error.material-not-defined-in-mesh = Материал «{material}» не определён в меше. Используйте команду «Сбросить переопределение» в контекстном меню имени свойства, чтобы его удалить.
 error.material-expects-paged-atlas = Материал ожидает постраничный атлас, но значение свойства {property} не является постраничным.
 error.material-does-not-support-paged-atlases = Материал не поддерживает постраничные атласы, но значение свойства {property} является постраничным.

--- a/editor/src/clj/editor/model.clj
+++ b/editor/src/clj/editor/model.clj
@@ -96,7 +96,6 @@
 
 (defn- prop-resource-unsupported-format? [v name supported-exts]
   (when (and v
-             (resource/exists? v)
              (not (contains? (set supported-exts) (resource/type-ext v))))
     (localization/message "error.model-unsupported-file-format"
                           {"property" name

--- a/editor/src/clj/editor/model.clj
+++ b/editor/src/clj/editor/model.clj
@@ -91,7 +91,7 @@
 (defn- resource-format-message [resource]
   (let [ext (resource/type-ext resource)]
     (if (str/blank? ext)
-      "no file extension"
+      (localization/message "error.no-file-extension")
       (str "." ext))))
 
 (defn- prop-resource-unsupported-format? [v name supported-exts]

--- a/editor/src/clj/editor/model.clj
+++ b/editor/src/clj/editor/model.clj
@@ -88,6 +88,25 @@
   (or (validation/prop-error nil-severity _node-id prop-kw validation/prop-nil? prop-value prop-name)
       (validation/prop-error :fatal _node-id prop-kw validation/prop-resource-not-exists? prop-value prop-name)))
 
+(defn- resource-format-message [resource]
+  (let [ext (resource/type-ext resource)]
+    (if (str/blank? ext)
+      "no file extension"
+      (str "." ext))))
+
+(defn- prop-resource-unsupported-format? [v name supported-exts]
+  (when (and v
+             (resource/exists? v)
+             (not (contains? (set supported-exts) (resource/type-ext v))))
+    (localization/message "error.model-unsupported-file-format"
+                          {"property" name
+                           "resource" (resource/resource->proj-path v)
+                           "format" (resource-format-message v)
+                           "supported_formats" (validation/format-ext-message supported-exts)})))
+
+(defn- prop-resource-format-error [_node-id prop-kw prop-value prop-name supported-exts]
+  (validation/prop-error :fatal _node-id prop-kw prop-resource-unsupported-format? prop-value prop-name supported-exts))
+
 (defn- validate-default-animation [_node-id default-animation animation-ids]
   (when (not (str/blank? default-animation))
     (validation/prop-error :fatal _node-id :default-animation validation/prop-member-of? default-animation (set animation-ids)
@@ -122,8 +141,11 @@
 
 (g/defnk produce-build-targets [_node-id resource pb-msg dep-build-targets default-animation animation-ids animation-set-build-target animation-set-build-target-single mesh-set-build-target materials material-binding-infos skeleton-build-target animations mesh skeleton create-go-bones]
   (or (some->> (into [(prop-resource-error :fatal _node-id :mesh mesh mesh-message)
+                      (prop-resource-format-error _node-id :mesh mesh mesh-message model-scene/model-file-types)
                       (validation/prop-error :fatal _node-id :skeleton validation/prop-resource-not-exists? skeleton skeleton-message)
+                      (prop-resource-format-error _node-id :skeleton skeleton skeleton-message model-scene/model-file-types)
                       (validation/prop-error :fatal _node-id :animations validation/prop-resource-not-exists? animations animations-message)
+                      (prop-resource-format-error _node-id :animations animations animations-message model-scene/animation-file-types)
                       (validate-default-animation _node-id default-animation animation-ids)
                       (validation/prop-error :fatal _node-id :materials validation/prop-empty? (:materials pb-msg) material-message)]
                      (map (fn [{:keys [name material]}]
@@ -431,7 +453,8 @@
             (dynamic error (g/fnk [_node-id mesh ^:try scene]
                              (if (g/error-value? scene)
                                scene
-                               (prop-resource-error :fatal _node-id :mesh mesh mesh-message))))
+                               (or (prop-resource-error :fatal _node-id :mesh mesh mesh-message)
+                                   (prop-resource-format-error _node-id :mesh mesh mesh-message model-scene/model-file-types)))))
             (dynamic edit-type (g/constantly {:type resource/Resource
                                               :ext model-scene/model-file-types}))
             (dynamic label (properties/label-dynamic :model :mesh))
@@ -473,7 +496,8 @@
             (dynamic error (g/fnk [_node-id skeleton ^:try skeleton-bones]
                              (if (g/error-value? skeleton-bones)
                                skeleton-bones
-                               (validation/prop-error :fatal _node-id :skeleton validation/prop-resource-not-exists? skeleton skeleton-message))))
+                               (or (validation/prop-error :fatal _node-id :skeleton validation/prop-resource-not-exists? skeleton skeleton-message)
+                                   (prop-resource-format-error _node-id :skeleton skeleton skeleton-message model-scene/model-file-types)))))
             (dynamic edit-type (g/constantly {:type resource/Resource
                                               :ext model-scene/model-file-types}))
             (dynamic label (properties/label-dynamic :model :skeleton))
@@ -490,7 +514,8 @@
             (dynamic error (g/fnk [_node-id animations ^:try animations-bones]
                              (if (g/error-value? animations-bones)
                                animations-bones
-                               (validation/prop-error :fatal _node-id :animations validation/prop-resource-not-exists? animations animations-message))))
+                               (or (validation/prop-error :fatal _node-id :animations validation/prop-resource-not-exists? animations animations-message)
+                                   (prop-resource-format-error _node-id :animations animations animations-message model-scene/animation-file-types)))))
             (dynamic edit-type (g/constantly {:type resource/Resource
                                               :ext model-scene/animation-file-types}))
             (dynamic label (properties/label-dynamic :model :animations))

--- a/editor/test/integration/model_test.clj
+++ b/editor/test/integration/model_test.clj
@@ -94,6 +94,22 @@
             (is (g/error? (test-util/prop-error node-id :mesh)))
             (is (g/error-value? (g/node-value node-id :build-targets))))))
 
+      (testing "unsupported model file formats fail before build"
+        (let [dae-resource (workspace/resolve-workspace-resource workspace "/model/unsupported.dae")]
+          (doseq [prop-kw [:mesh :skeleton :animations]]
+            (test-util/with-prop [node-id prop-kw dae-resource]
+              (let [prop-error (test-util/prop-error node-id prop-kw)
+                    prop-error-message (test-util/localization (g/error-message prop-error))
+                    build-targets (g/node-value node-id :build-targets)
+                    build-error-message (some->> (tree-seq :causes :causes build-targets)
+                                                 (some :message)
+                                                 test-util/localization)]
+                (is (g/error? prop-error))
+                (is (re-find #"unsupported format \.dae" prop-error-message))
+                (is (re-find #"Defold supports only" prop-error-message))
+                (is (g/error-value? build-targets))
+                (is (= prop-error-message build-error-message)))))))
+
       (testing "material must be assigned and exist"
         (is (not (g/error-value? (g/node-value node-id :build-targets))))
         (doseq [v [nil (workspace/resolve-workspace-resource workspace "/not_found.material")]]

--- a/editor/test/resources/test_project/model/unsupported.dae
+++ b/editor/test/resources/test_project/model/unsupported.dae
@@ -1,0 +1,1 @@
+unsupported


### PR DESCRIPTION
I found that if collada model still used in 1.13.0 user get an exeption, which is far away from a good UX. With this PR I'm adding a proper error that explains the problem
```
editor.pipeline$decorate_build_exception.invokeStatic.class clojure.lang.ExceptionInfo: Failed to build node '/main/main.collection' -> 'go' -> 'embedded.go' -> 'go/model' -> 'embedded.model'.
    at editor.pipeline$decorate_build_exception.invokeStatic(pipeline.clj:217)
    at editor.pipeline$build_BANG_$fn$fn.invoke(pipeline.clj:262)
    at editor.pipeline$build_BANG_$fn.invoke(pipeline.clj:258)
    at clojure.core$map$fn.invoke(core.clj:2772)
    at clojure.lang.LazySeq.force(LazySeq.java:50)
    at clojure.lang.LazySeq.realize(LazySeq.java:89)
    at clojure.lang.LazySeq.seq(LazySeq.java:106)
    at clojure.lang.Cons.next(Cons.java:41)
    at clojure.lang.RT.next(RT.java:733)
    at clojure.core$next__5470.invokeStatic(core.clj:64)
    at clojure.core$dorun.invokeStatic(core.clj:3150)
    at clojure.core$doall.invokeStatic(core.clj:3156)
    at editor.pipeline$batched_pmap$fn.invoke(pipeline.clj:195)
    at clojure.core$pmap$fn$fn.invoke(core.clj:7169)
    at clojure.core$binding_conveyor_fn$fn.invoke(core.clj:2047)
    at clojure.lang.AFn.call(AFn.java:18)
    at java.util.concurrent.FutureTask.run(FutureTask.java:328)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
    at java.lang.Thread.run(Thread.java:1474)

com.google.protobuf.AbstractMessage$Builder.newUninitializedMessageException.class com.google.protobuf.UninitializedMessageException: Message missing required fields: mesh_set
    at com.google.protobuf.AbstractMessage$Builder.newUninitializedMessageException(AbstractMessage.java:467)
    at com.dynamo.rig.proto.Rig$RigScene$Builder.build(Rig.java:40002)
    at com.dynamo.rig.proto.Rig$RigScene$Builder.build(Rig.java:39941)
    at editor.protobuf$pb_builder_raw$builder_fn.invoke(protobuf.clj:858)
    at editor.protobuf$map__GT_bytes.invokeStatic(protobuf.clj:1188)
    at editor.pipeline$build_protobuf.invokeStatic(pipeline.clj:73)
    at editor.pipeline$build_protobuf.invoke(pipeline.clj:71)
    at editor.pipeline$build_BANG_$fn$fn.invoke(pipeline.clj:259)
    at editor.pipeline$build_BANG_$fn.invoke(pipeline.clj:258)
    at clojure.core$map$fn.invoke(core.clj:2772)
    at clojure.lang.LazySeq.force(LazySeq.java:50)
    at clojure.lang.LazySeq.realize(LazySeq.java:89)
    at clojure.lang.LazySeq.seq(LazySeq.java:106)
    at clojure.lang.Cons.next(Cons.java:41)
    at clojure.lang.RT.next(RT.java:733)
    at clojure.core$next__5470.invokeStatic(core.clj:64)
    at clojure.core$dorun.invokeStatic(core.clj:3150)
    at clojure.core$doall.invokeStatic(core.clj:3156)
    at editor.pipeline$batched_pmap$fn.invoke(pipeline.clj:195)
    at clojure.core$pmap$fn$fn.invoke(core.clj:7169)
    at clojure.core$binding_conveyor_fn$fn.invoke(core.clj:2047)
    at clojure.lang.AFn.call(AFn.java:18)
    at java.util.concurrent.FutureTask.run(FutureTask.java:328)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
    at java.lang.Thread.run(Thread.java:1474)
    ```