### PR TITLE
Restore old behaviour when writing custom resources into game.project

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/ProjectBuildTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/ProjectBuildTest.java
@@ -581,9 +581,26 @@ public class ProjectBuildTest {
 
         BobProjectProperties outputProperties = new BobProjectProperties();
         outputProperties.load(new FileInputStream(new File(contentRoot, "build/game.projectc")));
+        String serializedCustomResourcesValue = outputProperties.getStringValue("project", "custom_resources");
         String[] serializedCustomResources = outputProperties.getStringArrayValue("project", "custom_resources", new String[0]);
+        assertEquals(3, serializedCustomResourcesValue.split(", ", -1).length);
         assertEquals(new HashSet<>(Arrays.asList("/project_resource.txt", "/extension1_resource.txt", "/extension2_resource.txt")),
                      new HashSet<>(Arrays.asList(serializedCustomResources)));
+    }
+
+    @Test
+    public void testArchiveBuildPreservesCustomResourcePathSpelling() throws IOException, CompileExceptionError, MultipleCompileException, ParseException {
+        createDefaultFiles();
+        createFile(contentRoot, "game.project", "[project]\ncustom_resources = foo/../assets/\n");
+        createFile(contentRoot, "assets/resource.txt", "resource");
+
+        buildArchive(false);
+
+        assertTrue(new File(contentRoot, "build/assets/resource.txt").isFile());
+
+        BobProjectProperties outputProperties = new BobProjectProperties();
+        outputProperties.load(new FileInputStream(new File(contentRoot, "build/game.projectc")));
+        assertEquals("foo/../assets/", outputProperties.getStringValue("project", "custom_resources"));
     }
 
     @Test

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/GameProjectBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/GameProjectBuilder.java
@@ -22,6 +22,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -321,6 +322,7 @@ public class GameProjectBuilder extends Builder {
     static public void transformGameProjectFile(BobProjectProperties properties) {
         String gamepadsPath = properties.getStringValue("input", "gamepads", DEFAULT_GAMEPADS);
         String gamepadDbPath = properties.getStringValue("input", "gamepad_database", DEFAULT_GAMEPAD_DATABASE);
+        String[] projectCustomResources = properties.getStringArrayValue("project", "custom_resources", new String[0]);
         String[] customResources = properties.getStringArrayValueMerged("project", "custom_resources", new String[0]);
 
         properties.removePrivateFields();
@@ -340,8 +342,8 @@ public class GameProjectBuilder extends Builder {
 
         properties.putStringValue("input", "gamepads", getGamepadsOutputPath(gamepadsPath, gamepadDbPath));
         properties.putStringValue("input", "gamepad_database", null);
-        if (customResources.length > 0) {
-            properties.putStringValue("project", "custom_resources", String.join(",", customResources));
+        if (!Arrays.equals(projectCustomResources, customResources)) {
+            properties.putStringValue("project", "custom_resources", String.join(", ", customResources));
         }
     }
 

--- a/editor/src/clj/editor/game_project.clj
+++ b/editor/src/clj/editor/game_project.clj
@@ -167,22 +167,30 @@
 (defn- file-resource? [resource]
   (= (resource/source-type resource) :file))
 
-(defn- parse-custom-resource-paths [custom-resources-setting]
+(defn- parse-custom-resource-setting [custom-resources-setting]
   (into []
         (comp
           (map string/trim)
-          (remove string/blank?)
-          (map #(FilenameUtils/normalize % true))
-          (map (comp strip-trailing-slash fs/with-leading-slash)))
+          (remove string/blank?))
         (string/split (or custom-resources-setting "") #",")))
 
-(defn- merge-custom-resource-path-settings [settings]
-  (->> settings
-       (into []
-             (comp
-               (mapcat parse-custom-resource-paths)
-               (distinct)))
-       (coll/join-to-string ", ")))
+(defn- parse-custom-resource-paths [custom-resources-setting]
+  (into []
+        (comp
+          (map #(FilenameUtils/normalize % true))
+          (map (comp strip-trailing-slash fs/with-leading-slash))
+          (distinct))
+        (parse-custom-resource-setting custom-resources-setting)))
+
+(defn- merge-custom-resource-settings [default-settings project-setting]
+  (let [default-values (into [] (mapcat parse-custom-resource-setting) default-settings)
+        project-values (parse-custom-resource-setting project-setting)
+        merged-values (->> project-values
+                           (into default-values)
+                           (into [] (distinct)))]
+    (if (= project-values merged-values)
+      project-setting
+      (coll/join-to-string ", " merged-values))))
 
 (def ^:private resource-setting-connections-template
   {["display" "display_profiles"] [[:build-targets :dep-build-targets]
@@ -282,14 +290,13 @@
 
   (output custom-resources-setting g/Any :cached
           (g/fnk [meta-info raw-settings]
-            (merge-custom-resource-path-settings
-              (conj
-                (settings-core/get-default-setting-values
-                  (:settings meta-info)
-                  ["project" "custom_resources"])
-                (settings-core/get-setting
-                  raw-settings
-                  ["project" "custom_resources"])))))
+            (merge-custom-resource-settings
+              (settings-core/get-default-setting-values
+                (:settings meta-info)
+                ["project" "custom_resources"])
+              (settings-core/get-setting
+                raw-settings
+                ["project" "custom_resources"]))))
 
   (output ssl-certificates-resource resource/Resource
           (g/fnk [_node-id settings-map]

--- a/editor/test/integration/build_test.clj
+++ b/editor/test/integration/build_test.clj
@@ -782,6 +782,10 @@
   (let [value (settings-core/get-setting properties path)]
     (is (= expected-value value))))
 
+(defn- check-built-project-setting [workspace path expected-value]
+  (with-open [reader (io/reader (build-path workspace "game.projectc"))]
+    (check-project-setting (settings-core/parse-settings reader) path expected-value)))
+
 (deftest build-game-project-with-buildtime-conversion
   (with-loaded-project "test/resources/buildtime_conversion"
     (let [game-project (test-util/resource-node project "/game.project")]
@@ -901,8 +905,9 @@
         (check-file-contents workspace
                              [["assets/some.stuff" "some.stuff"]
                               ["assets/some2.stuff" "some2.stuff"]]))
-      (with-setting ["project" "custom_resources"] "foo/../assets"
+      (with-setting ["project" "custom_resources"] "foo/../assets/"
         (project-build! project game-project)
+        (check-built-project-setting workspace ["project" "custom_resources"] "foo/../assets/")
         (check-file-contents workspace
                              [["assets/some.stuff" "some.stuff"]
                               ["assets/some2.stuff" "some2.stuff"]]))
@@ -914,6 +919,7 @@
                               ["root.stuff" "root.stuff"]]))
       (with-setting ["project" "custom_resources"] "assets, root.stuff, /more_assets/"
         (project-build! project game-project)
+        (check-built-project-setting workspace ["project" "custom_resources"] "assets, root.stuff, /more_assets/")
         (check-file-contents workspace
                              [["assets/some.stuff" "some.stuff"]
                               ["assets/some2.stuff" "some2.stuff"]
@@ -942,12 +948,13 @@
       (workspace/resource-sync! workspace)
       (let [project (test-util/setup-project! workspace)
             game-project (test-util/resource-node project "/game.project")]
-        (project-build! project game-project)
-        (is (string/includes? (slurp (build-path workspace "game.projectc"))
-                              "custom_resources = /assets"))
-        (check-file-contents workspace
-                             [["assets/some.stuff" "some.stuff"]
-                              ["assets/some2.stuff" "some2.stuff"]])))))
+        (with-setting ["project" "custom_resources"] "root.stuff"
+          (project-build! project game-project)
+          (check-built-project-setting workspace ["project" "custom_resources"] "assets, root.stuff")
+          (check-file-contents workspace
+                               [["assets/some.stuff" "some.stuff"]
+                                ["assets/some2.stuff" "some2.stuff"]
+                                ["root.stuff" "root.stuff"]]))))))
 
 (deftest build-with-custom-resources-from-unsaved-ext-properties-default
   (with-clean-system
@@ -970,8 +977,7 @@
           (string/split-lines "[project]\ncustom_resources.default = more_assets\n"))
 
         (project-build! project game-project)
-        (is (string/includes? (slurp (build-path workspace "game.projectc"))
-                              "custom_resources = /more_assets"))
+        (check-built-project-setting workspace ["project" "custom_resources"] "more_assets")
         (check-file-contents workspace
                              [["more_assets/some_more.stuff" "some_more.stuff"]
                               ["more_assets/some_more2.stuff" "some_more2.stuff"]])))))


### PR DESCRIPTION
PR #12988 unintentionally exposed normalized custom-resource paths through project.custom_resources in the built game.projectc:

```lua
-- game.project value:
custom_resources = foo/../assets/
-- was serialized into:
custom_resources = /assets
```

Path normalization is necessary when locating and copying resources, but it should not alter the configuration value returned at runtime.

#### Technical changes

* Separated custom-resource parsing for serialization from normalized resource discovery.
* Preserved the original custom_resources value when extension defaults add no entries.
* Kept path normalization, leading-slash handling, trailing-slash removal, and deduplication internal to resource discovery.
* Aligned Editor and Bob merged-value formatting.
* Added Editor and Bob regression coverage for non-canonical paths, trailing slashes, resource discovery, and extension merging.