### PR TITLE
Material editor: Fix User matrix4 to show 4x4 floats

### DIFF
--- a/editor/src/clj/editor/compute.clj
+++ b/editor/src/clj/editor/compute.clj
@@ -46,13 +46,19 @@
       (render-program-utils/gen-form-data-constants "compute.constants" :constants)
       (render-program-utils/gen-form-data-samplers "compute.samplers" :samplers)]}]})
 
+(defn- set-form-op [{:keys [node-id]} [property] value]
+  (g/set-property node-id property
+                  (if-not (= :constants property)
+                    value
+                    (mapv render-program-utils/coerce-constant value))))
+
 (g/defnk produce-form-data [_node-id compute-program constants samplers :as args]
   (let [values (select-keys args (mapcat :path (get-in form-data [:sections 0 :fields])))
         form-values (into {} (map (fn [[k v]] [[k] v]) values))]
     (-> form-data
         (assoc :values form-values)
         (assoc :form-ops {:user-data {:node-id _node-id}
-                          :set protobuf-forms-util/set-form-op
+                          :set set-form-op
                           :clear protobuf-forms-util/clear-form-op}))))
 
 (g/defnk produce-save-value [compute-program constants samplers]

--- a/editor/src/clj/editor/material.clj
+++ b/editor/src/clj/editor/material.clj
@@ -158,12 +158,14 @@
   (case (:type constant)
     (:constant-type-user :constant-type-user-color) (let [[x y z w] (:value constant)]
                                                       (Vector4d. x y z w))
-    :constant-type-user-matrix4 (let [[x y z w] (:value constant)]
-                                  (doto (Matrix4d.)
-                                    (.setElement 0 0 x)
-                                    (.setElement 1 0 y)
-                                    (.setElement 2 0 z)
-                                    (.setElement 3 0 w)))
+    :constant-type-user-matrix4 (let [[m00 m10 m20 m30
+                                       m01 m11 m21 m31
+                                       m02 m12 m22 m32
+                                       m03 m13 m23 m33] (:value constant)]
+                                  (Matrix4d. (double-array [m00 m01 m02 m03
+                                                            m10 m11 m12 m13
+                                                            m20 m21 m22 m23
+                                                            m30 m31 m32 m33])))
     :constant-type-time (Vector4d. 0.0 0.0 0.0 0.0)
     :constant-type-viewproj :view-proj
     :constant-type-world :world
@@ -430,6 +432,9 @@
 
 (defn- set-form-value-fn [property value user-data]
   (case property
+    (:vertex-constants :fragment-constants)
+    (mapv render-program-utils/coerce-constant value)
+
     :attributes
     ;; When setting the attributes, coerce the existing values to conform to the
     ;; updated data and vector type.

--- a/editor/src/clj/editor/render_program_utils.clj
+++ b/editor/src/clj/editor/render_program_utils.clj
@@ -139,7 +139,7 @@
       (assoc constant :value protobuf/vector4-zero)
 
       (= :constant-type-user-matrix4 constant-type)
-      (protobuf/sanitize constant :value #(into [] (comp (take 4) cat) %))
+      (protobuf/sanitize constant :value #(into [] cat (coll/resize % 4 protobuf/vector4-zero)))
 
       :else
       (protobuf/sanitize constant :value hack-downgrade-constant-value))))

--- a/editor/src/clj/editor/render_program_utils.clj
+++ b/editor/src/clj/editor/render_program_utils.clj
@@ -14,7 +14,8 @@
 
 (ns editor.render-program-utils
   (:require [editor.protobuf :as protobuf]
-            [editor.protobuf-forms :as protobuf-forms])
+            [editor.protobuf-forms :as protobuf-forms]
+            [util.coll :as coll])
   (:import [com.dynamo.render.proto Material$MaterialDesc$ConstantType Material$MaterialDesc$FilterModeMag Material$MaterialDesc$FilterModeMin Material$MaterialDesc$Sampler Material$MaterialDesc$WrapMode]))
 
 (set! *warn-on-reflection* true)
@@ -42,6 +43,7 @@
             :localization-key (str localization-key ".value")
             :type (case (:type selected-constant default-constant-type)
                     :constant-type-user-color :color
+                    :constant-type-user-matrix4 :mat4
                     :vec4)}]}]}))})
 
 (defn gen-form-data-samplers [localization-key path-key]
@@ -122,21 +124,44 @@
 
 (defn sanitize-constant [constant]
   {:pre [(map? constant)]} ; Material$MaterialDesc$Constant in map format.
-  (if (editable-constant-type? (:type constant))
-    (update constant :value #(or % [protobuf/vector4-zero]))
-    (dissoc constant :value)))
+  (if-not (editable-constant-type? (:type constant))
+    (dissoc constant :value)
+    (let [default-value (if (= :constant-type-user-matrix4 (:type constant))
+                          (vec (repeat 4 protobuf/vector4-zero))
+                          [protobuf/vector4-zero])]
+      (update constant :value #(or % default-value)))))
 
 (defn- constant->editable-constant [constant]
   {:pre [(map? constant)]} ; Material$MaterialDesc$Constant in map format.
-  (if (editable-constant-type? (:type constant))
-    (protobuf/sanitize constant :value hack-downgrade-constant-value)
-    (assoc constant :value protobuf/vector4-zero)))
+  (let [constant-type (:type constant)]
+    (cond
+      (not (editable-constant-type? constant-type))
+      (assoc constant :value protobuf/vector4-zero)
+
+      (= :constant-type-user-matrix4 constant-type)
+      (protobuf/sanitize constant :value #(into [] (comp (take 4) cat) %))
+
+      :else
+      (protobuf/sanitize constant :value hack-downgrade-constant-value))))
 
 (defn- editable-constant->constant [constant]
   {:pre [(map? constant)]} ; Material$MaterialDesc$Constant in map format.
-  (if (editable-constant-type? (:type constant))
-    (protobuf/sanitize constant :value hack-upgrade-constant-value)
-    (dissoc constant :value)))
+  (let [constant-type (:type constant)]
+    (cond
+      (not (editable-constant-type? constant-type))
+      (dissoc constant :value)
+
+      (= :constant-type-user-matrix4 constant-type)
+      (protobuf/sanitize constant :value #(into [] (partition-all 4) %))
+
+      :else
+      (protobuf/sanitize constant :value hack-upgrade-constant-value))))
+
+(defn coerce-constant [constant]
+  {:pre [(map? constant)]} ; Material$MaterialDesc$Constant in map format.
+  (update constant :value coll/resize
+          (if (= :constant-type-user-matrix4 (:type constant)) 16 4)
+          protobuf/float-zero))
 
 (def constants->editable-constants (partial mapv constant->editable-constant))
 

--- a/editor/test/integration/material_test.clj
+++ b/editor/test/integration/material_test.clj
@@ -54,7 +54,12 @@
               [9.0 10.0 11.0 12.0]
               [13.0 14.0 15.0 16.0]]
              (mapv #(mapv double %) (:value (first saved-constants)))))
-      (is (= 4 (count (:value (second saved-constants))))))))
+      (is (= 4 (count (:value (second saved-constants)))))
+      (is (= (into (mapv float [1.0 2.0 3.0 4.0])
+                   (repeat 12 protobuf/float-zero))
+             (:value (nth fragment-constants 2))))
+      (is (= 4 (count (:value (nth saved-constants 2)))))
+      (is (some? (g/node-value node-id :shader))))))
 
 (deftest matrix4-material-constant-type-switch
   (test-util/with-loaded-project

--- a/editor/test/integration/material_test.clj
+++ b/editor/test/integration/material_test.clj
@@ -15,6 +15,7 @@
 (ns integration.material-test
   (:require [clojure.test :refer :all]
             [dynamo.graph :as g]
+            [editor.form :as form]
             [editor.protobuf :as protobuf]
             [editor.resource :as resource]
             [editor.workspace :as workspace]
@@ -38,6 +39,38 @@
     (let [node-id (test-util/resource-node project "/materials/test_missing_constant_value.material")]
       (is (= protobuf/vector4-zero (get-in (g/node-value node-id :fragment-constants) [0 :value])))
       (is (= [protobuf/vector4-zero] (get-in (g/node-value node-id :save-value) [:fragment-constants 0 :value]))))))
+
+(deftest matrix4-material-constant-value
+  (test-util/with-loaded-project
+    (let [node-id (test-util/resource-node project "/materials/test_matrix4_constant.material")
+          fragment-constants (g/node-value node-id :fragment-constants)
+          saved-constants (:fragment-constants (g/node-value node-id :save-value))]
+      (is (= (mapv float (range 1.0 17.0))
+             (:value (first fragment-constants))))
+      (is (= (mapv float (repeat 16 0.0))
+             (:value (second fragment-constants))))
+      (is (= [[1.0 2.0 3.0 4.0]
+              [5.0 6.0 7.0 8.0]
+              [9.0 10.0 11.0 12.0]
+              [13.0 14.0 15.0 16.0]]
+             (mapv #(mapv double %) (:value (first saved-constants)))))
+      (is (= 4 (count (:value (second saved-constants))))))))
+
+(deftest matrix4-material-constant-type-switch
+  (test-util/with-loaded-project
+    (let [node-id (test-util/resource-node project "/materials/test_matrix4_constant.material")
+          set-constant-type! (fn [constant-type]
+                               (let [constants (assoc-in (g/node-value node-id :fragment-constants)
+                                                         [0 :type] constant-type)]
+                                 (g/transact {:undoable false}
+                                   (form/set-value (:form-ops (g/node-value node-id :form-data))
+                                                   [:fragment-constants]
+                                                   constants))))]
+      (set-constant-type! :constant-type-user)
+      (is (= 4 (count (:value (first (g/node-value node-id :fragment-constants))))))
+
+      (set-constant-type! :constant-type-user-matrix4)
+      (is (= 16 (count (:value (first (g/node-value node-id :fragment-constants)))))))))
 
 (deftest material-pbr-parameters
   ;; Test that all exposed PBR parameters are found, and that they are true

--- a/editor/test/integration/material_test.clj
+++ b/editor/test/integration/material_test.clj
@@ -59,7 +59,7 @@
                    (repeat 12 protobuf/float-zero))
              (:value (nth fragment-constants 2))))
       (is (= 4 (count (:value (nth saved-constants 2)))))
-      (is (some? (g/node-value node-id :shader))))))
+      (is (not (g/error? (g/node-value node-id :shader)))))))
 
 (deftest matrix4-material-constant-type-switch
   (test-util/with-loaded-project

--- a/editor/test/resources/test_project/materials/test_matrix4_constant.material
+++ b/editor/test/resources/test_project/materials/test_matrix4_constant.material
@@ -1,0 +1,36 @@
+name: "Matrix4 Constant"
+tags: "test"
+vertex_program: "/materials/test.vp"
+fragment_program: "/materials/test.fp"
+fragment_constants {
+  name: "user_matrix"
+  type: CONSTANT_TYPE_USER_MATRIX4
+  value {
+    x: 1.0
+    y: 2.0
+    z: 3.0
+    w: 4.0
+  }
+  value {
+    x: 5.0
+    y: 6.0
+    z: 7.0
+    w: 8.0
+  }
+  value {
+    x: 9.0
+    y: 10.0
+    z: 11.0
+    w: 12.0
+  }
+  value {
+    x: 13.0
+    y: 14.0
+    z: 15.0
+    w: 16.0
+  }
+}
+fragment_constants {
+  name: "missing_matrix"
+  type: CONSTANT_TYPE_USER_MATRIX4
+}

--- a/editor/test/resources/test_project/materials/test_matrix4_constant.material
+++ b/editor/test/resources/test_project/materials/test_matrix4_constant.material
@@ -34,3 +34,13 @@ fragment_constants {
   name: "missing_matrix"
   type: CONSTANT_TYPE_USER_MATRIX4
 }
+fragment_constants {
+  name: "legacy_matrix"
+  type: CONSTANT_TYPE_USER_MATRIX4
+  value {
+    x: 1.0
+    y: 2.0
+    z: 3.0
+    w: 4.0
+  }
+}


### PR DESCRIPTION
When editing a material containing a matrix4 value it is now presented as a 4x4 grid of input fields for float values:

<img width="693" height="294" alt="image" src="https://github.com/user-attachments/assets/dc046f06-8b27-43c6-8cdd-393c0eee4298" />


Fixes #13008
