### PR TITLE
Establish outbound connections from editor resource nodes prior to loading

### DIFF
--- a/editor/src/clj/editor/code/resource.clj
+++ b/editor/src/clj/editor/code/resource.clj
@@ -22,6 +22,7 @@
             [editor.types :as types]
             [editor.workspace :as workspace]
             [schema.core :as s]
+            [util.eduction :as e]
             [util.text-util :as text-util])
   (:import [editor.code.data Cursor CursorRange]))
 
@@ -162,12 +163,17 @@
       :modified-lines lines
       :modified-indent-type indent-type)))
 
-(defn- load-fn [additional-load-fn lazy-loaded connect-breakpoints project self resource lines]
-  (concat
-    (when-not lazy-loaded
-      (eager-load self lines))
+(defn- connect-fn [additional-connect-fn connect-breakpoints project self resource]
+  (e/concat
     (when connect-breakpoints
       (g/connect self :breakpoints project :breakpoints))
+    (when additional-connect-fn
+      (additional-connect-fn project self resource))))
+
+(defn- load-fn [additional-load-fn lazy-loaded project self resource lines]
+  (e/concat
+    (when-not lazy-loaded
+      (eager-load self lines))
     (when additional-load-fn
       (additional-load-fn project self resource))))
 
@@ -226,16 +232,20 @@
 
 (defn register-code-resource-type [workspace & {:keys [ext node-type language icon view-types view-opts tags tag-opts label lazy-loaded additional-load-fn built-pb-class] :as args}]
   (let [connect-breakpoints (contains? tags :debuggable)
-        load-fn (partial load-fn additional-load-fn lazy-loaded connect-breakpoints)
-        args (-> args
-                 (dissoc :additional-load-fn)
-                 (assoc :load-fn load-fn
-                        :read-fn read-fn
-                        :write-fn write-fn
-                        :search-fn search-fn
-                        :search-value-fn search-value-fn
-                        :source-value-fn source-value-fn
-                        :textual? true
-                        :test-info (cond-> {:type :code}
-                                           built-pb-class (assoc :built-pb-class built-pb-class))))]
+        additional-connect-fn (:connect-fn args)
+        resource-connect-fn (when (or additional-connect-fn connect-breakpoints)
+                              (partial connect-fn additional-connect-fn connect-breakpoints))
+        resource-load-fn (partial load-fn additional-load-fn lazy-loaded)
+        args (cond-> (-> args
+                         (dissoc :additional-load-fn :connect-fn)
+                         (assoc :load-fn resource-load-fn
+                                :read-fn read-fn
+                                :write-fn write-fn
+                                :search-fn search-fn
+                                :search-value-fn search-value-fn
+                                :source-value-fn source-value-fn
+                                :textual? true
+                                :test-info (cond-> {:type :code}
+                                             built-pb-class (assoc :built-pb-class built-pb-class))))
+               resource-connect-fn (assoc :connect-fn resource-connect-fn))]
     (apply workspace/register-resource-type workspace (mapcat identity args))))

--- a/editor/src/clj/editor/code/script.clj
+++ b/editor/src/clj/editor/code/script.clj
@@ -30,7 +30,8 @@
             [editor.resource :as resource]
             [editor.types :as types]
             [schema.core :as s]
-            [util.coll :as coll]))
+            [util.coll :as coll]
+            [util.eduction :as e]))
 
 (set! *warn-on-reflection* true)
 (set! *unchecked-math* :warn-on-boxed)
@@ -526,19 +527,24 @@
                    :reference-completions true
                    :tags #{:debuggable}}])
 
