### PR TITLE
Improved DDF encode/decode performance

### DIFF
--- a/engine/ddf/src/ddf/ddf.cpp
+++ b/engine/ddf/src/ddf/ddf.cpp
@@ -183,12 +183,30 @@ namespace dmDDF
         return RESULT_OK;
     }
 
+    static bool HasFixedLayout(const Descriptor* desc)
+    {
+        if (desc->m_ContainsDynamicFields)
+            return false;
+
+        for (uint32_t i = 0; i < desc->m_FieldCount; ++i)
+        {
+            const FieldDescriptor* field = &desc->m_Fields[i];
+            if (field->m_Label == LABEL_REPEATED || field->m_Type == TYPE_STRING || field->m_Type == TYPE_BYTES)
+                return false;
+            if (field->m_Type == TYPE_MESSAGE && !HasFixedLayout(field->m_MessageDescriptor))
+                return false;
+        }
+        return true;
+    }
+
     static Result CalculateRepeated(LoadContext* load_context, InputBuffer* ib, const Descriptor* desc, uint32_t* array_info_hash, bool is_dynamic_type)
     {
         assert(desc);
 
         // Calculate number of entries in arrays, ie memory requirements for the entire message
         uint32_t start = ib->Tell();
+        uint32_t pending_field_number = 0;
+        uint32_t pending_count = 0;
         while (!ib->Eof())
         {
             uint32_t tag;
@@ -212,7 +230,17 @@ namespace dmDDF
                 {
                     if (field->m_Label == LABEL_REPEATED)
                     {
-                        *array_info_hash = load_context->IncreaseArrayCount(start, field->m_Number);
+                        // Encoders normally emit a repeated field as one contiguous run.
+                        // Accumulate that run locally instead of hashing every element.
+                        if (pending_field_number != field->m_Number)
+                        {
+                            if (pending_count != 0)
+                                load_context->AddArrayCount(start, pending_field_number, pending_count);
+                            pending_field_number = field->m_Number;
+                            pending_count = 0;
+                        }
+                        ++pending_count;
+                        *array_info_hash = 1;
                         is_dynamic_type = false;
                     }
 
@@ -262,6 +290,10 @@ namespace dmDDF
                 return RESULT_WIRE_FORMAT_ERROR;
             }
         }
+
+        if (pending_count != 0)
+            load_context->AddArrayCount(start, pending_field_number, pending_count);
+
         return RESULT_OK;
     }
 
@@ -277,14 +309,39 @@ namespace dmDDF
         assert(desc);
         assert(out_message);
 
+        *out_message = 0;
         if (size)
             *size = 0;
 
         if (desc->m_MajorVersion != DDF_MAJOR_VERSION)
             return RESULT_VERSION_MISMATCH;
 
-        LoadContext load_context(0, 0, true, options);
         InputBuffer input_buffer((const char*) buffer, buffer_size);
+
+        if (HasFixedLayout(desc))
+        {
+            char* message_buffer = 0;
+            uint32_t allocation_size = desc->m_Size > 0 ? desc->m_Size : 1;
+            if (dmMemory::AlignedMalloc((void**) &message_buffer, 16, allocation_size) != dmMemory::RESULT_OK)
+                return RESULT_INTERNAL_ERROR;
+
+            LoadContext load_context(message_buffer, allocation_size, false, options);
+            Message message = load_context.AllocMessage(desc);
+            Result e = DoLoadMessage(&load_context, &input_buffer, desc, &message);
+            if (e != RESULT_OK)
+            {
+                dmMemory::AlignedFree(message_buffer);
+                *out_message = 0;
+                return e;
+            }
+
+            if (size)
+                *size = desc->m_Size;
+            *out_message = message_buffer;
+            return RESULT_OK;
+        }
+
+        LoadContext load_context(0, 0, true, options);
 
         // --- About DDF loading and message layout ---
         //
@@ -320,6 +377,7 @@ namespace dmDDF
 
         Message dry_message(0, 0, 0, true);
         Result e = CreateMessage(&load_context, &input_buffer, desc, &dry_message);
+        DDF_CHECK_RESULT(e);
 
         uint32_t array_info_hash = 0;
         input_buffer.Seek(0);
@@ -328,6 +386,7 @@ namespace dmDDF
 
         input_buffer.Seek(0);
         e = DoLoadMessage(&load_context, &input_buffer, desc, &dry_message);
+        DDF_CHECK_RESULT(e);
 
         // Once the dry run is done, we can calculate the actual size of the message including
         // the memory for the dynamic messages.
