### PR TITLE
Prevent crashes after script update errors

### DIFF
--- a/engine/engine/src/test/CMakeLists.txt
+++ b/engine/engine/src/test/CMakeLists.txt
@@ -57,6 +57,7 @@ set(ENGINE_TEST_CONTENT_STAMP "${ENGINE_TEST_RUNTIME_ROOT}/.cmake/test_content.s
 set(ENGINE_TEST_CONTENT_SCRIPT "${ENGINE_TEST_ROOT}/build_cmake_test_content.py")
 set(ENGINE_TEST_CONTENT_SETTINGS
   "cross_script_messaging.ini"
+  "issue-12703.ini"
   "render_script.ini"
   "camera_acquire_input_focus.ini"
   "text_input.ini")

--- a/engine/engine/src/test/issue-12703.ini
+++ b/engine/engine/src/test/issue-12703.ini
@@ -1,0 +1,3 @@
+[bootstrap]
+main_collection = /issue-12703/issue-12703.collectionc
+render = /issue-12703/issue-12703.renderc

--- a/engine/engine/src/test/issue-12703/issue-12703.collection
+++ b/engine/engine/src/test/issue-12703/issue-12703.collection
@@ -1,0 +1,14 @@
+name: "issue-12703"
+scale_along_z: 0
+embedded_instances {
+  id: "go"
+  data: "components {\n"
+  "  id: \"script\"\n"
+  "  component: \"/issue-12703/issue-12703.script\"\n"
+  "}\n"
+  "components {\n"
+  "  id: \"sprite\"\n"
+  "  component: \"/sprite/coll.sprite\"\n"
+  "}\n"
+  ""
+}

--- a/engine/engine/src/test/issue-12703/issue-12703.collection
+++ b/engine/engine/src/test/issue-12703/issue-12703.collection
@@ -6,9 +6,10 @@ embedded_instances {
   "  id: \"script\"\n"
   "  component: \"/issue-12703/issue-12703.script\"\n"
   "}\n"
-  "components {\n"
-  "  id: \"sprite\"\n"
-  "  component: \"/sprite/coll.sprite\"\n"
+  "embedded_components {\n"
+  "  id: \"proxy\"\n"
+  "  type: \"collectionproxy\"\n"
+  "  data: \"collection: \\\"/issue-12703/level.collection\\\"\\n\"\n"
   "}\n"
   ""
 }

--- a/engine/engine/src/test/issue-12703/issue-12703.render
+++ b/engine/engine/src/test/issue-12703/issue-12703.render
@@ -1,0 +1,1 @@
+script: "/issue-12703/issue-12703.render_script"

--- a/engine/engine/src/test/issue-12703/issue-12703.render_script
+++ b/engine/engine/src/test/issue-12703/issue-12703.render_script
@@ -1,0 +1,9 @@
+function init(self)
+	self.tile_predicate = render.predicate({ "tile" })
+end
+
+function update(self)
+	render.set_view(vmath.matrix4())
+	render.set_projection(vmath.matrix4())
+	render.draw(self.tile_predicate)
+end

--- a/engine/engine/src/test/issue-12703/issue-12703.script
+++ b/engine/engine/src/test/issue-12703/issue-12703.script
@@ -1,20 +1,17 @@
 function init(self)
 	self.frame = 0
+	msg.post("#proxy", "load")
 end
 
 function update(self, dt)
 	self.frame = self.frame + 1
-
-	if self.frame == 1 then
-		msg.post("#sprite", "disable")
-	elseif self.frame == 2 then
+	if self.frame == 5 then
 		sys.exit(0)
 	end
 end
 
-function late_update(self, dt)
-	if self.frame == 1 then
-		msg.post("#sprite", "enable")
-		json.decode("[{} {}]")
+function on_message(self, message_id, message)
+	if message_id == hash("proxy_loaded") then
+		msg.post("#proxy", "enable")
 	end
 end

--- a/engine/engine/src/test/issue-12703/issue-12703.script
+++ b/engine/engine/src/test/issue-12703/issue-12703.script
@@ -1,0 +1,20 @@
+function init(self)
+	self.frame = 0
+end
+
+function update(self, dt)
+	self.frame = self.frame + 1
+
+	if self.frame == 1 then
+		msg.post("#sprite", "disable")
+	elseif self.frame == 2 then
+		sys.exit(0)
+	end
+end
+
+function late_update(self, dt)
+	if self.frame == 1 then
+		msg.post("#sprite", "enable")
+		json.decode("[{} {}]")
+	end
+end

--- a/engine/engine/src/test/issue-12703/level.collection
+++ b/engine/engine/src/test/issue-12703/level.collection
@@ -1,0 +1,14 @@
+name: "level"
+scale_along_z: 0
+embedded_instances {
+  id: "go"
+  data: "components {\n"
+  "  id: \"script\"\n"
+  "  component: \"/issue-12703/level.script\"\n"
+  "}\n"
+  "components {\n"
+  "  id: \"sprite\"\n"
+  "  component: \"/sprite/coll.sprite\"\n"
+  "}\n"
+  ""
+}

--- a/engine/engine/src/test/issue-12703/level.script
+++ b/engine/engine/src/test/issue-12703/level.script
@@ -1,0 +1,3 @@
+function update(self, dt)
+	json.decode("[{} {}]")
+end

--- a/engine/engine/src/test/main.collection
+++ b/engine/engine/src/test/main.collection
@@ -160,5 +160,11 @@ embedded_instances {
   "  data: \"collection: \\\"/issue-12362/issue-12362.collection\\\"\\n"
   "\"\n"
   "}\n"
+  "embedded_components {\n"
+  "  id: \"collectionproxy34\"\n"
+  "  type: \"collectionproxy\"\n"
+  "  data: \"collection: \\\"/issue-12703/issue-12703.collection\\\"\\n"
+  "\"\n"
+  "}\n"
   ""
 }

--- a/engine/engine/src/test/test_engine.cpp
+++ b/engine/engine/src/test/test_engine.cpp
@@ -626,10 +626,14 @@ TEST_F(EngineTest, ISSUE_12362)
     ASSERT_EQ(0, Launch(DM_ARRAY_SIZE(argv), (char**)argv, 0, 0, 0));
 }
 
