### PR TITLE
Offload font map generation to a later build phase

### DIFF
--- a/editor/src/clj/editor/font.clj
+++ b/editor/src/clj/editor/font.clj
@@ -41,7 +41,7 @@
             [editor.workspace :as workspace]
             [schema.core :as schema]
             [service.log :as log])
-  (:import [com.dynamo.bob.font BMFont]
+  (:import [com.dynamo.bob.font BMFont Fontc]
            [com.dynamo.render.proto Font$FontDesc Font$FontMap Font$FontRenderMode Font$FontTextureFormat Font$GlyphBank]
            [com.google.protobuf ByteString]
            [com.jogamp.opengl GL GL2]
@@ -652,7 +652,8 @@
     (make-font-map _node-id font type font-desc (make-font-resource-resolver font font-resource-map))))
 
 (defn- build-glyph-bank [resource _dep-resources user-data]
-  (let [{:keys [font-map]} user-data]
+  (let [{:keys [font-desc font font-resource-map type digest-ignored/node-id]} user-data
+        font-map (make-font-map node-id font type font-desc (make-font-resource-resolver font font-resource-map))]
     (g/precluding-errors
       [font-map]
       (let [compressed-font-map (font-gen/compress font-map)]
@@ -666,47 +667,64 @@
      :build-fn build-glyph-bank
      :user-data user-data}))
 
-(g/defnk produce-build-targets [_node-id resource cache-width cache-height font-map material dep-build-targets runtime-generation-build-target]
+(g/defnk produce-build-targets [_node-id resource font save-value material dep-build-targets runtime-generation-build-target font-resource-map]
   (or (when-let [errors (->> [(validation/prop-error :fatal _node-id :material validation/prop-nil? material material-message)
                               (validation/prop-error :fatal _node-id :material validation/prop-resource-not-exists? material material-message)]
                              (remove nil?)
                              (not-empty))]
         (g/error-aggregate errors))
-      (let [workspace (resource/workspace resource)
-            pb-map (protobuf/make-map-without-defaults Font$FontMap
-                     :material material
-                     :size (:size font-map)
-                     :antialias (:antialias font-map)
-                     :shadow-x (:shadow-x font-map)
-                     :shadow-y (:shadow-y font-map)
-                     :shadow-blur (:shadow-blur font-map)
-                     :shadow-alpha (:shadow-alpha font-map)
-                     :alpha (:alpha font-map)
-                     :outline-alpha (:outline-alpha font-map)
-                     :outline-width (:outline-width font-map)
-                     :layer-mask (:layer-mask font-map)
-                     :output-format (:output-format font-map)
-                     :render-mode (:render-mode font-map)
-                     :all-chars (:all-chars font-map)
-                     :characters (:characters font-map)
-                     :cache-width cache-width
-                     :cache-height cache-height
-                     :sdf-spread (:sdf-spread font-map)
-                     :sdf-outline (:sdf-outline font-map)
-                     :sdf-shadow (:sdf-shadow font-map))
+      (let [font-desc (protobuf/inject-defaults Font$FontDesc save-value)
+            font-desc-pb (protobuf/map->pb Font$FontDesc font-desc)
+            workspace (resource/workspace resource)
+            output-format (:output-format font-desc)
+            type (font-type font output-format)
+            is-distance-field (= :type-distance-field output-format)
+            pb-map (cond-> (protobuf/make-map-without-defaults Font$FontMap
+                             :material material
+                             :size (:size font-desc)
+                             :antialias (:antialias font-desc)
+                             :shadow-x (:shadow-x font-desc)
+                             :shadow-y (:shadow-y font-desc)
+                             :shadow-blur (:shadow-blur font-desc)
+                             :shadow-alpha (:shadow-alpha font-desc)
+                             :alpha (:alpha font-desc)
+                             :outline-alpha (:outline-alpha font-desc)
+                             :outline-width (:outline-width font-desc)
+                             :layer-mask (Fontc/GetFontMapLayerMask font-desc-pb)
+                             :output-format output-format
+                             :render-mode (:render-mode font-desc)
+                             :all-chars (:all-chars font-desc)
+                             :characters (:characters font-desc)
+                             :cache-width (:cache-width font-desc)
+                             :cache-height (:cache-height font-desc))
 
-            [pb-map dep-build-targets]
-            (if (and runtime-generation-build-target
-                     (= :type-distance-field (:output-format font-map))) ; Currently, only distance field fonts can be runtime-generated.
-              [(assoc pb-map :font (:resource runtime-generation-build-target))
-               (conj dep-build-targets runtime-generation-build-target)]
-              (let [glyph-bank-pb-fields (protobuf/field-key-set Font$GlyphBank)
-                    glyph-bank-user-data {:font-map (select-keys font-map glyph-bank-pb-fields)}
-                    glyph-bank-build-target (make-glyph-bank-build-target workspace _node-id glyph-bank-user-data)]
-                [(assoc pb-map :glyph-bank (:resource glyph-bank-build-target))
-                 (conj dep-build-targets glyph-bank-build-target)]))]
-
-        [(pipeline/make-protobuf-build-target _node-id resource Font$FontMap pb-map dep-build-targets)])))
+                           is-distance-field
+                           (assoc :sdf-spread (Fontc/GetFontMapSdfSpread font-desc-pb)
+                                  :sdf-outline (Fontc/GetFontMapSdfOutline font-desc-pb)
+                                  :sdf-shadow (Fontc/GetFontMapSdfShadow font-desc-pb)))]
+        (if (and runtime-generation-build-target
+                 ;; Currently, only distance field fonts can be runtime-generated.
+                 is-distance-field)
+          [(pipeline/make-protobuf-build-target _node-id resource Font$FontMap
+             (assoc pb-map :font (:resource runtime-generation-build-target))
+             (conj dep-build-targets runtime-generation-build-target))]
+          (let [source-sha1s (into (sorted-map)
+                                   (comp (filter #(and (some? %) (resource/exists? %)))
+                                         (map (juxt resource/proj-path
+                                                    resource/resource->path-inclusive-sha1-hex)))
+                                   (cons font (vals font-resource-map)))
+                glyph-bank-build-target (make-glyph-bank-build-target
+                                          workspace
+                                          _node-id
+                                          {:font-desc font-desc
+                                           :font font
+                                           :font-resource-map font-resource-map
+                                           :digest-ignored/node-id _node-id
+                                           :type type
+                                           :source-sha1s source-sha1s})]
+            [(pipeline/make-protobuf-build-target _node-id resource Font$FontMap
+               (assoc pb-map :glyph-bank (:resource glyph-bank-build-target))
+               (conj dep-build-targets glyph-bank-build-target))])))))
 
 (g/defnode BitmapFontSourceNode
   (inherits resource-node/ResourceNode)

--- a/editor/src/clj/editor/font.clj
+++ b/editor/src/clj/editor/font.clj
@@ -699,9 +699,10 @@
                              :cache-height (:cache-height font-desc))
 
                            is-distance-field
-                           (assoc :sdf-spread (Fontc/GetFontMapSdfSpread font-desc-pb)
-                                  :sdf-outline (Fontc/GetFontMapSdfOutline font-desc-pb)
-                                  :sdf-shadow (Fontc/GetFontMapSdfShadow font-desc-pb)))]
+                           (merge (protobuf/make-map-without-defaults Font$FontMap
+                                    :sdf-spread (Fontc/GetFontMapSdfSpread font-desc-pb)
+                                    :sdf-outline (Fontc/GetFontMapSdfOutline font-desc-pb)
+                                    :sdf-shadow (Fontc/GetFontMapSdfShadow font-desc-pb))))]
         (if (and runtime-generation-build-target
                  ;; Currently, only distance field fonts can be runtime-generated.
                  is-distance-field)

--- a/editor/test/integration/font_test.clj
+++ b/editor/test/integration/font_test.clj
@@ -18,9 +18,11 @@
             [dynamo.graph :as g]
             [editor.defold-project :as project]
             [editor.font :as font]
+            [editor.pipeline.font-gen :as font-gen]
             [editor.protobuf :as protobuf]
             [editor.workspace :as workspace]
-            [integration.test-util :as test-util])
+            [integration.test-util :as test-util]
+            [util.coll :as coll])
   (:import [com.dynamo.render.proto Font$FontDesc]))
 
 (defn- prop [node-id label]
@@ -84,6 +86,16 @@
       (is (not (.contains no-break " ")))
       (is (< w ew))
       (is (< eh h)))))
