### PR TITLE
Fix duplicate POSIX crash dump reporting during re-entrant signal handling

### DIFF
--- a/engine/crash/src/backtrace_execinfo.cpp
+++ b/engine/crash/src/backtrace_execinfo.cpp
@@ -101,17 +101,23 @@ namespace dmCrash
 
     static void Handler(const int signum, siginfo_t *const si, void *const sc)
     {
+        bool first_signal_handler = BeginSignalHandler();
+
         // The default behavior is restored for the signal.
         // Unless this is done first thing in the signal handler we'll
         // be stuck in a signal-handler loop forever.
         ResetToDefaultSignalHandler(signum);
 
-        if (g_CrashDumpEnabled)
+        if (g_CrashDumpEnabled && first_signal_handler)
         {
             OnCrash(signum);
         }
 
-        ChainSignalOrRaiseDefault(signum, si, sc, g_PreviousSignalActions, Handler);
+        if (first_signal_handler)
+        {
+            ChainSignalOrRaiseDefault(signum, si, sc, g_PreviousSignalActions, Handler);
+            EndSignalHandler();
+        }
     }
 
     void InstallOnSignal(int signum)

--- a/engine/crash/src/backtrace_libunwind.cpp
+++ b/engine/crash/src/backtrace_libunwind.cpp
@@ -201,17 +201,23 @@ namespace dmCrash
 
     static void Handler(const int signum, siginfo_t *const si, void *const sc)
     {
+        bool first_signal_handler = BeginSignalHandler();
+
         // The default behavior is restored for the signal.
         // Unless this is done first thing in the signal handler we'll
         // be stuck in a signal-handler loop forever.
         ResetToDefaultSignalHandler(signum);
 
-        if (g_CrashDumpEnabled)
+        if (g_CrashDumpEnabled && first_signal_handler)
         {
             OnCrash(signum);
         }
 
-        ChainSignalOrRaiseDefault(signum, si, sc, g_PreviousSignalActions, Handler);
+        if (first_signal_handler)
+        {
+            ChainSignalOrRaiseDefault(signum, si, sc, g_PreviousSignalActions, Handler);
+            EndSignalHandler();
+        }
     }
 
     void InstallOnSignal(int signum)

--- a/engine/crash/src/backtrace_libunwind_ndk.cpp
+++ b/engine/crash/src/backtrace_libunwind_ndk.cpp
@@ -98,12 +98,14 @@ namespace dmCrash
 
     static void Handler(const int signo, siginfo_t* const si, void *const sc)
     {
+        bool first_signal_handler = BeginSignalHandler();
+
         // The default behavior is restored for the signal.
         // Unless this is done first thing in the signal handler we'll
         // be stuck in a signal-handler loop forever.
         ResetToDefaultSignalHandler(signo);
 
-        if (g_CrashDumpEnabled)
+        if (g_CrashDumpEnabled && first_signal_handler)
         {
             AppState* state = GetAppState();
 
@@ -129,7 +131,11 @@ namespace dmCrash
             dLib::SetDebugMode(is_debug_mode);
         }
 
-        ChainSignalOrRaiseDefault(signo, si, sc, g_PreviousSignalActions, Handler);
+        if (first_signal_handler)
+        {
+            ChainSignalOrRaiseDefault(signo, si, sc, g_PreviousSignalActions, Handler);
+            EndSignalHandler();
+        }
     }
 
     void WriteDump()

--- a/engine/crash/src/backtrace_signal_posix.cpp
+++ b/engine/crash/src/backtrace_signal_posix.cpp
@@ -20,6 +20,8 @@
 
 namespace dmCrash
 {
+    static volatile sig_atomic_t g_SignalHandlerActive = 0;
+
     static struct sigaction* GetPreviousSignalAction(int signum, struct sigaction* previous_signal_actions)
     {
         return IsValidSignal(signum) && previous_signal_actions ? &previous_signal_actions[signum] : 0;
@@ -153,5 +155,21 @@ namespace dmCrash
         sa.sa_flags = SA_SIGINFO;
 
         return sigaction(signum, &sa, previous_signal_action) == 0;
+    }
+
+    bool BeginSignalHandler()
+    {
+        if (g_SignalHandlerActive)
+        {
+            return false;
+        }
+
+        g_SignalHandlerActive = 1;
+        return true;
+    }
+
+    void EndSignalHandler()
+    {
+        g_SignalHandlerActive = 0;
     }
 }

