### PR TITLE
Add project build time metrics to load-project dev module

### DIFF
--- a/editor/src/clj/editor/build.clj
+++ b/editor/src/clj/editor/build.clj
@@ -29,14 +29,8 @@
             [util.fn :as fn])
   (:import [java.util ArrayDeque HashMap HashSet]))
 
-(defn- batched-pmap [f batches]
-  (->> batches
-       (pmap (fn [batch] (doall (map f batch))))
-       (reduce concat)
-       doall))
-
-(defn- available-processors []
-  (.availableProcessors (Runtime/getRuntime)))
+(set! *warn-on-reflection* true)
+(set! *unchecked-math* :warn-on-boxed)
 
 (defn- compiling-progress-message [node-id->resource-path node-id]
   (if (nil? node-id)
@@ -78,9 +72,9 @@
          (cond-> ret (not (g/error-value? ret)) flatten-build-targets)))))
   ([^HashMap seen stack build-targets project proj-path->dynamic-build-targets report-node-id-progress! evaluation-context]
    (let [ret
-         (into
-           []
-           (comp
+         (if (g/error-value? build-targets)
+           build-targets
+           (coll/into-> build-targets []
              coll/flatten-xf
              (map (fn [build-target]
                     (if (g/error-value? build-target)
@@ -129,8 +123,7 @@
                                           (assoc :deps resolved-deps)
                                           (dissoc :dynamic-deps)))))]
                             (.put seen content-hash result)
-                            result)))))))
-           build-targets)]
+                            result))))))))]
      (or (g/flatten-errors ret) ret))))
 
 (defn resolve-dependencies
@@ -165,58 +158,73 @@
 (defn- throw-build-cancelled-exception! []
   (throw (ex-info "Build cancelled." {:ex-type :task-cancelled})))
 
-(defn build-project!
-  [project node-id old-artifact-map opts evaluation-context]
-  (let [extra-build-targets (:extra-build-targets opts)
-        task-cancelled? (or (:task-cancelled? opts)
-                            fn/constantly-false)
-        supplied-render-progress! (or (:render-progress! opts)
-                                      progress/null-render-progress!)
+(defn- throw-if-task-cancelled! [task-cancelled?]
+  (when (task-cancelled?)
+    (throw-build-cancelled-exception!)))
 
-        render-progress!
-        (if (= fn/constantly-false task-cancelled?)
-          supplied-render-progress!
-          (fn render-progress! [progress]
-            (if (task-cancelled?)
-              (throw-build-cancelled-exception!)
-              (supplied-render-progress! progress))))
+(defn- cancellable-render-progress [render-progress! task-cancelled?]
+  {:pre [(ifn? render-progress!)
+         (ifn? task-cancelled?)]}
+  (if (= fn/constantly-false task-cancelled?)
+    render-progress!
+    (fn cancellable-render-progress! [progress]
+      (throw-if-task-cancelled! task-cancelled?)
+      (render-progress! progress))))
 
-        steps (atom [])
+(defn make-node-id->resource-path [project evaluation-context]
+  (set/map-invert (g/node-value project :nodes-by-resource-path evaluation-context)))
+
+(defn node-build-targets [node-id node-id->resource-path render-progress! task-cancelled? evaluation-context]
+  {:pre [(map? node-id->resource-path)
+         (ifn? render-progress!)
+         (ifn? task-cancelled?)]}
+  (let [steps (atom [])
 
         collect-tracer-fn
         (fn collect-tracer-fn [state node output-type label]
-          (cond
-            (task-cancelled?)
-            (throw-build-cancelled-exception!)
-
-            (and (= :build-targets label)
-                 (= :begin state)
-                 (= :output output-type))
+          (throw-if-task-cancelled! task-cancelled?)
+          (when (and (= :build-targets label)
+                     (= :begin state)
+                     (= :output output-type))
             (swap! steps conj node)))
 
         _ (g/node-value node-id :build-targets (assoc evaluation-context :dry-run true :tracer collect-tracer-fn))
-        node-id->resource-path (set/map-invert (g/node-value project :nodes-by-resource-path evaluation-context))
         progress-message-fn (partial compiling-progress-message node-id->resource-path)
         step-count (count @steps)
         progress-tracer (project/make-progress-tracer :build-targets step-count progress-message-fn (progress/nest-render-progress render-progress! (progress/make localization/empty-message 10 0 true) 5))
-        evaluation-context-with-progress-trace (assoc evaluation-context :tracer progress-tracer)
-        _ (doseq [node-id (rseq @steps)]
-            (try
-              (g/node-value node-id :build-targets evaluation-context-with-progress-trace)
-              (catch Throwable error
-                (throw (pipeline/decorate-build-exception error :compile node-id nil evaluation-context)))))
-        #_#_#_#_
-        prewarm-partitions (partition-all (max (quot step-count (+ (available-processors) 2)) 1000) (rseq @steps))
-        _ (batched-pmap (fn [node-id] (g/node-value node-id :build-targets evaluation-context-with-progress-trace)) prewarm-partitions)
-        node-build-targets (g/node-value node-id :build-targets evaluation-context)
-        build-targets (resolve-deps-impl
-                        [node-build-targets extra-build-targets]
-                        project
-                        (fn report-resolve-deps-node-id-progress! [node-id]
-                          (when-let [path (node-id->resource-path node-id)]
-                            (render-progress! (progress/make-indeterminate (localization/message "progress.resolving-resource" {"resource" path})))))
-                        evaluation-context)]
-    (if (g/error? build-targets)
-      {:error build-targets}
-      (let [build-dir (workspace/build-path (project/workspace project evaluation-context))]
-        (pipeline/build! build-targets build-dir old-artifact-map evaluation-context (progress/nest-render-progress render-progress! (progress/make localization/empty-message 10 5 true) 5))))))
+        evaluation-context-with-progress-trace (assoc evaluation-context :tracer progress-tracer)]
+    (doseq [node-id (rseq @steps)]
+      (try
+        (g/node-value node-id :build-targets evaluation-context-with-progress-trace)
+        (catch Throwable error
+          (throw (pipeline/decorate-build-exception error :compile node-id nil evaluation-context)))))
+    (g/node-value node-id :build-targets evaluation-context)))
+
+(defn- resolve-dependencies-with-progress [build-targets project node-id->resource-path render-progress! evaluation-context]
+  {:pre [(map? node-id->resource-path)
+         (ifn? render-progress!)]}
+  (resolve-deps-impl
+    build-targets
+    project
+    (fn report-resolve-deps-node-id-progress! [node-id]
+      (when-let [path (node-id->resource-path node-id)]
+        (render-progress! (progress/make-indeterminate (localization/message "progress.resolving-resource" {"resource" path})))))
+    evaluation-context))
+
+(defn build-build-targets! [build-targets workspace old-artifact-map render-progress! evaluation-context]
+  {:pre [(ifn? render-progress!)]}
+  (if (g/error? build-targets)
+    {:error build-targets}
+    (let [build-dir (workspace/build-path workspace)]
+      (pipeline/build! build-targets build-dir old-artifact-map evaluation-context (progress/nest-render-progress render-progress! (progress/make localization/empty-message 10 5 true) 5)))))
+
+(defn build-project! [project node-id old-artifact-map opts evaluation-context]
+  (let [workspace (project/workspace project evaluation-context)
+        extra-build-targets (:extra-build-targets opts)
+        task-cancelled? (or (:task-cancelled? opts) fn/constantly-false)
+        render-progress! (or (:render-progress! opts) progress/null-render-progress!)
+        cancellable-render-progress! (cancellable-render-progress render-progress! task-cancelled?)
+        node-id->resource-path (make-node-id->resource-path project evaluation-context)
+        node-build-targets (node-build-targets node-id node-id->resource-path cancellable-render-progress! task-cancelled? evaluation-context)
+        build-targets (resolve-dependencies-with-progress [node-build-targets extra-build-targets] project node-id->resource-path cancellable-render-progress! evaluation-context)]
+    (build-build-targets! build-targets workspace old-artifact-map cancellable-render-progress! evaluation-context)))

--- a/editor/src/clj/editor/build.clj
+++ b/editor/src/clj/editor/build.clj
@@ -151,9 +151,7 @@
      (resolve-node-dependencies node project evaluation-context)))
   ([node project evaluation-context]
    (let [build-targets (g/node-value node :build-targets evaluation-context)]
-     (if (g/error-value? build-targets)
-       build-targets
-       (resolve-deps-impl build-targets project nil evaluation-context)))))
+     (resolve-deps-impl build-targets project nil evaluation-context))))
 
 (defn- throw-build-cancelled-exception! []
   (throw (ex-info "Build cancelled." {:ex-type :task-cancelled})))

