### PR TITLE
Normalize the gamepad name in dmHID::GetGamepadDeviceName()

### DIFF
--- a/engine/dlib/src/dlib/dstrings.cpp
+++ b/engine/dlib/src/dlib/dstrings.cpp
@@ -13,6 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #include <assert.h>
+#include <ctype.h>
 #include <stdarg.h>
 #include <string.h>
 #include <errno.h>
@@ -216,6 +217,25 @@ dmStrlCat(char *dst, const char *src, size_t siz)
         return(dlen + (s - src));       /* count does not include NUL */
 }
 
+size_t dmStrTrim(char* dst, size_t dst_size, const char* src)
+{
+    while (isspace((unsigned char)*src))
+        ++src;
+
+    const char* end = src + strlen(src);
+    while (end > src && isspace((unsigned char)end[-1]))
+        --end;
+
+    size_t length = end - src;
+    if (dst_size > 0)
+    {
+        size_t copy_length = length < dst_size ? length : dst_size - 1;
+        memmove(dst, src, copy_length);
+        dst[copy_length] = '\0';
+    }
+    return length;
+}
+
 int dmStrCaseCmp(const char *s1, const char *s2)
 {
 #ifdef _WIN32
@@ -330,4 +350,3 @@ void dmStrError(char* dst, size_t size, int err)
 #undef DM_STRERROR_USE_POSIX
 #undef DM_STRERROR_USE_UNSAFE
 #undef DM_STRERROR_FN
-

--- a/engine/dlib/src/dmsdk/dlib/dstrings.h
+++ b/engine/dlib/src/dmsdk/dlib/dstrings.h
@@ -115,6 +115,29 @@ size_t dmStrlCpy(char *dst, const char *src, size_t size);
  */
 size_t dmStrlCat(char *dst, const char *src, size_t size);
 
+/*# Copy a string without leading and trailing whitespace
+ *
+ * Copies a null-terminated string without leading and trailing whitespace, as
+ * classified by `isspace()`. Internal whitespace is preserved. At most
+ * `dst_size - 1` characters are copied and the destination is always null-terminated
+ * when `dst_size` is greater than zero. The source and destination may overlap,
+ * including being the same buffer.
+ *
+ * @name dmStrTrim
+ * @param dst [type:char*] Destination buffer
+ * @param dst_size [type:size_t] Size of the destination buffer
+ * @param src [type:const char*] Null-terminated source string
+ * @return Length of the trimmed string, excluding the terminating null byte. If
+ * this is greater than or equal to `dst_size`, the destination was truncated.
+ * @examples
+ *
+ * ```cpp
+ * char dst[4];
+ * dmStrTrim(dst, sizeof(dst), "  foo  "); // dst = "foo"
+ * ```
+ */
+size_t dmStrTrim(char* dst, size_t dst_size, const char* src);
+
 /*# Case-insensitive string comparison
  *
  * Case-insensitive string comparison

--- a/engine/dlib/src/dmsdk/dlib/dstrings.h
+++ b/engine/dlib/src/dmsdk/dlib/dstrings.h
@@ -115,20 +115,18 @@ size_t dmStrlCpy(char *dst, const char *src, size_t size);
  */
 size_t dmStrlCat(char *dst, const char *src, size_t size);
 
-/*# Copy a string without leading and trailing whitespace
+/*# Trim a string
  *
- * Copies a null-terminated string without leading and trailing whitespace, as
- * classified by `isspace()`. Internal whitespace is preserved. At most
- * `dst_size - 1` characters are copied and the destination is always null-terminated
- * when `dst_size` is greater than zero. The source and destination may overlap,
- * including being the same buffer.
+ * Copies a string while removing leading and trailing whitespace. Internal
+ * whitespace is preserved. The source and destination may be the same buffer.
+ * The destination is null-terminated when `dst_size` is greater than zero.
  *
  * @name dmStrTrim
  * @param dst [type:char*] Destination buffer
  * @param dst_size [type:size_t] Size of the destination buffer
  * @param src [type:const char*] Null-terminated source string
- * @return Length of the trimmed string, excluding the terminating null byte. If
- * this is greater than or equal to `dst_size`, the destination was truncated.
+ * @return Length of the trimmed source string. If the return value is greater
+ * than or equal to `dst_size`, the destination was truncated.
  * @examples
  *
  * ```cpp

--- a/engine/dlib/src/test/test_dstrings.cpp
+++ b/engine/dlib/src/test/test_dstrings.cpp
@@ -167,6 +167,42 @@ TEST(dmStrings, dmStrlCat3)
     ASSERT_STREQ("xyzfo", dst);
 }
 
+TEST(dmStrings, dmStrTrim)
+{
+    struct TestCase
+    {
+        const char* m_Input;
+        const char* m_Expected;
+    };
+
+    const TestCase cases[] = {
+        { "",                 "" },
+        { "foo",              "foo" },
+        { "  foo  ",          "foo" },
+        { "     ",            "" },
+        { "\t\r\nfoo \v\f",   "foo" },
+        { "foo  bar",         "foo  bar" },
+        { "foo\tbar",         "foo\tbar" },
+    };
+
+    for (uint32_t i = 0; i < sizeof(cases) / sizeof(cases[0]); ++i)
+    {
+        char string[64];
+        dmStrlCpy(string, cases[i].m_Input, sizeof(string));
+        size_t length = dmStrTrim(string, sizeof(string), string);
+        ASSERT_EQ(strlen(cases[i].m_Expected), length);
+        ASSERT_STREQ(cases[i].m_Expected, string);
+    }
+
+    char truncated[4];
+    ASSERT_EQ(6U, dmStrTrim(truncated, sizeof(truncated), "  foobar  "));
+    ASSERT_STREQ("foo", truncated);
+
+    char untouched = 'x';
+    ASSERT_EQ(3U, dmStrTrim(&untouched, 0, " foo "));
+    ASSERT_EQ('x', untouched);
+}
+
 TEST(dmStrings, dmStrCaseCmp)
 {
     ASSERT_GT(0, dmStrCaseCmp("a", "b"));

--- a/engine/hid/src/native/hid_native.cpp
+++ b/engine/hid/src/native/hid_native.cpp
@@ -388,6 +388,7 @@ namespace dmHID
                 dmStrlCpy(name, sdl_name, MAX_GAMEPAD_NAME_LENGTH);
             }
         }
+        dmStrTrim(name, MAX_GAMEPAD_NAME_LENGTH, name);
     }
 
     bool GetGamepadDeviceGuid(HContext context, HGamepad gamepad, GamepadGuid* guid)


### PR DESCRIPTION
The user facing gamepad name now is trimmed of whitespace:
E.g. `'USB Joystick '` will now show as `'USB Joystick'`.

Fixes https://github.com/defold/defold/issues/12758

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
