### PR TITLE
Add editor script API to open code resources at a particular line

### DIFF
--- a/editor/.cljfmt.edn
+++ b/editor/.cljfmt.edn
@@ -13,15 +13,17 @@
 ;; specific language governing permissions and limitations under the License.
 
 {:function-arguments-indentation :cursive
- :extra-indents {cljfx.composite/props [[:inner 0]]
-                 clojure.core/assoc [[:inner 0]]
+ :indent-line-comments? true
+ :extra-indents {assoc [[:block 1]]
+                 assoc! [[:block 1]]
+                 cljfx.composite/props [[:inner 0]]
                  clojure.core.cache/defcache [[:inner 0]]
-                 clojure.core/assoc! [[:inner 0]]
-                 clojure.core/cond-> [[:inner 0]]
                  clojure.core/defmulti [[:inner 0]]
                  clojure.core/defonce [[:inner 0]]
                  clojure.core/vector-of [[:inner 0]]
+                 clojure.test.check.properties/for-all [[:block 1]]
                  clojure.test/are [[:inner 0]]
+                 cond-> [[:inner 0]]
                  dev/run-with-progress [[:inner 0]]
                  dev/run-with-terminal-progress [[:inner 0]]
                  dynamo.graph/construct [[:inner 0]]
@@ -44,8 +46,10 @@
                  editor.data/register-data-resource-type [[:inner 0]]
                  editor.defold-project/read-nodes [[:inner 0]]
                  editor.defold-project/with-transpiler-txs-fn [[:inner 0]]
+                 editor.editor-tab/register-type! [[:block 1]]
                  editor.editor-extensions.runtime/lua-fn [[:inner 0]]
                  editor.editor-extensions.runtime/suspendable-lua-fn [[:inner 0]]
+                 editor.editor-extensions.runtime/suspendable-varargs-lua-fn [[:inner 0]]
                  editor.editor-extensions.runtime/varargs-lua-fn [[:inner 0]]
                  editor.editor-extensions.validation/ensure [[:inner 0]]
                  editor.editor-extensions.vm/with-lock [[:inner 0]]
@@ -122,6 +126,9 @@
                  util.debug-util/log-time-and-memory [[:inner 0]]
                  util.debug-util/measuring [[:inner 0]]
                  util.debug-util/metrics-time [[:inner 0]]
+                 util.defonce/protocol [[:block 1] [:inner 1]]
+                 util.defonce/record [[:block 2] [:inner 1]]
+                 util.defonce/type [[:block 2] [:inner 1]]
                  util.profiler/profile [[:inner 0]]
                  vlaaad.reveal/defaction [[:inner 0]]
                  vlaaad.reveal/defstream [[:inner 0]]}

--- a/editor/project.clj
+++ b/editor/project.clj
@@ -35,8 +35,11 @@
 
   :local-repo       ~(pathname (local-maven-repository-directory))
 
-  :plugins          [[lein-protobuf-minimal-mg "0.4.5" :hooks false]
+  :plugins          [[dev.weavejester/lein-cljfmt "0.16.4"]
+                     [lein-protobuf-minimal-mg "0.4.5" :hooks false]
                      [codox "0.9.3"]]
+
+  :cljfmt           {:load-config-file? true}
 
   :dependencies     [[org.clojure/clojure                         "1.12.0"]
                      [org.clojure/core.cache                      "0.7.1"]

--- a/editor/src/clj/editor/animation_set.clj
+++ b/editor/src/clj/editor/animation_set.clj
@@ -115,10 +115,10 @@
 (g/defnk produce-animation-set-build-target [_node-id resource animation-set]
   (when (not (empty? animation-set))
     (bt/with-content-hash
-       {:node-id _node-id
-        :resource (workspace/make-build-resource resource)
-        :build-fn build-animation-set
-        :user-data {:animation-set animation-set}})))
+      {:node-id _node-id
+       :resource (workspace/make-build-resource resource)
+       :build-fn build-animation-set
+       :user-data {:animation-set animation-set}})))
 
 (def ^:private form-sections
   {:navigation false
@@ -195,4 +195,4 @@
     :sanitize-fn sanitize-animation-set
     :node-type AnimationSetNode
     :ddf-type Rig$AnimationSetDesc
-    :view-types [:cljfx-form-view :text]))
+    :view-types [:form :text]))

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -102,7 +102,6 @@
             [util.fn :as fn]
             [util.http-server :as http-server]
             [util.profiler :as profiler]
-            [util.text-util :as text-util]
             [util.thread-util :as thread-util])
   (:import [com.defold.editor Editor]
            [com.dynamo.bob Platform]
@@ -1357,11 +1356,11 @@
                                  (group-by #(= :fatal (:severity %)))))]
                       (finish-with-result!
                         (cond-> project-build-results
-                                errors
-                                (update :error (fn [existing-error]
-                                                 (g/map->error {:causes (cond-> errors existing-error (conj existing-error))})))
-                                warnings
-                                (assoc :warning (g/map->error {:causes warnings})))))
+                          errors
+                          (update :error (fn [existing-error]
+                                           (g/map->error {:causes (cond-> errors existing-error (conj existing-error))})))
+                          warnings
+                          (assoc :warning (g/map->error {:causes warnings})))))
                     (finish-with-result! project-build-results)))))
             (finish-with-result! project-build-results)))
 
@@ -1600,7 +1599,7 @@
   ;; Only one of them can be active at a time. This creates the impression that
   ;; there is a single menu item whose label changes in various states.
   (active? [debug-view evaluation-context]
-           (not (debug-view/debugging? debug-view evaluation-context)))
+    (not (debug-view/debugging? debug-view evaluation-context)))
   (enabled? [] (not (build-in-progress?)))
   (run [project workspace prefs web-server build-errors-view console-view debug-view main-stage tool-tab-pane localization]
     (when (debugging-supported? project localization)
@@ -1661,14 +1660,14 @@
 
 (handler/defhandler :project.clean-build-html5 :global
   (run [project prefs web-server build-errors-view changes-view main-stage tool-tab-pane localization]
-       (when (dialogs/make-confirmation-dialog localization clean-build-dialog-info)
-         (build-html5! project prefs web-server build-errors-view changes-view main-stage tool-tab-pane
-                       bob/clean-build-html5-bob-commands))))
+    (when (dialogs/make-confirmation-dialog localization clean-build-dialog-info)
+      (build-html5! project prefs web-server build-errors-view changes-view main-stage tool-tab-pane
+                    bob/clean-build-html5-bob-commands))))
 
 (handler/defhandler :project.build-html5 :global
   (run [project prefs web-server build-errors-view changes-view main-stage tool-tab-pane]
-       (build-html5! project prefs web-server build-errors-view changes-view main-stage tool-tab-pane
-                     bob/build-html5-bob-commands)))
+    (build-html5! project prefs web-server build-errors-view changes-view main-stage tool-tab-pane
+                  bob/build-html5-bob-commands)))
 
 (defn- updated-build-resource-proj-paths [old-etags new-etags]
   ;; We only want to return resources that were present in the old etags since
@@ -1756,7 +1755,7 @@
 
 (handler/defhandler :window.tab.close :global
   (enabled? [app-view evaluation-context]
-            (not-empty (get-active-tabs app-view evaluation-context)))
+    (not-empty (get-active-tabs app-view evaluation-context)))
   (run [app-view]
     (let [tab-pane (g/node-value app-view :active-tab-pane)]
       (when-let [tab (ui/selected-tab tab-pane)]
@@ -1764,7 +1763,7 @@
 
 (handler/defhandler :window.tab.close-others :global
   (enabled? [app-view evaluation-context]
-            (not-empty (next (get-active-tabs app-view evaluation-context))))
+    (not-empty (next (get-active-tabs app-view evaluation-context))))
   (run [app-view]
     (let [tab-pane ^TabPane (g/node-value app-view :active-tab-pane)]
       (when-let [selected-tab (ui/selected-tab tab-pane)]
@@ -1778,7 +1777,7 @@
 
 (handler/defhandler :window.tab.close-all :global
   (enabled? [app-view evaluation-context]
-            (not-empty (get-active-tabs app-view evaluation-context)))
+    (not-empty (get-active-tabs app-view evaluation-context)))
   (run [app-view]
     (let [tab-pane ^TabPane (g/node-value app-view :active-tab-pane)]
       (doseq [tab (vec (.getTabs tab-pane))]
@@ -1825,70 +1824,70 @@
 
 (handler/defhandler :window.tab.move-to-other-group :global
   (enabled? [app-view evaluation-context]
-            (< 1 (open-tab-count app-view evaluation-context)))
+    (< 1 (open-tab-count app-view evaluation-context)))
   (run [app-view user-data prefs]
-       (let [editor-tabs-split ^SplitPane (g/node-value app-view :editor-tabs-split)
-             active-tab ^Tab (g/node-value app-view :active-tab)
-             source-tab-pane (.getTabPane active-tab)
-             dest-tab-pane (or (find-other-tab-pane editor-tabs-split source-tab-pane)
-                               (add-other-tab-pane! editor-tabs-split app-view prefs))]
-         (.remove (.getTabs source-tab-pane) active-tab)
-         (.add (.getTabs dest-tab-pane) active-tab)
-         (.select (.getSelectionModel dest-tab-pane) active-tab)
-         (.requestFocus dest-tab-pane))))
+    (let [editor-tabs-split ^SplitPane (g/node-value app-view :editor-tabs-split)
+          active-tab ^Tab (g/node-value app-view :active-tab)
+          source-tab-pane (.getTabPane active-tab)
+          dest-tab-pane (or (find-other-tab-pane editor-tabs-split source-tab-pane)
+                            (add-other-tab-pane! editor-tabs-split app-view prefs))]
+      (.remove (.getTabs source-tab-pane) active-tab)
+      (.add (.getTabs dest-tab-pane) active-tab)
+      (.select (.getSelectionModel dest-tab-pane) active-tab)
+      (.requestFocus dest-tab-pane))))
 
 (handler/defhandler :window.tab.swap-with-other-group :global
   (enabled? [app-view evaluation-context]
-            (< 1 (open-tab-pane-count app-view evaluation-context)))
+    (< 1 (open-tab-pane-count app-view evaluation-context)))
   (run [app-view user-data]
-       (let [editor-tabs-split ^SplitPane (g/node-value app-view :editor-tabs-split)
-             active-tab ^Tab (g/node-value app-view :active-tab)
-             active-tab-pane (.getTabPane active-tab)
-             other-tab-pane (find-other-tab-pane editor-tabs-split active-tab-pane)
-             active-tab-pane-selection (.getSelectionModel active-tab-pane)
-             other-tab-pane-selection (.getSelectionModel other-tab-pane)
-             active-tab-index (.getSelectedIndex active-tab-pane-selection)
-             other-tab-index (.getSelectedIndex other-tab-pane-selection)
-             active-tabs (.getTabs active-tab-pane)
-             other-tabs (.getTabs other-tab-pane)
-             other-tab (.get other-tabs other-tab-index)]
-         ;; Fix for DEFEDIT-1673:
-         ;; We need to swap in a dummy tab here so that a tab is never in both
-         ;; TabPanes at once, since the tab lists are observed internally. If we
-         ;; do not, the tabs will lose track of their parent TabPane.
-         (.set other-tabs other-tab-index (Tab.))
-         (.set active-tabs active-tab-index other-tab)
-         (.set other-tabs other-tab-index active-tab)
-         (.select active-tab-pane-selection other-tab)
-         (.select other-tab-pane-selection active-tab)
-         (.requestFocus other-tab-pane))))
+    (let [editor-tabs-split ^SplitPane (g/node-value app-view :editor-tabs-split)
+          active-tab ^Tab (g/node-value app-view :active-tab)
+          active-tab-pane (.getTabPane active-tab)
+          other-tab-pane (find-other-tab-pane editor-tabs-split active-tab-pane)
+          active-tab-pane-selection (.getSelectionModel active-tab-pane)
+          other-tab-pane-selection (.getSelectionModel other-tab-pane)
+          active-tab-index (.getSelectedIndex active-tab-pane-selection)
+          other-tab-index (.getSelectedIndex other-tab-pane-selection)
+          active-tabs (.getTabs active-tab-pane)
+          other-tabs (.getTabs other-tab-pane)
+          other-tab (.get other-tabs other-tab-index)]
+      ;; Fix for DEFEDIT-1673:
+      ;; We need to swap in a dummy tab here so that a tab is never in both
+      ;; TabPanes at once, since the tab lists are observed internally. If we
+      ;; do not, the tabs will lose track of their parent TabPane.
+      (.set other-tabs other-tab-index (Tab.))
+      (.set active-tabs active-tab-index other-tab)
+      (.set other-tabs other-tab-index active-tab)
+      (.select active-tab-pane-selection other-tab)
+      (.select other-tab-pane-selection active-tab)
+      (.requestFocus other-tab-pane))))
 
 (handler/defhandler :window.tab.join-groups :global
   (enabled? [app-view evaluation-context]
-            (< 1 (open-tab-pane-count app-view evaluation-context)))
+    (< 1 (open-tab-pane-count app-view evaluation-context)))
   (run [app-view prefs user-data]
-       (let [editor-tabs-split ^SplitPane (g/node-value app-view :editor-tabs-split)
-             active-tab ^Tab (g/node-value app-view :active-tab)
-             tab-panes (.getItems editor-tabs-split)
-             first-tab-pane ^TabPane (.get tab-panes 0)
-             second-tab-pane ^TabPane (.get tab-panes 1)
-             first-tabs (.getTabs first-tab-pane)
-             second-tabs (.getTabs second-tab-pane)
-             moved-tabs (vec second-tabs)
-             first-tab-pane-was-active (= first-tab-pane (some-> active-tab .getTabPane))]
-         (.clear second-tabs)
-         (.addAll first-tabs ^Collection moved-tabs)
-         (cond
-           (not first-tab-pane-was-active)
-           (do
-             (.requestFocus first-tab-pane)
-             (.select (.getSelectionModel first-tab-pane) active-tab))
+    (let [editor-tabs-split ^SplitPane (g/node-value app-view :editor-tabs-split)
+          active-tab ^Tab (g/node-value app-view :active-tab)
+          tab-panes (.getItems editor-tabs-split)
+          first-tab-pane ^TabPane (.get tab-panes 0)
+          second-tab-pane ^TabPane (.get tab-panes 1)
+          first-tabs (.getTabs first-tab-pane)
+          second-tabs (.getTabs second-tab-pane)
+          moved-tabs (vec second-tabs)
+          first-tab-pane-was-active (= first-tab-pane (some-> active-tab .getTabPane))]
+      (.clear second-tabs)
+      (.addAll first-tabs ^Collection moved-tabs)
+      (cond
+        (not first-tab-pane-was-active)
+        (do
+          (.requestFocus first-tab-pane)
+          (.select (.getSelectionModel first-tab-pane) active-tab))
 
-           (not= active-tab (ui/selected-tab first-tab-pane))
-           (.select (.getSelectionModel first-tab-pane) active-tab)
+        (not= active-tab (ui/selected-tab first-tab-pane))
+        (.select (.getSelectionModel first-tab-pane) active-tab)
 
-           :else
-           (on-active-tab-changed! app-view prefs active-tab true)))))
+        :else
+        (on-active-tab-changed! app-view prefs active-tab true)))))
 
 (defn make-about-dialog [localization]
   (let [root ^Parent (ui/load-fxml "about.fxml")
@@ -2243,7 +2242,7 @@
 (let [TabHeaderSkin (Class/forName "javafx.scene.control.skin.TabPaneSkin$TabHeaderSkin")
       getTab (.getDeclaredMethod TabHeaderSkin "getTab" (into-array Class []))]
   (.setAccessible getTab true)
-  (defn- handle-tab-pane-mouse-pressed! 
+  (defn- handle-tab-pane-mouse-pressed!
     [^TabPane tab-pane ^MouseEvent event]
     (when (= MouseButton/SECONDARY (.getButton event))
       (when-let [node (ui/closest-node-where #(instance? TabHeaderSkin %) (.getTarget event))]
@@ -2557,8 +2556,8 @@
                   :on-closed-fn (fn on-resource-tab-closed [view]
                                   (g/with-auto-evaluation-context evaluation-context
                                     (when-let [resource-node (some-> (g/node-value view :view-data evaluation-context)
-                                                                    second
-                                                                    :resource-node)]
+                                                                     second
+                                                                     :resource-node)]
                                       (let [resource (resource-node/resource (:basis evaluation-context) resource-node)]
                                         (recent-files/add! prefs resource view-type)
                                         (when (= :scene (:id view-type))
@@ -2573,7 +2572,7 @@
 (defn- substitute-args [tmpl args]
   (reduce (fn [tmpl [key val]]
             (string/replace tmpl (format "{%s}" (name key)) (str val)))
-    tmpl args))
+          tmpl args))
 
 (defn- custom-code-editor-executable-path-preference
   ^String [prefs]
@@ -2581,12 +2580,6 @@
           (prefs/get [:code :custom-editor])
           (string/trim)
           (not-empty)))
-
-(defn- view-types
-  [resource]
-  (cond->> (:view-types (resource/resource-type resource))
-           (text-util/binary? resource)
-           (e/filter #(not= :code (:id %)))))
 
 (defn- select-editor-tab!
   ([^Tab tab open-opts]
@@ -2635,7 +2628,7 @@
                                           {})))
         text-view-type (workspace/get-view-type workspace :text evaluation-context)
         view-type (or (:selected-view-type opts)
-                      (first (view-types resource))
+                      (first (workspace/resource-view-types resource))
                       text-view-type)
         view-type-id (:id view-type)
         specific-view-type-selected (some? (:selected-view-type opts))]
@@ -2664,7 +2657,7 @@
                                       (prefs/get prefs [:code :open-file-at-line])
                                       (prefs/get prefs [:code :open-file])))
               arg-sub (cond-> {:file (resource/externally-available-absolute-path resource)}
-                              cursor-range (assoc :line (CursorRange->line-number cursor-range)))
+                        cursor-range (assoc :line (CursorRange->line-number cursor-range)))
               args (->> (string/split arg-tmpl #" ")
                         (mapv #(substitute-args % arg-sub)))
               project-directory (workspace/project-directory basis workspace)]
@@ -2871,7 +2864,7 @@
 
 (defn- open-resource-plans-from-prefs [app-view prefs workspace project evaluation-context]
   (let [basis (:basis evaluation-context)
-        prefs-data-per-tab-per-tab-pane (prefs/get prefs [:workflow :open-tabs])
+        prefs-data-per-tab-per-tab-pane (recent-files/get-open-tabs prefs)
         selected-tab-index-by-tab-pane-index (prefs/get prefs [:workflow :last-selected-tabs :tab-selection-by-pane])]
     (coll/into-> prefs-data-per-tab-per-tab-pane []
       (coll/mapcat-indexed
@@ -2960,10 +2953,10 @@
                                                :use-custom-editor false})]
                                 [(view-type->option view-type)])))
                     (map view-type->option))
-                  (cond->> (view-types resource)
+                  (cond->> (workspace/resource-view-types resource)
 
-                           active-view-type-id
-                           (e/filter #(not= active-view-type-id (:id %)))))))))))
+                    active-view-type-id
+                    (e/filter #(not= active-view-type-id (:id %)))))))))))
 
 (handler/defhandler :private/recent-files :global
   (enabled? [prefs workspace evaluation-context]
@@ -2973,19 +2966,19 @@
     (-> [{:label (localization/message "command.file.reopen-recent")
           :command :file.reopen-recent}]
         (cond-> (recent-files/exist? prefs workspace evaluation-context)
-                (->
-                  (conj menu-items/separator)
-                  (into
-                    (map (fn [[resource view-type :as resource+view-type]]
-                           {:label (-> "command.private.recent-files.option.entry"
-                                       (localization/message
-                                         {"path" (resource/proj-path resource)
-                                          "view" (:label view-type)})
-                                       (localization/transform string/replace "_" "__"))
-                            :command :private/open-selected-recent-file
-                            :user-data resource+view-type}))
-                    (recent-files/some-recent prefs workspace evaluation-context))
-                  (conj menu-items/separator)))
+          (->
+            (conj menu-items/separator)
+            (into
+              (map (fn [[resource view-type :as resource+view-type]]
+                     {:label (-> "command.private.recent-files.option.entry"
+                                 (localization/message
+                                   {"path" (resource/proj-path resource)
+                                    "view" (:label view-type)})
+                                 (localization/transform string/replace "_" "__"))
+                      :command :private/open-selected-recent-file
+                      :user-data resource+view-type}))
+              (recent-files/some-recent prefs workspace evaluation-context))
+            (conj menu-items/separator)))
         (conj {:label (localization/message "command.private.recent-files.option.more")
                :command :file.open-recent}))))
 
@@ -3080,97 +3073,97 @@
 (handler/defhandler :file.save-all :global
   (enabled? [] (not (bob/build-in-progress?)))
   (run [app-view changes-view project]
-       (async-save! app-view changes-view project project/dirty-save-data)))
+    (async-save! app-view changes-view project project/dirty-save-data)))
 
 (handler/defhandler :file.save-and-upgrade-all :global
   (enabled? [] (not (bob/build-in-progress?)))
   (run [app-view changes-view project workspace localization]
-       (let [git (g/node-value changes-view :git)]
-         (when (and
+    (let [git (g/node-value changes-view :git)]
+      (when (and
 
-                 ;; Check if the project is under version control. If not,
-                 ;; advise against performing the file format upgrade, and show
-                 ;; a dialog on how to set up version control for the project.
-                 ;; The user can opt to proceed with the upgrade anyway.
-                 (or (some? git)
-                     (dialogs/make-confirmation-dialog
-                       localization
-                       {:title (localization/message "dialog.save-and-upgrade.title.not-safe")
-                        :size :default
-                        :icon :icon/triangle-error
-                        :header (localization/message "dialog.save-and-upgrade.version-control.header")
-                        :content (make-version-control-info-dialog-content
-                                   localization
-                                   (localization/message "dialog.save-and-upgrade.version-control.preamble"))
-                        :buttons [{:text (localization/message "dialog.save-and-upgrade.button.abort")
-                                   :cancel-button true
-                                   :default-button true
-                                   :result false}
-                                  {:text (localization/message "dialog.save-and-upgrade.button.proceed-anyway")
-                                   :variant :danger
-                                   :result true}]}))
+              ;; Check if the project is under version control. If not,
+              ;; advise against performing the file format upgrade, and show
+              ;; a dialog on how to set up version control for the project.
+              ;; The user can opt to proceed with the upgrade anyway.
+              (or (some? git)
+                  (dialogs/make-confirmation-dialog
+                    localization
+                    {:title (localization/message "dialog.save-and-upgrade.title.not-safe")
+                     :size :default
+                     :icon :icon/triangle-error
+                     :header (localization/message "dialog.save-and-upgrade.version-control.header")
+                     :content (make-version-control-info-dialog-content
+                                localization
+                                (localization/message "dialog.save-and-upgrade.version-control.preamble"))
+                     :buttons [{:text (localization/message "dialog.save-and-upgrade.button.abort")
+                                :cancel-button true
+                                :default-button true
+                                :result false}
+                               {:text (localization/message "dialog.save-and-upgrade.button.proceed-anyway")
+                                :variant :danger
+                                :result true}]}))
 
-                 ;; Check if there are uncommitted changes. If so, show a dialog
-                 ;; advising against performing the file format upgrade, and
-                 ;; instead ask the user to commit their changes before
-                 ;; retrying. The user can opt to proceed with the upgrade
-                 ;; anyway.
-                 (or (nil? git)
-                     (not (git/has-local-changes? git))
-                     (dialogs/make-confirmation-dialog
+              ;; Check if there are uncommitted changes. If so, show a dialog
+              ;; advising against performing the file format upgrade, and
+              ;; instead ask the user to commit their changes before
+              ;; retrying. The user can opt to proceed with the upgrade
+              ;; anyway.
+              (or (nil? git)
+                  (not (git/has-local-changes? git))
+                  (dialogs/make-confirmation-dialog
+                    localization
+                    {:title (localization/message "dialog.save-and-upgrade.title.not-safe")
+                     :size :default
+                     :icon :icon/triangle-error
+                     :header (localization/message "dialog.save-and-upgrade.uncommitted.header")
+                     :content {:fx/type fxui/legacy-label
+                               :style-class "dialog-content-padding"
+                               :text (localization (localization/message "dialog.save-and-upgrade.uncommitted.content"))}
+                     :buttons [{:text (localization/message "dialog.save-and-upgrade.button.abort")
+                                :cancel-button true
+                                :default-button true
+                                :result false}
+                               {:text (localization/message "dialog.save-and-upgrade.button.proceed-anyway")
+                                :variant :danger
+                                :result true}]})))
+
+        ;; We've deemed it safe to proceed with the file format upgrade, or
+        ;; the user has chosen to ignore our warnings. Show one last
+        ;; confirmation dialog before proceeding.
+        (let [workspace-has-non-editable-directories (workspace/has-non-editable-directories? workspace)
+              buttons (cond-> [{:text (localization/message "dialog.button.cancel")
+                                :cancel-button true
+                                :default-button true
+                                :result nil}
+                               {:text (localization/message (if workspace-has-non-editable-directories
+                                                              "dialog.save-and-upgrade.button.upgrade-editable-files"
+                                                              "dialog.save-and-upgrade.button.upgrade-project-files"))
+                                :variant :danger
+                                :result :upgrade-editable-files}]
+
+                        workspace-has-non-editable-directories
+                        (conj {:text (localization/message "dialog.save-and-upgrade.button.upgrade-all-files")
+                               :variant :danger
+                               :result :upgrade-all-files}))
+              result (dialogs/make-confirmation-dialog
                        localization
-                       {:title (localization/message "dialog.save-and-upgrade.title.not-safe")
-                        :size :default
-                        :icon :icon/triangle-error
-                        :header (localization/message "dialog.save-and-upgrade.uncommitted.header")
+                       {:title (localization/message "dialog.save-and-upgrade.confirm.title")
+                        :size :large
+                        :icon :icon/circle-question
+                        :header (localization/message "dialog.save-and-upgrade.confirm.header")
                         :content {:fx/type fxui/legacy-label
                                   :style-class "dialog-content-padding"
-                                  :text (localization (localization/message "dialog.save-and-upgrade.uncommitted.content"))}
-                        :buttons [{:text (localization/message "dialog.save-and-upgrade.button.abort")
-                                   :cancel-button true
-                                   :default-button true
-                                   :result false}
-                                  {:text (localization/message "dialog.save-and-upgrade.button.proceed-anyway")
-                                   :variant :danger
-                                   :result true}]})))
+                                  :text (localization (localization/message "dialog.save-and-upgrade.confirm.content"))}
+                        :buttons buttons})
+              save-data-fn (case result
+                             :upgrade-editable-files (partial project/upgraded-file-formats-save-data false)
+                             :upgrade-all-files (partial project/upgraded-file-formats-save-data true)
+                             nil)]
 
-           ;; We've deemed it safe to proceed with the file format upgrade, or
-           ;; the user has chosen to ignore our warnings. Show one last
-           ;; confirmation dialog before proceeding.
-           (let [workspace-has-non-editable-directories (workspace/has-non-editable-directories? workspace)
-                 buttons (cond-> [{:text (localization/message "dialog.button.cancel")
-                                   :cancel-button true
-                                   :default-button true
-                                   :result nil}
-                                  {:text (localization/message (if workspace-has-non-editable-directories
-                                                                 "dialog.save-and-upgrade.button.upgrade-editable-files"
-                                                                 "dialog.save-and-upgrade.button.upgrade-project-files"))
-                                   :variant :danger
-                                   :result :upgrade-editable-files}]
-
-                                 workspace-has-non-editable-directories
-                                 (conj {:text (localization/message "dialog.save-and-upgrade.button.upgrade-all-files")
-                                        :variant :danger
-                                        :result :upgrade-all-files}))
-                 result (dialogs/make-confirmation-dialog
-                          localization
-                          {:title (localization/message "dialog.save-and-upgrade.confirm.title")
-                           :size :large
-                           :icon :icon/circle-question
-                           :header (localization/message "dialog.save-and-upgrade.confirm.header")
-                           :content {:fx/type fxui/legacy-label
-                                     :style-class "dialog-content-padding"
-                                     :text (localization (localization/message "dialog.save-and-upgrade.confirm.content"))}
-                           :buttons buttons})
-                 save-data-fn (case result
-                                :upgrade-editable-files (partial project/upgraded-file-formats-save-data false)
-                                :upgrade-all-files (partial project/upgraded-file-formats-save-data true)
-                                nil)]
-
-             (when save-data-fn
-               ;; The user has opted to proceed with the file format upgrade.
-               (project/clear-cached-save-data! project)
-               (async-save! app-view changes-view project save-data-fn)))))))
+          (when save-data-fn
+            ;; The user has opted to proceed with the file format upgrade.
+            (project/clear-cached-save-data! project)
+            (async-save! app-view changes-view project save-data-fn)))))))
 
 (handler/defhandler :file.load-external-changes :global
   (active? [prefs] (not (async-reload-on-app-focus? prefs)))
@@ -3312,25 +3305,25 @@
 
 (handler/defhandler :window.toggle-left-pane :global
   (run [^Stage main-stage]
-       (let [main-scene (.getScene main-stage)]
-         (set-pane-visible! main-scene :left (not (pane-visible? main-scene :left))))))
+    (let [main-scene (.getScene main-stage)]
+      (set-pane-visible! main-scene :left (not (pane-visible? main-scene :left))))))
 
 (handler/defhandler :window.toggle-right-pane :global
   (run [^Stage main-stage]
-       (let [main-scene (.getScene main-stage)]
-         (set-pane-visible! main-scene :right (not (pane-visible? main-scene :right))))))
+    (let [main-scene (.getScene main-stage)]
+      (set-pane-visible! main-scene :right (not (pane-visible? main-scene :right))))))
 
 (handler/defhandler :window.toggle-bottom-pane :global
   (run [^Stage main-stage]
-       (let [main-scene (.getScene main-stage)]
-         (set-pane-visible! main-scene :bottom (not (pane-visible? main-scene :bottom))))))
+    (let [main-scene (.getScene main-stage)]
+      (set-pane-visible! main-scene :bottom (not (pane-visible? main-scene :bottom))))))
 
 (handler/defhandler :window.toggle-changed-files-pane :global
   (enabled? [^Stage main-stage]
-            (pane-visible? (.getScene main-stage) :left))
+    (pane-visible? (.getScene main-stage) :left))
   (run [^Stage main-stage]
-       (let [main-scene (.getScene main-stage)]
-         (set-pane-visible! main-scene :changed-files (not (pane-visible? main-scene :changed-files))))))
+    (let [main-scene (.getScene main-stage)]
+      (set-pane-visible! main-scene :changed-files (not (pane-visible? main-scene :changed-files))))))
 
 (handler/defhandler :window.show-console :global
   (run [^Stage main-stage tool-tab-pane] (show-console! (.getScene main-stage) tool-tab-pane)))
