### PR TITLE
Treat empty resource fields as nil even if they have a default value

### DIFF
--- a/editor/src/clj/editor/game_project.clj
+++ b/editor/src/clj/editor/game_project.clj
@@ -37,13 +37,10 @@
 
 (def game-project-icon "icons/32/Icons_04-Project-file.png")
 
-(def ^:private gamepads-setting-path ["input" "gamepads"])
-(def ^:private gamepad-database-setting-path ["input" "gamepad_database"])
-
 (defn- ignored-setting?
   [{:keys [path]}]
   (or (= ["project" "dependencies"] path)
-      (= gamepad-database-setting-path path)))
+      (= ["input" "gamepad_database"] path)))
 
 ;; Transform a settings map with build-time settings conversions.
 (defn- transform-settings! [settings]
@@ -54,39 +51,26 @@
         (assoc  ["display", "update_frequency"] 0))
     settings))
 
-(defn- explicit-empty-setting? [raw-settings path]
-  (= "" (settings-core/get-setting raw-settings path)))
-
-(defn- built-resource-setting [path value meta-settings path->built-resource-settings dep-resources]
-  (let [meta-setting (settings-core/get-meta-setting meta-settings path)
-        build-resource (path->built-resource-settings path)]
-    (cond
-      (:unknown-setting meta-setting)
-      {:path path :value value}
-
-      build-resource
-      {:path path :value (resource/proj-path (dep-resources build-resource))}
-
-      (and (= gamepads-setting-path path)
-           (= "" value))
-      {:path path :value value}
-
-      (and (some? value) (not= "" value))
-      {:path path
-       :value (if (= :resource (:type meta-setting))
-                (resource/proj-path value)
-                (settings-core/render-raw-setting-value meta-setting value))})))
-
 (defn- build-game-project [resource dep-resources user-data]
-  (let [{:keys [settings-map raw-settings meta-settings path->built-resource-settings]} user-data
-        settings-map (cond-> (transform-settings! settings-map)
-                             (explicit-empty-setting? raw-settings gamepads-setting-path)
-                             (assoc gamepads-setting-path ""))
+  (let [{:keys [settings-map meta-settings path->built-resource-settings]} user-data
         settings (into []
                        (comp (keep (fn [[path value]]
-                                     (built-resource-setting path value meta-settings path->built-resource-settings dep-resources)))
-                             (remove ignored-setting?))
-                       (sort-by first settings-map))
+                                     (let [meta-setting (settings-core/get-meta-setting meta-settings path)]
+                                       (when (or (:unknown-setting meta-setting)
+                                                 (and (= :resource (:type meta-setting))
+                                                      (nil? value)
+                                                      (:default meta-setting))
+                                                 (and (some? value) (not= "" value)))
+                                         {:path path :value value}))))
+                             (remove ignored-setting?)
+                             (keep (fn [{:keys [path value] :as setting}]
+                                     (let [meta-setting (settings-core/get-meta-setting meta-settings path)]
+                                       (if (= :resource (:type meta-setting))
+                                         (if-let [build-resource (path->built-resource-settings path)]
+                                           (assoc setting :value (resource/proj-path (dep-resources build-resource)))
+                                           (assoc setting :value (resource/resource->proj-path value)))
+                                         (assoc setting :value (settings-core/render-raw-setting-value meta-setting value)))))))
+                       (sort-by first (transform-settings! settings-map)))
         user-data-content (settings-core/settings->str settings meta-settings :comma-separated-list)]
     {:resource resource :content (.getBytes user-data-content)}))
 
@@ -139,56 +123,45 @@
    ["graphics" "texture_profiles"] [[:build-targets :dep-build-targets]
                                     [:pb :texture-profiles-data]]
    ["input" "gamepads"] [[:build-targets :gamepads-build-targets]
-                         [:_node-id :gamepads-node-id]
                          [:resource :gamepads-resource]
                          [:pb :gamepads-pb]]
    ["input" "gamepad_database"] [[:resource :gamepad-database-resource]
                                  [:lines :gamepad-database-lines]]
    ["input" "game_binding"] [[:build-targets :dep-build-targets]]})
 
