### PR TITLE
Fix Vulkan crash during graphics shutdownfix crash

### DIFF
--- a/engine/graphics/src/test/test_app_graphics.cpp
+++ b/engine/graphics/src/test/test_app_graphics.cpp
@@ -636,8 +636,8 @@ struct AsyncTextureUploadShutdownTest : ITest
 
     void OnGraphicsClosed(EngineCtx* engine) override
     {
-        dmLogInfo("Issue #12878 reproducer: Vulkan device destroyed; waiting for async texture job");
-        if (WaitForAtomic(&m_WorkerDrained, 1, 5 * 1000 * 1000))
+        dmLogInfo("Issue #12878 reproducer: Vulkan device destroyed; verifying async texture job drained");
+        if (dmAtomicGet32(&m_WorkerDrained))
         {
             delete[] (const uint8_t*) m_TextureParams.m_Data;
             m_TextureParams.m_Data = 0;

--- a/engine/graphics/src/test/test_app_graphics.cpp
+++ b/engine/graphics/src/test/test_app_graphics.cpp
@@ -62,6 +62,18 @@ static bool ShouldAutoExit()
     return value && value[0] != 0 && strcmp(value, "0") != 0 && !TestMainIsDebuggerAttached();
 }
 
+static bool HasArgument(const char* argument)
+{
+    for (int i = 0; i < g_AppArgc; ++i)
+    {
+        if (strcmp(g_AppArgv[i], argument) == 0)
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
 struct RunLoopParams
 {
     int     m_Argc;
@@ -176,6 +188,8 @@ struct ITest
 {
     virtual void Initialize(EngineCtx*) {};
     virtual void Execute(EngineCtx*) {};
+    virtual void OnGraphicsClosing(EngineCtx*) {};
+    virtual void OnGraphicsClosed(EngineCtx*) {};
 };
 
 struct EngineCtx
@@ -503,6 +517,136 @@ struct AsyncTextureUploadTest : ITest
         }
 
         CreateTextures(engine);
+    }
+};
+
+// Regression test for https://github.com/defold/defold/issues/12878.
+//
+// Verifies that VulkanCloseWindow waits for in-flight async texture uploads
+// before destroying the logical device. The worker is deliberately delayed
+// until graphics shutdown begins; without the shutdown barrier, the queued
+// upload resumes after device destruction and crashes in Vulkan. The reported
+// crash reaches vkWaitForFences, while this deterministic test may fail at an
+// earlier Vulkan call due to the same context/device lifetime race.
+struct AsyncTextureUploadShutdownTest : ITest
+{
+    int32_atomic_t             m_BlockWorker;
+    int32_atomic_t             m_WorkerStarted;
+    int32_atomic_t             m_WorkerReleased;
+    int32_atomic_t             m_WorkerDrained;
+    dmGraphics::HTexture       m_Texture;
+    dmGraphics::TextureParams  m_TextureParams;
+
+    AsyncTextureUploadShutdownTest()
+    : m_Texture(0)
+    {
+        dmAtomicStore32(&m_BlockWorker, 1);
+        dmAtomicStore32(&m_WorkerStarted, 0);
+        dmAtomicStore32(&m_WorkerReleased, 0);
+        dmAtomicStore32(&m_WorkerDrained, 0);
+    }
+
+    static int BlockWorker(HJobContext, HJob, void*, void* data)
+    {
+        AsyncTextureUploadShutdownTest* test = (AsyncTextureUploadShutdownTest*) data;
+        dmAtomicStore32(&test->m_WorkerStarted, 1);
+        while (dmAtomicGet32(&test->m_BlockWorker))
+        {
+            dmTime::Sleep(100);
+        }
+        dmAtomicStore32(&test->m_WorkerReleased, 1);
+
+        // Give the main thread enough time to destroy the Vulkan device. A
+        // correct CloseWindow implementation will wait for this job and the
+        // queued upload instead.
+        dmTime::Sleep(1000 * 1000);
+        return 0;
+    }
+
+    static int MarkWorkerDrained(HJobContext, HJob, void*, void* data)
+    {
+        AsyncTextureUploadShutdownTest* test = (AsyncTextureUploadShutdownTest*) data;
+        dmAtomicStore32(&test->m_WorkerDrained, 1);
+        return 0;
+    }
+
+    static void PushJob(HJobContext job_context, FJobProcess process, void* data)
+    {
+        Job job = {};
+        job.m_Process = process;
+        job.m_Data = data;
+        HJob hjob = JobSystemCreateJob(job_context, &job);
+        JobSystemPushJob(job_context, hjob);
+    }
+
+    static bool WaitForAtomic(int32_atomic_t* value, int32_t expected, uint64_t timeout_us)
+    {
+        uint64_t timeout = dmTime::GetMonotonicTime() + timeout_us;
+        while (dmAtomicGet32(value) != expected && dmTime::GetMonotonicTime() < timeout)
+        {
+            dmTime::Sleep(100);
+        }
+        return dmAtomicGet32(value) == expected;
+    }
+
+    void Initialize(EngineCtx* engine) override
+    {
+        PushJob(engine->m_JobContext, BlockWorker, this);
+        if (!WaitForAtomic(&m_WorkerStarted, 1, 5 * 1000 * 1000))
+        {
+            dmLogError("Issue #12878 reproducer: worker did not start");
+            engine->m_Failed = true;
+            engine->m_Running = 0;
+            return;
+        }
+
+        const uint32_t width = 128;
+        const uint32_t height = 128;
+
+        dmGraphics::TextureCreationParams creation_params;
+        creation_params.m_Width = width;
+        creation_params.m_Height = height;
+        creation_params.m_OriginalWidth = width;
+        creation_params.m_OriginalHeight = height;
+
+        m_TextureParams.m_DataSize = width * height * 4;
+        m_TextureParams.m_Data = new uint8_t[m_TextureParams.m_DataSize];
+        m_TextureParams.m_Width = width;
+        m_TextureParams.m_Height = height;
+        m_TextureParams.m_Format = dmGraphics::TEXTURE_FORMAT_RGBA;
+
+        m_Texture = dmGraphics::NewTexture(engine->m_GraphicsContext, creation_params);
+        dmGraphics::SetTextureAsync(engine->m_GraphicsContext, m_Texture, m_TextureParams, 0, 0);
+
+        // This sentinel can only run after the async texture job has returned.
+        PushJob(engine->m_JobContext, MarkWorkerDrained, this);
+    }
+
+    void OnGraphicsClosing(EngineCtx* engine) override
+    {
+        dmLogInfo("Issue #12878 reproducer: releasing worker before Vulkan teardown");
+        dmAtomicStore32(&m_BlockWorker, 0);
+
+        if (!WaitForAtomic(&m_WorkerReleased, 1, 5 * 1000 * 1000))
+        {
+            dmLogError("Issue #12878 reproducer: worker was not released");
+            engine->m_Failed = true;
+        }
+    }
+
+    void OnGraphicsClosed(EngineCtx* engine) override
+    {
+        dmLogInfo("Issue #12878 reproducer: Vulkan device destroyed; waiting for async texture job");
+        if (WaitForAtomic(&m_WorkerDrained, 1, 5 * 1000 * 1000))
+        {
+            delete[] (const uint8_t*) m_TextureParams.m_Data;
+            m_TextureParams.m_Data = 0;
+        }
+        else
+        {
+            dmLogError("Issue #12878 reproducer: worker did not drain");
+            engine->m_Failed = true;
+        }
     }
 };
 
@@ -952,17 +1096,38 @@ static void* EngineCreate(int argc, char** argv)
         return 0;
     }
 
