### PR TITLE
Return target URL when launching a game using editor HTTP API

### DIFF
--- a/editor/resources/localization/en.editor_localization
+++ b/editor/resources/localization/en.editor_localization
@@ -2670,6 +2670,8 @@ quick-help.build-and-run-project = Build and Run Project
 quick-help.start-or-attach-debugger = Start or Attach Debugger
 
 # Error Messages
+error.engine.url-not-reported-before-exit = Engine exited before reporting its service URL.
+error.engine.url-not-reported-in-time = Engine service URL was not reported within 15 seconds. The game may still be running.
 error.assigned-image-has-internal-errors = The assigned image has internal errors.
 error.sampler-not-defined-in-material = "{sampler}" is not defined in the Material. Use the "Clear Override" command from the label's context menu to remove the property. If the sampler is necessary for the shader, add a missing sampler in the Material.
 error.light.invalid-source = The light file could not be parsed. Fix the text format or revert your changes.

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -1522,8 +1522,10 @@
                  (or engine skip-engine))
           (do
             (show-console! main-scene tool-tab-pane)
-            (let [{:keys [error]} (launch-built-project! project engine project-directory prefs web-server false focus)]
-              (cond-> build-results error (assoc :error (exception->target-error error)))))
+            (let [{:keys [error target]} (launch-built-project! project engine project-directory prefs web-server false focus)]
+              (cond-> build-results
+                error (assoc :error (exception->target-error error))
+                target (assoc :target target))))
           build-results)))))
 
 (handler/defhandler :project.compile :global
@@ -1584,7 +1586,9 @@
           (let [{:keys [error target]} (launch-built-project! project engine project-directory prefs web-server true true)]
             (when (and target (nil? (debug-view/current-session debug-view)))
               (debug-view/start-debugger! debug-view project (:address target "localhost") (:instance-index target 0)))
-            (cond-> build-results error (assoc :error (exception->target-error error))))
+            (cond-> build-results
+              error (assoc :error (exception->target-error error))
+              target (assoc :target target)))
           build-results)))))
 
 (defn- attach-debugger! [workspace project prefs debug-view render-build-error!]
@@ -1600,11 +1604,14 @@
                     :old-artifact-map (workspace/artifact-map workspace)
                     :prefs prefs)
       (fn [build-results]
-        (when (handle-build-results! workspace render-build-error! build-results)
+        (if-not (handle-build-results! workspace render-build-error! build-results)
+          build-results
           (let [target (targets/selected-target prefs)]
-            (when (targets/controllable-target? target)
-              (debug-view/attach! debug-view project target (:artifacts build-results)))))
-        build-results))))
+            (if-not (targets/controllable-target? target)
+              build-results
+              (do
+                (debug-view/attach! debug-view project target (:artifacts build-results))
+                (assoc build-results :target target)))))))))
 
 (handler/defhandler :debugger.start :global
   ;; NOTE: Shares a shortcut with :debug-view/continue.
@@ -1756,7 +1763,7 @@
                   (doseq [launched-target (targets/all-launched-targets)]
                     (engine/reload-build-resources! launched-target updated-build-resources))
                   (engine/reload-build-resources! target updated-build-resources)))
-              build-results
+              (cond-> build-results (targets/controllable-target? target) (assoc :target target))
               (catch Exception e
                 (dialogs/make-info-dialog
                   localization

--- a/editor/src/clj/editor/command_requests.clj
+++ b/editor/src/clj/editor/command_requests.clj
@@ -20,8 +20,10 @@
             [editor.disk :as disk]
             [editor.future :as future]
             [editor.library :as library]
+            [editor.localization :as localization]
             [editor.lsp.server :as lsp.server]
             [editor.resource :as resource]
+            [editor.targets :as targets]
             [editor.ui :as ui]
             [util.coll :as coll]
             [util.http-server :as http-server])
@@ -40,21 +42,43 @@
     "false" {:focus false}
     (throw (http-server/error (http-server/response 400 "Invalid focus value; expected true or false\n")))))
 
