### PR TITLE
Add new text property type

### DIFF
--- a/editor/resources/localization/en.editor_localization
+++ b/editor/resources/localization/en.editor_localization
@@ -2687,6 +2687,7 @@ error.tile-source.total-width-exceeds-image-width = The total width ("Tile Width
 error.tile-source.total-height-exceeds-image-height = The total height ("Tile Height" + "Tile Margin") is greater than the "Image" height ({total_height} vs {image_height}).
 error.property-contains-url-prohibited-characters = "{property}" should not contain special URL symbols such as "#" or ":".
 error.property-cannot-start-or-end-with-space = "{property}" should not start or end with a space character.
+error.property-cannot-contain-nul = "{property}" cannot contain NUL characters.
 error.property-cannot-be-negative = "{property}" cannot be negative.
 error.property-must-be-greater-than-zero = "{property}" must be greater than zero.
 error.property-must-be-at-least = "{property}" must be at least {min}.

--- a/editor/src/clj/editor/code/script_compilation.clj
+++ b/editor/src/clj/editor/code/script_compilation.clj
@@ -89,8 +89,14 @@
     (workspace->extensions workspace evaluation-context)))
 
 (defn script-property-edit-type [workspace prop-type resource-kind script-property-type evaluation-context]
-  (let [base-map (if (= resource/Resource prop-type)
+  (let [base-map (cond
+                   (= resource/Resource prop-type)
                    {:type prop-type :ext (resource-kind-extensions workspace resource-kind evaluation-context)}
+
+                   (= :script-property-type-text script-property-type)
+                   {:type :multi-line-text}
+
+                   :else
                    {:type prop-type})]
     (assoc base-map :script-property-type script-property-type)))
 
@@ -115,7 +121,15 @@
                                           "resource" (resource/proj-path resource)}))))))
 
 (defn validate-value-against-edit-type [node-id prop-kw prop-name value edit-type]
-  (when (= resource/Resource (:type edit-type))
+  (cond
+    (and (= :script-property-type-text (:script-property-type edit-type))
+         (string? value)
+         (not= -1 (.indexOf ^String value (int \u0000))))
+    (g/->error node-id prop-kw :fatal value
+               (localization/message "error.property-cannot-contain-nul"
+                                     {"property" (validation/format-name prop-name)}))
+
+    (= resource/Resource (:type edit-type))
     (resource-assignment-error node-id prop-kw prop-name value (:ext edit-type))))
 
 (defn lua-info->script-properties [lua-info]

--- a/editor/styling/stylesheets/modules/_extensions.scss
+++ b/editor/styling/stylesheets/modules/_extensions.scss
@@ -153,6 +153,11 @@ $ext-line-height: 26px;
         -fx-highlight-fill: -df-background-input;
         -fx-highlight-text-fill: -df-text-selected;
         -fx-padding: 1px 1px;
+        &:readonly {
+            -fx-text-fill: -df-text-dark;
+            -fx-text-inner-color: -df-text-dark;
+            -fx-highlight-text-fill: -df-text-dark;
+        }
         &:hover { -fx-border-color: -df-component-light; }
         &:focused {
             -fx-border-width: 1px 1px 2px 1px;

--- a/editor/test/editor/lua_parser_test.clj
+++ b/editor/test/editor/lua_parser_test.clj
@@ -195,6 +195,8 @@
               {:type :script-property-type-number :value -4.0e-10}
               {:type :script-property-type-text :value "foo"}
               {:type :script-property-type-text :value "bar"}
+              {:type :script-property-type-text :value "Spelare å\nsecond line"}
+              {:type :script-property-type-text :value "å"}
               {:type :script-property-type-hash :value ""}
               {:type :script-property-type-hash :value "aBc3"}
               {:type :script-property-type-url :value ""}
@@ -244,6 +246,8 @@
                                        "go.property(\"test\", -4.0e-10)"
                                        "go.property(\"test\", 'foo')"
                                        "go.property(\"test\", \"bar\")"
+                                       "go.property(\"test\", [[Spelare å\nsecond line]])"
+                                       "go.property(\"test\", \"\\xC3\\xA5\")"
                                        "go.property(\"test\", hash(''))"
                                        "go.property(\"test\", hash('aBc3'))"
                                        "go.property(\"test\", msg.url())"

--- a/editor/test/integration/script_properties_test.clj
+++ b/editor/test/integration/script_properties_test.clj
@@ -108,7 +108,18 @@
       (is (overridden? script-c "number"))
       (clear! script-c "number")
       (is (= 1.0 (prop script-c "number")))
-      (is (not (overridden? script-c "number"))))))
+      (is (not (overridden? script-c "number")))
+
+      (is (= "game object text å\nsecond line" (prop script-c "text")))
+      (is (= :multi-line-text
+             (get-in (g/node-value script-c :_properties)
+                     [:properties :__text :edit-type :type])))
+      (prop! script-c "text" "edited text å\nsecond line")
+      (is (= "edited text å\nsecond line" (prop script-c "text")))
+      (is (overridden? script-c "text"))
+      (clear! script-c "text")
+      (is (= "script text å\nsecond line" (prop script-c "text")))
+      (is (not (overridden? script-c "text"))))))
 
 (deftest script-properties-broken-component
   (tu/with-loaded-project
@@ -141,6 +152,7 @@
                                           "material" (workspace/resolve-workspace-resource workspace "/script/resources/from_props_game_object.material")
                                           "number" 2.0
                                           "quat" [180.0 0.0 0.0]
+                                          "text" "game object text å\nsecond line"
                                           "texture" (workspace/resolve-workspace-resource workspace "/script/resources/from_props_game_object.png")
                                           "url" "/url"
                                           "vec3" [1.0 2.0 3.0]
@@ -159,7 +171,12 @@
               script-c (:node-id outline)]
           (is (:outline-overridden? outline))
           (is (= val (prop script-c "number")))
-          (is (overridden? script-c "number")))))))
+          (is (overridden? script-c "number")))))
+    (doseq [[path value] [[[0 0] "collection text å\nsecond line"]
+                          [[1 0] "embedded text å\nsecond line"]]]
+      (let [script-c (:node-id (tu/outline (tu/resource-node project "/collection/props.collection") path))]
+        (is (= value (prop script-c "text")))
+        (is (overridden? script-c "text"))))))
 
 (deftest script-properties-broken-collection
   (tu/with-loaded-project
@@ -207,6 +224,7 @@
                                             "material" (workspace/resolve-workspace-resource workspace "/script/resources/from_props_game_object.material")
                                             "number" 3.0
                                             "quat" [180.0 0.0 0.0]
+                                            "text" "collection text å\nsecond line"
                                             "texture" (workspace/resolve-workspace-resource workspace "/script/resources/from_props_collection.png")
                                             "url" "/url2"
                                             "vec3" [1.0 2.0 3.0]
@@ -332,6 +350,58 @@
               (when (= wanted-id item-id)
                 item)))
           items)))
