### PR TITLE
Fix whitespace when generating the Jni+Java bindings

### DIFF
--- a/engine/jni/scripts/gen_java.py
+++ b/engine/jni/scripts/gen_java.py
@@ -187,6 +187,27 @@ def l(s):
     global out_lines
     out_lines += s + '\n'
 
+def detect_newline(path):
+    if not os.path.exists(path):
+        return '\n'
+    with open(path, 'rb') as f_inp:
+        line = f_inp.readline()
+    if b'\r\n' in line:
+        return '\r\n'
+    if b'\r' in line:
+        return '\r'
+    return '\n'
+
+def write_generated(path, text):
+    newline = detect_newline(path)
+    data = text.replace('\n', newline).encode('utf-8')
+    if os.path.exists(path):
+        with open(path, 'rb') as f_inp:
+            if f_inp.read() == data:
+                return
+    with open(path, 'wb') as f_outp:
+        f_outp.write(data)
+
 def as_zig_prim_type(s):
     return prim_types[s]
 
@@ -1240,19 +1261,16 @@ def generate(header_path, namespace, package_name, includes, java_outdir, jni_ou
 
     gen_java_source(ir, module_name, package_name)
 
-    with open(output_java_path, 'w', newline='\n') as f_outp:
-        f_outp.write(out_lines)
+    write_generated(output_java_path, out_lines)
     print("Wrote", output_java_path)
 
     reset_lines()
     gen_jni_source(ir, module_name, os.path.basename(output_jni_h_path), package_name)
 
-    with open(output_jni_cpp_path, 'w', newline='\n') as f_outp:
-        f_outp.write(out_lines)
+    write_generated(output_jni_cpp_path, out_lines)
     print("Wrote", output_jni_cpp_path)
 
     reset_lines()
     gen_jni_header(ir, module_name, package_name)
-    with open(output_jni_h_path, 'w', newline='\n') as f_outp:
-        f_outp.write(out_lines)
+    write_generated(output_jni_h_path, out_lines)
     print("Wrote", output_jni_h_path)


### PR DESCRIPTION
## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
