### PR TITLE
Fix fallback for missing project files

### DIFF
--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -707,7 +707,7 @@ namespace dmEngine
             paths[2] = p3;
         }
 
-        for (uint32_t i = 0; i < 3; ++i)
+        for (uint32_t i = 0; i < DM_ARRAY_SIZE(paths); ++i)
         {
             if (paths[i] && dmSys::ResourceExists(paths[i]))
             {

--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -670,11 +670,10 @@ namespace dmEngine
 
     bool GetProjectFile(int argc, char *argv[], char* resources_path, char* project_file, uint32_t project_file_size)
     {
-        // check up to four paths
         char p1[DMPATH_MAX_PATH];   // mount: game.projectc
         char p2[DMPATH_MAX_PATH];   // mount: build/default/game.projectc
         char p3[DMPATH_MAX_PATH];   // game.projectc if resource path is provided
-        const char* paths[4] = { 0x0, p1, p2, 0x0};
+        const char* paths[3] = { p1, p2, 0x0 };
 
         if (argc > 1 && argv[argc-1][0] != '-')
         {
@@ -685,7 +684,8 @@ namespace dmEngine
             size_t suffix_len = strlen(suffix);
             if ((suffix_len <= arg_len) && strcmp(lastarg + arg_len - suffix_len, suffix) == 0)
             {
-                paths[0] = lastarg;
+                dmStrlCpy(project_file, lastarg, project_file_size);
+                return true;
             }
         }
 
@@ -704,10 +704,10 @@ namespace dmEngine
         if (resources_path)
         {
             dmPath::Concat(resources_path, "game.projectc", p3, sizeof(p3));
-            paths[3] = p3;
+            paths[2] = p3;
         }
 
-        for (uint32_t i = 0; i < 4; ++i)
+        for (uint32_t i = 0; i < 3; ++i)
         {
             if (paths[i] && dmSys::ResourceExists(paths[i]))
             {

--- a/engine/engine/src/test/test_engine.cpp
+++ b/engine/engine/src/test/test_engine.cpp
@@ -232,6 +232,19 @@ TEST_F(EngineTest, NonProjectLastArgumentDoesNotOverrideProjectFile)
     ASSERT_STREQ(expected_project_file, project_file);
 }
 
+TEST_F(EngineTest, MissingProjectLastArgumentOverridesProjectFile)
+{
+    char resources_path[256];
+    MAKE_PATH(resources_path, "/");
+
+    char missing_project_file[256];
+    MAKE_PATH(missing_project_file, "/notexist.projectc");
+    const char* argv[] = {"test_engine", missing_project_file};
+    char project_file[256];
+    ASSERT_TRUE(dmEngine::GetProjectFile(DM_ARRAY_SIZE(argv), (char**)argv, resources_path, project_file, sizeof(project_file)));
+    ASSERT_STREQ(missing_project_file, project_file);
+}
+
 static void PostRunFrameCount(dmEngine::HEngine engine, void* ctx)
 {
     dmEngine::Stats stats;


### PR DESCRIPTION
Explicit `.projectc` arguments that reference a missing file now fail during startup instead of silently loading the bundled project. Extension-owned arguments such as Steam’s `+connect_lobby <lobby ID>` remain ignored by project-file detection, preserving the original fix while preventing engine tests and CI jobs from hanging.

Fix https://github.com/defold/defold/issues/12880

### Technical changes

- Return explicit `.projectc` arguments directly and let project loading report missing files.
- Search default project locations only when no explicit project argument was supplied.
- Preserve the extension-argument behavior introduced by https://github.com/defold/defold/pull/12965.
- Add coverage verifying that a missing explicit project overrides the bundled project.
- Rebuilt `test_engine` and verified `ProjectFail`, `NonProjectLastArgumentDoesNotOverrideProjectFile`, and `MissingProjectLastArgumentOverridesProjectFile` on arm64 macOS.