### PR TITLE
Add `editor.fetch_libraries()` command to editor scripts

### DIFF
--- a/editor/.codex/skills/clojure-code-style/SKILL.md
+++ b/editor/.codex/skills/clojure-code-style/SKILL.md
@@ -3,7 +3,7 @@ name: clojure-code-style
 description: Use for all Clojure changes and final checks.
 ---
 
-Applies to your changes only, keep the rest of the code untouched unless explicitly asked.
+Applies to your changes only, keep the rest of the code untouched unless explicitly asked. Carefully go through every rule.
 
 # Rules
 
@@ -46,7 +46,7 @@ Prefer `if-let`/`when-let` over `if-some`/`when-some`. Latter can be used only w
 
 Use `clj-kondo` to find and fix lint issues in your changes.
 
-## Inline single-use trivial helpers/constants
+## Inline single-use trivial helpers/constants/locals
 
 They make the code worse because they make the logic/behavior non-local, introducing a separation where there is none.
 

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -3166,6 +3166,8 @@
       (when-let [handler+context (handler/active command [_context] false)]
         (handler/run handler+context)))))
 
+(declare ^:private fetch-libraries)
+
 (defn reload-extensions! [app-view project kind workspace changes-view build-errors-view prefs localization web-server]
   (extensions/reload!
     project kind
@@ -3207,6 +3209,8 @@
                             (catch Throwable e (error-reporting/report-exception! e)))
                           (future/complete! f nil))
                         f))
+    :fetch-libraries! (fn fetch-libraries! []
+                        (fetch-libraries app-view workspace project changes-view build-errors-view prefs localization web-server))
     :invoke-bob! (fn invoke-bob! [options commands evaluation-context]
                    (let [f (future/make)]
                      (fx/on-fx-thread
@@ -3245,20 +3249,24 @@
 
 (defn- fetch-libraries [app-view workspace project changes-view build-errors-view prefs localization web-server]
   (let [library-uris (project/project-dependencies project)]
-    (future
-      (error-reporting/catch-all!
+    (future/io
+      (try
         (ui/with-progress [render-fetch-progress! (make-render-task-progress :fetch-libraries)]
           (let [lib-results (library/fetch! (workspace/project-directory workspace) library-uris render-fetch-progress!)
                 render-install-progress! (make-render-task-progress :resource-sync)]
             (render-install-progress! (progress/make (localization/message "progress.installing-updated-libraries")))
-            (ui/run-later
-              (workspace/set-project-dependencies! workspace lib-results)
-              (disk/async-reload!
-                render-install-progress! workspace [] changes-view
-                (fn [success]
-                  (when success
-                    (reload-extensions! app-view project :library workspace changes-view build-errors-view prefs localization web-server)
-                    (project/update-fetch-libraries-notification! project)))))))))))
+            (ui/run-now (workspace/set-project-dependencies! workspace lib-results))
+            (if-not (let [reload-completed (promise)]
+                      (disk/async-reload! render-install-progress! workspace [] changes-view reload-completed)
+                      @reload-completed)
+              [lib-results false]
+              (ui/run-now
+                (reload-extensions! app-view project :library workspace changes-view build-errors-view prefs localization web-server)
+                (project/update-fetch-libraries-notification! project)
+                [lib-results true]))))
+        (catch Throwable error
+          (error-reporting/report-exception! error)
+          (throw error))))))
 
 (handler/defhandler :private/add-dependency :global
   (enabled? [] (disk-availability/available?))

--- a/editor/src/clj/editor/command_requests.clj
+++ b/editor/src/clj/editor/command_requests.clj
@@ -18,12 +18,14 @@
             [editor.build-errors-view :as build-errors-view]
             [editor.disk :as disk]
             [editor.future :as future]
+            [editor.library :as library]
             [editor.lsp.server :as lsp.server]
             [editor.resource :as resource]
             [editor.ui :as ui]
             [service.log :as log]
             [util.coll :as coll]
-            [util.http-server :as http-server]))
+            [util.http-server :as http-server])
+  (:import [com.dynamo.bob.util Library$Result]))
 
 (set! *warn-on-reflection* true)
 