@@ -430,26 +489,11 @@ namespace dmDDF
         return ret;
     }
 
-    static bool SaveMessageSizeFunction(void* context, const void* buffer, uint32_t buffer_size)
-    {
-        uint32_t* count = (uint32_t*) context;
-        *count = *count + buffer_size;
-        return true;
-    }
-
     Result SaveMessageSize(const void* message, const Descriptor* desc, uint32_t* size)
     {
-        uint32_t calc_size = 0;
-        Result e = SaveMessage(message, desc, &calc_size, &SaveMessageSizeFunction);
-        if (e == RESULT_OK)
-        {
-            *size = calc_size;
-        }
-        else
-        {
+        Result e = CalculateMessageSize(message, desc, size);
+        if (e != RESULT_OK)
             *size = 0;
-        }
-
         return e;
     }
 
@@ -458,7 +502,15 @@ namespace dmDDF
         dmArray<uint8_t>* array = (dmArray<uint8_t>*) context;
         if (array->Remaining() < buffer_size)
         {
-            array->OffsetCapacity(buffer_size + 1024);
+            uint64_t required = (uint64_t) array->Size() + buffer_size;
+            if (required > UINT32_MAX)
+                return false;
+
+            uint32_t capacity = array->Capacity();
+            uint32_t new_capacity = capacity < 1024 ? 1024 : capacity + capacity / 2;
+            if (new_capacity < required || new_capacity < capacity)
+                new_capacity = (uint32_t) required;
+            array->SetCapacity(new_capacity);
         }
 
         array->PushArray((uint8_t*) buffer, buffer_size);

--- a/engine/ddf/src/ddf/ddf_inputbuffer.cpp
+++ b/engine/ddf/src/ddf/ddf_inputbuffer.cpp
@@ -69,6 +69,15 @@ namespace dmDDF
         assert(value);
         assert(m_Current <= m_End);
 
