### PR TITLE
Rename internal library to dmbedtls to avoid naming collisions

### DIFF
--- a/build_tools/waf_dynamo.py
+++ b/build_tools/waf_dynamo.py
@@ -2241,7 +2241,7 @@ def detect(conf):
 
     conf.env['STLIB_DLIB'] = ['dlib', 'image', 'zip']
     if feature_enabled('mbedtls') or target_os not in (TargetOS.MACOS, TargetOS.IOS):
-        conf.env['STLIB_DLIB'].append('mbedtls')
+        conf.env['STLIB_DLIB'].append('dmbedtls')
     if target_os in (TargetOS.MACOS, TargetOS.IOS):
         conf.env['FRAMEWORK_DLIB'] = ['CFNetwork', 'Security']
 

--- a/engine/crash/wscript
+++ b/engine/crash/wscript
@@ -33,7 +33,7 @@ def configure(conf):
 
     conf.env.append_value('CPPPATH', "default/src")
 
-    conf.env['STLIB_DLIB'] = ['dlib', 'image', 'zip', 'mbedtls']
+    conf.env['STLIB_DLIB'] = ['dlib', 'image', 'zip', 'dmbedtls']
     conf.env['STLIB_DDF'] = 'ddf'
     conf.env['STLIB_RESOURCE'] = 'resource'
     conf.env['STLIB_EXTENSION'] = 'extension'

--- a/engine/ddf/wscript
+++ b/engine/ddf/wscript
@@ -45,7 +45,7 @@ def configure(conf):
 
     conf.find_program('ddfc_cxx', var='DDFC_CXX', path_list = [os.path.abspath('src')], mandatory = True)
 
-    conf.env['STLIB_DLIB'] = ['dlib', 'image', 'mbedtls']
+    conf.env['STLIB_DLIB'] = ['dlib', 'image', 'dmbedtls']
     conf.env['STLIB_PROTOBUF'] = ['protobuf']
 
     if conf.env.PLATFORM == 'linux':

--- a/engine/dlib/src/test/wscript
+++ b/engine/dlib/src/test/wscript
@@ -55,7 +55,7 @@ def create_test(bld, name, extra_libs = None, extra_features = None, embed_sourc
 
     local_libs = 'dlib zip'.split()
     if feature_enabled('mbedtls') or target_os not in ['macos', 'ios']:
-        local_libs.append('mbedtls')
+        local_libs.append('dmbedtls')
 
     use_profile_null = bld.env.PLATFORM in ('wasm-web', 'wasm_pthread-web', 'arm64-nx64', 'x86_64-ps4', 'x86_64-ps5', 'x86_64-xbone')
     if use_profile_null:

--- a/engine/dlib/src/wscript
+++ b/engine/dlib/src/wscript
@@ -232,23 +232,23 @@ def build(bld):
         './mbedtls/tf-psa-crypto/utilities',
     ]
 
-    mbedtls = bld.stlib(features    = 'c cxx remove_flags',
+    dmbedtls = bld.stlib(features    = 'c cxx remove_flags',
                   includes    = mbedtls_includes,
-                  target      = 'mbedtls',
+                  target      = 'dmbedtls',
                   source      = bld.path.ant_glob(mbedtls_dirs),
                   remove_flags= remove_flags,
                   defines     = mbedtls_defines)
     if new_opt_level:
-        mbedtls.env.append_unique('CFLAGS', FLAG_ST % 's')
+        dmbedtls.env.append_unique('CFLAGS', FLAG_ST % 's')
 
     # Create a separate library, in order to separate it from the ASAN builds
-    mbedtls_noasan = bld.stlib(features     = ' '.join(mbedtls.features) + ' skip_asan',
-                         includes     = mbedtls.includes,
+    dmbedtls_noasan = bld.stlib(features     = ' '.join(dmbedtls.features) + ' skip_asan',
+                         includes     = dmbedtls.includes,
                          remove_flags = remove_flags,
-                         defines      = mbedtls.defines,
-                         target       = 'mbedtls_noasan')
-    mbedtls_noasan.source = [x for x in mbedtls.source]
-    mbedtls_noasan.env.append_unique('CFLAGS', FLAG_ST % 's')
+                         defines      = dmbedtls.defines,
+                         target       = 'dmbedtls_noasan')
+    dmbedtls_noasan.source = [x for x in dmbedtls.source]
+    dmbedtls_noasan.env.append_unique('CFLAGS', FLAG_ST % 's')
 
     libzip_dirs = ['zip/**/*.c']
 
@@ -334,7 +334,7 @@ def build(bld):
                                 includes = mbedtls_public_includes,
                                 target = 'dlib_shared',
                                 defines= ['VALGRIND'] + extra_defines + mbedtls_defines,
-                                use = ['SOCKET', 'profile_null_noasan', 'mbedtls_noasan', 'zip_noasan'])
+                                use = ['SOCKET', 'profile_null_noasan', 'dmbedtls_noasan', 'zip_noasan'])
 
         dlib_shared.source = [x for x in dlib.source]
 

