### PR TITLE
Add debug SPIR-V optimizer flags

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Bob.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Bob.java
@@ -494,6 +494,7 @@ public class Bob {
                 // debug options
                 opt(null, "debug-ne-upload", ZERO, "Outputs the files sent to build server as upload.zip"),
                 opt(null, "debug-output-spirv", ONE, "Force build SPIR-V shaders"),
+                opt(null, "debug-spirv-opt", ONE, "Set SPIR-V optimizer mode: skip, -O, -Os, or -Oconfig=<file>"),
                 opt(null, "debug-output-wgsl", ONE, "Force build WGSL shaders"),
                 opt(null, "debug-output-hlsl", ONE, "Force build HLSL shaders"),
                 opt(null, "debug-output-msl", ONE, "Force build Metal shaders"),

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/IShaderCompiler.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/IShaderCompiler.java
@@ -29,6 +29,7 @@ public interface IShaderCompiler {
         public int maxPageCount;
         public boolean forceSplitSamplers;
         public boolean excludeGlesSm100;
+        public String spirvOptMode = "";
         public Shaderc.ShaderPrecision glslEsDefaultFloatPrecision = Shaderc.ShaderPrecision.SHADER_PRECISION_MEDIUMP;
         public Shaderc.ShaderPrecision glslEsDefaultIntPrecision   = Shaderc.ShaderPrecision.SHADER_PRECISION_HIGHP;
     };

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderCompilers.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderCompilers.java
@@ -163,6 +163,7 @@ public class ShaderCompilers {
 
             ShaderCompilePipeline.Options opts = new ShaderCompilePipeline.Options();
             opts.splitTextureSamplers = compileOptions.forceSplitSamplers;
+            opts.spirvOptMode = compileOptions.spirvOptMode;
             opts.glslEsDefaultFloatPrecision = compileOptions.glslEsDefaultFloatPrecision;
             opts.glslEsDefaultIntPrecision = compileOptions.glslEsDefaultIntPrecision;
 

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderProgramBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderProgramBuilder.java
@@ -142,6 +142,7 @@ public class ShaderProgramBuilder extends Builder {
         }
 
         compileOptions.excludeGlesSm100 = getExcludeGlesSm100Flag();
+        compileOptions.spirvOptMode = this.project.option("debug-spirv-opt", "");
         compileOptions.glslEsDefaultFloatPrecision = shaderPrecisionFromString(this.project.getProjectProperties().getStringValue("shader", "glsl_es_default_precision_float", "mediump"));
         compileOptions.glslEsDefaultIntPrecision = shaderPrecisionFromString(this.project.getProjectProperties().getStringValue("shader", "glsl_es_default_precision_int", "highp"));
 

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/shader/ShaderCompilePipeline.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/shader/ShaderCompilePipeline.java
@@ -40,6 +40,7 @@ public class ShaderCompilePipeline {
     public static class Options {
         public boolean splitTextureSamplers;
         public ArrayList<String> defines = new ArrayList<>();
+        public String spirvOptMode = "";
         public Shaderc.ShaderPrecision glslEsDefaultFloatPrecision = Shaderc.ShaderPrecision.SHADER_PRECISION_MEDIUMP;
         public Shaderc.ShaderPrecision glslEsDefaultIntPrecision   = Shaderc.ShaderPrecision.SHADER_PRECISION_HIGHP;
     }
@@ -205,12 +206,31 @@ public class ShaderCompilePipeline {
         checkResult(resourcePath, result);
     }
 
-    private void generateSPIRvOptimized(String resourcePath, String pathFileInSpv, String pathFileOutSpvOpt) throws IOException, CompileExceptionError{
+    private List<String> getSPIRvOptArgs() throws CompileExceptionError {
+        String mode = this.options.spirvOptMode;
+        if (mode == null || mode.isBlank()) {
+            return List.of("-O");
+        }
+
+        mode = mode.trim();
+        if (mode.equals("skip") || mode.equals("-O") || mode.equals("-Os") || mode.startsWith("-Oconfig=")) {
+            return List.of(mode);
+        }
+
+        throw new CompileExceptionError(String.format(
+            "Invalid --debug-spirv-opt value '%s'. Use skip, -O, -Os, or -Oconfig=<file>.", mode));
+    }
+
+    private void generateSPIRvOptimized(String resourcePath, String pathFileInSpv, String pathFileOutSpvOpt, List<String> optArgs) throws IOException, CompileExceptionError{
         // Run optimization pass on the result
-        Result result = Exec.execResult(spirvOptExe,
-            "-O",
-            pathFileInSpv,
-            "-o", pathFileOutSpvOpt);
+        ArrayList<String> args = new ArrayList<>();
+        args.add(spirvOptExe);
+        args.addAll(optArgs);
+        args.add(pathFileInSpv);
+        args.add("-o");
+        args.add(pathFileOutSpvOpt);
+
+        Result result = Exec.execResult(args.toArray(new String[0]));
         checkResult(resourcePath, result);
     }
 
@@ -290,10 +310,14 @@ public class ShaderCompilePipeline {
             FileUtil.deleteOnExit(fileOutSpv);
             generateSPIRv(module.desc.resourcePath, module.desc.type, fileInGLSL.getAbsolutePath(), fileOutSpv.getAbsolutePath());
 
-            // Generate an optimized version of the final .spv file
-            File fileOutSpvOpt = File.createTempFile(this.pipelineName, ".optimized.spv");
-            FileUtil.deleteOnExit(fileOutSpvOpt);
-            generateSPIRvOptimized(module.desc.resourcePath, fileOutSpv.getAbsolutePath(), fileOutSpvOpt.getAbsolutePath());
+            List<String> spirvOptArgs = getSPIRvOptArgs();
+            File fileOutSpvOpt = fileOutSpv;
+            if (!spirvOptArgs.contains("skip")) {
+                // Generate an optimized version of the final .spv file
+                fileOutSpvOpt = File.createTempFile(this.pipelineName, ".optimized.spv");
+                FileUtil.deleteOnExit(fileOutSpvOpt);
+                generateSPIRvOptimized(module.desc.resourcePath, fileOutSpv.getAbsolutePath(), fileOutSpvOpt.getAbsolutePath(), spirvOptArgs);
+            }
 
             module.spirvFile = fileOutSpvOpt;
             module.spirvContext = ShadercJni.NewShaderContext(ToShadercShaderStageValue(module.desc.type), FileUtils.readFileToByteArray(fileOutSpvOpt));


### PR DESCRIPTION
New debug options have been added to bob.jar for passing optimization flags to bob for performance measurements:

```
java -jar bob.jar --debug-spirv-opt=skip|-O|-Os|-Oconfig=<file>

skip - no optimization
-O - optimize for performance
-Os - optimize for size
-Oconfig=<file> - pass in a file that specifies specific performance switches
```

The -O and -Os flags combine multiple flags to achieve its goal, where as with the config file case you can specify specific optimization flags to diagnose.