+
+(deftest build-targets-do-not-generate-font-map
+  (test-util/with-loaded-project
+    (let [node-id (test-util/resource-node project "/fonts/score.font")]
+      (g/clear-system-cache!)
+      (with-redefs [font-gen/generate (fn [& _]
+                                        (throw (AssertionError. "font-map should not be generated for build-targets")))]
+        (let [build-targets (g/node-value node-id :build-targets)]
+          (when (is (not (g/error? build-targets)))
+            (is (some? (coll/some #(get-in % [:user-data :pb-map :glyph-bank]) build-targets)))))))))
 
 (deftest validation
   (test-util/with-loaded-project


### PR DESCRIPTION
On large projects with many fonts (that don't use runtime generation), build times improved by 7-15%.

Technical notes:

Build time measurements are generally noisy, but for me, the build time of a clean build improved by ~15%, warm build improved by 14%, and hot build by 7%.

Here are 2 example profiling runs of before vs after changes:

| Phase | Baseline run 1 | Font changes run 1 | Delta | 
|---|---:|---:|---:|
| clean-build | 7:28 | 5:51 | -1:37, -21.7% |
| warm-build | 4:56 | 4:00 | -0:56, -18.9% |
| hot-build | 28.37 s | 25.03 s | -3.34 s, -11.8% |

| Phase | Baseline run 2 | Font changes run 2 | Delta | 
|---|---:|---:|---:|
| clean-build | 8:03 | 6:57 | -1:06, -13.7% |
| warm-build | 4:59 | 4:28 | -0:31, -10.4% |
| hot-build | 28.97 s | 27.25 s | -1.72 s, -5.9% |

As a reminder:
- Clean build: nothing in disc cache
- Warm build: disc cache exists
- Hot build: disc and in-memory caches exist

To be honest, I expected to only get improvements for the wam build (we now get the result from the cache), but I guess it makes sense that the clean build also improved. Getting the tree of initial build targets uses node-value, so essentially sequential, while build fns are invoked in parallel, so this change also parallelizes font-map building.

Related to #11988