### PR TITLE
Show variable values when hovering code while the debugger is paused

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -388,6 +388,7 @@
   (input sub-selections-by-resource-node g/Any)
   (input debugger-sidebar-panes g/Any)
   (input debugger-execution-locations g/Any)
+  (input debugger-suspension-variables g/Any)
   (input scene-visibility g/NodeID)
 
   (output open-sidebar-panes g/Any :cached (g/fnk [open-sidebar-panes] (into {} open-sidebar-panes)))
@@ -441,7 +442,8 @@
                                                             resource (:resource (get open-views view))]
                                                       :when resource]
                                                 (ui/text! tab (tab-title resource (contains? open-dirty-views view)))))))
-  (output debugger-execution-locations g/Any (gu/passthrough debugger-execution-locations)))
+  (output debugger-execution-locations g/Any (gu/passthrough debugger-execution-locations))
+  (output debugger-suspension-variables g/Any (gu/passthrough debugger-suspension-variables)))
 
 (defn- selection->openable-resources [selection evaluation-context]
   (when-let [resources (handler/adapt-every selection resource/Resource evaluation-context)]

--- a/editor/src/clj/editor/code/data.clj
+++ b/editor/src/clj/editor/code/data.clj
@@ -1065,6 +1065,48 @@
         (->CursorRange (->Cursor row start-col)
                        (->Cursor row end-col))))))
 
