### PR TITLE
Allow WebView-host opt-outs via pre-set Module.* properties

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/bundle/test/DmLoaderTemplateTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/bundle/test/DmLoaderTemplateTest.java
@@ -54,7 +54,10 @@ public class DmLoaderTemplateTest {
         String src = readDmLoaderTemplate();
 
         int captureIdx = src.indexOf("var DEFOLD_HOST_NO_PTHREAD");
-        int redefineIdx = src.indexOf("var Module = {");
+        // Anchor on the redefinition's first property (`engineVersion`) so
+// the search isn't fooled by documentation comments earlier in the
+// file that mention `var Module = {...}` literally.
+int redefineIdx = src.indexOf("var Module = {\n    engineVersion");
         int consumeIdx = src.indexOf("if (DEFOLD_HOST_NO_PTHREAD)");
 
         assertTrue("missing DEFOLD_HOST_NO_PTHREAD capture", captureIdx >= 0);
@@ -70,5 +73,69 @@ public class DmLoaderTemplateTest {
             "DEFOLD_HOST_NO_PTHREAD must be consumed *after* the Module "
                 + "redefinition so the probe site uses the captured value",
             consumeIdx > redefineIdx);
+    }
+
+    /**
+     * Five additional host opt-outs share the same capture-before-
+     * redefinition pattern: a WebView wrapper pre-sets one or more of
+     * `isWebGL2Supported`, `webGLContextAttributes`,
+     * `webGLExtensionFilter`, `showButtonStrip`, or
+     * `autoReloadOnWebGLContextRestore` on Module before the loader
+     * script runs. Each capture must appear before `var Module = {`
+     * so the host-set property survives the redefinition.
+     */
+    @Test
+    public void allHostOptOutsCapturedBeforeModuleRedefinition() throws IOException {
+        String src = readDmLoaderTemplate();
+
+        // Anchor on the redefinition's first property (`engineVersion`) so
+// the search isn't fooled by documentation comments earlier in the
+// file that mention `var Module = {...}` literally.
+int redefineIdx = src.indexOf("var Module = {\n    engineVersion");
+        assertTrue("missing `var Module = {` redefinition", redefineIdx >= 0);
+
+        String[] captureTokens = {
+            "var DEFOLD_HOST_NO_PTHREAD",
+            "var DEFOLD_HOST_NO_WEBGL2",
+            "var DEFOLD_HOST_GL_CTX_ATTRS",
+            "var DEFOLD_HOST_GL_EXT_FILTER",
+            "var DEFOLD_HOST_NO_BUTTON_STRIP",
+            "var DEFOLD_HOST_WEBGL_RELOAD",
+        };
+        for (String token : captureTokens) {
+            int idx = src.indexOf(token);
+            assertTrue("missing capture: " + token, idx >= 0);
+            assertTrue(
+                token + " must be captured *before* `var Module = {` "
+                    + "or the host-set property is discarded before the capture runs",
+                idx < redefineIdx);
+        }
+    }
+
+    /**
+     * The non-pthread opt-outs (WebGL2 downgrade, ctx attrs, extension
+     * filter, CSS, context-loss) only patch DOM / prototypes — they
+     * don't touch Module — so they're applied immediately at the
+     * capture site rather than deferred to a second consumer block.
+     * The IIFE wrapping these applies must therefore appear *before*
+     * the Module redefinition.
+     */
+    @Test
+    public void hostOptOutApplyBlockRunsBeforeModuleRedefinition() throws IOException {
+        String src = readDmLoaderTemplate();
+
+        int applyIdx = src.indexOf("function applyDefoldHostOptOuts");
+        // Anchor on the redefinition's first property (`engineVersion`) so
+// the search isn't fooled by documentation comments earlier in the
+// file that mention `var Module = {...}` literally.
+int redefineIdx = src.indexOf("var Module = {\n    engineVersion");
+
+        assertTrue("missing applyDefoldHostOptOuts IIFE", applyIdx >= 0);
+        assertTrue("missing `var Module = {` redefinition", redefineIdx >= 0);
+        assertTrue(
+            "applyDefoldHostOptOuts must run *before* `var Module = {` "
+                + "so the prototype / DOM patches are installed before the "
+                + "WASM engine creates the WebGL context",
+            applyIdx < redefineIdx);
     }
 }

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/bundle/test/DmLoaderTemplateTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/bundle/test/DmLoaderTemplateTest.java
@@ -1,0 +1,74 @@
+// Copyright 2020-2026 The Defold Foundation
+// Copyright 2014-2020 King
+// Copyright 2009-2014 Ragnar Svensson, Christian Murray
+// Licensed under the Defold License version 1.0 (the "License"); you may not use
+// this file except in compliance with the License.
+//
+// You may obtain a copy of the License, together with FAQs at
+// https://www.defold.com/license
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package com.dynamo.bob.bundle.test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.dynamo.bob.bundle.HTML5Bundler;
+
+/**
+ * Verifies invariants of the dmloader.js bundle template that aren't
+ * easy to assert from runtime behaviour because the bob test module
+ * has no JS execution harness.
+ */
+public class DmLoaderTemplateTest {
+
+    private static String readDmLoaderTemplate() throws IOException {
+        URL url = HTML5Bundler.class.getResource("resources/web/dmloader.js");
+        assertNotNull("dmloader.js template missing from classpath", url);
+        try (InputStream in = url.openStream()) {
+            return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+
+    /**
+     * dmloader.js defines `var Module = {...}` partway through the file,
+     * which would discard any host-set Module object loaded earlier on
+     * the page. The host opt-out for pthread WASM is therefore captured
+     * into a separate variable (DEFOLD_HOST_NO_PTHREAD) before that
+     * assignment, and consumed at the probe site below. Both pieces
+     * must be present for the opt-out to actually take effect.
+     */
+    @Test
+    public void hostPthreadOptOutIsCapturedBeforeModuleRedefinition() throws IOException {
+        String src = readDmLoaderTemplate();
+
+        int captureIdx = src.indexOf("var DEFOLD_HOST_NO_PTHREAD");
+        int redefineIdx = src.indexOf("var Module = {");
+        int consumeIdx = src.indexOf("if (DEFOLD_HOST_NO_PTHREAD)");
+
+        assertTrue("missing DEFOLD_HOST_NO_PTHREAD capture", captureIdx >= 0);
+        assertTrue("missing `var Module = {` redefinition", redefineIdx >= 0);
+        assertTrue("missing DEFOLD_HOST_NO_PTHREAD consumer at probe site", consumeIdx >= 0);
+
+        assertTrue(
+            "DEFOLD_HOST_NO_PTHREAD must be captured *before* `var Module = {` "
+                + "or the host-set property is discarded before the capture runs",
+            captureIdx < redefineIdx);
+
+        assertTrue(
+            "DEFOLD_HOST_NO_PTHREAD must be consumed *after* the Module "
+                + "redefinition so the probe site uses the captured value",
+            consumeIdx > redefineIdx);
+    }
+}

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/resources/web/dmloader.js
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/resources/web/dmloader.js
@@ -1308,9 +1308,17 @@ Module['onRuntimeInitialized'] = function() {
     Module.runApp("canvas");
 };
 
-Module["isWASMPthreadSupported"] = {{DEFOLD_HAS_WASM_PTHREAD_ENGINE}} 
-    && ((typeof window === 'undefined') || window.isSecureContext && window.crossOriginIsolated)
-    && typeof SharedArrayBuffer !== 'undefined';
+// Pthread variant requires SharedArrayBuffer + crossOriginIsolated, but
+// some hosts that satisfy both still can't construct Workers (e.g. a
+// WebView wrapper serving the bundle from a custom URL scheme, where
+// Chromium's separate Worker origin check rejects `new Worker(...)`).
+// Let those hosts opt out by pre-setting `Module.isWASMPthreadSupported
+// = false` before dmloader.js executes; otherwise run the normal probe.
+if (Module["isWASMPthreadSupported"] !== false) {
+    Module["isWASMPthreadSupported"] = {{DEFOLD_HAS_WASM_PTHREAD_ENGINE}}
+        && ((typeof window === 'undefined') || window.isSecureContext && window.crossOriginIsolated)
+        && typeof SharedArrayBuffer !== 'undefined';
+}
 
 Module["locateFile"] = function(path, scriptDirectory)
 {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/resources/web/dmloader.js
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/resources/web/dmloader.js
@@ -925,16 +925,152 @@ var Progress = {
     }
 };
 
-// Capture host opt-out before dmloader's `var Module = {...}` below
-// replaces the global. Embedding hosts that can't construct same-origin
-// Workers (e.g. a WebView wrapper serving the bundle from a custom URL
-// scheme) pre-set `Module.isWASMPthreadSupported = false` on the page
-// to force the single-threaded WASM; without this capture the
-// assignment that follows would discard the host-set property and the
-// guard at the probe site below would never see the opt-out.
-var DEFOLD_HOST_NO_PTHREAD = (typeof Module !== "undefined")
-    && Module
-    && Module.isWASMPthreadSupported === false;
+// --- WebView-host opt-outs ----------------------------------------------
+// Capture host-set properties before dmloader's `var Module = {...}`
+// below replaces the global. Embedding hosts (typically WebView
+// wrappers that serve the bundle from a custom URL scheme) pre-set
+// these on Module on the page *before* `<script src="dmloader.js">` so
+// dmloader can fine-tune behaviour without rewriting the bundle on
+// serve. Without capture, the assignment that follows would discard
+// the host-set properties before any guard could see them.
+//
+//   Module.isWASMPthreadSupported  === false      // force single-threaded WASM
+//   Module.isWebGL2Supported       === false      // downgrade webgl2 -> webgl
+//   Module.webGLContextAttributes  = {...}        // override GL context attrs
+//   Module.webGLExtensionFilter    = (n) => bool  // strip GL extension names
+//   Module.showButtonStrip         === false      // hide canvas footer chrome
+//   Module.autoReloadOnWebGLContextRestore === true // reload on context restored
+//
+// Default behaviour is byte-identical when nothing is pre-set — each
+// capture below yields undefined / null / false and the matching apply
+// block skips. Concrete motivation in #12397.
+var _DEFOLD_HOST = (typeof Module !== "undefined" && Module) || null;
+
+var DEFOLD_HOST_NO_PTHREAD = _DEFOLD_HOST
+    && _DEFOLD_HOST.isWASMPthreadSupported === false;
+
+var DEFOLD_HOST_NO_WEBGL2 = _DEFOLD_HOST
+    && _DEFOLD_HOST.isWebGL2Supported === false;
+
+var DEFOLD_HOST_GL_CTX_ATTRS = (_DEFOLD_HOST
+    && _DEFOLD_HOST.webGLContextAttributes) || null;
+
+var DEFOLD_HOST_GL_EXT_FILTER = (_DEFOLD_HOST
+    && typeof _DEFOLD_HOST.webGLExtensionFilter === "function")
+        ? _DEFOLD_HOST.webGLExtensionFilter : null;
+
+var DEFOLD_HOST_NO_BUTTON_STRIP = _DEFOLD_HOST
+    && _DEFOLD_HOST.showButtonStrip === false;
+
+var DEFOLD_HOST_WEBGL_RELOAD = _DEFOLD_HOST
+    && _DEFOLD_HOST.autoReloadOnWebGLContextRestore === true;
+
+// Apply the non-pthread opt-outs immediately. They patch prototypes /
+// inject DOM only and don't reference Module, so they're safe before
+// the redefinition. pthread is consumed further down at the probe
+// site because the final value has to end up as a property on the
+// post-redefinition Module object.
+(function applyDefoldHostOptOuts() {
+    // WebGL2 downgrade + context-attrs override. Some embedded GLES
+    // drivers report WebGL2 support but trip inside Defold's VAO /
+    // instancing init; returning a WebGL1 context lets the engine
+    // fall back to its WebGL1 GL initializer. Host-supplied attrs
+    // (e.g. preserveDrawingBuffer:true to survive a flaky compositor)
+    // are merged into both the downgraded path and the pass-through.
+    if ((DEFOLD_HOST_NO_WEBGL2 || DEFOLD_HOST_GL_CTX_ATTRS)
+            && typeof HTMLCanvasElement !== "undefined") {
+        var _origGetContext = HTMLCanvasElement.prototype.getContext;
+        HTMLCanvasElement.prototype.getContext = function (type, attrs) {
+            var mergedAttrs = DEFOLD_HOST_GL_CTX_ATTRS
+                ? Object.assign({}, attrs || {}, DEFOLD_HOST_GL_CTX_ATTRS)
+                : attrs;
+            if (DEFOLD_HOST_NO_WEBGL2
+                    && (type === "webgl2" || type === "experimental-webgl2")) {
+                return _origGetContext.call(this, "webgl", mergedAttrs)
+                    || _origGetContext.call(this, "experimental-webgl", mergedAttrs);
+            }
+            return _origGetContext.call(this, type, mergedAttrs);
+        };
+    }
+
+    // Extension filter. Hosts whose underlying GLES driver falsely
+    // advertises compressed-texture / float-texture / depth-texture
+    // extensions pass a (name) => boolean callback returning true
+    // for names that should be stripped from getSupportedExtensions
+    // and made null from getExtension.
+    if (DEFOLD_HOST_GL_EXT_FILTER) {
+        var _wrapExt = function (proto) {
+            if (!proto) return;
+            var _sup = proto.getSupportedExtensions;
+            if (_sup) {
+                proto.getSupportedExtensions = function () {
+                    var exts = _sup.call(this) || [];
+                    return exts.filter(function (e) {
+                        return !DEFOLD_HOST_GL_EXT_FILTER(e);
+                    });
+                };
+            }
+            var _get = proto.getExtension;
+            if (_get) {
+                proto.getExtension = function (name) {
+                    if (DEFOLD_HOST_GL_EXT_FILTER(name)) return null;
+                    return _get.call(this, name);
+                };
+            }
+        };
+        if (typeof WebGLRenderingContext  !== "undefined") _wrapExt(WebGLRenderingContext.prototype);
+        if (typeof WebGL2RenderingContext !== "undefined") _wrapExt(WebGL2RenderingContext.prototype);
+    }
+
+    // Hide the engine_template footer button strip. The stock
+    // template emits <div class="buttons-background"> for the
+    // Fullscreen / Made-with-Defold links; suppressing the inner
+    // anchors via game.project leaves a 42 px white bar behind.
+    // Hosts that want a true-fullscreen canvas opt out here.
+    if (DEFOLD_HOST_NO_BUTTON_STRIP && typeof document !== "undefined") {
+        var _injectNoButtonStripCSS = function () {
+            if (!document.head) return;
+            var style = document.createElement("style");
+            style.setAttribute("data-defold", "no-button-strip");
+            style.textContent = ".buttons-background { display: none !important; }";
+            document.head.appendChild(style);
+        };
+        if (document.readyState === "loading") {
+            document.addEventListener("DOMContentLoaded", _injectNoButtonStripCSS);
+        } else {
+            _injectNoButtonStripCSS();
+        }
+    }
+
+    // WebGL context-loss recovery. WebView hosts can drop the WebGL
+    // backbuffer when the host pauses / re-attaches the view; the
+    // engine renderer has no recovery path so frames render black.
+    // preventDefault() on lost asks the browser to restore; on the
+    // restored event we reload the page so the engine boots cleanly.
+    // The player lands on the title and can resume from autosave.
+    if (DEFOLD_HOST_WEBGL_RELOAD && typeof document !== "undefined") {
+        var _attachWebGLLossHandlers = function () {
+            var canvas = document.getElementById("canvas");
+            if (!canvas) {
+                setTimeout(_attachWebGLLossHandlers, 100);
+                return;
+            }
+            canvas.addEventListener("webglcontextlost", function (e) {
+                e.preventDefault();
+            }, false);
+            canvas.addEventListener("webglcontextrestored", function () {
+                if (typeof window !== "undefined" && window.location && window.location.reload) {
+                    window.location.reload();
+                }
+            }, false);
+        };
+        if (document.readyState === "loading") {
+            document.addEventListener("DOMContentLoaded", _attachWebGLLossHandlers);
+        } else {
+            _attachWebGLLossHandlers();
+        }
+    }
+})();
 
 /* ********************************************************************* */
 /* Module is Emscripten namespace                                        */

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/resources/web/dmloader.js
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/resources/web/dmloader.js
@@ -925,6 +925,17 @@ var Progress = {
     }
 };
 
+// Capture host opt-out before dmloader's `var Module = {...}` below
+// replaces the global. Embedding hosts that can't construct same-origin
+// Workers (e.g. a WebView wrapper serving the bundle from a custom URL
+// scheme) pre-set `Module.isWASMPthreadSupported = false` on the page
+// to force the single-threaded WASM; without this capture the
+// assignment that follows would discard the host-set property and the
+// guard at the probe site below would never see the opt-out.
+var DEFOLD_HOST_NO_PTHREAD = (typeof Module !== "undefined")
+    && Module
+    && Module.isWASMPthreadSupported === false;
+
 /* ********************************************************************* */
 /* Module is Emscripten namespace                                        */
 /* ********************************************************************* */
@@ -1308,13 +1319,11 @@ Module['onRuntimeInitialized'] = function() {
     Module.runApp("canvas");
 };
 
-// Pthread variant requires SharedArrayBuffer + crossOriginIsolated, but
-// some hosts that satisfy both still can't construct Workers (e.g. a
-// WebView wrapper serving the bundle from a custom URL scheme, where
-// Chromium's separate Worker origin check rejects `new Worker(...)`).
-// Let those hosts opt out by pre-setting `Module.isWASMPthreadSupported
-// = false` before dmloader.js executes; otherwise run the normal probe.
-if (Module["isWASMPthreadSupported"] !== false) {
+if (DEFOLD_HOST_NO_PTHREAD) {
+    // Host opted out before dmloader's `var Module = {...}` replaced
+    // the global; honour that and pick the single-threaded WASM.
+    Module["isWASMPthreadSupported"] = false;
+} else {
     Module["isWASMPthreadSupported"] = {{DEFOLD_HAS_WASM_PTHREAD_ENGINE}}
         && ((typeof window === 'undefined') || window.isSecureContext && window.crossOriginIsolated)
         && typeof SharedArrayBuffer !== 'undefined';


### PR DESCRIPTION
Embedding hosts can now pre-set the following properties on `Module` *before* `<script src="dmloader.js">` runs to fine-tune behaviour without rewriting the bundle on serve. All six share one capture-before-redefinition mechanism: read the host-set value into a top-level `DEFOLD_HOST_*` variable before dmloader's `var Module = {...}` discards the global, then apply at the IIFE that runs immediately after the captures.

| Property                                       | Effect                                                                                                                              |
| ---------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
| `Module.isWASMPthreadSupported = false`        | Force the single-threaded WASM variant. (Original pthread case — see #12397.)                                                       |
| `Module.isWebGL2Supported = false`             | Downgrade `getContext('webgl2')` to `'webgl'`. Bypasses VAO / instancing init paths broken in some embedded GLES drivers.           |
| `Module.webGLContextAttributes = {...}`        | Merged into the GL context attrs. Notably `preserveDrawingBuffer:true` to survive a flaky host compositor.                          |
| `Module.webGLExtensionFilter = (n) => boolean` | Strip falsely-advertised extension names (compressed-texture, float-texture, depth-texture) from `getSupportedExtensions`.          |
| `Module.showButtonStrip = false`               | Hide the engine_template footer button strip (a 42 px white bar that survives even when both inner anchors are off via game.project).|
| `Module.autoReloadOnWebGLContextRestore = true`| Attach `webglcontextlost` / `webglcontextrestored` listeners; reload on restore so Defold re-initialises GL cleanly.                |

Default behaviour is byte-identical when nothing is pre-set — each capture yields `undefined` / `null` / `false` and the matching apply block skips.

The concrete reproducer that motivated all six is the same: a WebView wrapper that serves the bundle from a custom URL scheme (`myscheme://`) — Chromium's separate Worker origin check rejects pthread WASM (the original case), and the embedded GLES driver underneath the WebView frequently advertises capabilities it can't actually deliver (the new cases). Hand-rewriting `dmloader.js` byte-for-byte on serve worked but was fragile and had to be redone every Defold release.

Closes #12397.

### Latest validation (2026-05-25)

* For hosts that control the build, the original pthread case is now confirmed to be solvable cleanly at build time with stock tooling: `bob.jar --platform js-web --architectures wasm-web` produces a single-threaded bundle (`<game>.wasm` + `<game>_wasm.js`, no `*_pthread*`, and `dmloader.js` emits `Module["isWASMPthreadSupported"] = false ...`). My OHOS HAP path now does exactly that and no longer rewrites `dmloader.js` for the pthread part.
* That does **not** make this PR obsolete. The runtime opt-out is still useful for black-box bundle consumers and for teams shipping one generic HTML5 bundle to multiple hosts with different Worker behaviour.
* I also tested engine-side mitigation in a Defold fork: a real WebGL2 probe before committing the renderer, plus runtime validation of reported texture capabilities. Those reduce Defold-owned failure modes, but on the OHOS emulator they were not sufficient by themselves.
* In current testing, the OHOS emulator still requires the host-side equivalents of `Module.isWebGL2Supported = false` and `Module.webGLExtensionFilter = ...`. Without that host shim, the emulator could go fully offline after launch; the emulator-side logs showed compressed-texture / ASTC failure immediately before the drop (`decode_compressed_texture: astc format` / `decode astc image error`) and the crash monitor recorded `Client heartbeat lost, exit` with Windows code `3221226505`.
* After reintroducing the host-side WebGL1 downgrade + extension filter in the OHOS wrapper, the HAP stayed up through repeated multi-minute soaks and `hdc` remained connected. So the WebGL2 / extension-filter opt-outs in this PR are still load-bearing in practice even with better engine-side probing.
* The remaining `DGLES` spam (`bind external with nullptr gbuffer`, `createimage with ctx null`) still appears to be below Defold, in ArkWeb/Chromium GPU plus the OHOS emulator's DGLES/compositor stack. I do not currently have evidence that Defold alone can eliminate those messages.

### Technical changes

* `dmloader.js`'s `var Module = {...}` unconditionally replaces any pre-existing global. A guard at the consumer site is therefore insufficient — by the time the consumer runs, the host-set property is gone. Capture each opt-out into a top-level `DEFOLD_HOST_*` variable *before* the Module redefinition. The `applyDefoldHostOptOuts` IIFE runs at the capture site (immediately after the captures, still before the redefinition) and installs prototype / DOM patches that don't touch Module.
* `Module.isWASMPthreadSupported` is the only opt-out that has to be a property on the post-redefinition Module object, so its consumer stays at the original probe site.
* The host-facing API is the standard Emscripten pattern: `var Module = { ... };` on the page before the `<script src="dmloader.js">` tag. Either a `var` declaration or `window.Module = {...}` works; `let Module = ...` does not, because top-level `let` creates a script-scoped binding that dmloader's global `var Module` can't see.
* Strict `=== false` / `=== true` boolean checks where applicable so only the explicit opt-in / opt-out triggers; truthy/falsy values like `0`, `null`, `""`, or `undefined` are ignored.
* No API change. No new dependencies. The five new opt-outs are additive; the pthread path is unchanged from v2.

### Test

`DmLoaderTemplateTest` gets three assertions covering the template invariants (the bob test module has no JS execution harness, so these are text-level checks against the resource):

1. `hostPthreadOptOutIsCapturedBeforeModuleRedefinition` — unchanged from v2 except the `indexOf("var Module = {")` anchor is tightened to `"var Module = {\n    engineVersion"` so it doesn't match documentation comments earlier in the file that mention `var Module = {...}` literally.
2. `allHostOptOutsCapturedBeforeModuleRedefinition` — every `DEFOLD_HOST_*` capture token appears before the redefinition.
3. `hostOptOutApplyBlockRunsBeforeModuleRedefinition` — the `applyDefoldHostOptOuts` IIFE also runs before the redefinition, so prototype / DOM patches install before the WASM creates the WebGL context.

Manual repro: in the host page, set any combination of the six properties on Module before the `<script src="dmloader.js">` tag and observe the effect. For pthread specifically, `Module["locateFile"]` returns `{exe-name}.wasm` instead of `{exe-name}_pthread.wasm`. For WebGL2 downgrade, `canvas.getContext('webgl2')` returns a `WebGL1RenderingContext` instance.

### Review iteration

* v1: only a guard at the probe site. Codex review correctly flagged that this couldn't honour the host opt-out because `var Module = {...}` discards the host-set property before the guard runs.
* v2: capture-before-redefinition, branch-after — limited to the pthread case.
* **v3 (current): same capture pattern generalised to five additional opt-outs.** Each is independently motivated by a concrete WebView-wrapper failure mode that the existing API surface couldn't address. The five additions are additive and can be reviewed / rejected piecewise without affecting the pthread fix.

## PR checklist

* [x] Code
   * [x] Add engine and/or editor unit tests. — _`DmLoaderTemplateTest` extended with two additional invariant assertions (`allHostOptOutsCapturedBeforeModuleRedefinition`, `hostOptOutApplyBlockRunsBeforeModuleRedefinition`); the original pthread test's anchor is also tightened so it stops accidentally matching documentation comments._
   * [x] New and changed code follows the overall code style of existing code
   * [x] Add comments where needed — _Each opt-out has a per-block comment explaining the concrete failure mode that motivated it and the mechanism of the fix._
* [x] Documentation
   * [x] Make sure that API documentation is updated in code comments — _The umbrella comment block above the captures enumerates every `Module.X` host-facing API._
   * [x] Make sure that manuals are updated (in github.com/defold/doc) — _Companion PR [defold/doc#635](https://github.com/defold/doc/pull/635) adds a new "Host-set Module properties" subsection to the HTML5 manual covering all six opt-outs (table + example + the `let` vs `var` gotcha + the strict sentinel-value semantics). Tracks this PR; ready to land in parallel._
* [x] Prepare pull request and affected issue for automatic release notes generator
   * [x] Pull request - Write a message that explains what this pull request does
   * [x] Pull request - Write a pull request title that summarises what the pull request does
   * [x] Pull request - Link the pull request to the issue(s) it is closing — _`Closes #12397`._
   * [ ] Affected issue - Assign the issue to a project. — _The Defold org project boards aren't writeable by non-maintainers (`gh project list --owner defold` rejects with `missing required scopes [read:project]`, and `gh issue edit --add-project HTML5` returns project-not-found from outside the org). Please triage #12397 to the appropriate project as part of merge — the rest of the checklist is honoured._
   * [x] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change. — _Not a breaking change: default behaviour is byte-identical when nothing pre-sets the property. No label applied._
   * [x] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes. — _Should appear in release notes (this adds a host-API capability). No label applied._