### PR TITLE
Make editor endpoints await command completion

### DIFF
--- a/editor/project.clj
+++ b/editor/project.clj
@@ -91,7 +91,7 @@
 
                      [com.github.ben-manes.caffeine/caffeine "3.1.2"]
 
-                     [cljfx "1.10.10"
+                     [cljfx "1.10.361"
                       :exclusions [org.clojure/clojure
                                    org.openjfx/javafx-base
                                    org.openjfx/javafx-graphics

--- a/editor/resources/localization/en.editor_localization
+++ b/editor/resources/localization/en.editor_localization
@@ -2715,6 +2715,7 @@ error.lua-preprocessing-failed = Lua preprocessing failed.\n{error}
 error.go-property-disallowed = go.property cannot be used in this file type.
 error.transpiler-compilation-failed = Compilation failed: {error}
 error.animation-set-build-failed = Failed to build {resource}: {error}
+error.bob.failed-to-save-project = Failed to save the project before invoking Bob.
 error.blend-mode-add-alpha-replaced = `{old}` is deprecated and behaves exactly like `{new}` because Defold uses premultiplied alpha. Select `{new}` instead.
 error.duplicate-instance-id = "{id}" is in use by another instance.
 error.non-unique-ids = The following ids are not unique: {ids}.

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -1517,7 +1517,9 @@
                     :task-cancelled? task-cancelled?
                     :old-artifact-map (workspace/artifact-map workspace))
       (fn [{:keys [engine] :as build-results}]
-        (if (and (handle-build-results! workspace render-build-error! build-results) launch (or engine skip-engine))
+        (if (and (handle-build-results! workspace render-build-error! build-results)
+                 launch
+                 (or engine skip-engine))
           (do
             (show-console! main-scene tool-tab-pane)
             (let [{:keys [error]} (launch-built-project! project engine project-directory prefs web-server false focus)]
@@ -1577,7 +1579,8 @@
                     :task-cancelled? task-cancelled?
                     :old-artifact-map (workspace/artifact-map workspace))
       (fn [{:keys [engine] :as build-results}]
-        (if (and (handle-build-results! workspace render-build-error! build-results) (or engine skip-engine))
+        (if (and (handle-build-results! workspace render-build-error! build-results)
+                 (or engine skip-engine))
           (let [{:keys [error target]} (launch-built-project! project engine project-directory prefs web-server true true)]
             (when (and target (nil? (debug-view/current-session debug-view)))
               (debug-view/start-debugger! debug-view project (:address target "localhost") (:instance-index target 0)))

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -1074,37 +1074,39 @@
                                    (console/start-log-pump! log-stream (make-launched-log-sink launched-target (partial on-service-url-found prefs)))))
                                last-launched-target))]
     (try
-      (cond
-        (or (not selected-target) (targets/all-launched-targets? selected-target))
-        (launch-new-engine!)
+      {:target
+       (cond
+         (or (not selected-target) (targets/all-launched-targets? selected-target))
+         (launch-new-engine!)
 
-        (not (targets/controllable-target? selected-target))
-        (do
-          (assert (targets/launched-target? selected-target))
-          (launch-new-engine!))
+         (not (targets/controllable-target? selected-target))
+         (do
+           (assert (targets/launched-target? selected-target))
+           (launch-new-engine!))
 
-        (target-cannot-swap-engine? selected-target)
-        (let [log-stream (engine/get-log-service-stream selected-target)]
-          (console/set-log-service-stream log-stream)
-          (reboot-engine! selected-target web-server debug focus))
+         (target-cannot-swap-engine? selected-target)
+         (let [log-stream (engine/get-log-service-stream selected-target)]
+           (console/set-log-service-stream log-stream)
+           (reboot-engine! selected-target web-server debug focus))
 
-        :else
-        (do
-          (assert (and (targets/controllable-target? selected-target) (targets/launched-target? selected-target)))
-          (if (= (:id engine-descriptor) (:engine-id selected-target))
-            (do
-              ;; We're running "the same" engine and can reuse the
-              ;; running process by rebooting
-              (console/reset-console-stream! (:log-stream selected-target))
-              (console/reset-remote-log-pump-thread! nil)
-              ;; Launched target log pump already
-              ;; running to keep engine process
-              ;; from halting because stdout/err is
-              ;; not consumed.
-              (reboot-engine! selected-target web-server debug focus))
-            (launch-new-engine!))))
+         :else
+         (do
+           (assert (and (targets/controllable-target? selected-target) (targets/launched-target? selected-target)))
+           (if (= (:id engine-descriptor) (:engine-id selected-target))
+             (do
+               ;; We're running "the same" engine and can reuse the
+               ;; running process by rebooting
+               (console/reset-console-stream! (:log-stream selected-target))
+               (console/reset-remote-log-pump-thread! nil)
+               ;; Launched target log pump already
+               ;; running to keep engine process
+               ;; from halting because stdout/err is
+               ;; not consumed.
+               (reboot-engine! selected-target web-server debug focus))
+             (launch-new-engine!))))}
       (catch SocketTimeoutException e
-        (debug-view/show-connect-failed-info! e (project/workspace project)))
+        (debug-view/show-connect-failed-info! e (project/workspace project))
+        {:error e})
       (catch Exception e
         (log/warn :exception e)
         (let [localization (g/with-auto-evaluation-context evaluation-context
@@ -1124,7 +1126,8 @@
                                                         (localization/message "dialog.launch-failed.target.new-local-engine"))}))}
                                  {:fx/type fxui/legacy-label
                                   :text (localization (localization/message "dialog.launch-failed.detail"))}]}
-             :content (.getMessage e)}))))))
+             :content (.getMessage e)}))
+        {:error e}))))
 
 (defn- get-cycle-detected-help-message [basis node-id]
   (let [proj-path (some-> (resource-node/owner-resource basis node-id) resource/proj-path)
@@ -1495,6 +1498,9 @@
       (workspace/save-build-cache! workspace))
     (nil? error)))
 
