### PR TITLE
Make sure the engine is not copied twice when bundling for Android

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/AndroidBundler.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/AndroidBundler.java
@@ -624,9 +624,9 @@ public class AndroidBundler implements IBundler {
 
                     // Skip libdmengine.so, libdmengine_release.so etc
                     // In a build without native extensions we will download
-                    // dmengine if it doesn't exist in bob.jar, see the two
+                    // dmengine if it doesn't exist in bob.jar (see the two
                     // methods getDefaultDmengineFiles() and downloadExes() in
-                    // EngineArtifactsProvider.java
+                    // EngineArtifactsProvider.java)
                     if (filename.contains("dmengine")) {
                         return false;
                     }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/AndroidBundler.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/AndroidBundler.java
@@ -622,7 +622,12 @@ public class AndroidBundler implements IBundler {
                     String filename = path.getFileName().toString();
                     String pathStr = path.toString();
 
-                    if (filename.equals("libdmengine.so")) {
+                    // Skip libdmengine.so, libdmengine_release.so etc
+                    // In a build without native extensions we will download
+                    // dmengine if it doesn't exist in bob.jar, see the two
+                    // methods getDefaultDmengineFiles() and downloadExes() in
+                    // EngineArtifactsProvider.java
+                    if (filename.contains("dmengine")) {
                         return false;
                     }
 
@@ -631,6 +636,7 @@ public class AndroidBundler implements IBundler {
                         return false;
                     }
 
+                    logger.info("Copying shared library " + filename);
                     return true;
                 });
                 BundleHelper.throwIfCanceled(canceled);


### PR DESCRIPTION
We download libdmengine.so, libdmengine_release.so or libdemengine_headless.so if it is not present in bob.jar. This resulted in a larger bundle due to the fact that the engine lib was copied a second time in release and headless builds. This fix makes sure that all variants of the engine are excluded when shared libraries are copied.

Fixes #12695