### PR TITLE
Add `editor.ui.tabs()` and `editor.ui.tab()` to editor scripts

### DIFF
--- a/editor/src/clj/editor/editor_extensions/ui_components.clj
+++ b/editor/src/clj/editor/editor_extensions/ui_components.clj
@@ -23,6 +23,8 @@
             [cljfx.fx.row-constraints :as fx.row-constraints]
             [cljfx.fx.stack-pane :as fx.stack-pane]
             [cljfx.fx.stage :as fx.stage]
+            [cljfx.fx.tab :as fx.tab]
+            [cljfx.fx.tab-pane :as fx.tab-pane]
             [cljfx.fx.v-box :as fx.v-box]
             [cljfx.lifecycle :as fx.lifecycle]
             [cljfx.mutator :as fx.mutator]
@@ -158,6 +160,25 @@
 (defn- scroll-view [{:keys [content]}]
   {:fx/type fxui/scroll
    :content content})
+
+(defn- tabs-view [{:keys [tabs]}]
+  (cond-> {:fx/type fx.tab-pane/lifecycle
+           :style-class ["tab-pane" "ext-tab-pane"]}
+          tabs (assoc :tabs (filterv identity tabs))))
+
+(fxui/defc tab-view
+  {:compose [{:fx/type fx/ext-get-env :env [:localization-state]}]}
+  [{:keys [text content icon enabled localization-state]
+    :or {enabled true}}]
+  (cond-> {:fx/type fx.tab/lifecycle
+           :text (localization-state text)
+           :closable false
+           :disable (not enabled)}
+          content (assoc :content content)
+          icon (assoc :graphic {:fx/type fx.stack-pane/lifecycle
+                                :style-class ["ext-tab-icon"]
+                                :alignment :center
+                                :children [icon]})))
 
 (defn- apply-constraints [props props-key lifecycle grow-key constraints]
   (assoc props props-key (mapv (fn [maybe-constraint]
@@ -1294,6 +1315,7 @@
             [ui-docs/grid-component grid-view]
             [ui-docs/separator-component separator-view]
             [ui-docs/scroll-component scroll-view]
+            [ui-docs/tabs-component tabs-view]
             [ui-docs/label-component label-view]
             [ui-docs/paragraph-component paragraph-view]
             [ui-docs/heading-component heading-view]
@@ -1310,6 +1332,7 @@
             [ui-docs/integer-field-component integer-field-view]
             [ui-docs/number-field-component number-field-view]
             [ui-docs/dialog-button-component dialog-button-view]
+            [ui-docs/tab-component tab-view]
             [ui-docs/dialog-component dialog-view]])
          (eduction
            (map (fn [[script-doc lua-fn]]

--- a/editor/src/clj/editor/editor_extensions/ui_components.clj
+++ b/editor/src/clj/editor/editor_extensions/ui_components.clj
@@ -164,7 +164,13 @@
 (defn- tabs-view [{:keys [tabs]}]
   (cond-> {:fx/type fx.tab-pane/lifecycle
            :style-class ["tab-pane" "ext-tab-pane"]}
-          tabs (assoc :tabs (filterv identity tabs))))
+          tabs (assoc :tabs
+                      (into []
+                            (keep-indexed
+                              (fn [i desc]
+                                (when desc
+                                  (assoc desc :fx/key i))))
+                            tabs))))
 
 (fxui/defc tab-view
   {:compose [{:fx/type fx/ext-get-env :env [:localization-state]}]}

--- a/editor/src/clj/editor/editor_extensions/ui_docs.clj
+++ b/editor/src/clj/editor/editor_extensions/ui_docs.clj
@@ -219,6 +219,13 @@
                     :doc "content component")]
         read-only-common-props))
 
+(def ^:private tabs-props
+  (into [(make-prop :tabs
+                    :coerce children-coercer
+                    :types ["component[]"]
+                    :doc "array of <code>editor.ui.tab(...)</code> components")]
+        read-only-common-props))
+
 (def ^:private label-without-color-specific-props
   [(make-prop :text :types ["string" "message"] :coerce string-or-message-pattern-coercer :doc "the text, either a string or a localization message")
    (enum-prop :text_alignment :enum :text-alignment :doc "text alignment within paragraph bounds")])
@@ -359,6 +366,24 @@
               :coerce coerce/boolean
               :doc "determines if the button can be interacted with")])
 
