### PR TITLE
Use active override material to calculate correct vertex buffer capacity

### DIFF
--- a/engine/gamesys/src/gamesys/components/comp_sprite.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sprite.cpp
@@ -1769,6 +1769,34 @@ namespace dmGameSystem
         *ib_where = indices;
     }
 
+    static void EnsureVertexBufferCapacity(SpriteWorld* sprite_world, uint32_t vertex_stride, dmRender::RenderListEntry* buf, uint32_t* begin, uint32_t* end)
+    {
+        uint32_t write_offset = sprite_world->m_VertexBufferWritePtr - sprite_world->m_VertexBufferData;
+        uint32_t required_size = write_offset;
+
+        const dmArray<SpriteComponent>& components = sprite_world->m_Components.GetRawObjects();
+        for (uint32_t* i = begin; i != end; ++i)
+        {
+            uint32_t component_index = (uint32_t) buf[*i].m_UserData;
+            const SpriteComponent& component = components[component_index];
+            uint32_t remainder = required_size % vertex_stride;
+            if (remainder != 0)
+            {
+                required_size += vertex_stride - remainder;
+            }
+            required_size += component.m_VertexCount * vertex_stride;
+        }
+
+        if (required_size <= sprite_world->m_VertexMemorySize)
+        {
+            return;
+        }
+
+        sprite_world->m_VertexBufferData = (uint8_t*) realloc(sprite_world->m_VertexBufferData, required_size);
+        sprite_world->m_VertexBufferWritePtr = sprite_world->m_VertexBufferData + write_offset;
+        sprite_world->m_VertexMemorySize = required_size;
+    }
+
     static void RenderBatch(SpriteWorld* sprite_world, dmRender::HRenderContext render_context, dmRender::RenderListEntry *buf, uint32_t* begin, uint32_t* end)
     {
         DM_PROFILE("SpriteRenderBatch");
@@ -1796,6 +1824,10 @@ namespace dmGameSystem
         dmGraphics::VertexAttributeInfos material_attribute_info;
         // Same default coordinate space as the editor
         FillMaterialAttributeInfos(material, vx_decl, &material_attribute_info);
+
+        // The context material can have a larger vertex format than the component material
+        // used during update. Grow the CPU staging buffer before writing this batch.
+        EnsureVertexBufferCapacity(sprite_world, material_attribute_info.m_VertexStride, buf, begin, end);
 
         // Fill in vertex buffer
         uint8_t* vb_begin = sprite_world->m_VertexBufferWritePtr;
@@ -2148,7 +2180,7 @@ namespace dmGameSystem
         world->m_ReallocBuffers   |= vertex_memsize > world->m_VertexMemorySize || num_indices > world->m_IndexCount;
         world->m_VertexCount      = num_vertices;
         world->m_IndexCount       = num_indices;
-        world->m_VertexMemorySize = vertex_memsize;
+        world->m_VertexMemorySize = dmMath::Max(world->m_VertexMemorySize, vertex_memsize);
 
         return dmGameObject::UPDATE_RESULT_OK;
     }
@@ -2747,6 +2779,11 @@ namespace dmGameSystem
         SpriteWorld* world = (SpriteWorld*) sprite_world;
         *vx_buffer = world->m_VertexBuffer;
         *ix_buffer = world->m_IndexBuffer;
+    }
+
+    uint32_t GetSpriteWorldVertexBufferCapacity(void* sprite_world)
+    {
+        return ((SpriteWorld*) sprite_world)->m_VertexMemorySize;
     }
 
     void GetSpriteWorldDynamicAttributePool(void* sprite_world, DynamicAttributePool** pool_out)

--- a/engine/gamesys/src/gamesys/test/sprite/attribute_stride.fp
+++ b/engine/gamesys/src/gamesys/test/sprite/attribute_stride.fp
@@ -1,0 +1,6 @@
+varying vec4 var_crash_attr;
+
+void main()
+{
+    gl_FragColor = var_crash_attr;
+}

