### PR TITLE
Fix runtime font job teardown crash

### DIFF
--- a/engine/gamesys/src/gamesys/fontgen/fontgen.cpp
+++ b/engine/gamesys/src/gamesys/fontgen/fontgen.cpp
@@ -88,6 +88,7 @@ struct FontGenJobData
     HJobContext                         m_Jobs;
     dmGameSystem::FPrewarmTextCallback  m_Callback;     // Only set for the last item in the queue
     void*                               m_CallbackCtx;  // Only set for the last item in the queue
+    bool                                m_Canceling;
 };
 
 Context* g_FontExtContext = 0;
@@ -131,6 +132,11 @@ void FontGenDestroyJobData(FontGenJobData* jobdata)
         ReleaseJobItem(&jobdata->m_Items[i]);
     }
     delete jobdata;
+}
+
+void FontGenCancelJobData(FontGenJobData* jobdata)
+{
+    jobdata->m_Canceling = true;
 }
 
 static void FontGenJobDataSetup(FontGenJobData* jobdata, uint32_t num_glyphs, dmGameSystem::FPrewarmTextCallback cbk, void* cbk_ctx)
@@ -303,7 +309,7 @@ static void JobPostProcessGlyph(HJobContext job_thread, HJob job, JobSystemStatu
     uint64_t tstart = dmTime::GetMonotonicTime();
 #endif
 
-    if (!item->m_Font)
+    if (job_status != JOBSYSTEM_STATUS_FINISHED || jobdata->m_Canceling || !item->m_Font)
     {
         ReleaseJobItem(item);
         return;

--- a/engine/gamesys/src/gamesys/fontgen/fontgen.h
+++ b/engine/gamesys/src/gamesys/fontgen/fontgen.h
@@ -38,6 +38,7 @@ namespace dmGameSystem
     struct FontGenJobData;
     FontGenJobData* FontGenCreateJobData(FontResource* resource, uint32_t num_glyphs);
     void            FontGenDestroyJobData(FontGenJobData* jobdata);
+    void            FontGenCancelJobData(FontGenJobData* jobdata);
 
     HJob FontGenAddGlyphByIndex(FontGenJobData* jobdata, HFont font, uint32_t glyph_index, dmGameSystem::FPrewarmTextCallback cbk, void* cbk_ctx);
     HJob FontGenAddGlyphs(FontGenJobData* jobdata, TextGlyph* glyphs, uint32_t num_glyphs, dmGameSystem::FPrewarmTextCallback cbk, void* cbk_ctx);

--- a/engine/gamesys/src/gamesys/resources/res_font.cpp
+++ b/engine/gamesys/src/gamesys/resources/res_font.cpp
@@ -52,6 +52,7 @@ namespace dmGameSystem
     }
 
     static void DecRefJobResourceInfo(dmResource::HFactory factory, FontResource* resource, FontJobResourceInfo* job_info);
+    static void DestroyJobInfo(FontJobResourceInfo* job_info);
 
     FontResource::FontResource()
     {
@@ -105,6 +106,18 @@ namespace dmGameSystem
         }
     }
 
