### PR TITLE
Show notification with a Restart suggestion on dll unpack failure

### DIFF
--- a/editor/resources/localization/en.editor_localization
+++ b/editor/resources/localization/en.editor_localization
@@ -367,7 +367,7 @@ notification.reload-editor-scripts.action.reload = Reload Editor Scripts
 
 # Reload plugins notification
 
-notification.reload-plugins-failed = Native extension plugins could not be reloaded. Restart Defold to reload them. If this project is open in another Defold editor, close that editor first.\n\nFile: {file}\n\nUnderlying error from the OS:\n{error}
+notification.reload-plugins-failed = Native extension plugins could not be reloaded. Restart Defold to reload them.\n\nFile: {file}\n\nUnderlying error from the OS:\n{error}
 notification.reload-plugins-failed.action.restart = Restart Defold
 
 # Open custom editor notifications

--- a/editor/resources/localization/en.editor_localization
+++ b/editor/resources/localization/en.editor_localization
@@ -269,6 +269,13 @@ dialog.quit-defold.header = Unsaved changes exist, are you sure you want to quit
 dialog.quit-defold.button.cancel = Cancel and Keep Working
 dialog.quit-defold.button.quit = Quit Without Saving
 
+# Restart Defold dialog
+
+dialog.restart-defold.title = Restart Defold?
+dialog.restart-defold.header = Unsaved changes exist. Save changes before restarting Defold?
+dialog.restart-defold.button.cancel = Cancel
+dialog.restart-defold.button.save-and-restart = Save and Restart
+
 # Save and upgrade file formats dialogs
 
 dialog.save-and-upgrade.title.not-safe = Not Safe to Upgrade File Formats
@@ -357,6 +364,11 @@ notification.fetch-libraries.dependency-problem = {uri}: {problem}
 
 notification.reload-editor-scripts = Editor scripts have changed. Do you want to reload them now?
 notification.reload-editor-scripts.action.reload = Reload Editor Scripts
+
+# Reload plugins notification
+
+notification.reload-plugins-failed = Native extension plugins could not be reloaded. Restart Defold to reload them. If this project is open in another Defold editor, close that editor first.\n\nFile: {file}\n\nUnderlying error from the OS:\n{error}
+notification.reload-plugins-failed.action.restart = Restart Defold
 
 # Open custom editor notifications
 

--- a/editor/resources/localization/ru.editor_localization
+++ b/editor/resources/localization/ru.editor_localization
@@ -269,6 +269,13 @@ dialog.quit-defold.header = Есть несохранённые изменени
 dialog.quit-defold.button.cancel = Отменить и продолжить работу
 dialog.quit-defold.button.quit = Выйти без сохранения
 
+# Restart Defold dialog
+
+dialog.restart-defold.title = Перезапустить Defold?
+dialog.restart-defold.header = Есть несохранённые изменения. Сохранить изменения перед перезапуском Defold?
+dialog.restart-defold.button.cancel = Отмена
+dialog.restart-defold.button.save-and-restart = Сохранить и перезапустить
+
 # Save and upgrade file formats dialogs
 
 dialog.save-and-upgrade.title.not-safe = Небезопасно обновлять форматы файлов
@@ -357,6 +364,11 @@ notification.fetch-libraries.dependency-problem = {uri}\: {problem}
 
 notification.reload-editor-scripts = Скрипты редактора изменились. Перезагрузить их сейчас?
 notification.reload-editor-scripts.action.reload = Перезагрузить скрипты редактора
+
+# Reload plugins notification
+
+notification.reload-plugins-failed = Не удалось перезагрузить нативные плагины расширений. Перезапустите Defold, чтобы загрузить их заново. Если этот проект открыт в другом редакторе Defold, сначала закройте тот редактор.\n\nФайл\: {file}\n\nИсходная ошибка ОС\:\n{error}
+notification.reload-plugins-failed.action.restart = Перезапустить Defold
 
 # Open custom editor notifications
 

--- a/editor/resources/localization/ru.editor_localization
+++ b/editor/resources/localization/ru.editor_localization
@@ -367,7 +367,7 @@ notification.reload-editor-scripts.action.reload = Перезагрузить с
 
 # Reload plugins notification
 
