### PR TITLE
Fix for calling GetIfAddresses() multiple times per frame

### DIFF
--- a/engine/dlib/src/dlib/socket_win32.cpp
+++ b/engine/dlib/src/dlib/socket_win32.cpp
@@ -16,6 +16,8 @@
 #include "socket_private.h"
 
 #include <dmsdk/dlib/log.h>
+#include <dmsdk/dlib/mutex.h>
+#include <dmsdk/dlib/time.h>
 
 #include <WinSock2.h>
 #include <WS2tcpip.h>
@@ -30,6 +32,20 @@ typedef int socklen_t;
 
 namespace dmSocket
 {
+    static const uint64_t GETIFADDRS_CACHE_INTERVAL_US = 1000000;
+    static const ULONG GETIFADDRS_CACHE_INITIAL_SIZE = 16 * 1024;
+
+    struct SocketContext
+    {
+        dmMutex::HMutex       m_IfAddrCacheMutex;
+        PIP_ADAPTER_ADDRESSES m_IfAddrCache;
+        ULONG                 m_IfAddrCacheSize;
+        bool                  m_IfAddrCacheValid;
+        uint64_t              m_IfAddrCacheExpires;
+    };
+
+    static SocketContext* g_SocketContext = 0;
+
     int GetSocketLastError()
     {
         return WSAGetLastError();
@@ -40,104 +56,149 @@ namespace dmSocket
         return WSAEINTR;
     }
 
+    static void ParseIfAddresses(PIP_ADAPTER_ADDRESSES paddresses, IfAddr* addresses, uint32_t addresses_count, uint32_t* count)
+    {
+        *count = 0;
+
+        PIP_ADAPTER_ADDRESSES       pcurraddresses = paddresses;
+        PIP_ADAPTER_UNICAST_ADDRESS punicast = NULL;
+
+        while (pcurraddresses && *count < addresses_count)
+        {
+            if (pcurraddresses->IfType != IF_TYPE_SOFTWARE_LOOPBACK)
+            {
+                punicast = pcurraddresses->FirstUnicastAddress;
+                if (punicast)
+                {
+                    for (unsigned i = 0; punicast != NULL && *count < addresses_count; i++)
+                    {
+                        IfAddr* a = &addresses[*count];
+                        memset(a, 0, sizeof(*a));
+
+                        wcstombs(a->m_Name, pcurraddresses->FriendlyName, sizeof(a->m_Name));
+                        a->m_Name[sizeof(a->m_Name) - 1] = 0;
+
+                        if (pcurraddresses->OperStatus == IfOperStatusUp)
+                        {
+                            a->m_Flags |= FLAGS_UP;
+                            a->m_Flags |= FLAGS_RUNNING;
+                        }
+
+                        if (punicast->Address.lpSockaddr->sa_family == AF_INET)
+                        {
+                            a->m_Flags |= FLAGS_INET;
+                            a->m_Address.m_family = DOMAIN_IPV4;
+                            sockaddr_in* ia = (sockaddr_in*)punicast->Address.lpSockaddr;
+                            *IPv4(&a->m_Address) = ia->sin_addr.s_addr;
+                        }
+                        else if (punicast->Address.lpSockaddr->sa_family == AF_INET6)
+                        {
+                            a->m_Flags |= FLAGS_INET;
+                            a->m_Address.m_family = DOMAIN_IPV6;
+                            sockaddr_in6* ia = (sockaddr_in6*)punicast->Address.lpSockaddr;
+                            memcpy(IPv6(&a->m_Address), &ia->sin6_addr, sizeof(struct in6_addr));
+                        }
+
+                        a->m_Flags |= FLAGS_LINK;
+                        a->m_MacAddress[0] = pcurraddresses->PhysicalAddress[0];
+                        a->m_MacAddress[1] = pcurraddresses->PhysicalAddress[1];
+                        a->m_MacAddress[2] = pcurraddresses->PhysicalAddress[2];
+                        a->m_MacAddress[3] = pcurraddresses->PhysicalAddress[3];
+                        a->m_MacAddress[4] = pcurraddresses->PhysicalAddress[4];
+                        a->m_MacAddress[5] = pcurraddresses->PhysicalAddress[5];
+
+                        punicast = punicast->Next;
+                        *count = *count + 1;
+                    }
+                }
+            }
+            pcurraddresses = pcurraddresses->Next;
+        }
+    }
+
+    static void RefreshIfAddrCache(SocketContext* context)
+    {
+        ULONG flags = GAA_FLAG_INCLUDE_PREFIX;
+        ULONG family = AF_INET;
+
+        ULONG out_buf_len = context->m_IfAddrCacheSize;
+        DWORD ret = GetAdaptersAddresses(family, flags, NULL, context->m_IfAddrCache, &out_buf_len);
+
+        if (ret == ERROR_BUFFER_OVERFLOW)
+        {
+            context->m_IfAddrCache = (PIP_ADAPTER_ADDRESSES)realloc(context->m_IfAddrCache, out_buf_len);;
+            context->m_IfAddrCacheSize = out_buf_len;
+            ret = GetAdaptersAddresses(family, flags, NULL, context->m_IfAddrCache, &out_buf_len);
+        }
+
+        context->m_IfAddrCacheValid = ret == NO_ERROR;
+        if (!context->m_IfAddrCacheValid && ret != ERROR_NO_DATA)
+        {
+            dmLogError("GetAdaptersAddresses failed (%d)\n", ret);
+        }
+
+        context->m_IfAddrCacheExpires = dmTime::GetMonotonicTime() + GETIFADDRS_CACHE_INTERVAL_US;
+    }
+
     void GetIfAddresses(IfAddr* addresses, uint32_t addresses_count, uint32_t* count)
     {
         *count = 0;
-        ULONG                 flags = GAA_FLAG_INCLUDE_PREFIX;
-        ULONG                 family = AF_INET;
-
-        ULONG                 out_buf_len;
-        PIP_ADAPTER_ADDRESSES paddresses = NULL;
-
-        // Ask for the length first
-        DWORD ret = GetAdaptersAddresses(family, flags, NULL, NULL, &out_buf_len);
-
-        if (ret == ERROR_BUFFER_OVERFLOW)
-        { // the address pointer is null ofc
-            paddresses = (IP_ADAPTER_ADDRESSES*)malloc(out_buf_len);
-            ret = GetAdaptersAddresses(family, flags, NULL, paddresses, &out_buf_len);
-        }
-
-        PIP_ADAPTER_ADDRESSES       pcurraddresses = NULL;
-        PIP_ADAPTER_UNICAST_ADDRESS punicast = NULL;
-
-        if (ret == NO_ERROR)
+        if (addresses == 0 || addresses_count == 0)
         {
-            pcurraddresses = paddresses;
-            while (pcurraddresses && *count < addresses_count)
-            {
-                if (pcurraddresses->IfType != IF_TYPE_SOFTWARE_LOOPBACK)
-                {
-                    punicast = pcurraddresses->FirstUnicastAddress;
-                    if (punicast)
-                    {
-                        for (unsigned i = 0; punicast != NULL; i++)
-                        {
-                            IfAddr* a = &addresses[*count];
-                            memset(a, 0, sizeof(*a));
-
-                            wcstombs(a->m_Name, pcurraddresses->FriendlyName, sizeof(a->m_Name));
-                            a->m_Name[sizeof(a->m_Name) - 1] = 0;
-
-                            if (pcurraddresses->OperStatus == IfOperStatusUp)
-                            {
-                                a->m_Flags |= FLAGS_UP;
-                                a->m_Flags |= FLAGS_RUNNING;
-                            }
-
-                            if (punicast->Address.lpSockaddr->sa_family == AF_INET)
-                            {
-                                a->m_Flags |= FLAGS_INET;
-                                a->m_Address.m_family = DOMAIN_IPV4;
-                                sockaddr_in* ia = (sockaddr_in*)punicast->Address.lpSockaddr;
-                                *IPv4(&a->m_Address) = ia->sin_addr.s_addr;
-                            }
-                            else if (punicast->Address.lpSockaddr->sa_family == AF_INET6)
-                            {
-                                a->m_Flags |= FLAGS_INET;
-                                a->m_Address.m_family = DOMAIN_IPV6;
-                                sockaddr_in6* ia = (sockaddr_in6*)punicast->Address.lpSockaddr;
-                                memcpy(IPv6(&a->m_Address), &ia->sin6_addr, sizeof(struct in6_addr));
-                            }
-
-                            a->m_Flags |= FLAGS_LINK;
-                            a->m_MacAddress[0] = pcurraddresses->PhysicalAddress[0];
-                            a->m_MacAddress[1] = pcurraddresses->PhysicalAddress[1];
-                            a->m_MacAddress[2] = pcurraddresses->PhysicalAddress[2];
-                            a->m_MacAddress[3] = pcurraddresses->PhysicalAddress[3];
-                            a->m_MacAddress[4] = pcurraddresses->PhysicalAddress[4];
-                            a->m_MacAddress[5] = pcurraddresses->PhysicalAddress[5];
-
-                            punicast = punicast->Next;
-                            *count = *count + 1;
-                        }
-                    }
-                }
-                pcurraddresses = pcurraddresses->Next;
-            }
+            return;
         }
-        else
+
+        SocketContext* context = g_SocketContext;
+        assert(context);
+        assert(context->m_IfAddrCacheMutex);
+        DM_MUTEX_SCOPED_LOCK(context->m_IfAddrCacheMutex);
+
+        uint64_t now = dmTime::GetMonotonicTime();
+        if (now >= context->m_IfAddrCacheExpires)
         {
-            if (ret != ERROR_NO_DATA)
-            {
-                dmLogError("GetAdaptersAddresses failed (%d)\n", ret);
-            }
+            RefreshIfAddrCache(context);
         }
 
-        free(paddresses);
-        return;
+        if (context->m_IfAddrCacheValid)
+        {
+            ParseIfAddresses(context->m_IfAddrCache, addresses, addresses_count, count);
+        }
     }
 
     Result PlatformInitialize()
     {
         WORD    version_requested = MAKEWORD(2, 2);
         WSADATA wsa_data;
-        int     result = WSAStartup(version_requested, &wsa_data);
-        return result == 0 ? RESULT_OK : NATIVETORESULT(DM_SOCKET_ERRNO());
+
+        int result = WSAStartup(version_requested, &wsa_data);
+        if (result != 0)
+        {
+            return NATIVETORESULT(result);
+        }
+        g_SocketContext = (SocketContext*)calloc(1, sizeof(SocketContext));
+        if (g_SocketContext == 0)
+        {
+            WSACleanup();
+            return RESULT_UNKNOWN;
+        }
+
+        g_SocketContext->m_IfAddrCacheMutex = dmMutex::New();
+        return RESULT_OK;
     }
 
     Result PlatformFinalize()
     {
+        SocketContext* context = g_SocketContext;
+        if (context != 0)
+        {
+            if (context->m_IfAddrCacheMutex != 0)
+            {
+                dmMutex::Delete(context->m_IfAddrCacheMutex);
+            }
+            free(context->m_IfAddrCache);
+            free(context);
+            g_SocketContext = 0;
+        }
         WSACleanup();
         return RESULT_OK;
     }

--- a/engine/dlib/src/dlib/socket_win32.cpp
+++ b/engine/dlib/src/dlib/socket_win32.cpp
@@ -126,7 +126,7 @@ namespace dmSocket
 
         if (ret == ERROR_BUFFER_OVERFLOW)
         {
-            context->m_IfAddrCache = (PIP_ADAPTER_ADDRESSES)realloc(context->m_IfAddrCache, out_buf_len);;
+            context->m_IfAddrCache = (PIP_ADAPTER_ADDRESSES)realloc(context->m_IfAddrCache, out_buf_len);
             context->m_IfAddrCacheSize = out_buf_len;
             ret = GetAdaptersAddresses(family, flags, NULL, context->m_IfAddrCache, &out_buf_len);
         }
@@ -149,7 +149,11 @@ namespace dmSocket
         }
 
         SocketContext* context = g_SocketContext;
