### PR TITLE
Fix crash when creating and releasing dynamic resources from different collections

### DIFF
--- a/engine/gameobject/src/gameobject/gameobject.cpp
+++ b/engine/gameobject/src/gameobject/gameobject.cpp
@@ -359,7 +359,7 @@ namespace dmGameObject
         DM_MUTEX_SCOPED_LOCK(regist->m_Mutex);
         // 1. Collection A creates the resource and records its hash.
         // 2. Collection B calls resource.release().
-        // 3. Removing the hash only from B leaves A's entry after the descriptor is deleted.
+        // 3. Searching only B finds nothing, so A's entry outlives the deleted descriptor.
         // 4. If the path is recreated before A unloads, A's hash resolves to the new resource.
         // Search every collection in the register to remove the actual owner's entry.
         for (uint32_t collection_index = 0; collection_index < regist->m_Collections.Size(); ++collection_index)

--- a/engine/gameobject/src/gameobject/gameobject.cpp
+++ b/engine/gameobject/src/gameobject/gameobject.cpp
@@ -343,6 +343,7 @@ namespace dmGameObject
     void RemoveDynamicResourceHash(HCollection hcollection, dmhash_t resource_hash)
     {
         Register* regist = hcollection->m_Collection->m_Register;
+        DM_MUTEX_SCOPED_LOCK(regist->m_Mutex);
         // Search every collection in the register to remove the actual owner's entry.
         // We need to do this to avoid the following scenario (#13002):
         //
@@ -359,7 +360,7 @@ namespace dmGameObject
                 if (collection->m_DynamicResources[resource_index] == resource_hash)
                 {
                     collection->m_DynamicResources.EraseSwap(resource_index);
-                    return;
+                    break;
                 }
             }
         }

