### PR TITLE
Added Box2D script functions for joints

### DIFF
--- a/engine/gamesys/src/gamesys/scripts/box2d/script_box2d.h
+++ b/engine/gamesys/src/gamesys/scripts/box2d/script_box2d.h
@@ -35,6 +35,9 @@ namespace dmGameSystem
     void  ScriptBox2DInitializeBody(struct lua_State* L);
     void  ScriptBox2DInvalidateBody(void* body);
     void  ScriptBox2DFinalizeBody();
+    void  ScriptBox2DInitializeJoint(struct lua_State* L);
+    void  ScriptBox2DInvalidateJoint(void* joint);
+    void  ScriptBox2DFinalizeJoint();
     void  ScriptBox2DInitializeFixture(struct lua_State* L);
     void  ScriptBox2DInitializeShape(struct lua_State* L);
 }

--- a/engine/gamesys/src/gamesys/scripts/box2d/v2/script_box2d_body_v2.cpp
+++ b/engine/gamesys/src/gamesys/scripts/box2d/v2/script_box2d_body_v2.cpp
@@ -1576,10 +1576,10 @@ namespace dmGameSystem
  * @return enabled [type: boolean] is the rotation fixed
  */
 
-/** Get the list of all joints attached to this body.
- * @name b2d.body.get_joint_list
+/*# Get the joints attached to this body.
+ * @name b2d.body.get_joints
  * @param body [type: b2Body] body
- * @return edge [type: b2JointEdge] the first joint
+ * @return joints [type: table] array of `b2Joint` handles created by `b2d.joint`
  */
 
 /** Get the list of all contacts attached to this body.

--- a/engine/gamesys/src/gamesys/scripts/box2d/v2/script_box2d_body_v2.cpp
+++ b/engine/gamesys/src/gamesys/scripts/box2d/v2/script_box2d_body_v2.cpp
@@ -368,7 +368,15 @@ namespace dmGameSystem
         return VerifyBodyInternal(L, luabody, 0);
     }
 
-    static dmhash_t GetBodyInstanceId(b2Body* body)
+    dmGameObject::HCollection GetBodyCollection(lua_State* L, int index)
+    {
+        B2DLuaBody* luabody = CheckBodyInternal(L, index);
+        B2DBodyMeta* body_meta = 0;
+        VerifyBodyInternal(L, luabody, &body_meta);
+        return body_meta ? body_meta->m_Collection : 0;
+    }
+
+    dmhash_t GetBodyInstanceId(b2Body* body)
     {
         void* user_data = body->GetUserData(); // The component. See CompCollisionObjectCreate in comp_collision_object.cpp
 
@@ -609,6 +617,31 @@ namespace dmGameSystem
             lua_rawseti(L, -2, fixture_index);
             fixture = fixture->GetNext();
             ++fixture_index;
+        }
+
+        return 1;
+    }
+
+    static int Body_GetJoints(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        B2DLuaBody* luabody = CheckBodyInternal(L, 1);
+        B2DBodyMeta* body_meta = 0;
+        b2Body* body = VerifyBodyInternal(L, luabody, &body_meta);
+
+        lua_newtable(L);
+
+        b2JointEdge* joint_edge = body->GetJointList();
+        int joint_index = 1;
+        while (joint_edge)
+        {
+            if (IsJointTracked(joint_edge->joint))
+            {
+                PushJoint(L, joint_edge->joint, body_meta ? body_meta->m_Collection : 0);
+                lua_rawseti(L, -2, joint_index);
+                ++joint_index;
+            }
+            joint_edge = joint_edge->next;
         }
 
         return 1;
@@ -1003,6 +1036,7 @@ namespace dmGameSystem
         {"set_mass_data", Body_SetMassData},
         {"reset_mass_data", Body_ResetMassData},
         {"get_fixtures", Body_GetFixtures},
+        {"get_joints", Body_GetJoints},
         {"destroy_fixture", Body_DestroyFixture},
         {"get_angle", Body_GetAngle},
 
@@ -1094,6 +1128,7 @@ namespace dmGameSystem
 
         lua_setfield(L, -2, "body");
 
+        ScriptBox2DInitializeJoint(L);
         ScriptBox2DInitializeFixture(L);
         ScriptBox2DInitializeShape(L);
     }
@@ -1118,6 +1153,13 @@ namespace dmGameSystem
             fixture = next_fixture;
         }
 
+        b2JointEdge* joint_edge = b2_body->GetJointList();
+        while (joint_edge)
+        {
+            ScriptBox2DInvalidateJoint(joint_edge->joint);
+            joint_edge = joint_edge->next;
+        }
+
         HOpaqueHandle* handle = g_BodyToHandle.Get(BodyPtrToKey(b2_body));
         if (handle)
         {
@@ -1133,6 +1175,7 @@ namespace dmGameSystem
         ClearFixtureShapes();
         g_BodyToHandle.Clear();
         g_BodyMeta.Clear();
+        ScriptBox2DFinalizeJoint();
     }
 }
 

--- a/engine/gamesys/src/gamesys/scripts/box2d/v2/script_box2d_joint_v2.cpp
+++ b/engine/gamesys/src/gamesys/scripts/box2d/v2/script_box2d_joint_v2.cpp
@@ -336,13 +336,6 @@ namespace dmGameSystem
         return 1;
     }
 
-    static int Joint_SetCollideConnected(lua_State* L)
-    {
-        DM_LUA_STACK_CHECK(L, 0);
-        CheckJoint(L, 1);
-        return luaL_error(L, "b2d.joint.set_collide_connected is only supported by Box2D v3.");
-    }
-
     static int Joint_SetMouseTarget(lua_State* L)
     {
         DM_LUA_STACK_CHECK(L, 0);
@@ -661,7 +654,6 @@ namespace dmGameSystem
         {"get_local_anchor_a", Joint_GetLocalAnchorA},
         {"get_local_anchor_b", Joint_GetLocalAnchorB},
         {"get_collide_connected", Joint_GetCollideConnected},
-        {"set_collide_connected", Joint_SetCollideConnected},
         {"set_mouse_target", Joint_SetMouseTarget},
         {"get_reaction_force", Joint_GetReactionForce},
         {"get_reaction_torque", Joint_GetReactionTorque},

--- a/engine/gamesys/src/gamesys/scripts/box2d/v2/script_box2d_joint_v2.cpp
+++ b/engine/gamesys/src/gamesys/scripts/box2d/v2/script_box2d_joint_v2.cpp
@@ -223,15 +223,69 @@ namespace dmGameSystem
         return (b2Joint*)joint_ptr;
     }
 
-    static B2DJointMeta* GetJointMeta(lua_State* L, B2DLuaJoint* luajoint)
+    static b2Joint* CheckJoint(lua_State* L, int index, HOpaqueHandle* out_handle)
     {
-        B2DJointMeta* joint_meta = g_JointMeta.Get(luajoint->m_Handle);
-        if (!joint_meta)
+        B2DLuaJoint* luajoint = CheckJointInternal(L, index);
+        uintptr_t* joint_ptr = g_JointHandles.Get(luajoint->m_Handle);
+        if (!joint_ptr)
         {
             luaL_error(L, "Invalid b2joint handle.");
             return 0;
         }
-        return joint_meta;
+
+        if (out_handle)
+        {
+            *out_handle = luajoint->m_Handle;
+        }
+
+        return (b2Joint*)joint_ptr;
+    }
+
+    static b2Joint* CheckJoint(lua_State* L, int index, B2DJointMeta** out_joint_meta)
+    {
+        B2DLuaJoint* luajoint = CheckJointInternal(L, index);
+        uintptr_t* joint_ptr = g_JointHandles.Get(luajoint->m_Handle);
+        if (!joint_ptr)
+        {
+            luaL_error(L, "Invalid b2joint handle.");
+            return 0;
+        }
+
+        if (out_joint_meta)
+        {
+            *out_joint_meta = g_JointMeta.Get(luajoint->m_Handle);
+            if (!*out_joint_meta)
+            {
+                luaL_error(L, "Invalid b2joint handle.");
+                return 0;
+            }
+        }
+
+        return (b2Joint*)joint_ptr;
+    }
+
+    static b2Joint* CheckJointType(lua_State* L, int index, B2DJointMeta** out_joint_meta, b2JointType joint_type, const char* function_name, const char* joint_type_name)
+    {
+        b2Joint* joint = CheckJoint(L, index, out_joint_meta);
+        if (joint->GetType() != joint_type)
+        {
+            luaL_error(L, "b2d.joint.%s can only be used with %s joints.", function_name, joint_type_name);
+            return 0;
+        }
+        return joint;
+    }
+
+    static b2Joint* CheckJointType(lua_State* L, int index, b2JointType joint_type, const char* function_name, const char* joint_type_name)
+    {
+        return CheckJointType(L, index, 0, joint_type, function_name, joint_type_name);
+    }
+
+    static void CheckJointWorldUnlocked(lua_State* L, b2Joint* joint, const char* function_name)
+    {
+        if (joint->GetBodyA()->GetWorld()->IsLocked())
+        {
+            luaL_error(L, "Could not call b2d.joint.%s. The world is locked.", function_name);
+        }
     }
 
     static B2DLuaJoint* ToJoint(lua_State* L, int index)
@@ -274,15 +328,15 @@ namespace dmGameSystem
     static int Joint_Destroy(lua_State* L)
     {
         DM_LUA_STACK_CHECK(L, 0);
-        B2DLuaJoint* luajoint = CheckJointInternal(L, 1);
-        b2Joint* joint = CheckJoint(L, 1);
+        HOpaqueHandle joint_handle = INVALID_OPAQUE_HANDLE;
+        b2Joint* joint = CheckJoint(L, 1, &joint_handle);
         b2World* world = joint->GetBodyA()->GetWorld();
         if (world->IsLocked())
         {
             return luaL_error(L, "Could not destroy joint. The world is locked.");
         }
         world->DestroyJoint(joint);
-        InvalidateJointHandle(luajoint->m_Handle);
+        InvalidateJointHandle(joint_handle);
         return 0;
     }
 
@@ -296,9 +350,8 @@ namespace dmGameSystem
     static int Joint_GetBodyA(lua_State* L)
     {
         DM_LUA_STACK_CHECK(L, 1);
-        B2DLuaJoint* luajoint = CheckJointInternal(L, 1);
-        B2DJointMeta* joint_meta = GetJointMeta(L, luajoint);
-        b2Body* body = CheckJoint(L, 1)->GetBodyA();
+        B2DJointMeta* joint_meta = 0;
+        b2Body* body = CheckJoint(L, 1, &joint_meta)->GetBodyA();
         PushBody(L, body, joint_meta ? joint_meta->m_Collection : 0, GetBodyInstanceId(body));
         return 1;
     }
@@ -306,9 +359,8 @@ namespace dmGameSystem
     static int Joint_GetBodyB(lua_State* L)
     {
         DM_LUA_STACK_CHECK(L, 1);
-        B2DLuaJoint* luajoint = CheckJointInternal(L, 1);
-        B2DJointMeta* joint_meta = GetJointMeta(L, luajoint);
-        b2Body* body = CheckJoint(L, 1)->GetBodyB();
+        B2DJointMeta* joint_meta = 0;
+        b2Body* body = CheckJoint(L, 1, &joint_meta)->GetBodyB();
         PushBody(L, body, joint_meta ? joint_meta->m_Collection : 0, GetBodyInstanceId(body));
         return 1;
     }
@@ -326,6 +378,27 @@ namespace dmGameSystem
         DM_LUA_STACK_CHECK(L, 1);
         b2Joint* joint = CheckJoint(L, 1);
         dmScript::PushVector3(L, FromB2(joint->GetBodyB()->GetLocalPoint(joint->GetAnchorB()), GetInvPhysicsScale()));
+        return 1;
+    }
+
+    static int Joint_GetAnchorA(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        dmScript::PushVector3(L, FromB2(CheckJoint(L, 1)->GetAnchorA(), GetInvPhysicsScale()));
+        return 1;
+    }
+
+    static int Joint_GetAnchorB(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        dmScript::PushVector3(L, FromB2(CheckJoint(L, 1)->GetAnchorB(), GetInvPhysicsScale()));
+        return 1;
+    }
+
+    static int Joint_IsActive(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        lua_pushboolean(L, CheckJoint(L, 1)->IsActive());
         return 1;
     }
 
@@ -351,6 +424,499 @@ namespace dmGameSystem
         }
         ((b2MouseJoint*)joint)->SetTarget(CheckVec2(L, 2, GetPhysicsScale()));
         return 0;
+    }
+
+    static int Joint_GetMouseTarget(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        b2MouseJoint* joint = (b2MouseJoint*)CheckJointType(L, 1, e_mouseJoint, "get_mouse_target", "mouse");
+        dmScript::PushVector3(L, FromB2(joint->GetTarget(), GetInvPhysicsScale()));
+        return 1;
+    }
+
+    static int Joint_SetLength(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        b2DistanceJoint* joint = (b2DistanceJoint*)CheckJointType(L, 1, e_distanceJoint, "set_length", "distance");
+        CheckJointWorldUnlocked(L, joint, "set_length");
+        joint->SetLength((float)luaL_checknumber(L, 2) * GetPhysicsScale());
+        return 0;
+    }
+
+    static int Joint_GetLength(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        b2DistanceJoint* joint = (b2DistanceJoint*)CheckJointType(L, 1, e_distanceJoint, "get_length", "distance");
+        lua_pushnumber(L, joint->GetLength() * GetInvPhysicsScale());
+        return 1;
+    }
+
+    static int Joint_SetFrequency(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        b2Joint* joint = CheckJoint(L, 1);
+        CheckJointWorldUnlocked(L, joint, "set_frequency");
+        float frequency = (float)luaL_checknumber(L, 2);
+        switch (joint->GetType())
+        {
+            case e_distanceJoint: ((b2DistanceJoint*)joint)->SetFrequency(frequency); break;
+            case e_mouseJoint: ((b2MouseJoint*)joint)->SetFrequency(frequency); break;
+            case e_weldJoint: ((b2WeldJoint*)joint)->SetFrequency(frequency); break;
+            case e_wheelJoint: ((b2WheelJoint*)joint)->SetSpringFrequencyHz(frequency); break;
+            default: return luaL_error(L, "b2d.joint.set_frequency can only be used with distance, mouse, weld, or wheel joints.");
+        }
+        return 0;
+    }
+
+    static int Joint_GetFrequency(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        b2Joint* joint = CheckJoint(L, 1);
+        switch (joint->GetType())
+        {
+            case e_distanceJoint: lua_pushnumber(L, ((b2DistanceJoint*)joint)->GetFrequency()); break;
+            case e_mouseJoint: lua_pushnumber(L, ((b2MouseJoint*)joint)->GetFrequency()); break;
+            case e_weldJoint: lua_pushnumber(L, ((b2WeldJoint*)joint)->GetFrequency()); break;
+            case e_wheelJoint: lua_pushnumber(L, ((b2WheelJoint*)joint)->GetSpringFrequencyHz()); break;
+            default: return luaL_error(L, "b2d.joint.get_frequency can only be used with distance, mouse, weld, or wheel joints.");
+        }
+        return 1;
+    }
+
+    static int Joint_SetDampingRatio(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        b2Joint* joint = CheckJoint(L, 1);
+        CheckJointWorldUnlocked(L, joint, "set_damping_ratio");
+        float damping_ratio = (float)luaL_checknumber(L, 2);
+        switch (joint->GetType())
+        {
+            case e_distanceJoint: ((b2DistanceJoint*)joint)->SetDampingRatio(damping_ratio); break;
+            case e_mouseJoint: ((b2MouseJoint*)joint)->SetDampingRatio(damping_ratio); break;
+            case e_weldJoint: ((b2WeldJoint*)joint)->SetDampingRatio(damping_ratio); break;
+            case e_wheelJoint: ((b2WheelJoint*)joint)->SetSpringDampingRatio(damping_ratio); break;
+            default: return luaL_error(L, "b2d.joint.set_damping_ratio can only be used with distance, mouse, weld, or wheel joints.");
+        }
+        return 0;
+    }
+
+    static int Joint_GetDampingRatio(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        b2Joint* joint = CheckJoint(L, 1);
+        switch (joint->GetType())
+        {
+            case e_distanceJoint: lua_pushnumber(L, ((b2DistanceJoint*)joint)->GetDampingRatio()); break;
+            case e_mouseJoint: lua_pushnumber(L, ((b2MouseJoint*)joint)->GetDampingRatio()); break;
+            case e_weldJoint: lua_pushnumber(L, ((b2WeldJoint*)joint)->GetDampingRatio()); break;
+            case e_wheelJoint: lua_pushnumber(L, ((b2WheelJoint*)joint)->GetSpringDampingRatio()); break;
+            default: return luaL_error(L, "b2d.joint.get_damping_ratio can only be used with distance, mouse, weld, or wheel joints.");
+        }
+        return 1;
+    }
+
+    static int Joint_GetLocalAxisA(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        b2Joint* joint = CheckJoint(L, 1);
+        switch (joint->GetType())
+        {
+            case e_prismaticJoint: dmScript::PushVector3(L, FromB2(((b2PrismaticJoint*)joint)->GetLocalAxisA(), 1.0f)); break;
+            case e_wheelJoint: dmScript::PushVector3(L, FromB2(((b2WheelJoint*)joint)->GetLocalAxisA(), 1.0f)); break;
+            default: return luaL_error(L, "b2d.joint.get_local_axis_a can only be used with prismatic or wheel joints.");
+        }
+        return 1;
+    }
+
+    static int Joint_GetReferenceAngle(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        b2Joint* joint = CheckJoint(L, 1);
+        switch (joint->GetType())
+        {
+            case e_prismaticJoint: lua_pushnumber(L, ((b2PrismaticJoint*)joint)->GetReferenceAngle()); break;
+            case e_revoluteJoint: lua_pushnumber(L, ((b2RevoluteJoint*)joint)->GetReferenceAngle()); break;
+            case e_weldJoint: lua_pushnumber(L, ((b2WeldJoint*)joint)->GetReferenceAngle()); break;
+            default: return luaL_error(L, "b2d.joint.get_reference_angle can only be used with prismatic, revolute, or weld joints.");
+        }
+        return 1;
+    }
+
+    static int Joint_GetJointTranslation(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        b2Joint* joint = CheckJoint(L, 1);
+        switch (joint->GetType())
+        {
+            case e_prismaticJoint: lua_pushnumber(L, ((b2PrismaticJoint*)joint)->GetJointTranslation() * GetInvPhysicsScale()); break;
+            case e_wheelJoint: lua_pushnumber(L, ((b2WheelJoint*)joint)->GetJointTranslation() * GetInvPhysicsScale()); break;
+            default: return luaL_error(L, "b2d.joint.get_joint_translation can only be used with prismatic or wheel joints.");
+        }
+        return 1;
+    }
+
+    static int Joint_GetJointSpeed(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        b2Joint* joint = CheckJoint(L, 1);
+        switch (joint->GetType())
+        {
+            case e_prismaticJoint: lua_pushnumber(L, ((b2PrismaticJoint*)joint)->GetJointSpeed() * GetInvPhysicsScale()); break;
+            case e_revoluteJoint: lua_pushnumber(L, ((b2RevoluteJoint*)joint)->GetJointSpeed()); break;
+            case e_wheelJoint: lua_pushnumber(L, ((b2WheelJoint*)joint)->GetJointSpeed() * GetInvPhysicsScale()); break;
+            default: return luaL_error(L, "b2d.joint.get_joint_speed can only be used with prismatic, revolute, or wheel joints.");
+        }
+        return 1;
+    }
+
+    static int Joint_GetJointAngle(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        b2RevoluteJoint* joint = (b2RevoluteJoint*)CheckJointType(L, 1, e_revoluteJoint, "get_joint_angle", "revolute");
+        lua_pushnumber(L, joint->GetJointAngle());
+        return 1;
+    }
+
+    static int Joint_EnableLimit(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        b2Joint* joint = CheckJoint(L, 1);
+        CheckJointWorldUnlocked(L, joint, "enable_limit");
+        bool enable_limit = lua_toboolean(L, 2);
+        switch (joint->GetType())
+        {
+            case e_prismaticJoint: ((b2PrismaticJoint*)joint)->EnableLimit(enable_limit); break;
+            case e_revoluteJoint: ((b2RevoluteJoint*)joint)->EnableLimit(enable_limit); break;
+            default: return luaL_error(L, "b2d.joint.enable_limit can only be used with prismatic or revolute joints.");
+        }
+        return 0;
+    }
+
+    static int Joint_IsLimitEnabled(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        b2Joint* joint = CheckJoint(L, 1);
+        switch (joint->GetType())
+        {
+            case e_prismaticJoint: lua_pushboolean(L, ((b2PrismaticJoint*)joint)->IsLimitEnabled()); break;
+            case e_revoluteJoint: lua_pushboolean(L, ((b2RevoluteJoint*)joint)->IsLimitEnabled()); break;
+            default: return luaL_error(L, "b2d.joint.is_limit_enabled can only be used with prismatic or revolute joints.");
+        }
+        return 1;
+    }
+
+    static int Joint_SetLimits(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        b2Joint* joint = CheckJoint(L, 1);
+        CheckJointWorldUnlocked(L, joint, "set_limits");
+        switch (joint->GetType())
+        {
+            case e_prismaticJoint:
+                ((b2PrismaticJoint*)joint)->SetLimits((float)luaL_checknumber(L, 2) * GetPhysicsScale(), (float)luaL_checknumber(L, 3) * GetPhysicsScale());
+                break;
+            case e_revoluteJoint:
+                ((b2RevoluteJoint*)joint)->SetLimits((float)luaL_checknumber(L, 2), (float)luaL_checknumber(L, 3));
+                break;
+            default: return luaL_error(L, "b2d.joint.set_limits can only be used with prismatic or revolute joints.");
+        }
+        return 0;
+    }
+
+    static int Joint_GetLowerLimit(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        b2Joint* joint = CheckJoint(L, 1);
+        switch (joint->GetType())
+        {
+            case e_prismaticJoint: lua_pushnumber(L, ((b2PrismaticJoint*)joint)->GetLowerLimit() * GetInvPhysicsScale()); break;
+            case e_revoluteJoint: lua_pushnumber(L, ((b2RevoluteJoint*)joint)->GetLowerLimit()); break;
+            default: return luaL_error(L, "b2d.joint.get_lower_limit can only be used with prismatic or revolute joints.");
+        }
+        return 1;
+    }
+
+    static int Joint_GetUpperLimit(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        b2Joint* joint = CheckJoint(L, 1);
+        switch (joint->GetType())
+        {
+            case e_prismaticJoint: lua_pushnumber(L, ((b2PrismaticJoint*)joint)->GetUpperLimit() * GetInvPhysicsScale()); break;
+            case e_revoluteJoint: lua_pushnumber(L, ((b2RevoluteJoint*)joint)->GetUpperLimit()); break;
+            default: return luaL_error(L, "b2d.joint.get_upper_limit can only be used with prismatic or revolute joints.");
+        }
+        return 1;
+    }
+
+    static int Joint_EnableMotor(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        b2Joint* joint = CheckJoint(L, 1);
+        CheckJointWorldUnlocked(L, joint, "enable_motor");
+        bool enable_motor = lua_toboolean(L, 2);
+        switch (joint->GetType())
+        {
+            case e_prismaticJoint: ((b2PrismaticJoint*)joint)->EnableMotor(enable_motor); break;
+            case e_revoluteJoint: ((b2RevoluteJoint*)joint)->EnableMotor(enable_motor); break;
+            case e_wheelJoint: ((b2WheelJoint*)joint)->EnableMotor(enable_motor); break;
+            default: return luaL_error(L, "b2d.joint.enable_motor can only be used with prismatic, revolute, or wheel joints.");
+        }
+        return 0;
+    }
+
+    static int Joint_IsMotorEnabled(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        b2Joint* joint = CheckJoint(L, 1);
+        switch (joint->GetType())
+        {
+            case e_prismaticJoint: lua_pushboolean(L, ((b2PrismaticJoint*)joint)->IsMotorEnabled()); break;
+            case e_revoluteJoint: lua_pushboolean(L, ((b2RevoluteJoint*)joint)->IsMotorEnabled()); break;
+            case e_wheelJoint: lua_pushboolean(L, ((b2WheelJoint*)joint)->IsMotorEnabled()); break;
+            default: return luaL_error(L, "b2d.joint.is_motor_enabled can only be used with prismatic, revolute, or wheel joints.");
+        }
+        return 1;
+    }
+
+    static int Joint_SetMotorSpeed(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        b2Joint* joint = CheckJoint(L, 1);
+        CheckJointWorldUnlocked(L, joint, "set_motor_speed");
+        float motor_speed = (float)luaL_checknumber(L, 2);
+        switch (joint->GetType())
+        {
+            case e_prismaticJoint: ((b2PrismaticJoint*)joint)->SetMotorSpeed(motor_speed * GetPhysicsScale()); break;
+            case e_revoluteJoint: ((b2RevoluteJoint*)joint)->SetMotorSpeed(motor_speed); break;
+            case e_wheelJoint: ((b2WheelJoint*)joint)->SetMotorSpeed(motor_speed); break;
+            default: return luaL_error(L, "b2d.joint.set_motor_speed can only be used with prismatic, revolute, or wheel joints.");
+        }
+        return 0;
+    }
+
+    static int Joint_GetMotorSpeed(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        b2Joint* joint = CheckJoint(L, 1);
+        switch (joint->GetType())
+        {
+            case e_prismaticJoint: lua_pushnumber(L, ((b2PrismaticJoint*)joint)->GetMotorSpeed() * GetInvPhysicsScale()); break;
+            case e_revoluteJoint: lua_pushnumber(L, ((b2RevoluteJoint*)joint)->GetMotorSpeed()); break;
+            case e_wheelJoint: lua_pushnumber(L, ((b2WheelJoint*)joint)->GetMotorSpeed()); break;
+            default: return luaL_error(L, "b2d.joint.get_motor_speed can only be used with prismatic, revolute, or wheel joints.");
+        }
+        return 1;
+    }
+
+    static int Joint_SetMaxMotorForce(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        b2PrismaticJoint* joint = (b2PrismaticJoint*)CheckJointType(L, 1, e_prismaticJoint, "set_max_motor_force", "prismatic");
+        CheckJointWorldUnlocked(L, joint, "set_max_motor_force");
+        joint->SetMaxMotorForce((float)luaL_checknumber(L, 2) * GetPhysicsScale());
+        return 0;
+    }
+
+    static int Joint_GetMaxMotorForce(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        b2PrismaticJoint* joint = (b2PrismaticJoint*)CheckJointType(L, 1, e_prismaticJoint, "get_max_motor_force", "prismatic");
+        lua_pushnumber(L, joint->GetMaxMotorForce() * GetInvPhysicsScale());
+        return 1;
+    }
+
+    static int Joint_GetMotorForce(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        b2PrismaticJoint* joint = (b2PrismaticJoint*)CheckJointType(L, 1, e_prismaticJoint, "get_motor_force", "prismatic");
+        float inv_dt = (float)luaL_optnumber(L, 2, 1.0);
+        lua_pushnumber(L, joint->GetMotorForce(inv_dt) * GetInvPhysicsScale());
+        return 1;
+    }
+
+    static int Joint_SetMaxMotorTorque(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        b2Joint* joint = CheckJoint(L, 1);
+        CheckJointWorldUnlocked(L, joint, "set_max_motor_torque");
+        float max_motor_torque = (float)luaL_checknumber(L, 2) * GetPhysicsScale();
+        switch (joint->GetType())
+        {
+            case e_revoluteJoint: ((b2RevoluteJoint*)joint)->SetMaxMotorTorque(max_motor_torque); break;
+            case e_wheelJoint: ((b2WheelJoint*)joint)->SetMaxMotorTorque(max_motor_torque); break;
+            default: return luaL_error(L, "b2d.joint.set_max_motor_torque can only be used with revolute or wheel joints.");
+        }
+        return 0;
+    }
+
+    static int Joint_GetMaxMotorTorque(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        b2Joint* joint = CheckJoint(L, 1);
+        switch (joint->GetType())
+        {
+            case e_revoluteJoint: lua_pushnumber(L, ((b2RevoluteJoint*)joint)->GetMaxMotorTorque() * GetInvPhysicsScale()); break;
+            case e_wheelJoint: lua_pushnumber(L, ((b2WheelJoint*)joint)->GetMaxMotorTorque() * GetInvPhysicsScale()); break;
+            default: return luaL_error(L, "b2d.joint.get_max_motor_torque can only be used with revolute or wheel joints.");
+        }
+        return 1;
+    }
+
+    static int Joint_GetMotorTorque(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        b2Joint* joint = CheckJoint(L, 1);
+        float inv_dt = (float)luaL_optnumber(L, 2, 1.0);
+        switch (joint->GetType())
+        {
+            case e_revoluteJoint: lua_pushnumber(L, ((b2RevoluteJoint*)joint)->GetMotorTorque(inv_dt) * GetInvPhysicsScale()); break;
+            case e_wheelJoint: lua_pushnumber(L, ((b2WheelJoint*)joint)->GetMotorTorque(inv_dt) * GetInvPhysicsScale()); break;
+            default: return luaL_error(L, "b2d.joint.get_motor_torque can only be used with revolute or wheel joints.");
+        }
+        return 1;
+    }
+
+    static int Joint_SetMaxForce(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        b2Joint* joint = CheckJoint(L, 1);
+        CheckJointWorldUnlocked(L, joint, "set_max_force");
+        float max_force = (float)luaL_checknumber(L, 2) * GetPhysicsScale();
+        switch (joint->GetType())
+        {
+            case e_mouseJoint: ((b2MouseJoint*)joint)->SetMaxForce(max_force); break;
+            case e_frictionJoint: ((b2FrictionJoint*)joint)->SetMaxForce(max_force); break;
+            default: return luaL_error(L, "b2d.joint.set_max_force can only be used with mouse or friction joints.");
+        }
+        return 0;
+    }
+
+    static int Joint_GetMaxForce(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        b2Joint* joint = CheckJoint(L, 1);
+        switch (joint->GetType())
+        {
+            case e_mouseJoint: lua_pushnumber(L, ((b2MouseJoint*)joint)->GetMaxForce() * GetInvPhysicsScale()); break;
+            case e_frictionJoint: lua_pushnumber(L, ((b2FrictionJoint*)joint)->GetMaxForce() * GetInvPhysicsScale()); break;
+            default: return luaL_error(L, "b2d.joint.get_max_force can only be used with mouse or friction joints.");
+        }
+        return 1;
+    }
+
+    static int Joint_SetMaxTorque(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        b2FrictionJoint* joint = (b2FrictionJoint*)CheckJointType(L, 1, e_frictionJoint, "set_max_torque", "friction");
+        CheckJointWorldUnlocked(L, joint, "set_max_torque");
+        joint->SetMaxTorque((float)luaL_checknumber(L, 2) * GetPhysicsScale());
+        return 0;
+    }
+
+    static int Joint_GetMaxTorque(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        b2FrictionJoint* joint = (b2FrictionJoint*)CheckJointType(L, 1, e_frictionJoint, "get_max_torque", "friction");
+        lua_pushnumber(L, joint->GetMaxTorque() * GetInvPhysicsScale());
+        return 1;
+    }
+
+    static int Joint_SetMaxLength(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        b2RopeJoint* joint = (b2RopeJoint*)CheckJointType(L, 1, e_ropeJoint, "set_max_length", "rope");
+        CheckJointWorldUnlocked(L, joint, "set_max_length");
+        joint->SetMaxLength((float)luaL_checknumber(L, 2) * GetPhysicsScale());
+        return 0;
+    }
+
+    static int Joint_GetMaxLength(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        b2RopeJoint* joint = (b2RopeJoint*)CheckJointType(L, 1, e_ropeJoint, "get_max_length", "rope");
+        lua_pushnumber(L, joint->GetMaxLength() * GetInvPhysicsScale());
+        return 1;
+    }
+
+    static int Joint_GetLimitState(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        b2RopeJoint* joint = (b2RopeJoint*)CheckJointType(L, 1, e_ropeJoint, "get_limit_state", "rope");
+        lua_pushinteger(L, joint->GetLimitState());
+        return 1;
+    }
+
+    static int Joint_GetGroundAnchorA(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        b2PulleyJoint* joint = (b2PulleyJoint*)CheckJointType(L, 1, e_pulleyJoint, "get_ground_anchor_a", "pulley");
+        dmScript::PushVector3(L, FromB2(joint->GetGroundAnchorA(), GetInvPhysicsScale()));
+        return 1;
+    }
+
+    static int Joint_GetGroundAnchorB(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        b2PulleyJoint* joint = (b2PulleyJoint*)CheckJointType(L, 1, e_pulleyJoint, "get_ground_anchor_b", "pulley");
+        dmScript::PushVector3(L, FromB2(joint->GetGroundAnchorB(), GetInvPhysicsScale()));
+        return 1;
+    }
+
+    static int Joint_GetLengthA(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        b2PulleyJoint* joint = (b2PulleyJoint*)CheckJointType(L, 1, e_pulleyJoint, "get_length_a", "pulley");
+        lua_pushnumber(L, joint->GetLengthA() * GetInvPhysicsScale());
+        return 1;
+    }
+
+    static int Joint_GetLengthB(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        b2PulleyJoint* joint = (b2PulleyJoint*)CheckJointType(L, 1, e_pulleyJoint, "get_length_b", "pulley");
+        lua_pushnumber(L, joint->GetLengthB() * GetInvPhysicsScale());
+        return 1;
+    }
+
+    static int Joint_SetRatio(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        b2GearJoint* joint = (b2GearJoint*)CheckJointType(L, 1, e_gearJoint, "set_ratio", "gear");
+        CheckJointWorldUnlocked(L, joint, "set_ratio");
+        joint->SetRatio((float)luaL_checknumber(L, 2));
+        return 0;
+    }
+
+    static int Joint_GetRatio(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        b2Joint* joint = CheckJoint(L, 1);
+        switch (joint->GetType())
+        {
+            case e_gearJoint: lua_pushnumber(L, ((b2GearJoint*)joint)->GetRatio()); break;
+            case e_pulleyJoint: lua_pushnumber(L, ((b2PulleyJoint*)joint)->GetRatio()); break;
+            default: return luaL_error(L, "b2d.joint.get_ratio can only be used with gear or pulley joints.");
+        }
+        return 1;
+    }
+
+    static int Joint_GetJoint1(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        B2DJointMeta* joint_meta = 0;
+        b2GearJoint* joint = (b2GearJoint*)CheckJointType(L, 1, &joint_meta, e_gearJoint, "get_joint1", "gear");
+        PushJoint(L, joint->GetJoint1(), joint_meta ? joint_meta->m_Collection : 0);
+        return 1;
+    }
+
+    static int Joint_GetJoint2(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        B2DJointMeta* joint_meta = 0;
+        b2GearJoint* joint = (b2GearJoint*)CheckJointType(L, 1, &joint_meta, e_gearJoint, "get_joint2", "gear");
+        PushJoint(L, joint->GetJoint2(), joint_meta ? joint_meta->m_Collection : 0);
+        return 1;
     }
 
     static int Joint_GetReactionForce(lua_State* L)
@@ -465,7 +1031,7 @@ namespace dmGameSystem
         def.lowerAngle = GetNumberField(L, def_index, "lower_angle", def.lowerAngle);
         def.upperAngle = GetNumberField(L, def_index, "upper_angle", def.upperAngle);
         def.enableMotor = GetBoolField(L, def_index, "enable_motor", def.enableMotor);
-        def.maxMotorTorque = GetNumberField(L, def_index, "max_motor_torque", def.maxMotorTorque);
+        def.maxMotorTorque = GetNumberField(L, def_index, "max_motor_torque", def.maxMotorTorque) * GetPhysicsScale();
         def.motorSpeed = GetNumberField(L, def_index, "motor_speed", def.motorSpeed);
 
         PushJoint(L, world->CreateJoint(&def), collection);
@@ -512,7 +1078,7 @@ namespace dmGameSystem
         ReadCommonAnchoredDef(L, def_index, &def.localAnchorA, &def.localAnchorB);
         def.localAxisA = GetVec2Field(L, def_index, "local_axis_a", def.localAxisA, 1.0f);
         def.enableMotor = GetBoolField(L, def_index, "enable_motor", def.enableMotor);
-        def.maxMotorTorque = GetNumberField(L, def_index, "max_motor_torque", def.maxMotorTorque);
+        def.maxMotorTorque = GetNumberField(L, def_index, "max_motor_torque", def.maxMotorTorque) * GetPhysicsScale();
         def.motorSpeed = GetNumberField(L, def_index, "motor_speed", def.motorSpeed);
         def.frequencyHz = GetNumberField(L, def_index, HasField(L, def_index, "frequency") ? "frequency" : "hertz", def.frequencyHz);
         def.dampingRatio = GetNumberField(L, def_index, HasField(L, def_index, "damping") ? "damping" : "damping_ratio", def.dampingRatio);
@@ -537,7 +1103,7 @@ namespace dmGameSystem
         ReadCommonDef(L, def_index, &def);
         ReadCommonAnchoredDef(L, def_index, &def.localAnchorA, &def.localAnchorB);
         def.maxForce = GetNumberField(L, def_index, "max_force", def.maxForce) * GetPhysicsScale();
-        def.maxTorque = GetNumberField(L, def_index, "max_torque", def.maxTorque);
+        def.maxTorque = GetNumberField(L, def_index, "max_torque", def.maxTorque) * GetPhysicsScale();
 
         PushJoint(L, world->CreateJoint(&def), collection);
         return 1;
@@ -592,9 +1158,8 @@ namespace dmGameSystem
     static int Joint_CreateGear(lua_State* L)
     {
         DM_LUA_STACK_CHECK(L, 1);
-        B2DLuaJoint* luajoint = CheckJointInternal(L, 1);
-        B2DJointMeta* joint_meta = GetJointMeta(L, luajoint);
-        b2Joint* joint1 = CheckJoint(L, 1);
+        B2DJointMeta* joint_meta = 0;
+        b2Joint* joint1 = CheckJoint(L, 1, &joint_meta);
         b2Joint* joint2 = CheckJoint(L, 2);
         b2World* world = joint1->GetBodyA()->GetWorld();
         if (world != joint2->GetBodyA()->GetWorld())
@@ -608,6 +1173,7 @@ namespace dmGameSystem
         int def_index = CheckDefinitionTable(L, 3);
 
         b2GearJointDef def;
+        ReadCommonDef(L, def_index, &def);
         def.bodyA = joint1->GetBodyA();
         def.bodyB = joint2->GetBodyB();
         def.joint1 = joint1;
@@ -653,8 +1219,57 @@ namespace dmGameSystem
         {"get_body_b", Joint_GetBodyB},
         {"get_local_anchor_a", Joint_GetLocalAnchorA},
         {"get_local_anchor_b", Joint_GetLocalAnchorB},
+        {"get_anchor_a", Joint_GetAnchorA},
+        {"get_anchor_b", Joint_GetAnchorB},
+        {"is_active", Joint_IsActive},
         {"get_collide_connected", Joint_GetCollideConnected},
         {"set_mouse_target", Joint_SetMouseTarget},
+        {"get_mouse_target", Joint_GetMouseTarget},
+        {"set_length", Joint_SetLength},
+        {"get_length", Joint_GetLength},
+        {"set_frequency", Joint_SetFrequency},
+        {"get_frequency", Joint_GetFrequency},
+        {"set_hertz", Joint_SetFrequency},
+        {"get_hertz", Joint_GetFrequency},
+        {"set_damping_ratio", Joint_SetDampingRatio},
+        {"get_damping_ratio", Joint_GetDampingRatio},
+        {"set_spring_damping_ratio", Joint_SetDampingRatio},
+        {"get_spring_damping_ratio", Joint_GetDampingRatio},
+        {"get_local_axis_a", Joint_GetLocalAxisA},
+        {"get_reference_angle", Joint_GetReferenceAngle},
+        {"get_joint_translation", Joint_GetJointTranslation},
+        {"get_joint_speed", Joint_GetJointSpeed},
+        {"get_joint_angle", Joint_GetJointAngle},
+        {"enable_limit", Joint_EnableLimit},
+        {"is_limit_enabled", Joint_IsLimitEnabled},
+        {"set_limits", Joint_SetLimits},
+        {"get_lower_limit", Joint_GetLowerLimit},
+        {"get_upper_limit", Joint_GetUpperLimit},
+        {"enable_motor", Joint_EnableMotor},
+        {"is_motor_enabled", Joint_IsMotorEnabled},
+        {"set_motor_speed", Joint_SetMotorSpeed},
+        {"get_motor_speed", Joint_GetMotorSpeed},
+        {"set_max_motor_force", Joint_SetMaxMotorForce},
+        {"get_max_motor_force", Joint_GetMaxMotorForce},
+        {"get_motor_force", Joint_GetMotorForce},
+        {"set_max_motor_torque", Joint_SetMaxMotorTorque},
+        {"get_max_motor_torque", Joint_GetMaxMotorTorque},
+        {"get_motor_torque", Joint_GetMotorTorque},
+        {"set_max_force", Joint_SetMaxForce},
+        {"get_max_force", Joint_GetMaxForce},
+        {"set_max_torque", Joint_SetMaxTorque},
+        {"get_max_torque", Joint_GetMaxTorque},
+        {"set_max_length", Joint_SetMaxLength},
+        {"get_max_length", Joint_GetMaxLength},
+        {"get_limit_state", Joint_GetLimitState},
+        {"get_ground_anchor_a", Joint_GetGroundAnchorA},
+        {"get_ground_anchor_b", Joint_GetGroundAnchorB},
+        {"get_length_a", Joint_GetLengthA},
+        {"get_length_b", Joint_GetLengthB},
+        {"set_ratio", Joint_SetRatio},
+        {"get_ratio", Joint_GetRatio},
+        {"get_joint1", Joint_GetJoint1},
+        {"get_joint2", Joint_GetJoint2},
         {"get_reaction_force", Joint_GetReactionForce},
         {"get_reaction_torque", Joint_GetReactionTorque},
         {"create_distance", Joint_CreateDistance},
@@ -692,6 +1307,10 @@ namespace dmGameSystem
         SET_CONSTANT(e_weldJoint, "JOINT_TYPE_WELD");
         SET_CONSTANT(e_frictionJoint, "JOINT_TYPE_FRICTION");
         SET_CONSTANT(e_ropeJoint, "JOINT_TYPE_ROPE");
+        SET_CONSTANT(e_inactiveLimit, "LIMIT_STATE_INACTIVE");
+        SET_CONSTANT(e_atLowerLimit, "LIMIT_STATE_AT_LOWER");
+        SET_CONSTANT(e_atUpperLimit, "LIMIT_STATE_AT_UPPER");
+        SET_CONSTANT(e_equalLimits, "LIMIT_STATE_EQUAL");
 
 #undef SET_CONSTANT
 

--- a/engine/gamesys/src/gamesys/scripts/box2d/v2/script_box2d_joint_v2.cpp
+++ b/engine/gamesys/src/gamesys/scripts/box2d/v2/script_box2d_joint_v2.cpp
@@ -447,7 +447,7 @@ namespace dmGameSystem
     {
         DM_LUA_STACK_CHECK(L, 1);
         b2DistanceJoint* joint = (b2DistanceJoint*)CheckJointType(L, 1, e_distanceJoint, "get_length", "distance");
-        lua_pushnumber(L, joint->GetLength() * GetInvPhysicsScale());
+        lua_pushnumber(L, joint->GetLength() * (lua_Number)GetInvPhysicsScale());
         return 1;
     }
 
@@ -548,8 +548,8 @@ namespace dmGameSystem
         b2Joint* joint = CheckJoint(L, 1);
         switch (joint->GetType())
         {
-            case e_prismaticJoint: lua_pushnumber(L, ((b2PrismaticJoint*)joint)->GetJointTranslation() * GetInvPhysicsScale()); break;
-            case e_wheelJoint: lua_pushnumber(L, ((b2WheelJoint*)joint)->GetJointTranslation() * GetInvPhysicsScale()); break;
+            case e_prismaticJoint: lua_pushnumber(L, ((b2PrismaticJoint*)joint)->GetJointTranslation() * (lua_Number)GetInvPhysicsScale()); break;
+            case e_wheelJoint: lua_pushnumber(L, ((b2WheelJoint*)joint)->GetJointTranslation() * (lua_Number)GetInvPhysicsScale()); break;
             default: return luaL_error(L, "b2d.joint.get_joint_translation can only be used with prismatic or wheel joints.");
         }
         return 1;
@@ -561,9 +561,9 @@ namespace dmGameSystem
         b2Joint* joint = CheckJoint(L, 1);
         switch (joint->GetType())
         {
-            case e_prismaticJoint: lua_pushnumber(L, ((b2PrismaticJoint*)joint)->GetJointSpeed() * GetInvPhysicsScale()); break;
+            case e_prismaticJoint: lua_pushnumber(L, ((b2PrismaticJoint*)joint)->GetJointSpeed() * (lua_Number)GetInvPhysicsScale()); break;
             case e_revoluteJoint: lua_pushnumber(L, ((b2RevoluteJoint*)joint)->GetJointSpeed()); break;
-            case e_wheelJoint: lua_pushnumber(L, ((b2WheelJoint*)joint)->GetJointSpeed() * GetInvPhysicsScale()); break;
+            case e_wheelJoint: lua_pushnumber(L, ((b2WheelJoint*)joint)->GetJointSpeed() * (lua_Number)GetInvPhysicsScale()); break;
             default: return luaL_error(L, "b2d.joint.get_joint_speed can only be used with prismatic, revolute, or wheel joints.");
         }
         return 1;
@@ -629,7 +629,7 @@ namespace dmGameSystem
         b2Joint* joint = CheckJoint(L, 1);
         switch (joint->GetType())
         {
-            case e_prismaticJoint: lua_pushnumber(L, ((b2PrismaticJoint*)joint)->GetLowerLimit() * GetInvPhysicsScale()); break;
+            case e_prismaticJoint: lua_pushnumber(L, ((b2PrismaticJoint*)joint)->GetLowerLimit() * (lua_Number)GetInvPhysicsScale()); break;
             case e_revoluteJoint: lua_pushnumber(L, ((b2RevoluteJoint*)joint)->GetLowerLimit()); break;
             default: return luaL_error(L, "b2d.joint.get_lower_limit can only be used with prismatic or revolute joints.");
         }
@@ -642,7 +642,7 @@ namespace dmGameSystem
         b2Joint* joint = CheckJoint(L, 1);
         switch (joint->GetType())
         {
-            case e_prismaticJoint: lua_pushnumber(L, ((b2PrismaticJoint*)joint)->GetUpperLimit() * GetInvPhysicsScale()); break;
+            case e_prismaticJoint: lua_pushnumber(L, ((b2PrismaticJoint*)joint)->GetUpperLimit() * (lua_Number)GetInvPhysicsScale()); break;
             case e_revoluteJoint: lua_pushnumber(L, ((b2RevoluteJoint*)joint)->GetUpperLimit()); break;
             default: return luaL_error(L, "b2d.joint.get_upper_limit can only be used with prismatic or revolute joints.");
         }
@@ -701,7 +701,7 @@ namespace dmGameSystem
         b2Joint* joint = CheckJoint(L, 1);
         switch (joint->GetType())
         {
-            case e_prismaticJoint: lua_pushnumber(L, ((b2PrismaticJoint*)joint)->GetMotorSpeed() * GetInvPhysicsScale()); break;
+            case e_prismaticJoint: lua_pushnumber(L, ((b2PrismaticJoint*)joint)->GetMotorSpeed() * (lua_Number)GetInvPhysicsScale()); break;
             case e_revoluteJoint: lua_pushnumber(L, ((b2RevoluteJoint*)joint)->GetMotorSpeed()); break;
             case e_wheelJoint: lua_pushnumber(L, ((b2WheelJoint*)joint)->GetMotorSpeed()); break;
             default: return luaL_error(L, "b2d.joint.get_motor_speed can only be used with prismatic, revolute, or wheel joints.");
@@ -722,7 +722,7 @@ namespace dmGameSystem
     {
         DM_LUA_STACK_CHECK(L, 1);
         b2PrismaticJoint* joint = (b2PrismaticJoint*)CheckJointType(L, 1, e_prismaticJoint, "get_max_motor_force", "prismatic");
-        lua_pushnumber(L, joint->GetMaxMotorForce() * GetInvPhysicsScale());
+        lua_pushnumber(L, joint->GetMaxMotorForce() * (lua_Number)GetInvPhysicsScale());
         return 1;
     }
 
@@ -731,7 +731,7 @@ namespace dmGameSystem
         DM_LUA_STACK_CHECK(L, 1);
         b2PrismaticJoint* joint = (b2PrismaticJoint*)CheckJointType(L, 1, e_prismaticJoint, "get_motor_force", "prismatic");
         float inv_dt = (float)luaL_optnumber(L, 2, 1.0);
-        lua_pushnumber(L, joint->GetMotorForce(inv_dt) * GetInvPhysicsScale());
+        lua_pushnumber(L, joint->GetMotorForce(inv_dt) * (lua_Number)GetInvPhysicsScale());
         return 1;
     }
 
@@ -756,8 +756,8 @@ namespace dmGameSystem
         b2Joint* joint = CheckJoint(L, 1);
         switch (joint->GetType())
         {
-            case e_revoluteJoint: lua_pushnumber(L, ((b2RevoluteJoint*)joint)->GetMaxMotorTorque() * GetInvPhysicsScale()); break;
-            case e_wheelJoint: lua_pushnumber(L, ((b2WheelJoint*)joint)->GetMaxMotorTorque() * GetInvPhysicsScale()); break;
+            case e_revoluteJoint: lua_pushnumber(L, ((b2RevoluteJoint*)joint)->GetMaxMotorTorque() * (lua_Number)GetInvPhysicsScale()); break;
+            case e_wheelJoint: lua_pushnumber(L, ((b2WheelJoint*)joint)->GetMaxMotorTorque() * (lua_Number)GetInvPhysicsScale()); break;
             default: return luaL_error(L, "b2d.joint.get_max_motor_torque can only be used with revolute or wheel joints.");
         }
         return 1;
@@ -770,8 +770,8 @@ namespace dmGameSystem
         float inv_dt = (float)luaL_optnumber(L, 2, 1.0);
         switch (joint->GetType())
         {
-            case e_revoluteJoint: lua_pushnumber(L, ((b2RevoluteJoint*)joint)->GetMotorTorque(inv_dt) * GetInvPhysicsScale()); break;
-            case e_wheelJoint: lua_pushnumber(L, ((b2WheelJoint*)joint)->GetMotorTorque(inv_dt) * GetInvPhysicsScale()); break;
+            case e_revoluteJoint: lua_pushnumber(L, ((b2RevoluteJoint*)joint)->GetMotorTorque(inv_dt) * (lua_Number)GetInvPhysicsScale()); break;
+            case e_wheelJoint: lua_pushnumber(L, ((b2WheelJoint*)joint)->GetMotorTorque(inv_dt) * (lua_Number)GetInvPhysicsScale()); break;
             default: return luaL_error(L, "b2d.joint.get_motor_torque can only be used with revolute or wheel joints.");
         }
         return 1;
@@ -798,8 +798,8 @@ namespace dmGameSystem
         b2Joint* joint = CheckJoint(L, 1);
         switch (joint->GetType())
         {
-            case e_mouseJoint: lua_pushnumber(L, ((b2MouseJoint*)joint)->GetMaxForce() * GetInvPhysicsScale()); break;
-            case e_frictionJoint: lua_pushnumber(L, ((b2FrictionJoint*)joint)->GetMaxForce() * GetInvPhysicsScale()); break;
+            case e_mouseJoint: lua_pushnumber(L, ((b2MouseJoint*)joint)->GetMaxForce() * (lua_Number)GetInvPhysicsScale()); break;
+            case e_frictionJoint: lua_pushnumber(L, ((b2FrictionJoint*)joint)->GetMaxForce() * (lua_Number)GetInvPhysicsScale()); break;
             default: return luaL_error(L, "b2d.joint.get_max_force can only be used with mouse or friction joints.");
         }
         return 1;
@@ -818,7 +818,7 @@ namespace dmGameSystem
     {
         DM_LUA_STACK_CHECK(L, 1);
         b2FrictionJoint* joint = (b2FrictionJoint*)CheckJointType(L, 1, e_frictionJoint, "get_max_torque", "friction");
-        lua_pushnumber(L, joint->GetMaxTorque() * GetInvPhysicsScale());
+        lua_pushnumber(L, joint->GetMaxTorque() * (lua_Number)GetInvPhysicsScale());
         return 1;
     }
 
@@ -835,7 +835,7 @@ namespace dmGameSystem
     {
         DM_LUA_STACK_CHECK(L, 1);
         b2RopeJoint* joint = (b2RopeJoint*)CheckJointType(L, 1, e_ropeJoint, "get_max_length", "rope");
-        lua_pushnumber(L, joint->GetMaxLength() * GetInvPhysicsScale());
+        lua_pushnumber(L, joint->GetMaxLength() * (lua_Number)GetInvPhysicsScale());
         return 1;
     }
 
@@ -867,7 +867,7 @@ namespace dmGameSystem
     {
         DM_LUA_STACK_CHECK(L, 1);
         b2PulleyJoint* joint = (b2PulleyJoint*)CheckJointType(L, 1, e_pulleyJoint, "get_length_a", "pulley");
-        lua_pushnumber(L, joint->GetLengthA() * GetInvPhysicsScale());
+        lua_pushnumber(L, joint->GetLengthA() * (lua_Number)GetInvPhysicsScale());
         return 1;
     }
 
@@ -875,7 +875,7 @@ namespace dmGameSystem
     {
         DM_LUA_STACK_CHECK(L, 1);
         b2PulleyJoint* joint = (b2PulleyJoint*)CheckJointType(L, 1, e_pulleyJoint, "get_length_b", "pulley");
-        lua_pushnumber(L, joint->GetLengthB() * GetInvPhysicsScale());
+        lua_pushnumber(L, joint->GetLengthB() * (lua_Number)GetInvPhysicsScale());
         return 1;
     }
 
@@ -933,7 +933,7 @@ namespace dmGameSystem
         DM_LUA_STACK_CHECK(L, 1);
         b2Joint* joint = CheckJoint(L, 1);
         float inv_dt = (float)luaL_optnumber(L, 2, 1.0);
-        lua_pushnumber(L, joint->GetReactionTorque(inv_dt) * GetInvPhysicsScale());
+        lua_pushnumber(L, joint->GetReactionTorque(inv_dt) * (lua_Number)GetInvPhysicsScale());
         return 1;
     }
 

--- a/engine/gamesys/src/gamesys/scripts/box2d/v2/script_box2d_joint_v2.cpp
+++ b/engine/gamesys/src/gamesys/scripts/box2d/v2/script_box2d_joint_v2.cpp
@@ -1,0 +1,754 @@
+// Copyright 2020-2026 The Defold Foundation
+// Copyright 2014-2020 King
+// Copyright 2009-2014 Ragnar Svensson, Christian Murray
+// Licensed under the Defold License version 1.0 (the "License"); you may not use
+// this file except in compliance with the License.
+
+#include <Box2D/Dynamics/b2Body.h>
+#include <Box2D/Dynamics/b2World.h>
+#include <Box2D/Dynamics/Joints/b2DistanceJoint.h>
+#include <Box2D/Dynamics/Joints/b2FrictionJoint.h>
+#include <Box2D/Dynamics/Joints/b2GearJoint.h>
+#include <Box2D/Dynamics/Joints/b2Joint.h>
+#include <Box2D/Dynamics/Joints/b2MouseJoint.h>
+#include <Box2D/Dynamics/Joints/b2PrismaticJoint.h>
+#include <Box2D/Dynamics/Joints/b2PulleyJoint.h>
+#include <Box2D/Dynamics/Joints/b2RevoluteJoint.h>
+#include <Box2D/Dynamics/Joints/b2RopeJoint.h>
+#include <Box2D/Dynamics/Joints/b2WeldJoint.h>
+#include <Box2D/Dynamics/Joints/b2WheelJoint.h>
+
+#include <dlib/opaque_handle_container.h>
+#include <dmsdk/dlib/hashtable.h>
+#include <gameobject/script.h>
+
+#include "gamesys.h"
+#include "gamesys_private.h"
+#include "script_box2d_v2.h"
+
+extern "C"
+{
+#include <lua/lauxlib.h>
+#include <lua/lualib.h>
+}
+
+namespace dmGameSystem
+{
+    static uint32_t TYPE_HASH_JOINT = 0;
+
+    #define BOX2D_TYPE_NAME_JOINT "b2joint"
+
+    struct B2DLuaJoint
+    {
+        HOpaqueHandle             m_Handle;
+    };
+
+    struct B2DJointMeta
+    {
+        dmGameObject::HCollection m_Collection;
+    };
+
+    static dmOpaqueHandleContainer<uintptr_t> g_JointHandles;
+    static dmHashTable64<HOpaqueHandle>       g_JointToHandle;
+    static dmHashTable32<B2DJointMeta>        g_JointMeta;
+
+    static uint64_t JointPtrToKey(const b2Joint* joint)
+    {
+        return (uint64_t)(uintptr_t)joint;
+    }
+
+    static int AbsIndex(lua_State* L, int index)
+    {
+        return index < 0 ? lua_gettop(L) + index + 1 : index;
+    }
+
+    static b2Vec2 CheckVec2(lua_State* L, int index, float scale)
+    {
+        dmVMath::Vector3* v = dmScript::CheckVector3(L, index);
+        return b2Vec2(v->getX() * scale, v->getY() * scale);
+    }
+
+    static dmVMath::Vector3 FromB2(const b2Vec2& p, float inv_scale)
+    {
+        return dmVMath::Vector3(p.x * inv_scale, p.y * inv_scale, 0);
+    }
+
+    static bool HasField(lua_State* L, int table_index, const char* field)
+    {
+        if (table_index == 0)
+        {
+            return false;
+        }
+        lua_getfield(L, table_index, field);
+        bool has_field = !lua_isnil(L, -1);
+        lua_pop(L, 1);
+        return has_field;
+    }
+
+    static bool GetBoolField(lua_State* L, int table_index, const char* field, bool default_value)
+    {
+        if (table_index == 0)
+        {
+            return default_value;
+        }
+        lua_getfield(L, table_index, field);
+        bool value = lua_isnil(L, -1) ? default_value : lua_toboolean(L, -1);
+        lua_pop(L, 1);
+        return value;
+    }
+
+    static float GetNumberField(lua_State* L, int table_index, const char* field, float default_value)
+    {
+        if (table_index == 0)
+        {
+            return default_value;
+        }
+        lua_getfield(L, table_index, field);
+        float value = lua_isnil(L, -1) ? default_value : (float)luaL_checknumber(L, -1);
+        lua_pop(L, 1);
+        return value;
+    }
+
+    static b2Vec2 GetVec2Field(lua_State* L, int table_index, const char* field, b2Vec2 default_value, float scale)
+    {
+        if (table_index == 0)
+        {
+            return default_value;
+        }
+        lua_getfield(L, table_index, field);
+        b2Vec2 value = lua_isnil(L, -1) ? default_value : CheckVec2(L, -1, scale);
+        lua_pop(L, 1);
+        return value;
+    }
+
+    static int CheckDefinitionTable(lua_State* L, int index)
+    {
+        if (lua_isnoneornil(L, index))
+        {
+            return 0;
+        }
+        luaL_checktype(L, index, LUA_TTABLE);
+        return AbsIndex(L, index);
+    }
+
+    static void EnsureJointHandleCapacity()
+    {
+        if (g_JointHandles.Full())
+        {
+            g_JointHandles.Allocate(32);
+            g_JointToHandle.OffsetCapacity(32);
+            g_JointMeta.OffsetCapacity(32);
+        }
+    }
+
+    static void InvalidateJointHandle(HOpaqueHandle handle)
+    {
+        uintptr_t* joint_ptr = g_JointHandles.Get(handle);
+        if (!joint_ptr)
+            return;
+
+        HOpaqueHandle* mapped_handle = g_JointToHandle.Get(JointPtrToKey((b2Joint*)joint_ptr));
+        if (mapped_handle && *mapped_handle == handle)
+        {
+            g_JointToHandle.Erase(JointPtrToKey((b2Joint*)joint_ptr));
+        }
+
+        if (g_JointMeta.Get(handle))
+        {
+            g_JointMeta.Erase(handle);
+        }
+        g_JointHandles.Release(handle);
+    }
+
+    static void RegisterJointHandle(b2Joint* joint, dmGameObject::HCollection collection, HOpaqueHandle* out_handle)
+    {
+        assert(joint);
+        EnsureJointHandleCapacity();
+
+        HOpaqueHandle* existing_handle = g_JointToHandle.Get(JointPtrToKey(joint));
+        if (existing_handle && g_JointHandles.Get(*existing_handle))
+        {
+            B2DJointMeta* joint_meta = g_JointMeta.Get(*existing_handle);
+            if (joint_meta)
+            {
+                joint_meta->m_Collection = collection;
+            }
+            *out_handle = *existing_handle;
+            return;
+        }
+
+        HOpaqueHandle handle = g_JointHandles.Put((uintptr_t*)joint);
+        g_JointToHandle.Put(JointPtrToKey(joint), handle);
+
+        B2DJointMeta joint_meta = {};
+        joint_meta.m_Collection = collection;
+        g_JointMeta.Put(handle, joint_meta);
+
+        *out_handle = handle;
+    }
+
+    bool IsJointTracked(b2Joint* joint)
+    {
+        if (!joint)
+        {
+            return false;
+        }
+
+        HOpaqueHandle* handle = g_JointToHandle.Get(JointPtrToKey(joint));
+        return handle && g_JointHandles.Get(*handle);
+    }
+
+    void PushJoint(lua_State* L, b2Joint* joint, dmGameObject::HCollection collection)
+    {
+        B2DLuaJoint* luajoint = (B2DLuaJoint*)lua_newuserdata(L, sizeof(B2DLuaJoint));
+        RegisterJointHandle(joint, collection, &luajoint->m_Handle);
+        luaL_getmetatable(L, BOX2D_TYPE_NAME_JOINT);
+        lua_setmetatable(L, -2);
+    }
+
+    static B2DLuaJoint* CheckJointInternal(lua_State* L, int index)
+    {
+        return (B2DLuaJoint*)dmScript::CheckUserType(L, index, TYPE_HASH_JOINT, "Expected user type " BOX2D_TYPE_NAME_JOINT);
+    }
+
+    static b2Joint* CheckJoint(lua_State* L, int index)
+    {
+        B2DLuaJoint* luajoint = CheckJointInternal(L, index);
+        uintptr_t* joint_ptr = g_JointHandles.Get(luajoint->m_Handle);
+        if (!joint_ptr)
+        {
+            luaL_error(L, "Invalid b2joint handle.");
+            return 0;
+        }
+        return (b2Joint*)joint_ptr;
+    }
+
+    static B2DJointMeta* GetJointMeta(lua_State* L, B2DLuaJoint* luajoint)
+    {
+        B2DJointMeta* joint_meta = g_JointMeta.Get(luajoint->m_Handle);
+        if (!joint_meta)
+        {
+            luaL_error(L, "Invalid b2joint handle.");
+            return 0;
+        }
+        return joint_meta;
+    }
+
+    static B2DLuaJoint* ToJoint(lua_State* L, int index)
+    {
+        return (B2DLuaJoint*)dmScript::ToUserType(L, index, TYPE_HASH_JOINT);
+    }
+
+    static void CheckJointDefBodies(lua_State* L, int body_a_index, int body_b_index, b2Body** body_a, b2Body** body_b, b2World** world)
+    {
+        body_a_index = AbsIndex(L, body_a_index);
+        body_b_index = AbsIndex(L, body_b_index);
+        *body_a = CheckBody(L, body_a_index);
+        *body_b = CheckBody(L, body_b_index);
+        b2World* world_a = (*body_a)->GetWorld();
+        b2World* world_b = (*body_b)->GetWorld();
+        if (world_a != world_b)
+        {
+            luaL_error(L, "joints can only be connected to bodies in the same Box2D world.");
+            return;
+        }
+        if (world_a->IsLocked())
+        {
+            luaL_error(L, "Could not create joint. The world is locked.");
+            return;
+        }
+        *world = world_a;
+    }
+
+    static void ReadCommonDef(lua_State* L, int table_index, b2JointDef* def)
+    {
+        def->collideConnected = GetBoolField(L, table_index, "collide_connected", def->collideConnected);
+    }
+
+    static void ReadCommonAnchoredDef(lua_State* L, int table_index, b2Vec2* local_anchor_a, b2Vec2* local_anchor_b)
+    {
+        *local_anchor_a = GetVec2Field(L, table_index, "local_anchor_a", *local_anchor_a, GetPhysicsScale());
+        *local_anchor_b = GetVec2Field(L, table_index, "local_anchor_b", *local_anchor_b, GetPhysicsScale());
+    }
+
+    static int Joint_Destroy(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        B2DLuaJoint* luajoint = CheckJointInternal(L, 1);
+        b2Joint* joint = CheckJoint(L, 1);
+        b2World* world = joint->GetBodyA()->GetWorld();
+        if (world->IsLocked())
+        {
+            return luaL_error(L, "Could not destroy joint. The world is locked.");
+        }
+        world->DestroyJoint(joint);
+        InvalidateJointHandle(luajoint->m_Handle);
+        return 0;
+    }
+
+    static int Joint_GetType(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        lua_pushinteger(L, CheckJoint(L, 1)->GetType());
+        return 1;
+    }
+
+    static int Joint_GetBodyA(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        B2DLuaJoint* luajoint = CheckJointInternal(L, 1);
+        B2DJointMeta* joint_meta = GetJointMeta(L, luajoint);
+        b2Body* body = CheckJoint(L, 1)->GetBodyA();
+        PushBody(L, body, joint_meta ? joint_meta->m_Collection : 0, GetBodyInstanceId(body));
+        return 1;
+    }
+
+    static int Joint_GetBodyB(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        B2DLuaJoint* luajoint = CheckJointInternal(L, 1);
+        B2DJointMeta* joint_meta = GetJointMeta(L, luajoint);
+        b2Body* body = CheckJoint(L, 1)->GetBodyB();
+        PushBody(L, body, joint_meta ? joint_meta->m_Collection : 0, GetBodyInstanceId(body));
+        return 1;
+    }
+
+    static int Joint_GetLocalAnchorA(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        b2Joint* joint = CheckJoint(L, 1);
+        dmScript::PushVector3(L, FromB2(joint->GetBodyA()->GetLocalPoint(joint->GetAnchorA()), GetInvPhysicsScale()));
+        return 1;
+    }
+
+    static int Joint_GetLocalAnchorB(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        b2Joint* joint = CheckJoint(L, 1);
+        dmScript::PushVector3(L, FromB2(joint->GetBodyB()->GetLocalPoint(joint->GetAnchorB()), GetInvPhysicsScale()));
+        return 1;
+    }
+
+    static int Joint_GetCollideConnected(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        lua_pushboolean(L, CheckJoint(L, 1)->GetCollideConnected());
+        return 1;
+    }
+
+    static int Joint_SetCollideConnected(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        CheckJoint(L, 1);
+        return luaL_error(L, "b2d.joint.set_collide_connected is only supported by Box2D v3.");
+    }
+
+    static int Joint_SetMouseTarget(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        b2Joint* joint = CheckJoint(L, 1);
+        if (joint->GetType() != e_mouseJoint)
+        {
+            return luaL_error(L, "b2d.joint.set_mouse_target can only be used with mouse joints.");
+        }
+        b2World* world = joint->GetBodyA()->GetWorld();
+        if (world->IsLocked())
+        {
+            return luaL_error(L, "Could not set mouse joint target. The world is locked.");
+        }
+        ((b2MouseJoint*)joint)->SetTarget(CheckVec2(L, 2, GetPhysicsScale()));
+        return 0;
+    }
+
+    static int Joint_GetReactionForce(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        b2Joint* joint = CheckJoint(L, 1);
+        float inv_dt = (float)luaL_optnumber(L, 2, 1.0);
+        dmScript::PushVector3(L, FromB2(joint->GetReactionForce(inv_dt), GetInvPhysicsScale()));
+        return 1;
+    }
+
+    static int Joint_GetReactionTorque(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        b2Joint* joint = CheckJoint(L, 1);
+        float inv_dt = (float)luaL_optnumber(L, 2, 1.0);
+        lua_pushnumber(L, joint->GetReactionTorque(inv_dt) * GetInvPhysicsScale());
+        return 1;
+    }
+
+    static int Joint_CreateDistance(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        dmGameObject::HCollection collection = GetBodyCollection(L, 1);
+        b2Body* body_a = 0;
+        b2Body* body_b = 0;
+        b2World* world = 0;
+        CheckJointDefBodies(L, 1, 2, &body_a, &body_b, &world);
+        int def_index = CheckDefinitionTable(L, 3);
+
+        b2DistanceJointDef def;
+        def.bodyA = body_a;
+        def.bodyB = body_b;
+        ReadCommonDef(L, def_index, &def);
+        ReadCommonAnchoredDef(L, def_index, &def.localAnchorA, &def.localAnchorB);
+        def.length = GetNumberField(L, def_index, "length", def.length) * GetPhysicsScale();
+        def.frequencyHz = GetNumberField(L, def_index, HasField(L, def_index, "frequency") ? "frequency" : "hertz", def.frequencyHz);
+        def.dampingRatio = GetNumberField(L, def_index, HasField(L, def_index, "damping") ? "damping" : "damping_ratio", def.dampingRatio);
+
+        PushJoint(L, world->CreateJoint(&def), collection);
+        return 1;
+    }
+
+    static int Joint_CreateMouse(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        dmGameObject::HCollection collection = GetBodyCollection(L, 1);
+        b2Body* body_a = 0;
+        b2Body* body_b = 0;
+        b2World* world = 0;
+        CheckJointDefBodies(L, 1, 2, &body_a, &body_b, &world);
+        int def_index = CheckDefinitionTable(L, 3);
+
+        b2MouseJointDef def;
+        def.bodyA = body_a;
+        def.bodyB = body_b;
+        ReadCommonDef(L, def_index, &def);
+        def.target = GetVec2Field(L, def_index, "target", def.target, GetPhysicsScale());
+        def.maxForce = GetNumberField(L, def_index, "max_force", def.maxForce) * GetPhysicsScale();
+        def.frequencyHz = GetNumberField(L, def_index, HasField(L, def_index, "frequency") ? "frequency" : "hertz", def.frequencyHz);
+        def.dampingRatio = GetNumberField(L, def_index, HasField(L, def_index, "damping") ? "damping" : "damping_ratio", def.dampingRatio);
+
+        PushJoint(L, world->CreateJoint(&def), collection);
+        return 1;
+    }
+
+    static int Joint_CreatePrismatic(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        dmGameObject::HCollection collection = GetBodyCollection(L, 1);
+        b2Body* body_a = 0;
+        b2Body* body_b = 0;
+        b2World* world = 0;
+        CheckJointDefBodies(L, 1, 2, &body_a, &body_b, &world);
+        int def_index = CheckDefinitionTable(L, 3);
+
+        b2PrismaticJointDef def;
+        def.bodyA = body_a;
+        def.bodyB = body_b;
+        ReadCommonDef(L, def_index, &def);
+        ReadCommonAnchoredDef(L, def_index, &def.localAnchorA, &def.localAnchorB);
+        def.localAxisA = GetVec2Field(L, def_index, "local_axis_a", def.localAxisA, 1.0f);
+        def.referenceAngle = GetNumberField(L, def_index, "reference_angle", def.referenceAngle);
+        def.enableLimit = GetBoolField(L, def_index, "enable_limit", def.enableLimit);
+        def.lowerTranslation = GetNumberField(L, def_index, "lower_translation", def.lowerTranslation) * GetPhysicsScale();
+        def.upperTranslation = GetNumberField(L, def_index, "upper_translation", def.upperTranslation) * GetPhysicsScale();
+        def.enableMotor = GetBoolField(L, def_index, "enable_motor", def.enableMotor);
+        def.maxMotorForce = GetNumberField(L, def_index, "max_motor_force", def.maxMotorForce) * GetPhysicsScale();
+        def.motorSpeed = GetNumberField(L, def_index, "motor_speed", def.motorSpeed) * GetPhysicsScale();
+
+        PushJoint(L, world->CreateJoint(&def), collection);
+        return 1;
+    }
+
+    static int Joint_CreateRevolute(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        dmGameObject::HCollection collection = GetBodyCollection(L, 1);
+        b2Body* body_a = 0;
+        b2Body* body_b = 0;
+        b2World* world = 0;
+        CheckJointDefBodies(L, 1, 2, &body_a, &body_b, &world);
+        int def_index = CheckDefinitionTable(L, 3);
+
+        b2RevoluteJointDef def;
+        def.bodyA = body_a;
+        def.bodyB = body_b;
+        ReadCommonDef(L, def_index, &def);
+        ReadCommonAnchoredDef(L, def_index, &def.localAnchorA, &def.localAnchorB);
+        def.referenceAngle = GetNumberField(L, def_index, "reference_angle", def.referenceAngle);
+        def.enableLimit = GetBoolField(L, def_index, "enable_limit", def.enableLimit);
+        def.lowerAngle = GetNumberField(L, def_index, "lower_angle", def.lowerAngle);
+        def.upperAngle = GetNumberField(L, def_index, "upper_angle", def.upperAngle);
+        def.enableMotor = GetBoolField(L, def_index, "enable_motor", def.enableMotor);
+        def.maxMotorTorque = GetNumberField(L, def_index, "max_motor_torque", def.maxMotorTorque);
+        def.motorSpeed = GetNumberField(L, def_index, "motor_speed", def.motorSpeed);
+
+        PushJoint(L, world->CreateJoint(&def), collection);
+        return 1;
+    }
+
+    static int Joint_CreateWeld(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        dmGameObject::HCollection collection = GetBodyCollection(L, 1);
+        b2Body* body_a = 0;
+        b2Body* body_b = 0;
+        b2World* world = 0;
+        CheckJointDefBodies(L, 1, 2, &body_a, &body_b, &world);
+        int def_index = CheckDefinitionTable(L, 3);
+
+        b2WeldJointDef def;
+        def.bodyA = body_a;
+        def.bodyB = body_b;
+        ReadCommonDef(L, def_index, &def);
+        ReadCommonAnchoredDef(L, def_index, &def.localAnchorA, &def.localAnchorB);
+        def.referenceAngle = GetNumberField(L, def_index, "reference_angle", def.referenceAngle);
+        def.frequencyHz = GetNumberField(L, def_index, HasField(L, def_index, "frequency") ? "frequency" : "hertz", def.frequencyHz);
+        def.dampingRatio = GetNumberField(L, def_index, HasField(L, def_index, "damping") ? "damping" : "damping_ratio", def.dampingRatio);
+
+        PushJoint(L, world->CreateJoint(&def), collection);
+        return 1;
+    }
+
+    static int Joint_CreateWheel(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        dmGameObject::HCollection collection = GetBodyCollection(L, 1);
+        b2Body* body_a = 0;
+        b2Body* body_b = 0;
+        b2World* world = 0;
+        CheckJointDefBodies(L, 1, 2, &body_a, &body_b, &world);
+        int def_index = CheckDefinitionTable(L, 3);
+
+        b2WheelJointDef def;
+        def.bodyA = body_a;
+        def.bodyB = body_b;
+        ReadCommonDef(L, def_index, &def);
+        ReadCommonAnchoredDef(L, def_index, &def.localAnchorA, &def.localAnchorB);
+        def.localAxisA = GetVec2Field(L, def_index, "local_axis_a", def.localAxisA, 1.0f);
+        def.enableMotor = GetBoolField(L, def_index, "enable_motor", def.enableMotor);
+        def.maxMotorTorque = GetNumberField(L, def_index, "max_motor_torque", def.maxMotorTorque);
+        def.motorSpeed = GetNumberField(L, def_index, "motor_speed", def.motorSpeed);
+        def.frequencyHz = GetNumberField(L, def_index, HasField(L, def_index, "frequency") ? "frequency" : "hertz", def.frequencyHz);
+        def.dampingRatio = GetNumberField(L, def_index, HasField(L, def_index, "damping") ? "damping" : "damping_ratio", def.dampingRatio);
+
+        PushJoint(L, world->CreateJoint(&def), collection);
+        return 1;
+    }
+
+    static int Joint_CreateFriction(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        dmGameObject::HCollection collection = GetBodyCollection(L, 1);
+        b2Body* body_a = 0;
+        b2Body* body_b = 0;
+        b2World* world = 0;
+        CheckJointDefBodies(L, 1, 2, &body_a, &body_b, &world);
+        int def_index = CheckDefinitionTable(L, 3);
+
+        b2FrictionJointDef def;
+        def.bodyA = body_a;
+        def.bodyB = body_b;
+        ReadCommonDef(L, def_index, &def);
+        ReadCommonAnchoredDef(L, def_index, &def.localAnchorA, &def.localAnchorB);
+        def.maxForce = GetNumberField(L, def_index, "max_force", def.maxForce) * GetPhysicsScale();
+        def.maxTorque = GetNumberField(L, def_index, "max_torque", def.maxTorque);
+
+        PushJoint(L, world->CreateJoint(&def), collection);
+        return 1;
+    }
+
+    static int Joint_CreateRope(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        dmGameObject::HCollection collection = GetBodyCollection(L, 1);
+        b2Body* body_a = 0;
+        b2Body* body_b = 0;
+        b2World* world = 0;
+        CheckJointDefBodies(L, 1, 2, &body_a, &body_b, &world);
+        int def_index = CheckDefinitionTable(L, 3);
+
+        b2RopeJointDef def;
+        def.bodyA = body_a;
+        def.bodyB = body_b;
+        ReadCommonDef(L, def_index, &def);
+        ReadCommonAnchoredDef(L, def_index, &def.localAnchorA, &def.localAnchorB);
+        def.maxLength = GetNumberField(L, def_index, "max_length", def.maxLength) * GetPhysicsScale();
+
+        PushJoint(L, world->CreateJoint(&def), collection);
+        return 1;
+    }
+
+    static int Joint_CreatePulley(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        dmGameObject::HCollection collection = GetBodyCollection(L, 1);
+        b2Body* body_a = 0;
+        b2Body* body_b = 0;
+        b2World* world = 0;
+        CheckJointDefBodies(L, 1, 2, &body_a, &body_b, &world);
+        int def_index = CheckDefinitionTable(L, 3);
+
+        b2PulleyJointDef def;
+        def.bodyA = body_a;
+        def.bodyB = body_b;
+        ReadCommonDef(L, def_index, &def);
+        ReadCommonAnchoredDef(L, def_index, &def.localAnchorA, &def.localAnchorB);
+        def.groundAnchorA = GetVec2Field(L, def_index, "ground_anchor_a", def.groundAnchorA, GetPhysicsScale());
+        def.groundAnchorB = GetVec2Field(L, def_index, "ground_anchor_b", def.groundAnchorB, GetPhysicsScale());
+        def.lengthA = GetNumberField(L, def_index, "length_a", def.lengthA) * GetPhysicsScale();
+        def.lengthB = GetNumberField(L, def_index, "length_b", def.lengthB) * GetPhysicsScale();
+        def.ratio = GetNumberField(L, def_index, "ratio", def.ratio);
+
+        PushJoint(L, world->CreateJoint(&def), collection);
+        return 1;
+    }
+
+    static int Joint_CreateGear(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        B2DLuaJoint* luajoint = CheckJointInternal(L, 1);
+        B2DJointMeta* joint_meta = GetJointMeta(L, luajoint);
+        b2Joint* joint1 = CheckJoint(L, 1);
+        b2Joint* joint2 = CheckJoint(L, 2);
+        b2World* world = joint1->GetBodyA()->GetWorld();
+        if (world != joint2->GetBodyA()->GetWorld())
+        {
+            return luaL_error(L, "gear joints can only connect joints in the same Box2D world.");
+        }
+        if (world->IsLocked())
+        {
+            return luaL_error(L, "Could not create joint. The world is locked.");
+        }
+        int def_index = CheckDefinitionTable(L, 3);
+
+        b2GearJointDef def;
+        def.bodyA = joint1->GetBodyA();
+        def.bodyB = joint2->GetBodyB();
+        def.joint1 = joint1;
+        def.joint2 = joint2;
+        def.ratio = GetNumberField(L, def_index, "ratio", def.ratio);
+
+        PushJoint(L, world->CreateJoint(&def), joint_meta ? joint_meta->m_Collection : 0);
+        return 1;
+    }
+
+    static int Joint_tostring(lua_State* L)
+    {
+        b2Joint* joint = CheckJoint(L, 1);
+        lua_pushfstring(L, "Box2D.%s = %p", BOX2D_TYPE_NAME_JOINT, joint);
+        return 1;
+    }
+
+    static int Joint_eq(lua_State* L)
+    {
+        B2DLuaJoint* a = ToJoint(L, 1);
+        B2DLuaJoint* b = ToJoint(L, 2);
+        lua_pushboolean(L, a && b && a->m_Handle == b->m_Handle);
+        return 1;
+    }
+
+    static const luaL_reg Joint_methods[] =
+    {
+        {0, 0}
+    };
+
+    static const luaL_reg Joint_meta[] =
+    {
+        {"__tostring", Joint_tostring},
+        {"__eq", Joint_eq},
+        {0, 0}
+    };
+
+    static const luaL_reg Joint_functions[] =
+    {
+        {"destroy", Joint_Destroy},
+        {"get_type", Joint_GetType},
+        {"get_body_a", Joint_GetBodyA},
+        {"get_body_b", Joint_GetBodyB},
+        {"get_local_anchor_a", Joint_GetLocalAnchorA},
+        {"get_local_anchor_b", Joint_GetLocalAnchorB},
+        {"get_collide_connected", Joint_GetCollideConnected},
+        {"set_collide_connected", Joint_SetCollideConnected},
+        {"set_mouse_target", Joint_SetMouseTarget},
+        {"get_reaction_force", Joint_GetReactionForce},
+        {"get_reaction_torque", Joint_GetReactionTorque},
+        {"create_distance", Joint_CreateDistance},
+        {"create_mouse", Joint_CreateMouse},
+        {"create_prismatic", Joint_CreatePrismatic},
+        {"create_revolute", Joint_CreateRevolute},
+        {"create_weld", Joint_CreateWeld},
+        {"create_wheel", Joint_CreateWheel},
+        {"create_friction", Joint_CreateFriction},
+        {"create_rope", Joint_CreateRope},
+        {"create_pulley", Joint_CreatePulley},
+        {"create_gear", Joint_CreateGear},
+        {0, 0}
+    };
+
+    void ScriptBox2DInitializeJoint(lua_State* L)
+    {
+        TYPE_HASH_JOINT = dmScript::RegisterUserType(L, BOX2D_TYPE_NAME_JOINT, Joint_methods, Joint_meta);
+
+        lua_newtable(L);
+        luaL_register(L, 0, Joint_functions);
+
+#define SET_CONSTANT(NAME, CUSTOM_NAME) \
+        lua_pushnumber(L, (lua_Number)NAME); \
+        lua_setfield(L, -2, CUSTOM_NAME);
+
+        SET_CONSTANT(e_unknownJoint, "JOINT_TYPE_UNKNOWN");
+        SET_CONSTANT(e_revoluteJoint, "JOINT_TYPE_REVOLUTE");
+        SET_CONSTANT(e_prismaticJoint, "JOINT_TYPE_PRISMATIC");
+        SET_CONSTANT(e_distanceJoint, "JOINT_TYPE_DISTANCE");
+        SET_CONSTANT(e_pulleyJoint, "JOINT_TYPE_PULLEY");
+        SET_CONSTANT(e_mouseJoint, "JOINT_TYPE_MOUSE");
+        SET_CONSTANT(e_gearJoint, "JOINT_TYPE_GEAR");
+        SET_CONSTANT(e_wheelJoint, "JOINT_TYPE_WHEEL");
+        SET_CONSTANT(e_weldJoint, "JOINT_TYPE_WELD");
+        SET_CONSTANT(e_frictionJoint, "JOINT_TYPE_FRICTION");
+        SET_CONSTANT(e_ropeJoint, "JOINT_TYPE_ROPE");
+
+#undef SET_CONSTANT
+
+        lua_setfield(L, -2, "joint");
+    }
+
+    void ScriptBox2DInvalidateJoint(void* joint)
+    {
+        if (!joint)
+        {
+            return;
+        }
+
+        HOpaqueHandle* handle = g_JointToHandle.Get(JointPtrToKey((b2Joint*)joint));
+        if (handle)
+        {
+            InvalidateJointHandle(*handle);
+        }
+    }
+
+    void ScriptBox2DFinalizeJoint()
+    {
+        TYPE_HASH_JOINT = 0;
+
+        for (uint32_t i = 0; i < g_JointHandles.Capacity(); ++i)
+        {
+            if (g_JointHandles.GetByIndex(i))
+            {
+                g_JointHandles.Release(g_JointHandles.IndexToHandle(i));
+            }
+        }
+        g_JointToHandle.Clear();
+        g_JointMeta.Clear();
+    }
+}
+
+/*# Box2D b2Joint documentation
+ *
+ * Functions for interacting with native Box2D joints.
+ *
+ * @document
+ * @name b2d.joint
+ * @namespace b2d.joint
+ * @language Lua
+ * @version 2
+ */
+
+/*# Box2D joint
+ * @typedef
+ * @name b2Joint
+ * @param value [type:userdata]
+ */

