### PR TITLE
Resolve game.project resource defaults before rendering the form

### DIFF
--- a/editor/src/clj/editor/settings.clj
+++ b/editor/src/clj/editor/settings.clj
@@ -47,28 +47,37 @@
   ;; resource-setting-reference only consumed by SettingsNode and already cached there.
   (output resource-setting-reference g/Any (g/fnk [_node-id path value] {:path path :node-id _node-id :value value})))
 
+(defn- resolve-resource-settings [settings value-field resolve-resource-fn]
+  (mapv (fn [setting]
+          (cond-> setting
+                  ;; Resolve string resource values so the form gets typed values.
+                  ;; This covers raw settings without ResourceSettingNodes, and
+                  ;; defaults from metadata merged after load.
+                  (and (= :resource (:type setting))
+                       (string? (get setting value-field)))
+                  (update value-field resolve-resource-fn)))
+        settings))
+
+(defn- type-annotate-settings [settings meta-settings]
+  (let [meta-settings-map (settings-core/make-meta-settings-map meta-settings)]
+    (mapv #(assoc % :type (:type (meta-settings-map (:path %)))) settings)))
+
 (defn- resolve-resource-settings-from-raw [basis raw-settings meta-settings owner-resource]
   ;; evaluation context is an `^:unsafe` part of the output: can be used only
   ;; for resource resolution (that are then only needed for paths)
-  (let [resolve-resource #(workspace/resolve-resource basis owner-resource %)
-        meta-settings-map (settings-core/make-meta-settings-map meta-settings)]
-    (->> raw-settings
-         (settings-core/settings-with-value)
-         (settings-core/sanitize-settings meta-settings)
-         (mapv (fn [{:keys [path value] :as setting}]
-                 ;; We resolve raw string values to resources so the form gets
-                 ;; typed values; this may happen when a :resource setting is
-                 ;; defined via, e.g., game.properties, without a corresponding
-                 ;; ResourceSettingNode in the graph.
-                 (cond-> setting
-                         (and (string? value) (= :resource (:type (meta-settings-map path))))
-                         (assoc :value (resolve-resource value))))))))
+  (let [resolve-resource #(workspace/resolve-resource basis owner-resource %)]
+    (-> raw-settings
+        (settings-core/settings-with-value)
+        (->> (settings-core/sanitize-settings meta-settings))
+        (type-annotate-settings meta-settings)
+        (resolve-resource-settings :value resolve-resource))))
 
 (g/defnk produce-settings-map [^:unsafe _evaluation-context owner-resource meta-info raw-settings resource-settings]
   ;; we use evaluation context to resolve a resource; we only need the resource
   ;; for its path, so it's safe to use it here
   (let [basis (:basis _evaluation-context)
-        meta-settings (:settings meta-info)
+        resolve-resource #(workspace/resolve-resource basis owner-resource %)
+        meta-settings (resolve-resource-settings (:settings meta-info) :default resolve-resource)
         sanitized-settings (resolve-resource-settings-from-raw basis raw-settings meta-settings owner-resource)
         all-settings (concat (settings-core/make-default-settings meta-settings) sanitized-settings resource-settings)
         settings-map (settings-core/make-settings-map all-settings)]
@@ -211,6 +220,8 @@
   ;; we use evaluation context to resolve a resource; we only need the resource
   ;; for its path, so it's safe to use it here
   (let [basis (:basis _evaluation-context)
+        resolve-resource #(workspace/resolve-resource basis owner-resource %)
+        meta-info (update meta-info :settings resolve-resource-settings :default resolve-resource)
         meta-settings (:settings meta-info)
         sanitized-settings (resolve-resource-settings-from-raw basis raw-settings meta-settings owner-resource)
         non-defaulted-setting-paths (into #{}
@@ -292,17 +303,6 @@
               (cond-> raw-meta-info
                       project-meta-info (settings-core/merge-meta-infos project-meta-info)
                       (and ext-meta-info (= "project" (resource/type-ext owner-resource))) (settings-core/merge-meta-infos ext-meta-info))))))
-
-(defn- resolve-resource-settings [settings value-field resolve-resource-fn]
-  (mapv (fn [setting]
-          (if (= :resource (:type setting))
-            (update setting value-field resolve-resource-fn)
-            setting))
-        settings))
-
-(defn- type-annotate-settings [settings meta-settings]
-  (let [meta-settings-map (settings-core/make-meta-settings-map meta-settings)]
-    (mapv #(assoc % :type (:type (meta-settings-map (:path %)))) settings)))
 
 (defn load-settings-node [project owner-resource-node self resource raw-settings initial-meta-info resource-setting-connections]
   (let [basis (g/now)


### PR DESCRIPTION
Some native extensions add project settings with default file references. Opening game.project could crash when those defaults were shown in the editor. These defaults are now handled correctly.

Fix #12365