--- a/engine/extension/wscript
+++ b/engine/extension/wscript
@@ -27,7 +27,7 @@ def configure(conf):
 
     conf.env.append_value('INCLUDES', "src")
     conf.env.append_value('INCLUDES', "../src")
-    conf.env['STLIB_DLIB'] = ['dlib', 'image', 'mbedtls']
+    conf.env['STLIB_DLIB'] = ['dlib', 'image', 'dmbedtls']
 
     conf.env.append_unique('DEFINES', 'DLIB_LOG_DOMAIN="EXTENSION"')
 

--- a/engine/gameobject/wscript
+++ b/engine/gameobject/wscript
@@ -31,7 +31,7 @@ def configure(conf):
 
     conf.env.append_value('INCLUDES', 'src')
     conf.env.append_value('INCLUDES', 'src/proto')
-    conf.env['STLIB_DLIB']      = ['dlib', 'image', 'zip', 'mbedtls']
+    conf.env['STLIB_DLIB']      = ['dlib', 'image', 'zip', 'dmbedtls']
     conf.env['STLIB_DDF']       = 'ddf'
     conf.env['STLIB_RIG']       = 'rig'
     conf.env['STLIB_RESOURCE']  = 'resource'

--- a/engine/gamesys/src/gamesys/test/CMakeLists.txt
+++ b/engine/gamesys/src/gamesys/test/CMakeLists.txt
@@ -165,7 +165,7 @@ if(DEFOLD_PLATFORM_SUPPORTS_COMPUTE)
 endif()
 
 set(_DEFOLD_TEST_LIBS
-  testmain test_script dlib mbedtls zip ddf resource gameobject extension script input
+  testmain test_script dlib dmbedtls zip ddf resource gameobject extension script input
   particle rig gui liveupdate graphics_null profile_null platform_null hid_null
   physics render render_font_default font sound_null box2d_defold)
 

--- a/engine/gamesys/wscript
+++ b/engine/gamesys/wscript
@@ -43,7 +43,7 @@ def configure(conf):
         conf.env.append_value('LINKFLAGS', ['opengl32.lib', 'user32.lib', 'shell32.lib', 'xinput9_1_0.lib', 'dinput8.lib', 'dxguid.lib'])
 
     conf.env.append_value('INCLUDES', "default/src")
-    conf.env['STLIB_DLIB'] = ['dlib', 'image', 'zip', 'mbedtls']
+    conf.env['STLIB_DLIB'] = ['dlib', 'image', 'zip', 'dmbedtls']
     conf.env['STLIB_DDF'] = 'ddf'
     conf.env['STLIB_RESOURCE'] = 'resource'
     conf.env['STLIB_GAMEOBJECT'] = 'gameobject'

--- a/engine/gui/wscript
+++ b/engine/gui/wscript
@@ -31,7 +31,7 @@ def configure(conf):
     conf.recurse('src')
 
     conf.env.append_value('INCLUDES', 'src')
-    conf.env['STLIB_DLIB'] = ['dlib', 'image', 'zip', 'mbedtls']
+    conf.env['STLIB_DLIB'] = ['dlib', 'image', 'zip', 'dmbedtls']
     conf.env['STLIB_DDF'] = 'ddf'
     conf.env['STLIB_PARTICLE'] = 'particle'
     conf.env['STLIB_RIG'] = 'rig'