-(defn- additional-load-fn
+(defn- connect-fn
   [annotations reference-completions project self resource]
   (g/with-auto-evaluation-context evaluation-context
-    (let [code-preprocessors (project/code-preprocessors project evaluation-context)
-          script-intelligence (project/script-intelligence project evaluation-context)
+    (let [script-intelligence (project/script-intelligence project evaluation-context)
           script-annotations (project/script-annotations project evaluation-context)]
-      (concat
-        (g/connect code-preprocessors :lua-preprocessors self :lua-preprocessors)
-        (g/connect script-intelligence :lua-completions self :script-intelligence-completions)
+      (e/concat
         (when reference-completions
           (g/connect self :required-module-info script-intelligence :required-module-infos))
         (when (and annotations (resource/zip-resource? resource))
           (g/connect self :resource-with-lines script-annotations :script-annotations))))))
+
+(defn- additional-load-fn [project self _resource]
+  (g/with-auto-evaluation-context evaluation-context
+    (let [code-preprocessors (project/code-preprocessors project evaluation-context)
+          script-intelligence (project/script-intelligence project evaluation-context)]
+      (e/concat
+        (g/connect code-preprocessors :lua-preprocessors self :lua-preprocessors)
+        (g/connect script-intelligence :lua-completions self :script-intelligence-completions)))))
 
 (defn register-resource-types [workspace]
   (for [def script-defs
@@ -548,7 +554,8 @@
                          :built-pb-class script-compilation/built-pb-class
                          :language "lua"
                          :lazy-loaded false
-                         :additional-load-fn (partial additional-load-fn (:annotations def) (:reference-completions def))
+                         :connect-fn (partial connect-fn (:annotations def) (:reference-completions def))
+                         :additional-load-fn additional-load-fn
                          :view-types [:code :default]
                          :view-opts lua-code-opts))]]
     (apply r/register-code-resource-type workspace (mapcat identity args))))

--- a/editor/src/clj/editor/defold_project.clj
+++ b/editor/src/clj/editor/defold_project.clj
@@ -917,14 +917,15 @@
 (defn make-resource-node-tx-data [project node-type node-id resource]
   {:pre [(g/node-id? project)
          (g/node-id? node-id)
-         (resource/resource? resource)
-         (not (resource/folder? resource))]}
+         (resource/resource? resource)]}
   (e/concat
     (g/add-node
       (g/construct node-type
         :_node-id node-id
         :resource resource))
-    (g/connect node-id :node-id+resource project :node-id+resources)))
+    (g/connect node-id :node-id+resource project :node-id+resources)
+    (when-let [connect-fn (:connect-fn (resource/resource-type resource))]
+      (connect-fn project node-id resource))))
 
 (defn make-resource-nodes-tx-data [project node-id+resource-pairs]
   {:pre [(g/node-id? project)]}
@@ -944,18 +945,6 @@
                   (fn [[node-id resource]]
                     (make-resource-node-tx-data project node-type node-id resource))))))))
 
-(defn setup-game-project-tx-data [project game-project]
-  (when (some? game-project)
-    (assert (g/node-id? game-project))
-    (let [script-intelligence (script-intelligence project)]
-      (e/concat
-        (g/connect script-intelligence :build-errors game-project :build-errors)
-        (g/connect game-project :display-profiles-data project :display-profiles)
-        (g/connect game-project :texture-profiles-data project :texture-profiles)
-        (g/connect game-project :use-font-layout project :use-font-layout)
-        (g/connect game-project :use-rich-text project :use-rich-text)
-        (g/connect game-project :settings-map project :settings)))))
-
 (defn load-project!
   ([project]
    (load-project! project progress/null-render-progress!))
@@ -969,20 +958,6 @@
          transaction-metrics (du/make-metrics-collector)
          project-graph (g/node-id->graph-id project)
          node-id+resource-pairs (make-node-id+resource-pairs project-graph resources)
-
-         game-project-resource
-         (g/let-ec [basis (:basis evaluation-context)
-                    workspace (workspace project evaluation-context)]
-           (workspace/find-resource basis workspace "/game.project"))
-
-         game-project-node-id
-         (when game-project-resource
-           (coll/some
-             (fn [[node-id resource]]
-               (when (identical? game-project-resource resource)
-                 node-id))
-             node-id+resource-pairs))
-
          read-progress-span 1
          load-progress-span 3
          total-progress-span (+ read-progress-span load-progress-span)
@@ -1005,23 +980,17 @@
                         :undoable false}
 
          prelude-tx-data
-         (e/concat
-           (make-resource-nodes-tx-data project node-id+resource-pairs)
-
-           ;; Make sure the game.project node is property connected before
-           ;; loading the resource nodes, since establishing these connections
-           ;; will invalidate any dependent outputs in the cache.
-
-           ;; TODO(save-value-cleanup): There are implicit dependencies between
-           ;; texture profiles and image resources. We probably want to ensure
-           ;; the texture profiles are loaded before anything that makes
-           ;; implicit use of them to avoid potentially costly cache
-           ;; invalidation.
-           (setup-game-project-tx-data project game-project-node-id))
+         (make-resource-nodes-tx-data project node-id+resource-pairs)
 
          ;; Load the resource nodes. Referenced nodes will be loaded prior to
          ;; nodes that refer to them, provided the :dependencies-fn reports the
          ;; referenced proj-paths correctly.
