### PR TITLE
Improve error handling around using broken resources in editor scripts

### DIFF
--- a/editor/src/clj/editor/editor_extensions.clj
+++ b/editor/src/clj/editor/editor_extensions.clj
@@ -148,14 +148,17 @@
 
 ;; region script API
 
-(defn- make-ext-get-fn [project]
+(defn- make-ext-get-fn [project localization]
   (rt/lua-fn ext-get [{:keys [rt evaluation-context]} lua-node-id-or-path lua-property]
     (let [unresolved-editor-lookup (rt/->clj rt graph/unresolved-editor-lookup-coercer lua-node-id-or-path)
           property (rt/->clj rt coerce/string lua-property)
           editor-lookup (graph/resolve-unresolved-editor-lookup unresolved-editor-lookup project evaluation-context)
           getter (graph/ext-value-getter editor-lookup property project evaluation-context)]
       (if getter
-        (getter)
+        (let [result (getter)]
+          (if (g/error-value? result)
+            (throw (LuaError. (str "Can't get \"" property "\" property: " (localization (g/error-message result)))))
+            result))
         (throw (LuaError. (str (if (resource/resource? editor-lookup)
                                  (resource/proj-path editor-lookup)
                                  (name (graph/node-id->type-keyword (graph/editor-lookup->node-id editor-lookup) evaluation-context)))
@@ -235,26 +238,37 @@
                       (spit file-path content))
                     path+contents)))
           (future/then (fn [_] (reload-resources!)))
-          (future/then rt/and-refresh-context)))))
+          (future/then
+            (fn [_]
+              (g/let-ec [basis (:basis evaluation-context)
+                         invalid-proj-paths
+                         (coll/into-> created-resource-infos []
+                           (keep (fn [{proj-path 1}]
+                                   (when-let [node-id (project/get-resource-node project proj-path evaluation-context)]
+                                     (when (g/defective? basis node-id)
+                                       proj-path)))))]
+                (rt/and-refresh-context
+                  (when-let [invalid-proj-paths (coll/not-empty invalid-proj-paths)]
+                    (LuaError. (str "Created resources are invalid: " (coll/join-to-string ", " invalid-proj-paths))))))))))))
 
 (defn- make-ext-create-directory-fn [project reload-resources!]
   (rt/suspendable-lua-fn ext-create-directory [{:keys [rt evaluation-context]} lua-proj-path]
-    (let [^String proj-path (rt/->clj rt graph/resource-path-coercer lua-proj-path)]
-      (let [basis (:basis evaluation-context)
-            workspace (project/workspace project evaluation-context)
-            root-path (-> (workspace/project-directory basis workspace)
-                          (path/real))
-            dir-path (-> (str root-path proj-path)
-                         (path/normalized))]
-        (if (.startsWith dir-path root-path)
-          (try
-            (path/create-directories! dir-path)
-            (future/then (reload-resources!) rt/and-refresh-context)
-            (catch FileAlreadyExistsException e
-              (throw (LuaError. (str "File already exists: " (.getMessage e)))))
-            (catch Exception e
-              (throw (LuaError. ^String (or (.getMessage e) (.getSimpleName (class e)))))))
-          (throw (LuaError. (str "Can't create " dir-path ": outside of project directory"))))))))
+    (let [^String proj-path (rt/->clj rt graph/resource-path-coercer lua-proj-path)
+          basis (:basis evaluation-context)
+          workspace (project/workspace project evaluation-context)
+          root-path (-> (workspace/project-directory basis workspace)
+                        (path/real))
+          dir-path (-> (str root-path proj-path)
+                       (path/normalized))]
+      (if (.startsWith dir-path root-path)
+        (try
+          (path/create-directories! dir-path)
+          (future/then (reload-resources!) rt/and-refresh-context)
+          (catch FileAlreadyExistsException e
+            (throw (LuaError. (str "File already exists: " (.getMessage e)))))
+          (catch Exception e
+            (throw (LuaError. ^String (or (.getMessage e) (.getSimpleName (class e)))))))
+        (throw (LuaError. (str "Can't create " dir-path ": outside of project directory")))))))
 
 (defn- make-ext-delete-directory-fn [project reload-resources!]
   (rt/suspendable-lua-fn ext-delete-directory [{:keys [rt evaluation-context]} lua-proj-path]
@@ -276,7 +290,7 @@
         (throw (LuaError. (str "Can't delete " dir-path ": outside of project directory")))
 
         (= (.getNameCount dir-path) (.getNameCount root-path))
-        (throw (LuaError. (str "Can't delete the project directory itself")))
+        (throw (LuaError. "Can't delete the project directory itself"))
 
         (protected-path? dir-path)
         (throw (LuaError. (str "Can't delete " dir-path ": protected by editor")))
@@ -432,7 +446,7 @@
 
 (defn- make-ext-tx-set-fn [project]
   (rt/lua-fn ext-tx-set [{:keys [rt evaluation-context]} lua-node-id-or-path lua-property lua-value]
-    (let [node-id (graph/unresolved-editor-lookup->node-id
+    (let [node-id (graph/editable-unresolved-editor-lookup->node-id
                     (rt/->clj rt graph/unresolved-editor-lookup-coercer lua-node-id-or-path)
                     project
                     evaluation-context)
@@ -967,7 +981,7 @@
                   :out (line-writer #(display-output! :out %))
                   :err (line-writer #(display-output! :err %))
                   :env {"editor" {"bundle" {"project_binary_name" ext-project-binary-name} ;; undocumented, hidden API!
-                                  "get" (make-ext-get-fn project)
+                                  "get" (make-ext-get-fn project localization)
                                   "can_add" (graph/make-ext-can-add-fn project)
                                   "can_get" (make-ext-can-get-fn project)
                                   "can_reorder" (graph/make-ext-can-reorder-fn project)

--- a/editor/src/clj/editor/editor_extensions/docs.clj
+++ b/editor/src/clj/editor/editor_extensions/docs.clj
@@ -58,7 +58,7 @@
           :type :function
           :parameters [node-param property-param]
           :returnvalues [boolean-ret-param]
-          :description "Check if you can get this property so `editor.get()` won't throw an error"}
+          :description "Check whether this property is exposed for reading on the supplied node or resource."}
          {:name "editor.properties"
           :type :function
           :parameters [node-param]
@@ -70,22 +70,22 @@
           :type :function
           :parameters [node-param property-param]
           :returnvalues [boolean-ret-param]
-          :description "Check if `editor.tx.add()` (as well as `editor.tx.clear()` and `editor.tx.remove()`) transaction with this property won't throw an error"}
+          :description "Check whether this list property supports add, clear, and remove operations on the supplied node."}
          {:name "editor.can_set"
           :type :function
           :parameters [node-param property-param]
           :returnvalues [boolean-ret-param]
-          :description "Check if `editor.tx.set()` transaction with this property won't throw an error"}
+          :description "Check whether this property is exposed for setting on the supplied node."}
          {:name "editor.can_reorder"
           :type :function
           :parameters [node-param property-param]
           :returnvalues [boolean-ret-param]
-          :description "Check if `editor.tx.reorder()` transaction with this property won't throw an error"}
+          :description "Check whether this list property supports reordering on the supplied node."}
          {:name "editor.can_reset"
           :type :function
           :parameters [node-param property-param]
           :returnvalues [boolean-ret-param]
-          :description "Check if `editor.tx.reset()` transaction with this property won't throw an error"}
+          :description "Check whether this property supports reset on the supplied node."}
          {:name "editor.command"
           :type :function
           :description "Create an editor command"

--- a/editor/src/clj/editor/editor_extensions/graph.clj
+++ b/editor/src/clj/editor/editor_extensions/graph.clj
@@ -124,6 +124,19 @@
       (throw (LuaError. (str (resource/proj-path editor-lookup) " is not a file resource"))))
     (editor-lookup->node-id editor-lookup)))
 
+(defn editable-unresolved-editor-lookup->node-id
+  "Resolve unresolved-editor-lookup and return existing non-defective node id.
+
+  Folder resources and defective nodes are rejected with LuaError."
+  [unresolved-editor-lookup project evaluation-context]
+  (let [node-id (unresolved-editor-lookup->node-id unresolved-editor-lookup project evaluation-context)]
+    (when (g/defective? (:basis evaluation-context) node-id)
+      (throw (LuaError. (if (string? unresolved-editor-lookup)
+                          (str "Cannot edit defective resource: " unresolved-editor-lookup)
+                          (str "Cannot edit defective node of type "
+                               (name (g/node-type-kw (:basis evaluation-context) node-id)))))))
+    node-id))
+
 (defn node-id->type-keyword [node-id evaluation-context]
   (g/node-type-kw (:basis evaluation-context) node-id))
 
@@ -743,7 +756,7 @@
 (defn make-ext-reset-fn [project]
   (rt/varargs-lua-fn ext-reset [{:keys [rt evaluation-context]} varargs]
     (let [{:keys [node property]} (rt/->clj rt reset-args-coercer varargs)
-          node-id (unresolved-editor-lookup->node-id node project evaluation-context)]
+          node-id (editable-unresolved-editor-lookup->node-id node project evaluation-context)]
       (if-let [resetter ((ext-property-resetter (node-id->type-keyword node-id evaluation-context)) node-id property evaluation-context)]
         (-> (resetter)
             (with-meta {:type :transaction-step})
@@ -1032,7 +1045,7 @@
   (rt/varargs-lua-fn ext-add [{:keys [rt evaluation-context]} varargs]
     (let [{:keys [node property attachment]} (rt/->clj rt add-args-coercer varargs)
           workspace (project/workspace project evaluation-context)
-          node-id (unresolved-editor-lookup->node-id node project evaluation-context)
+          node-id (editable-unresolved-editor-lookup->node-id node project evaluation-context)
           list-kw (property->prop-kw property)]
       (when-not (attachment/defined? workspace node-id list-kw evaluation-context)
         (throw (LuaError. (format "\"%s\" is undefined" property))))
@@ -1065,7 +1078,7 @@
   (rt/varargs-lua-fn ext-clear [{:keys [rt evaluation-context]} varargs]
     (let [{:keys [node property]} (rt/->clj rt clear-args-coercer varargs)
           workspace (project/workspace project evaluation-context)
-          node-id (unresolved-editor-lookup->node-id node project evaluation-context)
+          node-id (editable-unresolved-editor-lookup->node-id node project evaluation-context)
           list-kw (property->prop-kw property)]
       (when-not (attachment/defined? workspace node-id list-kw evaluation-context)
         (throw (LuaError. (format "\"%s\" is undefined" property))))
@@ -1082,7 +1095,7 @@
   (rt/varargs-lua-fn ext-remove [{:keys [rt evaluation-context]} varargs]
     (let [{:keys [node property child]} (rt/->clj rt remove-args-coercer varargs)
           workspace (project/workspace project evaluation-context)
-          node-id (unresolved-editor-lookup->node-id node project evaluation-context)
+          node-id (editable-unresolved-editor-lookup->node-id node project evaluation-context)
           child-node-id (unresolved-editor-lookup->node-id child project evaluation-context)
           list-kw (property->prop-kw property)]
       (when-not (attachment/defined? workspace node-id list-kw evaluation-context)
@@ -1117,7 +1130,7 @@
   (rt/varargs-lua-fn ext-reorder [{:keys [rt evaluation-context]} varargs]
     (let [{:keys [node property children]} (rt/->clj rt reorder-args-coercer varargs)
           workspace (project/workspace project evaluation-context)
-          node-id (unresolved-editor-lookup->node-id node project evaluation-context)
+          node-id (editable-unresolved-editor-lookup->node-id node project evaluation-context)
           list-kw (property->prop-kw property)
           reordered-child-node-ids (mapv #(unresolved-editor-lookup->node-id % project evaluation-context) children)]
       (when-not (attachment/defined? workspace node-id list-kw evaluation-context)

--- a/editor/test/integration/editor_extensions_test.clj
+++ b/editor/test/integration/editor_extensions_test.clj
@@ -39,6 +39,7 @@
             [editor.web-server :as web-server]
             [editor.workspace :as workspace]
             [integration.test-util :as test-util]
+            [service.log :as log]
             [support.test-support :as test-support]
             [util.coll :as coll]
             [util.diff :as diff]
@@ -1141,11 +1142,12 @@ editor.tx.reset(\"/test/invalid.go\", \"text\") => Cannot edit defective resourc
 ")
 
 (deftest resources-io-test
-  (test-util/with-scratch-project "test/resources/editor_extensions/resources_io_project"
-    (let [out (StringBuilder.)]
-      (reload-editor-scripts! project :display-output! #(doto out (.append %2) (.append \newline)))
-      (run-edit-menu-test-command!)
-      (expect-script-output resource-io-test-output out))))
+  (log/without-logging
+    (test-util/with-scratch-project "test/resources/editor_extensions/resources_io_project"
+      (let [out (StringBuilder.)]
+        (reload-editor-scripts! project :display-output! #(doto out (.append %2) (.append \newline)))
+        (run-edit-menu-test-command!)
+        (expect-script-output resource-io-test-output out)))))
 
 (defn- expected-zip-test-output [root]
   (str "Testing zip.pack...

--- a/editor/test/integration/editor_extensions_test.clj
+++ b/editor/test/integration/editor_extensions_test.clj
@@ -1125,6 +1125,19 @@ editor.create_resources({\"/test/repeated.go\", \"/test/repeated.go\"}) => Resou
   /npc.collection
   /npc.go
   /UPPER.COLLECTION
+editor.create_resources({{\"/test/invalid.go\", \"\\\"name\\\":\\\"invalid\\\"\"}}) => Created resources are invalid: /test/invalid.go
+/test
+  /config.json
+  /invalid.go
+  /npc.collection
+  /npc.go
+  /UPPER.COLLECTION
+editor.tx.set(\"/test/invalid.go\", \"text\", ...) => Cannot edit defective resource: /test/invalid.go
+editor.tx.add(\"/test/invalid.go\", \"components\", ...) => Cannot edit defective resource: /test/invalid.go
+editor.tx.clear(\"/test/invalid.go\", \"components\") => Cannot edit defective resource: /test/invalid.go
+editor.tx.remove(\"/test/invalid.go\", \"components\", ...) => Cannot edit defective resource: /test/invalid.go
+editor.tx.reorder(\"/test/invalid.go\", \"components\", ...) => Cannot edit defective resource: /test/invalid.go
+editor.tx.reset(\"/test/invalid.go\", \"text\") => Cannot edit defective resource: /test/invalid.go
 ")
 
 (deftest resources-io-test

--- a/editor/test/resources/editor_extensions/resources_io_project/test.editor_script
+++ b/editor/test/resources/editor_extensions/resources_io_project/test.editor_script
@@ -45,6 +45,11 @@ local function pprint_resource(resource, props)
     pprint(entity)
 end
 
+local function expect_error(label, fn, ...)
+    local success, message = pcall(fn, ...)
+    print(("%s => %s"):format(label, success and "ok!" or message))
+end
+
 function M.get_commands()
     return {
         editor.command({
@@ -70,6 +75,15 @@ function M.get_commands()
                 create_resources({"/test/../../../outside.txt"})
                 create_resources({"/test/npc.go"})
                 create_resources({"/test/repeated.go", "/test/repeated.go"})
+                create_resources({
+                    {"/test/invalid.go", "\"name\":\"invalid\""}
+                })
+                expect_error("editor.tx.set(\"/test/invalid.go\", \"text\", ...)", editor.tx.set, "/test/invalid.go", "text", "name: \"invalid\"")
+                expect_error("editor.tx.add(\"/test/invalid.go\", \"components\", ...)", editor.tx.add, "/test/invalid.go", "components", {type = "label"})
+                expect_error("editor.tx.clear(\"/test/invalid.go\", \"components\")", editor.tx.clear, "/test/invalid.go", "components")
+                expect_error("editor.tx.remove(\"/test/invalid.go\", \"components\", ...)", editor.tx.remove, "/test/invalid.go", "components", "/test/invalid.go")
+                expect_error("editor.tx.reorder(\"/test/invalid.go\", \"components\", ...)", editor.tx.reorder, "/test/invalid.go", "components", {})
+                expect_error("editor.tx.reset(\"/test/invalid.go\", \"text\")", editor.tx.reset, "/test/invalid.go", "text")
 
                 editor.delete_directory("/test")
             end


### PR DESCRIPTION
Editor scripts now report invalid resources created with `editor.create_resources()` instead of silently accepting them. For example:
```lua
editor.create_resources({{"/test/invalid.go", "\"name\":\"invalid\""}})
--> Created resources are invalid: /test/invalid.go
```

Trying to edit a broken resource also fails:
```lua
editor.tx.add("/test/invalid.go", "components", { type = "label" })
--> Cannot edit defective resource: /test/invalid.go
```

Fix #11183