### PR TITLE
Fix Android crash when an input device is disconnected in the same frame as it is detected

### DIFF
--- a/external/glfw/java/com/dynamo/android/DefoldActivity.java
+++ b/external/glfw/java/com/dynamo/android/DefoldActivity.java
@@ -571,13 +571,17 @@ public class DefoldActivity extends NativeActivity {
         mGameControllerDeviceIds.clear();
         for (int deviceId : InputDevice.getDeviceIds()) {
             InputDevice device = InputDevice.getDevice(deviceId);
-            int sources = device.getSources();
-            // Filter game controller discovery to gamepads and joysticks. DPAD-only devices
-            // are still handled as key input in android_init.c, but should not be registered
-            // as gamepads here.
-            if (((sources & InputDevice.SOURCE_GAMEPAD) == InputDevice.SOURCE_GAMEPAD) ||
-                ((sources & InputDevice.SOURCE_JOYSTICK) == InputDevice.SOURCE_JOYSTICK)) {
-                mGameControllerDeviceIds.add(deviceId);
+            // a device can become disconnected or reconfigured in between the
+            // call to getDeviceIds() and getDevice()
+            if (device != null) {
+                int sources = device.getSources();
+                // Filter game controller discovery to gamepads and joysticks. DPAD-only devices
+                // are still handled as key input in android_init.c, but should not be registered
+                // as gamepads here.
+                if (((sources & InputDevice.SOURCE_GAMEPAD) == InputDevice.SOURCE_GAMEPAD) ||
+                    ((sources & InputDevice.SOURCE_JOYSTICK) == InputDevice.SOURCE_JOYSTICK)) {
+                    mGameControllerDeviceIds.add(deviceId);
+                }
             }
         }
 


### PR DESCRIPTION
This fixes an issue on Android where the engine would crash if an input device is detected by the engine in the same frame as it is disconnected.

Fixes #12771