### PR TITLE
Fix crash related to gamepad detection on Android

### DIFF
--- a/external/glfw/java/com/dynamo/android/DefoldActivity.java
+++ b/external/glfw/java/com/dynamo/android/DefoldActivity.java
@@ -603,7 +603,10 @@ public class DefoldActivity extends NativeActivity {
         String name = "Android Controller";
         InputDevice device = InputDevice.getDevice(deviceId);
         if (device != null) {
-            name = device.getName();
+            String deviceName = device.getName();
+            if (deviceName != null && !deviceName.isEmpty()) {
+                name = deviceName;
+            }
         }
         return name;
     }
@@ -621,7 +624,10 @@ public class DefoldActivity extends NativeActivity {
             if (descriptor != null && !descriptor.isEmpty()) {
                 return descriptor;
             }
-            return device.getName();
+            String deviceName = device.getName();
+            if (deviceName != null && !deviceName.isEmpty()) {
+                return deviceName;
+            }
         }
         return "Android Controller";
     }

--- a/external/glfw/lib/android/android_jni.c
+++ b/external/glfw/lib/android/android_jni.c
@@ -13,6 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #include "android_jni.h"
+#include "android_log.h"
 #include <assert.h>
 
 
@@ -67,9 +68,33 @@ void JNIDetachCurrentThreadIfNeeded(int did_attach)
     }
 }
 
-jmethodID JNIGetMethodID(JNIEnv* env, jobject instance, char* method, char* signature)
+int JNICheckAndClearException(JNIEnv* env)
+{
+    if (!(*env)->ExceptionCheck(env))
+    {
+        return 0;
+    }
+
+    (*env)->ExceptionDescribe(env);
+    (*env)->ExceptionClear(env);
+    return 1;
+}
+
+jmethodID JNIGetMethodID(JNIEnv* env, jobject instance, const char* method, const char* signature)
 {
     if (instance == 0) return 0;
     jclass clazz = (*env)->GetObjectClass(env, instance);
-    return (*env)->GetMethodID(env, clazz, method, signature);
+    if (JNICheckAndClearException(env) || clazz == 0)
+    {
+        if (clazz != 0)
+        {
+            (*env)->DeleteLocalRef(env, clazz);
+        }
+        return 0;
+    }
+
+    jmethodID method_id = (*env)->GetMethodID(env, clazz, method, signature);
+    int exception = JNICheckAndClearException(env);
+    (*env)->DeleteLocalRef(env, clazz);
+    return exception ? 0 : method_id;
 }

--- a/external/glfw/lib/android/android_jni.c
+++ b/external/glfw/lib/android/android_jni.c
@@ -13,7 +13,6 @@
 // specific language governing permissions and limitations under the License.
 
 #include "android_jni.h"
-#include "android_log.h"
 #include <assert.h>
 
 

--- a/external/glfw/lib/android/android_jni.h
+++ b/external/glfw/lib/android/android_jni.h
@@ -27,7 +27,8 @@ JNIEnv* JNIAttachCurrentThread();
 void JNIDetachCurrentThread();
 void JNIAttachCurrentThreadIfNeeded(int* did_attach);
 void JNIDetachCurrentThreadIfNeeded(int did_attach);
-jmethodID JNIGetMethodID(JNIEnv* env, jobject instance, char* method, char* signature);
+int JNICheckAndClearException(JNIEnv* env, const char* operation);
+jmethodID JNIGetMethodID(JNIEnv* env, jobject instance, const char* method, const char* signature);
 int JNIAndroidSetCommandLine(ANativeActivity* activity);
 
 #endif // DM_GLFW_ANDROID_JNI_H

