### PR TITLE
Fix markdown performance degradation with very large images

### DIFF
--- a/editor/src/clj/editor/markdown.clj
+++ b/editor/src/clj/editor/markdown.clj
@@ -34,6 +34,7 @@
             [editor.code.resource :as r]
             [editor.defold-project :as project]
             [editor.fxui :as fxui]
+            [editor.image-util :as image-util]
             [editor.localization :as localization]
             [editor.resource :as resource]
             [editor.ui :as ui]
@@ -401,6 +402,16 @@
                                            :max-width 1000}))
          :children views}))))
 
+(def ^:private max-image-decode-width 2048)
+
+(defn- decode-width [resource]
+  (let [size (try
+               (image-util/read-size resource)
+               (catch Exception _
+                 nil))]
+    (when (and size (> (long (:width size)) (long max-image-decode-width)))
+      (double max-image-decode-width))))
+
 (defn- construct-image [src base-resource]
   (when-not (coll/empty? src)
     (when-let [^URI uri (try (URI. src) (catch URISyntaxException _))]
@@ -409,8 +420,11 @@
         (when-let [base-resource base-resource]
           (let [resource (workspace/resolve-resource base-resource (.getPath uri))]
             (when (resource/exists? resource)
-              (with-open [is (io/input-stream resource)]
-                (Image. is)))))))))
+              (let [width (decode-width resource)]
+                (with-open [is (io/input-stream resource)]
+                  (if width
+                    (Image. is width 0.0 #_preserve-ratio true #_smooth true)
+                    (Image. is)))))))))))
 
 (def ^:private prop-image-width-cap
   (fx/make-binding-prop


### PR DESCRIPTION
This change improves performance when viewing markdown files containing large images.

Fixes #12927

### Technical changes

This doesn't necessarily fix the problem, it just makes it harder to trigger it. The real issue is that Prism has a max vram cap of 512MB which was causing churn. By capping the images, it'll be harder to hit, but another option could be to up the vram max to 1GB `-Dprism.maxvram=1G`. We can do both and really make this hard to trigger.