### PR TITLE
Fix Lua timer self-cancel crashes

### DIFF
--- a/engine/script/src/script_timer.cpp
+++ b/engine/script/src/script_timer.cpp
@@ -88,8 +88,10 @@ namespace dmScript
         dmSet<uint16_t>     m_Instances; // the pool indices
         dmArray<uint16_t>   m_ScratchBuffer; // When doing operations on the timer instances, we need a copy to avoid self modification of m_Instances
         uint16_t            m_Version;   // Incremented to avoid collisions each time we push timer indexes back to the m_IndexPool
+        uint16_t            m_CallbackInvocationDepth;
         uint16_t            m_InUpdate : 1;
         uint16_t            m_IsDirty : 1;
+        uint16_t            m_HasDeferredDeadTimers : 1;
     };
 
     dmArray<TimerWorld*> g_Worlds;
@@ -167,14 +169,17 @@ namespace dmScript
         timer_world->m_Instances.SetCapacity(INITIAL_TIMER_CAPACITY);
 
         timer_world->m_Version = 0;
+        timer_world->m_CallbackInvocationDepth = 0;
         timer_world->m_InUpdate = 0;
         timer_world->m_IsDirty = 0;
+        timer_world->m_HasDeferredDeadTimers = 0;
         return timer_world;
     }
 
     void DeleteTimerWorld(HTimerWorld timer_world)
     {
         assert(timer_world->m_InUpdate == 0);
+        assert(timer_world->m_CallbackInvocationDepth == 0);
         delete timer_world;
     }
 
@@ -212,6 +217,46 @@ namespace dmScript
             tgt[i] = src[i];
         }
         return size;
+    }
+
+    static uint32_t FreeDeadTimers(HTimerWorld timer_world)
+    {
+        assert(timer_world != 0x0);
+
+        uint32_t size = CopyIndices(timer_world->m_Instances, timer_world->m_ScratchBuffer);
+        uint32_t free_count = 0;
+        for (uint32_t i = 0; i < size; ++i)
+        {
+            Timer* timer = GetTimerFromIndex(timer_world, timer_world->m_ScratchBuffer[i]);
+            if (timer && timer->m_IsAlive == 0)
+            {
+                FreeTimer(timer_world, timer);
+                ++free_count;
+            }
+        }
+        return free_count;
+    }
+
+    static void BeginLuaTimerCallback(HTimerWorld timer_world)
+    {
+        assert(timer_world != 0x0);
+        ++timer_world->m_CallbackInvocationDepth;
+    }
+
+    static void EndLuaTimerCallback(HTimerWorld timer_world)
+    {
+        assert(timer_world != 0x0);
+        assert(timer_world->m_CallbackInvocationDepth > 0);
+        --timer_world->m_CallbackInvocationDepth;
+
+        if (timer_world->m_CallbackInvocationDepth == 0 && timer_world->m_InUpdate == 0 && timer_world->m_HasDeferredDeadTimers)
+        {
+            timer_world->m_HasDeferredDeadTimers = 0;
+            if (FreeDeadTimers(timer_world) > 0)
+            {
+                ++timer_world->m_Version;
+            }
+        }
     }
 
     void UpdateTimers(HTimerWorld timer_world, float dt)
@@ -301,6 +346,12 @@ namespace dmScript
             }
         }
 
+        if (timer_world->m_HasDeferredDeadTimers)
+        {
+            timer_world->m_HasDeferredDeadTimers = 0;
+            FreeDeadTimers(timer_world);
+        }
+
         if (timer_world->m_IsDirty)
         {
             ++timer_world->m_Version;
@@ -351,10 +402,14 @@ namespace dmScript
         timer->m_IsAlive = 0;
         timer->m_Callback(timer_world, TIMER_EVENT_CANCELLED, timer->m_Handle, 0.f, timer->m_Owner, timer->m_UserData);
 
-        if (timer_world->m_InUpdate == 0)
+        if (timer_world->m_InUpdate == 0 && timer_world->m_CallbackInvocationDepth == 0)
         {
             FreeTimer(timer_world, timer);
             ++timer_world->m_Version;
+        }
+        else
+        {
+            timer_world->m_HasDeferredDeadTimers = 1;
         }
 
         return true;
@@ -387,9 +442,13 @@ namespace dmScript
                 ++cancelled_count;
             }
 