--- a/engine/gamesys/src/gamesys/test/sprite/attribute_stride.go
+++ b/engine/gamesys/src/gamesys/test/sprite/attribute_stride.go
@@ -1,0 +1,4 @@
+components {
+  id: "sprite"
+  component: "/sprite/attribute_stride.sprite"
+}

--- a/engine/gamesys/src/gamesys/test/sprite/attribute_stride.sprite
+++ b/engine/gamesys/src/gamesys/test/sprite/attribute_stride.sprite
@@ -1,0 +1,12 @@
+tile_set: "/sprite/tile_valid.tileset"
+default_animation: "anim"
+material: "/sprite/attribute_stride_scalar.material"
+attributes {
+  name: "crash_attr"
+  semantic_type: SEMANTIC_TYPE_NONE
+  data_type: TYPE_FLOAT
+  vector_type: VECTOR_TYPE_SCALAR
+  double_values {
+    v: 1.0
+  }
+}

--- a/engine/gamesys/src/gamesys/test/sprite/attribute_stride_mat4.material
+++ b/engine/gamesys/src/gamesys/test/sprite/attribute_stride_mat4.material
@@ -1,0 +1,29 @@
+name: "attribute_stride_mat4"
+tags: "tile"
+vertex_program: "/sprite/attribute_stride_mat4.vp"
+fragment_program: "/sprite/attribute_stride.fp"
+vertex_space: VERTEX_SPACE_WORLD
+attributes {
+  name: "crash_attr"
+  semantic_type: SEMANTIC_TYPE_NONE
+  data_type: TYPE_FLOAT
+  vector_type: VECTOR_TYPE_MAT4
+  double_values {
+    v: 1.0
+    v: 0.0
+    v: 0.0
+    v: 0.0
+    v: 0.0
+    v: 1.0
+    v: 0.0
+    v: 0.0
+    v: 0.0
+    v: 0.0
+    v: 1.0
+    v: 0.0
+    v: 0.0
+    v: 0.0
+    v: 0.0
+    v: 1.0
+  }
+}

--- a/engine/gamesys/src/gamesys/test/sprite/attribute_stride_mat4.vp
+++ b/engine/gamesys/src/gamesys/test/sprite/attribute_stride_mat4.vp
@@ -1,0 +1,10 @@
+attribute vec4 position;
+attribute mat4 crash_attr;
+
+varying vec4 var_crash_attr;
+
+void main()
+{
+    gl_Position = position;
+    var_crash_attr = crash_attr[0];
+}

--- a/engine/gamesys/src/gamesys/test/sprite/attribute_stride_scalar.material
+++ b/engine/gamesys/src/gamesys/test/sprite/attribute_stride_scalar.material
@@ -1,0 +1,14 @@
+name: "attribute_stride_scalar"
+tags: "tile"
+vertex_program: "/sprite/attribute_stride_scalar.vp"
+fragment_program: "/sprite/attribute_stride.fp"
+vertex_space: VERTEX_SPACE_WORLD
+attributes {
+  name: "crash_attr"
+  semantic_type: SEMANTIC_TYPE_NONE
+  data_type: TYPE_FLOAT
+  vector_type: VECTOR_TYPE_SCALAR
+  double_values {
+    v: 1.0
+  }
+}

--- a/engine/gamesys/src/gamesys/test/sprite/attribute_stride_scalar.vp
+++ b/engine/gamesys/src/gamesys/test/sprite/attribute_stride_scalar.vp
@@ -1,0 +1,10 @@
+attribute vec4 position;
+attribute float crash_attr;
+
+varying vec4 var_crash_attr;
+
+void main()
+{
+    gl_Position = position;
+    var_crash_attr = vec4(crash_attr, 0.0, 0.0, 1.0);
+}

--- a/engine/gamesys/src/gamesys/test/sprite/build.inputs
+++ b/engine/gamesys/src/gamesys/test/sprite/build.inputs
@@ -1,5 +1,7 @@
 /sprite/default.texture_profiles
 /sprite/atlas_valid_64x64.atlas
