### PR TITLE
Use local Maven repository for editor dependencies

### DIFF
--- a/editor/.gitignore
+++ b/editor/.gitignore
@@ -5,6 +5,7 @@ pom.xml
 pom.xml.asc
 *.jar
 *.class
+/.m2
 /.lein-*
 /.nrepl-port
 /doc/api

--- a/editor/project.clj
+++ b/editor/project.clj
@@ -12,11 +12,28 @@
 ;; CONDITIONS OF ANY KIND, either express or implied. See the License for the
 ;; specific language governing permissions and limitations under the License.
 
+(defn- pathname
+  ^String [^java.io.File file]
+  (.replace (.getPath file) \\ \/))
+
+(defn- local-maven-repository-directory
+  ^java.io.File []
+  (let [project-directory (.getParentFile (.getCanonicalFile (java.io.File. *file*)))
+        local-maven-repository-directory (.getCanonicalFile (java.io.File. project-directory ".m2/repository"))]
+    (when-not (or (.isDirectory local-maven-repository-directory) (.mkdirs local-maven-repository-directory))
+      (throw (ex-info (format "Unable to create local Maven repository directory '%s'." local-maven-repository-directory)
+                      {:local-maven-repository-directory (str local-maven-repository-directory)})))
+    local-maven-repository-directory))
+
+(defn- local-maven-jar-file
+  ^java.io.File [^String relative-jar-path]
+  (java.io.File. (local-maven-repository-directory) relative-jar-path))
+
 (defproject defold-editor "2.0.0-SNAPSHOT"
   :description      "Defold game editor"
   :url              "https://www.defold.com/learn/"
 
-  :repositories     {"local" ~(str (.toURI (java.io.File. "localjars")))}
+  :local-repo       ~(pathname (local-maven-repository-directory))
 
   :plugins          [[lein-protobuf-minimal-mg "0.4.5" :hooks false]
                      [codox "0.9.3"]]
@@ -52,7 +69,6 @@
                      [net.java.dev.jna/jna-platform               "4.1.0"]
 
                      [com.defold.lib/bob                          "1.0"]
-                     [com.defold.lib/openmali                     "1.0"]
                      [com.defold.lib/icu4j                        "1.0"]
 
                      [metosin/reitit-core "0.8.0-alpha1"]
@@ -245,9 +261,7 @@
                                               [org.openjfx/javafx-web "25"]]}
                       :metrics {:jvm-opts ["-Ddefold.metrics=true"]}
                       :jamm {:dependencies [[com.github.jbellis/jamm "0.4.0"]]
-                             :jvm-opts [~(str "-javaagent:"
-                                           (.replace (System/getProperty "user.home") \\ \/)
-                                           "/.m2/repository/com/github/jbellis/jamm/0.4.0/jamm-0.4.0.jar")
+                             :jvm-opts [~(str "-javaagent:" (pathname (local-maven-jar-file "com/github/jbellis/jamm/0.4.0/jamm-0.4.0.jar")))
                                         "-Ddefold.jamm=true"
                                         "--add-opens=java.base/java.util=ALL-UNNAMED"
                                         "--add-opens=java.base/java.util.function=ALL-UNNAMED"

--- a/editor/tasks/leiningen/local_jars.clj
+++ b/editor/tasks/leiningen/local_jars.clj
@@ -27,12 +27,6 @@
 
 (defn dynamo-home [] (get (System/getenv) "DYNAMO_HOME"))
 
-(def ^:private jar-decls
-  [{:artifact-id "openmali"
-    :group-id "com.defold.lib"
-    :jar-file "../com.dynamo.cr/com.dynamo.cr.bob/lib/openmali.jar"
-    :version "1.0"}])
-
 (defn- clean-icu4j-data
   ;; Useful link:
   ;; https://unicode-org.github.io/icu/userguide/icu_data/buildtool.html#file-slicing-coarse-grained-features
@@ -91,27 +85,30 @@
     :out
     string/trim))
 
-(defn bob-artifact-file ^File
-  [archive git-sha]
+(defn bob-artifact-file
+  ^File [archive git-sha]
   (let [f (when git-sha
             (http-cache/download (format "https://%s/archive/%s/bob/bob.jar" archive git-sha)))]
     (or f (io/file (dynamo-home) "share/java/bob.jar"))))
 
 (defn local-jars
-  "Install local jar dependencies into the ~/.m2 Maven repository."
+  "Install custom-built jar dependencies into the project's local Maven repository."
   [project & [git-sha]]
-  (let [sha (or git-sha (:engine project))
+  (let [local-repo (:local-repo project)
+        sha (or git-sha (:engine project))
         archive-domain (get project :archive-domain)
-        jar-decls (conj jar-decls
-                        {:artifact-id "bob"
-                         :group-id "com.defold.lib"
-                         :jar-file (.getAbsolutePath (bob-artifact-file archive-domain sha))
-                         :version "1.0"}
-                        {:artifact-id "icu4j"
-                         :group-id "com.defold.lib"
-                         :version "1.0"
-                         :jar-file (str (clean-icu4j-data (:icu4j project)))})]
+        jar-decls [{:artifact-id "bob"
+                    :group-id "com.defold.lib"
+                    :jar-file (.getAbsolutePath (bob-artifact-file archive-domain sha))
+                    :version "1.0"}
+                   {:artifact-id "icu4j"
+                    :group-id "com.defold.lib"
+                    :version "1.0"
+                    :jar-file (str (clean-icu4j-data (:icu4j project)))}]]
+    (when-not local-repo
+      (throw (ex-info "Missing project :local-repo" {:task "local-jars"})))
     (doseq [{:keys [group-id artifact-id version jar-file]} (sort-by :jar-file jar-decls)]
       (main/info (format "Installing %s as [%s \"%s\"]" jar-file (symbol group-id artifact-id) version))
       (aether/install-artifacts
+        :local-repo local-repo
         :files {[(symbol group-id artifact-id) version] jar-file}))))

--- a/editor/tasks/leiningen/pack.clj
+++ b/editor/tasks/leiningen/pack.clj
@@ -119,13 +119,12 @@
    "windows-x64"      ["x86_64-win32"]})
 
 (defn jar-file
-  ^File [[artifact version & {:keys [classifier]} :as dependency]]
-  (io/file (str (System/getProperty "user.home")
-                "/.m2/repository/"
-                (str/replace (namespace artifact) "." "/")
-                "/" (name artifact)
-                "/" version
-                "/" (name artifact) "-" version
+  ^File [local-repo [artifact version & {:keys [classifier]}]]
+  (io/file local-repo
+           (str/replace (namespace artifact) "." "/")
+           (name artifact)
+           version
+           (str (name artifact) "-" version
                 (some->> classifier name (str "-")) ".jar")))
 
 (defn jogl-native-dep?
@@ -135,10 +134,10 @@
        classifier))
 
 (defn extract-jogl-native-dep
-  [[artifact version & {:keys [classifier]} :as dependency] pack-path selected-platforms]
+  [local-repo [_ _ & {:keys [classifier]} :as dependency] pack-path selected-platforms]
   (let [java-platform (str/replace-first classifier "natives-" "")
         natives-path (str "natives/" java-platform)]
-    (with-open [zip-file (ZipFile. (jar-file dependency))]
+    (with-open [zip-file (ZipFile. (jar-file local-repo dependency))]
       (doseq [^ZipEntry entry (enumeration-seq (.entries zip-file))]
         (when (.startsWith (.getName entry) natives-path)
           (let [libname (.getName (io/file (.getName entry)))]
@@ -150,9 +149,9 @@
                 (io/copy (.getInputStream zip-file entry) dest)))))))))
 
 (defn pack-jogl-natives
-  [pack-path dependencies selected-platforms]
+  [pack-path local-repo dependencies selected-platforms]
   (doseq [jogl-native-dep (filter jogl-native-dep? dependencies)]
-    (extract-jogl-native-dep jogl-native-dep pack-path selected-platforms)))
+    (extract-jogl-native-dep local-repo jogl-native-dep pack-path selected-platforms)))
 
 (defn pack-lua-language-server [pack-path lua-language-server-version selected-platforms]
   (let [release-path (-> (format "https://github.com/defold/lua-language-server/releases/download/%s/release.zip"
@@ -213,12 +212,14 @@
 
 (defn pack
   "Pack all files that need to be unpacked at runtime into `pack-path`."
-  [{:keys [dependencies packing] :as project} & [git-sha]]
+  [{:keys [dependencies local-repo packing] :as project} & [git-sha]]
   (let [sha (or git-sha (:engine project))
         archive-domain (get project :archive-domain)
         {:keys [pack-path lua-language-server-version target-platform]} packing
         platforms-to-pack (selected-platforms target-platform)]
+    (when-not local-repo
+      (throw (ex-info "Missing project :local-repo" {:task "pack"})))
     (FileUtils/deleteQuietly (io/file pack-path))
     (copy-artifacts pack-path archive-domain sha platforms-to-pack)
-    (pack-jogl-natives pack-path dependencies platforms-to-pack)
+    (pack-jogl-natives pack-path local-repo dependencies platforms-to-pack)
     (pack-lua-language-server pack-path lua-language-server-version platforms-to-pack)))


### PR DESCRIPTION
As part of the editor build process, we commit some custom-built `.jar` files (such as Bob) to the Maven repository under a hard-coded `1.0` version so they can be picked up by `project.clj`. This is problematic when working with multiple Git worktrees since there may be incompatibilities between different source versions of these `.jar` files.

As a workaround, this PR changes `lein init` and `lein pack` to use a local Maven repository under `defold-checkout/editor/.m2/repository` for dependencies rather than the global `~/.m2/repository`. 

This makes it easier to have processes running concurrently from multiple Git worktrees, since you no longer have to match the Bob sources across all worktrees.

It also removes an unused dependency on `openmali` from the editor.