### PR TITLE
Add `indeterminate` checkbox state to editor scripts UI.

### DIFF
--- a/editor/src/clj/editor/editor_extensions/ui_components.clj
+++ b/editor/src/clj/editor/editor_extensions/ui_components.clj
@@ -471,13 +471,15 @@
 
 (fxui/defc check-box-view
   {:compose [{:fx/type fx/ext-get-env :env [:localization-state]}]}
-  [{:keys [rt text text_alignment alignment issue tooltip enabled value on_value_changed localization-state]
+  [{:keys [rt text text_alignment alignment issue tooltip enabled value indeterminate on_value_changed localization-state]
     :or {enabled true
+         indeterminate false
          value false}}]
   (wrap-in-alignment-container
     {:fx/type ext-with-extra-check-box-props
      :desc (-> {:fx/type fxui/check-box
                 :disable (not enabled)
+                :indeterminate indeterminate
                 :selected value}
                (set-tooltip-and-issue tooltip issue localization-state)
                (cond->

--- a/editor/src/clj/editor/editor_extensions/ui_docs.clj
+++ b/editor/src/clj/editor/editor_extensions/ui_docs.clj
@@ -309,7 +309,8 @@
 
 (def ^:private check-box-specific-props
   [(make-prop :value :coerce coerce/boolean :doc "determines if the checkbox should appear checked")
-   (make-prop :on_value_changed :coerce coerce/function :doc "change callback, will receive the new value")])
+   (make-prop :on_value_changed :coerce coerce/function :doc "change callback, will receive the new value")
+   (make-prop :indeterminate :coerce coerce/boolean :doc "determines if the checkbox should appear in the mixed state")])
 
 (def ^:private check-box-props
   (into [] cat [check-box-specific-props label-without-color-specific-props input-with-issue-props]))

--- a/editor/test/integration/editor_extensions_test.clj
+++ b/editor/test/integration/editor_extensions_test.clj
@@ -874,6 +874,7 @@ editor.ui.image({image = 'foo', width = -1}) => -1 is not positive
 editor.ui.dialog({title = 'Dialog title', width = false}) => false is not a number
 editor.ui.dialog({title = 'Dialog title', height = -1}) => -1 is not positive
 editor.ui.dialog({title = 'Dialog title', resizable = 1}) => 1 is not a boolean
+editor.ui.check_box({indeterminate = 1}) => 1 is not a boolean
 editor.ui.tab({}) => {} must have the \"text\" key
 ")
 

--- a/editor/test/resources/editor_extensions/ui_project/test.editor_script
+++ b/editor/test/resources/editor_extensions/ui_project/test.editor_script
@@ -238,6 +238,11 @@ function M.get_commands()
                                                 issue = {severity = editor.ui.ISSUE_SEVERITY.ERROR, message = "error message"}
                                             }),
                                             editor.ui.check_box({
+                                                text = "Indeterminate check box",
+                                                indeterminate = true,
+                                                value = true
+                                            }),
+                                            editor.ui.check_box({
                                                 value = true
                                             })
                                         }
@@ -306,6 +311,7 @@ function M.get_commands()
                 expect_error("editor.ui.dialog({title = 'Dialog title', width = false})", editor.ui.dialog, {title = "Dialog title", width = false})
                 expect_error("editor.ui.dialog({title = 'Dialog title', height = -1})", editor.ui.dialog, {title = "Dialog title", height = -1})
                 expect_error("editor.ui.dialog({title = 'Dialog title', resizable = 1})", editor.ui.dialog, {title = "Dialog title", resizable = 1})
+                expect_error("editor.ui.check_box({indeterminate = 1})", editor.ui.check_box, {indeterminate = 1})
                 expect_error("editor.ui.tab({})", editor.ui.tab, {})
 
                 -- editor.ui.show_dialog(dialog)


### PR DESCRIPTION
Now it's possible to create check-boxes with indeterminate state. An indeterminate state is a third visual indicator  used for a checkbox when a subset of its child items are partially selected.

```lua
editor.ui.check_box({
    text = "Mixed selection",
    value = true,
    indeterminate = true
})
```

Fix #12547