### PR TITLE
Remember scene settings and camera state, better camera and grid defaults

### DIFF
--- a/editor/resources/localization/en.editor_localization
+++ b/editor/resources/localization/en.editor_localization
@@ -1133,6 +1133,7 @@ scene-popup.scene-visibility.gui-shapes = GUI Shapes
 scene-popup.scene-visibility.gui-particle-effects = GUI Particle Effects
 scene-popup.scene-visibility.gui-spine-scenes = GUI Spine Scenes
 scene-popup.scene-visibility.gui-text = GUI Text
+scene-popup.scene-visibility.lights = Lights
 scene-popup.scene-visibility.models = Models
 scene-popup.scene-visibility.particle-effects = Particle Effects
 scene-popup.scene-visibility.skeletons = Skeletons

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -523,6 +523,7 @@
              new-resource-node-id (some-> new-active-tab (editor-tab/resource-node-id evaluation-context))
              new-view-node-id (some-> new-active-tab editor-tab/view-node-id)
              should-load-scene-visibility (and is-in-active-tab-pane
+                                               (not= old-active-tab new-active-tab)
                                                (= :scene (some-> new-active-tab editor-tab/view-type-id)))
              path-key (when should-load-scene-visibility
                         (resource/resource->proj-path
@@ -2227,9 +2228,9 @@
   (g/let-ec [open-views (g/node-value app-view :open-views evaluation-context)
              scene-view-ids (g/node-value app-view :scene-view-ids evaluation-context)]
     (doseq [view-id scene-view-ids]
-      (when-let [resource (:resource (get open-views view-id))]
-        (save-scene-camera-prefs! prefs view-id resource))
       (try
+        (when-let [resource (:resource (get open-views view-id))]
+          (save-scene-camera-prefs! prefs view-id resource))
         (scene/dispose-scene-view! view-id)
         (catch Throwable error
           (error-reporting/report-exception! error)))))
@@ -2400,8 +2401,7 @@
       (get scene-default-camera-projection-by-ext ext :orthographic))))
 
 (defn- camera-prefs [camera]
-  {:2d-mode (camera/mode-2d? camera)
-   :projection (:type camera)
+  {:projection (:type camera)
    :position (math/vecmath->clj (:position camera))
    :rotation (math/vecmath->clj (:rotation camera))
    :fov-x (:fov-x camera)
@@ -2418,18 +2418,16 @@
                                 (camera-prefs camera)))))
 
 (defn- try-load-camera-from-prefs [prefs path-key]
-  (when-let [{:keys [projection position rotation fov-x fov-y focus-point]}
-             (prefs/get-pref-entry-in prefs [:scene :resource-settings] path-key [:camera] nil)]
-    (let [[position-x position-y position-z] position
-          [rotation-x rotation-y rotation-z rotation-w] rotation
-          [focus-x focus-y focus-z focus-w] focus-point]
-      (assoc (camera/make-camera (or projection :orthographic)
-                                 identity
-                                 {:fov-x (or fov-x 1000.0)
-                                  :fov-y (or fov-y 1000.0)})
-        :position (Point3d. (double position-x) (double position-y) (double position-z))
-        :rotation (Quat4d. (double rotation-x) (double rotation-y) (double rotation-z) (double rotation-w))
-        :focus-point (Vector4d. (double focus-x) (double focus-y) (double focus-z) (double focus-w))))))
+  (let [{:keys [projection position rotation fov-x fov-y focus-point]}
+        (prefs/get-pref-entry-in prefs [:scene :resource-settings] path-key [:camera] nil)]
+    (when (and projection position rotation fov-x fov-y focus-point)
+      (let [[position-x position-y position-z] position
+            [rotation-x rotation-y rotation-z rotation-w] rotation
+            [focus-x focus-y focus-z focus-w] focus-point]
+        (assoc (camera/make-camera projection identity {:fov-x fov-x :fov-y fov-y})
+          :position (Point3d. (double position-x) (double position-y) (double position-z))
+          :rotation (Quat4d. (double rotation-x) (double rotation-y) (double rotation-z) (double rotation-w))
+          :focus-point (Vector4d. (double focus-x) (double focus-y) (double focus-z) (double focus-w)))))))
 
 (defn- make-tab! [app-view prefs localization resource-node view-type ^ObservableList tabs opts]
   (let [basis (g/now)

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -367,6 +367,7 @@
   (property manip-space g/Keyword)
   (property keymap g/Any)
   (property localization g/Any)
+  (property scene-visibility g/Any)
 
   (input outline-pane-desc g/Any)
   (input properties-pane-desc g/Any)
@@ -486,8 +487,12 @@
              ^SplitPane editor-tabs-split (g/node-value app-view :editor-tabs-split evaluation-context)
              ^Scene app-scene (g/node-value app-view :scene evaluation-context)
              properties-view (g/node-value app-view :properties-view evaluation-context)
+             scene-visibility (g/node-value app-view :scene-visibility evaluation-context)
              new-resource-node-id (some-> new-active-tab (editor-tab/resource-node-id evaluation-context))
              new-view-node-id (some-> new-active-tab editor-tab/view-node-id)
+             resource (resource-node/resource basis new-resource-node-id)
+             prefs (g/node-value scene-visibility :prefs evaluation-context)
+             path-key (resource/resource->proj-path resource)
 
              tx-data
              (when (and is-in-active-tab-pane
@@ -509,6 +514,17 @@
     ;; The remaining steps should always be performed, even if we didn't end up
     ;; updating the graph connections.
     (recent-files/save-tab-selections! prefs app-view)
+
+    ;; Update scene-visibility settings
+    (g/with-auto-evaluation-context evaluation-context
+      (if-let [settings (prefs/get-pref-entry prefs [:scene :resource-settings] path-key)]
+        (scene-visibility/update-settings scene-visibility settings evaluation-context)
+        (scene-visibility/update-settings scene-visibility
+                                          ;; TODO JOE: This doesn't belong here
+                                          {:filters-enabled true :filtered-renderable-tags (cond-> #{}
+                                                                                             (system/defold-dev?)
+                                                                                             (conj :dev-visibility-bounds))}
+                                          evaluation-context)))
 
     (g/let-ec [active-tab-pane (g/node-value app-view :active-tab-pane evaluation-context)]
       (doseq [^TabPane tab-pane (.getItems editor-tabs-split)]

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -2238,7 +2238,14 @@
     (refresh-scene-view! view-id dt))
   (scene-cache/prune-context! nil))
 
-(declare save-scene-camera-prefs!)
+(defn- save-scene-camera-prefs! [prefs view resource]
+  (g/let-ec [camera (some-> (:basis evaluation-context)
+                            (scene/view->camera view)
+                            (g/node-value :local-camera evaluation-context))
+             path-key (resource/resource->proj-path resource)]
+    (when (and camera path-key)
+      (prefs/set-pref-entry-in! prefs [:scene :resource-settings] path-key [:camera]
+                                (camera/camera->prefs-value camera)))))
 
 (let [TabHeaderSkin (Class/forName "javafx.scene.control.skin.TabPaneSkin$TabHeaderSkin")
       getTab (.getDeclaredMethod TabHeaderSkin "getTab" (into-array Class []))]
@@ -2413,15 +2420,6 @@
           :perspective))
 
       (get scene-default-camera-projection-by-ext ext :orthographic))))
-
-(defn- save-scene-camera-prefs! [prefs view resource]
-  (g/let-ec [camera (some-> (:basis evaluation-context)
-                            (scene/view->camera view)
-                            (g/node-value :local-camera evaluation-context))
-             path-key (resource/resource->proj-path resource)]
-    (when (and camera path-key)
-      (prefs/set-pref-entry-in! prefs [:scene :resource-settings] path-key [:camera]
-                                (camera/camera->prefs-value camera)))))
 
 (defn- make-tab! [app-view prefs localization resource-node view-type ^ObservableList tabs opts]
   (let [basis (g/now)

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -144,6 +144,36 @@
                    :pane-id "changed-files-pane"
                    :split-id "assets-split"}})
 
+(def ^:private scene-default-camera-projection-by-ext
+    {"model" :perspective
+     "mesh" :perspective
+     "cubemap" :perspective
+     "gltf" :perspective
+     "glb" :perspective
+     "directional_light" :perspective
+     "point_light" :perspective
+     "spot_light" :perspective
+     "ambient_light" :perspective
+
+     ;; Unless we find a better way to determine whether these can start in perspective
+     ;; just open them as orthographic
+     "go" :orthographic
+     "collection" :orthographic
+     "particlefx" :orthographic
+
+     "jpg" :orthographic
+     "jpeg" :orthographic
+     "png" :orthographic
+     "atlas" :orthographic
+     "tilesource" :orthographic
+     "tileset" :orthographic
+     "tilemap" :orthographic
+     "tilegrid" :orthographic
+     "gui" :orthographic
+     "font" :orthographic
+     "sprite" :orthographic
+     "label" :orthographic})
+
 (defn- pane-visible? [^Scene main-scene pane-kw]
   (let [{:keys [pane-id split-id]} (split-info-by-pane-kw pane-kw)]
     (some? (.lookup main-scene (str "#" split-id " #" pane-id)))))
@@ -2191,12 +2221,17 @@
     (refresh-scene-view! view-id dt))
   (scene-cache/prune-context! nil))
 