+(defn- exception->target-error [error]
+  (g/map->error {:severity :fatal :message (or (ex-message error) (.getName (class error)))}))
+
 (defn- build-handler [project workspace prefs web-server build-errors-view main-stage tool-tab-pane launch focus]
   (let [project-directory (workspace/project-directory workspace)
         main-scene (.getScene ^Stage main-stage)
@@ -1511,11 +1517,12 @@
                     :task-cancelled? task-cancelled?
                     :old-artifact-map (workspace/artifact-map workspace))
       (fn [{:keys [engine] :as build-results}]
-        (when (handle-build-results! workspace render-build-error! build-results)
-          (when (and launch (or engine skip-engine))
+        (if (and (handle-build-results! workspace render-build-error! build-results) launch (or engine skip-engine))
+          (do
             (show-console! main-scene tool-tab-pane)
-            (launch-built-project! project engine project-directory prefs web-server false focus)))
-        build-results))))
+            (let [{:keys [error]} (launch-built-project! project engine project-directory prefs web-server false focus)]
+              (cond-> build-results error (assoc :error (exception->target-error error)))))
+          build-results)))))
 
 (handler/defhandler :project.compile :global
   (enabled? [] (not (build-in-progress?)))
@@ -1570,11 +1577,12 @@
                     :task-cancelled? task-cancelled?
                     :old-artifact-map (workspace/artifact-map workspace))
       (fn [{:keys [engine] :as build-results}]
-        (when (handle-build-results! workspace render-build-error! build-results)
-          (when (or engine skip-engine)
-            (when-let [target (launch-built-project! project engine project-directory prefs web-server true true)]
-              (when (nil? (debug-view/current-session debug-view))
-                (debug-view/start-debugger! debug-view project (:address target "localhost") (:instance-index target 0))))))))))
+        (if (and (handle-build-results! workspace render-build-error! build-results) (or engine skip-engine))
+          (let [{:keys [error target]} (launch-built-project! project engine project-directory prefs web-server true true)]
+            (when (and target (nil? (debug-view/current-session debug-view)))
+              (debug-view/start-debugger! debug-view project (:address target "localhost") (:instance-index target 0)))
+            (cond-> build-results error (assoc :error (exception->target-error error))))
+          build-results)))))
 
 (defn- attach-debugger! [workspace project prefs debug-view render-build-error!]
   (let [[render-progress! task-cancelled?] (begin-task-progress! :build)]
@@ -1592,7 +1600,8 @@
         (when (handle-build-results! workspace render-build-error! build-results)
           (let [target (targets/selected-target prefs)]
             (when (targets/controllable-target? target)
-              (debug-view/attach! debug-view project target (:artifacts build-results)))))))))
+              (debug-view/attach! debug-view project target (:artifacts build-results)))))
+        build-results))))
 
 (handler/defhandler :debugger.start :global
   ;; NOTE: Shares a shortcut with :debug-view/continue.
@@ -1602,7 +1611,9 @@
     (not (debug-view/debugging? debug-view evaluation-context)))
   (enabled? [] (not (build-in-progress?)))
   (run [project workspace prefs web-server build-errors-view console-view debug-view main-stage tool-tab-pane localization]
-    (when (debugging-supported? project localization)
+    (if-not (debugging-supported? project localization)
+      {:error (g/map->error {:severity :fatal
+                             :message (localization/message "dialog.debugging-not-supported.header")})}
       (let [main-scene (.getScene ^Stage main-stage)
             render-build-error! (make-render-build-error main-scene tool-tab-pane build-errors-view)]
         (build-errors-view/clear-build-errors build-errors-view)
@@ -1648,15 +1659,20 @@
         bob-args (bob/build-html5-bob-options project prefs)
         out (start-new-log-pipe!)]
     (build-errors-view/clear-build-errors build-errors-view)
-    (disk/async-bob-build! render-reload-progress! render-save-progress! render-build-progress! out build-task-cancelled?
-                           render-build-error! bob-commands bob-args project changes-view
-                           (fn [successful?]
-                             (when successful?
-                               (let [url (str (http-server/local-url web-server) "/html5")]
-                                 (if (prefs/get prefs [:build :open-html5-build])
-                                   (ui/open-url url)
-                                   (console/append-console-entry! nil (format "INFO: The game is available at %s" url))))
-                               (.close out))))))
+    (future/io
+      (try
+        (let [build-results (disk/bob-build! render-reload-progress! render-save-progress! render-build-progress!
+                                             out build-task-cancelled? bob-commands bob-args project changes-view)]
+          (ui/run-now
+            (if-let [error (:error build-results)]
+              (render-build-error! error)
+              (let [url (str (http-server/local-url web-server) "/html5")]
+                (if (prefs/get prefs [:build :open-html5-build])
+                  (ui/open-url url)
+                  (console/append-console-entry! nil (format "INFO: The game is available at %s" url))))))
+          build-results)
+        (finally
+          (.close out))))))
 
 (handler/defhandler :project.clean-build-html5 :global
   (run [project prefs web-server build-errors-view changes-view main-stage tool-tab-pane localization]
@@ -1721,9 +1737,11 @@
                     :task-cancelled? task-cancelled?
                     :old-artifact-map (workspace/artifact-map workspace)
                     :prefs prefs)
-      (fn [{:keys [error artifact-map etags]}]
+      (fn [{:keys [error artifact-map etags] :as build-results}]
         (if (some? error)
-          (render-build-error! error)
+          (do
+            (render-build-error! error)
+            build-results)
           (do
             (workspace/artifact-map! workspace artifact-map)
             (workspace/etags! workspace etags)
@@ -1737,6 +1755,7 @@
                   (doseq [launched-target (targets/all-launched-targets)]
                     (engine/reload-build-resources! launched-target updated-build-resources))
                   (engine/reload-build-resources! target updated-build-resources)))
+              build-results
               (catch Exception e
                 (dialogs/make-info-dialog
                   localization
@@ -1745,7 +1764,8 @@
                    :header (localization/message
                              "dialog.hot-reload-failed.header"
                              {"engine" (targets/target-message (targets/selected-target prefs))})
-                   :content (.getMessage e)})))))))))
+                   :content (.getMessage e)})
+                (assoc build-results :error (exception->target-error e))))))))))
 
 (handler/defhandler :run.hot-reload :global
   (enabled? [debug-view prefs evaluation-context]
@@ -3550,37 +3570,29 @@
     :fetch-libraries! (fn fetch-libraries! []
                         (fetch-libraries app-view workspace project changes-view build-errors-view prefs localization web-server))
     :invoke-bob! (fn invoke-bob! [options commands evaluation-context]
-                   (let [f (future/make)]
-                     (fx/on-fx-thread
-                       (let [options (cond-> options
-                                       (not (contains? options "build-server"))
-                                       (assoc "build-server" (native-extensions/get-build-server-url prefs project evaluation-context))
-                                       (not (contains? options "build-server-header"))
-                                       (assoc "build-server-header" (native-extensions/get-build-server-headers prefs)))
-                             main-scene (g/node-value app-view :scene evaluation-context)
-                             tool-tab-pane (g/node-value app-view :tool-tab-pane evaluation-context)
-                             render-build-error! (make-render-build-error main-scene tool-tab-pane build-errors-view)
-                             render-reload-progress! (make-render-task-progress :resource-sync)
-                             render-save-progress! (make-render-task-progress :save-all)
-                             [render-build-progress! build-task-cancelled?] (begin-task-progress! :build)
-                             out (start-new-log-pipe!)]
-                         (build-errors-view/clear-build-errors build-errors-view)
-                         (disk/async-bob-build! render-reload-progress!
-                                                render-save-progress!
-                                                render-build-progress!
-                                                out
-                                                build-task-cancelled?
-                                                render-build-error!
-                                                commands
-                                                options
-                                                project
-                                                changes-view
-                                                (fn [successful]
-                                                  (if successful
-                                                    (future/complete! f nil)
-                                                    (future/fail! f (LuaError. "Bob invocation failed")))
-                                                  (.close out)))))
-                     f))
+                   (let [options (cond-> options
+                                   (not (contains? options "build-server"))
+                                   (assoc "build-server" (native-extensions/get-build-server-url prefs project evaluation-context))
+                                   (not (contains? options "build-server-header"))
+                                   (assoc "build-server-header" (native-extensions/get-build-server-headers prefs)))
+                         main-scene (g/node-value app-view :scene evaluation-context)
+                         tool-tab-pane (g/node-value app-view :tool-tab-pane evaluation-context)
+                         render-build-error! (make-render-build-error main-scene tool-tab-pane build-errors-view)
+                         render-reload-progress! (make-render-task-progress :resource-sync)
+                         render-save-progress! (make-render-task-progress :save-all)
+                         [render-build-progress! build-task-cancelled?] (begin-task-progress! :build)
+                         out (start-new-log-pipe!)]
+                     (future/io
+                       (try
+                         (ui/run-now (build-errors-view/clear-build-errors build-errors-view))
+                         (let [{:keys [error]}
+                               (disk/bob-build! render-reload-progress! render-save-progress! render-build-progress!
+                                                out build-task-cancelled? commands options project changes-view)]
+                           (when error
+                             (ui/run-now (render-build-error! error))
+                             (throw (LuaError. "Bob invocation failed"))))
+                         (finally
+                           (.close out))))))
     :web-server web-server)
   (ui/user-data! (g/node-value app-view :scene) ::ui/refresh-requested? true)
   (ui/invalidate-menubar-item! ::project/bundle))

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -1659,23 +1659,21 @@
         render-reload-progress! (make-render-task-progress :resource-sync)
         render-save-progress! (make-render-task-progress :save-all)
         [render-build-progress! build-task-cancelled?] (begin-task-progress! :build)
