### PR TITLE
Added ASTC support check for Android

### DIFF
--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -328,6 +328,7 @@ static bool OpenGLValidateASTCSupport()
     glGetIntegerv(GL_TEXTURE_BINDING_2D, &previous_texture_binding);
     OpenGLClearGLError();
 
+    dmLogInfo("Checking ASTC support. May produce GL error.");
     GLuint texture = 0;
     glGenTextures(1, &texture);
     glBindTexture(GL_TEXTURE_2D, texture);
@@ -363,6 +364,8 @@ static bool OpenGLValidateASTCArraySupport()
         0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF
 
     };
+
+    dmLogInfo("Checking ASTC Array support. May produce GL error.");
 
     GLint previous_texture_binding = 0;
     glGetIntegerv(GL_TEXTURE_BINDING_2D_ARRAY, &previous_texture_binding);

--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -315,6 +315,75 @@ static void OpenGLClearGLError()
     }
 }
 
+#if defined(ANDROID)
+static bool OpenGLValidateASTCSupport()
+{
+    // One opaque white ASTC 4x4 block.
+    static const unsigned char astc_texture_data[] = {
+        0xFC, 0xFD, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF
+    };
+
+    GLint previous_texture_binding = 0;
+    glGetIntegerv(GL_TEXTURE_BINDING_2D, &previous_texture_binding);
+    OpenGLClearGLError();
+
+    GLuint texture = 0;
+    glGenTextures(1, &texture);
+    glBindTexture(GL_TEXTURE_2D, texture);
+    glCompressedTexImage2D(GL_TEXTURE_2D, 0, DMGRAPHICS_TEXTURE_FORMAT_RGBA_ASTC_4x4_KHR,
+        4, 4, 0, (GLsizei) sizeof(astc_texture_data), astc_texture_data);
+
+    GLint err = glGetError();
+
+    glBindTexture(GL_TEXTURE_2D, (GLuint) previous_texture_binding);
+    glDeleteTextures(1, &texture);
+    OpenGLClearGLError();
+
+    if (err != 0)
+    {
+        dmLogWarning("ASTC texture support reported by driver, but a 4x4 ASTC texture upload failed with %s. Disabling ASTC texture support.",
+            GetGLErrorLiteral(err));
+        return false;
+    }
+
+    return true;
+}
+#endif
+
+#if defined(__EMSCRIPTEN__)
+static bool OpenGLValidateASTCArraySupport()
+{
+    // Two opaque white ASTC 4x4 blocks, one per array layer.
+    static const unsigned char astc_texture_data[] = {
+        0xFC, 0xFD, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+
+        0xFC, 0xFD, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF
+
+    };
+
+    GLint previous_texture_binding = 0;
+    glGetIntegerv(GL_TEXTURE_BINDING_2D_ARRAY, &previous_texture_binding);
+    OpenGLClearGLError();
+
+    GLuint texture = 0;
+    glGenTextures(1, &texture);
+    glBindTexture(GL_TEXTURE_2D_ARRAY, texture);
+    DMGRAPHICS_COMPRESSED_TEX_IMAGE_3D(GL_TEXTURE_2D_ARRAY, 0, DMGRAPHICS_TEXTURE_FORMAT_RGBA_ASTC_4x4_KHR,
+        4, 4, 2, 0, (GLsizei) sizeof(astc_texture_data), astc_texture_data);
+
+    GLint err = glGetError();
+
+    glBindTexture(GL_TEXTURE_2D_ARRAY, (GLuint) previous_texture_binding);
+    glDeleteTextures(1, &texture);
+    OpenGLClearGLError();
+
+    return err == 0;
+}
+#endif
+
 #define CLEAR_GL_ERROR { if(g_Context->m_BaseContext.m_VerifyGraphicsCalls) OpenGLClearGLError(); }
 
 static void LogFrameBufferError(GLenum status)
@@ -1627,14 +1696,11 @@ static void LogFrameBufferError(GLenum status)
         }
 
         // https://www.khronos.org/registry/OpenGL/extensions/ARB/ARB_ES3_compatibility.txt
