### PR TITLE
Editor: Use default light when no light exist in scene preview

### DIFF
--- a/editor/src/clj/editor/gl/light.clj
+++ b/editor/src/clj/editor/gl/light.clj
@@ -27,6 +27,18 @@
 
 (def ^:const default-max-preview-lights 8)
 
+(def default-preview-ambient-light
+  (Vector3d. 0.2 0.2 0.2))
+
+(def default-preview-directional-light-entry
+  {:node-id-path [::default-preview-directional-light]
+   :world-translation math/zero-v3
+   :light-type :directional
+   :packed-light {:position (Vector4d. 0.0 0.0 0.0 1.0)
+                  :color (Vector4d. 1.0 1.0 1.0 1.0)
+                  :direction-range (Vector4d. 0.0 -1.0 0.0 0.0)
+                  :params (Vector4d. 0.0 1.0 0.0 0.0)}})
+
 (defn- engine-light-type-index
   ^double [light-type-kw]
   (case light-type-kw
@@ -172,6 +184,12 @@
          :directional-light-entries directional-light-entries
          :local-light-entries local-light-entries
          :local-light-budget local-light-budget}))))
+
+(defn with-default-preview-lights [preview-light-data]
+  (assoc preview-light-data
+    :ambient-light default-preview-ambient-light
+    :directional-light-entries [default-preview-directional-light-entry]
+    :local-light-budget (dec default-max-preview-lights)))
 
 (defn- preview-light-entry-distance-squared
   ^double [preview-light-entry ^Point3d position]

--- a/editor/src/clj/editor/light.clj
+++ b/editor/src/clj/editor/light.clj
@@ -331,7 +331,7 @@
                 (.glDrawArrays gl GL/GL_TRIANGLES 0 (count vbuf)))
               (finally
                 (gl/gl-disable gl GL/GL_BLEND)
-                (.glPolygonMode gl GL/GL_FRONT_AND_BACK GL2/GL_LINE))))
+                (.glPolygonMode gl GL/GL_FRONT_AND_BACK GL2/GL_FILL))))
 
           pass/selection
           (let [vbuf (vbuf-push-light-icon-quads! (->selection-icon-vtx (* renderable-count 6)) camera viewport renderables light-icon-picking-color)

--- a/editor/src/clj/editor/scene.clj
+++ b/editor/src/clj/editor/scene.clj
@@ -714,6 +714,9 @@
                                           (and (not has-hidden-outline-key-path)
                                                (get-in flat-renderable [:user-data :editor-preview-light]))
                                           (conj! flat-renderable))
+        has-model? (or (:has-model? flattened-scene)
+                       (and is-visible
+                            (contains? (:tags renderable) :model)))
         scene-aabb (cond-> (:scene-aabb flattened-scene)
                            (and is-visible (not (geom/empty-aabb? visibility-aabb)))
                            (geom/aabb-union (geom/aabb-transform visibility-aabb world-transform)))]
@@ -744,6 +747,7 @@
                                             alloc-picking-id!)))
             {:renderables pass-renderables
              :preview-light-renderables preview-light-renderables
+             :has-model? has-model?
              :scene-aabb scene-aabb}
             (:children scene))))
 
@@ -779,9 +783,10 @@
         parent-world-rotation geom/NoRotation
         parent-world-transform geom/Identity4d
         parent-world-scale (Vector3d. 1 1 1)]
-    (let [{:keys [renderables preview-light-renderables scene-aabb]}
+    (let [{:keys [renderables preview-light-renderables has-model? scene-aabb]}
           (flatten-scene-renderables! {:renderables (make-pass-renderables)
                                        :preview-light-renderables (transient [])
+                                       :has-model? false
                                        :scene-aabb geom/null-aabb}
                                       true
                                       true
@@ -797,9 +802,14 @@
                                       parent-world-scale
                                       parent-world-transform
                                       alloc-picking-id!)
-          preview-light-renderables (persistent! preview-light-renderables)]
+          preview-light-renderables (persistent! preview-light-renderables)
+          add-default-preview-lights? (and has-model?
+                                           (empty? preview-light-renderables))
+          preview-light-data (cond-> (light/preview-light-data-from-renderables preview-light-renderables)
+                               add-default-preview-lights?
+                               light/with-default-preview-lights)]
       {:renderables (persist-pass-renderables! renderables)
-       :preview-light-data (light/preview-light-data-from-renderables preview-light-renderables)
+       :preview-light-data preview-light-data
        :scene-aabb (if (geom/null-aabb? scene-aabb)
                      geom/empty-bounding-box
                      scene-aabb)})))

