### PR TITLE
Fix issue when using number in call to vmath.matrix4_scale

### DIFF
--- a/engine/script/src/script_vmath.cpp
+++ b/engine/script/src/script_vmath.cpp
@@ -2517,6 +2517,7 @@ namespace dmScript
                 y = x; z = x;
             }
             PushMatrix4(L, Matrix4::scale(Vector3(x, y, z)));
+            return 1;
         }
         else
         {

--- a/engine/script/src/test/scripts/test_matrix4.lua
+++ b/engine/script/src/test/scripts/test_matrix4.lua
@@ -172,9 +172,9 @@ assert(tostring(m) == ("" .. m))
 
 -- matrix4_scale
 -- use value for x, y and z
-assert(vmath.matrix4_scale(1) == vmath.matrix4(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1))
+assert("foo " .. tostring(vmath.matrix4_scale(1)) == "foo vmath.matrix4(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1)")
 -- use first value for x, y and z
-assert(vmath.matrix4_scale(1,2) == vmath.matrix4(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1))
+assert("foo " .. tostring(vmath.matrix4_scale(1,2)) == "foo vmath.matrix4(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1)")
 -- use provided values as x,y and z
-assert(vmath.matrix4_scale(1,2,3) == vmath.matrix4(1, 0, 0, 0, 0, 2, 0, 0, 0, 0, 3, 0, 0, 0, 0, 1))
-assert(vmath.matrix4_scale(vmath.vector3(1,2,3)) == vmath.matrix4(1, 0, 0, 0, 0, 2, 0, 0, 0, 0, 3, 0, 0, 0, 0, 1))
+assert("foo " .. tostring(vmath.matrix4_scale(1,2,3)) == "foo vmath.matrix4(1, 0, 0, 0, 0, 2, 0, 0, 0, 0, 3, 0, 0, 0, 0, 1)")
+assert("foo " .. tostring(vmath.matrix4_scale(vmath.vector3(1,2,3))) == "foo vmath.matrix4(1, 0, 0, 0, 0, 2, 0, 0, 0, 0, 3, 0, 0, 0, 0, 1)")

--- a/engine/script/src/test/scripts/test_matrix4.lua
+++ b/engine/script/src/test/scripts/test_matrix4.lua
@@ -169,3 +169,12 @@ m.c1 = vmath.vector4(-10.01,-10.01,-10.01,-10.01)
 m.c2 = vmath.vector4(-10.01,-10.01,-10.01,-10.01)
 m.c3 = vmath.vector4(-10.01,-10.01,-10.01,-10.01)
 assert(tostring(m) == ("" .. m))
+
+-- matrix4_scale
+-- use value for x, y and z
+assert(vmath.matrix4_scale(1) == vmath.matrix4(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1))
+-- use first value for x, y and z
+assert(vmath.matrix4_scale(1,2) == vmath.matrix4(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1)
+-- use provided values as x,y and z
+assert(vmath.matrix4_scale(1,2,3) == vmath.matrix4(1, 0, 0, 0, 0, 2, 0, 0, 0, 0, 3, 0, 0, 0, 0, 1))
+assert(vmath.matrix4_scale(vmath.vector3(1,2,3)) == vmath.matrix4(1, 0, 0, 0, 0, 2, 0, 0, 0, 0, 3, 0, 0, 0, 0, 1))

--- a/engine/script/src/test/scripts/test_matrix4.lua
+++ b/engine/script/src/test/scripts/test_matrix4.lua
@@ -174,7 +174,7 @@ assert(tostring(m) == ("" .. m))
 -- use value for x, y and z
 assert(vmath.matrix4_scale(1) == vmath.matrix4(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1))
 -- use first value for x, y and z
-assert(vmath.matrix4_scale(1,2) == vmath.matrix4(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1)
+assert(vmath.matrix4_scale(1,2) == vmath.matrix4(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1))
 -- use provided values as x,y and z
 assert(vmath.matrix4_scale(1,2,3) == vmath.matrix4(1, 0, 0, 0, 0, 2, 0, 0, 0, 0, 3, 0, 0, 0, 0, 1))
 assert(vmath.matrix4_scale(vmath.vector3(1,2,3)) == vmath.matrix4(1, 0, 0, 0, 0, 2, 0, 0, 0, 0, 3, 0, 0, 0, 0, 1))


### PR DESCRIPTION
Fix when using a number value in call to `vmath.matrix4_scale()`.

Fixes #12722 

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
