### PR TITLE
Implement HTTP file download in editor scripts

### DIFF
--- a/editor/src/clj/editor/editor_extensions.clj
+++ b/editor/src/clj/editor/editor_extensions.clj
@@ -66,10 +66,11 @@
            [com.dynamo.bob Platform]
            [com.dynamo.bob.bundle BundleHelper]
            [com.dynamo.bob.util Library$Result]
-           [java.io PrintStream PushbackReader]
+           [java.io InputStream PrintStream PushbackReader]
            [java.net URI]
            [java.nio.file FileAlreadyExistsException Files NotDirectoryException Path]
            [java.util HashSet]
+           [java.util.concurrent ExecutionException]
            [org.apache.commons.io FilenameUtils]
            [org.luaj.vm2 LuaError LuaFunction LuaString LuaTable LuaValue Prototype]))
 
@@ -623,35 +624,60 @@
 
 (def http-request-options-coercer
   (coerce/one-of
-    (coerce/hash-map
-      :opt {:method coerce/string
-            :headers (coerce/map-of coerce/string coerce/string)
-            :body coerce/string
-            :as (coerce/enum :string :json)}
-      :extra-keys false)
+    (coerce/wrap-with-pred
+      (coerce/hash-map
+        :opt {:method coerce/string
+              :headers (coerce/map-of coerce/string coerce/string)
+              :body coerce/string
+              :as (coerce/enum :string :json)
+              :path coerce/string}
+        :extra-keys false)
+      #(not (and (contains? % :as) (contains? % :path)))
+      "specifies mutually exclusive 'as' and 'path' options")
     coerce/null))
 
-(def ext-http-request
+(defn- make-ext-http-request-fn [^Path project-path reload-resources!]
   (rt/suspendable-lua-fn ext-http-request
     ([ctx lua-url]
      (ext-http-request ctx lua-url nil))
     ([{:keys [rt]} lua-url maybe-lua-options]
      (let [options (some->> maybe-lua-options (rt/->clj rt http-request-options-coercer))
-           json (= :json (:as options))]
-       (try
-         (-> (http/request
-               (rt/->clj rt coerce/string lua-url)
-               (cond-> options json (assoc :as :input-stream)))
-             (future/then
-               (fn http-request-then [response]
-                 (cond-> response json (assoc :body (with-open [reader (io/reader (:body response))]
-                                                      (json/read reader))))))
-             (future/catch
-               (fn http-request-catch [e]
-                 (throw (LuaError. (str (or (ex-message e) (.getSimpleName (class e)))))))))
-         ;; we might get an exception when parsing the URI before we start the async request execution
-         (catch Throwable e
-           (throw (LuaError. (str (or (ex-message e) (.getSimpleName (class e))))))))))))
+           json (= :json (:as options))
+           path (:path options)]
+       (future/io
+         (try
+           (let [response @(http/request
+                             (rt/->clj rt coerce/string lua-url)
+                             (-> options (dissoc :path) (cond-> (or json path) (assoc :as :input-stream))))]
+             (cond
+               json
+               (assoc response :body (with-open [reader (io/reader (:body response))]
+                                       (json/read reader)))
+     
+               path
+               (with-open [^InputStream body (:body response)]
+                 (if-not (<= 200 (:status response) 299)
+                   (dissoc response :body)
+                   (let [destination (path/resolve-normalized project-path path)
+                         stored-path (path/atomic-replace!
+                                       destination
+                                       (fn write-response-body [temp-path]
+                                         (with-open [output (io/output-stream temp-path)]
+                                           (io/copy body output))))
+                         response (-> response
+                                      (dissoc :body)
+                                      (assoc :path (str stored-path)))]
+                     (if (path/starts-with? destination project-path)
+                       (do
+                         @(reload-resources!)
+                         (rt/and-refresh-context response))
+                       response))))
+     
+               :else
+               response))
+           (catch Throwable e
+             (let [e (if (instance? ExecutionException e) (ex-cause e) e)]
+               (throw (LuaError. (str (or (ex-message e) (.getSimpleName (class e))))))))))))))
 
 ;; endregion
 
@@ -1036,7 +1062,7 @@
                                   "version" (system/defold-version)
                                   "engine_sha1" (system/defold-engine-sha1)
                                   "editor_sha1" (system/defold-editor-sha1)}
-                        "http" {"request" ext-http-request
+                        "http" {"request" (make-ext-http-request-fn project-path reload-resources!)
                                 "server" (ext.http-server/env workspace project-path web-server)}
                         "image" (ext.image/env project-path)
                         "json" {"decode" ext-json-decode

--- a/editor/src/clj/editor/editor_extensions/docs.clj
+++ b/editor/src/clj/editor/editor_extensions/docs.clj
@@ -421,7 +421,10 @@ editor.create_resources({
                                       :doc "request body"}
                                      {:name "as"
                                       :types ["string"]
-                                      :doc "response body converter, either <code>\"string\"</code> or <code>\"json\"</code>"}]))}]
+                                      :doc "response body converter, either <code>\"string\"</code> or <code>\"json\"</code>; mutually exclusive with <code>path</code>"}
+                                     {:name "path"
+                                      :types ["string"]
+                                      :doc "destination file path, resolved against project root if relative; mutually exclusive with <code>as</code>"}]))}]
           :returnvalues [{:name "response"
                           :types ["table"]
                           :doc (str "HTTP response, a table with the following keys:"
@@ -434,7 +437,10 @@ editor.create_resources({
                                         :doc "response headers, a table where each key is a lower-cased string, and each value is either a string or an array of strings if the header was repeated"}
                                        {:name "body"
                                         :types ["string" "any" "nil"]
-                                        :doc "response body, present only when <code>as</code> option was provided, either a string or a parsed json value"}]))}]}
+                                        :doc "response body, present only when <code>as</code> option was provided, either a string or a parsed json value"}
+                                       {:name "path"
+                                        :types ["string" "nil"]
+                                        :doc "resolved absolute destination path, present only after a successful response was written when the <code>path</code> option was provided"}]))}]}
          {:name "http.server"
           :type :module
           :description "Editor's HTTP server-related functionality"}

