### PR TITLE
Fix Vulkan iconification crash

### DIFF
--- a/engine/graphics/src/vulkan/graphics_vulkan.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan.cpp
@@ -1828,6 +1828,11 @@ bail:
         DM_PROFILE(__FUNCTION__);
         VulkanContext* context = (VulkanContext*) _context;
 
+        if (!context->m_FrameBegun)
+        {
+            return;
+        }
+
         uint32_t frameInFlight = context->m_CurrentFrameInFlight;
         FrameResource& currentFrame = context->m_FrameResources[frameInFlight];
 
@@ -1902,7 +1907,11 @@ bail:
             context->m_SwapChain->m_LastPresentId = present_id;
         }
 
-        if (res != VK_SUCCESS && res != VK_SUBOPTIMAL_KHR)
+        if (res == VK_ERROR_OUT_OF_DATE_KHR)
+        {
+            dmLogOnceWarning("Vulkan swapchain is out of date, reason: VK_ERROR_OUT_OF_DATE_KHR.");
+        }
+        else if (res != VK_SUCCESS && res != VK_SUBOPTIMAL_KHR)
         {
             CHECK_VK_ERROR(res);
         }

--- a/engine/graphics/src/vulkan/graphics_vulkan.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan.cpp
@@ -1736,7 +1736,6 @@ bail:
 
         // Wait for GPU to finish work for this frame-in-flight
         vkWaitForFences(vk_device, 1, &currentFrame.m_SubmitFence, VK_TRUE, UINT64_MAX);
-        vkResetFences(vk_device, 1, &currentFrame.m_SubmitFence);
 
         // Acquire next swap chain image
         VkResult res = context->m_SwapChain->Advance(vk_device, currentFrame.m_ImageAvailable);
@@ -1761,6 +1760,9 @@ bail:
                 return;
             }
         }
+
+        // Only reset after a successful acquire. If we bail before submitting, the fence must stay signaled.
+        vkResetFences(vk_device, 1, &currentFrame.m_SubmitFence);
 
         // Flush per-swapchain-image resources to destroy
         if (context->m_MainResourcesToDestroy[frameInFlight]->Size() > 0)


### PR DESCRIPTION
When the "run while iconified" is enabled and the engine has selected Vulkan as the main graphics adapter, minimizing the engine causes a crash. This has now been fixed and should be applicable for all platforms that support Vulkan.

Fixes #9904
Fixes #12599
Fixes #11838