### PR TITLE
Fix sprite component crash

### DIFF
--- a/engine/engine/src/test/issue-12362/issue-12362.collection
+++ b/engine/engine/src/test/issue-12362/issue-12362.collection
@@ -1,0 +1,14 @@
+name: "issue-12362"
+scale_along_z: 0
+embedded_instances {
+  id: "go"
+  data: "components {\n"
+  "  id: \"script\"\n"
+  "  component: \"/issue-12362/issue-12362.script\"\n"
+  "}\n"
+  "components {\n"
+  "  id: \"sprite\"\n"
+  "  component: \"/sprite/coll.sprite\"\n"
+  "}\n"
+  ""
+}

--- a/engine/engine/src/test/issue-12362/issue-12362.script
+++ b/engine/engine/src/test/issue-12362/issue-12362.script
@@ -1,0 +1,19 @@
+function init(self)
+	self.frame = 0
+end
+
+function update(self, dt)
+	self.frame = self.frame + 1
+
+	if self.frame == 1 then
+		msg.post("#sprite", "disable")
+	elseif self.frame == 2 then
+		sys.exit(0)
+	end
+end
+
+function late_update(self, dt)
+	if self.frame == 1 then
+		msg.post("#sprite", "enable")
+	end
+end

--- a/engine/engine/src/test/main.collection
+++ b/engine/engine/src/test/main.collection
@@ -154,5 +154,11 @@ embedded_instances {
   "  data: \"collection: \\\"/late_update/late_update.collection\\\"\\n"
   "\"\n"
   "}\n"
+  "embedded_components {\n"
+  "  id: \"collectionproxy33\"\n"
+  "  type: \"collectionproxy\"\n"
+  "  data: \"collection: \\\"/issue-12362/issue-12362.collection\\\"\\n"
+  "\"\n"
+  "}\n"
   ""
 }

--- a/engine/engine/src/test/test_engine.cpp
+++ b/engine/engine/src/test/test_engine.cpp
@@ -521,6 +521,13 @@ TEST_F(EngineTest, ISSUE_10323)
     ASSERT_EQ(0, Launch(DM_ARRAY_SIZE(argv), (char**)argv, 0, 0, 0));
 }
 
+TEST_F(EngineTest, ISSUE_12362)
+{
+    char project_path[256];
+    const char* argv[] = {"test_engine", "--config=bootstrap.main_collection=/issue-12362/issue-12362.collectionc", "--config=network.http_cache_enabled=0", "--config=dmengine.unload_builtins=0", MAKE_PATH(project_path, "/game.projectc")};
+    ASSERT_EQ(0, Launch(DM_ARRAY_SIZE(argv), (char**)argv, 0, 0, 0));
+}
+
 TEST_F(EngineTest, ModelComponent)
 {
     char project_path[256];

--- a/engine/gamesys/src/gamesys/components/comp_sprite.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sprite.cpp
@@ -152,6 +152,11 @@ namespace dmGameSystem
         uint16_t                    m_AnimationID; // index into array
         uint16_t                    m_DynamicVertexAttributeIndex;
         uint16_t                    m_ComponentIndex;
+        //------------------- cached values related to vertex/index buffer allocation----------
+        uint16_t                    m_VertexCount;
+        uint16_t                    m_IndexCount;
+        uint16_t                    m_VertexStride;
+        //-------------------------------------------------------------------------------------
         uint16_t                    m_Enabled : 1;
         uint16_t                    m_DoTick : 1;
         uint16_t                    m_FlipHorizontal : 1;
@@ -737,6 +742,9 @@ namespace dmGameSystem
 
         dmMessage::ResetURL(&component->m_Listener);
 
+        component->m_VertexCount = 0;
+        component->m_VertexStride = 1;
+        component->m_IndexCount = 0;
         component->m_ComponentIndex = params.m_ComponentIndex;
         component->m_Enabled = 1;
         component->m_FunctionRef = 0;
@@ -860,6 +868,33 @@ namespace dmGameSystem
         {
             *out_x_pivot = geometry->m_PivotX;
             *out_y_pivot = geometry->m_PivotY;
+        }
+    }
+
+    static inline void UpdateVertexMetricsCache(SpriteComponent* component, const AnimationData* anim_data, dmRender::HRenderContext render_context)
+    {
+        dmRender::HMaterial material           = GetRenderMaterial(render_context, component);
+        dmGraphics::HVertexDeclaration vx_decl = dmRender::GetVertexDeclaration(material);
+        component->m_VertexStride              = dmGraphics::GetVertexDeclarationStride(vx_decl);
+        uint8_t textures_num                   = component->m_NumTextures;
+
+        if (textures_num == 0 || anim_data->m_CanUseQuads)
+        {
+            if (component->m_UseSlice9)
+            {
+                component->m_VertexCount   += SPRITE_VERTEX_COUNT_SLICE9;
+                component->m_IndexCount    += SPRITE_INDEX_COUNT_SLICE9;
+            }
+            else
+            {
+                component->m_VertexCount   += SPRITE_VERTEX_COUNT_LEGACY;
+                component->m_IndexCount    += SPRITE_INDEX_COUNT_LEGACY;
+            }
+        }
+        else
+        {
+            component->m_VertexCount += anim_data->m_VertexCount;
+            component->m_IndexCount += anim_data->m_IndicesCount;
         }
     }
 
