### PR TITLE
Relax default animation validation in editor scripts

### DIFF
--- a/editor/src/clj/editor/editor_extensions/graph.clj
+++ b/editor/src/clj/editor/editor_extensions/graph.clj
@@ -255,17 +255,24 @@
       property
       (string/replace property "-" "_"))))
 
+(defn- available-outline-property [prop-kw outline-property]
+  (when outline-property
+    (let [outline-property (cond-> outline-property
+                                   (:ext-edit-type outline-property)
+                                   (assoc :edit-type (:ext-edit-type outline-property))
+
+                                   (not (contains? outline-property :prop-kw))
+                                   (assoc :prop-kw prop-kw))]
+      (when (and (properties/visible? outline-property)
+                 (edit-type-id->value-converter (properties/property-edit-type-id outline-property)))
+        outline-property))))
+
 (defn- outline-property [node-id property evaluation-context]
   (let [prop-kw (property->prop-kw property)
         outline-property (-> node-id
                              (g/node-value :_properties evaluation-context)
                              (get-in [:properties prop-kw]))]
-    (when (and outline-property
-               (properties/visible? outline-property)
-               (edit-type-id->value-converter (properties/property-edit-type-id outline-property)))
-      (cond-> outline-property
-              (not (contains? outline-property :prop-kw))
-              (assoc :prop-kw prop-kw)))))
+    (available-outline-property prop-kw outline-property)))
 
 (defn- make-property-fn-builder [{:keys [parents]} node-type-kw->f result-fn]
   (fn/memoize
@@ -445,8 +452,7 @@
   (fn OutlineNode-lister [node-id evaluation-context]
     (coll/into-> (:properties (g/node-value node-id :_properties evaluation-context)) []
       (keep (fn [[prop-kw outline-property]]
-              (when (and (properties/visible? outline-property)
-                         (some? (-> outline-property properties/property-edit-type-id edit-type-id->value-converter)))
+              (when (available-outline-property prop-kw outline-property)
                 (prop-kw->property prop-kw)))))))
 
 (defn ext-value-getter

--- a/editor/src/clj/editor/editor_extensions/graph.clj
+++ b/editor/src/clj/editor/editor_extensions/graph.clj
@@ -256,15 +256,16 @@
       (string/replace property "-" "_"))))
 
 (defn- available-outline-property [prop-kw outline-property]
-  (when outline-property
-    (let [outline-property (cond-> outline-property
-                                   (:ext-edit-type outline-property)
-                                   (assoc :edit-type (:ext-edit-type outline-property))
+  (when (and outline-property
+             (properties/visible? outline-property))
+    (let [ext-edit-type (:ext-edit-type outline-property)
+          outline-property (cond-> outline-property
+                                   ext-edit-type
+                                   (assoc :edit-type ext-edit-type)
 
                                    (not (contains? outline-property :prop-kw))
                                    (assoc :prop-kw prop-kw))]
-      (when (and (properties/visible? outline-property)
-                 (edit-type-id->value-converter (properties/property-edit-type-id outline-property)))
+      (when (edit-type-id->value-converter (properties/property-edit-type-id outline-property))
         outline-property))))
 
 (defn- outline-property [node-id property evaluation-context]

--- a/editor/src/clj/editor/sprite.clj
+++ b/editor/src/clj/editor/sprite.clj
@@ -531,7 +531,8 @@
                                    (let [{:keys [anim-data sampler]} primary-texture-binding-info
                                          image-property-label (if (= 1 (count textures)) image-message sampler)]
                                      (validation/prop-error :fatal _node-id :default-animation validation/prop-anim-missing-in? default-animation anim-data image-property-label))))))
-            (dynamic edit-type (g/fnk [anim-ids] (properties/->choicebox anim-ids))))
+            (dynamic edit-type (g/fnk [anim-ids] (properties/->choicebox anim-ids)))
+            (dynamic ext-edit-type (g/constantly {:type g/Str})))
 
   (property material resource/Resource ; Default assigned in load-fn.
             (value (gu/passthrough material-resource))

--- a/editor/test/integration/editor_extensions_test.clj
+++ b/editor/test/integration/editor_extensions_test.clj
@@ -1515,6 +1515,18 @@ new tiles from the graph => {
       (run-edit-menu-test-command!)
       (expect-script-output expected-tilemap-test-output out))))
 
