### PR TITLE
Improve idle CPU usage

### DIFF
--- a/editor/.cljfmt.edn
+++ b/editor/.cljfmt.edn
@@ -14,6 +14,7 @@
 
 {:function-arguments-indentation :cursive
  :extra-indents {cljfx.composite/props [[:inner 0]]
+                 clojure.core/assoc [[:inner 0]]
                  clojure.core.cache/defcache [[:inner 0]]
                  clojure.core/assoc! [[:inner 0]]
                  clojure.core/defmulti [[:inner 0]]

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -386,6 +386,7 @@
   (output open-sidebar-panes g/Any :cached (g/fnk [open-sidebar-panes] (into {} open-sidebar-panes)))
   (output open-views g/Any :cached (g/fnk [open-views] (into {} open-views)))
   (output open-dirty-views g/Any :cached (g/fnk [open-dirty-views] (into #{} (keep #(when (second %) (first %))) open-dirty-views)))
+  (output scene-view-ids g/Any :cached (gu/passthrough scene-view-ids))
   (output hidden-renderable-tags types/RenderableTags (gu/passthrough hidden-renderable-tags))
   (output hidden-node-outline-key-paths types/NodeOutlineKeyPaths (gu/passthrough hidden-node-outline-key-paths))
   (output active-tab-pane TabPane (g/fnk [^Tab active-tab ^SplitPane editor-tabs-split]

--- a/editor/src/clj/editor/code/view.clj
+++ b/editor/src/clj/editor/code/view.clj
@@ -865,6 +865,12 @@
 (g/defnk produce-cursor-repaint-info [canvas color-scheme cursor-opacity layout lines repaint-trigger visible-cursors :as cursor-repaint-info]
   cursor-repaint-info)
 
+(g/defnk produce-tick-info [cursor-opacity elapsed-time-at-last-action gesture-start layout lines :as tick-info]
+  tick-info)
+
+(g/defnk produce-repaint-info [canvas-repaint-info completions-showing cursor-repaint-info hover-showing-regions rename-cursor-range resource-node :as repaint-info]
+  repaint-info)
+
 (defn- make-cursor-rectangle
   ^Rectangle [^Paint fill opacity ^Rect cursor-rect]
   (doto (Rectangle. (.x cursor-rect) (.y cursor-rect) (.w cursor-rect) (.h cursor-rect))
@@ -1629,7 +1635,9 @@
   (output minimap-cursor-range-draw-infos CursorRangeDrawInfos :cached produce-minimap-cursor-range-draw-infos)
   (output execution-markers r/Regions :cached produce-execution-markers)
   (output canvas-repaint-info g/Any :cached produce-canvas-repaint-info)
-  (output cursor-repaint-info g/Any :cached produce-cursor-repaint-info))
+  (output cursor-repaint-info g/Any :cached produce-cursor-repaint-info)
+  (output tick-info g/Any :cached produce-tick-info)
+  (output repaint-info g/Any :cached produce-repaint-info))
 
 (defn- mouse-button [^MouseEvent event]
   (condp = (.getButton event)
@@ -2145,7 +2153,7 @@
 
 (def ^:private ^:const completion-icon-text-spacing 4.0)
 
-(defn- completion-list-cell-view [completion]
+(defn- completion-list-cell-view [view-node completion]
   (if completion
     (let [text (:display-string completion)
           matching-indices (fuzzy-choices/matching-indices completion)]
@@ -2162,14 +2170,15 @@
                             (fuzzy-choices/make-matched-text-flow-cljfx
                               text matching-indices
                               :deprecated (contains? (:tags completion) :deprecated))]}
-       :on-mouse-clicked {:event :accept :completion completion}})
+       :on-mouse-clicked (fn [_]
+                           (accept-suggestion! view-node (code-completion/insertion completion)))})
     {}))
 
 (defn- completion-popup-view
   [{:keys [canvas-repaint-info font font-name font-size
            visible-completion-ranges query screen-bounds completions-showing
            completions-doc project completions-combined completions-selected-index
-           completions-shortcut-text]}]
+           completions-shortcut-text view-node]}]
   (let [item-count (count completions-combined)]
     (if (or (not completions-showing) (zero? item-count))
       {:fx/type fxui/ext-value :value nil}
@@ -2244,14 +2253,26 @@
                   :props {:items [refresh-key completions-combined]}
                   :desc
                   {:fx/type fx.ext.list-view/with-selection-props
-                   :props {:on-selected-index-changed {:event :select}}
+                   :props {:on-selected-index-changed (fn [index]
+                                                        (set-properties! view-node nil {:completions-selected-index index})
+                                                        (resolve-selected-completion! view-node))}
                    :desc
                    {:fx/type fx.list-view/lifecycle
                     :style {:-fx-font-family (str \" font-name \") :-fx-font-size font-size}
                     :id "fuzzy-choices-list-view"
                     :style-class ["flat-list-view" "completion-popup-list-view"]
                     :fixed-cell-size cell-height
-                    :event-filter {:event :completion-list-view-event-filter}
+                    :event-filter (fn [e]
+                                    (when (instance? KeyEvent e)
+                                      (let [^KeyEvent e e
+                                            code (.getCode e)]
+                                        ;; redirect everything except arrows to canvas
+                                        (when-not (or (= KeyCode/UP code)
+                                                      (= KeyCode/DOWN code)
+                                                      (= KeyCode/PAGE_UP code)
+                                                      (= KeyCode/PAGE_DOWN code))
+                                          (ui/send-event! (get-property view-node :canvas) e)
+                                          (.consume e)))))
                     :min-width completions-width
                     :pref-width completions-width
                     :max-width completions-width
@@ -2259,7 +2280,7 @@
                     :pref-height (* cell-height item-count)
                     :max-height (min (* cell-height max-visible-completions-count) max-completions-height)
                     :cell-factory {:fx/cell-type fx.list-cell/lifecycle
-                                   :describe completion-list-cell-view}}}}}]
+                                   :describe (fn/partial completion-list-cell-view view-node)}}}}}]
                completions-shortcut-text
                (conj {:fx/type fx.label/lifecycle
                       :style-class "completion-popup-hint"
@@ -2284,7 +2305,7 @@
                :showing completions-showing
                :auto-fix false
                :auto-hide true
-               :on-auto-hide {:event :auto-hide}
+               :on-auto-hide (fn [_] (hide-suggestions! view-node))
                :hide-on-escape false
                :content [{:fx/type fx/ext-get-ref :ref :content}]}}]
             completions-doc
