### PR TITLE
Align the texture buffer for morph targets to 4

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/util/TextureUtilTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/util/TextureUtilTest.java
@@ -40,14 +40,41 @@ import com.dynamo.graphics.proto.Graphics.TextureProfiles;
 
 public class TextureUtilTest {
 
+    /* Intent: verify that generated texture resources align embedded image payloads.
+    ** Setup: one small byte texture alternative and one RGBA32F texture alternative are
+    ** written through the default texture resource path.
+    ** Expected: each serialized mip offset skips any inserted padding, each payload starts
+    ** on a 4-byte boundary, and the original image data is preserved.
+    */
     @Test
     public void testWriteGenerateResultCanAlignFirstImageData() throws Exception {
-        byte[] imageData = new byte[16];
-        for (int i = 0; i < imageData.length; ++i) {
-            imageData[i] = (byte)i;
+        byte[] byteImageData = new byte[5];
+        for (int i = 0; i < byteImageData.length; ++i) {
+            byteImageData[i] = (byte)i;
         }
 
-        TextureImage.Image image = TextureImage.Image.newBuilder()
+        byte[] floatImageData = new byte[16];
+        for (int i = 0; i < floatImageData.length; ++i) {
+            floatImageData[i] = (byte)(i + 16);
+        }
+
+        TextureImage.Image byteImage = TextureImage.Image.newBuilder()
+                .setWidth(1)
+                .setHeight(1)
+                .setDepth(1)
+                .setOriginalWidth(1)
+                .setOriginalHeight(1)
+                .setOriginalDepth(1)
+                .setFormat(TextureImage.TextureFormat.TEXTURE_FORMAT_RGBA)
+                .addMipMapOffset(0)
+                .addMipMapSize(byteImageData.length)
+                .addMipMapSizeCompressed(byteImageData.length)
+                .addMipMapDimensions(1)
+                .addMipMapDimensions(1)
+                .setDataSize(byteImageData.length)
+                .build();
+
+        TextureImage.Image floatImage = TextureImage.Image.newBuilder()
                 .setWidth(1)
                 .setHeight(1)
                 .setDepth(1)
@@ -56,39 +83,49 @@ public class TextureUtilTest {
                 .setOriginalDepth(1)
                 .setFormat(TextureImage.TextureFormat.TEXTURE_FORMAT_RGBA32F)
                 .addMipMapOffset(0)
-                .addMipMapSize(imageData.length)
-                .addMipMapSizeCompressed(imageData.length)
+                .addMipMapSize(floatImageData.length)
+                .addMipMapSizeCompressed(floatImageData.length)
                 .addMipMapDimensions(1)
                 .addMipMapDimensions(1)
-                .setDataSize(imageData.length)
+                .setDataSize(floatImageData.length)
                 .build();
 
         TextureGenerator.GenerateResult generateResult = new TextureGenerator.GenerateResult();
         generateResult.textureImage = TextureImage.newBuilder()
-                .addAlternatives(image)
+                .addAlternatives(byteImage)
+                .addAlternatives(floatImage)
                 .setType(TextureImage.Type.TYPE_2D_ARRAY)
                 .setCount(1)
                 .build();
         generateResult.imageDatas = new ArrayList<>();
-        generateResult.imageDatas.add(imageData);
+        generateResult.imageDatas.add(byteImageData);
+        generateResult.imageDatas.add(floatImageData);
 
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        TextureUtil.writeGenerateResultToOutputStream(generateResult, out, 4);
+        TextureUtil.writeGenerateResultToOutputStream(generateResult, out);
         byte[] textureBytes = out.toByteArray();
 
         ByteBuffer headerSizeBuffer = ByteBuffer.wrap(textureBytes, 0, Integer.BYTES);
         headerSizeBuffer.order(ByteOrder.LITTLE_ENDIAN);
         int headerSize = headerSizeBuffer.getInt();
         TextureImage textureImage = TextureImage.parseFrom(Arrays.copyOfRange(textureBytes, Integer.BYTES, Integer.BYTES + headerSize));
-        TextureImage.Image alignedImage = textureImage.getAlternatives(0);
+        TextureImage.Image alignedByteImage = textureImage.getAlternatives(0);
+        TextureImage.Image alignedFloatImage = textureImage.getAlternatives(1);
 
-        int mipOffset = alignedImage.getMipMapOffset(0);
-        int imageDataOffset = Integer.BYTES + headerSize + mipOffset;
-        assertEquals(0, imageDataOffset % 4);
-        assertEquals(imageData.length + mipOffset, alignedImage.getDataSize());
+        int payloadOffset = Integer.BYTES + headerSize;
+        int byteImageDataOffset = payloadOffset + alignedByteImage.getMipMapOffset(0);
+        int floatImageDataOffset = payloadOffset + alignedByteImage.getDataSize() + alignedFloatImage.getMipMapOffset(0);
 
-        for (int i = 0; i < imageData.length; ++i) {
-            assertEquals(imageData[i], textureBytes[imageDataOffset + i]);
+        assertEquals(0, byteImageDataOffset % 4);
+        assertEquals(0, floatImageDataOffset % 4);
+        assertEquals(byteImageData.length + alignedByteImage.getMipMapOffset(0), alignedByteImage.getDataSize());
+        assertEquals(floatImageData.length + alignedFloatImage.getMipMapOffset(0), alignedFloatImage.getDataSize());
+
+        for (int i = 0; i < byteImageData.length; ++i) {
+            assertEquals(byteImageData[i], textureBytes[byteImageDataOffset + i]);
+        }
+        for (int i = 0; i < floatImageData.length; ++i) {
+            assertEquals(floatImageData[i], textureBytes[floatImageDataOffset + i]);
         }
     }
 

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/util/TextureUtilTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/util/TextureUtilTest.java
@@ -18,20 +18,79 @@ import static org.junit.Assert.assertEquals;
 
 import java.awt.Color;
 import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.ArrayList;
+import java.util.Arrays;
 
 import javax.imageio.ImageIO;
 
 import org.junit.Test;
 
+import com.dynamo.bob.pipeline.TextureGenerator;
 import com.dynamo.bob.util.TextureUtil;
 import com.dynamo.graphics.proto.Graphics.PathSettings;
+import com.dynamo.graphics.proto.Graphics.TextureImage;
 import com.dynamo.graphics.proto.Graphics.TextureProfile;
 import com.dynamo.graphics.proto.Graphics.TextureProfiles;
 
 public class TextureUtilTest {
+
+    @Test
+    public void testWriteGenerateResultCanAlignFirstImageData() throws Exception {
+        byte[] imageData = new byte[16];
+        for (int i = 0; i < imageData.length; ++i) {
+            imageData[i] = (byte)i;
+        }
+
+        TextureImage.Image image = TextureImage.Image.newBuilder()
+                .setWidth(1)
+                .setHeight(1)
+                .setDepth(1)
+                .setOriginalWidth(1)
+                .setOriginalHeight(1)
+                .setOriginalDepth(1)
+                .setFormat(TextureImage.TextureFormat.TEXTURE_FORMAT_RGBA32F)
+                .addMipMapOffset(0)
+                .addMipMapSize(imageData.length)
+                .addMipMapSizeCompressed(imageData.length)
+                .addMipMapDimensions(1)
+                .addMipMapDimensions(1)
+                .setDataSize(imageData.length)
+                .build();
+
+        TextureGenerator.GenerateResult generateResult = new TextureGenerator.GenerateResult();
+        generateResult.textureImage = TextureImage.newBuilder()
+                .addAlternatives(image)
+                .setType(TextureImage.Type.TYPE_2D_ARRAY)
+                .setCount(1)
+                .build();
+        generateResult.imageDatas = new ArrayList<>();
+        generateResult.imageDatas.add(imageData);
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        TextureUtil.writeGenerateResultToOutputStream(generateResult, out, 4);
+        byte[] textureBytes = out.toByteArray();
+
+        ByteBuffer headerSizeBuffer = ByteBuffer.wrap(textureBytes, 0, Integer.BYTES);
+        headerSizeBuffer.order(ByteOrder.LITTLE_ENDIAN);
+        int headerSize = headerSizeBuffer.getInt();
+        TextureImage textureImage = TextureImage.parseFrom(Arrays.copyOfRange(textureBytes, Integer.BYTES, Integer.BYTES + headerSize));
+        TextureImage.Image alignedImage = textureImage.getAlternatives(0);
+
+        int mipOffset = alignedImage.getMipMapOffset(0);
+        int imageDataOffset = Integer.BYTES + headerSize + mipOffset;
+        assertEquals(0, imageDataOffset % 4);
+        assertEquals(imageData.length + mipOffset, alignedImage.getDataSize());
+
+        for (int i = 0; i < imageData.length; ++i) {
+            assertEquals(imageData[i], textureBytes[imageDataOffset + i]);
+        }
+    }
 
     @Test
     public void testExtrudeBorders() {

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/util/TextureUtilTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/util/TextureUtilTest.java
@@ -40,11 +40,11 @@ import com.dynamo.graphics.proto.Graphics.TextureProfiles;
 
 public class TextureUtilTest {
 
-    /* Intent: verify that generated texture resources align embedded image payloads.
+    /* Intent: verify that generated texture resources align embedded typed image payloads.
     ** Setup: one small byte texture alternative and one RGBA32F texture alternative are
     ** written through the default texture resource path.
-    ** Expected: each serialized mip offset skips any inserted padding, each payload starts
-    ** on a 4-byte boundary, and the original image data is preserved.
+    ** Expected: the byte alternative is unchanged, the float alternative mip offset skips any
+    ** inserted padding so it starts on a 4-byte boundary, and both image payloads are preserved.
     */
     @Test
     public void testWriteGenerateResultCanAlignFirstImageData() throws Exception {
@@ -116,9 +116,9 @@ public class TextureUtilTest {
         int byteImageDataOffset = payloadOffset + alignedByteImage.getMipMapOffset(0);
         int floatImageDataOffset = payloadOffset + alignedByteImage.getDataSize() + alignedFloatImage.getMipMapOffset(0);
 
-        assertEquals(0, byteImageDataOffset % 4);
         assertEquals(0, floatImageDataOffset % 4);
-        assertEquals(byteImageData.length + alignedByteImage.getMipMapOffset(0), alignedByteImage.getDataSize());
+        assertEquals(0, alignedByteImage.getMipMapOffset(0));
+        assertEquals(byteImageData.length, alignedByteImage.getDataSize());
         assertEquals(floatImageData.length + alignedFloatImage.getMipMapOffset(0), alignedFloatImage.getDataSize());
 
         for (int i = 0; i < byteImageData.length; ++i) {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/MeshsetBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/MeshsetBuilder.java
@@ -169,8 +169,7 @@ public class MeshsetBuilder extends Builder  {
             ArrayList<ModelUtil.CollectedMorphTargetTexture> morphTargetTextures = morphTextureCollector.getTextures();
             ArrayList<IResource> morphTargetTextureOutputs = morphTextureCollector.getOutputs();
             for (int i = 0; i < morphTargetTextures.size(); ++i) {
-                // WebGL float texture uploads require the first image payload to be 4-byte aligned.
-                TextureUtil.writeGenerateResultToResource(morphTargetTextures.get(i).texture.toGenerateResult(), morphTargetTextureOutputs.get(i), 4);
+                TextureUtil.writeGenerateResultToResource(morphTargetTextures.get(i).texture.toGenerateResult(), morphTargetTextureOutputs.get(i));
             }
         }
 

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/MeshsetBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/MeshsetBuilder.java
@@ -169,7 +169,8 @@ public class MeshsetBuilder extends Builder  {
             ArrayList<ModelUtil.CollectedMorphTargetTexture> morphTargetTextures = morphTextureCollector.getTextures();
             ArrayList<IResource> morphTargetTextureOutputs = morphTextureCollector.getOutputs();
             for (int i = 0; i < morphTargetTextures.size(); ++i) {
-                TextureUtil.writeGenerateResultToResource(morphTargetTextures.get(i).texture.toGenerateResult(), morphTargetTextureOutputs.get(i));
+                // WebGL float texture uploads require the first image payload to be 4-byte aligned.
+                TextureUtil.writeGenerateResultToResource(morphTargetTextures.get(i).texture.toGenerateResult(), morphTargetTextureOutputs.get(i), 4);
             }
         }
 

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/TextureUtil.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/TextureUtil.java
@@ -49,6 +49,8 @@ import static com.dynamo.bob.util.MiscUtil.concatenateArrays;
 
 public class TextureUtil {
 
+    private static final int DEFAULT_FIRST_IMAGE_DATA_ALIGNMENT = 4;
+
     static {
         TimeProfiler.start("ImageIO.setUseCache");
         ImageIO.setUseCache(false);
@@ -322,11 +324,11 @@ public class TextureUtil {
 
     // Called from bob and editor when building texture resources
     public static void writeGenerateResultToOutputStream(TextureGenerator.GenerateResult generateResult, OutputStream stream) throws IOException {
-        writeGenerateResultToOutputStream(generateResult, stream, 1);
+        writeGenerateResultToOutputStream(generateResult, stream, DEFAULT_FIRST_IMAGE_DATA_ALIGNMENT);
     }
 
-    public static void writeGenerateResultToOutputStream(TextureGenerator.GenerateResult generateResult, OutputStream stream, int firstImageDataAlignment) throws IOException {
-        AlignedGenerateResult alignedGenerateResult = alignFirstImageData(generateResult, firstImageDataAlignment);
+    public static void writeGenerateResultToOutputStream(TextureGenerator.GenerateResult generateResult, OutputStream stream, int imageDataAlignment) throws IOException {
+        AlignedGenerateResult alignedGenerateResult = alignImageData(generateResult, imageDataAlignment);
         byte[] header = alignedGenerateResult.textureImage.toByteArray();
 
         ByteBuffer buffer = ByteBuffer.allocate(4);
@@ -336,9 +338,6 @@ public class TextureUtil {
 
         stream.write(headerSizeInBytes);
         stream.write(header);
-        if (alignedGenerateResult.prefixPadding.length > 0) {
-            stream.write(alignedGenerateResult.prefixPadding);
-        }
         for (byte[] imageData : alignedGenerateResult.imageDatas) {
             stream.write(imageData);
         }
@@ -346,11 +345,11 @@ public class TextureUtil {
     }
 
     public static void writeGenerateResultToResource(TextureGenerator.GenerateResult generateResult, IResource resource) throws IOException {
-        writeGenerateResultToResource(generateResult, resource, 1);
+        writeGenerateResultToResource(generateResult, resource, DEFAULT_FIRST_IMAGE_DATA_ALIGNMENT);
     }
 
-    public static void writeGenerateResultToResource(TextureGenerator.GenerateResult generateResult, IResource resource, int firstImageDataAlignment) throws IOException {
-        AlignedGenerateResult alignedGenerateResult = alignFirstImageData(generateResult, firstImageDataAlignment);
+    public static void writeGenerateResultToResource(TextureGenerator.GenerateResult generateResult, IResource resource, int imageDataAlignment) throws IOException {
+        AlignedGenerateResult alignedGenerateResult = alignImageData(generateResult, imageDataAlignment);
         byte[] header = alignedGenerateResult.textureImage.toByteArray();
 
         ByteBuffer buffer = ByteBuffer.allocate(4);
@@ -361,9 +360,6 @@ public class TextureUtil {
         resource.setContent(headerSizeInBytes);
         resource.appendContent(header);
 
-        if (alignedGenerateResult.prefixPadding.length > 0) {
-            resource.appendContent(alignedGenerateResult.prefixPadding);
-        }
         for (byte[] imageData : alignedGenerateResult.imageDatas) {
             resource.appendContent(imageData);
         }
@@ -372,48 +368,98 @@ public class TextureUtil {
     private static class AlignedGenerateResult {
         final TextureImage textureImage;
         final ArrayList<byte[]> imageDatas;
-        final byte[] prefixPadding;
 
-        AlignedGenerateResult(TextureImage textureImage, ArrayList<byte[]> imageDatas, int prefixPaddingSize) {
+        AlignedGenerateResult(TextureImage textureImage, ArrayList<byte[]> imageDatas) {
             this.textureImage = textureImage;
             this.imageDatas = imageDatas;
-            this.prefixPadding = new byte[prefixPaddingSize];
         }
     }
 
-    private static AlignedGenerateResult alignFirstImageData(TextureGenerator.GenerateResult generateResult, int alignment) {
+    private static AlignedGenerateResult alignImageData(TextureGenerator.GenerateResult generateResult, int alignment) {
         if (alignment <= 1 || generateResult.imageDatas.isEmpty() || generateResult.textureImage.getAlternativesCount() == 0) {
-            return new AlignedGenerateResult(generateResult.textureImage, generateResult.imageDatas, 0);
+            return new AlignedGenerateResult(generateResult.textureImage, generateResult.imageDatas);
         }
 
-        for (int padding = 0; padding < alignment; ++padding) {
-            TextureImage alignedTextureImage = addFirstImagePadding(generateResult.textureImage, padding);
+        int alternativeCount = generateResult.textureImage.getAlternativesCount();
+        int[] alternativePaddings = new int[alternativeCount];
+        for (int attempt = 0; attempt < alternativeCount * alignment + 1; ++attempt) {
+            TextureImage alignedTextureImage = addImagePadding(generateResult.textureImage, alternativePaddings);
             int headerSize = alignedTextureImage.toByteArray().length;
-            int firstImageOffset = Integer.BYTES + headerSize + padding;
-            if (firstImageOffset % alignment == 0) {
-                return new AlignedGenerateResult(alignedTextureImage, generateResult.imageDatas, padding);
+            int alternativeOffset = 0;
+            boolean changed = false;
+
+            for (int i = 0; i < alternativeCount; ++i) {
+                TextureImage.Image image = generateResult.textureImage.getAlternatives(i);
+                int firstMipOffset = image.getMipMapOffsetCount() > 0 ? image.getMipMapOffset(0) : 0;
+                int unpaddedImageOffset = Integer.BYTES + headerSize + alternativeOffset + firstMipOffset;
+                int padding = (alignment - (unpaddedImageOffset % alignment)) % alignment;
+                if (alternativePaddings[i] != padding) {
+                    alternativePaddings[i] = padding;
+                    changed = true;
+                }
+                alternativeOffset += image.getDataSize() + padding;
+            }
+
+            if (!changed) {
+                return new AlignedGenerateResult(alignedTextureImage, addImageDataPadding(generateResult, alternativePaddings));
             }
         }
 
         throw new IllegalStateException(String.format("Unable to align texture image data to %d bytes", alignment));
     }
 
-    private static TextureImage addFirstImagePadding(TextureImage textureImage, int padding) {
+    private static TextureImage addImagePadding(TextureImage textureImage, int[] alternativePaddings) {
+        TextureImage.Builder textureImageBuilder = textureImage.toBuilder();
+        for (int i = 0; i < alternativePaddings.length; ++i) {
+            textureImageBuilder.setAlternatives(i, addImagePadding(textureImage.getAlternatives(i), alternativePaddings[i]));
+        }
+        return textureImageBuilder.build();
+    }
+
+    private static TextureImage.Image addImagePadding(TextureImage.Image image, int padding) {
         if (padding == 0) {
-            return textureImage;
+            return image;
         }
 
-        // The padding is part of the first alternative's data range; mip offsets skip over it at runtime.
-        TextureImage.Image firstImage = textureImage.getAlternatives(0);
-        TextureImage.Image.Builder firstImageBuilder = firstImage.toBuilder();
-        firstImageBuilder.setDataSize(firstImage.getDataSize() + padding);
-        for (int i = 0; i < firstImage.getMipMapOffsetCount(); ++i) {
-            firstImageBuilder.setMipMapOffset(i, firstImage.getMipMapOffset(i) + padding);
+        // The padding is part of the alternative's data range; mip offsets skip over it at runtime.
+        TextureImage.Image.Builder imageBuilder = image.toBuilder();
+        imageBuilder.setDataSize(image.getDataSize() + padding);
+        for (int i = 0; i < image.getMipMapOffsetCount(); ++i) {
+            imageBuilder.setMipMapOffset(i, image.getMipMapOffset(i) + padding);
+        }
+        return imageBuilder.build();
+    }
+
+    private static ArrayList<byte[]> addImageDataPadding(TextureGenerator.GenerateResult generateResult, int[] alternativePaddings) {
+        ArrayList<byte[]> imageDatas = new ArrayList<>();
+        int imageDataIndex = 0;
+
+        for (int i = 0; i < generateResult.textureImage.getAlternativesCount(); ++i) {
+            int padding = alternativePaddings[i];
+            if (padding > 0) {
+                imageDatas.add(new byte[padding]);
+            }
+
+            int remainingDataSize = generateResult.textureImage.getAlternatives(i).getDataSize();
+            while (remainingDataSize > 0) {
+                if (imageDataIndex >= generateResult.imageDatas.size()) {
+                    throw new IllegalStateException("Texture image data is smaller than the texture metadata describes");
+                }
+
+                byte[] imageData = generateResult.imageDatas.get(imageDataIndex++);
+                if (imageData.length > remainingDataSize) {
+                    throw new IllegalStateException("Texture image data spans multiple texture alternatives");
+                }
+
+                imageDatas.add(imageData);
+                remainingDataSize -= imageData.length;
+            }
         }
 
-        return textureImage.toBuilder()
-                .setAlternatives(0, firstImageBuilder)
-                .build();
+        if (imageDataIndex != generateResult.imageDatas.size()) {
+            throw new IllegalStateException("Texture image data is larger than the texture metadata describes");
+        }
+        return imageDatas;
     }
 
     public static TextureImage textureResourceBytesToTextureImage(byte[] content) throws InvalidProtocolBufferException {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/TextureUtil.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/TextureUtil.java
@@ -322,7 +322,12 @@ public class TextureUtil {
 
     // Called from bob and editor when building texture resources
     public static void writeGenerateResultToOutputStream(TextureGenerator.GenerateResult generateResult, OutputStream stream) throws IOException {
-        byte[] header = generateResult.textureImage.toByteArray();
+        writeGenerateResultToOutputStream(generateResult, stream, 1);
+    }
+
+    public static void writeGenerateResultToOutputStream(TextureGenerator.GenerateResult generateResult, OutputStream stream, int firstImageDataAlignment) throws IOException {
+        AlignedGenerateResult alignedGenerateResult = alignFirstImageData(generateResult, firstImageDataAlignment);
+        byte[] header = alignedGenerateResult.textureImage.toByteArray();
 
         ByteBuffer buffer = ByteBuffer.allocate(4);
         buffer.order(ByteOrder.LITTLE_ENDIAN);
@@ -331,14 +336,22 @@ public class TextureUtil {
 
         stream.write(headerSizeInBytes);
         stream.write(header);
-        for (byte[] imageData : generateResult.imageDatas) {
+        if (alignedGenerateResult.prefixPadding.length > 0) {
+            stream.write(alignedGenerateResult.prefixPadding);
+        }
+        for (byte[] imageData : alignedGenerateResult.imageDatas) {
             stream.write(imageData);
         }
         stream.flush();
     }
 
     public static void writeGenerateResultToResource(TextureGenerator.GenerateResult generateResult, IResource resource) throws IOException {
-        byte[] header = generateResult.textureImage.toByteArray();
+        writeGenerateResultToResource(generateResult, resource, 1);
+    }
+
+    public static void writeGenerateResultToResource(TextureGenerator.GenerateResult generateResult, IResource resource, int firstImageDataAlignment) throws IOException {
+        AlignedGenerateResult alignedGenerateResult = alignFirstImageData(generateResult, firstImageDataAlignment);
+        byte[] header = alignedGenerateResult.textureImage.toByteArray();
 
         ByteBuffer buffer = ByteBuffer.allocate(4);
         buffer.order(ByteOrder.LITTLE_ENDIAN);
@@ -348,9 +361,59 @@ public class TextureUtil {
         resource.setContent(headerSizeInBytes);
         resource.appendContent(header);
 
-        for (byte[] imageData : generateResult.imageDatas) {
+        if (alignedGenerateResult.prefixPadding.length > 0) {
+            resource.appendContent(alignedGenerateResult.prefixPadding);
+        }
+        for (byte[] imageData : alignedGenerateResult.imageDatas) {
             resource.appendContent(imageData);
         }
+    }
+
+    private static class AlignedGenerateResult {
+        final TextureImage textureImage;
+        final ArrayList<byte[]> imageDatas;
+        final byte[] prefixPadding;
+
+        AlignedGenerateResult(TextureImage textureImage, ArrayList<byte[]> imageDatas, int prefixPaddingSize) {
+            this.textureImage = textureImage;
+            this.imageDatas = imageDatas;
+            this.prefixPadding = new byte[prefixPaddingSize];
+        }
+    }
+
+    private static AlignedGenerateResult alignFirstImageData(TextureGenerator.GenerateResult generateResult, int alignment) {
+        if (alignment <= 1 || generateResult.imageDatas.isEmpty() || generateResult.textureImage.getAlternativesCount() == 0) {
+            return new AlignedGenerateResult(generateResult.textureImage, generateResult.imageDatas, 0);
+        }
+
+        for (int padding = 0; padding < alignment; ++padding) {
+            TextureImage alignedTextureImage = addFirstImagePadding(generateResult.textureImage, padding);
+            int headerSize = alignedTextureImage.toByteArray().length;
+            int firstImageOffset = Integer.BYTES + headerSize + padding;
+            if (firstImageOffset % alignment == 0) {
+                return new AlignedGenerateResult(alignedTextureImage, generateResult.imageDatas, padding);
+            }
+        }
+
+        throw new IllegalStateException(String.format("Unable to align texture image data to %d bytes", alignment));
+    }
+
+    private static TextureImage addFirstImagePadding(TextureImage textureImage, int padding) {
+        if (padding == 0) {
+            return textureImage;
+        }
+
+        // The padding is part of the first alternative's data range; mip offsets skip over it at runtime.
+        TextureImage.Image firstImage = textureImage.getAlternatives(0);
+        TextureImage.Image.Builder firstImageBuilder = firstImage.toBuilder();
+        firstImageBuilder.setDataSize(firstImage.getDataSize() + padding);
+        for (int i = 0; i < firstImage.getMipMapOffsetCount(); ++i) {
+            firstImageBuilder.setMipMapOffset(i, firstImage.getMipMapOffset(i) + padding);
+        }
+
+        return textureImage.toBuilder()
+                .setAlternatives(0, firstImageBuilder)
+                .build();
     }
 
     public static TextureImage textureResourceBytesToTextureImage(byte[] content) throws InvalidProtocolBufferException {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/TextureUtil.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/TextureUtil.java
@@ -49,7 +49,7 @@ import static com.dynamo.bob.util.MiscUtil.concatenateArrays;
 
 public class TextureUtil {
 
-    private static final int DEFAULT_FIRST_IMAGE_DATA_ALIGNMENT = 4;
+    private static final int MAX_IMAGE_DATA_ALIGNMENT = 4;
 
     static {
         TimeProfiler.start("ImageIO.setUseCache");
@@ -324,7 +324,7 @@ public class TextureUtil {
 
     // Called from bob and editor when building texture resources
     public static void writeGenerateResultToOutputStream(TextureGenerator.GenerateResult generateResult, OutputStream stream) throws IOException {
-        writeGenerateResultToOutputStream(generateResult, stream, DEFAULT_FIRST_IMAGE_DATA_ALIGNMENT);
+        writeGenerateResultToOutputStream(generateResult, stream, MAX_IMAGE_DATA_ALIGNMENT);
     }
 
     public static void writeGenerateResultToOutputStream(TextureGenerator.GenerateResult generateResult, OutputStream stream, int imageDataAlignment) throws IOException {
@@ -345,7 +345,7 @@ public class TextureUtil {
     }
 
     public static void writeGenerateResultToResource(TextureGenerator.GenerateResult generateResult, IResource resource) throws IOException {
-        writeGenerateResultToResource(generateResult, resource, DEFAULT_FIRST_IMAGE_DATA_ALIGNMENT);
+        writeGenerateResultToResource(generateResult, resource, MAX_IMAGE_DATA_ALIGNMENT);
     }
 
     public static void writeGenerateResultToResource(TextureGenerator.GenerateResult generateResult, IResource resource, int imageDataAlignment) throws IOException {
@@ -375,14 +375,25 @@ public class TextureUtil {
         }
     }
 
-    private static AlignedGenerateResult alignImageData(TextureGenerator.GenerateResult generateResult, int alignment) {
-        if (alignment <= 1 || generateResult.imageDatas.isEmpty() || generateResult.textureImage.getAlternativesCount() == 0) {
+    private static AlignedGenerateResult alignImageData(TextureGenerator.GenerateResult generateResult, int maxAlignment) {
+        if (maxAlignment <= 1 || generateResult.imageDatas.isEmpty() || generateResult.textureImage.getAlternativesCount() == 0) {
             return new AlignedGenerateResult(generateResult.textureImage, generateResult.imageDatas);
         }
 
         int alternativeCount = generateResult.textureImage.getAlternativesCount();
+        int[] alternativeAlignments = new int[alternativeCount];
         int[] alternativePaddings = new int[alternativeCount];
-        for (int attempt = 0; attempt < alternativeCount * alignment + 1; ++attempt) {
+        boolean needsAlignment = false;
+        for (int i = 0; i < alternativeCount; ++i) {
+            alternativeAlignments[i] = Math.min(maxAlignment, getTextureFormatDataAlignment(generateResult.textureImage.getAlternatives(i).getFormat()));
+            needsAlignment |= alternativeAlignments[i] > 1;
+        }
+
+        if (!needsAlignment) {
+            return new AlignedGenerateResult(generateResult.textureImage, generateResult.imageDatas);
+        }
+
+        for (int attempt = 0; attempt < alternativeCount * maxAlignment + 1; ++attempt) {
             TextureImage alignedTextureImage = addImagePadding(generateResult.textureImage, alternativePaddings);
             int headerSize = alignedTextureImage.toByteArray().length;
             int alternativeOffset = 0;
@@ -392,7 +403,8 @@ public class TextureUtil {
                 TextureImage.Image image = generateResult.textureImage.getAlternatives(i);
                 int firstMipOffset = image.getMipMapOffsetCount() > 0 ? image.getMipMapOffset(0) : 0;
                 int unpaddedImageOffset = Integer.BYTES + headerSize + alternativeOffset + firstMipOffset;
-                int padding = (alignment - (unpaddedImageOffset % alignment)) % alignment;
+                int alignment = alternativeAlignments[i];
+                int padding = alignment <= 1 ? 0 : (alignment - (unpaddedImageOffset % alignment)) % alignment;
                 if (alternativePaddings[i] != padding) {
                     alternativePaddings[i] = padding;
                     changed = true;
@@ -405,7 +417,26 @@ public class TextureUtil {
             }
         }
 
-        throw new IllegalStateException(String.format("Unable to align texture image data to %d bytes", alignment));
+        throw new IllegalStateException(String.format("Unable to align texture image data to %d bytes", maxAlignment));
+    }
+
+    private static int getTextureFormatDataAlignment(TextureImage.TextureFormat format) {
+        switch (format) {
+            case TEXTURE_FORMAT_RGB_16BPP:
+            case TEXTURE_FORMAT_RGBA_16BPP:
+            case TEXTURE_FORMAT_RGB16F:
+            case TEXTURE_FORMAT_RGBA16F:
+            case TEXTURE_FORMAT_R16F:
+            case TEXTURE_FORMAT_RG16F:
+                return 2;
+            case TEXTURE_FORMAT_RGB32F:
+            case TEXTURE_FORMAT_RGBA32F:
+            case TEXTURE_FORMAT_R32F:
+            case TEXTURE_FORMAT_RG32F:
+                return 4;
+            default:
+                return 1;
+        }
     }
 
     private static TextureImage addImagePadding(TextureImage textureImage, int[] alternativePaddings) {


### PR DESCRIPTION
Regression fix for 1.13.1:
While moving the texture generation process to the pipeline step, it caused WebGL to behave erratically while all other platforms behaved correctly. After a ton of investigation, it boiled down to misaligned memory for the texture buffer.

We now always align the first image data appended to texture sets by 4, so it's future proof when we introduce HDR textures and so forth.