### PR TITLE
Disable Collision Object "Group" property when it's a tilemap or tilegrid

### DIFF
--- a/editor/resources/localization/en.editor_localization
+++ b/editor/resources/localization/en.editor_localization
@@ -1213,6 +1213,7 @@ property.collision-object.event-contact.tooltip = If disabled, filters out any c
 property.collision-object.event-trigger = Generate Trigger Events
 property.collision-object.event-trigger.tooltip = If disabled, filters out any trigger events involving this collision object
 property.collision-object.group = Group
+property.collision-object.group.tilemap.tooltip = This property is not used when Collision Shape is a tilemap. Collision groups are defined in the tilemap's tile source.
 property.collision-object.mask = Mask
 property.collision-object.shape.diameter = Diameter
 property.collision-object.shape.dimensions = Dimensions

--- a/editor/src/clj/editor/collision_object.clj
+++ b/editor/src/clj/editor/collision_object.clj
@@ -772,7 +772,9 @@
   (collision-groups/color collision-groups-data group))
 
 (defn- tilemap-collision-shape? [collision-shape]
-  (contains? #{"tilemap" "tilegrid"} (resource/type-ext collision-shape)))
+  (boolean
+    (when collision-shape
+      (contains? #{"tilemap" "tilegrid"} (resource/type-ext collision-shape)))))
 
 (g/defnode CollisionObjectNode
   (inherits resource-node/ResourceNode)

--- a/editor/src/clj/editor/collision_object.clj
+++ b/editor/src/clj/editor/collision_object.clj
@@ -772,7 +772,7 @@
   (collision-groups/color collision-groups-data group))
 
 (defn- tilemap-collision-shape? [collision-shape]
-  (contains? #{"tilemap" "tilegrid"} (some-> collision-shape resource/resource-type :ext)))
+  (contains? #{"tilemap" "tilegrid"} (resource/type-ext collision-shape)))
 
 (g/defnode CollisionObjectNode
   (inherits resource-node/ResourceNode)

--- a/editor/src/clj/editor/collision_object.clj
+++ b/editor/src/clj/editor/collision_object.clj
@@ -771,6 +771,9 @@
   [collision-groups-data group]
   (collision-groups/color collision-groups-data group))
 
+(defn- tilemap-collision-shape? [collision-shape]
+  (contains? #{"tilemap" "tilegrid"} (some-> collision-shape resource/resource-type :ext)))
+
 (g/defnode CollisionObjectNode
   (inherits resource-node/ResourceNode)
 
@@ -849,8 +852,11 @@
             (dynamic tooltip (properties/tooltip-dynamic :collision-object :event-trigger)))
 
   (property group g/Str ; Required protobuf field.
+            (dynamic read-only? (g/fnk [collision-shape] (tilemap-collision-shape? collision-shape)))
             (dynamic label (properties/label-dynamic :collision-object :group))
-            (dynamic tooltip (properties/tooltip-dynamic :collision-object :group)))
+            (dynamic tooltip (g/fnk [collision-shape]
+                               (when (tilemap-collision-shape? collision-shape)
+                                 (localization/message "property.collision-object.group.tilemap.tooltip")))))
   (property mask g/Str ; Nil is valid default.
             (dynamic label (properties/label-dynamic :collision-object :mask))
             (dynamic tooltip (properties/tooltip-dynamic :collision-object :mask)))

--- a/editor/test/integration/collision_object_test.clj
+++ b/editor/test/integration/collision_object_test.clj
@@ -91,6 +91,20 @@
               (test-util/with-prop [shape prop value]
                 (is (g/error? (g/node-value node-id :build-targets)))))))))))
 
+(deftest group-property-read-only-for-tilemap
+  (test-util/with-loaded-project
+    (testing "group is editable when collision-shape is nil"
+      (let [node-id (test-util/resource-node project "/collision_object/new.collisionobject")]
+        (is (not (test-util/prop-read-only? node-id :group)))))
+
+    (testing "group is read-only when collision-shape is a tilemap"
+      (let [node-id (test-util/resource-node project "/collision_object/tile_map_collision_shape.collisionobject")]
+        (is (test-util/prop-read-only? node-id :group))))
+
+    (testing "existing group value is preserved under a tilemap collision-shape"
+      (let [node-id (test-util/resource-node project "/collision_object/tile_map_collision_shape.collisionobject")]
+        (is (= "default" (test-util/prop node-id :group)))))))
+
 (deftest manip-scale-preserves-types
   (test-util/with-loaded-project
     (let [project-graph (g/node-id->graph-id project)


### PR DESCRIPTION
The editor will now disable the `Group` property of a collision object component when the `Collision Shape` property is set to a tilemap resource. The collision object groups are instead controlled by the groups defined within the tile source used by the assigned tilemap.

Fixes #12371