### PR TITLE
Add Code location for editor script commands

### DIFF
--- a/editor/.clj-kondo/config.edn
+++ b/editor/.clj-kondo/config.edn
@@ -1,4 +1,5 @@
-{:hooks {:analyze-call {clojure.core.cache/defcache hooks.clojure-core-cache/defcache
+{:hooks {:analyze-call {clojure.core/map hooks.clojure-core/map
+                        clojure.core.cache/defcache hooks.clojure-core-cache/defcache
                         clojure.test.check.clojure-test/defspec hooks.clojure-test-check-clojure-test/defspec
                         dynamo.graph/deftype hooks.dynamo-graph/deftype
                         dynamo.graph/defnode hooks.dynamo-graph/defnode

--- a/editor/.clj-kondo/hooks/clojure_core.clj
+++ b/editor/.clj-kondo/hooks/clojure_core.clj
@@ -1,0 +1,42 @@
+;; Copyright 2020-2026 The Defold Foundation
+;; Copyright 2014-2020 King
+;; Copyright 2009-2014 Ragnar Svensson, Christian Murray
+;; Licensed under the Defold License version 1.0 (the "License"); you may not use
+;; this file except in compliance with the License.
+;;
+;; You may obtain a copy of the License, together with FAQs at
+;; https://www.defold.com/license
+;;
+;; Unless required by applicable law or agreed to in writing, software distributed
+;; under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+;; CONDITIONS OF ANY KIND, either express or implied. See the License for the
+;; specific language governing permissions and limitations under the License.
+
+(ns hooks.clojure-core
+  (:refer-clojure :exclude [map])
+  (:require [clj-kondo.hooks-api :as api]))
+
+(defn- map-fn-node [map-node arity]
+  (let [args (mapv #(api/token-node (symbol (str "_x" % "__"))) (range arity))]
+    (api/list-node
+      [(api/token-node 'fn)
+       (api/vector-node args)
+       (api/list-node
+         (list* (api/token-node 'get)
+                map-node
+                args))])))
+
+(defn map [{:keys [node]}]
+  (let [[map-symbol-node f-node & coll-nodes] (:children node)
+        f-arity (case (count coll-nodes)
+                  0 1
+                  1 1
+                  2 2
+                  nil)]
+    {:node
+     (if (and f-arity (= :map (:tag f-node)))
+       (api/list-node
+         (list* map-symbol-node
+                (map-fn-node f-node f-arity)
+                coll-nodes))
+       node)}))

--- a/editor/src/clj/editor/code/view.clj
+++ b/editor/src/clj/editor/code/view.clj
@@ -2643,8 +2643,8 @@
   [{:command :edit.cut :label (localization/message "command.edit.cut")}
    {:command :edit.copy :label (localization/message "command.edit.copy")}
    {:command :edit.paste :label (localization/message "command.edit.paste")}
-   {:command :code.duplicate-selection :label (localization/message "command.code.duplicate-selection")}
    {:command :code.select-all :label (localization/message "command.code.select-all")}
+   (menu-items/separator-with-id :editor.code-view/context-menu-end)
    (menu-items/separator-with-id :editor.app-view/edit-end)])
 
 (defn handle-mouse-pressed! [view-node ^MouseEvent event]

--- a/editor/src/clj/editor/editor_extensions/commands.clj
+++ b/editor/src/clj/editor/editor_extensions/commands.clj
@@ -27,8 +27,7 @@
             [editor.lsp.async :as lsp.async]
             [editor.resource :as resource]
             [editor.scene :as scene]
-            [util.coll :as coll]
-            [util.fn :as fn]))
+            [util.coll :as coll]))
 
 (set! *warn-on-reflection* true)
 
@@ -131,7 +130,7 @@
   (coerce/hash-map
     :req {:label ui-docs/string-or-message-pattern-coercer
           :locations (coerce/vector-of
-                       (coerce/enum "Assets" "Bundle" "Debug" "Edit" "Outline" "Project" "Scene" "View" "Help")
+                       (coerce/enum "Assets" "Bundle" "Code" "Debug" "Edit" "Outline" "Project" "Scene" "View" "Help")
                        :distinct true
                        :min-count 1)}
     :opt {:query (coerce/hash-map
@@ -164,17 +163,19 @@
         contexts (into #{}
                        (map {"Assets" :asset-browser
                              "Bundle" :global
+                             "Code" :code-view
                              "Debug" :global
                              "Edit" :global
                              "Outline" :outline
                              "Project" :global
-                             "Scene" :global
+                             "Scene" :workbench
                              "View" :global
                              "Help" :global})
                        locations)
         locations (into #{}
                         (map {"Assets" :editor.asset-browser/context-menu-end
                               "Bundle" :editor.bundle/menu
+                              "Code" :editor.code-view/context-menu-end
                               "Debug" :editor.debug-view/debug-end
                               "Edit" :editor.app-view/edit-end
                               "Outline" :editor.outline-view/context-menu-end

--- a/editor/src/clj/editor/editor_extensions/docs.clj
+++ b/editor/src/clj/editor/editor_extensions/docs.clj
@@ -98,7 +98,7 @@
                                       :doc "required, user-visible command name, either a string or a localization message"}
                                      {:name "locations"
                                       :types ["string[]"]
-                                      :doc "required, a non-empty list of locations where the command is displayed in the editor, values are either <code>\"Edit\"</code>, <code>\"View\"</code>, <code>\"Project\"</code>, <code>\"Debug\"</code> (the editor menubar), <code>\"Assets\"</code> (the assets pane), or <code>\"Outline\"</code> (the outline pane)"}
+                                      :doc "required, a non-empty list of locations where the command is displayed in the editor, values are either <code>\"Edit\"</code>, <code>\"View\"</code>, <code>\"Project\"</code>, <code>\"Debug\"</code> (the editor menubar), <code>\"Assets\"</code> (the assets pane), <code>\"Outline\"</code> (the outline pane), <code>\"Scene\"</code> (the scene view), or <code>\"Code\"</code> (the code editor)"}
                                      {:name "query"
                                       :types ["table"]
                                       :doc (str "optional, a query that both controls the command availability and provides additional information to the command handler functions; a table with the following keys:"
@@ -109,7 +109,7 @@
                                                               (lua-completion/args-doc-html
                                                                 [{:name "type"
                                                                   :types ["string"]
-                                                                  :doc "either <code>\"resource\"</code> (selected resource) or <code>\"outline\"</code> (selected outline node)"}
+                                                                  :doc "either <code>\"resource\"</code> (selected resource), <code>\"outline\"</code> (selected outline node), or <code>\"scene\"</code> (selected scene node)"}
                                                                  {:name "cardinality"
                                                                   :types ["string"]
                                                                   :doc "either <code>\"one\"</code> (will use first selected item) or <code>\"many\"</code> (will use all selected items)"}]))}

--- a/editor/test/integration/editor_extensions_test.clj
+++ b/editor/test/integration/editor_extensions_test.clj
@@ -404,7 +404,7 @@
       ;; Run the separate scene command from the Scene context menu.
       (let [handler+context (handler/active
                               (:command (first (handler/realize-menu :editor.scene-selection/context-menu-end)))
-                              (eval-handler-contexts :global [sprite-node-id])
+                              (eval-handler-contexts :workbench [sprite-node-id])
                               {})]
         (is (= [1.0 1.0 1.0] (test-util/prop sprite-node-id :scale)))
         (is (some? handler+context))
@@ -774,7 +774,7 @@ scene.node.get_parent_succeeds=false
                            (is (handler/enabled? handler+context))
                            @(handler/run handler+context)))]
       (run-command! :editor.outline-view/context-menu-end :outline [sprite-outline] "Outline Parent Chain Test")
-      (run-command! :editor.scene-selection/context-menu-end :global [sprite-node-id] "Scene Parent Chain Test")
+      (run-command! :editor.scene-selection/context-menu-end :workbench [sprite-node-id] "Scene Parent Chain Test")
       (expect-script-output expected-outline-selection-parent-chain-test-output out))))
 
 (deftest external-file-attributes-test


### PR DESCRIPTION
Now commands that target `Code` location will show up in the Code editor context menu.

Fix #11529
