### PR TITLE
Speed up LiveUpdate archive creation

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/archive/test/ArchiveTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/archive/test/ArchiveTest.java
@@ -26,8 +26,9 @@ import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
@@ -143,7 +144,7 @@ public class ArchiveTest {
         RandomAccessFile outFileData = new RandomAccessFile(outputData, "rw");
         outFileIndex.setLength(0);
         outFileData.setLength(0);
-        ab.write(outFileIndex, outFileData, new ArrayList<String>());
+        ab.write(outFileIndex, outFileData, new HashSet<String>());
         outFileIndex.close();
         outFileData.close();
 
@@ -249,7 +250,7 @@ public class ArchiveTest {
             index.setLength(0);
             data.setLength(0);
             data.seek(resourceOffset);
-            ab.write(index, data, new ArrayList<String>());
+            ab.write(index, data, new HashSet<String>());
         }
 
         try (RandomAccessFile index = new RandomAccessFile(outputIndex, "r")) {
@@ -283,7 +284,7 @@ public class ArchiveTest {
         RandomAccessFile outFileData = new RandomAccessFile(outputData, "rw");
         outFileIndex.setLength(0);
         outFileData.setLength(0);
-        ab.write(outFileIndex, outFileData, new ArrayList<String>());
+        ab.write(outFileIndex, outFileData, new HashSet<String>());
         outFileIndex.close();
         outFileData.close();
 
@@ -322,7 +323,7 @@ public class ArchiveTest {
             RandomAccessFile archiveData = new RandomAccessFile(outputData, "rw");
             archiveIndex.setLength(0);
             archiveData.setLength(0);
-            instance.write(archiveIndex, archiveData, new ArrayList<String>());
+            instance.write(archiveIndex, archiveData, new HashSet<String>());
             archiveIndex.close();
             archiveData.close();
 
@@ -398,7 +399,7 @@ public class ArchiveTest {
         ResourceNode collectionproxy1 = addExcludedEntry("main.collectionproxyc", "beta", instance, collection1);
         ResourceNode gameobject1 = addEntry("main.goc", "delta", instance, collectionproxy1);
 
-        List<String> excludedResources = resourceGraph.createExcludedResourcesList();
+        Set<String> excludedResources = resourceGraph.createExcludedResourcesList();
 
         // Test
         RandomAccessFile outFileIndex = new RandomAccessFile(outputIndex, "rw");
@@ -426,7 +427,7 @@ public class ArchiveTest {
         ResourceNode gameobject1 = addEntry("level1.goc", "gamma", instance, collectionproxy1);
         ResourceNode gameobject2 = addEntry("level2.goc", "epsilon", instance, collectionproxy2);
 
-        List<String> excludedResources = resourceGraph.createExcludedResourcesList();
+        Set<String> excludedResources = resourceGraph.createExcludedResourcesList();
 
         // Test
         RandomAccessFile outFileIndex = new RandomAccessFile(outputIndex, "rw");
@@ -456,7 +457,7 @@ public class ArchiveTest {
         ResourceNode gameobject1 = addEntry("shared.goc", "gamma", instance, collectionproxy1);
         ResourceNode gameobject2 = addEntry("shared.goc", "gamma", instance, collectionproxy2);
 
-        List<String> excludedResources = resourceGraph.createExcludedResourcesList();
+        Set<String> excludedResources = resourceGraph.createExcludedResourcesList();
 
         // Test
         RandomAccessFile outFileIndex = new RandomAccessFile(outputIndex, "rw");
@@ -486,7 +487,7 @@ public class ArchiveTest {
         ResourceNode gameobject1 = addEntry("level1.goc", "gamma", instance, collectionproxy1);
         ResourceNode gameobject2 = addEntry("level2.goc", "epsilon", instance, collectionproxy2);
 
-        List<String> excludedResources = resourceGraph.createExcludedResourcesList();
+        Set<String> excludedResources = resourceGraph.createExcludedResourcesList();
 
         // Test
         RandomAccessFile outFileIndex = new RandomAccessFile(outputIndex, "rw");
@@ -515,7 +516,7 @@ public class ArchiveTest {
         ResourceNode gameobject11 = addEntry("level1.goc", "gamma", instance, collectionproxy1); // should be bundled
         ResourceNode gameobject2 = addEntry("level2.goc", "epsilon", instance, collectionproxy2); // should be excluded
 
-        List<String> excludedResources = resourceGraph.createExcludedResourcesList();
+        Set<String> excludedResources = resourceGraph.createExcludedResourcesList();
 
         // Test
         RandomAccessFile outFileIndex = new RandomAccessFile(outputIndex, "rw");
@@ -547,7 +548,7 @@ public class ArchiveTest {
         ResourceNode gameobject2 = addEntry("level2.goc", "epsilon", instance, collectionproxy2); // should be excluded
         ResourceNode gameobject3 = addEntry("level3.goc", "eta", instance, collectionproxy2); // should be excluded
 
-        List<String> excludedResources = resourceGraph.createExcludedResourcesList();
+        Set<String> excludedResources = resourceGraph.createExcludedResourcesList();
 
         // Test
         RandomAccessFile outFileIndex = new RandomAccessFile(outputIndex, "rw");
@@ -577,7 +578,7 @@ public class ArchiveTest {
         ResourceNode gameobject1 = addEntry("level1.goc", "gamma", instance, collectionproxy1);
         ResourceNode gameobject2 = addEntry("level2.goc", "epsilon", instance, collectionproxy2);
 
-        List<String> excludedResources = resourceGraph.createExcludedResourcesList();
+        Set<String> excludedResources = resourceGraph.createExcludedResourcesList();
 
         // Test
         RandomAccessFile outFileIndex = new RandomAccessFile(outputIndex, "rw");

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/graph/test/ResourceGraphTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/graph/test/ResourceGraphTest.java
@@ -17,7 +17,7 @@ package com.dynamo.bob.pipeline.graph.test;
 import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
-import java.util.List;
+import java.util.Set;
 
 import org.junit.After;
 import org.junit.Before;
@@ -98,7 +98,7 @@ public class ResourceGraphTest {
 
     @Test
     public void testUsageCounts() throws IOException {
-        List<String> excludedResources = resourceGraph.createExcludedResourcesList();
+        Set<String> excludedResources = resourceGraph.createExcludedResourcesList();
         System.out.println("excludedResources " + excludedResources);
         assertEquals(3, excludedResources.size());
     }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/archive/ArchiveBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/archive/ArchiveBuilder.java
@@ -163,7 +163,7 @@ public class ArchiveBuilder {
         return includedEntries;
     }
 
-    private void writeArchiveEntry(RandomAccessFile archiveData, ArchiveEntry entry, List<String> excludedResources, ConcurrentHashMap<String, ArchiveEntry> writtenIntoArcd) throws IOException, CompileExceptionError {
+    private void writeArchiveEntry(RandomAccessFile archiveData, ArchiveEntry entry, Set<String> excludedResources, ConcurrentHashMap<String, ArchiveEntry> writtenIntoArcd) throws IOException, CompileExceptionError {
         byte[] buffer = this.loadResourceData(entry.getFilename());
 
         int resourceEntryFlags = 0;
@@ -335,7 +335,7 @@ public class ArchiveBuilder {
     //                                            ↓
     //                    → Final in-memory resource ready for use
     //
-    public void write(RandomAccessFile archiveIndex, RandomAccessFile archiveData, List<String> excludedResources) throws IOException, CompileExceptionError {
+    public void write(RandomAccessFile archiveIndex, RandomAccessFile archiveData, Set<String> excludedResources) throws IOException, CompileExceptionError {
         // create the executor service to write entries in parallel
         int nThreads = project.getMaxCpuThreads();
         logger.info("Creating archive entries with a fixed thread pool executor using %d threads", nThreads);
@@ -480,7 +480,7 @@ public class ArchiveBuilder {
 
             ResourceNode rootNode = resourceGraph.getRootNode();
 
-            List<String> excludedResources = new ArrayList<String>();
+            Set<String> excludedResources = new HashSet<String>();
 
             // set up publisher - has to be done before creating the ArchiveBuilder
             PublisherSettings settings = new PublisherSettings();

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/GameProjectBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/GameProjectBuilder.java
@@ -233,7 +233,7 @@ public class GameProjectBuilder extends Builder {
         return resourcePadding;
     }
 
-    private void createArchive(ArchiveBuilder archiveBuilder, Collection<IResource> resources, RandomAccessFile archiveIndex, RandomAccessFile archiveData, List<String> excludedResources) throws IOException, CompileExceptionError {
+    private void createArchive(ArchiveBuilder archiveBuilder, Collection<IResource> resources, RandomAccessFile archiveIndex, RandomAccessFile archiveData, Set<String> excludedResources) throws IOException, CompileExceptionError {
         TimeProfiler.start("createArchive");
         logger.info("GameProjectBuilder.createArchive");
         long tstart = System.currentTimeMillis();
@@ -392,12 +392,12 @@ public class GameProjectBuilder extends Builder {
             logger.info("Creation of the excluded resources list.");
             tstart = System.currentTimeMillis();
             boolean shouldPublishLU = project.option("liveupdate", "false").equals("true");
-            List<String> excludedResources;
+            Set<String> excludedResources;
             if (shouldPublishLU) {
                 excludedResources = resourceGraph.createExcludedResourcesList();
             }
             else {
-                excludedResources = new ArrayList<String>();
+                excludedResources = new HashSet<String>();
             }
             tend = System.currentTimeMillis();
             logger.info("Creation of the excluded resources list took %f s", (tend-tstart)/1000.0);

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/graph/ResourceGraph.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/graph/ResourceGraph.java
@@ -19,8 +19,6 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.HashMap;
-import java.util.List;
-import java.util.LinkedList;
 import java.util.Collection;
 
 import java.io.Writer;
@@ -217,15 +215,15 @@ public class ResourceGraph implements IResourceVisitor {
     }
 
     /**
-     * Create a list of all excluded resources. A resource is considered to be
+     * Create a set of all excluded resources. A resource is considered to be
      * excluded if it is only referenced from excluded collection proxies. If a
      * resource is referenced both from an excluded collection proxy and from
      * a non-excluded collection it will not be considered an excluded resource.
-     * @return List of excluded resources
+     * @return Set of excluded resources
      */
-    public List<String> createExcludedResourcesList() {
+    public Set<String> createExcludedResourcesList() {
         findAllResourcesReferencedFromMainCollection();
-        List<String> excludedResources = new LinkedList<>();
+        Set<String> excludedResources = new HashSet<>();
         for (ResourceNode node : resourceNodes) {
             if (node.isInMainBundle()) {
                 continue;


### PR DESCRIPTION
This change significantly speeds up live update archive creation by changing the underlying data structure holding  the excluded files.

## Technical changes

Switching from LinkedList to HashSet will save significant time on the many `contains()` queries done on the list/set of excluded files. A quick benchmark of contains() performance:

Items | Queries | LinkedList | HashSet | Speedup
-- | -- | -- | -- | --
1,000 | 10,000 | 1,378.8 ns | 27.1 ns | 50.9×
10,000 | 20,000 | 13,382.8 ns | 8.8 ns | 1,520×
100,000 | 20,000 | 136,089.5 ns | 8.9 ns | 15,294.6×

Fixes #12806 