+(defn- extend-identifier-cursor-range-backward-across-dot
+  "If `cursor-range` is immediately preceded by a '.' that is itself preceded
+  by an identifier character, returns a cursor range whose `from` is extended
+  backward to cover that preceding identifier segment and the dot. Otherwise
+  returns `cursor-range` unchanged."
+  ^CursorRange [lines ^CursorRange cursor-range]
+  (let [from (cursor-range-start cursor-range)
+        row (.row from)
+        line (lines row)
+        dot-col (dec (.col from))]
+    (if (and (= \. (get line dot-col))
+             (identifier-character-at-index? line (dec dot-col)))
+      (let [segment-cursor-range (word-cursor-range-at-cursor lines (->Cursor row (dec dot-col)))]
+        (->CursorRange (cursor-range-start segment-cursor-range) (cursor-range-end cursor-range)))
+      cursor-range)))
+
+(defn identifier-expression-at-cursor
+  "Returns {:text \"self.field\" :cursor-range <CursorRange>} for the
+  identifier or dotted identifier chain at `cursor`, or nil when `cursor` is
+  not over an identifier character or the word begins with a digit. The range
+  extends backward across '.'-separated segments - hovering \"field\" in
+  \"self.field\" yields the whole chain - and never forward. ':' does not
+  join segments; it is a method call, not an indexable value."
+  [lines cursor]
+  (let [adjusted-cursor (adjust-cursor lines cursor)
+        row (.row adjusted-cursor)
+        col (.col adjusted-cursor)
+        line (lines row)]
+    (when (and (< col (count line))
+               (identifier-character-at-index? line col))
+      (let [word-cursor-range (word-cursor-range-at-cursor lines adjusted-cursor)
+            word-text (cursor-range-text lines word-cursor-range)]
+        (when-not (Character/isDigit (.charAt ^String word-text 0))
+          (let [expression-cursor-range
+                (loop [cursor-range word-cursor-range]
+                  (let [extended-cursor-range (extend-identifier-cursor-range-backward-across-dot lines cursor-range)]
+                    (if (= extended-cursor-range cursor-range)
+                      cursor-range
+                      (recur extended-cursor-range))))]
+            {:text (cursor-range-text lines expression-cursor-range)
+             :cursor-range expression-cursor-range}))))))
+
 (defn word-cursor-range? [lines ^CursorRange adjusted-cursor-range]
   (let [cursor (cursor-range-start adjusted-cursor-range)
         word-cursor-range (word-cursor-range-at-cursor lines cursor)]

--- a/editor/src/clj/editor/code/view.clj
+++ b/editor/src/clj/editor/code/view.clj
@@ -1555,9 +1555,10 @@
   ;; both popup and canvas mouse events...
   (property hover-mouse-over-popup g/Bool (default false) (dynamic visible (g/constantly false)))
   ;; all displayed hovered regions
-  (output hover-showing-regions g/Any :cached (g/fnk [visible-regions hover-showing-cursor hover-showing-debug-region]
+  (output hover-showing-regions g/Any :cached (g/fnk [visible-regions hover-showing-cursor hover-showing-debug-region debugger-suspension-variables]
                                                 (when hover-showing-cursor
-                                                  (let [debug-region (when (and hover-showing-debug-region
+                                                  (let [debug-region (when (and debugger-suspension-variables
+                                                                                hover-showing-debug-region
                                                                                 (data/cursor-range-contains-exclusive? hover-showing-debug-region hover-showing-cursor))
                                                                        hover-showing-debug-region)
                                                         lsp-regions (->> visible-regions
@@ -2735,7 +2736,7 @@
                                  (when (and (= :suspended (mobdebug/state debug-session))
                                             (compare-and-set! debug-hover-eval-in-flight false true))
                                    (try
-                                     (let [ret (mobdebug/exec debug-session text 0)]
+                                     (let [ret (mobdebug/exec debug-session text (:frame-index suspension-variables 0))]
                                        (when-some [result (:result ret)]
                                          (when-some [[_ value] (first result)]
                                            (variable-hover/evaluated-region text value cursor-range))))

--- a/editor/src/clj/editor/code/view.clj
+++ b/editor/src/clj/editor/code/view.clj
@@ -31,6 +31,7 @@
             [cljfx.fx.text-field :as fx.text-field]
             [cljfx.fx.tree-cell :as fx.tree-cell]
             [cljfx.fx.tree-item :as fx.tree-item]
+            [cljfx.fx.tree-view :as fx.tree-view]
             [cljfx.fx.v-box :as fx.v-box]
             [cljfx.lifecycle :as fx.lifecycle]
             [cljfx.mutator :as mutator]
@@ -42,6 +43,9 @@
             [editor.code.data :as data]
             [editor.code.resource :as r]
             [editor.code.util :refer [split-lines]]
+            [editor.debugging.mobdebug :as mobdebug]
+            [editor.debugging.variable-hover :as variable-hover]
+            [editor.debugging.variable-tree :as variable-tree]
             [editor.defold-project :as project]
             [editor.dialogs :as dialogs]
             [editor.editor-extensions.node-types :as node-types]
@@ -52,6 +56,7 @@
             [editor.keymap :as keymap]
             [editor.localization :as localization]
             [editor.lsp :as lsp]
+            [editor.lua :as lua]
             [editor.markdown :as markdown]
             [editor.menu-items :as menu-items]
             [editor.notifications :as notifications]
@@ -1544,17 +1549,24 @@
   (property hover-cursor-lsp-regions g/Any (dynamic visible (g/constantly false)))
   ;; hover regions for the showing cursor, visible
   (property hover-showing-lsp-regions g/Any (dynamic visible (g/constantly false)))
+  ;; debug variable hover region for the showing cursor, visible; resolved async while suspended
+  (property hover-showing-debug-region g/Any (dynamic visible (g/constantly false)))
   ;; we need to track if we are hovering the popup because on Windows we receive
   ;; both popup and canvas mouse events...
   (property hover-mouse-over-popup g/Bool (default false) (dynamic visible (g/constantly false)))
   ;; all displayed hovered regions
-  (output hover-showing-regions g/Any :cached (g/fnk [visible-regions hover-showing-cursor]
+  (output hover-showing-regions g/Any :cached (g/fnk [visible-regions hover-showing-cursor hover-showing-debug-region]
                                                 (when hover-showing-cursor
-                                                  (->> visible-regions
-                                                       (e/filter :hoverable)
-                                                       (e/filter #(data/cursor-range-contains-exclusive? % hover-showing-cursor))
-                                                       vec
-                                                       coll/not-empty))))
+                                                  (let [debug-region (when (and hover-showing-debug-region
+                                                                                (data/cursor-range-contains-exclusive? hover-showing-debug-region hover-showing-cursor))
+                                                                       hover-showing-debug-region)
+                                                        lsp-regions (->> visible-regions
+                                                                         (e/filter :hoverable)
+                                                                         (e/filter #(data/cursor-range-contains-exclusive? % hover-showing-cursor))
+                                                                         (e/filter #(or (nil? debug-region) (not= :hover (:type %))))
+                                                                         vec)]
+                                                    (coll/not-empty
+                                                      (cond->> lsp-regions debug-region (into [debug-region])))))))
   ;; when showing a hover, this is a region that is considered a single hovered thing
   (output hover-showing-region g/Any :cached (g/fnk [hover-showing-regions ^Cursor hover-showing-cursor]
                                                (when hover-showing-cursor
@@ -1610,6 +1622,7 @@
   (input open-views g/Any) ;; open views from app-view
   (input project g/NodeID) ;; used for completions doc popup, e.g. for opening defold:// URIs
   (input debugger-execution-locations g/Any)
+  (input debugger-suspension-variables g/Any)
   (input keymap g/Any)
 
   (output completion-context g/Any :cached produce-completion-context)
@@ -1874,7 +1887,7 @@
                     :completions-previous-combined-ids nil}))
 
 (defn- hide-hover! [view-node]
-  (set-properties! view-node nil {:hover-showing-cursor nil :hover-showing-lsp-regions nil :hover-mouse-over-popup false}))
+  (set-properties! view-node nil {:hover-showing-cursor nil :hover-showing-lsp-regions nil :hover-showing-debug-region nil :hover-mouse-over-popup false}))
 
 (defn- suggestions-shown? [view-node]
   (g/with-auto-evaluation-context evaluation-context
@@ -2692,6 +2705,54 @@
                                   {:hover-showing-lsp-regions hover-lsp-regions}))]
           (set-properties! view-node nil properties))))))
 
+;; one debug session serves all editor views; at most one hover EXEC runs
+;; against it at a time
+(defonce ^:private debug-hover-eval-in-flight (atom false))
+
+(def ^:private debug-hover-eval-excluded-words
+  "Words the expression extractor accepts but that never name a value worth a
+  debugger evaluation round-trip."
+  (reduce into #{} [lua/control-flow-keywords lua/logic-keywords lua/lua-constants]))
+
+(defn- request-debug-hover!
+  "Resolves the debug value at `request-cursor` and stores it in
+  `:hover-showing-debug-region`. Runs off the FX thread since resolution can
+  block on debugger socket round-trips."
+  [view-node request-cursor evaluation-context]
+  (when-some [suspension-variables (get-property view-node :debugger-suspension-variables evaluation-context)]
+    (let [lines (get-property view-node :lines evaluation-context)
+          node-id+type+resource (get-property view-node :node-id+type+resource evaluation-context)]
+      (future
+        (try
+          (let [proj-path (some-> node-id+type+resource (get 2) resource/proj-path)
+                expr (data/identifier-expression-at-cursor lines request-cursor)
+                region (variable-hover/variable-hover-region suspension-variables proj-path expr)
+                region (or region
+                           (when-some [{:keys [text cursor-range]} expr]
+                             (when (and (= proj-path (:file suspension-variables))
+                                        (not (contains? debug-hover-eval-excluded-words text)))
+                               (when-some [debug-session (:debug-session suspension-variables)]
+                                 (when (and (= :suspended (mobdebug/state debug-session))
+                                            (compare-and-set! debug-hover-eval-in-flight false true))
+                                   (try
+                                     (let [ret (mobdebug/exec debug-session text 0)]
+                                       (when-some [result (:result ret)]
+                                         (when-some [[_ value] (first result)]
+                                           (variable-hover/evaluated-region text value cursor-range))))
+                                     (finally
+                                       (reset! debug-hover-eval-in-flight false))))))))]
+            (ui/run-later
+              (when (g/node-exists? view-node)
+                (let [showing-cursor (get-property view-node :hover-showing-cursor)]
+                  ;; the pointer may have moved within the token while resolution ran
+                  (when (or (= request-cursor showing-cursor)
+                            (and region
+                                 showing-cursor
+                                 (data/cursor-range-contains-exclusive? region showing-cursor)))
+                    (set-properties! view-node nil {:hover-showing-debug-region region}))))))
+          (catch Throwable error
+            (error-reporting/report-exception! error)))))))
+
 (defn- refresh-hover-state! [view-node]
   (when (g/node-exists? view-node)
     (set-properties!
@@ -2699,10 +2760,16 @@
       (g/with-auto-evaluation-context evaluation-context
         (if-let [hover-cursor (when (some-> ^Canvas (get-property view-node :canvas evaluation-context) .getScene .getWindow .isFocused)
                                 (get-property view-node :hover-cursor evaluation-context))]
-          {:hover-showing-cursor hover-cursor
-           :hover-showing-lsp-regions (mapv #(assoc % :hoverable true) (get-property view-node :hover-cursor-lsp-regions evaluation-context))}
+          (do
+            (request-debug-hover! view-node hover-cursor evaluation-context)
+            {:hover-showing-cursor hover-cursor
+             :hover-showing-lsp-regions (mapv #(assoc % :hoverable true) (get-property view-node :hover-cursor-lsp-regions evaluation-context))
+             :hover-showing-debug-region (when-some [showing-region (get-property view-node :hover-showing-debug-region evaluation-context)]
+                                           (when (data/cursor-range-contains-exclusive? showing-region hover-cursor)
+                                             showing-region))})
           {:hover-showing-cursor nil
            :hover-showing-lsp-regions nil
+           :hover-showing-debug-region nil
            :hover-mouse-over-popup false})))))
 
 (defn- schedule-hover-refresh!
@@ -3650,6 +3717,7 @@
       {:undoable false}
       (concat
         (g/connect app-view :debugger-execution-locations view-node :debugger-execution-locations)
+        (g/connect app-view :debugger-suspension-variables view-node :debugger-suspension-variables)
         (gu/connect-existing-outputs resource-node-type resource-node view-node
           [[:completions :completions]
            [:cursor-ranges :cursor-ranges]
@@ -3703,6 +3771,26 @@
 (defn handle-hover-popup-auto-hide! [view-node _]
   (hide-hover! view-node))
 
+(def ^:private hover-popup-content-width
+  "Max width of markdown content and min width of the debug tree in the hover
+  popup."
+  350.0)
+
+(def ^:private ext-with-hover-tree-view-props
+  (fx/make-ext-with-props fx.tree-view/props))
+
+(defn- hover-debug-tree-view [{:keys [expr-text value available-height]}]
+  {:fx/type fx.stack-pane/lifecycle
+   :style-class ["md-code-block" "debug-hover-tree-block"]
+   :children [{:fx/type ext-with-hover-tree-view-props
+               :desc {:fx/type fx/ext-instance-factory
+                      :create (fn/partial variable-tree/make-expression-tree-view
+                                          expr-text value
+                                          {:min-width hover-popup-content-width
+                                           :available-height available-height})}
+               :props {:cell-factory {:fx/cell-type fx.tree-cell/lifecycle
+                                      :describe variable-tree/describe-hover-variables-cell}}}]})
+
 (defn- hover-popup-view [props]
   (let [{:keys [canvas-repaint-info project screen-bounds
                 hover-showing-regions hover-showing-region view-node]} props
@@ -3741,22 +3829,42 @@
           :min-width 10
           :min-height 10
           :style-class "hover-background"}
-         {:fx/type markdown/view
-          :content (->> hover-showing-regions
-                        (e/mapcat
-                          (fn [region]
-                            (when (:hoverable region)
-                              (case (:type region)
-                                :diagnostic (map plaintext->markdown (:messages region))
-                                :hover [(let [{:keys [content]} region
-                                              {:keys [type value]} content]
-                                          (case type
-                                            :plaintext (plaintext->markdown value)
-                                            :markdown value))]))))
-                        (coll/join-to-string "\n\n<hr>\n\n"))
-          :project project
-          :max-width 350.0
-          :max-height max-popup-height}]}]}}))
+         (let [debug-region (coll/some #(when (= :debug-variable (:type %)) %) hover-showing-regions)
+               tree-value (when debug-region
+                            (let [value (:value debug-region)]
+                              (when (variable-tree/expandable-value? value)
+                                value)))
+               markdown-content (->> hover-showing-regions
+                                     (e/mapcat
+                                       (fn [region]
+                                         (when (:hoverable region)
+                                           (case (:type region)
+                                             :diagnostic (map plaintext->markdown (:messages region))
+                                             :hover [(let [{:keys [content]} region
+                                                           {:keys [type value]} content]
+                                                       (case type
+                                                         :plaintext (plaintext->markdown value)
+                                                         :markdown value))]
+                                             :debug-variable (when-not tree-value
+                                                               [(format "<pre>%s</pre>"
+                                                                        (string/replace (-> region :content :value)
+                                                                                        #"[&<>]" {"&" "&amp;" "<" "&lt;" ">" "&gt;"}))])))))
+                                     (coll/join-to-string "\n\n<hr>\n\n"))]
+           {:fx/type fx.v-box/lifecycle
+            :children
+            (cond-> []
+              (not (string/blank? markdown-content))
+              (conj {:fx/type markdown/view
+                     :content markdown-content
+                     :project project
+                     :max-width hover-popup-content-width
+                     :max-height max-popup-height})
+
+              (some? tree-value)
+              (conj {:fx/type hover-debug-tree-view
+                     :expr-text (:expr-text debug-region)
+                     :value tree-value
+                     :available-height max-popup-height}))})]}]}}))
 
 (defn repaint-view! [view-node elapsed-time {:keys [cursor-visible editable] :as _opts}]
   (assert (boolean? cursor-visible))

--- a/editor/src/clj/editor/debug_view.clj
+++ b/editor/src/clj/editor/debug_view.clj
@@ -168,11 +168,14 @@
           frames)))
 
 (g/defnk produce-suspension-variables
-  [suspension-state debug-session]
-  (when-some [frame (-> suspension-state :stack first)]
-    (-> frame
-        (select-keys [:file :locals :upvalues])
-        (assoc :debug-session debug-session))))
+  [suspension-state debug-session selected-frame-index]
+  (when-some [frames (:stack suspension-state)]
+    (let [frame-index (or selected-frame-index 0)]
+      (when-some [frame (nth frames frame-index nil)]
+        (-> frame
+            (select-keys [:file :locals :upvalues])
+            (assoc :debug-session debug-session
+                   :frame-index frame-index))))))
 
 (g/deftype History [String])
 
@@ -184,6 +187,7 @@
 
   (property debug-session g/Any)
   (property suspension-state g/Any)
+  (property selected-frame-index g/Any)
 
   (property console-grid-pane Parent)
   (property call-stack-view ListView)
@@ -368,6 +372,11 @@
                               (when (and file line)
                                 (let [open-resource-fn (g/node-value debug-view :open-resource-fn)]
                                   (open-resource-fn file line))))
+                            (g/transact
+                              {:undoable false}
+                              (g/set-property debug-view :selected-frame-index
+                                              (when selected-frame
+                                                (first (.getSelectedIndices (.getSelectionModel call-stack-view))))))
                             (.setRoot variables-view (variable-tree/make-variables-tree-item
                                                        (:locals selected-frame)
                                                        (:upvalues selected-frame))))))

--- a/editor/src/clj/editor/debug_view.clj
+++ b/editor/src/clj/editor/debug_view.clj
@@ -28,6 +28,7 @@
             [editor.console :as console]
             [editor.core :as core]
             [editor.debugging.mobdebug :as mobdebug]
+            [editor.debugging.variable-tree :as variable-tree]
             [editor.defold-project :as project]
             [editor.dialogs :as dialogs]
             [editor.engine :as engine]
@@ -44,11 +45,10 @@
             [editor.workspace :as workspace]
             [service.log :as log])
   (:import [com.dynamo.lua.proto Lua$LuaModule]
-           [editor.debugging.mobdebug LuaStructure]
            [java.nio.file Files]
            [java.util Collection]
            [javafx.scene Parent]
-           [javafx.scene.control Button ListView TextField TreeItem TreeView]
+           [javafx.scene.control Button ListView TextField TreeView]
            [javafx.scene.input KeyCode KeyEvent]
            [org.apache.commons.io FilenameUtils]))
 
@@ -137,12 +137,6 @@
              :props {:cell-factory {:fx/cell-type fx.list-cell/lifecycle
                                     :describe describe-call-stack-cell}}}})
 
-(defn describe-variables-cell [{:keys [display-name display-value]}]
-  {:graphic {:fx/type fx.h-box/lifecycle
-             :children [{:fx/type fx.label/lifecycle :text display-name}
-                        {:fx/type fx.label/lifecycle :text " = " :style-class ["label" "equals"]}
-                        {:fx/type fx.label/lifecycle :text display-value}]}})
-
 (def ^:private ext-with-tree-view-props
   (fx/make-ext-with-props fx.tree-view/props))
 
@@ -155,7 +149,7 @@
              :desc {:fx/type ui/ext-value
                     :value variables-view}
              :props {:cell-factory {:fx/cell-type fx.tree-cell/lifecycle
-                                    :describe describe-variables-cell}}}})
+                                    :describe variable-tree/describe-variables-cell}}}})
 
 (g/defnk produce-debugger-sidebar-panes
   [debug-session suspension-state call-stack-view variables-view localization]
@@ -172,6 +166,13 @@
                              (select-keys [:file :line])
                              (assoc :type (if (zero? i) :current-line :current-frame)))))
           frames)))