+(def ^:private expected-embedded-sprite-default-animation-output
+  "direct default_animation: logo
+nested default_animation: logo
+")
+
+(deftest embedded-sprite-default-animation-test
+  (test-util/with-loaded-project "test/resources/editor_extensions/embedded_sprite_default_animation_project"
+    (let [out (StringBuilder.)]
+      (reload-editor-scripts! project :display-output! #(doto out (.append %2) (.append \newline)))
+      (run-edit-menu-test-command!)
+      (expect-script-output expected-embedded-sprite-default-animation-output out))))
+
 (def ^:private expected-attachment-test-output
   "Atlas initial state:
   images: 0

--- a/editor/test/resources/editor_extensions/embedded_sprite_default_animation_project/.gitignore
+++ b/editor/test/resources/editor_extensions/embedded_sprite_default_animation_project/.gitignore
@@ -1,0 +1,11 @@
+/.editor_settings
+/.internal
+/build
+.externalToolBuilders
+.DS_Store
+Thumbs.db
+.lock-wscript
+*.pyc
+.project
+.cproject
+builtins

--- a/editor/test/resources/editor_extensions/embedded_sprite_default_animation_project/game.project
+++ b/editor/test/resources/editor_extensions/embedded_sprite_default_animation_project/game.project
@@ -1,0 +1,5 @@
+[bootstrap]
+main_collection = /main/main.collectionc
+
+[project]
+title = embedded_sprite_default_animation_project

--- a/editor/test/resources/editor_extensions/embedded_sprite_default_animation_project/logo.atlas
+++ b/editor/test/resources/editor_extensions/embedded_sprite_default_animation_project/logo.atlas
@@ -1,0 +1,12 @@
+animations {
+  id: "logo"
+  images {
+    image: "/builtins/assets/images/logo/logo_256.png"
+  }
+  playback: PLAYBACK_ONCE_FORWARD
+  fps: 30
+  flip_horizontal: 0
+  flip_vertical: 0
+}
+margin: 0
+extrude_borders: 0

--- a/editor/test/resources/editor_extensions/embedded_sprite_default_animation_project/main/main.collection
+++ b/editor/test/resources/editor_extensions/embedded_sprite_default_animation_project/main/main.collection
@@ -1,0 +1,2 @@
+name: "main"
+scale_along_z: 0

--- a/editor/test/resources/editor_extensions/embedded_sprite_default_animation_project/test.editor_script
+++ b/editor/test/resources/editor_extensions/embedded_sprite_default_animation_project/test.editor_script
@@ -1,0 +1,48 @@
+local M = {}
+
+function M.get_commands()
+    return {
+        editor.command({
+            id = "defold.test",
+            label = "Test",
+            locations = {"Edit"},
+            run = function()
+                local collection = "/main/main.collection"
+                local go_resource = "/test.go"
+
+                editor.transact({
+                    editor.tx.add(go_resource, "components", {
+                        type = "sprite",
+                        id = "direct-sprite",
+                        __sampler__texture_sampler__0 = "/logo.atlas",
+                        default_animation = "logo"
+                    })
+                })
+
+                local direct_sprite = editor.get(go_resource, "components")[2]
+                print(("direct default_animation: %s"):format(editor.get(direct_sprite, "default_animation")))
+
+                editor.transact({
+                    editor.tx.add(collection, "children", {
+                        type = "go",
+                        id = "sprite-go",
+                        components = {
+                            {
+                                type = "sprite",
+                                id = "sprite",
+                                __sampler__texture_sampler__0 = "/logo.atlas",
+                                default_animation = "logo"
+                            }
+                        }
+                    })
+                })
+
+                local go = editor.get(collection, "children")[1]
+                local sprite = editor.get(go, "components")[1]
+                print(("nested default_animation: %s"):format(editor.get(sprite, "default_animation")))
+            end
+        })
+    }
+end
+
+return M

--- a/editor/test/resources/editor_extensions/embedded_sprite_default_animation_project/test.go
+++ b/editor/test/resources/editor_extensions/embedded_sprite_default_animation_project/test.go
@@ -1,0 +1,5 @@
+embedded_components {
+  id: "existing"
+  type: "sprite"
+  data: "default_animation: \"\"\nmaterial: \"/builtins/materials/sprite.material\"\nblend_mode: BLEND_MODE_ALPHA\n"
+}


### PR DESCRIPTION
Now it's possible to set a default animation without setting the right atlas first.

Technical notes:

I considered another approach, but it turned out to be much more complex. I thought, ideally, we would create a special setter with `g/expand-ec` that would perform the validation inside the transaction. There were 2 issues with this approach:
1. It would require establishing an ordering for sprite properties. Currently, when we add a new sprite component using editor scripts, we use a lua table, i.e., an unordered hash map. So we would need to add sorting or something like that.
2. Sprites can be used as embedded components, so we would need to add the same custom property + ordering logic for embedded components as well.

In the end, I think simply allowing to set a string value is fine, since it's allowed in the data model, and animation validation is a separate build error check.