### PR TITLE
Breakpoints exception during startup

### DIFF
--- a/editor/src/clj/editor/breakpoints_view.clj
+++ b/editor/src/clj/editor/breakpoints_view.clj
@@ -39,12 +39,12 @@
             [editor.resource :as resource]
             [editor.ui :as ui]
             [editor.workspace :as workspace]
+            [util.coll :as coll]
             [util.fn :as fn])
   (:import [javafx.scene Node Parent]
            [javafx.scene.control TableView]
            [javafx.scene.input KeyCode KeyEvent MouseButton MouseEvent]
-           [javafx.scene.layout AnchorPane]
-           [javafx.util Callback]))
+           [javafx.scene.layout AnchorPane]))
 
 (set! *warn-on-reflection* true)
 
@@ -81,11 +81,18 @@
   (let [region (code-data/make-breakpoint-region lines (:row breakpoint))]
     (merge region (select-keys breakpoint [:condition :enabled]))))
 
+(defn- breakpoint-row-in-lines? [lines breakpoint]
+  (let [row (:row breakpoint)]
+    (and (<= 0 row)
+         (< row (count lines)))))
+
 (defn- update-script-regions-from-breakpoints [script-node breakpoints evaluation-context]
   (let [lines (g/node-value script-node :lines evaluation-context)
         regions (g/node-value script-node :regions evaluation-context)
         non-bp-regions (remove code-data/breakpoint-region? regions)
-        bp-regions (map (partial breakpoint->region lines) breakpoints)]
+        bp-regions (coll/into-> breakpoints []
+                     (filter (partial breakpoint-row-in-lines? lines))
+                     (map (partial breakpoint->region lines)))]
     (vec (sort (concat non-bp-regions bp-regions)))))
 
 (defn- get-breakpoints-in-script [breakpoints breakpoint]
@@ -195,7 +202,7 @@
                     (= 2 (.getClickCount e)))
            (open-resource-fn resource (inc row)))))}))
 
-(defn- column-enabled-cell-factory [project swap-state breakpoints idx]
+(defn- column-enabled-cell-factory [project breakpoints idx]
   (when-let [breakpoint (get breakpoints idx)]
     {:style-class ["enabled-cell"]
      :alignment :center
@@ -290,7 +297,7 @@
                                  (.consume me)
                                  (swap-state assoc :edited-breakpoint breakpoint))))}))))
 
