### PR TITLE
Fix `go.world_to_local_position` and `go.world_to_local_transform`

### DIFF
--- a/engine/gameobject/src/gameobject/gameobject_script.cpp
+++ b/engine/gameobject/src/gameobject/gameobject_script.cpp
@@ -2153,11 +2153,10 @@ namespace dmGameObject
         DM_LUA_STACK_CHECK(L, 1);
         dmVMath::Vector3* world_position = dmScript::CheckVector3(L, 1);
         Instance* instance = ResolveInstance(L, 2);
-        dmVMath::Matrix4 go_transform = dmGameObject::GetWorldMatrix(instance);
-        dmVMath::Matrix4 world_transform = dmVMath::Matrix4::identity();
-        world_transform.setTranslation(*world_position);
-        dmVMath::Matrix4 result_transfrom = world_transform * go_transform;
-        dmScript::PushVector3(L, result_transfrom.getTranslation());
+        dmVMath::Matrix4 go_world_transform = dmGameObject::GetWorldMatrix(instance);
+        dmVMath::Matrix4 inv_transform = dmVMath::Inverse(go_world_transform);
+        dmVMath::Vector4 local_position = inv_transform * dmVMath::Vector4(*world_position, 1.0f);
+        dmScript::PushVector3(L, local_position.getXYZ());
         return 1;
     }
 
@@ -2184,9 +2183,9 @@ namespace dmGameObject
         DM_LUA_STACK_CHECK(L, 1);
         dmVMath::Matrix4* world_transform = dmScript::CheckMatrix4(L, 1);
         Instance* instance = ResolveInstance(L, 2);
-        const dmVMath::Matrix4& go_transform = dmGameObject::GetWorldMatrix(instance);
+        dmVMath::Matrix4 inv_transform = dmVMath::Inverse(dmGameObject::GetWorldMatrix(instance));
 
-        dmScript::PushMatrix4(L,  *world_transform * go_transform);
+        dmScript::PushMatrix4(L, inv_transform * *world_transform);
         return 1;
     }
 

--- a/engine/gameobject/src/gameobject/test/script/build.inputs
+++ b/engine/gameobject/src/gameobject/test/script/build.inputs
@@ -38,3 +38,7 @@ url.go
 url.script
 url_nil_id.go
 url_nil_id.script
+world_to_local_pos.go
+world_to_local_pos.script
+world_to_local_transform.go
+world_to_local_transform.script

--- a/engine/gameobject/src/gameobject/test/script/test_gameobject_script.cpp
+++ b/engine/gameobject/src/gameobject/test/script/test_gameobject_script.cpp
@@ -682,3 +682,169 @@ TEST_F(ScriptTest, TestExists)
 
     ASSERT_TRUE(dmGameObject::Init(m_Collection));
 }