-        if (OpenGLIsExtensionSupported(_context, "GL_KHR_texture_compression_astc_ldr") ||
-            OpenGLIsExtensionSupported(_context, "GL_OES_texture_compression_astc") ||
-            OpenGLIsExtensionSupported(_context, "OES_texture_compression_astc") ||
-            OpenGLIsExtensionSupported(_context, "WEBGL_compressed_texture_astc"))
-        {
-            context->m_ASTCSupport = 1;
-            context->m_ASTCArrayTextureSupport = 1;
-        }
+        bool astc_supported = OpenGLIsExtensionSupported(_context, "GL_KHR_texture_compression_astc_ldr") ||
+                              OpenGLIsExtensionSupported(_context, "GL_OES_texture_compression_astc") ||
+                              OpenGLIsExtensionSupported(_context, "OES_texture_compression_astc") ||
+                              OpenGLIsExtensionSupported(_context, "WEBGL_compressed_texture_astc");
+        bool astc_array_textures_supported = true;
 
         // Check if we're using a recent enough OpenGL version
         if (context->m_IsGles3Version)
@@ -1686,42 +1752,12 @@ static void LogFrameBufferError(GLenum status)
         {
             GLint *pCompressedFormats = new GLint[iNumCompressedFormats];
             glGetIntegerv(GL_COMPRESSED_TEXTURE_FORMATS, pCompressedFormats);
-            bool isPagedASTCSupported = true;
-            #if defined (__EMSCRIPTEN__)
-            // Workaround for some old phones which don't work with ASTC in glCompressedTexImage3D
-            // see https://github.com/defold/defold/issues/8030
-            // and https://github.com/defold/defold/issues/11009
-            if (context->m_IsGles3Version && OpenGLIsTextureFormatSupported(_context, TEXTURE_FORMAT_RGBA_ASTC_4X4)) {
-                unsigned char fakeZeroBuffer[] = {
-                    0xFC, 0xFD, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-                    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-
-                    0xFC, 0xFD, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-                    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF
-
-                };
-                GLuint texture;
-                glGenTextures(1, &texture);
-                glBindTexture(GL_TEXTURE_2D_ARRAY, texture);
-                DMGRAPHICS_COMPRESSED_TEX_IMAGE_3D(GL_TEXTURE_2D_ARRAY, 0, DMGRAPHICS_TEXTURE_FORMAT_RGBA_ASTC_4x4_KHR, 4, 4, 2, 0, 32, &fakeZeroBuffer);
-                GLint err = glGetError();
-                if (err != 0)
-                {
-                    // Only disable ASTC for array textures; keep 2D ASTC enabled
-                    context->m_ASTCArrayTextureSupport = 0;
-                    isPagedASTCSupported = false;
-                }
-                glDeleteTextures(1, &texture);
-            }
-            #endif
             for (int i = 0; i < iNumCompressedFormats; i++)
             {
                 // If 4x4 is supported, all ASTC formats should be supported.
                 if (pCompressedFormats[i] == DMGRAPHICS_TEXTURE_FORMAT_RGBA_ASTC_4x4_KHR)
                 {
-                    context->m_ASTCSupport = 1;
-                    if (isPagedASTCSupported)
-                        context->m_ASTCArrayTextureSupport = 1;
+                    astc_supported = true;
                 }
                 else
                 {
@@ -1736,9 +1772,33 @@ static void LogFrameBufferError(GLenum status)
                     }
                 }
             }
+            #if defined (__EMSCRIPTEN__)
+            // Workaround for some old phones which don't work with ASTC in glCompressedTexImage3D
+            // see https://github.com/defold/defold/issues/8030
+            // and https://github.com/defold/defold/issues/11009
+            if (context->m_IsGles3Version && astc_supported)
+            {
+                astc_array_textures_supported = OpenGLValidateASTCArraySupport();
+            }
+            #endif
             delete[] pCompressedFormats;
         }
 
