### PR TITLE
Show a notification when editor scripts should be reloaded

### DIFF
--- a/editor/.clj-kondo/hooks/dynamo_graph.clj
+++ b/editor/.clj-kondo/hooks/dynamo_graph.clj
@@ -150,12 +150,19 @@
   (api/list-node
     [(api/token-node 'dynamo.graph/make-evaluation-context)]))
 
+(defn- symbols-in-node [node]
+  (into #{}
+        (filter symbol?)
+        (tree-seq coll? seq (api/sexpr node))))
+
 (defn- let-ec-init-node [init-node]
   (api/list-node
     [(api/token-node 'let)
      (api/vector-node
        [(api/token-node 'evaluation-context)
-        (evaluation-context-node)])
+        (evaluation-context-node)
+        (api/token-node '_evaluation-context-used-by-clj-kondo-hook)
+        (api/token-node 'evaluation-context)])
      init-node]))
 
 (defn- let-ec-binding-nodes [binding-node]
@@ -185,6 +192,7 @@
 (defn- fn-like-node? [node]
   (let [head (call-head node)]
     (contains? '#{fn fn* clojure.core/fn dynamo.graph/fnk g/fnk
+                  dynamo.graph/constantly g/constantly
                   editor.gui/gen-outline-fnk gen-outline-fnk}
                head)))
 
@@ -229,11 +237,6 @@
        [(api/token-node 'ex-info)
         (api/token-node "lint-only graph value")
         (api/map-node [])])]))
-
-(defn- symbols-in-node [node]
-  (into #{}
-        (filter symbol?)
-        (tree-seq coll? seq (api/sexpr node))))
 
 (defn- scoped-expression-node [labels nodes]
   (let [used-labels (into #{}
@@ -285,14 +288,13 @@
   (let [[_ _ _ & tail] (:children form-node)]
     (loop [nodes []
            tail tail]
-      (if-let [[option-node value-node & tail] (seq tail)]
-        (recur
-          (cond-> nodes
-                  (and (keyword? (api/sexpr option-node))
-                       value-node
-                       (not (keyword? (api/sexpr value-node))))
-                  (conj value-node))
-          tail)
+      (if-let [[option-node & tail] (seq tail)]
+        (let [value-node (first tail)]
+          (if (and (keyword? (api/sexpr option-node))
+                   value-node
+                   (not (keyword? (api/sexpr value-node))))
+            (recur (conj nodes value-node) (rest tail))
+            (recur nodes tail)))
         nodes))))
 
 (defn- property-option-nodes [form-node]

--- a/editor/resources/localization/en.editor_localization
+++ b/editor/resources/localization/en.editor_localization
@@ -353,6 +353,11 @@ notification.fetch-libraries.problem.install-failed = failed to install
 notification.fetch-libraries.problem.unknown = unknown problem — {problem}
 notification.fetch-libraries.dependency-problem = {uri}: {problem}
 
+# Editor scripts notification
+
+notification.reload-editor-scripts = Editor scripts have changed. Do you want to reload them now?
+notification.reload-editor-scripts.action.reload = Reload Editor Scripts
+
 # Open custom editor notifications
 
 notification.open-custom-editor-failed.error = Could not run external editor "{editor}".\n\nUnderlying error from the OS:\n{error}

--- a/editor/resources/localization/ru.editor_localization
+++ b/editor/resources/localization/ru.editor_localization
@@ -353,6 +353,11 @@ notification.fetch-libraries.problem.install-failed = не удалось уст
 notification.fetch-libraries.problem.unknown = неизвестная проблема — {problem}
 notification.fetch-libraries.dependency-problem = {uri}\: {problem}
 
+# Editor scripts notification
+
+notification.reload-editor-scripts = Скрипты редактора изменились. Перезагрузить их сейчас?
+notification.reload-editor-scripts.action.reload = Перезагрузить скрипты редактора
+
 # Open custom editor notifications
 
 notification.open-custom-editor-failed.error = Не удалось запустить внешний редактор «{editor}».\n\nИсходная ошибка ОС\:\n{error}

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -2098,6 +2098,29 @@
     (when (not= (.getTitle stage) new-title)
       (.setTitle stage new-title))))
 
+(defn- make-reload-editor-scripts-notification-updater [project]
+  (let [last-reload-needed (volatile! nil)]
+    (fn update-reload-editor-scripts-notification! [evaluation-context]
+      (let [workspace (project/workspace project evaluation-context)
+            reload-needed (extensions/reload-needed? project evaluation-context)]
+        (when (not= @last-reload-needed reload-needed)
+          (vreset! last-reload-needed reload-needed)
+          (let [notifications (workspace/notifications workspace evaluation-context)
+                notification-id ::editor-scripts-changed]
+            (g/transact
+              (if reload-needed
+                (notifications/show
+                  notifications
+                  {:id notification-id
+                   :type :info
+                   :message (localization/message "notification.reload-editor-scripts")
+                   :actions [{:message (localization/message "notification.reload-editor-scripts.action.reload")
+                              :on-action #(ui/execute-command
+                                            (ui/contexts (ui/main-scene) true)
+                                            :project.reload-editor-scripts
+                                            nil)}]})
+                (notifications/close notifications notification-id)))))))))
+
 (defn- refresh-menus-and-toolbars! [app-view ^Scene scene evaluation-context]
   (ui/user-data! scene :keymap (g/node-value app-view :keymap evaluation-context))
   (ui/refresh scene evaluation-context))
@@ -2224,6 +2247,7 @@
       (ui/on-closed! stage (fn [_] (dispose-scene-views! app-view)))
 
       (let [prev-localization-bundle (volatile! nil)
+            reload-editor-scripts-notification-updater (make-reload-editor-scripts-notification-updater project)
             refresh-timer (ui/->timer
                             "refresh-app-view"
                             (fn [_animation-timer _elapsed dt]
@@ -2242,6 +2266,7 @@
                                           (localization/set-bundle! localization ::project localization-bundle)))
                                       (refresh-menus-and-toolbars! app-view app-scene evaluation-context)
                                       (refresh-views! app-view evaluation-context)
+                                      (reload-editor-scripts-notification-updater evaluation-context)
                                       (refresh-app-title! stage project evaluation-context)))
                                   ;; Scene views are always refreshed, since they may play animations.
                                   ;; This performs graph mutations, so needs to manage its own evaluation-contexts.
@@ -3214,6 +3239,7 @@
                                                   (.close out)))))
                      f))
     :web-server web-server)
