### PR TITLE
Add `/preview` endpoint that returns scenes as PNGs

### DIFF
--- a/editor/src/clj/editor/boot_open_project.clj
+++ b/editor/src/clj/editor/boot_open_project.clj
@@ -218,6 +218,7 @@
                                   (console/routes console-view)
                                   (hot-reload/routes workspace)
                                   (bob/routes project)
+                                  (scene/routes project app-view)
                                   (command-requests/router root localization (app-view/make-render-task-progress :resource-sync))
                                   (doc/routes)
                                   (http-server.prefs/routes prefs)]))

--- a/editor/src/clj/editor/camera.clj
+++ b/editor/src/clj/editor/camera.clj
@@ -45,6 +45,8 @@
 (def fov-x-35mm-full-frame 54.4)
 (def fov-y-35mm-full-frame 37.8)
 
+(def ^:const orthographic-framing-margin 1.1)
+
 (def vector3-up (Vector3d. 0.0 1.0 0.0))
 
 (defn camera-forward-vector
@@ -547,14 +549,14 @@
               factor-y (/ proj-height h)
               fov-x-prim  (* factor-x (.fov-x camera))
               fov-y-prim  (* factor-y (.fov-y camera))]
-          [(* 1.1 fov-x-prim) (* 1.1 fov-y-prim)])))))
+          [(* orthographic-framing-margin fov-x-prim) (* orthographic-framing-margin fov-y-prim)])))))
 
 (defn camera-orthographic-frame-aabb
   ^Camera [^Camera camera ^Region viewport ^AABB aabb]
   {:pre [(= :orthographic (:type camera))]}
   (let [aspect (/ ^double (:fov-x camera) ^double (:fov-y camera))
         [^double fov-x ^double fov-y] (camera-orthographic-fov-from-aabb camera viewport aabb)
-        [fov-x fov-y] (if (> (/ fov-x aspect) (* aspect fov-y))
+        [fov-x fov-y] (if (> (/ fov-x aspect) fov-y)
                         [fov-x (/ fov-x aspect)]
                         [(* aspect fov-y) fov-y])
         filter-fn (or (:filter-fn camera) identity)]

--- a/editor/src/clj/editor/scene.clj
+++ b/editor/src/clj/editor/scene.clj
@@ -20,10 +20,12 @@
             [cljfx.fx.text-area :as fx.text-area]
             [clojure.set :as set]
             [clojure.spec.alpha :as s]
+            [clojure.string :as string]
             [dynamo.graph :as g]
             [editor.background :as background]
             [editor.camera :as c]
             [editor.colors :as colors]
+            [editor.defold-project :as project]
             [editor.editor-extensions.node-types :as node-types]
             [editor.error-reporting :as error-reporting]
             [editor.fxui :as fxui]
@@ -65,6 +67,7 @@
             [editor.workspace :as workspace]
             [service.log :as log]
             [util.coll :as coll :refer [pair]]
+            [util.http-server :as http-server]
             [util.profiler :as profiler])
   (:import [com.jogamp.opengl GL GL2 GLAutoDrawable GLContext GLOffscreenAutoDrawable]
            [com.jogamp.opengl.glu GLU]
@@ -72,6 +75,7 @@
            [editor.pose Pose]
            [editor.types AABB Camera Rect Region]
            [java.awt.image BufferedImage]
+           [java.io ByteArrayOutputStream]
            [java.lang Math Runnable]
            [java.nio IntBuffer]
            [javafx.beans.value ChangeListener]
@@ -83,6 +87,7 @@
            [javafx.scene.input KeyCode KeyEvent]
            [javafx.scene.layout AnchorPane Pane]
            [javafx.stage Window]
+           [javax.imageio ImageIO]
            [javax.vecmath Matrix4d Point3d Quat4d Tuple3d Vector3d]
            [sun.awt.image IntegerComponentRaster]))
 
@@ -1517,6 +1522,23 @@
                        (selection-framing-info view-node-id evaluation-context))]
     (apply-framing-info! framing-info animate?)))
 