@@ -45,6 +47,25 @@
                                       maybe-resource (assoc :resource (resource/proj-path maybe-resource))
                                       cursor-range (assoc :range (lsp.server/editor-cursor-range->lsp-range cursor-range)))))))]
         (http-server/json-response {:success (not error) :issues issues} (if error 422 200))))))
+
+(defn- fetch-libraries-response [result localization-state]
+  (future/then
+    result
+    (fn [[lib-results reload-succeeded]]
+      (let [success (and reload-succeeded (coll/not-any? Library$Result/.problem lib-results))]
+        (http-server/json-response
+          {:success success
+           :libraries (coll/into-> lib-results []
+                        (map (fn [^Library$Result result]
+                               (let [problem (.problem result)]
+                                 (cond-> {:uri (str (.uri result))
+                                          :success (not problem)}
+                                   problem
+                                   (assoc :message (localization-state (library/result-message result))))))))}
+          (cond
+            (not reload-succeeded) 500
+            success 200
+            :else 422))))))
 
 (def ^:private supported-commands
   ;; Notable exclusions:
@@ -120,7 +141,8 @@
    :fetch-libraries
    {:ui-handler :project.fetch-libraries
     :help "Download the latest version of the project library dependencies."
-    :resource-sync true}
+    :resource-sync true
+    :response-fn fetch-libraries-response}
 
    :hot-reload
    {:ui-handler :run.hot-reload

--- a/editor/src/clj/editor/editor_extensions.clj
+++ b/editor/src/clj/editor/editor_extensions.clj
@@ -42,6 +42,8 @@
             [editor.future :as future]
             [editor.graph-util :as gu]
             [editor.handler :as handler]
+            [editor.library :as library]
+            [editor.localization :as localization]
             [editor.lsp :as lsp]
             [editor.lsp.async :as lsp.async]
             [editor.os :as os]
@@ -62,6 +64,7 @@
   (:import [clojure.lang IDeref Murmur3]
            [com.dynamo.bob Platform]
            [com.dynamo.bob.bundle BundleHelper]
+           [com.dynamo.bob.util Library$Result]
            [java.io PrintStream PushbackReader]
            [java.net URI]
            [java.nio.file FileAlreadyExistsException Files NotDirectoryException Path]
@@ -463,6 +466,20 @@
 (defn- make-ext-save-fn [save!]
   (rt/suspendable-lua-fn ext-save [_]
     (future/then (save!) rt/and-refresh-context)))
+
+(defn- make-ext-fetch-libraries-fn [fetch-libraries! localization-state]
+  (rt/suspendable-lua-fn ext-fetch-libraries [_]
+    (future/then
+      (fetch-libraries!)
+      (fn [[lib-results reload-succeeded]]
+        (rt/and-refresh-context
+          (if-not reload-succeeded
+            (LuaError. "Reload failed")
+            (let [error-messages (coll/into-> lib-results []
+                                   (filter Library$Result/.problem)
+                                   (map library/result-message))]
+              (when (coll/not-empty error-messages)
+                (LuaError. ^String (localization-state (localization/join "\n" error-messages)))))))))))
 
 (defn- make-open-resource-fn [workspace open-resource!]
   (rt/suspendable-lua-fn open-resource [{:keys [rt evaluation-context]} lua-resource-path]
@@ -952,6 +969,9 @@
                           has OS-defined file association, returns
                           CompletableFuture (that might complete exceptionally
                           if resource could not be opened)
+    :fetch-libraries!     0-arg function that asynchronously fetches libraries,
+                          returns a CompletableFuture that completes with tuple
+                          [library-results reload-succeeded]
     :invoke-bob!          3-arg function that asynchronously invokes bob and
                           returns a CompletableFuture (which may complete
                           exceptionally if bob invocation fails). The args:
@@ -962,8 +982,8 @@
                                                   strings
                             evaluation-context    evaluation context of the
                                                   invocation"
-  [project kind & {:keys [web-server prefs localization reload-resources! display-output! save! open-resource! invoke-bob!] :as opts}]
-  {:pre [web-server prefs localization reload-resources! display-output! save! open-resource! invoke-bob!]}
+  [project kind & {:keys [web-server prefs localization reload-resources! display-output! save! open-resource! fetch-libraries! invoke-bob!] :as opts}]
+  {:pre [web-server prefs localization reload-resources! display-output! save! open-resource! fetch-libraries! invoke-bob!]}
   (g/let-ec [basis (:basis evaluation-context)
              lsp (lsp/get-node-lsp basis project)
              script-annotations (project/script-annotations project evaluation-context)
@@ -1001,6 +1021,7 @@
                                   "platform" (.getPair (Platform/getHostPlatform))
                                   "prefs" (prefs-functions/env prefs)
                                   "save" (make-ext-save-fn save!)
+                                  "fetch_libraries" (make-ext-fetch-libraries-fn fetch-libraries! localization)
                                   "transact" ext-transact
                                   "tx" {"set" (make-ext-tx-set-fn project)
                                         "add" (graph/make-ext-add-fn project)

--- a/editor/src/clj/editor/editor_extensions/docs.clj
+++ b/editor/src/clj/editor/editor_extensions/docs.clj
@@ -305,6 +305,10 @@ editor.create_resources({
           :type :function
           :parameters []
           :description "Persist any unsaved changes to disk"}
+         {:name "editor.fetch_libraries"
+          :type :function
+          :parameters []
+          :description "Download the latest version of the project library dependencies and reload library-provided editor scripts.\n\nThis function may replace library-provided editor commands, hooks, routes, and UI contributed by editor scripts, so it should typically be the last operation performed by a command."}
          {:name "editor.transact"
           :type :function
           :parameters [{:name "txs"

--- a/editor/test/integration/editor_extensions_test.clj
+++ b/editor/test/integration/editor_extensions_test.clj
@@ -28,11 +28,13 @@
             [editor.future :as future]
             [editor.graph-util :as gu]
             [editor.handler :as handler]
+            [editor.library :as library]
             [editor.os :as os]
             [editor.outline-view :as outline-view]
             [editor.pipeline.bob :as bob]
             [editor.prefs :as prefs]
             [editor.process :as process]
+            [editor.progress :as progress]
             [editor.properties :as properties]
             [editor.resource :as resource]
             [editor.ui :as ui]
@@ -320,6 +322,9 @@
 (defn- open-resource-noop! [_]
   (future/completed nil))
 
+(defn- fetch-libraries-noop! []
+  (future/completed [[] true]))
+
 (defn- make-invoke-bob-fn [project]
   (fn invoke-bob! [options commands _]
     (future/io
@@ -330,8 +335,9 @@
 (def ^:private stopped-server
   (http-server/stop! (http-server/start! (web-server/make-dynamic-handler [])) 0))
 
-(defn- reload-editor-scripts! [project & {:keys [display-output! kind open-resource! prefs web-server]
+(defn- reload-editor-scripts! [project & {:keys [display-output! fetch-libraries! kind open-resource! prefs web-server]
                                           :or {display-output! println
+                                               fetch-libraries! fetch-libraries-noop!
                                                kind :all
                                                open-resource! open-resource-noop!
                                                web-server stopped-server}}]
@@ -342,6 +348,7 @@
                       :display-output! display-output!
                       :save! (make-save-fn project)
                       :open-resource! open-resource!
+                      :fetch-libraries! fetch-libraries!
                       :invoke-bob! (make-invoke-bob-fn project)
                       :web-server web-server))
 
@@ -781,6 +788,33 @@
   (let [actual (normalize-pprint-output (str actual))
         output-matches-expectation (= expected actual)]
     (is output-matches-expectation (when-not output-matches-expectation (string/join "\n" (diff/make-diff-output-lines expected actual 3))))))
+
+(def ^:private expected-fetch-libraries-test-output
+  "fetch libraries: ok
+resource exists after fetch: true
+fetch missing libraries: error
+resource exists after failed fetch: false
+")
+
+(deftest fetch-libraries-test
+  (test-util/with-scratch-project "test/resources/editor_extensions/fetch_libraries_test"
+    (with-open [_server (http-server/start! test-util/lib-server-handler :port 58091)]
+      (let [out (StringBuilder.)]
+        (reload-editor-scripts!
+          project
+          :display-output! #(doto out (.append %2) (.append \newline))
+          :fetch-libraries! (fn fetch-libraries! []
+                              (future/io
+                                (let [lib-results (library/fetch!
+                                                    (workspace/project-directory workspace)
+                                                    (project/project-dependencies project)
+                                                    progress/null-render-progress!)]
+                                  (ui/run-now
+                                    (workspace/set-project-dependencies! workspace lib-results)
+                                    (workspace/resource-sync! workspace [] progress/null-render-progress!))
+                                  [lib-results true]))))
+        (run-edit-menu-test-command!)
+        (expect-script-output expected-fetch-libraries-test-output out)))))
 
 (def ^:private expected-outline-selection-parent-chain-test-output
   "outline.child.can_get_parent=true

--- a/editor/test/resources/editor_extensions/fetch_libraries_test/.gitignore
+++ b/editor/test/resources/editor_extensions/fetch_libraries_test/.gitignore
@@ -1,0 +1,11 @@
+/.internal
+/.editor_settings
+/build
+.externalToolBuilders
+.DS_Store
+Thumbs.db
+.lock-wscript
+*.pyc
+.project
+.cproject
+builtins

--- a/editor/test/resources/editor_extensions/fetch_libraries_test/game.project
+++ b/editor/test/resources/editor_extensions/fetch_libraries_test/game.project
@@ -1,0 +1,15 @@
+[bootstrap]
+main_collection = /main/main.collectionc
+
+[script]
+shared_state = 1
+
+[display]
+width = 960
+height = 640
+
+[android]
+input_method = HiddenInputField
+
+[project]
+title = fetch_libraries_test

--- a/editor/test/resources/editor_extensions/fetch_libraries_test/test.editor_script
+++ b/editor/test/resources/editor_extensions/fetch_libraries_test/test.editor_script
@@ -1,0 +1,28 @@
+local M = {}
+
+function M.get_commands()
+    return {{
+        label = "Test",
+        locations = {"Edit"},
+        run = function()
+            editor.transact({
+                editor.tx.set("/game.project", "project.dependencies", {
+                    "http://localhost:58091/lib/lib_resource_project"
+                })
+            })
+            local ok = pcall(editor.fetch_libraries)
+            print("fetch libraries: " .. (ok and "ok" or "error"))
+            print("resource exists after fetch: " .. tostring(editor.resource_attributes("/lib_resource_project/simple.gui").exists))
+            editor.transact({
+                editor.tx.set("/game.project", "project.dependencies", {
+                    "http://localhost:58091/missing_lib_resource_project"
+                })
+            })
+            ok = pcall(editor.fetch_libraries)
+            print("fetch missing libraries: " .. (ok and "ok" or "error"))
+            print("resource exists after failed fetch: " .. tostring(editor.resource_attributes("/lib_resource_project/simple.gui").exists))
+        end
+    }}
+end
+
+return M


### PR DESCRIPTION
Use `editor.fetch_libraries()` in editor scripts to fetch libraries programmatically.

Fix #6233