### PR TITLE
Use cgltf_accessor_unpack_floats for sparse float reading

### DIFF
--- a/engine/modelc/src/modelimporter_gltf.cpp
+++ b/engine/modelc/src/modelimporter_gltf.cpp
@@ -259,37 +259,44 @@ static float* ReadAccessorFloat(cgltf_accessor* accessor, uint32_t desired_num_c
     if (desired_num_components == 0)
         desired_num_components = num_components;
 
-    uint32_t size = accessor->count * num_components;
+    uint32_t source_size = accessor->count * num_components;
+    uint32_t size = source_size;
     if (desired_num_components > num_components)
         size = accessor->count * desired_num_components;
 
     *out_count = size;
     float* out = new float[size]; // Now the buffer will fit the max num components
-    float* writeptr = out;
 
     if (desired_num_components > num_components)
     {
-        for (uint32_t i = 0; i < accessor->count; ++i)
-        {
-            for (uint32_t j = 0; j < desired_num_components; ++j)
-                *writeptr++ = default_value;
-        }
-    }
-
-    writeptr = out;
-
-    for (uint32_t i = 0; i < accessor->count; ++i)
-    {
-        bool result = cgltf_accessor_read_float(accessor, i, writeptr, num_components);
-
-        if (!result)
+        float* packed = new float[source_size];
+        cgltf_size unpacked = cgltf_accessor_unpack_floats(accessor, packed, source_size);
+        if (unpacked != source_size)
         {
             printf("Couldn't read floats!\n");
+            delete[] packed;
             delete[] out;
             return 0;
         }
 
-        writeptr += desired_num_components;
+        for (uint32_t i = 0; i < accessor->count; ++i)
+        {
+            for (uint32_t j = 0; j < desired_num_components; ++j)
+            {
+                out[i * desired_num_components + j] = j < num_components ? packed[i * num_components + j] : default_value;
+            }
+        }
+
+        delete[] packed;
+        return out;
+    }
+
+    cgltf_size unpacked = cgltf_accessor_unpack_floats(accessor, out, source_size);
+    if (unpacked != source_size)
+    {
+        printf("Couldn't read floats!\n");
+        delete[] out;
+        return 0;
     }
 
     return out;

--- a/engine/modelc/src/modelimporter_gltf.cpp
+++ b/engine/modelc/src/modelimporter_gltf.cpp
@@ -1951,9 +1951,25 @@ static void LoadScene(Scene* scene, cgltf_data* data)
     GenerateRootBone(scene);
 }
 
+static bool ValidateGltfData(Scene* scene, cgltf_data* data)
+{
+    cgltf_result result = cgltf_validate(data);
+    if (result != cgltf_result_success)
+    {
+        char buf[128];
+        dmSnPrintf(buf, sizeof(buf), "Failed to validate gltf file: %s (%d)", GetResultStr(result), result);
+        printf("%s\n", buf);
+        SetLoadError(scene, buf);
+        return false;
+    }
+    return true;
+}
+
 static bool LoadFinalizeGltf(Scene* scene)
 {
     GltfData* data = (GltfData*)scene->m_OpaqueSceneData;
+    if (!ValidateGltfData(scene, data->m_Data))
+        return false;
     LoadScene(scene, data->m_Data);
     return scene->m_LoadError == 0;
 }
@@ -1961,12 +1977,7 @@ static bool LoadFinalizeGltf(Scene* scene)
 static bool ValidateGltf(Scene* scene)
 {
     GltfData* data = (GltfData*)scene->m_OpaqueSceneData;
-    cgltf_result result = cgltf_validate(data->m_Data);
-    if (result != cgltf_result_success)
-    {
-        printf("Failed to validate gltf file: %s (%d)\n", GetResultStr(result), result);
-    }
-    return result == cgltf_result_success;
+    return ValidateGltfData(scene, data->m_Data);
 }
 
 static void DestroyGltf(Scene* scene)

--- a/engine/modelc/src/modelimporter_gltf.cpp
+++ b/engine/modelc/src/modelimporter_gltf.cpp
@@ -361,6 +361,98 @@ static float* ReadAccessorMatrix4(cgltf_accessor* accessor, uint32_t index, floa
     return out;
 }
 