+
+(deftest edit-text-script-property-test
+  (with-clean-system
+    (let [workspace (tu/setup-scratch-workspace! world "test/resources/empty_project")
+          project (tu/setup-project! workspace)
+          build-output (partial tu/build-output project)
+          props-script (doto (tu/make-resource-node! project "/props.script")
+                         (edit-script! ["go.property('text', 'script text å\\nsecond line')"]))
+          props-game-object (tu/make-resource-node! project "/props.go")
+          props-script-component (tu/add-referenced-component! props-game-object (resource-node/resource props-script))
+          default-value "script text å\nsecond line"
+          override-value "game object text ö\nsecond line"]
+      (with-open [_ (tu/make-directory-deleter (workspace/project-directory workspace))]
+        (testing "Script default"
+          (let [text-property (:__text (properties props-script))]
+            (is (= default-value (:value text-property)))
+            (is (= g/Str (:type text-property)))
+            (is (= :multi-line-text (get-in text-property [:edit-type :type]))))
+          (with-open [_ (tu/build! props-script)]
+            (let [built-script (protobuf/bytes->map-with-defaults Lua$LuaModule (build-output "/props.script"))]
+              (is (= default-value
+                     (get (tu/unpack-property-declarations (:properties built-script)) "text"))))))
+
+        (testing "Game object override"
+          (edit-property! props-script-component :__text override-value)
+          (is (= override-value (prop props-script-component "text")))
+          (is (tu/prop-overridden? props-script-component :__text))
+
+          (let [saved-game-object (save-value props-game-object)
+                saved-script-component (find-corresponding (:components saved-game-object) props-script-component)]
+            (is (= [{:id "text"
+                     :value override-value
+                     :type :property-type-text}]
+                   (:properties saved-script-component))))
+
+          (with-open [_ (tu/build! props-game-object)]
+            (let [built-game-object (protobuf/bytes->map-with-defaults GameObject$PrototypeDesc (build-output "/props.go"))
+                  built-script-component (find-corresponding (:components built-game-object) props-script-component)]
+              (is (= override-value
+                     (get (tu/unpack-property-declarations (:property-decls built-script-component)) "text")))))
+
+          (reset-property! props-script-component :__text)
+          (is (= default-value (prop props-script-component "text")))
+          (is (not (tu/prop-overridden? props-script-component :__text))))
+
+        (testing "Embedded NUL validation"
+          (edit-property! props-script-component :__text "invalid\u0000text")
+          (let [property-error (tu/prop-error props-script-component :__text)]
+            (is (g/error? property-error))
+            (is (= (localization/message "error.property-cannot-contain-nul" {"property" "Text"})
+                   (:message property-error))))
+          (is (g/error? (tu/build-error! props-game-object))))))))
 
 (def ^:private error-item-open-info-without-opts (comp pop :args build-errors-view/error-item-open-info))
 

