### PR TITLE
Fix Linux territory detection for encoded locales

### DIFF
--- a/engine/dlib/src/dlib/sys.cpp
+++ b/engine/dlib/src/dlib/sys.cpp
@@ -229,18 +229,22 @@ namespace dmSys
 
     void FillLanguageTerritory(const char* lang, struct SystemInfo* info)
     {
-        // find first separator ("-" or "_")
-        size_t lang_len = lang ? strlen(lang) : 0;
+        // POSIX locale names use <language>[_<territory>][.<codeset>][@<modifier>].
+        // Ignore the codeset and modifier before parsing the language tag.
+        size_t lang_len = lang ? strcspn(lang, ".@") : 0;
         if(lang_len == 0)
         {
             lang = "en_US";
             lang_len = strlen(lang);
             dmLogWarning("Invalid language parameter (empty field), using default: \"%s\"", lang);
         }
+        const char* lang_end = lang + lang_len;
+
+        // Find the first and last separator ("-" or "_") in the cleaned locale name.
         const char* sep_first = lang;
-        while((*sep_first) && (*sep_first != '-') && (*sep_first != '_'))
+        while((sep_first != lang_end) && (*sep_first != '-') && (*sep_first != '_'))
             ++sep_first;
-        const char* sep_last = lang + lang_len;
+        const char* sep_last = lang_end;
         while((sep_last != sep_first) && (*sep_last != '-') && (*sep_last != '_'))
             --sep_last;
 
@@ -248,19 +252,19 @@ namespace dmSys
 
         if(sep_first != sep_last)
         {
-            // Language script. If there is more than one separator, this is what is up to the last separator (<language>-<script>-<territory> format)
+            // With multiple separators, everything before the last one forms the device language (for example, <language>-<script>).
             dmStrlCpy(info->m_DeviceLanguage, lang, dmMath::Min((size_t)(sep_last+1 - lang), sizeof(info->m_DeviceLanguage)));
             info->m_DeviceLanguage[sep_first - lang] = '-';
         }
         else
         {
-            // No language script, default to language
+            // Without a script, the device language defaults to the language.
             dmStrlCpy(info->m_DeviceLanguage, info->m_Language, dmMath::Min(sizeof(info->m_DeviceLanguage), sizeof(info->m_Language)));
         }
 
-        if(sep_last != lang + lang_len)
+        if(sep_last != lang_end)
         {
-            dmStrlCpy(info->m_Territory, sep_last + 1, dmMath::Min((size_t)((lang + lang_len) - sep_last), sizeof(info->m_Territory)));
+            dmStrlCpy(info->m_Territory, sep_last + 1, dmMath::Min((size_t)(lang_end - sep_last), sizeof(info->m_Territory)));
         }
         else
         {

--- a/engine/dlib/src/test/test_sys.cpp
+++ b/engine/dlib/src/test/test_sys.cpp
@@ -489,7 +489,13 @@ TEST(dmSys, GetSystemInfo)
     CHECK_LANG_TERR("sv", "sv", "sv", "");
     CHECK_LANG_TERR("sv_SE", "sv", "sv", "SE");
     CHECK_LANG_TERR("sv-SE", "sv", "sv", "SE");
+    CHECK_LANG_TERR("en_GB.UTF-8", "en", "en", "GB");
+    CHECK_LANG_TERR("en_GB.utf8", "en", "en", "GB");
+    CHECK_LANG_TERR("en_GB.UTF-8@euro", "en", "en", "GB");
+    CHECK_LANG_TERR("en_GB@euro", "en", "en", "GB");
+    CHECK_LANG_TERR("C.UTF-8", "C", "C", "");
     CHECK_LANG_TERR("zh_Hant_CN", "zh", "zh-Hant", "CN");
+    CHECK_LANG_TERR("zh_Hant_CN.UTF-8", "zh", "zh-Hant", "CN");
     CHECK_LANG_TERR("zh-Hant-CN", "zh", "zh-Hant", "CN");
     CHECK_LANG_TERR("zh_Hant-CN", "zh", "zh-Hant", "CN");
     CHECK_LANG_TERR("zh-Hant_CN", "zh", "zh-Hant", "CN");


### PR DESCRIPTION
Linux builds now report the correct territory when the system locale includes a character encoding or modifier. For example, `LANG=en_GB.UTF-8` now produces `sys.get_sys_info().territory == "GB"` instead of `"8"`.

Fix https://github.com/defold/defold/issues/12680

### Technical changes

- Ignore POSIX locale codeset and modifier suffixes before parsing language and territory.
- Bound separator scanning and territory extraction to the cleaned locale identifier.
- Preserve existing language-script-territory parsing behavior.
- Add coverage for UTF-8 suffix variants, modifiers, `C.UTF-8`, and scripted locale identifiers.
- Verified with `test_sys`: 13 tests and 108 assertions passed.