+(def ^:private tab-props
+  [(make-prop :text
+              :coerce string-or-message-pattern-coercer
+              :required true
+              :types ["string" "message"]
+              :doc "tab header text, either a string or a localization message")
+   (make-prop :content
+              :coerce child-coercer
+              :types ["component"]
+              :doc "tab content component")
+   (make-prop :icon
+              :coerce child-coercer
+              :types ["component"]
+              :doc "tab header icon component")
+   (make-prop :enabled
+              :coerce coerce/boolean
+              :doc "determines if the tab can be selected")])
+
 (def ^:private dialog-props
   [(make-prop :title
               :coerce string-or-message-pattern-coercer
@@ -478,6 +503,12 @@
     :description "Layout container that optionally shows scroll bars if child contents overflow the assigned bounds"
     :props scroll-props))
 
+(def tabs-component
+  (component
+    "tabs"
+    :description "Layout container that shows one selected tab content at a time"
+    :props tabs-props))
+
 (def label-component
   (component
     "label"
@@ -561,6 +592,12 @@
     "dialog_button"
     :props dialog-button-props
     :description "Dialog button shown in the footer of a dialog"))
+
+(def tab-component
+  (component
+    "tab"
+    :props tab-props
+    :description "Tab used in the <code>tabs</code> prop of <code>editor.ui.tabs(...)</code>"))
 
 (def dialog-component
   (component
@@ -769,6 +806,7 @@ end)</code></pre>"})
               grid-component
               separator-component
               scroll-component
+              tabs-component
               label-component
               paragraph-component
               heading-component
@@ -785,6 +823,7 @@ end)</code></pre>"})
               integer-field-component
               number-field-component
               dialog-button-component
+              tab-component
               dialog-component])
            [show-dialog-doc
             function-component-doc

--- a/editor/styling/stylesheets/modules/_extensions.scss
+++ b/editor/styling/stylesheets/modules/_extensions.scss
@@ -1,3 +1,5 @@
+@use "sass:string";
+
 $ext-spacing-small: 4px;
 $ext-spacing-medium: 8px;
 $ext-spacing-large: 16px;
@@ -540,5 +542,16 @@ $ext-line-height: 26px;
                 & > .ext-combo-box-arrow-button { -fx-border-color: -df-error-severity-fatal; }
             }
         }
+    }
+    &-tab-pane {
+        & > .tab-content-area {
+            -fx-background-color: string.unquote("null");
+        }
+    }
+    &-tab-icon {
+        -fx-min-width: 16px;
+        -fx-max-width: 16px;
+        -fx-min-height: 16px;
+        -fx-max-height: 16px;
     }
 }

--- a/editor/test/integration/editor_extensions_test.clj
+++ b/editor/test/integration/editor_extensions_test.clj
@@ -874,6 +874,7 @@ editor.ui.image({image = 'foo', width = -1}) => -1 is not positive
 editor.ui.dialog({title = 'Dialog title', width = false}) => false is not a number
 editor.ui.dialog({title = 'Dialog title', height = -1}) => -1 is not positive
 editor.ui.dialog({title = 'Dialog title', resizable = 1}) => 1 is not a boolean
+editor.ui.tab({}) => {} must have the \"text\" key
 ")
 
 (deftest ui-test

--- a/editor/test/resources/editor_extensions/localization_project/test.editor_script
+++ b/editor/test/resources/editor_extensions/localization_project/test.editor_script
@@ -62,6 +62,14 @@ function M.get_commands()
                             title = message,
                             tooltip = message,
                             issue = {severity = editor.ui.ISSUE_SEVERITY.WARNING, message = message}
+                        }),
+                        editor.ui.tabs({
+                            tabs = {
+                                editor.ui.tab({
+                                    text = message,
+                                    content = editor.ui.label({ text = message })
+                                })
+                            }
                         })
                     }
                 }),

--- a/editor/test/resources/editor_extensions/ui_project/test.editor_script
+++ b/editor/test/resources/editor_extensions/ui_project/test.editor_script
@@ -242,6 +242,39 @@ function M.get_commands()
                                             })
                                         }
                                     })
+                                },
+                                {
+                                    editor.ui.label({
+                                        text = "Tabs",
+                                        alignment = editor.ui.ALIGNMENT.TOP_RIGHT
+                                    }),
+                                    editor.ui.tabs({
+                                        tabs = {
+                                            editor.ui.tab({
+                                                text = "General",
+                                                icon = editor.ui.image({
+                                                    image = "/builtins/assets/images/logo/logo_256.png"
+                                                }),
+                                                content = editor.ui.vertical({
+                                                    padding = editor.ui.PADDING.LARGE,
+                                                    children = {
+                                                        editor.ui.label({
+                                                            text = "General content"
+                                                        })
+                                                    }
+                                                })
+                                            }),
+                                            false,
+                                            editor.ui.tab({
+                                                text = "Empty",
+                                                content = false
+                                            }),
+                                            editor.ui.tab({
+                                                text = "Disabled",
+                                                enabled = false
+                                            })
+                                        }
+                                    })
                                 }
                             }
                         })
@@ -273,6 +306,7 @@ function M.get_commands()
                 expect_error("editor.ui.dialog({title = 'Dialog title', width = false})", editor.ui.dialog, {title = "Dialog title", width = false})
                 expect_error("editor.ui.dialog({title = 'Dialog title', height = -1})", editor.ui.dialog, {title = "Dialog title", height = -1})
                 expect_error("editor.ui.dialog({title = 'Dialog title', resizable = 1})", editor.ui.dialog, {title = "Dialog title", resizable = 1})
+                expect_error("editor.ui.tab({})", editor.ui.tab, {})
 
                 -- editor.ui.show_dialog(dialog)
             end


### PR DESCRIPTION
Now it's possible to create tab panes using editor scripts, e.g.:

<img width="872" height="632" alt="Screenshot 2026-06-03 at 08 39 25" src="https://github.com/user-attachments/assets/1777f3ee-f579-4cb1-a981-ffffdf47dd60" />

Fix #11670