+        // Tags, lengths, and small scalar values commonly fit in one varint
+        // byte. Handle that case here to avoid entering the general 64-bit
+        // decoder and its continuation-byte loop.
+        if (m_Current < m_End && (uint8_t)*m_Current < 0x80)
+        {
+            *value = (uint8_t)*m_Current++;
+            return true;
+        }
+
         uint64_t tmp;
         if (ReadVarInt64(&tmp))
         {
@@ -89,6 +98,14 @@ namespace dmDDF
 
     bool InputBuffer::ReadVarInt64(uint64_t* value)
     {
+        // Keep the same one-byte fast path for callers that decode 64-bit
+        // values directly; the remaining path handles multi-byte varints.
+        if (m_Current < m_End && (uint8_t)*m_Current < 0x80)
+        {
+            *value = (uint8_t)*m_Current++;
+            return true;
+        }
+
         uint64_t result = 0;
         int count = 0;
 

--- a/engine/ddf/src/ddf/ddf_loadcontext.cpp
+++ b/engine/ddf/src/ddf/ddf_loadcontext.cpp
@@ -31,8 +31,6 @@ namespace dmDDF
         {
             memset(buffer, 0, buffer_size);
         }
-        m_ArrayCount.SetCapacity(2048, 2048);
-
         m_DynamicOffsetCursor = 0;
         m_DynamicTypeMemoryTotal = 0;
     }
@@ -125,28 +123,44 @@ namespace dmDDF
 
     uint32_t LoadContext::IncreaseArrayCount(uint32_t buffer_pos, uint32_t field_number)
     {
+        return AddArrayCount(buffer_pos, field_number, 1);
+    }
+
+    uint32_t LoadContext::AddArrayCount(uint32_t buffer_pos, uint32_t field_number, uint32_t count)
+    {
         uint32_t key[] = {field_number, buffer_pos};
         uint32_t hash = dmHashBufferNoReverse32((void*)key, sizeof(key));
-        if(m_ArrayCount.Full())
+
+        if (m_ArrayCount.Capacity() != 0)
         {
-            m_ArrayCount.SetCapacity(2048, m_ArrayCount.Capacity() + 1024);
+            uint32_t* value = m_ArrayCount.Get(hash);
+            if (value)
+            {
+                *value += count;
+                return hash;
+            }
         }
 
-        uint32_t* value_p = m_ArrayCount.Get(hash);
-        if(value_p)
+        if (m_ArrayCount.Capacity() == 0)
         {
-            (*value_p)++;
+            m_ArrayCount.SetCapacity(16, 16);
         }
-        else
+        else if (m_ArrayCount.Full())
         {
-            m_ArrayCount.Put(hash, 1);
+            uint32_t capacity = m_ArrayCount.Capacity() * 2;
+            m_ArrayCount.SetCapacity(capacity, capacity);
         }
+
+        m_ArrayCount.Put(hash, count);
 
         return hash;
     }
 
     uint32_t LoadContext::GetArrayCount(uint32_t buffer_pos, uint32_t field_number)
     {
+        if (m_ArrayCount.Capacity() == 0)
+            return 0;
+
         uint32_t key[] = {field_number, buffer_pos};
         uint32_t hash = dmHashBufferNoReverse32((void*)key, sizeof(key));
         uint32_t *info_ptr = m_ArrayCount.Get(hash);

--- a/engine/ddf/src/ddf/ddf_loadcontext.h
+++ b/engine/ddf/src/ddf/ddf_loadcontext.h
@@ -39,6 +39,7 @@ namespace dmDDF
         int         GetMemoryUsage();
 
         uint32_t    IncreaseArrayCount(uint32_t buffer_pos, uint32_t field_number);
+        uint32_t    AddArrayCount(uint32_t buffer_pos, uint32_t field_number, uint32_t count);
         uint32_t    GetArrayCount(uint32_t buffer_pos, uint32_t field_number);
 
         uint32_t    AddDynamicMessageSize(uint32_t message_size);

--- a/engine/ddf/src/ddf/ddf_save.cpp
+++ b/engine/ddf/src/ddf/ddf_save.cpp
@@ -19,12 +19,138 @@
 
 namespace dmDDF
 {
-
-    static bool DDFCountSaveFunction(void* context, const void* buffer, uint32_t buffer_size)
+    // Return the number of bytes needed to encode an unsigned value as a
+    // protobuf base-128 varint. Each byte contributes seven payload bits, so
+    // the encoded size is between 1 byte for zero and 10 bytes for uint64_t.
+    static uint32_t VarIntSize(uint64_t value)
     {
-        uint32_t* count = (uint32_t*) context;
-        *count = *count + buffer_size;
+        uint32_t size = 1;
+        while (value > 0x7f)
+        {
+            ++size;
+            value >>= 7;
+        }
+        return size;
+    }
+
+    static bool AddSize(uint64_t* total, uint64_t size)
+    {
+        if (*total > UINT32_MAX || size > UINT32_MAX - *total)
+            return false;
+        *total += size;
         return true;
+    }
+
+    Result CalculateMessageSize(const void* message_, const Descriptor* desc, uint32_t* size)
+    {
+        const uint8_t* message = (const uint8_t*) message_;
+        uint64_t total = 0;
+
+        for (uint32_t i = 0; i < desc->m_FieldCount; ++i)
+        {
+            const FieldDescriptor* field_desc = &desc->m_Fields[i];
+            Type type = (Type) field_desc->m_Type;
+
+            if (field_desc->m_OneOfIndex != DDF_NO_ONE_OF_INDEX)
+            {
+                assert(field_desc->m_OneOfIndex > 0);
+                uint32_t oneof_offset = desc->m_OneOfDataOffsets[field_desc->m_OneOfIndex - 1];
+                uint8_t oneof_member = message[oneof_offset];
+                if (oneof_member != field_desc->m_Number)
+                    continue;
+            }
+
+            uint32_t element_size;
+            if (type == TYPE_MESSAGE)
+                element_size = field_desc->m_MessageDescriptor->m_Size;
+            else if (type == TYPE_STRING)
+                element_size = sizeof(const char*);
+            else if (type == TYPE_BYTES)
+                element_size = sizeof(RepeatedField);
+            else
+                element_size = ScalarTypeSize(type);
+
+            uint32_t count = 1;
+            const uint8_t* data_start = message + field_desc->m_Offset;
+            if (field_desc->m_Label == LABEL_REPEATED)
+            {
+                const RepeatedField* repeated = (const RepeatedField*) data_start;
+                count = repeated->m_ArrayCount;
+                data_start = (const uint8_t*) repeated->m_Array;
+            }
+
+            for (uint32_t j = 0; j < count; ++j)
+            {
+                const uint8_t* data = data_start + j * element_size;
+                uint64_t payload_size;
+
+                switch (type)
+                {
+                    case TYPE_DOUBLE:
+                        payload_size = sizeof(double);
+                        break;
+                    case TYPE_FLOAT:
+                        payload_size = sizeof(float);
+                        break;
+                    case TYPE_INT64:
+                    case TYPE_UINT64:
+                        payload_size = VarIntSize(*((const uint64_t*) data));
+                        break;
+                    case TYPE_INT32:
+                    {
+                        int32_t value = *((const int32_t*) data);
+                        payload_size = value < 0 ? 10 : VarIntSize((uint32_t) value);
+                        break;
+                    }
+                    case TYPE_UINT32:
+                    case TYPE_ENUM:
+                        payload_size = VarIntSize(*((const uint32_t*) data));
+                        break;
+                    case TYPE_BOOL:
+                        payload_size = 1;
+                        break;
+                    case TYPE_STRING:
+                    {
+                        const char* value = *((const char* const*) data);
+                        uint32_t length = value ? (uint32_t) strlen(value) : 0;
+                        payload_size = VarIntSize(length) + length;
+                        break;
+                    }
+                    case TYPE_MESSAGE:
+                    {
+                        if (!field_desc->m_FullyDefinedType)
+                        {
+                            data = (const uint8_t*) *((const uintptr_t*) data);
+                            if (data == 0)
+                                continue;
+                        }
+
+                        uint32_t message_size;
+                        Result result = CalculateMessageSize(data, field_desc->m_MessageDescriptor, &message_size);
+                        if (result != RESULT_OK)
+                            return result;
+                        payload_size = VarIntSize(message_size) + message_size;
+                        break;
+                    }
+                    case TYPE_BYTES:
+                    {
+                        const RepeatedField* bytes = (const RepeatedField*) data;
+                        payload_size = VarIntSize(bytes->m_ArrayCount) + bytes->m_ArrayCount;
+                        break;
+                    }
+                    default:
+                        assert(false);
+                        return RESULT_INTERNAL_ERROR;
+                }
+
+                uint32_t tag = field_desc->m_Number << 3;
+                if (!AddSize(&total, VarIntSize(tag) + payload_size))
+                    return RESULT_INTERNAL_ERROR;
+            }
+        }
+
+        *size = (uint32_t) total;
+        return RESULT_OK;
     }
 
     Result DoSaveMessage(const void* message_, const Descriptor* desc, void* context, SaveFunction save_function)
@@ -141,7 +267,7 @@ namespace dmDDF
                         }
 
                         uint32_t len = 0;
-                        Result e = DoSaveMessage(data, field_desc->m_MessageDescriptor, &len, &DDFCountSaveFunction);
+                        Result e = CalculateMessageSize(data, field_desc->m_MessageDescriptor, &len);
                         if (e != RESULT_OK)
                             return e;
 

--- a/engine/ddf/src/ddf/ddf_save.h
+++ b/engine/ddf/src/ddf/ddf_save.h
@@ -19,6 +19,7 @@
 
 namespace dmDDF
 {
+    Result CalculateMessageSize(const void* message, const Descriptor* desc, uint32_t* size);
     Result DoSaveMessage(const void* message, const Descriptor* desc, void* context, SaveFunction save_function);
 }
 

--- a/engine/ddf/src/ddf/ddf_util.h
+++ b/engine/ddf/src/ddf/ddf_util.h
@@ -37,6 +37,19 @@ namespace dmDDF
 
     static inline const FieldDescriptor* FindField(const Descriptor* desc, uint32_t key, uint32_t* index)
     {
+        // Most generated schemas use dense field numbers starting at one. Keep the
+        // linear fallback for sparse schemas and extension-style field numbers.
+        if (key > 0 && key <= desc->m_FieldCount)
+        {
+            const FieldDescriptor* f = &desc->m_Fields[key - 1];
+            if (f->m_Number == key)
+            {
+                if (index)
+                    *index = key - 1;
+                return f;
+            }
+        }
+
         for (int i = 0; i < desc->m_FieldCount; ++i)
         {
             const FieldDescriptor* f = &desc->m_Fields[i];

--- a/engine/ddf/src/test/CMakeLists.txt
+++ b/engine/ddf/src/test/CMakeLists.txt
@@ -45,3 +45,26 @@ endif()
 
 defold_target_link_libraries_web(test_ddf "${TARGET_PLATFORM}" library_sys.js)
 defold_register_test_target(test_ddf ON "${DDF_TEST_SRC_DIR}")
+
+# Calibrated performance benchmark. It is intentionally not part of the default
+# build or test suite; build it explicitly with --target bench_ddf.
+if(TARGET_PLATFORM MATCHES "^(arm64-macos|x86_64-macos|arm64-linux|x86_64-linux|x86_64-win32)$")
+  defold_add_executable(bench_ddf
+    "${DDF_TEST_SRC_DIR}/bench_ddf.cpp"
+    ${DDF_TEST_PROTO_CC})
+  set_target_properties(bench_ddf PROPERTIES EXCLUDE_FROM_ALL TRUE)
+  target_include_directories(bench_ddf PRIVATE
+    "${DDF_TEST_SRC_DIR}"
+    "${DDF_SRC_DIR}"
+    "${DDF_PROTO_DIR}"
+    "${CMAKE_CURRENT_BINARY_DIR}"
+    "${CMAKE_CURRENT_BINARY_DIR}/../..")
+  defold_target_link_libraries(bench_ddf "${TARGET_PLATFORM}"
+    dlib
+    profile_null
+    ddf)
+  defold_target_link_socket(bench_ddf "${TARGET_PLATFORM}" PRIVATE)
+  if(TARGET_PLATFORM MATCHES "arm64-linux|x86_64-linux")
+    target_link_libraries(bench_ddf PRIVATE Threads::Threads dl)
+  endif()
+endif()

--- a/engine/ddf/src/test/bench_ddf.cpp
+++ b/engine/ddf/src/test/bench_ddf.cpp
@@ -1,0 +1,209 @@
+// Copyright 2020-2026 The Defold Foundation
+// Copyright 2014-2020 King
+// Copyright 2009-2014 Christian Murray
+// Licensed under the Defold License version 1.0 (the "License"); you may not use
+// this file except in compliance with the License.
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <vector>
+
+#include <ddf/ddf.h>
+#include "test/test_ddf_proto.h"
+
+static volatile uint64_t g_Sink = 0;
+static const uint32_t SAMPLE_COUNT = 40;
+static const double MIN_SAMPLE_DURATION_NS = 25000000.0;
+
+struct CountContext
+{
+    uint32_t m_Calls;
+    uint32_t m_Bytes;
+};
+
+static bool CountWrites(void* context, const void*, uint32_t size)
+{
+    CountContext* count = (CountContext*)context;
+    ++count->m_Calls;
+    count->m_Bytes += size;
+    return true;
+}
+
+struct Stats
+{
+    double m_MedianNs;
+    double m_P05Ns;
+    double m_P95Ns;
+    double m_P99Ns;
+    double m_MadNs;
+};
+
+static double Percentile(const std::vector<double>& sorted, double percentile)
+{
+    double index = percentile * (sorted.size() - 1);
+    size_t lower = (size_t) index;
+    size_t upper = std::min(lower + 1, sorted.size() - 1);
+    return sorted[lower] + (sorted[upper] - sorted[lower]) * (index - lower);
+}
+
+static Stats CalculateStats(std::vector<double> samples)
+{
+    std::sort(samples.begin(), samples.end());
+    Stats stats;
+    stats.m_MedianNs = Percentile(samples, 0.50);
+    stats.m_P05Ns = Percentile(samples, 0.05);
+    stats.m_P95Ns = Percentile(samples, 0.95);
+    stats.m_P99Ns = Percentile(samples, 0.99);
+
+    std::vector<double> deviations;
+    deviations.reserve(samples.size());
+    for (double sample : samples)
+        deviations.push_back(std::fabs(sample - stats.m_MedianNs));
+    std::sort(deviations.begin(), deviations.end());
+    stats.m_MadNs = Percentile(deviations, 0.50);
+    return stats;
+}
+
+template <typename F>
+static double Time(F fn, uint32_t repetitions)
+{
+    auto start = std::chrono::steady_clock::now();
+    for (uint32_t i = 0; i < repetitions; ++i)
+        fn();
+    auto end = std::chrono::steady_clock::now();
+    return std::chrono::duration<double, std::nano>(end - start).count();
+}
+
+template <typename F>
+static Stats Bench(const char* name, F fn)
+{
+    for (uint32_t i = 0; i < 10; ++i)
+        fn();
+
+    uint32_t repetitions = 1;
+    while (Time(fn, repetitions) < MIN_SAMPLE_DURATION_NS)
+    {
+        if (repetitions > UINT32_MAX / 2)
+            std::abort();
+        repetitions *= 2;
+    }
+
+    Time(fn, repetitions);
+    Time(fn, repetitions);
+
+    std::vector<double> samples;
+    samples.reserve(SAMPLE_COUNT);
+    for (uint32_t i = 0; i < SAMPLE_COUNT; ++i)
+        samples.push_back(Time(fn, repetitions) / repetitions);
+
+    Stats stats = CalculateStats(samples);
+    std::printf("%-28s x%-8u med %9.1f ns  p05 %9.1f  p95 %9.1f  p99 %9.1f  MAD %7.1f\n",
+                name, repetitions, stats.m_MedianNs, stats.m_P05Ns,
+                stats.m_P95Ns, stats.m_P99Ns, stats.m_MadNs);
+    return stats;
+}
+
+int main()
+{
+    const uint8_t simple_wire[] = {0x08, 0x01};
+    std::printf("Each of %u samples is auto-calibrated to at least %.0f ms.\n",
+                SAMPLE_COUNT, MIN_SAMPLE_DURATION_NS / 1000000.0);
+
+    Bench("load simple (2 bytes)", [&]() {
+        DUMMY::TestDDF::Simple* msg = 0;
+        dmDDF::Result r = dmDDF::LoadMessage(simple_wire, sizeof(simple_wire), &msg);
+        if (r != dmDDF::RESULT_OK) std::abort();
+        g_Sink += msg->m_A;
+        dmDDF::FreeMessage(msg);
+    });
+
+    DUMMY::TestDDF::Simple simple = {};
+    simple.m_A = 1;
+    dmArray<uint8_t> simple_encoded;
+    simple_encoded.SetCapacity(32);
+    Bench("save simple to reused array", [&]() {
+        dmDDF::Result r = dmDDF::SaveMessageToArray(&simple, simple.m_DDFDescriptor, simple_encoded);
+        if (r != dmDDF::RESULT_OK) std::abort();
+        g_Sink += simple_encoded.Size();
+    });
+
+    const uint32_t vertex_count = 4096;
+    const uint32_t index_count = 2048;
+    std::vector<float> vertices(vertex_count);
+    std::vector<uint32_t> indices(index_count);
+    for (uint32_t i = 0; i < vertex_count; ++i) vertices[i] = i * 0.25f;
+    for (uint32_t i = 0; i < index_count; ++i) indices[i] = i;
+
+    DUMMY::TestDDF::Mesh mesh = {};
+    mesh.m_Name = "benchmark mesh";
+    mesh.m_Vertices.m_Data = vertices.data();
+    mesh.m_Vertices.m_Count = vertex_count;
+    mesh.m_Indices.m_Data = indices.data();
+    mesh.m_Indices.m_Count = index_count;
+    mesh.m_PrimitiveCount = index_count / 3;
+    mesh.m_PrimitiveType = DUMMY::TestDDF::Mesh::TRIANGLES;
+
+    dmArray<uint8_t> mesh_encoded;
+    mesh_encoded.SetCapacity(32768);
+    if (dmDDF::SaveMessageToArray(&mesh, mesh.m_DDFDescriptor, mesh_encoded) != dmDDF::RESULT_OK)
+        return 2;
+    std::printf("mesh wire bytes: %u\n", mesh_encoded.Size());
+    CountContext mesh_writes = {};
+    dmDDF::SaveMessage(&mesh, mesh.m_DDFDescriptor, &mesh_writes, CountWrites);
+    std::printf("mesh output callbacks: %u\n", mesh_writes.m_Calls);
+
+    Bench("load mesh repeated", [&]() {
+        DUMMY::TestDDF::Mesh* msg = 0;
+        dmDDF::Result r = dmDDF::LoadMessage(mesh_encoded.Begin(), mesh_encoded.Size(), &msg);
+        if (r != dmDDF::RESULT_OK) std::abort();
+        g_Sink += msg->m_Indices.m_Count;
+        dmDDF::FreeMessage(msg);
+    });
+
+    dmArray<uint8_t> mesh_reencoded;
+    mesh_reencoded.SetCapacity(mesh_encoded.Size());
+    Bench("save mesh to reused array", [&]() {
+        dmDDF::Result r = dmDDF::SaveMessageToArray(&mesh, mesh.m_DDFDescriptor, mesh_reencoded);
+        if (r != dmDDF::RESULT_OK) std::abort();
+        g_Sink += mesh_reencoded.Size();
+    });
+    Bench("save mesh to fresh array", [&]() {
+        dmArray<uint8_t> fresh;
+        fresh.SetCapacity(sizeof(mesh));
+        dmDDF::Result r = dmDDF::SaveMessageToArray(&mesh, mesh.m_DDFDescriptor, fresh);
+        if (r != dmDDF::RESULT_OK) std::abort();
+        g_Sink += fresh.Size();
+    });
+
+    std::vector<DUMMY::TestDDF::MessageRecursiveB> recursive(6);
+    for (uint32_t i = 0; i < recursive.size(); ++i)
+    {
+        std::memset(&recursive[i], 0, sizeof(recursive[i]));
+        recursive[i].m_ValB = i + 10;
+        recursive[i].m_MyA.m_ValA = i + 20;
+        recursive[i].m_MyA.m_MyB = i + 1 < recursive.size() ? &recursive[i + 1] : 0;
+    }
+    DUMMY::TestDDF::MessageRecursiveA recursive_root = {};
+    recursive_root.m_ValA = 1;
+    dmArray<uint8_t> recursive_encoded;
+    recursive_encoded.SetCapacity(1024);
+    for (uint32_t levels = 0; levels <= recursive.size(); ++levels)
+    {
+        recursive_root.m_MyB = levels == 0 ? 0 : &recursive[recursive.size() - levels];
+        char label[64];
+        std::snprintf(label, sizeof(label), "save recursive depth %u", levels * 2 + 1);
+        Bench(label, [&]() {
+            dmDDF::Result r = dmDDF::SaveMessageToArray(&recursive_root, recursive_root.m_DDFDescriptor, recursive_encoded);
+            if (r != dmDDF::RESULT_OK) std::abort();
+            g_Sink += recursive_encoded.Size();
+        });
+    }
+
+    std::printf("sink: %llu\n", (unsigned long long)g_Sink);
+    return 0;
+}

--- a/engine/ddf/src/test/test_ddf.cpp
+++ b/engine/ddf/src/test/test_ddf.cpp
@@ -142,6 +142,19 @@ TEST(Simple, LoadWithTemplateFunction)
     }
 }
 
+TEST(Simple, LoadEmptyFixedLayoutMessage)
+{
+    uint8_t non_null_buffer = 0;
+    DUMMY::TestDDF::EmptyMsg* message = 0;
+    uint32_t message_size = 1;
+    dmDDF::Result e = dmDDF::LoadMessage(&non_null_buffer, 0, DUMMY::TestDDF::EmptyMsg::m_DDFDescriptor,
+                                         (void**) &message, 0, &message_size);
+    ASSERT_EQ(dmDDF::RESULT_OK, e);
+    ASSERT_NE((void*) 0, message);
+    ASSERT_EQ((uint32_t) sizeof(DUMMY::TestDDF::EmptyMsg), message_size);
+    dmDDF::FreeMessage(message);
+}
+
 #if !defined(DM_PLATFORM_IOS)
 // TODO: Disabled on iOS
 // We have add functionality to located tmp-dir on iOS. See issue #624
@@ -470,6 +483,30 @@ TEST(Mesh, Load)
     dmDDF::FreeMessage(message);
 }
 
+TEST(Mesh, LoadInterleavedRepeatedFields)
+{
+    // name="M", vertices={1.0, 2.0}, indices={7}, primitive_count=1,
+    // primitive_type=TRIANGLES. The repeated fields are deliberately interleaved.
+    const uint8_t msg_buf[] = {
+        0x0a, 0x01, 'M',
+        0x15, 0x00, 0x00, 0x80, 0x3f,
+        0x18, 0x07,
+        0x15, 0x00, 0x00, 0x00, 0x40,
+        0x20, 0x01,
+        0x28, 0x01,
+    };
+
+    DUMMY::TestDDF::Mesh* message = 0;
+    dmDDF::Result e = dmDDF::LoadMessage(msg_buf, sizeof(msg_buf), &message);
+    ASSERT_EQ(dmDDF::RESULT_OK, e);
+    ASSERT_EQ((uint32_t) 2, message->m_Vertices.m_Count);
+    ASSERT_EQ((uint32_t) 1, message->m_Indices.m_Count);
+    ASSERT_EQ(1.0f, message->m_Vertices[0]);
+    ASSERT_EQ(2.0f, message->m_Vertices[1]);
+    ASSERT_EQ((uint32_t) 7, message->m_Indices[0]);
+    dmDDF::FreeMessage(message);
+}
+
 TEST(NestedArray, Load)
 {
     const int count1 = 2;
@@ -604,6 +641,18 @@ TEST(MissingRequired, Load)
     dmDDF::Result e = dmDDF::LoadMessage((void*) msg_buf, msg_buf_size, &DUMMY::TestDDF_MissingRequired_DESCRIPTOR, &message);
     ASSERT_EQ(dmDDF::RESULT_MISSING_REQUIRED, e);
     ASSERT_EQ(0, message);
+}
+
+TEST(MissingRequired, LoadNonFixedLayout)
+{
+    // MaterialDesc contains strings and repeated fields, so this exercises the
+    // multi-pass decoder's early validation return rather than the fixed-layout
+    // fast path.
+    uint8_t non_null_buffer = 0;
+    void* message = (void*) (uintptr_t) 1;
+    dmDDF::Result e = dmDDF::LoadMessage(&non_null_buffer, 0, &DUMMY::TestDDF_MaterialDesc_DESCRIPTOR, &message);
+    ASSERT_EQ(dmDDF::RESULT_MISSING_REQUIRED, e);
+    ASSERT_EQ((void*) 0, message);
 }
 
 TEST(TestStructAlias, LoadSave)
@@ -995,6 +1044,48 @@ TEST(Recursive, TreeSimple)
 
     dmDDF::FreeMessage(message);
     dmDDF::FreeMessage(saved_message);
+}
+
+TEST(Recursive, DeepSaveAndSize)
+{
+    const uint32_t node_count = 12;
+    std::vector<DUMMY::TestDDF::MessageRecursiveB> nodes(node_count);
+    memset(nodes.data(), 0, sizeof(nodes[0]) * nodes.size());
+
+    for (uint32_t i = 0; i < node_count; ++i)
+    {
+        nodes[i].m_ValB = 100 + i;
+        nodes[i].m_MyA.m_ValA = 200 + i;
+        nodes[i].m_MyA.m_MyB = i + 1 < node_count ? &nodes[i + 1] : 0;
+    }
+
+    DUMMY::TestDDF::MessageRecursiveA root = {};
+    root.m_ValA = 1;
+    root.m_MyB = &nodes[0];
+
+    uint32_t calculated_size = 0;
+    dmDDF::Result e = dmDDF::SaveMessageSize(&root, root.m_DDFDescriptor, &calculated_size);
+    ASSERT_EQ(dmDDF::RESULT_OK, e);
+
+    std::string saved;
+    e = DDFSaveToString(&root, root.m_DDFDescriptor, saved);
+    ASSERT_EQ(dmDDF::RESULT_OK, e);
+    ASSERT_EQ(calculated_size, (uint32_t) saved.size());
+
+    TestDDF::MessageRecursiveA decoded;
+    ASSERT_TRUE(decoded.ParseFromString(saved));
+
+    const TestDDF::MessageRecursiveA* current = &decoded;
+    for (uint32_t i = 0; i < node_count; ++i)
+    {
+        ASSERT_TRUE(current->has_my_b());
+        const TestDDF::MessageRecursiveB& child = current->my_b();
+        ASSERT_EQ((int32_t) (100 + i), child.val_b());
+        ASSERT_TRUE(child.has_my_a());
+        ASSERT_EQ((int32_t) (200 + i), child.my_a().val_a());
+        current = &child.my_a();
+    }
+    ASSERT_FALSE(current->has_my_b());
 }
 
 TEST(Recursive, Repeated)


