### PR TITLE
Fix LSP document symbols race condition when starting editor

### DIFF
--- a/editor/src/clj/editor/lsp.clj
+++ b/editor/src/clj/editor/lsp.clj
@@ -166,6 +166,8 @@
         :when (contains? languages language)]
     (set-view-node-completion-trigger-characters-tx state resource view-node)))
 
+(declare request-document-symbols)
+
 (defn- on-server-initialized [server capabilities]
   {:pre [(s/assert ::server server)
          (s/assert ::lsp.server/capabilities capabilities)]}
@@ -185,7 +187,15 @@
           (g/transact
             {:undoable false}
             (refresh-completion-trigger-characters-for-languages-tx state languages))))
-      state)))
+      (if (:document-symbol capabilities)
+        (reduce
+          (fn [state resource]
+            (if (contains? languages (resource/language resource))
+              (request-document-symbols state resource)
+              state))
+          state
+          (keys (:resource->view-node state)))
+        state))))
 
 (defprotocol ServerResponse
   (server-response-value [response])


### PR DESCRIPTION
Sometimes script files could load first before Lua LSP had a chance to finish loading so the structure pane and Jump to Symbol would not work until modifying the file.

Fixes #12951