### PR TITLE
Increased precision of the world matrix for vp used by lit materials

### DIFF
--- a/engine/engine/content/builtins/materials/model_instanced.vp
+++ b/engine/engine/content/builtins/materials/model_instanced.vp
@@ -13,7 +13,7 @@ in mediump vec3 normal;
 // instanced rendering is automatically triggered.
 // To read more about instancing in Defold, navigate to
 // https://defold.com/manuals/material/#instancing
-in mediump mat4 mtx_world;
+in highp mat4 mtx_world;
 in mediump mat4 mtx_normal;
 
 out highp vec4 var_position;

--- a/engine/engine/content/builtins/materials/model_skinned_instanced.vp
+++ b/engine/engine/content/builtins/materials/model_skinned_instanced.vp
@@ -15,7 +15,7 @@ in mediump vec4 bone_indices;
 // instanced rendering is automatically triggered.
 // To read more about instancing in Defold, navigate to
 // https://defold.com/manuals/material/#instancing
-in mediump mat4 mtx_world;
+in highp mat4 mtx_world;
 in mediump mat4 mtx_normal;
 in highp vec4 animation_data;
 


### PR DESCRIPTION
On ES2 based backends (WebGL) the medium precision produced bad results with lighting on edges of models. Increasing the precision of the mtx_world in vertex programs used by lit materials solves these issues. Fixes #12737 