--- a/editor/src/clj/editor/scene.clj
+++ b/editor/src/clj/editor/scene.clj
@@ -714,9 +714,6 @@
                                           (and (not has-hidden-outline-key-path)
                                                (get-in flat-renderable [:user-data :editor-preview-light]))
                                           (conj! flat-renderable))
-        has-model? (or (:has-model? flattened-scene)
-                       (and is-visible
-                            (contains? (:tags renderable) :model)))
         scene-aabb (cond-> (:scene-aabb flattened-scene)
                            (and is-visible (not (geom/empty-aabb? visibility-aabb)))
                            (geom/aabb-union (geom/aabb-transform visibility-aabb world-transform)))]
@@ -747,7 +744,6 @@
                                             alloc-picking-id!)))
             {:renderables pass-renderables
              :preview-light-renderables preview-light-renderables
-             :has-model? has-model?
              :scene-aabb scene-aabb}
             (:children scene))))
 
@@ -783,10 +779,9 @@
         parent-world-rotation geom/NoRotation
         parent-world-transform geom/Identity4d
         parent-world-scale (Vector3d. 1 1 1)]
-    (let [{:keys [renderables preview-light-renderables has-model? scene-aabb]}
+    (let [{:keys [renderables preview-light-renderables scene-aabb]}
           (flatten-scene-renderables! {:renderables (make-pass-renderables)
                                        :preview-light-renderables (transient [])
-                                       :has-model? false
                                        :scene-aabb geom/null-aabb}
                                       true
                                       true
@@ -803,8 +798,7 @@
                                       parent-world-transform
                                       alloc-picking-id!)
           preview-light-renderables (persistent! preview-light-renderables)
-          add-default-preview-lights? (and has-model?
-                                           (empty? preview-light-renderables))
+          add-default-preview-lights? (empty? preview-light-renderables)
           preview-light-data (cond-> (light/preview-light-data-from-renderables preview-light-renderables)
                                add-default-preview-lights?
                                light/with-default-preview-lights)]

--- a/engine/engine/content/builtins/materials/lighting.glsl
+++ b/engine/engine/content/builtins/materials/lighting.glsl
@@ -45,6 +45,11 @@ vec3 world_to_view_dir(vec3 d)
     return normalize((var_view * vec4(d, 0.0)).xyz);
 }
 
+vec3 ambient_light()
+{
+     return light_info.xyz;
+}
+
 vec3 diffuse_lambert(int index, vec3 normal, vec3 view_position)
 {
     int type = int(lights[index].params.x);
@@ -81,8 +86,7 @@ vec3 diffuse_lambert(int index, vec3 normal, vec3 view_position)
 
 vec3 diffuse_lambert(vec3 view_normal, vec3 view_position)
 {
-    // Apply accumulated ambient light as base.
-    vec3 total_light = light_info.xyz;
+    vec3 total_light = vec3(0.0);
     int light_count = int(light_info.w);
 
     for (int i = 0; i < MAX_LIGHT_COUNT; ++i)

--- a/engine/engine/content/builtins/materials/model_lit.fp
+++ b/engine/engine/content/builtins/materials/model_lit.fp
@@ -23,6 +23,7 @@ void main()
     // We need to premultiply the tint as well so tint alpha scales both color and alpha.
     vec4 tint_pm = vec4(tint.xyz * tint.w, tint.w);
     vec4 color = texture(tex0, var_texcoord0.xy) * tint_pm;
-    vec3 lighting = diffuse_lambert(normalize(var_normal), var_position.xyz);
-    out_fragColor = vec4(color.rgb * lighting, color.a);
+    vec3 ambient = ambient_light();
+    vec3 diffuse = diffuse_lambert(normalize(var_normal), var_position.xyz);
+    out_fragColor = vec4(color.rgb * (ambient + diffuse), color.a);
 }


### PR DESCRIPTION
Fixes #12594 

#### Technical changes

* If no lights exist in the scene (and the renderables _crave_ light data) we now populate the buffer with two artificial lights  - one ambient at 20% white and one directional light at 100% white pointing downwards
* after rendering light icons, we make sure to reset the draw state to FILL
* minor cleanup in the model_lit.fp + lighting.glsl so it's easier to reuse in other shaders 