### PR TITLE
Improve UI responsiveness during builds

### DIFF
--- a/editor/project.clj
+++ b/editor/project.clj
@@ -88,7 +88,7 @@
 
                      [com.github.ben-manes.caffeine/caffeine "3.1.2"]
 
-                     [cljfx "1.10.6"
+                     [cljfx "1.10.8"
                       :exclusions [org.clojure/clojure
                                    org.openjfx/javafx-base
                                    org.openjfx/javafx-graphics

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -737,27 +737,21 @@
 (defn- local-url [target web-server]
   (format "http://%s:%s%s" (:local-address target) (http-server/port web-server) hot-reload/url-prefix))
 
-(def ^:private app-task-progress
-  {:main (ref progress/done)
-   :build (ref progress/done)
-   :resource-sync (ref progress/done)
-   :save-all (ref progress/done)
-   :fetch-libraries (ref progress/done)
-   :download-update (ref progress/done)})
+(def ^:private initial-app-task-progress
+  {:main progress/done
+   :build progress/done
+   :resource-sync progress/done
+   :save-all progress/done
+   :fetch-libraries progress/done
+   :download-update progress/done})
 
-(declare ^:private render-task-progress!)
-
-(defn- cancel-task!
-  [task-key]
-  (dosync
-    (let [progress-ref (task-key app-task-progress)]
-      (render-task-progress! task-key (progress/cancel @progress-ref)))))
+(def ^:private app-task-state
+  (atom {:progress initial-app-task-progress
+         :render-ui-inflight false}))
 
 (def ^:private app-task-ui-priority
   "Task priority in descending order (from highest to lowest)"
   [:save-all :resource-sync :fetch-libraries :build :download-update :main])
-
-(def ^:private render-task-progress-ui-inflight (ref false))
 
 (def status-bar-controls-delay
   (delay
@@ -765,29 +759,46 @@
       (.. (ui/main-stage) (getScene) (getRoot) (lookup "#status-bar"))
       ["progress-bar" "progress-hbox" "progress-percentage-label" "status-label" "progress-cancel-button"])))
 
+(declare ^:private render-task-progress-ui!)
+
+(defn- update-app-task-state! [f & args]
+  (let [[old-state new-state] (apply swap-vals! app-task-state f args)]
+    (when (and (not (:render-ui-inflight old-state))
+               (:render-ui-inflight new-state))
+      (ui/run-later (render-task-progress-ui!)))
+    [old-state new-state]))
+
+(defn- set-task-progress-state [state key progress]
+  (-> state
+      (update :progress assoc key progress)
+      (assoc :render-ui-inflight true)))
+
+(defn- update-task-progress-state [state key f & args]
+  (set-task-progress-state state key (apply f (-> state :progress (get key)) args)))
+
+(defn- cancel-task!
+  [task-key]
+  (update-app-task-state! update-task-progress-state task-key progress/cancel))
+
 (defn- render-task-progress-ui! []
-  (let [task-progress-snapshot (ref nil)]
-    (dosync
-      (ref-set render-task-progress-ui-inflight false)
-      (ref-set task-progress-snapshot
-               (into {} (map (juxt first (comp deref second))) app-task-progress)))
+  (let [task-progress-snapshot (:progress (swap! app-task-state assoc :render-ui-inflight false))]
     (let [[key progress] (->> app-task-ui-priority
-                              (map (juxt identity @task-progress-snapshot))
+                              (map (juxt identity task-progress-snapshot))
                               (filter (comp (complement progress/done?) second))
                               first)
-          show-progress-hbox? (boolean (and (not= key :main)
-                                            progress
-                                            (not (progress/done? progress))))
+          show-progress-hbox (boolean (and (not= key :main)
+                                           progress
+                                           (not (progress/done? progress))))
           localization (ui/user-data (.getScene (ui/main-stage)) :localization)
           {:keys [progress-bar progress-hbox progress-percentage-label status-label progress-cancel-button]} @status-bar-controls-delay]
       (ui/render-progress-message!
-        (if key progress (@task-progress-snapshot :main))
+        (if key progress (task-progress-snapshot :main))
         status-label
         localization)
       ;; The bottom right of the status bar can show either the progress-hbox
       ;; or the update-link, or both. The progress-hbox will cover
       ;; the update-link if both are visible.
-      (if-not show-progress-hbox?
+      (if-not show-progress-hbox
         (ui/visible! progress-hbox false)
         (do
           (ui/visible! progress-hbox true)
@@ -804,40 +815,38 @@
               (ui/on-action! identity))))))))
 
 (defn- render-task-progress! [key progress]
-  (let [schedule-render-task-progress-ui (ref false)]
-    (dosync
-      (ref-set (get app-task-progress key) progress)
-      (ref-set schedule-render-task-progress-ui (not @render-task-progress-ui-inflight))
-      (ref-set render-task-progress-ui-inflight true))
-    (when @schedule-render-task-progress-ui
-      (ui/run-later (render-task-progress-ui!)))))
+  (update-app-task-state! set-task-progress-state key progress))
 
 (defn make-render-task-progress [key]
-  (assert (contains? app-task-progress key))
+  (assert (contains? initial-app-task-progress key))
   (progress/throttle-render-progress
     (fn [progress] (render-task-progress! key progress))))
 
 (defn begin-task-progress! [key]
-  (let [progress-ref (get app-task-progress key)
-        prev-progress-atom (atom nil)]
-    (assert (some? progress-ref))
+  (let [prev-progress-atom (atom nil)]
+    (assert (contains? initial-app-task-progress key))
     (pair
       (fn render-progress! [progress]
         ;; Combined throttling and inheritance of cancel state.
         ;; The first call to render-progress! overwrites the cancel state of the
-        ;; progress-ref, and then subsequent calls will inherit the cancel state
-        ;; from the progress-ref. This is to ensure we see changes to the
-        ;; progress-refs cancel state from the cancel-task! function.
+        ;; task progress, and then subsequent calls will inherit the cancel state
+        ;; from the task progress. This is to ensure we see changes to the
+        ;; task progress cancel state from the cancel-task! function.
         (let [prev-progress @prev-progress-atom
-              progress (cond-> progress
-                               prev-progress
-                               (progress/with-inherited-cancel-state @progress-ref))]
-          (when (progress/relevant-change? prev-progress progress)
-            (reset! prev-progress-atom progress)
-            (render-task-progress! key progress))))
+              [old-state new-state] (update-app-task-state!
+                                      (fn [state]
+                                        (let [current-progress (-> state :progress (get key))
+                                              progress (cond-> progress
+                                                         prev-progress
+                                                         (progress/with-inherited-cancel-state current-progress))]
+                                          (if (progress/relevant-change? prev-progress progress)
+                                            (set-task-progress-state state key progress)
+                                            state))))]
+          (when-not (= old-state new-state)
+            (reset! prev-progress-atom (-> new-state :progress (get key))))))
 
       (fn task-cancelled? []
-        (progress/cancelled? @progress-ref)))))
+        (-> @app-task-state :progress (get key) progress/cancelled?)))))
 
 (defn render-main-task-progress! [progress]
   (render-task-progress! :main progress))