@@ -2334,7 +2355,14 @@
                                         (cond->
                                           {:fx/type markdown/view
                                            :base-url (:base-url doc)
-                                           :event-filter {:event :doc-event-filter}
+                                           :event-filter (fn [e]
+                                                           (when (instance? KeyEvent e)
+                                                             (let [^KeyEvent e e
+                                                                   ^Node source (.getSource e)
+                                                                   ^PopupWindow window (.getWindow (.getScene source))
+                                                                   target (.getFocusOwner (.getScene (.getOwnerWindow window)))]
+                                                               (ui/send-event! target e)
+                                                               (.consume e))))
                                            :max-width doc-width
                                            :max-height doc-max-height
                                            :project project
@@ -2345,41 +2373,6 @@
                                                       :else "<small>no documentation</small>")}
                                           (not align-right)
                                           (assoc :min-width doc-width))]}]}})))}}))))
-
-(defn- handle-completion-popup-event [view-node e]
-  (case (:event e)
-    :doc-event-filter
-    (let [e (:fx/event e)]
-      (when (instance? KeyEvent e)
-        (let [^KeyEvent e e
-              ^Node source (.getSource e)
-              ^PopupWindow window (.getWindow (.getScene source))
-              target (.getFocusOwner (.getScene (.getOwnerWindow window)))]
-          (ui/send-event! target e)
-          (.consume e))))
-
-    :auto-hide
-    (hide-suggestions! view-node)
-
-    :completion-list-view-event-filter
-    (let [e (:fx/event e)]
-      (when (instance? KeyEvent e)
-        (let [^KeyEvent e e
-              code (.getCode e)]
-          ;; redirect everything except arrows to canvas
-          (when-not (or (= KeyCode/UP code)
-                        (= KeyCode/DOWN code)
-                        (= KeyCode/PAGE_UP code)
-                        (= KeyCode/PAGE_DOWN code))
-            (ui/send-event! (get-property view-node :canvas) e)
-            (.consume e)))))
-
-    :select
-    (do
-      (set-properties! view-node nil {:completions-selected-index (:fx/event e)})
-      (resolve-selected-completion! view-node))
-    :accept
-    (accept-suggestion! view-node (code-completion/insertion (:completion e)))))
 
 ;; -----------------------------------------------------------------------------
 
@@ -3668,14 +3661,13 @@
   (g/user-data! view-node :elapsed-time elapsed-time)
 
   ;; Perform necessary property updates in preparation for repaint.
