### PR TITLE
Accept uppercase file extensions for referenced resources

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/fs/test/ResourceUtilTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/fs/test/ResourceUtilTest.java
@@ -132,6 +132,16 @@ public class ResourceUtilTest {
     }
 
     @Test
+    public void testExtensionMappingsAreCaseInsensitive() {
+        ResourceUtil.registerMapping(".png", ".texturec");
+
+        assertEquals(".texturec", ResourceUtil.getOutputExt(".PNG"));
+        assertEquals(".texturec", ResourceUtil.getOutputExt(".PnG"));
+        assertEquals("/Textures/Image.texturec",
+                ResourceUtil.minifyPathAndReplaceExt("/Textures/Image.PnG", ".png", ".texturec"));
+    }
+
+    @Test
     public void testMinifyEnabledUnsupportedSuffixKeepsPathAndAddsSlashForNonBuild() {
         ResourceUtil.enableMinification(true);
         assertEquals("/foo.bar", ResourceUtil.minifyPath("foo.bar"));

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/LightBuilderTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/LightBuilderTest.java
@@ -160,6 +160,12 @@ public class LightBuilderTest extends AbstractProtoBuilderTest {
     }
 
     @Test
+    public void testLightBuilderWithMixedCaseExtension() throws Exception {
+        assertLightTags("/light/Test.PoInT_LiGhT", POINT_LIGHT_SOURCE, "point_light");
+        assertNotNull(getFile("build/light/Test.point_light.lightc"));
+    }
+
+    @Test
     public void testLightBuilderColor() throws Exception {
         assertBuiltLightColor("/light/test.directional_light", LIGHT_SOURCE, 0.25, 0.5, 0.75);
         assertBuiltLightColor("/light/test.ambient_light", LIGHT_SOURCE, 0.25, 0.5, 0.75);

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/ModelBuilderTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/ModelBuilderTest.java
@@ -101,4 +101,34 @@ public class ModelBuilderTest extends AbstractProtoBuilderTest {
         assertEquals(ResourceUtil.minifyPath("/test_skeleton.skeletonc"), rigScene.getSkeleton());
         assertEquals("/test_animation_generated_0.animationsetc", rigScene.getAnimationSet());
     }
+
+    @Test
+    public void testModelTextureWithMixedCaseExtension() throws Exception {
+        addFile("/test_meshset.gltf", GLTF);
+        addImage("/test.png", 16, 16);
+        addFile("/Textures/Test.PnG", getFile("/test.png"));
+
+        String shaderSource = "void main() {}\n";
+        addFile("/testModelTexture.vp", shaderSource);
+        addFile("/testModelTexture.fp", shaderSource);
+        addFile("/test.material",
+                "name: \"test_material\"\n" +
+                "vertex_program: \"/testModelTexture.vp\"\n" +
+                "fragment_program: \"/testModelTexture.fp\"\n");
+
+        String modelSource =
+                "mesh: \"/test_meshset.gltf\"\n" +
+                "materials {\n" +
+                "  name: \"default\"\n" +
+                "  material: \"/test.material\"\n" +
+                "  textures {\n" +
+                "    sampler: \"texture_sampler\"\n" +
+                "    texture: \"/Textures/Test.PnG\"\n" +
+                "  }\n" +
+                "}\n";
+
+        Model model = getMessage(build("/test.model", modelSource), Model.class);
+        assertEquals("/Textures/Test.texturec",
+                model.getMaterials(0).getTextures(0).getTexture());
+    }
 }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
@@ -428,7 +428,7 @@ public class Project implements AutoCloseable {
                 BuilderParams builderParams = klass.getAnnotation(BuilderParams.class);
                 if (builderParams != null) {
                     for (String inExt : builderParams.inExts()) {
-                        extToBuilder.put(inExt, (Class<? extends Builder>) klass);
+                        extToBuilder.put(StringUtil.toLowerCase(inExt), (Class<? extends Builder>) klass);
                         ResourceUtil.registerMapping(inExt, builderParams.outExt());
                     }
                     Builder.addParamsDigest(klass, this.getOptions(), builderParams);
@@ -499,7 +499,7 @@ public class Project implements AutoCloseable {
     }
 
     private Class<? extends Builder> getBuilderFromExtension(String input) {
-        String ext = "." + FilenameUtils.getExtension(input);
+        String ext = "." + StringUtil.toLowerCase(FilenameUtils.getExtension(input));
         Class<? extends Builder> builderClass = extToBuilder.get(ext);
         return builderClass;
     }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/fs/ResourceUtil.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/fs/ResourceUtil.java
@@ -15,11 +15,14 @@
 package com.dynamo.bob.fs;
 
 import com.dynamo.bob.util.MurmurHash;
+import com.dynamo.bob.util.StringUtil;
 
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Collections;
+
+import org.apache.commons.lang3.StringUtils;
 
 public class ResourceUtil {
 
@@ -34,7 +37,7 @@ public class ResourceUtil {
     protected static String buildDirectory = null;
 
     public static void registerMapping(String inExt, String outExt) {
-        extensionMapping.put(inExt, outExt);
+        extensionMapping.put(StringUtil.toLowerCase(inExt), outExt);
         minifySupport.add(outExt);
     }
 
@@ -58,15 +61,16 @@ public class ResourceUtil {
     }
 
     /**
-     * Optionally change suffix of filename if the requested input suffix matches
+     * Optionally change suffix of filename if the requested input suffix matches,
+     * ignoring character case
      * @param path path to change suffix for
      * @param from input suffix
      * @param to output suffix
      * @return modified path if input suffix matched, otherwise the original input path
      */
     public static String replaceExt(String path, String from, String to) {
-        if (path.endsWith(from)) {
-            return path.substring(0, path.lastIndexOf(from)).concat(to);
+        if (StringUtils.endsWithIgnoreCase(path, from)) {
+            return path.substring(0, path.length() - from.length()).concat(to);
         }
         return path;
     }
@@ -77,7 +81,7 @@ public class ResourceUtil {
     * @return the output suffix (including the '.')
     */
     public static String getOutputExt(String inExt) {
-        String outExt = extensionMapping.get(inExt); // Get the output ext, or use the inExt as default
+        String outExt = extensionMapping.get(StringUtil.toLowerCase(inExt)); // Get the output ext, or use the inExt as default
         if (outExt != null)
             return outExt;
         return inExt;

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/LightBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/LightBuilder.java
@@ -25,6 +25,7 @@ import com.dynamo.bob.ProtoParams;
 import com.dynamo.bob.Task;
 import com.dynamo.bob.fs.IResource;
 import com.dynamo.bob.fs.ResourceUtil;
+import com.dynamo.bob.util.StringUtil;
 import com.dynamo.gamesys.proto.DataProto.Data;
 import com.dynamo.proto.DdfStruct.ListValue;
 import com.dynamo.proto.DdfStruct.Struct;
@@ -138,7 +139,7 @@ public class LightBuilder extends ProtoBuilder<Data.Builder> {
     }
 
     private static String lightTypeTagFromResource(IResource resource) {
-        String ext = FilenameUtils.getExtension(resource.getPath());
+        String ext = StringUtil.toLowerCase(FilenameUtils.getExtension(resource.getPath()));
         switch (ext) {
             case "point_light":
                 return "point_light";

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ProtoBuilders.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ProtoBuilders.java
@@ -34,6 +34,7 @@ import com.dynamo.bob.ProtoParams;
 import com.dynamo.bob.Task;
 import com.dynamo.bob.fs.IResource;
 import com.dynamo.bob.fs.ResourceUtil;
+import com.dynamo.bob.util.StringUtil;
 import com.dynamo.bob.util.BobNLS;
 import com.dynamo.bob.util.MathUtil;
 import com.dynamo.bob.util.TextureUtil;
@@ -66,7 +67,7 @@ public class ProtoBuilders {
 
     public static String getTextureSetExt(String str) throws Exception {
         Map<String, String> types = TextureUtil.getAtlasFileTypes();
-        String suffix = "." + FilenameUtils.getExtension(str);
+        String suffix = "." + StringUtil.toLowerCase(FilenameUtils.getExtension(str));
         String replacement = types.getOrDefault(suffix, null);
         if (replacement != null) {
             return replacement;


### PR DESCRIPTION
This change makes sure that the build process can successfully build referenced resources with uppercase file extensions such as `image.PNG`.

Fixes #12614 

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
