### PR TITLE
Add `active_view` query to editor script commands

### DIFF
--- a/editor/src/clj/editor/cljfx_form_view.clj
+++ b/editor/src/clj/editor/cljfx_form_view.clj
@@ -42,6 +42,7 @@
             [clojure.string :as string]
             [dynamo.graph :as g]
             [editor.dialogs :as dialogs]
+            [editor.editor-extensions.node-types :as node-types]
             [editor.error-reporting :as error-reporting]
             [editor.field-expression :as field-expression]
             [editor.form :as form]
@@ -93,6 +94,8 @@
   (property renderer g/Any)
   (output sidebar-panes g/Any (g/constantly [:outline-pane]))
   (output form-view g/Any :cached produce-form-view))
+
+(node-types/register-node-type-name! CljfxFormView "form")
 
 (defmulti handle-event :event-type)
 

--- a/editor/src/clj/editor/code/view.clj
+++ b/editor/src/clj/editor/code/view.clj
@@ -4163,6 +4163,7 @@
         dispose-breakpoint-editor! (create-breakpoint-editor! view-node canvas tab)
         context-env {:clipboard (Clipboard/getSystemClipboard)
                      :editable editable
+                     :app-view app-view
                      :goto-line-bar goto-line-bar
                      :find-bar find-bar
                      :replace-bar replace-bar

--- a/editor/src/clj/editor/code/view.clj
+++ b/editor/src/clj/editor/code/view.clj
@@ -43,6 +43,7 @@
             [editor.code.resource :as r]
             [editor.code.util :refer [split-lines]]
             [editor.defold-project :as project]
+            [editor.editor-extensions.node-types :as node-types]
             [editor.error-reporting :as error-reporting]
             [editor.fxui :as fxui]
             [editor.graph-util :as gu]
@@ -2373,6 +2374,8 @@
                                                       :else "<small>no documentation</small>")}
                                           (not align-right)
                                           (assoc :min-width doc-width))]}]}})))}}))))
+
+(node-types/register-node-type-name! CodeEditorView "code")
 
 ;; -----------------------------------------------------------------------------
 

--- a/editor/src/clj/editor/editor_extensions/commands.clj
+++ b/editor/src/clj/editor/editor_extensions/commands.clj
@@ -114,11 +114,28 @@
                    (g/update-cache-from-evaluation-context! evaluation-context))
                  (cont assoc :selection res)))))
 
+(defn- gen-active-view-query [q acc]
+  (let [expected-type (case (:type q)
+                        "code" :editor.code.view/CodeEditorView
+                        "scene" :editor.scene/SceneView
+                        "html" :editor.html-view/HtmlViewNode
+                        "form" :editor.cljfx-form-view/CljfxFormView)]
+    (gen-query acc [env cont]
+      (let [evaluation-context (or (:evaluation-context env)
+                                   (g/make-evaluation-context))]
+        (when-let [view (some-> (:app-view env)
+                                (g/node-value :active-view evaluation-context))]
+          (when (g/node-kw-instance? (:basis evaluation-context) expected-type view)
+            (when-not (:evaluation-context env)
+              (g/update-cache-from-evaluation-context! evaluation-context))
+            (cont assoc :active_view (editor-lookup-userdata view))))))))
+
 (defn- compile-query [q project]
   (reduce-kv
     (fn [acc k v]
       (case k
         :selection (gen-selection-query v acc project)
+        :active_view (gen-active-view-query v acc)
         :argument (gen-query acc [env cont] (cont assoc :argument (:user-data env)))
         acc))
     (fn [lua-fn]
@@ -137,6 +154,9 @@
                    :opt {:selection (coerce/hash-map
                                       :req {:type (coerce/enum :resource :outline :scene)
                                             :cardinality (coerce/enum :one :many)})
+                         :active_view (coerce/hash-map
+                                        :req {:type (coerce/enum "code" "scene" "html" "form")}
+                                        :extra-keys false)
                          :argument (coerce/const true)})
           :id prefs-docs/serializable-keyword-coercer
           :active coerce/function

--- a/editor/src/clj/editor/editor_extensions/commands.clj
+++ b/editor/src/clj/editor/editor_extensions/commands.clj
@@ -27,7 +27,8 @@
             [editor.lsp.async :as lsp.async]
             [editor.resource :as resource]
             [editor.scene :as scene]
-            [util.coll :as coll]))
+            [util.coll :as coll]
+            [util.fn :as fn]))
 
 (set! *warn-on-reflection* true)
 
