### PR TITLE
Fix for handling when macOS/iOS blocks while creating a SSL socket

### DIFF
--- a/engine/dlib/src/dlib/sslsocket_apple.mm
+++ b/engine/dlib/src/dlib/sslsocket_apple.mm
@@ -209,6 +209,34 @@ namespace dmSSLSocket
         return RESULT_HANDSHAKE_FAILED;
     }
 
+    static dmSocket::Result ReadStreamNotReadyResult(CFReadStreamRef read_stream)
+    {
+        CFStreamStatus status = CFReadStreamGetStatus(read_stream);
+        if (status == kCFStreamStatusError)
+        {
+            return StreamErrorToSocketResult(CFReadStreamGetError(read_stream));
+        }
+        if (status == kCFStreamStatusAtEnd || status == kCFStreamStatusClosed)
+        {
+            return dmSocket::RESULT_CONNRESET;
+        }
+        return dmSocket::RESULT_WOULDBLOCK;
+    }
+
+    static dmSocket::Result WriteStreamNotReadyResult(CFWriteStreamRef write_stream)
+    {
+        CFStreamStatus status = CFWriteStreamGetStatus(write_stream);
+        if (status == kCFStreamStatusError)
+        {
+            return StreamErrorToSocketResult(CFWriteStreamGetError(write_stream));
+        }
+        if (status == kCFStreamStatusAtEnd || status == kCFStreamStatusClosed)
+        {
+            return dmSocket::RESULT_CONNRESET;
+        }
+        return dmSocket::RESULT_WOULDBLOCK;
+    }
+
     static bool SetStreamProperty(CFReadStreamRef read_stream, CFWriteStreamRef write_stream, CFStringRef property, CFTypeRef value)
     {
         return CFReadStreamSetProperty(read_stream, property, value) && CFWriteStreamSetProperty(write_stream, property, value);
@@ -349,6 +377,11 @@ namespace dmSSLSocket
             *sent_bytes = 0;
         }
 
