### PR TITLE
Component primitive order unification

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/tile/test/TileSetGeneratorTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/tile/test/TileSetGeneratorTest.java
@@ -208,7 +208,7 @@ public class TileSetGeneratorTest {
         // bottom right, bottom left, top left, top right
         List<Float> expectedVertices = Arrays.asList(0.5f, -0.5f, -0.5f, -0.5f, -0.5f, 0.5f, 0.5f, 0.5f);
         List<Float> expectedUVs = Arrays.asList(maxU, minV, minU, minV, minU, maxV, maxU, maxV);
-        List<Integer> expectedIndices = Arrays.asList(0, 1, 2, 0, 2, 3);
+        List<Integer> expectedIndices = Arrays.asList(0, 2, 1, 0, 3, 2);
 
         assertThat(geometry.getVerticesList(), is(expectedVertices));
         assertThat(geometry.getUvsList(), is(expectedUVs));

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/textureset/TextureSetGenerator.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/textureset/TextureSetGenerator.java
@@ -239,7 +239,7 @@ public class TextureSetGenerator {
 
         // We must respect the upper limit of the vertex hull count
         if (points == null || points.length > hullVertexCount) {
-            // Generates a CW rect
+            // Generates a CCW rect (vertices go BL -> TL -> TR -> BR)
             points = new ConvexHull2D.PointF[4];
             points[0] = new ConvexHull2D.PointF(-0.5,-0.5);
             points[1] = new ConvexHull2D.PointF(-0.5, 0.5);
@@ -255,10 +255,11 @@ public class TextureSetGenerator {
             geometryBuilder.addUvs(0);
         }
 
+        // CCW winding order (OpenGL front-face default)
         for (int v = 1; v <= points.length-2; ++v) {
             geometryBuilder.addIndices(0);
-            geometryBuilder.addIndices(v);
             geometryBuilder.addIndices(v+1);
+            geometryBuilder.addIndices(v);
         }
 
         return geometryBuilder.build();

--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -2274,20 +2274,21 @@ namespace dmGameSystem
                 v = 0.5f + d * s;
                 BoxVertex vOuter(node_transforms[i] * Point3(u,v,0), u0 + ((uv_rotated ? v : u) * su), v0 + ((uv_rotated ? u : 1-v) * sv), pm_color, page_index);
 
-                // both inner & outer are doubled at first / last entry to generate degenerate triangles
+                // both outer & inner are doubled at first / last entry to generate degenerate triangles
                 // for the triangle strip, allowing more than one pie to be chained together in the same
                 // drawcall.
+                // CCW winding order: push outer before inner so front face points toward camera
                 if (first)
                 {
-                    gui_world->m_ClientVertexBuffer.Push(vInner);
+                    gui_world->m_ClientVertexBuffer.Push(vOuter);
                     first = false;
                 }
 
-                gui_world->m_ClientVertexBuffer.Push(vInner);
                 gui_world->m_ClientVertexBuffer.Push(vOuter);
+                gui_world->m_ClientVertexBuffer.Push(vInner);
 
                 if (j == generate-1)
-                    gui_world->m_ClientVertexBuffer.Push(vOuter);
+                    gui_world->m_ClientVertexBuffer.Push(vInner);
             }
 
             assert((gui_world->m_ClientVertexBuffer.Size() - sizeBefore) <= ComputeRequiredVertices(dmGui::GetNodePerimeterVertices(scene, entries[i].m_Node)));

--- a/engine/gamesys/src/gamesys/components/comp_sprite.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sprite.cpp
@@ -1680,25 +1680,27 @@ namespace dmGameSystem
                         printf("  %u: %.2f, %.2f\t%.2f, %.2f\n", f, vertices[f].x, vertices[f].y, vertices[f].u, vertices[f].v );
                 #endif
 
+                    // CCW winding order (OpenGL front-face default)
+                    // Vertices: [0]=BL, [1]=TL, [2]=TR, [3]=BR
                     if (sprite_world->m_Is16BitIndex)
                     {
                         uint16_t* indices_16 = (uint16_t*) indices;
                         indices_16[0] = vertex_offset + 0;
-                        indices_16[1] = vertex_offset + 1;
+                        indices_16[1] = vertex_offset + 3;
                         indices_16[2] = vertex_offset + 2;
-                        indices_16[3] = vertex_offset + 2;
-                        indices_16[4] = vertex_offset + 3;
-                        indices_16[5] = vertex_offset + 0;
+                        indices_16[3] = vertex_offset + 0;
+                        indices_16[4] = vertex_offset + 2;
+                        indices_16[5] = vertex_offset + 1;
                     }
                     else
                     {
                         uint32_t* indices_32 = (uint32_t*) indices;
                         indices_32[0] = vertex_offset + 0;
-                        indices_32[1] = vertex_offset + 1;
+                        indices_32[1] = vertex_offset + 3;
                         indices_32[2] = vertex_offset + 2;
-                        indices_32[3] = vertex_offset + 2;
-                        indices_32[4] = vertex_offset + 3;
-                        indices_32[5] = vertex_offset + 0;
+                        indices_32[3] = vertex_offset + 0;
+                        indices_32[4] = vertex_offset + 2;
+                        indices_32[5] = vertex_offset + 1;
                     }
                     vertex_offset += SPRITE_VERTEX_COUNT_LEGACY;
                     indices       += SPRITE_INDEX_COUNT_LEGACY * index_type_size;

--- a/engine/gamesys/src/gamesys/components/comp_tilegrid.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_tilegrid.cpp
@@ -548,20 +548,24 @@ namespace dmGameSystem
         DM_PROFILE("CreateVertexData");
         /*
          *   0----3
-         *   | \  |
-         *   |  \ |
+         *   |  / |
+         *   | /  |
          *   1____2
+         *
+         * CCW winding order (OpenGL front-face default)
+         * Triangle 1: v0(BL) -> v1(BR) -> v2(TR)
+         * Triangle 2: v3(TR) -> v4(TL) -> v5(BL)
         */
         static int tex_coord_order[] = {
-            0,1,2,2,3,0,
-            3,2,1,1,0,3,    //h
-            1,0,3,3,2,1,    //v
-            2,3,0,0,1,2,    //hv
+            0,3,2,2,1,0,
+            3,0,1,1,2,3,    //h
+            1,2,3,3,0,1,    //v
+            2,1,0,0,3,2,    //hv
             // rotate 90 degrees:
-            3,0,1,1,2,3,
-            0,3,2,2,1,0,    //h
-            2,1,0,0,3,2,    //v
-            1,2,3,3,0,1     //hv
+            3,2,1,1,0,3,
+            0,1,2,2,3,0,    //h
+            2,3,0,0,1,2,    //v
+            1,0,3,3,2,1     //hv
         };
 
         dmGameSystemDDF::TextureSet* texture_set_ddf = texture_set->m_TextureSet;
@@ -625,11 +629,12 @@ namespace dmGameSystem
                             where[_I].v = _V; \
                         }
 
+                    // CCW winding: BL, BR, TR, TR, TL, BL
                     SET_VERTEX(0, p[0], p[1], z, puv[tex_lookup[0] * 2], puv[tex_lookup[0] * 2 + 1]);
-                    SET_VERTEX(1, p[0], p[3], z, puv[tex_lookup[1] * 2], puv[tex_lookup[1] * 2 + 1]);
+                    SET_VERTEX(1, p[2], p[1], z, puv[tex_lookup[1] * 2], puv[tex_lookup[1] * 2 + 1]);
                     SET_VERTEX(2, p[2], p[3], z, puv[tex_lookup[2] * 2], puv[tex_lookup[2] * 2 + 1]);
                     SET_VERTEX(3, p[2], p[3], z, puv[tex_lookup[3] * 2], puv[tex_lookup[3] * 2 + 1]);
-                    SET_VERTEX(4, p[2], p[1], z, puv[tex_lookup[4] * 2], puv[tex_lookup[4] * 2 + 1]);
+                    SET_VERTEX(4, p[0], p[3], z, puv[tex_lookup[4] * 2], puv[tex_lookup[4] * 2 + 1]);
                     SET_VERTEX(5, p[0], p[1], z, puv[tex_lookup[5] * 2], puv[tex_lookup[5] * 2 + 1]);
 
                     where += 6;

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -5556,17 +5556,17 @@ TEST_F(ComponentTest, DispatchBuffersTest)
         float p3[] = {  pfx_s,  pfx_s};
 
         SET_VTX_A(pfx_a[0], p0[0], p0[1], 1.0f, 0.0f);
-        SET_VTX_A(pfx_a[1], p1[0], p1[1], 1.0f, 0.0f);
+        SET_VTX_A(pfx_a[1], p2[0], p2[1], 1.0f, 0.0f);
         SET_VTX_A(pfx_a[2], p3[0], p3[1], 1.0f, 0.0f);
         SET_VTX_A(pfx_a[3], p3[0], p3[1], 1.0f, 0.0f);
-        SET_VTX_A(pfx_a[4], p2[0], p2[1], 1.0f, 0.0f);
+        SET_VTX_A(pfx_a[4], p1[0], p1[1], 1.0f, 0.0f);
         SET_VTX_A(pfx_a[5], p0[0], p0[1], 1.0f, 0.0f);
 
         SET_VTX_B(pfx_b[0], p0[0], p0[1], 0.0f, 4.0f, 3.0f, 2.0f, 1.0f);
-        SET_VTX_B(pfx_b[1], p1[0], p1[1], 0.0f, 4.0f, 3.0f, 2.0f, 1.0f);
+        SET_VTX_B(pfx_b[1], p2[0], p2[1], 0.0f, 4.0f, 3.0f, 2.0f, 1.0f);
         SET_VTX_B(pfx_b[2], p3[0], p3[1], 0.0f, 4.0f, 3.0f, 2.0f, 1.0f);
         SET_VTX_B(pfx_b[3], p3[0], p3[1], 0.0f, 4.0f, 3.0f, 2.0f, 1.0f);
-        SET_VTX_B(pfx_b[4], p2[0], p2[1], 0.0f, 4.0f, 3.0f, 2.0f, 1.0f);
+        SET_VTX_B(pfx_b[4], p1[0], p1[1], 0.0f, 4.0f, 3.0f, 2.0f, 1.0f);
         SET_VTX_B(pfx_b[5], p0[0], p0[1], 0.0f, 4.0f, 3.0f, 2.0f, 1.0f);
 
         for (int i = 0; i < num_draws; ++i)
@@ -6405,7 +6405,7 @@ BoxRenderParams box_render_params[] =
             dmGameSystem::BoxVertex(Vector4(16.000000, 16.000000, 0.0, 0.0), 0.500000, 1.000000, Vector4(1.0, 1.0, 1.0, 1.0), 0)
         },
         18,
