### PR TITLE
Fix render target crash on OpenGL ES 3

### DIFF
--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -1780,9 +1780,9 @@ static void LogFrameBufferError(GLenum status)
         context->m_PackedDepthStencilSupport = 1;
     #endif
 
-        // Packed depth/stencil is part of the OpenGL ES 3.0 core API, so an ES 3
-        // driver is not required to advertise either of the legacy extensions.
-        if (context->m_IsGles3Version ||
+        // Packed depth/stencil is part of the OpenGL ES 3.0 core API, so a GLES 3
+        // context is not required to advertise either of the legacy extensions.
+        if ((context->m_IsShaderLanguageGles && context->m_IsGles3Version) ||
             OpenGLIsExtensionSupported(_context, "GL_OES_packed_depth_stencil") ||
             OpenGLIsExtensionSupported(_context, "GL_EXT_packed_depth_stencil"))
         {

--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -1780,9 +1780,9 @@ static void LogFrameBufferError(GLenum status)
         context->m_PackedDepthStencilSupport = 1;
     #endif
 
-        // Packed depth/stencil is part of the OpenGL ES 3.0 core API, so a GLES 3
-        // context is not required to advertise either of the legacy extensions.
-        if ((context->m_IsShaderLanguageGles && context->m_IsGles3Version) ||
+        // Packed depth/stencil is part of the OpenGL ES 3.0 core API, so an ES 3
+        // driver is not required to advertise either of the legacy extensions.
+        if (context->m_IsGles3Version ||
             OpenGLIsExtensionSupported(_context, "GL_OES_packed_depth_stencil") ||
             OpenGLIsExtensionSupported(_context, "GL_EXT_packed_depth_stencil"))
         {

--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -1780,7 +1780,11 @@ static void LogFrameBufferError(GLenum status)
         context->m_PackedDepthStencilSupport = 1;
     #endif
 
-        if ((OpenGLIsExtensionSupported(_context, "GL_OES_packed_depth_stencil")) || (OpenGLIsExtensionSupported(_context, "GL_EXT_packed_depth_stencil")))
+        // Packed depth/stencil is part of the OpenGL ES 3.0 core API, so an ES 3
+        // driver is not required to advertise either of the legacy extensions.
+        if (context->m_IsGles3Version ||
+            OpenGLIsExtensionSupported(_context, "GL_OES_packed_depth_stencil") ||
+            OpenGLIsExtensionSupported(_context, "GL_EXT_packed_depth_stencil"))
         {
             context->m_PackedDepthStencilSupport = 1;
         }


### PR DESCRIPTION
Render targets using both depth and stencil attachments could crash with `GL_FRAMEBUFFER_UNSUPPORTED` on OpenGL ES 3 drivers that do not advertise legacy packed depth/stencil extensions. The engine now recognizes packed depth/stencil as a core OpenGL ES 3 capability and uses the supported combined attachment.

### Technical changes

- Detect packed depth/stencil support from the OpenGL ES context version.
- Retain legacy OES and EXT extension checks for older contexts.
- Verified with an Android ARM64 engine build.
- Verified on a Pixel 8 API 37.1 emulator using a minimal RGBA + depth + stencil render-target reproducer. The patched engine remained running, while the unpatched control aborted.