### PR TITLE
Set Box2d bodies to awake state when transform/scaling is changed

### DIFF
--- a/engine/physics/src/physics/box2d/box2d_physics.cpp
+++ b/engine/physics/src/physics/box2d/box2d_physics.cpp
@@ -549,11 +549,7 @@ namespace dmPhysics
 
                         b2Rot b2_rot = b2MakeRot(angle);
                         b2Body_SetTransform(body_id, b2_position, b2_rot);
-                        b2Body_EnableSleep(body_id, false);
-                    }
-                    else
-                    {
-                        b2Body_EnableSleep(body_id, true);
+                        b2Body_SetAwake(body_id, true);
                     }
                 }
 

--- a/engine/physics/src/physics/box2d/box2d_physics.cpp
+++ b/engine/physics/src/physics/box2d/box2d_physics.cpp
@@ -378,6 +378,8 @@ namespace dmPhysics
         return dmMath::Min(v[0], v[1]);
     }
 
+    static const float SCALE_EPSILON = 0.000001f;
+
     static void UpdateScale(HWorld2D world, Body* body, bool force_update)
     {
         dmTransform::Transform world_transform;
@@ -391,7 +393,7 @@ namespace dmPhysics
             ShapeData* shape_data = body->m_Shapes[i];
             b2ShapeId shape_id = shape_data->m_ShapeId;
 
-            if (shape_data->m_LastScale == object_scale && !force_update)
+            if (fabsf(shape_data->m_LastScale - object_scale) <= SCALE_EPSILON && !force_update)
             {
                 continue;
             }

--- a/engine/physics/src/physics/box2d_defold/box2d_defold_physics.cpp
+++ b/engine/physics/src/physics/box2d_defold/box2d_defold_physics.cpp
@@ -396,7 +396,7 @@ namespace dmPhysics
         float object_scale = GetUniformScale2D(world_transform);
 
         b2Fixture* fix = body->GetFixtureList();
-        bool allow_sleep = true;
+        bool scale_changed = true;
         while( fix )
         {
             b2Shape* shape = fix->GetShape();
@@ -405,7 +405,7 @@ namespace dmPhysics
                 break;
             }
             shape->m_lastScale = object_scale;
-            allow_sleep = false;
+            scale_changed = false;
 
             if (fix->GetShape()->GetType() == b2Shape::e_circle) {
                 // creation scale for circles, is the initial radius
@@ -428,7 +428,7 @@ namespace dmPhysics
             fix = fix->GetNext();
         }
 
-        if (!allow_sleep)
+        if (!scale_changed)
         {
             body->SetAwake(true);
         }
@@ -471,11 +471,7 @@ namespace dmPhysics
                         b2Vec2 b2_position;
                         ToB2(position, b2_position, scale);
                         body->SetTransform(b2_position, angle);
-                        body->SetSleepingAllowed(false);
-                    }
-                    else
-                    {
-                        body->SetSleepingAllowed(true);
+                        body->SetAwake(true);
                     }
                 }
 

--- a/engine/physics/src/physics/box2d_defold/box2d_defold_physics.cpp
+++ b/engine/physics/src/physics/box2d_defold/box2d_defold_physics.cpp
@@ -388,6 +388,8 @@ namespace dmPhysics
         return dmMath::Min(v[0], v[1]);
     }
 