-        {0, 1, 2, 0, 2, 2, 0, 2, 3, 0, 3, 3, 0, 3, 3, 0, 3, 3}
+        {0, 2, 1, 0, 2, 2, 0, 3, 2, 0, 3, 3, 0, 3, 3, 0, 3, 3}
     },
     // 9-slice params: off | Use geometries: off | Flip uv: off | Texture: tilesource animation
     {
@@ -6417,7 +6417,7 @@ BoxRenderParams box_render_params[] =
             dmGameSystem::BoxVertex(Vector4(16.000000, -16.000000, 0.0, 0.0), 0.500000, 0.500000, Vector4(1.0, 1.0, 1.0, 1.0), 0)
         },
         6,
-        {0, 1, 2, 0, 2, 3}
+        {0, 2, 1, 0, 3, 2}
     },
     // 9-slice params: off | Use geometries: off | Flip uv: u | Texture: tilesource animation
     {
@@ -6429,7 +6429,7 @@ BoxRenderParams box_render_params[] =
             dmGameSystem::BoxVertex(Vector4(16.000000, -16.000000, 0.0, 0.0), 0.000000, 0.500000, Vector4(1.0, 1.0, 1.0, 1.0), 0)
         },
         6,
-        {0, 1, 2, 0, 2, 3}
+        {0, 2, 1, 0, 3, 2}
     },
     // 9-slice params: off | Use geometries: off | Flip uv: uv | Texture: tilesource animation
     {
@@ -6441,7 +6441,7 @@ BoxRenderParams box_render_params[] =
             dmGameSystem::BoxVertex(Vector4(-16.000000, 16.000000, 0.0, 0.0), 0.500000, 0.500000, Vector4(1.0, 1.0, 1.0, 1.0), 0)
         },
         6,
