### PR TITLE
Fix GUI flipbook cursor behavior

### DIFF
--- a/engine/gamesys/src/gamesys/test/gui/gui_flipbook_cursor.gui_script
+++ b/engine/gamesys/src/gamesys/test/gui/gui_flipbook_cursor.gui_script
@@ -17,12 +17,17 @@ test_err = false
 test_err_str = ""
 
 cursor_test_params = {
+    -- Playback none should apply the initial cursor and keep it unchanged,
+    -- regardless of the animation frame rate.
+    {"anim_none_0",     0.5, 1.0, {0.5, 0.5}},
+    {"anim_none_60",    0.5, 1.0, {0.5, 0.5}},
+
     {"anim_once",       0.0, 1.0, {0.0, 0.25, 0.5, 0.75, 1.0}},
     {"anim_once",      -1.0, 1.0, {0.0, 0.25, 0.5, 0.75, 1.0}}, -- Same as above, but cursor should be clamped
     {"anim_once",       1.0, 1.0, {1.0, 1.0}},                  -- Again, clamped, but will also be at end of anim.
-    {"anim_once_back",  0.0, 1.0, {0.0, 0.75, 0.5, 0.25, 0.0}},
+    {"anim_once_back",  0.0, 1.0, {1.0, 0.75, 0.5, 0.25, 0.0}},
     {"anim_loop",       0.0, 1.0, {0.0, 0.25, 0.5, 0.75, 1.0, 0.25, 0.5, 0.75}},
-    {"anim_loop_back",  0.0, 1.0, {0.0, 0.75, 0.5, 0.25, 0.0, 0.75, 0.5, 0.25}},
+    {"anim_loop_back",  0.0, 1.0, {1.0, 0.75, 0.5, 0.25, 0.0, 0.75, 0.5, 0.25}},
 
     -- Ping-pong in GUI is different from Sprite flipbook animations.
     -- In GUI the flipbook animations doesn't skip duplicate mid and ending frame.
@@ -33,6 +38,7 @@ cursor_test_params = {
 
     -- Cursor start
     {"anim_once",          0.5, 1.0, {0.5, 0.75, 1.0, 1.0}},
+    {"anim_once_back",    0.25, 1.0, {0.75, 0.5, 0.25, 0.0, 0.0}},
     {"anim_once_back",     0.5, 1.0, {0.5, 0.25, 0.0, 0.0}},
     {"anim_loop",          0.5, 1.0, {0.5, 0.75, 1.0, 0.25, 0.5, 0.75, 1.0}},
     {"anim_loop_back",     0.5, 1.0, {0.5, 0.25, 0.0, 0.75, 0.5, 0.25, 0.0}},
@@ -41,25 +47,25 @@ cursor_test_params = {
 
     -- Playback rate, x2 speed
     {"anim_once",          0.0, 2.0, {0.0, 0.5, 1.0, 1.0}},
-    {"anim_once_back",     0.0, 2.0, {0.0, 0.5, 0.0, 0.0}},
+    {"anim_once_back",     0.0, 2.0, {1.0, 0.5, 0.0, 0.0}},
     {"anim_loop",          0.0, 2.0, {0.0, 0.5, 1.0, 0.5, 1.0}},
-    {"anim_loop_back",     0.0, 2.0, {0.0, 0.5, 0.0, 0.5, 0.0}},
+    {"anim_loop_back",     0.0, 2.0, {1.0, 0.5, 0.0, 0.5, 0.0}},
     {"anim_once_pingpong", 0.0, 2.0, {0.0, 0.5, 1.0, 0.5, 0.0, 0.0}},
     {"anim_loop_pingpong", 0.0, 2.0, {0.0, 0.5, 1.0, 0.5, 0.0, 0.5, 1.0}},
 
     -- Playback rate, x0 speed
     {"anim_once",          0.0, 0.0, {0.0, 0.0, 0.0}},
-    {"anim_once_back",     0.0, 0.0, {0.0, 1.0, 1.0}},
+    {"anim_once_back",     0.0, 0.0, {1.0, 1.0, 1.0}},
     {"anim_loop",          0.0, 0.0, {0.0, 0.0, 0.0}},
-    {"anim_loop_back",     0.0, 0.0, {0.0, 1.0, 1.0}},
+    {"anim_loop_back",     0.0, 0.0, {1.0, 1.0, 1.0}},
     {"anim_once_pingpong", 0.0, 0.0, {0.0, 0.0, 0.0}},
     {"anim_loop_pingpong", 0.0, 0.0, {0.0, 0.0, 0.0}},
 
     -- Playback rate, -x2 speed
     {"anim_once",          0.0, -2.0, {0.0, 0.0, 0.0}},
-    {"anim_once_back",     0.0, -2.0, {0.0, 1.0, 1.0}},
+    {"anim_once_back",     0.0, -2.0, {1.0, 1.0, 1.0}},
     {"anim_loop",          0.0, -2.0, {0.0, 0.0, 0.0}},
-    {"anim_loop_back",     0.0, -2.0, {0.0, 1.0, 1.0}},
+    {"anim_loop_back",     0.0, -2.0, {1.0, 1.0, 1.0}},
     {"anim_once_pingpong", 0.0, -2.0, {0.0, 0.0, 0.0}},
     {"anim_loop_pingpong", 0.0, -2.0, {0.0, 0.0, 0.0}},
 }

--- a/engine/gamesys/src/gamesys/test/gui/tile_flipbook.tilesource
+++ b/engine/gamesys/src/gamesys/test/gui/tile_flipbook.tilesource
@@ -15,6 +15,24 @@ animations {
   flip_vertical: 0
 }
 animations {
+  id: "anim_none_0"
+  start_tile: 1
+  end_tile: 4
+  playback: PLAYBACK_NONE
+  fps: 0
+  flip_horizontal: 0
+  flip_vertical: 0
+}
+animations {
+  id: "anim_none_60"
+  start_tile: 1
+  end_tile: 4
+  playback: PLAYBACK_NONE
+  fps: 60
+  flip_horizontal: 0
+  flip_vertical: 0
+}
+animations {
   id: "anim_once"
   start_tile: 1
   end_tile: 4

--- a/engine/gamesys/src/gamesys/test/sprite/tile_flipbook.tilesource
+++ b/engine/gamesys/src/gamesys/test/sprite/tile_flipbook.tilesource
@@ -15,6 +15,24 @@ animations {
   flip_vertical: 0
 }
 animations {
+  id: "anim_none_0"
+  start_tile: 1
+  end_tile: 4
+  playback: PLAYBACK_NONE
+  fps: 0
+  flip_horizontal: 0
+  flip_vertical: 0
+}
+animations {
+  id: "anim_none_60"
+  start_tile: 1
+  end_tile: 4
+  playback: PLAYBACK_NONE
+  fps: 60
+  flip_horizontal: 0
+  flip_vertical: 0
+}
+animations {
   id: "anim_once"
   start_tile: 1
   end_tile: 4

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -7107,6 +7107,11 @@ INSTANTIATE_TEST_CASE_P(BoxRender, BoxRenderTest, jc_test_values_in(box_render_p
 #define F2T3 2.0f/3.0f
 const CursorTestParams cursor_properties[] = {
 
+    // Playback none should apply the initial cursor and keep it unchanged,
+    // regardless of the animation frame rate.
+    {"anim_none_0",     0.5f, 1.0f, {0.5f, 0.5f}, 2},
+    {"anim_none_60",    0.5f, 1.0f, {0.5f, 0.5f}, 2},
+
     // Forward & backward
     {"anim_once",       0.0f, 1.0f, {0.0f, 0.25f, 0.5f, 0.75f, 1.0f}, 5},
     {"anim_once",      -1.0f, 1.0f, {0.0f, 0.25f, 0.5f, 0.75f, 1.0f}, 5}, // Same as above, but cursor should be clamped
@@ -7125,6 +7130,7 @@ const CursorTestParams cursor_properties[] = {
 
     // Cursor start
     {"anim_once",          0.5f, 1.0f, {0.5f, 0.75f, 1.0f, 1.0f}, 4},
+    {"anim_once_back",    0.25f, 1.0f, {0.75f, 0.5f, 0.25f, 0.0f, 0.0f}, 5},
     {"anim_once_back",     0.5f, 1.0f, {0.5f, 0.25f, 0.0f, 0.0f}, 4},
     {"anim_loop",          0.5f, 1.0f, {0.5f, 0.75f, 0.0f, 0.25f, 0.5f, 0.75f, 0.0f}, 7},
     {"anim_loop_back",     0.5f, 1.0f, {0.5f, 0.25f, 1.0f, 0.75f, 0.5f, 0.25f, 1.0f}, 7},

--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -4329,6 +4329,7 @@ namespace dmGui
         uint64_t anim_frames = (anim_desc.m_State.m_End - anim_desc.m_State.m_Start);
         dmGui::Playback playback = (dmGui::Playback)anim_desc.m_State.m_Playback;
         bool pingpong = playback == dmGui::PLAYBACK_ONCE_PINGPONG || playback == dmGui::PLAYBACK_LOOP_PINGPONG;
+        bool backwards = playback == dmGui::PLAYBACK_ONCE_BACKWARD || playback == dmGui::PLAYBACK_LOOP_BACKWARD;
 
         // Ping pong for flipbook animations should result in double the
         // animation duration.
@@ -4367,7 +4368,8 @@ namespace dmGui
         anim->m_From = 0.0f,
         anim->m_FirstUpdate = 0.0f;
         anim->m_Elapsed = elapsed;
-        n->m_Node.m_FlipbookAnimPosition = offset;
+        // As for sprites, offset is playback progress while the cursor is the visible position.
+        n->m_Node.m_FlipbookAnimPosition = backwards ? 1.0f - offset : offset;
     }
 
     static inline FetchTextureSetAnimResult FetchTextureSetAnim(HScene scene, InternalNode* n, dmhash_t anim)
@@ -4456,6 +4458,8 @@ namespace dmGui
         if(n->m_Node.m_TextureSetAnimDesc.m_State.m_Playback == PLAYBACK_NONE)
         {
             CancelAnimationComponent(scene, node, &n->m_Node.m_FlipbookAnimPosition);
+            // As for sprites, PLAYBACK_NONE still uses the offset to select a static frame.
+            n->m_Node.m_FlipbookAnimPosition = dmMath::Clamp(offset, 0.0f, 1.0f);
             if (anim_complete_callback != 0x0)
             {
                 anim_complete_callback(scene, node, true, callback_userdata1, callback_userdata2);
@@ -4883,8 +4887,14 @@ namespace dmGui
         if (n->m_Node.m_FlipbookAnimHash != 0)
         {
             float playback_rate = GetNodeFlipbookPlaybackRate(scene, node);
-            float cursor = GetNodeFlipbookCursor(scene, node);
-            PlayNodeFlipbookAnim(scene, *out_node, n->m_Node.m_FlipbookAnimHash, cursor, playback_rate, 0, 0, 0);
+            // Convert the visible cursor back to playback progress before starting the clone.
+            float offset = GetNodeFlipbookCursor(scene, node);
+            Playback playback = (Playback)n->m_Node.m_TextureSetAnimDesc.m_State.m_Playback;
+            if (playback == PLAYBACK_ONCE_BACKWARD || playback == PLAYBACK_LOOP_BACKWARD)
+            {
+                offset = 1.0f - offset;
+            }
+            PlayNodeFlipbookAnim(scene, *out_node, n->m_Node.m_FlipbookAnimHash, offset, playback_rate, 0, 0, 0);
         }
 
         if (n->m_Node.m_ParticleInstance != 0x0)

--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -4887,14 +4887,32 @@ namespace dmGui
         if (n->m_Node.m_FlipbookAnimHash != 0)
         {
             float playback_rate = GetNodeFlipbookPlaybackRate(scene, node);
+            // The visible cursor is ambiguous at a loop wrap, so preserve the active animation phase separately.
+            Animation* source_animation = GetComponentAnimation(scene, node, &n->m_Node.m_FlipbookAnimPosition);
+            bool copy_animation_phase = source_animation != 0 && source_animation->m_Cancelled == 0;
+            float animation_elapsed = copy_animation_phase ? source_animation->m_Elapsed : 0.0f;
+            uint16_t animation_backwards = copy_animation_phase ? source_animation->m_Backwards : 0;
+
             // Convert the visible cursor back to playback progress before starting the clone.
-            float offset = GetNodeFlipbookCursor(scene, node);
+            float cursor = GetNodeFlipbookCursor(scene, node);
+            float offset = cursor;
             Playback playback = (Playback)n->m_Node.m_TextureSetAnimDesc.m_State.m_Playback;
             if (playback == PLAYBACK_ONCE_BACKWARD || playback == PLAYBACK_LOOP_BACKWARD)
             {
                 offset = 1.0f - offset;
             }
             PlayNodeFlipbookAnim(scene, *out_node, n->m_Node.m_FlipbookAnimHash, offset, playback_rate, 0, 0, 0);
+
+            if (copy_animation_phase)
+            {
+                Animation* clone_animation = GetComponentAnimation(scene, *out_node, &out_n->m_Node.m_FlipbookAnimPosition);
+                if (clone_animation != 0)
+                {
+                    clone_animation->m_Elapsed = animation_elapsed;
+                    clone_animation->m_Backwards = animation_backwards;
+                    out_n->m_Node.m_FlipbookAnimPosition = cursor;
+                }
+            }
         }
 
         if (n->m_Node.m_ParticleInstance != 0x0)

--- a/engine/gui/src/test/test_gui.cpp
+++ b/engine/gui/src/test/test_gui.cpp
@@ -114,6 +114,8 @@ dmGui::FetchTextureSetAnimResult FetchTextureSetAnimCallback(dmGui::HTextureSour
     out_data->m_TexCoords = &uv_quad[0];
     out_data->m_State.m_End = 1;
     out_data->m_State.m_FPS = 30;
+    if (animation == dmHashString64("ta_backward"))
+        out_data->m_State.m_Playback = dmGui::PLAYBACK_ONCE_BACKWARD;
     out_data->m_FlipHorizontal = 1;
     return dmGui::FETCH_ANIMATION_OK;
 }
@@ -5463,6 +5465,40 @@ TEST_F(dmGuiTest, CloneNodeAndAnim)
     ASSERT_EQ(dmGui::GetNodeFlipbookAnimId(m_Scene, node), dmGui::GetNodeFlipbookAnimId(m_Scene, clone));
 
     // cleanup
+    dmGui::RemoveTexture(m_Scene, dmHashString64("t1"));
+}
+
+TEST_F(dmGuiTest, CloneNodeAndBackwardAnim)
+{
+    int t1;
+    dmGui::Result r;
+
+    r = dmGui::AddTexture(m_Scene, dmHashString64("t1"), (dmGui::HTextureSource) &t1, dmGui::NODE_TEXTURE_TYPE_TEXTURE_SET, 1, 1);
+    ASSERT_EQ(r, dmGui::RESULT_OK);
+
+    dmGui::HNode node = dmGui::NewNode(m_Scene, Point3(5,5,0), Vector3(10,10,0), dmGui::NODE_TYPE_BOX, 0);
+    ASSERT_NE((dmGui::HNode) 0, node);
+
+    r = dmGui::SetNodeTexture(m_Scene, node, "t1");
+    ASSERT_EQ(r, dmGui::RESULT_OK);
+
+    r = dmGui::PlayNodeFlipbookAnim(m_Scene, node, "ta_backward", 0.25f, 2.0f, 0x0);
+    ASSERT_EQ(r, dmGui::RESULT_OK);
+    ASSERT_EQ(0.75f, dmGui::GetNodeFlipbookCursor(m_Scene, node));
+
+    dmGui::HNode clone;
+    r = dmGui::CloneNode(m_Scene, node, &clone);
+    ASSERT_EQ(r, dmGui::RESULT_OK);
+    ASSERT_NE((dmGui::HNode) 0, clone);
+
+    ASSERT_EQ(dmGui::GetNodeFlipbookPlaybackRate(m_Scene, node), dmGui::GetNodeFlipbookPlaybackRate(m_Scene, clone));
+    ASSERT_EQ(dmGui::GetNodeFlipbookCursor(m_Scene, node), dmGui::GetNodeFlipbookCursor(m_Scene, clone));
+    ASSERT_EQ(dmGui::GetNodeFlipbookAnimId(m_Scene, node), dmGui::GetNodeFlipbookAnimId(m_Scene, clone));
+
+    r = dmGui::UpdateScene(m_Scene, 1.0f / 240.0f);
+    ASSERT_EQ(r, dmGui::RESULT_OK);
+    ASSERT_EQ(dmGui::GetNodeFlipbookCursor(m_Scene, node), dmGui::GetNodeFlipbookCursor(m_Scene, clone));
+
     dmGui::RemoveTexture(m_Scene, dmHashString64("t1"));
 }
 

--- a/engine/gui/src/test/test_gui.cpp
+++ b/engine/gui/src/test/test_gui.cpp
@@ -116,6 +116,8 @@ dmGui::FetchTextureSetAnimResult FetchTextureSetAnimCallback(dmGui::HTextureSour
     out_data->m_State.m_FPS = 30;
     if (animation == dmHashString64("ta_backward"))
         out_data->m_State.m_Playback = dmGui::PLAYBACK_ONCE_BACKWARD;
+    else if (animation == dmHashString64("ta_loop_backward"))
+        out_data->m_State.m_Playback = dmGui::PLAYBACK_LOOP_BACKWARD;
     out_data->m_FlipHorizontal = 1;
     return dmGui::FETCH_ANIMATION_OK;
 }
@@ -5497,6 +5499,41 @@ TEST_F(dmGuiTest, CloneNodeAndBackwardAnim)
 
     r = dmGui::UpdateScene(m_Scene, 1.0f / 240.0f);
     ASSERT_EQ(r, dmGui::RESULT_OK);
+    ASSERT_EQ(dmGui::GetNodeFlipbookCursor(m_Scene, node), dmGui::GetNodeFlipbookCursor(m_Scene, clone));
+
+    dmGui::RemoveTexture(m_Scene, dmHashString64("t1"));
+}
+
+TEST_F(dmGuiTest, CloneNodeAndBackwardLoopAnimAtWrap)
+{
+    int t1;
+    dmGui::Result r;
+
+    r = dmGui::AddTexture(m_Scene, dmHashString64("t1"), (dmGui::HTextureSource) &t1, dmGui::NODE_TEXTURE_TYPE_TEXTURE_SET, 1, 1);
+    ASSERT_EQ(r, dmGui::RESULT_OK);
+
+    dmGui::HNode node = dmGui::NewNode(m_Scene, Point3(5,5,0), Vector3(10,10,0), dmGui::NODE_TYPE_BOX, 0);
+    ASSERT_NE((dmGui::HNode) 0, node);
+
+    r = dmGui::SetNodeTexture(m_Scene, node, "t1");
+    ASSERT_EQ(r, dmGui::RESULT_OK);
+
+    r = dmGui::PlayNodeFlipbookAnim(m_Scene, node, "ta_loop_backward", 0.0f, 1.0f, 0x0);
+    ASSERT_EQ(r, dmGui::RESULT_OK);
+    ASSERT_EQ(1.0f, dmGui::GetNodeFlipbookCursor(m_Scene, node));
+
+    r = dmGui::UpdateScene(m_Scene, 1.0f / 30.0f);
+    ASSERT_EQ(r, dmGui::RESULT_OK);
+    ASSERT_EQ(0.0f, dmGui::GetNodeFlipbookCursor(m_Scene, node));
+
+    dmGui::HNode clone;
+    r = dmGui::CloneNode(m_Scene, node, &clone);
+    ASSERT_EQ(r, dmGui::RESULT_OK);
+    ASSERT_EQ(dmGui::GetNodeFlipbookCursor(m_Scene, node), dmGui::GetNodeFlipbookCursor(m_Scene, clone));
+
+    r = dmGui::UpdateScene(m_Scene, 1.0f / 240.0f);
+    ASSERT_EQ(r, dmGui::RESULT_OK);
+    ASSERT_NE(0.0f, dmGui::GetNodeFlipbookCursor(m_Scene, node));
     ASSERT_EQ(dmGui::GetNodeFlipbookCursor(m_Scene, node), dmGui::GetNodeFlipbookCursor(m_Scene, clone));
 
     dmGui::RemoveTexture(m_Scene, dmHashString64("t1"));


### PR DESCRIPTION
GUI flipbook animations now respect the requested offset when playback is set to None, allowing static animations to display the selected frame consistently with sprites. Backward animations also start on the correct frame immediately, including when chained from a completion callback, and cloned GUI nodes preserve the current backward-animation position.

Fix https://github.com/defold/defold/issues/8718
Fix https://github.com/defold/defold/issues/8854
Fix https://github.com/defold/defold/issues/12663

### Technical changes

- Apply the clamped offset directly when starting a GUI flipbook animation with `PLAYBACK_NONE`.
- Treat backward-animation offsets as playback progress and initialize the visible cursor to `1 - offset`, matching sprite behavior.
- Convert the visible cursor back to playback progress when cloning a node with a backward animation.
- Add matching GUI and sprite fixtures for `PLAYBACK_NONE` animations with zero and non-zero frame rates.
- Extend GUI and sprite cursor tests with static animations, initial backward-frame expectations, a non-symmetric backward offset, and different playback rates.
- Add a GUI unit test ensuring cloned backward animations preserve their cursor, animation, and playback rate.
- Verified the complete gamesys suite with 510 tests and 19,448 assertions, and the complete GUI suite with 134 tests and 69,329 assertions on arm64 macOS.