### PR TITLE
Add clear console escape sequences

### DIFF
--- a/editor/src/clj/editor/console.clj
+++ b/editor/src/clj/editor/console.clj
@@ -98,8 +98,8 @@
   "Clear the console. Callable from a background thread."
   []
   (let [subscribers (:stream-subscribers (swap! pending-atom assoc :clear true :entries [] :index 0))]
-    ;; ESC [ 2 J clears the screen, ESC [ H moves the cursor to the home position.
-    (run! #(% "\u001b[2J\u001b[H\n") subscribers)))
+    ;; ESC [ 3 J clears scrollback, ESC [ H moves the cursor to the home position, ESC [ 2 J clears the screen.
+    (run! #(% "\n\u001b[3J\u001b[H\u001b[2J") subscribers)))
 
 (def ^:private remote-log-pump-thread (atom nil))
 (def ^:private console-stream (atom nil))

--- a/editor/src/clj/editor/console.clj
+++ b/editor/src/clj/editor/console.clj
@@ -98,7 +98,8 @@
   "Clear the console. Callable from a background thread."
   []
   (let [subscribers (:stream-subscribers (swap! pending-atom assoc :clear true :entries [] :index 0))]
-    (run! #(% "\n") subscribers)))
+    ;; ESC [ 2 J clears the screen, ESC [ H moves the cursor to the home position.
+    (run! #(% "\u001b[2J\u001b[H\n") subscribers)))
 
 (def ^:private remote-log-pump-thread (atom nil))
 (def ^:private console-stream (atom nil))

--- a/editor/test/integration/web_server_test.clj
+++ b/editor/test/integration/web_server_test.clj
@@ -339,7 +339,7 @@
                   (console/append-console-line! "after")
                   (is (= "after" (deref (future (.readLine reader)) 2000 ::timeout)))
                   (console/clear-console!)
-                  (is (= "" (deref (future (.readLine reader)) 2000 ::timeout))))))
+                  (is (= "\u001b[2J\u001b[H" (deref (future (.readLine reader)) 2000 ::timeout))))))
             (let [{:keys [status]} @(http/request (str url "/command/") :as :string)]
               (is (= 404 status)))
             (let [{:keys [status headers body]} @(http/request (str url "/command/build-html5") :as :string)]

--- a/editor/test/integration/web_server_test.clj
+++ b/editor/test/integration/web_server_test.clj
@@ -339,7 +339,11 @@
                   (console/append-console-line! "after")
                   (is (= "after" (deref (future (.readLine reader)) 2000 ::timeout)))
                   (console/clear-console!)
-                  (is (= "\u001b[2J\u001b[H" (deref (future (.readLine reader)) 2000 ::timeout))))))
+                  (is (= "" (deref (future (.readLine reader)) 2000 ::timeout)))
+                  (let [buffer (char-array 11)
+                        read-count (deref (future (.read reader buffer 0 (alength buffer))) 2000 ::timeout)]
+                    (is (= (alength buffer) read-count))
+                    (is (= "\u001b[3J\u001b[H\u001b[2J" (String. buffer)))))))
             (let [{:keys [status]} @(http/request (str url "/command/") :as :string)]
               (is (= 404 status)))
             (let [{:keys [status headers body]} @(http/request (str url "/command/build-html5") :as :string)]


### PR DESCRIPTION
Now we emit a clear marker when clearing the console stream.

The marker is a leading newline followed by the same xterm-style escape sequence emitted by `clear`:

- `\n` preserves the previous behavior for simple line-oriented clients, which still observe an empty line on clear.
- `ESC [ 3 J` clears scrollback.
- `ESC [ H` moves the cursor to the home position.
- `ESC [ 2 J` clears the screen.

This allows `/console/stream` users to get a proper clear notification instead of just a newline. For example, this automatically works in shell console streaming:
```sh
curl -N http://localhost:$(cat .internal/editor.port)/console/stream
```

Fix #12431