### PR TITLE
Deprecated misspelled event constant `window.WINDOW_EVENT_ICONFIED`

### DIFF
--- a/engine/gamesys/src/gamesys/scripts/script_window.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_window.cpp
@@ -40,6 +40,7 @@ enum WindowEvent
     WINDOW_EVENT_FOCUS_GAINED = 1,
     WINDOW_EVENT_RESIZED = 2,
     WINDOW_EVENT_ICONFIED = 3,
+    WINDOW_EVENT_ICONIFIED = 3,
     WINDOW_EVENT_DEICONIFIED = 4,
 };
 
@@ -134,8 +135,8 @@ static void RunCallback(CallbackInfo* cbinfo)
  *         print("window.WINDOW_EVENT_FOCUS_LOST")
  *     elseif event == window.WINDOW_EVENT_FOCUS_GAINED then
  *         print("window.WINDOW_EVENT_FOCUS_GAINED")
- *     elseif event == window.WINDOW_EVENT_ICONFIED then
- *         print("window.WINDOW_EVENT_ICONFIED")
+ *     elseif event == window.WINDOW_EVENT_ICONIFIED then
+ *         print("window.WINDOW_EVENT_ICONIFIED")
  *     elseif event == window.WINDOW_EVENT_DEICONIFIED then
  *         print("window.WINDOW_EVENT_DEICONIFIED")
  *     elseif event == window.WINDOW_EVENT_RESIZED then
@@ -496,7 +497,7 @@ static const luaL_reg Module_methods[] =
  * [icon:osx] [icon:windows] [icon:linux] This event is sent to a window event listener when the game window or app screen is
  * iconified (reduced to an application icon in a toolbar, application tray or similar).
  *
- * @name window.WINDOW_EVENT_ICONFIED
+ * @name window.WINDOW_EVENT_ICONIFIED
  * @constant
  */
 
@@ -540,7 +541,8 @@ static void LuaInit(lua_State* L)
     SETCONSTANT(WINDOW_EVENT_FOCUS_LOST)
     SETCONSTANT(WINDOW_EVENT_FOCUS_GAINED)
     SETCONSTANT(WINDOW_EVENT_RESIZED)
-    SETCONSTANT(WINDOW_EVENT_ICONFIED)
+    SETCONSTANT(WINDOW_EVENT_ICONFIED)      // https://github.com/defold/defold/issues/12910
+    SETCONSTANT(WINDOW_EVENT_ICONIFIED)
     SETCONSTANT(WINDOW_EVENT_DEICONIFIED)
 
     SETCONSTANT(DIMMING_UNKNOWN)
@@ -580,7 +582,7 @@ void ScriptWindowOnWindowIconify(bool iconify)
 {
     CallbackInfo cbinfo;
     cbinfo.m_Info = &g_Window;
-    cbinfo.m_Event = iconify ? WINDOW_EVENT_ICONFIED : WINDOW_EVENT_DEICONIFIED;
+    cbinfo.m_Event = iconify ? WINDOW_EVENT_ICONIFIED : WINDOW_EVENT_DEICONIFIED;
     RunCallback(&cbinfo);
 }
 


### PR DESCRIPTION
The event constant `window.WINDOW_EVENT_ICONFIED` was misspelled. The correctly spelled event constant `window.WINDOW_EVENT_ICONIFIED` has been added. The old constant still works but will be removed in a future version. Please migrate any code using the old constant.

Fixes #12910 

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
