### PR TITLE
Fix IllegalArgumentException when closing a tab whose captured resour…

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -2555,10 +2555,14 @@
                                      (view/connect-resource-node view resource-node))
 
                   :on-closed-fn (fn on-resource-tab-closed [view]
-                                  (let [resource (resource-node/resource (g/now) resource-node)]
-                                    (recent-files/add! prefs resource view-type)
-                                    (when (= :scene (:id view-type))
-                                      (save-scene-camera-prefs! prefs view resource))))}]
+                                  (g/with-auto-evaluation-context evaluation-context
+                                    (when-let [resource-node (some-> (g/node-value view :view-data evaluation-context)
+                                                                    second
+                                                                    :resource-node)]
+                                      (let [resource (resource-node/resource (:basis evaluation-context) resource-node)]
+                                        (recent-files/add! prefs resource view-type)
+                                        (when (= :scene (:id view-type))
+                                          (save-scene-camera-prefs! prefs view resource))))))}]
     (recent-files/add! prefs resource view-type)
     (let [^Tab tab (make-editor-tab! app-view localization tabs tab-spec view-opts)]
       (.setOnSelectionChanged tab (ui/event-handler event


### PR DESCRIPTION
The captured resource-node could be stale, which then leads to the following exception

```
java.lang.IllegalArgumentException: No implementation of method: :node-type of protocol: #'internal.graph.types/Node found for class: nil
	at clojure.core$_cache_protocol_fn.invokeStatic(core_deftype.clj:585)
	at clojure.core$_cache_protocol_fn.invoke(core_deftype.clj:577)
	at internal.graph.types$eval13586$fn__13639$G__13567__13644.invoke(types.clj:116)
	at dynamo.graph$node_instance_STAR__QMARK_.invokeStatic(graph.clj:1541)
	at dynamo.graph$node_instance_STAR__QMARK_.invoke(graph.clj:1537)
	at editor.resource_node$resource.invokeStatic(resource_node.clj:190)
	at editor.resource_node$resource.invoke(resource_node.clj:185)
	at editor.app_view$make_tab_BANG_$on_resource_tab_closed__110924.invoke(app_view.clj:2558)
	at editor.app_view$make_editor_tab_BANG_$fn__110918.invoke(app_view.clj:2504)
	at editor.ui$chain_handler$reify__50785.handle(ui.clj:2657)
	at com.sun.javafx.event.CompositeEventHandler.dispatchBubblingEvent(CompositeEventHandler.java:86)
	at com.sun.javafx.event.EventHandlerManager.dispatchBubblingEvent(EventHandlerManager.java:232)
	at com.sun.javafx.event.EventHandlerManager.dispatchBubblingEvent(EventHandlerManager.java:189)
	at com.sun.javafx.event.BasicEventDispatcher.dispatchEvent(BasicEventDispatcher.java:58)
	at com.sun.javafx.event.EventDispatchChainImpl.dispatchEvent(EventDispatchChainImpl.java:114)
	at com.sun.javafx.event.EventUtil.fireEventImpl(EventUtil.java:74)
	at com.sun.javafx.event.EventUtil.fireEvent(EventUtil.java:49)
	at javafx.event.Event.fireEvent(Event.java:199)
	at com.sun.javafx.scene.control.behavior.TabPaneBehavior.closeTab(TabPaneBehavior.java:99)
	at javafx.scene.control.skin.TabPaneSkin$TabHeaderSkin$3.handle(TabPaneSkin.java:1322)
	at javafx.scene.control.skin.TabPaneSkin$TabHeaderSkin$3.handle(TabPaneSkin.java:1317)
	at com.sun.javafx.event.CompositeEventHandler.dispatchBubblingEvent(CompositeEventHandler.java:86)
	at com.sun.javafx.event.EventHandlerManager.dispatchBubblingEvent(EventHandlerManager.java:232)
	at com.sun.javafx.event.EventHandlerManager.dispatchBubblingEvent(EventHandlerManager.java:189)
	at com.sun.javafx.event.CompositeEventDispatcher.dispatchBubblingEvent(CompositeEventDispatcher.java:59)
	at com.sun.javafx.event.BasicEventDispatcher.dispatchEvent(BasicEventDispatcher.java:58)
	at com.sun.javafx.event.EventDispatchChainImpl.dispatchEvent(EventDispatchChainImpl.java:114)
        ....
	at com.sun.javafx.event.EventUtil.fireEventImpl(EventUtil.java:74)
	at com.sun.javafx.event.EventUtil.fireEvent(EventUtil.java:54)
	at javafx.event.Event.fireEvent(Event.java:199)
	at javafx.scene.Scene$MouseHandler.process(Scene.java:4061)
	at javafx.scene.Scene.processMouseEvent(Scene.java:1947)
	at javafx.scene.Scene$ScenePeerListener.mouseEvent(Scene.java:2784)
	at com.sun.javafx.tk.quantum.GlassViewEventHandler$MouseEventNotification.get(GlassViewEventHandler.java:353)
	at com.sun.javafx.tk.quantum.GlassViewEventHandler$MouseEventNotification.get(GlassViewEventHandler.java:255)
	at com.sun.javafx.tk.quantum.QuantumToolkit.runWithoutRenderLock(QuantumToolkit.java:424)
	at com.sun.javafx.tk.quantum.GlassViewEventHandler.handleMouseEvent(GlassViewEventHandler.java:387)
	at com.sun.glass.ui.View.handleMouseEvent(View.java:573)
	at com.sun.glass.ui.View.notifyMouse(View.java:975)
	at com.sun.glass.ui.gtk.GtkApplication._runLoop(Native Method)
	at com.sun.glass.ui.gtk.GtkApplication.lambda$runLoop$0(GtkApplication.java:240)
	at java.base/java.lang.Thread.run(Thread.java:1474)

```