+         ;;
+         ;; TODO(save-value-cleanup): There are implicit dependencies between
+         ;; texture profiles and image resources. We probably want to ensure
+         ;; the texture profiles are loaded before anything that makes
+         ;; implicit use of them to avoid potentially costly cache
+         ;; invalidation.
          migrated-resource-node-ids
          (let [render-progress! (progress/nest-render-progress render-progress! total-progress load-progress-span)]
            (du/measuring process-metrics :load-new-nodes
@@ -1716,9 +1685,8 @@
       [tx-data-context-map pending-resource-node-id nil]
       (let [graph-id (g/node-id->graph-id project)
             node-type (resource-node-type resource)
-            creation-tx-data (g/make-nodes graph-id [resource-node-id [node-type :resource resource]]
-                               (g/connect resource-node-id :node-id+resource project :node-id+resources))
-            created-resource-node-id (first (g/tx-data-added-node-ids creation-tx-data))
+            created-resource-node-id (first (g/take-node-ids graph-id 1))
+            creation-tx-data (make-resource-node-tx-data project node-type created-resource-node-id resource)
             created-resource-nodes' (assoc (or created-resource-nodes {}) resource created-resource-node-id)
             tx-data-context-map' (assoc tx-data-context-map :created-resource-nodes created-resource-nodes')]
         [tx-data-context-map' created-resource-node-id creation-tx-data]))))

--- a/editor/src/clj/editor/editor_localization.clj
+++ b/editor/src/clj/editor/editor_localization.clj
@@ -33,7 +33,7 @@
               (resource/proj-path resource)
               #(data/lines-reader lines)))))
 
-(defn- additional-load-fn [project self _resource]
+(defn- connect-fn [project self _resource]
   (g/with-auto-evaluation-context evaluation-context
     (let [bundle (project/editor-localization-bundle project evaluation-context)]
       (g/connect self :resource-path+reader-fn bundle :resource-path+reader-fns))))
@@ -47,6 +47,6 @@
     :icon "icons/32/Icons_05-Project-info.png"
     :category (localization/message "resource.category.editor")
     :language "properties"
-    :additional-load-fn additional-load-fn
+    :connect-fn connect-fn
     :view-types [:code :default]
     :view-opts {:code {:grammar java-properties/grammar}}))

--- a/editor/src/clj/editor/editor_script.clj
+++ b/editor/src/clj/editor/editor_script.clj
@@ -19,7 +19,8 @@
             [editor.code.script :as script]
             [editor.editor-extensions.runtime :as rt]
             [editor.localization :as localization]
-            [editor.resource :as resource])
+            [editor.resource :as resource]
+            [util.eduction :as e])
   (:import [clojure.lang Util]))
 
 (def ^:private editor-extension-compilation-failed-message
@@ -53,13 +54,13 @@
     :view-opts script/lua-code-opts
     :node-type EditorScript
     :lazy-loaded false
-    :additional-load-fn
+    :connect-fn
     (fn [project self resource]
       (let [extensions (g/node-value project :editor-extensions)]
         (if (resource/file-resource? resource)
-          (concat
+          (e/concat
             (g/connect self :prototype extensions :project-prototypes)
             (g/connect self :reload-signature extensions :project-reload-signatures))
-          (concat
+          (e/concat
             (g/connect self :prototype extensions :library-prototypes)
             (g/connect self :reload-signature extensions :library-reload-signatures)))))))

--- a/editor/src/clj/editor/game_project.clj
+++ b/editor/src/clj/editor/game_project.clj
@@ -33,6 +33,7 @@
             [editor.workspace :as workspace]
             [util.coll :as coll :refer [pair]]
             [util.defonce :as defonce]
+            [util.eduction :as e]
             [util.path :as path])
   (:import [com.dynamo.bob.util DependencyMetadata Library$Archive Library$Result]
            [com.fasterxml.jackson.databind ObjectMapper]
@@ -372,6 +373,19 @@
 
 ;;; loading node
 
+(defn- connect-game-project [project self _resource]
+  ;; Make sure the game.project node is properly connected before executing any
+  ;; load-fns, since establishing these connections will invalidate any
+  ;; dependent outputs in the cache.
+  (let [script-intelligence (g/node-value project :script-intelligence)]
+    (e/concat
+      (g/connect script-intelligence :build-errors self :build-errors)
+      (g/connect self :display-profiles-data project :display-profiles)
+      (g/connect self :texture-profiles-data project :texture-profiles)
+      (g/connect self :use-font-layout project :use-font-layout)
+      (g/connect self :use-rich-text project :use-rich-text)
+      (g/connect self :settings-map project :settings))))
+
 (defn- load-game-project [project self resource source-value]
   (let [graph-id (g/node-id->graph-id self)
         workspace (resource/workspace resource)
@@ -410,6 +424,7 @@
     :ext "project"
     :label (localization/message "resource.type.project")
     :node-type GameProjectNode
+    :connect-fn connect-game-project
     :load-fn load-game-project
     :meta-settings (:settings gpcore/basic-meta-info)
     :icon game-project-icon

--- a/editor/src/clj/editor/game_project.clj
+++ b/editor/src/clj/editor/game_project.clj
@@ -373,18 +373,19 @@
 
 ;;; loading node
 
-(defn- connect-game-project [project self _resource]
+(defn- connect-game-project [project self resource]
   ;; Make sure the game.project node is properly connected before executing any
   ;; load-fns, since establishing these connections will invalidate any
   ;; dependent outputs in the cache.
-  (let [script-intelligence (g/node-value project :script-intelligence)]
-    (e/concat
-      (g/connect script-intelligence :build-errors self :build-errors)
-      (g/connect self :display-profiles-data project :display-profiles)
-      (g/connect self :texture-profiles-data project :texture-profiles)
-      (g/connect self :use-font-layout project :use-font-layout)
-      (g/connect self :use-rich-text project :use-rich-text)
-      (g/connect self :settings-map project :settings))))
+  (when (= "/game.project" (resource/proj-path resource)) ; There might be other `.project` files. We only want `/game.project` here.
+    (let [script-intelligence (g/node-value project :script-intelligence)]
+      (e/concat
+        (g/connect script-intelligence :build-errors self :build-errors)
+        (g/connect self :display-profiles-data project :display-profiles)
+        (g/connect self :texture-profiles-data project :texture-profiles)
+        (g/connect self :use-font-layout project :use-font-layout)
+        (g/connect self :use-rich-text project :use-rich-text)
+        (g/connect self :settings-map project :settings)))))
 
 (defn- load-game-project [project self resource source-value]
   (let [graph-id (g/node-id->graph-id self)

--- a/editor/src/clj/editor/game_properties.clj
+++ b/editor/src/clj/editor/game_properties.clj
@@ -40,7 +40,7 @@
               (catch Exception e
                 (g/->error _node-id :meta-info :fatal resource (.getMessage e) (ex-data e)))))))
 
-(defn- additional-load-fn [project self _resource]
+(defn- connect-fn [project self _resource]
   (g/connect self :proj-path+meta-info project :proj-path+meta-info-pairs))
 
 (defn register-resource-types [workspace]
@@ -48,7 +48,7 @@
     workspace
     :ext "properties"
     :node-type GameProperties
-    :additional-load-fn additional-load-fn
+    :connect-fn connect-fn
     :label (localization/message "resource.type.properties")
     :icon "icons/32/Icons_05-Project-info.png"
     :language "ini"

--- a/editor/src/clj/editor/script_api.clj
+++ b/editor/src/clj/editor/script_api.clj
@@ -23,7 +23,8 @@
             [editor.localization :as localization]
             [editor.resource :as resource]
             [editor.yaml :as yaml]
-            [util.coll :as coll]))
+            [util.coll :as coll]
+            [util.eduction :as e]))
 
 (set! *warn-on-reflection* true)
 (set! *unchecked-math* :warn-on-boxed)
@@ -154,17 +155,17 @@
   (output build-errors g/Any produce-build-errors)
   (output completions si/ScriptCompletions produce-completions))
 
