### PR TITLE
Improve HTML loading time

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/bundle/test/HTML5BundlerTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/bundle/test/HTML5BundlerTest.java
@@ -1,0 +1,90 @@
+// Copyright 2020-2026 The Defold Foundation
+// Copyright 2014-2020 King
+// Copyright 2009-2014 Ragnar Svensson, Christian Murray
+// Licensed under the Defold License version 1.0 (the "License"); you may not use
+// this file except in compliance with the License.
+//
+// You may obtain a copy of the License, together with FAQs at
+// https://www.defold.com/license
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package com.dynamo.bob.bundle.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+
+import com.dynamo.bob.bundle.HTML5Bundler;
+
+/**
+ * Tests for HTML5Bundler.getUrlOrigin(), which decides if index.html should contain a
+ * preconnect hint for the origin hosting the game archive (html5.archive_location_prefix).
+ * A null result means "no hint", ie the archive is loaded from the same origin as index.html.
+ */
+public class HTML5BundlerTest {
+
+    // The default value of html5.archive_location_prefix and other relative prefixes must not
+    // produce a preconnect hint, since they are served from the same origin as index.html.
+    @Test
+    public void testRelativeArchiveLocationPrefixHasNoOrigin() {
+        assertNull(HTML5Bundler.getUrlOrigin("archive"));
+        assertNull(HTML5Bundler.getUrlOrigin("/archive"));
+        assertNull(HTML5Bundler.getUrlOrigin("./archive"));
+        assertNull(HTML5Bundler.getUrlOrigin("../foo/archive"));
+        assertNull(HTML5Bundler.getUrlOrigin("some/nested/archive"));
+        assertNull(HTML5Bundler.getUrlOrigin(""));
+    }
+
+    @Test
+    public void testAbsoluteArchiveLocationPrefix() {
+        assertEquals("https://cdn.example.com", HTML5Bundler.getUrlOrigin("https://cdn.example.com/games/mygame/archive"));
+        assertEquals("http://cdn.example.com", HTML5Bundler.getUrlOrigin("http://cdn.example.com/archive"));
+    }
+
+    // A prefix without any path is a valid url and should still yield an origin
+    @Test
+    public void testAbsoluteArchiveLocationPrefixWithoutPath() {
+        assertEquals("https://cdn.example.com", HTML5Bundler.getUrlOrigin("https://cdn.example.com"));
+        assertEquals("https://cdn.example.com", HTML5Bundler.getUrlOrigin("https://cdn.example.com/"));
+    }
+
+    // A non default port is part of the origin and must be kept, or the browser would warm up
+    // a connection to the wrong endpoint
+    @Test
+    public void testAbsoluteArchiveLocationPrefixWithPort() {
+        assertEquals("https://cdn.example.com:8443", HTML5Bundler.getUrlOrigin("https://cdn.example.com:8443/archive"));
+        assertEquals("http://localhost:8080", HTML5Bundler.getUrlOrigin("http://localhost:8080/archive"));
+    }
+
+    // A protocol relative prefix inherits the scheme of the page, and the hint should do the same
+    @Test
+    public void testProtocolRelativeArchiveLocationPrefix() {
+        assertEquals("//cdn.example.com", HTML5Bundler.getUrlOrigin("//cdn.example.com/archive"));
+        assertEquals("//cdn.example.com:8443", HTML5Bundler.getUrlOrigin("//cdn.example.com:8443/archive"));
+    }
+
+    // Everything the browser cannot preconnect to should be ignored rather than throw, so that a
+    // surprising archive_location_prefix never breaks bundling
+    @Test
+    public void testUnsupportedSchemeHasNoOrigin() {
+        assertNull(HTML5Bundler.getUrlOrigin("ftp://cdn.example.com/archive"));
+        assertNull(HTML5Bundler.getUrlOrigin("file:///Users/me/archive"));
+    }
+
+    @Test
+    public void testMalformedUrlHasNoOrigin() {
+        assertNull(HTML5Bundler.getUrlOrigin("https://cdn.example.com/a b c"));
+        assertNull(HTML5Bundler.getUrlOrigin("https://"));
+        assertNull(HTML5Bundler.getUrlOrigin("::not a url::"));
+    }
+
+    @Test
+    public void testNullUrlHasNoOrigin() {
+        assertNull(HTML5Bundler.getUrlOrigin(null));
+    }
+}

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/HTML5Bundler.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/HTML5Bundler.java
@@ -28,6 +28,8 @@ import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
@@ -166,6 +168,13 @@ public class HTML5Bundler implements IBundler {
             properties.put("DEFOLD_ENGINE_ARGUMENTS", engineArguments);
         }
 
