### PR TITLE
Format on save with option

### DIFF
--- a/editor/resources/localization/en.editor_localization
+++ b/editor/resources/localization/en.editor_localization
@@ -724,6 +724,8 @@ prefs.label.code.zoom-on-scroll = Zoom on Scroll
 prefs.label.code.hover = Hover popup
 prefs.help.code.hover = Show code documentation popup on hover
 prefs.label.code.auto-closing-parens = Auto-insert closing parens
+prefs.label.code.format-on-save = Format on save
+prefs.help.code.format-on-save = Run the language server formatter on open files when saving
 
 # Extensions tab
 prefs.label.extensions.build-server = Build Server

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -31,6 +31,7 @@
             [editor.build-errors-view :as build-errors-view]
             [editor.camera :as camera]
             [editor.code.data :as data :refer [CursorRange->line-number]]
+            [editor.code.view :as code-view]
             [editor.console :as console]
             [editor.debug-view :as debug-view]
             [editor.defold-project :as project]
@@ -971,7 +972,7 @@
   [app-view changes-view project prefs]
   (when (and (auto-save-on-app-unfocus? prefs)
              (can-async-save?))
-    (async-save! app-view changes-view project project/dirty-save-data)))
+    (async-save! app-view changes-view project prefs project/dirty-save-data)))
 
 (defn- decorate-target [engine-descriptor target]
   (assoc target :engine-id (:id engine-descriptor)))
@@ -3035,22 +3036,36 @@
                                                                       :use-custom-editor false})))))
 
 (defn- async-save!
-  ([app-view changes-view project save-data-fn]
-   (async-save! app-view changes-view project save-data-fn nil))
-  ([app-view changes-view project save-data-fn callback!]
+  ([app-view changes-view project prefs save-data-fn]
+   (async-save! app-view changes-view project prefs save-data-fn nil))
+  ([app-view changes-view project prefs save-data-fn callback!]
    {:pre [(g/node-id? app-view)
           (g/node-id? changes-view)
           (g/node-id? project)
           (ifn? save-data-fn)
           (or (nil? callback!) (ifn? callback!))]}
    (let [render-reload-progress! (make-render-task-progress :resource-sync)
-         render-save-progress! (make-render-task-progress :save-all)]
-     (disk/async-save! render-reload-progress! render-save-progress! save-data-fn project changes-view
-                       (fn [successful?]
-                         (when successful?
-                           (ui/user-data! (g/node-value app-view :scene) ::ui/refresh-requested? true))
-                         (when callback!
-                           (callback! successful? render-reload-progress! render-save-progress!)))))))
+         render-save-progress! (make-render-task-progress :save-all)
+         save! (fn save! []
+                 (disk/async-save! render-reload-progress! render-save-progress! save-data-fn project changes-view
+                                   (fn [successful?]
+                                     (when successful?
+                                       (ui/user-data! (g/node-value app-view :scene) ::ui/refresh-requested? true))
+                                     (when callback!
+                                       (callback! successful? render-reload-progress! render-save-progress!)))))]
+     (if-not (prefs/get prefs [:code :format-on-save])
+       (save!)
+       (do
+         (disk-availability/push-busy!)
+         (try
+           (code-view/async-format-on-save!
+             (coll/keys (g/node-value app-view :open-views))
+             (fn formatted! []
+               (disk-availability/pop-busy!)
+               (save!)))
+           (catch Throwable error
+             (disk-availability/pop-busy!)
+             (throw error))))))))
 
 (defn- restart-defold! [^Stage stage prefs]
   (store-window-state! stage prefs)
@@ -3075,7 +3090,7 @@
                            {:text (localization/message "dialog.restart-defold.button.save-and-restart")
                             :default-button true
                             :result true}]})
-          (async-save! app-view changes-view project project/dirty-save-data
+          (async-save! app-view changes-view project prefs project/dirty-save-data
                        (fn [successful? _render-reload-progress! _render-save-progress!]
                          (when successful?
                            (restart-defold! stage prefs)))))))))
@@ -3100,12 +3115,12 @@
 
 (handler/defhandler :file.save-all :global
   (enabled? [] (not (bob/build-in-progress?)))
-  (run [app-view changes-view project]
-    (async-save! app-view changes-view project project/dirty-save-data)))
+  (run [app-view changes-view project prefs]
+    (async-save! app-view changes-view project prefs project/dirty-save-data)))
 
 (handler/defhandler :file.save-and-upgrade-all :global
   (enabled? [] (not (bob/build-in-progress?)))
-  (run [app-view changes-view project workspace localization]
+  (run [app-view changes-view project prefs workspace localization]
     (let [git (g/node-value changes-view :git)]
       (when (and
 
@@ -3191,7 +3206,7 @@
           (when save-data-fn
             ;; The user has opted to proceed with the file format upgrade.
             (project/clear-cached-save-data! project)
-            (async-save! app-view changes-view project save-data-fn)))))))
+            (async-save! app-view changes-view project prefs save-data-fn)))))))
 
 (handler/defhandler :file.load-external-changes :global
   (active? [prefs] (not (async-reload-on-app-focus? prefs)))

--- a/editor/src/clj/editor/code/view.clj
+++ b/editor/src/clj/editor/code/view.clj
@@ -3080,14 +3080,18 @@
                                line-edits
                                (get-property view-node :layout evaluation-context)))))))))
 
