### PR TITLE
Optimized physics messages sent to Lua

### DIFF
--- a/engine/gamesys/src/gamesys/components/comp_collision_object.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_collision_object.cpp
@@ -374,32 +374,58 @@ namespace dmGameSystem
 
         // We want to avoid serializing the message, for performance
         uint32_t msg_size = 0;
-        if (desc->m_NameHash == dmPhysicsDDF::CollisionEvent::m_DDFDescriptor->m_NameHash)
-            msg_size = sizeof(dmPhysicsDDF::CollisionEvent);
-        else if (desc->m_NameHash == dmPhysicsDDF::ContactPointEvent::m_DDFDescriptor->m_NameHash)
-            msg_size = sizeof(dmPhysicsDDF::ContactPointEvent);
-        else if (desc->m_NameHash == dmPhysicsDDF::TriggerEvent::m_DDFDescriptor->m_NameHash)
-            msg_size = sizeof(dmPhysicsDDF::TriggerEvent);
-        else if (desc->m_NameHash == dmPhysicsDDF::RayCastResponse::m_DDFDescriptor->m_NameHash)
-            msg_size = sizeof(dmPhysicsDDF::RayCastResponse);
-        else if (desc->m_NameHash == dmPhysicsDDF::RayCastMissed::m_DDFDescriptor->m_NameHash)
-            msg_size = sizeof(dmPhysicsDDF::RayCastMissed);
-
-        if (world->m_MessageData.Remaining() < msg_size)
+        PhysicsMessageType msg_type;
+        if (desc == dmPhysicsDDF::CollisionEvent::m_DDFDescriptor)
         {
-            world->m_MessageData.OffsetCapacity( 2 * 1024 );
+            msg_size = sizeof(dmPhysicsDDF::CollisionEvent);
+            msg_type = PHYSICS_MESSAGE_TYPE_COLLISION;
+        }
+        else if (desc == dmPhysicsDDF::ContactPointEvent::m_DDFDescriptor)
+        {
+            msg_size = sizeof(dmPhysicsDDF::ContactPointEvent);
+            msg_type = PHYSICS_MESSAGE_TYPE_CONTACT_POINT;
+        }
+        else if (desc == dmPhysicsDDF::TriggerEvent::m_DDFDescriptor)
+        {
+            msg_size = sizeof(dmPhysicsDDF::TriggerEvent);
+            msg_type = PHYSICS_MESSAGE_TYPE_TRIGGER;
+        }
+        else if (desc == dmPhysicsDDF::RayCastResponse::m_DDFDescriptor)
+        {
+            msg_size = sizeof(dmPhysicsDDF::RayCastResponse);
+            msg_type = PHYSICS_MESSAGE_TYPE_RAY_CAST_RESPONSE;
+        }
+        else if (desc == dmPhysicsDDF::RayCastMissed::m_DDFDescriptor)
+        {
+            msg_size = sizeof(dmPhysicsDDF::RayCastMissed);
+            msg_type = PHYSICS_MESSAGE_TYPE_RAY_CAST_MISSED;
+        }
+        else
+        {
+            assert(false);
+            return;
+        }
+
+        const uint32_t message_alignment = 16;
+        const uint32_t aligned_offset = (world->m_MessageData.Size() + message_alignment - 1) & ~(message_alignment - 1);
+
+        if (world->m_MessageData.Capacity() < aligned_offset + msg_size)
+        {
+            const uint32_t required_capacity = aligned_offset + msg_size;
+            const uint32_t grown_capacity = dmMath::Max(2U * 1024U, world->m_MessageData.Capacity() * 2U);
+            world->m_MessageData.SetCapacity(dmMath::Max(required_capacity, grown_capacity));
         }
 
         if (world->m_MessageInfos.Full())
         {
-            world->m_MessageInfos.OffsetCapacity(64);
+            world->m_MessageInfos.SetCapacity(dmMath::Max(64U, world->m_MessageInfos.Capacity() * 2U));
         }
 
         PhysicsMessage msg;
-        msg.m_Descriptor = desc;
-        msg.m_Offset     = world->m_MessageData.Size();
-        msg.m_Size       = msg_size;
+        msg.m_Offset = aligned_offset;
+        msg.m_Type   = msg_type;
 
+        world->m_MessageData.SetSize(aligned_offset);
         world->m_MessageData.PushArray((uint8_t*)data, msg_size);
         world->m_MessageInfos.Push(msg);
     }

--- a/engine/gamesys/src/gamesys/gamesys.h
+++ b/engine/gamesys/src/gamesys/gamesys.h
@@ -146,11 +146,19 @@ namespace dmGameSystem
         GetJointReactionTorqueFn m_GetJointReactionTorque;
     };
 
+    enum PhysicsMessageType
+    {
+        PHYSICS_MESSAGE_TYPE_COLLISION,
+        PHYSICS_MESSAGE_TYPE_CONTACT_POINT,
+        PHYSICS_MESSAGE_TYPE_TRIGGER,
+        PHYSICS_MESSAGE_TYPE_RAY_CAST_RESPONSE,
+        PHYSICS_MESSAGE_TYPE_RAY_CAST_MISSED,
+    };
+
     struct PhysicsMessage
     {
-        const dmDDF::Descriptor* m_Descriptor; // They're static, so we can store the pointer
-        uint32_t m_Offset;  // Offset into payload array
-        uint32_t m_Size;    // Size of the data
+        uint32_t           m_Offset; // Aligned offset into payload array
+        PhysicsMessageType m_Type;
     };
 
     struct CollisionWorld

--- a/engine/gamesys/src/gamesys/scripts/script_physics.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_physics.cpp
@@ -2103,6 +2103,16 @@ namespace dmGameSystem
         lua_State* L = dmScript::GetCallbackLuaContext(cbk);
         DM_LUA_STACK_CHECK(L, 0);
 
