### PR TITLE
Quit Defold if the project folder was removed or moved

### DIFF
--- a/editor/resources/localization/en.editor_localization
+++ b/editor/resources/localization/en.editor_localization
@@ -279,6 +279,12 @@ dialog.quit-defold.header = Unsaved changes exist, are you sure you want to quit
 dialog.quit-defold.button.cancel = Cancel and Keep Working
 dialog.quit-defold.button.quit = Quit Without Saving
 
+# Project directory unavailable dialog
+
+dialog.project-directory-unavailable.title = Project Folder Unavailable
+dialog.project-directory-unavailable.header = The project folder can no longer be found
+dialog.project-directory-unavailable.content = The project folder was moved, renamed, or deleted outside Defold. Defold must quit. Any unsaved changes will be lost.
+
 # Restart Defold dialog
 
 dialog.restart-defold.title = Restart Defold?

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -904,10 +904,28 @@
 
 (defn async-reload!
   [app-view changes-view workspace moved-files]
-  (let [render-reload-progress! (make-render-task-progress :resource-sync)]
-    (disk/async-reload! render-reload-progress! workspace moved-files changes-view
-                        (fn [_success]
-                          (ui/user-data! (g/node-value app-view :scene) ::ui/refresh-requested? true)))))
+  (if-not (.isDirectory (workspace/project-directory workspace))
+    (g/let-ec [^Stage stage (g/node-value app-view :stage evaluation-context)
+               localization (g/node-value app-view :localization evaluation-context)]
+      (dialogs/make-info-dialog
+        localization
+        {:title (localization/message "dialog.project-directory-unavailable.title")
+         :icon :icon/triangle-error
+         :header (localization/message "dialog.project-directory-unavailable.header")
+         :content {:wrap-text true
+                   :text (localization/message "dialog.project-directory-unavailable.content")}
+         :buttons [{:text (localization/message "dialog.button.quit")
+                    :cancel-button true
+                    :default-button true}]})
+      (.setOnCloseRequest stage nil)
+      (.close stage))
+    (disk/async-reload!
+      (make-render-task-progress :resource-sync)
+      workspace
+      moved-files
+      changes-view
+      (fn [_success]
+        (ui/user-data! (g/node-value app-view :scene) ::ui/refresh-requested? true)))))
 
 (defn handle-application-focused! [app-view changes-view workspace prefs]
   (when (and (disk-availability/available?)


### PR DESCRIPTION
If a project directory is removed or renamed, the Defold editor can no longer be used. Previously, the editor raised an exception in such cases. Now, we show a dialog informing the user that the editor will quit:

<img width="608" height="386" alt="Screenshot 2026-07-22 at 14 31 37" src="https://github.com/user-attachments/assets/bb211948-e8d9-4ea5-ad9f-3b7a4af0203c" />


Fix #10913