### PR TITLE
Changed Host header of the http request to use URI's authority component

### DIFF
--- a/engine/dlib/src/dlib/http/http_client.cpp
+++ b/engine/dlib/src/dlib/http/http_client.cpp
@@ -617,7 +617,7 @@ if (sock_res != dmSocket::RESULT_OK)\
         HTTP_CLIENT_SENDALL_AND_BAIL(encoded_path)
         HTTP_CLIENT_SENDALL_AND_BAIL(" HTTP/1.1\r\n")
         HTTP_CLIENT_SENDALL_AND_BAIL("Host: ");
-        HTTP_CLIENT_SENDALL_AND_BAIL(client->m_HostURI.m_Hostname);
+        HTTP_CLIENT_SENDALL_AND_BAIL(client->m_HostURI.m_Location);
         HTTP_CLIENT_SENDALL_AND_BAIL("\r\n");
 
         if (client->m_HttpWriteHeaders) {


### PR DESCRIPTION
The HTTP implementation had an issue with Host header. The header didn't include the target port. Per [RFC 9110](https://datatracker.ietf.org/doc/html/rfc9110#name-host-and-authority) the header Host should include the target host and optionally target port. [RFC 9112 §3.2](https://datatracker.ietf.org/doc/html/rfc9112#section-3.2) further specifies that the header Host should include the authority component of the uri excluding the userinfo.

Fixes #12602 

### Technical Changes
##  Relevant

The specification mentions userinfo in the uri. But the engine doesn't implement it. So I just skipped this part. I don't think userinfo is a useful feature, so don't think it should be implemented.