### PR TITLE
Add editor tests around cascade-deletion of owned substructure from resource nodes

### DIFF
--- a/editor/project.clj
+++ b/editor/project.clj
@@ -348,9 +348,9 @@
                                 :proto-paths       ["test/proto"]
                                 :resource-paths    ["test/resources"]
                                 :jvm-opts          ["-Ddefold.extension.lua-preprocessor.url=https://github.com/defold/extension-lua-preprocessor/archive/refs/tags/1.2.0.zip"
-                                                    "-Ddefold.extension.rive.url=https://github.com/defold/extension-rive/archive/refs/tags/13.0.0.zip"
+                                                    "-Ddefold.extension.rive.url=https://github.com/defold/extension-rive/archive/refs/tags/13.0.1.zip"
                                                     "-Ddefold.extension.simpledata.url=https://github.com/defold/extension-simpledata/archive/refs/tags/v1.2.0.zip"
-                                                    "-Ddefold.extension.spine.url=https://github.com/defold/extension-spine/archive/refs/tags/4.7.0.zip"
+                                                    "-Ddefold.extension.spine.url=https://github.com/defold/extension-spine/archive/refs/tags/4.7.7.zip"
                                                     "-Ddefold.extension.teal.url=https://github.com/defold/extension-teal/archive/refs/tags/v1.5.zip"
                                                     "-Ddefold.extension.texturepacker.url=https://github.com/defold/extension-texturepacker/archive/refs/tags/2.7.0.zip"
                                                     "-Ddefold.unpack.path=tmp/unpack"

--- a/editor/test/integration/extension_spine_test.clj
+++ b/editor/test/integration/extension_spine_test.clj
@@ -346,7 +346,7 @@
                               error-item-of-parent-resource (first (:children error-tree))
                               error-item-of-faulty-node (first (:children error-item-of-parent-resource))
                               error-message-of-faulty-node (:message error-item-of-faulty-node)]
-                          (is (re-matches #"Spine Json file '.*' doesn't end with '\.spinejson'" error-message-of-faulty-node))
+                          (is (re-matches #"Spine Data file '.*' must end with '\.spinejson' or '\.skel'" error-message-of-faulty-node))
                           (is (= [error-resource error-resource-node]
                                  (error-item-open-info-without-opts error-item-of-parent-resource)))
                           (is (= [error-resource error-resource-node]

--- a/editor/test/integration/save_data_test.clj
+++ b/editor/test/integration/save_data_test.clj
@@ -25,8 +25,9 @@
             [editor.resource :as resource]
             [editor.settings-core :as settings-core]
             [editor.workspace :as workspace]
-            [internal.util :as util]
             [integration.test-util :as test-util]
+            [internal.system :as is]
+            [internal.util :as util]
             [util.coll :as coll :refer [pair]]
             [util.fn :as fn]
             [util.text-util :as text-util])
@@ -1614,3 +1615,35 @@
 
       (testing "Save-related data is in cache after saving the project."
         (is (= {} (test-util/uncached-save-data-outputs-by-proj-path project)))))))
+
+(deftest no-substructure-remains-after-resource-node-deletion-test
+  (testing "Owned substructure is cleaned up after deleting resource nodes."
+    (let [surviving-node-type-kw?
+          #{:editor.code.preprocessors/CodePreprocessorsNode
+            :editor.code.script-annotations/ScriptAnnotations
+            :editor.code.script-intelligence/ScriptIntelligenceNode
+            :editor.code.transpilers/CodeTranspilersNode
+            :editor.code.transpilers/TranspilerNode
+            :editor.defold-project/Project
+            :editor.editor-extensions/EditorExtensions
+            :editor.editor-localization-bundle/EditorLocalizationBundle
+            :editor.notifications/NotificationsNode
+            :editor.workspace/Workspace
+            :integration.test-util/MockAppView}]
+      (test-util/with-loaded-project project-path
+        (let [resource-node-ids (vals (g/node-value project :nodes-by-resource-path))]
+          (g/transact
+            (g/delete-nodes resource-node-ids))
+          (let [leaked-node-frequencies
+                (->> @g/*the-system*
+                     (is/graphs)
+                     (eduction
+                       (map val)
+                       (mapcat :nodes)
+                       (map val)
+                       (map g/node-type)
+                       (map :k)
+                       (remove surviving-node-type-kw?))
+                     (frequencies)
+                     (into (sorted-map)))]
+            (is (= {} leaked-node-frequencies))))))))


### PR DESCRIPTION
It was discovered that some substructure nodes owned by resource nodes in `extension-spine` and `extension-rive` were not deleted alongside their owning `ResourceNode`. A test was added to the save-data-tests to ensure all such nodes are properly deleted.

It may not be strictly save-data related, but we have meta-test in place for that project to ensure all configurations are covered, which benefits us here.