+        // If the game archive is hosted somewhere else than index.html (typically a CDN) we let
+        // the engine_template.html emit a preconnect hint for that origin. Must be done after the
+        // local launch check above, since that resets the archive location prefix.
+        String archiveOrigin = getUrlOrigin((String)properties.get("DEFOLD_ARCHIVE_LOCATION_PREFIX"));
+        properties.put("DEFOLD_HAS_ARCHIVE_ORIGIN", archiveOrigin != null);
+        properties.put("DEFOLD_ARCHIVE_ORIGIN", archiveOrigin != null ? archiveOrigin : "");
+
         properties.put("DEFOLD_CUSTOM_CSS_INLINE", "");
         IResource customCSS = project.getResource("html5", "cssfile");
         if (customCSS != null) {
@@ -285,6 +294,35 @@ public class HTML5Bundler implements IBundler {
             finally {
                 IOUtils.closeQuietly(output);
             }
+        }
+    }
+
+    /**
+     * Get the origin (scheme://host[:port]) of an absolute or protocol relative url.
+     * @param url The url to get the origin from
+     * @return The origin, or null if the url is relative (ie same origin as index.html)
+     */
+    public static String getUrlOrigin(String url) {
+        if (url == null) {
+            return null;
+        }
+        // a protocol relative url ("//cdn.example.com/foo") inherits the scheme of the page
+        boolean protocolRelative = url.startsWith("//");
+        try {
+            URI uri = new URI(protocolRelative ? "https:" + url : url);
+            String host = uri.getHost();
+            String scheme = uri.getScheme();
+            if (host == null) {
+                return null;
+            }
+            if (!protocolRelative && !"http".equals(scheme) && !"https".equals(scheme)) {
+                return null;
+            }
+            String port = uri.getPort() != -1 ? ":" + uri.getPort() : "";
+            return (protocolRelative ? "//" : scheme + "://") + host + port;
+        }
+        catch (URISyntaxException e) {
+            return null;
         }
     }
 

--- a/engine/engine/content/builtins/manifests/web/engine_template.html
+++ b/engine/engine/content/builtins/manifests/web/engine_template.html
@@ -7,6 +7,45 @@
 	<meta name="apple-mobile-web-app-capable" content="yes">
 	<!-- The above 4 meta tags *must* come first in the head; any other head content must come *after* these tags -->
 
