### PR TITLE
Asan fixes for fontc_shared

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/build.gradle
+++ b/com.dynamo.cr/com.dynamo.cr.bob/build.gradle
@@ -451,6 +451,7 @@ task createBobLightJar(type: Jar, dependsOn: [compileBobLight, createExternalLib
                     'lib/**/*modelc_shared*',
                     'lib/**/*shaderc_shared*',
                     'lib/**/*fontc_shared*'
+            exclude '**/*dSYM.zip'
         }
     }
     from project.classesDir
@@ -489,15 +490,24 @@ task createBobLightJar(type: Jar, dependsOn: [compileBobLight, createExternalLib
     }
 
     doLast {
-        def hostFontcPrefix = "lib/${project.hostPlatform}/"
+        def hostFontcLibraryNames = [
+                'x86_64-macos': 'libfontc_shared.dylib',
+                'arm64-macos': 'libfontc_shared.dylib',
+                'x86_64-linux': 'libfontc_shared.so',
+                'arm64-linux': 'libfontc_shared.so',
+                'x86_64-win32': 'fontc_shared.dll'
+        ]
+        def hostFontcLibraryName = hostFontcLibraryNames[project.hostPlatform]
+        if (!hostFontcLibraryName) {
+            throw new GradleException("Unsupported host platform: ${project.hostPlatform}")
+        }
+        def hostFontcPath = "lib/${project.hostPlatform}/${hostFontcLibraryName}"
         def hasHostFontc = false
         new ZipFile(archiveFile.get().asFile).withCloseable { zipFile ->
-            hasHostFontc = zipFile.entries().find { entry ->
-                entry.name.startsWith(hostFontcPrefix) && entry.name.contains('fontc_shared')
-            } != null
+            hasHostFontc = zipFile.getEntry(hostFontcPath) != null
         }
         if (!hasHostFontc) {
-            throw new GradleException("bob-light.jar is missing the host font compiler library under ${hostFontcPrefix}")
+            throw new GradleException("bob-light.jar is missing the host font compiler library: ${hostFontcPath}")
         }
     }
 }

--- a/com.dynamo.cr/com.dynamo.cr.bob/build.gradle
+++ b/com.dynamo.cr/com.dynamo.cr.bob/build.gradle
@@ -443,6 +443,16 @@ task createBobLightJar(type: Jar, dependsOn: [compileBobLight, createExternalLib
     destinationDirectory = file("${project.bobDir}/dist")
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 
+    // Engine cross-builds install host compiler libraries into DYNAMO_HOME.
+    // Package those fresh artifacts before any potentially stale staged copies.
+    from {
+        fileTree(project.dynamoHome) {
+            include 'lib/**/*texc_shared*',
+                    'lib/**/*modelc_shared*',
+                    'lib/**/*shaderc_shared*',
+                    'lib/**/*fontc_shared*'
+        }
+    }
     from project.classesDir
     from fileTree(project.bobDir) {
         include 'lib/**/*texc_shared*',
@@ -476,6 +486,19 @@ task createBobLightJar(type: Jar, dependsOn: [compileBobLight, createExternalLib
             attrs['Class-Path'] = privateBobPluginClassPath
         }
         attributes attrs
+    }
+
+    doLast {
+        def hostFontcPrefix = "lib/${project.hostPlatform}/"
+        def hasHostFontc = false
+        new ZipFile(archiveFile.get().asFile).withCloseable { zipFile ->
+            hasHostFontc = zipFile.entries().find { entry ->
+                entry.name.startsWith(hostFontcPrefix) && entry.name.contains('fontc_shared')
+            } != null
+        }
+        if (!hasHostFontc) {
+            throw new GradleException("bob-light.jar is missing the host font compiler library under ${hostFontcPrefix}")
+        }
     }
 }
 

--- a/engine/font/CMakeLists.txt
+++ b/engine/font/CMakeLists.txt
@@ -85,6 +85,20 @@ endif()
 if(FONT_RENDERER_IS_DESKTOP)
   find_package(Python3 COMPONENTS Interpreter REQUIRED)
 
+  defold_add_library(font_skribidi_noasan STATIC ${FONT_SKRIBIDI_SOURCES})
+  target_include_directories(font_skribidi_noasan PUBLIC "${FONT_SRC_DIR}" "${FONT_RENDER_SRC_DIR}" "${FONT_ROOT}")
+  target_compile_definitions(font_skribidi_noasan PRIVATE
+    "DLIB_LOG_DOMAIN=\"FONT\""
+    FONT_USE_HARFBUZZ
+    FONT_USE_SKRIBIDI)
+  defold_target_link_libraries(font_skribidi_noasan "${TARGET_PLATFORM}" SCOPE PUBLIC
+    dlib_noasan
+    harfbuzz
+    sheenbidi
+    unibreak
+    skribidi)
+  set_target_properties(font_skribidi_noasan PROPERTIES DEFOLD_SDK_HEADERS_TARGET font_sdk_headers)
+
   add_library(fontc_shared SHARED
     "${FONTC_SRC_DIR}/fontc.cpp"
     "${FONT_GLYPH_VERTEX_SOURCE}")
@@ -93,7 +107,7 @@ if(FONT_RENDERER_IS_DESKTOP)
   target_compile_definitions(fontc_shared PRIVATE
     FONT_USE_HARFBUZZ
     FONT_USE_SKRIBIDI)
-  defold_target_link_libraries(fontc_shared "${TARGET_PLATFORM}" font_skribidi image profile_null)
+  defold_target_link_libraries(fontc_shared "${TARGET_PLATFORM}" font_skribidi_noasan image_noasan profile_null_noasan)
   defold_codesign_target(fontc_shared "../engine/darwin/entitlements-macos-debug.plist")
 
   set(FONT_RENDERER_JAR "${CMAKE_CURRENT_BINARY_DIR}/fontrenderer.jar")


### PR DESCRIPTION
## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