+(defn- frame-preview! [view-node-id]
+  (g/let-ec [framing-info (selection-framing-info view-node-id evaluation-context)
+             viewport (g/node-value view-node-id :viewport evaluation-context)
+             [viewport-width viewport-height] (vp-dims viewport)]
+    (apply-framing-info!
+      (update framing-info :end-camera
+              (fn [camera]
+                (if-not (= :orthographic (:type camera))
+                  camera
+                  (let [fov-x (/ (:fov-x camera) c/orthographic-framing-margin)
+                        fov-y (/ (:fov-y camera) c/orthographic-framing-margin)]
+                    (assoc camera
+                      ;; Add a one-pixel margin on each side to avoid edge clipping.
+                      :fov-x (+ fov-x (* 2.0 (/ fov-x viewport-width)))
+                      :fov-y (+ fov-y (* 2.0 (/ fov-y viewport-height))))))))
+      false)))
+
 (handler/defhandler :scene.frame-selection :global
   (active? [app-view evaluation-context]
     (active-scene-view app-view evaluation-context))
@@ -2030,6 +2052,13 @@
         (scene-cache/prune-context! gl)
         buf-image))))
 
+(g/defnk produce-preview-renderables [aux-render-data scene-render-data]
+  (:renderables
+    (merge-render-datas
+      {:renderables (select-keys (:renderables aux-render-data) [pass/background])}
+      {}
+      scene-render-data)))
+
 (g/defnode PreviewView
   (inherits view/WorkbenchView)
   (inherits SceneRenderer)
@@ -2067,7 +2096,7 @@
   (output tool-selection g/Any :cached produce-tool-selection)
   (output selected-tool-renderables g/Any :cached produce-selected-tool-renderables)
   (output frame BufferedImage produce-frame)
-  (output all-renderables pass/RenderData :cached (g/fnk [scene-render-data] (:renderables (merge-render-datas {} {} scene-render-data))))
+  (output all-renderables pass/RenderData :cached produce-preview-renderables)
   (output image WritableImage :cached (g/fnk [frame] (when frame (SwingFXUtils/toFXImage frame nil))))
   (output displayed-node-properties g/Any :cached
           (g/fnk [selected-node-properties preview-overrides]
@@ -2136,7 +2165,8 @@
                   (g/connect view-id         :scene-aabb                    camera          :scene-aabb)
                   (g/connect view-id         :viewport                      camera          :viewport)
 
-                  (g/connect app-view-id     :selected-node-ids             view-id         :selection)
+                  (when (:inherit-selection opts true)
+                    (g/connect app-view-id   :selected-node-ids             view-id         :selection))
                   (g/connect app-view-id     :active-view                   view-id         :active-view)
                   (g/connect app-view-id     :active-tool                   view-id         :active-tool)
                   (g/connect app-view-id     :manip-space                   view-id         :manip-space)
@@ -2191,15 +2221,24 @@
                  (dissoc :grid))]
     (g/transact
       (setup-view view-id resource-node opts))
-    (frame-selection! view-id false)
+    (frame-preview! view-id)
     view-id))
 