+// The collection proxy contains a script that fails during regular update and a sprite
+// that is rendered without frustum culling. Rendering still runs after the script error,
+// so the proxy collection's late update must run and allocate the sprite vertex buffer.
+// Without that late update, ASan reports a heap-buffer-overflow in sprite rendering.
 TEST_F(EngineTest, ISSUE_12703)
 {
     char project_path[256];
-    const char* argv[] = {"test_engine", "--config=bootstrap.main_collection=/issue-12703/issue-12703.collectionc", "--config=dmengine.unload_builtins=0", MAKE_PATH(project_path, "/game.projectc")};
+    const char* argv[] = {"test_engine", "--config=bootstrap.main_collection=/issue-12703/issue-12703.collectionc", "--config=bootstrap.render=/issue-12703/issue-12703.renderc", "--config=dmengine.unload_builtins=0", MAKE_PATH(project_path, "/game.projectc")};
     ASSERT_EQ(0, Launch(DM_ARRAY_SIZE(argv), (char**)argv, 0, 0, 0));
 }
 

--- a/engine/engine/src/test/test_engine.cpp
+++ b/engine/engine/src/test/test_engine.cpp
@@ -626,6 +626,13 @@ TEST_F(EngineTest, ISSUE_12362)
     ASSERT_EQ(0, Launch(DM_ARRAY_SIZE(argv), (char**)argv, 0, 0, 0));
 }
 
+TEST_F(EngineTest, ISSUE_12703)
+{
+    char project_path[256];
+    const char* argv[] = {"test_engine", "--config=bootstrap.main_collection=/issue-12703/issue-12703.collectionc", "--config=dmengine.unload_builtins=0", MAKE_PATH(project_path, "/game.projectc")};
+    ASSERT_EQ(0, Launch(DM_ARRAY_SIZE(argv), (char**)argv, 0, 0, 0));
+}
+
 TEST_F(EngineTest, ModelComponent)
 {
     char project_path[256];

--- a/engine/engine/src/test/wscript
+++ b/engine/engine/src/test/wscript
@@ -115,6 +115,7 @@ def build(bld):
     # Build custom collections first to prevent overrides in default game.projectc
     settings = [
         'cross_script_messaging.ini',
+        'issue-12703.ini',
         'render_script.ini',
         'camera_acquire_input_focus.ini',
         'text_input.ini']

--- a/engine/gameobject/src/gameobject/gameobject.cpp
+++ b/engine/gameobject/src/gameobject/gameobject.cpp
@@ -2844,16 +2844,21 @@ namespace dmGameObject
         // 1. for each fixed step, call component's fixed update
         //      - Lua fixed_update() (comp_script.cpp)
         //      - CompCollisionObjectFixedUpdate() (comp_collision_object.cpp)
+        // Keep running subsequent update phases after a component error. The engine
+        // still renders the collection, and late update prepares component render data.
         for (uint32_t step = 0; step < num_fixed_steps; ++step)
         {
-            ret = ret && UpdateComponentFunction(collection, component_type_count, UPDATE_FUNCTION_TYPE_FIXED_UPDATE, fixed_update_params);
+            if (!UpdateComponentFunction(collection, component_type_count, UPDATE_FUNCTION_TYPE_FIXED_UPDATE, fixed_update_params))
+                ret = false;
         }
 
         // 2. call component's regular update
-        ret = ret && UpdateComponentFunction(collection, component_type_count, UPDATE_FUNCTION_TYPE_UPDATE, update_params);
+        if (!UpdateComponentFunction(collection, component_type_count, UPDATE_FUNCTION_TYPE_UPDATE, update_params))
+            ret = false;
 
         // 3. call component's late update
-        ret = ret && UpdateComponentFunction(collection, component_type_count, UPDATE_FUNCTION_TYPE_LATE_UPDATE, update_params);
+        if (!UpdateComponentFunction(collection, component_type_count, UPDATE_FUNCTION_TYPE_LATE_UPDATE, update_params))
+            ret = false;
 
         collection->m_InUpdate = 0;
         if (collection->m_DirtyTransforms)


### PR DESCRIPTION
The engine now reports script errors, without subsequently crashing while rendering sprites. Required update phases continue running after an error so render data remains valid.

Fix https://github.com/defold/defold/issues/12703
Fix https://github.com/defold/defold/issues/12781

### Technical changes

- Changed game object update processing to retain failure results without short-circuiting subsequent fixed, regular, and late-update phases.
- Ensured late update can prepare component render data even when an earlier update reports an error.
- Added a regression test using a collection proxy containing a failing JSON script and a sprite.
- Added a custom render script without frustum culling to ensure the affected sprite batch is rendered during the test.
- Registered the new test resources with the engine test build.
- Verified `EngineTest.ISSUE_12703` under AddressSanitizer, along with `EngineTest.ISSUE_12362` and `EngineTest.LateUpdate`.