### PR TITLE
Fix exception when zooming in on an animation preview too much

### DIFF
--- a/editor/src/clj/editor/scene.clj
+++ b/editor/src/clj/editor/scene.clj
@@ -1120,8 +1120,8 @@
         y1 (- y0 scaled-height)
         left (- x1 preview-close-button-size)
         top y1]
-    {:anchor-pane/left (max 0.0 left)
-     :anchor-pane/top (max 0.0 top)}))
+    {:anchor-pane/left (max 0.0 (min left (- (double (:right viewport)) preview-close-button-size)))
+     :anchor-pane/top (max 0.0 (min top (- (double (:bottom viewport)) preview-close-button-size)))}))
 
 (defn- active-animation-anim-data [updatables active-updatable-ids]
   (some (fn [updatable-id]

--- a/editor/src/clj/editor/scene.clj
+++ b/editor/src/clj/editor/scene.clj
@@ -1108,20 +1108,18 @@
    :anchor-pane/right camera-inset-margin})
 
 (defn- animation-preview-anchor-props [camera viewport anim-data]
-  (let [[sx sy _] (c/scale-factor camera viewport)
-        offset texture-set/animation-preview-offset
+  (let [offset texture-set/animation-preview-offset
         image-width (double (:width anim-data))
         image-height (double (:height anim-data))
-        scaled-width (/ image-width sx)
-        scaled-height (/ image-height sy)
+        [scaled-width scaled-height] (texture-set/animation-preview-size camera viewport image-width image-height)
         x0 offset
         y0 (- (double (:bottom viewport)) offset)
         x1 (+ x0 scaled-width)
         y1 (- y0 scaled-height)
         left (- x1 preview-close-button-size)
         top y1]
-    {:anchor-pane/left (max 0.0 (min left (- (double (:right viewport)) preview-close-button-size)))
-     :anchor-pane/top (max 0.0 (min top (- (double (:bottom viewport)) preview-close-button-size)))}))
+    {:anchor-pane/left (max 0.0 left)
+     :anchor-pane/top (max 0.0 top)}))
 
 (defn- active-animation-anim-data [updatables active-updatable-ids]
   (some (fn [updatable-id]

--- a/editor/src/clj/editor/texture_set.clj
+++ b/editor/src/clj/editor/texture_set.clj
@@ -358,6 +358,22 @@
 
 (def ^:const animation-preview-offset 40.0)
 
+(defn animation-preview-size
+  [camera viewport ^double image-width ^double image-height]
+  (let [[^double sx ^double sy _] (camera/scale-factor camera viewport)
+        scaled-width (/ image-width sx)
+        scaled-height (/ image-height sy)
+        max-width (max 0.0 (- (double (:right viewport))
+                              (double (:left viewport))
+                              (* 2.0 animation-preview-offset)))
+        max-height (max 0.0 (- (double (:bottom viewport))
+                               (double (:top viewport))
+                               (* 2.0 animation-preview-offset)))
+        scale (min 1.0
+                   (/ max-width scaled-width)
+                   (/ max-height scaled-height))]
+    [(* scaled-width scale) (* scaled-height scale)]))
+
 (defn- animation-frame->vertex-floats
   [animation-frame world-transform]
   (let [size [(:width animation-frame)
@@ -394,13 +410,6 @@
 (defn render-animation-overlay
   [^GL2 gl render-args renderables]
   (let [{:keys [camera viewport]} render-args
-        [^double sx ^double sy ^double sz] (camera/scale-factor camera viewport)
-        scale-m (doto (Matrix4d.)
-                  (.setIdentity)
-                  (.setM00 (/ 1.0 sx))
-                  (.setM11 (- (/ 1.0 sy))) ; flip
-                  (.setM22 (/ 1.0 sz))
-                  (.setM33 1.0))
         world-pos (Vector3d. animation-preview-offset (- (double (:bottom viewport)) animation-preview-offset) 0.0)]
     (doseq [renderable renderables]
       (let [state (-> renderable :updatable :state)]
@@ -409,10 +418,15 @@
                 anim-data (:anim-data user-data)
                 image-width (double (:width anim-data))
                 image-height (double (:height anim-data))
+                [^double scaled-width ^double scaled-height] (animation-preview-size camera viewport image-width image-height)
+                scale-m (doto (Matrix4d.)
+                          (.setIdentity)
+                          (.setM00 (/ scaled-width image-width))
+                          (.setM11 (- (/ scaled-height image-height)))) ; flip
                 world-transform (doto (Matrix4d.)
                                   (.setIdentity)
-                                  (.setTranslation (Vector3d. (+ (.x world-pos) (* 0.5 (/ 1.0 sx) image-width))
-                                                              (- (.y world-pos) (* 0.5 (/ 1.0 sy) image-height))
+                                  (.setTranslation (Vector3d. (+ (.x world-pos) (* 0.5 scaled-width))
+                                                              (- (.y world-pos) (* 0.5 scaled-height))
                                                               0.0))
                                   (.mul scale-m))
                 vertex-count (anim-data->vertex-count anim-data frame)
@@ -422,8 +436,8 @@
                     gpu-texture (:gpu-texture user-data)
                     x0 (.x world-pos)
                     y0 (.y world-pos)
-                    x1 (+ x0 (* (/ 1.0 sx) image-width))
-                    y1 (- y0 (* (/ 1.0 sy) image-height))
+                    x1 (+ x0 scaled-width)
+                    y1 (- y0 scaled-height)
                     [cr cg cb ca] colors/outline-color
                     [xr xg xb xa] colors/scene-background]
                 (.glColor4d gl xr xg xb xa)

--- a/editor/src/clj/editor/texture_set.clj
+++ b/editor/src/clj/editor/texture_set.clj
@@ -360,7 +360,9 @@
 
 (defn animation-preview-size
   [camera viewport ^double image-width ^double image-height]
-  (let [[^double sx ^double sy _] (camera/scale-factor camera viewport)
+  (let [[sx sy _] (camera/scale-factor camera viewport)
+        sx (double sx)
+        sy (double sy)
         scaled-width (/ image-width sx)
         scaled-height (/ image-height sy)
         max-width (max 0.0 (- (double (:right viewport))
@@ -418,7 +420,9 @@
                 anim-data (:anim-data user-data)
                 image-width (double (:width anim-data))
                 image-height (double (:height anim-data))
-                [^double scaled-width ^double scaled-height] (animation-preview-size camera viewport image-width image-height)
+                [scaled-width scaled-height] (animation-preview-size camera viewport image-width image-height)
+                scaled-width (double scaled-width)
+                scaled-height (double scaled-height)
                 scale-m (doto (Matrix4d.)
                           (.setIdentity)
                           (.setM00 (/ scaled-width image-width))


### PR DESCRIPTION
Previously, excessive zooming could cause the animation preview in a scene view to become too large, causing GL errors. Now, we limit the size by the viewport.

Fix #12698