@@ -3432,8 +3425,8 @@
                                                           :ok-label (localization/message "dialog.open-assets.button.ok")
                                                           :filter-atom filter-term-atom
                                                           :tooltip-gen (partial gen-tooltip workspace project app-view)}
-                                                         (some? term)
-                                                         (assoc :filter term)))
+                                                   (some? term)
+                                                   (assoc :filter term)))
         filter-term @filter-term-atom]
     (when (not= prev-filter-term filter-term)
       (prefs/set! prefs open-assets-term-prefs-key filter-term))
@@ -3546,11 +3539,11 @@
                                          (future/complete! f nil))
                                      (future/fail! f (Exception. "Save failed")))))
                f))
-    :open-resource! (fn ext-open-resource! [resource]
+    :open-resource! (fn ext-open-resource! [resource opts]
                       (let [f (future/make)]
                         (ui/run-later
                           (try
-                            (open-resource! app-view prefs localization project resource)
+                            (open-resource! app-view prefs localization project resource opts)
                             (catch Throwable e (error-reporting/report-exception! e)))
                           (future/complete! f nil))
                         f))
@@ -3560,10 +3553,10 @@
                    (let [f (future/make)]
                      (fx/on-fx-thread
                        (let [options (cond-> options
-                                             (not (contains? options "build-server"))
-                                             (assoc "build-server" (native-extensions/get-build-server-url prefs project evaluation-context))
-                                             (not (contains? options "build-server-header"))
-                                             (assoc "build-server-header" (native-extensions/get-build-server-headers prefs)))
+                                       (not (contains? options "build-server"))
+                                       (assoc "build-server" (native-extensions/get-build-server-url prefs project evaluation-context))
+                                       (not (contains? options "build-server-header"))
+                                       (assoc "build-server-header" (native-extensions/get-build-server-headers prefs)))
                              main-scene (g/node-value app-view :scene evaluation-context)
                              tool-tab-pane (g/node-value app-view :tool-tab-pane evaluation-context)
                              render-build-error! (make-render-build-error main-scene tool-tab-pane build-errors-view)

--- a/editor/src/clj/editor/camera_editor.clj
+++ b/editor/src/clj/editor/camera_editor.clj
@@ -292,7 +292,7 @@
       (gl/gl-draw-arrays gl GL/GL_LINES 0 (count vertex-buffer)))))
 
 (g/defnk produce-camera-scene
-[_node-id fov aspect-ratio auto-aspect-ratio near-z far-z orthographic-projection orthographic-zoom orthographic-mode project-display-width project-display-height project-render-clear-color]
+  [_node-id fov aspect-ratio auto-aspect-ratio near-z far-z orthographic-projection orthographic-zoom orthographic-mode project-display-width project-display-height project-render-clear-color]
   ;; TODO: Better AABB calculation
   (let [^double ext-x far-z
         ^double ext-y far-z
@@ -402,7 +402,7 @@
     :icon camera-icon
     :icon-class :property
     :category (localization/message "resource.category.components")
-    :view-types [:cljfx-form-view :text]
+    :view-types [:form :text]
     :view-opts {}
     :tags #{:component}
     :tag-opts {:component {:transform-properties #{}}}

--- a/editor/src/clj/editor/cljfx_form_view.clj
+++ b/editor/src/clj/editor/cljfx_form_view.clj
@@ -148,7 +148,7 @@
 
 (defn- text-field [props]
   (assoc props :fx/type fx.text-field/lifecycle
-               :style-class ["text-field" "cljfx-form-text-field"]))
+         :style-class ["text-field" "cljfx-form-text-field"]))
 
 (defn- add-image-fit-size [{:keys [fit-size] :as props}]
   (-> props
@@ -161,15 +161,15 @@
               (assoc :graphic {:fx/type fx.image-view/lifecycle
                                :image (icons/get-image (:image props))}))
 
-          (contains? props :fit-size)
-          add-image-fit-size))
+    (contains? props :fit-size)
+    add-image-fit-size))
 
 (defn- icon-button [props]
   (cond-> (assoc props :fx/type fx.button/lifecycle
-                       :style-class ["button" "cljfx-form-icon-button"])
+                 :style-class ["button" "cljfx-form-icon-button"])
 
-          (contains? props :image)
-          add-image))
+    (contains? props :image)
+    add-image))
 
 (defmulti form-input-view
   "Form input component function
@@ -217,7 +217,7 @@
 (defn- default-cell-input-view [field]
   (wrap-cancel-on-escape
     (assoc field :fx/type form-input-view
-                 :on-value-changed (:on-commit field))
+           :on-value-changed (:on-commit field))
     (:on-cancel field)))
 
 (defmethod cell-input-view :default [field]
@@ -384,7 +384,7 @@
                                 :state-path state-path
                                 :on-value-changed on-value-changed})
       (cond-> (contains? state :form-input-state)
-              (assoc :state (:form-input-state state)))
+        (assoc :state (:form-input-state state)))
       (wrap-cancel-on-escape on-cancel)
       (wrap-commit-on-enter on-commit state-path)
       (wrap-focus-text-field)))
@@ -624,7 +624,7 @@
                :resource-string-converter resource-string-converter
                :state-path (conj state-path :edit :state))
         (cond-> (contains? edit :state)
-                (assoc :state (:state edit))))))
+          (assoc :state (:state edit))))))
 
 (defn- display-value-text [{:keys [type] :as field} value]
   (case type
@@ -797,16 +797,16 @@
                                    :or {value []}
                                    :as field}]
   (assoc field :fx/type list-input
-               :max-width normal-field-width
-               :on-edited {:event-type :edit-list-item
-                           :value value
-                           :on-value-changed on-value-changed}
-               :on-added {:event-type :add-list-items
-                          :value value
-                          :on-value-changed on-value-changed}
-               :on-removed {:event-type :remove-list-items
-                            :value value
-                            :on-value-changed on-value-changed}))
+         :max-width normal-field-width
+         :on-edited {:event-type :edit-list-item
+                     :value value
+                     :on-value-changed on-value-changed}
+         :on-added {:event-type :add-list-items
+                    :value value
+                    :on-value-changed on-value-changed}
+         :on-removed {:event-type :remove-list-items
+                      :value value
+                      :on-value-changed on-value-changed}))
 
 ;; endregion
 
