### PR TITLE
Improve windows local toolchains discoverability

### DIFF
--- a/README_SETUP.md
+++ b/README_SETUP.md
@@ -326,8 +326,8 @@ defold$ ./scripts/build.py check_sdk --verbose
 
 * When installing, in the "Workloads" tab, select the "Desktop Development with C++"
 
-* We also require Clang:
-  * In Visual Studio Installer, under Individual components, select *C++ Clang Compiler for Windows* and *MSBuild support for LLVM (clang-cl) toolset*.
+* We also require Clang and MFC/ATL libraries:
+  * In Visual Studio Installer, under Individual components, select *C++ Clang Compiler for Windows*, *MSBuild support for LLVM (clang-cl) toolset*, *C++ ATL for x64/x86 (MSVC v14.50)* and *C++ MFC for x64/x86 (MSVC v14.50)*.
 
   * Add clang to your PATH. For a default installation, the path to add will likely be C:\Program Files\Microsoft Visual Studio\2026\Community\VC\Tools\Llvm\bin
 

--- a/scripts/cmake/sdk_windows.cmake
+++ b/scripts/cmake/sdk_windows.cmake
@@ -295,10 +295,10 @@ if(_VSWHERE)
 endif()
 
 list(APPEND _VS_LOCAL_ROOTS
-    "C:/Program Files/Microsoft Visual Studio/2026/BuildTools"
-    "C:/Program Files/Microsoft Visual Studio/2026/Community"
-    "C:/Program Files (x86)/Microsoft Visual Studio/2026/BuildTools"
-    "C:/Program Files (x86)/Microsoft Visual Studio/2026/Community")
+    "C:/Program Files/Microsoft Visual Studio/18/BuildTools"
+    "C:/Program Files/Microsoft Visual Studio/18/Community"
+    "C:/Program Files (x86)/Microsoft Visual Studio/18/BuildTools"
+    "C:/Program Files (x86)/Microsoft Visual Studio/18/Community")
 list(REMOVE_DUPLICATES _VS_LOCAL_ROOTS)
 
 if(_VS_LOCAL_ROOTS)
@@ -676,10 +676,10 @@ if(NOT DEFOLD_MSVC_INCLUDE_DIR)
         endif()
     endif()
     list(APPEND _MSVC_INC_CANDIDATE_ROOTS
-        "C:/Program Files/Microsoft Visual Studio/2026/BuildTools"
-        "C:/Program Files/Microsoft Visual Studio/2026/Community"
-        "C:/Program Files (x86)/Microsoft Visual Studio/2026/BuildTools"
-        "C:/Program Files (x86)/Microsoft Visual Studio/2026/Community"
+        "C:/Program Files/Microsoft Visual Studio/18/BuildTools"
+        "C:/Program Files/Microsoft Visual Studio/18/Community"
+        "C:/Program Files (x86)/Microsoft Visual Studio/18/BuildTools"
+        "C:/Program Files (x86)/Microsoft Visual Studio/18/Community"
     )
     list(REMOVE_DUPLICATES _MSVC_INC_CANDIDATE_ROOTS)
 
@@ -748,10 +748,10 @@ if(NOT DEFOLD_MSVC_LIB_DIR)
         endif()
     endif()
     list(APPEND _MSVC_CANDIDATE_ROOTS
-        "C:/Program Files/Microsoft Visual Studio/2026/BuildTools"
-        "C:/Program Files/Microsoft Visual Studio/2026/Community"
-        "C:/Program Files (x86)/Microsoft Visual Studio/2026/BuildTools"
-        "C:/Program Files (x86)/Microsoft Visual Studio/2026/Community"
+        "C:/Program Files/Microsoft Visual Studio/18/BuildTools"
+        "C:/Program Files/Microsoft Visual Studio/18/Community"
+        "C:/Program Files (x86)/Microsoft Visual Studio/18/BuildTools"
+        "C:/Program Files (x86)/Microsoft Visual Studio/18/Community"
     )
     list(REMOVE_DUPLICATES _MSVC_CANDIDATE_ROOTS)
 

--- a/scripts/cmake/sdk_windows.cmake
+++ b/scripts/cmake/sdk_windows.cmake
@@ -295,6 +295,8 @@ if(_VSWHERE)
 endif()
 
 list(APPEND _VS_LOCAL_ROOTS
+    "C:/Program Files/Microsoft Visual Studio/2026/BuildTools"
+    "C:/Program Files/Microsoft Visual Studio/2026/Community"
     "C:/Program Files (x86)/Microsoft Visual Studio/2026/BuildTools"
     "C:/Program Files (x86)/Microsoft Visual Studio/2026/Community")
 list(REMOVE_DUPLICATES _VS_LOCAL_ROOTS)
@@ -674,6 +676,8 @@ if(NOT DEFOLD_MSVC_INCLUDE_DIR)
         endif()
     endif()
     list(APPEND _MSVC_INC_CANDIDATE_ROOTS
+        "C:/Program Files/Microsoft Visual Studio/2026/BuildTools"
+        "C:/Program Files/Microsoft Visual Studio/2026/Community"
         "C:/Program Files (x86)/Microsoft Visual Studio/2026/BuildTools"
         "C:/Program Files (x86)/Microsoft Visual Studio/2026/Community"
     )
@@ -744,10 +748,10 @@ if(NOT DEFOLD_MSVC_LIB_DIR)
         endif()
     endif()
     list(APPEND _MSVC_CANDIDATE_ROOTS
-        "C:/Program Files (x86)/Microsoft Visual Studio/2022/BuildTools"
-        "C:/Program Files (x86)/Microsoft Visual Studio/2022/Community"
-        "C:/Program Files (x86)/Microsoft Visual Studio/2019/BuildTools"
-        "C:/Program Files (x86)/Microsoft Visual Studio/2019/Community"
+        "C:/Program Files/Microsoft Visual Studio/2026/BuildTools"
+        "C:/Program Files/Microsoft Visual Studio/2026/Community"
+        "C:/Program Files (x86)/Microsoft Visual Studio/2026/BuildTools"
+        "C:/Program Files (x86)/Microsoft Visual Studio/2026/Community"
     )
     list(REMOVE_DUPLICATES _MSVC_CANDIDATE_ROOTS)
 


### PR DESCRIPTION
## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