+static bool ReadSparseIndex(const uint8_t* data, cgltf_component_type component_type, cgltf_size* out)
+{
+    switch (component_type)
+    {
+        case cgltf_component_type_r_8u:
+            *out = *data;
+            return true;
+        case cgltf_component_type_r_16u:
+        {
+            uint16_t value;
+            memcpy(&value, data, sizeof(value));
+            *out = value;
+            return true;
+        }
+        case cgltf_component_type_r_32u:
+        {
+            uint32_t value;
+            memcpy(&value, data, sizeof(value));
+            *out = value;
+            return true;
+        }
+        default:
+            return false;
+    }
+}
+
+static bool ValidateSparseAccessorsForUnpack(Scene* scene, cgltf_data* data)
+{
+    for (cgltf_size i = 0; i < data->accessors_count; ++i)
+    {
+        cgltf_accessor* accessor = &data->accessors[i];
+        if (!accessor->is_sparse)
+            continue;
+
+        cgltf_size element_size = cgltf_calc_size(accessor->type, accessor->component_type);
+        if (element_size == 0)
+        {
+            SetLoadError(scene, "Invalid sparse accessor component type.");
+            return false;
+        }
+
+        if (accessor->buffer_view && accessor->count > 0)
+        {
+            cgltf_size req_size = accessor->offset + accessor->stride * (accessor->count - 1) + element_size;
+            if (accessor->buffer_view->size < req_size)
+            {
+                SetLoadError(scene, "Sparse accessor base buffer view is too short.");
+                return false;
+            }
+        }
+
+        cgltf_accessor_sparse* sparse = &accessor->sparse;
+        cgltf_size index_component_size = cgltf_component_size(sparse->indices_component_type);
+        if (index_component_size == 0 || !sparse->indices_buffer_view || !sparse->values_buffer_view)
+        {
+            SetLoadError(scene, "Invalid sparse accessor indices or values.");
+            return false;
+        }
+
+        cgltf_size indices_req_size = sparse->indices_byte_offset + index_component_size * sparse->count;
+        cgltf_size values_req_size = sparse->values_byte_offset + element_size * sparse->count;
+        if (sparse->indices_buffer_view->size < indices_req_size ||
+            sparse->values_buffer_view->size < values_req_size)
+        {
+            SetLoadError(scene, "Sparse accessor buffer view is too short.");
+            return false;
+        }
+
+        const uint8_t* index_data = cgltf_buffer_view_data(sparse->indices_buffer_view);
+        const uint8_t* values_data = cgltf_buffer_view_data(sparse->values_buffer_view);
+        if (!index_data || !values_data)
+        {
+            SetLoadError(scene, "Sparse accessor buffer data is missing.");
+            return false;
+        }
+
+        index_data += sparse->indices_byte_offset;
+        for (cgltf_size j = 0; j < sparse->count; ++j, index_data += index_component_size)
+        {
+            cgltf_size sparse_index = 0;
+            if (!ReadSparseIndex(index_data, sparse->indices_component_type, &sparse_index) ||
+                sparse_index >= accessor->count)
+            {
+                SetLoadError(scene, "Sparse accessor index is out of range.");
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
 static uint32_t FindNodeIndex(cgltf_node* node, uint32_t nodes_count, cgltf_node* nodes)
 {
     for (uint32_t i = 0; i < nodes_count; ++i)
@@ -1951,24 +2043,10 @@ static void LoadScene(Scene* scene, cgltf_data* data)
     GenerateRootBone(scene);
 }
 
-static bool ValidateGltfData(Scene* scene, cgltf_data* data)
-{
-    cgltf_result result = cgltf_validate(data);
-    if (result != cgltf_result_success)
-    {
-        char buf[128];
-        dmSnPrintf(buf, sizeof(buf), "Failed to validate gltf file: %s (%d)", GetResultStr(result), result);
-        printf("%s\n", buf);
-        SetLoadError(scene, buf);
-        return false;
-    }
-    return true;
-}
-
 static bool LoadFinalizeGltf(Scene* scene)
 {
     GltfData* data = (GltfData*)scene->m_OpaqueSceneData;
-    if (!ValidateGltfData(scene, data->m_Data))
+    if (!ValidateSparseAccessorsForUnpack(scene, data->m_Data))
         return false;
     LoadScene(scene, data->m_Data);
     return scene->m_LoadError == 0;
@@ -1977,7 +2055,12 @@ static bool LoadFinalizeGltf(Scene* scene)
 static bool ValidateGltf(Scene* scene)
 {
     GltfData* data = (GltfData*)scene->m_OpaqueSceneData;
-    return ValidateGltfData(scene, data->m_Data);
+    cgltf_result result = cgltf_validate(data->m_Data);
+    if (result != cgltf_result_success)
+    {
+        printf("Failed to validate gltf file: %s (%d)\n", GetResultStr(result), result);
+    }
+    return result == cgltf_result_success;
 }
 
 static void DestroyGltf(Scene* scene)

--- a/engine/modelc/src/test/assets/sparse_morph_target.gltf
+++ b/engine/modelc/src/test/assets/sparse_morph_target.gltf
@@ -1,0 +1,106 @@
+{
+  "asset": {
+    "version": "2.0"
+  },
+  "buffers": [
+    {
+      "uri": "data:application/octet-stream;base64,AAAAAAAAAAAAAAAAAACAPwAAAAAAAAAAAAAAAAAAgD8AAAAAAAABAAIAAAABAAAAAAAAAAAAgD8AAAAA",
+      "byteLength": 60
+    }
+  ],
+  "bufferViews": [
+    {
+      "buffer": 0,
+      "byteOffset": 0,
+      "byteLength": 36
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 36,
+      "byteLength": 6
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 44,
+      "byteLength": 2
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 48,
+      "byteLength": 12
+    }
+  ],
+  "accessors": [
+    {
+      "bufferView": 0,
+      "componentType": 5126,
+      "count": 3,
+      "type": "VEC3",
+      "min": [
+        0,
+        0,
+        0
+      ],
+      "max": [
+        1,
+        1,
+        0
+      ]
+    },
+    {
+      "bufferView": 1,
+      "componentType": 5123,
+      "count": 3,
+      "type": "SCALAR"
+    },
+    {
+      "componentType": 5126,
+      "count": 3,
+      "type": "VEC3",
+      "sparse": {
+        "count": 1,
+        "indices": {
+          "bufferView": 2,
+          "componentType": 5123
+        },
+        "values": {
+          "bufferView": 3
+        }
+      }
+    }
+  ],
+  "meshes": [
+    {
+      "name": "SparseMorphTriangle",
+      "weights": [
+        0
+      ],
+      "primitives": [
+        {
+          "attributes": {
+            "POSITION": 0
+          },
+          "indices": 1,
+          "targets": [
+            {
+              "POSITION": 2
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "nodes": [
+    {
+      "mesh": 0
+    }
+  ],
+  "scenes": [
+    {
+      "nodes": [
+        0
+      ]
+    }
+  ],
+  "scene": 0
+}

--- a/engine/modelc/src/test/test_model.cpp
+++ b/engine/modelc/src/test/test_model.cpp
@@ -163,6 +163,32 @@ TEST(ModelGLTF, MorphWeightsAnimationChannel)
     dmModelImporter::DestroyScene(scene);
 }
 
+TEST(ModelGLTF, SparseMorphTarget)
+{
+    dmModelImporter::Options options;
+    dmModelImporter::Scene* scene = LoadScene("./src/test/assets/sparse_morph_target.gltf", options);
+    ASSERT_NE((void*)0, scene);
+
+    ASSERT_EQ(1u, scene->m_Models.Size());
+    ASSERT_EQ(1u, scene->m_Models[0].m_Meshes.Size());
+
+    dmModelImporter::Mesh* mesh = &scene->m_Models[0].m_Meshes[0];
+    ASSERT_EQ(1u, mesh->m_MorphTargets.Size());
+    ASSERT_EQ(9u, mesh->m_MorphTargets[0].m_Positions.Size());
+
+    ASSERT_NEAR(0.0f, mesh->m_MorphTargets[0].m_Positions[0], 1e-6f);
+    ASSERT_NEAR(0.0f, mesh->m_MorphTargets[0].m_Positions[1], 1e-6f);
+    ASSERT_NEAR(0.0f, mesh->m_MorphTargets[0].m_Positions[2], 1e-6f);
+    ASSERT_NEAR(0.0f, mesh->m_MorphTargets[0].m_Positions[3], 1e-6f);
+    ASSERT_NEAR(1.0f, mesh->m_MorphTargets[0].m_Positions[4], 1e-6f);
+    ASSERT_NEAR(0.0f, mesh->m_MorphTargets[0].m_Positions[5], 1e-6f);
+    ASSERT_NEAR(0.0f, mesh->m_MorphTargets[0].m_Positions[6], 1e-6f);
+    ASSERT_NEAR(0.0f, mesh->m_MorphTargets[0].m_Positions[7], 1e-6f);
+    ASSERT_NEAR(0.0f, mesh->m_MorphTargets[0].m_Positions[8], 1e-6f);
+
+    dmModelImporter::DestroyScene(scene);
+}
+
 TEST(ModelGLTF, LoadSkeleton)
 {
     const char* path = "./src/test/assets/skeleton1.gltf";


### PR DESCRIPTION
Fixed a crash when importing glTF/GLB files that use sparse accessors for morph target data. 

#### Technical changes

The importer was reading float attributes with cgltf_accessor_read_float(), which fails for sparse accessors, then passed the resulting null buffer into dmArray::Set(), triggering the user_array != 0 assertion. The fix switches float accessor loading to cgltf_accessor_unpack_floats(), which correctly expands sparse accessors and zero-filled bases while preserving existing component padding behavior.