### PR TITLE
Avoid WebGL getParameter INVALID_ENUM on startup

### DIFF
--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -1967,8 +1967,14 @@ static void LogFrameBufferError(GLenum status)
 
             // GL has no separate "max vertex buffer bindings" before
             // GL 4.3 (GL_MAX_VERTEX_ATTRIB_BINDINGS); fall back to attrib count.
-        #ifdef GL_MAX_VERTEX_ATTRIB_BINDINGS
-            limits.m_MaxVertexBuffers = (uint32_t) OpenGLGetInteger(GL_MAX_VERTEX_ATTRIB_BINDINGS);
+            // Emscripten headers expose the define, but WebGL getParameter() support
+            // is not portable here and may report INVALID_ENUM, so keep the fallback.
+        #if defined(GL_MAX_VERTEX_ATTRIB_BINDINGS) && !defined(__EMSCRIPTEN__)
+            GLint max_vertex_attrib_bindings = OpenGLGetInteger(GL_MAX_VERTEX_ATTRIB_BINDINGS);
+            if (max_vertex_attrib_bindings > 0)
+            {
+                limits.m_MaxVertexBuffers = (uint32_t) max_vertex_attrib_bindings;
+            }
         #endif
 
         #if defined(GL_MAX_COMPUTE_WORK_GROUP_SIZE) && defined(DM_HAVE_OPENGL_COMPUTE_SUPPORT)


### PR DESCRIPTION
HTML5 builds no longer query a non-portable WebGL graphics limit during startup. Browsers that reject this parameter keep using the existing vertex-attribute based fallback, avoiding the `getParameter` `INVALID_ENUM` warning while preserving native OpenGL behavior.

### Technical changes

- Skips the `GL_MAX_VERTEX_ATTRIB_BINDINGS` query on Emscripten because WebGL support for that `getParameter()` enum is not portable even though Emscripten headers expose the define.
- Keeps the existing `m_MaxVertexBuffers = m_MaxVertexAttributes` fallback for WebGL.
- Preserves the native OpenGL override when `GL_MAX_VERTEX_ATTRIB_BINDINGS` is available, and only applies it when the queried value is positive.

Crash log (from Safari):
```
[Error] WebGL: INVALID_ENUM: getParameter: invalid parameter name
	getParameter
	emscriptenWebGLGet (TravelMerge_wasm.js:1:175237)
	_glGetIntegerv (TravelMerge_wasm.js:1:179382)
	.wasm-function[3132]
	.wasm-function[3786]
	.wasm-function[2412]
	(anonymous function) (TravelMerge_wasm.js:1:285297)
	callMain (TravelMerge_wasm.js:1:289450)
	_callMain (dmloader.js:1221)
	_preloadAndCallMain (dmloader.js:1205)
	(anonymous function) (dmloader.js:1176)
	(anonymous function) (dmloader.js:1100)
	doCallback (TravelMerge_wasm.js:1:63448)
	done (TravelMerge_wasm.js:1:63604)
	(anonymous function) (TravelMerge_wasm.js:1:54457)
```

