### PR TITLE
Filtered "Search in Files" search speed improvement

### DIFF
--- a/editor/src/clj/editor/defold_project_search.clj
+++ b/editor/src/clj/editor/defold_project_search.clj
@@ -31,42 +31,55 @@
   (some-> entry :resource resource/proj-path))
 
 (defn make-search-data-future
-  "Returns a future yielding search data for every project resource that passes
-  search-resource?, each with its :search-value built and ready to match against."
+  "Returns a map of :data-future and :cancel!. Deref :data-future for search data
+  covering every project resource that passes search-resource?, each with its
+  :search-value built and ready to match against. Call :cancel! to abandon the
+  work without reporting an error."
   [report-error! project search-resource?]
-  (let [evaluation-context (g/make-evaluation-context)]
-    (future
-      (try
-        (let [search-data
-              (->> (g/node-value project :node-id+resources evaluation-context)
-                   (into []
-                         (keep (fn [[node-id resource]]
-                                 (thread-util/throw-if-interrupted!)
-                                 (when (and (resource/loaded? resource)
-                                            (not (resource/internal? resource))
-                                            (= :file (resource/source-type resource))
-                                            (search-resource? resource))
-                                   (let [resource-type (resource/resource-type resource)
-                                         search-value-fn (when (:search-fn resource-type)
-                                                           (:search-value-fn resource-type))]
-                                     (when (and search-value-fn
-                                                (resource/exists? resource)
-                                                (resource/textual? resource))
-                                       (let [search-value (search-value-fn node-id resource evaluation-context)]
-                                         (when-not (g/error? search-value)
-                                           {:resource resource
-                                            :search-value search-value}))))))))
-                   (sort-by search-data-sort-key))]
-          (ui/run-later
-            (project/update-system-cache-save-data! evaluation-context)
-            (project/log-cache-info! (g/cache) "Cached searched save values in system cache."))
-          search-data)
-        (catch InterruptedException _
-          ;; future-cancel was invoked because the filter changed; discard.
-          nil)
-        (catch Throwable error
-          (report-error! error)
-          nil)))))
+  (let [evaluation-context (g/make-evaluation-context)
+
+        ;; Interrupting the thread can surface as any exception, not just
+        ;; InterruptedException, so we record that we cancelled rather than
+        ;; guessing from the exception type.
+        cancelled (volatile! false)
+
+        data-future
+        (future
+          (try
+            (let [search-data
+                  (->> (g/node-value project :node-id+resources evaluation-context)
+                       (into []
+                             (keep (fn [[node-id resource]]
+                                     (thread-util/throw-if-interrupted!)
+                                     (when (and (resource/loaded? resource)
+                                                (not (resource/internal? resource))
+                                                (= :file (resource/source-type resource))
+                                                (search-resource? resource))
+                                       (let [resource-type (resource/resource-type resource)
+                                             search-value-fn (when (:search-fn resource-type)
+                                                               (:search-value-fn resource-type))]
+                                         (when (and search-value-fn
+                                                    (resource/exists? resource)
+                                                    (resource/textual? resource))
+                                           (let [search-value (search-value-fn node-id resource evaluation-context)]
+                                             (when-not (g/error? search-value)
+                                               {:resource resource
+                                                :search-value search-value}))))))))
+                       (sort-by search-data-sort-key))]
+              (ui/run-later
+                (project/update-system-cache-save-data! evaluation-context)
+                (project/log-cache-info! (g/cache) "Cached searched save values in system cache."))
+              search-data)
+            (catch Throwable error
+              (when-not @cancelled
+                (report-error! error))
+              nil)
+            (finally
+              (Thread/interrupted))))]
+    {:data-future data-future
+     :cancel! (fn cancel! []
+                (vreset! cancelled true)
+                (future-cancel data-future))}))
 
 (defn- resource-matches-library-setting? [resource include-libraries?]
   (or include-libraries?
@@ -166,13 +179,15 @@
           (let [filter-key [searched-exts search-libraries]
                 current @search-data-atom]
             (if (= (:key current) filter-key)
-              (:future current)
-              (let [new-future (make-search-data-future
-                                 report-error! project
-                                 (make-search-resource? searched-exts search-libraries))]
-                (reset! search-data-atom {:key filter-key :future new-future})
-                (some-> current :future future-cancel)
-                new-future))))
+              (:data-future current)
+              (let [{:keys [data-future cancel!]}
+                    (make-search-data-future
+                      report-error! project
+                      (make-search-resource? searched-exts search-libraries))]
+                (reset! search-data-atom {:key filter-key :data-future data-future :cancel! cancel!})
+                (when current
+                  ((:cancel! current)))
+                data-future))))
 
         abort-search! (fn [pending-search]
                         (some-> pending-search :thread future-cancel)
@@ -207,9 +222,9 @@
      :abort-search! (fn []
                       (try
                         (swap! pending-search-atom abort-search!)
-                        (let [current @search-data-atom]
+                        (when-let [current @search-data-atom]
                           (reset! search-data-atom nil)
-                          (some-> current :future future-cancel))
+                          ((:cancel! current)))
                         (catch Throwable error
                           (report-error! error)))
                       nil)}))

--- a/editor/src/clj/editor/defold_project_search.clj
+++ b/editor/src/clj/editor/defold_project_search.clj
@@ -197,16 +197,19 @@
     (prepare-search-data! initial-searched-exts initial-search-libraries)
     {:start-search! (fn [search-string searched-exts include-libraries?]
                       (try
-                        (let [search-data-future (when (seq search-string)
-                                                   (prepare-search-data! searched-exts include-libraries?))]
-                          (swap! pending-search-atom start-search! search-data-future search-string))
+                        (let [search-data-future (prepare-search-data! searched-exts include-libraries?)]
+                          (swap! pending-search-atom start-search!
+                                 (when (coll/not-empty search-string) search-data-future)
+                                 search-string))
                         (catch Throwable error
                           (report-error! error)))
                       nil)
      :abort-search! (fn []
                       (try
                         (swap! pending-search-atom abort-search!)
-                        (some-> @search-data-atom :future future-cancel)
+                        (let [current @search-data-atom]
+                          (reset! search-data-atom nil)
+                          (some-> current :future future-cancel))
                         (catch Throwable error
                           (report-error! error)))
                       nil)}))

