### PR TITLE
Fix right click context menu not showing selected object in scene

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -2384,6 +2384,7 @@
                                       (refresh-views! app-view evaluation-context)
                                       (reload-editor-scripts-notification-updater evaluation-context)
                                       (refresh-app-title! stage project evaluation-context)))
+                                  (ui/show-requested-context-menu!)
                                   ;; Scene views are always refreshed, since they may play animations.
                                   ;; This performs graph mutations, so needs to manage its own evaluation-contexts.
                                   (refresh-scene-views! app-view dt)))))]

--- a/editor/src/clj/editor/scene.clj
+++ b/editor/src/clj/editor/scene.clj
@@ -1771,7 +1771,6 @@
             active-updatables)))
 
 (defn update-image-view! [view-id ^ImageView image-view ^GLAutoDrawable drawable async-copy-state-atom dt]
-  (ui/show-requested-context-menu!)
   (let [action-queue (g/user-data view-id ::input-action-queue)
         [render-mode play-mode active-updatables updatable-states]
         (g/with-auto-evaluation-context evaluation-context

--- a/editor/src/clj/editor/scene.clj
+++ b/editor/src/clj/editor/scene.clj
@@ -1771,6 +1771,7 @@
             active-updatables)))
 
 (defn update-image-view! [view-id ^ImageView image-view ^GLAutoDrawable drawable async-copy-state-atom dt]
+  (ui/show-requested-context-menu!)
   (let [action-queue (g/user-data view-id ::input-action-queue)
         [render-mode play-mode active-updatables updatable-states]
         (g/with-auto-evaluation-context evaluation-context

--- a/editor/src/clj/editor/scene_selection.clj
+++ b/editor/src/clj/editor/scene_selection.clj
@@ -206,9 +206,12 @@
                             (g/set-property self :prev-selection nil)))
                         (when contextual?
                           (let [node ^Node (:target action)
-                                scene ^Scene (.getScene node)
-                                context-menu (init-scene-context-menu! scene node)]
-                            (.show context-menu node ^double (:screen-x action) ^double (:screen-y action))))
+                                screen-x (:screen-x action)
+                                screen-y (:screen-y action)]
+                            (ui/request-context-menu!
+                              #(when-let [scene (.getScene node)]
+                                 (-> (init-scene-context-menu! scene node)
+                                     (.show node ^double screen-x ^double screen-y))))))
                         nil)
       :mouse-moved (if start
                      (let [new-mode (if (and (= :single mode) (< min-pick-size (distance start cursor-pos)))

--- a/editor/src/clj/editor/ui.clj
+++ b/editor/src/clj/editor/ui.clj
@@ -1812,6 +1812,19 @@
           context-menu (init-context-menu! menu-location scene)]
       (.show context-menu node (.getScreenX event) (.getScreenY event)))))
 
+(defn request-context-menu!
+  "Queue a context menu to be shown after the next view refresh."
+  [show-fn!]
+  (user-data! (main-scene) ::requested-context-menu show-fn!))
+
+(defn show-requested-context-menu!
+  "Show the context menu queued by [[request-context-menu!]], if any."
+  []
+  (let [scene (main-scene)]
+    (when-let [show-fn! (user-data scene ::requested-context-menu)]
+      (user-data! scene ::requested-context-menu nil)
+      (show-fn!))))
+
 (defn register-context-menu
   "Register a context menu listener on a control for the menu location
 

--- a/editor/test/integration/scene_input_bindings_test.clj
+++ b/editor/test/integration/scene_input_bindings_test.clj
@@ -28,7 +28,7 @@
             [editor.types :as types]
             [editor.ui :as ui]
             [integration.test-util :as test-util])
-  (:import [javafx.scene Group]
+  (:import [javafx.scene Group Scene]
            [javafx.scene.control ContextMenu]
            [javax.vecmath Point3d]))
 
@@ -478,24 +478,35 @@
           :binding {:button :secondary :modifiers #{}}}])
       (let [[resource-node view] (test-util/open-scene-view! project app-view "/logic/atlas_sprite.collection" 128 128)
             go-node (ffirst (g/sources-of resource-node :child-scenes))
-            ;; Showing the context menu on release is a JavaFX side effect that needs a
-            ;; live scene/window we don't have here. The object is selected just before
-            ;; the menu shows, so stub the menu with a no-op ContextMenu and assert the
-            ;; selection.
+            ;; Showing the context menu is a JavaFX side effect that needs a live
+            ;; scene/window we don't have here, so stub it with a ContextMenu that only
+            ;; records the show. Queueing and draining the menu both go through the main
+            ;; stage's scene, so we need a fake one of those too.
+            shown (atom nil)
             menu-stub (ui/run-now (proxy [ContextMenu] []
-                                    (show [_node _x _y] nil)))]
+                                    (show [node x y] (reset! shown [node x y]))))
+            anchor (Group.)
+            stage (ui/run-now (doto (ui/make-stage)
+                                (.setScene (Scene. anchor))))]
         ;; The root scene node is selected initially, not the game object.
         (is (test-util/selected? app-view resource-node))
-        (with-redefs [selection/init-scene-context-menu! (fn [_scene _node] menu-stub)]
+        (with-redefs [ui/*main-stage* (atom stage)
+                      selection/init-scene-context-menu! (fn [_scene _node] menu-stub)]
           (reduce
             (partial dispatch-action! view)
             (input/make-input-state)
             [(action :mouse-moved 64.0 64.0 :secondary [])
              (action :mouse-pressed 64.0 64.0 :secondary [])
              (assoc (action :mouse-released 64.0 64.0 :secondary [])
-               :target (Group.))]))
-        (is (test-util/selected? app-view go-node)
-            "Right-clicking the object should select it before showing the context menu.")))))
+               :target anchor)])
+          (is (test-util/selected? app-view go-node)
+              "Right-clicking the object should select it before showing the context menu.")
+          (is (nil? @shown)
+              "The menu must not show during the release, or it would be built against the stale outline selection.")
+          ;; What the refresh timer does on the next tick, after the outline has caught up.
+          (ui/show-requested-context-menu!)
+          (is (= [anchor 64.0 64.0] @shown)
+              "The queued menu should show at the click position on the next refresh."))))))
 
 (deftest empty-camera-binding-override-disables-default-pan
   (test-util/with-loaded-project


### PR DESCRIPTION
This fixes an issue when right clicking on an object in a scene view, the first click does not include the recently selected object it seems, so "Show/Hide Selected Objects" appears disabled.

Fixes #12670