-(defn- dispose-scene-views! [app-view]
-  (doseq [view-id (g/node-value app-view :scene-view-ids)]
-    (try
-      (scene/dispose-scene-view! view-id)
-      (catch Throwable error
-        (error-reporting/report-exception! error))))
+(declare save-scene-camera-prefs!)
+
+(defn- dispose-scene-views! [app-view prefs]
+  (let [open-views (g/node-value app-view :open-views)]
+    (doseq [view-id (g/node-value app-view :scene-view-ids)]
+      (when-let [resource (:resource (get open-views view-id))]
+        (save-scene-camera-prefs! prefs view-id resource))
+      (try
+        (scene/dispose-scene-view! view-id)
+        (catch Throwable error
+          (error-reporting/report-exception! error)))))
   (scene-cache/drop-context! nil))
 
 (let [TabHeaderSkin (Class/forName "javafx.scene.control.skin.TabPaneSkin$TabHeaderSkin")
@@ -2290,7 +2325,7 @@
                     (handle-focus-owner-change! app-view prefs new-focus-owner)))
 
       (ui/register-menubar app-scene menu-bar ::menubar)
-      (ui/on-closed! stage (fn [_] (dispose-scene-views! app-view)))
+      (ui/on-closed! stage (fn [_] (dispose-scene-views! app-view prefs)))
 
       (error-reporting/init-disabled-functionality-notifier!
         (fn notify-disabled-functionality! []
@@ -2351,6 +2386,17 @@
 
 (declare open-resource!)
 
+(defn- default-camera-projection [project resource]
+  (let [ext (some-> resource resource/resource-type :ext)]
+    (case ext
+      "collisionobject"
+      (let [game-project (project/get-resource-node project "/game.project")]
+        (if (= "2D" (game-project/get-setting game-project ["physics" "type"]))
+          :orthographic
+          :perspective))
+
+      (get scene-default-camera-projection-by-ext ext :orthographic))))
+
 (defn- camera-prefs [camera]
   {:2d-mode (camera/mode-2d? camera)
    :projection (:type camera)
@@ -2359,6 +2405,15 @@
    :fov-x (:fov-x camera)
    :fov-y (:fov-y camera)
    :focus-point (math/vecmath->clj (:focus-point camera))})
+
+(defn- save-scene-camera-prefs! [prefs view resource]
+  (g/let-ec [camera (some-> (:basis evaluation-context)
+                            (scene/view->camera view)
+                            (g/node-value :local-camera evaluation-context))
+             path-key (resource/resource->proj-path resource)]
+    (when (and camera path-key)
+      (prefs/set-pref-entry-in! prefs [:scene :resource-settings] path-key [:camera]
+                                (camera-prefs camera)))))
 
 (defn- try-load-camera-from-prefs [prefs path-key]
   (when-let [{:keys [projection position rotation fov-x fov-y focus-point]}
@@ -2393,6 +2448,10 @@
         view-graph (g/make-graph! :history false :volatility 2)
         select-fn (partial select app-view)
         open-resource-fn (partial open-resource! app-view prefs localization project)
+        stored-camera (try-load-camera-from-prefs prefs (resource/resource->proj-path resource))
+        camera-opts (if stored-camera
+                      {:camera stored-camera}
+                      {:default-camera-projection (default-camera-projection project resource)})
         opts (merge opts
                     (get (:view-opts resource-type) (:id view-type))
                     {:app-view app-view
@@ -2402,8 +2461,9 @@
                      :project project
                      :workspace workspace
                      :localization localization
-                     :camera (try-load-camera-from-prefs prefs (resource/resource->proj-path resource))
-                     :tab tab})
+                     :tab tab}
+                    (when (= :scene (:id view-type))
+                      camera-opts))
         make-view-fn (:make-view-fn view-type)
         view (make-view-fn view-graph parent resource-node opts)]
     (assert (g/node-instance? view/WorkbenchView view))
@@ -2427,13 +2487,7 @@
       (.setOnClosed tab (ui/event-handler event
                           (recent-files/add! prefs resource view-type)
                           (when (= :scene (:id view-type))
-                            (g/let-ec [camera (some-> (:basis evaluation-context)
-                                                      (scene/view->camera view)
-                                                      (g/node-value :local-camera evaluation-context))
-                                       path-key (resource/resource->proj-path resource)]
-                              (when (and camera path-key)
-                                (prefs/set-pref-entry-in! prefs [:scene :resource-settings] path-key [:camera]
-                                                          (camera-prefs camera)))))
+                            (save-scene-camera-prefs! prefs view resource))
 
                           ;; The menu refresh can occur after the view graph is
                           ;; deleted but before the tab controls lose input

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -518,13 +518,7 @@
 
     ;; Update scene-visibility settings
     (when should-load-scene-visibility
-      (if-let [settings (prefs/get-pref-entry prefs [:scene :visibility-resource-settings] path-key)]
-        (scene-visibility/update-settings scene-visibility settings)
-        (scene-visibility/update-settings scene-visibility
-                                          ;; TODO JOE: This doesn't belong here
-                                          {:filters-enabled true :filtered-renderable-tags (cond-> #{}
-                                                                                             (system/defold-dev?)
-                                                                                             (conj :dev-visibility-bounds))})))
+      (scene-visibility/load-settings! scene-visibility prefs path-key))
 
     (g/let-ec [active-tab-pane (g/node-value app-view :active-tab-pane evaluation-context)]
       (doseq [^TabPane tab-pane (.getItems editor-tabs-split)]
@@ -544,11 +538,13 @@
 
 (handler/defhandler :scene.visibility.show-settings :workbench
   (run [app-view localization scene-visibility]
-    (when-let [btn (scene-visibility/toggle-button app-view)]
-      (scene-visibility/show-settings! (g/node-value app-view :keymap) localization btn scene-visibility)))
+    (g/let-ec [btn (scene-visibility/toggle-button app-view evaluation-context)
+               keymap (g/node-value app-view :keymap evaluation-context)]
+      (when btn
+        (scene-visibility/show-settings! keymap localization btn scene-visibility))))
   (state [app-view scene-visibility evaluation-context]
-    (when-let [btn (scene-visibility/toggle-button app-view)]
-      (scene-visibility/sync-filter-button-style! app-view scene-visibility evaluation-context)
+    (when-let [btn (scene-visibility/toggle-button app-view evaluation-context)]
+      (scene-visibility/sync-filter-button-style! btn scene-visibility evaluation-context)
       (settings-popup/settings-visible? btn))))
 
 (defn- get-settings-button [^Tab tab button-id]

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -62,7 +62,6 @@
             [editor.lsp :as lsp]
             [editor.lua :as lua]
             [editor.markdown :as markdown]
-            [editor.math :as math]
             [editor.menu-items :as menu-items]
             [editor.mouse-binding :as mouse-binding]
             [editor.notifications :as notifications]
@@ -125,7 +124,6 @@
            [javafx.scene.shape Ellipse]
            [javafx.scene.text Font]
            [javafx.stage Screen Stage WindowEvent]
-           [javax.vecmath Point3d Quat4d Vector4d]
            [org.luaj.vm2 LuaError]))
 
 (set! *warn-on-reflection* true)
@@ -399,7 +397,6 @@
   (property manip-space g/Keyword)
   (property keymap g/Any)
   (property localization g/Any)
-  (property scene-visibility g/Any)
 
   (input outline-pane-desc g/Any)
   (input properties-pane-desc g/Any)
@@ -418,6 +415,7 @@
   (input sub-selections-by-resource-node g/Any)
   (input debugger-sidebar-panes g/Any)
   (input debugger-execution-locations g/Any)
+  (input scene-visibility g/NodeID)
 
   (output open-sidebar-panes g/Any :cached (g/fnk [open-sidebar-panes] (into {} open-sidebar-panes)))
   (output open-views g/Any :cached (g/fnk [open-views] (into {} open-views)))
@@ -2242,18 +2240,6 @@
 
 (declare save-scene-camera-prefs!)
 
-(defn- dispose-scene-views! [app-view prefs]
-  (g/let-ec [open-views (g/node-value app-view :open-views evaluation-context)
-             scene-view-ids (g/node-value app-view :scene-view-ids evaluation-context)]
-    (doseq [view-id scene-view-ids]
-      (try
-        (when-let [resource (:resource (get open-views view-id))]
-          (save-scene-camera-prefs! prefs view-id resource))
-        (scene/dispose-scene-view! view-id)
-        (catch Throwable error
-          (error-reporting/report-exception! error)))))
-  (scene-cache/drop-context! nil))
-
 (let [TabHeaderSkin (Class/forName "javafx.scene.control.skin.TabPaneSkin$TabHeaderSkin")
       getTab (.getDeclaredMethod TabHeaderSkin "getTab" (into-array Class []))]
   (.setAccessible getTab true)
@@ -2345,7 +2331,17 @@
                     (handle-focus-owner-change! app-view prefs new-focus-owner)))
 
       (ui/register-menubar app-scene menu-bar ::menubar)
-      (ui/on-closed! stage (fn [_] (dispose-scene-views! app-view prefs)))
+      (ui/on-closed! stage (fn [_]
+                             (g/let-ec [open-views (g/node-value app-view :open-views evaluation-context)
+                                        scene-view-ids (g/node-value app-view :scene-view-ids evaluation-context)]
+                               (doseq [view-id scene-view-ids]
+                                 (try
+                                   (when-let [resource (:resource (get open-views view-id))]
+                                     (save-scene-camera-prefs! prefs view-id resource))
+                                   (scene/dispose-scene-view! view-id)
+                                   (catch Throwable error
+                                     (error-reporting/report-exception! error)))))
+                             (scene-cache/drop-context! nil)))
 
       (error-reporting/init-disabled-functionality-notifier!
         (fn notify-disabled-functionality! []
@@ -2418,14 +2414,6 @@
 
       (get scene-default-camera-projection-by-ext ext :orthographic))))
 
-(defn- camera-prefs [camera]
-  {:projection (:type camera)
-   :position (math/vecmath->clj (:position camera))
-   :rotation (math/vecmath->clj (:rotation camera))
-   :fov-x (:fov-x camera)
-   :fov-y (:fov-y camera)
-   :focus-point (math/vecmath->clj (:focus-point camera))})
-
 (defn- save-scene-camera-prefs! [prefs view resource]
   (g/let-ec [camera (some-> (:basis evaluation-context)
                             (scene/view->camera view)
@@ -2433,19 +2421,7 @@
              path-key (resource/resource->proj-path resource)]
     (when (and camera path-key)
       (prefs/set-pref-entry-in! prefs [:scene :resource-settings] path-key [:camera]
-                                (camera-prefs camera)))))
-
-(defn- try-load-camera-from-prefs [prefs path-key]
-  (let [{:keys [projection position rotation fov-x fov-y focus-point]}
-        (prefs/get-pref-entry-in prefs [:scene :resource-settings] path-key [:camera] nil)]
-    (when (and projection position rotation fov-x fov-y focus-point)
-      (let [[position-x position-y position-z] position
-            [rotation-x rotation-y rotation-z rotation-w] rotation
-            [focus-x focus-y focus-z focus-w] focus-point]
-        (assoc (camera/make-camera projection identity {:fov-x fov-x :fov-y fov-y})
-          :position (Point3d. (double position-x) (double position-y) (double position-z))
-          :rotation (Quat4d. (double rotation-x) (double rotation-y) (double rotation-z) (double rotation-w))
-          :focus-point (Vector4d. (double focus-x) (double focus-y) (double focus-z) (double focus-w)))))))
+                                (camera/camera->prefs-value camera)))))
 
 (defn- make-tab! [app-view prefs localization resource-node view-type ^ObservableList tabs opts]
   (let [basis (g/now)
@@ -2466,7 +2442,7 @@
         view-graph (g/make-graph! :history false :volatility 2)
         select-fn (partial select app-view)
         open-resource-fn (partial open-resource! app-view prefs localization project)
-        stored-camera (try-load-camera-from-prefs prefs (resource/resource->proj-path resource))
+        stored-camera (camera/try-load-camera-from-prefs prefs (resource/resource->proj-path resource))
         camera-opts (if stored-camera
                       {:camera stored-camera}
                       {:default-camera-projection (default-camera-projection project resource)})
@@ -2503,9 +2479,11 @@
                                     (recent-files/add! prefs resource view-type))))
     (let [close-handler (.getOnClosed tab)]
       (.setOnClosed tab (ui/event-handler event
-                          (recent-files/add! prefs resource view-type)
-                          (when (= :scene (:id view-type))
-                            (save-scene-camera-prefs! prefs view resource))
+                          (let [basis (g/now)
+                                resource (resource-node/resource basis resource-node)]
+                            (recent-files/add! prefs resource view-type)
+                            (when (= :scene (:id view-type))
+                              (save-scene-camera-prefs! prefs view resource)))
 
                           ;; The menu refresh can occur after the view graph is
                           ;; deleted but before the tab controls lose input

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -490,10 +490,11 @@
              scene-visibility (g/node-value app-view :scene-visibility evaluation-context)
              new-resource-node-id (some-> new-active-tab (editor-tab/resource-node-id evaluation-context))
              new-view-node-id (some-> new-active-tab editor-tab/view-node-id)
-             resource (resource-node/resource basis new-resource-node-id)
-             prefs (g/node-value scene-visibility :prefs evaluation-context)
-             path-key (resource/resource->proj-path resource)
-
+             should-load-scene-visibility (and is-in-active-tab-pane
+                                               (= :scene (some-> new-active-tab editor-tab/view-type-id)))
+             path-key (when should-load-scene-visibility
+                        (resource/resource->proj-path
+                          (resource-node/resource basis new-resource-node-id)))
              tx-data
              (when (and is-in-active-tab-pane
                         (not= old-active-tab new-active-tab))
@@ -516,15 +517,14 @@
     (recent-files/save-tab-selections! prefs app-view)
 
     ;; Update scene-visibility settings
-    (g/with-auto-evaluation-context evaluation-context
-      (if-let [settings (prefs/get-pref-entry prefs [:scene :resource-settings] path-key)]
-        (scene-visibility/update-settings scene-visibility settings evaluation-context)
+    (when should-load-scene-visibility
+      (if-let [settings (prefs/get-pref-entry prefs [:scene :visibility-resource-settings] path-key)]
+        (scene-visibility/update-settings scene-visibility settings)
         (scene-visibility/update-settings scene-visibility
                                           ;; TODO JOE: This doesn't belong here
                                           {:filters-enabled true :filtered-renderable-tags (cond-> #{}
                                                                                              (system/defold-dev?)
-                                                                                             (conj :dev-visibility-bounds))}
-                                          evaluation-context)))
+                                                                                             (conj :dev-visibility-bounds))})))
 
     (g/let-ec [active-tab-pane (g/node-value app-view :active-tab-pane evaluation-context)]
       (doseq [^TabPane tab-pane (.getItems editor-tabs-split)]

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -61,6 +61,7 @@
             [editor.localization :as localization]
             [editor.lsp :as lsp]
             [editor.lua :as lua]
+            [editor.math :as math]
             [editor.markdown :as markdown]
             [editor.menu-items :as menu-items]
             [editor.mouse-binding :as mouse-binding]
@@ -124,6 +125,7 @@
            [javafx.scene.shape Ellipse]
            [javafx.scene.text Font]
            [javafx.stage Screen Stage WindowEvent]
+           [javax.vecmath Point3d Quat4d Vector4d]
            [org.luaj.vm2 LuaError]))
 
 (set! *warn-on-reflection* true)
@@ -2349,6 +2351,29 @@
 
 (declare open-resource!)
 
+(defn- camera-prefs [camera]
+  {:2d-mode (camera/mode-2d? camera)
+   :projection (:type camera)
+   :position (math/vecmath->clj (:position camera))
+   :rotation (math/vecmath->clj (:rotation camera))
+   :fov-x (:fov-x camera)
+   :fov-y (:fov-y camera)
+   :focus-point (math/vecmath->clj (:focus-point camera))})
+
+(defn- try-load-camera-from-prefs [prefs path-key]
+  (when-let [{:keys [projection position rotation fov-x fov-y focus-point]}
+             (prefs/get-pref-entry-in prefs [:scene :resource-settings] path-key [:camera])]
+    (let [[position-x position-y position-z] position
+          [rotation-x rotation-y rotation-z rotation-w] rotation
+          [focus-x focus-y focus-z focus-w] focus-point]
+      (assoc (camera/make-camera (or projection :orthographic)
+                                 identity
+                                 {:fov-x (or fov-x 1000.0)
+                                  :fov-y (or fov-y 1000.0)})
+        :position (Point3d. (double position-x) (double position-y) (double position-z))
+        :rotation (Quat4d. (double rotation-x) (double rotation-y) (double rotation-z) (double rotation-w))
+        :focus-point (Vector4d. (double focus-x) (double focus-y) (double focus-z) (double focus-w))))))
+
 (defn- make-tab! [app-view prefs localization resource-node view-type ^ObservableList tabs opts]
   (let [basis (g/now)
         project (project/get-project basis resource-node)
@@ -2377,6 +2402,7 @@
                      :project project
                      :workspace workspace
                      :localization localization
+                     :camera (try-load-camera-from-prefs prefs (resource/resource->proj-path resource))
                      :tab tab})
         make-view-fn (:make-view-fn view-type)
         view (make-view-fn view-graph parent resource-node opts)]
@@ -2400,6 +2426,15 @@
     (let [close-handler (.getOnClosed tab)]
       (.setOnClosed tab (ui/event-handler event
                           (recent-files/add! prefs resource view-type)
+                          (when (= :scene (:id view-type))
+                            (g/let-ec [camera (some-> (:basis evaluation-context)
+                                                      (scene/view->camera view)
+                                                      (g/node-value :local-camera evaluation-context))
+                                       path-key (resource/resource->proj-path resource)]
+                              (when (and camera path-key)
+                                (prefs/set-pref-entry-in! prefs [:scene :resource-settings] path-key [:camera]
+                                                          (camera-prefs camera)))))
+
                           ;; The menu refresh can occur after the view graph is
                           ;; deleted but before the tab controls lose input
                           ;; focus, causing handlers to evaluate against deleted

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -48,6 +48,7 @@
             [editor.future :as future]
             [editor.fxui :as fxui]
             [editor.game-project :as game-project]
+            [editor.geom :as geom]
             [editor.git :as git]
             [editor.github :as github]
             [editor.graph-util :as gu]
@@ -124,6 +125,7 @@
            [javafx.scene.shape Ellipse]
            [javafx.scene.text Font]
            [javafx.stage Screen Stage WindowEvent]
+           [javax.vecmath Point3d]
            [org.luaj.vm2 LuaError]))
 
 (set! *warn-on-reflection* true)
@@ -141,36 +143,6 @@
    :changed-files {:index 1
                    :pane-id "changed-files-pane"
                    :split-id "assets-split"}})