+    #if defined(ANDROID)
+        if (astc_supported)
+        {
+            // The issue is that the Android Emulator may report support, but not actually support it
+            // So we do a quick verification
+            // (https://github.com/defold/defold/issues/12511)
+            astc_supported = OpenGLValidateASTCSupport();
+        }
+    #endif
+
+        if (astc_supported)
+        {
+            context->m_ASTCSupport = 1;
+            context->m_ASTCArrayTextureSupport = astc_array_textures_supported;
+        }
 
 #if defined (__EMSCRIPTEN__)
         // webgl GL_DEPTH_STENCIL_ATTACHMENT for stenciling and GL_DEPTH_COMPONENT16 for depth only by specifications, even though it reports 24-bit depth and no packed depth stencil extensions.

--- a/scripts/mobile/android_emulator.sh
+++ b/scripts/mobile/android_emulator.sh
@@ -4,17 +4,17 @@ set -euo pipefail
 
 usage() {
     cat <<'EOF'
-usage: ci/rendertest/android/emulator_start.sh (--avd NAME [options] | --stop)
+usage: scripts/mobile/android_emulator.sh (--avd NAME [options] | --run-apk APK | --list-avds | --stop)
 
-Start an Android emulator and wait until adb can see it, or stop a running emulator.
+Start an Android emulator and wait until adb can see it, run an APK on a running emulator, or stop a running emulator.
 
-To list installed avd's:
+To list installed AVDs:
 
-  ${HOME}/Library/Android/sdk/emulator/emulator -list-avds                                                                [android-tests] 10:25:48
-  Pixel_8_Pro_API_36
+  scripts/mobile/android_emulator.sh --list-avds
 
 Options:
-  --avd NAME            Android Virtual Device name. Required.
+  --avd NAME            Android Virtual Device name. Required when starting.
+  --run-apk APK         Install and launch an APK on the running emulator. Can be used with --avd.
   --list-avds           Print installed Android Virtual Device names and exit.
   --gpu MODE            GPU emulation mode passed to the emulator. Default: auto
   --output DIR          Output directory for emulator logs. Default: build/render-tests/android
@@ -24,17 +24,37 @@ Options:
 EOF
 }
 