+  (ui/user-data! (g/node-value app-view :scene) ::ui/refresh-requested? true)
   (ui/invalidate-menubar-item! ::project/bundle))
 
 (defn- fetch-libraries [app-view workspace project changes-view build-errors-view prefs localization web-server]

--- a/editor/src/clj/editor/editor_extensions.clj
+++ b/editor/src/clj/editor/editor_extensions.clj
@@ -80,8 +80,12 @@
                              msg     string message, may be multiline
     :project-prototypes    vector of project-owned editor script Prototypes
     :library-prototypes    vector of library-provided editor script Prototypes
-    :reload-signature      hash of editor script paths and lines when the
-                           runtime was last reloaded
+    :project-reload-signature
+                           hash of project editor script paths and lines when
+                           the runtime was last reloaded
+    :library-reload-signature
+                           hash of library editor script paths and lines when
+                           the runtime was last reloaded
     :rt                    editor script runtime
     :all                   map of module function keyword to a vector of tuples:
                              path      proj-path of an editor script
@@ -123,16 +127,21 @@
 (defn- unwrap-error-values [arr]
   (mapv #(cond-> % (g/error? %) :value) arr))
 
-(g/defnk produce-reload-signature [reload-signatures]
-  (Murmur3/hashUnordered reload-signatures))
+(g/defnk produce-project-reload-signature [project-reload-signatures]
+  (Murmur3/hashUnordered project-reload-signatures))
+
+(g/defnk produce-library-reload-signature [library-reload-signatures]
+  (Murmur3/hashUnordered library-reload-signatures))
 
 (g/defnode EditorExtensions
   (input project-prototypes g/Any :array :substitute unwrap-error-values)
   (input library-prototypes g/Any :array :substitute unwrap-error-values)
-  (input reload-signatures g/Int :array)
+  (input project-reload-signatures g/Int :array)
+  (input library-reload-signatures g/Int :array)
   (output project-prototypes g/Any (gu/passthrough project-prototypes))
   (output library-prototypes g/Any (gu/passthrough library-prototypes))
-  (output reload-signature g/Int :cached produce-reload-signature))
+  (output project-reload-signature g/Int :cached produce-project-reload-signature)
+  (output library-reload-signature g/Int :cached produce-library-reload-signature))
 
 (defn make [graph]
   (first (g/tx-nodes-added (g/transact (g/make-node graph EditorExtensions)))))
@@ -896,9 +905,12 @@
 (defn reload-needed?
   "Return true if reloading editor scripts would change the runtime"
   [project evaluation-context]
-  (let [extensions (g/node-value project :editor-extensions evaluation-context)]
-    (not= (:reload-signature (g/user-data extensions :state))
-          (g/node-value extensions :reload-signature evaluation-context))))
+  (let [extensions (g/node-value project :editor-extensions evaluation-context)
+        state (g/user-data extensions :state)]
+    (or (not= (:project-reload-signature state)
+              (g/node-value extensions :project-reload-signature evaluation-context))
+        (not= (:library-reload-signature state)
+              (g/node-value extensions :library-reload-signature evaluation-context)))))
 
 (defn reload!
   "Reload the extensions
@@ -943,6 +955,8 @@
              script-annotations (project/script-annotations project evaluation-context)
              extensions (g/node-value project :editor-extensions evaluation-context)
              old-state (ext-state project evaluation-context)
+             reload-project (or (= :all kind) (= :project kind))
+             reload-library (or (= :all kind) (= :library kind))
              workspace (project/workspace project evaluation-context)
              project-path (.toPath (workspace/project-directory basis workspace))
              rt (rt/make
@@ -1006,11 +1020,16 @@
              new-state (re-create-ext-state
                          (assoc opts
                            :rt rt
-                           :reload-signature (g/node-value extensions :reload-signature evaluation-context)
-                           :library-prototypes (if (or (= :all kind) (= :library kind))
+                           :project-reload-signature (if reload-project
+                                                       (g/node-value extensions :project-reload-signature evaluation-context)
+                                                       (:project-reload-signature old-state))
+                           :library-reload-signature (if reload-library
+                                                       (g/node-value extensions :library-reload-signature evaluation-context)
+                                                       (:library-reload-signature old-state))
+                           :library-prototypes (if reload-library
                                                  (g/node-value extensions :library-prototypes evaluation-context)
                                                  (:library-prototypes old-state []))
-                           :project-prototypes (if (or (= :all kind) (= :project kind))
+                           :project-prototypes (if reload-project
                                                  (g/node-value extensions :project-prototypes evaluation-context)
                                                  (:project-prototypes old-state [])))
                          evaluation-context)

--- a/editor/src/clj/editor/editor_extensions.clj
+++ b/editor/src/clj/editor/editor_extensions.clj
@@ -59,7 +59,7 @@
             [util.http-client :as http]
             [util.http-server :as http-server]
             [util.path :as path])
-  (:import [clojure.lang IDeref]
+  (:import [clojure.lang IDeref Murmur3]
            [com.dynamo.bob Platform]
            [com.dynamo.bob.bundle BundleHelper]
            [java.io PrintStream PushbackReader]
@@ -80,6 +80,8 @@
                              msg     string message, may be multiline
     :project-prototypes    vector of project-owned editor script Prototypes
     :library-prototypes    vector of library-provided editor script Prototypes
+    :reload-signature      hash of editor script paths and lines when the
+                           runtime was last reloaded
     :rt                    editor script runtime
     :all                   map of module function keyword to a vector of tuples:
                              path      proj-path of an editor script
@@ -121,11 +123,16 @@
 (defn- unwrap-error-values [arr]
   (mapv #(cond-> % (g/error? %) :value) arr))
 
+(g/defnk produce-reload-signature [reload-signatures]
+  (Murmur3/hashUnordered reload-signatures))
+
 (g/defnode EditorExtensions
   (input project-prototypes g/Any :array :substitute unwrap-error-values)
   (input library-prototypes g/Any :array :substitute unwrap-error-values)
+  (input reload-signatures g/Int :array)
   (output project-prototypes g/Any (gu/passthrough project-prototypes))
-  (output library-prototypes g/Any (gu/passthrough library-prototypes)))
+  (output library-prototypes g/Any (gu/passthrough library-prototypes))
+  (output reload-signature g/Int :cached produce-reload-signature))
 
 (defn make [graph]
   (first (g/tx-nodes-added (g/transact (g/make-node graph EditorExtensions)))))
@@ -886,6 +893,13 @@
 
 ;; region public API
 
+(defn reload-needed?
+  "Return true if reloading editor scripts would change the runtime"
+  [project evaluation-context]
+  (let [extensions (g/node-value project :editor-extensions evaluation-context)]
+    (not= (:reload-signature (g/user-data extensions :state))
+          (g/node-value extensions :reload-signature evaluation-context))))
+
 (defn reload!
   "Reload the extensions
 
@@ -992,6 +1006,7 @@
              new-state (re-create-ext-state
                          (assoc opts
                            :rt rt
+                           :reload-signature (g/node-value extensions :reload-signature evaluation-context)
                            :library-prototypes (if (or (= :all kind) (= :library kind))
                                                  (g/node-value extensions :library-prototypes evaluation-context)
                                                  (:library-prototypes old-state []))

--- a/editor/src/clj/editor/editor_extensions.clj
+++ b/editor/src/clj/editor/editor_extensions.clj
@@ -136,8 +136,8 @@
 (g/defnode EditorExtensions
   (input project-prototypes g/Any :array :substitute unwrap-error-values)
   (input library-prototypes g/Any :array :substitute unwrap-error-values)
-  (input project-reload-signatures g/Int :array)
-  (input library-reload-signatures g/Int :array)
+  (input project-reload-signatures g/Int :array :substitute gu/array-subst-remove-errors)
+  (input library-reload-signatures g/Int :array :substitute gu/array-subst-remove-errors)
   (output project-prototypes g/Any (gu/passthrough project-prototypes))
   (output library-prototypes g/Any (gu/passthrough library-prototypes))
   (output project-reload-signature g/Int :cached produce-project-reload-signature)

--- a/editor/src/clj/editor/editor_script.clj
+++ b/editor/src/clj/editor/editor_script.clj
@@ -60,10 +60,11 @@
                                  :lazy-loaded false
                                  :additional-load-fn
                                  (fn [project self resource]
-                                   (let [extensions (g/node-value project :editor-extensions)
-                                         target (if (resource/file-resource? resource)
-                                                  :project-prototypes
-                                                  :library-prototypes)]
-                                     (concat
-                                       (g/connect self :prototype extensions target)
-                                       (g/connect self :reload-signature extensions :reload-signatures))))))
+                                   (let [extensions (g/node-value project :editor-extensions)]
+                                     (if (resource/file-resource? resource)
+                                       (concat
+                                         (g/connect self :prototype extensions :project-prototypes)
+                                         (g/connect self :reload-signature extensions :project-reload-signatures))
+                                       (concat
+                                         (g/connect self :prototype extensions :library-prototypes)
+                                         (g/connect self :reload-signature extensions :library-reload-signatures)))))))

--- a/editor/src/clj/editor/editor_script.clj
+++ b/editor/src/clj/editor/editor_script.clj
@@ -20,25 +20,32 @@
             [editor.editor-extensions.runtime :as rt]
             [editor.localization :as localization]
             [editor.lua :as lua]
-            [editor.resource :as resource]))
+            [editor.resource :as resource])
+  (:import [clojure.lang Util]))
 
 (def ^:private editor-extension-compilation-failed-message
   (localization/message "error.editor-extension-compilation-failed"))
 
 (g/defnk produce-prototype [_node-id lines resource]
   (try
-    (rt/read (data/lines-input-stream lines) (resource/resource->proj-path resource))
+    (rt/read (data/lines-input-stream lines) (resource/proj-path resource))
     (catch Exception e
       (g/->error _node-id :prototype :fatal e editor-extension-compilation-failed-message))))
 
 (def completions
   (merge-with into lua/std-libs-docs lua/editor-completions))
 
+(g/defnk produce-reload-signature [lines resource]
+  (Util/hashCombine
+    (hash (resource/proj-path resource))
+    (hash lines)))
+
 (g/defnode EditorScript
   (inherits r/CodeEditorResourceNode)
   (input globals g/Any)
   (output completions g/Any (g/constantly completions))
-  (output prototype g/Any :cached produce-prototype))
+  (output prototype g/Any :cached produce-prototype)
+  (output reload-signature g/Int :cached produce-reload-signature))
 
 (defn register-resource-types [workspace]
   (r/register-code-resource-type workspace
@@ -57,4 +64,6 @@
                                          target (if (resource/file-resource? resource)
                                                   :project-prototypes
                                                   :library-prototypes)]
-                                     (g/connect self :prototype extensions target)))))
+                                     (concat
+                                       (g/connect self :prototype extensions target)
+                                       (g/connect self :reload-signature extensions :reload-signatures))))))