-(defn- gamepad-database-error [_node-id gamepad-database-resource]
-  (when (and gamepad-database-resource
-             (resource/exists? gamepad-database-resource)
-             (not= "txt" (resource/ext gamepad-database-resource)))
-    (g/->error _node-id :build-targets :fatal gamepad-database-resource
-               (localization/message "error.game-project.gamepad-database-must-be-txt"))))
-
-(g/defnk produce-build-targets [_node-id build-errors resource settings-map raw-settings meta-info custom-build-targets resource-settings dep-build-targets gamepads-build-targets gamepads-node-id gamepads-resource gamepads-pb gamepad-database-resource gamepad-database-lines]
-  (let [gamepads-empty (explicit-empty-setting? raw-settings gamepads-setting-path)
-        gamepad-database-empty (explicit-empty-setting? raw-settings gamepad-database-setting-path)
-        gamepads-build-targets (when-not gamepads-empty gamepads-build-targets)
-        gamepads-resource (when-not gamepads-empty gamepads-resource)
-        gamepads-pb (when-not gamepads-empty gamepads-pb)
-        gamepad-database-resource (when-not gamepad-database-empty gamepad-database-resource)
-        gamepad-database-lines (when-not gamepad-database-empty gamepad-database-lines)]
-    (g/precluding-errors [(some-> (g/flatten-errors build-errors) (assoc :_node-id _node-id))
-                          gamepads-pb
-                          gamepad-database-lines
-                          (gamepad-database-error _node-id gamepad-database-resource)]
-     (let [gamepads-build-target (if (and gamepads-build-targets
-                                           (not gamepad-database-resource))
-                                    (peek gamepads-build-targets)
-                                    (gamepads/make-build-target (or gamepads-node-id _node-id) gamepads-resource gamepads-pb gamepad-database-resource gamepad-database-lines))
-           dep-build-targets (cond-> (vec (into (flatten dep-build-targets) custom-build-targets))
-                                     gamepads-build-target (conj gamepads-build-target))
-           deps-by-source (into {} (map (fn [{build-resource :resource}]
-                                          [(:resource build-resource) build-resource]))
-                                dep-build-targets)
-           path->built-resource-settings (cond-> (into {} (keep (fn [{:keys [path value]}]
-                                                                  (when (resource-setting-connections-template path)
-                                                                    [path (deps-by-source value)])))
-                                                                resource-settings)
-                                         gamepads-build-target
-                                         (assoc gamepads-setting-path (:resource gamepads-build-target)))]
-       [(bt/with-content-hash
-          {:node-id _node-id
-           :resource (workspace/make-build-resource resource)
-           :build-fn build-game-project
-           :user-data {:settings-map settings-map
-                       :raw-settings raw-settings
-                       :meta-settings (:settings meta-info)
-                       :path->built-resource-settings path->built-resource-settings}
-           :deps dep-build-targets})]))))
+(g/defnk produce-build-targets [_node-id build-errors resource settings-map meta-info custom-build-targets resource-settings dep-build-targets gamepads-build-targets gamepads-resource gamepads-pb gamepad-database-resource gamepad-database-lines]
+  (g/precluding-errors [(some-> (g/flatten-errors build-errors) (assoc :_node-id _node-id))
+                        gamepads-pb
+                        gamepad-database-lines
+                        (when (and gamepad-database-resource
+                                   (resource/exists? gamepad-database-resource)
+                                   (not= "txt" (resource/ext gamepad-database-resource)))
+                          (g/->error _node-id :build-targets :fatal gamepad-database-resource
+                                     (localization/message "error.game-project.gamepad-database-must-be-txt")))]
+    (let [gamepads-build-target (if (and gamepads-build-targets (not gamepad-database-resource))
+                                  (peek gamepads-build-targets)
+                                  (gamepads/make-build-target _node-id gamepads-resource gamepads-pb gamepad-database-resource gamepad-database-lines))
+          dep-build-targets (cond-> (vec (into (flatten dep-build-targets) custom-build-targets))
+                              gamepads-build-target (conj gamepads-build-target))
+          deps-by-source (into {}
+                               (map (fn [{build-resource :resource}]
+                                      [(:resource build-resource) build-resource]))
+                               dep-build-targets)
+          path->built-resource-settings (cond-> (into {}
+                                                      (keep (fn [{:keys [path value]}]
+                                                              (when (resource-setting-connections-template path)
+                                                                [path (deps-by-source value)])))
+                                                      resource-settings)
+                                          gamepads-build-target
+                                          (assoc ["input" "gamepads"] (:resource gamepads-build-target)))]
+      [(bt/with-content-hash
+         {:node-id _node-id
+          :resource (workspace/make-build-resource resource)
+          :build-fn build-game-project
+          :user-data {:settings-map settings-map
+                      :meta-settings (:settings meta-info)
+                      :path->built-resource-settings path->built-resource-settings}
+          :deps dep-build-targets})])))
 
 (g/defnode GameProjectNode
   (inherits resource-node/ResourceNode)
@@ -206,12 +179,10 @@
   (input form-data g/Any)
   (output form-data g/Any :cached (gu/passthrough form-data))
 
-  (input raw-settings g/Any)
   (input resource-settings g/Any)
 
   (input gamepads-resource resource/Resource)
   (input gamepads-build-targets g/Any)
-  (input gamepads-node-id g/NodeID)
   (input gamepads-pb g/Any)
   (input gamepad-database-resource resource/Resource)
   (input gamepad-database-lines g/Any)
@@ -311,7 +282,6 @@
         (g/connect settings-node :settings-map self :settings-map)
         (g/connect settings-node :save-value self :save-value)
         (g/connect settings-node :form-data self :form-data)
-        (g/connect settings-node :raw-settings self :raw-settings)
         (g/connect settings-node :meta-info self :meta-info)
         (g/connect settings-node :resource-settings self :resource-settings)
         (g/connect settings-node :setting-errors self :build-errors)

--- a/editor/src/clj/editor/game_properties.clj
+++ b/editor/src/clj/editor/game_properties.clj
@@ -20,16 +20,23 @@
             [editor.localization :as localization]
             [editor.resource :as resource]
             [editor.settings-core :as settings-core]
+            [editor.workspace :as workspace]
             [util.coll :as coll])
   (:import [java.io BufferedReader]))
 
 (g/defnode GameProperties
   (inherits r/CodeEditorResourceNode)
   (output proj-path+meta-info g/Any :cached
-          (g/fnk [_node-id resource lines]
+          (g/fnk [^:unsafe _evaluation-context _node-id resource lines]
+            ;; Safe because the evaluation context is only used to resolve stable proj-paths for resource defaults.
             (try
               (with-open [rdr (BufferedReader. (data/lines-reader lines))]
-                (coll/pair (resource/proj-path resource) (settings-core/load-meta-properties rdr)))
+                (coll/pair (resource/proj-path resource)
+                           (update (settings-core/load-meta-properties rdr)
+                                   :settings
+                                   settings-core/resolve-resource-settings
+                                   :default
+                                   #(workspace/resolve-resource (:basis _evaluation-context) resource %))))
               (catch Exception e
                 (g/->error _node-id :meta-info :fatal resource (.getMessage e) (ex-data e)))))))
 

--- a/editor/src/clj/editor/settings.clj
+++ b/editor/src/clj/editor/settings.clj
@@ -47,17 +47,6 @@
   ;; resource-setting-reference only consumed by SettingsNode and already cached there.
   (output resource-setting-reference g/Any (g/fnk [_node-id path value] {:path path :node-id _node-id :value value})))
 
-(defn- resolve-resource-settings [settings value-field resolve-resource-fn]
-  (mapv (fn [setting]
-          (cond-> setting
-                  ;; Resolve string resource values so the form gets typed values.
-                  ;; This covers raw settings without ResourceSettingNodes, and
-                  ;; defaults from metadata merged after load.
-                  (and (= :resource (:type setting))
-                       (string? (get setting value-field)))
-                  (update value-field resolve-resource-fn)))
-        settings))
-
 (defn- type-annotate-settings [settings meta-settings]
   (let [meta-settings-map (settings-core/make-meta-settings-map meta-settings)]
     (mapv #(assoc % :type (:type (meta-settings-map (:path %)))) settings)))
@@ -70,18 +59,17 @@
         (settings-core/settings-with-value)
         (->> (settings-core/sanitize-settings meta-settings))
         (type-annotate-settings meta-settings)
-        (resolve-resource-settings :value resolve-resource))))
+        (settings-core/resolve-resource-settings :value resolve-resource))))
 
 (g/defnk produce-settings-map [^:unsafe _evaluation-context owner-resource meta-info raw-settings resource-settings]
   ;; we use evaluation context to resolve a resource; we only need the resource
   ;; for its path, so it's safe to use it here
   (let [basis (:basis _evaluation-context)
-        resolve-resource #(workspace/resolve-resource basis owner-resource %)
-        meta-settings (resolve-resource-settings (:settings meta-info) :default resolve-resource)
-        sanitized-settings (resolve-resource-settings-from-raw basis raw-settings meta-settings owner-resource)
-        all-settings (concat (settings-core/make-default-settings meta-settings) sanitized-settings resource-settings)
-        settings-map (settings-core/make-settings-map all-settings)]
-    settings-map))
+        meta-settings (:settings meta-info)]
+    (settings-core/make-settings-map
+      (concat (settings-core/make-default-settings meta-settings)
+              (resolve-resource-settings-from-raw basis raw-settings meta-settings owner-resource)
+              resource-settings))))
 
 (defn- set-raw-setting [settings {:keys [path] :as meta-setting} value]
   (settings-core/set-setting settings path (settings-core/render-raw-setting-value meta-setting value)))