+    static const float SCALE_EPSILON = 0.000001f;
+
     static void UpdateScale(HWorld2D world, b2Body* body)
     {
         dmTransform::Transform world_transform;
@@ -396,16 +398,16 @@ namespace dmPhysics
         float object_scale = GetUniformScale2D(world_transform);
 
         b2Fixture* fix = body->GetFixtureList();
-        bool scale_changed = true;
+        bool scale_changed = false;
         while( fix )
         {
             b2Shape* shape = fix->GetShape();
-            if (shape->m_lastScale == object_scale )
+            if (fabsf(shape->m_lastScale - object_scale) <= SCALE_EPSILON )
             {
                 break;
             }
             shape->m_lastScale = object_scale;
-            scale_changed = false;
+            scale_changed = true;
 
             if (fix->GetShape()->GetType() == b2Shape::e_circle) {
                 // creation scale for circles, is the initial radius
@@ -428,7 +430,7 @@ namespace dmPhysics
             fix = fix->GetNext();
         }
 
-        if (!scale_changed)
+        if (scale_changed)
         {
             body->SetAwake(true);
         }

--- a/engine/physics/src/physics/test/test_physics.cpp
+++ b/engine/physics/src/physics/test/test_physics.cpp
@@ -470,7 +470,7 @@ TYPED_TEST(PhysicsTest, DynamicTransformUpdatesBodyPositionAndPreservesVelocity)
      * The body's Box2D transform is updated from the external transform, and
      * both linear and angular velocity remain unchanged.
      */
-    TestFixture::RecreateContextAndWorld(PHYSICS_SCALE, 1);
+    TestFixture::RecreateContextAndWorld(PHYSICS_SCALE, true);
     TestFixture::m_StepWorldContext.m_DT = 0.0f;
     const float POSITION_EPSILON = 0.000001f;
     const float VELOCITY_EPSILON = 0.000001f;
@@ -541,7 +541,7 @@ TYPED_TEST(PhysicsTest, DynamicTransformSyncAllowsSleeping)
      * The body reaches a sleeping state within the sleep timeout even though the
      * dynamic-transform sync path updated its Box2D transform every step.
      */
-    TestFixture::RecreateContextAndWorld(PHYSICS_SCALE, 1);
+    TestFixture::RecreateContextAndWorld(PHYSICS_SCALE, true);
     (*TestFixture::m_Test.m_SetGravityFunc)(TestFixture::m_World, Vector3(0.0f, 0.0f, 0.0f));
 
     VisualObject vo;
@@ -595,7 +595,7 @@ TYPED_TEST(PhysicsTest, DynamicTransformScaleNoiseDoesNotWakeSleepingBody)
      * The sleeping body remains asleep after the sub-epsilon scale change, and
      * wakes when the scale changes by more than the scale epsilon.
      */
-    TestFixture::RecreateContextAndWorld(PHYSICS_SCALE, 1);
+    TestFixture::RecreateContextAndWorld(PHYSICS_SCALE, true);
     (*TestFixture::m_Test.m_SetGravityFunc)(TestFixture::m_World, Vector3(0.0f, 0.0f, 0.0f));
 
     VisualObject vo;
@@ -645,7 +645,7 @@ TYPED_TEST(PhysicsTest, DynamicBodyOnGroundSleepsWithDynamicTransformSync)
      * Expected results:
      * The dynamic body reaches Box2D's sleeping state.
      */
-    TestFixture::RecreateContextAndWorld(PHYSICS_SCALE, 1);
+    TestFixture::RecreateContextAndWorld(PHYSICS_SCALE, true);
 
     VisualObject ground_vo;
     ground_vo.m_Position = Point3(0.0f, -1.0f, 0.0f);

--- a/engine/physics/src/physics/test/test_physics.cpp
+++ b/engine/physics/src/physics/test/test_physics.cpp
@@ -451,6 +451,247 @@ TYPED_TEST(PhysicsTest, WorldTransformCallbacks)
     (*TestFixture::m_Test.m_DeleteCollisionShapeFunc)(shape);
 }
 
+#if defined(PHYSICS_TEST_BOX2D) || defined(PHYSICS_TEST_BOX2D_DEFOLD)
+TYPED_TEST(PhysicsTest, DynamicTransformUpdatesBodyPositionAndPreservesVelocity)
+{
+    /*
+     * Intent:
+     * Verify the Box2D dynamic-transform sync path used by StepWorld2D when
+     * physics.allow_dynamic_transforms is enabled. Updating the external game
+     * object transform should move the dynamic body without resetting velocity.
+     *
+     * Setup:
+     * Recreate the 2D physics world with m_AllowDynamicTransforms enabled,
+     * create one dynamic body backed by a VisualObject transform callback, set
+     * non-zero linear and angular velocities, then change the VisualObject
+     * position and rotation before stepping with dt = 0.
+     *
+     * Expected results:
+     * The body's Box2D transform is updated from the external transform, and
+     * both linear and angular velocity remain unchanged.
+     */
+    TestFixture::RecreateContextAndWorld(PHYSICS_SCALE, 1);
+    TestFixture::m_StepWorldContext.m_DT = 0.0f;
+    const float POSITION_EPSILON = 0.000001f;
+    const float VELOCITY_EPSILON = 0.000001f;
+    const float ROTATION_EPSILON = 0.001f;
+
+    VisualObject vo;
+    vo.m_Position = Point3(1.0f, 2.0f, 0.0f);
+    vo.m_Rotation = Quat(0.0f, 0.0f, 0.0f, 1.0f);
+
+    dmPhysics::CollisionObjectData data;
+    data.m_UserData = &vo;
+    typename TypeParam::CollisionShapeType shape = (*TestFixture::m_Test.m_NewBoxShapeFunc)(TestFixture::m_Context, Vector3(0.5f, 0.5f, 0.5f));
+    typename TypeParam::CollisionObjectType co = (*TestFixture::m_Test.m_NewCollisionObjectFunc)(TestFixture::m_World, data, &shape, 1u);
+
+    Vector3 linear_velocity(3.0f, -2.0f, 0.0f);
+    Vector3 angular_velocity(0.0f, 0.0f, 1.75f);
+    (*TestFixture::m_Test.m_SetLinearVelocityFunc)(TestFixture::m_Context, co, linear_velocity);
+    (*TestFixture::m_Test.m_SetAngularVelocityFunc)(TestFixture::m_Context, co, angular_velocity);
+
+    Point3 new_position(4.0f, 7.0f, 0.0f);
+    Quat new_rotation = Quat::rotationZ(0.5f);
+    vo.m_Position = new_position;
+    vo.m_Rotation = new_rotation;
+
+    (*TestFixture::m_Test.m_StepWorldFunc)(TestFixture::m_World, TestFixture::m_StepWorldContext);
+
+    Point3 body_position = (*TestFixture::m_Test.m_GetWorldPositionFunc)(TestFixture::m_Context, co);
+    for (int i = 0; i < 3; ++i)
+    {
+        ASSERT_NEAR(new_position.getElem(i), body_position.getElem(i), POSITION_EPSILON);
+        ASSERT_NEAR(new_position.getElem(i), vo.m_Position.getElem(i), POSITION_EPSILON);
+    }
+
+    Quat body_rotation = (*TestFixture::m_Test.m_GetWorldRotationFunc)(TestFixture::m_Context, co);
+    for (int i = 0; i < 4; ++i)
+    {
+        ASSERT_NEAR(new_rotation.getElem(i), body_rotation.getElem(i), ROTATION_EPSILON);
+        ASSERT_NEAR(new_rotation.getElem(i), vo.m_Rotation.getElem(i), ROTATION_EPSILON);
+    }
+
+    Vector3 body_linear_velocity = (*TestFixture::m_Test.m_GetLinearVelocityFunc)(TestFixture::m_Context, co);
+    Vector3 body_angular_velocity = (*TestFixture::m_Test.m_GetAngularVelocityFunc)(TestFixture::m_Context, co);
+    for (int i = 0; i < 3; ++i)
+    {
+        ASSERT_NEAR(linear_velocity.getElem(i), body_linear_velocity.getElem(i), VELOCITY_EPSILON);
+        ASSERT_NEAR(angular_velocity.getElem(i), body_angular_velocity.getElem(i), VELOCITY_EPSILON);
+    }
+
+    (*TestFixture::m_Test.m_DeleteCollisionObjectFunc)(TestFixture::m_World, co);
+    (*TestFixture::m_Test.m_DeleteCollisionShapeFunc)(shape);
+}
+
+TYPED_TEST(PhysicsTest, DynamicTransformSyncAllowsSleeping)
+{
+    /*
+     * Intent:
+     * Verify that repeated Box2D dynamic-transform sync wakes the body without
+     * disabling sleep. A dynamic body that is externally repositioned while it
+     * has no velocity should still be able to accumulate sleep time.
+     *
+     * Setup:
+     * Recreate the 2D physics world with m_AllowDynamicTransforms enabled,
+     * disable gravity, create one idle dynamic body backed by a VisualObject
+     * transform callback, then move the VisualObject by more than the sync
+     * epsilon before every step.
+     *
+     * Expected results:
+     * The body reaches a sleeping state within the sleep timeout even though the
+     * dynamic-transform sync path updated its Box2D transform every step.
+     */
+    TestFixture::RecreateContextAndWorld(PHYSICS_SCALE, 1);
+    (*TestFixture::m_Test.m_SetGravityFunc)(TestFixture::m_World, Vector3(0.0f, 0.0f, 0.0f));
+
+    VisualObject vo;
+    vo.m_Position = Point3(0.0f, 0.0f, 0.0f);
+    vo.m_Rotation = Quat(0.0f, 0.0f, 0.0f, 1.0f);
+
+    dmPhysics::CollisionObjectData data;
+    data.m_Type = dmPhysics::COLLISION_OBJECT_TYPE_DYNAMIC;
+    data.m_UserData = &vo;
+    typename TypeParam::CollisionShapeType shape = (*TestFixture::m_Test.m_NewBoxShapeFunc)(TestFixture::m_Context, Vector3(0.5f, 0.5f, 0.5f));
+    typename TypeParam::CollisionObjectType co = (*TestFixture::m_Test.m_NewCollisionObjectFunc)(TestFixture::m_World, data, &shape, 1u);
+    ASSERT_FALSE((*TestFixture::m_Test.m_IsSleepingFunc)(co));
+
+    const float position_delta = 0.001f;
+    const float sleep_timeout = 2.1f;
+    int steps = (int)(sleep_timeout / TestFixture::m_StepWorldContext.m_DT);
+    bool slept = false;
+    for (int i = 0; i < steps; ++i)
+    {
+        vo.m_Position += Vector3(position_delta, 0.0f, 0.0f);
+        (*TestFixture::m_Test.m_StepWorldFunc)(TestFixture::m_World, TestFixture::m_StepWorldContext);
+
+        if ((*TestFixture::m_Test.m_IsSleepingFunc)(co))
+        {
+            slept = true;
+            break;
+        }
+    }
+
+    ASSERT_TRUE(slept);
+
+    (*TestFixture::m_Test.m_DeleteCollisionObjectFunc)(TestFixture::m_World, co);
+    (*TestFixture::m_Test.m_DeleteCollisionShapeFunc)(shape);
+}
+
+TYPED_TEST(PhysicsTest, DynamicTransformScaleNoiseDoesNotWakeSleepingBody)
+{
+    /*
+     * Intent:
+     * Verify that Box2D dynamic-transform scale sync wakes sleeping bodies only
+     * for meaningful scale changes. Tiny scale noise should not keep a sleeping
+     * body awake, but an actual scale update should wake it.
+     *
+     * Setup:
+     * Recreate the 2D physics world with m_AllowDynamicTransforms enabled,
+     * disable gravity, create one idle dynamic body backed by a VisualObject
+     * transform callback, and step until the body sleeps. Then apply sub-epsilon
+     * scale noise followed by a larger scale change.
+     *
+     * Expected results:
+     * The sleeping body remains asleep after the sub-epsilon scale change, and
+     * wakes when the scale changes by more than the scale epsilon.
+     */
+    TestFixture::RecreateContextAndWorld(PHYSICS_SCALE, 1);
+    (*TestFixture::m_Test.m_SetGravityFunc)(TestFixture::m_World, Vector3(0.0f, 0.0f, 0.0f));
+
+    VisualObject vo;
+    vo.m_Position = Point3(0.0f, 0.0f, 0.0f);
+    vo.m_Rotation = Quat(0.0f, 0.0f, 0.0f, 1.0f);
+    vo.m_Scale = 1.0f;
+
+    dmPhysics::CollisionObjectData data;
+    data.m_Type = dmPhysics::COLLISION_OBJECT_TYPE_DYNAMIC;
+    data.m_UserData = &vo;
+    typename TypeParam::CollisionShapeType shape = (*TestFixture::m_Test.m_NewBoxShapeFunc)(TestFixture::m_Context, Vector3(0.5f, 0.5f, 0.5f));
+    typename TypeParam::CollisionObjectType co = (*TestFixture::m_Test.m_NewCollisionObjectFunc)(TestFixture::m_World, data, &shape, 1u);
+    ASSERT_FALSE((*TestFixture::m_Test.m_IsSleepingFunc)(co));
+
+    const float sleep_timeout = 2.1f;
+    int steps = (int)(sleep_timeout / TestFixture::m_StepWorldContext.m_DT);
+    for (int i = 0; i < steps; ++i)
+    {
+        (*TestFixture::m_Test.m_StepWorldFunc)(TestFixture::m_World, TestFixture::m_StepWorldContext);
+    }
+    ASSERT_TRUE((*TestFixture::m_Test.m_IsSleepingFunc)(co));
+
+    vo.m_Scale += 0.0000005f;
+    (*TestFixture::m_Test.m_StepWorldFunc)(TestFixture::m_World, TestFixture::m_StepWorldContext);
+    ASSERT_TRUE((*TestFixture::m_Test.m_IsSleepingFunc)(co));
+
+    vo.m_Scale += 0.001f;
+    (*TestFixture::m_Test.m_StepWorldFunc)(TestFixture::m_World, TestFixture::m_StepWorldContext);
+    ASSERT_FALSE((*TestFixture::m_Test.m_IsSleepingFunc)(co));
+
+    (*TestFixture::m_Test.m_DeleteCollisionObjectFunc)(TestFixture::m_World, co);
+    (*TestFixture::m_Test.m_DeleteCollisionShapeFunc)(shape);
+}
+
+TYPED_TEST(PhysicsTest, DynamicBodyOnGroundSleepsWithDynamicTransformSync)
+{
+    /*
+     * Intent:
+     * Verify that a normal dynamic body can come to rest and sleep while
+     * Box2D dynamic-transform sync is enabled.
+     *
+     * Setup:
+     * Recreate the 2D physics world with m_AllowDynamicTransforms enabled,
+     * create one static ground body and one dynamic box above it, then step the
+     * world long enough for the dynamic body to settle on the ground.
+     *
+     * Expected results:
+     * The dynamic body reaches Box2D's sleeping state.
+     */
+    TestFixture::RecreateContextAndWorld(PHYSICS_SCALE, 1);
+
+    VisualObject ground_vo;
+    ground_vo.m_Position = Point3(0.0f, -1.0f, 0.0f);
+    ground_vo.m_Rotation = Quat(0.0f, 0.0f, 0.0f, 1.0f);
+
+    dmPhysics::CollisionObjectData ground_data;
+    ground_data.m_Type = dmPhysics::COLLISION_OBJECT_TYPE_STATIC;
+    ground_data.m_Mass = 0.0f;
+    ground_data.m_UserData = &ground_vo;
+    typename TypeParam::CollisionShapeType ground_shape = (*TestFixture::m_Test.m_NewBoxShapeFunc)(TestFixture::m_Context, Vector3(10.0f, 0.5f, 0.5f));
+    typename TypeParam::CollisionObjectType ground_co = (*TestFixture::m_Test.m_NewCollisionObjectFunc)(TestFixture::m_World, ground_data, &ground_shape, 1u);
+
+    VisualObject box_vo;
+    box_vo.m_Position = Point3(0.0f, 2.0f, 0.0f);
+    box_vo.m_Rotation = Quat(0.0f, 0.0f, 0.0f, 1.0f);
+
+    dmPhysics::CollisionObjectData box_data;
+    box_data.m_Type = dmPhysics::COLLISION_OBJECT_TYPE_DYNAMIC;
+    box_data.m_UserData = &box_vo;
+    typename TypeParam::CollisionShapeType box_shape = (*TestFixture::m_Test.m_NewBoxShapeFunc)(TestFixture::m_Context, Vector3(0.5f, 0.5f, 0.5f));
+    typename TypeParam::CollisionObjectType box_co = (*TestFixture::m_Test.m_NewCollisionObjectFunc)(TestFixture::m_World, box_data, &box_shape, 1u);
+    ASSERT_FALSE((*TestFixture::m_Test.m_IsSleepingFunc)(box_co));
+
+    const float sleep_timeout = 4.0f;
+    int steps = (int)(sleep_timeout / TestFixture::m_StepWorldContext.m_DT);
+    bool slept = false;
+    for (int i = 0; i < steps; ++i)
+    {
+        (*TestFixture::m_Test.m_StepWorldFunc)(TestFixture::m_World, TestFixture::m_StepWorldContext);
+
+        if ((*TestFixture::m_Test.m_IsSleepingFunc)(box_co))
+        {
+            slept = true;
+            break;
+        }
+    }
+
+    ASSERT_TRUE(slept);
+
+    (*TestFixture::m_Test.m_DeleteCollisionObjectFunc)(TestFixture::m_World, box_co);
+    (*TestFixture::m_Test.m_DeleteCollisionShapeFunc)(box_shape);
+    (*TestFixture::m_Test.m_DeleteCollisionObjectFunc)(TestFixture::m_World, ground_co);
+    (*TestFixture::m_Test.m_DeleteCollisionShapeFunc)(ground_shape);
+}
+#endif
+
 TYPED_TEST(PhysicsTest, GroundBoxCollision)
 {
     float ground_height_half_ext = 1.0f;

--- a/engine/physics/src/physics/test/test_physics.h
+++ b/engine/physics/src/physics/test/test_physics.h
@@ -52,11 +52,17 @@ protected:
 
     void SetupContextAndWorld(float physics_scale)
     {
+        SetupContextAndWorld(physics_scale, 0);
+    }
+
+    void SetupContextAndWorld(float physics_scale, uint8_t allow_dynamic_transforms)
+    {
         dmPhysics::NewContextParams context_params = dmPhysics::NewContextParams();
         context_params.m_Scale = physics_scale;
         context_params.m_RayCastLimit2D = 64;
         context_params.m_RayCastLimit3D = 128;
         context_params.m_TriggerOverlapCapacity = 16;
+        context_params.m_AllowDynamicTransforms = allow_dynamic_transforms;
         m_Context = (*m_Test.m_NewContextFunc)(context_params);
         dmPhysics::NewWorldParams world_params;
         world_params.m_GetWorldTransformCallback = GetWorldTransform;
@@ -74,6 +80,13 @@ protected:
         m_StepWorldContext.m_Box2DVelocityIterations = 10;
         m_StepWorldContext.m_Box2DPositionIterations = 10;
         m_StepWorldContext.m_Box2DSubStepCount = 10;
+    }
+
+    void RecreateContextAndWorld(float physics_scale, uint8_t allow_dynamic_transforms)
+    {
+        (*m_Test.m_DeleteWorldFunc)(m_Context, m_World);
+        (*m_Test.m_DeleteContextFunc)(m_Context);
+        SetupContextAndWorld(physics_scale, allow_dynamic_transforms);
     }
 
     void TearDown() override

--- a/engine/physics/src/physics/test/test_physics.h
+++ b/engine/physics/src/physics/test/test_physics.h
@@ -47,15 +47,10 @@ protected:
 
     void SetUp() override
     {
-        SetupContextAndWorld(PHYSICS_SCALE);
+        SetupContextAndWorld(PHYSICS_SCALE, false);
     }
 
-    void SetupContextAndWorld(float physics_scale)
-    {
-        SetupContextAndWorld(physics_scale, 0);
-    }
-
-    void SetupContextAndWorld(float physics_scale, uint8_t allow_dynamic_transforms)
+    void SetupContextAndWorld(float physics_scale, bool allow_dynamic_transforms)
     {
         dmPhysics::NewContextParams context_params = dmPhysics::NewContextParams();
         context_params.m_Scale = physics_scale;
@@ -82,7 +77,7 @@ protected:
         m_StepWorldContext.m_Box2DSubStepCount = 10;
     }
 
-    void RecreateContextAndWorld(float physics_scale, uint8_t allow_dynamic_transforms)
+    void RecreateContextAndWorld(float physics_scale, bool allow_dynamic_transforms)
     {
         (*m_Test.m_DeleteWorldFunc)(m_Context, m_World);
         (*m_Test.m_DeleteContextFunc)(m_Context);
@@ -110,7 +105,7 @@ protected:
 
     virtual void SetUp()
     {
-        this->SetupContextAndWorld(PRECISION_ROUNDING_PHYSICS_SCALE);
+        this->SetupContextAndWorld(PRECISION_ROUNDING_PHYSICS_SCALE, false);
     }
 };
 


### PR DESCRIPTION
The new Lua api still couldn't enable/disable sleep, due to an issue in our physics wrappers.
https://forum.defold.com/t/setting-enable-sleep-isnt-persistent/82877

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
