### PR TITLE
Improve warm build performance of large projects by 19%

### DIFF
--- a/editor/src/clj/util/digestable.clj
+++ b/editor/src/clj/util/digestable.clj
@@ -129,35 +129,58 @@
   (let [tag-sym (symbol (.getSimpleName (class resource)))]
     (digest-tagged! tag-sym (resource/resource-hash resource) writer opts)))
 
-(defn- to-sorted-map [map]
-  {:pre [(map? map)]}
-  (if (or (sorted? map)
-          (< (count map) 2))
-    map
-    (into (sorted-map)
-          map)))
-
 (defn- digest-map! [coll writer opts]
-  (let [sorted-map (to-sorted-map coll)
-        last-index (dec (count sorted-map))]
-    (digest-raw! "{" writer)
-    (reduce-kv (fn digest-map-entry! [^long index key value]
-                 (if (ignored-key? key)
-                   index
-                   (try
-                     (digest! key writer opts)
-                     (digest-raw! " " writer)
-                     (if (node-id-entry? key value)
-                       (digest-tagged! 'Node (persistent-node-id-value value opts) writer opts)
-                       (digest! value writer opts))
-                     (when (< index last-index)
-                       (digest-raw! ", " writer))
-                     (inc index)
-                     (catch Throwable error
-                       (throw (augment-throwable-with-path error coll key))))))
-               0
-               sorted-map)
-    (digest-raw! "}" writer)))
+  {:pre [(map? coll)]}
+  (digest-raw! "{" writer)
+  (let [n (count coll)
+        last-index (dec n)]
+    (if (or (sorted? coll)
+            (< n 2))
+      (reduce-kv
+        (fn digest-map-entry! [^long index key value]
+          (if (ignored-key? key)
+            index
+            (try
+              (digest! key writer opts)
+              (digest-raw! " " writer)
+              (if (node-id-entry? key value)
+                (digest-tagged! 'Node (persistent-node-id-value value opts) writer opts)
+                (digest! value writer opts))
+              (when (< index last-index)
+                (digest-raw! ", " writer))
+              (inc index)
+              (catch Throwable error
+                (throw (augment-throwable-with-path error coll key))))))
+        0
+        coll)
+      (let [^objects keys-array (object-array n)]
+        (reduce-kv
+          (fn put-key-in-array! [^long index key _value]
+            (aset keys-array index key)
+            (unchecked-inc-int index))
+          0
+          coll)
+        (Arrays/sort keys-array compare)
+        (loop [array-index 0
+               output-index 0]
+          (when (< array-index n)
+            (let [key (aget keys-array array-index)]
+              (if (ignored-key? key)
+                (recur (unchecked-inc-int array-index) output-index)
+                (do
+                  (try
+                    (digest! key writer opts)
+                    (digest-raw! " " writer)
+                    (let [value (get coll key)]
+                      (if (node-id-entry? key value)
+                        (digest-tagged! 'Node (persistent-node-id-value value opts) writer opts)
+                        (digest! value writer opts)))
+                    (when (< output-index last-index)
+                      (digest-raw! ", " writer))
+                    (catch Throwable error
+                      (throw (augment-throwable-with-path error coll key))))
+                  (recur (unchecked-inc-int array-index) (unchecked-inc-int output-index))))))))))
+  (digest-raw! "}" writer))
 
 (defn- to-sorted-set [set]
   {:pre [(set? set)]}
@@ -283,4 +306,3 @@
                        (System/arraycopy result-bytes 0 padded (- 20 len) len)
                        padded))]
     (util.digest/bytes->hex normalized)))
-


### PR DESCRIPTION
On a large project the measured warm build time (when there is a build cache on disc) improved from 3m16s to 2m37s.

Technical notes:
I did 2 measurement runs, numbers above are averages of these runs:
```
;; before
"Elapsed time: 205720.703959 msecs"
"Elapsed time: 186601.907958 msecs"
;; after
"Elapsed time: 153019.124916 msecs"
"Elapsed time: 161656.230708 msecs"
```
We no longer use sorted maps for content hashing. They are very slow to build. Here are microbenchmark results for building a sorted map (old approach) vs sorting an array of keys (new approach):

| map size | old | new | improvement |
|---:|---:|---:|---:|
| 8 | 2.04 µs | 1.08 µs | 47.07% |
| 32 | 8.16 µs | 6.16 µs | 24.50% |
| 128 | 46.73 µs | 31.67 µs | 32.21% |
| 512 | 249.86 µs | 169.14 µs | 32.31% |

Time is microseconds per call; lower is better.

Fix #11988