-(defn- additional-load-fn
+(defn- connect-fn
   [project self resource]
   (let [si (project/script-intelligence project)]
-    (concat (g/connect self :completions si :lua-completions)
-            (when (resource/file-resource? resource)
-              ;; Only connect to the script-intelligence build errors if this is
-              ;; a file resource. The assumption is that if it is a file
-              ;; resource then it is being actively worked on. Otherwise, it
-              ;; belongs to an external dependency and should not stop the build
-              ;; on errors.
-              (g/connect self :build-errors si :build-errors)))))
+    (e/concat
+      (g/connect self :completions si :lua-completions)
+      (when (resource/file-resource? resource)
+        ;; Only connect to the script-intelligence build errors if this is a
+        ;; file resource. The assumption is that if it is a file resource then
+        ;; it is being actively worked on. Otherwise, it belongs to an external
+        ;; dependency and should not stop the build on errors.
+        (g/connect self :build-errors si :build-errors)))))
 
 (defn register-resource-types
   [workspace]
@@ -175,7 +176,7 @@
     :view-types [:code :default]
     :view-opts nil
     :node-type ScriptApiNode
-    :additional-load-fn additional-load-fn
+    :connect-fn connect-fn
     :textual? true
     :lazy-loaded true
     :language "yaml"))

