### PR TITLE
Fix TSan race issue with macOS/iOS SSLSocket implementation

### DIFF
--- a/build_tools/waf_dynamo.py
+++ b/build_tools/waf_dynamo.py
@@ -1139,7 +1139,13 @@ def codesign(task):
     if not hasattr(task.generator, 'sdkinfo'):
         task.generator.sdkinfo = sdk.get_sdk_info(SDK_ROOT, bld.env['PLATFORM'])
 
-    ret = bld.exec_command('CODESIGN_ALLOCATE=%s/usr/bin/codesign_allocate codesign -f -s "%s" --resource-rules=%s --entitlements %s %s' % (sdk.get_toolchain_root(task.generator.sdkinfo, bld.env['PLATFORM']), identity, resource_rules_plist_file, entitlements_path, signed_exe_dir))
+    codesign_allocate = os.path.join(sdk.get_toolchain_root(task.generator.sdkinfo, bld.env['PLATFORM']), 'usr', 'bin', 'codesign_allocate')
+    ret = bld.exec_command('CODESIGN_ALLOCATE=%s codesign -f -s %s --resource-rules=%s --entitlements %s %s' % (
+        shlex.quote(codesign_allocate),
+        shlex.quote(identity),
+        shlex.quote(resource_rules_plist_file),
+        shlex.quote(entitlements_path),
+        shlex.quote(signed_exe_dir)))
     if ret != 0:
         error('Error running codesign')
         return 1
@@ -1824,10 +1830,14 @@ def js_web_web_link_flags(self):
                 js = os.path.join(jsLibHome, lib)
             self.env.append_value('LINKFLAGS', ['--js-library', js])
 
-Task.task_factory('dSYM', '${DSYMUTIL} -o ${TGT} ${SRC}',
+def dsym(task):
+    dsymutil = Utils.to_list(task.env.DSYMUTIL)[0]
+    return task.exec_command([dsymutil, '-o', task.outputs[0].abspath(), task.inputs[0].abspath()])
+
+Task.task_factory('dSYM',
+                      func=dsym,
                       color='YELLOW',
-                      after='link_task',
-                      shell=True)
+                      after='link_task')
 
 Task.task_factory('DSYMZIP', '${ZIP} -r ${TGT} ${SRC}',
                       color='BROWN',

--- a/engine/dlib/src/dlib/sslsocket_apple.mm
+++ b/engine/dlib/src/dlib/sslsocket_apple.mm
@@ -159,16 +159,37 @@ namespace dmSSLSocket
         CFRunLoopRef     m_RunLoop;
     };
 
-    static void UpdateScheduledStreams(CFRunLoopRef run_loop)
+    static void ScheduleStreams(CFReadStreamRef read_stream, CFWriteStreamRef write_stream, CFRunLoopRef run_loop)
     {
-        if (run_loop == CFRunLoopGetCurrent())
+        CFReadStreamScheduleWithRunLoop(read_stream, run_loop, kCFRunLoopDefaultMode);
+        CFWriteStreamScheduleWithRunLoop(write_stream, run_loop, kCFRunLoopDefaultMode);
+    }
+
+    static void UnscheduleStreams(CFReadStreamRef read_stream, CFWriteStreamRef write_stream, CFRunLoopRef run_loop)
+    {
+        CFReadStreamUnscheduleFromRunLoop(read_stream, run_loop, kCFRunLoopDefaultMode);
+        CFWriteStreamUnscheduleFromRunLoop(write_stream, run_loop, kCFRunLoopDefaultMode);
+    }
+
+    static void EnsureStreamsScheduledOnCurrentRunLoop(Socket socket)
+    {
+        // HTTP connections can be pooled across worker threads. Keep CFStream
+        // readiness updates attached to the run loop of the thread doing I/O.
+        CFRunLoopRef run_loop = CFRunLoopGetCurrent();
+        if (socket->m_RunLoop == run_loop)
         {
-            CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.0, true);
+            return;
         }
-        else
+
+        if (socket->m_RunLoop != 0)
         {
-            CFRunLoopWakeUp(run_loop);
+            UnscheduleStreams(socket->m_ReadStream, socket->m_WriteStream, socket->m_RunLoop);
+            CFRelease(socket->m_RunLoop);
         }