@@ -1988,9 +2023,6 @@ namespace dmGameSystem
 
         UpdateAnimationDataCache(world);
 
-        uint32_t num_vertices    = 0;
-        uint32_t num_indices     = 0;
-        uint32_t vertex_memsize  = 0;
         dmArray<SpriteComponent>& components = world->m_Components.GetRawObjects();
         uint32_t n = components.Size();
 
@@ -2017,41 +2049,13 @@ namespace dmGameSystem
                 AnimationReHash(component);
             }
 
-            dmRender::HMaterial material           = GetRenderMaterial(render_context, component);
-            dmGraphics::HVertexDeclaration vx_decl = dmRender::GetVertexDeclaration(material);
-            uint32_t vertex_stride                 = dmGraphics::GetVertexDeclarationStride(vx_decl);
-            uint8_t textures_num                   = component->m_NumTextures;
-
-            // We need to pad the buffer if the vertex stride doesn't start at an even byte offset from the start
-            vertex_memsize += vertex_stride - vertex_memsize % vertex_stride;
-
             // Get the correct animation frames, and other meta data
             AnimationData* anim_data = GetOrCreateAnimationData(world, component);
             // update cached pivot
             if (is_component_changed)
             {
                 GetPivot(anim_data, &component->m_PivotX, &component->m_PivotY);
-            }
-            if (textures_num == 0 || anim_data->m_CanUseQuads)
-            {
-                if (component->m_UseSlice9)
-                {
-                    num_vertices   += SPRITE_VERTEX_COUNT_SLICE9;
-                    num_indices    += SPRITE_INDEX_COUNT_SLICE9;
-                    vertex_memsize += SPRITE_VERTEX_COUNT_SLICE9 * vertex_stride;
-                }
-                else
-                {
-                    num_vertices   += SPRITE_VERTEX_COUNT_LEGACY;
-                    num_indices    += SPRITE_INDEX_COUNT_LEGACY;
-                    vertex_memsize += SPRITE_VERTEX_COUNT_LEGACY * vertex_stride;
-                }
-            }
-            else
-            {
-                num_vertices += anim_data->m_VertexCount;
-                num_indices += anim_data->m_IndicesCount;
-                vertex_memsize += anim_data->m_VertexCount * vertex_stride;
+                UpdateVertexMetricsCache(component, anim_data, render_context);
             }
 
             // TODO: check when we need send messages
@@ -2060,19 +2064,11 @@ namespace dmGameSystem
             PostMessages(component);
         }
 