-        assert(context);
+        if (context == 0)
+        {
+            return;
+        }
+
         assert(context->m_IfAddrCacheMutex);
         DM_MUTEX_SCOPED_LOCK(context->m_IfAddrCacheMutex);
 

--- a/engine/script/src/test/test_script_sys.cpp
+++ b/engine/script/src/test/test_script_sys.cpp
@@ -17,6 +17,7 @@
 
 #include <testmain/testmain.h>
 #include <dlib/log.h>
+#include <dlib/socket.h>
 
 class ScriptSysTest : public dmScriptTest::ScriptTest
 {
@@ -52,6 +53,9 @@ int main(int argc, char **argv)
 {
     dmExportedSymbols();
     TestMainPlatformInit();
+    dmSocket::Initialize();
     jc_test_init(&argc, argv);
-    return jc_test_run_all();
+    int ret = jc_test_run_all();
+    dmSocket::Finalize();
+    return ret;
 }


### PR DESCRIPTION
This fixes an issue where calling the `dmSys::GetIfAddresses()` on Windows platforms could potentially stall for a very long time if it was called multiple times per frame.

From scripting side, this corresponds to the `sys.get_ifaddrs()`function.

### Technical changes

* Only allow an update every 1s
* Keeps thread safety using a `dmMutex::HMutex`
* Stores the returned data from GetAdaptersAddresses, in order to keep allocations to a minimum.

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