--- a/external/glfw/lib/android/android_joystick.c
+++ b/external/glfw/lib/android/android_joystick.c
@@ -279,28 +279,54 @@ void glfwAndroidUpdateJoystick(const AInputEvent* event)
 void glfwAndroidDiscoverJoysticks()
 {
     int32_t joystickIndex;
-
-    // prepare all connected gamepads to be refreshed
-    for (joystickIndex = 0; joystickIndex <= GLFW_JOYSTICK_LAST; joystickIndex++)
-    {
-        if (_glfwJoy[joystickIndex].State == GLFW_ANDROID_GAMEPAD_CONNECTED)
-        {
-            _glfwJoy[joystickIndex].State = GLFW_ANDROID_GAMEPAD_REFRESHING;
-        }
-    }
+    int discovery_succeeded = 0;
 
     JNIEnv* env = JNIAttachCurrentThread();
     if (env)
     {
         jobject native_activity = g_AndroidApp->activity->clazz;
+        if (native_activity == 0) goto cleanup_and_early_exit;
+
         jmethodID get_game_controller_device_ids = JNIGetMethodID(env, native_activity, "getGameControllerDeviceIds", "()[I");
         jmethodID get_game_controller_device_name = JNIGetMethodID(env, native_activity, "getGameControllerDeviceName", "(I)Ljava/lang/String;");
         jmethodID get_game_controller_device_descriptor = JNIGetMethodID(env, native_activity, "getGameControllerDeviceDescriptor", "(I)Ljava/lang/String;");
         jmethodID get_game_controller_device_vendor_id = JNIGetMethodID(env, native_activity, "getGameControllerDeviceVendorId", "(I)I");
         jmethodID get_game_controller_device_product_id = JNIGetMethodID(env, native_activity, "getGameControllerDeviceProductId", "(I)I");
+        if (get_game_controller_device_ids == 0) goto cleanup_and_early_exit;
+        if (get_game_controller_device_name == 0) goto cleanup_and_early_exit;
+        if (get_game_controller_device_descriptor == 0) goto cleanup_and_early_exit;
+        if (get_game_controller_device_vendor_id == 0) goto cleanup_and_early_exit;
+        if (get_game_controller_device_product_id == 0) goto cleanup_and_early_exit;
+
         jintArray device_ids = (*env)->CallObjectMethod(env, native_activity, get_game_controller_device_ids);
+        if (JNICheckAndClearException(env) || device_ids == 0)
+        {
+            goto cleanup_and_early_exit;
+        }
+
         jsize len = (*env)->GetArrayLength(env, device_ids);
+        if (JNICheckAndClearException(env))
+        {
+            goto cleanup_and_early_exit;
+        }
+
         jint *elements = (*env)->GetIntArrayElements(env, device_ids, 0);
+        if (JNICheckAndClearException(env) || elements == 0)
+        {
+            goto cleanup_and_early_exit;
+        }
+
+        // Prepare connected gamepads to be refreshed only after discovery has
+        // returned a valid array. Earlier failures must leave their state intact.
+        for (joystickIndex = 0; joystickIndex <= GLFW_JOYSTICK_LAST; joystickIndex++)
+        {
+            if (_glfwJoy[joystickIndex].State == GLFW_ANDROID_GAMEPAD_CONNECTED)
+            {
+                _glfwJoy[joystickIndex].State = GLFW_ANDROID_GAMEPAD_REFRESHING;
+            }
+        }
+        discovery_succeeded = 1;
+
         for (int i=0; i<len; i++)
         {
             int32_t deviceId = elements[i];
@@ -309,25 +335,70 @@ void glfwAndroidDiscoverJoysticks()
             {
                 jint jni_device_id = deviceId;
                 jstring jni_device_name = (*env)->CallObjectMethod(env, native_activity, get_game_controller_device_name, jni_device_id);
+                if (JNICheckAndClearException(env) || jni_device_name == 0)
+                {
+                    discovery_succeeded = 0;
+                    goto cleanup_and_break;
+                }
+
                 jstring jni_device_descriptor = (*env)->CallObjectMethod(env, native_activity, get_game_controller_device_descriptor, jni_device_id);
+                if (JNICheckAndClearException(env) || jni_device_descriptor == 0)
+                {
+                    discovery_succeeded = 0;
+                    goto cleanup_and_break;
+                }
+
                 jint vendor_id = (*env)->CallIntMethod(env, native_activity, get_game_controller_device_vendor_id, jni_device_id);
+                if (JNICheckAndClearException(env))
+                {
+                    discovery_succeeded = 0;
+                    goto cleanup_and_break;
+                }
+
                 jint product_id = (*env)->CallIntMethod(env, native_activity, get_game_controller_device_product_id, jni_device_id);
+                if (JNICheckAndClearException(env))
+                {
+                    discovery_succeeded = 0;
+                    goto cleanup_and_break;
+                }
+
                 char deviceGuid[DEVICE_GUID_LENGTH + 1];
                 const char *deviceName = (*env)->GetStringUTFChars(env, jni_device_name, 0);
+                if (JNICheckAndClearException(env) || deviceName == 0)
+                {
+                    discovery_succeeded = 0;
+                    goto cleanup_and_break;
+                }
+
                 const char *deviceDescriptor = (*env)->GetStringUTFChars(env, jni_device_descriptor, 0);
+                if (JNICheckAndClearException(env) || deviceDescriptor == 0)
+                {
+                    discovery_succeeded = 0;
+                    goto cleanup_and_break;
+                }
 
                 glfwCreateJoystickDeviceGuid(SDL_ANDROID_GAMEPAD_BUS, (unsigned short) vendor_id, (unsigned short) product_id,
                     0, 0, deviceDescriptor, 0, 0, deviceGuid);
                 deviceIndex = glfwAndroidConnectJoystick(deviceId, deviceName, deviceGuid);
-                (*env)->ReleaseStringUTFChars(env, jni_device_descriptor, deviceDescriptor);
-                (*env)->ReleaseStringUTFChars(env, jni_device_name, deviceName);
+cleanup_and_break:
+                if (deviceDescriptor != 0)      (*env)->ReleaseStringUTFChars(env, jni_device_descriptor, deviceDescriptor);
+                if (deviceName != 0)            (*env)->ReleaseStringUTFChars(env, jni_device_name, deviceName);
+                if (jni_device_descriptor != 0) (*env)->DeleteLocalRef(env, jni_device_descriptor);
+                if (jni_device_name != 0)       (*env)->DeleteLocalRef(env, jni_device_name);
+                if (!discovery_succeeded)
+                {
+                    break;
+                }
             }
             else
             {
                 _glfwJoy[deviceIndex].State = GLFW_ANDROID_GAMEPAD_CONNECTED;
             }
         }
-        (*env)->ReleaseIntArrayElements(env, device_ids, elements, 0);
+
+cleanup_and_early_exit:
+        if (elements != 0) (*env)->ReleaseIntArrayElements(env, device_ids, elements, JNI_ABORT); // JNI_ABORT because we are not modifying elements
+        if (device_ids != 0) (*env)->DeleteLocalRef(env, device_ids);
         JNIDetachCurrentThread();
     }
 
@@ -336,7 +407,14 @@ void glfwAndroidDiscoverJoysticks()
     {
         if (_glfwJoy[joystickIndex].State == GLFW_ANDROID_GAMEPAD_REFRESHING)
         {
-            glfwAndroidDisconnectJoystick(joystickIndex);
+            if (discovery_succeeded)
+            {
+                glfwAndroidDisconnectJoystick(joystickIndex);
+            }
+            else
+            {
+                _glfwJoy[joystickIndex].State = GLFW_ANDROID_GAMEPAD_CONNECTED;
+            }
         }
     }
 }