+        // SetupCallback, the cached field keys, the largest event table, and
+        // transient values from creating uncached hashes can exceed Lua's
+        // guaranteed LUA_MINSTACK slots.
+        const int required_stack_slots = 32;
+        if (!lua_checkstack(L, required_stack_slots))
+        {
+            dmLogError("Failed to grow Lua stack for physics.set_event_listener() callback");
+            return;
+        }
+
         if (!dmScript::SetupCallback(cbk))
         {
             dmLogError("Failed to setup physics.set_event_listener() callback");

--- a/engine/gamesys/src/gamesys/scripts/script_physics.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_physics.cpp
@@ -43,6 +43,134 @@ static uint32_t PHYSICS_CONTEXT_HASH = 0;
 
 namespace dmGameSystem
 {
+    static dmScript::Result CollisionResponseDecoder(lua_State* L, const dmDDF::Descriptor*, const char* data)
+    {
+        DM_PROFILE("CollisionResponseDecoder");
+        const dmPhysicsDDF::CollisionResponse* message = (const dmPhysicsDDF::CollisionResponse*)data;
+
+        lua_createtable(L, 0, 5);
+        dmScript::PushHash(L, message->m_OtherId);
+        lua_setfield(L, -2, "other_id");
+        dmScript::PushHash(L, message->m_Group);
+        lua_setfield(L, -2, "group");
+        dmScript::PushVector3(L, dmVMath::Vector3(message->m_OtherPosition));
+        lua_setfield(L, -2, "other_position");
+        dmScript::PushHash(L, message->m_OtherGroup);
+        lua_setfield(L, -2, "other_group");
+        dmScript::PushHash(L, message->m_OwnGroup);
+        lua_setfield(L, -2, "own_group");
+        return dmScript::RESULT_OK;
+    }
+
+    static dmScript::Result ContactPointResponseDecoder(lua_State* L, const dmDDF::Descriptor*, const char* data)
+    {
+        DM_PROFILE("ContactPointResponseDecoder");
+        const dmPhysicsDDF::ContactPointResponse* message = (const dmPhysicsDDF::ContactPointResponse*)data;
+
+        lua_createtable(L, 0, 13);
+        dmScript::PushVector3(L, dmVMath::Vector3(message->m_Position));
+        lua_setfield(L, -2, "position");
+        dmScript::PushVector3(L, message->m_Normal);
+        lua_setfield(L, -2, "normal");
+        dmScript::PushVector3(L, message->m_RelativeVelocity);
+        lua_setfield(L, -2, "relative_velocity");
+        lua_pushnumber(L, message->m_Distance);
+        lua_setfield(L, -2, "distance");
+        lua_pushnumber(L, message->m_AppliedImpulse);
+        lua_setfield(L, -2, "applied_impulse");
+        lua_pushnumber(L, message->m_LifeTime);
+        lua_setfield(L, -2, "life_time");
+        lua_pushnumber(L, message->m_Mass);
+        lua_setfield(L, -2, "mass");
+        lua_pushnumber(L, message->m_OtherMass);
+        lua_setfield(L, -2, "other_mass");
+        dmScript::PushHash(L, message->m_OtherId);
+        lua_setfield(L, -2, "other_id");
+        dmScript::PushVector3(L, dmVMath::Vector3(message->m_OtherPosition));
+        lua_setfield(L, -2, "other_position");
+        dmScript::PushHash(L, message->m_Group);
+        lua_setfield(L, -2, "group");
+        dmScript::PushHash(L, message->m_OtherGroup);
+        lua_setfield(L, -2, "other_group");
+        dmScript::PushHash(L, message->m_OwnGroup);
+        lua_setfield(L, -2, "own_group");
+        return dmScript::RESULT_OK;
+    }
+
+    static dmScript::Result TriggerResponseDecoder(lua_State* L, const dmDDF::Descriptor*, const char* data)
+    {
+        DM_PROFILE("TriggerResponseDecoder");
+        const dmPhysicsDDF::TriggerResponse* message = (const dmPhysicsDDF::TriggerResponse*)data;
+
+        lua_createtable(L, 0, 5);
+        dmScript::PushHash(L, message->m_OtherId);
+        lua_setfield(L, -2, "other_id");
+        lua_pushboolean(L, message->m_Enter);
+        lua_setfield(L, -2, "enter");
+        dmScript::PushHash(L, message->m_Group);
+        lua_setfield(L, -2, "group");
+        dmScript::PushHash(L, message->m_OtherGroup);
+        lua_setfield(L, -2, "other_group");
+        dmScript::PushHash(L, message->m_OwnGroup);
+        lua_setfield(L, -2, "own_group");
+        return dmScript::RESULT_OK;
+    }
+
+    static dmScript::Result RayCastResponseDecoder(lua_State* L, const dmDDF::Descriptor*, const char* data)
+    {
+        DM_PROFILE("RayCastResponseDecoder");
+        const dmPhysicsDDF::RayCastResponse* message = (const dmPhysicsDDF::RayCastResponse*)data;
+
+        lua_createtable(L, 0, 6);
+        lua_pushnumber(L, message->m_Fraction);
+        lua_setfield(L, -2, "fraction");
+        dmScript::PushVector3(L, dmVMath::Vector3(message->m_Position));
+        lua_setfield(L, -2, "position");
+        dmScript::PushVector3(L, message->m_Normal);
+        lua_setfield(L, -2, "normal");
+        dmScript::PushHash(L, message->m_Id);
+        lua_setfield(L, -2, "id");
+        dmScript::PushHash(L, message->m_Group);
+        lua_setfield(L, -2, "group");
+        lua_pushinteger(L, (int)message->m_RequestId);
+        lua_setfield(L, -2, "request_id");
+        return dmScript::RESULT_OK;
+    }
+
+    static dmScript::Result RayCastMissedDecoder(lua_State* L, const dmDDF::Descriptor*, const char* data)
+    {
+        DM_PROFILE("RayCastMissedDecoder");
+        const dmPhysicsDDF::RayCastMissed* message = (const dmPhysicsDDF::RayCastMissed*)data;
+
+        lua_createtable(L, 0, 1);
+        lua_pushinteger(L, (int)message->m_RequestId);
+        lua_setfield(L, -2, "request_id");
+        return dmScript::RESULT_OK;
+    }
+
+    static dmScript::Result VelocityResponseDecoder(lua_State* L, const dmDDF::Descriptor*, const char* data)
+    {
+        DM_PROFILE("VelocityResponseDecoder");
+        const dmPhysicsDDF::VelocityResponse* message = (const dmPhysicsDDF::VelocityResponse*)data;
+
+        lua_createtable(L, 0, 2);
+        dmScript::PushVector3(L, message->m_LinearVelocity);
+        lua_setfield(L, -2, "linear_velocity");
+        dmScript::PushVector3(L, message->m_AngularVelocity);
+        lua_setfield(L, -2, "angular_velocity");
+        return dmScript::RESULT_OK;
+    }
+
+    static void RegisterPhysicsDDFDecoders()
+    {
+        dmScript::RegisterDDFDecoder(dmPhysicsDDF::CollisionResponse::m_DDFDescriptor, &CollisionResponseDecoder);
+        dmScript::RegisterDDFDecoder(dmPhysicsDDF::ContactPointResponse::m_DDFDescriptor, &ContactPointResponseDecoder);
+        dmScript::RegisterDDFDecoder(dmPhysicsDDF::TriggerResponse::m_DDFDescriptor, &TriggerResponseDecoder);
+        dmScript::RegisterDDFDecoder(dmPhysicsDDF::RayCastResponse::m_DDFDescriptor, &RayCastResponseDecoder);
+        dmScript::RegisterDDFDecoder(dmPhysicsDDF::RayCastMissed::m_DDFDescriptor, &RayCastMissedDecoder);
+        dmScript::RegisterDDFDecoder(dmPhysicsDDF::VelocityResponse::m_DDFDescriptor, &VelocityResponseDecoder);
+    }
+
     /*# Collision object physics API documentation
      *
      * Functions and messages for collision object physics interaction
@@ -1749,127 +1877,217 @@ namespace dmGameSystem
         dmScript::TeardownCallback(cbk);
     }
 
-    static void PushCollision(lua_State* L, dmPhysicsDDF::Collision* collision)
+    static void PushVector3WithMetatable(lua_State* L, const dmVMath::Vector3& value, int metatable_index)
     {
-        lua_createtable(L, 0, 3);
-
-        dmScript::PushVector3(L, *((dmVMath::Vector3*) &collision->m_Position));
-        lua_setfield(L, -2, "position");
-        dmScript::PushHash(L, collision->m_Id);
-        lua_setfield(L, -2, "id");
-        dmScript::PushHash(L, collision->m_Group);
-        lua_setfield(L, -2, "group");
+        dmVMath::Vector3* userdata = (dmVMath::Vector3*)lua_newuserdata(L, sizeof(dmVMath::Vector3));
+        *userdata = value;
+        lua_pushvalue(L, metatable_index);
+        lua_setmetatable(L, -2);
     }
 
-    static void PushCollisionEvent(lua_State* L, dmPhysicsDDF::CollisionEvent* event)
+    enum PhysicsLuaKey
+    {
+        PHYSICS_LUA_KEY_A,
+        PHYSICS_LUA_KEY_B,
+        PHYSICS_LUA_KEY_TYPE,
+        PHYSICS_LUA_KEY_POSITION,
+        PHYSICS_LUA_KEY_ID,
+        PHYSICS_LUA_KEY_GROUP,
+        PHYSICS_LUA_KEY_INSTANCE_POSITION,
+        PHYSICS_LUA_KEY_NORMAL,
+        PHYSICS_LUA_KEY_RELATIVE_VELOCITY,
+        PHYSICS_LUA_KEY_MASS,
+        PHYSICS_LUA_KEY_DISTANCE,
+        PHYSICS_LUA_KEY_APPLIED_IMPULSE,
+        PHYSICS_LUA_KEY_ENTER,
+        PHYSICS_LUA_KEY_FRACTION,
+        PHYSICS_LUA_KEY_REQUEST_ID,
+        PHYSICS_LUA_KEY_COUNT,
+    };
+
+    static const char* PHYSICS_LUA_KEY_NAMES[PHYSICS_LUA_KEY_COUNT] =
+    {
+        "a",
+        "b",
+        "type",
+        "position",
+        "id",
+        "group",
+        "instance_position",
+        "normal",
+        "relative_velocity",
+        "mass",
+        "distance",
+        "applied_impulse",
+        "enter",
+        "fraction",
+        "request_id",
+    };
+
+    struct PhysicsLuaKeys
+    {
+        int m_StackIndices[PHYSICS_LUA_KEY_COUNT];
+    };
+
+    static void PushPhysicsLuaKeys(lua_State* L, PhysicsLuaKeys* keys)
+    {
+        for (uint32_t i = 0; i < PHYSICS_LUA_KEY_COUNT; ++i)
+        {
+            lua_pushstring(L, PHYSICS_LUA_KEY_NAMES[i]);
+            keys->m_StackIndices[i] = lua_gettop(L);
+        }
+    }
+
+    static void SetPhysicsLuaField(lua_State* L, int table_index, const PhysicsLuaKeys& keys, PhysicsLuaKey key)
+    {
+        lua_pushvalue(L, keys.m_StackIndices[key]);
+        lua_insert(L, -2);
+        lua_rawset(L, table_index);
+    }
+
+    static void PushCollision(lua_State* L, dmPhysicsDDF::Collision* collision, int vector3_metatable_index, const PhysicsLuaKeys& keys)
+    {
+        lua_createtable(L, 0, 3);
+        const int table_index = lua_gettop(L);
+
+        PushVector3WithMetatable(L, *((dmVMath::Vector3*) &collision->m_Position), vector3_metatable_index);
+        SetPhysicsLuaField(L, table_index, keys, PHYSICS_LUA_KEY_POSITION);
+        dmScript::PushHash(L, collision->m_Id);
+        SetPhysicsLuaField(L, table_index, keys, PHYSICS_LUA_KEY_ID);
+        dmScript::PushHash(L, collision->m_Group);
+        SetPhysicsLuaField(L, table_index, keys, PHYSICS_LUA_KEY_GROUP);
+    }
+
+    static void PushCollisionEvent(lua_State* L, dmPhysicsDDF::CollisionEvent* event, int vector3_metatable_index, const PhysicsLuaKeys& keys)
     {
         DM_PROFILE("PushCollisionEvent");
 
         lua_createtable(L, 0, 2);
+        const int table_index = lua_gettop(L);
 
-        PushCollision(L, &event->m_A);
-        lua_setfield(L, -2, "a");
+        PushCollision(L, &event->m_A, vector3_metatable_index, keys);
+        SetPhysicsLuaField(L, table_index, keys, PHYSICS_LUA_KEY_A);
 
-        PushCollision(L, &event->m_B);
-        lua_setfield(L, -2, "b");
+        PushCollision(L, &event->m_B, vector3_metatable_index, keys);
+        SetPhysicsLuaField(L, table_index, keys, PHYSICS_LUA_KEY_B);
     }
 
-    static void PushContactPoint(lua_State* L, dmPhysicsDDF::ContactPoint* point)
+    static void PushContactPoint(lua_State* L, dmPhysicsDDF::ContactPoint* point, int vector3_metatable_index, const PhysicsLuaKeys& keys)
     {
         lua_createtable(L, 0, 7);
+        const int table_index = lua_gettop(L);
 
-        dmScript::PushVector3(L, *((dmVMath::Vector3*) &point->m_Position));
-        lua_setfield(L, -2, "position");
+        PushVector3WithMetatable(L, *((dmVMath::Vector3*) &point->m_Position), vector3_metatable_index);
+        SetPhysicsLuaField(L, table_index, keys, PHYSICS_LUA_KEY_POSITION);
 
-        dmScript::PushVector3(L, *((dmVMath::Vector3*) &point->m_InstancePosition));
-        lua_setfield(L, -2, "instance_position");
+        PushVector3WithMetatable(L, *((dmVMath::Vector3*) &point->m_InstancePosition), vector3_metatable_index);
+        SetPhysicsLuaField(L, table_index, keys, PHYSICS_LUA_KEY_INSTANCE_POSITION);
 
-        dmScript::PushVector3(L, point->m_Normal);
-        lua_setfield(L, -2, "normal");
+        PushVector3WithMetatable(L, point->m_Normal, vector3_metatable_index);
+        SetPhysicsLuaField(L, table_index, keys, PHYSICS_LUA_KEY_NORMAL);
 
-        dmScript::PushVector3(L, point->m_RelativeVelocity);
-        lua_setfield(L, -2, "relative_velocity");
+        PushVector3WithMetatable(L, point->m_RelativeVelocity, vector3_metatable_index);
+        SetPhysicsLuaField(L, table_index, keys, PHYSICS_LUA_KEY_RELATIVE_VELOCITY);
 
         lua_pushnumber(L, point->m_Mass);
-        lua_setfield(L, -2, "mass");
+        SetPhysicsLuaField(L, table_index, keys, PHYSICS_LUA_KEY_MASS);
 
         dmScript::PushHash(L, point->m_Id);
-        lua_setfield(L, -2, "id");
+        SetPhysicsLuaField(L, table_index, keys, PHYSICS_LUA_KEY_ID);
         dmScript::PushHash(L, point->m_Group);
-        lua_setfield(L, -2, "group");
+        SetPhysicsLuaField(L, table_index, keys, PHYSICS_LUA_KEY_GROUP);
     }
 
-    static void PushContactPointEvent(lua_State* L, dmPhysicsDDF::ContactPointEvent* event)
+    static void PushContactPointEvent(lua_State* L, dmPhysicsDDF::ContactPointEvent* event, int vector3_metatable_index, const PhysicsLuaKeys& keys)
     {
         DM_PROFILE("PushContactPointEvent");
 
         lua_createtable(L, 0, 4);
+        const int table_index = lua_gettop(L);
 
-        PushContactPoint(L, &event->m_A);
-        lua_setfield(L, -2, "a");
+        PushContactPoint(L, &event->m_A, vector3_metatable_index, keys);
+        SetPhysicsLuaField(L, table_index, keys, PHYSICS_LUA_KEY_A);
 
-        PushContactPoint(L, &event->m_B);
-        lua_setfield(L, -2, "b");
+        PushContactPoint(L, &event->m_B, vector3_metatable_index, keys);
+        SetPhysicsLuaField(L, table_index, keys, PHYSICS_LUA_KEY_B);
 
         lua_pushnumber(L, event->m_Distance);
-        lua_setfield(L, -2, "distance");
+        SetPhysicsLuaField(L, table_index, keys, PHYSICS_LUA_KEY_DISTANCE);
 
         lua_pushnumber(L, event->m_AppliedImpulse);
-        lua_setfield(L, -2, "applied_impulse");
+        SetPhysicsLuaField(L, table_index, keys, PHYSICS_LUA_KEY_APPLIED_IMPULSE);
     }
 
-    static void PushTrigger(lua_State* L, dmPhysicsDDF::Trigger* trigger)
+    static void PushTrigger(lua_State* L, dmPhysicsDDF::Trigger* trigger, const PhysicsLuaKeys& keys)
     {
         lua_createtable(L, 0, 2);
+        const int table_index = lua_gettop(L);
 
         dmScript::PushHash(L, trigger->m_Id);
-        lua_setfield(L, -2, "id");
+        SetPhysicsLuaField(L, table_index, keys, PHYSICS_LUA_KEY_ID);
         dmScript::PushHash(L, trigger->m_Group);
-        lua_setfield(L, -2, "group");
+        SetPhysicsLuaField(L, table_index, keys, PHYSICS_LUA_KEY_GROUP);
     }
 
-    static void PushTriggerEvent(lua_State* L, dmPhysicsDDF::TriggerEvent* event)
+    static void PushTriggerEvent(lua_State* L, dmPhysicsDDF::TriggerEvent* event, const PhysicsLuaKeys& keys)
     {
         DM_PROFILE("PushTriggerEvent");
 
         lua_createtable(L, 0, 3);
+        const int table_index = lua_gettop(L);
 
         lua_pushboolean(L, event->m_Enter);
-        lua_setfield(L, -2, "enter");
+        SetPhysicsLuaField(L, table_index, keys, PHYSICS_LUA_KEY_ENTER);
 
-        PushTrigger(L, &event->m_A);
-        lua_setfield(L, -2, "a");
+        PushTrigger(L, &event->m_A, keys);
+        SetPhysicsLuaField(L, table_index, keys, PHYSICS_LUA_KEY_A);
 
-        PushTrigger(L, &event->m_B);
-        lua_setfield(L, -2, "b");
+        PushTrigger(L, &event->m_B, keys);
+        SetPhysicsLuaField(L, table_index, keys, PHYSICS_LUA_KEY_B);
     }
 
-    static void PushRayCastResponse(lua_State* L, dmPhysicsDDF::RayCastResponse* event)
+    static void PushRayCastResponse(lua_State* L, dmPhysicsDDF::RayCastResponse* event, const PhysicsLuaKeys& keys)
     {
         DM_PROFILE("PushRayCastResponse");
 
         lua_createtable(L, 0, 6);
+        const int table_index = lua_gettop(L);
 
         dmScript::PushVector3(L, *((dmVMath::Vector3*) &event->m_Position));
-        lua_setfield(L, -2, "position");
+        SetPhysicsLuaField(L, table_index, keys, PHYSICS_LUA_KEY_POSITION);
         dmScript::PushVector3(L, event->m_Normal);
-        lua_setfield(L, -2, "normal");
+        SetPhysicsLuaField(L, table_index, keys, PHYSICS_LUA_KEY_NORMAL);
         lua_pushnumber(L, event->m_Fraction);
-        lua_setfield(L, -2, "fraction");
+        SetPhysicsLuaField(L, table_index, keys, PHYSICS_LUA_KEY_FRACTION);
         dmScript::PushHash(L, event->m_Id);
-        lua_setfield(L, -2, "id");
+        SetPhysicsLuaField(L, table_index, keys, PHYSICS_LUA_KEY_ID);
         dmScript::PushHash(L, event->m_Group);
-        lua_setfield(L, -2, "group");
+        SetPhysicsLuaField(L, table_index, keys, PHYSICS_LUA_KEY_GROUP);
         lua_pushinteger(L, event->m_RequestId);
-        lua_setfield(L, -2, "request_id");
+        SetPhysicsLuaField(L, table_index, keys, PHYSICS_LUA_KEY_REQUEST_ID);
     }
 
-    static void PushRayCastMissed(lua_State* L, dmPhysicsDDF::RayCastMissed* event)
+    static void PushRayCastMissed(lua_State* L, dmPhysicsDDF::RayCastMissed* event, const PhysicsLuaKeys& keys)
     {
         DM_PROFILE("PushRayCastMissed");
         lua_createtable(L, 0, 1);
+        const int table_index = lua_gettop(L);
         lua_pushinteger(L, event->m_RequestId);
-        lua_setfield(L, -2, "request_id");
+        SetPhysicsLuaField(L, table_index, keys, PHYSICS_LUA_KEY_REQUEST_ID);
+    }
+
+    static dmhash_t GetPhysicsMessageNameHash(PhysicsMessageType type)
+    {
+        switch (type)
+        {
+            case PHYSICS_MESSAGE_TYPE_COLLISION:         return dmPhysicsDDF::CollisionEvent::m_DDFDescriptor->m_NameHash;
+            case PHYSICS_MESSAGE_TYPE_CONTACT_POINT:     return dmPhysicsDDF::ContactPointEvent::m_DDFDescriptor->m_NameHash;
+            case PHYSICS_MESSAGE_TYPE_TRIGGER:           return dmPhysicsDDF::TriggerEvent::m_DDFDescriptor->m_NameHash;
+            case PHYSICS_MESSAGE_TYPE_RAY_CAST_RESPONSE: return dmPhysicsDDF::RayCastResponse::m_DDFDescriptor->m_NameHash;
+            case PHYSICS_MESSAGE_TYPE_RAY_CAST_MISSED:   return dmPhysicsDDF::RayCastMissed::m_DDFDescriptor->m_NameHash;
+        }
+        assert(false);
+        return 0;
     }
 
     void RunBatchedEventCallback(dmScript::LuaCallbackInfo* cbk, uint32_t count, PhysicsMessage* infos, const uint8_t* payload)
@@ -1891,6 +2109,14 @@ namespace dmGameSystem
             return;
         }
 
+        // All vector3 values in the batch use the same metatable. Fetch it once
+        // instead of looking it up in the Lua registry for every vector value.
+        luaL_getmetatable(L, "vector3");
+        const int vector3_metatable_index = lua_gettop(L);
+
+        PhysicsLuaKeys keys;
+        PushPhysicsLuaKeys(L, &keys);
+
         lua_createtable(L, count, 0);
         // -1: events table
 
@@ -1899,31 +2125,29 @@ namespace dmGameSystem
             PhysicsMessage& msg = infos[i];
             void* data = (void*)&payload[msg.m_Offset];
 
-            if (msg.m_Descriptor->m_NameHash == dmPhysicsDDF::CollisionEvent::m_DDFDescriptor->m_NameHash)
+            switch (msg.m_Type)
             {
-                PushCollisionEvent(L, (dmPhysicsDDF::CollisionEvent*)data);
-            }
-            else if (msg.m_Descriptor->m_NameHash == dmPhysicsDDF::ContactPointEvent::m_DDFDescriptor->m_NameHash)
-            {
-                PushContactPointEvent(L, (dmPhysicsDDF::ContactPointEvent*)data);
-            }
-            else if (msg.m_Descriptor->m_NameHash == dmPhysicsDDF::TriggerEvent::m_DDFDescriptor->m_NameHash)
-            {
-                PushTriggerEvent(L, (dmPhysicsDDF::TriggerEvent*)data);
-            }
-            else if (msg.m_Descriptor->m_NameHash == dmPhysicsDDF::RayCastResponse::m_DDFDescriptor->m_NameHash)
-            {
-                PushRayCastResponse(L, (dmPhysicsDDF::RayCastResponse*)data);
-            }
-            else if (msg.m_Descriptor->m_NameHash == dmPhysicsDDF::RayCastMissed::m_DDFDescriptor->m_NameHash)
-            {
-                PushRayCastMissed(L, (dmPhysicsDDF::RayCastMissed*)data);
+                case PHYSICS_MESSAGE_TYPE_COLLISION:
+                    PushCollisionEvent(L, (dmPhysicsDDF::CollisionEvent*)data, vector3_metatable_index, keys);
+                    break;
+                case PHYSICS_MESSAGE_TYPE_CONTACT_POINT:
+                    PushContactPointEvent(L, (dmPhysicsDDF::ContactPointEvent*)data, vector3_metatable_index, keys);
+                    break;
+                case PHYSICS_MESSAGE_TYPE_TRIGGER:
+                    PushTriggerEvent(L, (dmPhysicsDDF::TriggerEvent*)data, keys);
+                    break;
+                case PHYSICS_MESSAGE_TYPE_RAY_CAST_RESPONSE:
+                    PushRayCastResponse(L, (dmPhysicsDDF::RayCastResponse*)data, keys);
+                    break;
+                case PHYSICS_MESSAGE_TYPE_RAY_CAST_MISSED:
+                    PushRayCastMissed(L, (dmPhysicsDDF::RayCastMissed*)data, keys);
+                    break;
             }
             // -2: events table
             // -1: event
 
-            dmScript::PushHash(L, msg.m_Descriptor->m_NameHash);
-            lua_setfield(L, -2, "type");
+            dmScript::PushHash(L, GetPhysicsMessageNameHash(msg.m_Type));
+            SetPhysicsLuaField(L, lua_gettop(L) - 1, keys, PHYSICS_LUA_KEY_TYPE);
             // -2: events table
             // -1: event
 
@@ -1932,6 +2156,11 @@ namespace dmGameSystem
             // -1: events table
         }
         // -1: events table
+
+        // Move the result below the cached metatable and keys and then discard
+        // all cached stack values before invoking the callback.
+        lua_insert(L, vector3_metatable_index);
+        lua_settop(L, vector3_metatable_index);
 
         {
             DM_PROFILE("PCall");
@@ -1975,6 +2204,8 @@ namespace dmGameSystem
 
     void ScriptPhysicsRegister(const ScriptLibContext& context)
     {
+        RegisterPhysicsDDFDecoders();
+
         lua_State* L = context.m_LuaState;
         luaL_register(L, "physics", PHYSICS_FUNCTIONS);
 

--- a/engine/gamesys/src/gamesys/test/test_gamesys_physics.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys_physics.cpp
@@ -1,6 +1,8 @@
 #include <test_script.h>
+#include <stddef.h>
 #include <dlib/dstrings.h>
 #include <dlib/time.h>
+#include <gamesys/components/comp_collision_object.h>
 #include <gamesys/physics_ddf.h>
 
 #include "test_gamesys.h"
@@ -16,6 +18,92 @@ static void AssertLua(lua_State* L, const char* source)
         lua_pop(L, 1);
     }
     ASSERT_EQ(0, result);
+}
+
+struct PhysicsCallbackTestInstance
+{
+    int      m_ContextTableRef;
+    uint32_t m_UniqueScriptId;
+};
+
+static int GetPhysicsCallbackTestContextTableRef(lua_State* L)
+{
+    PhysicsCallbackTestInstance* instance = (PhysicsCallbackTestInstance*) lua_touserdata(L, 1);
+    lua_pushnumber(L, instance->m_ContextTableRef);
+    return 1;
+}
+
+static int GetPhysicsCallbackTestUniqueScriptId(lua_State* L)
+{
+    PhysicsCallbackTestInstance* instance = (PhysicsCallbackTestInstance*) lua_touserdata(L, 1);
+    lua_pushinteger(L, instance->m_UniqueScriptId);
+    return 1;
+}
+
+static int IsPhysicsCallbackTestInstanceValid(lua_State* L)
+{
+    lua_pushboolean(L, lua_touserdata(L, 1) != 0);
+    return 1;
+}
+
+static const luaL_reg PHYSICS_CALLBACK_TEST_INSTANCE_METHODS[] =
+{
+    { 0, 0 }
+};
+
+static const luaL_reg PHYSICS_CALLBACK_TEST_INSTANCE_META[] =
+{
+    { dmScript::META_TABLE_IS_VALID, IsPhysicsCallbackTestInstanceValid },
+    { dmScript::META_GET_INSTANCE_CONTEXT_TABLE_REF, GetPhysicsCallbackTestContextTableRef },
+    { dmScript::META_GET_UNIQUE_SCRIPT_ID, GetPhysicsCallbackTestUniqueScriptId },
+    { 0, 0 }
+};
+
+struct PhysicsTestCallback
+{
+    dmScript::LuaCallbackInfo* m_Callback;
+    int                        m_InstanceRef;
+    int                        m_ContextTableRef;
+    int                        m_PreviousInstanceRef;
+};
+
+static PhysicsTestCallback CreatePhysicsTestCallback(lua_State* L, const char* function_name)
+{
+    dmScript::GetInstance(L);
+    int previous_instance_ref = dmScript::Ref(L, LUA_REGISTRYINDEX);
+
+    dmScript::RegisterUserType(L, "PhysicsCallbackTestInstance",
+                               PHYSICS_CALLBACK_TEST_INSTANCE_METHODS,
+                               PHYSICS_CALLBACK_TEST_INSTANCE_META);
+
+    PhysicsCallbackTestInstance* instance = (PhysicsCallbackTestInstance*) lua_newuserdata(L, sizeof(PhysicsCallbackTestInstance));
+    luaL_getmetatable(L, "PhysicsCallbackTestInstance");
+    lua_setmetatable(L, -2);
+    lua_newtable(L);
+    instance->m_ContextTableRef = dmScript::Ref(L, LUA_REGISTRYINDEX);
+    instance->m_UniqueScriptId = dmScript::GenerateUniqueScriptId();
+    int instance_ref = dmScript::Ref(L, LUA_REGISTRYINDEX);
+
+    lua_rawgeti(L, LUA_REGISTRYINDEX, instance_ref);
+    dmScript::SetInstance(L);
+
+    lua_getglobal(L, function_name);
+    dmScript::LuaCallbackInfo* callback = dmScript::CreateCallback(L, -1);
+    lua_pop(L, 1);
+
+    PhysicsTestCallback result = { callback, instance_ref, instance->m_ContextTableRef, previous_instance_ref };
+    return result;
+}
+
+static void DestroyPhysicsTestCallback(lua_State* L, PhysicsTestCallback* callback)
+{
+    dmScript::DestroyCallback(callback->m_Callback);
+    dmScript::Unref(L, LUA_REGISTRYINDEX, callback->m_InstanceRef);
+    dmScript::Unref(L, LUA_REGISTRYINDEX, callback->m_ContextTableRef);
+
+    lua_rawgeti(L, LUA_REGISTRYINDEX, callback->m_PreviousInstanceRef);
+    dmScript::SetInstance(L);
+    dmScript::Unref(L, LUA_REGISTRYINDEX, callback->m_PreviousInstanceRef);
 }
 
 static void RunPhysicsScriptTest(dmResource::HFactory factory, dmGameObject::HCollection collection, dmGameObject::UpdateContext* update_context,
@@ -264,6 +352,113 @@ TEST_F(ComponentTest, PhysicsDDFDecoderTest)
     lua_pushnil(L); lua_setglobal(L, "decoded_ray");
     lua_pushnil(L); lua_setglobal(L, "decoded_missed");
     lua_pushnil(L); lua_setglobal(L, "decoded_velocity");
+}
+
+TEST_F(ComponentTest, PhysicsBatchedEventDecoderTest)
+{
+    lua_State* L = dmScript::GetLuaState(m_ScriptContext);
+    AssertLua(L,
+        "function capture_physics_events(self, events)\n"
+        "    decoded_physics_events = events\n"
+        "end\n");
+
+    PhysicsTestCallback callback = CreatePhysicsTestCallback(L, "capture_physics_events");
+    ASSERT_NE((dmScript::LuaCallbackInfo*) 0, callback.m_Callback);
+
+    struct PhysicsEventBatchPayload
+    {
+        alignas(16) dmPhysicsDDF::CollisionEvent    m_Collision;
+        alignas(16) dmPhysicsDDF::ContactPointEvent m_Contact;
+        alignas(16) dmPhysicsDDF::TriggerEvent      m_Trigger;
+        alignas(16) dmPhysicsDDF::RayCastResponse   m_RayCastResponse;
+        alignas(16) dmPhysicsDDF::RayCastMissed     m_RayCastMissed;
+    } payload = {};
+
+    payload.m_Collision.m_A.m_Position = Point3(1.0f, 2.0f, 3.0f);
+    payload.m_Collision.m_A.m_Id = dmHashString64("collision_a");
+    payload.m_Collision.m_A.m_Group = dmHashString64("group_a");
+    payload.m_Collision.m_B.m_Position = Point3(4.0f, 5.0f, 6.0f);
+    payload.m_Collision.m_B.m_Id = dmHashString64("collision_b");
+    payload.m_Collision.m_B.m_Group = dmHashString64("group_b");
+
+    payload.m_Contact.m_A.m_Position = Point3(7.0f, 8.0f, 9.0f);
+    payload.m_Contact.m_A.m_InstancePosition = Point3(10.0f, 11.0f, 12.0f);
+    payload.m_Contact.m_A.m_Normal = Vector3(0.0f, 1.0f, 0.0f);
+    payload.m_Contact.m_A.m_RelativeVelocity = Vector3(1.0f, 2.0f, 3.0f);
+    payload.m_Contact.m_A.m_Mass = 1.25f;
+    payload.m_Contact.m_A.m_Id = dmHashString64("contact_a");
+    payload.m_Contact.m_A.m_Group = dmHashString64("group_a");
+    payload.m_Contact.m_B.m_Position = Point3(13.0f, 14.0f, 15.0f);
+    payload.m_Contact.m_B.m_InstancePosition = Point3(16.0f, 17.0f, 18.0f);
+    payload.m_Contact.m_B.m_Normal = Vector3(0.0f, -1.0f, 0.0f);
+    payload.m_Contact.m_B.m_RelativeVelocity = Vector3(-1.0f, -2.0f, -3.0f);
+    payload.m_Contact.m_B.m_Mass = 2.5f;
+    payload.m_Contact.m_B.m_Id = dmHashString64("contact_b");
+    payload.m_Contact.m_B.m_Group = dmHashString64("group_b");
+    payload.m_Contact.m_Distance = 0.25f;
+    payload.m_Contact.m_AppliedImpulse = 3.5f;
+
+    payload.m_Trigger.m_Enter = true;
+    payload.m_Trigger.m_A.m_Id = dmHashString64("trigger_a");
+    payload.m_Trigger.m_A.m_Group = dmHashString64("group_a");
+    payload.m_Trigger.m_B.m_Id = dmHashString64("trigger_b");
+    payload.m_Trigger.m_B.m_Group = dmHashString64("group_b");
+
+    payload.m_RayCastResponse.m_Fraction = 0.75f;
+    payload.m_RayCastResponse.m_Position = Point3(19.0f, 20.0f, 21.0f);
+    payload.m_RayCastResponse.m_Normal = Vector3(0.0f, 0.0f, 1.0f);
+    payload.m_RayCastResponse.m_Id = dmHashString64("ray_id");
+    payload.m_RayCastResponse.m_Group = dmHashString64("ray_group");
+    payload.m_RayCastResponse.m_RequestId = 42;
+    payload.m_RayCastMissed.m_RequestId = 43;
+
+    dmGameSystem::PhysicsMessage messages[] =
+    {
+        { (uint32_t) offsetof(PhysicsEventBatchPayload, m_Collision),       dmGameSystem::PHYSICS_MESSAGE_TYPE_COLLISION },
+        { (uint32_t) offsetof(PhysicsEventBatchPayload, m_Contact),         dmGameSystem::PHYSICS_MESSAGE_TYPE_CONTACT_POINT },
+        { (uint32_t) offsetof(PhysicsEventBatchPayload, m_Trigger),         dmGameSystem::PHYSICS_MESSAGE_TYPE_TRIGGER },
+        { (uint32_t) offsetof(PhysicsEventBatchPayload, m_RayCastResponse), dmGameSystem::PHYSICS_MESSAGE_TYPE_RAY_CAST_RESPONSE },
+        { (uint32_t) offsetof(PhysicsEventBatchPayload, m_RayCastMissed),   dmGameSystem::PHYSICS_MESSAGE_TYPE_RAY_CAST_MISSED },
+    };
+
+    dmGameSystem::RunBatchedEventCallback(callback.m_Callback, DM_ARRAY_SIZE(messages), messages, (const uint8_t*) &payload);
+
+    AssertLua(L,
+        "local events = decoded_physics_events\n"
+        "assert(#events == 5)\n"
+        "assert(events[1].type == hash('collision_event'))\n"
+        "assert(events[1].a.position == vmath.vector3(1, 2, 3))\n"
+        "assert(events[1].a.id == hash('collision_a') and events[1].a.group == hash('group_a'))\n"
+        "assert(events[1].b.position == vmath.vector3(4, 5, 6))\n"
+        "assert(events[1].b.id == hash('collision_b') and events[1].b.group == hash('group_b'))\n"
+        "assert(events[2].type == hash('contact_point_event'))\n"
+        "assert(events[2].a.position == vmath.vector3(7, 8, 9))\n"
+        "assert(events[2].a.instance_position == vmath.vector3(10, 11, 12))\n"
+        "assert(events[2].a.normal == vmath.vector3(0, 1, 0))\n"
+        "assert(events[2].a.relative_velocity == vmath.vector3(1, 2, 3))\n"
+        "assert(events[2].a.mass == 1.25)\n"
+        "assert(events[2].a.id == hash('contact_a') and events[2].a.group == hash('group_a'))\n"
+        "assert(events[2].b.position == vmath.vector3(13, 14, 15))\n"
+        "assert(events[2].b.instance_position == vmath.vector3(16, 17, 18))\n"
+        "assert(events[2].b.normal == vmath.vector3(0, -1, 0))\n"
+        "assert(events[2].b.relative_velocity == vmath.vector3(-1, -2, -3))\n"
+        "assert(events[2].b.mass == 2.5)\n"
+        "assert(events[2].b.id == hash('contact_b') and events[2].b.group == hash('group_b'))\n"
+        "assert(events[2].distance == 0.25 and events[2].applied_impulse == 3.5)\n"
+        "assert(events[3].type == hash('trigger_event') and events[3].enter)\n"
+        "assert(events[3].a.id == hash('trigger_a') and events[3].a.group == hash('group_a'))\n"
+        "assert(events[3].b.id == hash('trigger_b') and events[3].b.group == hash('group_b'))\n"
+        "assert(events[4].type == hash('ray_cast_response'))\n"
+        "assert(events[4].fraction == 0.75)\n"
+        "assert(events[4].position == vmath.vector3(19, 20, 21))\n"
+        "assert(events[4].normal == vmath.vector3(0, 0, 1))\n"
+        "assert(events[4].id == hash('ray_id') and events[4].group == hash('ray_group'))\n"
+        "assert(events[4].request_id == 42)\n"
+        "assert(events[5].type == hash('ray_cast_missed') and events[5].request_id == 43)\n");
+
+    lua_pushnil(L); lua_setglobal(L, "decoded_physics_events");
+    lua_pushnil(L); lua_setglobal(L, "capture_physics_events");
+    DestroyPhysicsTestCallback(L, &callback);
 }
 
 /* Update mass for physics collision object */

--- a/engine/gamesys/src/gamesys/test/test_gamesys_physics.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys_physics.cpp
@@ -1,10 +1,22 @@
 #include <test_script.h>
 #include <dlib/dstrings.h>
 #include <dlib/time.h>
+#include <gamesys/physics_ddf.h>
 
 #include "test_gamesys.h"
 
 using namespace dmVMath;
+
+static void AssertLua(lua_State* L, const char* source)
+{
+    int result = luaL_dostring(L, source);
+    if (result != 0)
+    {
+        dmLogError("Lua assertion failed: %s", lua_tostring(L, -1));
+        lua_pop(L, 1);
+    }
+    ASSERT_EQ(0, result);
+}
 
 static void RunPhysicsScriptTest(dmResource::HFactory factory, dmGameObject::HCollection collection, dmGameObject::UpdateContext* update_context,
                                  dmScript::HContext script_context, const char* prototype_path, const char* instance_path)
@@ -153,6 +165,105 @@ TEST_F(ComponentTest, PhysicsListenerTest)
 
     ASSERT_TRUE(dmGameObject::Final(m_Collection));
 
+}
+
+TEST_F(ComponentTest, PhysicsDDFDecoderTest)
+{
+    lua_State* L = dmScript::GetLuaState(m_ScriptContext);
+
+    dmPhysicsDDF::CollisionResponse collision = {};
+    collision.m_OtherId = dmHashString64("other");
+    collision.m_Group = dmHashString64("group");
+    collision.m_OtherPosition = Point3(1.0f, 2.0f, 3.0f);
+    collision.m_OtherGroup = dmHashString64("other_group");
+    collision.m_OwnGroup = dmHashString64("own_group");
+    dmScript::PushDDF(L, dmPhysicsDDF::CollisionResponse::m_DDFDescriptor, (const char*)&collision, false);
+    lua_setglobal(L, "decoded_collision");
+
+    dmPhysicsDDF::ContactPointResponse contact = {};
+    contact.m_Position = Point3(4.0f, 5.0f, 6.0f);
+    contact.m_Normal = Vector3(0.0f, 1.0f, 0.0f);
+    contact.m_RelativeVelocity = Vector3(7.0f, 8.0f, 9.0f);
+    contact.m_Distance = 0.25f;
+    contact.m_AppliedImpulse = 2.0f;
+    contact.m_LifeTime = 3.0f;
+    contact.m_Mass = 4.0f;
+    contact.m_OtherMass = 5.0f;
+    contact.m_OtherId = dmHashString64("other");
+    contact.m_OtherPosition = Point3(10.0f, 11.0f, 12.0f);
+    contact.m_Group = dmHashString64("group");
+    contact.m_OtherGroup = dmHashString64("other_group");
+    contact.m_OwnGroup = dmHashString64("own_group");
+    dmScript::PushDDF(L, dmPhysicsDDF::ContactPointResponse::m_DDFDescriptor, (const char*)&contact, false);
+    lua_setglobal(L, "decoded_contact");
+
+    dmPhysicsDDF::TriggerResponse trigger = {};
+    trigger.m_OtherId = dmHashString64("other");
+    trigger.m_Enter = true;
+    trigger.m_Group = dmHashString64("group");
+    trigger.m_OtherGroup = dmHashString64("other_group");
+    trigger.m_OwnGroup = dmHashString64("own_group");
+    dmScript::PushDDF(L, dmPhysicsDDF::TriggerResponse::m_DDFDescriptor, (const char*)&trigger, false);
+    lua_setglobal(L, "decoded_trigger");
+
+    dmPhysicsDDF::RayCastResponse ray = {};
+    ray.m_Fraction = 0.5f;
+    ray.m_Position = Point3(13.0f, 14.0f, 15.0f);
+    ray.m_Normal = Vector3(0.0f, 0.0f, 1.0f);
+    ray.m_Id = dmHashString64("other");
+    ray.m_Group = dmHashString64("group");
+    ray.m_RequestId = 17;
+    dmScript::PushDDF(L, dmPhysicsDDF::RayCastResponse::m_DDFDescriptor, (const char*)&ray, false);
+    lua_setglobal(L, "decoded_ray");
+
+    dmPhysicsDDF::RayCastMissed missed = {};
+    missed.m_RequestId = 18;
+    dmScript::PushDDF(L, dmPhysicsDDF::RayCastMissed::m_DDFDescriptor, (const char*)&missed, false);
+    lua_setglobal(L, "decoded_missed");
+
+    dmPhysicsDDF::VelocityResponse velocity = {};
+    velocity.m_LinearVelocity = Vector3(1.0f, 2.0f, 3.0f);
+    velocity.m_AngularVelocity = Vector3(4.0f, 5.0f, 6.0f);
+    dmScript::PushDDF(L, dmPhysicsDDF::VelocityResponse::m_DDFDescriptor, (const char*)&velocity, false);
+    lua_setglobal(L, "decoded_velocity");
+
+    AssertLua(L,
+        "assert(decoded_collision.other_id == hash('other'))\n"
+        "assert(decoded_collision.group == hash('group'))\n"
+        "assert(decoded_collision.other_position == vmath.vector3(1, 2, 3))\n"
+        "assert(decoded_collision.other_group == hash('other_group'))\n"
+        "assert(decoded_collision.own_group == hash('own_group'))\n"
+        "assert(decoded_contact.position == vmath.vector3(4, 5, 6))\n"
+        "assert(decoded_contact.normal == vmath.vector3(0, 1, 0))\n"
+        "assert(decoded_contact.relative_velocity == vmath.vector3(7, 8, 9))\n"
+        "assert(decoded_contact.distance == 0.25)\n"
+        "assert(decoded_contact.applied_impulse == 2)\n"
+        "assert(decoded_contact.life_time == 3)\n"
+        "assert(decoded_contact.mass == 4)\n"
+        "assert(decoded_contact.other_mass == 5)\n"
+        "assert(decoded_contact.other_id == hash('other'))\n"
+        "assert(decoded_contact.other_position == vmath.vector3(10, 11, 12))\n"
+        "assert(decoded_contact.group == hash('group'))\n"
+        "assert(decoded_contact.other_group == hash('other_group'))\n"
+        "assert(decoded_contact.own_group == hash('own_group'))\n"
+        "assert(decoded_trigger.other_id == hash('other') and decoded_trigger.enter)\n"
+        "assert(decoded_trigger.group == hash('group'))\n"
+        "assert(decoded_trigger.other_group == hash('other_group'))\n"
+        "assert(decoded_trigger.own_group == hash('own_group'))\n"
+        "assert(decoded_ray.fraction == 0.5)\n"
+        "assert(decoded_ray.position == vmath.vector3(13, 14, 15))\n"
+        "assert(decoded_ray.normal == vmath.vector3(0, 0, 1))\n"
+        "assert(decoded_ray.id == hash('other') and decoded_ray.group == hash('group'))\n"
+        "assert(decoded_ray.request_id == 17 and decoded_missed.request_id == 18)\n"
+        "assert(decoded_velocity.linear_velocity == vmath.vector3(1, 2, 3))\n"
+        "assert(decoded_velocity.angular_velocity == vmath.vector3(4, 5, 6))\n");
+
+    lua_pushnil(L); lua_setglobal(L, "decoded_collision");
+    lua_pushnil(L); lua_setglobal(L, "decoded_contact");
+    lua_pushnil(L); lua_setglobal(L, "decoded_trigger");
+    lua_pushnil(L); lua_setglobal(L, "decoded_ray");
+    lua_pushnil(L); lua_setglobal(L, "decoded_missed");
+    lua_pushnil(L); lua_setglobal(L, "decoded_velocity");
 }
 
 /* Update mass for physics collision object */


### PR DESCRIPTION
We improved the physics message dispatch performance from the engine to Lua.
It improves regular per-message callbacks as well as batches sent to the physics listener.

Fixes: https://github.com/defold/defold/issues/12979

### Technical changes

This PR optimizes both physics-to-Lua delivery paths without changing the Lua API:
- One-by-one messages use specialized DDF decoders instead of reflective conversion.
- Batched events use compact message metadata, aligned payload storage, geometrically growing buffers, cached Lua field keys/vector3 metatable, and raw table writes.
- Added Lua stack-capacity handling and correctness coverage for collision, contact, trigger, ray-hit, and ray-miss batches.

1,000 messages | Before | After | Faster
-- | -- | -- | --
CollisionResponse | 361.7 µs | 353.1 µs | 2.4%
ContactPointResponse | 605.7 µs | 568.6 µs | 6.1%
Collision batch | 410.9 µs | 372.4 µs | 9.4%
Contact-point batch | 769.8 µs | 670.9 µs | 12.8%

Setup: six alternating process pairs, 40 calibrated throughput samples of at least 25 ms and 400 latency samples per process. Each review fix was performance-checked separately; none introduced a measurable regression.

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