+if [[ $# -eq 0 ]]; then
+    usage
+    exit 0
+fi
+
 AVD_NAME=""
 LIST_AVDS=0
 GPU_MODE="auto"
 OUTPUT_DIR="build/render-tests/android"
 EMULATOR_ARGS=()
+RUN_APK=""
 STOP_EMULATOR="0"
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --avd)
+            if [[ $# -lt 2 || -z "${2:-}" ]]; then
+                echo "--avd requires a name" >&2
+                usage >&2
+                exit 1
+            fi
             AVD_NAME="${2:-}"
+            shift 2
+            ;;
+        --run-apk)
+            if [[ $# -lt 2 || -z "${2:-}" ]]; then
+                echo "--run-apk requires an APK path" >&2
+                usage >&2
+                exit 1
+            fi
+            RUN_APK="${2:-}"
             shift 2
             ;;
         --list-avds)
@@ -42,14 +62,29 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
         --gpu)
+            if [[ $# -lt 2 || -z "${2:-}" ]]; then
+                echo "--gpu requires a mode, for example auto, host, or software" >&2
+                usage >&2
+                exit 1
+            fi
             GPU_MODE="${2:-}"
             shift 2
             ;;
         --output)
+            if [[ $# -lt 2 || -z "${2:-}" ]]; then
+                echo "--output requires a directory" >&2
+                usage >&2
+                exit 1
+            fi
             OUTPUT_DIR="${2:-}"
             shift 2
             ;;
         --emulator-arg)
+            if [[ $# -lt 2 || -z "${2:-}" ]]; then
+                echo "--emulator-arg requires an argument" >&2
+                usage >&2
+                exit 1
+            fi
             EMULATOR_ARGS+=("${2:-}")
             shift 2
             ;;
@@ -69,8 +104,33 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-if [[ "${STOP_EMULATOR}" == "0" ]] && [[ -z "${AVD_NAME}" ]]; then
+ACTION_COUNT=0
+if [[ "${STOP_EMULATOR}" == "1" ]]; then
+    ACTION_COUNT=$((ACTION_COUNT + 1))
+fi
+if [[ "${LIST_AVDS}" -eq 1 ]]; then
+    ACTION_COUNT=$((ACTION_COUNT + 1))
+fi
+if [[ "${ACTION_COUNT}" -gt 1 ]]; then
+    echo "--stop and --list-avds cannot be used together" >&2
+    usage >&2
+    exit 1
+fi
+
+if [[ "${ACTION_COUNT}" -gt 0 ]] && [[ -n "${RUN_APK}" ]]; then
+    echo "--run-apk cannot be used with --stop or --list-avds" >&2
+    usage >&2
+    exit 1
+fi
+
+if [[ "${STOP_EMULATOR}" == "0" ]] && [[ "${LIST_AVDS}" -eq 0 ]] && [[ -z "${AVD_NAME}" ]] && [[ -z "${RUN_APK}" ]]; then
     echo "--avd is required" >&2
+    usage >&2
+    exit 1
+fi
+
+if [[ -n "${RUN_APK}" ]] && [[ ! -f "${RUN_APK}" ]]; then
+    echo "APK not found: ${RUN_APK}" >&2
     exit 1
 fi
 
@@ -87,6 +147,119 @@ fi
 
 list_running_emulators() {
     "${ADB_BIN}" devices | awk 'NR > 1 && $2 != "offline" && $1 ~ /^emulator-/ { print $1 }'
+}
+
+require_adb_binary() {
+    ADB_BIN="${ADB_BIN:-adb}"
+    if ! command -v "${ADB_BIN}" >/dev/null 2>&1; then
+        echo "adb not found on PATH" >&2
+        exit 1
+    fi
+}
+
+find_android_build_tool_binary() {
+    local tool_name="$1"
+    local candidate
+    local sdk_root
+    local sdk_roots=(
+        "${ANDROID_SDK_ROOT:-}"
+        "${ANDROID_HOME:-}"
+        "${HOME}/Android/Sdk"
+        "${HOME}/Library/Android/sdk"
+        "${LOCALAPPDATA:-}/Android/Sdk"
+    )
+
+    if command -v "${tool_name}" >/dev/null 2>&1; then
+        command -v "${tool_name}"
+        return 0
+    fi
+
+    for sdk_root in "${sdk_roots[@]}"; do
+        if [[ -z "${sdk_root}" || ! -d "${sdk_root}/build-tools" ]]; then
+            continue
+        fi
+
+        while IFS= read -r candidate; do
+            if [[ -x "${candidate}" ]]; then
+                printf '%s\n' "${candidate}"
+                return 0
+            fi
+        done < <(find "${sdk_root}/build-tools" -type f \( -name "${tool_name}" -o -name "${tool_name}.exe" \) 2>/dev/null | sort -r)
+    done
+
+    return 1
+}
+
+require_aapt2_binary() {
+    AAPT2_BIN="${AAPT2_BIN:-}"
+    if [[ -n "${AAPT2_BIN}" ]]; then
+        if command -v "${AAPT2_BIN}" >/dev/null 2>&1; then
+            return 0
+        fi
+
+        echo "aapt2 not found at AAPT2_BIN=${AAPT2_BIN}" >&2
+        exit 1
+    fi
+
+    if AAPT2_BIN="$(find_android_build_tool_binary "aapt2")"; then
+        return 0
+    fi
+
+    echo "aapt2 not found on PATH or in common Android SDK locations. Set ANDROID_SDK_ROOT, ANDROID_HOME, or AAPT2_BIN." >&2
+    exit 1
+}
+
+get_single_running_emulator() {
+    local action_name="${1:-use}"
+    local running_serials
+    local running_count
+
+    running_serials="$(list_running_emulators)"
+    running_count="$(printf '%s\n' "${running_serials}" | awk 'NF { count++ } END { print count + 0 }')"
+
+    if [[ "${running_count}" -eq 0 ]]; then
+        echo "No running emulator found in adb devices." >&2
+        exit 1
+    fi
+
+    if [[ "${running_count}" -gt 1 ]]; then
+        echo "More than one running emulator found; refusing to guess which one to ${action_name}." >&2
+        printf 'Running emulators:\n%s\n' "${running_serials}" >&2
+        exit 1
+    fi
+
+    printf '%s\n' "${running_serials}"
+}
+
+get_apk_package_name() {
+    local apk_path="$1"
+    local package_name
+
+    require_aapt2_binary
+    if ! package_name="$("${AAPT2_BIN}" dump badging "${apk_path}" 2>/dev/null | awk -F"'" '/^package: name=/ { print $2; exit }')"; then
+        echo "Failed to read APK metadata from ${apk_path}" >&2
+        exit 1
+    fi
+    if [[ -z "${package_name}" ]]; then
+        echo "Failed to determine package name from ${apk_path}" >&2
+        exit 1
+    fi
+
+    printf '%s\n' "${package_name}"
+}
+
+install_and_run_apk() {
+    local adb_serial="$1"
+    local apk_path="$2"
+    local package_name
+
+    package_name="$(get_apk_package_name "${apk_path}")"
+
+    echo "Installing ${apk_path} on ${adb_serial}"
+    "${ADB_BIN}" -s "${adb_serial}" install -r "${apk_path}"
+
+    echo "Launching ${package_name}"
+    "${ADB_BIN}" -s "${adb_serial}" shell monkey -p "${package_name}" -c android.intent.category.LAUNCHER 1
 }
 
 find_emulator_binary() {
@@ -121,26 +294,10 @@ find_emulator_binary() {
 }
 
 stop_running_emulator() {
-    local running_serials
-    local running_count
     local adb_serial
     local deadline_epoch
 
-    running_serials="$(list_running_emulators)"
-    running_count="$(printf '%s\n' "${running_serials}" | awk 'NF { count++ } END { print count + 0 }')"
-
-    if [[ "${running_count}" -eq 0 ]]; then
-        echo "No running emulator found in adb devices." >&2
-        exit 1
-    fi
-
-    if [[ "${running_count}" -gt 1 ]]; then
-        echo "More than one running emulator found; refusing to guess which one to stop." >&2
-        printf 'Running emulators:\n%s\n' "${running_serials}" >&2
-        exit 1
-    fi
-
-    adb_serial="${running_serials}"
+    adb_serial="$(get_single_running_emulator "stop")"
     "${ADB_BIN}" -s "${adb_serial}" emu kill >/dev/null
 
     deadline_epoch="$(( $(date +%s) + TIMEOUT_SECONDS ))"
@@ -158,7 +315,16 @@ stop_running_emulator() {
 }
 
 if [[ "${STOP_EMULATOR}" == "1" ]]; then
+    require_adb_binary
     stop_running_emulator
+    exit 0
+fi
+
+if [[ -n "${RUN_APK}" && -z "${AVD_NAME}" ]]; then
+    require_adb_binary
+    ADB_SERIAL="$(get_single_running_emulator "use")"
+    install_and_run_apk "${ADB_SERIAL}" "${RUN_APK}"
+    echo "${ADB_SERIAL}"
     exit 0
 fi
 
@@ -207,11 +373,7 @@ if ! printf '%s\n' "${AVAILABLE_AVDS_TEXT}" | grep -Fxq -- "${AVD_NAME}"; then
     exit 1
 fi
 
-ADB_BIN="${ADB_BIN:-adb}"
-if ! command -v "${ADB_BIN}" >/dev/null 2>&1; then
-    echo "adb not found on PATH" >&2
-    exit 1
-fi
+require_adb_binary
 
 OUTPUT_DIR_ABS="${OUTPUT_DIR}"
 mkdir -p "${OUTPUT_DIR_ABS}"
@@ -265,6 +427,10 @@ if [[ -z "${ADB_SERIAL}" ]]; then
     echo "Emulator process started with PID ${EMULATOR_PID}. Log: ${LOG_PATH}" >&2
     echo "Timed out waiting for the emulator to appear in adb devices." >&2
     exit 1
+fi
+
+if [[ -n "${RUN_APK}" ]]; then
+    install_and_run_apk "${ADB_SERIAL}" "${RUN_APK}"
 fi
 
 echo "${ADB_SERIAL}"


### PR DESCRIPTION
In some cases (e.g. Android Emulator), the Android OpenGL device reports ASTC support, but the driver returns `GL_INVALID_ENUM` when creating the texture. We now disable the astc support if we can't create an astc texture during startup.

Fixes https://github.com/defold/defold/issues/12511

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