+
+static void RunWorldToLocalPositionTest(
+    ScriptTest* t,
+    const Matrix4& target_world,
+    const Vector3& world_input,
+    const Vector3& expected_local)
+{
+    lua_State* L = dmScript::GetLuaState(t->m_ScriptContext);
+
+    dmScript::PushVector3(L, world_input);
+    lua_setglobal(L, "WORLD_POS_INPUT");
+    lua_pushnumber(L, expected_local.getX()); lua_setglobal(L, "EXPECTED_X");
+    lua_pushnumber(L, expected_local.getY()); lua_setglobal(L, "EXPECTED_Y");
+    lua_pushnumber(L, expected_local.getZ()); lua_setglobal(L, "EXPECTED_Z");
+
+    dmGameObject::HInstance tester = dmGameObject::New(t->m_Collection, "/world_to_local_pos.goc");
+    ASSERT_NE((dmGameObject::HInstance)0, tester);
+
+    dmGameObject::HInstance target = dmGameObject::New(t->m_Collection, "/null.goc");
+    ASSERT_NE((dmGameObject::HInstance)0, target);
+    ASSERT_EQ(dmGameObject::RESULT_OK, dmGameObject::SetIdentifier(t->m_Collection, target, "target"));
+
+    ASSERT_TRUE(dmGameObject::Init(t->m_Collection));
+
+    t->m_Collection->m_Collection->m_WorldTransforms[target->m_Index] = target_world;
+
+    ASSERT_TRUE(dmGameObject::Update(t->m_Collection, &t->m_UpdateContext));
+
+    ASSERT_TRUE(dmGameObject::Final(t->m_Collection));
+    dmGameObject::Delete(t->m_Collection, tester, false);
+    dmGameObject::Delete(t->m_Collection, target, false);
+}
+
+// World point coincides with the target origin: local result must be (0,0,0).
+TEST_F(ScriptTest, WorldToLocalPosition_PointAtTargetOrigin)
+{
+    Vector3 target_pos(10.0f, 5.0f, -3.0f);
+    RunWorldToLocalPositionTest(this,
+        Matrix4::translation(target_pos),
+        target_pos,         // world_input == target world origin
+        Vector3(0, 0, 0));  // expected local
+}
+
+// World point offset from target along X: local result must reflect that pure offset.
+TEST_F(ScriptTest, WorldToLocalPosition_OffsetAlongX)
+{
+    Vector3 target_pos(10.0f, 0.0f, 0.0f);
+    Vector3 world_input(25.0f, 0.0f, 0.0f);
+    RunWorldToLocalPositionTest(this,
+        Matrix4::translation(target_pos),
+        world_input,
+        Vector3(15.0f, 0.0f, 0.0f)); // 25 - 10 = 15 in local X
+}
+
+static void RunWorldToLocalTransformTest(
+    ScriptTest* t,
+    const Matrix4& target_world,
+    const Matrix4& world_input,
+    const Vector3& expected_local_translation)
+{
+    lua_State* L = dmScript::GetLuaState(t->m_ScriptContext);
+
+    dmScript::PushMatrix4(L, world_input);
+    lua_setglobal(L, "WORLD_TRANSFORM_INPUT");
+    lua_pushnumber(L, expected_local_translation.getX()); lua_setglobal(L, "EXPECTED_TX");
+    lua_pushnumber(L, expected_local_translation.getY()); lua_setglobal(L, "EXPECTED_TY");
+    lua_pushnumber(L, expected_local_translation.getZ()); lua_setglobal(L, "EXPECTED_TZ");
+
+    dmGameObject::HInstance tester = dmGameObject::New(t->m_Collection, "/world_to_local_transform.goc");
+    ASSERT_NE((dmGameObject::HInstance)0, tester);
+
+    dmGameObject::HInstance target = dmGameObject::New(t->m_Collection, "/null.goc");
+    ASSERT_NE((dmGameObject::HInstance)0, target);
+    ASSERT_EQ(dmGameObject::RESULT_OK, dmGameObject::SetIdentifier(t->m_Collection, target, "target"));
+
+    ASSERT_TRUE(dmGameObject::Init(t->m_Collection));
+
+    t->m_Collection->m_Collection->m_WorldTransforms[target->m_Index] = target_world;
+
+    ASSERT_TRUE(dmGameObject::Update(t->m_Collection, &t->m_UpdateContext));
+
+    ASSERT_TRUE(dmGameObject::Final(t->m_Collection));
+    dmGameObject::Delete(t->m_Collection, tester, false);
+    dmGameObject::Delete(t->m_Collection, target, false);
+}
+
+// Input transform at same position as target: local translation must be (0,0,0).
+TEST_F(ScriptTest, WorldToLocalTransform_IdentityRelativeTransform)
+{
+    Vector3 pos(10.0f, 5.0f, -3.0f);
+    RunWorldToLocalTransformTest(this,
+        Matrix4::translation(pos),
+        Matrix4::translation(pos),
+        Vector3(0.0f, 0.0f, 0.0f));
+}
+
+// Input transform offset from target along X: local translation must reflect that offset.
+TEST_F(ScriptTest, WorldToLocalTransform_OffsetAlongX)
+{
+    Vector3 target_pos(10.0f, 0.0f, 0.0f);
+    Vector3 input_pos(25.0f, 0.0f, 0.0f);
+    RunWorldToLocalTransformTest(this,
+        Matrix4::translation(target_pos),
+        Matrix4::translation(input_pos),
+        Vector3(15.0f, 0.0f, 0.0f)); // 25 - 10 = 15 in local X
+}
+
+// --- Tests derived from forum report ---
+// https://forum.defold.com/t/trouble-with-go-world-to-local-position-seems-to-be-adding-positions-together/80333
+//
+// The old broken implementation multiplied world_transform * go_transform (forward),
+// which effectively *added* positions instead of subtracting them.
+// e.g. click at (268.5, 264.5), object at (250, 250) → got (518.5, 514.5) instead of (18.5, 14.5).
+
+// Reproduces the exact numbers from the first forum reporter.
+// Object at (250, 250), click at (268.5, 264.5) → local offset must be (18.5, 14.5), not the sum (518.5, 514.5).
+TEST_F(ScriptTest, WorldToLocalPosition_ForumReport_ClickOffset)
+{
+    RunWorldToLocalPositionTest(this,
+        Matrix4::translation(Vector3(250.0f, 250.0f, 0.0f)),
+        Vector3(268.5f, 264.5f, 0.0f),
+        Vector3(18.5f, 14.5f, 0.0f));
+}
+
+// Reproduces the second reporter's case: object's own world position → local must be (0,0,0), not (2,0,0).
+TEST_F(ScriptTest, WorldToLocalPosition_ForumReport_OwnPositionIsZero)
+{
+    Vector3 obj_world_pos(2.0f, 0.0f, 0.0f);
+    RunWorldToLocalPositionTest(this,
+        Matrix4::translation(obj_world_pos),
+        obj_world_pos,
+        Vector3(0.0f, 0.0f, 0.0f));
+}
+
+// Verifies that a 45-degree rotation is correctly accounted for in the inverse.
+// Object at (10,10) rotated 45 deg CCW around Z.
+// World point that corresponds to local (3,4) computed as: world = T + R * local.
+TEST_F(ScriptTest, WorldToLocalPosition_ForumReport_45DegRotation)
+{
+    Matrix4 rot = Matrix4::rotationZ(M_PI * 0.25f);
+    Matrix4 target_world = Matrix4::translation(Vector3(10.0f, 10.0f, 0.0f)) * rot;
+
+    // world = (10,10) + R(45) * (3,4): verified numerically as (9.2929, 14.9497)
+    RunWorldToLocalPositionTest(this,
+        target_world,
+        Vector3(9.292893f, 14.949747f, 0.0f),
+        Vector3(3.0f, 4.0f, 0.0f));
+}
+
+// Verifies that a 90-degree rotation is correctly accounted for in the inverse.
+// Object at (10,10) rotated 90 deg around Z. World point directly above object in world space
+// maps to a point along local X after inverse-rotating.
+TEST_F(ScriptTest, WorldToLocalPosition_ForumReport_WithRotation)
+{
+    // 90 deg CCW around Z: local X -> world Y, local Y -> -world X
+    Matrix4 rot = Matrix4::rotationZ(M_PI * 0.5f);
+    Matrix4 target_world = Matrix4::translation(Vector3(10.0f, 10.0f, 0.0f)) * rot;
+
+    // A point 5 units along world Y from the object origin.
+    // R(90 CCW) maps local X -> world Y, so inverse maps world Y -> local X: result is +5 on local X.
+    Vector3 world_input(10.0f, 15.0f, 0.0f);
+    RunWorldToLocalPositionTest(this,
+        target_world,
+        world_input,
+        Vector3(5.0f, 0.0f, 0.0f));
+}

