### PR TITLE
Editor: Fix macOS dialog windows showing in-window menu bars

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -1879,7 +1879,7 @@
     :id ::file
     :children [{:label (localization/message "command.file.new")
                 :id ::new
-                :expand false
+                :user-data {:no-expand true}
                 :command :file.new}
                {:label (localization/message "command.file.open")
                 :id ::open

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -1879,6 +1879,7 @@
     :id ::file
     :children [{:label (localization/message "command.file.new")
                 :id ::new
+                :expand false
                 :command :file.new}
                {:label (localization/message "command.file.open")
                 :id ::open

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -1879,7 +1879,7 @@
     :id ::file
     :children [{:label (localization/message "command.file.new")
                 :id ::new
-                :user-data {:no-expand true}
+                :expand false
                 :command :file.new}
                {:label (localization/message "command.file.open")
                 :id ::open

--- a/editor/src/clj/editor/asset_browser.clj
+++ b/editor/src/clj/editor/asset_browser.clj
@@ -584,7 +584,8 @@
               (app-view/open-resource! app-view prefs localization project resource))
             (select-resource! asset-browser resource))))))
   (options [workspace user-data localization evaluation-context]
-    (when (not user-data)
+    (when (or (not user-data)
+              (not (:no-expand user-data)))
       (let [basis (:basis evaluation-context)
 
             base-columns

--- a/editor/src/clj/editor/asset_browser.clj
+++ b/editor/src/clj/editor/asset_browser.clj
@@ -584,8 +584,7 @@
               (app-view/open-resource! app-view prefs localization project resource))
             (select-resource! asset-browser resource))))))
   (options [workspace user-data localization evaluation-context]
-    (when (or (not user-data)
-              (not (:no-expand user-data)))
+    (when (not user-data)
       (let [basis (:basis evaluation-context)
 
             base-columns

--- a/editor/src/clj/editor/ui.clj
+++ b/editor/src/clj/editor/ui.clj
@@ -1655,7 +1655,8 @@
         (let [label (or (handler/label handler-ctx evaluation-context) label)
               enabled? (handler/enabled? handler-ctx evaluation-context)
               key-combo (first (keymap/shortcuts keymap command))
-              options (handler/options handler-ctx evaluation-context)]
+              options (when (not (false? (:expand item)))
+                        (handler/options handler-ctx evaluation-context))]
           (if (or (nil? options)
                   (and key-combo (not (:expand item))))
             (make-menu-command scene id label localization icon style key-combo user-data command enabled? check)

--- a/editor/src/clj/editor/ui.clj
+++ b/editor/src/clj/editor/ui.clj
@@ -1659,7 +1659,8 @@
           (if (or (nil? options)
                   (and key-combo (not (:expand item))))
             (make-menu-command scene id label localization icon style key-combo user-data command enabled? check)
-            (if (some-> options meta :layout (= :grid))
+            (if (and (some-> options meta :layout (= :grid))
+                     (:expand item))
               (let [grid-menu (make-grid-menu scene localization options command-contexts evaluation-context)]
                 (make-submenu id label localization icon style [grid-menu] #(focus-first-grid-menu-item grid-menu)))
               (make-submenu id label localization icon style

--- a/editor/src/clj/editor/ui.clj
+++ b/editor/src/clj/editor/ui.clj
@@ -1656,8 +1656,11 @@
               enabled? (handler/enabled? handler-ctx evaluation-context)
               key-combo (first (keymap/shortcuts keymap command))
               options (handler/options handler-ctx evaluation-context)]
+          ;; NOTE: We have to make a distinction for menu items without :expand key
+          ;; vs ones that have explicitly set it to false, effecitvely forcing no expansion
           (if (or (nil? options)
-                  (not (:expand item)))
+                  (and key-combo (nil? (:expand item)))
+                  (false? (:expand item)))
             (make-menu-command scene id label localization icon style key-combo user-data command enabled? check)
             (if (and (some-> options meta :layout (= :grid))
                      (:expand item))

--- a/editor/src/clj/editor/ui.clj
+++ b/editor/src/clj/editor/ui.clj
@@ -1657,7 +1657,7 @@
               key-combo (first (keymap/shortcuts keymap command))
               options (handler/options handler-ctx evaluation-context)]
           (if (or (nil? options)
-                  (and key-combo (not (:expand item))))
+                  (not (:expand item)))
             (make-menu-command scene id label localization icon style key-combo user-data command enabled? check)
             (if (and (some-> options meta :layout (= :grid))
                      (:expand item))

--- a/editor/src/clj/editor/ui.clj
+++ b/editor/src/clj/editor/ui.clj
@@ -1656,14 +1656,10 @@
               enabled? (handler/enabled? handler-ctx evaluation-context)
               key-combo (first (keymap/shortcuts keymap command))
               options (handler/options handler-ctx evaluation-context)]
-          ;; NOTE: We have to make a distinction for menu items without :expand key
-          ;; vs ones that have explicitly set it to false, effecitvely forcing no expansion
           (if (or (nil? options)
-                  (and key-combo (nil? (:expand item)))
-                  (false? (:expand item)))
+                  (and key-combo (not (:expand item))))
             (make-menu-command scene id label localization icon style key-combo user-data command enabled? check)
-            (if (and (some-> options meta :layout (= :grid))
-                     (:expand item))
+            (if (some-> options meta :layout (= :grid))
               (let [grid-menu (make-grid-menu scene localization options command-contexts evaluation-context)]
                 (make-submenu id label localization icon style [grid-menu] #(focus-first-grid-menu-item grid-menu)))
               (make-submenu id label localization icon style


### PR DESCRIPTION
The menu bars no longer show up. Also the native system menu on macOS better reflects what options are available.

Fix #12156

### Technical changes

Original finding explaining why the menu bars were showing up to begin with is here;
https://github.com/defold/defold/pull/12324#issuecomment-4405978657

This PR also fixes the following;

<img width="1600" height="1000" alt="image" src="https://github.com/user-attachments/assets/8ffc3564-fc61-4bb9-b28a-c572ed6cd120" />


The context system cannot find a key-combo for command.file.new when a dialog window is opened, which is likely correct behavior. However, there is an edge case when generating menus where if we evaluate whether to make a sub-menu or to create a command entry, if the item _has_ options populated, then it depends on it having a key-combo assigned in order to render as a command. This is unique to command.file.new since it can be both a single command and a submenu.

I first tried adding an `:expand false` descriptor to the command, and it worked, however, it was still generating options, so as a small optimization, we avoid computing them by using `:user-data` instead and checking for `:no-expand` when deciding whether to populate options.