### PR TITLE
Only integration.save-data-test uses the save_data_project

### DIFF
--- a/editor/src/clj/editor/ui.clj
+++ b/editor/src/clj/editor/ui.clj
@@ -218,10 +218,10 @@
   @*main-stage*)
 
 (defn main-scene ^Scene []
-  (.. (main-stage) (getScene)))
+  (some-> (main-stage) .getScene))
 
 (defn main-root ^Node []
-  (.. (main-scene) (getRoot)))
+  (some-> (main-scene) .getRoot))
 
 (defn- main-menu-id ^MenuBar []
   (:menu-id (user-data (main-root) ::menubar)))
@@ -2623,7 +2623,8 @@
     (.start timer))
   (reset! stopped-timers #{})
   (handler/enable-disabled-handlers!)
-  (user-data! (main-scene) ::refresh-requested? true)
+  (when-some [main-scene (main-scene)]
+    (user-data! main-scene ::refresh-requested? true))
   nil)
 
 (defn anim! [^double duration anim-fn end-fn]

--- a/editor/test/editor/protobuf_types_test.clj
+++ b/editor/test/editor/protobuf_types_test.clj
@@ -17,7 +17,6 @@
             [dynamo.graph :as g]
             [editor.defold-project :as project]
             [editor.editor-extensions :as extensions]
-            [editor.progress :as progress]
             [editor.resource :as resource]
             [integration.test-util :as test-util]
             [service.log :as log]
@@ -36,6 +35,8 @@
    "/test.atlas" ["/builtins/graphics/particle_blob.png"]
    "/test.camera" []
    "/test.collection" []
+   "/test.compute" ["/test.cp"]
+   "/test.cp" []
    "/test_embedded_gos.collection" ["/test.collection"
                                     "/main.collection"
                                     "/test.tilemap"
@@ -134,7 +135,18 @@
    "/test2.gui" ["/test.material"]})
 
 (defn fallback-dependencies-fn [resource-type]
-  (when (#{"vp" "fp" "lua" "script" "gui_script" "wav" "json" "render_script" "gltf" "glb"} (:ext resource-type))
+  (when (#{"cp"
+           "fp"
+           "glb"
+           "gltf"
+           "gui_script"
+           "json"
+           "lua"
+           "render_script"
+           "script"
+           "vp"
+           "wav"}
+         (:ext resource-type))
     (constantly [])))
 
 (deftest dependencies

--- a/editor/test/integration/compute_test.clj
+++ b/editor/test/integration/compute_test.clj
@@ -18,6 +18,6 @@
             [integration.test-util :as test-util]))
 
 (deftest compute-build-targets
-  (test-util/with-loaded-project "test/resources/save_data_project"
-    (let [node-id (test-util/resource-node project "/checked.compute")]
+  (test-util/with-loaded-project "test/resources/all_types_project"
+    (let [node-id (test-util/resource-node project "/test.compute")]
       (is (not (g/error? (g/node-value node-id :build-targets)))))))

--- a/editor/test/integration/engine/native_extensions_test.clj
+++ b/editor/test/integration/engine/native_extensions_test.clj
@@ -20,12 +20,10 @@
             [editor.app-view :as app-view]
             [editor.defold-project :as project]
             [editor.engine.native-extensions :as native-extensions]
-            [editor.fs :as fs]
             [editor.resource :as resource]
             [editor.workspace :as workspace]
             [editor.yaml :as yaml]
             [integration.test-util :as test-util]
-            [service.log :as log]
             [support.test-support :refer [with-clean-system]]
             [util.repo :as repo])
   (:import [com.defold.extender.client ExtenderResource]
@@ -128,28 +126,26 @@
 (deftest ^:native-extensions app-manifest-context-test
   (testing "app manifest is synthesized with editor build options"
     (with-clean-system
-      (let [workspace (test-util/setup-workspace! world "test/resources/extension_project")
+      (let [workspace (test-util/setup-workspace! world "test/resources/empty_project")
             project (test-util/setup-project! workspace)
             resources (make-extender-resources project "x86_64-macos")]
         (is (= {"context" expected-editor-build-context}
                (extender-resource-yaml resources "_app/app.manifest"))))))
   (testing "configured app manifest is merged with editor build options"
     (with-clean-system
-      (let [workspace (test-util/setup-workspace! world "test/resources/save_data_project")
-            project (log/without-logging
-                      (test-util/setup-project! workspace))
+      (let [workspace (test-util/setup-workspace! world "test/resources/extension_project")
+            project (test-util/setup-project! workspace)
             resources (make-extender-resources project "x86_64-macos")
-            app-manifest-file (io/file (workspace/project-directory workspace) "checked.appmanifest")
+            app-manifest-file (io/file (workspace/project-directory workspace) "game.appmanifest")
             app-manifest (yaml/load (slurp app-manifest-file))]
         (is (= 1 (count (extender-resources resources "_app/app.manifest"))))
         (is (= (assoc app-manifest "context" expected-editor-build-context)
                (extender-resource-yaml resources "_app/app.manifest"))))))
   (testing "configured app manifest in flow style is merged as yaml data"
     (with-clean-system
-      (let [workspace (test-util/setup-workspace! world "test/resources/save_data_project")
-            project (log/without-logging
-                      (test-util/setup-project! workspace))
-            app-manifest (project/get-resource-node project "/checked.appmanifest")]
+      (let [workspace (test-util/setup-workspace! world "test/resources/extension_project")
+            project (test-util/setup-project! workspace)
+            app-manifest (project/get-resource-node project "/game.appmanifest")]
         (test-util/set-code-editor-source! app-manifest "{\"platforms\": {\"wasm-web\": {\"context\": {}}}}\n")
         (let [resources (make-extender-resources project "wasm-web")]
           (is (= {"context" expected-editor-build-context
@@ -160,16 +156,13 @@
                    "context: true\n"]]
     (testing (str "configured invalid app manifest is uploaded unchanged: " (string/trim content))
       (with-clean-system
-        (let [workspace (test-util/setup-workspace! world "test/resources/save_data_project")
-              project (log/without-logging
-                        (test-util/setup-project! workspace))
-              app-manifest (project/get-resource-node project "/checked.appmanifest")]
+        (let [workspace (test-util/setup-workspace! world "test/resources/extension_project")
+              project (test-util/setup-project! workspace)
+              app-manifest (project/get-resource-node project "/game.appmanifest")]
           (test-util/set-code-editor-source! app-manifest content)
           (let [resources (make-extender-resources project "x86_64-macos")]
             (is (= content
                    (extender-resource-content (extender-resource resources "_app/app.manifest"))))))))))
-
-(defn- dummy-file [] (fs/create-temp-file! "dummy" ""))
 
 (defn- blocking-async-build! [project prefs]
   @(app-view/async-build! project :prefs prefs))

--- a/editor/test/resources/all_types_project/test.compute
+++ b/editor/test/resources/all_types_project/test.compute
@@ -1,0 +1,31 @@
+compute_program: "/test.cp"
+constants {
+  name: "constant_1"
+  type: CONSTANT_TYPE_USER
+  value {
+    x: 1.0
+    y: 2.0
+    z: 13.0
+    w: 99.0
+  }
+}
+constants {
+  name: "constant_2"
+  type: CONSTANT_TYPE_VIEWPROJ
+}
+samplers {
+  name: "texture0"
+  wrap_u: WRAP_MODE_MIRRORED_REPEAT
+  wrap_v: WRAP_MODE_CLAMP_TO_EDGE
+  filter_min: FILTER_MODE_MIN_LINEAR
+  filter_mag: FILTER_MODE_MAG_NEAREST
+  max_anisotropy: 0.0
+}
+samplers {
+  name: "texture1"
+  wrap_u: WRAP_MODE_CLAMP_TO_EDGE
+  wrap_v: WRAP_MODE_CLAMP_TO_EDGE
+  filter_min: FILTER_MODE_MIN_NEAREST
+  filter_mag: FILTER_MODE_MAG_LINEAR
+  max_anisotropy: 16.0
+}

--- a/editor/test/resources/all_types_project/test.cp
+++ b/editor/test/resources/all_types_project/test.cp
@@ -1,0 +1,13 @@
+#version 430
+
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+layout(rgba32f) uniform image2D texture_out;
+
+uniform vec4 color;
+
+void main()
+{
+    ivec2 tex_coord = ivec2(gl_GlobalInvocationID.xy);
+    imageStore(texture_out, tex_coord, color);
+}

--- a/editor/test/resources/extension_project/game.appmanifest
+++ b/editor/test/resources/extension_project/game.appmanifest
@@ -1,0 +1,112 @@
+platforms:
+  armv7-ios:
+    context:
+      excludeLibs: []
+      excludeSymbols: []
+      symbols: []
+      libs: []
+      frameworks: []
+      linkFlags: []
+  arm64-ios:
+    context:
+      excludeLibs: []
+      excludeSymbols: []
+      symbols: []
+      libs: []
+      frameworks: []
+      linkFlags: []
+  x86_64-ios:
+    context:
+      excludeLibs: []
+      excludeSymbols: []
+      symbols: []
+      libs: []
+      frameworks: []
+      linkFlags: []
+  armv7-android:
+    context:
+      excludeLibs: []
+      excludeJars: []
+      excludeSymbols: []
+      symbols: []
+      libs: []
+      linkFlags: []
+      jetifier: true
+  arm64-android:
+    context:
+      excludeLibs: []
+      excludeJars: []
+      excludeSymbols: []
+      symbols: []
+      libs: []
+      linkFlags: []
+      jetifier: true
+  x86_64-android:
+    context:
+      excludeLibs: []
+      excludeJars: []
+      excludeSymbols: []
+      symbols: []
+      libs: []
+      linkFlags: []
+      jetifier: true
+  arm64-osx:
+    context:
+      excludeLibs: []
+      excludeSymbols: []
+      symbols: []
+      libs: []
+      frameworks: []
+      linkFlags: []
+  x86_64-osx:
+    context:
+      excludeLibs: []
+      excludeSymbols: []
+      symbols: []
+      libs: []
+      frameworks: []
+      linkFlags: []
+  x86_64-linux:
+    context:
+      excludeLibs: []
+      excludeSymbols: []
+      symbols: []
+      libs: []
+      linkFlags: []
+  arm64-linux:
+    context:
+      excludeLibs: []
+      excludeSymbols: []
+      symbols: []
+      libs: []
+      linkFlags: []
+  x86-win32:
+    context:
+      excludeLibs: []
+      excludeSymbols: []
+      symbols: []
+      libs: []
+      linkFlags: []
+  x86_64-win32:
+    context:
+      excludeLibs: []
+      excludeSymbols: []
+      symbols: []
+      libs: []
+      linkFlags: []
+  wasm-web:
+    context:
+      excludeLibs: []
+      excludeJsLibs: []
+      excludeSymbols: []
+      symbols: []
+      libs: []
+      linkFlags: []
+  wasm_pthread-web:
+    context:
+      excludeLibs: []
+      excludeJsLibs: []
+      excludeSymbols: []
+      symbols: []
+      libs: []
+      linkFlags: []

--- a/editor/test/resources/extension_project/game.project
+++ b/editor/test/resources/extension_project/game.project
@@ -1,3 +1,5 @@
 [project]
 title = Empty project
 
+[native_extension]
+app_manifest = /game.appmanifest


### PR DESCRIPTION
Update the editor tests so only the `integration.save-data-test` module uses the `save_data_project`. Previously, the "This project is not used by any other tests." comment in `integration.save-data-test` lied about this.

Also fixed `dev/clear-enable-all!` exception when run from a headless REPL.