+
+        CFRetain(run_loop);
+        ScheduleStreams(socket->m_ReadStream, socket->m_WriteStream, run_loop);
+        socket->m_RunLoop = run_loop;
     }
 
     static dmSocket::Result StreamErrorToSocketResult(CFStreamError error)
@@ -334,16 +355,14 @@ namespace dmSSLSocket
 
         CFRunLoopRef run_loop = CFRunLoopGetCurrent();
         CFRetain(run_loop);
-        CFReadStreamScheduleWithRunLoop(read_stream, run_loop, kCFRunLoopDefaultMode);
-        CFWriteStreamScheduleWithRunLoop(write_stream, run_loop, kCFRunLoopDefaultMode);
+        ScheduleStreams(read_stream, write_stream, run_loop);
 
         bool read_opened = CFReadStreamOpen(read_stream);
         bool write_opened = CFWriteStreamOpen(write_stream);
         if (!read_opened || !write_opened)
         {
             Result result = StreamErrorToSSLResult(read_opened ? CFWriteStreamGetError(write_stream) : CFReadStreamGetError(read_stream));
-            CFReadStreamUnscheduleFromRunLoop(read_stream, run_loop, kCFRunLoopDefaultMode);
-            CFWriteStreamUnscheduleFromRunLoop(write_stream, run_loop, kCFRunLoopDefaultMode);
+            UnscheduleStreams(read_stream, write_stream, run_loop);
             CFRelease(run_loop);
             CFRelease(read_stream);
             CFRelease(write_stream);
@@ -352,8 +371,7 @@ namespace dmSSLSocket
 
         if (!ValidatePeerCertificateChain(read_stream))
         {
-            CFReadStreamUnscheduleFromRunLoop(read_stream, run_loop, kCFRunLoopDefaultMode);
-            CFWriteStreamUnscheduleFromRunLoop(write_stream, run_loop, kCFRunLoopDefaultMode);
+            UnscheduleStreams(read_stream, write_stream, run_loop);
             CFRelease(run_loop);
             CFReadStreamClose(read_stream);
             CFWriteStreamClose(write_stream);
@@ -365,8 +383,7 @@ namespace dmSSLSocket
         Socket ssl_socket = (Socket)malloc(sizeof(SSLSocket));
         if (ssl_socket == 0)
         {
-            CFReadStreamUnscheduleFromRunLoop(read_stream, run_loop, kCFRunLoopDefaultMode);
-            CFWriteStreamUnscheduleFromRunLoop(write_stream, run_loop, kCFRunLoopDefaultMode);
+            UnscheduleStreams(read_stream, write_stream, run_loop);
             CFRelease(run_loop);
             CFReadStreamClose(read_stream);
             CFWriteStreamClose(write_stream);
@@ -390,8 +407,7 @@ namespace dmSSLSocket
         {
             return RESULT_OK;
         }
-        CFReadStreamUnscheduleFromRunLoop(socket->m_ReadStream, socket->m_RunLoop, kCFRunLoopDefaultMode);
-        CFWriteStreamUnscheduleFromRunLoop(socket->m_WriteStream, socket->m_RunLoop, kCFRunLoopDefaultMode);
+        UnscheduleStreams(socket->m_ReadStream, socket->m_WriteStream, socket->m_RunLoop);
         CFReadStreamClose(socket->m_ReadStream);
         CFWriteStreamClose(socket->m_WriteStream);
         CFRelease(socket->m_ReadStream);
@@ -408,9 +424,10 @@ namespace dmSSLSocket
             *sent_bytes = 0;
         }
 
+        EnsureStreamsScheduledOnCurrentRunLoop(socket);
         if (!CFWriteStreamCanAcceptBytes(socket->m_WriteStream))
         {
-            UpdateScheduledStreams(socket->m_RunLoop);
+            CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.0, true);
             return WriteStreamNotReadyResult(socket->m_WriteStream);
         }
 
@@ -437,9 +454,10 @@ namespace dmSSLSocket
             *received_bytes = 0;
         }
 
