### PR TITLE
Add a test ensuring we don't reorder editor script commands

### DIFF
--- a/editor/test/integration/editor_extensions_test.clj
+++ b/editor/test/integration/editor_extensions_test.clj
@@ -436,6 +436,29 @@
                 (catch Throwable e e))))
         (is (= [2 2 2] (test-util/prop sprite-node-id :scale)))))))
 
+(deftest editor-script-commands-preserve-declaration-order-test
+  (test-util/with-loaded-project "test/resources/editor_extensions/command_order_project"
+    (reload-editor-scripts! project)
+    (let [command-labels (into []
+                               (comp
+                                 (filter (fn [{:keys [command]}]
+                                           (and command
+                                                (handler/synthetic-command? command))))
+                                 (map (fn [{:keys [command]}]
+                                        (some-> (handler/active command (eval-handler-contexts :global []) {})
+                                                handler/label))))
+                               (handler/realize-menu :editor.app-view/edit-end))]
+      (is (= ["Command 7"
+              "Command 2"
+              "Command 9"
+              "Command 1"
+              "Command 5"
+              "Command 3"
+              "Command 8"
+              "Command 4"
+              "Command 6"]
+             command-labels)))))
+
 (deftest refresh-context-after-write-test
   (test-util/with-scratch-project "test/resources/editor_extensions/refresh_context_project"
     (let [output (atom [])

--- a/editor/test/resources/editor_extensions/command_order_project/.gitignore
+++ b/editor/test/resources/editor_extensions/command_order_project/.gitignore
@@ -1,0 +1,11 @@
+/.internal
+/.editor_settings
+/build
+.externalToolBuilders
+.DS_Store
+Thumbs.db
+.lock-wscript
+*.pyc
+.project
+.cproject
+builtins

--- a/editor/test/resources/editor_extensions/command_order_project/game.project
+++ b/editor/test/resources/editor_extensions/command_order_project/game.project
@@ -1,0 +1,16 @@
+[bootstrap]
+main_collection = /main/main.collectionc
+
+[script]
+shared_state = 1
+
+[display]
+width = 960
+height = 640
+
+[android]
+input_method = HiddenInputField
+
+[project]
+title = command_order_project
+

--- a/editor/test/resources/editor_extensions/command_order_project/test.editor_script
+++ b/editor/test/resources/editor_extensions/command_order_project/test.editor_script
@@ -1,0 +1,44 @@
+local M = {}
+
+function M.get_commands()
+    return {
+        {
+            label = "Command 7",
+            locations = {"Edit"}
+        },
+        {
+            label = "Command 2",
+            locations = {"Edit"}
+        },
+        {
+            label = "Command 9",
+            locations = {"Edit"}
+        },
+        {
+            label = "Command 1",
+            locations = {"Edit"}
+        },
+        {
+            label = "Command 5",
+            locations = {"Edit"}
+        },
+        {
+            label = "Command 3",
+            locations = {"Edit"}
+        },
+        {
+            label = "Command 8",
+            locations = {"Edit"}
+        },
+        {
+            label = "Command 4",
+            locations = {"Edit"}
+        },
+        {
+            label = "Command 6",
+            locations = {"Edit"}
+        }
+    }
+end
+
+return M


### PR DESCRIPTION
The issue was already fixed during command registration refactoring, but this PR adds a test.

Fix #8902