### PR TITLE
Allow removing GUI runtime texture mappings

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -458,7 +458,7 @@ jobs:
           path: '${{ github.workspace }}/com.dynamo.cr/com.dynamo.cr.bob/dist'
         }
       },
-      { name: 'Install dependencies', run: sudo apt-get install -y libgl1-mesa-dev libglw1-mesa-dev freeglut3-dev },
+      { name: 'Install dependencies', run: sudo apt-get update && sudo apt-get install -y libgl1-mesa-dev libglw1-mesa-dev freeglut3-dev },
       {
         name: 'Build editor',
         if: (github.event_name != 'repository_dispatch') || ((github.event_name == 'repository_dispatch') && (github.event.client_payload.skip_editor != true)),
@@ -504,7 +504,7 @@ jobs:
           path: '${{ github.workspace }}/com.dynamo.cr/com.dynamo.cr.bob/dist'
         }
       },
-      { name: 'Install dependencies', run: sudo apt-get install -y libgl1-mesa-dev libglw1-mesa-dev freeglut3-dev },
+      { name: 'Install dependencies', run: sudo apt-get update && sudo apt-get install -y libgl1-mesa-dev libglw1-mesa-dev freeglut3-dev },
       {
         name: 'Test editor',
         if: (github.event_name != 'repository_dispatch') || ((github.event_name == 'repository_dispatch') && (github.event.client_payload.skip_editor != true)),

--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -2528,6 +2528,20 @@ namespace dmGameSystem
         return dmHashString64(buffer);
     }
 