+{{#DEFOLD_HAS_ARCHIVE_ORIGIN}}
+	<!--
+	The game archive is hosted on another origin (html5.archive_location_prefix). Warm up the
+	connection to it while this page is being parsed, so that DNS, TCP and TLS setup is already
+	done when dmloader.js makes the first request. This benefits archive_files.json as well as
+	every game data piece downloaded after it.
+	-->
+	<link rel="preconnect" href="{{DEFOLD_ARCHIVE_ORIGIN}}" crossorigin>
+
+{{/DEFOLD_HAS_ARCHIVE_ORIGIN}}
+	<!--
+	Preload the archive manifest so the browser fetches it in parallel with dmloader.js
+	instead of waiting until dmloader.js has downloaded and executed. archive_files.json
+	is otherwise requested by JavaScript (an XHR in dmloader.js) and is invisible to the
+	preload scanner, yet it gates the wasm and game-data downloads. The href must match
+	the runtime archive_location_filter exactly (same DEFOLD_ARCHIVE_LOCATION_PREFIX/SUFFIX
+	used in dmloader.js), and as="fetch" + crossorigin must match the XHR so the preloaded
+	response is reused rather than fetched a second time. See issue #8716.
+	-->
+	<link rel="preload" as="fetch" crossorigin href="{{DEFOLD_ARCHIVE_LOCATION_PREFIX}}/archive_files.json{{DEFOLD_ARCHIVE_LOCATION_SUFFIX}}">
+{{#DEFOLD_HAS_WASM_ENGINE}}
+{{^DEFOLD_HAS_WASM_PTHREAD_ENGINE}}
+
+	<!--
+	Preload the engine. dmloader.js does not start downloading it until archive_files.json has
+	been received and parsed (see EngineLoader.loadWasmAsync), which puts the two largest files
+	in the bundle several round trips deep in the critical path. These hints start the transfer
+	while this page is still being parsed instead.
+	Only emitted when the pthread engine is not bundled: with both engines bundled dmloader.js
+	picks between <exe>.wasm and <exe>_pthread.wasm at runtime depending on whether the page is
+	cross origin isolated, so a static hint could download megabytes that are never used.
+	as="fetch" + crossorigin matches how dmloader.js requests them, either with an
+	XMLHttpRequest or with fetch() when html5.wasm_streaming is enabled.
+	-->
+	<link rel="preload" as="fetch" crossorigin href="{{exe-name}}_wasm.js">
+	<link rel="preload" as="fetch" crossorigin href="{{exe-name}}.wasm">
+{{/DEFOLD_HAS_WASM_PTHREAD_ENGINE}}
+{{/DEFOLD_HAS_WASM_ENGINE}}
+
 	<title>{{project.title}} {{project.version}}</title>
 	<style type='text/css'>
 	/* Disable user selection to avoid strange bug in Chrome on Windows:

--- a/engine/engine/content/builtins/manifests/web/engine_template.html
+++ b/engine/engine/content/builtins/manifests/web/engine_template.html
@@ -8,16 +8,16 @@
 	<!-- The above 4 meta tags *must* come first in the head; any other head content must come *after* these tags -->
 
 {{#DEFOLD_HAS_ARCHIVE_ORIGIN}}
-	<!--
+{{!
 	The game archive is hosted on another origin (html5.archive_location_prefix). Warm up the
 	connection to it while this page is being parsed, so that DNS, TCP and TLS setup is already
 	done when dmloader.js makes the first request. This benefits archive_files.json as well as
 	every game data piece downloaded after it.
-	-->
+}}
 	<link rel="preconnect" href="{{DEFOLD_ARCHIVE_ORIGIN}}" crossorigin>
 
 {{/DEFOLD_HAS_ARCHIVE_ORIGIN}}
-	<!--
+{{!
 	Preload the archive manifest so the browser fetches it in parallel with dmloader.js
 	instead of waiting until dmloader.js has downloaded and executed. archive_files.json
 	is otherwise requested by JavaScript (an XHR in dmloader.js) and is invisible to the
@@ -25,12 +25,12 @@
 	the runtime archive_location_filter exactly (same DEFOLD_ARCHIVE_LOCATION_PREFIX/SUFFIX
 	used in dmloader.js), and as="fetch" + crossorigin must match the XHR so the preloaded
 	response is reused rather than fetched a second time. See issue #8716.
-	-->
+}}
 	<link rel="preload" as="fetch" crossorigin href="{{DEFOLD_ARCHIVE_LOCATION_PREFIX}}/archive_files.json{{DEFOLD_ARCHIVE_LOCATION_SUFFIX}}">
 {{#DEFOLD_HAS_WASM_ENGINE}}
 {{^DEFOLD_HAS_WASM_PTHREAD_ENGINE}}
 
-	<!--
+{{!
 	Preload the engine. dmloader.js does not start downloading it until archive_files.json has
 	been received and parsed (see EngineLoader.loadWasmAsync), which puts the two largest files
 	in the bundle several round trips deep in the critical path. These hints start the transfer
@@ -40,7 +40,7 @@
 	cross origin isolated, so a static hint could download megabytes that are never used.
 	as="fetch" + crossorigin matches how dmloader.js requests them, either with an
 	XMLHttpRequest or with fetch() when html5.wasm_streaming is enabled.
-	-->
+}}
 	<link rel="preload" as="fetch" crossorigin href="{{exe-name}}_wasm.js">
 	<link rel="preload" as="fetch" crossorigin href="{{exe-name}}.wasm">
 {{/DEFOLD_HAS_WASM_PTHREAD_ENGINE}}


### PR DESCRIPTION
⚠️ ⚠️ ⚠️ `engine_template.html` was changed. If you have custom template file - please update it. ⚠️ ⚠️ ⚠️

Added browser resource hints for json/js/wasm files.

Fixes #8716 

### Technical changes
Good article with explanation of browser resource hints: https://www.debugbear.com/blog/resource-hints-rel-preload-prefetch-preconnect
Added following hints:
* always preload resource manifest json file `archive_files.json`
* preload `_wasm.js` and `.wasm` files if builds contains only WASM target. In case if build contains WASM + WASM pthread targets we don't preload anything because we need dynamically determine which variant will be used.
* if additional files (wasm, arcd, etc.) hosted in another place rather than index.html (for example, behind CDN) - add `preconnect` hint to eliminate additional network round trips.

Additionally mark comment blocks as excluded from result HTML.


## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
