### PR TITLE
Add a mutex for guarding the graphics queue for Vulkan

### DIFF
--- a/engine/graphics/src/test/test_app_graphics.cpp
+++ b/engine/graphics/src/test/test_app_graphics.cpp
@@ -1270,9 +1270,9 @@ static void* EngineCreate(int argc, char** argv)
     graphics_context_params.m_DefaultTextureMinFilter = dmGraphics::TEXTURE_FILTER_LINEAR_MIPMAP_NEAREST;
     graphics_context_params.m_DefaultTextureMagFilter = dmGraphics::TEXTURE_FILTER_LINEAR_MIPMAP_NEAREST;
     graphics_context_params.m_VerifyGraphicsCalls     = 1;
-//#if defined(DM_VULKAN_VALIDATION)
+#if defined(DM_VULKAN_VALIDATION)
     graphics_context_params.m_UseValidationLayers     = 1;
-//#endif
+#endif
     graphics_context_params.m_Window                  = engine->m_Window;
     graphics_context_params.m_Width                   = 512;
     graphics_context_params.m_Height                  = 512;

--- a/engine/graphics/src/test/test_app_graphics.cpp
+++ b/engine/graphics/src/test/test_app_graphics.cpp
@@ -672,7 +672,7 @@ struct AsyncTextureUploadQueueTest : ITest
     static const uint32_t TEXTURE_WIDTH         = 128;
     static const uint32_t TEXTURE_HEIGHT        = 128;
     static const uint32_t MAX_UPLOADS_IN_FLIGHT = 128;
-    static const uint32_t TARGET_UPLOAD_COUNT   = 4096;
+    static const uint32_t TARGET_UPLOAD_COUNT   = 512;
     static const uint64_t TEST_TIMEOUT_US       = 60ULL * 1000ULL * 1000ULL;
 
     EngineCtx*                 m_Engine;

--- a/engine/graphics/src/test/test_app_graphics.cpp
+++ b/engine/graphics/src/test/test_app_graphics.cpp
@@ -650,6 +650,178 @@ struct AsyncTextureUploadShutdownTest : ITest
     }
 };
 
+// Regression/stress test for:
+// https://github.com/defold/defold/issues/12898
+// https://github.com/defold/defold/issues/12902
+//
+// Keeps the Vulkan upload worker busy while the main thread continuously
+// submits and presents frames. Both paths currently use the same VkQueue, so
+// this test exercises the missing external queue synchronization reported as
+// either a driver crash in AsyncProcessCallback or a GPU fence that never
+// signals. Run with the Vulkan validation layers enabled to also catch Vulkan
+// thread-safety violations on platforms where the driver tolerates the race.
+struct AsyncTextureUploadQueueTest : ITest
+{
+    struct UploadSlot
+    {
+        AsyncTextureUploadQueueTest* m_Test;
+        dmGraphics::HTexture         m_Texture;
+        bool                         m_Pending;
+    };
+
+    static const uint32_t TEXTURE_WIDTH         = 128;
+    static const uint32_t TEXTURE_HEIGHT        = 128;
+    static const uint32_t MAX_UPLOADS_IN_FLIGHT = 128;
+    static const uint32_t TARGET_UPLOAD_COUNT   = 4096;
+    static const uint64_t TEST_TIMEOUT_US       = 60ULL * 1000ULL * 1000ULL;
+
+    EngineCtx*                 m_Engine;
+    dmArray<UploadSlot>        m_Uploads;
+    dmGraphics::TextureParams  m_TextureParams;
+    uint8_t*                   m_TextureData;
+    uint32_t                   m_SubmittedCount;
+    uint32_t                   m_CompletedCount;
+    uint64_t                   m_StartTime;
+    bool                       m_CallbackFailed;
+
+    AsyncTextureUploadQueueTest()
+    : m_Engine(0)
+    , m_TextureData(0)
+    , m_SubmittedCount(0)
+    , m_CompletedCount(0)
+    , m_StartTime(0)
+    , m_CallbackFailed(false)
+    {
+    }
+
+    static void UploadComplete(dmGraphics::HTexture texture, void* user_data)
+    {
+        UploadSlot* slot = (UploadSlot*) user_data;
+        AsyncTextureUploadQueueTest* test = slot->m_Test;
+
+        if (!slot->m_Pending || slot->m_Texture != texture)
+        {
+            dmLogError("Async texture queue test: unexpected upload callback");
+            test->m_CallbackFailed = true;
+            return;
+        }
+
+        slot->m_Pending = false;
+        test->m_CompletedCount++;
+
+        uint32_t status = dmGraphics::GetTextureStatusFlags(test->m_Engine->m_GraphicsContext, texture);
+        if (status & dmGraphics::TEXTURE_STATUS_DATA_PENDING)
+        {
+            dmLogError("Async texture queue test: texture is still pending in its completion callback");
+            test->m_CallbackFailed = true;
+        }
+    }
+
+    void SubmitUploads()
+    {
+        for (uint32_t i = 0; i < m_Uploads.Size() && m_SubmittedCount < TARGET_UPLOAD_COUNT; ++i)
+        {
+            UploadSlot& slot = m_Uploads[i];
+            if (slot.m_Pending)
+            {
+                continue;
+            }
+
+            slot.m_Pending = true;
+            dmGraphics::SetTextureAsync(m_Engine->m_GraphicsContext, slot.m_Texture, m_TextureParams, UploadComplete, &slot);
+            m_SubmittedCount++;
+        }
+    }
+
+    void Initialize(EngineCtx* engine) override
+    {
+        m_Engine = engine;
+        m_StartTime = dmTime::GetMonotonicTime();
+
+        const uint32_t texture_data_size = TEXTURE_WIDTH * TEXTURE_HEIGHT * 4;
+        m_TextureData = new uint8_t[texture_data_size];
+        for (uint32_t i = 0; i < texture_data_size; ++i)
+        {
+            m_TextureData[i] = (uint8_t) i;
+        }
+
+        m_TextureParams.m_DataSize = texture_data_size;
+        m_TextureParams.m_Data     = m_TextureData;
+        m_TextureParams.m_Width    = TEXTURE_WIDTH;
+        m_TextureParams.m_Height   = TEXTURE_HEIGHT;
+        m_TextureParams.m_Format   = dmGraphics::TEXTURE_FORMAT_RGBA;
+
+        m_Uploads.SetCapacity(MAX_UPLOADS_IN_FLIGHT);
+        m_Uploads.SetSize(MAX_UPLOADS_IN_FLIGHT);
+
+        dmGraphics::TextureCreationParams creation_params;
+        creation_params.m_Width          = TEXTURE_WIDTH;
+        creation_params.m_Height         = TEXTURE_HEIGHT;
+        creation_params.m_OriginalWidth  = TEXTURE_WIDTH;
+        creation_params.m_OriginalHeight = TEXTURE_HEIGHT;
+        creation_params.m_MipMapCount    = 1;
+
+        for (uint32_t i = 0; i < m_Uploads.Size(); ++i)
+        {
+            UploadSlot& slot = m_Uploads[i];
+            slot.m_Test    = this;
+            slot.m_Texture = dmGraphics::NewTexture(engine->m_GraphicsContext, creation_params);
+            slot.m_Pending = false;
+        }
+
+        SubmitUploads();
+        dmLogInfo("Async texture queue test: submitted %u initial uploads", m_SubmittedCount);
+    }
+
+    void Execute(EngineCtx* engine) override
+    {
+        dmGraphics::Clear(engine->m_GraphicsContext, dmGraphics::BUFFER_TYPE_COLOR0_BIT,
+            26, 51, 77, 255, 1.0f, 0);
+
+        if (m_CallbackFailed)
+        {
+            engine->m_Failed = true;
+            engine->m_Running = 0;
+            return;
+        }
+
+        SubmitUploads();
+
+        if (m_SubmittedCount == TARGET_UPLOAD_COUNT && m_CompletedCount == TARGET_UPLOAD_COUNT)
+        {
+            dmLogInfo("Async texture queue test: completed all %u uploads", m_CompletedCount);
+            engine->m_Running = 0;
+            return;
+        }
+
+        if (dmTime::GetMonotonicTime() - m_StartTime > TEST_TIMEOUT_US)
+        {
+            dmLogError("Async texture queue test timed out: submitted=%u completed=%u",
+                m_SubmittedCount, m_CompletedCount);
+            engine->m_Failed = true;
+            engine->m_Running = 0;
+        }
+    }
+
+    void OnGraphicsClosing(EngineCtx* engine) override
+    {
+        if (m_SubmittedCount == m_CompletedCount)
+        {
+            for (uint32_t i = 0; i < m_Uploads.Size(); ++i)
+            {
+                dmGraphics::DeleteTexture(engine->m_GraphicsContext, m_Uploads[i].m_Texture);
+                m_Uploads[i].m_Texture = 0;
+            }
+        }
+    }
+
+    void OnGraphicsClosed(EngineCtx*) override
+    {
+        delete[] m_TextureData;
+        m_TextureData = 0;
+    }
+};
+
 struct ComputeTest : ITest
 {
     dmGraphics::HProgram         m_Program;
@@ -1110,6 +1282,20 @@ static void* EngineCreate(int argc, char** argv)
             engine->m_Test = new AsyncTextureUploadShutdownTest();
         }
     }
