### PR TITLE
Updated Box2d v3 api with chain and other missing functions

### DIFF
--- a/engine/docs/script_doc.py
+++ b/engine/docs/script_doc.py
@@ -422,7 +422,7 @@ LUA_TYPES = [
     "string", "number", "boolean", "table", "userdata", "nil", "function", "thread",
     "vector", "vector3", "vector4", "matrix4", "quaternion", "hash", "url", "node",
     "constant", "resource", "buffer", "any", "file",
-    "b2World", "b2Body", "b2BodyType", "bufferstream" ]
+    "b2World", "b2Body", "b2BodyType", "b2Shape", "b2Chain", "bufferstream" ]
 CPP_TYPES = [
     "string", "float", "double", "long", "int", "bool", "char", "void",
     "int8_t", "uint8_t", "int16_t", "uint16_t", "int32_atomic_t", "int32_t", "uint32_t", "int64_t", "uint64_t",

--- a/engine/docs/test_script_doc.py
+++ b/engine/docs/test_script_doc.py
@@ -173,6 +173,7 @@ foobar
  * @param param_x [type:string|number|boolean|function|nil|userdata|thread|file] DOCX
  * @param param_y [type:vector|vector3|vector4|matrix4|quaternion|hash|url|node|resource|buffer] DOCY
  * @param param_z [type:constant|any] DOCZ
+ * @param param_b2 [type:b2World|b2Body|b2BodyType|b2Shape|b2Chain] DOCB2
  */
 """
         elements = script_doc.parse_document(doc).elements

--- a/engine/gamesys/CMakeLists.txt
+++ b/engine/gamesys/CMakeLists.txt
@@ -175,7 +175,8 @@ defold_add_library(script_box2d_defold STATIC
     "${GS_SRC_DIR}/scripts/box2d/v2/script_box2d_body_v2.cpp"
     "${GS_SRC_DIR}/scripts/box2d/v2/script_box2d_fixture_v2.cpp"
     "${GS_SRC_DIR}/scripts/box2d/v2/script_box2d_joint_v2.cpp"
-    "${GS_SRC_DIR}/scripts/box2d/v2/script_box2d_shape_v2.cpp")
+    "${GS_SRC_DIR}/scripts/box2d/v2/script_box2d_shape_v2.cpp"
+    "${GS_SRC_DIR}/scripts/box2d/v2/script_box2d_world_v2.cpp")
 target_include_directories(script_box2d_defold PUBLIC
     "${GS_SRC_DIR}"
     "${GS_DMSDK_SRC_DIR}"

--- a/engine/gamesys/CMakeLists.txt
+++ b/engine/gamesys/CMakeLists.txt
@@ -158,8 +158,10 @@ target_include_directories(gamesys_rig_null PUBLIC "${GS_SRC_DIR}" "${GS_DMSDK_S
 defold_add_library(script_box2d STATIC
     "${GS_SRC_DIR}/scripts/box2d/script_box2d.cpp"
     "${GS_SRC_DIR}/scripts/box2d/v3/script_box2d_body_v3.cpp"
+    "${GS_SRC_DIR}/scripts/box2d/v3/script_box2d_chain_v3.cpp"
     "${GS_SRC_DIR}/scripts/box2d/v3/script_box2d_joint_v3.cpp"
-    "${GS_SRC_DIR}/scripts/box2d/v3/script_box2d_shape_v3.cpp")
+    "${GS_SRC_DIR}/scripts/box2d/v3/script_box2d_shape_v3.cpp"
+    "${GS_SRC_DIR}/scripts/box2d/v3/script_box2d_world_v3.cpp")
 # Default to the Defold-provided Box2D headers
 target_include_directories(script_box2d PUBLIC
     "${GS_SRC_DIR}"

--- a/engine/gamesys/src/gamesys/scripts/box2d/script_box2d.cpp
+++ b/engine/gamesys/src/gamesys/scripts/box2d/script_box2d.cpp
@@ -39,11 +39,6 @@ namespace dmGameSystem
     static float g_PhysicsScale = 1.0f;
     static float g_InvPhysicsScale = 1.0f / g_PhysicsScale;
 
-    void PushWorld(struct lua_State* L, void* world)
-    {
-        lua_pushlightuserdata(L, world);
-    }
-
     void SetPhysicsScale(float scale)
     {
         g_PhysicsScale = scale;

--- a/engine/gamesys/src/gamesys/scripts/box2d/script_box2d.h
+++ b/engine/gamesys/src/gamesys/scripts/box2d/script_box2d.h
@@ -38,6 +38,7 @@ namespace dmGameSystem
     void  ScriptBox2DInitializeJoint(struct lua_State* L);
     void  ScriptBox2DInvalidateJoint(void* joint);
     void  ScriptBox2DFinalizeJoint();
+    void  ScriptBox2DInitializeWorld(struct lua_State* L);
     void  ScriptBox2DInitializeFixture(struct lua_State* L);
     void  ScriptBox2DInitializeShape(struct lua_State* L);
 }

--- a/engine/gamesys/src/gamesys/scripts/box2d/v2/script_box2d_body_v2.cpp
+++ b/engine/gamesys/src/gamesys/scripts/box2d/v2/script_box2d_body_v2.cpp
@@ -43,6 +43,11 @@ namespace dmGameSystem
 
     #define BOX2D_TYPE_NAME_BODY "b2body"
 
+    void PushWorld(struct lua_State* L, void* world)
+    {
+        lua_pushlightuserdata(L, world);
+    }
+
     struct B2DLuaBody
     {
         HOpaqueHandle             m_Handle;

--- a/engine/gamesys/src/gamesys/scripts/box2d/v2/script_box2d_body_v2.cpp
+++ b/engine/gamesys/src/gamesys/scripts/box2d/v2/script_box2d_body_v2.cpp
@@ -1133,6 +1133,7 @@ namespace dmGameSystem
 
         lua_setfield(L, -2, "body");
 
+        ScriptBox2DInitializeWorld(L);
         ScriptBox2DInitializeJoint(L);
         ScriptBox2DInitializeFixture(L);
         ScriptBox2DInitializeShape(L);

--- a/engine/gamesys/src/gamesys/scripts/box2d/v2/script_box2d_v2.h
+++ b/engine/gamesys/src/gamesys/scripts/box2d/v2/script_box2d_v2.h
@@ -57,6 +57,7 @@ namespace dmGameSystem
     void       ScriptBox2DInitializeJoint(struct lua_State* L);
     void       ScriptBox2DInvalidateJoint(void* joint);
     void       ScriptBox2DFinalizeJoint();
+    void       ScriptBox2DInitializeWorld(struct lua_State* L);
     void       ScriptBox2DInitializeFixture(struct lua_State* L);
     void       ScriptBox2DInitializeShape(struct lua_State* L);
 }

--- a/engine/gamesys/src/gamesys/scripts/box2d/v2/script_box2d_world_v2.cpp
+++ b/engine/gamesys/src/gamesys/scripts/box2d/v2/script_box2d_world_v2.cpp
@@ -1,0 +1,848 @@
+// Copyright 2020-2026 The Defold Foundation
+// Copyright 2014-2020 King
+// Copyright 2009-2014 Ragnar Svensson, Christian Murray
+// Licensed under the Defold License version 1.0 (the "License"); you may not use
+// this file except in compliance with the License.
+//
+// You may obtain a copy of the License, together with FAQs at
+// https://www.defold.com/license
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#include <stdio.h>
+
+#include <Box2D/Collision/b2Distance.h>
+#include <Box2D/Collision/b2TimeOfImpact.h>
+#include <Box2D/Dynamics/b2ContactManager.h>
+#include <Box2D/Dynamics/b2Fixture.h>
+#include <Box2D/Dynamics/b2World.h>
+
+#include <dlib/array.h>
+#include <script/script.h>
+#include <gameobject/script.h>
+
+#include "components/comp_collision_object.h"
+#include "script_box2d_v2.h"
+
+extern "C"
+{
+#include <lua/lauxlib.h>
+#include <lua/lualib.h>
+}
+
+namespace dmGameSystem
+{
+    struct QueryFilter
+    {
+        uint16 m_CategoryBits;
+        uint16 m_MaskBits;
+        int16  m_GroupIndex;
+        bool   m_HasGroupIndex;
+    };
+
+    struct QueryStats
+    {
+        int m_NodeVisits;
+        int m_LeafVisits;
+    };
+
+    struct FixtureChild
+    {
+        b2Fixture* m_Fixture;
+        int32      m_ChildIndex;
+    };
+
+    struct QueryContext
+    {
+        lua_State*            m_L;
+        int                   m_TableIndex;
+        int                   m_Count;
+        int                   m_MaxResults;
+        QueryFilter           m_Filter;
+        QueryStats            m_Stats;
+        dmArray<FixtureChild> m_Seen;
+    };
+
+    static b2Vec2 CheckVec2(lua_State* L, int index, float scale)
+    {
+        dmVMath::Vector3* v = dmScript::CheckVector3(L, index);
+        return b2Vec2(v->getX() * scale, v->getY() * scale);
+    }
+
+    static dmVMath::Vector3 FromB2(const b2Vec2& p, float inv_scale)
+    {
+        return dmVMath::Vector3(p.x * inv_scale, p.y * inv_scale, 0);
+    }
+
+    static int AbsIndex(lua_State* L, int index)
+    {
+        return index < 0 ? lua_gettop(L) + index + 1 : index;
+    }
+
+    static b2World* CheckWorld(lua_State* L, int index)
+    {
+        b2World* world = lua_islightuserdata(L, index) ? (b2World*)lua_touserdata(L, index) : 0;
+        if (!world)
+        {
+            luaL_error(L, "Expected b2World.");
+            return 0;
+        }
+        return world;
+    }
+
+    static int CheckMaxResults(lua_State* L, int index)
+    {
+        if (lua_isnoneornil(L, index))
+        {
+            return 0;
+        }
+
+        int max_results = luaL_checkinteger(L, index);
+        if (max_results < 0)
+        {
+            luaL_error(L, "max_results must be >= 0.");
+            return 0;
+        }
+        return max_results;
+    }
+
+    static bool HasResultCapacity(const QueryContext* context)
+    {
+        return context->m_MaxResults <= 0 || context->m_Count < context->m_MaxResults;
+    }
+
+    static b2AABB CheckAABB(lua_State* L, int index)
+    {
+        luaL_checktype(L, index, LUA_TTABLE);
+
+        b2AABB aabb;
+
+        lua_getfield(L, index, "lower");
+        aabb.lowerBound = CheckVec2(L, -1, GetPhysicsScale());
+        lua_pop(L, 1);
+
+        lua_getfield(L, index, "upper");
+        aabb.upperBound = CheckVec2(L, -1, GetPhysicsScale());
+        lua_pop(L, 1);
+
+        if (!aabb.IsValid())
+        {
+            luaL_error(L, "Invalid AABB.");
+        }
+
+        return aabb;
+    }
+
+    static QueryFilter CheckQueryFilter(lua_State* L, int index)
+    {
+        QueryFilter filter = {};
+        filter.m_CategoryBits = 0xffff;
+        filter.m_MaskBits = 0xffff;
+        filter.m_GroupIndex = 0;
+        filter.m_HasGroupIndex = false;
+
+        if (lua_isnoneornil(L, index))
+        {
+            return filter;
+        }
+
+        luaL_checktype(L, index, LUA_TTABLE);
+
+        lua_getfield(L, index, "category_bits");
+        if (!lua_isnil(L, -1))
+        {
+            filter.m_CategoryBits = (uint16)luaL_checkinteger(L, -1);
+        }
+        lua_pop(L, 1);
+
+        lua_getfield(L, index, "mask_bits");
+        if (!lua_isnil(L, -1))
+        {
+            filter.m_MaskBits = (uint16)luaL_checkinteger(L, -1);
+        }
+        lua_pop(L, 1);
+
+        lua_getfield(L, index, "group_index");
+        if (!lua_isnil(L, -1))
+        {
+            filter.m_GroupIndex = (int16)luaL_checkinteger(L, -1);
+            filter.m_HasGroupIndex = true;
+        }
+        lua_pop(L, 1);
+
+        return filter;
+    }
+
+    static bool MatchesFilter(b2Fixture* fixture, int32 child_index, const QueryFilter& query_filter)
+    {
+        const b2Filter& fixture_filter = fixture->GetFilterData(child_index);
+        if (query_filter.m_HasGroupIndex && fixture_filter.groupIndex != query_filter.m_GroupIndex)
+        {
+            return false;
+        }
+
+        return (fixture_filter.categoryBits & query_filter.m_MaskBits) != 0 && (query_filter.m_CategoryBits & fixture_filter.maskBits) != 0;
+    }
+
+    static int GetFixtureIndex(b2Body* body, const b2Fixture* fixture)
+    {
+        int fixture_index = 1;
+        for (b2Fixture* current = body->GetFixtureList(); current; current = current->GetNext(), ++fixture_index)
+        {
+            if (current == fixture)
+            {
+                return fixture_index;
+            }
+        }
+        return 0;
+    }
+
+    static void PushBodyForBody(lua_State* L, b2Body* body)
+    {
+        dmGameObject::HCollection collection = 0;
+        dmhash_t instance_id = 0;
+
+        void* user_data = body->GetUserData();
+        dmGameObject::HInstance instance = user_data ? CompCollisionObjectGetInstance(user_data) : 0;
+        if (instance)
+        {
+            collection = dmGameObject::GetCollection(instance);
+            instance_id = dmGameObject::GetIdentifier(instance);
+        }
+
+        PushBody(L, body, collection, instance_id);
+    }
+
+    static void PushFixtureInfo(lua_State* L, b2Fixture* fixture, int32 child_index)
+    {
+        b2Body* body = fixture->GetBody();
+
+        lua_newtable(L);
+
+        PushBodyForBody(L, body);
+        lua_setfield(L, -2, "body");
+
+        lua_pushinteger(L, GetFixtureIndex(body, fixture));
+        lua_setfield(L, -2, "index");
+
+        lua_pushinteger(L, child_index + 1);
+        lua_setfield(L, -2, "child_index");
+
+        lua_pushinteger(L, fixture->GetType());
+        lua_setfield(L, -2, "type");
+
+        lua_pushboolean(L, fixture->IsSensor());
+        lua_setfield(L, -2, "sensor");
+
+        lua_pushnumber(L, fixture->GetDensity());
+        lua_setfield(L, -2, "density");
+
+        lua_pushnumber(L, fixture->GetFriction());
+        lua_setfield(L, -2, "friction");
+
+        lua_pushnumber(L, fixture->GetRestitution());
+        lua_setfield(L, -2, "restitution");
+
+        lua_pushinteger(L, fixture->GetShape()->GetChildCount());
+        lua_setfield(L, -2, "child_count");
+    }
+
+    static bool HasSeenFixtureChild(const QueryContext* context, b2Fixture* fixture, int32 child_index)
+    {
+        for (uint32_t i = 0; i < context->m_Seen.Size(); ++i)
+        {
+            if (context->m_Seen[i].m_Fixture == fixture && context->m_Seen[i].m_ChildIndex == child_index)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    static void MarkSeenFixtureChild(QueryContext* context, b2Fixture* fixture, int32 child_index)
+    {
+        if (context->m_Seen.Remaining() == 0)
+        {
+            if (context->m_Seen.Capacity() == 0)
+            {
+                context->m_Seen.SetCapacity(16);
+            }
+            else
+            {
+                context->m_Seen.OffsetCapacity(16);
+            }
+        }
+
+        uint32_t index = context->m_Seen.Size();
+        context->m_Seen.SetSize(index + 1);
+        FixtureChild& entry = context->m_Seen[index];
+        entry.m_Fixture = fixture;
+        entry.m_ChildIndex = child_index;
+    }
+
+    static bool PushFixtureResult(QueryContext* context, b2Fixture* fixture, int32 child_index)
+    {
+        if (!HasResultCapacity(context) || HasSeenFixtureChild(context, fixture, child_index))
+        {
+            return HasResultCapacity(context);
+        }
+
+        MarkSeenFixtureChild(context, fixture, child_index);
+        PushFixtureInfo(context->m_L, fixture, child_index);
+        lua_rawseti(context->m_L, context->m_TableIndex, ++context->m_Count);
+        return HasResultCapacity(context);
+    }
+
+    static void PushCastHit(lua_State* L, b2Fixture* fixture, int32 child_index, const b2Vec2& point, const b2Vec2& normal, float fraction)
+    {
+        lua_newtable(L);
+
+        PushFixtureInfo(L, fixture, child_index);
+        lua_pushvalue(L, -1);
+        lua_setfield(L, -3, "shape");
+        lua_setfield(L, -2, "fixture");
+
+        dmScript::PushVector3(L, FromB2(point, GetInvPhysicsScale()));
+        lua_setfield(L, -2, "point");
+
+        dmScript::PushVector3(L, FromB2(normal, 1.0f));
+        lua_setfield(L, -2, "normal");
+
+        lua_pushnumber(L, fraction);
+        lua_setfield(L, -2, "fraction");
+    }
+
+    static void PushTreeStats(lua_State* L, const QueryStats& stats)
+    {
+        lua_newtable(L);
+
+        lua_pushinteger(L, stats.m_NodeVisits);
+        lua_setfield(L, -2, "node_visits");
+
+        lua_pushinteger(L, stats.m_LeafVisits);
+        lua_setfield(L, -2, "leaf_visits");
+    }
+
+    static b2AABB ComputeShapeAABB(const b2Shape* shape, const b2Transform& transform)
+    {
+        b2AABB result;
+        bool has_aabb = false;
+        const int child_count = shape->GetChildCount();
+        for (int i = 0; i < child_count; ++i)
+        {
+            b2AABB child_aabb;
+            shape->ComputeAABB(&child_aabb, transform, i);
+            if (has_aabb)
+            {
+                result.Combine(child_aabb);
+            }
+            else
+            {
+                result = child_aabb;
+                has_aabb = true;
+            }
+        }
+        return result;
+    }
+
+    static bool SupportsDistanceProxy(const b2Shape* shape)
+    {
+        return shape->GetType() != b2Shape::e_grid;
+    }
+
+    static b2Sweep MakeSweep(const b2Vec2& local_center, const b2Vec2& start_center, const b2Vec2& end_center, float start_angle, float end_angle)
+    {
+        b2Sweep sweep;
+        sweep.localCenter = local_center;
+        sweep.c0 = start_center;
+        sweep.c = end_center;
+        sweep.a0 = start_angle;
+        sweep.a = end_angle;
+        sweep.alpha0 = 0.0f;
+        return sweep;
+    }
+
+    static bool ComputeShapeCastHit(const b2Shape* query_shape, int32 query_child_index, b2Fixture* fixture, int32 fixture_child_index, const b2Vec2& translation, float* out_fraction, b2Vec2* out_point, b2Vec2* out_normal)
+    {
+        if (!SupportsDistanceProxy(query_shape) || !SupportsDistanceProxy(fixture->GetShape()))
+        {
+            return false;
+        }
+
+        b2DistanceProxy proxy_a;
+        b2DistanceProxy proxy_b;
+        proxy_a.Set(query_shape, query_child_index);
+        proxy_b.Set(fixture->GetShape(), fixture_child_index);
+
+        b2Body* body = fixture->GetBody();
+        b2Sweep sweep_a = MakeSweep(b2Vec2_zero, b2Vec2_zero, translation, 0.0f, 0.0f);
+        b2Sweep sweep_b = MakeSweep(body->GetLocalCenter(), body->GetWorldCenter(), body->GetWorldCenter(), body->GetAngle(), body->GetAngle());
+
+        b2TOIInput toi_input;
+        toi_input.proxyA = proxy_a;
+        toi_input.proxyB = proxy_b;
+        toi_input.sweepA = sweep_a;
+        toi_input.sweepB = sweep_b;
+        toi_input.tMax = 1.0f;
+
+        b2TOIOutput toi_output;
+        b2TimeOfImpact(&toi_output, &toi_input);
+        if (toi_output.state != b2TOIOutput::e_touching && toi_output.state != b2TOIOutput::e_overlapped)
+        {
+            return false;
+        }
+
+        b2Transform xf_a;
+        b2Transform xf_b;
+        sweep_a.GetTransform(&xf_a, toi_output.t);
+        sweep_b.GetTransform(&xf_b, toi_output.t);
+
+        b2SimplexCache cache;
+        cache.count = 0;
+
+        b2DistanceInput distance_input;
+        distance_input.proxyA = proxy_a;
+        distance_input.proxyB = proxy_b;
+        distance_input.transformA = xf_a;
+        distance_input.transformB = xf_b;
+        distance_input.useRadii = true;
+
+        b2DistanceOutput distance_output;
+        b2Distance(&distance_output, &cache, &distance_input);
+
+        cache.count = 0;
+        b2DistanceInput normal_input = distance_input;
+        normal_input.useRadii = false;
+        b2DistanceOutput normal_output;
+        b2Distance(&normal_output, &cache, &normal_input);
+
+        b2Vec2 normal = normal_output.pointA - normal_output.pointB;
+        float length = normal.Length();
+        if (length > b2_epsilon)
+        {
+            normal *= 1.0f / length;
+        }
+        else if (translation.LengthSquared() > b2_epsilon * b2_epsilon)
+        {
+            normal.Set(-translation.x, -translation.y);
+            normal.Normalize();
+        }
+        else
+        {
+            normal.Set(1.0f, 0.0f);
+        }
+
+        *out_fraction = toi_output.t;
+        *out_point = distance_output.pointB;
+        *out_normal = normal;
+        return true;
+    }
+
+    class OverlapAABBCallback
+    {
+    public:
+        OverlapAABBCallback(const b2BroadPhase* broad_phase, QueryContext* context)
+        : m_BroadPhase(broad_phase)
+        , m_Context(context)
+        {
+        }
+
+        bool QueryCallback(int32 proxy_id)
+        {
+            ++m_Context->m_Stats.m_LeafVisits;
+
+            b2FixtureProxy* proxy = (b2FixtureProxy*)m_BroadPhase->GetUserData(proxy_id);
+            if (!proxy || !MatchesFilter(proxy->fixture, proxy->childIndex, m_Context->m_Filter))
+            {
+                return true;
+            }
+
+            return PushFixtureResult(m_Context, proxy->fixture, proxy->childIndex);
+        }
+
+    private:
+        const b2BroadPhase* m_BroadPhase;
+        QueryContext*      m_Context;
+    };
+
+    class OverlapShapeCallback
+    {
+    public:
+        OverlapShapeCallback(const b2BroadPhase* broad_phase, QueryContext* context, const b2Shape* query_shape)
+        : m_BroadPhase(broad_phase)
+        , m_Context(context)
+        , m_QueryShape(query_shape)
+        {
+            b2Transform identity;
+            identity.SetIdentity();
+            m_QueryTransform = identity;
+        }
+
+        bool QueryCallback(int32 proxy_id)
+        {
+            ++m_Context->m_Stats.m_LeafVisits;
+
+            b2FixtureProxy* proxy = (b2FixtureProxy*)m_BroadPhase->GetUserData(proxy_id);
+            if (!proxy || !MatchesFilter(proxy->fixture, proxy->childIndex, m_Context->m_Filter))
+            {
+                return true;
+            }
+
+            const int query_child_count = m_QueryShape->GetChildCount();
+            b2Transform fixture_transform = proxy->fixture->GetBody()->GetTransform();
+            for (int i = 0; i < query_child_count; ++i)
+            {
+                if (b2TestOverlap(m_QueryShape, i, proxy->fixture->GetShape(), proxy->childIndex, m_QueryTransform, fixture_transform))
+                {
+                    return PushFixtureResult(m_Context, proxy->fixture, proxy->childIndex);
+                }
+            }
+            return true;
+        }
+
+    private:
+        const b2BroadPhase* m_BroadPhase;
+        QueryContext*      m_Context;
+        const b2Shape*     m_QueryShape;
+        b2Transform        m_QueryTransform;
+    };
+
+    class ShapeCastCallback
+    {
+    public:
+        ShapeCastCallback(const b2BroadPhase* broad_phase, QueryContext* context, const b2Shape* query_shape, const b2Vec2& translation)
+        : m_BroadPhase(broad_phase)
+        , m_Context(context)
+        , m_QueryShape(query_shape)
+        , m_Translation(translation)
+        {
+        }
+
+        bool QueryCallback(int32 proxy_id)
+        {
+            ++m_Context->m_Stats.m_LeafVisits;
+
+            b2FixtureProxy* proxy = (b2FixtureProxy*)m_BroadPhase->GetUserData(proxy_id);
+            if (!proxy || !MatchesFilter(proxy->fixture, proxy->childIndex, m_Context->m_Filter))
+            {
+                return true;
+            }
+
+            float best_fraction = 1.0f;
+            b2Vec2 best_point = b2Vec2_zero;
+            b2Vec2 best_normal = b2Vec2_zero;
+            bool hit = false;
+            const int query_child_count = m_QueryShape->GetChildCount();
+            for (int i = 0; i < query_child_count; ++i)
+            {
+                float fraction = 0.0f;
+                b2Vec2 point;
+                b2Vec2 normal;
+                if (ComputeShapeCastHit(m_QueryShape, i, proxy->fixture, proxy->childIndex, m_Translation, &fraction, &point, &normal) && fraction <= best_fraction)
+                {
+                    best_fraction = fraction;
+                    best_point = point;
+                    best_normal = normal;
+                    hit = true;
+                }
+            }
+
+            if (!hit || !HasResultCapacity(m_Context))
+            {
+                return HasResultCapacity(m_Context);
+            }
+
+            PushCastHit(m_Context->m_L, proxy->fixture, proxy->childIndex, best_point, best_normal, best_fraction);
+            lua_rawseti(m_Context->m_L, m_Context->m_TableIndex, ++m_Context->m_Count);
+            return HasResultCapacity(m_Context);
+        }
+
+    private:
+        const b2BroadPhase* m_BroadPhase;
+        QueryContext*      m_Context;
+        const b2Shape*     m_QueryShape;
+        b2Vec2             m_Translation;
+    };
+
+    class RayCastCallback : public b2RayCastCallback
+    {
+    public:
+        RayCastCallback(QueryContext* context)
+        : m_Context(context)
+        {
+        }
+
+        float32 ReportFixture(b2Fixture* fixture, int32 child_index, const b2Vec2& point, const b2Vec2& normal, float32 fraction)
+        {
+            ++m_Context->m_Stats.m_LeafVisits;
+
+            if (!MatchesFilter(fixture, child_index, m_Context->m_Filter))
+            {
+                return -1.0f;
+            }
+
+            PushCastHit(m_Context->m_L, fixture, child_index, point, normal, fraction);
+            lua_rawseti(m_Context->m_L, m_Context->m_TableIndex, ++m_Context->m_Count);
+            return HasResultCapacity(m_Context) ? 1.0f : 0.0f;
+        }
+
+    private:
+        QueryContext* m_Context;
+    };
+
+    class ClosestRayCastCallback : public b2RayCastCallback
+    {
+    public:
+        ClosestRayCastCallback(QueryContext* context)
+        : m_Context(context)
+        , m_Fixture(0)
+        , m_ChildIndex(0)
+        , m_Point(b2Vec2_zero)
+        , m_Normal(b2Vec2_zero)
+        , m_Fraction(1.0f)
+        {
+        }
+
+        float32 ReportFixture(b2Fixture* fixture, int32 child_index, const b2Vec2& point, const b2Vec2& normal, float32 fraction)
+        {
+            ++m_Context->m_Stats.m_LeafVisits;
+
+            if (!MatchesFilter(fixture, child_index, m_Context->m_Filter))
+            {
+                return -1.0f;
+            }
+
+            m_Fixture = fixture;
+            m_ChildIndex = child_index;
+            m_Point = point;
+            m_Normal = normal;
+            m_Fraction = fraction;
+            return fraction;
+        }
+
+        bool HasHit() const
+        {
+            return m_Fixture != 0;
+        }
+
+        void PushHit(lua_State* L) const
+        {
+            PushCastHit(L, m_Fixture, m_ChildIndex, m_Point, m_Normal, m_Fraction);
+        }
+
+    private:
+        QueryContext* m_Context;
+        b2Fixture*   m_Fixture;
+        int32        m_ChildIndex;
+        b2Vec2       m_Point;
+        b2Vec2       m_Normal;
+        float32      m_Fraction;
+    };
+
+    static void InitQueryContext(QueryContext* context, lua_State* L, int table_index, const QueryFilter& filter, int max_results)
+    {
+        context->m_L = L;
+        context->m_TableIndex = table_index;
+        context->m_Count = 0;
+        context->m_MaxResults = max_results;
+        context->m_Filter = filter;
+        context->m_Stats.m_NodeVisits = 0;
+        context->m_Stats.m_LeafVisits = 0;
+    }
+
+    static int World_OverlapAABB(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 2);
+        b2World* world = CheckWorld(L, 1);
+        b2AABB aabb = CheckAABB(L, 2);
+        QueryFilter filter = CheckQueryFilter(L, 3);
+
+        lua_newtable(L);
+        QueryContext context;
+        InitQueryContext(&context, L, AbsIndex(L, -1), filter, CheckMaxResults(L, 4));
+        const b2BroadPhase& broad_phase = world->GetContactManager().m_broadPhase;
+        OverlapAABBCallback callback(&broad_phase, &context);
+        broad_phase.Query(&callback, aabb);
+
+        PushTreeStats(L, context.m_Stats);
+        return 2;
+    }
+
+    static int World_OverlapShape(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 2);
+        b2World* world = CheckWorld(L, 1);
+
+        FixtureShapeDef shape_def;
+        const b2Shape* query_shape = CheckShapeDef(L, 2, &shape_def);
+        b2Transform identity;
+        identity.SetIdentity();
+        b2AABB query_aabb = ComputeShapeAABB(query_shape, identity);
+
+        QueryFilter filter = CheckQueryFilter(L, 3);
+        lua_newtable(L);
+        QueryContext context;
+        InitQueryContext(&context, L, AbsIndex(L, -1), filter, CheckMaxResults(L, 4));
+        const b2BroadPhase& broad_phase = world->GetContactManager().m_broadPhase;
+        OverlapShapeCallback callback(&broad_phase, &context, query_shape);
+        broad_phase.Query(&callback, query_aabb);
+
+        PushTreeStats(L, context.m_Stats);
+        return 2;
+    }
+
+    static int World_CastRay(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 2);
+        b2World* world = CheckWorld(L, 1);
+        b2Vec2 origin = CheckVec2(L, 2, GetPhysicsScale());
+        b2Vec2 translation = CheckVec2(L, 3, GetPhysicsScale());
+        QueryFilter filter = CheckQueryFilter(L, 4);
+
+        lua_newtable(L);
+        QueryContext context;
+        InitQueryContext(&context, L, AbsIndex(L, -1), filter, CheckMaxResults(L, 5));
+        RayCastCallback callback(&context);
+        world->RayCast(&callback, origin, origin + translation);
+
+        PushTreeStats(L, context.m_Stats);
+        return 2;
+    }
+
+    static int World_CastRayClosest(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        b2World* world = CheckWorld(L, 1);
+        b2Vec2 origin = CheckVec2(L, 2, GetPhysicsScale());
+        b2Vec2 translation = CheckVec2(L, 3, GetPhysicsScale());
+        QueryFilter filter = CheckQueryFilter(L, 4);
+
+        QueryContext context;
+        InitQueryContext(&context, L, 0, filter, 1);
+        ClosestRayCastCallback callback(&context);
+        world->RayCast(&callback, origin, origin + translation);
+        if (!callback.HasHit())
+        {
+            lua_pushnil(L);
+            return 1;
+        }
+
+        callback.PushHit(L);
+        lua_pushinteger(L, context.m_Stats.m_NodeVisits);
+        lua_setfield(L, -2, "node_visits");
+        lua_pushinteger(L, context.m_Stats.m_LeafVisits);
+        lua_setfield(L, -2, "leaf_visits");
+        return 1;
+    }
+
+    static int World_CastShape(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 2);
+        b2World* world = CheckWorld(L, 1);
+
+        FixtureShapeDef shape_def;
+        const b2Shape* query_shape = CheckShapeDef(L, 2, &shape_def);
+        b2Vec2 translation = CheckVec2(L, 3, GetPhysicsScale());
+
+        b2Transform start_transform;
+        start_transform.SetIdentity();
+        b2Transform end_transform;
+        end_transform.Set(translation, 0.0f);
+        b2AABB query_aabb = ComputeShapeAABB(query_shape, start_transform);
+        query_aabb.Combine(ComputeShapeAABB(query_shape, end_transform));
+
+        QueryFilter filter = CheckQueryFilter(L, 4);
+        lua_newtable(L);
+        QueryContext context;
+        InitQueryContext(&context, L, AbsIndex(L, -1), filter, CheckMaxResults(L, 5));
+        const b2BroadPhase& broad_phase = world->GetContactManager().m_broadPhase;
+        ShapeCastCallback callback(&broad_phase, &context, query_shape, translation);
+        broad_phase.Query(&callback, query_aabb);
+
+        PushTreeStats(L, context.m_Stats);
+        return 2;
+    }
+
+    static const luaL_reg World_functions[] =
+    {
+        {"overlap_aabb", World_OverlapAABB},
+        {"overlap_shape", World_OverlapShape},
+        {"cast_ray", World_CastRay},
+        {"cast_ray_closest", World_CastRayClosest},
+        {"cast_shape", World_CastShape},
+        {0,0}
+    };
+
+    void ScriptBox2DInitializeWorld(lua_State* L)
+    {
+        lua_newtable(L);
+        luaL_register(L, 0, World_functions);
+        lua_setfield(L, -2, "world");
+    }
+}
+
+/*# Box2D b2World documentation
+ *
+ * Query and cast functions for the Defold-owned Box2D v2 world.
+ *
+ * @document
+ * @name b2d.world
+ * @namespace b2d.world
+ * @language Lua
+ */
+
+/*# Overlap an AABB.
+ * @name b2d.world.overlap_aabb
+ * @param world [type: b2World] world from `b2d.get_world` or `b2d.body.get_world`
+ * @param aabb [type: table] table with `lower` and `upper` vector3 fields
+ * @param filter [type: table] optional query filter with `category_bits`, `mask_bits`, and optional `group_index`
+ * @param max_results [type: number] optional maximum result count
+ * @return fixtures [type: table] array of fixture info tables
+ * @return stats [type: table] table with `node_visits` and `leaf_visits`
+ */
+
+/*# Overlap a shape.
+ * @name b2d.world.overlap_shape
+ * @param world [type: b2World] world from `b2d.get_world` or `b2d.body.get_world`
+ * @param shape [type: table] shape table using the same format as the `shape` field in `b2d.body.create_fixture`
+ * @param filter [type: table] optional query filter with `category_bits`, `mask_bits`, and optional `group_index`
+ * @param max_results [type: number] optional maximum result count
+ * @return fixtures [type: table] array of fixture info tables
+ * @return stats [type: table] table with `node_visits` and `leaf_visits`
+ */
+
+/*# Cast a ray.
+ * @name b2d.world.cast_ray
+ * @param world [type: b2World] world from `b2d.get_world` or `b2d.body.get_world`
+ * @param origin [type: vector3] world ray origin
+ * @param translation [type: vector3] world ray translation
+ * @param filter [type: table] optional query filter with `category_bits`, `mask_bits`, and optional `group_index`
+ * @param max_results [type: number] optional maximum result count
+ * @return hits [type: table] array of hit tables with `fixture`, `shape`, `point`, `normal`, and `fraction`
+ * @return stats [type: table] table with `node_visits` and `leaf_visits`
+ */
+
+/*# Cast a ray and return the closest hit.
+ * @name b2d.world.cast_ray_closest
+ * @param world [type: b2World] world from `b2d.get_world` or `b2d.body.get_world`
+ * @param origin [type: vector3] world ray origin
+ * @param translation [type: vector3] world ray translation
+ * @param filter [type: table] optional query filter with `category_bits`, `mask_bits`, and optional `group_index`
+ * @return hit [type: table] hit table with `fixture`, `shape`, `point`, `normal`, `fraction`, `node_visits`, and `leaf_visits`, or nil
+ */
+
+/*# Cast a shape.
+ * Uses Box2D v2 time-of-impact for fixture child shapes that support distance proxies.
+ * Grid fixture children are skipped.
+ * @name b2d.world.cast_shape
+ * @param world [type: b2World] world from `b2d.get_world` or `b2d.body.get_world`
+ * @param shape [type: table] shape table using the same format as the `shape` field in `b2d.body.create_fixture`
+ * @param translation [type: vector3] world shape translation
+ * @param filter [type: table] optional query filter with `category_bits`, `mask_bits`, and optional `group_index`
+ * @param max_results [type: number] optional maximum result count
+ * @return hits [type: table] array of hit tables with `fixture`, `shape`, `point`, `normal`, and `fraction`
+ * @return stats [type: table] table with `node_visits` and `leaf_visits`
+ */

--- a/engine/gamesys/src/gamesys/scripts/box2d/v3/script_box2d_body_v3.cpp
+++ b/engine/gamesys/src/gamesys/scripts/box2d/v3/script_box2d_body_v3.cpp
@@ -217,7 +217,7 @@ namespace dmGameSystem
         return shapes[shape_index - 1];
     }
 
-    static int GetShapeIndex(b2BodyId body, b2ShapeId shape)
+    int GetShapeIndex(b2BodyId body, b2ShapeId shape)
     {
         const int shape_count = GetShapeCount(body);
         if (shape_count == 0)
@@ -239,12 +239,15 @@ namespace dmGameSystem
         return 0;
     }
 
-    static void PushShapeInfo(lua_State* L, b2ShapeId shape, int shape_index)
+    void PushShapeInfo(lua_State* L, b2ShapeId shape, int shape_index)
     {
         lua_newtable(L);
 
         lua_pushinteger(L, shape_index);
         lua_setfield(L, -2, "index");
+
+        PushShapeId(L, shape);
+        lua_setfield(L, -2, "shape_id");
 
         lua_pushinteger(L, NormalizeShapeTypeForLua(b2Shape_GetType(shape)));
         lua_setfield(L, -2, "type");
@@ -260,6 +263,9 @@ namespace dmGameSystem
 
         lua_pushnumber(L, b2Shape_GetRestitution(shape));
         lua_setfield(L, -2, "restitution");
+
+        lua_pushinteger(L, b2Shape_GetMaterial(shape));
+        lua_setfield(L, -2, "material");
 
         lua_pushinteger(L, 1);
         lua_setfield(L, -2, "child_count");
@@ -803,8 +809,7 @@ namespace dmGameSystem
     {
         DM_LUA_STACK_CHECK(L, 1);
         b2BodyId* body = CheckBody(L, 1);
-        b2WorldId* world_id_ptr = (b2WorldId*) lua_newuserdata(L, sizeof(b2WorldId));
-        *world_id_ptr = b2Body_GetWorld(*body);
+        PushWorldId(L, b2Body_GetWorld(*body));
         return 1;
     }
 
@@ -838,6 +843,7 @@ namespace dmGameSystem
     static const luaL_reg Body_functions[] =
     {
         {"create_shape", Body_CreateShape},
+        {"create_chain", Body_CreateChain},
         {"get_position", Body_GetPosition},
         {"get_transform", Body_GetTransform},
         {"set_transform", Body_SetTransform},
@@ -937,8 +943,10 @@ namespace dmGameSystem
 
         lua_setfield(L, -2, "body");
 
+        ScriptBox2DInitializeWorld(L);
         ScriptBox2DInitializeJoint(L);
         ScriptBox2DInitializeShape(L);
+        ScriptBox2DInitializeChain(L);
     }
 
     void ScriptBox2DInvalidateBody(void* body)
@@ -949,6 +957,9 @@ namespace dmGameSystem
     void ScriptBox2DFinalizeBody()
     {
         TYPE_HASH_BODY = 0;
+        ScriptBox2DFinalizeChain();
+        ScriptBox2DFinalizeShape();
+        ScriptBox2DFinalizeWorld();
         ScriptBox2DFinalizeJoint();
     }
 }
@@ -996,10 +1007,67 @@ namespace dmGameSystem
  * Creates a shape and attaches it to this body.
  * If the density is non-zero, this function automatically updates the mass of the body.
  * Contacts are not created until the next time step.
+ * The definition may include `density`, `friction`, `restitution`, `material`,
+ * `sensor` or `is_sensor`, `filter`, and the shape table itself. The shape table
+ * can be in `definition.shape` or directly in `definition`.
  * @warning This function is locked during callbacks.
  * @name b2d.body.create_shape
  * @param body [type: b2Body] body
  * @param definition [type: table] the shape definition.
+ */
+
+/*# Create a chain and attach its segment shapes to this body.
+ * Chains are one-sided connected segments with optional ghost vertices at
+ * the ends of open chains. Ghost vertices are creation-time chain data only and
+ * cannot be added to arbitrary shapes, bodies, or joints after creation.
+ *
+ * `definition.vertices`
+ * : [type:table] array of local `vector3` vertices. Open chains require at least 2 vertices. Loop chains require at least 4 vertices.
+ *
+ * `definition.loop`
+ * : [type:boolean] true to create a closed loop chain.
+ *
+ * `definition.prev_vertex`
+ * : [type:vector3] optional ghost vertex before the first vertex for open chains.
+ *
+ * `definition.next_vertex`
+ * : [type:vector3] optional ghost vertex after the last vertex for open chains.
+ *
+ * `definition.friction`
+ * : [type:number] optional friction.
+ *
+ * `definition.restitution`
+ * : [type:number] optional restitution.
+ *
+ * `definition.material`
+ * : [type:number] optional material id.
+ *
+ * `definition.filter`
+ * : [type:table] optional filter with `category_bits`, `mask_bits`, and `group_index`.
+ *
+ * `definition.enable_sensor_events`
+ * : [type:boolean] true to enable sensor events for chain segments.
+ *
+ * @warning This function is locked during callbacks.
+ * @name b2d.body.create_chain
+ * @param body [type: b2Body] body
+ * @param definition [type: table] the chain definition
+ * @return chain [type: b2Chain] created chain handle
+ * @return segments [type: table] array of shape info tables for the chain segments
+ * @examples
+ *
+ * ```lua
+ * local chain, segments = b2d.body.create_chain(body, {
+ *     vertices = {
+ *         vmath.vector3(-64, 0, 0),
+ *         vmath.vector3(0, 16, 0),
+ *         vmath.vector3(64, 0, 0),
+ *     },
+ *     prev_vertex = vmath.vector3(-96, 0, 0),
+ *     next_vertex = vmath.vector3(96, 0, 0),
+ *     friction = 0.6,
+ * })
+ * ```
  */
 
 /**
@@ -1324,7 +1392,7 @@ namespace dmGameSystem
 /** Get the list of all shapes attached to this body.
  * @name b2d.body.get_shapes
  * @param body [type: b2Body] body
- * @return shapes [type: table] a table of functional shape entries
+ * @return shapes [type: table] a table of shape info entries. Each entry includes `shape_id` for use with `b2d.shape` functions.
  */
 
 /*# Get the joints attached to this body.

--- a/engine/gamesys/src/gamesys/scripts/box2d/v3/script_box2d_body_v3.cpp
+++ b/engine/gamesys/src/gamesys/scripts/box2d/v3/script_box2d_body_v3.cpp
@@ -15,7 +15,6 @@
 #include <stdio.h>
 #include <string.h>
 
-
 #include <box2d/box2d.h>
 
 #include <dlib/array.h>
@@ -149,6 +148,17 @@ namespace dmGameSystem
         return mass_data;
     }
 
+    static void PushAABB(lua_State* L, const b2AABB& aabb)
+    {
+        lua_newtable(L);
+
+        dmScript::PushVector3(L, FromB2(aabb.lowerBound, GetInvPhysicsScale()));
+        lua_setfield(L, -2, "lower");
+
+        dmScript::PushVector3(L, FromB2(aabb.upperBound, GetInvPhysicsScale()));
+        lua_setfield(L, -2, "upper");
+    }
+
     static B2DLuaBody* CheckBodyInternal(lua_State* L, int index)
     {
         return (B2DLuaBody*)dmScript::CheckUserType(L, index, TYPE_HASH_BODY, "Expected user type " BOX2D_TYPE_NAME_BODY);
@@ -275,6 +285,113 @@ namespace dmGameSystem
         lua_setfield(L, -2, "is_chain_segment");
     }
 
+    static void PushManifoldPoint(lua_State* L, const b2ManifoldPoint& point)
+    {
+        lua_newtable(L);
+
+        dmScript::PushVector3(L, FromB2(point.point, GetInvPhysicsScale()));
+        lua_setfield(L, -2, "point");
+
+        dmScript::PushVector3(L, FromB2(point.anchorA, GetInvPhysicsScale()));
+        lua_setfield(L, -2, "anchor_a");
+
+        dmScript::PushVector3(L, FromB2(point.anchorB, GetInvPhysicsScale()));
+        lua_setfield(L, -2, "anchor_b");
+
+        lua_pushnumber(L, point.separation * GetInvPhysicsScale());
+        lua_setfield(L, -2, "separation");
+
+        lua_pushnumber(L, point.normalImpulse);
+        lua_setfield(L, -2, "normal_impulse");
+
+        lua_pushnumber(L, point.tangentImpulse);
+        lua_setfield(L, -2, "tangent_impulse");
+
+        lua_pushnumber(L, point.totalNormalImpulse);
+        lua_setfield(L, -2, "total_normal_impulse");
+
+        lua_pushnumber(L, point.normalVelocity * GetInvPhysicsScale());
+        lua_setfield(L, -2, "normal_velocity");
+
+        lua_pushinteger(L, point.id);
+        lua_setfield(L, -2, "id");
+
+        lua_pushboolean(L, point.persisted);
+        lua_setfield(L, -2, "persisted");
+    }
+
+    void PushContactData(lua_State* L, const b2ContactData& contact_data)
+    {
+        lua_newtable(L);
+
+        b2BodyId body_a = b2Shape_GetBody(contact_data.shapeIdA);
+        PushShapeInfo(L, contact_data.shapeIdA, GetShapeIndex(body_a, contact_data.shapeIdA));
+        lua_setfield(L, -2, "shape_a");
+
+        b2BodyId body_b = b2Shape_GetBody(contact_data.shapeIdB);
+        PushShapeInfo(L, contact_data.shapeIdB, GetShapeIndex(body_b, contact_data.shapeIdB));
+        lua_setfield(L, -2, "shape_b");
+
+        dmScript::PushVector3(L, FromB2(contact_data.manifold.normal, 1.0f));
+        lua_setfield(L, -2, "normal");
+
+        lua_pushnumber(L, contact_data.manifold.rollingImpulse);
+        lua_setfield(L, -2, "rolling_impulse");
+
+        lua_pushinteger(L, contact_data.manifold.pointCount);
+        lua_setfield(L, -2, "point_count");
+
+        lua_newtable(L);
+        for (int i = 0; i < contact_data.manifold.pointCount; ++i)
+        {
+            PushManifoldPoint(L, contact_data.manifold.points[i]);
+            lua_rawseti(L, -2, i + 1);
+        }
+        lua_setfield(L, -2, "points");
+    }
+
+    static int Body_IsValid(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        B2DLuaBody* luabody = CheckBodyInternal(L, 1);
+        if (luabody->m_InstanceId)
+        {
+            dmGameObject::HInstance instance = dmGameObject::GetInstanceFromIdentifier(luabody->m_Collection, luabody->m_InstanceId);
+            if (!instance || dmGameObject::GetGeneration(instance) != luabody->m_InstanceGeneration)
+            {
+                lua_pushboolean(L, false);
+                return 1;
+            }
+        }
+
+        lua_pushboolean(L, b2Body_IsValid(luabody->m_Body));
+        return 1;
+    }
+
+    static int Body_SetName(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        b2BodyId* body = CheckBody(L, 1);
+        b2Body_SetName(*body, luaL_checkstring(L, 2));
+        return 0;
+    }
+
+    static int Body_GetName(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        b2BodyId* body = CheckBody(L, 1);
+        const char* name = b2Body_GetName(*body);
+        if (name)
+        {
+            lua_pushstring(L, name);
+        }
+        else
+        {
+            lua_pushnil(L);
+        }
+        return 1;
+    }
+
     static int Body_GetPosition(lua_State* L)
     {
         DM_LUA_STACK_CHECK(L, 1);
@@ -299,6 +416,17 @@ namespace dmGameSystem
         float angle = luaL_checknumber(L, 3);
         b2Rot rot = b2MakeRot(angle);
         b2Body_SetTransform(*body, position, rot);
+        return 0;
+    }
+
+    static int Body_SetTargetTransform(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        b2BodyId* body = CheckBody(L, 1);
+        b2Transform target;
+        target.p = CheckVec2(L, 2, GetPhysicsScale());
+        target.q = b2MakeRot(luaL_checknumber(L, 3));
+        b2Body_SetTargetTransform(*body, target, luaL_checknumber(L, 4));
         return 0;
     }
 
@@ -336,6 +464,15 @@ namespace dmGameSystem
         b2Vec2 impulse = CheckVec2(L, 2, GetPhysicsScale());
         b2Vec2 position = CheckVec2(L, 3, GetPhysicsScale()); // position relative center of body
         b2Body_ApplyLinearImpulse(*body, impulse, position, true);
+        return 0;
+    }
+
+    static int Body_ApplyLinearImpulseToCenter(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        b2BodyId* body = CheckBody(L, 1);
+        b2Vec2 impulse = CheckVec2(L, 2, GetPhysicsScale());
+        b2Body_ApplyLinearImpulseToCenter(*body, impulse, true);
         return 0;
     }
 
@@ -482,6 +619,38 @@ namespace dmGameSystem
                 ++joint_index;
             }
         }
+        return 1;
+    }
+
+    static int Body_GetContactData(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        b2BodyId* body = CheckBody(L, 1);
+        int capacity = b2Body_GetContactCapacity(*body);
+
+        lua_newtable(L);
+        if (capacity == 0)
+        {
+            return 1;
+        }
+
+        dmArray<b2ContactData> contact_data;
+        contact_data.SetCapacity(capacity);
+        contact_data.SetSize(capacity);
+        int count = b2Body_GetContactData(*body, contact_data.Begin(), capacity);
+        for (int i = 0; i < count; ++i)
+        {
+            PushContactData(L, contact_data[i]);
+            lua_rawseti(L, -2, i + 1);
+        }
+        return 1;
+    }
+
+    static int Body_ComputeAABB(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        b2BodyId* body = CheckBody(L, 1);
+        PushAABB(L, b2Body_ComputeAABB(*body));
         return 1;
     }
 
@@ -722,6 +891,22 @@ namespace dmGameSystem
         return 0;
     }
 
+    static int Body_SetSleepThreshold(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        b2BodyId* body = CheckBody(L, 1);
+        b2Body_SetSleepThreshold(*body, luaL_checknumber(L, 2) * GetPhysicsScale());
+        return 0;
+    }
+
+    static int Body_GetSleepThreshold(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        b2BodyId* body = CheckBody(L, 1);
+        lua_pushnumber(L, b2Body_GetSleepThreshold(*body) * GetInvPhysicsScale());
+        return 1;
+    }
+
     static int Body_SetSleepingAllowed(lua_State* L)
     {
         return Body_EnableSleep(L);
@@ -748,6 +933,22 @@ namespace dmGameSystem
         {
             b2Body_Disable(*body);
         }
+        return 0;
+    }
+
+    static int Body_EnableContactEvents(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        b2BodyId* body = CheckBody(L, 1);
+        b2Body_EnableContactEvents(*body, lua_toboolean(L, 2));
+        return 0;
+    }
+
+    static int Body_EnableHitEvents(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        b2BodyId* body = CheckBody(L, 1);
+        b2Body_EnableHitEvents(*body, lua_toboolean(L, 2));
         return 0;
     }
 
@@ -842,11 +1043,15 @@ namespace dmGameSystem
 
     static const luaL_reg Body_functions[] =
     {
+        {"is_valid", Body_IsValid},
         {"create_shape", Body_CreateShape},
         {"create_chain", Body_CreateChain},
+        {"get_name", Body_GetName},
+        {"set_name", Body_SetName},
         {"get_position", Body_GetPosition},
         {"get_transform", Body_GetTransform},
         {"set_transform", Body_SetTransform},
+        {"set_target_transform", Body_SetTargetTransform},
 
         //{"get_user_data", Body_GetUserData}, - could return the game object id ? ur url?
         //{"set_user_data", Body_SetUserData}, - could attach the body to a game object?
@@ -860,6 +1065,8 @@ namespace dmGameSystem
         {"get_angle", Body_GetAngle},
         {"get_shapes", Body_GetShapes},
         {"get_joints", Body_GetJoints},
+        {"get_contact_data", Body_GetContactData},
+        {"compute_aabb", Body_ComputeAABB},
         {"destroy_shape", Body_DestroyShape},
 
         {"get_linear_velocity", Body_GetLinearVelocity},
@@ -885,11 +1092,15 @@ namespace dmGameSystem
 
         {"is_sleeping_enabled", Body_IsSleepingEnabled},
         {"enable_sleep", Body_EnableSleep},
+        {"get_sleep_threshold", Body_GetSleepThreshold},
+        {"set_sleep_threshold", Body_SetSleepThreshold},
         {"is_sleeping_allowed", Body_IsSleepingAllowed},
         {"set_sleeping_allowed", Body_SetSleepingAllowed},
 
         {"is_active", Body_IsActive},
         {"set_active", Body_SetActive},
+        {"enable_contact_events", Body_EnableContactEvents},
+        {"enable_hit_events", Body_EnableHitEvents},
 
         {"get_gravity_scale", Body_GetGravityScale},
         {"set_gravity_scale", Body_SetGravityScale},
@@ -917,6 +1128,7 @@ namespace dmGameSystem
         {"apply_torque", Body_ApplyTorque},
 
         {"apply_linear_impulse", Body_ApplyLinearImpulse},
+        {"apply_linear_impulse_to_center", Body_ApplyLinearImpulseToCenter},
         {"apply_angular_impulse", Body_ApplyAngularImpulse},
 
         {"get_world", Body_GetWorld},
@@ -1430,4 +1642,72 @@ namespace dmGameSystem
  * @note Defold Specific
  * @param body [type: b2Body] body
  * @return force [type: vector3]
+ */
+
+/*# Validate a body handle.
+ * @name b2d.body.is_valid
+ * @param body [type: b2Body] body
+ * @return valid [type: boolean] true if the body handle still refers to a live Box2D body
+ */
+
+/*# Set the body name.
+ * @name b2d.body.set_name
+ * @param body [type: b2Body] body
+ * @param name [type: string] body name
+ */
+
+/*# Get the body name.
+ * @name b2d.body.get_name
+ * @param body [type: b2Body] body
+ * @return name [type: string] body name, or nil if no name is set
+ */
+
+/*# Set velocity to reach a target transform.
+ * @name b2d.body.set_target_transform
+ * @param body [type: b2Body] body
+ * @param position [type: vector3] target world position
+ * @param angle [type: number] target world angle in radians
+ * @param time_step [type: number] time step used to compute velocity
+ */
+
+/*# Apply a linear impulse to the center of mass.
+ * @name b2d.body.apply_linear_impulse_to_center
+ * @param body [type: b2Body] body
+ * @param impulse [type: vector3] world impulse vector
+ */
+
+/*# Set the sleep velocity threshold.
+ * @name b2d.body.set_sleep_threshold
+ * @param body [type: b2Body] body
+ * @param threshold [type: number] velocity threshold in Defold units per second
+ */
+
+/*# Get the sleep velocity threshold.
+ * @name b2d.body.get_sleep_threshold
+ * @param body [type: b2Body] body
+ * @return threshold [type: number] velocity threshold in Defold units per second
+ */
+
+/*# Enable or disable contact events on all body shapes.
+ * @name b2d.body.enable_contact_events
+ * @param body [type: b2Body] body
+ * @param enable [type: boolean] true to enable contact events
+ */
+
+/*# Enable or disable hit events on all body shapes.
+ * @name b2d.body.enable_hit_events
+ * @param body [type: b2Body] body
+ * @param enable [type: boolean] true to enable hit events
+ */
+
+/*# Get touching contact data for a body.
+ * @name b2d.body.get_contact_data
+ * @param body [type: b2Body] body
+ * @return contacts [type: table] array of contact tables
+ */
+
+/*# Compute the world AABB of all body shapes.
+ * @name b2d.body.compute_aabb
+ * @param body [type: b2Body] body
+ * @return aabb [type: table] table with `lower` and `upper` vector3 fields
  */

--- a/engine/gamesys/src/gamesys/scripts/box2d/v3/script_box2d_chain_v3.cpp
+++ b/engine/gamesys/src/gamesys/scripts/box2d/v3/script_box2d_chain_v3.cpp
@@ -399,6 +399,21 @@ namespace dmGameSystem
         return 0;
     }
 
+    static int Chain_IsValid(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        B2DLuaChain* luachain = CheckChainInternal(L, 1);
+        lua_pushboolean(L, b2Chain_IsValid(luachain->m_Chain));
+        return 1;
+    }
+
+    static int Chain_GetWorld(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        PushWorldId(L, b2Chain_GetWorld(*CheckChain(L, 1)));
+        return 1;
+    }
+
     static int Chain_GetSegmentCount(lua_State* L)
     {
         DM_LUA_STACK_CHECK(L, 1);
@@ -579,6 +594,8 @@ namespace dmGameSystem
     static const luaL_reg Chain_functions[] =
     {
         {"destroy", Chain_Destroy},
+        {"is_valid", Chain_IsValid},
+        {"get_world", Chain_GetWorld},
         {"get_segment_count", Chain_GetSegmentCount},
         {"get_segments", Chain_GetSegments},
         {"get_geometry", Chain_GetGeometry},
@@ -631,6 +648,18 @@ namespace dmGameSystem
  * @warning This function is locked during callbacks.
  * @name b2d.chain.destroy
  * @param chain [type: b2Chain] chain
+ */
+
+/*# Validate a chain handle.
+ * @name b2d.chain.is_valid
+ * @param chain [type: b2Chain] chain
+ * @return valid [type: boolean] true if the chain handle still refers to a live Box2D chain
+ */
+
+/*# Get the world owning a chain.
+ * @name b2d.chain.get_world
+ * @param chain [type: b2Chain] chain
+ * @return world [type: b2World] owning world
  */
 
 /*# Get the number of segment shapes in a chain.

--- a/engine/gamesys/src/gamesys/scripts/box2d/v3/script_box2d_chain_v3.cpp
+++ b/engine/gamesys/src/gamesys/scripts/box2d/v3/script_box2d_chain_v3.cpp
@@ -1,0 +1,700 @@
+// Copyright 2020-2026 The Defold Foundation
+// Copyright 2014-2020 King
+// Copyright 2009-2014 Ragnar Svensson, Christian Murray
+// Licensed under the Defold License version 1.0 (the "License"); you may not use
+// this file except in compliance with the License.
+
+#include <string.h>
+
+#include <box2d/box2d.h>
+
+#include <dlib/array.h>
+#include <script/script.h>
+#include <gameobject/script.h>
+
+#include "script_box2d_v3.h"
+
+extern "C"
+{
+#include <lua/lauxlib.h>
+#include <lua/lualib.h>
+}
+
+namespace dmGameSystem
+{
+    static uint32_t TYPE_HASH_CHAIN = 0;
+
+    #define BOX2D_TYPE_NAME_CHAIN "b2chain"
+
+    struct B2DLuaChain
+    {
+        b2ChainId m_Chain;
+    };
+
+    static b2Vec2 CheckVec2(lua_State* L, int index, float scale)
+    {
+        dmVMath::Vector3* v = dmScript::CheckVector3(L, index);
+        b2Vec2 b2v = { v->getX() * scale, v->getY() * scale };
+        return b2v;
+    }
+
+    static dmVMath::Vector3 FromB2(const b2Vec2& p, float inv_scale)
+    {
+        return dmVMath::Vector3(p.x * inv_scale, p.y * inv_scale, 0);
+    }
+
+    static int AbsIndex(lua_State* L, int index)
+    {
+        return index < 0 ? lua_gettop(L) + index + 1 : index;
+    }
+
+    static bool HasField(lua_State* L, int index, const char* field_name)
+    {
+        lua_getfield(L, index, field_name);
+        bool has_field = !lua_isnil(L, -1);
+        lua_pop(L, 1);
+        return has_field;
+    }
+
+    static bool TryGetNumberField(lua_State* L, int index, const char* field_name, float* out_value)
+    {
+        lua_getfield(L, index, field_name);
+        if (lua_isnil(L, -1))
+        {
+            lua_pop(L, 1);
+            return false;
+        }
+
+        *out_value = luaL_checknumber(L, -1);
+        lua_pop(L, 1);
+        return true;
+    }
+
+    static bool TryGetIntegerField(lua_State* L, int index, const char* field_name, int* out_value)
+    {
+        lua_getfield(L, index, field_name);
+        if (lua_isnil(L, -1))
+        {
+            lua_pop(L, 1);
+            return false;
+        }
+
+        *out_value = luaL_checkinteger(L, -1);
+        lua_pop(L, 1);
+        return true;
+    }
+
+    static bool TryGetBooleanField(lua_State* L, int index, const char* field_name, bool* out_value)
+    {
+        lua_getfield(L, index, field_name);
+        if (lua_isnil(L, -1))
+        {
+            lua_pop(L, 1);
+            return false;
+        }
+
+        *out_value = lua_toboolean(L, -1) != 0;
+        lua_pop(L, 1);
+        return true;
+    }
+
+    static bool TryGetVec2Field(lua_State* L, int index, const char* field_name, b2Vec2* out_value)
+    {
+        lua_getfield(L, index, field_name);
+        if (lua_isnil(L, -1))
+        {
+            lua_pop(L, 1);
+            return false;
+        }
+
+        *out_value = CheckVec2(L, -1, GetPhysicsScale());
+        lua_pop(L, 1);
+        return true;
+    }
+
+    static void CheckVerticesTable(lua_State* L, int index, int min_count, dmArray<b2Vec2>* out_vertices)
+    {
+        luaL_checktype(L, index, LUA_TTABLE);
+
+        int count = (int)lua_objlen(L, index);
+        if (count < min_count)
+        {
+            luaL_error(L, "Expected at least %d vertices, got %d.", min_count, count);
+            return;
+        }
+
+        out_vertices->SetCapacity(count);
+        out_vertices->SetSize(count);
+        for (int i = 0; i < count; ++i)
+        {
+            lua_rawgeti(L, index, i + 1);
+            (*out_vertices)[i] = CheckVec2(L, -1, GetPhysicsScale());
+            lua_pop(L, 1);
+        }
+    }
+
+    static b2Filter CheckFilterData(lua_State* L, int index)
+    {
+        luaL_checktype(L, index, LUA_TTABLE);
+
+        b2Filter filter = b2DefaultFilter();
+
+        lua_getfield(L, index, "category_bits");
+        if (!lua_isnil(L, -1))
+        {
+            filter.categoryBits = (uint64_t)luaL_checknumber(L, -1);
+        }
+        lua_pop(L, 1);
+
+        lua_getfield(L, index, "mask_bits");
+        if (!lua_isnil(L, -1))
+        {
+            filter.maskBits = (uint64_t)luaL_checknumber(L, -1);
+        }
+        lua_pop(L, 1);
+
+        lua_getfield(L, index, "group_index");
+        if (!lua_isnil(L, -1))
+        {
+            filter.groupIndex = (int)luaL_checkinteger(L, -1);
+        }
+        lua_pop(L, 1);
+
+        return filter;
+    }
+
+    static void ValidateChainPoints(lua_State* L, const dmArray<b2Vec2>& points)
+    {
+        const float min_distance = 0.005f * b2GetLengthUnitsPerMeter();
+        const float min_distance_squared = min_distance * min_distance;
+
+        for (uint32_t i = 0; i < points.Size(); ++i)
+        {
+            for (uint32_t j = i + 1; j < points.Size(); ++j)
+            {
+                if (b2DistanceSquared(points[i], points[j]) < min_distance_squared)
+                {
+                    luaL_error(L, "Chain vertices must be separated by at least %g physics units.", min_distance);
+                    return;
+                }
+            }
+        }
+    }
+
+    static b2Vec2 SynthesizePreviousVertex(const dmArray<b2Vec2>& vertices)
+    {
+        return b2Add(vertices[0], b2Sub(vertices[0], vertices[1]));
+    }
+
+    static b2Vec2 SynthesizeNextVertex(const dmArray<b2Vec2>& vertices)
+    {
+        const uint32_t last = vertices.Size() - 1;
+        return b2Add(vertices[last], b2Sub(vertices[last], vertices[last - 1]));
+    }
+
+    static void PushSegments(lua_State* L, b2ChainId chain)
+    {
+        int segment_count = b2Chain_GetSegmentCount(chain);
+        dmArray<b2ShapeId> segments;
+        segments.SetCapacity(segment_count);
+        segments.SetSize(segment_count);
+
+        int actual_count = b2Chain_GetSegments(chain, segments.Begin(), segment_count);
+
+        lua_newtable(L);
+        for (int i = 0; i < actual_count; ++i)
+        {
+            b2BodyId body = b2Shape_GetBody(segments[i]);
+            PushShapeInfo(L, segments[i], GetShapeIndex(body, segments[i]));
+            lua_rawseti(L, -2, i + 1);
+        }
+    }
+
+    static B2DLuaChain* CheckChainInternal(lua_State* L, int index)
+    {
+        return (B2DLuaChain*)dmScript::CheckUserType(L, index, TYPE_HASH_CHAIN, "Expected user type " BOX2D_TYPE_NAME_CHAIN);
+    }
+
+    static b2ChainId* CheckChain(lua_State* L, int index)
+    {
+        B2DLuaChain* luachain = CheckChainInternal(L, index);
+        if (!b2Chain_IsValid(luachain->m_Chain))
+        {
+            luaL_error(L, "Invalid b2chain handle.");
+            return 0;
+        }
+        return &luachain->m_Chain;
+    }
+
+    static b2ChainId* ToChain(lua_State* L, int index)
+    {
+        B2DLuaChain* luachain = (B2DLuaChain*)dmScript::ToUserType(L, index, TYPE_HASH_CHAIN);
+        return luachain ? &luachain->m_Chain : 0;
+    }
+
+    static void CheckChainUnlocked(lua_State* L, b2ChainId chain, const char* function_name)
+    {
+        b2WorldId world = b2Chain_GetWorld(chain);
+        if (b2World_IsLocked(world))
+        {
+            luaL_error(L, "Could not call b2d.chain.%s. The world is locked.", function_name);
+        }
+    }
+
+    static b2ShapeId CheckBodyShape(lua_State* L, int body_index, int shape_index_index)
+    {
+        b2BodyId* body = CheckBody(L, body_index);
+        int shape_index = luaL_checkinteger(L, shape_index_index);
+        b2ShapeId shape = GetShapeByIndex(*body, shape_index);
+        if (!b2Shape_IsValid(shape))
+        {
+            luaL_error(L, "shape_index %d out of range.", shape_index);
+            return b2_nullShapeId;
+        }
+        return shape;
+    }
+
+    static b2ShapeId CheckShapeArg(lua_State* L, int index)
+    {
+        b2ShapeId* shape = ToShapeId(L, index);
+        if (shape)
+        {
+            if (!b2Shape_IsValid(*shape))
+            {
+                luaL_error(L, "Invalid b2shape handle.");
+                return b2_nullShapeId;
+            }
+            return *shape;
+        }
+
+        return CheckBodyShape(L, index, index + 1);
+    }
+
+    void PushChain(lua_State* L, b2ChainId chain_id)
+    {
+        B2DLuaChain* luachain = (B2DLuaChain*)lua_newuserdata(L, sizeof(B2DLuaChain));
+        luachain->m_Chain = chain_id;
+
+        luaL_getmetatable(L, BOX2D_TYPE_NAME_CHAIN);
+        lua_setmetatable(L, -2);
+    }
+
+    int Body_CreateChain(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 2);
+        b2BodyId* body = CheckBody(L, 1);
+        b2WorldId world = b2Body_GetWorld(*body);
+        if (b2World_IsLocked(world))
+        {
+            return luaL_error(L, "Could not create chain. The world is locked.");
+        }
+
+        int definition_index = AbsIndex(L, 2);
+        luaL_checktype(L, definition_index, LUA_TTABLE);
+
+        bool loop = false;
+        TryGetBooleanField(L, definition_index, "loop", &loop);
+
+        if (loop && (HasField(L, definition_index, "prev_vertex") || HasField(L, definition_index, "next_vertex")))
+        {
+            return luaL_error(L, "Loop chains do not use prev_vertex or next_vertex.");
+        }
+
+        dmArray<b2Vec2> vertices;
+        lua_getfield(L, definition_index, "vertices");
+        CheckVerticesTable(L, -1, loop ? 4 : 2, &vertices);
+        lua_pop(L, 1);
+
+        dmArray<b2Vec2> chain_points;
+        if (loop)
+        {
+            chain_points.SetCapacity(vertices.Size());
+            chain_points.SetSize(vertices.Size());
+            for (uint32_t i = 0; i < vertices.Size(); ++i)
+            {
+                chain_points[i] = vertices[i];
+            }
+        }
+        else
+        {
+            chain_points.SetCapacity(vertices.Size() + 2);
+            chain_points.SetSize(vertices.Size() + 2);
+
+            b2Vec2 prev_vertex = SynthesizePreviousVertex(vertices);
+            b2Vec2 next_vertex = SynthesizeNextVertex(vertices);
+            TryGetVec2Field(L, definition_index, "prev_vertex", &prev_vertex);
+            TryGetVec2Field(L, definition_index, "next_vertex", &next_vertex);
+
+            chain_points[0] = prev_vertex;
+            for (uint32_t i = 0; i < vertices.Size(); ++i)
+            {
+                chain_points[i + 1] = vertices[i];
+            }
+            chain_points[chain_points.Size() - 1] = next_vertex;
+        }
+
+        ValidateChainPoints(L, chain_points);
+
+        b2SurfaceMaterial material = b2DefaultSurfaceMaterial();
+
+        float float_value = 0.0f;
+        if (TryGetNumberField(L, definition_index, "friction", &float_value))
+        {
+            material.friction = float_value;
+        }
+
+        if (TryGetNumberField(L, definition_index, "restitution", &float_value))
+        {
+            material.restitution = float_value;
+        }
+
+        int material_value = 0;
+        if (TryGetIntegerField(L, definition_index, "material", &material_value))
+        {
+            material.userMaterialId = material_value;
+        }
+
+        b2ChainDef chain_def = b2DefaultChainDef();
+        chain_def.userData = b2Body_GetUserData(*body);
+        chain_def.points = chain_points.Begin();
+        chain_def.count = chain_points.Size();
+        chain_def.materials = &material;
+        chain_def.materialCount = 1;
+        chain_def.isLoop = loop;
+
+        lua_getfield(L, definition_index, "filter");
+        if (!lua_isnil(L, -1))
+        {
+            chain_def.filter = CheckFilterData(L, -1);
+        }
+        lua_pop(L, 1);
+
+        bool enable_sensor_events = chain_def.enableSensorEvents;
+        TryGetBooleanField(L, definition_index, "enable_sensor_events", &enable_sensor_events);
+        chain_def.enableSensorEvents = enable_sensor_events;
+
+        b2ChainId chain = b2CreateChain(*body, &chain_def);
+        if (!b2Chain_IsValid(chain))
+        {
+            return luaL_error(L, "Could not create chain. The world may be locked.");
+        }
+
+        PushChain(L, chain);
+        PushSegments(L, chain);
+        return 2;
+    }
+
+    static int Chain_Destroy(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        B2DLuaChain* luachain = CheckChainInternal(L, 1);
+        if (!b2Chain_IsValid(luachain->m_Chain))
+        {
+            return luaL_error(L, "Invalid b2chain handle.");
+        }
+
+        CheckChainUnlocked(L, luachain->m_Chain, "destroy");
+        b2DestroyChain(luachain->m_Chain);
+        luachain->m_Chain = b2_nullChainId;
+        return 0;
+    }
+
+    static int Chain_GetSegmentCount(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        b2ChainId chain = *CheckChain(L, 1);
+        CheckChainUnlocked(L, chain, "get_segment_count");
+        lua_pushinteger(L, b2Chain_GetSegmentCount(chain));
+        return 1;
+    }
+
+    static int Chain_GetSegments(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        b2ChainId chain = *CheckChain(L, 1);
+        CheckChainUnlocked(L, chain, "get_segments");
+        PushSegments(L, chain);
+        return 1;
+    }
+
+    static bool PointsEqual(const b2Vec2& a, const b2Vec2& b)
+    {
+        return b2DistanceSquared(a, b) < 0.000001f;
+    }
+
+    static int Chain_GetGeometry(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        b2ChainId chain = *CheckChain(L, 1);
+        CheckChainUnlocked(L, chain, "get_geometry");
+
+        int segment_count = b2Chain_GetSegmentCount(chain);
+        dmArray<b2ShapeId> segments;
+        segments.SetCapacity(segment_count);
+        segments.SetSize(segment_count);
+        segment_count = b2Chain_GetSegments(chain, segments.Begin(), segment_count);
+        if (segment_count <= 0)
+        {
+            return luaL_error(L, "Could not resolve chain segments.");
+        }
+
+        b2ChainSegment first_segment = b2Shape_GetChainSegment(segments[0]);
+        b2ChainSegment last_segment = b2Shape_GetChainSegment(segments[segment_count - 1]);
+        bool loop = PointsEqual(last_segment.segment.point2, first_segment.segment.point1);
+
+        lua_newtable(L);
+
+        lua_pushboolean(L, loop);
+        lua_setfield(L, -2, "loop");
+
+        lua_pushinteger(L, segment_count);
+        lua_setfield(L, -2, "segment_count");
+
+        lua_newtable(L);
+        if (loop)
+        {
+            for (int i = 0; i < segment_count; ++i)
+            {
+                b2ChainSegment segment = b2Shape_GetChainSegment(segments[i]);
+                dmScript::PushVector3(L, FromB2(segment.segment.point1, GetInvPhysicsScale()));
+                lua_rawseti(L, -2, i + 1);
+            }
+        }
+        else
+        {
+            dmScript::PushVector3(L, FromB2(first_segment.segment.point1, GetInvPhysicsScale()));
+            lua_rawseti(L, -2, 1);
+
+            for (int i = 0; i < segment_count; ++i)
+            {
+                b2ChainSegment segment = b2Shape_GetChainSegment(segments[i]);
+                dmScript::PushVector3(L, FromB2(segment.segment.point2, GetInvPhysicsScale()));
+                lua_rawseti(L, -2, i + 2);
+            }
+        }
+        lua_setfield(L, -2, "vertices");
+
+        if (!loop)
+        {
+            dmScript::PushVector3(L, FromB2(first_segment.ghost1, GetInvPhysicsScale()));
+            lua_setfield(L, -2, "prev_vertex");
+
+            dmScript::PushVector3(L, FromB2(last_segment.ghost2, GetInvPhysicsScale()));
+            lua_setfield(L, -2, "next_vertex");
+        }
+
+        return 1;
+    }
+
+    static int Chain_FromShape(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        b2ShapeId shape = CheckShapeArg(L, 1);
+        b2ChainId chain = b2Shape_GetParentChain(shape);
+        if (!b2Chain_IsValid(chain))
+        {
+            lua_pushnil(L);
+            return 1;
+        }
+
+        PushChain(L, chain);
+        return 1;
+    }
+
+    static int Chain_GetFriction(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        lua_pushnumber(L, b2Chain_GetFriction(*CheckChain(L, 1)));
+        return 1;
+    }
+
+    static int Chain_SetFriction(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        b2ChainId chain = *CheckChain(L, 1);
+        CheckChainUnlocked(L, chain, "set_friction");
+        b2Chain_SetFriction(chain, luaL_checknumber(L, 2));
+        return 0;
+    }
+
+    static int Chain_GetRestitution(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        lua_pushnumber(L, b2Chain_GetRestitution(*CheckChain(L, 1)));
+        return 1;
+    }
+
+    static int Chain_SetRestitution(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        b2ChainId chain = *CheckChain(L, 1);
+        CheckChainUnlocked(L, chain, "set_restitution");
+        b2Chain_SetRestitution(chain, luaL_checknumber(L, 2));
+        return 0;
+    }
+
+    static int Chain_GetMaterial(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        lua_pushinteger(L, b2Chain_GetMaterial(*CheckChain(L, 1)));
+        return 1;
+    }
+
+    static int Chain_SetMaterial(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        b2ChainId chain = *CheckChain(L, 1);
+        CheckChainUnlocked(L, chain, "set_material");
+        b2Chain_SetMaterial(chain, luaL_checkinteger(L, 2));
+        return 0;
+    }
+
+    static int Chain_tostring(lua_State *L)
+    {
+        B2DLuaChain* luachain = CheckChainInternal(L, 1);
+        lua_pushfstring(L, "Box2D.%s = %p", BOX2D_TYPE_NAME_CHAIN, &luachain->m_Chain);
+        return 1;
+    }
+
+    static int Chain_eq(lua_State *L)
+    {
+        b2ChainId* a = ToChain(L, 1);
+        b2ChainId* b = ToChain(L, 2);
+        lua_pushboolean(L, a && b && memcmp(a, b, sizeof(b2ChainId)) == 0);
+        return 1;
+    }
+
+    static const luaL_reg Chain_methods[] =
+    {
+        {0,0}
+    };
+
+    static const luaL_reg Chain_meta[] =
+    {
+        {"__tostring", Chain_tostring},
+        {"__eq", Chain_eq},
+        {0,0}
+    };
+
+    static const luaL_reg Chain_functions[] =
+    {
+        {"destroy", Chain_Destroy},
+        {"get_segment_count", Chain_GetSegmentCount},
+        {"get_segments", Chain_GetSegments},
+        {"get_geometry", Chain_GetGeometry},
+        {"from_shape", Chain_FromShape},
+        {"get_friction", Chain_GetFriction},
+        {"set_friction", Chain_SetFriction},
+        {"get_restitution", Chain_GetRestitution},
+        {"set_restitution", Chain_SetRestitution},
+        {"get_material", Chain_GetMaterial},
+        {"set_material", Chain_SetMaterial},
+        {0,0}
+    };
+
+    void ScriptBox2DInitializeChain(lua_State* L)
+    {
+        TYPE_HASH_CHAIN = dmScript::RegisterUserType(L, BOX2D_TYPE_NAME_CHAIN, Chain_methods, Chain_meta);
+
+        lua_newtable(L);
+        luaL_register(L, 0, Chain_functions);
+        lua_setfield(L, -2, "chain");
+    }
+
+    void ScriptBox2DFinalizeChain()
+    {
+        TYPE_HASH_CHAIN = 0;
+    }
+}
+
+/*# Box2D b2Chain documentation
+ *
+ * Functions for Box2D v3 chains. A chain owns multiple connected segment
+ * shapes, so it is represented by a separate `b2Chain` handle.
+ *
+ * @document
+ * @name b2d.chain
+ * @namespace b2d.chain
+ * @language Lua
+ * @version 3
+ */
+
+/*# Box2D chain
+ * @typedef
+ * @name b2Chain
+ * @param value [type:userdata]
+ */
+
+/*# Destroy a chain.
+ * Destroying a chain removes all segment shapes owned by the chain. Destroying
+ * any segment shape through `b2d.body.destroy_shape` also destroys its parent chain.
+ * @warning This function is locked during callbacks.
+ * @name b2d.chain.destroy
+ * @param chain [type: b2Chain] chain
+ */
+
+/*# Get the number of segment shapes in a chain.
+ * @name b2d.chain.get_segment_count
+ * @param chain [type: b2Chain] chain
+ * @return count [type: number] segment count
+ */
+
+/*# Get the segment shapes owned by a chain.
+ * @name b2d.chain.get_segments
+ * @param chain [type: b2Chain] chain
+ * @return segments [type: table] array of shape info tables for the chain segments. Each entry includes `shape_id`.
+ */
+
+/*# Get the chain geometry.
+ * Returns a chain geometry table with `loop`, `segment_count`, and `vertices`.
+ * Open chains also include `prev_vertex` and `next_vertex` ghost vertices.
+ * @name b2d.chain.get_geometry
+ * @param chain [type: b2Chain] chain
+ * @return geometry [type: table] chain geometry table
+ */
+
+/*# Get the parent chain for a chain segment shape.
+ * Returns `nil` if the shape is not a chain segment.
+ * @name b2d.chain.from_shape
+ * @param shape_id [type: b2Shape] shape handle from a shape info table, or pass `body, shape_index`
+ * @return chain [type: b2Chain|nil] parent chain, or `nil` if the shape is not a chain segment
+ */
+
+/*# Get chain friction.
+ * @name b2d.chain.get_friction
+ * @param chain [type: b2Chain] chain
+ * @return friction [type: number] chain friction
+ */
+
+/*# Set chain friction.
+ * @warning This function is locked during callbacks.
+ * @name b2d.chain.set_friction
+ * @param chain [type: b2Chain] chain
+ * @param friction [type: number] chain friction
+ */
+
+/*# Get chain restitution.
+ * @name b2d.chain.get_restitution
+ * @param chain [type: b2Chain] chain
+ * @return restitution [type: number] chain restitution
+ */
+
+/*# Set chain restitution.
+ * @warning This function is locked during callbacks.
+ * @name b2d.chain.set_restitution
+ * @param chain [type: b2Chain] chain
+ * @param restitution [type: number] chain restitution
+ */
+
+/*# Get chain material id.
+ * @name b2d.chain.get_material
+ * @param chain [type: b2Chain] chain
+ * @return material [type: number] chain material id
+ */
+
+/*# Set chain material id.
+ * @warning This function is locked during callbacks.
+ * @name b2d.chain.set_material
+ * @param chain [type: b2Chain] chain
+ * @param material [type: number] chain material id
+ */

--- a/engine/gamesys/src/gamesys/scripts/box2d/v3/script_box2d_joint_v3.cpp
+++ b/engine/gamesys/src/gamesys/scripts/box2d/v3/script_box2d_joint_v3.cpp
@@ -250,6 +250,21 @@ namespace dmGameSystem
         return 0;
     }
 
+    static int Joint_IsValid(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        B2DLuaJoint* luajoint = CheckJointInternal(L, 1);
+        lua_pushboolean(L, b2Joint_IsValid(luajoint->m_Joint));
+        return 1;
+    }
+
+    static int Joint_GetWorld(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        PushWorldId(L, b2Joint_GetWorld(CheckJoint(L, 1)));
+        return 1;
+    }
+
     static int Joint_GetType(lua_State* L)
     {
         DM_LUA_STACK_CHECK(L, 1);
@@ -1198,6 +1213,8 @@ namespace dmGameSystem
     static const luaL_reg Joint_functions[] =
     {
         {"destroy", Joint_Destroy},
+        {"is_valid", Joint_IsValid},
+        {"get_world", Joint_GetWorld},
         {"get_type", Joint_GetType},
         {"get_body_a", Joint_GetBodyA},
         {"get_body_b", Joint_GetBodyB},
@@ -1376,6 +1393,18 @@ namespace dmGameSystem
 /*# Destroy a joint created by `b2d.joint`.
  * @name b2d.joint.destroy
  * @param joint [type: b2Joint] joint
+ */
+
+/*# Validate a joint handle.
+ * @name b2d.joint.is_valid
+ * @param joint [type: b2Joint] joint
+ * @return valid [type: boolean] true if the joint handle still refers to a live Box2D joint
+ */
+
+/*# Get the world owning a joint.
+ * @name b2d.joint.get_world
+ * @param joint [type: b2Joint] joint
+ * @return world [type: b2World] owning world
  */
 
 /*# Get the joint type.

--- a/engine/gamesys/src/gamesys/scripts/box2d/v3/script_box2d_shape_v3.cpp
+++ b/engine/gamesys/src/gamesys/scripts/box2d/v3/script_box2d_shape_v3.cpp
@@ -20,6 +20,7 @@
 #include <script/script.h>
 #include <gameobject/script.h>
 
+#include "gamesys.h"
 #include "script_box2d_v3.h"
 
 extern "C"
@@ -49,6 +50,37 @@ namespace dmGameSystem
     static dmVMath::Vector3 FromB2(const b2Vec2& p, float inv_scale)
     {
         return dmVMath::Vector3(p.x * inv_scale, p.y * inv_scale, 0);
+    }
+
+    static void PushMassData(lua_State* L, const b2MassData& mass_data)
+    {
+        lua_newtable(L);
+
+        lua_pushnumber(L, mass_data.mass);
+        lua_setfield(L, -2, "mass");
+
+        dmScript::PushVector3(L, FromB2(mass_data.center, GetInvPhysicsScale()));
+        lua_setfield(L, -2, "center");
+
+        lua_pushnumber(L, mass_data.rotationalInertia);
+        lua_setfield(L, -2, "inertia");
+    }
+
+    static void PushCastOutput(lua_State* L, const b2CastOutput& output)
+    {
+        lua_newtable(L);
+
+        dmScript::PushVector3(L, FromB2(output.point, GetInvPhysicsScale()));
+        lua_setfield(L, -2, "point");
+
+        dmScript::PushVector3(L, FromB2(output.normal, 1.0f));
+        lua_setfield(L, -2, "normal");
+
+        lua_pushnumber(L, output.fraction);
+        lua_setfield(L, -2, "fraction");
+
+        lua_pushinteger(L, output.iterations);
+        lua_setfield(L, -2, "iterations");
     }
 
     static bool TryGetNumberField(lua_State* L, int index, const char* field_name, float* out_value)
@@ -520,6 +552,45 @@ namespace dmGameSystem
         lua_setfield(L, -2, "group_index");
     }
 
+    static int Shape_IsValid(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        b2ShapeId* shape = ToShapeId(L, 1);
+        if (shape)
+        {
+            lua_pushboolean(L, b2Shape_IsValid(*shape));
+            return 1;
+        }
+
+        b2BodyId* body = CheckBody(L, 1);
+        int shape_index = luaL_checkinteger(L, 2);
+        lua_pushboolean(L, b2Shape_IsValid(GetShapeByIndex(*body, shape_index)));
+        return 1;
+    }
+
+    static int Shape_GetBody(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        b2BodyId body = b2Shape_GetBody(CheckShape(L, 1));
+        CollisionComponent* component = (CollisionComponent*)b2Body_GetUserData(body);
+        if (!component || !component->m_Instance)
+        {
+            return luaL_error(L, "Could not resolve shape body owner.");
+        }
+
+        dmGameObject::HCollection collection = dmGameObject::GetCollection(component->m_Instance);
+        dmhash_t instance_id = dmGameObject::GetIdentifier(component->m_Instance);
+        PushBody(L, &body, collection, instance_id);
+        return 1;
+    }
+
+    static int Shape_GetWorld(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        PushWorldId(L, b2Shape_GetWorld(CheckShape(L, 1)));
+        return 1;
+    }
+
     static int Shape_GetType(lua_State* L)
     {
         DM_LUA_STACK_CHECK(L, 1);
@@ -652,6 +723,62 @@ namespace dmGameSystem
         return 0;
     }
 
+    static int Shape_EnableSensorEvents(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        b2Shape_EnableSensorEvents(CheckShape(L, 1), lua_toboolean(L, GetShapeValueIndex(L, 1)));
+        return 0;
+    }
+
+    static int Shape_AreSensorEventsEnabled(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        lua_pushboolean(L, b2Shape_AreSensorEventsEnabled(CheckShape(L, 1)));
+        return 1;
+    }
+
+    static int Shape_EnableContactEvents(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        b2Shape_EnableContactEvents(CheckShape(L, 1), lua_toboolean(L, GetShapeValueIndex(L, 1)));
+        return 0;
+    }
+
+    static int Shape_AreContactEventsEnabled(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        lua_pushboolean(L, b2Shape_AreContactEventsEnabled(CheckShape(L, 1)));
+        return 1;
+    }
+
+    static int Shape_EnablePreSolveEvents(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        b2Shape_EnablePreSolveEvents(CheckShape(L, 1), lua_toboolean(L, GetShapeValueIndex(L, 1)));
+        return 0;
+    }
+
+    static int Shape_ArePreSolveEventsEnabled(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        lua_pushboolean(L, b2Shape_ArePreSolveEventsEnabled(CheckShape(L, 1)));
+        return 1;
+    }
+
+    static int Shape_EnableHitEvents(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        b2Shape_EnableHitEvents(CheckShape(L, 1), lua_toboolean(L, GetShapeValueIndex(L, 1)));
+        return 0;
+    }
+
+    static int Shape_AreHitEventsEnabled(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        lua_pushboolean(L, b2Shape_AreHitEventsEnabled(CheckShape(L, 1)));
+        return 1;
+    }
+
     static int Shape_GetFilterData(lua_State* L)
     {
         DM_LUA_STACK_CHECK(L, 1);
@@ -692,6 +819,28 @@ namespace dmGameSystem
         return 1;
     }
 
+    static int Shape_RayCast(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        b2ShapeId shape = CheckShape(L, 1);
+        int value_index = GetShapeValueIndex(L, 1);
+
+        b2RayCastInput input = {};
+        input.origin = CheckVec2(L, value_index, GetPhysicsScale());
+        input.translation = CheckVec2(L, value_index + 1, GetPhysicsScale());
+        input.maxFraction = lua_isnoneornil(L, value_index + 2) ? 1.0f : luaL_checknumber(L, value_index + 2);
+
+        b2CastOutput output = b2Shape_RayCast(shape, &input);
+        if (!output.hit)
+        {
+            lua_pushnil(L);
+            return 1;
+        }
+
+        PushCastOutput(L, output);
+        return 1;
+    }
+
     static int Shape_GetAABB(lua_State* L)
     {
         DM_LUA_STACK_CHECK(L, 1);
@@ -705,6 +854,92 @@ namespace dmGameSystem
 
         dmScript::PushVector3(L, FromB2(aabb.upperBound, GetInvPhysicsScale()));
         lua_setfield(L, -2, "upper");
+        return 1;
+    }
+
+    static int Shape_GetContactCapacity(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        lua_pushinteger(L, b2Shape_GetContactCapacity(CheckShape(L, 1)));
+        return 1;
+    }
+
+    static int Shape_GetContactData(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        b2ShapeId shape = CheckShape(L, 1);
+        int capacity = b2Shape_GetContactCapacity(shape);
+
+        lua_newtable(L);
+        if (capacity == 0)
+        {
+            return 1;
+        }
+
+        dmArray<b2ContactData> contact_data;
+        contact_data.SetCapacity(capacity);
+        contact_data.SetSize(capacity);
+        int count = b2Shape_GetContactData(shape, contact_data.Begin(), capacity);
+        for (int i = 0; i < count; ++i)
+        {
+            PushContactData(L, contact_data[i]);
+            lua_rawseti(L, -2, i + 1);
+        }
+        return 1;
+    }
+
+    static int Shape_GetSensorCapacity(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        lua_pushinteger(L, b2Shape_GetSensorCapacity(CheckShape(L, 1)));
+        return 1;
+    }
+
+    static int Shape_GetSensorOverlaps(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        b2ShapeId shape = CheckShape(L, 1);
+        int capacity = b2Shape_GetSensorCapacity(shape);
+
+        lua_newtable(L);
+        if (capacity == 0)
+        {
+            return 1;
+        }
+
+        dmArray<b2ShapeId> overlaps;
+        overlaps.SetCapacity(capacity);
+        overlaps.SetSize(capacity);
+        int count = b2Shape_GetSensorOverlaps(shape, overlaps.Begin(), capacity);
+        int result_index = 1;
+        for (int i = 0; i < count; ++i)
+        {
+            if (!b2Shape_IsValid(overlaps[i]))
+            {
+                continue;
+            }
+
+            b2BodyId body = b2Shape_GetBody(overlaps[i]);
+            PushShapeInfo(L, overlaps[i], GetShapeIndex(body, overlaps[i]));
+            lua_rawseti(L, -2, result_index);
+            ++result_index;
+        }
+        return 1;
+    }
+
+    static int Shape_GetMassData(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        PushMassData(L, b2Shape_GetMassData(CheckShape(L, 1)));
+        return 1;
+    }
+
+    static int Shape_GetClosestPoint(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        b2ShapeId shape = CheckShape(L, 1);
+        b2Vec2 target = CheckVec2(L, GetShapeValueIndex(L, 1), GetPhysicsScale());
+        dmScript::PushVector3(L, FromB2(b2Shape_GetClosestPoint(shape, target), GetInvPhysicsScale()));
         return 1;
     }
 
@@ -744,8 +979,11 @@ namespace dmGameSystem
 
     static const luaL_reg Shape_functions[] =
     {
+        {"is_valid", Shape_IsValid},
         {"get_shape", Shape_GetShape},
         {"set_shape", Shape_SetShape},
+        {"get_body", Shape_GetBody},
+        {"get_world", Shape_GetWorld},
         {"get_type", Shape_GetType},
         {"is_sensor", Shape_IsSensor},
         {"set_sensor", Shape_SetSensor},
@@ -757,11 +995,26 @@ namespace dmGameSystem
         {"set_restitution", Shape_SetRestitution},
         {"get_material", Shape_GetMaterial},
         {"set_material", Shape_SetMaterial},
+        {"enable_sensor_events", Shape_EnableSensorEvents},
+        {"are_sensor_events_enabled", Shape_AreSensorEventsEnabled},
+        {"enable_contact_events", Shape_EnableContactEvents},
+        {"are_contact_events_enabled", Shape_AreContactEventsEnabled},
+        {"enable_pre_solve_events", Shape_EnablePreSolveEvents},
+        {"are_pre_solve_events_enabled", Shape_ArePreSolveEventsEnabled},
+        {"enable_hit_events", Shape_EnableHitEvents},
+        {"are_hit_events_enabled", Shape_AreHitEventsEnabled},
         {"get_filter_data", Shape_GetFilterData},
         {"set_filter_data", Shape_SetFilterData},
         {"refilter", Shape_Refilter},
         {"test_point", Shape_TestPoint},
+        {"ray_cast", Shape_RayCast},
         {"get_aabb", Shape_GetAABB},
+        {"get_contact_capacity", Shape_GetContactCapacity},
+        {"get_contact_data", Shape_GetContactData},
+        {"get_sensor_capacity", Shape_GetSensorCapacity},
+        {"get_sensor_overlaps", Shape_GetSensorOverlaps},
+        {"get_mass_data", Shape_GetMassData},
+        {"get_closest_point", Shape_GetClosestPoint},
         {0,0}
     };
 
@@ -899,4 +1152,116 @@ namespace dmGameSystem
  * @name b2d.shape.set_material
  * @param shape_id [type: b2Shape] shape handle from a shape info table, or pass `body, shape_index`
  * @param material [type: number] shape material id
+ */
+
+/*# Validate a shape handle.
+ * @name b2d.shape.is_valid
+ * @param shape_id [type: b2Shape] shape handle from a shape info table, or pass `body, shape_index`
+ * @return valid [type: boolean] true if the shape handle still refers to a live Box2D shape
+ */
+
+/*# Get the body owning a shape.
+ * @name b2d.shape.get_body
+ * @param shape_id [type: b2Shape] shape handle from a shape info table, or pass `body, shape_index`
+ * @return body [type: b2Body] owning body
+ */
+
+/*# Get the world owning a shape.
+ * @name b2d.shape.get_world
+ * @param shape_id [type: b2Shape] shape handle from a shape info table, or pass `body, shape_index`
+ * @return world [type: b2World] owning world
+ */
+
+/*# Enable or disable sensor events for a shape.
+ * @name b2d.shape.enable_sensor_events
+ * @param shape_id [type: b2Shape] shape handle from a shape info table, or pass `body, shape_index`
+ * @param enable [type: boolean] true to enable sensor events
+ */
+
+/*# Check if sensor events are enabled for a shape.
+ * @name b2d.shape.are_sensor_events_enabled
+ * @param shape_id [type: b2Shape] shape handle from a shape info table, or pass `body, shape_index`
+ * @return enabled [type: boolean] true if sensor events are enabled
+ */
+
+/*# Enable or disable contact events for a shape.
+ * @name b2d.shape.enable_contact_events
+ * @param shape_id [type: b2Shape] shape handle from a shape info table, or pass `body, shape_index`
+ * @param enable [type: boolean] true to enable contact events
+ */
+
+/*# Check if contact events are enabled for a shape.
+ * @name b2d.shape.are_contact_events_enabled
+ * @param shape_id [type: b2Shape] shape handle from a shape info table, or pass `body, shape_index`
+ * @return enabled [type: boolean] true if contact events are enabled
+ */
+
+/*# Enable or disable pre-solve events for a shape.
+ * @name b2d.shape.enable_pre_solve_events
+ * @param shape_id [type: b2Shape] shape handle from a shape info table, or pass `body, shape_index`
+ * @param enable [type: boolean] true to enable pre-solve events
+ */
+
+/*# Check if pre-solve events are enabled for a shape.
+ * @name b2d.shape.are_pre_solve_events_enabled
+ * @param shape_id [type: b2Shape] shape handle from a shape info table, or pass `body, shape_index`
+ * @return enabled [type: boolean] true if pre-solve events are enabled
+ */
+
+/*# Enable or disable hit events for a shape.
+ * @name b2d.shape.enable_hit_events
+ * @param shape_id [type: b2Shape] shape handle from a shape info table, or pass `body, shape_index`
+ * @param enable [type: boolean] true to enable hit events
+ */
+
+/*# Check if hit events are enabled for a shape.
+ * @name b2d.shape.are_hit_events_enabled
+ * @param shape_id [type: b2Shape] shape handle from a shape info table, or pass `body, shape_index`
+ * @return enabled [type: boolean] true if hit events are enabled
+ */
+
+/*# Ray cast a shape directly.
+ * @name b2d.shape.ray_cast
+ * @param shape_id [type: b2Shape] shape handle from a shape info table, or pass `body, shape_index`
+ * @param origin [type: vector3] world ray origin
+ * @param translation [type: vector3] world ray translation
+ * @param max_fraction [type: number] optional maximum translation fraction, defaults to 1
+ * @return hit [type: table] hit table with `point`, `normal`, `fraction`, and `iterations`, or nil
+ */
+
+/*# Get shape contact capacity.
+ * @name b2d.shape.get_contact_capacity
+ * @param shape_id [type: b2Shape] shape handle from a shape info table, or pass `body, shape_index`
+ * @return capacity [type: number] maximum contact data count
+ */
+
+/*# Get touching contact data for a shape.
+ * @name b2d.shape.get_contact_data
+ * @param shape_id [type: b2Shape] shape handle from a shape info table, or pass `body, shape_index`
+ * @return contacts [type: table] array of contact tables
+ */
+
+/*# Get sensor overlap capacity.
+ * @name b2d.shape.get_sensor_capacity
+ * @param shape_id [type: b2Shape] shape handle from a shape info table, or pass `body, shape_index`
+ * @return capacity [type: number] maximum sensor overlap count
+ */
+
+/*# Get sensor overlaps.
+ * @name b2d.shape.get_sensor_overlaps
+ * @param shape_id [type: b2Shape] shape handle from a shape info table, or pass `body, shape_index`
+ * @return overlaps [type: table] array of shape info tables
+ */
+
+/*# Get mass data for a shape.
+ * @name b2d.shape.get_mass_data
+ * @param shape_id [type: b2Shape] shape handle from a shape info table, or pass `body, shape_index`
+ * @return data [type: table] table with `mass`, `center`, and `inertia`
+ */
+
+/*# Get the closest point on a shape.
+ * @name b2d.shape.get_closest_point
+ * @param shape_id [type: b2Shape] shape handle from a shape info table, or pass `body, shape_index`
+ * @param target [type: vector3] world target point
+ * @return point [type: vector3] closest world point on the shape
  */

--- a/engine/gamesys/src/gamesys/scripts/box2d/v3/script_box2d_shape_v3.cpp
+++ b/engine/gamesys/src/gamesys/scripts/box2d/v3/script_box2d_shape_v3.cpp
@@ -30,6 +30,15 @@ extern "C"
 
 namespace dmGameSystem
 {
+    static uint32_t TYPE_HASH_SHAPE = 0;
+
+    #define BOX2D_TYPE_NAME_SHAPE "b2shape"
+
+    struct B2DLuaShape
+    {
+        b2ShapeId m_Shape;
+    };
+
     static b2Vec2 CheckVec2(lua_State* L, int index, float scale)
     {
         dmVMath::Vector3* v = dmScript::CheckVector3(L, index);
@@ -167,7 +176,7 @@ namespace dmGameSystem
             return shape_def;
         }
 
-        if (type == SHAPE_TYPE_EDGE)
+        if (type == SHAPE_TYPE_SEGMENT)
         {
             shape_def.m_Type = B2DShapeDef::TYPE_SEGMENT;
 
@@ -277,6 +286,13 @@ namespace dmGameSystem
             shape_create_def.material.restitution = value;
         }
 
+        lua_getfield(L, index, "material");
+        if (!lua_isnil(L, -1))
+        {
+            shape_create_def.material.userMaterialId = luaL_checkinteger(L, -1);
+        }
+        lua_pop(L, 1);
+
         if (TryGetNumberField(L, index, "density", &value))
         {
             shape_create_def.density = value;
@@ -306,6 +322,37 @@ namespace dmGameSystem
         lua_pop(L, 1);
 
         *out_shape_create_def = shape_create_def;
+    }
+
+    static B2DLuaShape* CheckShapeInternal(lua_State* L, int index)
+    {
+        return (B2DLuaShape*)dmScript::CheckUserType(L, index, TYPE_HASH_SHAPE, "Expected user type " BOX2D_TYPE_NAME_SHAPE);
+    }
+
+    b2ShapeId* CheckShapeId(lua_State* L, int index)
+    {
+        B2DLuaShape* luashape = CheckShapeInternal(L, index);
+        if (!b2Shape_IsValid(luashape->m_Shape))
+        {
+            luaL_error(L, "Invalid b2shape handle.");
+            return 0;
+        }
+        return &luashape->m_Shape;
+    }
+
+    b2ShapeId* ToShapeId(lua_State* L, int index)
+    {
+        B2DLuaShape* luashape = (B2DLuaShape*)dmScript::ToUserType(L, index, TYPE_HASH_SHAPE);
+        return luashape ? &luashape->m_Shape : 0;
+    }
+
+    void PushShapeId(lua_State* L, b2ShapeId shape_id)
+    {
+        B2DLuaShape* luashape = (B2DLuaShape*)lua_newuserdata(L, sizeof(B2DLuaShape));
+        luashape->m_Shape = shape_id;
+
+        luaL_getmetatable(L, BOX2D_TYPE_NAME_SHAPE);
+        lua_setmetatable(L, -2);
     }
 
     void PushShape(lua_State* L, b2ShapeId shape_id)
@@ -348,7 +395,7 @@ namespace dmGameSystem
             case b2_segmentShape:
             {
                 b2Segment segment = b2Shape_GetSegment(shape_id);
-                lua_pushinteger(L, SHAPE_TYPE_EDGE);
+                lua_pushinteger(L, SHAPE_TYPE_SEGMENT);
                 lua_setfield(L, -2, "type");
 
                 dmScript::PushVector3(L, FromB2(segment.point1, GetInvPhysicsScale()));
@@ -362,7 +409,7 @@ namespace dmGameSystem
             case b2_chainSegmentShape:
             {
                 b2ChainSegment segment = b2Shape_GetChainSegment(shape_id);
-                lua_pushinteger(L, SHAPE_TYPE_EDGE);
+                lua_pushinteger(L, SHAPE_TYPE_SEGMENT);
                 lua_setfield(L, -2, "type");
 
                 dmScript::PushVector3(L, FromB2(segment.ghost1, GetInvPhysicsScale()));
@@ -403,7 +450,7 @@ namespace dmGameSystem
         }
     }
 
-    static b2ShapeId CheckShape(lua_State* L, int body_index, int shape_index_index)
+    static b2ShapeId CheckShapeByBodyIndex(lua_State* L, int body_index, int shape_index_index)
     {
         b2BodyId* body = CheckBody(L, body_index);
         int shape_index = luaL_checkinteger(L, shape_index_index);
@@ -416,12 +463,46 @@ namespace dmGameSystem
         return shape;
     }
 
+    static b2ShapeId CheckShape(lua_State* L, int index)
+    {
+        b2ShapeId* shape = ToShapeId(L, index);
+        if (shape)
+        {
+            if (!b2Shape_IsValid(*shape))
+            {
+                luaL_error(L, "Invalid b2shape handle.");
+                return b2_nullShapeId;
+            }
+            return *shape;
+        }
+
+        return CheckShapeByBodyIndex(L, index, index + 1);
+    }
+
+    static int GetShapeArgCount(lua_State* L, int index)
+    {
+        return ToShapeId(L, index) ? 1 : 2;
+    }
+
+    static int GetShapeValueIndex(lua_State* L, int index)
+    {
+        return index + GetShapeArgCount(L, index);
+    }
+
     static void CheckChildIndex(lua_State* L, int index)
     {
         int child_index = luaL_checkinteger(L, index);
         if (child_index != 1)
         {
             luaL_error(L, "child_index %d out of range [1, 1].", child_index);
+        }
+    }
+
+    static void CheckOptionalChildIndex(lua_State* L, int index)
+    {
+        if (!lua_isnoneornil(L, index))
+        {
+            CheckChildIndex(L, index);
         }
     }
 
@@ -442,7 +523,7 @@ namespace dmGameSystem
     static int Shape_GetType(lua_State* L)
     {
         DM_LUA_STACK_CHECK(L, 1);
-        b2ShapeId shape = CheckShape(L, 1, 2);
+        b2ShapeId shape = CheckShape(L, 1);
         lua_pushinteger(L, NormalizeShapeTypeForLua(b2Shape_GetType(shape)));
         return 1;
     }
@@ -450,20 +531,15 @@ namespace dmGameSystem
     static int Shape_GetShape(lua_State* L)
     {
         DM_LUA_STACK_CHECK(L, 1);
-        PushShape(L, CheckShape(L, 1, 2));
+        PushShape(L, CheckShape(L, 1));
         return 1;
     }
 
     static int Shape_SetShape(lua_State* L)
     {
         DM_LUA_STACK_CHECK(L, 0);
-        b2BodyId* body = CheckBody(L, 1);
-        int shape_index = luaL_checkinteger(L, 2);
-        b2ShapeId shape = GetShapeByIndex(*body, shape_index);
-        if (!b2Shape_IsValid(shape))
-        {
-            return luaL_error(L, "shape_index %d out of range.", shape_index);
-        }
+        b2ShapeId shape = CheckShape(L, 1);
+        int shape_def_index = GetShapeValueIndex(L, 1);
 
         b2ChainId parent_chain = b2Shape_GetParentChain(shape);
         if (b2Chain_IsValid(parent_chain))
@@ -477,7 +553,7 @@ namespace dmGameSystem
             return luaL_error(L, "Could not set shape. The world is locked.");
         }
 
-        B2DShapeDef shape_def = CheckShapeUpdateDef(L, 3);
+        B2DShapeDef shape_def = CheckShapeUpdateDef(L, shape_def_index);
         switch (shape_def.m_Type)
         {
             case B2DShapeDef::TYPE_CIRCLE:
@@ -494,10 +570,11 @@ namespace dmGameSystem
                 break;
         }
 
-        bool update_mass = lua_gettop(L) >= 4 && !lua_isnil(L, 4) && lua_toboolean(L, 4);
+        int update_mass_index = shape_def_index + 1;
+        bool update_mass = lua_gettop(L) >= update_mass_index && !lua_isnil(L, update_mass_index) && lua_toboolean(L, update_mass_index);
         if (update_mass)
         {
-            b2Body_ApplyMassFromShapes(*body);
+            b2Body_ApplyMassFromShapes(b2Shape_GetBody(shape));
         }
         return 0;
     }
@@ -505,7 +582,7 @@ namespace dmGameSystem
     static int Shape_IsSensor(lua_State* L)
     {
         DM_LUA_STACK_CHECK(L, 1);
-        lua_pushboolean(L, b2Shape_IsSensor(CheckShape(L, 1, 2)));
+        lua_pushboolean(L, b2Shape_IsSensor(CheckShape(L, 1)));
         return 1;
     }
 
@@ -518,52 +595,68 @@ namespace dmGameSystem
     static int Shape_GetDensity(lua_State* L)
     {
         DM_LUA_STACK_CHECK(L, 1);
-        lua_pushnumber(L, b2Shape_GetDensity(CheckShape(L, 1, 2)));
+        lua_pushnumber(L, b2Shape_GetDensity(CheckShape(L, 1)));
         return 1;
     }
 
     static int Shape_SetDensity(lua_State* L)
     {
         DM_LUA_STACK_CHECK(L, 0);
-        b2ShapeId shape = CheckShape(L, 1, 2);
-        bool update_mass = lua_gettop(L) >= 4 && !lua_isnil(L, 4) && lua_toboolean(L, 4);
-        b2Shape_SetDensity(shape, luaL_checknumber(L, 3), update_mass);
+        b2ShapeId shape = CheckShape(L, 1);
+        int value_index = GetShapeValueIndex(L, 1);
+        int update_mass_index = value_index + 1;
+        bool update_mass = lua_gettop(L) >= update_mass_index && !lua_isnil(L, update_mass_index) && lua_toboolean(L, update_mass_index);
+        b2Shape_SetDensity(shape, luaL_checknumber(L, value_index), update_mass);
         return 0;
     }
 
     static int Shape_GetFriction(lua_State* L)
     {
         DM_LUA_STACK_CHECK(L, 1);
-        lua_pushnumber(L, b2Shape_GetFriction(CheckShape(L, 1, 2)));
+        lua_pushnumber(L, b2Shape_GetFriction(CheckShape(L, 1)));
         return 1;
     }
 
     static int Shape_SetFriction(lua_State* L)
     {
         DM_LUA_STACK_CHECK(L, 0);
-        b2Shape_SetFriction(CheckShape(L, 1, 2), luaL_checknumber(L, 3));
+        b2Shape_SetFriction(CheckShape(L, 1), luaL_checknumber(L, GetShapeValueIndex(L, 1)));
         return 0;
     }
 
     static int Shape_GetRestitution(lua_State* L)
     {
         DM_LUA_STACK_CHECK(L, 1);
-        lua_pushnumber(L, b2Shape_GetRestitution(CheckShape(L, 1, 2)));
+        lua_pushnumber(L, b2Shape_GetRestitution(CheckShape(L, 1)));
         return 1;
     }
 
     static int Shape_SetRestitution(lua_State* L)
     {
         DM_LUA_STACK_CHECK(L, 0);
-        b2Shape_SetRestitution(CheckShape(L, 1, 2), luaL_checknumber(L, 3));
+        b2Shape_SetRestitution(CheckShape(L, 1), luaL_checknumber(L, GetShapeValueIndex(L, 1)));
+        return 0;
+    }
+
+    static int Shape_GetMaterial(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        lua_pushinteger(L, b2Shape_GetMaterial(CheckShape(L, 1)));
+        return 1;
+    }
+
+    static int Shape_SetMaterial(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        b2Shape_SetMaterial(CheckShape(L, 1), luaL_checkinteger(L, GetShapeValueIndex(L, 1)));
         return 0;
     }
 
     static int Shape_GetFilterData(lua_State* L)
     {
         DM_LUA_STACK_CHECK(L, 1);
-        b2ShapeId shape = CheckShape(L, 1, 2);
-        CheckChildIndex(L, 3);
+        b2ShapeId shape = CheckShape(L, 1);
+        CheckOptionalChildIndex(L, GetShapeValueIndex(L, 1));
         PushFilterData(L, b2Shape_GetFilter(shape));
         return 1;
     }
@@ -571,16 +664,21 @@ namespace dmGameSystem
     static int Shape_SetFilterData(lua_State* L)
     {
         DM_LUA_STACK_CHECK(L, 0);
-        b2ShapeId shape = CheckShape(L, 1, 2);
-        CheckChildIndex(L, 3);
-        b2Shape_SetFilter(shape, CheckFilterData(L, 4));
+        b2ShapeId shape = CheckShape(L, 1);
+        int filter_index = GetShapeValueIndex(L, 1);
+        if (!lua_istable(L, filter_index))
+        {
+            CheckOptionalChildIndex(L, filter_index);
+            ++filter_index;
+        }
+        b2Shape_SetFilter(shape, CheckFilterData(L, filter_index));
         return 0;
     }
 
     static int Shape_Refilter(lua_State* L)
     {
         DM_LUA_STACK_CHECK(L, 0);
-        b2ShapeId shape = CheckShape(L, 1, 2);
+        b2ShapeId shape = CheckShape(L, 1);
         b2Shape_SetFilter(shape, b2Shape_GetFilter(shape));
         return 0;
     }
@@ -588,8 +686,8 @@ namespace dmGameSystem
     static int Shape_TestPoint(lua_State* L)
     {
         DM_LUA_STACK_CHECK(L, 1);
-        b2ShapeId shape = CheckShape(L, 1, 2);
-        b2Vec2 point = CheckVec2(L, 3, GetPhysicsScale());
+        b2ShapeId shape = CheckShape(L, 1);
+        b2Vec2 point = CheckVec2(L, GetShapeValueIndex(L, 1), GetPhysicsScale());
         lua_pushboolean(L, b2Shape_TestPoint(shape, point));
         return 1;
     }
@@ -597,8 +695,8 @@ namespace dmGameSystem
     static int Shape_GetAABB(lua_State* L)
     {
         DM_LUA_STACK_CHECK(L, 1);
-        b2ShapeId shape = CheckShape(L, 1, 2);
-        CheckChildIndex(L, 3);
+        b2ShapeId shape = CheckShape(L, 1);
+        CheckOptionalChildIndex(L, GetShapeValueIndex(L, 1));
         b2AABB aabb = b2Shape_GetAABB(shape);
 
         lua_newtable(L);
@@ -609,6 +707,40 @@ namespace dmGameSystem
         lua_setfield(L, -2, "upper");
         return 1;
     }
+
+    static int Shape_tostring(lua_State *L)
+    {
+        B2DLuaShape* luashape = CheckShapeInternal(L, 1);
+        lua_pushfstring(L, "Box2D.%s = %p", BOX2D_TYPE_NAME_SHAPE, &luashape->m_Shape);
+        return 1;
+    }
+
+    static int Shape_eq(lua_State *L)
+    {
+        b2ShapeId* a = ToShapeId(L, 1);
+        b2ShapeId* b = ToShapeId(L, 2);
+        bool equal = false;
+        if (a && b)
+        {
+            b2ShapeId shape_a = *a;
+            b2ShapeId shape_b = *b;
+            equal = B2_ID_EQUALS(shape_a, shape_b);
+        }
+        lua_pushboolean(L, equal);
+        return 1;
+    }
+
+    static const luaL_reg Shape_methods[] =
+    {
+        {0,0}
+    };
+
+    static const luaL_reg Shape_meta[] =
+    {
+        {"__tostring", Shape_tostring},
+        {"__eq", Shape_eq},
+        {0,0}
+    };
 
     static const luaL_reg Shape_functions[] =
     {
@@ -623,6 +755,8 @@ namespace dmGameSystem
         {"set_friction", Shape_SetFriction},
         {"get_restitution", Shape_GetRestitution},
         {"set_restitution", Shape_SetRestitution},
+        {"get_material", Shape_GetMaterial},
+        {"set_material", Shape_SetMaterial},
         {"get_filter_data", Shape_GetFilterData},
         {"set_filter_data", Shape_SetFilterData},
         {"refilter", Shape_Refilter},
@@ -633,6 +767,8 @@ namespace dmGameSystem
 
     void ScriptBox2DInitializeShape(lua_State* L)
     {
+        TYPE_HASH_SHAPE = dmScript::RegisterUserType(L, BOX2D_TYPE_NAME_SHAPE, Shape_methods, Shape_meta);
+
         lua_newtable(L);
         luaL_register(L, 0, Shape_functions);
 
@@ -642,8 +778,8 @@ namespace dmGameSystem
 
         SET_CONSTANT(b2_circleShape, "SHAPE_TYPE_CIRCLE");
         SET_CONSTANT(b2_capsuleShape, "SHAPE_TYPE_CAPSULE");
+        SET_CONSTANT(SHAPE_TYPE_SEGMENT, "SHAPE_TYPE_SEGMENT");
         SET_CONSTANT(SHAPE_TYPE_EDGE, "SHAPE_TYPE_EDGE");
-        SET_CONSTANT(SHAPE_TYPE_EDGE, "SHAPE_TYPE_SEGMENT");
         SET_CONSTANT(b2_polygonShape, "SHAPE_TYPE_POLYGON");
         SET_CONSTANT(SHAPE_TYPE_BOX, "SHAPE_TYPE_BOX");
 
@@ -651,12 +787,19 @@ namespace dmGameSystem
 
         lua_setfield(L, -2, "shape");
     }
+
+    void ScriptBox2DFinalizeShape()
+    {
+        TYPE_HASH_SHAPE = 0;
+    }
 }
 
 /*# Box2D b2Shape documentation
  *
  * Constants and functions for Box2D v3 shape tables used with
  * `b2d.body.create_shape` and returned from `b2d.shape.get_shape`.
+ * Shape functions accept either a `b2Shape` handle as the first argument or
+ * the legacy `body, shape_index` argument pair.
  *
  * @document
  * @name b2d.shape
@@ -664,10 +807,15 @@ namespace dmGameSystem
  * @language Lua
  */
 
+/*# Box2D shape
+ * @typedef
+ * @name b2Shape
+ * @param value [type:userdata]
+ */
+
 /*# Get a shape's geometry.
  * @name b2d.shape.get_shape
- * @param body [type: b2Body] body
- * @param shape_index [type: number] 1-based shape index from `b2d.body.get_shapes`
+ * @param shape_id [type: b2Shape] shape handle from a shape info table, or pass `body, shape_index`
  * @return shape [type: table] shape table with numeric `type` from `b2d.shape.SHAPE_TYPE_*`
  */
 
@@ -677,9 +825,8 @@ namespace dmGameSystem
  * updated unless `update_mass` is true.
  * @warning This function is locked during callbacks.
  * @name b2d.shape.set_shape
- * @param body [type: b2Body] body
- * @param shape_index [type: number] 1-based shape index from `b2d.body.get_shapes`
- * @param shape [type: table] shape table with numeric `type` from `b2d.shape.SHAPE_TYPE_*`
+ * @param shape_id [type: b2Shape] shape handle from a shape info table, or pass `body, shape_index`
+ * @param definition [type: table] shape table with numeric `type` from `b2d.shape.SHAPE_TYPE_*`
  * @param update_mass [type: boolean] true to reset body mass from shapes
  * @examples
  *
@@ -691,9 +838,9 @@ namespace dmGameSystem
  * circle.center = vmath.vector3(24, 0, 0)
  * b2d.shape.set_shape(body, 1, circle, true)
  *
- * -- Replace an edge shape's local endpoints.
+ * -- Replace a segment shape's local endpoints.
  * b2d.shape.set_shape(body, 2, {
- *     type = b2d.shape.SHAPE_TYPE_EDGE,
+ *     type = b2d.shape.SHAPE_TYPE_SEGMENT,
  *     v1 = vmath.vector3(-32, 0, 0),
  *     v2 = vmath.vector3( 32, 0, 0),
  * })
@@ -719,7 +866,13 @@ namespace dmGameSystem
  * @constant
  */
 
-/*# Edge shape type.
+/*# Segment shape type.
+ * @name b2d.shape.SHAPE_TYPE_SEGMENT
+ * @constant
+ */
+
+/*# Edge shape type alias.
+ * Compatibility alias for `b2d.shape.SHAPE_TYPE_SEGMENT`.
  * @name b2d.shape.SHAPE_TYPE_EDGE
  * @constant
  */
@@ -733,4 +886,17 @@ namespace dmGameSystem
  * Uses the polygon enum value, but indicates the `hx`/`hy` box convenience format.
  * @name b2d.shape.SHAPE_TYPE_BOX
  * @constant
+ */
+
+/*# Get shape material id.
+ * @name b2d.shape.get_material
+ * @param shape_id [type: b2Shape] shape handle from a shape info table, or pass `body, shape_index`
+ * @return material [type: number] shape material id
+ */
+
+/*# Set shape material id.
+ * @warning This function is locked during callbacks.
+ * @name b2d.shape.set_material
+ * @param shape_id [type: b2Shape] shape handle from a shape info table, or pass `body, shape_index`
+ * @param material [type: number] shape material id
  */

--- a/engine/gamesys/src/gamesys/scripts/box2d/v3/script_box2d_v3.h
+++ b/engine/gamesys/src/gamesys/scripts/box2d/v3/script_box2d_v3.h
@@ -23,8 +23,9 @@ namespace dmGameSystem
 {
     enum
     {
-        SHAPE_TYPE_BOX  = b2_polygonShape,
-        SHAPE_TYPE_EDGE = b2_segmentShape,
+        SHAPE_TYPE_BOX     = b2_polygonShape,
+        SHAPE_TYPE_SEGMENT = b2_segmentShape,
+        SHAPE_TYPE_EDGE    = SHAPE_TYPE_SEGMENT,
     };
 
     struct B2DShapeDef
@@ -53,26 +54,40 @@ namespace dmGameSystem
         {
             case b2_segmentShape:
             case b2_chainSegmentShape:
-                return SHAPE_TYPE_EDGE;
+                return SHAPE_TYPE_SEGMENT;
             default:
                 return type;
         }
     }
 
     b2BodyId*   CheckBody(struct lua_State* L, int index);
+    b2WorldId*  CheckWorld(struct lua_State* L, int index);
+    b2ShapeId*  CheckShapeId(struct lua_State* L, int index);
+    b2ShapeId*  ToShapeId(struct lua_State* L, int index);
     dmGameObject::HCollection GetBodyCollection(struct lua_State* L, int index);
     b2ShapeId   GetShapeByIndex(b2BodyId body, int shape_index);
+    int         GetShapeIndex(b2BodyId body, b2ShapeId shape);
     bool        IsJointTracked(b2JointId joint_id);
     void        PushJoint(struct lua_State* L, b2JointId joint_id, dmGameObject::HCollection collection);
+    void        PushWorldId(struct lua_State* L, b2WorldId world_id);
+    void        PushChain(struct lua_State* L, b2ChainId chain_id);
+    void        PushShapeId(struct lua_State* L, b2ShapeId shape_id);
+    void        PushShapeInfo(struct lua_State* L, b2ShapeId shape, int shape_index);
     B2DShapeDef CheckShapeDef(struct lua_State* L, int index);
     void        CheckShapeCreateDef(struct lua_State* L, int index, B2DShapeDef* out_shape_def, b2ShapeDef* out_shape_create_def);
     void        PushShape(struct lua_State* L, b2ShapeId shape_id);
+    int         Body_CreateChain(struct lua_State* L);
     void        ScriptBox2DInitializeBody(struct lua_State* L);
     void        ScriptBox2DInvalidateBody(void* body);
     void        ScriptBox2DFinalizeBody();
+    void        ScriptBox2DInitializeWorld(struct lua_State* L);
+    void        ScriptBox2DFinalizeWorld();
     void        ScriptBox2DInitializeJoint(struct lua_State* L);
     void        ScriptBox2DFinalizeJoint();
     void        ScriptBox2DInitializeShape(struct lua_State* L);
+    void        ScriptBox2DFinalizeShape();
+    void        ScriptBox2DInitializeChain(struct lua_State* L);
+    void        ScriptBox2DFinalizeChain();
 }
 
 #endif // DM_GAMESYS_SCRIPT_BOX2D_V3_H

--- a/engine/gamesys/src/gamesys/scripts/box2d/v3/script_box2d_v3.h
+++ b/engine/gamesys/src/gamesys/scripts/box2d/v3/script_box2d_v3.h
@@ -61,6 +61,7 @@ namespace dmGameSystem
     }
 
     b2BodyId*   CheckBody(struct lua_State* L, int index);
+    void        PushBody(struct lua_State* L, void* body, dmGameObject::HCollection collection, dmhash_t instance_id);
     b2WorldId*  CheckWorld(struct lua_State* L, int index);
     b2ShapeId*  CheckShapeId(struct lua_State* L, int index);
     b2ShapeId*  ToShapeId(struct lua_State* L, int index);
@@ -73,6 +74,7 @@ namespace dmGameSystem
     void        PushChain(struct lua_State* L, b2ChainId chain_id);
     void        PushShapeId(struct lua_State* L, b2ShapeId shape_id);
     void        PushShapeInfo(struct lua_State* L, b2ShapeId shape, int shape_index);
+    void        PushContactData(struct lua_State* L, const b2ContactData& contact_data);
     B2DShapeDef CheckShapeDef(struct lua_State* L, int index);
     void        CheckShapeCreateDef(struct lua_State* L, int index, B2DShapeDef* out_shape_def, b2ShapeDef* out_shape_create_def);
     void        PushShape(struct lua_State* L, b2ShapeId shape_id);

--- a/engine/gamesys/src/gamesys/scripts/box2d/v3/script_box2d_world_v3.cpp
+++ b/engine/gamesys/src/gamesys/scripts/box2d/v3/script_box2d_world_v3.cpp
@@ -1,0 +1,1080 @@
+// Copyright 2020-2026 The Defold Foundation
+// Copyright 2014-2020 King
+// Copyright 2009-2014 Ragnar Svensson, Christian Murray
+// Licensed under the Defold License version 1.0 (the "License"); you may not use
+// this file except in compliance with the License.
+
+#include <string.h>
+
+#include <box2d/box2d.h>
+
+#include <dlib/array.h>
+#include <script/script.h>
+#include <gameobject/script.h>
+
+#include "script_box2d_v3.h"
+
+extern "C"
+{
+#include <lua/lauxlib.h>
+#include <lua/lualib.h>
+}
+
+namespace dmGameSystem
+{
+    static uint32_t TYPE_HASH_WORLD = 0;
+
+    #define BOX2D_TYPE_NAME_WORLD "b2world"
+
+    struct B2DLuaWorld
+    {
+        b2WorldId m_World;
+    };
+
+    struct QueryContext
+    {
+        lua_State* m_L;
+        int        m_TableIndex;
+        int        m_Count;
+        int        m_MaxResults;
+    };
+
+    static b2Vec2 CheckVec2(lua_State* L, int index, float scale)
+    {
+        dmVMath::Vector3* v = dmScript::CheckVector3(L, index);
+        b2Vec2 b2v = { v->getX() * scale, v->getY() * scale };
+        return b2v;
+    }
+
+    static dmVMath::Vector3 FromB2(const b2Vec2& p, float inv_scale)
+    {
+        return dmVMath::Vector3(p.x * inv_scale, p.y * inv_scale, 0);
+    }
+
+    static int AbsIndex(lua_State* L, int index)
+    {
+        return index < 0 ? lua_gettop(L) + index + 1 : index;
+    }
+
+    static bool HasResultCapacity(const QueryContext* context)
+    {
+        return context->m_MaxResults <= 0 || context->m_Count < context->m_MaxResults;
+    }
+
+    static int CheckMaxResults(lua_State* L, int index)
+    {
+        if (lua_isnoneornil(L, index))
+        {
+            return 0;
+        }
+
+        int max_results = luaL_checkinteger(L, index);
+        if (max_results < 0)
+        {
+            luaL_error(L, "max_results must be >= 0.");
+            return 0;
+        }
+        return max_results;
+    }
+
+    static B2DLuaWorld* CheckWorldInternal(lua_State* L, int index)
+    {
+        return (B2DLuaWorld*)dmScript::CheckUserType(L, index, TYPE_HASH_WORLD, "Expected user type " BOX2D_TYPE_NAME_WORLD);
+    }
+
+    b2WorldId* CheckWorld(lua_State* L, int index)
+    {
+        B2DLuaWorld* luaworld = CheckWorldInternal(L, index);
+        if (!b2World_IsValid(luaworld->m_World))
+        {
+            luaL_error(L, "Invalid b2world handle.");
+            return 0;
+        }
+        return &luaworld->m_World;
+    }
+
+    static b2WorldId* ToWorld(lua_State* L, int index)
+    {
+        B2DLuaWorld* luaworld = (B2DLuaWorld*)dmScript::ToUserType(L, index, TYPE_HASH_WORLD);
+        return luaworld ? &luaworld->m_World : 0;
+    }
+
+    void PushWorldId(lua_State* L, b2WorldId world_id)
+    {
+        B2DLuaWorld* luaworld = (B2DLuaWorld*)lua_newuserdata(L, sizeof(B2DLuaWorld));
+        luaworld->m_World = world_id;
+
+        luaL_getmetatable(L, BOX2D_TYPE_NAME_WORLD);
+        lua_setmetatable(L, -2);
+    }
+
+    void PushWorld(lua_State* L, void* world)
+    {
+        if (world)
+        {
+            PushWorldId(L, *(b2WorldId*)world);
+        }
+        else
+        {
+            lua_pushnil(L);
+        }
+    }
+
+    static void CheckWorldUnlocked(lua_State* L, b2WorldId world, const char* function_name)
+    {
+        if (b2World_IsLocked(world))
+        {
+            luaL_error(L, "Could not call b2d.world.%s. The world is locked.", function_name);
+        }
+    }
+
+    static b2QueryFilter CheckQueryFilter(lua_State* L, int index)
+    {
+        b2QueryFilter filter = b2DefaultQueryFilter();
+        if (lua_isnoneornil(L, index))
+        {
+            return filter;
+        }
+
+        luaL_checktype(L, index, LUA_TTABLE);
+
+        lua_getfield(L, index, "category_bits");
+        if (!lua_isnil(L, -1))
+        {
+            filter.categoryBits = (uint64_t)luaL_checknumber(L, -1);
+        }
+        lua_pop(L, 1);
+
+        lua_getfield(L, index, "mask_bits");
+        if (!lua_isnil(L, -1))
+        {
+            filter.maskBits = (uint64_t)luaL_checknumber(L, -1);
+        }
+        lua_pop(L, 1);
+
+        return filter;
+    }
+
+    static b2AABB CheckAABB(lua_State* L, int index)
+    {
+        luaL_checktype(L, index, LUA_TTABLE);
+
+        b2AABB aabb;
+
+        lua_getfield(L, index, "lower");
+        aabb.lowerBound = CheckVec2(L, -1, GetPhysicsScale());
+        lua_pop(L, 1);
+
+        lua_getfield(L, index, "upper");
+        aabb.upperBound = CheckVec2(L, -1, GetPhysicsScale());
+        lua_pop(L, 1);
+
+        return aabb;
+    }
+
+    static b2Capsule CheckCapsule(lua_State* L, int index)
+    {
+        luaL_checktype(L, index, LUA_TTABLE);
+
+        b2Capsule capsule;
+
+        lua_getfield(L, index, "center1");
+        capsule.center1 = CheckVec2(L, -1, GetPhysicsScale());
+        lua_pop(L, 1);
+
+        lua_getfield(L, index, "center2");
+        capsule.center2 = CheckVec2(L, -1, GetPhysicsScale());
+        lua_pop(L, 1);
+
+        lua_getfield(L, index, "radius");
+        capsule.radius = luaL_checknumber(L, -1) * GetPhysicsScale();
+        lua_pop(L, 1);
+
+        return capsule;
+    }
+
+    static b2ShapeProxy MakeShapeProxy(const B2DShapeDef& shape_def)
+    {
+        b2ShapeProxy proxy = {};
+
+        switch (shape_def.m_Type)
+        {
+            case B2DShapeDef::TYPE_CIRCLE:
+                proxy.points[0] = shape_def.m_Circle.center;
+                proxy.count = 1;
+                proxy.radius = shape_def.m_Circle.radius;
+                break;
+            case B2DShapeDef::TYPE_CAPSULE:
+                proxy.points[0] = shape_def.m_Capsule.center1;
+                proxy.points[1] = shape_def.m_Capsule.center2;
+                proxy.count = 2;
+                proxy.radius = shape_def.m_Capsule.radius;
+                break;
+            case B2DShapeDef::TYPE_SEGMENT:
+                proxy.points[0] = shape_def.m_Segment.point1;
+                proxy.points[1] = shape_def.m_Segment.point2;
+                proxy.count = 2;
+                proxy.radius = 0.0f;
+                break;
+            case B2DShapeDef::TYPE_POLYGON:
+                proxy.count = shape_def.m_Polygon.count;
+                proxy.radius = shape_def.m_Polygon.radius;
+                for (int i = 0; i < shape_def.m_Polygon.count; ++i)
+                {
+                    proxy.points[i] = shape_def.m_Polygon.vertices[i];
+                }
+                break;
+        }
+
+        return proxy;
+    }
+
+    static void PushTreeStats(lua_State* L, const b2TreeStats& stats)
+    {
+        lua_newtable(L);
+
+        lua_pushinteger(L, stats.nodeVisits);
+        lua_setfield(L, -2, "node_visits");
+
+        lua_pushinteger(L, stats.leafVisits);
+        lua_setfield(L, -2, "leaf_visits");
+    }
+
+    static void PushShapeInfoForShape(lua_State* L, b2ShapeId shape)
+    {
+        b2BodyId body = b2Shape_GetBody(shape);
+        PushShapeInfo(L, shape, GetShapeIndex(body, shape));
+    }
+
+    static void PushCastHit(lua_State* L, b2ShapeId shape, b2Vec2 point, b2Vec2 normal, float fraction)
+    {
+        lua_newtable(L);
+
+        PushShapeInfoForShape(L, shape);
+        lua_setfield(L, -2, "shape");
+
+        dmScript::PushVector3(L, FromB2(point, GetInvPhysicsScale()));
+        lua_setfield(L, -2, "point");
+
+        dmScript::PushVector3(L, FromB2(normal, 1.0f));
+        lua_setfield(L, -2, "normal");
+
+        lua_pushnumber(L, fraction);
+        lua_setfield(L, -2, "fraction");
+    }
+
+    static bool OverlapResultCallback(b2ShapeId shape_id, void* user_context)
+    {
+        QueryContext* context = (QueryContext*)user_context;
+        if (!HasResultCapacity(context))
+        {
+            return false;
+        }
+
+        PushShapeInfoForShape(context->m_L, shape_id);
+        lua_rawseti(context->m_L, context->m_TableIndex, ++context->m_Count);
+        return HasResultCapacity(context);
+    }
+
+    static float CastResultCallback(b2ShapeId shape_id, b2Vec2 point, b2Vec2 normal, float fraction, void* user_context)
+    {
+        QueryContext* context = (QueryContext*)user_context;
+        if (!HasResultCapacity(context))
+        {
+            return 0.0f;
+        }
+
+        PushCastHit(context->m_L, shape_id, point, normal, fraction);
+        lua_rawseti(context->m_L, context->m_TableIndex, ++context->m_Count);
+        return HasResultCapacity(context) ? 1.0f : 0.0f;
+    }
+
+    static bool PlaneResultCallback(b2ShapeId shape_id, const b2PlaneResult* plane, void* user_context)
+    {
+        QueryContext* context = (QueryContext*)user_context;
+        if (!HasResultCapacity(context))
+        {
+            return false;
+        }
+
+        lua_State* L = context->m_L;
+        lua_newtable(L);
+
+        PushShapeInfoForShape(L, shape_id);
+        lua_setfield(L, -2, "shape");
+
+        dmScript::PushVector3(L, FromB2(plane->plane.normal, 1.0f));
+        lua_setfield(L, -2, "normal");
+
+        lua_pushnumber(L, plane->plane.offset * GetInvPhysicsScale());
+        lua_setfield(L, -2, "offset");
+
+        lua_pushboolean(L, plane->hit);
+        lua_setfield(L, -2, "hit");
+
+        lua_rawseti(L, context->m_TableIndex, ++context->m_Count);
+        return HasResultCapacity(context);
+    }
+
+    static int World_IsValid(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        B2DLuaWorld* luaworld = CheckWorldInternal(L, 1);
+        lua_pushboolean(L, b2World_IsValid(luaworld->m_World));
+        return 1;
+    }
+
+    static int World_IsLocked(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        lua_pushboolean(L, b2World_IsLocked(*CheckWorld(L, 1)));
+        return 1;
+    }
+
+    static int World_GetGravity(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        dmScript::PushVector3(L, FromB2(b2World_GetGravity(*CheckWorld(L, 1)), GetInvPhysicsScale()));
+        return 1;
+    }
+
+    static int World_SetGravity(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        b2WorldId world = *CheckWorld(L, 1);
+        CheckWorldUnlocked(L, world, "set_gravity");
+        b2World_SetGravity(world, CheckVec2(L, 2, GetPhysicsScale()));
+        return 0;
+    }
+
+    static int World_EnableSleeping(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        b2WorldId world = *CheckWorld(L, 1);
+        CheckWorldUnlocked(L, world, "enable_sleeping");
+        b2World_EnableSleeping(world, lua_toboolean(L, 2));
+        return 0;
+    }
+
+    static int World_IsSleepingEnabled(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        lua_pushboolean(L, b2World_IsSleepingEnabled(*CheckWorld(L, 1)));
+        return 1;
+    }
+
+    static int World_EnableContinuous(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        b2WorldId world = *CheckWorld(L, 1);
+        CheckWorldUnlocked(L, world, "enable_continuous");
+        b2World_EnableContinuous(world, lua_toboolean(L, 2));
+        return 0;
+    }
+
+    static int World_IsContinuousEnabled(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        lua_pushboolean(L, b2World_IsContinuousEnabled(*CheckWorld(L, 1)));
+        return 1;
+    }
+
+    static int World_SetRestitutionThreshold(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        b2WorldId world = *CheckWorld(L, 1);
+        CheckWorldUnlocked(L, world, "set_restitution_threshold");
+        b2World_SetRestitutionThreshold(world, luaL_checknumber(L, 2) * GetPhysicsScale());
+        return 0;
+    }
+
+    static int World_GetRestitutionThreshold(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        lua_pushnumber(L, b2World_GetRestitutionThreshold(*CheckWorld(L, 1)) * (lua_Number)GetInvPhysicsScale());
+        return 1;
+    }
+
+    static int World_SetHitEventThreshold(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        b2WorldId world = *CheckWorld(L, 1);
+        CheckWorldUnlocked(L, world, "set_hit_event_threshold");
+        b2World_SetHitEventThreshold(world, luaL_checknumber(L, 2) * GetPhysicsScale());
+        return 0;
+    }
+
+    static int World_GetHitEventThreshold(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        lua_pushnumber(L, b2World_GetHitEventThreshold(*CheckWorld(L, 1)) * (lua_Number)GetInvPhysicsScale());
+        return 1;
+    }
+
+    static int World_SetMaximumLinearSpeed(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        b2WorldId world = *CheckWorld(L, 1);
+        CheckWorldUnlocked(L, world, "set_maximum_linear_speed");
+        b2World_SetMaximumLinearSpeed(world, luaL_checknumber(L, 2) * GetPhysicsScale());
+        return 0;
+    }
+
+    static int World_GetMaximumLinearSpeed(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        lua_pushnumber(L, b2World_GetMaximumLinearSpeed(*CheckWorld(L, 1)) * (lua_Number)GetInvPhysicsScale());
+        return 1;
+    }
+
+    static int World_EnableWarmStarting(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        b2WorldId world = *CheckWorld(L, 1);
+        CheckWorldUnlocked(L, world, "enable_warm_starting");
+        b2World_EnableWarmStarting(world, lua_toboolean(L, 2));
+        return 0;
+    }
+
+    static int World_IsWarmStartingEnabled(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        lua_pushboolean(L, b2World_IsWarmStartingEnabled(*CheckWorld(L, 1)));
+        return 1;
+    }
+
+    static int World_GetAwakeBodyCount(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        lua_pushinteger(L, b2World_GetAwakeBodyCount(*CheckWorld(L, 1)));
+        return 1;
+    }
+
+    static int World_SetContactTuning(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        b2WorldId world = *CheckWorld(L, 1);
+        CheckWorldUnlocked(L, world, "set_contact_tuning");
+        b2World_SetContactTuning(world, luaL_checknumber(L, 2), luaL_checknumber(L, 3), luaL_checknumber(L, 4) * GetPhysicsScale());
+        return 0;
+    }
+
+    static int World_SetJointTuning(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        b2WorldId world = *CheckWorld(L, 1);
+        CheckWorldUnlocked(L, world, "set_joint_tuning");
+        b2World_SetJointTuning(world, luaL_checknumber(L, 2), luaL_checknumber(L, 3));
+        return 0;
+    }
+
+    static int World_GetProfile(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        b2Profile profile = b2World_GetProfile(*CheckWorld(L, 1));
+
+        lua_newtable(L);
+
+#define SET_PROFILE_FIELD(NAME, FIELD_NAME) \
+        lua_pushnumber(L, profile.NAME); \
+        lua_setfield(L, -2, FIELD_NAME);
+
+        SET_PROFILE_FIELD(step, "step");
+        SET_PROFILE_FIELD(pairs, "pairs");
+        SET_PROFILE_FIELD(collide, "collide");
+        SET_PROFILE_FIELD(solve, "solve");
+        SET_PROFILE_FIELD(mergeIslands, "merge_islands");
+        SET_PROFILE_FIELD(prepareStages, "prepare_stages");
+        SET_PROFILE_FIELD(solveConstraints, "solve_constraints");
+        SET_PROFILE_FIELD(prepareConstraints, "prepare_constraints");
+        SET_PROFILE_FIELD(integrateVelocities, "integrate_velocities");
+        SET_PROFILE_FIELD(warmStart, "warm_start");
+        SET_PROFILE_FIELD(solveImpulses, "solve_impulses");
+        SET_PROFILE_FIELD(integratePositions, "integrate_positions");
+        SET_PROFILE_FIELD(relaxImpulses, "relax_impulses");
+        SET_PROFILE_FIELD(applyRestitution, "apply_restitution");
+        SET_PROFILE_FIELD(storeImpulses, "store_impulses");
+        SET_PROFILE_FIELD(splitIslands, "split_islands");
+        SET_PROFILE_FIELD(transforms, "transforms");
+        SET_PROFILE_FIELD(hitEvents, "hit_events");
+        SET_PROFILE_FIELD(refit, "refit");
+        SET_PROFILE_FIELD(bullets, "bullets");
+        SET_PROFILE_FIELD(sleepIslands, "sleep_islands");
+        SET_PROFILE_FIELD(sensors, "sensors");
+
+#undef SET_PROFILE_FIELD
+
+        return 1;
+    }
+
+    static int World_GetCounters(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        b2Counters counters = b2World_GetCounters(*CheckWorld(L, 1));
+
+        lua_newtable(L);
+
+#define SET_COUNTER_FIELD(NAME, FIELD_NAME) \
+        lua_pushinteger(L, counters.NAME); \
+        lua_setfield(L, -2, FIELD_NAME);
+
+        SET_COUNTER_FIELD(bodyCount, "body_count");
+        SET_COUNTER_FIELD(shapeCount, "shape_count");
+        SET_COUNTER_FIELD(contactCount, "contact_count");
+        SET_COUNTER_FIELD(jointCount, "joint_count");
+        SET_COUNTER_FIELD(islandCount, "island_count");
+        SET_COUNTER_FIELD(stackUsed, "stack_used");
+        SET_COUNTER_FIELD(staticTreeHeight, "static_tree_height");
+        SET_COUNTER_FIELD(treeHeight, "tree_height");
+        SET_COUNTER_FIELD(byteCount, "byte_count");
+        SET_COUNTER_FIELD(taskCount, "task_count");
+
+#undef SET_COUNTER_FIELD
+
+        lua_newtable(L);
+        for (int i = 0; i < 12; ++i)
+        {
+            lua_pushinteger(L, counters.colorCounts[i]);
+            lua_rawseti(L, -2, i + 1);
+        }
+        lua_setfield(L, -2, "color_counts");
+
+        return 1;
+    }
+
+    static int World_Explode(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        b2WorldId world = *CheckWorld(L, 1);
+        CheckWorldUnlocked(L, world, "explode");
+        luaL_checktype(L, 2, LUA_TTABLE);
+
+        b2ExplosionDef def = b2DefaultExplosionDef();
+
+        lua_getfield(L, 2, "position");
+        def.position = CheckVec2(L, -1, GetPhysicsScale());
+        lua_pop(L, 1);
+
+        lua_getfield(L, 2, "radius");
+        def.radius = luaL_checknumber(L, -1) * GetPhysicsScale();
+        lua_pop(L, 1);
+
+        lua_getfield(L, 2, "falloff");
+        def.falloff = luaL_checknumber(L, -1) * GetPhysicsScale();
+        lua_pop(L, 1);
+
+        lua_getfield(L, 2, "impulse_per_length");
+        def.impulsePerLength = luaL_checknumber(L, -1) * GetPhysicsScale();
+        lua_pop(L, 1);
+
+        lua_getfield(L, 2, "mask_bits");
+        if (!lua_isnil(L, -1))
+        {
+            def.maskBits = (uint64_t)luaL_checknumber(L, -1);
+        }
+        lua_pop(L, 1);
+
+        b2World_Explode(world, &def);
+        return 0;
+    }
+
+    static int World_RebuildStaticTree(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        b2WorldId world = *CheckWorld(L, 1);
+        CheckWorldUnlocked(L, world, "rebuild_static_tree");
+        b2World_RebuildStaticTree(world);
+        return 0;
+    }
+
+    static int World_EnableSpeculative(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        b2WorldId world = *CheckWorld(L, 1);
+        CheckWorldUnlocked(L, world, "enable_speculative");
+        b2World_EnableSpeculative(world, lua_toboolean(L, 2));
+        return 0;
+    }
+
+    static int World_OverlapAABB(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 2);
+        b2WorldId world = *CheckWorld(L, 1);
+        CheckWorldUnlocked(L, world, "overlap_aabb");
+        b2AABB aabb = CheckAABB(L, 2);
+        b2QueryFilter filter = CheckQueryFilter(L, 3);
+
+        lua_newtable(L);
+        QueryContext context = { L, AbsIndex(L, -1), 0, CheckMaxResults(L, 4) };
+        b2TreeStats stats = b2World_OverlapAABB(world, aabb, filter, OverlapResultCallback, &context);
+
+        PushTreeStats(L, stats);
+        return 2;
+    }
+
+    static int World_OverlapShape(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 2);
+        b2WorldId world = *CheckWorld(L, 1);
+        CheckWorldUnlocked(L, world, "overlap_shape");
+        B2DShapeDef shape_def = CheckShapeDef(L, 2);
+        b2ShapeProxy proxy = MakeShapeProxy(shape_def);
+        b2QueryFilter filter = CheckQueryFilter(L, 3);
+
+        lua_newtable(L);
+        QueryContext context = { L, AbsIndex(L, -1), 0, CheckMaxResults(L, 4) };
+        b2TreeStats stats = b2World_OverlapShape(world, &proxy, filter, OverlapResultCallback, &context);
+
+        PushTreeStats(L, stats);
+        return 2;
+    }
+
+    static int World_CastRay(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 2);
+        b2WorldId world = *CheckWorld(L, 1);
+        CheckWorldUnlocked(L, world, "cast_ray");
+        b2Vec2 origin = CheckVec2(L, 2, GetPhysicsScale());
+        b2Vec2 translation = CheckVec2(L, 3, GetPhysicsScale());
+        b2QueryFilter filter = CheckQueryFilter(L, 4);
+
+        lua_newtable(L);
+        QueryContext context = { L, AbsIndex(L, -1), 0, CheckMaxResults(L, 5) };
+        b2TreeStats stats = b2World_CastRay(world, origin, translation, filter, CastResultCallback, &context);
+
+        PushTreeStats(L, stats);
+        return 2;
+    }
+
+    static int World_CastRayClosest(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        b2WorldId world = *CheckWorld(L, 1);
+        CheckWorldUnlocked(L, world, "cast_ray_closest");
+        b2Vec2 origin = CheckVec2(L, 2, GetPhysicsScale());
+        b2Vec2 translation = CheckVec2(L, 3, GetPhysicsScale());
+        b2QueryFilter filter = CheckQueryFilter(L, 4);
+
+        b2RayResult result = b2World_CastRayClosest(world, origin, translation, filter);
+        if (!result.hit)
+        {
+            lua_pushnil(L);
+            return 1;
+        }
+
+        PushCastHit(L, result.shapeId, result.point, result.normal, result.fraction);
+        lua_pushinteger(L, result.nodeVisits);
+        lua_setfield(L, -2, "node_visits");
+        lua_pushinteger(L, result.leafVisits);
+        lua_setfield(L, -2, "leaf_visits");
+        return 1;
+    }
+
+    static int World_CastShape(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 2);
+        b2WorldId world = *CheckWorld(L, 1);
+        CheckWorldUnlocked(L, world, "cast_shape");
+        B2DShapeDef shape_def = CheckShapeDef(L, 2);
+        b2ShapeProxy proxy = MakeShapeProxy(shape_def);
+        b2Vec2 translation = CheckVec2(L, 3, GetPhysicsScale());
+        b2QueryFilter filter = CheckQueryFilter(L, 4);
+
+        lua_newtable(L);
+        QueryContext context = { L, AbsIndex(L, -1), 0, CheckMaxResults(L, 5) };
+        b2TreeStats stats = b2World_CastShape(world, &proxy, translation, filter, CastResultCallback, &context);
+
+        PushTreeStats(L, stats);
+        return 2;
+    }
+
+    static int World_CastMover(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        b2WorldId world = *CheckWorld(L, 1);
+        CheckWorldUnlocked(L, world, "cast_mover");
+        b2Capsule capsule = CheckCapsule(L, 2);
+        b2Vec2 translation = CheckVec2(L, 3, GetPhysicsScale());
+        b2QueryFilter filter = CheckQueryFilter(L, 4);
+
+        lua_pushnumber(L, b2World_CastMover(world, &capsule, translation, filter));
+        return 1;
+    }
+
+    static int World_CollideMover(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        b2WorldId world = *CheckWorld(L, 1);
+        CheckWorldUnlocked(L, world, "collide_mover");
+        b2Capsule capsule = CheckCapsule(L, 2);
+        b2QueryFilter filter = CheckQueryFilter(L, 3);
+
+        lua_newtable(L);
+        QueryContext context = { L, AbsIndex(L, -1), 0, CheckMaxResults(L, 4) };
+        b2World_CollideMover(world, &capsule, filter, PlaneResultCallback, &context);
+        return 1;
+    }
+
+    static int World_tostring(lua_State *L)
+    {
+        B2DLuaWorld* luaworld = CheckWorldInternal(L, 1);
+        lua_pushfstring(L, "Box2D.%s = %p", BOX2D_TYPE_NAME_WORLD, &luaworld->m_World);
+        return 1;
+    }
+
+    static int World_eq(lua_State *L)
+    {
+        b2WorldId* a = ToWorld(L, 1);
+        b2WorldId* b = ToWorld(L, 2);
+        lua_pushboolean(L, a && b && memcmp(a, b, sizeof(b2WorldId)) == 0);
+        return 1;
+    }
+
+    static const luaL_reg World_methods[] =
+    {
+        {0,0}
+    };
+
+    static const luaL_reg World_meta[] =
+    {
+        {"__tostring", World_tostring},
+        {"__eq", World_eq},
+        {0,0}
+    };
+
+    static const luaL_reg World_functions[] =
+    {
+        {"is_valid", World_IsValid},
+        {"is_locked", World_IsLocked},
+        {"get_gravity", World_GetGravity},
+        {"set_gravity", World_SetGravity},
+        {"enable_sleeping", World_EnableSleeping},
+        {"is_sleeping_enabled", World_IsSleepingEnabled},
+        {"enable_continuous", World_EnableContinuous},
+        {"is_continuous_enabled", World_IsContinuousEnabled},
+        {"set_restitution_threshold", World_SetRestitutionThreshold},
+        {"get_restitution_threshold", World_GetRestitutionThreshold},
+        {"set_hit_event_threshold", World_SetHitEventThreshold},
+        {"get_hit_event_threshold", World_GetHitEventThreshold},
+        {"set_maximum_linear_speed", World_SetMaximumLinearSpeed},
+        {"get_maximum_linear_speed", World_GetMaximumLinearSpeed},
+        {"enable_warm_starting", World_EnableWarmStarting},
+        {"is_warm_starting_enabled", World_IsWarmStartingEnabled},
+        {"get_awake_body_count", World_GetAwakeBodyCount},
+        {"set_contact_tuning", World_SetContactTuning},
+        {"set_joint_tuning", World_SetJointTuning},
+        {"get_profile", World_GetProfile},
+        {"get_counters", World_GetCounters},
+        {"explode", World_Explode},
+        {"rebuild_static_tree", World_RebuildStaticTree},
+        {"enable_speculative", World_EnableSpeculative},
+        {"overlap_aabb", World_OverlapAABB},
+        {"overlap_shape", World_OverlapShape},
+        {"cast_ray", World_CastRay},
+        {"cast_ray_closest", World_CastRayClosest},
+        {"cast_shape", World_CastShape},
+        {"cast_mover", World_CastMover},
+        {"collide_mover", World_CollideMover},
+        {0,0}
+    };
+
+    void ScriptBox2DInitializeWorld(lua_State* L)
+    {
+        TYPE_HASH_WORLD = dmScript::RegisterUserType(L, BOX2D_TYPE_NAME_WORLD, World_methods, World_meta);
+
+        lua_newtable(L);
+        luaL_register(L, 0, World_functions);
+        lua_setfield(L, -2, "world");
+    }
+
+    void ScriptBox2DFinalizeWorld()
+    {
+        TYPE_HASH_WORLD = 0;
+    }
+}
+
+/*# Box2D b2World documentation
+ *
+ * Functions for querying and tuning the Box2D v3 world owned by the current
+ * Defold collection. World creation, destruction, stepping, debug draw,
+ * callbacks, and user data remain owned by Defold.
+ *
+ * Query filters are optional tables with `category_bits` and `mask_bits`.
+ * When omitted, Box2D default query filtering is used.
+ *
+ * Shape result tables include `shape_id`, `index`, `type`, `sensor`,
+ * `density`, `friction`, `restitution`, `material`, `child_count`, and
+ * `is_chain_segment`.
+ * Chain segment shapes report `type = b2d.shape.SHAPE_TYPE_SEGMENT`.
+ *
+ * Tree stats tables include `node_visits` and `leaf_visits`.
+ *
+ * Cast hit tables include `shape`, `point`, `normal`, and `fraction`.
+ *
+ * @document
+ * @name b2d.world
+ * @namespace b2d.world
+ * @language Lua
+ * @version 3
+ */
+
+/*# Check whether a world handle is valid.
+ * @name b2d.world.is_valid
+ * @param world [type: b2World] world
+ * @return valid [type: boolean] true if the world handle is valid
+ */
+
+/*# Check whether the world is locked.
+ * The world is locked during callbacks and some simulation phases. Functions
+ * marked as locked during callbacks cannot be called while this returns true.
+ * @name b2d.world.is_locked
+ * @param world [type: b2World] world
+ * @return locked [type: boolean] true if the world is locked
+ */
+
+/*# Get world gravity.
+ * @name b2d.world.get_gravity
+ * @param world [type: b2World] world
+ * @return gravity [type: vector3] gravity vector
+ */
+
+/*# Set world gravity.
+ * @warning This function is locked during callbacks.
+ * @name b2d.world.set_gravity
+ * @param world [type: b2World] world
+ * @param gravity [type: vector3] gravity vector
+ */
+
+/*# Enable or disable world sleeping.
+ * @warning This function is locked during callbacks.
+ * @name b2d.world.enable_sleeping
+ * @param world [type: b2World] world
+ * @param enable [type: boolean] true to allow sleeping
+ */
+
+/*# Get whether world sleeping is enabled.
+ * @name b2d.world.is_sleeping_enabled
+ * @param world [type: b2World] world
+ * @return enabled [type: boolean] true if sleeping is enabled
+ */
+
+/*# Enable or disable continuous collision.
+ * @warning This function is locked during callbacks.
+ * @name b2d.world.enable_continuous
+ * @param world [type: b2World] world
+ * @param enable [type: boolean] true to enable continuous collision
+ */
+
+/*# Get whether continuous collision is enabled.
+ * @name b2d.world.is_continuous_enabled
+ * @param world [type: b2World] world
+ * @return enabled [type: boolean] true if continuous collision is enabled
+ */
+
+/*# Set the restitution threshold.
+ * Collisions below this relative speed use inelastic collision response.
+ * @warning This function is locked during callbacks.
+ * @name b2d.world.set_restitution_threshold
+ * @param world [type: b2World] world
+ * @param threshold [type: number] restitution threshold in project units per second
+ */
+
+/*# Get the restitution threshold.
+ * @name b2d.world.get_restitution_threshold
+ * @param world [type: b2World] world
+ * @return threshold [type: number] restitution threshold in project units per second
+ */
+
+/*# Set the hit event threshold.
+ * @warning This function is locked during callbacks.
+ * @name b2d.world.set_hit_event_threshold
+ * @param world [type: b2World] world
+ * @param threshold [type: number] hit event threshold in project units per second
+ */
+
+/*# Get the hit event threshold.
+ * @name b2d.world.get_hit_event_threshold
+ * @param world [type: b2World] world
+ * @return threshold [type: number] hit event threshold in project units per second
+ */
+
+/*# Set the maximum linear speed.
+ * @warning This function is locked during callbacks.
+ * @name b2d.world.set_maximum_linear_speed
+ * @param world [type: b2World] world
+ * @param speed [type: number] maximum linear speed in project units per second
+ */
+
+/*# Get the maximum linear speed.
+ * @name b2d.world.get_maximum_linear_speed
+ * @param world [type: b2World] world
+ * @return speed [type: number] maximum linear speed in project units per second
+ */
+
+/*# Enable or disable warm starting.
+ * @warning This function is locked during callbacks.
+ * @name b2d.world.enable_warm_starting
+ * @param world [type: b2World] world
+ * @param enable [type: boolean] true to enable warm starting
+ */
+
+/*# Get whether warm starting is enabled.
+ * @name b2d.world.is_warm_starting_enabled
+ * @param world [type: b2World] world
+ * @return enabled [type: boolean] true if warm starting is enabled
+ */
+
+/*# Get the number of awake bodies.
+ * @name b2d.world.get_awake_body_count
+ * @param world [type: b2World] world
+ * @return count [type: number] awake body count
+ */
+
+/*# Set contact solver tuning.
+ * @warning This function is locked during callbacks.
+ * @name b2d.world.set_contact_tuning
+ * @param world [type: b2World] world
+ * @param hertz [type: number] contact stiffness frequency in hertz
+ * @param damping_ratio [type: number] contact damping ratio
+ * @param pushout [type: number] pushout velocity in project units per second
+ */
+
+/*# Set joint solver tuning.
+ * @warning This function is locked during callbacks.
+ * @name b2d.world.set_joint_tuning
+ * @param world [type: b2World] world
+ * @param hertz [type: number] joint stiffness frequency in hertz
+ * @param damping_ratio [type: number] joint damping ratio
+ */
+
+/*# Get world profiling data.
+ * The returned table contains Box2D timing fields including `step`, `pairs`,
+ * `collide`, `solve`, `merge_islands`, `prepare_stages`, `solve_constraints`,
+ * `prepare_constraints`, `integrate_velocities`, `warm_start`,
+ * `solve_impulses`, `integrate_positions`, `relax_impulses`,
+ * `apply_restitution`, `store_impulses`, `split_islands`, `transforms`,
+ * `hit_events`, `refit`, `bullets`, `sleep_islands`, and `sensors`.
+ * @name b2d.world.get_profile
+ * @param world [type: b2World] world
+ * @return profile [type: table] world profiling data
+ */
+
+/*# Get world counters.
+ * The returned table contains `body_count`, `shape_count`, `contact_count`,
+ * `joint_count`, `island_count`, `stack_used`, `static_tree_height`,
+ * `tree_height`, `byte_count`, `task_count`, and `color_counts`.
+ * @name b2d.world.get_counters
+ * @param world [type: b2World] world
+ * @return counters [type: table] world counters
+ */
+
+/*# Apply an explosion impulse.
+ * The definition table requires `position`, `radius`, `falloff`, and
+ * `impulse_per_length`. It may also include `mask_bits`.
+ * @warning This function is locked during callbacks.
+ * @name b2d.world.explode
+ * @param world [type: b2World] world
+ * @param definition [type: table] explosion definition
+ */
+
+/*# Rebuild the static broad-phase tree.
+ * @warning This function is locked during callbacks.
+ * @name b2d.world.rebuild_static_tree
+ * @param world [type: b2World] world
+ */
+
+/*# Enable or disable speculative collision.
+ * @warning This function is locked during callbacks.
+ * @name b2d.world.enable_speculative
+ * @param world [type: b2World] world
+ * @param enable [type: boolean] true to enable speculative collision
+ */
+
+/*# Find shapes overlapping an AABB.
+ * The AABB table has `lower` and `upper` `vector3` fields.
+ * @warning This function is locked during callbacks.
+ * @name b2d.world.overlap_aabb
+ * @param world [type: b2World] world
+ * @param aabb [type: table] AABB table with `lower` and `upper`
+ * @param [filter] [type: table] optional query filter with `category_bits` and `mask_bits`
+ * @param [max_results] [type: number] optional maximum result count. Omit or pass 0 for unlimited results.
+ * @return hits [type: table] array of shape info tables
+ * @return stats [type: table] tree stats table
+ */
+
+/*# Find shapes overlapping a shape proxy.
+ * The shape table uses the same circle, capsule, segment, polygon, and box formats
+ * as `b2d.body.create_shape`.
+ * @warning This function is locked during callbacks.
+ * @name b2d.world.overlap_shape
+ * @param world [type: b2World] world
+ * @param shape [type: table] shape table
+ * @param [filter] [type: table] optional query filter with `category_bits` and `mask_bits`
+ * @param [max_results] [type: number] optional maximum result count. Omit or pass 0 for unlimited results.
+ * @return hits [type: table] array of shape info tables
+ * @return stats [type: table] tree stats table
+ */
+
+/*# Cast a ray and collect hits.
+ * The translation is the ray displacement from `origin`. Result order is not
+ * guaranteed by Box2D.
+ * @warning This function is locked during callbacks.
+ * @name b2d.world.cast_ray
+ * @param world [type: b2World] world
+ * @param origin [type: vector3] ray start position
+ * @param translation [type: vector3] ray displacement
+ * @param [filter] [type: table] optional query filter with `category_bits` and `mask_bits`
+ * @param [max_results] [type: number] optional maximum result count. Omit or pass 0 for unlimited results.
+ * @return hits [type: table] array of cast hit tables
+ * @return stats [type: table] tree stats table
+ */
+
+/*# Cast a ray and return the closest hit.
+ * The translation is the ray displacement from `origin`.
+ * @warning This function is locked during callbacks.
+ * @name b2d.world.cast_ray_closest
+ * @param world [type: b2World] world
+ * @param origin [type: vector3] ray start position
+ * @param translation [type: vector3] ray displacement
+ * @param [filter] [type: table] optional query filter with `category_bits` and `mask_bits`
+ * @return hit [type: table|nil] closest cast hit table with `node_visits` and `leaf_visits`, or `nil` on miss
+ */
+
+/*# Cast a shape and collect hits.
+ * The shape table uses the same circle, capsule, segment, polygon, and box formats
+ * as `b2d.body.create_shape`. The translation is the shape displacement.
+ * @warning This function is locked during callbacks.
+ * @name b2d.world.cast_shape
+ * @param world [type: b2World] world
+ * @param shape [type: table] shape table
+ * @param translation [type: vector3] shape displacement
+ * @param [filter] [type: table] optional query filter with `category_bits` and `mask_bits`
+ * @param [max_results] [type: number] optional maximum result count. Omit or pass 0 for unlimited results.
+ * @return hits [type: table] array of cast hit tables
+ * @return stats [type: table] tree stats table
+ */
+
+/*# Cast a mover capsule.
+ * The capsule table has `center1`, `center2`, and `radius` fields. The return
+ * value is the fraction of `translation` that can be traveled before collision,
+ * or 1 if there is no hit.
+ * @warning This function is locked during callbacks.
+ * @name b2d.world.cast_mover
+ * @param world [type: b2World] world
+ * @param capsule [type: table] capsule table with `center1`, `center2`, and `radius`
+ * @param translation [type: vector3] capsule displacement
+ * @param [filter] [type: table] optional query filter with `category_bits` and `mask_bits`
+ * @return fraction [type: number] travel fraction before collision
+ */
+
+/*# Collide a mover capsule against the world.
+ * The capsule table has `center1`, `center2`, and `radius` fields. Plane result
+ * tables include `shape`, `normal`, `offset`, and `hit`.
+ * @warning This function is locked during callbacks.
+ * @name b2d.world.collide_mover
+ * @param world [type: b2World] world
+ * @param capsule [type: table] capsule table with `center1`, `center2`, and `radius`
+ * @param [filter] [type: table] optional query filter with `category_bits` and `mask_bits`
+ * @param [max_results] [type: number] optional maximum result count. Omit or pass 0 for unlimited results.
+ * @return planes [type: table] array of plane result tables
+ */

--- a/engine/gamesys/src/gamesys/test/collision_object/box2d_chain_test.go
+++ b/engine/gamesys/src/gamesys/test/collision_object/box2d_chain_test.go
@@ -1,0 +1,8 @@
+components {
+  id: "collisionobject"
+  component: "/collision_object/base.collisionobject"
+}
+components {
+  id: "script"
+  component: "/collision_object/box2d_chain_test.script"
+}

--- a/engine/gamesys/src/gamesys/test/collision_object/box2d_chain_test.script
+++ b/engine/gamesys/src/gamesys/test/collision_object/box2d_chain_test.script
@@ -1,0 +1,265 @@
+-- Copyright 2020-2026 The Defold Foundation
+-- Copyright 2014-2020 King
+-- Copyright 2009-2014 Ragnar Svensson, Christian Murray
+-- Licensed under the Defold License version 1.0 (the "License"); you may not use
+-- this file except in compliance with the License.
+--
+-- You may obtain a copy of the License, together with FAQs at
+-- https://www.defold.com/license
+--
+-- Unless required by applicable law or agreed to in writing, software distributed
+-- under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+-- CONDITIONS OF ANY KIND, either express or implied. See the License for the
+-- specific language governing permissions and limitations under the License.
+
+tests_done = false
+
+-- Test intent:
+-- Verify the v3-only chain userdata API and its segment-shape integration.
+-- Setup:
+-- Create isolated open and loop chains on a static body and query through b2d.chain,
+-- b2d.shape and b2d.world.
+-- Expected:
+-- Segments report as segment shapes with chain ownership, casts hit the expected segment,
+-- property setters round-trip, and destroying a chain or segment invalidates the chain.
+
+local function assert_error(func)
+    local r, err = pcall(func)
+    if not r then
+        print(err)
+    end
+    assert(not r)
+end
+
+local function assert_near(a, b, eps)
+    if not eps then
+        eps = 0.001
+    end
+    local diff = math.abs(a - b)
+    if not (diff < eps) then
+        local err_msg = "assert_near failed, a: " .. tostring(a) .. ", b: " .. tostring(b) .. " diff == " .. tostring(diff) .. " >= " .. tostring(eps)
+        error(debug.traceback(err_msg))
+    end
+end
+
+local function assert_vec3_near(a, b, eps)
+    assert_near(a.x, b.x, eps)
+    assert_near(a.y, b.y, eps)
+    assert_near(a.z, b.z, eps)
+end
+
+local function find_hit_for_shape(hits, shape_id)
+    for _, hit in ipairs(hits) do
+        local shape = hit.shape or hit
+        if shape.shape_id == shape_id then
+            return hit
+        end
+    end
+    return nil
+end
+
+local function test_v3_chains(body)
+    local world = b2d.get_world()
+    assert(world ~= nil)
+    assert(world == b2d.body.get_world(body))
+
+    local chain, segments = b2d.body.create_chain(body, {
+        vertices = {
+            vmath.vector3(-16, 20, 0),
+            vmath.vector3(0, 28, 0),
+            vmath.vector3(16, 20, 0),
+        },
+        prev_vertex = vmath.vector3(-24, 12, 0),
+        next_vertex = vmath.vector3(24, 12, 0),
+        friction = 0.2,
+        restitution = 0.1,
+        material = 7,
+        filter = {
+            category_bits = 1,
+            mask_bits = 1,
+            group_index = 0,
+        },
+        enable_sensor_events = true,
+    })
+    assert(chain ~= nil)
+    assert(b2d.chain.is_valid(chain))
+    assert(b2d.chain.get_world(chain) == world)
+    assert(#segments == 2)
+    assert(b2d.chain.get_segment_count(chain) == #segments)
+    assert(segments[1].type == b2d.shape.SHAPE_TYPE_SEGMENT)
+    assert(segments[1].shape_id ~= nil)
+    assert(segments[1].is_chain_segment)
+
+    local segment_snapshot = b2d.shape.get_shape(segments[1].shape_id)
+    assert(segment_snapshot.type == b2d.shape.SHAPE_TYPE_SEGMENT)
+    assert(segment_snapshot.v0 ~= nil)
+    assert(segment_snapshot.v1 ~= nil)
+    assert(segment_snapshot.v2 ~= nil)
+    assert(segment_snapshot.v3 ~= nil)
+    assert_error(function() b2d.shape.set_shape(segments[1].shape_id, segment_snapshot) end)
+
+    local chain_from_shape = b2d.chain.from_shape(segments[1].shape_id)
+    assert(chain_from_shape == chain)
+    assert(b2d.chain.from_shape(body, 1) == nil)
+
+    local chain_segments = b2d.chain.get_segments(chain)
+    assert(#chain_segments == 2)
+    assert(chain_segments[2].is_chain_segment)
+
+    local geometry = b2d.chain.get_geometry(chain)
+    assert(not geometry.loop)
+    assert(#geometry.vertices == 3)
+    assert_vec3_near(geometry.prev_vertex, vmath.vector3(-24, 12, 0))
+    assert_vec3_near(geometry.next_vertex, vmath.vector3(24, 12, 0))
+
+    assert_near(b2d.chain.get_friction(chain), 0.2)
+    assert_near(b2d.chain.get_restitution(chain), 0.1)
+    assert(b2d.chain.get_material(chain) == 7)
+    b2d.chain.set_friction(chain, 0.4)
+    b2d.chain.set_restitution(chain, 0.3)
+    b2d.chain.set_material(chain, 11)
+    assert_near(b2d.chain.get_friction(chain), 0.4)
+    assert_near(b2d.chain.get_restitution(chain), 0.3)
+    assert(b2d.chain.get_material(chain) == 11)
+
+    local hits, stats = b2d.world.overlap_aabb(world, {
+        lower = vmath.vector3(-20, 18, 0),
+        upper = vmath.vector3(20, 30, 0),
+    }, nil, 16)
+    assert(type(hits) == "table")
+    assert(#hits > 0)
+    assert(type(stats.node_visits) == "number")
+    assert(type(stats.leaf_visits) == "number")
+
+    local shape_hits, shape_stats = b2d.world.overlap_shape(world, {
+        type = b2d.shape.SHAPE_TYPE_CIRCLE,
+        center = vmath.vector3(8, 24, 0),
+        radius = 3,
+    }, nil, 16)
+    assert(type(shape_hits) == "table")
+    assert(type(shape_stats.node_visits) == "number")
+    local expected_shape_id = segments[2].shape_id
+    assert(find_hit_for_shape(shape_hits, expected_shape_id) ~= nil)
+
+    local expected_cast_point = vmath.vector3(8, 24, 0)
+    local expected_ray_fraction = 16 / 60
+    local ray_hits, ray_stats = b2d.world.cast_ray(world, vmath.vector3(8, 8, 0), vmath.vector3(0, 60, 0), nil, 16)
+    assert(type(ray_hits) == "table")
+    assert(type(ray_stats.leaf_visits) == "number")
+    local ray_chain_hit = find_hit_for_shape(ray_hits, expected_shape_id)
+    assert(ray_chain_hit ~= nil)
+    assert(ray_chain_hit.shape.shape_id == expected_shape_id)
+    assert(ray_chain_hit.shape.is_chain_segment)
+    assert_vec3_near(ray_chain_hit.point, expected_cast_point, 0.1)
+    assert_near(ray_chain_hit.fraction, expected_ray_fraction, 0.01)
+
+    local closest = b2d.world.cast_ray_closest(world, vmath.vector3(8, 8, 0), vmath.vector3(0, 60, 0))
+    assert(closest ~= nil)
+    assert(closest.shape.shape_id == expected_shape_id)
+    assert(closest.shape.is_chain_segment)
+    assert_vec3_near(closest.point, expected_cast_point, 0.1)
+    assert_near(closest.fraction, expected_ray_fraction, 0.01)
+
+    local cast_hits, cast_stats = b2d.world.cast_shape(world, {
+        type = b2d.shape.SHAPE_TYPE_CIRCLE,
+        center = vmath.vector3(8, 8, 0),
+        radius = 1,
+    }, vmath.vector3(0, 60, 0), nil, 16)
+    assert(type(cast_hits) == "table")
+    assert(type(cast_stats.node_visits) == "number")
+    local shape_chain_hit = find_hit_for_shape(cast_hits, expected_shape_id)
+    assert(shape_chain_hit ~= nil)
+    assert(shape_chain_hit.shape.shape_id == expected_shape_id)
+    assert(shape_chain_hit.shape.is_chain_segment)
+    assert_vec3_near(shape_chain_hit.point, expected_cast_point, 2.0)
+    assert(shape_chain_hit.fraction > 0.2 and shape_chain_hit.fraction < 0.3)
+
+    local mover_fraction = b2d.world.cast_mover(world, {
+        center1 = vmath.vector3(6, 8, 0),
+        center2 = vmath.vector3(10, 8, 0),
+        radius = 1,
+    }, vmath.vector3(0, 60, 0))
+    assert(type(mover_fraction) == "number")
+    assert(mover_fraction > 0.2 and mover_fraction < 0.3)
+
+    local planes = b2d.world.collide_mover(world, {
+        center1 = vmath.vector3(6, 24, 0),
+        center2 = vmath.vector3(10, 24, 0),
+        radius = 2,
+    }, nil, 16)
+    assert(type(planes) == "table")
+    if #planes > 0 then
+        assert(planes[1].shape ~= nil)
+        assert(planes[1].normal ~= nil)
+        assert(type(planes[1].offset) == "number")
+        assert(type(planes[1].hit) == "boolean")
+    end
+
+    b2d.chain.destroy(chain)
+    assert(not b2d.chain.is_valid(chain))
+    assert_error(function() b2d.chain.get_segment_count(chain) end)
+
+    local loop_chain, loop_segments = b2d.body.create_chain(body, {
+        loop = true,
+        vertices = {
+            vmath.vector3(-4, 40, 0),
+            vmath.vector3(4, 40, 0),
+            vmath.vector3(4, 48, 0),
+            vmath.vector3(-4, 48, 0),
+        },
+    })
+    assert(loop_chain ~= nil)
+    assert(#loop_segments == 4)
+    local loop_geometry = b2d.chain.get_geometry(loop_chain)
+    assert(loop_geometry.loop)
+    assert(#loop_geometry.vertices == 4)
+
+    b2d.body.destroy_shape(body, loop_segments[1].index)
+    assert_error(function() b2d.chain.get_segment_count(loop_chain) end)
+
+    assert_error(function()
+        b2d.body.create_chain(body, {
+            loop = true,
+            vertices = {
+                vmath.vector3(0, 0, 0),
+                vmath.vector3(1, 0, 0),
+                vmath.vector3(1, 1, 0),
+            },
+        })
+    end)
+
+    assert_error(function()
+        b2d.body.create_chain(body, {
+            loop = true,
+            prev_vertex = vmath.vector3(-1, 0, 0),
+            vertices = {
+                vmath.vector3(0, 0, 0),
+                vmath.vector3(1, 0, 0),
+                vmath.vector3(1, 1, 0),
+                vmath.vector3(0, 1, 0),
+            },
+        })
+    end)
+
+    assert_error(function()
+        b2d.body.create_chain(body, {
+            vertices = {
+                vmath.vector3(0, 0, 0),
+            },
+        })
+    end)
+end
+
+function init(self)
+    if b2d ~= nil then
+        local body = b2d.get_body("#collisionobject")
+        assert(body ~= nil)
+        if PHYSICS == "box2dv3" then
+            test_v3_chains(body)
+        else
+            assert(b2d.chain == nil)
+            assert(b2d.body.create_chain == nil)
+        end
+    end
+    tests_done = true
+end

--- a/engine/gamesys/src/gamesys/test/collision_object/box2d_shape_test.go
+++ b/engine/gamesys/src/gamesys/test/collision_object/box2d_shape_test.go
@@ -1,0 +1,8 @@
+components {
+  id: "collisionobject"
+  component: "/collision_object/body.collisionobject"
+}
+components {
+  id: "script"
+  component: "/collision_object/box2d_shape_test.script"
+}

--- a/engine/gamesys/src/gamesys/test/collision_object/box2d_shape_test.script
+++ b/engine/gamesys/src/gamesys/test/collision_object/box2d_shape_test.script
@@ -1,0 +1,203 @@
+-- Copyright 2020-2026 The Defold Foundation
+-- Copyright 2014-2020 King
+-- Copyright 2009-2014 Ragnar Svensson, Christian Murray
+-- Licensed under the Defold License version 1.0 (the "License"); you may not use
+-- this file except in compliance with the License.
+--
+-- You may obtain a copy of the License, together with FAQs at
+-- https://www.defold.com/license
+--
+-- Unless required by applicable law or agreed to in writing, software distributed
+-- under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+-- CONDITIONS OF ANY KIND, either express or implied. See the License for the
+-- specific language governing permissions and limitations under the License.
+
+tests_done = false
+
+-- Test intent:
+-- Verify shape-facing Lua APIs without depending on normal physics contacts.
+-- Setup:
+-- Add one isolated circle to the test body, then read/update its shape data and flags.
+-- Expected:
+-- v2 fixture shape helpers round-trip geometry/properties; v3 body and shape-id helpers
+-- validate ownership, event flags, material, ray casts, mass data and invalidation.
+
+local function assert_error(func)
+    local r, err = pcall(func)
+    if not r then
+        print(err)
+    end
+    assert(not r)
+end
+
+local function assert_near(a, b, eps)
+    if not eps then
+        eps = 0.001
+    end
+    local diff = math.abs(a - b)
+    if not (diff < eps) then
+        local err_msg = "assert_near failed, a: " .. tostring(a) .. ", b: " .. tostring(b) .. " diff == " .. tostring(diff) .. " >= " .. tostring(eps)
+        error(debug.traceback(err_msg))
+    end
+end
+
+local function assert_vec3_near(a, b, eps)
+    assert_near(a.x, b.x, eps)
+    assert_near(a.y, b.y, eps)
+    assert_near(a.z, b.z, eps)
+end
+
+local zp = vmath.vector3(0)
+
+local function test_v2_fixture_shapes(body)
+    assert(b2d.fixture ~= nil)
+    assert(b2d.shape.SHAPE_TYPE_CHAIN ~= nil)
+
+    local target = vmath.vector3(100000, 100000, 0)
+    local fixture = b2d.body.create_fixture(body, {
+        density = 0.5,
+        friction = 0.2,
+        restitution = 0.1,
+        sensor = false,
+        shape = {
+            type = b2d.shape.SHAPE_TYPE_CIRCLE,
+            center = target,
+            radius = 2,
+        },
+        filter = {
+            category_bits = 4,
+            mask_bits = 4,
+            group_index = 0,
+        },
+    })
+    assert(fixture ~= nil)
+    assert(b2d.fixture.get_type(body, fixture.index) == b2d.shape.SHAPE_TYPE_CIRCLE)
+
+    local shape = b2d.fixture.get_shape(body, fixture.index)
+    assert(shape.type == b2d.shape.SHAPE_TYPE_CIRCLE)
+    assert_vec3_near(shape.center, target)
+    assert_near(shape.radius, 2)
+
+    local updated_center = target + vmath.vector3(1, 0, 0)
+    b2d.fixture.set_shape(body, fixture.index, {
+        type = b2d.shape.SHAPE_TYPE_CIRCLE,
+        center = updated_center,
+        radius = 3,
+    }, true)
+    local updated_shape = b2d.fixture.get_shape(body, fixture.index)
+    assert_vec3_near(updated_shape.center, updated_center)
+    assert_near(updated_shape.radius, 3)
+
+    b2d.fixture.set_sensor(body, fixture.index, true)
+    assert(b2d.fixture.is_sensor(body, fixture.index))
+    b2d.fixture.set_density(body, fixture.index, 0.75, true)
+    assert_near(b2d.fixture.get_density(body, fixture.index), 0.75)
+    b2d.fixture.set_friction(body, fixture.index, 0.4)
+    assert_near(b2d.fixture.get_friction(body, fixture.index), 0.4)
+    b2d.fixture.set_restitution(body, fixture.index, 0.3)
+    assert_near(b2d.fixture.get_restitution(body, fixture.index), 0.3)
+
+    local filter = {
+        category_bits = 8,
+        mask_bits = 8,
+        group_index = 0,
+    }
+    b2d.fixture.set_filter_data(body, fixture.index, 1, filter)
+    local filter_data = b2d.fixture.get_filter_data(body, fixture.index, 1)
+    assert(filter_data.category_bits == filter.category_bits)
+    assert(filter_data.mask_bits == filter.mask_bits)
+    assert(filter_data.group_index == filter.group_index)
+    b2d.fixture.refilter(body, fixture.index, true)
+
+    assert(b2d.fixture.test_point(body, fixture.index, updated_center))
+    local aabb = b2d.fixture.get_aabb(body, fixture.index, 1)
+    assert(aabb.lower.x <= aabb.upper.x)
+    assert(aabb.lower.y <= aabb.upper.y)
+
+    b2d.body.destroy_fixture(body, fixture.index)
+end
+
+local function test_v3_body_and_shapes(body)
+    local world = b2d.get_world()
+    assert(world ~= nil)
+    assert(world == b2d.body.get_world(body))
+
+    assert(b2d.body.is_valid(body))
+    b2d.body.set_name(body, "shape-test-body")
+    assert(b2d.body.get_name(body) == "shape-test-body")
+    local body_position = b2d.body.get_position(body)
+    local body_angle = b2d.body.get_angle(body)
+    b2d.body.set_target_transform(body, body_position, body_angle, 1 / 60)
+    b2d.body.apply_linear_impulse_to_center(body, zp)
+    local sleep_threshold = b2d.body.get_sleep_threshold(body)
+    b2d.body.set_sleep_threshold(body, sleep_threshold + 1)
+    assert_near(b2d.body.get_sleep_threshold(body), sleep_threshold + 1)
+    b2d.body.set_sleep_threshold(body, sleep_threshold)
+    b2d.body.enable_contact_events(body, true)
+    b2d.body.enable_hit_events(body, true)
+    assert(type(b2d.body.get_contact_data(body)) == "table")
+
+    local target = vmath.vector3(100000, 100000, 0)
+    local material_shape = b2d.body.create_shape(body, {
+        type = b2d.shape.SHAPE_TYPE_CIRCLE,
+        center = target,
+        radius = 1,
+        density = 0,
+        material = 13,
+    })
+    assert(material_shape.material == 13)
+    assert(material_shape.shape_id ~= nil)
+    assert(b2d.shape.get_type(material_shape.shape_id) == b2d.shape.SHAPE_TYPE_CIRCLE)
+    assert(b2d.shape.get_shape(material_shape.shape_id).type == b2d.shape.SHAPE_TYPE_CIRCLE)
+    assert(b2d.shape.get_material(material_shape.shape_id) == 13)
+    b2d.shape.set_material(material_shape.shape_id, 17)
+    assert(b2d.shape.get_material(material_shape.shape_id) == 17)
+    local material_shape_info = b2d.body.get_shapes(body)[material_shape.index]
+    assert(material_shape_info.shape_id == material_shape.shape_id)
+    assert(material_shape_info.material == 17)
+    assert(b2d.shape.is_valid(material_shape.shape_id))
+    assert(b2d.shape.get_body(material_shape.shape_id) == body)
+    assert(b2d.shape.get_world(material_shape.shape_id) == world)
+
+    b2d.shape.enable_sensor_events(material_shape.shape_id, true)
+    assert(b2d.shape.are_sensor_events_enabled(material_shape.shape_id))
+    b2d.shape.enable_contact_events(material_shape.shape_id, true)
+    assert(b2d.shape.are_contact_events_enabled(material_shape.shape_id))
+    b2d.shape.enable_pre_solve_events(material_shape.shape_id, true)
+    assert(b2d.shape.are_pre_solve_events_enabled(material_shape.shape_id))
+    b2d.shape.enable_hit_events(material_shape.shape_id, true)
+    assert(b2d.shape.are_hit_events_enabled(material_shape.shape_id))
+
+    local shape_ray_hit = b2d.shape.ray_cast(material_shape.shape_id, target + vmath.vector3(0, -2, 0), vmath.vector3(0, 4, 0))
+    assert(shape_ray_hit ~= nil)
+    assert_vec3_near(shape_ray_hit.point, target + vmath.vector3(0, -1, 0), 0.1)
+    assert_near(shape_ray_hit.fraction, 0.25, 0.01)
+    assert(type(shape_ray_hit.iterations) == "number")
+    assert(type(b2d.shape.get_contact_capacity(material_shape.shape_id)) == "number")
+    assert(type(b2d.shape.get_contact_data(material_shape.shape_id)) == "table")
+    assert(type(b2d.shape.get_sensor_capacity(material_shape.shape_id)) == "number")
+    assert(type(b2d.shape.get_sensor_overlaps(material_shape.shape_id)) == "table")
+    local shape_mass_data = b2d.shape.get_mass_data(material_shape.shape_id)
+    assert(type(shape_mass_data.mass) == "number")
+    assert_vec3_near(b2d.shape.get_closest_point(material_shape.shape_id, target + vmath.vector3(4, 0, 0)), target + vmath.vector3(1, 0, 0), 0.1)
+
+    local material_body_aabb = b2d.body.compute_aabb(body)
+    assert(material_body_aabb.lower.x <= material_body_aabb.upper.x)
+    assert(material_body_aabb.lower.y <= material_body_aabb.upper.y)
+    b2d.body.destroy_shape(body, material_shape.index)
+    assert(not b2d.shape.is_valid(material_shape.shape_id))
+    assert_error(function() b2d.shape.get_type(material_shape.shape_id) end)
+end
+
+function init(self)
+    if b2d ~= nil then
+        local body = b2d.get_body("#collisionobject")
+        assert(body ~= nil)
+        if PHYSICS == "box2dv3" then
+            test_v3_body_and_shapes(body)
+        else
+            test_v2_fixture_shapes(body)
+        end
+    end
+    tests_done = true
+end

--- a/engine/gamesys/src/gamesys/test/collision_object/box2d_world_test.go
+++ b/engine/gamesys/src/gamesys/test/collision_object/box2d_world_test.go
@@ -1,0 +1,8 @@
+components {
+  id: "collisionobject"
+  component: "/collision_object/body.collisionobject"
+}
+components {
+  id: "script"
+  component: "/collision_object/box2d_world_test.script"
+}

--- a/engine/gamesys/src/gamesys/test/collision_object/box2d_world_test.script
+++ b/engine/gamesys/src/gamesys/test/collision_object/box2d_world_test.script
@@ -1,0 +1,311 @@
+-- Copyright 2020-2026 The Defold Foundation
+-- Copyright 2014-2020 King
+-- Copyright 2009-2014 Ragnar Svensson, Christian Murray
+-- Licensed under the Defold License version 1.0 (the "License"); you may not use
+-- this file except in compliance with the License.
+--
+-- You may obtain a copy of the License, together with FAQs at
+-- https://www.defold.com/license
+--
+-- Unless required by applicable law or agreed to in writing, software distributed
+-- under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+-- CONDITIONS OF ANY KIND, either express or implied. See the License for the
+-- specific language governing permissions and limitations under the License.
+
+tests_done = false
+
+-- Test intent:
+-- Verify the Lua b2d.world query/cast wrappers against a single known circle.
+-- Setup:
+-- Add one far-away circle to the test body so it is isolated from built-in test shapes.
+-- Expected:
+-- Overlap and cast APIs return that exact shape/fixture, with hit points and fractions
+-- close to the analytically expected circle contact.
+
+local function assert_near(a, b, eps)
+    if not eps then
+        eps = 0.001
+    end
+    local diff = math.abs(a - b)
+    if not (diff < eps) then
+        local err_msg = "assert_near failed, a: " .. tostring(a) .. ", b: " .. tostring(b) .. " diff == " .. tostring(diff) .. " >= " .. tostring(eps)
+        error(debug.traceback(err_msg))
+    end
+end
+
+local function assert_vec3_near(a, b, eps)
+    assert_near(a.x, b.x, eps)
+    assert_near(a.y, b.y, eps)
+    assert_near(a.z, b.z, eps)
+end
+
+local function find_fixture_hit(hits, body, fixture_index)
+    for _, hit in ipairs(hits) do
+        local fixture = hit.fixture or hit.shape or hit
+        if fixture.body == body and fixture.index == fixture_index then
+            return hit
+        end
+    end
+    return nil
+end
+
+local function find_shape_hit(hits, shape_id)
+    for _, hit in ipairs(hits) do
+        local shape = hit.shape or hit
+        if shape.shape_id == shape_id then
+            return hit
+        end
+    end
+    return nil
+end
+
+local function test_v2_world(body)
+    local world = b2d.get_world()
+    assert(world ~= nil)
+    assert(world == b2d.body.get_world(body))
+    assert(b2d.world ~= nil)
+
+    local target = vmath.vector3(100000, 100000, 0)
+    local query_filter = {
+        category_bits = 2,
+        mask_bits = 2,
+        group_index = 0,
+    }
+    local fixture = b2d.body.create_fixture(body, {
+        density = 0,
+        shape = {
+            type = b2d.shape.SHAPE_TYPE_CIRCLE,
+            center = target,
+            radius = 1,
+        },
+        filter = query_filter,
+    })
+    assert(fixture ~= nil)
+
+    local overlap_hits, overlap_stats = b2d.world.overlap_aabb(world, {
+        lower = target - vmath.vector3(2, 2, 0),
+        upper = target + vmath.vector3(2, 2, 0),
+    }, query_filter, 8)
+    assert(type(overlap_hits) == "table")
+    assert(type(overlap_stats.node_visits) == "number")
+    assert(type(overlap_stats.leaf_visits) == "number")
+    local overlap_hit = find_fixture_hit(overlap_hits, body, fixture.index)
+    assert(overlap_hit ~= nil)
+    assert(overlap_hit.type == b2d.shape.SHAPE_TYPE_CIRCLE)
+    assert(overlap_hit.child_index == 1)
+
+    local shape_hits, shape_stats = b2d.world.overlap_shape(world, {
+        type = b2d.shape.SHAPE_TYPE_CIRCLE,
+        center = target,
+        radius = 0.5,
+    }, query_filter, 8)
+    assert(type(shape_hits) == "table")
+    assert(type(shape_stats.leaf_visits) == "number")
+    local shape_overlap_hit = find_fixture_hit(shape_hits, body, fixture.index)
+    assert(shape_overlap_hit ~= nil)
+    assert(shape_overlap_hit.type == b2d.shape.SHAPE_TYPE_CIRCLE)
+
+    local ray_origin = target + vmath.vector3(0, -2, 0)
+    local ray_translation = vmath.vector3(0, 4, 0)
+    local expected_ray_point = target + vmath.vector3(0, -1, 0)
+    local ray_hits, ray_stats = b2d.world.cast_ray(world, ray_origin, ray_translation, query_filter, 8)
+    assert(type(ray_hits) == "table")
+    assert(type(ray_stats.leaf_visits) == "number")
+    local ray_hit = find_fixture_hit(ray_hits, body, fixture.index)
+    assert(ray_hit ~= nil)
+    assert_vec3_near(ray_hit.point, expected_ray_point, 0.1)
+    assert_near(ray_hit.fraction, 0.25, 0.01)
+
+    local closest = b2d.world.cast_ray_closest(world, ray_origin, ray_translation, query_filter)
+    assert(closest ~= nil)
+    assert(closest.fixture.body == body)
+    assert(closest.fixture.index == fixture.index)
+    assert_vec3_near(closest.point, expected_ray_point, 0.1)
+    assert_near(closest.fraction, 0.25, 0.01)
+
+    local cast_hits, cast_stats = b2d.world.cast_shape(world, {
+        type = b2d.shape.SHAPE_TYPE_CIRCLE,
+        center = ray_origin,
+        radius = 0.5,
+    }, ray_translation, query_filter, 8)
+    assert(type(cast_hits) == "table")
+    assert(type(cast_stats.node_visits) == "number")
+    local cast_hit = find_fixture_hit(cast_hits, body, fixture.index)
+    assert(cast_hit ~= nil)
+    assert_vec3_near(cast_hit.point, expected_ray_point, 0.2)
+    assert_near(cast_hit.fraction, 0.125, 0.02)
+
+    b2d.body.destroy_fixture(body, fixture.index)
+end
+
+local function test_v3_world(body)
+    local world = b2d.get_world()
+    assert(world ~= nil)
+    assert(world == b2d.body.get_world(body))
+    assert(b2d.world.is_valid(world))
+    assert(not b2d.world.is_locked(world))
+
+    local original_gravity = b2d.world.get_gravity(world)
+    b2d.world.set_gravity(world, vmath.vector3(0, -123, 0))
+    assert_vec3_near(b2d.world.get_gravity(world), vmath.vector3(0, -123, 0))
+    b2d.world.set_gravity(world, original_gravity)
+
+    local sleeping_enabled = b2d.world.is_sleeping_enabled(world)
+    b2d.world.enable_sleeping(world, not sleeping_enabled)
+    assert(b2d.world.is_sleeping_enabled(world) == not sleeping_enabled)
+    b2d.world.enable_sleeping(world, sleeping_enabled)
+
+    local continuous_enabled = b2d.world.is_continuous_enabled(world)
+    b2d.world.enable_continuous(world, not continuous_enabled)
+    assert(b2d.world.is_continuous_enabled(world) == not continuous_enabled)
+    b2d.world.enable_continuous(world, continuous_enabled)
+
+    local warm_starting_enabled = b2d.world.is_warm_starting_enabled(world)
+    b2d.world.enable_warm_starting(world, not warm_starting_enabled)
+    assert(b2d.world.is_warm_starting_enabled(world) == not warm_starting_enabled)
+    b2d.world.enable_warm_starting(world, warm_starting_enabled)
+
+    local restitution_threshold = b2d.world.get_restitution_threshold(world)
+    b2d.world.set_restitution_threshold(world, restitution_threshold + 1)
+    assert_near(b2d.world.get_restitution_threshold(world), restitution_threshold + 1)
+    b2d.world.set_restitution_threshold(world, restitution_threshold)
+
+    local hit_event_threshold = b2d.world.get_hit_event_threshold(world)
+    b2d.world.set_hit_event_threshold(world, hit_event_threshold + 1)
+    assert_near(b2d.world.get_hit_event_threshold(world), hit_event_threshold + 1)
+    b2d.world.set_hit_event_threshold(world, hit_event_threshold)
+
+    local max_linear_speed = b2d.world.get_maximum_linear_speed(world)
+    b2d.world.set_maximum_linear_speed(world, max_linear_speed + 10)
+    assert_near(b2d.world.get_maximum_linear_speed(world), max_linear_speed + 10)
+    b2d.world.set_maximum_linear_speed(world, max_linear_speed)
+
+    b2d.world.set_contact_tuning(world, 30, 10, 3)
+    b2d.world.set_joint_tuning(world, 60, 2)
+    assert(type(b2d.world.get_awake_body_count(world)) == "number")
+
+    local profile = b2d.world.get_profile(world)
+    assert(type(profile) == "table")
+    assert(type(profile.step) == "number")
+
+    local counters = b2d.world.get_counters(world)
+    assert(type(counters) == "table")
+    assert(type(counters.body_count) == "number")
+    assert(type(counters.color_counts) == "table")
+
+    b2d.world.explode(world, {
+        position = vmath.vector3(100000, 100000, 0),
+        radius = 1,
+        falloff = 1,
+        impulse_per_length = 1,
+    })
+    b2d.world.rebuild_static_tree(world)
+    b2d.world.enable_speculative(world, false)
+    b2d.world.enable_speculative(world, true)
+
+    local target = vmath.vector3(100000, 100000, 0)
+    local query_filter = {
+        category_bits = 2,
+        mask_bits = 2,
+    }
+    local shape = b2d.body.create_shape(body, {
+        type = b2d.shape.SHAPE_TYPE_CIRCLE,
+        center = target,
+        radius = 1,
+        density = 0,
+        filter = query_filter,
+    })
+    assert(shape ~= nil)
+    assert(shape.shape_id ~= nil)
+
+    local overlap_hits, overlap_stats = b2d.world.overlap_aabb(world, {
+        lower = target - vmath.vector3(2, 2, 0),
+        upper = target + vmath.vector3(2, 2, 0),
+    }, query_filter, 8)
+    assert(type(overlap_hits) == "table")
+    assert(type(overlap_stats.node_visits) == "number")
+    assert(type(overlap_stats.leaf_visits) == "number")
+    local overlap_hit = find_shape_hit(overlap_hits, shape.shape_id)
+    assert(overlap_hit ~= nil)
+    assert(overlap_hit.type == b2d.shape.SHAPE_TYPE_CIRCLE)
+
+    local shape_hits, shape_stats = b2d.world.overlap_shape(world, {
+        type = b2d.shape.SHAPE_TYPE_CIRCLE,
+        center = target,
+        radius = 0.5,
+    }, query_filter, 8)
+    assert(type(shape_hits) == "table")
+    assert(type(shape_stats.leaf_visits) == "number")
+    local shape_overlap_hit = find_shape_hit(shape_hits, shape.shape_id)
+    assert(shape_overlap_hit ~= nil)
+    assert(shape_overlap_hit.type == b2d.shape.SHAPE_TYPE_CIRCLE)
+
+    local ray_origin = target + vmath.vector3(0, -2, 0)
+    local ray_translation = vmath.vector3(0, 4, 0)
+    local expected_ray_point = target + vmath.vector3(0, -1, 0)
+    local ray_hits, ray_stats = b2d.world.cast_ray(world, ray_origin, ray_translation, query_filter, 8)
+    assert(type(ray_hits) == "table")
+    assert(type(ray_stats.leaf_visits) == "number")
+    local ray_hit = find_shape_hit(ray_hits, shape.shape_id)
+    assert(ray_hit ~= nil)
+    assert(ray_hit.shape.shape_id == shape.shape_id)
+    assert_vec3_near(ray_hit.point, expected_ray_point, 0.1)
+    assert_near(ray_hit.fraction, 0.25, 0.01)
+
+    local closest = b2d.world.cast_ray_closest(world, ray_origin, ray_translation, query_filter)
+    assert(closest ~= nil)
+    assert(closest.shape.shape_id == shape.shape_id)
+    assert_vec3_near(closest.point, expected_ray_point, 0.1)
+    assert_near(closest.fraction, 0.25, 0.01)
+    assert(type(closest.node_visits) == "number")
+    assert(type(closest.leaf_visits) == "number")
+
+    local cast_hits, cast_stats = b2d.world.cast_shape(world, {
+        type = b2d.shape.SHAPE_TYPE_CIRCLE,
+        center = ray_origin,
+        radius = 0.5,
+    }, ray_translation, query_filter, 8)
+    assert(type(cast_hits) == "table")
+    assert(type(cast_stats.node_visits) == "number")
+    local cast_hit = find_shape_hit(cast_hits, shape.shape_id)
+    assert(cast_hit ~= nil)
+    assert(cast_hit.shape.shape_id == shape.shape_id)
+    assert_vec3_near(cast_hit.point, expected_ray_point, 0.5)
+    assert_near(cast_hit.fraction, 0.125, 0.05)
+
+    local mover_fraction = b2d.world.cast_mover(world, {
+        center1 = ray_origin + vmath.vector3(-0.5, 0, 0),
+        center2 = ray_origin + vmath.vector3(0.5, 0, 0),
+        radius = 0.5,
+    }, ray_translation)
+    assert(type(mover_fraction) == "number")
+    assert(mover_fraction >= 0 and mover_fraction <= 1)
+
+    local planes = b2d.world.collide_mover(world, {
+        center1 = target + vmath.vector3(-0.5, 0, 0),
+        center2 = target + vmath.vector3(0.5, 0, 0),
+        radius = 2,
+    }, query_filter, 8)
+    assert(type(planes) == "table")
+    if #planes > 0 then
+        assert(planes[1].shape ~= nil)
+        assert(planes[1].normal ~= nil)
+        assert(type(planes[1].offset) == "number")
+        assert(type(planes[1].hit) == "boolean")
+    end
+
+    b2d.body.destroy_shape(body, shape.index)
+end
+
+function init(self)
+    if b2d ~= nil then
+        local body = b2d.get_body("#collisionobject")
+        assert(body ~= nil)
+        if PHYSICS == "box2dv3" then
+            test_v3_world(body)
+        else
+            test_v2_world(body)
+        end
+    end
+    tests_done = true
+end

--- a/engine/gamesys/src/gamesys/test/collision_object/build.inputs
+++ b/engine/gamesys/src/gamesys/test/collision_object/build.inputs
@@ -1,4 +1,7 @@
 /collision_object/default.texture_profiles
+/collision_object/box2d_chain_test.go
+/collision_object/box2d_shape_test.go
+/collision_object/box2d_world_test.go
 /collision_object/body.go
 /collision_object/callback_object.go
 /collision_object/callback_trigger.go

--- a/engine/gamesys/src/gamesys/test/collision_object/joint_test.script
+++ b/engine/gamesys/src/gamesys/test/collision_object/joint_test.script
@@ -44,6 +44,291 @@ end
 -- reusable zero point
 local zp = vmath.vector3(0)
 
+local function test_native_b2d_world_and_chains(body_a, body_b, body_c)
+    local world = b2d.get_world()
+    assert(world ~= nil)
+    assert(world == b2d.body.get_world(body_a))
+    assert(world == b2d.body.get_world(body_b))
+    assert(world == b2d.body.get_world(body_c))
+    assert(b2d.world.is_valid(world))
+    assert(not b2d.world.is_locked(world))
+
+    local original_gravity = b2d.world.get_gravity(world)
+    b2d.world.set_gravity(world, vmath.vector3(0, -123, 0))
+    assert_vec3_near(b2d.world.get_gravity(world), vmath.vector3(0, -123, 0))
+    b2d.world.set_gravity(world, original_gravity)
+
+    local sleeping_enabled = b2d.world.is_sleeping_enabled(world)
+    b2d.world.enable_sleeping(world, not sleeping_enabled)
+    assert(b2d.world.is_sleeping_enabled(world) == not sleeping_enabled)
+    b2d.world.enable_sleeping(world, sleeping_enabled)
+
+    local continuous_enabled = b2d.world.is_continuous_enabled(world)
+    b2d.world.enable_continuous(world, not continuous_enabled)
+    assert(b2d.world.is_continuous_enabled(world) == not continuous_enabled)
+    b2d.world.enable_continuous(world, continuous_enabled)
+
+    local warm_starting_enabled = b2d.world.is_warm_starting_enabled(world)
+    b2d.world.enable_warm_starting(world, not warm_starting_enabled)
+    assert(b2d.world.is_warm_starting_enabled(world) == not warm_starting_enabled)
+    b2d.world.enable_warm_starting(world, warm_starting_enabled)
+
+    local restitution_threshold = b2d.world.get_restitution_threshold(world)
+    b2d.world.set_restitution_threshold(world, restitution_threshold + 1)
+    assert_near(b2d.world.get_restitution_threshold(world), restitution_threshold + 1)
+    b2d.world.set_restitution_threshold(world, restitution_threshold)
+
+    local hit_event_threshold = b2d.world.get_hit_event_threshold(world)
+    b2d.world.set_hit_event_threshold(world, hit_event_threshold + 1)
+    assert_near(b2d.world.get_hit_event_threshold(world), hit_event_threshold + 1)
+    b2d.world.set_hit_event_threshold(world, hit_event_threshold)
+
+    local max_linear_speed = b2d.world.get_maximum_linear_speed(world)
+    b2d.world.set_maximum_linear_speed(world, max_linear_speed + 10)
+    assert_near(b2d.world.get_maximum_linear_speed(world), max_linear_speed + 10)
+    b2d.world.set_maximum_linear_speed(world, max_linear_speed)
+
+    b2d.world.set_contact_tuning(world, 30, 10, 3)
+    b2d.world.set_joint_tuning(world, 60, 2)
+    assert(type(b2d.world.get_awake_body_count(world)) == "number")
+
+    local profile = b2d.world.get_profile(world)
+    assert(type(profile) == "table")
+    assert(type(profile.step) == "number")
+
+    local counters = b2d.world.get_counters(world)
+    assert(type(counters) == "table")
+    assert(type(counters.body_count) == "number")
+    assert(type(counters.color_counts) == "table")
+
+    b2d.world.explode(world, {
+        position = vmath.vector3(100000, 100000, 0),
+        radius = 1,
+        falloff = 1,
+        impulse_per_length = 1,
+    })
+    b2d.world.rebuild_static_tree(world)
+    b2d.world.enable_speculative(world, false)
+    b2d.world.enable_speculative(world, true)
+
+    local material_shape = b2d.body.create_shape(body_a, {
+        type = b2d.shape.SHAPE_TYPE_CIRCLE,
+        center = vmath.vector3(100000, 100000, 0),
+        radius = 1,
+        density = 0,
+        material = 13,
+    })
+    assert(material_shape.material == 13)
+    assert(material_shape.shape_id ~= nil)
+    assert(b2d.shape.get_type(material_shape.shape_id) == b2d.shape.SHAPE_TYPE_CIRCLE)
+    assert(b2d.shape.get_shape(material_shape.shape_id).type == b2d.shape.SHAPE_TYPE_CIRCLE)
+    assert(b2d.shape.get_material(material_shape.shape_id) == 13)
+    b2d.shape.set_material(material_shape.shape_id, 17)
+    assert(b2d.shape.get_material(material_shape.shape_id) == 17)
+    local material_shape_info = b2d.body.get_shapes(body_a)[material_shape.index]
+    assert(material_shape_info.shape_id == material_shape.shape_id)
+    assert(material_shape_info.material == 17)
+    b2d.body.destroy_shape(body_a, material_shape.index)
+    assert_error(function() b2d.shape.get_type(material_shape.shape_id) end)
+
+    local chain, segments = b2d.body.create_chain(body_c, {
+        vertices = {
+            vmath.vector3(-16, 20, 0),
+            vmath.vector3(0, 28, 0),
+            vmath.vector3(16, 20, 0),
+        },
+        prev_vertex = vmath.vector3(-24, 12, 0),
+        next_vertex = vmath.vector3(24, 12, 0),
+        friction = 0.2,
+        restitution = 0.1,
+        material = 7,
+        filter = {
+            category_bits = 1,
+            mask_bits = 1,
+            group_index = 0,
+        },
+        enable_sensor_events = true,
+    })
+    assert(chain ~= nil)
+    assert(#segments == 2)
+    assert(b2d.chain.get_segment_count(chain) == #segments)
+    assert(segments[1].type == b2d.shape.SHAPE_TYPE_SEGMENT)
+    assert(segments[1].shape_id ~= nil)
+    assert(segments[1].is_chain_segment)
+
+    local segment_snapshot = b2d.shape.get_shape(segments[1].shape_id)
+    assert(segment_snapshot.type == b2d.shape.SHAPE_TYPE_SEGMENT)
+    assert(segment_snapshot.v0 ~= nil)
+    assert(segment_snapshot.v1 ~= nil)
+    assert(segment_snapshot.v2 ~= nil)
+    assert(segment_snapshot.v3 ~= nil)
+    assert_error(function() b2d.shape.set_shape(segments[1].shape_id, segment_snapshot) end)
+
+    local chain_from_shape = b2d.chain.from_shape(segments[1].shape_id)
+    assert(chain_from_shape == chain)
+    assert(b2d.chain.from_shape(body_a, 1) == nil)
+
+    local chain_segments = b2d.chain.get_segments(chain)
+    assert(#chain_segments == 2)
+    assert(chain_segments[2].is_chain_segment)
+
+    local geometry = b2d.chain.get_geometry(chain)
+    assert(not geometry.loop)
+    assert(#geometry.vertices == 3)
+    assert_vec3_near(geometry.prev_vertex, vmath.vector3(-24, 12, 0))
+    assert_vec3_near(geometry.next_vertex, vmath.vector3(24, 12, 0))
+
+    assert_near(b2d.chain.get_friction(chain), 0.2)
+    assert_near(b2d.chain.get_restitution(chain), 0.1)
+    assert(b2d.chain.get_material(chain) == 7)
+    b2d.chain.set_friction(chain, 0.4)
+    b2d.chain.set_restitution(chain, 0.3)
+    b2d.chain.set_material(chain, 11)
+    assert_near(b2d.chain.get_friction(chain), 0.4)
+    assert_near(b2d.chain.get_restitution(chain), 0.3)
+    assert(b2d.chain.get_material(chain) == 11)
+
+    local hits, stats = b2d.world.overlap_aabb(world, {
+        lower = vmath.vector3(-20, -84, 0),
+        upper = vmath.vector3(20, -68, 0),
+    }, {}, 16)
+    assert(type(hits) == "table")
+    assert(#hits > 0)
+    assert(type(stats.node_visits) == "number")
+    assert(type(stats.leaf_visits) == "number")
+
+    local shape_hits, shape_stats = b2d.world.overlap_shape(world, {
+        type = b2d.shape.SHAPE_TYPE_CIRCLE,
+        center = vmath.vector3(8, -76, 0),
+        radius = 3,
+    }, nil, 16)
+    assert(type(shape_hits) == "table")
+    assert(#shape_hits > 0)
+    assert(type(shape_stats.node_visits) == "number")
+
+    local expected_cast_shape_index = segments[2].index
+    local expected_cast_point = vmath.vector3(8, -76, 0)
+    local expected_ray_fraction = 12 / 60
+    local function find_hit_for_shape(hits, shape_index)
+        for _, hit in ipairs(hits) do
+            if hit.shape and hit.shape.index == shape_index then
+                return hit
+            end
+        end
+        return nil
+    end
+
+    local ray_hits, ray_stats = b2d.world.cast_ray(world, vmath.vector3(8, -88, 0), vmath.vector3(0, 60, 0), nil, 16)
+    assert(type(ray_hits) == "table")
+    assert(#ray_hits > 0)
+    assert(type(ray_stats.leaf_visits) == "number")
+    local ray_chain_hit = find_hit_for_shape(ray_hits, expected_cast_shape_index)
+    assert(ray_chain_hit ~= nil)
+    assert(ray_chain_hit.shape.shape_id == segments[2].shape_id)
+    assert(ray_chain_hit.shape.is_chain_segment)
+    assert_vec3_near(ray_chain_hit.point, expected_cast_point, 0.1)
+    assert_near(ray_chain_hit.fraction, expected_ray_fraction, 0.01)
+
+    local closest = b2d.world.cast_ray_closest(world, vmath.vector3(8, -88, 0), vmath.vector3(0, 60, 0))
+    assert(closest ~= nil)
+    assert(closest.shape.index == expected_cast_shape_index)
+    assert(closest.shape.shape_id == segments[2].shape_id)
+    assert(closest.shape.is_chain_segment)
+    assert_vec3_near(closest.point, expected_cast_point, 0.1)
+    assert_near(closest.fraction, expected_ray_fraction, 0.01)
+    assert(type(closest.node_visits) == "number")
+    assert(type(closest.leaf_visits) == "number")
+
+    local cast_hits, cast_stats = b2d.world.cast_shape(world, {
+        type = b2d.shape.SHAPE_TYPE_CIRCLE,
+        center = vmath.vector3(8, -88, 0),
+        radius = 1,
+    }, vmath.vector3(0, 60, 0), nil, 16)
+    assert(type(cast_hits) == "table")
+    assert(#cast_hits > 0)
+    assert(type(cast_stats.node_visits) == "number")
+    local shape_chain_hit = find_hit_for_shape(cast_hits, expected_cast_shape_index)
+    assert(shape_chain_hit ~= nil)
+    assert(shape_chain_hit.shape.shape_id == segments[2].shape_id)
+    assert(shape_chain_hit.shape.is_chain_segment)
+    assert_vec3_near(shape_chain_hit.point, expected_cast_point, 2.0)
+    assert(shape_chain_hit.fraction > 0.15 and shape_chain_hit.fraction < 0.25)
+
+    local mover_fraction = b2d.world.cast_mover(world, {
+        center1 = vmath.vector3(6, -88, 0),
+        center2 = vmath.vector3(10, -88, 0),
+        radius = 1,
+    }, vmath.vector3(0, 60, 0))
+    assert(type(mover_fraction) == "number")
+    assert(mover_fraction > 0.15 and mover_fraction < 0.25)
+
+    local planes = b2d.world.collide_mover(world, {
+        center1 = vmath.vector3(6, -76, 0),
+        center2 = vmath.vector3(10, -76, 0),
+        radius = 2,
+    }, nil, 16)
+    assert(type(planes) == "table")
+    if #planes > 0 then
+        assert(planes[1].shape ~= nil)
+        assert(planes[1].normal ~= nil)
+        assert(type(planes[1].offset) == "number")
+        assert(type(planes[1].hit) == "boolean")
+    end
+
+    b2d.chain.destroy(chain)
+    assert_error(function() b2d.chain.get_segment_count(chain) end)
+
+    local loop_chain, loop_segments = b2d.body.create_chain(body_c, {
+        loop = true,
+        vertices = {
+            vmath.vector3(-4, 40, 0),
+            vmath.vector3(4, 40, 0),
+            vmath.vector3(4, 48, 0),
+            vmath.vector3(-4, 48, 0),
+        },
+    })
+    assert(loop_chain ~= nil)
+    assert(#loop_segments == 4)
+    local loop_geometry = b2d.chain.get_geometry(loop_chain)
+    assert(loop_geometry.loop)
+    assert(#loop_geometry.vertices == 4)
+
+    b2d.body.destroy_shape(body_c, loop_segments[1].index)
+    assert_error(function() b2d.chain.get_segment_count(loop_chain) end)
+
+    assert_error(function()
+        b2d.body.create_chain(body_c, {
+            loop = true,
+            vertices = {
+                vmath.vector3(0, 0, 0),
+                vmath.vector3(1, 0, 0),
+                vmath.vector3(1, 1, 0),
+            },
+        })
+    end)
+
+    assert_error(function()
+        b2d.body.create_chain(body_c, {
+            loop = true,
+            prev_vertex = vmath.vector3(-1, 0, 0),
+            vertices = {
+                vmath.vector3(0, 0, 0),
+                vmath.vector3(1, 0, 0),
+                vmath.vector3(1, 1, 0),
+                vmath.vector3(0, 1, 0),
+            },
+        })
+    end)
+
+    assert_error(function()
+        b2d.body.create_chain(body_c, {
+            vertices = {
+                vmath.vector3(0, 0, 0),
+            },
+        })
+    end)
+end
+
 local function test_native_b2d_joints(self)
     if b2d == nil then
         return
@@ -55,6 +340,10 @@ local function test_native_b2d_joints(self)
     assert(body_a ~= nil)
     assert(body_b ~= nil)
     assert(body_c ~= nil)
+
+    if PHYSICS == "box2dv3" then
+        test_native_b2d_world_and_chains(body_a, body_b, body_c)
+    end
 
     local managed_joint_id = "native_managed_joint"
     physics.create_joint(physics.JOINT_TYPE_SPRING, self.a_coll, managed_joint_id, zp, self.b_coll, zp)

--- a/engine/gamesys/src/gamesys/test/collision_object/joint_test.script
+++ b/engine/gamesys/src/gamesys/test/collision_object/joint_test.script
@@ -474,12 +474,6 @@ local function test_native_b2d_joints(self)
     assert(body_b ~= nil)
     assert(body_c ~= nil)
 
-    if PHYSICS == "box2dv3" then
-        test_native_b2d_world_and_chains(body_a, body_b, body_c)
-    else
-        test_native_b2d_v2_world_queries(body_a)
-    end
-
     local managed_joint_id = "native_managed_joint"
     physics.create_joint(physics.JOINT_TYPE_SPRING, self.a_coll, managed_joint_id, zp, self.b_coll, zp)
     assert(#b2d.body.get_joints(body_a) == 0)

--- a/engine/gamesys/src/gamesys/test/collision_object/joint_test.script
+++ b/engine/gamesys/src/gamesys/test/collision_object/joint_test.script
@@ -374,6 +374,94 @@ local function test_native_b2d_world_and_chains(body_a, body_b, body_c)
     end)
 end
 
+local function test_native_b2d_v2_world_queries(body_a)
+    local world = b2d.get_world()
+    assert(world ~= nil)
+    assert(world == b2d.body.get_world(body_a))
+    assert(b2d.world ~= nil)
+
+    local target = vmath.vector3(100000, 100000, 0)
+    local query_filter = {
+        category_bits = 2,
+        mask_bits = 2,
+        group_index = 0,
+    }
+    local fixture = b2d.body.create_fixture(body_a, {
+        density = 0,
+        shape = {
+            type = b2d.shape.SHAPE_TYPE_CIRCLE,
+            center = target,
+            radius = 1,
+        },
+        filter = query_filter,
+    })
+    assert(fixture ~= nil)
+
+    local function find_fixture_hit(hits, body, fixture_index)
+        for _, hit in ipairs(hits) do
+            local fixture_info = hit.fixture or hit.shape or hit
+            if fixture_info.body == body and fixture_info.index == fixture_index then
+                return hit
+            end
+        end
+        return nil
+    end
+
+    local overlap_hits, overlap_stats = b2d.world.overlap_aabb(world, {
+        lower = target - vmath.vector3(2, 2, 0),
+        upper = target + vmath.vector3(2, 2, 0),
+    }, query_filter, 8)
+    assert(type(overlap_hits) == "table")
+    assert(type(overlap_stats.node_visits) == "number")
+    assert(type(overlap_stats.leaf_visits) == "number")
+    local overlap_hit = find_fixture_hit(overlap_hits, body_a, fixture.index)
+    assert(overlap_hit ~= nil)
+    assert(overlap_hit.type == b2d.shape.SHAPE_TYPE_CIRCLE)
+    assert(overlap_hit.child_index == 1)
+
+    local shape_hits, shape_stats = b2d.world.overlap_shape(world, {
+        type = b2d.shape.SHAPE_TYPE_CIRCLE,
+        center = target,
+        radius = 0.5,
+    }, query_filter, 8)
+    assert(type(shape_hits) == "table")
+    assert(type(shape_stats.leaf_visits) == "number")
+    local shape_overlap_hit = find_fixture_hit(shape_hits, body_a, fixture.index)
+    assert(shape_overlap_hit ~= nil)
+    assert(shape_overlap_hit.type == b2d.shape.SHAPE_TYPE_CIRCLE)
+
+    local ray_origin = target + vmath.vector3(0, -2, 0)
+    local ray_translation = vmath.vector3(0, 4, 0)
+    local ray_hits, ray_stats = b2d.world.cast_ray(world, ray_origin, ray_translation, query_filter, 8)
+    assert(type(ray_hits) == "table")
+    assert(type(ray_stats.leaf_visits) == "number")
+    local ray_hit = find_fixture_hit(ray_hits, body_a, fixture.index)
+    assert(ray_hit ~= nil)
+    assert_vec3_near(ray_hit.point, target + vmath.vector3(0, -1, 0), 0.1)
+    assert_near(ray_hit.fraction, 0.25, 0.01)
+
+    local closest = b2d.world.cast_ray_closest(world, ray_origin, ray_translation, query_filter)
+    assert(closest ~= nil)
+    assert(closest.fixture.body == body_a)
+    assert(closest.fixture.index == fixture.index)
+    assert_vec3_near(closest.point, target + vmath.vector3(0, -1, 0), 0.1)
+    assert_near(closest.fraction, 0.25, 0.01)
+
+    local cast_hits, cast_stats = b2d.world.cast_shape(world, {
+        type = b2d.shape.SHAPE_TYPE_CIRCLE,
+        center = ray_origin,
+        radius = 0.5,
+    }, ray_translation, query_filter, 8)
+    assert(type(cast_hits) == "table")
+    assert(type(cast_stats.node_visits) == "number")
+    local cast_hit = find_fixture_hit(cast_hits, body_a, fixture.index)
+    assert(cast_hit ~= nil)
+    assert_vec3_near(cast_hit.point, target + vmath.vector3(0, -1, 0), 0.2)
+    assert_near(cast_hit.fraction, 0.125, 0.02)
+
+    b2d.body.destroy_fixture(body_a, fixture.index)
+end
+
 local function test_native_b2d_joints(self)
     if b2d == nil then
         return
@@ -388,6 +476,8 @@ local function test_native_b2d_joints(self)
 
     if PHYSICS == "box2dv3" then
         test_native_b2d_world_and_chains(body_a, body_b, body_c)
+    else
+        test_native_b2d_v2_world_queries(body_a)
     end
 
     local managed_joint_id = "native_managed_joint"

--- a/engine/gamesys/src/gamesys/test/collision_object/joint_test.script
+++ b/engine/gamesys/src/gamesys/test/collision_object/joint_test.script
@@ -111,6 +111,21 @@ local function test_native_b2d_world_and_chains(body_a, body_b, body_c)
     b2d.world.enable_speculative(world, false)
     b2d.world.enable_speculative(world, true)
 
+    assert(b2d.body.is_valid(body_a))
+    b2d.body.set_name(body_a, "joint-test-a")
+    assert(b2d.body.get_name(body_a) == "joint-test-a")
+    local body_position = b2d.body.get_position(body_a)
+    local body_angle = b2d.body.get_angle(body_a)
+    b2d.body.set_target_transform(body_a, body_position, body_angle, 1 / 60)
+    b2d.body.apply_linear_impulse_to_center(body_a, zp)
+    local sleep_threshold = b2d.body.get_sleep_threshold(body_a)
+    b2d.body.set_sleep_threshold(body_a, sleep_threshold + 1)
+    assert_near(b2d.body.get_sleep_threshold(body_a), sleep_threshold + 1)
+    b2d.body.set_sleep_threshold(body_a, sleep_threshold)
+    b2d.body.enable_contact_events(body_a, true)
+    b2d.body.enable_hit_events(body_a, true)
+    assert(type(b2d.body.get_contact_data(body_a)) == "table")
+
     local material_shape = b2d.body.create_shape(body_a, {
         type = b2d.shape.SHAPE_TYPE_CIRCLE,
         center = vmath.vector3(100000, 100000, 0),
@@ -128,7 +143,34 @@ local function test_native_b2d_world_and_chains(body_a, body_b, body_c)
     local material_shape_info = b2d.body.get_shapes(body_a)[material_shape.index]
     assert(material_shape_info.shape_id == material_shape.shape_id)
     assert(material_shape_info.material == 17)
+    assert(b2d.shape.is_valid(material_shape.shape_id))
+    assert(b2d.shape.get_body(material_shape.shape_id) == body_a)
+    assert(b2d.shape.get_world(material_shape.shape_id) == world)
+    b2d.shape.enable_sensor_events(material_shape.shape_id, true)
+    assert(b2d.shape.are_sensor_events_enabled(material_shape.shape_id))
+    b2d.shape.enable_contact_events(material_shape.shape_id, true)
+    assert(b2d.shape.are_contact_events_enabled(material_shape.shape_id))
+    b2d.shape.enable_pre_solve_events(material_shape.shape_id, true)
+    assert(b2d.shape.are_pre_solve_events_enabled(material_shape.shape_id))
+    b2d.shape.enable_hit_events(material_shape.shape_id, true)
+    assert(b2d.shape.are_hit_events_enabled(material_shape.shape_id))
+    local shape_ray_hit = b2d.shape.ray_cast(material_shape.shape_id, vmath.vector3(100000, 99998, 0), vmath.vector3(0, 4, 0))
+    assert(shape_ray_hit ~= nil)
+    assert_vec3_near(shape_ray_hit.point, vmath.vector3(100000, 99999, 0), 0.1)
+    assert_near(shape_ray_hit.fraction, 0.25, 0.01)
+    assert(type(shape_ray_hit.iterations) == "number")
+    assert(type(b2d.shape.get_contact_capacity(material_shape.shape_id)) == "number")
+    assert(type(b2d.shape.get_contact_data(material_shape.shape_id)) == "table")
+    assert(type(b2d.shape.get_sensor_capacity(material_shape.shape_id)) == "number")
+    assert(type(b2d.shape.get_sensor_overlaps(material_shape.shape_id)) == "table")
+    local shape_mass_data = b2d.shape.get_mass_data(material_shape.shape_id)
+    assert(type(shape_mass_data.mass) == "number")
+    assert_vec3_near(b2d.shape.get_closest_point(material_shape.shape_id, vmath.vector3(100004, 100000, 0)), vmath.vector3(100001, 100000, 0), 0.1)
+    local material_body_aabb = b2d.body.compute_aabb(body_a)
+    assert(material_body_aabb.lower.x <= material_body_aabb.upper.x)
+    assert(material_body_aabb.lower.y <= material_body_aabb.upper.y)
     b2d.body.destroy_shape(body_a, material_shape.index)
+    assert(not b2d.shape.is_valid(material_shape.shape_id))
     assert_error(function() b2d.shape.get_type(material_shape.shape_id) end)
 
     local chain, segments = b2d.body.create_chain(body_c, {
@@ -150,6 +192,8 @@ local function test_native_b2d_world_and_chains(body_a, body_b, body_c)
         enable_sensor_events = true,
     })
     assert(chain ~= nil)
+    assert(b2d.chain.is_valid(chain))
+    assert(b2d.chain.get_world(chain) == world)
     assert(#segments == 2)
     assert(b2d.chain.get_segment_count(chain) == #segments)
     assert(segments[1].type == b2d.shape.SHAPE_TYPE_SEGMENT)
@@ -276,6 +320,7 @@ local function test_native_b2d_world_and_chains(body_a, body_b, body_c)
     end
 
     b2d.chain.destroy(chain)
+    assert(not b2d.chain.is_valid(chain))
     assert_error(function() b2d.chain.get_segment_count(chain) end)
 
     local loop_chain, loop_segments = b2d.body.create_chain(body_c, {
@@ -377,6 +422,8 @@ local function test_native_b2d_joints(self)
     assert(found)
 
     if PHYSICS == "box2dv3" then
+        assert(b2d.joint.is_valid(joint))
+        assert(b2d.joint.get_world(joint) == b2d.body.get_world(body_a))
         b2d.joint.set_collide_connected(joint, true)
         assert(b2d.joint.get_collide_connected(joint))
         b2d.joint.wake_bodies(joint)
@@ -543,6 +590,9 @@ local function test_native_b2d_joints(self)
     end
 
     b2d.joint.destroy(joint)
+    if PHYSICS == "box2dv3" then
+        assert(not b2d.joint.is_valid(joint))
+    end
     assert_error(function() b2d.joint.get_type(joint) end)
 end
 

--- a/engine/gamesys/src/gamesys/test/test_gamesys_physics.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys_physics.cpp
@@ -6,6 +6,30 @@
 
 using namespace dmVMath;
 
+static void RunPhysicsScriptTest(dmResource::HFactory factory, dmGameObject::HCollection collection, dmGameObject::UpdateContext* update_context,
+                                 dmScript::HContext script_context, const char* prototype_path, const char* instance_path)
+{
+    dmHashEnableReverseHash(true);
+    lua_State* L = dmScript::GetLuaState(script_context);
+
+    dmGameObject::HInstance go = Spawn(factory, collection, prototype_path, dmHashString64(instance_path), 0,
+                                       Point3(0, 0, 0), Quat(0, 0, 0, 1), Vector3(1, 1, 1));
+    ASSERT_NE((void*)0, go);
+
+    bool tests_done = false;
+    while (!tests_done)
+    {
+        ASSERT_TRUE(dmGameObject::Update(collection, update_context));
+        ASSERT_TRUE(dmGameObject::PostUpdate(collection));
+
+        lua_getglobal(L, "tests_done");
+        tests_done = lua_toboolean(L, -1);
+        lua_pop(L, 1);
+    }
+
+    ASSERT_TRUE(dmGameObject::Final(collection));
+}
+
 /* Physics joints */
 TEST_F(ComponentTest, JointTest)
 {
@@ -54,6 +78,39 @@ TEST_F(ComponentTest, JointTest)
 
     ASSERT_TRUE(dmGameObject::Final(m_Collection));
 
+}
+
+TEST_F(ComponentTest, Box2DWorldApiTest)
+{
+    /* Intent: verify b2d.world query and cast wrappers.
+    ** Setup: one scripted dynamic collision object creates an isolated shape.
+    ** Expected: b2d.world overlap and cast wrappers identify that shape/fixture
+    ** at the expected approximate hit position and fraction.
+    */
+    RunPhysicsScriptTest(m_Factory, m_Collection, &m_UpdateContext, m_ScriptContext,
+                         "/collision_object/box2d_world_test.goc", "/box2d_world_test");
+}
+
+TEST_F(ComponentTest, Box2DShapeApiTest)
+{
+    /* Intent: verify shape-facing Box2D Lua wrappers.
+    ** Setup: one scripted dynamic collision object owns the tested shape/fixture.
+    ** Expected: v2 fixture shape helpers and v3 body/shape-id helpers round-trip
+    ** properties, ownership and derived data, then report invalid handles after destroy.
+    */
+    RunPhysicsScriptTest(m_Factory, m_Collection, &m_UpdateContext, m_ScriptContext,
+                         "/collision_object/box2d_shape_test.goc", "/box2d_shape_test");
+}
+
+TEST_F(ComponentTest, Box2DChainApiTest)
+{
+    /* Intent: verify v3 chain userdata and segment-shape integration.
+    ** Setup: one scripted static collision object creates v3 chains far from base geometry.
+    ** Expected: v3 chain userdata, segment shapes, world casts and destroy invalidation
+    ** behave consistently; v2 exposes no native chain userdata API.
+    */
+    RunPhysicsScriptTest(m_Factory, m_Collection, &m_UpdateContext, m_ScriptContext,
+                         "/collision_object/box2d_chain_test.goc", "/box2d_chain_test");
 }
 
 /* Physics listener */
@@ -151,4 +208,3 @@ int main(int argc, char **argv)
     dmLog::LogFinalize();
     return result;
 }
-

--- a/engine/gamesys/src/gamesys/wscript
+++ b/engine/gamesys/src/gamesys/wscript
@@ -91,7 +91,7 @@ def build(bld):
 
     bld.stlib(features = 'cxx',
         includes = '. .. ../../src ../../proto',
-        source = 'scripts/box2d/script_box2d.cpp scripts/box2d/v3/script_box2d_body_v3.cpp scripts/box2d/v3/script_box2d_joint_v3.cpp scripts/box2d/v3/script_box2d_shape_v3.cpp',
+        source = 'scripts/box2d/script_box2d.cpp scripts/box2d/v3/script_box2d_body_v3.cpp scripts/box2d/v3/script_box2d_chain_v3.cpp scripts/box2d/v3/script_box2d_joint_v3.cpp scripts/box2d/v3/script_box2d_shape_v3.cpp scripts/box2d/v3/script_box2d_world_v3.cpp',
         uselib = 'LUA',
         target = 'script_box2d')
 

--- a/engine/gamesys/src/gamesys/wscript
+++ b/engine/gamesys/src/gamesys/wscript
@@ -97,7 +97,7 @@ def build(bld):
 
     bld.stlib(features = 'cxx',
         includes = '. .. ../../src ../../proto ' + build_util.get_dynamo_ext('include', 'box2d_defold'),
-        source = 'scripts/box2d/script_box2d.cpp scripts/box2d/v2/script_box2d_body_v2.cpp scripts/box2d/v2/script_box2d_fixture_v2.cpp scripts/box2d/v2/script_box2d_joint_v2.cpp scripts/box2d/v2/script_box2d_shape_v2.cpp',
+        source = 'scripts/box2d/script_box2d.cpp scripts/box2d/v2/script_box2d_body_v2.cpp scripts/box2d/v2/script_box2d_fixture_v2.cpp scripts/box2d/v2/script_box2d_joint_v2.cpp scripts/box2d/v2/script_box2d_shape_v2.cpp scripts/box2d/v2/script_box2d_world_v2.cpp',
         uselib = 'LUA',
         target = 'script_box2d_defold')
 


### PR DESCRIPTION
Adds Box2D v3 chain support, typed world/shape handles, and a new b2d.world Lua module.

Box2D v3 added/changed APIs:
- b2d.body.create_chain
- b2d.body.is_valid
- b2d.body.get_name
- b2d.body.set_name
- b2d.body.set_target_transform
- b2d.body.apply_linear_impulse_to_center
- b2d.body.get_sleep_threshold
- b2d.body.set_sleep_threshold
- b2d.body.enable_contact_events
- b2d.body.enable_hit_events
- b2d.body.get_contact_data
- b2d.body.compute_aabb
- b2d.body.create_shape changed to expose material data
- b2d.body.get_shapes changed to expose shape_id and material data
- b2d.chain.destroy
- b2d.chain.is_valid
- b2d.chain.get_world
- b2d.chain.get_segment_count
- b2d.chain.get_segments
- b2d.chain.get_geometry
- b2d.chain.from_shape
- b2d.chain.get_friction
- b2d.chain.set_friction
- b2d.chain.get_restitution
- b2d.chain.set_restitution
- b2d.chain.get_material
- b2d.chain.set_material
- b2d.shape.SHAPE_TYPE_SEGMENT
- b2d.shape.get_shape changed to report chain segments as SHAPE_TYPE_SEGMENT
- b2d.shape.is_valid
- b2d.shape.get_body
- b2d.shape.get_world
- b2d.shape.get_material
- b2d.shape.set_material
- b2d.shape.enable_sensor_events
- b2d.shape.are_sensor_events_enabled
- b2d.shape.enable_contact_events
- b2d.shape.are_contact_events_enabled
- b2d.shape.enable_pre_solve_events
- b2d.shape.are_pre_solve_events_enabled
- b2d.shape.enable_hit_events
- b2d.shape.are_hit_events_enabled
- b2d.shape.ray_cast
- b2d.shape.get_contact_capacity
- b2d.shape.get_contact_data
- b2d.shape.get_sensor_capacity
- b2d.shape.get_sensor_overlaps
- b2d.shape.get_mass_data
- b2d.shape.get_closest_point
- b2d.joint.is_valid
- b2d.joint.get_world
- b2d.world.is_valid
- b2d.world.is_locked
- b2d.world.get_gravity
- b2d.world.set_gravity
- b2d.world.enable_sleeping
- b2d.world.is_sleeping_enabled
- b2d.world.enable_continuous
- b2d.world.is_continuous_enabled
- b2d.world.set_restitution_threshold
- b2d.world.get_restitution_threshold
- b2d.world.set_hit_event_threshold
- b2d.world.get_hit_event_threshold
- b2d.world.set_maximum_linear_speed
- b2d.world.get_maximum_linear_speed
- b2d.world.enable_warm_starting
- b2d.world.is_warm_starting_enabled
- b2d.world.get_awake_body_count
- b2d.world.set_contact_tuning
- b2d.world.set_joint_tuning
- b2d.world.get_profile
- b2d.world.get_counters
- b2d.world.explode
- b2d.world.rebuild_static_tree
- b2d.world.enable_speculative
- b2d.world.overlap_aabb
- b2d.world.overlap_shape
- b2d.world.cast_ray
- b2d.world.cast_ray_closest
- b2d.world.cast_shape
- b2d.world.cast_mover
- b2d.world.collide_mover

Box2D v2 added APIs:
- b2d.world.overlap_aabb
- b2d.world.overlap_shape
- b2d.world.cast_ray
- b2d.world.cast_ray_closest
- b2d.world.cast_shape

See current example: https://github.com/JCash/example-box2d

### Technical changes

Box2D v3 APIs intentionally not wrapped

The Lua surface is limited to APIs that fit Defold’s ownership model and are useful from script.

#### World lifecycle / stepping

Not wrapped:
- `b2CreateWorld`
- `b2DestroyWorld`
- `b2World_Step`
- `b2World_Draw`

Reason: Defold owns world creation, destruction, stepping order, and debug drawing. Lua gets validated `b2World` handles through existing Defold physics objects, but cannot create or drive independent worlds.

#### World events and callbacks

Not wrapped:
- `b2World_GetBodyEvents`
- `b2World_GetSensorEvents`
- `b2World_GetContactEvents`
- `b2World_SetCustomFilterCallback`
- `b2World_SetPreSolveCallback`
- `b2World_SetFrictionCallback`
- `b2World_SetRestitutionCallback`

Reason: These are callback/event integration points that need engine-owned lifetime, threading, and dispatch semantics. Defold already routes physics events through its component/message system, and exposing raw callbacks to Lua would be unsafe during simulation.

#### User data and diagnostics

Box2D v3 APIs Without Lua Wrappers

Scoped to the v3 runtime API in `external/box2d/Box2D/include/box2d/box2d.h`.

#### World

- `b2CreateWorld`
- `b2DestroyWorld`
- `b2World_Step`
- `b2World_Draw`
- `b2World_GetBodyEvents`
- `b2World_GetSensorEvents`
- `b2World_GetContactEvents`
- `b2World_SetCustomFilterCallback`
- `b2World_SetPreSolveCallback`
- `b2World_SetUserData`
- `b2World_GetUserData`
- `b2World_SetFrictionCallback`
- `b2World_SetRestitutionCallback`
- `b2World_DumpMemoryStats`

#### Body

- `b2CreateBody`
- `b2DestroyBody`
- `b2Body_SetUserData`
- `b2Body_GetUserData`
- `b2Body_GetShapeCount`
- `b2Body_GetJointCount`
- `b2Body_GetContactCapacity`

#### Shape

- `b2Shape_SetUserData`
- `b2Shape_GetUserData`

These shape APIs are covered through generic Lua wrappers rather than one-to-one function names:

- `b2Shape_GetCircle` -> `b2d.shape.get_shape`
- `b2Shape_GetSegment` -> `b2d.shape.get_shape`
- `b2Shape_GetChainSegment` -> `b2d.shape.get_shape`
- `b2Shape_GetCapsule` -> `b2d.shape.get_shape`
- `b2Shape_GetPolygon` -> `b2d.shape.get_shape`
- `b2Shape_SetCircle` -> `b2d.shape.set_shape`
- `b2Shape_SetSegment` -> `b2d.shape.set_shape`
- `b2Shape_SetCapsule` -> `b2d.shape.set_shape`
- `b2Shape_SetPolygon` -> `b2d.shape.set_shape`
- `b2Shape_GetParentChain` -> `b2d.chain.from_shape`

#### Joint

- `b2Joint_SetUserData`
- `b2Joint_GetUserData`

#### Intentionally Not Wrapped

World/body creation, destruction, stepping, debug draw, callback registration, and userdata are intentionally not exposed. Defold owns Box2D lifecycle, update order, callback dispatch, and object ownership.

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