--- a/engine/crash/src/backtrace_signal_posix.h
+++ b/engine/crash/src/backtrace_signal_posix.h
@@ -31,6 +31,8 @@ namespace dmCrash
     void RaiseDefaultSignalHandler(int signum, const siginfo_t* si);
     void ChainSignalOrRaiseDefault(int signum, siginfo_t* si, void* sc, struct sigaction* previous_signal_actions, FSignalAction current_handler);
     bool InstallSignalHandler(int signum, FSignalAction handler, struct sigaction* previous_signal_actions);
+    bool BeginSignalHandler();
+    void EndSignalHandler();
 }
 
 #endif

--- a/engine/crash/src/test/test_crash_posix_signal.cpp
+++ b/engine/crash/src/test/test_crash_posix_signal.cpp
@@ -37,6 +37,9 @@ static volatile sig_atomic_t g_PreviousSignalHandlerWasRestored = 0;
 static volatile sig_atomic_t g_CallbackOrderCount = 0;
 static volatile sig_atomic_t g_CallbackOrder[MAX_CALLBACK_RECORDS];
 static volatile sig_atomic_t g_ChainFromCurrentSignalAction = 0;
+static volatile sig_atomic_t g_TestCrashDumpWrites = 0;
+static volatile sig_atomic_t g_PreviousSignalActionShouldReenterCurrent = 0;
+static volatile sig_atomic_t g_PreviousSignalActionDidReenterCurrent = 0;
 static struct sigaction g_TestPreviousSignalActions[dmCrash::MAX_SIGNAL_COUNT];
 
 static void RecordCallback(TestCallback callback)
@@ -58,12 +61,17 @@ static void ResetCallbackState()
     g_PreviousSignalHandlerWasRestored = 0;
     g_CallbackOrderCount = 0;
     g_ChainFromCurrentSignalAction = 0;
+    g_TestCrashDumpWrites = 0;
+    g_PreviousSignalActionShouldReenterCurrent = 0;
+    g_PreviousSignalActionDidReenterCurrent = 0;
 
     for (int i = 0; i < MAX_CALLBACK_RECORDS; ++i)
     {
         g_CallbackOrder[i] = 0;
     }
 }
+
+static void TestCurrentSignalActionWithCrashDumpGuard(int signum, siginfo_t* si, void* sc);
 
 static void TestCurrentSignalAction(int signum, siginfo_t* si, void* sc)
 {
@@ -91,6 +99,18 @@ static void TestPreviousSignalAction(int signum, siginfo_t* si, void* sc)
     g_PreviousSignalActionWasRestored = (current.sa_flags & SA_SIGINFO) && current.sa_sigaction == TestPreviousSignalAction;
 }
 
