### PR TITLE
Fix runtime font job teardown crash

### DIFF
--- a/engine/dlib/src/dlib/jobsystem.cpp
+++ b/engine/dlib/src/dlib/jobsystem.cpp
@@ -211,6 +211,7 @@ static void FreeJob(JobThreadContext* ctx, HJob hjob)
 
     item.m_Generation = INVALID_INDEX;
     item.m_Status = JOBSYSTEM_STATUS_FREE;
+    item.m_CancelRequested = 0;
 
     ctx->m_Items.Free(index, false);
 }

--- a/engine/dlib/src/dlib/jobsystem.cpp
+++ b/engine/dlib/src/dlib/jobsystem.cpp
@@ -333,22 +333,24 @@ static JobSystemResult CancelJobInternal(JobThreadContext* ctx, HJob hjob)
     if (!item)
         return JOBSYSTEM_RESULT_INVALID_HANDLE;
 
+    JobSystemResult result = JOBSYSTEM_RESULT_CANCELED;
+
     if (item->m_Status == JOBSYSTEM_STATUS_PROCESSING || item->m_Status == JOBSYSTEM_STATUS_CALLBACK)
     {
         item->m_CancelRequested = 1;
-        return JOBSYSTEM_RESULT_PENDING;
+        result = JOBSYSTEM_RESULT_PENDING;
     }
-    if (item->m_Status == JOBSYSTEM_STATUS_FINISHED)
+    else if (item->m_Status == JOBSYSTEM_STATUS_FINISHED)
     {
         item->m_Status = JOBSYSTEM_STATUS_CANCELED;
         item->m_Result = 0;
-        return JOBSYSTEM_RESULT_CANCELED;
     }
-
-    // Can only cancel queued/created items directly, but still wait on children when already canceled
-    assert(item->m_Status == JOBSYSTEM_STATUS_CREATED || item->m_Status == JOBSYSTEM_STATUS_QUEUED || item->m_Status == JOBSYSTEM_STATUS_CANCELED);
-
-    JobSystemResult result = JOBSYSTEM_RESULT_CANCELED;
+    else
+    {
+        // Can only cancel queued/created items directly, but still wait on children when already canceled
+        assert(item->m_Status == JOBSYSTEM_STATUS_CREATED || item->m_Status == JOBSYSTEM_STATUS_QUEUED || item->m_Status == JOBSYSTEM_STATUS_CANCELED);
+        item->m_Status = JOBSYSTEM_STATUS_CANCELED;
+    }
 
     HJob hchild = item->m_FirstChild;
     while (hchild != INVALID_JOB)
@@ -371,7 +373,6 @@ static JobSystemResult CancelJobInternal(JobThreadContext* ctx, HJob hjob)
         hchild = child->m_Sibling;
     }
 
-    item->m_Status = JOBSYSTEM_STATUS_CANCELED;
     return result;
 }
 

--- a/engine/dlib/src/dlib/jobsystem.cpp
+++ b/engine/dlib/src/dlib/jobsystem.cpp
@@ -55,6 +55,8 @@ struct JobItem
     int32_atomic_t  m_NumChildrenCompleted;
 
     JobSystemStatus m_Status;
+    uint8_t         m_CancelRequested:1;
+    uint8_t         :7;
 };
 
 struct JobThreadContext
@@ -330,13 +332,16 @@ static JobSystemResult CancelJobInternal(JobThreadContext* ctx, HJob hjob)
     if (!item)
         return JOBSYSTEM_RESULT_INVALID_HANDLE;
 
-    if (item->m_Status == JOBSYSTEM_STATUS_PROCESSING)
+    if (item->m_Status == JOBSYSTEM_STATUS_PROCESSING || item->m_Status == JOBSYSTEM_STATUS_CALLBACK)
     {
+        item->m_CancelRequested = 1;
         return JOBSYSTEM_RESULT_PENDING;
     }
     if (item->m_Status == JOBSYSTEM_STATUS_FINISHED)
     {
-        return JOBSYSTEM_RESULT_OK;
+        item->m_Status = JOBSYSTEM_STATUS_CANCELED;
+        item->m_Result = 0;
+        return JOBSYSTEM_RESULT_CANCELED;
     }
 
     // Can only cancel queued/created items directly, but still wait on children when already canceled