--- a/external/glfw/lib/android/android_joystick.c
+++ b/external/glfw/lib/android/android_joystick.c
@@ -287,31 +287,55 @@ void glfwAndroidDiscoverJoysticks()
         jobject native_activity = g_AndroidApp->activity->clazz;
         if (native_activity == 0) goto cleanup_and_early_exit;
 
-        jmethodID get_game_controller_device_ids = JNIGetMethodID(env, native_activity, "getGameControllerDeviceIds", "()[I");
-        jmethodID get_game_controller_device_name = JNIGetMethodID(env, native_activity, "getGameControllerDeviceName", "(I)Ljava/lang/String;");
-        jmethodID get_game_controller_device_descriptor = JNIGetMethodID(env, native_activity, "getGameControllerDeviceDescriptor", "(I)Ljava/lang/String;");
-        jmethodID get_game_controller_device_vendor_id = JNIGetMethodID(env, native_activity, "getGameControllerDeviceVendorId", "(I)I");
-        jmethodID get_game_controller_device_product_id = JNIGetMethodID(env, native_activity, "getGameControllerDeviceProductId", "(I)I");
-        if (get_game_controller_device_ids == 0) goto cleanup_and_early_exit;
-        if (get_game_controller_device_name == 0) goto cleanup_and_early_exit;
-        if (get_game_controller_device_descriptor == 0) goto cleanup_and_early_exit;
-        if (get_game_controller_device_vendor_id == 0) goto cleanup_and_early_exit;
-        if (get_game_controller_device_product_id == 0) goto cleanup_and_early_exit;
+        jmethodID get_game_controller_device_ids = 0;
+        jmethodID get_game_controller_device_name = 0;
+        jmethodID get_game_controller_device_descriptor = 0;
+        jmethodID get_game_controller_device_vendor_id = 0;
+        jmethodID get_game_controller_device_product_id = 0;
+        jintArray device_ids = 0;
+        jsize device_ids_len = 0;
+        jint *device_ids_elements = 0;
 