-        bob-args (bob/build-html5-bob-options project prefs)
-        out (start-new-log-pipe!)]
+        bob-args (bob/build-html5-bob-options project prefs)]
     (build-errors-view/clear-build-errors build-errors-view)
     (future/io
-      (try
-        (let [build-results (disk/bob-build! render-reload-progress! render-save-progress! render-build-progress!
-                                             out build-task-cancelled? bob-commands bob-args project changes-view)]
-          (ui/run-now
-            (if-let [error (:error build-results)]
-              (render-build-error! error)
-              (let [url (str (http-server/local-url web-server) "/html5")]
-                (if (prefs/get prefs [:build :open-html5-build])
-                  (ui/open-url url)
-                  (console/append-console-entry! nil (format "INFO: The game is available at %s" url))))))
-          build-results)
-        (finally
-          (.close out))))))
+      (let [build-results
+            (with-open [out (start-new-log-pipe!)]
+              (disk/bob-build! render-reload-progress! render-save-progress! render-build-progress!
+                               out build-task-cancelled? bob-commands bob-args project changes-view))]
+        (ui/run-now
+          (if-let [error (:error build-results)]
+            (render-build-error! error)
+            (let [url (str (http-server/local-url web-server) "/html5")]
+              (if (prefs/get prefs [:build :open-html5-build])
+                (ui/open-url url)
+                (console/append-console-entry! nil (format "INFO: The game is available at %s" url))))))
+        build-results))))
 
 (handler/defhandler :project.clean-build-html5 :global
   (run [project prefs web-server build-errors-view changes-view main-stage tool-tab-pane localization]
@@ -3583,19 +3581,16 @@
                          render-build-error! (make-render-build-error main-scene tool-tab-pane build-errors-view)
                          render-reload-progress! (make-render-task-progress :resource-sync)
                          render-save-progress! (make-render-task-progress :save-all)
-                         [render-build-progress! build-task-cancelled?] (begin-task-progress! :build)
-                         out (start-new-log-pipe!)]
+                         [render-build-progress! build-task-cancelled?] (begin-task-progress! :build)]
                      (future/io
-                       (try
-                         (ui/run-now (build-errors-view/clear-build-errors build-errors-view))
-                         (let [{:keys [error]}
+                       (ui/run-now (build-errors-view/clear-build-errors build-errors-view))
+                       (let [{:keys [error]}
+                             (with-open [out (start-new-log-pipe!)]
                                (disk/bob-build! render-reload-progress! render-save-progress! render-build-progress!
-                                                out build-task-cancelled? commands options project changes-view)]
-                           (when error
-                             (ui/run-now (render-build-error! error))
-                             (throw (LuaError. "Bob invocation failed"))))
-                         (finally
-                           (.close out))))))
+                                                out build-task-cancelled? commands options project changes-view))]
+                         (when error
+                           (ui/run-now (render-build-error! error))
+                           (throw (LuaError. "Bob invocation failed")))))))
     :web-server web-server)
   (ui/user-data! (g/node-value app-view :scene) ::ui/refresh-requested? true)
   (ui/invalidate-menubar-item! ::project/bundle))

--- a/editor/src/clj/editor/command_requests.clj
+++ b/editor/src/clj/editor/command_requests.clj
@@ -23,7 +23,6 @@
             [editor.lsp.server :as lsp.server]
             [editor.resource :as resource]
             [editor.ui :as ui]
-            [service.log :as log]
             [util.coll :as coll]
             [util.http-server :as http-server])
   (:import [com.dynamo.bob.util Library$Result]))
@@ -41,297 +40,394 @@
     "false" {:focus false}
     (throw (http-server/error (http-server/response 400 "Invalid focus value; expected true or false\n")))))
 
