### PR TITLE
Add Lua stack index arguments to dmSDK functions LuaToJson and JsonToLua

### DIFF
--- a/engine/script/src/dmsdk/script/script.h
+++ b/engine/script/src/dmsdk/script/script.h
@@ -525,7 +525,8 @@ namespace dmScript
     int JsonToLua(lua_State* L, const char* json, size_t json_len);
 
     /*# convert a Lua table to a Json string
-     * Convert a Lua table to a Json string
+     * Convert the Lua value at stack index 1 to a Json string
+     * An options table can be provided at stack index 2.
      *
      * @name LuaToJson
      * @param L [type:lua_State*] lua state
@@ -534,6 +535,19 @@ namespace dmScript
      * @return int [type:int] <0 if it fails. >=0 if it succeeds.
      */
     int LuaToJson(lua_State* L, char** json, size_t* json_len);
+
+    /*# convert a Lua table to a Json string
+     * Convert the Lua value at the supplied stack index to a Json string
+     *
+     * @name LuaToJson
+     * @param L [type:lua_State*] lua state
+     * @param index [type:int] lua stack index of the value to encode
+     * @param options_index [type:int] lua stack index to check for an options table
+     * @param json [type:char**] [out] Pointer to char*, which will receive a newly allocated string. Use free().
+     * @param json_len [type:size_t*] length of json string
+     * @return int [type:int] <0 if it fails. >=0 if it succeeds.
+     */
+    int LuaToJson(lua_State* L, int index, int options_index, char** json, size_t* json_len);
 
     /*# callback info struct
      * callback info struct that will hold the relevant info needed to make a callback into Lua

--- a/engine/script/src/dmsdk/script/script.h
+++ b/engine/script/src/dmsdk/script/script.h
@@ -521,12 +521,12 @@ namespace dmScript
      *
      * @name JsonToLua
      * @param L [type:lua_State*] lua state
+     * @param options_index [type:int] lua stack index to check for an options table
      * @param json [type:const char*] json string
      * @param json_len [type:size_t] length of json string
-     * @param options_index [type:int] lua stack index to check for an options table
      * @return int [type:int] 1 if it succeeds. Throws a Lua error if it fails
      */
-    int JsonToLua(lua_State* L, const char* json, size_t json_len, int options_index);
+    int JsonToLua(lua_State* L, int options_index, const char* json, size_t json_len);
 
     // DEPRECATED
     int LuaToJson(lua_State* L, char** json, size_t* json_len);

--- a/engine/script/src/dmsdk/script/script.h
+++ b/engine/script/src/dmsdk/script/script.h
@@ -512,16 +512,7 @@ namespace dmScript
      */
     void PushDDF(lua_State*L, const dmDDF::Descriptor* descriptor, const char* data, bool pointers_are_offsets);
 
-    /*# convert a Json string to a Lua table
-     * Convert a Json string to Lua table.
-     * @note Throws Lua error if it fails to parser the json
-     *
-     * @name JsonToLua
-     * @param L [type:lua_State*] lua state
-     * @param json [type:const char*] json string
-     * @param json_len [type:size_t] length of json string
-     * @return int [type:int] 1 if it succeeds. Throws a Lua error if it fails
-     */
+    // DEPRECATED
     int JsonToLua(lua_State* L, const char* json, size_t json_len);
 
     /*# convert a Json string to a Lua table
@@ -537,16 +528,7 @@ namespace dmScript
      */
     int JsonToLua(lua_State* L, const char* json, size_t json_len, int options_index);
 
