### PR TITLE
Fix a crash when calling `font.prewarm_text()` twice in short succession

### DIFF
--- a/engine/gamesys/src/gamesys/scripts/script_font.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_font.cpp
@@ -173,8 +173,8 @@ static void PrewarmTextCallback(void* _ctx, int result, const char* errmsg)
 
             dmScript::TeardownCallback(cbk);
         }
-        dmScript::DestroyCallback(cbk); // only do this if you're not using the callback again
     }
+    dmScript::DestroyCallback(cbk); // only do this if you're not using the callback again
     delete ctx;
 }
 

--- a/engine/gamesys/src/gamesys/scripts/script_font.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_font.cpp
@@ -154,25 +154,30 @@ static void PrewarmTextCallback(void* _ctx, int result, const char* errmsg)
 {
     CallbackContext* ctx = (CallbackContext*)_ctx;
     dmScript::LuaCallbackInfo* cbk = ctx->m_Callback;
-
-    lua_State* L = dmScript::GetCallbackLuaContext(cbk);
-    DM_LUA_STACK_CHECK(L, 0);
-
-    if (dmScript::SetupCallback(cbk))
+    if (cbk)
     {
-        int nargs = 3;
-        lua_pushinteger(L, (int)ctx->m_Request);
-        lua_pushboolean(L, result != 0);
-        if (0 != errmsg)
-            lua_pushstring(L, errmsg);
-        else
-            lua_pushnil(L);
+        if (dmScript::IsCallbackValid(cbk))
+        {
+            lua_State* L = dmScript::GetCallbackLuaContext(cbk);
+            DM_LUA_STACK_CHECK(L, 0);
 
-        dmScript::PCall(L, 1 + nargs, 0); // self + # user arguments
+            if (dmScript::SetupCallback(cbk))
+            {
+                int nargs = 3;
+                lua_pushinteger(L, (int)ctx->m_Request);
+                lua_pushboolean(L, result != 0);
+                if (0 != errmsg)
+                    lua_pushstring(L, errmsg);
+                else
+                    lua_pushnil(L);
 
-        dmScript::TeardownCallback(cbk);
+                dmScript::PCall(L, 1 + nargs, 0); // self + # user arguments
+
+                dmScript::TeardownCallback(cbk);
+            }
+        }
+        dmScript::DestroyCallback(cbk); // only do this if you're not using the callback again
     }
-    dmScript::DestroyCallback(cbk); // only do this if you're not using the callback again
     delete ctx;
 }
 