-
-(def ^:private scene-default-camera-projection-by-ext
-  {"model" :perspective
-   "mesh" :perspective
-   "cubemap" :perspective
-   "gltf" :perspective
-   "glb" :perspective
-   "directional_light" :perspective
-   "point_light" :perspective
-   "spot_light" :perspective
-   "ambient_light" :perspective
-
-   ;; Unless we find a better way to determine whether these can start in perspective
-   ;; just open them as orthographic
-   "go" :orthographic
-   "collection" :orthographic
-   "particlefx" :orthographic
-
-   "jpg" :orthographic
-   "jpeg" :orthographic
-   "png" :orthographic
-   "atlas" :orthographic
-   "tilesource" :orthographic
-   "tileset" :orthographic
-   "tilemap" :orthographic
-   "tilegrid" :orthographic
-   "gui" :orthographic
-   "font" :orthographic
-   "sprite" :orthographic
-   "label" :orthographic})
 
 (defn- pane-visible? [^Scene main-scene pane-kw]
   (let [{:keys [pane-id split-id]} (split-info-by-pane-kw pane-kw)]
@@ -2409,9 +2381,15 @@
 
 (declare open-resource!)
 
-(defn- default-camera-projection [project resource]
+(defn- default-camera-projection [project resource resource-node]
   (let [ext (some-> resource resource/resource-type :ext)]
     (case ext
+      ("model" "mesh" "gltf" "glb")
+      :perspective
+
+      ("png" "jpg" "jpeg" "atlas" "tilesource" "tileset" "tilegrid" "tilemap" "gui" "font" "sprite" "label")
+      :orthographic
+
       "collisionobject"
       (g/let-ec [game-project (project/get-resource-node project "/game.project" evaluation-context)
                  physics-type (game-project/get-setting game-project ["physics" "type"] evaluation-context)]
@@ -2419,7 +2397,21 @@
           :orthographic
           :perspective))
 
-      (get scene-default-camera-projection-by-ext ext :orthographic))))
+      (g/let-ec [scene (g/node-value resource-node :scene evaluation-context)]
+        (letfn [(has-depth? [node]
+                  (let [aabb (:aabb node)
+                        ^Point3d extent (when aabb (geom/aabb-extent aabb))]
+                    (if (and extent
+                             (pos? (.z extent))
+                             (contains? node :renderable)
+                             (not (contains? (get-in node [:renderable :tags]) :camera)))
+                      true
+                      (boolean (some has-depth? (:children node))))))]
+          (if (and scene
+                   (not (g/error? scene))
+                   (has-depth? scene))
+            :perspective
+            :orthographic))))))
 
 (defn- make-tab! [app-view prefs localization resource-node view-type ^ObservableList tabs opts]
   (let [basis (g/now)
@@ -2440,10 +2432,10 @@
         view-graph (g/make-graph! :history false :volatility 2)
         select-fn (partial select app-view)
         open-resource-fn (partial open-resource! app-view prefs localization project)
-        stored-camera (camera/try-load-camera-from-prefs prefs (resource/resource->proj-path resource))
-        camera-opts (if stored-camera
-                      {:camera stored-camera}
-                      {:default-camera-projection (default-camera-projection project resource)})
+        camera-opts (when (= :scene (:id view-type))
+                      (if-some [stored-camera (camera/try-load-camera-from-prefs prefs (resource/resource->proj-path resource))]
+                        {:camera stored-camera}
+                        {:default-camera-projection (default-camera-projection project resource resource-node)}))
         opts (merge opts
                     (get (:view-opts resource-type) (:id view-type))
                     {:app-view app-view
@@ -2454,8 +2446,7 @@
                      :workspace workspace
                      :localization localization
                      :tab tab}
-                    (when (= :scene (:id view-type))
-                      camera-opts))
+                    camera-opts)
         make-view-fn (:make-view-fn view-type)
         view (make-view-fn view-graph parent resource-node opts)]
     (assert (g/node-instance? view/WorkbenchView view))

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -61,8 +61,8 @@
             [editor.localization :as localization]
             [editor.lsp :as lsp]
             [editor.lua :as lua]
-            [editor.math :as math]
             [editor.markdown :as markdown]
+            [editor.math :as math]
             [editor.menu-items :as menu-items]
             [editor.mouse-binding :as mouse-binding]
             [editor.notifications :as notifications]
@@ -145,34 +145,34 @@
                    :split-id "assets-split"}})
 
 (def ^:private scene-default-camera-projection-by-ext
-    {"model" :perspective
-     "mesh" :perspective
-     "cubemap" :perspective
-     "gltf" :perspective
-     "glb" :perspective
-     "directional_light" :perspective
-     "point_light" :perspective
-     "spot_light" :perspective
-     "ambient_light" :perspective
+  {"model" :perspective
+   "mesh" :perspective
+   "cubemap" :perspective
+   "gltf" :perspective
+   "glb" :perspective
+   "directional_light" :perspective
+   "point_light" :perspective
+   "spot_light" :perspective
+   "ambient_light" :perspective
 
-     ;; Unless we find a better way to determine whether these can start in perspective
-     ;; just open them as orthographic
-     "go" :orthographic
-     "collection" :orthographic
-     "particlefx" :orthographic
+   ;; Unless we find a better way to determine whether these can start in perspective
+   ;; just open them as orthographic
+   "go" :orthographic
+   "collection" :orthographic
+   "particlefx" :orthographic
 
-     "jpg" :orthographic
-     "jpeg" :orthographic
-     "png" :orthographic
-     "atlas" :orthographic
-     "tilesource" :orthographic
-     "tileset" :orthographic
-     "tilemap" :orthographic
-     "tilegrid" :orthographic
-     "gui" :orthographic
-     "font" :orthographic
-     "sprite" :orthographic
-     "label" :orthographic})
+   "jpg" :orthographic
+   "jpeg" :orthographic
+   "png" :orthographic
+   "atlas" :orthographic
+   "tilesource" :orthographic
+   "tileset" :orthographic
+   "tilemap" :orthographic
+   "tilegrid" :orthographic
+   "gui" :orthographic
+   "font" :orthographic
+   "sprite" :orthographic
+   "label" :orthographic})
 
 (defn- pane-visible? [^Scene main-scene pane-kw]
   (let [{:keys [pane-id split-id]} (split-info-by-pane-kw pane-kw)]
@@ -2224,8 +2224,9 @@
 (declare save-scene-camera-prefs!)
 
 (defn- dispose-scene-views! [app-view prefs]
-  (let [open-views (g/node-value app-view :open-views)]
-    (doseq [view-id (g/node-value app-view :scene-view-ids)]
+  (g/let-ec [open-views (g/node-value app-view :open-views evaluation-context)
+             scene-view-ids (g/node-value app-view :scene-view-ids evaluation-context)]
+    (doseq [view-id scene-view-ids]
       (when-let [resource (:resource (get open-views view-id))]
         (save-scene-camera-prefs! prefs view-id resource))
       (try
@@ -2390,8 +2391,9 @@
   (let [ext (some-> resource resource/resource-type :ext)]
     (case ext
       "collisionobject"
-      (let [game-project (project/get-resource-node project "/game.project")]
-        (if (= "2D" (game-project/get-setting game-project ["physics" "type"]))
+      (g/let-ec [game-project (project/get-resource-node project "/game.project" evaluation-context)
+                 physics-type (game-project/get-setting game-project ["physics" "type"] evaluation-context)]
+        (if (= "2D" physics-type)
           :orthographic
           :perspective))
 
@@ -2417,7 +2419,7 @@
 
 (defn- try-load-camera-from-prefs [prefs path-key]
   (when-let [{:keys [projection position rotation fov-x fov-y focus-point]}
-             (prefs/get-pref-entry-in prefs [:scene :resource-settings] path-key [:camera])]
+             (prefs/get-pref-entry-in prefs [:scene :resource-settings] path-key [:camera] nil)]
     (let [[position-x position-y position-z] position
           [rotation-x rotation-y rotation-z rotation-w] rotation
           [focus-x focus-y focus-z focus-w] focus-point]

--- a/editor/src/clj/editor/boot_open_project.clj
+++ b/editor/src/clj/editor/boot_open_project.clj
@@ -106,6 +106,29 @@
 (defn- find-tab [^TabPane tabs id]
   (some #(and (= id (.getId ^Tab %)) %) (.getTabs tabs)))
 
+(defn- clean-up-resource-prefs [prefs changes]
+  (let [moved (reduce (fn [settings [old new]]
+                        (let [old-path-key (:project-path old)
+                              new-path-key (:project-path new)]
+                          (if-let [entry (get settings old-path-key)]
+                            (-> settings
+                                (update :settings dissoc old-path-key)
+                                (update :settings assoc new-path-key entry)
+                                (update :moved conj old-path-key))
+                            settings)))
+                      {:settings (prefs/get prefs [:scene :resource-settings])
+                       :moved #{}}
+                      (:moved changes))
+        updated-settings (reduce (fn [settings entry]
+                                   (let [path-key (:project-path entry)]
+                                     (if (and (contains? settings path-key)
+                                              (not (contains? (:moved moved) path-key)))
+                                       (dissoc settings path-key)
+                                       settings)))
+                                 (:settings moved)
+                                 (:removed changes))]
+    (prefs/set! prefs [:scene :resource-settings] updated-settings)))
+
 (defn- handle-resource-changes! [app-scene tab-panes open-views changes-view]
   (ui/user-data! app-scene ::ui/refresh-requested? true)
   (app-view/remove-invalid-tabs! tab-panes open-views)
@@ -278,10 +301,11 @@
 
       (workspace/add-resource-listener! workspace 0
                                         (reify resource/ResourceListener
-                                          (handle-changes [_ _ _]
+                                          (handle-changes [_ changes _]
                                             (let [open-views (g/node-value app-view :open-views)
                                                   panes (.getItems ^SplitPane editor-tabs-split)]
-                                              (handle-resource-changes! scene panes open-views changes-view)))))
+                                              (handle-resource-changes! scene panes open-views changes-view)
+                                              (clean-up-resource-prefs prefs changes)))))
 
       (.addEventFilter scene
                        InputEvent/ANY

--- a/editor/src/clj/editor/boot_open_project.clj
+++ b/editor/src/clj/editor/boot_open_project.clj
@@ -110,7 +110,7 @@
   (let [moved (reduce (fn [settings [old new]]
                         (let [old-path-key (:project-path old)
                               new-path-key (:project-path new)]
-                          (if-let [entry (get settings old-path-key)]
+                          (if-let [entry (get-in settings [:settings old-path-key])]
                             (-> settings
                                 (update :settings dissoc old-path-key)
                                 (update :settings assoc new-path-key entry)

--- a/editor/src/clj/editor/boot_open_project.clj
+++ b/editor/src/clj/editor/boot_open_project.clj
@@ -129,6 +129,12 @@
                                  (:removed changes))]
     (prefs/set! prefs [:scene :resource-settings] updated-settings)))
 
+(defn- prune-resource-prefs! [prefs workspace]
+  (let [basis (g/now)
+        settings (prefs/get prefs [:scene :resource-settings])
+        pruned (into {} (filter (fn [[path-key _]] (workspace/find-resource basis workspace path-key))) settings)]
+    (prefs/set! prefs [:scene :resource-settings] pruned)))
+
 (defn- handle-resource-changes! [app-scene tab-panes open-views changes-view]
   (ui/user-data! app-scene ::ui/refresh-requested? true)
   (app-view/remove-invalid-tabs! tab-panes open-views)
@@ -393,7 +399,6 @@
         (ui/context! workbench :workbench context-env (app-view/->selection-provider app-view) dynamics))
       (g/transact
         (concat
-          (g/set-property app-view :scene-visibility scene-visibility)
           (for [label [:selected-node-ids-by-resource-node :selected-node-properties-by-resource-node :sub-selections-by-resource-node]]
             (g/connect project label app-view label))
           (g/connect project :_node-id app-view :project-id)
@@ -406,6 +411,7 @@
           (g/connect outline-view :tree-selection scene-visibility :outline-selection)
           (g/connect properties-view :_node-id app-view :properties-view)
           (g/connect properties-view :pane-desc app-view :properties-pane-desc)
+          (g/connect scene-visibility :_node-id app-view :scene-visibility)
           (g/connect scene-visibility :hidden-renderable-tags app-view :hidden-renderable-tags)
           (g/connect scene-visibility :outline-name-paths outline-view :outline-name-paths)
           (g/connect scene-visibility :hidden-node-outline-key-paths app-view :hidden-node-outline-key-paths)
@@ -463,6 +469,8 @@
 
           (when (git/internal-files-are-tracked? git)
             (show-tracked-internal-files-warning! localization))
+
+          (prune-resource-prefs! prefs workspace)
 
           (ui/timer-start! ui-timer)
           (slog/smoke-log "stage-loaded"))))

--- a/editor/src/clj/editor/boot_open_project.clj
+++ b/editor/src/clj/editor/boot_open_project.clj
@@ -173,7 +173,7 @@
           workbench            (.lookup root "#workbench")
           notifications        (.lookup root "#notifications")
           [app-view ui-timer]  (app-view/make-app-view *view-graph* project stage menu-bar editor-tabs-split right-split tool-tabs prefs localization)
-          scene-visibility     (scene-visibility/make-scene-visibility-node! *view-graph* app-view)
+          scene-visibility     (scene-visibility/make-scene-visibility-node! *view-graph* prefs app-view)
           outline-view         (outline-view/make-outline-view *view-graph* project app-view localization)
           asset-browser        (asset-browser/make-asset-browser *view-graph* workspace assets prefs localization)
           open-resource        (partial app-view/open-resource! app-view prefs localization project)
@@ -369,6 +369,7 @@
         (ui/context! workbench :workbench context-env (app-view/->selection-provider app-view) dynamics))
       (g/transact
         (concat
+          (g/set-property app-view :scene-visibility scene-visibility)
           (for [label [:selected-node-ids-by-resource-node :selected-node-properties-by-resource-node :sub-selections-by-resource-node]]
             (g/connect project label app-view label))
           (g/connect project :_node-id app-view :project-id)

--- a/editor/src/clj/editor/camera.clj
+++ b/editor/src/clj/editor/camera.clj
@@ -210,13 +210,6 @@
               0.0
               filter-fn))))
 
-(defn default-scene-camera
-  "The camera a scene view opens with when the resource has no stored camera."
-  ^Camera [prefs projection]
-  (if (= :perspective projection)
-    (make-camera :perspective identity {:fov-y (prefs/get prefs prefs-key-fov)})
-    (make-camera :orthographic identity {:fov-x 1000 :fov-y 1000})))
-
 (defn- set-extents
   ^Camera [^Camera camera fov-x fov-y z-near z-far]
   (assoc camera
@@ -528,6 +521,18 @@
     (assoc camera
            :position (Point3d. (.x delta) (.y delta) (.z delta))
            :rotation r)))
+
+(def ^:private default-3d-tumble
+  "The tumble realign-camera applies when toggling out of 2D mode."
+  [200.0 -100.0])
+
+(defn default-scene-camera
+  ^Camera [prefs projection]
+  (if (= :perspective projection)
+    (let [[dx dy] default-3d-tumble]
+      (tumble (make-camera :perspective identity {:fov-y (prefs/get prefs prefs-key-fov)})
+              dx dy))
+    (make-camera :orthographic identity {:fov-x 1000 :fov-y 1000})))
 
 (def ^:private camera-command->movement
   {:scene.camera.free-look :look
@@ -891,7 +896,8 @@
      (if (mode-2d? local-cam)
        (let [viewport (g/node-value camera-node :viewport evaluation-context)
              camera-3d (or (g/node-value camera-node :cached-3d-camera evaluation-context)
-                           (tumble local-cam 200.0 -100.0))
+                           (let [[dx dy] default-3d-tumble]
+                             (tumble local-cam dx dy)))
              camera-3d (sync-camera-position camera-node camera-3d local-cam viewport)
              local-cam (cond-> local-cam
                          (= (:type camera-3d) :perspective)

--- a/editor/src/clj/editor/camera.clj
+++ b/editor/src/clj/editor/camera.clj
@@ -534,6 +534,27 @@
               dx dy))
     (make-camera :orthographic identity {:fov-x 1000 :fov-y 1000})))
 
+(defn camera->prefs-value [camera]
+  (let [^Vector4d focus-point (:focus-point camera)]
+    {:projection (:type camera)
+     :position (math/vecmath->clj (:position camera))
+     :rotation (math/vecmath->clj (:rotation camera))
+     :fov-x (:fov-x camera)
+     :fov-y (:fov-y camera)
+     :focus-point [(.x focus-point) (.y focus-point) (.z focus-point)]}))
+
+(defn try-load-camera-from-prefs [prefs path-key]
+  (let [{:keys [projection position rotation fov-x fov-y focus-point]}
+        (prefs/get-pref-entry-in prefs [:scene :resource-settings] path-key [:camera] nil)]
+    (when (and projection position rotation fov-x fov-y focus-point)
+      (let [[position-x position-y position-z] position
+            [rotation-x rotation-y rotation-z rotation-w] rotation
+            [focus-x focus-y focus-z] focus-point]
+        (assoc (make-camera projection identity {:fov-x fov-x :fov-y fov-y})
+          :position (Point3d. (double position-x) (double position-y) (double position-z))
+          :rotation (Quat4d. (double rotation-x) (double rotation-y) (double rotation-z) (double rotation-w))
+          :focus-point (Vector4d. (double focus-x) (double focus-y) (double focus-z) 1.0))))))
+
 (def ^:private camera-command->movement
   {:scene.camera.free-look :look
    :scene.camera.orbit :tumble

--- a/editor/src/clj/editor/camera.clj
+++ b/editor/src/clj/editor/camera.clj
@@ -210,6 +210,13 @@
               0.0
               filter-fn))))
 
+(defn default-scene-camera
+  "The camera a scene view opens with when the resource has no stored camera."
+  ^Camera [prefs projection]
+  (if (= :perspective projection)
+    (make-camera :perspective identity {:fov-y (prefs/get prefs prefs-key-fov)})
+    (make-camera :orthographic identity {:fov-x 1000 :fov-y 1000})))
+
 (defn- set-extents
   ^Camera [^Camera camera fov-x fov-y z-near z-far]
   (assoc camera

--- a/editor/src/clj/editor/grid.clj
+++ b/editor/src/clj/editor/grid.clj
@@ -245,16 +245,16 @@
                     (conj (snap-out-to-grid aabb grid-size-large)))
      :plane plane}))
 
-(defn- grid-mode [camera]
+(defn- grid-mode
+  "Returns :grid-2d or :grid-3d depending on camera projection mode"
+  [camera]
   (if (c/mode-2d? camera) :grid-2d :grid-3d))
 
 (defn- get-grid-pref [prefs camera path]
-  (let [grid-mode (grid-mode camera)]
-    (prefs/get prefs (into [:scene grid-mode] path))))
+  (prefs/get prefs (into [:scene (grid-mode camera)] path)))
 
 (defn- set-grid-pref! [prefs camera path value]
-  (let [grid-mode (grid-mode camera)]
-    (prefs/set! prefs (into [:scene grid-mode] path) value)))
+  (prefs/set! prefs (into [:scene (grid-mode camera)] path) value))
 
 (g/defnk produce-merged-options
   [prefs camera options]

--- a/editor/src/clj/editor/grid.clj
+++ b/editor/src/clj/editor/grid.clj
@@ -245,17 +245,23 @@
                     (conj (snap-out-to-grid aabb grid-size-large)))
      :plane plane}))
 
+(defn- grid-mode [camera]
+  (if (c/mode-2d? camera) :grid-2d :grid-3d))
+
+(defn- get-grid-pref [prefs camera path]
+  (let [grid-mode (grid-mode camera)]
+    (prefs/get prefs (into [:scene grid-mode] path))))
+
+(defn- set-grid-pref! [prefs camera path value]
+  (let [grid-mode (grid-mode camera)]
+    (prefs/set! prefs (into [:scene grid-mode] path) value)))
+
 (g/defnk produce-merged-options
   [prefs camera options]
-  (cond-> (if prefs (prefs/get prefs [:scene :grid]) {})
-          :always
-          (assoc :auto-scale true)
-
-          options
-          (merge options)
-
-          (c/mode-2d? camera)
-          (assoc :active-plane :z)))
+  (let [mode-2d (c/mode-2d? camera)]
+    (merge (get-grid-pref prefs camera [])
+           options
+           {:auto-scale true})))
 
 (g/defnode Grid
   (property prefs g/Any)
@@ -275,27 +281,28 @@
 (defn show-settings! [^Parent owner app-view prefs keymap localization]
   (let [scene-view-id (g/node-value app-view :active-view)
         grid (g/node-value scene-view-id :grid)
+        camera (g/node-value grid :camera)
         ignored-keys (set (keys (g/node-value grid :options)))
         value-changed-fn (fn [k v]
-                           (prefs/set! prefs [:scene :grid k] v)
+                           (set-grid-pref! prefs camera [k] v)
                            (invalidate-grids! app-view))
         all-descriptors
         [{:type :reset-all
           :on-reset (fn [swap-state]
-                      (prefs/reset-path! prefs [:scene :grid])
-                      (swap-state merge (prefs/get prefs [:scene :grid]))
+                      (prefs/reset-path! prefs [:scene (grid-mode camera)])
+                      (swap-state merge (get-grid-pref prefs camera []))
                       (invalidate-grids! app-view))}
          {:key :size :type :vec3-floats
-          :value (prefs/get prefs [:scene :grid :size])
+          :value (get-grid-pref prefs camera [:size])
           :on-value-changed (partial value-changed-fn :size)}
          {:key :active-plane :type :vec3-toggle :label "scene-popup.grid.plane"
-          :value (prefs/get prefs [:scene :grid :active-plane])
+          :value (get-grid-pref prefs camera [:active-plane])
           :on-value-changed (partial value-changed-fn :active-plane)}
          {:key :color :type :color :label "scene-popup.grid.color"
-          :value (prefs/get prefs [:scene :grid :color])
+          :value (get-grid-pref prefs camera [:color])
           :on-value-changed (partial value-changed-fn :color)}
          {:key :opacity :type :slider :label "scene-popup.grid.opacity" :min 0.0 :max 1.0
-          :value (prefs/get prefs [:scene :grid :opacity])
+          :value (get-grid-pref prefs camera [:opacity])
           :on-value-changed (partial value-changed-fn :opacity)
           :slider-value->string (fn [^double v]
                                   (str (Math/round (* v 100)) "%"))}]

--- a/editor/src/clj/editor/grid.clj
+++ b/editor/src/clj/editor/grid.clj
@@ -259,9 +259,9 @@
 (g/defnk produce-merged-options
   [prefs camera options]
   (let [mode-2d (c/mode-2d? camera)]
-    (merge (get-grid-pref prefs camera [])
-           options
-           {:auto-scale true})))
+    (merge (if prefs (get-grid-pref prefs camera []) {})
+           {:auto-scale true}
+           options)))
 
 (g/defnode Grid
   (property prefs g/Any)

--- a/editor/src/clj/editor/grid.clj
+++ b/editor/src/clj/editor/grid.clj
@@ -258,10 +258,9 @@
 
 (g/defnk produce-merged-options
   [prefs camera options]
-  (let [mode-2d (c/mode-2d? camera)]
-    (merge (if prefs (get-grid-pref prefs camera []) {})
-           {:auto-scale true}
-           options)))
+  (merge (if prefs (get-grid-pref prefs camera []) {})
+         {:auto-scale true}
+         options))
 
 (g/defnode Grid
   (property prefs g/Any)

--- a/editor/src/clj/editor/grid.clj
+++ b/editor/src/clj/editor/grid.clj
@@ -273,38 +273,41 @@
   (output renderable pass/RenderData :cached produce-renderable))
 
 (defn- invalidate-grids! [app-view]
-  (let [scene-view-id (g/node-value app-view :active-view)
-        grid-id (g/node-value scene-view-id :grid)]
+  (g/let-ec [scene-view-id (g/node-value app-view :active-view evaluation-context)
+             grid-id (g/node-value scene-view-id :grid evaluation-context)]
     (g/transact [(g/invalidate-output grid-id :grids)])))
 
 (defn show-settings! [^Parent owner app-view prefs keymap localization]
-  (let [scene-view-id (g/node-value app-view :active-view)
-        grid (g/node-value scene-view-id :grid)
-        camera (g/node-value grid :camera)
-        ignored-keys (set (keys (g/node-value grid :options)))
-        value-changed-fn (fn [k v]
-                           (set-grid-pref! prefs camera [k] v)
-                           (invalidate-grids! app-view))
-        all-descriptors
-        [{:type :reset-all
-          :on-reset (fn [swap-state]
-                      (prefs/reset-path! prefs [:scene (grid-mode camera)])
-                      (swap-state merge (get-grid-pref prefs camera []))
-                      (invalidate-grids! app-view))}
-         {:key :size :type :vec3-floats
-          :value (get-grid-pref prefs camera [:size])
-          :on-value-changed (partial value-changed-fn :size)}
-         {:key :active-plane :type :vec3-toggle :label "scene-popup.grid.plane"
-          :value (get-grid-pref prefs camera [:active-plane])
-          :on-value-changed (partial value-changed-fn :active-plane)}
-         {:key :color :type :color :label "scene-popup.grid.color"
-          :value (get-grid-pref prefs camera [:color])
-          :on-value-changed (partial value-changed-fn :color)}
-         {:key :opacity :type :slider :label "scene-popup.grid.opacity" :min 0.0 :max 1.0
-          :value (get-grid-pref prefs camera [:opacity])
-          :on-value-changed (partial value-changed-fn :opacity)
-          :slider-value->string (fn [^double v]
-                                  (str (Math/round (* v 100)) "%"))}]
-        descriptors (filterv #(not (contains? ignored-keys (:key %))) all-descriptors)
-        initial-state (into {} (keep #(when-let [k (:key %)] [k (:value %)])) descriptors)]
-    (settings-popup/show! owner keymap localization initial-state 240 descriptors)))
+  (g/let-ec [scene-view-id (g/node-value app-view :active-view evaluation-context)
+             grid (g/node-value scene-view-id :grid evaluation-context)
+             camera (g/node-value grid :camera evaluation-context)
+             ignored-keys (set (keys (g/node-value grid :options evaluation-context)))]
+    (let [value-changed-fn (fn [k v]
+                             (set-grid-pref! prefs camera [k] v)
+                             (invalidate-grids! app-view))
+
+          all-descriptors
+          [{:type :reset-all
+            :on-reset (fn [swap-state]
+                        (prefs/reset-path! prefs [:scene (grid-mode camera)])
+                        (swap-state merge (get-grid-pref prefs camera []))
+                        (invalidate-grids! app-view))}
+           {:key :size :type :vec3-floats
+            :value (get-grid-pref prefs camera [:size])
+            :on-value-changed (partial value-changed-fn :size)}
+           {:key :active-plane :type :vec3-toggle :label "scene-popup.grid.plane"
+            :value (get-grid-pref prefs camera [:active-plane])
+            :on-value-changed (partial value-changed-fn :active-plane)}
+           {:key :color :type :color :label "scene-popup.grid.color"
+            :value (get-grid-pref prefs camera [:color])
+            :on-value-changed (partial value-changed-fn :color)}
+           {:key :opacity :type :slider :label "scene-popup.grid.opacity" :min 0.0 :max 1.0
+            :value (get-grid-pref prefs camera [:opacity])
+            :on-value-changed (partial value-changed-fn :opacity)
+            :slider-value->string (fn [^double v]
+                                    (str (Math/round (* v 100)) "%"))}]
+
+          descriptors (filterv #(not (contains? ignored-keys (:key %))) all-descriptors)
+
+          initial-state (into {} (keep #(when-let [k (:key %)] [k (:value %)])) descriptors)]
+      (settings-popup/show! owner keymap localization initial-state 240 descriptors))))

--- a/editor/src/clj/editor/prefs.clj
+++ b/editor/src/clj/editor/prefs.clj
@@ -893,8 +893,7 @@
   (update! prefs pref-path assoc-in (into [entry-key] entry-path) value))
 
 (defn update-pref-entry-in! [prefs pref-path entry-key entry-path f & args]
-  (update! prefs pref-path
-                 #(apply update-in % (into [entry-key] entry-path) f args)))
+  (update! prefs pref-path #(apply update-in % (into [entry-key] entry-path) f args)))
 
 (defn schema
   "Get a preference schema at a specified get-in path"

--- a/editor/src/clj/editor/prefs.clj
+++ b/editor/src/clj/editor/prefs.clj
@@ -267,14 +267,22 @@
                                                                           :projection {:type :enum
                                                                                        :values [:orthographic :perspective]
                                                                                        :default :orthographic}
-                                                                          :position (vec3-schema 0.0 0.0 0.0)
-                                                                          :rotation {:type :object
-                                                                                     :properties {:x {:type :number :default 0.0}
-                                                                                                  :y {:type :number :default 0.0}
-                                                                                                  :z {:type :number :default 0.0}
-                                                                                                  :w {:type :number :default 1.0}}}
+                                                                          :position {:type :tuple
+                                                                                     :items [{:type :number :default 0.0}
+                                                                                             {:type :number :default 0.0}
+                                                                                             {:type :number :default 0.0}]}
+                                                                          :rotation {:type :tuple
+                                                                                     :items [{:type :number :default 0.0}
+                                                                                             {:type :number :default 0.0}
+                                                                                             {:type :number :default 0.0}
+                                                                                             {:type :number :default 1.0}]}
+                                                                          :fov-x {:type :number :default 1000.0}
                                                                           :fov-y {:type :number :default 1000.0}
-                                                                          :focus-point (vec3-schema 0.0 0.0 0.0)}}}}}
+                                                                          :focus-point {:type :tuple
+                                                                                        :items [{:type :number :default 0.0}
+                                                                                                {:type :number :default 0.0}
+                                                                                                {:type :number :default 0.0}
+                                                                                                {:type :number :default 1.0}]}}}}}}
              ;; NOTE: We also track whether the grid button is active or not, however, not here. Because the grid visibility
              ;; is controlled by the SceneVisibilityNode, we ended up piggy-backing a per-resource grid button active setting
              ;; through [:scene :resource-settings <resource-proj-path> :scene-visibility]

--- a/editor/src/clj/editor/prefs.clj
+++ b/editor/src/clj/editor/prefs.clj
@@ -276,6 +276,7 @@
                                                                  :properties {:filters-enabled {:type :boolean :default true}
                                                                               :filtered-renderable-tags {:type :set :item {:type :keyword}}}}}}}
              :grid-2d {:type :object
+                       :scope :project
                        :properties {:visible {:type :boolean :default true}
                                     :size vec3-schema
                                     :active-plane {:type :enum :values [:x :y :z] :default :z}
@@ -284,13 +285,14 @@
                                             :items [{:type :number} {:type :number} {:type :number} {:type :number}]
                                             :default [0.5 0.5 0.5 1.0]}}}
              :grid-3d {:type :object
-                    :properties {:visible {:type :boolean :default true}
-                                 :size vec3-schema
-                                 :active-plane {:type :enum :values [:x :y :z] :default :y}
-                                 :opacity {:type :number :default 0.25}
-                                 :color {:type :tuple
-                                         :items [{:type :number} {:type :number} {:type :number} {:type :number}]
-                                         :default [0.5 0.5 0.5 1.0]}}}
+                       :scope :project
+                       :properties {:visible {:type :boolean :default true}
+                                    :size vec3-schema
+                                    :active-plane {:type :enum :values [:x :y :z] :default :y}
+                                    :opacity {:type :number :default 0.25}
+                                    :color {:type :tuple
+                                            :items [{:type :number} {:type :number} {:type :number} {:type :number}]
+                                            :default [0.5 0.5 0.5 1.0]}}}
              :perspective-camera {:type :object
                                   :scope :project
                                   :properties {:speed {:type :number :default 1.0}

--- a/editor/src/clj/editor/prefs.clj
+++ b/editor/src/clj/editor/prefs.clj
@@ -78,6 +78,12 @@
 
 #_[:boolean :string :password :locale :keyword :integer :number :one-of :array :set :object :object-of :enum :tuple]
 
+(def ^:private vec3-schema
+  {:type :object
+   :properties {:x {:type :number :default 1.0}
+                :y {:type :number :default 1.0}
+                :z {:type :number :default 1.0}}})
+
 (def default-schema
   {:type :object
    :properties
@@ -249,15 +255,38 @@
     :scene {:type :object
             :properties
             {:move-whole-pixels {:type :boolean :default true}
-             :grid {:type :object
-                    :scope :project
-                    :properties {:size {:type :object
-                                        :scope :project
-                                        :properties
-                                        {:x {:type :number :default 1.0}
-                                         :y {:type :number :default 1.0}
-                                         :z {:type :number :default 1.0}}}
-                                 :active-plane {:type :enum :values [:x :y :z] :default :z}
+             :resource-settings {:type :object-of
+                                 :scope :project
+                                 :key {:type :string}
+                                 :val {:type :object
+                                       :properties {:camera {:type :object
+                                                             :properties {:2d-mode {:type :boolean :default true}
+                                                                          :projection {:type :enum
+                                                                                       :values [:orthographic :perspective]
+                                                                                       :default :orthographic}
+                                                                          :position vec3-schema
+                                                                          :rotation {:type :object
+                                                                                     :properties {:x {:type :number :default 0.0}
+                                                                                                  :y {:type :number :default 0.0}
+                                                                                                  :z {:type :number :default 0.0}
+                                                                                                  :w {:type :number :default 1.0}}}
+                                                                          :fov-y {:type :number :default 1000.0}
+                                                                          :focus-point vec3-schema}}
+                                                    :visibility {:type :object
+                                                                 :properties {:filters-enabled {:type :boolean :default true}
+                                                                              :filtered-renderable-tags {:type :set :item {:type :keyword}}}}}}}
+             :grid-2d {:type :object
+                       :properties {:visible {:type :boolean :default true}
+                                    :size vec3-schema
+                                    :active-plane {:type :enum :values [:x :y :z] :default :z}
+                                    :opacity {:type :number :default 0.25}
+                                    :color {:type :tuple
+                                            :items [{:type :number} {:type :number} {:type :number} {:type :number}]
+                                            :default [0.5 0.5 0.5 1.0]}}}
+             :grid-3d {:type :object
+                    :properties {:visible {:type :boolean :default true}
+                                 :size vec3-schema
+                                 :active-plane {:type :enum :values [:x :y :z] :default :y}
                                  :opacity {:type :number :default 0.25}
                                  :color {:type :tuple
                                          :items [{:type :number} {:type :number} {:type :number} {:type :number}]
@@ -838,6 +867,30 @@
                  m
                  events))))
     nil))
+
+(defn get-pref-entry
+  ([prefs pref-path entry-key]
+   (get-pref-entry prefs pref-path entry-key nil))
+  ([prefs pref-path entry-key default]
+   (clojure.core/get (get prefs pref-path) entry-key default)))
+
+(defn get-pref-entry-in
+  ([prefs pref-path entry-key entry-path]
+   (get-pref-entry-in prefs pref-path entry-key entry-path nil))
+  ([prefs pref-path entry-key entry-path default]
+   (get-in (get prefs pref-path)
+           (into [entry-key] entry-path)
+           default)))
+
+(defn set-pref-entry! [prefs pref-path entry-key value]
+  (update! prefs pref-path assoc entry-key value))
+
+(defn set-pref-entry-in! [prefs pref-path entry-key entry-path value]
+  (update! prefs pref-path assoc-in (into [entry-key] entry-path) value))
+
+(defn update-pref-entry-in! [prefs pref-path entry-key entry-path f & args]
+  (update! prefs pref-path
+                 #(apply update-in % (into [entry-key] entry-path) f args)))
 
 (defn schema
   "Get a preference schema at a specified get-in path"

--- a/editor/src/clj/editor/prefs.clj
+++ b/editor/src/clj/editor/prefs.clj
@@ -280,8 +280,7 @@
                                                                           :focus-point {:type :tuple
                                                                                         :items [{:type :number :default 0.0}
                                                                                                 {:type :number :default 0.0}
-                                                                                                {:type :number :default 0.0}
-                                                                                                {:type :number :default 1.0}]}}}}}}
+                                                                                                {:type :number :default 0.0}]}}}}}}
              ;; NOTE: We also track whether the grid button is active or not, however, not here. Because the grid visibility
              ;; is controlled by the SceneVisibilityNode, we ended up piggy-backing a per-resource grid button active setting
              ;; through [:scene :resource-settings <resource-proj-path> :scene-visibility]

--- a/editor/src/clj/editor/prefs.clj
+++ b/editor/src/clj/editor/prefs.clj
@@ -78,11 +78,11 @@
 
 #_[:boolean :string :password :locale :keyword :integer :number :one-of :array :set :object :object-of :enum :tuple]
 
-(def ^:private vec3-schema
+(defn- vec3-schema [^double x ^double y ^double z]
   {:type :object
-   :properties {:x {:type :number :default 1.0}
-                :y {:type :number :default 1.0}
-                :z {:type :number :default 1.0}}})
+   :properties {:x {:type :number :default x}
+                :y {:type :number :default y}
+                :z {:type :number :default z}}})
 
 (def default-schema
   {:type :object
@@ -255,32 +255,32 @@
     :scene {:type :object
             :properties
             {:move-whole-pixels {:type :boolean :default true}
-             :camera-resource-settings {:type :object-of
-                                        :scope :project
-                                        :key {:type :string}
-                                        :val {:type :object
-                                              :properties {:2d-mode {:type :boolean :default true}
-                                                           :projection {:type :enum
-                                                                        :values [:orthographic :perspective]
-                                                                        :default :orthographic}
-                                                           :position vec3-schema
-                                                           :rotation {:type :object
-                                                                      :properties {:x {:type :number :default 0.0}
-                                                                                   :y {:type :number :default 0.0}
-                                                                                   :z {:type :number :default 0.0}
-                                                                                   :w {:type :number :default 1.0}}}
-                                                           :fov-y {:type :number :default 1000.0}
-                                                           :focus-point vec3-schema}}}
-             :visibility-resource-settings {:type :object-of
-                                            :scope :project
-                                            :key {:type :string}
-                                            :val {:type :object
-                                                  :properties {:filters-enabled {:type :boolean :default true}
-                                                               :filtered-renderable-tags {:type :set :item {:type :keyword}}}}}
+             :resource-settings {:type :object-of
+                                 :scope :project
+                                 :key {:type :string}
+                                 :val {:type :object
+                                       :properties {:scene-visibility {:type :object
+                                                                       :properties {:filters-enabled {:type :boolean :default true}
+                                                                                    :filtered-renderable-tags {:type :set :item {:type :keyword}}}}
+                                                    :camera {:type :object
+                                                             :properties {:2d-mode {:type :boolean :default true}
+                                                                          :projection {:type :enum
+                                                                                       :values [:orthographic :perspective]
+                                                                                       :default :orthographic}
+                                                                          :position (vec3-schema 0.0 0.0 0.0)
+                                                                          :rotation {:type :object
+                                                                                     :properties {:x {:type :number :default 0.0}
+                                                                                                  :y {:type :number :default 0.0}
+                                                                                                  :z {:type :number :default 0.0}
+                                                                                                  :w {:type :number :default 1.0}}}
+                                                                          :fov-y {:type :number :default 1000.0}
+                                                                          :focus-point (vec3-schema 0.0 0.0 0.0)}}}}}
+             ;; NOTE: We also track whether the grid button is active or not, however, not here. Because the grid visibility
+             ;; is controlled by the SceneVisibilityNode, we ended up piggy-backing a per-resource grid button active setting
+             ;; through [:scene :resource-settings <resource-proj-path> :scene-visibility]
              :grid-2d {:type :object
                        :scope :project
-                       :properties {:visible {:type :boolean :default true}
-                                    :size vec3-schema
+                       :properties {:size (vec3-schema 1.0 1.0 1.0)
                                     :active-plane {:type :enum :values [:x :y :z] :default :z}
                                     :opacity {:type :number :default 0.25}
                                     :color {:type :tuple
@@ -288,8 +288,7 @@
                                             :default [0.5 0.5 0.5 1.0]}}}
              :grid-3d {:type :object
                        :scope :project
-                       :properties {:visible {:type :boolean :default true}
-                                    :size vec3-schema
+                       :properties {:size (vec3-schema 1.0 1.0 1.0)
                                     :active-plane {:type :enum :values [:x :y :z] :default :y}
                                     :opacity {:type :number :default 0.25}
                                     :color {:type :tuple

--- a/editor/src/clj/editor/prefs.clj
+++ b/editor/src/clj/editor/prefs.clj
@@ -78,7 +78,7 @@
 
 #_[:boolean :string :password :locale :keyword :integer :number :one-of :array :set :object :object-of :enum :tuple]
 
-(defn- vec3-schema [^double x ^double y ^double z]
+(defn- vec3-schema [x y z]
   {:type :object
    :properties {:x {:type :number :default x}
                 :y {:type :number :default y}
@@ -879,28 +879,13 @@
                  events))))
     nil))
 
-(defn get-pref-entry
-  ([prefs pref-path entry-key]
-   (get-pref-entry prefs pref-path entry-key nil))
-  ([prefs pref-path entry-key default]
-   (clojure.core/get (get prefs pref-path) entry-key default)))
-
-(defn get-pref-entry-in
-  ([prefs pref-path entry-key entry-path]
-   (get-pref-entry-in prefs pref-path entry-key entry-path nil))
-  ([prefs pref-path entry-key entry-path default]
-   (get-in (get prefs pref-path)
-           (into [entry-key] entry-path)
-           default)))
-
-(defn set-pref-entry! [prefs pref-path entry-key value]
-  (update! prefs pref-path assoc entry-key value))
+(defn get-pref-entry-in [prefs pref-path entry-key entry-path default]
+  (get-in (get prefs pref-path)
+          (into [entry-key] entry-path)
+          default))
 
 (defn set-pref-entry-in! [prefs pref-path entry-key entry-path value]
   (update! prefs pref-path assoc-in (into [entry-key] entry-path) value))
-
-(defn update-pref-entry-in! [prefs pref-path entry-key entry-path f & args]
-  (update! prefs pref-path #(apply update-in % (into [entry-key] entry-path) f args)))
 
 (defn schema
   "Get a preference schema at a specified get-in path"

--- a/editor/src/clj/editor/prefs.clj
+++ b/editor/src/clj/editor/prefs.clj
@@ -255,26 +255,28 @@
     :scene {:type :object
             :properties
             {:move-whole-pixels {:type :boolean :default true}
-             :resource-settings {:type :object-of
-                                 :scope :project
-                                 :key {:type :string}
-                                 :val {:type :object
-                                       :properties {:camera {:type :object
-                                                             :properties {:2d-mode {:type :boolean :default true}
-                                                                          :projection {:type :enum
-                                                                                       :values [:orthographic :perspective]
-                                                                                       :default :orthographic}
-                                                                          :position vec3-schema
-                                                                          :rotation {:type :object
-                                                                                     :properties {:x {:type :number :default 0.0}
-                                                                                                  :y {:type :number :default 0.0}
-                                                                                                  :z {:type :number :default 0.0}
-                                                                                                  :w {:type :number :default 1.0}}}
-                                                                          :fov-y {:type :number :default 1000.0}
-                                                                          :focus-point vec3-schema}}
-                                                    :visibility {:type :object
-                                                                 :properties {:filters-enabled {:type :boolean :default true}
-                                                                              :filtered-renderable-tags {:type :set :item {:type :keyword}}}}}}}
+             :camera-resource-settings {:type :object-of
+                                        :scope :project
+                                        :key {:type :string}
+                                        :val {:type :object
+                                              :properties {:2d-mode {:type :boolean :default true}
+                                                           :projection {:type :enum
+                                                                        :values [:orthographic :perspective]
+                                                                        :default :orthographic}
+                                                           :position vec3-schema
+                                                           :rotation {:type :object
+                                                                      :properties {:x {:type :number :default 0.0}
+                                                                                   :y {:type :number :default 0.0}
+                                                                                   :z {:type :number :default 0.0}
+                                                                                   :w {:type :number :default 1.0}}}
+                                                           :fov-y {:type :number :default 1000.0}
+                                                           :focus-point vec3-schema}}}
+             :visibility-resource-settings {:type :object-of
+                                            :scope :project
+                                            :key {:type :string}
+                                            :val {:type :object
+                                                  :properties {:filters-enabled {:type :boolean :default true}
+                                                               :filtered-renderable-tags {:type :set :item {:type :keyword}}}}}
              :grid-2d {:type :object
                        :scope :project
                        :properties {:visible {:type :boolean :default true}

--- a/editor/src/clj/editor/prefs.clj
+++ b/editor/src/clj/editor/prefs.clj
@@ -263,8 +263,7 @@
                                                                        :properties {:filters-enabled {:type :boolean :default true}
                                                                                     :filtered-renderable-tags {:type :set :item {:type :keyword}}}}
                                                     :camera {:type :object
-                                                             :properties {:2d-mode {:type :boolean :default true}
-                                                                          :projection {:type :enum
+                                                             :properties {:projection {:type :enum
                                                                                        :values [:orthographic :perspective]
                                                                                        :default :orthographic}
                                                                           :position {:type :tuple

--- a/editor/src/clj/editor/scene.clj
+++ b/editor/src/clj/editor/scene.clj
@@ -1813,12 +1813,15 @@
             (ui/user-data! image-view ::last-frame-version frame-version)
             (scene-cache/prune-context! gl)
             (reset! async-copy-state-atom (scene-async/finish-image! (scene-async/begin-read! @async-copy-state-atom gl) gl))))))
-    ;; call frame-selection if it's the very first aabb change for the scene
+    ;; Call frame-selection if it's the very first aabb change for the scene, unless
+    ;; we restored a camera from prefs and should preserve it through initial load.
     (let [prev-aabb (ui/user-data image-view ::prev-scene-aabb)
+          preserve-initial-camera (ui/user-data image-view ::preserve-initial-camera)
           [scene-aabb reframing-info]
           (g/with-auto-evaluation-context evaluation-context
             (let [scene-aabb (g/node-value view-id :scene-aabb evaluation-context)
-                  reframing-info (when (and prev-aabb
+                  reframing-info (when (and (not preserve-initial-camera)
+                                            prev-aabb
                                             (geom/predefined-aabb? prev-aabb)
                                             (not (geom/predefined-aabb? scene-aabb)))
                                    (aabb-framing-info view-id scene-aabb evaluation-context))]
@@ -1826,6 +1829,9 @@
                     reframing-info)))]
 
       (ui/user-data! image-view ::prev-scene-aabb scene-aabb)
+      (when (and preserve-initial-camera
+                 (not (geom/predefined-aabb? scene-aabb)))
+        (ui/user-data! image-view ::preserve-initial-camera false))
       (when reframing-info
         (apply-framing-info! reframing-info true)))
     (let [new-image (scene-async/image @async-copy-state-atom)]
@@ -1999,17 +2005,20 @@
                              (ui/on-closed! (:tab opts) (fn [_]
                                                           (ui/kill-event-dispatch! this)
                                                           (dispose-scene-view! view-id)))
-                            (if camera-inset-drawable
-                              (g/set-properties! view-id
-                                                :drawable drawable
-                                                :picking-drawable picking-drawable
-                                                :camera-inset-drawable camera-inset-drawable
-                                                :async-copy-state (atom (scene-async/make-async-copy-state width height)))
-                              (g/set-properties! view-id
-                                                :drawable drawable
-                                                :picking-drawable picking-drawable
-                                                :async-copy-state (atom (scene-async/make-async-copy-state width height))))
-                             (frame-selection! view-id false)))))
+                             (when (:camera opts)
+                               (ui/user-data! image-view ::preserve-initial-camera true))
+                             (if camera-inset-drawable
+                               (g/set-properties! view-id
+                                                 :drawable drawable
+                                                 :picking-drawable picking-drawable
+                                                 :camera-inset-drawable camera-inset-drawable
+                                                 :async-copy-state (atom (scene-async/make-async-copy-state width height)))
+                               (g/set-properties! view-id
+                                                 :drawable drawable
+                                                 :picking-drawable picking-drawable
+                                                 :async-copy-state (atom (scene-async/make-async-copy-state width height))))
+                             (when-not (:camera opts)
+                               (frame-selection! view-id false))))))
                      (catch Throwable error
                        (error-reporting/report-exception! error)))
                    (proxy-super layoutChildren))))]

--- a/editor/src/clj/editor/scene.clj
+++ b/editor/src/clj/editor/scene.clj
@@ -44,6 +44,7 @@
             [editor.mouse-binding :as mouse-binding]
             [editor.os :as os]
             [editor.pose :as pose]
+            [editor.prefs :as prefs]
             [editor.properties :as properties]
             [editor.protobuf :as protobuf]
             [editor.render-util :as render-util]
@@ -2134,6 +2135,11 @@
 (defmethod attach-tool-controller :default
   [_ tool-node view-id resource-node])
 
+(defn- make-default-scene-camera [prefs projection]
+  (if (= projection :perspective)
+    (c/make-camera :perspective identity {:fov-y (prefs/get prefs [:scene :perspective-camera :fov])})
+    (c/make-camera :orthographic identity {:fov-x 1000 :fov-y 1000})))
+
 (defn setup-view [view-id resource-node opts]
   (let [view-graph           (g/node-id->graph-id view-id)
         app-view-id          (:app-view opts)
@@ -2153,7 +2159,8 @@
                                                                                    (g/operation-sequence op-seq)
                                                                                    (g/operation-label (localization/message "operation.select"))
                                                                                    (select-fn selection))))]
-                   camera          [c/CameraController :local-camera (or (:camera opts) (c/make-camera :orthographic identity {:fov-x 1000 :fov-y 1000}))
+                   camera          [c/CameraController :local-camera (or (:camera opts)
+                                                                         (make-default-scene-camera prefs (:default-camera-projection opts)))
                                                        :image-view (g/node-value view-id :image-view)
                                                        :prefs prefs]
                    grid            (grid-type :prefs prefs)

--- a/editor/src/clj/editor/scene.clj
+++ b/editor/src/clj/editor/scene.clj
@@ -44,7 +44,6 @@
             [editor.mouse-binding :as mouse-binding]
             [editor.os :as os]
             [editor.pose :as pose]
-            [editor.prefs :as prefs]
             [editor.properties :as properties]
             [editor.protobuf :as protobuf]
             [editor.render-util :as render-util]
@@ -2135,11 +2134,6 @@
 (defmethod attach-tool-controller :default
   [_ tool-node view-id resource-node])
 
-(defn- make-default-scene-camera [prefs projection]
-  (if (= projection :perspective)
-    (c/make-camera :perspective identity {:fov-y (prefs/get prefs [:scene :perspective-camera :fov])})
-    (c/make-camera :orthographic identity {:fov-x 1000 :fov-y 1000})))
-
 (defn setup-view [view-id resource-node opts]
   (let [view-graph           (g/node-id->graph-id view-id)
         app-view-id          (:app-view opts)
@@ -2160,7 +2154,7 @@
                                                                                    (g/operation-label (localization/message "operation.select"))
                                                                                    (select-fn selection))))]
                    camera          [c/CameraController :local-camera (or (:camera opts)
-                                                                         (make-default-scene-camera prefs (:default-camera-projection opts)))
+                                                                         (c/default-scene-camera prefs (:default-camera-projection opts)))
                                                        :image-view (g/node-value view-id :image-view)
                                                        :prefs prefs]
                    grid            (grid-type :prefs prefs)

--- a/editor/src/clj/editor/scene_visibility.clj
+++ b/editor/src/clj/editor/scene_visibility.clj
@@ -16,6 +16,9 @@
   (:require [clojure.set :as set]
             [dynamo.graph :as g]
             [editor.handler :as handler]
+            [editor.prefs :as prefs]
+            [editor.resource :as resource]
+            [editor.resource-node :as resource-node]
             [editor.system :as system]
             [editor.types :as types]
             [editor.ui :as ui]
@@ -113,6 +116,7 @@
 (def ^:private outline-selection-entry->outline-name-path (comp not-empty vec next :node-outline-key-path))
 
 (g/defnode SceneVisibilityNode
+  (property prefs g/Any)
   (property app-view g/NodeID)
   (property visibility-filters-enabled? g/Bool (default true))
   (property filtered-renderable-tags types/RenderableTags (default #{:dev-visibility-bounds}))
@@ -174,8 +178,8 @@
                                                                                     hide-history))
                                                                                 scene-hide-history-datas)))))
 