--- a/engine/gameobject/src/gameobject/test/script/world_to_local_pos.go_pb
+++ b/engine/gameobject/src/gameobject/test/script/world_to_local_pos.go_pb
@@ -1,0 +1,4 @@
+components {
+  id: "script"
+  component: "/world_to_local_pos.scriptc"
+}

--- a/engine/gameobject/src/gameobject/test/script/world_to_local_pos.script
+++ b/engine/gameobject/src/gameobject/test/script/world_to_local_pos.script
@@ -1,0 +1,26 @@
+-- Copyright 2020-2026 The Defold Foundation
+-- Copyright 2014-2020 King
+-- Copyright 2009-2014 Ragnar Svensson, Christian Murray
+-- Licensed under the Defold License version 1.0 (the "License"); you may not use
+-- this file except in compliance with the License.
+--
+-- You may obtain a copy of the License, together with FAQs at
+-- https://www.defold.com/license
+--
+-- Unless required by applicable law or agreed to in writing, software distributed
+-- under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+-- CONDITIONS OF ANY KIND, either express or implied. See the License for the
+-- specific language governing permissions and limitations under the License.
+
+local function assert_near(label, exp, act, eps)
+    assert(math.abs(exp - act) < eps, string.format("%s: expected %f but was %f", label, exp, act))
+end
+
+local eps = 0.0001
+
+function update(self, dt)
+    local result = go.world_to_local_position(_G.WORLD_POS_INPUT, hash("target"))
+    assert_near("x", _G.EXPECTED_X, result.x, eps)
+    assert_near("y", _G.EXPECTED_Y, result.y, eps)
+    assert_near("z", _G.EXPECTED_Z, result.z, eps)
+end

--- a/engine/gameobject/src/gameobject/test/script/world_to_local_transform.go_pb
+++ b/engine/gameobject/src/gameobject/test/script/world_to_local_transform.go_pb
@@ -1,0 +1,4 @@
+components {
+  id: "script"
+  component: "/world_to_local_transform.scriptc"
+}

--- a/engine/gameobject/src/gameobject/test/script/world_to_local_transform.script
+++ b/engine/gameobject/src/gameobject/test/script/world_to_local_transform.script
@@ -1,0 +1,27 @@
+-- Copyright 2020-2026 The Defold Foundation
+-- Copyright 2014-2020 King
+-- Copyright 2009-2014 Ragnar Svensson, Christian Murray
+-- Licensed under the Defold License version 1.0 (the "License"); you may not use
+-- this file except in compliance with the License.
+--
+-- You may obtain a copy of the License, together with FAQs at
+-- https://www.defold.com/license
+--
+-- Unless required by applicable law or agreed to in writing, software distributed
+-- under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+-- CONDITIONS OF ANY KIND, either express or implied. See the License for the
+-- specific language governing permissions and limitations under the License.
+
+local function assert_near(label, exp, act, eps)
+    assert(math.abs(exp - act) < eps, string.format("%s: expected %f but was %f", label, exp, act))
+end
+
+local eps = 0.0001
+
+function update(self, dt)
+    local result = go.world_to_local_transform(_G.WORLD_TRANSFORM_INPUT, hash("target"))
+    -- m03/m13/m23 = translation column (row, col indexing)
+    assert_near("tx", _G.EXPECTED_TX, result.m03, eps)
+    assert_near("ty", _G.EXPECTED_TY, result.m13, eps)
+    assert_near("tz", _G.EXPECTED_TZ, result.m23, eps)
+end


### PR DESCRIPTION
Fixed a regression where `go.world_to_local_position()` and `go.world_to_local_transform()` no longer returned the correct values.

Fixes #12549 

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
