### PR TITLE
Clean up Bob temporary files

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/archive/test/ArchiveTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/archive/test/ArchiveTest.java
@@ -40,7 +40,6 @@ import com.dynamo.bob.archive.ArchiveBuilder;
 import com.dynamo.bob.archive.ArchiveReader;
 import com.dynamo.bob.archive.ManifestBuilder;
 import com.dynamo.bob.Project;
-import com.dynamo.bob.util.FileUtil;
 import com.dynamo.bob.fs.DefaultFileSystem;
 import com.dynamo.bob.pipeline.graph.ResourceNode;
 import com.dynamo.bob.pipeline.graph.ResourceGraph;
@@ -63,7 +62,6 @@ public class ArchiveTest {
     private String createDummyFile(String dir, String filepath, byte[] data) throws IOException {
         File tmp = new File(Paths.get(FilenameUtils.concat(dir, filepath)).toString());
         tmp.getParentFile().mkdirs();
-        FileUtil.deleteOnExit(tmp);
 
         FileOutputStream fos = new FileOutputStream(tmp);
         fos.write(data);

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/archive/test/ArchiveTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/archive/test/ArchiveTest.java
@@ -118,6 +118,9 @@ public class ArchiveTest {
 
     @After
     public void tearDown() throws IOException {
+        if (project != null) {
+            project.dispose();
+        }
         FileUtils.deleteDirectory(new File(contentRoot));
         FileUtils.deleteQuietly(outputDarc);
 

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/archive/test/ManifestTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/archive/test/ManifestTest.java
@@ -112,35 +112,36 @@ public class ManifestTest {
         }
 
         private ResourceGraph createResourceGraph() {
-            Project project = new Project(new DefaultFileSystem());
-            ResourceGraph graph = new ResourceGraph(project);
+            try (Project project = new Project(new DefaultFileSystem())) {
+                ResourceGraph graph = new ResourceGraph(project);
 
-            ResourceNode root = graph.getRootNode();
-            ResourceNode mainCollection = graph.add("/main/main.collectionc", root);
-            ResourceNode mainGo = graph.add("/main/main.goc", mainCollection);
-            graph.add("/main/main.scriptc", mainGo);
-            ResourceNode dynamicCollection = graph.add("/main/dynamic.collectionc", mainCollection);
-            ResourceNode dynamicGo = graph.add("/main/dynamic.goc", dynamicCollection);
-            ResourceNode sharedGo = graph.add("/main/shared_go.goc", mainCollection);
+                ResourceNode root = graph.getRootNode();
+                ResourceNode mainCollection = graph.add("/main/main.collectionc", root);
+                ResourceNode mainGo = graph.add("/main/main.goc", mainCollection);
+                graph.add("/main/main.scriptc", mainGo);
+                ResourceNode dynamicCollection = graph.add("/main/dynamic.collectionc", mainCollection);
+                ResourceNode dynamicGo = graph.add("/main/dynamic.goc", dynamicCollection);
+                ResourceNode sharedGo = graph.add("/main/shared_go.goc", mainCollection);
 
-            ResourceNode level1Proxy = graph.add("/main/level1.collectionproxyc", mainGo);
-            ResourceNode level1Collection = graph.add("/main/level1.collectionc", level1Proxy);
-            level1Proxy.setType(ResourceNode.Type.ExcludedCollectionProxy);
-            level1Collection.setType(ResourceNode.Type.ExcludedCollection);
-            ResourceNode level1Go = graph.add("/main/level1.goc", level1Collection);
-            graph.add("/main/level1.scriptc", level1Go);
+                ResourceNode level1Proxy = graph.add("/main/level1.collectionproxyc", mainGo);
+                ResourceNode level1Collection = graph.add("/main/level1.collectionc", level1Proxy);
+                level1Proxy.setType(ResourceNode.Type.ExcludedCollectionProxy);
+                level1Collection.setType(ResourceNode.Type.ExcludedCollection);
+                ResourceNode level1Go = graph.add("/main/level1.goc", level1Collection);
+                graph.add("/main/level1.scriptc", level1Go);
 
-            ResourceNode level2Proxy = graph.add("/main/level2.collectionproxyc", level1Go);
-            ResourceNode level2Collection = graph.add("/main/level2.collectionc", level2Proxy);
-            graph.add("/main/level2.goc", level2Collection);
-            graph.add("/main/level2.soundc", level2Collection);
+                ResourceNode level2Proxy = graph.add("/main/level2.collectionproxyc", level1Go);
+                ResourceNode level2Collection = graph.add("/main/level2.collectionc", level2Proxy);
+                graph.add("/main/level2.goc", level2Collection);
+                graph.add("/main/level2.soundc", level2Collection);
 
-            graph.add(dynamicGo, level1Collection);
-            graph.add(dynamicGo, level2Collection);
-            graph.add(sharedGo, level1Go);
+                graph.add(dynamicGo, level1Collection);
+                graph.add(dynamicGo, level2Collection);
+                graph.add(sharedGo, level1Go);
 
-            graph.findAllResourcesReferencedFromMainCollection();
-            return graph;
+                graph.findAllResourcesReferencedFromMainCollection();
+                return graph;
+            }
         }
 
         public HashDigest projectIdentifierHash() {

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/bundle/test/BundleHelperTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/bundle/test/BundleHelperTest.java
@@ -40,7 +40,6 @@ import com.dynamo.bob.ClassLoaderResourceScanner;
 import com.dynamo.bob.CompileExceptionError;
 import com.dynamo.bob.Platform;
 import com.dynamo.bob.bundle.BundleHelper;
-import com.dynamo.bob.util.FileUtil;
 import com.dynamo.bob.bundle.BundleHelper.ResourceInfo;
 import com.dynamo.bob.fs.ClassLoaderMountPoint;
 import com.dynamo.bob.fs.IResource;
@@ -344,7 +343,6 @@ public class BundleHelperTest {
 
     private void createMockFile(File dir, String name) throws IOException {
         File file = new File(dir, name);
-        FileUtil.deleteOnExit(file);
         FileUtils.copyInputStreamToFile(new ByteArrayInputStream("dummy".getBytes()), file);
     }
 

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/bundle/test/BundlerTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/bundle/test/BundlerTest.java
@@ -65,7 +65,6 @@ import com.dynamo.bob.Platform;
 import com.dynamo.bob.Progress;
 import com.dynamo.bob.Project;
 import com.dynamo.bob.TaskResult;
-import com.dynamo.bob.util.FileUtil;
 import com.dynamo.bob.archive.ArchiveBuilder;
 import com.dynamo.bob.archive.ManifestBuilder;
 import com.dynamo.bob.archive.publisher.NullPublisher;
@@ -450,7 +449,6 @@ public class BundlerTest {
 
     private String createFile(String root, String name, String content) throws IOException {
         File file = new File(root, name);
-        FileUtil.deleteOnExit(file);
         FileUtils.copyInputStreamToFile(new ByteArrayInputStream(content.getBytes()), file);
         return file.getAbsolutePath();
     }

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/bundle/test/BundlerTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/bundle/test/BundlerTest.java
@@ -334,21 +334,22 @@ public class BundlerTest {
     }
 
     void build() throws IOException, CompileExceptionError, MultipleCompileException {
-        Project project = new Project(new DefaultFileSystem(), contentRoot, "build");
-        project.setPublisher(new NullPublisher(new PublisherSettings()));
+        try (Project project = new Project(new DefaultFileSystem(), contentRoot, "build")) {
+            project.setPublisher(new NullPublisher(new PublisherSettings()));
 
-        ClassLoaderScanner scanner = new ClassLoaderScanner();
-        project.scan(scanner, "com.dynamo.bob");
-        project.scan(scanner, "com.dynamo.bob.pipeline");
+            ClassLoaderScanner scanner = new ClassLoaderScanner();
+            project.scan(scanner, "com.dynamo.bob");
+            project.scan(scanner, "com.dynamo.bob.pipeline");
 
-        setProjectProperties(project);
+            setProjectProperties(project);
 
-        List<TaskResult> result = project.build(Progress.discarding(), "clean", "build", "bundle");
-        for (TaskResult taskResult : result) {
-            assertTrue(taskResult.toString(), taskResult.isOk());
+            List<TaskResult> result = project.build(Progress.discarding(), "clean", "build", "bundle");
+            for (TaskResult taskResult : result) {
+                assertTrue(taskResult.toString(), taskResult.isOk());
+            }
+
+            verifyEngineBinaries();
         }
-
-        verifyEngineBinaries();
     }
 
     @SuppressWarnings("unused")
@@ -430,20 +431,21 @@ public class BundlerTest {
         createDefaultFiles(contentRoot);
         outputDir = new File(contentRoot, "build").getAbsolutePath();
 
-        Project project = new Project(new DefaultFileSystem(), contentRoot, "build");
-        project.setPublisher(new NullPublisher(new PublisherSettings()));
+        try (Project project = new Project(new DefaultFileSystem(), contentRoot, "build")) {
+            project.setPublisher(new NullPublisher(new PublisherSettings()));
 
-        ClassLoaderScanner scanner = new ClassLoaderScanner();
-        project.scan(scanner, "com.dynamo.bob");
-        project.scan(scanner, "com.dynamo.bob.pipeline");
+            ClassLoaderScanner scanner = new ClassLoaderScanner();
+            project.scan(scanner, "com.dynamo.bob");
+            project.scan(scanner, "com.dynamo.bob.pipeline");
 
-        setProjectProperties(project);
+            setProjectProperties(project);
 
-        try {
-            project.build(Progress.discarding(), "bundle");
-            fail("Expected bundle output under build directory to be rejected.");
-        } catch (CompileExceptionError e) {
-            assertTrue(e.getMessage().contains(outputDir));
+            try {
+                project.build(Progress.discarding(), "bundle");
+                fail("Expected bundle output under build directory to be rejected.");
+            } catch (CompileExceptionError e) {
+                assertTrue(e.getMessage().contains(outputDir));
+            }
         }
     }
 
@@ -788,38 +790,39 @@ public class BundlerTest {
 
         createDefaultFiles(contentRoot);
 
-        Project project = new Project(new DefaultFileSystem(), contentRoot, "build");
-        project.setPublisher(new NullPublisher(new PublisherSettings()));
-        ClassLoaderScanner scanner = new ClassLoaderScanner();
-        project.scan(scanner, "com.dynamo.bob");
-        project.scan(scanner, "com.dynamo.bob.pipeline");
-        setProjectProperties(project);
+        try (Project project = new Project(new DefaultFileSystem(), contentRoot, "build")) {
+            project.setPublisher(new NullPublisher(new PublisherSettings()));
+            ClassLoaderScanner scanner = new ClassLoaderScanner();
+            project.scan(scanner, "com.dynamo.bob");
+            project.scan(scanner, "com.dynamo.bob.pipeline");
+            setProjectProperties(project);
 
-        List<TaskResult> buildResult = project.build(Progress.discarding(), "clean", "build");
-        for (TaskResult taskResult : buildResult) {
-            assertTrue(taskResult.toString(), taskResult.isOk());
-        }
+            List<TaskResult> buildResult = project.build(Progress.discarding(), "clean", "build");
+            for (TaskResult taskResult : buildResult) {
+                assertTrue(taskResult.toString(), taskResult.isOk());
+            }
 
-        String binaryOutputDir = project.getBinaryOutputDirectory();
-        File platformBinaryDir = new File(binaryOutputDir, platform.getExtenderPair());
-        platformBinaryDir.mkdirs();
+            String binaryOutputDir = project.getBinaryOutputDirectory();
+            File platformBinaryDir = new File(binaryOutputDir, platform.getExtenderPair());
+            platformBinaryDir.mkdirs();
 
-        String libName = platform.getLibPrefix() + "testlib" + platform.getLibSuffix();
-        createFile(platformBinaryDir.getAbsolutePath(), libName, "mock_library_content");
+            String libName = platform.getLibPrefix() + "testlib" + platform.getLibSuffix();
+            createFile(platformBinaryDir.getAbsolutePath(), libName, "mock_library_content");
 
-        List<TaskResult> bundleResult = project.build(Progress.discarding(), "bundle");
-        for (TaskResult taskResult : bundleResult) {
-            assertTrue(taskResult.toString(), taskResult.isOk());
-        }
+            List<TaskResult> bundleResult = project.build(Progress.discarding(), "bundle");
+            for (TaskResult taskResult : bundleResult) {
+                assertTrue(taskResult.toString(), taskResult.isOk());
+            }
 
-        List<String> bundleFiles = getBundleFiles();
-        String expectedLibPath = getExpectedDynamicLibraryPath(libName);
+            List<String> bundleFiles = getBundleFiles();
+            String expectedLibPath = getExpectedDynamicLibraryPath(libName);
 
-        if (expectedLibPath != null) {
-            assertTrue(
-                    "Expected dynamic library " + expectedLibPath + " not found in bundle. Bundle files: "
-                            + bundleFiles,
-                    bundleFiles.contains(expectedLibPath));
+            if (expectedLibPath != null) {
+                assertTrue(
+                        "Expected dynamic library " + expectedLibPath + " not found in bundle. Bundle files: "
+                                + bundleFiles,
+                        bundleFiles.contains(expectedLibPath));
+            }
         }
     }
 

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/bundle/test/MacOSBundlerTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/bundle/test/MacOSBundlerTest.java
@@ -35,7 +35,6 @@ import com.dynamo.bob.Progress;
 import com.dynamo.bob.ClassLoaderScanner;
 import com.dynamo.bob.Platform;
 import com.dynamo.bob.Project;
-import com.dynamo.bob.util.FileUtil;
 import com.dynamo.bob.archive.publisher.NullPublisher;
 import com.dynamo.bob.archive.publisher.PublisherSettings;
 import com.dynamo.bob.bundle.MacOSBundler;
@@ -127,7 +126,6 @@ public class MacOSBundlerTest {
 
     private String createFile(String root, String name, String content) throws IOException {
         File file = new File(root, name);
-        FileUtil.deleteOnExit(file);
         FileUtils.copyInputStreamToFile(new ByteArrayInputStream(content.getBytes()), file);
         return file.getAbsolutePath();
     }

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/bundle/test/MacOSBundlerTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/bundle/test/MacOSBundlerTest.java
@@ -80,8 +80,7 @@ public class MacOSBundlerTest {
     }
 
     void build() throws IOException, CompileExceptionError, MultipleCompileException {
-        try {
-            Project project = new Project(new DefaultFileSystem(), contentRoot, "build");
+        try (Project project = new Project(new DefaultFileSystem(), contentRoot, "build")) {
             project.setPublisher(new NullPublisher(new PublisherSettings()));
 
             ClassLoaderScanner scanner = new ClassLoaderScanner();

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/cache/test/ResourceCacheKeyTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/cache/test/ResourceCacheKeyTest.java
@@ -204,41 +204,42 @@ public class ResourceCacheKeyTest {
 	@Test
 	public void testAllParametersExist() throws IOException, CompileExceptionError, NoSuchFieldException, IllegalAccessException, NoSuchMethodException, InvocationTargetException {
 		// Initialize project
-		Project project = new Project(new DefaultFileSystem());
-		project.scanJavaClasses();
-		project.configurePreBuildProjectOptions();
+		try (Project project = new Project(new DefaultFileSystem())) {
+			project.scanJavaClasses();
+			project.configurePreBuildProjectOptions();
 
-		// Access private static field classToParamsDigest
-		Class<?> builderClass = Builder.class;
-		Field field = builderClass.getDeclaredField("classToParamsDigest");
-		field.setAccessible(true);
-		Map<Class<?>, byte[]> map = (Map<Class<?>, byte[]>) field.get(null);
+			// Access private static field classToParamsDigest
+			Class<?> builderClass = Builder.class;
+			Field field = builderClass.getDeclaredField("classToParamsDigest");
+			field.setAccessible(true);
+			Map<Class<?>, byte[]> map = (Map<Class<?>, byte[]>) field.get(null);
 
-		// Get all available command line options
-		List<Bob.CommandLineOption> commandLineOptions = Bob.getCommandLineOptions();
-		Set<String> allOptions = new HashSet<>();
+			// Get all available command line options
+			List<Bob.CommandLineOption> commandLineOptions = Bob.getCommandLineOptions();
+			Set<String> allOptions = new HashSet<>();
 
-		// Collect all long options
-		for (Bob.CommandLineOption option : commandLineOptions) {
-			allOptions.add(option.longOpt);
-		}
+			// Collect all long options
+			for (Bob.CommandLineOption option : commandLineOptions) {
+				allOptions.add(option.longOpt);
+			}
 
-		for (String key :project.getOptions().keySet()) {
-			allOptions.add(key);
-		}
+			for (String key :project.getOptions().keySet()) {
+				allOptions.add(key);
+			}
 
-		// Validate each parameter in classToParamsDigest
-		for (Class<?> klass : map.keySet()) {
-			String[] params = klass.getAnnotation(BuilderParams.class).paramsForSignature();
+			// Validate each parameter in classToParamsDigest
+			for (Class<?> klass : map.keySet()) {
+				String[] params = klass.getAnnotation(BuilderParams.class).paramsForSignature();
 
-			for (String param : params) {
-				if (!allOptions.contains(param)) {
-					if (param.equals("important_option"))
-					{
-						assertEquals(BuilderParams.class.toString(), "interface com.dynamo.bob.BuilderParams");
-					}
-					else {
-						Assert.fail("Class " + klass.getName() + " uses parameter '" + param + "' in classToParamsDigest, but it does not exist in the command line options.");
+				for (String param : params) {
+					if (!allOptions.contains(param)) {
+						if (param.equals("important_option"))
+						{
+							assertEquals(BuilderParams.class.toString(), "interface com.dynamo.bob.BuilderParams");
+						}
+						else {
+							Assert.fail("Class " + klass.getName() + " uses parameter '" + param + "' in classToParamsDigest, but it does not exist in the command line options.");
+						}
 					}
 				}
 			}
@@ -252,26 +253,26 @@ public class ResourceCacheKeyTest {
 	@Test
 	public void testNoNewParametersAdded() throws IOException, CompileExceptionError, NoSuchFieldException, IllegalAccessException {
 		// Initialize project
-		Project project = new Project(new DefaultFileSystem());
-		project.scanJavaClasses();
+		try (Project project = new Project(new DefaultFileSystem())) {
+			project.scanJavaClasses();
 
-		// Access private static field classToParamsDigest
-		Class<?> builderClass = Builder.class;
-		Field field = builderClass.getDeclaredField("classToParamsDigest");
-		field.setAccessible(true);
-		Map<Class<?>, byte[]> map = (Map<Class<?>, byte[]>) field.get(null);
+			// Access private static field classToParamsDigest
+			Class<?> builderClass = Builder.class;
+			Field field = builderClass.getDeclaredField("classToParamsDigest");
+			field.setAccessible(true);
+			Map<Class<?>, byte[]> map = (Map<Class<?>, byte[]>) field.get(null);
 
-		// Get all available command line options
-		List<Bob.CommandLineOption> commandLineOptions = Bob.getCommandLineOptions();
-		List<String> allOptions = new ArrayList<>();
+			// Get all available command line options
+			List<Bob.CommandLineOption> commandLineOptions = Bob.getCommandLineOptions();
+			List<String> allOptions = new ArrayList<>();
 
-		// Collect all long options
-		for (Bob.CommandLineOption option : commandLineOptions) {
-			allOptions.add(option.longOpt);
-		}
-		Collections.sort(allOptions);
+			// Collect all long options
+			for (Bob.CommandLineOption option : commandLineOptions) {
+				allOptions.add(option.longOpt);
+			}
+			Collections.sort(allOptions);
 
-		List<String> existentParameters = new ArrayList<>(List.of(new String[]{
+			List<String> existentParameters = new ArrayList<>(List.of(new String[]{
                 "architectures",
                 "archive",
                 "archive-resource-padding",
@@ -334,8 +335,9 @@ public class ResourceCacheKeyTest {
                 "with-sha1",
                 "with-symbols"}));
 
-		Collections.sort(existentParameters);
+			Collections.sort(existentParameters);
 
-		assertEquals("Lists are not equal!", existentParameters, allOptions);
+			assertEquals("Lists are not equal!", existentParameters, allOptions);
+		}
 	}
 }

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/JarTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/JarTest.java
@@ -127,22 +127,23 @@ public class JarTest {
     public void testNonJarBuild() throws Exception {
         IFileSystem fs = new DefaultFileSystem();
         String cwd = new File("test/proj").getAbsolutePath();
-        Project p = new Project(fs, cwd, "build/default");
-        p.setPublisher(new NullPublisher(new PublisherSettings()));
+        try (Project p = new Project(fs, cwd, "build/default")) {
+            p.setPublisher(new NullPublisher(new PublisherSettings()));
 
-        ClassLoaderScanner scanner = new ClassLoaderScanner();
-        p.scan(scanner, "com.dynamo.bob");
-        p.scan(scanner, "com.dynamo.bob.pipeline");
+            ClassLoaderScanner scanner = new ClassLoaderScanner();
+            p.scan(scanner, "com.dynamo.bob");
+            p.scan(scanner, "com.dynamo.bob.pipeline");
 
-        List<TaskResult> result = p.build(Progress.console(), "distclean", "build");
-        assertFalse(result.isEmpty());
-        boolean res = true;
-        for (TaskResult taskResult : result) {
-            if (!taskResult.isOk()) {
-                res = false;
-                break;
+            List<TaskResult> result = p.build(Progress.console(), "distclean", "build");
+            assertFalse(result.isEmpty());
+            boolean res = true;
+            for (TaskResult taskResult : result) {
+                if (!taskResult.isOk()) {
+                    res = false;
+                    break;
+                }
             }
+            assertTrue(res);
         }
-        assertTrue(res);
     }
 }

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/ShaderCompilePipelineTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/ShaderCompilePipelineTest.java
@@ -283,23 +283,27 @@ public class ShaderCompilePipelineTest {
         ArrayList<ShaderCompilePipeline.ShaderModuleDesc> shaderModuleDescs = toShaderDescs(vsShader, fsShader);
 
         ShaderCompilePipeline pipeline = new ShaderCompilePipeline("testCompareTypes");
-        ShaderCompilePipeline.createShaderPipeline(pipeline, shaderModuleDescs, new ShaderCompilePipeline.Options());
+        try {
+            ShaderCompilePipeline.createShaderPipeline(pipeline, shaderModuleDescs, new ShaderCompilePipeline.Options());
 
-        SPIRVReflector reflectorVs = pipeline.getReflectionData(ShaderDesc.ShaderType.SHADER_TYPE_VERTEX);
-        SPIRVReflector reflectorFs = pipeline.getReflectionData(ShaderDesc.ShaderType.SHADER_TYPE_FRAGMENT);
+            SPIRVReflector reflectorVs = pipeline.getReflectionData(ShaderDesc.ShaderType.SHADER_TYPE_VERTEX);
+            SPIRVReflector reflectorFs = pipeline.getReflectionData(ShaderDesc.ShaderType.SHADER_TYPE_FRAGMENT);
 
-        assertTrue(SPIRVReflector.AreResourceTypesEqual(reflectorVs, reflectorFs, "equal"));
-        assertFalse(SPIRVReflector.AreResourceTypesEqual(reflectorVs, reflectorFs, "not_equal"));
-        assertFalse(SPIRVReflector.AreResourceTypesEqual(reflectorVs, reflectorFs, "not_equal_two"));
+            assertTrue(SPIRVReflector.AreResourceTypesEqual(reflectorVs, reflectorFs, "equal"));
+            assertFalse(SPIRVReflector.AreResourceTypesEqual(reflectorVs, reflectorFs, "not_equal"));
+            assertFalse(SPIRVReflector.AreResourceTypesEqual(reflectorVs, reflectorFs, "not_equal_two"));
 
-        // The "equal" ubos should be merged, which means that it will only be part of the VS reflection and not the FS
-        Shaderc.ShaderResource equalUboA = getShaderResource(reflectorVs, "equal");
-        Shaderc.ShaderResource equalUboB = getShaderResource(reflectorFs, "equal");
-        assert equalUboA != null;
-        assert equalUboB == null;
+            // The "equal" ubos should be merged, which means that it will only be part of the VS reflection and not the FS
+            Shaderc.ShaderResource equalUboA = getShaderResource(reflectorVs, "equal");
+            Shaderc.ShaderResource equalUboB = getShaderResource(reflectorFs, "equal");
+            assert equalUboA != null;
+            assert equalUboB == null;
 
-        int combinedShaderStages = Shaderc.ShaderStage.SHADER_STAGE_VERTEX.getValue() + Shaderc.ShaderStage.SHADER_STAGE_FRAGMENT.getValue();
-        assertEquals(combinedShaderStages, equalUboA.stageFlags);
+            int combinedShaderStages = Shaderc.ShaderStage.SHADER_STAGE_VERTEX.getValue() + Shaderc.ShaderStage.SHADER_STAGE_FRAGMENT.getValue();
+            assertEquals(combinedShaderStages, equalUboA.stageFlags);
+        } finally {
+            ShaderCompilePipeline.destroyShaderPipeline(pipeline);
+        }
     }
 
     private Shaderc.ShaderResource getShaderResource(SPIRVReflector reflector, String name) {

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/graph/test/ResourceGraphTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/graph/test/ResourceGraphTest.java
@@ -32,10 +32,11 @@ public class ResourceGraphTest {
 
 
     private ResourceGraph resourceGraph;
+    private Project project;
 
 
     private ResourceGraph createResourceGraph() {
-        Project project = new Project(new DefaultFileSystem());
+        project = new Project(new DefaultFileSystem());
         ResourceGraph graph = new ResourceGraph(project);
 
         /*
@@ -89,7 +90,9 @@ public class ResourceGraphTest {
 
     @After
     public void tearDown() throws IOException {
-
+        if (project != null) {
+            project.dispose();
+        }
     }
 
 

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/BobProjectPropertiesTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/BobProjectPropertiesTest.java
@@ -21,7 +21,6 @@ import com.dynamo.bob.MultipleCompileException;
 import com.dynamo.bob.Project;
 import com.dynamo.bob.util.BobProjectProperties;
 import com.dynamo.bob.fs.DefaultFileSystem;
-import com.dynamo.bob.util.FileUtil;
 
 import java.nio.file.Files;
 import java.io.File;
@@ -119,7 +118,6 @@ public class BobProjectPropertiesTest {
 
     private String createFile(String root, String name, String content) throws IOException {
         File file = new File(root, name);
-        FileUtil.deleteOnExit(file);
         FileUtils.copyInputStreamToFile(new ByteArrayInputStream(content.getBytes()), file);
         return file.getAbsolutePath();
     }

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/BobProjectPropertiesTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/BobProjectPropertiesTest.java
@@ -95,11 +95,12 @@ public class BobProjectPropertiesTest {
         createFile(contentRoot, "extension1/ext.manifest", "name: Extension1\n");
         createFile(contentRoot, "extension1/"+BobProjectProperties.PROPERTIES_FILE, "[project]\ncustom_property.private = 1");
 
-        Project project = new Project(new DefaultFileSystem(), contentRoot, "build");
-        project.loadProjectFile(true);
-        BobProjectProperties properties = project.getProjectProperties();
+        try (Project project = new Project(new DefaultFileSystem(), contentRoot, "build")) {
+            project.loadProjectFile(true);
+            BobProjectProperties properties = project.getProjectProperties();
 
-        assertEquals(true, properties.isPrivate("project", "custom_property"));
+            assertEquals(true, properties.isPrivate("project", "custom_property"));
+        }
     }
 
     @Test
@@ -109,11 +110,12 @@ public class BobProjectPropertiesTest {
         createFile(contentRoot, "extension1/"+BobProjectProperties.PROPERTIES_FILE, "[project]\ncustom_property.private = 1");
         createFile(contentRoot, BobProjectProperties.PROPERTIES_PROJECT_FILE, "[project]\ncustom_property.private = 0");
 
-        Project project = new Project(new DefaultFileSystem(), contentRoot, "build");
-        project.loadProjectFile(true);
-        BobProjectProperties properties = project.getProjectProperties();
+        try (Project project = new Project(new DefaultFileSystem(), contentRoot, "build")) {
+            project.loadProjectFile(true);
+            BobProjectProperties properties = project.getProjectProperties();
 
-        assertEquals(false, properties.isPrivate("project", "custom_property"));
+            assertEquals(false, properties.isPrivate("project", "custom_property"));
+        }
     }
 
     private String createFile(String root, String name, String content) throws IOException {

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/BobTempDirectoryTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/BobTempDirectoryTest.java
@@ -32,9 +32,9 @@ import org.junit.rules.TemporaryFolder;
 
 import com.dynamo.bob.Project;
 import com.dynamo.bob.fs.DefaultFileSystem;
-import com.dynamo.bob.util.BobTempScope;
+import com.dynamo.bob.util.BobTempDirectory;
 
-public class BobTempScopeTest {
+public class BobTempDirectoryTest {
     private static final String KEEP_TEMP_PROPERTY = "defold.bob.keepTemp";
 
     private String previousKeepTempProperty;
@@ -57,57 +57,57 @@ public class BobTempScopeTest {
         }
     }
 
-    public static class UnclosedScopeProcess {
+    public static class UnclosedDirectoryProcess {
         public static void main(String[] args) throws Exception {
             System.setProperty(KEEP_TEMP_PROPERTY, "false");
-            BobTempScope scope = new BobTempScope();
-            File tempFile = scope.createTempFile("bob-temp-scope-shutdown-test", ".tmp");
+            BobTempDirectory directory = new BobTempDirectory();
+            File tempFile = directory.createTempFile("bob-temp-directory-shutdown-test", ".tmp");
 
             Files.write(tempFile.toPath(), "temp".getBytes(StandardCharsets.UTF_8));
-            Files.write(new File(args[0]).toPath(), scope.getRootDirectory().getAbsolutePath().getBytes(StandardCharsets.UTF_8));
+            Files.write(new File(args[0]).toPath(), directory.getRootDirectory().getAbsolutePath().getBytes(StandardCharsets.UTF_8));
         }
     }
 
     @Test
-    public void testCloseDeletesScopeDirectory() throws Exception {
-        // Creates a scoped temp file, directory, and nested file, then verifies close() removes the entire scope tree.
-        File scopeRoot;
+    public void testCloseDeletesTempDirectory() throws Exception {
+        // Creates a temp file, directory, and nested file, then verifies close() removes the entire temp tree.
+        File rootDirectory;
         File tempFile;
         File tempDirectory;
 
-        try (BobTempScope scope = new BobTempScope()) {
-            scopeRoot = scope.getRootDirectory();
-            tempFile = scope.createTempFile("bob-temp-scope-test", ".tmp");
-            tempDirectory = scope.createTempDirectory("bob-temp-scope-test-dir");
+        try (BobTempDirectory directory = new BobTempDirectory()) {
+            rootDirectory = directory.getRootDirectory();
+            tempFile = directory.createTempFile("bob-temp-directory-test", ".tmp");
+            tempDirectory = directory.createTempDirectory("bob-temp-directory-test-dir");
             File nestedFile = new File(tempDirectory, "nested.tmp");
 
             Files.write(tempFile.toPath(), "temp".getBytes(StandardCharsets.UTF_8));
             Files.write(nestedFile.toPath(), "nested".getBytes(StandardCharsets.UTF_8));
 
-            assertTrue(scopeRoot.isDirectory());
+            assertTrue(rootDirectory.isDirectory());
             assertTrue(tempFile.isFile());
             assertTrue(tempDirectory.isDirectory());
             assertTrue(nestedFile.isFile());
         }
 
-        assertFalse(scopeRoot.exists());
+        assertFalse(rootDirectory.exists());
         assertFalse(tempFile.exists());
         assertFalse(tempDirectory.exists());
     }
 
     @Test
-    public void testUnclosedScopeIsCleanedWhenJvmExits() throws Exception {
-        // Starts a child JVM that leaves a scope open, then verifies process shutdown removes the scope root.
-        File scopePathFile = temporaryFolder.newFile("unclosed-scope-root.txt");
-        assertTrue(scopePathFile.delete());
+    public void testUnclosedTempDirectoryIsCleanedWhenJvmExits() throws Exception {
+        // Starts a child JVM that leaves a temp directory open, then verifies process shutdown removes the root.
+        File rootPathFile = temporaryFolder.newFile("unclosed-temp-directory-root.txt");
+        assertTrue(rootPathFile.delete());
 
         String javaExecutable = new File(System.getProperty("java.home"), "bin/java").getAbsolutePath();
         Process process = new ProcessBuilder(
                 javaExecutable,
                 "-cp",
                 System.getProperty("java.class.path"),
-                UnclosedScopeProcess.class.getName(),
-                scopePathFile.getAbsolutePath())
+                UnclosedDirectoryProcess.class.getName(),
+                rootPathFile.getAbsolutePath())
                 .redirectErrorStream(true)
                 .start();
 
@@ -115,43 +115,43 @@ public class BobTempScopeTest {
         int exitCode = process.waitFor();
 
         assertEquals(processOutput, 0, exitCode);
-        File scopeRoot = new File(new String(Files.readAllBytes(scopePathFile.toPath()), StandardCharsets.UTF_8).trim());
-        assertFalse(scopeRoot.exists());
+        File rootDirectory = new File(new String(Files.readAllBytes(rootPathFile.toPath()), StandardCharsets.UTF_8).trim());
+        assertFalse(rootDirectory.exists());
     }
 
     @Test
     public void testClosePreventsFurtherTempCreation() throws Exception {
-        // Verifies a closed scope deletes its root and rejects any later temp-file creation with IOException.
-        BobTempScope scope = new BobTempScope();
-        scope.close();
+        // Verifies a closed temp directory deletes its root and rejects any later temp-file creation with IOException.
+        BobTempDirectory directory = new BobTempDirectory();
+        directory.close();
 
         try {
-            scope.createTempFile("bob-temp-scope-test", ".tmp");
+            directory.createTempFile("bob-temp-directory-test", ".tmp");
             fail("Expected temp file creation after close to fail");
         } catch (IOException expected) {
         }
 
-        assertFalse(scope.getRootDirectory().exists());
+        assertFalse(directory.getRootDirectory().exists());
     }
 
     @Test
-    public void testProjectDisposeClosesTempScope() throws Exception {
-        // Verifies Project.dispose() closes the attached scope and removes temps created through the Project API.
-        BobTempScope scope = new BobTempScope();
-        File scopeRoot = scope.getRootDirectory();
+    public void testProjectDisposeClosesTempDirectory() throws Exception {
+        // Verifies Project.dispose() closes the attached temp directory and removes temps created through the Project API.
+        BobTempDirectory directory = new BobTempDirectory();
+        File rootDirectory = directory.getRootDirectory();
         File projectRoot = temporaryFolder.newFolder("project");
-        Project project = new Project(getClass().getClassLoader(), new DefaultFileSystem(), projectRoot.getAbsolutePath(), "build/default", scope);
+        Project project = new Project(getClass().getClassLoader(), new DefaultFileSystem(), projectRoot.getAbsolutePath(), "build/default", directory);
 
-        File tempFile = project.createTempFile("project-temp-scope-test", ".tmp");
-        File tempDirectory = project.createTempDirectory("project-temp-scope-test-dir");
+        File tempFile = project.createTempFile("project-temp-directory-test", ".tmp");
+        File tempDirectory = project.createTempDirectory("project-temp-directory-test-dir");
 
-        assertTrue(scopeRoot.isDirectory());
+        assertTrue(rootDirectory.isDirectory());
         assertTrue(tempFile.isFile());
         assertTrue(tempDirectory.isDirectory());
 
         project.dispose();
 
-        assertFalse(scopeRoot.exists());
+        assertFalse(rootDirectory.exists());
         assertFalse(tempFile.exists());
         assertFalse(tempDirectory.exists());
     }

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/BobTempScopeTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/BobTempScopeTest.java
@@ -14,6 +14,7 @@
 
 package com.dynamo.bob.test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -56,6 +57,17 @@ public class BobTempScopeTest {
         }
     }
 
+    public static class UnclosedScopeProcess {
+        public static void main(String[] args) throws Exception {
+            System.setProperty(KEEP_TEMP_PROPERTY, "false");
+            BobTempScope scope = new BobTempScope();
+            File tempFile = scope.createTempFile("bob-temp-scope-shutdown-test", ".tmp");
+
+            Files.write(tempFile.toPath(), "temp".getBytes(StandardCharsets.UTF_8));
+            Files.write(new File(args[0]).toPath(), scope.getRootDirectory().getAbsolutePath().getBytes(StandardCharsets.UTF_8));
+        }
+    }
+
     @Test
     public void testCloseDeletesScopeDirectory() throws Exception {
         // Creates a scoped temp file, directory, and nested file, then verifies close() removes the entire scope tree.
@@ -81,6 +93,30 @@ public class BobTempScopeTest {
         assertFalse(scopeRoot.exists());
         assertFalse(tempFile.exists());
         assertFalse(tempDirectory.exists());
+    }
+
+    @Test
+    public void testUnclosedScopeIsCleanedWhenJvmExits() throws Exception {
+        // Starts a child JVM that leaves a scope open, then verifies process shutdown removes the scope root.
+        File scopePathFile = temporaryFolder.newFile("unclosed-scope-root.txt");
+        assertTrue(scopePathFile.delete());
+
+        String javaExecutable = new File(System.getProperty("java.home"), "bin/java").getAbsolutePath();
+        Process process = new ProcessBuilder(
+                javaExecutable,
+                "-cp",
+                System.getProperty("java.class.path"),
+                UnclosedScopeProcess.class.getName(),
+                scopePathFile.getAbsolutePath())
+                .redirectErrorStream(true)
+                .start();
+
+        String processOutput = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+        int exitCode = process.waitFor();
+
+        assertEquals(processOutput, 0, exitCode);
+        File scopeRoot = new File(new String(Files.readAllBytes(scopePathFile.toPath()), StandardCharsets.UTF_8).trim());
+        assertFalse(scopeRoot.exists());
     }
 
     @Test

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/BobTempScopeTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/BobTempScopeTest.java
@@ -1,0 +1,122 @@
+// Copyright 2020-2026 The Defold Foundation
+// Copyright 2014-2020 King
+// Copyright 2009-2014 Ragnar Svensson, Christian Murray
+// Licensed under the Defold License version 1.0 (the "License"); you may not use
+// this file except in compliance with the License.
+//
+// You may obtain a copy of the License, together with FAQs at
+// https://www.defold.com/license
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package com.dynamo.bob.test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import com.dynamo.bob.Project;
+import com.dynamo.bob.fs.DefaultFileSystem;
+import com.dynamo.bob.util.BobTempScope;
+
+public class BobTempScopeTest {
+    private static final String KEEP_TEMP_PROPERTY = "defold.bob.keepTemp";
+
+    private String previousKeepTempProperty;
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Before
+    public void setUp() {
+        previousKeepTempProperty = System.getProperty(KEEP_TEMP_PROPERTY);
+        System.setProperty(KEEP_TEMP_PROPERTY, "false");
+    }
+
+    @After
+    public void tearDown() {
+        if (previousKeepTempProperty == null) {
+            System.clearProperty(KEEP_TEMP_PROPERTY);
+        } else {
+            System.setProperty(KEEP_TEMP_PROPERTY, previousKeepTempProperty);
+        }
+    }
+
+    @Test
+    public void testCloseDeletesScopeDirectory() throws Exception {
+        // Bob invocation temp files should disappear when the per-invocation scope is closed.
+        File scopeRoot;
+        File tempFile;
+        File tempDirectory;
+
+        try (BobTempScope scope = new BobTempScope()) {
+            scopeRoot = scope.getRootDirectory();
+            tempFile = scope.createTempFile("bob-temp-scope-test", ".tmp");
+            tempDirectory = scope.createTempDirectory("bob-temp-scope-test-dir");
+            File nestedFile = new File(tempDirectory, "nested.tmp");
+
+            Files.write(tempFile.toPath(), "temp".getBytes(StandardCharsets.UTF_8));
+            Files.write(nestedFile.toPath(), "nested".getBytes(StandardCharsets.UTF_8));
+
+            assertTrue(scopeRoot.isDirectory());
+            assertTrue(tempFile.isFile());
+            assertTrue(tempDirectory.isDirectory());
+            assertTrue(nestedFile.isFile());
+        }
+
+        assertFalse(scopeRoot.exists());
+        assertFalse(tempFile.exists());
+        assertFalse(tempDirectory.exists());
+    }
+
+    @Test
+    public void testClosePreventsFurtherTempCreation() throws Exception {
+        // Closed scopes must fail fast so callers cannot leak files into a disposed invocation.
+        BobTempScope scope = new BobTempScope();
+        scope.close();
+
+        try {
+            scope.createTempFile("bob-temp-scope-test", ".tmp");
+            fail("Expected temp file creation after close to fail");
+        } catch (IOException expected) {
+        }
+
+        assertFalse(scope.getRootDirectory().exists());
+    }
+
+    @Test
+    public void testProjectDisposeClosesTempScope() throws Exception {
+        // Bob.invoke() disposes the project, so project disposal must also clean scoped temp files.
+        BobTempScope scope = new BobTempScope();
+        File scopeRoot = scope.getRootDirectory();
+        File projectRoot = temporaryFolder.newFolder("project");
+        Project project = new Project(getClass().getClassLoader(), new DefaultFileSystem(), projectRoot.getAbsolutePath(), "build/default", scope);
+
+        File tempFile = project.createTempFile("project-temp-scope-test", ".tmp");
+        File tempDirectory = project.createTempDirectory("project-temp-scope-test-dir");
+
+        assertTrue(scopeRoot.isDirectory());
+        assertTrue(tempFile.isFile());
+        assertTrue(tempDirectory.isDirectory());
+
+        project.dispose();
+
+        assertFalse(scopeRoot.exists());
+        assertFalse(tempFile.exists());
+        assertFalse(tempDirectory.exists());
+    }
+}

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/BobTempScopeTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/BobTempScopeTest.java
@@ -58,7 +58,7 @@ public class BobTempScopeTest {
 
     @Test
     public void testCloseDeletesScopeDirectory() throws Exception {
-        // Bob invocation temp files should disappear when the per-invocation scope is closed.
+        // Creates a scoped temp file, directory, and nested file, then verifies close() removes the entire scope tree.
         File scopeRoot;
         File tempFile;
         File tempDirectory;
@@ -85,7 +85,7 @@ public class BobTempScopeTest {
 
     @Test
     public void testClosePreventsFurtherTempCreation() throws Exception {
-        // Closed scopes must fail fast so callers cannot leak files into a disposed invocation.
+        // Verifies a closed scope deletes its root and rejects any later temp-file creation with IOException.
         BobTempScope scope = new BobTempScope();
         scope.close();
 
@@ -100,7 +100,7 @@ public class BobTempScopeTest {
 
     @Test
     public void testProjectDisposeClosesTempScope() throws Exception {
-        // Bob.invoke() disposes the project, so project disposal must also clean scoped temp files.
+        // Verifies Project.dispose() closes the attached scope and removes temps created through the Project API.
         BobTempScope scope = new BobTempScope();
         File scopeRoot = scope.getRootDirectory();
         File projectRoot = temporaryFolder.newFolder("project");

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/JBobTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/JBobTest.java
@@ -247,7 +247,7 @@ public class JBobTest {
             }
 
             try {
-                Bob.extractToFolder(zipPath.toUri().toURL(), targetDir.toFile(), false);
+                Bob.extractToFolder(zipPath.toUri().toURL(), targetDir.toFile());
                 fail("Expected IOException");
             } catch (IOException exception) {
                 assertTrue(exception.getMessage(), exception.getMessage().contains("resolves outside"));

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/ProjectBuildTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/ProjectBuildTest.java
@@ -82,24 +82,25 @@ public class ProjectBuildTest {
     }
 
     private void build(boolean archive, boolean publishLiveupdate) throws IOException, CompileExceptionError, MultipleCompileException {
-        Project project = new Project(new DefaultFileSystem(), contentRoot, "build");
-        project.setPublisher(new NullPublisher(new PublisherSettings()));
+        try (Project project = new Project(new DefaultFileSystem(), contentRoot, "build")) {
+            project.setPublisher(new NullPublisher(new PublisherSettings()));
 
-        ClassLoaderScanner scanner = new ClassLoaderScanner();
-        project.scan(scanner, "com.dynamo.bob");
-        project.scan(scanner, "com.dynamo.bob.pipeline");
+            ClassLoaderScanner scanner = new ClassLoaderScanner();
+            project.scan(scanner, "com.dynamo.bob");
+            project.scan(scanner, "com.dynamo.bob.pipeline");
 
-        if (archive) {
-            project.setOption("archive", "true");
-        }
-        if (publishLiveupdate) {
-            project.setOption("liveupdate", "true");
-        }
+            if (archive) {
+                project.setOption("archive", "true");
+            }
+            if (publishLiveupdate) {
+                project.setOption("liveupdate", "true");
+            }
 
-        // project.setOption("platform", Platform.X86Win32.getPair());
-        List<TaskResult> result = project.build(Progress.discarding(), "clean", "build");
-        for (TaskResult taskResult : result) {
-            assertTrue(taskResult.toString(), taskResult.isOk());
+            // project.setOption("platform", Platform.X86Win32.getPair());
+            List<TaskResult> result = project.build(Progress.discarding(), "clean", "build");
+            for (TaskResult taskResult : result) {
+                assertTrue(taskResult.toString(), taskResult.isOk());
+            }
         }
     }
 
@@ -251,8 +252,7 @@ public class ProjectBuildTest {
         createFile(contentRoot, "ignored-file.txt", "");
         createFile(contentRoot, "ignored-without-leading-slash.txt", "");
 
-        Project project = new Project(new DefaultFileSystem(), contentRoot, "build");
-        try {
+        try (Project project = new Project(new DefaultFileSystem(), contentRoot, "build")) {
             List<String> paths = new ArrayList<>();
             project.findResourcePaths("", paths);
             assertEquals(7, paths.size());
@@ -274,8 +274,6 @@ public class ProjectBuildTest {
             project.findResourceDirs("", dirs);
             assertEquals(2, dirs.size());
             assertEquals(new HashSet<>(Arrays.asList("sub", "visible")), new HashSet<>(dirs));
-        } finally {
-            project.dispose();
         }
     }
 

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/ProjectBuildTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/ProjectBuildTest.java
@@ -58,6 +58,21 @@ public class ProjectBuildTest {
     private String contentRoot;
     private String projectName = "Unnamed";
 
+    private static class CountingPublisher extends NullPublisher {
+        int startCount = 0;
+        int stopCount = 0;
+
+        @Override
+        public void start() throws CompileExceptionError {
+            startCount++;
+        }
+
+        @Override
+        public void stop() throws CompileExceptionError {
+            stopCount++;
+        }
+    }
+
     @Before
     public void setUp() throws Exception {
         projectName = "Unnamed";
@@ -346,6 +361,33 @@ public class ProjectBuildTest {
         assertTrue(hasResource(bundledManifestData, "/logic/level.collectionc"));
         assertTrue(hasResource(bundledManifestData, "/logic/level.goc"));
         assertTrue(hasResource(bundledManifestData, "/logic/level.scriptc"));
+    }
+
+    @Test
+    // Verifies archive builds start the publisher once, so stateful publishers do not leak or reset temp outputs.
+    public void testArchiveBuildStartsPublisherOnce() throws IOException, CompileExceptionError, MultipleCompileException {
+        createDefaultFiles();
+        CountingPublisher publisher = new CountingPublisher();
+
+        try (Project project = new Project(new DefaultFileSystem(), contentRoot, "build") {
+            @Override
+            public void createPublisher() throws CompileExceptionError {
+                setPublisher(publisher);
+            }
+        }) {
+            ClassLoaderScanner scanner = new ClassLoaderScanner();
+            project.scan(scanner, "com.dynamo.bob");
+            project.scan(scanner, "com.dynamo.bob.pipeline");
+            project.setOption("archive", "true");
+
+            List<TaskResult> result = project.build(Progress.discarding(), "clean", "build");
+            for (TaskResult taskResult : result) {
+                assertTrue(taskResult.toString(), taskResult.isOk());
+            }
+        }
+
+        assertEquals(1, publisher.startCount);
+        assertEquals(1, publisher.stopCount);
     }
 
     @Test

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/ProjectBuildTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/ProjectBuildTest.java
@@ -45,7 +45,6 @@ import com.dynamo.bob.ClassLoaderScanner;
 import com.dynamo.bob.Progress;
 import com.dynamo.bob.Project;
 import com.dynamo.bob.TaskResult;
-import com.dynamo.bob.util.FileUtil;
 import com.dynamo.bob.archive.publisher.NullPublisher;
 import com.dynamo.bob.archive.publisher.PublisherSettings;
 import com.dynamo.bob.fs.DefaultFileSystem;
@@ -476,7 +475,6 @@ public class ProjectBuildTest {
 
     private String createFile(String root, String name, String content) throws IOException {
         File file = new File(root, name);
-        FileUtil.deleteOnExit(file);
         FileUtils.copyInputStreamToFile(new ByteArrayInputStream(content.getBytes()), file);
         return file.getAbsolutePath();
     }

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/util/FontTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/util/FontTest.java
@@ -57,10 +57,6 @@ public class FontTest {
     @Rule
     public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
-    private File newTempFile(String prefix, String suffix) throws IOException {
-        return File.createTempFile(prefix, suffix, temporaryFolder.getRoot());
-    }
-
     private String copyResourceToDir(String tmpDir, String resName) throws IOException {
         String outputPath = Paths.get(tmpDir, resName).toString();
 
@@ -237,7 +233,7 @@ public class FontTest {
             .build();
 
         // temp output file
-        File outfile = newTempFile("glyph-bank-output", ".glyph_bankc");
+        File outfile = temporaryFolder.newFile("glyph-bank-output.glyph_bankc");
 
         // compile font
         Fontc fontc = new Fontc();
@@ -283,7 +279,7 @@ public class FontTest {
             .build();
 
         // temp output file
-        File outfile = newTempFile("glyph-bank-output", ".glyph_bankc");
+        File outfile = temporaryFolder.newFile("glyph-bank-output.glyph_bankc");
 
         // compile font
         Fontc fontc = new Fontc();
@@ -329,7 +325,7 @@ public class FontTest {
             .build();
 
         // temp output file
-        File outfile = newTempFile("glyph-bank-output", ".glyph_bankc");
+        File outfile = temporaryFolder.newFile("glyph-bank-output.glyph_bankc");
 
         // compile font
         Fontc fontc = new Fontc();
@@ -374,7 +370,7 @@ public class FontTest {
             .build();
 
         // temp output file
-        File outfile = newTempFile("glyph-bank-output", ".glyph_bankc");
+        File outfile = temporaryFolder.newFile("glyph-bank-output.glyph_bankc");
 
         // compile font
         Fontc fontc = new Fontc();
@@ -457,7 +453,7 @@ public class FontTest {
                 .setSize(24)
                 .build();
 
-        File outfile = newTempFile("font-output", ".fontc");
+        File outfile = temporaryFolder.newFile("font-output.fontc");
 
         // compile font
         boolean success = true;
@@ -504,7 +500,7 @@ public class FontTest {
             .build();
 
         // temp output file
-        File outfile = newTempFile("font-output", ".fontc");
+        File outfile = temporaryFolder.newFile("font-output.fontc");
 
         // compile font
         Fontc fontc = new Fontc();
@@ -546,7 +542,7 @@ public class FontTest {
             .build();
 
         // temp output file
-        File outfile = newTempFile("font-output", ".fontc");
+        File outfile = temporaryFolder.newFile("font-output.fontc");
 
         // compile font
         Fontc fontc = new Fontc();

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/util/FontTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/util/FontTest.java
@@ -30,14 +30,15 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
 
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import com.dynamo.bob.font.BMFont;
 import com.dynamo.bob.font.BMFont.BMFontFormatException;
@@ -45,7 +46,6 @@ import com.dynamo.bob.font.BMFont.ChannelData;
 import com.dynamo.bob.font.BMFont.Char;
 import com.dynamo.bob.font.Fontc;
 import com.dynamo.bob.font.Fontc.FontResourceResolver;
-import com.dynamo.bob.util.FileUtil;
 import com.dynamo.render.proto.Font.FontDesc;
 import com.dynamo.render.proto.Font.GlyphBank;
 import com.dynamo.render.proto.Font.GlyphBank.Glyph;
@@ -54,12 +54,18 @@ public class FontTest {
 
     private static final double EPSILON = 0.000001;
 
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    private File newTempFile(String prefix, String suffix) throws IOException {
+        return File.createTempFile(prefix, suffix, temporaryFolder.getRoot());
+    }
+
     private String copyResourceToDir(String tmpDir, String resName) throws IOException {
         String outputPath = Paths.get(tmpDir, resName).toString();
 
         InputStream inputStream = getClass().getResourceAsStream(resName);
         File outputFile = new File(outputPath);
-        FileUtil.deleteOnExit(outputFile);
         OutputStream outputStream = new FileOutputStream(outputFile);
         IOUtils.copy(inputStream, outputStream);
         inputStream.close();
@@ -231,8 +237,7 @@ public class FontTest {
             .build();
 
         // temp output file
-        File outfile = File.createTempFile("glyph-bank-output", ".glyph_bankc");
-        FileUtil.deleteOnExit(outfile);
+        File outfile = newTempFile("glyph-bank-output", ".glyph_bankc");
 
         // compile font
         Fontc fontc = new Fontc();
@@ -278,8 +283,7 @@ public class FontTest {
             .build();
 
         // temp output file
-        File outfile = File.createTempFile("glyph-bank-output", ".glyph_bankc");
-        FileUtil.deleteOnExit(outfile);
+        File outfile = newTempFile("glyph-bank-output", ".glyph_bankc");
 
         // compile font
         Fontc fontc = new Fontc();
@@ -325,8 +329,7 @@ public class FontTest {
             .build();
 
         // temp output file
-        File outfile = File.createTempFile("glyph-bank-output", ".glyph_bankc");
-        FileUtil.deleteOnExit(outfile);
+        File outfile = newTempFile("glyph-bank-output", ".glyph_bankc");
 
         // compile font
         Fontc fontc = new Fontc();
@@ -371,8 +374,7 @@ public class FontTest {
             .build();
 
         // temp output file
-        File outfile = File.createTempFile("glyph-bank-output", ".glyph_bankc");
-        FileUtil.deleteOnExit(outfile);
+        File outfile = newTempFile("glyph-bank-output", ".glyph_bankc");
 
         // compile font
         Fontc fontc = new Fontc();
@@ -455,8 +457,7 @@ public class FontTest {
                 .setSize(24)
                 .build();
 
-        File outfile = File.createTempFile("font-output", ".fontc");
-        FileUtil.deleteOnExit(outfile);
+        File outfile = newTempFile("font-output", ".fontc");
 
         // compile font
         boolean success = true;
@@ -491,8 +492,7 @@ public class FontTest {
     public void testFNT() throws Exception {
 
         // copy fnt and texture file
-        final Path tmpDir = Files.createTempDirectory("fnt-tmp");
-        FileUtil.deleteOnExit(tmpDir.toFile());
+        final Path tmpDir = temporaryFolder.newFolder("fnt-tmp").toPath();
         String tmpFnt = copyResourceToDir(tmpDir.toString(), "bmfont.fnt");
         copyResourceToDir(tmpDir.toString(), "bmfont.png");
 
@@ -504,8 +504,7 @@ public class FontTest {
             .build();
 
         // temp output file
-        File outfile = File.createTempFile("font-output", ".fontc");
-        FileUtil.deleteOnExit(outfile);
+        File outfile = newTempFile("font-output", ".fontc");
 
         // compile font
         Fontc fontc = new Fontc();
@@ -547,8 +546,7 @@ public class FontTest {
             .build();
 
         // temp output file
-        File outfile = File.createTempFile("font-output", ".fontc");
-        FileUtil.deleteOnExit(outfile);
+        File outfile = newTempFile("font-output", ".fontc");
 
         // compile font
         Fontc fontc = new Fontc();

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Bob.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Bob.java
@@ -22,7 +22,6 @@ import com.dynamo.bob.logging.Logger;
 import com.dynamo.bob.util.BobProjectProperties;
 import com.dynamo.bob.util.BobTempScope;
 import com.dynamo.bob.util.BuildInputDataCollector;
-import com.dynamo.bob.util.FileUtil;
 import com.dynamo.bob.util.Library;
 import com.dynamo.bob.util.Library.Result;
 import com.dynamo.bob.util.PackedResources;
@@ -182,7 +181,7 @@ public class Bob {
         return dstFile;
     }
 
-    public static void extractToFolder(final URL url, File toFolder, boolean deleteOnExit) throws IOException {
+    public static void extractToFolder(final URL url, File toFolder) throws IOException {
         TimeProfiler.start("extractToFolder %s", toFolder.toString());
         TimeProfiler.addData("url", url.toString());
         ZipInputStream zipStream = new ZipInputStream(new BufferedInputStream(url.openStream()));
@@ -194,8 +193,6 @@ public class Bob {
                 if (!entry.isDirectory()) {
 
                     File dstFile = resolveArchiveEntry(toFolder, entry.getName());
-                    if (deleteOnExit)
-                        FileUtil.deleteOnExit(dstFile);
                     dstFile.getParentFile().mkdirs();
 
                     OutputStream fileStream = null;
@@ -226,7 +223,7 @@ public class Bob {
     }
 
     public static void extract(final URL url, File toFolder) throws IOException {
-        extractToFolder(url, toFolder, true);
+        extractToFolder(url, toFolder);
     }
 
     public static void atomicExtractDirectory(final URL url, File toFolder, String directoryName) throws IOException {
@@ -238,7 +235,7 @@ public class Bob {
         toFolder.mkdirs();
         File tmpFolder = new File(toFolder, String.format(".%s_%d", directoryName, System.nanoTime()));
         try {
-            extractToFolder(url, tmpFolder, false);
+            extractToFolder(url, tmpFolder);
             File extracted = new File(tmpFolder, directoryName);
             if (!extracted.isDirectory()) {
                 throw new IOException(String.format("Archive '%s' did not contain directory '%s'", url, directoryName));

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Bob.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Bob.java
@@ -20,7 +20,7 @@ import com.dynamo.bob.fs.IResource;
 import com.dynamo.bob.logging.LogHelper;
 import com.dynamo.bob.logging.Logger;
 import com.dynamo.bob.util.BobProjectProperties;
-import com.dynamo.bob.util.BobTempScope;
+import com.dynamo.bob.util.BobTempDirectory;
 import com.dynamo.bob.util.BuildInputDataCollector;
 import com.dynamo.bob.util.Library;
 import com.dynamo.bob.util.Library.Result;
@@ -643,7 +643,7 @@ public class Bob {
     }
 
     private static Project createProject(ClassLoader classLoader, String rootDirectory, String buildDirectory, String email, String auth) throws IOException {
-        Project project = new Project(classLoader, new DefaultFileSystem(), rootDirectory, buildDirectory, new BobTempScope());
+        Project project = new Project(classLoader, new DefaultFileSystem(), rootDirectory, buildDirectory, new BobTempDirectory());
         project.setOption("email", email);
         project.setOption("auth", auth);
 

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Bob.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Bob.java
@@ -20,6 +20,7 @@ import com.dynamo.bob.fs.IResource;
 import com.dynamo.bob.logging.LogHelper;
 import com.dynamo.bob.logging.Logger;
 import com.dynamo.bob.util.BobProjectProperties;
+import com.dynamo.bob.util.BobTempScope;
 import com.dynamo.bob.util.BuildInputDataCollector;
 import com.dynamo.bob.util.FileUtil;
 import com.dynamo.bob.util.Library;
@@ -644,8 +645,8 @@ public class Bob {
         }
     }
 
-    private static Project createProject(ClassLoader classLoader, String rootDirectory, String buildDirectory, String email, String auth) {
-        Project project = new Project(classLoader, new DefaultFileSystem(), rootDirectory, buildDirectory);
+    private static Project createProject(ClassLoader classLoader, String rootDirectory, String buildDirectory, String email, String auth) throws IOException {
+        Project project = new Project(classLoader, new DefaultFileSystem(), rootDirectory, buildDirectory, new BobTempScope());
         project.setOption("email", email);
         project.setOption("auth", auth);
 
@@ -782,6 +783,7 @@ public class Bob {
                 TimeProfiler.init(reportFiles);
             }
 
+            Project project = null;
             try {
                 TimeProfiler.start("ParseCommandLine");
                 if (cmd.hasOption("debug") && cmd.hasOption("variant")) {
@@ -824,7 +826,7 @@ public class Bob {
 
                 String email = getOptionsValue(cmd, 'e', null);
                 String auth = getOptionsValue(cmd, 'u', null);
-                Project project = createProject(classLoader, rootDirectory, buildDirectory, email, auth);
+                project = createProject(classLoader, rootDirectory, buildDirectory, email, auth);
                 EngineArtifactsProvider.setCacheBase(new File(project.getBuildCachePath()));
 
                 if (cmd.hasOption("settings")) {
@@ -1030,9 +1032,11 @@ public class Bob {
                     System.out.println("\nThe build failed for the following reasons:");
                     System.out.println(errors);
                 }
-                project.dispose();
                 return new InvocationResult(ret, result);
             } finally {
+                if (project != null) {
+                    project.dispose();
+                }
                 TimeProfiler.createReport();
             }
         }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
@@ -136,7 +136,7 @@ public class Project {
     private HashMap<String, Task> tasks;
     private Set<String> circularDependencyChecker = new LinkedHashSet<>();
     private State state;
-    private BobTempScope tempScope;
+    private volatile BobTempScope tempScope;
     private String rootDirectory = ".";
     private String buildDirectory = "build";
     private Map<String, String> options = new HashMap<String, String>();
@@ -218,10 +218,17 @@ public class Project {
     }
 
     private BobTempScope getOrCreateTempScope() throws IOException {
-        if (this.tempScope == null) {
-            this.tempScope = new BobTempScope();
+        BobTempScope scope = this.tempScope;
+        if (scope == null) {
+            synchronized (this) {
+                scope = this.tempScope;
+                if (scope == null) {
+                    scope = new BobTempScope();
+                    this.tempScope = scope;
+                }
+            }
         }
-        return this.tempScope;
+        return scope;
     }
 
     public File createTempFile(String prefix, String suffix) throws IOException {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
@@ -52,7 +52,6 @@ import com.dynamo.bob.plugin.PluginScanner;
 import com.dynamo.bob.util.BobProjectProperties;
 import com.dynamo.bob.util.BobTempScope;
 import com.dynamo.bob.util.BuildInputDataCollector;
-import com.dynamo.bob.util.FileUtil;
 import com.dynamo.bob.util.Library;
 import com.dynamo.bob.util.MinifyPathCollector;
 import com.dynamo.bob.util.ReportGenerator;
@@ -218,22 +217,19 @@ public class Project {
         }
     }
 
-    public File createTempFile(String prefix, String suffix) throws IOException {
+    private BobTempScope getOrCreateTempScope() throws IOException {
         if (this.tempScope == null) {
-            File file = File.createTempFile(prefix, suffix);
-            FileUtil.deleteOnExit(file);
-            return file;
+            this.tempScope = new BobTempScope();
         }
-        return this.tempScope.createTempFile(prefix, suffix);
+        return this.tempScope;
+    }
+
+    public File createTempFile(String prefix, String suffix) throws IOException {
+        return getOrCreateTempScope().createTempFile(prefix, suffix);
     }
 
     public File createTempDirectory(String prefix) throws IOException {
-        if (this.tempScope == null) {
-            File directory = Files.createTempDirectory(prefix).toFile();
-            FileUtil.deleteOnExit(directory);
-            return directory;
-        }
-        return this.tempScope.createTempDirectory(prefix);
+        return getOrCreateTempScope().createTempDirectory(prefix);
     }
 
     public String getRootDirectory() {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
@@ -50,7 +50,9 @@ import com.dynamo.bob.pipeline.TextureGenerator;
 import com.dynamo.bob.plugin.IPlugin;
 import com.dynamo.bob.plugin.PluginScanner;
 import com.dynamo.bob.util.BobProjectProperties;
+import com.dynamo.bob.util.BobTempScope;
 import com.dynamo.bob.util.BuildInputDataCollector;
+import com.dynamo.bob.util.FileUtil;
 import com.dynamo.bob.util.Library;
 import com.dynamo.bob.util.MinifyPathCollector;
 import com.dynamo.bob.util.ReportGenerator;
@@ -135,6 +137,7 @@ public class Project {
     private HashMap<String, Task> tasks;
     private Set<String> circularDependencyChecker = new LinkedHashSet<>();
     private State state;
+    private BobTempScope tempScope;
     private String rootDirectory = ".";
     private String buildDirectory = "build";
     private Map<String, String> options = new HashMap<String, String>();
@@ -184,7 +187,12 @@ public class Project {
 
     // For the editor
     public Project(ClassLoader loader, IFileSystem fileSystem, String sourceRootDirectory, String buildDirectory) {
+        this(loader, fileSystem, sourceRootDirectory, buildDirectory, null);
+    }
+
+    public Project(ClassLoader loader, IFileSystem fileSystem, String sourceRootDirectory, String buildDirectory, BobTempScope tempScope) {
         this.classLoader = loader;
+        this.tempScope = tempScope;
         this.rootDirectory = normalizeNoEndSeparator(new File(sourceRootDirectory).getAbsolutePath(), true);
         this.buildDirectory = normalizeNoEndSeparator(buildDirectory, true);
         this.fileSystem = fileSystem;
@@ -200,7 +208,32 @@ public class Project {
     }
 
     public void dispose() {
-        this.fileSystem.close();
+        try {
+            this.fileSystem.close();
+        } finally {
+            if (this.tempScope != null) {
+                this.tempScope.close();
+                this.tempScope = null;
+            }
+        }
+    }
+
+    public File createTempFile(String prefix, String suffix) throws IOException {
+        if (this.tempScope == null) {
+            File file = File.createTempFile(prefix, suffix);
+            FileUtil.deleteOnExit(file);
+            return file;
+        }
+        return this.tempScope.createTempFile(prefix, suffix);
+    }
+
+    public File createTempDirectory(String prefix) throws IOException {
+        if (this.tempScope == null) {
+            File directory = Files.createTempDirectory(prefix).toFile();
+            FileUtil.deleteOnExit(directory);
+            return directory;
+        }
+        return this.tempScope.createTempDirectory(prefix);
     }
 
     public String getRootDirectory() {
@@ -560,7 +593,7 @@ public class Project {
                     if (PublisherSettings.PublishMode.Amazon.equals(settings.getMode())) {
                         this.publisher = new AWSPublisher(settings);
                     } else if (PublisherSettings.PublishMode.Zip.equals(settings.getMode())) {
-                        this.publisher = new ZipPublisher(getRootDirectory(), settings);
+                        this.publisher = new ZipPublisher(this, getRootDirectory(), settings);
                     } else if (PublisherSettings.PublishMode.Folder.equals(settings.getMode())) {
                         this.publisher = new FolderPublisher(getRootDirectory(), settings);
                     } else {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
@@ -111,7 +111,7 @@ import static org.apache.commons.io.FilenameUtils.normalizeNoEndSeparator;
  * @author Christian Murray
  *
  */
-public class Project {
+public class Project implements AutoCloseable {
 
     private static Logger logger = Logger.getLogger(Project.class.getName());
 
@@ -215,6 +215,11 @@ public class Project {
                 this.tempScope = null;
             }
         }
+    }
+
+    @Override
+    public void close() {
+        dispose();
     }
 
     private BobTempScope getOrCreateTempScope() throws IOException {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
@@ -50,7 +50,7 @@ import com.dynamo.bob.pipeline.TextureGenerator;
 import com.dynamo.bob.plugin.IPlugin;
 import com.dynamo.bob.plugin.PluginScanner;
 import com.dynamo.bob.util.BobProjectProperties;
-import com.dynamo.bob.util.BobTempScope;
+import com.dynamo.bob.util.BobTempDirectory;
 import com.dynamo.bob.util.BuildInputDataCollector;
 import com.dynamo.bob.util.Library;
 import com.dynamo.bob.util.MinifyPathCollector;
@@ -136,7 +136,7 @@ public class Project implements AutoCloseable {
     private HashMap<String, Task> tasks;
     private Set<String> circularDependencyChecker = new LinkedHashSet<>();
     private State state;
-    private volatile BobTempScope tempScope;
+    private volatile BobTempDirectory tempDirectory;
     private String rootDirectory = ".";
     private String buildDirectory = "build";
     private Map<String, String> options = new HashMap<String, String>();
@@ -189,9 +189,9 @@ public class Project implements AutoCloseable {
         this(loader, fileSystem, sourceRootDirectory, buildDirectory, null);
     }
 
-    public Project(ClassLoader loader, IFileSystem fileSystem, String sourceRootDirectory, String buildDirectory, BobTempScope tempScope) {
+    public Project(ClassLoader loader, IFileSystem fileSystem, String sourceRootDirectory, String buildDirectory, BobTempDirectory tempDirectory) {
         this.classLoader = loader;
-        this.tempScope = tempScope;
+        this.tempDirectory = tempDirectory;
         this.rootDirectory = normalizeNoEndSeparator(new File(sourceRootDirectory).getAbsolutePath(), true);
         this.buildDirectory = normalizeNoEndSeparator(buildDirectory, true);
         this.fileSystem = fileSystem;
@@ -210,9 +210,9 @@ public class Project implements AutoCloseable {
         try {
             this.fileSystem.close();
         } finally {
-            if (this.tempScope != null) {
-                this.tempScope.close();
-                this.tempScope = null;
+            if (this.tempDirectory != null) {
+                this.tempDirectory.close();
+                this.tempDirectory = null;
             }
         }
     }
@@ -222,26 +222,26 @@ public class Project implements AutoCloseable {
         dispose();
     }
 
-    private BobTempScope getOrCreateTempScope() throws IOException {
-        BobTempScope scope = this.tempScope;
-        if (scope == null) {
+    private BobTempDirectory getOrCreateTempDirectory() throws IOException {
+        BobTempDirectory directory = this.tempDirectory;
+        if (directory == null) {
             synchronized (this) {
-                scope = this.tempScope;
-                if (scope == null) {
-                    scope = new BobTempScope();
-                    this.tempScope = scope;
+                directory = this.tempDirectory;
+                if (directory == null) {
+                    directory = new BobTempDirectory();
+                    this.tempDirectory = directory;
                 }
             }
         }
-        return scope;
+        return directory;
     }
 
     public File createTempFile(String prefix, String suffix) throws IOException {
-        return getOrCreateTempScope().createTempFile(prefix, suffix);
+        return getOrCreateTempDirectory().createTempFile(prefix, suffix);
     }
 
     public File createTempDirectory(String prefix) throws IOException {
-        return getOrCreateTempScope().createTempDirectory(prefix);
+        return getOrCreateTempDirectory().createTempDirectory(prefix);
     }
 
     public String getRootDirectory() {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/archive/ArchiveBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/archive/ArchiveBuilder.java
@@ -445,90 +445,94 @@ public class ArchiveBuilder {
         manifestBuilder.setSignatureSignAlgorithm(SignAlgorithm.SIGN_RSA);
 
         Project project = new Project(new DefaultFileSystem());
-        // Keep builtins archives deterministic; parallel writes make .arcd offsets depend on thread scheduling.
-        project.setOption("max-cpu-threads", "1");
-        ResourceGraph resourceGraph = new ResourceGraph(project);
-        manifestBuilder.setResourceGraph(resourceGraph);
-
-        ResourceNode rootNode = resourceGraph.getRootNode();
-
-        List<String> excludedResources = new ArrayList<String>();
-
-        // set up publisher - has to be done before creating the ArchiveBuilder
-        PublisherSettings settings = new PublisherSettings();
-        settings.setZipFilepath(dirpathRoot.getAbsolutePath());
-        ZipPublisher publisher = new ZipPublisher(project, dirpathRoot.getAbsolutePath(), settings);
-        project.setPublisher(publisher);
-        publisher.setFilename(filepathZipArchive.getName());
-
-        int archivedEntries = 0;
-        String dirpathRootString = dirpathRoot.toString();
-        ArchiveBuilder archiveBuilder = new ArchiveBuilder(dirpathRoot.toString(), manifestBuilder, 4, project);
-        archiveBuilder.setForceCompression(doCompress);
-        for (File currentInput : inputs) {
-            String absolutePath = currentInput.getAbsolutePath();
-            boolean encrypt = ( absolutePath.endsWith("luac") ||
-                                absolutePath.endsWith("scriptc") ||
-                                absolutePath.endsWith("gui_scriptc") ||
-                                absolutePath.endsWith("render_scriptc"));
-            if (currentInput.getName().startsWith("liveupdate.")){
-                archiveBuilder.add(absolutePath, doCompress, encrypt, true);
-
-                String relativePath = currentInput.getAbsolutePath().substring(dirpathRootString.length());
-                relativePath = FilenameUtils.separatorsToUnix(relativePath);
-                excludedResources.add(relativePath);
-            } else {
-                archivedEntries++;
-                archiveBuilder.add(absolutePath, doCompress, encrypt, false);
-            }
-            ResourceNode currentNode = new ResourceNode(currentInput.getPath());
-            rootNode.addChild(currentNode);
-        }
-        System.out.println("Added " + Integer.toString(archivedEntries + excludedResources.size()) + " entries to archive (" + Integer.toString(excludedResources.size()) + " entries tagged as 'liveupdate' in archive).");
-
-        RandomAccessFile archiveIndex = new RandomAccessFile(filepathArchiveIndex, "rw");
-        RandomAccessFile archiveData  = new RandomAccessFile(filepathArchiveData, "rw");
-        archiveIndex.setLength(0);
-        archiveData.setLength(0);
-
-        publisher.start();
-        FileOutputStream outputStreamManifest = new FileOutputStream(filepathManifest);
         try {
-            System.out.println("Writing " + filepathArchiveIndex.getCanonicalPath());
-            System.out.println("Writing " + filepathArchiveData.getCanonicalPath());
+            // Keep builtins archives deterministic; parallel writes make .arcd offsets depend on thread scheduling.
+            project.setOption("max-cpu-threads", "1");
+            ResourceGraph resourceGraph = new ResourceGraph(project);
+            manifestBuilder.setResourceGraph(resourceGraph);
 
-            archiveBuilder.write(archiveIndex, archiveData, excludedResources);
+            ResourceNode rootNode = resourceGraph.getRootNode();
 
-            System.out.println("Writing " + filepathManifest.getCanonicalPath());
-            byte[] manifestFile = manifestBuilder.buildManifest();
-            outputStreamManifest.write(manifestFile);
+            List<String> excludedResources = new ArrayList<String>();
 
-            if (doOutputManifestHashFile) {
-                if (filepathManifestHash.exists()) {
-                    filepathManifestHash.delete();
-                    filepathManifestHash.createNewFile();
+            // set up publisher - has to be done before creating the ArchiveBuilder
+            PublisherSettings settings = new PublisherSettings();
+            settings.setZipFilepath(dirpathRoot.getAbsolutePath());
+            ZipPublisher publisher = new ZipPublisher(project, dirpathRoot.getAbsolutePath(), settings);
+            project.setPublisher(publisher);
+            publisher.setFilename(filepathZipArchive.getName());
+
+            int archivedEntries = 0;
+            String dirpathRootString = dirpathRoot.toString();
+            ArchiveBuilder archiveBuilder = new ArchiveBuilder(dirpathRoot.toString(), manifestBuilder, 4, project);
+            archiveBuilder.setForceCompression(doCompress);
+            for (File currentInput : inputs) {
+                String absolutePath = currentInput.getAbsolutePath();
+                boolean encrypt = ( absolutePath.endsWith("luac") ||
+                                    absolutePath.endsWith("scriptc") ||
+                                    absolutePath.endsWith("gui_scriptc") ||
+                                    absolutePath.endsWith("render_scriptc"));
+                if (currentInput.getName().startsWith("liveupdate.")){
+                    archiveBuilder.add(absolutePath, doCompress, encrypt, true);
+
+                    String relativePath = currentInput.getAbsolutePath().substring(dirpathRootString.length());
+                    relativePath = FilenameUtils.separatorsToUnix(relativePath);
+                    excludedResources.add(relativePath);
+                } else {
+                    archivedEntries++;
+                    archiveBuilder.add(absolutePath, doCompress, encrypt, false);
                 }
-                FileOutputStream manifestHashOutoutStream = new FileOutputStream(filepathManifestHash);
-                manifestHashOutoutStream.write(manifestBuilder.getManifestDataHash());
-                manifestHashOutoutStream.close();
+                ResourceNode currentNode = new ResourceNode(currentInput.getPath());
+                rootNode.addChild(currentNode);
             }
+            System.out.println("Added " + Integer.toString(archivedEntries + excludedResources.size()) + " entries to archive (" + Integer.toString(excludedResources.size()) + " entries tagged as 'liveupdate' in archive).");
 
-            String liveupdateManifestFilename = "liveupdate.game.dmanifest";
-            File luManifestFile = new File(dirpathRoot, liveupdateManifestFilename);
-            FileUtils.copyFile(filepathManifest, luManifestFile);
-            publisher.publish(new ArchiveEntry(dirpathRoot.getAbsolutePath(), luManifestFile.getAbsolutePath()), luManifestFile);
+            RandomAccessFile archiveIndex = new RandomAccessFile(filepathArchiveIndex, "rw");
+            RandomAccessFile archiveData  = new RandomAccessFile(filepathArchiveData, "rw");
+            archiveIndex.setLength(0);
+            archiveData.setLength(0);
 
-        } finally {
+            publisher.start();
+            FileOutputStream outputStreamManifest = new FileOutputStream(filepathManifest);
             try {
-                publisher.stop();
-                archiveIndex.close();
-                archiveData.close();
-                outputStreamManifest.close();
-            } catch (IOException exception) {
-                // Nothing to do, moving on ...
-            }
-        }
+                System.out.println("Writing " + filepathArchiveIndex.getCanonicalPath());
+                System.out.println("Writing " + filepathArchiveData.getCanonicalPath());
 
-        System.out.println("Done.");
+                archiveBuilder.write(archiveIndex, archiveData, excludedResources);
+
+                System.out.println("Writing " + filepathManifest.getCanonicalPath());
+                byte[] manifestFile = manifestBuilder.buildManifest();
+                outputStreamManifest.write(manifestFile);
+
+                if (doOutputManifestHashFile) {
+                    if (filepathManifestHash.exists()) {
+                        filepathManifestHash.delete();
+                        filepathManifestHash.createNewFile();
+                    }
+                    FileOutputStream manifestHashOutoutStream = new FileOutputStream(filepathManifestHash);
+                    manifestHashOutoutStream.write(manifestBuilder.getManifestDataHash());
+                    manifestHashOutoutStream.close();
+                }
+
+                String liveupdateManifestFilename = "liveupdate.game.dmanifest";
+                File luManifestFile = new File(dirpathRoot, liveupdateManifestFilename);
+                FileUtils.copyFile(filepathManifest, luManifestFile);
+                publisher.publish(new ArchiveEntry(dirpathRoot.getAbsolutePath(), luManifestFile.getAbsolutePath()), luManifestFile);
+
+            } finally {
+                try {
+                    publisher.stop();
+                    archiveIndex.close();
+                    archiveData.close();
+                    outputStreamManifest.close();
+                } catch (IOException exception) {
+                    // Nothing to do, moving on ...
+                }
+            }
+
+            System.out.println("Done.");
+        } finally {
+            project.dispose();
+        }
     }
 }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/archive/ArchiveBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/archive/ArchiveBuilder.java
@@ -444,8 +444,7 @@ public class ArchiveBuilder {
         manifestBuilder.setSignatureHashAlgorithm(HashAlgorithm.HASH_SHA256);
         manifestBuilder.setSignatureSignAlgorithm(SignAlgorithm.SIGN_RSA);
 
-        Project project = new Project(new DefaultFileSystem());
-        try {
+        try (Project project = new Project(new DefaultFileSystem())) {
             // Keep builtins archives deterministic; parallel writes make .arcd offsets depend on thread scheduling.
             project.setOption("max-cpu-threads", "1");
             ResourceGraph resourceGraph = new ResourceGraph(project);
@@ -531,8 +530,6 @@ public class ArchiveBuilder {
             }
 
             System.out.println("Done.");
-        } finally {
-            project.dispose();
         }
     }
 }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/archive/ArchiveBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/archive/ArchiveBuilder.java
@@ -457,7 +457,7 @@ public class ArchiveBuilder {
         // set up publisher - has to be done before creating the ArchiveBuilder
         PublisherSettings settings = new PublisherSettings();
         settings.setZipFilepath(dirpathRoot.getAbsolutePath());
-        ZipPublisher publisher = new ZipPublisher(dirpathRoot.getAbsolutePath(), settings);
+        ZipPublisher publisher = new ZipPublisher(project, dirpathRoot.getAbsolutePath(), settings);
         project.setPublisher(publisher);
         publisher.setFilename(filepathZipArchive.getName());
 

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/archive/publisher/ZipPublisher.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/archive/publisher/ZipPublisher.java
@@ -15,6 +15,7 @@
 package com.dynamo.bob.archive.publisher;
 
 import com.dynamo.bob.CompileExceptionError;
+import com.dynamo.bob.Project;
 import com.dynamo.bob.archive.ArchiveEntry;
 import com.dynamo.bob.logging.Logger;
 import org.apache.commons.io.IOUtils;
@@ -39,6 +40,7 @@ public class ZipPublisher extends Publisher {
     private File tempZipFile = null;
     private File destZipFile = null;
     private String projectRoot = null;
+    private Project project = null;
     private String filename = null;
     private ZipOutputStream zipOutputStream;
     private Set<String> zipEntries = ConcurrentHashMap.newKeySet();
@@ -46,6 +48,11 @@ public class ZipPublisher extends Publisher {
     public ZipPublisher(String projectRoot, PublisherSettings settings) {
         super(settings);
         this.projectRoot = projectRoot;
+    }
+
+    public ZipPublisher(Project project, String projectRoot, PublisherSettings settings) {
+        this(projectRoot, settings);
+        this.project = project;
     }
 
     public void setFilename(String filename)
@@ -61,7 +68,9 @@ public class ZipPublisher extends Publisher {
     public void start() throws CompileExceptionError {
         try {
             String tempFilePrefix = "defold.resourcepack_" + this.platform + "_";
-            this.tempZipFile = File.createTempFile(tempFilePrefix, ".zip");
+            this.tempZipFile = this.project == null
+                    ? File.createTempFile(tempFilePrefix, ".zip")
+                    : this.project.createTempFile(tempFilePrefix, ".zip");
 
             String destZipName = this.tempZipFile.getName();
             if (this.filename != null) {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/AndroidBundler.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/AndroidBundler.java
@@ -50,7 +50,6 @@ import com.dynamo.bob.pipeline.ExtenderUtil;
 import com.dynamo.bob.logging.Logger;
 import com.dynamo.bob.util.BobProjectProperties;
 import com.dynamo.bob.util.Exec;
-import com.dynamo.bob.util.FileUtil;
 import com.dynamo.bob.util.Exec.Result;
 import com.dynamo.bob.util.TimeProfiler;
 
@@ -334,7 +333,6 @@ public class AndroidBundler implements IBundler {
     */
     private File copyLocalResources(Project project, File outDir, BundleHelper helper, ICanceled canceled) throws IOException, CompileExceptionError {
         File androidResDir = createDir(outDir, "res");
-        FileUtil.deleteOnExit(androidResDir);
 
         File resDir = new File(androidResDir, "com.defold.android");
         resDir.mkdirs();
@@ -357,8 +355,7 @@ public class AndroidBundler implements IBundler {
         logger.info("Compiling resources from " + androidResDir.getAbsolutePath());
         try {
             // compile the resources using aapt2 to flat format files
-            File compiledResourcesDir = Files.createTempDirectory("compiled_resources").toFile();
-            FileUtil.deleteOnExit(compiledResourcesDir);
+            File compiledResourcesDir = project.createTempDirectory("compiled_resources");
 
             // compile the resources for each package
             for (File packageDir : androidResDir.listFiles(File::isDirectory)) {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/BundleHelper.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/BundleHelper.java
@@ -64,7 +64,6 @@ import com.dynamo.bob.fs.IResource;
 import com.dynamo.bob.pipeline.ExtenderUtil;
 import com.dynamo.bob.pipeline.ExtenderUtil.FileExtenderResource;
 import com.dynamo.bob.util.BobProjectProperties;
-import com.dynamo.bob.util.FileUtil;
 import com.dynamo.bob.util.Exec;
 import com.dynamo.bob.util.Exec.Result;
 import com.dynamo.bob.logging.Logger;
@@ -452,7 +451,7 @@ public class BundleHelper {
                 largestIcon = resource;
             }
         }
-        File largestIconFile = File.createTempFile("temp", "default_icon.png");
+        File largestIconFile = project.createTempFile("temp", "default_icon.png");
 
         if (largestIcon != null) {
             IResource largestIconRes = project.getResource(largestIcon);
@@ -535,10 +534,10 @@ public class BundleHelper {
         return new ArrayList<String>(Arrays.asList(line.split("\\s*,\\s*")));
     }
 
-    public static File copyResourceToTempFile(String resourcePath) throws IOException
+    public static File copyResourceToTempFile(Project project, String resourcePath) throws IOException
     {
         String filename = FilenameUtils.getName(resourcePath);
-        File file = File.createTempFile("temp", filename);
+        File file = project.createTempFile("temp", filename);
         URL url = BundleHelper.class.getResource(resourcePath);
         FileUtils.writeByteArrayToFile(file, IOUtils.toByteArray(url));
         return file;
@@ -805,8 +804,7 @@ public class BundleHelper {
         File zipFile = null;
 
         try {
-            zipFile = File.createTempFile("build_" + sdkVersion, ".zip");
-            FileUtil.deleteOnExit(zipFile);
+            zipFile = project.createTempFile("build_" + sdkVersion, ".zip");
         } catch (IOException e) {
             throw new CompileExceptionError("Failed to create temp zip file", e.getCause());
         }
@@ -1051,7 +1049,7 @@ public class BundleHelper {
                 });
     }
 
-    public static void createFatLibrary(List<Platform> architectures, String projectOutputDir, File targetDir, ICanceled canceled) throws IOException {
+    public static void createFatLibrary(Project project, List<Platform> architectures, String projectOutputDir, File targetDir, ICanceled canceled) throws IOException {
         Set<String> copiedFileNames = new HashSet<>();
         for (int i = 0; i < architectures.size(); ++i) {
             Platform arch = architectures.get(i);
@@ -1087,8 +1085,7 @@ public class BundleHelper {
                         // Create fat/universal binary
                         try {
                             if (allLibs.size() > 1) {
-                                File dynamicLib = File.createTempFile(libraryName, "");
-                                FileUtil.deleteOnExit(dynamicLib);
+                                File dynamicLib = project.createTempFile(libraryName, "");
                                 BundleHelper.throwIfCanceled(canceled);
                                 lipoBinaries(dynamicLib, allLibs);
 

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/IOSBundler.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/IOSBundler.java
@@ -52,7 +52,6 @@ import com.dynamo.bob.logging.Logger;
 import com.dynamo.bob.util.BobProjectProperties;
 import com.dynamo.bob.util.Exec;
 import com.dynamo.bob.util.Exec.Result;
-import com.dynamo.bob.util.FileUtil;
 
 @BundlerParams(platforms = {"arm64-ios", "x86_64-ios"})
 public class IOSBundler implements IBundler {
@@ -77,22 +76,8 @@ public class IOSBundler implements IBundler {
         }
     }
 
-    private static File createTempDirectory() throws IOException {
-        final File temp;
-
-        temp = File.createTempFile("temp_defold_", Long.toString(System.nanoTime()));
-
-        if(!(temp.delete()))
-        {
-            throw new IOException("Could not delete temp file: " + temp.getAbsolutePath());
-        }
-
-        if(!(temp.mkdir()))
-        {
-            throw new IOException("Could not create temp directory: " + temp.getAbsolutePath());
-        }
-
-        return (temp);
+    private static File createTempDirectory(Project project) throws IOException {
+        return project.createTempDirectory("temp_defold_");
     }
 
     public static List<File> getBinariesFromArchitectures(Project project, List<Platform> architectures, String variant) throws IOException {
@@ -399,8 +384,7 @@ public class IOSBundler implements IBundler {
 
         BundleHelper.throwIfCanceled(canceled);
         // Create fat/universal binary
-        File exe = File.createTempFile("dmengine", "");
-        FileUtil.deleteOnExit(exe);
+        File exe = project.createTempFile("dmengine", "");
 
         BundleHelper.throwIfCanceled(canceled);
 
@@ -428,7 +412,7 @@ public class IOSBundler implements IBundler {
             File binaryDir = new File(FilenameUtils.concat(project.getBinaryOutputDirectory(), platform.getExtenderPair()));
             BundleHelper.copySharedLibraries(platform, binaryDir, appDir);
         } else {
-            BundleHelper.createFatLibrary(architectures, project.getBinaryOutputDirectory(), appDir, canceled);
+            BundleHelper.createFatLibrary(project, architectures, project.getBinaryOutputDirectory(), appDir, canceled);
         }
 
         // Copy extension frameworks
@@ -479,8 +463,7 @@ public class IOSBundler implements IBundler {
         BundleHelper.throwIfCanceled(canceled);
 
         // Package zip file
-        File tmpZipDir = createTempDirectory();
-        FileUtil.deleteOnExit(tmpZipDir);
+        File tmpZipDir = createTempDirectory(project);
         File swiftSupportDir = new File(tmpZipDir, "SwiftSupport");
 
         // Copy any libswift*.dylib files from the Frameworks folder
@@ -516,15 +499,14 @@ public class IOSBundler implements IBundler {
             // Copy Provisioning Profile
             FileUtils.copyFile(new File(provisioningProfile), new File(appDir, "embedded.mobileprovision"));
 
-            File textProvisionFile = File.createTempFile("mobileprovision", ".plist");
-            FileUtil.deleteOnExit(textProvisionFile);
+            File textProvisionFile = project.createTempFile("mobileprovision", ".plist");
 
             Result securityResult = Exec.execResult("security", "cms", "-D", "-i", provisioningProfile, "-o", textProvisionFile.getAbsolutePath());
             if (securityResult.ret != 0) {
                 logger.severe("Error executing security command:\n" + new String(securityResult.stdOutErr));
             }
 
-            File entitlementOut = File.createTempFile("entitlement", ".xcent");
+            File entitlementOut = project.createTempFile("entitlement", ".xcent");
             String customEntitlementsProperty = projectProperties.getStringValue("ios", "entitlements");
             Boolean overrideEntitlementsProperty = projectProperties.getBooleanValue("ios", "override_entitlements", false);
 
@@ -591,7 +573,6 @@ public class IOSBundler implements IBundler {
                     entitlements.initFileLocator(locator);
                     entitlements.write(writer);
                     writer.close();
-                    FileUtil.deleteOnExit(entitlementOut);
                 }
                 catch (ConfigurationException e) {
                     logger.severe("Error reading provisioning profile '" + provisioningProfile + "'. Make sure this is a valid provisioning profile file." );

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/MacOSBundler.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/MacOSBundler.java
@@ -29,7 +29,6 @@ import com.dynamo.bob.fs.IResource;
 import com.dynamo.bob.pipeline.ExtenderUtil;
 import com.dynamo.bob.logging.Logger;
 import com.dynamo.bob.util.BobProjectProperties;
-import com.dynamo.bob.util.FileUtil;
 import com.dynamo.bob.util.Exec;
 import com.dynamo.bob.util.Exec.Result;
 import org.apache.commons.io.FilenameUtils;
@@ -153,8 +152,7 @@ public class MacOSBundler implements IBundler {
         copyIcon(projectProperties, new File(project.getRootDirectory()), resourcesDir);
 
         // Create fat/universal binary
-        File exe = File.createTempFile("dmengine", "");
-        FileUtil.deleteOnExit(exe);
+        File exe = project.createTempFile("dmengine", "");
 
         BundleHelper.throwIfCanceled(canceled);
 
@@ -177,7 +175,7 @@ public class MacOSBundler implements IBundler {
             File binaryDir = new File(FilenameUtils.concat(project.getBinaryOutputDirectory(), platform.getExtenderPair()));
             BundleHelper.copySharedLibraries(platform, binaryDir, macosDir);
         } else {
-            BundleHelper.createFatLibrary(architectures, project.getBinaryOutputDirectory(), macosDir, canceled);
+            BundleHelper.createFatLibrary(project, architectures, project.getBinaryOutputDirectory(), macosDir, canceled);
         }
 
         // Copy debug symbols
@@ -202,7 +200,7 @@ public class MacOSBundler implements IBundler {
         if (variant.equals(Bob.VARIANT_DEBUG))
         {
             logger.info("Adding debug entitlements");
-            File entitlementsFile = BundleHelper.copyResourceToTempFile("resources/macos/entitlements-debug.plist");
+            File entitlementsFile = BundleHelper.copyResourceToTempFile(project, "resources/macos/entitlements-debug.plist");
             Result r = Exec.execResult("codesign", "-f", "-s", "-", "--entitlements", entitlementsFile.getAbsolutePath(), appDir.getAbsolutePath());
             if (r.ret != 0) {
                 throw new IOException(new String(r.stdOutErr));

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/GameProjectBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/GameProjectBuilder.java
@@ -345,7 +345,6 @@ public class GameProjectBuilder extends Builder {
                 RandomAccessFile archiveData = createRandomAccessFile(archiveDataHandle);
 
                 // create the archive and manifest
-                project.getPublisher().start();
                 ManifestBuilder manifestBuilder = createManifestBuilder(resourceGraph);
                 ArchiveBuilder archiveBuilder = new ArchiveBuilder(root, manifestBuilder, getResourcePadding(), project);
                 createArchive(archiveBuilder, resources, archiveIndex, archiveData, excludedResources);

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/GameProjectBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/GameProjectBuilder.java
@@ -50,7 +50,6 @@ import com.dynamo.bob.archive.ManifestBuilder;
 import com.dynamo.bob.archive.publisher.Publisher;
 import com.dynamo.bob.bundle.BundleHelper;
 import com.dynamo.bob.fs.IResource;
-import com.dynamo.bob.util.FileUtil;
 import com.dynamo.bob.logging.Logger;
 import com.dynamo.bob.pipeline.graph.ResourceGraph;
 import com.dynamo.bob.util.BobProjectProperties;
@@ -86,7 +85,6 @@ public class GameProjectBuilder extends Builder {
     private static final Logger logger = Logger.getLogger(GameProjectBuilder.class.getName());
 
     private RandomAccessFile createRandomAccessFile(File handle) throws IOException {
-        FileUtil.deleteOnExit(handle);
         RandomAccessFile file = new RandomAccessFile(handle, "rw");
         file.setLength(0);
         return file;
@@ -341,9 +339,9 @@ public class GameProjectBuilder extends Builder {
                 // Create output for the data archive
                 String platform = project.option("platform", "generic");
                 project.getPublisher().setPlatform(platform);
-                File archiveIndexHandle = File.createTempFile("defold.index_", ".arci");
+                File archiveIndexHandle = project.createTempFile("defold.index_", ".arci");
                 RandomAccessFile archiveIndex = createRandomAccessFile(archiveIndexHandle);
-                File archiveDataHandle = File.createTempFile("defold.data_", ".arcd");
+                File archiveDataHandle = project.createTempFile("defold.data_", ".arcd");
                 RandomAccessFile archiveData = createRandomAccessFile(archiveDataHandle);
 
                 // create the archive and manifest

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/LuaBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/LuaBuilder.java
@@ -293,8 +293,8 @@ public abstract class LuaBuilder extends Builder {
 
     /* We currently prefer source code over plain lua byte code due to the smaller size
     public byte[] constructLuaBytecode(Task task, String luacExe, String source) throws IOException, CompileExceptionError {
-        File outputFile = File.createTempFile("script", ".raw");
-        File inputFile = File.createTempFile("script", ".lua");
+        File outputFile = project.createTempFile("script", ".raw");
+        File inputFile = project.createTempFile("script", ".lua");
 
         List<String> options = new ArrayList<String>();
         options.add(Bob.getExe(Platform.getHostPlatform(), luacExe));
@@ -349,8 +349,8 @@ public abstract class LuaBuilder extends Builder {
 
     public byte[] constructLuaJITBytecode(Task task, String source, boolean gen32bit) throws IOException, CompileExceptionError {
 
-        File outputFile = File.createTempFile("script", ".raw");
-        File inputFile = File.createTempFile("script", ".lua");
+        File outputFile = project.createTempFile("script", ".raw");
+        File inputFile = project.createTempFile("script", ".lua");
 
         // -b = generate bytecode
         // 

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/OggBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/OggBuilder.java
@@ -53,7 +53,7 @@ public class OggBuilder extends CopyBuilder{
         } else {
             File tmpOggFile = null;
             try {
-                tmpOggFile = File.createTempFile("ogg_tmp", null, Bob.getRootFolder());
+                tmpOggFile = project.createTempFile("ogg_tmp", null);
                 BufferedOutputStream os = new BufferedOutputStream(new FileOutputStream(tmpOggFile));
                 try {
                     os.write(task.firstInput().getContent());

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/OpusBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/OpusBuilder.java
@@ -49,7 +49,7 @@ public class OpusBuilder extends CopyBuilder{
 
         File tmpOggFile = null;
         try {
-            tmpOggFile = File.createTempFile("ogg_tmp", null, Bob.getRootFolder());
+            tmpOggFile = project.createTempFile("ogg_tmp", null);
             BufferedOutputStream os = new BufferedOutputStream(new FileOutputStream(tmpOggFile));
             try {
                 os.write(input.getContent());

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderCompilers.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderCompilers.java
@@ -223,63 +223,68 @@ public class ShaderCompilers {
                 opts.splitTextureSamplers |= shaderLanguageRequiresSplitTextureSamplers(shaderLanguage);
             }
 
-            ShaderCompilePipeline pipeline = ShaderProgramBuilder.newShaderPipeline(resourceOutputPath, shaderModules, opts);
-            ArrayList<ShaderProgramBuilder.ShaderBuildResult> shaderBuildResults = new ArrayList<>();
+            ShaderCompilePipeline pipeline = null;
+            try {
+                pipeline = ShaderProgramBuilder.newShaderPipeline(resourceOutputPath, shaderModules, opts);
+                ArrayList<ShaderProgramBuilder.ShaderBuildResult> shaderBuildResults = new ArrayList<>();
 
-            HashMap<ShaderDesc.ShaderType, Boolean> shaderTypeKeys = new HashMap<>();
-            Shaderc.HLSLRootSignature hlslRootSignature = null;
+                HashMap<ShaderDesc.ShaderType, Boolean> shaderTypeKeys = new HashMap<>();
+                Shaderc.HLSLRootSignature hlslRootSignature = null;
 
-            for (ShaderDesc.Language shaderLanguage : shaderLanguages) {
+                for (ShaderDesc.Language shaderLanguage : shaderLanguages) {
 
-                boolean arrayTextureFallbackRequired = ShaderUtil.VariantTextureArrayFallback.isRequired(shaderLanguage);
+                    boolean arrayTextureFallbackRequired = ShaderUtil.VariantTextureArrayFallback.isRequired(shaderLanguage);
 
-                boolean create_hlsl_root_signature = shaderLanguage == ShaderDesc.Language.LANGUAGE_HLSL_51;
-                List<Shaderc.ShaderCompileResult> compiled_shaders = new ArrayList<>();
+                    boolean create_hlsl_root_signature = shaderLanguage == ShaderDesc.Language.LANGUAGE_HLSL_51;
+                    List<Shaderc.ShaderCompileResult> compiled_shaders = new ArrayList<>();
 
-                for (ShaderCompilePipeline.ShaderModuleDesc shaderModule : shaderModules) {
+                    for (ShaderCompilePipeline.ShaderModuleDesc shaderModule : shaderModules) {
 
-                    boolean variantTextureArray = false;
-                    Shaderc.ShaderCompileResult crossCompileResult = pipeline.crossCompile(shaderModule.type, shaderLanguage);
+                        boolean variantTextureArray = false;
+                        Shaderc.ShaderCompileResult crossCompileResult = pipeline.crossCompile(shaderModule.type, shaderLanguage);
 
-                    if (!shaderTypeKeys.containsKey(shaderModule.type)) {
-                        shaderTypeKeys.put(shaderModule.type, true);
-                    }
-
-                    if (arrayTextureFallbackRequired) {
-                        ShaderUtil.Common.GLSLCompileResult variantCompileResult = ShaderUtil.VariantTextureArrayFallback.transform(new String(crossCompileResult.data), compileOptions.maxPageCount);
-                        if (variantCompileResult != null && variantCompileResult.arraySamplers.length > 0) {
-                            crossCompileResult.data = variantCompileResult.source.getBytes();
-                            variantTextureArray = true;
+                        if (!shaderTypeKeys.containsKey(shaderModule.type)) {
+                            shaderTypeKeys.put(shaderModule.type, true);
                         }
+
+                        if (arrayTextureFallbackRequired) {
+                            ShaderUtil.Common.GLSLCompileResult variantCompileResult = ShaderUtil.VariantTextureArrayFallback.transform(new String(crossCompileResult.data), compileOptions.maxPageCount);
+                            if (variantCompileResult != null && variantCompileResult.arraySamplers.length > 0) {
+                                crossCompileResult.data = variantCompileResult.source.getBytes();
+                                variantTextureArray = true;
+                            }
+                        }
+
+                        ShaderDesc.Shader.Builder builder = ShaderProgramBuilder.makeShaderBuilder(crossCompileResult, shaderLanguage, shaderModule.type);
+                        shaderBuildResults.add(new ShaderProgramBuilder.ShaderBuildResult(builder));
+
+                        if (variantTextureArray) {
+                            builder.setVariantTextureArray(true);
+                        }
+
+                        compiled_shaders.add(crossCompileResult);
                     }
 
-                    ShaderDesc.Shader.Builder builder = ShaderProgramBuilder.makeShaderBuilder(crossCompileResult, shaderLanguage, shaderModule.type);
-                    shaderBuildResults.add(new ShaderProgramBuilder.ShaderBuildResult(builder));
-
-                    if (variantTextureArray) {
-                        builder.setVariantTextureArray(true);
+                    if (create_hlsl_root_signature) {
+                        hlslRootSignature = pipeline.createRootSignature(shaderLanguage, compiled_shaders);
                     }
-
-                    compiled_shaders.add(crossCompileResult);
                 }
 
-                if (create_hlsl_root_signature) {
-                    hlslRootSignature = pipeline.createRootSignature(shaderLanguage, compiled_shaders);
+                ShaderProgramBuilder.ShaderCompileResult compileResult = new ShaderProgramBuilder.ShaderCompileResult();
+                compileResult.shaderBuildResults = shaderBuildResults;
+
+                for(ShaderDesc.ShaderType type : shaderTypeKeys.keySet()) {
+                    compileResult.reflectors.add(pipeline.getReflectionData(type));
+                }
+
+                compileResult.hlslRootSignature = hlslRootSignature != null ? hlslRootSignature.hLSLRootSignature : null;
+
+                return compileResult;
+            } finally {
+                if (pipeline != null) {
+                    ShaderCompilePipeline.destroyShaderPipeline(pipeline);
                 }
             }
-
-            ShaderProgramBuilder.ShaderCompileResult compileResult = new ShaderProgramBuilder.ShaderCompileResult();
-            compileResult.shaderBuildResults = shaderBuildResults;
-
-            for(ShaderDesc.ShaderType type : shaderTypeKeys.keySet()) {
-                compileResult.reflectors.add(pipeline.getReflectionData(type));
-            }
-
-            compileResult.hlslRootSignature = hlslRootSignature != null ? hlslRootSignature.hLSLRootSignature : null;
-
-            ShaderCompilePipeline.destroyShaderPipeline(pipeline);
-
-            return compileResult;
         }
     }
 

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderProgramBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderProgramBuilder.java
@@ -589,68 +589,69 @@ public class ShaderProgramBuilder extends Builder {
         System.setProperty("java.awt.headless", "true");
         ShaderProgramBuilder builder = new ShaderProgramBuilder();
 
-        Project project = new Project(new DefaultFileSystem());
-        project.scanJavaClasses();
-        builder.setProject(project);
+        try (Project project = new Project(new DefaultFileSystem())) {
+            project.scanJavaClasses();
+            builder.setProject(project);
 
-        if (args.length < 3) {
-            System.err.println("Unable to build shader - no platform passed in.%n");
-            return;
-        }
-
-        ArrayList<ShaderCompilePipeline.ShaderModuleDesc> modules = new ArrayList<>();
-
-        String outputPath, platform, contentRoot;
-
-        if (args.length == 4) {
-            outputPath   = args[1];
-            platform     = args[2];
-            contentRoot  = args[3];
-            modules.add(GetShaderDesc(project, args[0], contentRoot));
-        } else {
-            outputPath   = args[2];
-            platform     = args[3];
-            contentRoot  = args[4];
-            modules.add(GetShaderDesc(project, args[0], contentRoot));
-            modules.add(GetShaderDesc(project, args[1], contentRoot));
-        }
-
-        assert platform != null;
-        Platform outputPlatform = Platform.get(platform);
-        IShaderCompiler shaderCompiler = project.getShaderCompiler(outputPlatform);
-        if (shaderCompiler == null) {
-            System.err.printf("Unable to build shader - no shader compiler found.%n");
-            return;
-        }
-
-        try (BufferedOutputStream os = new BufferedOutputStream(new FileOutputStream(outputPath))) {
-
-            IShaderCompiler.CompileOptions compileOptions = new IShaderCompiler.CompileOptions();
-            compileOptions.forceIncludeShaderLanguages.add(ShaderDesc.Language.LANGUAGE_GLSL_SM120);
-            compileOptions.forceIncludeShaderLanguages.add(ShaderDesc.Language.LANGUAGE_GLSL_SM330);
-            compileOptions.forceIncludeShaderLanguages.add(ShaderDesc.Language.LANGUAGE_GLES_SM100);
-            compileOptions.forceIncludeShaderLanguages.add(ShaderDesc.Language.LANGUAGE_GLES_SM300);
-            if (Platform.getHostPlatform().isWindows()) {
-                compileOptions.forceIncludeShaderLanguages.add(ShaderDesc.Language.LANGUAGE_HLSL_51);
-            }
-            compileOptions.forceIncludeShaderLanguages.add(ShaderDesc.Language.LANGUAGE_MSL_22);
-            compileOptions.forceIncludeShaderLanguages.add(ShaderDesc.Language.LANGUAGE_SPIRV);
-            compileOptions.forceIncludeShaderLanguages.add(ShaderDesc.Language.LANGUAGE_WGSL);
-
-            if (platform.equals(Platform.X86_64PS4) || platform.equals(Platform.X86_64PS5))
-            {
-                compileOptions.forceIncludeShaderLanguages.add(ShaderDesc.Language.LANGUAGE_PSSL);
+            if (args.length < 3) {
+                System.err.println("Unable to build shader - no platform passed in.%n");
+                return;
             }
 
+            ArrayList<ShaderCompilePipeline.ShaderModuleDesc> modules = new ArrayList<>();
 
-            try {
-                ShaderCompileResult shaderCompilerResult = shaderCompiler.compile(modules, outputPath, compileOptions);
-                ShaderDescBuildResult shaderDescResult = buildResultsToShaderDescBuildResults(shaderCompilerResult);
-                shaderDescResult.shaderDesc.writeTo(os);
+            String outputPath, platform, contentRoot;
 
-            } catch (Exception e) {
-                System.err.printf("Error: %s\n", e.getMessage());
-                throw e;
+            if (args.length == 4) {
+                outputPath   = args[1];
+                platform     = args[2];
+                contentRoot  = args[3];
+                modules.add(GetShaderDesc(project, args[0], contentRoot));
+            } else {
+                outputPath   = args[2];
+                platform     = args[3];
+                contentRoot  = args[4];
+                modules.add(GetShaderDesc(project, args[0], contentRoot));
+                modules.add(GetShaderDesc(project, args[1], contentRoot));
+            }
+
+            assert platform != null;
+            Platform outputPlatform = Platform.get(platform);
+            IShaderCompiler shaderCompiler = project.getShaderCompiler(outputPlatform);
+            if (shaderCompiler == null) {
+                System.err.printf("Unable to build shader - no shader compiler found.%n");
+                return;
+            }
+
+            try (BufferedOutputStream os = new BufferedOutputStream(new FileOutputStream(outputPath))) {
+
+                IShaderCompiler.CompileOptions compileOptions = new IShaderCompiler.CompileOptions();
+                compileOptions.forceIncludeShaderLanguages.add(ShaderDesc.Language.LANGUAGE_GLSL_SM120);
+                compileOptions.forceIncludeShaderLanguages.add(ShaderDesc.Language.LANGUAGE_GLSL_SM330);
+                compileOptions.forceIncludeShaderLanguages.add(ShaderDesc.Language.LANGUAGE_GLES_SM100);
+                compileOptions.forceIncludeShaderLanguages.add(ShaderDesc.Language.LANGUAGE_GLES_SM300);
+                if (Platform.getHostPlatform().isWindows()) {
+                    compileOptions.forceIncludeShaderLanguages.add(ShaderDesc.Language.LANGUAGE_HLSL_51);
+                }
+                compileOptions.forceIncludeShaderLanguages.add(ShaderDesc.Language.LANGUAGE_MSL_22);
+                compileOptions.forceIncludeShaderLanguages.add(ShaderDesc.Language.LANGUAGE_SPIRV);
+                compileOptions.forceIncludeShaderLanguages.add(ShaderDesc.Language.LANGUAGE_WGSL);
+
+                if (platform.equals(Platform.X86_64PS4) || platform.equals(Platform.X86_64PS5))
+                {
+                    compileOptions.forceIncludeShaderLanguages.add(ShaderDesc.Language.LANGUAGE_PSSL);
+                }
+
+
+                try {
+                    ShaderCompileResult shaderCompilerResult = shaderCompiler.compile(modules, outputPath, compileOptions);
+                    ShaderDescBuildResult shaderDescResult = buildResultsToShaderDescBuildResults(shaderCompilerResult);
+                    shaderDescResult.shaderDesc.writeTo(os);
+
+                } catch (Exception e) {
+                    System.err.printf("Error: %s\n", e.getMessage());
+                    throw e;
+                }
             }
         }
     }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderProgramBuilderEditor.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderProgramBuilderEditor.java
@@ -41,17 +41,22 @@ public class ShaderProgramBuilderEditor {
         options.glslEsDefaultIntPrecision = intPrecision;
 
         ShaderCompilePipeline pipeline = ShaderProgramBuilder.newShaderPipeline(resourcePath, shaderDescs, options);
-        Shaderc.ShaderCompileResult result = pipeline.crossCompile(shaderType, shaderLanguage);
+        try {
+            Shaderc.ShaderCompileResult result = pipeline.crossCompile(shaderType, shaderLanguage);
 
-        String compiledSource = new String(result.data);
-        ShaderUtil.Common.GLSLCompileResult variantCompileResult = ShaderUtil.VariantTextureArrayFallback.transform(compiledSource, maxPageCount);
+            String compiledSource = new String(result.data);
+            ShaderUtil.Common.GLSLCompileResult variantCompileResult = ShaderUtil.VariantTextureArrayFallback.transform(compiledSource, maxPageCount);
+            SPIRVReflector reflector = pipeline.getReflectionData(shaderType);
 
-        // If the variant transformation didn't do anything, we pass the original source but without array samplers
-        if (variantCompileResult != null) {
-            variantCompileResult.reflector = pipeline.getReflectionData(shaderType);
-            return variantCompileResult;
-        } else {
-            return new ShaderUtil.Common.GLSLCompileResult(compiledSource, pipeline.getReflectionData(shaderType));
+            // If the variant transformation didn't do anything, we pass the original source but without array samplers
+            if (variantCompileResult != null) {
+                variantCompileResult.reflector = reflector;
+                return variantCompileResult;
+            } else {
+                return new ShaderUtil.Common.GLSLCompileResult(compiledSource, reflector);
+            }
+        } finally {
+            ShaderCompilePipeline.destroyShaderPipeline(pipeline);
         }
     }
 
@@ -87,63 +92,67 @@ public class ShaderProgramBuilderEditor {
             return res;
         }
 
-        HashMap<Graphics.ShaderDesc.ShaderType, Boolean> shaderTypeKeys = new HashMap<>();
-        ArrayList<ShaderProgramBuilder.ShaderBuildResult> shaderBuildResults = new ArrayList<>();
+        try {
+            HashMap<Graphics.ShaderDesc.ShaderType, Boolean> shaderTypeKeys = new HashMap<>();
+            ArrayList<ShaderProgramBuilder.ShaderBuildResult> shaderBuildResults = new ArrayList<>();
 
-        for (Graphics.ShaderDesc.Language shaderLanguage : shaderLanguages) {
-            for (ShaderCompilePipeline.ShaderModuleDesc shaderModule : shaderModuleDescsArrayList) {
-                // Some languages might not be compatible with the shader type, e.g webgl and compute shaders
-                if (!isCompatibleLanguage(shaderModule.type, shaderLanguage)) {
-                    continue;
-                }
-
-                if (!shaderTypeKeys.containsKey(shaderModule.type)) {
-                    shaderTypeKeys.put(shaderModule.type, true);
-                }
-
-                Shaderc.ShaderCompileResult result = new Shaderc.ShaderCompileResult();
-                byte[] source;
-                try {
-                    result = pipeline.crossCompile(shaderModule.type, shaderLanguage);
-                    source = result.data;
-                } catch (CompileExceptionError e) {
-                    shaderBuildResults.add(new ShaderProgramBuilder.ShaderBuildResult(new String[]{e.getMessage()}));
-                    continue;
-                }
-
-                boolean variantTextureArray = false;
-
-                if (ShaderUtil.VariantTextureArrayFallback.isRequired(shaderLanguage)) {
-                    ShaderUtil.Common.GLSLCompileResult variantCompileResult = ShaderUtil.VariantTextureArrayFallback.transform(new String(source), maxPageCount);
-                    if (variantCompileResult != null && variantCompileResult.arraySamplers.length > 0) {
-                        source = variantCompileResult.source.getBytes();
-                        variantTextureArray = true;
+            for (Graphics.ShaderDesc.Language shaderLanguage : shaderLanguages) {
+                for (ShaderCompilePipeline.ShaderModuleDesc shaderModule : shaderModuleDescsArrayList) {
+                    // Some languages might not be compatible with the shader type, e.g webgl and compute shaders
+                    if (!isCompatibleLanguage(shaderModule.type, shaderLanguage)) {
+                        continue;
                     }
+
+                    if (!shaderTypeKeys.containsKey(shaderModule.type)) {
+                        shaderTypeKeys.put(shaderModule.type, true);
+                    }
+
+                    Shaderc.ShaderCompileResult result = new Shaderc.ShaderCompileResult();
+                    byte[] source;
+                    try {
+                        result = pipeline.crossCompile(shaderModule.type, shaderLanguage);
+                        source = result.data;
+                    } catch (CompileExceptionError e) {
+                        shaderBuildResults.add(new ShaderProgramBuilder.ShaderBuildResult(new String[]{e.getMessage()}));
+                        continue;
+                    }
+
+                    boolean variantTextureArray = false;
+
+                    if (ShaderUtil.VariantTextureArrayFallback.isRequired(shaderLanguage)) {
+                        ShaderUtil.Common.GLSLCompileResult variantCompileResult = ShaderUtil.VariantTextureArrayFallback.transform(new String(source), maxPageCount);
+                        if (variantCompileResult != null && variantCompileResult.arraySamplers.length > 0) {
+                            source = variantCompileResult.source.getBytes();
+                            variantTextureArray = true;
+                        }
+                    }
+
+                    result.data = source;
+
+                    Graphics.ShaderDesc.Shader.Builder builder = ShaderProgramBuilder.makeShaderBuilder(result, shaderLanguage, shaderModule.type);
+
+                    // Note: We are not doing builder.setVariantTextureArray(variantTextureArray); because calling that function
+                    //       will mark the field as being set, regardless of the value. We only want to mark the field if we need to.
+                    if (variantTextureArray) {
+                        builder.setVariantTextureArray(true);
+                    }
+                    shaderBuildResults.add(new ShaderProgramBuilder.ShaderBuildResult(builder));
                 }
+            }
 
-                result.data = source;
+            ShaderProgramBuilder.ShaderCompileResult compileResult = new ShaderProgramBuilder.ShaderCompileResult();
 
-                Graphics.ShaderDesc.Shader.Builder builder = ShaderProgramBuilder.makeShaderBuilder(result, shaderLanguage, shaderModule.type);
-
-                // Note: We are not doing builder.setVariantTextureArray(variantTextureArray); because calling that function
-                //       will mark the field as being set, regardless of the value. We only want to mark the field if we need to.
-                if (variantTextureArray) {
-                    builder.setVariantTextureArray(true);
+            for(Graphics.ShaderDesc.ShaderType type : shaderTypeKeys.keySet()) {
+                SPIRVReflector reflector = pipeline.getReflectionData(type);
+                if (reflector != null) {
+                    compileResult.reflectors.add(reflector);
                 }
-                shaderBuildResults.add(new ShaderProgramBuilder.ShaderBuildResult(builder));
             }
+
+            compileResult.shaderBuildResults = shaderBuildResults;
+            return buildResultsToShaderDescBuildResults(compileResult);
+        } finally {
+            ShaderCompilePipeline.destroyShaderPipeline(pipeline);
         }
-
-        ShaderProgramBuilder.ShaderCompileResult compileResult = new ShaderProgramBuilder.ShaderCompileResult();
-
-        for(Graphics.ShaderDesc.ShaderType type : shaderTypeKeys.keySet()) {
-            SPIRVReflector reflector = pipeline.getReflectionData(type);
-            if (reflector != null) {
-                compileResult.reflectors.add(reflector);
-            }
-        }
-
-        compileResult.shaderBuildResults = shaderBuildResults;
-        return buildResultsToShaderDescBuildResults(compileResult);
     }
 }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/shader/ShaderCompilePipeline.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/shader/ShaderCompilePipeline.java
@@ -27,7 +27,6 @@ import com.dynamo.bob.CompileExceptionError;
 import com.dynamo.bob.pipeline.Shaderc;
 import com.dynamo.bob.pipeline.ShadercJni;
 import com.dynamo.bob.util.Exec;
-import com.dynamo.bob.util.FileUtil;
 import com.dynamo.bob.util.Exec.Result;
 import com.dynamo.bob.util.MurmurHash;
 
@@ -66,6 +65,7 @@ public class ShaderCompilePipeline {
 
     protected String pipelineName;
     protected ArrayList<ShaderModule> shaderModules = new ArrayList<>();
+    protected ArrayList<File> tempFiles = new ArrayList<>();
     protected Options options                       = null;
 
     private static String tintExe = null;
@@ -81,7 +81,17 @@ public class ShaderCompilePipeline {
     }
 
     protected void reset() {
+        for (File tempFile : tempFiles) {
+            FileUtils.deleteQuietly(tempFile);
+        }
+        tempFiles.clear();
         shaderModules.clear();
+    }
+
+    protected File createTempFile(String prefix, String suffix) throws IOException {
+        File file = File.createTempFile(prefix, suffix);
+        tempFiles.add(file);
+        return file;
     }
 
     private static String ShaderTypeToSpirvStage(ShaderDesc.ShaderType shaderType) {
@@ -278,8 +288,7 @@ public class ShaderCompilePipeline {
         for (ShaderModule module : this.shaderModules) {
             String baseName = this.pipelineName + "." + ShaderTypeToSpirvStage(module.desc.type);
 
-            File fileInGLSL = File.createTempFile(baseName, ".glsl");
-            FileUtil.deleteOnExit(fileInGLSL);
+            File fileInGLSL = createTempFile(baseName, ".glsl");
 
             String glsl = module.desc.source;
             if (this.options.splitTextureSamplers) {
@@ -288,13 +297,11 @@ public class ShaderCompilePipeline {
             }
             FileUtils.writeByteArrayToFile(fileInGLSL, glsl.getBytes());
 
-            File fileOutSpv = File.createTempFile(baseName, ".spv");
-            FileUtil.deleteOnExit(fileOutSpv);
+            File fileOutSpv = createTempFile(baseName, ".spv");
             generateSPIRv(module.desc.resourcePath, module.desc.type, fileInGLSL.getAbsolutePath(), fileOutSpv.getAbsolutePath());
 
             // Generate an optimized version of the final .spv file
-            File fileOutSpvOpt = File.createTempFile(this.pipelineName, ".optimized.spv");
-            FileUtil.deleteOnExit(fileOutSpvOpt);
+            File fileOutSpvOpt = createTempFile(this.pipelineName, ".optimized.spv");
             generateSPIRvOptimized(module.desc.resourcePath, fileOutSpv.getAbsolutePath(), fileOutSpvOpt.getAbsolutePath());
 
             module.spirvFile = fileOutSpvOpt;
@@ -327,8 +334,7 @@ public class ShaderCompilePipeline {
                 ShadercJni.DeleteShaderContext(fragmentModule.spirvContext);
 
                 String baseName = this.pipelineName + "." + ShaderTypeToSpirvStage(fragmentModule.desc.type);
-                File remappedSpvFile = File.createTempFile(baseName, ".remapped.spv");
-                FileUtil.deleteOnExit(remappedSpvFile);
+                File remappedSpvFile = createTempFile(baseName, ".remapped.spv");
                 FileUtils.writeByteArrayToFile(remappedSpvFile, remappedSpv.data);
 
                 fragmentModule.spirvContext = remappedSpvContext;
@@ -467,8 +473,7 @@ public class ShaderCompilePipeline {
             String shaderTypeStr = ShaderTypeToSpirvStage(shaderType);
             String versionStr    = "v" + version;
 
-            File fileCrossCompiled = File.createTempFile(this.pipelineName, "." + versionStr + "." + shaderTypeStr);
-            FileUtil.deleteOnExit(fileCrossCompiled);
+            File fileCrossCompiled = createTempFile(this.pipelineName, "." + versionStr + "." + shaderTypeStr);
 
             generateWGSL(module.desc.resourcePath, module.spirvFile.getAbsolutePath(), fileCrossCompiled.getAbsolutePath());
 
@@ -548,11 +553,16 @@ public class ShaderCompilePipeline {
     public static ShaderCompilePipeline createShaderPipeline(ShaderCompilePipeline pipeline, ArrayList<ShaderModuleDesc> descs, Options options) throws IOException, CompileExceptionError {
         pipeline.options = options;
         pipeline.reset();
-        for (ShaderModuleDesc desc : descs) {
-            pipeline.addShaderModule(desc);
+        try {
+            for (ShaderModuleDesc desc : descs) {
+                pipeline.addShaderModule(desc);
+            }
+            pipeline.prepare();
+            return pipeline;
+        } catch (IOException | CompileExceptionError | RuntimeException e) {
+            destroyShaderPipeline(pipeline);
+            throw e;
         }
-        pipeline.prepare();
-        return pipeline;
     }
 
     public static void destroyShaderPipeline(ShaderCompilePipeline pipeline) {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/shader/ShaderCompilePipelineLegacy.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/shader/ShaderCompilePipelineLegacy.java
@@ -24,7 +24,6 @@ import com.dynamo.bob.Platform;
 import com.dynamo.bob.pipeline.Shaderc;
 import com.dynamo.bob.pipeline.ShadercJni;
 import com.dynamo.bob.util.Exec;
-import com.dynamo.bob.util.FileUtil;
 import com.dynamo.bob.pipeline.ShaderUtil;
 import com.dynamo.graphics.proto.Graphics.ShaderDesc;
 import org.apache.commons.io.FileUtils;
@@ -75,13 +74,11 @@ public class ShaderCompilePipelineLegacy extends ShaderCompilePipeline {
         return null;
     }
 
-    static private String compileSPIRVToWGSL(String resourcePath, byte[] shaderSource, String resourceOutput)  throws IOException, CompileExceptionError {
-        File file_in_spv = File.createTempFile(FilenameUtils.getName(resourceOutput), ".spv");
-        FileUtil.deleteOnExit(file_in_spv);
+    private String compileSPIRVToWGSL(String resourcePath, byte[] shaderSource, String resourceOutput)  throws IOException, CompileExceptionError {
+        File file_in_spv = createTempFile(FilenameUtils.getName(resourceOutput), ".spv");
         FileUtils.writeByteArrayToFile(file_in_spv, shaderSource);
 
-        File file_out_wgsl = File.createTempFile(FilenameUtils.getName(resourceOutput), ".wgsl");
-        FileUtil.deleteOnExit(file_out_wgsl);
+        File file_out_wgsl = createTempFile(FilenameUtils.getName(resourceOutput), ".wgsl");
         generateWGSL(resourcePath, file_in_spv.getAbsolutePath(), file_out_wgsl.getAbsolutePath());
         return FileUtils.readFileToString(file_out_wgsl);
     }
@@ -102,12 +99,10 @@ public class ShaderCompilePipelineLegacy extends ShaderCompilePipeline {
 
             ShaderUtil.ES2ToES3Converter.Result es3Result = ShaderUtil.ES2ToES3Converter.transform(shaderSource, shaderType, targetProfile, version, true, splitTextureSamplers, this.options.glslEsDefaultFloatPrecision, this.options.glslEsDefaultIntPrecision);
 
-            File file_in_compute = File.createTempFile(FilenameUtils.getName(resourceOutput), ".cp");
-            FileUtil.deleteOnExit(file_in_compute);
+            File file_in_compute = createTempFile(FilenameUtils.getName(resourceOutput), ".cp");
             FileUtils.writeByteArrayToFile(file_in_compute, es3Result.output.getBytes());
 
-            file_out_spv = File.createTempFile(FilenameUtils.getName(resourceOutput), ".spv");
-            FileUtil.deleteOnExit(file_out_spv);
+            file_out_spv = createTempFile(FilenameUtils.getName(resourceOutput), ".spv");
 
             result = Exec.execResult(glslangExe,
                     "-w",
@@ -144,12 +139,10 @@ public class ShaderCompilePipelineLegacy extends ShaderCompilePipeline {
             }
 
             // compile GLSL (ES3 or Desktop 140) to SPIR-V
-            File file_in_glsl = File.createTempFile(FilenameUtils.getName(resourceOutput), ".glsl");
-            FileUtil.deleteOnExit(file_in_glsl);
+            File file_in_glsl = createTempFile(FilenameUtils.getName(resourceOutput), ".glsl");
             FileUtils.writeByteArrayToFile(file_in_glsl, shaderSource.getBytes());
 
-            file_out_spv = File.createTempFile(FilenameUtils.getName(resourceOutput), ".spv");
-            FileUtil.deleteOnExit(file_out_spv);
+            file_out_spv = createTempFile(FilenameUtils.getName(resourceOutput), ".spv");
 
             String spirvShaderStage = (shaderType == ShaderDesc.ShaderType.SHADER_TYPE_VERTEX ? "vert" : "frag");
 
@@ -185,8 +178,7 @@ public class ShaderCompilePipelineLegacy extends ShaderCompilePipeline {
             checkResult(moduleLegacy.desc.resourcePath, resultString);
         }
 
-        File file_out_spv_opt = File.createTempFile(FilenameUtils.getName(resourceOutput), ".spv");
-        FileUtil.deleteOnExit(file_out_spv_opt);
+        File file_out_spv_opt = createTempFile(FilenameUtils.getName(resourceOutput), ".spv");
 
         // Run optimization pass
         result = Exec.execResult(spirvOptExe,

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/BobTempDirectory.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/BobTempDirectory.java
@@ -26,9 +26,9 @@ import java.nio.file.Files;
  * under one root so {@link com.dynamo.bob.Project#dispose()} can remove them
  * together after the build.
  */
-public class BobTempScope implements AutoCloseable {
+public class BobTempDirectory implements AutoCloseable {
 
-    private static final Logger logger = Logger.getLogger(BobTempScope.class.getName());
+    private static final Logger logger = Logger.getLogger(BobTempDirectory.class.getName());
     private static final String KEEP_TEMP_ENV = "DM_BOB_KEEP_TEMP";
     private static final String KEEP_TEMP_PROPERTY = "defold.bob.keepTemp";
 
@@ -37,10 +37,10 @@ public class BobTempScope implements AutoCloseable {
     private final Thread shutdownHook;
     private boolean closed = false;
 
-    public BobTempScope() throws IOException {
+    public BobTempDirectory() throws IOException {
         this.rootDirectory = Files.createTempDirectory("defold-bob-invoke-").toFile();
         this.keepTemp = shouldKeepTemp();
-        this.shutdownHook = new Thread(this::cleanupOnShutdown, "bob-temp-scope-cleanup");
+        this.shutdownHook = new Thread(this::cleanupOnShutdown, "bob-temp-directory-cleanup");
         Runtime.getRuntime().addShutdownHook(this.shutdownHook);
     }
 
@@ -70,7 +70,7 @@ public class BobTempScope implements AutoCloseable {
 
     private void checkOpen() throws IOException {
         if (closed) {
-            throw new IOException("Bob temporary scope is already closed");
+            throw new IOException("Bob temporary directory is already closed");
         }
     }
 

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/BobTempScope.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/BobTempScope.java
@@ -1,0 +1,88 @@
+// Copyright 2020-2026 The Defold Foundation
+// Copyright 2014-2020 King
+// Copyright 2009-2014 Ragnar Svensson, Christian Murray
+// Licensed under the Defold License version 1.0 (the "License"); you may not use
+// this file except in compliance with the License.
+//
+// You may obtain a copy of the License, together with FAQs at
+// https://www.defold.com/license
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package com.dynamo.bob.util;
+
+import com.dynamo.bob.logging.Logger;
+import org.apache.commons.io.FileUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+public class BobTempScope implements AutoCloseable {
+
+    private static final Logger logger = Logger.getLogger(BobTempScope.class.getName());
+    private static final String KEEP_TEMP_ENV = "DM_BOB_KEEP_TEMP";
+    private static final String KEEP_TEMP_PROPERTY = "defold.bob.keepTemp";
+
+    private final File rootDirectory;
+    private final boolean keepTemp;
+    private boolean closed = false;
+
+    public BobTempScope() throws IOException {
+        this.rootDirectory = Files.createTempDirectory("defold-bob-invoke-").toFile();
+        this.keepTemp = shouldKeepTemp();
+    }
+
+    private static boolean shouldKeepTemp() {
+        String propertyValue = System.getProperty(KEEP_TEMP_PROPERTY);
+        if (propertyValue != null) {
+            return Boolean.parseBoolean(propertyValue);
+        }
+
+        String envValue = System.getenv(KEEP_TEMP_ENV);
+        return envValue != null && !envValue.isEmpty() && !"0".equals(envValue) && !"false".equalsIgnoreCase(envValue);
+    }
+
+    public synchronized File createTempFile(String prefix, String suffix) throws IOException {
+        checkOpen();
+        return Files.createTempFile(rootDirectory.toPath(), prefix, suffix).toFile();
+    }
+
+    public synchronized File createTempDirectory(String prefix) throws IOException {
+        checkOpen();
+        return Files.createTempDirectory(rootDirectory.toPath(), prefix).toFile();
+    }
+
+    public File getRootDirectory() {
+        return rootDirectory;
+    }
+
+    private void checkOpen() throws IOException {
+        if (closed) {
+            throw new IOException("Bob temporary scope is already closed");
+        }
+    }
+
+    @Override
+    public synchronized void close() {
+        if (closed) {
+            return;
+        }
+        closed = true;
+
+        if (keepTemp) {
+            logger.info("Keeping Bob temporary directory '%s'", rootDirectory.getAbsolutePath());
+            return;
+        }
+
+        try {
+            FileUtils.deleteDirectory(rootDirectory);
+        } catch (IOException e) {
+            logger.warning("Failed to delete Bob temporary directory '%s': %s", rootDirectory.getAbsolutePath(), e.getMessage());
+            FileUtil.deleteOnExit(rootDirectory);
+        }
+    }
+}

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/BobTempScope.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/BobTempScope.java
@@ -21,6 +21,11 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 
+/**
+ * Owns temporary files and directories created during a Bob invocation, keeping them
+ * under one root so {@link com.dynamo.bob.Project#dispose()} can remove them
+ * together after the build.
+ */
 public class BobTempScope implements AutoCloseable {
 
     private static final Logger logger = Logger.getLogger(BobTempScope.class.getName());
@@ -29,11 +34,14 @@ public class BobTempScope implements AutoCloseable {
 
     private final File rootDirectory;
     private final boolean keepTemp;
+    private final Thread shutdownHook;
     private boolean closed = false;
 
     public BobTempScope() throws IOException {
         this.rootDirectory = Files.createTempDirectory("defold-bob-invoke-").toFile();
         this.keepTemp = shouldKeepTemp();
+        this.shutdownHook = new Thread(this::cleanupOnShutdown, "bob-temp-scope-cleanup");
+        Runtime.getRuntime().addShutdownHook(this.shutdownHook);
     }
 
     private static boolean shouldKeepTemp() {
@@ -43,7 +51,7 @@ public class BobTempScope implements AutoCloseable {
         }
 
         String envValue = System.getenv(KEEP_TEMP_ENV);
-        return envValue != null && !envValue.isEmpty() && !"0".equals(envValue) && !"false".equalsIgnoreCase(envValue);
+        return envValue != null && ("1".equals(envValue) || "true".equalsIgnoreCase(envValue));
     }
 
     public synchronized File createTempFile(String prefix, String suffix) throws IOException {
@@ -72,7 +80,27 @@ public class BobTempScope implements AutoCloseable {
             return;
         }
         closed = true;
+        unregisterShutdownHook();
+        cleanupRootDirectory();
+    }
 
+    private synchronized void cleanupOnShutdown() {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        cleanupRootDirectory();
+    }
+
+    private void unregisterShutdownHook() {
+        try {
+            Runtime.getRuntime().removeShutdownHook(this.shutdownHook);
+        } catch (IllegalStateException ignored) {
+            // The JVM is already shutting down, so the hook is either running or about to run.
+        }
+    }
+
+    private void cleanupRootDirectory() {
         if (keepTemp) {
             logger.info("Keeping Bob temporary directory '%s'", rootDirectory.getAbsolutePath());
             return;

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/BobTempScope.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/BobTempScope.java
@@ -82,7 +82,6 @@ public class BobTempScope implements AutoCloseable {
             FileUtils.deleteDirectory(rootDirectory);
         } catch (IOException e) {
             logger.warning("Failed to delete Bob temporary directory '%s': %s", rootDirectory.getAbsolutePath(), e.getMessage());
-            FileUtil.deleteOnExit(rootDirectory);
         }
     }
 }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/FileUtil.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/FileUtil.java
@@ -22,12 +22,10 @@ import java.io.FileInputStream;
 import java.io.BufferedInputStream;
 import java.util.zip.Checksum;
 import java.util.zip.CRC32;
-import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.io.FileUtils;
 
 public class FileUtil {
 
@@ -83,18 +81,5 @@ public class FileUtil {
 		updateDigest(file, digest);
 		return digest.digest();
 	}
-
-    public static void deleteOnExit(Path path) {
-        File f = path.toFile();
-        deleteOnExit(f);
-    }
-
-    public static void deleteOnExit(File f) {
-        if (f.isDirectory()) {
-            Runtime.getRuntime().addShutdownHook(new Thread(() -> FileUtils.deleteQuietly(f)));
-        } else {
-            f.deleteOnExit();
-        }
-    }
 
 }

--- a/editor/src/java/com/defold/libs/ResourceUnpacker.java
+++ b/editor/src/java/com/defold/libs/ResourceUnpacker.java
@@ -45,7 +45,6 @@ import java.util.stream.Stream;
 
 import com.defold.editor.Editor;
 import com.dynamo.bob.Platform;
-import com.dynamo.bob.util.FileUtil;
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -460,7 +459,7 @@ public class ResourceUnpacker {
             return ensureDirectory(Editor.getSupportPath().resolve(Paths.get("unpack", sha1 + "-" + arch)));
         } else {
             Path tmpDir = Files.createTempDirectory("defold-unpack");
-            FileUtil.deleteOnExit(tmpDir);
+            Runtime.getRuntime().addShutdownHook(new Thread(() -> FileUtils.deleteQuietly(tmpDir.toFile())));
             return tmpDir;
         }
     }

--- a/engine/ddf/src/java_test/com/dynamo/ddf/test/DDFLoaderTest.java
+++ b/engine/ddf/src/java_test/com/dynamo/ddf/test/DDFLoaderTest.java
@@ -39,8 +39,6 @@ import com.dynamo.ddf.proto.TestDDF.Simple01Repeated;
 import com.dynamo.ddf.proto.TestDDF.Simple02Repeated;
 import com.dynamo.ddf.proto.TestDDF.StringRepeated;
 import com.dynamo.ddf.proto.TestDDF.Mesh.Primitive;
-import com.dynamo.bob.util.FileUtil;
-
 import com.google.protobuf.ByteString;
 import com.google.protobuf.DynamicMessage;
 import com.google.protobuf.Message;
@@ -78,13 +76,16 @@ public class DDFLoaderTest
             throws IOException
     {
         File f = File.createTempFile("tmp_defold_", ".pb");
-        FileUtil.deleteOnExit(f);
-
-        FileWriter w = new FileWriter(f);
-        w.write(TextFormat.printToString(m));
-        w.close();
-
-        return DDF.loadTextFormat(new FileReader(f), klass);
+        try {
+            try (FileWriter w = new FileWriter(f)) {
+                w.write(TextFormat.printToString(m));
+            }
+            try (FileReader reader = new FileReader(f)) {
+                return DDF.loadTextFormat(reader, klass);
+            }
+        } finally {
+            f.delete();
+        }
     }
 
     @Test


### PR DESCRIPTION
Bob now removes temporary files created during builds, archiving, bundling, and shader compilation when the build finishes. This prevents stale temporary files from accumulating across repeated Bob runs while still allowing temporary files to be kept explicitly for debugging.

Fix https://github.com/defold/defold/issues/12591

### Technical changes
Better to review with Hide whitespace option because of big try blocks
<img width="415" height="352" alt="CleanShot 2026-06-15 at 12 46 00@2x" src="https://github.com/user-attachments/assets/69009f60-27ce-40c0-babb-0b4c8b21286b" />


- Added `BobTempScope`, a per-project temporary directory scope with `DM_BOB_KEEP_TEMP` / `defold.bob.keepTemp` opt-out support.
- Made `Project` `AutoCloseable`, added `createTempFile()` / `createTempDirectory()`, and dispose the Bob CLI project in a `finally` block (I know, you Björn, not a huge fan of these new features, but in this case it helps to avoid all these `finally()` blocks all around especially taking into account that many tests bypass `invoke()`)
- Routed temporary file creation through `Project` in archive publishing, resource archives, Android/iOS/macOS bundling, Lua bytecode, Ogg/Opus handling, and zip publishing.
- Updated shader compilation pipelines to track temporary files and destroy shader pipeline resources in `finally` paths.
- Removed `FileUtil.deleteOnExit()` usage and cleaned up tests to use explicit cleanup, `TemporaryFolder`, or try-with-resources project disposal.
- Updated archive extraction helpers now that extracted files are not registered with JVM-wide delete-on-exit cleanup.
- Added `BobTempScopeTest` coverage for scoped cleanup, closed-scope behavior, and `Project.dispose()` cleanup.