### PR TITLE
Add `/command/compile` and `/command/run` endpoints to editor server

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -1442,7 +1442,7 @@
       (workspace/save-build-cache! workspace))
     (nil? error)))
 
-(defn- build-handler [project workspace prefs web-server build-errors-view main-stage tool-tab-pane]
+(defn- build-handler [project workspace prefs web-server build-errors-view main-stage tool-tab-pane launch]
   (let [project-directory (workspace/project-directory workspace)
         main-scene (.getScene ^Stage main-stage)
         render-build-error! (make-render-build-error main-scene tool-tab-pane build-errors-view)
@@ -1459,16 +1459,21 @@
                     :old-artifact-map (workspace/artifact-map workspace))
       (fn [{:keys [engine] :as build-results}]
         (when (handle-build-results! workspace render-build-error! build-results)
-          (when (or engine skip-engine)
+          (when (and launch (or engine skip-engine))
             (show-console! main-scene tool-tab-pane)
             (launch-built-project! project engine project-directory prefs web-server false)))
         build-results))))
+
+(handler/defhandler :project.compile :global
+  (enabled? [] (not (build-in-progress?)))
+  (run [project workspace prefs web-server build-errors-view main-stage tool-tab-pane]
+    (build-handler project workspace prefs web-server build-errors-view main-stage tool-tab-pane false)))
 
 (handler/defhandler :project.build :global
   (enabled? [] (not (build-in-progress?)))
   (run [project workspace prefs web-server build-errors-view debug-view main-stage tool-tab-pane]
     (debug-view/detach! debug-view)
-    (build-handler project workspace prefs web-server build-errors-view main-stage tool-tab-pane)))
+    (build-handler project workspace prefs web-server build-errors-view main-stage tool-tab-pane true)))
 
 (handler/defhandler :run.set-instance-count :global
   (options [prefs user-data]
@@ -1573,7 +1578,7 @@
               (dialogs/make-confirmation-dialog localization clean-build-dialog-info))
       (debug-view/detach! debug-view)
       (workspace/clear-build-cache! workspace)
-      (build-handler project workspace prefs web-server build-errors-view main-stage tool-tab-pane))))
+      (build-handler project workspace prefs web-server build-errors-view main-stage tool-tab-pane true))))
 
 (defn- start-new-log-pipe!
   ^PipedOutputStream []

--- a/editor/src/clj/editor/command_requests.clj
+++ b/editor/src/clj/editor/command_requests.clj
@@ -76,7 +76,14 @@
 
    :build
    {:ui-handler :project.build
-    :help "Build and run the project."
+    ;; Deprecated compatibility alias. Remove after 2027-07-15.
+    :deprecated true
+    :resource-sync true
+    :response-fn build-response}
+
+   :compile
+   {:ui-handler :project.compile
+    :help "Compile the project without running it."
     :resource-sync true
     :response-fn build-response}
 
@@ -182,6 +189,12 @@
    {:ui-handler :help.report-suggestion
     :help "Open the Report Suggestion page in a web browser."}
 
+   :run
+   {:ui-handler :project.build
+    :help "Compile and run the project."
+    :resource-sync true
+    :response-fn build-response}
+
    :show-build-errors
    {:ui-handler :window.show-build-errors
     :help "Show the Build Errors tab."}
@@ -212,8 +225,9 @@
 
 (defn- command-openapi []
   (let [command->help (coll/into-> supported-commands (sorted-map)
-                       (map (fn [[command {:keys [help]}]]
-                              (coll/pair (name command) help))))]
+                       (keep (fn [[command {:keys [deprecated help]}]]
+                               (when-not deprecated
+                                 (coll/pair (name command) help)))))]
     {:summary "Execute an editor command"
      :description (str "Available commands:\n"
                        (coll/join-to-string
@@ -302,7 +316,7 @@
   (-> @(util.http-client/request
          (str "http://localhost:"
               (slurp (str (g/node-value (dev/workspace) :root) "/.internal/editor.port"))
-              "/command/build")
+              "/command/run")
          :method "POST"
          :as :string)
       :body

--- a/editor/test/integration/web_server_test.clj
+++ b/editor/test/integration/web_server_test.clj
@@ -324,7 +324,10 @@
                 (let [post-command (get-in json-body ["paths" "/command/{command}" "post"])]
                   (is (= "Execute an editor command" (get post-command "summary")))
                   (is (string/includes? (get post-command "description") "`build-html5`"))
-                  (is (some #{"build-html5"} (get-in post-command ["parameters" 0 "schema" "enum"]))))))
+                  (let [commands (get-in post-command ["parameters" 0 "schema" "enum"])]
+                    (is (coll/any? #{"compile"} commands))
+                    (is (coll/any? #{"run"} commands))
+                    (is (coll/not-any? #{"build"} commands))))))
             (let [{:keys [status headers body]} @(http/request
                                                     (str url "/preview/collection/components/test.gui?width=32&height=32")
                                                     :as :byte-array)]


### PR DESCRIPTION
Now, third-party IDEs and coding agents can compile the project without running it.

Fix #12708