+
+(g/defnk produce-suspension-variables
+  [suspension-state debug-session]
+  (when-some [frame (-> suspension-state :stack first)]
+    (-> frame
+        (select-keys [:file :locals :upvalues])
+        (assoc :debug-session debug-session))))
 
 (g/deftype History [String])
 
@@ -196,6 +197,7 @@
   (output update-available-controls g/Any :cached update-available-controls!)
   (output update-call-stack g/Any :cached update-call-stack!)
   (output execution-locations g/Any :cached produce-execution-locations)
+  (output suspension-variables g/Any :cached produce-suspension-variables)
   (output debugger-sidebar-panes g/Any :cached produce-debugger-sidebar-panes))
 
 (defn- current-stack-frame
@@ -229,6 +231,9 @@
             (= :bad-request (:error ret))
             (console/append-console-entry! :eval-error "Bad request")
 
+            (= :not-suspended (:error ret))
+            (console/append-console-entry! :eval-error "Debugger is not suspended")
+
             (string? (:error ret))
             (console/append-console-entry! :eval-error (sanitize-eval-error (:error ret)))
 
@@ -257,29 +262,6 @@
     (ui/bind-action! step-out-debugger-button :debugger.step-out)
     (ui/bind-action! step-over-debugger-button :debugger.step-over)
     (ui/bind-action! stop-debugger-button :debugger.stop)))
