### PR TITLE
Show multiple notifications at once

### DIFF
--- a/editor/project.clj
+++ b/editor/project.clj
@@ -88,7 +88,7 @@
 
                      [com.github.ben-manes.caffeine/caffeine "3.1.2"]
 
-                     [cljfx "1.10.9"
+                     [cljfx "1.10.10"
                       :exclusions [org.clojure/clojure
                                    org.openjfx/javafx-base
                                    org.openjfx/javafx-graphics

--- a/editor/resources/localization/en.editor_localization
+++ b/editor/resources/localization/en.editor_localization
@@ -354,6 +354,10 @@ dialog.fetch-libraries.host-unreachable.title = Fetch Failed
 dialog.fetch-libraries.host-unreachable.header = Fetch was aborted because a host could not be reached
 dialog.fetch-libraries.host-unreachable.content = Unreachable host: {host}\n\nPlease verify your internet connection and try again.
 
+# Notification view
+
+notification.more = + {count} more
+
 # Fetch libraries notification
 
 notification.fetch-libraries.changed = Project dependencies have changed. Do you want to fetch the libraries now?

--- a/editor/resources/localization/ru.editor_localization
+++ b/editor/resources/localization/ru.editor_localization
@@ -345,6 +345,10 @@ dialog.fetch-libraries.host-unreachable.title = Ошибка обновлени�
 dialog.fetch-libraries.host-unreachable.header = Загрузка остановлена\: хост недоступен
 dialog.fetch-libraries.host-unreachable.content = Недоступный хост\: {host}\n\nПроверьте подключение к интернету и попробуйте ещё раз.
 
+# Notification view
+
+notification.more = + ещё {count}
+
 # Fetch libraries notification
 
 notification.fetch-libraries.changed = Зависимости проекта изменились. Обновить библиотеки сейчас?

--- a/editor/src/clj/editor/fxui.clj
+++ b/editor/src/clj/editor/fxui.clj
@@ -972,16 +972,14 @@
           props
           (if-let [style-class (padding->style-class padding)]
             (-> props (dissoc :padding) (add-style-classes style-class))
-            (if (number? padding)
-              props
-              (throw (AssertionError. (str "Invalid padding: " padding))))))))))
+            props))))))
 
 (defn grid
   "Grid pane
 
   Supports all :grid-pane props, plus:
     :alignment    additionally supports :top, :left, :right and :bottom
-    :padding      either :none, :small, :medium, :large or number
+    :padding      additionally supports :none, :small, :medium and :large
     :spacing      either :none, :small, :medium, :large or number"
   [props]
   (-> props
@@ -995,7 +993,7 @@
 
   Supports all :h-box props, plus:
     :alignment    additionally supports :top, :left, :right and :bottom
-    :padding      either :none, :small, :medium, :large or number
+    :padding      additionally supports :none, :small, :medium and :large
     :spacing      either :none, :small, :medium, :large or number"
   [props]
   (-> props
@@ -1009,7 +1007,7 @@
 
   Supports all :v-box props, plus:
     :alignment    additionally supports :top, :left, :right and :bottom
-    :padding      either :none, :small, :medium, :large or number
+    :padding      additionally supports :none, :small, :medium and :large
     :spacing      either :none, :small, :medium, :large or number"
   [props]
   (-> props

--- a/editor/src/clj/editor/notifications_view.clj
+++ b/editor/src/clj/editor/notifications_view.clj
@@ -16,105 +16,128 @@
   (:require [cljfx.api :as fx]
             [cljfx.fx.button :as fx.button]
             [cljfx.fx.flow-pane :as fx.flow-pane]
-            [cljfx.fx.h-box :as fx.h-box]
             [cljfx.fx.region :as fx.region]
             [cljfx.fx.stack-pane :as fx.stack-pane]
             [cljfx.fx.v-box :as fx.v-box]
             [dynamo.graph :as g]
             [editor.error-reporting :as error-reporting]
             [editor.fxui :as fxui]
+            [editor.localization :as localization]
             [editor.notifications :as notifications]
             [editor.ui :as ui]))
 
 (def ^:private ext-with-v-box-props
   (fx/make-ext-with-props fx.v-box/props))
 
-(defn- close-notification! [{:keys [notifications-node id]}]
-  (notifications/close! notifications-node id))
-
-(defn- invoke-action! [{:keys [on-action] :as event}]
+(defn- invoke-action! [notifications-node id on-action]
   (try
     (on-action)
     (catch Exception e
       (error-reporting/report-exception! e)))
-  (close-notification! event))
+  (notifications/close! notifications-node id))
 
-(defn- notifications-view [{:keys [id->notification ids]} parent localization]
-  (let [n (count ids)]
+(defn- notification-view
+  [{:keys [id localization-state notification notifications-node]}]
+  (let [typical-button-count 3
+        horizontal-padding 14
+        vertical-padding 8
+        close-button-margin 4
+        spacing 4
+        {:keys [type message actions]} notification]
+    {:fx/type fx.stack-pane/lifecycle
+     :max-width (+ (* typical-button-count 100) ;; min button width
+                   (* 2 horizontal-padding)
+                   (* (dec typical-button-count) spacing))
+     :children
+     [{:fx/type fx.region/lifecycle
+       :style-class "notification-card-background"
+       :pseudo-classes #{type}}
+      {:fx/type fxui/vertical
+       :children
+       (cond-> [{:fx/type fxui/horizontal
+                 :alignment :top-left
+                 :padding {:top vertical-padding
+                           :bottom vertical-padding
+                           :left horizontal-padding
+                           :right (- horizontal-padding close-button-margin)}
+                 :spacing spacing
+                 :fill-height false
+                 :children [{:fx/type fxui/paragraph
+                             :h-box/hgrow :always
+                             :text (localization-state message)}
+                            {:fx/type fx.region/lifecycle
+                             :h-box/margin close-button-margin
+                             :on-mouse-clicked (fn [_]
+                                                 (notifications/close! notifications-node id))
+                             :min-width 10
+                             :min-height 10
+                             :style-class "notification-card-close-button"}]}]
+               (pos? (count actions))
+               (conj {:fx/type fx.flow-pane/lifecycle
+                      :hgap spacing
+                      :vgap spacing
+                      :padding {:left horizontal-padding
+                                :right horizontal-padding
+                                :bottom vertical-padding}
+                      :children (mapv
+                                  (fn [{:keys [message on-action]}]
+                                    {:fx/type fx.button/lifecycle
+                                     :style-class ["button" "notification-card-button"]
+                                     :text (localization-state message)
+                                     :on-action (fn [_]
+                                                  (invoke-action! notifications-node id on-action))})
+                                  actions)}))}]}))
+
+(ui/defc ^:private notifications-view
+  {:compose [{:fx/type fx/ext-watcher :ref (:localization props) :key :localization-state}]}
+  [{:keys [localization-state notifications notifications-node parent]}]
+  (let [{:keys [id->notification ids]} notifications
+        hidden-count (max 0 (- (count ids) 3))]
     {:fx/type ext-with-v-box-props
      :desc {:fx/type ui/ext-value :value parent}
      :props
-     {:padding 10
+     {:alignment :center-right
+      :fill-width false
+      :padding 10
+      :spacing 8
       :children
-      (cond-> []
-              (pos? n)
-              (conj
-                (let [typical-button-count 3
-                      horizontal-padding 14
-                      vertical-padding 8
-                      close-button-margin 4
-                      spacing 4
-                      id (peek ids)
-                      {:keys [type message actions]} (id->notification id)]
-                  {:fx/type fx.stack-pane/lifecycle
-                   :max-width (+ (* typical-button-count 100) ;; min button width
-                                 (* 2 horizontal-padding)
-                                 (* (dec typical-button-count) spacing))
+      (-> []
+          (cond-> (pos? hidden-count)
+            (conj {:fx/type fx.stack-pane/lifecycle
                    :children
                    [{:fx/type fx.region/lifecycle
                      :style-class "notification-card-background"
-                     :pseudo-classes #{type}}
-                    {:fx/type fx.v-box/lifecycle
+                     :pseudo-classes #{(reduce #(max-key {:info 0 :warning 1 :error 2} %1 (:type (id->notification %2)))
+                                               :info
+                                               (subvec ids 0 hidden-count))}}
+                    {:fx/type fxui/vertical
+                     :padding {:top 0 :right 6 :bottom 0 :left 6}
                      :children
-                     (cond-> [{:fx/type fx.h-box/lifecycle
-                               :alignment :top-left
-                               :padding {:top vertical-padding
-                                         :bottom vertical-padding
-                                         :left horizontal-padding
-                                         :right (- horizontal-padding close-button-margin)}
-                               :spacing spacing
-                               :fill-height false
-                               :children [{:fx/type fxui/ext-localize
-                                           :h-box/hgrow :always
-                                           :localization localization
-                                           :message message
-                                           :desc {:fx/type fxui/legacy-label
-                                                  :max-width Double/MAX_VALUE}}
-                                          {:fx/type fx.region/lifecycle
-                                           :h-box/margin close-button-margin
-                                           :on-mouse-clicked {:fn #'close-notification! :id id}
-                                           :min-width 10
-                                           :min-height 10
-                                           :style-class "notification-card-close-button"}]}]
-                             (pos? (count actions))
-                             (conj {:fx/type fx.flow-pane/lifecycle
-                                    :hgap spacing
-                                    :vgap spacing
-                                    :padding {:left horizontal-padding
-                                              :right horizontal-padding
-                                              :bottom vertical-padding}
-                                    :children (mapv
-                                                (fn [{:keys [message on-action]}]
-                                                  {:fx/type fxui/ext-localize
-                                                   :localization localization
-                                                   :message message
-                                                   :desc
-                                                   {:fx/type fx.button/lifecycle
-                                                    :style-class ["button" "notification-card-button"]
-                                                    :on-action {:fn #'invoke-action!
-                                                                :id id
-                                                                :on-action on-action}}})
-                                                actions)}))}]})))}}))
+                     [{:fx/type fxui/label
+                       :text (localization-state
+                               (localization/message
+                                 "notification.more"
+                                 {"count" hidden-count}))}]}]}))
+          (into
+            (map
+              (fn [id]
+                {:fx/type notification-view
+                 :id id
+                 :localization-state localization-state
+                 :notification (id->notification id)
+                 :notifications-node notifications-node}))
+            (subvec ids hidden-count)))}}))
 
 (defn init! [notifications-node parent localization]
-  (let [renderer (fx/create-renderer
-                   :error-handler error-reporting/report-exception!
-                   :opts {:fx.opt/map-event-handler #((:fn %) (assoc % :notifications-node notifications-node))}
-                   :middleware (comp
-                                 fxui/wrap-dedupe-desc
-                                 (fx/wrap-map-desc #'notifications-view parent localization)))]
-    (ui/timer-start!
-      (ui/->timer 30 "notifications-view-timer"
-                  (fn [_timer _elapsed _dt]
-                    (renderer (g/node-value notifications-node :notifications)))))
-    nil))
+  (ui/timer-start!
+    (ui/->timer 30 "notifications-view-timer"
+                (fn [_timer _elapsed _dt]
+                  (ui/advance-ui-user-data-component!
+                    parent
+                    ::view
+                    {:fx/type notifications-view
+                     :localization localization
+                     :notifications (g/node-value notifications-node :notifications)
+                     :notifications-node notifications-node
+                     :parent parent}))))
+  nil)


### PR DESCRIPTION
The editor now has enough useful notifications that many may be emitted at the same time. Previously, we showed only 1 at a time; now we show up to 3, with an indicator if there are more.

<img width="617" height="454" alt="Screenshot 2026-07-22 at 13 08 36" src="https://github.com/user-attachments/assets/cb4110ce-14c9-413e-805b-1d42425b6a1a" />

Fix #12727