@@ -170,7 +158,7 @@
                              (section-title category-name (get-in meta-info [:categories category-name])))}))
 
 (defn get-setting-build-error [setting-value meta-setting label]
-  (if (and (some? setting-value))
+  (when (some? setting-value)
     (let [max-error (when (some? (:maximum meta-setting))
                       (validation/prop-maximum-check? (:maximum meta-setting) setting-value (string/join "." (:path meta-setting))))
           min-error (when (some? (:minimum meta-setting))
@@ -220,8 +208,6 @@
   ;; we use evaluation context to resolve a resource; we only need the resource
   ;; for its path, so it's safe to use it here
   (let [basis (:basis _evaluation-context)
-        resolve-resource #(workspace/resolve-resource basis owner-resource %)
-        meta-info (update meta-info :settings resolve-resource-settings :default resolve-resource)
         meta-settings (:settings meta-info)
         sanitized-settings (resolve-resource-settings-from-raw basis raw-settings meta-settings owner-resource)
         non-defaulted-setting-paths (into #{}
@@ -308,11 +294,11 @@
   (let [basis (g/now)
         resolve-resource #(workspace/resolve-resource basis resource %)
         meta-info (-> (settings-core/add-meta-info-for-unknown-settings initial-meta-info raw-settings)
-                      (update :settings resolve-resource-settings :default resolve-resource))
+                      (update :settings settings-core/resolve-resource-settings :default resolve-resource))
         meta-settings (:settings meta-info)
         settings (-> (settings-core/sanitize-settings meta-settings raw-settings) ; this provokes parse errors if any
                      (type-annotate-settings meta-settings)
-                     (resolve-resource-settings :value resolve-resource))
+                     (settings-core/resolve-resource-settings :value resolve-resource))
         resource-setting-paths (set (map :path (filter #(= :resource (:type %)) meta-settings)))]
     (concat
       ;; We retain the actual raw string settings and update these when/if the user changes a setting,

--- a/editor/src/clj/editor/settings_core.clj
+++ b/editor/src/clj/editor/settings_core.clj
@@ -356,6 +356,17 @@
 (defn sanitize-settings [meta-settings settings]
   (mapv (partial sanitize-setting (make-meta-settings-map meta-settings)) settings))
 
+(defn resolve-resource-settings [settings value-field resolve-resource-fn]
+  (mapv (fn [setting]
+          (cond-> setting
+                  ;; Resolve string resource values so the form gets typed values.
+                  ;; This covers raw settings without ResourceSettingNodes, and
+                  ;; defaults from metadata merged after load.
+                  (and (= :resource (:type setting))
+                       (string? (get setting value-field)))
+                  (update value-field resolve-resource-fn)))
+        settings))
+
 (defn make-default-settings [meta-settings]
   (mapv (fn [meta-setting]
           {:path (:path meta-setting)
@@ -467,8 +478,9 @@
     (:default (nth meta-settings index))))
 
 (defn get-setting-or-default [meta-settings settings path]
-  (or (get-setting settings path)
-      (get-default-setting meta-settings path)))
+  (if-let [index (setting-index settings path)]
+    (:value (nth settings index))
+    (get-default-setting meta-settings path)))
 
 (defn get-meta-setting
   [meta-settings path]

--- a/editor/test/editor/settings_test.clj
+++ b/editor/test/editor/settings_test.clj
@@ -13,8 +13,10 @@
 ;; specific language governing permissions and limitations under the License.
 
 (ns editor.settings-test
-  (:require [clojure.test :refer :all]
-            [editor.settings-core :as settings-core]))
+  (:require [clojure.java.io :as io]
+            [clojure.test :refer :all]
+            [editor.settings-core :as settings-core]
+            [integration.test-util :as test-util]))
 
 (deftest merge-meta-infos-prefers-known-settings
   (let [known-setting {:path ["section" "key"]
@@ -32,3 +34,19 @@
            (settings-core/merge-meta-infos
              {:settings [known-setting]}
              {:settings [unknown-setting]})))))
+
+(deftest get-setting-or-default-preserves-present-nil-value
+  (let [root (io/file ".")
+        default-resource (test-util/make-fake-file-resource nil
+                                                            (.getPath root)
+                                                            (io/file root "default.resource")
+                                                            (byte-array 0))
+        meta-settings [{:path ["section" "key"]
+                        :type :resource
+                        :default default-resource}]]
+    (is (nil? (settings-core/get-setting-or-default meta-settings
+                                                    [{:path ["section" "key"]
+                                                      :value nil}]
+                                                    ["section" "key"])))
+    (is (identical? default-resource
+                    (settings-core/get-setting-or-default meta-settings [] ["section" "key"])))))

--- a/editor/test/integration/build_test.clj
+++ b/editor/test/integration/build_test.clj
@@ -833,6 +833,31 @@
                                ;; Check so empty custom properties are included as empty strings
                                (check-project-setting built-properties ["custom" "should_be_empty"] "")))))))
 
+(deftest build-game-project-preserves-explicit-empty-resource-settings
+  (let [project-path (test-util/make-temp-project-copy! "test/resources/game_project_properties")]
+    (with-open [_ (test-util/make-directory-deleter project-path)]
+      (spit (io/file project-path "game.project")
+            (str "[project]\n"
+                 "title = Explicit Empty Resource Settings\n\n"
+                 "[bootstrap]\n"
+                 "main_collection = main.collectionc\n"
+                 "render = \n\n"
+                 "[display]\n"
+                 "display_profiles = \n\n"
+                 "[input]\n"
+                 "game_binding = game.input_bindingc\n"))
+      (with-clean-system
+        (let [workspace (test-util/setup-workspace! world project-path)
+              project (test-util/setup-project! workspace)
+              game-project (test-util/resource-node project "/game.project")]
+          (is (nil? (game-project/get-setting game-project ["bootstrap" "render"])))
+          (is (nil? (game-project/get-setting game-project ["display" "display_profiles"])))
+          (with-open [_ (test-util/build! game-project)]
+            (with-open [r (io/reader (build-path workspace "game.projectc"))]
+              (let [built-properties (settings-core/parse-settings r)]
+                (check-project-setting built-properties ["bootstrap" "render"] "")
+                (check-project-setting built-properties ["display" "display_profiles"] "")))))))))
+
 (defmacro with-setting [path value & body]
   ;; assumes game-project in scope
   (let [path-list (string/split path #"/")]

--- a/editor/test/integration/game_properties_test.clj
+++ b/editor/test/integration/game_properties_test.clj
@@ -14,6 +14,7 @@
 
 (ns integration.game-properties-test
   (:require [clojure.test :refer :all]
+            [editor.resource :as resource]
             [integration.test-util :as test-util]))
 
 (set! *warn-on-reflection* true)
@@ -25,4 +26,8 @@
       (is (true? (test-util/get-setting game-project ["project" "subtitles"])))
       (is (true? (test-util/get-setting game-project ["tv" "show_ads"])))
       (is (= 128 (test-util/get-setting game-project ["spine" "max_count"])))
+      (is (= "/game.project" (resource/proj-path (test-util/get-setting game-project ["defaults" "proj_path"]))))
+      (is (= "/game.project" (resource/proj-path (test-util/get-setting game-project ["defaults" "relative"]))))
+      (is (nil? (test-util/get-setting game-project ["defaults" "none"])))
+      (is (nil? (test-util/get-setting game-project ["defaults" "empty"])))
       (is (thrown-with-msg? Throwable #"Invalid setting path." (test-util/get-setting game-project ["unrelated" "unexpected"]))))))

--- a/editor/test/resources/game_properties_project/ext/ext.properties
+++ b/editor/test/resources/game_properties_project/ext/ext.properties
@@ -3,3 +3,16 @@ group = Components
 
 max_count.type = integer
 max_count.default = 128
+
+[defaults]
+
+proj_path.type = resource
+proj_path.default = /game.project
+
+relative.type = resource
+relative.default = ../game.project
+
+none.type = resource
+
+empty.type = resource
+empty.default =


### PR DESCRIPTION
Context:

When reviewing PR https://github.com/defold/defold/pull/12629, me and Mathias found an issue in the editor: if a game.project has a resoruce property set to empty string, while there is a non-empty default, that default will be used instead. In particular, the problem was in `get-setting-or-default` that did `(or (setting-value) (default-setting-value))`. I fixed the issue, and then rolled back some changes to `game_project.clj` that introduced a workaround for the issue. Perhaps a better way to review changes to `game_project.clj` is to look at `git diff 11b80b629dfa0c934933b1c11e88b7e515a10a80^ -- src/clj/editor/game_project.clj`.

After doing this change, I noticed that defaults that are coming from `ext.properties` files are strings. We already had an issue caused by this that I recently fixed — https://github.com/defold/defold/pull/12370. But the problem is, I fixed it by resolving default strings to resources in the wrong place, not early enough. For example, I did it in `produce-form-data` fn in settings.clj, but we really need to do it as early as possible, otherwise we will continue having problems with default resource fields being strings. So I moved the logic to game_properties.clj, where we actually parse and produce ext meta settings.
