### PR TITLE
Build content in engine based on which adapters are being linked

### DIFF
--- a/engine/engine/CMakeLists.txt
+++ b/engine/engine/CMakeLists.txt
@@ -107,6 +107,23 @@ set(ENGINE_BUILTINS_WORK_ROOT "${CMAKE_CURRENT_BINARY_DIR}/content-work")
 set(ENGINE_BUILTINS_OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}/content")
 set(ENGINE_BUILTINS_COMPILED_DIR "${ENGINE_BUILTINS_WORK_ROOT}/build/default/builtins")
 set(ENGINE_BUILTINS_STAMP "${CMAKE_CURRENT_BINARY_DIR}/content/builtins.stamp")
+defold_get_graphics_symbols(ENGINE_GRAPHICS_SYMBOLS "${TARGET_PLATFORM}")
+set(ENGINE_SHADER_OUTPUT_ARGS)
+if("GraphicsAdapterOpenGL" IN_LIST ENGINE_GRAPHICS_SYMBOLS OR "GraphicsAdapterOpenGLES" IN_LIST ENGINE_GRAPHICS_SYMBOLS)
+  list(APPEND ENGINE_SHADER_OUTPUT_ARGS --shader-output glsl)
+endif()
+if("GraphicsAdapterVulkan" IN_LIST ENGINE_GRAPHICS_SYMBOLS)
+  list(APPEND ENGINE_SHADER_OUTPUT_ARGS --shader-output spirv)
+endif()
+if("GraphicsAdapterWebGPU" IN_LIST ENGINE_GRAPHICS_SYMBOLS)
+  list(APPEND ENGINE_SHADER_OUTPUT_ARGS --shader-output wgsl)
+endif()
+if("GraphicsAdapterDX12" IN_LIST ENGINE_GRAPHICS_SYMBOLS)
+  list(APPEND ENGINE_SHADER_OUTPUT_ARGS --shader-output hlsl)
+endif()
+if("GraphicsAdapterMetal" IN_LIST ENGINE_GRAPHICS_SYMBOLS)
+  list(APPEND ENGINE_SHADER_OUTPUT_ARGS --shader-output msl)
+endif()
 add_custom_command(
   OUTPUT
     "${ENGINE_BUILTINS_OUTPUT_DIR}/builtins.arci"
@@ -120,6 +137,7 @@ add_custom_command(
     --stamp "${ENGINE_BUILTINS_STAMP}"
     --bob-light "${ENGINE_BOB_LIGHT}"
     --platform "${TARGET_PLATFORM}"
+    ${ENGINE_SHADER_OUTPUT_ARGS}
     --java "${Java_JAVA_EXECUTABLE}"
   DEPENDS "${ENGINE_CMAKE_CONTENT_SCRIPT}" "${ENGINE_BOB_LIGHT}" ${ENGINE_CONTENT_SOURCES}
   COMMENT "Building engine builtin archive"
@@ -339,7 +357,6 @@ endif()
 if(WITH_OPUS)
   list(APPEND ENGINE_EXPORTED_SYMBOLS AudioDecoderOpus)
 endif()
-defold_get_graphics_symbols(ENGINE_GRAPHICS_SYMBOLS "${TARGET_PLATFORM}")
 list(APPEND ENGINE_EXPORTED_SYMBOLS ${ENGINE_GRAPHICS_SYMBOLS})
 
 set(ENGINE_PROFILE_LIBS profile profilerext)

--- a/engine/engine/scripts/build_cmake_content.py
+++ b/engine/engine/scripts/build_cmake_content.py
@@ -168,6 +168,10 @@ def build_builtins(args):
         args.platform,
         "--variant=debug",
         "--use-vanilla-lua",
+    ]
+    for shader_output in args.shader_output:
+        java_cmd.append("--debug-output-%s=true" % shader_output)
+    java_cmd += [
         "--build-input-file",
         build_inputs.name,
         "clean",
@@ -231,6 +235,7 @@ def main():
     builtins.add_argument("--stamp", required=True)
     builtins.add_argument("--bob-light", required=True)
     builtins.add_argument("--platform", required=True)
+    builtins.add_argument("--shader-output", action="append", default=[])
     builtins.add_argument("--java", required=True)
     builtins.set_defaults(func=build_builtins)
 


### PR DESCRIPTION
#### Technical changes

When building the builtin files that we embed into the engine, we now take the list of optional graphics adapters into account so we can generate the correct content accordingly. This is only needed for the content that is being embedded by the build system into the engine. 