--- a/editor/src/clj/editor/settings.clj
+++ b/editor/src/clj/editor/settings.clj
@@ -33,16 +33,35 @@
   (property path g/Any)
   (property value resource/Resource
             (dynamic visible (g/constantly false))
-            (value (gu/passthrough resource))
+            (value (g/fnk [resource value]
+                     ;; We only connect the :resource input when we have a
+                     ;; resource node. A "missing" ResourceNode will be created
+                     ;; for non-existing paths, but not if the resource refers
+                     ;; to a folder.
+                     (or resource value)))
             (set (fn [evaluation-context self old-value new-value]
-                   (concat
-                     ;; connect resource node to this
-                     (project/resource-setter evaluation-context self old-value new-value [:resource :resource])
-                     (when-let [resource-connections (g/node-value self :resource-connections evaluation-context)]
-                       (let [[target-node connections] resource-connections]
-                         ;; connect extra resource node outputs directly to target-node (GameProjectNode for instance)
-                         (apply project/resource-setter evaluation-context target-node old-value new-value
-                                connections)))))))
+                   (let [project (project/get-project (:basis evaluation-context) self)
+                         _ (assert (g/node-id? project))
+                         resource-connections (g/node-value self :resource-connections evaluation-context)
+
+                         all-connections
+                         (cond-> [[self [[:resource :resource]]]]
+                           (coll/not-empty resource-connections)
+                           (conj resource-connections))]
+
+                     (g/eager-tx-data
+                       (concat
+                         (when (some-> old-value resource/source-type (= :file))
+                           (e/mapcat
+                             (fn [[target-node connections]]
+                               (project/disconnect-resource-node evaluation-context project old-value target-node connections))
+                             all-connections))
+                         (when (some-> new-value resource/source-type (= :file))
+                           (e/mapcat
+                             (fn [[target-node connections]]
+                               (:tx-data (project/connect-resource-node evaluation-context project new-value target-node connections)))
+                             all-connections))))))))
+
   (input resource resource/Resource)
   ;; resource-setting-reference only consumed by SettingsNode and already cached there.
   (output resource-setting-reference g/Any (g/fnk [_node-id path value] {:path path :node-id _node-id :value value})))

--- a/editor/src/clj/editor/settings.clj
+++ b/editor/src/clj/editor/settings.clj
@@ -33,35 +33,16 @@
   (property path g/Any)
   (property value resource/Resource
             (dynamic visible (g/constantly false))
-            (value (g/fnk [resource value]
-                     ;; We only connect the :resource input when we have a
-                     ;; resource node. A "missing" ResourceNode will be created
-                     ;; for non-existing paths, but not if the resource refers
-                     ;; to a folder.
-                     (or resource value)))
+            (value (gu/passthrough resource))
             (set (fn [evaluation-context self old-value new-value]
-                   (let [project (project/get-project (:basis evaluation-context) self)
-                         _ (assert (g/node-id? project))
-                         resource-connections (g/node-value self :resource-connections evaluation-context)
-
-                         all-connections
-                         (cond-> [[self [[:resource :resource]]]]
-                           (coll/not-empty resource-connections)
-                           (conj resource-connections))]
-
-                     (g/eager-tx-data
-                       (concat
-                         (when (some-> old-value resource/source-type (= :file))
-                           (e/mapcat
-                             (fn [[target-node connections]]
-                               (project/disconnect-resource-node evaluation-context project old-value target-node connections))
-                             all-connections))
-                         (when (some-> new-value resource/source-type (= :file))
-                           (e/mapcat
-                             (fn [[target-node connections]]
-                               (:tx-data (project/connect-resource-node evaluation-context project new-value target-node connections)))
-                             all-connections))))))))
-
+                   (concat
+                     ;; connect resource node to this
+                     (project/resource-setter evaluation-context self old-value new-value [:resource :resource])
+                     (when-let [resource-connections (g/node-value self :resource-connections evaluation-context)]
+                       (let [[target-node connections] resource-connections]
+                         ;; connect extra resource node outputs directly to target-node (GameProjectNode for instance)
+                         (apply project/resource-setter evaluation-context target-node old-value new-value
+                                connections)))))))
   (input resource resource/Resource)
   ;; resource-setting-reference only consumed by SettingsNode and already cached there.
   (output resource-setting-reference g/Any (g/fnk [_node-id path value] {:path path :node-id _node-id :value value})))

--- a/editor/src/clj/editor/workspace.clj
+++ b/editor/src/clj/editor/workspace.clj
@@ -264,6 +264,10 @@ ordinary paths."
     :dependencies-fn    fn of node's :source-value output to a collection of
                         resource project paths that this node depends on,
                         affects loading order