--- a/editor/src/dev/load_project.clj
+++ b/editor/src/dev/load_project.clj
@@ -38,8 +38,15 @@
 
 (set! *warn-on-reflection* true)
 
-;; Set to the path of the project directory you want to load.
-(defonce project-path "test/resources/save_data_project")
+;; Set DM_DEV_LOAD_PROJECT_PATH to the path of the project directory you want to load.
+(def ^:private default-project-path "test/resources/save_data_project")
+
+(defonce project-path
+  (let [^String env-project-path (System/getenv "DM_DEV_LOAD_PROJECT_PATH")]
+    (if (or (nil? env-project-path)
+            (.isEmpty env-project-path))
+      default-project-path
+      env-project-path)))
 
 ;; When true, generate tx-data for loaded nodes in a separate step before
 ;; applying it in a transaction. Allows us to profile the two phases in

--- a/editor/src/dev/load_project.clj
+++ b/editor/src/dev/load_project.clj
@@ -13,8 +13,7 @@
 ;; specific language governing permissions and limitations under the License.
 
 (ns load-project
-  (:require [dev :as dev]
-            [dynamo.graph :as g]
+  (:require [dynamo.graph :as g]
             [editor.defold-project :as project]
             [editor.editor-extensions :as extensions]
             [editor.library :as library]
@@ -31,7 +30,7 @@
             [internal.system :as is]
             [internal.transaction :as it]
             [service.log :as log]
-            [util.coll :as coll :refer [pair]]
+            [util.coll :as coll]
             [util.debug-util :as du]
             [util.eduction :as e])
   (:import [java.util List]))
@@ -85,9 +84,7 @@
    :apply-load-tx-data
    :update-overrides
    :update-successors
-   :cache-save-data
-   :store-post-load-system
-   :calculate-scene-deps])
+   :cache-save-data])
 
 (def ^:private final-task-index
   (let [task-index (.indexOf task-phases final-task)]
@@ -280,36 +277,3 @@
      :task-metrics @task-metrics
      :resource-metrics @resource-metrics
      :transaction-metrics @transaction-metrics}))
