### PR TITLE
Write Defold installation location to a well-known place

### DIFF
--- a/editor/src/clj/editor/boot.clj
+++ b/editor/src/clj/editor/boot.clj
@@ -142,8 +142,10 @@
         (fn write-installations-json-temp-file [temp-path]
           (with-open [writer (io/writer temp-path :encoding "UTF-8")]
             (-> (when (path/exists? registry-path)
-                  (with-open [reader (io/reader registry-path :encoding "UTF-8")]
-                    (json/read reader :key-fn keyword)))
+                  (try
+                    (with-open [reader (io/reader registry-path :encoding "UTF-8")]
+                      (json/read reader :key-fn keyword))
+                    (catch Exception _)))
                 (coll/into->
                   [{:launcherPath launcher-path
                     :installPath (str (case os

--- a/editor/src/clj/editor/boot.clj
+++ b/editor/src/clj/editor/boot.clj
@@ -13,16 +13,19 @@
 ;; specific language governing permissions and limitations under the License.
 
 (ns editor.boot
-  (:require [clojure.java.io :as io]
+  (:require [clojure.data.json :as json]
+            [clojure.java.io :as io]
             [clojure.stacktrace :as stack]
             [clojure.tools.cli :as cli]
             [editor.analytics :as analytics]
             [editor.connection-properties :refer [connection-properties]]
             [editor.dialogs :as dialogs]
             [editor.error-reporting :as error-reporting]
+            [editor.fs :as fs]
             [editor.gl :as gl]
             [editor.keymap :as keymap]
             [editor.localization :as localization]
+            [editor.os :as os]
             [editor.prefs :as prefs]
             [editor.progress :as progress]
             [editor.system :as system]
@@ -30,9 +33,12 @@
             [editor.updater :as updater]
             [editor.welcome :as welcome]
             [service.log :as log]
+            [util.coll :as coll]
+            [util.path :as path]
             [util.repo :as repo])
   (:import [com.defold.editor Shutdown]
            [com.dynamo.bob.archive EngineVersion]
+           [java.time Instant]
            [java.util Arrays]
            [javax.imageio ImageIO]))
 
@@ -100,12 +106,12 @@
 
 (defn- set-sha1-revisions-from-repo! []
   ;; Use the sha1 of the HEAD commit as the editor revision.
-  (when (empty? (system/defold-editor-sha1))
+  (when (coll/empty? (system/defold-editor-sha1))
     (when-some [editor-sha1 (repo/detect-editor-sha1)]
       (system/set-defold-editor-sha1! editor-sha1)))
 
   ;; If we don't have an engine sha1 specified, use the sha1 from Bob.
-  (when (empty? (system/defold-engine-sha1))
+  (when (coll/empty? (system/defold-engine-sha1))
     (system/set-defold-engine-sha1! EngineVersion/sha1)))
 
 (defn disable-imageio-cache!
@@ -117,6 +123,37 @@
   ;; Path to preference file, mainly used for testing
   [["-prefs" "--preferences PATH" "Path to preferences file"]
    ["-p" "--port PORT" "Editor server port" :default 0 :parse-fn ^[String] Long/valueOf]])
+
+(defn write-installations-json! [launcher-path resources-path]
+  (try
+    (let [os (os/os)
+          launcher-path (str (path/real launcher-path))
+          registry-path (path/of
+                          (case os
+                            :macos (fs/evaluate-path "~/Library/Preferences")
+                            :linux (or (fs/evaluate-path "$XDG_CONFIG_HOME")
+                                       (fs/evaluate-path "~/.config"))
+                            :win32 (or (fs/evaluate-path "$APPDATA")
+                                       (fs/evaluate-path "~/AppData/Roaming")))
+                          "Defold"
+                          "installations.json")]
+      (path/atomic-replace!
+        registry-path
+        (fn write-installations-json-temp-file [temp-path]
+          (with-open [writer (io/writer temp-path :encoding "UTF-8")]
+            (-> (when (path/exists? registry-path)
+                  (with-open [reader (io/reader registry-path :encoding "UTF-8")]
+                    (json/read reader :key-fn keyword)))
+                (coll/into->
+                  [{:launcherPath launcher-path
+                    :installPath (str (case os
+                                        :macos (path/real resources-path "../..")
+                                        (:linux :win32) (path/real resources-path)))
+                    :lastLaunchedAt (str (Instant/now))}]
+                  (remove #(= launcher-path (:launcherPath %))))
+                (json/write writer))))))
+    (catch Exception e
+      (log/warn :message "Failed to write installations.json." :exception e))))
 
 ;; Entry point from java EditorApplication is in editor.bootloader/main, which calls this function.
 (defn main [args namespace-loader]
@@ -134,6 +171,10 @@
         analytics-url (:analytics-url connection-properties)
         analytics-send-interval 300
         cid (analytics/start! analytics-url localization analytics-send-interval)]
+    (when-not (system/defold-dev?)
+      (when-let [launcher-path (system/defold-launcherpath)]
+        (when-let [resources-path (system/defold-resourcespath)]
+          (write-installations-json! launcher-path resources-path))))
     (Shutdown/addShutdownAction analytics/shutdown!)
     (error-reporting/setup-error-reporting! {:notifier {:notify-fn (partial notify-user localization)}
                                              :sentry (-> connection-properties

--- a/editor/src/clj/util/path.clj
+++ b/editor/src/clj/util/path.clj
@@ -21,7 +21,7 @@
            [java.io BufferedInputStream BufferedOutputStream File]
            [java.net URI URL]
            [java.nio.charset Charset StandardCharsets]
-           [java.nio.file CopyOption FileVisitResult FileVisitor Files LinkOption NoSuchFileException OpenOption Path StandardOpenOption]
+           [java.nio.file AtomicMoveNotSupportedException CopyOption FileVisitResult FileVisitor Files LinkOption NoSuchFileException OpenOption Path StandardCopyOption StandardOpenOption]
            [java.nio.file.attribute BasicFileAttributes FileAttribute FileTime]
            [java.util Set]
            [java.util.regex Pattern]))
@@ -30,6 +30,8 @@
 (set! *unchecked-math* :warn-on-boxed)
 
 (defonce ^:private ^CopyOption/1 empty-copy-option-array (make-array CopyOption 0))
+(defonce ^:private ^CopyOption/1 atomic-replace-copy-options (into-array CopyOption [StandardCopyOption/ATOMIC_MOVE StandardCopyOption/REPLACE_EXISTING]))
+(defonce ^:private ^CopyOption/1 replace-existing-copy-options (into-array CopyOption [StandardCopyOption/REPLACE_EXISTING]))
 (defonce ^:private ^FileAttribute/1 empty-file-attribute-array (make-array FileAttribute 0))
 (defonce ^:private ^String/1 empty-string-array (make-array String 0))
 
@@ -413,6 +415,31 @@
   (let [path (to-path x)]
     (when-let [parent (.getParent path)]
       (create-directories! parent))
+    path))
+
+(defn atomic-replace!
+  "Coerces the argument to a java.nio.file.Path, creates a temporary file in
+  the same directory, passes the temp Path to write-temp-path-fn, then replaces
+  the target path with the temp file.
+
+  The same-directory temp file gives Files/move with ATOMIC_MOVE the best
+  chance to be supported by the filesystem. If atomic move is unsupported, this
+  falls back to a replace-only move. This avoids exposing partially-written
+  target files during normal operation, but it does not fsync the temp file or
+  directory and should not be treated as durable transaction storage. Returns
+  the target Path."
+  ^Path
+  [path write-temp-path-fn]
+  (let [path (create-parent-directories! path)
+        temp-path (Files/createTempFile (parent path) (str (leaf path) ".") ".tmp" empty-file-attribute-array)]
+    (try
+      (write-temp-path-fn temp-path)
+      (try
+        (Files/move temp-path path atomic-replace-copy-options)
+        (catch AtomicMoveNotSupportedException _
+          (Files/move temp-path path replace-existing-copy-options)))
+      (finally
+        (Files/deleteIfExists temp-path)))
     path))
 
 (defn create-symlink!

--- a/editor/src/clj/util/path.clj
+++ b/editor/src/clj/util/path.clj
@@ -427,10 +427,11 @@
   falls back to a replace-only move. This avoids exposing partially-written
   target files during normal operation, but it does not fsync the temp file or
   directory and should not be treated as durable transaction storage. Returns
-  the target Path."
+  the absolute target Path."
   ^Path
   [path write-temp-path-fn]
-  (let [path (create-parent-directories! path)
+  (let [path (absolute path)
+        path (create-parent-directories! path)
         temp-path (Files/createTempFile (parent path) (str (leaf path) ".") ".tmp" empty-file-attribute-array)]
     (try
       (write-temp-path-fn temp-path)

--- a/editor/test/editor/boot_test.clj
+++ b/editor/test/editor/boot_test.clj
@@ -31,11 +31,15 @@
           launcher-b (path/of install-root "DefoldB")
           registry-path (path/of config-root "Defold" "installations.json")
           resources-a (path/of install-root "DefoldA.app" "Contents" "Resources")
-          resources-b (path/of install-root "DefoldB.app" "Contents" "Resources")]
+          resources-b (path/of install-root "DefoldB.app" "Contents" "Resources")
+          launcher-c (path/of install-root "DefoldC")
+          resources-c (path/of install-root "DefoldC.app" "Contents" "Resources")]
       (path/create-directories! resources-a)
       (path/create-directories! resources-b)
+      (path/create-directories! resources-c)
       (spit launcher-a "")
       (spit launcher-b "")
+      (spit launcher-c "")
 
       (with-redefs [fs/evaluate-path (fn evaluate-path [raw-path]
                                        (case raw-path
@@ -45,8 +49,17 @@
         (boot/write-installations-json! launcher-a resources-a)
         (boot/write-installations-json! launcher-b resources-b)
         (boot/write-installations-json! launcher-a resources-a)
+        (boot/write-installations-json! (path/relativize (path/absolute ".") launcher-c) resources-c)
 
         (let [installations (json/read-str (slurp registry-path) :key-fn keyword)]
-          (is (= [(str (path/real launcher-a))
+          (is (= [(str (path/real launcher-c))
+                  (str (path/real launcher-a))
                   (str (path/real launcher-b))]
+                 (mapv :launcherPath installations))))
+
+        (spit registry-path "{")
+        (boot/write-installations-json! launcher-b resources-b)
+
+        (let [installations (json/read-str (slurp registry-path) :key-fn keyword)]
+          (is (= [(str (path/real launcher-b))]
                  (mapv :launcherPath installations))))))))

--- a/editor/test/editor/boot_test.clj
+++ b/editor/test/editor/boot_test.clj
@@ -1,0 +1,52 @@
+;; Copyright 2020-2026 The Defold Foundation
+;; Copyright 2014-2020 King
+;; Copyright 2009-2014 Ragnar Svensson, Christian Murray
+;; Licensed under the Defold License version 1.0 (the "License"); you may not use
+;; this file except in compliance with the License.
+;;
+;; You may obtain a copy of the License, together with FAQs at
+;; https://www.defold.com/license
+;;
+;; Unless required by applicable law or agreed to in writing, software distributed
+;; under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+;; CONDITIONS OF ANY KIND, either express or implied. See the License for the
+;; specific language governing permissions and limitations under the License.
+
+(ns editor.boot-test
+  (:require [clojure.data.json :as json]
+            [clojure.test :refer :all]
+            [editor.boot :as boot]
+            [editor.fs :as fs]
+            [editor.os :as os]
+            [integration.test-util :as test-util]
+            [util.path :as path]))
+
+(set! *warn-on-reflection* true)
+
+(deftest write-installations-json-test
+  (test-util/with-temp-dir! dir
+    (let [config-root (path/of dir "config")
+          install-root (path/of dir "install")
+          launcher-a (path/of install-root "DefoldA")
+          launcher-b (path/of install-root "DefoldB")
+          registry-path (path/of config-root "Defold" "installations.json")
+          resources-a (path/of install-root "DefoldA.app" "Contents" "Resources")
+          resources-b (path/of install-root "DefoldB.app" "Contents" "Resources")]
+      (path/create-directories! resources-a)
+      (path/create-directories! resources-b)
+      (spit launcher-a "")
+      (spit launcher-b "")
+
+      (with-redefs [fs/evaluate-path (fn evaluate-path [raw-path]
+                                       (case raw-path
+                                         "~/Library/Preferences" (str config-root)
+                                         nil))
+                    os/os (constantly :macos)]
+        (boot/write-installations-json! launcher-a resources-a)
+        (boot/write-installations-json! launcher-b resources-b)
+        (boot/write-installations-json! launcher-a resources-a)
+
+        (let [installations (json/read-str (slurp registry-path) :key-fn keyword)]
+          (is (= [(str (path/real launcher-a))
+                  (str (path/real launcher-b))]
+                 (mapv :launcherPath installations))))))))

--- a/editor/test/util/path_test.clj
+++ b/editor/test/util/path_test.clj
@@ -17,7 +17,7 @@
             [editor.fs :as fs]
             [integration.test-util :as test-util]
             [util.path :as path])
-  (:import [java.nio.file NoSuchFileException]))
+  (:import [java.nio.file Files NoSuchFileException]))
 
 (set! *warn-on-reflection* true)
 
@@ -80,3 +80,37 @@
         (is (= expected (path/real dir "SymlinkDirectory" "ExistingFile.txt")))
         (when-not fs/is-case-sensitive
           (is (= expected (path/real dir "symlinkDIRECTORY" "existingFILE.txt"))))))))
+
+(deftest atomic-replace-test
+  (test-util/with-temp-dir! dir
+    (testing "Creates parent directories and replaces the target."
+      (let [target (path/of dir "MissingDirectory" "target.txt")]
+        (is (= target (path/atomic-replace!
+                        target
+                        (fn write-temp-path [temp-path]
+                          (spit temp-path "first")))))
+        (is (= "first" (slurp target)))
+
+        (path/atomic-replace!
+          target
+          (fn write-temp-path [temp-path]
+            (spit temp-path "second")))
+        (is (= "second" (slurp target)))))
+
+    (testing "Propagates write failures, preserves the target, and cleans up the temp file."
+      (let [target (path/of dir "Failure" "target.txt")]
+        (path/create-parent-directories! target)
+        (spit target "original")
+
+        (is (thrown-with-msg?
+              Exception
+              #"write failed"
+              (path/atomic-replace!
+                target
+                (fn write-temp-path [temp-path]
+                  (spit temp-path "replacement")
+                  (throw (Exception. "write failed"))))))
+
+        (is (= "original" (slurp target)))
+        (with-open [paths (Files/list (path/parent target))]
+          (is (= #{target} (set (vec (.toArray paths))))))))))

--- a/editor/test/util/path_test.clj
+++ b/editor/test/util/path_test.clj
@@ -85,10 +85,7 @@
   (test-util/with-temp-dir! dir
     (testing "Creates parent directories and replaces the target."
       (let [target (path/of dir "MissingDirectory" "target.txt")]
-        (is (= target (path/atomic-replace!
-                        target
-                        (fn write-temp-path [temp-path]
-                          (spit temp-path "first")))))
+        (is (= (path/absolute target) (path/atomic-replace! target #(spit % "first"))))
         (is (= "first" (slurp target)))
 
         (path/atomic-replace!
@@ -96,6 +93,15 @@
           (fn write-temp-path [temp-path]
             (spit temp-path "second")))
         (is (= "second" (slurp target)))))
+
+    (testing "Supports target paths without a parent."
+      (let [target (path/of (str "atomic-replace-test-" (random-uuid) ".txt"))]
+        (try
+          (is (= (path/absolute target) (path/atomic-replace! target #(spit % "content"))))
+          (is (= "content" (slurp target)))
+          (finally
+            (when (path/exists? target)
+              (path/delete! target))))))
 
     (testing "Propagates write failures, preserves the target, and cleans up the temp file."
       (let [target (path/of dir "Failure" "target.txt")]


### PR DESCRIPTION
This should make it easier for third-party IDE integrations to discover where the Defold editor is located.

On startup, the editor writes its launcher and installation paths to:
| OS      | Location |
|---------|----------|
| macOS   | `~/Library/Application Support/Defold/installations.json` |
| Linux   | `${XDG_STATE_HOME:-~/.local/state}/Defold/installations.json` |
| Windows | `%LOCALAPPDATA%\Defold\installations.json` |

The file is a JSON array of objects, e.g.:
```json
[
  {
    "launcherPath": "/Applications/Defold.app/Contents/MacOS/Defold",
    "installPath": "/Applications/Defold.app",
    "lastLaunchedAt": "2026-07-06T12:34:56.789Z"
  }
]
```

Fix #12062 