--- a/engine/gamesys/src/gamesys/scripts/box2d/v2/script_box2d_joint_v2.cpp
+++ b/engine/gamesys/src/gamesys/scripts/box2d/v2/script_box2d_joint_v2.cpp
@@ -1363,3 +1363,516 @@ namespace dmGameSystem
  * @name b2Joint
  * @param value [type:userdata]
  */
+
+/*# Unknown joint type.
+ * @name b2d.joint.JOINT_TYPE_UNKNOWN
+ * @constant
+ */
+
+/*# Revolute joint type.
+ * @name b2d.joint.JOINT_TYPE_REVOLUTE
+ * @constant
+ */
+
+/*# Prismatic joint type.
+ * @name b2d.joint.JOINT_TYPE_PRISMATIC
+ * @constant
+ */
+
+/*# Distance joint type.
+ * @name b2d.joint.JOINT_TYPE_DISTANCE
+ * @constant
+ */
+
+/*# Pulley joint type.
+ * @name b2d.joint.JOINT_TYPE_PULLEY
+ * @constant
+ */
+
+/*# Mouse joint type.
+ * @name b2d.joint.JOINT_TYPE_MOUSE
+ * @constant
+ */
+
+/*# Gear joint type.
+ * @name b2d.joint.JOINT_TYPE_GEAR
+ * @constant
+ */
+
+/*# Wheel joint type.
+ * @name b2d.joint.JOINT_TYPE_WHEEL
+ * @constant
+ */
+
+/*# Weld joint type.
+ * @name b2d.joint.JOINT_TYPE_WELD
+ * @constant
+ */
+
+/*# Friction joint type.
+ * @name b2d.joint.JOINT_TYPE_FRICTION
+ * @constant
+ */
+
+/*# Rope joint type.
+ * @name b2d.joint.JOINT_TYPE_ROPE
+ * @constant
+ */
+
+/*# Inactive limit state.
+ * @name b2d.joint.LIMIT_STATE_INACTIVE
+ * @constant
+ */
+
+/*# At lower limit state.
+ * @name b2d.joint.LIMIT_STATE_AT_LOWER
+ * @constant
+ */
+
+/*# At upper limit state.
+ * @name b2d.joint.LIMIT_STATE_AT_UPPER
+ * @constant
+ */
+
+/*# Equal limits state.
+ * @name b2d.joint.LIMIT_STATE_EQUAL
+ * @constant
+ */
+
+/*# Destroy a joint created by `b2d.joint`.
+ * @name b2d.joint.destroy
+ * @param joint [type: b2Joint] joint
+ */
+
+/*# Get the joint type.
+ * @name b2d.joint.get_type
+ * @param joint [type: b2Joint] joint
+ * @return type [type: number] one of the `JOINT_TYPE_*` constants
+ */
+
+/*# Get the first body connected to a joint.
+ * @name b2d.joint.get_body_a
+ * @param joint [type: b2Joint] joint
+ * @return body [type: b2Body] body A
+ */
+
+/*# Get the second body connected to a joint.
+ * @name b2d.joint.get_body_b
+ * @param joint [type: b2Joint] joint
+ * @return body [type: b2Body] body B
+ */
+
+/*# Get the local anchor on body A.
+ * @name b2d.joint.get_local_anchor_a
+ * @param joint [type: b2Joint] joint
+ * @return anchor [type: vector3] local anchor
+ */
+
+/*# Get the local anchor on body B.
+ * @name b2d.joint.get_local_anchor_b
+ * @param joint [type: b2Joint] joint
+ * @return anchor [type: vector3] local anchor
+ */
+
+/*# Get the world anchor on body A.
+ * @name b2d.joint.get_anchor_a
+ * @param joint [type: b2Joint] joint
+ * @return anchor [type: vector3] world anchor
+ */
+
+/*# Get the world anchor on body B.
+ * @name b2d.joint.get_anchor_b
+ * @param joint [type: b2Joint] joint
+ * @return anchor [type: vector3] world anchor
+ */
+
+/*# Get whether the joint is active.
+ * @name b2d.joint.is_active
+ * @param joint [type: b2Joint] joint
+ * @return active [type: boolean] true if the joint is active
+ */
+
+/*# Get whether connected bodies can collide.
+ * @name b2d.joint.get_collide_connected
+ * @param joint [type: b2Joint] joint
+ * @return collide [type: boolean] true if connected bodies can collide
+ */
+
+/*# Set the target for a mouse joint.
+ * @name b2d.joint.set_mouse_target
+ * @param joint [type: b2Joint] mouse joint
+ * @param target [type: vector3] world target
+ */
+
+/*# Get the target for a mouse joint.
+ * @name b2d.joint.get_mouse_target
+ * @param joint [type: b2Joint] mouse joint
+ * @return target [type: vector3] world target
+ */
+
+/*# Set the distance joint length.
+ * @name b2d.joint.set_length
+ * @param joint [type: b2Joint] distance joint
+ * @param length [type: number] length in project units
+ */
+
+/*# Get the distance joint length.
+ * @name b2d.joint.get_length
+ * @param joint [type: b2Joint] distance joint
+ * @return length [type: number] length in project units
+ */
+
+/*# Set spring frequency.
+ * @name b2d.joint.set_frequency
+ * @param joint [type: b2Joint] distance, mouse, weld, or wheel joint
+ * @param frequency [type: number] frequency in hertz
+ */
+
+/*# Get spring frequency.
+ * @name b2d.joint.get_frequency
+ * @param joint [type: b2Joint] distance, mouse, weld, or wheel joint
+ * @return frequency [type: number] frequency in hertz
+ */
+
+/*# Alias for `b2d.joint.set_frequency`.
+ * @name b2d.joint.set_hertz
+ * @param joint [type: b2Joint] distance, mouse, weld, or wheel joint
+ * @param hertz [type: number] frequency in hertz
+ */
+
+/*# Alias for `b2d.joint.get_frequency`.
+ * @name b2d.joint.get_hertz
+ * @param joint [type: b2Joint] distance, mouse, weld, or wheel joint
+ * @return hertz [type: number] frequency in hertz
+ */
+
+/*# Set spring damping ratio.
+ * @name b2d.joint.set_damping_ratio
+ * @param joint [type: b2Joint] distance, mouse, weld, or wheel joint
+ * @param ratio [type: number] damping ratio
+ */
+
+/*# Get spring damping ratio.
+ * @name b2d.joint.get_damping_ratio
+ * @param joint [type: b2Joint] distance, mouse, weld, or wheel joint
+ * @return ratio [type: number] damping ratio
+ */
+
+/*# Alias for `b2d.joint.set_damping_ratio`.
+ * @name b2d.joint.set_spring_damping_ratio
+ * @param joint [type: b2Joint] distance, mouse, weld, or wheel joint
+ * @param ratio [type: number] damping ratio
+ */
+
+/*# Alias for `b2d.joint.get_damping_ratio`.
+ * @name b2d.joint.get_spring_damping_ratio
+ * @param joint [type: b2Joint] distance, mouse, weld, or wheel joint
+ * @return ratio [type: number] damping ratio
+ */
+
+/*# Get the local axis on body A.
+ * @name b2d.joint.get_local_axis_a
+ * @param joint [type: b2Joint] prismatic or wheel joint
+ * @return axis [type: vector3] local axis
+ */
+
+/*# Get the reference angle.
+ * @name b2d.joint.get_reference_angle
+ * @param joint [type: b2Joint] prismatic, revolute, or weld joint
+ * @return angle [type: number] reference angle in radians
+ */
+
+/*# Get joint translation.
+ * @name b2d.joint.get_joint_translation
+ * @param joint [type: b2Joint] prismatic or wheel joint
+ * @return translation [type: number] translation in project units
+ */
+
+/*# Get joint speed.
+ * @name b2d.joint.get_joint_speed
+ * @param joint [type: b2Joint] prismatic, revolute, or wheel joint
+ * @return speed [type: number] joint speed
+ */
+
+/*# Get revolute joint angle.
+ * @name b2d.joint.get_joint_angle
+ * @param joint [type: b2Joint] revolute joint
+ * @return angle [type: number] angle in radians
+ */
+
+/*# Enable or disable joint limits.
+ * @name b2d.joint.enable_limit
+ * @param joint [type: b2Joint] prismatic or revolute joint
+ * @param enable [type: boolean] true to enable limits
+ */
+
+/*# Get whether joint limits are enabled.
+ * @name b2d.joint.is_limit_enabled
+ * @param joint [type: b2Joint] prismatic or revolute joint
+ * @return enabled [type: boolean] true if limits are enabled
+ */
+
+/*# Set joint limits.
+ * @name b2d.joint.set_limits
+ * @param joint [type: b2Joint] prismatic or revolute joint
+ * @param lower [type: number] lower limit
+ * @param upper [type: number] upper limit
+ */
+
+/*# Get the lower joint limit.
+ * @name b2d.joint.get_lower_limit
+ * @param joint [type: b2Joint] prismatic or revolute joint
+ * @return lower [type: number] lower limit
+ */
+
+/*# Get the upper joint limit.
+ * @name b2d.joint.get_upper_limit
+ * @param joint [type: b2Joint] prismatic or revolute joint
+ * @return upper [type: number] upper limit
+ */
+
+/*# Enable or disable the joint motor.
+ * @name b2d.joint.enable_motor
+ * @param joint [type: b2Joint] prismatic, revolute, or wheel joint
+ * @param enable [type: boolean] true to enable the motor
+ */
+
+/*# Get whether the joint motor is enabled.
+ * @name b2d.joint.is_motor_enabled
+ * @param joint [type: b2Joint] prismatic, revolute, or wheel joint
+ * @return enabled [type: boolean] true if the motor is enabled
+ */
+
+/*# Set motor speed.
+ * @name b2d.joint.set_motor_speed
+ * @param joint [type: b2Joint] prismatic, revolute, or wheel joint
+ * @param speed [type: number] motor speed
+ */
+
+/*# Get motor speed.
+ * @name b2d.joint.get_motor_speed
+ * @param joint [type: b2Joint] prismatic, revolute, or wheel joint
+ * @return speed [type: number] motor speed
+ */
+
+/*# Set maximum motor force.
+ * @name b2d.joint.set_max_motor_force
+ * @param joint [type: b2Joint] prismatic joint
+ * @param force [type: number] maximum motor force
+ */
+
+/*# Get maximum motor force.
+ * @name b2d.joint.get_max_motor_force
+ * @param joint [type: b2Joint] prismatic joint
+ * @return force [type: number] maximum motor force
+ */
+
+/*# Get current motor force.
+ * @name b2d.joint.get_motor_force
+ * @param joint [type: b2Joint] prismatic joint
+ * @param inv_dt [type: number] inverse time step
+ * @return force [type: number] motor force
+ */
+
+/*# Set maximum motor torque.
+ * @name b2d.joint.set_max_motor_torque
+ * @param joint [type: b2Joint] revolute or wheel joint
+ * @param torque [type: number] maximum motor torque
+ */
+
+/*# Get maximum motor torque.
+ * @name b2d.joint.get_max_motor_torque
+ * @param joint [type: b2Joint] revolute or wheel joint
+ * @return torque [type: number] maximum motor torque
+ */
+
+/*# Get current motor torque.
+ * @name b2d.joint.get_motor_torque
+ * @param joint [type: b2Joint] revolute or wheel joint
+ * @param inv_dt [type: number] inverse time step
+ * @return torque [type: number] motor torque
+ */
+
+/*# Set maximum force.
+ * @name b2d.joint.set_max_force
+ * @param joint [type: b2Joint] mouse or friction joint
+ * @param force [type: number] maximum force
+ */
+
+/*# Get maximum force.
+ * @name b2d.joint.get_max_force
+ * @param joint [type: b2Joint] mouse or friction joint
+ * @return force [type: number] maximum force
+ */
+
+/*# Set maximum torque.
+ * @name b2d.joint.set_max_torque
+ * @param joint [type: b2Joint] friction joint
+ * @param torque [type: number] maximum torque
+ */
+
+/*# Get maximum torque.
+ * @name b2d.joint.get_max_torque
+ * @param joint [type: b2Joint] friction joint
+ * @return torque [type: number] maximum torque
+ */
+
+/*# Set rope maximum length.
+ * @name b2d.joint.set_max_length
+ * @param joint [type: b2Joint] rope joint
+ * @param length [type: number] maximum length in project units
+ */
+
+/*# Get rope maximum length.
+ * @name b2d.joint.get_max_length
+ * @param joint [type: b2Joint] rope joint
+ * @return length [type: number] maximum length in project units
+ */
+
+/*# Get rope limit state.
+ * @name b2d.joint.get_limit_state
+ * @param joint [type: b2Joint] rope joint
+ * @return state [type: number] one of the `LIMIT_STATE_*` constants
+ */
+
+/*# Get pulley ground anchor A.
+ * @name b2d.joint.get_ground_anchor_a
+ * @param joint [type: b2Joint] pulley joint
+ * @return anchor [type: vector3] world anchor
+ */
+
+/*# Get pulley ground anchor B.
+ * @name b2d.joint.get_ground_anchor_b
+ * @param joint [type: b2Joint] pulley joint
+ * @return anchor [type: vector3] world anchor
+ */
+
+/*# Get pulley segment length A.
+ * @name b2d.joint.get_length_a
+ * @param joint [type: b2Joint] pulley joint
+ * @return length [type: number] length in project units
+ */
+
+/*# Get pulley segment length B.
+ * @name b2d.joint.get_length_b
+ * @param joint [type: b2Joint] pulley joint
+ * @return length [type: number] length in project units
+ */
+
+/*# Set gear joint ratio.
+ * @name b2d.joint.set_ratio
+ * @param joint [type: b2Joint] gear joint
+ * @param ratio [type: number] gear ratio
+ */
+
+/*# Get joint ratio.
+ * @name b2d.joint.get_ratio
+ * @param joint [type: b2Joint] pulley or gear joint
+ * @return ratio [type: number] joint ratio
+ */
+
+/*# Get the first joint connected to a gear joint.
+ * @name b2d.joint.get_joint1
+ * @param joint [type: b2Joint] gear joint
+ * @return joint1 [type: b2Joint] first connected joint
+ */
+
+/*# Get the second joint connected to a gear joint.
+ * @name b2d.joint.get_joint2
+ * @param joint [type: b2Joint] gear joint
+ * @return joint2 [type: b2Joint] second connected joint
+ */
+
+/*# Get reaction force.
+ * @name b2d.joint.get_reaction_force
+ * @param joint [type: b2Joint] joint
+ * @param inv_dt [type: number] inverse time step
+ * @return force [type: vector3] reaction force
+ */
+
+/*# Get reaction torque.
+ * @name b2d.joint.get_reaction_torque
+ * @param joint [type: b2Joint] joint
+ * @param inv_dt [type: number] inverse time step
+ * @return torque [type: number] reaction torque
+ */
+
+/*# Create a distance joint.
+ * @name b2d.joint.create_distance
+ * @param body_a [type: b2Body] first body
+ * @param body_b [type: b2Body] second body
+ * @param definition [type: table] optional definition with `local_anchor_a`, `local_anchor_b`, `length`, `frequency`, `damping_ratio`, and `collide_connected`
+ * @return joint [type: b2Joint] created joint
+ */
+
+/*# Create a mouse joint.
+ * @name b2d.joint.create_mouse
+ * @param body_a [type: b2Body] first body
+ * @param body_b [type: b2Body] second body
+ * @param definition [type: table] optional definition with `target`, `max_force`, `frequency`, `damping_ratio`, and `collide_connected`
+ * @return joint [type: b2Joint] created joint
+ */
+
+/*# Create a prismatic joint.
+ * @name b2d.joint.create_prismatic
+ * @param body_a [type: b2Body] first body
+ * @param body_b [type: b2Body] second body
+ * @param definition [type: table] optional definition with `local_anchor_a`, `local_anchor_b`, `local_axis_a`, `reference_angle`, `enable_limit`, `lower_translation`, `upper_translation`, `enable_motor`, `max_motor_force`, `motor_speed`, and `collide_connected`
+ * @return joint [type: b2Joint] created joint
+ */
+
+/*# Create a revolute joint.
+ * @name b2d.joint.create_revolute
+ * @param body_a [type: b2Body] first body
+ * @param body_b [type: b2Body] second body
+ * @param definition [type: table] optional definition with `local_anchor_a`, `local_anchor_b`, `reference_angle`, `enable_limit`, `lower_angle`, `upper_angle`, `enable_motor`, `max_motor_torque`, `motor_speed`, and `collide_connected`
+ * @return joint [type: b2Joint] created joint
+ */
+
+/*# Create a weld joint.
+ * @name b2d.joint.create_weld
+ * @param body_a [type: b2Body] first body
+ * @param body_b [type: b2Body] second body
+ * @param definition [type: table] optional definition with `local_anchor_a`, `local_anchor_b`, `reference_angle`, `frequency`, `damping_ratio`, and `collide_connected`
+ * @return joint [type: b2Joint] created joint
+ */
+
+/*# Create a wheel joint.
+ * @name b2d.joint.create_wheel
+ * @param body_a [type: b2Body] first body
+ * @param body_b [type: b2Body] second body
+ * @param definition [type: table] optional definition with `local_anchor_a`, `local_anchor_b`, `local_axis_a`, `enable_motor`, `max_motor_torque`, `motor_speed`, `frequency`, `damping_ratio`, and `collide_connected`
+ * @return joint [type: b2Joint] created joint
+ */
+
+/*# Create a friction joint.
+ * @name b2d.joint.create_friction
+ * @param body_a [type: b2Body] first body
+ * @param body_b [type: b2Body] second body
+ * @param definition [type: table] optional definition with `local_anchor_a`, `local_anchor_b`, `max_force`, `max_torque`, and `collide_connected`
+ * @return joint [type: b2Joint] created joint
+ */
+
+/*# Create a rope joint.
+ * @name b2d.joint.create_rope
+ * @param body_a [type: b2Body] first body
+ * @param body_b [type: b2Body] second body
+ * @param definition [type: table] optional definition with `local_anchor_a`, `local_anchor_b`, `max_length`, and `collide_connected`
+ * @return joint [type: b2Joint] created joint
+ */
+
+/*# Create a pulley joint.
+ * @name b2d.joint.create_pulley
+ * @param body_a [type: b2Body] first body
+ * @param body_b [type: b2Body] second body
+ * @param definition [type: table] optional definition with `ground_anchor_a`, `ground_anchor_b`, `local_anchor_a`, `local_anchor_b`, `length_a`, `length_b`, `ratio`, and `collide_connected`
+ * @return joint [type: b2Joint] created joint
+ */
+
+/*# Create a gear joint.
+ * @name b2d.joint.create_gear
+ * @param joint1 [type: b2Joint] first revolute or prismatic joint
+ * @param joint2 [type: b2Joint] second revolute or prismatic joint
+ * @param definition [type: table] optional definition with `ratio`
+ * @return joint [type: b2Joint] created joint
+ */

