### PR TITLE
Improve toolbar refresh performance

### DIFF
--- a/editor/project.clj
+++ b/editor/project.clj
@@ -88,7 +88,7 @@
 
                      [com.github.ben-manes.caffeine/caffeine "3.1.2"]
 
-                     [cljfx "1.10.8"
+                     [cljfx "1.10.9"
                       :exclusions [org.clojure/clojure
                                    org.openjfx/javafx-base
                                    org.openjfx/javafx-graphics

--- a/editor/src/clj/editor/scene_visibility.clj
+++ b/editor/src/clj/editor/scene_visibility.clj
@@ -18,11 +18,12 @@
             [editor.handler :as handler]
             [editor.system :as system]
             [editor.types :as types]
+            [editor.ui :as ui]
             [editor.ui.settings-popup :as settings-popup]
             [internal.util :as iutil]
             [schema.core :as s])
   (:import [javafx.css PseudoClass]
-           [javafx.scene Parent]
+           [javafx.scene Node Parent]
            [javafx.scene.control Tab ToggleButton]))
 
 (set! *warn-on-reflection* true)
@@ -338,10 +339,10 @@
         (renderable-tag-descriptors scene-visibility)))
 
 (defn toggle-button [app-view]
-  (some-> ^Tab (g/node-value app-view :active-tab)
-          .getContent
-          (.lookup "#visibility-settings-graphic")
-          .getParent))
+  (some-> (g/node-value app-view :active-tab)
+          Tab/.getContent
+          (ui/lookup-by-id "visibility-settings-graphic")
+          Node/.getParent))
 
 (defn sync-filter-button-style! [app-view scene-visibility evaluation-context]
   (when-let [btn ^ToggleButton (toggle-button app-view)]

--- a/editor/src/clj/editor/ui.clj
+++ b/editor/src/clj/editor/ui.clj
@@ -57,7 +57,7 @@
            [java.awt Desktop Desktop$Action]
            [java.io File IOException]
            [java.net URI]
-           [java.util Collection]
+           [java.util ArrayDeque Collection]
            [javafx.animation AnimationTimer KeyFrame KeyValue Timeline]
            [javafx.application Platform]
            [javafx.beans InvalidationListener Observable]
@@ -286,8 +286,27 @@
            (.initOwner stage owner)))
      stage)))
 
+(defn lookup-by-id
+  "Find node by id, significantly faster than Node/.lookup"
+  [^Node root ^String id]
+  (let [nodes (ArrayDeque.)]
+    (loop [node root]
+      (if (= id (.getId node))
+        node
+        (do
+          (when (instance? Parent node)
+            ;; Push children in reverse order so LIFO deque traversal visits
+            ;; siblings in normal child order.
+            (let [children (.getChildrenUnmodifiable ^Parent node)]
+              (loop [i (dec (.size children))]
+                (when-not (neg? i)
+                  (.push nodes (.get children i))
+                  (recur (dec i))))))
+          (when-not (.isEmpty nodes)
+            (recur (.pop nodes))))))))
+
 (defn collect-controls [^Parent root keys]
-  (let [controls (zipmap (map keyword keys) (map #(.lookup root (str "#" %)) keys))
+  (let [controls (zipmap (map keyword keys) (map #(lookup-by-id root %) keys))
         missing (->> controls
                   (filter (fn [[k v]] (when (nil? v) k)))
                   (map first))]


### PR DESCRIPTION
After implementing #12706, I decided to measure the performance of toolbar updates. 

Baseline before cljfx: 0.86-0.96 ms per noop update, 4.10-5.88ms per modifying update
After #12706: 1.46-1.61ms per noop update, 5.64-6.95 per modifying update.

Here is how the refresh toolbars CPU profile looked after cljfx migration:
<img width="1370" height="768" alt="Screenshot 2026-07-09 at 10 05 22" src="https://github.com/user-attachments/assets/2c361408-6977-4c14-a94b-f02464f495a0" />
cljfx is a big part, but so are Node lookups in scene visibility refresh

So, using cljfx introduced a perf regression. This PR fixes it, with the following numbers: ~0.68 ms per noop update, 2.29-2.47ms per modifying update. Here is the new profile:

<img width="1371" height="764" alt="Screenshot 2026-07-09 at 10 08 03" src="https://github.com/user-attachments/assets/483ff058-cf3a-4dc7-bd01-e74c21b686ee" />
Node lookups disappeared, and cljfx became a smaller piece of the pie too.