@@ -952,8 +952,8 @@
   (let [edit (get-in ui-state (conj state-path :edit))]
     (cond-> [[:set-ui-state (update-in ui-state state-path dissoc :edit)]]
 
-            (some? (:value edit))
-            (conj [:dispatch (assoc on-value-changed :fx/event (value-with-edit value edit))]))))
+      (some? (:value edit))
+      (conj [:dispatch (assoc on-value-changed :fx/event (value-with-edit value edit))]))))
 
 (defmethod handle-event :commit-table-edit [{:keys [fx/event
                                                     edit-path
@@ -1022,24 +1022,24 @@
   (let [{:keys [edit]} state
         edit-path (into [(:index edit)] (:path column))
         input-state-path (conj state-path :edit :state)]
-      (-> column
-          (assoc :fx/type cell-input-view
-                 :value item
-                 :max-width normal-field-width
-                 :on-value-changed {:event-type :keep-table-edit
-                                    :state-path state-path}
-                 :on-cancel {:event-type :cancel-table-edit
-                             :state-path state-path}
-                 :on-commit {:event-type :commit-table-edit
-                             :edit-path edit-path
-                             :state-path state-path
-                             :value value
-                             :on-value-changed on-value-changed}
-                 :localization-state localization-state
-                 :resource-string-converter resource-string-converter
-                 :state-path input-state-path)
-          (cond-> (contains? edit :state)
-                  (assoc :state (:state edit))))))
+    (-> column
+        (assoc :fx/type cell-input-view
+               :value item
+               :max-width normal-field-width
+               :on-value-changed {:event-type :keep-table-edit
+                                  :state-path state-path}
+               :on-cancel {:event-type :cancel-table-edit
+                           :state-path state-path}
+               :on-commit {:event-type :commit-table-edit
+                           :edit-path edit-path
+                           :state-path state-path
+                           :value value
+                           :on-value-changed on-value-changed}
+               :localization-state localization-state
+               :resource-string-converter resource-string-converter
+               :state-path input-state-path)
+        (cond-> (contains? edit :state)
+          (assoc :state (:state edit))))))
 
 (defn- table-cell-value-factory [path [i x]]
   [i (get-in x path)])
@@ -1291,8 +1291,8 @@
                  :localization-state localization-state
                  :resource-string-converter resource-string-converter}
 
-                (contains? state :key)
-                (assoc :state (:key state)))
+          (contains? state :key)
+          (assoc :state (:key state)))
 
         selected-item-fields
         (when selected-index
@@ -1327,31 +1327,31 @@
                                                 :grid-pane/margin {:top 5}
                                                 :opacity 0.6
                                                 :text (get-label-text localization-state field)}]
-                                              (and (form/optional-field? field)
-                                                   (not= field-value ::no-value))
-                                              (conj {:fx/type icon-button
-                                                     :grid-pane/column 1
-                                                     :image "icons/32/Icons_S_02_Reset.png"
-                                                     :on-action {:event-type :2panel-value-clear
-                                                                 :index selected-index
-                                                                 :value-path (:path field)
-                                                                 :set fn-setter
-                                                                 :value value
-                                                                 :on-value-changed on-value-changed}}))}
+                                        (and (form/optional-field? field)
+                                             (not= field-value ::no-value))
+                                        (conj {:fx/type icon-button
+                                               :grid-pane/column 1
+                                               :image "icons/32/Icons_S_02_Reset.png"
+                                               :on-action {:event-type :2panel-value-clear
+                                                           :index selected-index
+                                                           :value-path (:path field)
+                                                           :set fn-setter
+                                                           :value value
+                                                           :on-value-changed on-value-changed}}))}
                            (cond->
                              (assoc field :fx/type form-input-view
-                                          :value (if (= ::no-value field-value)
-                                                   (form/field-default field)
-                                                   field-value)
-                                          :on-value-changed {:event-type :2panel-value-set
-                                                             :index selected-index
-                                                             :value-path (:path field)
-                                                             :value value
-                                                             :set fn-setter
-                                                             :on-value-changed on-value-changed}
-                                          :state-path field-state-path
-                                          :localization-state localization-state
-                                          :resource-string-converter resource-string-converter)
+                                    :value (if (= ::no-value field-value)
+                                             (form/field-default field)
+                                             field-value)
+                                    :on-value-changed {:event-type :2panel-value-set
+                                                       :index selected-index
+                                                       :value-path (:path field)
+                                                       :value value
+                                                       :set fn-setter
+                                                       :on-value-changed on-value-changed}
+                                    :state-path field-state-path
+                                    :localization-state localization-state
+                                    :resource-string-converter resource-string-converter)
                              (not= ::no-value field-state)
                              (assoc :state field-state))]}))))
                  (:sections
@@ -1380,68 +1380,68 @@
                 :build-targets)
         help-text (get-help-text localization-state field)]
     (cond-> []
-            :always
-            (conj (cond->
-                    {:fx/type fx.label/lifecycle
-                     :fx/key [:label path]
-                     :grid-pane/row row
-                     :grid-pane/column 0
-                     :grid-pane/valignment :top
-                     :grid-pane/margin {:top 5}
-                     :visible visible
-                     :managed visible
-                     :alignment :top-left
-                     :text (get-label-text localization-state field)}
-                    help-text
-                    (fxui/apply-tooltip
-                      {:fx/type fxui/tooltip
-                       :content-display :graphic-only
-                       :style {:-fx-padding 0}
-                       :graphic {:fx/type markdown/view
-                                 :content help-text
-                                 :max-width 350.0
-                                 :project project}})))
-            (and (form/optional-field? field)
-                 (not= value ::no-value))
-            (conj {:fx/type icon-button
-                   :fx/key [:clear path]
-                   :grid-pane/row row
-                   :grid-pane/column 1
-                   :grid-pane/valignment :top
-                   :grid-pane/halignment :right
-                   :visible visible
-                   :managed visible
-                   :image "icons/32/Icons_S_02_Reset.png"
-                   :on-action {:event-type :clear
-                               :path path}})
+      :always
+      (conj (cond->
+              {:fx/type fx.label/lifecycle
+               :fx/key [:label path]
+               :grid-pane/row row
+               :grid-pane/column 0
+               :grid-pane/valignment :top
+               :grid-pane/margin {:top 5}
+               :visible visible
+               :managed visible
+               :alignment :top-left
+               :text (get-label-text localization-state field)}
+              help-text
+              (fxui/apply-tooltip
+                {:fx/type fxui/tooltip
+                 :content-display :graphic-only
+                 :style {:-fx-padding 0}
+                 :graphic {:fx/type markdown/view
+                           :content help-text
+                           :max-width 350.0
+                           :project project}})))
+      (and (form/optional-field? field)
+           (not= value ::no-value))
+      (conj {:fx/type icon-button
+             :fx/key [:clear path]
+             :grid-pane/row row
+             :grid-pane/column 1
+             :grid-pane/valignment :top
+             :grid-pane/halignment :right
+             :visible visible
+             :managed visible
+             :image "icons/32/Icons_S_02_Reset.png"
+             :on-action {:event-type :clear
+                         :path path}})
 
-            :always
-            (conj {:fx/type fx.v-box/lifecycle
-                   :fx/key [:control path]
-                   :style-class (case (:severity error)
-                                  :fatal ["cljfx-form-error"]
-                                  :warning ["cljfx-form-warning"]
-                                  [])
-                   :grid-pane/row row
-                   :grid-pane/column 2
-                   :visible visible
-                   :managed visible
-                   :min-height line-height
-                   :alignment :center-left
-                   :children [(cond-> field
-                                      :always
-                                      (assoc :fx/type form-input-view
-                                             :localization-state localization-state
-                                             :resource-string-converter resource-string-converter
-                                             :value (if (= ::no-value value)
-                                                      (form/field-default field)
-                                                      value)
-                                             :on-value-changed {:event-type :set
-                                                                :path path}
-                                             :state-path state-path)
+      :always
+      (conj {:fx/type fx.v-box/lifecycle
+             :fx/key [:control path]
+             :style-class (case (:severity error)
+                            :fatal ["cljfx-form-error"]
+                            :warning ["cljfx-form-warning"]
+                            [])
+             :grid-pane/row row
+             :grid-pane/column 2
+             :visible visible
+             :managed visible
+             :min-height line-height
+             :alignment :center-left
+             :children [(cond-> field
+                          :always
+                          (assoc :fx/type form-input-view
+                                 :localization-state localization-state
+                                 :resource-string-converter resource-string-converter
+                                 :value (if (= ::no-value value)
+                                          (form/field-default field)
+                                          value)
+                                 :on-value-changed {:event-type :set
+                                                    :path path}
+                                 :state-path state-path)
 
-                                      (not= ::no-value state)
-                                      (assoc :state state))]}))))
+                          (not= ::no-value state)
+                          (assoc :state state))]}))))
 
 (defn- section-view [{:keys [title help fields values ui-state resource-string-converter visible localization-state project]}]
   {:fx/type fx.v-box/lifecycle
@@ -1449,41 +1449,41 @@
    :managed visible
    :children (cond-> []
 
-                     :always
-                     (conj {:fx/type fx.label/lifecycle
-                            :style-class ["label" "cljfx-form-title"]
-                            :text title})
+               :always
+               (conj {:fx/type fx.label/lifecycle
+                      :style-class ["label" "cljfx-form-title"]
+                      :text title})
 
-                     help
-                     (conj {:fx/type fx.label/lifecycle :text help})
+               help
+               (conj {:fx/type fx.label/lifecycle :text help})
 
-                     :always
-                     (conj {:fx/type fx.grid-pane/lifecycle
-                            :style-class "cljfx-form-fields"
-                            :vgap line-spacing
-                            :column-constraints [{:fx/type fx.column-constraints/lifecycle
-                                                  :min-width 150
-                                                  :max-width 150}
-                                                 {:fx/type fx.column-constraints/lifecycle
-                                                  :min-width line-height
-                                                  :max-width line-height}
-                                                 {:fx/type fx.column-constraints/lifecycle
-                                                  :hgrow :always
-                                                  :min-width 200
-                                                  :max-width large-field-width}]
-                            :children (first
-                                        (reduce
-                                          (fn [[acc row] field]
-                                            [(into acc (make-row values
-                                                                 ui-state
-                                                                 resource-string-converter
-                                                                 row
-                                                                 field
-                                                                 localization-state
-                                                                 project))
-                                             (if (:visible field) (inc row) row)])
-                                          [[] 0]
-                                          fields))}))})
+               :always
+               (conj {:fx/type fx.grid-pane/lifecycle
+                      :style-class "cljfx-form-fields"
+                      :vgap line-spacing
+                      :column-constraints [{:fx/type fx.column-constraints/lifecycle
+                                            :min-width 150
+                                            :max-width 150}
+                                           {:fx/type fx.column-constraints/lifecycle
+                                            :min-width line-height
+                                            :max-width line-height}
+                                           {:fx/type fx.column-constraints/lifecycle
+                                            :hgrow :always
+                                            :min-width 200
+                                            :max-width large-field-width}]
+                      :children (first
+                                  (reduce
+                                    (fn [[acc row] field]
+                                      [(into acc (make-row values
+                                                           ui-state
+                                                           resource-string-converter
+                                                           row
+                                                           field
+                                                           localization-state
+                                                           project))
+                                       (if (:visible field) (inc row) row)])
+                                    [[] 0]
+                                    fields))}))})
 
 ;; region filtering
 
@@ -1717,14 +1717,14 @@
                                                                   :style-class "cljfx-form"}
                                                            selected-section
                                                            (assoc :children
-                                                                  [(assoc selected-section
-                                                                     :fx/type section-view
-                                                                     :fx/key selected-section-title
-                                                                     :values values
-                                                                     :ui-state ui-state
-                                                                     :localization-state localization-state
-                                                                     :project project
-                                                                     :resource-string-converter resource-string-converter)]))}}]})
+                                                             [(assoc selected-section
+                                                                :fx/type section-view
+                                                                :fx/key selected-section-title
+                                                                :values values
+                                                                :ui-state ui-state
+                                                                :localization-state localization-state
+                                                                :project project
+                                                                :resource-string-converter resource-string-converter)]))}}]})
 
                           {:fx/type fx/ext-on-instance-lifecycle
                            :anchor-pane/top 0
@@ -1845,11 +1845,11 @@
 
 (defn register-view-types [workspace]
   (workspace/register-view-type workspace
-                                :id :cljfx-form-view
-                                :label (localization/message "resource.view.form")
-                                :make-view-fn make-form-view))
+    :id :form
+    :label (localization/message "resource.view.form")
+    :make-view-fn make-form-view))
 
 (handler/defhandler :edit.find :form
   (run [^Node root]
-       (when-let [node (.lookup root "#filter-text-field")]
-         (.requestFocus node))))
+    (when-let [node (.lookup root "#filter-text-field")]
+      (.requestFocus node))))

--- a/editor/src/clj/editor/code/view.clj
+++ b/editor/src/clj/editor/code/view.clj
@@ -44,6 +44,7 @@
             [editor.code.util :refer [split-lines]]
             [editor.defold-project :as project]
             [editor.dialogs :as dialogs]
+            [editor.editor-extensions.coerce :as coerce]
             [editor.editor-extensions.node-types :as node-types]
             [editor.error-reporting :as error-reporting]
             [editor.fxui :as fxui]
@@ -1389,10 +1390,10 @@
                  :spacing :small
                  :children (cond-> [{:fx/type code-type-icon :type kind}
                                     {:fx/type fxui/label :text name}]
-                                   (not (coll/empty? detail))
-                                   (conj {:fx/type fxui/label
-                                          :text (summarize-document-symbol-detail detail)
-                                          :color :hint}))}})))
+                             (not (coll/empty? detail))
+                             (conj {:fx/type fxui/label
+                                    :text (summarize-document-symbol-detail detail)
+                                    :color :hint}))}})))
 
 (defn- navigate-to-document-symbol! [view-node document-symbol]
   (when document-symbol
@@ -1531,8 +1532,8 @@
                              :document-symbols document-symbols
                              :localization localization
                              :view-node _node-id}}]
-                    (has-visible-properties? resource-properties)
-                    (conj :properties-pane))))
+              (has-visible-properties? resource-properties)
+              (conj :properties-pane))))
 
   ;; the cursor position for which we show the hover.
   (property hover-showing-cursor g/Any (dynamic visible (g/constantly false)))
@@ -1656,7 +1657,6 @@
     MouseButton/MIDDLE :middle
     MouseButton/BACK :back
     MouseButton/FORWARD :forward))
-
 
 ;; -----------------------------------------------------------------------------
 ;; Code completion
@@ -1989,8 +1989,8 @@
       (set-properties! view-node :selection
                        (cond-> {:cursor-ranges new-cursor-ranges}
 
-                               (not= (count regions) (count new-regions))
-                               (assoc :regions new-regions))))))
+                         (not= (count regions) (count new-regions))
+                         (assoc :regions new-regions))))))
 
 (def ^:private prev-tab-trigger! #(select-closest-tab-trigger-region! :prev %))
 (def ^:private next-tab-trigger! #(select-closest-tab-trigger-region! :next %))
@@ -2762,8 +2762,8 @@
                               y)
             (cond->
               (and lsp
-                (prefs/get prefs hover-pref-path)
-                (not (get-property view-node :hover-mouse-over-popup evaluation-context)))
+                   (prefs/get prefs hover-pref-path)
+                   (not (get-property view-node :hover-mouse-over-popup evaluation-context)))
               (merge
                 (let [hover-character-cursor (data/canvas->character-cursor layout lines x y)]
                   (request-lsp-hover! view-node lsp resource-node hover-character-cursor evaluation-context))))))))
@@ -2877,13 +2877,13 @@
 (handler/defhandler :edit.cut :code-view
   (active? [editable] editable)
   (enabled? [view-node evaluation-context]
-            (has-selection? view-node evaluation-context))
+    (has-selection? view-node evaluation-context))
   (run [view-node clipboard] (cut! view-node clipboard)))
 
 (handler/defhandler :edit.paste :code-view
   (active? [editable] editable)
   (enabled? [view-node clipboard evaluation-context]
-            (can-paste? view-node clipboard evaluation-context))
+    (can-paste? view-node clipboard evaluation-context))
   (run [view-node clipboard] (paste! view-node clipboard)))
 
 (handler/defhandler :code.duplicate-selection :code-view
@@ -2896,8 +2896,8 @@
 
 (handler/defhandler :code.toggle-comment :code-view
   (active? [editable view-node evaluation-context]
-           (and editable
-                (contains? (get-property view-node :grammar evaluation-context) :line-comment)))
+    (and editable
+         (contains? (get-property view-node :grammar evaluation-context) :line-comment)))
   (run [view-node] (toggle-comment! view-node)))
 
 (handler/defhandler :code.delete-previous-char :code-view
@@ -2959,17 +2959,17 @@
 (handler/defhandler :code.reindent :code-view
   (active? [editable] editable)
   (enabled? [view-node evaluation-context]
-            (not-every? data/cursor-range-empty?
-                        (get-property view-node :cursor-ranges evaluation-context)))
+    (not-every? data/cursor-range-empty?
+                (get-property view-node :cursor-ranges evaluation-context)))
   (run [view-node]
-       (set-properties! view-node nil
-                        (data/reindent (get-property view-node :indent-level-pattern)
-                                       (get-property view-node :indent-string)
-                                       (get-property view-node :grammar)
-                                       (get-property view-node :lines)
-                                       (get-property view-node :cursor-ranges)
-                                       (get-property view-node :regions)
-                                       (get-property view-node :layout)))))
+    (set-properties! view-node nil
+                     (data/reindent (get-property view-node :indent-level-pattern)
+                                    (get-property view-node :indent-string)
+                                    (get-property view-node :grammar)
+                                    (get-property view-node :lines)
+                                    (get-property view-node :cursor-ranges)
+                                    (get-property view-node :regions)
+                                    (get-property view-node :layout)))))
 
 (handler/defhandler :code.convert-indentation :code-view
   (label [user-data]
@@ -2991,12 +2991,12 @@
         :user-data :four-spaces}]))
   (active? [editable] editable)
   (run [view-node user-data]
-       (set-properties! view-node nil
-                        (data/convert-indentation (get-property view-node :indent-type)
-                                                  user-data
-                                                  (get-property view-node :lines)
-                                                  (get-property view-node :cursor-ranges)
-                                                  (get-property view-node :regions)))))
+    (set-properties! view-node nil
+                     (data/convert-indentation (get-property view-node :indent-type)
+                                               user-data
+                                               (get-property view-node :lines)
+                                               (get-property view-node :cursor-ranges)
+                                               (get-property view-node :regions)))))
 
 (defn- show-goto-popup! [view-node open-resource-fn results]
   (g/with-auto-evaluation-context evaluation-context
@@ -3169,7 +3169,7 @@
                                                              display-name
                                                              indices
                                                              :deprecated (contains? tags :deprecated))
-                                                           :min-width :use-pref-size)]
+                                                      :min-width :use-pref-size)]
                                              (coll/not-empty detail)
                                              (conj {:fx/type fx.region/lifecycle
                                                     :h-box/hgrow :always
@@ -3360,26 +3360,26 @@
 
 (handler/defhandler :code.goto-line :code-view-tools
   (run [goto-line-bar]
-       (set-bar-ui-type! :goto-line)
-       (ui/with-controls goto-line-bar [^TextField line-field]
-         (.requestFocus line-field)
-         (.selectAll line-field))))
+    (set-bar-ui-type! :goto-line)
+    (ui/with-controls goto-line-bar [^TextField line-field]
+      (.requestFocus line-field)
+      (.selectAll line-field))))
 
 (handler/defhandler :private/goto-entered-line :goto-line-bar
   (enabled? [goto-line-bar view-node evaluation-context]
-            (some? (try-parse-goto-line-bar-row view-node goto-line-bar evaluation-context)))
+    (some? (try-parse-goto-line-bar-row view-node goto-line-bar evaluation-context)))
   (run [goto-line-bar view-node]
-       (when-some [line-number (try-parse-goto-line-bar-row view-node goto-line-bar)]
-         (let [cursor-range (data/Cursor->CursorRange (data/->Cursor line-number 0))]
-           (set-properties! view-node :navigation
-                            (data/select-and-frame (get-property view-node :lines)
-                                                   (get-property view-node :layout)
-                                                   cursor-range)))
-         (set-bar-ui-type! :hidden)
-         ;; Close bar on next tick so the code view will not insert a newline
-         ;; if the bar was dismissed by pressing the Enter key.
-         (ui/run-later
-           (focus-code-editor! view-node)))))
+    (when-some [line-number (try-parse-goto-line-bar-row view-node goto-line-bar)]
+      (let [cursor-range (data/Cursor->CursorRange (data/->Cursor line-number 0))]
+        (set-properties! view-node :navigation
+                         (data/select-and-frame (get-property view-node :lines)
+                                                (get-property view-node :layout)
+                                                cursor-range)))
+      (set-bar-ui-type! :hidden)
+      ;; Close bar on next tick so the code view will not insert a newline
+      ;; if the bar was dismissed by pressing the Enter key.
+      (ui/run-later
+        (focus-code-editor! view-node)))))
 
 ;; -----------------------------------------------------------------------------
 ;; Find & Replace