--- a/engine/gamesys/src/gamesys/scripts/box2d/v2/script_box2d_v2.h
+++ b/engine/gamesys/src/gamesys/scripts/box2d/v2/script_box2d_v2.h
@@ -26,6 +26,7 @@
 
 class b2Body;
 class b2Fixture;
+class b2Joint;
 struct b2FixtureDef;
 
 namespace dmGameSystem
@@ -40,8 +41,12 @@ namespace dmGameSystem
     };
 
     b2Body*    CheckBody(struct lua_State* L, int index);
+    dmGameObject::HCollection GetBodyCollection(struct lua_State* L, int index);
+    dmhash_t   GetBodyInstanceId(b2Body* body);
     b2Fixture* GetFixtureByIndex(b2Body* body, int fixture_index);
+    bool       IsJointTracked(b2Joint* joint);
     void       PushBodyFromReference(struct lua_State* L, b2Body* body, int reference_index);
+    void       PushJoint(struct lua_State* L, b2Joint* joint, dmGameObject::HCollection collection);
     void       TrackOwnedFixtureShape(b2Fixture* fixture, FixtureShapeDef* shape_def);
     void       ReleaseOwnedFixtureShape(b2Fixture* fixture);
     const b2Shape* CheckShapeDef(struct lua_State* L, int index, FixtureShapeDef* out_shape);