-    /*# convert a Lua table to a Json string
-     * Convert the Lua value at stack index 1 to a Json string
-     * An options table can be provided at stack index 2.
-     *
-     * @name LuaToJson
-     * @param L [type:lua_State*] lua state
-     * @param json [type:char**] [out] Pointer to char*, which will receive a newly allocated string. Use free().
-     * @param json_len [type:size_t*] length of json string
-     * @return int [type:int] <0 if it fails. >=0 if it succeeds.
-     */
+    // DEPRECATED
     int LuaToJson(lua_State* L, char** json, size_t* json_len);
 
     /*# convert a Lua table to a Json string

--- a/engine/script/src/dmsdk/script/script.h
+++ b/engine/script/src/dmsdk/script/script.h
@@ -524,6 +524,19 @@ namespace dmScript
      */
     int JsonToLua(lua_State* L, const char* json, size_t json_len);
 
+    /*# convert a Json string to a Lua table
+     * Convert a Json string to Lua table.
+     * @note Throws Lua error if it fails to parser the json
+     *
+     * @name JsonToLua
+     * @param L [type:lua_State*] lua state
+     * @param json [type:const char*] json string
+     * @param json_len [type:size_t] length of json string
+     * @param options_index [type:int] lua stack index to check for an options table
+     * @return int [type:int] 1 if it succeeds. Throws a Lua error if it fails
+     */
+    int JsonToLua(lua_State* L, const char* json, size_t json_len, int options_index);
+
     /*# convert a Lua table to a Json string
      * Convert the Lua value at stack index 1 to a Json string
      * An options table can be provided at stack index 2.

--- a/engine/script/src/luacjson/lua_cjson.c
+++ b/engine/script/src/luacjson/lua_cjson.c
@@ -471,7 +471,9 @@ static void json_create_config(lua_State *l)
 #endif // DEFOLD
 
 // DEFOLD
-static void json_initialize_config(lua_State *l, json_config_t* cfg, int encode_keep_buffer, int protected_mode, char* errbuf, size_t errbuf_len)
+static void json_initialize_config(lua_State *l, json_config_t* cfg,
+                                   int encode_keep_buffer, int protected_mode,
+                                   int options_index, char* errbuf, size_t errbuf_len)
 {
     int i;
 
@@ -545,9 +547,9 @@ static void json_initialize_config(lua_State *l, json_config_t* cfg, int encode_
     cfg->escape2char['u'] = 'u';          /* Unicode parsing required */
 
     // read additional config values from options table