@@ -3515,49 +3515,49 @@
 
 (handler/defhandler :edit.find :code-view
   (run [find-bar view-node]
-       (when-some [selected-text (non-empty-single-selection-text view-node)]
-         (set-find-term! selected-text))
-       (set-bar-ui-type! :find)
-       (focus-term-field! find-bar)))
+    (when-some [selected-text (non-empty-single-selection-text view-node)]
+      (set-find-term! selected-text))
+    (set-bar-ui-type! :find)
+    (focus-term-field! find-bar)))
 
 (handler/defhandler :code.replace-text :code-view
   (active? [editable] editable)
   (run [replace-bar view-node]
-       (when-some [selected-text (non-empty-single-selection-text view-node)]
-         (set-find-term! selected-text))
-       (set-bar-ui-type! :replace)
-       (focus-term-field! replace-bar)))
+    (when-some [selected-text (non-empty-single-selection-text view-node)]
+      (set-find-term! selected-text))
+    (set-bar-ui-type! :replace)
+    (focus-term-field! replace-bar)))
 
 (handler/defhandler :edit.find :code-view-tools ;; In practice, from find / replace and go to line bars.
   (run [find-bar]
-       (set-bar-ui-type! :find)
-       (focus-term-field! find-bar)))
+    (set-bar-ui-type! :find)
+    (focus-term-field! find-bar)))
 
 (handler/defhandler :code.replace-text :code-view-tools
   (active? [editable] editable)
   (run [replace-bar]
-       (set-bar-ui-type! :replace)
-       (focus-term-field! replace-bar)))
+    (set-bar-ui-type! :replace)
+    (focus-term-field! replace-bar)))
 
 (handler/defhandler :code.escape :code-view-tools
   (run [find-bar replace-bar view-node]
-       (cond
-         (in-tab-trigger? view-node)
-         (exit-tab-trigger! view-node)
+    (cond
+      (in-tab-trigger? view-node)
+      (exit-tab-trigger! view-node)
 
-         (hover-visible? view-node)
-         (hide-hover! view-node)
+      (hover-visible? view-node)
+      (hide-hover! view-node)
 
-         (suggestions-visible? view-node)
-         (hide-suggestions! view-node)
+      (suggestions-visible? view-node)
+      (hide-suggestions! view-node)
 
-         (bar-ui-visible?)
-         (do (set-bar-ui-type! :hidden)
-             (focus-code-editor! view-node))
+      (bar-ui-visible?)
+      (do (set-bar-ui-type! :hidden)
+          (focus-code-editor! view-node))
 
-         :else
-         (set-properties! view-node :selection
-                          (data/escape (get-property view-node :cursor-ranges))))))
+      :else
+      (set-properties! view-node :selection
+                       (data/escape (get-property view-node :cursor-ranges))))))
 
 (handler/defhandler :code.find-next :code-view-find-bar
   (run [view-node] (find-next! view-node)))
@@ -3773,8 +3773,8 @@
                      tick-props
                      (let [new-cursor-opacity (cursor-opacity elapsed-time-at-last-action elapsed-time)]
                        (cond-> tick-props
-                               (not= old-cursor-opacity new-cursor-opacity)
-                               (assoc :cursor-opacity new-cursor-opacity))))]
+                         (not= old-cursor-opacity new-cursor-opacity)
+                         (assoc :cursor-opacity new-cursor-opacity))))]
     (set-properties! view-node nil props))
 
   ;; Repaint the view.
@@ -3893,8 +3893,8 @@
           gutter-shadow-color (color-lookup color-scheme "editor.gutter.shadow")
           gutter-breakpoint-color (color-lookup color-scheme "editor.gutter.breakpoint")
           gutter-cursor-line-background-color (color-lookup color-scheme (if (= :input-focused focus-state)
-                                                                            "editor.gutter.cursor.line.background"
-                                                                            "editor.gutter.cursor.line.background.inactive"))
+                                                                           "editor.gutter.cursor.line.background"
+                                                                           "editor.gutter.cursor.line.background.inactive"))
           gutter-execution-marker-current-color (color-lookup color-scheme "editor.gutter.execution-marker.current")
           gutter-execution-marker-frame-color (color-lookup color-scheme "editor.gutter.execution-marker.frame")]
 
@@ -4208,14 +4208,14 @@
                                     (g/node-value view-node :lines evaluation-context)
                                     (g/node-value view-node :regions evaluation-context)
                                     edited-breakpoint)
-                                  :edited-breakpoint edited-breakpoint))
+                             :edited-breakpoint edited-breakpoint))
 
                          :apply
                          (assoc (data/ensure-breakpoint-region
                                   (g/node-value view-node :lines evaluation-context)
                                   (g/node-value view-node :regions evaluation-context)
                                   edited-breakpoint)
-                                :edited-breakpoint nil)))
+                           :edited-breakpoint nil)))
                      (ui/user-data! (ui/main-scene) ::ui/refresh-requested? true))))}
         :middleware (comp
                       fxui/wrap-dedupe-desc
@@ -4514,6 +4514,27 @@
                                             cursor-range)))
   (done-fn))
 
+(def ^:private positive-integer-coercer
+  (coerce/wrap-with-pred coerce/integer pos? "is not positive"))
+
+(def ^:private cursor-coercer
+  (coerce/wrap-transform
+    (coerce/hash-map :req {:line positive-integer-coercer}
+                     :opt {:column positive-integer-coercer}
+                     :extra-keys false)
+    #(data/->Cursor (dec (long (:line %))) (dec (long (:column % 1))))))
+
+(def ^:private open-resource-args-coercer
+  (coerce/wrap-transform
+    (coerce/one-of
+      (coerce/wrap-transform cursor-coercer data/Cursor->CursorRange)
+      (coerce/wrap-transform
+        (coerce/hash-map :req {:from cursor-coercer
+                               :to cursor-coercer}
+                         :extra-keys false)
+        data/map->CursorRange))
+    #(hash-map :cursor-range %)))
+
 (defn register-view-types [workspace]
   (concat
     (workspace/register-view-type workspace
@@ -4521,12 +4542,14 @@
       :label (localization/message "resource.view.code")
       :make-view-fn make-view!
       :focus-fn focus-view!
+      :open-resource-args-coercer open-resource-args-coercer
       :text-selection-fn non-empty-single-selection-text)
     (workspace/register-view-type workspace
       :id :text
       :label (localization/message "resource.view.text")
       :make-view-fn make-view!
       :focus-fn focus-view!
+      :open-resource-args-coercer open-resource-args-coercer
       :text-selection-fn non-empty-single-selection-text)))
 
 (register-fundamental-read-only-handlers! *ns* :code-view :code-view-tools)

--- a/editor/src/clj/editor/collection_proxy.clj
+++ b/editor/src/clj/editor/collection_proxy.clj
@@ -119,8 +119,8 @@
                                                               :label (localization/message "outline.collection-proxy")
                                                               :icon collection-proxy-icon}
 
-                                                             (resource/resource? collection)
-                                                             (assoc :link collection :outline-reference? false))))
+                                                       (resource/resource? collection)
+                                                       (assoc :link collection :outline-reference? false))))
 
   (output save-value g/Any :cached produce-save-value)
   (output build-targets g/Any :cached produce-build-targets))
@@ -135,7 +135,7 @@
     :icon collection-proxy-icon
     :icon-class :property
     :category (localization/message "resource.category.components")
-    :view-types [:cljfx-form-view :text]
+    :view-types [:form :text]
     :view-opts {}
     :tags #{:component}
     :tag-opts {:component {:transform-properties #{}}}

--- a/editor/src/clj/editor/compute.clj
+++ b/editor/src/clj/editor/compute.clj
@@ -145,4 +145,4 @@
     :icon "icons/32/Icons_31-Material.png"
     :icon-class :property
     :category (localization/message "resource.category.shaders")
-    :view-types [:cljfx-form-view :text]))
+    :view-types [:form :text]))

--- a/editor/src/clj/editor/display_profiles.clj
+++ b/editor/src/clj/editor/display_profiles.clj
@@ -29,7 +29,7 @@
 
 (def pb-def {:ext "display_profiles"
              :label (localization/message "resource.type.display-profiles")
-             :view-types [:cljfx-form-view :text]
+             :view-types [:form :text]
              :icon "icons/32/Icons_50-Display-profiles.png"
              :icon-class :property
              :category (localization/message "resource.category.project_settings")
@@ -59,19 +59,19 @@
                                :qualifiers qualifiers}))
   (output pb-msg g/Any produce-profile-pb-msg)
   (output profile-data g/Any (g/fnk [_node-id pb-msg]
-                                    (assoc pb-msg :node-id _node-id))))
+                               (assoc pb-msg :node-id _node-id))))
 
 (defn- add-profile [node-id name qualifiers]
   (g/make-nodes (g/node-id->graph-id node-id)
-                [profile [ProfileNode
-                          :name name
-                          :qualifiers (mapv #(update % :device-models text-util/join-comma-separated-string)
-                                            qualifiers)]]
-                (for [[from to] [[:_node-id :nodes]
-                                 [:pb-msg :profile-msgs]
-                                 [:form-values :profile-form-values]
-                                 [:profile-data :profile-data]]]
-                  (g/connect profile from node-id to))))
+    [profile [ProfileNode
+              :name name
+              :qualifiers (mapv #(update % :device-models text-util/join-comma-separated-string)
+                                qualifiers)]]
+    (for [[from to] [[:_node-id :nodes]
+                     [:pb-msg :profile-msgs]
+                     [:form-values :profile-form-values]
+                     [:profile-data :profile-data]]]
+      (g/connect profile from node-id to))))
 
 (defn- add-profile! [node-id name qualifiers]
   (g/transact (add-profile node-id name qualifiers)))
@@ -143,8 +143,8 @@
                                        :auto-layout-selection (boolean auto-layout-selection))))
   (input profile-form-values g/Any :array)
   (output form-values g/Any (g/fnk [profile-form-values auto-layout-selection]
-                                   {[:profiles] profile-form-values
-                                    [:auto-layout-selection] (boolean auto-layout-selection)}))
+                              {[:profiles] profile-form-values
+                               [:auto-layout-selection] (boolean auto-layout-selection)}))
   (output form-data-desc g/Any :cached produce-form-data-desc)
   (output form-data g/Any :cached produce-form-data)
 

--- a/editor/src/clj/editor/editor_extensions.clj
+++ b/editor/src/clj/editor/editor_extensions.clj
@@ -235,7 +235,7 @@
                                                                   type-ext (string/lower-case (FilenameUtils/getExtension file-name))]
                                                               (workspace/replace-template-name (type-ext->template type-ext) base-name)))]
                                             (coll/pair file-path content))))
-                                  created-resource-infos)]
+                                      created-resource-infos)]
               (->> path+contents
                    (e/map key)
                    (frequencies)
@@ -290,10 +290,7 @@
                        (path/normalized))
           protected-paths (mapv #(.resolve root-path ^String %)
                                 [".git"
-                                 ".internal"])
-          protected-path? (fn protected-path? [^Path path]
-                            (some #(.startsWith path ^Path %)
-                                  protected-paths))]
+                                 ".internal"])]
       (cond
         (not (.startsWith dir-path root-path))
         (throw (LuaError. (str "Can't delete " dir-path ": outside of project directory")))
@@ -301,7 +298,7 @@
         (= (.getNameCount dir-path) (.getNameCount root-path))
         (throw (LuaError. "Can't delete the project directory itself"))
 
-        (protected-path? dir-path)
+        (coll/any? #(.startsWith dir-path ^Path %) protected-paths)
         (throw (LuaError. (str "Can't delete " dir-path ": protected by editor")))
 
         :else
@@ -355,7 +352,7 @@
 
 (defn- make-ext-execute-fn [^Path project-path reload-resources!]
   (rt/suspendable-lua-fn ext-execute [{:keys [rt]} & lua-args]
-    (when (empty? lua-args)
+    (when (coll/empty? lua-args)
       (throw (LuaError. "No arguments provided to editor.execute()")))
     (let [last-arg (rt/->clj rt execute-last-arg-coercer (last lua-args))
           butlast-args (mapv #(rt/->clj rt coerce/string %) (butlast lua-args))
@@ -380,23 +377,23 @@
                        (actions/input-stream->console (process/err p) (rt/stderr rt)))]
       (-> (.onExit p)
           (cond-> out-future (future/then (fn [_] out-future))
-                  err-future (future/then (fn [_] err-future)))
+            err-future (future/then (fn [_] err-future)))
           (future/then
             (fn [_]
               (let [exit-code (.exitValue p)]
                 (when-not (zero? exit-code)
                   (throw (LuaError. (format "Command \"%s\" exited with code %s"
-                                            (string/join " " cmd+args)
+                                            (coll/join-to-string " " cmd+args)
                                             exit-code)))))))
           (cond-> maybe-output-future
-                  (future/then (fn [_] maybe-output-future))
+            (future/then (fn [_] maybe-output-future))
 
-                  reload
-                  (future/then
-                    (fn [result]
-                      (future/then
-                        (reload-resources!)
-                        (fn [_] (rt/and-refresh-context result))))))))))
+            reload
+            (future/then
+              (fn [result]
+                (future/then
+                  (reload-resources!)
+                  (fn [_] (rt/and-refresh-context result))))))))))
 
 (def bob-options-coercer
   (let [scalar-coercer (coerce/one-of coerce/string coerce/boolean coerce/integer)]
@@ -409,7 +406,7 @@
 
 (defn- make-ext-bob-fn [invoke-bob!]
   (rt/suspendable-lua-fn bob [{:keys [rt evaluation-context]} & lua-args]
-    (let [[options commands] (if (empty? lua-args)
+    (let [[options commands] (if (coll/empty? lua-args)
                                [{} []]
                                (let [options-or-command (rt/->clj rt bob-options-or-command-coercer (first lua-args))
                                      first-arg-is-command (string? options-or-command)
@@ -487,13 +484,27 @@
               (when (coll/not-empty error-messages)
                 (LuaError. ^String (localization-state (localization/join "\n" error-messages)))))))))))
 
+(def ^:private open-resource-args-coercer
+  (coerce/regex :resource-path graph/resource-path-coercer
+                :rest :? [:view (coerce/enum :code :text :scene :html :form)
+                          :args :? coerce/untouched]))
+
 (defn- make-open-resource-fn [workspace open-resource!]
-  (rt/suspendable-lua-fn open-resource [{:keys [rt evaluation-context]} lua-resource-path]
-    (let [basis (:basis evaluation-context)
-          resource-path (rt/->clj rt graph/resource-path-coercer lua-resource-path)
-          resource (workspace/find-resource basis workspace resource-path)]
+  (rt/suspendable-varargs-lua-fn open-resource [{:keys [rt evaluation-context]} varargs]
+    (let [{:keys [resource-path]
+           {:keys [view args]} :rest} (rt/->clj rt open-resource-args-coercer varargs)
+          resource (workspace/find-resource (:basis evaluation-context) workspace resource-path)]
       (when (and resource (resource/exists? resource) (resource/openable? resource))
-        (open-resource! resource)))))
+        (if-not view
+          (open-resource! resource {})
+          (let [view-type (or (coll/first-where #(= view (:id %)) (workspace/resource-view-types resource))
+                              (throw (LuaError. (format "Resource '%s' does not support the '%s' view" resource-path (name view)))))
+                view-opts (if-not args
+                            {}
+                            (if-let [args-coercer (:open-resource-args-coercer view-type)]
+                              (rt/->clj rt args-coercer args)
+                              (throw (LuaError. (format "The '%s' view does not accept open-resource args" (name view))))))]
+            (open-resource! resource (assoc view-opts :selected-view-type view-type))))))))
 
 (def ext-browse-fn
   (rt/suspendable-lua-fn browse [{:keys [rt]} lua-string]
@@ -607,7 +618,7 @@
                                                   (pprint (.arg kv-varargs 2) indent seen)
                                                   ;; wrap `true` in boolean so that the loop compiles, otherwise it complains
                                                   ;; about java.lang.Boolean not matching primitive boolean ¯\_(ツ)_/¯
-                                                  (recur k (boolean true))))))))
+                                                  (recur k #_{:clj-kondo/ignore [:redundant-primitive-coercion]} (boolean true))))))))
                                       (.println out)
                                       (write-indent! out indent)
                                       (.print out "}"))))
@@ -657,7 +668,7 @@
                json
                (assoc response :body (with-open [reader (io/reader (:body response))]
                                        (json/read reader)))
-     
+
                path
                (with-open [^InputStream body (:body response)]
                  (if-not (<= 200 (:status response) 299)
@@ -676,7 +687,7 @@
                          @(reload-resources!)
                          (rt/and-refresh-context response))
                        response))))
-     
+
                :else
                response))
            (catch Throwable e
@@ -735,7 +746,6 @@
       (g/let-ec [sync-hash (script-annotations/sync-hash script-annotations evaluation-context)]
         (lsp/set-servers! lsp (conj ext-language-servers (built-in-lua-language-server sync-hash)))))))
 
-
 ;; endregion
 
 ;; region reload
@@ -768,7 +778,7 @@
 (defn- prefs-schema [state evaluation-context]
   (let [{:keys [rt]} state
         report-omitted-schema! (fn report-omitted-schema! [path reason]
-                                 (.println (rt/stderr rt) (str "Omitting prefs schema definition for path '" (string/join "." (map name path)) "': " reason)))
+                                 (.println (rt/stderr rt) (str "Omitting prefs schema definition for path '" (coll/join-to-string "." (e/map name path)) "': " reason)))
         omit-on-conflict (fn omit-on-conflict [a b path]
                            (if (= a b)
                              a
@@ -925,7 +935,7 @@
                    (-> acc
                        (update :all add-all-entry proto-path module)
                        (cond-> (= hooks-file-path proto-path)
-                               (assoc :hooks module)))
+                         (assoc :hooks module)))
                    acc))
 
                (nil? x)