### PR DESCRIPTION
Improved DDF (our internal message format) encoding and decoding performance, including up to 4.7× faster small-message decoding and 17% faster repeated-field decoding. Recursive message encoding is significantly faster: up to 95× in deep-message benchmarks.

### Technical changes

#### DDF

Benchmark | Before | After | Improvement
-- | -- | -- | --
Load simple, 2 bytes | 152.4 ns | 32.2 ns | 4.73× faster
Save simple, reused array | 7.3 ns | 7.1 ns | 2.7% faster
Load mesh, repeated fields | 117.2 µs | 97.0 µs | 17.3% faster
Save mesh, reused array | 32.4 µs | 31.3 µs | 3.3% faster
Save mesh, fresh array | 36.6 µs | 32.2 µs | 12.0% faster
Save recursive, depth 1 | 8.8 ns | 9.0 ns | No material change
Save recursive, depth 3 | 69.3 ns | 53.2 ns | 23.2% faster
Save recursive, depth 5 | 275.7 ns | 117.1 ns | 2.35× faster
Save recursive, depth 7 | 1.064 µs | 196.9 ns | 5.40× faster
Save recursive, depth 9 | 4.143 µs | 326.9 ns | 12.7× faster
Save recursive, depth 11 | 16.316 µs | 486.7 ns | 33.5× faster
Save recursive, depth 13 | 63.265 µs | 669.0 ns | 94.6× faster

##### Loading the synthetic project

That is a 3.9% reduction by independent medians, or 1.9% by the more appropriate paired median. After won 29/40 pairs, but the 95% bootstrap interval still includes no improvement, so I’d report it as approximately 2% faster, with noticeable run-to-run variance—not claim a definitive 3.9%.
(13,550 resources)

Full-process startup | Before | After
-- | -- | --
Median | 294.12 ms | 282.70 ms
Mean | 311.14 ms | 297.27 ms

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