+    static bool HasPendingJob(FontResource* font, FontJobResourceInfo* job_info)
+    {
+        for (uint32_t i = 0; i < font->m_PendingJobs.Size(); ++i)
+        {
+            if (font->m_PendingJobs[i] == job_info)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
     static void DeallocateJobResourceInfo(FontJobResourceInfo* job_info)
     {
         FontGenDestroyJobData(job_info->m_FontGenJobData);
@@ -113,22 +126,32 @@ namespace dmGameSystem
 
     static void CancelPendingJobs(FontResource* font)
     {
-        for (uint32_t i = 0; i < font->m_PendingJobs.Size(); ++i)
+        while (font->m_PendingJobs.Size() > 0)
         {
-            FontJobResourceInfo* job_info = font->m_PendingJobs[i];
-            HJob hjob = job_info->m_Job;
+            FontJobResourceInfo* job_info = font->m_PendingJobs[0];
+            job_info->m_Resource = font;
+            job_info->m_Canceling = true;
+            FontGenCancelJobData(job_info->m_FontGenJobData);
 
-            JobSystemResult jr = JobSystemCancelJob(font->m_Jobs, hjob);
-            while (JOBSYSTEM_RESULT_PENDING == jr)
+            JobSystemResult jr = JobSystemCancelJob(font->m_Jobs, job_info->m_Job);
+            if (jr == JOBSYSTEM_RESULT_INVALID_HANDLE)
             {
-                dmTime::Sleep(1000);
-                jr = JobSystemCancelJob(font->m_Jobs, hjob);
+                DestroyJobInfo(job_info);
+                continue;
             }
 
-            DecRefJobResourceInfo(font->m_Factory, font, job_info);
-            DeallocateJobResourceInfo(job_info);
+            if (jr == JOBSYSTEM_RESULT_PENDING)
+            {
+                dmTime::Sleep(1000);
+            }
+
+            JobSystemUpdate(font->m_Jobs, 0);
+
+            if (HasPendingJob(font, job_info) && jr != JOBSYSTEM_RESULT_PENDING)
+            {
+                dmTime::Sleep(1000);
+            }
         }
-        font->m_PendingJobs.SetSize(0);
     }
 
     static void ReleaseResourceIter(void* ctx, const uint64_t* hash, TTFResource** presource)
@@ -165,6 +188,7 @@ namespace dmGameSystem
         job_info->m_Callback = cbk;
         job_info->m_CallbackContext = cbk_ctx;
         job_info->m_Resource = resource;
+        job_info->m_Canceling = false;
 
         HFontCollection fontcollection = ResFontGetFontCollection(resource);
         uint32_t num_fonts = FontCollectionGetFontCount(fontcollection);
@@ -212,7 +236,7 @@ namespace dmGameSystem
     static void TextCallbackJobInfo(void* cbk_ctx, int result, const char* errmsg)
     {
         FontJobResourceInfo* job_info = (FontJobResourceInfo*)cbk_ctx;
-        if (job_info->m_Callback)
+        if (!job_info->m_Canceling && job_info->m_Callback)
             job_info->m_Callback(job_info->m_CallbackContext, result, errmsg);
         DestroyJobInfo(job_info);
     }

--- a/engine/gamesys/src/gamesys/resources/res_font_private.h
+++ b/engine/gamesys/src/gamesys/resources/res_font_private.h
@@ -41,6 +41,7 @@ namespace dmGameSystem
         FontGenJobData*         m_FontGenJobData; // the job scratch data, owned by the sentinel job
         FontResource*           m_Resource;
         HJob                    m_Job;
+        bool                    m_Canceling;
 
         FPrewarmTextCallback    m_Callback;
         void*                   m_CallbackContext;

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -2985,20 +2985,37 @@ TEST_F(FontTest, DynamicGlyph)
     dmResource::Release(m_Factory, font);
 }
 
+struct DynamicFontJobCallbackState
+{
+    uint32_t m_CallbackCount;
+};
+
+static void DynamicFontJobCallback(void* ctx, int result, const char* errmsg)
+{
+    (void)result;
+    (void)errmsg;
+    DynamicFontJobCallbackState* state = (DynamicFontJobCallbackState*)ctx;
+    state->m_CallbackCount++;
+}
+
 TEST_F(FontTest, ReloadCancelsPendingDynamicFontJobs)
 {
     const char path_font[] = "/font/dyn_glyph_bank_test_1.fontc";
     dmGameSystem::FontResource* font = 0;
+    DynamicFontJobCallbackState callback_state = {0};
 
     ASSERT_EQ(dmResource::RESULT_OK, dmResource::Get(m_Factory, path_font, (void**) &font));
     ASSERT_NE((void*)0, font);
     ASSERT_EQ(0u, font->m_PendingJobs.Size());
 
-    ASSERT_EQ(dmResource::RESULT_OK, dmGameSystem::ResFontPrewarmText(font, "Reload pending jobs", 0, 0));
+    ASSERT_EQ(dmResource::RESULT_OK, dmGameSystem::ResFontPrewarmText(font, "Reload pending jobs", DynamicFontJobCallback, &callback_state));
     ASSERT_GT(font->m_PendingJobs.Size(), 0u);
 
     ASSERT_EQ(dmResource::RESULT_OK, dmResource::ReloadResource(m_Factory, path_font, 0));
     ASSERT_EQ(0u, font->m_PendingJobs.Size());
+
+    JobSystemUpdate(m_JobContext, 0);
+    ASSERT_EQ(0u, callback_state.m_CallbackCount);
 
     dmResource::Release(m_Factory, font);
 }


### PR DESCRIPTION
Prevents pending dynamic font glyph jobs from using freed font job data during resource reload or destruction. Adds a regression test for canceling pending dynamic font jobs.

Fix https://github.com/defold/defold/issues/12437