### PR TITLE
Keep old and new input/output remappings in shader pipeline

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/ShaderCompilePipelineTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/ShaderCompilePipelineTest.java
@@ -330,8 +330,7 @@ public class ShaderCompilePipelineTest {
         return null;
     }
 
-    @Test
-    public void testRemapInputOutputs() throws Exception {
+    private void assertRemapInputOutputs(ShaderCompilePipeline.Options options) throws Exception {
         String vsShader =
                  """
                 #version 140
@@ -366,8 +365,6 @@ public class ShaderCompilePipelineTest {
         ArrayList<ShaderCompilePipeline.ShaderModuleDesc> shaderModuleDescs = toShaderDescs(vsShader, fsShader);
 
         ShaderCompilePipeline pipeline = new ShaderCompilePipeline("testRemapping");
-        ShaderCompilePipeline.Options options = new ShaderCompilePipeline.Options();
-        options.remapVertexFragmentIOForHLSL = true;
         ShaderCompilePipeline.createShaderPipeline(pipeline, shaderModuleDescs, options);
 
         SPIRVReflector reflectorVs = pipeline.getReflectionData(ShaderDesc.ShaderType.SHADER_TYPE_VERTEX);
@@ -388,6 +385,18 @@ public class ShaderCompilePipelineTest {
         }
 
         ShaderCompilePipeline.destroyShaderPipeline(pipeline);
+    }
+
+    @Test
+    public void testRemapInputOutputs() throws Exception {
+        assertRemapInputOutputs(new ShaderCompilePipeline.Options());
+    }
+
+    @Test
+    public void testRemapInputOutputsForHLSL() throws Exception {
+        ShaderCompilePipeline.Options options = new ShaderCompilePipeline.Options();
+        options.remapVertexFragmentIOForHLSL = true;
+        assertRemapInputOutputs(options);
     }
 
     @Test

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/shader/ShaderCompilePipeline.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/shader/ShaderCompilePipeline.java
@@ -352,9 +352,11 @@ public class ShaderCompilePipeline {
             long compilerVs = 0;
             long compilerFs = 0;
             if (this.options != null && this.options.remapVertexFragmentIOForHLSL) {
-                RemapCompilers remapCompilers = remapOutputsAndInputs(vertexModule, fragmentModule);
+                RemapCompilers remapCompilers = remapOutputsAndInputsForHLSL(vertexModule, fragmentModule);
                 compilerVs = remapCompilers.vertexCompiler;
                 compilerFs = remapCompilers.fragmentCompiler;
+            } else {
+                compilerFs = remapFragmentInputsToVertexOutputs(vertexModule, fragmentModule);
             }
             compilerFs = mergeResources(vertexModule, fragmentModule, compilerFs, mergedResources);
 
@@ -405,6 +407,23 @@ public class ShaderCompilePipeline {
         int columnCount = Math.max(1, resource.type.columnCount);
         int arraySize = Math.max(1, resource.type.arraySize);
         return columnCount * arraySize;
+    }
+
+    // SPIR-V modules are compiled one stage at a time, so matching vertex outputs and
+    // fragment inputs can receive different automatically assigned locations. Preserve
+    // the vertex stage and restore the fragment-stage remapping used by all backends
+    // before the HLSL-specific remapper was introduced.
+    private long remapFragmentInputsToVertexOutputs(ShaderModule vertexModule, ShaderModule fragmentModule) {
+        long compiler = 0;
+        for (Shaderc.ShaderResource output : vertexModule.spirvReflector.getOutputs()) {
+            for (Shaderc.ShaderResource input : fragmentModule.spirvReflector.getInputs()) {
+                if (output.name.equals(input.name) && output.location != input.location) {
+                    compiler = ensureSpirvCompiler(compiler, fragmentModule.spirvContext);
+                    ShadercJni.SetResourceLocation(fragmentModule.spirvContext, compiler, input.nameHash, output.location);
+                }
+            }
+        }
+        return compiler;
     }
 
     private void recompileSpirvModule(ShaderModule module, long compiler) throws IOException, CompileExceptionError {
@@ -503,7 +522,7 @@ public class ShaderCompilePipeline {
      * A remap compiler is only created for a stage if at least one location needs to
      * change for that stage.
      */
-    private RemapCompilers remapOutputsAndInputs(ShaderModule vertexModule, ShaderModule fragmentModule) {
+    private RemapCompilers remapOutputsAndInputsForHLSL(ShaderModule vertexModule, ShaderModule fragmentModule) {
         RemapCompilers compilers = new RemapCompilers();
 
         ArrayList<Shaderc.ShaderResource> outputs = vertexModule.spirvReflector.getOutputs();


### PR DESCRIPTION
Regression fix for remapping inputs and outputs for SPIR-v based shaders.