-notification.reload-plugins-failed = Не удалось перезагрузить нативные плагины расширений. Перезапустите Defold, чтобы загрузить их заново. Если этот проект открыт в другом редакторе Defold, сначала закройте тот редактор.\n\nФайл\: {file}\n\nИсходная ошибка ОС\:\n{error}
+notification.reload-plugins-failed = Не удалось перезагрузить нативные плагины расширений. Перезапустите Defold, чтобы загрузить их заново.\n\nФайл\: {file}\n\nИсходная ошибка ОС\:\n{error}
 notification.reload-plugins-failed.action.restart = Перезапустить Defold
 
 # Open custom editor notifications

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -102,6 +102,7 @@
            [com.dynamo.bob Platform]
            [com.sun.javafx.scene NodeHelper]
            [java.io File IOException PipedInputStream PipedOutputStream]
+           [java.lang.management ManagementFactory]
            [java.net SocketTimeoutException URL]
            [java.time LocalTime]
            [java.time.format DateTimeFormatter]
@@ -626,6 +627,23 @@
     (let [^Stage main-stage (ui/main-stage)]
       (.fireEvent main-stage (WindowEvent. main-stage WindowEvent/WINDOW_CLOSE_REQUEST)))))
 
+(defn- start-launcher! []
+  (if (system/defold-dev?)
+    (apply process/start!
+           {:dir (System/getProperty "user.dir")
+            :out :inherit
+            :err :inherit}
+           (str (io/file (System/getProperty "java.home") "bin" (if (os/is-win32?) "java.exe" "java")))
+           (into (vec (.getInputArguments (ManagementFactory/getRuntimeMXBean)))
+                 ["-cp" (System/getProperty "java.class.path") "com.defold.editor.Main"]))
+    (let [resources-path (system/defold-resourcespath)]
+      (process/start!
+        {:dir (.getCanonicalFile
+                (case (.getOs (Platform/getHostPlatform))
+                  "macos" (io/file resources-path "../../")
+                  ("linux" "win32") (io/file resources-path)))}
+        (system/defold-launcherpath)))))
+
 (defn store-window-dimensions [^Stage stage prefs]
   (let [dims    {:x           (.getX stage)
                  :y           (.getY stage)
@@ -699,6 +717,12 @@
                            (remove (partial pane-visible? scene))
                            (keys split-info-by-pane-kw))]
     (prefs/set! prefs prefs-hidden-panes hidden-panes)))
+
+(defn store-window-state! [^Stage stage prefs]
+  (let [scene (.getScene stage)]
+    (store-window-dimensions stage prefs)
+    (store-split-positions! scene prefs)
+    (store-hidden-panes! scene prefs)))
 
 (defn restore-hidden-panes! [^Scene scene prefs]
   (let [hidden-panes (stored-hidden-panes prefs)]
@@ -1870,13 +1894,7 @@
   (run [] (ui/reload-root-styles!)))
 
 (handler/defhandler :file.open-project :global
-  (active? [] (and (system/defold-resourcespath) (system/defold-launcherpath)))
-  (run [] (let [resources-path (system/defold-resourcespath)
-                install-dir (.getCanonicalFile
-                              (case (.getOs (Platform/getHostPlatform))
-                                "macos" (io/file resources-path "../../")
-                                ("linux" "win32") (io/file resources-path)))]
-            (process/start! {:dir install-dir} (system/defold-launcherpath)))))
+  (run [] (start-launcher!)))
 
 (handler/register-menu! ::menubar
   [{:label (localization/message "menu.file")
@@ -2722,6 +2740,34 @@
                            (ui/user-data! (g/node-value app-view :scene) ::ui/refresh-requested? true))
                          (when callback!
                            (callback! successful? render-reload-progress! render-save-progress!)))))))
