### PR TITLE
Per-channel update bundle directories

### DIFF
--- a/editor/src/clj/editor/updater.clj
+++ b/editor/src/clj/editor/updater.clj
@@ -172,21 +172,26 @@
 (def ^:private ^File support-dir
   (.getCanonicalFile (.toFile (Editor/getSupportPath))))
 
-(def ^:private ^File update-dir
-  (io/file support-dir "update"))
+(def ^:private ^File updates-dir
+  (io/file support-dir "updates"))
 
-(def ^:private ^File update-sha1-file
-  (io/file support-dir "update.sha1"))
+(defn- channel-update-paths [channel]
+  (let [channel-dir (io/file updates-dir channel)]
+    {:update-dir (io/file channel-dir "bundle")
+     :update-sha1-file (io/file channel-dir "sha1")}))
 
 (defn- make-updater [channel editor-sha1 downloaded-sha1 platform install-dir launcher-path protected-dirs]
-  {:channel channel
-   :platform platform
-   :install-dir install-dir
-   :launcher-path launcher-path
-   :editor-sha1 editor-sha1
-   :protected-dirs protected-dirs
-   :state-atom (atom {:downloaded-sha1 downloaded-sha1
-                      :server-sha1 editor-sha1})})
+  (let [{:keys [update-dir update-sha1-file]} (channel-update-paths channel)]
+    {:channel channel
+     :platform platform
+     :install-dir install-dir
+     :launcher-path launcher-path
+     :editor-sha1 editor-sha1
+     :protected-dirs protected-dirs
+     :update-dir update-dir
+     :update-sha1-file update-sha1-file
+     :state-atom (atom {:downloaded-sha1 downloaded-sha1
+                        :server-sha1 editor-sha1})}))
 
 (defn add-progress-watch
   "Adds a watch that gets notified on download and extraction progress of
@@ -291,7 +296,7 @@
   (not (zero? (bit-and unix-mode execute-permission-flag))))
 
 (defn- extract! [updater ^File zip-file server-sha1 track-extract-progress! cancelled-atom]
-  (let [{:keys [state-atom]} updater
+  (let [{:keys [state-atom update-dir update-sha1-file]} updater
         {:keys [downloaded-sha1]} @state-atom]
     (when (some? downloaded-sha1)
       (log/info :message "Removing previously downloaded update")
@@ -332,8 +337,8 @@
 
 (defn download-and-extract!
   "Asynchronously downloads newest zip distribution to temporary directory,
-  extracts it to `{support-dir}/update` and creates `{support-dir}/update.sha1`
-  file containing downloaded update's sha1
+  extracts it to `{support-dir}/updates/{channel}/bundle` and creates
+  `{support-dir}/updates/{channel}/sha1` file containing downloaded update's sha1
 
   Returns future that eventually will contain boolean indicating the success of
   operation"
@@ -404,7 +409,7 @@
   "Installs previously downloaded update"
   [updater]
   {:pre [(can-install-update? updater)]}
-  (let [{:keys [install-dir state-atom]} updater
+  (let [{:keys [install-dir state-atom ^File update-dir update-sha1-file]} updater
         {:keys [current-download downloaded-sha1]} @state-atom]
     (when (some? current-download)
       (reset! (:cancelled-derefable current-download) true)
@@ -519,13 +524,14 @@
                             "win32" "./Defold.exe"
                             "linux" "./Defold"
                             "macos" "./Contents/MacOS/Defold"))
-        downloaded-sha1 (when (.exists update-sha1-file)
-                          (slurp update-sha1-file))
         initial-update-delay 1000
         update-delay 3600000]
     (if (or (string/blank? channel) (string/blank? sha1))
       (do
         (log/info :message "Automatic updates disabled" :channel channel :sha1 sha1)
         nil)
-      (doto (make-updater channel sha1 downloaded-sha1 platform install-dir launcher-path protected-dirs)
-        (start-timer! initial-update-delay update-delay)))))
+      (let [^File update-sha1-file (:update-sha1-file (channel-update-paths channel))
+            downloaded-sha1 (when (.exists update-sha1-file)
+                              (slurp update-sha1-file))]
+        (doto (make-updater channel sha1 downloaded-sha1 platform install-dir launcher-path protected-dirs)
+          (start-timer! initial-update-delay update-delay))))))

--- a/editor/test/editor/updater_test.clj
+++ b/editor/test/editor/updater_test.clj
@@ -49,7 +49,13 @@
                           test-port channel))]
     (f)))
 
-(use-fixtures :once error-log-level-fixture test-urls-fixture)
+(defn- test-support-dir-fixture [f]
+  (let [^File temp-updates-dir (fs/create-temp-directory! "updater-test-updates")]
+    (with-redefs [updater/updates-dir temp-updates-dir]
+      (f))
+    (fs/delete-directory! temp-updates-dir)))
+
+(use-fixtures :once error-log-level-fixture test-urls-fixture test-support-dir-fixture)
 
 (defn make-handler-resources [channel sha1]
   {(format "/editor2/channels/%s/update-v4.json" channel)
@@ -63,6 +69,12 @@
     (fn [request]
       (get resources (:path request) http-server/not-found))))
 
