### PR TITLE
Fix crash during async texture upload

### DIFF
--- a/engine/gamesys/src/gamesys/scripts/script_resource.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_resource.cpp
@@ -1218,10 +1218,6 @@ static int CreateTextureAsync(lua_State* L)
 
     // Execute the upload, the upload buffer should now be locked by this request
     dmGraphics::SetTextureAsync(g_ResourceModule.m_GraphicsContext, texture_dst, texture_params, HandleRequestCompleted, request);
-    if (!request->m_Completed && dmGraphics::GetTextureStatusFlags(g_ResourceModule.m_GraphicsContext, texture_dst) == dmGraphics::TEXTURE_STATUS_OK)
-    {
-        HandleRequestCompleted(texture_dst, request);
-    }
 
     dmScript::PushHash(L, create_params.m_PathHash);
     lua_pushnumber(L, request_handle);

--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -5367,6 +5367,10 @@ static void LogFrameBufferError(GLenum status)
         else
         {
             SetTexture(_context, texture, params);
+            if (callback)
+            {
+                callback(texture, user_data);
+            }
         }
     }
 


### PR DESCRIPTION
Fix a crash during asynchronous texture upload.

## Technical Changes

This race condition can occur:

1. Main thread calls SetTextureAsync() with request as user_data.
2. SetTextureAsync() queues the worker job and returns.
3. The main thread is preempted before executing the old status check.
4. The worker completes and clears m_DataState.
5. The main thread resumes and calls GetTextureStatusFlags().
6. It sees TEXTURE_STATUS_OK, even though the main-thread completion callback has not run.
7. The fallback calls HandleRequestCompleted() itself.

Fixes #13017 