### PR TITLE
Tsan fixes for calling non-thread safe initialization code in mbedtls

### DIFF
--- a/engine/dlib/src/dlib/sslsocket_mbedtls.cpp
+++ b/engine/dlib/src/dlib/sslsocket_mbedtls.cpp
@@ -305,18 +305,10 @@ Result New(dmSocket::Socket socket, const char* host, uint64_t timeout, Socket* 
     mbedtls_ssl_config_init(c->m_MbedConf);
 
 #if defined(MBEDTLS_DEBUG_C)
-    mbedtls_debug_set_threshold(MBED_DEBUG_LEVEL);
     mbedtls_ssl_conf_dbg(c->m_MbedConf, mbedtls_debug, 0);
 #endif
 
     int ret = 0;
-    Result result = InitializePSA();
-    if (result != RESULT_OK)
-    {
-        Delete(c);
-        return result;
-    }
-
     if ((ret = mbedtls_ssl_config_defaults(c->m_MbedConf,
                                            MBEDTLS_SSL_IS_CLIENT,
                                            MBEDTLS_SSL_TRANSPORT_STREAM,
@@ -577,6 +569,10 @@ Result Initialize()
         dm_mbedtls_condition_wait
     );
 
+#if defined(MBEDTLS_DEBUG_C)
+    mbedtls_debug_set_threshold(MBED_DEBUG_LEVEL);
+#endif
+
     Result result = InitializePSA();
     if (result != RESULT_OK)
     {
@@ -601,6 +597,10 @@ namespace dmSSLSocket
 
 Result Initialize()
 {
+#if defined(MBEDTLS_DEBUG_C)
+    mbedtls_debug_set_threshold(MBED_DEBUG_LEVEL);
+#endif
+
     return InitializePSA();
 }
 

--- a/engine/dlib/src/mbedtls/defold/tf_psa_crypto_user_config.h
+++ b/engine/dlib/src/mbedtls/defold/tf_psa_crypto_user_config.h
@@ -17,6 +17,12 @@
 
 #include "mbedtls_rename.h"
 
+/* Defold does not call the mbedTLS self-test APIs at runtime. Leaving them
+ * enabled adds global counters to ECC operations, which race during concurrent
+ * TLS handshakes.
+ */
+#undef MBEDTLS_SELF_TEST
+
 #if defined(DM_MBEDTLS_DISABLE_ASM)
 #undef MBEDTLS_HAVE_ASM
 #undef MBEDTLS_AESNI_C


### PR DESCRIPTION


## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