+
+(defn- restart-defold! [^Stage stage prefs]
+  (store-window-state! stage prefs)
+  (ui/close! stage)
+  (start-launcher!))
+
+(handler/defhandler :app.restart :global
+  (run [app-view changes-view project prefs localization]
+    (let [^Stage stage (ui/main-stage)
+          dirty-save-data (project/dirty-save-data project)]
+      (if (coll/empty? dirty-save-data)
+        (restart-defold! stage prefs)
+        (when (dialogs/make-confirmation-dialog
+                localization
+                {:title (localization/message "dialog.restart-defold.title")
+                 :icon :icon/circle-question
+                 :size :large
+                 :header (localization/message "dialog.restart-defold.header")
+                 :buttons [{:text (localization/message "dialog.restart-defold.button.cancel")
+                            :cancel-button true
+                            :result false}
+                           {:text (localization/message "dialog.restart-defold.button.save-and-restart")
+                            :default-button true
+                            :result true}]})
+          (async-save! app-view changes-view project project/dirty-save-data
+                       (fn [successful? _render-reload-progress! _render-save-progress!]
+                         (when successful?
+                           (restart-defold! stage prefs)))))))))
 
 (defn- make-version-control-info-dialog-content
   ([localization]

--- a/editor/src/clj/editor/boot_open_project.clj
+++ b/editor/src/clj/editor/boot_open_project.clj
@@ -109,12 +109,6 @@
   (app-view/remove-invalid-tabs! tab-panes open-views)
   (changes-view/refresh! changes-view))
 
-(defn- persist-window-state!
-  [^Stage stage ^Scene scene prefs]
-  (app-view/store-window-dimensions stage prefs)
-  (app-view/store-split-positions! scene prefs)
-  (app-view/store-hidden-panes! scene prefs))
-
 (defn- init-pending-update-indicator! [^Stage stage link project changes-view updater localization]
   (let [render-reload-progress! (app-view/make-render-task-progress :resource-sync)
         render-save-progress! (app-view/make-render-task-progress :save-all)
@@ -318,7 +312,7 @@
                                         (fn [successful?]
                                           (if successful?
                                             (do
-                                              (persist-window-state! stage scene prefs)
+                                              (app-view/store-window-state! stage prefs)
                                               (ui/close! stage))
                                             (ui/enable-ui!)))))
                                     false)
@@ -337,7 +331,7 @@
                                                                  :variant :danger
                                                                  :result true}]}))]
                                     (when result
-                                      (persist-window-state! stage scene prefs))
+                                      (app-view/store-window-state! stage prefs))
                                     result)))))
 
       (ui/on-closed! stage (fn [_]

--- a/editor/src/clj/editor/workspace.clj
+++ b/editor/src/clj/editor/workspace.clj
@@ -44,7 +44,7 @@ ordinary paths."
            [com.dynamo.bob Platform]
            [com.dynamo.bob.util Library$Problem$DefoldMinVersion Library$Problem$FailedHTTPRequest Library$Problem$FetchFailed Library$Problem$HttpConnectTimeout Library$Problem$InstallFailed Library$Problem$InvalidArchive Library$Problem$Missing Library$Result]
            [editor.resource FileResource]
-           [java.io File FileNotFoundException IOException PushbackReader]
+           [java.io File FileNotFoundException PushbackReader]
            [org.apache.commons.io FilenameUtils]))
 
 (set! *warn-on-reflection* true)
@@ -110,12 +110,12 @@ ordinary paths."
 
 (defrecord BuildResource [resource prefix]
   resource/Resource
-  (children [this] nil)
+  (children [_] nil)
   (ext [this] (:build-ext (resource/resource-type this) "unknown"))
-  (resource-type [this] (resource/resource-type resource))
-  (source-type [this] (resource/source-type resource))
-  (read-only? [this] false)
-  (symlink? [this] false)
+  (resource-type [_] (resource/resource-type resource))
+  (source-type [_] (resource/source-type resource))
+  (read-only? [_] false)
+  (symlink? [_] false)
   (path [this] (let [ext (resource/ext this)
                      ext (if (not-empty ext) (str "." ext) "")]
                  (if-let [path (resource/path resource)]
@@ -124,12 +124,12 @@ ordinary paths."
                      (str prefix "_generated_" suffix ext)))))
   (abs-path [this] (.getAbsolutePath (io/file (build-path (resource/workspace this)) (resource/path this))))
   (proj-path [this] (str "/" (resource/path this)))
