### PR TITLE
Add non-modal option to dialogs created by editor scripts

### DIFF
--- a/editor/src/clj/editor/editor_extensions/ui_components.clj
+++ b/editor/src/clj/editor/editor_extensions/ui_components.clj
@@ -835,10 +835,11 @@
       (fx/run-later
         (future/complete!
           f
-          (fxui/show-dialog-and-await-result!
-            :event-handler #(assoc %1 ::fxui/result (:result %2))
-            :error-handler #(future/fail! f %)
-            :description desc)))
+          (rt/and-refresh-context
+            (fxui/show-dialog-and-await-result!
+              :event-handler #(assoc %1 ::fxui/result (:result %2))
+              :error-handler #(future/fail! f %)
+              :description desc))))
       f)))
 
 ;; endregion

--- a/editor/src/clj/editor/editor_extensions/ui_components.clj
+++ b/editor/src/clj/editor/editor_extensions/ui_components.clj
@@ -734,7 +734,8 @@
 
 (fxui/defc dialog-view
   {:compose [{:fx/type fx/ext-get-env :env [:localization-state]}]}
-  [{:keys [title header content buttons localization-state]}]
+  [{:keys [title header content buttons modal localization-state]
+    :or {modal true}}]
   (let [title (localization-state title)
         header (or header {:fx/type fxui/legacy-label :text title :variant :header})
         buttons (into []
@@ -756,6 +757,9 @@
              :on-close-request {:result cancel-result}
              :header header
              :footer footer}
+            (not modal)
+            (assoc :modality :none)
+
             content
             (assoc :content content))))
 

--- a/editor/src/clj/editor/editor_extensions/ui_docs.clj
+++ b/editor/src/clj/editor/editor_extensions/ui_docs.clj
@@ -376,7 +376,10 @@
    (make-prop :buttons
               :coerce children-coercer
               :types ["component[]"]
-              :doc "array of <code>editor.ui.dialog_button(...)</code> components, footer of the dialog. Defaults to a single Close button")])
+              :doc "array of <code>editor.ui.dialog_button(...)</code> components, footer of the dialog. Defaults to a single Close button")
+   (make-prop :modal
+              :coerce coerce/boolean
+              :doc "if set to <code>false</code>, the dialog window stays on top but does not block interaction with the editor")])
 
 (def ^:private external-file-dialog-title-doc
   "OS window title, either a string or a localization message")
@@ -580,7 +583,7 @@
 (def show-dialog-doc
   {:name "show_dialog"
    :type :function
-   :description "Show a modal dialog and await a result"
+   :description "Show a dialog and await a result"
    :parameters [{:name "dialog"
                  :types ["component"]
                  :doc "a component that resolves to <code>editor.ui.dialog(...)</code>"}]

--- a/editor/test/resources/editor_extensions/ui_project/test.editor_script
+++ b/editor/test/resources/editor_extensions/ui_project/test.editor_script
@@ -18,6 +18,7 @@ function M.get_commands()
             run = function()
                 local dialog = editor.ui.dialog({
                     title = "Dialog title",
+                    modal = false,
                     header = editor.ui.heading({
                         text = "Header on the Right",
                         color = editor.ui.COLOR.HINT,


### PR DESCRIPTION
We added a `modal` option to `editor.ui.dialog` in editor scripts. Set `modal = false` to keep the dialog open while users continue working in the editor behind it.

This is useful for editor-script tools, tutorials, and assistants that need to stay visible while the user selects files, edits scenes, or changes properties in the main editor.

Fix #11439
