### PR TITLE
Improve `lift-target-arcs` performance

### DIFF
--- a/editor/src/clj/internal/graph.clj
+++ b/editor/src/clj/internal/graph.clj
@@ -799,18 +799,20 @@
                    (into result propagated-arcs))))))))
 
 (defn- lift-target-arcs [basis target-id target-override-chain arcs]
-  (loop [override-chain target-override-chain
-         arcs arcs]
-    (let [override-id (first override-chain)]
-      (if (nil? override-id)
-        (mapv #(assoc % :target-id target-id) arcs)
-        (recur (rest override-chain)
-               (mapv (fn [^Arc arc]
-                       (let [source-id (.source-id arc)]
-                         (if-some [source-override-node-id (override-of (node-id->graph basis source-id) source-id override-id)]
-                           (assoc arc :source-id source-override-node-id)
-                           arc)))
-                     arcs))))))
+  (mapv
+    (fn [^Arc arc]
+      (let [original-source-id (.source-id arc)
+            graph (node-id->graph basis original-source-id)
+            source-id (reduce (fn [source-id override-id]
+                                (or (override-of graph source-id override-id)
+                                    source-id))
+                              original-source-id
+                              target-override-chain)]
+        (if (and (= source-id original-source-id)
+                 (= target-id (.target-id arc)))
+          arc
+          (Arc. source-id (.source-label arc) target-id (.target-label arc)))))
+    arcs))
 
 (defn- collect-override-chains+explicit-arcs
   "Used by arcs-by-source to find explicit arcs from all original nodes


### PR DESCRIPTION
This change improves build performance of big projects by 3% (2m26s -> 2m20s on a measured run).

What's interesting is that this work started as a way to reduce allocations (too much mapv uses), but the thing that moved the needle was extracting and reusing a `graph` local. So, the change technically changes the behavior by adding an assumption that wasn't in the function before (the assumption — all overrides are in the same graph), but we already had the same assumption in practice, e.g., in `g/override-predecessors`.

Related to #11988
