### PR TITLE
Complete component ids when typing # in a script string

### DIFF
--- a/editor/src/clj/editor/code/script.clj
+++ b/editor/src/clj/editor/code/script.clj
@@ -13,12 +13,15 @@
 ;; specific language governing permissions and limitations under the License.
 
 (ns editor.code.script
-  (:require [dynamo.graph :as g]
+  (:require [clojure.string :as string]
+            [dynamo.graph :as g]
+            [editor.code-completion :as code-completion]
             [editor.code.data :as data]
             [editor.code.resource :as r]
             [editor.code.script-annotations :as script-annotations]
             [editor.code.script-compilation :as script-compilation]
             [editor.code.script-intelligence :as script-intelligence]
+            [editor.core :as core]
             [editor.defold-project :as project]
             [editor.graph-util :as gu]
             [editor.localization :as localization]
@@ -26,9 +29,11 @@
             [editor.lua-parser :as lua-parser]
             [editor.properties :as properties]
             [editor.resource :as resource]
+            [editor.resource-node :as resource-node]
             [editor.types :as types]
+            [internal.graph.types :as gt]
             [schema.core :as s]
-            [util.coll :as coll]))
+            [util.coll :as coll :refer [pair]]))
 
 (set! *warn-on-reflection* true)
 (set! *unchecked-math* :warn-on-boxed)
@@ -133,7 +138,7 @@
                  :close-scopes {\' "punctuation.definition.string.quoted.end.lua"
                                 \" "punctuation.definition.string.quoted.end.lua"
                                 \] "punctuation.definition.string.end.lua"}}