--- a/editor/src/clj/editor/defold_project_search.clj
+++ b/editor/src/clj/editor/defold_project_search.clj
@@ -32,59 +32,46 @@
   (some-> entry :resource resource/proj-path))
 
 (defn make-search-data-future
-  "Returns a map of :data-future and :cancel!. Deref :data-future for search data
-  covering every project resource that passes search-resource?, each with its
-  :search-value built and ready to match against. Call :cancel! to abandon the
-  work without reporting an error."
+  "Returns a future yielding search data for every project resource that passes
+  search-resource?, each with its :search-value built and ready to match against."
   [report-error! project search-resource?]
-  (let [evaluation-context (g/make-evaluation-context)
-
-        ;; Interrupting the thread can surface as any exception, not just
-        ;; InterruptedException, so we record that we cancelled rather than
-        ;; guessing from the exception type.
-        cancelled (volatile! false)
-
-        data-future
-        (future
-          (try
-            (let [search-data
-                  (->> (g/node-value project :node-id+resources evaluation-context)
-                       (into []
-                             (keep (fn [[node-id resource]]
-                                     (thread-util/throw-if-interrupted!)
-                                     (when (and (resource/loaded? resource)
-                                                (not (resource/internal? resource))
-                                                (= :file (resource/source-type resource))
-                                                (search-resource? resource))
-                                       (let [resource-type (resource/resource-type resource)
-                                             search-value-fn (when (:search-fn resource-type)
-                                                               (:search-value-fn resource-type))]
-                                         (when (and search-value-fn
-                                                    (resource/exists? resource)
-                                                    (resource/textual? resource))
-                                           (let [search-value (search-value-fn node-id resource evaluation-context)]
-                                             (when-not (g/error? search-value)
-                                               {:resource resource
-                                                :search-value search-value}))))))))
-                       (sort-by search-data-sort-key))]
-              (ui/run-later
-                (project/update-system-cache-save-data! evaluation-context)
-                (project/log-cache-info! (g/cache) "Cached searched save values in system cache."))
-              search-data)
-            (catch Throwable error
-              ;; Keep the save values we managed to build, so the next filter
-              ;; does not have to recompute them from scratch.
-              (ui/run-later
-                (project/update-system-cache-save-data! evaluation-context))
-              (when-not @cancelled
-                (report-error! error))
-              nil)
-            (finally
-              (Thread/interrupted))))]
-    {:data-future data-future
-     :cancel! (fn cancel! []
-                (vreset! cancelled true)
-                (future-cancel data-future))}))
+  (let [evaluation-context (g/make-evaluation-context)]
+    (future
+      (try
+        (let [search-data
+              (->> (g/node-value project :node-id+resources evaluation-context)
+                   (into []
+                         (keep (fn [[node-id resource]]
+                                 (thread-util/throw-if-interrupted!)
+                                 (when (and (resource/loaded? resource)
+                                            (not (resource/internal? resource))
+                                            (= :file (resource/source-type resource))
+                                            (search-resource? resource))
+                                   (let [resource-type (resource/resource-type resource)
+                                         search-value-fn (when (:search-fn resource-type)
+                                                           (:search-value-fn resource-type))]
+                                     (when (and search-value-fn
+                                                (resource/exists? resource)
+                                                (resource/textual? resource))
+                                       (let [search-value (search-value-fn node-id resource evaluation-context)]
+                                         (when-not (g/error? search-value)
+                                           {:resource resource
+                                            :search-value search-value}))))))))
+                   (sort-by search-data-sort-key))]
+          (ui/run-later
+            (project/update-system-cache-save-data! evaluation-context)
+            (project/log-cache-info! (g/cache) "Cached searched save values in system cache."))
+          search-data)
+        (catch InterruptedException _
+          ;; future-cancel was invoked from another thread.
+          (ui/run-later
+            (project/update-system-cache-save-data! evaluation-context))
+          nil)
+        (catch Throwable error
+          (ui/run-later
+            (project/update-system-cache-save-data! evaluation-context))
+          (report-error! error)
+          nil)))))
 
 (defn- resource-matches-library-setting? [resource include-libraries?]
   (or include-libraries?
@@ -143,6 +130,7 @@
         (run! produce-fn (sequence xform (deref search-data-future)))
         (produce-fn ::done))
       (catch InterruptedException _
+        ;; future-cancel was invoked from another thread.
         nil)
       (catch CancellationException _
         nil)
@@ -208,12 +196,12 @@
                               nil)))]
     {:start-search! (fn [search-string searched-exts include-libraries?]
                       (try
-                        (let [{:keys [data-future] :as search-data} (prepare-search-data! searched-exts include-libraries?)
-                              [previous-search-data] (swap-vals! active-search-data-atom (constantly search-data))]
-                          (when (and previous-search-data
-                                     (not (identical? previous-search-data search-data)))
-                            ((:cancel! previous-search-data)))
-                          (swap! pending-search-atom start-search! data-future search-string))
+                        (let [search-data-future (prepare-search-data! searched-exts include-libraries?)
+                              [previous-search-data-future] (swap-vals! active-search-data-atom (constantly search-data-future))]
+                          (when (and previous-search-data-future
+                                     (not (identical? previous-search-data-future search-data-future)))
+                            (future-cancel previous-search-data-future))
+                          (swap! pending-search-atom start-search! search-data-future search-string))
                         (catch Throwable error
                           (report-error! error)))
                       nil)
@@ -221,9 +209,8 @@
                       (try
                         (swap! pending-search-atom abort-search!)
                         (fn/clear-memoized! prepare-search-data!)
-                        (let [[search-data] (swap-vals! active-search-data-atom (constantly nil))]
-                          (when-let [cancel! (:cancel! search-data)]
-                            (cancel!)))
+                        (let [[search-data-future] (swap-vals! active-search-data-atom (constantly nil))]
+                          (some-> search-data-future future-cancel))
                         (catch Throwable error
                           (report-error! error)))
                       nil)}))

--- a/editor/src/clj/editor/defold_project_search.clj
+++ b/editor/src/clj/editor/defold_project_search.clj
@@ -115,15 +115,15 @@
                      (string/replace #" " "")
                      (string/split #","))]
     (coll/into-> searched-exts []
-                 (remove empty?)
-                 (map #(string/replace % #"\*?\." ""))
-                 (distinct))))
+      (remove empty?)
+      (map #(string/replace % #"\*?\." ""))
+      (distinct))))
 
 (defn- make-search-resource? [searched-ext-strings search-libraries]
   {:pre [(boolean? search-libraries)]}
   (let [file-ext-patterns
         (coll/into-> searched-ext-strings []
-                     (map #(text-util/search-string->re-pattern % :case-insensitive)))]
+          (map #(text-util/search-string->re-pattern % :case-insensitive)))]
     (fn search-resource? [resource]
       (and (resource-matches-library-setting? resource search-libraries)
            (resource-matches-file-ext? resource file-ext-patterns)))))

--- a/editor/src/clj/editor/defold_project_search.clj
+++ b/editor/src/clj/editor/defold_project_search.clj
@@ -23,7 +23,7 @@
             [util.text-util :as text-util]
             [util.thread-util :as thread-util])
   (:import [java.util ArrayList]
-           [java.util.concurrent LinkedBlockingQueue]))
+           [java.util.concurrent CancellationException LinkedBlockingQueue]))
 
 (set! *warn-on-reflection* true)
 
