### PR TITLE
Close Add Component context menu on selecting a component

### DIFF
--- a/editor/src/clj/editor/ui.clj
+++ b/editor/src/clj/editor/ui.clj
@@ -1620,7 +1620,9 @@
       (some-> content
               (.lookup ".grid-menu-item-enabled")
               (.requestFocus)))))
-
+;; NOTE: make-grid-menu sets :hide-on-click to false because a CustomMenuItem can have headers and
+;; empty space that we don't want dismissing the context menu when clicked on. So manually walk up
+;; the PopupWindow and hide them
 (defn- hide-popup-window-chain! [^Event event]
   (let [node ^Node (.getSource event)]
     (loop [window (some-> node .getScene .getWindow)]

--- a/editor/src/clj/editor/ui.clj
+++ b/editor/src/clj/editor/ui.clj
@@ -1621,6 +1621,13 @@
               (.lookup ".grid-menu-item-enabled")
               (.requestFocus)))))
 
+(defn- hide-popup-window-chain! [^Event event]
+  (let [node ^Node (.getSource event)]
+    (loop [window (some-> node .getScene .getWindow)]
+      (when (instance? PopupWindow window)
+        (.hide ^PopupWindow window)
+        (recur (.getOwnerWindow ^PopupWindow window))))))
+
 (defn- make-grid-menu
   "Create a grid-based menu component with categorized items arranged in columns
 
@@ -1691,10 +1698,13 @@
                                     {:fx/type fx.button/lifecycle
                                      :text (localization label)
                                      :disable (not enabled?)
-                                     :on-action (fn [_] (invoke-handler (contexts scene false) command user-data))
+                                     :on-action (fn [e]
+                                                  (hide-popup-window-chain! e)
+                                                  (invoke-handler (contexts scene false) command user-data))
                                      :on-key-pressed (fn [^KeyEvent e]
                                                        (when (= KeyCode/ENTER (.getCode e))
                                                          (.consume e)
+                                                         (hide-popup-window-chain! e)
                                                          (invoke-handler (contexts scene false) command user-data)))
                                      :on-mouse-entered (fn [^MouseEvent e] (.requestFocus ^Node (.getSource e)))
                                      :style-class (into ["grid-menu-item-base"]


### PR DESCRIPTION
This fixes an issue where the Add Component context menu remained open after selecting a component in the scene view.

Fix #12638