-(defn- build-response [{:keys [error warning]} localization-state]
-  (let [issues (coll/into-> [error warning] []
-                 (filter some?)
-                 (mapcat #(:children (build-errors-view/build-resource-tree %)))
-                 (mapcat :children)
-                 (map (fn [{:keys [message severity parent cursor-range]}]
-                        (let [maybe-resource (:resource parent)]
-                          (cond-> {:message (localization-state message)
-                                   :severity (case severity
-                                               :fatal :error
-                                               :info :information
-                                               severity)}
-                            maybe-resource (assoc :resource (resource/proj-path maybe-resource))
-                            cursor-range (assoc :range (lsp.server/editor-cursor-range->lsp-range cursor-range)))))))]
-    (http-server/json-response {:success (not error) :issues issues} (if error 422 200))))
+(defn- build-response [{:keys [error target warning]} localization-state]
+  (let [target-url-result (when target
+                            (if-let [url (:url target)]
+                              url
+                              (let [url-promise (promise)
+                                    cancel! (targets/when-url-or-removed (:id target) url-promise)]
+                                (or (try
+                                      (deref url-promise 15000 ::timeout)
+                                      (finally
+                                        (cancel!)))
+                                    ::target-removed))))
+        success (and (not error) (not= ::target-removed target-url-result))
+        issues (-> [error warning]
+                   (coll/into-> []
+                     (filter some?)
+                     (mapcat #(:children (build-errors-view/build-resource-tree %)))
+                     (mapcat :children)
+                     (map (fn [{:keys [message severity parent cursor-range]}]
+                            (let [maybe-resource (:resource parent)]
+                              (cond-> {:message (localization-state message)
+                                       :severity (case severity
+                                                   :fatal :error
+                                                   :info :information
+                                                   severity)}
+                                maybe-resource (assoc :resource (resource/proj-path maybe-resource))
+                                cursor-range (assoc :range (lsp.server/editor-cursor-range->lsp-range cursor-range)))))))
+                   (cond->
+                     (= ::target-removed target-url-result)
+                     (conj {:message (localization-state (localization/message "error.engine.url-not-reported-before-exit"))
+                            :severity :error})
+
+                     (= ::timeout target-url-result)
+                     (conj {:message (localization-state (localization/message "error.engine.url-not-reported-in-time"))
+                            :severity :warning})))]
+    (http-server/json-response
+      (cond-> {:success success :issues issues} (string? target-url-result) (assoc :target {:url target-url-result}))
+      (if success 200 422))))
 
 (defn- fetch-libraries-response [[lib-results reload-succeeded] localization-state]
   (let [success (and reload-succeeded (coll/not-any? Library$Result/.problem lib-results))]

--- a/editor/src/clj/editor/targets.clj
+++ b/editor/src/clj/editor/targets.clj
@@ -25,7 +25,8 @@
             [editor.prefs :as prefs]
             [editor.process :as process]
             [editor.ui :as ui]
-            [editor.workspace :as workspace])
+            [editor.workspace :as workspace]
+            [util.coll :as coll])
   (:import [com.dynamo.discovery MDNS MDNS$Logger MDNSServiceInfo]
            [java.io ByteArrayOutputStream]
            [java.net InetAddress NetworkInterface URL URLConnection]
@@ -101,44 +102,45 @@
     (invalidate-target-menu!)
     (process/on-exit! (:process launched-target)
                       (fn []
-                        (swap! launched-targets (partial remove #(= (:id %) (:id launched-target))))
+                        (swap! launched-targets coll/filterv-> #(not= (:id %) (:id launched-target)))
                         (clear-selected-target-hint!)
                         (invalidate-target-menu!)))
     launched-target))
 
 (defn- find-by-id [targets id]
-  (some #(when (= (:id %) id) %) targets))
+  (coll/first-where #(= (:id %) id) targets))
 
-(defn- url-watcher [id callback]
-  (fn [key ref _ targets]
-    (let [target (find-by-id targets id)
-          url (:url target)]
-      (when (or url (nil? target))
-        (remove-watch ref key))
-      (when url
-        (callback url)))))
+(defn when-url-or-removed [id callback]
+  (let [key (Object.)
+        completed (atom false)
+        watcher (fn [key ref _ targets]
+                  (let [target (find-by-id targets id)
+                        url (:url target)]
+                    (when (and (or url (nil? target))
+                               (compare-and-set! completed false true))
+                      (remove-watch ref key)
+                      (callback url))))]
+    (add-watch launched-targets key watcher)
+    (watcher key launched-targets nil @launched-targets)
+    (fn cancel-url-watch! []
+      (when (compare-and-set! completed false true)
+        (remove-watch launched-targets key)))))
 
 (defn when-url [id callback]
-  (when-let [target (find-by-id @launched-targets id)]
-    (if-let [url (:url target)]
-      (callback url)
-      (add-watch launched-targets [::url id callback] (url-watcher id callback)))))
+  (when-url-or-removed id #(when % (callback %))))
 
 (defn update-launched-target! [target target-info]
-  (let [old @launched-targets
-        result-target (volatile! nil)]
-    (reset! launched-targets
-            (map (fn [launched-target]
-                   (if (= (:id launched-target) (:id target))
-                     (let [rt (merge launched-target target-info)]
-                       (vreset! result-target rt)
-                       rt)
-                     launched-target))
-                 old))
-    (when (not= old @launched-targets)
+  (let [target-id (:id target)
+        [old new] (swap-vals! launched-targets
+                              coll/mapv->
+                              (fn [launched-target]
+                                (if (= target-id (:id launched-target))
+                                  (merge launched-target target-info)
+                                  launched-target)))]
+    (when (not= old new)
       (clear-selected-target-hint!)
       (invalidate-target-menu!))
-    @result-target))
+    (find-by-id new target-id)))
 
 (defn launched-targets? []
   (seq @launched-targets))
@@ -167,8 +169,8 @@
                      (if (not= (last xs) message)
                        (let [discard (max 0 (inc (- (count xs) max-log-entries)))]
                          (-> xs
-                           (conj message)
-                           (subvec discard)))
+                             (conj message)
+                             (subvec discard)))
                        xs)))
   nil)
 
@@ -234,7 +236,7 @@
       (assoc :name (:name discovered-target)))))
 
 (defn- dedupe-targets-by-url [targets]
-  (vals
+  (coll/vals
     (reduce (fn [targets-by-url target]
               (update targets-by-url (:url target)
                       (fn [existing]
@@ -254,9 +256,9 @@
                   devices)
         old-targets @targets-atom
         targets (->> devices
-                  (pmap device->target)
-                  (filter some?)
-                  (dedupe-targets-by-url))
+                     (pmap device->target)
+                     (filter some?)
+                     (dedupe-targets-by-url))
         {external-targets false local-targets true} (group-by local-target? targets)
         targets (into [] (comp cat (distinct)) [(sort-by :url local-targets)
                                                 (sort-by :url external-targets)])]
@@ -287,7 +289,7 @@
 
 (defn- targets-worker []
   (let [mdns-service' (MDNS. (reify MDNS$Logger
-                               (log [this msg] (log msg))))]
+                               (log [_this msg] (log msg))))]
     (try
       (if (.setup mdns-service')
         (do
@@ -301,8 +303,7 @@
                 (reset! last-search now))
               (when (or search? changed?)
                 (update-targets! update-targets-context (devices mdns-service'))))))
-        (do
-          (reset! running false)))
+        (reset! running false))
       (catch Exception e
         (prn e))
       (finally
@@ -345,12 +346,11 @@
                    targets (all-targets)]
                (or (find-by-id targets target-id)
                    (when-let [{:keys [address port]} (manual-target-id->address-port target-id)]
-                     (some (fn [target]
-                             (when (and (remote-target? target)
-                                        (= address (:address target))
-                                        (= port (:port target)))
-                               target))
-                           targets))))))))
+                     (coll/first-where (fn [target]
+                                         (and (remote-target? target)
+                                              (= address (:address target))
+                                              (= port (:port target))))
+                                       targets))))))))
 
 (defn controllable-target? [target]
   (some? (:url target)))
@@ -453,7 +453,7 @@
                 mdns-options))))))
 
 (defn- locate-device [ip port]
-  (when (not-empty ip)
+  (when (coll/not-empty ip)
     (let [port (or port "8001")
           inet-addr (InetAddress/getByName ip)
           n-ifs (MDNS/getMCastInterfaces)
@@ -495,7 +495,7 @@
   (enabled? [app-view] (launched-targets?))
   (active? [] true)
   (run []
-       (kill-launched-targets!)))
+    (kill-launched-targets!)))
 
 (handler/register-menu! ::menubar :editor.defold-project/targets
   [{:label (localization/message "command.run.select-target")


### PR DESCRIPTION
Now, the editor HTTP API returns the engine URL when running a game, allowing agents and third-party tools to find it more easily. Previously, finding the URL required parsing the engine log. 

Example:

```sh
curl -sS -X POST "http://127.0.0.1:$(cat .internal/editor.port)/command/run" | jq
{
  "success": true,
  "issues": [],
  "target": {
    "url": "http://127.0.0.1:58715"
  }
}
```

Fix #13024