### PR TITLE
Fix use-after-free in InvokeCallback teardown (cancel-timer-from-own-callback crash)

### DIFF
--- a/engine/script/src/script.cpp
+++ b/engine/script/src/script.cpp
@@ -2013,13 +2013,24 @@ namespace dmScript
         return true;
     }
 
-    void TeardownCallback(lua_State* L)
+    // Internal teardown using an explicit lua_State. InvokeCallback passes the
+    // lua_State it captured *before* PCall, because user code run by PCall may
+    // have freed the LuaCallbackInfo userdata (e.g. cancelling, from within its
+    // own callback, the timer that owns it). Re-reading cbk->m_L after that would
+    // dereference freed memory. The captured L (the main thread) stays valid.
+    static void TeardownCallbackWithState(lua_State* L)
     {
         // [-2] old instance
         // [-1] context table
         lua_pop(L, 1);
 
         SetInstance(L);
+    }
+
+    void TeardownCallback(LuaCallbackInfo* cbk)
+    {
+        // Public API: keep the existing signature for external callers.
+        TeardownCallbackWithState(cbk->m_L);
     }
 
     bool InvokeCallback(LuaCallbackInfo* cbk, LuaCallbackUserFn fn, void* user_context)
@@ -2055,13 +2066,9 @@ namespace dmScript
 
         // [-2] old instance
         // [-1] context table
-        // NOTE: Use the lua_State captured at the top of this function, not
-        // cbk->m_L. User code run by PCall above may have unreferenced this
-        // callback (e.g. cancelling the timer that owns it from within its own
-        // callback); the LuaCallbackInfo is a Lua userdata, so a GC step during
-        // that code can then free cbk. Re-reading cbk->m_L here would dereference
-        // freed memory. The captured L (the main thread) stays valid regardless.
-        TeardownCallback(L);
+        // Use the lua_State captured before PCall, not cbk->m_L: PCall may have run
+        // user code that freed the callback userdata (see TeardownCallbackWithState).
+        TeardownCallbackWithState(L);
 
         return ret != 0 ? false : true;
     }

--- a/engine/script/src/script.cpp
+++ b/engine/script/src/script.cpp
@@ -2013,9 +2013,8 @@ namespace dmScript
         return true;
     }
 
-    void TeardownCallback(LuaCallbackInfo* cbk)
+    void TeardownCallback(lua_State* L)
     {
-        lua_State* L = cbk->m_L;
         // [-2] old instance
         // [-1] context table
         lua_pop(L, 1);
@@ -2056,7 +2055,13 @@ namespace dmScript
 
         // [-2] old instance
         // [-1] context table
-        TeardownCallback(cbk);
+        // NOTE: Use the lua_State captured at the top of this function, not
+        // cbk->m_L. User code run by PCall above may have unreferenced this
+        // callback (e.g. cancelling the timer that owns it from within its own
+        // callback); the LuaCallbackInfo is a Lua userdata, so a GC step during
+        // that code can then free cbk. Re-reading cbk->m_L here would dereference
+        // freed memory. The captured L (the main thread) stays valid regardless.
+        TeardownCallback(L);
 
         return ret != 0 ? false : true;
     }


### PR DESCRIPTION
## Summary

`InvokeCallback` can dereference a freed `LuaCallbackInfo` during teardown, causing a `SIGSEGV`. After `PCall` runs the user's Lua callback, `InvokeCallback` calls `TeardownCallback(cbk)`, which reads `cbk->m_L`:

```cpp
void TeardownCallback(LuaCallbackInfo* cbk) {
    lua_State* L = cbk->m_L;   // <-- cbk may already be freed here
    ...
}
```

`LuaCallbackInfo` is a Lua **userdata** (allocated via `lua_newuserdata` in `CreateCallback`), kept alive only by `m_CallbackInfoRef` in the registry. If the user code executed by `PCall` un-references the callback — the classic case being **cancelling, from inside a timer's own callback, the very timer that owns it** — `DestroyCallback` runs `dmScript::Unref(... m_CallbackInfoRef)`, making the userdata GC-eligible. A subsequent allocation in that same callback (e.g. `timer.delay` creating the next timer via `lua_newuserdata`) can trigger a GC step that collects `cbk`. When `PCall` returns, `TeardownCallback(cbk)` reads `cbk->m_L` from freed/reused memory → garbage `lua_State*` → crash in `lua_settop`.

## Evidence

Symbolicated from a release crashdump (Defold 1.12.4, arm64-osx), identical fault across runs:

```
Thread crashed: EXC_BAD_ACCESS (KERN_INVALID_ADDRESS) at 0xf00a0e6d893ec886
lua_settop + 112
dmScript::TeardownCallback(...)  (script.cpp)
dmScript::InvokeCallback(...)    (script.cpp)
dmScript::LuaTimerCallback(...)  (script_timer.cpp)
dmScript::UpdateTimers(...)
```

`x0` (the `lua_State*`) is itself a garbage pointer (`0xf00a0e6d893ec85e`), i.e. `cbk` is no longer a valid `LuaCallbackInfo`. The crash reproduced after both ~23 s and ~14 min of runtime — it is GC-timing dependent, not time-accumulation.

## Minimal repro

```lua
local function arm()
    local id
    id = timer.delay(1/60, true, function()
        timer.cancel(id)   -- un-refs this callback's LuaCallbackInfo
        arm()              -- timer.delay allocates -> GC step may free the old cbk
    end)
end
arm()
```

(This is exactly the shape of Insality's `panthera` animation loop, which is how it was found.)

A **deterministic** variant that crashes on the first timer tick — forcing the free before `InvokeCallback`'s teardown runs, removing the GC-timing dependence — is in [this comment](https://github.com/defold/defold/pull/12588#issuecomment-4701578262).

## Fix

`InvokeCallback` already captures `lua_State* L = cbk->m_L` at the top, and that `L` (the main thread) stays valid for the whole call regardless of the userdata's GC state. Route `InvokeCallback`'s teardown through that captured `L` instead of re-reading `cbk`.

`TeardownCallback(LuaCallbackInfo*)` is **public dmsdk API** (declared in `dmsdk/script/script.h`, called from ~11 other translation units: `script_window/font/resource/model/particlefx/physics/liveupdate/render/html5/sys`), so its signature must not change. This PR therefore:

- adds a private `static void TeardownCallbackWithState(lua_State* L)` with the actual teardown body;
- keeps `void TeardownCallback(LuaCallbackInfo* cbk)` as a thin wrapper (`TeardownCallbackWithState(cbk->m_L)`) — public symbol and behaviour preserved for all external callers;
- changes only `InvokeCallback` to call `TeardownCallbackWithState(L)` with its captured, still-valid `L`.

After this, `InvokeCallback` never dereferences `cbk` after user code has run.

## Notes / limitations

- This fixes the general `InvokeCallback` path, shared by all callback users (timers, events, http, etc.), not just timers.
- `LuaTimerCallback` (`script_timer.cpp`) also dereferences `callback` after `InvokeCallback` returns, but is short-circuited for `TIMER_EVENT_TRIGGER_WILL_REPEAT` (the repeating-timer case above), so it is not hit by this repro. The other public `TeardownCallback(cbk)` callers remain theoretically exposed if their own `PCall` frees the callback; happy to follow up if you'd like that hardened too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