-(defn- column-remove-btn-cell-factory [swap-state project breakpoints idx]
+(defn- column-remove-btn-cell-factory [project breakpoints idx]
   (when-let [breakpoint (get breakpoints idx)]
     {:alignment :center
      :graphic
@@ -360,7 +367,7 @@
       :sortable false
       :cell-value-factory identity
       :cell-factory {:fx/cell-type fx.table-cell/lifecycle
-                     :describe (fn/partial column-enabled-cell-factory project swap-state breakpoints)}}
+                     :describe (fn/partial column-enabled-cell-factory project breakpoints)}}
      {:fx/type fx.table-column/lifecycle
       :text (localization-state (localization/message "breakpoints.column.line"))
       :pref-width 50
@@ -404,7 +411,7 @@
       :sortable false
       :cell-value-factory identity
       :cell-factory {:fx/cell-type fx.table-cell/lifecycle
-                     :describe (fn/partial column-remove-btn-cell-factory swap-state project breakpoints)}}]}})
+                     :describe (fn/partial column-remove-btn-cell-factory project breakpoints)}}]}})
 
 (ui/defc breakpoints-view
   {:compose [{:fx/type fx/ext-watcher
@@ -470,16 +477,14 @@
 
 (handler/defhandler :breakpoints.edit-selected :breakpoints-view
   (enabled? [selection] (= (count selection) 1))
-  (run [project swap-state breakpoints selection]
-    (g/with-auto-evaluation-context evaluation-context
-      (swap-state assoc :edited-breakpoint (first selection)))))
+  (run [swap-state selection]
+    (swap-state assoc :edited-breakpoint (first selection))))
 
 (handler/defhandler :breakpoints.go-to-line :breakpoints-view
   (enabled? [selection] (= 1 (count selection)))
-  (run [project swap-state open-resource-fn selection]
-    (g/with-auto-evaluation-context evaluation-context
-      (let [{:keys [resource row]} (first selection)]
-        (open-resource-fn resource (inc row))))))
+  (run [open-resource-fn selection]
+    (let [{:keys [resource row]} (first selection)]
+      (open-resource-fn resource (inc row)))))
 
 (handler/defhandler :breakpoints.show-in-assets :breakpoints-view
   (enabled? [selection] (= 1 (count selection)))

--- a/editor/test/editor/breakpoints_view_test.clj
+++ b/editor/test/editor/breakpoints_view_test.clj
@@ -15,9 +15,9 @@
 (ns editor.breakpoints-view-test
   (:require [clojure.test :refer :all]
             [dynamo.graph :as g]
-            [editor.code.data :as code.data]
             [editor.code.script :as code.script]
             [editor.breakpoints-view :as breakpoints-view]
+            [editor.prefs :as prefs]
             [integration.test-util :as test-util]))
 
 (def ^:private project-path "test/resources/geometry_wars")
@@ -36,9 +36,8 @@
                                 new-breakpoints
                                 action-fn))
           set-breakpoints-on-script! (fn [breakpoints]
-                                       (let [regions (g/node-value script-node :regions)]
-                                         (g/set-property! script-node :regions
-                                           (mapv (partial #'breakpoints-view/breakpoint->region lines) breakpoints))))]
+                                       (g/set-property! script-node :regions
+                                         (mapv (partial #'breakpoints-view/breakpoint->region lines) breakpoints)))]
       (testing "new breakpoints are mapped to regions"
         (let [breakpoints [{:row 1 :resource script-resource :condition "x > 5" :enabled true}
                            {:row 2 :resource script-resource :enabled false}]
@@ -52,7 +51,7 @@
         (let [breakpoints [{:row 1 :resource script-resource :condition "x > 5" :enabled true}
                            {:row 2 :resource script-resource :enabled false}]
               _ (set-breakpoints-on-script! breakpoints)
-              _ (call-set-regions! breakpoints breakpoints (fn [all new] new))
+              _ (call-set-regions! breakpoints breakpoints (fn [_all new] new))
               regions (g/node-value script-node :regions)]
           (is (= 2 (count regions)))
           (doseq [[bp region] (map vector breakpoints regions)]
@@ -73,7 +72,7 @@
                             {:row 2 :resource script-resource :enabled false}
                             {:row 5 :resource script-resource :condition "new1" :enabled true}
                             {:row 6 :resource script-resource :enabled false}]
-              _ (call-set-regions! original-bps modified-bps (fn [all new] new))
+              _ (call-set-regions! original-bps modified-bps (fn [_all new] new))
               new-bps (mapv (partial code.script/region->breakpoint script-resource)
                             (g/node-value script-node :regions))]
 
@@ -94,3 +93,30 @@
             (is (true? (:enabled new-1)))
             (is (nil? (:condition new-2)))
             (is (false? (:enabled new-2)))))))))
+
+(deftest restore-breakpoints-skips-stale-rows-test
+  (test-util/with-loaded-project project-path
+    (let [test-prefs (test-util/make-test-prefs)
+          script-proj-path "/main/main.script"
+          script-resource (test-util/resource workspace script-proj-path)
+          script-node (test-util/resource-node project script-resource)
+          line-count (count (g/node-value script-node :lines))
+          valid-breakpoint {:proj-path script-proj-path
+                            :row 1
+                            :condition "x > 5"
+                            :enabled true}
+          stale-breakpoints [{:proj-path script-proj-path
+                              :row -1
+                              :enabled true}
+                             {:proj-path script-proj-path
+                              :row line-count
+                              :enabled true}]]
+      (try
+        (prefs/set! test-prefs [:code :breakpoints] (into [valid-breakpoint] stale-breakpoints))
+        (breakpoints-view/restore-breakpoints! project test-prefs)
+        (let [breakpoints (g/node-value project :breakpoints)]
+          (is (= [script-resource] (mapv :resource breakpoints)))
+          (is (= [(dissoc valid-breakpoint :proj-path)]
+                 (mapv #(select-keys % [:row :condition :enabled]) breakpoints))))
+        (finally
+          (prefs/reset-path! test-prefs [:code :breakpoints]))))))


### PR DESCRIPTION
Fixed an issue where the editor could fail to finish launching if a saved breakpoint referred to a line that no longer exists, such as after a source control update changed the file.

Fixes #12709

### Technical changes

Also did some clean up after a clj-kondo pass