### PR DESCRIPTION
This changes improves the build times by around 4% (on an example big project, a test run of clean, warm and hot builds went from 12:27 to 11:59).

Technical notes:

Measurements are still very noisy, here are the results of a few runs:

| Run | clean-build | warm-build | hot-build | wall |
|---|---:|---:|---:|---:|
| Warmup, discarded | 8:34 | 4:02 | 32.47s | 15:39.90 | 
| Baseline, no app-view changes | 6:33 | 3:13 | 30.54s | 12:27.66 | 
| With app-view changes | 6:01 | 3:29 | 31.98s | 11:59.15 |

For comparison, here are hot build flame graphs:
1. before [hot-build-flamegraph.html](https://github.com/user-attachments/files/27595710/hot-build-flamegraph.html)
2. after [hot-build-flamegraph.html](https://github.com/user-attachments/files/27595728/hot-build-flamegraph.html)

You can see that the after-run is negatively affected by the GC, but if we compare `render-task-progress` occurrences, we go from 13% total occurrences to 0.35%.

Before:
<img width="1388" height="699" alt="Screenshot 2026-05-11 at 15 13 55" src="https://github.com/user-attachments/assets/0f4005df-489d-424a-9a71-327a7e9264c2" />
After:
<img width="1471" height="807" alt="Screenshot 2026-05-11 at 15 16 40" src="https://github.com/user-attachments/assets/0d93848c-6c98-4f75-b5cb-c5870b00cb70" />


Related to #11988