+/sprite/attribute_stride.go
+/sprite/attribute_stride_mat4.material
 /sprite/cursor.go
 /sprite/flipbook_cursor.script
 /sprite/frame_count_sprite_frame_count.go

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -2471,6 +2471,22 @@ TEST_F(SpriteTest, Slice9FlipGeometry)
     ASSERT_TRUE(dmGameObject::Final(m_Collection));
 }
 
+/*
+ * Intent:
+ * Verify that sprite vertex staging memory is grown using the active render
+ * material's vertex stride before vertex data is generated.
+ *
+ * Setup:
+ * Create a sprite whose component material has a scalar custom attribute,
+ * then draw it through a render script that overrides the material with one
+ * where the same attribute is a mat4. Confirm that the staging buffer was
+ * initially sized from the smaller component-material stride.
+ *
+ * Expected results:
+ * Rendering grows the staging buffer to fit four vertices using the larger
+ * override-material stride, and the complete vertex data is uploaded without
+ * writing beyond the allocated staging memory.
+ */
 TEST_F(SpriteTest, RenderScriptMaterialOverrideGrowsVertexBuffer)
 {
     dmHashEnableReverseHash(true);

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -118,6 +118,7 @@ namespace dmGameSystem
 {
     void DumpResourceRefs(dmGameObject::HCollection collection);
     extern void GetSpriteWorldRenderBuffers(void* world, dmRender::HBufferedRenderBuffer* vx_buffer, dmRender::HBufferedRenderBuffer* ix_buffer);
+    extern uint32_t GetSpriteWorldVertexBufferCapacity(void* sprite_world);
     extern void GetSpriteWorldDynamicAttributePool(void* sprite_world, DynamicAttributePool** pool_out);
     extern void GetSpriteComponentScale(void* sprite_component, dmVMath::Vector3* scale_out);
     extern uint16_t GetSpriteComponentAnimationIndex(void* sprite_component);
@@ -2467,6 +2468,77 @@ TEST_F(SpriteTest, Slice9FlipGeometry)
     }
 
     dmResource::Release(m_Factory, material_resource);
+    ASSERT_TRUE(dmGameObject::Final(m_Collection));
+}
+
+TEST_F(SpriteTest, RenderScriptMaterialOverrideGrowsVertexBuffer)
+{
+    dmHashEnableReverseHash(true);
+
+    dmRender::RenderContext* render_context_ptr = (dmRender::RenderContext*) m_RenderContext;
+    render_context_ptr->m_MultiBufferingRequired = 1;
+
+    dmGameSystem::MaterialResource* mat4_material_resource = 0;
+    ASSERT_EQ(dmResource::RESULT_OK, dmResource::Get(m_Factory, "/sprite/attribute_stride_mat4.materialc", (void**) &mat4_material_resource));
+
+    const char* render_script_source =
+        "function init(self)\n"
+        "    self.predicate = render.predicate({\"tile\"})\n"
+        "end\n"
+        "function update(self)\n"
+        "    render.enable_material(\"attribute_stride_mat4\")\n"
+        "    render.draw(self.predicate)\n"
+        "    render.disable_material()\n"
+        "end\n";
+    dmLuaDDF::LuaSource lua_source;
+    memset(&lua_source, 0, sizeof(lua_source));
+    lua_source.m_Script.m_Data = (uint8_t*) render_script_source;
+    lua_source.m_Script.m_Count = strlen(render_script_source);
+    lua_source.m_Bytecode.m_Data = (uint8_t*) render_script_source;
+    lua_source.m_Bytecode.m_Count = strlen(render_script_source);
+    lua_source.m_Bytecode64.m_Data = (uint8_t*) render_script_source;
+    lua_source.m_Bytecode64.m_Count = strlen(render_script_source);
+    lua_source.m_Filename = "sprite-attribute-stride-render-script";
+
+    dmRender::HRenderScript render_script = dmRender::NewRenderScript(m_RenderContext, &lua_source);
+    ASSERT_NE((dmRender::HRenderScript) 0, render_script);
+    dmRender::HRenderScriptInstance render_script_instance = dmRender::NewRenderScriptInstance(m_RenderContext, render_script);
+    ASSERT_NE((dmRender::HRenderScriptInstance) 0, render_script_instance);
+    dmRender::AddRenderScriptInstanceRenderResource(render_script_instance, "attribute_stride_mat4", (uint64_t) mat4_material_resource->m_Material, dmRender::RENDER_RESOURCE_TYPE_MATERIAL);
+    ASSERT_EQ(dmRender::RENDER_SCRIPT_RESULT_OK, dmRender::InitRenderScriptInstance(render_script_instance));
+
+    ASSERT_TRUE(dmGameObject::Init(m_Collection));
+    dmGameObject::HInstance go = Spawn(m_Factory, m_Collection, "/sprite/attribute_stride.goc", dmHashString64("/go"), 0, Point3(0, 0, 0), Quat(0, 0, 0, 1), Vector3(1, 1, 1));
+    ASSERT_NE((void*) 0, go);
+    ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+
+    dmRender::RenderListBegin(m_RenderContext);
+    dmGameObject::Render(m_Collection);
+    ASSERT_EQ(dmRender::RENDER_SCRIPT_RESULT_OK, dmRender::DispatchRenderScriptInstance(render_script_instance));
+    dmRender::RenderListEnd(m_RenderContext);
+
+    void* sprite_world = dmGameObject::GetWorld(m_Collection, dmGameObject::GetComponentTypeIndex(m_Collection, dmHashString64("spritec")));
+    ASSERT_NE((void*) 0, sprite_world);
+
+    const uint32_t vertex_count = 4;
+    dmGraphics::HVertexDeclaration mat4_vertex_declaration = dmRender::GetVertexDeclaration(mat4_material_resource->m_Material, dmGraphics::VERTEX_STEP_FUNCTION_VERTEX);
+    const uint32_t mat4_vertex_stride = dmGraphics::GetVertexDeclarationStride(mat4_vertex_declaration);
+    const uint32_t required_capacity = vertex_count * mat4_vertex_stride;
+    ASSERT_LT(dmGameSystem::GetSpriteWorldVertexBufferCapacity(sprite_world), required_capacity);
+
+    dmGraphics::BeginFrame(m_GraphicsContext);
+    ASSERT_EQ(dmRender::RENDER_SCRIPT_RESULT_OK, dmRender::UpdateRenderScriptInstance(render_script_instance, m_UpdateContext.m_DT));
+    ASSERT_EQ(required_capacity, dmGameSystem::GetSpriteWorldVertexBufferCapacity(sprite_world));
+
+    dmRender::BufferedRenderBuffer* vertex_buffer = 0;
+    dmRender::BufferedRenderBuffer* index_buffer = 0;
+    dmGameSystem::GetSpriteWorldRenderBuffers(sprite_world, &vertex_buffer, &index_buffer);
+    ASSERT_EQ(1u, vertex_buffer->m_Buffers.Size());
+    ASSERT_EQ(required_capacity, dmGraphics::GetVertexBufferSize(vertex_buffer->m_Buffers[0]));
+
+    dmRender::DeleteRenderScriptInstance(render_script_instance);
+    dmRender::DeleteRenderScript(m_RenderContext, render_script);
+    dmResource::Release(m_Factory, mat4_material_resource);
     ASSERT_TRUE(dmGameObject::Final(m_Collection));
 }
 


### PR DESCRIPTION
Fixed an issue where the vertex memory for sprites were allocated based on the sprite's own material. When the render script overrides the material that has a different vertex layout, this could cause the vertex attribute write functions to write past the buffer limits, causing an engine crash. This has now been addressed by taking the layout of the override material into account.

Fixes #12677

#### Technical changes
* Calculate sprite batch memory requirements using the active override material’s vertex stride.
* Apply the same stride alignment as CreateVertexData().
* Grow the CPU vertex staging buffer before vertex generation.
* Preserve staging-buffer capacity across updates to avoid repeated reallocations.
* Add a scalar-to-mat4 render-material override regression test and supporting test resources.