-(defn make-scene-visibility-node! [view-graph app-view]
-  (g/make-node! view-graph SceneVisibilityNode :app-view app-view))
+(defn make-scene-visibility-node! [view-graph prefs app-view]
+  (g/make-node! view-graph SceneVisibilityNode :prefs prefs :app-view app-view))
 
 ;; -----------------------------------------------------------------------------
 ;; Per-Object Visibility
@@ -283,8 +287,20 @@
 
 (defn- toggle-tag-visibility-fn [scene-visibility tag]
   (fn [v]
-    (g/update-property! scene-visibility :filtered-renderable-tags (if v disj conj) tag)
-    (sync-popup-state! scene-visibility)))
+    ;; TODO JOE: Refactor this somehow
+    (g/with-auto-evaluation-context evaluation-context
+      (let [basis (:basis evaluation-context)
+            prefs (g/node-value scene-visibility :prefs evaluation-context)
+            resource-node (first (g/node-value scene-visibility :active-resource-node+type evaluation-context))
+            path-key (resource/resource->proj-path (resource-node/resource basis resource-node))
+            tags (g/node-value scene-visibility :filtered-renderable-tags evaluation-context)
+            updated-tags ((if v disj conj) tags tag)]
+        (g/set-property! scene-visibility :filtered-renderable-tags updated-tags)
+        (prefs/update! prefs [:scene :resource-settings] assoc
+                       path-key
+                       {:filters-enabled true
+                        :filtered-renderable-tags updated-tags}))
+      (sync-popup-state! scene-visibility))))
 
 (defn renderable-tag-descriptors [scene-visibility]
   (let [filtered-tags (g/node-value scene-visibility :filtered-renderable-tags)
@@ -299,8 +315,18 @@
     (cond-> [{:key :visibility-filters :type :toggle :label "scene-popup.scene-visibility.visibility-filters"
               :value filters-enabled?
               :on-value-changed (fn [v]
-                                  (g/set-property! scene-visibility :visibility-filters-enabled? v)
-                                  (sync-popup-state! scene-visibility))
+                                  (g/with-auto-evaluation-context evaluation-context
+                                    (let [basis (:basis evaluation-context)
+                                          prefs (g/node-value scene-visibility :prefs evaluation-context)
+                                          resource-node (first (g/node-value scene-visibility :active-resource-node+type evaluation-context))
+                                          path-key (resource/resource->proj-path (resource-node/resource basis resource-node))
+                                          tags (g/node-value scene-visibility :filtered-renderable-tags evaluation-context)]
+                                      (g/set-property! scene-visibility :visibility-filters-enabled? v)
+                                      (prefs/update! prefs [:scene :resource-settings] assoc
+                                                     path-key
+                                                     {:filters-enabled v
+                                                      :filtered-renderable-tags tags}))
+                                    (sync-popup-state! scene-visibility)))
               :command :scene.visibility.toggle-filters}
              {:type :space}
              (tag-toggle :collision-shape "collision-shapes")
@@ -378,6 +404,12 @@
                         (if (contains? tags tag)
                           (disj tags tag)
                           (conj tags tag)))))
+
+(defn update-settings [scene-visibility {:keys [filters-enabled filtered-renderable-tags]} evaluation-context]
+  (g/transact
+    (concat
+      (g/set-property scene-visibility :visibility-filters-enabled? filters-enabled)
+      (g/set-property scene-visibility :filtered-renderable-tags filtered-renderable-tags))))
 
 (handler/defhandler :scene.visibility.toggle-filters :workbench
   (active? [scene-visibility evaluation-context]

--- a/editor/src/clj/editor/scene_visibility.clj
+++ b/editor/src/clj/editor/scene_visibility.clj
@@ -269,9 +269,8 @@
              path-key (resource/resource->proj-path (resource-node/resource basis resource-node))
              updated-settings (update-fn (settings scene-visibility evaluation-context))]
     (set-settings! scene-visibility updated-settings)
-    (prefs/update! prefs [:scene :visibility-resource-settings] assoc
-                   path-key
-                   updated-settings)
+    (prefs/set-pref-entry-in! prefs [:scene :resource-settings] path-key [:scene-visibility]
+                              updated-settings)
     (sync-popup-state! scene-visibility)))
 
 (defn- toggle-tag-visibility-fn [scene-visibility tag]
@@ -298,6 +297,7 @@
              (tag-toggle :gui-particlefx "gui-particle-effects")
              (tag-toggle :gui-spine "gui-spine-scenes")
              (tag-toggle :gui-text "gui-text")
+             (tag-toggle :light "lights")
              (tag-toggle :model "models")
              (tag-toggle :particlefx "particle-effects")
              (tag-toggle :skeleton "skeletons")
@@ -329,8 +329,8 @@
   (let [{:keys [filters-enabled filtered-renderable-tags]} (settings scene-visibility evaluation-context)]
     (.pseudoClassStateChanged btn (PseudoClass/getPseudoClass "filters-active")
                               (boolean (and filters-enabled
-                                            (some #(not-every? never-appear-filtered-tags %)
-                                                  filtered-renderable-tags))))))
+                                            (not-every? never-appear-filtered-tags
+                                                        filtered-renderable-tags))))))
 
 (defn show-settings! [keymap localization ^Parent owner scene-visibility]
   (let [setting-descriptors (g/let-ec [current-settings (settings scene-visibility evaluation-context)]
@@ -360,8 +360,8 @@
 (defn load-settings!
   "Applies the stored visibility settings for a scene resource, or the defaults."
   [scene-visibility prefs proj-path]
-  (let [stored-settings (prefs/get-pref-entry prefs [:scene :visibility-resource-settings]
-                                              proj-path default-settings)]
+  (let [stored-settings (prefs/get-pref-entry-in prefs [:scene :resource-settings]
+                                                 proj-path [:scene-visibility] default-settings)]
     (set-settings! scene-visibility stored-settings)))
 
 (handler/defhandler :scene.visibility.toggle-filters :workbench

--- a/editor/src/clj/editor/scene_visibility.clj
+++ b/editor/src/clj/editor/scene_visibility.clj
@@ -266,12 +266,13 @@
 (defn- set-visibility-settings! [scene-visibility update-fn]
   (g/let-ec [basis (:basis evaluation-context)
              prefs (g/node-value scene-visibility :prefs evaluation-context)
-             resource-node (first (g/node-value scene-visibility :active-resource-node+type evaluation-context))
-             path-key (resource/resource->proj-path (resource-node/resource basis resource-node))
+             resource-node (g/node-value scene-visibility :active-scene-resource-node evaluation-context)
+             path-key (some->> resource-node (resource-node/resource basis) resource/proj-path)
              updated-settings (update-fn (settings scene-visibility evaluation-context))]
     (set-settings! scene-visibility updated-settings)
-    (prefs/set-pref-entry-in! prefs [:scene :resource-settings] path-key [:scene-visibility]
-                              updated-settings)
+    (when path-key
+      (prefs/set-pref-entry-in! prefs [:scene :resource-settings] path-key [:scene-visibility]
+                                updated-settings))
     (sync-popup-state! scene-visibility)))
 
 (defn- toggle-tag-visibility-fn [scene-visibility tag]

--- a/editor/src/clj/editor/scene_visibility.clj
+++ b/editor/src/clj/editor/scene_visibility.clj
@@ -31,49 +31,6 @@
 
 (set! *warn-on-reflection* true)
 
-(def ^:private renderable-tag-toggles-info
-  (cond-> [{:label "Collision Shapes" :tag :collision-shape}
-           {:label "Camera" :tag :camera}
-           #_{:label "GUI Elements" :tag :gui} ; This tag exists, but we decided to hide it and put in granular control instead. Add back if we make the toggles hierarchical?
-           {:label "GUI Bounds" :tag :gui-bounds}
-           {:label "GUI Shapes" :tag :gui-shape}
-           {:label "GUI Particle Effects" :tag :gui-particlefx}
-           {:label "GUI Spine Scenes" :tag :gui-spine}
-           {:label "GUI Text" :tag :gui-text}
-           {:label "Lights" :tag :light}
-           {:label "Models" :tag :model}
-           {:label "Particle Effects" :tag :particlefx}
-           {:label "Skeletons" :tag :skeleton}
-           {:label "Spine Scenes" :tag :spine}
-           {:label "Sprites" :tag :sprite}
-           {:label "Text" :tag :text}
-           {:label "Tile Maps" :tag :tilemap}
-           {:label :separator}
-           {:label "Component Guides" :tag :outline :command :scene.visibility.toggle-component-guides :always-enabled true}]
-
-          (system/defold-dev?)
-          (into [{:label :separator}
-                 {:label "Scene Visibility Bounds" :tag :dev-visibility-bounds :appear-filtered false}])))
-
-(def ^:private appear-filtered-renderable-tags
-  (into #{}
-        (keep (fn [{:keys [appear-filtered tag]
-                    :or {appear-filtered true}}]
-                (when appear-filtered
-                  tag)))
-        renderable-tag-toggles-info))
-
-(defn filters-appear-active?
-  "Returns true if some parts of the scene are hidden due to visibility filters."
-  ([scene-visibility]
-   (g/with-auto-evaluation-context evaluation-context
-     (filters-appear-active? scene-visibility evaluation-context)))
-  ([scene-visibility evaluation-context]
-   (boolean
-     (and (g/node-value scene-visibility :visibility-filters-enabled? evaluation-context)
-          (some appear-filtered-renderable-tags
-                (g/node-value scene-visibility :filtered-renderable-tags evaluation-context))))))
-
 ;; -----------------------------------------------------------------------------
 ;; SceneVisibilityNode
 ;; -----------------------------------------------------------------------------
@@ -115,11 +72,26 @@
 
 (def ^:private outline-selection-entry->outline-name-path (comp not-empty vec next :node-outline-key-path))
 
+;; Applied to scene resources that have no stored visibility settings yet.
+(def default-settings
+  {:filters-enabled true
+   :filtered-renderable-tags #{:dev-visibility-bounds}})
+
+(defn settings [scene-visibility evaluation-context]
+  {:filters-enabled (g/node-value scene-visibility :visibility-filters-enabled? evaluation-context)
+   :filtered-renderable-tags (g/node-value scene-visibility :filtered-renderable-tags evaluation-context)})
+
+(defn set-settings! [scene-visibility {:keys [filters-enabled filtered-renderable-tags]}]
+  (g/transact
+    (concat
+      (g/set-property scene-visibility :visibility-filters-enabled? filters-enabled)
+      (g/set-property scene-visibility :filtered-renderable-tags filtered-renderable-tags))))
+
 (g/defnode SceneVisibilityNode
   (property prefs g/Any)
   (property app-view g/NodeID)
-  (property visibility-filters-enabled? g/Bool (default true))
-  (property filtered-renderable-tags types/RenderableTags (default #{:dev-visibility-bounds}))
+  (property visibility-filters-enabled? g/Bool (default (:filters-enabled default-settings)))
+  (property filtered-renderable-tags types/RenderableTags (default (:filtered-renderable-tags default-settings)))
   (property popup-advance-fn g/Any (default nil))
 
   (input active-resource-node+type g/Any)
@@ -277,53 +249,46 @@
 ;; -----------------------------------------------------------------------------
 ;; Visibility Filters
 ;; -----------------------------------------------------------------------------
-(declare sync-filter-button-style!)
+(declare sync-filter-button-style! toggle-button)
 
 (defn- sync-popup-state! [scene-visibility]
   (g/with-auto-evaluation-context evaluation-context
-    (sync-filter-button-style! (g/node-value scene-visibility :app-view) scene-visibility evaluation-context)
-    (when-let [advance! (g/node-value scene-visibility :popup-advance-fn)]
-      (advance!))))
+    (let [app-view (g/node-value scene-visibility :app-view evaluation-context)
+          btn (toggle-button app-view evaluation-context)]
+      (when btn
+        (sync-filter-button-style! btn scene-visibility evaluation-context))))
+  ;; advance! recomputes the popup state on its own, so it must run outside the
+  ;; evaluation-context scope above.
+  (when-let [advance! (g/node-value scene-visibility :popup-advance-fn)]
+    (advance!)))
 
-(defn- set-visibility-settings! [scene-visibility filters-enabled filtered-renderable-tags evaluation-context]
-  (let [basis (:basis evaluation-context)
-        prefs (g/node-value scene-visibility :prefs evaluation-context)
-        resource-node (first (g/node-value scene-visibility :active-resource-node+type evaluation-context))
-        path-key (resource/resource->proj-path (resource-node/resource basis resource-node))]
-    (g/transact
-      (concat
-        (g/set-property scene-visibility :visibility-filters-enabled? filters-enabled)
-        (g/set-property scene-visibility :filtered-renderable-tags filtered-renderable-tags)))
+(defn- set-visibility-settings! [scene-visibility update-fn]
+  (g/let-ec [basis (:basis evaluation-context)
+             prefs (g/node-value scene-visibility :prefs evaluation-context)
+             resource-node (first (g/node-value scene-visibility :active-resource-node+type evaluation-context))
+             path-key (resource/resource->proj-path (resource-node/resource basis resource-node))
+             updated-settings (update-fn (settings scene-visibility evaluation-context))]
+    (set-settings! scene-visibility updated-settings)
     (prefs/update! prefs [:scene :visibility-resource-settings] assoc
                    path-key
-                   {:filters-enabled filters-enabled
-                    :filtered-renderable-tags filtered-renderable-tags})
+                   updated-settings)
     (sync-popup-state! scene-visibility)))
 
 (defn- toggle-tag-visibility-fn [scene-visibility tag]
   (fn [v]
-    (g/with-auto-evaluation-context evaluation-context
-      (let [filters-enabled (g/node-value scene-visibility :visibility-filters-enabled?)
-            tags (g/node-value scene-visibility :filtered-renderable-tags evaluation-context)
-            updated-tags ((if v disj conj) tags tag)]
-        (set-visibility-settings! scene-visibility filters-enabled updated-tags evaluation-context)))))
+    (set-visibility-settings! scene-visibility #(update % :filtered-renderable-tags (if v disj conj) tag))))
 
-(defn renderable-tag-descriptors [scene-visibility]
-  (let [filtered-tags (g/node-value scene-visibility :filtered-renderable-tags)
-        filters-enabled? (g/node-value scene-visibility :visibility-filters-enabled?)
-        tag-toggle (fn [key label]
+(defn renderable-tag-descriptors [scene-visibility {:keys [filters-enabled filtered-renderable-tags]}]
+  (let [tag-toggle (fn [key label]
                      {:key key :type :toggle
                       :label (str "scene-popup.scene-visibility." label)
-                      :value (not (contains? filtered-tags key))
+                      :value (not (contains? filtered-renderable-tags key))
                       :on-value-changed (toggle-tag-visibility-fn scene-visibility key)
                       :style-class "compact-toggle"
                       :disabled? (fn [state] (not (:visibility-filters state)))})]
     (cond-> [{:key :visibility-filters :type :toggle :label "scene-popup.scene-visibility.visibility-filters"
-              :value filters-enabled?
-              :on-value-changed (fn [v]
-                                  (g/with-auto-evaluation-context evaluation-context
-                                    (let [tags (g/node-value scene-visibility :filtered-renderable-tags evaluation-context)]
-                                      (set-visibility-settings! scene-visibility v tags evaluation-context))))
+              :value filters-enabled
+              :on-value-changed (fn [v] (set-visibility-settings! scene-visibility #(assoc % :filters-enabled v)))
               :command :scene.visibility.toggle-filters}
              {:type :space}
              (tag-toggle :collision-shape "collision-shapes")
@@ -342,51 +307,43 @@
              (tag-toggle :tilemap "tile-maps")
              {:type :separator}
              {:key :outline :type :toggle :label "scene-popup.scene-visibility.component-guides"
-              :value (not (contains? filtered-tags :outline))
+              :value (not (contains? filtered-renderable-tags :outline))
               :on-value-changed (toggle-tag-visibility-fn scene-visibility :outline)
               :command :scene.visibility.toggle-component-guides}]
             (system/defold-dev?)
             (into [{:type :separator}
                    {:key :dev-visibility-bounds :type :toggle :label "scene-popup.scene-visibility.scene-visibility-bounds"
-                    :value (not (contains? filtered-tags :dev-visibility-bounds))
+                    :value (not (contains? filtered-renderable-tags :dev-visibility-bounds))
                     :on-value-changed (toggle-tag-visibility-fn scene-visibility :dev-visibility-bounds)
-                    :appear-filtered false
                     :disabled? (fn [state] (not (:visibility-filters state)))}]))))
 
-(defn- appear-filtered-renderable-tags [scene-visibility]
-  (into #{}
-        (keep (fn [{:keys [appear-filtered key]
-                    :or {appear-filtered true}}]
-                (when appear-filtered
-                  key)))
-        (renderable-tag-descriptors scene-visibility)))
+(def ^:private never-appear-filtered-tags #{:grid :dev-visibility-bounds})
 
-(defn toggle-button [app-view]
-  (some-> (g/node-value app-view :active-tab)
+(defn toggle-button [app-view evaluation-context]
+  (some-> (g/node-value app-view :active-tab evaluation-context)
           Tab/.getContent
           (ui/lookup-by-id "visibility-settings-graphic")
           Node/.getParent))
 
-(defn sync-filter-button-style! [app-view scene-visibility evaluation-context]
-  (when-let [btn ^ToggleButton (toggle-button app-view)]
-    (if (and (g/node-value scene-visibility :visibility-filters-enabled? evaluation-context)
-             (some (appear-filtered-renderable-tags scene-visibility)
-                   (g/node-value scene-visibility :filtered-renderable-tags evaluation-context)))
-      (.pseudoClassStateChanged btn (PseudoClass/getPseudoClass "filters-active") true)
-      (.pseudoClassStateChanged btn (PseudoClass/getPseudoClass "filters-active") false))))
+(defn sync-filter-button-style! [^ToggleButton btn scene-visibility evaluation-context]
+  (let [{:keys [filters-enabled filtered-renderable-tags]} (settings scene-visibility evaluation-context)]
+    (.pseudoClassStateChanged btn (PseudoClass/getPseudoClass "filters-active")
+                              (boolean (and filters-enabled
+                                            (some #(not-every? never-appear-filtered-tags %)
+                                                  filtered-renderable-tags))))))
 
 (defn show-settings! [keymap localization ^Parent owner scene-visibility]
-  (let [setting-descriptors (mapv #(dissoc % :appear-filtered)
-                                  (renderable-tag-descriptors scene-visibility))
+  (let [setting-descriptors (g/let-ec [current-settings (settings scene-visibility evaluation-context)]
+                              (renderable-tag-descriptors scene-visibility current-settings))
         keys (keep :key setting-descriptors)
         compute-state (fn []
-                        (let [filtered-tags (g/node-value scene-visibility :filtered-renderable-tags)
-                              filters-enabled? (g/node-value scene-visibility :visibility-filters-enabled?)]
-                          (into {} (map (fn [key]
-                                          [key (if (= :visibility-filters key)
-                                                 filters-enabled?
-                                                 (not (contains? filtered-tags key)))]))
-                                keys)))
+                        (g/with-auto-evaluation-context evaluation-context
+                          (let [{:keys [filters-enabled filtered-renderable-tags]} (settings scene-visibility evaluation-context)]
+                            (into {} (map (fn [key]
+                                            [key (if (= :visibility-filters key)
+                                                   filters-enabled
+                                                   (not (contains? filtered-renderable-tags key)))]))
+                                  keys))))
         advance! (settings-popup/show! owner keymap localization (compute-state) 230 setting-descriptors
                                        (fn []
                                          (g/set-property! scene-visibility :popup-advance-fn nil)
@@ -396,26 +353,22 @@
       (g/set-property! scene-visibility :popup-advance-fn advance-with-state!))))
 
 (defn toggle-tag-visibility! [scene-visibility tag]
-  (g/with-auto-evaluation-context evaluation-context
-    (let [filters-enabled (g/node-value scene-visibility :visibility-filters-enabled? evaluation-context)
-          tags (g/node-value scene-visibility :filtered-renderable-tags evaluation-context)
-          updated-tags (if (contains? tags tag) (disj tags tag) (conj tags tag))]
-      (set-visibility-settings! scene-visibility filters-enabled updated-tags evaluation-context))))
+  (set-visibility-settings! scene-visibility
+                            (fn [settings]
+                              (update settings :filtered-renderable-tags #((if (contains? % tag) disj conj) % tag)))))
 
-(defn update-settings [scene-visibility {:keys [filters-enabled filtered-renderable-tags]}]
-  (g/transact
-    (concat
-      (g/set-property scene-visibility :visibility-filters-enabled? filters-enabled)
-      (g/set-property scene-visibility :filtered-renderable-tags filtered-renderable-tags))))
+(defn load-settings!
+  "Applies the stored visibility settings for a scene resource, or the defaults."
+  [scene-visibility prefs proj-path]
+  (let [stored-settings (prefs/get-pref-entry prefs [:scene :visibility-resource-settings]
+                                              proj-path default-settings)]
+    (set-settings! scene-visibility stored-settings)))
 
 (handler/defhandler :scene.visibility.toggle-filters :workbench
   (active? [scene-visibility evaluation-context]
     (g/node-value scene-visibility :active-scene-resource-node evaluation-context))
   (run [scene-visibility]
-    (g/with-auto-evaluation-context evaluation-context
-      (let [filters-enabled (g/node-value scene-visibility :visibility-filters-enabled? evaluation-context)
-            tags (g/node-value scene-visibility :filtered-renderable-tags evaluation-context)]
-        (set-visibility-settings! scene-visibility (not filters-enabled) tags evaluation-context)))))
+    (set-visibility-settings! scene-visibility #(update % :filters-enabled not))))
 
 (handler/defhandler :scene.visibility.toggle-component-guides :workbench
   (active? [scene-visibility evaluation-context]

--- a/editor/src/clj/editor/scene_visibility.clj
+++ b/editor/src/clj/editor/scene_visibility.clj
@@ -285,22 +285,28 @@
     (when-let [advance! (g/node-value scene-visibility :popup-advance-fn)]
       (advance!))))
 
+(defn- set-visibility-settings! [scene-visibility filters-enabled filtered-renderable-tags evaluation-context]
+  (let [basis (:basis evaluation-context)
+        prefs (g/node-value scene-visibility :prefs evaluation-context)
+        resource-node (first (g/node-value scene-visibility :active-resource-node+type evaluation-context))
+        path-key (resource/resource->proj-path (resource-node/resource basis resource-node))]
+    (g/transact
+      (concat
+        (g/set-property scene-visibility :visibility-filters-enabled? filters-enabled)
+        (g/set-property scene-visibility :filtered-renderable-tags filtered-renderable-tags)))
+    (prefs/update! prefs [:scene :visibility-resource-settings] assoc
+                   path-key
+                   {:filters-enabled filters-enabled
+                    :filtered-renderable-tags filtered-renderable-tags})
+    (sync-popup-state! scene-visibility)))
+
 (defn- toggle-tag-visibility-fn [scene-visibility tag]
   (fn [v]
-    ;; TODO JOE: Refactor this somehow
     (g/with-auto-evaluation-context evaluation-context
-      (let [basis (:basis evaluation-context)
-            prefs (g/node-value scene-visibility :prefs evaluation-context)
-            resource-node (first (g/node-value scene-visibility :active-resource-node+type evaluation-context))
-            path-key (resource/resource->proj-path (resource-node/resource basis resource-node))
+      (let [filters-enabled (g/node-value scene-visibility :visibility-filters-enabled?)
             tags (g/node-value scene-visibility :filtered-renderable-tags evaluation-context)
             updated-tags ((if v disj conj) tags tag)]
-        (g/set-property! scene-visibility :filtered-renderable-tags updated-tags)
-        (prefs/update! prefs [:scene :resource-settings] assoc
-                       path-key
-                       {:filters-enabled true
-                        :filtered-renderable-tags updated-tags}))
-      (sync-popup-state! scene-visibility))))
+        (set-visibility-settings! scene-visibility filters-enabled updated-tags evaluation-context)))))
 
 (defn renderable-tag-descriptors [scene-visibility]
   (let [filtered-tags (g/node-value scene-visibility :filtered-renderable-tags)
@@ -316,17 +322,8 @@
               :value filters-enabled?
               :on-value-changed (fn [v]
                                   (g/with-auto-evaluation-context evaluation-context
-                                    (let [basis (:basis evaluation-context)
-                                          prefs (g/node-value scene-visibility :prefs evaluation-context)
-                                          resource-node (first (g/node-value scene-visibility :active-resource-node+type evaluation-context))
-                                          path-key (resource/resource->proj-path (resource-node/resource basis resource-node))
-                                          tags (g/node-value scene-visibility :filtered-renderable-tags evaluation-context)]
-                                      (g/set-property! scene-visibility :visibility-filters-enabled? v)
-                                      (prefs/update! prefs [:scene :resource-settings] assoc
-                                                     path-key
-                                                     {:filters-enabled v
-                                                      :filtered-renderable-tags tags}))
-                                    (sync-popup-state! scene-visibility)))
+                                    (let [tags (g/node-value scene-visibility :filtered-renderable-tags evaluation-context)]
+                                      (set-visibility-settings! scene-visibility v tags evaluation-context))))
               :command :scene.visibility.toggle-filters}
              {:type :space}
              (tag-toggle :collision-shape "collision-shapes")
@@ -399,13 +396,13 @@
       (g/set-property! scene-visibility :popup-advance-fn advance-with-state!))))
 
 (defn toggle-tag-visibility! [scene-visibility tag]
-  (g/update-property! scene-visibility :filtered-renderable-tags
-                      (fn [tags]
-                        (if (contains? tags tag)
-                          (disj tags tag)
-                          (conj tags tag)))))
+  (g/with-auto-evaluation-context evaluation-context
+    (let [filters-enabled (g/node-value scene-visibility :visibility-filters-enabled? evaluation-context)
+          tags (g/node-value scene-visibility :filtered-renderable-tags evaluation-context)
+          updated-tags (if (contains? tags tag) (disj tags tag) (conj tags tag))]
+      (set-visibility-settings! scene-visibility filters-enabled updated-tags evaluation-context))))
 
-(defn update-settings [scene-visibility {:keys [filters-enabled filtered-renderable-tags]} evaluation-context]
+(defn update-settings [scene-visibility {:keys [filters-enabled filtered-renderable-tags]}]
   (g/transact
     (concat
       (g/set-property scene-visibility :visibility-filters-enabled? filters-enabled)
@@ -415,7 +412,10 @@
   (active? [scene-visibility evaluation-context]
     (g/node-value scene-visibility :active-scene-resource-node evaluation-context))
   (run [scene-visibility]
-    (g/update-property! scene-visibility :visibility-filters-enabled? not)))
+    (g/with-auto-evaluation-context evaluation-context
+      (let [filters-enabled (g/node-value scene-visibility :visibility-filters-enabled? evaluation-context)
+            tags (g/node-value scene-visibility :filtered-renderable-tags evaluation-context)]
+        (set-visibility-settings! scene-visibility (not filters-enabled) tags evaluation-context)))))
 
 (handler/defhandler :scene.visibility.toggle-component-guides :workbench
   (active? [scene-visibility evaluation-context]

--- a/editor/src/clj/editor/scene_visibility.clj
+++ b/editor/src/clj/editor/scene_visibility.clj
@@ -24,7 +24,8 @@
             [editor.ui :as ui]
             [editor.ui.settings-popup :as settings-popup]
             [internal.util :as iutil]
-            [schema.core :as s])
+            [schema.core :as s]
+            [util.coll :as coll])
   (:import [javafx.css PseudoClass]
            [javafx.scene Node Parent]
            [javafx.scene.control Tab ToggleButton]))
@@ -329,8 +330,8 @@
   (let [{:keys [filters-enabled filtered-renderable-tags]} (settings scene-visibility evaluation-context)]
     (.pseudoClassStateChanged btn (PseudoClass/getPseudoClass "filters-active")
                               (boolean (and filters-enabled
-                                            (not-every? never-appear-filtered-tags
-                                                        filtered-renderable-tags))))))
+                                            (coll/not-every? never-appear-filtered-tags
+                                                             filtered-renderable-tags))))))
 
 (defn show-settings! [keymap localization ^Parent owner scene-visibility]
   (let [setting-descriptors (g/let-ec [current-settings (settings scene-visibility evaluation-context)]

--- a/editor/test/integration/scene_resource_prefs_test.clj
+++ b/editor/test/integration/scene_resource_prefs_test.clj
@@ -18,6 +18,7 @@
   (:require [clojure.test :refer :all]
             [dynamo.graph :as g]
             [editor.app-view :as app-view]
+            [editor.boot-open-project :as boot-open-project]
             [editor.camera :as camera]
             [editor.fs :as fs]
             [editor.grid :as grid]
@@ -34,6 +35,7 @@
 (def ^:private try-load-camera-from-prefs #'app-view/try-load-camera-from-prefs)
 (def ^:private set-visibility-settings! #'scene-visibility/set-visibility-settings!)
 (def ^:private grid-mode #'grid/grid-mode)
+(def ^:private clean-up-resource-prefs #'boot-open-project/clean-up-resource-prefs)
 
 (def ^:private resource-settings-path [:scene :resource-settings])
 
@@ -223,3 +225,83 @@
       (testing "2D mode uses the configured plane rather than forcing :z"
         (prefs/set! prefs [:scene :grid-2d :active-plane] :x)
         (is (= :x (:active-plane (merged-options))))))))
+
+;; -----------------------------------------------------------------------------
+;; Resource sync cleanup
+;; -----------------------------------------------------------------------------
+
+(def ^:private an-entry
+  {:scene-visibility {:filters-enabled false :filtered-renderable-tags #{:sprite}}})
+
+(defn- resource-change
+  "clean-up-resource-prefs only reads :project-path off these; the resource maps
+  handle-changes really receives carry a dozen more keys."
+  [proj-path]
+  {:project-path proj-path :source-type :file})
+
+(defn- changes [& {:as overrides}]
+  (merge {:added [] :removed [] :changed [] :moved ()} overrides))
+
+(defn- seed-settings! [prefs settings]
+  ;; prefs/set! validates the whole :object-of map and resets it to {} if an
+  ;; entry violates the schema, which would make every assertion below pass
+  ;; against an empty map. Fail loudly here instead.
+  (prefs/set! prefs resource-settings-path settings)
+  (is (= settings (prefs/get prefs resource-settings-path))
+      "the seeded settings should survive schema validation"))
+
+(defn- settings-of [prefs]
+  (prefs/get prefs resource-settings-path))
+
+(deftest deleting-a-resource-drops-only-its-entry
+  (let [prefs (make-isolated-prefs)]
+    (seed-settings! prefs {"/a.collection" an-entry "/b.go" an-entry})
+    (clean-up-resource-prefs prefs (changes :removed [(resource-change "/a.collection")]))
+    (is (= {"/b.go" an-entry} (settings-of prefs)))))
+
+(deftest renaming-a-resource-carries-its-entry-to-the-new-path
+  ;; A rename arrives with the old path in *both* :moved and :removed, and the
+  ;; new path in :added. The :removed handling must not undo the move.
+  (let [prefs (make-isolated-prefs)
+        old (resource-change "/game/asdf.sprite")
+        new (resource-change "/game/rename_sprite.sprite")]
+    (seed-settings! prefs {"/game/asdf.sprite" an-entry "/game/other.go" an-entry})
+    (clean-up-resource-prefs prefs (changes :added [new] :removed [old] :moved [[old new]]))
+    (is (= {"/game/rename_sprite.sprite" an-entry "/game/other.go" an-entry}
+           (settings-of prefs)))))
+
+(deftest renaming-a-folder-carries-every-entry-under-it
+  ;; One sync can move many resources at once; each move is independent.
+  (let [prefs (make-isolated-prefs)
+        moves (mapv (fn [[from to]] [(resource-change from) (resource-change to)])
+                    [["/old/a.collection" "/new/a.collection"]
+                     ["/old/b.go" "/new/b.go"]])]
+    (seed-settings! prefs {"/old/a.collection" an-entry
+                           "/old/b.go" an-entry
+                           "/elsewhere/c.go" an-entry})
+    (clean-up-resource-prefs prefs (changes :added (mapv second moves)
+                                            :removed (mapv first moves)
+                                            :moved moves))
+    (is (= {"/new/a.collection" an-entry
+            "/new/b.go" an-entry
+            "/elsewhere/c.go" an-entry}
+           (settings-of prefs)))))
+
+(deftest cleanup-leaves-untracked-resources-alone
+  (let [prefs (make-isolated-prefs)
+        old (resource-change "/never-opened.sprite")
+        new (resource-change "/renamed.sprite")]
+    (seed-settings! prefs {"/a.collection" an-entry})
+
+    (testing "renaming a resource that was never opened invents no entry"
+      (clean-up-resource-prefs prefs (changes :added [new] :removed [old] :moved [[old new]]))
+      (is (= {"/a.collection" an-entry} (settings-of prefs))))
+
+    (testing "deleting a resource that was never opened is a no-op"
+      (clean-up-resource-prefs prefs (changes :removed [(resource-change "/gone.go")]))
+      (is (= {"/a.collection" an-entry} (settings-of prefs))))
+
+    (testing "added and changed resources are not our concern"
+      (clean-up-resource-prefs prefs (changes :added [(resource-change "/fresh.go")]
+                                              :changed [(resource-change "/a.collection")]))
+      (is (= {"/a.collection" an-entry} (settings-of prefs))))))

--- a/editor/test/integration/scene_resource_prefs_test.clj
+++ b/editor/test/integration/scene_resource_prefs_test.clj
@@ -17,6 +17,7 @@
   split 2D/3D grid presets."
   (:require [clojure.test :refer :all]
             [dynamo.graph :as g]
+            [editor.app-view :as app-view]
             [editor.boot-open-project :as boot-open-project]
             [editor.camera :as camera]
             [editor.fs :as fs]
@@ -35,6 +36,7 @@
 (def ^:private set-visibility-settings! #'scene-visibility/set-visibility-settings!)
 (def ^:private grid-mode #'grid/grid-mode)
 (def ^:private clean-up-resource-prefs #'boot-open-project/clean-up-resource-prefs)
+(def ^:private default-camera-projection #'app-view/default-camera-projection)
 
 (def ^:private resource-settings-path [:scene :resource-settings])
 
@@ -304,3 +306,47 @@
       (clean-up-resource-prefs prefs (changes :added [(resource-change "/fresh.go")]
                                               :changed [(resource-change "/a.collection")]))
       (is (= {"/a.collection" an-entry} (settings-of prefs))))))
+
+;; -----------------------------------------------------------------------------
+;; Default camera projection
+;; -----------------------------------------------------------------------------
+
+(defn- projection-of [project proj-path]
+  (let [resource-node (test-util/resource-node project proj-path)]
+    (default-camera-projection project (g/node-value resource-node :resource) resource-node)))
+
+(deftest scene-geometry-decides-the-default-projection
+  (test-util/with-loaded-project
+    (testing "a game object whose only bounds come from a camera stays orthographic"
+      (is (= :orthographic (projection-of project "/logic/main.go"))))
+
+    (testing "2D content stays orthographic"
+      (is (= :orthographic (projection-of project "/logic/atlas_sprite.go")))
+      (is (= :orthographic (projection-of project "/logic/atlas_sprite.collection"))))))
+
+(deftest a-scene-that-fails-to-produce-falls-back-to-orthographic
+  ;; /graphics/box.model still uses the pre-migration single material fields, so
+  ;; its scene evaluates to an ErrorValue. Opening the tab must not blow up.
+  (test-util/with-loaded-project
+    (let [box-go (test-util/resource-node project "/graphics/box.go")]
+      (is (g/error? (g/node-value box-go :scene))
+          "fixture check: box.go is expected to have a broken scene")
+      (is (= :orthographic (projection-of project "/graphics/box.go"))))))
+
+(deftest projection-traverses-nested-collections
+  (test-util/with-loaded-project "test/resources/build_project/SideScroller"
+    (testing "collection -> game object -> model"
+      (is (= :perspective (projection-of project "/main/main.collection"))))
+
+    (testing "collections nested three deep with no geometry stay orthographic"
+      ;; base -> sub1 -> sub2 -> empty.go, all structural nodes with sentinel aabbs.
+      (is (= :orthographic (projection-of project "/hierarchy/base.collection"))))))
+
+(deftest a-model-outweighs-a-camera-in-the-same-game-object
+  (test-util/with-loaded-project "test/resources/all_types_project"
+    (is (= :perspective (projection-of project "/test.go")))))
+
+(deftest collision-objects-follow-the-project-physics-type
+  (test-util/with-loaded-project
+    ;; test_project sets physics type = 3D.
+    (is (= :perspective (projection-of project "/collision_object/embedded_shapes.collisionobject")))))

--- a/editor/test/integration/scene_resource_prefs_test.clj
+++ b/editor/test/integration/scene_resource_prefs_test.clj
@@ -17,7 +17,6 @@
   split 2D/3D grid presets."
   (:require [clojure.test :refer :all]
             [dynamo.graph :as g]
-            [editor.app-view :as app-view]
             [editor.boot-open-project :as boot-open-project]
             [editor.camera :as camera]
             [editor.fs :as fs]
@@ -31,8 +30,8 @@
 
 (set! *warn-on-reflection* true)
 
-(def ^:private camera-prefs #'app-view/camera-prefs)
-(def ^:private try-load-camera-from-prefs #'app-view/try-load-camera-from-prefs)
+(def ^:private camera-prefs camera/camera->prefs-value)
+(def ^:private try-load-camera-from-prefs camera/try-load-camera-from-prefs)
 (def ^:private set-visibility-settings! #'scene-visibility/set-visibility-settings!)
 (def ^:private grid-mode #'grid/grid-mode)
 (def ^:private clean-up-resource-prefs #'boot-open-project/clean-up-resource-prefs)

--- a/editor/test/integration/scene_resource_prefs_test.clj
+++ b/editor/test/integration/scene_resource_prefs_test.clj
@@ -1,0 +1,225 @@
+;; Copyright 2020-2026 The Defold Foundation
+;; Copyright 2014-2020 King
+;; Copyright 2009-2014 Ragnar Svensson, Christian Murray
+;; Licensed under the Defold License version 1.0 (the "License"); you may not use
+;; this file except in compliance with the License.
+;;
+;; You may obtain a copy of the License, together with FAQs at
+;; https://www.defold.com/license
+;;
+;; Unless required by applicable law or agreed to in writing, software distributed
+;; under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+;; CONDITIONS OF ANY KIND, either express or implied. See the License for the
+;; specific language governing permissions and limitations under the License.
+
+(ns integration.scene-resource-prefs-test
+  "Per-resource scene view state: camera, visibility filters, and the project's
+  split 2D/3D grid presets."
+  (:require [clojure.test :refer :all]
+            [dynamo.graph :as g]
+            [editor.app-view :as app-view]
+            [editor.camera :as camera]
+            [editor.fs :as fs]
+            [editor.grid :as grid]
+            [editor.math :as math]
+            [editor.prefs :as prefs]
+            [editor.scene :as scene]
+            [editor.scene-visibility :as scene-visibility]
+            [integration.test-util :as test-util])
+  (:import [javax.vecmath Point3d Vector4d]))
+
+(set! *warn-on-reflection* true)
+
+(def ^:private camera-prefs #'app-view/camera-prefs)
+(def ^:private try-load-camera-from-prefs #'app-view/try-load-camera-from-prefs)
+(def ^:private set-visibility-settings! #'scene-visibility/set-visibility-settings!)
+(def ^:private grid-mode #'grid/grid-mode)
+
+(def ^:private resource-settings-path [:scene :resource-settings])
+
+(defn- make-isolated-prefs
+  "prefs/set! mutates a process-global atom keyed by file path, and the shared
+  test prefs file would let resource-settings leak between tests, which is
+  exactly what the isolation tests below are checking. Give each test its own."
+  []
+  (let [file (fs/create-temp-file! "scene-resource-prefs-test" ".editor_settings")]
+    (prefs/make :scopes {:global file :project file} :schemas [:default])))
+
+(defn- store-camera! [prefs proj-path camera]
+  (prefs/set-pref-entry-in! prefs resource-settings-path proj-path [:camera]
+                            (camera-prefs camera)))
+
+(defn- visibility-settings [scene-visibility]
+  (g/with-auto-evaluation-context evaluation-context
+    (scene-visibility/settings scene-visibility evaluation-context)))
+
+;; -----------------------------------------------------------------------------
+;; Camera <-> prefs
+;; -----------------------------------------------------------------------------
+
+(deftest camera-survives-a-prefs-round-trip
+  (doseq [[label camera]
+          [["orthographic"
+            (assoc (camera/make-camera :orthographic identity {:fov-x 1000.0 :fov-y 1000.0})
+              :position (Point3d. 12.5 -3.25 900.0)
+              :focus-point (Vector4d. 1.0 2.0 3.0 1.0))]
+
+           ["perspective, rotated off the front view"
+            (assoc (camera/make-camera :perspective identity {:fov-x 54.4 :fov-y 37.8})
+              :position (Point3d. -40.0 15.0 220.0)
+              :rotation (math/euler->quat [0.0 45.0 0.0]))]]]
+    (testing label
+      (let [prefs (make-isolated-prefs)]
+        (store-camera! prefs "/a.collection" camera)
+        ;; try-load-camera-from-prefs rebuilds the record via make-camera and
+        ;; restores only the persisted fields, so the whole Camera won't be = to
+        ;; the original. Assert the restored camera serializes back identically.
+        (is (= (camera-prefs camera)
+               (camera-prefs (try-load-camera-from-prefs prefs "/a.collection"))))))))
+
+(deftest incomplete-stored-camera-falls-back-to-the-default
+  (let [prefs (make-isolated-prefs)
+        camera (camera/make-camera :orthographic identity {:fov-x 1000.0 :fov-y 1000.0})]
+    (testing "nothing stored for the resource"
+      (is (nil? (try-load-camera-from-prefs prefs "/never-opened.collection"))))
+
+    (testing "an entry exists but is missing a field"
+      (doseq [dropped-key [:projection :position :rotation :fov-x :fov-y :focus-point]]
+        (prefs/set-pref-entry-in! prefs resource-settings-path "/a.collection" [:camera]
+                                  (dissoc (camera-prefs camera) dropped-key))
+        (is (nil? (try-load-camera-from-prefs prefs "/a.collection"))
+            (str "a camera missing " dropped-key " should be ignored, not partially restored"))))))
+
+(deftest resource-entries-do-not-clobber-each-other
+  ;; Every write rewrites the whole :object-of map, so a bad update would drop
+  ;; sibling resources or the sibling key under the same resource.
+  (let [prefs (make-isolated-prefs)
+        collection-camera (assoc (camera/make-camera :orthographic identity {:fov-x 1000.0 :fov-y 1000.0})
+                            :position (Point3d. 10.0 20.0 30.0))
+        go-camera (assoc (camera/make-camera :perspective identity {:fov-x 54.4 :fov-y 37.8})
+                    :position (Point3d. -5.0 -6.0 -7.0))]
+    (store-camera! prefs "/a.collection" collection-camera)
+    (store-camera! prefs "/b.go" go-camera)
+    (prefs/set-pref-entry-in! prefs resource-settings-path "/a.collection" [:scene-visibility]
+                              {:filters-enabled false :filtered-renderable-tags #{:sprite}})
+
+    (testing "each resource keeps its own camera"
+      (is (= [10.0 20.0 30.0] (:position (camera-prefs (try-load-camera-from-prefs prefs "/a.collection")))))
+      (is (= [-5.0 -6.0 -7.0] (:position (camera-prefs (try-load-camera-from-prefs prefs "/b.go"))))))
+
+    (testing "camera and visibility coexist under one resource"
+      (is (= :orthographic (:projection (camera-prefs (try-load-camera-from-prefs prefs "/a.collection")))))
+      (is (= {:filters-enabled false :filtered-renderable-tags #{:sprite}}
+             (prefs/get-pref-entry-in prefs resource-settings-path "/a.collection" [:scene-visibility] nil))))))
+
+;; -----------------------------------------------------------------------------
+;; Visibility filters
+;; -----------------------------------------------------------------------------
+
+(deftest visibility-settings-load-per-resource
+  (test-util/with-loaded-project
+    (let [prefs (make-isolated-prefs)
+          scene-visibility (scene-visibility/make-scene-visibility-node!
+                             (test-util/make-view-graph!) prefs app-view)
+          stored {:filters-enabled false :filtered-renderable-tags #{:sprite :model}}]
+      (prefs/set-pref-entry-in! prefs resource-settings-path "/logic/atlas_sprite.collection" [:scene-visibility] stored)
+
+      (testing "a resource with stored settings gets them back"
+        (scene-visibility/load-settings! scene-visibility prefs "/logic/atlas_sprite.collection")
+        (is (= stored (visibility-settings scene-visibility))))
+
+      (testing "a resource with nothing stored resets to the defaults, not the previous resource's state"
+        (scene-visibility/load-settings! scene-visibility prefs "/logic/atlas_sprite.go")
+        (is (= scene-visibility/default-settings (visibility-settings scene-visibility)))))))
+
+(deftest visibility-settings-persist-against-the-active-resource
+  (test-util/with-loaded-project
+    (let [prefs (make-isolated-prefs)
+          scene-visibility (scene-visibility/make-scene-visibility-node!
+                             (test-util/make-view-graph!) prefs app-view)
+          collection-path "/logic/atlas_sprite.collection"
+          go-path "/logic/atlas_sprite.go"
+          stored-tags (fn [proj-path]
+                        (prefs/get-pref-entry-in prefs resource-settings-path proj-path
+                                                 [:scene-visibility :filtered-renderable-tags] nil))]
+      (g/transact (g/connect app-view :active-resource-node+type scene-visibility :active-resource-node+type))
+
+      (test-util/open-scene-view! project app-view collection-path 128 128 {:prefs prefs})
+      (set-visibility-settings! scene-visibility #(update % :filtered-renderable-tags conj :sprite))
+
+      (test-util/open-scene-view! project app-view go-path 128 128 {:prefs prefs})
+      (scene-visibility/load-settings! scene-visibility prefs go-path)
+      (set-visibility-settings! scene-visibility #(update % :filtered-renderable-tags conj :tilemap))
+
+      (testing "each resource's toggles landed under its own key"
+        (is (contains? (stored-tags collection-path) :sprite))
+        (is (not (contains? (stored-tags collection-path) :tilemap)))
+        (is (contains? (stored-tags go-path) :tilemap))
+        (is (not (contains? (stored-tags go-path) :sprite))))
+
+      (testing "switching back restores the first resource's state"
+        (scene-visibility/load-settings! scene-visibility prefs collection-path)
+        (let [tags (:filtered-renderable-tags (visibility-settings scene-visibility))]
+          (is (contains? tags :sprite))
+          (is (not (contains? tags :tilemap))))))))
+
+(deftest visibility-settings-are-not-persisted-without-an-active-scene
+  ;; The popup's toggle callbacks are not guarded by a handler active? predicate,
+  ;; so a toggle can fire while no scene resource is active. The view state should
+  ;; still update; it just must not invent a prefs entry.
+  (test-util/with-loaded-project
+    (let [prefs (make-isolated-prefs)
+          scene-visibility (scene-visibility/make-scene-visibility-node!
+                             (test-util/make-view-graph!) prefs app-view)]
+      (set-visibility-settings! scene-visibility #(assoc % :filters-enabled false))
+      (is (false? (:filters-enabled (visibility-settings scene-visibility)))
+          "the toggle should still take effect in the view")
+      (is (= {} (prefs/get prefs resource-settings-path))
+          "no resource entry should have been written"))))
+
+;; -----------------------------------------------------------------------------
+;; Grid presets
+;; -----------------------------------------------------------------------------
+
+(deftest grid-mode-follows-the-view-not-just-the-projection
+  (let [orthographic (camera/make-camera :orthographic identity {:fov-x 1000.0 :fov-y 1000.0})]
+    (is (= :grid-2d (grid-mode orthographic)))
+    (is (= :grid-3d (grid-mode (camera/make-camera :perspective identity {:fov-x 54.4 :fov-y 37.8}))))
+
+    (testing "an orthographic camera rotated off the front view is a 3D view"
+      (is (= :grid-3d (grid-mode (assoc orthographic :rotation (math/euler->quat [0.0 45.0 0.0]))))))))
+
+(deftest grid-reads-the-preset-its-camera-selects
+  (test-util/with-loaded-project
+    (let [prefs (make-isolated-prefs)
+          [_ view-id] (test-util/open-scene-view! project app-view "/logic/atlas_sprite.collection" 128 128 {:prefs prefs})
+          camera-id (scene/view->camera view-id)
+          ;; A preview view has no Grid: setup-view only attaches one when :grid
+          ;; is in the view opts, and make-preview dissocs it. Attach a Grid to
+          ;; the view's real CameraController the way attach-grid does, so the
+          ;; camera we read is the one produce-camera actually hands the grid.
+          grid-id (first
+                    (g/tx-nodes-added
+                      (g/transact
+                        (g/make-nodes (g/node-id->graph-id view-id) [grid [grid/Grid :prefs prefs]]
+                          (g/connect camera-id :camera grid :camera)))))
+          merged-options #(g/node-value grid-id :merged-options)
+          set-camera! #(g/set-property! camera-id :local-camera %)]
+      (prefs/set! prefs [:scene :grid-2d :opacity] 0.125)
+      (prefs/set! prefs [:scene :grid-3d :opacity] 0.875)
+
+      (testing "a front-on orthographic camera uses the 2D preset"
+        (set-camera! (camera/make-camera :orthographic identity {:fov-x 1000.0 :fov-y 1000.0}))
+        (is (= 0.125 (:opacity (merged-options)))))
+
+      (testing "a perspective camera uses the 3D preset"
+        (set-camera! (camera/make-camera :perspective identity {:fov-x 54.4 :fov-y 37.8}))
+        (is (= 0.875 (:opacity (merged-options)))))
+
+      (testing "switching back picks the 2D preset up again"
+        (set-camera! (camera/make-camera :orthographic identity {:fov-x 1000.0 :fov-y 1000.0}))
+        (is (= 0.125 (:opacity (merged-options)))))
+
+      (testing "2D mode uses the configured plane rather than forcing :z"
+        (prefs/set! prefs [:scene :grid-2d :active-plane] :x)
+        (is (= :x (:active-plane (merged-options))))))))


### PR DESCRIPTION
This change persists scene settings and camera state:

- Camera state (2D/3D, position, rotation, zoom, etc;) is now remembered for every resource. If a resource tab is closed (like collection, atlas, go, etc;) or the editor is restarted, the camera will restored to the state it was in.
- Scene visibility settings are also now per scene and remembered. The visibility for one collection can be different from another.
- 3D resources (such as model, gltf/glb,mesh, etc;) now start in perspective mode
- Grid settings now remember if working in a 2D or 3D scene. When the 2D button is toggled the grid settings will change to whatever was configured for that specific mode.

Fixes #12472

### Technical changes

Additional Note:

Scene visibility had a few issues; it needed some clean up and apparently the light toggle wasn't working. There was also some poor evaluation-context uses and some dead code. So a good chunk of changes are just cleaning stuff up.