-    //engine->m_Test = new ComputeTest();
-    //engine->m_Test = new StorageBufferTest();
-    //engine->m_Test = new ReadPixelsTest();
-    //engine->m_Test = new AsyncTextureUploadTest();
-    //engine->m_Test = new ClearBackbufferTest();
-    dmLogInfo("test_app_graphics: running ClearBackbufferTest");
-    engine->m_Test = new ClearBackbufferTest();
+    if (HasArgument("issue-12878"))
+    {
+        if (dmGraphics::GetInstalledAdapterFamily() != dmGraphics::ADAPTER_FAMILY_VULKAN)
+        {
+            dmLogError("Issue #12878 reproducer requires the Vulkan adapter");
+            engine->m_Failed = true;
+            engine->m_Test = new ClearBackbufferTest();
+        }
+        else
+        {
+            dmLogInfo("test_app_graphics: running AsyncTextureUploadShutdownTest");
+            engine->m_Test = new AsyncTextureUploadShutdownTest();
+        }
+    }
+    else
+    {
+        //engine->m_Test = new ComputeTest();
+        //engine->m_Test = new StorageBufferTest();
+        //engine->m_Test = new ReadPixelsTest();
+        //engine->m_Test = new AsyncTextureUploadTest();
+        //engine->m_Test = new ClearBackbufferTest();
+        dmLogInfo("test_app_graphics: running ClearBackbufferTest");
+        engine->m_Test = new ClearBackbufferTest();
+    }
     engine->m_Test->Initialize(engine);
 
     engine->m_WasCreated++;
     engine->m_Running = engine->m_Failed ? 0 : 1;