@@ -121,14 +122,16 @@
                         "html" :editor.html-view/HtmlViewNode
                         "form" :editor.cljfx-form-view/CljfxFormView)]
     (gen-query acc [env cont]
-      (let [evaluation-context (or (:evaluation-context env)
-                                   (g/make-evaluation-context))]
-        (when-let [view (some-> (:app-view env)
-                                (g/node-value :active-view evaluation-context))]
-          (when (g/node-kw-instance? (:basis evaluation-context) expected-type view)
-            (when-not (:evaluation-context env)
-              (g/update-cache-from-evaluation-context! evaluation-context))
-            (cont assoc :active_view (editor-lookup-userdata view))))))))
+      (when-let [app-view (:app-view env)]
+        (let [evaluation-context (or (:evaluation-context env)
+                                     (g/make-evaluation-context))]
+          (try
+            (when-let [view (g/node-value app-view :active-view evaluation-context)]
+              (when (g/node-kw-instance? (:basis evaluation-context) expected-type view)
+                (cont assoc :active_view (editor-lookup-userdata view))))
+            (finally
+              (when-not (:evaluation-context env)
+                (g/update-cache-from-evaluation-context! evaluation-context)))))))))
 
 (defn- compile-query [q project]
   (reduce-kv
@@ -222,7 +225,7 @@
                          (rt/->clj rt coerce/to-boolean (rt/invoke-immediate-1 (:rt state) {:evaluation-context (:evaluation-context env)} active (rt/->lua opts)))))))
 
             (and (not active) query)
-            (assoc :active? (lua-fn->env-fn (constantly true)))
+            (assoc :active? (lua-fn->env-fn fn/constantly-true))
 
             run
             (assoc :run

--- a/editor/src/clj/editor/editor_extensions/docs.clj
+++ b/editor/src/clj/editor/editor_extensions/docs.clj
@@ -113,6 +113,13 @@
                                                                  {:name "cardinality"
                                                                   :types ["string"]
                                                                   :doc "either <code>\"one\"</code> (will use first selected item) or <code>\"many\"</code> (will use all selected items)"}]))}
+                                                   {:name "active_view"
+                                                    :types ["table"]
+                                                    :doc (str "current active editor view, a table with the following keys:"
+                                                              (lua-completion/args-doc-html
+                                                                [{:name "type"
+                                                                  :types ["string"]
+                                                                  :doc "either <code>\"code\"</code>, <code>\"scene\"</code>, <code>\"html\"</code>, or <code>\"form\"</code>"}]))}
                                                    {:name "argument"
                                                     :types ["table"]
                                                     :doc "the command argument"}]))}