-            if (timer_world->m_InUpdate == 0)
+            if (timer_world->m_InUpdate == 0 && timer_world->m_CallbackInvocationDepth == 0)
             {
                 FreeTimer(timer_world, timer);
+            }
+            else
+            {
+                timer_world->m_HasDeferredDeadTimers = 1;
             }
         }
 
@@ -527,15 +586,9 @@ namespace dmScript
         {
             LuaTimerCallbackArgs args = { timer_handle, time_elapsed };
 
+            BeginLuaTimerCallback(timer_world);
             InvokeCallback(callback, LuaTimerCallbackArgsCB, &args);
-        }
-
-        if ((event_type != TIMER_EVENT_TRIGGER_WILL_REPEAT) && IsCallbackValid(callback))
-        {
-            DestroyCallback(callback);
-
-            Timer* timer = GetTimerFromHandle(timer_world, timer_handle);
-            timer->m_UserData = 0;
+            EndLuaTimerCallback(timer_world);
         }
     }
 
@@ -700,7 +753,7 @@ namespace dmScript
         dmScript::HTimerWorld timer_world = CheckTimerWorld(L);
 
         Timer* timer = GetTimerFromHandle(timer_world, timer_handle);
-        if (!timer)
+        if (!timer || timer->m_IsAlive == 0)
         {
             lua_pushboolean(L, 0);
             return 1;
@@ -714,7 +767,9 @@ namespace dmScript
         }
 
         LuaTimerCallbackArgs args = { timer->m_Handle, timer->m_Delay - timer->m_Remaining };
+        BeginLuaTimerCallback(timer_world);
         InvokeCallback(callback, LuaTimerCallbackArgsCB, &args);
+        EndLuaTimerCallback(timer_world);
 
         lua_pushboolean(L, 1);
         return 1;
@@ -759,7 +814,7 @@ namespace dmScript
         dmScript::HTimerWorld timer_world = CheckTimerWorld(L);
 
         Timer* timer = GetTimerFromHandle(timer_world, timer_handle);
-        if (!timer)
+        if (!timer || timer->m_IsAlive == 0)
         {
             lua_pushnil(L);
             return 1;

--- a/engine/script/src/test/test_script_timer.cpp
+++ b/engine/script/src/test/test_script_timer.cpp
@@ -1031,6 +1031,365 @@ TEST_F(ScriptTimerTest, TestLuaTimerGetInfo)
     dmScript::DeleteScriptWorld(script_world);
 }
 