-(defn- format-whole-document! [view-node lsp resource indent-type lines]
+(defn- format-whole-document! [view-node lsp resource indent-type lines done! & {:as opts}]
   (lsp/format-document!
     lsp resource indent-type
     (fn [response]
       (ui/run-later
-        (if response
-          (apply-formatting-edits! view-node lines (:edits response))
-          (show-formatting-failed-notification! resource))))))
+        (try
+          (if response
+            (apply-formatting-edits! view-node lines (:edits response))
+            (show-formatting-failed-notification! resource))
+          (finally
+            (done!)))))
+    opts))
 
 (defn- format-selected-rows! [view-node lsp resource indent-type lines cursor-ranges]
   (when-let [row-spans (coll/not-empty (data/format-row-spans lines cursor-ranges))]
@@ -3100,6 +3104,36 @@
             (apply-formatting-edits!
               view-node lines
               (vec (sort-by key (into [] (mapcat :edits) responses))))))))))
+
+(defn async-format-on-save! [view-nodes done!]
+  (g/let-ec [basis (:basis evaluation-context)
+             pending
+             (into []
+                   (keep
+                     (fn [view-node]
+                       (when (g/node-instance? basis CodeEditorView view-node)
+                         (let [resource-node (get-property view-node :resource-node evaluation-context)
+                               resource (g/node-value resource-node :resource evaluation-context)
+                               lsp (lsp/get-node-lsp basis resource-node)]
+                           (when (and (resource/file-resource? resource)
+                                      (true? (g/node-value resource-node :dirty evaluation-context))
+                                      (lsp/has-language-servers-running-for-language? lsp (resource/language resource)))
+                             {:view-node view-node
+                              :lsp lsp
+                              :resource resource
+                              :indent-type (get-property view-node :indent-type evaluation-context)
+                              :lines (get-property view-node :lines evaluation-context)})))))
+                   view-nodes)]
+    (if (coll/empty? pending)
+      (done!)
+      (let [remaining-volatile (volatile! (count pending))]
+        (doseq [{:keys [view-node lsp resource indent-type lines]} pending]
+          (format-whole-document!
+            view-node lsp resource indent-type lines
+            (fn []
+              (when (zero? (long (vswap! remaining-volatile #(dec (long %)))))
+                (done!)))
+            :timeout-ms 2000))))))
 
 (defn- formatting-selected-rows? [cursor-ranges]
   (coll/not-every? data/cursor-range-empty? cursor-ranges))
@@ -3120,7 +3154,7 @@
         (show-no-language-server-for-resource-language-notification! resource)
         (if (formatting-selected-rows? cursor-ranges)
           (format-selected-rows! view-node lsp resource indent-type lines cursor-ranges)
-          (format-whole-document! view-node lsp resource indent-type lines))))))
+          (format-whole-document! view-node lsp resource indent-type lines fn/constantly-nil))))))
 
 (handler/defhandler :code.goto-definition :code-view
   (enabled? [view-node evaluation-context]

--- a/editor/src/clj/editor/prefs.clj
+++ b/editor/src/clj/editor/prefs.clj
@@ -130,6 +130,8 @@
                           :scope :project}
             :auto-closing-parens {:type :boolean
                                   :default true}
+            :format-on-save {:type :boolean
+                             :default false}
             :visibility {:type :object
                          :properties
                          {:indentation-guides {:type :boolean :default true}

--- a/editor/src/clj/editor/prefs_dialog.clj
+++ b/editor/src/clj/editor/prefs_dialog.clj
@@ -76,7 +76,8 @@
                 [:code :font :name]
                 [:code :zoom-on-scroll]
                 [:code :hover]
-                [:code :auto-closing-parens]]}
+                [:code :auto-closing-parens]
+                [:code :format-on-save]]}
        {:pattern (localization/message "prefs.tab.extensions")
         :paths [[:extensions :build-server]
                 [:extensions :build-server-username]


### PR DESCRIPTION
Using the new LSP format document/format region feature `Alt + Shift + F`, there is now an option in `Preferences > Code` for running the formatter for all files on save. This option is disabled by default and must be enabled.

<img width="732" height="379" alt="image" src="https://github.com/user-attachments/assets/73416490-32ff-42f4-b857-3f9314a4493e" />


Fixes #11527
Fixes #12993


### Technical changes

There are other save file paths like when closing the editor, editor extension, and update/restart, but I decided that maybe it would be better to only allow this feature when manually saving, so there are less surprises
