### PR TITLE
Fix iOS audio glitches after returning from other media apps

### DIFF
--- a/engine/sound/src/devices/device_avaudio.mm
+++ b/engine/sound/src/devices/device_avaudio.mm
@@ -36,6 +36,8 @@ namespace dmDeviceAVAudio
         dmArray<AVAudioPCMBuffer*>  m_FreeBuffers;
         uint32_t                    m_MixRate;
         uint32_t                    m_FramesPerBuffer;
+        uint32_t                    m_BufferCount;
+        uint32_t                    m_MaxBufferCount;
         bool                        m_Started;
         dmMutex::HMutex             m_Mutex;
         id                          m_EngineConfigObserver;
@@ -50,6 +52,8 @@ namespace dmDeviceAVAudio
         , m_Format(nil)
         , m_MixRate(0)
         , m_FramesPerBuffer(0)
+        , m_BufferCount(0)
+        , m_MaxBufferCount(0)
         , m_Started(false)
         , m_Mutex(0)
         , m_EngineConfigObserver(nil)
@@ -60,6 +64,39 @@ namespace dmDeviceAVAudio
 #endif
         }
     };
+
+#if TARGET_OS_IPHONE
+    static const double IOS_MAX_TRANSIENT_IO_BUFFER_DURATION = 0.12;
+#endif
+
+    static uint32_t GetBufferCountForDuration(uint32_t mix_rate, uint32_t frames_per_buffer, double duration)
+    {
+        if (mix_rate == 0 || frames_per_buffer == 0 || duration <= 0.0)
+        {
+            return 0;
+        }
+
+        uint32_t frames = (uint32_t)(duration * (double)mix_rate + 0.5);
+        return (frames + frames_per_buffer - 1) / frames_per_buffer;
+    }
+
+    static uint32_t DeviceAVAudioGetEffectiveBufferCount(AVAudioDevice* device)
+    {
+        uint32_t buffer_count = device->m_BufferCount;
+#if TARGET_OS_IPHONE
+        AVAudioSession* session = [AVAudioSession sharedInstance];
+        uint32_t io_buffer_count = GetBufferCountForDuration(device->m_MixRate, device->m_FramesPerBuffer, session.IOBufferDuration);
+        if (io_buffer_count >= buffer_count)
+        {
+            buffer_count = io_buffer_count + 1;
+        }
+        if (buffer_count > device->m_MaxBufferCount)
+        {
+            buffer_count = device->m_MaxBufferCount;
+        }
+#endif
+        return buffer_count;
+    }
 
     static void DeviceAVAudioScheduleReconfigure(AVAudioDevice* device)
     {
@@ -181,6 +218,19 @@ namespace dmDeviceAVAudio
 
         // Respect engine-provided frame count if set; otherwise use engine default
         device->m_FramesPerBuffer = params->m_FrameCount ? params->m_FrameCount : dmSound::GetDefaultFrameCount(device->m_MixRate);
+        device->m_BufferCount = params->m_BufferCount;
+        device->m_MaxBufferCount = params->m_BufferCount;
+#if TARGET_OS_IPHONE
+        uint32_t transient_buffer_count = GetBufferCountForDuration(device->m_MixRate, device->m_FramesPerBuffer, IOS_MAX_TRANSIENT_IO_BUFFER_DURATION);
+        if (transient_buffer_count > 0)
+        {
+            transient_buffer_count += 1;
+            if (device->m_MaxBufferCount < transient_buffer_count)
+            {
+                device->m_MaxBufferCount = transient_buffer_count;
+            }
+        }
+#endif
 
         device->m_Format = [[AVAudioFormat alloc] initWithCommonFormat:AVAudioPCMFormatFloat32
                                                          sampleRate:device->m_MixRate
@@ -223,12 +273,12 @@ namespace dmDeviceAVAudio
             }];
 #endif
 
-        device->m_AllBuffers.SetCapacity(params->m_BufferCount);
-        device->m_AllBuffers.SetSize(params->m_BufferCount);
-        device->m_FreeBuffers.SetCapacity(params->m_BufferCount);
+        device->m_AllBuffers.SetCapacity(device->m_MaxBufferCount);
+        device->m_AllBuffers.SetSize(device->m_MaxBufferCount);
+        device->m_FreeBuffers.SetCapacity(device->m_MaxBufferCount);
         device->m_FreeBuffers.SetSize(0);
 
-        for (uint32_t i = 0; i < params->m_BufferCount; ++i)
+        for (uint32_t i = 0; i < device->m_MaxBufferCount; ++i)
         {
             AVAudioPCMBuffer* buf = [[AVAudioPCMBuffer alloc] initWithPCMFormat:device->m_Format
                                                                     frameCapacity:device->m_FramesPerBuffer];
@@ -349,7 +399,16 @@ namespace dmDeviceAVAudio
             return 1;
         }
         DM_MUTEX_SCOPED_LOCK(device->m_Mutex);
-        return device->m_FreeBuffers.Size();
+        uint32_t free_count = device->m_FreeBuffers.Size();
+        uint32_t queued_count = device->m_MaxBufferCount - free_count;
+        uint32_t effective_buffer_count = DeviceAVAudioGetEffectiveBufferCount(device);
+        if (queued_count >= effective_buffer_count)
+        {
+            return 0;
+        }
+
+        uint32_t free_slots = effective_buffer_count - queued_count;
+        return dmMath::Min(free_count, free_slots);
     }
 
 