+    :connect-fn         a function from project, new node id and resource to
+                        connection transaction steps, invoked when the resource
+                        shell is added to the project and before any resource
+                        load-fns run
     :load-fn            a function from project, new node id and resource to
                         transaction step, invoked on loading the resource of
                         the type; default editor.placeholder-resource/load-node
@@ -333,7 +337,7 @@ ordinary paths."
     :auto-connect-save-data?    whether changes to the resource are saved
                                 to disc (this can also be enabled in load-fn)
                                 when there is a :write-fn, default true"
-  [workspace & {:keys [textual? language editable ext build-ext node-type load-fn dependencies-fn search-fn search-value-fn source-value-fn read-fn write-fn icon icon-class category view-types view-opts tags tag-opts template test-info label stateless? lazy-loaded allow-unloaded-use auto-connect-save-data?]}]
+  [workspace & {:keys [textual? language editable ext build-ext node-type connect-fn load-fn dependencies-fn search-fn search-value-fn source-value-fn read-fn write-fn icon icon-class category view-types view-opts tags tag-opts template test-info label stateless? lazy-loaded allow-unloaded-use auto-connect-save-data?]}]
   {:pre [(or (nil? icon-class) (resource/icon-class->style-class icon-class))]}
   (let [view-types (mapv canonical-view-type-id view-types)
         editable (if (nil? editable) true (boolean editable))
@@ -343,6 +347,7 @@ ordinary paths."
                        :editable editable
                        :editor-openable (some? (coll/some editor-openable-view-type? view-types))
                        :node-type node-type
+                       :connect-fn connect-fn
                        :load-fn load-fn
                        :dependencies-fn dependencies-fn
                        :write-fn write-fn

--- a/editor/src/dev/load_project.clj
+++ b/editor/src/dev/load_project.clj
@@ -273,7 +273,6 @@
             (coll/into->
               (e/concat
                 (project/make-resource-nodes-tx-data project node-id+resource-pairs)
-                (project/setup-game-project-tx-data project (ensure-some game-project-node-id))
                 (workspace/merge-disk-sha256s workspace disk-sha256s-by-node-id)
                 (project/load-nodes-tx-data project node-load-infos progress/null-render-progress! progress/null-render-progress! resource-metrics))
               (if separate-load-tx-data-generation [] :eduction)

--- a/editor/test/editor/defold_project_test.clj
+++ b/editor/test/editor/defold_project_test.clj
@@ -22,9 +22,8 @@
             [editor.resource-node :as resource-node]
             [editor.workspace :as workspace]
             [integration.test-util :as test-util]
-            [support.test-support :refer [with-clean-system]]))
-
-(def ^:private load-counter (atom 0))
+            [support.test-support :refer [with-clean-system]]
+            [util.eduction :as e]))
 
 (g/defnode ANode
   (inherits resource-node/ResourceNode)
@@ -44,37 +43,46 @@
   (inherits resource-node/ResourceNode)
   (property value g/Str))
 
-(defn- read-a [resource]
-  (read-string (slurp resource)))
-
-(defn- dependencies-a [source-value]
-  (keep source-value [:b]))
-
-(defn- connect-a [project self _resource]
-  (g/connect project :_node-id self :project-node-id))
-
-(defn- load-a [_project self resource source-value]
-  (swap! load-counter inc)
-  (let [source-resource (workspace/resolve-resource resource (:b source-value))]
-    (concat
-     (g/set-property self :value-piece "set incorrectly")
-     (g/set-property self :source-resource source-resource)
-     (g/set-property self :value "bogus value"))))
-
-(defn- load-b [_project self resource]
-  (swap! load-counter inc)
-  (let [data (read-string (slurp resource))]
-    (g/set-property self :value (:value data))))
-
 (defn- register-resource-types [workspace types]
   (for [type types]
     (apply workspace/register-resource-type workspace (flatten (vec type)))))
 
 (deftest loading
-  (reset! load-counter 0)
   (with-clean-system
     (test-util/with-ui-run-later-rebound
-      (let [workspace (workspace/make-workspace world
+      (let [load-counter (atom 0)
+
+            read-a
+            (fn read-a [resource]
+              (read-string (slurp resource)))
+
+            dependencies-a
+            (fn dependencies-a [source-value]
+              (keep source-value [:b]))
+
+            connect-a
+            (fn connect-a [project self _resource]
+              (g/connect project :_node-id self :project-node-id))
+
+            load-a
+            (fn load-a [project self resource source-value]
+              (swap! load-counter inc)
+              (let [source-resource (workspace/resolve-resource resource (:b source-value))]
+                (e/concat
+                  (g/callback-ec
+                    (fn check-connect-fn-happened [evaluation-context]
+                      (is (= project (g/node-value self :project-node-id evaluation-context)))))
+                  (g/set-property self :value-piece "set incorrectly")
+                  (g/set-property self :source-resource source-resource)
+                  (g/set-property self :value "bogus value"))))
+
+            load-b
+            (fn load-b [_project self resource]
+              (swap! load-counter inc)
+              (let [data (read-string (slurp resource))]
+                (g/set-property self :value (:value data))))
+
+            workspace (workspace/make-workspace world
                                                 (.getAbsolutePath (io/file "test/resources/load_project"))
                                                 {}
                                                 {}
@@ -95,9 +103,6 @@
                                                  :label "Type B"}])))
         (workspace/resource-sync! workspace)
         (let [project (test-util/setup-project! workspace)
-              a1 (project/get-resource-node project "/a1.type_a")
-              a2 (project/get-resource-node project "/a2.type_a")]
+              a1 (project/get-resource-node project "/a1.type_a")]
           (is (= 3 @load-counter))
-          (is (= project (g/node-value a1 :project-node-id)))
-          (is (= project (g/node-value a2 :project-node-id)))
           (is (= "t" (g/node-value a1 :value-piece))))))))