@@ -49,6 +54,9 @@ namespace dmGameSystem
     void       ScriptBox2DInitializeBody(struct lua_State* L);
     void       ScriptBox2DInvalidateBody(void* body);
     void       ScriptBox2DFinalizeBody();
+    void       ScriptBox2DInitializeJoint(struct lua_State* L);
+    void       ScriptBox2DInvalidateJoint(void* joint);
+    void       ScriptBox2DFinalizeJoint();
     void       ScriptBox2DInitializeFixture(struct lua_State* L);
     void       ScriptBox2DInitializeShape(struct lua_State* L);
 }

--- a/engine/gamesys/src/gamesys/scripts/box2d/v3/script_box2d_body_v3.cpp
+++ b/engine/gamesys/src/gamesys/scripts/box2d/v3/script_box2d_body_v3.cpp
@@ -179,6 +179,13 @@ namespace dmGameSystem
         return &luabody->m_Body;
     }
 
+    dmGameObject::HCollection GetBodyCollection(lua_State* L, int index)
+    {
+        B2DLuaBody* luabody = CheckBodyInternal(L, index);
+        VerifyBodyInternal(L, luabody);
+        return luabody->m_Collection;
+    }
+
     static b2BodyId* ToBody(lua_State* L, int index)
     {
         B2DLuaBody* luabody = (B2DLuaBody*)dmScript::ToUserType(L, index, TYPE_HASH_BODY);
@@ -442,6 +449,32 @@ namespace dmGameSystem
         {
             PushShapeInfo(L, shapes[i], i + 1);
             lua_rawseti(L, -2, i + 1);
+        }
+        return 1;
+    }
+
+    static int Body_GetJoints(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        dmGameObject::HCollection collection = GetBodyCollection(L, 1);
+        b2BodyId* body = CheckBody(L, 1);
+
+        const int joint_count = b2Body_GetJointCount(*body);
+        dmArray<b2JointId> joints;
+        joints.SetCapacity(joint_count);
+        joints.SetSize(joint_count);
+        b2Body_GetJoints(*body, joints.Begin(), joint_count);
+
+        lua_newtable(L);
+        int joint_index = 1;
+        for (int i = 0; i < joint_count; ++i)
+        {
+            if (IsJointTracked(joints[i]))
+            {
+                PushJoint(L, joints[i], collection);
+                lua_rawseti(L, -2, joint_index);
+                ++joint_index;
+            }
         }
         return 1;
     }
@@ -820,6 +853,7 @@ namespace dmGameSystem
         {"reset_mass_data", Body_ResetMassData},
         {"get_angle", Body_GetAngle},
         {"get_shapes", Body_GetShapes},
+        {"get_joints", Body_GetJoints},
         {"destroy_shape", Body_DestroyShape},
 
         {"get_linear_velocity", Body_GetLinearVelocity},
@@ -903,6 +937,7 @@ namespace dmGameSystem
 
         lua_setfield(L, -2, "body");
 
+        ScriptBox2DInitializeJoint(L);
         ScriptBox2DInitializeShape(L);
     }
 
@@ -914,6 +949,7 @@ namespace dmGameSystem
     void ScriptBox2DFinalizeBody()
     {
         TYPE_HASH_BODY = 0;
+        ScriptBox2DFinalizeJoint();
     }
 }
 

--- a/engine/gamesys/src/gamesys/scripts/box2d/v3/script_box2d_body_v3.cpp
+++ b/engine/gamesys/src/gamesys/scripts/box2d/v3/script_box2d_body_v3.cpp
@@ -1327,10 +1327,10 @@ namespace dmGameSystem
  * @return shapes [type: table] a table of functional shape entries
  */
 