-(defn dispose-preview [node-id]
-  (when-some [^GLAutoDrawable drawable (g/node-value node-id :drawable)]
-    (gl/with-drawable-as-current drawable
-      (scene-cache/drop-context! gl))
-    (.destroy drawable)
-    (g/set-property! node-id :drawable nil)))
+(defn dispose-preview
+  ([node-id]
+   (g/with-auto-evaluation-context evaluation-context
+     (dispose-preview node-id evaluation-context)))
+  ([node-id evaluation-context]
+   (when-some [^GLAutoDrawable drawable (g/node-value node-id :drawable evaluation-context)]
+     (gl/with-drawable-as-current drawable
+       (scene-cache/drop-context! gl))
+     (.destroy drawable)
+     (g/set-property! node-id :drawable nil))
+   (when-some [^GLAutoDrawable picking-drawable (g/node-value node-id :picking-drawable evaluation-context)]
+     (gl/with-drawable-as-current picking-drawable
+       (scene-cache/drop-context! gl))
+     (.destroy picking-drawable)
+     (g/set-property! node-id :picking-drawable nil))))
 
 (defn- focus-view! [view-id _opts done-fn]
   (if-some [^ImageView image-view (g/node-value view-id :image-view)]
@@ -2334,3 +2373,72 @@
 
 (defmethod scene-tools/manip-scale ::SceneNode [node-id ^Vector3d delta manip-phase initial-evaluation-context]
   (manip-scale-scene-node node-id delta manip-phase initial-evaluation-context))
+
+(defn- render-preview-response [project app-view request]
+  (g/let-ec [params (coll/into-> (string/split (:query request "") #"&") {}
+                      (map
+                        (fn [s]
+                          (let [[k v] (string/split s #"=" 2)]
+                            [(keyword k) (or v "")]))))
+             width (or (some-> (:width params) parse-long)
+                       (g/node-value project :display-width evaluation-context))
+             height (or (some-> (:height params) parse-long)
+                        (g/node-value project :display-height evaluation-context))
+             _ (when-not (and (<= 1 width 4096) (<= 1 height 4096))
+                 (throw (http-server/error (http-server/response 400 "Invalid dimensions\n"))))
+             workspace (project/workspace project evaluation-context)
+             resource (or (workspace/find-resource (:basis evaluation-context) workspace (str "/" (:path (:path-params request))))
+                          (throw (http-server/error http-server/not-found)))
+             resource-type (resource/lookup-resource-type (:basis evaluation-context) workspace resource)
+             resource-node (or (project/get-resource-node project resource evaluation-context)
+                               (throw (http-server/error (http-server/response 422 "Resource is not loaded\n"))))
+             view-type (or (coll/first-where #(= :scene (:id %)) (:view-types resource-type))
+                           (throw (http-server/error (http-server/response 422 "Resource does not support previews\n"))))
+             make-preview-fn (:make-preview-fn view-type)]
+    (let [view-graph (g/make-graph! :history false :volatility 2)]
+      (try
+        (let [opts (assoc (:scene (:view-opts resource-type))
+                     :app-view app-view
+                     :camera (c/make-camera :orthographic identity {:fov-x width :fov-y height})
+                     :select-fn (fn [_selection _op-seq])
+                     :inherit-selection false
+                     :project project
+                     :workspace workspace)
+              preview (make-preview-fn view-graph resource-node opts width height)]
+          (g/with-auto-evaluation-context evaluation-context
+            (try
+              (let [out (ByteArrayOutputStream.)
+                    ^BufferedImage frame (g/node-value preview :frame evaluation-context)
+                    flipped-frame (BufferedImage. (.getWidth frame) (.getHeight frame) (.getType frame))
+                    graphics (.createGraphics flipped-frame)]
+                (try
+                  (.drawImage graphics frame 0 (.getHeight frame) (.getWidth frame) (- (.getHeight frame)) nil)
+                  (finally
+                    (.dispose graphics)))
+                (ImageIO/write flipped-frame "png" out)
+                (http-server/response 200 {"content-type" "image/png"} (.toByteArray out)))
+              (finally
+                (dispose-preview preview evaluation-context)))))
+        (finally
+          (g/delete-graph! view-graph))))))
+
+(defn routes [project app-view]
+  {"/preview/{*path}"
+   {"GET" (with-meta
+            (bound-fn [request]
+              @(fx/on-fx-thread
+                 (render-preview-response project app-view request)))
+            {:openapi
+             {:summary "Render scene resource as PNG"
+              :parameters [{:name "path"
+                            :in "path"
+                            :required true
+                            :description "Project path"
+                            :schema {:type "string"}}
+                           {:name "width"
+                            :in "query"
+                            :schema {:type "integer"}}
+                           {:name "height"
+                            :in "query"
+                            :schema {:type "integer"}}]
+              :responses {"200" {:content {"image/png" {}}}}}})}})

--- a/editor/test/editor/camera_test.clj
+++ b/editor/test/editor/camera_test.clj
@@ -39,6 +39,21 @@
           proj (c/camera-projection-matrix framed-camera)]
       (is (.epsilonEquals proj-before proj math/epsilon)))))
 
+(deftest frame-wide-aabb
+  (testing "Framing a wide AABB should fit the whole bounds in the viewport"
+    (let [camera (c/make-camera :orthographic identity {:fov-x 960.0
+                                                        :fov-y 640.0})
+          viewport (t/->Region 0 960 0 640)
+          aabb (t/->AABB (Point3d. 0.0 0.0 0.0)
+                          (Point3d. 1224.0 640.0 0.0))
+          camera (c/camera-orthographic-frame-aabb camera viewport aabb)
+          min-proj (c/camera-project camera viewport (.. aabb min))
+          max-proj (c/camera-project camera viewport (.. aabb max))]
+      (is (<= (:left viewport) (.x min-proj) (:right viewport)))
+      (is (<= (:left viewport) (.x max-proj) (:right viewport)))
+      (is (<= (:top viewport) (.y min-proj) (:bottom viewport)))
+      (is (<= (:top viewport) (.y max-proj) (:bottom viewport))))))
+
 (deftest look-rotation-pitch-clamp
   (testing "Pitch should clamp at ±86 degrees even with extreme dy input"
     (let [camera (c/make-camera :perspective)

--- a/editor/test/integration/web_server_test.clj
+++ b/editor/test/integration/web_server_test.clj
@@ -31,6 +31,7 @@
             [editor.pipeline.bob :as bob]
             [editor.prefs :as prefs]
             [editor.progress :as progress]
+            [editor.scene :as scene]
             [editor.ui :as ui]
             [editor.web-server :as web-server]
             [editor.workspace :as workspace]
@@ -44,7 +45,8 @@
            [java.nio.charset StandardCharsets]
            [javafx.scene Scene]
            [javafx.scene.layout Region]
-           [javafx.stage Stage]))
+           [javafx.stage Stage]
+           [javax.imageio ImageIO]))
 
 (set! *warn-on-reflection* true)
 
@@ -296,6 +298,7 @@
                                              (console/routes console-view)
                                              (hot-reload/routes workspace)
                                              (bob/routes project)
+                                             (scene/routes project app-view)
                                              (command-requests/router root test-util/localization progress/null-render-progress!)
                                              (doc/routes)])))]
           (let [url (http-server/local-url server)]
@@ -313,6 +316,7 @@
                        (get-in json-body ["components" "securitySchemes" "token" "description"])))
                 (is (contains? (get json-body "paths") "/console"))
                 (is (contains? (get json-body "paths") "/console/stream"))
