### PR TITLE
Fix laggy manipulator gizmo for Gui nodes on large projects

### DIFF
--- a/editor/src/clj/editor/scene_tools.clj
+++ b/editor/src/clj/editor/scene_tools.clj
@@ -556,7 +556,6 @@
         start-pos (action->manip-pos start-action lead-transform active-manip manip-rotation project-fn)
         manipulations-fn (make-drag-manipulations-fn manip-opts active-manip manip-origin original-values initial-evaluation-context)]
     {:active-manip active-manip
-     :initial-evaluation-context initial-evaluation-context
      :lead-transform lead-transform
      :manip-origin manip-origin
      :manip-rotation manip-rotation


### PR DESCRIPTION
Fixes #12854

### Technical changes

`make-drag-start-state` was constructing a map that included an evaluation context. Previously the ec was being kept in an atom. During a graph node operation, a `case` expression was evaluating the value of the map and this would hash the whole clojure map, including an ec that on large projects would noticeably slow down the initial drag start. After grepping manually and searching with agents, I could not find any uses for this value of the map, so removing the key seems to fix the issue.

I used the big synthetic project, `gui_0235` to replicate