-/** Get the list of all joints attached to this body.
- * @name b2d.body.get_joint_list
+/*# Get the joints attached to this body.
+ * @name b2d.body.get_joints
  * @param body [type: b2Body] body
- * @return edge [type: b2JointEdge] the first joint
+ * @return joints [type: table] array of `b2Joint` handles created by `b2d.joint`
  */
 
 /** Get the list of all contacts attached to this body.

--- a/engine/gamesys/src/gamesys/scripts/box2d/v3/script_box2d_joint_v3.cpp
+++ b/engine/gamesys/src/gamesys/scripts/box2d/v3/script_box2d_joint_v3.cpp
@@ -1,0 +1,624 @@
+// Copyright 2020-2026 The Defold Foundation
+// Copyright 2014-2020 King
+// Copyright 2009-2014 Ragnar Svensson, Christian Murray
+// Licensed under the Defold License version 1.0 (the "License"); you may not use
+// this file except in compliance with the License.
+
+#include <string.h>
+
+#include <box2d/box2d.h>
+
+#include <dlib/array.h>
+#include <dmsdk/dlib/hashtable.h>
+#include <gameobject/script.h>
+
+#include "gamesys.h"
+#include "gamesys_private.h"
+#include "script_box2d_v3.h"
+
+extern "C"
+{
+#include <lua/lauxlib.h>
+#include <lua/lualib.h>
+}
+
+namespace dmGameSystem
+{
+    static uint32_t TYPE_HASH_JOINT = 0;
+
+    #define BOX2D_TYPE_NAME_JOINT "b2joint"
+
+    struct B2DLuaJoint
+    {
+        b2JointId                 m_Joint;
+        dmGameObject::HCollection m_Collection;
+    };
+
+    static dmHashTable64<uint8_t> g_JointIds;
+
+    static uint64_t JointIdToKey(b2JointId joint_id)
+    {
+        return b2StoreJointId(joint_id);
+    }
+
+    static void EnsureJointIdCapacity()
+    {
+        if (g_JointIds.Full())
+        {
+            g_JointIds.OffsetCapacity(32);
+        }
+    }
+
+    static void TrackJoint(b2JointId joint_id)
+    {
+        EnsureJointIdCapacity();
+        g_JointIds.Put(JointIdToKey(joint_id), 1);
+    }
+
+    static void UntrackJoint(b2JointId joint_id)
+    {
+        if (g_JointIds.Get(JointIdToKey(joint_id)))
+        {
+            g_JointIds.Erase(JointIdToKey(joint_id));
+        }
+    }
+
+    bool IsJointTracked(b2JointId joint_id)
+    {
+        return g_JointIds.Get(JointIdToKey(joint_id)) != 0;
+    }
+
+    static int AbsIndex(lua_State* L, int index)
+    {
+        return index < 0 ? lua_gettop(L) + index + 1 : index;
+    }
+
+    static b2Vec2 CheckVec2(lua_State* L, int index, float scale)
+    {
+        dmVMath::Vector3* v = dmScript::CheckVector3(L, index);
+        b2Vec2 b2v = { v->getX() * scale, v->getY() * scale };
+        return b2v;
+    }
+
+    static dmVMath::Vector3 FromB2(const b2Vec2& p, float inv_scale)
+    {
+        return dmVMath::Vector3(p.x * inv_scale, p.y * inv_scale, 0);
+    }
+
+    static bool HasField(lua_State* L, int table_index, const char* field)
+    {
+        if (table_index == 0)
+        {
+            return false;
+        }
+        lua_getfield(L, table_index, field);
+        bool has_field = !lua_isnil(L, -1);
+        lua_pop(L, 1);
+        return has_field;
+    }
+
+    static bool GetBoolField(lua_State* L, int table_index, const char* field, bool default_value)
+    {
+        if (table_index == 0)
+        {
+            return default_value;
+        }
+        lua_getfield(L, table_index, field);
+        bool value = lua_isnil(L, -1) ? default_value : lua_toboolean(L, -1);
+        lua_pop(L, 1);
+        return value;
+    }
+
+    static float GetNumberField(lua_State* L, int table_index, const char* field, float default_value)
+    {
+        if (table_index == 0)
+        {
+            return default_value;
+        }
+        lua_getfield(L, table_index, field);
+        float value = lua_isnil(L, -1) ? default_value : (float)luaL_checknumber(L, -1);
+        lua_pop(L, 1);
+        return value;
+    }
+
+    static b2Vec2 GetVec2Field(lua_State* L, int table_index, const char* field, b2Vec2 default_value, float scale)
+    {
+        if (table_index == 0)
+        {
+            return default_value;
+        }
+        lua_getfield(L, table_index, field);
+        b2Vec2 value = lua_isnil(L, -1) ? default_value : CheckVec2(L, -1, scale);
+        lua_pop(L, 1);
+        return value;
+    }
+
+    static void CheckJointDefBodies(lua_State* L, int body_a_index, int body_b_index, b2BodyId** body_a, b2BodyId** body_b, b2WorldId* world)
+    {
+        body_a_index = AbsIndex(L, body_a_index);
+        body_b_index = AbsIndex(L, body_b_index);
+        *body_a = CheckBody(L, body_a_index);
+        *body_b = CheckBody(L, body_b_index);
+        b2WorldId world_a = b2Body_GetWorld(**body_a);
+        b2WorldId world_b = b2Body_GetWorld(**body_b);
+        if (world_a.index1 != world_b.index1 || world_a.generation != world_b.generation)
+        {
+            luaL_error(L, "joints can only be connected to bodies in the same Box2D world.");
+            return;
+        }
+        if (b2World_IsLocked(world_a))
+        {
+            luaL_error(L, "Could not create joint. The world is locked.");
+            return;
+        }
+        *world = world_a;
+    }
+
+    static int CheckDefinitionTable(lua_State* L, int index)
+    {
+        if (lua_isnoneornil(L, index))
+        {
+            return 0;
+        }
+
+        luaL_checktype(L, index, LUA_TTABLE);
+        return AbsIndex(L, index);
+    }
+
+    static void ReadCommonAnchoredDef(lua_State* L, int table_index, b2Vec2* local_anchor_a, b2Vec2* local_anchor_b, bool* collide_connected)
+    {
+        *local_anchor_a    = GetVec2Field(L, table_index, "local_anchor_a", *local_anchor_a, GetPhysicsScale());
+        *local_anchor_b    = GetVec2Field(L, table_index, "local_anchor_b", *local_anchor_b, GetPhysicsScale());
+        *collide_connected = GetBoolField(L, table_index, "collide_connected", *collide_connected);
+    }
+
+    void PushJoint(lua_State* L, b2JointId joint_id, dmGameObject::HCollection collection)
+    {
+        B2DLuaJoint* luajoint = (B2DLuaJoint*)lua_newuserdata(L, sizeof(B2DLuaJoint));
+        luajoint->m_Joint = joint_id;
+        luajoint->m_Collection = collection;
+        luaL_getmetatable(L, BOX2D_TYPE_NAME_JOINT);
+        lua_setmetatable(L, -2);
+    }
+
+    static void PushCreatedJoint(lua_State* L, b2JointId joint_id, dmGameObject::HCollection collection)
+    {
+        TrackJoint(joint_id);
+        PushJoint(L, joint_id, collection);
+    }
+
+    static B2DLuaJoint* CheckJointInternal(lua_State* L, int index)
+    {
+        return (B2DLuaJoint*)dmScript::CheckUserType(L, index, TYPE_HASH_JOINT, "Expected user type " BOX2D_TYPE_NAME_JOINT);
+    }
+
+    static b2JointId CheckJoint(lua_State* L, int index)
+    {
+        B2DLuaJoint* luajoint = CheckJointInternal(L, index);
+        if (!b2Joint_IsValid(luajoint->m_Joint))
+        {
+            luaL_error(L, "Invalid b2joint handle.");
+            return b2_nullJointId;
+        }
+        return luajoint->m_Joint;
+    }
+
+    static b2JointId* ToJoint(lua_State* L, int index)
+    {
+        B2DLuaJoint* luajoint = (B2DLuaJoint*)dmScript::ToUserType(L, index, TYPE_HASH_JOINT);
+        return luajoint ? &luajoint->m_Joint : 0;
+    }
+
+    static int Joint_Destroy(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        B2DLuaJoint* luajoint = CheckJointInternal(L, 1);
+        if (!b2Joint_IsValid(luajoint->m_Joint))
+        {
+            return luaL_error(L, "Invalid b2joint handle.");
+        }
+        if (!IsJointTracked(luajoint->m_Joint))
+        {
+            return luaL_error(L, "Cannot destroy a joint not created by b2d.joint.");
+        }
+        UntrackJoint(luajoint->m_Joint);
+        b2DestroyJoint(luajoint->m_Joint);
+        luajoint->m_Joint = b2_nullJointId;
+        return 0;
+    }
+
+    static int Joint_GetType(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        lua_pushinteger(L, b2Joint_GetType(CheckJoint(L, 1)));
+        return 1;
+    }
+
+    static int Joint_GetBodyA(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        B2DLuaJoint* luajoint = CheckJointInternal(L, 1);
+        b2JointId joint = CheckJoint(L, 1);
+        b2BodyId body = b2Joint_GetBodyA(joint);
+        PushBody(L, &body, luajoint->m_Collection, 0);
+        return 1;
+    }
+
+    static int Joint_GetBodyB(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        B2DLuaJoint* luajoint = CheckJointInternal(L, 1);
+        b2JointId joint = CheckJoint(L, 1);
+        b2BodyId body = b2Joint_GetBodyB(joint);
+        PushBody(L, &body, luajoint->m_Collection, 0);
+        return 1;
+    }
+
+    static int Joint_GetLocalAnchorA(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        dmScript::PushVector3(L, FromB2(b2Joint_GetLocalAnchorA(CheckJoint(L, 1)), GetInvPhysicsScale()));
+        return 1;
+    }
+
+    static int Joint_GetLocalAnchorB(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        dmScript::PushVector3(L, FromB2(b2Joint_GetLocalAnchorB(CheckJoint(L, 1)), GetInvPhysicsScale()));
+        return 1;
+    }
+
+    static int Joint_GetCollideConnected(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        lua_pushboolean(L, b2Joint_GetCollideConnected(CheckJoint(L, 1)));
+        return 1;
+    }
+
+    static int Joint_SetCollideConnected(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        b2Joint_SetCollideConnected(CheckJoint(L, 1), lua_toboolean(L, 2));
+        return 0;
+    }
+
+    static int Joint_SetMouseTarget(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        b2JointId joint = CheckJoint(L, 1);
+        if (b2Joint_GetType(joint) != b2_mouseJoint)
+        {
+            return luaL_error(L, "b2d.joint.set_mouse_target can only be used with mouse joints.");
+        }
+        if (b2World_IsLocked(b2Joint_GetWorld(joint)))
+        {
+            return luaL_error(L, "Could not set mouse joint target. The world is locked.");
+        }
+        b2MouseJoint_SetTarget(joint, CheckVec2(L, 2, GetPhysicsScale()));
+        return 0;
+    }
+
+    static int Joint_GetReactionForce(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        dmScript::PushVector3(L, FromB2(b2Joint_GetConstraintForce(CheckJoint(L, 1)), GetInvPhysicsScale()));
+        return 1;
+    }
+
+    static int Joint_GetReactionTorque(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        lua_pushnumber(L, b2Joint_GetConstraintTorque(CheckJoint(L, 1)) * GetInvPhysicsScale());
+        return 1;
+    }
+
+    static int Joint_CreateDistance(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        dmGameObject::HCollection collection = GetBodyCollection(L, 1);
+        b2BodyId* body_a = 0;
+        b2BodyId* body_b = 0;
+        b2WorldId world = b2_nullWorldId;
+        CheckJointDefBodies(L, 1, 2, &body_a, &body_b, &world);
+        int def_index = CheckDefinitionTable(L, 3);
+
+        b2DistanceJointDef def = b2DefaultDistanceJointDef();
+        def.bodyIdA = *body_a;
+        def.bodyIdB = *body_b;
+        ReadCommonAnchoredDef(L, def_index, &def.localAnchorA, &def.localAnchorB, &def.collideConnected);
+        def.length = GetNumberField(L, def_index, "length", def.length) * GetPhysicsScale();
+        def.minLength = GetNumberField(L, def_index, "min_length", def.minLength) * GetPhysicsScale();
+        def.maxLength = GetNumberField(L, def_index, "max_length", def.maxLength) * GetPhysicsScale();
+        def.enableSpring = GetBoolField(L, def_index, "enable_spring", def.enableSpring);
+        def.hertz = GetNumberField(L, def_index, HasField(L, def_index, "frequency") ? "frequency" : "hertz", def.hertz);
+        def.dampingRatio = GetNumberField(L, def_index, HasField(L, def_index, "damping") ? "damping" : "damping_ratio", def.dampingRatio);
+        def.enableLimit = GetBoolField(L, def_index, "enable_limit", def.enableLimit);
+        def.enableMotor = GetBoolField(L, def_index, "enable_motor", def.enableMotor);
+        def.maxMotorForce = GetNumberField(L, def_index, "max_motor_force", def.maxMotorForce) * GetPhysicsScale();
+        def.motorSpeed = GetNumberField(L, def_index, "motor_speed", def.motorSpeed) * GetPhysicsScale();
+
+        b2JointId joint = b2CreateDistanceJoint(world, &def);
+        PushCreatedJoint(L, joint, collection);
+        return 1;
+    }
+
+    static int Joint_CreateMouse(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        dmGameObject::HCollection collection = GetBodyCollection(L, 1);
+        b2BodyId* body_a = 0;
+        b2BodyId* body_b = 0;
+        b2WorldId world = b2_nullWorldId;
+        CheckJointDefBodies(L, 1, 2, &body_a, &body_b, &world);
+        int def_index = CheckDefinitionTable(L, 3);
+
+        b2MouseJointDef def = b2DefaultMouseJointDef();
+        def.bodyIdA = *body_a;
+        def.bodyIdB = *body_b;
+        def.target = GetVec2Field(L, def_index, "target", def.target, GetPhysicsScale());
+        def.hertz = GetNumberField(L, def_index, HasField(L, def_index, "frequency") ? "frequency" : "hertz", def.hertz);
+        def.dampingRatio = GetNumberField(L, def_index, HasField(L, def_index, "damping") ? "damping" : "damping_ratio", def.dampingRatio);
+        def.maxForce = GetNumberField(L, def_index, "max_force", def.maxForce) * GetPhysicsScale();
+        def.collideConnected = GetBoolField(L, def_index, "collide_connected", def.collideConnected);
+
+        PushCreatedJoint(L, b2CreateMouseJoint(world, &def), collection);
+        return 1;
+    }
+
+    static int Joint_CreatePrismatic(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        dmGameObject::HCollection collection = GetBodyCollection(L, 1);
+        b2BodyId* body_a = 0;
+        b2BodyId* body_b = 0;
+        b2WorldId world = b2_nullWorldId;
+        CheckJointDefBodies(L, 1, 2, &body_a, &body_b, &world);
+        int def_index = CheckDefinitionTable(L, 3);
+
+        b2PrismaticJointDef def = b2DefaultPrismaticJointDef();
+        def.bodyIdA = *body_a;
+        def.bodyIdB = *body_b;
+        ReadCommonAnchoredDef(L, def_index, &def.localAnchorA, &def.localAnchorB, &def.collideConnected);
+        def.localAxisA = GetVec2Field(L, def_index, "local_axis_a", def.localAxisA, 1.0f);
+        def.referenceAngle = GetNumberField(L, def_index, "reference_angle", def.referenceAngle);
+        def.enableSpring = GetBoolField(L, def_index, "enable_spring", def.enableSpring);
+        def.hertz = GetNumberField(L, def_index, HasField(L, def_index, "frequency") ? "frequency" : "hertz", def.hertz);
+        def.dampingRatio = GetNumberField(L, def_index, HasField(L, def_index, "damping") ? "damping" : "damping_ratio", def.dampingRatio);
+        def.enableLimit = GetBoolField(L, def_index, "enable_limit", def.enableLimit);
+        def.lowerTranslation = GetNumberField(L, def_index, "lower_translation", def.lowerTranslation) * GetPhysicsScale();
+        def.upperTranslation = GetNumberField(L, def_index, "upper_translation", def.upperTranslation) * GetPhysicsScale();
+        def.enableMotor = GetBoolField(L, def_index, "enable_motor", def.enableMotor);
+        def.maxMotorForce = GetNumberField(L, def_index, "max_motor_force", def.maxMotorForce) * GetPhysicsScale();
+        def.motorSpeed = GetNumberField(L, def_index, "motor_speed", def.motorSpeed) * GetPhysicsScale();
+
+        PushCreatedJoint(L, b2CreatePrismaticJoint(world, &def), collection);
+        return 1;
+    }
+
+    static int Joint_CreateRevolute(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        dmGameObject::HCollection collection = GetBodyCollection(L, 1);
+        b2BodyId* body_a = 0;
+        b2BodyId* body_b = 0;
+        b2WorldId world = b2_nullWorldId;
+        CheckJointDefBodies(L, 1, 2, &body_a, &body_b, &world);
+        int def_index = CheckDefinitionTable(L, 3);
+
+        b2RevoluteJointDef def = b2DefaultRevoluteJointDef();
+        def.bodyIdA = *body_a;
+        def.bodyIdB = *body_b;
+        ReadCommonAnchoredDef(L, def_index, &def.localAnchorA, &def.localAnchorB, &def.collideConnected);
+        def.referenceAngle = GetNumberField(L, def_index, "reference_angle", def.referenceAngle);
+        def.enableSpring = GetBoolField(L, def_index, "enable_spring", def.enableSpring);
+        def.hertz = GetNumberField(L, def_index, HasField(L, def_index, "frequency") ? "frequency" : "hertz", def.hertz);
+        def.dampingRatio = GetNumberField(L, def_index, HasField(L, def_index, "damping") ? "damping" : "damping_ratio", def.dampingRatio);
+        def.enableLimit = GetBoolField(L, def_index, "enable_limit", def.enableLimit);
+        def.lowerAngle = GetNumberField(L, def_index, "lower_angle", def.lowerAngle);
+        def.upperAngle = GetNumberField(L, def_index, "upper_angle", def.upperAngle);
+        def.enableMotor = GetBoolField(L, def_index, "enable_motor", def.enableMotor);
+        def.maxMotorTorque = GetNumberField(L, def_index, "max_motor_torque", def.maxMotorTorque);
+        def.motorSpeed = GetNumberField(L, def_index, "motor_speed", def.motorSpeed);
+
+        PushCreatedJoint(L, b2CreateRevoluteJoint(world, &def), collection);
+        return 1;
+    }
+
+    static int Joint_CreateWeld(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        dmGameObject::HCollection collection = GetBodyCollection(L, 1);
+        b2BodyId* body_a = 0;
+        b2BodyId* body_b = 0;
+        b2WorldId world = b2_nullWorldId;
+        CheckJointDefBodies(L, 1, 2, &body_a, &body_b, &world);
+        int def_index = CheckDefinitionTable(L, 3);
+
+        b2WeldJointDef def = b2DefaultWeldJointDef();
+        def.bodyIdA = *body_a;
+        def.bodyIdB = *body_b;
+        ReadCommonAnchoredDef(L, def_index, &def.localAnchorA, &def.localAnchorB, &def.collideConnected);
+        def.referenceAngle = GetNumberField(L, def_index, "reference_angle", def.referenceAngle);
+        float hertz = GetNumberField(L, def_index, HasField(L, def_index, "frequency") ? "frequency" : "hertz", def.linearHertz);
+        float damping = GetNumberField(L, def_index, HasField(L, def_index, "damping") ? "damping" : "damping_ratio", def.linearDampingRatio);
+        def.linearHertz = GetNumberField(L, def_index, "linear_hertz", hertz);
+        def.angularHertz = GetNumberField(L, def_index, "angular_hertz", hertz);
+        def.linearDampingRatio = GetNumberField(L, def_index, "linear_damping_ratio", damping);
+        def.angularDampingRatio = GetNumberField(L, def_index, "angular_damping_ratio", damping);
+
+        PushCreatedJoint(L, b2CreateWeldJoint(world, &def), collection);
+        return 1;
+    }
+
+    static int Joint_CreateWheel(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        dmGameObject::HCollection collection = GetBodyCollection(L, 1);
+        b2BodyId* body_a = 0;
+        b2BodyId* body_b = 0;
+        b2WorldId world = b2_nullWorldId;
+        CheckJointDefBodies(L, 1, 2, &body_a, &body_b, &world);
+        int def_index = CheckDefinitionTable(L, 3);
+
+        b2WheelJointDef def = b2DefaultWheelJointDef();
+        def.bodyIdA = *body_a;
+        def.bodyIdB = *body_b;
+        ReadCommonAnchoredDef(L, def_index, &def.localAnchorA, &def.localAnchorB, &def.collideConnected);
+        def.localAxisA = GetVec2Field(L, def_index, "local_axis_a", def.localAxisA, 1.0f);
+        def.enableSpring = GetBoolField(L, def_index, "enable_spring", def.enableSpring);
+        def.hertz = GetNumberField(L, def_index, HasField(L, def_index, "frequency") ? "frequency" : "hertz", def.hertz);
+        def.dampingRatio = GetNumberField(L, def_index, HasField(L, def_index, "damping") ? "damping" : "damping_ratio", def.dampingRatio);
+        def.enableLimit = GetBoolField(L, def_index, "enable_limit", def.enableLimit);
+        def.lowerTranslation = GetNumberField(L, def_index, "lower_translation", def.lowerTranslation) * GetPhysicsScale();
+        def.upperTranslation = GetNumberField(L, def_index, "upper_translation", def.upperTranslation) * GetPhysicsScale();
+        def.enableMotor = GetBoolField(L, def_index, "enable_motor", def.enableMotor);
+        def.maxMotorTorque = GetNumberField(L, def_index, "max_motor_torque", def.maxMotorTorque);
+        def.motorSpeed = GetNumberField(L, def_index, "motor_speed", def.motorSpeed);
+
+        PushCreatedJoint(L, b2CreateWheelJoint(world, &def), collection);
+        return 1;
+    }
+
+    static int Joint_CreateMotor(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        dmGameObject::HCollection collection = GetBodyCollection(L, 1);
+        b2BodyId* body_a = 0;
+        b2BodyId* body_b = 0;
+        b2WorldId world = b2_nullWorldId;
+        CheckJointDefBodies(L, 1, 2, &body_a, &body_b, &world);
+        int def_index = CheckDefinitionTable(L, 3);
+
+        b2MotorJointDef def = b2DefaultMotorJointDef();
+        def.bodyIdA = *body_a;
+        def.bodyIdB = *body_b;
+        def.linearOffset = GetVec2Field(L, def_index, "linear_offset", def.linearOffset, GetPhysicsScale());
+        def.angularOffset = GetNumberField(L, def_index, "angular_offset", def.angularOffset);
+        def.maxForce = GetNumberField(L, def_index, "max_force", def.maxForce) * GetPhysicsScale();
+        def.maxTorque = GetNumberField(L, def_index, "max_torque", def.maxTorque);
+        def.correctionFactor = GetNumberField(L, def_index, "correction_factor", def.correctionFactor);
+        def.collideConnected = GetBoolField(L, def_index, "collide_connected", def.collideConnected);
+
+        PushCreatedJoint(L, b2CreateMotorJoint(world, &def), collection);
+        return 1;
+    }
+
+    static int Joint_CreateFilter(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        dmGameObject::HCollection collection = GetBodyCollection(L, 1);
+        b2BodyId* body_a = 0;
+        b2BodyId* body_b = 0;
+        b2WorldId world = b2_nullWorldId;
+        CheckJointDefBodies(L, 1, 2, &body_a, &body_b, &world);
+
+        b2FilterJointDef def = b2DefaultFilterJointDef();
+        def.bodyIdA = *body_a;
+        def.bodyIdB = *body_b;
+
+        PushCreatedJoint(L, b2CreateFilterJoint(world, &def), collection);
+        return 1;
+    }
+
+    static int Joint_tostring(lua_State* L)
+    {
+        b2JointId joint = CheckJoint(L, 1);
+        lua_pushfstring(L, "Box2D.%s = %p", BOX2D_TYPE_NAME_JOINT, &joint);
+        return 1;
+    }
+
+    static int Joint_eq(lua_State* L)
+    {
+        b2JointId* a = ToJoint(L, 1);
+        b2JointId* b = ToJoint(L, 2);
+        lua_pushboolean(L, a && b && memcmp(a, b, sizeof(b2JointId)) == 0);
+        return 1;
+    }
+
+    static const luaL_reg Joint_methods[] =
+    {
+        {0, 0}
+    };
+
+    static const luaL_reg Joint_meta[] =
+    {
+        {"__tostring", Joint_tostring},
+        {"__eq", Joint_eq},
+        {0, 0}
+    };
+
+    static const luaL_reg Joint_functions[] =
+    {
+        {"destroy", Joint_Destroy},
+        {"get_type", Joint_GetType},
+        {"get_body_a", Joint_GetBodyA},
+        {"get_body_b", Joint_GetBodyB},
+        {"get_local_anchor_a", Joint_GetLocalAnchorA},
+        {"get_local_anchor_b", Joint_GetLocalAnchorB},
+        {"get_collide_connected", Joint_GetCollideConnected},
+        {"set_collide_connected", Joint_SetCollideConnected},
+        {"set_mouse_target", Joint_SetMouseTarget},
+        {"get_reaction_force", Joint_GetReactionForce},
+        {"get_reaction_torque", Joint_GetReactionTorque},
+        {"create_distance", Joint_CreateDistance},
+        {"create_mouse", Joint_CreateMouse},
+        {"create_prismatic", Joint_CreatePrismatic},
+        {"create_revolute", Joint_CreateRevolute},
+        {"create_weld", Joint_CreateWeld},
+        {"create_wheel", Joint_CreateWheel},
+        {"create_motor", Joint_CreateMotor},
+        {"create_filter", Joint_CreateFilter},
+        {0, 0}
+    };
+
+    void ScriptBox2DInitializeJoint(lua_State* L)
+    {
+        TYPE_HASH_JOINT = dmScript::RegisterUserType(L, BOX2D_TYPE_NAME_JOINT, Joint_methods, Joint_meta);
+
+        lua_newtable(L);
+        luaL_register(L, 0, Joint_functions);
+
+#define SET_CONSTANT(NAME, CUSTOM_NAME) \
+        lua_pushnumber(L, (lua_Number)NAME); \
+        lua_setfield(L, -2, CUSTOM_NAME);
+
+        SET_CONSTANT(b2_distanceJoint, "JOINT_TYPE_DISTANCE");
+        SET_CONSTANT(b2_filterJoint, "JOINT_TYPE_FILTER");
+        SET_CONSTANT(b2_motorJoint, "JOINT_TYPE_MOTOR");
+        SET_CONSTANT(b2_mouseJoint, "JOINT_TYPE_MOUSE");
+        SET_CONSTANT(b2_prismaticJoint, "JOINT_TYPE_PRISMATIC");
+        SET_CONSTANT(b2_revoluteJoint, "JOINT_TYPE_REVOLUTE");
+        SET_CONSTANT(b2_weldJoint, "JOINT_TYPE_WELD");
+        SET_CONSTANT(b2_wheelJoint, "JOINT_TYPE_WHEEL");
+
+#undef SET_CONSTANT
+
+        lua_setfield(L, -2, "joint");
+    }
+
+    void ScriptBox2DFinalizeJoint()
+    {
+        TYPE_HASH_JOINT = 0;
+        if (g_JointIds.Capacity() > 0)
+        {
+            g_JointIds.Clear();
+        }
+    }
+}
+
+/*# Box2D b2Joint documentation
+ *
+ * Functions for interacting with native Box2D joints.
+ *
+ * @document
+ * @name b2d.joint
+ * @namespace b2d.joint
+ * @language Lua
+ * @version 3
+ */
+
+/*# Box2D joint
+ * @typedef
+ * @name b2Joint
+ * @param value [type:userdata]
+ */

--- a/engine/gamesys/src/gamesys/scripts/box2d/v3/script_box2d_joint_v3.cpp
+++ b/engine/gamesys/src/gamesys/scripts/box2d/v3/script_box2d_joint_v3.cpp
@@ -317,6 +317,13 @@ namespace dmGameSystem
         return 0;
     }
 