--- a/editor/test/editor/defold_project_test.clj
+++ b/editor/test/editor/defold_project_test.clj
@@ -37,6 +37,7 @@
             (set (fn [evaluation-context self _old-value new-value]
                    (let [project (project/get-project (:basis evaluation-context) self)]
                      (:tx-data (project/connect-resource-node evaluation-context project new-value self [[:value :value-input]]))))))
+  (input project-node-id g/NodeID)
   (input value-input g/Str))
 
 (g/defnode BNode
@@ -48,6 +49,9 @@
 
 (defn- dependencies-a [source-value]
   (keep source-value [:b]))
+
+(defn- connect-a [project self _resource]
+  (g/connect project :_node-id self :project-node-id))
 
 (defn- load-a [_project self resource source-value]
   (swap! load-counter inc)
@@ -82,6 +86,7 @@
                                                  :node-type ANode
                                                  :read-fn read-a
                                                  :dependencies-fn dependencies-a
+                                                 :connect-fn connect-a
                                                  :load-fn load-a
                                                  :label "Type A"}
                                                 {:ext "type_b"
@@ -90,6 +95,9 @@
                                                  :label "Type B"}])))
         (workspace/resource-sync! workspace)
         (let [project (test-util/setup-project! workspace)
-              a1 (project/get-resource-node project "/a1.type_a")]
+              a1 (project/get-resource-node project "/a1.type_a")
+              a2 (project/get-resource-node project "/a2.type_a")]
           (is (= 3 @load-counter))
+          (is (= project (g/node-value a1 :project-node-id)))
+          (is (= project (g/node-value a2 :project-node-id)))
           (is (= "t" (g/node-value a1 :value-piece))))))))

--- a/editor/test/integration/game_project_test.clj
+++ b/editor/test/integration/game_project_test.clj
@@ -13,16 +13,16 @@
 ;; specific language governing permissions and limitations under the License.
 
 (ns integration.game-project-test
-  (:require [clojure.test :refer :all]
-            [clojure.java.io :as io]
+  (:require [clojure.java.io :as io]
+            [clojure.test :refer :all]
             [dynamo.graph :as g]
-            [support.test-support :refer [with-clean-system spit-until-new-mtime]]
-            [integration.test-util :as test-util]
+            [editor.defold-project :as project]
             [editor.fs :as fs]
             [editor.resource :as resource]
             [editor.workspace :as workspace]
-            [editor.defold-project :as project]
-            [service.log :as log])
+            [integration.test-util :as test-util]
+            [service.log :as log]
+            [support.test-support :refer [spit-until-new-mtime with-clean-system]])
   (:import [java.io File]))
 
 (def ^:dynamic ^String *project-path*)
@@ -63,12 +63,27 @@
 (defn- title [settings]
   (settings ["project" "title"]))
 