-        {0, 1, 2, 0, 2, 3}
+        {0, 2, 1, 0, 3, 2}
     },
     // 9-slice params: on | Use geometries: 8 | Flip uv: uv | Texture: tilesource animation
     {
@@ -6537,7 +6537,7 @@ BoxRenderParams box_render_params[] =
             dmGameSystem::BoxVertex(Vector4(32.000000, -32.000000, 0.0, 0.0), 0.500000, 0.500000, Vector4(1.0, 1.0, 1.0, 1.0),  1)
         },
         6,
-        {0, 1, 2, 0, 2, 3}
+        {0, 2, 1, 0, 3, 2}
     }
 };
 INSTANTIATE_TEST_CASE_P(BoxRender, BoxRenderTest, jc_test_values_in(box_render_params));

--- a/engine/particle/src/particle.cpp
+++ b/engine/particle/src/particle.cpp
@@ -1132,11 +1132,13 @@ namespace dmParticle
                                                     uint32_t* bytes_written)
     {
         DM_PROFILE(__FUNCTION__);
+        // CCW winding order (OpenGL front-face default)
+        // Vertices: v0=BL, v1=BR, v2=TR, v3=TR, v4=TL, v5=BL
         static int tex_coord_order[] = {
-            0,1,2,2,3,0,
-            3,2,1,1,0,3,	//h
-            1,0,3,3,2,1,	//v
-            2,3,0,0,1,2		//hv
+            0,3,2,2,1,0,
+            3,0,1,1,2,3,	//h
+            1,2,3,3,0,1,	//v
+            2,1,0,0,3,2		//hv
         };
 
         uint32_t vertex_size = attribute_infos.m_VertexStride;
@@ -1207,11 +1209,12 @@ namespace dmParticle
 
             float hx = render_state.m_HalfWidth;
             float hy = render_state.m_HalfHeight;
+            // CCW winding: BL, BR, TR, TR, TL, BL
             position_local_flat[0] = Point3(-hx, -hy, 0.0f);
-            position_local_flat[1] = Point3(-hx,  hy, 0.0f);
+            position_local_flat[1] = Point3( hx, -hy, 0.0f);
             position_local_flat[2] = Point3( hx,  hy, 0.0f);
             position_local_flat[3] = position_local_flat[2];
-            position_local_flat[4] = Point3( hx, -hy, 0.0f);
+            position_local_flat[4] = Point3(-hx,  hy, 0.0f);
             position_local_flat[5] = position_local_flat[0];
 
             world_matrix = dmTransform::ToMatrix4(render_state.m_WorldTransform);

--- a/engine/particle/src/test/test_particle.cpp
+++ b/engine/particle/src/test/test_particle.cpp
@@ -158,21 +158,21 @@ void ParticleTest::VerifyVertexTexCoords(TestVertex* vertex_buffer, float* tex_c
         v1 = tc[7];
     }
 
-    // The particle vertices are emitted in the following order:
-    // 1 -- 2               3
-    // |         then       |
-    // 0               5 -- 4
+    // The particle vertices are emitted in the following CCW order:
+    //      4 -- 3/2
+    //      |      |
+    //     5/0 -- 1
 
     ASSERT_NEAR(u0, vertex_buffer[0].m_U, EPSILON);
     ASSERT_NEAR(v1, vertex_buffer[0].m_V, EPSILON);
-    ASSERT_NEAR(u0, vertex_buffer[1].m_U, EPSILON);
-    ASSERT_NEAR(v0, vertex_buffer[1].m_V, EPSILON);
+    ASSERT_NEAR(u1, vertex_buffer[1].m_U, EPSILON);
+    ASSERT_NEAR(v1, vertex_buffer[1].m_V, EPSILON);
     ASSERT_NEAR(u1, vertex_buffer[2].m_U, EPSILON);
     ASSERT_NEAR(v0, vertex_buffer[2].m_V, EPSILON);
     ASSERT_NEAR(u1, vertex_buffer[3].m_U, EPSILON);
     ASSERT_NEAR(v0, vertex_buffer[3].m_V, EPSILON);
-    ASSERT_NEAR(u1, vertex_buffer[4].m_U, EPSILON);
-    ASSERT_NEAR(v1, vertex_buffer[4].m_V, EPSILON);
+    ASSERT_NEAR(u0, vertex_buffer[4].m_U, EPSILON);
+    ASSERT_NEAR(v0, vertex_buffer[4].m_V, EPSILON);
     ASSERT_NEAR(u0, vertex_buffer[5].m_U, EPSILON);
     ASSERT_NEAR(v1, vertex_buffer[5].m_V, EPSILON);
 }