+    static int Joint_WakeBodies(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        b2Joint_WakeBodies(CheckJoint(L, 1));
+        return 0;
+    }
+
     static int Joint_SetMouseTarget(lua_State* L)
     {
         DM_LUA_STACK_CHECK(L, 0);
@@ -1196,6 +1203,7 @@ namespace dmGameSystem
         {"get_anchor_b", Joint_GetAnchorB},
         {"get_collide_connected", Joint_GetCollideConnected},
         {"set_collide_connected", Joint_SetCollideConnected},
+        {"wake_bodies", Joint_WakeBodies},
         {"set_mouse_target", Joint_SetMouseTarget},
         {"get_mouse_target", Joint_GetMouseTarget},
         {"set_length", Joint_SetLength},

--- a/engine/gamesys/src/gamesys/scripts/box2d/v3/script_box2d_joint_v3.cpp
+++ b/engine/gamesys/src/gamesys/scripts/box2d/v3/script_box2d_joint_v3.cpp
@@ -364,7 +364,7 @@ namespace dmGameSystem
     static int Joint_GetLength(lua_State* L)
     {
         DM_LUA_STACK_CHECK(L, 1);
-        lua_pushnumber(L, b2DistanceJoint_GetLength(CheckJointType(L, 1, b2_distanceJoint, "get_length", "distance")) * GetInvPhysicsScale());
+        lua_pushnumber(L, b2DistanceJoint_GetLength(CheckJointType(L, 1, b2_distanceJoint, "get_length", "distance")) * (lua_Number)GetInvPhysicsScale());
         return 1;
     }
 
@@ -489,7 +489,7 @@ namespace dmGameSystem
     static int Joint_GetMinLength(lua_State* L)
     {
         DM_LUA_STACK_CHECK(L, 1);
-        lua_pushnumber(L, b2DistanceJoint_GetMinLength(CheckJointType(L, 1, b2_distanceJoint, "get_min_length", "distance")) * GetInvPhysicsScale());
+        lua_pushnumber(L, b2DistanceJoint_GetMinLength(CheckJointType(L, 1, b2_distanceJoint, "get_min_length", "distance")) * (lua_Number)GetInvPhysicsScale());
         return 1;
     }
 
@@ -505,14 +505,14 @@ namespace dmGameSystem
     static int Joint_GetMaxLength(lua_State* L)
     {
         DM_LUA_STACK_CHECK(L, 1);
-        lua_pushnumber(L, b2DistanceJoint_GetMaxLength(CheckJointType(L, 1, b2_distanceJoint, "get_max_length", "distance")) * GetInvPhysicsScale());
+        lua_pushnumber(L, b2DistanceJoint_GetMaxLength(CheckJointType(L, 1, b2_distanceJoint, "get_max_length", "distance")) * (lua_Number)GetInvPhysicsScale());
         return 1;
     }
 
     static int Joint_GetCurrentLength(lua_State* L)
     {
         DM_LUA_STACK_CHECK(L, 1);
-        lua_pushnumber(L, b2DistanceJoint_GetCurrentLength(CheckJointType(L, 1, b2_distanceJoint, "get_current_length", "distance")) * GetInvPhysicsScale());
+        lua_pushnumber(L, b2DistanceJoint_GetCurrentLength(CheckJointType(L, 1, b2_distanceJoint, "get_current_length", "distance")) * (lua_Number)GetInvPhysicsScale());
         return 1;
     }
 
@@ -575,9 +575,9 @@ namespace dmGameSystem
         b2JointId joint = CheckJoint(L, 1);
         switch (b2Joint_GetType(joint))
         {
-            case b2_prismaticJoint: lua_pushnumber(L, b2PrismaticJoint_GetLowerLimit(joint) * GetInvPhysicsScale()); break;
+            case b2_prismaticJoint: lua_pushnumber(L, b2PrismaticJoint_GetLowerLimit(joint) * (lua_Number)GetInvPhysicsScale()); break;
             case b2_revoluteJoint: lua_pushnumber(L, b2RevoluteJoint_GetLowerLimit(joint)); break;
-            case b2_wheelJoint: lua_pushnumber(L, b2WheelJoint_GetLowerLimit(joint) * GetInvPhysicsScale()); break;
+            case b2_wheelJoint: lua_pushnumber(L, b2WheelJoint_GetLowerLimit(joint) * (lua_Number)GetInvPhysicsScale()); break;
             default: return luaL_error(L, "b2d.joint.get_lower_limit can only be used with prismatic, revolute, or wheel joints.");
         }
         return 1;
@@ -589,9 +589,9 @@ namespace dmGameSystem
         b2JointId joint = CheckJoint(L, 1);
         switch (b2Joint_GetType(joint))
         {
-            case b2_prismaticJoint: lua_pushnumber(L, b2PrismaticJoint_GetUpperLimit(joint) * GetInvPhysicsScale()); break;
+            case b2_prismaticJoint: lua_pushnumber(L, b2PrismaticJoint_GetUpperLimit(joint) * (lua_Number)GetInvPhysicsScale()); break;
             case b2_revoluteJoint: lua_pushnumber(L, b2RevoluteJoint_GetUpperLimit(joint)); break;
-            case b2_wheelJoint: lua_pushnumber(L, b2WheelJoint_GetUpperLimit(joint) * GetInvPhysicsScale()); break;
+            case b2_wheelJoint: lua_pushnumber(L, b2WheelJoint_GetUpperLimit(joint) * (lua_Number)GetInvPhysicsScale()); break;
             default: return luaL_error(L, "b2d.joint.get_upper_limit can only be used with prismatic, revolute, or wheel joints.");
         }
         return 1;
@@ -652,8 +652,8 @@ namespace dmGameSystem
         b2JointId joint = CheckJoint(L, 1);
         switch (b2Joint_GetType(joint))
         {
-            case b2_distanceJoint: lua_pushnumber(L, b2DistanceJoint_GetMotorSpeed(joint) * GetInvPhysicsScale()); break;
-            case b2_prismaticJoint: lua_pushnumber(L, b2PrismaticJoint_GetMotorSpeed(joint) * GetInvPhysicsScale()); break;
+            case b2_distanceJoint: lua_pushnumber(L, b2DistanceJoint_GetMotorSpeed(joint) * (lua_Number)GetInvPhysicsScale()); break;
+            case b2_prismaticJoint: lua_pushnumber(L, b2PrismaticJoint_GetMotorSpeed(joint) * (lua_Number)GetInvPhysicsScale()); break;
             case b2_revoluteJoint: lua_pushnumber(L, b2RevoluteJoint_GetMotorSpeed(joint)); break;
             case b2_wheelJoint: lua_pushnumber(L, b2WheelJoint_GetMotorSpeed(joint)); break;
             default: return luaL_error(L, "b2d.joint.get_motor_speed can only be used with distance, prismatic, revolute, or wheel joints.");
@@ -682,8 +682,8 @@ namespace dmGameSystem
         b2JointId joint = CheckJoint(L, 1);
         switch (b2Joint_GetType(joint))
         {
-            case b2_distanceJoint: lua_pushnumber(L, b2DistanceJoint_GetMaxMotorForce(joint) * GetInvPhysicsScale()); break;
-            case b2_prismaticJoint: lua_pushnumber(L, b2PrismaticJoint_GetMaxMotorForce(joint) * GetInvPhysicsScale()); break;
+            case b2_distanceJoint: lua_pushnumber(L, b2DistanceJoint_GetMaxMotorForce(joint) * (lua_Number)GetInvPhysicsScale()); break;
+            case b2_prismaticJoint: lua_pushnumber(L, b2PrismaticJoint_GetMaxMotorForce(joint) * (lua_Number)GetInvPhysicsScale()); break;
             default: return luaL_error(L, "b2d.joint.get_max_motor_force can only be used with distance or prismatic joints.");
         }
         return 1;
@@ -695,8 +695,8 @@ namespace dmGameSystem
         b2JointId joint = CheckJoint(L, 1);
         switch (b2Joint_GetType(joint))
         {
-            case b2_distanceJoint: lua_pushnumber(L, b2DistanceJoint_GetMotorForce(joint) * GetInvPhysicsScale()); break;
-            case b2_prismaticJoint: lua_pushnumber(L, b2PrismaticJoint_GetMotorForce(joint) * GetInvPhysicsScale()); break;
+            case b2_distanceJoint: lua_pushnumber(L, b2DistanceJoint_GetMotorForce(joint) * (lua_Number)GetInvPhysicsScale()); break;
+            case b2_prismaticJoint: lua_pushnumber(L, b2PrismaticJoint_GetMotorForce(joint) * (lua_Number)GetInvPhysicsScale()); break;
             default: return luaL_error(L, "b2d.joint.get_motor_force can only be used with distance or prismatic joints.");
         }
         return 1;
@@ -723,8 +723,8 @@ namespace dmGameSystem
         b2JointId joint = CheckJoint(L, 1);
         switch (b2Joint_GetType(joint))
         {
-            case b2_revoluteJoint: lua_pushnumber(L, b2RevoluteJoint_GetMaxMotorTorque(joint) * GetInvPhysicsScale()); break;
-            case b2_wheelJoint: lua_pushnumber(L, b2WheelJoint_GetMaxMotorTorque(joint) * GetInvPhysicsScale()); break;
+            case b2_revoluteJoint: lua_pushnumber(L, b2RevoluteJoint_GetMaxMotorTorque(joint) * (lua_Number)GetInvPhysicsScale()); break;
+            case b2_wheelJoint: lua_pushnumber(L, b2WheelJoint_GetMaxMotorTorque(joint) * (lua_Number)GetInvPhysicsScale()); break;
             default: return luaL_error(L, "b2d.joint.get_max_motor_torque can only be used with revolute or wheel joints.");
         }
         return 1;
@@ -736,8 +736,8 @@ namespace dmGameSystem
         b2JointId joint = CheckJoint(L, 1);
         switch (b2Joint_GetType(joint))
         {
-            case b2_revoluteJoint: lua_pushnumber(L, b2RevoluteJoint_GetMotorTorque(joint) * GetInvPhysicsScale()); break;
-            case b2_wheelJoint: lua_pushnumber(L, b2WheelJoint_GetMotorTorque(joint) * GetInvPhysicsScale()); break;
+            case b2_revoluteJoint: lua_pushnumber(L, b2RevoluteJoint_GetMotorTorque(joint) * (lua_Number)GetInvPhysicsScale()); break;
+            case b2_wheelJoint: lua_pushnumber(L, b2WheelJoint_GetMotorTorque(joint) * (lua_Number)GetInvPhysicsScale()); break;
             default: return luaL_error(L, "b2d.joint.get_motor_torque can only be used with revolute or wheel joints.");
         }
         return 1;
@@ -764,8 +764,8 @@ namespace dmGameSystem
         b2JointId joint = CheckJoint(L, 1);
         switch (b2Joint_GetType(joint))
         {
-            case b2_mouseJoint: lua_pushnumber(L, b2MouseJoint_GetMaxForce(joint) * GetInvPhysicsScale()); break;
-            case b2_motorJoint: lua_pushnumber(L, b2MotorJoint_GetMaxForce(joint) * GetInvPhysicsScale()); break;
+            case b2_mouseJoint: lua_pushnumber(L, b2MouseJoint_GetMaxForce(joint) * (lua_Number)GetInvPhysicsScale()); break;
+            case b2_motorJoint: lua_pushnumber(L, b2MotorJoint_GetMaxForce(joint) * (lua_Number)GetInvPhysicsScale()); break;
             default: return luaL_error(L, "b2d.joint.get_max_force can only be used with mouse or motor joints.");
         }
         return 1;
@@ -783,7 +783,7 @@ namespace dmGameSystem
     static int Joint_GetMaxTorque(lua_State* L)
     {
         DM_LUA_STACK_CHECK(L, 1);
-        lua_pushnumber(L, b2MotorJoint_GetMaxTorque(CheckJointType(L, 1, b2_motorJoint, "get_max_torque", "motor")) * GetInvPhysicsScale());
+        lua_pushnumber(L, b2MotorJoint_GetMaxTorque(CheckJointType(L, 1, b2_motorJoint, "get_max_torque", "motor")) * (lua_Number)GetInvPhysicsScale());
         return 1;
     }
 
@@ -841,7 +841,7 @@ namespace dmGameSystem
         b2JointId joint = CheckJoint(L, 1);
         switch (b2Joint_GetType(joint))
         {
-            case b2_prismaticJoint: lua_pushnumber(L, b2PrismaticJoint_GetTranslation(joint) * GetInvPhysicsScale()); break;
+            case b2_prismaticJoint: lua_pushnumber(L, b2PrismaticJoint_GetTranslation(joint) * (lua_Number)GetInvPhysicsScale()); break;
             default: return luaL_error(L, "b2d.joint.get_joint_translation can only be used with prismatic joints.");
         }
         return 1;
@@ -853,7 +853,7 @@ namespace dmGameSystem
         b2JointId joint = CheckJoint(L, 1);
         switch (b2Joint_GetType(joint))
         {
-            case b2_prismaticJoint: lua_pushnumber(L, b2PrismaticJoint_GetSpeed(joint) * GetInvPhysicsScale()); break;
+            case b2_prismaticJoint: lua_pushnumber(L, b2PrismaticJoint_GetSpeed(joint) * (lua_Number)GetInvPhysicsScale()); break;
             default: return luaL_error(L, "b2d.joint.get_joint_speed can only be used with prismatic joints.");
         }
         return 1;
@@ -956,7 +956,7 @@ namespace dmGameSystem
     static int Joint_GetReactionTorque(lua_State* L)
     {
         DM_LUA_STACK_CHECK(L, 1);
-        lua_pushnumber(L, b2Joint_GetConstraintTorque(CheckJoint(L, 1)) * GetInvPhysicsScale());
+        lua_pushnumber(L, b2Joint_GetConstraintTorque(CheckJoint(L, 1)) * (lua_Number)GetInvPhysicsScale());
         return 1;
     }
 

--- a/engine/gamesys/src/gamesys/scripts/box2d/v3/script_box2d_joint_v3.cpp
+++ b/engine/gamesys/src/gamesys/scripts/box2d/v3/script_box2d_joint_v3.cpp
@@ -1332,3 +1332,545 @@ namespace dmGameSystem
  * @name b2Joint
  * @param value [type:userdata]
  */
+
+/*# Distance joint type.
+ * @name b2d.joint.JOINT_TYPE_DISTANCE
+ * @constant
+ */
+
+/*# Filter joint type.
+ * @name b2d.joint.JOINT_TYPE_FILTER
+ * @constant
+ */
+
+/*# Motor joint type.
+ * @name b2d.joint.JOINT_TYPE_MOTOR
+ * @constant
+ */
+
+/*# Mouse joint type.
+ * @name b2d.joint.JOINT_TYPE_MOUSE
+ * @constant
+ */
+
+/*# Prismatic joint type.
+ * @name b2d.joint.JOINT_TYPE_PRISMATIC
+ * @constant
+ */
+
+/*# Revolute joint type.
+ * @name b2d.joint.JOINT_TYPE_REVOLUTE
+ * @constant
+ */
+
+/*# Weld joint type.
+ * @name b2d.joint.JOINT_TYPE_WELD
+ * @constant
+ */
+
+/*# Wheel joint type.
+ * @name b2d.joint.JOINT_TYPE_WHEEL
+ * @constant
+ */
+
+/*# Destroy a joint created by `b2d.joint`.
+ * @name b2d.joint.destroy
+ * @param joint [type: b2Joint] joint
+ */
+
+/*# Get the joint type.
+ * @name b2d.joint.get_type
+ * @param joint [type: b2Joint] joint
+ * @return type [type: number] one of the `JOINT_TYPE_*` constants
+ */
+
+/*# Get the first body connected to a joint.
+ * @name b2d.joint.get_body_a
+ * @param joint [type: b2Joint] joint
+ * @return body [type: b2Body] body A
+ */
+
+/*# Get the second body connected to a joint.
+ * @name b2d.joint.get_body_b
+ * @param joint [type: b2Joint] joint
+ * @return body [type: b2Body] body B
+ */
+
+/*# Get the local anchor on body A.
+ * @name b2d.joint.get_local_anchor_a
+ * @param joint [type: b2Joint] joint
+ * @return anchor [type: vector3] local anchor
+ */
+
+/*# Get the local anchor on body B.
+ * @name b2d.joint.get_local_anchor_b
+ * @param joint [type: b2Joint] joint
+ * @return anchor [type: vector3] local anchor
+ */
+
+/*# Get the world anchor on body A.
+ * @name b2d.joint.get_anchor_a
+ * @param joint [type: b2Joint] joint
+ * @return anchor [type: vector3] world anchor
+ */
+
+/*# Get the world anchor on body B.
+ * @name b2d.joint.get_anchor_b
+ * @param joint [type: b2Joint] joint
+ * @return anchor [type: vector3] world anchor
+ */
+
+/*# Get whether connected bodies can collide.
+ * @name b2d.joint.get_collide_connected
+ * @param joint [type: b2Joint] joint
+ * @return collide [type: boolean] true if connected bodies can collide
+ */
+
+/*# Set whether connected bodies can collide.
+ * @name b2d.joint.set_collide_connected
+ * @param joint [type: b2Joint] joint
+ * @param collide [type: boolean] true if connected bodies can collide
+ */
+
+/*# Wake the bodies connected to a joint.
+ * @name b2d.joint.wake_bodies
+ * @param joint [type: b2Joint] joint
+ */
+
+/*# Set the target for a mouse joint.
+ * @name b2d.joint.set_mouse_target
+ * @param joint [type: b2Joint] mouse joint
+ * @param target [type: vector3] world target
+ */
+
+/*# Get the target for a mouse joint.
+ * @name b2d.joint.get_mouse_target
+ * @param joint [type: b2Joint] mouse joint
+ * @return target [type: vector3] world target
+ */
+
+/*# Set the distance joint length.
+ * @name b2d.joint.set_length
+ * @param joint [type: b2Joint] distance joint
+ * @param length [type: number] length in project units
+ */
+
+/*# Get the distance joint length.
+ * @name b2d.joint.get_length
+ * @param joint [type: b2Joint] distance joint
+ * @return length [type: number] length in project units
+ */
+
+/*# Enable or disable joint spring behavior.
+ * @name b2d.joint.enable_spring
+ * @param joint [type: b2Joint] distance, prismatic, revolute, or wheel joint
+ * @param enable [type: boolean] true to enable the spring
+ */
+
+/*# Get whether joint spring behavior is enabled.
+ * @name b2d.joint.is_spring_enabled
+ * @param joint [type: b2Joint] distance, prismatic, revolute, or wheel joint
+ * @return enabled [type: boolean] true if the spring is enabled
+ */
+
+/*# Set spring frequency.
+ * @name b2d.joint.set_spring_hertz
+ * @param joint [type: b2Joint] distance, mouse, prismatic, revolute, or wheel joint
+ * @param hertz [type: number] frequency in hertz
+ */
+
+/*# Get spring frequency.
+ * @name b2d.joint.get_spring_hertz
+ * @param joint [type: b2Joint] distance, mouse, prismatic, revolute, or wheel joint
+ * @return hertz [type: number] frequency in hertz
+ */
+
+/*# Alias for `b2d.joint.set_spring_hertz`.
+ * @name b2d.joint.set_hertz
+ * @param joint [type: b2Joint] distance, mouse, prismatic, revolute, or wheel joint
+ * @param hertz [type: number] frequency in hertz
+ */
+
+/*# Alias for `b2d.joint.get_spring_hertz`.
+ * @name b2d.joint.get_hertz
+ * @param joint [type: b2Joint] distance, mouse, prismatic, revolute, or wheel joint
+ * @return hertz [type: number] frequency in hertz
+ */
+
+/*# Alias for `b2d.joint.set_spring_hertz`.
+ * @name b2d.joint.set_frequency
+ * @param joint [type: b2Joint] distance, mouse, prismatic, revolute, or wheel joint
+ * @param frequency [type: number] frequency in hertz
+ */
+
+/*# Alias for `b2d.joint.get_spring_hertz`.
+ * @name b2d.joint.get_frequency
+ * @param joint [type: b2Joint] distance, mouse, prismatic, revolute, or wheel joint
+ * @return frequency [type: number] frequency in hertz
+ */
+
+/*# Set spring damping ratio.
+ * @name b2d.joint.set_spring_damping_ratio
+ * @param joint [type: b2Joint] distance, mouse, prismatic, revolute, or wheel joint
+ * @param ratio [type: number] damping ratio
+ */
+
+/*# Get spring damping ratio.
+ * @name b2d.joint.get_spring_damping_ratio
+ * @param joint [type: b2Joint] distance, mouse, prismatic, revolute, or wheel joint
+ * @return ratio [type: number] damping ratio
+ */
+
+/*# Alias for `b2d.joint.set_spring_damping_ratio`.
+ * @name b2d.joint.set_damping_ratio
+ * @param joint [type: b2Joint] distance, mouse, prismatic, revolute, or wheel joint
+ * @param ratio [type: number] damping ratio
+ */
+
+/*# Alias for `b2d.joint.get_spring_damping_ratio`.
+ * @name b2d.joint.get_damping_ratio
+ * @param joint [type: b2Joint] distance, mouse, prismatic, revolute, or wheel joint
+ * @return ratio [type: number] damping ratio
+ */
+
+/*# Set the distance joint length range.
+ * @name b2d.joint.set_length_range
+ * @param joint [type: b2Joint] distance joint
+ * @param min_length [type: number] minimum length in project units
+ * @param max_length [type: number] maximum length in project units
+ */
+
+/*# Set the distance joint minimum length.
+ * @name b2d.joint.set_min_length
+ * @param joint [type: b2Joint] distance joint
+ * @param length [type: number] minimum length in project units
+ */
+
+/*# Get the distance joint minimum length.
+ * @name b2d.joint.get_min_length
+ * @param joint [type: b2Joint] distance joint
+ * @return length [type: number] minimum length in project units
+ */
+
+/*# Set the distance joint maximum length.
+ * @name b2d.joint.set_max_length
+ * @param joint [type: b2Joint] distance joint
+ * @param length [type: number] maximum length in project units
+ */
+
+/*# Get the distance joint maximum length.
+ * @name b2d.joint.get_max_length
+ * @param joint [type: b2Joint] distance joint
+ * @return length [type: number] maximum length in project units
+ */
+
+/*# Get the current distance joint length.
+ * @name b2d.joint.get_current_length
+ * @param joint [type: b2Joint] distance joint
+ * @return length [type: number] current length in project units
+ */
+
+/*# Enable or disable joint limits.
+ * @name b2d.joint.enable_limit
+ * @param joint [type: b2Joint] distance, prismatic, revolute, or wheel joint
+ * @param enable [type: boolean] true to enable limits
+ */
+
+/*# Get whether joint limits are enabled.
+ * @name b2d.joint.is_limit_enabled
+ * @param joint [type: b2Joint] distance, prismatic, revolute, or wheel joint
+ * @return enabled [type: boolean] true if limits are enabled
+ */
+
+/*# Set joint limits.
+ * @name b2d.joint.set_limits
+ * @param joint [type: b2Joint] prismatic, revolute, or wheel joint
+ * @param lower [type: number] lower limit
+ * @param upper [type: number] upper limit
+ */
+
+/*# Get the lower joint limit.
+ * @name b2d.joint.get_lower_limit
+ * @param joint [type: b2Joint] prismatic, revolute, or wheel joint
+ * @return lower [type: number] lower limit
+ */
+
+/*# Get the upper joint limit.
+ * @name b2d.joint.get_upper_limit
+ * @param joint [type: b2Joint] prismatic, revolute, or wheel joint
+ * @return upper [type: number] upper limit
+ */
+
+/*# Enable or disable the joint motor.
+ * @name b2d.joint.enable_motor
+ * @param joint [type: b2Joint] distance, prismatic, revolute, or wheel joint
+ * @param enable [type: boolean] true to enable the motor
+ */
+
+/*# Get whether the joint motor is enabled.
+ * @name b2d.joint.is_motor_enabled
+ * @param joint [type: b2Joint] distance, prismatic, revolute, or wheel joint
+ * @return enabled [type: boolean] true if the motor is enabled
+ */
+
+/*# Set motor speed.
+ * @name b2d.joint.set_motor_speed
+ * @param joint [type: b2Joint] distance, prismatic, revolute, or wheel joint
+ * @param speed [type: number] motor speed
+ */
+
+/*# Get motor speed.
+ * @name b2d.joint.get_motor_speed
+ * @param joint [type: b2Joint] distance, prismatic, revolute, or wheel joint
+ * @return speed [type: number] motor speed
+ */
+
+/*# Set maximum motor force.
+ * @name b2d.joint.set_max_motor_force
+ * @param joint [type: b2Joint] distance or prismatic joint
+ * @param force [type: number] maximum motor force
+ */
+
+/*# Get maximum motor force.
+ * @name b2d.joint.get_max_motor_force
+ * @param joint [type: b2Joint] distance or prismatic joint
+ * @return force [type: number] maximum motor force
+ */
+
+/*# Get current motor force.
+ * @name b2d.joint.get_motor_force
+ * @param joint [type: b2Joint] distance or prismatic joint
+ * @return force [type: number] motor force
+ */
+
+/*# Set maximum motor torque.
+ * @name b2d.joint.set_max_motor_torque
+ * @param joint [type: b2Joint] revolute or wheel joint
+ * @param torque [type: number] maximum motor torque
+ */
+
+/*# Get maximum motor torque.
+ * @name b2d.joint.get_max_motor_torque
+ * @param joint [type: b2Joint] revolute or wheel joint
+ * @return torque [type: number] maximum motor torque
+ */
+
+/*# Get current motor torque.
+ * @name b2d.joint.get_motor_torque
+ * @param joint [type: b2Joint] revolute or wheel joint
+ * @return torque [type: number] motor torque
+ */
+
+/*# Set maximum force.
+ * @name b2d.joint.set_max_force
+ * @param joint [type: b2Joint] mouse or motor joint
+ * @param force [type: number] maximum force
+ */
+
+/*# Get maximum force.
+ * @name b2d.joint.get_max_force
+ * @param joint [type: b2Joint] mouse or motor joint
+ * @return force [type: number] maximum force
+ */
+
+/*# Set maximum torque.
+ * @name b2d.joint.set_max_torque
+ * @param joint [type: b2Joint] motor joint
+ * @param torque [type: number] maximum torque
+ */
+
+/*# Get maximum torque.
+ * @name b2d.joint.get_max_torque
+ * @param joint [type: b2Joint] motor joint
+ * @return torque [type: number] maximum torque
+ */
+
+/*# Set motor joint linear offset.
+ * @name b2d.joint.set_linear_offset
+ * @param joint [type: b2Joint] motor joint
+ * @param offset [type: vector3] linear offset in project units
+ */
+
+/*# Get motor joint linear offset.
+ * @name b2d.joint.get_linear_offset
+ * @param joint [type: b2Joint] motor joint
+ * @return offset [type: vector3] linear offset in project units
+ */
+
+/*# Set motor joint angular offset.
+ * @name b2d.joint.set_angular_offset
+ * @param joint [type: b2Joint] motor joint
+ * @param offset [type: number] angular offset in radians
+ */
+
+/*# Get motor joint angular offset.
+ * @name b2d.joint.get_angular_offset
+ * @param joint [type: b2Joint] motor joint
+ * @return offset [type: number] angular offset in radians
+ */
+
+/*# Set motor joint correction factor.
+ * @name b2d.joint.set_correction_factor
+ * @param joint [type: b2Joint] motor joint
+ * @param factor [type: number] correction factor
+ */
+
+/*# Get motor joint correction factor.
+ * @name b2d.joint.get_correction_factor
+ * @param joint [type: b2Joint] motor joint
+ * @return factor [type: number] correction factor
+ */
+
+/*# Get joint translation.
+ * @name b2d.joint.get_joint_translation
+ * @param joint [type: b2Joint] prismatic joint
+ * @return translation [type: number] translation in project units
+ */
+
+/*# Get joint speed.
+ * @name b2d.joint.get_joint_speed
+ * @param joint [type: b2Joint] prismatic joint
+ * @return speed [type: number] joint speed
+ */
+
+/*# Get revolute joint angle.
+ * @name b2d.joint.get_joint_angle
+ * @param joint [type: b2Joint] revolute joint
+ * @return angle [type: number] angle in radians
+ */
+
+/*# Set weld joint reference angle.
+ * @name b2d.joint.set_reference_angle
+ * @param joint [type: b2Joint] weld joint
+ * @param angle [type: number] reference angle in radians
+ */
+
+/*# Get weld joint reference angle.
+ * @name b2d.joint.get_reference_angle
+ * @param joint [type: b2Joint] weld joint
+ * @return angle [type: number] reference angle in radians
+ */
+
+/*# Set weld joint linear frequency.
+ * @name b2d.joint.set_linear_hertz
+ * @param joint [type: b2Joint] weld joint
+ * @param hertz [type: number] frequency in hertz
+ */
+
+/*# Get weld joint linear frequency.
+ * @name b2d.joint.get_linear_hertz
+ * @param joint [type: b2Joint] weld joint
+ * @return hertz [type: number] frequency in hertz
+ */
+
+/*# Set weld joint linear damping ratio.
+ * @name b2d.joint.set_linear_damping_ratio
+ * @param joint [type: b2Joint] weld joint
+ * @param ratio [type: number] damping ratio
+ */
+
+/*# Get weld joint linear damping ratio.
+ * @name b2d.joint.get_linear_damping_ratio
+ * @param joint [type: b2Joint] weld joint
+ * @return ratio [type: number] damping ratio
+ */
+
+/*# Set weld joint angular frequency.
+ * @name b2d.joint.set_angular_hertz
+ * @param joint [type: b2Joint] weld joint
+ * @param hertz [type: number] frequency in hertz
+ */
+
+/*# Get weld joint angular frequency.
+ * @name b2d.joint.get_angular_hertz
+ * @param joint [type: b2Joint] weld joint
+ * @return hertz [type: number] frequency in hertz
+ */
+
+/*# Set weld joint angular damping ratio.
+ * @name b2d.joint.set_angular_damping_ratio
+ * @param joint [type: b2Joint] weld joint
+ * @param ratio [type: number] damping ratio
+ */
+
+/*# Get weld joint angular damping ratio.
+ * @name b2d.joint.get_angular_damping_ratio
+ * @param joint [type: b2Joint] weld joint
+ * @return ratio [type: number] damping ratio
+ */
+
+/*# Get reaction force.
+ * @name b2d.joint.get_reaction_force
+ * @param joint [type: b2Joint] joint
+ * @return force [type: vector3] reaction force
+ */
+
+/*# Get reaction torque.
+ * @name b2d.joint.get_reaction_torque
+ * @param joint [type: b2Joint] joint
+ * @return torque [type: number] reaction torque
+ */
+
+/*# Create a distance joint.
+ * @name b2d.joint.create_distance
+ * @param body_a [type: b2Body] first body
+ * @param body_b [type: b2Body] second body
+ * @param definition [type: table] optional definition with `local_anchor_a`, `local_anchor_b`, `length`, `min_length`, `max_length`, `enable_spring`, `hertz` or `frequency`, `damping_ratio`, `enable_limit`, `enable_motor`, `max_motor_force`, `motor_speed`, and `collide_connected`
+ * @return joint [type: b2Joint] created joint
+ */
+
+/*# Create a mouse joint.
+ * @name b2d.joint.create_mouse
+ * @param body_a [type: b2Body] first body
+ * @param body_b [type: b2Body] second body
+ * @param definition [type: table] optional definition with `target`, `hertz` or `frequency`, `damping_ratio`, `max_force`, and `collide_connected`
+ * @return joint [type: b2Joint] created joint
+ */
+
+/*# Create a prismatic joint.
+ * @name b2d.joint.create_prismatic
+ * @param body_a [type: b2Body] first body
+ * @param body_b [type: b2Body] second body
+ * @param definition [type: table] optional definition with `local_anchor_a`, `local_anchor_b`, `local_axis_a`, `reference_angle`, `enable_spring`, `hertz` or `frequency`, `damping_ratio`, `enable_limit`, `lower_translation`, `upper_translation`, `enable_motor`, `max_motor_force`, `motor_speed`, and `collide_connected`
+ * @return joint [type: b2Joint] created joint
+ */
+
+/*# Create a revolute joint.
+ * @name b2d.joint.create_revolute
+ * @param body_a [type: b2Body] first body
+ * @param body_b [type: b2Body] second body
+ * @param definition [type: table] optional definition with `local_anchor_a`, `local_anchor_b`, `reference_angle`, `enable_spring`, `hertz` or `frequency`, `damping_ratio`, `enable_limit`, `lower_angle`, `upper_angle`, `enable_motor`, `max_motor_torque`, `motor_speed`, and `collide_connected`
+ * @return joint [type: b2Joint] created joint
+ */
+
+/*# Create a weld joint.
+ * @name b2d.joint.create_weld
+ * @param body_a [type: b2Body] first body
+ * @param body_b [type: b2Body] second body
+ * @param definition [type: table] optional definition with `local_anchor_a`, `local_anchor_b`, `reference_angle`, `linear_hertz`, `angular_hertz`, `linear_damping_ratio`, `angular_damping_ratio`, and `collide_connected`
+ * @return joint [type: b2Joint] created joint
+ */
+
+/*# Create a wheel joint.
+ * @name b2d.joint.create_wheel
+ * @param body_a [type: b2Body] first body
+ * @param body_b [type: b2Body] second body
+ * @param definition [type: table] optional definition with `local_anchor_a`, `local_anchor_b`, `local_axis_a`, `enable_spring`, `hertz` or `frequency`, `damping_ratio`, `enable_limit`, `lower_translation`, `upper_translation`, `enable_motor`, `max_motor_torque`, `motor_speed`, and `collide_connected`
+ * @return joint [type: b2Joint] created joint
+ */
+
+/*# Create a motor joint.
+ * @name b2d.joint.create_motor
+ * @param body_a [type: b2Body] first body
+ * @param body_b [type: b2Body] second body
+ * @param definition [type: table] optional definition with `linear_offset`, `angular_offset`, `max_force`, `max_torque`, `correction_factor`, and `collide_connected`
+ * @return joint [type: b2Joint] created joint
+ */
+
+/*# Create a filter joint.
+ * @name b2d.joint.create_filter
+ * @param body_a [type: b2Body] first body
+ * @param body_b [type: b2Body] second body
+ * @param definition [type: table] optional definition table
+ * @return joint [type: b2Joint] created joint
+ */

--- a/engine/gamesys/src/gamesys/scripts/box2d/v3/script_box2d_joint_v3.cpp
+++ b/engine/gamesys/src/gamesys/scripts/box2d/v3/script_box2d_joint_v3.cpp
@@ -240,6 +240,10 @@ namespace dmGameSystem
         {
             return luaL_error(L, "Cannot destroy a joint not created by b2d.joint.");
         }
+        if (b2World_IsLocked(b2Joint_GetWorld(luajoint->m_Joint)))
+        {
+            return luaL_error(L, "Could not destroy joint. The world is locked.");
+        }
         UntrackJoint(luajoint->m_Joint);
         b2DestroyJoint(luajoint->m_Joint);
         luajoint->m_Joint = b2_nullJointId;

--- a/engine/gamesys/src/gamesys/scripts/box2d/v3/script_box2d_joint_v3.cpp
+++ b/engine/gamesys/src/gamesys/scripts/box2d/v3/script_box2d_joint_v3.cpp
@@ -203,6 +203,25 @@ namespace dmGameSystem
         return luajoint->m_Joint;
     }
 
+    static b2JointId CheckJointType(lua_State* L, int index, b2JointType joint_type, const char* function_name, const char* joint_type_name)
+    {
+        b2JointId joint = CheckJoint(L, index);
+        if (b2Joint_GetType(joint) != joint_type)
+        {
+            luaL_error(L, "b2d.joint.%s can only be used with %s joints.", function_name, joint_type_name);
+            return b2_nullJointId;
+        }
+        return joint;
+    }
+
+    static void CheckJointWorldUnlocked(lua_State* L, b2JointId joint, const char* function_name)
+    {
+        if (b2World_IsLocked(b2Joint_GetWorld(joint)))
+        {
+            luaL_error(L, "Could not call b2d.joint.%s. The world is locked.", function_name);
+        }
+    }
+
     static b2JointId* ToJoint(lua_State* L, int index)
     {
         B2DLuaJoint* luajoint = (B2DLuaJoint*)dmScript::ToUserType(L, index, TYPE_HASH_JOINT);
@@ -268,6 +287,22 @@ namespace dmGameSystem
         return 1;
     }
 
+    static int Joint_GetAnchorA(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        b2JointId joint = CheckJoint(L, 1);
+        dmScript::PushVector3(L, FromB2(b2Body_GetWorldPoint(b2Joint_GetBodyA(joint), b2Joint_GetLocalAnchorA(joint)), GetInvPhysicsScale()));
+        return 1;
+    }
+
+    static int Joint_GetAnchorB(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        b2JointId joint = CheckJoint(L, 1);
+        dmScript::PushVector3(L, FromB2(b2Body_GetWorldPoint(b2Joint_GetBodyB(joint), b2Joint_GetLocalAnchorB(joint)), GetInvPhysicsScale()));
+        return 1;
+    }
+
     static int Joint_GetCollideConnected(lua_State* L)
     {
         DM_LUA_STACK_CHECK(L, 1);
@@ -296,6 +331,608 @@ namespace dmGameSystem
         }
         b2MouseJoint_SetTarget(joint, CheckVec2(L, 2, GetPhysicsScale()));
         return 0;
+    }
+
+    static int Joint_GetMouseTarget(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        b2JointId joint = CheckJointType(L, 1, b2_mouseJoint, "get_mouse_target", "mouse");
+        dmScript::PushVector3(L, FromB2(b2MouseJoint_GetTarget(joint), GetInvPhysicsScale()));
+        return 1;
+    }
+
+    static int Joint_SetLength(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        b2JointId joint = CheckJointType(L, 1, b2_distanceJoint, "set_length", "distance");
+        CheckJointWorldUnlocked(L, joint, "set_length");
+        b2DistanceJoint_SetLength(joint, (float)luaL_checknumber(L, 2) * GetPhysicsScale());
+        return 0;
+    }
+
+    static int Joint_GetLength(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        lua_pushnumber(L, b2DistanceJoint_GetLength(CheckJointType(L, 1, b2_distanceJoint, "get_length", "distance")) * GetInvPhysicsScale());
+        return 1;
+    }
+
+    static int Joint_EnableSpring(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        b2JointId joint = CheckJoint(L, 1);
+        CheckJointWorldUnlocked(L, joint, "enable_spring");
+        bool enable_spring = lua_toboolean(L, 2);
+        switch (b2Joint_GetType(joint))
+        {
+            case b2_distanceJoint: b2DistanceJoint_EnableSpring(joint, enable_spring); break;
+            case b2_prismaticJoint: b2PrismaticJoint_EnableSpring(joint, enable_spring); break;
+            case b2_revoluteJoint: b2RevoluteJoint_EnableSpring(joint, enable_spring); break;
+            case b2_wheelJoint: b2WheelJoint_EnableSpring(joint, enable_spring); break;
+            default: return luaL_error(L, "b2d.joint.enable_spring can only be used with distance, prismatic, revolute, or wheel joints.");
+        }
+        return 0;
+    }
+
+    static int Joint_IsSpringEnabled(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        b2JointId joint = CheckJoint(L, 1);
+        switch (b2Joint_GetType(joint))
+        {
+            case b2_distanceJoint: lua_pushboolean(L, b2DistanceJoint_IsSpringEnabled(joint)); break;
+            case b2_prismaticJoint: lua_pushboolean(L, b2PrismaticJoint_IsSpringEnabled(joint)); break;
+            case b2_revoluteJoint: lua_pushboolean(L, b2RevoluteJoint_IsSpringEnabled(joint)); break;
+            case b2_wheelJoint: lua_pushboolean(L, b2WheelJoint_IsSpringEnabled(joint)); break;
+            default: return luaL_error(L, "b2d.joint.is_spring_enabled can only be used with distance, prismatic, revolute, or wheel joints.");
+        }
+        return 1;
+    }
+
+    static int Joint_SetSpringHertz(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        b2JointId joint = CheckJoint(L, 1);
+        CheckJointWorldUnlocked(L, joint, "set_spring_hertz");
+        float hertz = (float)luaL_checknumber(L, 2);
+        switch (b2Joint_GetType(joint))
+        {
+            case b2_distanceJoint: b2DistanceJoint_SetSpringHertz(joint, hertz); break;
+            case b2_mouseJoint: b2MouseJoint_SetSpringHertz(joint, hertz); break;
+            case b2_prismaticJoint: b2PrismaticJoint_SetSpringHertz(joint, hertz); break;
+            case b2_revoluteJoint: b2RevoluteJoint_SetSpringHertz(joint, hertz); break;
+            case b2_wheelJoint: b2WheelJoint_SetSpringHertz(joint, hertz); break;
+            default: return luaL_error(L, "b2d.joint.set_spring_hertz can only be used with distance, mouse, prismatic, revolute, or wheel joints.");
+        }
+        return 0;
+    }
+
+    static int Joint_GetSpringHertz(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        b2JointId joint = CheckJoint(L, 1);
+        switch (b2Joint_GetType(joint))
+        {
+            case b2_distanceJoint: lua_pushnumber(L, b2DistanceJoint_GetSpringHertz(joint)); break;
+            case b2_mouseJoint: lua_pushnumber(L, b2MouseJoint_GetSpringHertz(joint)); break;
+            case b2_prismaticJoint: lua_pushnumber(L, b2PrismaticJoint_GetSpringHertz(joint)); break;
+            case b2_revoluteJoint: lua_pushnumber(L, b2RevoluteJoint_GetSpringHertz(joint)); break;
+            case b2_wheelJoint: lua_pushnumber(L, b2WheelJoint_GetSpringHertz(joint)); break;
+            default: return luaL_error(L, "b2d.joint.get_spring_hertz can only be used with distance, mouse, prismatic, revolute, or wheel joints.");
+        }
+        return 1;
+    }
+
+    static int Joint_SetSpringDampingRatio(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        b2JointId joint = CheckJoint(L, 1);
+        CheckJointWorldUnlocked(L, joint, "set_spring_damping_ratio");
+        float damping_ratio = (float)luaL_checknumber(L, 2);
+        switch (b2Joint_GetType(joint))
+        {
+            case b2_distanceJoint: b2DistanceJoint_SetSpringDampingRatio(joint, damping_ratio); break;
+            case b2_mouseJoint: b2MouseJoint_SetSpringDampingRatio(joint, damping_ratio); break;
+            case b2_prismaticJoint: b2PrismaticJoint_SetSpringDampingRatio(joint, damping_ratio); break;
+            case b2_revoluteJoint: b2RevoluteJoint_SetSpringDampingRatio(joint, damping_ratio); break;
+            case b2_wheelJoint: b2WheelJoint_SetSpringDampingRatio(joint, damping_ratio); break;
+            default: return luaL_error(L, "b2d.joint.set_spring_damping_ratio can only be used with distance, mouse, prismatic, revolute, or wheel joints.");
+        }
+        return 0;
+    }
+
+    static int Joint_GetSpringDampingRatio(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        b2JointId joint = CheckJoint(L, 1);
+        switch (b2Joint_GetType(joint))
+        {
+            case b2_distanceJoint: lua_pushnumber(L, b2DistanceJoint_GetSpringDampingRatio(joint)); break;
+            case b2_mouseJoint: lua_pushnumber(L, b2MouseJoint_GetSpringDampingRatio(joint)); break;
+            case b2_prismaticJoint: lua_pushnumber(L, b2PrismaticJoint_GetSpringDampingRatio(joint)); break;
+            case b2_revoluteJoint: lua_pushnumber(L, b2RevoluteJoint_GetSpringDampingRatio(joint)); break;
+            case b2_wheelJoint: lua_pushnumber(L, b2WheelJoint_GetSpringDampingRatio(joint)); break;
+            default: return luaL_error(L, "b2d.joint.get_spring_damping_ratio can only be used with distance, mouse, prismatic, revolute, or wheel joints.");
+        }
+        return 1;
+    }
+
+    static int Joint_SetLengthRange(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        b2JointId joint = CheckJointType(L, 1, b2_distanceJoint, "set_length_range", "distance");
+        CheckJointWorldUnlocked(L, joint, "set_length_range");
+        b2DistanceJoint_SetLengthRange(joint, (float)luaL_checknumber(L, 2) * GetPhysicsScale(), (float)luaL_checknumber(L, 3) * GetPhysicsScale());
+        return 0;
+    }
+
+    static int Joint_SetMinLength(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        b2JointId joint = CheckJointType(L, 1, b2_distanceJoint, "set_min_length", "distance");
+        CheckJointWorldUnlocked(L, joint, "set_min_length");
+        b2DistanceJoint_SetLengthRange(joint, (float)luaL_checknumber(L, 2) * GetPhysicsScale(), b2DistanceJoint_GetMaxLength(joint));
+        return 0;
+    }
+
+    static int Joint_GetMinLength(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        lua_pushnumber(L, b2DistanceJoint_GetMinLength(CheckJointType(L, 1, b2_distanceJoint, "get_min_length", "distance")) * GetInvPhysicsScale());
+        return 1;
+    }
+
+    static int Joint_SetMaxLength(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        b2JointId joint = CheckJointType(L, 1, b2_distanceJoint, "set_max_length", "distance");
+        CheckJointWorldUnlocked(L, joint, "set_max_length");
+        b2DistanceJoint_SetLengthRange(joint, b2DistanceJoint_GetMinLength(joint), (float)luaL_checknumber(L, 2) * GetPhysicsScale());
+        return 0;
+    }
+
+    static int Joint_GetMaxLength(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        lua_pushnumber(L, b2DistanceJoint_GetMaxLength(CheckJointType(L, 1, b2_distanceJoint, "get_max_length", "distance")) * GetInvPhysicsScale());
+        return 1;
+    }
+
+    static int Joint_GetCurrentLength(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        lua_pushnumber(L, b2DistanceJoint_GetCurrentLength(CheckJointType(L, 1, b2_distanceJoint, "get_current_length", "distance")) * GetInvPhysicsScale());
+        return 1;
+    }
+
+    static int Joint_EnableLimit(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        b2JointId joint = CheckJoint(L, 1);
+        CheckJointWorldUnlocked(L, joint, "enable_limit");
+        bool enable_limit = lua_toboolean(L, 2);
+        switch (b2Joint_GetType(joint))
+        {
+            case b2_distanceJoint: b2DistanceJoint_EnableLimit(joint, enable_limit); break;
+            case b2_prismaticJoint: b2PrismaticJoint_EnableLimit(joint, enable_limit); break;
+            case b2_revoluteJoint: b2RevoluteJoint_EnableLimit(joint, enable_limit); break;
+            case b2_wheelJoint: b2WheelJoint_EnableLimit(joint, enable_limit); break;
+            default: return luaL_error(L, "b2d.joint.enable_limit can only be used with distance, prismatic, revolute, or wheel joints.");
+        }
+        return 0;
+    }
+
+    static int Joint_IsLimitEnabled(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        b2JointId joint = CheckJoint(L, 1);
+        switch (b2Joint_GetType(joint))
+        {
+            case b2_distanceJoint: lua_pushboolean(L, b2DistanceJoint_IsLimitEnabled(joint)); break;
+            case b2_prismaticJoint: lua_pushboolean(L, b2PrismaticJoint_IsLimitEnabled(joint)); break;
+            case b2_revoluteJoint: lua_pushboolean(L, b2RevoluteJoint_IsLimitEnabled(joint)); break;
+            case b2_wheelJoint: lua_pushboolean(L, b2WheelJoint_IsLimitEnabled(joint)); break;
+            default: return luaL_error(L, "b2d.joint.is_limit_enabled can only be used with distance, prismatic, revolute, or wheel joints.");
+        }
+        return 1;
+    }
+
+    static int Joint_SetLimits(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        b2JointId joint = CheckJoint(L, 1);
+        CheckJointWorldUnlocked(L, joint, "set_limits");
+        switch (b2Joint_GetType(joint))
+        {
+            case b2_prismaticJoint:
+                b2PrismaticJoint_SetLimits(joint, (float)luaL_checknumber(L, 2) * GetPhysicsScale(), (float)luaL_checknumber(L, 3) * GetPhysicsScale());
+                break;
+            case b2_revoluteJoint:
+                b2RevoluteJoint_SetLimits(joint, (float)luaL_checknumber(L, 2), (float)luaL_checknumber(L, 3));
+                break;
+            case b2_wheelJoint:
+                b2WheelJoint_SetLimits(joint, (float)luaL_checknumber(L, 2) * GetPhysicsScale(), (float)luaL_checknumber(L, 3) * GetPhysicsScale());
+                break;
+            default: return luaL_error(L, "b2d.joint.set_limits can only be used with prismatic, revolute, or wheel joints. Use set_length_range for distance joints.");
+        }
+        return 0;
+    }
+
+    static int Joint_GetLowerLimit(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        b2JointId joint = CheckJoint(L, 1);
+        switch (b2Joint_GetType(joint))
+        {
+            case b2_prismaticJoint: lua_pushnumber(L, b2PrismaticJoint_GetLowerLimit(joint) * GetInvPhysicsScale()); break;
+            case b2_revoluteJoint: lua_pushnumber(L, b2RevoluteJoint_GetLowerLimit(joint)); break;
+            case b2_wheelJoint: lua_pushnumber(L, b2WheelJoint_GetLowerLimit(joint) * GetInvPhysicsScale()); break;
+            default: return luaL_error(L, "b2d.joint.get_lower_limit can only be used with prismatic, revolute, or wheel joints.");
+        }
+        return 1;
+    }
+
+    static int Joint_GetUpperLimit(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        b2JointId joint = CheckJoint(L, 1);
+        switch (b2Joint_GetType(joint))
+        {
+            case b2_prismaticJoint: lua_pushnumber(L, b2PrismaticJoint_GetUpperLimit(joint) * GetInvPhysicsScale()); break;
+            case b2_revoluteJoint: lua_pushnumber(L, b2RevoluteJoint_GetUpperLimit(joint)); break;
+            case b2_wheelJoint: lua_pushnumber(L, b2WheelJoint_GetUpperLimit(joint) * GetInvPhysicsScale()); break;
+            default: return luaL_error(L, "b2d.joint.get_upper_limit can only be used with prismatic, revolute, or wheel joints.");
+        }
+        return 1;
+    }
+
+    static int Joint_EnableMotor(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        b2JointId joint = CheckJoint(L, 1);
+        CheckJointWorldUnlocked(L, joint, "enable_motor");
+        bool enable_motor = lua_toboolean(L, 2);
+        switch (b2Joint_GetType(joint))
+        {
+            case b2_distanceJoint: b2DistanceJoint_EnableMotor(joint, enable_motor); break;
+            case b2_prismaticJoint: b2PrismaticJoint_EnableMotor(joint, enable_motor); break;
+            case b2_revoluteJoint: b2RevoluteJoint_EnableMotor(joint, enable_motor); break;
+            case b2_wheelJoint: b2WheelJoint_EnableMotor(joint, enable_motor); break;
+            default: return luaL_error(L, "b2d.joint.enable_motor can only be used with distance, prismatic, revolute, or wheel joints.");
+        }
+        return 0;
+    }
+
+    static int Joint_IsMotorEnabled(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        b2JointId joint = CheckJoint(L, 1);
+        switch (b2Joint_GetType(joint))
+        {
+            case b2_distanceJoint: lua_pushboolean(L, b2DistanceJoint_IsMotorEnabled(joint)); break;
+            case b2_prismaticJoint: lua_pushboolean(L, b2PrismaticJoint_IsMotorEnabled(joint)); break;
+            case b2_revoluteJoint: lua_pushboolean(L, b2RevoluteJoint_IsMotorEnabled(joint)); break;
+            case b2_wheelJoint: lua_pushboolean(L, b2WheelJoint_IsMotorEnabled(joint)); break;
+            default: return luaL_error(L, "b2d.joint.is_motor_enabled can only be used with distance, prismatic, revolute, or wheel joints.");
+        }
+        return 1;
+    }
+
+    static int Joint_SetMotorSpeed(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        b2JointId joint = CheckJoint(L, 1);
+        CheckJointWorldUnlocked(L, joint, "set_motor_speed");
+        float motor_speed = (float)luaL_checknumber(L, 2);
+        switch (b2Joint_GetType(joint))
+        {
+            case b2_distanceJoint: b2DistanceJoint_SetMotorSpeed(joint, motor_speed * GetPhysicsScale()); break;
+            case b2_prismaticJoint: b2PrismaticJoint_SetMotorSpeed(joint, motor_speed * GetPhysicsScale()); break;
+            case b2_revoluteJoint: b2RevoluteJoint_SetMotorSpeed(joint, motor_speed); break;
+            case b2_wheelJoint: b2WheelJoint_SetMotorSpeed(joint, motor_speed); break;
+            default: return luaL_error(L, "b2d.joint.set_motor_speed can only be used with distance, prismatic, revolute, or wheel joints.");
+        }
+        return 0;
+    }
+
+    static int Joint_GetMotorSpeed(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        b2JointId joint = CheckJoint(L, 1);
+        switch (b2Joint_GetType(joint))
+        {
+            case b2_distanceJoint: lua_pushnumber(L, b2DistanceJoint_GetMotorSpeed(joint) * GetInvPhysicsScale()); break;
+            case b2_prismaticJoint: lua_pushnumber(L, b2PrismaticJoint_GetMotorSpeed(joint) * GetInvPhysicsScale()); break;
+            case b2_revoluteJoint: lua_pushnumber(L, b2RevoluteJoint_GetMotorSpeed(joint)); break;
+            case b2_wheelJoint: lua_pushnumber(L, b2WheelJoint_GetMotorSpeed(joint)); break;
+            default: return luaL_error(L, "b2d.joint.get_motor_speed can only be used with distance, prismatic, revolute, or wheel joints.");
+        }
+        return 1;
+    }
+
+    static int Joint_SetMaxMotorForce(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        b2JointId joint = CheckJoint(L, 1);
+        CheckJointWorldUnlocked(L, joint, "set_max_motor_force");
+        float max_motor_force = (float)luaL_checknumber(L, 2) * GetPhysicsScale();
+        switch (b2Joint_GetType(joint))
+        {
+            case b2_distanceJoint: b2DistanceJoint_SetMaxMotorForce(joint, max_motor_force); break;
+            case b2_prismaticJoint: b2PrismaticJoint_SetMaxMotorForce(joint, max_motor_force); break;
+            default: return luaL_error(L, "b2d.joint.set_max_motor_force can only be used with distance or prismatic joints.");
+        }
+        return 0;
+    }
+
+    static int Joint_GetMaxMotorForce(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        b2JointId joint = CheckJoint(L, 1);
+        switch (b2Joint_GetType(joint))
+        {
+            case b2_distanceJoint: lua_pushnumber(L, b2DistanceJoint_GetMaxMotorForce(joint) * GetInvPhysicsScale()); break;
+            case b2_prismaticJoint: lua_pushnumber(L, b2PrismaticJoint_GetMaxMotorForce(joint) * GetInvPhysicsScale()); break;
+            default: return luaL_error(L, "b2d.joint.get_max_motor_force can only be used with distance or prismatic joints.");
+        }
+        return 1;
+    }
+
+    static int Joint_GetMotorForce(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        b2JointId joint = CheckJoint(L, 1);
+        switch (b2Joint_GetType(joint))
+        {
+            case b2_distanceJoint: lua_pushnumber(L, b2DistanceJoint_GetMotorForce(joint) * GetInvPhysicsScale()); break;
+            case b2_prismaticJoint: lua_pushnumber(L, b2PrismaticJoint_GetMotorForce(joint) * GetInvPhysicsScale()); break;
+            default: return luaL_error(L, "b2d.joint.get_motor_force can only be used with distance or prismatic joints.");
+        }
+        return 1;
+    }
+
+    static int Joint_SetMaxMotorTorque(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        b2JointId joint = CheckJoint(L, 1);
+        CheckJointWorldUnlocked(L, joint, "set_max_motor_torque");
+        float max_motor_torque = (float)luaL_checknumber(L, 2) * GetPhysicsScale();
+        switch (b2Joint_GetType(joint))
+        {
+            case b2_revoluteJoint: b2RevoluteJoint_SetMaxMotorTorque(joint, max_motor_torque); break;
+            case b2_wheelJoint: b2WheelJoint_SetMaxMotorTorque(joint, max_motor_torque); break;
+            default: return luaL_error(L, "b2d.joint.set_max_motor_torque can only be used with revolute or wheel joints.");
+        }
+        return 0;
+    }
+
+    static int Joint_GetMaxMotorTorque(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        b2JointId joint = CheckJoint(L, 1);
+        switch (b2Joint_GetType(joint))
+        {
+            case b2_revoluteJoint: lua_pushnumber(L, b2RevoluteJoint_GetMaxMotorTorque(joint) * GetInvPhysicsScale()); break;
+            case b2_wheelJoint: lua_pushnumber(L, b2WheelJoint_GetMaxMotorTorque(joint) * GetInvPhysicsScale()); break;
+            default: return luaL_error(L, "b2d.joint.get_max_motor_torque can only be used with revolute or wheel joints.");
+        }
+        return 1;
+    }
+
+    static int Joint_GetMotorTorque(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        b2JointId joint = CheckJoint(L, 1);
+        switch (b2Joint_GetType(joint))
+        {
+            case b2_revoluteJoint: lua_pushnumber(L, b2RevoluteJoint_GetMotorTorque(joint) * GetInvPhysicsScale()); break;
+            case b2_wheelJoint: lua_pushnumber(L, b2WheelJoint_GetMotorTorque(joint) * GetInvPhysicsScale()); break;
+            default: return luaL_error(L, "b2d.joint.get_motor_torque can only be used with revolute or wheel joints.");
+        }
+        return 1;
+    }
+
+    static int Joint_SetMaxForce(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        b2JointId joint = CheckJoint(L, 1);
+        CheckJointWorldUnlocked(L, joint, "set_max_force");
+        float max_force = (float)luaL_checknumber(L, 2) * GetPhysicsScale();
+        switch (b2Joint_GetType(joint))
+        {
+            case b2_mouseJoint: b2MouseJoint_SetMaxForce(joint, max_force); break;
+            case b2_motorJoint: b2MotorJoint_SetMaxForce(joint, max_force); break;
+            default: return luaL_error(L, "b2d.joint.set_max_force can only be used with mouse or motor joints.");
+        }
+        return 0;
+    }
+
+    static int Joint_GetMaxForce(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        b2JointId joint = CheckJoint(L, 1);
+        switch (b2Joint_GetType(joint))
+        {
+            case b2_mouseJoint: lua_pushnumber(L, b2MouseJoint_GetMaxForce(joint) * GetInvPhysicsScale()); break;
+            case b2_motorJoint: lua_pushnumber(L, b2MotorJoint_GetMaxForce(joint) * GetInvPhysicsScale()); break;
+            default: return luaL_error(L, "b2d.joint.get_max_force can only be used with mouse or motor joints.");
+        }
+        return 1;
+    }
+
+    static int Joint_SetMaxTorque(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        b2JointId joint = CheckJointType(L, 1, b2_motorJoint, "set_max_torque", "motor");
+        CheckJointWorldUnlocked(L, joint, "set_max_torque");
+        b2MotorJoint_SetMaxTorque(joint, (float)luaL_checknumber(L, 2) * GetPhysicsScale());
+        return 0;
+    }
+
+    static int Joint_GetMaxTorque(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        lua_pushnumber(L, b2MotorJoint_GetMaxTorque(CheckJointType(L, 1, b2_motorJoint, "get_max_torque", "motor")) * GetInvPhysicsScale());
+        return 1;
+    }
+
+    static int Joint_SetLinearOffset(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        b2JointId joint = CheckJointType(L, 1, b2_motorJoint, "set_linear_offset", "motor");
+        CheckJointWorldUnlocked(L, joint, "set_linear_offset");
+        b2MotorJoint_SetLinearOffset(joint, CheckVec2(L, 2, GetPhysicsScale()));
+        return 0;
+    }
+
+    static int Joint_GetLinearOffset(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        dmScript::PushVector3(L, FromB2(b2MotorJoint_GetLinearOffset(CheckJointType(L, 1, b2_motorJoint, "get_linear_offset", "motor")), GetInvPhysicsScale()));
+        return 1;
+    }
+
+    static int Joint_SetAngularOffset(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        b2JointId joint = CheckJointType(L, 1, b2_motorJoint, "set_angular_offset", "motor");
+        CheckJointWorldUnlocked(L, joint, "set_angular_offset");
+        b2MotorJoint_SetAngularOffset(joint, (float)luaL_checknumber(L, 2));
+        return 0;
+    }
+
+    static int Joint_GetAngularOffset(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        lua_pushnumber(L, b2MotorJoint_GetAngularOffset(CheckJointType(L, 1, b2_motorJoint, "get_angular_offset", "motor")));
+        return 1;
+    }
+
+    static int Joint_SetCorrectionFactor(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        b2JointId joint = CheckJointType(L, 1, b2_motorJoint, "set_correction_factor", "motor");
+        CheckJointWorldUnlocked(L, joint, "set_correction_factor");
+        b2MotorJoint_SetCorrectionFactor(joint, (float)luaL_checknumber(L, 2));
+        return 0;
+    }
+
+    static int Joint_GetCorrectionFactor(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        lua_pushnumber(L, b2MotorJoint_GetCorrectionFactor(CheckJointType(L, 1, b2_motorJoint, "get_correction_factor", "motor")));
+        return 1;
+    }
+
+    static int Joint_GetJointTranslation(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        b2JointId joint = CheckJoint(L, 1);
+        switch (b2Joint_GetType(joint))
+        {
+            case b2_prismaticJoint: lua_pushnumber(L, b2PrismaticJoint_GetTranslation(joint) * GetInvPhysicsScale()); break;
+            default: return luaL_error(L, "b2d.joint.get_joint_translation can only be used with prismatic joints.");
+        }
+        return 1;
+    }
+
+    static int Joint_GetJointSpeed(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        b2JointId joint = CheckJoint(L, 1);
+        switch (b2Joint_GetType(joint))
+        {
+            case b2_prismaticJoint: lua_pushnumber(L, b2PrismaticJoint_GetSpeed(joint) * GetInvPhysicsScale()); break;
+            default: return luaL_error(L, "b2d.joint.get_joint_speed can only be used with prismatic joints.");
+        }
+        return 1;
+    }
+
+    static int Joint_GetJointAngle(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        lua_pushnumber(L, b2RevoluteJoint_GetAngle(CheckJointType(L, 1, b2_revoluteJoint, "get_joint_angle", "revolute")));
+        return 1;
+    }
+
+    static int Joint_SetReferenceAngle(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        b2JointId joint = CheckJointType(L, 1, b2_weldJoint, "set_reference_angle", "weld");
+        CheckJointWorldUnlocked(L, joint, "set_reference_angle");
+        b2WeldJoint_SetReferenceAngle(joint, (float)luaL_checknumber(L, 2));
+        return 0;
+    }
+
+    static int Joint_GetReferenceAngle(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        lua_pushnumber(L, b2WeldJoint_GetReferenceAngle(CheckJointType(L, 1, b2_weldJoint, "get_reference_angle", "weld")));
+        return 1;
+    }
+
+    static int Joint_SetLinearHertz(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        b2JointId joint = CheckJointType(L, 1, b2_weldJoint, "set_linear_hertz", "weld");
+        CheckJointWorldUnlocked(L, joint, "set_linear_hertz");
+        b2WeldJoint_SetLinearHertz(joint, (float)luaL_checknumber(L, 2));
+        return 0;
+    }
+
+    static int Joint_GetLinearHertz(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        lua_pushnumber(L, b2WeldJoint_GetLinearHertz(CheckJointType(L, 1, b2_weldJoint, "get_linear_hertz", "weld")));
+        return 1;
+    }
+
+    static int Joint_SetLinearDampingRatio(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        b2JointId joint = CheckJointType(L, 1, b2_weldJoint, "set_linear_damping_ratio", "weld");
+        CheckJointWorldUnlocked(L, joint, "set_linear_damping_ratio");
+        b2WeldJoint_SetLinearDampingRatio(joint, (float)luaL_checknumber(L, 2));
+        return 0;
+    }
+
+    static int Joint_GetLinearDampingRatio(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        lua_pushnumber(L, b2WeldJoint_GetLinearDampingRatio(CheckJointType(L, 1, b2_weldJoint, "get_linear_damping_ratio", "weld")));
+        return 1;
+    }
+
+    static int Joint_SetAngularHertz(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        b2JointId joint = CheckJointType(L, 1, b2_weldJoint, "set_angular_hertz", "weld");
+        CheckJointWorldUnlocked(L, joint, "set_angular_hertz");
+        b2WeldJoint_SetAngularHertz(joint, (float)luaL_checknumber(L, 2));
+        return 0;
+    }
+
+    static int Joint_GetAngularHertz(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        lua_pushnumber(L, b2WeldJoint_GetAngularHertz(CheckJointType(L, 1, b2_weldJoint, "get_angular_hertz", "weld")));
+        return 1;
+    }
+
+    static int Joint_SetAngularDampingRatio(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        b2JointId joint = CheckJointType(L, 1, b2_weldJoint, "set_angular_damping_ratio", "weld");
+        CheckJointWorldUnlocked(L, joint, "set_angular_damping_ratio");
+        b2WeldJoint_SetAngularDampingRatio(joint, (float)luaL_checknumber(L, 2));
+        return 0;
+    }
+
+    static int Joint_GetAngularDampingRatio(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        lua_pushnumber(L, b2WeldJoint_GetAngularDampingRatio(CheckJointType(L, 1, b2_weldJoint, "get_angular_damping_ratio", "weld")));
+        return 1;
     }
 
     static int Joint_GetReactionForce(lua_State* L)