+                (is (contains? (get json-body "paths") "/preview/{path}"))
                 (let [get-ref (get-in json-body ["paths" "/ref" "get"])
                       param-names (into #{} (map #(get % "name")) (get get-ref "parameters"))]
                   (is get-ref)
@@ -321,6 +325,20 @@
                   (is (= "Execute an editor command" (get post-command "summary")))
                   (is (string/includes? (get post-command "description") "`build-html5`"))
                   (is (some #{"build-html5"} (get-in post-command ["parameters" 0 "schema" "enum"]))))))
+            (let [{:keys [status headers body]} @(http/request
+                                                    (str url "/preview/collection/components/test.gui?width=32&height=32")
+                                                    :as :byte-array)]
+              (is (= 200 status))
+              (is (= "image/png" (get headers "content-type")))
+              (is (= [0x89 0x50 0x4e 0x47 0x0d 0x0a 0x1a 0x0a]
+                     (into []
+                           (comp
+                             (take 8)
+                             (map #(bit-and 0xff %)))
+                           body)))
+              (let [image (ImageIO/read (ByteArrayInputStream. body))]
+                (is (= 32 (.getWidth image)))
+                (is (= 32 (.getHeight image)))))
             (let [{:keys [status headers body]} @(http/request (str url "/ref?environment=runtime&language=Lua&q=go.property") :as :string)
                   json-body (json/read-str body :key-fn keyword)]
               (is (= 200 status))

--- a/editor/test/integration/web_server_test.clj
+++ b/editor/test/integration/web_server_test.clj
@@ -330,12 +330,6 @@
                                                     :as :byte-array)]
               (is (= 200 status))
               (is (= "image/png" (get headers "content-type")))
-              (is (= [0x89 0x50 0x4e 0x47 0x0d 0x0a 0x1a 0x0a]
-                     (into []
-                           (comp
-                             (take 8)
-                             (map #(bit-and 0xff %)))
-                           body)))
               (let [image (ImageIO/read (ByteArrayInputStream. body))]
                 (is (= 32 (.getWidth image)))
                 (is (= 32 (.getHeight image)))))


### PR DESCRIPTION
Now, the editor's HTTP server can return PNGs of scenes in the project. This is useful for agentic workflows that need to see what the scene looks like when an agent edits it. As usual, the endpoint is documented in the OpenAPI spec, so the only thing your agent needs to use it is still the URL `http://localhost:$(cat .internal/editor.port)/openapi.json`.

Fix #12690