+        if (!CFWriteStreamCanAcceptBytes(socket->m_WriteStream))
+        {
+            return WriteStreamNotReadyResult(socket->m_WriteStream);
+        }
+
         CFIndex result = CFWriteStreamWrite(socket->m_WriteStream, (const UInt8*)buffer, length);
         if (result > 0)
         {
@@ -370,6 +403,11 @@ namespace dmSSLSocket
         if (received_bytes != 0)
         {
             *received_bytes = 0;
+        }
+
+        if (!CFReadStreamHasBytesAvailable(socket->m_ReadStream))
+        {
+            return ReadStreamNotReadyResult(socket->m_ReadStream);
         }
 
         CFIndex result = CFReadStreamRead(socket->m_ReadStream, (UInt8*)buffer, length);

--- a/engine/dlib/src/test/test_sslsocket.cpp
+++ b/engine/dlib/src/test/test_sslsocket.cpp
@@ -1,0 +1,226 @@
+// Copyright 2020-2026 The Defold Foundation
+// Copyright 2014-2020 King
+// Copyright 2009-2014 Ragnar Svensson, Christian Murray
+// Licensed under the Defold License version 1.0 (the "License"); you may not use
+// this file except in compliance with the License.
+//
+// You may obtain a copy of the License, together with FAQs at
+// https://www.defold.com/license
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#include <stdint.h>
+#include <string.h>
+
+#include <dlib/configfile.h>
+#include <dlib/dstrings.h>
+#include <dlib/log.h>
+#include <dlib/socket.h>
+#include <dlib/sslsocket.h>
+#include <dlib/testutil.h>
+#include <dlib/time.h>
+
+#define JC_TEST_IMPLEMENTATION
+#include <jc_test/jc_test.h>
+
+static int g_HttpPortTLS = -1;
+static char g_HttpAddress[128] = "localhost";
+
+static void CloseSockets(dmSocket::Socket socket, dmSSLSocket::Socket ssl_socket)
+{
+    if (ssl_socket != dmSSLSocket::INVALID_SOCKET_HANDLE)
+    {
+        dmSSLSocket::Delete(ssl_socket);
+    }
+    if (socket != dmSocket::INVALID_SOCKET_HANDLE)
+    {
+        dmSocket::Delete(socket);
+    }
+}
+
+static void ConnectTLSSocket(dmSocket::Socket* socket, dmSSLSocket::Socket* ssl_socket)
+{
+    *socket = dmSocket::INVALID_SOCKET_HANDLE;
+    *ssl_socket = dmSSLSocket::INVALID_SOCKET_HANDLE;
+
+    dmSocket::Result socket_result = dmSocket::New(dmSocket::DOMAIN_IPV4, dmSocket::TYPE_STREAM, dmSocket::PROTOCOL_TCP, socket);
+    ASSERT_EQ(dmSocket::RESULT_OK, socket_result);
+
+    dmSocket::Address address;
+    socket_result = dmSocket::GetHostByName(g_HttpAddress, &address, true, false);
+    ASSERT_EQ(dmSocket::RESULT_OK, socket_result);
+
+    socket_result = dmSocket::Connect(*socket, address, g_HttpPortTLS);
+    ASSERT_EQ(dmSocket::RESULT_OK, socket_result);
+
+    dmSSLSocket::Result ssl_result = dmSSLSocket::New(*socket, g_HttpAddress, 10 * 1000000, ssl_socket);
+    ASSERT_EQ(dmSSLSocket::RESULT_OK, ssl_result);
+}
+
+static void SendAll(dmSSLSocket::Socket ssl_socket, const char* buffer, uint32_t length)
+{
+    uint32_t total_sent = 0;
+    uint64_t start = dmTime::GetMonotonicTime();
+    while (total_sent < length)
+    {
+        int sent = 0;
+        dmSocket::Result result = dmSSLSocket::Send(ssl_socket, buffer + total_sent, length - total_sent, &sent);
+        if (result == dmSocket::RESULT_WOULDBLOCK)
+        {
+            ASSERT_LT(dmTime::GetMonotonicTime() - start, 5 * 1000000ULL);
+            dmTime::Sleep(1000);
+            continue;
+        }
+
+        ASSERT_EQ(dmSocket::RESULT_OK, result);
+        ASSERT_GT(sent, 0);
+        total_sent += sent;
+    }
+}
+
+static void SendString(dmSSLSocket::Socket ssl_socket, const char* buffer)
+{
+    SendAll(ssl_socket, buffer, (uint32_t)strlen(buffer));
+}
+
+static void SendWebSocketHandshakeLikeExtension(dmSSLSocket::Socket ssl_socket)
+{
+    char host[160];
+    dmSnPrintf(host, sizeof(host), "%s:%d", g_HttpAddress, g_HttpPortTLS);
+
+    SendString(ssl_socket, "GET ");
+    SendString(ssl_socket, "/");
+    SendString(ssl_socket, " HTTP/1.1\r\n");
+    SendString(ssl_socket, "Host: ");
+    SendString(ssl_socket, host);
+    SendString(ssl_socket, "\r\n");
+    SendString(ssl_socket, "Upgrade: websocket\r\n");
+    SendString(ssl_socket, "Connection: Upgrade\r\n");
+    SendString(ssl_socket, "Sec-WebSocket-Key: 0123456789ABCDEF012345==\r\n");
+    SendString(ssl_socket, "Sec-WebSocket-Version: 13\r\n");
+    SendString(ssl_socket, "\r\n");
+}
+
+static bool WaitForRawSocketReadable(dmSocket::Socket socket, uint64_t timeout)
+{
+    dmSocket::Selector selector;
+    dmSocket::SelectorZero(&selector);
+    dmSocket::SelectorSet(&selector, dmSocket::SELECTOR_KIND_READ, socket);
+    dmSocket::Result select_result = dmSocket::Select(&selector, timeout);
+    return select_result == dmSocket::RESULT_OK && dmSocket::SelectorIsSet(&selector, dmSocket::SELECTOR_KIND_READ, socket);
+}
+
+// The SSL socket API must preserve nonblocking socket semantics. The Apple
+// CFStream backend used to call CFReadStreamRead directly here, which can block
+// when the TLS connection is established but no application data is available.
+TEST(dmSSLSocket, ReceiveWithoutApplicationDataReturnsWouldBlock)
+{
+#if !defined(__MACH__)
+    SKIP();
+#endif
+
+    dmSocket::Socket socket = dmSocket::INVALID_SOCKET_HANDLE;
+    dmSSLSocket::Socket ssl_socket = dmSSLSocket::INVALID_SOCKET_HANDLE;
+
+    ConnectTLSSocket(&socket, &ssl_socket);
+    ASSERT_EQ(dmSocket::RESULT_OK, dmSSLSocket::SetReceiveTimeout(ssl_socket, 1000));
+
+    char response[4096];
+    int received = -1;
+    uint64_t start = dmTime::GetMonotonicTime();
+    dmSocket::Result receive_result = dmSSLSocket::Receive(ssl_socket, response, sizeof(response), &received);
+    uint64_t elapsed = dmTime::GetMonotonicTime() - start;
+
+    ASSERT_EQ(dmSocket::RESULT_WOULDBLOCK, receive_result);
+    ASSERT_EQ(0, received);
+    ASSERT_LT(elapsed, 100 * 1000ULL);
+
+    CloseSockets(socket, ssl_socket);
+}
+
+// Reproduces the extension-websocket#65 read pattern: send the websocket
+// handshake as several SSL writes, wait for the raw TCP socket to become
+// readable, and then do one SSL receive. This must not stall for seconds.
+TEST(dmSSLSocket, ReceiveReturnsAfterUnderlyingSocketIsReadable)
+{
+#if !defined(__MACH__)
+    SKIP();
+#endif
+
+    dmSocket::Socket socket = dmSocket::INVALID_SOCKET_HANDLE;
+    dmSSLSocket::Socket ssl_socket = dmSSLSocket::INVALID_SOCKET_HANDLE;
+
+    ConnectTLSSocket(&socket, &ssl_socket);
+
+    SendWebSocketHandshakeLikeExtension(ssl_socket);
+
+    char response[4096];
+    int received = 0;
+    dmSocket::Result receive_result = dmSocket::RESULT_WOULDBLOCK;
+    uint64_t start = dmTime::GetMonotonicTime();
+    while (receive_result == dmSocket::RESULT_WOULDBLOCK && dmTime::GetMonotonicTime() - start < 1000 * 1000ULL)
+    {
+        ASSERT_TRUE(WaitForRawSocketReadable(socket, 5 * 1000000));
+        receive_result = dmSSLSocket::Receive(ssl_socket, response, sizeof(response) - 1, &received);
+        if (receive_result == dmSocket::RESULT_WOULDBLOCK)
+        {
+            dmTime::Sleep(10 * 1000);
+        }
+    }
+    uint64_t elapsed = dmTime::GetMonotonicTime() - start;
+
+    ASSERT_EQ(dmSocket::RESULT_OK, receive_result);
+    ASSERT_GT(received, 0);
+    ASSERT_LT(elapsed, 1000 * 1000ULL);
+
+    CloseSockets(socket, ssl_socket);
+}
+
+static void Usage()
+{
+    dmLogError("Usage: <exe> <config>");
+    dmLogError("Be sure to start the http server before starting this test.");
+    dmLogError("You can use the config file created by the server");
+}
+
+int main(int argc, char **argv)
+{
+    jc_test_init(&argc, argv);
+
+    if (argc > 1)
+    {
+        char path[512];
+        dmTestUtil::MakeHostPath(path, sizeof(path), argv[1]);
+
+        dmConfigFile::HConfig config;
+        if (dmConfigFile::Load(path, argc, (const char**)argv, &config) != dmConfigFile::RESULT_OK)
+        {
+            dmLogError("Could not read config file '%s'", argv[1]);
+            Usage();
+            return 1;
+        }
+
+        const char* ip = dmConfigFile::GetString(config, "server.ip", "localhost");
+        dmStrlCpy(g_HttpAddress, ip, sizeof(g_HttpAddress));
+        dmTestUtil::GetSocketsFromConfig(config, 0, &g_HttpPortTLS, 0);
+        dmConfigFile::Delete(config);
+    }
+    else
+    {
+        Usage();
+        return 1;
+    }
+
+    dmLogSetLevel(LOG_SEVERITY_INFO);
+    dmSocket::Initialize();
+    dmSSLSocket::Initialize();
+
+    int ret = jc_test_run_all();
+
+    dmSSLSocket::Finalize();
+    dmSocket::Finalize();
+    return ret;
+}

--- a/engine/dlib/src/test/wscript
+++ b/engine/dlib/src/test/wscript
@@ -189,6 +189,7 @@ def build(bld):
         create_test(bld, 'test_httpcache', extra_libs = ['THREAD'], extra_defines = extra_defines, skip_run = skip_http_run)
         create_test(bld, 'test_httpserver', extra_libs = ['THREAD'], extra_defines = extra_defines, skip_run = skip_http_run)
         create_test(bld, 'test_webserver', extra_libs = ['THREAD'], extra_defines = extra_defines, skip_run = skip_http_run)
+        create_test(bld, 'test_sslsocket', extra_libs = ['THREAD'], extra_defines = extra_defines, skip_run = skip_http_run)
         create_test(bld, 'test_connection_pool', extra_features = ['embed'], extra_libs = ['THREAD'],
                     extra_includes = ['.'], extra_defines = extra_defines)
 


### PR DESCRIPTION
This fixes an issue when SSL sockets for macOS/iOS would stall for a very long time.

Fixes https://github.com/defold/extension-websocket/issues/65

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
