### PR TITLE
Remove `exclude_entries_from_main_manifest` flag from game.project

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/ProjectBuildTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/ProjectBuildTest.java
@@ -301,18 +301,22 @@ public class ProjectBuildTest {
     }
 
     @Test
-    public void testArchiveBuildCanKeepExcludedEntriesInBundledManifest() throws IOException, CompileExceptionError, MultipleCompileException {
+    public void testArchiveBuildIgnoresDeprecatedManifestEntrySetting() throws IOException, CompileExceptionError, MultipleCompileException, ParseException {
         createExcludedLiveUpdateProject("exclude_entries_from_main_manifest = 0\n");
 
         buildArchive(true);
 
         Manifest.ManifestData bundledManifestData = readManifestData(getBundledManifestFile());
         Manifest.ManifestData publishedManifestData = readManifestData(getPublishedManifestFile());
+        BobProjectProperties outputProps = new BobProjectProperties();
+        outputProps.load(new FileInputStream(new File(contentRoot + "/build/game.projectc")));
 
-        assertTrue(countExcludedEntries(bundledManifestData) > 0);
+        assertEquals(0, countExcludedEntries(bundledManifestData));
         assertTrue(bundledManifestData.getHasExcludedResources());
         assertTrue(publishedManifestData.getHasExcludedResources());
-        assertEquals(publishedManifestData, bundledManifestData);
+        assertFalse(hasResource(bundledManifestData, "/logic/level.collectionc"));
+        assertTrue(hasResource(publishedManifestData, "/logic/level.collectionc"));
+        checkProjectSetting(outputProps, "liveupdate", "exclude_entries_from_main_manifest", null);
     }
 
     @Test

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
@@ -1080,9 +1080,8 @@ enabled.type = bool
 enabled.help = enables the use of live update
 enabled.default = 1
 
-exclude_entries_from_main_manifest.type = bool
-exclude_entries_from_main_manifest.help = omit liveupdate-only resources from the packaged game.dmanifest while keeping the published liveupdate.game.dmanifest complete
-exclude_entries_from_main_manifest.default = 1
+exclude_entries_from_main_manifest.private = 1
+exclude_entries_from_main_manifest.deprecated = 1
 
 settings.type = resource
 settings.help = liveupdate settings

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/GameProjectBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/GameProjectBuilder.java
@@ -273,10 +273,6 @@ public class GameProjectBuilder extends Builder {
         return manifestBuilder;
     }
 
-    private boolean shouldStripLiveUpdateEntriesFromMainManifest() {
-        return project.getProjectProperties().getBooleanValue("liveupdate", "exclude_entries_from_main_manifest", true);
-    }
-
     // Used to transform an input game.project properties map to a game.projectc representation.
     // Can be used for doing build time properties' conversion.
     static public void transformGameProjectFile(BobProjectProperties properties) {
@@ -356,9 +352,7 @@ public class GameProjectBuilder extends Builder {
                 ArchiveBuilder archiveBuilder = new ArchiveBuilder(root, manifestBuilder, getResourcePadding(), project);
                 createArchive(archiveBuilder, resources, archiveIndex, archiveData, excludedResources);
                 byte[] fullManifestFile = manifestBuilder.buildManifest();
-                byte[] bundledManifestFile = shouldStripLiveUpdateEntriesFromMainManifest()
-                        ? manifestBuilder.buildManifest(true)
-                        : fullManifestFile;
+                byte[] bundledManifestFile = manifestBuilder.buildManifest(true);
                 this.project.setArchiveBuilder(archiveBuilder);
 
                 // Write outputs to the build system

--- a/editor/resources/localization/en.editor_localization
+++ b/editor/resources/localization/en.editor_localization
@@ -2053,8 +2053,6 @@ form.label.project.liveupdate = Live Update
 form.help.project.liveupdate = Live Update settings
 form.label.project.liveupdate.enabled = Enabled
 form.help.project.liveupdate.enabled = Enables the use of live update
-form.label.project.liveupdate.exclude_entries_from_main_manifest = Strip Live Update Entries from Main Manifest
-form.help.project.liveupdate.exclude_entries_from_main_manifest = When enabled, liveupdate-only resources are omitted from the packaged game.dmanifest. The published liveupdate.game.dmanifest remains complete.
 form.label.project.liveupdate.settings = Settings
 form.help.project.liveupdate.settings = Live Update settings resource
 

--- a/editor/resources/localization/ru.editor_localization
+++ b/editor/resources/localization/ru.editor_localization
@@ -2053,8 +2053,6 @@ form.label.project.liveupdate = Live Update
 form.help.project.liveupdate = Настройки Live Update
 form.label.project.liveupdate.enabled = Включено
 form.help.project.liveupdate.enabled = Включает использование Live Update
-form.label.project.liveupdate.exclude_entries_from_main_manifest = Убирать записи Live Update из основного манифеста
-form.help.project.liveupdate.exclude_entries_from_main_manifest = Если включено, ресурсы только для Live Update не попадают в упакованный game.dmanifest. Публикуемый liveupdate.game.dmanifest при этом остаётся полным.
 form.label.project.liveupdate.settings = Настройки
 form.help.project.liveupdate.settings = Файл настроек Live Update
 

--- a/editor/test/integration/save_data_test.clj
+++ b/editor/test/integration/save_data_test.clj
@@ -74,6 +74,7 @@
     ["display" "variable_dt"] :deprecated
     ["html5" "custom_heap_size"] :deprecated
     ["html5" "set_custom_heap_size"] :deprecated
+    ["liveupdate" "exclude_entries_from_main_manifest"] :deprecated
     ["shader" "output_spirv"] :deprecated}})
 
 (def ^:private pb-type-field-names

--- a/editor/test/resources/save_data_project/game.project
+++ b/editor/test/resources/save_data_project/game.project
@@ -278,7 +278,6 @@ defold_min_version = 1.10.0
 
 [liveupdate]
 enabled = 1
-exclude_entries_from_main_manifest = 1
 settings = /liveupdate.settings
 
 [native_extension]


### PR DESCRIPTION
There is no way to use this data without API we have removed in 1.13.0