-(defn- build-response [result localization-state]
-  (future/then
-    result
-    (fn [{:keys [error warning]}]
-      (let [issues (coll/into-> [error warning] []
-                     (filter some?)
-                     (mapcat #(:children (build-errors-view/build-resource-tree %)))
-                     (mapcat :children)
-                     (map (fn [{:keys [message severity parent cursor-range]}]
-                            (let [maybe-resource (:resource parent)]
-                              (cond-> {:message (localization-state message)
-                                       :severity (case severity
-                                                   :fatal :error
-                                                   :info :information
-                                                   severity)}
-                                      maybe-resource (assoc :resource (resource/proj-path maybe-resource))
-                                      cursor-range (assoc :range (lsp.server/editor-cursor-range->lsp-range cursor-range)))))))]
-        (http-server/json-response {:success (not error) :issues issues} (if error 422 200))))))
+(defn- build-response [{:keys [error warning]} localization-state]
+  (let [issues (coll/into-> [error warning] []
+                            (filter some?)
+                            (mapcat #(:children (build-errors-view/build-resource-tree %)))
+                            (mapcat :children)
+                            (map (fn [{:keys [message severity parent cursor-range]}]
+                                   (let [maybe-resource (:resource parent)]
+                                     (cond-> {:message (localization-state message)
+                                              :severity (case severity
+                                                          :fatal :error
+                                                          :info :information
+                                                          severity)}
+                                       maybe-resource (assoc :resource (resource/proj-path maybe-resource))
+                                       cursor-range (assoc :range (lsp.server/editor-cursor-range->lsp-range cursor-range)))))))]
+    (http-server/json-response {:success (not error) :issues issues} (if error 422 200))))
 
-(defn- fetch-libraries-response [result localization-state]
-  (future/then
-    result
-    (fn [[lib-results reload-succeeded]]
-      (let [success (and reload-succeeded (coll/not-any? Library$Result/.problem lib-results))]
-        (http-server/json-response
-          {:success success
-           :libraries (coll/into-> lib-results []
-                        (map (fn [^Library$Result result]
-                               (let [problem (.problem result)]
-                                 (cond-> {:uri (str (.uri result))
-                                          :success (not problem)}
-                                   problem
-                                   (assoc :message (localization-state (library/result-message result))))))))}
-          (cond
-            (not reload-succeeded) 500
-            success 200
-            :else 422))))))
+(defn- fetch-libraries-response [[lib-results reload-succeeded] localization-state]
+  (let [success (and reload-succeeded (coll/not-any? Library$Result/.problem lib-results))]
+    (http-server/json-response
+      {:success success
+       :libraries (coll/into-> lib-results []
+                               (map (fn [^Library$Result result]
+                                      (let [problem (.problem result)]
+                                        (cond-> {:uri (str (.uri result))
+                                                 :success (not problem)}
+                                          problem
+                                          (assoc :message (localization-state (library/result-message result))))))))}
+      (cond
+        (not reload-succeeded) 500
+        success 200
+        :else 422))))
 
-(def ^:private supported-commands
-  ;; Notable exclusions:
-  ;; :save-all, :quit, anything that would open a modal dialog.
-  {:asset-portal
-   {:ui-handler :help.open-asset-portal
-    :help "Open the Asset Portal in a web browser."}
-
-   :build
-   {:ui-handler :project.build
-    ;; Deprecated compatibility alias. Remove after 2027-07-15.
-    :deprecated true
-    :resource-sync true
-    :response-fn build-response}
-
-   :compile
-   {:ui-handler :project.compile
-    :help "Compile the project without running it."
-    :resource-sync true
-    :response-fn build-response}
-
-   :build-html5
-   {:ui-handler :project.build-html5
-    :help "Build the project for HTML5 and open it in a web browser."
-    :resource-sync true}
-
-   :debugger-break
-   {:ui-handler :debugger.break
-    :help "Break into the debugger."}
-
-   :debugger-continue
-   {:ui-handler :debugger.continue
-    :help "Resume execution in the debugger."}
-
-   :debugger-detach
-   {:ui-handler :debugger.detach
-    :help "Detach the debugger from the running project."}
-
-   :debugger-start
-   {:ui-handler :debugger.start
-    :help "Start the project with the debugger, or attach the debugger to the running project."
-    :resource-sync true}
-
-   :debugger-step-into
-   {:ui-handler :debugger.step-into
-    :help "Step into the current expression in the debugger."}
-
-   :debugger-step-out
-   {:ui-handler :debugger.step-out
-    :help "Step out of the current expression in the debugger."}
-
-   :debugger-step-over
-   {:ui-handler :debugger.step-over
-    :help "Step over the current expression in the debugger."}
-
-   :debugger-stop
-   {:ui-handler :debugger.stop
-    :help "Stop the debugger and the running project."}
-
-   :documentation
-   {:ui-handler :help.open-documentation
-    :help "Open the Defold documentation in a web browser."}
-
-   :donate-page
-   {:ui-handler :help.open-donations
-    :help "Open the Donate to Defold page in a web browser."}
-
-   :editor-logs
-   {:ui-handler :help.open-logs
-    :help "Show the directory containing the editor logs."}
-
-   :engine-profiler
-   {:ui-handler :run.open-profiler
-    :help "Open the Engine Profiler in a web browser."}
-
-   :engine-resource-profiler
-   {:ui-handler :run.open-resource-profiler
-    :help "Open the Engine Resource Profiler in a web browser."}
-
-   :fetch-libraries
-   {:ui-handler :project.fetch-libraries
-    :help "Download the latest version of the project library dependencies."
-    :resource-sync true
-    :response-fn fetch-libraries-response}
-
-   :hot-reload
-   {:ui-handler :run.hot-reload
-    :help "Hot-reload all modified files into the running project."
-    :resource-sync true}
-
-   :issues
-   {:ui-handler :help.open-issues
-    :help "Open the Defold Issue Tracker in a web browser."}
-
-   :clean-build
-   {:ui-handler :project.clean-build
-    :user-data {:skip-confirmation true}
-    :help "Clears build caches and rebuilds. Use only if builds fail oddly or miss changes."
-    :resource-sync true
-    :response-fn build-response}
-
-   :rebundle
-   {:ui-handler :project.rebundle
-    :help "Re-bundle the project using the previous Bundle dialog settings."
-    :resource-sync true}
-
-   :reload-extensions
-   {:ui-handler :project.reload-editor-scripts
-    :help "Reload editor extensions."
-    :resource-sync true}
-
-   :reload-stylesheets
-   {:ui-handler :dev.reload-css
-    :help "Reload editor stylesheets."}
-
-   :report-issue
-   {:ui-handler :help.report-issue
-    :help "Open the Report Issue page in a web browser."}
-
-   :report-suggestion
-   {:ui-handler :help.report-suggestion
-    :help "Open the Report Suggestion page in a web browser."}
-
-   :run
-   {:ui-handler :project.build
-    :help "Compile and run the project."
-    :request->user-data run-request-user-data
-    :resource-sync true
-    :response-fn build-response}
-
-   :show-build-errors
-   {:ui-handler :window.show-build-errors
-    :help "Show the Build Errors tab."}
-
-   :show-console
-   {:ui-handler :window.show-console
-    :help "Show the Console tab."}
-
-   :show-curve-editor
-   {:ui-handler :window.show-curve-editor
-    :help "Show the Curve Editor tab."}
-
-   :support-forum
-   {:ui-handler :help.open-forum
-    :help "Open the Defold Support Forum in a web browser."}
-
-   :toggle-pane-bottom
-   {:ui-handler :window.toggle-bottom-pane
-    :help "Toggle visibility of the bottom editor pane."}
-
-   :toggle-pane-left
-   {:ui-handler :window.toggle-left-pane
-    :help "Toggle visibility of the left editor pane."}
-
-   :toggle-pane-right
-   {:ui-handler :window.toggle-right-pane
-    :help "Toggle visibility of the right editor pane."}})
-
-(defn- command-openapi []
-  (let [command->help (coll/into-> supported-commands (sorted-map)
-                       (keep (fn [[command {:keys [deprecated help]}]]
-                               (when-not deprecated
-                                 (coll/pair (name command) help)))))]
-    {:summary "Execute an editor command"
-     :description (str "Available commands:\n"
-                       (coll/join-to-string
-                         "\n"
-                         (coll/into-> command->help :eduction
-                           (map (fn [[command help]]
-                                  (str "- `" command "`: " help))))))
-     :parameters [{:name "command"
-                   :in "path"
-                   :required true
-                   :description "Command to execute."
-                   :schema {:type "string"
-                            :enum (persistent!
-                                    (reduce-kv (fn [acc command _]
-                                                 (conj! acc command))
-                                               (transient [])
-                                               command->help))}}
-                  {:name "focus"
-                   :in "query"
-                   :description "Whether the launched game takes focus; only applies to `run`"
-                   :schema {:type "boolean"
-                            :default true}}]
-     :responses {"200" {:description "Command completed and returned a response body"}
-                 "202" {:description "Accepted"}
-                 "403" {:description "Forbidden"}
-                 "404" {:description "Unknown command"}
-                 "422" {:description "Command failed validation/build checks"}
-                 "500" {:description "Internal server error"}}}))
-
-(defn- resolve-ui-handler-ctx [ui-node ui-handler user-data]
+(defn- resolve-command-handler [ui-node command user-data]
   {:pre [(ui/node? ui-node)
-         (keyword? ui-handler)
+         (keyword? command)
          (map? user-data)]}
   @(fx/on-fx-thread
      (g/let-ec [command-contexts (ui/node-contexts ui-node true evaluation-context)]
-       (ui/resolve-handler-ctx command-contexts ui-handler user-data))))
+       (ui/resolve-handler-ctx command-contexts command user-data))))
+
+(defn- resolve-command-handler! [ui-node command user-data]
+  (let [handler (resolve-command-handler ui-node command user-data)]
+    (case handler
+      (::ui/not-active ::ui/not-enabled) (throw (http-server/error http-server/forbidden))
+      handler)))
+
+(defn- execute-handler! [handler]
+  (future/unwrap @(fx/on-fx-thread (ui/execute-handler-ctx handler))))
+
+(defn- execute-command! [ui-node command user-data]
+  (execute-handler! (resolve-command-handler! ui-node command user-data)))
+
+(defn- resource-sync! [ui-node render-reload-progress! handler]
+  (let [{:keys [changes-view workspace]} (:env (second handler))
+        result (promise)]
+    (assert (g/node-id? changes-view))
+    (assert (g/node-id? workspace))
+    (disk/async-reload!
+      render-reload-progress! workspace [] changes-view
+      (fn async-reload-continuation [success]
+        ;; This callback is executed on the ui thread.
+        (when-not success
+          (ui/user-data! (ui/scene ui-node) ::ui/refresh-requested? true))
+        (deliver result success)))
+    (when-not @result
+      (throw (http-server/error http-server/internal-server-error)))))
 
 (defn router [ui-node localization render-reload-progress!]
-  {"/command/{command}"
+  {"/command/asset-portal"
+   {"POST" (with-meta
+             (bound-fn [_request]
+               (future/io
+                 (execute-command! ui-node :help.open-asset-portal {})
+                 http-server/ok))
+             {:openapi {:summary "Open the Asset Portal in a web browser."
+                        :responses {"200" {:description "OK"}}}})}
+
+   ;; Deprecated compatibility alias. Remove after 2027-07-15.
+   "/command/build"
+   {"POST" (bound-fn [_request]
+             (future/io
+               (let [handler (resolve-command-handler! ui-node :project.build {})]
+                 (resource-sync! ui-node render-reload-progress! handler)
+                 (build-response (execute-handler! handler) @localization))))}
+
+   "/command/build-html5"
+   {"POST" (with-meta
+             (bound-fn [_request]
+               (future/io
+                 (let [handler (resolve-command-handler! ui-node :project.build-html5 {})]
+                   (resource-sync! ui-node render-reload-progress! handler)
+                   (build-response (execute-handler! handler) @localization))))
+             {:openapi {:summary "Build the project for HTML5 and open it in a web browser."
+                        :responses {"200" {:description "OK"}}}})}
+
+   "/command/clean-build"
+   {"POST" (with-meta
+             (bound-fn [_request]
+               (future/io
+                 (let [handler (resolve-command-handler! ui-node :project.clean-build {:skip-confirmation true})]
+                   (resource-sync! ui-node render-reload-progress! handler)
+                   (build-response (execute-handler! handler) @localization))))
+             {:openapi {:summary "Clears build caches and rebuilds. Use only if builds fail oddly or miss changes."
+                        :responses {"200" {:description "OK"}}}})}
+
+   "/command/compile"
+   {"POST" (with-meta
+             (bound-fn [_request]
+               (future/io
+                 (let [handler (resolve-command-handler! ui-node :project.compile {})]
+                   (resource-sync! ui-node render-reload-progress! handler)
+                   (build-response (execute-handler! handler) @localization))))
+             {:openapi {:summary "Compile the project without running it."
+                        :responses {"200" {:description "OK"}}}})}
+
+   "/command/debugger-break"
+   {"POST" (with-meta
+             (bound-fn [_request]
+               (future/io
+                 (execute-command! ui-node :debugger.break {})
+                 http-server/accepted))
+             {:openapi {:summary "Break into the debugger."
+                        :responses {"202" {:description "Accepted"}}}})}
+
+   "/command/debugger-continue"
+   {"POST" (with-meta
+             (bound-fn [_request]
+               (future/io
+                 (execute-command! ui-node :debugger.continue {})
+                 http-server/ok))
+             {:openapi {:summary "Resume execution in the debugger."
+                        :responses {"200" {:description "OK"}}}})}
+
+   "/command/debugger-detach"
+   {"POST" (with-meta
+             (bound-fn [_request]
+               (future/io
+                 (execute-command! ui-node :debugger.detach {})
+                 http-server/ok))
+             {:openapi {:summary "Detach the debugger from the running project."
+                        :responses {"200" {:description "OK"}}}})}
+
+   "/command/debugger-start"
+   {"POST" (with-meta
+             (bound-fn [_request]
+               (future/io
+                 (let [handler (resolve-command-handler! ui-node :debugger.start {})]
+                   (resource-sync! ui-node render-reload-progress! handler)
+                   (build-response (execute-handler! handler) @localization))))
+             {:openapi {:summary "Start the project with the debugger, or attach the debugger to the running project."
+                        :responses {"200" {:description "OK"}}}})}
+
+   "/command/debugger-step-into"
+   {"POST" (with-meta
+             (bound-fn [_request]
+               (future/io
+                 (execute-command! ui-node :debugger.step-into {})
+                 http-server/ok))
+             {:openapi {:summary "Step into the current expression in the debugger."
+                        :responses {"200" {:description "OK"}}}})}
+
+   "/command/debugger-step-out"
+   {"POST" (with-meta
+             (bound-fn [_request]
+               (future/io
+                 (execute-command! ui-node :debugger.step-out {})
+                 http-server/ok))
+             {:openapi {:summary "Step out of the current expression in the debugger."
+                        :responses {"200" {:description "OK"}}}})}
+
+   "/command/debugger-step-over"
+   {"POST" (with-meta
+             (bound-fn [_request]
+               (future/io
+                 (execute-command! ui-node :debugger.step-over {})
+                 http-server/ok))
+             {:openapi {:summary "Step over the current expression in the debugger."
+                        :responses {"200" {:description "OK"}}}})}
+
+   "/command/debugger-stop"
+   {"POST" (with-meta
+             (bound-fn [_request]
+               (future/io
+                 (execute-command! ui-node :debugger.stop {})
+                 http-server/ok))
+             {:openapi {:summary "Stop the debugger and the running project."
+                        :responses {"200" {:description "OK"}}}})}
+
+   "/command/documentation"
+   {"POST" (with-meta
+             (bound-fn [_request]
+               (future/io
+                 (execute-command! ui-node :help.open-documentation {})
+                 http-server/ok))
+             {:openapi {:summary "Open the Defold documentation in a web browser."
+                        :responses {"200" {:description "OK"}}}})}
+
+   "/command/donate-page"
+   {"POST" (with-meta
+             (bound-fn [_request]
+               (future/io
+                 (execute-command! ui-node :help.open-donations {})
+                 http-server/ok))
+             {:openapi {:summary "Open the Donate to Defold page in a web browser."
+                        :responses {"200" {:description "OK"}}}})}
+
+   "/command/editor-logs"
+   {"POST" (with-meta
+             (bound-fn [_request]
+               (future/io
+                 (execute-command! ui-node :help.open-logs {})
+                 http-server/ok))
+             {:openapi {:summary "Show the directory containing the editor logs."
+                        :responses {"200" {:description "OK"}}}})}
+
+   "/command/engine-profiler"
+   {"POST" (with-meta
+             (bound-fn [_request]
+               (future/io
+                 (execute-command! ui-node :run.open-profiler {})
+                 http-server/ok))
+             {:openapi {:summary "Open the Engine Profiler in a web browser."
+                        :responses {"200" {:description "OK"}}}})}
+
+   "/command/engine-resource-profiler"
+   {"POST" (with-meta
+             (bound-fn [_request]
+               (future/io
+                 (execute-command! ui-node :run.open-resource-profiler {})
+                 http-server/ok))
+             {:openapi {:summary "Open the Engine Resource Profiler in a web browser."
+                        :responses {"200" {:description "OK"}}}})}
+
+   "/command/fetch-libraries"
+   {"POST" (with-meta
+             (bound-fn [_request]
+               (future/io
+                 (let [handler (resolve-command-handler! ui-node :project.fetch-libraries {})]
+                   (resource-sync! ui-node render-reload-progress! handler)
+                   (fetch-libraries-response (execute-handler! handler) @localization))))
+             {:openapi {:summary "Download the latest version of the project library dependencies."
+                        :responses {"200" {:description "OK"}}}})}
+
+   "/command/hot-reload"
+   {"POST" (with-meta
+             (bound-fn [_request]
+               (future/io
+                 (let [handler (resolve-command-handler! ui-node :run.hot-reload {})]
+                   (resource-sync! ui-node render-reload-progress! handler)
+                   (build-response (execute-handler! handler) @localization))))
+             {:openapi {:summary "Hot-reload all modified files into the running project."
+                        :responses {"200" {:description "OK"}}}})}
+
+   "/command/issues"
+   {"POST" (with-meta
+             (bound-fn [_request]
+               (future/io
+                 (execute-command! ui-node :help.open-issues {})
+                 http-server/ok))
+             {:openapi {:summary "Open the Defold Issue Tracker in a web browser."
+                        :responses {"200" {:description "OK"}}}})}
+
+   "/command/rebundle"
+   {"POST" (with-meta
+             (bound-fn [_request]
+               (future/io
+                 (let [handler (resolve-command-handler! ui-node :project.rebundle {})]
+                   (resource-sync! ui-node render-reload-progress! handler)
+                   (execute-handler! handler)
+                   http-server/ok)))
+             {:openapi {:summary "Re-bundle the project using the previous Bundle dialog settings."
+                        :responses {"200" {:description "OK"}}}})}
+
+   "/command/reload-extensions"
+   {"POST" (with-meta
+             (bound-fn [_request]
+               (future/io
+                 (let [handler (resolve-command-handler! ui-node :project.reload-editor-scripts {})]
+                   (resource-sync! ui-node render-reload-progress! handler)
+                   (execute-handler! handler)
+                   http-server/ok)))
+             {:openapi {:summary "Reload editor extensions."
+                        :responses {"200" {:description "OK"}}}})}
+
+   "/command/reload-stylesheets"
+   {"POST" (with-meta
+             (bound-fn [_request]
+               (future/io
+                 (execute-command! ui-node :dev.reload-css {})
+                 http-server/ok))
+             {:openapi {:summary "Reload editor stylesheets."
+                        :responses {"200" {:description "OK"}}}})}
+
+   "/command/report-issue"
+   {"POST" (with-meta
+             (bound-fn [_request]
+               (future/io
+                 (execute-command! ui-node :help.report-issue {})
+                 http-server/ok))
+             {:openapi {:summary "Open the Report Issue page in a web browser."
+                        :responses {"200" {:description "OK"}}}})}
+
+   "/command/report-suggestion"
+   {"POST" (with-meta
+             (bound-fn [_request]
+               (future/io
+                 (execute-command! ui-node :help.report-suggestion {})
+                 http-server/ok))
+             {:openapi {:summary "Open the Report Suggestion page in a web browser."
+                        :responses {"200" {:description "OK"}}}})}
+
+   "/command/run"
    {"POST" (with-meta
              (bound-fn [request]
-               (let [command (-> request :path-params :command keyword)]
-                 (if-let [{:keys [ui-handler user-data request->user-data resource-sync response-fn]} (supported-commands command)]
-                   (let [ui-handler-ctx (resolve-ui-handler-ctx
-                                          ui-node
-                                          ui-handler
-                                          (cond-> (or user-data {})
-                                                  request->user-data (merge (request->user-data request))))]
-                     (case ui-handler-ctx
-                       (::ui/not-active ::ui/not-enabled) http-server/forbidden
-                       (let [{:keys [changes-view workspace]} (:env (second ui-handler-ctx))
-                             result-future (future/make)
-                             execute-command!
-                             (bound-fn execute-command! []
-                               (-> (try
-                                     (future/completed (ui/execute-handler-ctx ui-handler-ctx))
-                                     (catch Throwable e (future/failed e)))
-                                   (future/then
-                                     (fn [result]
-                                       (if response-fn
-                                         (response-fn result @localization)
-                                         http-server/accepted)))
-                                   (future/then
-                                     (fn [response]
-                                       (future/complete! result-future response)))
-                                   (future/catch
-                                     (fn [error]
-                                       (log/error :msg "Failed to handle command request"
-                                                  :request request
-                                                  :exception error)
-                                       (future/complete! result-future http-server/internal-server-error)))))]
-                         (assert (g/node-id? changes-view))
-                         (assert (g/node-id? workspace))
-                         (when-not (Boolean/getBoolean "defold.tests")
-                           (log/info :msg "Processing request" :command command))
-                         (if-not resource-sync
-                           (ui/run-later (execute-command!))
-                           (disk/async-reload!
-                             render-reload-progress! workspace [] changes-view
-                             (fn async-reload-continuation [success]
-                               ;; This callback is executed on the ui thread.
-                               (if success
-                                 (execute-command!)
-                                 (do
-                                   ;; Explicitly refresh the UI after the reload, since
-                                   ;; the ui-handler will not have done so on failure.
-                                   (ui/user-data! (ui/scene ui-node) ::ui/refresh-requested? true)
-                                   (future/complete! result-future http-server/internal-server-error))))))
-                         result-future)))
-                   http-server/not-found)))
-             {:openapi (command-openapi)})}})
+               (future/io
+                 (let [handler (resolve-command-handler! ui-node :project.build (run-request-user-data request))]
+                   (resource-sync! ui-node render-reload-progress! handler)
+                   (build-response (execute-handler! handler) @localization))))
+             {:openapi {:summary "Compile and run the project."
+                        :parameters [{:name "focus"
+                                      :in "query"
+                                      :description "Whether the launched game takes focus."
+                                      :schema {:type "boolean"
+                                               :default true}}]
+                        :responses {"200" {:description "OK"}}}})}
+
+   "/command/show-build-errors"
+   {"POST" (with-meta
+             (bound-fn [_request]
+               (future/io
+                 (execute-command! ui-node :window.show-build-errors {})
+                 http-server/ok))
+             {:openapi {:summary "Show the Build Errors tab."
+                        :responses {"200" {:description "OK"}}}})}
+
+   "/command/show-console"
+   {"POST" (with-meta
+             (bound-fn [_request]
+               (future/io
+                 (execute-command! ui-node :window.show-console {})
+                 http-server/ok))
+             {:openapi {:summary "Show the Console tab."
+                        :responses {"200" {:description "OK"}}}})}
+
+   "/command/show-curve-editor"
+   {"POST" (with-meta
+             (bound-fn [_request]
+               (future/io
+                 (execute-command! ui-node :window.show-curve-editor {})
+                 http-server/ok))
+             {:openapi {:summary "Show the Curve Editor tab."
+                        :responses {"200" {:description "OK"}}}})}
+
+   "/command/support-forum"
+   {"POST" (with-meta
+             (bound-fn [_request]
+               (future/io
+                 (execute-command! ui-node :help.open-forum {})
+                 http-server/ok))
+             {:openapi {:summary "Open the Defold Support Forum in a web browser."
+                        :responses {"200" {:description "OK"}}}})}
+
+   "/command/toggle-pane-bottom"
+   {"POST" (with-meta
+             (bound-fn [_request]
+               (future/io
+                 (execute-command! ui-node :window.toggle-bottom-pane {})
+                 http-server/ok))
+             {:openapi {:summary "Toggle visibility of the bottom editor pane."
+                        :responses {"200" {:description "OK"}}}})}
+
+   "/command/toggle-pane-left"
+   {"POST" (with-meta
+             (bound-fn [_request]
+               (future/io
+                 (execute-command! ui-node :window.toggle-left-pane {})
+                 http-server/ok))
+             {:openapi {:summary "Toggle visibility of the left editor pane."
+                        :responses {"200" {:description "OK"}}}})}
+
+   "/command/toggle-pane-right"
+   {"POST" (with-meta
+             (bound-fn [_request]
+               (future/io
+                 (execute-command! ui-node :window.toggle-right-pane {})
+                 http-server/ok))
+             {:openapi {:summary "Toggle visibility of the right editor pane."
+                        :responses {"200" {:description "OK"}}}})}})
 
 (comment
 

--- a/editor/src/clj/editor/command_requests.clj
+++ b/editor/src/clj/editor/command_requests.clj
@@ -42,18 +42,18 @@
 
 (defn- build-response [{:keys [error warning]} localization-state]
   (let [issues (coll/into-> [error warning] []
-                            (filter some?)
-                            (mapcat #(:children (build-errors-view/build-resource-tree %)))
-                            (mapcat :children)
-                            (map (fn [{:keys [message severity parent cursor-range]}]
-                                   (let [maybe-resource (:resource parent)]
-                                     (cond-> {:message (localization-state message)
-                                              :severity (case severity
-                                                          :fatal :error
-                                                          :info :information
-                                                          severity)}
-                                       maybe-resource (assoc :resource (resource/proj-path maybe-resource))
-                                       cursor-range (assoc :range (lsp.server/editor-cursor-range->lsp-range cursor-range)))))))]
+                 (filter some?)
+                 (mapcat #(:children (build-errors-view/build-resource-tree %)))
+                 (mapcat :children)
+                 (map (fn [{:keys [message severity parent cursor-range]}]
+                        (let [maybe-resource (:resource parent)]
+                          (cond-> {:message (localization-state message)
+                                   :severity (case severity
+                                               :fatal :error
+                                               :info :information
+                                               severity)}
+                            maybe-resource (assoc :resource (resource/proj-path maybe-resource))
+                            cursor-range (assoc :range (lsp.server/editor-cursor-range->lsp-range cursor-range)))))))]
     (http-server/json-response {:success (not error) :issues issues} (if error 422 200))))
 
 (defn- fetch-libraries-response [[lib-results reload-succeeded] localization-state]
@@ -61,12 +61,12 @@
     (http-server/json-response
       {:success success
        :libraries (coll/into-> lib-results []
-                               (map (fn [^Library$Result result]
-                                      (let [problem (.problem result)]
-                                        (cond-> {:uri (str (.uri result))
-                                                 :success (not problem)}
-                                          problem
-                                          (assoc :message (localization-state (library/result-message result))))))))}
+                    (map (fn [^Library$Result result]
+                           (let [problem (.problem result)]
+                             (cond-> {:uri (str (.uri result))
+                                      :success (not problem)}
+                               problem
+                               (assoc :message (localization-state (library/result-message result))))))))}
       (cond
         (not reload-succeeded) 500
         success 200

--- a/editor/src/clj/editor/disk.clj
+++ b/editor/src/clj/editor/disk.clj
@@ -300,103 +300,58 @@
 ;; Bob build
 ;; -----------------------------------------------------------------------------
 
-(defn- handle-bob-error! [render-error! project evaluation-context {:keys [error exception] :as _result}]
-  (cond
-    error
-    (do (render-error! error)
-        true)
-
-    exception
-    (do (render-error! (engine-build-errors/exception->error-value exception project evaluation-context))
-        true)))
-
-(defn async-bob-build! [render-reload-progress! render-save-progress! render-build-progress! log-output-stream task-cancelled? render-build-error! bob-commands bob-options project changes-view callback!]
+(defn bob-build! [render-reload-progress! render-save-progress! render-build-progress! log-output-stream task-cancelled? bob-commands bob-options project changes-view]
   (disk-availability/push-busy!)
-  (future
-    (try
-      (let [invoke-bundle-hooks (boolean (some #(= "bundle" %) bob-commands))
-            hook-opts {:output-directory (or (get bob-options "bundle-output")
-                                             (get bob-options "output")
-                                             "build/default")
-                       :platform (get bob-options "platform")
-                       :variant (get bob-options "variant" "release")}]
-        (render-reload-progress! (progress/make-indeterminate (localization/message "progress.executing-bundle-hook")))
-        (if-let [extension-error (when invoke-bundle-hooks
-                                   @(extensions/execute-hook! project
-                                                              :on_bundle_started
-                                                              hook-opts
-                                                              :exception-policy :as-error))]
-          (try
-            (when invoke-bundle-hooks
-              @(extensions/execute-hook! project
-                                         :on_bundle_finished
-                                         (assoc hook-opts :success false)
-                                         :exception-policy :ignore))
-            (ui/run-later
-              (try
-                (handle-bob-error! render-build-error! project (g/make-evaluation-context) {:error extension-error})
-                (when (some? callback!) (callback! false))
-                (finally
-                  (disk-availability/pop-busy!)
-                  (render-reload-progress! progress/done))))
-            (catch Throwable error
-              (disk-availability/pop-busy!)
-              (render-reload-progress! progress/done)
-              (throw error)))
-          (do
-            (render-reload-progress! progress/done)
-
-            ;; We need to save because bob reads from FS.
-            (async-save!
-              render-reload-progress! render-save-progress! project/dirty-save-data project changes-view
-              (fn [successful?]
-                (if-not successful?
-                  (try
-                    (when (some? callback!)
-                      (callback! false))
-                    (finally
-                      (disk-availability/pop-busy!)))
-                  (try
-                    (render-build-progress! (progress/make-cancellable-indeterminate (localization/message "progress.building")))
-                    ;; evaluation-context below is used to map
-                    ;; project paths to resource node id:s. To be
-                    ;; strictly correct, we should probably re-use
-                    ;; the ec created when saving - so the graph
-                    ;; state in the ec corresponds with the state
-                    ;; bob sees on disk.
+  (try
+    (let [invoke-bundle-hooks (coll/any? #(= "bundle" %) bob-commands)
+          hook-opts {:output-directory (or (get bob-options "bundle-output")
+                                           (get bob-options "output")
+                                           "build/default")
+                     :platform (get bob-options "platform")
+                     :variant (get bob-options "variant" "release")}]
+      (render-reload-progress! (progress/make-indeterminate (localization/message "progress.executing-bundle-hook")))
+      (let [extension-error (when invoke-bundle-hooks
+                              @(extensions/execute-hook! project
+                                                         :on_bundle_started
+                                                         hook-opts
+                                                         :exception-policy :as-error))]
+        (render-reload-progress! progress/done)
+        (let [build-results
+              (if extension-error
+                {:error extension-error}
+                ;; We need to save because bob reads from FS.
+                (let [save-completed (promise)]
+                  (async-save! render-reload-progress! render-save-progress! project/dirty-save-data project changes-view save-completed)
+                  (if-not @save-completed
+                    {:error (g/map->error {:severity :fatal
+                                           :message (localization/message "error.bob.failed-to-save-project")})}
+                    ;; Ideally we'd reuse the evaluation context from saving, so its graph
+                    ;; state corresponds to what Bob sees on disk.
                     (let [evaluation-context (g/make-evaluation-context)]
-                      (future
-                        (try
-                          (let [result (bob/invoke! project bob-options bob-commands
-                                                    :task-cancelled? task-cancelled?
-                                                    :render-progress! render-build-progress!
-                                                    :evaluation-context evaluation-context
-                                                    :log-output-stream log-output-stream)]
-                            (when invoke-bundle-hooks
-                              @(extensions/execute-hook!
-                                 project
-                                 :on_bundle_finished
-                                 (assoc hook-opts
-                                   :success (not (or (:error result)
-                                                     (:exception result))))
-                                 :exception-policy :ignore))
-                            (render-build-progress! progress/done)
-                            (ui/run-later
-                              (try
-                                (let [successful? (not (handle-bob-error! render-build-error! project evaluation-context result))]
-                                  (when (some? callback!)
-                                    (callback! successful?)))
-                                (finally
-                                  (disk-availability/pop-busy!)
-                                  (g/update-cache-from-evaluation-context! evaluation-context)))))
-                          (catch Throwable error
-                            (disk-availability/pop-busy!)
-                            (render-build-progress! progress/done)
-                            (error-reporting/report-exception! error)))))
-                    (catch Throwable error
-                      (disk-availability/pop-busy!)
-                      (throw error)))))))))
-      (catch Throwable error
-        (disk-availability/pop-busy!)
-        (render-build-progress! progress/done)
-        (error-reporting/report-exception! error)))))
+                      (try
+                        (render-build-progress! (progress/make-cancellable-indeterminate (localization/message "progress.building")))
+                        (let [{:keys [error exception]} (bob/invoke! project bob-options bob-commands
+                                                                     :task-cancelled? task-cancelled?
+                                                                     :render-progress! render-build-progress!
+                                                                     :evaluation-context evaluation-context
+                                                                     :log-output-stream log-output-stream)]
+                          (cond
+                            error {:error error}
+                            exception {:error (engine-build-errors/exception->error-value exception project evaluation-context)}
+                            :else {}))
+                        (finally
+                          (ui/run-now
+                            (g/update-cache-from-evaluation-context! evaluation-context))))))))]
+          (when invoke-bundle-hooks
+            @(extensions/execute-hook! project
+                                       :on_bundle_finished
+                                       (assoc hook-opts :success (not (:error build-results)))
+                                       :exception-policy :ignore))
+          build-results)))
+    (catch Throwable error
+      (error-reporting/report-exception! error)
+      (throw error))
+    (finally
+      (render-reload-progress! progress/done)
+      (render-build-progress! progress/done)
+      (disk-availability/pop-busy!))))

--- a/editor/src/clj/editor/disk.clj
+++ b/editor/src/clj/editor/disk.clj
@@ -330,11 +330,13 @@
                     (let [evaluation-context (g/make-evaluation-context)]
                       (try
                         (render-build-progress! (progress/make-cancellable-indeterminate (localization/message "progress.building")))
-                        (let [{:keys [error exception]} (bob/invoke! project bob-options bob-commands
-                                                                     :task-cancelled? task-cancelled?
-                                                                     :render-progress! render-build-progress!
-                                                                     :evaluation-context evaluation-context
-                                                                     :log-output-stream log-output-stream)]
+                        (let [{:keys [error exception]}
+                              (bob/invoke!
+                                project bob-options bob-commands
+                                :task-cancelled? task-cancelled?
+                                :render-progress! render-build-progress!
+                                :evaluation-context evaluation-context
+                                :log-output-stream log-output-stream)]
                           (cond
                             error {:error error}
                             exception {:error (engine-build-errors/exception->error-value exception project evaluation-context)}
@@ -343,10 +345,11 @@
                           (ui/run-now
                             (g/update-cache-from-evaluation-context! evaluation-context))))))))]
           (when invoke-bundle-hooks
-            @(extensions/execute-hook! project
-                                       :on_bundle_finished
-                                       (assoc hook-opts :success (not (:error build-results)))
-                                       :exception-policy :ignore))
+            @(extensions/execute-hook!
+               project
+               :on_bundle_finished
+               (assoc hook-opts :success (not (:error build-results)))
+               :exception-policy :ignore))
           build-results)))
     (catch Throwable error
       (error-reporting/report-exception! error)

--- a/editor/src/clj/editor/disk.clj
+++ b/editor/src/clj/editor/disk.clj
@@ -325,8 +325,12 @@
                   (if-not @save-completed
                     {:error (g/map->error {:severity :fatal
                                            :message (localization/message "error.bob.failed-to-save-project")})}
-                    ;; Ideally we'd reuse the evaluation context from saving, so its graph
-                    ;; state corresponds to what Bob sees on disk.
+                    ;; evaluation-context below is used to map
+                    ;; project paths to resource node id:s. To be
+                    ;; strictly correct, we should probably re-use
+                    ;; the ec created when saving - so the graph
+                    ;; state in the ec corresponds with the state
+                    ;; bob sees on disk.
                     (let [evaluation-context (g/make-evaluation-context)]
                       (try
                         (render-build-progress! (progress/make-cancellable-indeterminate (localization/message "progress.building")))

--- a/editor/src/clj/editor/future.clj
+++ b/editor/src/clj/editor/future.clj
@@ -58,6 +58,14 @@
     x
     (completed x)))
 
+(defn unwrap [x]
+  (if-not (instance? CompletableFuture x)
+    x
+    (try
+      (.join ^CompletableFuture x)
+      (catch CompletionException ex
+        (throw (.getCause ex))))))
+
 (defn failed
   ^CompletableFuture [ex]
   (CompletableFuture/failedFuture ex))

--- a/editor/src/clj/util/http_server.clj
+++ b/editor/src/clj/util/http_server.clj
@@ -21,6 +21,8 @@
             [editor.util :as util]
             [reitit.core :as reitit]
             [service.log :as log]
+            [util.coll :as coll]
+            [util.defonce :as defonce]
             [util.path :as path])
   (:import [com.sun.net.httpserver Headers HttpHandler HttpServer]
            [java.io Closeable File IOException]
@@ -93,13 +95,13 @@
 ;;   the file content would still be recognized by the server that responds with
 ;;   the cached response.
 ;; To achieve this, we use these protocols:
-(defprotocol ContentType (content-type [body] "static content-type string or nil if unknown; default nil"))
-(defprotocol ContentLength (content-length [body] "static content-length in bytes (long) or nil if unknown; default nil"))
-(defprotocol ->Data (->data [body] "convert body to reusable immutable data"))
-(defprotocol ->Connection (->connection [data] "open connection to HTTP response data before sending; the connection may know its content-type and content-length at send time, is written via connection-write!, and may be Closeable; default identity"))
-(defprotocol ConnectionContentType (connection-content-type [connection] "dynamic content-type string or nil if unknown; default nil"))
-(defprotocol ConnectionContentLength (connection-content-length [connection] "dynamic content-length in bytes (long) or nil if unknown; default nil"))
-(defprotocol ConnectionWrite (connection-write! [connection output-stream] "write HTTP response body directly to output-stream"))
+(defonce/protocol ContentType (content-type [body] "static content-type string or nil if unknown; default nil"))
+(defonce/protocol ContentLength (content-length [body] "static content-length in bytes (long) or nil if unknown; default nil"))
+(defonce/protocol ->Data (->data [body] "convert body to reusable immutable data"))
+(defonce/protocol ->Connection (->connection [data] "open connection to HTTP response data before sending; the connection may know its content-type and content-length at send time, is written via connection-write!, and may be Closeable; default identity"))
+(defonce/protocol ConnectionContentType (connection-content-type [connection] "dynamic content-type string or nil if unknown; default nil"))
+(defonce/protocol ConnectionContentLength (connection-content-length [connection] "dynamic content-length in bytes (long) or nil if unknown; default nil"))
+(defonce/protocol ConnectionWrite (connection-write! [connection output-stream] "write HTTP response body directly to output-stream"))
 ;; During response creation, if content-length and content-type weren't
 ;; explicitly provided, we try to infer them. We use `content-type` fn on a
 ;; provided body, and then try it on the data produced using `->data`. We
@@ -198,6 +200,7 @@
 (defn- make-status-response [status body]
   (response status (str status \space body \newline)))
 
+(def ok (make-status-response 200 "OK"))
 (def accepted (make-status-response 202 "Accepted"))
 (def forbidden (make-status-response 403 "Forbidden"))
 (def not-found (make-status-response 404 "Not Found"))
@@ -205,7 +208,7 @@
 (def internal-server-error (make-status-response 500 "Internal Server Error"))
 (defn redirect [location] (response 302 {"location" location} nil))
 
-(deftype ServerWithHandler [^HttpServer server handler]
+(defonce/type ServerWithHandler [^HttpServer server handler]
   Closeable
   (close [_] (.stop server 0)))
 
@@ -402,9 +405,9 @@
    server))
 
 (defn- allowed-methods [method->handler]
-  (let [method-set (-> method->handler keys set (conj "OPTIONS"))
+  (let [method-set (into #{"OPTIONS"} (coll/keys method->handler))
         method-set (cond-> method-set (contains? method-set "GET") (conj "HEAD"))]
-    (string/join ", " (sort method-set))))
+    (coll/join-to-string ", " (coll/sort method-set))))
 
 (defn- invoke-handler [handler request router match]
   (handler (assoc request :path-params (:path-params match) :router router)))

--- a/editor/test/integration/web_server_test.clj
+++ b/editor/test/integration/web_server_test.clj
@@ -327,17 +327,17 @@
                 (let [get-ref (get-in json-body ["paths" "/ref" "get"])
                       param-names (into #{} (map #(get % "name")) (get get-ref "parameters"))]
                   (is get-ref)
-                  (is (every? param-names ["environment" "language" "q"])))
-                (let [post-command (get-in json-body ["paths" "/command/{command}" "post"])]
-                  (is (= "Execute an editor command" (get post-command "summary")))
-                  (is (string/includes? (get post-command "description") "`build-html5`"))
-                  (let [commands (get-in post-command ["parameters" 0 "schema" "enum"])]
-                    (is (coll/any? #{"compile"} commands))
-                    (is (coll/any? #{"run"} commands))
-                    (is (coll/not-any? #{"build"} commands)))
-                  (let [focus-parameter (coll/first-where #(= "focus" (get % "name")) (get post-command "parameters"))]
+                  (is (coll/every? param-names ["environment" "language" "q"])))
+                (let [paths (get json-body "paths")
+                      post-build-html5 (get-in paths ["/command/build-html5" "post"])
+                      post-compile (get-in paths ["/command/compile" "post"])
+                      post-run (get-in paths ["/command/run" "post"])]
+                  (is (not (contains? paths "/command/build")))
+                  (is (get-in post-build-html5 ["responses" "200"]))
+                  (is (get-in post-compile ["responses" "200"]))
+                  (is (get-in post-run ["responses" "200"]))
+                  (let [focus-parameter (coll/first-where #(= "focus" (get % "name")) (get post-run "parameters"))]
                     (is (= "query" (get focus-parameter "in")))
-                    (is (string/includes? (get focus-parameter "description") "`run`"))
                     (is (= {"type" "boolean" "default" true} (get focus-parameter "schema")))))))
             (let [{:keys [status]} @(http/request (str url "/command/run?focus=invalid") :method "POST")]
               (is (= 400 status)))
@@ -354,15 +354,15 @@
               (is (= 200 status))
               (is (= "application/json" (get headers "content-type")))
               (is (not (coll/empty? json-body)))
-              (is (every? #(= "runtime" (:environment %)) json-body))
-              (is (every? #(= "Lua" (:language %)) json-body))
+              (is (coll/every? #(= "runtime" (:environment %)) json-body))
+              (is (coll/every? #(= "Lua" (:language %)) json-body))
               (is (coll/any? #(= "go.property" (:name %)) json-body)))
             (let [{:keys [status headers body]} @(http/request (str url "/ref?environment=editor&q=editor.prefs.get") :as :string)
                   json-body (json/read-str body :key-fn keyword)]
               (is (= 200 status))
               (is (= "application/json" (get headers "content-type")))
               (is (not (coll/empty? json-body)))
-              (is (every? #(= "editor" (:environment %)) json-body))
+              (is (coll/every? #(= "editor" (:environment %)) json-body))
               (is (coll/any? #(= "editor.prefs.get" (:name %)) json-body)))
             (let [{:keys [status body]} @(http/request (str url "/ref?q=game%20object") :as :string)
                   json-body (json/read-str body :key-fn keyword)]
@@ -380,9 +380,9 @@
               (is (coll/any? #(= "runtime" (:environment %)) json-body))
               (is (coll/any? #(= "Lua" (:language %)) json-body))
               (is (coll/any? #(= "C++" (:language %)) json-body))
-              (is (every? (fn [element]
-                            (#{"Lua" "C++"} (:language element)))
-                          json-body)))
+              (is (coll/every? (fn [element]
+                                 (#{"Lua" "C++"} (:language element)))
+                               json-body)))
             (let [{:keys [status headers body]} @(http/request (str url "/engine-profiler/") :as :string)]
               (is (= 200 status))
               (is (= "text/html" (get headers "content-type")))
@@ -418,9 +418,10 @@
               (is (= 405 status))
               (is (= "OPTIONS, POST" (get headers "allow")))
               (is (= "405 Method Not Allowed\n" body)))
-            (with-redefs [ui/open-url (promise)]
-              (let [{:keys [status body]} @(http/request (str url "/command/report-issue") :method "POST" :as :string)]
-                (is (= 202 status))
-                (is (= "202 Accepted\n" body)))
-              (when (is (realized? ui/open-url))
-                (is (string/includes? @ui/open-url "github.com/defold/defold/issues"))))))))))
+            (let [opened-url (promise)]
+              (with-redefs [ui/open-url opened-url]
+                (let [{:keys [status body]} @(http/request (str url "/command/report-issue") :method "POST" :as :string)]
+                  (is (= 200 status))
+                  (is (= "200 OK\n" body)))
+                (when (is (realized? opened-url))
+                  (is (string/includes? @opened-url "github.com/defold/defold/issues")))))))))))


### PR DESCRIPTION
Now, `/command/build-html5`, `/command/debugger-start` and `/command/hot-reload` endpoints return structured results upon completion.

Fix #12916
Fix #12829
