### PR TITLE
Support `arcd` archives over 4 GiB

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob.test/build.gradle
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/build.gradle
@@ -3,6 +3,7 @@ apply from: '../com.dynamo.cr.bob/build.gradle'
 def testClassesDir = file("$testDir/build")
 def testTmpDir = file("$testDir/tmp")
 def DM_BOB_BUNDLERTEST_ONLY_HOST = project.hasProperty('DM_BOB_BUNDLERTEST_ONLY_HOST') ? project.property('DM_BOB_BUNDLERTEST_ONLY_HOST') : ''
+def DM_BOB_LARGE_ARCHIVE_TEST = (project.hasProperty('DM_BOB_LARGE_ARCHIVE_TEST') ? project.property('DM_BOB_LARGE_ARCHIVE_TEST') : System.getenv('DM_BOB_LARGE_ARCHIVE_TEST') ?: '').toString()
 
 task cleanTestDirs(type: Delete) {
     delete testClassesDir, testTmpDir
@@ -66,6 +67,7 @@ task testJar(type: Test, dependsOn: createTestJar) {
         } else {
             systemProperty 'DM_BOB_BUNDLERTEST_ONLY_HOST', DM_BOB_BUNDLERTEST_ONLY_HOST
         }
+        systemProperty 'DM_BOB_LARGE_ARCHIVE_TEST', DM_BOB_LARGE_ARCHIVE_TEST
     }
 
     testLogging {
@@ -86,6 +88,10 @@ task testJar(type: Test, dependsOn: createTestJar) {
 // old-fashioned way to run a single test in jar
 task runSingleTest(type: Test, dependsOn: createTestJar) {
     useJUnit()
+
+    doFirst {
+        systemProperty 'DM_BOB_LARGE_ARCHIVE_TEST', DM_BOB_LARGE_ARCHIVE_TEST
+    }
 
     testLogging {
         events 'passed', 'skipped', 'failed', 'standardOut'

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/build.gradle
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/build.gradle
@@ -3,7 +3,6 @@ apply from: '../com.dynamo.cr.bob/build.gradle'
 def testClassesDir = file("$testDir/build")
 def testTmpDir = file("$testDir/tmp")
 def DM_BOB_BUNDLERTEST_ONLY_HOST = project.hasProperty('DM_BOB_BUNDLERTEST_ONLY_HOST') ? project.property('DM_BOB_BUNDLERTEST_ONLY_HOST') : ''
-def DM_BOB_LARGE_ARCHIVE_TEST = (project.hasProperty('DM_BOB_LARGE_ARCHIVE_TEST') ? project.property('DM_BOB_LARGE_ARCHIVE_TEST') : System.getenv('DM_BOB_LARGE_ARCHIVE_TEST') ?: '').toString()
 
 task cleanTestDirs(type: Delete) {
     delete testClassesDir, testTmpDir
@@ -67,7 +66,6 @@ task testJar(type: Test, dependsOn: createTestJar) {
         } else {
             systemProperty 'DM_BOB_BUNDLERTEST_ONLY_HOST', DM_BOB_BUNDLERTEST_ONLY_HOST
         }
-        systemProperty 'DM_BOB_LARGE_ARCHIVE_TEST', DM_BOB_LARGE_ARCHIVE_TEST
     }
 
     testLogging {
@@ -88,10 +86,6 @@ task testJar(type: Test, dependsOn: createTestJar) {
 // old-fashioned way to run a single test in jar
 task runSingleTest(type: Test, dependsOn: createTestJar) {
     useJUnit()
-
-    doFirst {
-        systemProperty 'DM_BOB_LARGE_ARCHIVE_TEST', DM_BOB_LARGE_ARCHIVE_TEST
-    }
 
     testLogging {
         events 'passed', 'skipped', 'failed', 'standardOut'

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/archive/test/ArchiveTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/archive/test/ArchiveTest.java
@@ -146,16 +146,23 @@ public class ArchiveTest {
         outFileIndex.close();
         outFileData.close();
 
+        // A normal tiny archive does not need 64-bit offsets, so the builder should keep
+        // emitting v5 to preserve old-engine compatibility. The first index header field
+        // is the archive version, which proves the conditional rollout decision.
+        try (RandomAccessFile index = new RandomAccessFile(outputIndex, "r")) {
+            assertEquals(ArchiveBuilder.VERSION_5, index.readInt());
+        }
+
         // Read
         ArchiveReader ar = new ArchiveReader(outputIndex.getAbsolutePath(), outputData.getAbsolutePath(), null);
         ar.read();
         ar.close();
     }
 
+    // Existing v5 archives can contain offsets above Integer.MAX_VALUE. This hand-written
+    // v5 index points to a sparse .arcd payload at 0x80000010, which proves ArchiveReader
+    // converts the 32-bit field to an unsigned long before seeking and reading.
     @Test
-    // Tests that ArchiveReader treats the 32-bit archive data offset as unsigned.
-    // It writes a sparse .arcd payload at 0x80000010 and verifies getEntryContent()
-    // seeks to that unsigned position instead of sign-extending it to a negative long.
     public void testReaderHandlesResourceOffsetAbove2GiB() throws IOException {
         final int resourceOffset = 0x80000010;
         final int hashLength = 20;
@@ -170,7 +177,7 @@ public class ArchiveTest {
         try (RandomAccessFile index = new RandomAccessFile(outputIndex, "rw");
              RandomAccessFile data = new RandomAccessFile(outputData, "rw")) {
             index.setLength(0);
-            index.writeInt(ArchiveReader.VERSION);
+            index.writeInt(ArchiveReader.VERSION_5);
             index.writeInt(0); // Pad
             index.writeLong(0); // UserData
             index.writeInt(1); // EntryCount
@@ -193,6 +200,91 @@ public class ArchiveTest {
         try {
             ar.read();
             assertArrayEquals(payload, ar.getEntryContent(ar.getEntries().get(0)));
+        } finally {
+            ar.close();
+        }
+    }
+
+    // V6 stores archive flags in the high 4 bits of the first entry word and the offset
+    // in the low 60 bits. This hand-written v6 index uses the currently unused fourth
+    // flag bit and a sparse payload above 4 GiB, proving ArchiveReader decodes both
+    // values from the packed word before seeking to the resource data.
+    @Test
+    public void testReaderHandlesVersion6PackedOffsetAndFlags() throws IOException {
+        final long resourceOffset = ArchiveBuilder.MAX_UNSIGNED_INT_OFFSET + 1L;
+        final int flags = 1 << 3;
+        final int hashLength = 20;
+        final int hashOffset = 48;
+        final int entryOffset = hashOffset + ArchiveReader.HASH_BUFFER_BYTESIZE;
+        byte[] hash = new byte[ArchiveReader.HASH_BUFFER_BYTESIZE];
+        for (int i = 0; i < hashLength; ++i) {
+            hash[i] = (byte) (i * 11 + 5);
+        }
+        byte[] payload = new byte[] { 0x41, 0x52, 0x43, 0x36, 0x55, 0x66, 0x77, 0x01 };
+
+        try (RandomAccessFile index = new RandomAccessFile(outputIndex, "rw");
+             RandomAccessFile data = new RandomAccessFile(outputData, "rw")) {
+            index.setLength(0);
+            index.writeInt(ArchiveReader.VERSION_6);
+            index.writeInt(0); // Pad
+            index.writeLong(0); // UserData
+            index.writeInt(1); // EntryCount
+            index.writeInt(entryOffset);
+            index.writeInt(hashOffset);
+            index.writeInt(hashLength);
+            index.write(new byte[16]); // Archive index MD5
+            index.write(hash);
+            index.writeLong(((long) flags << ArchiveBuilder.V6_FLAGS_SHIFT) | resourceOffset);
+            index.writeInt(payload.length);
+            index.writeInt(ArchiveEntry.FLAG_UNCOMPRESSED);
+
+            data.setLength(0);
+            data.seek(resourceOffset);
+            data.write(payload);
+        }
+
+        ArchiveReader ar = new ArchiveReader(outputIndex.getAbsolutePath(), outputData.getAbsolutePath(), null);
+        try {
+            ar.read();
+            ArchiveEntry entry = ar.getEntries().get(0);
+            assertEquals(resourceOffset, entry.getResourceOffset());
+            assertEquals(flags, entry.getFlags());
+            assertArrayEquals(payload, ar.getEntryContent(entry));
+        } finally {
+            ar.close();
+        }
+    }
+
+    // The rollout keeps small archives on v5 and switches to v6 only when an offset no
+    // longer fits in uint32. Pre-seeking the data file past 0xffffffff before writing one
+    // tiny resource forces that condition, then the test verifies the v6 header, stored
+    // offset, and readable payload.
+    @Test
+    public void testBuilderWritesVersion6ForResourceOffsetAbove4GiB() throws IOException, CompileExceptionError {
+        final long resourceOffset = ArchiveBuilder.MAX_UNSIGNED_INT_OFFSET + 1L;
+        byte[] payload = new byte[] { (byte) 0xde, (byte) 0xad, (byte) 0xbe, (byte) 0xef, 0x11, 0x22, 0x33, 0x44 };
+
+        ArchiveBuilder ab = new ArchiveBuilder(contentRoot, manifestBuilder, 4, project);
+        ab.add(createDummyFile(contentRoot, "large-offset.bin", payload));
+
+        try (RandomAccessFile index = new RandomAccessFile(outputIndex, "rw");
+             RandomAccessFile data = new RandomAccessFile(outputData, "rw")) {
+            index.setLength(0);
+            data.setLength(0);
+            data.seek(resourceOffset);
+            ab.write(index, data, new ArrayList<String>());
+        }
+
+        try (RandomAccessFile index = new RandomAccessFile(outputIndex, "r")) {
+            assertEquals(ArchiveBuilder.VERSION_6, index.readInt());
+        }
+
+        ArchiveReader ar = new ArchiveReader(outputIndex.getAbsolutePath(), outputData.getAbsolutePath(), null);
+        try {
+            ar.read();
+            ArchiveEntry entry = ar.getEntries().get(0);
+            assertEquals(resourceOffset, entry.getResourceOffset());
+            assertArrayEquals(payload, ar.getEntryContent(entry));
         } finally {
             ar.close();
         }

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/archive/test/ArchiveTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/archive/test/ArchiveTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -160,47 +161,24 @@ public class ArchiveTest {
         ar.close();
     }
 
-    // Existing v5 archives can contain offsets above Integer.MAX_VALUE. This hand-written
-    // v5 index points to a sparse .arcd payload at 0x80000010, which proves ArchiveReader
-    // converts the 32-bit field to an unsigned long before seeking and reading.
+    // New builds no longer need v5 archive compatibility. This minimal v5 index
+    // verifies ArchiveReader fails fast with the unsupported-version error instead
+    // of trying to parse the old entry layout.
     @Test
-    public void testReaderHandlesResourceOffsetAbove2GiB() throws IOException {
-        final int resourceOffset = 0x80000010;
-        final int hashLength = 20;
-        final int hashOffset = 48;
-        final int entryOffset = hashOffset + ArchiveReader.HASH_BUFFER_BYTESIZE;
-        byte[] hash = new byte[ArchiveReader.HASH_BUFFER_BYTESIZE];
-        for (int i = 0; i < hashLength; ++i) {
-            hash[i] = (byte) (i * 7 + 3);
-        }
-        byte[] payload = new byte[] { (byte) 0xde, (byte) 0xad, (byte) 0xbe, (byte) 0xef, 0x11, 0x22, 0x33, 0x44 };
-
+    public void testReaderRejectsVersion5Archive() throws IOException {
         try (RandomAccessFile index = new RandomAccessFile(outputIndex, "rw");
              RandomAccessFile data = new RandomAccessFile(outputData, "rw")) {
             index.setLength(0);
-            index.writeInt(ArchiveReader.VERSION_5);
-            index.writeInt(0); // Pad
-            index.writeLong(0); // UserData
-            index.writeInt(1); // EntryCount
-            index.writeInt(entryOffset);
-            index.writeInt(hashOffset);
-            index.writeInt(hashLength);
-            index.write(new byte[16]); // Archive index MD5
-            index.write(hash);
-            index.writeInt(resourceOffset);
-            index.writeInt(payload.length);
-            index.writeInt(ArchiveEntry.FLAG_UNCOMPRESSED);
-            index.writeInt(0); // Flags
-
+            index.writeInt(5);
             data.setLength(0);
-            data.seek(Integer.toUnsignedLong(resourceOffset));
-            data.write(payload);
         }
 
         ArchiveReader ar = new ArchiveReader(outputIndex.getAbsolutePath(), outputData.getAbsolutePath(), null);
         try {
             ar.read();
-            assertArrayEquals(payload, ar.getEntryContent(ar.getEntries().get(0)));
+            fail("Expected v5 archives to be rejected.");
+        } catch (IOException e) {
+            assertTrue(e.getMessage().contains("Unsupported archive index version: 5"));
         } finally {
             ar.close();
         }

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/archive/test/ArchiveTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/archive/test/ArchiveTest.java
@@ -146,11 +146,12 @@ public class ArchiveTest {
         outFileIndex.close();
         outFileData.close();
 
-        // A normal tiny archive does not need 64-bit offsets, so the builder should keep
-        // emitting v5 to preserve old-engine compatibility. The first index header field
-        // is the archive version, which proves the conditional rollout decision.
+        // A normal tiny archive now emits v6 and uses the packed entry layout even when
+        // offsets fit in 32 bits.
         try (RandomAccessFile index = new RandomAccessFile(outputIndex, "r")) {
-            assertEquals(ArchiveBuilder.VERSION_5, index.readInt());
+            assertEquals(ArchiveBuilder.VERSION_6, index.readInt());
+            index.readInt(); // Pad
+            assertEquals(0L, index.readLong());
         }
 
         // Read
@@ -255,10 +256,8 @@ public class ArchiveTest {
         }
     }
 
-    // The rollout keeps small archives on v5 and switches to v6 only when an offset no
-    // longer fits in uint32. Pre-seeking the data file past 0xffffffff before writing one
-    // tiny resource forces that condition, then the test verifies the v6 header, stored
-    // offset, and readable payload.
+    // The builder always emits v6. Pre-seeking the data file past 0xffffffff before writing
+    // one tiny resource verifies the packed offset and readable payload.
     @Test
     public void testBuilderWritesVersion6ForResourceOffsetAbove4GiB() throws IOException, CompileExceptionError {
         final long resourceOffset = ArchiveBuilder.MAX_UNSIGNED_INT_OFFSET + 1L;
@@ -277,6 +276,8 @@ public class ArchiveTest {
 
         try (RandomAccessFile index = new RandomAccessFile(outputIndex, "r")) {
             assertEquals(ArchiveBuilder.VERSION_6, index.readInt());
+            index.readInt(); // Pad
+            assertEquals(0L, index.readLong());
         }
 
         ArchiveReader ar = new ArchiveReader(outputIndex.getAbsolutePath(), outputData.getAbsolutePath(), null);

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/archive/test/ArchiveTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/archive/test/ArchiveTest.java
@@ -153,6 +153,52 @@ public class ArchiveTest {
     }
 
     @Test
+    // Tests that ArchiveReader treats the 32-bit archive data offset as unsigned.
+    // It writes a sparse .arcd payload at 0x80000010 and verifies getEntryContent()
+    // seeks to that unsigned position instead of sign-extending it to a negative long.
+    public void testReaderHandlesResourceOffsetAbove2GiB() throws IOException {
+        final int resourceOffset = 0x80000010;
+        final int hashLength = 20;
+        final int hashOffset = 48;
+        final int entryOffset = hashOffset + ArchiveReader.HASH_BUFFER_BYTESIZE;
+        byte[] hash = new byte[ArchiveReader.HASH_BUFFER_BYTESIZE];
+        for (int i = 0; i < hashLength; ++i) {
+            hash[i] = (byte) (i * 7 + 3);
+        }
+        byte[] payload = new byte[] { (byte) 0xde, (byte) 0xad, (byte) 0xbe, (byte) 0xef, 0x11, 0x22, 0x33, 0x44 };
+
+        try (RandomAccessFile index = new RandomAccessFile(outputIndex, "rw");
+             RandomAccessFile data = new RandomAccessFile(outputData, "rw")) {
+            index.setLength(0);
+            index.writeInt(ArchiveReader.VERSION);
+            index.writeInt(0); // Pad
+            index.writeLong(0); // UserData
+            index.writeInt(1); // EntryCount
+            index.writeInt(entryOffset);
+            index.writeInt(hashOffset);
+            index.writeInt(hashLength);
+            index.write(new byte[16]); // Archive index MD5
+            index.write(hash);
+            index.writeInt(resourceOffset);
+            index.writeInt(payload.length);
+            index.writeInt(ArchiveEntry.FLAG_UNCOMPRESSED);
+            index.writeInt(0); // Flags
+
+            data.setLength(0);
+            data.seek(Integer.toUnsignedLong(resourceOffset));
+            data.write(payload);
+        }
+
+        ArchiveReader ar = new ArchiveReader(outputIndex.getAbsolutePath(), outputData.getAbsolutePath(), null);
+        try {
+            ar.read();
+            assertArrayEquals(payload, ar.getEntryContent(ar.getEntries().get(0)));
+        } finally {
+            ar.close();
+        }
+    }
+
+    @Test
     public void testEntriesOrder() throws IOException, CompileExceptionError {
 
         // Create

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/ProjectBuildTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/ProjectBuildTest.java
@@ -57,7 +57,6 @@ import com.dynamo.liveupdate.proto.Manifest.ResourceEntryFlag;
 
 public class ProjectBuildTest {
 
-    private static final String LARGE_ARCHIVE_TEST_PROPERTY = "DM_BOB_LARGE_ARCHIVE_TEST";
     private static final int LARGE_ARCHIVE_CUSTOM_RESOURCE_COUNT = 6;
     private static final long LARGE_ARCHIVE_CUSTOM_RESOURCE_SIZE = 16L;
     private static final int LARGE_ARCHIVE_RESOURCE_PADDING = 512 * 1024 * 1024;
@@ -424,9 +423,6 @@ public class ProjectBuildTest {
     // contains at least one unsigned resource offset above that boundary.
     public void testArchiveBuildGeneratedLargeCustomResources() throws Exception {
         Assume.assumeTrue(
-                "Set " + LARGE_ARCHIVE_TEST_PROPERTY + "=0 to skip the generated >2 GiB archive test.",
-                isLargeArchiveTestEnabled());
-        Assume.assumeTrue(
                 "Generated large archive test needs at least 6 GiB of free temp disk space.",
                 new File(contentRoot).getUsableSpace() >= MIN_LARGE_ARCHIVE_TEST_FREE_SPACE);
 
@@ -445,18 +441,6 @@ public class ProjectBuildTest {
         } finally {
             FileUtils.deleteDirectory(new File(contentRoot));
         }
-    }
-
-    private static boolean isLargeArchiveTestEnabled() {
-        String value = System.getProperty(LARGE_ARCHIVE_TEST_PROPERTY);
-        if (value == null) {
-            value = System.getenv(LARGE_ARCHIVE_TEST_PROPERTY);
-        }
-        return !isFalsey(value);
-    }
-
-    private static boolean isFalsey(String value) {
-        return value != null && (value.equals("0") || value.equalsIgnoreCase("false") || value.equalsIgnoreCase("no"));
     }
 
     private void createGeneratedLargeCustomResourceArchiveProject() throws IOException {

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/ProjectBuildTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/ProjectBuildTest.java
@@ -418,7 +418,10 @@ public class ProjectBuildTest {
     }
 
     @Test
-    // Builds a generated project with sparse-padded custom resources and verifies the archive crosses 2 GiB.
+    // Tests that Bob can build archives with resource offsets above 2 GiB.
+    // It generates small custom resources, uses large archive-resource-padding to
+    // create sparse gaps, then verifies game.arcd crosses 2 GiB and the index
+    // contains at least one unsigned resource offset above that boundary.
     public void testArchiveBuildGeneratedLargeCustomResources() throws Exception {
         Assume.assumeTrue(
                 "Set " + LARGE_ARCHIVE_TEST_PROPERTY + "=0 to skip the generated >2 GiB archive test.",

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/ProjectBuildTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/ProjectBuildTest.java
@@ -511,20 +511,13 @@ public class ProjectBuildTest {
             input.readInt(); // HashOffset
             input.readInt(); // HashLength
             input.seek(entryOffset);
+            if (version != ArchiveBuilder.VERSION_6) {
+                throw new IOException("Unsupported archive index version: " + version);
+            }
             for (int i = 0; i < entryCount; ++i) {
-                long resourceOffset;
-                if (version == ArchiveBuilder.VERSION_5) {
-                    resourceOffset = Integer.toUnsignedLong(input.readInt());
-                    input.readInt(); // ResourceSize
-                    input.readInt(); // ResourceCompressedSize
-                    input.readInt(); // Flags
-                } else if (version == ArchiveBuilder.VERSION_6) {
-                    resourceOffset = input.readLong() & ArchiveBuilder.V6_OFFSET_MASK;
-                    input.readInt(); // ResourceSize
-                    input.readInt(); // ResourceCompressedSize
-                } else {
-                    throw new IOException("Unsupported archive index version: " + version);
-                }
+                long resourceOffset = input.readLong() & ArchiveBuilder.V6_OFFSET_MASK;
+                input.readInt(); // ResourceSize
+                input.readInt(); // ResourceCompressedSize
                 if (resourceOffset > TWO_GIB) {
                     return true;
                 }

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/ProjectBuildTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/ProjectBuildTest.java
@@ -47,6 +47,7 @@ import com.dynamo.bob.ClassLoaderScanner;
 import com.dynamo.bob.Progress;
 import com.dynamo.bob.Project;
 import com.dynamo.bob.TaskResult;
+import com.dynamo.bob.archive.ArchiveBuilder;
 import com.dynamo.bob.archive.publisher.NullPublisher;
 import com.dynamo.bob.archive.publisher.PublisherSettings;
 import com.dynamo.bob.fs.DefaultFileSystem;
@@ -502,7 +503,7 @@ public class ProjectBuildTest {
 
     private static boolean hasArchiveEntryOffsetAbove2GiB(File archiveIndex) throws IOException {
         try (RandomAccessFile input = new RandomAccessFile(archiveIndex, "r")) {
-            input.readInt();  // Version
+            int version = input.readInt();
             input.readInt();  // Padding
             input.readLong(); // UserData
             int entryCount = input.readInt();
@@ -511,10 +512,19 @@ public class ProjectBuildTest {
             input.readInt(); // HashLength
             input.seek(entryOffset);
             for (int i = 0; i < entryCount; ++i) {
-                long resourceOffset = Integer.toUnsignedLong(input.readInt());
-                input.readInt(); // ResourceSize
-                input.readInt(); // ResourceCompressedSize
-                input.readInt(); // Flags
+                long resourceOffset;
+                if (version == ArchiveBuilder.VERSION_5) {
+                    resourceOffset = Integer.toUnsignedLong(input.readInt());
+                    input.readInt(); // ResourceSize
+                    input.readInt(); // ResourceCompressedSize
+                    input.readInt(); // Flags
+                } else if (version == ArchiveBuilder.VERSION_6) {
+                    resourceOffset = input.readLong() & ArchiveBuilder.V6_OFFSET_MASK;
+                    input.readInt(); // ResourceSize
+                    input.readInt(); // ResourceCompressedSize
+                } else {
+                    throw new IOException("Unsupported archive index version: " + version);
+                }
                 if (resourceOffset > TWO_GIB) {
                     return true;
                 }

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/ProjectBuildTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/ProjectBuildTest.java
@@ -19,6 +19,7 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.RandomAccessFile;
 import java.nio.file.Files;
 import java.text.ParseException;
 import java.util.ArrayList;
@@ -34,6 +35,7 @@ import javax.imageio.ImageIO;
 
 import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.commons.io.FileUtils;
+import org.junit.Assume;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -54,6 +56,13 @@ import com.dynamo.liveupdate.proto.Manifest;
 import com.dynamo.liveupdate.proto.Manifest.ResourceEntryFlag;
 
 public class ProjectBuildTest {
+
+    private static final String LARGE_ARCHIVE_TEST_PROPERTY = "DM_BOB_LARGE_ARCHIVE_TEST";
+    private static final int LARGE_ARCHIVE_CUSTOM_RESOURCE_COUNT = 6;
+    private static final long LARGE_ARCHIVE_CUSTOM_RESOURCE_SIZE = 16L;
+    private static final int LARGE_ARCHIVE_RESOURCE_PADDING = 512 * 1024 * 1024;
+    private static final long TWO_GIB = 2L * 1024L * 1024L * 1024L;
+    private static final long MIN_LARGE_ARCHIVE_TEST_FREE_SPACE = 6L * 1024L * 1024L * 1024L;
 
     private String contentRoot;
     private String projectName = "Unnamed";
@@ -406,6 +415,125 @@ public class ProjectBuildTest {
         assertFalse(bundledManifestData.getHasExcludedResources());
         assertFalse(publishedManifestData.getHasExcludedResources());
         assertEquals(publishedManifestData, bundledManifestData);
+    }
+
+    @Test
+    // Builds a generated project with sparse-padded custom resources and verifies the archive crosses 2 GiB.
+    public void testArchiveBuildGeneratedLargeCustomResources() throws Exception {
+        Assume.assumeTrue(
+                "Set " + LARGE_ARCHIVE_TEST_PROPERTY + "=0 to skip the generated >2 GiB archive test.",
+                isLargeArchiveTestEnabled());
+        Assume.assumeTrue(
+                "Generated large archive test needs at least 6 GiB of free temp disk space.",
+                new File(contentRoot).getUsableSpace() >= MIN_LARGE_ARCHIVE_TEST_FREE_SPACE);
+
+        try {
+            createGeneratedLargeCustomResourceArchiveProject();
+            buildGeneratedLargeCustomResourceArchiveProject();
+
+            File archiveData = new File(contentRoot, "build/game.arcd");
+            File archiveIndex = new File(contentRoot, "build/game.arci");
+            File buildReportJson = new File(contentRoot, "large_archive_report.json");
+            File buildReportHtml = new File(contentRoot, "large_archive_report.html");
+            assertTrue("Expected game.arcd to exceed 2 GiB, was " + archiveData.length(), archiveData.length() > TWO_GIB);
+            assertTrue("Expected at least one archive entry to start beyond 2 GiB.", hasArchiveEntryOffsetAbove2GiB(archiveIndex));
+            assertTrue("Expected JSON build report to be written.", buildReportJson.isFile());
+            assertTrue("Expected HTML build report to be written.", buildReportHtml.isFile());
+        } finally {
+            FileUtils.deleteDirectory(new File(contentRoot));
+        }
+    }
+
+    private static boolean isLargeArchiveTestEnabled() {
+        String value = System.getProperty(LARGE_ARCHIVE_TEST_PROPERTY);
+        if (value == null) {
+            value = System.getenv(LARGE_ARCHIVE_TEST_PROPERTY);
+        }
+        return !isFalsey(value);
+    }
+
+    private static boolean isFalsey(String value) {
+        return value != null && (value.equals("0") || value.equalsIgnoreCase("false") || value.equalsIgnoreCase("no"));
+    }
+
+    private void createGeneratedLargeCustomResourceArchiveProject() throws IOException {
+        createDefaultFiles();
+        Files.deleteIfExists(new File(contentRoot, "test.png").toPath());
+        createFile(contentRoot, "game.project",
+                "[project]\n" +
+                "title = Large Archive Test\n" +
+                "compress_archive = 0\n" +
+                "custom_resources = /large\n" +
+                "\n" +
+                "[bootstrap]\n" +
+                "main_collection = /logic/main.collectionc\n" +
+                "\n" +
+                "[display]\n" +
+                "width=640\n" +
+                "height=480\n");
+
+        for (int i = 0; i < LARGE_ARCHIVE_CUSTOM_RESOURCE_COUNT; ++i) {
+            createLargeCustomResource(new File(contentRoot, String.format("large/blob_%02d.raw", i)), LARGE_ARCHIVE_CUSTOM_RESOURCE_SIZE, i);
+        }
+    }
+
+    private void buildGeneratedLargeCustomResourceArchiveProject() throws IOException, CompileExceptionError, MultipleCompileException {
+        try (Project project = new Project(new DefaultFileSystem(), contentRoot, "build")) {
+            project.setPublisher(new NullPublisher(new PublisherSettings()));
+
+            ClassLoaderScanner scanner = new ClassLoaderScanner();
+            project.scan(scanner, "com.dynamo.bob");
+            project.scan(scanner, "com.dynamo.bob.pipeline");
+
+            project.setOption("archive", "true");
+            project.setOption("archive-resource-padding", Integer.toString(LARGE_ARCHIVE_RESOURCE_PADDING));
+            project.setOption("build-report-json", new File(contentRoot, "large_archive_report.json").getAbsolutePath());
+            project.setOption("build-report-html", new File(contentRoot, "large_archive_report.html").getAbsolutePath());
+            project.setOption("max-cpu-threads", "1");
+
+            List<TaskResult> result = project.build(Progress.discarding(), "clean", "build");
+            for (TaskResult taskResult : result) {
+                assertTrue(taskResult.toString(), taskResult.isOk());
+            }
+        }
+    }
+
+    private static void createLargeCustomResource(File file, long size, int index) throws IOException {
+        File parent = file.getParentFile();
+        if (parent != null) {
+            parent.mkdirs();
+        }
+
+        try (RandomAccessFile output = new RandomAccessFile(file, "rw")) {
+            output.setLength(size);
+            output.seek(0);
+            output.writeLong(0xdef01d0000000000L + index);
+            output.seek(size - Long.BYTES);
+            output.writeLong(0x5eed000000000000L + index);
+        }
+    }
+
+    private static boolean hasArchiveEntryOffsetAbove2GiB(File archiveIndex) throws IOException {
+        try (RandomAccessFile input = new RandomAccessFile(archiveIndex, "r")) {
+            input.readInt();  // Version
+            input.readInt();  // Padding
+            input.readLong(); // UserData
+            int entryCount = input.readInt();
+            long entryOffset = Integer.toUnsignedLong(input.readInt());
+            input.readInt(); // HashOffset
+            input.readInt(); // HashLength
+            input.seek(entryOffset);
+            for (int i = 0; i < entryCount; ++i) {
+                long resourceOffset = Integer.toUnsignedLong(input.readInt());
+                input.readInt(); // ResourceSize
+                input.readInt(); // ResourceCompressedSize
+                input.readInt(); // Flags
+                if (resourceOffset > TWO_GIB) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     private void createExcludedLiveUpdateProject(String extraLiveUpdateSettings) throws IOException {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/archive/ArchiveBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/archive/ArchiveBuilder.java
@@ -60,9 +60,15 @@ public class ArchiveBuilder {
 
     private static Logger logger = Logger.getLogger(ArchiveBuilder.class.getName());
 
-    public static final int VERSION = 5;
+    public static final int VERSION_5 = 5;
+    public static final int VERSION_6 = 6;
+    public static final int VERSION = VERSION_6;
     public static final int HASH_MAX_LENGTH = 64; // 512 bits
     public static final int MD5_HASH_DIGEST_BYTE_LENGTH = 16; // 128 bits
+    public static final long MAX_UNSIGNED_INT_OFFSET = 0xffffffffL;
+    public static final int V6_FLAGS_SHIFT = 60;
+    public static final int V6_MAX_FLAGS = 0xf;
+    public static final long V6_OFFSET_MASK = 0x0fffffffffffffffL;
 
     private List<ArchiveEntry> entries = new ArrayList<ArchiveEntry>();
     private List<ArchiveEntry> excludedEntries;
@@ -218,7 +224,7 @@ public class ArchiveBuilder {
                 // do not write to it at the same time
                 synchronized (archiveData) {
                     alignBuffer(archiveData, this.resourcePadding);
-                    entry.setResourceOffset((int) archiveData.getFilePointer());
+                    entry.setResourceOffset(archiveData.getFilePointer());
                     archiveData.write(buffer, 0, buffer.length);
                 }
             }
@@ -236,8 +242,10 @@ public class ArchiveBuilder {
     private void writeArchiveIndex(RandomAccessFile archiveIndex, List<ArchiveEntry> archiveEntries) throws IOException {
         TimeProfiler.start("writeArchiveIndex");
 
+        int version = archiveIndexVersion(archiveEntries);
+
         // INDEX
-        archiveIndex.writeInt(VERSION); // Version
+        archiveIndex.writeInt(version); // Version
         archiveIndex.writeInt(0); // Pad
         archiveIndex.writeLong(0); // UserData, used in runtime to distinguish between if the index and resources are memory mapped or loaded from disk
         archiveIndex.writeInt(0); // EntryCount
@@ -260,12 +268,18 @@ public class ArchiveBuilder {
         int entryOffset = (int) archiveIndex.getFilePointer();
         alignBuffer(archiveIndex, 4);
 
-        ByteBuffer indexBuffer = ByteBuffer.allocate(4 * 4 * archiveEntries.size());
+        ByteBuffer indexBuffer = ByteBuffer.allocate(getArchiveEntryDataSize(version) * archiveEntries.size());
         for (ArchiveEntry entry : archiveEntries) {
-            indexBuffer.putInt(entry.getResourceOffset());
-            indexBuffer.putInt(entry.getSize());
-            indexBuffer.putInt(entry.getCompressedSize());
-            indexBuffer.putInt(entry.getFlags());
+            if (version == VERSION_5) {
+                indexBuffer.putInt((int) entry.getResourceOffset());
+                indexBuffer.putInt(entry.getSize());
+                indexBuffer.putInt(entry.getCompressedSize());
+                indexBuffer.putInt(entry.getFlags());
+            } else {
+                indexBuffer.putLong(packArchiveEntryOffsetAndFlags(entry));
+                indexBuffer.putInt(entry.getSize());
+                indexBuffer.putInt(entry.getCompressedSize());
+            }
         }
         archiveIndex.write(indexBuffer.array());
 
@@ -284,7 +298,7 @@ public class ArchiveBuilder {
 
         // Update index header with offsets
         archiveIndex.seek(0);
-        archiveIndex.writeInt(VERSION);
+        archiveIndex.writeInt(version);
         archiveIndex.writeInt(0); // Pad
         archiveIndex.writeLong(0); // UserData
         archiveIndex.writeInt(archiveEntries.size());
@@ -296,6 +310,33 @@ public class ArchiveBuilder {
         TimeProfiler.stop();
     }
 
+    private int archiveIndexVersion(List<ArchiveEntry> archiveEntries) {
+        for (ArchiveEntry entry : archiveEntries) {
+            if (entry.getResourceOffset() > MAX_UNSIGNED_INT_OFFSET) {
+                return VERSION_6;
+            }
+        }
+        return VERSION_5;
+    }
+
+    public static int getArchiveEntryDataSize(int version) {
+        return 16;
+    }
+
+    private static long packArchiveEntryOffsetAndFlags(ArchiveEntry entry) throws IOException {
+        long resourceOffset = entry.getResourceOffset();
+        if (resourceOffset < 0 || resourceOffset > V6_OFFSET_MASK) {
+            throw new IOException(String.format("Archive entry offset %d cannot fit in v6 offset field", resourceOffset));
+        }
+
+        int flags = entry.getFlags();
+        if ((flags & ~V6_MAX_FLAGS) != 0) {
+            throw new IOException(String.format("Archive entry flags 0x%x cannot fit in v6 flags field", flags));
+        }
+
+        return ((long) flags << V6_FLAGS_SHIFT) | resourceOffset;
+    }
+
     // The flow of how a resource is found in the archive:
     // URL → url_hash ───> Manifest: url_hash → data_hash
     //                                            ↓
@@ -303,7 +344,8 @@ public class ArchiveBuilder {
     //                                            ↓
     //                    Archive Index: if found, use index to get Entry from parallel EntryData array
     //                                            ↓
-    //                    EntryData = { offset, size, compressed_size, flags }
+    //                    v5 EntryData = { offset, size, compressed_size, flags }
+    //                    v6 EntryData = { offset_and_flags, size, compressed_size }
     //                                            ↓
     //                    Read bytes from .arcd (using offset via fseek or mmap)
     //                                            ↓

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/archive/ArchiveBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/archive/ArchiveBuilder.java
@@ -363,11 +363,15 @@ public class ArchiveBuilder {
     }
 
     private void alignBuffer(RandomAccessFile outFile, int align) throws IOException {
-        int pos = (int) outFile.getFilePointer();
-        int newPos = (int) (outFile.getFilePointer() + (align - 1));
-        newPos &= ~(align - 1);
+        long pos = outFile.getFilePointer();
+        long newPos = (pos + align - 1L) & ~((long) align - 1L);
+        long padding = newPos - pos;
+        if (padding > 4096) {
+            outFile.seek(newPos);
+            return;
+        }
 
-        for (int i = 0; i < (newPos - pos); ++i) {
+        for (int i = 0; i < padding; ++i) {
             outFile.writeByte((byte) 0);
         }
     }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/archive/ArchiveBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/archive/ArchiveBuilder.java
@@ -60,7 +60,6 @@ public class ArchiveBuilder {
 
     private static Logger logger = Logger.getLogger(ArchiveBuilder.class.getName());
 
-    public static final int VERSION_5 = 5;
     public static final int VERSION_6 = 6;
     public static final int VERSION = VERSION_6;
     public static final int HASH_MAX_LENGTH = 64; // 512 bits
@@ -328,8 +327,7 @@ public class ArchiveBuilder {
     //                                            ↓
     //                    Archive Index: if found, use index to get Entry from parallel EntryData array
     //                                            ↓
-    //                    32-bit EntryData = { offset, size, compressed_size, flags }
-    //                    64-bit EntryData = { offset_and_flags, size, compressed_size }
+    //                    EntryData = { offset_and_flags, size, compressed_size }
     //                                            ↓
     //                    Read bytes from .arcd (using offset via fseek or mmap)
     //                                            ↓

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/archive/ArchiveBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/archive/ArchiveBuilder.java
@@ -242,12 +242,12 @@ public class ArchiveBuilder {
     private void writeArchiveIndex(RandomAccessFile archiveIndex, List<ArchiveEntry> archiveEntries) throws IOException {
         TimeProfiler.start("writeArchiveIndex");
 
-        int version = archiveIndexVersion(archiveEntries);
+        int version = VERSION;
 
         // INDEX
         archiveIndex.writeInt(version); // Version
         archiveIndex.writeInt(0); // Pad
-        archiveIndex.writeLong(0); // UserData, used in runtime to distinguish between if the index and resources are memory mapped or loaded from disk
+        archiveIndex.writeLong(0); // UserData. Runtime reuses this field after loading.
         archiveIndex.writeInt(0); // EntryCount
         archiveIndex.writeInt(0); // EntryOffset
         archiveIndex.writeInt(0); // HashOffset
@@ -270,16 +270,9 @@ public class ArchiveBuilder {
 
         ByteBuffer indexBuffer = ByteBuffer.allocate(getArchiveEntryDataSize(version) * archiveEntries.size());
         for (ArchiveEntry entry : archiveEntries) {
-            if (version == VERSION_5) {
-                indexBuffer.putInt((int) entry.getResourceOffset());
-                indexBuffer.putInt(entry.getSize());
-                indexBuffer.putInt(entry.getCompressedSize());
-                indexBuffer.putInt(entry.getFlags());
-            } else {
-                indexBuffer.putLong(packArchiveEntryOffsetAndFlags(entry));
-                indexBuffer.putInt(entry.getSize());
-                indexBuffer.putInt(entry.getCompressedSize());
-            }
+            indexBuffer.putLong(packArchiveEntryOffsetAndFlags(entry));
+            indexBuffer.putInt(entry.getSize());
+            indexBuffer.putInt(entry.getCompressedSize());
         }
         archiveIndex.write(indexBuffer.array());
 
@@ -310,15 +303,6 @@ public class ArchiveBuilder {
         TimeProfiler.stop();
     }
 
-    private int archiveIndexVersion(List<ArchiveEntry> archiveEntries) {
-        for (ArchiveEntry entry : archiveEntries) {
-            if (entry.getResourceOffset() > MAX_UNSIGNED_INT_OFFSET) {
-                return VERSION_6;
-            }
-        }
-        return VERSION_5;
-    }
-
     public static int getArchiveEntryDataSize(int version) {
         return 16;
     }
@@ -344,8 +328,8 @@ public class ArchiveBuilder {
     //                                            ↓
     //                    Archive Index: if found, use index to get Entry from parallel EntryData array
     //                                            ↓
-    //                    v5 EntryData = { offset, size, compressed_size, flags }
-    //                    v6 EntryData = { offset_and_flags, size, compressed_size }
+    //                    32-bit EntryData = { offset, size, compressed_size, flags }
+    //                    64-bit EntryData = { offset_and_flags, size, compressed_size }
     //                                            ↓
     //                    Read bytes from .arcd (using offset via fseek or mmap)
     //                                            ↓

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/archive/ArchiveEntry.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/archive/ArchiveEntry.java
@@ -27,7 +27,7 @@ public class ArchiveEntry implements Comparable<ArchiveEntry> {
 
     private int size;
     private int compressedSize;
-    private int resourceOffset;
+    private long resourceOffset;
     private int flags = 0;
     private String relName;
     private String fileName;
@@ -123,11 +123,11 @@ public class ArchiveEntry implements Comparable<ArchiveEntry> {
         this.hexDigest = hexDigest;
     }
 
-    public int getResourceOffset() {
+    public long getResourceOffset() {
         return resourceOffset;
     }
 
-    public void setResourceOffset(int resourceOffset) {
+    public void setResourceOffset(long resourceOffset) {
         this.resourceOffset = resourceOffset;
     }
 

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/archive/ArchiveReader.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/archive/ArchiveReader.java
@@ -82,7 +82,7 @@ public class ArchiveReader {
     private void readArchiveData(int indexVersion) throws IOException {
         // INDEX
         archiveIndexFile.readInt(); // Pad
-        archiveIndexFile.readLong(); // UserData, should be 0
+        archiveIndexFile.readLong(); // UserData
         entryCount = archiveIndexFile.readInt();
         entryOffset = archiveIndexFile.readInt();
         hashOffset = archiveIndexFile.readInt();

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/archive/ArchiveReader.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/archive/ArchiveReader.java
@@ -30,7 +30,6 @@ import com.dynamo.liveupdate.proto.Manifest.ManifestFile;
 import com.dynamo.liveupdate.proto.Manifest.ResourceEntry;
 
 public class ArchiveReader {
-    public static final int VERSION_5 = 5;
     public static final int VERSION_6 = 6;
     public static final int VERSION = VERSION_6;
     public static final int HASH_BUFFER_BYTESIZE = 64; // 512 bits
@@ -72,14 +71,14 @@ public class ArchiveReader {
 
         // Version
         int indexVersion = this.archiveIndexFile.readInt();
-        if (indexVersion == ArchiveReader.VERSION_5 || indexVersion == ArchiveReader.VERSION_6) {
-            readArchiveData(indexVersion);
+        if (indexVersion == ArchiveReader.VERSION_6) {
+            readArchiveData();
         } else {
             throw new IOException("Unsupported archive index version: " + indexVersion);
         }
     }
 
-    private void readArchiveData(int indexVersion) throws IOException {
+    private void readArchiveData() throws IOException {
         // INDEX
         archiveIndexFile.readInt(); // Pad
         archiveIndexFile.readLong(); // UserData
@@ -123,18 +122,11 @@ public class ArchiveReader {
         for (int i=0; i<entryCount; ++i) {
             ArchiveEntry e = entries.get(i);
 
-            if (indexVersion == ArchiveReader.VERSION_5) {
-                e.setResourceOffset(Integer.toUnsignedLong(archiveIndexFile.readInt()));
-                e.setSize(archiveIndexFile.readInt());
-                e.setCompressedSize(archiveIndexFile.readInt());
-                e.setFlags(archiveIndexFile.readInt());
-            } else {
-                long offsetAndFlags = archiveIndexFile.readLong();
-                e.setResourceOffset(offsetAndFlags & V6_OFFSET_MASK);
-                e.setSize(archiveIndexFile.readInt());
-                e.setCompressedSize(archiveIndexFile.readInt());
-                e.setFlags((int) (offsetAndFlags >>> V6_FLAGS_SHIFT));
-            }
+            long offsetAndFlags = archiveIndexFile.readLong();
+            e.setResourceOffset(offsetAndFlags & V6_OFFSET_MASK);
+            e.setSize(archiveIndexFile.readInt());
+            e.setCompressedSize(archiveIndexFile.readInt());
+            e.setFlags((int) (offsetAndFlags >>> V6_FLAGS_SHIFT));
         }
     }
 

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/archive/ArchiveReader.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/archive/ArchiveReader.java
@@ -130,9 +130,13 @@ public class ArchiveReader {
         return entries;
     }
 
+    private static long getResourceOffset(ArchiveEntry entry) {
+        return Integer.toUnsignedLong(entry.getResourceOffset());
+    }
+
     public byte[] getEntryContent(ArchiveEntry entry) throws IOException {
         byte[] buf = new byte[entry.getSize()];
-        archiveDataFile.seek(entry.getResourceOffset());
+        archiveDataFile.seek(getResourceOffset(entry));
         archiveDataFile.read(buf, 0, entry.getSize());
 
         return buf;
@@ -151,7 +155,7 @@ public class ArchiveReader {
 
             // extract
             byte[] buf = new byte[entry.getSize()];
-            archiveDataFile.seek(entry.getResourceOffset());
+            archiveDataFile.seek(getResourceOffset(entry));
             archiveDataFile.read(buf, 0, readSize);
 
             File fo = new File(outdir);

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/archive/ArchiveReader.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/archive/ArchiveReader.java
@@ -30,8 +30,12 @@ import com.dynamo.liveupdate.proto.Manifest.ManifestFile;
 import com.dynamo.liveupdate.proto.Manifest.ResourceEntry;
 
 public class ArchiveReader {
-    public static final int VERSION = 5;
+    public static final int VERSION_5 = 5;
+    public static final int VERSION_6 = 6;
+    public static final int VERSION = VERSION_6;
     public static final int HASH_BUFFER_BYTESIZE = 64; // 512 bits
+    private static final int V6_FLAGS_SHIFT = 60;
+    private static final long V6_OFFSET_MASK = 0x0fffffffffffffffL;
 
     private ArrayList<ArchiveEntry> entries = null;
 
@@ -68,14 +72,14 @@ public class ArchiveReader {
 
         // Version
         int indexVersion = this.archiveIndexFile.readInt();
-        if (indexVersion == ArchiveReader.VERSION) {
-            readArchiveData();
+        if (indexVersion == ArchiveReader.VERSION_5 || indexVersion == ArchiveReader.VERSION_6) {
+            readArchiveData(indexVersion);
         } else {
             throw new IOException("Unsupported archive index version: " + indexVersion);
         }
     }
 
-    private void readArchiveData() throws IOException {
+    private void readArchiveData(int indexVersion) throws IOException {
         // INDEX
         archiveIndexFile.readInt(); // Pad
         archiveIndexFile.readLong(); // UserData, should be 0
@@ -119,10 +123,18 @@ public class ArchiveReader {
         for (int i=0; i<entryCount; ++i) {
             ArchiveEntry e = entries.get(i);
 
-            e.setResourceOffset(archiveIndexFile.readInt());
-            e.setSize(archiveIndexFile.readInt());
-            e.setCompressedSize(archiveIndexFile.readInt());
-            e.setFlags(archiveIndexFile.readInt());
+            if (indexVersion == ArchiveReader.VERSION_5) {
+                e.setResourceOffset(Integer.toUnsignedLong(archiveIndexFile.readInt()));
+                e.setSize(archiveIndexFile.readInt());
+                e.setCompressedSize(archiveIndexFile.readInt());
+                e.setFlags(archiveIndexFile.readInt());
+            } else {
+                long offsetAndFlags = archiveIndexFile.readLong();
+                e.setResourceOffset(offsetAndFlags & V6_OFFSET_MASK);
+                e.setSize(archiveIndexFile.readInt());
+                e.setCompressedSize(archiveIndexFile.readInt());
+                e.setFlags((int) (offsetAndFlags >>> V6_FLAGS_SHIFT));
+            }
         }
     }
 
@@ -131,7 +143,7 @@ public class ArchiveReader {
     }
 
     private static long getResourceOffset(ArchiveEntry entry) {
-        return Integer.toUnsignedLong(entry.getResourceOffset());
+        return entry.getResourceOffset();
     }
 
     public byte[] getEntryContent(ArchiveEntry entry) throws IOException {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/GameProjectBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/GameProjectBuilder.java
@@ -356,14 +356,15 @@ public class GameProjectBuilder extends Builder {
             String platform = project.option("platform", "generic");
             project.getPublisher().setPlatform(platform);
             File archiveIndexHandle = project.createTempFile("defold.index_", ".arci");
-            RandomAccessFile archiveIndex = createRandomAccessFile(archiveIndexHandle);
             File archiveDataHandle = project.createTempFile("defold.data_", ".arcd");
-            RandomAccessFile archiveData = createRandomAccessFile(archiveDataHandle);
 
             // create the archive and manifest
             ManifestBuilder manifestBuilder = createManifestBuilder(resourceGraph);
             ArchiveBuilder archiveBuilder = new ArchiveBuilder(root, manifestBuilder, getResourcePadding(), project);
-            createArchive(archiveBuilder, resources, archiveIndex, archiveData, excludedResources);
+            try (RandomAccessFile archiveIndex = createRandomAccessFile(archiveIndexHandle);
+                 RandomAccessFile archiveData = createRandomAccessFile(archiveDataHandle)) {
+                createArchive(archiveBuilder, resources, archiveIndex, archiveData, excludedResources);
+            }
             byte[] fullManifestFile = manifestBuilder.buildManifest();
             byte[] bundledManifestFile = manifestBuilder.buildManifest(true);
             this.project.setArchiveBuilder(archiveBuilder);

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/GameProjectBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/GameProjectBuilder.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -29,10 +30,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import com.dynamo.bob.fs.ResourceUtil;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.io.IOUtils;
 
 import com.dynamo.bob.Bob;
 import com.dynamo.bob.Builder;
@@ -49,7 +48,9 @@ import com.dynamo.bob.archive.EngineVersion;
 import com.dynamo.bob.archive.ManifestBuilder;
 import com.dynamo.bob.archive.publisher.Publisher;
 import com.dynamo.bob.bundle.BundleHelper;
+import com.dynamo.bob.fs.DefaultResource;
 import com.dynamo.bob.fs.IResource;
+import com.dynamo.bob.fs.ResourceUtil;
 import com.dynamo.bob.logging.Logger;
 import com.dynamo.bob.pipeline.graph.ResourceGraph;
 import com.dynamo.bob.util.BobProjectProperties;
@@ -290,118 +291,127 @@ public class GameProjectBuilder extends Builder {
         properties.putStringValue("project", "title_as_file_name", fileNameTitle);
     }
 
+    private static void setOutputContentFromFile(IResource output, File sourceFile) throws IOException {
+        // Archive temp files are fully written and closed before this point. For regular
+        // filesystem outputs we can move them directly and avoid streaming large archives
+        // through setContent(); the fallback stream owns its cleanup locally.
+        if (output instanceof DefaultResource) {
+            File destination = new File(output.getAbsPath());
+            File parent = destination.getParentFile();
+            if (parent != null) {
+                parent.mkdirs();
+            }
+            Files.move(sourceFile.toPath(), destination.toPath(), StandardCopyOption.REPLACE_EXISTING);
+            return;
+        }
+
+        try (FileInputStream inputStream = new FileInputStream(sourceFile)) {
+            output.setContent(inputStream);
+        }
+    }
+
     @Override
     public void build(Task task) throws CompileExceptionError, IOException {
-        FileInputStream archiveIndexInputStream = null;
-        FileInputStream archiveDataInputStream = null;
-
         IResource input = task.input(0);
 
         BobProjectProperties properties = Project.loadProperties(project, input, project.getPropertyFiles(), true);
         final String root = FilenameUtils.concat(project.getRootDirectory(), project.getBuildDirectory());
 
-        try {
-            if (project.option("archive", "false").equals("true")) {
-                // create the resource graphs
-                // the full graph contains all resources in the project
-                TimeProfiler.start("Generate resource graph");
-                logger.info("Generating the resource graph");
-                long tstart = System.currentTimeMillis();
-                ResourceGraph resourceGraph = createResourceGraph(project);
-                long tend = System.currentTimeMillis();
-                logger.info("Generating the resource graph took %f s", (tend-tstart)/1000.0);
-                TimeProfiler.stop();
+        if (project.option("archive", "false").equals("true")) {
+            // create the resource graphs
+            // the full graph contains all resources in the project
+            TimeProfiler.start("Generate resource graph");
+            logger.info("Generating the resource graph");
+            long tstart = System.currentTimeMillis();
+            ResourceGraph resourceGraph = createResourceGraph(project);
+            long tend = System.currentTimeMillis();
+            logger.info("Generating the resource graph took %f s", (tend-tstart)/1000.0);
+            TimeProfiler.stop();
 
-                // create full list of resources including the custom resources
-                // make sure to not archive the .arci, .arcd, .projectc, .dmanifest, or .resourcepack.zip
-                // also make sure to not archive the comp counter files
-                Set<IResource> resources = getCustomResources(project);
-                resources.addAll(resourceGraph.getResources());
-                for (IResource resource : task.getOutputs()) {
-                    resources.remove(resource);
-                }
-
-                TimeProfiler.start("Create excluded resources");
-                logger.info("Creation of the excluded resources list.");
-                tstart = System.currentTimeMillis();
-                boolean shouldPublishLU = project.option("liveupdate", "false").equals("true");
-                List<String> excludedResources;
-                if (shouldPublishLU) {
-                    excludedResources = resourceGraph.createExcludedResourcesList();
-                }
-                else {
-                    excludedResources = new ArrayList<String>();
-                }
-                tend = System.currentTimeMillis();
-                logger.info("Creation of the excluded resources list took %f s", (tend-tstart)/1000.0);
-                TimeProfiler.stop();
-
-                // Create output for the data archive
-                String platform = project.option("platform", "generic");
-                project.getPublisher().setPlatform(platform);
-                File archiveIndexHandle = project.createTempFile("defold.index_", ".arci");
-                RandomAccessFile archiveIndex = createRandomAccessFile(archiveIndexHandle);
-                File archiveDataHandle = project.createTempFile("defold.data_", ".arcd");
-                RandomAccessFile archiveData = createRandomAccessFile(archiveDataHandle);
-
-                // create the archive and manifest
-                ManifestBuilder manifestBuilder = createManifestBuilder(resourceGraph);
-                ArchiveBuilder archiveBuilder = new ArchiveBuilder(root, manifestBuilder, getResourcePadding(), project);
-                createArchive(archiveBuilder, resources, archiveIndex, archiveData, excludedResources);
-                byte[] fullManifestFile = manifestBuilder.buildManifest();
-                byte[] bundledManifestFile = manifestBuilder.buildManifest(true);
-                this.project.setArchiveBuilder(archiveBuilder);
-
-                // Write outputs to the build system
-                // game.arci
-                archiveIndexInputStream = new FileInputStream(archiveIndexHandle);
-                task.getOutputs().get(1).setContent(archiveIndexInputStream);
-
-                // game.arcd
-                archiveDataInputStream = new FileInputStream(archiveDataHandle);
-                task.getOutputs().get(2).setContent(archiveDataInputStream);
-
-                // game.dmanifest
-                task.getOutputs().get(3).setContent(bundledManifestFile);
-
-                // game.graph.json
-                resourceGraph.setHexDigests(archiveBuilder.getCachedHexDigests());
-                logger.info("Writing the resource graph to json");
-                tstart = System.currentTimeMillis();
-                String resourceGraphJSON = resourceGraph.toJSON();
-                task.getOutputs().get(4).setContent(resourceGraphJSON.getBytes());
-                tend = System.currentTimeMillis();
-                logger.info("Writing the resource graph to json took %f s", (tend-tstart)/1000.0);
-
-                // Add copy of game.dmanifest to be published with liveupdate resources
-                File manifestFileHandle = new File(task.getOutputs().get(3).getAbsPath());
-                String liveupdateManifestFilename = "liveupdate.game.dmanifest";
-                File manifestTmpFileHandle = new File(FilenameUtils.concat(manifestFileHandle.getParent(), liveupdateManifestFilename));
-                FileUtils.writeByteArrayToFile(manifestTmpFileHandle, fullManifestFile);
-
-                ArchiveEntry manifestArchiveEntry = new ArchiveEntry(root, manifestTmpFileHandle.getAbsolutePath());
-                project.getPublisher().publish(manifestArchiveEntry, manifestTmpFileHandle);
-                project.getPublisher().stop();
-
-                // Copy SSL public keys if specified
-                String sslCertificatesPath = project.getProjectProperties().getStringValue("network", "ssl_certificates");
-                if (sslCertificatesPath != null && !sslCertificatesPath.isEmpty())
-                {
-                    File source = new File(project.getRootDirectory(), sslCertificatesPath);
-                    File buildDir = new File(project.getRootDirectory(), project.getBuildDirectory());
-                    File dist = new File(buildDir, BundleHelper.SSL_CERTIFICATES_NAME);
-                    FileUtils.copyFile(source, dist);
-                }
-
-                manifestTmpFileHandle.delete();
+            // create full list of resources including the custom resources
+            // make sure to not archive the .arci, .arcd, .projectc, .dmanifest, or .resourcepack.zip
+            // also make sure to not archive the comp counter files
+            Set<IResource> resources = getCustomResources(project);
+            resources.addAll(resourceGraph.getResources());
+            for (IResource resource : task.getOutputs()) {
+                resources.remove(resource);
             }
 
-            transformGameProjectFile(properties);
-            task.getOutputs().get(0).setContent(properties.serialize().getBytes());
-        } finally {
-            IOUtils.closeQuietly(archiveIndexInputStream);
-            IOUtils.closeQuietly(archiveDataInputStream);
+            TimeProfiler.start("Create excluded resources");
+            logger.info("Creation of the excluded resources list.");
+            tstart = System.currentTimeMillis();
+            boolean shouldPublishLU = project.option("liveupdate", "false").equals("true");
+            List<String> excludedResources;
+            if (shouldPublishLU) {
+                excludedResources = resourceGraph.createExcludedResourcesList();
+            }
+            else {
+                excludedResources = new ArrayList<String>();
+            }
+            tend = System.currentTimeMillis();
+            logger.info("Creation of the excluded resources list took %f s", (tend-tstart)/1000.0);
+            TimeProfiler.stop();
+
+            // Create output for the data archive
+            String platform = project.option("platform", "generic");
+            project.getPublisher().setPlatform(platform);
+            File archiveIndexHandle = project.createTempFile("defold.index_", ".arci");
+            RandomAccessFile archiveIndex = createRandomAccessFile(archiveIndexHandle);
+            File archiveDataHandle = project.createTempFile("defold.data_", ".arcd");
+            RandomAccessFile archiveData = createRandomAccessFile(archiveDataHandle);
+
+            // create the archive and manifest
+            ManifestBuilder manifestBuilder = createManifestBuilder(resourceGraph);
+            ArchiveBuilder archiveBuilder = new ArchiveBuilder(root, manifestBuilder, getResourcePadding(), project);
+            createArchive(archiveBuilder, resources, archiveIndex, archiveData, excludedResources);
+            byte[] fullManifestFile = manifestBuilder.buildManifest();
+            byte[] bundledManifestFile = manifestBuilder.buildManifest(true);
+            this.project.setArchiveBuilder(archiveBuilder);
+
+            // Write outputs to the build system
+            // game.arci
+            setOutputContentFromFile(task.getOutputs().get(1), archiveIndexHandle);
+
+            // game.arcd
+            setOutputContentFromFile(task.getOutputs().get(2), archiveDataHandle);
+
+            // game.dmanifest
+            task.getOutputs().get(3).setContent(bundledManifestFile);
+
+            // game.graph.json
+            resourceGraph.setHexDigests(archiveBuilder.getCachedHexDigests());
+            logger.info("Writing the resource graph to json");
+            tstart = System.currentTimeMillis();
+            String resourceGraphJSON = resourceGraph.toJSON();
+            task.getOutputs().get(4).setContent(resourceGraphJSON.getBytes());
+            tend = System.currentTimeMillis();
+            logger.info("Writing the resource graph to json took %f s", (tend-tstart)/1000.0);
+
+            // Add copy of game.dmanifest to be published with liveupdate resources
+            File manifestFileHandle = new File(task.getOutputs().get(3).getAbsPath());
+            String liveupdateManifestFilename = "liveupdate.game.dmanifest";
+            File manifestTmpFileHandle = new File(FilenameUtils.concat(manifestFileHandle.getParent(), liveupdateManifestFilename));
+            FileUtils.writeByteArrayToFile(manifestTmpFileHandle, fullManifestFile);
+
+            ArchiveEntry manifestArchiveEntry = new ArchiveEntry(root, manifestTmpFileHandle.getAbsolutePath());
+            project.getPublisher().publish(manifestArchiveEntry, manifestTmpFileHandle);
+            project.getPublisher().stop();
+
+            // Copy SSL public keys if specified
+            String sslCertificatesPath = project.getProjectProperties().getStringValue("network", "ssl_certificates");
+            if (sslCertificatesPath != null && !sslCertificatesPath.isEmpty())
+            {
+                File source = new File(project.getRootDirectory(), sslCertificatesPath);
+                File buildDir = new File(project.getRootDirectory(), project.getBuildDirectory());
+                File dist = new File(buildDir, BundleHelper.SSL_CERTIFICATES_NAME);
+                FileUtils.copyFile(source, dist);
+            }
+
+            manifestTmpFileHandle.delete();
         }
+
+        transformGameProjectFile(properties);
+        task.getOutputs().get(0).setContent(properties.serialize().getBytes());
     }
 
     @Override

--- a/engine/docs/ARCHIVE_FORMAT.md
+++ b/engine/docs/ARCHIVE_FORMAT.md
@@ -59,7 +59,7 @@ The hashes are a 64bit hash (using [dmHashString64()](https://defold.com/ref/sta
 
 The resource entry contains the archive data offset, resource size, compressed size (if it is compressed), and a set of flags with meta data, such as if the resource is compressed and/or obfuscated.
 
-Archive index version 5 uses 32-bit archive data offsets and a separate 32-bit flags field. Archive index version 6 is the current writer version and always uses the packed 64-bit entry layout: flags are stored in the high 4 bits of a 64-bit entry word and the low 60 bits store the archive data offset, so a `.arcd` file can grow beyond 4 GiB without increasing the entry size. Resource sizes remain 32-bit in both versions.
+Archive index version 6 is the current supported version and uses the packed 64-bit entry layout: flags are stored in the high 4 bits of a 64-bit entry word and the low 60 bits store the archive data offset, so a `.arcd` file can grow beyond 4 GiB without increasing the entry size. Resource sizes remain 32-bit.
 
 <pre>
 HEADER:
@@ -71,12 +71,7 @@ HASH0
 HASH1
  ...
 HASHn
-ENTRY0 (v5)
-  entry.resource_offset
-  entry.resource_size
-  entry.resource_compressed_size
-  entry.flags
-ENTRY0 (v6)
+ENTRY0
   entry.offset_and_flags             # flags in bits 63..60, offset in bits 59..0
   entry.resource_size
   entry.resource_compressed_size

--- a/engine/docs/ARCHIVE_FORMAT.md
+++ b/engine/docs/ARCHIVE_FORMAT.md
@@ -57,7 +57,9 @@ These two lists are of the same length, are in fact a 1:1 match. This makes it e
 
 The hashes are a 64bit hash (using [dmHashString64()](https://defold.com/ref/stable/dmHash/?q=dmhashstring64#dmHashString64:string)) of the relative file path of the resource.
 
-The resource entry contains the resource size, and compressed size (if it is compressed). It also has a set of flags with meta data, such as if the resource is compressed and/or obfuscated.
+The resource entry contains the archive data offset, resource size, compressed size (if it is compressed), and a set of flags with meta data, such as if the resource is compressed and/or obfuscated.
+
+Archive index version 5 uses 32-bit archive data offsets and a separate 32-bit flags field. Archive index version 6 packs the flags into the high 4 bits of a 64-bit entry word and uses the low 60 bits for the archive data offset, so a `.arcd` file can grow beyond 4 GiB without increasing the entry size. The builder still writes version 5 when all resource offsets fit in 32 bits, and only writes version 6 when at least one resource offset requires it. Resource sizes remain 32-bit in both versions.
 
 <pre>
 HEADER:
@@ -69,11 +71,15 @@ HASH0
 HASH1
  ...
 HASHn
-ENTRY0
+ENTRY0 (v5)
   entry.resource_offset
   entry.resource_size
   entry.resource_compressed_size
   entry.flags
+ENTRY0 (v6)
+  entry.offset_and_flags             # flags in bits 63..60, offset in bits 59..0
+  entry.resource_size
+  entry.resource_compressed_size
 ENTRY1
  ...
 ENTRYn
@@ -114,5 +120,3 @@ See [ManifestBuilder.java](https://github.com/defold/defold/blob/dev/com.dynamo.
 #### Debugging
 
 It is possible to print the contents of a `.dmanifest` by calling `<defold>/scripts/unpack_ddf.py /path/to/game.dmanifest`
-
-

--- a/engine/docs/ARCHIVE_FORMAT.md
+++ b/engine/docs/ARCHIVE_FORMAT.md
@@ -59,7 +59,7 @@ The hashes are a 64bit hash (using [dmHashString64()](https://defold.com/ref/sta
 
 The resource entry contains the archive data offset, resource size, compressed size (if it is compressed), and a set of flags with meta data, such as if the resource is compressed and/or obfuscated.
 
-Archive index version 5 uses 32-bit archive data offsets and a separate 32-bit flags field. Archive index version 6 packs the flags into the high 4 bits of a 64-bit entry word and uses the low 60 bits for the archive data offset, so a `.arcd` file can grow beyond 4 GiB without increasing the entry size. The builder still writes version 5 when all resource offsets fit in 32 bits, and only writes version 6 when at least one resource offset requires it. Resource sizes remain 32-bit in both versions.
+Archive index version 5 uses 32-bit archive data offsets and a separate 32-bit flags field. Archive index version 6 is the current writer version and always uses the packed 64-bit entry layout: flags are stored in the high 4 bits of a 64-bit entry word and the low 60 bits store the archive data offset, so a `.arcd` file can grow beyond 4 GiB without increasing the entry size. Resource sizes remain 32-bit in both versions.
 
 <pre>
 HEADER:

--- a/engine/resource/src/mount/mount_android.cpp
+++ b/engine/resource/src/mount/mount_android.cpp
@@ -44,9 +44,46 @@ namespace dmResource
         AAsset* data_asset;
         void* data_map; // non null if retrieved by MapFile
         void* index_map; // non null if retrieved by MapFile
-        uint32_t data_length;
+        uint64_t data_length;
         uint32_t index_length;
     };
+
+    static Result MapArchiveFile(const char* path, void*& out_map, uint64_t& out_size)
+    {
+        int fd = open(path, O_RDONLY);
+        if (fd < 0)
+        {
+            return RESULT_RESOURCE_NOT_FOUND;
+        }
+
+        struct stat fs;
+        if (fstat(fd, &fs))
+        {
+            close(fd);
+            return RESULT_IO_ERROR;
+        }
+
+        out_map = mmap(0, fs.st_size, PROT_READ, MAP_SHARED, fd, 0);
+        close(fd);
+
+        if (!out_map || out_map == (void*)-1)
+        {
+            return RESULT_IO_ERROR;
+        }
+
+        out_size = (uint64_t)fs.st_size;
+
+        return RESULT_OK;
+    }
+
+    static Result UnmapArchiveFile(void*& map, uint64_t size)
+    {
+        if (map != 0x0)
+        {
+            munmap(map, (size_t)size);
+        }
+        return RESULT_OK;
+    }
 
     Result MapAsset(const char* path, void*& out_asset, uint32_t& out_size, void*& out_map)
     {
@@ -133,7 +170,7 @@ namespace dmResource
         uint32_t index_length = 0;
         void* index_map = 0x0;
         AAsset* data_asset = 0x0;
-        uint32_t data_length = 0;
+        uint64_t data_length = 0;
         void* data_map = 0x0;
 
         Result r;
@@ -142,7 +179,9 @@ namespace dmResource
         bool mem_mapped_data = false;
         if (strcmp(data_path, "game.arcd") == 0)
         {
-            r = MapAsset(data_path, (void*&)data_asset, data_length, data_map);
+            uint32_t data_asset_length = 0;
+            r = MapAsset(data_path, (void*&)data_asset, data_asset_length, data_map);
+            data_length = data_asset_length;
             if (r != RESULT_OK)
             {
                 dmLogError("Error when mapping data file '%s', result = %i", data_path, r);
@@ -150,7 +189,7 @@ namespace dmResource
             }
         } else
         {
-            r = MapFile(data_path, data_map, data_length);
+            r = MapArchiveFile(data_path, data_map, data_length);
             if (r != RESULT_OK)
             {
                 dmLogError("Error mapping liveupdate data file, result = %i", r);
@@ -167,9 +206,9 @@ namespace dmResource
             if (r != RESULT_OK)
             {
                 if (mem_mapped_data)
-                    UnmapFile(data_map, data_length);
+                    UnmapArchiveFile(data_map, data_length);
                 else
-                    UnmapAsset((void*&)data_asset, data_length);
+                    UnmapAsset((void*&)data_asset, (uint32_t)data_length);
                 dmLogError("Error when mapping index file, result: %i", r);
                 return RESULT_IO_ERROR;
             }
@@ -180,9 +219,9 @@ namespace dmResource
             if (r != RESULT_OK)
             {
                 if (mem_mapped_data)
-                    UnmapFile(data_map, data_length);
+                    UnmapArchiveFile(data_map, data_length);
                 else
-                    UnmapAsset((void*&)data_asset, data_length);
+                    UnmapAsset((void*&)data_asset, (uint32_t)data_length);
                 dmLogError("Error mapping liveupdate index file, result = %i", r);
                 return RESULT_IO_ERROR;
             }
@@ -195,9 +234,9 @@ namespace dmResource
         if (res != dmResourceArchive::RESULT_OK)
         {
             if (mem_mapped_data)
-                UnmapFile(data_map, data_length);
+                UnmapArchiveFile(data_map, data_length);
             else
-                UnmapAsset((void*&)data_asset, data_length);
+                UnmapAsset((void*&)data_asset, (uint32_t)data_length);
 
             if (mem_mapped_index)
                 UnmapFile(index_map, index_length);
@@ -240,10 +279,10 @@ namespace dmResource
 
         if (info->data_asset)
         {
-            UnmapAsset((void*&)info->data_asset, info->data_length);
+            UnmapAsset((void*&)info->data_asset, (uint32_t)info->data_length);
         } else if(info->data_map)
         {
-            UnmapFile(info->data_map, info->data_length);
+            UnmapArchiveFile(info->data_map, info->data_length);
         }
 
         delete info;

--- a/engine/resource/src/mount/mount_android.cpp
+++ b/engine/resource/src/mount/mount_android.cpp
@@ -202,6 +202,17 @@ namespace dmResource
             r = MapArchiveFile(data_path, data_map, data_length);
             if (r != RESULT_OK)
             {
+                dmResourceArchive::Result load_result = dmResourceArchive::LoadArchiveFromFile(index_path, data_path, archive);
+                if (load_result == dmResourceArchive::RESULT_OK)
+                {
+                    *mount_info = 0;
+                    return RESULT_OK;
+                }
+                if (load_result == dmResourceArchive::RESULT_VERSION_MISMATCH)
+                {
+                    return RESULT_VERSION_MISMATCH;
+                }
+
                 dmLogError("Error mapping liveupdate data file, result = %i", r);
                 return RESULT_IO_ERROR;
             }
@@ -275,6 +286,10 @@ namespace dmResource
 
         if (!info)
         {
+            if (archive)
+            {
+                dmResourceArchive::Delete(archive);
+            }
             return;
         }
 

--- a/engine/resource/src/mount/mount_android.cpp
+++ b/engine/resource/src/mount/mount_android.cpp
@@ -21,6 +21,10 @@
 #include <fcntl.h>
 #include <unistd.h>
 
+#ifndef O_LARGEFILE
+#define O_LARGEFILE 0
+#endif
+
 #include <android_native_app_glue.h>
 #include <android/asset_manager.h>
 
@@ -50,14 +54,20 @@ namespace dmResource
 
     static Result MapArchiveFile(const char* path, void*& out_map, uint64_t& out_size)
     {
-        int fd = open(path, O_RDONLY);
+        int fd = open(path, O_RDONLY | O_LARGEFILE);
         if (fd < 0)
         {
             return RESULT_RESOURCE_NOT_FOUND;
         }
 
-        struct stat fs;
-        if (fstat(fd, &fs))
+        struct stat64 fs;
+        if (fstat64(fd, &fs))
+        {
+            close(fd);
+            return RESULT_IO_ERROR;
+        }
+
+        if ((uint64_t)fs.st_size > (uint64_t)((size_t)-1))
         {
             close(fd);
             return RESULT_IO_ERROR;

--- a/engine/resource/src/mount/mount_mmap.cpp
+++ b/engine/resource/src/mount/mount_mmap.cpp
@@ -130,6 +130,24 @@ namespace dmResource
         return UnmapFile(map, size);
     }
 
+    static Result MountArchiveFromFileBacked(const char* index_path, const char* data_path, dmResourceArchive::HArchiveIndexContainer* archive, void** mount_info)
+    {
+        dmResourceArchive::Result result = dmResourceArchive::LoadArchiveFromFile(index_path, data_path, archive);
+        if (result == dmResourceArchive::RESULT_OK)
+        {
+            // A null mount_info marks a file-backed archive. UnmountArchiveInternal()
+            // will only delete the archive container; there are no mapped regions to release.
+            *mount_info = 0;
+            return RESULT_OK;
+        }
+        if (result == dmResourceArchive::RESULT_VERSION_MISMATCH)
+        {
+            return RESULT_VERSION_MISMATCH;
+        }
+
+        return RESULT_IO_ERROR;
+    }
+
     Result MountArchiveInternal(const char* index_path, const char* data_path, dmResourceArchive::HArchiveIndexContainer* archive, void** mount_info)
     {
         void* index_map = 0x0;
@@ -147,6 +165,12 @@ namespace dmResource
         if (r != RESULT_OK)
         {
             munmap(index_map, index_size);
+            Result fallback_result = MountArchiveFromFileBacked(index_path, data_path, archive, mount_info);
+            if (fallback_result != RESULT_IO_ERROR)
+            {
+                return fallback_result;
+            }
+
             dmLogError("Error when mapping data file '%s', result = %i", data_path, r);
             return r;
         }

--- a/engine/resource/src/mount/mount_mmap.cpp
+++ b/engine/resource/src/mount/mount_mmap.cpp
@@ -36,6 +36,37 @@ namespace dmResource
         uint64_t data_length;
     };
 
+    static Result MapArchiveFile(const char* path, void*& out_map, uint64_t& out_size)
+    {
+        int fd = open(path, O_RDONLY);
+        if (fd < 0)
+        {
+            return RESULT_RESOURCE_NOT_FOUND;
+        }
+
+        struct stat fs;
+        if (fstat(fd, &fs))
+        {
+            close(fd);
+            return RESULT_IO_ERROR;
+        }
+        out_map = mmap(NULL, fs.st_size, PROT_READ, MAP_SHARED, fd, 0);
+        close(fd);
+
+        if (!out_map || out_map == MAP_FAILED)
+        {
+            int err = errno;
+            char errstr[128];
+            dmStrError(errstr, sizeof(errstr), err);
+            dmLogError("Failed to memory map file %s: errno: %d %s", path, err, errstr);
+            return RESULT_IO_ERROR;
+        }
+
+        out_size = (uint64_t)fs.st_size;
+
+        return RESULT_OK;
+    }
+
     Result MapFile(const char* path, void*& out_map, uint32_t& out_size)
     {
         int fd = open(path, O_RDONLY);
@@ -111,8 +142,8 @@ namespace dmResource
         }
 
         void* data_map = 0x0;
-        uint32_t data_size = 0;
-        r = MapFile(data_path, data_map, data_size);
+        uint64_t data_size = 0;
+        r = MapArchiveFile(data_path, data_map, data_size);
         if (r != RESULT_OK)
         {
             munmap(index_map, index_size);
@@ -126,7 +157,7 @@ namespace dmResource
         if (res != dmResourceArchive::RESULT_OK)
         {
             munmap(index_map, index_size);
-            munmap(data_map, data_size);
+            munmap(data_map, (size_t)data_size);
             if (res == dmResourceArchive::RESULT_VERSION_MISMATCH)
                 return RESULT_VERSION_MISMATCH;
             return RESULT_IO_ERROR;
@@ -150,12 +181,12 @@ namespace dmResource
         {
             if (info->index_map)
             {
-                munmap(info->index_map, info->index_length);
+                munmap(info->index_map, (size_t)info->index_length);
             }
 
             if (info->data_map)
             {
-                munmap(info->data_map, info->data_length);
+                munmap(info->data_map, (size_t)info->data_length);
             }
             delete info;
         }

--- a/engine/resource/src/providers/provider_archive.cpp
+++ b/engine/resource/src/providers/provider_archive.cpp
@@ -227,8 +227,13 @@ namespace dmResourceProviderArchive
         {
             if (buffer_len < dmEndian::ToNetwork(entry->m_ArchiveInfo->m_ResourceSize))
                 return dmResourceProvider::RESULT_INVAL_ERROR;
-            dmResourceArchive::ReadEntry(archive->m_ArchiveIndex, entry->m_ArchiveInfo, buffer);
-            return dmResourceProvider::RESULT_OK;
+
+            dmResourceArchive::Result result = dmResourceArchive::ReadEntry(archive->m_ArchiveIndex,
+                                                                            entry->m_ArchiveInfo,
+                                                                            buffer);
+            return result == dmResourceArchive::RESULT_OK
+                ? dmResourceProvider::RESULT_OK
+                : dmResourceProvider::RESULT_IO_ERROR;
         }
 
         return dmResourceProvider::RESULT_NOT_FOUND;
@@ -240,8 +245,15 @@ namespace dmResourceProviderArchive
         EntryInfo* entry = archive->m_EntryMap.Get(path_hash);
         if (entry)
         {
-            dmResourceArchive::ReadEntryPartial(archive->m_ArchiveIndex, entry->m_ArchiveInfo, offset, size, buffer, nread);
-            return dmResourceProvider::RESULT_OK;
+            dmResourceArchive::Result result = dmResourceArchive::ReadEntryPartial(archive->m_ArchiveIndex,
+                                                                                   entry->m_ArchiveInfo,
+                                                                                   offset,
+                                                                                   size,
+                                                                                   buffer,
+                                                                                   nread);
+            return result == dmResourceArchive::RESULT_OK
+                ? dmResourceProvider::RESULT_OK
+                : dmResourceProvider::RESULT_IO_ERROR;
         }
 
         return dmResourceProvider::RESULT_NOT_FOUND;

--- a/engine/resource/src/providers/provider_archive_private.cpp
+++ b/engine/resource/src/providers/provider_archive_private.cpp
@@ -16,6 +16,7 @@
 #include "provider_archive_private.h"
 #include "../resource.h"
 
+#include <inttypes.h>
 #include <dlib/dstrings.h>
 #include <dlib/endian.hpp>
 #include <dlib/log.h>
@@ -60,8 +61,9 @@ namespace dmResourceProviderArchivePrivate
         uint8_t* hashes = 0;
         dmResourceArchive::EntryData* entries = 0;
 
-        // If archive is loaded from file use the member arrays for hashes and entries, otherwise read with mem offsets.
-        if (!archive->m_IsMemMapped)
+        // If archive is loaded from file, or a v5 memory mapped index was normalized,
+        // use the member arrays for hashes and entries. Otherwise read with memory offsets.
+        if (archive->m_ArchiveFileIndex && archive->m_ArchiveFileIndex->m_Entries)
         {
             hashes = archive->m_ArchiveFileIndex->m_Hashes;
             entries = archive->m_ArchiveFileIndex->m_Entries;
@@ -77,12 +79,13 @@ namespace dmResourceProviderArchivePrivate
             uint8_t* h = (hashes + dmResourceArchive::MAX_HASH * i);
             dmResourceArchive::EntryData* e = &entries[i];
 
-            uint32_t flags = dmEndian::ToNetwork(e->m_Flags);
-            printf("entry e/c/l: %d%d%d sz: %u csz: %u off: %u hash: ",
+            uint32_t flags = dmResourceArchive::GetEntryFlags(e);
+            uint64_t resource_offset = dmResourceArchive::GetEntryResourceDataOffset(e);
+            printf("entry e/c/l: %d%d%d sz: %u csz: %u off: %" PRIu64 " hash: ",
                 (flags & dmResourceArchive::ENTRY_FLAG_ENCRYPTED) != 0,
                 (flags & dmResourceArchive::ENTRY_FLAG_COMPRESSED) != 0,
                 (flags & dmResourceArchive::ENTRY_FLAG_LIVEUPDATE_DATA) != 0,
-                dmEndian::ToNetwork(e->m_ResourceSize), dmEndian::ToNetwork(e->m_ResourceCompressedSize), dmEndian::ToNetwork(e->m_ResourceDataOffset));
+                dmEndian::ToNetwork(e->m_ResourceSize), dmEndian::ToNetwork(e->m_ResourceCompressedSize), resource_offset);
 
             PrintHash(h, 20);
             printf("\n");

--- a/engine/resource/src/providers/provider_archive_private.cpp
+++ b/engine/resource/src/providers/provider_archive_private.cpp
@@ -61,8 +61,8 @@ namespace dmResourceProviderArchivePrivate
         uint8_t* hashes = 0;
         dmResourceArchive::EntryData* entries = 0;
 
-        // If archive is loaded from file, or a v5 memory mapped index was normalized,
-        // use the member arrays for hashes and entries. Otherwise read with memory offsets.
+        // If archive is loaded from file, or a 32-bit-layout memory mapped index was
+        // normalized, use the member arrays for hashes and entries. Otherwise read with memory offsets.
         if (archive->m_ArchiveFileIndex && archive->m_ArchiveFileIndex->m_Entries)
         {
             hashes = archive->m_ArchiveFileIndex->m_Hashes;

--- a/engine/resource/src/resource_archive.cpp
+++ b/engine/resource/src/resource_archive.cpp
@@ -12,11 +12,22 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
+#if defined(__linux__) && !defined(__ANDROID__) && !defined(_LARGEFILE64_SOURCE)
+#define _LARGEFILE64_SOURCE 1
+#endif
+
 #include <stdint.h>
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/types.h>
+#if defined(__ANDROID__)
+#include <fcntl.h>
+#include <unistd.h>
+#ifndef O_LARGEFILE
+#define O_LARGEFILE 0
+#endif
+#endif
 
 #include "resource.h"
 #include "resource_archive.h"
@@ -44,10 +55,37 @@ namespace dmResourceArchive
 {
     const static uint64_t FILE_LOADED_INDICATOR = 1337;
 
+    static FILE* OpenResourceData(const char* path)
+    {
+#if defined(__ANDROID__)
+        int fd = open(path, O_RDONLY | O_LARGEFILE);
+        if (fd < 0)
+        {
+            return 0;
+        }
+        FILE* file = fdopen(fd, "rb");
+        if (!file)
+        {
+            close(fd);
+            return 0;
+        }
+        setvbuf(file, 0, _IONBF, 0);
+        return file;
+#elif defined(__linux__)
+        return fopen64(path, "rb");
+#else
+        return fopen(path, "rb");
+#endif
+    }
+
     static int SeekResourceData(FILE* file, uint64_t offset)
     {
 #if defined(_WIN32)
         return _fseeki64(file, (int64_t)offset, SEEK_SET);
+#elif defined(__ANDROID__)
+        return lseek64(fileno(file), (off64_t)offset, SEEK_SET) < 0 ? -1 : 0;
+#elif defined(__linux__)
+        return fseeko64(file, (off64_t)offset, SEEK_SET);
 #else
         return fseeko(file, (off_t)offset, SEEK_SET);
 #endif
@@ -142,7 +180,7 @@ namespace dmResourceArchive
         // Mark that this archive was loaded from file, and not memory-mapped
         ai->m_Userdata = FILE_LOADED_INDICATOR;
 
-        f_data = fopen(data_file_path, "rb");
+        f_data = OpenResourceData(data_file_path);
 
         if (!f_data)
         {

--- a/engine/resource/src/resource_archive.cpp
+++ b/engine/resource/src/resource_archive.cpp
@@ -59,29 +59,9 @@ namespace dmResourceArchive
 
     DM_STATIC_ASSERT(sizeof(EntryData) == ENTRY_DATA_SIZE_V6, Invalid_Archive_EntryData_Size);
 
-    struct EntryData32
-    {
-        uint32_t m_ResourceDataOffset;
-        uint32_t m_ResourceSize;
-        uint32_t m_ResourceCompressedSize;
-        uint32_t m_Flags;
-    };
-
     static bool IsSupportedVersion(uint32_t version)
     {
-        return version == VERSION_5 || version == VERSION_6;
-    }
-
-    static bool ArchiveIndexEntryDataUses64BitOffsets(const ArchiveIndex* archive_index)
-    {
-        uint32_t version = dmEndian::ToNetwork(archive_index->m_Version);
         return version == VERSION_6;
-    }
-
-    static bool ArchiveIndexEntryDataNeedsNormalize(const ArchiveIndex* archive_index)
-    {
-        uint32_t version = dmEndian::ToNetwork(archive_index->m_Version);
-        return version == VERSION_5;
     }
 
     uint64_t PackEntryDataOffsetAndFlags(uint64_t resource_offset, uint32_t flags)
@@ -101,55 +81,14 @@ namespace dmResourceArchive
         return (uint32_t)(offset_and_flags >> ENTRY_DATA_FLAGS_SHIFT);
     }
 
-    static void ConvertEntryData32(const EntryData32* source, EntryData* target, uint32_t entry_count)
+    static Result ReadEntryData(FILE* file, uint32_t entry_count, EntryData* entries)
     {
-        for (uint32_t i = 0; i < entry_count; ++i)
-        {
-            uint64_t resource_offset = dmEndian::ToNetwork(source[i].m_ResourceDataOffset);
-            uint32_t flags = dmEndian::ToNetwork(source[i].m_Flags);
-            target[i].m_ResourceDataOffsetAndFlags = dmEndian::ToNetwork(PackEntryDataOffsetAndFlags(resource_offset, flags));
-            target[i].m_ResourceSize = source[i].m_ResourceSize;
-            target[i].m_ResourceCompressedSize = source[i].m_ResourceCompressedSize;
-        }
-    }
-
-    static Result ReadEntryData(FILE* file, const ArchiveIndex* archive_index, uint32_t entry_count, EntryData* entries)
-    {
-        if (!ArchiveIndexEntryDataUses64BitOffsets(archive_index))
-        {
-            EntryData32* entries_32 = new EntryData32[entry_count];
-            uint32_t entries_total_size = entry_count * ENTRY_DATA_SIZE_V5;
-            if (fread(entries_32, 1, entries_total_size, file) != entries_total_size)
-            {
-                delete[] entries_32;
-                return RESULT_IO_ERROR;
-            }
-            ConvertEntryData32(entries_32, entries, entry_count);
-            delete[] entries_32;
-            return RESULT_OK;
-        }
-
         uint32_t entries_total_size = entry_count * ENTRY_DATA_SIZE_V6;
         if (fread(entries, 1, entries_total_size, file) != entries_total_size)
         {
             return RESULT_IO_ERROR;
         }
         return RESULT_OK;
-    }
-
-    static void NormalizeArchiveIndex32(ArchiveIndexContainer* archive)
-    {
-        const uint32_t entry_count = dmEndian::ToNetwork(archive->m_ArchiveIndex->m_EntryDataCount);
-        const uint32_t entry_offset = dmEndian::ToNetwork(archive->m_ArchiveIndex->m_EntryDataOffset);
-        const uint32_t hash_offset = dmEndian::ToNetwork(archive->m_ArchiveIndex->m_HashOffset);
-
-        ArchiveFileIndex* file_index = archive->m_ArchiveFileIndex;
-        file_index->m_Hashes = new uint8_t[entry_count * dmResourceArchive::MAX_HASH];
-        memcpy(file_index->m_Hashes, (uint8_t*)((uintptr_t)archive->m_ArchiveIndex + hash_offset), entry_count * dmResourceArchive::MAX_HASH);
-
-        file_index->m_Entries = new EntryData[entry_count];
-        const EntryData32* entries_32 = (const EntryData32*)((uintptr_t)archive->m_ArchiveIndex + entry_offset);
-        ConvertEntryData32(entries_32, file_index->m_Entries, entry_count);
     }
 
     static void ClearArchiveFileIndexLookup(ArchiveFileIndex* file_index)
@@ -232,6 +171,23 @@ namespace dmResourceArchive
 
     // *********************************************************************************
 
+    static void DeleteArchiveFileIndex(ArchiveFileIndex* afi)
+    {
+        if (afi != 0)
+        {
+            delete[] afi->m_Entries;
+            delete[] afi->m_Hashes;
+
+            if (afi->m_FileResourceData)
+            {
+                fclose(afi->m_FileResourceData);
+                afi->m_FileResourceData = 0;
+            }
+        }
+
+        delete afi;
+    }
+
     static void CleanupResources(FILE* index_file, FILE* data_file, ArchiveIndexContainer* archive)
     {
         if (index_file)
@@ -239,19 +195,28 @@ namespace dmResourceArchive
             fclose(index_file);
         }
 
-        if (data_file)
-        {
-            fclose(data_file);
-        }
-
         if (archive)
         {
+            bool archive_file_index_owns_data_file = data_file &&
+                archive->m_ArchiveFileIndex &&
+                archive->m_ArchiveFileIndex->m_FileResourceData == data_file;
+            DeleteArchiveFileIndex(archive->m_ArchiveFileIndex);
+            if (archive_file_index_owns_data_file)
+            {
+                data_file = 0;
+            }
+
             if (archive->m_ArchiveIndex)
             {
                 delete archive->m_ArchiveIndex;
             }
 
             delete archive;
+        }
+
+        if (data_file)
+        {
+            fclose(data_file);
         }
     }
 
@@ -282,7 +247,7 @@ namespace dmResourceArchive
         uint32_t version = dmEndian::ToNetwork(ai->m_Version);
         if(!IsSupportedVersion(version))
         {
-            dmLogError("Archive version differs. Expected %d or %d, but it was %d", VERSION_5, VERSION_6, version);
+            dmLogError("Archive version differs. Expected %d, but it was %d", VERSION_6, version);
             CleanupResources(f_index, f_data, aic);
             return RESULT_VERSION_MISMATCH;
         }
@@ -303,7 +268,7 @@ namespace dmResourceArchive
 
         fseek(f_index, entry_offset, SEEK_SET);
         aic->m_ArchiveFileIndex->m_Entries = new EntryData[entry_count];
-        if (ReadEntryData(f_index, ai, entry_count, aic->m_ArchiveFileIndex->m_Entries) != RESULT_OK)
+        if (ReadEntryData(f_index, entry_count, aic->m_ArchiveFileIndex->m_Entries) != RESULT_OK)
         {
             CleanupResources(f_index, f_data, aic);
             return RESULT_IO_ERROR;
@@ -338,7 +303,7 @@ namespace dmResourceArchive
         uint32_t version = dmEndian::ToNetwork(a->m_Version);
         if (!IsSupportedVersion(version))
         {
-            dmLogError("Archive version differs. Expected %d or %d, but it was %d", VERSION_5, VERSION_6, version);
+            dmLogError("Archive version differs. Expected %d, but it was %d", VERSION_6, version);
             delete *archive;
             *archive = 0;
             return RESULT_VERSION_MISMATCH;
@@ -352,29 +317,7 @@ namespace dmResourceArchive
         (*archive)->m_ArchiveIndex = a;
         (*archive)->m_ArchiveIndexSize = index_buffer_size;
 
-        if (ArchiveIndexEntryDataNeedsNormalize(a))
-        {
-            NormalizeArchiveIndex32(*archive);
-        }
-
         return RESULT_OK;
-    }
-
-    static void DeleteArchiveFileIndex(ArchiveFileIndex* afi)
-    {
-        if (afi != 0)
-        {
-            delete[] afi->m_Entries;
-            delete[] afi->m_Hashes;
-
-            if (afi->m_FileResourceData)
-            {
-                fclose(afi->m_FileResourceData);
-                afi->m_FileResourceData = 0;
-            }
-        }
-
-        delete afi;
     }
 
     void Delete(HArchiveIndexContainer &archive)
@@ -643,11 +586,6 @@ namespace dmResourceArchive
         archive_container->m_ArchiveIndex = new_index;
         // Since we store data sequentially when doing the deep-copy we want to access it in that fashion
         archive_container->m_IsMemMapped = mem_mapped;
-
-        if (ArchiveIndexEntryDataNeedsNormalize(new_index))
-        {
-            NormalizeArchiveIndex32(archive_container);
-        }
     }
 
     uint32_t GetEntryCount(HArchiveIndexContainer archive)

--- a/engine/resource/src/resource_archive.cpp
+++ b/engine/resource/src/resource_archive.cpp
@@ -140,6 +140,19 @@ namespace dmResourceArchive
         ConvertEntryDataV5(entries_v5, file_index->m_Entries, entry_count);
     }
 
+    static void ClearArchiveFileIndexLookup(ArchiveFileIndex* file_index)
+    {
+        if (!file_index)
+        {
+            return;
+        }
+
+        delete[] file_index->m_Hashes;
+        delete[] file_index->m_Entries;
+        file_index->m_Hashes = 0;
+        file_index->m_Entries = 0;
+    }
+
     static uint8_t* GetArchiveHashes(HArchiveIndexContainer archive)
     {
         if (archive->m_ArchiveFileIndex && archive->m_ArchiveFileIndex->m_Hashes)
@@ -611,10 +624,18 @@ namespace dmResourceArchive
         {
             delete archive_container->m_ArchiveIndex;
         }
+
+        ClearArchiveFileIndexLookup(archive_container->m_ArchiveFileIndex);
+
         // Use this runtime archive index until the next reboot
         archive_container->m_ArchiveIndex = new_index;
         // Since we store data sequentially when doing the deep-copy we want to access it in that fashion
         archive_container->m_IsMemMapped = mem_mapped;
+
+        if (dmEndian::ToNetwork(new_index->m_Version) == VERSION_5)
+        {
+            NormalizeArchiveIndexV5(archive_container);
+        }
     }
 
     uint32_t GetEntryCount(HArchiveIndexContainer archive)

--- a/engine/resource/src/resource_archive.cpp
+++ b/engine/resource/src/resource_archive.cpp
@@ -16,6 +16,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <sys/types.h>
 
 #include "resource.h"
 #include "resource_archive.h"
@@ -42,6 +43,15 @@
 namespace dmResourceArchive
 {
     const static uint64_t FILE_LOADED_INDICATOR = 1337;
+
+    static int SeekResourceData(FILE* file, uint64_t offset)
+    {
+#if defined(_WIN32)
+        return _fseeki64(file, (int64_t)offset, SEEK_SET);
+#else
+        return fseeko(file, (off_t)offset, SEEK_SET);
+#endif
+    }
 
     ArchiveIndex::ArchiveIndex()
     {
@@ -318,7 +328,10 @@ namespace dmResourceArchive
         {
             // we need to read from the file on disc
             FILE* resource_file = afi->m_FileResourceData;
-            fseek(resource_file, resource_offset, SEEK_SET);
+            if (SeekResourceData(resource_file, resource_offset) != 0)
+            {
+                return dmResourceArchive::RESULT_IO_ERROR;
+            }
 
             Result result = dmResourceArchive::RESULT_OK;
             // Note, we don't need to check if it's encrypted here, as it's guaranteed to
@@ -440,7 +453,10 @@ namespace dmResourceArchive
         {
             // we need to read from the file on disc
             FILE* resource_file = afi->m_FileResourceData;
-            fseek(resource_file, resource_offset+offset, SEEK_SET);
+            if (SeekResourceData(resource_file, (uint64_t)resource_offset + offset) != 0)
+            {
+                return RESULT_IO_ERROR;
+            }
 
             // we can read directly to the output buffer
             size_t nmemb = fread(buffer, 1, size, resource_file);

--- a/engine/resource/src/resource_archive.cpp
+++ b/engine/resource/src/resource_archive.cpp
@@ -17,6 +17,7 @@
 #endif
 
 #include <stdint.h>
+#include <inttypes.h>
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -41,6 +42,7 @@
 #include <dlib/lz4.h>
 #include <dlib/memory.h>
 #include <dlib/path.h>
+#include <dlib/static_assert.h>
 #include <dlib/sys.h>
 
 #define DEBUG_LOG 1
@@ -54,6 +56,111 @@
 namespace dmResourceArchive
 {
     const static uint64_t FILE_LOADED_INDICATOR = 1337;
+
+    DM_STATIC_ASSERT(sizeof(EntryData) == ENTRY_DATA_SIZE_V6, Invalid_Archive_EntryData_Size);
+
+    struct EntryDataV5
+    {
+        uint32_t m_ResourceDataOffset;
+        uint32_t m_ResourceSize;
+        uint32_t m_ResourceCompressedSize;
+        uint32_t m_Flags;
+    };
+
+    static bool IsSupportedVersion(uint32_t version)
+    {
+        return version == VERSION_5 || version == VERSION_6;
+    }
+
+    uint64_t PackEntryDataOffsetAndFlags(uint64_t resource_offset, uint32_t flags)
+    {
+        return ((uint64_t)(flags & ENTRY_DATA_FLAGS_MASK) << ENTRY_DATA_FLAGS_SHIFT) | (resource_offset & ENTRY_DATA_OFFSET_MASK);
+    }
+
+    uint64_t GetEntryResourceDataOffset(const EntryData* entry)
+    {
+        uint64_t offset_and_flags = dmEndian::ToNetwork(entry->m_ResourceDataOffsetAndFlags);
+        return offset_and_flags & ENTRY_DATA_OFFSET_MASK;
+    }
+
+    uint32_t GetEntryFlags(const EntryData* entry)
+    {
+        uint64_t offset_and_flags = dmEndian::ToNetwork(entry->m_ResourceDataOffsetAndFlags);
+        return (uint32_t)(offset_and_flags >> ENTRY_DATA_FLAGS_SHIFT);
+    }
+
+    static void ConvertEntryDataV5(const EntryDataV5* source, EntryData* target, uint32_t entry_count)
+    {
+        for (uint32_t i = 0; i < entry_count; ++i)
+        {
+            uint64_t resource_offset = dmEndian::ToNetwork(source[i].m_ResourceDataOffset);
+            uint32_t flags = dmEndian::ToNetwork(source[i].m_Flags);
+            target[i].m_ResourceDataOffsetAndFlags = dmEndian::ToNetwork(PackEntryDataOffsetAndFlags(resource_offset, flags));
+            target[i].m_ResourceSize = source[i].m_ResourceSize;
+            target[i].m_ResourceCompressedSize = source[i].m_ResourceCompressedSize;
+        }
+    }
+
+    static Result ReadEntryData(FILE* file, uint32_t version, uint32_t entry_count, EntryData* entries)
+    {
+        if (version == VERSION_5)
+        {
+            EntryDataV5* entries_v5 = new EntryDataV5[entry_count];
+            uint32_t entries_total_size = entry_count * ENTRY_DATA_SIZE_V5;
+            if (fread(entries_v5, 1, entries_total_size, file) != entries_total_size)
+            {
+                delete[] entries_v5;
+                return RESULT_IO_ERROR;
+            }
+            ConvertEntryDataV5(entries_v5, entries, entry_count);
+            delete[] entries_v5;
+            return RESULT_OK;
+        }
+
+        uint32_t entries_total_size = entry_count * ENTRY_DATA_SIZE_V6;
+        if (fread(entries, 1, entries_total_size, file) != entries_total_size)
+        {
+            return RESULT_IO_ERROR;
+        }
+        return RESULT_OK;
+    }
+
+    static void NormalizeArchiveIndexV5(ArchiveIndexContainer* archive)
+    {
+        const uint32_t entry_count = dmEndian::ToNetwork(archive->m_ArchiveIndex->m_EntryDataCount);
+        const uint32_t entry_offset = dmEndian::ToNetwork(archive->m_ArchiveIndex->m_EntryDataOffset);
+        const uint32_t hash_offset = dmEndian::ToNetwork(archive->m_ArchiveIndex->m_HashOffset);
+
+        ArchiveFileIndex* file_index = archive->m_ArchiveFileIndex;
+        file_index->m_Hashes = new uint8_t[entry_count * dmResourceArchive::MAX_HASH];
+        memcpy(file_index->m_Hashes, (uint8_t*)((uintptr_t)archive->m_ArchiveIndex + hash_offset), entry_count * dmResourceArchive::MAX_HASH);
+
+        file_index->m_Entries = new EntryData[entry_count];
+        const EntryDataV5* entries_v5 = (const EntryDataV5*)((uintptr_t)archive->m_ArchiveIndex + entry_offset);
+        ConvertEntryDataV5(entries_v5, file_index->m_Entries, entry_count);
+    }
+
+    static uint8_t* GetArchiveHashes(HArchiveIndexContainer archive)
+    {
+        if (archive->m_ArchiveFileIndex && archive->m_ArchiveFileIndex->m_Hashes)
+        {
+            return archive->m_ArchiveFileIndex->m_Hashes;
+        }
+
+        uint32_t hash_offset = dmEndian::ToNetwork(archive->m_ArchiveIndex->m_HashOffset);
+        return (uint8_t*)((uintptr_t)archive->m_ArchiveIndex + hash_offset);
+    }
+
+    static EntryData* GetArchiveEntries(HArchiveIndexContainer archive)
+    {
+        if (archive->m_ArchiveFileIndex && archive->m_ArchiveFileIndex->m_Entries)
+        {
+            return archive->m_ArchiveFileIndex->m_Entries;
+        }
+
+        uint32_t entry_offset = dmEndian::ToNetwork(archive->m_ArchiveIndex->m_EntryDataOffset);
+        return (EntryData*)((uintptr_t)archive->m_ArchiveIndex + entry_offset);
+    }
 
     static FILE* OpenResourceData(const char* path)
     {
@@ -147,9 +254,10 @@ namespace dmResourceArchive
             return RESULT_IO_ERROR;
         }
 
-        if(dmEndian::ToNetwork(ai->m_Version) != VERSION)
+        uint32_t version = dmEndian::ToNetwork(ai->m_Version);
+        if(!IsSupportedVersion(version))
         {
-            dmLogError("Archive version differs. Expected %d, but it was %d", VERSION, dmEndian::ToNetwork(ai->m_Version));
+            dmLogError("Archive version differs. Expected %d or %d, but it was %d", VERSION_5, VERSION_6, version);
             CleanupResources(f_index, f_data, aic);
             return RESULT_VERSION_MISMATCH;
         }
@@ -170,8 +278,7 @@ namespace dmResourceArchive
 
         fseek(f_index, entry_offset, SEEK_SET);
         aic->m_ArchiveFileIndex->m_Entries = new EntryData[entry_count];
-        uint32_t entries_total_size = entry_count * sizeof(EntryData);
-        if (fread(aic->m_ArchiveFileIndex->m_Entries, 1, entries_total_size, f_index) != entries_total_size)
+        if (ReadEntryData(f_index, version, entry_count, aic->m_ArchiveFileIndex->m_Entries) != RESULT_OK)
         {
             CleanupResources(f_index, f_data, aic);
             return RESULT_IO_ERROR;
@@ -197,16 +304,18 @@ namespace dmResourceArchive
     }
 
     Result WrapArchiveBuffer(const void* index_buffer, uint32_t index_buffer_size, bool mem_mapped_index,
-                             const void* resource_data, uint32_t resource_data_size, bool mem_mapped_data,
+                             const void* resource_data, uint64_t resource_data_size, bool mem_mapped_data,
                              HArchiveIndexContainer* archive)
     {
         *archive = new ArchiveIndexContainer;
         (*archive)->m_IsMemMapped = mem_mapped_index;
         ArchiveIndex* a = (ArchiveIndex*) index_buffer;
         uint32_t version = dmEndian::ToNetwork(a->m_Version);
-        if (version != VERSION)
+        if (!IsSupportedVersion(version))
         {
-            dmLogError("Archive version differs. Expected %d, but it was %d", VERSION, version);
+            dmLogError("Archive version differs. Expected %d or %d, but it was %d", VERSION_5, VERSION_6, version);
+            delete *archive;
+            *archive = 0;
             return RESULT_VERSION_MISMATCH;
         }
 
@@ -217,6 +326,11 @@ namespace dmResourceArchive
 
         (*archive)->m_ArchiveIndex = a;
         (*archive)->m_ArchiveIndexSize = index_buffer_size;
+
+        if (version == VERSION_5)
+        {
+            NormalizeArchiveIndexV5(*archive);
+        }
 
         return RESULT_OK;
     }
@@ -262,22 +376,8 @@ namespace dmResourceArchive
     dmResourceArchive::Result FindEntry(dmResourceArchive::HArchiveIndexContainer archive, const uint8_t* hash, uint32_t hash_len, dmResourceArchive::EntryData** entry)
     {
         uint32_t entry_count = dmEndian::ToNetwork(archive->m_ArchiveIndex->m_EntryDataCount);
-        uint32_t entry_offset = dmEndian::ToNetwork(archive->m_ArchiveIndex->m_EntryDataOffset);
-        uint32_t hash_offset = dmEndian::ToNetwork(archive->m_ArchiveIndex->m_HashOffset);
-        uint8_t* hashes = 0;
-        dmResourceArchive::EntryData* entries = 0;
-
-        // If archive is loaded from file use the member arrays for hashes and entries, otherwise read with mem offsets.
-        if (!archive->m_IsMemMapped)
-        {
-            hashes = archive->m_ArchiveFileIndex->m_Hashes;
-            entries = archive->m_ArchiveFileIndex->m_Entries;
-        }
-        else
-        {
-            hashes = (uint8_t*)((uintptr_t)archive->m_ArchiveIndex + hash_offset);
-            entries = (dmResourceArchive::EntryData*)((uintptr_t)archive->m_ArchiveIndex + entry_offset);
-        }
+        uint8_t* hashes = GetArchiveHashes(archive);
+        dmResourceArchive::EntryData* entries = GetArchiveEntries(archive);
 
         // Search for hash with binary search (entries are sorted on hash)
         int first = 0;
@@ -312,32 +412,19 @@ namespace dmResourceArchive
     void DebugArchiveIndex(HArchiveIndexContainer archive)
     {
         uint32_t entry_count = dmEndian::ToNetwork(archive->m_ArchiveIndex->m_EntryDataCount);
-        uint32_t entry_offset = dmEndian::ToNetwork(archive->m_ArchiveIndex->m_EntryDataOffset);
-        uint32_t hash_offset = dmEndian::ToNetwork(archive->m_ArchiveIndex->m_HashOffset);
-        uint8_t* hashes = 0;
-        dmResourceArchive::EntryData* entries = 0;
+        uint8_t* hashes = GetArchiveHashes(archive);
+        dmResourceArchive::EntryData* entries = GetArchiveEntries(archive);
 
         dmLogInfo("HArchiveIndexContainer: %p  %s", archive, archive->m_ArchiveFileIndex?archive->m_ArchiveFileIndex->m_Path:"no path");
-
-        // If archive is loaded from file use the member arrays for hashes and entries, otherwise read with mem offsets.
-        if (!archive->m_IsMemMapped)
-        {
-            hashes = archive->m_ArchiveFileIndex->m_Hashes;
-            entries = archive->m_ArchiveFileIndex->m_Entries;
-        }
-        else
-        {
-            hashes = (uint8_t*)((uintptr_t)archive->m_ArchiveIndex + hash_offset);
-            entries = (dmResourceArchive::EntryData*)((uintptr_t)archive->m_ArchiveIndex + entry_offset);
-        }
 
         for (uint32_t i = 0; i < entry_count; ++i)
         {
             uint8_t* h = (hashes + dmResourceArchive::MAX_HASH * i);
             dmResourceArchive::EntryData* e = &entries[i];
-            uint32_t flags = dmEndian::ToNetwork(e->m_Flags);
+            uint32_t flags = GetEntryFlags(e);
+            uint64_t resource_offset = GetEntryResourceDataOffset(e);
 
-            printf("entry: off: %4u  sz: %4u  csz: %4u flags: %2u encr: %d lu: %d hash: ", dmEndian::ToNetwork(e->m_ResourceDataOffset), dmEndian::ToNetwork(e->m_ResourceSize), dmEndian::ToNetwork(e->m_ResourceCompressedSize),
+            printf("entry: off: %4" PRIu64 "  sz: %4u  csz: %4u flags: %2u encr: %d lu: %d hash: ", resource_offset, dmEndian::ToNetwork(e->m_ResourceSize), dmEndian::ToNetwork(e->m_ResourceCompressedSize),
                                 flags, flags & ENTRY_FLAG_ENCRYPTED, flags & ENTRY_FLAG_LIVEUPDATE_DATA);
             dmResource::PrintHash(h, 20);
             printf("\n");
@@ -347,9 +434,9 @@ namespace dmResourceArchive
     Result ReadEntry(HArchiveIndexContainer archive, const EntryData* entry, void* buffer)
     {
         // We always assume it's in Host format, since it may arrive from memory mapped data
-        const uint32_t flags            = dmEndian::ToNetwork(entry->m_Flags);
+        const uint32_t flags            = GetEntryFlags(entry);
         const uint32_t size             = dmEndian::ToNetwork(entry->m_ResourceSize);
-        const uint32_t resource_offset  = dmEndian::ToNetwork(entry->m_ResourceDataOffset);
+        const uint64_t resource_offset  = GetEntryResourceDataOffset(entry);
               uint32_t compressed_size  = dmEndian::ToNetwork(entry->m_ResourceCompressedSize);
 
         bool encrypted = (flags & dmResourceArchive::ENTRY_FLAG_ENCRYPTED);
@@ -470,7 +557,7 @@ namespace dmResourceArchive
     {
         // We always assume it's in Host format, since it may arrive from memory mapped data
         const uint32_t resource_size    = dmEndian::ToNetwork(entry->m_ResourceSize);
-        const uint32_t resource_offset  = dmEndian::ToNetwork(entry->m_ResourceDataOffset);
+        const uint64_t resource_offset  = GetEntryResourceDataOffset(entry);
 
         if (offset >= resource_size)
         {
@@ -491,7 +578,7 @@ namespace dmResourceArchive
         {
             // we need to read from the file on disc
             FILE* resource_file = afi->m_FileResourceData;
-            if (SeekResourceData(resource_file, (uint64_t)resource_offset + offset) != 0)
+            if (SeekResourceData(resource_file, resource_offset + offset) != 0)
             {
                 return RESULT_IO_ERROR;
             }

--- a/engine/resource/src/resource_archive.cpp
+++ b/engine/resource/src/resource_archive.cpp
@@ -59,7 +59,7 @@ namespace dmResourceArchive
 
     DM_STATIC_ASSERT(sizeof(EntryData) == ENTRY_DATA_SIZE_V6, Invalid_Archive_EntryData_Size);
 
-    struct EntryDataV5
+    struct EntryData32
     {
         uint32_t m_ResourceDataOffset;
         uint32_t m_ResourceSize;
@@ -70,6 +70,18 @@ namespace dmResourceArchive
     static bool IsSupportedVersion(uint32_t version)
     {
         return version == VERSION_5 || version == VERSION_6;
+    }
+
+    static bool ArchiveIndexEntryDataUses64BitOffsets(const ArchiveIndex* archive_index)
+    {
+        uint32_t version = dmEndian::ToNetwork(archive_index->m_Version);
+        return version == VERSION_6;
+    }
+
+    static bool ArchiveIndexEntryDataNeedsNormalize(const ArchiveIndex* archive_index)
+    {
+        uint32_t version = dmEndian::ToNetwork(archive_index->m_Version);
+        return version == VERSION_5;
     }
 
     uint64_t PackEntryDataOffsetAndFlags(uint64_t resource_offset, uint32_t flags)
@@ -89,7 +101,7 @@ namespace dmResourceArchive
         return (uint32_t)(offset_and_flags >> ENTRY_DATA_FLAGS_SHIFT);
     }
 
-    static void ConvertEntryDataV5(const EntryDataV5* source, EntryData* target, uint32_t entry_count)
+    static void ConvertEntryData32(const EntryData32* source, EntryData* target, uint32_t entry_count)
     {
         for (uint32_t i = 0; i < entry_count; ++i)
         {
@@ -101,19 +113,19 @@ namespace dmResourceArchive
         }
     }
 
-    static Result ReadEntryData(FILE* file, uint32_t version, uint32_t entry_count, EntryData* entries)
+    static Result ReadEntryData(FILE* file, const ArchiveIndex* archive_index, uint32_t entry_count, EntryData* entries)
     {
-        if (version == VERSION_5)
+        if (!ArchiveIndexEntryDataUses64BitOffsets(archive_index))
         {
-            EntryDataV5* entries_v5 = new EntryDataV5[entry_count];
+            EntryData32* entries_32 = new EntryData32[entry_count];
             uint32_t entries_total_size = entry_count * ENTRY_DATA_SIZE_V5;
-            if (fread(entries_v5, 1, entries_total_size, file) != entries_total_size)
+            if (fread(entries_32, 1, entries_total_size, file) != entries_total_size)
             {
-                delete[] entries_v5;
+                delete[] entries_32;
                 return RESULT_IO_ERROR;
             }
-            ConvertEntryDataV5(entries_v5, entries, entry_count);
-            delete[] entries_v5;
+            ConvertEntryData32(entries_32, entries, entry_count);
+            delete[] entries_32;
             return RESULT_OK;
         }
 
@@ -125,7 +137,7 @@ namespace dmResourceArchive
         return RESULT_OK;
     }
 
-    static void NormalizeArchiveIndexV5(ArchiveIndexContainer* archive)
+    static void NormalizeArchiveIndex32(ArchiveIndexContainer* archive)
     {
         const uint32_t entry_count = dmEndian::ToNetwork(archive->m_ArchiveIndex->m_EntryDataCount);
         const uint32_t entry_offset = dmEndian::ToNetwork(archive->m_ArchiveIndex->m_EntryDataOffset);
@@ -136,8 +148,8 @@ namespace dmResourceArchive
         memcpy(file_index->m_Hashes, (uint8_t*)((uintptr_t)archive->m_ArchiveIndex + hash_offset), entry_count * dmResourceArchive::MAX_HASH);
 
         file_index->m_Entries = new EntryData[entry_count];
-        const EntryDataV5* entries_v5 = (const EntryDataV5*)((uintptr_t)archive->m_ArchiveIndex + entry_offset);
-        ConvertEntryDataV5(entries_v5, file_index->m_Entries, entry_count);
+        const EntryData32* entries_32 = (const EntryData32*)((uintptr_t)archive->m_ArchiveIndex + entry_offset);
+        ConvertEntryData32(entries_32, file_index->m_Entries, entry_count);
     }
 
     static void ClearArchiveFileIndexLookup(ArchiveFileIndex* file_index)
@@ -175,7 +187,7 @@ namespace dmResourceArchive
         return (EntryData*)((uintptr_t)archive->m_ArchiveIndex + entry_offset);
     }
 
-    static FILE* OpenResourceData(const char* path)
+    static FILE* FileOpen64(const char* path)
     {
 #if defined(__ANDROID__)
         int fd = open(path, O_RDONLY | O_LARGEFILE);
@@ -198,7 +210,7 @@ namespace dmResourceArchive
 #endif
     }
 
-    static int SeekResourceData(FILE* file, uint64_t offset)
+    static int FileSeek64(FILE* file, uint64_t offset)
     {
 #if defined(_WIN32)
         return _fseeki64(file, (int64_t)offset, SEEK_SET);
@@ -291,7 +303,7 @@ namespace dmResourceArchive
 
         fseek(f_index, entry_offset, SEEK_SET);
         aic->m_ArchiveFileIndex->m_Entries = new EntryData[entry_count];
-        if (ReadEntryData(f_index, version, entry_count, aic->m_ArchiveFileIndex->m_Entries) != RESULT_OK)
+        if (ReadEntryData(f_index, ai, entry_count, aic->m_ArchiveFileIndex->m_Entries) != RESULT_OK)
         {
             CleanupResources(f_index, f_data, aic);
             return RESULT_IO_ERROR;
@@ -300,7 +312,7 @@ namespace dmResourceArchive
         // Mark that this archive was loaded from file, and not memory-mapped
         ai->m_Userdata = FILE_LOADED_INDICATOR;
 
-        f_data = OpenResourceData(data_file_path);
+        f_data = FileOpen64(data_file_path);
 
         if (!f_data)
         {
@@ -340,9 +352,9 @@ namespace dmResourceArchive
         (*archive)->m_ArchiveIndex = a;
         (*archive)->m_ArchiveIndexSize = index_buffer_size;
 
-        if (version == VERSION_5)
+        if (ArchiveIndexEntryDataNeedsNormalize(a))
         {
-            NormalizeArchiveIndexV5(*archive);
+            NormalizeArchiveIndex32(*archive);
         }
 
         return RESULT_OK;
@@ -466,7 +478,7 @@ namespace dmResourceArchive
         {
             // we need to read from the file on disc
             FILE* resource_file = afi->m_FileResourceData;
-            if (SeekResourceData(resource_file, resource_offset) != 0)
+            if (FileSeek64(resource_file, resource_offset) != 0)
             {
                 return dmResourceArchive::RESULT_IO_ERROR;
             }
@@ -591,7 +603,7 @@ namespace dmResourceArchive
         {
             // we need to read from the file on disc
             FILE* resource_file = afi->m_FileResourceData;
-            if (SeekResourceData(resource_file, resource_offset + offset) != 0)
+            if (FileSeek64(resource_file, resource_offset + offset) != 0)
             {
                 return RESULT_IO_ERROR;
             }
@@ -632,9 +644,9 @@ namespace dmResourceArchive
         // Since we store data sequentially when doing the deep-copy we want to access it in that fashion
         archive_container->m_IsMemMapped = mem_mapped;
 
-        if (dmEndian::ToNetwork(new_index->m_Version) == VERSION_5)
+        if (ArchiveIndexEntryDataNeedsNormalize(new_index))
         {
-            NormalizeArchiveIndexV5(archive_container);
+            NormalizeArchiveIndex32(archive_container);
         }
     }
 

--- a/engine/resource/src/resource_archive.h
+++ b/engine/resource/src/resource_archive.h
@@ -76,7 +76,7 @@ namespace dmResourceArchive
             m_ResourceSize(0),
             m_ResourceCompressedSize(0) {}
 
-        uint64_t m_ResourceDataOffsetAndFlags; // v6 packs 4 high flag bits and 60 low offset bits
+        uint64_t m_ResourceDataOffsetAndFlags; // Internal/64-bit layout packs 4 high flag bits and 60 low offset bits
         uint32_t m_ResourceSize;
         uint32_t m_ResourceCompressedSize;  // 0xFFFFFFFF if uncompressed
     };
@@ -92,7 +92,7 @@ namespace dmResourceArchive
 
         uint32_t m_Version;
         uint32_t :32;
-        uint64_t m_Userdata;
+        uint64_t m_Userdata; // Runtime may overwrite this after loading.
         uint32_t m_EntryDataCount;
         uint32_t m_EntryDataOffset;
         uint32_t m_HashOffset;

--- a/engine/resource/src/resource_archive.h
+++ b/engine/resource/src/resource_archive.h
@@ -33,7 +33,15 @@ namespace dmResourceArchive
      * to check a manifest to ensure that it's compatible with the engine's
      * version of the archive format.
      */
-    const static uint32_t VERSION = 5;
+    const static uint32_t VERSION_5 = 5;
+    const static uint32_t VERSION_6 = 6;
+    const static uint32_t VERSION = VERSION_6;
+    const static uint32_t ENTRY_DATA_SIZE_V5 = 16;
+    const static uint32_t ENTRY_DATA_SIZE_V6 = 16;
+    const static uint32_t ENTRY_DATA_FLAGS_BITS = 4;
+    const static uint32_t ENTRY_DATA_FLAGS_SHIFT = 64 - ENTRY_DATA_FLAGS_BITS;
+    const static uint32_t ENTRY_DATA_FLAGS_MASK = (1 << ENTRY_DATA_FLAGS_BITS) - 1;
+    const static uint64_t ENTRY_DATA_OFFSET_MASK = (1ULL << ENTRY_DATA_FLAGS_SHIFT) - 1;
 
     // Maximum hash length convention. This size should large enough.
     // If this length changes the VERSION needs to be bumped.
@@ -61,19 +69,21 @@ namespace dmResourceArchive
     };
 
     // part of the .arci file format
-    struct DM_ALIGNED(16) EntryData
+    struct EntryData
     {
         EntryData() :
-            m_ResourceDataOffset(0),
+            m_ResourceDataOffsetAndFlags(0),
             m_ResourceSize(0),
-            m_ResourceCompressedSize(0),
-            m_Flags(0) {}
+            m_ResourceCompressedSize(0) {}
 
-        uint32_t m_ResourceDataOffset;
+        uint64_t m_ResourceDataOffsetAndFlags; // v6 packs 4 high flag bits and 60 low offset bits
         uint32_t m_ResourceSize;
         uint32_t m_ResourceCompressedSize;  // 0xFFFFFFFF if uncompressed
-        uint32_t m_Flags;                   // A combination of dmResourceArchive::EntryFlag
     };
+
+    uint64_t PackEntryDataOffsetAndFlags(uint64_t resource_offset, uint32_t flags);
+    uint64_t GetEntryResourceDataOffset(const EntryData* entry);
+    uint32_t GetEntryFlags(const EntryData* entry);
 
     // For memory mapped files (or files read directly into memory)
     struct DM_ALIGNED(16) ArchiveIndex
@@ -102,7 +112,7 @@ namespace dmResourceArchive
         EntryData*  m_Entries;          // Indices of this list matches indices of m_Hashes
         FILE*       m_FileResourceData; // game.arcd file handle
         uint8_t*    m_ResourceData;     // mem-mapped game.arcd
-        uint32_t    m_ResourceSize;     // the size of the memory mapped region
+        uint64_t    m_ResourceSize;     // the size of the memory mapped region
         bool        m_IsMemMapped;      // Is the data memory mapped?
     };
 
@@ -133,7 +143,7 @@ namespace dmResourceArchive
     // It is written by the ArchiveBuilder.java in writeResourcePack()
     struct DM_ALIGNED(16) LiveUpdateResourceHeader {
         uint32_t    m_Size;
-        uint8_t     m_Flags;        // See dmResourceArchive::EntryData / EntryFlag
+        uint8_t     m_Flags;        // See dmResourceArchive::EntryFlag
         uint8_t     m_Padding[11];
     };
 
@@ -190,7 +200,7 @@ namespace dmResourceArchive
      * @return RESULT_OK on success
      */
     Result WrapArchiveBuffer(const void* index_buffer, uint32_t index_buffer_size, bool mem_mapped_index,
-                             const void* resource_data, uint32_t resource_data_size, bool mem_mapped_data,
+                             const void* resource_data, uint64_t resource_data_size, bool mem_mapped_data,
                              HArchiveIndexContainer* archive);
 
     /**

--- a/engine/resource/src/resource_archive.h
+++ b/engine/resource/src/resource_archive.h
@@ -33,10 +33,8 @@ namespace dmResourceArchive
      * to check a manifest to ensure that it's compatible with the engine's
      * version of the archive format.
      */
-    const static uint32_t VERSION_5 = 5;
     const static uint32_t VERSION_6 = 6;
     const static uint32_t VERSION = VERSION_6;
-    const static uint32_t ENTRY_DATA_SIZE_V5 = 16;
     const static uint32_t ENTRY_DATA_SIZE_V6 = 16;
     const static uint32_t ENTRY_DATA_FLAGS_BITS = 4;
     const static uint32_t ENTRY_DATA_FLAGS_SHIFT = 64 - ENTRY_DATA_FLAGS_BITS;

--- a/engine/resource/src/test/CMakeLists.txt
+++ b/engine/resource/src/test/CMakeLists.txt
@@ -191,6 +191,32 @@ resource_archive(RESOURCE_LU_BASE_OUTPUTS luresources_base FALSE ${RESOURCE_ARCH
 resource_archive(RESOURCE_LU_COMPRESSED_OUTPUTS luresources_compressed TRUE ${RESOURCE_ARCHIVE_OUTPUTS})
 resource_archive(RESOURCE_PB_OUTPUTS resources_pb FALSE ${RESOURCE_PROTO_MESSAGE_OUTPUTS})
 
+set(RESOURCE_ARCHIVE_EMBED_INPUTS
+  "${RESOURCE_TEST_BUILD_DIR}/resources.arci"
+  "${RESOURCE_TEST_BUILD_DIR}/resources.arcd"
+  "${RESOURCE_TEST_BUILD_DIR}/resources.dmanifest"
+  "${RESOURCE_TEST_BUILD_DIR}/resources.manifest_hash"
+  "${RESOURCE_TEST_BUILD_DIR}/resources_compressed.arci"
+  "${RESOURCE_TEST_BUILD_DIR}/resources_compressed.arcd"
+  "${RESOURCE_TEST_BUILD_DIR}/resources_compressed.dmanifest"
+  "${RESOURCE_TEST_BUILD_DIR}/resources_no_lu.arci"
+  "${RESOURCE_TEST_BUILD_DIR}/resources_no_lu.arcd"
+  "${RESOURCE_TEST_BUILD_DIR}/resources_no_lu.dmanifest")
+
+set(RESOURCE_ARCHIVE_EMBED_SOURCES)
+foreach(_resource_archive_embed_input IN LISTS RESOURCE_ARCHIVE_EMBED_INPUTS)
+  get_filename_component(_resource_archive_embed_name "${_resource_archive_embed_input}" NAME)
+  set(_resource_archive_embed_h "${CMAKE_CURRENT_BINARY_DIR}/generated/embed/${_resource_archive_embed_name}.embed.h")
+  set(_resource_archive_embed_cpp "${CMAKE_CURRENT_BINARY_DIR}/generated/embed/${_resource_archive_embed_name}.embed.cpp")
+  defold_embed_to_header(
+    INPUT "${_resource_archive_embed_input}"
+    OUTPUT_HEADER "${_resource_archive_embed_h}"
+    OUTPUT_CPP "${_resource_archive_embed_cpp}")
+  list(APPEND RESOURCE_ARCHIVE_EMBED_SOURCES "${_resource_archive_embed_cpp}")
+endforeach()
+
+set_source_files_properties(${RESOURCE_ARCHIVE_EMBED_SOURCES} PROPERTIES GENERATED TRUE)
+
 set(RESOURCE_LU_OUTPUTS)
 foreach(_resource_ext IN ITEMS arci arcd dmanifest manifest_hash)
   set(_resource_lu_output "${RESOURCE_TEST_BUILD_DIR}/luresources.${_resource_ext}")
@@ -317,3 +343,9 @@ resource_configure_test(test_provider_multi ON ResourceProviderArchive ResourceP
 
 defold_add_executable(test_resource_chunk_cache "${RESOURCE_TEST_ROOT}/test_resource_chunk_cache.cpp")
 resource_configure_test(test_resource_chunk_cache ON ResourceProviderArchive)
+
+defold_add_executable(test_resource_archive
+  "${RESOURCE_TEST_ROOT}/test_resource_archive.cpp"
+  ${RESOURCE_ARCHIVE_EMBED_SOURCES})
+resource_configure_test(test_resource_archive ON)
+defold_target_link_app(test_resource_archive "${TARGET_PLATFORM}" SCOPE PRIVATE)

--- a/engine/resource/src/test/test_resource_archive.cpp
+++ b/engine/resource/src/test/test_resource_archive.cpp
@@ -177,7 +177,7 @@ static bool TestMarkFileSparse(FILE* file)
 #endif
 }
 
-static bool WriteArchiveIndexV5(const char* archive_path, const uint8_t* hash, uint32_t hash_len, uint32_t resource_offset, uint32_t resource_size)
+static bool WriteArchiveHeaderWithVersion(const char* archive_path, uint32_t version)
 {
     FILE* file = fopen(archive_path, "wb");
     if (!file)
@@ -187,25 +187,9 @@ static bool WriteArchiveIndexV5(const char* archive_path, const uint8_t* hash, u
 
     dmResourceArchive::ArchiveIndex header;
     memset(&header, 0, sizeof(header));
-    header.m_Version = dmEndian::ToNetwork(dmResourceArchive::VERSION_5);
-    header.m_EntryDataCount = dmEndian::ToNetwork(1U);
-    header.m_EntryDataOffset = dmEndian::ToNetwork((uint32_t)(sizeof(dmResourceArchive::ArchiveIndex) + dmResourceArchive::MAX_HASH));
-    header.m_HashOffset = dmEndian::ToNetwork((uint32_t)sizeof(dmResourceArchive::ArchiveIndex));
-    header.m_HashLength = dmEndian::ToNetwork(hash_len);
-
-    uint8_t hash_buffer[dmResourceArchive::MAX_HASH] = { 0 };
-    memcpy(hash_buffer, hash, hash_len);
-
-    uint32_t entry[4] = {
-        dmEndian::ToNetwork(resource_offset),
-        dmEndian::ToNetwork(resource_size),
-        dmEndian::ToNetwork(0xFFFFFFFFU),
-        dmEndian::ToNetwork(0U)
-    };
+    header.m_Version = dmEndian::ToNetwork(version);
 
     bool ok = fwrite(&header, 1, sizeof(header), file) == sizeof(header);
-    ok = ok && fwrite(hash_buffer, 1, sizeof(hash_buffer), file) == sizeof(hash_buffer);
-    ok = ok && fwrite(&entry, 1, sizeof(entry), file) == sizeof(entry);
     fclose(file);
     return ok;
 }
@@ -562,50 +546,26 @@ TEST(dmResourceArchive, LoadFromDisk_Compressed)
     dmResourceArchive::Delete(archive);
 }
 
-// Old v5 archives can place data above 2 GiB, so the v6 reader changes must keep treating
-// the 32-bit offset field as unsigned. This hand-written v5 index points at a sparse
-// .arcd payload at 0x80000010 and verifies both full and partial file-backed reads.
-TEST(dmResourceArchive, LoadFromDisk_ResourceOffsetAbove2GiB)
+// New builds no longer need v5 archive compatibility. This minimal v5 index
+// verifies the engine rejects the archive version before attempting to load
+// hashes or entries using the old layout.
+TEST(dmResourceArchive, LoadFromDisk_RejectsVersion5Archive)
 {
-    const uint32_t resource_offset = 0x80000010U;
-    const uint8_t hash[20] = {
-        0x90, 0x9b, 0x2f, 0x3a, 0x7d, 0x0e, 0x41, 0x87, 0xa1, 0x54,
-        0x98, 0x77, 0x65, 0x43, 0x21, 0x10, 0xca, 0xfe, 0xba, 0xbe
-    };
-    const uint8_t payload[] = { 0xde, 0xad, 0xbe, 0xef, 0x11, 0x22, 0x33, 0x44 };
-
     char archive_path[512];
     char resource_path[512];
-    dmTestUtil::MakeHostPath(archive_path, sizeof(archive_path), "build/src/test/large_offset_sparse.arci");
-    dmTestUtil::MakeHostPath(resource_path, sizeof(resource_path), "build/src/test/large_offset_sparse.arcd");
+    dmTestUtil::MakeHostPath(archive_path, sizeof(archive_path), "build/src/test/version5_unsupported.arci");
+    dmTestUtil::MakeHostPath(resource_path, sizeof(resource_path), "build/src/test/version5_unsupported.arcd");
 
     remove(archive_path);
     remove(resource_path);
 
-    ASSERT_TRUE(WriteArchiveIndexV5(archive_path, hash, sizeof(hash), resource_offset, sizeof(payload)));
-    ASSERT_TRUE(WriteLargeOffsetArchiveData(resource_path, resource_offset, payload, sizeof(payload)));
+    ASSERT_TRUE(WriteArchiveHeaderWithVersion(archive_path, 5));
 
     dmResourceArchive::HArchiveIndexContainer archive = 0;
     dmResourceArchive::Result result = dmResourceArchive::LoadArchiveFromFile(archive_path, resource_path, &archive);
-    ASSERT_EQ(dmResourceArchive::RESULT_OK, result);
+    ASSERT_EQ(dmResourceArchive::RESULT_VERSION_MISMATCH, result);
+    ASSERT_EQ((dmResourceArchive::HArchiveIndexContainer)0, archive);
 
-    dmResourceArchive::EntryData* entry = 0;
-    result = dmResourceArchive::FindEntry(archive, hash, sizeof(hash), &entry);
-    ASSERT_EQ(dmResourceArchive::RESULT_OK, result);
-
-    uint8_t buffer[sizeof(payload)] = { 0 };
-    result = dmResourceArchive::ReadEntry(archive, entry, buffer);
-    ASSERT_EQ(dmResourceArchive::RESULT_OK, result);
-    ASSERT_ARRAY_EQ_LEN(payload, buffer, sizeof(payload));
-
-    uint8_t partial_buffer[4] = { 0 };
-    uint32_t nread = 0;
-    result = dmResourceArchive::ReadEntryPartial(archive, entry, 2, sizeof(partial_buffer), partial_buffer, &nread);
-    ASSERT_EQ(dmResourceArchive::RESULT_OK, result);
-    ASSERT_EQ((uint32_t)sizeof(partial_buffer), nread);
-    ASSERT_ARRAY_EQ_LEN(payload + 2, partial_buffer, sizeof(partial_buffer));
-
-    dmResourceArchive::Delete(archive);
     remove(archive_path);
     remove(resource_path);
 }
@@ -674,7 +634,7 @@ TEST(dmResourceArchive, MountArchiveInternal_ResourceOffsetAbove4GiB)
     remove(resource_path);
 }
 
-// File-backed archives keep normalized hash/entry arrays for v5 indexes. Replacing the
+// File-backed archives keep hash/entry arrays beside the loaded index. Replacing the
 // active index must discard those arrays, otherwise lookups continue using the old index.
 TEST(dmResourceArchive, SetNewArchiveIndex_ClearsFileBackedLookupArrays)
 {
@@ -690,13 +650,13 @@ TEST(dmResourceArchive, SetNewArchiveIndex_ClearsFileBackedLookupArrays)
 
     char archive_path[512];
     char resource_path[512];
-    dmTestUtil::MakeHostPath(archive_path, sizeof(archive_path), "build/src/test/replace_index_v5.arci");
-    dmTestUtil::MakeHostPath(resource_path, sizeof(resource_path), "build/src/test/replace_index_v5.arcd");
+    dmTestUtil::MakeHostPath(archive_path, sizeof(archive_path), "build/src/test/replace_index_v6.arci");
+    dmTestUtil::MakeHostPath(resource_path, sizeof(resource_path), "build/src/test/replace_index_v6.arcd");
 
     remove(archive_path);
     remove(resource_path);
 
-    ASSERT_TRUE(WriteArchiveIndexV5(archive_path, old_hash, sizeof(old_hash), 0, sizeof(payload)));
+    ASSERT_TRUE(WriteArchiveIndexV6(archive_path, old_hash, sizeof(old_hash), 0, sizeof(payload), 0));
     ASSERT_TRUE(WriteLargeOffsetArchiveData(resource_path, 0, payload, sizeof(payload)));
 
     dmResourceArchive::HArchiveIndexContainer archive = 0;

--- a/engine/resource/src/test/test_resource_archive.cpp
+++ b/engine/resource/src/test/test_resource_archive.cpp
@@ -256,6 +256,37 @@ static bool WriteLargeOffsetArchiveData(const char* resource_path, uint64_t reso
     return ok;
 }
 
+static void WriteLargeOffsetArchiveV6(const char* archive_path, const char* resource_path, const uint8_t* hash, uint32_t hash_len, uint64_t resource_offset, const uint8_t* payload, uint32_t payload_size, uint32_t flags)
+{
+    remove(archive_path);
+    remove(resource_path);
+
+    ASSERT_TRUE(WriteArchiveIndexV6(archive_path, hash, hash_len, resource_offset, payload_size, flags));
+    ASSERT_TRUE(WriteLargeOffsetArchiveData(resource_path, resource_offset, payload, payload_size));
+}
+
+static void AssertArchiveEntryReadable(dmResourceArchive::HArchiveIndexContainer archive, const uint8_t* hash, uint32_t hash_len, uint64_t resource_offset, uint32_t flags, const uint8_t* payload, uint32_t payload_size)
+{
+    dmResourceArchive::EntryData* entry = 0;
+    dmResourceArchive::Result result = dmResourceArchive::FindEntry(archive, hash, hash_len, &entry);
+    ASSERT_EQ(dmResourceArchive::RESULT_OK, result);
+    ASSERT_EQ(resource_offset, dmResourceArchive::GetEntryResourceDataOffset(entry));
+    ASSERT_EQ(flags, dmResourceArchive::GetEntryFlags(entry));
+
+    uint8_t buffer[16] = { 0 };
+    ASSERT_LE(payload_size, (uint32_t)sizeof(buffer));
+    result = dmResourceArchive::ReadEntry(archive, entry, buffer);
+    ASSERT_EQ(dmResourceArchive::RESULT_OK, result);
+    ASSERT_ARRAY_EQ_LEN(payload, buffer, payload_size);
+
+    uint8_t partial_buffer[4] = { 0 };
+    uint32_t nread = 0;
+    result = dmResourceArchive::ReadEntryPartial(archive, entry, 2, sizeof(partial_buffer), partial_buffer, &nread);
+    ASSERT_EQ(dmResourceArchive::RESULT_OK, result);
+    ASSERT_EQ((uint32_t)sizeof(partial_buffer), nread);
+    ASSERT_ARRAY_EQ_LEN(payload + 2, partial_buffer, sizeof(partial_buffer));
+}
+
 bool IsLiveUpdateResource(dmhash_t lu_path_hash)
 {
     for (uint32_t i = 0; i < (sizeof(liveupdate_path_hash) / sizeof(liveupdate_path_hash[0])); ++i)
@@ -597,35 +628,47 @@ TEST(dmResourceArchive, LoadFromDisk_ResourceOffsetAbove4GiB)
     dmTestUtil::MakeHostPath(archive_path, sizeof(archive_path), "build/src/test/large_offset_v6_sparse.arci");
     dmTestUtil::MakeHostPath(resource_path, sizeof(resource_path), "build/src/test/large_offset_v6_sparse.arcd");
 
-    remove(archive_path);
-    remove(resource_path);
-
-    ASSERT_TRUE(WriteArchiveIndexV6(archive_path, hash, sizeof(hash), resource_offset, sizeof(payload), flags));
-    ASSERT_TRUE(WriteLargeOffsetArchiveData(resource_path, resource_offset, payload, sizeof(payload)));
+    WriteLargeOffsetArchiveV6(archive_path, resource_path, hash, sizeof(hash), resource_offset, payload, sizeof(payload), flags);
 
     dmResourceArchive::HArchiveIndexContainer archive = 0;
     dmResourceArchive::Result result = dmResourceArchive::LoadArchiveFromFile(archive_path, resource_path, &archive);
     ASSERT_EQ(dmResourceArchive::RESULT_OK, result);
 
-    dmResourceArchive::EntryData* entry = 0;
-    result = dmResourceArchive::FindEntry(archive, hash, sizeof(hash), &entry);
-    ASSERT_EQ(dmResourceArchive::RESULT_OK, result);
-    ASSERT_EQ(resource_offset, dmResourceArchive::GetEntryResourceDataOffset(entry));
-    ASSERT_EQ(flags, dmResourceArchive::GetEntryFlags(entry));
-
-    uint8_t buffer[sizeof(payload)] = { 0 };
-    result = dmResourceArchive::ReadEntry(archive, entry, buffer);
-    ASSERT_EQ(dmResourceArchive::RESULT_OK, result);
-    ASSERT_ARRAY_EQ_LEN(payload, buffer, sizeof(payload));
-
-    uint8_t partial_buffer[4] = { 0 };
-    uint32_t nread = 0;
-    result = dmResourceArchive::ReadEntryPartial(archive, entry, 2, sizeof(partial_buffer), partial_buffer, &nread);
-    ASSERT_EQ(dmResourceArchive::RESULT_OK, result);
-    ASSERT_EQ((uint32_t)sizeof(partial_buffer), nread);
-    ASSERT_ARRAY_EQ_LEN(payload + 2, partial_buffer, sizeof(partial_buffer));
+    AssertArchiveEntryReadable(archive, hash, sizeof(hash), resource_offset, flags, payload, sizeof(payload));
 
     dmResourceArchive::Delete(archive);
+    remove(archive_path);
+    remove(resource_path);
+}
+
+// Platform mount code may choose mmap instead of the file-backed archive reader. This
+// verifies that mounting a local v6 archive with data above 4 GiB still allows full and
+// partial reads through the mounted archive handle.
+TEST(dmResourceArchive, MountArchiveInternal_ResourceOffsetAbove4GiB)
+{
+    const uint64_t resource_offset = 0x100000010ULL;
+    const uint32_t flags = 1 << 3;
+    const uint8_t hash[20] = {
+        0x63, 0xd9, 0xa1, 0x2b, 0x5c, 0x6d, 0x7e, 0x8f, 0x90, 0xab,
+        0xbc, 0xcd, 0xde, 0xef, 0x10, 0x21, 0x32, 0x43, 0x54, 0x66
+    };
+    const uint8_t payload[] = { 0x4d, 0x4e, 0x54, 0x36, 0xde, 0xad, 0xbe, 0xef };
+
+    char archive_path[512];
+    char resource_path[512];
+    dmTestUtil::MakeHostPath(archive_path, sizeof(archive_path), "build/src/test/mount_large_offset_v6_sparse.arci");
+    dmTestUtil::MakeHostPath(resource_path, sizeof(resource_path), "build/src/test/mount_large_offset_v6_sparse.arcd");
+
+    WriteLargeOffsetArchiveV6(archive_path, resource_path, hash, sizeof(hash), resource_offset, payload, sizeof(payload), flags);
+
+    dmResourceArchive::HArchiveIndexContainer archive = 0;
+    void* mount_info = 0;
+    dmResource::Result mount_result = dmResource::MountArchiveInternal(archive_path, resource_path, &archive, &mount_info);
+    ASSERT_EQ(dmResource::RESULT_OK, mount_result);
+
+    AssertArchiveEntryReadable(archive, hash, sizeof(hash), resource_offset, flags, payload, sizeof(payload));
+
+    dmResource::UnmountArchiveInternal(archive, mount_info);
     remove(archive_path);
     remove(resource_path);
 }

--- a/engine/resource/src/test/test_resource_archive.cpp
+++ b/engine/resource/src/test/test_resource_archive.cpp
@@ -229,14 +229,15 @@ static bool WriteArchiveIndexV6(const char* archive_path, const uint8_t* hash, u
     uint8_t hash_buffer[dmResourceArchive::MAX_HASH] = { 0 };
     memcpy(hash_buffer, hash, hash_len);
 
+    bool ok = fwrite(&header, 1, sizeof(header), file) == sizeof(header);
+    ok = ok && fwrite(hash_buffer, 1, sizeof(hash_buffer), file) == sizeof(hash_buffer);
+
     dmResourceArchive::EntryData entry;
     entry.m_ResourceDataOffsetAndFlags = dmEndian::ToNetwork(dmResourceArchive::PackEntryDataOffsetAndFlags(resource_offset, flags));
     entry.m_ResourceSize = dmEndian::ToNetwork(resource_size);
     entry.m_ResourceCompressedSize = dmEndian::ToNetwork(0xFFFFFFFFU);
-
-    bool ok = fwrite(&header, 1, sizeof(header), file) == sizeof(header);
-    ok = ok && fwrite(hash_buffer, 1, sizeof(hash_buffer), file) == sizeof(hash_buffer);
     ok = ok && fwrite(&entry, 1, sizeof(entry), file) == sizeof(entry);
+
     fclose(file);
     return ok;
 }
@@ -610,9 +611,9 @@ TEST(dmResourceArchive, LoadFromDisk_ResourceOffsetAbove2GiB)
 }
 
 // V6 exists to let .arcd data grow past the uint32 offset limit while keeping resource
-// sizes uint32. This hand-written v6 index packs the currently unused fourth flag bit
-// with an offset above 4 GiB, writes a tiny payload there in a sparse .arcd, and verifies
-// the decoded flags plus full and partial file-backed reads.
+// sizes uint32. The entry packs the currently unused fourth flag bit with an offset
+// above 4 GiB, writes a tiny payload there in a sparse .arcd, and verifies the decoded
+// flags plus full and partial file-backed reads.
 TEST(dmResourceArchive, LoadFromDisk_ResourceOffsetAbove4GiB)
 {
     const uint64_t resource_offset = 0x100000010ULL;

--- a/engine/resource/src/test/test_resource_archive.cpp
+++ b/engine/resource/src/test/test_resource_archive.cpp
@@ -13,6 +13,16 @@
 // specific language governing permissions and limitations under the License.
 
 #include <stdint.h>
+#include <stdio.h>
+#include <sys/types.h>
+#if defined(_WIN32)
+#include <io.h>
+#include <dlib/safe_windows.h>
+#ifndef _MSC_VER
+#include <windows.h>
+#endif
+#include <winioctl.h>
+#endif
 #include "../resource.h"
 #include "../resource_manifest.h"
 #include "../resource_manifest_private.h"
@@ -104,6 +114,78 @@ static const uint8_t compressed_content_hash[][20] = {
     {  16U, 184U, 254U, 147U, 172U,  48U,  89U, 214U,  29U,  90U, 128U, 156U,  37U,  60U, 100U,  69U, 246U, 252U, 122U,  99U },
     {  90U,  15U,  50U,  67U, 184U,   5U, 147U, 194U, 160U, 203U,  45U, 150U,  20U, 194U,  55U, 123U, 189U, 218U, 105U, 103U }
 };
+
+static int TestSeekFile64(FILE* file, uint64_t offset)
+{
+#if defined(_WIN32)
+    return _fseeki64(file, (int64_t)offset, SEEK_SET);
+#else
+    return fseeko(file, (off_t)offset, SEEK_SET);
+#endif
+}
+
+static bool TestMarkFileSparse(FILE* file)
+{
+#if defined(_WIN32)
+    HANDLE handle = (HANDLE)_get_osfhandle(_fileno(file));
+    if (handle == INVALID_HANDLE_VALUE)
+    {
+        return false;
+    }
+
+    DWORD bytes_returned = 0;
+    return DeviceIoControl(handle, FSCTL_SET_SPARSE, 0, 0, 0, 0, &bytes_returned, 0) != 0;
+#else
+    return true;
+#endif
+}
+
+static bool WriteLargeOffsetArchiveIndex(const char* archive_path, const uint8_t* hash, uint32_t hash_len, uint32_t resource_offset, uint32_t resource_size)
+{
+    FILE* file = fopen(archive_path, "wb");
+    if (!file)
+    {
+        return false;
+    }
+
+    dmResourceArchive::ArchiveIndex header;
+    memset(&header, 0, sizeof(header));
+    header.m_Version = dmEndian::ToNetwork(dmResourceArchive::VERSION);
+    header.m_EntryDataCount = dmEndian::ToNetwork(1U);
+    header.m_EntryDataOffset = dmEndian::ToNetwork((uint32_t)(sizeof(dmResourceArchive::ArchiveIndex) + dmResourceArchive::MAX_HASH));
+    header.m_HashOffset = dmEndian::ToNetwork((uint32_t)sizeof(dmResourceArchive::ArchiveIndex));
+    header.m_HashLength = dmEndian::ToNetwork(hash_len);
+
+    uint8_t hash_buffer[dmResourceArchive::MAX_HASH] = { 0 };
+    memcpy(hash_buffer, hash, hash_len);
+
+    dmResourceArchive::EntryData entry;
+    entry.m_ResourceDataOffset = dmEndian::ToNetwork(resource_offset);
+    entry.m_ResourceSize = dmEndian::ToNetwork(resource_size);
+    entry.m_ResourceCompressedSize = dmEndian::ToNetwork(0xFFFFFFFFU);
+    entry.m_Flags = dmEndian::ToNetwork(0U);
+
+    bool ok = fwrite(&header, 1, sizeof(header), file) == sizeof(header);
+    ok = ok && fwrite(hash_buffer, 1, sizeof(hash_buffer), file) == sizeof(hash_buffer);
+    ok = ok && fwrite(&entry, 1, sizeof(entry), file) == sizeof(entry);
+    fclose(file);
+    return ok;
+}
+
+static bool WriteLargeOffsetArchiveData(const char* resource_path, uint32_t resource_offset, const uint8_t* payload, uint32_t payload_size)
+{
+    FILE* file = fopen(resource_path, "wb");
+    if (!file)
+    {
+        return false;
+    }
+
+    bool ok = TestMarkFileSparse(file);
+    ok = ok && TestSeekFile64(file, resource_offset) == 0;
+    ok = ok && fwrite(payload, 1, payload_size, file) == payload_size;
+    fclose(file);
+    return ok;
+}
 
 bool IsLiveUpdateResource(dmhash_t lu_path_hash)
 {
@@ -377,6 +459,52 @@ TEST(dmResourceArchive, LoadFromDisk_Compressed)
     ASSERT_EQ(dmResourceArchive::RESULT_NOT_FOUND, result);
 
     dmResourceArchive::Delete(archive);
+}
+
+// Verifies that disk-backed archive reads can seek to resources whose data starts beyond 2 GiB.
+TEST(dmResourceArchive, LoadFromDisk_ResourceOffsetAbove2GiB)
+{
+    const uint32_t resource_offset = 0x80000010U;
+    const uint8_t hash[20] = {
+        0x90, 0x9b, 0x2f, 0x3a, 0x7d, 0x0e, 0x41, 0x87, 0xa1, 0x54,
+        0x98, 0x77, 0x65, 0x43, 0x21, 0x10, 0xca, 0xfe, 0xba, 0xbe
+    };
+    const uint8_t payload[] = { 0xde, 0xad, 0xbe, 0xef, 0x11, 0x22, 0x33, 0x44 };
+
+    char archive_path[512];
+    char resource_path[512];
+    dmTestUtil::MakeHostPath(archive_path, sizeof(archive_path), "build/src/test/large_offset_sparse.arci");
+    dmTestUtil::MakeHostPath(resource_path, sizeof(resource_path), "build/src/test/large_offset_sparse.arcd");
+
+    remove(archive_path);
+    remove(resource_path);
+
+    ASSERT_TRUE(WriteLargeOffsetArchiveIndex(archive_path, hash, sizeof(hash), resource_offset, sizeof(payload)));
+    ASSERT_TRUE(WriteLargeOffsetArchiveData(resource_path, resource_offset, payload, sizeof(payload)));
+
+    dmResourceArchive::HArchiveIndexContainer archive = 0;
+    dmResourceArchive::Result result = dmResourceArchive::LoadArchiveFromFile(archive_path, resource_path, &archive);
+    ASSERT_EQ(dmResourceArchive::RESULT_OK, result);
+
+    dmResourceArchive::EntryData* entry = 0;
+    result = dmResourceArchive::FindEntry(archive, hash, sizeof(hash), &entry);
+    ASSERT_EQ(dmResourceArchive::RESULT_OK, result);
+
+    uint8_t buffer[sizeof(payload)] = { 0 };
+    result = dmResourceArchive::ReadEntry(archive, entry, buffer);
+    ASSERT_EQ(dmResourceArchive::RESULT_OK, result);
+    ASSERT_ARRAY_EQ_LEN(payload, buffer, sizeof(payload));
+
+    uint8_t partial_buffer[4] = { 0 };
+    uint32_t nread = 0;
+    result = dmResourceArchive::ReadEntryPartial(archive, entry, 2, sizeof(partial_buffer), partial_buffer, &nread);
+    ASSERT_EQ(dmResourceArchive::RESULT_OK, result);
+    ASSERT_EQ((uint32_t)sizeof(partial_buffer), nread);
+    ASSERT_ARRAY_EQ_LEN(payload + 2, partial_buffer, sizeof(partial_buffer));
+
+    dmResourceArchive::Delete(archive);
+    remove(archive_path);
+    remove(resource_path);
 }
 
 

--- a/engine/resource/src/test/test_resource_archive.cpp
+++ b/engine/resource/src/test/test_resource_archive.cpp
@@ -461,7 +461,9 @@ TEST(dmResourceArchive, LoadFromDisk_Compressed)
     dmResourceArchive::Delete(archive);
 }
 
-// Verifies that disk-backed archive reads can seek to resources whose data starts beyond 2 GiB.
+// Tests that file-backed archive reads treat the 32-bit resource data offset as unsigned.
+// It writes a sparse .arcd payload at 0x80000010 and verifies both full and partial
+// reads seek to that position instead of using a signed 32-bit fseek offset.
 TEST(dmResourceArchive, LoadFromDisk_ResourceOffsetAbove2GiB)
 {
     const uint32_t resource_offset = 0x80000010U;

--- a/engine/resource/src/test/test_resource_archive.cpp
+++ b/engine/resource/src/test/test_resource_archive.cpp
@@ -673,6 +673,73 @@ TEST(dmResourceArchive, MountArchiveInternal_ResourceOffsetAbove4GiB)
     remove(resource_path);
 }
 
+// File-backed archives keep normalized hash/entry arrays for v5 indexes. Replacing the
+// active index must discard those arrays, otherwise lookups continue using the old index.
+TEST(dmResourceArchive, SetNewArchiveIndex_ClearsFileBackedLookupArrays)
+{
+    const uint8_t old_hash[20] = {
+        0x01, 0x12, 0x23, 0x34, 0x45, 0x56, 0x67, 0x78, 0x89, 0x9a,
+        0xab, 0xbc, 0xcd, 0xde, 0xef, 0xf0, 0x10, 0x20, 0x30, 0x40
+    };
+    const uint8_t new_hash[20] = {
+        0x02, 0x13, 0x24, 0x35, 0x46, 0x57, 0x68, 0x79, 0x8a, 0x9b,
+        0xac, 0xbd, 0xce, 0xdf, 0xe0, 0xf1, 0x11, 0x21, 0x31, 0x41
+    };
+    const uint8_t payload[] = { 'r', 'e', 'p', 'l', 'a', 'c', 'e', 0 };
+
+    char archive_path[512];
+    char resource_path[512];
+    dmTestUtil::MakeHostPath(archive_path, sizeof(archive_path), "build/src/test/replace_index_v5.arci");
+    dmTestUtil::MakeHostPath(resource_path, sizeof(resource_path), "build/src/test/replace_index_v5.arcd");
+
+    remove(archive_path);
+    remove(resource_path);
+
+    ASSERT_TRUE(WriteArchiveIndexV5(archive_path, old_hash, sizeof(old_hash), 0, sizeof(payload)));
+    ASSERT_TRUE(WriteLargeOffsetArchiveData(resource_path, 0, payload, sizeof(payload)));
+
+    dmResourceArchive::HArchiveIndexContainer archive = 0;
+    dmResourceArchive::Result result = dmResourceArchive::LoadArchiveFromFile(archive_path, resource_path, &archive);
+    ASSERT_EQ(dmResourceArchive::RESULT_OK, result);
+
+    struct ArchiveIndexV6Buffer
+    {
+        dmResourceArchive::ArchiveIndex m_Header;
+        uint8_t m_Hash[dmResourceArchive::MAX_HASH];
+        dmResourceArchive::EntryData m_Entry;
+    };
+
+    ArchiveIndexV6Buffer replacement;
+    memset(&replacement, 0, sizeof(replacement));
+    replacement.m_Header.m_Version = dmEndian::ToNetwork(dmResourceArchive::VERSION_6);
+    replacement.m_Header.m_EntryDataCount = dmEndian::ToNetwork(1U);
+    replacement.m_Header.m_EntryDataOffset = dmEndian::ToNetwork((uint32_t)((uintptr_t)&replacement.m_Entry - (uintptr_t)&replacement));
+    replacement.m_Header.m_HashOffset = dmEndian::ToNetwork((uint32_t)((uintptr_t)&replacement.m_Hash - (uintptr_t)&replacement));
+    replacement.m_Header.m_HashLength = dmEndian::ToNetwork((uint32_t)sizeof(new_hash));
+    memcpy(replacement.m_Hash, new_hash, sizeof(new_hash));
+    replacement.m_Entry.m_ResourceDataOffsetAndFlags = dmEndian::ToNetwork(dmResourceArchive::PackEntryDataOffsetAndFlags(0, 0));
+    replacement.m_Entry.m_ResourceSize = dmEndian::ToNetwork((uint32_t)sizeof(payload));
+    replacement.m_Entry.m_ResourceCompressedSize = dmEndian::ToNetwork(0xFFFFFFFFU);
+
+    dmResourceArchive::SetNewArchiveIndex(archive, &replacement.m_Header, true);
+
+    dmResourceArchive::EntryData* entry = 0;
+    result = dmResourceArchive::FindEntry(archive, old_hash, sizeof(old_hash), &entry);
+    ASSERT_EQ(dmResourceArchive::RESULT_NOT_FOUND, result);
+
+    result = dmResourceArchive::FindEntry(archive, new_hash, sizeof(new_hash), &entry);
+    ASSERT_EQ(dmResourceArchive::RESULT_OK, result);
+
+    uint8_t buffer[sizeof(payload)] = { 0 };
+    result = dmResourceArchive::ReadEntry(archive, entry, buffer);
+    ASSERT_EQ(dmResourceArchive::RESULT_OK, result);
+    ASSERT_ARRAY_EQ_LEN(payload, buffer, sizeof(payload));
+
+    dmResourceArchive::Delete(archive);
+    remove(archive_path);
+    remove(resource_path);
+}
+
 // Bundled and mapped archives do not go through the file-load normalization path, so v6
 // lookup must work directly from the 16-byte packed entry layout. This in-memory v6 index
 // contains one mapped entry with the currently unused fourth flag bit and verifies

--- a/engine/resource/src/test/test_resource_archive.cpp
+++ b/engine/resource/src/test/test_resource_archive.cpp
@@ -12,6 +12,10 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
+#if defined(__linux__) && !defined(__ANDROID__) && !defined(_LARGEFILE64_SOURCE)
+#define _LARGEFILE64_SOURCE 1
+#endif
+
 #include <stdint.h>
 #include <stdio.h>
 #include <sys/types.h>
@@ -22,6 +26,12 @@
 #include <windows.h>
 #endif
 #include <winioctl.h>
+#elif defined(__ANDROID__)
+#include <fcntl.h>
+#include <unistd.h>
+#ifndef O_LARGEFILE
+#define O_LARGEFILE 0
+#endif
 #endif
 #include "../resource.h"
 #include "../resource_manifest.h"
@@ -115,10 +125,37 @@ static const uint8_t compressed_content_hash[][20] = {
     {  90U,  15U,  50U,  67U, 184U,   5U, 147U, 194U, 160U, 203U,  45U, 150U,  20U, 194U,  55U, 123U, 189U, 218U, 105U, 103U }
 };
 
+static FILE* TestOpenLargeFileForWrite(const char* path)
+{
+#if defined(__ANDROID__)
+    int fd = open(path, O_CREAT | O_TRUNC | O_WRONLY | O_LARGEFILE, 0666);
+    if (fd < 0)
+    {
+        return 0;
+    }
+    FILE* file = fdopen(fd, "wb");
+    if (!file)
+    {
+        close(fd);
+        return 0;
+    }
+    setvbuf(file, 0, _IONBF, 0);
+    return file;
+#elif defined(__linux__)
+    return fopen64(path, "wb");
+#else
+    return fopen(path, "wb");
+#endif
+}
+
 static int TestSeekFile64(FILE* file, uint64_t offset)
 {
 #if defined(_WIN32)
     return _fseeki64(file, (int64_t)offset, SEEK_SET);
+#elif defined(__ANDROID__)
+    return lseek64(fileno(file), (off64_t)offset, SEEK_SET) < 0 ? -1 : 0;
+#elif defined(__linux__)
+    return fseeko64(file, (off64_t)offset, SEEK_SET);
 #else
     return fseeko(file, (off_t)offset, SEEK_SET);
 #endif
@@ -174,7 +211,7 @@ static bool WriteLargeOffsetArchiveIndex(const char* archive_path, const uint8_t
 
 static bool WriteLargeOffsetArchiveData(const char* resource_path, uint32_t resource_offset, const uint8_t* payload, uint32_t payload_size)
 {
-    FILE* file = fopen(resource_path, "wb");
+    FILE* file = TestOpenLargeFileForWrite(resource_path);
     if (!file)
     {
         return false;
@@ -463,7 +500,7 @@ TEST(dmResourceArchive, LoadFromDisk_Compressed)
 
 // Tests that file-backed archive reads treat the 32-bit resource data offset as unsigned.
 // It writes a sparse .arcd payload at 0x80000010 and verifies both full and partial
-// reads seek to that position instead of using a signed 32-bit fseek offset.
+// reads seek to that position instead of using a signed 32-bit file offset.
 TEST(dmResourceArchive, LoadFromDisk_ResourceOffsetAbove2GiB)
 {
     const uint32_t resource_offset = 0x80000010U;

--- a/engine/resource/src/test/test_resource_archive.cpp
+++ b/engine/resource/src/test/test_resource_archive.cpp
@@ -177,7 +177,7 @@ static bool TestMarkFileSparse(FILE* file)
 #endif
 }
 
-static bool WriteLargeOffsetArchiveIndex(const char* archive_path, const uint8_t* hash, uint32_t hash_len, uint32_t resource_offset, uint32_t resource_size)
+static bool WriteArchiveIndexV5(const char* archive_path, const uint8_t* hash, uint32_t hash_len, uint32_t resource_offset, uint32_t resource_size)
 {
     FILE* file = fopen(archive_path, "wb");
     if (!file)
@@ -187,7 +187,40 @@ static bool WriteLargeOffsetArchiveIndex(const char* archive_path, const uint8_t
 
     dmResourceArchive::ArchiveIndex header;
     memset(&header, 0, sizeof(header));
-    header.m_Version = dmEndian::ToNetwork(dmResourceArchive::VERSION);
+    header.m_Version = dmEndian::ToNetwork(dmResourceArchive::VERSION_5);
+    header.m_EntryDataCount = dmEndian::ToNetwork(1U);
+    header.m_EntryDataOffset = dmEndian::ToNetwork((uint32_t)(sizeof(dmResourceArchive::ArchiveIndex) + dmResourceArchive::MAX_HASH));
+    header.m_HashOffset = dmEndian::ToNetwork((uint32_t)sizeof(dmResourceArchive::ArchiveIndex));
+    header.m_HashLength = dmEndian::ToNetwork(hash_len);
+
+    uint8_t hash_buffer[dmResourceArchive::MAX_HASH] = { 0 };
+    memcpy(hash_buffer, hash, hash_len);
+
+    uint32_t entry[4] = {
+        dmEndian::ToNetwork(resource_offset),
+        dmEndian::ToNetwork(resource_size),
+        dmEndian::ToNetwork(0xFFFFFFFFU),
+        dmEndian::ToNetwork(0U)
+    };
+
+    bool ok = fwrite(&header, 1, sizeof(header), file) == sizeof(header);
+    ok = ok && fwrite(hash_buffer, 1, sizeof(hash_buffer), file) == sizeof(hash_buffer);
+    ok = ok && fwrite(&entry, 1, sizeof(entry), file) == sizeof(entry);
+    fclose(file);
+    return ok;
+}
+
+static bool WriteArchiveIndexV6(const char* archive_path, const uint8_t* hash, uint32_t hash_len, uint64_t resource_offset, uint32_t resource_size, uint32_t flags)
+{
+    FILE* file = fopen(archive_path, "wb");
+    if (!file)
+    {
+        return false;
+    }
+
+    dmResourceArchive::ArchiveIndex header;
+    memset(&header, 0, sizeof(header));
+    header.m_Version = dmEndian::ToNetwork(dmResourceArchive::VERSION_6);
     header.m_EntryDataCount = dmEndian::ToNetwork(1U);
     header.m_EntryDataOffset = dmEndian::ToNetwork((uint32_t)(sizeof(dmResourceArchive::ArchiveIndex) + dmResourceArchive::MAX_HASH));
     header.m_HashOffset = dmEndian::ToNetwork((uint32_t)sizeof(dmResourceArchive::ArchiveIndex));
@@ -197,10 +230,9 @@ static bool WriteLargeOffsetArchiveIndex(const char* archive_path, const uint8_t
     memcpy(hash_buffer, hash, hash_len);
 
     dmResourceArchive::EntryData entry;
-    entry.m_ResourceDataOffset = dmEndian::ToNetwork(resource_offset);
+    entry.m_ResourceDataOffsetAndFlags = dmEndian::ToNetwork(dmResourceArchive::PackEntryDataOffsetAndFlags(resource_offset, flags));
     entry.m_ResourceSize = dmEndian::ToNetwork(resource_size);
     entry.m_ResourceCompressedSize = dmEndian::ToNetwork(0xFFFFFFFFU);
-    entry.m_Flags = dmEndian::ToNetwork(0U);
 
     bool ok = fwrite(&header, 1, sizeof(header), file) == sizeof(header);
     ok = ok && fwrite(hash_buffer, 1, sizeof(hash_buffer), file) == sizeof(hash_buffer);
@@ -209,7 +241,7 @@ static bool WriteLargeOffsetArchiveIndex(const char* archive_path, const uint8_t
     return ok;
 }
 
-static bool WriteLargeOffsetArchiveData(const char* resource_path, uint32_t resource_offset, const uint8_t* payload, uint32_t payload_size)
+static bool WriteLargeOffsetArchiveData(const char* resource_path, uint64_t resource_offset, const uint8_t* payload, uint32_t payload_size)
 {
     FILE* file = TestOpenLargeFileForWrite(resource_path);
     if (!file)
@@ -498,9 +530,9 @@ TEST(dmResourceArchive, LoadFromDisk_Compressed)
     dmResourceArchive::Delete(archive);
 }
 
-// Tests that file-backed archive reads treat the 32-bit resource data offset as unsigned.
-// It writes a sparse .arcd payload at 0x80000010 and verifies both full and partial
-// reads seek to that position instead of using a signed 32-bit file offset.
+// Old v5 archives can place data above 2 GiB, so the v6 reader changes must keep treating
+// the 32-bit offset field as unsigned. This hand-written v5 index points at a sparse
+// .arcd payload at 0x80000010 and verifies both full and partial file-backed reads.
 TEST(dmResourceArchive, LoadFromDisk_ResourceOffsetAbove2GiB)
 {
     const uint32_t resource_offset = 0x80000010U;
@@ -518,7 +550,7 @@ TEST(dmResourceArchive, LoadFromDisk_ResourceOffsetAbove2GiB)
     remove(archive_path);
     remove(resource_path);
 
-    ASSERT_TRUE(WriteLargeOffsetArchiveIndex(archive_path, hash, sizeof(hash), resource_offset, sizeof(payload)));
+    ASSERT_TRUE(WriteArchiveIndexV5(archive_path, hash, sizeof(hash), resource_offset, sizeof(payload)));
     ASSERT_TRUE(WriteLargeOffsetArchiveData(resource_path, resource_offset, payload, sizeof(payload)));
 
     dmResourceArchive::HArchiveIndexContainer archive = 0;
@@ -544,6 +576,107 @@ TEST(dmResourceArchive, LoadFromDisk_ResourceOffsetAbove2GiB)
     dmResourceArchive::Delete(archive);
     remove(archive_path);
     remove(resource_path);
+}
+
+// V6 exists to let .arcd data grow past the uint32 offset limit while keeping resource
+// sizes uint32. This hand-written v6 index packs the currently unused fourth flag bit
+// with an offset above 4 GiB, writes a tiny payload there in a sparse .arcd, and verifies
+// the decoded flags plus full and partial file-backed reads.
+TEST(dmResourceArchive, LoadFromDisk_ResourceOffsetAbove4GiB)
+{
+    const uint64_t resource_offset = 0x100000010ULL;
+    const uint32_t flags = 1 << 3;
+    const uint8_t hash[20] = {
+        0x43, 0xe9, 0xa1, 0x2b, 0x5c, 0x6d, 0x7e, 0x8f, 0x90, 0xab,
+        0xbc, 0xcd, 0xde, 0xef, 0x10, 0x21, 0x32, 0x43, 0x54, 0x65
+    };
+    const uint8_t payload[] = { 0x41, 0x52, 0x43, 0x36, 0xde, 0xad, 0xbe, 0xef };
+
+    char archive_path[512];
+    char resource_path[512];
+    dmTestUtil::MakeHostPath(archive_path, sizeof(archive_path), "build/src/test/large_offset_v6_sparse.arci");
+    dmTestUtil::MakeHostPath(resource_path, sizeof(resource_path), "build/src/test/large_offset_v6_sparse.arcd");
+
+    remove(archive_path);
+    remove(resource_path);
+
+    ASSERT_TRUE(WriteArchiveIndexV6(archive_path, hash, sizeof(hash), resource_offset, sizeof(payload), flags));
+    ASSERT_TRUE(WriteLargeOffsetArchiveData(resource_path, resource_offset, payload, sizeof(payload)));
+
+    dmResourceArchive::HArchiveIndexContainer archive = 0;
+    dmResourceArchive::Result result = dmResourceArchive::LoadArchiveFromFile(archive_path, resource_path, &archive);
+    ASSERT_EQ(dmResourceArchive::RESULT_OK, result);
+
+    dmResourceArchive::EntryData* entry = 0;
+    result = dmResourceArchive::FindEntry(archive, hash, sizeof(hash), &entry);
+    ASSERT_EQ(dmResourceArchive::RESULT_OK, result);
+    ASSERT_EQ(resource_offset, dmResourceArchive::GetEntryResourceDataOffset(entry));
+    ASSERT_EQ(flags, dmResourceArchive::GetEntryFlags(entry));
+
+    uint8_t buffer[sizeof(payload)] = { 0 };
+    result = dmResourceArchive::ReadEntry(archive, entry, buffer);
+    ASSERT_EQ(dmResourceArchive::RESULT_OK, result);
+    ASSERT_ARRAY_EQ_LEN(payload, buffer, sizeof(payload));
+
+    uint8_t partial_buffer[4] = { 0 };
+    uint32_t nread = 0;
+    result = dmResourceArchive::ReadEntryPartial(archive, entry, 2, sizeof(partial_buffer), partial_buffer, &nread);
+    ASSERT_EQ(dmResourceArchive::RESULT_OK, result);
+    ASSERT_EQ((uint32_t)sizeof(partial_buffer), nread);
+    ASSERT_ARRAY_EQ_LEN(payload + 2, partial_buffer, sizeof(partial_buffer));
+
+    dmResourceArchive::Delete(archive);
+    remove(archive_path);
+    remove(resource_path);
+}
+
+// Bundled and mapped archives do not go through the file-load normalization path, so v6
+// lookup must work directly from the 16-byte packed entry layout. This in-memory v6 index
+// contains one mapped entry with the currently unused fourth flag bit and verifies
+// FindEntry plus ReadEntry against mapped payload bytes.
+TEST(dmResourceArchive, Wrap_Version6)
+{
+    const uint32_t flags = 1 << 3;
+    const uint8_t hash[20] = {
+        0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa,
+        0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00, 0x10, 0x20, 0x30, 0x40
+    };
+    const uint8_t payload[] = { 'v', '6', '_', 'w', 'r', 'a', 'p', 0 };
+
+    struct ArchiveIndexV6Buffer
+    {
+        dmResourceArchive::ArchiveIndex m_Header;
+        uint8_t m_Hash[dmResourceArchive::MAX_HASH];
+        dmResourceArchive::EntryData m_Entry;
+    };
+
+    ArchiveIndexV6Buffer index_buffer;
+    memset(&index_buffer, 0, sizeof(index_buffer));
+    index_buffer.m_Header.m_Version = dmEndian::ToNetwork(dmResourceArchive::VERSION_6);
+    index_buffer.m_Header.m_EntryDataCount = dmEndian::ToNetwork(1U);
+    index_buffer.m_Header.m_EntryDataOffset = dmEndian::ToNetwork((uint32_t)((uintptr_t)&index_buffer.m_Entry - (uintptr_t)&index_buffer));
+    index_buffer.m_Header.m_HashOffset = dmEndian::ToNetwork((uint32_t)((uintptr_t)&index_buffer.m_Hash - (uintptr_t)&index_buffer));
+    index_buffer.m_Header.m_HashLength = dmEndian::ToNetwork((uint32_t)sizeof(hash));
+    memcpy(index_buffer.m_Hash, hash, sizeof(hash));
+    index_buffer.m_Entry.m_ResourceDataOffsetAndFlags = dmEndian::ToNetwork(dmResourceArchive::PackEntryDataOffsetAndFlags(0, flags));
+    index_buffer.m_Entry.m_ResourceSize = dmEndian::ToNetwork((uint32_t)sizeof(payload));
+    index_buffer.m_Entry.m_ResourceCompressedSize = dmEndian::ToNetwork(0xFFFFFFFFU);
+
+    dmResourceArchive::HArchiveIndexContainer archive = 0;
+    dmResourceArchive::Result result = dmResourceArchive::WrapArchiveBuffer(&index_buffer, sizeof(index_buffer), true, payload, sizeof(payload), true, &archive);
+    ASSERT_EQ(dmResourceArchive::RESULT_OK, result);
+
+    dmResourceArchive::EntryData* entry = 0;
+    result = dmResourceArchive::FindEntry(archive, hash, sizeof(hash), &entry);
+    ASSERT_EQ(dmResourceArchive::RESULT_OK, result);
+    ASSERT_EQ(flags, dmResourceArchive::GetEntryFlags(entry));
+
+    uint8_t buffer[sizeof(payload)] = { 0 };
+    result = dmResourceArchive::ReadEntry(archive, entry, buffer);
+    ASSERT_EQ(dmResourceArchive::RESULT_OK, result);
+    ASSERT_ARRAY_EQ_LEN(payload, buffer, sizeof(payload));
+
+    dmResourceArchive::Delete(archive);
 }
 
 

--- a/scripts/unpack_arc.py
+++ b/scripts/unpack_arc.py
@@ -151,12 +151,9 @@ if __name__ == "__main__":
     entryOffset = struct.unpack_from(">I", arci, 20)[0]
     hashesOffset = struct.unpack_from(">I", arci, 24)[0]
     hashLength = struct.unpack_from(">I", arci, 28)[0]
-    if archiveVersion == 5:
-        entrySize = 16
-    elif archiveVersion == 6:
-        entrySize = 16
-    else:
+    if archiveVersion != 6:
         raise Exception("Unsupported archive index version: %d" % archiveVersion)
+    entrySize = 16
 
     def read_arcd(offset, size):
         if arcd_path:
@@ -193,17 +190,11 @@ if __name__ == "__main__":
         for url, h in hash_map.items():
             if hash == h:
                 currentEntryOffset = entryOffset + (i * entrySize)
-                if archiveVersion == 5:
-                    offset = struct.unpack_from(">I", arci, currentEntryOffset + 0)[0]
-                    uncompressed_size = struct.unpack_from(">I", arci, currentEntryOffset + 4)[0]
-                    compressed_size = struct.unpack_from(">I", arci, currentEntryOffset + 8)[0]
-                    flags = struct.unpack_from(">I", arci, currentEntryOffset + 12)[0]
-                else:
-                    offset_and_flags = struct.unpack_from(">Q", arci, currentEntryOffset + 0)[0]
-                    offset = offset_and_flags & ARCHIVE_V6_OFFSET_MASK
-                    flags = offset_and_flags >> ARCHIVE_V6_FLAGS_SHIFT
-                    uncompressed_size = struct.unpack_from(">I", arci, currentEntryOffset + 8)[0]
-                    compressed_size = struct.unpack_from(">I", arci, currentEntryOffset + 12)[0]
+                offset_and_flags = struct.unpack_from(">Q", arci, currentEntryOffset + 0)[0]
+                offset = offset_and_flags & ARCHIVE_V6_OFFSET_MASK
+                flags = offset_and_flags >> ARCHIVE_V6_FLAGS_SHIFT
+                uncompressed_size = struct.unpack_from(">I", arci, currentEntryOffset + 8)[0]
+                compressed_size = struct.unpack_from(">I", arci, currentEntryOffset + 12)[0]
                 size = compressed_size
                 if compressed_size == 0xFFFFFFFF:
                     size = uncompressed_size

--- a/scripts/unpack_arc.py
+++ b/scripts/unpack_arc.py
@@ -33,6 +33,9 @@ import binascii
 import json
 
 XTEA_BLOCK_SIZE = 8
+ARCHIVE_V6_FLAGS_SHIFT = 60
+ARCHIVE_V6_OFFSET_MASK = 0x0fffffffffffffff
+
 def xtea_decrypt(v, key, n=32):
     v0 = (v >> 32) & 0xFFFFFFFF;
     v1 = (v >> 0) & 0xFFFFFFFF;
@@ -88,33 +91,42 @@ if __name__ == "__main__":
     else:
         output = False
 
+    arcd_path = None
+    arcd_content = None
+    arcd_basedir = None
     if os.path.isdir(resources):
         with open(os.path.join(resources, "game.projectc"), "rb") as f:
             project = f.read()
         with open(os.path.join(resources, "game.dmanifest"), "rb") as f:
             manifest = f.read()
-        with open(os.path.join(resources, "game.arcd"), "rb") as f:
-            arcd = bytearray(f.read())
+        arcd_path = os.path.join(resources, "game.arcd")
         with open(os.path.join(resources, "game.arci"), "rb") as f:
             arci = f.read()
     else:
-        def gather_pieces(basedir, contents, name):
+        def find_content(contents, name):
             for content in contents:
                 if content['name'] == name:
-                    data = bytearray(content['size'])
-                    mv = memoryview(data)
-                    for piece in content['pieces']:
-                        piece_path = os.path.join(basedir, piece['name'])
-                        with open(piece_path, 'rb') as d:
-                            r = d.readinto(mv[piece['offset']:])
-                    return data
+                    return content
+            return None
+
+        def gather_pieces(basedir, contents, name):
+            content = find_content(contents, name)
+            if content:
+                data = bytearray(content['size'])
+                mv = memoryview(data)
+                for piece in content['pieces']:
+                    piece_path = os.path.join(basedir, piece['name'])
+                    with open(piece_path, 'rb') as d:
+                        r = d.readinto(mv[piece['offset']:])
+                return data
             return None
         with open(resources, 'r') as f:
             obj = json.load(f)
-            project = gather_pieces(os.path.dirname(resources), obj['content'], "game.projectc")
-            manifest = gather_pieces(os.path.dirname(resources), obj['content'], "game.dmanifest")
-            arcd = gather_pieces(os.path.dirname(resources), obj['content'], "game.arcd")
-            arci = gather_pieces(os.path.dirname(resources), obj['content'], "game.arci")
+            arcd_basedir = os.path.dirname(resources)
+            project = gather_pieces(arcd_basedir, obj['content'], "game.projectc")
+            manifest = gather_pieces(arcd_basedir, obj['content'], "game.dmanifest")
+            arcd_content = find_content(obj['content'], "game.arcd")
+            arci = gather_pieces(arcd_basedir, obj['content'], "game.arci")
 
     if output:
         with open(output + "/game.projectc", "wb") as o:
@@ -134,31 +146,76 @@ if __name__ == "__main__":
                 url = getattr(r, "url")
                 hash_map[url] = hash;
 
-    entryCount = struct.unpack_from(">i", arci, 16)[0]
-    entryOffset = struct.unpack_from(">i", arci, 20)[0]
-    hashesOffset = struct.unpack_from(">i", arci, 24)[0]
-    hashLength = struct.unpack_from(">i", arci, 28)[0]
+    archiveVersion = struct.unpack_from(">I", arci, 0)[0]
+    entryCount = struct.unpack_from(">I", arci, 16)[0]
+    entryOffset = struct.unpack_from(">I", arci, 20)[0]
+    hashesOffset = struct.unpack_from(">I", arci, 24)[0]
+    hashLength = struct.unpack_from(">I", arci, 28)[0]
+    if archiveVersion == 5:
+        entrySize = 16
+    elif archiveVersion == 6:
+        entrySize = 16
+    else:
+        raise Exception("Unsupported archive index version: %d" % archiveVersion)
+
+    def read_arcd(offset, size):
+        if arcd_path:
+            with open(arcd_path, "rb") as f:
+                f.seek(offset)
+                return bytearray(f.read(size))
+        if arcd_content:
+            data = bytearray(size)
+            mv = memoryview(data)
+            pieces = arcd_content['pieces']
+            end = offset + size
+            for i, piece in enumerate(pieces):
+                piece_offset = piece['offset']
+                if i + 1 < len(pieces):
+                    piece_end = pieces[i + 1]['offset']
+                else:
+                    piece_end = arcd_content['size']
+
+                read_offset = max(offset, piece_offset)
+                read_end = min(end, piece_end)
+                if read_offset >= read_end:
+                    continue
+
+                piece_path = os.path.join(arcd_basedir, piece['name'])
+                with open(piece_path, "rb") as f:
+                    f.seek(read_offset - piece_offset)
+                    f.readinto(mv[read_offset - offset:read_end - offset])
+            return data
+        raise Exception("No game.arcd data found")
+
     for i in range(0, entryCount):
         hashOffset = hashesOffset+(i*64)
         hash = arci[hashOffset:hashOffset+hashLength]
         for url, h in hash_map.items():
             if hash == h:
-                offset = struct.unpack_from(">i", arci, entryOffset + (i * 16) + 0)[0]
-                uncompressed_size = struct.unpack_from(">i", arci, entryOffset + (i * 16) + 4)[0]
-                compressed_size = struct.unpack_from(">i", arci, entryOffset + (i * 16) + 8)[0]
-                flags = struct.unpack_from(">i", arci, entryOffset + (i * 16) + 12)[0]
+                currentEntryOffset = entryOffset + (i * entrySize)
+                if archiveVersion == 5:
+                    offset = struct.unpack_from(">I", arci, currentEntryOffset + 0)[0]
+                    uncompressed_size = struct.unpack_from(">I", arci, currentEntryOffset + 4)[0]
+                    compressed_size = struct.unpack_from(">I", arci, currentEntryOffset + 8)[0]
+                    flags = struct.unpack_from(">I", arci, currentEntryOffset + 12)[0]
+                else:
+                    offset_and_flags = struct.unpack_from(">Q", arci, currentEntryOffset + 0)[0]
+                    offset = offset_and_flags & ARCHIVE_V6_OFFSET_MASK
+                    flags = offset_and_flags >> ARCHIVE_V6_FLAGS_SHIFT
+                    uncompressed_size = struct.unpack_from(">I", arci, currentEntryOffset + 8)[0]
+                    compressed_size = struct.unpack_from(">I", arci, currentEntryOffset + 12)[0]
                 size = compressed_size
-                if compressed_size == -1:
+                if compressed_size == 0xFFFFFFFF:
                     size = uncompressed_size
                 #print("Index found %s %d-%d" % (url, offset, size))
 
                 if output:
-                    data = arcd[offset:offset+size]
+                    data = read_arcd(offset, size)
                     try:
                         if flags & 1:
                             #print("encrypted")
                             xtea_decryptCTR(bytearray(b'aQj8CScgNP4VsfXK'), data)
-                        if compressed_size != -1:
+                        if compressed_size != 0xFFFFFFFF:
                             if options.uncompress:
                                 data = lz4.block.decompress(data, uncompressed_size)
                             else:
@@ -172,9 +229,7 @@ if __name__ == "__main__":
                     os.makedirs(os.path.dirname(output_file), 0o777, True)
                     with open(output_file, "wb") as o:
                         o.write(data)
-                elif compressed_size != -1:
+                elif compressed_size != 0xFFFFFFFF:
                     print("Found %s %d-%d(%d) [Compressed%s]" % (url, offset, size, compressed_size, " Encrypted" if flags & 1 else ""))
                 else:
                     print("Found %s %d-%d%s" % (url, offset, size, " [Encrypted]" if flags & 1 else ""))
-
-


### PR DESCRIPTION
Windows bundles with large game resource archives can now load resources at startup when archive data crosses the 2 GiB boundary, instead of failing with resource `FORMAT_ERROR` messages. The archive format also gains room for offsets beyond 4 GiB.

Fix https://github.com/defold/defold/issues/12592

### Technical changes
- Bump archive indexes to version 6 and pack entry flags into the high 4 bits of a 64-bit offset word.
- Change Bob archive offsets to `long`, reject v5 indexes, and add v6 read/write validation.
- Update runtime archive loading, mmap/file-backed reads, Android large-file handling, and provider error propagation for 64-bit offsets.
- Move generated archive temp files into filesystem outputs to avoid streaming very large `.arci`/`.arcd` files through `setContent()`.
- Update `unpack_arc.py` and archive format docs for the v6 packed entry layout.
- Add Bob and engine resource archive tests for v6, v5 rejection, sparse large offsets, mounted archives, wrapped indexes, and replacement indexes.