-    if (lua_istable(l, 2))
+    if (lua_istable(l, options_index))
     {
-        lua_pushvalue(l, 2); // push config table to top of stack
+        lua_pushvalue(l, options_index); // push config table to top of stack
 
         lua_getfield(l, -1, "decode_null_as_userdata");
         if (!lua_isnil(l, -1))
@@ -970,13 +972,14 @@ static int json_encode(lua_State *l)
 // a default config here to avoid passing the config as
 // a user data object.
 // Also, we return the generated string, and let the caller delete it
-int lua_cjson_encode(lua_State *l, char** json_str, size_t* json_length)
+int lua_cjson_encode(lua_State *l, int index, int options_index,
+                     char** json_str, size_t* json_length)
 {
     json_config_t cfg;
     strbuf_t local_encode_buf;
     strbuf_t *encode_buf;
 
-    json_initialize_config(l, &cfg, DEFAULT_ENCODE_KEEP_BUFFER, 1, 0, 0);
+    json_initialize_config(l, &cfg, DEFAULT_ENCODE_KEEP_BUFFER, 1, options_index, 0, 0);
     if (!cfg.encode_keep_buffer) {
         /* Use private buffer */
         encode_buf = &local_encode_buf;
@@ -987,7 +990,7 @@ int lua_cjson_encode(lua_State *l, char** json_str, size_t* json_length)
         strbuf_reset(encode_buf);
     }
 
-    lua_pushvalue(l, 1); // make sure the table to encode is on the top of the stack
+    lua_pushvalue(l, index); // make sure the value to encode is on top of the stack
     json_append_data(l, &cfg, 0, encode_buf);
     lua_pop(l, 1); // pop it again
 
@@ -1627,13 +1630,15 @@ static int DefoldError(json_config_t* cfg, const char* format, ...)
 // a default config here to avoid passing the config as
 // a user data object.
 // Note: We also have a boolean which decides upon the error handling
-int lua_cjson_decode(lua_State *l, const char* json_string, size_t json_len, int protected_mode, char* errbuf, size_t errbuf_len)
+int lua_cjson_decode(lua_State *l, const char* json_string, size_t json_len,
+                     int options_index, int protected_mode, char* errbuf,
+                     size_t errbuf_len)
 {
     json_config_t cfg;
     json_parse_t json;
     json_token_t token;
 
-    json_initialize_config(l, &cfg, 0, protected_mode, errbuf, errbuf_len);
+    json_initialize_config(l, &cfg, 0, protected_mode, options_index, errbuf, errbuf_len);
     json.cfg = &cfg;
     json.data = json_string;
     json.data_end = json_string + json_len;

--- a/engine/script/src/luacjson/lua_cjson.c
+++ b/engine/script/src/luacjson/lua_cjson.c
@@ -471,9 +471,9 @@ static void json_create_config(lua_State *l)
 #endif // DEFOLD
 
 // DEFOLD
-static void json_initialize_config(lua_State *l, json_config_t* cfg,
+static void json_initialize_config(lua_State *l, int options_index, json_config_t* cfg,
                                    int encode_keep_buffer, int protected_mode,
-                                   int options_index, char* errbuf, size_t errbuf_len)
+                                   char* errbuf, size_t errbuf_len)
 {
     int i;
 
@@ -979,7 +979,7 @@ int lua_cjson_encode(lua_State *l, int index, int options_index,
     strbuf_t local_encode_buf;
     strbuf_t *encode_buf;
 
-    json_initialize_config(l, &cfg, DEFAULT_ENCODE_KEEP_BUFFER, 1, options_index, 0, 0);
+    json_initialize_config(l, options_index, &cfg, DEFAULT_ENCODE_KEEP_BUFFER, 1, 0, 0);
     if (!cfg.encode_keep_buffer) {
         /* Use private buffer */
         encode_buf = &local_encode_buf;
@@ -1638,7 +1638,7 @@ int lua_cjson_decode(lua_State *l, const char* json_string, size_t json_len,
     json_parse_t json;
     json_token_t token;
 
-    json_initialize_config(l, &cfg, 0, protected_mode, options_index, errbuf, errbuf_len);
+    json_initialize_config(l, options_index, &cfg, 0, protected_mode, errbuf, errbuf_len);
     json.cfg = &cfg;
     json.data = json_string;
     json.data_end = json_string + json_len;

--- a/engine/script/src/script_json.cpp
+++ b/engine/script/src/script_json.cpp
@@ -46,7 +46,7 @@ namespace dmScript
      * @language Lua
      */
 
-    static int JsonToLuaInternal(lua_State* L, const char* json, size_t json_len, int options_index, int protected_mode)
+    static int JsonToLuaInternal(lua_State* L, int options_index, const char* json, size_t json_len, int protected_mode)
     {
         int top = lua_gettop(L);
         char buffer[256] = {0};
@@ -75,9 +75,9 @@ namespace dmScript
         return JsonToLuaInternal(L, json, json_len, 2, 0);
     }
 
-    int JsonToLua(lua_State* L, const char* json, size_t json_len, int options_index)
+    int JsonToLua(lua_State* L, int options_index, const char* json, size_t json_len)
     {
-        return JsonToLuaInternal(L, json, json_len, options_index, 0);
+        return JsonToLuaInternal(L, options_index, json, json_len, 0);
     }
 
     int LuaToJson(lua_State* L, char** json, size_t* json_len)
@@ -139,7 +139,7 @@ namespace dmScript
 
         size_t json_len;
         const char* json = luaL_checklstring(L, 1, &json_len);
-        return JsonToLuaInternal(L, json, json_len, 2, 1);
+        return JsonToLuaInternal(L, 2, json, json_len, 1);
     }
 
     /*# encode a lua table to a JSON string

--- a/engine/script/src/script_json.cpp
+++ b/engine/script/src/script_json.cpp
@@ -72,7 +72,7 @@ namespace dmScript
 
     int JsonToLua(lua_State* L, const char* json, size_t json_len)
     {
-        return JsonToLuaInternal(L, json, json_len, 2, 0);
+        return JsonToLuaInternal(L, 2, json, json_len, 0);
     }
 
     int JsonToLua(lua_State* L, int options_index, const char* json, size_t json_len)

--- a/engine/script/src/script_json.cpp
+++ b/engine/script/src/script_json.cpp
@@ -27,8 +27,8 @@ extern "C"
     #include <lua/lauxlib.h>
 
     // Defined in luacjson/lua_cjson.c
-    int lua_cjson_decode(lua_State* L, const char* json_string, size_t json_len, int protected_mode, char* errbuf, size_t errbuf_len);
-    int lua_cjson_encode(lua_State* L, char** json_str, size_t* json_length);
+    int lua_cjson_decode(lua_State* L, const char* json_string, size_t json_len, int options_index, int protected_mode, char* errbuf, size_t errbuf_len);
+    int lua_cjson_encode(lua_State* L, int index, int options_index, char** json_str, size_t* json_length);
 }
 
 #include "script_json.h"
@@ -46,11 +46,11 @@ namespace dmScript
      * @language Lua
      */
 
-    static int JsonToLuaInternal(lua_State* L, const char* json, size_t json_len, int protected_mode)
+    static int JsonToLuaInternal(lua_State* L, const char* json, size_t json_len, int options_index, int protected_mode)
     {
         int top = lua_gettop(L);
         char buffer[256] = {0};
-        int ret = lua_cjson_decode(L, json, json_len, protected_mode, buffer, sizeof(buffer));
+        int ret = lua_cjson_decode(L, json, json_len, options_index, protected_mode, buffer, sizeof(buffer));
         if (ret != 1)
         {
             lua_pop(L, lua_gettop(L) - top);
@@ -72,12 +72,17 @@ namespace dmScript
 
     int JsonToLua(lua_State* L, const char* json, size_t json_len)
     {
-        return JsonToLuaInternal(L, json, json_len, 0);
+        return JsonToLuaInternal(L, json, json_len, 2, 0);
     }
 
     int LuaToJson(lua_State* L, char** json, size_t* json_len)
     {
-        return lua_cjson_encode(L, json, json_len);
+        return LuaToJson(L, 1, 2, json, json_len);
+    }
+
+    int LuaToJson(lua_State* L, int index, int options_index, char** json, size_t* json_len)
+    {
+        return lua_cjson_encode(L, index, options_index, json, json_len);
     }
 
     /*# decode JSON from a string to a lua-table
@@ -129,7 +134,7 @@ namespace dmScript
 
         size_t json_len;
         const char* json = luaL_checklstring(L, 1, &json_len);
-        return JsonToLuaInternal(L, json, json_len, 1);
+        return JsonToLuaInternal(L, json, json_len, 2, 1);
     }
 
     /*# encode a lua table to a JSON string
@@ -177,7 +182,7 @@ namespace dmScript
 
         char* json = 0;
         size_t json_length = 0;
-        if (LuaToJson(L, &json, &json_length))
+        if (LuaToJson(L, 1, 2, &json, &json_length))
         {
             lua_pushlstring(L, json, json_length);
             free(json);

--- a/engine/script/src/script_json.cpp
+++ b/engine/script/src/script_json.cpp
@@ -75,9 +75,14 @@ namespace dmScript
         return JsonToLuaInternal(L, json, json_len, 2, 0);
     }
 
+    int JsonToLua(lua_State* L, const char* json, size_t json_len, int options_index)
+    {
+        return JsonToLuaInternal(L, json, json_len, options_index, 0);
+    }
+
     int LuaToJson(lua_State* L, char** json, size_t* json_len)
     {
-        return LuaToJson(L, 1, 2, json, json_len);
+        return lua_cjson_encode(L, 1, 2, json, json_len);
     }
 
     int LuaToJson(lua_State* L, int index, int options_index, char** json, size_t* json_len)

--- a/engine/script/src/test/test_script_json.cpp
+++ b/engine/script/src/test/test_script_json.cpp
@@ -130,6 +130,82 @@ TEST_F(ScriptJsonTest, TestLuaToJson)
     ASSERT_EQ(top, lua_gettop(L));
 }
 
+TEST_F(ScriptJsonTest, TestLuaToJsonWithStackIndex)
+{
+    int top = lua_gettop(L);
+
+    {
+        lua_newtable(L);
+            lua_pushstring(L, "first");
+            lua_setfield(L, -2, "name");
+
+        lua_newtable(L);
+            lua_pushstring(L, "second");
+            lua_setfield(L, -2, "name");
+            lua_newtable(L);
+            lua_setfield(L, -2, "empty");
+
+        lua_newtable(L);
+            lua_pushboolean(L, 0);
+            lua_setfield(L, -2, "encode_empty_table_as_object");
+
+        char* json = 0;
+        size_t json_length;
+        int ret = dmScript::LuaToJson(L, 2, 3, &json, &json_length);
+        ASSERT_EQ(1, ret);
+        ASSERT_TRUE(strstr(json, "\"name\":\"second\"") != 0);
+        ASSERT_TRUE(strstr(json, "\"empty\":[]") != 0);
+        free((void*)json);
+
+        json = 0;
+        json_length = 0;
+        ret = dmScript::LuaToJson(L, 1, 3, &json, &json_length);
+        ASSERT_EQ(1, ret);
+        ASSERT_EQ(16u, (uint32_t)json_length);
+        ASSERT_STREQ("{\"name\":\"first\"}", json);
+        free((void*)json);
+
+        lua_pop(L, 3);
+    }
+
+    ASSERT_EQ(top, lua_gettop(L));
+}
+
+TEST_F(ScriptJsonTest, TestLuaToJsonWithOptionsIndex)
+{
+    int top = lua_gettop(L);
+
+    {
+        lua_newtable(L);
+            lua_newtable(L);
+            lua_setfield(L, -2, "empty");
+
+        lua_newtable(L);
+            lua_pushboolean(L, 0);
+            lua_setfield(L, -2, "encode_empty_table_as_object");
+
+        char* json = 0;
+        size_t json_length = 0;
+        int ret = dmScript::LuaToJson(L, 1, 2, &json, &json_length);
+        ASSERT_EQ(1, ret);
+        ASSERT_EQ(12u, (uint32_t)json_length);
+        ASSERT_STREQ("{\"empty\":[]}", json);
+        free((void*)json);
+
+        json = 0;
+        json_length = 0;
+        ret = dmScript::LuaToJson(L, 1, 3, &json, &json_length);
+        ASSERT_EQ(1, ret);
+        ASSERT_EQ(12u, (uint32_t)json_length);
+        ASSERT_STREQ("{\"empty\":{}}", json);
+        free((void*)json);
+
+        lua_pop(L, 2);
+    }
+
+    ASSERT_EQ(top, lua_gettop(L));
+}
+
 extern "C" void dmExportedSymbols();
 
 int main(int argc, char **argv)


### PR DESCRIPTION
It is now possible to provide a Lua stack index to the dmSDK function `LuaToJson()` to specify which stack value to encode, as well as the index at which the option table is located. Previously the default was to always encode the value at stack index 1 and to read the options from index 2, which required workarounds for most use-cases. Also `JsonToLua()` now has a version which takes the stack index of the options table.

```cpp
int JsonToLua(lua_State* L, const char* json, size_t json_len, int options_index);
int LuaToJson(lua_State* L, int index, int options_index, char** json, size_t* json_len);
```

Fixes #9446 