+// Repro for https://github.com/defold/defold/issues/12436:
+// a repeating Lua timer cancels itself from inside its own callback, forces
+// GC/allocation pressure, and immediately starts a new repeating timer. This
+// exercises callback lifetime while the outer InvokeCallback is still unwinding.
+TEST_F(ScriptTimerTest, TestLuaRepeatingCancelRestartInCallback)
+{
+    int top = lua_gettop(L);
+    LuaInit(L);
+    int ref_count = dmScript::GetLuaRefCount();
+
+    dmScript::HScriptWorld script_world = dmScript::NewScriptWorld(m_Context);
+
+    const char pre_script[] =
+    "handle = nil\n"
+    "local callback\n"
+    "local function gc_pressure()\n"
+    "    collectgarbage(\"collect\")\n"
+    "    local garbage = {}\n"
+    "    local vector4 = vmath and vmath.vector4\n"
+    "    for i = 1, 4096 do\n"
+    "        if vector4 then\n"
+    "            garbage[#garbage + 1] = vector4(i, i, i, i)\n"
+    "        end\n"
+    "        garbage[#garbage + 1] = { i, tostring(i), tostring({}) }\n"
+    "    end\n"
+    "    return garbage\n"
+    "end\n"
+    "callback = function(self, timer_handle, elapsed_time)\n"
+    "    test.callback_counter(timer_handle, elapsed_time)\n"
+    "    assert(timer.cancel(timer_handle))\n"
+    "    _G.__timer_restart_gc_pressure = gc_pressure()\n"
+    "    handle = timer.delay(0, true, callback)\n"
+    "    assert(handle ~= timer.INVALID_TIMER_HANDLE)\n"
+    "end\n"
+    "handle = timer.delay(0, true, callback)\n"
+    "assert(handle ~= timer.INVALID_TIMER_HANDLE)\n";
+
+    const char post_script[] =
+    "assert(timer.cancel(handle))\n"
+    "handle = nil\n"
+    "_G.__timer_restart_gc_pressure = nil\n"
+    "collectgarbage(\"collect\")\n";
+
+    cb_callback_counter = 0u;
+    cb_elapsed_time = 0.0f;
+
+    const char* SCRIPTINSTANCE = "TestScriptInstance";
+
+    dmScript::RegisterUserType(L, SCRIPTINSTANCE, ScriptInstance_methods, ScriptInstance_meta);
+
+    CreateScriptInstance(L, SCRIPTINSTANCE);
+    dmScript::SetInstance(L);
+
+    ASSERT_TRUE(dmScript::IsInstanceValid(L));
+    dmScript::InitializeInstance(script_world);
+
+    ASSERT_TRUE(RunString(L, pre_script));
+    ASSERT_EQ(top, lua_gettop(L));
+
+    for (uint32_t i = 0; i < 4; ++i)
+    {
+        dmScript::UpdateScriptWorld(script_world, 1.0f);
+    }
+    ASSERT_EQ(4u, cb_callback_counter);
+    ASSERT_EQ(4.0f, cb_elapsed_time);
+
+    ASSERT_TRUE(RunString(L, post_script));
+    ASSERT_EQ(top, lua_gettop(L));
+
+    FinalizeInstance(script_world);
+
+    dmScript::GetInstance(L);
+    DeleteScriptInstance(L);
+
+    lua_pushnil(L);
+    dmScript::SetInstance(L);
+
+    dmScript::DeleteScriptWorld(script_world);
+    ASSERT_EQ(ref_count, dmScript::GetLuaRefCount());
+}
+
+// A one-shot Lua timer cancels itself from inside its own callback, forces
+// GC/allocation pressure, and immediately starts another one-shot timer. This verifies
+// that one-shot completion and explicit cancellation defer Lua callback destruction
+// until the outer InvokeCallback has unwound.
+TEST_F(ScriptTimerTest, TestLuaOneshotCancelRestartInCallback)
+{
+    int top = lua_gettop(L);
+    LuaInit(L);
+
+    dmScript::HScriptWorld script_world = dmScript::NewScriptWorld(m_Context);
+
+    const char pre_script[] =
+    "handle = nil\n"
+    "local callback\n"
+    "local function gc_pressure()\n"
+    "    collectgarbage(\"collect\")\n"
+    "    local garbage = {}\n"
+    "    local vector4 = vmath and vmath.vector4\n"
+    "    for i = 1, 4096 do\n"
+    "        if vector4 then\n"
+    "            garbage[#garbage + 1] = vector4(i, i, i, i)\n"
+    "        end\n"
+    "        garbage[#garbage + 1] = { i, tostring(i), tostring({}) }\n"
+    "    end\n"
+    "    return garbage\n"
+    "end\n"
+    "callback = function(self, timer_handle, elapsed_time)\n"
+    "    test.callback_counter(timer_handle, elapsed_time)\n"
+    "    assert(timer.cancel(timer_handle))\n"
+    "    _G.__timer_oneshot_gc_pressure = gc_pressure()\n"
+    "    handle = timer.delay(0, false, callback)\n"
+    "    assert(handle ~= timer.INVALID_TIMER_HANDLE)\n"
+    "end\n"
+    "handle = timer.delay(0, false, callback)\n"
+    "assert(handle ~= timer.INVALID_TIMER_HANDLE)\n";
+
+    const char post_script[] =
+    "assert(timer.cancel(handle))\n"
+    "handle = nil\n"
+    "_G.__timer_oneshot_gc_pressure = nil\n"
+    "collectgarbage(\"collect\")\n";
+
+    cb_callback_handle = dmScript::INVALID_TIMER_HANDLE;
+    cb_callback_counter = 0u;
+    cb_elapsed_time = 0.0f;
+
+    const char* SCRIPTINSTANCE = "TestScriptInstance";
+
+    dmScript::RegisterUserType(L, SCRIPTINSTANCE, ScriptInstance_methods, ScriptInstance_meta);
+
+    CreateScriptInstance(L, SCRIPTINSTANCE);
+    dmScript::SetInstance(L);
+
+    ASSERT_TRUE(dmScript::IsInstanceValid(L));
+    dmScript::InitializeInstance(script_world);
+
+    ASSERT_TRUE(RunString(L, pre_script));
+    ASSERT_EQ(top, lua_gettop(L));
+
+    for (uint32_t i = 0; i < 4; ++i)
+    {
+        dmScript::UpdateScriptWorld(script_world, 1.0f);
+    }
+    ASSERT_NE(dmScript::INVALID_TIMER_HANDLE, cb_callback_handle);
+    ASSERT_EQ(4u, cb_callback_counter);
+    ASSERT_EQ(4.0f, cb_elapsed_time);
+
+    ASSERT_TRUE(RunString(L, post_script));
+    ASSERT_EQ(top, lua_gettop(L));
+
+    FinalizeInstance(script_world);
+
+    dmScript::GetInstance(L);
+    DeleteScriptInstance(L);
+
+    lua_pushnil(L);
+    dmScript::SetInstance(L);
+
+    dmScript::DeleteScriptWorld(script_world);
+}
+
+// timer.trigger() invokes a Lua timer callback outside the timer update pass. The
+// callback cancels its own timer and pressures GC, verifying that the timer becomes
+// logically dead immediately while FreeTimer() is deferred until timer.trigger()
+// finishes unwinding.
+TEST_F(ScriptTimerTest, TestLuaTriggerCancelInCallback)
+{
+    int top = lua_gettop(L);
+    LuaInit(L);
+    int ref_count = dmScript::GetLuaRefCount();
+
+    dmScript::HScriptWorld script_world = dmScript::NewScriptWorld(m_Context);
+
+    const char trigger_script[] =
+    "handle = nil\n"
+    "local function gc_pressure()\n"
+    "    collectgarbage(\"collect\")\n"
+    "    local garbage = {}\n"
+    "    local vector4 = vmath and vmath.vector4\n"
+    "    for i = 1, 4096 do\n"
+    "        if vector4 then\n"
+    "            garbage[#garbage + 1] = vector4(i, i, i, i)\n"
+    "        end\n"
+    "        garbage[#garbage + 1] = { i, tostring(i), tostring({}) }\n"
+    "    end\n"
+    "    return garbage\n"
+    "end\n"
+    "local function callback(self, timer_handle, elapsed_time)\n"
+    "    test.callback_counter(timer_handle, elapsed_time)\n"
+    "    assert(timer.cancel(timer_handle))\n"
+    "    assert(timer.get_info(timer_handle) == nil)\n"
+    "    assert(not timer.trigger(timer_handle))\n"
+    "    _G.__timer_trigger_gc_pressure = gc_pressure()\n"
+    "end\n"
+    "handle = timer.delay(10, true, callback)\n"
+    "assert(handle ~= timer.INVALID_TIMER_HANDLE)\n"
+    "assert(timer.trigger(handle))\n"
+    "assert(not timer.cancel(handle))\n"
+    "handle = nil\n"
+    "_G.__timer_trigger_gc_pressure = nil\n"
+    "collectgarbage(\"collect\")\n";
+
+    cb_callback_handle = dmScript::INVALID_TIMER_HANDLE;
+    cb_callback_counter = 0u;
+    cb_elapsed_time = 0.0f;
+
+    const char* SCRIPTINSTANCE = "TestScriptInstance";
+
+    dmScript::RegisterUserType(L, SCRIPTINSTANCE, ScriptInstance_methods, ScriptInstance_meta);
+
+    CreateScriptInstance(L, SCRIPTINSTANCE);
+    dmScript::SetInstance(L);
+
+    ASSERT_TRUE(dmScript::IsInstanceValid(L));
+    dmScript::InitializeInstance(script_world);
+
+    ASSERT_TRUE(RunString(L, trigger_script));
+    ASSERT_EQ(top, lua_gettop(L));
+    ASSERT_NE(dmScript::INVALID_TIMER_HANDLE, cb_callback_handle);
+    ASSERT_EQ(1u, cb_callback_counter);
+    ASSERT_EQ(0.0f, cb_elapsed_time);
+
+    dmScript::UpdateScriptWorld(script_world, 10.0f);
+    ASSERT_EQ(1u, cb_callback_counter);
+    ASSERT_EQ(0.0f, cb_elapsed_time);
+
+    FinalizeInstance(script_world);
+
+    dmScript::GetInstance(L);
+    DeleteScriptInstance(L);
+
+    lua_pushnil(L);
+    dmScript::SetInstance(L);
+
+    dmScript::DeleteScriptWorld(script_world);
+    ASSERT_EQ(ref_count, dmScript::GetLuaRefCount());
+}
+
+// Cancelling a Lua timer from normal Lua code, outside both UpdateTimers and any
+// timer callback, should free the timer immediately, make get_info() return nil,
+// make a second cancel return false, and prevent later updates from invoking it.
+TEST_F(ScriptTimerTest, TestLuaCancelOutsideUpdate)
+{
+    int top = lua_gettop(L);
+    LuaInit(L);
+    int ref_count = dmScript::GetLuaRefCount();
+
+    dmScript::HScriptWorld script_world = dmScript::NewScriptWorld(m_Context);
+
+    const char cancel_script[] =
+    "handle = timer.delay(1, false, function(self, timer_handle, elapsed_time)\n"
+    "    test.callback_counter(timer_handle, elapsed_time)\n"
+    "end)\n"
+    "assert(handle ~= timer.INVALID_TIMER_HANDLE)\n"
+    "assert(timer.get_info(handle) ~= nil)\n"
+    "assert(timer.cancel(handle))\n"
+    "assert(timer.get_info(handle) == nil)\n"
+    "assert(not timer.cancel(handle))\n"
+    "handle = nil\n"
+    "collectgarbage(\"collect\")\n";
+
+    cb_callback_handle = dmScript::INVALID_TIMER_HANDLE;
+    cb_callback_counter = 0u;
+    cb_elapsed_time = 0.0f;
+
+    const char* SCRIPTINSTANCE = "TestScriptInstance";
+
+    dmScript::RegisterUserType(L, SCRIPTINSTANCE, ScriptInstance_methods, ScriptInstance_meta);
+
+    CreateScriptInstance(L, SCRIPTINSTANCE);
+    dmScript::SetInstance(L);
+
+    ASSERT_TRUE(dmScript::IsInstanceValid(L));
+    dmScript::InitializeInstance(script_world);
+
+    ASSERT_TRUE(RunString(L, cancel_script));
+    ASSERT_EQ(top, lua_gettop(L));
+    ASSERT_EQ(dmScript::INVALID_TIMER_HANDLE, cb_callback_handle);
+    ASSERT_EQ(0u, cb_callback_counter);
+    ASSERT_EQ(0.0f, cb_elapsed_time);
+
+    dmScript::UpdateScriptWorld(script_world, 2.0f);
+    ASSERT_EQ(0u, cb_callback_counter);
+    ASSERT_EQ(0.0f, cb_elapsed_time);
+
+    FinalizeInstance(script_world);
+
+    dmScript::GetInstance(L);
+    DeleteScriptInstance(L);
+
+    lua_pushnil(L);
+    dmScript::SetInstance(L);
+
+    dmScript::DeleteScriptWorld(script_world);
+    ASSERT_EQ(ref_count, dmScript::GetLuaRefCount());
+}
+
+// Finalizing a script instance removes all live Lua timers through KillTimers().
+// KillTimers() must destroy the timer-owned Lua callbacks without delivering
+// cancelled callbacks, and later script-world updates must not invoke them.
+TEST_F(ScriptTimerTest, TestLuaFinalizeKillsLiveTimers)
+{
+    int top = lua_gettop(L);
+    LuaInit(L);
+    int ref_count = dmScript::GetLuaRefCount();
+
+    dmScript::HScriptWorld script_world = dmScript::NewScriptWorld(m_Context);
+
+    const char pre_script[] =
+    "local function callback(self, timer_handle, elapsed_time)\n"
+    "    test.callback_counter(timer_handle, elapsed_time)\n"
+    "end\n"
+    "handle_1 = timer.delay(0, true, callback)\n"
+    "handle_2 = timer.delay(1, false, callback)\n"
+    "handle_3 = timer.delay(2, true, callback)\n"
+    "assert(handle_1 ~= timer.INVALID_TIMER_HANDLE)\n"
+    "assert(handle_2 ~= timer.INVALID_TIMER_HANDLE)\n"
+    "assert(handle_3 ~= timer.INVALID_TIMER_HANDLE)\n"
+    "assert(timer.get_info(handle_1) ~= nil)\n"
+    "assert(timer.get_info(handle_2) ~= nil)\n"
+    "assert(timer.get_info(handle_3) ~= nil)\n";
+
+    cb_callback_handle = dmScript::INVALID_TIMER_HANDLE;
+    cb_callback_counter = 0u;
+    cb_elapsed_time = 0.0f;
+
+    const char* SCRIPTINSTANCE = "TestScriptInstance";
+
+    dmScript::RegisterUserType(L, SCRIPTINSTANCE, ScriptInstance_methods, ScriptInstance_meta);
+
+    CreateScriptInstance(L, SCRIPTINSTANCE);
+    dmScript::SetInstance(L);
+
+    ASSERT_TRUE(dmScript::IsInstanceValid(L));
+    dmScript::InitializeInstance(script_world);
+
+    ASSERT_TRUE(RunString(L, pre_script));
+    ASSERT_EQ(top, lua_gettop(L));
+    ASSERT_EQ(dmScript::INVALID_TIMER_HANDLE, cb_callback_handle);
+    ASSERT_EQ(0u, cb_callback_counter);
+    ASSERT_EQ(0.0f, cb_elapsed_time);
+
+    FinalizeInstance(script_world);
+
+    dmScript::UpdateScriptWorld(script_world, 10.0f);
+    ASSERT_EQ(dmScript::INVALID_TIMER_HANDLE, cb_callback_handle);
+    ASSERT_EQ(0u, cb_callback_counter);
+    ASSERT_EQ(0.0f, cb_elapsed_time);
+
+    dmScript::GetInstance(L);
+    DeleteScriptInstance(L);
+
+    lua_pushnil(L);
+    dmScript::SetInstance(L);
+
+    dmScript::DeleteScriptWorld(script_world);
+    ASSERT_EQ(ref_count, dmScript::GetLuaRefCount());
+}
 
 TEST_F(ScriptTimerTest, TestLuaStress)
 {


### PR DESCRIPTION
Lua timers can now safely cancel or restart themselves from inside their own callbacks without freeing callback state while it is still running. This prevents crashes in timer-heavy callback flows and keeps cancelled timers immediately invisible to `timer.get_info()`, `timer.trigger()`, and repeated cancellation attempts.

Fix https://github.com/defold/defold/issues/12436

### Technical changes

- Tracks Lua timer callback invocation depth in `TimerWorld` and defers freeing dead timers until callbacks and timer updates have unwound.
- Adds shared deferred cleanup for dead timers and version updates when cleanup happens outside the normal update pass.
- Wraps both scheduled timer callbacks and `timer.trigger()` callbacks with begin/end callback guards.
- Treats timers marked not alive as invalid in `timer.trigger()` and `timer.get_info()`.
- Adds regression coverage for repeating and one-shot timers that cancel/restart inside callbacks, `timer.trigger()` cancellation, normal cancellation outside update, and script finalization killing live timers.