--- a/editor/test/resources/test_project/collection/props.collection
+++ b/editor/test/resources/test_project/collection/props.collection
@@ -35,6 +35,11 @@ instances {
       value: "/script/resources/from_props_collection.png"
       type: PROPERTY_TYPE_HASH
     }
+    properties {
+      id: "text"
+      value: "collection text å\nsecond line"
+      type: PROPERTY_TYPE_TEXT
+    }
   }
   scale3 {
     x: 1.0
@@ -78,6 +83,11 @@ embedded_instances {
   "    id: \"texture\"\n"
   "    value: \"/script/resources/from_props_collection.png\"\n"
   "    type: PROPERTY_TYPE_HASH\n"
+  "  }\n"
+  "  properties {\n"
+  "    id: \"text\"\n"
+  "    value: \"embedded text å\\nsecond line\"\n"
+  "    type: PROPERTY_TYPE_TEXT\n"
   "  }\n"
   "}\n"
   ""

--- a/editor/test/resources/test_project/game_object/props.go
+++ b/editor/test/resources/test_project/game_object/props.go
@@ -48,6 +48,11 @@ components {
     type: PROPERTY_TYPE_BOOLEAN
   }
   properties {
+    id: "text"
+    value: "game object text å\nsecond line"
+    type: PROPERTY_TYPE_TEXT
+  }
+  properties {
     id: "atlas"
     value: "/script/resources/from_props_game_object.atlas"
     type: PROPERTY_TYPE_HASH

--- a/editor/test/resources/test_project/script/props.script
+++ b/editor/test/resources/test_project/script/props.script
@@ -19,6 +19,8 @@ go.property("vec3", vmath.vector3(0.0, 0.0, 0.0))
 go.property("quat", vmath.quat(0.0, 0.0, 0.0, 1.0))
 go.property("vec4", vmath.vector4(0.0, 0.0, 0.0, 0.0))
 go.property("bool", false)
+go.property("text", [[script text å
+second line]])
 go.property("atlas", resource.atlas("/script/resources/from_props_script.atlas"))
 go.property("material", resource.material("/script/resources/from_props_script.material"))
 go.property("texture", resource.texture("/script/resources/from_props_script.png"))


### PR DESCRIPTION
Scripts can now declare text properties with go.property(), edit and override them using a multi-line text field in the editor, and access them like other script properties at runtime.

Text properties support UTF-8 and newline characters:

```lua
go.property("greeting", "Hello!\nWelcome to the game.")

function init(self)
    print(self.greeting)

    -- Label text is now a regular component property.
    go.set("#label", "text", self.greeting)
    local label_text = go.get("#label", "text")
end
```

Text property defaults and overrides can be configured on script components in game objects and collections.

⚠️ `label.set_text()` and `label.get_text()` are now deprecated in favor of `go.set()` and `go.get()` using the label’s "text" property. The deprecated functions have not been removed and remain available for backward compatibility.

Fixes #8420

* Adds a multi-line editor control for text script properties.
* Supports text property defaults and overrides in game objects, embedded instances, and collections.
* Preserves UTF-8 and multi-line values through saving and building.
* Rejects embedded NUL characters with a validation error.
* Adds parser and integration coverage for editing, overriding, resetting, saving, and building text properties.