--- a/editor/test/integration/editor_extensions_test.clj
+++ b/editor/test/integration/editor_extensions_test.clj
@@ -329,11 +329,12 @@
 (def ^:private stopped-server
   (http-server/stop! (http-server/start! (web-server/make-dynamic-handler [])) 0))
 
-(defn- reload-editor-scripts! [project & {:keys [display-output! open-resource! prefs web-server]
+(defn- reload-editor-scripts! [project & {:keys [display-output! kind open-resource! prefs web-server]
                                           :or {display-output! println
+                                               kind :all
                                                open-resource! open-resource-noop!
                                                web-server stopped-server}}]
-  (extensions/reload! project :all
+  (extensions/reload! project kind
                       :prefs (or prefs (test-util/make-test-prefs))
                       :localization test-util/localization
                       :reload-resources! (make-reload-resources-fn (project/workspace project))
@@ -342,6 +343,24 @@
                       :open-resource! open-resource!
                       :invoke-bob! (make-invoke-bob-fn project)
                       :web-server web-server))
+
+(deftest project-editor-script-change-stays-reload-needed-after-library-reload-test
+  (test-util/with-loaded-project "test/resources/editor_extensions/commands_project"
+    (let [script-node (test-util/resource-node project "/test.editor_script")
+          reload-needed? (fn []
+                            (g/with-auto-evaluation-context evaluation-context
+                              (extensions/reload-needed? project evaluation-context)))]
+      (reload-editor-scripts! project)
+      (is (not (reload-needed?)))
+
+      (test-util/update-code-editor-lines! script-node conj "-- changed")
+      (is (reload-needed?))
+
+      (reload-editor-scripts! project :kind :library)
+      (is (reload-needed?))
+
+      (reload-editor-scripts! project)
+      (is (not (reload-needed?))))))
 
 (defn- eval-handler-contexts [context-name selection]
   (let [selection-provider (->StaticSelection selection)
@@ -735,9 +754,9 @@
             ((vswap! hash->stable-id #(assoc % s (str "0x" (count %)))) s))))))
 
 (defn- expect-script-output [expected actual]
-  (let [actual (normalize-pprint-output (str actual))]
-    (let [output-matches-expectation (= expected actual)]
-      (is output-matches-expectation (when-not output-matches-expectation (string/join "\n" (diff/make-diff-output-lines expected actual 3)))))))
+  (let [actual (normalize-pprint-output (str actual))
+        output-matches-expectation (= expected actual)]
+    (is output-matches-expectation (when-not output-matches-expectation (string/join "\n" (diff/make-diff-output-lines expected actual 3))))))
 
 (def ^:private expected-outline-selection-parent-chain-test-output
   "outline.child.can_get_parent=true


### PR DESCRIPTION
We now show a notification popup that suggests reloading the editor scripts and fetching libraries when the dependencies list has changed.

Fix #6557