@@ -405,17 +410,23 @@ static void PutDone(JobThreadContext* ctx, HJob hjob, JobSystemStatus status, in
 {
     DM_MUTEX_OPTIONAL_SCOPED_LOCK(ctx->m_Mutex);
 
-    if (ctx->m_Done.Full())
-        ctx->m_Done.OffsetCapacity(16);
-    ctx->m_Done.Push(hjob);
-
     uint32_t generation = ToGeneration(hjob);
     uint32_t index      = ToIndex(hjob);
     JobItem& item = ctx->m_Items.Get(index);
     assert(item.m_Generation == generation);
 
+    if (status == JOBSYSTEM_STATUS_FINISHED && item.m_CancelRequested)
+    {
+        status = JOBSYSTEM_STATUS_CANCELED;
+        result = 0;
+    }
+
     item.m_Status = status;
     item.m_Result = result;
+
+    if (ctx->m_Done.Full())
+        ctx->m_Done.OffsetCapacity(16);
+    ctx->m_Done.Push(hjob);
 
     if (item.m_Parent != INVALID_JOB)
     {
@@ -584,6 +595,7 @@ static void ProcessFinishedJobs(HJobContext context, jc::RingBuffer<HJob>& items
             }
 
             item = *_item;
+            _item->m_Status = JOBSYSTEM_STATUS_CALLBACK;
         }
 
         Job& job = item.m_Job;

--- a/engine/dlib/src/dmsdk/dlib/jobsystem.h
+++ b/engine/dlib/src/dmsdk/dlib/jobsystem.h
@@ -210,7 +210,7 @@ enum JobSystemResult JobSystemPushJob(HJobContext context, HJob job);
  * @name JobSystemCancelJob
  * @param context [type:HJobContext] the job system context
  * @param job [type:HJob] the job to cancel
- * @return result [type:JobSystemResult] Returns JOBSYSTEM_RESULT_OK if finished, JOBSYSTEM_RESULT_CANCELED if canceled, or JOBSYSTEM_RESULT_PENDING if the job (or any child) is still in flight
+ * @return result [type:JobSystemResult] Returns JOBSYSTEM_RESULT_CANCELED if canceled, JOBSYSTEM_RESULT_PENDING if the job (or any child) is still in flight, or JOBSYSTEM_RESULT_INVALID_HANDLE if the handle is invalid
  * @examples
  * How to wait until a job has been cancelled or finished
  * ```c
@@ -220,6 +220,8 @@ enum JobSystemResult JobSystemPushJob(HJobContext context, HJob job);
  *     dmTime::Sleep(1000);
  *     jr = JobSystemCancelJob(job_context, hjob);
  * }
+ * // If the loop observed PENDING before this point, INVALID_HANDLE means the
+ * // job was flushed by JobSystemUpdate() between polls.
  * ```
  */
 enum JobSystemResult JobSystemCancelJob(HJobContext context, HJob job);

--- a/engine/dlib/src/dmsdk/dlib/jobsystem.h
+++ b/engine/dlib/src/dmsdk/dlib/jobsystem.h
@@ -57,7 +57,8 @@ typedef struct JobContext* HJobContext;
  * @member JOBSYSTEM_STATUS_QUEUED 2
  * @member JOBSYSTEM_STATUS_PROCESSING 3
  * @member JOBSYSTEM_STATUS_FINISHED 4
- * @member JOBSYSTEM_STATUS_CANCELED 5
+ * @member JOBSYSTEM_STATUS_CALLBACK 5
+ * @member JOBSYSTEM_STATUS_CANCELED 6
  */
 enum JobSystemStatus
 {
@@ -66,7 +67,8 @@ enum JobSystemStatus
     JOBSYSTEM_STATUS_QUEUED           = 2,
     JOBSYSTEM_STATUS_PROCESSING       = 3,
     JOBSYSTEM_STATUS_FINISHED         = 4,
-    JOBSYSTEM_STATUS_CANCELED         = 5,
+    JOBSYSTEM_STATUS_CALLBACK         = 5,
+    JOBSYSTEM_STATUS_CANCELED         = 6,
 };
 
 /*# job result enumeration

--- a/engine/dlib/src/test/test_job_system.cpp
+++ b/engine/dlib/src/test/test_job_system.cpp
@@ -437,6 +437,11 @@ static int32_t ProcessBlockingChild(HJobContext ctx, HJob job, void* user_contex
 
 static void CallbackBlockingChild(HJobContext ctx, HJob job, JobSystemStatus status, void* user_context, void* user_data, int32_t user_result)
 {
+    if (status != JOBSYSTEM_STATUS_FINISHED)
+    {
+        return;
+    }
+
     CancelPendingParentTrack* track = (CancelPendingParentTrack*)user_context;
     track->m_ChildCallbackStatus = status;
     dmAtomicIncrement32(&track->m_ChildCallbackCalled);
@@ -445,6 +450,83 @@ static void CallbackBlockingChild(HJobContext ctx, HJob job, JobSystemStatus sta
     {
         dmAtomicIncrement32(&track->m_ChildCallbackAfterResourceRelease);
     }
+}
+
+struct BlockingCallbackTrack
+{
+    HJobContext     m_JobSystem;
+    int32_atomic_t  m_CallbackStarted;
+    int32_atomic_t  m_AllowCallbackFinish;
+    int32_atomic_t  m_CallbackFinished;
+    int32_atomic_t  m_StopUpdateThread;
+    JobSystemStatus m_CallbackStatus;
+};
+
+static void CallbackBlocking(HJobContext ctx, HJob job, JobSystemStatus status, void* user_context, void* user_data, int32_t user_result)
+{
+    BlockingCallbackTrack* track = (BlockingCallbackTrack*)user_context;
+    track->m_CallbackStatus = status;
+    dmAtomicIncrement32(&track->m_CallbackStarted);
+
+    while (!dmAtomicGet32(&track->m_AllowCallbackFinish) && !dmAtomicGet32(&track->m_StopUpdateThread))
+    {
+        dmTime::Sleep(1000);
+    }
+
+    dmAtomicIncrement32(&track->m_CallbackFinished);
+}
+
+static void UpdateUntilCallbackStarted(void* user_data)
+{
+    BlockingCallbackTrack* track = (BlockingCallbackTrack*)user_data;
+    while (!dmAtomicGet32(&track->m_CallbackStarted) && !dmAtomicGet32(&track->m_StopUpdateThread))
+    {
+        JobSystemUpdate(track->m_JobSystem, 0);
+        dmTime::Sleep(1000);
+    }
+}
+
+TEST_P(dmJobSystemTest, CancelJobDuringCallbackReportsPending)
+{
+    if (GetParam().m_NumThreads == 0)
+    {
+        return;
+    }
+
+    BlockingCallbackTrack track = {};
+    track.m_JobSystem = m_JobSystem;
+    track.m_CallbackStatus = JOBSYSTEM_STATUS_FREE;
+
+    Job job = {};
+    job.m_Process = ProcessSimple;
+    job.m_Callback = CallbackBlocking;
+    job.m_Context = &track;
+
+    HJob hjob = JobSystemCreateJob(m_JobSystem, &job);
+    ASSERT_NE((HJob)0, hjob);
+    ASSERT_EQ(JOBSYSTEM_RESULT_OK, JobSystemPushJob(m_JobSystem, hjob));
+
+    dmThread::Thread update_thread = dmThread::New(UpdateUntilCallbackStarted, 0x80000, &track, "jobupd");
+    ASSERT_NE((dmThread::Thread)0, update_thread);
+
+    if (!WaitForAtomicValue(&track.m_CallbackStarted, 1, 500000))
+    {
+        dmAtomicStore32(&track.m_StopUpdateThread, 1);
+        dmAtomicStore32(&track.m_AllowCallbackFinish, 1);
+        dmThread::Join(update_thread);
+        ASSERT_EQ(1, dmAtomicGet32(&track.m_CallbackStarted));
+    }
+
+    JobSystemResult cancel_result = JobSystemCancelJob(m_JobSystem, hjob);
+    int callback_finished_before_release = dmAtomicGet32(&track.m_CallbackFinished);
+
+    dmAtomicStore32(&track.m_AllowCallbackFinish, 1);
+    dmThread::Join(update_thread);
+
+    ASSERT_EQ(JOBSYSTEM_RESULT_PENDING, cancel_result);
+    ASSERT_EQ(0, callback_finished_before_release);
+    ASSERT_EQ(1, dmAtomicGet32(&track.m_CallbackFinished));
+    ASSERT_EQ(JOBSYSTEM_STATUS_FINISHED, track.m_CallbackStatus);
 }
 
 // This tests that cancelling the parent after one of the children (not the last one) has finished.

--- a/engine/dlib/src/test/test_job_system.cpp
+++ b/engine/dlib/src/test/test_job_system.cpp
@@ -529,6 +529,8 @@ static void UpdateUntilCallbackStarted(void* user_data)
     }
 }
 
+// A finished-but-not-yet-flushed job should be converted to a canceled callback
+// when cancellation happens before JobSystemUpdate() runs callbacks.
 TEST_P(dmJobSystemTest, CancelFinishedJobBeforeUpdateReportsCanceled)
 {
     if (GetParam().m_NumThreads == 0)
@@ -572,6 +574,8 @@ TEST_P(dmJobSystemTest, CancelFinishedJobBeforeUpdateReportsCanceled)
     ASSERT_EQ(0, track.m_CallbackResult);
 }
 
+// Canceling a job whose callback is already running must stay pending until
+// the callback exits, so owners do not release callback-owned memory too early.
 TEST_P(dmJobSystemTest, CancelJobDuringCallbackReportsPending)
 {
     if (GetParam().m_NumThreads == 0)
@@ -615,6 +619,8 @@ TEST_P(dmJobSystemTest, CancelJobDuringCallbackReportsPending)
     ASSERT_EQ(JOBSYSTEM_STATUS_FINISHED, track.m_CallbackStatus);
 }
 
+// Canceling a parent must stay pending while one of its child callbacks is
+// already running, since the callback can still access shared job data.
 TEST_P(dmJobSystemTest, CancelParentDuringChildCallbackReportsPending)
 {
     if (GetParam().m_NumThreads == 0)
@@ -845,6 +851,8 @@ TEST_P(dmJobSystemTest, CancelParentAfterChild)
     }
 }
 
+// A canceled parent with an in-flight child must not report cancellation
+// complete until the child has finished and its callback has been suppressed.
 TEST_P(dmJobSystemTest, CancelPendingParentWithFinishedChildBeforeUpdate)
 {
     if (GetParam().m_NumThreads == 0)
@@ -906,6 +914,8 @@ TEST_P(dmJobSystemTest, CancelPendingParentWithFinishedChildBeforeUpdate)
     ASSERT_EQ(JOBSYSTEM_STATUS_FREE, track.m_ChildCallbackStatus);
 }
 
+// If both parent and child have finished before callbacks are flushed,
+// canceling the parent should still suppress the queued child callback.
 TEST_P(dmJobSystemTest, CancelFinishedParentWithFinishedChildBeforeUpdate)
 {
     if (GetParam().m_NumThreads == 0)

--- a/engine/dlib/src/test/test_job_system.cpp
+++ b/engine/dlib/src/test/test_job_system.cpp
@@ -403,6 +403,7 @@ struct CancelPendingParentTrack
     int32_atomic_t      m_ChildProcessEntered;
     int32_atomic_t      m_AllowChildProcessFinish;
     int32_atomic_t      m_ChildProcessFinished;
+    int32_atomic_t      m_ParentProcessFinished;
     int32_atomic_t      m_ResourceAlive;
     int32_atomic_t      m_ChildCallbackCalled;
     int32_atomic_t      m_ChildCallbackAfterResourceRelease;
@@ -432,6 +433,17 @@ static int32_t ProcessBlockingChild(HJobContext ctx, HJob job, void* user_contex
     }
 
     dmAtomicStore32(&track->m_ChildProcessFinished, 1);
+    return 1;
+}
+
+static int32_t ProcessTrackedParent(HJobContext ctx, HJob job, void* user_context, void* user_data)
+{
+    (void)ctx;
+    (void)job;
+    (void)user_data;
+
+    CancelPendingParentTrack* track = (CancelPendingParentTrack*)user_context;
+    dmAtomicStore32(&track->m_ParentProcessFinished, 1);
     return 1;
 }
 
@@ -757,6 +769,50 @@ TEST_P(dmJobSystemTest, CancelPendingParentWithFinishedChildBeforeUpdate)
     }
 
     ASSERT_EQ(JOBSYSTEM_RESULT_CANCELED, result);
+
+    dmAtomicStore32(&track.m_ResourceAlive, 0);
+    JobSystemUpdate(m_JobSystem, 0);
+
+    ASSERT_EQ(0, dmAtomicGet32(&track.m_ChildCallbackAfterResourceRelease));
+    ASSERT_EQ(0, dmAtomicGet32(&track.m_ChildCallbackCalled));
+    ASSERT_EQ(JOBSYSTEM_STATUS_FREE, track.m_ChildCallbackStatus);
+}
+
+TEST_P(dmJobSystemTest, CancelFinishedParentWithFinishedChildBeforeUpdate)
+{
+    if (GetParam().m_NumThreads == 0)
+    {
+        return;
+    }
+
+    CancelPendingParentTrack track = {};
+    track.m_ResourceAlive = 1;
+    track.m_ChildCallbackStatus = JOBSYSTEM_STATUS_FREE;
+    dmAtomicStore32(&track.m_AllowChildProcessFinish, 1);
+
+    Job parent_job = {};
+    parent_job.m_Process = ProcessTrackedParent;
+    parent_job.m_Context = &track;
+
+    HJob parent_hjob = JobSystemCreateJob(m_JobSystem, &parent_job);
+    ASSERT_NE((HJob)0, parent_hjob);
+
+    Job child_job = {};
+    child_job.m_Process = ProcessBlockingChild;
+    child_job.m_Callback = CallbackBlockingChild;
+    child_job.m_Context = &track;
+
+    HJob child_hjob = JobSystemCreateJob(m_JobSystem, &child_job);
+    ASSERT_NE((HJob)0, child_hjob);
+    ASSERT_EQ(JOBSYSTEM_RESULT_OK, JobSystemSetParent(m_JobSystem, child_hjob, parent_hjob));
+
+    ASSERT_EQ(JOBSYSTEM_RESULT_OK, JobSystemPushJob(m_JobSystem, child_hjob));
+    ASSERT_EQ(JOBSYSTEM_RESULT_OK, JobSystemPushJob(m_JobSystem, parent_hjob));
+
+    ASSERT_TRUE(WaitForAtomicValue(&track.m_ChildProcessFinished, 1, 500000));
+    ASSERT_TRUE(WaitForAtomicValue(&track.m_ParentProcessFinished, 1, 500000));
+
+    ASSERT_EQ(JOBSYSTEM_RESULT_CANCELED, JobSystemCancelJob(m_JobSystem, parent_hjob));
 
     dmAtomicStore32(&track.m_ResourceAlive, 0);
     JobSystemUpdate(m_JobSystem, 0);

--- a/engine/dlib/src/test/test_job_system.cpp
+++ b/engine/dlib/src/test/test_job_system.cpp
@@ -398,6 +398,55 @@ static void CallbackCancelParent(HJobContext ctx, HJob job, JobSystemStatus stat
     dmAtomicIncrement32(&parent->m_CallbackCalled);
 }
 
+struct CancelPendingParentTrack
+{
+    int32_atomic_t      m_ChildProcessEntered;
+    int32_atomic_t      m_AllowChildProcessFinish;
+    int32_atomic_t      m_ChildProcessFinished;
+    int32_atomic_t      m_ResourceAlive;
+    int32_atomic_t      m_ChildCallbackCalled;
+    int32_atomic_t      m_ChildCallbackAfterResourceRelease;
+    JobSystemStatus     m_ChildCallbackStatus;
+};
+
+static bool WaitForAtomicValue(int32_atomic_t* value, int32_t expected, uint64_t timeout)
+{
+    uint64_t stop_time = dmTime::GetMonotonicTime() + timeout;
+    while (dmTime::GetMonotonicTime() < stop_time)
+    {
+        if (dmAtomicGet32(value) == expected)
+            return true;
+        dmTime::Sleep(1000);
+    }
+    return dmAtomicGet32(value) == expected;
+}
+
+static int32_t ProcessBlockingChild(HJobContext ctx, HJob job, void* user_context, void* user_data)
+{
+    CancelPendingParentTrack* track = (CancelPendingParentTrack*)user_context;
+    dmAtomicStore32(&track->m_ChildProcessEntered, 1);
+
+    while (!dmAtomicGet32(&track->m_AllowChildProcessFinish))
+    {
+        dmTime::Sleep(1000);
+    }
+
+    dmAtomicStore32(&track->m_ChildProcessFinished, 1);
+    return 1;
+}
+
+static void CallbackBlockingChild(HJobContext ctx, HJob job, JobSystemStatus status, void* user_context, void* user_data, int32_t user_result)
+{
+    CancelPendingParentTrack* track = (CancelPendingParentTrack*)user_context;
+    track->m_ChildCallbackStatus = status;
+    dmAtomicIncrement32(&track->m_ChildCallbackCalled);
+
+    if (!dmAtomicGet32(&track->m_ResourceAlive))
+    {
+        dmAtomicIncrement32(&track->m_ChildCallbackAfterResourceRelease);
+    }
+}
+
 // This tests that cancelling the parent after one of the children (not the last one) has finished.
 // doesn't mess up the internal list of children.
 TEST_P(dmJobSystemTest, CancelParentAfterChild)
@@ -572,6 +621,67 @@ TEST_P(dmJobSystemTest, CancelParentAfterChild)
             }
         }
     }
+}
+
+TEST_P(dmJobSystemTest, CancelPendingParentWithFinishedChildBeforeUpdate)
+{
+    if (GetParam().m_NumThreads == 0)
+    {
+        return;
+    }
+
+    CancelPendingParentTrack track = {};
+    track.m_ResourceAlive = 1;
+    track.m_ChildCallbackStatus = JOBSYSTEM_STATUS_FREE;
+
+    Job parent_job = {};
+    parent_job.m_Process = ProcessSimple;
+
+    HJob parent_hjob = JobSystemCreateJob(m_JobSystem, &parent_job);
+    ASSERT_NE((HJob)0, parent_hjob);
+
+    Job child_job = {};
+    child_job.m_Process = ProcessBlockingChild;
+    child_job.m_Callback = CallbackBlockingChild;
+    child_job.m_Context = &track;
+
+    HJob child_hjob = JobSystemCreateJob(m_JobSystem, &child_job);
+    ASSERT_NE((HJob)0, child_hjob);
+    ASSERT_EQ(JOBSYSTEM_RESULT_OK, JobSystemSetParent(m_JobSystem, child_hjob, parent_hjob));
+
+    ASSERT_EQ(JOBSYSTEM_RESULT_OK, JobSystemPushJob(m_JobSystem, child_hjob));
+    ASSERT_EQ(JOBSYSTEM_RESULT_OK, JobSystemPushJob(m_JobSystem, parent_hjob));
+
+    ASSERT_TRUE(WaitForAtomicValue(&track.m_ChildProcessEntered, 1, 500000));
+
+    // Mirrors the dynamic font crash repro: the resource tracks the sentinel
+    // parent job, starts canceling it while a glyph child job is processing, and
+    // frees the shared job data once cancellation stops returning PENDING.
+    ASSERT_EQ(JOBSYSTEM_RESULT_PENDING, JobSystemCancelJob(m_JobSystem, parent_hjob));
+
+    dmAtomicStore32(&track.m_AllowChildProcessFinish, 1);
+    ASSERT_TRUE(WaitForAtomicValue(&track.m_ChildProcessFinished, 1, 500000));
+
+    JobSystemResult result = JOBSYSTEM_RESULT_PENDING;
+    uint64_t stop_time = dmTime::GetMonotonicTime() + 500000;
+    while (dmTime::GetMonotonicTime() < stop_time)
+    {
+        result = JobSystemCancelJob(m_JobSystem, parent_hjob);
+        if (result != JOBSYSTEM_RESULT_PENDING)
+        {
+            break;
+        }
+        dmTime::Sleep(1000);
+    }
+
+    ASSERT_EQ(JOBSYSTEM_RESULT_CANCELED, result);
+
+    dmAtomicStore32(&track.m_ResourceAlive, 0);
+    JobSystemUpdate(m_JobSystem, 0);
+
+    ASSERT_EQ(0, dmAtomicGet32(&track.m_ChildCallbackAfterResourceRelease));
+    ASSERT_EQ(0, dmAtomicGet32(&track.m_ChildCallbackCalled));
+    ASSERT_EQ(JOBSYSTEM_STATUS_FREE, track.m_ChildCallbackStatus);
 }
 
 

--- a/engine/dlib/src/test/test_job_system.cpp
+++ b/engine/dlib/src/test/test_job_system.cpp
@@ -410,6 +410,14 @@ struct CancelPendingParentTrack
     JobSystemStatus     m_ChildCallbackStatus;
 };
 
+struct FinishedBeforeUpdateTrack
+{
+    int32_atomic_t      m_ProcessFinished;
+    int32_atomic_t      m_CallbackCalled;
+    JobSystemStatus     m_CallbackStatus;
+    int32_t             m_CallbackResult;
+};
+
 static bool WaitForAtomicValue(int32_atomic_t* value, int32_t expected, uint64_t timeout)
 {
     uint64_t stop_time = dmTime::GetMonotonicTime() + timeout;
@@ -420,6 +428,29 @@ static bool WaitForAtomicValue(int32_atomic_t* value, int32_t expected, uint64_t
         dmTime::Sleep(1000);
     }
     return dmAtomicGet32(value) == expected;
+}
+
+static int32_t ProcessFinishedBeforeUpdate(HJobContext ctx, HJob job, void* user_context, void* user_data)
+{
+    (void)ctx;
+    (void)job;
+    (void)user_data;
+
+    FinishedBeforeUpdateTrack* track = (FinishedBeforeUpdateTrack*)user_context;
+    dmAtomicStore32(&track->m_ProcessFinished, 1);
+    return 1;
+}
+
+static void CallbackFinishedBeforeUpdate(HJobContext ctx, HJob job, JobSystemStatus status, void* user_context, void* user_data, int32_t user_result)
+{
+    (void)ctx;
+    (void)job;
+    (void)user_data;
+
+    FinishedBeforeUpdateTrack* track = (FinishedBeforeUpdateTrack*)user_context;
+    track->m_CallbackStatus = status;
+    track->m_CallbackResult = user_result;
+    dmAtomicIncrement32(&track->m_CallbackCalled);
 }
 
 static int32_t ProcessBlockingChild(HJobContext ctx, HJob job, void* user_context, void* user_data)
@@ -498,6 +529,49 @@ static void UpdateUntilCallbackStarted(void* user_data)
     }
 }
 
+TEST_P(dmJobSystemTest, CancelFinishedJobBeforeUpdateReportsCanceled)
+{
+    if (GetParam().m_NumThreads == 0)
+    {
+        return;
+    }
+
+    FinishedBeforeUpdateTrack track = {};
+    track.m_CallbackStatus = JOBSYSTEM_STATUS_FREE;
+
+    Job job = {};
+    job.m_Process = ProcessFinishedBeforeUpdate;
+    job.m_Callback = CallbackFinishedBeforeUpdate;
+    job.m_Context = &track;
+
+    HJob hjob = JobSystemCreateJob(m_JobSystem, &job);
+    ASSERT_NE((HJob)0, hjob);
+    ASSERT_EQ(JOBSYSTEM_RESULT_OK, JobSystemPushJob(m_JobSystem, hjob));
+
+    ASSERT_TRUE(WaitForAtomicValue(&track.m_ProcessFinished, 1, 500000));
+
+    JobSystemResult result = JOBSYSTEM_RESULT_PENDING;
+    uint64_t stop_time = dmTime::GetMonotonicTime() + 500000;
+    while (dmTime::GetMonotonicTime() < stop_time)
+    {
+        result = JobSystemCancelJob(m_JobSystem, hjob);
+        if (result != JOBSYSTEM_RESULT_PENDING)
+        {
+            break;
+        }
+        dmTime::Sleep(1000);
+    }
+
+    ASSERT_EQ(JOBSYSTEM_RESULT_CANCELED, result);
+    ASSERT_EQ(0, dmAtomicGet32(&track.m_CallbackCalled));
+
+    JobSystemUpdate(m_JobSystem, 0);
+
+    ASSERT_EQ(1, dmAtomicGet32(&track.m_CallbackCalled));
+    ASSERT_EQ(JOBSYSTEM_STATUS_CANCELED, track.m_CallbackStatus);
+    ASSERT_EQ(0, track.m_CallbackResult);
+}
+
 TEST_P(dmJobSystemTest, CancelJobDuringCallbackReportsPending)
 {
     if (GetParam().m_NumThreads == 0)
@@ -539,6 +613,60 @@ TEST_P(dmJobSystemTest, CancelJobDuringCallbackReportsPending)
     ASSERT_EQ(0, callback_finished_before_release);
     ASSERT_EQ(1, dmAtomicGet32(&track.m_CallbackFinished));
     ASSERT_EQ(JOBSYSTEM_STATUS_FINISHED, track.m_CallbackStatus);
+}
+
+TEST_P(dmJobSystemTest, CancelParentDuringChildCallbackReportsPending)
+{
+    if (GetParam().m_NumThreads == 0)
+    {
+        return;
+    }
+
+    BlockingCallbackTrack track = {};
+    track.m_JobSystem = m_JobSystem;
+    track.m_CallbackStatus = JOBSYSTEM_STATUS_FREE;
+
+    Job parent_job = {};
+    parent_job.m_Process = ProcessSimple;
+
+    HJob parent_hjob = JobSystemCreateJob(m_JobSystem, &parent_job);
+    ASSERT_NE((HJob)0, parent_hjob);
+
+    Job child_job = {};
+    child_job.m_Process = ProcessSimple;
+    child_job.m_Callback = CallbackBlocking;
+    child_job.m_Context = &track;
+
+    HJob child_hjob = JobSystemCreateJob(m_JobSystem, &child_job);
+    ASSERT_NE((HJob)0, child_hjob);
+    ASSERT_EQ(JOBSYSTEM_RESULT_OK, JobSystemSetParent(m_JobSystem, child_hjob, parent_hjob));
+
+    ASSERT_EQ(JOBSYSTEM_RESULT_OK, JobSystemPushJob(m_JobSystem, child_hjob));
+    ASSERT_EQ(JOBSYSTEM_RESULT_OK, JobSystemPushJob(m_JobSystem, parent_hjob));
+
+    dmThread::Thread update_thread = dmThread::New(UpdateUntilCallbackStarted, 0x80000, &track, "jobupd");
+    ASSERT_NE((dmThread::Thread)0, update_thread);
+
+    if (!WaitForAtomicValue(&track.m_CallbackStarted, 1, 500000))
+    {
+        dmAtomicStore32(&track.m_StopUpdateThread, 1);
+        dmAtomicStore32(&track.m_AllowCallbackFinish, 1);
+        dmThread::Join(update_thread);
+        ASSERT_EQ(1, dmAtomicGet32(&track.m_CallbackStarted));
+    }
+
+    JobSystemResult cancel_result = JobSystemCancelJob(m_JobSystem, parent_hjob);
+    int callback_finished_before_release = dmAtomicGet32(&track.m_CallbackFinished);
+
+    dmAtomicStore32(&track.m_AllowCallbackFinish, 1);
+    dmThread::Join(update_thread);
+
+    ASSERT_EQ(JOBSYSTEM_RESULT_PENDING, cancel_result);
+    ASSERT_EQ(0, callback_finished_before_release);
+    ASSERT_EQ(1, dmAtomicGet32(&track.m_CallbackFinished));
+    ASSERT_EQ(JOBSYSTEM_STATUS_FINISHED, track.m_CallbackStatus);
+
+    JobSystemUpdate(m_JobSystem, 0);
 }
 
 // This tests that cancelling the parent after one of the children (not the last one) has finished.

--- a/engine/gamesys/src/gamesys/fontgen/fontgen.cpp
+++ b/engine/gamesys/src/gamesys/fontgen/fontgen.cpp
@@ -276,8 +276,17 @@ static int JobProcessSentinelGlyph(HJobContext job_thread, HJob hjob, void* cont
 
 static void JobPostProcessSentinelGlyph(HJobContext job_thread, HJob hjob, JobSystemStatus job_status, void* context, void* data, int result)
 {
-    FontGenJobData* jobdata = (FontGenJobData*)context;
+    (void)job_thread;
+    (void)hjob;
     (void)data;
+    (void)result;
+
+    if (job_status != JOBSYSTEM_STATUS_FINISHED)
+    {
+        return;
+    }
+
+    FontGenJobData* jobdata = (FontGenJobData*)context;
 
 #if defined(FONTGEN_DEBUG)
     uint32_t count = jobdata->m_Items.Size();
@@ -296,6 +305,14 @@ static void JobPostProcessSentinelGlyph(HJobContext job_thread, HJob hjob, JobSy
 // Called on the main thread
 static void JobPostProcessGlyph(HJobContext job_thread, HJob job, JobSystemStatus job_status, void* context, void* data, int result)
 {
+    (void)job_thread;
+    (void)job;
+
+    if (job_status != JOBSYSTEM_STATUS_FINISHED)
+    {
+        return;
+    }
+
     FontGenJobData* jobdata = (FontGenJobData*)context;
     JobItem* item = (JobItem*)data;
 

--- a/engine/gamesys/src/gamesys/resources/res_font.cpp
+++ b/engine/gamesys/src/gamesys/resources/res_font.cpp
@@ -222,10 +222,18 @@ namespace dmGameSystem
 
         FPrewarmTextCallback callback = job_info->m_Callback;
         void* callback_context = job_info->m_CallbackContext;
+        char errmsg_copy[128];
+        const char* callback_errmsg = 0;
+        if (errmsg)
+        {
+            dmStrlCpy(errmsg_copy, errmsg, sizeof(errmsg_copy));
+            callback_errmsg = errmsg_copy;
+        }
+
         DestroyJobInfo(job_info);
 
         if (callback)
-            callback(callback_context, result, errmsg);
+            callback(callback_context, result, callback_errmsg);
     }
 
     dmResource::Result ResFontPrewarmText(FontResource* resource, const char* text, FPrewarmTextCallback cbk, void* cbk_ctx)

--- a/engine/gamesys/src/gamesys/resources/res_font.cpp
+++ b/engine/gamesys/src/gamesys/resources/res_font.cpp
@@ -113,6 +113,12 @@ namespace dmGameSystem
 
     static void CancelPendingJobs(FontResource* font)
     {
+        if (font->m_PendingJobs.Empty())
+        {
+            return;
+        }
+
+        font->m_Destroying = 1;
         for (uint32_t i = 0; i < font->m_PendingJobs.Size(); ++i)
         {
             FontJobResourceInfo* job_info = font->m_PendingJobs[i];
@@ -129,6 +135,7 @@ namespace dmGameSystem
             DeallocateJobResourceInfo(job_info);
         }
         font->m_PendingJobs.SetSize(0);
+        font->m_Destroying = 0;
     }
 
     static void ReleaseResourceIter(void* ctx, const uint64_t* hash, TTFResource** presource)
@@ -212,9 +219,13 @@ namespace dmGameSystem
     static void TextCallbackJobInfo(void* cbk_ctx, int result, const char* errmsg)
     {
         FontJobResourceInfo* job_info = (FontJobResourceInfo*)cbk_ctx;
-        if (job_info->m_Callback)
-            job_info->m_Callback(job_info->m_CallbackContext, result, errmsg);
+
+        FPrewarmTextCallback callback = job_info->m_Callback;
+        void* callback_context = job_info->m_CallbackContext;
         DestroyJobInfo(job_info);
+
+        if (callback)
+            callback(callback_context, result, errmsg);
     }
 
     dmResource::Result ResFontPrewarmText(FontResource* resource, const char* text, FPrewarmTextCallback cbk, void* cbk_ctx)
@@ -222,6 +233,11 @@ namespace dmGameSystem
         if (!resource->m_IsDynamic)
         {
             return dmResource::RESULT_NOT_SUPPORTED;
+        }
+
+        if (resource->m_Destroying)
+        {
+            return dmResource::RESULT_INVAL;
         }
 
         dmArray<uint32_t> codepoints;
@@ -539,6 +555,10 @@ namespace dmGameSystem
     static FontResult OnGlyphCacheMiss(void* user_ctx, dmRender::HFontMap font_map, HFont font, uint32_t glyph_index, FontGlyph** out)
     {
         FontResource* resource = (FontResource*)user_ctx;
+        if (resource->m_Destroying)
+        {
+            return FONT_RESULT_ERROR;
+        }
 
         // Increment all child resources (i.e. .ttf) before we send them to the thread
         FontJobResourceInfo* job_info = CreateJobResourceInfo(resource->m_Factory, resource, 1, 0, 0);

--- a/engine/gamesys/src/gamesys/resources/res_font_private.h
+++ b/engine/gamesys/src/gamesys/resources/res_font_private.h
@@ -62,6 +62,7 @@ namespace dmGameSystem
         uint8_t                 m_Padding;              // Extra space for outline + shadow
         uint8_t                 m_Prewarming:1;         // If true, it is currently waiting for glyphs to be prewamed (dynamic fonts only)
         uint8_t                 m_PrewarmDone:1;
+        uint8_t                 m_Destroying:1;
 
         dmHashTable64<TTFResource*> m_TTFResources;  // Maps path hash to a resource
         dmHashTable32<uint64_t>     m_FontHashes;    // Maps HFont path hash to a resource

--- a/engine/gamesys/src/gamesys/scripts/script_font.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_font.cpp
@@ -49,7 +49,6 @@ struct CallbackContext
     int                        m_Request;
 };
 
-
 /*#
  * associates a ttf resource to a .fontc file.
  * @note The ttf font is loaded via the resource system. There are a few ways it can be accessed:
@@ -217,24 +216,8 @@ static int PrewarmText(lua_State* L)
     dmhash_t fontc_path_hash = dmScript::CheckHashOrString(L, 1);
     const char* text = luaL_checkstring(L, 2);
 
-    dmScript::LuaCallbackInfo* luacbk = 0;
-    if (top > 2 && lua_isfunction(L, 3))
-    {
-        luacbk = dmScript::CreateCallback(L, 3);
-    }
-
     static int requests = 1;
     int request_id = requests++;
-
-    dmGameSystem::FPrewarmTextCallback callback = 0;
-    CallbackContext* cbk_ctx = 0;
-    if (luacbk)
-    {
-        callback = PrewarmTextCallback;
-        cbk_ctx = new CallbackContext;
-        cbk_ctx->m_Callback  = luacbk;
-        cbk_ctx->m_Request = request_id;
-    }
 
     dmGameSystem::FontResource* resource;
     dmResource::Result r = dmResource::GetWithExt(g_ResourceFactory, fontc_path_hash, EXT_HASH_FONTC, (void**)&resource);
@@ -243,10 +226,26 @@ static int PrewarmText(lua_State* L)
         return DM_LUA_ERROR("Failed to get font %s: %d", dmHashReverseSafe64(fontc_path_hash), r);
     }
 
+    dmGameSystem::FPrewarmTextCallback callback = 0;
+    CallbackContext* cbk_ctx = 0;
+    if (top > 2 && lua_isfunction(L, 3))
+    {
+        dmScript::LuaCallbackInfo* luacbk = dmScript::CreateCallback(L, 3);
+        callback = PrewarmTextCallback;
+        cbk_ctx = new CallbackContext;
+        cbk_ctx->m_Callback = luacbk;
+        cbk_ctx->m_Request = request_id;
+    }
+
     r = dmGameSystem::ResFontPrewarmText(resource, text, callback, cbk_ctx);
     if (dmResource::RESULT_OK != r)
     {
         dmResource::Release(g_ResourceFactory, resource);
+        if (cbk_ctx)
+        {
+            dmScript::DestroyCallback(cbk_ctx->m_Callback);
+            delete cbk_ctx;
+        }
         return DM_LUA_ERROR("Failed to add glyphs to font %s", dmHashReverseSafe64(fontc_path_hash));
     }
 
@@ -358,4 +357,3 @@ static dmExtension::Result ScriptFontFinalize(dmExtension::Params* params)
 DM_DECLARE_EXTENSION(ScriptFont, "ScriptFont", 0, 0, ScriptFontInitialize, 0, 0, ScriptFontFinalize)
 
 } // namespace
-

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -2985,7 +2985,99 @@ TEST_F(FontTest, DynamicGlyph)
     dmResource::Release(m_Factory, font);
 }
 
+struct DynamicFontJobCallbackState
+{
+    uint32_t                    m_CallbackCount;
+    int                         m_Result;
+    char                        m_ErrMsg[128];
+    dmResource::HFactory        m_Factory;
+    const char*                 m_Path;
+    uint32_t                    m_ReloadCount;
+    dmResource::Result          m_ReloadResult;
+};
+
+static void DynamicFontJobCallback(void* ctx, int result, const char* errmsg)
+{
+    DynamicFontJobCallbackState* state = (DynamicFontJobCallbackState*)ctx;
+    state->m_CallbackCount++;
+    state->m_Result = result;
+    dmStrlCpy(state->m_ErrMsg, errmsg ? errmsg : "", sizeof(state->m_ErrMsg));
+}
+
+static void DynamicFontJobReloadCallback(void* ctx, int result, const char* errmsg)
+{
+    DynamicFontJobCallback(ctx, result, errmsg);
+
+    DynamicFontJobCallbackState* state = (DynamicFontJobCallbackState*)ctx;
+    if (state->m_ReloadCount == 0)
+    {
+        state->m_ReloadCount++;
+        state->m_ReloadResult = dmResource::ReloadResource(state->m_Factory, state->m_Path, 0);
+    }
+}
+
+static bool WaitForDynamicFontJobCallbacks(HJobContext job_context, DynamicFontJobCallbackState* state, uint32_t callback_count)
+{
+    uint64_t stop_time = dmTime::GetMonotonicTime() + 500000;
+    while (state->m_CallbackCount < callback_count && dmTime::GetMonotonicTime() < stop_time)
+    {
+        JobSystemUpdate(job_context, 0);
+        dmTime::Sleep(1000);
+    }
+    return state->m_CallbackCount >= callback_count;
+}
+
 TEST_F(FontTest, ReloadCancelsPendingDynamicFontJobs)
+{
+    const char path_font[] = "/font/dyn_glyph_bank_test_1.fontc";
+    dmGameSystem::FontResource* font = 0;
+    DynamicFontJobCallbackState callback_state = {0, -1, {0}};
+
+    ASSERT_EQ(dmResource::RESULT_OK, dmResource::Get(m_Factory, path_font, (void**) &font));
+    ASSERT_NE((void*)0, font);
+    ASSERT_EQ(0u, font->m_PendingJobs.Size());
+
+    ASSERT_EQ(dmResource::RESULT_OK, dmGameSystem::ResFontPrewarmText(font, "Reload pending jobs", DynamicFontJobCallback, &callback_state));
+    ASSERT_GT(font->m_PendingJobs.Size(), 0u);
+
+    ASSERT_EQ(dmResource::RESULT_OK, dmResource::ReloadResource(m_Factory, path_font, 0));
+    ASSERT_EQ(0u, font->m_PendingJobs.Size());
+    ASSERT_EQ(0u, callback_state.m_CallbackCount);
+
+    JobSystemUpdate(m_JobContext, 0);
+    ASSERT_EQ(0u, callback_state.m_CallbackCount);
+
+    dmResource::Release(m_Factory, font);
+}
+
+TEST_F(FontTest, DynamicFontPrewarmCallbackCanReloadSameFont)
+{
+    const char path_font[] = "/font/dyn_glyph_bank_test_1.fontc";
+    dmGameSystem::FontResource* font = 0;
+    DynamicFontJobCallbackState callback_state = {0, -1, {0}};
+
+    ASSERT_EQ(dmResource::RESULT_OK, dmResource::Get(m_Factory, path_font, (void**) &font));
+    ASSERT_NE((void*)0, font);
+    ASSERT_EQ(0u, font->m_PendingJobs.Size());
+
+    callback_state.m_Factory = m_Factory;
+    callback_state.m_Path = path_font;
+    callback_state.m_ReloadResult = dmResource::RESULT_NOT_LOADED;
+
+    ASSERT_EQ(dmResource::RESULT_OK, dmGameSystem::ResFontPrewarmText(font, "Callback reloads same font", DynamicFontJobReloadCallback, &callback_state));
+    ASSERT_GT(font->m_PendingJobs.Size(), 0u);
+
+    ASSERT_TRUE(WaitForDynamicFontJobCallbacks(m_JobContext, &callback_state, 1));
+    ASSERT_EQ(1u, callback_state.m_CallbackCount);
+    ASSERT_EQ(1, callback_state.m_Result);
+    ASSERT_STREQ("", callback_state.m_ErrMsg);
+    ASSERT_EQ(1u, callback_state.m_ReloadCount);
+    ASSERT_EQ(dmResource::RESULT_OK, callback_state.m_ReloadResult);
+
+    dmResource::Release(m_Factory, font);
+}
+
+TEST_F(FontTest, DestroyingDynamicFontRejectsNewJobs)
 {
     const char path_font[] = "/font/dyn_glyph_bank_test_1.fontc";
     dmGameSystem::FontResource* font = 0;
@@ -2994,12 +3086,20 @@ TEST_F(FontTest, ReloadCancelsPendingDynamicFontJobs)
     ASSERT_NE((void*)0, font);
     ASSERT_EQ(0u, font->m_PendingJobs.Size());
 
-    ASSERT_EQ(dmResource::RESULT_OK, dmGameSystem::ResFontPrewarmText(font, "Reload pending jobs", 0, 0));
-    ASSERT_GT(font->m_PendingJobs.Size(), 0u);
-
-    ASSERT_EQ(dmResource::RESULT_OK, dmResource::ReloadResource(m_Factory, path_font, 0));
+    font->m_Destroying = 1;
+    ASSERT_EQ(dmResource::RESULT_INVAL, dmGameSystem::ResFontPrewarmText(font, "Rejected while destroying", 0, 0));
     ASSERT_EQ(0u, font->m_PendingJobs.Size());
 
+    dmRender::HFontMap font_map = dmGameSystem::ResFontGetHandle(font);
+    HFontCollection font_collection = dmRender::GetFontCollection(font_map);
+    HFont hfont = FontCollectionGetFont(font_collection, 0);
+
+    FontGlyph* glyph = 0;
+    ASSERT_EQ(FONT_RESULT_ERROR, GetGlyph(font_map, hfont, 'A', &glyph));
+    ASSERT_EQ((FontGlyph*)0, glyph);
+    ASSERT_EQ(0u, font->m_PendingJobs.Size());
+
+    font->m_Destroying = 0;
     dmResource::Release(m_Factory, font);
 }
 

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -3027,6 +3027,8 @@ static bool WaitForDynamicFontJobCallbacks(HJobContext job_context, DynamicFontJ
     return state->m_CallbackCount >= callback_count;
 }
 
+// Reloading a dynamic font with pending work must cancel the old jobs and
+// suppress callbacks after the old font state has been torn down.
 TEST_F(FontTest, ReloadCancelsPendingDynamicFontJobs)
 {
     const char path_font[] = "/font/dyn_glyph_bank_test_1.fontc";
@@ -3050,6 +3052,8 @@ TEST_F(FontTest, ReloadCancelsPendingDynamicFontJobs)
     dmResource::Release(m_Factory, font);
 }
 
+// Releasing a dynamic font with pending work must cancel the jobs and suppress
+// callbacks that would otherwise touch destroyed font job data.
 TEST_F(FontTest, ReleaseCancelsPendingDynamicFontJobs)
 {
     const char path_font[] = "/font/dyn_glyph_bank_test_1.fontc";
@@ -3070,6 +3074,8 @@ TEST_F(FontTest, ReleaseCancelsPendingDynamicFontJobs)
     ASSERT_EQ(0u, callback_state.m_CallbackCount);
 }
 
+// A successful prewarm callback may reload the same font because job ownership
+// is destroyed before invoking the user callback.
 TEST_F(FontTest, DynamicFontPrewarmCallbackCanReloadSameFont)
 {
     const char path_font[] = "/font/dyn_glyph_bank_test_1.fontc";
@@ -3097,6 +3103,8 @@ TEST_F(FontTest, DynamicFontPrewarmCallbackCanReloadSameFont)
     dmResource::Release(m_Factory, font);
 }
 
+// While a font resource is being destroyed, new dynamic glyph jobs must be
+// rejected from both explicit prewarm and cache-miss paths.
 TEST_F(FontTest, DestroyingDynamicFontRejectsNewJobs)
 {
     const char path_font[] = "/font/dyn_glyph_bank_test_1.fontc";

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -3050,6 +3050,26 @@ TEST_F(FontTest, ReloadCancelsPendingDynamicFontJobs)
     dmResource::Release(m_Factory, font);
 }
 
+TEST_F(FontTest, ReleaseCancelsPendingDynamicFontJobs)
+{
+    const char path_font[] = "/font/dyn_glyph_bank_test_1.fontc";
+    dmGameSystem::FontResource* font = 0;
+    DynamicFontJobCallbackState callback_state = {0, -1, {0}};
+
+    ASSERT_EQ(dmResource::RESULT_OK, dmResource::Get(m_Factory, path_font, (void**) &font));
+    ASSERT_NE((void*)0, font);
+    ASSERT_EQ(0u, font->m_PendingJobs.Size());
+
+    ASSERT_EQ(dmResource::RESULT_OK, dmGameSystem::ResFontPrewarmText(font, "Release pending jobs", DynamicFontJobCallback, &callback_state));
+    ASSERT_GT(font->m_PendingJobs.Size(), 0u);
+
+    dmResource::Release(m_Factory, font);
+    ASSERT_EQ(0u, callback_state.m_CallbackCount);
+
+    JobSystemUpdate(m_JobContext, 0);
+    ASSERT_EQ(0u, callback_state.m_CallbackCount);
+}
+
 TEST_F(FontTest, DynamicFontPrewarmCallbackCanReloadSameFont)
 {
     const char path_font[] = "/font/dyn_glyph_bank_test_1.fontc";


### PR DESCRIPTION
Prevents pending dynamic font glyph jobs from using freed font job data during resource reload or destruction. Adds a regression test for canceling pending dynamic font jobs.

Fix https://github.com/defold/defold/issues/12437