-        // In case if CompSpriteUpdate will be called several times before CompSpriteRender - assign flag with "bit or"
-        // to save flag state from previous update until ReallocBuffers will be called
-        world->m_ReallocBuffers   |= vertex_memsize > world->m_VertexMemorySize || num_indices > world->m_IndexCount;
-        world->m_VertexCount      = num_vertices;
-        world->m_IndexCount       = num_indices;
-        world->m_VertexMemorySize = vertex_memsize;
-
         dmRender::TrimBuffer(render_context, world->m_VertexBuffer);
         dmRender::RewindBuffer(render_context, world->m_VertexBuffer);
 
         dmRender::TrimBuffer(render_context, world->m_IndexBuffer);
         dmRender::RewindBuffer(render_context, world->m_IndexBuffer);
-
         world->m_DispatchCount = 0;
 
         return dmGameObject::UPDATE_RESULT_OK;
@@ -2089,6 +2085,10 @@ namespace dmGameSystem
         {
             return dmGameObject::UPDATE_RESULT_OK;
         }
+
+        uint32_t num_vertices    = 0;
+        uint32_t num_indices     = 0;
+        uint32_t vertex_memsize  = 0;
 
         bool sub_pixels = sprite_context->m_Subpixels;
 
@@ -2110,7 +2110,22 @@ namespace dmGameSystem
             world->m_CullingInfo[i].m_Position[1] = world_pos.getY();
             world->m_CullingInfo[i].m_Position[2] = world_pos.getZ();
             world->m_CullingInfo[i].m_Radius = radius_sq;
+
+            // We need to pad the buffer if the vertex stride doesn't start at an even byte offset from the start
+            vertex_memsize += component->m_VertexStride - vertex_memsize % component->m_VertexStride;
+
+            num_vertices += component->m_VertexCount;
+            num_indices += component->m_IndexCount;
+            vertex_memsize += component->m_VertexCount * component->m_VertexStride;
         }
+
+        // In case if CompSpriteUpdate will be called several times before CompSpriteRender - assign flag with "bit or"
+        // to save flag state from previous update until ReallocBuffers will be called
+        world->m_ReallocBuffers   |= vertex_memsize > world->m_VertexMemorySize || num_indices > world->m_IndexCount;
+        world->m_VertexCount      = num_vertices;
+        world->m_IndexCount       = num_indices;
+        world->m_VertexMemorySize = vertex_memsize;
+
         return dmGameObject::UPDATE_RESULT_OK;
     }
 

--- a/engine/gamesys/src/gamesys/components/comp_sprite.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sprite.cpp
@@ -882,19 +882,19 @@ namespace dmGameSystem
         {
             if (component->m_UseSlice9)
             {
-                component->m_VertexCount   += SPRITE_VERTEX_COUNT_SLICE9;
-                component->m_IndexCount    += SPRITE_INDEX_COUNT_SLICE9;
+                component->m_VertexCount   = SPRITE_VERTEX_COUNT_SLICE9;
+                component->m_IndexCount    = SPRITE_INDEX_COUNT_SLICE9;
             }
             else
             {
-                component->m_VertexCount   += SPRITE_VERTEX_COUNT_LEGACY;
-                component->m_IndexCount    += SPRITE_INDEX_COUNT_LEGACY;
+                component->m_VertexCount   = SPRITE_VERTEX_COUNT_LEGACY;
+                component->m_IndexCount    = SPRITE_INDEX_COUNT_LEGACY;
             }
         }
         else
         {
-            component->m_VertexCount += anim_data->m_VertexCount;
-            component->m_IndexCount += anim_data->m_IndicesCount;
+            component->m_VertexCount = anim_data->m_VertexCount;
+            component->m_IndexCount = anim_data->m_IndicesCount;
         }
     }
 


### PR DESCRIPTION
Fix crash when disabled sprite components enabled in `late_update` script function

### Technical changes
The main reason was in vertex and index buffers size. Previously vertex and index count calculated in `Update` function. Buffers reallocation happens in `Render` function. Component state (enabled or disable) takes into account when render buffers is being filled. So if in `Update` function component was disabled but before render call user enables it in `late_update` than buffer size is smaller than needed.
Solution is move size calculation to `LateUpdate`. But it requires data from AnimationData structure and from attached material (vertex_stride). To avoid pointer chasing I cached vertex count/index count/vertex stride and update it when `m_ReHash` flag is set. As upside - more cache-friendly code. As downside - every component consumes 6 bytes more.

Fixes #12362 

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