--- a/engine/sound/src/sound_ios.mm
+++ b/engine/sound/src/sound_ios.mm
@@ -26,22 +26,57 @@
 // ---------------------------------------------------------------------------
 namespace {
 
+    const uint32_t IOS_AUDIO_SESSION_MIX_RATE = 48000;
+
     bool g_audioInterrupted = false;
     bool g_isSessionRouteChangeReasonCategoryChange = false;
     bool g_ignoreRouteChange = false;
+    double g_preferredIOBufferDuration = 0.0;
 
     id<UIApplicationDelegate> g_soundApplicationDelegate;
+
+    void configurePreferredIOBufferDuration(dmConfigFile::HConfig config, const dmSound::InitializeParams* params) {
+        uint32_t frame_count = params->m_FrameCount;
+        if (config)
+        {
+            frame_count = (uint32_t) dmConfigFile::GetInt(config, "sound.sample_frame_count", (int32_t) frame_count);
+        }
+        if (frame_count == 0)
+        {
+            frame_count = dmSound::GetDefaultFrameCount(IOS_AUDIO_SESSION_MIX_RATE);
+        }
+        g_preferredIOBufferDuration = (double)frame_count / (double)IOS_AUDIO_SESSION_MIX_RATE;
+    }
+
+    void applyPreferredIOBufferDuration(AVAudioSession* session) {
+        if (g_preferredIOBufferDuration <= 0.0)
+        {
+            return;
+        }
+
+        NSError* error = nil;
+        BOOL success = [session setPreferredIOBufferDuration:g_preferredIOBufferDuration error:&error];
+        if (!success)
+        {
+            dmLogWarning("Failed to set preferred AudioSession IO buffer duration (%ld)", error ? (long)error.code : 0L);
+        }
+    }
 
     void activateAudioSession() {
         g_ignoreRouteChange = false;
         g_isSessionRouteChangeReasonCategoryChange = false;
-        NSError *error = nil;
-        [[AVAudioSession sharedInstance] setActive:YES error:&error];
-        g_audioInterrupted = false;
-        if(error != nil){
-            dmLogError("Failed to activate AudioSession (%ld)", error.code);
+        AVAudioSession* session = [AVAudioSession sharedInstance];
+        applyPreferredIOBufferDuration(session);
+
+        NSError* error = nil;
+        BOOL success = [session setActive:YES error:&error];
+        if (!success)
+        {
+            dmLogError("Failed to activate AudioSession (%ld)", error ? (long)error.code : 0L);
             return;
         }
+        applyPreferredIOBufferDuration(session);
+        g_audioInterrupted = false;
     }
 };
 
@@ -167,6 +202,8 @@ namespace dmSound
 {
     Result PlatformInitialize(dmConfigFile::HConfig config, const InitializeParams* params)
     {
+        ::configurePreferredIOBufferDuration(config, params);
+
         ::g_soundApplicationDelegate = [[SoundApplicationDelegate alloc] init];
         glfwRegisterUIApplicationDelegate(::g_soundApplicationDelegate);
 
@@ -183,12 +220,14 @@ namespace dmSound
                                               name:AVAudioSessionRouteChangeNotification
                                               object:[AVAudioSession sharedInstance]];
 
-        NSError *error = nil;
-        BOOL success = [[AVAudioSession sharedInstance] setCategory: AVAudioSessionCategoryAmbient error: &error];
+        AVAudioSession* session = [AVAudioSession sharedInstance];
+        NSError* error = nil;
+        BOOL success = [session setCategory: AVAudioSessionCategoryAmbient error: &error];
         if (!success)
         {
-            dmLogError("Failed to initialize AudioSession (%d)", (int)error.code);
+            dmLogError("Failed to initialize AudioSession (%d)", error ? (int)error.code : 0);
         }
+        ::applyPreferredIOBufferDuration(session);
 
         return RESULT_OK;
     }
@@ -220,4 +259,3 @@ namespace dmSound
     }
 
 }
-

--- a/engine/sound/src/test/test_sound_avaudio.mm
+++ b/engine/sound/src/test/test_sound_avaudio.mm
@@ -45,6 +45,8 @@ namespace
         dmArray<AVAudioPCMBuffer*>  m_FreeBuffers;
         uint32_t                    m_MixRate;
         uint32_t                    m_FramesPerBuffer;
+        uint32_t                    m_BufferCount;
+        uint32_t                    m_MaxBufferCount;
         bool                        m_Started;
         dmMutex::HMutex             m_Mutex;
         id                          m_EngineConfigObserver;


### PR DESCRIPTION
Fixes temporary audio distortion on iOS when returning to a Defold app after playing media in apps like Safari or YouTube or after ADS in the game. Audio now stabilizes immediately during the iOS audio session handoff. Normal playback latency is preserved once iOS returns to Defold’s preferred audio buffer size.

Fix https://github.com/defold/defold/issues/12541
Fix https://github.com/defold/extension-ironsource/issues/33

### Technical changes

- Store the requested device buffer count as `m_BufferCount`.
- Add `m_MaxBufferCount` for the larger transient AVAudio pool on iOS.
- Allocate `m_AllBuffers` and `m_FreeBuffers` using `m_MaxBufferCount` instead of `params->m_BufferCount`.
- Compute `m_MaxBufferCount` from a transient max IO buffer duration on iOS, with one extra cushion buffer.
- `DeviceAVAudioFreeBufferSlots()` reads the current `AVAudioSession.IOBufferDuration` and computes the effective queue target.
- While iOS still reports a large IO buffer, the backend can queue more of the already allocated `m_MaxBufferCount` buffers.
- Once `IOBufferDuration` normalizes, the effective target drops back to `m_BufferCount`, so extra buffers are not refilled and the queue drains back to normal latency.
- Request preferred `AVAudioSession` IO buffer duration during initialization and activation.