-        jintArray device_ids = (*env)->CallObjectMethod(env, native_activity, get_game_controller_device_ids);
+        get_game_controller_device_ids = JNIGetMethodID(env, native_activity, "getGameControllerDeviceIds", "()[I");
+        if (get_game_controller_device_ids == 0)
+        {
+            goto cleanup_and_early_exit;
+        }
+        get_game_controller_device_name = JNIGetMethodID(env, native_activity, "getGameControllerDeviceName", "(I)Ljava/lang/String;");
+        if (get_game_controller_device_name == 0)
+        {
+            goto cleanup_and_early_exit;
+        }
+        get_game_controller_device_descriptor = JNIGetMethodID(env, native_activity, "getGameControllerDeviceDescriptor", "(I)Ljava/lang/String;");
+        if (get_game_controller_device_descriptor == 0)
+        {
+            goto cleanup_and_early_exit;
+        }
+        get_game_controller_device_vendor_id = JNIGetMethodID(env, native_activity, "getGameControllerDeviceVendorId", "(I)I");
+        if (get_game_controller_device_vendor_id == 0)
+        {
+            goto cleanup_and_early_exit;
+        }
+        get_game_controller_device_product_id = JNIGetMethodID(env, native_activity, "getGameControllerDeviceProductId", "(I)I");
+        if (get_game_controller_device_product_id == 0)
+        {
+            goto cleanup_and_early_exit;
+        }
+
+        device_ids = (*env)->CallObjectMethod(env, native_activity, get_game_controller_device_ids);
         if (JNICheckAndClearException(env) || device_ids == 0)
         {
             goto cleanup_and_early_exit;
         }
 
-        jsize len = (*env)->GetArrayLength(env, device_ids);
+        device_ids_len = (*env)->GetArrayLength(env, device_ids);
         if (JNICheckAndClearException(env))
         {
             goto cleanup_and_early_exit;
         }
 
-        jint *elements = (*env)->GetIntArrayElements(env, device_ids, 0);
-        if (JNICheckAndClearException(env) || elements == 0)
+        device_ids_elements = (*env)->GetIntArrayElements(env, device_ids, 0);
+        if (JNICheckAndClearException(env) || device_ids_elements == 0)
         {
             goto cleanup_and_early_exit;
         }
@@ -327,64 +351,83 @@ void glfwAndroidDiscoverJoysticks()
         }
         discovery_succeeded = 1;
 