-
-(defonce post-load-system
-  (run-task!
-    :store-post-load-system
-    @g/*the-system*))
-
-(defn- evaluated-endpoints-by-proj-path [project output-label render-progress!]
-  (g/with-auto-evaluation-context evaluation-context
-    (let [basis (:basis evaluation-context)
-
-          proj-paths+node-ids
-          (->> (g/valid-node-value project :nodes-by-resource-path evaluation-context)
-               (filterv (fn [[_proj-path node-id]]
-                          (some-> (g/node-type* basis node-id)
-                                  (g/has-output? output-label))))
-               (sort-by key))
-
-          proj-path-count (count proj-paths+node-ids)]
-      (coll/into-> proj-paths+node-ids {}
-        (map-indexed
-          (fn [proj-path-index [proj-path node-id]]
-            (let [message (localization/message nil [] proj-path)
-                  progress (progress/make message proj-path-count proj-path-index)]
-              (render-progress! progress)
-              (let [evaluated-endpoints (dev/recursive-predecessor-endpoints basis node-id output-label)]
-                (pair proj-path evaluated-endpoints)))))))))
-
-(defonce evaluated-scene-endpoints-by-proj-path
-  (run-and-measure-task!
-    :calculate-scene-deps
-    (dev/run-with-terminal-progress "Calculating Scene Dependencies..."
-      (fn calc-scene-deps-with-progress [render-progress!]
-        (evaluated-endpoints-by-proj-path project :scene render-progress!)))))

--- a/editor/src/dev/load_project.clj
+++ b/editor/src/dev/load_project.clj
@@ -13,7 +13,8 @@
 ;; specific language governing permissions and limitations under the License.
 
 (ns load-project
-  (:require [dynamo.graph :as g]
+  (:require [clojure.java.io :as io]
+            [dynamo.graph :as g]
             [editor.defold-project :as project]
             [editor.editor-extensions :as extensions]
             [editor.library :as library]
@@ -74,9 +75,7 @@
     (task-fn)))
 
 (def ^:private ^List task-phases
-  [:setup-workspace
-   :fetch-libraries
-   :resource-sync
+  [:resource-sync
    :list-resources
    :make-project
    :read-resources
@@ -96,6 +95,14 @@
   (let [task-index (.indexOf task-phases task-key)]
     (assert (nat-int? task-index) (str "Invalid task-key: " task-key))
     (<= task-index (int final-task-index))))
+
+(defmacro ^:private ensure-some [expr]
+  `(if-some [result# ~expr]
+     result#
+     (throw
+       (ex-info
+         "Expression returned nil."
+         {:expr '~expr}))))
 
 (defonce ^:private task-metrics (du/make-metrics-collector))
 (defonce ^:private resource-metrics (du/make-metrics-collector))
@@ -128,8 +135,6 @@
      (measure-task! ~task-key ~@body)))
 
 (defonce runtime (Runtime/getRuntime))
-(defonce start-allocated-bytes (du/allocated-bytes runtime))
-(defonce start-time-nanos (System/nanoTime))
 (defonce prefs (prefs/project project-path))
 (defonce localization (localization/make prefs ::load-project {} ^[] Throwable/.printStackTrace))
 (defonce system-config (assoc (shared-editor-settings/load-project-system-config project-path localization) :cache-retain? project/cache-retain?))
@@ -146,25 +151,26 @@
     workspace))
 
 (defonce workspace
-  (run-and-measure-task!
-    :setup-workspace
-    (setup-workspace! workspace-graph-id project-path)))
-
-(defonce game-project-resource
-  (workspace/file-resource workspace "/game.project"))
+  (setup-workspace! workspace-graph-id project-path))
 
 (defonce up-to-date-lib-results
-  (run-and-measure-task!
-    :fetch-libraries
-    (let [dependencies (project/read-dependencies game-project-resource)
-          library-results (library/fetch! (workspace/project-directory workspace) dependencies progress/null-render-progress!)]
-      (workspace/set-project-dependencies! workspace library-results))))
+  (let [project-directory (workspace/project-directory workspace)
+        game-project-file (io/file project-directory "game.project")
+        dependencies (project/read-dependencies game-project-file)
+        library-results (library/fetch! project-directory dependencies progress/null-render-progress!)]
+    (workspace/set-project-dependencies! workspace library-results)))
+
+(defonce start-allocated-bytes (du/allocated-bytes runtime))
+(defonce start-time-nanos (System/nanoTime))
 
 (defonce ^:private -initial-resource-sync-
   (run-and-measure-task!
     :resource-sync
     (workspace/resource-sync! workspace)
     nil))
+
+(defonce game-project-resource
+  (workspace/find-resource workspace "/game.project"))
 
 (defonce project-graph-id (g/make-graph! :history true :volatility 1))
 
@@ -203,7 +209,7 @@
             (coll/into->
               (e/concat
                 (project/make-resource-nodes-tx-data project node-id+resource-pairs)
-                (project/setup-game-project-tx-data project game-project-node-id)
+                (project/setup-game-project-tx-data project (ensure-some game-project-node-id))
                 (workspace/merge-disk-sha256s workspace disk-sha256s-by-node-id)
                 (project/load-nodes-tx-data project node-load-infos progress/null-render-progress! progress/null-render-progress! resource-metrics))
               (if separate-load-tx-data-generation [] :eduction)
@@ -273,7 +279,7 @@
 
 (defonce load-metrics
   (du/when-metrics
-    {:new-nodes-by-path (g/node-value project :nodes-by-resource-path)
+    {:new-nodes-by-path (some-> project (g/node-value :nodes-by-resource-path))
      :task-metrics @task-metrics
      :resource-metrics @resource-metrics
      :transaction-metrics @transaction-metrics}))

--- a/editor/src/dev/load_project.clj
+++ b/editor/src/dev/load_project.clj
@@ -14,7 +14,9 @@
 
 (ns load-project
   (:require [clojure.java.io :as io]
+            [clojure.string :as string]
             [dynamo.graph :as g]
+            [editor.build :as build]
             [editor.defold-project :as project]
             [editor.editor-extensions :as extensions]
             [editor.library :as library]
@@ -33,13 +35,14 @@
             [service.log :as log]
             [util.coll :as coll]
             [util.debug-util :as du]
-            [util.eduction :as e])
+            [util.eduction :as e]
+            [util.fn :as fn])
   (:import [java.util List]))
 
 (set! *warn-on-reflection* true)
 
 ;; Set DM_DEV_LOAD_PROJECT_PATH to the path of the project directory you want to load.
-(def ^:private default-project-path "test/resources/save_data_project")
+(def ^:private default-project-path "test/resources/all_types_project")
 
 (defonce project-path
   (let [^String env-project-path (System/getenv "DM_DEV_LOAD_PROJECT_PATH")]
@@ -54,7 +57,7 @@
 (defonce separate-load-tx-data-generation true)
 
 ;; Set to one of the task-phases below to skip the rest of the tasks.
-(def final-task :cache-save-data)
+(def final-task :build-build-targets)
 
 ;; You can use this to start and stop your own profiling tool for certain tasks.
 (defn- user-profiling-hook! [task-key task-fn]
@@ -83,7 +86,10 @@
    :apply-load-tx-data
    :update-overrides
    :update-successors
-   :cache-save-data])
+   :cache-save-data
+   :evaluate-build-targets
+   :resolve-build-target-deps
+   :build-build-targets])
 
 (def ^:private final-task-index
   (let [task-index (.indexOf task-phases final-task)]
@@ -260,6 +266,26 @@
     migrated-resource-node-ids))
 
 (defonce ^:private -reset-undo- (g/reset-undo! project-graph-id))
+
+(defonce build-results
+  (g/with-auto-evaluation-context evaluation-context
+    (when-some [node-build-targets
+                (run-and-measure-task!
+                  :evaluate-build-targets
+                  (let [node-id->resource-path (build/make-node-id->resource-path project evaluation-context)]
+                    (build/node-build-targets (ensure-some game-project-node-id) node-id->resource-path progress/null-render-progress! fn/constantly-false evaluation-context)))]
+      (when-some [all-build-targets
+                  (run-and-measure-task!
+                    :resolve-build-target-deps
+                    (build/resolve-dependencies node-build-targets project evaluation-context))]
+        (let [build-results
+              (run-and-measure-task!
+                :build-build-targets
+                (build/build-build-targets! all-build-targets workspace {} progress/null-render-progress! evaluation-context))]
+          (when-some [error-value (:error build-results)]
+            (doseq [error-line (string/split-lines (localization (g/error-message error-value)))]
+              (log/error :message "build-failure" :cause error-line)))
+          build-results)))))
 
 (defonce total-duration-nanos
   (let [end-time-nanos (System/nanoTime)]


### PR DESCRIPTION
* You can now set the `DM_DEV_LOAD_PROJECT_PATH` environment variable to an absolute directory path to change which project is loaded by `load_project.clj`.
* Refactored the `build/build-project!` function into separate phases so that they can be called and measured from `load_project.clj`.
* Exclude the `:setup-workspace` and `:fetch-libraries` phases from the total measurements. `:setup-workspace` is trivial, and `:fetch-libraries` varies too much based on network conditions.
* Removed disabled `:store-post-load-system` phase. This just stored a snapshot of the populated `system` in a `var`.
* Removed disabled `:calculate-scene-deps` phase. This was used for a while to calculate graph dependencies for the `scene` output of various resources, but doesn't really belong here.
* Added `:evaluate-build-targets` phase. In this phase we evaluate the `build-targets` outputs for all nodes connected to the `build-targets` input on `/game.project`.
* Added `:resolve-build-target-deps` phase. In this phase we evaluate `build-targets` for any `dynamic-deps` listed in the prior `build-targets`.
* Added `:build-build-targets` phase. In this phase we call the `:build-fns` in the `build-targets`, which builds the data compiled in the `build-targets` and writes the resulting binaries to disk.

Related to #11988.