### PR TITLE
Re-organize when to split samplers in shader pipeline

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/ShaderProgramBuilderTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/ShaderProgramBuilderTest.java
@@ -147,13 +147,17 @@ public class ShaderProgramBuilderTest extends AbstractProtoBuilderTest {
     }
 
     private ShaderDesc compileShaderWithCompiler(IShaderCompiler shaderCompiler, String shaderAdapters, String outputResource) throws Exception {
+        return compileShaderWithCompiler(shaderCompiler, shaderAdapters, outputResource, fp);
+    }
+
+    private ShaderDesc compileShaderWithCompiler(IShaderCompiler shaderCompiler, String shaderAdapters, String outputResource, String source) throws Exception {
         IShaderCompiler.CompileOptions compileOptions = new IShaderCompiler.CompileOptions();
         compileOptions.shaderAdapters = shaderAdapters;
 
         ArrayList<ShaderCompilePipeline.ShaderModuleDesc> shaderModules = new ArrayList<>();
         ShaderCompilePipeline.ShaderModuleDesc shaderModule = new ShaderCompilePipeline.ShaderModuleDesc();
         shaderModule.type = ShaderDesc.ShaderType.SHADER_TYPE_FRAGMENT;
-        shaderModule.source = fp;
+        shaderModule.source = source;
         shaderModule.resourcePath = "/" + outputResource + ".fp";
         shaderModules.add(shaderModule);
 
@@ -492,6 +496,23 @@ public class ShaderProgramBuilderTest extends AbstractProtoBuilderTest {
         checkOnlyExpectedLanguages(
             compileShaderForPlatform(Platform.X86_64Win32, shaderAdapters, "manifest_win32_vulkan"),
             ShaderDesc.Language.LANGUAGE_SPIRV);
+
+        shaderAdapters = Project.getShaderAdaptersOption(Platform.WasmWeb, List.of(
+            platformSettings("symbols", List.of("GraphicsAdapterWebGPU"))));
+        String samplerSource =
+            "#version 140\n" +
+            "in vec2 var_texcoord0;\n" +
+            "out vec4 color_out;\n" +
+            "uniform sampler2D texture_sampler;\n" +
+            "void main()\n" +
+            "{\n" +
+            "   color_out = texture(texture_sampler, var_texcoord0.xy);\n" +
+            "}\n";
+        checkOnlyExpectedLanguages(
+            compileShaderWithCompiler(getProject().getShaderCompiler(Platform.WasmWeb), shaderAdapters, "manifest_webgpu_sampler", samplerSource),
+            ShaderDesc.Language.LANGUAGE_GLES_SM300,
+            ShaderDesc.Language.LANGUAGE_GLES_SM100,
+            ShaderDesc.Language.LANGUAGE_WGSL);
 
         shaderAdapters = Project.getShaderAdaptersOption(Platform.X86_64MacOS, List.of(
             platformSettings("excludeSymbols", List.of("GraphicsAdapterVulkan"))));

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderCompilers.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderCompilers.java
@@ -191,12 +191,24 @@ public class ShaderCompilers {
                 throw new CompileExceptionError("Can't match compute with graphics modules");
         }
 
+        private static boolean shaderLanguageRequiresSplitTextureSamplers(ShaderDesc.Language shaderLanguage) {
+            return shaderLanguage == ShaderDesc.Language.LANGUAGE_WGSL ||
+                   shaderLanguage == ShaderDesc.Language.LANGUAGE_HLSL_51 ||
+                   shaderLanguage == ShaderDesc.Language.LANGUAGE_HLSL_50;
+        }
+
         public ShaderProgramBuilder.ShaderCompileResult compile(ArrayList<ShaderCompilePipeline.ShaderModuleDesc> shaderModules, String resourceOutputPath, CompileOptions compileOptions) throws IOException, CompileExceptionError {
 
             // We need this for e.g. Win32 when creating the root signature bindings, to get a deterministic order.
             shaderModules.sort(Comparator.comparingInt(m -> m.type.getNumber()));
+            validateModules(shaderModules);
 
             boolean isComputeType = shaderModules.get(0).type == ShaderDesc.ShaderType.SHADER_TYPE_COMPUTE;
+            Set<ShaderDesc.Language> shaderLanguages = getPlatformShaderLanguages(isComputeType, compileOptions);
+            assert shaderLanguages != null;
+
+            // Used for tests, merge in potentially unsupported languages here.
+            shaderLanguages.addAll(compileOptions.forceIncludeShaderLanguages);
 
             ShaderCompilePipeline.Options opts = new ShaderCompilePipeline.Options();
             if (this.baseOptions != null) {
@@ -207,22 +219,12 @@ public class ShaderCompilers {
             opts.glslEsDefaultFloatPrecision = compileOptions.glslEsDefaultFloatPrecision;
             opts.glslEsDefaultIntPrecision = compileOptions.glslEsDefaultIntPrecision;
 
-            for (ShaderDesc.Language shaderLanguage : compileOptions.forceIncludeShaderLanguages) {
-                boolean isHLSL = shaderLanguage == ShaderDesc.Language.LANGUAGE_HLSL_51 || shaderLanguage == ShaderDesc.Language.LANGUAGE_HLSL_50;
-
-                opts.splitTextureSamplers |= isHLSL || shaderLanguage == ShaderDesc.Language.LANGUAGE_WGSL;
+            for (ShaderDesc.Language shaderLanguage : shaderLanguages) {
+                opts.splitTextureSamplers |= shaderLanguageRequiresSplitTextureSamplers(shaderLanguage);
             }
 
             ShaderCompilePipeline pipeline = ShaderProgramBuilder.newShaderPipeline(resourceOutputPath, shaderModules, opts);
             ArrayList<ShaderProgramBuilder.ShaderBuildResult> shaderBuildResults = new ArrayList<>();
-
-            validateModules(shaderModules);
-
-            Set<ShaderDesc.Language> shaderLanguages = getPlatformShaderLanguages(isComputeType, compileOptions);
-            assert shaderLanguages != null;
-
-            // Used for tests, merge in potentially unsupported languages here.
-            shaderLanguages.addAll(compileOptions.forceIncludeShaderLanguages);
 
             HashMap<ShaderDesc.ShaderType, Boolean> shaderTypeKeys = new HashMap<>();
             Shaderc.HLSLRootSignature hlslRootSignature = null;


### PR DESCRIPTION
Fixes a recent regression regarding building shader content for WebGPU builds.