--- a/engine/gameobject/src/gameobject/gameobject.cpp
+++ b/engine/gameobject/src/gameobject/gameobject.cpp
@@ -343,7 +343,6 @@ namespace dmGameObject
     void RemoveDynamicResourceHash(HCollection hcollection, dmhash_t resource_hash)
     {
         Register* regist = hcollection->m_Collection->m_Register;
-        DM_MUTEX_SCOPED_LOCK(regist->m_Mutex);
         // Search every collection in the register to remove the actual owner's entry.
         // We need to do this to avoid the following scenario (#13002):
         //
@@ -354,6 +353,7 @@ namespace dmGameObject
         for (uint32_t collection_index = 0; collection_index < regist->m_Collections.Size(); ++collection_index)
         {
             Collection* collection = regist->m_Collections[collection_index];
+            DM_MUTEX_SCOPED_LOCK(collection->m_Mutex);
             for (uint32_t resource_index = 0; resource_index < collection->m_DynamicResources.Size(); ++resource_index)
             {
                 if (collection->m_DynamicResources[resource_index] == resource_hash)

--- a/engine/gameobject/src/gameobject/gameobject.cpp
+++ b/engine/gameobject/src/gameobject/gameobject.cpp
@@ -322,24 +322,13 @@ namespace dmGameObject
     void AddDynamicResourceHash(HCollection hcollection, dmhash_t resource_hash)
     {
         Collection* collection = hcollection->m_Collection;
-        HResourceDescriptor rd = dmResource::FindByHash(collection->m_Factory, resource_hash);
-        if (!rd)
-        {
-            return;
-        }
-
-        DynamicResource dynamic_resource;
-        dynamic_resource.m_PathHash = resource_hash;
-        dynamic_resource.m_Version = dmResource::GetVersion(collection->m_Factory, dmResource::GetResource(rd));
-
         dmMutex::Lock(collection->m_Mutex);
-        // The creating collection tracks each dynamic resource generation once so it
-        // can release it when the collection is deleted. Avoid recording the same
-        // generation twice, since that would release it twice.
+        // The creating collection tracks each dynamic resource once so it can release
+        // it when the collection is deleted. Avoid recording the same resource twice,
+        // since that would release it twice.
         for (uint32_t i = 0; i < collection->m_DynamicResources.Size(); ++i)
         {
-            const DynamicResource& existing = collection->m_DynamicResources[i];
-            if (existing.m_PathHash == dynamic_resource.m_PathHash && existing.m_Version == dynamic_resource.m_Version)
+            if (collection->m_DynamicResources[i] == resource_hash)
             {
                 dmMutex::Unlock(collection->m_Mutex);
                 return;
@@ -349,7 +338,7 @@ namespace dmGameObject
         {
             collection->m_DynamicResources.OffsetCapacity(1);
         }
-        collection->m_DynamicResources.Push(dynamic_resource);
+        collection->m_DynamicResources.Push(resource_hash);
         dmMutex::Unlock(collection->m_Mutex);
     }
 
@@ -363,7 +352,7 @@ namespace dmGameObject
         // 1. Collection A creates the resource and records its hash.
         // 2. Collection B calls resource.release().
         // 3. Searching only B finds nothing, so A's entry is still in the register.
-        // 4. If B creates a resource at the same path before A unloads, A's hash resolves to it.
+        // 4. When A unloads, its stale entry resolves to a deleted descriptor and asserts.
         for (uint32_t collection_index = 0; collection_index < regist->m_Collections.Size(); ++collection_index)
         {
             Collection* collection = regist->m_Collections[collection_index];
@@ -371,8 +360,9 @@ namespace dmGameObject
             uint32_t resource_index = 0;
             while (resource_index < collection->m_DynamicResources.Size())
             {
-                if (collection->m_DynamicResources[resource_index].m_PathHash == resource_hash)
+                if (collection->m_DynamicResources[resource_index] == resource_hash)
                 {
+                    // Check the swapped-in entry at this index as well.
                     collection->m_DynamicResources.EraseSwap(resource_index);
                 }
                 else
@@ -389,19 +379,12 @@ namespace dmGameObject
         dmMutex::Lock(collection->m_Mutex);
         for (int i = 0; i < collection->m_DynamicResources.Size(); ++i)
         {
-            const DynamicResource& dynamic_resource = collection->m_DynamicResources[i];
-            HResourceDescriptor rd = dmResource::FindByHash(collection->m_Factory, dynamic_resource.m_PathHash);
+            HResourceDescriptor rd = dmResource::FindByHash(collection->m_Factory, collection->m_DynamicResources[i]);
             if (!rd)
             {
                 continue;
             }
             void* resource = dmResource::GetResource(rd);
-            // The path may have been reused after the tracked resource was released.
-            // Only release the resource generation that this collection recorded.
-            if (dmResource::GetVersion(collection->m_Factory, resource) != dynamic_resource.m_Version)
-            {
-                continue;
-            }
             dmResource::Release(collection->m_Factory, resource);
         }
         collection->m_DynamicResources.SetSize(0);

--- a/engine/gameobject/src/gameobject/gameobject.cpp
+++ b/engine/gameobject/src/gameobject/gameobject.cpp
@@ -357,11 +357,13 @@ namespace dmGameObject
     {
         Register* regist = hcollection->m_Collection->m_Register;
         DM_MUTEX_SCOPED_LOCK(regist->m_Mutex);
+        // Search every collection in the register to remove the actual owner's entry.
+        // We need to do this to avoid the following scenario (#13002):
+        //
         // 1. Collection A creates the resource and records its hash.
         // 2. Collection B calls resource.release().
-        // 3. Searching only B finds nothing, so A's entry outlives the deleted descriptor.
-        // 4. If the path is recreated before A unloads, A's hash resolves to the new resource.
-        // Search every collection in the register to remove the actual owner's entry.
+        // 3. Searching only B finds nothing, so A's entry is still in the register.
+        // 4. If B creates a resource at the same path before A unloads, A's hash resolves to it.
         for (uint32_t collection_index = 0; collection_index < regist->m_Collections.Size(); ++collection_index)
         {
             Collection* collection = regist->m_Collections[collection_index];

--- a/engine/gameobject/src/gameobject/gameobject.cpp
+++ b/engine/gameobject/src/gameobject/gameobject.cpp
@@ -322,7 +322,7 @@ namespace dmGameObject
     void AddDynamicResourceHash(HCollection hcollection, dmhash_t resource_hash)
     {
         Collection* collection = hcollection->m_Collection;
-        dmMutex::Lock(collection->m_Mutex);
+        DM_MUTEX_SCOPED_LOCK(collection->m_Mutex);
         // The creating collection tracks each dynamic resource once so it can release
         // it when the collection is deleted. Avoid recording the same resource twice,
         // since that would release it twice.
@@ -330,7 +330,6 @@ namespace dmGameObject
         {
             if (collection->m_DynamicResources[i] == resource_hash)
             {
-                dmMutex::Unlock(collection->m_Mutex);
                 return;
             }
         }
@@ -339,7 +338,6 @@ namespace dmGameObject
             collection->m_DynamicResources.OffsetCapacity(1);
         }
         collection->m_DynamicResources.Push(resource_hash);
-        dmMutex::Unlock(collection->m_Mutex);
     }
 
     void RemoveDynamicResourceHash(HCollection hcollection, dmhash_t resource_hash)
@@ -356,32 +354,26 @@ namespace dmGameObject
         for (uint32_t collection_index = 0; collection_index < regist->m_Collections.Size(); ++collection_index)
         {
             Collection* collection = regist->m_Collections[collection_index];
-            dmMutex::Lock(collection->m_Mutex);
-            uint32_t resource_index = 0;
-            while (resource_index < collection->m_DynamicResources.Size())
+            for (uint32_t resource_index = 0; resource_index < collection->m_DynamicResources.Size(); ++resource_index)
             {
                 if (collection->m_DynamicResources[resource_index] == resource_hash)
                 {
-                    // Check the swapped-in entry at this index as well.
                     collection->m_DynamicResources.EraseSwap(resource_index);
-                }
-                else
-                {
-                    ++resource_index;
+                    return;
                 }
             }
-            dmMutex::Unlock(collection->m_Mutex);
         }
     }
 
     static void ReleaseDynamicResources(Collection* collection)
     {
-        dmMutex::Lock(collection->m_Mutex);
+        DM_MUTEX_SCOPED_LOCK(collection->m_Mutex);
         for (int i = 0; i < collection->m_DynamicResources.Size(); ++i)
         {
             HResourceDescriptor rd = dmResource::FindByHash(collection->m_Factory, collection->m_DynamicResources[i]);
             if (!rd)
             {
+                dmLogError("Unable to find '%s' when releasing dynamic resources", dmHashReverseSafe64(collection->m_DynamicResources[i]));
                 continue;
             }
             void* resource = dmResource::GetResource(rd);
@@ -389,7 +381,6 @@ namespace dmGameObject
         }
         collection->m_DynamicResources.SetSize(0);
         collection->m_DynamicResources.SetCapacity(0);
-        dmMutex::Unlock(collection->m_Mutex);
     }
 
     void DeleteCollections(HRegister regist)

--- a/engine/gameobject/src/gameobject/gameobject.cpp
+++ b/engine/gameobject/src/gameobject/gameobject.cpp
@@ -322,27 +322,64 @@ namespace dmGameObject
     void AddDynamicResourceHash(HCollection hcollection, dmhash_t resource_hash)
     {
         Collection* collection = hcollection->m_Collection;
+        HResourceDescriptor rd = dmResource::FindByHash(collection->m_Factory, resource_hash);
+        if (!rd)
+        {
+            return;
+        }
+
+        DynamicResource dynamic_resource;
+        dynamic_resource.m_PathHash = resource_hash;
+        dynamic_resource.m_Version = dmResource::GetVersion(collection->m_Factory, dmResource::GetResource(rd));
+
         dmMutex::Lock(collection->m_Mutex);
+        // The creating collection tracks each dynamic resource generation once so it
+        // can release it when the collection is deleted. Avoid recording the same
+        // generation twice, since that would release it twice.
+        for (uint32_t i = 0; i < collection->m_DynamicResources.Size(); ++i)
+        {
+            const DynamicResource& existing = collection->m_DynamicResources[i];
+            if (existing.m_PathHash == dynamic_resource.m_PathHash && existing.m_Version == dynamic_resource.m_Version)
+            {
+                dmMutex::Unlock(collection->m_Mutex);
+                return;
+            }
+        }
         if (collection->m_DynamicResources.Remaining() == 0)
         {
             collection->m_DynamicResources.OffsetCapacity(1);
         }
-        collection->m_DynamicResources.Push(resource_hash);
+        collection->m_DynamicResources.Push(dynamic_resource);
         dmMutex::Unlock(collection->m_Mutex);
     }
 
     void RemoveDynamicResourceHash(HCollection hcollection, dmhash_t resource_hash)
     {
-        Collection* collection = hcollection->m_Collection;
-        dmMutex::Lock(collection->m_Mutex);
-        for (int i = 0; i < collection->m_DynamicResources.Size(); ++i)
+        Register* regist = hcollection->m_Collection->m_Register;
+        DM_MUTEX_SCOPED_LOCK(regist->m_Mutex);
+        // 1. Collection A creates the resource and records its hash.
+        // 2. Collection B calls resource.release().
+        // 3. Removing the hash only from B leaves A's entry after the descriptor is deleted.
+        // 4. If the path is recreated before A unloads, A's hash resolves to the new resource.
+        // Search every collection in the register to remove the actual owner's entry.
+        for (uint32_t collection_index = 0; collection_index < regist->m_Collections.Size(); ++collection_index)
         {
-            if (collection->m_DynamicResources[i] == resource_hash)
+            Collection* collection = regist->m_Collections[collection_index];
+            dmMutex::Lock(collection->m_Mutex);
+            uint32_t resource_index = 0;
+            while (resource_index < collection->m_DynamicResources.Size())
             {
-                collection->m_DynamicResources.EraseSwap(i);
+                if (collection->m_DynamicResources[resource_index].m_PathHash == resource_hash)
+                {
+                    collection->m_DynamicResources.EraseSwap(resource_index);
+                }
+                else
+                {
+                    ++resource_index;
+                }
             }
+            dmMutex::Unlock(collection->m_Mutex);
         }
-        dmMutex::Unlock(collection->m_Mutex);
     }
 
     static void ReleaseDynamicResources(Collection* collection)
@@ -350,9 +387,19 @@ namespace dmGameObject
         dmMutex::Lock(collection->m_Mutex);
         for (int i = 0; i < collection->m_DynamicResources.Size(); ++i)
         {
-            HResourceDescriptor rd = dmResource::FindByHash(collection->m_Factory, collection->m_DynamicResources[i]);
-            assert(rd);
+            const DynamicResource& dynamic_resource = collection->m_DynamicResources[i];
+            HResourceDescriptor rd = dmResource::FindByHash(collection->m_Factory, dynamic_resource.m_PathHash);
+            if (!rd)
+            {
+                continue;
+            }
             void* resource = dmResource::GetResource(rd);
+            // The path may have been reused after the tracked resource was released.
+            // Only release the resource generation that this collection recorded.
+            if (dmResource::GetVersion(collection->m_Factory, resource) != dynamic_resource.m_Version)
+            {
+                continue;
+            }
             dmResource::Release(collection->m_Factory, resource);
         }
         collection->m_DynamicResources.SetSize(0);

--- a/engine/gameobject/src/gameobject/gameobject.h
+++ b/engine/gameobject/src/gameobject/gameobject.h
@@ -356,9 +356,9 @@ namespace dmGameObject
     void UpdateTransforms(HCollection hcollection);
 
     /**
-     * Remove the reference to a dynamically created resource. This implies
-     * that the resource has been externally removed and should no longer be
-     * tracked by the collection, e.g resource.release(id) has been called
+     * Remove the reference to a dynamically created resource from all collections
+     * in the collection register. This implies that the resource has been externally
+     * removed and should no longer be tracked, e.g resource.release(id) has been called.
      */
     void RemoveDynamicResourceHash(HCollection collection, dmhash_t resource_hash);
 }

--- a/engine/gameobject/src/gameobject/gameobject_private.h
+++ b/engine/gameobject/src/gameobject/gameobject_private.h
@@ -205,6 +205,15 @@ namespace dmGameObject
         ~Register();
     };
 
+    // Identifies the exact generation of a runtime-created resource. If an entry
+    // outlives its resource descriptor, the version distinguishes it from a resource
+    // later recreated with the same path.
+    struct DynamicResource
+    {
+        dmhash_t m_PathHash;
+        uint16_t m_Version;
+    };
+
     // Max hierarchical depth
     // depth is interpreted as up to <depth> levels of child nodes including root-nodes
     // Must be greater than zero
@@ -256,7 +265,7 @@ namespace dmGameObject
         dmArray<Instance*>       m_InputFocusStack;
 
         // Array of dynamically created resources (i.e runtime-only resources)
-        dmArray<dmhash_t>        m_DynamicResources;
+        dmArray<DynamicResource> m_DynamicResources;
 
         // Name-hash of the collection.
         dmhash_t                 m_NameHash;

--- a/engine/gameobject/src/gameobject/gameobject_private.h
+++ b/engine/gameobject/src/gameobject/gameobject_private.h
@@ -205,15 +205,6 @@ namespace dmGameObject
         ~Register();
     };
 
-    // Identifies the exact generation of a runtime-created resource. If an entry
-    // outlives its resource descriptor, the version distinguishes it from a resource
-    // later recreated with the same path.
-    struct DynamicResource
-    {
-        dmhash_t m_PathHash;
-        uint16_t m_Version;
-    };
-
     // Max hierarchical depth
     // depth is interpreted as up to <depth> levels of child nodes including root-nodes
     // Must be greater than zero
@@ -265,7 +256,7 @@ namespace dmGameObject
         dmArray<Instance*>       m_InputFocusStack;
 
         // Array of dynamically created resources (i.e runtime-only resources)
-        dmArray<DynamicResource> m_DynamicResources;
+        dmArray<dmhash_t>        m_DynamicResources;
 
         // Name-hash of the collection.
         dmhash_t                 m_NameHash;

--- a/engine/gamesys/src/gamesys/test/collection_proxy/build.inputs
+++ b/engine/gamesys/src/gamesys/test/collection_proxy/build.inputs
@@ -1,5 +1,7 @@
 /collection_proxy/input_consume_no.go
 /collection_proxy/input_consume_yes.go
+/collection_proxy/release_dynamic_resource_root.go
+/collection_proxy/release_dynamic_resource_target.collection
 /collection_proxy/script_load_api.go
 /collection_proxy/script_load_callback.collection
 /collection_proxy/script_load_cancel_proxy.go

--- a/engine/gamesys/src/gamesys/test/collection_proxy/release_dynamic_resource.collectionproxy
+++ b/engine/gamesys/src/gamesys/test/collection_proxy/release_dynamic_resource.collectionproxy
@@ -1,0 +1,2 @@
+collection: "/collection_proxy/release_dynamic_resource_target.collection"
+exclude: true

--- a/engine/gamesys/src/gamesys/test/collection_proxy/release_dynamic_resource_root.go
+++ b/engine/gamesys/src/gamesys/test/collection_proxy/release_dynamic_resource_root.go
@@ -1,0 +1,8 @@
+components {
+  id: "script"
+  component: "/collection_proxy/release_dynamic_resource_root.script"
+}
+components {
+  id: "collectionproxy"
+  component: "/collection_proxy/release_dynamic_resource.collectionproxy"
+}

--- a/engine/gamesys/src/gamesys/test/collection_proxy/release_dynamic_resource_root.script
+++ b/engine/gamesys/src/gamesys/test/collection_proxy/release_dynamic_resource_root.script
@@ -1,0 +1,19 @@
+issue_13002_proxy_unloaded = false
+
+function init(self)
+    msg.post("#collectionproxy", "load")
+end
+
+function on_message(self, message_id, message, sender)
+    if message_id == hash("proxy_loaded") then
+        msg.post("#collectionproxy", "init")
+        msg.post("#collectionproxy", "enable")
+    elseif message_id == hash("dynamic_resource_created") then
+        -- The resource belongs to the proxy collection, but resource.release()
+        -- removes its bookkeeping entry from this calling collection.
+        resource.release(message.resource)
+        msg.post("#collectionproxy", "unload")
+    elseif message_id == hash("proxy_unloaded") then
+        issue_13002_proxy_unloaded = true
+    end
+end

--- a/engine/gamesys/src/gamesys/test/collection_proxy/release_dynamic_resource_target.collection
+++ b/engine/gamesys/src/gamesys/test/collection_proxy/release_dynamic_resource_target.collection
@@ -1,0 +1,5 @@
+name: "release_dynamic_resource_target"
+instances {
+  id: "go"
+  prototype: "/collection_proxy/release_dynamic_resource_target.go"
+}

--- a/engine/gamesys/src/gamesys/test/collection_proxy/release_dynamic_resource_target.go
+++ b/engine/gamesys/src/gamesys/test/collection_proxy/release_dynamic_resource_target.go
@@ -1,0 +1,4 @@
+components {
+  id: "script"
+  component: "/collection_proxy/release_dynamic_resource_target.script"
+}

--- a/engine/gamesys/src/gamesys/test/collection_proxy/release_dynamic_resource_target.script
+++ b/engine/gamesys/src/gamesys/test/collection_proxy/release_dynamic_resource_target.script
@@ -1,0 +1,12 @@
+function init(self)
+    local texture = resource.create_texture("/issue_13002.texturec", {
+        width = 1,
+        height = 1,
+        type = graphics.TEXTURE_TYPE_2D,
+        format = graphics.TEXTURE_FORMAT_RGBA,
+    })
+
+    msg.post("collection:/go#script", "dynamic_resource_created", {
+        resource = texture,
+    })
+end

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -1441,6 +1441,28 @@ TEST_F(CollectionProxyComponentTest, CollectionProxySetCollectionLoadInitialize)
     lua_pop(L, 1);
 }
 
+TEST_F(CollectionProxyComponentTest, ReleaseDynamicResourceFromAnotherCollection)
+{
+    // The proxy collection creates the resource, while this parent collection
+    // releases it. Unloading the proxy must not leave stale resource bookkeeping.
+    lua_State* L = dmScript::GetLuaState(m_ScriptContext);
+    dmGameObject::HInstance go = Spawn(m_Factory, m_Collection, "/collection_proxy/release_dynamic_resource_root.goc", dmHashString64("/go"), 0,
+                                       Point3(0, 0, 0), Quat(0, 0, 0, 1), Vector3(1, 1, 1));
+    ASSERT_NE((void*)0, go);
+
+    bool proxy_unloaded = false;
+    for (uint32_t i = 0; i < 64 && !proxy_unloaded; ++i)
+    {
+        UpdateAndPostUpdateCollection(m_Collection, &m_UpdateContext, m_Register);
+
+        lua_getglobal(L, "issue_13002_proxy_unloaded");
+        proxy_unloaded = lua_toboolean(L, -1) != 0;
+        lua_pop(L, 1);
+    }
+
+    ASSERT_TRUE(proxy_unloaded);
+}
+
 TEST_F(CollectionProxyComponentTest, CollectionProxyScriptLoadApi)
 {
     lua_State* L = dmScript::GetLuaState(m_ScriptContext);


### PR DESCRIPTION
This fixes a crash when a dynamic resource (texture, sound etc) is created in collection A, released in collection B and then collection A is unloaded (or the engine is shut down or rebooted).

Fixes #13002 