--- a/editor/src/clj/editor/editor_extensions/graph.clj
+++ b/editor/src/clj/editor/editor_extensions/graph.clj
@@ -412,6 +412,20 @@
     (cond-> ["path"] (textual-resource-node? node-id evaluation-context) (conj "text"))))
 
 (register-property-getter!
+  :editor.view/WorkbenchView
+  (fn WorkbenchView-getter [node-id property evaluation-context]
+    (case property
+      "resource" (fn get-resource []
+                   (some-> (g/node-value node-id :view-data evaluation-context)
+                           second
+                           :resource-node
+                           rt/wrap-userdata))
+      "dirty" #(g/node-value node-id :dirty evaluation-context)
+      nil))
+  (fn WorkbenchView-lister [_node-id _evaluation-context]
+    ["dirty" "resource"]))
+
+(register-property-getter!
   :editor.tile-source/TileSourceNode
   (fn TileSourceNode-getter [node-id property evaluation-context]
     (case property

--- a/editor/src/clj/editor/editor_extensions/graph.clj
+++ b/editor/src/clj/editor/editor_extensions/graph.clj
@@ -415,11 +415,7 @@
   :editor.view/WorkbenchView
   (fn WorkbenchView-getter [node-id property evaluation-context]
     (case property
-      "resource" (fn get-resource []
-                   (some-> (g/node-value node-id :view-data evaluation-context)
-                           second
-                           :resource-node
-                           rt/wrap-userdata))
+      "resource" #(rt/wrap-userdata (g/node-value node-id :resource-node evaluation-context))
       "dirty" #(g/node-value node-id :dirty evaluation-context)
       nil))
   (fn WorkbenchView-lister [_node-id _evaluation-context]

--- a/editor/src/clj/editor/html_view.clj
+++ b/editor/src/clj/editor/html_view.clj
@@ -14,6 +14,7 @@
 
 (ns editor.html-view
   (:require [dynamo.graph :as g]
+            [editor.editor-extensions.node-types :as node-types]
             [editor.fxui :as fxui]
             [editor.localization :as localization]
             [editor.markdown :as markdown]
@@ -44,6 +45,8 @@
   (input html g/Str)
   (input project g/NodeID)
   (output desc g/Any :cached produce-desc))
+
+(node-types/register-node-type-name! HtmlViewNode "html")
 
 (defn- repaint! [view-node]
   (fxui/advance-graph-user-data-component! view-node :view (g/node-value view-node :desc)))

--- a/editor/src/clj/editor/scene.clj
+++ b/editor/src/clj/editor/scene.clj
@@ -24,6 +24,7 @@
             [editor.background :as background]
             [editor.camera :as c]
             [editor.colors :as colors]
+            [editor.editor-extensions.node-types :as node-types]
             [editor.error-reporting :as error-reporting]
             [editor.fxui :as fxui]
             [editor.geom :as geom]
@@ -1331,6 +1332,8 @@
   (output displayed-node-properties g/Any :cached
           (g/fnk [selected-node-properties preview-overrides]
             (displayed-node-properties selected-node-properties preview-overrides))))
+
+(node-types/register-node-type-name! SceneView "scene")
 
 (defn cursor
   "Maps inconsistent cursor types across platforms.

--- a/editor/test/integration/editor_extensions_test.clj
+++ b/editor/test/integration/editor_extensions_test.clj
@@ -17,6 +17,8 @@
             [clojure.string :as string]
             [clojure.test :refer :all]
             [dynamo.graph :as g]
+            [editor.cljfx-form-view :as cljfx-form-view]
+            [editor.code.view :as code-view]
             [editor.defold-project :as project]
             [editor.editor-extensions :as extensions]
             [editor.editor-extensions.coerce :as coerce]
@@ -28,6 +30,7 @@
             [editor.future :as future]
             [editor.graph-util :as gu]
             [editor.handler :as handler]
+            [editor.html-view :as html-view]
             [editor.library :as library]
             [editor.os :as os]
             [editor.outline-view :as outline-view]
@@ -37,7 +40,9 @@
             [editor.progress :as progress]
             [editor.properties :as properties]
             [editor.resource :as resource]
+            [editor.scene :as scene]
             [editor.ui :as ui]
+            [editor.view :as view]
             [editor.web-server :as web-server]
             [editor.workspace :as workspace]
             [integration.test-util :as test-util]
@@ -2583,3 +2588,42 @@ localization.message('progress.loading-resource', {resource = message}) => Loadi
       (reload-editor-scripts! project :display-output! #(doto out (.append %2) (.append \newline)))
       (run-edit-menu-test-command!)
       (expect-script-output expected-localization-output out))))
+
+(deftest editor-script-active-view-commands-test
+  (test-util/with-loaded-project "test/resources/editor_extensions/active_view_project"
+    (let [out (StringBuilder.)]
+      (reload-editor-scripts! project :display-output! #(doto out (.append %2) (.append \newline)))
+      (run!
+        (fn [[proj-path view-node-type view-node-args label]]
+          (let [resource-node (test-util/resource-node project proj-path)
+                view-graph (test-util/make-view-graph!)
+                view-node (first (g/take-node-ids view-graph 1))]
+            (g/transact
+              (concat
+                (g/add-node (apply g/construct view-node-type :_node-id view-node view-node-args))
+                (view/connect-resource-node view-node resource-node)
+                (g/set-property app-view :active-view view-node)))
+            (let [command-contexts (g/with-auto-evaluation-context evaluation-context
+                                     (handler/eval-contexts
+                                       [(handler/->context :global {:app-view app-view})]
+                                       false
+                                       evaluation-context))
+                  handler+context (->> (handler/realize-menu :editor.app-view/view-end)
+                                       (e/keep :command)
+                                       (e/filter handler/synthetic-command?)
+                                       (e/keep #(handler/active % command-contexts {}))
+                                       (coll/first-where #(= label (handler/label %))))]
+              (assert handler+context "Test bug: undefined test command")
+              (is (handler/enabled? handler+context))
+              @(handler/run handler+context))))
+        [["/main/main.script" code-view/CodeEditorView [:gutter-view (code-view/->CodeEditorGutterView)] "Inspect Active Code View"]
+         ["/main/main.collection" scene/SceneView [] "Inspect Active Scene View"]
+         ["/README.md" html-view/HtmlViewNode [] "Inspect Active HTML View"]
+         ["/game.project" cljfx-form-view/CljfxFormView [] "Inspect Active Form View"]])
+      (expect-script-output
+        "type=code resource=/main/main.script dirty=false
+type=scene resource=/main/main.collection dirty=false
+type=html resource=/README.md dirty=false
+type=form resource=/game.project dirty=false
+"
+        out))))

--- a/editor/test/resources/editor_extensions/active_view_project/.gitignore
+++ b/editor/test/resources/editor_extensions/active_view_project/.gitignore
@@ -1,0 +1,11 @@
+/.editor_settings
+/.internal
+/build
+.externalToolBuilders
+.DS_Store
+Thumbs.db
+.lock-wscript
+*.pyc
+.project
+.cproject
+builtins

--- a/editor/test/resources/editor_extensions/active_view_project/README.md
+++ b/editor/test/resources/editor_extensions/active_view_project/README.md
@@ -1,0 +1,4 @@
+# Active View Project
+
+Open this file as an HTML view, then run the active view inspector command from
+the View menu.

--- a/editor/test/resources/editor_extensions/active_view_project/game.project
+++ b/editor/test/resources/editor_extensions/active_view_project/game.project
@@ -1,0 +1,18 @@
+[bootstrap]
+main_collection = /main/main.collectionc
+
+[script]
+shared_state = 1
+
+[display]
+width = 960
+height = 640
+
+[android]
+input_method = HiddenInputField
+
+[project]
+title = active_view_project
+
+[input]
+game_binding = /builtins/input/all.input_bindingc

--- a/editor/test/resources/editor_extensions/active_view_project/main/main.collection
+++ b/editor/test/resources/editor_extensions/active_view_project/main/main.collection
@@ -1,0 +1,26 @@
+name: "main"
+scale_along_z: 0
+embedded_instances {
+  id: "go"
+  data: "components {\n"
+  "  id: \"script\"\n"
+  "  component: \"/main/main.script\"\n"
+  "}\n"
+  ""
+  position {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  scale3 {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+  }
+}

--- a/editor/test/resources/editor_extensions/active_view_project/main/main.script
+++ b/editor/test/resources/editor_extensions/active_view_project/main/main.script
@@ -1,0 +1,3 @@
+function init(self)
+    print("active view test")
+end

--- a/editor/test/resources/editor_extensions/active_view_project/test.editor_script
+++ b/editor/test/resources/editor_extensions/active_view_project/test.editor_script
@@ -1,0 +1,26 @@
+local M = {}
+
+local function command(view_type, label)
+    return editor.command({
+        label = label,
+        locations = {"View"},
+        query = {active_view = {type = view_type}},
+        run = function(opts)
+            local view = opts.active_view
+            local resource = editor.get(view, "resource")
+            local resource_path = editor.get(resource, "path")
+            print(("type=%s resource=%s dirty=%s"):format(editor.get(view, "type"), resource_path, tostring(editor.get(view, "dirty"))))
+        end
+    })
+end
+
+function M.get_commands()
+    return {
+        command("code", "Inspect Active Code View"),
+        command("scene", "Inspect Active Scene View"),
+        command("html", "Inspect Active HTML View"),
+        command("form", "Inspect Active Form View")
+    }
+end
+
+return M


### PR DESCRIPTION
Now, it's possible to query active view node in editor script commands. Views can be queried by their type: `"code"`, `"scene"`, `"html"`, or `"form"`.

The active view exposes the following properties:
- `"type"`: the active view type
- `"resource"`: the resource shown in the view
- `"dirty"`: whether the view has unsaved changes

```lua
editor.command({
    label = "Print Active View",
    locations = {"View"},
    query = {active_view = {type = "code"}},
    run = function(opts)
        local view = opts.active_view
        local resource = editor.get(view, "resource")
        print(editor.get(view, "type"))
        print(editor.get(resource, "path"))
        print(editor.get(view, "dirty"))
    end
})
```

Fix #12658