### PR TITLE
Welcome screen: Persist projects until user removes them (remove 30 day expiration date)

### DIFF
--- a/editor/src/clj/editor/welcome.clj
+++ b/editor/src/clj/editor/welcome.clj
@@ -183,7 +183,6 @@
           (let [file (io/as-file path)
                 instant (time/try-parse-instant timestamp)]
             (when (and (some? instant)
-                       (<= (.toDays (time/since instant)) 30)
                        (fs/existing-file? file))
               (when-some [title (try-read-project-title file)]
                 {:project-file file


### PR DESCRIPTION
The Recent Projects list on the editor welcome screen used to have a 30 day expiration date. This has been changed and projects remain in the Recent Projects list until explicitly removed by the user.

Fixes #12605