+(defn- ensure-game-project-connections! [project game-project]
+  (let [script-intelligence (g/valid-node-value project :script-intelligence)]
+    (is (contains? (set (g/targets-of script-intelligence :build-errors))
+                   [game-project :build-errors]))
+    (is (contains? (set (g/sources-of project :display-profiles))
+                   [game-project :display-profiles-data]))
+    (is (contains? (set (g/sources-of project :texture-profiles))
+                   [game-project :texture-profiles-data]))
+    (is (contains? (set (g/sources-of project :use-font-layout))
+                   [game-project :use-font-layout]))
+    (is (contains? (set (g/sources-of project :settings))
+                   [game-project :settings-map]))))
+
 (deftest load-ok-project
   (with-clean-system
-    (let [[workspace project] (setup world)]
+    (let [[_workspace project] (setup world)]
       (testing "Settings loaded"
-        (let [settings (g/node-value project :settings)]
-          (is (= "Side-scroller" (title settings))))))))
+        (let [settings (g/node-value project :settings)
+              game-project (project/get-resource-node project "/game.project")]
+          (is (= "Side-scroller" (title settings)))
+          (ensure-game-project-connections! project game-project))))))
 
 (deftest load-incomplete-project
   (testing "Missing ResourceNodes are shared among all references to it."
@@ -89,14 +104,16 @@
   (with-clean-system
     (create-test-project)
     (write-file "game.project" "bad content")
-    (let [[workspace project] (log/without-logging (load-test-project world))]
+    (let [[workspace project] (log/without-logging (load-test-project world))
+          game-project (project/get-resource-node project "/game.project")]
       (testing "Defaults if can't load"
         (let [settings (g/node-value project :settings)]
           (is (= "unnamed" (title settings)))))
       (testing "Game project node is defective"
-        (let [gpn (project/get-resource-node project "/game.project")
-              gpn-settings-map (g/node-value gpn :settings-map)]
-          (is (error? :invalid-content gpn-settings-map)))))))
+        (let [gpn-settings-map (g/node-value game-project :settings-map)]
+          (is (error? :invalid-content gpn-settings-map))))
+      (testing "Connections"
+        (ensure-game-project-connections! project game-project)))))
 
 (deftest break-ok-project
   (with-clean-system
@@ -112,7 +129,8 @@
               gpn (project/get-resource-node project "/game.project")
               gpn-settings-map (g/node-value gpn :settings-map)]
           (is (= "unnamed" (title settings)))
-          (is (error? :invalid-content gpn-settings-map)))
+          (is (error? :invalid-content gpn-settings-map))
+          (ensure-game-project-connections! project gpn))
         (copy-file "game.project.backup" "game.project")
         (workspace/resource-sync! workspace))
       (testing "Restoring gives normal settings"
@@ -120,4 +138,5 @@
               gpn (project/get-resource-node project "/game.project")
               gpn-settings-map (g/node-value gpn :settings-map)]
           (is (= "Side-scroller" (title settings)))
-          (is (no-error? gpn-settings-map)))))))
+          (is (no-error? gpn-settings-map))
+          (ensure-game-project-connections! project gpn))))))

--- a/editor/test/integration/unload_test.clj
+++ b/editor/test/integration/unload_test.clj
@@ -532,6 +532,8 @@
 
           (let [project (test-util/setup-project! workspace)
                 loaded-proj-path? #(loaded-proj-path? project %)
+                script-intelligence (project/script-intelligence project)
+                unloaded-lua-node (project/get-resource-node project "/unloaded/unloaded.lua")
 
                 call-logged-transact!
                 (fn call-logged-transact! [tx-data]
@@ -547,6 +549,12 @@
               (is (not (loaded-proj-path? "/unloaded/unloaded.png")))
               (is (not (loaded-proj-path? "/unloaded/unloaded.tilesource")))
               (is (loaded-proj-path? "/loaded_referencing_unloaded_tilesource.script")))
+
+            (testing "Unloaded resource shells have their global connections."
+              (is (contains? (set (g/sources-of project :breakpoints))
+                             [unloaded-lua-node :breakpoints]))
+              (is (contains? (set (g/sources-of script-intelligence :required-module-infos))
+                             [unloaded-lua-node :required-module-info])))
 
             (testing "Editing a script to reference unloaded Lua modules will not load transitive dependencies."
               (let [node-load-info-tx-data-calls


### PR DESCRIPTION
Editor resource nodes now establish outbound connections to global systems before they are loaded. This change is intended to enable partial project loading in the future.

Part of #10166

### Technical changes
* `resource-types` can now optionally declare a `:connect-fn` that returns transaction steps to be executed as the node is connected to the graph, but prior to executing the `:load-fn`.
* Most resource-types have been updated to establish their outbound connections in a `:connect-fn` instead of in the `:load-fn`.
* The existing special handling of the `GameProject` node that ensured it established its connections prior to loading have been replaced with a `:connect-fn` in its resource-type.

The two remaining outbound connections are from the `:collision-group-node` outputs of `collision-object/CollisionObjectNode` and `tile-source/CollisionGroupNode`. These will be dealt with in a later PR.