### PR TITLE
Make nested editor script dialogs blocking (unless explicitly non-modal)

### DIFF
--- a/editor/src/clj/editor/editor_extensions/ui_components.clj
+++ b/editor/src/clj/editor/editor_extensions/ui_components.clj
@@ -733,8 +733,8 @@
       button)))
 
 (fxui/defc dialog-view
-  {:compose [{:fx/type fx/ext-get-env :env [:localization-state]}]}
-  [{:keys [title header content buttons modal localization-state]
+  {:compose [{:fx/type fx/ext-get-env :env [:localization-state :owner-window]}]}
+  [{:keys [title header content buttons modal localization-state owner-window]
     :or {modal true}}]
   (let [title (localization-state title)
         header (or header {:fx/type fxui/legacy-label :text title :variant :header})
@@ -754,6 +754,7 @@
                             buttons)}]
     (cond-> {:fx/type dialogs/dialog-stage
              :title title
+             :owner owner-window
              :on-close-request {:result cancel-result}
              :header header
              :footer footer}
@@ -807,9 +808,13 @@
              lifecycle updates, can be accessed using
              [[lifecycle-evaluation-context]] fn
            - localization state: available in cljfx env using [[fx/ext-get-env]]
-             with :localization-state key"
+             with :localization-state key
+           - owner window: available in cljfx env using [[fx/ext-get-env]]
+             with :owner-window key"
    :compose [{:fx/type fx/ext-watcher :ref (:localization props) :key :localization-state}
-             {:fx/type fx/ext-set-env :env {:localization-state (:localization-state props) :workspace (:workspace props)}}
+             {:fx/type fx/ext-set-env :env {:localization-state (:localization-state props)
+                                            :owner-window (:owner-window props)
+                                            :workspace (:workspace props)}}
              {:fx/type ext-with-evaluation-context}]}
   [{:keys [desc]}]
   desc)
@@ -826,9 +831,11 @@
 
 (defn- make-lua-show-dialog-fn [workspace localization]
   (rt/suspendable-lua-fn show-dialog [{:keys [rt]} lua-dialog-component]
-    (let [desc {:fx/type show-dialog-wrapper-view
+    (let [owner-window (current-owner-window)
+          desc {:fx/type show-dialog-wrapper-view
                 :desc {:fx/type root-view
                        :localization localization
+                       :owner-window owner-window
                        :workspace workspace
                        :desc (rt/->clj rt ui-docs/component-coercer lua-dialog-component)}}
           f (future/make)]


### PR DESCRIPTION
Nested editor script dialogs are now blocking, unless exlicitly non-modal.

Technical notes:

Here is a repro editor script (adds `Edit` -> `Repro Nested Dialog Blocking` command):
```lua
local M = {}

local function show_nested_dialog(depth)
    local result = editor.ui.show_dialog(editor.ui.dialog({
        title = ("Nested dialog #%d"):format(depth),
        content = editor.ui.vertical({
            padding = editor.ui.PADDING.LARGE,
            children = {
                editor.ui.heading({
                    text = ("Nested dialog #%d"):format(depth),
                    style = editor.ui.HEADING_STYLE.DIALOG
                }),
                editor.ui.paragraph({
                    text = "Open another nested dialog, then verify every parent dialog is blocked until its child closes."
                }),
                editor.ui.string_field({
                    value = ("Try editing nested dialog #%d while its child is open"):format(depth),
                    on_value_changed = function(value)
                        print(("Nested dialog #%d field changed while child may be open: %s"):format(depth, tostring(value)))
                    end
                }),
                editor.ui.button({
                    text = "Open nested dialog",
                    on_pressed = function()
                        print(("Opening nested dialog #%d"):format(depth + 1))
                        show_nested_dialog(depth + 1)
                    end
                }),
                editor.ui.button({
                    text = "Nested dialog button",
                    on_pressed = function()
                        print(("Nested dialog #%d button pressed while child may be open"):format(depth))
                    end
                })
            }
        }),
        buttons = {
            editor.ui.dialog_button({
                text = "Close nested dialog",
                cancel = true,
                default = true,
                result = ("nested-%d-closed"):format(depth)
            })
        }
    }))
    print(("Nested dialog #%d result: %s"):format(depth, tostring(result)))
end

function M.get_commands()
    return {
        {
            label = "Repro Nested Dialog Blocking",
            locations = {"Edit"},
            id = "defold.test.nested-dialog-blocking",
            run = function()
                local parent_dialog = editor.ui.dialog({
                    title = "Parent dialog",
                    modal = true,
                    content = editor.ui.vertical({
                        padding = editor.ui.PADDING.LARGE,
                        children = {
                            editor.ui.heading({
                                text = "Parent dialog",
                                style = editor.ui.HEADING_STYLE.DIALOG
                            }),
                            editor.ui.paragraph({
                                text = "Open a child dialog, then verify the parent cannot be edited, clicked, or closed until the child is closed."
                            }),
                            editor.ui.string_field({
                                value = "Try editing this while the child is open",
                                on_value_changed = function(value)
                                    print(("Parent field changed while child may be open: %s"):format(tostring(value)))
                                end
                            }),
                            editor.ui.button({
                                text = "Open child dialog",
                                on_pressed = function()
                                    print("Opening nested dialog #1")
                                    show_nested_dialog(1)
                                end
                            }),
                            editor.ui.button({
                                text = "Parent button",
                                on_pressed = function()
                                    print("Parent button pressed while child may be open")
                                end
                            })
                        }
                    }),
                    buttons = {
                        editor.ui.dialog_button({
                            text = "Close parent",
                            cancel = true,
                            default = true,
                            result = "parent-closed"
                        })
                    }
                })
                local result = editor.ui.show_dialog(parent_dialog)
                print(("Parent dialog result: %s"):format(tostring(result)))
            end
        }
    }
end

return M

```
Fix #10219