### PR TITLE
dmSDK: Improved access to the context registry for extensions

### DIFF
--- a/engine/dlib/src/dlib/context_registry.cpp
+++ b/engine/dlib/src/dlib/context_registry.cpp
@@ -16,8 +16,6 @@
 
 #include <dlib/hashtable.h>
 
-#include <assert.h>
-
 struct ContextRegistry
 {
     dmHashTable64<void*> m_Contexts;
@@ -43,19 +41,16 @@ void ContextRegistryDestroy(HContextRegistry registry)
 
 int ContextRegistrySet(HContextRegistry registry, const char* name, void* context)
 {
-    assert(registry);
-    assert(name);
     return ContextRegistrySetByHash(registry, dmHashString64(name), context);
 }
 
 int ContextRegistrySetByHash(HContextRegistry registry, dmhash_t name_hash, void* context)
 {
-    assert(registry);
-
-    EnsureSize(&registry->m_Contexts);
-
     if (context)
+    {
+        EnsureSize(&registry->m_Contexts);
         registry->m_Contexts.Put(name_hash, context);
+    }
     else
     {
         void** pvalue = registry->m_Contexts.Get(name_hash);
@@ -65,17 +60,13 @@ int ContextRegistrySetByHash(HContextRegistry registry, dmhash_t name_hash, void
     return 0;
 }
 
-void* ContextRegistryGetByName(HContextRegistry registry, const char* name)
+void* ContextRegistryGet(HContextRegistry registry, const char* name)
 {
-    assert(registry);
-    assert(name);
     return ContextRegistryGetByHash(registry, dmHashString64(name));
 }
 
 void* ContextRegistryGetByHash(HContextRegistry registry, dmhash_t name_hash)
 {
-    assert(registry);
-
     void** pcontext = registry->m_Contexts.Get(name_hash);
     if (pcontext != 0)
     {

--- a/engine/dlib/src/dlib/context_registry.cpp
+++ b/engine/dlib/src/dlib/context_registry.cpp
@@ -1,0 +1,85 @@
+// Copyright 2020-2026 The Defold Foundation
+// Copyright 2014-2020 King
+// Copyright 2009-2014 Ragnar Svensson, Christian Murray
+// Licensed under the Defold License version 1.0 (the "License"); you may not use
+// this file except in compliance with the License.
+//
+// You may obtain a copy of the License, together with FAQs at
+// https://www.defold.com/license
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#include <dlib/context_registry.h>
+
+#include <dlib/hashtable.h>
+
+#include <assert.h>
+
+struct ContextRegistry
+{
+    dmHashTable64<void*> m_Contexts;
+};
+
+static void EnsureSize(dmHashTable64<void*>* contexts)
+{
+    if (contexts->Full())
+    {
+        contexts->OffsetCapacity(4);
+    }
+}
+
+HContextRegistry ContextRegistryCreate()
+{
+    return new ContextRegistry;
+}
+
+void ContextRegistryDestroy(HContextRegistry registry)
+{
+    delete registry;
+}
+
+int ContextRegistrySet(HContextRegistry registry, const char* name, void* context)
+{
+    assert(registry);
+    assert(name);
+    return ContextRegistrySetByHash(registry, dmHashString64(name), context);
+}
+
+int ContextRegistrySetByHash(HContextRegistry registry, dmhash_t name_hash, void* context)
+{
+    assert(registry);
+
+    EnsureSize(&registry->m_Contexts);
+
+    if (context)
+        registry->m_Contexts.Put(name_hash, context);
+    else
+    {
+        void** pvalue = registry->m_Contexts.Get(name_hash);
+        if (pvalue)
+            registry->m_Contexts.Erase(name_hash);
+    }
+    return 0;
+}
+
+void* ContextRegistryGetByName(HContextRegistry registry, const char* name)
+{
+    assert(registry);
+    assert(name);
+    return ContextRegistryGetByHash(registry, dmHashString64(name));
+}
+
+void* ContextRegistryGetByHash(HContextRegistry registry, dmhash_t name_hash)
+{
+    assert(registry);
+
+    void** pcontext = registry->m_Contexts.Get(name_hash);
+    if (pcontext != 0)
+    {
+        return *pcontext;
+    }
+    return 0;
+}

--- a/engine/dlib/src/dlib/context_registry.h
+++ b/engine/dlib/src/dlib/context_registry.h
@@ -1,0 +1,31 @@
+// Copyright 2020-2026 The Defold Foundation
+// Copyright 2014-2020 King
+// Copyright 2009-2014 Ragnar Svensson, Christian Murray
+// Licensed under the Defold License version 1.0 (the "License"); you may not use
+// this file except in compliance with the License.
+//
+// You may obtain a copy of the License, together with FAQs at
+// https://www.defold.com/license
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#ifndef DM_CONTEXT_REGISTRY_H
+#define DM_CONTEXT_REGISTRY_H
+
+#include <dmsdk/dlib/context_registry.h>
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+HContextRegistry ContextRegistryCreate();
+void ContextRegistryDestroy(HContextRegistry registry);
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif // DM_CONTEXT_REGISTRY_H

--- a/engine/dlib/src/dmsdk/dlib/configfile.h
+++ b/engine/dlib/src/dmsdk/dlib/configfile.h
@@ -42,6 +42,13 @@ extern "C" {
  */
 typedef struct ConfigFile* HConfigFile;
 
+/*# Config file extension context name
+ * Name used when registering the config file with the engine context registry.
+ * @constant
+ * @name CONFIGFILE_CONTEXT_NAME
+ */
+#define CONFIGFILE_CONTEXT_NAME "config"
+
 /*#
  *
  * Get config value as string, returns default if the key isn't found

--- a/engine/dlib/src/dmsdk/dlib/context_registry.h
+++ b/engine/dlib/src/dmsdk/dlib/context_registry.h
@@ -59,12 +59,12 @@ int ContextRegistrySetByHash(HContextRegistry registry, dmhash_t name_hash, void
 
 /*#
  * Gets a context from the context registry using a specified name.
- * @name ContextRegistryGetByName
+ * @name ContextRegistryGet
  * @param registry [type:HContextRegistry] the context registry
  * @param name [type:const char*] the context name
  * @return context [type:void*] The context, if it exists
  */
-void* ContextRegistryGetByName(HContextRegistry registry, const char* name);
+void* ContextRegistryGet(HContextRegistry registry, const char* name);
 
 /*#
  * Gets a context from the context registry using a specified name hash.

--- a/engine/dlib/src/dmsdk/dlib/context_registry.h
+++ b/engine/dlib/src/dmsdk/dlib/context_registry.h
@@ -1,0 +1,82 @@
+// Copyright 2020-2026 The Defold Foundation
+// Copyright 2014-2020 King
+// Copyright 2009-2014 Ragnar Svensson, Christian Murray
+// Licensed under the Defold License version 1.0 (the "License"); you may not use
+// this file except in compliance with the License.
+//
+// You may obtain a copy of the License, together with FAQs at
+// https://www.defold.com/license
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#ifndef DMSDK_DLIB_CONTEXT_REGISTRY_H
+#define DMSDK_DLIB_CONTEXT_REGISTRY_H
+
+#include <dmsdk/dlib/hash.h>
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/*# ContextRegistry API documentation
+ *
+ * A named registry for engine-owned context pointers.
+ *
+ * @document
+ * @name ContextRegistry
+ * @language C
+ */
+
+/*#
+ * Context registry handle.
+ * @typedef
+ * @name HContextRegistry
+ */
+typedef struct ContextRegistry* HContextRegistry;
+
+/*#
+ * Sets a context in the context registry using a specified name.
+ * @name ContextRegistrySet
+ * @param registry [type:HContextRegistry] the context registry
+ * @param name [type:const char*] the context name
+ * @param context [type:void*] the context, or 0 to remove the context
+ * @return result [type:int] 0 if successful
+ */
+int ContextRegistrySet(HContextRegistry registry, const char* name, void* context);
+
+/*#
+ * Sets a context in the context registry using a specified name hash.
+ * @name ContextRegistrySetByHash
+ * @param registry [type:HContextRegistry] the context registry
+ * @param name_hash [type:dmhash_t] the context name hash
+ * @param context [type:void*] the context, or 0 to remove the context
+ * @return result [type:int] 0 if successful
+ */
+int ContextRegistrySetByHash(HContextRegistry registry, dmhash_t name_hash, void* context);
+
+/*#
+ * Gets a context from the context registry using a specified name.
+ * @name ContextRegistryGetByName
+ * @param registry [type:HContextRegistry] the context registry
+ * @param name [type:const char*] the context name
+ * @return context [type:void*] The context, if it exists
+ */
+void* ContextRegistryGetByName(HContextRegistry registry, const char* name);
+
+/*#
+ * Gets a context from the context registry using a specified name hash.
+ * @name ContextRegistryGetByHash
+ * @param registry [type:HContextRegistry] the context registry
+ * @param name_hash [type:dmhash_t] the context name hash
+ * @return context [type:void*] The context, if it exists
+ */
+void* ContextRegistryGetByHash(HContextRegistry registry, dmhash_t name_hash);
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif // DMSDK_DLIB_CONTEXT_REGISTRY_H

--- a/engine/dlib/src/dmsdk/dlib/jobsystem.h
+++ b/engine/dlib/src/dmsdk/dlib/jobsystem.h
@@ -37,6 +37,13 @@ extern "C" {
  * @language C
  */
 
+/*# Job system extension context name
+ * Name used when registering the job system with the engine context registry.
+ * @constant
+ * @name JOB_SYSTEM_CONTEXT_NAME
+ */
+#define JOB_SYSTEM_CONTEXT_NAME "jobs"
+
 /*# Job handle
  * @typedef
  * @name HJob

--- a/engine/dlib/src/dmsdk/dlib/webserver.h
+++ b/engine/dlib/src/dmsdk/dlib/webserver.h
@@ -29,6 +29,13 @@
  * @language C++
  */
 
+/*# Web server extension context name
+ * Name used when registering the web server with the engine context registry.
+ * @constant
+ * @name WEBSERVER_CONTEXT_NAME
+ */
+#define WEBSERVER_CONTEXT_NAME "webserver"
+
 namespace dmWebServer
 {
     /*# web server handle
@@ -166,4 +173,3 @@ namespace dmWebServer
 }
 
 #endif // DMSDK_WEBSERVER_H
-

--- a/engine/dlib/src/test/test_context_registry.c
+++ b/engine/dlib/src/test/test_context_registry.c
@@ -116,16 +116,19 @@ static int TestContextRegistry(void)
     int alpha = 1;
     int beta = 2;
 
+    TEST_CHECK(ContextRegistrySet(registry, "missing", 0) == 0);
+    TEST_CHECK(ContextRegistryGet(registry, "missing") == 0);
+
     TEST_CHECK(ContextRegistrySet(registry, "alpha", &alpha) == 0);
-    TEST_CHECK(ContextRegistryGetByName(registry, "alpha") == &alpha);
+    TEST_CHECK(ContextRegistryGet(registry, "alpha") == &alpha);
     TEST_CHECK(ContextRegistryGetByHash(registry, dmHashString64("alpha")) == &alpha);
 
     TEST_CHECK(ContextRegistrySetByHash(registry, dmHashString64("beta"), &beta) == 0);
-    TEST_CHECK(ContextRegistryGetByName(registry, "beta") == &beta);
+    TEST_CHECK(ContextRegistryGet(registry, "beta") == &beta);
     TEST_CHECK(ContextRegistryGetByHash(registry, dmHashString64("beta")) == &beta);
 
     TEST_CHECK(ContextRegistrySet(registry, "alpha", 0) == 0);
-    TEST_CHECK(ContextRegistryGetByName(registry, "alpha") == 0);
+    TEST_CHECK(ContextRegistryGet(registry, "alpha") == 0);
 
     TEST_CHECK(ContextRegistrySetByHash(registry, dmHashString64("beta"), 0) == 0);
     TEST_CHECK(ContextRegistryGetByHash(registry, dmHashString64("beta")) == 0);

--- a/engine/dlib/src/test/test_context_registry.c
+++ b/engine/dlib/src/test/test_context_registry.c
@@ -1,0 +1,152 @@
+// Copyright 2020-2026 The Defold Foundation
+// Copyright 2014-2020 King
+// Copyright 2009-2014 Ragnar Svensson, Christian Murray
+// Licensed under the Defold License version 1.0 (the "License"); you may not use
+// this file except in compliance with the License.
+//
+// You may obtain a copy of the License, together with FAQs at
+// https://www.defold.com/license
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <dlib/context_registry.h>
+
+#if defined(_WIN32)
+    #include <io.h>
+    #include <windows.h>
+    #ifndef ENABLE_VIRTUAL_TERMINAL_PROCESSING
+        #define ENABLE_VIRTUAL_TERMINAL_PROCESSING 0x0004
+    #endif
+#else
+    #include <unistd.h>
+#endif
+
+#define TEST_COLOR_RESET "\033[0m"
+#define TEST_COLOR_RED   "\033[31m"
+#define TEST_COLOR_GREEN "\033[32m"
+#define TEST_COLOR_CYAN  "\033[36m"
+
+static int g_TestColorOutput = 0;
+
+#if defined(_WIN32)
+static int TestEnableVirtualTerminalProcessing(void)
+{
+    HANDLE stdout_handle = GetStdHandle(STD_OUTPUT_HANDLE);
+    DWORD mode = 0;
+
+    if (stdout_handle == INVALID_HANDLE_VALUE)
+    {
+        return 0;
+    }
+
+    if (!GetConsoleMode(stdout_handle, &mode))
+    {
+        return 0;
+    }
+
+    if (mode & ENABLE_VIRTUAL_TERMINAL_PROCESSING)
+    {
+        return 1;
+    }
+
+    return SetConsoleMode(stdout_handle, mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING) != 0;
+}
+#endif
+
+static int TestStdoutSupportsColor(void)
+{
+    const char* no_color = getenv("NO_COLOR");
+    if (no_color && no_color[0] != 0)
+    {
+        return 0;
+    }
+
+#if defined(_WIN32)
+    if (_isatty(_fileno(stdout)) == 0)
+    {
+        return 0;
+    }
+
+    return TestEnableVirtualTerminalProcessing();
+#else
+    const char* term = getenv("TERM");
+    return isatty(STDOUT_FILENO) && term && strcmp(term, "dumb") != 0;
+#endif
+}
+
+static void PrintTestStatus(const char* color, const char* tag, const char* name)
+{
+    if (g_TestColorOutput)
+    {
+        printf("%s%s%s %s\n", color, tag, TEST_COLOR_RESET, name);
+    }
+    else
+    {
+        printf("%s %s\n", tag, name);
+    }
+    fflush(stdout);
+}
+
+static void PrintTestFailed(const char* name, int result)
+{
+    if (g_TestColorOutput)
+    {
+        fprintf(stderr, "%s[  FAILED  ]%s %s: %d\n", TEST_COLOR_RED, TEST_COLOR_RESET, name, result);
+    }
+    else
+    {
+        fprintf(stderr, "[  FAILED  ] %s: %d\n", name, result);
+    }
+}
+
+#define TEST_CHECK(_EXPR) do { if (!(_EXPR)) { fprintf(stderr, "TEST_CHECK failed at line %s:%d: %s\n", __FILE__, __LINE__, #_EXPR); return __LINE__; } } while (0)
+#define RUN_TEST(_NAME, _CALL) do { PrintTestStatus(TEST_COLOR_CYAN, "[ RUN      ]", (_NAME)); result = (_CALL); if (result != 0) { PrintTestFailed((_NAME), result); return result; } PrintTestStatus(TEST_COLOR_GREEN, "[       OK ]", (_NAME)); } while (0)
+
+static int TestContextRegistry(void)
+{
+    HContextRegistry registry = ContextRegistryCreate();
+
+    int alpha = 1;
+    int beta = 2;
+
+    TEST_CHECK(ContextRegistrySet(registry, "alpha", &alpha) == 0);
+    TEST_CHECK(ContextRegistryGetByName(registry, "alpha") == &alpha);
+    TEST_CHECK(ContextRegistryGetByHash(registry, dmHashString64("alpha")) == &alpha);
+
+    TEST_CHECK(ContextRegistrySetByHash(registry, dmHashString64("beta"), &beta) == 0);
+    TEST_CHECK(ContextRegistryGetByName(registry, "beta") == &beta);
+    TEST_CHECK(ContextRegistryGetByHash(registry, dmHashString64("beta")) == &beta);
+
+    TEST_CHECK(ContextRegistrySet(registry, "alpha", 0) == 0);
+    TEST_CHECK(ContextRegistryGetByName(registry, "alpha") == 0);
+
+    TEST_CHECK(ContextRegistrySetByHash(registry, dmHashString64("beta"), 0) == 0);
+    TEST_CHECK(ContextRegistryGetByHash(registry, dmHashString64("beta")) == 0);
+
+    ContextRegistryDestroy(registry);
+
+    return 0;
+}
+
+int main(int argc, char** argv)
+{
+    int result;
+
+    (void) argc;
+    (void) argv;
+
+    g_TestColorOutput = TestStdoutSupportsColor();
+
+    RUN_TEST("TestContextRegistry", TestContextRegistry());
+
+    PrintTestStatus(TEST_COLOR_GREEN, "[  PASSED  ]", "test_context_registry");
+
+    return 0;
+}

--- a/engine/dlib/src/test/wscript
+++ b/engine/dlib/src/test/wscript
@@ -7,7 +7,8 @@ from BuildUtility import create_build_utility
 
 def create_test(bld, name, extra_libs = None, extra_features = None, embed_source = None,
                 extra_includes = None, extra_defines = None, extra_source = None,
-                skip_run = False, extra_local_libs = None, exclude_libs = None, target_name = None):
+                skip_run = False, extra_local_libs = None, exclude_libs = None, target_name = None,
+                source = None, c_only = False):
 
     # Sometimes, we need to disable certain tests until they're supported
     if not platform_supports_feature(bld.env.PLATFORM, name, {}):
@@ -22,7 +23,7 @@ def create_test(bld, name, extra_libs = None, extra_features = None, embed_sourc
     if 'DM_IPV6_UNSUPPORTED' in os.environ:
         req_defines += ['DM_IPV6_UNSUPPORTED']
 
-    req_features = ['cxx', 'cprogram']
+    req_features = ['cxx', 'c', 'cprogram'] if c_only else ['cxx', 'cprogram']
     req_includes = ['../../src']
     req_embed = None
 
@@ -75,11 +76,15 @@ def create_test(bld, name, extra_libs = None, extra_features = None, embed_sourc
 
     if extra_source is None:
         extra_source = []
+    if source is None:
+        source = (name + '.cpp').split()
+    elif isinstance(source, str):
+        source = source.split()
 
     use_lib_list = '%s %s %s' % (' '.join(req_libs), ' '.join(local_libs), ' '.join(extra_local_libs))
     task_args = {
         'features': ' '.join(req_features),
-        'source': extra_source + (name + '.cpp').split() + platform_source,
+        'source': extra_source + source + platform_source,
         'use': use_lib_list,
         'web_libs': ['library_sys.js'], # part of dlib, which we're testing
         'includes': req_includes,
@@ -161,6 +166,7 @@ def build(bld):
     create_test(bld, 'test_indexpool')
     create_test(bld, 'test_dlib', extra_libs = ['THREAD'], extra_features = ['c'], extra_source = ['test_endian.c'])
     create_test(bld, 'test_hash', extra_libs = ['THREAD'], extra_features = ['c'], extra_source = ['test_hash.c'])
+    create_test(bld, 'test_context_registry', source = 'test_context_registry.c', c_only = True)
 
     create_test(bld, 'test_time')
 

--- a/engine/dlib/src/wscript
+++ b/engine/dlib/src/wscript
@@ -435,6 +435,7 @@ def build(bld):
     bld.install_files('${PREFIX}/include/dlib', 'dlib/buffer.h')
     bld.install_files('${PREFIX}/include/dlib', 'dlib/condition_variable.h')
     bld.install_files('${PREFIX}/include/dlib', 'dlib/configfile.h')
+    bld.install_files('${PREFIX}/include/dlib', 'dlib/context_registry.h')
     bld.install_files('${PREFIX}/include/dlib', 'dlib/crypt.h')
     bld.install_files('${PREFIX}/include/dlib', 'dlib/dalloca.h')
     bld.install_files('${PREFIX}/include/dlib', 'dlib/dlib.h')

--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -1063,6 +1063,11 @@ namespace dmEngine
         }
 #endif
 
+        JobSystemCreateParams job_thread_create_param;
+        job_thread_create_param.m_ThreadNamePrefix  = "DefoldJob";
+        job_thread_create_param.m_ThreadCount       = 1;
+        engine->m_JobThreadContext                  = JobSystemCreate(&job_thread_create_param);
+
         PopulateContextRegistry(engine, 0);
 
         ScopedExtensionAppParams app_params(engine);
@@ -1201,11 +1206,6 @@ namespace dmEngine
         {
             swap_interval = 0;
         }
-
-        JobSystemCreateParams job_thread_create_param;
-        job_thread_create_param.m_ThreadNamePrefix  = "DefoldJob";
-        job_thread_create_param.m_ThreadCount       = 1;
-        engine->m_JobThreadContext                  = JobSystemCreate(&job_thread_create_param);
 
         dmGraphics::ContextParams graphics_context_params;
         graphics_context_params.m_DefaultTextureMinFilter = ConvertMinTextureFilter(dmConfigFile::GetString(engine->m_Config, "graphics.default_texture_min_filter", "linear"));

--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -49,6 +49,7 @@
 #include <dlib/thread.h>
 #include <dlib/time.h>
 #include <graphics/graphics.h>
+#include <extension/extension.h>
 #include <extension/extension.hpp>
 #include <gamesys/gamesys.h>
 #include <gamesys/model_ddf.h>

--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -140,6 +140,12 @@ namespace dmEngine
         }
     }
 
+    static void SetScriptContextInContextRegistry(HContextRegistry context_registry, dmScript::HContext script_context)
+    {
+        ContextRegistrySet(context_registry, SCRIPT_CONTEXT_NAME, script_context);
+        ContextRegistrySet(context_registry, LUA_CONTEXT_NAME, script_context ? dmScript::GetLuaState(script_context) : 0);
+    }
+
     static void PopulateContextRegistry(HEngine engine, dmScript::HContext script_context)
     {
         ContextRegistrySet(engine->m_ContextRegistry, CONFIGFILE_CONTEXT_NAME, engine->m_Config);
@@ -154,8 +160,7 @@ namespace dmEngine
         ContextRegistrySet(engine->m_ContextRegistry, JOB_SYSTEM_CONTEXT_NAME, engine->m_JobThreadContext);
         ContextRegistrySet(engine->m_ContextRegistry, "gui_scriptc", engine->m_GuiScriptContext);
         ContextRegistrySet(engine->m_ContextRegistry, "guic", engine->m_GuiContext);
-        ContextRegistrySet(engine->m_ContextRegistry, SCRIPT_CONTEXT_NAME, script_context);
-        ContextRegistrySet(engine->m_ContextRegistry, LUA_CONTEXT_NAME, script_context ? dmScript::GetLuaState(script_context) : 0);
+        SetScriptContextInContextRegistry(engine->m_ContextRegistry, script_context);
     }
 
     struct ScopedExtensionAppParams
@@ -182,7 +187,10 @@ namespace dmEngine
     struct ScopedExtensionParams
     {
         ExtensionParams m_Params;
+        HEngine         m_Engine;
+
         ScopedExtensionParams(HEngine engine)
+        : m_Engine(engine)
         {
             ExtensionParamsInitialize(&m_Params);
             ExtensionParamsSetContextRegistry(&m_Params, engine->m_ContextRegistry);
@@ -196,7 +204,8 @@ namespace dmEngine
         }
         void SetLuaContext(dmScript::HContext script_context)
         {
-            m_Params.m_L = dmScript::GetLuaState(script_context);
+            m_Params.m_L = script_context ? dmScript::GetLuaState(script_context) : 0;
+            SetScriptContextInContextRegistry(m_Engine->m_ContextRegistry, script_context);
         }
 
         operator ExtensionParams* ()

--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -441,6 +441,7 @@ namespace dmEngine
         m_PreviousFrameTime = dmTime::GetMonotonicTime();
         m_HttpCache = 0;
         m_ContextRegistry = ContextRegistryCreate();
+        dmGameObject::SetContextRegistry(m_Register, m_ContextRegistry);
     }
 
     HEngine New(dmEngineService::HEngineService engine_service)

--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -16,7 +16,16 @@
 
 #include "engine_private.h"
 
+#include <dmsdk/dlib/configfile.h>
+#include <dmsdk/dlib/jobsystem.h>
 #include <dmsdk/dlib/vmath.h>
+#include <dmsdk/dlib/webserver.h>
+#include <dmsdk/gameobject/gameobject.h>
+#include <dmsdk/graphics/graphics.h>
+#include <dmsdk/hid/hid.h>
+#include <dmsdk/render/render.h>
+#include <dmsdk/resource/resource.h>
+#include <dmsdk/script/script.h>
 
 #include <sys/stat.h>
 
@@ -130,19 +139,33 @@ namespace dmEngine
         }
     }
 
+    static void PopulateContextRegistry(HEngine engine, dmScript::HContext script_context)
+    {
+        ContextRegistrySet(engine->m_ContextRegistry, CONFIGFILE_CONTEXT_NAME, engine->m_Config);
+        dmWebServer::HServer webserver = dmEngineService::GetWebServer(engine->m_EngineService);
+        ContextRegistrySet(engine->m_ContextRegistry, WEBSERVER_CONTEXT_NAME, webserver);
+        ContextRegistrySet(engine->m_ContextRegistry, GAMEOBJECT_CONTEXT_NAME, engine->m_Register);
+        ContextRegistrySet(engine->m_ContextRegistry, HID_CONTEXT_NAME, engine->m_HidContext);
+        ContextRegistrySet(engine->m_ContextRegistry, RESOURCE_FACTORY_CONTEXT_NAME, engine->m_Factory);
+        ContextRegistrySet(engine->m_ContextRegistry, GRAPHICS_CONTEXT_NAME, engine->m_GraphicsContext);
+        ContextRegistrySet(engine->m_ContextRegistry, RENDER_CONTEXT_NAME, engine->m_RenderContext);
+        ContextRegistrySet(engine->m_ContextRegistry, "http_cache", engine->m_HttpCache);
+        ContextRegistrySet(engine->m_ContextRegistry, JOB_SYSTEM_CONTEXT_NAME, engine->m_JobThreadContext);
+        ContextRegistrySet(engine->m_ContextRegistry, "gui_scriptc", engine->m_GuiScriptContext);
+        ContextRegistrySet(engine->m_ContextRegistry, "guic", engine->m_GuiContext);
+        ContextRegistrySet(engine->m_ContextRegistry, SCRIPT_CONTEXT_NAME, script_context);
+        ContextRegistrySet(engine->m_ContextRegistry, LUA_CONTEXT_NAME, script_context ? dmScript::GetLuaState(script_context) : 0);
+    }
+
     struct ScopedExtensionAppParams
     {
         ExtensionAppParams m_AppParams;
         ScopedExtensionAppParams(HEngine engine)
         {
             ExtensionAppParamsInitialize(&m_AppParams);
+            ExtensionAppParamsSetContextRegistry(&m_AppParams, engine->m_ContextRegistry);
             m_AppParams.m_ConfigFile = engine->m_Config;
             m_AppParams.m_ExitStatus = GetAppExitStatusFromAction(engine->m_RunResult.m_Action);
-            ExtensionAppParamsSetContext(&m_AppParams, "config", engine->m_Config);
-            dmWebServer::HServer webserver = dmEngineService::GetWebServer(engine->m_EngineService);
-            ExtensionAppParamsSetContext(&m_AppParams, "webserver", webserver);
-            ExtensionAppParamsSetContext(&m_AppParams, "register", engine->m_Register);
-            ExtensionAppParamsSetContext(&m_AppParams, "hid", engine->m_HidContext);
         }
         ~ScopedExtensionAppParams()
         {
@@ -157,29 +180,14 @@ namespace dmEngine
 
     struct ScopedExtensionParams
     {
-        HEngine         m_Engine;
         ExtensionParams m_Params;
         ScopedExtensionParams(HEngine engine)
-        : m_Engine(engine)
         {
             ExtensionParamsInitialize(&m_Params);
+            ExtensionParamsSetContextRegistry(&m_Params, engine->m_ContextRegistry);
             m_Params.m_ConfigFile = engine->m_Config;
             m_Params.m_ResourceFactory = engine->m_Factory;
             SetLuaContext(engine->m_SharedScriptContext ? engine->m_SharedScriptContext : engine->m_GOScriptContext);
-
-            ExtensionParamsSetContext(&m_Params, "config", engine->m_Config);
-            dmWebServer::HServer webserver = dmEngineService::GetWebServer(engine->m_EngineService);
-            ExtensionParamsSetContext(&m_Params, "webserver", webserver);
-            ExtensionParamsSetContext(&m_Params, "register", engine->m_Register);
-            ExtensionParamsSetContext(&m_Params, "hid", engine->m_HidContext);
-            ExtensionParamsSetContext(&m_Params, "factory", engine->m_Factory);
-            ExtensionParamsSetContext(&m_Params, "graphics", engine->m_GraphicsContext);
-            ExtensionParamsSetContext(&m_Params, "render", engine->m_RenderContext);
-            if (engine->m_HttpCache)
-                ExtensionParamsSetContext(&m_Params, "http_cache", engine->m_HttpCache);
-
-            if (engine->m_JobThreadContext)
-                ExtensionParamsSetContext(&m_Params, "jobs", engine->m_JobThreadContext);
         }
         ~ScopedExtensionParams()
         {
@@ -188,8 +196,6 @@ namespace dmEngine
         void SetLuaContext(dmScript::HContext script_context)
         {
             m_Params.m_L = dmScript::GetLuaState(script_context);
-            ExtensionParamsSetContext(&m_Params, "script", script_context);
-            ExtensionParamsSetContext(&m_Params, "lua", m_Params.m_L);
         }
 
         operator ExtensionParams* ()
@@ -299,15 +305,17 @@ namespace dmEngine
         dmGameSystem::OnWindowIconify(iconify != 0);
     }
 
-    static void SetupComponentCreateContext(HEngine engine, dmGameObject::ComponentTypeCreateCtx& component_create_ctx)
+    static void SetupComponentCreateContext(HEngine engine, dmGameObject::ComponentTypeCreateCtx& component_create_ctx, dmGameObject::ComponentTypeCreateCtxImpl& component_create_ctx_impl)
     {
+        component_create_ctx_impl.m_ContextRegistry = engine->m_ContextRegistry;
+        component_create_ctx.m_Impl = &component_create_ctx_impl;
         component_create_ctx.m_Config = engine->m_Config;
         component_create_ctx.m_Script = engine->m_GOScriptContext;
         component_create_ctx.m_Register = engine->m_Register;
         component_create_ctx.m_Factory = engine->m_Factory;
         component_create_ctx.m_Contexts.SetCapacity(3, 8);
-        component_create_ctx.m_Contexts.Put(dmHashString64("graphics"), engine->m_GraphicsContext);
-        component_create_ctx.m_Contexts.Put(dmHashString64("render"), engine->m_RenderContext);
+        component_create_ctx.m_Contexts.Put(dmHashString64(GRAPHICS_CONTEXT_NAME), engine->m_GraphicsContext);
+        component_create_ctx.m_Contexts.Put(dmHashString64(RENDER_CONTEXT_NAME), engine->m_RenderContext);
         if (engine->m_GuiContext)
         {
             component_create_ctx.m_Contexts.Put(dmHashString64("gui_scriptc"), engine->m_GuiScriptContext);
@@ -432,6 +440,7 @@ namespace dmEngine
         m_AccumFrameTime = 0;
         m_PreviousFrameTime = dmTime::GetMonotonicTime();
         m_HttpCache = 0;
+        m_ContextRegistry = ContextRegistryCreate();
     }
 
     HEngine New(dmEngineService::HEngineService engine_service)
@@ -462,8 +471,9 @@ namespace dmEngine
             dmResource::DeregisterTypes(engine->m_Factory, &engine->m_ResourceTypeContexts);
         }
 
+        dmGameObject::ComponentTypeCreateCtxImpl component_create_ctx_impl;
         dmGameObject::ComponentTypeCreateCtx component_create_ctx;
-        SetupComponentCreateContext(engine, component_create_ctx);
+        SetupComponentCreateContext(engine, component_create_ctx, component_create_ctx_impl);
 
         dmGameObject::DestroyRegisteredComponentTypes(&component_create_ctx);
 
@@ -568,13 +578,18 @@ namespace dmEngine
         if (engine->m_PhysicsContextBullet3D.m_Context)
             dmPhysics::DeleteContext3D(engine->m_PhysicsContextBullet3D.m_Context);
 
-        ScopedExtensionAppParams app_params(engine);
-        dmExtension::AppFinalize(app_params);
+        {
+            ScopedExtensionAppParams app_params(engine);
+            dmExtension::AppFinalize(app_params);
+        }
 
 #if !defined(DM_NO_HTTP_CACHE)
         if (engine->m_HttpCache)
             dmHttpCache::Close(engine->m_HttpCache);
 #endif
+
+        ContextRegistryDestroy(engine->m_ContextRegistry);
+        engine->m_ContextRegistry = 0;
 
         dmBuffer::DeleteContext();
 
@@ -1012,6 +1027,33 @@ namespace dmEngine
 #endif
         engine->m_HidContext = dmHID::NewContext(new_hid_params);
 
+        engine->m_HttpCache = 0;
+#if !defined(DM_NO_HTTP_CACHE)
+        int http_cache_enabled = dmConfigFile::GetInt(engine->m_Config, "network.http_cache_enabled", 1);
+        if (http_cache_enabled)
+        {
+            char path[1024];
+            dmHttpCache::NewParams cache_params;
+            dmSys::Result sys_result = dmSys::GetApplicationSupportPath(DMSYS_APPLICATION_NAME, path, sizeof(path));
+            if (sys_result == dmSys::RESULT_OK)
+            {
+                dmStrlCat(path, "/http-cache", sizeof(path));
+                cache_params.m_Path = path;
+                dmHttpCache::Result cache_r = dmHttpCache::Open(&cache_params, &engine->m_HttpCache);
+                if (cache_r != dmHttpCache::RESULT_OK)
+                {
+                    dmLogWarning("Unable to open http cache (%d)", cache_r);
+                }
+            }
+            else
+            {
+                dmLogWarning("Unable to locate application support path for \"%s\": (%d)", DMSYS_APPLICATION_NAME, sys_result);
+            }
+        }
+#endif
+
+        PopulateContextRegistry(engine, 0);
+
         ScopedExtensionAppParams app_params(engine);
         dmExtension::Result er = dmExtension::AppInitialize(app_params);
         if (er != dmExtension::RESULT_OK) {
@@ -1198,32 +1240,6 @@ namespace dmEngine
 
         SetUpdateFrequency(engine, dmConfigFile::GetInt(engine->m_Config, "display.update_frequency", 0));
 
-        engine->m_HttpCache = 0;
-#if !defined(DM_NO_HTTP_CACHE)
-        int http_cache_enabled = dmConfigFile::GetInt(engine->m_Config, "network.http_cache_enabled", 1);
-        if (http_cache_enabled)
-        {
-            char path[1024];
-            dmHttpCache::NewParams cache_params;
-            dmSys::Result sys_result = dmSys::GetApplicationSupportPath(DMSYS_APPLICATION_NAME, path, sizeof(path));
-            if (sys_result == dmSys::RESULT_OK)
-            {
-                dmStrlCat(path, "/http-cache", sizeof(path));
-                cache_params.m_Path = path;
-                dmHttpCache::Result cache_r = dmHttpCache::Open(&cache_params, &engine->m_HttpCache);
-                if (cache_r != dmHttpCache::RESULT_OK)
-                {
-                    dmLogWarning("Unable to open http cache (%d)", cache_r);
-                }
-            }
-            else
-            {
-                dmLogWarning("Unable to locate application support path for \"%s\": (%d)", DMSYS_APPLICATION_NAME, sys_result);
-            }
-        }
-#endif
-
-
         const uint32_t max_resources = dmConfigFile::GetInt(engine->m_Config, dmResource::MAX_RESOURCES_KEY, 1024);
         dmResource::NewFactoryParams params;
         params.m_MaxResources = max_resources;
@@ -1262,6 +1278,7 @@ namespace dmEngine
         script_params.m_ConfigFile      = engine->m_Config;
         script_params.m_GraphicsContext = engine->m_GraphicsContext;
 
+        PopulateContextRegistry(engine, 0);
 
         ScopedExtensionParams extension_params(engine);
 
@@ -1270,6 +1287,7 @@ namespace dmEngine
         {
             engine->m_SharedScriptContext = dmScript::NewContext(script_params);
             dmScript::Initialize(engine->m_SharedScriptContext);
+            PopulateContextRegistry(engine, engine->m_SharedScriptContext);
             extension_params.SetLuaContext(engine->m_SharedScriptContext);
             dmExtension::Initialize(extension_params);
 
@@ -1283,16 +1301,19 @@ namespace dmEngine
         {
             engine->m_GOScriptContext = dmScript::NewContext(script_params);
             dmScript::Initialize(engine->m_GOScriptContext);
+            PopulateContextRegistry(engine, engine->m_GOScriptContext);
             extension_params.SetLuaContext(engine->m_GOScriptContext);
             dmExtension::Initialize(extension_params);
 
             engine->m_RenderScriptContext = dmScript::NewContext(script_params);
             dmScript::Initialize(engine->m_RenderScriptContext);
+            PopulateContextRegistry(engine, engine->m_RenderScriptContext);
             extension_params.SetLuaContext(engine->m_RenderScriptContext);
             dmExtension::Initialize(extension_params);
 
             engine->m_GuiScriptContext = dmScript::NewContext(script_params);
             dmScript::Initialize(engine->m_GuiScriptContext);
+            PopulateContextRegistry(engine, engine->m_GuiScriptContext);
             extension_params.SetLuaContext(engine->m_GuiScriptContext);
             dmExtension::Initialize(extension_params);
 
@@ -1301,6 +1322,7 @@ namespace dmEngine
             module_script_contexts.Push(engine->m_RenderScriptContext);
             module_script_contexts.Push(engine->m_GuiScriptContext);
         }
+        PopulateContextRegistry(engine, engine->m_SharedScriptContext ? engine->m_SharedScriptContext : engine->m_GOScriptContext);
 
         dmSound::InitializeParams sound_params;
         sound_params.m_OutputDevice = "default";
@@ -1341,6 +1363,7 @@ namespace dmEngine
 #endif
         render_params.m_MaxBatches = (uint32_t) dmConfigFile::GetInt(engine->m_Config, "graphics.max_font_batches", 128);
         engine->m_RenderContext = dmRender::NewRenderContext(engine->m_GraphicsContext, render_params);
+        PopulateContextRegistry(engine, engine->m_SharedScriptContext ? engine->m_SharedScriptContext : engine->m_GOScriptContext);
 
         dmGameObject::Initialize(engine->m_Register, engine->m_GOScriptContext);
 
@@ -1406,6 +1429,7 @@ namespace dmEngine
         gui_params.m_Dpi = physical_dpi;
 
         engine->m_GuiContext = dmGui::NewContext(&gui_params);
+        PopulateContextRegistry(engine, engine->m_SharedScriptContext ? engine->m_SharedScriptContext : engine->m_GOScriptContext);
 
         UpdateGuiSafeAreaAdjust(engine, physical_width, physical_height);
 
@@ -1511,8 +1535,9 @@ namespace dmEngine
             engine->m_CollectionFactoryContext.m_ScriptContext = engine->m_GOScriptContext;
         }
 
+        dmGameObject::ComponentTypeCreateCtxImpl component_create_ctx_impl;
         dmGameObject::ComponentTypeCreateCtx component_create_ctx;
-        SetupComponentCreateContext(engine, component_create_ctx);
+        SetupComponentCreateContext(engine, component_create_ctx, component_create_ctx_impl);
 
         dmResource::Result fact_result;
         dmGameSystem::ScriptLibContext script_lib_context;

--- a/engine/engine/src/engine_private.h
+++ b/engine/engine/src/engine_private.h
@@ -21,6 +21,7 @@
 #include <dlib/hashtable.h>
 #include <dlib/jobsystem.h>
 #include <dlib/message.h>
+#include <dlib/context_registry.h>
 #include <dlib/http_cache.h>
 
 #include <resource/resource.h>
@@ -154,6 +155,7 @@ namespace dmEngine
         dmInput::HBinding                           m_GameInputBinding;
         dmRender::HDisplayProfiles                  m_DisplayProfiles;
         dmHttpCache::HCache                         m_HttpCache;
+        HContextRegistry                            m_ContextRegistry;
 
         dmGameSystem::RenderScriptPrototype*        m_RenderScriptPrototype;
 

--- a/engine/engine/src/extension.cpp
+++ b/engine/engine/src/extension.cpp
@@ -19,24 +19,24 @@ namespace dmEngine
     dmConfigFile::HConfig GetConfigFile(dmExtension::AppParams* app_params)
     {
         HContextRegistry context_registry = ExtensionAppParamsGetContextRegistry(app_params);
-        return (HConfigFile)ContextRegistryGetByName(context_registry, CONFIGFILE_CONTEXT_NAME);
+        return (HConfigFile)ContextRegistryGet(context_registry, CONFIGFILE_CONTEXT_NAME);
     }
 
     dmWebServer::HServer GetWebServer(dmExtension::AppParams* app_params)
     {
         HContextRegistry context_registry = ExtensionAppParamsGetContextRegistry(app_params);
-        return (dmWebServer::HServer)ContextRegistryGetByName(context_registry, WEBSERVER_CONTEXT_NAME);
+        return (dmWebServer::HServer)ContextRegistryGet(context_registry, WEBSERVER_CONTEXT_NAME);
     }
 
     dmGameObject::HRegister GetGameObjectRegister(dmExtension::AppParams* app_params)
     {
         HContextRegistry context_registry = ExtensionAppParamsGetContextRegistry(app_params);
-        return (dmGameObject::HRegister)ContextRegistryGetByName(context_registry, GAMEOBJECT_CONTEXT_NAME);
+        return (dmGameObject::HRegister)ContextRegistryGet(context_registry, GAMEOBJECT_CONTEXT_NAME);
     }
 
     dmHID::HContext GetHIDContext(dmExtension::AppParams* app_params)
     {
         HContextRegistry context_registry = ExtensionAppParamsGetContextRegistry(app_params);
-        return (dmHID::HContext)ContextRegistryGetByName(context_registry, HID_CONTEXT_NAME);
+        return (dmHID::HContext)ContextRegistryGet(context_registry, HID_CONTEXT_NAME);
     }
 }

--- a/engine/engine/src/extension.cpp
+++ b/engine/engine/src/extension.cpp
@@ -18,21 +18,25 @@ namespace dmEngine
 {
     dmConfigFile::HConfig GetConfigFile(dmExtension::AppParams* app_params)
     {
-        return (HConfigFile)ExtensionAppParamsGetContext(app_params, dmHashString64("config"));
+        HContextRegistry context_registry = ExtensionAppParamsGetContextRegistry(app_params);
+        return (HConfigFile)ContextRegistryGetByName(context_registry, CONFIGFILE_CONTEXT_NAME);
     }
 
     dmWebServer::HServer GetWebServer(dmExtension::AppParams* app_params)
     {
-        return (dmWebServer::HServer)ExtensionAppParamsGetContext(app_params, dmHashString64("webserver"));
+        HContextRegistry context_registry = ExtensionAppParamsGetContextRegistry(app_params);
+        return (dmWebServer::HServer)ContextRegistryGetByName(context_registry, WEBSERVER_CONTEXT_NAME);
     }
 
     dmGameObject::HRegister GetGameObjectRegister(dmExtension::AppParams* app_params)
     {
-        return (dmGameObject::HRegister)ExtensionAppParamsGetContext(app_params, dmHashString64("register"));
+        HContextRegistry context_registry = ExtensionAppParamsGetContextRegistry(app_params);
+        return (dmGameObject::HRegister)ContextRegistryGetByName(context_registry, GAMEOBJECT_CONTEXT_NAME);
     }
 
     dmHID::HContext GetHIDContext(dmExtension::AppParams* app_params)
     {
-        return (dmHID::HContext)ExtensionAppParamsGetContext(app_params, dmHashString64("hid"));
+        HContextRegistry context_registry = ExtensionAppParamsGetContextRegistry(app_params);
+        return (dmHID::HContext)ContextRegistryGetByName(context_registry, HID_CONTEXT_NAME);
     }
 }

--- a/engine/extension/src/dmsdk/extension/extension.h
+++ b/engine/extension/src/dmsdk/extension/extension.h
@@ -20,6 +20,7 @@
 
 #include <dmsdk/dlib/align.h> // DM_ALIGNED
 #include <dmsdk/dlib/configfile.h>
+#include <dmsdk/dlib/context_registry.h>
 
 #if defined(__cplusplus)
 extern "C" {
@@ -116,6 +117,14 @@ typedef enum ExtensionAppExitCode
 } ExtensionAppExitCode;
 
 /*#
+ * Extension context cache.
+ * @note Deprecated. Use [ref:HContextRegistry] instead.
+ * @typedef
+ * @name HExtensionContextCache
+ */
+typedef HContextRegistry HExtensionContextCache;
+
+/*#
  * The extension app parameters
  * @struct
  * @name ExtensionAppParams
@@ -190,7 +199,136 @@ void ExtensionParamsInitialize(ExtensionParams* app_params);
 void ExtensionParamsFinalize(ExtensionParams* params);
 
 /*#
+ * Creates an extension context cache.
+ * @note Deprecated. Context registries are engine-owned; use [ref:ExtensionAppParamsGetContextRegistry] or [ref:ExtensionParamsGetContextRegistry] instead.
+ * @name ExtensionContextCacheCreate
+ * @return context_cache [type:HExtensionContextCache] the context cache
+ */
+HExtensionContextCache ExtensionContextCacheCreate();
+
+/*#
+ * Destroys an extension context cache.
+ * @note Deprecated. Context registries are engine-owned; use [ref:ExtensionAppParamsGetContextRegistry] or [ref:ExtensionParamsGetContextRegistry] instead.
+ * @name ExtensionContextCacheDestroy
+ * @param context_cache [type:HExtensionContextCache] the context cache
+ */
+void ExtensionContextCacheDestroy(HExtensionContextCache context_cache);
+
+/*#
+ * Sets the context registry used by the extension app params.
+ * The params do not take ownership of the registry. The registry must outlive any params that use it.
+ * @name ExtensionAppParamsSetContextRegistry
+ * @param params [type:ExtensionAppParams*] the params
+ * @param context_registry [type:HContextRegistry] the context registry
+ */
+void ExtensionAppParamsSetContextRegistry(ExtensionAppParams* params, HContextRegistry context_registry);
+
+/*#
+ * Gets the context registry used by the extension app params.
+ * @name ExtensionAppParamsGetContextRegistry
+ * @param params [type:ExtensionAppParams*] the params
+ * @return context_registry [type:HContextRegistry] the context registry
+ */
+HContextRegistry ExtensionAppParamsGetContextRegistry(ExtensionAppParams* params);
+
+/*#
+ * Sets the context registry used by the extension params.
+ * The params do not take ownership of the registry. The registry must outlive any params that use it.
+ * @name ExtensionParamsSetContextRegistry
+ * @param params [type:ExtensionParams*] the params
+ * @param context_registry [type:HContextRegistry] the context registry
+ */
+void ExtensionParamsSetContextRegistry(ExtensionParams* params, HContextRegistry context_registry);
+
+/*#
+ * Gets the context registry used by the extension params.
+ * @name ExtensionParamsGetContextRegistry
+ * @param params [type:ExtensionParams*] the params
+ * @return context_registry [type:HContextRegistry] the context registry
+ */
+HContextRegistry ExtensionParamsGetContextRegistry(ExtensionParams* params);
+
+/*#
+ * Sets the context cache used by the extension app params.
+ * @note Deprecated. Use [ref:ExtensionAppParamsSetContextRegistry] instead.
+ * @name ExtensionAppParamsSetContextCache
+ * @param params [type:ExtensionAppParams*] the params
+ * @param context_cache [type:HExtensionContextCache] the context cache
+ */
+void ExtensionAppParamsSetContextCache(ExtensionAppParams* params, HExtensionContextCache context_cache);
+
+/*#
+ * Gets the context cache used by the extension app params.
+ * @note Deprecated. Use [ref:ExtensionAppParamsGetContextRegistry] instead.
+ * @name ExtensionAppParamsGetContextCache
+ * @param params [type:ExtensionAppParams*] the params
+ * @return context_cache [type:HExtensionContextCache] the context cache
+ */
+HExtensionContextCache ExtensionAppParamsGetContextCache(ExtensionAppParams* params);
+
+/*#
+ * Sets the context cache used by the extension params.
+ * @note Deprecated. Use [ref:ExtensionParamsSetContextRegistry] instead.
+ * @name ExtensionParamsSetContextCache
+ * @param params [type:ExtensionParams*] the params
+ * @param context_cache [type:HExtensionContextCache] the context cache
+ */
+void ExtensionParamsSetContextCache(ExtensionParams* params, HExtensionContextCache context_cache);
+
+/*#
+ * Gets the context cache used by the extension params.
+ * @note Deprecated. Use [ref:ExtensionParamsGetContextRegistry] instead.
+ * @name ExtensionParamsGetContextCache
+ * @param params [type:ExtensionParams*] the params
+ * @return context_cache [type:HExtensionContextCache] the context cache
+ */
+HExtensionContextCache ExtensionParamsGetContextCache(ExtensionParams* params);
+
+/*#
+ * Sets a context in the extension context cache using a specified name.
+ * @note Deprecated. Use [ref:ContextRegistrySet] instead.
+ * @name ExtensionContextCacheSetContext
+ * @param context_cache [type:HExtensionContextCache] the context cache
+ * @param name [type:const char*] the context name
+ * @param context [type:void*] the context, or 0 to remove the context
+ * @return result [type:int] 0 if successful
+ */
+int ExtensionContextCacheSetContext(HExtensionContextCache context_cache, const char* name, void* context);
+
+/*#
+ * Sets a context in the extension context cache using a specified name hash.
+ * @note Deprecated. Use [ref:ContextRegistrySetByHash] instead.
+ * @name ExtensionContextCacheSetContextByHash
+ * @param context_cache [type:HExtensionContextCache] the context cache
+ * @param name_hash [type:dmhash_t] the context name hash
+ * @param context [type:void*] the context, or 0 to remove the context
+ * @return result [type:int] 0 if successful
+ */
+int ExtensionContextCacheSetContextByHash(HExtensionContextCache context_cache, dmhash_t name_hash, void* context);
+
+/*#
+ * Gets a context from the extension context cache using a specified name.
+ * @note Deprecated. Use [ref:ContextRegistryGetByName] instead.
+ * @name ExtensionContextCacheGetContextByName
+ * @param context_cache [type:HExtensionContextCache] the context cache
+ * @param name [type:const char*] the context name
+ * @return context [type:void*] The context, if it exists
+ */
+void* ExtensionContextCacheGetContextByName(HExtensionContextCache context_cache, const char* name);
+
+/*#
+ * Gets a context from the extension context cache using a specified name hash.
+ * @note Deprecated. Use [ref:ContextRegistryGetByHash] instead.
+ * @name ExtensionContextCacheGetContextByHash
+ * @param context_cache [type:HExtensionContextCache] the context cache
+ * @param name_hash [type:dmhash_t] the context name hash
+ * @return context [type:void*] The context, if it exists
+ */
+void* ExtensionContextCacheGetContextByHash(HExtensionContextCache context_cache, dmhash_t name_hash);
+
+/*#
  * Sets a context using a specified name
+ * @note Deprecated. Use [ref:ContextRegistrySet] on [ref:HContextRegistry] instead.
  * @name ExtensionAppParamsSetContext
  * @param params [type:ExtensionAppParams] the params
  * @param name [type:const char*] the context name
@@ -201,6 +339,7 @@ int ExtensionAppParamsSetContext(ExtensionAppParams* params, const char* name, v
 
 /*#
  * Gets a context using a specified name
+ * @note Deprecated. Use [ref:ContextRegistryGetByName] on [ref:HContextRegistry] instead.
  * @name ExtensionAppParamsGetContextByName
  * @param params [type:ExtensionAppParams] the params
  * @param name [type:const char*] the context name
@@ -210,6 +349,7 @@ void* ExtensionAppParamsGetContextByName(ExtensionAppParams* params, const char*
 
 /*#
  * Gets a context using a specified name hash
+ * @note Deprecated. Use [ref:ContextRegistryGetByHash] on [ref:HContextRegistry] instead.
  * @name ExtensionAppParamsGetContext
  * @param params [type:ExtensionAppParams] the params
  * @param name_hash [type:dmhash_t] the context name hash
@@ -226,8 +366,9 @@ ExtensionAppExitCode ExtensionAppParamsGetAppExitCode(ExtensionAppParams* app_pa
 
 /*#
  * Sets a context using a specified name
+ * @note Deprecated. Use [ref:ContextRegistrySet] on [ref:HContextRegistry] instead.
  * @name ExtensionParamsSetContext
- * @param params [type:ExtensionAppParams] the params
+ * @param params [type:ExtensionParams] the params
  * @param name [type:const char*] the context name
  * @param context [type:void*] the context
  * @return result [type:int] 0 if successful
@@ -236,6 +377,7 @@ int ExtensionParamsSetContext(ExtensionParams* params, const char* name, void* c
 
 /*#
  * Gets a context using a specified name
+ * @note Deprecated. Use [ref:ContextRegistryGetByName] on [ref:HContextRegistry] instead.
  * @name ExtensionParamsGetContextByName
  * @param params [type:ExtensionParams] the params
  * @param name [type:const char*] the context name
@@ -245,6 +387,7 @@ void* ExtensionParamsGetContextByName(ExtensionParams* params, const char* name)
 
 /*#
  * Gets a context using a specified name hash
+ * @note Deprecated. Use [ref:ContextRegistryGetByHash] on [ref:HContextRegistry] instead.
  * @name ExtensionParamsGetContext
  * @param params [type:ExtensionParams] the params
  * @param name_hash [type:dmhash_t] the context name hash

--- a/engine/extension/src/dmsdk/extension/extension.h
+++ b/engine/extension/src/dmsdk/extension/extension.h
@@ -117,14 +117,6 @@ typedef enum ExtensionAppExitCode
 } ExtensionAppExitCode;
 
 /*#
- * Extension context cache.
- * @note Deprecated. Use [ref:HContextRegistry] instead.
- * @typedef
- * @name HExtensionContextCache
- */
-typedef HContextRegistry HExtensionContextCache;
-
-/*#
  * The extension app parameters
  * @struct
  * @name ExtensionAppParams
@@ -199,31 +191,6 @@ void ExtensionParamsInitialize(ExtensionParams* app_params);
 void ExtensionParamsFinalize(ExtensionParams* params);
 
 /*#
- * Creates an extension context cache.
- * @note Deprecated. Context registries are engine-owned; use [ref:ExtensionAppParamsGetContextRegistry] or [ref:ExtensionParamsGetContextRegistry] instead.
- * @name ExtensionContextCacheCreate
- * @return context_cache [type:HExtensionContextCache] the context cache
- */
-HExtensionContextCache ExtensionContextCacheCreate();
-
-/*#
- * Destroys an extension context cache.
- * @note Deprecated. Context registries are engine-owned; use [ref:ExtensionAppParamsGetContextRegistry] or [ref:ExtensionParamsGetContextRegistry] instead.
- * @name ExtensionContextCacheDestroy
- * @param context_cache [type:HExtensionContextCache] the context cache
- */
-void ExtensionContextCacheDestroy(HExtensionContextCache context_cache);
-
-/*#
- * Sets the context registry used by the extension app params.
- * The params do not take ownership of the registry. The registry must outlive any params that use it.
- * @name ExtensionAppParamsSetContextRegistry
- * @param params [type:ExtensionAppParams*] the params
- * @param context_registry [type:HContextRegistry] the context registry
- */
-void ExtensionAppParamsSetContextRegistry(ExtensionAppParams* params, HContextRegistry context_registry);
-
-/*#
  * Gets the context registry used by the extension app params.
  * @name ExtensionAppParamsGetContextRegistry
  * @param params [type:ExtensionAppParams*] the params
@@ -232,99 +199,12 @@ void ExtensionAppParamsSetContextRegistry(ExtensionAppParams* params, HContextRe
 HContextRegistry ExtensionAppParamsGetContextRegistry(ExtensionAppParams* params);
 
 /*#
- * Sets the context registry used by the extension params.
- * The params do not take ownership of the registry. The registry must outlive any params that use it.
- * @name ExtensionParamsSetContextRegistry
- * @param params [type:ExtensionParams*] the params
- * @param context_registry [type:HContextRegistry] the context registry
- */
-void ExtensionParamsSetContextRegistry(ExtensionParams* params, HContextRegistry context_registry);
-
-/*#
  * Gets the context registry used by the extension params.
  * @name ExtensionParamsGetContextRegistry
  * @param params [type:ExtensionParams*] the params
  * @return context_registry [type:HContextRegistry] the context registry
  */
 HContextRegistry ExtensionParamsGetContextRegistry(ExtensionParams* params);
-
-/*#
- * Sets the context cache used by the extension app params.
- * @note Deprecated. Use [ref:ExtensionAppParamsSetContextRegistry] instead.
- * @name ExtensionAppParamsSetContextCache
- * @param params [type:ExtensionAppParams*] the params
- * @param context_cache [type:HExtensionContextCache] the context cache
- */
-void ExtensionAppParamsSetContextCache(ExtensionAppParams* params, HExtensionContextCache context_cache);
-
-/*#
- * Gets the context cache used by the extension app params.
- * @note Deprecated. Use [ref:ExtensionAppParamsGetContextRegistry] instead.
- * @name ExtensionAppParamsGetContextCache
- * @param params [type:ExtensionAppParams*] the params
- * @return context_cache [type:HExtensionContextCache] the context cache
- */
-HExtensionContextCache ExtensionAppParamsGetContextCache(ExtensionAppParams* params);
-
-/*#
- * Sets the context cache used by the extension params.
- * @note Deprecated. Use [ref:ExtensionParamsSetContextRegistry] instead.
- * @name ExtensionParamsSetContextCache
- * @param params [type:ExtensionParams*] the params
- * @param context_cache [type:HExtensionContextCache] the context cache
- */
-void ExtensionParamsSetContextCache(ExtensionParams* params, HExtensionContextCache context_cache);
-
-/*#
- * Gets the context cache used by the extension params.
- * @note Deprecated. Use [ref:ExtensionParamsGetContextRegistry] instead.
- * @name ExtensionParamsGetContextCache
- * @param params [type:ExtensionParams*] the params
- * @return context_cache [type:HExtensionContextCache] the context cache
- */
-HExtensionContextCache ExtensionParamsGetContextCache(ExtensionParams* params);
-
-/*#
- * Sets a context in the extension context cache using a specified name.
- * @note Deprecated. Use [ref:ContextRegistrySet] instead.
- * @name ExtensionContextCacheSetContext
- * @param context_cache [type:HExtensionContextCache] the context cache
- * @param name [type:const char*] the context name
- * @param context [type:void*] the context, or 0 to remove the context
- * @return result [type:int] 0 if successful
- */
-int ExtensionContextCacheSetContext(HExtensionContextCache context_cache, const char* name, void* context);
-
-/*#
- * Sets a context in the extension context cache using a specified name hash.
- * @note Deprecated. Use [ref:ContextRegistrySetByHash] instead.
- * @name ExtensionContextCacheSetContextByHash
- * @param context_cache [type:HExtensionContextCache] the context cache
- * @param name_hash [type:dmhash_t] the context name hash
- * @param context [type:void*] the context, or 0 to remove the context
- * @return result [type:int] 0 if successful
- */
-int ExtensionContextCacheSetContextByHash(HExtensionContextCache context_cache, dmhash_t name_hash, void* context);
-
-/*#
- * Gets a context from the extension context cache using a specified name.
- * @note Deprecated. Use [ref:ContextRegistryGetByName] instead.
- * @name ExtensionContextCacheGetContextByName
- * @param context_cache [type:HExtensionContextCache] the context cache
- * @param name [type:const char*] the context name
- * @return context [type:void*] The context, if it exists
- */
-void* ExtensionContextCacheGetContextByName(HExtensionContextCache context_cache, const char* name);
-
-/*#
- * Gets a context from the extension context cache using a specified name hash.
- * @note Deprecated. Use [ref:ContextRegistryGetByHash] instead.
- * @name ExtensionContextCacheGetContextByHash
- * @param context_cache [type:HExtensionContextCache] the context cache
- * @param name_hash [type:dmhash_t] the context name hash
- * @return context [type:void*] The context, if it exists
- */
-void* ExtensionContextCacheGetContextByHash(HExtensionContextCache context_cache, dmhash_t name_hash);
 
 /*#
  * Sets a context using a specified name
@@ -339,7 +219,7 @@ int ExtensionAppParamsSetContext(ExtensionAppParams* params, const char* name, v
 
 /*#
  * Gets a context using a specified name
- * @note Deprecated. Use [ref:ContextRegistryGetByName] on [ref:HContextRegistry] instead.
+ * @note Deprecated. Use [ref:ContextRegistryGet] on [ref:HContextRegistry] instead.
  * @name ExtensionAppParamsGetContextByName
  * @param params [type:ExtensionAppParams] the params
  * @param name [type:const char*] the context name
@@ -377,7 +257,7 @@ int ExtensionParamsSetContext(ExtensionParams* params, const char* name, void* c
 
 /*#
  * Gets a context using a specified name
- * @note Deprecated. Use [ref:ContextRegistryGetByName] on [ref:HContextRegistry] instead.
+ * @note Deprecated. Use [ref:ContextRegistryGet] on [ref:HContextRegistry] instead.
  * @name ExtensionParamsGetContextByName
  * @param params [type:ExtensionParams] the params
  * @param name [type:const char*] the context name

--- a/engine/extension/src/dmsdk/extension/extension.hpp
+++ b/engine/extension/src/dmsdk/extension/extension.hpp
@@ -20,32 +20,61 @@
 #endif
 
 #include <dmsdk/extension/extension_gen.hpp>
-#include <dmsdk/dlib/hash.h>
 
 namespace dmExtension {
 
    template<typename T>
+   T GetContextAsType(HContextRegistry context_registry, const char* name)
+   {
+      return (T)ContextRegistryGetByName(context_registry, name);
+   }
+
+   template<typename T>
+   T GetContextAsTypeByHash(HContextRegistry context_registry, dmhash_t name_hash)
+   {
+      return (T)ContextRegistryGetByHash(context_registry, name_hash);
+   }
+
+   template<typename T>
+   T GetContextAsType(HContextRegistry context_registry, dmhash_t name_hash)
+   {
+      return GetContextAsTypeByHash<T>(context_registry, name_hash);
+   }
+
+   template<typename T>
    T GetContextAsType(dmExtension::AppParams* app_params, const char* name)
    {
-      return (T)ExtensionAppParamsGetContextByName((ExtensionAppParams*)app_params, name);
+      return GetContextAsType<T>(ExtensionAppParamsGetContextRegistry((ExtensionAppParams*)app_params), name);
+   }
+
+   template<typename T>
+   T GetContextAsTypeByHash(dmExtension::AppParams* app_params, dmhash_t name_hash)
+   {
+      return GetContextAsTypeByHash<T>(ExtensionAppParamsGetContextRegistry((ExtensionAppParams*)app_params), name_hash);
    }
 
    template<typename T>
    T GetContextAsType(dmExtension::AppParams* app_params, dmhash_t name_hash)
    {
-      return (T)ExtensionAppParamsGetContext((ExtensionAppParams*)app_params, name_hash);
+      return GetContextAsTypeByHash<T>(app_params, name_hash);
    }
 
    template<typename T>
    T GetContextAsType(dmExtension::Params* params, const char* name)
    {
-      return (T)ExtensionParamsGetContextByName((ExtensionParams*)params, name);
+      return GetContextAsType<T>(ExtensionParamsGetContextRegistry((ExtensionParams*)params), name);
+   }
+
+   template<typename T>
+   T GetContextAsTypeByHash(dmExtension::Params* params, dmhash_t name_hash)
+   {
+      return GetContextAsTypeByHash<T>(ExtensionParamsGetContextRegistry((ExtensionParams*)params), name_hash);
    }
 
    template<typename T>
    T GetContextAsType(dmExtension::Params* params, dmhash_t name_hash)
    {
-      return (T)ExtensionParamsGetContext((ExtensionParams*)params, name_hash);
+      return GetContextAsTypeByHash<T>(params, name_hash);
    }
 
 

--- a/engine/extension/src/dmsdk/extension/extension.hpp
+++ b/engine/extension/src/dmsdk/extension/extension.hpp
@@ -20,64 +20,83 @@
 #endif
 
 #include <dmsdk/extension/extension_gen.hpp>
+#include <dmsdk/dlib/log.h>
+
+#if defined(_MSC_VER)
+#define DM_EXTENSION_DEPRECATED_CONTEXT_HELPER __declspec(deprecated("Use the context registry API directly instead"))
+#elif defined(__GNUC__) || defined(__clang__)
+#define DM_EXTENSION_DEPRECATED_CONTEXT_HELPER __attribute__((deprecated("Use the context registry API directly instead")))
+#else
+#define DM_EXTENSION_DEPRECATED_CONTEXT_HELPER
+#endif
 
 namespace dmExtension {
 
    template<typename T>
-   T GetContextAsType(HContextRegistry context_registry, const char* name)
+   DM_EXTENSION_DEPRECATED_CONTEXT_HELPER T GetContextAsType(HContextRegistry context_registry, const char* name)
    {
-      return (T)ContextRegistryGetByName(context_registry, name);
+      dmLogOnceWarning("%s", "dmExtension::GetContextAsType is deprecated. Use ContextRegistryGet directly instead.");
+      return (T)ContextRegistryGet(context_registry, name);
    }
 
    template<typename T>
-   T GetContextAsTypeByHash(HContextRegistry context_registry, dmhash_t name_hash)
+   DM_EXTENSION_DEPRECATED_CONTEXT_HELPER T GetContextAsTypeByHash(HContextRegistry context_registry, dmhash_t name_hash)
    {
+      dmLogOnceWarning("%s", "dmExtension::GetContextAsTypeByHash is deprecated. Use ContextRegistryGetByHash directly instead.");
       return (T)ContextRegistryGetByHash(context_registry, name_hash);
    }
 
    template<typename T>
-   T GetContextAsType(HContextRegistry context_registry, dmhash_t name_hash)
+   DM_EXTENSION_DEPRECATED_CONTEXT_HELPER T GetContextAsType(HContextRegistry context_registry, dmhash_t name_hash)
    {
-      return GetContextAsTypeByHash<T>(context_registry, name_hash);
+      dmLogOnceWarning("%s", "dmExtension::GetContextAsType is deprecated. Use ContextRegistryGetByHash directly instead.");
+      return (T)ContextRegistryGetByHash(context_registry, name_hash);
    }
 
    template<typename T>
-   T GetContextAsType(dmExtension::AppParams* app_params, const char* name)
+   DM_EXTENSION_DEPRECATED_CONTEXT_HELPER T GetContextAsType(dmExtension::AppParams* app_params, const char* name)
    {
-      return GetContextAsType<T>(ExtensionAppParamsGetContextRegistry((ExtensionAppParams*)app_params), name);
+      dmLogOnceWarning("%s", "dmExtension::GetContextAsType is deprecated. Use ExtensionAppParamsGetContextRegistry and the context registry API directly instead.");
+      return (T)ContextRegistryGet(ExtensionAppParamsGetContextRegistry((ExtensionAppParams*)app_params), name);
    }
 
    template<typename T>
-   T GetContextAsTypeByHash(dmExtension::AppParams* app_params, dmhash_t name_hash)
+   DM_EXTENSION_DEPRECATED_CONTEXT_HELPER T GetContextAsTypeByHash(dmExtension::AppParams* app_params, dmhash_t name_hash)
    {
-      return GetContextAsTypeByHash<T>(ExtensionAppParamsGetContextRegistry((ExtensionAppParams*)app_params), name_hash);
+      dmLogOnceWarning("%s", "dmExtension::GetContextAsTypeByHash is deprecated. Use ExtensionAppParamsGetContextRegistry and the context registry API directly instead.");
+      return (T)ContextRegistryGetByHash(ExtensionAppParamsGetContextRegistry((ExtensionAppParams*)app_params), name_hash);
    }
 
    template<typename T>
-   T GetContextAsType(dmExtension::AppParams* app_params, dmhash_t name_hash)
+   DM_EXTENSION_DEPRECATED_CONTEXT_HELPER T GetContextAsType(dmExtension::AppParams* app_params, dmhash_t name_hash)
    {
-      return GetContextAsTypeByHash<T>(app_params, name_hash);
+      dmLogOnceWarning("%s", "dmExtension::GetContextAsType is deprecated. Use ExtensionAppParamsGetContextRegistry and the context registry API directly instead.");
+      return (T)ContextRegistryGetByHash(ExtensionAppParamsGetContextRegistry((ExtensionAppParams*)app_params), name_hash);
    }
 
    template<typename T>
-   T GetContextAsType(dmExtension::Params* params, const char* name)
+   DM_EXTENSION_DEPRECATED_CONTEXT_HELPER T GetContextAsType(dmExtension::Params* params, const char* name)
    {
-      return GetContextAsType<T>(ExtensionParamsGetContextRegistry((ExtensionParams*)params), name);
+      dmLogOnceWarning("%s", "dmExtension::GetContextAsType is deprecated. Use ExtensionParamsGetContextRegistry and the context registry API directly instead.");
+      return (T)ContextRegistryGet(ExtensionParamsGetContextRegistry((ExtensionParams*)params), name);
    }
 
    template<typename T>
-   T GetContextAsTypeByHash(dmExtension::Params* params, dmhash_t name_hash)
+   DM_EXTENSION_DEPRECATED_CONTEXT_HELPER T GetContextAsTypeByHash(dmExtension::Params* params, dmhash_t name_hash)
    {
-      return GetContextAsTypeByHash<T>(ExtensionParamsGetContextRegistry((ExtensionParams*)params), name_hash);
+      dmLogOnceWarning("%s", "dmExtension::GetContextAsTypeByHash is deprecated. Use ExtensionParamsGetContextRegistry and the context registry API directly instead.");
+      return (T)ContextRegistryGetByHash(ExtensionParamsGetContextRegistry((ExtensionParams*)params), name_hash);
    }
 
    template<typename T>
-   T GetContextAsType(dmExtension::Params* params, dmhash_t name_hash)
+   DM_EXTENSION_DEPRECATED_CONTEXT_HELPER T GetContextAsType(dmExtension::Params* params, dmhash_t name_hash)
    {
-      return GetContextAsTypeByHash<T>(params, name_hash);
+      dmLogOnceWarning("%s", "dmExtension::GetContextAsType is deprecated. Use ExtensionParamsGetContextRegistry and the context registry API directly instead.");
+      return (T)ContextRegistryGetByHash(ExtensionParamsGetContextRegistry((ExtensionParams*)params), name_hash);
    }
-
 
 } // namespace
+
+#undef DM_EXTENSION_DEPRECATED_CONTEXT_HELPER
 
 #endif // DMSDK_EXTENSION_HPP

--- a/engine/extension/src/extension.cpp
+++ b/engine/extension/src/extension.cpp
@@ -119,16 +119,6 @@ void ExtensionParamsFinalize(ExtensionParams* params)
     params->m_Impl = 0;
 }
 
-HExtensionContextCache ExtensionContextCacheCreate()
-{
-    return ContextRegistryCreate();
-}
-
-void ExtensionContextCacheDestroy(HExtensionContextCache context_cache)
-{
-    ContextRegistryDestroy(context_cache);
-}
-
 void ExtensionAppParamsSetContextRegistry(ExtensionAppParams* params, HContextRegistry context_registry)
 {
     params->m_Impl->m_ContextRegistry = context_registry;
@@ -149,46 +139,6 @@ HContextRegistry ExtensionParamsGetContextRegistry(ExtensionParams* params)
     return params->m_Impl->m_ContextRegistry;
 }
 
-void ExtensionAppParamsSetContextCache(ExtensionAppParams* params, HExtensionContextCache context_cache)
-{
-    ExtensionAppParamsSetContextRegistry(params, context_cache);
-}
-
-HExtensionContextCache ExtensionAppParamsGetContextCache(ExtensionAppParams* params)
-{
-    return ExtensionAppParamsGetContextRegistry(params);
-}
-
-void ExtensionParamsSetContextCache(ExtensionParams* params, HExtensionContextCache context_cache)
-{
-    ExtensionParamsSetContextRegistry(params, context_cache);
-}
-
-HExtensionContextCache ExtensionParamsGetContextCache(ExtensionParams* params)
-{
-    return ExtensionParamsGetContextRegistry(params);
-}
-
-int ExtensionContextCacheSetContext(HExtensionContextCache context_cache, const char* name, void* context)
-{
-    return ContextRegistrySet(context_cache, name, context);
-}
-
-int ExtensionContextCacheSetContextByHash(HExtensionContextCache context_cache, dmhash_t name_hash, void* context)
-{
-    return ContextRegistrySetByHash(context_cache, name_hash, context);
-}
-
-void* ExtensionContextCacheGetContextByName(HExtensionContextCache context_cache, const char* name)
-{
-    return ContextRegistryGetByName(context_cache, name);
-}
-
-void* ExtensionContextCacheGetContextByHash(HExtensionContextCache context_cache, dmhash_t name_hash)
-{
-    return ContextRegistryGetByHash(context_cache, name_hash);
-}
-
 int ExtensionAppParamsSetContext(ExtensionAppParams* params, const char* name, void* context)
 {
     return ContextRegistrySet(ExtensionAppParamsGetContextRegistry(params), name, context);
@@ -201,7 +151,7 @@ void* ExtensionAppParamsGetContext(ExtensionAppParams* params, dmhash_t name_has
 
 void* ExtensionAppParamsGetContextByName(ExtensionAppParams* params, const char* name)
 {
-    return ContextRegistryGetByName(ExtensionAppParamsGetContextRegistry(params), name);
+    return ContextRegistryGet(ExtensionAppParamsGetContextRegistry(params), name);
 }
 
 ExtensionAppExitCode ExtensionAppParamsGetAppExitCode(ExtensionAppParams* app_params)
@@ -221,7 +171,7 @@ void* ExtensionParamsGetContext(ExtensionParams* params, dmhash_t name_hash)
 
 void* ExtensionParamsGetContextByName(ExtensionParams* params, const char* name)
 {
-    return ContextRegistryGetByName(ExtensionParamsGetContextRegistry(params), name);
+    return ContextRegistryGet(ExtensionParamsGetContextRegistry(params), name);
 }
 
 

--- a/engine/extension/src/extension.cpp
+++ b/engine/extension/src/extension.cpp
@@ -24,50 +24,12 @@
 struct ExtensionParamsImpl
 {
     HContextRegistry m_ContextRegistry;
-    bool             m_OwnsContextRegistry;
 
     ExtensionParamsImpl()
     : m_ContextRegistry(0)
-    , m_OwnsContextRegistry(false)
     {
     }
 };
-
-static ExtensionParamsImpl* NewExtensionParamsImpl()
-{
-    ExtensionParamsImpl* impl = new ExtensionParamsImpl;
-    impl->m_ContextRegistry = ContextRegistryCreate();
-    impl->m_OwnsContextRegistry = true;
-    return impl;
-}
-
-static void DeleteExtensionParamsImpl(ExtensionParamsImpl* impl)
-{
-    if (impl->m_OwnsContextRegistry)
-    {
-        ContextRegistryDestroy(impl->m_ContextRegistry);
-    }
-    delete impl;
-}
-
-static void SetContextRegistry(ExtensionParamsImpl* impl, HContextRegistry context_registry)
-{
-    assert(impl);
-    assert(context_registry);
-
-    if (impl->m_ContextRegistry == context_registry)
-    {
-        return;
-    }
-
-    if (impl->m_OwnsContextRegistry)
-    {
-        ContextRegistryDestroy(impl->m_ContextRegistry);
-    }
-
-    impl->m_ContextRegistry = context_registry;
-    impl->m_OwnsContextRegistry = false;
-}
 
 #if defined(__cplusplus)
 extern "C" {
@@ -136,24 +98,24 @@ bool ExtensionRegisterCallback(ExtensionCallbackType callback_type, FExtensionCa
 void ExtensionAppParamsInitialize(ExtensionAppParams* app_params)
 {
     memset(app_params, 0, sizeof(*app_params));
-    app_params->m_Impl = NewExtensionParamsImpl();
+    app_params->m_Impl = new ExtensionParamsImpl;
 }
 
 void ExtensionAppParamsFinalize(ExtensionAppParams* app_params)
 {
-    DeleteExtensionParamsImpl(app_params->m_Impl);
+    delete app_params->m_Impl;
     app_params->m_Impl = 0;
 }
 
 void ExtensionParamsInitialize(ExtensionParams* params)
 {
     memset(params, 0, sizeof(*params));
-    params->m_Impl = NewExtensionParamsImpl();
+    params->m_Impl = new ExtensionParamsImpl;
 }
 
 void ExtensionParamsFinalize(ExtensionParams* params)
 {
-    DeleteExtensionParamsImpl(params->m_Impl);
+    delete params->m_Impl;
     params->m_Impl = 0;
 }
 
@@ -169,7 +131,7 @@ void ExtensionContextCacheDestroy(HExtensionContextCache context_cache)
 
 void ExtensionAppParamsSetContextRegistry(ExtensionAppParams* params, HContextRegistry context_registry)
 {
-    SetContextRegistry(params->m_Impl, context_registry);
+    params->m_Impl->m_ContextRegistry = context_registry;
 }
 
 HContextRegistry ExtensionAppParamsGetContextRegistry(ExtensionAppParams* params)
@@ -179,7 +141,7 @@ HContextRegistry ExtensionAppParamsGetContextRegistry(ExtensionAppParams* params
 
 void ExtensionParamsSetContextRegistry(ExtensionParams* params, HContextRegistry context_registry)
 {
-    SetContextRegistry(params->m_Impl, context_registry);
+    params->m_Impl->m_ContextRegistry = context_registry;
 }
 
 HContextRegistry ExtensionParamsGetContextRegistry(ExtensionParams* params)

--- a/engine/extension/src/extension.cpp
+++ b/engine/extension/src/extension.cpp
@@ -12,9 +12,9 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
+#include <dlib/context_registry.h>
 #include <dlib/dstrings.h>
 #include <dlib/log.h>
-#include <dlib/hashtable.h>
 #include <dlib/static_assert.h>
 
 #include <dmsdk/dlib/profile.h>
@@ -23,48 +23,51 @@
 
 struct ExtensionParamsImpl
 {
-    dmHashTable64<void*> m_Contexts;
+    HContextRegistry m_ContextRegistry;
+    bool             m_OwnsContextRegistry;
+
+    ExtensionParamsImpl()
+    : m_ContextRegistry(0)
+    , m_OwnsContextRegistry(false)
+    {
+    }
 };
 
-static void EnsureSize(dmHashTable64<void*>* tbl)
+static ExtensionParamsImpl* NewExtensionParamsImpl()
 {
-    if (tbl->Full())
+    ExtensionParamsImpl* impl = new ExtensionParamsImpl;
+    impl->m_ContextRegistry = ContextRegistryCreate();
+    impl->m_OwnsContextRegistry = true;
+    return impl;
+}
+
+static void DeleteExtensionParamsImpl(ExtensionParamsImpl* impl)
+{
+    if (impl->m_OwnsContextRegistry)
     {
-        tbl->OffsetCapacity(4);
+        ContextRegistryDestroy(impl->m_ContextRegistry);
     }
+    delete impl;
 }
 
-static int SetContext(dmHashTable64<void*>* contexts, dmhash_t name_hash, void* context)
+static void SetContextRegistry(ExtensionParamsImpl* impl, HContextRegistry context_registry)
 {
-    assert(contexts);
-    EnsureSize(contexts);
+    assert(impl);
+    assert(context_registry);
 
-    if (context)
-        contexts->Put(name_hash, context);
-    else
+    if (impl->m_ContextRegistry == context_registry)
     {
-        void** pvalue = contexts->Get(name_hash);
-        if (pvalue)
-            contexts->Erase(name_hash);
+        return;
     }
-    return 0;
-}
 
-static int SetContext(dmHashTable64<void*>* contexts, const char* name, void* context)
-{
-    return SetContext(contexts, dmHashString64(name), context);
-}
-
-static void* GetContext(dmHashTable64<void*>* contexts, dmhash_t name_hash)
-{
-    void** pcontext = contexts->Get(name_hash);
-    if (pcontext != 0)
+    if (impl->m_OwnsContextRegistry)
     {
-        return *pcontext;
+        ContextRegistryDestroy(impl->m_ContextRegistry);
     }
-    return 0;
-}
 
+    impl->m_ContextRegistry = context_registry;
+    impl->m_OwnsContextRegistry = false;
+}
 
 #if defined(__cplusplus)
 extern "C" {
@@ -133,42 +136,110 @@ bool ExtensionRegisterCallback(ExtensionCallbackType callback_type, FExtensionCa
 void ExtensionAppParamsInitialize(ExtensionAppParams* app_params)
 {
     memset(app_params, 0, sizeof(*app_params));
-    app_params->m_Impl = new ExtensionParamsImpl;
-    memset(app_params->m_Impl, 0, sizeof(*app_params->m_Impl));
+    app_params->m_Impl = NewExtensionParamsImpl();
 }
 
 void ExtensionAppParamsFinalize(ExtensionAppParams* app_params)
 {
-    delete app_params->m_Impl;
+    DeleteExtensionParamsImpl(app_params->m_Impl);
     app_params->m_Impl = 0;
 }
 
 void ExtensionParamsInitialize(ExtensionParams* params)
 {
     memset(params, 0, sizeof(*params));
-    params->m_Impl = new ExtensionParamsImpl;
-    memset(params->m_Impl, 0, sizeof(*params->m_Impl));
+    params->m_Impl = NewExtensionParamsImpl();
 }
 
 void ExtensionParamsFinalize(ExtensionParams* params)
 {
-    delete params->m_Impl;
+    DeleteExtensionParamsImpl(params->m_Impl);
     params->m_Impl = 0;
+}
+
+HExtensionContextCache ExtensionContextCacheCreate()
+{
+    return ContextRegistryCreate();
+}
+
+void ExtensionContextCacheDestroy(HExtensionContextCache context_cache)
+{
+    ContextRegistryDestroy(context_cache);
+}
+
+void ExtensionAppParamsSetContextRegistry(ExtensionAppParams* params, HContextRegistry context_registry)
+{
+    SetContextRegistry(params->m_Impl, context_registry);
+}
+
+HContextRegistry ExtensionAppParamsGetContextRegistry(ExtensionAppParams* params)
+{
+    return params->m_Impl->m_ContextRegistry;
+}
+
+void ExtensionParamsSetContextRegistry(ExtensionParams* params, HContextRegistry context_registry)
+{
+    SetContextRegistry(params->m_Impl, context_registry);
+}
+
+HContextRegistry ExtensionParamsGetContextRegistry(ExtensionParams* params)
+{
+    return params->m_Impl->m_ContextRegistry;
+}
+
+void ExtensionAppParamsSetContextCache(ExtensionAppParams* params, HExtensionContextCache context_cache)
+{
+    ExtensionAppParamsSetContextRegistry(params, context_cache);
+}
+
+HExtensionContextCache ExtensionAppParamsGetContextCache(ExtensionAppParams* params)
+{
+    return ExtensionAppParamsGetContextRegistry(params);
+}
+
+void ExtensionParamsSetContextCache(ExtensionParams* params, HExtensionContextCache context_cache)
+{
+    ExtensionParamsSetContextRegistry(params, context_cache);
+}
+
+HExtensionContextCache ExtensionParamsGetContextCache(ExtensionParams* params)
+{
+    return ExtensionParamsGetContextRegistry(params);
+}
+
+int ExtensionContextCacheSetContext(HExtensionContextCache context_cache, const char* name, void* context)
+{
+    return ContextRegistrySet(context_cache, name, context);
+}
+
+int ExtensionContextCacheSetContextByHash(HExtensionContextCache context_cache, dmhash_t name_hash, void* context)
+{
+    return ContextRegistrySetByHash(context_cache, name_hash, context);
+}
+
+void* ExtensionContextCacheGetContextByName(HExtensionContextCache context_cache, const char* name)
+{
+    return ContextRegistryGetByName(context_cache, name);
+}
+
+void* ExtensionContextCacheGetContextByHash(HExtensionContextCache context_cache, dmhash_t name_hash)
+{
+    return ContextRegistryGetByHash(context_cache, name_hash);
 }
 
 int ExtensionAppParamsSetContext(ExtensionAppParams* params, const char* name, void* context)
 {
-    return SetContext(&params->m_Impl->m_Contexts, name, context);
+    return ContextRegistrySet(ExtensionAppParamsGetContextRegistry(params), name, context);
 }
 
 void* ExtensionAppParamsGetContext(ExtensionAppParams* params, dmhash_t name_hash)
 {
-    return GetContext(&params->m_Impl->m_Contexts, name_hash);
+    return ContextRegistryGetByHash(ExtensionAppParamsGetContextRegistry(params), name_hash);
 }
 
 void* ExtensionAppParamsGetContextByName(ExtensionAppParams* params, const char* name)
 {
-    return GetContext(&params->m_Impl->m_Contexts, dmHashString64(name));
+    return ContextRegistryGetByName(ExtensionAppParamsGetContextRegistry(params), name);
 }
 
 ExtensionAppExitCode ExtensionAppParamsGetAppExitCode(ExtensionAppParams* app_params)
@@ -178,17 +249,17 @@ ExtensionAppExitCode ExtensionAppParamsGetAppExitCode(ExtensionAppParams* app_pa
 
 int ExtensionParamsSetContext(ExtensionParams* params, const char* name, void* context)
 {
-    return SetContext(&params->m_Impl->m_Contexts, name, context);
+    return ContextRegistrySet(ExtensionParamsGetContextRegistry(params), name, context);
 }
 
 void* ExtensionParamsGetContext(ExtensionParams* params, dmhash_t name_hash)
 {
-    return GetContext(&params->m_Impl->m_Contexts, name_hash);
+    return ContextRegistryGetByHash(ExtensionParamsGetContextRegistry(params), name_hash);
 }
 
 void* ExtensionParamsGetContextByName(ExtensionParams* params, const char* name)
 {
-    return GetContext(&params->m_Impl->m_Contexts, dmHashString64(name));
+    return ContextRegistryGetByName(ExtensionParamsGetContextRegistry(params), name);
 }
 
 

--- a/engine/extension/src/extension.h
+++ b/engine/extension/src/extension.h
@@ -1,0 +1,31 @@
+// Copyright 2020-2026 The Defold Foundation
+// Copyright 2014-2020 King
+// Copyright 2009-2014 Ragnar Svensson, Christian Murray
+// Licensed under the Defold License version 1.0 (the "License"); you may not use
+// this file except in compliance with the License.
+//
+// You may obtain a copy of the License, together with FAQs at
+// https://www.defold.com/license
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#ifndef DM_EXTENSION_H
+#define DM_EXTENSION_H
+
+#include <dmsdk/extension/extension.h>
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+void ExtensionAppParamsSetContextRegistry(ExtensionAppParams* params, HContextRegistry context_registry);
+void ExtensionParamsSetContextRegistry(ExtensionParams* params, HContextRegistry context_registry);
+
+#if defined(__cplusplus)
+} // extern "C"
+#endif
+
+#endif // #ifndef DM_EXTENSION_H

--- a/engine/extension/src/extension.hpp
+++ b/engine/extension/src/extension.hpp
@@ -19,12 +19,6 @@
 
 struct ExtensionDesc;
 
-extern "C"
-{
-    void ExtensionAppParamsSetContextRegistry(ExtensionAppParams* params, HContextRegistry context_registry);
-    void ExtensionParamsSetContextRegistry(ExtensionParams* params, HContextRegistry context_registry);
-}
-
 namespace dmExtension
 {
     typedef const ExtensionDesc* HExtension;

--- a/engine/extension/src/extension.hpp
+++ b/engine/extension/src/extension.hpp
@@ -19,6 +19,12 @@
 
 struct ExtensionDesc;
 
+extern "C"
+{
+    void ExtensionAppParamsSetContextRegistry(ExtensionAppParams* params, HContextRegistry context_registry);
+    void ExtensionParamsSetContextRegistry(ExtensionParams* params, HContextRegistry context_registry);
+}
+
 namespace dmExtension
 {
     typedef const ExtensionDesc* HExtension;

--- a/engine/extension/src/test/test_extension.cpp
+++ b/engine/extension/src/test/test_extension.cpp
@@ -15,6 +15,7 @@
 #include <stdlib.h>
 #define JC_TEST_IMPLEMENTATION
 #include <jc_test/jc_test.h>
+#include "../extension.h"
 #include "../extension.hpp"
 #include "test_extension.h"
 #include <dlib/context_registry.h>

--- a/engine/extension/src/test/test_extension.cpp
+++ b/engine/extension/src/test/test_extension.cpp
@@ -56,7 +56,7 @@ TEST(dmExtension, Basic)
 
     int engine_hash_context = 7331;
     ContextRegistrySetByHash(context_registry, dmHashString64("engine_hash"), &engine_hash_context);
-    ASSERT_EQ((void*)&engine_hash_context, ContextRegistryGetByName(context_registry, "engine_hash"));
+    ASSERT_EQ((void*)&engine_hash_context, ContextRegistryGet(context_registry, "engine_hash"));
 
     ASSERT_EQ(0, g_TestAppInitCount);
     ASSERT_EQ(dmExtension::RESULT_OK, dmExtension::AppInitialize(&appparams));
@@ -65,7 +65,7 @@ TEST(dmExtension, Basic)
     ASSERT_NE((dmExtension::HExtension)0, extension);
     ASSERT_EQ((dmExtension::HExtension)0, dmExtension::GetNextExtension(extension));
 
-    ASSERT_NE((void*)0, ContextRegistryGetByName(context_registry, "lib"));
+    ASSERT_NE((void*)0, ContextRegistryGet(context_registry, "lib"));
     ASSERT_NE((void*)0, ContextRegistryGetByHash(context_registry, dmHashString64("lib")));
 
     ExtensionAppParamsFinalize(&appparams);
@@ -74,13 +74,13 @@ TEST(dmExtension, Basic)
     ExtensionParamsInitialize(&params);
     ExtensionParamsSetContextRegistry(&params, context_registry);
 
-    ASSERT_NE((void*)0, ContextRegistryGetByName(context_registry, "lib"));
+    ASSERT_NE((void*)0, ContextRegistryGet(context_registry, "lib"));
     ASSERT_NE((void*)0, ContextRegistryGetByHash(context_registry, dmHashString64("lib")));
 
     ASSERT_EQ(dmExtension::RESULT_OK, dmExtension::Initialize(&params));
     ASSERT_EQ(1, g_TestInitCount);
     ASSERT_EQ(1, g_TestContextCount);
-    ASSERT_NE((void*)0, ContextRegistryGetByName(context_registry, "init"));
+    ASSERT_NE((void*)0, ContextRegistryGet(context_registry, "init"));
 
     for (int i = 0; i < 5; ++i)
     {
@@ -91,7 +91,7 @@ TEST(dmExtension, Basic)
     ASSERT_EQ(dmExtension::RESULT_OK, dmExtension::Finalize(&params));
     ASSERT_EQ(0, g_TestInitCount);
     ASSERT_EQ(0, g_TestContextCount);
-    ASSERT_EQ((void*)0, ContextRegistryGetByName(context_registry, "init"));
+    ASSERT_EQ((void*)0, ContextRegistryGet(context_registry, "init"));
 
     dmExtension::Event event;
     event.m_Event = (ExtensionEventID)dmExtension::EVENT_ID_ACTIVATEAPP;
@@ -111,7 +111,7 @@ TEST(dmExtension, Basic)
     ASSERT_EQ(0, g_TestAppInitCount);
 
     // it deregistered its own context
-    ASSERT_EQ((void*)0, ContextRegistryGetByName(context_registry, "lib"));
+    ASSERT_EQ((void*)0, ContextRegistryGet(context_registry, "lib"));
     ASSERT_EQ((void*)0, ContextRegistryGetByHash(context_registry, dmHashString64("lib")));
 
     ExtensionAppParamsFinalize(&appfinalizeparams);

--- a/engine/extension/src/test/test_extension.cpp
+++ b/engine/extension/src/test/test_extension.cpp
@@ -17,6 +17,7 @@
 #include <jc_test/jc_test.h>
 #include "../extension.hpp"
 #include "test_extension.h"
+#include <dlib/context_registry.h>
 #include <dlib/hashtable.h>
 
 extern "C"
@@ -31,6 +32,7 @@ extern int g_TestAppInitCount;
 extern int g_TestInitCount;
 extern int g_TestUpdateCount;
 extern int g_TestAppEventCount;
+extern int g_TestContextCount;
 
 extern "C" void TestExt();
 
@@ -42,11 +44,19 @@ struct Initializer {
 
 TEST(dmExtension, Basic)
 {
+    HContextRegistry context_registry = ContextRegistryCreate();
+
     dmExtension::AppParams appparams;
     ExtensionAppParamsInitialize(&appparams);
+    ExtensionAppParamsSetContextRegistry(&appparams, context_registry);
 
     int engine_context = 1337;
-    ExtensionAppParamsSetContext(&appparams, "engine", &engine_context);
+    ContextRegistrySet(context_registry, "engine", &engine_context);
+    ASSERT_EQ((void*)&engine_context, ContextRegistryGetByHash(context_registry, dmHashString64("engine")));
+
+    int engine_hash_context = 7331;
+    ContextRegistrySetByHash(context_registry, dmHashString64("engine_hash"), &engine_hash_context);
+    ASSERT_EQ((void*)&engine_hash_context, ContextRegistryGetByName(context_registry, "engine_hash"));
 
     ASSERT_EQ(0, g_TestAppInitCount);
     ASSERT_EQ(dmExtension::RESULT_OK, dmExtension::AppInitialize(&appparams));
@@ -55,14 +65,22 @@ TEST(dmExtension, Basic)
     ASSERT_NE((dmExtension::HExtension)0, extension);
     ASSERT_EQ((dmExtension::HExtension)0, dmExtension::GetNextExtension(extension));
 
-    ASSERT_NE((void*)0, ExtensionAppParamsGetContextByName(&appparams, "lib"));
-    ASSERT_NE((void*)0, ExtensionAppParamsGetContext(&appparams, dmHashString64("lib")));
+    ASSERT_NE((void*)0, ContextRegistryGetByName(context_registry, "lib"));
+    ASSERT_NE((void*)0, ContextRegistryGetByHash(context_registry, dmHashString64("lib")));
+
+    ExtensionAppParamsFinalize(&appparams);
 
     dmExtension::Params params;
     ExtensionParamsInitialize(&params);
+    ExtensionParamsSetContextRegistry(&params, context_registry);
+
+    ASSERT_NE((void*)0, ContextRegistryGetByName(context_registry, "lib"));
+    ASSERT_NE((void*)0, ContextRegistryGetByHash(context_registry, dmHashString64("lib")));
 
     ASSERT_EQ(dmExtension::RESULT_OK, dmExtension::Initialize(&params));
     ASSERT_EQ(1, g_TestInitCount);
+    ASSERT_EQ(1, g_TestContextCount);
+    ASSERT_NE((void*)0, ContextRegistryGetByName(context_registry, "init"));
 
     for (int i = 0; i < 5; ++i)
     {
@@ -72,8 +90,8 @@ TEST(dmExtension, Basic)
     }
     ASSERT_EQ(dmExtension::RESULT_OK, dmExtension::Finalize(&params));
     ASSERT_EQ(0, g_TestInitCount);
-
-    ExtensionParamsFinalize(&params);
+    ASSERT_EQ(0, g_TestContextCount);
+    ASSERT_EQ((void*)0, ContextRegistryGetByName(context_registry, "init"));
 
     dmExtension::Event event;
     event.m_Event = (ExtensionEventID)dmExtension::EVENT_ID_ACTIVATEAPP;
@@ -83,14 +101,22 @@ TEST(dmExtension, Basic)
     dmExtension::DispatchEvent(&params, &event);
     ASSERT_EQ(0, g_TestAppEventCount);
 
-    dmExtension::AppFinalize(&appparams);
+    ExtensionParamsFinalize(&params);
+
+    dmExtension::AppParams appfinalizeparams;
+    ExtensionAppParamsInitialize(&appfinalizeparams);
+    ExtensionAppParamsSetContextRegistry(&appfinalizeparams, context_registry);
+
+    dmExtension::AppFinalize(&appfinalizeparams);
     ASSERT_EQ(0, g_TestAppInitCount);
 
     // it deregistered its own context
-    ASSERT_EQ((void*)0, ExtensionAppParamsGetContextByName(&appparams, "lib"));
-    ASSERT_EQ((void*)0, ExtensionAppParamsGetContext(&appparams, dmHashString64("lib")));
+    ASSERT_EQ((void*)0, ContextRegistryGetByName(context_registry, "lib"));
+    ASSERT_EQ((void*)0, ContextRegistryGetByHash(context_registry, dmHashString64("lib")));
 
-    ExtensionAppParamsFinalize(&appparams);
+    ExtensionAppParamsFinalize(&appfinalizeparams);
+
+    ContextRegistryDestroy(context_registry);
 }
 
 int main(int argc, char **argv)

--- a/engine/extension/src/test/test_extension_lib.cpp
+++ b/engine/extension/src/test/test_extension_lib.cpp
@@ -37,12 +37,12 @@ static int g_InitContext = 0;
 static dmExtension::Result AppInitializeTest(dmExtension::AppParams* params)
 {
     HContextRegistry context_registry = ExtensionAppParamsGetContextRegistry(params);
-    int* engine = (int*)ContextRegistryGetByName(context_registry, "engine");
+    int* engine = (int*)ContextRegistryGet(context_registry, "engine");
     assert(engine != 0);
     assert(*engine == 1337);
 
     ContextRegistrySet(context_registry, "lib", &g_LibContext);
-    int* libctx = (int*)ContextRegistryGetByName(context_registry, "lib");
+    int* libctx = (int*)ContextRegistryGet(context_registry, "lib");
     assert(libctx == &g_LibContext);
     *libctx = 1976;
 
@@ -53,7 +53,7 @@ static dmExtension::Result AppInitializeTest(dmExtension::AppParams* params)
 static dmExtension::Result AppFinalizeTest(dmExtension::AppParams* params)
 {
     HContextRegistry context_registry = ExtensionAppParamsGetContextRegistry(params);
-    int* libctx = (int*)ContextRegistryGetByName(context_registry, "lib");
+    int* libctx = (int*)ContextRegistryGet(context_registry, "lib");
     assert(libctx == &g_LibContext);
     *libctx = 1976;
 
@@ -66,12 +66,12 @@ static dmExtension::Result AppFinalizeTest(dmExtension::AppParams* params)
 static dmExtension::Result InitializeTest(dmExtension::Params* params)
 {
     HContextRegistry context_registry = ExtensionParamsGetContextRegistry(params);
-    int* libctx = (int*)ContextRegistryGetByName(context_registry, "lib");
+    int* libctx = (int*)ContextRegistryGet(context_registry, "lib");
     assert(libctx == &g_LibContext);
     assert(*libctx == 1976);
 
     ContextRegistrySet(context_registry, "init", &g_InitContext);
-    int* initctx = (int*)ContextRegistryGetByName(context_registry, "init");
+    int* initctx = (int*)ContextRegistryGet(context_registry, "init");
     assert(initctx == &g_InitContext);
     *initctx = 2026;
 
@@ -97,11 +97,11 @@ void OnEventTest(dmExtension::Params* params, const dmExtension::Event* event)
 static dmExtension::Result FinalizeTest(dmExtension::Params* params)
 {
     HContextRegistry context_registry = ExtensionParamsGetContextRegistry(params);
-    int* libctx = (int*)ContextRegistryGetByName(context_registry, "lib");
+    int* libctx = (int*)ContextRegistryGet(context_registry, "lib");
     assert(libctx == &g_LibContext);
     assert(*libctx == 1976);
 
-    int* initctx = (int*)ContextRegistryGetByName(context_registry, "init");
+    int* initctx = (int*)ContextRegistryGet(context_registry, "init");
     assert(initctx == &g_InitContext);
     assert(*initctx == 2026);
 

--- a/engine/extension/src/test/test_extension_lib.cpp
+++ b/engine/extension/src/test/test_extension_lib.cpp
@@ -32,15 +32,17 @@ int g_TestAppEventCount = 0;
 int g_TestContextCount = 0;
 
 static int g_LibContext = 0;
+static int g_InitContext = 0;
 
 static dmExtension::Result AppInitializeTest(dmExtension::AppParams* params)
 {
-    int* engine = (int*)ExtensionAppParamsGetContextByName(params, "engine");
+    HContextRegistry context_registry = ExtensionAppParamsGetContextRegistry(params);
+    int* engine = (int*)ContextRegistryGetByName(context_registry, "engine");
     assert(engine != 0);
     assert(*engine == 1337);
 
-    ExtensionAppParamsSetContext(params, "lib", &g_LibContext);
-    int* libctx = (int*)ExtensionAppParamsGetContextByName(params, "lib");
+    ContextRegistrySet(context_registry, "lib", &g_LibContext);
+    int* libctx = (int*)ContextRegistryGetByName(context_registry, "lib");
     assert(libctx == &g_LibContext);
     *libctx = 1976;
 
@@ -50,11 +52,12 @@ static dmExtension::Result AppInitializeTest(dmExtension::AppParams* params)
 
 static dmExtension::Result AppFinalizeTest(dmExtension::AppParams* params)
 {
-    int* libctx = (int*)ExtensionAppParamsGetContextByName(params, "lib");
+    HContextRegistry context_registry = ExtensionAppParamsGetContextRegistry(params);
+    int* libctx = (int*)ContextRegistryGetByName(context_registry, "lib");
     assert(libctx == &g_LibContext);
     *libctx = 1976;
 
-    ExtensionAppParamsSetContext(params, "lib", 0);
+    ContextRegistrySet(context_registry, "lib", 0);
 
     g_TestAppInitCount--;
     return dmExtension::RESULT_OK;
@@ -62,6 +65,17 @@ static dmExtension::Result AppFinalizeTest(dmExtension::AppParams* params)
 
 static dmExtension::Result InitializeTest(dmExtension::Params* params)
 {
+    HContextRegistry context_registry = ExtensionParamsGetContextRegistry(params);
+    int* libctx = (int*)ContextRegistryGetByName(context_registry, "lib");
+    assert(libctx == &g_LibContext);
+    assert(*libctx == 1976);
+
+    ContextRegistrySet(context_registry, "init", &g_InitContext);
+    int* initctx = (int*)ContextRegistryGetByName(context_registry, "init");
+    assert(initctx == &g_InitContext);
+    *initctx = 2026;
+
+    g_TestContextCount++;
     g_TestInitCount++;
     return dmExtension::RESULT_OK;
 }
@@ -82,6 +96,18 @@ void OnEventTest(dmExtension::Params* params, const dmExtension::Event* event)
 
 static dmExtension::Result FinalizeTest(dmExtension::Params* params)
 {
+    HContextRegistry context_registry = ExtensionParamsGetContextRegistry(params);
+    int* libctx = (int*)ContextRegistryGetByName(context_registry, "lib");
+    assert(libctx == &g_LibContext);
+    assert(*libctx == 1976);
+
+    int* initctx = (int*)ContextRegistryGetByName(context_registry, "init");
+    assert(initctx == &g_InitContext);
+    assert(*initctx == 2026);
+
+    ContextRegistrySet(context_registry, "init", 0);
+
+    g_TestContextCount--;
     g_TestInitCount--;
     return dmExtension::RESULT_OK;
 }

--- a/engine/extension/src/wscript
+++ b/engine/extension/src/wscript
@@ -21,7 +21,7 @@ def build(bld):
 
     bld.add_group() # not sure why needed, but it won't build with '--skip-build-tests' otherwise. Use '-v -v' for more info
 
-    bld.install_files('${PREFIX}/include/extension', 'extension.hpp')
+    bld.install_files('${PREFIX}/include/extension', 'extension.h extension.hpp')
     dmsdk_add_files(bld, '${PREFIX}/sdk/include/dmsdk', 'dmsdk')
     dmsdk_add_files(bld, '${PREFIX}/sdk/cs/dmsdk', 'cs/dmsdk')
 

--- a/engine/gameobject/src/dmsdk/gameobject/component.h
+++ b/engine/gameobject/src/dmsdk/gameobject/component.h
@@ -787,19 +787,12 @@ namespace dmGameObject
     };
 
     /*# get the context registry from the component type create context
-     * @name ComponentTypeCreateCtxGetContextRegistry
+     * Use the returned registry with ContextRegistryGet and ContextRegistrySet to access named engine contexts.
+     * @name ComponentGetContextRegistry
      * @param ctx [type: const ComponentTypeCreateCtx*] component type create context
      * @return registry [type: HContextRegistry] engine context registry
      */
-    HContextRegistry ComponentTypeCreateCtxGetContextRegistry(const ComponentTypeCreateCtx* ctx);
-
-    /*# get a named context from the component type create context
-     * @name ComponentTypeGetContext
-     * @param ctx [type: const ComponentTypeCreateCtx*] component type create context
-     * @param name [type: const char*] context name
-     * @return context [type: void*] context pointer, if it exists
-     */
-    void* ComponentTypeGetContext(const ComponentTypeCreateCtx* ctx, const char* name);
+    HContextRegistry ComponentGetContextRegistry(const ComponentTypeCreateCtx* ctx);
 
     typedef Result (*ComponentTypeCreateFunction)(const ComponentTypeCreateCtx* ctx, HComponentType type);
     typedef Result (*ComponentTypeDestroyFunction)(const ComponentTypeCreateCtx* ctx, HComponentType type);

--- a/engine/gameobject/src/dmsdk/gameobject/component.h
+++ b/engine/gameobject/src/dmsdk/gameobject/component.h
@@ -56,14 +56,16 @@ namespace dmGameObject
      * @member m_World [type: void**] Out-parameter of the pointer in which to store the created world
      * @member m_MaxComponentInstances [type: uint32_t] Max components count of this type in current collection counted at the build stage.
      *                                         If component in factory then value is 0xFFFFFFFF
+     * @member m_ContextRegistry [type: HContextRegistry] Engine context registry
      */
     struct ComponentNewWorldParams
     {
-        void* m_Context;
-        uint8_t m_ComponentIndex;
-        uint32_t m_MaxInstances;
-        void** m_World;
-        uint32_t m_MaxComponentInstances;
+        void*            m_Context;
+        uint8_t          m_ComponentIndex;
+        uint32_t         m_MaxInstances;
+        void**           m_World;
+        uint32_t         m_MaxComponentInstances;
+        HContextRegistry m_ContextRegistry;
     };
 
     /*#
@@ -81,11 +83,13 @@ namespace dmGameObject
      * @name ComponentDeleteWorldParams
      * @member m_Context [type void*] Context for the component type
      * @member m_World [type void*] The pointer to the world to destroy
+     * @member m_ContextRegistry [type: HContextRegistry] Engine context registry
      */
     struct ComponentDeleteWorldParams
     {
-        void* m_Context;
-        void* m_World;
+        void*            m_Context;
+        void*            m_World;
+        HContextRegistry m_ContextRegistry;
     };
 
     /*#
@@ -111,6 +115,7 @@ namespace dmGameObject
      * @member m_Context [type: void*] User context
      * @member m_UserData [type: uintptr_t*] User data storage pointer
      * @member m_ComponentIndex [type: uint16_t] Index of the component type being created (among all component types)
+     * @member m_ContextRegistry [type: HContextRegistry] Engine context registry
      */
     struct ComponentCreateParams
     {
@@ -124,6 +129,7 @@ namespace dmGameObject
         void*               m_Context;
         uintptr_t*          m_UserData;
         uint16_t            m_ComponentIndex;
+        HContextRegistry    m_ContextRegistry;
     };
 
     /*#
@@ -145,14 +151,16 @@ namespace dmGameObject
      * @member m_World [type: void*] Component world
      * @member m_Context [type: void*] User context
      * @member m_UserData [type: uintptr_t*] User data storage pointer
+     * @member m_ContextRegistry [type: HContextRegistry] Engine context registry
      */
     struct ComponentDestroyParams
     {
-        HCollection m_Collection;
-        HInstance m_Instance;
-        void* m_World;
-        void* m_Context;
-        uintptr_t* m_UserData;
+        HCollection      m_Collection;
+        HInstance        m_Instance;
+        void*            m_World;
+        void*            m_Context;
+        uintptr_t*       m_UserData;
+        HContextRegistry m_ContextRegistry;
     };
 
     /*#
@@ -173,14 +181,16 @@ namespace dmGameObject
      * @member m_World [type: void*] Component world
      * @member m_Context [type: void*] User context
      * @member m_UserData [type: uintptr_t*] User data storage pointer
+     * @member m_ContextRegistry [type: HContextRegistry] Engine context registry
      */
     struct ComponentInitParams
     {
-        HCollection m_Collection;
-        HInstance m_Instance;
-        void* m_World;
-        void* m_Context;
-        uintptr_t* m_UserData;
+        HCollection      m_Collection;
+        HInstance        m_Instance;
+        void*            m_World;
+        void*            m_Context;
+        uintptr_t*       m_UserData;
+        HContextRegistry m_ContextRegistry;
     };
 
     /*#
@@ -201,14 +211,16 @@ namespace dmGameObject
      * @member m_World [type: void*] Component world
      * @member m_Context [type: void*] User context
      * @member m_UserData [type: uintptr_t*] User data storage pointer
+     * @member m_ContextRegistry [type: HContextRegistry] Engine context registry
      */
     struct ComponentFinalParams
     {
-        HCollection m_Collection;
-        HInstance m_Instance;
-        void* m_World;
-        void* m_Context;
-        uintptr_t* m_UserData;
+        HCollection      m_Collection;
+        HInstance        m_Instance;
+        void*            m_World;
+        void*            m_Context;
+        uintptr_t*       m_UserData;
+        HContextRegistry m_ContextRegistry;
     };
 
     /*#
@@ -774,7 +786,20 @@ namespace dmGameObject
         dmHashTable64<void*>        m_Contexts; // deprecated
     };
 
+    /*# get the context registry from the component type create context
+     * @name ComponentTypeCreateCtxGetContextRegistry
+     * @param ctx [type: const ComponentTypeCreateCtx*] component type create context
+     * @return registry [type: HContextRegistry] engine context registry
+     */
     HContextRegistry ComponentTypeCreateCtxGetContextRegistry(const ComponentTypeCreateCtx* ctx);
+
+    /*# get a named context from the component type create context
+     * @name ComponentTypeGetContext
+     * @param ctx [type: const ComponentTypeCreateCtx*] component type create context
+     * @param name [type: const char*] context name
+     * @return context [type: void*] context pointer, if it exists
+     */
+    void* ComponentTypeGetContext(const ComponentTypeCreateCtx* ctx, const char* name);
 
     typedef Result (*ComponentTypeCreateFunction)(const ComponentTypeCreateCtx* ctx, HComponentType type);
     typedef Result (*ComponentTypeDestroyFunction)(const ComponentTypeCreateCtx* ctx, HComponentType type);

--- a/engine/gameobject/src/dmsdk/gameobject/component.h
+++ b/engine/gameobject/src/dmsdk/gameobject/component.h
@@ -18,6 +18,7 @@
 #include <dmsdk/gameobject/gameobject.h>
 #include <dmsdk/dlib/hash.h>
 #include <dmsdk/dlib/configfile_gen.hpp>
+#include <dmsdk/dlib/context_registry.h>
 #include <dmsdk/dlib/hashtable.h>
 #include <dmsdk/dlib/vmath.h>
 #include <dmsdk/script/script.h>
@@ -36,6 +37,7 @@ namespace dmGameObject
      */
 
     struct ComponentType;
+    struct ComponentTypeCreateCtxImpl;
 
     /*#
      * Component type handle. It holds the life time functions for a type.
@@ -760,15 +762,19 @@ namespace dmGameObject
      * @member m_Factory [type: dmResource::HFactory] The resource factory
      * @member m_Register [type: dmGameObject::HRegister] The game object registry
      * @member m_Script [type: dmScript::HContext] The shared script context
-     * @member m_Contexts [type: dmHashTable64<void*>] Mappings between names and contextx
+     * @member m_Contexts [type: dmHashTable64<void*>] Mappings between names and contexts
+     * @member m_Impl [type: dmGameObject::ComponentTypeCreateCtxImpl*] Opaque implementation data
      */
     struct ComponentTypeCreateCtx {
-        dmConfigFile::HConfig    m_Config;
-        dmResource::HFactory     m_Factory;
-        dmGameObject::HRegister  m_Register;
-        dmScript::HContext       m_Script;
-        dmHashTable64<void*>     m_Contexts;
+        ComponentTypeCreateCtxImpl* m_Impl;
+        dmConfigFile::HConfig       m_Config; // deprecated
+        dmResource::HFactory        m_Factory; // deprecated
+        dmGameObject::HRegister     m_Register; // deprecated
+        dmScript::HContext          m_Script; // deprecated
+        dmHashTable64<void*>        m_Contexts; // deprecated
     };
+
+    HContextRegistry ComponentTypeCreateCtxGetContextRegistry(const ComponentTypeCreateCtx* ctx);
 
     typedef Result (*ComponentTypeCreateFunction)(const ComponentTypeCreateCtx* ctx, HComponentType type);
     typedef Result (*ComponentTypeDestroyFunction)(const ComponentTypeCreateCtx* ctx, HComponentType type);

--- a/engine/gameobject/src/dmsdk/gameobject/component.h
+++ b/engine/gameobject/src/dmsdk/gameobject/component.h
@@ -56,16 +56,14 @@ namespace dmGameObject
      * @member m_World [type: void**] Out-parameter of the pointer in which to store the created world
      * @member m_MaxComponentInstances [type: uint32_t] Max components count of this type in current collection counted at the build stage.
      *                                         If component in factory then value is 0xFFFFFFFF
-     * @member m_ContextRegistry [type: HContextRegistry] Engine context registry
      */
     struct ComponentNewWorldParams
     {
-        void*            m_Context;
-        uint8_t          m_ComponentIndex;
-        uint32_t         m_MaxInstances;
-        void**           m_World;
-        uint32_t         m_MaxComponentInstances;
-        HContextRegistry m_ContextRegistry;
+        void*    m_Context;
+        uint8_t  m_ComponentIndex;
+        uint32_t m_MaxInstances;
+        void**   m_World;
+        uint32_t m_MaxComponentInstances;
     };
 
     /*#
@@ -83,13 +81,11 @@ namespace dmGameObject
      * @name ComponentDeleteWorldParams
      * @member m_Context [type void*] Context for the component type
      * @member m_World [type void*] The pointer to the world to destroy
-     * @member m_ContextRegistry [type: HContextRegistry] Engine context registry
      */
     struct ComponentDeleteWorldParams
     {
-        void*            m_Context;
-        void*            m_World;
-        HContextRegistry m_ContextRegistry;
+        void* m_Context;
+        void* m_World;
     };
 
     /*#
@@ -115,21 +111,19 @@ namespace dmGameObject
      * @member m_Context [type: void*] User context
      * @member m_UserData [type: uintptr_t*] User data storage pointer
      * @member m_ComponentIndex [type: uint16_t] Index of the component type being created (among all component types)
-     * @member m_ContextRegistry [type: HContextRegistry] Engine context registry
      */
     struct ComponentCreateParams
     {
-        HInstance           m_Instance;
-        dmVMath::Point3     m_Position;
-        dmVMath::Quat       m_Rotation;
-        dmVMath::Vector3    m_Scale;
-        PropertySet         m_PropertySet;
-        void*               m_Resource;
-        void*               m_World;
-        void*               m_Context;
-        uintptr_t*          m_UserData;
-        uint16_t            m_ComponentIndex;
-        HContextRegistry    m_ContextRegistry;
+        HInstance        m_Instance;
+        dmVMath::Point3  m_Position;
+        dmVMath::Quat    m_Rotation;
+        dmVMath::Vector3 m_Scale;
+        PropertySet      m_PropertySet;
+        void*            m_Resource;
+        void*            m_World;
+        void*            m_Context;
+        uintptr_t*       m_UserData;
+        uint16_t         m_ComponentIndex;
     };
 
     /*#
@@ -151,16 +145,14 @@ namespace dmGameObject
      * @member m_World [type: void*] Component world
      * @member m_Context [type: void*] User context
      * @member m_UserData [type: uintptr_t*] User data storage pointer
-     * @member m_ContextRegistry [type: HContextRegistry] Engine context registry
      */
     struct ComponentDestroyParams
     {
-        HCollection      m_Collection;
-        HInstance        m_Instance;
-        void*            m_World;
-        void*            m_Context;
-        uintptr_t*       m_UserData;
-        HContextRegistry m_ContextRegistry;
+        HCollection m_Collection;
+        HInstance   m_Instance;
+        void*       m_World;
+        void*       m_Context;
+        uintptr_t*  m_UserData;
     };
 
     /*#
@@ -181,16 +173,14 @@ namespace dmGameObject
      * @member m_World [type: void*] Component world
      * @member m_Context [type: void*] User context
      * @member m_UserData [type: uintptr_t*] User data storage pointer
-     * @member m_ContextRegistry [type: HContextRegistry] Engine context registry
      */
     struct ComponentInitParams
     {
-        HCollection      m_Collection;
-        HInstance        m_Instance;
-        void*            m_World;
-        void*            m_Context;
-        uintptr_t*       m_UserData;
-        HContextRegistry m_ContextRegistry;
+        HCollection m_Collection;
+        HInstance   m_Instance;
+        void*       m_World;
+        void*       m_Context;
+        uintptr_t*  m_UserData;
     };
 
     /*#
@@ -211,16 +201,14 @@ namespace dmGameObject
      * @member m_World [type: void*] Component world
      * @member m_Context [type: void*] User context
      * @member m_UserData [type: uintptr_t*] User data storage pointer
-     * @member m_ContextRegistry [type: HContextRegistry] Engine context registry
      */
     struct ComponentFinalParams
     {
-        HCollection      m_Collection;
-        HInstance        m_Instance;
-        void*            m_World;
-        void*            m_Context;
-        uintptr_t*       m_UserData;
-        HContextRegistry m_ContextRegistry;
+        HCollection m_Collection;
+        HInstance   m_Instance;
+        void*       m_World;
+        void*       m_Context;
+        uintptr_t*  m_UserData;
     };
 
     /*#

--- a/engine/gameobject/src/dmsdk/gameobject/gameobject.h
+++ b/engine/gameobject/src/dmsdk/gameobject/gameobject.h
@@ -33,6 +33,13 @@
  * @language C++
  */
 
+/*# Game object extension context name
+ * Name used when registering the game object context with the engine context registry.
+ * @constant
+ * @name GAMEOBJECT_CONTEXT_NAME
+ */
+#define GAMEOBJECT_CONTEXT_NAME "register"
+
 namespace dmMessage
 {
     struct URL;

--- a/engine/gameobject/src/gameobject/component.cpp
+++ b/engine/gameobject/src/gameobject/component.cpp
@@ -27,6 +27,11 @@ HContextRegistry ComponentTypeCreateCtxGetContextRegistry(const ComponentTypeCre
     return ctx->m_Impl->m_ContextRegistry;
 }
 
+void* ComponentTypeGetContext(const ComponentTypeCreateCtx* ctx, const char* name)
+{
+    return ContextRegistryGetByName(ComponentTypeCreateCtxGetContextRegistry(ctx), name);
+}
+
 Result RegisterComponentTypeDescriptor(ComponentTypeDescriptor* desc, const char* name, ComponentTypeCreateFunction create_fn, ComponentTypeDestroyFunction destroy_fn)
 {
     DM_STATIC_ASSERT(dmGameObject::s_ComponentTypeDescBufferSize >= sizeof(ComponentTypeDescriptor), Invalid_Struct_Size);

--- a/engine/gameobject/src/gameobject/component.cpp
+++ b/engine/gameobject/src/gameobject/component.cpp
@@ -14,22 +14,17 @@
 
 #include "component.h"
 
-#include <dlib/static_assert.h>
 #include <dlib/hash.h>
+#include <dlib/static_assert.h>
 
 namespace dmGameObject
 {
 
 static ComponentTypeDescriptor g_ComponentTypeSentinel = {0};
 
-HContextRegistry ComponentTypeCreateCtxGetContextRegistry(const ComponentTypeCreateCtx* ctx)
+HContextRegistry ComponentGetContextRegistry(const ComponentTypeCreateCtx* ctx)
 {
     return ctx->m_Impl->m_ContextRegistry;
-}
-
-void* ComponentTypeGetContext(const ComponentTypeCreateCtx* ctx, const char* name)
-{
-    return ContextRegistryGetByName(ComponentTypeCreateCtxGetContextRegistry(ctx), name);
 }
 
 Result RegisterComponentTypeDescriptor(ComponentTypeDescriptor* desc, const char* name, ComponentTypeCreateFunction create_fn, ComponentTypeDestroyFunction destroy_fn)

--- a/engine/gameobject/src/gameobject/component.cpp
+++ b/engine/gameobject/src/gameobject/component.cpp
@@ -22,6 +22,11 @@ namespace dmGameObject
 
 static ComponentTypeDescriptor g_ComponentTypeSentinel = {0};
 
+HContextRegistry ComponentTypeCreateCtxGetContextRegistry(const ComponentTypeCreateCtx* ctx)
+{
+    return ctx->m_Impl->m_ContextRegistry;
+}
+
 Result RegisterComponentTypeDescriptor(ComponentTypeDescriptor* desc, const char* name, ComponentTypeCreateFunction create_fn, ComponentTypeDestroyFunction destroy_fn)
 {
     DM_STATIC_ASSERT(dmGameObject::s_ComponentTypeDescBufferSize >= sizeof(ComponentTypeDescriptor), Invalid_Struct_Size);

--- a/engine/gameobject/src/gameobject/component.h
+++ b/engine/gameobject/src/gameobject/component.h
@@ -22,6 +22,11 @@
 
 namespace dmGameObject
 {
+    struct ComponentTypeCreateCtxImpl
+    {
+        HContextRegistry m_ContextRegistry;
+    };
+
     /*#
      * Collection of component registration data.
      */

--- a/engine/gameobject/src/gameobject/gameobject.cpp
+++ b/engine/gameobject/src/gameobject/gameobject.cpp
@@ -430,7 +430,6 @@ namespace dmGameObject
                 params.m_MaxComponentInstances = GetMaxComponentInstances(regist->m_ComponentTypes[i].m_NameHash, collection_desc);
                 params.m_MaxInstances = max_instances;
                 params.m_World = &collection->m_ComponentWorlds[i];
-                params.m_ContextRegistry = regist->m_ContextRegistry;
                 regist->m_ComponentTypes[i].m_NewWorldFunction(params);
             }
         }
@@ -450,7 +449,6 @@ namespace dmGameObject
             ComponentDeleteWorldParams params;
             params.m_Context = regist->m_ComponentTypes[i].m_Context;
             params.m_World = collection->m_ComponentWorlds[i];
-            params.m_ContextRegistry = regist->m_ContextRegistry;
             if (regist->m_ComponentTypes[i].m_DeleteWorldFunction)
                 regist->m_ComponentTypes[i].m_DeleteWorldFunction(params);
         }
@@ -914,7 +912,6 @@ namespace dmGameObject
             params.m_Context = component_type->m_Context;
             params.m_UserData = component_instance_data;
             params.m_PropertySet = component->m_PropertySet;
-            params.m_ContextRegistry = collection->m_Register->m_ContextRegistry;
             CreateResult create_result =  component_type->m_CreateFunction(params);
             if (create_result == CREATE_RESULT_OK)
             {
@@ -948,7 +945,6 @@ namespace dmGameObject
                 params.m_World = collection->m_ComponentWorlds[component->m_TypeIndex];
                 params.m_Context = component_type->m_Context;
                 params.m_UserData = component_instance_data;
-                params.m_ContextRegistry = collection->m_Register->m_ContextRegistry;
                 component_type->m_DestroyFunction(params);
             }
         }
@@ -985,7 +981,6 @@ namespace dmGameObject
             params.m_World = collection->m_ComponentWorlds[component->m_TypeIndex];
             params.m_Context = component_type->m_Context;
             params.m_UserData = component_instance_data;
-            params.m_ContextRegistry = collection->m_Register->m_ContextRegistry;
             component_type->m_DestroyFunction(params);
         }
     }
@@ -1818,7 +1813,6 @@ namespace dmGameObject
                 params.m_World = collection->m_ComponentWorlds[component->m_TypeIndex];
                 params.m_Context = component_type->m_Context;
                 params.m_UserData = component_instance_data;
-                params.m_ContextRegistry = collection->m_Register->m_ContextRegistry;
                 CreateResult result = component_type->m_InitFunction(params);
                 if (result != CREATE_RESULT_OK)
                 {
@@ -1930,7 +1924,6 @@ namespace dmGameObject
                 params.m_World = collection->m_ComponentWorlds[component->m_TypeIndex];
                 params.m_Context = component_type->m_Context;
                 params.m_UserData = component_instance_data;
-                params.m_ContextRegistry = collection->m_Register->m_ContextRegistry;
                 CreateResult result = component_type->m_FinalFunction(params);
                 if (result != CREATE_RESULT_OK)
                 {

--- a/engine/gameobject/src/gameobject/gameobject.cpp
+++ b/engine/gameobject/src/gameobject/gameobject.cpp
@@ -214,6 +214,7 @@ namespace dmGameObject
         m_ComponentTypeCount = 0;
         m_DefaultCollectionCapacity = DEFAULT_MAX_COLLECTION_CAPACITY;
         m_DefaultInputStackCapacity = DEFAULT_MAX_INPUT_STACK_CAPACITY;
+        m_ContextRegistry = 0;
         m_Mutex = dmMutex::New();
     }
 
@@ -289,6 +290,16 @@ namespace dmGameObject
     {
         assert(regist != 0x0);
         return regist->m_DefaultCollectionCapacity;
+    }
+
+    void SetContextRegistry(HRegister regist, HContextRegistry context_registry)
+    {
+        regist->m_ContextRegistry = context_registry;
+    }
+
+    HContextRegistry GetContextRegistry(HRegister regist)
+    {
+        return regist->m_ContextRegistry;
     }
 
     void SetInputStackDefaultCapacity(HRegister regist, uint32_t capacity)
@@ -406,7 +417,7 @@ namespace dmGameObject
         {
             instances_in_collection = dmMath::Min(max_instances, instances_in_collection);
         }
-        Collection* collection = new Collection(0, 0, instances_in_collection, GetInputStackDefaultCapacity(regist));
+        Collection* collection = new Collection(0, regist, instances_in_collection, GetInputStackDefaultCapacity(regist));
         collection->m_Mutex = dmMutex::New();
 
         for (uint32_t i = 0; i < regist->m_ComponentTypeCount; ++i)
@@ -419,6 +430,7 @@ namespace dmGameObject
                 params.m_MaxComponentInstances = GetMaxComponentInstances(regist->m_ComponentTypes[i].m_NameHash, collection_desc);
                 params.m_MaxInstances = max_instances;
                 params.m_World = &collection->m_ComponentWorlds[i];
+                params.m_ContextRegistry = regist->m_ContextRegistry;
                 regist->m_ComponentTypes[i].m_NewWorldFunction(params);
             }
         }
@@ -438,6 +450,7 @@ namespace dmGameObject
             ComponentDeleteWorldParams params;
             params.m_Context = regist->m_ComponentTypes[i].m_Context;
             params.m_World = collection->m_ComponentWorlds[i];
+            params.m_ContextRegistry = regist->m_ContextRegistry;
             if (regist->m_ComponentTypes[i].m_DeleteWorldFunction)
                 regist->m_ComponentTypes[i].m_DeleteWorldFunction(params);
         }
@@ -901,6 +914,7 @@ namespace dmGameObject
             params.m_Context = component_type->m_Context;
             params.m_UserData = component_instance_data;
             params.m_PropertySet = component->m_PropertySet;
+            params.m_ContextRegistry = collection->m_Register->m_ContextRegistry;
             CreateResult create_result =  component_type->m_CreateFunction(params);
             if (create_result == CREATE_RESULT_OK)
             {
@@ -934,6 +948,7 @@ namespace dmGameObject
                 params.m_World = collection->m_ComponentWorlds[component->m_TypeIndex];
                 params.m_Context = component_type->m_Context;
                 params.m_UserData = component_instance_data;
+                params.m_ContextRegistry = collection->m_Register->m_ContextRegistry;
                 component_type->m_DestroyFunction(params);
             }
         }
@@ -970,6 +985,7 @@ namespace dmGameObject
             params.m_World = collection->m_ComponentWorlds[component->m_TypeIndex];
             params.m_Context = component_type->m_Context;
             params.m_UserData = component_instance_data;
+            params.m_ContextRegistry = collection->m_Register->m_ContextRegistry;
             component_type->m_DestroyFunction(params);
         }
     }
@@ -1802,6 +1818,7 @@ namespace dmGameObject
                 params.m_World = collection->m_ComponentWorlds[component->m_TypeIndex];
                 params.m_Context = component_type->m_Context;
                 params.m_UserData = component_instance_data;
+                params.m_ContextRegistry = collection->m_Register->m_ContextRegistry;
                 CreateResult result = component_type->m_InitFunction(params);
                 if (result != CREATE_RESULT_OK)
                 {
@@ -1913,6 +1930,7 @@ namespace dmGameObject
                 params.m_World = collection->m_ComponentWorlds[component->m_TypeIndex];
                 params.m_Context = component_type->m_Context;
                 params.m_UserData = component_instance_data;
+                params.m_ContextRegistry = collection->m_Register->m_ContextRegistry;
                 CreateResult result = component_type->m_FinalFunction(params);
                 if (result != CREATE_RESULT_OK)
                 {

--- a/engine/gameobject/src/gameobject/gameobject.h
+++ b/engine/gameobject/src/gameobject/gameobject.h
@@ -20,6 +20,7 @@
 #include <dmsdk/gameobject/gameobject.h>
 
 #include <dlib/easing.h>
+#include <dlib/context_registry.h>
 #include <dlib/hashtable.h>
 #include <dlib/message.h>
 #include <dlib/transform.h>
@@ -89,6 +90,9 @@ namespace dmGameObject
      * @return Default capacity
      */
     uint32_t GetCollectionDefaultCapacity(HRegister regist);
+
+    void SetContextRegistry(HRegister regist, HContextRegistry context_registry);
+    HContextRegistry GetContextRegistry(HRegister regist);
 
     /**
      * Set default input stack capacity of collections in this register. This does not affect existing collections.

--- a/engine/gameobject/src/gameobject/gameobject_private.h
+++ b/engine/gameobject/src/gameobject/gameobject_private.h
@@ -199,6 +199,7 @@ namespace dmGameObject
         // Default capacity of collections
         uint32_t                    m_DefaultCollectionCapacity;
         uint32_t                    m_DefaultInputStackCapacity;
+        HContextRegistry            m_ContextRegistry;
 
         Register();
         ~Register();

--- a/engine/gameobject/src/gameobject/test/component/test_gameobject_component.cpp
+++ b/engine/gameobject/src/gameobject/test/component/test_gameobject_component.cpp
@@ -16,6 +16,7 @@
 
 #include <map>
 
+#include <dlib/context_registry.h>
 #include <dlib/dstrings.h>
 #include <dlib/hash.h>
 #include <dlib/path.h>
@@ -51,6 +52,9 @@ protected:
 
         m_Register = dmGameObject::NewRegister();
         dmGameObject::Initialize(m_Register, m_ScriptContext);
+        m_ContextRegistry = ContextRegistryCreate();
+        ContextRegistrySet(m_ContextRegistry, "component_test", this);
+        dmGameObject::SetContextRegistry(m_Register, m_ContextRegistry);
 
         m_Contexts.SetCapacity(7,16);
         m_Contexts.Put(dmHashString64("goc"), m_Register);
@@ -144,6 +148,8 @@ protected:
         dmGameObject::PostUpdate(m_Register);
         dmScript::Finalize(m_ScriptContext);
         dmScript::DeleteContext(m_ScriptContext);
+        dmGameObject::SetContextRegistry(m_Register, 0);
+        ContextRegistryDestroy(m_ContextRegistry);
         dmGameObject::DeleteRegister(m_Register);
         dmResource::DeleteFactory(m_Factory);
     }
@@ -186,6 +192,7 @@ public:
     std::map<uint64_t, uint32_t> m_ComponentDestroyCountMap;
     std::map<uint64_t, uint32_t> m_ComponentUpdateCountMap;
     std::map<uint64_t, uint32_t> m_ComponentAddToUpdateCountMap;
+    std::map<uint64_t, uint32_t> m_ComponentContextRegistryCountMap;
     std::map<uint64_t, uint32_t> m_MaxComponentCreateCountMap;
 
     std::map<uint64_t, uint32_t> m_ComponentUpdateOrderMap;
@@ -199,6 +206,7 @@ public:
     dmResource::HFactory m_Factory;
     dmGameObject::ModuleContext m_ModuleContext;
     dmHashTable64<void*> m_Contexts;
+    HContextRegistry m_ContextRegistry;
 };
 
 template <typename T>
@@ -248,6 +256,11 @@ static dmGameObject::CreateResult GenericComponentCreate(const dmGameObject::Com
         }
     }
 
+    if (ContextRegistryGetByName(params.m_ContextRegistry, "component_test") == game_object_test)
+    {
+        game_object_test->m_ComponentContextRegistryCountMap[T::m_DDFHash]++;
+    }
+
     game_object_test->m_ComponentCreateCountMap[T::m_DDFHash]++;
     return dmGameObject::CREATE_RESULT_OK;
 }
@@ -256,6 +269,11 @@ template <typename T>
 static dmGameObject::CreateResult GenericComponentInit(const dmGameObject::ComponentInitParams& params)
 {
     ComponentTest* game_object_test = (ComponentTest*) params.m_Context;
+    if (ContextRegistryGetByName(params.m_ContextRegistry, "component_test") == game_object_test)
+    {
+        game_object_test->m_ComponentContextRegistryCountMap[T::m_DDFHash]++;
+    }
+
     game_object_test->m_ComponentInitCountMap[T::m_DDFHash]++;
     return dmGameObject::CREATE_RESULT_OK;
 }
@@ -264,6 +282,11 @@ template <typename T>
 static dmGameObject::CreateResult GenericComponentFinal(const dmGameObject::ComponentFinalParams& params)
 {
     ComponentTest* game_object_test = (ComponentTest*) params.m_Context;
+    if (ContextRegistryGetByName(params.m_ContextRegistry, "component_test") == game_object_test)
+    {
+        game_object_test->m_ComponentContextRegistryCountMap[T::m_DDFHash]++;
+    }
+
     game_object_test->m_ComponentFinalCountMap[T::m_DDFHash]++;
     return dmGameObject::CREATE_RESULT_OK;
 }
@@ -296,6 +319,11 @@ static dmGameObject::CreateResult GenericComponentDestroy(const dmGameObject::Co
     }
 
     game_object_test->m_ComponentDestroyCountMap[T::m_DDFHash]++;
+    if (ContextRegistryGetByName(params.m_ContextRegistry, "component_test") == game_object_test)
+    {
+        game_object_test->m_ComponentContextRegistryCountMap[T::m_DDFHash]++;
+    }
+
     return dmGameObject::CREATE_RESULT_OK;
 }
 
@@ -347,6 +375,7 @@ TEST_F(ComponentTest, TestUpdate)
     ASSERT_EQ((uint32_t) 1, m_ComponentUpdateCountMap[TestGameObjectDDF::AResource::m_DDFHash]);
     ASSERT_EQ((uint32_t) 1, m_ComponentFinalCountMap[TestGameObjectDDF::AResource::m_DDFHash]);
     ASSERT_EQ((uint32_t) 1, m_ComponentDestroyCountMap[TestGameObjectDDF::AResource::m_DDFHash]);
+    ASSERT_EQ((uint32_t) 4, m_ComponentContextRegistryCountMap[TestGameObjectDDF::AResource::m_DDFHash]);
 }
 
 TEST_F(ComponentTest, TestPostDeleteUpdate)
@@ -630,6 +659,8 @@ struct ComponentApiTestContext
     int m_Destroyed;
     void* m_CreateContext;
     void* m_DestroyContext;
+    void* m_CreateRegistryContext;
+    void* m_DestroyRegistryContext;
 } g_ComponentApiTestContext;
 
 static dmResource::Result ResourceTypeTestResourceCreate(const dmResource::ResourceCreateParams* params)
@@ -649,6 +680,7 @@ static dmGameObject::Result ComponentTypeTest_Create(const dmGameObject::Compone
 {
     g_ComponentApiTestContext.m_Created = 1;
     g_ComponentApiTestContext.m_CreateContext = malloc(1);
+    g_ComponentApiTestContext.m_CreateRegistryContext = ComponentTypeGetContext(ctx, "component_api");
 
     ComponentTypeSetContext(type, g_ComponentApiTestContext.m_CreateContext);
     return dmGameObject::RESULT_OK;
@@ -658,6 +690,7 @@ static dmGameObject::Result ComponentTypeTest_Destroy(const dmGameObject::Compon
 {
     g_ComponentApiTestContext.m_Destroyed = 1;
     g_ComponentApiTestContext.m_DestroyContext = ComponentTypeGetContext(type);
+    g_ComponentApiTestContext.m_DestroyRegistryContext = ComponentTypeGetContext(ctx, "component_api");
 
     ComponentTypeSetContext(type, g_ComponentApiTestContext.m_CreateContext);
     return dmGameObject::RESULT_OK;
@@ -697,8 +730,14 @@ TEST(ComponentApi, CreateDestroyType)
     dmGameObject::Result r = dmGameObject::RegisterComponentTypeDescriptor((dmGameObject::ComponentTypeDescriptor*)component_desc_testc, "testc", ComponentTypeTest_Create, ComponentTypeTest_Destroy);
     ASSERT_EQ(dmGameObject::RESULT_OK, r);
 
-    dmGameObject::ComponentTypeCreateCtx component_create_ctx;
-    component_create_ctx.m_Impl = 0;
+    HContextRegistry context_registry = ContextRegistryCreate();
+    ContextRegistrySet(context_registry, "component_api", &g_ComponentApiTestContext);
+
+    dmGameObject::ComponentTypeCreateCtxImpl component_create_ctx_impl;
+    component_create_ctx_impl.m_ContextRegistry = context_registry;
+
+    dmGameObject::ComponentTypeCreateCtx component_create_ctx = {};
+    component_create_ctx.m_Impl = &component_create_ctx_impl;
     component_create_ctx.m_Factory = factory;
     component_create_ctx.m_Register = regist;
     component_create_ctx.m_Script = 0;
@@ -713,13 +752,16 @@ TEST(ComponentApi, CreateDestroyType)
     ASSERT_EQ(1, g_ComponentApiTestContext.m_Created);
     ASSERT_EQ(0, g_ComponentApiTestContext.m_Destroyed);
     ASSERT_NE((void*)0, g_ComponentApiTestContext.m_CreateContext);
+    ASSERT_EQ((void*)&g_ComponentApiTestContext, g_ComponentApiTestContext.m_CreateRegistryContext);
 
     dmGameObject::DestroyRegisteredComponentTypes(&component_create_ctx);
     ASSERT_EQ(1, g_ComponentApiTestContext.m_Destroyed);
     ASSERT_EQ(g_ComponentApiTestContext.m_CreateContext, g_ComponentApiTestContext.m_DestroyContext);
+    ASSERT_EQ((void*)&g_ComponentApiTestContext, g_ComponentApiTestContext.m_DestroyRegistryContext);
     ////////////////////////////////////////////
 
     free((void*)g_ComponentApiTestContext.m_CreateContext);
+    ContextRegistryDestroy(context_registry);
     dmGameObject::DeleteRegister(regist);
     dmScript::Finalize(script_context);
     dmScript::DeleteContext(script_context);

--- a/engine/gameobject/src/gameobject/test/component/test_gameobject_component.cpp
+++ b/engine/gameobject/src/gameobject/test/component/test_gameobject_component.cpp
@@ -698,6 +698,7 @@ TEST(ComponentApi, CreateDestroyType)
     ASSERT_EQ(dmGameObject::RESULT_OK, r);
 
     dmGameObject::ComponentTypeCreateCtx component_create_ctx;
+    component_create_ctx.m_Impl = 0;
     component_create_ctx.m_Factory = factory;
     component_create_ctx.m_Register = regist;
     component_create_ctx.m_Script = 0;

--- a/engine/gameobject/src/gameobject/test/component/test_gameobject_component.cpp
+++ b/engine/gameobject/src/gameobject/test/component/test_gameobject_component.cpp
@@ -63,7 +63,11 @@ protected:
         m_Contexts.Put(dmHashString64("luac"), &m_ModuleContext);
         dmResource::RegisterTypes(m_Factory, &m_Contexts);
 
+        dmGameObject::ComponentTypeCreateCtxImpl component_create_ctx_impl;
+        component_create_ctx_impl.m_ContextRegistry = m_ContextRegistry;
+
         dmGameObject::ComponentTypeCreateCtx component_create_ctx = {};
+        component_create_ctx.m_Impl = &component_create_ctx_impl;
         component_create_ctx.m_Script = m_ScriptContext;
         component_create_ctx.m_Register = m_Register;
         component_create_ctx.m_Factory = m_Factory;
@@ -256,7 +260,7 @@ static dmGameObject::CreateResult GenericComponentCreate(const dmGameObject::Com
         }
     }
 
-    if (ContextRegistryGetByName(params.m_ContextRegistry, "component_test") == game_object_test)
+    if (ContextRegistryGet(params.m_ContextRegistry, "component_test") == game_object_test)
     {
         game_object_test->m_ComponentContextRegistryCountMap[T::m_DDFHash]++;
     }
@@ -269,7 +273,7 @@ template <typename T>
 static dmGameObject::CreateResult GenericComponentInit(const dmGameObject::ComponentInitParams& params)
 {
     ComponentTest* game_object_test = (ComponentTest*) params.m_Context;
-    if (ContextRegistryGetByName(params.m_ContextRegistry, "component_test") == game_object_test)
+    if (ContextRegistryGet(params.m_ContextRegistry, "component_test") == game_object_test)
     {
         game_object_test->m_ComponentContextRegistryCountMap[T::m_DDFHash]++;
     }
@@ -282,7 +286,7 @@ template <typename T>
 static dmGameObject::CreateResult GenericComponentFinal(const dmGameObject::ComponentFinalParams& params)
 {
     ComponentTest* game_object_test = (ComponentTest*) params.m_Context;
-    if (ContextRegistryGetByName(params.m_ContextRegistry, "component_test") == game_object_test)
+    if (ContextRegistryGet(params.m_ContextRegistry, "component_test") == game_object_test)
     {
         game_object_test->m_ComponentContextRegistryCountMap[T::m_DDFHash]++;
     }
@@ -319,7 +323,7 @@ static dmGameObject::CreateResult GenericComponentDestroy(const dmGameObject::Co
     }
 
     game_object_test->m_ComponentDestroyCountMap[T::m_DDFHash]++;
-    if (ContextRegistryGetByName(params.m_ContextRegistry, "component_test") == game_object_test)
+    if (ContextRegistryGet(params.m_ContextRegistry, "component_test") == game_object_test)
     {
         game_object_test->m_ComponentContextRegistryCountMap[T::m_DDFHash]++;
     }
@@ -661,6 +665,8 @@ struct ComponentApiTestContext
     void* m_DestroyContext;
     void* m_CreateRegistryContext;
     void* m_DestroyRegistryContext;
+    void* m_ComponentRegistryContext;
+    int m_ComponentRegistrySetResult;
 } g_ComponentApiTestContext;
 
 static dmResource::Result ResourceTypeTestResourceCreate(const dmResource::ResourceCreateParams* params)
@@ -680,7 +686,10 @@ static dmGameObject::Result ComponentTypeTest_Create(const dmGameObject::Compone
 {
     g_ComponentApiTestContext.m_Created = 1;
     g_ComponentApiTestContext.m_CreateContext = malloc(1);
-    g_ComponentApiTestContext.m_CreateRegistryContext = ComponentTypeGetContext(ctx, "component_api");
+    HContextRegistry context_registry = ComponentGetContextRegistry(ctx);
+    g_ComponentApiTestContext.m_CreateRegistryContext = ContextRegistryGet(context_registry, "component_api");
+    g_ComponentApiTestContext.m_ComponentRegistrySetResult = ContextRegistrySet(context_registry, "component_api_from_component", g_ComponentApiTestContext.m_CreateContext);
+    g_ComponentApiTestContext.m_ComponentRegistryContext = ContextRegistryGet(context_registry, "component_api_from_component");
 
     ComponentTypeSetContext(type, g_ComponentApiTestContext.m_CreateContext);
     return dmGameObject::RESULT_OK;
@@ -690,7 +699,8 @@ static dmGameObject::Result ComponentTypeTest_Destroy(const dmGameObject::Compon
 {
     g_ComponentApiTestContext.m_Destroyed = 1;
     g_ComponentApiTestContext.m_DestroyContext = ComponentTypeGetContext(type);
-    g_ComponentApiTestContext.m_DestroyRegistryContext = ComponentTypeGetContext(ctx, "component_api");
+    HContextRegistry context_registry = ComponentGetContextRegistry(ctx);
+    g_ComponentApiTestContext.m_DestroyRegistryContext = ContextRegistryGet(context_registry, "component_api");
 
     ComponentTypeSetContext(type, g_ComponentApiTestContext.m_CreateContext);
     return dmGameObject::RESULT_OK;
@@ -753,6 +763,8 @@ TEST(ComponentApi, CreateDestroyType)
     ASSERT_EQ(0, g_ComponentApiTestContext.m_Destroyed);
     ASSERT_NE((void*)0, g_ComponentApiTestContext.m_CreateContext);
     ASSERT_EQ((void*)&g_ComponentApiTestContext, g_ComponentApiTestContext.m_CreateRegistryContext);
+    ASSERT_EQ(0, g_ComponentApiTestContext.m_ComponentRegistrySetResult);
+    ASSERT_EQ(g_ComponentApiTestContext.m_CreateContext, g_ComponentApiTestContext.m_ComponentRegistryContext);
 
     dmGameObject::DestroyRegisteredComponentTypes(&component_create_ctx);
     ASSERT_EQ(1, g_ComponentApiTestContext.m_Destroyed);

--- a/engine/gameobject/src/gameobject/test/component/test_gameobject_component.cpp
+++ b/engine/gameobject/src/gameobject/test/component/test_gameobject_component.cpp
@@ -196,7 +196,6 @@ public:
     std::map<uint64_t, uint32_t> m_ComponentDestroyCountMap;
     std::map<uint64_t, uint32_t> m_ComponentUpdateCountMap;
     std::map<uint64_t, uint32_t> m_ComponentAddToUpdateCountMap;
-    std::map<uint64_t, uint32_t> m_ComponentContextRegistryCountMap;
     std::map<uint64_t, uint32_t> m_MaxComponentCreateCountMap;
 
     std::map<uint64_t, uint32_t> m_ComponentUpdateOrderMap;
@@ -260,11 +259,6 @@ static dmGameObject::CreateResult GenericComponentCreate(const dmGameObject::Com
         }
     }
 
-    if (ContextRegistryGet(params.m_ContextRegistry, "component_test") == game_object_test)
-    {
-        game_object_test->m_ComponentContextRegistryCountMap[T::m_DDFHash]++;
-    }
-
     game_object_test->m_ComponentCreateCountMap[T::m_DDFHash]++;
     return dmGameObject::CREATE_RESULT_OK;
 }
@@ -273,11 +267,6 @@ template <typename T>
 static dmGameObject::CreateResult GenericComponentInit(const dmGameObject::ComponentInitParams& params)
 {
     ComponentTest* game_object_test = (ComponentTest*) params.m_Context;
-    if (ContextRegistryGet(params.m_ContextRegistry, "component_test") == game_object_test)
-    {
-        game_object_test->m_ComponentContextRegistryCountMap[T::m_DDFHash]++;
-    }
-
     game_object_test->m_ComponentInitCountMap[T::m_DDFHash]++;
     return dmGameObject::CREATE_RESULT_OK;
 }
@@ -286,11 +275,6 @@ template <typename T>
 static dmGameObject::CreateResult GenericComponentFinal(const dmGameObject::ComponentFinalParams& params)
 {
     ComponentTest* game_object_test = (ComponentTest*) params.m_Context;
-    if (ContextRegistryGet(params.m_ContextRegistry, "component_test") == game_object_test)
-    {
-        game_object_test->m_ComponentContextRegistryCountMap[T::m_DDFHash]++;
-    }
-
     game_object_test->m_ComponentFinalCountMap[T::m_DDFHash]++;
     return dmGameObject::CREATE_RESULT_OK;
 }
@@ -323,10 +307,6 @@ static dmGameObject::CreateResult GenericComponentDestroy(const dmGameObject::Co
     }
 
     game_object_test->m_ComponentDestroyCountMap[T::m_DDFHash]++;
-    if (ContextRegistryGet(params.m_ContextRegistry, "component_test") == game_object_test)
-    {
-        game_object_test->m_ComponentContextRegistryCountMap[T::m_DDFHash]++;
-    }
 
     return dmGameObject::CREATE_RESULT_OK;
 }
@@ -379,7 +359,6 @@ TEST_F(ComponentTest, TestUpdate)
     ASSERT_EQ((uint32_t) 1, m_ComponentUpdateCountMap[TestGameObjectDDF::AResource::m_DDFHash]);
     ASSERT_EQ((uint32_t) 1, m_ComponentFinalCountMap[TestGameObjectDDF::AResource::m_DDFHash]);
     ASSERT_EQ((uint32_t) 1, m_ComponentDestroyCountMap[TestGameObjectDDF::AResource::m_DDFHash]);
-    ASSERT_EQ((uint32_t) 4, m_ComponentContextRegistryCountMap[TestGameObjectDDF::AResource::m_DDFHash]);
 }
 
 TEST_F(ComponentTest, TestPostDeleteUpdate)

--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -3444,9 +3444,9 @@ namespace dmGameSystem
 
         CompGuiContext* gui_context = new CompGuiContext;
         gui_context->m_Factory = ctx->m_Factory;
-        gui_context->m_RenderContext = *(dmRender::HRenderContext*)ctx->m_Contexts.Get(dmHashString64(RENDER_CONTEXT_NAME));
-        gui_context->m_GuiContext = *(dmGui::HContext*)ctx->m_Contexts.Get(dmHashString64("guic"));
-        gui_context->m_ScriptContext = *(dmScript::HContext*)ctx->m_Contexts.Get(dmHashString64("gui_scriptc"));
+        gui_context->m_RenderContext = (dmRender::HRenderContext) dmGameObject::ComponentTypeGetContext(ctx, RENDER_CONTEXT_NAME);
+        gui_context->m_GuiContext = (dmGui::HContext) dmGameObject::ComponentTypeGetContext(ctx, "guic");
+        gui_context->m_ScriptContext = (dmScript::HContext) dmGameObject::ComponentTypeGetContext(ctx, "gui_scriptc");
 
         gui_context->m_MaxGuiComponents = dmConfigFile::GetInt(ctx->m_Config, "gui.max_count", 64);
         gui_context->m_MaxParticleFXCount = dmConfigFile::GetInt(ctx->m_Config, "gui.max_particlefx_count", 64);

--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -3444,7 +3444,7 @@ namespace dmGameSystem
 
         CompGuiContext* gui_context = new CompGuiContext;
         gui_context->m_Factory = ctx->m_Factory;
-        gui_context->m_RenderContext = *(dmRender::HRenderContext*)ctx->m_Contexts.Get(dmHashString64("render"));
+        gui_context->m_RenderContext = *(dmRender::HRenderContext*)ctx->m_Contexts.Get(dmHashString64(RENDER_CONTEXT_NAME));
         gui_context->m_GuiContext = *(dmGui::HContext*)ctx->m_Contexts.Get(dmHashString64("guic"));
         gui_context->m_ScriptContext = *(dmScript::HContext*)ctx->m_Contexts.Get(dmHashString64("gui_scriptc"));
 

--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -3443,10 +3443,11 @@ namespace dmGameSystem
         g_CompGuiPropertyGetters.SetCapacity(4, 8);
 
         CompGuiContext* gui_context = new CompGuiContext;
+        HContextRegistry context_registry = dmGameObject::ComponentGetContextRegistry(ctx);
         gui_context->m_Factory = ctx->m_Factory;
-        gui_context->m_RenderContext = (dmRender::HRenderContext) dmGameObject::ComponentTypeGetContext(ctx, RENDER_CONTEXT_NAME);
-        gui_context->m_GuiContext = (dmGui::HContext) dmGameObject::ComponentTypeGetContext(ctx, "guic");
-        gui_context->m_ScriptContext = (dmScript::HContext) dmGameObject::ComponentTypeGetContext(ctx, "gui_scriptc");
+        gui_context->m_RenderContext = (dmRender::HRenderContext) ContextRegistryGet(context_registry, RENDER_CONTEXT_NAME);
+        gui_context->m_GuiContext = (dmGui::HContext) ContextRegistryGet(context_registry, "guic");
+        gui_context->m_ScriptContext = (dmScript::HContext) ContextRegistryGet(context_registry, "gui_scriptc");
 
         gui_context->m_MaxGuiComponents = dmConfigFile::GetInt(ctx->m_Config, "gui.max_count", 64);
         gui_context->m_MaxParticleFXCount = dmConfigFile::GetInt(ctx->m_Config, "gui.max_particlefx_count", 64);

--- a/engine/gamesys/src/gamesys/components/comp_light.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_light.cpp
@@ -159,7 +159,7 @@ namespace dmGameSystem
     {
         LightContext* light_context = new LightContext;
         light_context->m_Factory = ctx->m_Factory;
-        light_context->m_RenderContext = *(dmRender::HRenderContext*) ctx->m_Contexts.Get(dmHashString64(RENDER_CONTEXT_NAME));
+        light_context->m_RenderContext = (dmRender::HRenderContext) dmGameObject::ComponentTypeGetContext(ctx, RENDER_CONTEXT_NAME);
         light_context->m_MaxLightCount = (uint32_t) dmMath::Max(0, dmConfigFile::GetInt(ctx->m_Config, LIGHT_MAX_COUNT_KEY, 64));
 
         dmRender::SetLightBufferCount(light_context->m_RenderContext, light_context->m_MaxLightCount);

--- a/engine/gamesys/src/gamesys/components/comp_light.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_light.cpp
@@ -23,6 +23,7 @@
 #include <gamesys/gamesys_private.h>
 
 #include <dmsdk/gamesys/resources/res_light.h>
+#include <dmsdk/render/render.h>
 #include <dmsdk/resource/resource.h>
 
 namespace dmGameSystem
@@ -158,7 +159,7 @@ namespace dmGameSystem
     {
         LightContext* light_context = new LightContext;
         light_context->m_Factory = ctx->m_Factory;
-        light_context->m_RenderContext = *(dmRender::HRenderContext*) ctx->m_Contexts.Get(dmHashString64("render"));
+        light_context->m_RenderContext = *(dmRender::HRenderContext*) ctx->m_Contexts.Get(dmHashString64(RENDER_CONTEXT_NAME));
         light_context->m_MaxLightCount = (uint32_t) dmMath::Max(0, dmConfigFile::GetInt(ctx->m_Config, LIGHT_MAX_COUNT_KEY, 64));
 
         dmRender::SetLightBufferCount(light_context->m_RenderContext, light_context->m_MaxLightCount);

--- a/engine/gamesys/src/gamesys/components/comp_light.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_light.cpp
@@ -158,8 +158,9 @@ namespace dmGameSystem
     static dmGameObject::Result CompLightTypeCreate(const dmGameObject::ComponentTypeCreateCtx* ctx, dmGameObject::ComponentType* type)
     {
         LightContext* light_context = new LightContext;
+        HContextRegistry context_registry = dmGameObject::ComponentGetContextRegistry(ctx);
         light_context->m_Factory = ctx->m_Factory;
-        light_context->m_RenderContext = (dmRender::HRenderContext) dmGameObject::ComponentTypeGetContext(ctx, RENDER_CONTEXT_NAME);
+        light_context->m_RenderContext = (dmRender::HRenderContext) ContextRegistryGet(context_registry, RENDER_CONTEXT_NAME);
         light_context->m_MaxLightCount = (uint32_t) dmMath::Max(0, dmConfigFile::GetInt(ctx->m_Config, LIGHT_MAX_COUNT_KEY, 64));
 
         dmRender::SetLightBufferCount(light_context->m_RenderContext, light_context->m_MaxLightCount);

--- a/engine/gamesys/src/gamesys/components/comp_mesh.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_mesh.cpp
@@ -1161,8 +1161,9 @@ namespace dmGameSystem
     static dmGameObject::Result CompMeshTypeCreate(const dmGameObject::ComponentTypeCreateCtx* ctx, dmGameObject::ComponentType* type)
     {
         MeshContext* mesh_context = new MeshContext;
+        HContextRegistry context_registry = dmGameObject::ComponentGetContextRegistry(ctx);
         mesh_context->m_Factory = ctx->m_Factory;
-        mesh_context->m_RenderContext = (dmRender::HRenderContext) dmGameObject::ComponentTypeGetContext(ctx, RENDER_CONTEXT_NAME);
+        mesh_context->m_RenderContext = (dmRender::HRenderContext) ContextRegistryGet(context_registry, RENDER_CONTEXT_NAME);
         mesh_context->m_MaxMeshCount = dmConfigFile::GetInt(ctx->m_Config, "mesh.max_count", 128);
 
         ComponentTypeSetPrio(type, 725);

--- a/engine/gamesys/src/gamesys/components/comp_mesh.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_mesh.cpp
@@ -1162,7 +1162,7 @@ namespace dmGameSystem
     {
         MeshContext* mesh_context = new MeshContext;
         mesh_context->m_Factory = ctx->m_Factory;
-        mesh_context->m_RenderContext = *(dmRender::HRenderContext*)ctx->m_Contexts.Get(dmHashString64("render"));
+        mesh_context->m_RenderContext = *(dmRender::HRenderContext*)ctx->m_Contexts.Get(dmHashString64(RENDER_CONTEXT_NAME));
         mesh_context->m_MaxMeshCount = dmConfigFile::GetInt(ctx->m_Config, "mesh.max_count", 128);
 
         ComponentTypeSetPrio(type, 725);

--- a/engine/gamesys/src/gamesys/components/comp_mesh.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_mesh.cpp
@@ -1162,7 +1162,7 @@ namespace dmGameSystem
     {
         MeshContext* mesh_context = new MeshContext;
         mesh_context->m_Factory = ctx->m_Factory;
-        mesh_context->m_RenderContext = *(dmRender::HRenderContext*)ctx->m_Contexts.Get(dmHashString64(RENDER_CONTEXT_NAME));
+        mesh_context->m_RenderContext = (dmRender::HRenderContext) dmGameObject::ComponentTypeGetContext(ctx, RENDER_CONTEXT_NAME);
         mesh_context->m_MaxMeshCount = dmConfigFile::GetInt(ctx->m_Config, "mesh.max_count", 128);
 
         ComponentTypeSetPrio(type, 725);

--- a/engine/gamesys/src/gamesys/fontgen/fontgen.cpp
+++ b/engine/gamesys/src/gamesys/fontgen/fontgen.cpp
@@ -14,6 +14,7 @@
 
 #include <dmsdk/dlib/dstrings.h>
 #include <dmsdk/dlib/hash.h>
+#include <dmsdk/dlib/jobsystem.h>
 #include <dmsdk/dlib/log.h>
 #include <dmsdk/dlib/math.h>
 #include <dmsdk/dlib/time.h>
@@ -502,7 +503,7 @@ dmExtension::Result FontGenInitialize(dmExtension::Params* params)
     g_FontExtContext->m_StbttDefaultSdfPadding = dmConfigFile::GetInt(params->m_ConfigFile, "fontgen.stbtt_sdf_base_padding", 3);
     g_FontExtContext->m_StbttDefaultSdfEdge = dmConfigFile::GetInt(params->m_ConfigFile, "fontgen.stbtt_sdf_edge_value", 191);
 
-    g_FontExtContext->m_Jobs = dmExtension::GetContextAsType<HJobContext>(params, "jobs");
+    g_FontExtContext->m_Jobs = dmExtension::GetContextAsType<HJobContext>(params, JOB_SYSTEM_CONTEXT_NAME);
     return dmExtension::RESULT_OK;
 }
 

--- a/engine/gamesys/src/gamesys/fontgen/fontgen.cpp
+++ b/engine/gamesys/src/gamesys/fontgen/fontgen.cpp
@@ -503,7 +503,8 @@ dmExtension::Result FontGenInitialize(dmExtension::Params* params)
     g_FontExtContext->m_StbttDefaultSdfPadding = dmConfigFile::GetInt(params->m_ConfigFile, "fontgen.stbtt_sdf_base_padding", 3);
     g_FontExtContext->m_StbttDefaultSdfEdge = dmConfigFile::GetInt(params->m_ConfigFile, "fontgen.stbtt_sdf_edge_value", 191);
 
-    g_FontExtContext->m_Jobs = dmExtension::GetContextAsType<HJobContext>(params, JOB_SYSTEM_CONTEXT_NAME);
+    HContextRegistry context_registry = ExtensionParamsGetContextRegistry((ExtensionParams*)params);
+    g_FontExtContext->m_Jobs = (HJobContext) ContextRegistryGet(context_registry, JOB_SYSTEM_CONTEXT_NAME);
     return dmExtension::RESULT_OK;
 }
 

--- a/engine/gamesys/src/gamesys/scripts/script_http.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_http.cpp
@@ -306,7 +306,7 @@ namespace dmGameSystem
     {
         HContextRegistry context_registry = ExtensionAppParamsGetContextRegistry((ExtensionAppParams*)params);
 
-        dmConfigFile::HConfig config_file = dmExtension::GetContextAsType<dmConfigFile::HConfig>(context_registry, CONFIGFILE_CONTEXT_NAME);
+        dmConfigFile::HConfig config_file = (dmConfigFile::HConfig) ContextRegistryGet(context_registry, CONFIGFILE_CONTEXT_NAME);
         assert(config_file != 0);
         assert(g_Service == 0);
 
@@ -318,7 +318,7 @@ namespace dmGameSystem
             service_params.m_ThreadCount = dmConfigFile::GetInt(config_file, "network.http_thread_count", service_params.m_ThreadCount);
         }
 
-        service_params.m_HttpCache = dmExtension::GetContextAsType<dmHttpCache::HCache>(context_registry, "http_cache");
+        service_params.m_HttpCache = (dmHttpCache::HCache) ContextRegistryGet(context_registry, "http_cache");
 
         g_Service = dmHttpService::New(&service_params);
         if (g_Service == 0)
@@ -338,10 +338,10 @@ namespace dmGameSystem
     {
         HContextRegistry context_registry = ExtensionParamsGetContextRegistry((ExtensionParams*)params);
 
-        lua_State* L = dmExtension::GetContextAsType<lua_State*>(context_registry, LUA_CONTEXT_NAME);
+        lua_State* L = (lua_State*) ContextRegistryGet(context_registry, LUA_CONTEXT_NAME);
         assert(L != 0);
 
-        dmConfigFile::HConfig config_file = dmExtension::GetContextAsType<dmConfigFile::HConfig>(context_registry, CONFIGFILE_CONTEXT_NAME);
+        dmConfigFile::HConfig config_file = (dmConfigFile::HConfig) ContextRegistryGet(context_registry, CONFIGFILE_CONTEXT_NAME);
         assert(config_file != 0);
 
         int top = lua_gettop(L);

--- a/engine/gamesys/src/gamesys/scripts/script_http.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_http.cpp
@@ -18,6 +18,7 @@
 #include <ctype.h>
 #include <string.h>
 
+#include <dmsdk/dlib/configfile.h>
 #include <dmsdk/gameobject/script.h>
 
 #include <ddf/ddf.h>
@@ -59,6 +60,7 @@ namespace dmGameSystem
 
     static dmHttpService::HHttpService g_Service = 0;
     static uint64_t g_Timeout                    = 0;
+    static const char* SCRIPT_HTTP_SERVICE_CONTEXT_NAME = "http_service";
 
     static void ReportProgressCallback(dmHttpDDF::HttpRequestProgress* msg, dmMessage::URL* url, uintptr_t user_data)
     {
@@ -300,32 +302,49 @@ namespace dmGameSystem
         g_Timeout = timeout;
     }
 
+    static dmExtension::Result ScriptHttpAppInitialize(dmExtension::AppParams* params)
+    {
+        HContextRegistry context_registry = ExtensionAppParamsGetContextRegistry((ExtensionAppParams*)params);
+
+        dmConfigFile::HConfig config_file = dmExtension::GetContextAsType<dmConfigFile::HConfig>(context_registry, CONFIGFILE_CONTEXT_NAME);
+        assert(config_file != 0);
+        assert(g_Service == 0);
+
+        dmHttpService::Params service_params;
+        service_params.m_ReportProgressCallback = ReportProgressCallback;
+
+        if (config_file)
+        {
+            service_params.m_ThreadCount = dmConfigFile::GetInt(config_file, "network.http_thread_count", service_params.m_ThreadCount);
+        }
+
+        service_params.m_HttpCache = dmExtension::GetContextAsType<dmHttpCache::HCache>(context_registry, "http_cache");
+
+        g_Service = dmHttpService::New(&service_params);
+        if (g_Service == 0)
+        {
+            return dmExtension::RESULT_INIT_ERROR;
+        }
+
+        dmScript::RegisterDDFDecoder(dmHttpDDF::HttpResponse::m_DDFDescriptor, &HttpResponseDecoder);
+        dmScript::RegisterDDFDecoder(dmHttpDDF::HttpRequestProgress::m_DDFDescriptor, &HttpRequestProgressDecoder);
+
+        ContextRegistrySet(context_registry, SCRIPT_HTTP_SERVICE_CONTEXT_NAME, g_Service);
+
+        return dmExtension::RESULT_OK;
+    }
+
     static dmExtension::Result ScriptHttpInitialize(dmExtension::Params* params)
     {
-        lua_State* L = dmExtension::GetContextAsType<lua_State*>(params, "lua");
+        HContextRegistry context_registry = ExtensionParamsGetContextRegistry((ExtensionParams*)params);
+
+        lua_State* L = dmExtension::GetContextAsType<lua_State*>(context_registry, LUA_CONTEXT_NAME);
         assert(L != 0);
 
-        dmConfigFile::HConfig config_file = dmExtension::GetContextAsType<dmConfigFile::HConfig>(params, "config");
+        dmConfigFile::HConfig config_file = dmExtension::GetContextAsType<dmConfigFile::HConfig>(context_registry, CONFIGFILE_CONTEXT_NAME);
         assert(config_file != 0);
 
         int top = lua_gettop(L);
-
-        if (g_Service == 0)
-        {
-            dmHttpService::Params service_params;
-            service_params.m_ReportProgressCallback = ReportProgressCallback;
-
-            if (config_file)
-            {
-                service_params.m_ThreadCount = dmConfigFile::GetInt(config_file, "network.http_thread_count", service_params.m_ThreadCount);
-            }
-
-            service_params.m_HttpCache = dmExtension::GetContextAsType<dmHttpCache::HCache>(params, "http_cache");
-
-            g_Service = dmHttpService::New(&service_params);
-            dmScript::RegisterDDFDecoder(dmHttpDDF::HttpResponse::m_DDFDescriptor, &HttpResponseDecoder);
-            dmScript::RegisterDDFDecoder(dmHttpDDF::HttpRequestProgress::m_DDFDescriptor, &HttpRequestProgressDecoder);
-        }
 
         if (config_file)
         {
@@ -343,6 +362,15 @@ namespace dmGameSystem
 
     static dmExtension::Result ScriptHttpFinalize(dmExtension::Params* params)
     {
+        (void)params;
+        return dmExtension::RESULT_OK;
+    }
+
+    static dmExtension::Result ScriptHttpAppFinalize(dmExtension::AppParams* params)
+    {
+        HContextRegistry context_registry = ExtensionAppParamsGetContextRegistry((ExtensionAppParams*)params);
+        ContextRegistrySet(context_registry, SCRIPT_HTTP_SERVICE_CONTEXT_NAME, 0);
+
         if (g_Service != 0)
         {
             dmHttpService::Delete(g_Service);
@@ -351,5 +379,5 @@ namespace dmGameSystem
         return dmExtension::RESULT_OK;
     }
 
-    DM_DECLARE_EXTENSION(ScriptHttp, "ScriptHttp", 0, 0, ScriptHttpInitialize, 0, 0, ScriptHttpFinalize);
+    DM_DECLARE_EXTENSION(ScriptHttp, "ScriptHttp", ScriptHttpAppInitialize, ScriptHttpAppFinalize, ScriptHttpInitialize, 0, 0, ScriptHttpFinalize);
 }

--- a/engine/gamesys/src/gamesys/scripts/script_http_js.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_http_js.cpp
@@ -254,10 +254,12 @@ namespace dmGameSystem
 
     static dmExtension::Result ScriptHttpInitialize(dmExtension::Params* params)
     {
-        lua_State* L = dmExtension::GetContextAsType<lua_State*>(params, LUA_CONTEXT_NAME);
+        HContextRegistry context_registry = ExtensionParamsGetContextRegistry((ExtensionParams*)params);
+
+        lua_State* L = (lua_State*) ContextRegistryGet(context_registry, LUA_CONTEXT_NAME);
         assert(L != 0);
 
-        dmConfigFile::HConfig config_file = dmExtension::GetContextAsType<dmConfigFile::HConfig>(params, CONFIGFILE_CONTEXT_NAME);
+        dmConfigFile::HConfig config_file = (dmConfigFile::HConfig) ContextRegistryGet(context_registry, CONFIGFILE_CONTEXT_NAME);
         assert(config_file != 0);
 
         int top = lua_gettop(L);

--- a/engine/gamesys/src/gamesys/scripts/script_http_js.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_http_js.cpp
@@ -20,7 +20,9 @@
 
 #include <emscripten.h>
 
+#include <dmsdk/dlib/configfile.h>
 #include <dmsdk/gameobject/script.h>
+#include <dmsdk/script/script.h>
 #include <ddf/ddf.h>
 #include <dlib/dstrings.h>
 #include <dlib/hash.h>
@@ -252,10 +254,10 @@ namespace dmGameSystem
 
     static dmExtension::Result ScriptHttpInitialize(dmExtension::Params* params)
     {
-        lua_State* L = dmExtension::GetContextAsType<lua_State*>(params, "lua");
+        lua_State* L = dmExtension::GetContextAsType<lua_State*>(params, LUA_CONTEXT_NAME);
         assert(L != 0);
 
-        dmConfigFile::HConfig config_file = dmExtension::GetContextAsType<dmConfigFile::HConfig>(params, "config");
+        dmConfigFile::HConfig config_file = dmExtension::GetContextAsType<dmConfigFile::HConfig>(params, CONFIGFILE_CONTEXT_NAME);
         assert(config_file != 0);
 
         int top = lua_gettop(L);

--- a/engine/gamesys/src/gamesys/test/test_gamesys.h
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.h
@@ -25,6 +25,7 @@
 
 #include <sound/sound.h>
 #include <gameobject/component.h>
+#include <extension/extension.h>
 #include <extension/extension.hpp>
 #include <physics/physics.h>
 #include <rig/rig.h>

--- a/engine/gamesys/src/gamesys/test/test_gamesys.h
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.h
@@ -18,6 +18,7 @@
 #include <resource/resource.h>
 
 #include <dlib/buffer.h>
+#include <dlib/context_registry.h>
 #include <dlib/testutil.h>
 #include <hid/hid.h>
 #include <platform/window.hpp>
@@ -34,6 +35,10 @@
 #include "../components/comp_gui.h" // The GuiGetURLCallback et.al
 #include "../../../../graphics/src/graphics_private.h" // for unit test functions
 
+#include <dmsdk/dlib/configfile.h>
+#include <dmsdk/dlib/jobsystem.h>
+#include <dmsdk/graphics/graphics.h>
+#include <dmsdk/render/render.h>
 #include <dmsdk/script/script.h>
 #include <dmsdk/gamesys/script.h>
 
@@ -111,7 +116,7 @@ public:
 protected:
     void SetUp() override;
     void TearDown() override;
-    void SetupComponentCreateContext(dmGameObject::ComponentTypeCreateCtx& component_create_ctx);
+    void SetupComponentCreateContext(dmGameObject::ComponentTypeCreateCtx& component_create_ctx, dmGameObject::ComponentTypeCreateCtxImpl& component_create_ctx_impl);
 
     void WaitForTestsDone(int update_count, bool render, bool* result);
 
@@ -145,6 +150,7 @@ protected:
     dmHashTable64<void*> m_Contexts;
     ExtensionAppParams  m_AppParams;
     ExtensionParams     m_Params;
+    HContextRegistry    m_ContextRegistry;
 };
 
 class ScriptBaseTest : public GamesysTest<const char*>
@@ -498,15 +504,21 @@ bool CopyResource(const char* src, const char* dst);
 bool UnlinkResource(const char* name);
 
 template<typename T>
-void GamesysTest<T>::SetupComponentCreateContext(dmGameObject::ComponentTypeCreateCtx& component_create_ctx)
+void GamesysTest<T>::SetupComponentCreateContext(dmGameObject::ComponentTypeCreateCtx& component_create_ctx, dmGameObject::ComponentTypeCreateCtxImpl& component_create_ctx_impl)
 {
+    component_create_ctx_impl.m_ContextRegistry = m_ContextRegistry;
+    component_create_ctx.m_Impl = &component_create_ctx_impl;
     component_create_ctx.m_Script = m_ScriptContext;
     component_create_ctx.m_Register = m_Register;
     component_create_ctx.m_Factory = m_Factory;
     component_create_ctx.m_Config = m_Config;
+    ContextRegistrySet(m_ContextRegistry, GRAPHICS_CONTEXT_NAME, m_GraphicsContext);
+    ContextRegistrySet(m_ContextRegistry, RENDER_CONTEXT_NAME, m_RenderContext);
+    ContextRegistrySet(m_ContextRegistry, "guic", m_GuiContext);
+    ContextRegistrySet(m_ContextRegistry, "gui_scriptc", m_ScriptContext);
     component_create_ctx.m_Contexts.SetCapacity(3, 8);
-    component_create_ctx.m_Contexts.Put(dmHashString64("graphics"), m_GraphicsContext);
-    component_create_ctx.m_Contexts.Put(dmHashString64("render"), m_RenderContext);
+    component_create_ctx.m_Contexts.Put(dmHashString64(GRAPHICS_CONTEXT_NAME), m_GraphicsContext);
+    component_create_ctx.m_Contexts.Put(dmHashString64(RENDER_CONTEXT_NAME), m_RenderContext);
     component_create_ctx.m_Contexts.Put(dmHashString64("guic"), m_GuiContext);
     component_create_ctx.m_Contexts.Put(dmHashString64("gui_scriptc"), m_ScriptContext);
 }
@@ -579,13 +591,16 @@ void GamesysTest<T>::SetUp()
 
     ExtensionAppParamsInitialize(&m_AppParams);
     ExtensionParamsInitialize(&m_Params);
+    m_ContextRegistry = ContextRegistryCreate();
+    ExtensionAppParamsSetContextRegistry(&m_AppParams, m_ContextRegistry);
+    ExtensionParamsSetContextRegistry(&m_Params, m_ContextRegistry);
 
     m_Params.m_L = dmScript::GetLuaState(m_ScriptContext);
     m_Params.m_ResourceFactory = m_Factory;
     m_Params.m_ConfigFile = m_Config;
-    ExtensionParamsSetContext(&m_Params, "lua", dmScript::GetLuaState(m_ScriptContext));
-    ExtensionParamsSetContext(&m_Params, "config", m_Config);
-    ExtensionParamsSetContext(&m_Params, "jobs", m_JobContext);
+    ContextRegistrySet(m_ContextRegistry, LUA_CONTEXT_NAME, dmScript::GetLuaState(m_ScriptContext));
+    ContextRegistrySet(m_ContextRegistry, CONFIGFILE_CONTEXT_NAME, m_Config);
+    ContextRegistrySet(m_ContextRegistry, JOB_SYSTEM_CONTEXT_NAME, m_JobContext);
 
     dmExtension::AppInitialize(&m_AppParams);
     dmExtension::Initialize(&m_Params);
@@ -706,8 +721,9 @@ void GamesysTest<T>::SetUp()
     ASSERT_NE((void*)0, m_GamepadMapsDDF);
     dmInput::RegisterGamepads(m_InputContext, m_GamepadMapsDDF);
 
+    dmGameObject::ComponentTypeCreateCtxImpl component_create_ctx_impl;
     dmGameObject::ComponentTypeCreateCtx component_create_ctx;
-    SetupComponentCreateContext(component_create_ctx);
+    SetupComponentCreateContext(component_create_ctx, component_create_ctx_impl);
     dmGameObject::CreateRegisteredComponentTypes(&component_create_ctx);
 
     assert(dmGameObject::RESULT_OK == dmGameSystem::RegisterComponentTypes(m_Factory, m_Register, m_RenderContext, physics_context, &m_ParticleFXContext, &m_SpriteContext,
@@ -735,8 +751,9 @@ void GamesysTest<T>::TearDown()
 
     dmResource::DeregisterTypes(m_Factory, &m_Contexts);
 
+    dmGameObject::ComponentTypeCreateCtxImpl component_create_ctx_impl;
     dmGameObject::ComponentTypeCreateCtx component_create_ctx;
-    SetupComponentCreateContext(component_create_ctx);
+    SetupComponentCreateContext(component_create_ctx, component_create_ctx_impl);
     dmGameObject::DestroyRegisteredComponentTypes(&component_create_ctx);
 
     dmGameObject::DeleteRegister(m_Register);
@@ -774,6 +791,7 @@ void GamesysTest<T>::TearDown()
 
     dmExtension::AppFinalize(&m_AppParams);
     ExtensionAppParamsFinalize(&m_AppParams);
+    ContextRegistryDestroy(m_ContextRegistry);
 
     dmBuffer::DeleteContext();
     dmConfigFile::Delete(m_Config);

--- a/engine/gamesys/src/gamesys/test/test_gamesys.h
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.h
@@ -592,6 +592,7 @@ void GamesysTest<T>::SetUp()
     ExtensionAppParamsInitialize(&m_AppParams);
     ExtensionParamsInitialize(&m_Params);
     m_ContextRegistry = ContextRegistryCreate();
+    dmGameObject::SetContextRegistry(m_Register, m_ContextRegistry);
     ExtensionAppParamsSetContextRegistry(&m_AppParams, m_ContextRegistry);
     ExtensionParamsSetContextRegistry(&m_Params, m_ContextRegistry);
 

--- a/engine/gamesys/src/gamesys/test/test_gamesys_http.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys_http.cpp
@@ -49,6 +49,8 @@ TEST_F(ComponentTest, HTTPRequest)
 
     SetHttpAddress(L);
 
+    ASSERT_NE((void*)0, ContextRegistryGetByName(m_ContextRegistry, "http_service"));
+
     ASSERT_TRUE(dmGameObject::Init(m_Collection));
 
     dmGameObject::HInstance go = ::Spawn(m_Factory, m_Collection, "/http/http_request.goc", dmHashString64("/http_request"), 0, Point3(0, 0, 0), Quat(0, 0, 0, 1), Vector3(1, 1, 1));

--- a/engine/gamesys/src/gamesys/test/test_gamesys_http.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys_http.cpp
@@ -49,7 +49,7 @@ TEST_F(ComponentTest, HTTPRequest)
 
     SetHttpAddress(L);
 
-    ASSERT_NE((void*)0, ContextRegistryGetByName(m_ContextRegistry, "http_service"));
+    ASSERT_NE((void*)0, ContextRegistryGet(m_ContextRegistry, "http_service"));
 
     ASSERT_TRUE(dmGameObject::Init(m_Collection));
 

--- a/engine/gamesys/src/gamesys/test/test_script_http.cpp
+++ b/engine/gamesys/src/gamesys/test/test_script_http.cpp
@@ -32,6 +32,7 @@
 #include <dlib/testutil.h>
 #include <dlib/sys.h>
 #include <dlib/testutil.h>
+#include <extension/extension.h>
 #include <extension/extension.hpp>
 #include <platform/window.hpp>
 

--- a/engine/gamesys/src/gamesys/test/test_script_http.cpp
+++ b/engine/gamesys/src/gamesys/test/test_script_http.cpp
@@ -14,10 +14,15 @@
 
 #include "../scripts/script_http.h" // to set the timeout
 
+#include <dmsdk/dlib/configfile.h>
+#include <dmsdk/render/render.h>
+#include <dmsdk/script/script.h>
+
 #include <script/test_script.h>
 #include <script/script.h>
 #include <testmain/testmain.h>
 #include <dlib/configfile.h>
+#include <dlib/context_registry.h>
 #include <dlib/dstrings.h>
 #include <dlib/hash.h>
 #include <dlib/log.h>
@@ -102,6 +107,7 @@ public:
     dmRender::HRenderContext m_RenderContext;
     ExtensionAppParams  m_AppParams;
     ExtensionParams     m_Params;
+    HContextRegistry    m_ContextRegistry;
     int m_NumberOfFails;
 
 protected:
@@ -151,15 +157,19 @@ protected:
 
         ExtensionAppParamsInitialize(&m_AppParams);
         ExtensionParamsInitialize(&m_Params);
+        m_ContextRegistry = ContextRegistryCreate();
+        ExtensionAppParamsSetContextRegistry(&m_AppParams, m_ContextRegistry);
+        ExtensionParamsSetContextRegistry(&m_Params, m_ContextRegistry);
 
         m_Params.m_L = dmScript::GetLuaState(m_ScriptContext);
         m_Params.m_ConfigFile = m_ConfigFile;
         m_Params.m_ResourceFactory = m_Factory;
-        ExtensionParamsSetContext(&m_Params, "lua", dmScript::GetLuaState(m_ScriptContext));
-        ExtensionParamsSetContext(&m_Params, "config", m_ConfigFile);
-        ExtensionParamsSetContext(&m_Params, "render", m_RenderContext);
+        ContextRegistrySet(m_ContextRegistry, LUA_CONTEXT_NAME, dmScript::GetLuaState(m_ScriptContext));
+        ContextRegistrySet(m_ContextRegistry, CONFIGFILE_CONTEXT_NAME, m_ConfigFile);
+        ContextRegistrySet(m_ContextRegistry, RENDER_CONTEXT_NAME, m_RenderContext);
 
         dmExtension::AppInitialize(&m_AppParams);
+        ASSERT_NE((void*)0, ContextRegistryGetByName(m_ContextRegistry, "http_service"));
         dmExtension::Initialize(&m_Params);
 
         L = dmScript::GetLuaState(m_ScriptContext);
@@ -214,6 +224,7 @@ protected:
 
         ExtensionParamsFinalize(&m_Params);
         ExtensionAppParamsFinalize(&m_AppParams);
+        ContextRegistryDestroy(m_ContextRegistry);
 
         dmRender::DeleteRenderContext(m_RenderContext, m_ScriptContext);
         dmGraphics::CloseWindow(m_GraphicsContext);

--- a/engine/gamesys/src/gamesys/test/test_script_http.cpp
+++ b/engine/gamesys/src/gamesys/test/test_script_http.cpp
@@ -169,7 +169,7 @@ protected:
         ContextRegistrySet(m_ContextRegistry, RENDER_CONTEXT_NAME, m_RenderContext);
 
         dmExtension::AppInitialize(&m_AppParams);
-        ASSERT_NE((void*)0, ContextRegistryGetByName(m_ContextRegistry, "http_service"));
+        ASSERT_NE((void*)0, ContextRegistryGet(m_ContextRegistry, "http_service"));
         dmExtension::Initialize(&m_Params);
 
         L = dmScript::GetLuaState(m_ScriptContext);

--- a/engine/graphics/src/dmsdk/graphics/graphics.h
+++ b/engine/graphics/src/dmsdk/graphics/graphics.h
@@ -33,6 +33,13 @@
  * @language C++
  */
 
+/*# Graphics extension context name
+ * Name used when registering the graphics context with the engine context registry.
+ * @constant
+ * @name GRAPHICS_CONTEXT_NAME
+ */
+#define GRAPHICS_CONTEXT_NAME "graphics"
+
 namespace dmGraphics
 {
     /*#

--- a/engine/hid/src/dmsdk/hid/hid.h
+++ b/engine/hid/src/dmsdk/hid/hid.h
@@ -27,6 +27,13 @@
  * @language C++
  */
 
+/*# HID extension context name
+ * Name used when registering the HID context with the engine context registry.
+ * @constant
+ * @name HID_CONTEXT_NAME
+ */
+#define HID_CONTEXT_NAME "hid"
+
 namespace dmHID
 {
     /*# HID context handle

--- a/engine/render/src/dmsdk/render/render.h
+++ b/engine/render/src/dmsdk/render/render.h
@@ -36,6 +36,13 @@ namespace dmIntersection
  * @language C++
  */
 
+/*# Render extension context name
+ * Name used when registering the render context with the engine context registry.
+ * @constant
+ * @name RENDER_CONTEXT_NAME
+ */
+#define RENDER_CONTEXT_NAME "render"
+
 namespace dmRender
 {
     /*#

--- a/engine/resource/src/dmsdk/resource/resource.h
+++ b/engine/resource/src/dmsdk/resource/resource.h
@@ -29,6 +29,13 @@
 #include <dmsdk/dlib/hash.h>
 #include <dmsdk/dlib/align.h> // DM_ALIGNED
 
+/*# Resource factory extension context name
+ * Name used when registering the resource factory with the engine context registry.
+ * @constant
+ * @name RESOURCE_FACTORY_CONTEXT_NAME
+ */
+#define RESOURCE_FACTORY_CONTEXT_NAME "factory"
+
 /*#
 * Resource factory handle. Holds references to all currently loaded resources.
 * @name HResourceFactory

--- a/engine/script/src/dmsdk/script/script.h
+++ b/engine/script/src/dmsdk/script/script.h
@@ -41,6 +41,20 @@ namespace dmScript
      * @language C++
      */
 
+    /*# Script extension context name
+     * Name used when registering the script context with the engine context registry.
+     * @constant
+     * @name SCRIPT_CONTEXT_NAME
+     */
+    #define SCRIPT_CONTEXT_NAME "script"
+
+    /*# Lua extension context name
+     * Name used when registering the Lua state with the engine context registry.
+     * @constant
+     * @name LUA_CONTEXT_NAME
+     */
+    #define LUA_CONTEXT_NAME "lua"
+
     /*#
      * The script context
      * @typedef


### PR DESCRIPTION
Added public name variables for the registered extension/component contexts.
This allows for your extension to more securely get/use the correct context when initializing.

The currently supported contexts from `engine.cpp`:
| Constant | Context | Header |
|---|---|---|
| CONFIGFILE_CONTEXT_NAME | dmConfigFile::HConfig | <dmsdk/dlib/configfile.h> |
| GAMEOBJECT_CONTEXT_NAME | dmGameObject::HRegister | <dmsdk/gameobject/gameobject.h> |
| GRAPHICS_CONTEXT_NAME | dmGraphics::HContext | <dmsdk/graphics/graphics.h> |
| HID_CONTEXT_NAME | dmHID::HContext | <dmsdk/hid/hid.h> |
| JOB_SYSTEM_CONTEXT_NAME | HJobContext | <dmsdk/dlib/jobsystem.h> |
| LUA_CONTEXT_NAME | lua_State* | <dmsdk/script/script.h> |
| RENDER_CONTEXT_NAME | dmRender::HRenderContext | <dmsdk/render/render.h> |
| RESOURCE_FACTORY_CONTEXT_NAME | dmResource::HFactory | <dmsdk/resource/resource.h> |
| SCRIPT_CONTEXT_NAME | dmScript::HContext | <dmsdk/script/script.h> |
| WEBSERVER_CONTEXT_NAME | dmWebServer::HServer | <dmsdk/dlib/webserver.h> |

`dmsdk/dlib/context_registry.h`
  * ContextRegistrySet
  * ContextRegistryGet
  * ContextRegistrySetByHash
  * ContextRegistryGetByHash

`dmsdk/extension/extension.h`
  * ExtensionAppParamsGetContextRegistry
  * ExtensionParamsGetContextRegistry

`dmsdk/gameobject/component.h`
  * dmGameObject::ComponentGetContextRegistry
  
Examples:
```c
// Extension AppInitialize: Add a context
static dmExtension::Result MyAppInitialize(dmExtension::AppParams* params)
{
    HContextRegistry registry = ExtensionAppParamsGetContextRegistry((ExtensionAppParams*)params);
    ContextRegistrySet(registry, MY_CONTEXT_NAME, &g_MyContext);
    
    dmConfigFile::HConfig config = (dmConfigFile::HConfig)ContextRegistryGet(registry, CONFIGFILE_CONTEXT_NAME);

    return dmExtension::RESULT_OK;
}

// Component type create: get/set contexts through the same registry
static dmGameObject::Result MyComponentCreate(const dmGameObject::ComponentTypeCreateCtx* ctx, dmGameObject::HComponentType type)
{
    HContextRegistry registry = dmGameObject::ComponentGetContextRegistry(ctx);
    ...

    return dmGameObject::RESULT_OK;
}
```

### Technical changes

Related: https://github.com/defold/defold/issues/12428

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