+(defn- make-multi-channel-resource-handler [channel->sha1]
+  (let [resources (apply merge (map (fn [[channel sha1]] (make-handler-resources channel sha1))
+                                     channel->sha1))]
+    (fn [request]
+      (get resources (:path request) http-server/not-found))))
+
 (defn- list-files [dir]
   (->> (file-seq (io/file dir))
        (filter #(.isFile ^File %))
@@ -73,15 +85,22 @@
   ^ServerWithHandler [channel sha]
   (http-server/start! (make-resource-handler channel sha) :port test-port))
 
-(defn make-updater [channel sha1]
-  (#'updater/make-updater
-    channel
-    sha1
-    sha1
-    (Platform/getHostPlatform)
-    (io/file ".")
-    (io/file "no-launcher")
-    []))
+(defn- start-multi-channel-update-server!
+  ^ServerWithHandler [channel->sha1]
+  (http-server/start! (make-multi-channel-resource-handler channel->sha1) :port test-port))
+
+(defn make-updater
+  ([channel editor-sha1]
+   (make-updater channel editor-sha1 editor-sha1))
+  ([channel editor-sha1 downloaded-sha1]
+   (#'updater/make-updater
+     channel
+     editor-sha1
+     downloaded-sha1
+     (Platform/getHostPlatform)
+     (io/file ".")
+     (io/file "no-launcher")
+     [])))
 
 (deftest no-update-on-client-when-no-update-on-server
   (with-open [_ (start-update-server! "test" "1")]
@@ -106,8 +125,8 @@
 (deftest can-download-and-extract-update
   (with-open [_ (start-update-server! "test" "2")]
     (let [updater (make-updater "test" "1")
-          ^File update-sha1-file @#'updater/update-sha1-file
-          ^File update-dir @#'updater/update-dir]
+          ^File update-sha1-file (:update-sha1-file updater)
+          ^File update-dir (:update-dir updater)]
       (fs/delete-directory! update-dir)
       (fs/delete! update-sha1-file)
       (#'updater/check! updater)
@@ -117,6 +136,65 @@
       (is (= #{"extracted-file.txt"} (list-files update-dir)))
       (fs/delete-directory! update-dir)
       (fs/delete! update-sha1-file))))
+
+(deftest channel-downloads-do-not-clobber-each-other
+  (with-open [_ (start-multi-channel-update-server! {"alpha" "A2" "beta" "B2"})]
+    (let [alpha-install-dir (fs/create-temp-directory! "updater-test-install")
+          alpha-updater (assoc (make-updater "alpha" "A1" nil)
+                          :install-dir alpha-install-dir)
+          beta-updater (make-updater "beta" "B1" nil)
+          ^File alpha-dir (:update-dir alpha-updater)
+          ^File alpha-sha1-file (:update-sha1-file alpha-updater)
+          ^File beta-dir (:update-dir beta-updater)
+          ^File beta-sha1-file (:update-sha1-file beta-updater)]
+      (fs/delete-directory! alpha-dir)
+      (fs/delete! alpha-sha1-file)
+      (fs/delete-directory! beta-dir)
+      (fs/delete! beta-sha1-file)
+      (try
+        (#'updater/check! alpha-updater)
+        (#'updater/check! beta-updater)
+        (is (true? (updater/can-download-update? alpha-updater)))
+        (is (true? (updater/can-download-update? beta-updater)))
+
+        @(updater/download-and-extract! alpha-updater)
+        (is (true? (updater/can-install-update? alpha-updater)))
+        (is (false? (updater/can-install-update? beta-updater)))
+        (is (.exists alpha-dir))
+        (is (.exists alpha-sha1-file))
+        (is (= "A2" (slurp alpha-sha1-file)))
+        (is (not (.exists beta-dir)))
+        (is (not (.exists beta-sha1-file)))
+
+        @(updater/download-and-extract! beta-updater)
+        (is (true? (updater/can-install-update? beta-updater)))
+        (is (.exists beta-dir))
+        (is (.exists beta-sha1-file))
+        (is (= "B2" (slurp beta-sha1-file)))
+
+        ;; downloading beta didn't touch alpha's already-extracted bundle
+        (is (.exists alpha-dir))
+        (is (= "A2" (slurp alpha-sha1-file)))
+        (is (= #{"extracted-file.txt"} (list-files alpha-dir)))
+        (is (= #{"extracted-file.txt"} (list-files beta-dir)))
+
+        (updater/install! alpha-updater)
+        (is (= #{"extracted-file.txt"} (list-files alpha-install-dir)))
+        (is (false? (updater/can-install-update? alpha-updater)))
+        (is (not (.exists alpha-dir)))
+        (is (not (.exists alpha-sha1-file)))
+
+        ;; installing alpha didn't touch beta's still-pending download
+        (is (true? (updater/can-install-update? beta-updater)))
+        (is (.exists beta-dir))
+        (is (.exists beta-sha1-file))
+        (is (= "B2" (slurp beta-sha1-file)))
+        (finally
+          (fs/delete-directory! alpha-dir)
+          (fs/delete! alpha-sha1-file)
+          (fs/delete-directory! beta-dir)
+          (fs/delete! beta-sha1-file)
+          (fs/delete-directory! alpha-install-dir))))))
 
 (deftest throws-if-zip-is-missing-on-server
   (with-open [_ (start-update-server! "test" "2")]


### PR DESCRIPTION
For users with multiple editor installations with different channels (alpha, beta, stable), downloading an update for one channel would clobber another. This PR now saves the bundle per channel so they can be downloaded and installed independently. 

Fixes #12889