@@ -417,7 +1054,7 @@ namespace dmGameSystem
         def.lowerAngle = GetNumberField(L, def_index, "lower_angle", def.lowerAngle);
         def.upperAngle = GetNumberField(L, def_index, "upper_angle", def.upperAngle);
         def.enableMotor = GetBoolField(L, def_index, "enable_motor", def.enableMotor);
-        def.maxMotorTorque = GetNumberField(L, def_index, "max_motor_torque", def.maxMotorTorque);
+        def.maxMotorTorque = GetNumberField(L, def_index, "max_motor_torque", def.maxMotorTorque) * GetPhysicsScale();
         def.motorSpeed = GetNumberField(L, def_index, "motor_speed", def.motorSpeed);
 
         PushCreatedJoint(L, b2CreateRevoluteJoint(world, &def), collection);
@@ -472,7 +1109,7 @@ namespace dmGameSystem
         def.lowerTranslation = GetNumberField(L, def_index, "lower_translation", def.lowerTranslation) * GetPhysicsScale();
         def.upperTranslation = GetNumberField(L, def_index, "upper_translation", def.upperTranslation) * GetPhysicsScale();
         def.enableMotor = GetBoolField(L, def_index, "enable_motor", def.enableMotor);
-        def.maxMotorTorque = GetNumberField(L, def_index, "max_motor_torque", def.maxMotorTorque);
+        def.maxMotorTorque = GetNumberField(L, def_index, "max_motor_torque", def.maxMotorTorque) * GetPhysicsScale();
         def.motorSpeed = GetNumberField(L, def_index, "motor_speed", def.motorSpeed);
 
         PushCreatedJoint(L, b2CreateWheelJoint(world, &def), collection);