@@ -125,8 +125,7 @@
         (coll/into-> searched-ext-strings []
                      (map #(text-util/search-string->re-pattern % :case-insensitive)))]
     (fn search-resource? [resource]
-      (and (resource/loaded? resource)
-           (resource-matches-library-setting? resource search-libraries)
+      (and (resource-matches-library-setting? resource search-libraries)
            (resource-matches-file-ext? resource file-ext-patterns)))))
 
 (defn- start-search-thread [report-error! search-data-future resource-type->matches-fn produce-fn]
@@ -146,7 +145,7 @@
         (produce-fn ::done))
       (catch InterruptedException _
         nil)
-      (catch java.util.concurrent.CancellationException _
+      (catch CancellationException _
         nil)
       (catch Throwable error
         (report-error! error)
@@ -174,13 +173,14 @@
   and if there was a previous consumer, stop-consumer! will be called with it.
   Since many operations happen on a background thread, report-error! will be
   called with the Throwable in the event of an error."
-  [workspace project initial-searched-exts initial-search-libraries start-consumer! stop-consumer! report-error!]
+  [workspace project start-consumer! stop-consumer! report-error!]
   (let [pending-search-atom (atom nil)
 
         ;; Cached prep future, keyed by the ext/library filter. When the filter
         ;; changes, the now-obsolete future is cancelled so its whole-project
-        ;; work does not keep running in the background. The future is created
-        ;; outside any swap so a retry cannot leave an orphan running.
+        ;; work does not keep running in the background. Reading the atom and
+        ;; resetting it is not atomic, but every caller arrives on the UI
+        ;; thread, so there is no interleaving to guard against.
         search-data-atom (atom nil)
         prepare-search-data!
         (fn [searched-exts search-libraries]
@@ -204,7 +204,7 @@
                         nil)
         start-search! (fn [pending-search search-data-future search-string]
                         (abort-search! pending-search)
-                        (if search-data-future
+                        (if (coll/not-empty search-string)
                           (let [queue (LinkedBlockingQueue. 1024)
                                 produce-fn #(do
                                               (.put queue %))
@@ -218,13 +218,10 @@
                              :consumer consumer})
                           (do (start-consumer! (constantly [::done]))
                               nil)))]
-    (prepare-search-data! initial-searched-exts initial-search-libraries)
     {:start-search! (fn [search-string searched-exts include-libraries?]
                       (try
                         (let [search-data-future (prepare-search-data! searched-exts include-libraries?)]
-                          (swap! pending-search-atom start-search!
-                                 (when (coll/not-empty search-string) search-data-future)
-                                 search-string))
+                          (swap! pending-search-atom start-search! search-data-future search-string))
                         (catch Throwable error
                           (report-error! error)))
                       nil)

--- a/editor/src/clj/editor/defold_project_search.clj
+++ b/editor/src/clj/editor/defold_project_search.clj
@@ -30,7 +30,10 @@
 (defn- search-data-sort-key [entry]
   (some-> entry :resource resource/proj-path))
 
-(defn make-search-data-future [report-error! project]
+(defn make-search-data-future
+  "Returns a future yielding search data for every project resource that passes
+  search-resource?, each with its :search-value built and ready to match against."
+  [report-error! project search-resource?]
   (let [evaluation-context (g/make-evaluation-context)]
     (future
       (try
@@ -38,9 +41,11 @@
               (->> (g/node-value project :node-id+resources evaluation-context)
                    (into []
                          (keep (fn [[node-id resource]]
+                                 (thread-util/throw-if-interrupted!)
                                  (when (and (resource/loaded? resource)
                                             (not (resource/internal? resource))
-                                            (= :file (resource/source-type resource)))
+                                            (= :file (resource/source-type resource))
+                                            (search-resource? resource))
                                    (let [resource-type (resource/resource-type resource)
                                          search-value-fn (when (:search-fn resource-type)
                                                            (:search-value-fn resource-type))]
@@ -56,6 +61,9 @@
             (project/update-system-cache-save-data! evaluation-context)
             (project/log-cache-info! (g/cache) "Cached searched save values in system cache."))
           search-data)
+        (catch InterruptedException _
+          ;; future-cancel was invoked because the filter changed; discard.
+          nil)
         (catch Throwable error
           (report-error! error)
           nil)))))
@@ -100,25 +108,24 @@
            (resource-matches-library-setting? resource search-libraries)
            (resource-matches-file-ext? resource file-ext-patterns)))))
 
-(defn- start-search-thread [report-error! search-data-future resource-type->matches-fn search-resource? produce-fn]
-  {:pre [(ifn? search-resource?)]}
+(defn- start-search-thread [report-error! search-data-future resource-type->matches-fn produce-fn]
   (future
     (try
-      (let [xform (keep (fn [search-data]
+      (let [xform (keep (fn [entry]
                           (thread-util/throw-if-interrupted!)
-                          (let [resource (:resource search-data)]
-                            (when (search-resource? resource)
-                              (let [resource-type (resource/resource-type resource)
-                                    matches-fn (resource-type->matches-fn resource-type)
-                                    matches (when matches-fn
-                                              (matches-fn (:search-value search-data)))]
-                                (when-not (coll/empty? matches)
-                                  {:resource resource
-                                   :matches matches}))))))]
+                          (let [resource (:resource entry)
+                                resource-type (resource/resource-type resource)
+                                matches-fn (resource-type->matches-fn resource-type)
+                                matches (when matches-fn
+                                          (matches-fn (:search-value entry)))]
+                            (when-not (coll/empty? matches)
+                              {:resource resource
+                               :matches matches}))))]
         (run! produce-fn (sequence xform (deref search-data-future)))
         (produce-fn ::done))
       (catch InterruptedException _
-        ;; future-cancel was invoked from another thread.
+        nil)
+      (catch java.util.concurrent.CancellationException _
         nil)
       (catch Throwable error
         (report-error! error)
@@ -126,10 +133,9 @@
 
 (defn make-file-searcher
   "Returns a map of two functions, start-search! and abort-search! that can be
-  used to perform asynchronous search queries against an ordered sequence of
-  search data. The search data is expected to be sorted in the order
-  it should appear in the search results list, and entries are expected to have
-  :resource (Resource) and :search-value (anything) fields.
+  used to perform asynchronous search queries. Search content is prepared per
+  ext/library filter and rebuilt only when that filter changes; search-pattern
+  keystrokes match against the pre-built content.
   When start-search! is called, it will cancel any pending search and start a
   new search using the provided search-string and searched-exts arguments. It
   will call stop-consumer! with the value returned from the last call to
@@ -147,15 +153,34 @@
   and if there was a previous consumer, stop-consumer! will be called with it.
   Since many operations happen on a background thread, report-error! will be
   called with the Throwable in the event of an error."
-  [workspace search-data-future start-consumer! stop-consumer! report-error!]
+  [workspace project initial-searched-exts initial-search-libraries start-consumer! stop-consumer! report-error!]
   (let [pending-search-atom (atom nil)
+
+        ;; Cached prep future, keyed by the ext/library filter. When the filter
+        ;; changes, the now-obsolete future is cancelled so its whole-project
+        ;; work does not keep running in the background. The future is created
+        ;; outside any swap so a retry cannot leave an orphan running.
+        search-data-atom (atom nil)
+        prepare-search-data!
+        (fn [searched-exts search-libraries]
+          (let [filter-key [searched-exts search-libraries]
+                current @search-data-atom]
+            (if (= (:key current) filter-key)
+              (:future current)
+              (let [new-future (make-search-data-future
+                                 report-error! project
+                                 (make-search-resource? searched-exts search-libraries))]
+                (reset! search-data-atom {:key filter-key :future new-future})
+                (some-> current :future future-cancel)
+                new-future))))
+
         abort-search! (fn [pending-search]
                         (some-> pending-search :thread future-cancel)
                         (some-> pending-search :consumer stop-consumer!)
                         nil)
-        start-search! (fn [pending-search search-string searched-exts search-libraries]
+        start-search! (fn [pending-search search-data-future search-string]
                         (abort-search! pending-search)
-                        (if (seq search-string)
+                        (if search-data-future
                           (let [queue (LinkedBlockingQueue. 1024)
                                 produce-fn #(do
                                               (.put queue %))
@@ -163,22 +188,25 @@
                                               (.drainTo queue results)
                                               (seq results))
                                 resource-type->matches-fn (make-resource-type->matches-fn workspace search-string)
-                                search-resource? (make-search-resource? searched-exts search-libraries)
-                                thread (start-search-thread report-error! search-data-future resource-type->matches-fn search-resource? produce-fn)
+                                thread (start-search-thread report-error! search-data-future resource-type->matches-fn produce-fn)
                                 consumer (start-consumer! consume-fn)]
                             {:thread thread
                              :consumer consumer})
                           (do (start-consumer! (constantly [::done]))
                               nil)))]
+    (prepare-search-data! initial-searched-exts initial-search-libraries)
     {:start-search! (fn [search-string searched-exts include-libraries?]
                       (try
-                        (swap! pending-search-atom start-search! search-string searched-exts include-libraries?)
+                        (let [search-data-future (when (seq search-string)
+                                                   (prepare-search-data! searched-exts include-libraries?))]
+                          (swap! pending-search-atom start-search! search-data-future search-string))
                         (catch Throwable error
                           (report-error! error)))
                       nil)
      :abort-search! (fn []
                       (try
                         (swap! pending-search-atom abort-search!)
+                        (some-> @search-data-atom :future future-cancel)
                         (catch Throwable error
                           (report-error! error)))
                       nil)}))

--- a/editor/src/clj/editor/defold_project_search.clj
+++ b/editor/src/clj/editor/defold_project_search.clj
@@ -71,6 +71,10 @@
                 (project/log-cache-info! (g/cache) "Cached searched save values in system cache."))
               search-data)
             (catch Throwable error
+              ;; Keep the save values we managed to build, so the next filter
+              ;; does not have to recompute them from scratch.
+              (ui/run-later
+                (project/update-system-cache-save-data! evaluation-context))
               (when-not @cancelled
                 (report-error! error))
               nil)
@@ -106,16 +110,20 @@
     (fn resource-type->matches-fn [resource-type]
       (some-> resource-type :search-fn search-fn->matches-fn))))
 
-(defn- make-search-resource? [searched-exts search-libraries]
+(defn- parse-searched-exts [searched-exts]
+  (let [searched-exts (some-> searched-exts
+                     (string/replace #" " "")
+                     (string/split #","))]
+    (coll/into-> searched-exts []
+                 (remove empty?)
+                 (map #(string/replace % #"\*?\." ""))
+                 (distinct))))
+
+(defn- make-search-resource? [searched-ext-strings search-libraries]
   {:pre [(boolean? search-libraries)]}
   (let [file-ext-patterns
-        (into []
-              (comp (remove empty?)
-                    (distinct)
-                    (map #(text-util/search-string->re-pattern (string/replace % #"\*?\." "") :case-insensitive)))
-              (some-> searched-exts
-                      (string/replace #" " "")
-                      (string/split #",")))]
+        (coll/into-> searched-ext-strings []
+                     (map #(text-util/search-string->re-pattern % :case-insensitive)))]
     (fn search-resource? [resource]
       (and (resource/loaded? resource)
            (resource-matches-library-setting? resource search-libraries)
@@ -176,14 +184,15 @@
         search-data-atom (atom nil)
         prepare-search-data!
         (fn [searched-exts search-libraries]
-          (let [filter-key [searched-exts search-libraries]
+          (let [searched-ext-strings (parse-searched-exts searched-exts)
+                filter-key [searched-ext-strings search-libraries]
                 current @search-data-atom]
             (if (= (:key current) filter-key)
               (:data-future current)
               (let [{:keys [data-future cancel!]}
                     (make-search-data-future
                       report-error! project
-                      (make-search-resource? searched-exts search-libraries))]
+                      (make-search-resource? searched-ext-strings search-libraries))]
                 (reset! search-data-atom {:key filter-key :data-future data-future :cancel! cancel!})
                 (when current
                   ((:cancel! current)))

--- a/editor/src/clj/editor/defold_project_search.clj
+++ b/editor/src/clj/editor/defold_project_search.clj
@@ -20,6 +20,7 @@
             [editor.ui :as ui]
             [editor.workspace :as workspace]
             [util.coll :as coll :refer [pair]]
+            [util.fn :as fn]
             [util.text-util :as text-util]
             [util.thread-util :as thread-util])
   (:import [java.util ArrayList]
@@ -112,21 +113,19 @@
 
 (defn- parse-searched-exts [searched-exts]
   (let [searched-exts (some-> searched-exts
-                     (string/replace #" " "")
-                     (string/split #","))]
+                              (string/replace #" " "")
+                              (string/split #","))]
     (coll/into-> searched-exts []
       (remove empty?)
       (map #(string/replace % #"\*?\." ""))
-      (distinct))))
+      (distinct)
+      (map #(text-util/search-string->re-pattern % :case-insensitive)))))
 
-(defn- make-search-resource? [searched-ext-strings search-libraries]
+(defn- make-search-resource? [file-ext-patterns search-libraries]
   {:pre [(boolean? search-libraries)]}
-  (let [file-ext-patterns
-        (coll/into-> searched-ext-strings []
-          (map #(text-util/search-string->re-pattern % :case-insensitive)))]
-    (fn search-resource? [resource]
-      (and (resource-matches-library-setting? resource search-libraries)
-           (resource-matches-file-ext? resource file-ext-patterns)))))
+  (fn search-resource? [resource]
+    (and (resource-matches-library-setting? resource search-libraries)
+         (resource-matches-file-ext? resource file-ext-patterns))))
 
 (defn- start-search-thread [report-error! search-data-future resource-type->matches-fn produce-fn]
   (future
@@ -176,27 +175,16 @@
   [workspace project start-consumer! stop-consumer! report-error!]
   (let [pending-search-atom (atom nil)
 
-        ;; Cached prep future, keyed by the ext/library filter. When the filter
-        ;; changes, the now-obsolete future is cancelled so its whole-project
-        ;; work does not keep running in the background. Reading the atom and
-        ;; resetting it is not atomic, but every caller arrives on the UI
-        ;; thread, so there is no interleaving to guard against.
-        search-data-atom (atom nil)
+        active-search-data-atom (atom nil)
         prepare-search-data!
-        (fn [searched-exts search-libraries]
-          (let [searched-ext-strings (parse-searched-exts searched-exts)
-                filter-key [searched-ext-strings search-libraries]
-                current @search-data-atom]
-            (if (= (:key current) filter-key)
-              (:data-future current)
-              (let [{:keys [data-future cancel!]}
-                    (make-search-data-future
-                      report-error! project
-                      (make-search-resource? searched-ext-strings search-libraries))]
-                (reset! search-data-atom {:key filter-key :data-future data-future :cancel! cancel!})
-                (when current
-                  ((:cancel! current)))
-                data-future))))
+        (fn/memoize
+          {:limit 1}
+          (fn [searched-exts search-libraries]
+            (make-search-data-future
+              report-error! project
+              (make-search-resource?
+                (parse-searched-exts searched-exts)
+                search-libraries))))
 
         abort-search! (fn [pending-search]
                         (some-> pending-search :thread future-cancel)
@@ -220,17 +208,22 @@
                               nil)))]
     {:start-search! (fn [search-string searched-exts include-libraries?]
                       (try
-                        (let [search-data-future (prepare-search-data! searched-exts include-libraries?)]
-                          (swap! pending-search-atom start-search! search-data-future search-string))
+                        (let [{:keys [data-future] :as search-data} (prepare-search-data! searched-exts include-libraries?)
+                              [previous-search-data] (swap-vals! active-search-data-atom (constantly search-data))]
+                          (when (and previous-search-data
+                                     (not (identical? previous-search-data search-data)))
+                            ((:cancel! previous-search-data)))
+                          (swap! pending-search-atom start-search! data-future search-string))
                         (catch Throwable error
                           (report-error! error)))
                       nil)
      :abort-search! (fn []
                       (try
                         (swap! pending-search-atom abort-search!)
-                        (when-let [current @search-data-atom]
-                          (reset! search-data-atom nil)
-                          ((:cancel! current)))
+                        (fn/clear-memoized! prepare-search-data!)
+                        (let [[search-data] (swap-vals! active-search-data-atom (constantly nil))]
+                          (when-let [cancel! (:cancel! search-data)]
+                            (cancel!)))
                         (catch Throwable error
                           (report-error! error)))
                       nil)}))

--- a/editor/src/clj/editor/defold_project_search.clj
+++ b/editor/src/clj/editor/defold_project_search.clj
@@ -163,7 +163,7 @@
   [workspace project start-consumer! stop-consumer! report-error!]
   (let [pending-search-atom (atom nil)
 
-        active-search-data-atom (atom nil)
+        active-search-data-future-atom (atom nil)
         prepare-search-data!
         (fn/memoize
           {:limit 1}
@@ -197,7 +197,7 @@
     {:start-search! (fn [search-string searched-exts include-libraries?]
                       (try
                         (let [search-data-future (prepare-search-data! searched-exts include-libraries?)
-                              [previous-search-data-future] (swap-vals! active-search-data-atom (constantly search-data-future))]
+                              [previous-search-data-future] (swap-vals! active-search-data-future-atom (constantly search-data-future))]
                           (when (and previous-search-data-future
                                      (not (identical? previous-search-data-future search-data-future)))
                             (future-cancel previous-search-data-future))
@@ -209,7 +209,7 @@
                       (try
                         (swap! pending-search-atom abort-search!)
                         (fn/clear-memoized! prepare-search-data!)
-                        (let [[search-data-future] (swap-vals! active-search-data-atom (constantly nil))]
+                        (let [[search-data-future] (swap-vals! active-search-data-future-atom (constantly nil))]
                           (some-> search-data-future future-cancel))
                         (catch Throwable error
                           (report-error! error)))

--- a/editor/src/clj/editor/search_results_view.clj
+++ b/editor/src/clj/editor/search_results_view.clj
@@ -292,8 +292,10 @@
             stop-consumer! ui/timer-stop!
             report-error! (fn [error] (ui/run-later (throw error)))
             workspace (project/workspace project)
-            search-data-future (project-search/make-search-data-future report-error! project)
-            {:keys [abort-search! start-search!]} (project-search/make-file-searcher workspace search-data-future start-consumer! stop-consumer! report-error!)
+            {:keys [abort-search! start-search!]} (project-search/make-file-searcher workspace project
+                                                                                    (prefs/get prefs search-in-files-exts-prefs-key)
+                                                                                    (prefs/get prefs search-in-files-include-libraries-prefs-key)
+                                                                                    start-consumer! stop-consumer! report-error!)
             on-input-changed! (fn [_ _ _]
                                 (let [term (.getText search)
                                       exts (.getText types)

--- a/editor/src/clj/editor/search_results_view.clj
+++ b/editor/src/clj/editor/search_results_view.clj
@@ -292,10 +292,7 @@
             stop-consumer! ui/timer-stop!
             report-error! (fn [error] (ui/run-later (throw error)))
             workspace (project/workspace project)
-            {:keys [abort-search! start-search!]} (project-search/make-file-searcher workspace project
-                                                                                    (prefs/get prefs search-in-files-exts-prefs-key)
-                                                                                    (prefs/get prefs search-in-files-include-libraries-prefs-key)
-                                                                                    start-consumer! stop-consumer! report-error!)
+            {:keys [abort-search! start-search!]} (project-search/make-file-searcher workspace project start-consumer! stop-consumer! report-error!)
             on-input-changed! (fn [_ _ _]
                                 (let [term (.getText search)
                                       exts (.getText types)
@@ -314,12 +311,21 @@
                              (doseq [[resource opts] (resolve-search-in-files-tree-view-selection (ui/selection resources-tree))]
                                (open-fn resource opts))
                              (dismiss-and-abort-search!))]
+        (init-search-in-files-tree-view! resources-tree)
+
+        (let [term (prefs/get prefs search-in-files-term-prefs-key)
+              exts (prefs/get prefs search-in-files-exts-prefs-key)
+              include-libraries? (prefs/get prefs search-in-files-include-libraries-prefs-key)]
+          (start-search! term exts include-libraries?)
+          (ui/text! search term)
+          (ui/text! types exts)
+          (ui/value! include-libraries-check-box include-libraries?))
+
         (localization/localize! (.titleProperty stage) localization (localization/message "dialog.search-in-files.title"))
         (localization/localize! search-label localization (localization/message "dialog.search-in-files.label.search"))
         (localization/localize! types-label localization (localization/message "dialog.search-in-files.label.types"))
         (localization/localize! include-libraries-check-box localization (localization/message "dialog.search-in-files.label.include-libraries"))
         (localization/localize! ok localization (localization/message "dialog.search-in-files.button.keep-results"))
-        (init-search-in-files-tree-view! resources-tree)
 
         (ui/on-action! ok (fn on-ok! [_] (dismiss-and-show-find-results!)))
         (ui/on-double! resources-tree (fn on-double! [^Event event]
@@ -345,14 +351,6 @@
                                                 (.consume event)
                                                 (ui/request-focus! search))
                                nil))))
-
-        (let [term (prefs/get prefs search-in-files-term-prefs-key)
-              exts (prefs/get prefs search-in-files-exts-prefs-key)
-              include-libraries? (prefs/get prefs search-in-files-include-libraries-prefs-key)]
-          (ui/text! search term)
-          (ui/text! types exts)
-          (ui/value! include-libraries-check-box include-libraries?)
-          (start-search! term exts include-libraries?))
 
         (ui/observe (.textProperty search) on-input-changed!)
         (ui/observe (.textProperty types) on-input-changed!)

--- a/editor/test/editor/defold_project_search_test.clj
+++ b/editor/test/editor/defold_project_search_test.clj
@@ -136,7 +136,7 @@
 
 (defn- try-make-search-data-future [project]
   (let [report-error! (fn/make-call-logger)
-        search-data-future (:data-future (project-search/make-search-data-future report-error! project (constantly true)))]
+        search-data-future (:data-future (project-search/make-search-data-future report-error! project fn/constantly-true))]
     (deref search-data-future)
     (when (is (= [] (fn/call-logger-calls report-error!)))
       search-data-future)))
@@ -144,9 +144,8 @@
 (deftest file-searcher-test
   (test-util/with-loaded-project search-project-path
     (test-util/with-ui-run-later-rebound
-      (when-some [search-data-future (try-make-search-data-future project)]
-
-        (testing "All editable files are searched."
+      (testing "All editable files are searched."
+        (when-some [search-data-future (try-make-search-data-future project)]
           ;; Note: This is more of a sanity-check than anything else.
           ;; As we make the search system more flexible, these assumptions might
           ;; not hold.
@@ -161,147 +160,147 @@
                        (g/node-value project :node-id+resources))
                  (into (sorted-set)
                        (map (comp resource/proj-path :resource))
-                       (deref search-data-future)))))
+                       (deref search-data-future))))))
 
-        (testing "Matches expected results"
-          (let [report-error! (fn/make-call-logger)
-                consumer (make-consumer report-error!)
-                start-consumer! (partial consumer-start! consumer)
-                stop-consumer! consumer-stop!
-                {:keys [start-search! abort-search!]} (project-search/make-file-searcher workspace project start-consumer! stop-consumer! report-error!)
-                perform-search! (fn [term exts]
-                                  (start-search! term exts true)
-                                  (is (true? (test-util/block-until true? timeout-ms consumer-finished? consumer)))
-                                  (-> consumer consumer-consumed matched-text-by-proj-path))]
-            (is (= [] (perform-search! nil nil)))
-            (is (= [] (perform-search! "" nil)))
-            (is (= [] (perform-search! nil "")))
-            (is (set/subset? #{["/modules/colors.lua" ["red = {255, 0, 0},"
-                                                       "green = {0, 255, 0},"
-                                                       "blue = {0, 0, 255}"]]}
-                             (set (perform-search! "255" nil))))
-            (is (set/subset? #{["/scripts/actors.script" ["\"Will Smith\""]]
-                               ["/scripts/apples.script" ["\"Granny Smith\""]]}
-                             (set (perform-search! "smith" "script"))))
-            (is (set/subset? #{["/modules/colors.lua" ["return {"]]
-                               ["/scripts/actors.script" ["return {"]]
-                               ["/scripts/apples.script" ["return {"]]}
-                             (set (perform-search! "return" "lua, script"))))
-            (is (some #(.startsWith % "/builtins")
-                      (map first (perform-search! "return" "lua, script"))))
-            (is (= [["/foo.bar" ["Buckle my shoe;"]]] (perform-search! "buckle" nil)))
-            (abort-search!)
-            (is (true? (test-util/block-until true? timeout-ms consumer-stopped? consumer)))
-            (is (= [] (fn/call-logger-calls report-error!)))))
+      (testing "Matches expected results"
+        (let [report-error! (fn/make-call-logger)
+              consumer (make-consumer report-error!)
+              start-consumer! (partial consumer-start! consumer)
+              stop-consumer! consumer-stop!
+              {:keys [start-search! abort-search!]} (project-search/make-file-searcher workspace project start-consumer! stop-consumer! report-error!)
+              perform-search! (fn [term exts]
+                                (start-search! term exts true)
+                                (is (true? (test-util/block-until true? timeout-ms consumer-finished? consumer)))
+                                (-> consumer consumer-consumed matched-text-by-proj-path))]
+          (is (= [] (perform-search! nil nil)))
+          (is (= [] (perform-search! "" nil)))
+          (is (= [] (perform-search! nil "")))
+          (is (set/subset? #{["/modules/colors.lua" ["red = {255, 0, 0},"
+                                                     "green = {0, 255, 0},"
+                                                     "blue = {0, 0, 255}"]]}
+                           (set (perform-search! "255" nil))))
+          (is (set/subset? #{["/scripts/actors.script" ["\"Will Smith\""]]
+                             ["/scripts/apples.script" ["\"Granny Smith\""]]}
+                           (set (perform-search! "smith" "script"))))
+          (is (set/subset? #{["/modules/colors.lua" ["return {"]]
+                             ["/scripts/actors.script" ["return {"]]
+                             ["/scripts/apples.script" ["return {"]]}
+                           (set (perform-search! "return" "lua, script"))))
+          (is (some #(.startsWith % "/builtins")
+                    (map first (perform-search! "return" "lua, script"))))
+          (is (= [["/foo.bar" ["Buckle my shoe;"]]] (perform-search! "buckle" nil)))
+          (abort-search!)
+          (is (true? (test-util/block-until true? timeout-ms consumer-stopped? consumer)))
+          (is (= [] (fn/call-logger-calls report-error!)))))
 
-        (testing "Search can be aborted"
-          (let [report-error! (fn/make-call-logger)
-                consumer (make-consumer report-error!)
-                start-consumer! (partial consumer-start! consumer)
-                stop-consumer! consumer-stop!
-                {:keys [start-search! abort-search!]} (project-search/make-file-searcher workspace project start-consumer! stop-consumer! report-error!)]
-            (start-search! "*" nil true)
-            (is (true? (consumer-started? consumer)))
-            (abort-search!)
-            (is (true? (test-util/block-until true? timeout-ms consumer-stopped? consumer)))
-            (is (= [] (fn/call-logger-calls report-error!)))))
+      (testing "Search can be aborted"
+        (let [report-error! (fn/make-call-logger)
+              consumer (make-consumer report-error!)
+              start-consumer! (partial consumer-start! consumer)
+              stop-consumer! consumer-stop!
+              {:keys [start-search! abort-search!]} (project-search/make-file-searcher workspace project start-consumer! stop-consumer! report-error!)]
+          (start-search! "*" nil true)
+          (is (true? (consumer-started? consumer)))
+          (abort-search!)
+          (is (true? (test-util/block-until true? timeout-ms consumer-stopped? consumer)))
+          (is (= [] (fn/call-logger-calls report-error!)))))
 
-        (testing "Matches among specified file extensions"
-          (let [report-error! (fn/make-call-logger)
-                consumer (make-consumer report-error!)
-                start-consumer! (partial consumer-start! consumer)
-                stop-consumer! consumer-stop!
-                {:keys [start-search! abort-search!]} (project-search/make-file-searcher workspace project start-consumer! stop-consumer! report-error!)
-                search-string "peaNUTbutterjellytime"
-                perform-search! (fn [term exts]
-                                  (start-search! term exts true)
-                                  (is (true? (test-util/block-until true? timeout-ms consumer-finished? consumer)))
-                                  (-> consumer consumer-consumed matched-text-by-proj-path))]
-            (are [expected-count exts]
-              (= expected-count (count (perform-search! search-string exts)))
-              1 "g"
-              1 "go"
-              1 ".go"
-              1 "*.go"
-              2 "go,sCR"
-              2 nil
-              2 ""
-              0 "lua"
-              1 "lua,go"
-              1 " lua,  go"
-              1 " lua,  GO"
-              1 "script")
-            (abort-search!)
-            (is (true? (test-util/block-until true? timeout-ms consumer-stopped? consumer)))
-            (is (= [] (fn/call-logger-calls report-error!)))))
+      (testing "Matches among specified file extensions"
+        (let [report-error! (fn/make-call-logger)
+              consumer (make-consumer report-error!)
+              start-consumer! (partial consumer-start! consumer)
+              stop-consumer! consumer-stop!
+              {:keys [start-search! abort-search!]} (project-search/make-file-searcher workspace project start-consumer! stop-consumer! report-error!)
+              search-string "peaNUTbutterjellytime"
+              perform-search! (fn [term exts]
+                                (start-search! term exts true)
+                                (is (true? (test-util/block-until true? timeout-ms consumer-finished? consumer)))
+                                (-> consumer consumer-consumed matched-text-by-proj-path))]
+          (are [expected-count exts]
+            (= expected-count (count (perform-search! search-string exts)))
+            1 "g"
+            1 "go"
+            1 ".go"
+            1 "*.go"
+            2 "go,sCR"
+            2 nil
+            2 ""
+            0 "lua"
+            1 "lua,go"
+            1 " lua,  go"
+            1 " lua,  GO"
+            1 "script")
+          (abort-search!)
+          (is (true? (test-util/block-until true? timeout-ms consumer-stopped? consumer)))
+          (is (= [] (fn/call-logger-calls report-error!)))))
 
-        (testing "Include or exclude matches inside libraries"
-          (let [report-error! (fn/make-call-logger)
-                consumer (make-consumer report-error!)
-                start-consumer! (partial consumer-start! consumer)
-                stop-consumer! consumer-stop!
-                {:keys [start-search! abort-search!]} (project-search/make-file-searcher workspace project start-consumer! stop-consumer! report-error!)
-                perform-search! (fn [term exts include-libraries?]
-                                  (start-search! term exts include-libraries?)
-                                  (is (true? (test-util/block-until true? timeout-ms consumer-finished? consumer)))
-                                  (-> consumer consumer-consumed match-proj-paths))]
-            (is (= #{}
-                   (perform-search! "socket" "lua" false)))
-            (is (= #{"/builtins/scripts/mobdebug.lua" "/builtins/scripts/socket.lua"}
-                   (perform-search! "socket" "lua" true)))
-            (abort-search!)
-            (is (true? (test-util/block-until true? timeout-ms consumer-stopped? consumer)))
-            (is (= [] (fn/call-logger-calls report-error!)))))
+      (testing "Include or exclude matches inside libraries"
+        (let [report-error! (fn/make-call-logger)
+              consumer (make-consumer report-error!)
+              start-consumer! (partial consumer-start! consumer)
+              stop-consumer! consumer-stop!
+              {:keys [start-search! abort-search!]} (project-search/make-file-searcher workspace project start-consumer! stop-consumer! report-error!)
+              perform-search! (fn [term exts include-libraries?]
+                                (start-search! term exts include-libraries?)
+                                (is (true? (test-util/block-until true? timeout-ms consumer-finished? consumer)))
+                                (-> consumer consumer-consumed match-proj-paths))]
+          (is (= #{}
+                 (perform-search! "socket" "lua" false)))
+          (is (= #{"/builtins/scripts/mobdebug.lua" "/builtins/scripts/socket.lua"}
+                 (perform-search! "socket" "lua" true)))
+          (abort-search!)
+          (is (true? (test-util/block-until true? timeout-ms consumer-stopped? consumer)))
+          (is (= [] (fn/call-logger-calls report-error!)))))
 
-        (testing "Preparation only builds search data for filter-matching resources"
-          (let [report-error! (fn/make-call-logger)
-                all-data (deref (:data-future (project-search/make-search-data-future report-error! project (constantly true))))
-                script-data (deref (:data-future (project-search/make-search-data-future
-                                                   report-error! project
-                                                   (fn [resource] (= "script" (resource/type-ext resource))))))]
-            (is (pos? (count script-data)))
-            (is (< (count script-data) (count all-data)))
-            (is (= #{"script"}
-                   (into #{} (map (comp resource/type-ext :resource)) script-data)))
-            (is (= [] (fn/call-logger-calls report-error!)))))
+      (testing "Preparation only builds search data for filter-matching resources"
+        (let [report-error! (fn/make-call-logger)
+              all-data (deref (:data-future (project-search/make-search-data-future report-error! project (constantly true))))
+              script-data (deref (:data-future (project-search/make-search-data-future
+                                                 report-error! project
+                                                 (fn [resource] (= "script" (resource/type-ext resource))))))]
+          (is (pos? (count script-data)))
+          (is (< (count script-data) (count all-data)))
+          (is (= #{"script"}
+                 (into #{} (map (comp resource/type-ext :resource)) script-data)))
+          (is (= [] (fn/call-logger-calls report-error!)))))
 
-        (testing "Preparation is cached per filter and rebuilt only when the filter changes"
-          (let [report-error! (fn/make-call-logger)
-                consumer (make-consumer report-error!)
-                start-consumer! (partial consumer-start! consumer)
-                stop-consumer! consumer-stop!
-                builds (atom 0)
-                real-make-future project-search/make-search-data-future]
-            (with-redefs [project-search/make-search-data-future
-                          (fn [& args]
-                            (swap! builds inc)
-                            (apply real-make-future args))]
-              (let [{:keys [start-search! abort-search!]}
-                    (project-search/make-file-searcher workspace project start-consumer! stop-consumer! report-error!)]
-                (is (= 0 @builds))
-                (start-search! "return" "script" true)
-                (is (= 1 @builds))
-                (start-search! "smith" "script" true)
-                (is (= 1 @builds))
-                (start-search! "return" "lua" true)
-                (is (= 2 @builds))
-                (abort-search!)
-                (is (true? (test-util/block-until true? timeout-ms consumer-stopped? consumer)))
-                (is (= [] (fn/call-logger-calls report-error!)))))))
+      (testing "Preparation is cached per filter and rebuilt only when the filter changes"
+        (let [report-error! (fn/make-call-logger)
+              consumer (make-consumer report-error!)
+              start-consumer! (partial consumer-start! consumer)
+              stop-consumer! consumer-stop!
+              builds (atom 0)
+              real-make-future project-search/make-search-data-future]
+          (with-redefs [project-search/make-search-data-future
+                        (fn [& args]
+                          (swap! builds inc)
+                          (apply real-make-future args))]
+            (let [{:keys [start-search! abort-search!]}
+                  (project-search/make-file-searcher workspace project start-consumer! stop-consumer! report-error!)]
+              (is (= 0 @builds))
+              (start-search! "return" "script" true)
+              (is (= 1 @builds))
+              (start-search! "smith" "script" true)
+              (is (= 1 @builds))
+              (start-search! "return" "lua" true)
+              (is (= 2 @builds))
+              (abort-search!)
+              (is (true? (test-util/block-until true? timeout-ms consumer-stopped? consumer)))
+              (is (= [] (fn/call-logger-calls report-error!)))))))
 
-        (testing "A search runs correctly after a prior search with the same filter was aborted"
-          (let [report-error! (fn/make-call-logger)
-                consumer (make-consumer report-error!)
-                start-consumer! (partial consumer-start! consumer)
-                stop-consumer! consumer-stop!
-                {:keys [start-search! abort-search!]}
-                (project-search/make-file-searcher workspace project start-consumer! stop-consumer! report-error!)]
-            (start-search! "255" nil true)
-            (is (true? (test-util/block-until true? timeout-ms consumer-finished? consumer)))
-            (abort-search!)
-            (is (true? (test-util/block-until true? timeout-ms consumer-stopped? consumer)))
-            (start-search! "255" nil true)
-            (is (true? (test-util/block-until true? timeout-ms consumer-finished? consumer)))
-            (is (seq (consumer-consumed consumer)))
-            (abort-search!)
-            (is (= [] (fn/call-logger-calls report-error!)))))))))
+      (testing "A search runs correctly after a prior search with the same filter was aborted"
+        (let [report-error! (fn/make-call-logger)
+              consumer (make-consumer report-error!)
+              start-consumer! (partial consumer-start! consumer)
+              stop-consumer! consumer-stop!
+              {:keys [start-search! abort-search!]}
+              (project-search/make-file-searcher workspace project start-consumer! stop-consumer! report-error!)]
+          (start-search! "255" nil true)
+          (is (true? (test-util/block-until true? timeout-ms consumer-finished? consumer)))
+          (abort-search!)
+          (is (true? (test-util/block-until true? timeout-ms consumer-stopped? consumer)))
+          (start-search! "255" nil true)
+          (is (true? (test-util/block-until true? timeout-ms consumer-finished? consumer)))
+          (is (seq (consumer-consumed consumer)))
+          (abort-search!)
+          (is (= [] (fn/call-logger-calls report-error!))))))))

--- a/editor/test/editor/defold_project_search_test.clj
+++ b/editor/test/editor/defold_project_search_test.clj
@@ -251,4 +251,57 @@
                    (perform-search! "socket" "lua" true)))
             (abort-search!)
             (is (true? (test-util/block-until true? timeout-ms consumer-stopped? consumer)))
+            (is (= [] (fn/call-logger-calls report-error!)))))
+
+        (testing "Preparation only builds search data for filter-matching resources"
+          (let [report-error! (fn/make-call-logger)
+                all-data (deref (project-search/make-search-data-future report-error! project (constantly true)))
+                script-data (deref (project-search/make-search-data-future
+                                     report-error! project
+                                     (fn [resource] (= "script" (resource/type-ext resource)))))]
+            (is (pos? (count script-data)))
+            (is (< (count script-data) (count all-data)))
+            (is (= #{"script"}
+                   (into #{} (map (comp resource/type-ext :resource)) script-data)))
+            (is (= [] (fn/call-logger-calls report-error!)))))
+
+        (testing "Preparation is cached per filter and rebuilt only when the filter changes"
+          (let [report-error! (fn/make-call-logger)
+                consumer (make-consumer report-error!)
+                start-consumer! (partial consumer-start! consumer)
+                stop-consumer! consumer-stop!
+                builds (atom 0)
+                real-make-future project-search/make-search-data-future]
+            (with-redefs [project-search/make-search-data-future
+                          (fn [& args]
+                            (swap! builds inc)
+                            (apply real-make-future args))]
+              (let [{:keys [start-search! abort-search!]}
+                    (project-search/make-file-searcher workspace project nil true start-consumer! stop-consumer! report-error!)]
+                (is (= 1 @builds))
+                (start-search! "return" "script" true)
+                (is (= 2 @builds))
+                (start-search! "smith" "script" true)
+                (is (= 2 @builds))
+                (start-search! "return" "lua" true)
+                (is (= 3 @builds))
+                (abort-search!)
+                (is (true? (test-util/block-until true? timeout-ms consumer-stopped? consumer)))
+                (is (= [] (fn/call-logger-calls report-error!)))))))
+
+        (testing "A search runs correctly after a prior search with the same filter was aborted"
+          (let [report-error! (fn/make-call-logger)
+                consumer (make-consumer report-error!)
+                start-consumer! (partial consumer-start! consumer)
+                stop-consumer! consumer-stop!
+                {:keys [start-search! abort-search!]}
+                (project-search/make-file-searcher workspace project nil true start-consumer! stop-consumer! report-error!)]
+            (start-search! "255" nil true)
+            (is (true? (test-util/block-until true? timeout-ms consumer-finished? consumer)))
+            (abort-search!)
+            (is (true? (test-util/block-until true? timeout-ms consumer-stopped? consumer)))
+            (start-search! "255" nil true)
+            (is (true? (test-util/block-until true? timeout-ms consumer-finished? consumer)))
+            (is (seq (consumer-consumed consumer)))
+            (abort-search!)
             (is (= [] (fn/call-logger-calls report-error!)))))))))

--- a/editor/test/editor/defold_project_search_test.clj
+++ b/editor/test/editor/defold_project_search_test.clj
@@ -136,7 +136,7 @@
 
 (defn- try-make-search-data-future [project]
   (let [report-error! (fn/make-call-logger)
-        search-data-future (:data-future (project-search/make-search-data-future report-error! project fn/constantly-true))]
+        search-data-future (project-search/make-search-data-future report-error! project fn/constantly-true)]
     (deref search-data-future)
     (when (is (= [] (fn/call-logger-calls report-error!)))
       search-data-future)))
@@ -254,10 +254,10 @@
 
       (testing "Preparation only builds search data for filter-matching resources"
         (let [report-error! (fn/make-call-logger)
-              all-data (deref (:data-future (project-search/make-search-data-future report-error! project (constantly true))))
-              script-data (deref (:data-future (project-search/make-search-data-future
-                                                 report-error! project
-                                                 (fn [resource] (= "script" (resource/type-ext resource))))))]
+              all-data (deref (project-search/make-search-data-future report-error! project fn/constantly-true))
+              script-data (deref (project-search/make-search-data-future
+                                   report-error! project
+                                   (fn [resource] (= "script" (resource/type-ext resource)))))]
           (is (pos? (count script-data)))
           (is (< (count script-data) (count all-data)))
           (is (= #{"script"}

--- a/editor/test/editor/defold_project_search_test.clj
+++ b/editor/test/editor/defold_project_search_test.clj
@@ -136,7 +136,7 @@
 
 (defn- try-make-search-data-future [project]
   (let [report-error! (fn/make-call-logger)
-        search-data-future (project-search/make-search-data-future report-error! project)]
+        search-data-future (project-search/make-search-data-future report-error! project (constantly true))]
     (deref search-data-future)
     (when (is (= [] (fn/call-logger-calls report-error!)))
       search-data-future)))
@@ -168,7 +168,7 @@
                 consumer (make-consumer report-error!)
                 start-consumer! (partial consumer-start! consumer)
                 stop-consumer! consumer-stop!
-                {:keys [start-search! abort-search!]} (project-search/make-file-searcher workspace search-data-future start-consumer! stop-consumer! report-error!)
+                {:keys [start-search! abort-search!]} (project-search/make-file-searcher workspace project nil true start-consumer! stop-consumer! report-error!)
                 perform-search! (fn [term exts]
                                   (start-search! term exts true)
                                   (is (true? (test-util/block-until true? timeout-ms consumer-finished? consumer)))
@@ -199,7 +199,7 @@
                 consumer (make-consumer report-error!)
                 start-consumer! (partial consumer-start! consumer)
                 stop-consumer! consumer-stop!
-                {:keys [start-search! abort-search!]} (project-search/make-file-searcher workspace search-data-future start-consumer! stop-consumer! report-error!)]
+                {:keys [start-search! abort-search!]} (project-search/make-file-searcher workspace project nil true start-consumer! stop-consumer! report-error!)]
             (start-search! "*" nil true)
             (is (true? (consumer-started? consumer)))
             (abort-search!)
@@ -211,7 +211,7 @@
                 consumer (make-consumer report-error!)
                 start-consumer! (partial consumer-start! consumer)
                 stop-consumer! consumer-stop!
-                {:keys [start-search! abort-search!]} (project-search/make-file-searcher workspace search-data-future start-consumer! stop-consumer! report-error!)
+                {:keys [start-search! abort-search!]} (project-search/make-file-searcher workspace project nil true start-consumer! stop-consumer! report-error!)
                 search-string "peaNUTbutterjellytime"
                 perform-search! (fn [term exts]
                                   (start-search! term exts true)
@@ -240,7 +240,7 @@
                 consumer (make-consumer report-error!)
                 start-consumer! (partial consumer-start! consumer)
                 stop-consumer! consumer-stop!
-                {:keys [start-search! abort-search!]} (project-search/make-file-searcher workspace search-data-future start-consumer! stop-consumer! report-error!)
+                {:keys [start-search! abort-search!]} (project-search/make-file-searcher workspace project nil true start-consumer! stop-consumer! report-error!)
                 perform-search! (fn [term exts include-libraries?]
                                   (start-search! term exts include-libraries?)
                                   (is (true? (test-util/block-until true? timeout-ms consumer-finished? consumer)))

--- a/editor/test/editor/defold_project_search_test.clj
+++ b/editor/test/editor/defold_project_search_test.clj
@@ -136,7 +136,7 @@
 
 (defn- try-make-search-data-future [project]
   (let [report-error! (fn/make-call-logger)
-        search-data-future (project-search/make-search-data-future report-error! project (constantly true))]
+        search-data-future (:data-future (project-search/make-search-data-future report-error! project (constantly true)))]
     (deref search-data-future)
     (when (is (= [] (fn/call-logger-calls report-error!)))
       search-data-future)))
@@ -255,10 +255,10 @@
 
         (testing "Preparation only builds search data for filter-matching resources"
           (let [report-error! (fn/make-call-logger)
-                all-data (deref (project-search/make-search-data-future report-error! project (constantly true)))
-                script-data (deref (project-search/make-search-data-future
-                                     report-error! project
-                                     (fn [resource] (= "script" (resource/type-ext resource)))))]
+                all-data (deref (:data-future (project-search/make-search-data-future report-error! project (constantly true))))
+                script-data (deref (:data-future (project-search/make-search-data-future
+                                                   report-error! project
+                                                   (fn [resource] (= "script" (resource/type-ext resource))))))]
             (is (pos? (count script-data)))
             (is (< (count script-data) (count all-data)))
             (is (= #{"script"}

--- a/editor/test/editor/defold_project_search_test.clj
+++ b/editor/test/editor/defold_project_search_test.clj
@@ -288,19 +288,34 @@
               (is (true? (test-util/block-until true? timeout-ms consumer-stopped? consumer)))
               (is (= [] (fn/call-logger-calls report-error!)))))))
 
-      (testing "A search runs correctly after a prior search with the same filter was aborted"
+      (testing "Aborting an in-flight preparation evicts it from the cache"
         (let [report-error! (fn/make-call-logger)
               consumer (make-consumer report-error!)
               start-consumer! (partial consumer-start! consumer)
               stop-consumer! consumer-stop!
-              {:keys [start-search! abort-search!]}
-              (project-search/make-file-searcher workspace project start-consumer! stop-consumer! report-error!)]
-          (start-search! "255" nil true)
-          (is (true? (test-util/block-until true? timeout-ms consumer-finished? consumer)))
-          (abort-search!)
-          (is (true? (test-util/block-until true? timeout-ms consumer-stopped? consumer)))
-          (start-search! "255" nil true)
-          (is (true? (test-util/block-until true? timeout-ms consumer-finished? consumer)))
-          (is (seq (consumer-consumed consumer)))
-          (abort-search!)
-          (is (= [] (fn/call-logger-calls report-error!))))))))
+              preparation-started (promise)
+              builds (atom 0)
+              first-future-atom (atom nil)
+              real-make-future project-search/make-search-data-future]
+          (with-redefs [project-search/make-search-data-future
+                        (fn [& args]
+                          (if (= 1 (swap! builds inc))
+                            (let [blocking-promise (promise)
+                                  blocking-future (future
+                                                    (deliver preparation-started true)
+                                                    (deref blocking-promise))]
+                              (reset! first-future-atom blocking-future)
+                              blocking-future)
+                            (apply real-make-future args)))]
+            (let [{:keys [start-search! abort-search!]}
+                  (project-search/make-file-searcher workspace project start-consumer! stop-consumer! report-error!)]
+              (start-search! "255" nil true)
+              (is (true? (deref preparation-started timeout-ms false)))
+              (abort-search!)
+              (is (future-cancelled? @first-future-atom))
+              (start-search! "255" nil true)
+              (is (= 2 @builds))
+              (is (true? (test-util/block-until true? timeout-ms consumer-finished? consumer)))
+              (is (seq (consumer-consumed consumer)))
+              (abort-search!)
+              (is (= [] (fn/call-logger-calls report-error!))))))))))

--- a/editor/test/editor/defold_project_search_test.clj
+++ b/editor/test/editor/defold_project_search_test.clj
@@ -168,7 +168,7 @@
                 consumer (make-consumer report-error!)
                 start-consumer! (partial consumer-start! consumer)
                 stop-consumer! consumer-stop!
-                {:keys [start-search! abort-search!]} (project-search/make-file-searcher workspace project nil true start-consumer! stop-consumer! report-error!)
+                {:keys [start-search! abort-search!]} (project-search/make-file-searcher workspace project start-consumer! stop-consumer! report-error!)
                 perform-search! (fn [term exts]
                                   (start-search! term exts true)
                                   (is (true? (test-util/block-until true? timeout-ms consumer-finished? consumer)))
@@ -199,7 +199,7 @@
                 consumer (make-consumer report-error!)
                 start-consumer! (partial consumer-start! consumer)
                 stop-consumer! consumer-stop!
-                {:keys [start-search! abort-search!]} (project-search/make-file-searcher workspace project nil true start-consumer! stop-consumer! report-error!)]
+                {:keys [start-search! abort-search!]} (project-search/make-file-searcher workspace project start-consumer! stop-consumer! report-error!)]
             (start-search! "*" nil true)
             (is (true? (consumer-started? consumer)))
             (abort-search!)
@@ -211,7 +211,7 @@
                 consumer (make-consumer report-error!)
                 start-consumer! (partial consumer-start! consumer)
                 stop-consumer! consumer-stop!
-                {:keys [start-search! abort-search!]} (project-search/make-file-searcher workspace project nil true start-consumer! stop-consumer! report-error!)
+                {:keys [start-search! abort-search!]} (project-search/make-file-searcher workspace project start-consumer! stop-consumer! report-error!)
                 search-string "peaNUTbutterjellytime"
                 perform-search! (fn [term exts]
                                   (start-search! term exts true)
@@ -240,7 +240,7 @@
                 consumer (make-consumer report-error!)
                 start-consumer! (partial consumer-start! consumer)
                 stop-consumer! consumer-stop!
-                {:keys [start-search! abort-search!]} (project-search/make-file-searcher workspace project nil true start-consumer! stop-consumer! report-error!)
+                {:keys [start-search! abort-search!]} (project-search/make-file-searcher workspace project start-consumer! stop-consumer! report-error!)
                 perform-search! (fn [term exts include-libraries?]
                                   (start-search! term exts include-libraries?)
                                   (is (true? (test-util/block-until true? timeout-ms consumer-finished? consumer)))
@@ -277,14 +277,14 @@
                             (swap! builds inc)
                             (apply real-make-future args))]
               (let [{:keys [start-search! abort-search!]}
-                    (project-search/make-file-searcher workspace project nil true start-consumer! stop-consumer! report-error!)]
-                (is (= 1 @builds))
+                    (project-search/make-file-searcher workspace project start-consumer! stop-consumer! report-error!)]
+                (is (= 0 @builds))
                 (start-search! "return" "script" true)
-                (is (= 2 @builds))
+                (is (= 1 @builds))
                 (start-search! "smith" "script" true)
-                (is (= 2 @builds))
+                (is (= 1 @builds))
                 (start-search! "return" "lua" true)
-                (is (= 3 @builds))
+                (is (= 2 @builds))
                 (abort-search!)
                 (is (true? (test-util/block-until true? timeout-ms consumer-stopped? consumer)))
                 (is (= [] (fn/call-logger-calls report-error!)))))))
@@ -295,7 +295,7 @@
                 start-consumer! (partial consumer-start! consumer)
                 stop-consumer! consumer-stop!
                 {:keys [start-search! abort-search!]}
-                (project-search/make-file-searcher workspace project nil true start-consumer! stop-consumer! report-error!)]
+                (project-search/make-file-searcher workspace project start-consumer! stop-consumer! report-error!)]
             (start-search! "255" nil true)
             (is (true? (test-util/block-until true? timeout-ms consumer-finished? consumer)))
             (abort-search!)


### PR DESCRIPTION
When preparing search results, the editor would grab all textual resources without considering excluded file types from the search. Now the search dialog will only prepare the included file types for scanning, improving the speed at which results can start.

Fixes #11794

### Technical changes

Here's a repro project in case you want one that has a ton of files you can search through. One search term is "NEEDLE" .

[issue-11794-filter-search-speed.zip](https://github.com/user-attachments/files/30402558/issue-11794-filter-search-speed.zip)
