### PR TITLE
Fix sound exhaustion when Web Audio is unavailable

### DIFF
--- a/engine/sound/src/devices/device_js.cpp
+++ b/engine/sound/src/devices/device_js.cpp
@@ -26,6 +26,7 @@
 extern "C" {
     // Implementation in library_sound.js
     int dmDeviceJSOpen(int buffers);
+    void dmDeviceJSClose(int device);
     int dmGetDeviceSampleRate(int device);
     void dmDeviceJSPlaybackStarted(int device);
     void dmDeviceJSPlaybackIdle(int device);
@@ -50,6 +51,7 @@ namespace dmDeviceJS
         int deviceId = dmDeviceJSOpen(params->m_BufferCount);
         if (deviceId < 0)
         {
+            delete dev;
             return dmSound::RESULT_DEVICE_NOT_FOUND;
         }
         dev->devId = deviceId;
@@ -65,7 +67,9 @@ namespace dmDeviceJS
     void DeviceJSClose(dmSound::HDevice device)
     {
         assert(device);
-        delete (JSDevice*)(device);
+        JSDevice* dev = (JSDevice*) device;
+        dmDeviceJSClose(dev->devId);
+        delete dev;
     }
 
     dmSound::Result DeviceJSQueue(dmSound::HDevice device, const void* samples, uint32_t sample_count)

--- a/engine/sound/src/js/library_sound.js
+++ b/engine/sound/src/js/library_sound.js
@@ -41,6 +41,7 @@ var LibrarySoundDevice =
         NotifyContextStateChanged: function(shared) {
             var audioCtx = shared.audioCtx;
             var running = audioCtx !== undefined && audioCtx.state == "running";
+            // Retries can report the same state repeatedly. Reset device queues only on a real transition.
             if (running != shared.contextRunning) {
                 shared.contextRunning = running;
                 DefoldSoundDevice.ForEachDevice(shared, function(device) {
@@ -70,6 +71,7 @@ var LibrarySoundDevice =
             }
 
             var audioCtx = shared.audioCtx;
+            // Detach the failed context first so every device immediately switches to silent clocking.
             shared.audioCtx = undefined;
             shared.resumePending = false;
             if (audioCtx !== undefined) {
@@ -102,9 +104,11 @@ var LibrarySoundDevice =
 
             var audioCtx;
             try {
+                // The default sample rate varies by output device and can be lower than 44100 Hz.
                 audioCtx = new audioCtxCtor({ sampleRate: 48000 });
             } catch (e) {
                 try {
+                    // Some browsers do not support requesting a sample rate in the constructor.
                     audioCtx = new audioCtxCtor();
                 } catch (fallbackError) {
                     return undefined;
@@ -142,6 +146,7 @@ var LibrarySoundDevice =
                 try {
                     var resumeResult = audioCtx.resume();
                     if (resumeResult && resumeResult.then) {
+                        // Interaction may supersede an earlier pending resume. Ignore results from stale attempts.
                         var resumeAttempt = ++shared.resumeAttempt;
                         shared.resumePending = true;
                         resumeResult.then(function() {
@@ -185,6 +190,7 @@ var LibrarySoundDevice =
             }
 
             shared.retryTimer = root.setTimeout(function() {
+                // One shared timer services every Defold sound device on the page.
                 shared.retryTimer = null;
                 if (!DefoldSoundDevice.HasDevices(shared)) {
                     return;
@@ -252,6 +258,7 @@ var LibrarySoundDevice =
 
         var id = shared.count++;
         var audioCtx = DefoldSoundDevice.TryCreateAudioContext(shared);
+        // Keep this rate for the device lifetime. A recovered Web Audio context resamples if necessary.
         var sampleRate = audioCtx !== undefined ? audioCtx.sampleRate : 48000;
         if (audioCtx === undefined) {
             DefoldSoundDevice.WarnSilentFallback(shared);
@@ -295,8 +302,10 @@ var LibrarySoundDevice =
                 var now = DefoldSoundDevice.Now();
                 var audioTime = running && shared.audioCtx !== undefined ? (shared.audioCtx.currentTime || 0) : 0;
                 if (!running) {
+                    // The native mixer keeps advancing silently, so queued Web Audio must not replay on recovery.
                     this._cancelActiveSources();
                 }
+                // Change clocks without resetting native sound instances or their logical playback position.
                 this._resetQueueDecay(audioTime);
                 this.creatingTime = now;
                 this.lastTimeInSuspendedState = now;
@@ -324,6 +333,7 @@ var LibrarySoundDevice =
             },
             _trackActiveSource: function(source) {
                 var device = this;
+                // Keep scheduled sources only so context transitions and device close can cancel them.
                 this.activeSources.push(source);
                 source.onended = function() {
                     var index = device.activeSources.indexOf(source);
@@ -334,6 +344,7 @@ var LibrarySoundDevice =
             },
             _queueSilently: function(bufferDuration) {
                 var suspendedTime = this._getCurrentSuspendedTime();
+                // After an idle gap, start at wall-clock time instead of extending an expired queue.
                 this.suspendedBufferedTo = Math.max(this.suspendedBufferedTo, suspendedTime) + bufferDuration;
                 this.ignoreNextUnderrun = true;
             },
@@ -570,6 +581,7 @@ var LibrarySoundDevice =
                     this.bufferedTo += frame_count;
                 } catch (e) {
                     DefoldSoundDevice.HandleAudioFailure(shared, audioCtx);
+                    // Account for the failed real buffer once so native playback continues at the same rate.
                     this._queueSilently(len);
                 }
             },
@@ -622,6 +634,7 @@ var LibrarySoundDevice =
             return;
         }
 
+        // The context and recovery hooks are shared, so release them only after the final device closes.
         if (shared.retryTimer !== null && root.clearTimeout) {
             root.clearTimeout(shared.retryTimer);
             shared.retryTimer = null;

--- a/engine/sound/src/js/library_sound.js
+++ b/engine/sound/src/js/library_sound.js
@@ -142,15 +142,20 @@ var LibrarySoundDevice =
                 try {
                     var resumeResult = audioCtx.resume();
                     if (resumeResult && resumeResult.then) {
+                        var resumeAttempt = ++shared.resumeAttempt;
                         shared.resumePending = true;
                         resumeResult.then(function() {
-                            shared.resumePending = false;
-                            if (shared.audioCtx === audioCtx) {
-                                DefoldSoundDevice.NotifyContextStateChanged(shared);
+                            if (shared.audioCtx !== audioCtx || shared.resumeAttempt != resumeAttempt) {
+                                return;
                             }
-                        }, function() {
                             shared.resumePending = false;
-                            if (shared.audioCtx === audioCtx && audioCtx.state == "closed") {
+                            DefoldSoundDevice.NotifyContextStateChanged(shared);
+                        }, function() {
+                            if (shared.audioCtx !== audioCtx || shared.resumeAttempt != resumeAttempt) {
+                                return;
+                            }
+                            shared.resumePending = false;
+                            if (audioCtx.state == "closed") {
                                 DefoldSoundDevice.HandleAudioFailure(shared, audioCtx);
                             } else {
                                 DefoldSoundDevice.ScheduleAudioRetry(shared);
@@ -239,7 +244,8 @@ var LibrarySoundDevice =
                 recoveryLogged: false,
                 openedSilently: false,
                 contextRunning: false,
-                resumePending: false
+                resumePending: false,
+                resumeAttempt: 0
             };
             root._dmJSDeviceShared = shared;
         }
@@ -258,342 +264,342 @@ var LibrarySoundDevice =
 
         // Construct a device that uses Web Audio when it is running and a clocked silent queue otherwise.
         var device = {
-                sampleRate: sampleRate,
-                bufferedTo: 0,
-                bufferDuration: 0,
-                effectiveBufferCount: bufferCount,
-                latencyQueueFloorSeconds: 0,
-                learnedQueueFloorSeconds: 0,
-                adaptiveQueueSeconds: 0,
-                lastUnderrunTime: 0,
-                lastQueueDecayTime: 0,
-                ignoreNextUnderrun: false,
-                copyToChannelNeedsSlice: null,
-                activeSources: [],
-                creatingTime: DefoldSoundDevice.Now(),
-                lastTimeInSuspendedState: DefoldSoundDevice.Now(),
-                suspendedBufferedTo: 0,
-                // functions
-                _isContextRunning: function() {
-                    var audioCtx = shared.audioCtx;
-                    return audioCtx !== undefined && audioCtx.state == "running";
-                },
-                _getCurrentSuspendedTime: function() {
-                    if (!this._isContextRunning()) {
-                        this.lastTimeInSuspendedState = DefoldSoundDevice.Now();
-                        return this.lastTimeInSuspendedState - this.creatingTime;
-                    }
-                    return 0;
-                },
-                _onContextStateChanged: function(running) {
-                    var now = DefoldSoundDevice.Now();
-                    var audioTime = running && shared.audioCtx !== undefined ? (shared.audioCtx.currentTime || 0) : 0;
-                    if (!running) {
-                        this._cancelActiveSources();
-                    }
-                    this._resetQueueDecay(audioTime);
-                    this.creatingTime = now;
-                    this.lastTimeInSuspendedState = now;
-                    this.suspendedBufferedTo = 0;
-                    this.ignoreNextUnderrun = true;
-                    if (running) {
-                        // Force the first real buffer to start from the recovered context's current time.
-                        this.bufferedTo = 0;
-                    }
-                },
-                _cancelActiveSources: function() {
-                    for (var i = 0; i < this.activeSources.length; ++i) {
-                        var source = this.activeSources[i];
-                        source.onended = null;
-                        try {
-                            source.stop();
-                        } catch (e) {
-                        }
-                        try {
-                            source.disconnect();
-                        } catch (e) {
-                        }
-                    }
-                    this.activeSources.length = 0;
-                },
-                _trackActiveSource: function(source) {
-                    var device = this;
-                    this.activeSources.push(source);
-                    source.onended = function() {
-                        var index = device.activeSources.indexOf(source);
-                        if (index != -1) {
-                            device.activeSources.splice(index, 1);
-                        }
-                    };
-                },
-                _queueSilently: function(bufferDuration) {
-                    var suspendedTime = this._getCurrentSuspendedTime();
-                    this.suspendedBufferedTo = Math.max(this.suspendedBufferedTo, suspendedTime) + bufferDuration;
-                    this.ignoreNextUnderrun = true;
-                },
-                // Cache whether WebAudio needs a non-shared copy from WASM memory.
-                _needsCopyToChannelSlice: function(heapBuffer) {
-                    if (this.copyToChannelNeedsSlice === null) {
-                        this.copyToChannelNeedsSlice = typeof SharedArrayBuffer !== "undefined" && heapBuffer instanceof SharedArrayBuffer;
-                    }
-                    return this.copyToChannelNeedsSlice;
-                },
-                // Disabled-by-default trace hook for tuning browser-specific queue behavior.
-                _debugLogQueueResize: function(reason, previousBufferCount, newBufferCount, previousSeconds, seconds) {
-                    // Uncomment while tuning browser-specific HTML5 audio queue behavior.
-                    /*
-                    var floorSeconds = this._getAdaptiveQueueFloorSeconds();
-                    console.log("sound queue resize (" + reason + "): buffers " +
-                        previousBufferCount + " -> " + newBufferCount +
-                        ", seconds " + previousSeconds.toFixed(3) + " -> " +
-                        seconds.toFixed(3) +
-                        ", latency floor " + this.latencyQueueFloorSeconds.toFixed(3) +
-                        ", floor " + floorSeconds.toFixed(3) +
-                        ", learned " + this.learnedQueueFloorSeconds.toFixed(3) +
-                        ", buffer " + this.bufferDuration.toFixed(3));
-                    */
-                },
-                // Restart the stable-playback timer after underruns or context state changes.
-                _resetQueueDecay: function(audioTime) {
-                    this.lastUnderrunTime = audioTime;
-                    this.lastQueueDecayTime = audioTime;
-                },
-                // Convert a target queue duration into the buffer count reported to native code.
-                _queueSecondsToBufferCount: function(seconds) {
-                    if (this.bufferDuration <= 0) {
-                        return bufferCount;
-                    }
-                    return Math.max(
-                        bufferCount,
-                        Math.ceil(seconds / this.bufferDuration)
-                    );
-                },
-                // Keep the queue from decaying below browser latency or observed underrun needs.
-                _getAdaptiveQueueFloorSeconds: function() {
-                    return Math.max(
-                        this.latencyQueueFloorSeconds,
-                        this.learnedQueueFloorSeconds
-                    );
-                },
-                // Recompute the effective buffer count used by _freeBufferSlots().
-                _updateEffectiveBufferCount: function(reason, previousAdaptiveQueueSeconds) {
-                    var previousEffectiveBufferCount = this.effectiveBufferCount;
-                    if (this.bufferDuration <= 0) {
-                        this.effectiveBufferCount = bufferCount;
-                        return;
-                    }
-
-                    this.adaptiveQueueSeconds = Math.min(this.adaptiveQueueSeconds, maxAdaptiveQueueSeconds);
-                    this.effectiveBufferCount = this._queueSecondsToBufferCount(this.adaptiveQueueSeconds);
-                    if (this.effectiveBufferCount != previousEffectiveBufferCount) {
-                        this._debugLogQueueResize(
-                            reason,
-                            previousEffectiveBufferCount,
-                            this.effectiveBufferCount,
-                            previousAdaptiveQueueSeconds,
-                            this.adaptiveQueueSeconds
-                        );
-                    }
-                },
-                // Raise the queue target from browser-reported latency without shrinking it.
-                _updateQueueTarget: function() {
-                    var audioCtx = shared.audioCtx;
-                    if (audioCtx === undefined) {
-                        return;
-                    }
-                    var reportedLatency = Math.max(audioCtx.outputLatency || 0, audioCtx.baseLatency || 0);
-                    var latencyQueueSeconds = reportedLatency > 0 ? reportedLatency * outputLatencyQueueScale : 0;
-                    var targetQueueSeconds = Math.min(
-                        Math.max(bufferCount * this.bufferDuration, latencyQueueSeconds),
-                        maxAdaptiveQueueSeconds
-                    );
-                    this.latencyQueueFloorSeconds = Math.max(this.latencyQueueFloorSeconds, targetQueueSeconds);
-
-                    var previousAdaptiveQueueSeconds = this.adaptiveQueueSeconds;
-                    this.adaptiveQueueSeconds = Math.max(
-                        this.adaptiveQueueSeconds,
-                        this._getAdaptiveQueueFloorSeconds()
-                    );
-                    this._updateEffectiveBufferCount("target", previousAdaptiveQueueSeconds);
-                },
-                // Increase the queue after active-playback starvation and remember the new floor.
-                _growQueueAfterUnderrun: function(audioTime) {
-                    this._resetQueueDecay(audioTime);
-                    if (this.bufferDuration <= 0) {
-                        return;
-                    }
-
-                    var previousEffectiveBufferCount = this.effectiveBufferCount;
-                    var previousAdaptiveQueueSeconds = this.adaptiveQueueSeconds;
-                    var previousFloorSeconds = this._getAdaptiveQueueFloorSeconds();
-                    var previousFloorBufferCount = this._queueSecondsToBufferCount(previousFloorSeconds);
-
-                    this.learnedQueueFloorSeconds = Math.min(
-                        maxAdaptiveQueueSeconds,
-                        Math.max(
-                            this.learnedQueueFloorSeconds,
-                            (previousEffectiveBufferCount + 1) * this.bufferDuration
-                        )
-                    );
-
-                    var floorSeconds = this._getAdaptiveQueueFloorSeconds();
-                    if (floorSeconds != previousFloorSeconds) {
-                        this._debugLogQueueResize(
-                            "floor",
-                            previousFloorBufferCount,
-                            this._queueSecondsToBufferCount(floorSeconds),
-                            previousFloorSeconds,
-                            floorSeconds
-                        );
-                    }
-
-                    this.adaptiveQueueSeconds = Math.min(
-                        maxAdaptiveQueueSeconds,
-                        Math.max(
-                            this.adaptiveQueueSeconds * 1.5,
-                            this.adaptiveQueueSeconds + this.bufferDuration
-                        )
-                    );
-                    this._updateEffectiveBufferCount("underrun", previousAdaptiveQueueSeconds);
-                },
-                // Slowly reduce the queue after sustained playback, down to the current floor.
-                _decayQueueAfterStablePlayback: function(audioTime) {
-                    var floorSeconds = this._getAdaptiveQueueFloorSeconds();
-                    if (this.bufferDuration <= 0 || this.adaptiveQueueSeconds <= floorSeconds) {
-                        return;
-                    }
-
-                    if (audioTime - this.lastUnderrunTime < stablePlaybackSecondsBeforeDecay) {
-                        this.lastQueueDecayTime = audioTime;
-                        return;
-                    }
-
-                    var elapsed = audioTime - this.lastQueueDecayTime;
-                    if (elapsed <= 0) {
-                        return;
-                    }
-
-                    var decay = elapsed * this.bufferDuration * queueDecayBufferRate;
-                    var previousAdaptiveQueueSeconds = this.adaptiveQueueSeconds;
-                    this.adaptiveQueueSeconds = Math.max(
-                        floorSeconds,
-                        this.adaptiveQueueSeconds - decay
-                    );
-                    this.lastQueueDecayTime = audioTime;
-                    this._updateEffectiveBufferCount("decay", previousAdaptiveQueueSeconds);
-                },
-                _markPlaybackStarted: function() {
-                    var audioTime = this._isContextRunning() ? (shared.audioCtx.currentTime || 0) : 0;
-                    this.ignoreNextUnderrun = true;
-                    this._resetQueueDecay(audioTime);
-                },
-                _markPlaybackIdle: function() {
-                    // Mark idle so the next start doesn't learn the stale queue gap as an underrun.
-                    // Already scheduled WebAudio buffers are left to finish naturally.
-                    var audioTime = this._isContextRunning() ? (shared.audioCtx.currentTime || 0) : 0;
-                    this.ignoreNextUnderrun = true;
-                    this._resetQueueDecay(audioTime);
-                },
-                _queue: function(samples, frame_count) {
-                    var lastBufferDuration = this.bufferDuration;
-                    var len = frame_count / this.sampleRate;
-                    // use real buffer length next time.
-                    this.bufferDuration = len;
-
-                    // Advance a wall-clock queue while Web Audio is unavailable or autoplay-suspended.
-                    // This lets the native mixer reach end-of-stream and recycle sound instances.
-                    if (!this._isContextRunning()) {
-                        this._queueSilently(len);
-                        return;
-                    }
-
-                    var audioCtx = shared.audioCtx;
-                    try {
-                        this._updateQueueTarget();
-
-                        // Setup buffer for data delivery...
-                        var buf = audioCtx.createBuffer(2, frame_count, this.sampleRate);
-
-                        // Copy data from WASM memory
-                        var heapBuffer = HEAPF32.buffer;
-                        var needsCopy = this._needsCopyToChannelSlice(heapBuffer);
-                        for(var c=0;c<2;c++) {
-                            var input = new Float32Array(heapBuffer, samples, frame_count);
-                            // copyToChannel cannot handle SharedArrayBuffer views, so threaded builds need a non-shared copy.
-                            buf.copyToChannel(needsCopy ? input.slice() : input, c);
-                            samples += frame_count * 4; // 4 bytes = sizeof(float)
-                        }
-                        var source = audioCtx.createBufferSource();
-                        source.buffer = buf;
-                        source.connect(audioCtx.destination);
-                        this._trackActiveSource(source);
-
-                        var t = audioCtx.currentTime;
-                        var startTime;
-                        var firstBuffer = lastBufferDuration == 0.0;
-                        var bufferedToSeconds = this.bufferedTo / this.sampleRate;
-                        var underrun = !firstBuffer && bufferedToSeconds <= t;
-
-                        if (underrun) {
-                            // Suppress expected gaps after suspend/resume or an idle restart.
-                            // Other underruns are active-playback starvation and should grow the adaptive queue.
-                            if (this.ignoreNextUnderrun) {
-                                this.ignoreNextUnderrun = false;
-                                this._resetQueueDecay(t);
-                            } else {
-                                this._growQueueAfterUnderrun(t);
-                            }
-                        } else {
-                            this.ignoreNextUnderrun = false;
-                            if (!firstBuffer) {
-                                this._decayQueueAfterStablePlayback(t);
-                            }
-                        }
-
-                        // Underrun or first buffer?
-                        if (underrun || firstBuffer) {
-                            // Yes, restart buffering - offset is always computed based on queue length...
-                            var off = (this.effectiveBufferCount - 1) * this.bufferDuration;
-                            startTime = t + off;
-                            this.bufferedTo = startTime * this.sampleRate;
-                        } else {
-                            // No, normal delivery...
-                            startTime = this.bufferedTo / this.sampleRate;
-                        }
-                        source.start(startTime);
-                        this.bufferedTo += frame_count;
-                    } catch (e) {
-                        DefoldSoundDevice.HandleAudioFailure(shared, audioCtx);
-                        this._queueSilently(len);
-                    }
-                },
-                _freeBufferSlots: function() {
-                    // Always permit the first mix buffer so bufferDuration becomes known in silent mode too.
-                    if (this.bufferDuration <= 0) {
-                        return 1;
-                    }
-
-                    var ahead = 0;
-                    if (this._isContextRunning()) {
-                        ahead = this.bufferedTo / this.sampleRate - shared.audioCtx.currentTime;
-                    } else {
-                        // if audio context in suspended or closed state we simulate audio play
-                        // by calculating play time
-                        // when audio context become active - start filling audio buffer from the beginning
-                        // and start using audioCtx.currentTime
-                        ahead = this.suspendedBufferedTo - this._getCurrentSuspendedTime();
-                    }
-                    var inqueue = Math.ceil(ahead / this.bufferDuration);
-                    if (inqueue < 0) {
-                        inqueue = 0;
-                    }
-                    var left = this.effectiveBufferCount - inqueue;
-                    if (left < 0) {
-                        return 0;
-                    }
-                    return left;
+            sampleRate: sampleRate,
+            bufferedTo: 0,
+            bufferDuration: 0,
+            effectiveBufferCount: bufferCount,
+            latencyQueueFloorSeconds: 0,
+            learnedQueueFloorSeconds: 0,
+            adaptiveQueueSeconds: 0,
+            lastUnderrunTime: 0,
+            lastQueueDecayTime: 0,
+            ignoreNextUnderrun: false,
+            copyToChannelNeedsSlice: null,
+            activeSources: [],
+            creatingTime: DefoldSoundDevice.Now(),
+            lastTimeInSuspendedState: DefoldSoundDevice.Now(),
+            suspendedBufferedTo: 0,
+            // functions
+            _isContextRunning: function() {
+                var audioCtx = shared.audioCtx;
+                return audioCtx !== undefined && audioCtx.state == "running";
+            },
+            _getCurrentSuspendedTime: function() {
+                if (!this._isContextRunning()) {
+                    this.lastTimeInSuspendedState = DefoldSoundDevice.Now();
+                    return this.lastTimeInSuspendedState - this.creatingTime;
                 }
-            };
+                return 0;
+            },
+            _onContextStateChanged: function(running) {
+                var now = DefoldSoundDevice.Now();
+                var audioTime = running && shared.audioCtx !== undefined ? (shared.audioCtx.currentTime || 0) : 0;
+                if (!running) {
+                    this._cancelActiveSources();
+                }
+                this._resetQueueDecay(audioTime);
+                this.creatingTime = now;
+                this.lastTimeInSuspendedState = now;
+                this.suspendedBufferedTo = 0;
+                this.ignoreNextUnderrun = true;
+                if (running) {
+                    // Force the first real buffer to start from the recovered context's current time.
+                    this.bufferedTo = 0;
+                }
+            },
+            _cancelActiveSources: function() {
+                for (var i = 0; i < this.activeSources.length; ++i) {
+                    var source = this.activeSources[i];
+                    source.onended = null;
+                    try {
+                        source.stop();
+                    } catch (e) {
+                    }
+                    try {
+                        source.disconnect();
+                    } catch (e) {
+                    }
+                }
+                this.activeSources.length = 0;
+            },
+            _trackActiveSource: function(source) {
+                var device = this;
+                this.activeSources.push(source);
+                source.onended = function() {
+                    var index = device.activeSources.indexOf(source);
+                    if (index != -1) {
+                        device.activeSources.splice(index, 1);
+                    }
+                };
+            },
+            _queueSilently: function(bufferDuration) {
+                var suspendedTime = this._getCurrentSuspendedTime();
+                this.suspendedBufferedTo = Math.max(this.suspendedBufferedTo, suspendedTime) + bufferDuration;
+                this.ignoreNextUnderrun = true;
+            },
+            // Cache whether WebAudio needs a non-shared copy from WASM memory.
+            _needsCopyToChannelSlice: function(heapBuffer) {
+                if (this.copyToChannelNeedsSlice === null) {
+                    this.copyToChannelNeedsSlice = typeof SharedArrayBuffer !== "undefined" && heapBuffer instanceof SharedArrayBuffer;
+                }
+                return this.copyToChannelNeedsSlice;
+            },
+            // Disabled-by-default trace hook for tuning browser-specific queue behavior.
+            _debugLogQueueResize: function(reason, previousBufferCount, newBufferCount, previousSeconds, seconds) {
+                // Uncomment while tuning browser-specific HTML5 audio queue behavior.
+                /*
+                var floorSeconds = this._getAdaptiveQueueFloorSeconds();
+                console.log("sound queue resize (" + reason + "): buffers " +
+                    previousBufferCount + " -> " + newBufferCount +
+                    ", seconds " + previousSeconds.toFixed(3) + " -> " +
+                    seconds.toFixed(3) +
+                    ", latency floor " + this.latencyQueueFloorSeconds.toFixed(3) +
+                    ", floor " + floorSeconds.toFixed(3) +
+                    ", learned " + this.learnedQueueFloorSeconds.toFixed(3) +
+                    ", buffer " + this.bufferDuration.toFixed(3));
+                */
+            },
+            // Restart the stable-playback timer after underruns or context state changes.
+            _resetQueueDecay: function(audioTime) {
+                this.lastUnderrunTime = audioTime;
+                this.lastQueueDecayTime = audioTime;
+            },
+            // Convert a target queue duration into the buffer count reported to native code.
+            _queueSecondsToBufferCount: function(seconds) {
+                if (this.bufferDuration <= 0) {
+                    return bufferCount;
+                }
+                return Math.max(
+                    bufferCount,
+                    Math.ceil(seconds / this.bufferDuration)
+                );
+            },
+            // Keep the queue from decaying below browser latency or observed underrun needs.
+            _getAdaptiveQueueFloorSeconds: function() {
+                return Math.max(
+                    this.latencyQueueFloorSeconds,
+                    this.learnedQueueFloorSeconds
+                );
+            },
+            // Recompute the effective buffer count used by _freeBufferSlots().
+            _updateEffectiveBufferCount: function(reason, previousAdaptiveQueueSeconds) {
+                var previousEffectiveBufferCount = this.effectiveBufferCount;
+                if (this.bufferDuration <= 0) {
+                    this.effectiveBufferCount = bufferCount;
+                    return;
+                }
+
+                this.adaptiveQueueSeconds = Math.min(this.adaptiveQueueSeconds, maxAdaptiveQueueSeconds);
+                this.effectiveBufferCount = this._queueSecondsToBufferCount(this.adaptiveQueueSeconds);
+                if (this.effectiveBufferCount != previousEffectiveBufferCount) {
+                    this._debugLogQueueResize(
+                        reason,
+                        previousEffectiveBufferCount,
+                        this.effectiveBufferCount,
+                        previousAdaptiveQueueSeconds,
+                        this.adaptiveQueueSeconds
+                    );
+                }
+            },
+            // Raise the queue target from browser-reported latency without shrinking it.
+            _updateQueueTarget: function() {
+                var audioCtx = shared.audioCtx;
+                if (audioCtx === undefined) {
+                    return;
+                }
+                var reportedLatency = Math.max(audioCtx.outputLatency || 0, audioCtx.baseLatency || 0);
+                var latencyQueueSeconds = reportedLatency > 0 ? reportedLatency * outputLatencyQueueScale : 0;
+                var targetQueueSeconds = Math.min(
+                    Math.max(bufferCount * this.bufferDuration, latencyQueueSeconds),
+                    maxAdaptiveQueueSeconds
+                );
+                this.latencyQueueFloorSeconds = Math.max(this.latencyQueueFloorSeconds, targetQueueSeconds);
+
+                var previousAdaptiveQueueSeconds = this.adaptiveQueueSeconds;
+                this.adaptiveQueueSeconds = Math.max(
+                    this.adaptiveQueueSeconds,
+                    this._getAdaptiveQueueFloorSeconds()
+                );
+                this._updateEffectiveBufferCount("target", previousAdaptiveQueueSeconds);
+            },
+            // Increase the queue after active-playback starvation and remember the new floor.
+            _growQueueAfterUnderrun: function(audioTime) {
+                this._resetQueueDecay(audioTime);
+                if (this.bufferDuration <= 0) {
+                    return;
+                }
+
+                var previousEffectiveBufferCount = this.effectiveBufferCount;
+                var previousAdaptiveQueueSeconds = this.adaptiveQueueSeconds;
+                var previousFloorSeconds = this._getAdaptiveQueueFloorSeconds();
+                var previousFloorBufferCount = this._queueSecondsToBufferCount(previousFloorSeconds);
+
+                this.learnedQueueFloorSeconds = Math.min(
+                    maxAdaptiveQueueSeconds,
+                    Math.max(
+                        this.learnedQueueFloorSeconds,
+                        (previousEffectiveBufferCount + 1) * this.bufferDuration
+                    )
+                );
+
+                var floorSeconds = this._getAdaptiveQueueFloorSeconds();
+                if (floorSeconds != previousFloorSeconds) {
+                    this._debugLogQueueResize(
+                        "floor",
+                        previousFloorBufferCount,
+                        this._queueSecondsToBufferCount(floorSeconds),
+                        previousFloorSeconds,
+                        floorSeconds
+                    );
+                }
+
+                this.adaptiveQueueSeconds = Math.min(
+                    maxAdaptiveQueueSeconds,
+                    Math.max(
+                        this.adaptiveQueueSeconds * 1.5,
+                        this.adaptiveQueueSeconds + this.bufferDuration
+                    )
+                );
+                this._updateEffectiveBufferCount("underrun", previousAdaptiveQueueSeconds);
+            },
+            // Slowly reduce the queue after sustained playback, down to the current floor.
+            _decayQueueAfterStablePlayback: function(audioTime) {
+                var floorSeconds = this._getAdaptiveQueueFloorSeconds();
+                if (this.bufferDuration <= 0 || this.adaptiveQueueSeconds <= floorSeconds) {
+                    return;
+                }
+
+                if (audioTime - this.lastUnderrunTime < stablePlaybackSecondsBeforeDecay) {
+                    this.lastQueueDecayTime = audioTime;
+                    return;
+                }
+
+                var elapsed = audioTime - this.lastQueueDecayTime;
+                if (elapsed <= 0) {
+                    return;
+                }
+
+                var decay = elapsed * this.bufferDuration * queueDecayBufferRate;
+                var previousAdaptiveQueueSeconds = this.adaptiveQueueSeconds;
+                this.adaptiveQueueSeconds = Math.max(
+                    floorSeconds,
+                    this.adaptiveQueueSeconds - decay
+                );
+                this.lastQueueDecayTime = audioTime;
+                this._updateEffectiveBufferCount("decay", previousAdaptiveQueueSeconds);
+            },
+            _markPlaybackStarted: function() {
+                var audioTime = this._isContextRunning() ? (shared.audioCtx.currentTime || 0) : 0;
+                this.ignoreNextUnderrun = true;
+                this._resetQueueDecay(audioTime);
+            },
+            _markPlaybackIdle: function() {
+                // Mark idle so the next start doesn't learn the stale queue gap as an underrun.
+                // Already scheduled WebAudio buffers are left to finish naturally.
+                var audioTime = this._isContextRunning() ? (shared.audioCtx.currentTime || 0) : 0;
+                this.ignoreNextUnderrun = true;
+                this._resetQueueDecay(audioTime);
+            },
+            _queue: function(samples, frame_count) {
+                var lastBufferDuration = this.bufferDuration;
+                var len = frame_count / this.sampleRate;
+                // use real buffer length next time.
+                this.bufferDuration = len;
+
+                // Advance a wall-clock queue while Web Audio is unavailable or autoplay-suspended.
+                // This lets the native mixer reach end-of-stream and recycle sound instances.
+                if (!this._isContextRunning()) {
+                    this._queueSilently(len);
+                    return;
+                }
+
+                var audioCtx = shared.audioCtx;
+                try {
+                    this._updateQueueTarget();
+
+                    // Setup buffer for data delivery...
+                    var buf = audioCtx.createBuffer(2, frame_count, this.sampleRate);
+
+                    // Copy data from WASM memory
+                    var heapBuffer = HEAPF32.buffer;
+                    var needsCopy = this._needsCopyToChannelSlice(heapBuffer);
+                    for(var c=0;c<2;c++) {
+                        var input = new Float32Array(heapBuffer, samples, frame_count);
+                        // copyToChannel cannot handle SharedArrayBuffer views, so threaded builds need a non-shared copy.
+                        buf.copyToChannel(needsCopy ? input.slice() : input, c);
+                        samples += frame_count * 4; // 4 bytes = sizeof(float)
+                    }
+                    var source = audioCtx.createBufferSource();
+                    source.buffer = buf;
+                    source.connect(audioCtx.destination);
+                    this._trackActiveSource(source);
+
+                    var t = audioCtx.currentTime;
+                    var startTime;
+                    var firstBuffer = lastBufferDuration == 0.0;
+                    var bufferedToSeconds = this.bufferedTo / this.sampleRate;
+                    var underrun = !firstBuffer && bufferedToSeconds <= t;
+
+                    if (underrun) {
+                        // Suppress expected gaps after suspend/resume or an idle restart.
+                        // Other underruns are active-playback starvation and should grow the adaptive queue.
+                        if (this.ignoreNextUnderrun) {
+                            this.ignoreNextUnderrun = false;
+                            this._resetQueueDecay(t);
+                        } else {
+                            this._growQueueAfterUnderrun(t);
+                        }
+                    } else {
+                        this.ignoreNextUnderrun = false;
+                        if (!firstBuffer) {
+                            this._decayQueueAfterStablePlayback(t);
+                        }
+                    }
+
+                    // Underrun or first buffer?
+                    if (underrun || firstBuffer) {
+                        // Yes, restart buffering - offset is always computed based on queue length...
+                        var off = (this.effectiveBufferCount - 1) * this.bufferDuration;
+                        startTime = t + off;
+                        this.bufferedTo = startTime * this.sampleRate;
+                    } else {
+                        // No, normal delivery...
+                        startTime = this.bufferedTo / this.sampleRate;
+                    }
+                    source.start(startTime);
+                    this.bufferedTo += frame_count;
+                } catch (e) {
+                    DefoldSoundDevice.HandleAudioFailure(shared, audioCtx);
+                    this._queueSilently(len);
+                }
+            },
+            _freeBufferSlots: function() {
+                // Always permit the first mix buffer so bufferDuration becomes known in silent mode too.
+                if (this.bufferDuration <= 0) {
+                    return 1;
+                }
+
+                var ahead = 0;
+                if (this._isContextRunning()) {
+                    ahead = this.bufferedTo / this.sampleRate - shared.audioCtx.currentTime;
+                } else {
+                    // if audio context in suspended or closed state we simulate audio play
+                    // by calculating play time
+                    // when audio context become active - start filling audio buffer from the beginning
+                    // and start using audioCtx.currentTime
+                    ahead = this.suspendedBufferedTo - this._getCurrentSuspendedTime();
+                }
+                var inqueue = Math.ceil(ahead / this.bufferDuration);
+                if (inqueue < 0) {
+                    inqueue = 0;
+                }
+                var left = this.effectiveBufferCount - inqueue;
+                if (left < 0) {
+                    return 0;
+                }
+                return left;
+            }
+        };
 
         shared.devices[id] = device;
         DefoldSoundDevice.InstallDeviceChangeListener(shared);
@@ -642,47 +648,36 @@ var LibrarySoundDevice =
     dmDeviceJSClose__sig: 'vi',
 
     dmDeviceJSPlaybackStarted: function(id) {
-        var root = DefoldSoundDevice.GetGlobal();
-        var shared = root !== undefined ? root._dmJSDeviceShared : undefined;
-        if (shared !== undefined && shared.devices[id] !== undefined) {
-            shared.devices[id]._markPlaybackStarted();
-        }
+        var shared = DefoldSoundDevice.GetGlobal()._dmJSDeviceShared;
+        shared.devices[id]._markPlaybackStarted();
     },
     dmDeviceJSPlaybackStarted__proxy: 'sync',
     dmDeviceJSPlaybackStarted__sig: 'vi',
 
     dmDeviceJSPlaybackIdle: function(id) {
-        var root = DefoldSoundDevice.GetGlobal();
-        var shared = root !== undefined ? root._dmJSDeviceShared : undefined;
-        if (shared !== undefined && shared.devices[id] !== undefined) {
-            shared.devices[id]._markPlaybackIdle();
-        }
+        var shared = DefoldSoundDevice.GetGlobal()._dmJSDeviceShared;
+        shared.devices[id]._markPlaybackIdle();
     },
     dmDeviceJSPlaybackIdle__proxy: 'sync',
     dmDeviceJSPlaybackIdle__sig: 'vi',
 
     dmDeviceJSQueue: function(id, samples, sample_count) {
-        var root = DefoldSoundDevice.GetGlobal();
-        var shared = root !== undefined ? root._dmJSDeviceShared : undefined;
-        if (shared !== undefined && shared.devices[id] !== undefined) {
-            shared.devices[id]._queue(samples, sample_count);
-        }
+        var shared = DefoldSoundDevice.GetGlobal()._dmJSDeviceShared;
+        shared.devices[id]._queue(samples, sample_count);
     },
     dmDeviceJSQueue__proxy: 'sync',
     dmDeviceJSQueue__sig: 'viii',
 
     dmDeviceJSFreeBufferSlots: function(id) {
-        var root = DefoldSoundDevice.GetGlobal();
-        var shared = root !== undefined ? root._dmJSDeviceShared : undefined;
-        return shared !== undefined && shared.devices[id] !== undefined ? shared.devices[id]._freeBufferSlots() : 0;
+        var shared = DefoldSoundDevice.GetGlobal()._dmJSDeviceShared;
+        return shared.devices[id]._freeBufferSlots();
     },
     dmDeviceJSFreeBufferSlots__proxy: 'sync',
     dmDeviceJSFreeBufferSlots__sig: 'ii',
 
     dmGetDeviceSampleRate: function(id) {
-        var root = DefoldSoundDevice.GetGlobal();
-        var shared = root !== undefined ? root._dmJSDeviceShared : undefined;
-        return shared !== undefined && shared.devices[id] !== undefined ? shared.devices[id].sampleRate : 48000;
+        var shared = DefoldSoundDevice.GetGlobal()._dmJSDeviceShared;
+        return shared.devices[id].sampleRate;
     },
 }
 

--- a/engine/sound/src/js/library_sound.js
+++ b/engine/sound/src/js/library_sound.js
@@ -1,53 +1,264 @@
 var LibrarySoundDevice =
 {
     $DefoldSoundDevice: {
-        TryResumeAudio: function() {
-            if (typeof window !== "undefined" && window._dmJSDeviceShared) {
-                var audioCtx = window._dmJSDeviceShared.audioCtx;
-                if (audioCtx !== undefined && audioCtx.state != "running") {
-                    audioCtx.resume();
+        GetGlobal: function() {
+            if (typeof globalThis !== "undefined") {
+                return globalThis;
+            }
+            if (typeof window !== "undefined") {
+                return window;
+            }
+            if (typeof self !== "undefined") {
+                return self;
+            }
+            return undefined;
+        },
+        Now: function() {
+            return Date.now() / 1000;
+        },
+        ForEachDevice: function(shared, callback) {
+            for (var id in shared.devices) {
+                if (Object.prototype.hasOwnProperty.call(shared.devices, id)) {
+                    callback(shared.devices[id]);
                 }
+            }
+        },
+        HasDevices: function(shared) {
+            for (var id in shared.devices) {
+                if (Object.prototype.hasOwnProperty.call(shared.devices, id)) {
+                    return true;
+                }
+            }
+            return false;
+        },
+        WarnSilentFallback: function(shared) {
+            shared.openedSilently = true;
+            if (!shared.fallbackLogged && typeof console !== "undefined" && console.warn) {
+                console.warn("DEFOLD: Web Audio is unavailable. Continuing with silent audio and retrying every 2 seconds.");
+                shared.fallbackLogged = true;
+            }
+        },
+        NotifyContextStateChanged: function(shared) {
+            var audioCtx = shared.audioCtx;
+            var running = audioCtx !== undefined && audioCtx.state == "running";
+            if (running != shared.contextRunning) {
+                shared.contextRunning = running;
+                DefoldSoundDevice.ForEachDevice(shared, function(device) {
+                    device._onContextStateChanged(running);
+                });
+            }
+
+            if (running) {
+                if (shared.retryTimer !== null) {
+                    var root = DefoldSoundDevice.GetGlobal();
+                    if (root !== undefined && root.clearTimeout) {
+                        root.clearTimeout(shared.retryTimer);
+                    }
+                    shared.retryTimer = null;
+                }
+                if (shared.openedSilently && !shared.recoveryLogged && typeof console !== "undefined" && console.info) {
+                    console.info("DEFOLD: Web Audio became available. Switching from silent audio to normal output.");
+                    shared.recoveryLogged = true;
+                }
+            } else {
+                DefoldSoundDevice.ScheduleAudioRetry(shared);
+            }
+        },
+        HandleAudioFailure: function(shared, failedContext) {
+            if (failedContext !== undefined && shared.audioCtx !== failedContext) {
+                return;
+            }
+
+            var audioCtx = shared.audioCtx;
+            shared.audioCtx = undefined;
+            shared.resumePending = false;
+            if (audioCtx !== undefined) {
+                audioCtx.onstatechange = null;
+                if (audioCtx.state != "closed" && audioCtx.close) {
+                    try {
+                        var closeResult = audioCtx.close();
+                        if (closeResult && closeResult.catch) {
+                            closeResult.catch(function() {});
+                        }
+                    } catch (e) {
+                    }
+                }
+            }
+
+            DefoldSoundDevice.WarnSilentFallback(shared);
+            DefoldSoundDevice.NotifyContextStateChanged(shared);
+        },
+        TryCreateAudioContext: function(shared) {
+            if (shared.audioCtx !== undefined && shared.audioCtx.state != "closed") {
+                return shared.audioCtx;
+            }
+
+            shared.audioCtx = undefined;
+            var root = DefoldSoundDevice.GetGlobal();
+            var audioCtxCtor = root !== undefined ? (root.AudioContext || root.webkitAudioContext) : undefined;
+            if (audioCtxCtor === undefined) {
+                return undefined;
+            }
+
+            var audioCtx;
+            try {
+                audioCtx = new audioCtxCtor({ sampleRate: 48000 });
+            } catch (e) {
+                try {
+                    audioCtx = new audioCtxCtor();
+                } catch (fallbackError) {
+                    return undefined;
+                }
+            }
+
+            if (audioCtx === undefined || audioCtx.state == "closed") {
+                return undefined;
+            }
+
+            shared.audioCtx = audioCtx;
+            shared.resumePending = false;
+            audioCtx.onstatechange = function() {
+                if (shared.audioCtx !== audioCtx) {
+                    return;
+                }
+                if (audioCtx.state == "closed") {
+                    DefoldSoundDevice.HandleAudioFailure(shared, audioCtx);
+                } else {
+                    DefoldSoundDevice.NotifyContextStateChanged(shared);
+                }
+            };
+            DefoldSoundDevice.NotifyContextStateChanged(shared);
+            return audioCtx;
+        },
+        TryResumeSharedAudio: function(shared, forceResume) {
+            var audioCtx = DefoldSoundDevice.TryCreateAudioContext(shared);
+            if (audioCtx === undefined) {
+                DefoldSoundDevice.WarnSilentFallback(shared);
+                DefoldSoundDevice.ScheduleAudioRetry(shared);
+                return;
+            }
+
+            if (audioCtx.state != "running" && audioCtx.resume && (!shared.resumePending || forceResume)) {
+                try {
+                    var resumeResult = audioCtx.resume();
+                    if (resumeResult && resumeResult.then) {
+                        shared.resumePending = true;
+                        resumeResult.then(function() {
+                            shared.resumePending = false;
+                            if (shared.audioCtx === audioCtx) {
+                                DefoldSoundDevice.NotifyContextStateChanged(shared);
+                            }
+                        }, function() {
+                            shared.resumePending = false;
+                            if (shared.audioCtx === audioCtx && audioCtx.state == "closed") {
+                                DefoldSoundDevice.HandleAudioFailure(shared, audioCtx);
+                            } else {
+                                DefoldSoundDevice.ScheduleAudioRetry(shared);
+                            }
+                        });
+                    }
+                } catch (e) {
+                    DefoldSoundDevice.HandleAudioFailure(shared, audioCtx);
+                    return;
+                }
+            }
+
+            if (audioCtx.state == "running") {
+                DefoldSoundDevice.NotifyContextStateChanged(shared);
+            } else {
+                DefoldSoundDevice.ScheduleAudioRetry(shared);
+            }
+        },
+        ScheduleAudioRetry: function(shared) {
+            if (shared.retryTimer !== null || !DefoldSoundDevice.HasDevices(shared)) {
+                return;
+            }
+
+            var root = DefoldSoundDevice.GetGlobal();
+            if (root === undefined || !root.setTimeout) {
+                return;
+            }
+
+            shared.retryTimer = root.setTimeout(function() {
+                shared.retryTimer = null;
+                if (!DefoldSoundDevice.HasDevices(shared)) {
+                    return;
+                }
+                DefoldSoundDevice.TryResumeSharedAudio(shared, false);
+            }, 2000);
+        },
+        InstallDeviceChangeListener: function(shared) {
+            if (shared.deviceChangeHandler !== null) {
+                return;
+            }
+
+            var root = DefoldSoundDevice.GetGlobal();
+            var mediaDevices = root !== undefined && root.navigator ? root.navigator.mediaDevices : undefined;
+            if (mediaDevices && mediaDevices.addEventListener) {
+                shared.deviceChangeHandler = function() {
+                    DefoldSoundDevice.TryResumeSharedAudio(shared, true);
+                };
+                mediaDevices.addEventListener("devicechange", shared.deviceChangeHandler);
+            }
+        },
+        RemoveDeviceChangeListener: function(shared) {
+            if (shared.deviceChangeHandler === null) {
+                return;
+            }
+
+            var root = DefoldSoundDevice.GetGlobal();
+            var mediaDevices = root !== undefined && root.navigator ? root.navigator.mediaDevices : undefined;
+            if (mediaDevices && mediaDevices.removeEventListener) {
+                mediaDevices.removeEventListener("devicechange", shared.deviceChangeHandler);
+            }
+            shared.deviceChangeHandler = null;
+        },
+        TryResumeAudio: function() {
+            var root = DefoldSoundDevice.GetGlobal();
+            if (root !== undefined && root._dmJSDeviceShared) {
+                DefoldSoundDevice.TryResumeSharedAudio(root._dmJSDeviceShared, true);
             }
         }
     },
     dmDeviceJSOpen: function(bufferCount) {
-        if (typeof window === "undefined" || (!window.AudioContext && !window.webkitAudioContext)) {
+        var root = DefoldSoundDevice.GetGlobal();
+        if (root === undefined) {
             return -1;
         }
 
         // globally shared data
-        var shared = window._dmJSDeviceShared;
+        var shared = root._dmJSDeviceShared;
         if (shared === undefined) {
             shared = {
                 count: 0,
-                devices: {}
+                devices: {},
+                audioCtx: undefined,
+                retryTimer: null,
+                deviceChangeHandler: null,
+                fallbackLogged: false,
+                recoveryLogged: false,
+                openedSilently: false,
+                contextRunning: false,
+                resumePending: false
             };
-            window._dmJSDeviceShared = shared;
+            root._dmJSDeviceShared = shared;
         }
 
         var id = shared.count++;
-        var device;
+        var audioCtx = DefoldSoundDevice.TryCreateAudioContext(shared);
+        var sampleRate = audioCtx !== undefined ? audioCtx.sampleRate : 48000;
+        if (audioCtx === undefined) {
+            DefoldSoundDevice.WarnSilentFallback(shared);
+        }
 
-        if (window.AudioContext || window.webkitAudioContext) {
-            if (shared.audioCtx === undefined) {
-                var audioCtxCtor = window.AudioContext || window.webkitAudioContext;
-                try {
-                    // The default sampleRate varies depending on the output device and can be less than 44100.
-                    shared.audioCtx = new audioCtxCtor({ sampleRate: 48000 });
-                } catch (e) {
-                    // Fallback if the specified sampleRate isn't supported by the browser.
-                    shared.audioCtx = new audioCtxCtor();
-                }
-            }
+        var maxAdaptiveQueueSeconds = 0.250;
+        var outputLatencyQueueScale = 0.5;
+        var stablePlaybackSecondsBeforeDecay = 3.0;
+        var queueDecayBufferRate = 0.5;
 
-            var maxAdaptiveQueueSeconds = 0.250;
-            var outputLatencyQueueScale = 0.5;
-            var stablePlaybackSecondsBeforeDecay = 3.0;
-            var queueDecayBufferRate = 0.5;
-
-            // Construct web audio device.
-            device = {
-                sampleRate: shared.audioCtx.sampleRate,
+        // Construct a device that uses Web Audio when it is running and a clocked silent queue otherwise.
+        var device = {
+                sampleRate: sampleRate,
                 bufferedTo: 0,
                 bufferDuration: 0,
                 effectiveBufferCount: bufferCount,
@@ -58,20 +269,67 @@ var LibrarySoundDevice =
                 lastQueueDecayTime: 0,
                 ignoreNextUnderrun: false,
                 copyToChannelNeedsSlice: null,
-                creatingTime: Date.now() / 1000,
-                lastTimeInSuspendedState: Date.now() / 1000,
+                activeSources: [],
+                creatingTime: DefoldSoundDevice.Now(),
+                lastTimeInSuspendedState: DefoldSoundDevice.Now(),
                 suspendedBufferedTo: 0,
                 // functions
                 _isContextRunning: function() {
-                    var audioCtx = window._dmJSDeviceShared.audioCtx;
-                    return audioCtx !== undefined && audioCtx.state == "running"
+                    var audioCtx = shared.audioCtx;
+                    return audioCtx !== undefined && audioCtx.state == "running";
                 },
                 _getCurrentSuspendedTime: function() {
                     if (!this._isContextRunning()) {
-                        this.lastTimeInSuspendedState = Date.now() / 1000;
+                        this.lastTimeInSuspendedState = DefoldSoundDevice.Now();
                         return this.lastTimeInSuspendedState - this.creatingTime;
                     }
                     return 0;
+                },
+                _onContextStateChanged: function(running) {
+                    var now = DefoldSoundDevice.Now();
+                    var audioTime = running && shared.audioCtx !== undefined ? (shared.audioCtx.currentTime || 0) : 0;
+                    if (!running) {
+                        this._cancelActiveSources();
+                    }
+                    this._resetQueueDecay(audioTime);
+                    this.creatingTime = now;
+                    this.lastTimeInSuspendedState = now;
+                    this.suspendedBufferedTo = 0;
+                    this.ignoreNextUnderrun = true;
+                    if (running) {
+                        // Force the first real buffer to start from the recovered context's current time.
+                        this.bufferedTo = 0;
+                    }
+                },
+                _cancelActiveSources: function() {
+                    for (var i = 0; i < this.activeSources.length; ++i) {
+                        var source = this.activeSources[i];
+                        source.onended = null;
+                        try {
+                            source.stop();
+                        } catch (e) {
+                        }
+                        try {
+                            source.disconnect();
+                        } catch (e) {
+                        }
+                    }
+                    this.activeSources.length = 0;
+                },
+                _trackActiveSource: function(source) {
+                    var device = this;
+                    this.activeSources.push(source);
+                    source.onended = function() {
+                        var index = device.activeSources.indexOf(source);
+                        if (index != -1) {
+                            device.activeSources.splice(index, 1);
+                        }
+                    };
+                },
+                _queueSilently: function(bufferDuration) {
+                    var suspendedTime = this._getCurrentSuspendedTime();
+                    this.suspendedBufferedTo = Math.max(this.suspendedBufferedTo, suspendedTime) + bufferDuration;
+                    this.ignoreNextUnderrun = true;
                 },
                 // Cache whether WebAudio needs a non-shared copy from WASM memory.
                 _needsCopyToChannelSlice: function(heapBuffer) {
@@ -140,6 +398,9 @@ var LibrarySoundDevice =
                 // Raise the queue target from browser-reported latency without shrinking it.
                 _updateQueueTarget: function() {
                     var audioCtx = shared.audioCtx;
+                    if (audioCtx === undefined) {
+                        return;
+                    }
                     var reportedLatency = Math.max(audioCtx.outputLatency || 0, audioCtx.baseLatency || 0);
                     var latencyQueueSeconds = reportedLatency > 0 ? reportedLatency * outputLatencyQueueScale : 0;
                     var targetQueueSeconds = Math.min(
@@ -222,14 +483,14 @@ var LibrarySoundDevice =
                     this._updateEffectiveBufferCount("decay", previousAdaptiveQueueSeconds);
                 },
                 _markPlaybackStarted: function() {
-                    var audioTime = shared.audioCtx.currentTime || 0;
+                    var audioTime = this._isContextRunning() ? (shared.audioCtx.currentTime || 0) : 0;
                     this.ignoreNextUnderrun = true;
                     this._resetQueueDecay(audioTime);
                 },
                 _markPlaybackIdle: function() {
                     // Mark idle so the next start doesn't learn the stale queue gap as an underrun.
                     // Already scheduled WebAudio buffers are left to finish naturally.
-                    var audioTime = shared.audioCtx.currentTime || 0;
+                    var audioTime = this._isContextRunning() ? (shared.audioCtx.currentTime || 0) : 0;
                     this.ignoreNextUnderrun = true;
                     this._resetQueueDecay(audioTime);
                 },
@@ -239,74 +500,81 @@ var LibrarySoundDevice =
                     // use real buffer length next time.
                     this.bufferDuration = len;
 
-                    this._updateQueueTarget();
-
-                    // only append overall length of audio buffer in suspended stay
-                    // it helps prevent sound instance consume on the engine side
-                    // because from engine point of view - sound plays.
+                    // Advance a wall-clock queue while Web Audio is unavailable or autoplay-suspended.
+                    // This lets the native mixer reach end-of-stream and recycle sound instances.
                     if (!this._isContextRunning()) {
-                        this.suspendedBufferedTo += len;
-                        this.ignoreNextUnderrun = true;
+                        this._queueSilently(len);
                         return;
                     }
 
-                    // Setup buffer for data delivery...
-                    var buf = shared.audioCtx.createBuffer(2, frame_count, this.sampleRate);
+                    var audioCtx = shared.audioCtx;
+                    try {
+                        this._updateQueueTarget();
 
-                    // Copy data from WASM memory
-                    var heapBuffer = HEAPF32.buffer;
-                    var needsCopy = this._needsCopyToChannelSlice(heapBuffer);
-                    for(var c=0;c<2;c++) {
-                        var input = new Float32Array(heapBuffer, samples, frame_count);
-                        // copyToChannel cannot handle SharedArrayBuffer views, so threaded builds need a non-shared copy.
-                        buf.copyToChannel(needsCopy ? input.slice() : input, c);
-                        samples += frame_count * 4; // 4 bytes = sizeof(float)
-                    }
-                    var source = shared.audioCtx.createBufferSource();
-                    source.buffer = buf;
-                    source.connect(shared.audioCtx.destination);
+                        // Setup buffer for data delivery...
+                        var buf = audioCtx.createBuffer(2, frame_count, this.sampleRate);
 
-                    var t = shared.audioCtx.currentTime;
-                    var startTime;
-                    var firstBuffer = lastBufferDuration == 0.0;
-                    var bufferedToSeconds = this.bufferedTo / this.sampleRate;
-                    var underrun = !firstBuffer && bufferedToSeconds <= t;
+                        // Copy data from WASM memory
+                        var heapBuffer = HEAPF32.buffer;
+                        var needsCopy = this._needsCopyToChannelSlice(heapBuffer);
+                        for(var c=0;c<2;c++) {
+                            var input = new Float32Array(heapBuffer, samples, frame_count);
+                            // copyToChannel cannot handle SharedArrayBuffer views, so threaded builds need a non-shared copy.
+                            buf.copyToChannel(needsCopy ? input.slice() : input, c);
+                            samples += frame_count * 4; // 4 bytes = sizeof(float)
+                        }
+                        var source = audioCtx.createBufferSource();
+                        source.buffer = buf;
+                        source.connect(audioCtx.destination);
+                        this._trackActiveSource(source);
 
-                    if (underrun) {
-                        // Suppress expected gaps after suspend/resume or an idle restart.
-                        // Other underruns are active-playback starvation and should grow the adaptive queue.
-                        if (this.ignoreNextUnderrun) {
-                            this.ignoreNextUnderrun = false;
-                            this._resetQueueDecay(t);
+                        var t = audioCtx.currentTime;
+                        var startTime;
+                        var firstBuffer = lastBufferDuration == 0.0;
+                        var bufferedToSeconds = this.bufferedTo / this.sampleRate;
+                        var underrun = !firstBuffer && bufferedToSeconds <= t;
+
+                        if (underrun) {
+                            // Suppress expected gaps after suspend/resume or an idle restart.
+                            // Other underruns are active-playback starvation and should grow the adaptive queue.
+                            if (this.ignoreNextUnderrun) {
+                                this.ignoreNextUnderrun = false;
+                                this._resetQueueDecay(t);
+                            } else {
+                                this._growQueueAfterUnderrun(t);
+                            }
                         } else {
-                            this._growQueueAfterUnderrun(t);
+                            this.ignoreNextUnderrun = false;
+                            if (!firstBuffer) {
+                                this._decayQueueAfterStablePlayback(t);
+                            }
                         }
-                    } else {
-                        this.ignoreNextUnderrun = false;
-                        if (!firstBuffer) {
-                            this._decayQueueAfterStablePlayback(t);
-                        }
-                    }
 
-                    // Underrun or first buffer?
-                    if (underrun || firstBuffer) {
-                        // Yes, restart buffering - offset is always computed based on queue length...
-                        var off = (this.effectiveBufferCount - 1) * this.bufferDuration;
-                        startTime = t + off;
-                        this.bufferedTo = startTime * this.sampleRate;
-                    } else {
-                        // No, normal delivery...
-                        startTime = this.bufferedTo / this.sampleRate;
+                        // Underrun or first buffer?
+                        if (underrun || firstBuffer) {
+                            // Yes, restart buffering - offset is always computed based on queue length...
+                            var off = (this.effectiveBufferCount - 1) * this.bufferDuration;
+                            startTime = t + off;
+                            this.bufferedTo = startTime * this.sampleRate;
+                        } else {
+                            // No, normal delivery...
+                            startTime = this.bufferedTo / this.sampleRate;
+                        }
+                        source.start(startTime);
+                        this.bufferedTo += frame_count;
+                    } catch (e) {
+                        DefoldSoundDevice.HandleAudioFailure(shared, audioCtx);
+                        this._queueSilently(len);
                     }
-                    source.start(startTime);
-                    this.bufferedTo += frame_count;
                 },
                 _freeBufferSlots: function() {
+                    // Always permit the first mix buffer so bufferDuration becomes known in silent mode too.
+                    if (this.bufferDuration <= 0) {
+                        return 1;
+                    }
+
                     var ahead = 0;
                     if (this._isContextRunning()) {
-                        // before knowing the length of each buffer, we return a dummy count to enable initial delivery
-                        if (this.bufferDuration == 0)
-                            return 1;
                         ahead = this.bufferedTo / this.sampleRate - shared.audioCtx.currentTime;
                     } else {
                         // if audio context in suspended or closed state we simulate audio play
@@ -326,57 +594,95 @@ var LibrarySoundDevice =
                     return left;
                 }
             };
-        }
 
-        if (device != null) {
-            shared.audioCtx.onstatechange = function() {
-                var audioTime = shared.audioCtx.currentTime || 0;
-                device._resetQueueDecay(audioTime);
-                if (device._isContextRunning()) {
-                    device.timeInSuspendedState = Date.now() / 1000;
-                    device.ignoreNextUnderrun = true;
-                } else {
-                    // reset all counters for suspended or closed state
-                    device.creatingTime = Date.now() / 1000;
-                    device.lastTimeInSuspendedState = Date.now() / 1000;
-                    device.suspendedBufferedTo = 0;
-                    device.ignoreNextUnderrun = true;
-                }
-            };
-            shared.devices[id] = device;
-            return id;
-        }
-        return -1;
+        shared.devices[id] = device;
+        DefoldSoundDevice.InstallDeviceChangeListener(shared);
+        DefoldSoundDevice.NotifyContextStateChanged(shared);
+        return id;
     },
     dmDeviceJSOpen__proxy: 'sync',
     dmDeviceJSOpen__sig: 'ii',
 
+    dmDeviceJSClose: function(id) {
+        var root = DefoldSoundDevice.GetGlobal();
+        var shared = root !== undefined ? root._dmJSDeviceShared : undefined;
+        if (shared === undefined || shared.devices[id] === undefined) {
+            return;
+        }
+
+        shared.devices[id]._cancelActiveSources();
+        delete shared.devices[id];
+        if (DefoldSoundDevice.HasDevices(shared)) {
+            return;
+        }
+
+        if (shared.retryTimer !== null && root.clearTimeout) {
+            root.clearTimeout(shared.retryTimer);
+            shared.retryTimer = null;
+        }
+        DefoldSoundDevice.RemoveDeviceChangeListener(shared);
+
+        var audioCtx = shared.audioCtx;
+        shared.audioCtx = undefined;
+        if (audioCtx !== undefined) {
+            audioCtx.onstatechange = null;
+            if (audioCtx.state != "closed" && audioCtx.close) {
+                try {
+                    var closeResult = audioCtx.close();
+                    if (closeResult && closeResult.catch) {
+                        closeResult.catch(function() {});
+                    }
+                } catch (e) {
+                }
+            }
+        }
+        delete root._dmJSDeviceShared;
+    },
+    dmDeviceJSClose__proxy: 'sync',
+    dmDeviceJSClose__sig: 'vi',
+
     dmDeviceJSPlaybackStarted: function(id) {
-        window._dmJSDeviceShared.devices[id]._markPlaybackStarted();
+        var root = DefoldSoundDevice.GetGlobal();
+        var shared = root !== undefined ? root._dmJSDeviceShared : undefined;
+        if (shared !== undefined && shared.devices[id] !== undefined) {
+            shared.devices[id]._markPlaybackStarted();
+        }
     },
     dmDeviceJSPlaybackStarted__proxy: 'sync',
     dmDeviceJSPlaybackStarted__sig: 'vi',
 
     dmDeviceJSPlaybackIdle: function(id) {
-        window._dmJSDeviceShared.devices[id]._markPlaybackIdle();
+        var root = DefoldSoundDevice.GetGlobal();
+        var shared = root !== undefined ? root._dmJSDeviceShared : undefined;
+        if (shared !== undefined && shared.devices[id] !== undefined) {
+            shared.devices[id]._markPlaybackIdle();
+        }
     },
     dmDeviceJSPlaybackIdle__proxy: 'sync',
     dmDeviceJSPlaybackIdle__sig: 'vi',
 
     dmDeviceJSQueue: function(id, samples, sample_count) {
-        window._dmJSDeviceShared.devices[id]._queue(samples, sample_count)
+        var root = DefoldSoundDevice.GetGlobal();
+        var shared = root !== undefined ? root._dmJSDeviceShared : undefined;
+        if (shared !== undefined && shared.devices[id] !== undefined) {
+            shared.devices[id]._queue(samples, sample_count);
+        }
     },
     dmDeviceJSQueue__proxy: 'sync',
     dmDeviceJSQueue__sig: 'viii',
 
     dmDeviceJSFreeBufferSlots: function(id) {
-        return window._dmJSDeviceShared.devices[id]._freeBufferSlots();
+        var root = DefoldSoundDevice.GetGlobal();
+        var shared = root !== undefined ? root._dmJSDeviceShared : undefined;
+        return shared !== undefined && shared.devices[id] !== undefined ? shared.devices[id]._freeBufferSlots() : 0;
     },
     dmDeviceJSFreeBufferSlots__proxy: 'sync',
     dmDeviceJSFreeBufferSlots__sig: 'ii',
 
     dmGetDeviceSampleRate: function(id) {
-        return window._dmJSDeviceShared.devices[id].sampleRate;
+        var root = DefoldSoundDevice.GetGlobal();
+        var shared = root !== undefined ? root._dmJSDeviceShared : undefined;
+        return shared !== undefined && shared.devices[id] !== undefined ? shared.devices[id].sampleRate : 48000;
     },
 }
 

--- a/engine/sound/src/test/CMakeLists.txt
+++ b/engine/sound/src/test/CMakeLists.txt
@@ -205,3 +205,18 @@ if(TARGET_PLATFORM MATCHES "linux$")
   target_link_libraries(test_sound_openal PRIVATE sound_openal)
   sound_configure_test(test_sound_openal OFF)
 endif()
+
+if(TARGET_PLATFORM MATCHES "^(wasm-web|wasm_pthread-web)$")
+  _defold_find_wasm_runner(_sound_js_test_runner)
+  if(_sound_js_test_runner)
+    add_custom_target(run_test_library_sound_js
+      COMMAND "${_sound_js_test_runner}" "${SOUND_TEST_ROOT}/test_library_sound.js"
+      WORKING_DIRECTORY "${SOUND_ROOT}"
+      USES_TERMINAL)
+    if(TARGET run_tests)
+      add_dependencies(run_tests run_test_library_sound_js)
+    endif()
+  else()
+    message(WARNING "Bun or Node.js not found; run_test_library_sound_js is unavailable")
+  endif()
+endif()

--- a/engine/sound/src/test/test_library_sound.js
+++ b/engine/sound/src/test/test_library_sound.js
@@ -102,6 +102,21 @@ function resolvedResult() {
     };
 }
 
+function deferredResult() {
+    let onResolved = null;
+    let onRejected = null;
+    return {
+        promise: {
+            then: (resolved, rejected) => {
+                onResolved = resolved;
+                onRejected = rejected;
+            }
+        },
+        resolve: () => onResolved(),
+        reject: () => onRejected()
+    };
+}
+
 function makeAudioContext(options = {}) {
     const contexts = [];
     class FakeAudioContext {
@@ -116,6 +131,7 @@ function makeAudioContext(options = {}) {
             this.destination = {};
             this.onstatechange = null;
             this.startedBuffers = 0;
+            this.resumeCalls = 0;
             this.sources = [];
             this.closed = false;
             contexts.push(this);
@@ -148,8 +164,12 @@ function makeAudioContext(options = {}) {
             return source;
         }
         resume() {
+            this.resumeCalls++;
             if (options.throwOnResume) {
                 throw new Error("Audio resume failed");
+            }
+            if (options.resumeResult) {
+                return options.resumeResult;
             }
             this.state = "running";
             if (this.onstatechange) {
@@ -308,6 +328,43 @@ function testResumeFailureAndClosedContextFallBack() {
     assert.strictEqual(warnings.length, 1);
 }
 
+function testStaleResumeResultDoesNotAffectRecoveredContext() {
+    resetEnvironment();
+    const staleResume = deferredResult();
+    const StaleAudioContext = makeAudioContext({
+        initialState: "suspended",
+        resumeResult: staleResume.promise
+    });
+    global.AudioContext = StaleAudioContext;
+    global.LibrarySoundDevice.dmDeviceJSOpen(4);
+    global.DefoldSoundDevice.TryResumeAudio();
+
+    const staleContext = StaleAudioContext.contexts[0];
+    staleContext.state = "closed";
+    staleContext.onstatechange();
+
+    const recoveredResume = deferredResult();
+    const RecoveredAudioContext = makeAudioContext({
+        initialState: "suspended",
+        resumeResult: recoveredResume.promise
+    });
+    global.AudioContext = RecoveredAudioContext;
+    global.DefoldSoundDevice.TryResumeAudio();
+
+    const recoveredContext = RecoveredAudioContext.contexts[0];
+    assert.strictEqual(global._dmJSDeviceShared.resumePending, true);
+    staleResume.reject();
+    assert.strictEqual(global._dmJSDeviceShared.resumePending, true);
+
+    advanceTime(2000);
+    assert.strictEqual(recoveredContext.resumeCalls, 1);
+
+    recoveredContext.state = "running";
+    recoveredContext.onstatechange();
+    recoveredResume.resolve();
+    assert.strictEqual(global._dmJSDeviceShared.resumePending, false);
+}
+
 function testSharedContextAndCleanup() {
     resetEnvironment();
     const FakeAudioContext = makeAudioContext();
@@ -342,6 +399,7 @@ testInteractionAndDeviceChangeRecoverImmediately();
 testQueueFailureFallsBackAndRecovers();
 testSuspendCancelsQueuedSourcesBeforeRecovery();
 testResumeFailureAndClosedContextFallBack();
+testStaleResumeResultDoesNotAffectRecoveredContext();
 testSharedContextAndCleanup();
 
 process.stdout.write("HTML5 sound device tests passed\n");

--- a/engine/sound/src/test/test_library_sound.js
+++ b/engine/sound/src/test/test_library_sound.js
@@ -1,0 +1,347 @@
+const assert = require("assert");
+const fs = require("fs");
+const path = require("path");
+const vm = require("vm");
+
+let nowMs = 0;
+let nextTimerId = 1;
+let timers = new Map();
+let warnings = [];
+let infos = [];
+let deviceChangeHandler = null;
+
+function installEnvironment() {
+    global.Date.now = () => nowMs;
+    global.setTimeout = (callback, delay) => {
+        const id = nextTimerId++;
+        timers.set(id, { callback, deadline: nowMs + delay });
+        return id;
+    };
+    global.clearTimeout = (id) => timers.delete(id);
+    Object.defineProperty(global, "navigator", {
+        configurable: true,
+        value: {
+            mediaDevices: {
+                addEventListener: (name, callback) => {
+                    assert.strictEqual(name, "devicechange");
+                    deviceChangeHandler = callback;
+                },
+                removeEventListener: (name, callback) => {
+                    assert.strictEqual(name, "devicechange");
+                    if (deviceChangeHandler === callback) {
+                        deviceChangeHandler = null;
+                    }
+                }
+            }
+        }
+    });
+    global.console = {
+        warn: (message) => warnings.push(message),
+        info: (message) => infos.push(message),
+        log: () => {}
+    };
+    global.HEAPF32 = new Float32Array(32768);
+    global.autoAddDeps = () => {};
+    global.addToLibrary = () => {};
+
+    const libraryPath = path.join(__dirname, "..", "js", "library_sound.js");
+    const source = fs.readFileSync(libraryPath, "utf8");
+    vm.runInThisContext(source + "\nglobal.LibrarySoundDevice = LibrarySoundDevice;");
+    global.DefoldSoundDevice = global.LibrarySoundDevice.$DefoldSoundDevice;
+}
+
+function resetEnvironment() {
+    if (global._dmJSDeviceShared) {
+        const ids = Object.keys(global._dmJSDeviceShared.devices);
+        for (const id of ids) {
+            global.LibrarySoundDevice.dmDeviceJSClose(Number(id));
+        }
+    }
+    delete global.AudioContext;
+    delete global.webkitAudioContext;
+    delete global._dmJSDeviceShared;
+    nowMs = 0;
+    nextTimerId = 1;
+    timers = new Map();
+    warnings = [];
+    infos = [];
+    deviceChangeHandler = null;
+}
+
+function advanceTime(milliseconds) {
+    const target = nowMs + milliseconds;
+    while (true) {
+        let nextId = null;
+        let nextDeadline = Infinity;
+        for (const [id, timer] of timers) {
+            if (timer.deadline < nextDeadline) {
+                nextId = id;
+                nextDeadline = timer.deadline;
+            }
+        }
+        if (nextId === null || nextDeadline > target) {
+            break;
+        }
+        nowMs = nextDeadline;
+        const timer = timers.get(nextId);
+        timers.delete(nextId);
+        timer.callback();
+    }
+    nowMs = target;
+}
+
+function resolvedResult() {
+    return {
+        then: (onResolved) => {
+            if (onResolved) {
+                onResolved();
+            }
+            return resolvedResult();
+        },
+        catch: () => resolvedResult()
+    };
+}
+
+function makeAudioContext(options = {}) {
+    const contexts = [];
+    class FakeAudioContext {
+        constructor() {
+            if (options.throwOnConstruct) {
+                throw new Error("AudioContext unavailable");
+            }
+            this.sampleRate = options.sampleRate || 44100;
+            this.state = options.initialState || "running";
+            this.outputLatency = 0;
+            this.baseLatency = 0;
+            this.destination = {};
+            this.onstatechange = null;
+            this.startedBuffers = 0;
+            this.sources = [];
+            this.closed = false;
+            contexts.push(this);
+        }
+        get currentTime() {
+            return nowMs / 1000;
+        }
+        createBuffer(channelCount, frameCount) {
+            if (options.throwOnQueue) {
+                throw new Error("Audio queue failed");
+            }
+            assert.strictEqual(channelCount, 2);
+            return {
+                copyToChannel: (input) => assert.strictEqual(input.length, frameCount)
+            };
+        }
+        createBufferSource() {
+            const context = this;
+            const source = {
+                buffer: null,
+                onended: null,
+                stopped: false,
+                disconnected: false,
+                connect: () => {},
+                disconnect: () => source.disconnected = true,
+                start: () => context.startedBuffers++,
+                stop: () => source.stopped = true
+            };
+            context.sources.push(source);
+            return source;
+        }
+        resume() {
+            if (options.throwOnResume) {
+                throw new Error("Audio resume failed");
+            }
+            this.state = "running";
+            if (this.onstatechange) {
+                this.onstatechange();
+            }
+            return resolvedResult();
+        }
+        close() {
+            this.closed = true;
+            this.state = "closed";
+            return resolvedResult();
+        }
+    }
+    FakeAudioContext.contexts = contexts;
+    return FakeAudioContext;
+}
+
+function testSilentQueueAdvances() {
+    resetEnvironment();
+    const id = global.LibrarySoundDevice.dmDeviceJSOpen(4);
+    assert.strictEqual(id, 0);
+    assert.strictEqual(global.LibrarySoundDevice.dmGetDeviceSampleRate(id), 48000);
+    assert.strictEqual(global.LibrarySoundDevice.dmDeviceJSFreeBufferSlots(id), 1);
+
+    global.LibrarySoundDevice.dmDeviceJSQueue(id, 0, 4800);
+    assert.strictEqual(global.LibrarySoundDevice.dmDeviceJSFreeBufferSlots(id), 3);
+    advanceTime(100);
+    assert.strictEqual(global.LibrarySoundDevice.dmDeviceJSFreeBufferSlots(id), 4);
+    assert.strictEqual(warnings.length, 1);
+    assert.strictEqual(timers.size, 1);
+}
+
+function testSilentQueueRestartsAfterIdle() {
+    resetEnvironment();
+    const id = global.LibrarySoundDevice.dmDeviceJSOpen(4);
+
+    global.LibrarySoundDevice.dmDeviceJSQueue(id, 0, 4800);
+    advanceTime(100);
+    assert.strictEqual(global.LibrarySoundDevice.dmDeviceJSFreeBufferSlots(id), 4);
+
+    global.LibrarySoundDevice.dmDeviceJSPlaybackIdle(id);
+    advanceTime(9900);
+    global.LibrarySoundDevice.dmDeviceJSPlaybackStarted(id);
+    global.LibrarySoundDevice.dmDeviceJSQueue(id, 0, 4800);
+    assert.strictEqual(global.LibrarySoundDevice.dmDeviceJSFreeBufferSlots(id), 3);
+    advanceTime(100);
+    assert.strictEqual(global.LibrarySoundDevice.dmDeviceJSFreeBufferSlots(id), 4);
+}
+
+function testConstructorFailureStaysSilent() {
+    resetEnvironment();
+    global.AudioContext = makeAudioContext({ throwOnConstruct: true });
+    const id = global.LibrarySoundDevice.dmDeviceJSOpen(4);
+    assert.strictEqual(global.LibrarySoundDevice.dmGetDeviceSampleRate(id), 48000);
+    global.LibrarySoundDevice.dmDeviceJSQueue(id, 0, 4800);
+    advanceTime(2000);
+    assert.strictEqual(global.LibrarySoundDevice.dmDeviceJSFreeBufferSlots(id), 4);
+    assert.strictEqual(warnings.length, 1);
+}
+
+function testPeriodicRecoveryKeepsDeviceRate() {
+    resetEnvironment();
+    const id = global.LibrarySoundDevice.dmDeviceJSOpen(4);
+    const FakeAudioContext = makeAudioContext({ sampleRate: 44100 });
+    global.AudioContext = FakeAudioContext;
+
+    advanceTime(2000);
+    assert.strictEqual(FakeAudioContext.contexts.length, 1);
+    assert.strictEqual(global.LibrarySoundDevice.dmGetDeviceSampleRate(id), 48000);
+    global.LibrarySoundDevice.dmDeviceJSQueue(id, 0, 480);
+    assert.strictEqual(FakeAudioContext.contexts[0].startedBuffers, 1);
+    const bufferedTo = global._dmJSDeviceShared.devices[id].bufferedTo;
+    global.DefoldSoundDevice.TryResumeAudio();
+    assert.strictEqual(global._dmJSDeviceShared.devices[id].bufferedTo, bufferedTo);
+    assert.strictEqual(infos.length, 1);
+}
+
+function testInteractionAndDeviceChangeRecoverImmediately() {
+    resetEnvironment();
+    global.LibrarySoundDevice.dmDeviceJSOpen(4);
+    const SuspendedAudioContext = makeAudioContext({ initialState: "suspended" });
+    global.AudioContext = SuspendedAudioContext;
+    global.DefoldSoundDevice.TryResumeAudio();
+    assert.strictEqual(SuspendedAudioContext.contexts[0].state, "running");
+
+    resetEnvironment();
+    global.LibrarySoundDevice.dmDeviceJSOpen(4);
+    const RunningAudioContext = makeAudioContext();
+    global.AudioContext = RunningAudioContext;
+    assert.notStrictEqual(deviceChangeHandler, null);
+    deviceChangeHandler();
+    assert.strictEqual(RunningAudioContext.contexts.length, 1);
+    assert.strictEqual(RunningAudioContext.contexts[0].state, "running");
+}
+
+function testQueueFailureFallsBackAndRecovers() {
+    resetEnvironment();
+    const BrokenAudioContext = makeAudioContext({ throwOnQueue: true });
+    global.AudioContext = BrokenAudioContext;
+    const id = global.LibrarySoundDevice.dmDeviceJSOpen(4);
+    global.LibrarySoundDevice.dmDeviceJSQueue(id, 0, 4800);
+    assert.strictEqual(global._dmJSDeviceShared.audioCtx, undefined);
+    assert.strictEqual(global.LibrarySoundDevice.dmDeviceJSFreeBufferSlots(id), 3);
+
+    const RecoveredAudioContext = makeAudioContext();
+    global.AudioContext = RecoveredAudioContext;
+    advanceTime(2000);
+    global.LibrarySoundDevice.dmDeviceJSQueue(id, 0, 4800);
+    assert.strictEqual(RecoveredAudioContext.contexts[0].startedBuffers, 1);
+}
+
+function testSuspendCancelsQueuedSourcesBeforeRecovery() {
+    resetEnvironment();
+    const FakeAudioContext = makeAudioContext();
+    global.AudioContext = FakeAudioContext;
+    const id = global.LibrarySoundDevice.dmDeviceJSOpen(4);
+    const context = FakeAudioContext.contexts[0];
+
+    global.LibrarySoundDevice.dmDeviceJSQueue(id, 0, 4800);
+    const staleSource = context.sources[0];
+    assert.strictEqual(staleSource.stopped, false);
+
+    context.state = "suspended";
+    context.onstatechange();
+    assert.strictEqual(staleSource.stopped, true);
+    assert.strictEqual(staleSource.disconnected, true);
+    assert.strictEqual(global._dmJSDeviceShared.devices[id].activeSources.length, 0);
+
+    global.LibrarySoundDevice.dmDeviceJSQueue(id, 0, 4800);
+    context.state = "running";
+    context.onstatechange();
+    global.LibrarySoundDevice.dmDeviceJSQueue(id, 0, 4800);
+    assert.strictEqual(context.sources.length, 2);
+    assert.strictEqual(context.sources[1].stopped, false);
+    assert.strictEqual(global._dmJSDeviceShared.devices[id].activeSources.length, 1);
+}
+
+function testResumeFailureAndClosedContextFallBack() {
+    resetEnvironment();
+    const ResumeFailureContext = makeAudioContext({ initialState: "suspended", throwOnResume: true });
+    global.AudioContext = ResumeFailureContext;
+    global.LibrarySoundDevice.dmDeviceJSOpen(4);
+    global.DefoldSoundDevice.TryResumeAudio();
+    assert.strictEqual(global._dmJSDeviceShared.audioCtx, undefined);
+    assert.strictEqual(warnings.length, 1);
+
+    resetEnvironment();
+    const ClosingAudioContext = makeAudioContext();
+    global.AudioContext = ClosingAudioContext;
+    global.LibrarySoundDevice.dmDeviceJSOpen(4);
+    const context = ClosingAudioContext.contexts[0];
+    const stateChangeHandler = context.onstatechange;
+    context.state = "closed";
+    stateChangeHandler();
+    assert.strictEqual(global._dmJSDeviceShared.audioCtx, undefined);
+    assert.strictEqual(warnings.length, 1);
+}
+
+function testSharedContextAndCleanup() {
+    resetEnvironment();
+    const FakeAudioContext = makeAudioContext();
+    global.AudioContext = FakeAudioContext;
+    const first = global.LibrarySoundDevice.dmDeviceJSOpen(4);
+    const second = global.LibrarySoundDevice.dmDeviceJSOpen(4);
+    assert.strictEqual(FakeAudioContext.contexts.length, 1);
+
+    const context = FakeAudioContext.contexts[0];
+    global.LibrarySoundDevice.dmDeviceJSQueue(first, 0, 4800);
+    global.LibrarySoundDevice.dmDeviceJSQueue(second, 0, 4800);
+    global.LibrarySoundDevice.dmDeviceJSClose(first);
+    assert.strictEqual(context.sources[0].stopped, true);
+    assert.strictEqual(context.sources[1].stopped, false);
+    assert.strictEqual(context.closed, false);
+    assert.notStrictEqual(deviceChangeHandler, null);
+
+    global.LibrarySoundDevice.dmDeviceJSClose(second);
+    assert.strictEqual(context.sources[1].stopped, true);
+    assert.strictEqual(context.closed, true);
+    assert.strictEqual(deviceChangeHandler, null);
+    assert.strictEqual(global._dmJSDeviceShared, undefined);
+    assert.strictEqual(timers.size, 0);
+}
+
+installEnvironment();
+testSilentQueueAdvances();
+testSilentQueueRestartsAfterIdle();
+testConstructorFailureStaysSilent();
+testPeriodicRecoveryKeepsDeviceRate();
+testInteractionAndDeviceChangeRecoverImmediately();
+testQueueFailureFallsBackAndRecovers();
+testSuspendCancelsQueuedSourcesBeforeRecovery();
+testResumeFailureAndClosedContextFallBack();
+testSharedContextAndCleanup();
+
+process.stdout.write("HTML5 sound device tests passed\n");


### PR DESCRIPTION
HTML5 games now continue advancing sounds silently when the browser cannot create or run a Web Audio context. This prevents completed sounds from occupying all configured sound instances. When audio becomes available, output recovers automatically and active sounds continue from their current logical position.

### Technical changes

- Always create a valid HTML5 sound device, using a clocked 48 kHz silent fallback when Web Audio is unavailable.
- Continue consuming mixed buffers in silent mode so completed sound instances are released normally.
- Retry Web Audio every two seconds and immediately after user interaction or media-device changes.
- Preserve each device’s initial sample rate and switch recovered output to Web Audio without resetting native sound instances.
- Catch context creation, resume, buffer, and queue failures and return safely to silent playback.
- Share context-state handling across multiple Defold devices, guard asynchronous resume bookkeeping against stale contexts, and cancel obsolete queued sources during transitions.
- Add JavaScript-side device cleanup, including retry timers, device-change listeners, active sources, and the shared engine-owned context.
- Add defensive native cleanup when device opening fails and unregister the JavaScript device during close.
- Add deterministic fake-clock and fake-Web-Audio tests covering fallback, recovery, suspension, failures, stale resume promises, multiple devices, and final cleanup.
- Verified with `node --unhandled-rejections=strict engine/sound/src/test/test_library_sound.js` and JavaScript syntax checks.

Test Project:
[SilentDeviceTest.zip](https://github.com/user-attachments/files/30704467/SilentDeviceTest.zip)