-
-(defn- make-variable-tree-item
-  [[name value]]
-  (let [variable {:name name
-                  :display-name (mobdebug/lua-value->identity-string name)
-                  :value value
-                  :display-value (mobdebug/lua-value->identity-string value)}
-        tree-item (TreeItem. variable)
-        children (.getChildren tree-item)]
-    (when (and (instance? LuaStructure value)
-               (pos? (count value)))
-      (.add children (TreeItem.))
-      (ui/observe-once (.expandedProperty tree-item)
-                       (fn [_ _ _]
-                         (.setAll children ^Collection (map make-variable-tree-item value)))))
-    tree-item))
-
-(defn- make-variables-tree-item
-  [locals upvalues]
-  (let [ret (TreeItem.)
-        children (.getChildren ret)]
-    (.setAll children ^Collection (map make-variable-tree-item (concat locals upvalues)))
-    ret))
 
 (defn- switch-text! [^TextField text-field text]
   (doto text-field
@@ -386,7 +368,7 @@
                               (when (and file line)
                                 (let [open-resource-fn (g/node-value debug-view :open-resource-fn)]
                                   (open-resource-fn file line))))
-                            (.setRoot variables-view (make-variables-tree-item
+                            (.setRoot variables-view (variable-tree/make-variables-tree-item
                                                        (:locals selected-frame)
                                                        (:upvalues selected-frame))))))
 
@@ -458,6 +440,7 @@
   (g/transact
     {:undoable false}
     [(g/connect debug-view :execution-locations app-view :debugger-execution-locations)
+     (g/connect debug-view :suspension-variables app-view :debugger-suspension-variables)
      (g/connect debug-view :debugger-sidebar-panes app-view :debugger-sidebar-panes)])
   debug-view)
 