--- a/engine/gamesys/src/gamesys/scripts/script_font.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_font.cpp
@@ -154,27 +154,24 @@ static void PrewarmTextCallback(void* _ctx, int result, const char* errmsg)
 {
     CallbackContext* ctx = (CallbackContext*)_ctx;
     dmScript::LuaCallbackInfo* cbk = ctx->m_Callback;
-    if (cbk)
+    if (dmScript::IsCallbackValid(cbk))
     {
-        if (dmScript::IsCallbackValid(cbk))
+        lua_State* L = dmScript::GetCallbackLuaContext(cbk);
+        DM_LUA_STACK_CHECK(L, 0);
+
+        if (dmScript::SetupCallback(cbk))
         {
-            lua_State* L = dmScript::GetCallbackLuaContext(cbk);
-            DM_LUA_STACK_CHECK(L, 0);
+            int nargs = 3;
+            lua_pushinteger(L, (int)ctx->m_Request);
+            lua_pushboolean(L, result != 0);
+            if (0 != errmsg)
+                lua_pushstring(L, errmsg);
+            else
+                lua_pushnil(L);
 
-            if (dmScript::SetupCallback(cbk))
-            {
-                int nargs = 3;
-                lua_pushinteger(L, (int)ctx->m_Request);
-                lua_pushboolean(L, result != 0);
-                if (0 != errmsg)
-                    lua_pushstring(L, errmsg);
-                else
-                    lua_pushnil(L);
+            dmScript::PCall(L, 1 + nargs, 0); // self + # user arguments
 
-                dmScript::PCall(L, 1 + nargs, 0); // self + # user arguments
-
-                dmScript::TeardownCallback(cbk);
-            }
+            dmScript::TeardownCallback(cbk);
         }
         dmScript::DestroyCallback(cbk); // only do this if you're not using the callback again
     }

--- a/engine/gamesys/src/gamesys/test/font/build.inputs
+++ b/engine/gamesys/src/gamesys/test/font/build.inputs
@@ -2,4 +2,5 @@
 /font/glyph_bank_test_1.font
 /font/glyph_bank_test_2.font
 /font/invalid_material.font
+/font/prewarm_callback_instance_reuse.go
 /font/valid_font.font

--- a/engine/gamesys/src/gamesys/test/font/prewarm_callback_instance_reuse.go
+++ b/engine/gamesys/src/gamesys/test/font/prewarm_callback_instance_reuse.go
@@ -1,0 +1,4 @@
+components {
+  id: "script"
+  component: "/font/prewarm_callback_instance_reuse.script"
+}

--- a/engine/gamesys/src/gamesys/test/font/prewarm_callback_instance_reuse.script
+++ b/engine/gamesys/src/gamesys/test/font/prewarm_callback_instance_reuse.script
@@ -1,0 +1,31 @@
+-- Copyright 2020-2026 The Defold Foundation
+-- Copyright 2014-2020 King
+-- Copyright 2009-2014 Ragnar Svensson, Christian Murray
+-- Licensed under the Defold License version 1.0 (the "License"); you may not use
+-- this file except in compliance with the License.
+--
+-- You may obtain a copy of the License, together with FAQs at
+-- https://www.defold.com/license
+--
+-- Unless required by applicable law or agreed to in writing, software distributed
+-- under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+-- CONDITIONS OF ANY KIND, either express or implied. See the License for the
+-- specific language governing permissions and limitations under the License.
+
+prewarm_instance_count = 0
+prewarm_stale_callback_count = 0
+prewarm_replacement_callback_count = 0
+
+function init(self)
+    prewarm_instance_count = prewarm_instance_count + 1
+
+    if prewarm_instance_count == 1 then
+        font.prewarm_text("/font/dyn_glyph_bank_test_1.fontc", "First instance", function(self, request_id, result, errmsg)
+            prewarm_stale_callback_count = prewarm_stale_callback_count + 1
+        end)
+    else
+        font.prewarm_text("/font/dyn_glyph_bank_test_1.fontc", "Replacement instance", function(self, request_id, result, errmsg)
+            prewarm_replacement_callback_count = prewarm_replacement_callback_count + 1
+        end)
+    end
+end

--- a/engine/gamesys/src/gamesys/test/font/prewarm_callback_instance_reuse.script
+++ b/engine/gamesys/src/gamesys/test/font/prewarm_callback_instance_reuse.script
@@ -12,14 +12,11 @@
 -- CONDITIONS OF ANY KIND, either express or implied. See the License for the
 -- specific language governing permissions and limitations under the License.
 
-prewarm_instance_count = 0
 prewarm_stale_callback_count = 0
 prewarm_replacement_callback_count = 0
 
 function init(self)
-    prewarm_instance_count = prewarm_instance_count + 1
-
-    if prewarm_instance_count == 1 then
+    if go.get_id() == hash("/first") then
         font.prewarm_text("/font/dyn_glyph_bank_test_1.fontc", "First instance", function(self, request_id, result, errmsg)
             prewarm_stale_callback_count = prewarm_stale_callback_count + 1
         end)

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -3628,8 +3628,8 @@ TEST_F(FontTest, PrewarmTextRejectsCallbackAfterScriptInstanceReuse)
 
     // Occupy the only worker thread so both prewarm requests remain pending
     // until the two script instances have been created and destroyed/reused.
-    int32_atomic_t blocker_started = 0;
-    int32_atomic_t blocker_allow_finish = 0;
+    int32_t blocker_started = 0;
+    int32_t blocker_allow_finish = 0;
     Job blocker = {};
     blocker.m_Process = ProcessBlockingFontJob;
     blocker.m_Context = &blocker_started;

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -3600,6 +3600,101 @@ static bool WaitForDynamicFontJobCallbacks(HJobContext job_context, DynamicFontJ
     return state->m_CallbackCount >= callback_count;
 }
 
+static int32_t ProcessBlockingFontJob(HJobContext job_context, HJob job, void* user_context, void* user_data)
+{
+    (void)job_context;
+    (void)job;
+    int32_atomic_t* started = (int32_atomic_t*)user_context;
+    int32_atomic_t* allow_finish = (int32_atomic_t*)user_data;
+    dmAtomicStore32(started, 1);
+
+    uint64_t stop_time = dmTime::GetMonotonicTime() + 500000;
+    while (!dmAtomicGet32(allow_finish) && dmTime::GetMonotonicTime() < stop_time)
+    {
+        dmTime::Sleep(1000);
+    }
+    return 1;
+}
+
+// A completed prewarm request must not use callback/self references from a new
+// script instance that reused the destroyed instance's Lua context-table slot.
+TEST_F(FontTest, PrewarmTextRejectsCallbackAfterScriptInstanceReuse)
+{
+    ASSERT_TRUE(dmGameObject::Init(m_Collection));
+
+    dmGameSystem::FontResource* font = 0;
+    ASSERT_EQ(dmResource::RESULT_OK, dmResource::Get(m_Factory, "/font/dyn_glyph_bank_test_1.fontc", (void**)&font));
+    ASSERT_NE((void*)0, font);
+
+    // Occupy the only worker thread so both prewarm requests remain pending
+    // until the two script instances have been created and destroyed/reused.
+    int32_atomic_t blocker_started = 0;
+    int32_atomic_t blocker_allow_finish = 0;
+    Job blocker = {};
+    blocker.m_Process = ProcessBlockingFontJob;
+    blocker.m_Context = &blocker_started;
+    blocker.m_Data = &blocker_allow_finish;
+
+    HJob blocker_job = JobSystemCreateJob(m_JobContext, &blocker);
+    ASSERT_NE((HJob)0, blocker_job);
+    ASSERT_EQ(JOBSYSTEM_RESULT_OK, JobSystemPushJob(m_JobContext, blocker_job));
+
+    uint64_t blocker_stop_time = dmTime::GetMonotonicTime() + 500000;
+    while (!dmAtomicGet32(&blocker_started) && dmTime::GetMonotonicTime() < blocker_stop_time)
+    {
+        dmTime::Sleep(1000);
+    }
+    ASSERT_EQ(1, dmAtomicGet32(&blocker_started));
+
+    // The first instance starts a prewarm request. Its Lua callback remembers
+    // this instance's context-table reference plus callback/self indices.
+    dmGameObject::HInstance first = Spawn(m_Factory, m_Collection, "/font/prewarm_callback_instance_reuse.goc", dmHashString64("/first"), 0,
+                                          Point3(0, 0, 0), Quat(0, 0, 0, 1), Vector3(1, 1, 1));
+    ASSERT_NE((dmGameObject::HInstance)0, first);
+    ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+
+    // Destroy the first instance before its prewarm job completes. The Lua
+    // registry can now reuse its released context-table reference.
+    dmGameObject::Delete(m_Collection, first, false);
+    ASSERT_TRUE(dmGameObject::PostUpdate(m_Collection));
+
+    // The replacement instance deterministically reuses that registry slot and
+    // creates another callback with the same table-local callback/self indices.
+    // SetupCallback() alone cannot distinguish the old and new instances.
+    dmGameObject::HInstance replacement = Spawn(m_Factory, m_Collection, "/font/prewarm_callback_instance_reuse.goc", dmHashString64("/replacement"), 0,
+                                                Point3(0, 0, 0), Quat(0, 0, 0, 1), Vector3(1, 1, 1));
+    ASSERT_NE((dmGameObject::HInstance)0, replacement);
+    ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+
+    // Let the blocker and both font jobs finish, then dispatch their callbacks
+    // on this thread through JobSystemUpdate().
+    dmAtomicStore32(&blocker_allow_finish, 1);
+
+    uint64_t stop_time = dmTime::GetMonotonicTime() + 500000;
+    while (!font->m_PendingJobs.Empty() && dmTime::GetMonotonicTime() < stop_time)
+    {
+        JobSystemUpdate(m_JobContext, 0);
+        dmTime::Sleep(1000);
+    }
+
+    // IsCallbackValid() must reject the stale callback by unique script id.
+    // Without that check, the first completion resolves through the replacement
+    // context table and invokes its callback, making this count two instead of one.
+    lua_State* L = dmScript::GetLuaState(m_ScriptContext);
+    ASSERT_TRUE(font->m_PendingJobs.Empty());
+
+    lua_getglobal(L, "prewarm_stale_callback_count");
+    ASSERT_EQ(0, lua_tointeger(L, -1));
+    lua_pop(L, 1);
+
+    lua_getglobal(L, "prewarm_replacement_callback_count");
+    ASSERT_EQ(1, lua_tointeger(L, -1));
+    lua_pop(L, 1);
+
+    dmResource::Release(m_Factory, font);
+    ASSERT_TRUE(dmGameObject::Final(m_Collection));
+}
+
 // Reloading a dynamic font with pending work must cancel the old jobs and
 // suppress callbacks after the old font state has been torn down.
 TEST_F(FontTest, ReloadCancelsPendingDynamicFontJobs)


### PR DESCRIPTION
This change fixes a crash when calling `font.prewarm_text()` twice for the same font and in short succession.

Fixes #13015 