+        EnsureStreamsScheduledOnCurrentRunLoop(socket);
         if (!CFReadStreamHasBytesAvailable(socket->m_ReadStream))
         {
-            UpdateScheduledStreams(socket->m_RunLoop);
+            CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.0, true);
             return ReadStreamNotReadyResult(socket->m_ReadStream);
         }
 

--- a/engine/dlib/src/dlib/sslsocket_apple.mm
+++ b/engine/dlib/src/dlib/sslsocket_apple.mm
@@ -156,7 +156,20 @@ namespace dmSSLSocket
         dmSocket::Socket m_Socket;
         CFReadStreamRef  m_ReadStream;
         CFWriteStreamRef m_WriteStream;
+        CFRunLoopRef     m_RunLoop;
     };
+
+    static void UpdateScheduledStreams(CFRunLoopRef run_loop)
+    {
+        if (run_loop == CFRunLoopGetCurrent())
+        {
+            CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.0, true);
+        }
+        else
+        {
+            CFRunLoopWakeUp(run_loop);
+        }
+    }
 
     static dmSocket::Result StreamErrorToSocketResult(CFStreamError error)
     {
@@ -319,11 +332,19 @@ namespace dmSSLSocket
         dmSocket::SetReceiveTimeout(socket, timeout);
         dmSocket::SetBlocking(socket, false);
 
+        CFRunLoopRef run_loop = CFRunLoopGetCurrent();
+        CFRetain(run_loop);
+        CFReadStreamScheduleWithRunLoop(read_stream, run_loop, kCFRunLoopDefaultMode);
+        CFWriteStreamScheduleWithRunLoop(write_stream, run_loop, kCFRunLoopDefaultMode);
+
         bool read_opened = CFReadStreamOpen(read_stream);
         bool write_opened = CFWriteStreamOpen(write_stream);
         if (!read_opened || !write_opened)
         {
             Result result = StreamErrorToSSLResult(read_opened ? CFWriteStreamGetError(write_stream) : CFReadStreamGetError(read_stream));
+            CFReadStreamUnscheduleFromRunLoop(read_stream, run_loop, kCFRunLoopDefaultMode);
+            CFWriteStreamUnscheduleFromRunLoop(write_stream, run_loop, kCFRunLoopDefaultMode);
+            CFRelease(run_loop);
             CFRelease(read_stream);
             CFRelease(write_stream);
             return result;
@@ -331,6 +352,9 @@ namespace dmSSLSocket
 
         if (!ValidatePeerCertificateChain(read_stream))
         {
+            CFReadStreamUnscheduleFromRunLoop(read_stream, run_loop, kCFRunLoopDefaultMode);
+            CFWriteStreamUnscheduleFromRunLoop(write_stream, run_loop, kCFRunLoopDefaultMode);
+            CFRelease(run_loop);
             CFReadStreamClose(read_stream);
             CFWriteStreamClose(write_stream);
             CFRelease(read_stream);
@@ -341,6 +365,9 @@ namespace dmSSLSocket
         Socket ssl_socket = (Socket)malloc(sizeof(SSLSocket));
         if (ssl_socket == 0)
         {
+            CFReadStreamUnscheduleFromRunLoop(read_stream, run_loop, kCFRunLoopDefaultMode);
+            CFWriteStreamUnscheduleFromRunLoop(write_stream, run_loop, kCFRunLoopDefaultMode);
+            CFRelease(run_loop);
             CFReadStreamClose(read_stream);
             CFWriteStreamClose(write_stream);
             CFRelease(read_stream);
@@ -352,6 +379,7 @@ namespace dmSSLSocket
         ssl_socket->m_Socket      = socket;
         ssl_socket->m_ReadStream  = read_stream;
         ssl_socket->m_WriteStream = write_stream;
+        ssl_socket->m_RunLoop     = run_loop;
         *sslsocket = ssl_socket;
         return RESULT_OK;
     }
@@ -362,10 +390,13 @@ namespace dmSSLSocket
         {
             return RESULT_OK;
         }
+        CFReadStreamUnscheduleFromRunLoop(socket->m_ReadStream, socket->m_RunLoop, kCFRunLoopDefaultMode);
+        CFWriteStreamUnscheduleFromRunLoop(socket->m_WriteStream, socket->m_RunLoop, kCFRunLoopDefaultMode);
         CFReadStreamClose(socket->m_ReadStream);
         CFWriteStreamClose(socket->m_WriteStream);
         CFRelease(socket->m_ReadStream);
         CFRelease(socket->m_WriteStream);
+        CFRelease(socket->m_RunLoop);
         free(socket);
         return RESULT_OK;
     }
@@ -379,6 +410,7 @@ namespace dmSSLSocket
 
         if (!CFWriteStreamCanAcceptBytes(socket->m_WriteStream))
         {
+            UpdateScheduledStreams(socket->m_RunLoop);
             return WriteStreamNotReadyResult(socket->m_WriteStream);
         }
 
@@ -407,6 +439,7 @@ namespace dmSSLSocket
 
         if (!CFReadStreamHasBytesAvailable(socket->m_ReadStream))
         {
+            UpdateScheduledStreams(socket->m_RunLoop);
             return ReadStreamNotReadyResult(socket->m_ReadStream);
         }
 

--- a/engine/dlib/src/test/test_mdns.cpp
+++ b/engine/dlib/src/test/test_mdns.cpp
@@ -1045,6 +1045,32 @@ namespace
         }
     }
 