+    else if (HasArgument("issue-12898-12902"))
+    {
+        if (dmGraphics::GetInstalledAdapterFamily() != dmGraphics::ADAPTER_FAMILY_VULKAN)
+        {
+            dmLogError("Issues #12898/#12902 reproducer requires the Vulkan adapter");
+            engine->m_Failed = true;
+            engine->m_Test = new ClearBackbufferTest();
+        }
+        else
+        {
+            dmLogInfo("test_app_graphics: running AsyncTextureUploadQueueTest");
+            engine->m_Test = new AsyncTextureUploadQueueTest();
+        }
+    }
     else
     {
         //engine->m_Test = new ComputeTest();
@@ -1179,7 +1365,7 @@ static UpdateResult EngineUpdate(void* _engine)
 
     dmGraphics::Flip(engine->m_GraphicsContext);
 
-    if (ShouldAutoExit() && engine->m_WasRun >= TEST_APP_GRAPHICS_MAX_FRAME_COUNT)
+    if (ShouldAutoExit() && !HasArgument("issue-12898-12902") && engine->m_WasRun >= TEST_APP_GRAPHICS_MAX_FRAME_COUNT)
     {
         return RESULT_EXIT;
     }

--- a/engine/graphics/src/test/test_app_graphics.cpp
+++ b/engine/graphics/src/test/test_app_graphics.cpp
@@ -74,24 +74,6 @@ static bool HasArgument(const char* argument)
     return false;
 }
 
-static uint32_t GetEnvUInt(const char* name, uint32_t default_value)
-{
-    const char* value = getenv(name);
-    if (value == 0x0 || value[0] == 0)
-    {
-        return default_value;
-    }
-
-    char* end = 0x0;
-    unsigned long result = strtoul(value, &end, 10);
-    if (end == value || result == 0)
-    {
-        return default_value;
-    }
-
-    return (uint32_t) result;
-}
-
 struct RunLoopParams
 {
     int     m_Argc;
@@ -687,12 +669,13 @@ struct AsyncTextureUploadQueueTest : ITest
         bool                         m_Pending;
     };
 
-    static const uint32_t DEFAULT_TEXTURE_WIDTH         = 128;
-    static const uint32_t DEFAULT_TEXTURE_HEIGHT        = 128;
-    static const uint32_t DEFAULT_MAX_UPLOADS_IN_FLIGHT = 128;
-    static const uint32_t DEFAULT_TARGET_UPLOAD_COUNT   = 512*5;
-    static const uint32_t DEFAULT_TEST_TIMEOUT_S        = 60*2;
-    static const uint64_t PROGRESS_LOG_INTERVAL_US      = 1000ULL * 1000ULL;
+    static const uint32_t TEXTURE_WIDTH            = 128;
+    static const uint32_t TEXTURE_HEIGHT           = 128;
+    static const uint32_t MAX_UPLOADS_IN_FLIGHT    = 128;
+    static const uint32_t TARGET_UPLOAD_COUNT      = 512*5;
+    static const uint32_t TEST_TIMEOUT_S           = 60*2;
+    static const uint64_t TEST_TIMEOUT_US          = (uint64_t) TEST_TIMEOUT_S * 1000ULL * 1000ULL;
+    static const uint64_t PROGRESS_LOG_INTERVAL_US = 1000ULL * 1000ULL;
 
     EngineCtx*                 m_Engine;
     dmArray<UploadSlot>        m_Uploads;
@@ -702,11 +685,6 @@ struct AsyncTextureUploadQueueTest : ITest
     uint32_t                   m_CompletedCount;
     uint64_t                   m_StartTime;
     uint64_t                   m_LastProgressTime;
-    uint32_t                   m_TextureWidth;
-    uint32_t                   m_TextureHeight;
-    uint32_t                   m_MaxUploadsInFlight;
-    uint32_t                   m_TargetUploadCount;
-    uint64_t                   m_TestTimeoutUs;
     bool                       m_CallbackFailed;
 
     AsyncTextureUploadQueueTest()
@@ -716,11 +694,6 @@ struct AsyncTextureUploadQueueTest : ITest
     , m_CompletedCount(0)
     , m_StartTime(0)
     , m_LastProgressTime(0)
-    , m_TextureWidth(DEFAULT_TEXTURE_WIDTH)
-    , m_TextureHeight(DEFAULT_TEXTURE_HEIGHT)
-    , m_MaxUploadsInFlight(DEFAULT_MAX_UPLOADS_IN_FLIGHT)
-    , m_TargetUploadCount(DEFAULT_TARGET_UPLOAD_COUNT)
-    , m_TestTimeoutUs((uint64_t) DEFAULT_TEST_TIMEOUT_S * 1000ULL * 1000ULL)
     , m_CallbackFailed(false)
     {
     }