--- a/engine/input/src/test/CMakeLists.txt
+++ b/engine/input/src/test/CMakeLists.txt
@@ -68,7 +68,7 @@ target_include_directories(test_input PRIVATE
 
 defold_target_link_libraries(test_input "${TARGET_PLATFORM}"
     dlib
-    mbedtls
+    dmbedtls
     ddf
     profile_null
     testmain

--- a/engine/input/wscript
+++ b/engine/input/wscript
@@ -30,7 +30,7 @@ def configure(conf):
     conf.recurse('src')
 
     conf.env.append_value('INCLUDES', "src")
-    conf.env['STLIB_DLIB'] = ['dlib', 'image', 'mbedtls']
+    conf.env['STLIB_DLIB'] = ['dlib', 'image', 'dmbedtls']
     conf.env['STLIB_DDF'] = 'ddf'
 
     conf.env.append_unique('DEFINES', 'DLIB_LOG_DOMAIN="INPUT"')

--- a/engine/liveupdate/wscript
+++ b/engine/liveupdate/wscript
@@ -27,7 +27,7 @@ def configure(conf):
 
     conf.env['STLIB_DDF']      = 'ddf'
     conf.env['STLIB_RESOURCE'] = 'resource'
-    conf.env['STLIB_DLIB']     = ['dlib', 'image', 'zip', 'mbedtls']
+    conf.env['STLIB_DLIB']     = ['dlib', 'image', 'zip', 'dmbedtls']
 
     conf.env.append_unique('DEFINES', 'DLIB_LOG_DOMAIN="LIVEUPDATE"')
 

--- a/engine/profiler/wscript
+++ b/engine/profiler/wscript
@@ -29,7 +29,7 @@ def configure(conf):
     target_os = conf.env['TARGET_OS']
     conf.env.append_value('INCLUDES', "default/src")
 
-    conf.env['STLIB_DLIB'] = ['dlib', 'image', 'zip', 'mbedtls']
+    conf.env['STLIB_DLIB'] = ['dlib', 'image', 'zip', 'dmbedtls']
     conf.env['STLIB_DDF'] = 'ddf'
     conf.env['STLIB_RESOURCE'] = 'resource'
     conf.env['STLIB_EXTENSION'] = 'extension'

--- a/engine/render/wscript
+++ b/engine/render/wscript
@@ -43,7 +43,7 @@ def configure(conf):
     conf.env.append_value('INCLUDES', os.path.join(dynamo_home, "include" ))
     conf.env.append_value('INCLUDES', os.path.join(dynamo_home, "include", platform))
 
-    conf.env['STLIB_DLIB']          = ['dlib', 'image', 'zip', 'mbedtls']
+    conf.env['STLIB_DLIB']          = ['dlib', 'image', 'zip', 'dmbedtls']
     conf.env['STLIB_DDF']           = 'ddf'
     conf.env['STLIB_RESOURCE']      = 'resource'
     conf.env['STLIB_GRAPHICS']      = ['graphics', 'image', 'graphics_proto']

--- a/engine/resource/wscript
+++ b/engine/resource/wscript
@@ -57,7 +57,7 @@ def configure(conf):
     conf.recurse('src')
 
     conf.env.append_value('INCLUDES', "src")
-    conf.env['STLIB_DLIB'] = ['dlib', 'image', 'zip', 'mbedtls']
+    conf.env['STLIB_DLIB'] = ['dlib', 'image', 'zip', 'dmbedtls']
     conf.env['STLIB_DDF'] = 'ddf'
 
     conf.env.append_unique('DEFINES', 'DLIB_LOG_DOMAIN="RESOURCE"')

--- a/engine/script/wscript
+++ b/engine/script/wscript
@@ -33,7 +33,7 @@ def configure(conf):
     conf.env.append_value('INCLUDES', 'src')
     conf.env.append_value('INCLUDES', '../')
     conf.env.append_unique('DEFINES', 'DLIB_LOG_DOMAIN="SCRIPT"')
-    conf.env['STLIB_DLIB'] = ['dlib', 'image', 'zip', 'mbedtls']
+    conf.env['STLIB_DLIB'] = ['dlib', 'image', 'zip', 'dmbedtls']
     conf.env['STLIB_DDF'] = 'ddf'
     conf.env['STLIB_RESOURCE'] = 'resource'
     conf.env['STLIB_EXTENSION'] = 'extension'

--- a/engine/tools/wscript
+++ b/engine/tools/wscript
@@ -53,7 +53,7 @@ def configure(conf):
         conf.env.append_value('LINKFLAGS', ['-lEGL', '-lGLESv1_CM', '-lGLESv2', '-landroid'])
 
     conf.env.append_value('INCLUDES', "default/src")
-    conf.env['STLIB_DLIB'] = ['dlib', 'image', 'zip', 'mbedtls']
+    conf.env['STLIB_DLIB'] = ['dlib', 'image', 'zip', 'dmbedtls']
     conf.env['STLIB_DDF'] = 'ddf'
     conf.env['STLIB_TEXC'] = ['texc', 'basis_encoder']
     conf.env['STLIB_DMGLFW'] = glfw_library

--- a/share/extender/build_input.yml
+++ b/share/extender/build_input.yml
@@ -81,7 +81,7 @@ context:
                 "particle",
                 "rig",
                 "dlib",
-                "mbedtls",
+                "dmbedtls",
                 "image",
                 "image_null",
                 "dmglfw",
@@ -439,7 +439,7 @@ platforms:
         ANDROID_BUILD_TOOLS_PATH: "{{env.ANDROID_SDK_BUILD_TOOLS_PATH}}"
     context:
         engineJars: ["{{dynamo_home}}/ext/share/java/glfw_android.jar", "{{dynamo_home}}/share/java/gamesys_android.jar", "{{dynamo_home}}/share/java/sound_android.jar"]
-        engineLibs: ["engine", "engine_service", "mbedtls", "zip", "profile", "profilerext", "profiler_remotery", "record_null", "gameobject", "ddf", "font", "resource", "gamesys", "gamesys_model", "gamesys_rig", "script_box2d_defold", "graphics_opengles", "graphics_vulkan", "graphics_transcoder_basisu", "basis_transcoder", "physics", "BulletDynamics", "BulletCollision", "platform", "LinearMath", "box2d_defold", "render", "render_font_default", "script", "luajit-5.1", "extension", "hid", "input", "particle", "rig", "dlib", "image", "dmglfw", "gui", "crashext", "sound", "tremolo", "liveupdate", "unwind", "decoder_wav", "decoder_ogg"]
+        engineLibs: ["engine", "engine_service", "dmbedtls", "zip", "profile", "profilerext", "profiler_remotery", "record_null", "gameobject", "ddf", "font", "resource", "gamesys", "gamesys_model", "gamesys_rig", "script_box2d_defold", "graphics_opengles", "graphics_vulkan", "graphics_transcoder_basisu", "basis_transcoder", "physics", "BulletDynamics", "BulletCollision", "platform", "LinearMath", "box2d_defold", "render", "render_font_default", "script", "luajit-5.1", "extension", "hid", "input", "particle", "rig", "dlib", "image", "dmglfw", "gui", "crashext", "sound", "tremolo", "liveupdate", "unwind", "decoder_wav", "decoder_ogg"]
         platformIncludes:   ["{{env.NDK_PATH}}/sources/android/native_app_glue", "{{env.NDK_PATH}}/sources/android/cpufeatures"]
         flags:      ["-fno-exceptions", "-fvisibility=hidden"]
         linkFlags:  ["-Wl,--build-id=uuid"]
@@ -513,7 +513,7 @@ platforms:
         engineJsLibs:   ["sys", "script", "sound", "render", "profile"]
         externalJsLibs: ["glfw"]
         defines:    ["DM_PLATFORM_HTML5", "DM_LUA_USE_LUA51"]
-        engineLibs: ["engine", "engine_service", "mbedtls", "zip", "profile", "profilerext", "profiler_js", "record_null", "gameobject", "ddf", "font", "resource", "gamesys", "gamesys_model", "gamesys_rig", "script_box2d_defold", "graphics", "graphics_transcoder_basisu", "basis_transcoder", "physics", "BulletDynamics", "BulletCollision", "platform", "LinearMath", "box2d_defold", "render", "render_font_default", "script", "lua", "extension", "hid", "input", "particle", "rig", "dlib", "image", "dmglfw", "gui", "crashext", "liveupdate", "sound_nosimd", "decoder_wav", "decoder_ogg"]
+        engineLibs: ["engine", "engine_service", "dmbedtls", "zip", "profile", "profilerext", "profiler_js", "record_null", "gameobject", "ddf", "font", "resource", "gamesys", "gamesys_model", "gamesys_rig", "script_box2d_defold", "graphics", "graphics_transcoder_basisu", "basis_transcoder", "physics", "BulletDynamics", "BulletCollision", "platform", "LinearMath", "box2d_defold", "render", "render_font_default", "script", "lua", "extension", "hid", "input", "particle", "rig", "dlib", "image", "dmglfw", "gui", "crashext", "liveupdate", "sound_nosimd", "decoder_wav", "decoder_ogg"]
         flags:      ["-fno-exceptions", "-fno-rtti", "-fPIC", "-Wno-nontrivial-memcall"]
         linkFlags:  ["--emit-symbol-map", "-O{{optLevel}}"]
         emscriptenFlags: ["DISABLE_EXCEPTION_CATCHING=1"]
@@ -576,7 +576,7 @@ platforms:
         CLANG_HOME:         "{{env.CLANG_RESOURCE_DIR}}"
     context:
         systemIncludes: ["{{env.CLANG_HOME}}/include", "{{env.MSVC_DIR}}/include", "{{env.MSVC_DIR}}/atlmfc/include", "{{env.SDK_DIR}}/Include/{{env.SDK_VERSION}}/ucrt", "{{env.SDK_DIR}}/Include/{{env.SDK_VERSION}}/winrt", "{{env.SDK_DIR}}/Include/{{env.SDK_VERSION}}/um", "{{env.SDK_DIR}}/Include/{{env.SDK_VERSION}}/shared"]
-        engineLibs:     ["libengine","libengine_service","libmbedtls","libzip","libprofile","libprofilerext","libprofiler_remotery","librecord","libgameobject","libddf","libfont","libresource","gamesys","gamesys_model","gamesys_rig","libscript_box2d_defold","libgraphics","libgraphics_transcoder_basisu","libbasis_transcoder","libphysics","libBulletDynamics","libBulletCollision","platform","libLinearMath","libbox2d_defold","librender","librender_font_default","libscript","libluajit-5.1","libextension","hid","input","libparticle","librig","libdlib", "libimage", "libglfw3","libgui","libcrashext","libliveupdate","libsound","vpx", "libdecoder_wav", "libdecoder_ogg"]
+        engineLibs:     ["libengine","libengine_service","libdmbedtls","libzip","libprofile","libprofilerext","libprofiler_remotery","librecord","libgameobject","libddf","libfont","libresource","gamesys","gamesys_model","gamesys_rig","libscript_box2d_defold","libgraphics","libgraphics_transcoder_basisu","libbasis_transcoder","libphysics","libBulletDynamics","libBulletCollision","platform","libLinearMath","libbox2d_defold","librender","librender_font_default","libscript","libluajit-5.1","libextension","hid","input","libparticle","librig","libdlib", "libimage", "libglfw3","libgui","libcrashext","libliveupdate","libsound","vpx", "libdecoder_wav", "libdecoder_ogg"]
         libs:           ["OpenGL32", "delayimp", "User32", "shell32", "Xinput9_1_0", "dinput8", "dxguid", "WS2_32", "iphlpapi", "DbgHelp", "AdvAPI32", "bcrypt", "Psapi", "Gdi32", "ole32"]
         symbols:        ["GraphicsAdapterOpenGL", "ProfilerRemotery"]
 
@@ -619,7 +619,7 @@ platforms:
 
   linux:
     context:
-        engineLibs:     ["engine", "engine_service", "mbedtls", "zip", "profile", "profilerext", "profiler_remotery", "record", "gameobject", "ddf", "font", "resource", "gamesys", "gamesys_model", "gamesys_rig", "script_box2d_defold", "graphics_transcoder_basisu", "basis_transcoder", "physics", "BulletDynamics", "BulletCollision", "platform", "LinearMath", "box2d_defold", "render", "render_font_default", "script", "luajit-5.1", "extension", "hid", "input", "particle", "rig", "dlib", "image", "glfw3", "gui", "crashext", "liveupdate", "sound", "tremolo", "vpx", "decoder_wav", "decoder_ogg"]
+        engineLibs:     ["engine", "engine_service", "dmbedtls", "zip", "profile", "profilerext", "profiler_remotery", "record", "gameobject", "ddf", "font", "resource", "gamesys", "gamesys_model", "gamesys_rig", "script_box2d_defold", "graphics_transcoder_basisu", "basis_transcoder", "physics", "BulletDynamics", "BulletCollision", "platform", "LinearMath", "box2d_defold", "render", "render_font_default", "script", "luajit-5.1", "extension", "hid", "input", "particle", "rig", "dlib", "image", "glfw3", "gui", "crashext", "liveupdate", "sound", "tremolo", "vpx", "decoder_wav", "decoder_ogg"]
         defines:        ["DM_PLATFORM_LINUX", "__STDC_LIMIT_MACROS"]
         flags:          ["-g", "-O2", "-D__STDC_LIMIT_MACROS", "-Wall", "-Werror=format", "-fno-exceptions", "-fPIC", "-fvisibility=hidden"]
         linkFlags:      ["-g", "-O2", "-fuse-ld=lld"]


### PR DESCRIPTION
## Summary
- Renames the packaged mbedtls build artifact to `dmbedtls`
- Updates Waf, CMake, and extender build references to link against the new library name
- Keeps the feature flag, source layout, and upstream `mbedtls` API references unchanged

Related issue https://github.com/defold/defold/issues/10939#issuecomment-4506312390