### PR TITLE
Ignore external code for CodeQL

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,4 @@
+name: "Defold CodeQL configuration"
+
+paths-ignore:
+  - "external/**"


### PR DESCRIPTION
it also requires 
>github-codeql-config-file = ./.github/codeql/codeql-config.yml
in the repro properties (I'll add it)