### PR TITLE
Fix `gui.set_screen_position()` for nodes with scale

### DIFF
--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -4474,6 +4474,8 @@ namespace dmGui
         Vector4 adjust_scale;
         Vector4 offset(0.0f);
 
+        Vector3 position = screen_position;
+
         // Calculate the new parents scene transform
         // We also need to calculate values relative to adjustments and offset
         // corresponding to the values that would be used in AdjustPosScale (see reasoning below).
@@ -4482,10 +4484,22 @@ namespace dmGui
             CalculateNodeTransform(scene, parent_node, CalculateNodeTransformFlags(), parent_m);
             reference_scale = parent_node->m_Node.m_LocalAdjustScale;
             adjust_scale = ApplyAdjustOnReferenceScale(reference_scale, node->m_Node.m_AdjustMode);
+
+            Vector4 parent_local_position = inverse(parent_m) * Vector4(screen_position, 1.0f);
+            position = parent_local_position.getXYZ();
+
+            if (scene->m_AdjustReference == ADJUST_REFERENCE_LEGACY)
+            {
+                return position;
+            }
+
+            // For ADJUST_REFERENCE_PARENT the node's local transform is pre-multiplied
+            // by the inverse reference scale in UpdateLocalTransform. Reapply it before
+            // undoing the node adjustment below.
+            position = mulPerElem(position, reference_scale.getXYZ());
         } else {
             reference_scale = CalculateReferenceScale(scene, 0x0);
             adjust_scale = ApplyAdjustOnReferenceScale(reference_scale, node->m_Node.m_AdjustMode);
-            parent_m = Matrix4::scale(adjust_scale.getXYZ());
 
             Vector4 parent_dims = Vector4((float) scene->m_Width, (float) scene->m_Height, 0.0f, 1.0f);
             Vector4 adjusted_dims = mulPerElem(parent_dims, adjust_scale);
@@ -4494,10 +4508,6 @@ namespace dmGui
             offset.setX(offset.getX() + scene->m_AdjustOffsetX);
             offset.setY(offset.getY() + scene->m_AdjustOffsetY);
         }
-
-        // We calculate a new position that will be the relative position once
-        // the node has been childed to the new parent.
-        Vector3 position = screen_position - parent_m.getCol3().getXYZ();
 
         // We need to perform the inverse of what AdjustPosScale will do to counteract when
         // it will be applied during next call to CalculateNodeTransform.

--- a/engine/gui/src/test/test_gui.cpp
+++ b/engine/gui/src/test/test_gui.cpp
@@ -5530,6 +5530,57 @@ TEST_F(dmGuiTest, SetGetScreenPositionAdjustDisabledRoot)
     ASSERT_NEAR(target_screen.getY(), after_set.getY(), EPSILON);
 }
 
+TEST_F(dmGuiTest, SetGetScreenPositionLegacyScaledParent)
+{
+    dmGui::SetPhysicalResolution(m_Context, 100, 100);
+    dmGui::SetDefaultResolution(m_Context, 100, 100);
+    dmGui::SetSceneResolution(m_Scene, 100, 100);
+
+    dmGui::HNode parent = dmGui::NewNode(m_Scene, Point3(30, 20, 0), Vector3(40, 40, 0), dmGui::NODE_TYPE_BOX, 0);
+    dmGui::SetNodeProperty(m_Scene, parent, dmGui::PROPERTY_SCALE, Vector4(2.0f, 0.5f, 1.0f, 1.0f));
+
+    dmGui::HNode child = dmGui::NewNode(m_Scene, Point3(10, 8, 0), Vector3(10, 10, 0), dmGui::NODE_TYPE_BOX, 0);
+    dmGui::SetNodeParent(m_Scene, child, parent, false);
+
+    Vector4 before_set = _GET_NODE_SCENE_POSITION(m_Scene, child);
+    Point3 local_before = dmGui::GetNodePosition(m_Scene, child);
+    Point3 local_from_screen = dmGui::ScreenToLocalPosition(m_Scene, child, Point3(before_set.getXYZ()));
+    ASSERT_NEAR(local_before.getX(), local_from_screen.getX(), 0.0001f);
+    ASSERT_NEAR(local_before.getY(), local_from_screen.getY(), 0.0001f);
+
+    dmGui::SetScreenPosition(m_Scene, child, Point3(before_set.getXYZ()));
+
+    Vector4 after_set = _GET_NODE_SCENE_POSITION(m_Scene, child);
+    ASSERT_NEAR(before_set.getX(), after_set.getX(), 0.0001f);
+    ASSERT_NEAR(before_set.getY(), after_set.getY(), 0.0001f);
+}
+
+TEST_F(dmGuiTest, SetGetScreenPositionAdjustParentScaledParent)
+{
+    dmGui::SetPhysicalResolution(m_Context, 960, 640);
+    dmGui::SetDefaultResolution(m_Context, 960, 640);
+    dmGui::SetSceneResolution(m_Scene, 960, 640);
+    dmGui::SetSceneAdjustReference(m_Scene, dmGui::ADJUST_REFERENCE_PARENT);
+
+    dmGui::HNode parent = dmGui::NewNode(m_Scene, Point3(422, 388, 0), Vector3(100, 100, 0), dmGui::NODE_TYPE_BOX, 0);
+    dmGui::SetNodeProperty(m_Scene, parent, dmGui::PROPERTY_SCALE, Vector4(0.75f, 0.75f, 1.0f, 1.0f));
+
+    dmGui::HNode child = dmGui::NewNode(m_Scene, Point3(50, 50, 0), Vector3(100, 100, 0), dmGui::NODE_TYPE_BOX, 0);
+    dmGui::SetNodeParent(m_Scene, child, parent, false);
+
+    Vector4 before_set = _GET_NODE_SCENE_POSITION(m_Scene, child);
+    Point3 local_before = dmGui::GetNodePosition(m_Scene, child);
+    Point3 local_from_screen = dmGui::ScreenToLocalPosition(m_Scene, child, Point3(before_set.getXYZ()));
+    ASSERT_NEAR(local_before.getX(), local_from_screen.getX(), 0.0001f);
+    ASSERT_NEAR(local_before.getY(), local_from_screen.getY(), 0.0001f);
+
+    dmGui::SetScreenPosition(m_Scene, child, Point3(before_set.getXYZ()));
+
+    Vector4 after_set = _GET_NODE_SCENE_POSITION(m_Scene, child);
+    ASSERT_NEAR(before_set.getX(), after_set.getX(), 0.0001f);
+    ASSERT_NEAR(before_set.getY(), after_set.getY(), 0.0001f);
+}
+
 TEST_F(dmGuiTest, SetGetScreenPositionAdjustDisabledScaledParent)
 {
     dmGui::SetPhysicalResolution(m_Context, 100, 100);


### PR DESCRIPTION
Fixed an issue where `gui.set_screen_position()` and `gui.screen_to_local()` calculated incorrect positions for nodes with scaled parents.

Fix https://github.com/defold/defold/issues/12412