--- a/editor/test/integration/editor_extensions_test.clj
+++ b/editor/test/integration/editor_extensions_test.clj
@@ -1120,26 +1120,38 @@ POST http://localhost:23456/echo {\"y\":\"foo\",\"x\":4} as json => 200
 }
 POST http://localhost:23456/echo hello world! as string => 200
 \"hello world!\"
+GET http://localhost:23456/download as string => error ({as = \"string\", path = \"downloaded.txt\"} does not satisfy any of its requirements:
+- {as = \"string\", path = \"downloaded.txt\"} specifies mutually exclusive 'as' and 'path' options
+- {as = \"string\", path = \"downloaded.txt\"} is not nil)
+download into project => 200
+resource exists before/after: false/true
+\"downloaded content\"
+download outside project => 200
+path matches: true
 ")
 
 (deftest http-test
-  (test-util/with-loaded-project "test/resources/editor_extensions/http_project"
-    (let [server (http-server/start!
-                   (http-server/router-handler
-                     {"/redirect/foo" {"GET" (constantly (http-server/redirect "/foo"))}
-                      "/foo" {"GET" (constantly (http-server/response 200 "successfully redirected"))}
-                      "/" {"GET" (constantly (http-server/response 200 ""))}
-                      "/json" {"GET" (constantly (http-server/json-response {:a 1 :b [true]}))}
-                      "/echo" {"POST" (fn [request] (http-server/response 200 (:body request)))}})
-                   :port 23456)
-          out (StringBuilder.)]
-      (try
-        (reload-editor-scripts! project :display-output! #(doto out (.append %2) (.append \newline)))
-        ;; See test.editor_script: the test invokes http.request with various options and prints results
-        (run-edit-menu-test-command!)
-        (expect-script-output expected-http-test-output out)
-        (finally
-          (http-server/stop! server 0))))))
+  (test-util/with-temp-dir! outside-directory
+    (test-util/with-scratch-project "test/resources/editor_extensions/http_project"
+      (let [outside-path (path/of outside-directory "downloaded.txt")
+            server (http-server/start!
+                     (http-server/router-handler
+                       {"/redirect/foo" {"GET" (constantly (http-server/redirect "/foo"))}
+                        "/foo" {"GET" (constantly (http-server/response 200 "successfully redirected"))}
+                        "/" {"GET" (constantly (http-server/response 200 ""))}
+                        "/json" {"GET" (constantly (http-server/json-response {:a 1 :b [true]}))}
+                        "/echo" {"POST" (fn [request] (http-server/response 200 (:body request)))}
+                        "/download" {"GET" (constantly (http-server/response 200 "downloaded content"))}
+                        "/outside-path" {"GET" (constantly (http-server/response 200 (str outside-path)))}})
+                     :port 23456)
+            out (StringBuilder.)]
+        (try
+          (reload-editor-scripts! project :display-output! #(doto out (.append %2) (.append \newline)))
+          ;; See test.editor_script: the test invokes http.request with various options and prints results
+          (run-edit-menu-test-command!)
+          (expect-script-output expected-http-test-output out)
+          (finally
+            (http-server/stop! server 0)))))))
 
 (def ^:private resource-io-test-output
   "editor.create_resources({{\"/test/config.json\", \"{\\\"test\\\": true}\"}}) => ok!

--- a/editor/test/resources/editor_extensions/http_project/test.editor_script
+++ b/editor/test/resources/editor_extensions/http_project/test.editor_script
@@ -16,6 +16,12 @@ local function test(url, opts)
     end
 end
 
+local function download(url, path, label)
+    local result = http.request(url, {path = path})
+    print(("download %s => %s"):format(label, result.status))
+    return result
+end
+
 function M.get_commands()
     return {{
         label = "Test",
@@ -29,6 +35,16 @@ function M.get_commands()
             test("http://localhost:23456/json", {as = "json"})
             test("http://localhost:23456/echo", {as = "json", method = "POST", body = json.encode({x = 4, y = "foo"})})
             test("http://localhost:23456/echo", {as = "string", method = "POST", body = "hello world!"})
+            test("http://localhost:23456/download", {as = "string", path = "downloaded.txt"})
+            local resource_path = "/downloaded.txt"
+            local existed_before = editor.resource_attributes(resource_path).exists
+            download("http://localhost:23456/download", "downloaded.txt", "into project")
+            local exists_after = editor.resource_attributes(resource_path).exists
+            print(("resource exists before/after: %s/%s"):format(tostring(existed_before), tostring(exists_after)))
+            print(("%q"):format(editor.get(resource_path, "text")))
+            local outside_path = http.request("http://localhost:23456/outside-path", {as = "string"}).body
+            local outside_result = download("http://localhost:23456/download", outside_path, "outside project")
+            print(("path matches: %s"):format(tostring(outside_result.path == outside_path)))
         end
     }}
 end


### PR DESCRIPTION
Now, you can download files using the `path` option of the `http.request` fn:

```lua
local response = http.request(url, {
    path = "downloads/archive.zip"
})
```