-  (g/let-ec [tick-props (data/tick (g/node-value view-node :lines evaluation-context)
-                                   (g/node-value view-node :layout evaluation-context)
-                                   (g/node-value view-node :gesture-start evaluation-context))
+  (g/let-ec [{:keys [elapsed-time-at-last-action gesture-start layout lines]
+              old-cursor-opacity :cursor-opacity}
+             (g/node-value view-node :tick-info evaluation-context)
+             tick-props (data/tick lines layout gesture-start)
              props (if-not cursor-visible
                      tick-props
-                     (let [elapsed-time-at-last-action (g/node-value view-node :elapsed-time-at-last-action evaluation-context)
-                           old-cursor-opacity (g/node-value view-node :cursor-opacity evaluation-context)
-                           new-cursor-opacity (cursor-opacity elapsed-time-at-last-action elapsed-time)]
+                     (let [new-cursor-opacity (cursor-opacity elapsed-time-at-last-action elapsed-time)]
                        (cond-> tick-props
                                (not= old-cursor-opacity new-cursor-opacity)
                                (assoc :cursor-opacity new-cursor-opacity))))]
@@ -3684,73 +3676,61 @@
   ;; Repaint the view.
   (g/let-ec [prev-canvas-repaint-info (g/user-data view-node :canvas-repaint-info)
              prev-cursor-repaint-info (g/user-data view-node :cursor-repaint-info)
-             resource-node (g/node-value view-node :resource-node evaluation-context)
-             canvas-repaint-info (g/node-value view-node :canvas-repaint-info evaluation-context)
-             cursor-repaint-info (g/node-value view-node :cursor-repaint-info evaluation-context)]
+             {:keys [canvas-repaint-info completions-showing cursor-repaint-info hover-showing-regions rename-cursor-range resource-node]}
+             (g/node-value view-node :repaint-info evaluation-context)]
 
     ;; Repaint canvas if needed.
-    (when (not= prev-canvas-repaint-info canvas-repaint-info)
+    (when-not (identical? prev-canvas-repaint-info canvas-repaint-info)
       (g/user-data! view-node :canvas-repaint-info canvas-repaint-info)
       (let [row (data/last-visible-row (:minimap-layout canvas-repaint-info))]
         (repaint-canvas! canvas-repaint-info (get-valid-syntax-info resource-node canvas-repaint-info row))))
 
     (when editable
-      (g/with-auto-evaluation-context evaluation-context
-        ;; Show rename popup if appropriate
-        (fxui/advance-graph-user-data-component!
-          view-node :rename-popup
-          (when (g/node-value view-node :rename-cursor-range evaluation-context)
-            (g/node-value view-node :rename-view evaluation-context)))
-        ;; Show completion suggestions if appropriate.
-        (let [renderer (or (g/user-data view-node :completion-popup-renderer)
-                           (g/user-data!
-                             view-node
-                             :completion-popup-renderer
-                             (fx/create-renderer
-                               :error-handler error-reporting/report-exception!
-                               :middleware (comp
-                                             fxui/wrap-dedupe-desc
-                                             (fx/wrap-map-desc #'completion-popup-view))
-                               :opts {:fx.opt/map-event-handler #(handle-completion-popup-event view-node %)})))
-              ^Canvas canvas (:canvas canvas-repaint-info)]
-          (renderer {:completions-combined (g/node-value view-node :completions-combined evaluation-context)
-                     :completions-selected-index (g/node-value view-node :completions-selected-index evaluation-context)
-                     :completions-showing (g/node-value view-node :completions-showing evaluation-context)
-                     :completions-doc (g/node-value view-node :completions-doc evaluation-context)
-                     :completions-shortcut-text (g/node-value view-node :completions-shortcut-text evaluation-context)
-                     :project (g/node-value view-node :project evaluation-context)
-                     :canvas-repaint-info canvas-repaint-info
-                     :visible-completion-ranges (g/node-value view-node :visible-completion-ranges evaluation-context)
-                     :query (:query (g/node-value view-node :completion-context evaluation-context))
-                     :font (g/node-value view-node :font evaluation-context)
-                     :font-name (g/node-value view-node :font-name evaluation-context)
-                     :font-size (g/node-value view-node :font-size evaluation-context)
-                     :window-x (some-> (.getScene canvas) .getWindow .getX)
-                     :window-y (some-> (.getScene canvas) .getWindow .getY)
-                     :screen-bounds (mapv #(.getVisualBounds ^Screen %) (Screen/getScreens))}))))
+      ;; Show rename popup if appropriate
+      (fxui/advance-graph-user-data-component!
+        view-node :rename-popup
+        (when rename-cursor-range
+          (g/with-auto-evaluation-context evaluation-context
+            (g/node-value view-node :rename-view evaluation-context))))
+      ;; Show completion suggestions if appropriate.
+      (fxui/advance-graph-user-data-component!
+        view-node :completion-popup
+        (when completions-showing
+          (g/with-auto-evaluation-context evaluation-context
+            (let [scene (.getScene ^Canvas (:canvas canvas-repaint-info))]
+              {:fx/type completion-popup-view
+               :completions-combined (g/node-value view-node :completions-combined evaluation-context)
+               :completions-selected-index (g/node-value view-node :completions-selected-index evaluation-context)
+               :completions-showing completions-showing
+               :completions-doc (g/node-value view-node :completions-doc evaluation-context)
+               :completions-shortcut-text (g/node-value view-node :completions-shortcut-text evaluation-context)
+               :project (g/node-value view-node :project evaluation-context)
+               :canvas-repaint-info canvas-repaint-info
+               :visible-completion-ranges (g/node-value view-node :visible-completion-ranges evaluation-context)
+               :query (:query (g/node-value view-node :completion-context evaluation-context))
+               :font (g/node-value view-node :font evaluation-context)
+               :font-name (g/node-value view-node :font-name evaluation-context)
+               :font-size (g/node-value view-node :font-size evaluation-context)
+               :view-node view-node
+               :window-x (some-> scene .getWindow .getX)
+               :window-y (some-> scene .getWindow .getY)
+               :screen-bounds (mapv #(.getVisualBounds ^Screen %) (Screen/getScreens))})))))
 
     ;; Repaint hovered regions
-    (g/with-auto-evaluation-context evaluation-context
-      (let [hover-renderer (or (g/user-data view-node :hover-popup-renderer)
-                               (g/user-data!
-                                 view-node
-                                 :hover-popup-renderer
-                                 (fx/create-renderer
-                                   :error-handler error-reporting/report-exception!
-                                   :middleware (comp fxui/wrap-dedupe-desc
-                                                     (fx/wrap-map-desc #'hover-popup-view)))))
-            hover-showing-regions (g/node-value view-node :hover-showing-regions evaluation-context)]
-        (hover-renderer
-          (when hover-showing-regions
-            (let [scene (.getScene ^Canvas (:canvas canvas-repaint-info))]
-              {:hover-showing-regions hover-showing-regions
-               :hover-showing-region (g/node-value view-node :hover-showing-region evaluation-context)
-               :canvas-repaint-info canvas-repaint-info
-               :project (g/node-value view-node :project evaluation-context)
-               :view-node view-node
-               :screen-bounds (mapv #(.getVisualBounds ^Screen %) (Screen/getScreens))
-               :window-x (some-> scene .getWindow .getX)
-               :window-y (some-> scene .getWindow .getY)})))))
+    (fxui/advance-graph-user-data-component!
+      view-node :hover-popup
+      (when hover-showing-regions
+        (g/with-auto-evaluation-context evaluation-context
+          (let [scene (.getScene ^Canvas (:canvas canvas-repaint-info))]
+            {:fx/type hover-popup-view
+             :hover-showing-regions hover-showing-regions
+             :hover-showing-region (g/node-value view-node :hover-showing-region evaluation-context)
+             :canvas-repaint-info canvas-repaint-info
+             :project (g/node-value view-node :project evaluation-context)
+             :view-node view-node
+             :screen-bounds (mapv #(.getVisualBounds ^Screen %) (Screen/getScreens))
+             :window-x (some-> scene .getWindow .getX)
+             :window-y (some-> scene .getWindow .getY)}))))
 
     ;; Repaint cursors if needed.
     (when-not (identical? prev-cursor-repaint-info cursor-repaint-info)

--- a/editor/src/clj/editor/defold_project.clj
+++ b/editor/src/clj/editor/defold_project.clj
@@ -1837,11 +1837,13 @@
 (defn cache-retain?
   ([endpoint]
    (case (g/endpoint-label endpoint)
+     (:repaint-info :right-split-desc :scene-view-ids :tick-info) true
      (:build-targets) (project-resource-node? (g/now) (g/endpoint-node-id endpoint))
      (:save-data :save-value) (project-file-resource-node? (g/now) (g/endpoint-node-id endpoint))
      false))
   ([basis endpoint]
    (case (g/endpoint-label endpoint)
+     (:repaint-info :right-split-desc :scene-view-ids :tick-info) true
      (:build-targets) (project-resource-node? basis (g/endpoint-node-id endpoint))
      (:save-data :save-value) (project-file-resource-node? basis (g/endpoint-node-id endpoint))
      false)))

--- a/editor/src/clj/editor/scene_cache.clj
+++ b/editor/src/clj/editor/scene_cache.clj
@@ -85,20 +85,20 @@
 
 (defn- consume-pending-deletions-in-object-caches [object-caches context]
   (reduce-kv
-    (fn [[object-caches pending-deletions :as acc] cache-id cache-meta]
+    (fn [acc cache-id cache-meta]
       (let [caches-by-context (:caches cache-meta)
             cache-for-context (get caches-by-context context)
             pending-deletions-from-cache (some-> cache-for-context meta :pending-deletions)]
         (if (coll/empty? pending-deletions-from-cache)
           acc
-          (pair (assoc object-caches
-                       cache-id
-                       (assoc cache-meta
-                              :caches
-                              (assoc caches-by-context
-                                     context
-                                     (vary-meta cache-for-context dissoc :pending-deletions))))
-                (into pending-deletions pending-deletions-from-cache)))))
+          (pair (assoc (key acc)
+                  cache-id
+                  (assoc cache-meta
+                    :caches
+                    (assoc caches-by-context
+                      context
+                      (vary-meta cache-for-context dissoc :pending-deletions))))
+                (into (val acc) pending-deletions-from-cache)))))
     (pair object-caches
           [])
     object-caches))
@@ -177,7 +177,7 @@
 
 (defn- prune-context-in-object-caches [object-caches context]
   (reduce-kv
-    (fn [[object-caches deletions :as acc] cache-id cache-meta]
+    (fn [acc cache-id cache-meta]
       (let [caches-by-context (:caches cache-meta)
             cached-object+request-data-by-request-id (get caches-by-context context)]
         (if (nil? cached-object+request-data-by-request-id)
@@ -195,8 +195,8 @@
                                                (vector)))
                 pruned-caches-by-context (assoc caches-by-context context pruned-cached-object+request-data-by-request-id)
                 pruned-cache-meta (assoc cache-meta :caches pruned-caches-by-context)]
-            (pair (assoc object-caches cache-id pruned-cache-meta)
-                  (into deletions deletions-from-cache))))))
+            (pair (assoc (key acc) cache-id pruned-cache-meta)
+                  (into (val acc) deletions-from-cache))))))
     (pair object-caches
           [])
     object-caches))

--- a/editor/src/clj/editor/scene_cache.clj
+++ b/editor/src/clj/editor/scene_cache.clj
@@ -83,39 +83,23 @@
   (swap! object-caches-atom clear-object-caches)
   nil)
 
-(defn- consume-pending-deletions-in-caches-by-context [caches-by-context context]
-  (let [pending-deletions
-        (some-> caches-by-context
-                (get context)
-                (meta)
-                (:pending-deletions))
-
-        caches-by-context-without-pending-deletions
-        (cond-> caches-by-context
-                (coll/not-empty pending-deletions)
-                (update context vary-meta dissoc :pending-deletions))]
-
-    (pair caches-by-context-without-pending-deletions
-          pending-deletions)))
-
-(defn- consume-pending-deletions-in-cache-meta [cache-meta context]
-  (let [[caches-by-context-without-pending-deletions pending-deletions]
-        (consume-pending-deletions-in-caches-by-context (:caches cache-meta) context)
-
-        cache-meta-without-pending-deletions
-        (assoc cache-meta :caches caches-by-context-without-pending-deletions)]
-
-    (pair cache-meta-without-pending-deletions
-          pending-deletions)))
-
 (defn- consume-pending-deletions-in-object-caches [object-caches context]
   (reduce-kv
-    (fn [[object-caches pending-deletions] cache-id cache-meta]
-      (let [[cache-meta-without-pending-deletions pending-deletions-from-cache]
-            (consume-pending-deletions-in-cache-meta cache-meta context)]
-        (pair (assoc object-caches cache-id cache-meta-without-pending-deletions)
-              (into pending-deletions pending-deletions-from-cache))))
-    (pair (empty object-caches)
+    (fn [[object-caches pending-deletions :as acc] cache-id cache-meta]
+      (let [caches-by-context (:caches cache-meta)
+            cache-for-context (get caches-by-context context)
+            pending-deletions-from-cache (some-> cache-for-context meta :pending-deletions)]
+        (if (coll/empty? pending-deletions-from-cache)
+          acc
+          (pair (assoc object-caches
+                       cache-id
+                       (assoc cache-meta
+                              :caches
+                              (assoc caches-by-context
+                                     context
+                                     (vary-meta cache-for-context dissoc :pending-deletions))))
+                (into pending-deletions pending-deletions-from-cache)))))
+    (pair object-caches
           [])
     object-caches))
 
@@ -191,49 +175,29 @@
           (cache/lookup request-id) ; [cached-object request-data] pair.
           (first)))
 
-(defn- prune-context-in-caches-by-context [caches-by-context context destroy-batch-fn]
-  (let [cached-object+request-data-by-request-id
-        (get caches-by-context context)
-
-        pruned-cached-object+request-data-by-request-id
-        (some-> cached-object+request-data-by-request-id
-                (volatile-cache/prune))
-
-        deletions
-        (when (not= (count cached-object+request-data-by-request-id)
-                    (count pruned-cached-object+request-data-by-request-id))
-          (some-> (keep (fn [[request-id cached-object+request-data]]
-                          (when (not (cache/has? pruned-cached-object+request-data-by-request-id request-id))
-                            cached-object+request-data))
-                        cached-object+request-data-by-request-id)
-                  (coll/not-empty)
-                  (make-deletion destroy-batch-fn)
-                  (vector)))
-
-        pruned-caches-by-context
-        (assoc caches-by-context context pruned-cached-object+request-data-by-request-id)]
-
-    (pair pruned-caches-by-context
-          deletions)))
-
-(defn- prune-context-in-cache-meta [cache-meta context]
-  (let [[pruned-caches-by-context deletions]
-        (prune-context-in-caches-by-context (:caches cache-meta) context (:destroy-batch-fn cache-meta))
-
-        pruned-cache-meta
-        (assoc cache-meta :caches pruned-caches-by-context)]
-
-    (pair pruned-cache-meta
-          deletions)))
-
 (defn- prune-context-in-object-caches [object-caches context]
   (reduce-kv
-    (fn [[object-caches deletions] cache-id cache-meta]
-      (let [[pruned-cache-meta deletions-from-cache]
-            (prune-context-in-cache-meta cache-meta context)]
-        (pair (assoc object-caches cache-id pruned-cache-meta)
-              (into deletions deletions-from-cache))))
-    (pair (empty object-caches)
+    (fn [[object-caches deletions :as acc] cache-id cache-meta]
+      (let [caches-by-context (:caches cache-meta)
+            cached-object+request-data-by-request-id (get caches-by-context context)]
+        (if (nil? cached-object+request-data-by-request-id)
+          acc
+          (let [destroy-batch-fn (:destroy-batch-fn cache-meta)
+                pruned-cached-object+request-data-by-request-id (volatile-cache/prune cached-object+request-data-by-request-id)
+                deletions-from-cache (when (not= (count cached-object+request-data-by-request-id)
+                                                 (count pruned-cached-object+request-data-by-request-id))
+                                       (some-> (keep (fn [[request-id cached-object+request-data]]
+                                                       (when (not (cache/has? pruned-cached-object+request-data-by-request-id request-id))
+                                                         cached-object+request-data))
+                                                     cached-object+request-data-by-request-id)
+                                               (coll/not-empty)
+                                               (make-deletion destroy-batch-fn)
+                                               (vector)))
+                pruned-caches-by-context (assoc caches-by-context context pruned-cached-object+request-data-by-request-id)
+                pruned-cache-meta (assoc cache-meta :caches pruned-caches-by-context)]
+            (pair (assoc object-caches cache-id pruned-cache-meta)
+                  (into deletions deletions-from-cache))))))
+    (pair object-caches
           [])
     object-caches))
 

--- a/editor/src/clj/editor/ui.clj
+++ b/editor/src/clj/editor/ui.clj
@@ -2429,6 +2429,8 @@
     (doto (Timeline. 60 (into-array KeyFrame [(KeyFrame. ^Duration (Duration/seconds delay) handler values)]))
       (.play))))
 
+(def ^:private ^:const unfocused-timer-interval (long (* 1e9 (/ 1.0 15.0))))
+
 (defn ->timer
   ([name tick-fn]
    (->timer nil name tick-fn))
@@ -2438,14 +2440,14 @@
          interval (if fps
                     (long (* 1e9 (/ 1 (double fps))))
                     0)
-         unfocused-interval (max interval (long (* 1e9 (/ 1.0 15.0))))]
+         unfocused-interval (max interval unfocused-timer-interval)]
      {:last last
       :timer (proxy [AnimationTimer] []
                (handle [^long now]
                  (profiler/profile "timer" name
-	                 (let [elapsed (- now start)
-	                       delta (- now (long @last))
-	                       interval (if (:focused @focus-state) interval unfocused-interval)]
+                   (let [elapsed (- now start)
+                         delta (- now (long @last))
+                         interval (if (:focused @focus-state) interval unfocused-interval)]
                      (when (or (zero? interval) (> delta interval))
                        (run-later
                          (try

--- a/editor/src/clj/editor/ui.clj
+++ b/editor/src/clj/editor/ui.clj
@@ -2443,9 +2443,9 @@
       :timer (proxy [AnimationTimer] []
                (handle [^long now]
                  (profiler/profile "timer" name
-	                   (let [elapsed (- now start)
-	                         delta (- now (long @last))
-	                         interval (if (:focused @focus-state) interval unfocused-interval)]
+	                 (let [elapsed (- now start)
+	                       delta (- now (long @last))
+	                       interval (if (:focused @focus-state) interval unfocused-interval)]
                      (when (or (zero? interval) (> delta interval))
                        (run-later
                          (try

--- a/editor/src/clj/editor/ui.clj
+++ b/editor/src/clj/editor/ui.clj
@@ -2437,13 +2437,15 @@
          last (atom start)
          interval (if fps
                     (long (* 1e9 (/ 1 (double fps))))
-                    0)]
+                    0)
+         unfocused-interval (max interval (long (* 1e9 (/ 1.0 15.0))))]
      {:last last
       :timer (proxy [AnimationTimer] []
                (handle [^long now]
                  (profiler/profile "timer" name
-                   (let [elapsed (- now start)
-                         delta (- now (long @last))]
+	                   (let [elapsed (- now start)
+	                         delta (- now (long @last))
+	                         interval (if (:focused @focus-state) interval unfocused-interval)]
                      (when (or (zero? interval) (> delta interval))
                        (run-later
                          (try

--- a/editor/src/clj/internal/node.clj
+++ b/editor/src/clj/internal/node.clj
@@ -128,7 +128,7 @@
 (defn input-dependencies       [nt]        (some-> nt deref :input-dependencies))
 (defn property-display-order   [nt]        (some-> nt deref :property-display-order))
 (defn cascade-deletes          [nt]        (some-> nt deref :cascade-deletes))
-(defn behavior                 [nt label]  (some-> nt deref (get-in [:behavior label])))
+(defn behavior                 [nt label]  (some-> nt deref :behavior (get label)))
 (defn property-behavior        [nt label]  (some-> nt deref (get-in [:property-behavior label])))
 (defn declared-property-labels [nt]        (some-> nt deref :declared-property))
 
@@ -1611,8 +1611,8 @@
          (let [~node-id-sym (gt/node-id ~node-sym)]
            ~(check-jammed-form description label node-sym node-id-sym label-sym evaluation-context-sym
               (apply-default-property-shortcut-form description label node-sym node-id-sym label-sym evaluation-context-sym
-                (mark-in-production-form node-id-sym label-sym evaluation-context-sym
-                  (check-caches-form description label node-id-sym label-sym evaluation-context-sym
+                (check-caches-form description label node-id-sym label-sym evaluation-context-sym
+                  (mark-in-production-form node-id-sym label-sym evaluation-context-sym
                     (with-tracer-calls-form node-id-sym label-sym evaluation-context-sym tracer-label-type
                       (gather-arguments-form description label node-sym node-id-sym evaluation-context-sym arguments-sym
                         (call-production-function-form description label node-id-sym label-sym evaluation-context-sym arguments-sym result-sym

--- a/editor/src/clj/internal/system.clj
+++ b/editor/src/clj/internal/system.clj
@@ -405,11 +405,11 @@
 
 (defn user-data [system node-id key]
   (let [graph-id (gt/node-id->graph-id node-id)]
-    (get-in (:user-data system) [graph-id node-id key])))
+    (-> system :user-data (get graph-id) (get node-id) (get key))))
 
 (defn assoc-user-data [system node-id key value]
   (let [graph-id (gt/node-id->graph-id node-id)]
-    (assoc-in system [:user-data graph-id node-id key] value)))
+    (update system :user-data update graph-id update node-id assoc key value)))
 
 (defn update-user-data [system node-id key f & args]
   (let [graph-id (gt/node-id->graph-id node-id)]

--- a/editor/test/editor/resource_unpacker_test.clj
+++ b/editor/test/editor/resource_unpacker_test.clj
@@ -17,7 +17,8 @@
             [clojure.string :as string]
             [clojure.test :refer :all]
             [editor.fs :as fs])
-  (:import [com.defold.libs ResourceUnpacker ResourceUnpacker$NativeLibraryLoader]
+  (:import [ch.qos.logback.classic Level Logger]
+           [com.defold.libs ResourceUnpacker ResourceUnpacker$NativeLibraryLoader]
            [com.dynamo.bob Platform]
            [com.jogamp.common.jvm JNILibLoaderBase]
            [com.jogamp.common.os DynamicLibraryBundle NativeLibrary]
@@ -25,7 +26,10 @@
            [jogamp.opengl GLDrawableFactoryImpl]
            [java.nio.file Path]
            [java.util LinkedHashMap Map$Entry]
-           [java.util.concurrent CountDownLatch TimeUnit]))
+           [java.util.concurrent CountDownLatch TimeUnit]
+           [org.slf4j LoggerFactory]))
+
+(.setLevel ^Logger (LoggerFactory/getLogger ResourceUnpacker) Level/WARN)
 
 (defn- make-temp-library! ^Path [dir name]
   (let [file (io/file dir name)]

--- a/editor/test/editor/scene_cache_test.clj
+++ b/editor/test/editor/scene_cache_test.clj
@@ -74,3 +74,75 @@
     (is (retained? key))
     (drop-context!)
     (is (not (retained? key)))))
+
+(deftest process-pending-deletions []
+  (let [objects (atom {})
+        destroy-calls (atom [])]
+    (scene-cache/register-object-cache!
+      ::process-pending-deletions
+      (fn [context data]
+        (swap! objects assoc [context ::object] data)
+        ::object)
+      (fn [_ _ _])
+      (fn [context keys request-datas]
+        (swap! destroy-calls conj [context keys request-datas])
+        (doseq [key keys]
+          (swap! objects dissoc [context key]))))
+
+    (let [key (scene-cache/request-object! ::process-pending-deletions ::request ::context 1)]
+      (is (contains? @objects [::context key]))
+
+      ;; No deletion is pending before the cache is re-registered.
+      (scene-cache/process-pending-deletions! ::context)
+      (is (= [] @destroy-calls))
+      (is (contains? @objects [::context key]))
+
+      (scene-cache/register-object-cache! ::process-pending-deletions (fn [_ _]) (fn [_ _ _]) (fn [_ _ _]))
+
+      ;; Pending deletions are scoped to their originating context.
+      (scene-cache/process-pending-deletions! ::other-context)
+      (is (= [] @destroy-calls))
+      (is (contains? @objects [::context key]))
+
+      ;; The matching context consumes the queued deletion exactly once.
+      (scene-cache/process-pending-deletions! ::context)
+      (is (= [[::context [key] [1]]] @destroy-calls))
+      (is (not (contains? @objects [::context key])))
+
+      (scene-cache/process-pending-deletions! ::context)
+      (is (= [[::context [key] [1]]] @destroy-calls)))))
+
+(deftest prune-context []
+  (let [objects (atom {})
+        destroy-calls (atom [])]
+    (scene-cache/register-object-cache!
+      ::prune-context
+      (fn [context data]
+        (swap! objects assoc [context ::object] data)
+        ::object)
+      (fn [_ _ _])
+      (fn [context keys request-datas]
+        (swap! destroy-calls conj [context keys request-datas])
+        (doseq [key keys]
+          (swap! objects dissoc [context key]))))
+
+    (let [key (scene-cache/request-object! ::prune-context ::request ::context 1)]
+      (is (contains? @objects [::context key]))
+
+      ;; Other contexts do not prune this context's objects.
+      (scene-cache/prune-context! ::other-context)
+      (is (= [] @destroy-calls))
+      (is (contains? @objects [::context key]))
+
+      ;; The first matching prune clears usage tracking but retains the object.
+      (scene-cache/prune-context! ::context)
+      (is (= [] @destroy-calls))
+      (is (contains? @objects [::context key]))
+
+      ;; The next matching prune destroys the unused object exactly once.
+      (scene-cache/prune-context! ::context)
+      (is (= [[::context [key] [1]]] @destroy-calls))
+      (is (not (contains? @objects [::context key])))
+
+      (scene-cache/prune-context! ::context)
+      (is (= [[::context [key] [1]]] @destroy-calls)))))


### PR DESCRIPTION
Reduce idle editor CPU usage when the editor does not have focus. This drops CPU from around 8-12% to 3-6% on macOS.

Technical notes:

Measurements show that most of the time is spent in various refreshes we run when drawing:
<img width="1271" height="963" alt="Screenshot 2026-07-02 at 09 58 18" src="https://github.com/user-attachments/assets/179bca56-87df-4143-abff-c1b9d9a92862" />
Particularly, in the repaint of the console view (mostly node value and cache updates), right split refresh, and scene cache pruning.

This PR adds some micro-optimizations to the hot spots and additionally adds throttling to timers so all running timers are limited to 15 fps when the app is not focused.

Here is a CPU diff graph of before (red) vs after (blue):
<img width="1364" height="961" alt="Screenshot 2026-07-02 at 10 04 43" src="https://github.com/user-attachments/assets/693fcab3-1f7e-494e-8ebc-d75e3d99b1b0" />


Fix #12548