-  (resource-name [this] (resource/resource-name resource))
-  (workspace [this] (resource/workspace resource))
-  (resource-hash [this] (resource/resource-hash resource))
-  (openable? [this] false)
-  (editable? [this] false)
-  (loaded? [this] false)
+  (resource-name [_] (resource/resource-name resource))
+  (workspace [_] (resource/workspace resource))
+  (resource-hash [_] (resource/resource-hash resource))
+  (openable? [_] false)
+  (editable? [_] false)
+  (loaded? [_] false)
 
   io/IOFactory
   (make-input-stream [this opts] (io/make-input-stream (File. (resource/abs-path this)) opts))
@@ -681,9 +681,9 @@ ordinary paths."
   ([workspace resource]
    (unpack-resource! workspace nil resource))
   ([workspace infix-path resource]
-   (try
-     (let [resource-path (str infix-path (resource/proj-path resource))
-           target-file (plugin-path workspace resource-path)]
+   (let [resource-path (str infix-path (resource/proj-path resource))
+         target-file (plugin-path workspace resource-path)]
+     (try
        (fs/create-parent-directories! target-file)
        (with-open [is (io/input-stream resource)]
          (io/copy is target-file))
@@ -692,9 +692,23 @@ ordinary paths."
        (when (jar-file? resource)
          (register-jar-file! target-file))
        (when (shared-library? resource)
-         (register-shared-library-file! target-file)))
-     (catch FileNotFoundException e
-       (throw (IOException. "\nExtension plugins needs updating.\nPlease restart editor for these changes to take effect!" e))))))
+         (register-shared-library-file! target-file))
+       true
+       (catch FileNotFoundException e
+         (notifications/show!
+           (notifications workspace)
+           {:id ::reload-plugins-failed
+            :type :warning
+            :message (localization/message
+                       "notification.reload-plugins-failed"
+                       {"file" (str target-file)
+                        "error" (.getMessage e)})
+            :actions [{:message (localization/message "notification.reload-plugins-failed.action.restart")
+                       :on-action #(ui/execute-command
+                                     (ui/contexts (ui/main-scene) true)
+                                     :app.restart
+                                     nil)}]})
+         false)))))
 
 (defn- delete-directory-recursive [^File file]
   ;; Recursively delete a directory. // https://gist.github.com/olieidel/c551a911a4798312e4ef42a584677397
@@ -713,7 +727,7 @@ ordinary paths."
 (defn clean-editor-plugins! [workspace]
   ; At startup, we want to remove the plugins in order to avoid having issues copying the .dll on Windows
   (let [dir (plugin-path workspace)]
-    (if (.exists dir)
+    (when (.exists dir)
       (delete-directory-recursive dir))))
 
 (def ^:private plugin-zip-names
@@ -731,15 +745,15 @@ ordinary paths."
 
 (defn- unpack-plugin-zip! [workspace resource]
   {:pre [(string/ends-with? (resource/proj-path resource) ".zip")]}
-  (unpack-resource! workspace resource)
-  (let [proj-path (resource/proj-path resource)
-        plugin-file (plugin-path workspace proj-path)
-        infix-path (resource/parent-proj-path proj-path)]
-    (run! #(unpack-resource! workspace infix-path %)
-          (eduction
-            (mapcat resource/resource-seq)
-            (filter #(= :file (resource/source-type %)))
-            (:tree (resource/load-zip-resources workspace plugin-file))))))
+  (when (unpack-resource! workspace resource)
+    (let [proj-path (resource/proj-path resource)
+          plugin-file (plugin-path workspace proj-path)
+          infix-path (resource/parent-proj-path proj-path)]
+      (run! #(unpack-resource! workspace infix-path %)
+            (eduction
+              (mapcat resource/resource-seq)
+              (filter #(= :file (resource/source-type %)))
+              (:tree (resource/load-zip-resources workspace plugin-file)))))))
 
 (defn unpack-editor-plugins! [basis workspace changed]
   ;; Used for unpacking the .jar files and shared libraries (.so, .dylib, .dll).


### PR DESCRIPTION
The editor will now show a notification suggesting to restart the editor if a dll failed to unpack from an extension (due to a file lock or similar).

Fix #12329