-        for (int i=0; i<len; i++)
+        for (int i=0; i<device_ids_len; i++)
         {
-            int32_t deviceId = elements[i];
+            int32_t deviceId = device_ids_elements[i];
             int deviceIndex = glfwAndroidFindJoystick(deviceId);
             if (deviceIndex == -1)
             {
                 jint jni_device_id = deviceId;
-                jstring jni_device_name = (*env)->CallObjectMethod(env, native_activity, get_game_controller_device_name, jni_device_id);
+                jint vendor_id = 0;
+                jint product_id = 0;
+                jstring jni_device_name = 0;
+                jstring jni_device_descriptor = 0;
+                char *deviceName = 0;
+                char *deviceDescriptor = 0;
+                
+                jni_device_name = (*env)->CallObjectMethod(env, native_activity, get_game_controller_device_name, jni_device_id);
                 if (JNICheckAndClearException(env) || jni_device_name == 0)
                 {
                     discovery_succeeded = 0;
                     goto cleanup_and_break;
                 }
 
-                jstring jni_device_descriptor = (*env)->CallObjectMethod(env, native_activity, get_game_controller_device_descriptor, jni_device_id);
+                jni_device_descriptor = (*env)->CallObjectMethod(env, native_activity, get_game_controller_device_descriptor, jni_device_id);
                 if (JNICheckAndClearException(env) || jni_device_descriptor == 0)
                 {
                     discovery_succeeded = 0;
                     goto cleanup_and_break;
                 }
 
-                jint vendor_id = (*env)->CallIntMethod(env, native_activity, get_game_controller_device_vendor_id, jni_device_id);
+                vendor_id = (*env)->CallIntMethod(env, native_activity, get_game_controller_device_vendor_id, jni_device_id);
                 if (JNICheckAndClearException(env))
                 {
                     discovery_succeeded = 0;
                     goto cleanup_and_break;
                 }
 
-                jint product_id = (*env)->CallIntMethod(env, native_activity, get_game_controller_device_product_id, jni_device_id);
+                product_id = (*env)->CallIntMethod(env, native_activity, get_game_controller_device_product_id, jni_device_id);
                 if (JNICheckAndClearException(env))
                 {
                     discovery_succeeded = 0;
                     goto cleanup_and_break;
                 }
 
-                char deviceGuid[DEVICE_GUID_LENGTH + 1];
-                const char *deviceName = (*env)->GetStringUTFChars(env, jni_device_name, 0);
+                deviceName = (*env)->GetStringUTFChars(env, jni_device_name, 0);
                 if (JNICheckAndClearException(env) || deviceName == 0)
                 {
                     discovery_succeeded = 0;
                     goto cleanup_and_break;
                 }
 
-                const char *deviceDescriptor = (*env)->GetStringUTFChars(env, jni_device_descriptor, 0);
+                deviceDescriptor = (*env)->GetStringUTFChars(env, jni_device_descriptor, 0);
                 if (JNICheckAndClearException(env) || deviceDescriptor == 0)
                 {
                     discovery_succeeded = 0;
                     goto cleanup_and_break;
                 }
 
+                char deviceGuid[DEVICE_GUID_LENGTH + 1];
                 glfwCreateJoystickDeviceGuid(SDL_ANDROID_GAMEPAD_BUS, (unsigned short) vendor_id, (unsigned short) product_id,
                     0, 0, deviceDescriptor, 0, 0, deviceGuid);
                 deviceIndex = glfwAndroidConnectJoystick(deviceId, deviceName, deviceGuid);
 cleanup_and_break:
-                if (deviceDescriptor != 0)      (*env)->ReleaseStringUTFChars(env, jni_device_descriptor, deviceDescriptor);
-                if (deviceName != 0)            (*env)->ReleaseStringUTFChars(env, jni_device_name, deviceName);
-                if (jni_device_descriptor != 0) (*env)->DeleteLocalRef(env, jni_device_descriptor);
-                if (jni_device_name != 0)       (*env)->DeleteLocalRef(env, jni_device_name);
+                if (deviceDescriptor != 0)
+                {
+                    (*env)->ReleaseStringUTFChars(env, jni_device_descriptor, deviceDescriptor);
+                }
+                if (deviceName != 0)
+                {
+                    (*env)->ReleaseStringUTFChars(env, jni_device_name, deviceName);
+                }
+                if (jni_device_descriptor != 0)
+                {
+                    (*env)->DeleteLocalRef(env, jni_device_descriptor);
+                }
+                if (jni_device_name != 0)
+                {
+                    (*env)->DeleteLocalRef(env, jni_device_name);
+                }
                 if (!discovery_succeeded)
                 {
                     break;
@@ -397,8 +440,14 @@ cleanup_and_break:
         }
 
 cleanup_and_early_exit:
-        if (elements != 0) (*env)->ReleaseIntArrayElements(env, device_ids, elements, JNI_ABORT); // JNI_ABORT because we are not modifying elements
-        if (device_ids != 0) (*env)->DeleteLocalRef(env, device_ids);
+        if (device_ids_elements != 0)
+        {
+            (*env)->ReleaseIntArrayElements(env, device_ids, device_ids_elements, JNI_ABORT); // JNI_ABORT because we are not modifying elements
+        }
+        if (device_ids != 0)
+        {
+            (*env)->DeleteLocalRef(env, device_ids);
+        }
         JNIDetachCurrentThread();
     }
 


### PR DESCRIPTION
This changes guards against exceptions while polling for connected gamepads/input devices on Android.

Fixes #13029 

## Technical changes

This is a tentative fix to the problem. The polling happens every frame and it is not unlikely that a Java exception happens in certain rare cases. We never checked for exceptions in the JNI calls, and we did not really handle returned null values in a good way.