+    static bool WaitForOnlyResponseTxtId(dmMDNS::HMDNS mdns_a, dmMDNS::HMDNS mdns_b, dmSocket::Socket capture_socket,
+                                         dmSocket::Socket sender_socket, const std::vector<uint8_t>& query,
+                                         const char* full_service_name, const char* expected_id, uint32_t timeout_ms)
+    {
+        const uint64_t deadline = dmTime::GetMonotonicTime() + (uint64_t) timeout_ms * 1000ULL;
+        for (;;)
+        {
+            const uint64_t now = dmTime::GetMonotonicTime();
+            if (now >= deadline)
+                break;
+
+            // Prior multicast announcements can still be queued on the capture socket.
+            // Drain before each fresh query so stale packets cannot decide the race.
+            DrainSocket(capture_socket, 100);
+            if (!SendPacketToAddress(sender_socket, &query[0], (uint32_t) query.size(), MDNS_MULTICAST_IPV4, MDNS_PORT))
+                return false;
+
+            std::set<std::string> ids;
+            CollectResponseTxtIds(mdns_a, mdns_b, capture_socket, full_service_name, 500, &ids);
+            if (ids.size() == 1 && ids.find(expected_id) != ids.end())
+                return true;
+        }
+
+        return false;
+    }
+
     static bool SendQueryAndCapture(dmMDNS::HMDNS mdns, dmSocket::Socket socket, const char* qname, uint16_t qtype, const std::vector<std::string>& names, RawDnsPacket* packet, uint32_t timeout_ms)
     {
         std::vector<uint8_t> query;
@@ -1943,16 +1969,11 @@ TEST(MDNS, SimultaneousServiceProbesPickSingleWinner)
     ASSERT_EQ(dmMDNS::RESULT_OK, dmMDNS::RegisterService(cleanup_b.m_Mdns, &service_b));
 
     PumpMdnsPair(cleanup_a.m_Mdns, cleanup_b.m_Mdns, 500, 5 * 1000);
-    DrainSocket(capture.m_Socket, 100);
 
     std::vector<uint8_t> query;
     BuildQueryPacket(full_service_name, DNS_TYPE_ANY, &query);
-    ASSERT_TRUE(SendPacketToAddress(sender.m_Socket, &query[0], (uint32_t) query.size(), MDNS_MULTICAST_IPV4, MDNS_PORT));
-
-    std::set<std::string> ids;
-    CollectResponseTxtIds(cleanup_a.m_Mdns, cleanup_b.m_Mdns, capture.m_Socket, full_service_name, 800, &ids);
-    ASSERT_EQ(1U, ids.size());
-    ASSERT_TRUE(ids.find("probe-race-b") != ids.end());
+    ASSERT_TRUE(WaitForOnlyResponseTxtId(cleanup_a.m_Mdns, cleanup_b.m_Mdns, capture.m_Socket, sender.m_Socket,
+                                         query, full_service_name, "probe-race-b", 4000));
 }
 
 // Verifies the advertiser returns the expected PTR/SRV/TXT/A response set for valid queries.


### PR DESCRIPTION
## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
