### PR TITLE
Improve batched-pmap performance

### DIFF
--- a/editor/src/clj/editor/pipeline.clj
+++ b/editor/src/clj/editor/pipeline.clj
@@ -191,10 +191,7 @@
   (contains? #{"fontc"} (resource/ext (:resource build-target))))
 
 (defn- batched-pmap [f batches]
-  (->> batches
-       (pmap (fn [batch] (doall (map f batch))))
-       (reduce concat)
-       doall))
+  (into [] cat (coll/pmapv #(mapv f %) batches)))
 
 (def ^:private cheap-batch-size 500)
 (def ^:private expensive-batch-size 5)


### PR DESCRIPTION
On synthetic data, batched-pmap became 80% faster.

Old:
```
Execution time mean : 829,685145 µs
```
New:
```
Execution time mean : 143,104297 µs
```

When it comes to building the project, the improvement is pretty small, around 2% (3m05s -> 2m58s) on a warm run.

Related to #11988
