### PR TITLE
Produce correct canonical name for UBO members

### DIFF
--- a/engine/gamesys/src/gamesys/components/comp_model.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_model.cpp
@@ -64,7 +64,7 @@ namespace dmGameSystem
 
     const dmhash_t PBR_METALLIC_ROUGHNESS_BASE_COLOR_FACTOR                         = dmHashString64("pbrMetallicRoughness.baseColorFactor");
     const dmhash_t PBR_METALLIC_ROUGHNESS_METALLIC_AND_ROUGHNESS_FACTOR             = dmHashString64("pbrMetallicRoughness.metallicAndRoughnessFactor");
-    const dmhash_t PBR_METALLIC_ROUGHNESS_TEXTURES                                  = dmHashString64("pbrMetallicRoughness.metallicAndRoughnessTextures");
+    const dmhash_t PBR_METALLIC_ROUGHNESS_TEXTURES                                  = dmHashString64("pbrMetallicRoughness.metallicRoughnessTextures");
     const dmhash_t PBR_SPECULAR_GLOSSINESS_DIFFUSE_FACTOR                           = dmHashString64("pbrSpecularGlossiness.diffuseFactor");
     const dmhash_t PBR_SPECULAR_GLOSSINESS_SPECULAR_AND_SPECULAR_GLOSSINESS_FACTOR  = dmHashString64("pbrSpecularGlossiness.specularAndSpecularGlossinessFactor");
     const dmhash_t PBR_SPECULAR_GLOSSINESS_TEXTURES                                 = dmHashString64("pbrSpecularGlossiness.specularGlossinessTextures");

--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -3118,17 +3118,35 @@ static void LogFrameBufferError(GLenum status)
         }
     }
 
-    static inline char* GetBaseUniformName(char* str, uint32_t len)
+    static inline char* GetBaseUniformName(char* str, uint32_t len, bool strip_namespace)
     {
         char* ptr = str;
-        for (int i = len - 1; i >= 0; i--)
+        char* write = ptr;
+        for (uint32_t i = 0; i < len && ptr[i]; ++i)
         {
-            // For arrays, OpenGL returns the name as `name[0]`
             if (ptr[i] == '[')
             {
-                ptr[i] = 0;
+                while (i < len && ptr[i] && ptr[i] != ']')
+                {
+                    ++i;
+                }
             }
-            else if (ptr[i] == '.')
+            else
+            {
+                *write++ = ptr[i];
+            }
+        }
+        *write = 0;
+
+        if (!strip_namespace)
+        {
+            return ptr;
+        }
+
+        uint32_t normalized_len = strlen(ptr);
+        for (int i = (int) normalized_len - 1; i >= 0; i--)
+        {
+            if (ptr[i] == '.')
             {
                 return &ptr[i+1];
             }
@@ -3479,7 +3497,7 @@ static void LogFrameBufferError(GLenum status)
                 uniform_location = (HUniformLocation) glGetUniformLocation(program_handle, uniform_name_buffer);
             }
 
-            char* uniform_name = GetBaseUniformName(uniform_name_buffer, uniform_name_length);
+            char* uniform_name = GetBaseUniformName(uniform_name_buffer, uniform_name_length, uniform_block_index == -1);
             uniform_name_length = strlen(uniform_name);
 
             // These are temporary strings, we need copies of them.

--- a/engine/graphics/src/vulkan/graphics_vulkan.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan.cpp
@@ -1709,8 +1709,25 @@ bail:
         uint32_t swapchainImageIndex = context->m_SwapChain->m_ImageIndex;
         VkSemaphore renderFinishedSemaphore = context->m_SwapChain->m_RenderFinishedSemaphores[swapchainImageIndex];
 
+        FlushPendingRenderTargetClear(context, context->m_CurrentRenderTarget);
+
         // End the current render pass
         EndRenderPass(context);
+
+        // Present still requires a valid swapchain image layout even on frames that never
+        // materialized the main render pass.
+        if (!context->m_MainRTBegunThisFrame)
+        {
+            DM_MUTEX_SCOPED_LOCK(context->m_BaseContext.m_AssetHandleContainerMutex);
+            VulkanTexture* tex_sc = GetAssetFromContainer<VulkanTexture>(context->m_BaseContext.m_AssetHandleContainer, context->m_CurrentSwapchainTexture);
+            TransitionImageLayoutWithCmdBuffer(
+                context->m_MainCommandBuffers[frameInFlight],
+                tex_sc,
+                VK_IMAGE_ASPECT_COLOR_BIT,
+                VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
+                0,
+                1);
+        }
 
         // Finish recording the command buffer for this frame-in-flight
         VkCommandBuffer cmd = context->m_MainCommandBuffers[frameInFlight];
@@ -2692,6 +2709,9 @@ bail:
                             0,
                             bound_ubo->m_BaseUniformBuffer.m_Layout.m_Size);
                         TouchResource(context, &bound_ubo->m_DeviceBuffer);
+
+                        dynamic_offsets[dynamic_offset_index] = 0;
+                        dynamic_offset_index++;
                     }
                     else
                     {


### PR DESCRIPTION
### Technical changes

* using a uniform buffer with nested structs did not produce the correct canonical names for OpenGL
* fix for vulkan when using engine bounded uniform buffers (e.g the LightBuffer) and scratch uniform buffers
* validation error for vulkan related to deferred clearing of buffers
* use the correct assumed PbrMaterial uniform name for metallic+roughness textures