@@ -192,12 +192,12 @@ void ParticleTest::VerifyVertexDims(TestVertex* vertex_buffer, uint32_t particle
     for (uint32_t i = 0; i < particle_count; ++i)
     {
         TestVertex* v = &vertex_buffer[i*6];
-        float x = v[1].m_X - v[2].m_X;
-        float y = v[1].m_Y - v[2].m_Y;
+        float x = v[0].m_X - v[1].m_X;
+        float y = v[0].m_Y - v[1].m_Y;
         float w = sqrt(x * x + y * y);
         ASSERT_NEAR(size * width_factor, w, 0.000001f);
-        x = v[0].m_X - v[1].m_X;
-        y = v[0].m_Y - v[1].m_Y;
+        x = v[1].m_X - v[2].m_X;
+        y = v[1].m_Y - v[2].m_Y;
         float h = sqrt(x * x + y * y);
         ASSERT_NEAR(size * height_factor, h, 0.000001f);
     }
@@ -2255,10 +2255,10 @@ TEST_F(ParticleTest, Pivot)
 
     // Without pivot, y should be between -0.5 and 0.5
     ASSERT_NEAR(0.0f, vertex_buffer[0].m_Y, EPSILON); // bottom left
-    ASSERT_NEAR(1.0f, vertex_buffer[1].m_Y, EPSILON); // top left
+    ASSERT_NEAR(0.0f, vertex_buffer[1].m_Y, EPSILON); // bottom right
     ASSERT_NEAR(1.0f, vertex_buffer[2].m_Y, EPSILON); // top right
     ASSERT_NEAR(1.0f, vertex_buffer[3].m_Y, EPSILON); // top right
-    ASSERT_NEAR(0.0f, vertex_buffer[4].m_Y, EPSILON); // bottom right
+    ASSERT_NEAR(1.0f, vertex_buffer[4].m_Y, EPSILON); // top left
     ASSERT_NEAR(0.0f, vertex_buffer[5].m_Y, EPSILON); // bottom left
 
     dmParticle::DestroyInstance(m_Context, instance);

--- a/engine/render/src/render/font/default/font_default_vertex.cpp
+++ b/engine/render/src/render/font/default/font_default_vertex.cpp
@@ -164,19 +164,21 @@ static void OutputGlyph(FontGlyph* glyph,
 
     float xx = x - f_size_diff * 0.5f;
 
+    // CCW winding order (OpenGL front-face default)
+    // v1=BL, v2=BR, v3=TL, v4=v3=TL, v5=v2=BR, v6=TR
     (Vector4&) v1_layer_face.m_Position = transform * Vector4(xx + f_left_bearing, y - f_descent, 0, 1);
-    (Vector4&) v2_layer_face.m_Position = transform * Vector4(xx + f_left_bearing, y + f_ascent, 0, 1);
-    (Vector4&) v3_layer_face.m_Position = transform * Vector4(xx + f_left_bearing + f_width, y - f_descent, 0, 1);
+    (Vector4&) v2_layer_face.m_Position = transform * Vector4(xx + f_left_bearing + f_width, y - f_descent, 0, 1);
+    (Vector4&) v3_layer_face.m_Position = transform * Vector4(xx + f_left_bearing, y + f_ascent, 0, 1);
     (Vector4&) v6_layer_face.m_Position = transform * Vector4(xx + f_left_bearing + f_width, y + f_ascent, 0, 1);
 
     v1_layer_face.m_UV[0] = (tx + cache_cell_padding) * recip_w;
     v1_layer_face.m_UV[1] = (ty + cache_cell_padding + ascent + descent + px_cell_offset_y) * recip_h;
 
-    v2_layer_face.m_UV[0] = (tx + cache_cell_padding) * recip_w;
-    v2_layer_face.m_UV[1] = (ty + cache_cell_padding + px_cell_offset_y) * recip_h;
+    v2_layer_face.m_UV[0] = (tx + cache_cell_padding + width) * recip_w;
+    v2_layer_face.m_UV[1] = (ty + cache_cell_padding + ascent + descent + px_cell_offset_y) * recip_h;
 
-    v3_layer_face.m_UV[0] = (tx + cache_cell_padding + width) * recip_w;
-    v3_layer_face.m_UV[1] = (ty + cache_cell_padding + ascent + descent + px_cell_offset_y) * recip_h;
+    v3_layer_face.m_UV[0] = (tx + cache_cell_padding) * recip_w;
+    v3_layer_face.m_UV[1] = (ty + cache_cell_padding + px_cell_offset_y) * recip_h;
 
     v6_layer_face.m_UV[0] = (tx + cache_cell_padding + width) * recip_w;
     v6_layer_face.m_UV[1] = (ty + cache_cell_padding + px_cell_offset_y) * recip_h;
@@ -263,9 +265,10 @@ static void OutputGlyph(FontGlyph* glyph,
         v6_layer_shadow = v6_layer_face;
 
         // Shadow offsets must be calculated since we need to offset in local space (before vertex transformation)
+        // CCW winding: v1=BL, v2=BR, v3=TL, v6=TR
         (Vector4&) v1_layer_shadow.m_Position = transform * Vector4(xx + f_left_bearing + shadow_x, y - f_descent + shadow_y, 0, 1);
-        (Vector4&) v2_layer_shadow.m_Position = transform * Vector4(xx + f_left_bearing + shadow_x, y + f_ascent + shadow_y, 0, 1);
-        (Vector4&) v3_layer_shadow.m_Position = transform * Vector4(xx + f_left_bearing + shadow_x + f_width, y - f_descent + shadow_y, 0, 1);
+        (Vector4&) v2_layer_shadow.m_Position = transform * Vector4(xx + f_left_bearing + shadow_x + f_width, y - f_descent + shadow_y, 0, 1);
+        (Vector4&) v3_layer_shadow.m_Position = transform * Vector4(xx + f_left_bearing + shadow_x, y + f_ascent + shadow_y, 0, 1);
         (Vector4&) v6_layer_shadow.m_Position = transform * Vector4(xx + f_left_bearing + shadow_x + f_width, y + f_ascent + shadow_y, 0, 1);
 
         v4_layer_shadow = v3_layer_shadow;


### PR DESCRIPTION
⚠️ BREAKING CHANGE ⚠️

The vertices for the `sprite`, `gui`, `tilegrid` and `particle` components are now unified with the rest of the components. The engine is now using counter-clockwise ordering of the vertices so that the normal of the primitive is pointing towards the camera. This means that you can use the same face culling parameters for all components.

Regarding breaking change:
This should only have an impact if you are using face culling for your components. In the default render script, we have enabled backface culling only for models but if your project is using backface culling for other components you might have to switch the front/back face using `render.set_cull_face(graphics.FACE_TYPE_BACK)`. The default cull face mode is FACE_TYPE_BACK, so you can also just remove the `render.set_cull_face` call

Fixes https://github.com/defold/defold/issues/3543
Fixes https://github.com/defold/defold/issues/5666
Fixes https://github.com/defold/defold/issues/9072