+    static bool ReleaseResourcePropertyPointer(GuiComponent* component, dmResource::HFactory factory, void* resource)
+    {
+        for (uint32_t i = 0; i < component->m_ResourcePropertyPointers.Size(); ++i)
+        {
+            if (component->m_ResourcePropertyPointers[i] == resource)
+            {
+                component->m_ResourcePropertyPointers.EraseSwap(i);
+                dmResource::Release(factory, resource);
+                return true;
+            }
+        }
+        return false;
+    }
+
     static dmGui::HTextureSource NewTextureResourceCallback(dmGui::HScene scene, const dmhash_t path_hash, uint32_t width, uint32_t height,
                                                             dmImage::Type type, dmImage::CompressionType compression_type, const void* data, uint32_t data_size)
     {
@@ -2586,9 +2600,14 @@ namespace dmGameSystem
     static void DeleteTextureResourceCallback(dmGui::HScene scene, const dmhash_t path_hash, dmGui::HTextureSource texture_source)
     {
         GuiComponent* component = (GuiComponent*)dmGui::GetSceneUserData(scene);
+        dmResource::HFactory factory = dmGameObject::GetFactory(component->m_Instance);
+        if (ReleaseResourcePropertyPointer(component, factory, (void*)(uintptr_t) texture_source))
+        {
+            return;
+        }
+
         char resource_path[dmResource::RESOURCE_PATH_MAX];
         dmhash_t resolved_path_hash = ResolveDynamicTexturePath(component, path_hash, resource_path, sizeof(resource_path));
-        dmResource::HFactory factory = dmGameObject::GetFactory(component->m_Instance);
         ResourceDescriptor* rd = dmResource::FindByHash(factory, resolved_path_hash);
         if (rd)
         {
@@ -3147,6 +3166,7 @@ namespace dmGameSystem
                 if (r != dmGui::RESULT_OK)
                 {
                     dmLogError("Unable to add texture '%s' to scene (%d)", dmHashReverseSafe64(key),  r);
+                    dmResource::Release(factory, texture_source);
                     return dmGameObject::PROPERTY_RESULT_BUFFER_OVERFLOW;
                 }
                 if(gui_component->m_ResourcePropertyPointers.Full())

--- a/engine/gamesys/src/gamesys/test/gui/build.inputs
+++ b/engine/gamesys/src/gamesys/test/gui/build.inputs
@@ -5,6 +5,7 @@
 /gui/draw_count_test2.go
 /gui/get_set_material_constants.go
 /gui/goscript.go
+/gui/gui_set_texture_nil.go
 /gui/gui_flipbook_anim.go
 /gui/gui_flipbook_cursor.go
 /gui/gui_max_dynamic_textures.go

--- a/engine/gamesys/src/gamesys/test/gui/gui_set_texture_nil.go
+++ b/engine/gamesys/src/gamesys/test/gui/gui_set_texture_nil.go
@@ -1,0 +1,4 @@
+components {
+  id: "gui"
+  component: "/gui/gui_set_texture_nil.gui"
+}

--- a/engine/gamesys/src/gamesys/test/gui/gui_set_texture_nil.gui
+++ b/engine/gamesys/src/gamesys/test/gui/gui_set_texture_nil.gui
@@ -1,0 +1,63 @@
+script: "/gui/gui_set_texture_nil.gui_script"
+background_color {
+  x: 0.0
+  y: 0.0
+  z: 0.0
+  w: 0.0
+}
+nodes {
+  position {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  scale {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  size {
+    x: 16.0
+    y: 16.0
+    z: 0.0
+    w: 1.0
+  }
+  color {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  type: TYPE_BOX
+  blend_mode: BLEND_MODE_ALPHA
+  id: "box"
+  xanchor: XANCHOR_NONE
+  yanchor: YANCHOR_NONE
+  pivot: PIVOT_CENTER
+  adjust_mode: ADJUST_MODE_FIT
+  layer: ""
+  inherit_alpha: true
+  slice9 {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 0.0
+  }
+  clipping_mode: CLIPPING_MODE_NONE
+  clipping_visible: true
+  clipping_inverted: false
+  alpha: 1.0
+  template_node_child: false
+  size_mode: SIZE_MODE_MANUAL
+}
+material: "/gui/gui.material"
+adjust_reference: ADJUST_REFERENCE_PARENT
+max_nodes: 512

--- a/engine/gamesys/src/gamesys/test/gui/gui_set_texture_nil.gui_script
+++ b/engine/gamesys/src/gamesys/test/gui/gui_set_texture_nil.gui_script
@@ -1,0 +1,97 @@
+local KEY = "runtime_atlas"
+
+local TEXTURE_PARAMS = {
+    width = 16,
+    height = 16,
+    type = graphics.TEXTURE_TYPE_2D,
+    format = graphics.TEXTURE_FORMAT_RGBA,
+}
+
+local function assert_error(func)
+    local ok, err = pcall(func)
+    if not ok then
+        print(err)
+    end
+    assert(not ok)
+end
+
+local function make_texture_buffer()
+    local tex_buffer = buffer.create(TEXTURE_PARAMS.width * TEXTURE_PARAMS.height, {{name = hash("rgba"), type = buffer.VALUE_TYPE_UINT8, count = 4}})
+    local stream = buffer.get_stream(tex_buffer, hash("rgba"))
+    for i = 1, TEXTURE_PARAMS.width * TEXTURE_PARAMS.height * 4 do
+        stream[i] = 0xff
+    end
+    return tex_buffer
+end
+
+local function make_atlas(atlas_path, texture)
+    return resource.create_atlas(atlas_path, {
+        texture = texture,
+        animations = {
+            {
+                id = "frame",
+                width = 16,
+                height = 16,
+                frames = {1},
+                fps = 30,
+                playback = go.PLAYBACK_ONCE_FORWARD,
+            }
+        },
+        geometries = {
+            {
+                vertices = {0, 0, 0, 16, 16, 16, 16, 0},
+                uvs = {0, 0, 0, 16, 16, 16, 16, 0},
+                indices = {0, 1, 2, 0, 2, 3},
+            }
+        }
+    })
+end
+
+function init(self)
+    self.step = 0
+    gui_set_texture_nil_step = 0
+    gui_set_texture_nil_done = false
+end
+
+function update(self, dt)
+    self.step = self.step + 1
+
+    if self.step == 1 then
+        self.texture_a = resource.create_texture("/gui/set_texture_nil_a.texturec", TEXTURE_PARAMS, make_texture_buffer())
+        self.atlas_a = make_atlas("/gui/set_texture_nil_a.texturesetc", self.texture_a)
+        gui.set(msg.url(), "textures", self.atlas_a, {key = KEY})
+
+        local node = gui.get_node("box")
+        gui.set_texture(node, KEY)
+        gui.play_flipbook(node, "frame")
+    elseif self.step == 2 then
+        self.texture_b = resource.create_texture("/gui/set_texture_nil_b.texturec", TEXTURE_PARAMS, make_texture_buffer())
+        self.atlas_b = make_atlas("/gui/set_texture_nil_b.texturesetc", self.texture_b)
+        gui.set(msg.url(), "textures", self.atlas_b, {key = KEY})
+
+        local node = gui.get_node("box")
+        gui.set_texture(node, KEY)
+        gui.play_flipbook(node, "frame")
+    elseif self.step == 3 then
+        local node = gui.get_node("box")
+
+        assert_error(function() gui.set(msg.url(), "textures", nil) end)
+        assert_error(function() gui.set(msg.url(), "textures", nil, {key = "missing_runtime_atlas"}) end)
+        assert_error(function() gui.set(node, "texture", nil) end)
+        assert_error(function() gui.set_texture(node, nil) end)
+
+        gui.set(msg.url(), "textures", nil, {key = KEY})
+
+        resource.release(self.atlas_a)
+        resource.release(self.texture_a)
+
+        resource.release(self.atlas_b)
+        local recreated_atlas_b = make_atlas("/gui/set_texture_nil_b.texturesetc", self.texture_b)
+        resource.release(recreated_atlas_b)
+        resource.release(self.texture_b)
+
+        gui_set_texture_nil_done = true
+    end
+
+    gui_set_texture_nil_step = self.step
+end

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -2911,6 +2911,78 @@ TEST_F(GuiTest, TextureReloadRefreshesAtlasState)
     ASSERT_TRUE(dmGameObject::Final(m_Collection));
 }
 
+// Verifies that atlas resources assigned through gui.set(msg.url(), "textures", ...)
+// can be replaced and then explicitly removed. This guards the component-owned
+// resource references so script-side resource.release() can fully destroy the
+// old and current runtime atlases.
+TEST_F(GuiTest, GuiSetNilRemovesRuntimeTextureMapping)
+{
+    const char* atlas_a_path = "/gui/set_texture_nil_a.texturesetc";
+    const char* atlas_b_path = "/gui/set_texture_nil_b.texturesetc";
+    const dmhash_t atlas_a_hash = dmHashString64(atlas_a_path);
+    const dmhash_t atlas_b_hash = dmHashString64(atlas_b_path);
+    const dmhash_t texture_a_hash = dmHashString64("/gui/set_texture_nil_a.texturec");
+    const dmhash_t texture_b_hash = dmHashString64("/gui/set_texture_nil_b.texturec");
+
+    dmGameObject::HInstance go = Spawn(m_Factory, m_Collection, "/gui/gui_set_texture_nil.goc", dmHashString64("/go"), 0, Point3(0, 0, 0), Quat(0, 0, 0, 1), Vector3(1, 1, 1));
+    ASSERT_NE((void*)0x0, go);
+
+    uint32_t component_type_index        = dmGameObject::GetComponentTypeIndex(m_Collection, dmHashString64("guic"));
+    dmGameSystem::GuiWorld* gui_world    = (dmGameSystem::GuiWorld*) dmGameObject::GetWorld(m_Collection, component_type_index);
+    dmGameSystem::GuiComponent* gui_comp = gui_world->m_Components[0];
+    dmGui::HNode box = dmGui::GetNodeById(gui_comp->m_Scene, "box");
+    ASSERT_NE(0, box);
+
+    ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+
+    ASSERT_EQ(2, dmResource::GetRefCount(m_Factory, atlas_a_hash));
+
+    dmGameSystem::TextureSetResource* atlas_a = 0;
+    ASSERT_EQ(dmResource::RESULT_OK, dmResource::Get(m_Factory, atlas_a_path, (void**)&atlas_a));
+    ASSERT_NE((void*)0x0, atlas_a);
+    ASSERT_EQ(3, dmResource::GetRefCount(m_Factory, atlas_a_hash));
+
+    dmGui::NodeTextureType texture_type;
+    dmGui::HTextureSource texture_source = dmGui::GetNodeTexture(gui_comp->m_Scene, box, &texture_type);
+    ASSERT_EQ(dmGui::NODE_TEXTURE_TYPE_TEXTURE_SET, texture_type);
+    ASSERT_EQ((dmGui::HTextureSource) atlas_a, texture_source);
+
+    dmResource::Release(m_Factory, atlas_a);
+    ASSERT_EQ(2, dmResource::GetRefCount(m_Factory, atlas_a_hash));
+
+    ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+
+    ASSERT_EQ(1, dmResource::GetRefCount(m_Factory, atlas_a_hash));
+    ASSERT_EQ(2, dmResource::GetRefCount(m_Factory, atlas_b_hash));
+
+    dmGameSystem::TextureSetResource* atlas_b = 0;
+    ASSERT_EQ(dmResource::RESULT_OK, dmResource::Get(m_Factory, atlas_b_path, (void**)&atlas_b));
+    ASSERT_NE((void*)0x0, atlas_b);
+    ASSERT_EQ(3, dmResource::GetRefCount(m_Factory, atlas_b_hash));
+
+    texture_source = dmGui::GetNodeTexture(gui_comp->m_Scene, box, &texture_type);
+    ASSERT_EQ(dmGui::NODE_TEXTURE_TYPE_TEXTURE_SET, texture_type);
+    ASSERT_EQ((dmGui::HTextureSource) atlas_b, texture_source);
+
+    dmResource::Release(m_Factory, atlas_b);
+    ASSERT_EQ(2, dmResource::GetRefCount(m_Factory, atlas_b_hash));
+
+    ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+
+    lua_State* L = m_Scriptlibcontext.m_LuaState;
+    lua_getglobal(L, "gui_set_texture_nil_done");
+    bool done = lua_toboolean(L, -1);
+    lua_pop(L, 1);
+    ASSERT_TRUE(done);
+
+    ASSERT_EQ(0, dmResource::GetRefCount(m_Factory, atlas_a_hash));
+    ASSERT_EQ(0, dmResource::GetRefCount(m_Factory, atlas_b_hash));
+    ASSERT_EQ(0, dmResource::GetRefCount(m_Factory, texture_a_hash));
+    ASSERT_EQ(0, dmResource::GetRefCount(m_Factory, texture_b_hash));
+
+    ASSERT_TRUE(dmGameObject::Final(m_Collection));
+}
+
 TEST_F(GuiTest, AsyncTextureAutoSize)
 {
     dmGraphics::NullContext* null_context = (dmGraphics::NullContext*) m_GraphicsContext;

--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -745,10 +745,21 @@ namespace dmGui
 
     static Result AddTexture(HScene scene, dmHashTable64<TextureInfo>& info_array, dmhash_t texture_name_hash, HTextureSource texture_source, NodeTextureType texture_type, uint32_t original_width, uint32_t original_height, uint32_t image_type)
     {
-        if (info_array.Full())
-            return RESULT_OUT_OF_RESOURCES;
+        TextureInfo texture_info(texture_source, texture_type, original_width, original_height, image_type);
+        TextureInfo* existing_texture_info = info_array.Get(texture_name_hash);
 
-        info_array.Put(texture_name_hash, TextureInfo(texture_source, texture_type, original_width, original_height, image_type));
+        if (existing_texture_info)
+        {
+            *existing_texture_info = texture_info;
+        }
+        else
+        {
+            if (info_array.Full())
+                return RESULT_OUT_OF_RESOURCES;
+
+            info_array.Put(texture_name_hash, texture_info);
+        }
+
         UpdateTexture(scene, texture_name_hash, texture_source, texture_type);
 
         return RESULT_OK;

--- a/engine/gui/src/gui_null.cpp
+++ b/engine/gui/src/gui_null.cpp
@@ -175,6 +175,11 @@ namespace dmGui
         return RESULT_OK;
     }
 
+    Result AddDynamicTexture(HScene scene, dmhash_t texture_name_hash, dmGui::HTextureSource texture_source, NodeTextureType texture_type, uint32_t original_width, uint32_t original_height)
+    {
+        return RESULT_OK;
+    }
+
     void RemoveTexture(HScene scene, dmhash_t texture_name_hash)
     {
     }

--- a/engine/gui/src/gui_script.cpp
+++ b/engine/gui/src/gui_script.cpp
@@ -37,6 +37,8 @@ extern "C"
 
 namespace dmGui
 {
+    static const dmhash_t GUI_PROP_TEXTURES = dmHashString64("textures");
+
     /*# GUI API documentation
      *
      * GUI core hooks, functions, messages, properties and constants for
@@ -822,7 +824,7 @@ namespace dmGui
      * @name gui.set
      * @param node [type:node|url] node to set the property for, or msg.url() to the gui itself
      * @param property [type:string|hash|constant] the property to set
-     * @param value [type:number|vector4|vector3|quaternion] the property to set
+     * @param value [type:number|vector4|vector3|quaternion|nil] the property to set. `nil` is only supported for removing runtime texture mappings with `gui.set(msg.url(), "textures", nil, {key = ...})`.
      * @param [options] [type:table] optional options table (only applicable for material constants)
      * - `index` [type:number] index into array property (1 based)
      * - `key` [type:hash] name of internal property
@@ -883,6 +885,18 @@ namespace dmGui
      *    end
      * end
      * ```
+     *
+     * Remove a named runtime texture resource mapping:
+     *
+     * ```lua
+     * local atlas_id = resource.create_atlas("/runtime.texturesetc", atlas_params)
+     * gui.set(msg.url(), "textures", atlas_id, {key = "runtime_texture"})
+     * gui.set_texture(gui.get_node("box"), "runtime_texture")
+     *
+     * -- Later, remove the GUI mapping before releasing the atlas resource.
+     * gui.set(msg.url(), "textures", nil, {key = "runtime_texture"})
+     * resource.release(atlas_id)
+     * ```
      */
     static int LuaSet(lua_State* L)
     {
@@ -893,19 +907,55 @@ namespace dmGui
         dmhash_t property_hash = dmScript::CheckHashOrString(L, 2);
         dmGui::PropDesc* pd = dmGui::GetPropertyDesc(property_hash);
 
+        dmGameObject::LuaToPropertyOptionsResult options_result = {};
+
+        if (lua_gettop(L) > 3)
+        {
+            dmGameObject::LuaToPropertyOptions(L, 4, &options_result);
+        }
+
+        if (lua_isnil(L, 3))
+        {
+            if (!dmScript::IsURL(L, 1) || property_hash != GUI_PROP_TEXTURES)
+            {
+                return DM_LUA_ERROR("'gui.set()' only supports nil for gui.set(msg.url(), \"textures\", nil, {key = ...})");
+            }
+
+            dmMessage::URL sender;
+            dmScript::GetURL(L, &sender);
+            dmMessage::URL target;
+            dmScript::ResolveURL(L, 1, &target, &sender);
+            bool is_self = (sender.m_Socket == target.m_Socket) &&
+                           (sender.m_Path == target.m_Path) &&
+                           (sender.m_Fragment == target.m_Fragment);
+            if (!is_self)
+            {
+                return DM_LUA_ERROR("'gui.set()' can only be used to change a property of the GUI component itself, use 'msg.url()'");
+            }
+
+            dmGameObject::HInstance instance = (dmGameObject::HInstance)scene->m_Context->m_GetUserDataCallback(scene);
+
+            dmhash_t key = 0;
+            if (dmGameObject::GetPropertyOptionsKey((dmGameObject::HPropertyOptions)&options_result.m_Options, 0, &key) != dmGameObject::PROPERTY_RESULT_OK)
+            {
+                return HandleGoSetResult(L, dmGameObject::PROPERTY_RESULT_INVALID_KEY, property_hash, instance, target, options_result.m_Options);
+            }
+
+            Result r = DeleteDynamicTexture(scene, key);
+            if (r != RESULT_OK)
+            {
+                return DM_LUA_ERROR("failed to delete texture '%s' (result = %d)", dmHashReverseSafe64(key), r);
+            }
+
+            return 0;
+        }
+
         dmGameObject::PropertyVar property_var;
         dmGameObject::PropertyResult result = dmGameObject::LuaToVar(L, 3, property_var);
 
         if (result != dmGameObject::PROPERTY_RESULT_OK)
         {
             return DM_LUA_ERROR("Property '%s' has an unsupported type", dmHashReverseSafe64(property_hash));
-        }
-
-        dmGameObject::LuaToPropertyOptionsResult options_result = {};
-
-        if (lua_gettop(L) > 3)
-        {
-            dmGameObject::LuaToPropertyOptions(L, 4, &options_result);
         }
 
         if (dmScript::IsURL(L, 1))

--- a/engine/gui/src/test/test_gui.cpp
+++ b/engine/gui/src/test/test_gui.cpp
@@ -732,6 +732,33 @@ TEST_F(dmGuiTest, DynamicTexture)
     dmGui::RenderScene(m_Scene, rp, &count);
 }
 
+// Verifies that replacing an existing dynamic texture is treated as an update
+// even when the table is already full. This prevents releasing the old backing
+// resource while leaving the old texture entry installed.
+TEST_F(dmGuiTest, DynamicTextureReplaceWhenFull)
+{
+    uint32_t dynamic_texture_capacity = m_Scene->m_DynamicTextures.Capacity();
+    ASSERT_NE(0U, dynamic_texture_capacity);
+
+    for (uint32_t i = 0; i < dynamic_texture_capacity; ++i)
+    {
+        char texture_name[32];
+        dmSnPrintf(texture_name, sizeof(texture_name), "texture_%u", i);
+        ASSERT_EQ(dmGui::RESULT_OK, dmGui::AddDynamicTexture(m_Scene, dmHashString64(texture_name),
+                                                             (dmGui::HTextureSource)(uintptr_t)(i + 1),
+                                                             dmGui::NODE_TEXTURE_TYPE_TEXTURE_SET, 1, 1));
+    }
+
+    ASSERT_TRUE(m_Scene->m_DynamicTextures.Full());
+
+    const dmhash_t replaced_texture = dmHashString64("texture_0");
+    const dmGui::HTextureSource replacement_texture_source = (dmGui::HTextureSource)(uintptr_t)(dynamic_texture_capacity + 1);
+    ASSERT_EQ(dmGui::RESULT_OK, dmGui::AddDynamicTexture(m_Scene, replaced_texture, replacement_texture_source,
+                                                         dmGui::NODE_TEXTURE_TYPE_TEXTURE_SET, 2, 2));
+    ASSERT_EQ(replacement_texture_source, dmGui::GetTexture(m_Scene, replaced_texture));
+    ASSERT_EQ(dynamic_texture_capacity, m_Scene->m_DynamicTextures.Size());
+}
+
 
 #define ASSERT_BUFFER(exp, act, count)\
     for (uint32_t i = 0; i < count; ++i) {\


### PR DESCRIPTION
GUI scripts can now remove a named runtime texture mapping by calling `gui.set(msg.url(), "textures", nil, {key = ...})`. This lets projects release runtime-created atlas resources after they are no longer used by a GUI scene.

Fix https://github.com/defold/defold/issues/12049

### Technical changes

- Added `nil` handling to `gui.set()` for the GUI component `textures` property, restricted to `msg.url()` and keyed texture mappings.
- Releases component-owned resource property references when dynamic GUI texture mappings are deleted.
- Ensures failed texture mapping insertion releases the newly acquired resource reference.
- Allows same-key dynamic texture replacement when the dynamic texture table is already full, preventing stale entries after the old backing resource is released.
- Added gamesys coverage for replacing and removing runtime atlas mappings before `resource.release()`.
- Added GUI coverage for replacing an existing dynamic texture at full table capacity.