@@ -495,7 +1132,7 @@ namespace dmGameSystem
         def.linearOffset = GetVec2Field(L, def_index, "linear_offset", def.linearOffset, GetPhysicsScale());
         def.angularOffset = GetNumberField(L, def_index, "angular_offset", def.angularOffset);
         def.maxForce = GetNumberField(L, def_index, "max_force", def.maxForce) * GetPhysicsScale();
-        def.maxTorque = GetNumberField(L, def_index, "max_torque", def.maxTorque);
+        def.maxTorque = GetNumberField(L, def_index, "max_torque", def.maxTorque) * GetPhysicsScale();
         def.correctionFactor = GetNumberField(L, def_index, "correction_factor", def.correctionFactor);
         def.collideConnected = GetBoolField(L, def_index, "collide_connected", def.collideConnected);
 
@@ -555,9 +1192,70 @@ namespace dmGameSystem
         {"get_body_b", Joint_GetBodyB},
         {"get_local_anchor_a", Joint_GetLocalAnchorA},
         {"get_local_anchor_b", Joint_GetLocalAnchorB},
+        {"get_anchor_a", Joint_GetAnchorA},
+        {"get_anchor_b", Joint_GetAnchorB},
         {"get_collide_connected", Joint_GetCollideConnected},
         {"set_collide_connected", Joint_SetCollideConnected},
         {"set_mouse_target", Joint_SetMouseTarget},
+        {"get_mouse_target", Joint_GetMouseTarget},
+        {"set_length", Joint_SetLength},
+        {"get_length", Joint_GetLength},
+        {"enable_spring", Joint_EnableSpring},
+        {"is_spring_enabled", Joint_IsSpringEnabled},
+        {"set_spring_hertz", Joint_SetSpringHertz},
+        {"get_spring_hertz", Joint_GetSpringHertz},
+        {"set_hertz", Joint_SetSpringHertz},
+        {"get_hertz", Joint_GetSpringHertz},
+        {"set_frequency", Joint_SetSpringHertz},
+        {"get_frequency", Joint_GetSpringHertz},
+        {"set_spring_damping_ratio", Joint_SetSpringDampingRatio},
+        {"get_spring_damping_ratio", Joint_GetSpringDampingRatio},
+        {"set_damping_ratio", Joint_SetSpringDampingRatio},
+        {"get_damping_ratio", Joint_GetSpringDampingRatio},
+        {"set_length_range", Joint_SetLengthRange},
+        {"set_min_length", Joint_SetMinLength},
+        {"get_min_length", Joint_GetMinLength},
+        {"set_max_length", Joint_SetMaxLength},
+        {"get_max_length", Joint_GetMaxLength},
+        {"get_current_length", Joint_GetCurrentLength},
+        {"enable_limit", Joint_EnableLimit},
+        {"is_limit_enabled", Joint_IsLimitEnabled},
+        {"set_limits", Joint_SetLimits},
+        {"get_lower_limit", Joint_GetLowerLimit},
+        {"get_upper_limit", Joint_GetUpperLimit},
+        {"enable_motor", Joint_EnableMotor},
+        {"is_motor_enabled", Joint_IsMotorEnabled},
+        {"set_motor_speed", Joint_SetMotorSpeed},
+        {"get_motor_speed", Joint_GetMotorSpeed},
+        {"set_max_motor_force", Joint_SetMaxMotorForce},
+        {"get_max_motor_force", Joint_GetMaxMotorForce},
+        {"get_motor_force", Joint_GetMotorForce},
+        {"set_max_motor_torque", Joint_SetMaxMotorTorque},
+        {"get_max_motor_torque", Joint_GetMaxMotorTorque},
+        {"get_motor_torque", Joint_GetMotorTorque},
+        {"set_max_force", Joint_SetMaxForce},
+        {"get_max_force", Joint_GetMaxForce},
+        {"set_max_torque", Joint_SetMaxTorque},
+        {"get_max_torque", Joint_GetMaxTorque},
+        {"set_linear_offset", Joint_SetLinearOffset},
+        {"get_linear_offset", Joint_GetLinearOffset},
+        {"set_angular_offset", Joint_SetAngularOffset},
+        {"get_angular_offset", Joint_GetAngularOffset},
+        {"set_correction_factor", Joint_SetCorrectionFactor},
+        {"get_correction_factor", Joint_GetCorrectionFactor},
+        {"get_joint_translation", Joint_GetJointTranslation},
+        {"get_joint_speed", Joint_GetJointSpeed},
+        {"get_joint_angle", Joint_GetJointAngle},
+        {"set_reference_angle", Joint_SetReferenceAngle},
+        {"get_reference_angle", Joint_GetReferenceAngle},
+        {"set_linear_hertz", Joint_SetLinearHertz},
+        {"get_linear_hertz", Joint_GetLinearHertz},
+        {"set_linear_damping_ratio", Joint_SetLinearDampingRatio},
+        {"get_linear_damping_ratio", Joint_GetLinearDampingRatio},
+        {"set_angular_hertz", Joint_SetAngularHertz},
+        {"get_angular_hertz", Joint_GetAngularHertz},
+        {"set_angular_damping_ratio", Joint_SetAngularDampingRatio},
+        {"get_angular_damping_ratio", Joint_GetAngularDampingRatio},
         {"get_reaction_force", Joint_GetReactionForce},
         {"get_reaction_torque", Joint_GetReactionTorque},
         {"create_distance", Joint_CreateDistance},

--- a/engine/gamesys/src/gamesys/scripts/box2d/v3/script_box2d_v3.h
+++ b/engine/gamesys/src/gamesys/scripts/box2d/v3/script_box2d_v3.h
@@ -60,13 +60,18 @@ namespace dmGameSystem
     }
 
     b2BodyId*   CheckBody(struct lua_State* L, int index);
+    dmGameObject::HCollection GetBodyCollection(struct lua_State* L, int index);
     b2ShapeId   GetShapeByIndex(b2BodyId body, int shape_index);
+    bool        IsJointTracked(b2JointId joint_id);
+    void        PushJoint(struct lua_State* L, b2JointId joint_id, dmGameObject::HCollection collection);
     B2DShapeDef CheckShapeDef(struct lua_State* L, int index);
     void        CheckShapeCreateDef(struct lua_State* L, int index, B2DShapeDef* out_shape_def, b2ShapeDef* out_shape_create_def);
     void        PushShape(struct lua_State* L, b2ShapeId shape_id);
     void        ScriptBox2DInitializeBody(struct lua_State* L);
     void        ScriptBox2DInvalidateBody(void* body);
     void        ScriptBox2DFinalizeBody();
+    void        ScriptBox2DInitializeJoint(struct lua_State* L);
+    void        ScriptBox2DFinalizeJoint();
     void        ScriptBox2DInitializeShape(struct lua_State* L);
 }
 

--- a/engine/gamesys/src/gamesys/test/collision_object/joint_test.script
+++ b/engine/gamesys/src/gamesys/test/collision_object/joint_test.script
@@ -97,7 +97,151 @@ local function test_native_b2d_joints(self)
         max_force = 10,
     })
     b2d.joint.set_mouse_target(mouse_joint, vmath.vector3(7, 8, 0))
+    assert_vec3_near(b2d.joint.get_mouse_target(mouse_joint), vmath.vector3(7, 8, 0))
+    b2d.joint.set_max_force(mouse_joint, 11)
+    assert_near(b2d.joint.get_max_force(mouse_joint), 11)
+    b2d.joint.set_frequency(mouse_joint, 12)
+    assert_near(b2d.joint.get_frequency(mouse_joint), 12)
+    b2d.joint.set_damping_ratio(mouse_joint, 0.7)
+    assert_near(b2d.joint.get_damping_ratio(mouse_joint), 0.7)
     b2d.joint.destroy(mouse_joint)
+
+    b2d.joint.set_length(joint, 6)
+    assert_near(b2d.joint.get_length(joint), 6)
+    assert(b2d.joint.get_anchor_a(joint) ~= nil)
+    assert(b2d.joint.get_anchor_b(joint) ~= nil)
+
+    local prismatic_joint = b2d.joint.create_prismatic(body_a, body_b, {
+        local_axis_a = vmath.vector3(1, 0, 0),
+    })
+    b2d.joint.enable_limit(prismatic_joint, true)
+    assert(b2d.joint.is_limit_enabled(prismatic_joint))
+    b2d.joint.set_limits(prismatic_joint, -1, 2)
+    assert_near(b2d.joint.get_lower_limit(prismatic_joint), -1)
+    assert_near(b2d.joint.get_upper_limit(prismatic_joint), 2)
+    b2d.joint.enable_motor(prismatic_joint, true)
+    assert(b2d.joint.is_motor_enabled(prismatic_joint))
+    b2d.joint.set_motor_speed(prismatic_joint, 3)
+    assert_near(b2d.joint.get_motor_speed(prismatic_joint), 3)
+    b2d.joint.set_max_motor_force(prismatic_joint, 4)
+    assert_near(b2d.joint.get_max_motor_force(prismatic_joint), 4)
+    assert(type(b2d.joint.get_motor_force(prismatic_joint)) == "number")
+    assert(type(b2d.joint.get_joint_translation(prismatic_joint)) == "number")
+    assert(type(b2d.joint.get_joint_speed(prismatic_joint)) == "number")
+    b2d.joint.destroy(prismatic_joint)
+
+    local revolute_joint = b2d.joint.create_revolute(body_a, body_b)
+    b2d.joint.enable_limit(revolute_joint, true)
+    b2d.joint.set_limits(revolute_joint, -0.5, 0.5)
+    assert_near(b2d.joint.get_lower_limit(revolute_joint), -0.5)
+    assert_near(b2d.joint.get_upper_limit(revolute_joint), 0.5)
+    b2d.joint.enable_motor(revolute_joint, true)
+    b2d.joint.set_motor_speed(revolute_joint, 6)
+    assert_near(b2d.joint.get_motor_speed(revolute_joint), 6)
+    b2d.joint.set_max_motor_torque(revolute_joint, 7)
+    assert_near(b2d.joint.get_max_motor_torque(revolute_joint), 7)
+    assert(type(b2d.joint.get_motor_torque(revolute_joint)) == "number")
+    assert(type(b2d.joint.get_joint_angle(revolute_joint)) == "number")
+    b2d.joint.destroy(revolute_joint)
+
+    local weld_joint = b2d.joint.create_weld(body_a, body_b, {
+        reference_angle = 0.25,
+    })
+    assert_near(b2d.joint.get_reference_angle(weld_joint), 0.25)
+    b2d.joint.destroy(weld_joint)
+
+    local wheel_joint = b2d.joint.create_wheel(body_a, body_b, {
+        local_axis_a = vmath.vector3(0, 1, 0),
+    })
+    b2d.joint.enable_motor(wheel_joint, true)
+    b2d.joint.set_motor_speed(wheel_joint, 8)
+    assert_near(b2d.joint.get_motor_speed(wheel_joint), 8)
+    b2d.joint.set_max_motor_torque(wheel_joint, 9)
+    assert_near(b2d.joint.get_max_motor_torque(wheel_joint), 9)
+    b2d.joint.destroy(wheel_joint)
+
+    if PHYSICS == "box2dv3" then
+        b2d.joint.enable_spring(joint, true)
+        assert(b2d.joint.is_spring_enabled(joint))
+        b2d.joint.set_spring_hertz(joint, 13)
+        assert_near(b2d.joint.get_spring_hertz(joint), 13)
+        b2d.joint.set_spring_damping_ratio(joint, 0.8)
+        assert_near(b2d.joint.get_spring_damping_ratio(joint), 0.8)
+        b2d.joint.set_length_range(joint, 2, 7)
+        assert_near(b2d.joint.get_min_length(joint), 2)
+        assert_near(b2d.joint.get_max_length(joint), 7)
+        assert(type(b2d.joint.get_current_length(joint)) == "number")
+
+        local motor_joint = b2d.joint.create_motor(body_a, body_b)
+        b2d.joint.set_linear_offset(motor_joint, vmath.vector3(1, 2, 0))
+        assert_vec3_near(b2d.joint.get_linear_offset(motor_joint), vmath.vector3(1, 2, 0))
+        b2d.joint.set_angular_offset(motor_joint, 0.3)
+        assert_near(b2d.joint.get_angular_offset(motor_joint), 0.3)
+        b2d.joint.set_max_force(motor_joint, 14)
+        assert_near(b2d.joint.get_max_force(motor_joint), 14)
+        b2d.joint.set_max_torque(motor_joint, 15)
+        assert_near(b2d.joint.get_max_torque(motor_joint), 15)
+        b2d.joint.set_correction_factor(motor_joint, 0.4)
+        assert_near(b2d.joint.get_correction_factor(motor_joint), 0.4)
+        b2d.joint.destroy(motor_joint)
+
+        local weld_v3_joint = b2d.joint.create_weld(body_a, body_b)
+        b2d.joint.set_reference_angle(weld_v3_joint, 0.6)
+        assert_near(b2d.joint.get_reference_angle(weld_v3_joint), 0.6)
+        b2d.joint.set_linear_hertz(weld_v3_joint, 16)
+        assert_near(b2d.joint.get_linear_hertz(weld_v3_joint), 16)
+        b2d.joint.set_angular_hertz(weld_v3_joint, 17)
+        assert_near(b2d.joint.get_angular_hertz(weld_v3_joint), 17)
+        b2d.joint.set_linear_damping_ratio(weld_v3_joint, 0.5)
+        assert_near(b2d.joint.get_linear_damping_ratio(weld_v3_joint), 0.5)
+        b2d.joint.set_angular_damping_ratio(weld_v3_joint, 0.6)
+        assert_near(b2d.joint.get_angular_damping_ratio(weld_v3_joint), 0.6)
+        b2d.joint.destroy(weld_v3_joint)
+    else
+        assert(b2d.joint.enable_spring == nil)
+
+        local friction_joint = b2d.joint.create_friction(body_a, body_b)
+        b2d.joint.set_max_force(friction_joint, 18)
+        assert_near(b2d.joint.get_max_force(friction_joint), 18)
+        b2d.joint.set_max_torque(friction_joint, 19)
+        assert_near(b2d.joint.get_max_torque(friction_joint), 19)
+        b2d.joint.destroy(friction_joint)
+
+        local rope_joint = b2d.joint.create_rope(body_a, body_b, {
+            max_length = 3,
+        })
+        b2d.joint.set_max_length(rope_joint, 4)
+        assert_near(b2d.joint.get_max_length(rope_joint), 4)
+        assert(type(b2d.joint.get_limit_state(rope_joint)) == "number")
+        b2d.joint.destroy(rope_joint)
+
+        local pulley_joint = b2d.joint.create_pulley(body_a, body_b, {
+            ground_anchor_a = vmath.vector3(-1, 0, 0),
+            ground_anchor_b = vmath.vector3(1, 0, 0),
+            length_a = 2,
+            length_b = 3,
+            ratio = 1.5,
+        })
+        assert_vec3_near(b2d.joint.get_ground_anchor_a(pulley_joint), vmath.vector3(-1, 0, 0))
+        assert_vec3_near(b2d.joint.get_ground_anchor_b(pulley_joint), vmath.vector3(1, 0, 0))
+        assert(type(b2d.joint.get_length_a(pulley_joint)) == "number")
+        assert(type(b2d.joint.get_length_b(pulley_joint)) == "number")
+        assert_near(b2d.joint.get_ratio(pulley_joint), 1.5)
+        b2d.joint.destroy(pulley_joint)
+
+        local gear_revolute_joint = b2d.joint.create_revolute(body_a, body_b)
+        local gear_prismatic_joint = b2d.joint.create_prismatic(body_a, body_b)
+        local gear_joint = b2d.joint.create_gear(gear_revolute_joint, gear_prismatic_joint, {
+            ratio = 2,
+        })
+        b2d.joint.set_ratio(gear_joint, 3)
+        assert_near(b2d.joint.get_ratio(gear_joint), 3)
+        assert(b2d.joint.get_joint1(gear_joint) == gear_revolute_joint)
+        assert(b2d.joint.get_joint2(gear_joint) == gear_prismatic_joint)
+        b2d.joint.destroy(gear_joint)
+        b2d.joint.destroy(gear_prismatic_joint)
+        b2d.joint.destroy(gear_revolute_joint)
+    end
 
     b2d.joint.destroy(joint)
     assert_error(function() b2d.joint.get_type(joint) end)

--- a/engine/gamesys/src/gamesys/test/collision_object/joint_test.script
+++ b/engine/gamesys/src/gamesys/test/collision_object/joint_test.script
@@ -35,8 +35,73 @@ local function assert_near(a, b, eps)
     end
 end
 
+local function assert_vec3_near(a, b, eps)
+    assert_near(a.x, b.x, eps)
+    assert_near(a.y, b.y, eps)
+    assert_near(a.z, b.z, eps)
+end
+
 -- reusable zero point
 local zp = vmath.vector3(0)
+
+local function test_native_b2d_joints(self)
+    if b2d == nil then
+        return
+    end
+
+    local body_a = b2d.get_body(self.a_coll)
+    local body_b = b2d.get_body(self.b_coll)
+    assert(body_a ~= nil)
+    assert(body_b ~= nil)
+
+    local managed_joint_id = "native_managed_joint"
+    physics.create_joint(physics.JOINT_TYPE_SPRING, self.a_coll, managed_joint_id, zp, self.b_coll, zp)
+    assert(#b2d.body.get_joints(body_a) == 0)
+    physics.destroy_joint(self.a_coll, managed_joint_id)
+
+    local joint = b2d.joint.create_distance(body_a, body_b, {
+        local_anchor_a = vmath.vector3(1, 2, 0),
+        local_anchor_b = vmath.vector3(3, 4, 0),
+        length = 5,
+        collide_connected = false,
+    })
+    assert(joint ~= nil)
+    assert(b2d.joint.get_type(joint) == b2d.joint.JOINT_TYPE_DISTANCE)
+    assert(b2d.joint.get_body_a(joint) == body_a)
+    assert(b2d.joint.get_body_b(joint) == body_b)
+    assert(not b2d.joint.get_collide_connected(joint))
+    assert_vec3_near(b2d.joint.get_local_anchor_a(joint), vmath.vector3(1, 2, 0))
+    assert_vec3_near(b2d.joint.get_local_anchor_b(joint), vmath.vector3(3, 4, 0))
+    assert(b2d.joint.get_reaction_force(joint) ~= nil)
+    assert(type(b2d.joint.get_reaction_torque(joint)) == "number")
+
+    local joints = b2d.body.get_joints(body_a)
+    local found = false
+    for _, body_joint in ipairs(joints) do
+        if body_joint == joint then
+            found = true
+            break
+        end
+    end
+    assert(found)
+
+    if PHYSICS == "box2dv3" then
+        b2d.joint.set_collide_connected(joint, true)
+        assert(b2d.joint.get_collide_connected(joint))
+    else
+        assert_error(function() b2d.joint.set_collide_connected(joint, true) end)
+    end
+
+    local mouse_joint = b2d.joint.create_mouse(body_a, body_b, {
+        target = vmath.vector3(5, 6, 0),
+        max_force = 10,
+    })
+    b2d.joint.set_mouse_target(mouse_joint, vmath.vector3(7, 8, 0))
+    b2d.joint.destroy(mouse_joint)
+
+    b2d.joint.destroy(joint)
+    assert_error(function() b2d.joint.get_type(joint) end)
+end
 
 function init(self)
 
@@ -47,6 +112,8 @@ function init(self)
     self.b = "joint_test_b"
     self.b_coll = self.b .. "#collisionobject"
     self.joint_id = "test_joint"
+
+    test_native_b2d_joints(self)
 
     -- FAIL, test invalid parameters
     assert_error(function() physics.create_joint() end)
@@ -94,7 +161,7 @@ function init(self)
     physics.destroy_joint(self.a_coll, self.joint_id)
 
     if PHYSICS=="box2dv3" then
-        physics.create_joint(physics.JOINT_TYPE_HINGE, self.a_coll, self.joint_id, zp, self.b_coll, zp, { lower_angle = 0, upper_angle = 0.95 * 3.1415927410126, enable_limit = true })
+        physics.create_joint(physics.JOINT_TYPE_HINGE, self.a_coll, self.joint_id, zp, self.b_coll, zp, { lower_angle = 0, upper_angle = 0.94 * 3.1415927410126, enable_limit = true })
     else
         physics.create_joint(physics.JOINT_TYPE_HINGE, self.a_coll, self.joint_id, zp, self.b_coll, zp, { lower_angle = 0, upper_angle = 10, enable_limit = true })
     end

--- a/engine/gamesys/src/gamesys/test/collision_object/joint_test.script
+++ b/engine/gamesys/src/gamesys/test/collision_object/joint_test.script
@@ -89,7 +89,7 @@ local function test_native_b2d_joints(self)
         b2d.joint.set_collide_connected(joint, true)
         assert(b2d.joint.get_collide_connected(joint))
     else
-        assert_error(function() b2d.joint.set_collide_connected(joint, true) end)
+        assert(b2d.joint.set_collide_connected == nil)
     end
 
     local mouse_joint = b2d.joint.create_mouse(body_a, body_b, {

--- a/engine/gamesys/src/gamesys/test/collision_object/joint_test.script
+++ b/engine/gamesys/src/gamesys/test/collision_object/joint_test.script
@@ -88,8 +88,10 @@ local function test_native_b2d_joints(self)
     if PHYSICS == "box2dv3" then
         b2d.joint.set_collide_connected(joint, true)
         assert(b2d.joint.get_collide_connected(joint))
+        b2d.joint.wake_bodies(joint)
     else
         assert(b2d.joint.set_collide_connected == nil)
+        assert(b2d.joint.wake_bodies == nil)
     end
 
     local mouse_joint = b2d.joint.create_mouse(body_a, body_b, {

--- a/engine/gamesys/src/gamesys/wscript
+++ b/engine/gamesys/src/gamesys/wscript
@@ -91,13 +91,13 @@ def build(bld):
 
     bld.stlib(features = 'cxx',
         includes = '. .. ../../src ../../proto',
-        source = 'scripts/box2d/script_box2d.cpp scripts/box2d/v3/script_box2d_body_v3.cpp scripts/box2d/v3/script_box2d_shape_v3.cpp',
+        source = 'scripts/box2d/script_box2d.cpp scripts/box2d/v3/script_box2d_body_v3.cpp scripts/box2d/v3/script_box2d_joint_v3.cpp scripts/box2d/v3/script_box2d_shape_v3.cpp',
         uselib = 'LUA',
         target = 'script_box2d')
 
     bld.stlib(features = 'cxx',
         includes = '. .. ../../src ../../proto ' + build_util.get_dynamo_ext('include', 'box2d_defold'),
-        source = 'scripts/box2d/script_box2d.cpp scripts/box2d/v2/script_box2d_body_v2.cpp scripts/box2d/v2/script_box2d_fixture_v2.cpp scripts/box2d/v2/script_box2d_shape_v2.cpp',
+        source = 'scripts/box2d/script_box2d.cpp scripts/box2d/v2/script_box2d_body_v2.cpp scripts/box2d/v2/script_box2d_fixture_v2.cpp scripts/box2d/v2/script_box2d_joint_v2.cpp scripts/box2d/v2/script_box2d_shape_v2.cpp',
         uselib = 'LUA',
         target = 'script_box2d_defold')
 


### PR DESCRIPTION

Fixes https://github.com/defold/defold/issues/8753

### Box2D v2 Lua Joint API

  Added `b2d.body.get_joints`.

  Added `b2d.joint` functions:
  - `destroy`
  - `get_type`
  - `get_body_a`
  - `get_body_b`
  - `get_local_anchor_a`
  - `get_local_anchor_b`
  - `get_anchor_a`
  - `get_anchor_b`
  - `is_active`
  - `get_collide_connected`
  - `get_reaction_force`
  - `get_reaction_torque`

  Added v2 joint creation:
  - `create_distance`
  - `create_mouse`
  - `create_prismatic`
  - `create_revolute`
  - `create_weld`
  - `create_wheel`
  - `create_friction`
  - `create_rope`
  - `create_pulley`
  - `create_gear`

  Added v2 joint property access:
  - `set_mouse_target`, `get_mouse_target`
  - `set_length`, `get_length`
  - `set_frequency`, `get_frequency`
  - `set_hertz`, `get_hertz`
  - `set_damping_ratio`, `get_damping_ratio`
  - `set_spring_damping_ratio`, `get_spring_damping_ratio`
  - `get_local_axis_a`
  - `get_reference_angle`
  - `get_joint_translation`
  - `get_joint_speed`
  - `get_joint_angle`
  - `enable_limit`, `is_limit_enabled`
  - `set_limits`, `get_lower_limit`, `get_upper_limit`
  - `enable_motor`, `is_motor_enabled`
  - `set_motor_speed`, `get_motor_speed`
  - `set_max_motor_force`, `get_max_motor_force`, `get_motor_force`
  - `set_max_motor_torque`, `get_max_motor_torque`, `get_motor_torque`
  - `set_max_force`, `get_max_force`
  - `set_max_torque`, `get_max_torque`
  - `set_max_length`, `get_max_length`
  - `get_limit_state`
  - `get_ground_anchor_a`, `get_ground_anchor_b`
  - `get_length_a`, `get_length_b`
  - `set_ratio`, `get_ratio`
  - `get_joint1`, `get_joint2`

  ### Box2D v3 Lua Joint API

  Added `b2d.body.get_joints`.

  Added `b2d.joint` functions:
  - `destroy`
  - `get_type`
  - `get_body_a`
  - `get_body_b`
  - `get_local_anchor_a`
  - `get_local_anchor_b`
  - `get_anchor_a`
  - `get_anchor_b`
  - `get_collide_connected`
  - `set_collide_connected`
  - `wake_bodies`
  - `get_reaction_force`
  - `get_reaction_torque`

  Added v3 joint creation:
  - `create_distance`
  - `create_mouse`
  - `create_prismatic`
  - `create_revolute`
  - `create_weld`
  - `create_wheel`
  - `create_motor`
  - `create_filter`

  Added v3 joint property access:
  - `set_mouse_target`, `get_mouse_target`
  - `set_length`, `get_length`
  - `enable_spring`, `is_spring_enabled`
  - `set_spring_hertz`, `get_spring_hertz`
  - `set_hertz`, `get_hertz`
  - `set_frequency`, `get_frequency`
  - `set_spring_damping_ratio`, `get_spring_damping_ratio`
  - `set_damping_ratio`, `get_damping_ratio`
  - `set_length_range`
  - `set_min_length`, `get_min_length`
  - `set_max_length`, `get_max_length`
  - `get_current_length`
  - `enable_limit`, `is_limit_enabled`
  - `set_limits`, `get_lower_limit`, `get_upper_limit`
  - `enable_motor`, `is_motor_enabled`
  - `set_motor_speed`, `get_motor_speed`
  - `set_max_motor_force`, `get_max_motor_force`, `get_motor_force`
  - `set_max_motor_torque`, `get_max_motor_torque`, `get_motor_torque`
  - `set_max_force`, `get_max_force`
  - `set_max_torque`, `get_max_torque`
  - `set_linear_offset`, `get_linear_offset`
  - `set_angular_offset`, `get_angular_offset`
  - `set_correction_factor`, `get_correction_factor`
  - `get_joint_translation`
  - `get_joint_speed`
  - `get_joint_angle`
  - `set_reference_angle`, `get_reference_angle`
  - `set_linear_hertz`, `get_linear_hertz`
  - `set_linear_damping_ratio`, `get_linear_damping_ratio`
  - `set_angular_hertz`, `get_angular_hertz`
  - `set_angular_damping_ratio`, `get_angular_damping_ratio`
 
### Technical changes

https://github.com/JCash/example-box2d

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
