### PR TITLE
Fix atlas packing regression

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/textureset/test/TextureSetLayoutTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/textureset/test/TextureSetLayoutTest.java
@@ -26,7 +26,6 @@ import java.util.HashSet;
 import java.util.List;
 
 import org.junit.Test;
-import org.junit.Ignore;
 
 import com.dynamo.bob.CompileExceptionError;
 import com.dynamo.bob.textureset.TextureSetLayout;
@@ -349,7 +348,7 @@ public class TextureSetLayoutTest {
     }
 
     // The 26 source images of issue #12593's 2.atlas (chars_01..26), unextruded.
-    private static final int[][] ISSUE_12593_CHARS = {
+    private static final int[][] PORTRAIT_ATLAS_RECTS = {
         {227, 475}, {203, 434}, {265, 532}, {242, 521}, {236, 588}, {253, 567},
         {305, 552}, {308, 551}, {289, 620}, {259, 615}, {363, 584}, {316, 626},
         {264, 630}, {283, 507}, {193, 508}, {201, 500}, {322, 536}, {280, 514},
@@ -357,42 +356,38 @@ public class TextureSetLayoutTest {
         {319, 558}, {285, 497}
     };
 
-    // Each image is inflated by 2*extrudeBorders before being packed, matching the
-    // editor (atlas->texture-set-data) and bob (AtlasUtil.generateTextureSet) paths.
-    private List<Rect> issue12593Chars(int extrudeBorders) {
+    private List<Rect> portraitAtlasRects(int extrudeBorders) {
         int grow = 2 * extrudeBorders;
-        List<Rect> rects = new ArrayList<Rect>(ISSUE_12593_CHARS.length);
-        for (int i = 0; i < ISSUE_12593_CHARS.length; i++) {
+        List<Rect> rects = new ArrayList<Rect>(PORTRAIT_ATLAS_RECTS.length);
+        for (int i = 0; i < PORTRAIT_ATLAS_RECTS.length; i++) {
             rects.add(rect(Integer.toString(i), i,
-                           ISSUE_12593_CHARS[i][0] + grow,
-                           ISSUE_12593_CHARS[i][1] + grow));
+                           PORTRAIT_ATLAS_RECTS[i][0] + grow,
+                           PORTRAIT_ATLAS_RECTS[i][1] + grow));
         }
         return rects;
     }
 
-    // Issue #12593: with extrudeBorders=2 the 26 images pack into a single 2048x2048
-    // page. Verified end-to-end against the live editor (atlas :layout-size = 2048x2048).
+    // Issue #12593: increasing extrudeBorders for the reported portrait atlas
+    // should not produce a smaller packed page. This is distinct from the #11541
+    // canFitInPage regression covered by testMixedOrientationFit. Here we're making
+    // sure that the packing remains monotonic over N extrusions.
     @Test
-    public void testIssue12593ExtrudeTwoSinglePage() throws CompileExceptionError {
-        List<Layout> layouts = packedLayout(0, issue12593Chars(2));
-        assertEquals(1, layouts.size());
-        assertEquals(2048, layouts.get(0).getWidth());
-        assertEquals(2048, layouts.get(0).getHeight());
-    }
+    public void testIssue12593PortraitAtlasExtrudeBorders() throws CompileExceptionError {
+        long previousArea = 0;
+        int compactLayoutCount = 0;
 
-    // Issue #12593 phenomenon (B): with extrudeBorders=0 the same images (now SMALLER)
-    // packed to 4096x2048 instead of 2048x2048 -- counter-intuitively worse than the
-    // larger extrude=2 set above -- because the greedy MaxRects packer is non-monotonic:
-    // a single fixed seed ordering misses a packing that provably exists (it can be
-    // reconstructed from the extrude=2 solution by shrinking each placed rect). Fixed by
-    // the multi-seed-sort ensemble in createMaxRectsLayout, which also tries longest-side
-    // ordering and keeps the smaller result. Distinct from the #11541 canFitInPage
-    // regression covered by testMixedOrientationFit.
-    @Test
-    public void testIssue12593ExtrudeZeroSinglePage() throws CompileExceptionError {
-        List<Layout> layouts = packedLayout(0, issue12593Chars(0));
-        assertEquals(1, layouts.size());
-        assertEquals(2048, layouts.get(0).getWidth());
-        assertEquals(2048, layouts.get(0).getHeight());
+        for (int extrudeBorders = 0; extrudeBorders <= 5; extrudeBorders++) {
+            List<Layout> layouts = packedLayout(0, portraitAtlasRects(extrudeBorders));
+            assertEquals(1, layouts.size());
+            Layout layout = layouts.get(0);
+            long area = (long)layout.getWidth() * layout.getHeight();
+            assertTrue(String.format("extrudeBorders=%d packed to a smaller page area", extrudeBorders), area >= previousArea);
+            if (layout.getWidth() == 2048 && layout.getHeight() == 2048) {
+                compactLayoutCount++;
+            }
+            previousArea = area;
+        }
+
+        assertTrue("Expected at least three extrude border values to fit in 2048x2048", compactLayoutCount >= 3);
     }
 }

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/textureset/test/TextureSetLayoutTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/textureset/test/TextureSetLayoutTest.java
@@ -333,4 +333,17 @@ public class TextureSetLayoutTest {
         assertEquals(layout.getWidth(), 2048);
         assertEquals(layout.getHeight(), 1024);
     }
+
+    @Test
+    public void testMixedOrientationFit() throws CompileExceptionError {
+        List<Rect> rectangles
+            = Arrays.asList(rect("0", 0, 1089, 417),
+                            rect("1", 1, 369, 1080));
+        List<Layout> layouts = packedLayout(0, rectangles);
+        assertEquals(1, layouts.size());
+
+        Layout layout = layouts.get(0);
+        assertEquals(2048, layout.getWidth());
+        assertEquals(1024, layout.getHeight());
+    }
 }

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/textureset/test/TextureSetLayoutTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/textureset/test/TextureSetLayoutTest.java
@@ -343,6 +343,7 @@ public class TextureSetLayoutTest {
         assertEquals(1, layouts.size());
 
         Layout layout = layouts.get(0);
+        assertTrue("Expected occupancy to be above 40%", layouts.get(0).getOccupancy() >= 0.4);
         assertEquals(2048, layout.getWidth());
         assertEquals(1024, layout.getHeight());
     }
@@ -374,7 +375,7 @@ public class TextureSetLayoutTest {
     @Test
     public void testIssue12593PortraitAtlasExtrudeBorders() throws CompileExceptionError {
         long previousArea = 0;
-        int compactLayoutCount = 0;
+        int occupancyCount = 0;
 
         for (int extrudeBorders = 0; extrudeBorders <= 5; extrudeBorders++) {
             List<Layout> layouts = packedLayout(0, portraitAtlasRects(extrudeBorders));
@@ -382,12 +383,14 @@ public class TextureSetLayoutTest {
             Layout layout = layouts.get(0);
             long area = (long)layout.getWidth() * layout.getHeight();
             assertTrue(String.format("extrudeBorders=%d packed to a smaller page area", extrudeBorders), area >= previousArea);
-            if (layout.getWidth() == 2048 && layout.getHeight() == 2048) {
-                compactLayoutCount++;
+            if (layout.getOccupancy() >= 0.88f) {
+                occupancyCount++;
+            } else {
+                break;
             }
             previousArea = area;
         }
 
-        assertTrue("Expected at least three extrude border values to fit in 2048x2048", compactLayoutCount >= 3);
+        assertTrue("Expected occupancy to be above 88% for the first 3 extrusion borders", occupancyCount >= 3);
     }
 }

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/textureset/test/TextureSetLayoutTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/textureset/test/TextureSetLayoutTest.java
@@ -26,6 +26,7 @@ import java.util.HashSet;
 import java.util.List;
 
 import org.junit.Test;
+import org.junit.Ignore;
 
 import com.dynamo.bob.CompileExceptionError;
 import com.dynamo.bob.textureset.TextureSetLayout;
@@ -345,5 +346,53 @@ public class TextureSetLayoutTest {
         Layout layout = layouts.get(0);
         assertEquals(2048, layout.getWidth());
         assertEquals(1024, layout.getHeight());
+    }
+
+    // The 26 source images of issue #12593's 2.atlas (chars_01..26), unextruded.
+    private static final int[][] ISSUE_12593_CHARS = {
+        {227, 475}, {203, 434}, {265, 532}, {242, 521}, {236, 588}, {253, 567},
+        {305, 552}, {308, 551}, {289, 620}, {259, 615}, {363, 584}, {316, 626},
+        {264, 630}, {283, 507}, {193, 508}, {201, 500}, {322, 536}, {280, 514},
+        {224, 546}, {218, 520}, {260, 485}, {252, 486}, {246, 520}, {265, 495},
+        {319, 558}, {285, 497}
+    };
+
+    // Each image is inflated by 2*extrudeBorders before being packed, matching the
+    // editor (atlas->texture-set-data) and bob (AtlasUtil.generateTextureSet) paths.
+    private List<Rect> issue12593Chars(int extrudeBorders) {
+        int grow = 2 * extrudeBorders;
+        List<Rect> rects = new ArrayList<Rect>(ISSUE_12593_CHARS.length);
+        for (int i = 0; i < ISSUE_12593_CHARS.length; i++) {
+            rects.add(rect(Integer.toString(i), i,
+                           ISSUE_12593_CHARS[i][0] + grow,
+                           ISSUE_12593_CHARS[i][1] + grow));
+        }
+        return rects;
+    }
+
+    // Issue #12593: with extrudeBorders=2 the 26 images pack into a single 2048x2048
+    // page. Verified end-to-end against the live editor (atlas :layout-size = 2048x2048).
+    @Test
+    public void testIssue12593ExtrudeTwoSinglePage() throws CompileExceptionError {
+        List<Layout> layouts = packedLayout(0, issue12593Chars(2));
+        assertEquals(1, layouts.size());
+        assertEquals(2048, layouts.get(0).getWidth());
+        assertEquals(2048, layouts.get(0).getHeight());
+    }
+
+    // Issue #12593 phenomenon (B): with extrudeBorders=0 the same images (now SMALLER)
+    // packed to 4096x2048 instead of 2048x2048 -- counter-intuitively worse than the
+    // larger extrude=2 set above -- because the greedy MaxRects packer is non-monotonic:
+    // a single fixed seed ordering misses a packing that provably exists (it can be
+    // reconstructed from the extrude=2 solution by shrinking each placed rect). Fixed by
+    // the multi-seed-sort ensemble in createMaxRectsLayout, which also tries longest-side
+    // ordering and keeps the smaller result. Distinct from the #11541 canFitInPage
+    // regression covered by testMixedOrientationFit.
+    @Test
+    public void testIssue12593ExtrudeZeroSinglePage() throws CompileExceptionError {
+        List<Layout> layouts = packedLayout(0, issue12593Chars(0));
+        assertEquals(1, layouts.size());
+        assertEquals(2048, layouts.get(0).getWidth());
+        assertEquals(2048, layouts.get(0).getHeight());
     }
 }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/textureset/MaxRectsLayoutStrategy.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/textureset/MaxRectsLayoutStrategy.java
@@ -103,6 +103,8 @@ public class MaxRectsLayoutStrategy implements TextureSetLayoutStrategy {
         int minHeight = Integer.MAX_VALUE;
         int maxRectWidth = 0;
         int maxRectHeight = 0;
+        int maxMinSide = 0;
+        int maxMaxSide = 0;
         long totalRectArea = 0L;
         for (int i = 0, nn = inputRects.size(); i < nn; i++) {
             Rect rect = inputRects.get(i).rect;
@@ -110,6 +112,8 @@ public class MaxRectsLayoutStrategy implements TextureSetLayoutStrategy {
             minHeight = Math.min(minHeight, rect.getHeight());
             maxRectWidth = Math.max(maxRectWidth, rect.getWidth());
             maxRectHeight = Math.max(maxRectHeight, rect.getHeight());
+            maxMinSide = Math.max(maxMinSide, Math.min(rect.getWidth(), rect.getHeight()));
+            maxMaxSide = Math.max(maxMaxSide, Math.max(rect.getWidth(), rect.getHeight()));
             totalRectArea += (long)rect.getWidth() * (long)rect.getHeight();
             if (settings.rotation) {
                 if ((rect.getWidth() > settings.maxPageWidth - settings.paddingX || rect.getHeight() > settings.maxPageHeight - settings.paddingY)
@@ -130,7 +134,7 @@ public class MaxRectsLayoutStrategy implements TextureSetLayoutStrategy {
         }
         minWidth = Math.max(minWidth + settings.paddingX, settings.minPageWidth);
         minHeight = Math.max(minHeight + settings.paddingY, settings.minPageHeight);
-        RectStats rectStats = new RectStats(maxRectWidth, maxRectHeight, totalRectArea);
+        RectStats rectStats = new RectStats(maxRectWidth, maxRectHeight, maxMinSide, maxMaxSide, totalRectArea);
 
         // Find the minimal page size that fits all rects.
         Page bestResult = null;
@@ -239,9 +243,11 @@ public class MaxRectsLayoutStrategy implements TextureSetLayoutStrategy {
             return width >= stats.maxWidth && height >= stats.maxHeight;
         }
 
-        boolean fitsUpright = width >= stats.maxWidth && height >= stats.maxHeight;
-        boolean fitsRotated = width >= stats.maxHeight && height >= stats.maxWidth;
-        return fitsUpright || fitsRotated;
+        // Rotation allows each rect to orient its shorter side along the page's
+        // shorter side and its longer side along the page's longer side.
+        int pageMinSide = Math.min(width, height);
+        int pageMaxSide = Math.max(width, height);
+        return pageMinSide >= stats.maxMinSide && pageMaxSide >= stats.maxMaxSide;
     }
 
     static class BinarySearch {
@@ -308,11 +314,15 @@ public class MaxRectsLayoutStrategy implements TextureSetLayoutStrategy {
     static class RectStats {
         final int maxWidth;
         final int maxHeight;
+        final int maxMinSide;
+        final int maxMaxSide;
         final long totalArea;
 
-        RectStats(int maxWidth, int maxHeight, long totalArea) {
+        RectStats(int maxWidth, int maxHeight, int maxMinSide, int maxMaxSide, long totalArea) {
             this.maxWidth = maxWidth;
             this.maxHeight = maxHeight;
+            this.maxMinSide = maxMinSide;
+            this.maxMaxSide = maxMaxSide;
             this.totalArea = totalArea;
         }
     }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/textureset/TextureSetLayout.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/textureset/TextureSetLayout.java
@@ -261,6 +261,13 @@ public class TextureSetLayout {
         public int getHeight() {
             return height;
         }
+        public float getOccupancy() {
+            long used = 0;
+            for (Rect r : rectangles) {
+                used += (long) r.getWidth() * r.getHeight();
+            }
+            return (float) used / ((long) width * height);
+        }
 
         @Override
         public String toString() {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/textureset/TextureSetLayout.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/textureset/TextureSetLayout.java
@@ -340,14 +340,9 @@ public class TextureSetLayout {
      * @param rotate
      * @return
      */
-    // Seed orderings for the greedy MaxRects packer. The packer is a greedy
-    // heuristic and is non-monotonic: a single fixed sort lands on a good packing
-    // for some inputs and a needlessly large one for others (issue #12593, e.g. the
-    // same image set packs to 2048x2048 with one ordering but 4096x2048 with
-    // another). We pack with area-descending first - the historical order, kept as
-    // the fast path so existing layouts are byte-for-byte unchanged - and only when
-    // that result is not already at the minimal page size do we retry with alternate
-    // orderings and keep the best.
+    // Seed orderings for the greedy MaxRects packer. Area descending is the
+    // historical order and remains the fast path. Fallback orderings are used
+    // only when the fast path leaves room for a strictly smaller result.
     private static final Comparator<Rect> SORT_AREA_DESC = new Comparator<Rect>() {
         @Override
         public int compare(Rect o1, Rect o2) {
@@ -374,18 +369,6 @@ public class TextureSetLayout {
         }
     };
 
-    private static final Comparator<Rect> SORT_SHORTSIDE_DESC = new Comparator<Rect>() {
-        @Override
-        public int compare(Rect o1, Rect o2) {
-            int n1 = Math.min(o1.rect.width, o1.rect.height);
-            int n2 = Math.min(o2.rect.width, o2.rect.height);
-            if (n1 != n2) {
-                return n2 - n1;
-            }
-            return o2.getArea() - o1.getArea();
-        }
-    };
-
     private static final Comparator<Rect> SORT_PERIMETER_DESC = new Comparator<Rect>() {
         @Override
         public int compare(Rect o1, Rect o2) {
@@ -398,9 +381,9 @@ public class TextureSetLayout {
         }
     };
 
-    // Tried only when the area-descending fast path is sub-optimal.
+    // Fallback orderings for cases where the area-descending seed is not enough.
     private static final List<Comparator<Rect>> ALTERNATE_SORTS =
-        Arrays.asList(SORT_LONGSIDE_DESC, SORT_SHORTSIDE_DESC, SORT_PERIMETER_DESC);
+        Arrays.asList(SORT_LONGSIDE_DESC, SORT_PERIMETER_DESC);
 
     // The smallest square power-of-two page that could conceivably hold all rects,
     // bounded below by both the total area and the longest single side.

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/textureset/TextureSetLayout.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/textureset/TextureSetLayout.java
@@ -340,21 +340,124 @@ public class TextureSetLayout {
      * @param rotate
      * @return
      */
-    public static List<Layout> createMaxRectsLayout(int margin, List<Rect> rectangles, boolean rotate, float maxPageSizeW, float maxPageSizeH) throws CompileExceptionError {
-        // Sort by area first, then longest side
-        Collections.sort(rectangles, new Comparator<Rect>() {
-            @Override
-            public int compare(Rect o1, Rect o2) {
-                int a1 = o1.getArea();
-                int a2 = o2.getArea();
-                if (a1 != a2) {
-                    return a2 - a1;
-                }
-                int n1 = Math.max(o1.rect.width, o1.rect.height);
-                int n2 = Math.max(o2.rect.width, o2.rect.height);
+    // Seed orderings for the greedy MaxRects packer. The packer is a greedy
+    // heuristic and is non-monotonic: a single fixed sort lands on a good packing
+    // for some inputs and a needlessly large one for others (issue #12593, e.g. the
+    // same image set packs to 2048x2048 with one ordering but 4096x2048 with
+    // another). We pack with area-descending first - the historical order, kept as
+    // the fast path so existing layouts are byte-for-byte unchanged - and only when
+    // that result is not already at the minimal page size do we retry with alternate
+    // orderings and keep the best.
+    private static final Comparator<Rect> SORT_AREA_DESC = new Comparator<Rect>() {
+        @Override
+        public int compare(Rect o1, Rect o2) {
+            int a1 = o1.getArea();
+            int a2 = o2.getArea();
+            if (a1 != a2) {
+                return a2 - a1;
+            }
+            int n1 = Math.max(o1.rect.width, o1.rect.height);
+            int n2 = Math.max(o2.rect.width, o2.rect.height);
+            return n2 - n1;
+        }
+    };
+
+    private static final Comparator<Rect> SORT_LONGSIDE_DESC = new Comparator<Rect>() {
+        @Override
+        public int compare(Rect o1, Rect o2) {
+            int n1 = Math.max(o1.rect.width, o1.rect.height);
+            int n2 = Math.max(o2.rect.width, o2.rect.height);
+            if (n1 != n2) {
                 return n2 - n1;
             }
-        });
+            return o2.getArea() - o1.getArea();
+        }
+    };
+
+    private static final Comparator<Rect> SORT_SHORTSIDE_DESC = new Comparator<Rect>() {
+        @Override
+        public int compare(Rect o1, Rect o2) {
+            int n1 = Math.min(o1.rect.width, o1.rect.height);
+            int n2 = Math.min(o2.rect.width, o2.rect.height);
+            if (n1 != n2) {
+                return n2 - n1;
+            }
+            return o2.getArea() - o1.getArea();
+        }
+    };
+
+    private static final Comparator<Rect> SORT_PERIMETER_DESC = new Comparator<Rect>() {
+        @Override
+        public int compare(Rect o1, Rect o2) {
+            int p1 = o1.rect.width + o1.rect.height;
+            int p2 = o2.rect.width + o2.rect.height;
+            if (p1 != p2) {
+                return p2 - p1;
+            }
+            return o2.getArea() - o1.getArea();
+        }
+    };
+
+    // Tried only when the area-descending fast path is sub-optimal.
+    private static final List<Comparator<Rect>> ALTERNATE_SORTS =
+        Arrays.asList(SORT_LONGSIDE_DESC, SORT_SHORTSIDE_DESC, SORT_PERIMETER_DESC);
+
+    // The smallest square power-of-two page that could conceivably hold all rects,
+    // bounded below by both the total area and the longest single side.
+    private static int minimumSquarePageSize(int margin, List<Rect> rectangles) {
+        int maxLengthScale = 0;
+        int area = 0;
+        for (Rect rect : rectangles) {
+            area += rect.getArea();
+            maxLengthScale = Math.max(maxLengthScale, rect.rect.width);
+            maxLengthScale = Math.max(maxLengthScale, rect.rect.height);
+        }
+        maxLengthScale += margin * 2;
+        return 1 << getExponentNextOrMatchingPowerOfTwo(Math.max((int)Math.sqrt(area), maxLengthScale));
+    }
+
+    // Ranks two candidate page-sets: fewer pages wins, then smaller page area.
+    // Strictly-better only, so an equal result keeps the incumbent (area-desc)
+    // layout and its exact rectangle positions.
+    private static boolean isBetterLayout(List<Layout> candidate, List<Layout> incumbent) {
+        if (candidate.size() != incumbent.size()) {
+            return candidate.size() < incumbent.size();
+        }
+        long ca = (long)candidate.get(0).getWidth() * (long)candidate.get(0).getHeight();
+        long ia = (long)incumbent.get(0).getWidth() * (long)incumbent.get(0).getHeight();
+        return ca < ia;
+    }
+
+    public static List<Layout> createMaxRectsLayout(int margin, List<Rect> rectangles, boolean rotate, float maxPageSizeW, float maxPageSizeH) throws CompileExceptionError {
+        // Fast path: historical area-descending order. Preserves existing layouts.
+        List<Layout> best = layoutWithSort(margin, rectangles, rotate, maxPageSizeW, maxPageSizeH, SORT_AREA_DESC);
+
+        // Only retry alternate orderings when the fast path is not already optimal:
+        // a paged atlas that needed more than one page, or a single-page atlas that
+        // had to grow past the minimal square page. Keeps the common case at 1x cost.
+        boolean useMaxPageSize = maxPageSizeW > 0 && maxPageSizeH > 0;
+        boolean optimal;
+        if (useMaxPageSize) {
+            optimal = best.size() <= 1;
+        } else {
+            int floor = minimumSquarePageSize(margin, rectangles);
+            Layout page = best.get(0);
+            optimal = page.getWidth() <= floor && page.getHeight() <= floor;
+        }
+
+        if (!optimal) {
+            for (Comparator<Rect> comparator : ALTERNATE_SORTS) {
+                List<Layout> candidate = layoutWithSort(margin, rectangles, rotate, maxPageSizeW, maxPageSizeH, comparator);
+                if (isBetterLayout(candidate, best)) {
+                    best = candidate;
+                }
+            }
+        }
+        return best;
+    }
+
+    private static List<Layout> layoutWithSort(int margin, List<Rect> rectangles, boolean rotate, float maxPageSizeW, float maxPageSizeH, Comparator<Rect> comparator) throws CompileExceptionError {
+        Collections.sort(rectangles, comparator);
 
         boolean useMaxPageSize       = maxPageSizeW > 0 && maxPageSizeH > 0;
         final int defaultMinPageSize = 16;
@@ -401,17 +504,8 @@ public class TextureSetLayout {
 
             return layouts;
         } else {
-            // Calculate total area of rectangles and the max length of a rectangle
-            int maxLengthScale = 0;
-            int area = 0;
-            for (Rect rect : rectangles) {
-                area += rect.getArea();
-                maxLengthScale = Math.max(maxLengthScale, rect.rect.width);
-                maxLengthScale = Math.max(maxLengthScale, rect.rect.height);
-            }
-            maxLengthScale += margin * 2;
             // Ensure the longest length found in all of the images will fit within one page, irrespective of orientation.
-            final int defaultMaxPageSize = 1 << getExponentNextOrMatchingPowerOfTwo(Math.max((int)Math.sqrt(area), maxLengthScale));
+            final int defaultMaxPageSize = minimumSquarePageSize(margin, rectangles);
             MaxRectsLayoutStrategy.Settings settings = new MaxRectsLayoutStrategy.Settings();
             settings.maxPageHeight = defaultMaxPageSize;
             settings.maxPageWidth = defaultMaxPageSize;


### PR DESCRIPTION
A regression was fixed that would not allow certain images to be rotated, requiring extra space. Also improved the packing algorithm with extra attempts which helped reduce atlas sizes under certain cases with extrusion settings.

Fixes #12593

### Technical changes

Added an occupancy getter for layouts.