--- a/editor/src/clj/editor/debugging/mobdebug.clj
+++ b/editor/src/clj/editor/debugging/mobdebug.clj
@@ -535,18 +535,20 @@
 
 (defn exec [^DebugSession debug-session code frame]
   (with-session debug-session
-    (let [out (.out debug-session)
-          in (.in debug-session)]
-      (send-command! out (format "EXEC return %s --{stack=%s}" code frame))
-      (let [[status rest] (read-status in)]
-        (case status
-          "200" (when-let [[size] (re-match #"^OK\s+(\d+)$" rest)]
-                  (let [n (Integer/parseInt size)]
-                    {:result (decode-serialized-data debug-session (read-data in n))}))
-          "400" {:error :bad-request}
-          "401" (when-let [[size] (re-match #"^Error in Expression\s+(\d+)$" rest)]
-                  (let [n (Integer/parseInt size)]
-                    {:error (read-data in n)})))))))
+    (if-not (= :suspended (-state debug-session))
+      {:error :not-suspended}
+      (let [out (.out debug-session)
+            in (.in debug-session)]
+        (send-command! out (format "EXEC return %s --{stack=%s}" code frame))
+        (let [[status rest] (read-status in)]
+          (case status
+            "200" (when-let [[size] (re-match #"^OK\s+(\d+)$" rest)]
+                    (let [n (Integer/parseInt size)]
+                      {:result (decode-serialized-data debug-session (read-data in n))}))
+            "400" {:error :bad-request}
+            "401" (when-let [[size] (re-match #"^Error in Expression\s+(\d+)$" rest)]
+                    (let [n (Integer/parseInt size)]
+                      {:error (read-data in n)}))))))))
 
 
 ;; A note on "SETB file line condition":

--- a/editor/src/clj/editor/debugging/variable_hover.clj
+++ b/editor/src/clj/editor/debugging/variable_hover.clj
@@ -1,0 +1,107 @@
+;; Copyright 2020-2026 The Defold Foundation
+;; Copyright 2014-2020 King
+;; Copyright 2009-2014 Ragnar Svensson, Christian Murray
+;; Licensed under the Defold License version 1.0 (the "License"); you may not use
+;; this file except in compliance with the License.
+;;
+;; You may obtain a copy of the License, together with FAQs at
+;; https://www.defold.com/license
+;;
+;; Unless required by applicable law or agreed to in writing, software distributed
+;; under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+;; CONDITIONS OF ANY KIND, either express or implied. See the License for the
+;; specific language governing permissions and limitations under the License.
+
+(ns editor.debugging.variable-hover
+  "Resolves and renders the value of an identifier or dotted identifier chain
+  (e.g. \"self.field\") hovered in the code editor while the debugger is
+  suspended, and builds a hoverable region for it. Walking a LuaStructure
+  value can fetch unserialized content from the debugger, so callers run
+  these functions off the JavaFX thread."
+  (:require [clojure.string :as string]
+            [editor.code.data :as data]
+            [editor.debugging.mobdebug :as mobdebug]))
+
+(set! *warn-on-reflection* true)
+
+(def ^:private undefined
+  "Sentinel value distinguishing a missing key from one whose value is nil."
+  (Object.))
+
+(def ^:private max-hover-lines 40)
+(def ^:private max-hover-line-length 200)
+
+(defn resolve-value
+  "Resolves `expr-text` (e.g. \"self.field\") against `suspension-variables`,
+  a map of the shape {:file .. :locals .. :upvalues ..} produced from the top
+  stack frame of a suspended debug session. The head segment is looked up by
+  string key in :locals, then :upvalues; each remaining '.'-separated segment
+  is then walked with `get`, which both plain Clojure maps and
+  `editor.debugging.mobdebug/LuaStructure` support.
+
+  Returns {:value v} when the full chain resolves, where `v` may itself be
+  nil (a Lua variable holding nil), or nil when any segment along the chain
+  does not resolve."
+  [suspension-variables expr-text]
+  (let [[head & segments] (string/split expr-text #"\.")
+        locals (:locals suspension-variables)
+        upvalues (:upvalues suspension-variables)]
+    (loop [value (get locals head (get upvalues head undefined))
+           segments segments]
+      (cond
+        (identical? undefined value)
+        nil
+
+        (empty? segments)
+        {:value value}
+
+        (nil? value)
+        nil
+
+        :else
+        (recur (get value (first segments) undefined) (next segments))))))
+
+(defn render-value
+  [expr-text value]
+  (str expr-text " = " (mobdebug/lua-value->structure-string value)))
+
+(defn truncate-hover-text
+  "Caps `s` to `max-hover-lines` lines of at most `max-hover-line-length`
+  characters each, appending an ellipsis where content was cut."
+  [s]
+  (let [lines (string/split-lines s)
+        truncated-lines? (> (count lines) max-hover-lines)
+        capped-lines (cond-> (into [] (take max-hover-lines) lines)
+                       truncated-lines? (conj "..."))]
+    (->> capped-lines
+         (map (fn [line]
+                (if (> (count line) max-hover-line-length)
+                  (str (subs line 0 max-hover-line-length) "...")
+                  line)))
+         (string/join "\n"))))
+
+(defn evaluated-region
+  "Returns a hoverable :debug-variable region presenting `value` as the debug
+  value of the identifier expression `expr-text` spanning `cursor-range`."
+  [expr-text value cursor-range]
+  (data/map->CursorRange
+    {:from (:from cursor-range)
+     :to (:to cursor-range)
+     :type :debug-variable
+     :hoverable true
+     :expr-text expr-text
+     :value value
+     :content {:type :plaintext
+               :value (truncate-hover-text (render-value expr-text value))}}))
+
+(defn variable-hover-region
+  "Returns a hoverable region for the debug value of `expr`, an identifier
+  expression from `editor.code.data/identifier-expression-at-cursor`, or nil
+  when the expression does not resolve or `proj-path` is not the file
+  execution is suspended in."
+  [suspension-variables proj-path expr]
+  (when (some? suspension-variables)
+    (when (= proj-path (:file suspension-variables))
+      (when-some [{:keys [text cursor-range]} expr]
+        (when-some [{:keys [value]} (resolve-value suspension-variables text)]
+          (evaluated-region text value cursor-range))))))

--- a/editor/src/clj/editor/debugging/variable_tree.clj
+++ b/editor/src/clj/editor/debugging/variable_tree.clj
@@ -1,0 +1,155 @@
+;; Copyright 2020-2026 The Defold Foundation
+;; Copyright 2014-2020 King
+;; Copyright 2009-2014 Ragnar Svensson, Christian Murray
+;; Licensed under the Defold License version 1.0 (the "License"); you may not use
+;; this file except in compliance with the License.
+;;
+;; You may obtain a copy of the License, together with FAQs at
+;; https://www.defold.com/license
+;;
+;; Unless required by applicable law or agreed to in writing, software distributed
+;; under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+;; CONDITIONS OF ANY KIND, either express or implied. See the License for the
+;; specific language governing permissions and limitations under the License.
+
+(ns editor.debugging.variable-tree
+  "Tree items and cell rendering for suspended-debugger variable values,
+  shared between the debugger's Variables pane and the code editor's debug
+  hover popup. Tree items expand lazily: children of a LuaStructure are
+  materialized on first expansion, which may fetch deeper values from the
+  debugger."
+  (:require [cljfx.fx.button :as fx.button]
+            [cljfx.fx.h-box :as fx.h-box]
+            [cljfx.fx.label :as fx.label]
+            [cljfx.fx.region :as fx.region]
+            [editor.debugging.mobdebug :as mobdebug]
+            [editor.markdown :as markdown]
+            [editor.ui :as ui])
+  (:import [editor.debugging.mobdebug LuaStructure]
+           [java.util Collection]
+           [javafx.scene.control TreeItem TreeView]
+           [javafx.scene.input Clipboard ClipboardContent]))
+
+(set! *warn-on-reflection* true)
+
+(declare make-variable-tree-item)
+
+(defn- make-tree-item
+  ^TreeItem [variable value]
+  (let [tree-item (TreeItem. variable)
+        children (.getChildren tree-item)]
+    (when (and (instance? LuaStructure value)
+               (pos? (count value)))
+      (.add children (TreeItem.))
+      (ui/observe-once (.expandedProperty tree-item)
+                       (fn [_ _ _]
+                         (.setAll children ^Collection (map make-variable-tree-item value)))))
+    tree-item))
+
+(defn make-variable-tree-item
+  ^TreeItem [[name value]]
+  (make-tree-item {:name name
+                   :display-name (mobdebug/lua-value->identity-string name)
+                   :value value
+                   :display-value (mobdebug/lua-value->identity-string value)}
+                  value))
+
+(defn make-variables-tree-item
+  ^TreeItem [locals upvalues]
+  (let [ret (TreeItem.)
+        children (.getChildren ret)]
+    (.setAll children ^Collection (map make-variable-tree-item (concat locals upvalues)))
+    ret))
+
+(defn make-expression-tree-item
+  "Tree item rooting the value of an evaluated expression (e.g. a hovered
+  \"self.field\"), labeled with the expression text itself."
+  ^TreeItem [expr-text value]
+  (make-tree-item {:name expr-text
+                   :display-name expr-text
+                   :value value
+                   :display-value (mobdebug/lua-value->identity-string value)}
+                  value))
+
+(defn expandable-value?
+  "True when `value` is a Lua table with at least one entry."
+  [value]
+  (and (instance? LuaStructure value)
+       (pos? (count ^LuaStructure value))))
+
+(defn describe-variables-cell [{:keys [display-name display-value]}]
+  {:graphic {:fx/type fx.h-box/lifecycle
+             :children [{:fx/type fx.label/lifecycle :text display-name}
+                        {:fx/type fx.label/lifecycle :text " = " :style-class ["label" "equals"]}
+                        {:fx/type fx.label/lifecycle :text display-value}]}})
+
+(defn- copy-to-clipboard! [text]
+  (.setContent (Clipboard/getSystemClipboard)
+               (doto (ClipboardContent.)
+                 (.putString ^String text))))
+
+(defn describe-hover-variables-cell
+  "Like `describe-variables-cell`, with a row-hover Copy button that puts the
+  row's value (nested structure for tables) on the clipboard."
+  [{:keys [display-name display-value value]}]
+  {:graphic {:fx/type fx.h-box/lifecycle
+             :alignment :center-left
+             :children [{:fx/type fx.label/lifecycle :text display-name}
+                        {:fx/type fx.label/lifecycle :text " = " :style-class ["label" "equals"]}
+                        {:fx/type fx.label/lifecycle :text display-value}
+                        {:fx/type fx.region/lifecycle :h-box/hgrow :always}
+                        {:fx/type fx.button/lifecycle
+                         :style-class ["md-code-block-button" "debug-hover-copy-button"]
+                         :graphic markdown/copy-icon
+                         :on-action (fn [_]
+                                      (copy-to-clipboard!
+                                        (mobdebug/lua-value->structure-string value)))}]}})
+
+(def ^:private hover-tree-cell-height 24.0)
+
+(def ^:private hover-tree-insets-height
+  "Vertical space the TreeView adds around its rows."
+  4.0)
+
+(def ^:private hover-tree-max-height 600.0)
+
+(def ^:private hover-tree-max-width 640.0)
+
+(def ^:private hover-tree-mono-char-width
+  "Average glyph advance of $default-font-mono at $md-font-size
+  (base/_typography.scss). Recalibrate if either changes."
+  8.2)
+
+(def ^:private hover-tree-row-extra-width
+  "Horizontal space a row needs beyond its text: disclosure arrow, one level
+  of child indentation, the copy button, and view insets."
+  96.0)
+
+(defn- variable-row-text-length
+  [[name value]]
+  (+ (count (mobdebug/lua-value->identity-string name))
+     3 ; " = "
+     (count (mobdebug/lua-value->identity-string value))))
+
+(defn make-expression-tree-view
+  "A TreeView presenting `value` rooted at `expr-text` for the code editor's
+  hover popup: at least `min-width` wide, sized to show the whole first level
+  of the table, capped by `hover-tree-max-width`/`-height` and by
+  `available-height`, the screen space the popup can grow into."
+  ^TreeView [expr-text value {:keys [^double min-width ^double available-height]}]
+  (let [row-count (inc (count value))
+        content-height (+ hover-tree-insets-height (* hover-tree-cell-height row-count))
+        height (min content-height hover-tree-max-height available-height)
+        root-text-length (+ (count expr-text) 3 (count (mobdebug/lua-value->identity-string value)))
+        max-text-length (transduce (map variable-row-text-length) max root-text-length (seq value))
+        content-width (+ hover-tree-row-extra-width (* hover-tree-mono-char-width max-text-length))
+        width (-> content-width (max min-width) (min hover-tree-max-width))]
+    (doto (TreeView.)
+      (.setId "debug-hover-variables")
+      (ui/customize-tree-view! {:double-click-expand true})
+      (.setShowRoot true)
+      (.setFixedCellSize hover-tree-cell-height)
+      (.setRoot (doto (make-expression-tree-item expr-text value)
+                  (.setExpanded true)))
+      (.setPrefWidth width)
+      (.setPrefHeight height))))

--- a/editor/src/clj/editor/markdown.clj
+++ b/editor/src/clj/editor/markdown.clj
@@ -310,7 +310,7 @@
       {:fx/type fx.v-box/lifecycle
        :children lis})))
 
-(def ^:private copy-icon
+(def copy-icon
   {:fx/type fx.svg-path/lifecycle
    :style-class "md-code-block-icon"
    ;; chrome-restore icon by Microsoft (CC BY 4.0)

--- a/editor/styling/stylesheets/base/_palette.scss
+++ b/editor/styling/stylesheets/base/_palette.scss
@@ -15,6 +15,7 @@
 	-df-component-icon:       #8f9296;		// button icon (original name: bright-grey)
 
 	// Text and icons
+	-df-code-text:            #DDDDDD;		// code and debug value text (markdown code blocks, debug hover)
 	-df-text-dark:            #848484;		// property components (hardcoded in fxml in original css)
 	-df-text:                 #a2b0be;		// non editable text, input field hint (original name: bright-grey-light)
 	-df-text-light:           #f0f2f6;		// editable text (original name: defold-white)

--- a/editor/styling/stylesheets/base/_typography.scss
+++ b/editor/styling/stylesheets/base/_typography.scss
@@ -29,6 +29,7 @@
 
 $default-font-mono: 'Dejavu Sans Mono';
 $default-font: 'Source Sans Pro';
+$md-font-size: 13.5px;
 $default-font-bold: 'Source Sans Pro Semibold';
 $default-font-italic: 'Source Sans Pro Italic';
 $default-font-light: 'Source Sans Pro Light';

--- a/editor/styling/stylesheets/components/_markdown.scss
+++ b/editor/styling/stylesheets/components/_markdown.scss
@@ -15,7 +15,7 @@
       &-em      { -fx-font-family: "Source Sans Pro Italic"; }
       &-strong  { -fx-font-family: "Source Sans Pro Semibold"; }
       &-strong.md-em { -fx-font-family: "Source Sans Pro Semibold Italic";}
-      &-code    { -fx-font-family: "Dejavu Sans Mono"; -fx-fill: #DDDDDD; }
+      &-code    { -fx-font-family: $default-font-mono; -fx-fill: -df-code-text; }
       &-small   { -fx-fill: -df-text-dark; }
       &-sub     { -fx-font-size: 85%; -fx-translate-y: 3px; }
       &-sup     { -fx-font-size: 85%; -fx-translate-y: -5px; }
@@ -125,7 +125,7 @@
   }
   &-root {
     -fx-padding: 6px 8px;
-    -fx-font-size: 13.5px;
+    -fx-font-size: $md-font-size;
     -md-text-fill: -df-text;
     &.md-page-root {
         -fx-padding: 30px 30px;

--- a/editor/styling/stylesheets/modules/_debugger.scss
+++ b/editor/styling/stylesheets/modules/_debugger.scss
@@ -72,3 +72,39 @@
     }
   }
 }
+
+// insets match .md-root's padding and the padding adds .md-code-block's,
+// so the tree block frames like markdown content in the same popup
+.debug-hover-tree-block {
+  -fx-background-insets: 6px 8px;
+  -fx-padding: 16px 18px;
+}
+
+#debug-hover-variables {
+  -fx-background-color: transparent;
+  -fx-font-size: $md-font-size;
+
+  .tree-cell {
+    -fx-background-color: transparent;
+
+    .label {
+      -fx-font-family: $default-font-mono;
+      -fx-text-fill: -df-code-text;
+    }
+    .equals {
+      -fx-text-fill: -df-text-dark;
+      -fx-opacity: 0.8;
+    }
+    &:hover .label,
+    &:selected .label {
+      -fx-text-fill: -df-text-selected;
+    }
+
+    .debug-hover-copy-button {
+      visibility: hidden;
+    }
+    &:hover .debug-hover-copy-button {
+      visibility: visible;
+    }
+  }
+}

--- a/editor/test/editor/code/data_test.clj
+++ b/editor/test/editor/code/data_test.clj
@@ -1249,6 +1249,73 @@
   (is (false? (data/word-cursor-range? ["one"] (cr [0 1] [0 3]))))
   (is (false? (data/word-cursor-range? ["one"] (cr [0 0] [0 2])))))
 
+(deftest identifier-expression-at-cursor-test
+  (testing "Same range from any position inside the word"
+    (are [col]
+      (= {:text "health" :cursor-range (cr [0 0] [0 6])}
+         (data/identifier-expression-at-cursor ["health"] (->Cursor 0 col)))
+      0 3 5))
+
+  (testing "Cursor at end of line"
+    (is (nil? (data/identifier-expression-at-cursor ["health"] (->Cursor 0 6)))))
+
+  (testing "Cursor just past the word"
+    (is (nil? (data/identifier-expression-at-cursor ["health x"] (->Cursor 0 6)))))
+
+  (testing "Digit-led word rejected"
+    (are [col]
+      (nil? (data/identifier-expression-at-cursor ["123"] (->Cursor 0 col)))
+      0 1 2))
+
+  (testing "Digit inside identifier accepted"
+    (is (= {:text "x2" :cursor-range (cr [0 0] [0 2])}
+           (data/identifier-expression-at-cursor ["x2"] (->Cursor 0 1)))))
+
+  (testing "Underscore-led identifier"
+    (is (= {:text "_foo" :cursor-range (cr [0 0] [0 4])}
+           (data/identifier-expression-at-cursor ["_foo"] (->Cursor 0 0)))))
+
+  (testing "Whitespace and operators"
+    (are [col]
+      (nil? (data/identifier-expression-at-cursor ["a + b"] (->Cursor 0 col)))
+      1 2))
+
+  (testing "Empty line"
+    (is (nil? (data/identifier-expression-at-cursor [""] (->Cursor 0 0)))))
+
+  (testing "Cursor row past the last line"
+    (is (nil? (data/identifier-expression-at-cursor ["abc"] (->Cursor 5 0)))))
+
+  (testing "Dotted chain extends backward from any segment"
+    (let [line "self.weapon_popup.scale_default"]
+      (is (= {:text "self" :cursor-range (cr [0 0] [0 4])}
+             (data/identifier-expression-at-cursor [line] (->Cursor 0 1))))
+      (is (= {:text "self.weapon_popup" :cursor-range (cr [0 0] [0 17])}
+             (data/identifier-expression-at-cursor [line] (->Cursor 0 10))))
+      (is (= {:text "self.weapon_popup.scale_default" :cursor-range (cr [0 0] [0 31])}
+             (data/identifier-expression-at-cursor [line] (->Cursor 0 20))))))
+
+  (testing "Single-character segments"
+    (let [line "a.b.c"]
+      (is (= {:text "a" :cursor-range (cr [0 0] [0 1])}
+             (data/identifier-expression-at-cursor [line] (->Cursor 0 0))))
+      (is (= {:text "a.b" :cursor-range (cr [0 0] [0 3])}
+             (data/identifier-expression-at-cursor [line] (->Cursor 0 2))))
+      (is (= {:text "a.b.c" :cursor-range (cr [0 0] [0 5])}
+             (data/identifier-expression-at-cursor [line] (->Cursor 0 4))))))
+
+  (testing "Chain does not extend across a call expression"
+    (is (= {:text "x" :cursor-range (cr [0 4] [0 5])}
+           (data/identifier-expression-at-cursor ["f().x"] (->Cursor 0 4)))))
+
+  (testing "Method call ':' is not a chain separator"
+    (is (= {:text "method" :cursor-range (cr [0 5] [0 11])}
+           (data/identifier-expression-at-cursor ["self:method"] (->Cursor 0 7)))))
+
+  (testing "Multi-line input"
+    (is (= {:text "self.weapon_popup" :cursor-range (cr [1 0] [1 17])}
+           (data/identifier-expression-at-cursor ["one" "self.weapon_popup"] (->Cursor 1 10))))))
+
 (defn- find-prev-occurrence [haystack-lines needle-lines from-cursor]
   (data/find-prev-occurrence haystack-lines needle-lines from-cursor false false))
 

--- a/editor/test/editor/debugging/variable_hover_test.clj
+++ b/editor/test/editor/debugging/variable_hover_test.clj
@@ -1,0 +1,170 @@
+;; Copyright 2020-2026 The Defold Foundation
+;; Copyright 2014-2020 King
+;; Copyright 2009-2014 Ragnar Svensson, Christian Murray
+;; Licensed under the Defold License version 1.0 (the "License"); you may not use
+;; this file except in compliance with the License.
+;;
+;; You may obtain a copy of the License, together with FAQs at
+;; https://www.defold.com/license
+;;
+;; Unless required by applicable law or agreed to in writing, software distributed
+;; under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+;; CONDITIONS OF ANY KIND, either express or implied. See the License for the
+;; specific language governing permissions and limitations under the License.
+
+(ns editor.debugging.variable-hover-test
+  (:require [clojure.string :as string]
+            [clojure.test :refer :all]
+            [editor.code.data :as data :refer [->Cursor ->CursorRange]]
+            [editor.debugging.variable-hover :as variable-hover]))
+
+(defn- cr [[from-row from-col] [to-row to-col]]
+  (->CursorRange (->Cursor from-row from-col) (->Cursor to-row to-col)))
+
+;; -----------------------------------------------------------------------------
+;; resolve-value
+;; -----------------------------------------------------------------------------
+
+(deftest resolve-value-test
+  (testing "Local lookup"
+    (is (= {:value 100}
+           (variable-hover/resolve-value {:locals {"health" 100} :upvalues {}} "health"))))
+
+  (testing "Upvalue fallback"
+    (is (= {:value "hi"}
+           (variable-hover/resolve-value {:locals {} :upvalues {"outer" "hi"}} "outer"))))
+
+  (testing "Locals shadow upvalues"
+    (is (= {:value "local-val"}
+           (variable-hover/resolve-value {:locals {"x" "local-val"} :upvalues {"x" "upvalue-val"}} "x"))))
+
+  (testing "Unknown name"
+    (is (nil? (variable-hover/resolve-value {:locals {} :upvalues {}} "unknown"))))
+
+  (testing "Nil-valued local is distinct from a missing local"
+    (let [suspension-variables {:locals {"x" nil} :upvalues {}}]
+      (is (= {:value nil} (variable-hover/resolve-value suspension-variables "x"))
+          "existing key mapped to nil")
+      (is (nil? (variable-hover/resolve-value suspension-variables "y"))
+          "key never present")))
+
+  (testing "Dotted chain through nested values"
+    (let [suspension-variables {:locals {"self" {"weapon_popup" {"scale_default" 1}}} :upvalues {}}]
+      (is (= {:value 1}
+             (variable-hover/resolve-value suspension-variables "self.weapon_popup.scale_default")))
+      (is (nil? (variable-hover/resolve-value suspension-variables "self.missing"))
+          "last segment missing")))
+
+  (testing "Chain stops at a nil intermediate"
+    (let [suspension-variables {:locals {"self" {"weapon_popup" nil}} :upvalues {}}]
+      (is (nil? (variable-hover/resolve-value suspension-variables "self.weapon_popup.scale_default"))))))
+
+;; -----------------------------------------------------------------------------
+;; render-value
+;; -----------------------------------------------------------------------------
+
+(deftest render-value-test
+  (testing "Number value"
+    (is (= "health = 100" (variable-hover/render-value "health" 100))))
+
+  (testing "String value is quoted"
+    (is (= "name = \"hi\"" (variable-hover/render-value "name" "hi"))))
+
+  (testing "Nil value"
+    (is (= "x = nil" (variable-hover/render-value "x" nil))))
+
+  (testing "Table value"
+    (is (= "self = {\"weapon_popup\" {\"scale_default\" 1}}"
+           (variable-hover/render-value "self" {"weapon_popup" {"scale_default" 1}})))))
+
+;; -----------------------------------------------------------------------------
+;; truncate-hover-text
+;; -----------------------------------------------------------------------------
+
+(deftest truncate-hover-text-test
+  (testing "Empty string"
+    (is (= "" (variable-hover/truncate-hover-text ""))))
+
+  (testing "Within both caps"
+    (is (= "a\nb\nc" (variable-hover/truncate-hover-text "a\nb\nc"))))
+
+  (testing "At the line cap"
+    (let [s (string/join "\n" (repeat 40 "x"))]
+      (is (= s (variable-hover/truncate-hover-text s)))))
+
+  (testing "Past the line cap"
+    (let [s (string/join "\n" (repeat 41 "x"))
+          expected (str (string/join "\n" (repeat 40 "x")) "\n...")]
+      (is (= expected (variable-hover/truncate-hover-text s)))))
+
+  (testing "At the line-length cap"
+    (let [line (apply str (repeat 200 "a"))]
+      (is (= line (variable-hover/truncate-hover-text line)))))
+
+  (testing "Past the line-length cap"
+    (let [line (apply str (repeat 201 "a"))
+          expected (str (apply str (repeat 200 "a")) "...")]
+      (is (= expected (variable-hover/truncate-hover-text line)))))
+
+  (testing "Both caps together"
+    (let [long-line (apply str (repeat 250 "y"))
+          lines (assoc (vec (repeat 44 "short")) 10 long-line)
+          s (string/join "\n" lines)
+          truncated-long-line (str (apply str (repeat 200 "y")) "...")
+          expected (str (string/join "\n" (assoc (vec (repeat 40 "short")) 10 truncated-long-line))
+                        "\n...")]
+      (is (= expected (variable-hover/truncate-hover-text s))))))
+
+;; -----------------------------------------------------------------------------
+;; variable-hover-region
+;; -----------------------------------------------------------------------------
+
+(def ^:private proj-path "/main/player.script")
+
+(def ^:private suspension-variables
+  {:file proj-path
+   :locals {"health" 100
+            "self" {"weapon_popup" {"scale_default" 1}}}
+   :upvalues {"outer" "hi"}})
+
+(deftest variable-hover-region-test
+  (testing "Not suspended"
+    (is (nil? (variable-hover/variable-hover-region nil proj-path (data/identifier-expression-at-cursor ["health"] (->Cursor 0 0))))))
+
+  (testing "Different file"
+    (is (nil? (variable-hover/variable-hover-region suspension-variables "/main/other.script" (data/identifier-expression-at-cursor ["health"] (->Cursor 0 0))))))
+
+  (testing "No identifier at cursor"
+    (is (nil? (variable-hover/variable-hover-region suspension-variables proj-path (data/identifier-expression-at-cursor ["  "] (->Cursor 0 0))))))
+
+  (testing "Unresolved identifier"
+    (is (nil? (variable-hover/variable-hover-region suspension-variables proj-path (data/identifier-expression-at-cursor ["unknown_var"] (->Cursor 0 0))))))
+
+  (testing "Region shape"
+    (is (= (data/map->CursorRange
+             {:from (->Cursor 0 0)
+              :to (->Cursor 0 6)
+              :type :debug-variable
+              :hoverable true
+              :expr-text "health"
+              :value 100
+              :content {:type :plaintext :value "health = 100"}})
+           (variable-hover/variable-hover-region suspension-variables proj-path (data/identifier-expression-at-cursor ["health"] (->Cursor 0 0))))))
+
+  (testing "Nil-valued local produces a region"
+    (let [suspension-variables (assoc-in suspension-variables [:locals "nil_var"] nil)]
+      (is (= "nil_var = nil"
+             (get-in (variable-hover/variable-hover-region suspension-variables proj-path (data/identifier-expression-at-cursor ["nil_var"] (->Cursor 0 0)))
+                     [:content :value])))))
+
+  (testing "Dotted chain region"
+    (let [line "self.weapon_popup.scale_default"]
+      (is (= (data/map->CursorRange
+               {:from (->Cursor 0 0)
+                :to (->Cursor 0 31)
+                :type :debug-variable
+                :hoverable true
+                :expr-text line
+                :value 1
+                :content {:type :plaintext :value "self.weapon_popup.scale_default = 1"}})
+             (variable-hover/variable-hover-region suspension-variables proj-path (data/identifier-expression-at-cursor [line] (->Cursor 0 20))))))))


### PR DESCRIPTION
When the debugger is paused at a breakpoint, hovering over a variable in the code editor now shows its current value. Simple values show inline with a copy button, and tables open as an expandable tree that can be navigated and copied from, just like the Variables pane. Dotted expressions such as `self.position.y` are evaluated in the paused context, so fields of nested tables work too. While a value is showing, the regular documentation hover steps aside; error diagnostics still show.

Fixes #11181

### Technical changes
* Most of the UI/UX was inspired on VSCode source code.
* `editor.code.data/identifier-expression-at-cursor` extracts the identifier or dotted chain under the cursor (backward extension only; `:` is treated as a method call, not a chain separator).
* `editor.debugging.variable-hover` (new, pure) resolves the expression against the suspended frame's locals/upvalues and builds the hover region; a sentinel distinguishes a variable holding `nil` from a missing one.
* Expressions not found in the prefetched frame data are evaluated through the debug session's EXEC, in a `future` off the FX thread, at most one in flight at a time.
* `mobdebug/exec` now verifies the session is suspended inside the session lock and returns `{:error :not-suspended}` otherwise; an EXEC racing a resume could previously desync the protocol and close the debugger connection.
* The Variables pane tree-item and cell code moved to a shared `editor.debugging.variable-tree` namespace, reused by the hover popup (lazy expansion fetches deeper values on demand; each row has a hover-revealed copy button).
* While a debug region is showing for the hovered token, LSP `:hover` regions are filtered out of the popup; `:diagnostic` regions are kept.
* Styling: the tree renders inside the markdown code-block container with a shared palette color (`-df-code-text`) and font variables (`$default-font-mono`, `$md-font-size`); popup width/height follow content up to caps.
* Scope: values resolve against the top stack frame; tooltips prefetch two levels deep, deeper levels fetch when expanded in the tree. Both are natural follow-ups.
* Unit tests cover extraction, resolution, rendering, and region construction. The full editor suite shows no regressions (the same pre-existing Windows-local failures occur on `dev` on the same machine).

<img width="1496" height="657" alt="java_vlduk8QivB" src="https://github.com/user-attachments/assets/66f3fd9c-03c0-4e21-8dd8-73328e36173a" />
