### PR TITLE
 Include GLES variants in built-in debug shaders

### DIFF
--- a/engine/engine/content/builtins/connect/game.project
+++ b/engine/engine/content/builtins/connect/game.project
@@ -20,3 +20,7 @@ clear_color_alpha = 0
 
 [script]
 shared_state = 1
+
+[shader]
+output_glsl_es100 = 1
+output_glsl_es300 = 1


### PR DESCRIPTION
Built-in debug resources now include GLES 100 and GLES 300 shader variants, matching the behavior before the CMake migration. This ensures built-in font shaders work when a desktop project uses a GLES graphics adapter.

Fix https://github.com/defold/defold/issues/12833

### Technical changes

- Enabled `output_glsl_es100` and `output_glsl_es300` in the internal project used to compile embedded built-in resources.
- Verified the Windows-target built-ins build and confirmed that all 18 generated built-in shaders contain both GLES variants.