### PR TITLE
Do not reverse hash generated gui node ids

### DIFF
--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -4840,7 +4840,7 @@ namespace dmGui
         // generate a name for the cloned node
         char name[18];
         dmSnPrintf(name, 18, "__node%d", g_ClonedNodeCount++);
-        out_n->m_NameHash = dmHashString64(name);
+        out_n->m_NameHash = dmHashBufferNoReverse64(name, strlen(name));
         out_n->m_SceneTraversalCacheVersion = INVALID_INDEX;
         out_n->m_PrevIndex = INVALID_INDEX;
         out_n->m_NextIndex = INVALID_INDEX;

--- a/engine/gui/src/test/test_gui_script.cpp
+++ b/engine/gui/src/test/test_gui_script.cpp
@@ -474,6 +474,64 @@ TEST_F(dmGuiScriptTest, TestCloneTree)
     dmGui::DeleteScript(script);
 }
 
+TEST_F(dmGuiScriptTest, TestCloneTreeReverseHashTableGrowth)
+{
+    // A debug engine stores generated clone ids in the reverse-hash table. Repeatedly
+    // cloning and deleting a tree can grow that table until its resize allocation fails
+    // (the reported crash happened while hashing "__node431253"). The final allocation
+    // failure needs a memory-constrained process; this test reproduces the Lua path and
+    // crosses the same table resize.
+    dmHashEnableReverseHash(false);
+    dmHashEnableReverseHash(true);
+
+    dmGui::HScript script = NewScript(m_Context);
+
+    dmGui::NewSceneParams params;
+    // 64 source nodes plus 64 trees of 64 clones alive during each Lua callback,
+    // with a little headroom so the test does not depend on an exact pool boundary.
+    params.m_MaxNodes = 64 + 64 * 64 + 32;
+    params.m_MaxAnimations = 32;
+    params.m_UserData = this;
+    dmGui::HScene scene = dmGui::NewScene(m_Context, &params);
+    dmGui::SetSceneScript(scene, script);
+
+    const char* src =
+            "function init(self)\n"
+            "    self.root = gui.new_box_node(vmath.vector3(), vmath.vector3(1))\n"
+            "    gui.set_id(self.root, 'root')\n"
+            "    for _ = 2, 64 do\n"
+            "        local child = gui.new_box_node(vmath.vector3(), vmath.vector3(1))\n"
+            "        gui.set_parent(child, self.root)\n"
+            "    end\n"
+            "end\n"
+            "function update(self, dt)\n"
+            "    for _ = 1, 64 do\n"
+            "        local clones = gui.clone_tree(self.root)\n"
+            "        gui.delete_node(clones.root)\n"
+            "    end\n"
+            "end\n";
+
+    dmGui::Result result = SetScript(script, LuaSourceFromStr(src));
+    ASSERT_EQ(dmGui::RESULT_OK, result);
+
+    result = dmGui::InitScene(scene);
+    ASSERT_EQ(dmGui::RESULT_OK, result);
+
+    // 147 * 64 * 64 = 602,112 generated clone ids. This crosses the 573,440-entry
+    // reverse-hash resize that failed in the client report.
+    for (uint32_t i = 0; i < 147; ++i)
+    {
+        result = dmGui::UpdateScene(scene, 1.0f / 60.0f);
+        ASSERT_EQ(dmGui::RESULT_OK, result);
+    }
+
+    dmGui::DeleteScene(scene);
+    dmGui::DeleteScript(script);
+
+    // Clear the stress-test entries and restore the default state for this test binary.
+    dmHashEnableReverseHash(false);
+}
+
 TEST_F(dmGuiScriptTest, TestGetTree)
 {
     dmGui::HScript script = NewScript(m_Context);

--- a/engine/gui/src/test/test_gui_script.cpp
+++ b/engine/gui/src/test/test_gui_script.cpp
@@ -474,61 +474,25 @@ TEST_F(dmGuiScriptTest, TestCloneTree)
     dmGui::DeleteScript(script);
 }
 
-TEST_F(dmGuiScriptTest, TestCloneTreeReverseHashTableGrowth)
+TEST_F(dmGuiScriptTest, TestCloneNodeInternalIdNotReverseHashed)
 {
-    // A debug engine stores generated clone ids in the reverse-hash table. Repeatedly
-    // cloning and deleting a tree can grow that table until its resize allocation fails
-    // (the reported crash happened while hashing "__node431253"). The final allocation
-    // failure needs a memory-constrained process; this test reproduces the Lua path and
-    // crosses the same table resize.
     dmHashEnableReverseHash(false);
     dmHashEnableReverseHash(true);
 
-    dmGui::HScript script = NewScript(m_Context);
-
     dmGui::NewSceneParams params;
-    // 64 source nodes plus 64 trees of 64 clones alive during each Lua callback,
-    // with a little headroom so the test does not depend on an exact pool boundary.
-    params.m_MaxNodes = 64 + 64 * 64 + 32;
+    params.m_MaxNodes = 2;
     params.m_MaxAnimations = 32;
     params.m_UserData = this;
     dmGui::HScene scene = dmGui::NewScene(m_Context, &params);
-    dmGui::SetSceneScript(scene, script);
 
-    const char* src =
-            "function init(self)\n"
-            "    self.root = gui.new_box_node(vmath.vector3(), vmath.vector3(1))\n"
-            "    gui.set_id(self.root, 'root')\n"
-            "    for _ = 2, 64 do\n"
-            "        local child = gui.new_box_node(vmath.vector3(), vmath.vector3(1))\n"
-            "        gui.set_parent(child, self.root)\n"
-            "    end\n"
-            "end\n"
-            "function update(self, dt)\n"
-            "    for _ = 1, 64 do\n"
-            "        local clones = gui.clone_tree(self.root)\n"
-            "        gui.delete_node(clones.root)\n"
-            "    end\n"
-            "end\n";
+    dmGui::HNode node = dmGui::NewNode(scene, Point3(), Vector3(1.0f), dmGui::NODE_TYPE_BOX, 0);
+    dmGui::HNode clone = dmGui::INVALID_HANDLE;
+    ASSERT_EQ(dmGui::RESULT_OK, dmGui::CloneNode(scene, node, &clone));
 
-    dmGui::Result result = SetScript(script, LuaSourceFromStr(src));
-    ASSERT_EQ(dmGui::RESULT_OK, result);
-
-    result = dmGui::InitScene(scene);
-    ASSERT_EQ(dmGui::RESULT_OK, result);
-
-    // 147 * 64 * 64 = 602,112 generated clone ids. This crosses the 573,440-entry
-    // reverse-hash resize that failed in the client report.
-    for (uint32_t i = 0; i < 147; ++i)
-    {
-        result = dmGui::UpdateScene(scene, 1.0f / 60.0f);
-        ASSERT_EQ(dmGui::RESULT_OK, result);
-    }
+    dmhash_t clone_id = dmGui::GetNodeId(scene, clone);
+    ASSERT_EQ((const void*) 0, dmHashReverse64(clone_id, 0));
 
     dmGui::DeleteScene(scene);
-    dmGui::DeleteScript(script);
-
-    // Clear the stress-test entries and restore the default state for this test binary.
     dmHashEnableReverseHash(false);
 }
 


### PR DESCRIPTION
It is possible to run out of memory during long debug sessions if the game is cloning and deleting large amounts of gui nodes. The reverse hash table will in this case constantly grow and run out of memory when SetCapacity() is called. To avoid this situation generated node ids are no longer stored in the reverse hash lookup table.

Fixes #12780