### PR TITLE
Fix Box2D v2 gear joint body mapping

### DIFF
--- a/engine/gamesys/src/gamesys/scripts/box2d/v2/script_box2d_joint_v2.cpp
+++ b/engine/gamesys/src/gamesys/scripts/box2d/v2/script_box2d_joint_v2.cpp
@@ -1161,6 +1161,15 @@ namespace dmGameSystem
         B2DJointMeta* joint_meta = 0;
         b2Joint* joint1 = CheckJoint(L, 1, &joint_meta);
         b2Joint* joint2 = CheckJoint(L, 2);
+        if ((joint1->GetType() != e_revoluteJoint && joint1->GetType() != e_prismaticJoint) ||
+            (joint2->GetType() != e_revoluteJoint && joint2->GetType() != e_prismaticJoint))
+        {
+            return luaL_error(L, "gear joints can only connect revolute and prismatic joints.");
+        }
+        if (joint1->GetBodyB() == joint2->GetBodyB())
+        {
+            return luaL_error(L, "gear joints must connect joints with different secondary bodies.");
+        }
         b2World* world = joint1->GetBodyA()->GetWorld();
         if (world != joint2->GetBodyA()->GetWorld())
         {
@@ -1174,7 +1183,8 @@ namespace dmGameSystem
 
         b2GearJointDef def;
         ReadCommonDef(L, def_index, &def);
-        def.bodyA = joint1->GetBodyA();
+        // Box2D gear joints connect the secondary bodies of the two source joints.
+        def.bodyA = joint1->GetBodyB();
         def.bodyB = joint2->GetBodyB();
         def.joint1 = joint1;
         def.joint2 = joint2;

--- a/engine/gamesys/src/gamesys/test/collision_object/joint_test.script
+++ b/engine/gamesys/src/gamesys/test/collision_object/joint_test.script
@@ -51,8 +51,10 @@ local function test_native_b2d_joints(self)
 
     local body_a = b2d.get_body(self.a_coll)
     local body_b = b2d.get_body(self.b_coll)
+    local body_c = b2d.get_body(self.c_coll)
     assert(body_a ~= nil)
     assert(body_b ~= nil)
+    assert(body_c ~= nil)
 
     local managed_joint_id = "native_managed_joint"
     physics.create_joint(physics.JOINT_TYPE_SPRING, self.a_coll, managed_joint_id, zp, self.b_coll, zp)
@@ -231,8 +233,14 @@ local function test_native_b2d_joints(self)
         assert_near(b2d.joint.get_ratio(pulley_joint), 1.5)
         b2d.joint.destroy(pulley_joint)
 
+        local invalid_gear_revolute_joint = b2d.joint.create_revolute(body_a, body_b)
+        local invalid_gear_prismatic_joint = b2d.joint.create_prismatic(body_a, body_b)
+        assert_error(function() b2d.joint.create_gear(invalid_gear_revolute_joint, invalid_gear_prismatic_joint) end)
+        b2d.joint.destroy(invalid_gear_prismatic_joint)
+        b2d.joint.destroy(invalid_gear_revolute_joint)
+
         local gear_revolute_joint = b2d.joint.create_revolute(body_a, body_b)
-        local gear_prismatic_joint = b2d.joint.create_prismatic(body_a, body_b)
+        local gear_prismatic_joint = b2d.joint.create_prismatic(body_a, body_c)
         local gear_joint = b2d.joint.create_gear(gear_revolute_joint, gear_prismatic_joint, {
             ratio = 2,
         })
@@ -257,6 +265,8 @@ function init(self)
     self.a_coll = self.a .. "#collisionobject"
     self.b = "joint_test_b"
     self.b_coll = self.b .. "#collisionobject"
+    self.c = "joint_test_c"
+    self.c_coll = self.c .. "#joint_test_static_floor"
     self.joint_id = "test_joint"
 
     test_native_b2d_joints(self)


### PR DESCRIPTION
## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
