### PR TITLE
Add `/ref` API endpoint to editor's HTTP server

### DIFF
--- a/editor/project.clj
+++ b/editor/project.clj
@@ -267,7 +267,8 @@
                                :jvm-opts ["-Djol.magicFieldOffset=true" "-XX:+EnableDynamicAgentLoading"]
                                :injections [(require 'editor.reveal)]
                                :dependencies [[vlaaad/reveal "1.3.312"]
-                                              [org.openjfx/javafx-web "25"]]}
+                                              [org.openjfx/javafx-web "25"]]
+                               :repl-options {:nrepl-middleware [vlaaad.reveal.nrepl/middleware]}}
                       :metrics {:jvm-opts ["-Ddefold.metrics=true"]}
                       :jamm {:dependencies [[com.github.jbellis/jamm "0.4.0"]]
                              :jvm-opts [~(str "-javaagent:" (pathname (local-maven-jar-file "com/github/jbellis/jamm/0.4.0/jamm-0.4.0.jar")))

--- a/editor/src/clj/editor/boot_open_project.clj
+++ b/editor/src/clj/editor/boot_open_project.clj
@@ -30,6 +30,7 @@
             [editor.defold-project :as project]
             [editor.dialogs :as dialogs]
             [editor.disk :as disk]
+            [editor.doc :as doc]
             [editor.editor-extensions :as extensions]
             [editor.editor-extensions.server :as ext.server]
             [editor.engine-profiler :as engine-profiler]
@@ -222,6 +223,7 @@
                                   (hot-reload/routes workspace)
                                   (bob/routes project)
                                   (command-requests/router root localization (app-view/make-render-task-progress :resource-sync))
+                                  (doc/routes)
                                   (http-server.prefs/routes prefs)]))
           server-port (:port cli-options)
           web-server (try

--- a/editor/src/clj/editor/doc.clj
+++ b/editor/src/clj/editor/doc.clj
@@ -1,0 +1,150 @@
+;; Copyright 2020-2026 The Defold Foundation
+;; Copyright 2014-2020 King
+;; Copyright 2009-2014 Ragnar Svensson, Christian Murray
+;; Licensed under the Defold License version 1.0 (the "License"); you may not use
+;; this file except in compliance with the License.
+;;
+;; You may obtain a copy of the License, together with FAQs at
+;; https://www.defold.com/license
+;;
+;; Unless required by applicable law or agreed to in writing, software distributed
+;; under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+;; CONDITIONS OF ANY KIND, either express or implied. See the License for the
+;; specific language governing permissions and limitations under the License.
+
+(ns editor.doc
+  (:require [clojure.string :as string]
+            [editor.fs :as fs]
+            [editor.protobuf :as protobuf]
+            [internal.java :as java]
+            [service.log :as log]
+            [util.coll :as coll]
+            [util.eduction :as e]
+            [util.fn :as fn]
+            [util.http-server :as http-server]
+            [util.text-util :as text-util])
+  (:import [com.dynamo.scriptdoc.proto ScriptDoc$Document]
+           [clojure.lang IReduceInit]
+           [java.io IOException]
+           [java.nio.charset MalformedInputException]
+           [java.util.regex Pattern]))
+
+(def ^:private ref-index
+  (delay
+    (->> "doc"
+         (fs/class-path-walker java/class-loader)
+         (e/mapcat
+           (fn [path]
+             (when-let [{:keys [info elements]}
+                        (try
+                          (protobuf/read-map-with-defaults ScriptDoc$Document path)
+                          (catch MalformedInputException _
+                            (log/warn :message "Ignoring legacy-format documentation file." :path (str path))
+                            nil)
+                          (catch IOException e
+                            (log/error :message "Failed to read documentation file." :path (str path) :exception e)
+                            nil))]
+               (e/map (fn [element]
+                        (-> element
+                            (assoc :environment (if (= "editor" (:namespace info)) :editor :runtime))
+                            (cond-> (string/blank? (:language element)) (assoc :language (:language info)))))
+                      elements))))
+         vec
+         (sort-by :name)
+         vec)))
+
+(defn- all-matches [^Pattern re s]
+  (reify IReduceInit
+    (reduce [_ rf init]
+      (let [matcher (re-matcher re s)]
+        (loop [result init]
+          (if (.find matcher)
+            (let [result (rf result (.group matcher))]
+              (if (reduced? result)
+                (unreduced result)
+                (recur result)))
+            result))))))
+
+(defn- combine-preds [combine-fn preds]
+  (case (count preds)
+    0 fn/constantly-true
+    1 (first preds)
+    (apply combine-fn preds)))
+
+(defn- query-string->element-predicate [query]
+  (let [{:keys [environment language q]}
+        (into {}
+              (map
+                (fn [s]
+                  (let [[k v] (string/split s #"=" 2)]
+                    (coll/pair (keyword k) (or v "")))))
+              (string/split query #"&"))
+
+        environment-pred
+        (when environment
+          (let [value-preds
+                (mapv (fn [environment]
+                        (let [environment (keyword environment)]
+                          (fn environment-value-pred [element]
+                            (= environment (:environment element)))))
+                      (all-matches #"[^,\s]+" environment))]
+            (combine-preds some-fn value-preds)))
+
+        language-pred
+        (when language
+          (let [value-preds
+                (mapv (fn [language]
+                        (fn language-value-pred [element]
+                          (= language (:language element))))
+                      (all-matches #"[^,\s]+" language))]
+            (combine-preds some-fn value-preds)))
+
+        q-pred
+        (when q
+          (let [alternative-preds
+                (into []
+                      (keep
+                        (fn [alternative]
+                          (let [term-preds
+                                (mapv (fn [term]
+                                        (fn q-term-pred [element]
+                                          (coll/any?
+                                            #(text-util/includes-ignore-case? % term)
+                                            [(:name element)
+                                             (:brief element)
+                                             (:description element)])))
+                                      (all-matches #"\S+" alternative))]
+                            (when-not (zero? (count term-preds))
+                              (combine-preds every-pred term-preds)))))
+                      (string/split q #"\|"))]
+            (combine-preds some-fn alternative-preds)))]
+    (combine-preds
+      every-pred
+      (cond-> []
+        environment-pred (conj environment-pred)
+        language-pred (conj language-pred)
+        q-pred (conj q-pred)))))
+
+(defn- get-ref
+  {:openapi
+   {:summary "Runtime and editor API reference"
+    :parameters [{:name "environment"
+                  :in "query"
+                  :description "`editor` or `runtime`, comma-separated."
+                  :schema {:type "string"}}
+                 {:name "language"
+                  :in "query"
+                  :description "`Lua`, `C`, or `C++`, comma-separated."
+                  :schema {:type "string"}}
+                 {:name "q"
+                  :in "query"
+                  :description "Case-insensitive search; `|` is OR, whitespace is AND."
+                  :schema {:type "string"}}]
+    :responses {"200" {:description "Array of script doc elements."
+                       :content {"application/json" {}}}}}}
+  [request]
+  (http-server/json-response
+    (filterv (query-string->element-predicate (:query request "")) @ref-index)))
+
+(defn routes []
+  {"/ref" {"GET" #'get-ref}})

--- a/editor/test/integration/web_server_test.clj
+++ b/editor/test/integration/web_server_test.clj
@@ -22,6 +22,7 @@
             [editor.code.view :as view]
             [editor.command-requests :as command-requests]
             [editor.console :as console]
+            [editor.doc :as doc]
             [editor.engine-profiler :as engine-profiler]
             [editor.fs :as fs]
             [editor.handler :as handler]
@@ -295,7 +296,8 @@
                                              (console/routes console-view)
                                              (hot-reload/routes workspace)
                                              (bob/routes project)
-                                             (command-requests/router root test-util/localization progress/null-render-progress!)])))]
+                                             (command-requests/router root test-util/localization progress/null-render-progress!)
+                                             (doc/routes)])))]
           (let [url (http-server/local-url server)]
             (let [{:keys [status headers body]} @(http/request (str url "/") :as :string)]
               (is (= 200 status))
@@ -311,10 +313,48 @@
                        (get-in json-body ["components" "securitySchemes" "token" "description"])))
                 (is (contains? (get json-body "paths") "/console"))
                 (is (contains? (get json-body "paths") "/console/stream"))
+                (let [get-ref (get-in json-body ["paths" "/ref" "get"])
+                      param-names (into #{} (map #(get % "name")) (get get-ref "parameters"))]
+                  (is get-ref)
+                  (is (every? param-names ["environment" "language" "q"])))
                 (let [post-command (get-in json-body ["paths" "/command/{command}" "post"])]
                   (is (= "Execute an editor command" (get post-command "summary")))
                   (is (string/includes? (get post-command "description") "`build-html5`"))
                   (is (some #{"build-html5"} (get-in post-command ["parameters" 0 "schema" "enum"]))))))
+            (let [{:keys [status headers body]} @(http/request (str url "/ref?environment=runtime&language=Lua&q=go.property") :as :string)
+                  json-body (json/read-str body :key-fn keyword)]
+              (is (= 200 status))
+              (is (= "application/json" (get headers "content-type")))
+              (is (not (coll/empty? json-body)))
+              (is (every? #(= "runtime" (:environment %)) json-body))
+              (is (every? #(= "Lua" (:language %)) json-body))
+              (is (coll/any? #(= "go.property" (:name %)) json-body)))
+            (let [{:keys [status headers body]} @(http/request (str url "/ref?environment=editor&q=editor.prefs.get") :as :string)
+                  json-body (json/read-str body :key-fn keyword)]
+              (is (= 200 status))
+              (is (= "application/json" (get headers "content-type")))
+              (is (not (coll/empty? json-body)))
+              (is (every? #(= "editor" (:environment %)) json-body))
+              (is (coll/any? #(= "editor.prefs.get" (:name %)) json-body)))
+            (let [{:keys [status body]} @(http/request (str url "/ref?q=game%20object") :as :string)
+                  json-body (json/read-str body :key-fn keyword)]
+              (is (= 200 status))
+              (is (not (coll/empty? json-body))))
+            (let [{:keys [status body]} @(http/request (str url "/ref?q=go.property%7Ceditor.prefs.get") :as :string)
+                  json-body (json/read-str body :key-fn keyword)]
+              (is (= 200 status))
+              (is (coll/any? #(= "go.property" (:name %)) json-body))
+              (is (coll/any? #(= "editor.prefs.get" (:name %)) json-body)))
+            (let [{:keys [status body]} @(http/request (str url "/ref?environment=editor,runtime&language=Lua,C%2B%2B&q=property") :as :string)
+                  json-body (json/read-str body :key-fn keyword)]
+              (is (= 200 status))
+              (is (coll/any? #(= "editor" (:environment %)) json-body))
+              (is (coll/any? #(= "runtime" (:environment %)) json-body))
+              (is (coll/any? #(= "Lua" (:language %)) json-body))
+              (is (coll/any? #(= "C++" (:language %)) json-body))
+              (is (every? (fn [element]
+                            (#{"Lua" "C++"} (:language element)))
+                          json-body)))
             (let [{:keys [status headers body]} @(http/request (str url "/engine-profiler/") :as :string)]
               (is (= 200 status))
               (is (= "text/html" (get headers "content-type")))


### PR DESCRIPTION
We added an API reference endpoint so coding agents or third-party tools can query docs from the running editor:
```sh
curl -s "http://localhost:$(cat .internal/editor.port)/ref?q=go.animate" \
  | jq '.[0] | {name, type, brief}'
{
  "name": "go.animate",
  "type": "function",
  "brief": "animates a named property of the specified game object or component"
}
```

Fix #11994
