### PR TITLE
Fix callbacks created from Lua coroutines

### DIFF
--- a/engine/gamesys/src/gamesys/scripts/script_particlefx.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_particlefx.cpp
@@ -250,7 +250,7 @@ namespace dmGameSystem
 
         if (top > 1 && !lua_isnil(L, 2))
         {
-            data.m_CallbackInfo = dmScript::CreateCallback(dmScript::GetMainThread(L), -1);
+            data.m_CallbackInfo = dmScript::CreateCallback(L, 2);
             if (data.m_CallbackInfo == 0x0)
             {
                 return DM_LUA_ERROR("particlefx.play failed to create callback");

--- a/engine/gamesys/src/gamesys/scripts/script_resource.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_resource.cpp
@@ -1118,7 +1118,7 @@ static int CreateTextureAsync(lua_State* L)
     // The callback is optional, we don't have to do anything with the result if we don't need to.
     // I.e the upload can be fire-and-forget. There is no way an upload can fail in the graphics system,
     // we should catch any incorrectness here if that's the case.
-    dmScript::LuaCallbackInfo* callback_info = dmScript::CreateCallback(dmScript::GetMainThread(L), 4);
+    dmScript::LuaCallbackInfo* callback_info = dmScript::CreateCallback(L, 4);
 
     // Create an initial blank texture that can be used while we upload the texture data externally
     CreateTextureResourceParams create_texture_resource_params = create_params;
@@ -1162,7 +1162,7 @@ static int CreateTextureAsync(lua_State* L)
 
     SetTextureAsyncRequest* request = new SetTextureAsyncRequest();
     HOpaqueHandle request_handle = g_ResourceModule.m_LoadRequests.Put(request);
-    request->m_LuaState          = L;
+    request->m_LuaState          = dmScript::GetMainThread(L);
     request->m_TextureResource   = (TextureResource*) resource;
     request->m_Handle            = request_handle;
     request->m_CallbackInfo      = callback_info;

--- a/engine/gamesys/src/gamesys/scripts/script_sys_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_sys_gamesys.cpp
@@ -339,7 +339,7 @@ namespace dmGameSystem
     {
         int top          = lua_gettop(L);
         const char* path = luaL_checkstring(L, 1);
-        dmScript::LuaCallbackInfo* callback_info = dmScript::CreateCallback(dmScript::GetMainThread(L), 2);
+        dmScript::LuaCallbackInfo* callback_info = dmScript::CreateCallback(L, 2);
 
         if (callback_info == 0x0)
         {

--- a/engine/gamesys/src/gamesys/test/particlefx/build.inputs
+++ b/engine/gamesys/src/gamesys/test/particlefx/build.inputs
@@ -6,5 +6,6 @@
 /particlefx/particlefx_get_set_properties.go
 /particlefx/particlefx_get_set_properties.material
 /particlefx/particlefx_play.go
+/particlefx/particlefx_play_from_coroutine.go
 /particlefx/test_comp.go
 /particlefx/valid_particlefx.go

--- a/engine/gamesys/src/gamesys/test/particlefx/particlefx_play_from_coroutine.go
+++ b/engine/gamesys/src/gamesys/test/particlefx/particlefx_play_from_coroutine.go
@@ -1,0 +1,8 @@
+components {
+  id: "script"
+  component: "/particlefx/particlefx_play_from_coroutine.script"
+}
+components {
+  id: "particlefx"
+  component: "/particlefx/valid.particlefx"
+}

--- a/engine/gamesys/src/gamesys/test/particlefx/particlefx_play_from_coroutine.script
+++ b/engine/gamesys/src/gamesys/test/particlefx/particlefx_play_from_coroutine.script
@@ -1,0 +1,31 @@
+-- Copyright 2020-2026 The Defold Foundation
+-- Copyright 2014-2020 King
+-- Copyright 2009-2014 Ragnar Svensson, Christian Murray
+-- Licensed under the Defold License version 1.0 (the "License"); you may not use
+-- this file except in compliance with the License.
+--
+-- You may obtain a copy of the License, together with FAQs at
+-- https://www.defold.com/license
+--
+-- Unless required by applicable law or agreed to in writing, software distributed
+-- under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+-- CONDITIONS OF ANY KIND, either express or implied. See the License for the
+-- specific language governing permissions and limitations under the License.
+
+tests_done = false
+
+local function emitter_state_change(self, id, emitter, state)
+    if state == particlefx.EMITTER_STATE_POSTSPAWN then
+        tests_done = true
+    end
+end
+
+function init(self)
+    local co = coroutine.create(function()
+        particlefx.play("#particlefx", emitter_state_change)
+    end)
+
+    local ok, error = coroutine.resume(co)
+    assert(ok, tostring(error))
+    assert(coroutine.status(co) == "dead")
+end

--- a/engine/gamesys/src/gamesys/test/resource/build.inputs
+++ b/engine/gamesys/src/gamesys/test/resource/build.inputs
@@ -2,6 +2,7 @@
 /resource/booster_on_sfx.wav
 /resource/create_sound_data.go
 /resource/create_texture.go
+/resource/create_texture_async_from_coroutine.go
 /resource/font.font
 /resource/label.go
 /resource/layer_guitar_a.ogg

--- a/engine/gamesys/src/gamesys/test/resource/create_texture_async_from_coroutine.go
+++ b/engine/gamesys/src/gamesys/test/resource/create_texture_async_from_coroutine.go
@@ -1,0 +1,4 @@
+components {
+  id: "script"
+  component: "/resource/create_texture_async_from_coroutine.script"
+}

--- a/engine/gamesys/src/gamesys/test/resource/create_texture_async_from_coroutine.script
+++ b/engine/gamesys/src/gamesys/test/resource/create_texture_async_from_coroutine.script
@@ -1,0 +1,49 @@
+-- Copyright 2020-2026 The Defold Foundation
+-- Copyright 2014-2020 King
+-- Copyright 2009-2014 Ragnar Svensson, Christian Murray
+-- Licensed under the Defold License version 1.0 (the "License"); you may not use
+-- this file except in compliance with the License.
+--
+-- You may obtain a copy of the License, together with FAQs at
+-- https://www.defold.com/license
+--
+-- Unless required by applicable law or agreed to in writing, software distributed
+-- under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+-- CONDITIONS OF ANY KIND, either express or implied. See the License for the
+-- specific language governing permissions and limitations under the License.
+
+tests_done = false
+
+local texture_params = {
+    width = 4,
+    height = 4,
+    type = graphics.TEXTURE_TYPE_2D,
+    format = graphics.TEXTURE_FORMAT_RGBA,
+}
+
+function init(self)
+    local co = coroutine.create(function()
+        local texture_path = "/create_texture_async_from_coroutine.texturec"
+        local expected_path = hash(texture_path)
+        local texture_buffer = buffer.create(texture_params.width * texture_params.height, {
+            { name = hash("rgba"), type = buffer.VALUE_TYPE_UINT8, count = 4 }
+        })
+
+        resource.create_texture_async(texture_path, texture_params, texture_buffer, function(self, request_id, result)
+            assert(request_id ~= nil)
+            assert(result.path == expected_path)
+
+            local texture_info = resource.get_texture_info(result.path)
+            assert(texture_info.width == texture_params.width)
+            assert(texture_info.height == texture_params.height)
+            tests_done = true
+        end)
+    end)
+
+    local ok, error = coroutine.resume(co)
+    assert(ok, tostring(error))
+    assert(coroutine.status(co) == "dead")
+
+    co = nil
+    collectgarbage("collect")
+end

--- a/engine/gamesys/src/gamesys/test/sys/build.inputs
+++ b/engine/gamesys/src/gamesys/test/sys/build.inputs
@@ -1,3 +1,4 @@
 /sys/load_buffer_async.go
+/sys/load_buffer_async_from_coroutine.go
 /sys/load_buffer_sync.go
 /sys/sys_buffer_test_content.raw

--- a/engine/gamesys/src/gamesys/test/sys/load_buffer_async_from_coroutine.go
+++ b/engine/gamesys/src/gamesys/test/sys/load_buffer_async_from_coroutine.go
@@ -1,0 +1,4 @@
+components {
+  id: "script"
+  component: "/sys/load_buffer_async_from_coroutine.script"
+}

--- a/engine/gamesys/src/gamesys/test/sys/load_buffer_async_from_coroutine.script
+++ b/engine/gamesys/src/gamesys/test/sys/load_buffer_async_from_coroutine.script
@@ -1,0 +1,35 @@
+-- Copyright 2020-2026 The Defold Foundation
+-- Copyright 2014-2020 King
+-- Copyright 2009-2014 Ragnar Svensson, Christian Murray
+-- Licensed under the Defold License version 1.0 (the "License"); you may not use
+-- this file except in compliance with the License.
+--
+-- You may obtain a copy of the License, together with FAQs at
+-- https://www.defold.com/license
+--
+-- Unless required by applicable law or agreed to in writing, software distributed
+-- under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+-- CONDITIONS OF ANY KIND, either express or implied. See the License for the
+-- specific language governing permissions and limitations under the License.
+
+tests_done = false
+
+function init(self)
+    local co = coroutine.create(function()
+        local expected_data = "coroutine callback"
+        sys.load_buffer_async("/sys/sys_buffer_test_content.rawc", function(self, request_id, result)
+            assert(request_id ~= nil)
+            assert(result.status == sys.REQUEST_STATUS_FINISHED)
+            assert(result.buffer ~= nil)
+            assert(expected_data == "coroutine callback")
+            tests_done = true
+        end)
+    end)
+
+    local ok, error = coroutine.resume(co)
+    assert(ok, tostring(error))
+    assert(coroutine.status(co) == "dead")
+
+    co = nil
+    collectgarbage("collect")
+end

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -2614,6 +2614,26 @@ TEST_F(ParticleFxTest, PlayAnim)
     ASSERT_TRUE(dmGameObject::Final(m_Collection));
 }
 
+// Verify that particlefx.play() can capture and invoke an emitter callback when called from a coroutine.
+// The callback must be read from the coroutine's Lua stack; reading it from the main thread's stack
+// causes coroutine.resume() to fail with an unrelated value as its error object.
+TEST_F(ParticleFxTest, PlayAnimFromCoroutine)
+{
+    dmGameObject::HInstance go = Spawn(m_Factory, m_Collection, "/particlefx/particlefx_play_from_coroutine.goc", dmHashString64("/go"), 0, Point3(0, 0, 0), Quat(0, 0, 0, 1), Vector3(1, 1, 1));
+    ASSERT_NE((void*)0, go);
+
+    bool tests_done = false;
+    WaitForTestsDone(100, true, &tests_done);
+
+    if (!tests_done)
+    {
+        dmLogError("The playback didn't finish");
+    }
+    ASSERT_TRUE(tests_done);
+
+    ASSERT_TRUE(dmGameObject::Final(m_Collection));
+}
+
 TEST_F(ParticleFxTest, GetSetProperties)
 {
     dmGameSystem::MaterialResource *material;

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -916,6 +916,34 @@ TEST_F(ResourceFolderTest, TestCreateTextureFromScript)
     dmGameSystem::FinalizeScriptLibs(scriptlibcontext);
 }
 
+// Verify that resource.create_texture_async() keeps its callback and upload buffer alive after
+// the coroutine that created the request has finished and has been garbage collected.
+TEST_F(ResourceFolderTest, TestCreateTextureAsyncFromCoroutine)
+{
+    dmGameSystem::ScriptLibContext scriptlibcontext;
+    scriptlibcontext.m_Factory         = m_Factory;
+    scriptlibcontext.m_Register        = m_Register;
+    scriptlibcontext.m_LuaState        = dmScript::GetLuaState(m_ScriptContext);
+    scriptlibcontext.m_GraphicsContext = m_GraphicsContext;
+    scriptlibcontext.m_ScriptContext   = m_ScriptContext;
+    scriptlibcontext.m_JobContext      = m_JobContext;
+
+    dmGameSystem::InitializeScriptLibs(scriptlibcontext);
+
+    ASSERT_TRUE(dmGameObject::Init(m_Collection));
+
+    dmGraphics::NullContext* null_context = (dmGraphics::NullContext*) m_GraphicsContext;
+    null_context->m_UseAsyncTextureLoad   = 1;
+
+    dmGameObject::HInstance go = Spawn(m_Factory, m_Collection, "/resource/create_texture_async_from_coroutine.goc", dmHashString64("/create_texture_async_from_coroutine"), 0, Point3(0, 0, 0), Quat(0, 0, 0, 1), Vector3(1, 1, 1));
+    ASSERT_NE((void*)0, go);
+
+    ASSERT_TRUE(UpdateAndWaitUntilDone(scriptlibcontext, m_Collection, &m_UpdateContext, false, "tests_done"));
+
+    ASSERT_TRUE(dmGameObject::Final(m_Collection));
+    dmGameSystem::FinalizeScriptLibs(scriptlibcontext);
+}
+
 TEST_F(ResourceFolderTest, TestCreateSoundDataFromScript)
 {
     dmGameSystem::ScriptLibContext scriptlibcontext;
@@ -9275,6 +9303,20 @@ TEST_F(SysTest, LoadBufferASync)
 
     // Test 5
     ASSERT_TRUE(RunTestLoadBufferASync(5, m_Scriptlibcontext, m_Collection, &m_UpdateContext, true));
+
+    ASSERT_TRUE(dmGameObject::Final(m_Collection));
+}
+
+// Verify that sys.load_buffer_async() keeps its callback alive after the coroutine that created
+// the request has finished and has been garbage collected.
+TEST_F(SysTest, LoadBufferAsyncFromCoroutine)
+{
+    ASSERT_TRUE(dmGameObject::Init(m_Collection));
+
+    dmGameObject::HInstance go = Spawn(m_Factory, m_Collection, "/sys/load_buffer_async_from_coroutine.goc", dmHashString64("/load_buffer_async_from_coroutine"), 0, Point3(0, 0, 0), Quat(0, 0, 0, 1), Vector3(1, 1, 1));
+    ASSERT_NE((void*)0, go);
+
+    ASSERT_TRUE(UpdateAndWaitUntilDone(m_Scriptlibcontext, m_Collection, &m_UpdateContext, false, "tests_done", 3));
 
     ASSERT_TRUE(dmGameObject::Final(m_Collection));
 }


### PR DESCRIPTION
Particle effects, asynchronous buffer loading, and asynchronous texture creation now accept callbacks when called from a Lua coroutine. Callbacks remain valid after the originating coroutine finishes and is garbage collected, avoiding callback creation errors and unsafe texture cleanup.

### Technical changes

- Create callbacks from the calling Lua state in `particlefx.play()`, `sys.load_buffer_async()`, and `resource.create_texture_async()`.
- Store the main Lua state for asynchronous texture buffer cleanup so the request never retains a collected coroutine state.
- Add coroutine regression tests for all three APIs, including forced garbage collection before asynchronous completion.
- Add the new test resources to the Waf/Bob `build.inputs` files.
- Verify the new coroutine tests and existing async buffer and texture tests with `test_gamesys`.