@@ -750,7 +723,7 @@ struct AsyncTextureUploadQueueTest : ITest
 
     void SubmitUploads()
     {
-        for (uint32_t i = 0; i < m_Uploads.Size() && m_SubmittedCount < m_TargetUploadCount; ++i)
+        for (uint32_t i = 0; i < m_Uploads.Size() && m_SubmittedCount < TARGET_UPLOAD_COUNT; ++i)
         {
             UploadSlot& slot = m_Uploads[i];
             if (slot.m_Pending)
@@ -769,32 +742,11 @@ struct AsyncTextureUploadQueueTest : ITest
         m_Engine = engine;
         m_StartTime = dmTime::GetMonotonicTime();
         m_LastProgressTime = m_StartTime;
-        m_TextureWidth       = GetEnvUInt("DEFOLD_ASYNC_TEXTURE_WIDTH", DEFAULT_TEXTURE_WIDTH);
-        m_TextureHeight      = GetEnvUInt("DEFOLD_ASYNC_TEXTURE_HEIGHT", DEFAULT_TEXTURE_HEIGHT);
-        m_MaxUploadsInFlight = GetEnvUInt("DEFOLD_ASYNC_TEXTURE_IN_FLIGHT", DEFAULT_MAX_UPLOADS_IN_FLIGHT);
-        m_TargetUploadCount  = GetEnvUInt("DEFOLD_ASYNC_TEXTURE_UPLOADS", DEFAULT_TARGET_UPLOAD_COUNT);
-        m_TestTimeoutUs      = (uint64_t) GetEnvUInt("DEFOLD_ASYNC_TEXTURE_TIMEOUT_S", DEFAULT_TEST_TIMEOUT_S) * 1000ULL * 1000ULL;
-
-        if (m_TextureWidth > 0xffff || m_TextureHeight > 0xffff)
-        {
-            dmLogError("Async texture queue test dimensions are too large: %ux%u", m_TextureWidth, m_TextureHeight);
-            engine->m_Failed = true;
-            return;
-        }
-
-        const uint64_t texture_data_size_64 = (uint64_t) m_TextureWidth * m_TextureHeight * 4;
-        if (texture_data_size_64 > 0xffffffffULL)
-        {
-            dmLogError("Async texture queue test texture data is too large: %llu bytes", (unsigned long long) texture_data_size_64);
-            engine->m_Failed = true;
-            return;
-        }
 
         dmLogInfo("Async texture queue test: %ux%u RGBA, %u in flight, %u total uploads, %u s timeout",
-            m_TextureWidth, m_TextureHeight, m_MaxUploadsInFlight, m_TargetUploadCount,
-            (uint32_t) (m_TestTimeoutUs / (1000ULL * 1000ULL)));
+            TEXTURE_WIDTH, TEXTURE_HEIGHT, MAX_UPLOADS_IN_FLIGHT, TARGET_UPLOAD_COUNT, TEST_TIMEOUT_S);
 
-        const uint32_t texture_data_size = (uint32_t) texture_data_size_64;
+        const uint32_t texture_data_size = TEXTURE_WIDTH * TEXTURE_HEIGHT * 4;
         m_TextureData = new uint8_t[texture_data_size];
         for (uint32_t i = 0; i < texture_data_size; ++i)
         {
@@ -803,18 +755,18 @@ struct AsyncTextureUploadQueueTest : ITest
 
         m_TextureParams.m_DataSize = texture_data_size;
         m_TextureParams.m_Data     = m_TextureData;
-        m_TextureParams.m_Width    = (uint16_t) m_TextureWidth;
-        m_TextureParams.m_Height   = (uint16_t) m_TextureHeight;
+        m_TextureParams.m_Width    = (uint16_t) TEXTURE_WIDTH;
+        m_TextureParams.m_Height   = (uint16_t) TEXTURE_HEIGHT;
         m_TextureParams.m_Format   = dmGraphics::TEXTURE_FORMAT_RGBA;
 
-        m_Uploads.SetCapacity(m_MaxUploadsInFlight);
-        m_Uploads.SetSize(m_MaxUploadsInFlight);
+        m_Uploads.SetCapacity(MAX_UPLOADS_IN_FLIGHT);
+        m_Uploads.SetSize(MAX_UPLOADS_IN_FLIGHT);
 
         dmGraphics::TextureCreationParams creation_params;
-        creation_params.m_Width          = (uint16_t) m_TextureWidth;
-        creation_params.m_Height         = (uint16_t) m_TextureHeight;
-        creation_params.m_OriginalWidth  = (uint16_t) m_TextureWidth;
-        creation_params.m_OriginalHeight = (uint16_t) m_TextureHeight;
+        creation_params.m_Width          = (uint16_t) TEXTURE_WIDTH;
+        creation_params.m_Height         = (uint16_t) TEXTURE_HEIGHT;
+        creation_params.m_OriginalWidth  = (uint16_t) TEXTURE_WIDTH;
+        creation_params.m_OriginalHeight = (uint16_t) TEXTURE_HEIGHT;
         creation_params.m_MipMapCount    = 1;
 
         for (uint32_t i = 0; i < m_Uploads.Size(); ++i)
@@ -848,19 +800,19 @@ struct AsyncTextureUploadQueueTest : ITest
         {
             uint32_t in_flight = m_SubmittedCount - m_CompletedCount;
             dmLogInfo("Async texture queue test: progress %u/%u completed, %u submitted, %u in flight, %u s elapsed",
-                m_CompletedCount, m_TargetUploadCount, m_SubmittedCount, in_flight,
+                m_CompletedCount, TARGET_UPLOAD_COUNT, m_SubmittedCount, in_flight,
                 (uint32_t) ((now - m_StartTime) / (1000ULL * 1000ULL)));
             m_LastProgressTime = now;
         }
 
-        if (m_SubmittedCount == m_TargetUploadCount && m_CompletedCount == m_TargetUploadCount)
+        if (m_SubmittedCount == TARGET_UPLOAD_COUNT && m_CompletedCount == TARGET_UPLOAD_COUNT)
         {
             dmLogInfo("Async texture queue test: completed all %u uploads", m_CompletedCount);
             engine->m_Running = 0;
             return;
         }
 
-        if (now - m_StartTime > m_TestTimeoutUs)
+        if (now - m_StartTime > TEST_TIMEOUT_US)
         {
             dmLogError("Async texture queue test timed out: submitted=%u completed=%u",
                 m_SubmittedCount, m_CompletedCount);

--- a/engine/graphics/src/test/test_app_graphics.cpp
+++ b/engine/graphics/src/test/test_app_graphics.cpp
@@ -74,6 +74,24 @@ static bool HasArgument(const char* argument)
     return false;
 }
 
+static uint32_t GetEnvUInt(const char* name, uint32_t default_value)
+{
+    const char* value = getenv(name);
+    if (value == 0x0 || value[0] == 0)
+    {
+        return default_value;
+    }
+
+    char* end = 0x0;
+    unsigned long result = strtoul(value, &end, 10);
+    if (end == value || result == 0)
+    {
+        return default_value;
+    }
+
+    return (uint32_t) result;
+}
+
 struct RunLoopParams
 {
     int     m_Argc;
@@ -669,11 +687,12 @@ struct AsyncTextureUploadQueueTest : ITest
         bool                         m_Pending;
     };
 
-    static const uint32_t TEXTURE_WIDTH         = 128;
-    static const uint32_t TEXTURE_HEIGHT        = 128;
-    static const uint32_t MAX_UPLOADS_IN_FLIGHT = 128;
-    static const uint32_t TARGET_UPLOAD_COUNT   = 512;
-    static const uint64_t TEST_TIMEOUT_US       = 60ULL * 1000ULL * 1000ULL;
+    static const uint32_t DEFAULT_TEXTURE_WIDTH         = 128;
+    static const uint32_t DEFAULT_TEXTURE_HEIGHT        = 128;
+    static const uint32_t DEFAULT_MAX_UPLOADS_IN_FLIGHT = 128;
+    static const uint32_t DEFAULT_TARGET_UPLOAD_COUNT   = 512*5;
+    static const uint32_t DEFAULT_TEST_TIMEOUT_S        = 60*2;
+    static const uint64_t PROGRESS_LOG_INTERVAL_US      = 1000ULL * 1000ULL;
 
     EngineCtx*                 m_Engine;
     dmArray<UploadSlot>        m_Uploads;
@@ -682,6 +701,12 @@ struct AsyncTextureUploadQueueTest : ITest
     uint32_t                   m_SubmittedCount;
     uint32_t                   m_CompletedCount;
     uint64_t                   m_StartTime;
+    uint64_t                   m_LastProgressTime;
+    uint32_t                   m_TextureWidth;
+    uint32_t                   m_TextureHeight;
+    uint32_t                   m_MaxUploadsInFlight;
+    uint32_t                   m_TargetUploadCount;
+    uint64_t                   m_TestTimeoutUs;
     bool                       m_CallbackFailed;
 
     AsyncTextureUploadQueueTest()
@@ -690,6 +715,12 @@ struct AsyncTextureUploadQueueTest : ITest
     , m_SubmittedCount(0)
     , m_CompletedCount(0)
     , m_StartTime(0)
+    , m_LastProgressTime(0)
+    , m_TextureWidth(DEFAULT_TEXTURE_WIDTH)
+    , m_TextureHeight(DEFAULT_TEXTURE_HEIGHT)
+    , m_MaxUploadsInFlight(DEFAULT_MAX_UPLOADS_IN_FLIGHT)
+    , m_TargetUploadCount(DEFAULT_TARGET_UPLOAD_COUNT)
+    , m_TestTimeoutUs((uint64_t) DEFAULT_TEST_TIMEOUT_S * 1000ULL * 1000ULL)
     , m_CallbackFailed(false)
     {
     }
@@ -719,7 +750,7 @@ struct AsyncTextureUploadQueueTest : ITest
 
     void SubmitUploads()
     {
-        for (uint32_t i = 0; i < m_Uploads.Size() && m_SubmittedCount < TARGET_UPLOAD_COUNT; ++i)
+        for (uint32_t i = 0; i < m_Uploads.Size() && m_SubmittedCount < m_TargetUploadCount; ++i)
         {
             UploadSlot& slot = m_Uploads[i];
             if (slot.m_Pending)
@@ -737,8 +768,33 @@ struct AsyncTextureUploadQueueTest : ITest
     {
         m_Engine = engine;
         m_StartTime = dmTime::GetMonotonicTime();
+        m_LastProgressTime = m_StartTime;
+        m_TextureWidth       = GetEnvUInt("DEFOLD_ASYNC_TEXTURE_WIDTH", DEFAULT_TEXTURE_WIDTH);
+        m_TextureHeight      = GetEnvUInt("DEFOLD_ASYNC_TEXTURE_HEIGHT", DEFAULT_TEXTURE_HEIGHT);
+        m_MaxUploadsInFlight = GetEnvUInt("DEFOLD_ASYNC_TEXTURE_IN_FLIGHT", DEFAULT_MAX_UPLOADS_IN_FLIGHT);
+        m_TargetUploadCount  = GetEnvUInt("DEFOLD_ASYNC_TEXTURE_UPLOADS", DEFAULT_TARGET_UPLOAD_COUNT);
+        m_TestTimeoutUs      = (uint64_t) GetEnvUInt("DEFOLD_ASYNC_TEXTURE_TIMEOUT_S", DEFAULT_TEST_TIMEOUT_S) * 1000ULL * 1000ULL;
 
-        const uint32_t texture_data_size = TEXTURE_WIDTH * TEXTURE_HEIGHT * 4;
+        if (m_TextureWidth > 0xffff || m_TextureHeight > 0xffff)
+        {
+            dmLogError("Async texture queue test dimensions are too large: %ux%u", m_TextureWidth, m_TextureHeight);
+            engine->m_Failed = true;
+            return;
+        }
+
+        const uint64_t texture_data_size_64 = (uint64_t) m_TextureWidth * m_TextureHeight * 4;
+        if (texture_data_size_64 > 0xffffffffULL)
+        {
+            dmLogError("Async texture queue test texture data is too large: %llu bytes", (unsigned long long) texture_data_size_64);
+            engine->m_Failed = true;
+            return;
+        }
+
+        dmLogInfo("Async texture queue test: %ux%u RGBA, %u in flight, %u total uploads, %u s timeout",
+            m_TextureWidth, m_TextureHeight, m_MaxUploadsInFlight, m_TargetUploadCount,
+            (uint32_t) (m_TestTimeoutUs / (1000ULL * 1000ULL)));
+
+        const uint32_t texture_data_size = (uint32_t) texture_data_size_64;
         m_TextureData = new uint8_t[texture_data_size];
         for (uint32_t i = 0; i < texture_data_size; ++i)
         {
@@ -747,18 +803,18 @@ struct AsyncTextureUploadQueueTest : ITest
 
         m_TextureParams.m_DataSize = texture_data_size;
         m_TextureParams.m_Data     = m_TextureData;
-        m_TextureParams.m_Width    = TEXTURE_WIDTH;
-        m_TextureParams.m_Height   = TEXTURE_HEIGHT;
+        m_TextureParams.m_Width    = (uint16_t) m_TextureWidth;
+        m_TextureParams.m_Height   = (uint16_t) m_TextureHeight;
         m_TextureParams.m_Format   = dmGraphics::TEXTURE_FORMAT_RGBA;
 
-        m_Uploads.SetCapacity(MAX_UPLOADS_IN_FLIGHT);
-        m_Uploads.SetSize(MAX_UPLOADS_IN_FLIGHT);
+        m_Uploads.SetCapacity(m_MaxUploadsInFlight);
+        m_Uploads.SetSize(m_MaxUploadsInFlight);
 
         dmGraphics::TextureCreationParams creation_params;
-        creation_params.m_Width          = TEXTURE_WIDTH;
-        creation_params.m_Height         = TEXTURE_HEIGHT;
-        creation_params.m_OriginalWidth  = TEXTURE_WIDTH;
-        creation_params.m_OriginalHeight = TEXTURE_HEIGHT;
+        creation_params.m_Width          = (uint16_t) m_TextureWidth;
+        creation_params.m_Height         = (uint16_t) m_TextureHeight;
+        creation_params.m_OriginalWidth  = (uint16_t) m_TextureWidth;
+        creation_params.m_OriginalHeight = (uint16_t) m_TextureHeight;
         creation_params.m_MipMapCount    = 1;
 
         for (uint32_t i = 0; i < m_Uploads.Size(); ++i)
@@ -787,14 +843,24 @@ struct AsyncTextureUploadQueueTest : ITest
 
         SubmitUploads();
 
-        if (m_SubmittedCount == TARGET_UPLOAD_COUNT && m_CompletedCount == TARGET_UPLOAD_COUNT)
+        uint64_t now = dmTime::GetMonotonicTime();
+        if (now - m_LastProgressTime >= PROGRESS_LOG_INTERVAL_US)
+        {
+            uint32_t in_flight = m_SubmittedCount - m_CompletedCount;
+            dmLogInfo("Async texture queue test: progress %u/%u completed, %u submitted, %u in flight, %u s elapsed",
+                m_CompletedCount, m_TargetUploadCount, m_SubmittedCount, in_flight,
+                (uint32_t) ((now - m_StartTime) / (1000ULL * 1000ULL)));
+            m_LastProgressTime = now;
+        }
+
+        if (m_SubmittedCount == m_TargetUploadCount && m_CompletedCount == m_TargetUploadCount)
         {
             dmLogInfo("Async texture queue test: completed all %u uploads", m_CompletedCount);
             engine->m_Running = 0;
             return;
         }
 
-        if (dmTime::GetMonotonicTime() - m_StartTime > TEST_TIMEOUT_US)
+        if (now - m_StartTime > m_TestTimeoutUs)
         {
             dmLogError("Async texture queue test timed out: submitted=%u completed=%u",
                 m_SubmittedCount, m_CompletedCount);
@@ -1252,9 +1318,9 @@ static void* EngineCreate(int argc, char** argv)
     graphics_context_params.m_DefaultTextureMinFilter = dmGraphics::TEXTURE_FILTER_LINEAR_MIPMAP_NEAREST;
     graphics_context_params.m_DefaultTextureMagFilter = dmGraphics::TEXTURE_FILTER_LINEAR_MIPMAP_NEAREST;
     graphics_context_params.m_VerifyGraphicsCalls     = 1;
-#if defined(DM_VULKAN_VALIDATION)
+//#if defined(DM_VULKAN_VALIDATION)
     graphics_context_params.m_UseValidationLayers     = 1;
-#endif
+//#endif
     graphics_context_params.m_Window                  = engine->m_Window;
     graphics_context_params.m_Width                   = 512;
     graphics_context_params.m_Height                  = 512;

--- a/engine/graphics/src/vulkan/graphics_native.cpp
+++ b/engine/graphics/src/vulkan/graphics_native.cpp
@@ -149,9 +149,7 @@ namespace dmGraphics
 
         if (dmPlatform::GetWindowStateParam(context->m_BaseContext.m_Window, WINDOW_STATE_OPENED))
         {
-            VkDevice vk_device = context->m_LogicalDevice.m_Device;
-
-            SynchronizeDevice(vk_device);
+            SynchronizeDevice(&context->m_LogicalDevice);
 
             VulkanDestroyResources(_context);
 

--- a/engine/graphics/src/vulkan/graphics_vulkan.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan.cpp
@@ -2134,6 +2134,7 @@ bail:
 
         res = WriteToDeviceBuffer(context->m_LogicalDevice.m_Device, size, offset, data, bufferOut);
         CHECK_VK_ERROR(res);
+        TouchResource(context, bufferOut);
 
         if (!context->m_FrameBegun)
         {
@@ -2232,16 +2233,11 @@ bail:
             return;
         }
 
-        if (offset == 0)
+        if (offset == 0 && !buffer->m_Destroyed && buffer->m_Handle.m_Buffer != VK_NULL_HANDLE)
         {
-            // Coherent memory writes does not seem to be properly synced on MoltenVK,
-            // so for now we always mark the old buffer for destruction when updating the data.
-        #ifndef __MACH__
-            if (size != buffer->m_Base.m_Size)
-        #endif
-            {
-                DestroyResourceDeferred(context, buffer);
-            }
+            // Full updates replace the logical contents of the buffer. Vulkan command buffers keep
+            // references to VkBuffer storage, so do not overwrite storage that recorded draws may use.
+            DestroyResourceDeferred(context, buffer);
         }
 
         DeviceBufferUploadHelper(context, data, size, offset, buffer);
@@ -2420,8 +2416,8 @@ bail:
         DM_PROFILE(__FUNCTION__);
         assert(buffer);
         DeviceBuffer* buffer_ptr = (DeviceBuffer*) buffer;
-        assert(offset + size < buffer_ptr->m_Base.m_Size);
-        DeviceBufferUploadHelper(g_VulkanContext, data, size, 0, buffer_ptr);
+        assert(offset + size <= buffer_ptr->m_Base.m_Size);
+        DeviceBufferUploadHelper(g_VulkanContext, data, size, offset, buffer_ptr);
     }
 
     static bool VulkanIsIndexBufferFormatSupported(HContext _context, IndexBufferFormat format)

--- a/engine/graphics/src/vulkan/graphics_vulkan.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan.cpp
@@ -681,9 +681,7 @@ namespace dmGraphics
 
         if (res == VK_SUCCESS)
         {
-            res = TransitionImageLayout(vk_device,
-                context->m_LogicalDevice.m_CommandPool,
-                context->m_LogicalDevice.m_GraphicsQueue,
+            res = TransitionImageLayout(&context->m_LogicalDevice,
                 depth_stencil_texture_out,
                 vk_aspect_flags,
                 VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL);
@@ -1889,7 +1887,7 @@ bail:
         submitInfo.signalSemaphoreCount = 1;
         submitInfo.pSignalSemaphores    = &renderFinishedSemaphore;
 
-        res = vkQueueSubmit(context->m_LogicalDevice.m_GraphicsQueue, 1, &submitInfo, currentFrame.m_SubmitFence);
+        res = QueueSubmit(&context->m_LogicalDevice, 1, &submitInfo, currentFrame.m_SubmitFence);
         CHECK_VK_ERROR(res);
 
         // Present the swapchain image
@@ -1913,7 +1911,7 @@ bail:
             presentInfo.pNext = &present_id_info;
         }
 
-        res = vkQueuePresentKHR(context->m_LogicalDevice.m_PresentQueue, &presentInfo);
+        res = QueuePresent(&context->m_LogicalDevice, &presentInfo);
         if ((res == VK_SUCCESS || res == VK_SUBOPTIMAL_KHR) && present_id != 0)
         {
             context->m_SwapChain->m_LastPresentId = present_id;
@@ -2716,9 +2714,7 @@ bail:
         //       It would be better if we could decouple this somehow. Perhaps we can solve it by buffering all render events (with a render graph?)
         if (texture->m_ImageLayout[0] != image_layout && image_layout != VK_IMAGE_LAYOUT_UNDEFINED)
         {
-            VkResult res = TransitionImageLayout(context->m_LogicalDevice.m_Device,
-                context->m_LogicalDevice.m_CommandPool,
-                context->m_LogicalDevice.m_GraphicsQueue,
+            VkResult res = TransitionImageLayout(&context->m_LogicalDevice,
                 texture,
                 VK_IMAGE_ASPECT_COLOR_BIT,
                 image_layout);
@@ -4330,9 +4326,7 @@ bail:
                     new_texture_color);
                 CHECK_VK_ERROR(res);
 
-                res = TransitionImageLayout(context->m_LogicalDevice.m_Device,
-                    context->m_LogicalDevice.m_CommandPool,
-                    context->m_LogicalDevice.m_GraphicsQueue,
+                res = TransitionImageLayout(&context->m_LogicalDevice,
                     new_texture_color,
                     VK_IMAGE_ASPECT_COLOR_BIT,
                     VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
@@ -4724,8 +4718,7 @@ bail:
 
         VkFence submit_fence;
         res = SubmitCommandBuffer(
-            context->m_LogicalDevice.m_Device,
-            context->m_LogicalDevice.m_GraphicsQueue,
+            &context->m_LogicalDevice,
             vk_command_buffer,
             &submit_fence);
         CHECK_VK_ERROR(res);
@@ -5112,13 +5105,13 @@ bail:
             TransitionImageLayoutWithCmdBuffer(cmd_buffer, tex, VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, ap.m_Params.m_MipMap, tex_layer_count);
 
             VkFence fence;
-            VkResult res = SubmitCommandBuffer(context->m_LogicalDevice.m_Device, context->m_LogicalDevice.m_GraphicsQueue, cmd_buffer, &fence);
+            VkResult res = SubmitCommandBuffer(&context->m_LogicalDevice, cmd_buffer, &fence);
             CHECK_VK_ERROR(res);
 
             if (!is_memoryless)
             {
                 // We wait for the fence here so we don't keep a bunch of large buffers around.
-                // Waiting for the fence should be fine here anyway, since we have commited the work on a different queue than the "main" graphics queue
+                // The queue mutex is released before this wait so frame submissions can continue.
                 vkWaitForFences(context->m_LogicalDevice.m_Device, 1, &fence, VK_TRUE, UINT64_MAX);
                 vkDestroyFence(context->m_LogicalDevice.m_Device, fence, NULL);
                 DestroyDeviceBuffer(context->m_LogicalDevice.m_Device, &stage_buffer.m_Handle);
@@ -5451,7 +5444,7 @@ bail:
             1);
 
         VkFence fence;
-        res = SubmitCommandBuffer(context->m_LogicalDevice.m_Device, context->m_LogicalDevice.m_GraphicsQueue, vk_command_buffer, &fence);
+        res = SubmitCommandBuffer(&context->m_LogicalDevice, vk_command_buffer, &fence);
         CHECK_VK_ERROR(res);
 
         // Wait for the copy command to finish

--- a/engine/graphics/src/vulkan/graphics_vulkan.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan.cpp
@@ -2134,7 +2134,10 @@ bail:
 
         res = WriteToDeviceBuffer(context->m_LogicalDevice.m_Device, size, offset, data, bufferOut);
         CHECK_VK_ERROR(res);
-        TouchResource(context, bufferOut);
+        if (context->m_FrameBegun)
+        {
+            TouchResource(context, bufferOut);
+        }
 
         if (!context->m_FrameBegun)
         {
@@ -2237,6 +2240,11 @@ bail:
         {
             // Full updates replace the logical contents of the buffer. Vulkan command buffers keep
             // references to VkBuffer storage, so do not overwrite storage that recorded draws may use.
+            // This is a correctness-first form of buffer renaming; longer term, frequent dynamic
+            // uploads should avoid vkCreateBuffer/vkAllocateMemory churn by either writing transient
+            // vertex/index data into per-frame persistently mapped ring buffers with fresh draw
+            // offsets, or by keeping a small pool of backing buffers per logical buffer and reusing
+            // retired storage once the owning frame fence has signaled.
             DestroyResourceDeferred(context, buffer);
         }
 

--- a/engine/graphics/src/vulkan/graphics_vulkan.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan.cpp
@@ -952,7 +952,7 @@ namespace dmGraphics
         }
 
         // Flush all current commands
-        SynchronizeDevice(vk_device);
+        SynchronizeDevice(&context->m_LogicalDevice);
 
         DestroyMainFrameBuffers(context);
 
@@ -1007,7 +1007,7 @@ namespace dmGraphics
         CHECK_VK_ERROR(res);
 
         // Flush once again to make sure all transitions are complete
-        SynchronizeDevice(vk_device);
+        SynchronizeDevice(&context->m_LogicalDevice);
     }
 
     static void DestroyResourceImmediatedly(VulkanContext* context, ResourceToDestroy* resource)

--- a/engine/graphics/src/vulkan/graphics_vulkan.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan.cpp
@@ -4758,13 +4758,15 @@ bail:
             return;
         }
 
-        TextureFormat format_orig   = params.m_Format;
-        uint8_t tex_layer_count     = dmMath::Max(texture->m_LayerCount, params.m_LayerCount);
-        uint16_t tex_depth          = dmMath::Max(texture->m_Base.m_Depth, params.m_Depth);
-        uint8_t tex_bpp             = GetTextureFormatBitsPerPixel(params.m_Format);
-        size_t tex_data_size_bpp    = params.m_DataSize * tex_layer_count * 8; // Convert into bits
-        void*  tex_data_ptr         = (void*)params.m_Data;
-        VkFormat vk_format          = GetVulkanFormatFromTextureFormat(params.m_Format);
+        TextureFormat format_orig       = params.m_Format;
+        uint16_t params_depth           = dmMath::Max((uint16_t) 1, params.m_Depth);
+        uint8_t params_layer_count      = dmMath::Max((uint8_t) 1, params.m_LayerCount);
+        uint8_t tex_layer_count         = dmMath::Max(texture->m_LayerCount, params_layer_count);
+        uint16_t tex_depth              = dmMath::Max(texture->m_Base.m_Depth, params_depth);
+        uint8_t tex_bpp                 = GetTextureFormatBitsPerPixel(params.m_Format);
+        size_t tex_data_size_bpp        = params.m_DataSize * tex_layer_count * 8; // Convert into bits
+        void*  tex_data_ptr             = (void*)params.m_Data;
+        VkFormat vk_format              = GetVulkanFormatFromTextureFormat(params.m_Format);
 
         if (vk_format == VK_FORMAT_UNDEFINED)
         {
@@ -4812,13 +4814,13 @@ bail:
             if (texture->m_Format != vk_format ||
                 texture->m_Base.m_Width != params.m_Width ||
                 texture->m_Base.m_Height != params.m_Height ||
-                (IsTextureType3D(texture->m_Base.m_Type) && (texture->m_Base.m_Depth != params.m_Depth)))
+                (IsTextureType3D(texture->m_Base.m_Type) && (texture->m_Base.m_Depth != params_depth)))
             {
                 DestroyResourceDeferred(context, texture);
                 texture->m_Format = vk_format;
                 texture->m_Base.m_Width  = params.m_Width;
                 texture->m_Base.m_Height = params.m_Height;
-                texture->m_Base.m_Depth  = params.m_Depth;
+                texture->m_Base.m_Depth  = params_depth;
 
                 // Note:
                 // If the texture has requested mipmaps and we need to recreate the texture, make sure to allocate enough mipmaps.
@@ -5195,18 +5197,20 @@ bail:
     static void PrepareTextureForUploading(VulkanContext* context, VulkanTexture* texture, const TextureParams& params)
     {
         VkFormat vk_format = GetVulkanFormatFromTextureFormat(params.m_Format);
+        uint16_t params_depth      = dmMath::Max((uint16_t) 1, params.m_Depth);
+        uint8_t params_layer_count = dmMath::Max((uint8_t) 1, params.m_LayerCount);
         if (!params.m_SubUpdate && params.m_MipMap == 0)
         {
             if (texture->m_Format != vk_format ||
                 texture->m_Base.m_Width != params.m_Width ||
                 texture->m_Base.m_Height != params.m_Height ||
-                (IsTextureType3D(texture->m_Base.m_Type) && (texture->m_Base.m_Depth != params.m_Depth)))
+                (IsTextureType3D(texture->m_Base.m_Type) && (texture->m_Base.m_Depth != params_depth)))
             {
                 DestroyResourceDeferred(context, texture);
                 texture->m_Format = vk_format;
                 texture->m_Base.m_Width  = params.m_Width;
                 texture->m_Base.m_Height = params.m_Height;
-                texture->m_Base.m_Depth  = params.m_Depth;
+                texture->m_Base.m_Depth  = params_depth;
 
                 // Note:
                 // If the texture has requested mipmaps and we need to recreate the texture, make sure to allocate enough mipmaps.
@@ -5228,8 +5232,8 @@ bail:
             VkImageUsageFlags vk_usage_flags        = VK_IMAGE_USAGE_TRANSFER_DST_BIT;
             VkFormatFeatureFlags vk_format_features = VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT;
             VkMemoryPropertyFlags vk_memory_type    = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
-            uint16_t tex_depth                      = dmMath::Max(texture->m_Base.m_Depth, params.m_Depth);
-            uint8_t tex_layer_count                 = dmMath::Max(texture->m_LayerCount, params.m_LayerCount);
+            uint16_t tex_depth                      = dmMath::Max(texture->m_Base.m_Depth, params_depth);
+            uint8_t tex_layer_count                 = dmMath::Max(texture->m_LayerCount, params_layer_count);
             TextureFormat format_orig               = params.m_Format;
             if (format_orig == TEXTURE_FORMAT_RGB)
             {

--- a/engine/graphics/src/vulkan/graphics_vulkan_device.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan_device.cpp
@@ -19,6 +19,10 @@
 #include "graphics_vulkan_defines.h"
 #include "graphics_vulkan_private.h"
 
+#ifndef DM_VULKAN_QUEUE_MUTEX_ENABLED
+#define DM_VULKAN_QUEUE_MUTEX_ENABLED 1
+#endif
+
 namespace dmGraphics
 {
     void InitializeVulkanTexture(VulkanTexture* t)
@@ -650,13 +654,17 @@ namespace dmGraphics
 
     VkResult QueueSubmit(LogicalDevice* logical_device, uint32_t submit_count, const VkSubmitInfo* submit_info, VkFence fence)
     {
+#if DM_VULKAN_QUEUE_MUTEX_ENABLED
         DM_MUTEX_SCOPED_LOCK(logical_device->m_QueueMutex);
+#endif
         return vkQueueSubmit(logical_device->m_GraphicsQueue, submit_count, submit_info, fence);
     }
 
     VkResult QueuePresent(LogicalDevice* logical_device, const VkPresentInfoKHR* present_info)
     {
+#if DM_VULKAN_QUEUE_MUTEX_ENABLED
         DM_MUTEX_SCOPED_LOCK(logical_device->m_QueueMutex);
+#endif
         return vkQueuePresentKHR(logical_device->m_PresentQueue, present_info);
     }
 
@@ -1768,6 +1776,9 @@ bail:
             if (res == VK_SUCCESS)
             {
                 logicalDeviceOut->m_QueueMutex = dmMutex::New();
+#if !DM_VULKAN_QUEUE_MUTEX_ENABLED
+                dmLogWarning("Vulkan queue submit/present mutex disabled by DM_VULKAN_QUEUE_MUTEX_ENABLED=0");
+#endif
             }
         }
 

--- a/engine/graphics/src/vulkan/graphics_vulkan_device.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan_device.cpp
@@ -516,21 +516,21 @@ namespace dmGraphics
         texture->m_ImageLayout[base_mip_level] = new_layout;
     }
 
-    VkResult TransitionImageLayout(VkDevice vk_device,
-        VkCommandPool vk_command_pool,
-        VkQueue vk_queue,
+    VkResult TransitionImageLayout(LogicalDevice* logical_device,
         VulkanTexture* texture,
         VkImageAspectFlags vk_image_aspect,
         VkImageLayout vk_to_layout,
         uint32_t base_mip_level,
         uint32_t layer_count)
     {
+        VkDevice vk_device = logical_device->m_Device;
+        VkCommandPool vk_command_pool = logical_device->m_CommandPool;
         VkCommandBuffer vk_command_buffer = BeginSingleTimeCommands(vk_device, vk_command_pool);
 
         TransitionImageLayoutWithCmdBuffer(vk_command_buffer, texture, vk_image_aspect, vk_to_layout, base_mip_level, layer_count);
 
         VkFence fence;
-        SubmitCommandBuffer(vk_device, vk_queue, vk_command_buffer, &fence);
+        SubmitCommandBuffer(logical_device, vk_command_buffer, &fence);
 
         // Wait for the copy command to finish
         vkWaitForFences(vk_device, 1, &fence, VK_TRUE, UINT64_MAX);
@@ -648,8 +648,21 @@ namespace dmGraphics
         return cmd_buffer;
     }
 
-    VkResult SubmitCommandBuffer(VkDevice vk_device, VkQueue queue, VkCommandBuffer cmd, VkFence* fence_out)
+    VkResult QueueSubmit(LogicalDevice* logical_device, uint32_t submit_count, const VkSubmitInfo* submit_info, VkFence fence)
     {
+        DM_MUTEX_SCOPED_LOCK(logical_device->m_QueueMutex);
+        return vkQueueSubmit(logical_device->m_GraphicsQueue, submit_count, submit_info, fence);
+    }
+
+    VkResult QueuePresent(LogicalDevice* logical_device, const VkPresentInfoKHR* present_info)
+    {
+        DM_MUTEX_SCOPED_LOCK(logical_device->m_QueueMutex);
+        return vkQueuePresentKHR(logical_device->m_PresentQueue, present_info);
+    }
+
+    VkResult SubmitCommandBuffer(LogicalDevice* logical_device, VkCommandBuffer cmd, VkFence* fence_out)
+    {
+        VkDevice vk_device = logical_device->m_Device;
         VkResult res = vkEndCommandBuffer(cmd);
         if (res != VK_SUCCESS)
         {
@@ -665,7 +678,7 @@ namespace dmGraphics
         submit_info.commandBufferCount = 1;
         submit_info.pCommandBuffers = &cmd;
 
-        res = vkQueueSubmit(queue, 1, &submit_info, fence);
+        res = QueueSubmit(logical_device, 1, &submit_info, fence);
         if (res != VK_SUCCESS)
         {
             return res;
@@ -1583,6 +1596,7 @@ bail:
         vkDestroyCommandPool(device->m_Device, device->m_CommandPool, 0);
         vkDestroyCommandPool(device->m_Device, device->m_CommandPoolWorker, 0);
         vkDestroyDevice(device->m_Device, 0);
+        dmMutex::Delete(device->m_QueueMutex);
         memset(device, 0, sizeof(*device));
     }
 
@@ -1749,6 +1763,11 @@ bail:
                 vk_create_pool_info.flags            = VK_COMMAND_POOL_CREATE_TRANSIENT_BIT;
 
                 res = vkCreateCommandPool(logicalDeviceOut->m_Device, &vk_create_pool_info, 0, &logicalDeviceOut->m_CommandPoolWorker);
+            }
+
+            if (res == VK_SUCCESS)
+            {
+                logicalDeviceOut->m_QueueMutex = dmMutex::New();
             }
         }
 

--- a/engine/graphics/src/vulkan/graphics_vulkan_device.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan_device.cpp
@@ -781,7 +781,7 @@ namespace dmGraphics
             return res;
         }
 
-        bufferOut->m_Base.m_Size = (uint32_t) vk_buffer_memory_req.size;
+        bufferOut->m_Base.m_Size = (uint32_t) vk_size;
         bufferOut->m_Destroyed   = 0;
 
         return VK_SUCCESS;

--- a/engine/graphics/src/vulkan/graphics_vulkan_device.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan_device.cpp
@@ -19,10 +19,6 @@
 #include "graphics_vulkan_defines.h"
 #include "graphics_vulkan_private.h"
 
-#ifndef DM_VULKAN_QUEUE_MUTEX_ENABLED
-#define DM_VULKAN_QUEUE_MUTEX_ENABLED 1
-#endif
-
 namespace dmGraphics
 {
     void InitializeVulkanTexture(VulkanTexture* t)
@@ -654,17 +650,13 @@ namespace dmGraphics
 
     VkResult QueueSubmit(LogicalDevice* logical_device, uint32_t submit_count, const VkSubmitInfo* submit_info, VkFence fence)
     {
-#if DM_VULKAN_QUEUE_MUTEX_ENABLED
         DM_MUTEX_SCOPED_LOCK(logical_device->m_QueueMutex);
-#endif
         return vkQueueSubmit(logical_device->m_GraphicsQueue, submit_count, submit_info, fence);
     }
 
     VkResult QueuePresent(LogicalDevice* logical_device, const VkPresentInfoKHR* present_info)
     {
-#if DM_VULKAN_QUEUE_MUTEX_ENABLED
         DM_MUTEX_SCOPED_LOCK(logical_device->m_QueueMutex);
-#endif
         return vkQueuePresentKHR(logical_device->m_PresentQueue, present_info);
     }
 
@@ -1776,9 +1768,6 @@ bail:
             if (res == VK_SUCCESS)
             {
                 logicalDeviceOut->m_QueueMutex = dmMutex::New();
-#if !DM_VULKAN_QUEUE_MUTEX_ENABLED
-                dmLogWarning("Vulkan queue submit/present mutex disabled by DM_VULKAN_QUEUE_MUTEX_ENABLED=0");
-#endif
             }
         }
 

--- a/engine/graphics/src/vulkan/graphics_vulkan_private.h
+++ b/engine/graphics/src/vulkan/graphics_vulkan_private.h
@@ -261,11 +261,12 @@ namespace dmGraphics
 
     struct LogicalDevice
     {
-        VkDevice      m_Device;
-        VkQueue       m_GraphicsQueue;
-        VkQueue       m_PresentQueue;
-        VkCommandPool m_CommandPool;
-        VkCommandPool m_CommandPoolWorker;
+        VkDevice        m_Device;
+        VkQueue         m_GraphicsQueue;
+        VkQueue         m_PresentQueue;
+        VkCommandPool   m_CommandPool;
+        VkCommandPool   m_CommandPoolWorker;
+        dmMutex::HMutex m_QueueMutex; // Serializes host access to both queue handles (which may alias).
     };
 
     struct ShaderModule
@@ -593,13 +594,15 @@ namespace dmGraphics
 
     // Misc functions
     void            TransitionImageLayoutWithCmdBuffer(VkCommandBuffer vk_command_buffer, VulkanTexture* texture, VkImageAspectFlags vk_image_aspect, VkImageLayout vk_to_layout, uint32_t base_mip_level, uint32_t layer_count);
-    VkResult        TransitionImageLayout(VkDevice vk_device, VkCommandPool vk_command_pool, VkQueue vk_graphics_queue, VulkanTexture* texture, VkImageAspectFlags vk_image_aspect, VkImageLayout vk_to_layout, uint32_t baseMipLevel = 0, uint32_t layer_count = 1);
+    VkResult        TransitionImageLayout(LogicalDevice* logical_device, VulkanTexture* texture, VkImageAspectFlags vk_image_aspect, VkImageLayout vk_to_layout, uint32_t baseMipLevel = 0, uint32_t layer_count = 1);
     VkResult        WriteToDeviceBuffer(VkDevice vk_device, VkDeviceSize size, VkDeviceSize offset, const void* data, DeviceBuffer* buffer);
     void            DestroyPipelineCacheCb(VulkanContext* context, const uint64_t* key, Pipeline* value);
     void            FlushResourcesToDestroy(VulkanContext* context, ResourcesToDestroyList* resource_list);
     void            ResetScratchBuffer(VkDevice vk_device, ScratchBuffer* scratchBuffer);
     VkCommandBuffer BeginSingleTimeCommands(VkDevice device, VkCommandPool cmd_pool);
-    VkResult        SubmitCommandBuffer(VkDevice vk_device, VkQueue queue, VkCommandBuffer cmd, VkFence* fence_out);
+    VkResult        QueueSubmit(LogicalDevice* logical_device, uint32_t submit_count, const VkSubmitInfo* submit_info, VkFence fence);
+    VkResult        QueuePresent(LogicalDevice* logical_device, const VkPresentInfoKHR* present_info);
+    VkResult        SubmitCommandBuffer(LogicalDevice* logical_device, VkCommandBuffer cmd, VkFence* fence_out);
 
     // Implemented in graphics_vulkan_swap_chain.cpp
     //   wantedWidth and wantedHeight might be written to, we might not get the

--- a/engine/graphics/src/vulkan/graphics_vulkan_private.h
+++ b/engine/graphics/src/vulkan/graphics_vulkan_private.h
@@ -623,9 +623,10 @@ namespace dmGraphics
     int  OnWindowClose();
     void OnWindowFocus(int focus);
 
-    static inline void SynchronizeDevice(VkDevice vk_device)
+    static inline void SynchronizeDevice(LogicalDevice* logical_device)
     {
-        vkDeviceWaitIdle(vk_device);
+        DM_MUTEX_SCOPED_LOCK(logical_device->m_QueueMutex);
+        vkDeviceWaitIdle(logical_device->m_Device);
     }
 
     // Implemented per supported platform

--- a/engine/graphics/src/vulkan/graphics_vulkan_private.h
+++ b/engine/graphics/src/vulkan/graphics_vulkan_private.h
@@ -48,7 +48,11 @@ namespace dmGraphics
     {
         DeviceBuffer()
         : m_Base()
+        , m_MappedDataPtr(0)
+        , m_Usage(0)
+        , m_Destroyed(0)
         {
+            memset(&m_Handle, 0, sizeof(m_Handle));
         }
         DeviceBuffer(const VkBufferUsageFlags usage)
         : m_Base()

--- a/engine/graphics/src/vulkan/graphics_vulkan_swap_chain.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan_swap_chain.cpp
@@ -293,8 +293,8 @@ namespace dmGraphics
                 return res;
             }
 
-            res = TransitionImageLayout(vk_device, logicalDevice->m_CommandPool, logicalDevice->m_GraphicsQueue,
-                swapChain->m_ResolveTexture, VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
+            res = TransitionImageLayout(logicalDevice, swapChain->m_ResolveTexture,
+                VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
             if (res != VK_SUCCESS)
             {
                 return res;


### PR DESCRIPTION
### Technical changes

* Serializes Vulkan queue access for vkQueueSubmit and vkQueuePresentKHR through LogicalDevice::m_QueueMutex.
* Adds an async texture upload queue regression/stress test covering concurrent upload-worker queue usage while the main thread submits/presents frames.
* Fixes Vulkan dynamic vertex/index buffer overwrites by deferring old buffer storage on full buffer data uploads instead of overwriting storage that may still be referenced by recorded command buffers.
* Corrects Vulkan index buffer sub-data uploads to write at the requested byte offset.
* Tracks Vulkan buffer logical size from the requested vkCreateBuffer size instead of the padded memory allocation requirement.
* Fully initializes default-constructed Vulkan DeviceBuffer objects.
* Avoids retagging buffer frame ownership for CPU-only uploads performed outside an active frame.
* Simplifies the async texture queue test by using fixed stress-test parameters instead of environment-variable configuration.