### PR TITLE
Fix Base64Decode to handle input without padding

### DIFF
--- a/engine/dlib/src/dlib/crypt_mbedtls.cpp
+++ b/engine/dlib/src/dlib/crypt_mbedtls.cpp
@@ -74,7 +74,23 @@ namespace dmCrypt
     bool Base64Decode(const uint8_t* src, uint32_t src_len, uint8_t* dst, uint32_t* dst_len)
     {
         size_t out_len = 0;
-        int r = mbedtls_base64_decode(dst, *dst_len, &out_len, src, src_len);
+        int r;
+
+        uint32_t padding_needed = (4 - (src_len % 4)) % 4;
+        if (padding_needed > 0 && src_len > 0)
+        {
+            uint32_t padded_len = src_len + padding_needed;
+            uint8_t* padded_src = new uint8_t[padded_len];
+            memcpy(padded_src, src, src_len);
+            memset(padded_src + src_len, '=', padding_needed);
+            r = mbedtls_base64_decode(dst, *dst_len, &out_len, padded_src, padded_len);
+            delete[] padded_src;
+        }
+        else
+        {
+            r = mbedtls_base64_decode(dst, *dst_len, &out_len, src, src_len);
+        }
+
         if (r != 0)
         {
             if (*dst_len == 0)

--- a/engine/dlib/src/dlib/crypt_mbedtls.cpp
+++ b/engine/dlib/src/dlib/crypt_mbedtls.cpp
@@ -71,26 +71,26 @@ namespace dmCrypt
         return true;
     }
 
-    bool Base64Decode(const uint8_t* src, uint32_t src_len, uint8_t* dst, uint32_t* dst_len)
+    bool Base64Decode(const uint8_t* src_original, uint32_t src_len_original, uint8_t* dst, uint32_t* dst_len)
     {
         size_t out_len = 0;
 
-        uint32_t padding_needed = src_len > 0 ? ((4 - (src_len % 4)) % 4) : 0;
-
+        uint32_t padding_needed = (4 - (src_len_original % 4)) % 4;
         uint8_t* padded_src = 0;
-        uint32_t decode_src_len = src_len;
 
-        if (padding_needed != 0)
+        const uint8_t* src = src_original;
+        uint32_t src_len = src_len_original;
+
+        if (padding_needed > 0 && src_len_original > 0)
         {
-            decode_src_len = src_len + padding_needed;
-            padded_src = new uint8_t[decode_src_len];
-            memcpy(padded_src, src, src_len);
-            memset(padded_src + src_len, '=', padding_needed);
+            src_len = src_len_original + padding_needed;
+            padded_src = new uint8_t[src_len];
+            memcpy(padded_src, src_original, src_len_original);
+            memset(padded_src + src_len_original, '=', padding_needed);
+            src = padded_src;
         }
 
-        const uint8_t* decode_src = padded_src ? padded_src : src;
-
-        int r = mbedtls_base64_decode(dst, *dst_len, &out_len, decode_src, decode_src_len);
+        int r = mbedtls_base64_decode(dst, *dst_len, &out_len, src, src_len);
 
         if (padded_src)
         {

--- a/engine/dlib/src/dlib/crypt_mbedtls.cpp
+++ b/engine/dlib/src/dlib/crypt_mbedtls.cpp
@@ -71,22 +71,19 @@ namespace dmCrypt
         return true;
     }
 
-    bool Base64Decode(const uint8_t* src_original, uint32_t src_len_original, uint8_t* dst, uint32_t* dst_len)
+    bool Base64Decode(const uint8_t* src, uint32_t src_len, uint8_t* dst, uint32_t* dst_len)
     {
         size_t out_len = 0;
 
-        uint32_t padding_needed = (4 - (src_len_original % 4)) % 4;
+        uint32_t padding_needed = (4 - (src_len % 4)) % 4;
         uint8_t* padded_src = 0;
 
-        const uint8_t* src = src_original;
-        uint32_t src_len = src_len_original;
-
-        if (padding_needed > 0 && src_len_original > 0)
+        if (padding_needed > 0 && src_len > 0)
         {
-            src_len = src_len_original + padding_needed;
-            padded_src = new uint8_t[src_len];
-            memcpy(padded_src, src_original, src_len_original);
-            memset(padded_src + src_len_original, '=', padding_needed);
+            padded_src = new uint8_t[src_len + padding_needed];
+            memcpy(padded_src, src, src_len);
+            memset(padded_src + src_len, '=', padding_needed);
+            src_len = src_len + padding_needed;
             src = padded_src;
         }
 

--- a/engine/dlib/src/dlib/crypt_mbedtls.cpp
+++ b/engine/dlib/src/dlib/crypt_mbedtls.cpp
@@ -74,21 +74,27 @@ namespace dmCrypt
     bool Base64Decode(const uint8_t* src, uint32_t src_len, uint8_t* dst, uint32_t* dst_len)
     {
         size_t out_len = 0;
-        int r;
 
-        uint32_t padding_needed = (4 - (src_len % 4)) % 4;
-        if (padding_needed > 0 && src_len > 0)
+        uint32_t padding_needed = src_len > 0 ? ((4 - (src_len % 4)) % 4) : 0;
+
+        uint8_t* padded_src = 0;
+        uint32_t decode_src_len = src_len;
+
+        if (padding_needed != 0)
         {
-            uint32_t padded_len = src_len + padding_needed;
-            uint8_t* padded_src = new uint8_t[padded_len];
+            decode_src_len = src_len + padding_needed;
+            padded_src = new uint8_t[decode_src_len];
             memcpy(padded_src, src, src_len);
             memset(padded_src + src_len, '=', padding_needed);
-            r = mbedtls_base64_decode(dst, *dst_len, &out_len, padded_src, padded_len);
-            delete[] padded_src;
         }
-        else
+
+        const uint8_t* decode_src = padded_src ? padded_src : src;
+
+        int r = mbedtls_base64_decode(dst, *dst_len, &out_len, decode_src, decode_src_len);
+
+        if (padded_src)
         {
-            r = mbedtls_base64_decode(dst, *dst_len, &out_len, src, src_len);
+            delete[] padded_src;
         }
 
         if (r != 0)

--- a/engine/dlib/src/test/test_crypt.cpp
+++ b/engine/dlib/src/test/test_crypt.cpp
@@ -187,6 +187,63 @@ TEST(dmCrypt, Base64Decode)
     ASSERT_ARRAY_EQ_LEN(expected, (const char*)dst, dst_len);
 }
 
+TEST(dmCrypt, Base64DecodeNoPadding)
+{
+    const char* source_no_pad = "TG9yZW0gSXBzdW0";
+    const char* source_with_pad = "TG9yZW0gSXBzdW0=";
+    const char* expected = "Lorem Ipsum";
+
+    uint8_t dst1[64];
+    uint8_t dst2[64];
+    uint32_t dst_len1 = sizeof(dst1);
+    uint32_t dst_len2 = sizeof(dst2);
+    bool result1, result2;
+
+    result1 = dmCrypt::Base64Decode((const uint8_t*)source_no_pad, strlen(source_no_pad), dst1, &dst_len1);
+    result2 = dmCrypt::Base64Decode((const uint8_t*)source_with_pad, strlen(source_with_pad), dst2, &dst_len2);
+
+    ASSERT_EQ(true, result1);
+    ASSERT_EQ(true, result2);
+    ASSERT_EQ(strlen(expected), dst_len1);
+    ASSERT_EQ(strlen(expected), dst_len2);
+    ASSERT_ARRAY_EQ_LEN(expected, (const char*)dst1, dst_len1);
+    ASSERT_ARRAY_EQ_LEN(expected, (const char*)dst2, dst_len2);
+}
+
+TEST(dmCrypt, Base64DecodeNoPaddingJWT)
+{
+    const char* source = "YWJj";
+    const char* expected = "abc";
+
+    uint8_t dst[64];
+    uint32_t dst_len = sizeof(dst);
+    bool result = dmCrypt::Base64Decode((const uint8_t*)source, strlen(source), dst, &dst_len);
+
+    ASSERT_EQ(true, result);
+    ASSERT_EQ(strlen(expected), dst_len);
+    ASSERT_ARRAY_EQ_LEN(expected, (const char*)dst, dst_len);
+
+    const char* source2 = "YWI";
+    const char* expected2 = "ab";
+
+    dst_len = sizeof(dst);
+    result = dmCrypt::Base64Decode((const uint8_t*)source2, strlen(source2), dst, &dst_len);
+
+    ASSERT_EQ(true, result);
+    ASSERT_EQ(strlen(expected2), dst_len);
+    ASSERT_ARRAY_EQ_LEN(expected2, (const char*)dst, dst_len);
+
+    const char* source3 = "YQ";
+    const char* expected3 = "a";
+
+    dst_len = sizeof(dst);
+    result = dmCrypt::Base64Decode((const uint8_t*)source3, strlen(source3), dst, &dst_len);
+
+    ASSERT_EQ(true, result);
+    ASSERT_EQ(strlen(expected3), dst_len);
+    ASSERT_ARRAY_EQ_LEN(expected3, (const char*)dst, dst_len);
+}
+
 
 int main(int argc, char **argv)
 {


### PR DESCRIPTION
When decoding base64 strings that lack padding characters, `dmCrypt::Base64Decode` returns nil. This happens because mbedTLS's base64 decoder strictly requires padding, but many systems (particularly JWT implementations) omit padding per RFC 4648 section 3.2 which states that padding is not always required.

This issue can be observed while using the crypt extension with Nakama's JWT tokens. The server sends tokens without padding, and the decode fails silently.

The fix adds the missing `=` characters before passing the input to mbedTLS when the input length is not a multiple of 4. In addition, a test cases covering strings with and without padding was added to prevent regression.

The change should not affect consoles since it only modifies the mbedTLS path.

Fixes #11197