@@ -995,9 +1005,9 @@
     :save!                0-arg function that asynchronously saves any unsaved
                           changes, returns CompletableFuture (that might
                           complete exceptionally if reload fails)
-    :open-resource!       1-arg function that asynchronously opens the supplied
-                          resource either in an editor tab or in another app that
-                          has OS-defined file association, returns
+    :open-resource!       2-arg function that asynchronously opens the supplied
+                          resource with an options map, either in an editor tab
+                          or in another app, returns
                           CompletableFuture (that might complete exceptionally
                           if resource could not be opened)
     :fetch-libraries!     0-arg function that asynchronously fetches libraries,
@@ -1121,9 +1131,9 @@
                :message (str (name hook-keyword) " in " hooks-file-path " failed: " message)
                :severity :fatal}
 
-              line
-              (assoc-in [:user-data :cursor-range]
-                        (data/line-number->CursorRange (Integer/parseInt line)))))))
+        line
+        (assoc-in [:user-data :cursor-range]
+                  (data/line-number->CursorRange (Integer/parseInt line)))))))
 
 (defn execute-hook!
   "Execute hook defined in this project

--- a/editor/src/clj/editor/editor_extensions.clj
+++ b/editor/src/clj/editor/editor_extensions.clj
@@ -494,7 +494,8 @@
     (let [{:keys [resource-path]
            {:keys [view args]} :rest} (rt/->clj rt open-resource-args-coercer varargs)
           resource (workspace/find-resource (:basis evaluation-context) workspace resource-path)]
-      (when (and resource (resource/exists? resource) (resource/openable? resource))
+      (if-not (and resource (resource/exists? resource) (resource/openable? resource))
+        (throw (LuaError. (format "Resource '%s' could not be opened" resource-path)))
         (if-not view
           (open-resource! resource {})
           (let [view-type (or (coll/first-where #(= view (:id %)) (workspace/resource-view-types resource))

--- a/editor/src/clj/editor/editor_extensions/coerce.clj
+++ b/editor/src/clj/editor/editor_extensions/coerce.clj
@@ -15,11 +15,12 @@
 (ns editor.editor-extensions.coerce
   "Define efficient Varargs (0 or more LuaValues, typically 1) to Clojure
   conversions."
-  (:refer-clojure :exclude [boolean integer hash-map vector-of])
+  (:refer-clojure :exclude [boolean hash-map vector-of])
   (:require [clojure.string :as string]
             [editor.editor-extensions.vm :as vm]
             [editor.util :as util]
             [util.coll :as coll]
+            [util.defonce :as defonce]
             [util.eduction :as e]
             [util.fn :as fn])
   (:import [org.luaj.vm2 LuaDouble LuaError LuaInteger LuaString LuaValue Varargs]))
@@ -27,7 +28,7 @@
 (set! *warn-on-reflection* true)
 (set! *unchecked-math* :warn-on-boxed)
 
-(deftype Failure [lua-varargs explain-fn])
+(defonce/type Failure [lua-varargs explain-fn])
 
 (defmacro failure [lua-varargs-expr explain-expr]
   `(->Failure ~lua-varargs-expr (fn ~'explain-failure [] ~explain-expr)))
@@ -42,8 +43,8 @@
     (if (zero? n)
       ((.-explain-fn failure))
       (str (->> (range (.narg varargs))
-                (map #(vm/lua-value->string vm (.arg varargs (inc (int %)))))
-                (string/join ", "))
+                (e/map #(vm/lua-value->string vm (.arg varargs (inc (int %)))))
+                (coll/join-to-string ", "))
            " "
            ((.-explain-fn failure))))))
 
@@ -167,7 +168,7 @@
 
   Does not enforce the absence of other keys in the table"
   [& coercers]
-  {:pre [(not (empty? coercers))]}
+  {:pre [(not (coll/empty? coercers))]}
   (let [coercers (vec coercers)]
     ^{:schema {:type :tuple
                :items (mapv schema coercers)}}
@@ -271,32 +272,33 @@
     :min-count    minimum number of items in the collection
     :distinct     if true, ensures that the result does not have repeated items"
   [item-coercer & {:keys [min-count distinct]}]
-  (let [f ^{:schema {:type :array :item (schema item-coercer)}}
-          (fn coerce-coll-of [vm ^Varargs x]
-            (let [x (.arg1 x)]
-              (if (.istable x)
-                (let [acc (vm/with-lock vm
-                            (let [len (.rawlen x)]
-                              (transduce
-                                (comp
-                                  (map (fn [i]
-                                         (item-coercer vm (.rawget x (unchecked-inc-int i)))))
-                                  (halt-when failure?))
-                                conj!
-                                (range len))))]
-                  (if (failure? acc)
-                    acc
-                    (persistent! acc)))
-                (failure x "is not an array"))))]
+  (let [f
+        ^{:schema {:type :array :item (schema item-coercer)}}
+        (fn coerce-coll-of [vm ^Varargs x]
+          (let [x (.arg1 x)]
+            (if (.istable x)
+              (let [acc (vm/with-lock vm
+                          (let [len (.rawlen x)]
+                            (transduce
+                              (comp
+                                (map (fn [i]
+                                       (item-coercer vm (.rawget x (unchecked-inc-int i)))))
+                                (halt-when failure?))
+                              conj!
+                              (range len))))]
+                (if (failure? acc)
+                  acc
+                  (persistent! acc)))
+              (failure x "is not an array"))))]
     (cond-> f
 
-            min-count
-            (wrap-with-pred
-              #(<= ^long min-count (count %))
-              (str "needs at least " min-count " element" (when (< 1 ^long min-count) "s")))
+      min-count
+      (wrap-with-pred
+        #(<= ^long min-count (count %))
+        (str "needs at least " min-count " element" (when (< 1 ^long min-count) "s")))
 
-            distinct
-            (wrap-with-pred #(apply distinct? %) "should not have repeated elements"))))
+      distinct
+      (wrap-with-pred #(apply distinct? %) "should not have repeated elements"))))
 
 (defn hash-map
   "Coerces 1st Varargs arg to a Clojure map with required and optional keys
@@ -367,7 +369,7 @@
 (defn one-of
   "Tries several coercers in the provided order, returns first success result"
   [& coercers]
-  {:pre [(not (empty? coercers))]}
+  {:pre [(not (coll/empty? coercers))]}
   (let [v (vec coercers)
         schemas (into []
                       (comp
@@ -388,14 +390,16 @@
         (if (failure? ret)
           (failure x (str "does not satisfy any of its requirements:\n"
                           (->> coercers
-                               (map (fn [coercer]
-                                      (let [failure (coercer vm x)]
-                                        (assert (failure? failure))
-                                        (string/join "\n"
-                                                     (map str
-                                                          (cons "- " (repeat "  "))
-                                                          (string/split-lines (failure-message vm failure)))))))
-                               (string/join "\n"))))
+                               (e/map (fn [coercer]
+                                        (let [failure (coercer vm x)]
+                                          (assert (failure? failure))
+                                          (coll/join-to-string
+                                            "\n"
+                                            (e/map-indexed
+                                              (fn [^long i line]
+                                                (str (if (zero? i) "- " "  ") line))
+                                              (string/split-lines (failure-message vm failure)))))))
+                               (coll/join-to-string "\n"))))
           ret)))))
 
 (defn by-key
@@ -449,13 +453,124 @@
       LuaValue/NONE
       (str "Invalid argument:\n"
            (->> (conj failures final-failure)
-                (map (fn [failure]
-                       (string/join
-                         "\n"
-                         (map str
-                              (cons "- " (repeat "  "))
-                              (string/split-lines (failure-message vm failure))))))
-                (string/join "\n"))))))
+                (e/map (fn [failure]
+                         (coll/join-to-string
+                           "\n"
+                           (e/map-indexed
+                             (fn [^long i line]
+                               (str (if (zero? i) "- " "  ") line))
+                             (string/split-lines (failure-message vm failure))))))
+                (coll/join-to-string "\n"))))))
+
+(defonce/record RegexOp [key quantifier coerce group])
+(defonce/type RegexMatch [value ^long input-index failures])
+(defonce/type RegexFailure [failures final-failure])
+
+(defn- parse-regex-ops [source]
+  (let [ops (reduce
+              (fn [ops el]
+                (let [last-op (peek ops)
+                      last-op-complete (or (:coerce last-op) (:group last-op))]
+                  (cond
+                    (not (:key last-op))
+                    (do
+                      (when-not (keyword? el)
+                        (throw (IllegalArgumentException. "op key must be a keyword")))
+                      (conj ops (->RegexOp el nil nil nil)))
+
+                    (and (not (:quantifier last-op)) (#{:? :1} el))
+                    (assoc ops (dec (count ops)) (assoc last-op :quantifier el))
+
+                    (and (not last-op-complete) (fn? el))
+                    (assoc ops (dec (count ops)) (-> last-op
+                                                     (update :quantifier #(or % :1))
+                                                     (assoc :coerce el)))
+
+                    (and (not last-op-complete) (vector? el))
+                    (let [group (parse-regex-ops el)]
+                      (when (coll/empty? group)
+                        (throw (IllegalArgumentException. "regex group must include at least one op")))
+                      (assoc ops (dec (count ops)) (-> last-op
+                                                       (update :quantifier #(or % :1))
+                                                       (assoc :group group))))
+
+                    (and (keyword? el) last-op-complete)
+                    (conj ops (->RegexOp el nil nil nil))
+
+                    :else
+                    (throw (IllegalArgumentException. (str "unexpected input: " el))))))
+              []
+              source)]
+    (when-let [last-op (peek ops)]
+      (when-not (or (:coerce last-op) (:group last-op))
+        (throw (IllegalArgumentException. "regex op must include a pattern"))))
+    ops))
+
+(defn- finish-regex-failure [vm root failures final-failure]
+  (if-not root
+    (RegexFailure. failures final-failure)
+    (regex-failure vm failures final-failure)))
+
+(defn- match-regex-ops [vm ^Varargs inputs inputs-len ops input-index root]
+  (let [ops-len (count ops)]
+    (loop [result {}
+           input-index (long input-index)
+           op-index 0
+           failures []]
+      (cond
+        (= op-index ops-len)
+        (if (and root (not= input-index inputs-len))
+          (let [extra (.subargs inputs (inc input-index))]
+            (regex-failure vm failures (failure extra (if (= 1 (.narg extra)) "is unexpected" "are unexpected"))))
+          (if root
+            result
+            (RegexMatch. result input-index failures)))
+
+        :else
+        (let [^RegexOp op (ops op-index)
+              key (.-key op)
+              quantifier (.-quantifier op)
+              coerce (.-coerce op)
+              group (.-group op)]
+          (cond
+            group
+            (let [match (match-regex-ops vm inputs inputs-len group input-index false)]
+              (if (instance? RegexFailure match)
+                (let [^RegexFailure match match
+                      group-failures (.-failures match)
+                      group-final-failure (.-final-failure match)]
+                  (case quantifier
+                    :1 (finish-regex-failure vm root (into failures group-failures) group-final-failure)
+                    :? (recur result
+                              input-index
+                              (inc op-index)
+                              (into failures (conj group-failures group-final-failure)))))
+                (let [^RegexMatch match match
+                      match-input-index (.-input-index match)]
+                  (recur (if (and (= :? quantifier)
+                                  (= input-index match-input-index))
+                           result
+                           (assoc result key (.-value match)))
+                         match-input-index
+                         (inc op-index)
+                         (if (= input-index match-input-index)
+                           (into failures (.-failures match))
+                           (.-failures match))))))
+
+            (= input-index inputs-len)
+            (case quantifier
+              :1 (finish-regex-failure vm root failures (failure LuaValue/NONE "more arguments expected"))
+              :? (recur result input-index (inc op-index) failures))
+
+            :else
+            (let [value (coerce vm (.arg inputs (inc input-index)))]
+              (case quantifier
+                :1 (if (failure? value)
+                     (finish-regex-failure vm root failures value)
+                     (recur (assoc result key value) (inc input-index) (inc op-index) []))
+                :? (if (failure? value)
+                     (recur result input-index (inc op-index) (conj failures value))
+                     (recur (assoc result key value) (inc input-index) (inc op-index) []))))))))))
 
 (defn regex
   "Create a regex-like coercer that coerces Varargs to a clojure map
@@ -463,10 +578,13 @@
   Returns a coerced map of identifiers to coerced values
 
   Args:
-    ops    regex ops specification, a flat sequence of following values:
+    ops    regex ops specification, a sequence of following values:
              keyword       required, subsequence identifier
              quantifier    optional, currently only :? and :1 are supported
-             coercer       required, subsequence LuaValue coercer
+             pattern       required, either a LuaValue coercer or a vector
+                           containing a nested regex ops specification; a
+                           group must contain at least one op; an optional group
+                           that consumes no arguments is omitted from the result
 
   Examples:
     ;; Coerce Varargs with 0-3 LuaValues into an HTTP response map
@@ -475,59 +593,17 @@
                   :body :? coerce/string)
     ;; Coerce 2-element Varargs into person map (:1 can be omitted)
     (coerce/regex :first-name :1 coerce/string
-                  :last-name :1 coerce/string)"
+                  :last-name :1 coerce/string)
+    ;; Coerce 3 elements, nesting grouped captures under :range
+    (coerce/regex :path coerce/string
+                  :range [:from coerce/integer
+                          :to coerce/integer])
+    ;; Coerce either 1 or 3 elements; optional groups match atomically
+    (coerce/regex :path coerce/string
+                  :range :? [:from coerce/integer
+                             :to coerce/integer])"
   [& ops]
-  (let [ops (reduce
-              (fn [acc el]
-                (let [last-op (peek acc)]
-                  (cond
-                    (not (:key last-op))
-                    (do
-                      (when-not (keyword? el)
-                        (throw (IllegalArgumentException. "op key must be a keyword")))
-                      (conj acc (assoc last-op :key el)))
-
-                    (and (not (:quantifier last-op)) (#{:? :1} el))
-                    (assoc acc (dec (count acc)) (assoc last-op :quantifier el))
-
-                    (and (not (:coerce last-op)) (fn? el))
-                    (assoc acc (dec (count acc)) (-> last-op (update :quantifier #(or % :1)) (assoc :coerce el)))
-
-                    (and (keyword? el) (:coerce last-op))
-                    (conj acc {:key el})
-
-                    :else
-                    (throw (IllegalArgumentException. (str "unexpected input: " el))))))
-              []
-              ops)
-        ops-len (count ops)]
+  (let [ops (parse-regex-ops ops)]
     ^{:schema {:type :any}}
     (fn coerce-regex [vm ^Varargs inputs]
-      (let [inputs-len (.narg inputs)]
-        (loop [acc {}
-               input-index 0
-               op-index 0
-               failures []]
-          (cond
-            (= input-index inputs-len) ; finished input
-            (if (= op-index ops-len) ; also finished ops
-              acc
-              (case (:quantifier (ops op-index)) ; check if remaining ops are all optional
-                :1 (regex-failure vm failures (failure LuaValue/NONE "more arguments expected"))
-                :? (recur acc input-index (inc op-index) failures)))
-
-            (= op-index ops-len) ; finished ops, but there is more input
-            (let [extra (.subargs inputs (inc input-index))]
-              (regex-failure vm failures (failure extra (if (= 1 (.narg extra)) "is unexpected" "are unexpected"))))
-
-            :else
-            (let [{:keys [key quantifier coerce]} (ops op-index)
-                  lua-value (.arg inputs (inc input-index))
-                  v (coerce vm lua-value)]
-              (case quantifier
-                :1 (if (failure? v)
-                     (regex-failure vm failures v)
-                     (recur (assoc acc key v) (inc input-index) (inc op-index) []))
-                :? (if (failure? v)
-                     (recur acc input-index (inc op-index) (conj failures v))
-                     (recur (assoc acc key v) (inc input-index) (inc op-index) []))))))))))
+      (match-regex-ops vm inputs (.narg inputs) ops 0 true))))

--- a/editor/src/clj/editor/editor_extensions/docs.clj
+++ b/editor/src/clj/editor/editor_extensions/docs.clj
@@ -376,8 +376,14 @@ editor.create_resources({
           :description "Module with functions for creating UI elements in the editor"}
          {:name "editor.ui.open_resource"
           :type :function
-          :description "Open a resource, either in the editor or in a third-party app"
-          :parameters [resource-path-param]}]
+          :description "Open a resource using its primary or selected view, either in the editor or in a third-party app. Code and Text views accept a one-based cursor or range in <code>args</code>: <code>{line = 42}</code>, <code>{line = 42, column = 12}</code>, or <code>{from = {line = 42, column = 12}, to = {line = 43, column = 4}}</code>"
+          :parameters [resource-path-param
+                       {:name "[view]"
+                        :types ["string"]
+                        :doc "View to open: <code>\"code\"</code>, <code>\"text\"</code>, <code>\"scene\"</code>, <code>\"html\"</code>, or <code>\"form\"</code>"}
+                       {:name "[args]"
+                        :types ["any"]
+                        :doc "View-specific open arguments; requires <code>view</code>. Currently supported by Code and Text views."}]}]
         (e/mapcat
           (fn [[enum-id enum-values]]
             (let [id (ui-docs/->screaming-snake-case enum-id)]

--- a/editor/src/clj/editor/factory.clj
+++ b/editor/src/clj/editor/factory.clj
@@ -121,8 +121,8 @@
                    (project/resource-setter evaluation-context self old-value new-value
                                             [:resource :prototype-resource])))
             (dynamic error (g/fnk [_node-id prototype-resource]
-                                  (or (validation/prop-error :info _node-id :prototype validation/prop-nil? prototype-resource prototype-message)
-                                      (validation/prop-error :fatal _node-id :prototype validation/prop-resource-not-exists? prototype-resource prototype-message))))
+                             (or (validation/prop-error :info _node-id :prototype validation/prop-nil? prototype-resource prototype-message)
+                                 (validation/prop-error :fatal _node-id :prototype validation/prop-resource-not-exists? prototype-resource prototype-message))))
             (dynamic edit-type (g/fnk [factory-type]
                                  {:type resource/Resource :ext (get-in factory-types [factory-type :ext])}))
             (dynamic label (properties/label-dynamic :factory :prototype))
@@ -142,12 +142,11 @@
                                                               :label (get-in factory-types [factory-type :message])
                                                               :icon (get-in factory-types [factory-type :icon])}
 
-                                                             (resource/resource? prototype)
-                                                             (assoc :link prototype :outline-reference? false))))
+                                                       (resource/resource? prototype)
+                                                       (assoc :link prototype :outline-reference? false))))
 
   (output save-value g/Any :cached produce-save-value)
   (output build-targets g/Any :cached produce-build-targets))
-
 
 (defn register-resource-types
   [workspace]
@@ -161,7 +160,7 @@
       :icon (get-in factory-types [:game-object :icon])
       :icon-class :property
       :category (localization/message "resource.category.components")
-      :view-types [:cljfx-form-view :text]
+      :view-types [:form :text]
       :view-opts {}
       :tags #{:component}
       :tag-opts {:component {:transform-properties #{}}}
@@ -175,7 +174,7 @@
       :icon (get-in factory-types [:collection :icon])
       :icon-class :property
       :category (localization/message "resource.category.components")
-      :view-types [:cljfx-form-view :text]
+      :view-types [:form :text]
       :view-opts {}
       :tags #{:component}
       :tag-opts {:component {:transform-properties #{}}}

--- a/editor/src/clj/editor/game_project.clj
+++ b/editor/src/clj/editor/game_project.clj
@@ -224,7 +224,7 @@
         (conj (bt/with-content-hash
                 {:node-id _node-id
                  :resource (workspace/make-build-resource
-                              (->DependencyMetadataResource (resource/workspace resource)))
+                             (->DependencyMetadataResource (resource/workspace resource)))
                  :build-fn build-dependency-metadata
                  :user-data {:digest-ignored/dependencies dependencies
                              :dependency-content-hash-data (dependency-content-hash-data dependencies)}}))))))
@@ -300,7 +300,7 @@
 
                   directory-resources
                   (cond-> custom-resources-directory-resources
-                          ssl-certificates-directory-resource (conj ssl-certificates-directory-resource))
+                    ssl-certificates-directory-resource (conj ssl-certificates-directory-resource))
 
                   custom-resources
                   (coll/into-> directory-resources []
@@ -381,6 +381,6 @@
     :meta-settings (:settings gpcore/basic-meta-info)
     :icon game-project-icon
     :icon-class :property
-    :view-types [:cljfx-form-view :text]
+    :view-types [:form :text]
     :language "ini"
     :view-opts {:text {:grammar ini/grammar}}))

--- a/editor/src/clj/editor/gamepads.clj
+++ b/editor/src/clj/editor/gamepads.clj
@@ -39,7 +39,7 @@
    :icon-class :property
    :category (localization/message "resource.category.project_settings")
    :pb-class Input$GamepadMaps
-   :view-types [:cljfx-form-view :text]})
+   :view-types [:form :text]})
 
 (defonce/record GamepadDatabaseBuildResource [resource]
   resource/Resource

--- a/editor/src/clj/editor/live_update_settings.clj
+++ b/editor/src/clj/editor/live_update_settings.clj
@@ -64,32 +64,32 @@
 
   (output amazon-creds g/Any :cached
           (g/fnk [settings-map]
-                 (let [profile (get settings-map ["liveupdate" "amazon-credential-profile"])]
-                   (when (and profile (pos? (count profile)))
-                     {:profile profile}))))
+            (let [profile (get settings-map ["liveupdate" "amazon-credential-profile"])]
+              (when (and profile (pos? (count profile)))
+                {:profile profile}))))
 
   (output amazon-buckets g/Any :cached (g/fnk [amazon-creds] (if amazon-creds (get-bucket-names amazon-creds) [])))
 
   (input form-data g/Any)
   (output form-data g/Any :cached
           (g/fnk [form-data amazon-buckets]
-                 (-> form-data
-                     (assoc :navigation false)
-                     (form/update-form-setting ["liveupdate" "amazon-credential-profile"]
-                                               #(assoc %
-                                                       :type :choicebox
-                                                       :from-string str :to-string str
-                                                       :options (mapv (fn [profile]
-                                                                        [profile profile])
-                                                                      (sort (get-config-file-profiles)))))
-                     (form/update-form-setting ["liveupdate" "amazon-bucket"]
-                                               #(assoc %
-                                                       :type :choicebox
-                                                       :from-string str
-                                                       :to-string str
-                                                       :options (mapv (fn [bucket]
-                                                                        [bucket bucket])
-                                                                      (sort amazon-buckets)))))))
+            (-> form-data
+                (assoc :navigation false)
+                (form/update-form-setting ["liveupdate" "amazon-credential-profile"]
+                                          #(assoc %
+                                             :type :choicebox
+                                             :from-string str :to-string str
+                                             :options (mapv (fn [profile]
+                                                              [profile profile])
+                                                            (sort (get-config-file-profiles)))))
+                (form/update-form-setting ["liveupdate" "amazon-bucket"]
+                                          #(assoc %
+                                             :type :choicebox
+                                             :from-string str
+                                             :to-string str
+                                             :options (mapv (fn [bucket]
+                                                              [bucket bucket])
+                                                            (sort amazon-buckets)))))))
 
   (input save-value g/Any)
   (output save-value g/Any (gu/passthrough save-value))
@@ -103,11 +103,11 @@
   (let [graph-id (g/node-id->graph-id self)]
     (concat
       (g/make-nodes graph-id [settings-node settings/SettingsNode]
-                    (g/connect settings-node :_node-id self :nodes)
-                    (g/connect settings-node :settings-map self :settings-map)
-                    (g/connect settings-node :save-value self :save-value)
-                    (g/connect settings-node :form-data self :form-data)
-                    (settings/load-settings-node project self settings-node resource source-value basic-meta-info nil)))))
+        (g/connect settings-node :_node-id self :nodes)
+        (g/connect settings-node :settings-map self :settings-map)
+        (g/connect settings-node :save-value self :save-value)
+        (g/connect settings-node :form-data self :form-data)
+        (settings/load-settings-node project self settings-node resource source-value basic-meta-info nil)))))
 
 (defn register-resource-types [workspace]
   (resource-node/register-settings-resource-type workspace
@@ -117,7 +117,7 @@
     :load-fn load-live-update-settings
     :meta-settings (:settings basic-meta-info)
     :icon live-update-icon
-    :view-types [:cljfx-form-view :text]))
+    :view-types [:form :text]))
 
 (defn get-live-update-settings-path [project]
   (resource/resource->proj-path (get (project/settings project) ["liveupdate" "settings"])))

--- a/editor/src/clj/editor/material.clj
+++ b/editor/src/clj/editor/material.clj
@@ -73,9 +73,9 @@
       (-> editable-attribute
           (dissoc :values)
           (protobuf/assign attribute-value-keyword
-                           (when (and (not (graphics/engine-provided-attribute? editable-attribute))
-                                      (coll/not-empty stored-values))
-                             {:v stored-values}))))))
+            (when (and (not (graphics/engine-provided-attribute? editable-attribute))
+                       (coll/not-empty stored-values))
+              {:v stored-values}))))))
 
 (defn- save-value-attributes [editable-attributes]
   (mapv editable-attribute->attribute editable-attributes))
@@ -200,7 +200,7 @@
                                      shader-resource)
                   error-cursor-range (some-> ex-data :error-line-number code.data/line-number->CursorRange)
                   user-data (cond-> {:resource error-resource}
-                                    error-cursor-range (assoc :cursor-range error-cursor-range))]
+                              error-cursor-range (assoc :cursor-range error-cursor-range))]
               (g/->error shader-resource-node-id :lines :fatal nil message user-data))))))))
 
 (g/defnk produce-combined-shader-info [_node-id vertex-program vertex-shader-source-info fragment-program fragment-shader-source-info max-page-count glsl-es-default-precision-float glsl-es-default-precision-int]
@@ -505,9 +505,9 @@
                       :bytes bytes
                       :name-key name-key)
 
-                    (some? error-message)
-                    (assoc
-                      :error (g/->error _node-id :attributes :fatal nil error-message)))))
+              (some? error-message)
+              (assoc
+                :error (g/->error _node-id :attributes :fatal nil error-message)))))
         attributes))
 
 (defmulti handle-sampler-names-changed
@@ -539,20 +539,20 @@
             (dynamic visible (g/constantly false)))
 
   (property vertex-program resource/Resource ; Required protobuf field.
-    (dynamic visible (g/constantly false))
-    (value (gu/passthrough vertex-resource))
-    (set (fn [evaluation-context self old-value new-value]
-           (project/resource-setter evaluation-context self old-value new-value
-                                    [:resource :vertex-resource]
-                                    [:shader-source-info :vertex-shader-source-info]))))
+            (dynamic visible (g/constantly false))
+            (value (gu/passthrough vertex-resource))
+            (set (fn [evaluation-context self old-value new-value]
+                   (project/resource-setter evaluation-context self old-value new-value
+                                            [:resource :vertex-resource]
+                                            [:shader-source-info :vertex-shader-source-info]))))
 
   (property fragment-program resource/Resource ; Required protobuf field.
-    (dynamic visible (g/constantly false))
-    (value (gu/passthrough fragment-resource))
-    (set (fn [evaluation-context self old-value new-value]
-           (project/resource-setter evaluation-context self old-value new-value
-                                    [:resource :fragment-resource]
-                                    [:shader-source-info :fragment-shader-source-info]))))
+            (dynamic visible (g/constantly false))
+            (value (gu/passthrough fragment-resource))
+            (set (fn [evaluation-context self old-value new-value]
+                   (project/resource-setter evaluation-context self old-value new-value
+                                            [:resource :fragment-resource]
+                                            [:shader-source-info :fragment-shader-source-info]))))
 
   (property max-page-count g/Int (default (protobuf/default Material$MaterialDesc :max-page-count))
             (dynamic visible (g/constantly false)))
@@ -648,4 +648,4 @@
     :icon "icons/32/Icons_31-Material.png"
     :icon-class :property
     :category (localization/message "resource.category.shaders")
-    :view-types [:cljfx-form-view :text]))
+    :view-types [:form :text]))

--- a/editor/src/clj/editor/protobuf_types.clj
+++ b/editor/src/clj/editor/protobuf_types.clj
@@ -30,29 +30,29 @@
 (defn- migrate-texture-profile-format [compression-type compression-level]
   (let [compression-level-pb (when compression-level
                                (protobuf/val->pb-enum Graphics$TextureFormatAlternative$CompressionLevel compression-level))]
-   (case compression-type
-    :compression-type-webp
-    {:compressor TextureCompressorUncompressed/TextureCompressorName
-     :compressor-preset (TextureCompressorUncompressed/GetMigratedCompressionPreset)}
+    (case compression-type
+      :compression-type-webp
+      {:compressor TextureCompressorUncompressed/TextureCompressorName
+       :compressor-preset (TextureCompressorUncompressed/GetMigratedCompressionPreset)}
 
-    :compression-type-webp-lossy
-    {:compressor TextureCompressorBasisU/TextureCompressorName
-     :compressor-preset (TextureCompressorBasisU/GetMigratedCompressionPreset compression-level-pb)}
+      :compression-type-webp-lossy
+      {:compressor TextureCompressorBasisU/TextureCompressorName
+       :compressor-preset (TextureCompressorBasisU/GetMigratedCompressionPreset compression-level-pb)}
 
-    :compression-type-basis-uastc
-    {:compressor TextureCompressorBasisU/TextureCompressorName
-     :compressor-preset (TextureCompressorBasisU/GetMigratedCompressionPreset compression-level-pb)}
+      :compression-type-basis-uastc
+      {:compressor TextureCompressorBasisU/TextureCompressorName
+       :compressor-preset (TextureCompressorBasisU/GetMigratedCompressionPreset compression-level-pb)}
 
-    :compression-type-basis-etc1s
-    {:compressor TextureCompressorBasisU/TextureCompressorName
-     :compressor-preset (TextureCompressorBasisU/GetMigratedCompressionPreset compression-level-pb)}
+      :compression-type-basis-etc1s
+      {:compressor TextureCompressorBasisU/TextureCompressorName
+       :compressor-preset (TextureCompressorBasisU/GetMigratedCompressionPreset compression-level-pb)}
 
-    :compression-type-astc
-    {:compressor TextureCompressorASTC/TextureCompressorName
-     :compressor-preset (TextureCompressorASTC/GetMigratedCompressionPreset compression-level-pb)}
+      :compression-type-astc
+      {:compressor TextureCompressorASTC/TextureCompressorName
+       :compressor-preset (TextureCompressorASTC/GetMigratedCompressionPreset compression-level-pb)}
 
-    {:compressor TextureCompressorUncompressed/TextureCompressorName
-     :compressor-preset (TextureCompressorUncompressed/GetMigratedCompressionPreset)})))
+      {:compressor TextureCompressorUncompressed/TextureCompressorName
+       :compressor-preset (TextureCompressorUncompressed/GetMigratedCompressionPreset)})))
 
 (defn- sanitize-texture-profile-format [texture-format]
   (let [migrated-format (if (and (:compressor texture-format) (:compressor-preset texture-format))
@@ -100,7 +100,7 @@
                :category (localization/message "resource.category.project_settings")
                :pb-class Input$InputBinding
                :label (localization/message "resource.type.input-binding")
-               :view-types [:cljfx-form-view :text]}
+               :view-types [:form :text]}
               {:ext "convexshape"
                :label (localization/message "resource.type.convexshape")
                ; TODO - missing icon
@@ -108,7 +108,7 @@
                :pb-class Physics$ConvexShape}
               {:ext "texture_profiles"
                :label (localization/message "resource.type.texture-profiles")
-               :view-types [:cljfx-form-view :text]
+               :view-types [:form :text]
                :icon "icons/32/Icons_37-Texture-profile.png"
                :icon-class :property
                :category (localization/message "resource.category.project_settings")

--- a/editor/src/clj/editor/recent_files.clj
+++ b/editor/src/clj/editor/recent_files.clj
@@ -32,6 +32,15 @@
 
 (def ^:private history-size 32)
 
+(defn- canonical-prefs-data [[project-path view-type-id]]
+  [project-path (case view-type-id :cljfx-form-view :form view-type-id)])
+
+(defn- get-recent-files [prefs]
+  (mapv canonical-prefs-data (prefs/get prefs [:workflow :recent-files])))
+
+(defn get-open-tabs [prefs]
+  (mapv #(mapv canonical-prefs-data %) (prefs/get prefs [:workflow :open-tabs])))
+
 (defn- conj-history-item [items x]
   (let [new-items (into [] (remove #(= x %)) items)
         drop-count (- (count new-items)
@@ -45,7 +54,7 @@
          (some? (:id view-type))]}
   (let [item [(resource/proj-path resource) (:id view-type)]
         k [:workflow :recent-files]]
-    (prefs/set! prefs k (conj-history-item (prefs/get prefs k) item))))
+    (prefs/set! prefs k (conj-history-item (get-recent-files prefs) item))))
 
 (defn- project-path+view-type-id->resource+view-type [workspace evaluation-context [project-path view-type-id]]
   (when-let [res (workspace/find-resource (:basis evaluation-context) workspace project-path)]
@@ -54,7 +63,7 @@
         [res view-type]))))
 
 (defn- ordered-resource+view-types [prefs workspace evaluation-context]
-  (-> (prefs/get prefs [:workflow :recent-files])
+  (-> (get-recent-files prefs)
       rseq
       (->> (keep #(project-path+view-type-id->resource+view-type workspace evaluation-context %)))))
 
@@ -124,8 +133,8 @@
           tab-panes (.getItems editor-tabs-split)]
       {:selected-pane (.indexOf tab-panes active-tab-pane)
        :tab-selection-by-pane (mapv (fn [^TabPane pane]
-                                  (-> pane .getSelectionModel .getSelectedIndex))
-                                tab-panes)})))
+                                      (-> pane .getSelectionModel .getSelectedIndex))
+                                    tab-panes)})))
 
 (defn save-open-tabs! [prefs app-view]
   (prefs/set! prefs [:workflow :open-tabs] (collect-open-tabs app-view)))
@@ -137,11 +146,10 @@
   (defn save-open-tabs! [prefs app-view] nil)
   (defn save-tab-selections! [prefs app-view] nil)
   (prefs/set! (dev/prefs) [:workflow :open-tabs] [[["/main/main.collection" :collection] ["/scripts/knight.script" :code]]
-                                                  [["/scripts/utils_blah.lua" :code]["/scripts/utils.lua" :code]]])
-  (prefs/set! (dev/prefs) [:workflow :open-tabs] [[["/scripts/utils.lua" :code]["/scripts/knight.script" :code]]])
+                                                  [["/scripts/utils_blah.lua" :code] ["/scripts/utils.lua" :code]]])
+  (prefs/set! (dev/prefs) [:workflow :open-tabs] [[["/scripts/utils.lua" :code] ["/scripts/knight.script" :code]]])
   (prefs/set! (dev/prefs) [:workflow :last-selected-tabs] {:selected-pane 1, :tab-selection-by-pane [0 0]})
   (prefs/get (dev/prefs) [:workflow :open-tabs])
   (prefs/get (dev/prefs) [:workflow :last-selected-tabs])
   (prefs/get (dev/prefs) [:window])
-  (prefs/set! (dev/prefs) [:workflow :open-tabs] (collect-open-tabs (dev/app-view)))
-  ,)
+  (prefs/set! (dev/prefs) [:workflow :open-tabs] (collect-open-tabs (dev/app-view))))

--- a/editor/src/clj/editor/recent_files.clj
+++ b/editor/src/clj/editor/recent_files.clj
@@ -33,7 +33,7 @@
 (def ^:private history-size 32)
 
 (defn- canonical-prefs-data [[project-path view-type-id]]
-  [project-path (case view-type-id :cljfx-form-view :form view-type-id)])
+  [project-path (workspace/canonical-view-type-id view-type-id)])
 
 (defn- get-recent-files [prefs]
   (mapv canonical-prefs-data (prefs/get prefs [:workflow :recent-files])))

--- a/editor/src/clj/editor/render_pb.clj
+++ b/editor/src/clj/editor/render_pb.clj
@@ -61,7 +61,6 @@
     (g/connect named-render-resource :named-render-resource render-node :named-render-resources)
     (g/connect named-render-resource :dep-build-targets render-node :dep-build-targets)))
 
-
 (def ^:private form-sections
   {:navigation false
    :sections [{:localization-key "render"
@@ -198,5 +197,5 @@
     :icon "icons/32/Icons_30-Render.png"
     :icon-class :property
     :category (localization/message "resource.category.project_settings")
-    :view-types [:cljfx-form-view :text]
+    :view-types [:form :text]
     :label (localization/message "resource.type.render")))

--- a/editor/src/clj/editor/render_target.clj
+++ b/editor/src/clj/editor/render_target.clj
@@ -190,6 +190,6 @@
     :icon texture-icon
     :icon-class :design
     :category (localization/message "resource.category.resources")
-    :view-types [:cljfx-form-view :text]
+    :view-types [:form :text]
     :view-opts {}
     :label (localization/message "resource.type.render-target")))

--- a/editor/src/clj/editor/settings.clj
+++ b/editor/src/clj/editor/settings.clj
@@ -42,7 +42,7 @@
                        (let [[target-node connections] resource-connections]
                          ;; connect extra resource node outputs directly to target-node (GameProjectNode for instance)
                          (apply project/resource-setter evaluation-context target-node old-value new-value
-                           connections)))))))
+                                connections)))))))
   (input resource resource/Resource)
   ;; resource-setting-reference only consumed by SettingsNode and already cached there.
   (output resource-setting-reference g/Any (g/fnk [_node-id path value] {:path path :node-id _node-id :value value})))
@@ -260,20 +260,20 @@
 
   (output merged-raw-settings g/Any :cached
           (g/fnk [raw-settings meta-info resource-settings]
-                 (let [meta-settings-map (settings-core/make-meta-settings-map (:settings meta-info))
-                       raw-resource-settings (mapv (fn [setting]
-                                                    (update setting :value
-                                                            #(when %
-                                                               (settings-core/render-raw-setting-value
-                                                                 (meta-settings-map (:path setting))
-                                                                 (resource/resource->proj-path %)))))
-                                                  resource-settings)]
-                   (reduce (fn [raw {:keys [path value]}]
-                             (if (settings-core/get-setting raw path)
-                               (settings-core/set-setting raw path value)
-                               raw))
-                           raw-settings
-                           raw-resource-settings))))
+            (let [meta-settings-map (settings-core/make-meta-settings-map (:settings meta-info))
+                  raw-resource-settings (mapv (fn [setting]
+                                                (update setting :value
+                                                        #(when %
+                                                           (settings-core/render-raw-setting-value
+                                                             (meta-settings-map (:path setting))
+                                                             (resource/resource->proj-path %)))))
+                                              resource-settings)]
+              (reduce (fn [raw {:keys [path value]}]
+                        (if (settings-core/get-setting raw path)
+                          (settings-core/set-setting raw path value)
+                          raw))
+                      raw-settings
+                      raw-resource-settings))))
 
   (output settings-map g/Any :cached produce-settings-map)
   (output form-data g/Any :cached produce-form-data)
@@ -287,8 +287,8 @@
             (let [{:keys [ext-meta-info game-project-proj-path->additional-meta-info]} meta-infos
                   project-meta-info (game-project-proj-path->additional-meta-info (resource/proj-path owner-resource))]
               (cond-> raw-meta-info
-                      project-meta-info (settings-core/merge-meta-infos project-meta-info)
-                      (and ext-meta-info (= "project" (resource/type-ext owner-resource))) (settings-core/merge-meta-infos ext-meta-info))))))
+                project-meta-info (settings-core/merge-meta-infos project-meta-info)
+                (and ext-meta-info (= "project" (resource/type-ext owner-resource))) (settings-core/merge-meta-infos ext-meta-info))))))
 
 (defn load-settings-node [project owner-resource-node self resource raw-settings initial-meta-info resource-setting-connections]
   (let [basis (g/now)
@@ -346,4 +346,4 @@
     :node-type SimpleSettingsResourceNode
     :load-fn (partial load-simple-settings-resource-node meta-info)
     :meta-settings (:settings meta-info)
-    :view-types [:cljfx-form-view :text]))
+    :view-types [:form :text]))

--- a/editor/src/clj/editor/sound.clj
+++ b/editor/src/clj/editor/sound.clj
@@ -194,7 +194,7 @@
             (dynamic error (g/fnk [_node-id loopcount]
                              (validation/prop-error :fatal _node-id :loopcount (partial validation/prop-outside-range? [0 127]) loopcount loopcount-message)))
             (dynamic read-only? (g/fnk [looping]
-                                   (not looping)))
+                                  (not looping)))
             (dynamic label (properties/label-dynamic :sound :loopcount))
             (dynamic tooltip (properties/tooltip-dynamic :sound :loopcount)))
   (property group g/Str (default (protobuf/default Sound$SoundDesc :group))
@@ -231,7 +231,7 @@
       :icon sound-icon
       :icon-class :property
       :category (localization/message "resource.category.components")
-      :view-types [:cljfx-form-view :text]
+      :view-types [:form :text]
       :view-opts {}
       :tags #{:component}
       :tag-opts {:component {:transform-properties #{}}}

--- a/editor/src/clj/editor/workspace.clj
+++ b/editor/src/clj/editor/workspace.clj
@@ -39,7 +39,8 @@ ordinary paths."
             [util.coll :as coll :refer [pair]]
             [util.digest :as digest]
             [util.fn :as fn]
-            [util.path :as path])
+            [util.path :as path]
+            [util.text-util :as text-util])
   (:import [clojure.lang DynamicClassLoader]
            [com.dynamo.bob Platform]
            [com.dynamo.bob.util Library$Problem$DefoldMinVersion Library$Problem$FailedHTTPRequest Library$Problem$FetchFailed Library$Problem$HttpConnectTimeout Library$Problem$InstallFailed Library$Problem$InvalidArchive Library$Problem$Missing Library$Result]
@@ -202,6 +203,13 @@ ordinary paths."
   ([workspace id evaluation-context]
    (get (g/node-value workspace :view-types evaluation-context) id)))
 
+(defn resource-view-types
+  "Returns the effective registered view types advertised by the resource."
+  [resource]
+  (cond->> (:view-types (resource/resource-type resource))
+    (text-util/binary? resource)
+    (filterv #(not= :code (:id %)))))
+
 (defn- editor-openable-view-type? [view-type]
   (case view-type
     (:default :text) false
@@ -285,7 +293,7 @@ ordinary paths."
                         either a string or a MessagePattern instance
     :view-types         vector of alternative views that can be used for
                         resources of the resource type, e.g. :code, :scene,
-                        :cljfx-form-view, :text, :html or :default.
+                        :form, :text, :html or :default.
     :view-opts          a map from a view-type keyword to options map that will
                         be merged with other opts used when opening a view
     :tags               a set of keywords that can be used for customizing the
@@ -565,10 +573,10 @@ ordinary paths."
                                   (localization/join "\n"))})
            :actions
            (cond-> []
-                   show-fetch (conj {:message (localization/message "notification.fetch-libraries.action.fetch")
-                                     :on-action #(ui/execute-command (ui/contexts (ui/main-scene) true) :project.fetch-libraries nil)})
-                   show-open-project (conj {:message (localization/message "notification.fetch-libraries.action.open-game-project")
-                                            :on-action #(ui/execute-command (ui/contexts (ui/main-scene) true) :file.open "/game.project")}))})))))
+             show-fetch (conj {:message (localization/message "notification.fetch-libraries.action.fetch")
+                               :on-action #(ui/execute-command (ui/contexts (ui/main-scene) true) :project.fetch-libraries nil)})
+             show-open-project (conj {:message (localization/message "notification.fetch-libraries.action.open-game-project")
+                                      :on-action #(ui/execute-command (ui/contexts (ui/main-scene) true) :file.open "/game.project")}))})))))
 
 (defn set-project-dependencies! [workspace lib-results]
   (g/transact
@@ -688,10 +696,10 @@ ordinary paths."
   (.addURL ^DynamicClassLoader java/class-loader (io/as-url jar-file)))
 
 (defn- native-library-parent-dir-allowed? [parent-dir-name]
-    (->> (Platform/getHostPlatform)
-         .getExtenderPaths
-         (some #(= parent-dir-name %))
-         boolean))
+  (->> (Platform/getHostPlatform)
+       .getExtenderPaths
+       (some #(= parent-dir-name %))
+       boolean))
 
 (defn- register-shared-library-file! [^File shared-library-file]
   (let [parent-dir-file (.getParentFile shared-library-file)]
@@ -1172,11 +1180,15 @@ ordinary paths."
                            will be called on resource open request, opts will
                            only contain data passed from the code (e.g.
                            :cursor-range)
+    :open-resource-args-coercer
+                           editor-script coercer for view-specific
+                           editor.ui.open_resource args; should return a map of
+                           opts to pass to the view
     :text-selection-fn     fn of node id returned by :make-view-fn, should
                            return selected text as a string or nil; will be used
                            to pre-populate Open Assets and Search in Files
                            dialogs"
-  [workspace & {:keys [id label make-view-fn make-preview-fn dispose-preview-fn focus-fn text-selection-fn]}]
+  [workspace & {:keys [id label make-view-fn make-preview-fn dispose-preview-fn focus-fn open-resource-args-coercer text-selection-fn]}]
   (let [view-type (merge {:id    id
                           :label label}
                          (when make-view-fn
@@ -1187,6 +1199,8 @@ ordinary paths."
                            {:dispose-preview-fn dispose-preview-fn})
                          (when focus-fn
                            {:focus-fn focus-fn})
+                         (when open-resource-args-coercer
+                           {:open-resource-args-coercer open-resource-args-coercer})
                          (when text-selection-fn
                            {:text-selection-fn text-selection-fn}))]
     (g/non-undoable

--- a/editor/src/clj/editor/workspace.clj
+++ b/editor/src/clj/editor/workspace.clj
@@ -196,6 +196,11 @@ ordinary paths."
                              vec)]
     (assoc tree :children sorted-children)))
 
+(defn canonical-view-type-id [view-type-id]
+  (case view-type-id
+    :cljfx-form-view :form
+    view-type-id))
+
 (defn get-view-type
   ([workspace id]
    (g/with-auto-evaluation-context evaluation-context
@@ -330,12 +335,13 @@ ordinary paths."
                                 when there is a :write-fn, default true"
   [workspace & {:keys [textual? language editable ext build-ext node-type load-fn dependencies-fn search-fn search-value-fn source-value-fn read-fn write-fn icon icon-class category view-types view-opts tags tag-opts template test-info label stateless? lazy-loaded allow-unloaded-use auto-connect-save-data?]}]
   {:pre [(or (nil? icon-class) (resource/icon-class->style-class icon-class))]}
-  (let [editable (if (nil? editable) true (boolean editable))
+  (let [view-types (mapv canonical-view-type-id view-types)
+        editable (if (nil? editable) true (boolean editable))
         textual (true? textual?)
         resource-type {:textual? textual
                        :language (when textual (or language "plaintext"))
                        :editable editable
-                       :editor-openable (some? (some editor-openable-view-type? view-types))
+                       :editor-openable (some? (coll/some editor-openable-view-type? view-types))
                        :node-type node-type
                        :load-fn load-fn
                        :dependencies-fn dependencies-fn

--- a/editor/test/editor/editor_extensions/coerce_test.clj
+++ b/editor/test/editor/editor_extensions/coerce_test.clj
@@ -1,0 +1,355 @@
+;; Copyright 2020-2026 The Defold Foundation
+;; Copyright 2014-2020 King
+;; Copyright 2009-2014 Ragnar Svensson, Christian Murray
+;; Licensed under the Defold License version 1.0 (the "License"); you may not use
+;; this file except in compliance with the License.
+;;
+;; You may obtain a copy of the License, together with FAQs at
+;; https://www.defold.com/license
+;;
+;; Unless required by applicable law or agreed to in writing, software distributed
+;; under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+;; CONDITIONS OF ANY KIND, either express or implied. See the License for the
+;; specific language governing permissions and limitations under the License.
+
+(ns editor.editor-extensions.coerce-test
+  (:require [clojure.test :refer :all]
+            [clojure.test.check.clojure-test :refer [defspec]]
+            [clojure.test.check.generators :as gen]
+            [clojure.test.check.properties :as prop]
+            [editor.editor-extensions.coerce :as coerce]
+            [editor.editor-extensions.runtime :as rt]
+            [editor.editor-extensions.vm :as vm])
+  (:import [org.luaj.vm2 LuaError LuaValue Varargs]))
+
+(set! *warn-on-reflection* true)
+
+(def ^:private mismatch ::mismatch)
+
+(defn- token-set-coercer [accepted]
+  (fn coerce-token-set [_ ^Varargs args]
+    (let [lua-value (.arg1 args)]
+      (if (and (.isinttype lua-value)
+               (contains? accepted (.tolong lua-value)))
+        (.tolong lua-value)
+        (coerce/failure lua-value "does not match token set")))))
+
+(defn- syntax [ops]
+  (reduce
+    (fn [result {:keys [key quantifier pattern]}]
+      (cond-> (conj result key)
+        quantifier (conj quantifier)
+        true (conj (if-not (vector? pattern)
+                     (token-set-coercer pattern)
+                     (syntax pattern)))))
+    []
+    ops))
+
+(defn- compile-regex [ops]
+  (apply coerce/regex (syntax ops)))
+
+(defn- valid-group-bodies? [ops]
+  (reduce (fn [valid {:keys [pattern]}]
+            (if-not (and valid (vector? pattern))
+              valid
+              (and (pos? (count pattern))
+                   (valid-group-bodies? pattern))))
+          true
+          ops))
+
+(declare reference-match-prefix)
+
+(defn- attempt-pattern [pattern inputs input-index]
+  (if (vector? pattern)
+    (reference-match-prefix pattern inputs input-index)
+    (if-not (< input-index (count inputs))
+      mismatch
+      (let [input (inputs input-index)]
+        (if (contains? pattern input)
+          {:value input :next-input-index (inc input-index)}
+          mismatch)))))
+
+(defn- reference-match-prefix [ops inputs start-input-index]
+  (loop [result {}
+         input-index start-input-index
+         op-index 0]
+    (if (= op-index (count ops))
+      {:value result :next-input-index input-index}
+      (let [{:keys [key quantifier pattern]} (ops op-index)
+            match (attempt-pattern pattern inputs input-index)]
+        (if (identical? mismatch match)
+          (if (= :? quantifier)
+            (recur result input-index (inc op-index))
+            mismatch)
+          (let [next-input-index (:next-input-index match)]
+            (recur (if (and (= :? quantifier)
+                            (vector? pattern)
+                            (= input-index next-input-index))
+                     result
+                     (assoc result key (:value match)))
+                   next-input-index
+                   (inc op-index))))))))
+
+(defn- reference-match [ops inputs]
+  (let [match (reference-match-prefix ops inputs 0)]
+    (if (or (identical? mismatch match)
+            (not= (count inputs) (:next-input-index match)))
+      mismatch
+      (:value match))))
+
+(defn- actual-match [coercer inputs]
+  (coercer nil (apply rt/->varargs inputs)))
+
+(deftest nullable-group-test
+  (let [value (token-set-coercer #{0})
+        tail (token-set-coercer #{1})]
+    (doseq [ops [[:group []]
+                 [:group :? []]
+                 [:outer [:inner []]]]]
+      (is (thrown-with-msg? IllegalArgumentException
+                            #"regex group must include at least one op"
+                            (apply coerce/regex ops))))
+    (is (= {:group {}}
+           (actual-match (coerce/regex :group [:value :? value]) [])))
+    (is (= {}
+           (actual-match (coerce/regex :group :? [:value :? value]) [])))
+    (is (= {:group {} :tail 1}
+           (actual-match (coerce/regex :group [:value :? value]
+                                       :tail tail)
+                         [1])))
+    (is (= {:tail 1}
+           (actual-match (coerce/regex :group :? [:value :? value]
+                                       :tail tail)
+                         [1])))
+    (is (= {:group {:value 0}}
+           (actual-match (coerce/regex :group :? [:value :? value]) [0])))
+    (is (= {:outer {:inner {}}}
+           (actual-match (coerce/regex :outer [:inner [:value :? value]]) [])))
+    (is (= {:outer {}}
+           (actual-match (coerce/regex :outer [:inner :? [:value :? value]]) [])))
+    (is (= {:outer {:inner {:value 0}}}
+           (actual-match (coerce/regex :outer [:inner [:value value]]) [0])))))
+
+(deftest malformed-regex-specification-test
+  (let [value (token-set-coercer #{0})]
+    (doseq [ops [[:value]
+                 [:value :?]
+                 [:value :1]
+                 [:value nil]
+                 [0 value]
+                 [:value :? :1 value]
+                 [:group [:value]]
+                 [:group [:value :?]]]]
+      (is (thrown? IllegalArgumentException
+                   (apply coerce/regex ops))))))
+
+(def ^:private regex-ops-gen
+  (let [key-gen (gen/elements [:a :b :? :1 :*])
+        quantifier-gen (gen/elements [nil :1 :?])
+        token-set-gen (gen/elements [#{0} #{1} #{2}
+                                     #{0 1} #{0 2} #{1 2}
+                                     #{0 1 2}])
+        op-gen (fn [pattern-gen]
+                 (gen/let [key key-gen
+                           quantifier quantifier-gen
+                           pattern pattern-gen]
+                   {:key key
+                    :quantifier quantifier
+                    :pattern pattern}))
+        pattern-gen (gen/recursive-gen
+                      (fn [inner-pattern-gen]
+                        (gen/vector (op-gen inner-pattern-gen) 0 3))
+                      token-set-gen)]
+    (gen/vector (op-gen pattern-gen) 0 3)))
+
+(defspec generated-regex-matches-reference 500
+  (prop/for-all [ops (gen/resize 8 regex-ops-gen)
+                 inputs (gen/vector (gen/choose -1 2) 0 8)]
+    (if (valid-group-bodies? ops)
+      (let [expected (reference-match ops inputs)
+            actual (actual-match (compile-regex ops) inputs)]
+        (if (identical? mismatch expected)
+          (coerce/failure? actual)
+          (= expected actual)))
+      (try
+        (compile-regex ops)
+        false
+        (catch IllegalArgumentException _
+          true)))))
+
+(defn- exact-token-op [key token]
+  {:key key
+   :quantifier nil
+   :pattern #{token}})
+
+(defn- ensure-non-empty-groups [ops]
+  (mapv (fn [op]
+          (let [pattern (:pattern op)]
+            (if-not (vector? pattern)
+              op
+              (let [pattern (ensure-non-empty-groups pattern)
+                    pattern (if (zero? (count pattern))
+                              [(exact-token-op :group-value 0)]
+                              pattern)]
+                (assoc op :pattern pattern)))))
+        ops))
+
+(defn- assign-unique-tokens [ops next-token]
+  (reduce (fn [[result next-token] op]
+            (let [pattern (:pattern op)]
+              (if-not (vector? pattern)
+                [(conj result (assoc op :pattern #{next-token})) (inc next-token)]
+                (let [[pattern next-token] (assign-unique-tokens pattern next-token)]
+                  [(conj result (assoc op :pattern pattern)) next-token]))))
+          [[] next-token]
+          ops))
+
+(defn- witness-case [ops presence-bits start-bit-index]
+  (reduce (fn [[inputs expected bit-index] {:keys [key quantifier pattern]}]
+            (let [optional (= :? quantifier)
+                  next-bit-index (if optional (inc bit-index) bit-index)]
+              (if-not (or (not optional)
+                          (presence-bits (mod bit-index (count presence-bits))))
+                [inputs expected next-bit-index]
+                (if-not (vector? pattern)
+                  [(conj inputs (first pattern))
+                   (assoc expected key (first pattern))
+                   next-bit-index]
+                  (let [[nested-inputs nested-expected next-bit-index]
+                        (witness-case pattern presence-bits next-bit-index)]
+                    [(into inputs nested-inputs)
+                     (if (and optional (zero? (count nested-inputs)))
+                       expected
+                       (assoc expected key nested-expected))
+                     next-bit-index])))))
+          [[] {} start-bit-index]
+          ops))
+
+(defspec generated-regex-accepts-witness 250
+  (prop/for-all [ops (gen/resize 8 regex-ops-gen)
+                 presence-bits (gen/vector gen/boolean 1 16)]
+    (let [[ops] (assign-unique-tokens (ensure-non-empty-groups ops) 0)
+          [inputs expected] (witness-case ops presence-bits 0)]
+      (= expected (actual-match (compile-regex ops) inputs)))))
+
+(defspec generated-regex-rejects-invalid-token 150
+  (prop/for-all [ops (gen/resize 8 regex-ops-gen)
+                 presence-bits (gen/vector gen/boolean 1 16)
+                 insertion-index gen/nat]
+    (let [[ops] (assign-unique-tokens (ensure-non-empty-groups ops) 0)
+          [inputs] (witness-case ops presence-bits 0)
+          insertion-index (mod insertion-index (inc (count inputs)))]
+      (coerce/failure?
+        (actual-match (compile-regex ops)
+                      (into (conj (subvec inputs 0 insertion-index) -1)
+                            (subvec inputs insertion-index)))))))
+
+(defn- nested-prefix [tokens depth]
+  (if-not (zero? depth)
+    [{:key (keyword (str "nested" depth))
+      :quantifier nil
+      :pattern (nested-prefix tokens (dec depth))}]
+    (reduce-kv (fn [ops index token]
+                 (conj ops (exact-token-op (keyword (str "p" index)) token)))
+               []
+               tokens)))
+
+(defn- fallback-ops [tokens]
+  (reduce-kv (fn [ops index token]
+               (conj ops (exact-token-op (keyword (str "f" index)) token)))
+             []
+             tokens))
+
+(defspec generated-optional-group-rolls-back-atomically 100
+  (prop/for-all [prefix-length (gen/choose 1 5)
+                 depth (gen/choose 0 4)]
+    (let [inputs (vec (range prefix-length))
+          attempt (conj (nested-prefix inputs depth)
+                        (exact-token-op :missing prefix-length))
+          fallback (fallback-ops inputs)
+          ops (into [{:key :attempt :quantifier :? :pattern attempt}]
+                    fallback)
+          expected (into {} (map (juxt :key #(first (:pattern %)))) fallback)]
+      (= expected (actual-match (compile-regex ops) inputs)))))
+
+(defspec generated-optional-group-success-commits-greedily 100
+  (prop/for-all [prefix-length (gen/choose 1 5)
+                 depth (gen/choose 0 4)]
+    (let [inputs (vec (range prefix-length))
+          ops (into [{:key :attempt
+                      :quantifier :?
+                      :pattern (nested-prefix inputs depth)}]
+                    (fallback-ops inputs))]
+      (coerce/failure? (actual-match (compile-regex ops) inputs)))))
+
+(deftest capture-semantics-test
+  (testing "duplicate keys"
+    (is (= {:value 1}
+           (actual-match (coerce/regex :value (token-set-coercer #{0})
+                                       :value (token-set-coercer #{1}))
+                         [0 1])))
+    (is (= {:value 0}
+           (actual-match (coerce/regex :value (token-set-coercer #{0})
+                                       :value :? (token-set-coercer #{1}))
+                         [0]))))
+  (testing "position-sensitive keyword keys"
+    (is (= {:? 0 :1 1 :* 2}
+           (actual-match (coerce/regex :? (token-set-coercer #{0})
+                                       :1 (token-set-coercer #{1})
+                                       :* (token-set-coercer #{2}))
+                         [0 1 2]))))
+  (testing "nil and false values"
+    (let [coercer (coerce/regex :nil (coerce/enum nil)
+                                :false (coerce/enum false))]
+      (is (coerce/failure? (actual-match coercer [])))
+      (is (= {:nil nil :false false}
+             (actual-match coercer [nil false])))))
+  (testing "untouched identity"
+    (let [lua-value (LuaValue/valueOf "value")
+          coercer (coerce/regex :group [:value coerce/untouched])]
+      (is (identical? lua-value
+                      (get-in (coercer nil lua-value) [:group :value]))))))
+
+(deftest regex-reuse-and-attempt-count-test
+  (let [calls (atom [])
+        counting-coercer (fn [id accepted]
+                           (let [coercer (token-set-coercer accepted)]
+                             (fn [vm args]
+                               (swap! calls conj id)
+                               (coercer vm args))))
+        a (counting-coercer :a #{0})
+        b (counting-coercer :b #{1})
+        tail (counting-coercer :tail #{0})
+        coercer (coerce/regex :group :? [:a a :b b]
+                              :tail tail)]
+    (is (= {:tail 0} (actual-match coercer [0])))
+    (is (= [:a :tail] @calls))
+    (reset! calls [])
+    (is (= {:group {:a 0 :b 1} :tail 0}
+           (actual-match coercer [0 1 0])))
+    (is (= [:a :b :tail] @calls))
+    (reset! calls [])
+    (is (coerce/failure? (actual-match coercer [0 2])))
+    (is (= [:a :b :tail] @calls))
+    (reset! calls [])
+    (is (= {:group {:head 0}}
+           (actual-match (coerce/regex :group [:head (token-set-coercer #{0})
+                                               :value :? a])
+                         [0])))
+    (is (= [] @calls))))
+
+(deftest grouped-failure-message-test
+  (let [coercer (coerce/regex :group :? [:a :? (token-set-coercer #{0})
+                                         :b (token-set-coercer #{1})]
+                              :tail (token-set-coercer #{2}))]
+    (is (thrown-with-msg? LuaError
+                          #"(?s)^Invalid argument:\n(?!.*Invalid argument:)"
+                          (coerce/coerce (vm/make) coercer (rt/->varargs 3))))))
+
+(deftest zero-width-group-preserves-outer-failure-message-test
+  (let [coercer (coerce/regex :outer :? coerce/string
+                              :group :? [:inside :? coerce/boolean]
+                              :tail (coerce/enum nil))]
+    (is (thrown-with-msg? LuaError
+                          #"(?s)^Invalid argument:\n- 3 is not a string\n- 3 is not a boolean\n- 3 is not nil$"
+                          (coerce/coerce (vm/make) coercer (rt/->varargs 3))))))

--- a/editor/test/editor/recent_files_test.clj
+++ b/editor/test/editor/recent_files_test.clj
@@ -1,0 +1,62 @@
+;; Copyright 2020-2026 The Defold Foundation
+;; Copyright 2014-2020 King
+;; Copyright 2009-2014 Ragnar Svensson, Christian Murray
+;; Licensed under the Defold License version 1.0 (the "License"); you may not use
+;; this file except in compliance with the License.
+;;
+;; You may obtain a copy of the License, together with FAQs at
+;; https://www.defold.com/license
+;;
+;; Unless required by applicable law or agreed to in writing, software distributed
+;; under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+;; CONDITIONS OF ANY KIND, either express or implied. See the License for the
+;; specific language governing permissions and limitations under the License.
+
+(ns editor.recent-files-test
+  (:require [clojure.test :refer :all]
+            [editor.fs :as fs]
+            [editor.prefs :as prefs]
+            [editor.recent-files :as recent-files]
+            [editor.resource :as resource]
+            [editor.workspace :as workspace]))
+
+(defn- make-test-prefs []
+  (prefs/make :scopes {:project (fs/create-temp-file! "recent-files-test-project" ".editor_settings")}
+              :schemas [:default]))
+
+(deftest legacy-form-view-recent-files-test
+  (let [prefs (make-test-prefs)
+        legacy-prefs-data [["/game.project" :cljfx-form-view]]]
+    (prefs/set! prefs [:workflow :recent-files] legacy-prefs-data)
+
+    (with-redefs [resource/openable? (constantly true)
+                  workspace/find-resource (fn [_basis _workspace _project-path] ::resource)
+                  workspace/get-view-type (fn [_workspace view-type-id _evaluation-context]
+                                            {:id view-type-id})]
+      (is (= [[::resource {:id :form}]]
+             (vec (recent-files/some-recent prefs ::workspace {:basis ::basis})))))
+
+    (is (= legacy-prefs-data
+           (prefs/get prefs [:workflow :recent-files])))
+
+    (with-redefs [resource/openable? (constantly true)
+                  resource/proj-path (constantly "/game.project")]
+      (recent-files/add! prefs ::resource {:id :form}))
+
+    (is (= [["/game.project" :form]]
+           (prefs/get prefs [:workflow :recent-files])))))
+
+(deftest legacy-form-view-open-tabs-test
+  (let [prefs (make-test-prefs)
+        legacy-prefs-data [[["/game.project" :cljfx-form-view]
+                            ["/main/main.collection" :scene]]
+                           [["/input/gamepads.gamepads" :cljfx-form-view]]]]
+    (prefs/set! prefs [:workflow :open-tabs] legacy-prefs-data)
+
+    (is (= [[["/game.project" :form]
+             ["/main/main.collection" :scene]]
+            [["/input/gamepads.gamepads" :form]]]
+           (recent-files/get-open-tabs prefs)))
+
+    (is (= legacy-prefs-data
+           (prefs/get prefs [:workflow :open-tabs])))))

--- a/editor/test/integration/editor_extensions_test.clj
+++ b/editor/test/integration/editor_extensions_test.clj
@@ -18,6 +18,7 @@
             [clojure.test :refer :all]
             [dynamo.graph :as g]
             [editor.cljfx-form-view :as cljfx-form-view]
+            [editor.code.data :as data]
             [editor.code.view :as code-view]
             [editor.defold-project :as project]
             [editor.editor-extensions :as extensions]
@@ -40,6 +41,7 @@
             [editor.progress :as progress]
             [editor.properties :as properties]
             [editor.resource :as resource]
+            [editor.resource-types :as resource-types]
             [editor.scene :as scene]
             [editor.ui :as ui]
             [editor.view :as view]
@@ -245,34 +247,33 @@
           default-err (StringWriter.)
           override-out (StringWriter.)
           override-err (StringWriter.)
-            rt (rt/make
-                 :out default-out
-                 :err default-err
-                 :env {"suspend" (rt/suspendable-lua-fn [_]
-                                    (future/io (Thread/sleep 10)))
-                       "with_output_override" (rt/suspendable-lua-fn [{:keys [rt]} f]
-                                                (rt/invoke-suspending-1 rt {:override-out override-out
-                                                                            :override-err override-err}
-                                                                        f))})]
-        (->> (rt/read "print('default before')
-	                     io.stderr:write('default err before\\n')
-	                     with_output_override(function()
-	                       print('override')
-	                       io.stderr:write('override err\\n')
-	                       suspend()
-	                       print('override after')
-	                       io.stderr:write('override err after\\n')
-	                     end)
-	                     print('default after')
-	                     io.stderr:write('default err after\\n')")
-             (rt/bind rt)
-             (rt/invoke-suspending-1 rt)
-             (deref))
-        (is (= "default before\ndefault after\n" (.toString default-out)))
-        (is (= "default err before\ndefault err after\n" (.toString default-err)))
-        (is (= "override\noverride after\n" (.toString override-out)))
-        (is (= "override err\noverride err after\n" (.toString override-err))))))
-
+          rt (rt/make
+               :out default-out
+               :err default-err
+               :env {"suspend" (rt/suspendable-lua-fn [_]
+                                 (future/io (Thread/sleep 10)))
+                     "with_output_override" (rt/suspendable-lua-fn [{:keys [rt]} f]
+                                              (rt/invoke-suspending-1 rt {:override-out override-out
+                                                                          :override-err override-err}
+                                                                      f))})]
+      (->> (rt/read "print('default before')
+	                   io.stderr:write('default err before\\n')
+	                   with_output_override(function()
+	                     print('override')
+	                     io.stderr:write('override err\\n')
+	                     suspend()
+	                     print('override after')
+	                     io.stderr:write('override err after\\n')
+	                   end)
+	                   print('default after')
+	                   io.stderr:write('default err after\\n')")
+           (rt/bind rt)
+           (rt/invoke-suspending-1 rt)
+           (deref))
+      (is (= "default before\ndefault after\n" (.toString default-out)))
+      (is (= "default err before\ndefault err after\n" (.toString default-err)))
+      (is (= "override\noverride after\n" (.toString override-out)))
+      (is (= "override err\noverride err after\n" (.toString override-err))))))
 
 (deftest suspending-lua-failure-test
   (test-support/with-clean-system
@@ -324,7 +325,7 @@
       (save-project! project)
       (future/completed nil))))
 
-(defn- open-resource-noop! [_]
+(defn- open-resource-noop! [_resource _opts]
   (future/completed nil))
 
 (defn- fetch-libraries-noop! []
@@ -361,8 +362,8 @@
   (test-util/with-loaded-project "test/resources/editor_extensions/commands_project"
     (let [script-node (test-util/resource-node project "/test.editor_script")
           reload-needed? (fn []
-                            (g/with-auto-evaluation-context evaluation-context
-                              (extensions/reload-needed? project evaluation-context)))]
+                           (g/with-auto-evaluation-context evaluation-context
+                             (extensions/reload-needed? project evaluation-context)))]
       (reload-editor-scripts! project)
       (is (not (reload-needed?)))
 
@@ -416,7 +417,7 @@
                 (catch Throwable e e))))
         (is (= [1.5 1.5 1.5] (test-util/prop sprite-node-id :position)))
         (is (= 2.5 (test-util/prop sprite-node-id :playback-rate))))
-      
+
       ;; Reuse the same outline command from the Edit menu to verify that an
       ;; outline selection query still works outside the Outline view:
       (let [handler+context (handler/active
@@ -432,7 +433,7 @@
                 (catch Throwable e e))))
         (is (= [3 3 3] (test-util/prop sprite-node-id :position)))
         (is (= 4 (test-util/prop sprite-node-id :playback-rate))))
-      
+
       ;; Run the separate scene command from the Scene context menu.
       (let [handler+context (handler/active
                               (:command (first (handler/realize-menu :editor.scene-selection/context-menu-end)))
@@ -511,7 +512,7 @@
                           [:out (re-find #"\w+" line)]))
                    (string/split-lines
                      (process/exec! "git" "log" "--oneline" "--max-count=10")))
-            @output)))))
+             @output)))))
 
 (deftest transact-test
   (test-util/with-loaded-project "test/resources/editor_extensions/transact_test"
@@ -583,17 +584,31 @@
 
 (deftest open-resource-test
   (test-util/with-loaded-project "test/resources/editor_extensions/open_resource_project"
+    (g/transact
+      (concat
+        (cljfx-form-view/register-view-types workspace)
+        (code-view/register-view-types workspace)))
+    (resource-types/register-resource-types! workspace)
     (let [output (atom [])]
       (reload-editor-scripts! project
                               :display-output! #(swap! output conj [%1 %2])
-                              :open-resource! #(swap! output conj [:open-resource (resource/proj-path %)]))
+                              :open-resource! (fn [resource opts]
+                                                (swap! output conj [:open-resource
+                                                                    (resource/proj-path resource)
+                                                                    (some-> opts :selected-view-type :id)
+                                                                    (:cursor-range opts)])))
       (run-edit-menu-test-command!)
       ;; see test.editor script: it uses editor.open_resource with different resource
       ;; paths and prints results
-      (is (= [[:open-resource "/game.project"]
+      (is (= [[:open-resource "/game.project" nil nil]
               [:out "Open '/game.project': ok"]
               [:out "Open '/does_not_exist.txt': ok"]
-              [:out "Open 'not_a_resource_path.go': error"]]
+              [:out "Open 'not_a_resource_path.go': error"]
+              [:open-resource "/game.project" :form nil]
+              [:out "Open form view: ok"]
+              [:open-resource "/test.editor_script" :code (data/->CursorRange (data/->Cursor 2 1) (data/->Cursor 2 1))]
+              [:out "Open code position: ok"]
+              [:out "Open args without view: error"]]
              @output)))))
 
 (deftest coercer-test

--- a/editor/test/integration/editor_extensions_test.clj
+++ b/editor/test/integration/editor_extensions_test.clj
@@ -602,7 +602,7 @@
       ;; paths and prints results
       (is (= [[:open-resource "/game.project" nil nil]
               [:out "Open '/game.project': ok"]
-              [:out "Open '/does_not_exist.txt': ok"]
+              [:out "Open '/does_not_exist.txt': error"]
               [:out "Open 'not_a_resource_path.go': error"]
               [:open-resource "/game.project" :form nil]
               [:out "Open form view: ok"]

--- a/editor/test/integration/sparse_protobuf_test.clj
+++ b/editor/test/integration/sparse_protobuf_test.clj
@@ -740,7 +740,7 @@
                       openable-in-view-type? (into #{} (map :id) view-types)]
                   (testing proj-path
                     (is (not (g/error? (g/node-value resource-node :_properties))))
-                    (when (openable-in-view-type? :cljfx-form-view)
+                    (when (openable-in-view-type? :form)
                       (is (not (g/error? (g/node-value resource-node :form-data)))))
                     (when (openable-in-view-type? :scene)
                       (is (not (g/error? (g/node-value resource-node :scene)))))

--- a/editor/test/resources/editor_extensions/open_resource_project/test.editor_script
+++ b/editor/test/resources/editor_extensions/open_resource_project/test.editor_script
@@ -1,8 +1,8 @@
 local M = {}
 
-local function test_open_resource(resource_path) 
-    local success = pcall(editor.ui.open_resource, resource_path)
-    print("Open '" .. resource_path .. "': " .. (success and "ok" or "error"))
+local function test_open_resource(label, ...)
+    local success = pcall(editor.ui.open_resource, ...)
+    print("Open " .. label .. ": " .. (success and "ok" or "error"))
 end
 
 function M.get_commands()
@@ -10,9 +10,12 @@ function M.get_commands()
         label = "Test",
         locations = {"Edit"},
         run = function()
-            test_open_resource("/game.project")
-            test_open_resource("/does_not_exist.txt")
-            test_open_resource("not_a_resource_path.go")
+            test_open_resource("'/game.project'", "/game.project")
+            test_open_resource("'/does_not_exist.txt'", "/does_not_exist.txt")
+            test_open_resource("'not_a_resource_path.go'", "not_a_resource_path.go")
+            test_open_resource("form view", "/game.project", "form")
+            test_open_resource("code position", "/test.editor_script", "code", {line = 3, column = 2})
+            test_open_resource("args without view", "/test.editor_script", {line = 3})
         end
     }}
 end


### PR DESCRIPTION
We added 2 optional arguments to the `editor.ui.open_resource` function: `view` and `args`.

For example, to open a script at line 10, you can use the following code:
```lua
-- 1-indexed line
editor.ui.open_resource("/my/script.lua", "code", { line = 10 })
-- same thing, but with explicit 1-indexed column
editor.ui.open_resource("/my/script.lua", "code", { line = 10, column = 1 })
```
You can also select a particular range of text by providing `from` and `to` cursor positions:
```lua
-- select line 10, columns 1 to 12
editor.ui.open_resource("/my/script.lua", "code", {
    from = { line = 10, column = 1 },
    to = { line = 10, column = 12 }
})
```

Technical notes:

There are many changed files, but that's mostly indentation because I wanted to set up a shared formatter we can use so we don't have to worry about differences in code formatting in the future. Main changes are:
1. I renamed `:cljfx-form-view` to `:form` to keep view ids simple. This required a bit of conversion code in recent_files.clj that persists view ids in prefs.
2. I changed `coerce/regex` to support groups, which was needed to express a particular constraint in the `open_resource` fn: both `view` and `args` are optional, but if you want to provide `args`, you must also provide `view` first.
3. I added args->opts coercers so that view types can decide how their args are parsed

I suggest hiding whitespace diff when reviewing:
<img width="319" height="343" alt="Screenshot 2026-08-12 at 09 33 07" src="https://github.com/user-attachments/assets/6591b62f-a0e9-4b02-bcce-1ccee3885717" />

Fix #12918