-   :completion-trigger-characters #{"."}
+   :completion-trigger-characters #{"." "#"}
    :ignored-completion-trigger-characters #{"{" ","}
    :patterns [{:captures {1 {:name "keyword.control.lua"}
                           2 {:name "entity.name.function.scope.lua"}
@@ -440,6 +445,56 @@
 
   (output build-targets g/Any :cached produce-lua-build-targets))
 
+(defn- owning-game-object-id
+  "Returns the node id of the game object that owns a node, or nil"
+  [basis node-id]
+  (loop [node-id node-id]
+    (when node-id
+      (if (g/has-output? (g/node-type* basis node-id) :component-ids)
+        node-id
+        (recur (core/owner-node-id basis node-id))))))
+
+(defn- component-id-completions
+  "Completions for the component ids of the game objects using this script
+
+  The game objects are found by walking the graph arcs from the script node to
+  the components that reference it, the same way the Show References dialog
+  finds referencing resources."
+  [evaluation-context script-node-id]
+  (let [basis (:basis evaluation-context)
+        game-object-node-ids
+        (into #{}
+              (comp
+                (coll/tree-xf any? #(g/overrides basis %))
+                (mapcat #(g/explicit-arcs-by-source basis %))
+                (map gt/target-id)
+                (keep #(owning-game-object-id basis %))
+                (map #(g/override-root basis %)))
+              [script-node-id])
+        component-id->owner-proj-paths
+        (reduce
+          (fn [acc [component-id owner-proj-path]]
+            (update acc component-id (fnil conj (sorted-set)) owner-proj-path))
+          (sorted-map)
+          (eduction
+            (mapcat
+              (fn [game-object-node-id]
+                (let [owner-proj-path
+                      (some->> (resource-node/owner-resource-node-id basis game-object-node-id)
+                               (resource-node/resource basis)
+                               resource/proj-path)]
+                  (eduction
+                    (keep (fn [component-id]
+                            (when owner-proj-path
+                              (pair component-id owner-proj-path))))
+                    (keys (g/node-value game-object-node-id :component-ids evaluation-context))))))
+            game-object-node-ids))]
+    (mapv (fn [[component-id owner-proj-paths]]
+            (code-completion/make component-id
+                                  :type :property
+                                  :detail (string/join ", " owner-proj-paths)))
+          component-id->owner-proj-paths)))
+
 (g/defnode ScriptNode
   (inherits LuaCodeNode)
 
@@ -482,6 +537,12 @@
 
   (output _properties g/Properties :cached produce-properties)
   (output build-targets g/Any :cached produce-script-build-targets)
+  ;; The "#" completions are found by walking graph arcs, which the dependency
+  ;; system cannot track; this output is uncached so every pull reads the
+  ;; current graph state.
+  (output completions g/Any (g/fnk [^:unsafe _evaluation-context _node-id script-intelligence-completions]
+                              (assoc script-intelligence-completions
+                                     "#" (component-id-completions _evaluation-context _node-id))))
   (output resource-property-build-targets g/Any (gu/passthrough resource-property-build-targets))
   (output script-property-entries ScriptPropertyEntries (g/fnk [script-property-entries] (reduce into {} script-property-entries)))
   (output script-property-node-ids-by-name NameNodeIDMap (g/fnk [script-property-name+node-ids] (into {} script-property-name+node-ids))))

--- a/editor/src/clj/editor/code/view.clj
+++ b/editor/src/clj/editor/code/view.clj
@@ -910,7 +910,10 @@
   The map includes following keys (all required):
     :context           a string indicating a context in which the built-in
                        completions should be requested, e.g. for string
-                       \"socket.d\" before cursor the context will be \"socket\"
+                       \"socket.d\" before cursor the context will be \"socket\",
+                       and for string \"go.some_id\" opened with a quote before
+                       cursor the context will be \"#\" when \"#\" is a
+                       completion trigger character
     :query             a string used for filtering completions, e.g. for string
                        \"socket.d\" before cursor the query will be \"d\"
     :cursor-ranges     replacement ranges that should be used when
@@ -922,20 +925,24 @@
                        complete LSP completion list should be refreshed
     :trigger           single-character trigger string before cursor (\"\\n\" on
                        the start of the line, even it's the first one)"
-  [lines cursor-ranges]
+  [lines cursor-ranges completion-trigger-characters]
   {:pre [(pos? (count cursor-ranges))]}
-  (let [results (mapv (fn [^CursorRange cursor-range]
+  (let [hash-context (contains? completion-trigger-characters "#")
+        results (mapv (fn [^CursorRange cursor-range]
                         (let [suggestion-cursor (data/adjust-cursor lines (data/cursor-range-start cursor-range))
                               line (subs (lines (.-row suggestion-cursor)) 0 (.-col suggestion-cursor))
-                              prefix (or (re-find #"[a-zA-Z_][a-zA-Z_0-9.]*$" line) "")
+                              [context query] (if-let [hash-query (when hash-context
+                                                                    (second (re-find #"[\"']#([a-zA-Z0-9_-]*)$" line)))]
+                                                ["#" hash-query]
+                                                (let [prefix (or (re-find #"[a-zA-Z_][a-zA-Z_0-9.]*$" line) "")
+                                                      last-dot (string/last-index-of prefix ".")]
+                                                  [(if last-dot (subs prefix 0 last-dot) "")
+                                                   (if last-dot (subs prefix (inc ^long last-dot)) prefix)]))
                               affected-cursor (if (pos? (data/compare-cursor-position
                                                           (.-from cursor-range)
                                                           (.-to cursor-range)))
                                                 :to
                                                 :from)
-                              last-dot (string/last-index-of prefix ".")
-                              context (if last-dot (subs prefix 0 last-dot) "")
-                              query (if last-dot (subs prefix (inc ^long last-dot)) prefix)
                               replacement-range (update cursor-range affected-cursor update :col - (count query))]
                           [replacement-range context query]))
                       cursor-ranges)
@@ -1855,12 +1862,17 @@
    (g/with-auto-evaluation-context evaluation-context
      (implies-completions? view-node evaluation-context)))
   ([view-node evaluation-context]
-   (let [{:keys [trigger request-cursor]} (get-property view-node :completion-context evaluation-context)
+   (let [{:keys [trigger request-cursor context]} (get-property view-node :completion-context evaluation-context)
          trigger-characters (get-property view-node :completion-trigger-characters evaluation-context)
          syntax-scope (syntax-scope-before-cursor view-node request-cursor evaluation-context)]
      (boolean (and (not (contains? #{"\n" "\t" " "} trigger))
                    (or (re-matches #"[a-zA-Z_]" trigger)
                        (contains? trigger-characters trigger))
+                   ;; "#" only triggers completions at the start of a quoted
+                   ;; string, where the completion context recognizes it as a
+                   ;; component id position; elsewhere it's the Lua length
+                   ;; operator
+                   (or (not= "#" trigger) (= "#" context))
                    (not (string/starts-with? syntax-scope "punctuation.definition.string.end"))
                    (not (string/starts-with? syntax-scope "comment")))))))
 

--- a/editor/src/clj/editor/code/view.clj
+++ b/editor/src/clj/editor/code/view.clj
@@ -1867,7 +1867,9 @@
          syntax-scope (syntax-scope-before-cursor view-node request-cursor evaluation-context)]
      (boolean (and (not (contains? #{"\n" "\t" " "} trigger))
                    (or (re-matches #"[a-zA-Z_]" trigger)
-                       (contains? trigger-characters trigger))
+                       (contains? trigger-characters trigger)
+                       ;; component ids may contain digits and hyphens
+                       (and (= "#" context) (re-matches #"[0-9-]" trigger)))
                    ;; "#" only triggers completions at the start of a quoted
                    ;; string, where the completion context recognizes it as a
                    ;; component id position; elsewhere it's the Lua length

--- a/editor/test/editor/code/view_test.clj
+++ b/editor/test/editor/code/view_test.clj
@@ -1,0 +1,56 @@
+;; Copyright 2020-2026 The Defold Foundation
+;; Copyright 2014-2020 King
+;; Copyright 2009-2014 Ragnar Svensson, Christian Murray
+;; Licensed under the Defold License version 1.0 (the "License"); you may not use
+;; this file except in compliance with the License.
+;;
+;; You may obtain a copy of the License, together with FAQs at
+;; https://www.defold.com/license
+;;
+;; Unless required by applicable law or agreed to in writing, software distributed
+;; under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+;; CONDITIONS OF ANY KIND, either express or implied. See the License for the
+;; specific language governing permissions and limitations under the License.
+
+(ns editor.code.view-test
+  (:require [clojure.test :refer :all]
+            [editor.code.data :as data]
+            [editor.code.view :as view]))
+
+(set! *warn-on-reflection* true)
+
+(defn- completion-context [line trigger-characters]
+  (let [cursor (data/->Cursor 0 (count line))]
+    (view/produce-completion-context
+      {:lines [line]
+       :cursor-ranges [(data/Cursor->CursorRange cursor)]
+       :completion-trigger-characters trigger-characters})))
+
+(deftest produce-completion-context-test
+  (testing "dotted prefix"
+    (let [context (completion-context "socket.d" #{"." "#"})]
+      (is (= "socket" (:context context)))
+      (is (= "d" (:query context)))
+      (is (= "d" (:trigger context)))))
+  (testing "hash at the start of a string"
+    (let [context (completion-context "msg.post(\"#" #{"." "#"})]
+      (is (= "#" (:context context)))
+      (is (= "" (:query context)))
+      (is (= "#" (:trigger context)))))
+  (testing "hash with a partial component id"
+    (let [context (completion-context "msg.post(\"#play_s" #{"." "#"})]
+      (is (= "#" (:context context)))
+      (is (= "play_s" (:query context)))
+      (is (= (data/->Cursor 0 11) (:insert-cursor context)))))
+  (testing "hash in a single-quoted string"
+    (let [context (completion-context "msg.post('#cam" #{"." "#"})]
+      (is (= "#" (:context context)))
+      (is (= "cam" (:query context)))))
+  (testing "hash as the length operator is not a component id context"
+    (let [context (completion-context "local n = #" #{"." "#"})]
+      (is (= "" (:context context)))
+      (is (= "" (:query context)))))
+  (testing "hash context requires the hash trigger character"
+    (let [context (completion-context "msg.post(\"#play_s" #{"."})]
+      (is (= "" (:context context)))
+      (is (= "play_s" (:query context))))))

--- a/editor/test/editor/code/view_test.clj
+++ b/editor/test/editor/code/view_test.clj
@@ -46,6 +46,10 @@
     (let [context (completion-context "msg.post('#cam" #{"." "#"})]
       (is (= "#" (:context context)))
       (is (= "cam" (:query context)))))
+  (testing "hash query keeps digits and hyphens"
+    (let [context (completion-context "msg.post(\"#nil-2" #{"." "#"})]
+      (is (= "#" (:context context)))
+      (is (= "nil-2" (:query context)))))
   (testing "hash as the length operator is not a component id context"
     (let [context (completion-context "local n = #" #{"." "#"})]
       (is (= "" (:context context)))

--- a/editor/test/integration/script_completions_test.clj
+++ b/editor/test/integration/script_completions_test.clj
@@ -1,0 +1,35 @@
+;; Copyright 2020-2026 The Defold Foundation
+;; Copyright 2014-2020 King
+;; Copyright 2009-2014 Ragnar Svensson, Christian Murray
+;; Licensed under the Defold License version 1.0 (the "License"); you may not use
+;; this file except in compliance with the License.
+;;
+;; You may obtain a copy of the License, together with FAQs at
+;; https://www.defold.com/license
+;;
+;; Unless required by applicable law or agreed to in writing, software distributed
+;; under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+;; CONDITIONS OF ANY KIND, either express or implied. See the License for the
+;; specific language governing permissions and limitations under the License.
+
+(ns integration.script-completions-test
+  (:require [clojure.test :refer :all]
+            [dynamo.graph :as g]
+            [integration.test-util :as test-util]))
+
+(set! *warn-on-reflection* true)
+
+(deftest component-id-completions-test
+  (test-util/with-loaded-project
+    (testing "script attached to a game object completes its component ids"
+      (let [script-node (test-util/resource-node project "/logic/main.script")
+            completions (get (g/node-value script-node :completions) "#")]
+        (is (= ["camera" "gui" "script" "session_proxy"] (mapv :name completions)))
+        (is (every? #(= "/logic/main.go" (:detail %)) completions))))
+    (testing "component ids follow graph changes"
+      (let [script-node (test-util/resource-node project "/logic/main.script")
+            go-node (test-util/resource-node project "/logic/main.go")
+            camera-node (get (g/node-value go-node :component-ids) "camera")]
+        (g/transact (g/delete-node camera-node))
+        (is (= ["gui" "script" "session_proxy"]
+               (mapv :name (get (g/node-value script-node :completions) "#"))))))))


### PR DESCRIPTION
Typing `"#` in a script now opens the completion popup with the component ids of the game object(s) that use the script, so URLs like `"#sprite"` no longer require looking up ids in the `.go` or `.collection` file. A script attached to several game objects shows the union of their component ids, and the detail column shows which game object file each id comes from. The `#` character only triggers completions at the start of a quoted string; as the Lua length operator it behaves as before.

Fixes #12921

### Technical changes
* `#` is added to the Lua grammar's completion trigger characters. `produce-completion-context` in `code/view.clj` recognizes a quote-hash prefix as a new `"#"` completion context, gated on `#` being a completion trigger character, so other languages are unaffected. `implies-completions?` only lets `#` open the popup when the context parser recognized the quote-hash form, which keeps the Lua length operator from popping suggestions.
* `ScriptNode` overrides the `completions` output with an uncached fnk that walks graph arcs to the owning game objects (the same traversal the Show References dialog uses) and merges their `component-ids` under the `"#"` key. The output is uncached because arc walks are invisible to the dependency system; the walk starts from a single node and is cheap.
* Tests: `editor.code.view-test` covers the completion-context parsing (dotted prefix unchanged, quote-hash recognition in both quote styles, length-operator guard, per-language trigger gating); `integration.script-completions-test` verifies component ids and detail strings for a script referenced by a game object, and that the suggestions follow component deletion.

## PR checklist

* [x] Code
	* [x] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [x] Add comments where needed
* [ ] Documentation
	* [x] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [x] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does.
	* [x] Pull request - Link the pull request to the issue(s) it is closing.
	* [x] Affected issue - Assign the issue to a project.


<img width="744" height="445" alt="java_8Wjmc31P4t" src="https://github.com/user-attachments/assets/9b739b9f-8dd2-4b4e-83a6-c95140b1e526" />