+    if (HasArgument("issue-12878"))
+    {
+        engine->m_Running = 0;
+    }
     engine->m_TimeStart = dmTime::GetMonotonicTime();
 
     return &g_EngineCtx;
@@ -971,7 +1136,9 @@ static void* EngineCreate(int argc, char** argv)
 static void EngineDestroy(void* _engine)
 {
     EngineCtx* engine = (EngineCtx*)_engine;
+    engine->m_Test->OnGraphicsClosing(engine);
     dmGraphics::CloseWindow(engine->m_GraphicsContext);
+    engine->m_Test->OnGraphicsClosed(engine);
     dmGraphics::DeleteContext(engine->m_GraphicsContext);
     dmGraphics::Finalize();
 

--- a/engine/graphics/src/vulkan/graphics_native.cpp
+++ b/engine/graphics/src/vulkan/graphics_native.cpp
@@ -145,6 +145,8 @@ namespace dmGraphics
     void VulkanCloseWindow(HContext _context)
     {
         VulkanContext* context = (VulkanContext*) _context;
+        VulkanStopAsyncProcessing(context);
+
         if (dmPlatform::GetWindowStateParam(context->m_BaseContext.m_Window, WINDOW_STATE_OPENED))
         {
             VkDevice vk_device = context->m_LogicalDevice.m_Device;

--- a/engine/graphics/src/vulkan/graphics_vulkan.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan.cpp
@@ -21,6 +21,7 @@
 #include <dlib/log.h>
 #include <dlib/jobsystem.h>
 #include <dlib/thread.h>
+#include <dlib/time.h>
 
 #include <dmsdk/vectormath/cpp/vectormath_aos.h>
 
@@ -1705,7 +1706,7 @@ bail:
         VulkanContext* context = (VulkanContext*) _context;
         if (context != 0x0)
         {
-            dmAtomicStore32(&context->m_DeleteContextRequested, 1);
+            VulkanStopAsyncProcessing(context);
 
             for (uint32_t i = 0; i < DM_MAX_FRAMES_IN_FLIGHT; ++i)
             {
@@ -5134,6 +5135,52 @@ bail:
         return 0;
     }
 
+    static int AsyncStopBarrierCallback(HJobContext, HJob, void*, void* data)
+    {
+        int32_atomic_t* barrier_pending = (int32_atomic_t*) data;
+        dmAtomicStore32(barrier_pending, 0);
+        return 0;
+    }
+
+    void VulkanStopAsyncProcessing(VulkanContext* context)
+    {
+        if (!context->m_AsyncProcessingSupport)
+        {
+            dmAtomicStore32(&context->m_DeleteContextRequested, 1);
+            return;
+        }
+
+        int32_atomic_t barrier_pending;
+        {
+            DM_MUTEX_SCOPED_LOCK(context->m_BaseContext.m_AssetHandleContainerMutex);
+
+            if (dmAtomicGet32(&context->m_DeleteContextRequested))
+            {
+                return;
+            }
+
+            dmAtomicStore32(&context->m_DeleteContextRequested, 1);
+
+            // The graphics context currently uses a single worker. A barrier
+            // job therefore runs only after all previously queued async
+            // texture jobs have returned.
+            assert(JobSystemGetWorkerCount(context->m_JobContext) == 1);
+            dmAtomicStore32(&barrier_pending, 1);
+
+            Job job = {0};
+            job.m_Process = AsyncStopBarrierCallback;
+            job.m_Data = (void*) &barrier_pending;
+
+            HJob hjob = JobSystemCreateJob(context->m_JobContext, &job);
+            JobSystemPushJob(context->m_JobContext, hjob);
+        }
+
+        while (dmAtomicGet32(&barrier_pending))
+        {
+            dmTime::Sleep(100);
+        }
+    }
+
     // Called on thread where we update (which should be the main thread)
     static void AsyncCompleteCallback(HJobContext, HJob job, JobSystemStatus status, void* _context, void* data, int result)
     {
@@ -5240,6 +5287,12 @@ bail:
         if (context->m_AsyncProcessingSupport)
         {
             DM_MUTEX_SCOPED_LOCK(context->m_BaseContext.m_AssetHandleContainerMutex);
+
+            if (dmAtomicGet32(&context->m_DeleteContextRequested))
+            {
+                return;
+            }
+
             VulkanTexture* tex = GetAssetFromContainer<VulkanTexture>(context->m_BaseContext.m_AssetHandleContainer, texture);
 
             PrepareTextureForUploading(context, tex, params);

--- a/engine/graphics/src/vulkan/graphics_vulkan.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan.cpp
@@ -5152,6 +5152,9 @@ bail:
 
         int32_atomic_t barrier_pending;
         {
+            // Serialize shutdown with VulkanSetTextureAsync(). If an upload
+            // wins this lock, its job is queued before the barrier; if shutdown
+            // wins, the delete flag prevents jobs from being queued after it.
             DM_MUTEX_SCOPED_LOCK(context->m_BaseContext.m_AssetHandleContainerMutex);
 
             if (dmAtomicGet32(&context->m_DeleteContextRequested))

--- a/engine/graphics/src/vulkan/graphics_vulkan_private.h
+++ b/engine/graphics/src/vulkan/graphics_vulkan_private.h
@@ -610,6 +610,7 @@ namespace dmGraphics
 
     bool InitializeVulkan(HContext context);
     void InitializeVulkanTexture(VulkanTexture* t);
+    void VulkanStopAsyncProcessing(VulkanContext* context);
 
     void OnWindowResize(int width, int height);
     int  OnWindowClose();


### PR DESCRIPTION
Prevents Vulkan applications from crashing during graphics shutdown when an asynchronous texture upload is still queued or running. Graphics teardown now waits for outstanding upload work before destroying the Vulkan device.

Fix https://github.com/defold/defold/issues/12878

### Technical changes

- Stop accepting asynchronous Vulkan texture uploads once graphics shutdown begins.
- Add an idempotent worker barrier that drains previously queued graphics jobs before destroying Vulkan resources and the logical device.
- Serialize the shutdown flag and job-barrier submission with asynchronous texture job creation to prevent new work from being queued behind the barrier.
- Apply the barrier from both `VulkanCloseWindow()` and `VulkanDeleteContext()`.
- Add an opt-in `issue-12878` regression test that delays the worker until teardown and verifies that the async upload drains before device destruction.
- The barrier follows the engine's current single-worker job-system configuration and asserts that requirement.
- Verified the regression four consecutive times using Vulkan on Apple M1 Max; the normal Vulkan graphics test also passes.