+static void TestPreviousSignalActionReentersCurrent(int signum, siginfo_t* si, void* sc)
+{
+    g_PreviousSignalActionCalls++;
+    RecordCallback(TEST_CALLBACK_PREVIOUS_ACTION);
+
+    if (g_PreviousSignalActionShouldReenterCurrent && !g_PreviousSignalActionDidReenterCurrent)
+    {
+        g_PreviousSignalActionDidReenterCurrent = 1;
+        TestCurrentSignalActionWithCrashDumpGuard(signum, si, sc);
+    }
+}
+
 static void TestPreviousSignalHandler(int signum)
 {
     struct sigaction current;
@@ -100,6 +120,28 @@ static void TestPreviousSignalHandler(int signum)
     g_PreviousSignalHandlerCalls++;
     RecordCallback(TEST_CALLBACK_PREVIOUS_HANDLER);
     g_PreviousSignalHandlerWasRestored = current.sa_handler == TestPreviousSignalHandler;
+}
+
+static void TestCurrentSignalActionWithCrashDumpGuard(int signum, siginfo_t* si, void* sc)
+{
+    g_CurrentSignalActionCalls++;
+    RecordCallback(TEST_CALLBACK_CURRENT_ACTION);
+
+    bool first_signal_handler = dmCrash::BeginSignalHandler();
+    if (first_signal_handler)
+    {
+        g_TestCrashDumpWrites++;
+    }
+
+    if (g_ChainFromCurrentSignalAction && first_signal_handler)
+    {
+        dmCrash::ChainSignalOrRaiseDefault(signum, si, sc, g_TestPreviousSignalActions, TestCurrentSignalActionWithCrashDumpGuard);
+    }
+
+    if (first_signal_handler)
+    {
+        dmCrash::EndSignalHandler();
+    }
 }
 
 static void ClearSignalActions(struct sigaction* signal_actions)
@@ -273,6 +315,46 @@ TEST(dmCrashPosixSignalTest, TestChainSignalRestoresIgnoredPreviousAction)
     ASSERT_EQ(0, (int)g_PreviousSignalHandlerCalls);
     ASSERT_TRUE(restored_ignored);
     ASSERT_EQ(0, (int)g_CallbackOrderCount);
+}
+
+// Regression for abort-style signal delivery: the same signal can re-enter
+// Defold's handler while the first handler entry is still active. Only the
+// first entry should write the dump or chain to the previous handler.
+TEST(dmCrashPosixSignalTest, TestReenteredCurrentSignalHandlerWritesCrashDumpOnce)
+{
+    const int signum = SIGUSR1;
+
+    struct sigaction original;
+    memset(&original, 0, sizeof(original));
+    sigaction(signum, 0, &original);
+
+    ClearSignalActions(g_TestPreviousSignalActions);
+    sigemptyset(&g_TestPreviousSignalActions[signum].sa_mask);
+    g_TestPreviousSignalActions[signum].sa_sigaction = TestPreviousSignalActionReentersCurrent;
+    g_TestPreviousSignalActions[signum].sa_flags = SA_SIGINFO;
+
+    siginfo_t si;
+    memset(&si, 0, sizeof(si));
+    si.si_signo = signum;
+
+    ResetCallbackState();
+
+    g_ChainFromCurrentSignalAction = 1;
+    g_PreviousSignalActionShouldReenterCurrent = 1;
+    TestCurrentSignalActionWithCrashDumpGuard(signum, &si, 0);
+    g_PreviousSignalActionShouldReenterCurrent = 0;
+    g_ChainFromCurrentSignalAction = 0;
+
+    sigaction(signum, &original, 0);
+
+    ASSERT_EQ(2, (int)g_CurrentSignalActionCalls);
+    ASSERT_EQ(1, (int)g_PreviousSignalActionCalls);
+    ASSERT_EQ(1, (int)g_PreviousSignalActionDidReenterCurrent);
+    ASSERT_EQ(1, (int)g_TestCrashDumpWrites);
+    ASSERT_EQ(3, (int)g_CallbackOrderCount);
+    ASSERT_EQ((int)TEST_CALLBACK_CURRENT_ACTION, (int)g_CallbackOrder[0]);
+    ASSERT_EQ((int)TEST_CALLBACK_PREVIOUS_ACTION, (int)g_CallbackOrder[1]);
+    ASSERT_EQ((int)TEST_CALLBACK_CURRENT_ACTION, (int)g_CallbackOrder[2]);
 }
 
 int main(int argc, char **argv)


### PR DESCRIPTION
When a chained POSIX crash handler re-entered Defold’s signal handler before the first handler call completed, Defold could write/log the same crash dump twice and chain to previous handlers twice. This adds a small active-handler guard so only the first entry writes the dump and forwards the signal, with a regression test covering the re-entry case.