### PR TITLE
Remove view graph

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -2354,7 +2354,7 @@
              right-split-desc (g/node-value app-view :right-split-desc evaluation-context)]
     (ui/advance-ui-user-data-component! right-split ::ui right-split-desc)))
 
-(defn make-app-view [view-graph project ^Stage stage ^MenuBar menu-bar ^SplitPane editor-tabs-split right-split ^TabPane tool-tab-pane prefs localization]
+(defn make-app-view [graph project ^Stage stage ^MenuBar menu-bar ^SplitPane editor-tabs-split right-split ^TabPane tool-tab-pane prefs localization]
   (let [app-scene (.getScene stage)
         editor-tab-pane (TabPane.)]
     (ui/disable-menu-alt-key-mnemonic! menu-bar)
@@ -2366,7 +2366,7 @@
                      (g/tx-nodes-added
                        (g/transact
                          {:undoable false}
-                         (g/make-node view-graph AppView
+                         (g/make-node graph AppView
                                       :stage stage
                                       :scene app-scene
                                       :editor-tabs-split editor-tabs-split
@@ -2526,7 +2526,7 @@
               (.setGraphic icon)
               (editor-tab/set-view-type! view-type)
               (editor-tab/set-instance-key! instance-key))
-        view-graph (g/make-graph! :volatility 2)
+        view-graph (g/make-graph!)
         undo-stack-revisions-before (g/undo-stack-revisions)
         view (make-view-fn view-graph parent (assoc opts :app-view app-view :tab tab))]
     (assert (= undo-stack-revisions-before (g/undo-stack-revisions))

--- a/editor/src/clj/editor/boot_open_project.clj
+++ b/editor/src/clj/editor/boot_open_project.clj
@@ -73,7 +73,6 @@
 (set! *warn-on-reflection* true)
 
 (def ^:dynamic *project-graph*)
-(def ^:dynamic *view-graph*)
 
 (def the-root (atom nil))
 
@@ -84,8 +83,7 @@
 (defn initialize-project! [system-config]
   (when (nil? @the-root)
     (g/initialize! (assoc system-config :cache-retain? project/cache-retain?))
-    (alter-var-root #'*project-graph* (fn [_] (g/last-graph-added)))
-    (alter-var-root #'*view-graph* (fn [_] (g/make-graph! :volatility 2)))))
+    (alter-var-root #'*project-graph* (fn [_] (g/last-graph-added)))))
 
 (defn- setup-workspace! [project-path build-settings workspace-config localization]
   (let [workspace (workspace/make-workspace *project-graph* project-path build-settings workspace-config localization)]
@@ -200,41 +198,41 @@
           console-grid-pane    (.lookup root "#console-grid-pane")
           workbench            (.lookup root "#workbench")
           notifications        (.lookup root "#notifications")
-          [app-view ui-timer]  (app-view/make-app-view *view-graph* project stage menu-bar editor-tabs-split right-split tool-tabs prefs localization)
-          scene-visibility     (scene-visibility/make-scene-visibility-node! *view-graph* prefs app-view)
-          outline-view         (outline-view/make-outline-view *view-graph* project app-view localization)
-          asset-browser        (asset-browser/make-asset-browser *view-graph* workspace assets prefs localization)
+          [app-view ui-timer]  (app-view/make-app-view *project-graph* project stage menu-bar editor-tabs-split right-split tool-tabs prefs localization)
+          scene-visibility     (scene-visibility/make-scene-visibility-node! *project-graph* prefs app-view)
+          outline-view         (outline-view/make-outline-view *project-graph* project app-view localization)
+          asset-browser        (asset-browser/make-asset-browser *project-graph* workspace assets prefs localization)
           open-resource        (partial app-view/open-resource! app-view prefs localization project)
-          console-view         (console/make-console! *view-graph* workspace console-tab console-grid-pane open-resource prefs localization)
+          console-view         (console/make-console! *project-graph* workspace console-tab console-grid-pane open-resource prefs localization)
           _                    (notifications-view/init! (g/node-value workspace :notifications) notifications localization)
           build-errors-view    (build-errors-view/make-build-errors-view (.lookup root "#build-errors-tree")
                                                                          localization
                                                                          (fn [resource selected-node-ids opts]
                                                                            (when (open-resource resource opts)
                                                                              (app-view/select! app-view selected-node-ids))))
-          search-results-view  (search-results-view/make-search-results-view! *view-graph*
+          search-results-view  (search-results-view/make-search-results-view! *project-graph*
                                                                               (.lookup root "#search-results-container")
                                                                               open-resource)
-          properties-view      (properties-view/make-properties-view workspace project app-view search-results-view *view-graph* prefs)
-          changes-view         (changes-view/make-changes-view *view-graph* workspace prefs localization (.lookup root "#changes-container")
+          properties-view      (properties-view/make-properties-view workspace project app-view search-results-view *project-graph* prefs)
+          changes-view         (changes-view/make-changes-view *project-graph* workspace prefs localization (.lookup root "#changes-container")
                                                                (fn [changes-view moved-files]
                                                                  (app-view/async-reload! app-view changes-view workspace moved-files)))
           git                  (g/node-value changes-view :git)
           curve-tab            (find-tab tool-tabs "curve-editor-tab")
-          curve-view           (curve-view/make-view! app-view *view-graph*
+          curve-view           (curve-view/make-view! app-view *project-graph*
                                                       (.lookup root "#curve-editor-container")
                                                       (.lookup root "#curve-editor-list")
                                                       (.lookup root "#curve-editor-view")
                                                       localization
                                                       {:tab curve-tab})
-          debug-view           (debug-view/make-view! app-view *view-graph*
+          debug-view           (debug-view/make-view! app-view *project-graph*
                                                       project
                                                       root
                                                       open-resource
                                                       (partial app-view/debugger-state-changed! scene tool-tabs)
                                                       localization)
 
-          breakpoints-view (breakpoints-view/make-breakpoints-view workspace project open-resource *view-graph* prefs (.lookup root "#breakpoints-container"))
+          breakpoints-view (breakpoints-view/make-breakpoints-view workspace project open-resource *project-graph* prefs (.lookup root "#breakpoints-container"))
           token (web-server/make-token)
           server-handler (web-server/make-dynamic-handler
                            (into []

--- a/editor/src/clj/editor/breakpoints_view.clj
+++ b/editor/src/clj/editor/breakpoints_view.clj
@@ -454,13 +454,13 @@
 
   (output breakpoints-anchor-pane AnchorPane :cached produce-breakpoints-anchor-pane))
 
-(defn make-breakpoints-view [workspace project open-resource-fn view-graph prefs ^Node parent]
+(defn make-breakpoints-view [workspace project open-resource-fn graph prefs ^Node parent]
   (first
     (g/tx-nodes-added
       (g/transact
         {:undoable false}
         (let [open-res-fn (make-open-resource-fn open-resource-fn)]
-          (g/make-nodes view-graph [view [BreakpointsView :parent-view parent :prefs prefs :open-resource-fn open-res-fn]]
+          (g/make-nodes graph [view [BreakpointsView :parent-view parent :prefs prefs :open-resource-fn open-res-fn]]
             (g/connect workspace :_node-id view :workspace)
             (g/connect workspace :localization view :localization)
             (g/connect project :breakpoints view :breakpoints)
@@ -498,7 +498,7 @@
         open-resource (partial #'editor.app-view/open-resource!
                                (dev/app-view) (dev/prefs) (dev/localization) (dev/project))
         bp-view (make-breakpoints-view (dev/workspace) (dev/project) open-resource
-                                       editor.boot-open-project/*view-graph*
+                                       editor.boot-open-project/*project-graph*
                                        (dev/prefs) bp-container)
         auto-pulls [[bp-view :breakpoints-anchor-pane]]]
     (g/transact (concat (g/update-property (dev/app-view) :auto-pulls into auto-pulls))))

--- a/editor/src/clj/editor/changes_view.clj
+++ b/editor/src/clj/editor/changes_view.clj
@@ -162,7 +162,7 @@
            :message (localization/message "notification.changes-view.git-error")})
         nil))))
 
-(defn make-changes-view [view-graph workspace prefs localization ^Parent parent async-reload!]
+(defn make-changes-view [graph workspace prefs localization ^Parent parent async-reload!]
   (assert (fn? async-reload!))
   (let [^ListView list-view (.lookup parent "#changes")
         diff-button (.lookup parent "#changes-diff")
@@ -173,7 +173,7 @@
                   (g/tx-nodes-added
                     (g/transact
                       {:undoable false}
-                      (g/make-node view-graph ChangesView
+                      (g/make-node graph ChangesView
                                    :list-view list-view
                                    :progress-overlay progress-overlay
                                    :git git

--- a/editor/src/clj/editor/code/view.clj
+++ b/editor/src/clj/editor/code/view.clj
@@ -2631,7 +2631,7 @@
                (not= (int (.charAt character 0)) 0x7f))
       (insert-text! view-node prefs character))))
 
-(defn- refresh-mouse-cursor! [view-node ^MouseEvent event]
+(defn refresh-mouse-cursor! [view-node ^MouseEvent event]
   (let [hovered-element (get-property view-node :hovered-element)
         gesture-type (:type (get-property view-node :gesture-start))
         ^LayoutInfo layout (get-property view-node :layout)
@@ -2762,8 +2762,7 @@
             x (.getX event)
             y (.getY event)
             resource-node (get-property view-node :resource-node evaluation-context)
-            lsp (lsp/get-node-lsp (:basis evaluation-context) resource-node)
-            row (data/y->row layout y)]
+            lsp (lsp/get-node-lsp (:basis evaluation-context) resource-node)]
         (-> (data/mouse-moved (get-property view-node :lines evaluation-context)
                               (get-property view-node :cursor-ranges evaluation-context)
                               (get-property view-node :visible-regions evaluation-context)
@@ -2774,8 +2773,7 @@
                               x
                               y)
             (cond->
-              (and lsp
-                   (prefs/get prefs hover-pref-path)
+              (and (prefs/get prefs hover-pref-path)
                    (not (get-property view-node :hover-mouse-over-popup evaluation-context)))
               (merge
                 (let [hover-character-cursor (data/canvas->character-cursor layout lines x y)]

--- a/editor/src/clj/editor/console.clj
+++ b/editor/src/clj/editor/console.clj
@@ -447,6 +447,10 @@
   (output lines types/Lines (gu/passthrough modified-lines))
   (output request-response g/Any :cached produce-request-response))
 
+(g/defnode ConsoleView
+  (inherits view/CodeEditorView)
+  (input console-node g/NodeID :cascade-delete))
+
 (defn- gutter-metrics []
   [44.0 0.0])
 
@@ -541,12 +545,30 @@
     {:undoable false}
     (concat
       (g/connect console-node :_node-id view-node :resource-node)
+      (g/connect console-node :_node-id view-node :console-node)
       (g/connect console-node :indent-type view-node :indent-type)
       (g/connect console-node :cursor-ranges view-node :cursor-ranges)
       (g/connect console-node :invalidated-rows view-node :invalidated-rows)
       (g/connect console-node :lines view-node :lines)
       (g/connect console-node :regions view-node :regions)))
   view-node)
+
+(defn- handle-mouse-moved! [view-node ^MouseEvent event]
+  (.consume event)
+  (view/set-properties!
+    view-node :selection
+    (g/with-auto-evaluation-context evaluation-context
+      (let [layout (view/get-property view-node :layout evaluation-context)]
+        (data/mouse-moved (view/get-property view-node :lines evaluation-context)
+                          (view/get-property view-node :cursor-ranges evaluation-context)
+                          (view/get-property view-node :visible-regions evaluation-context)
+                          layout
+                          (view/get-property view-node :minimap-layout evaluation-context)
+                          (view/get-property view-node :gesture-start evaluation-context)
+                          (view/get-property view-node :hovered-element evaluation-context)
+                          (.getX event)
+                          (.getY event)))))
+  (view/refresh-mouse-cursor! view-node event))
 
 (def ^:const line-sub-regions-pattern #"(?<=^|\s|[<\"'`])(\/[^\s>\"'`:]+)(?::?)(\d+)?")
 (def ^:private ^:const line-sub-regions-pattern-partial #"([^\s<>:]+):(\d+)")
@@ -741,7 +763,7 @@
           (g/transact
             {:undoable false}
             [(g/make-node graph ConsoleNode)
-             (g/make-node graph view/CodeEditorView
+             (g/make-node graph ConsoleView
                           :canvas canvas
                           :canvas-width (.getWidth canvas)
                           :canvas-height (.getHeight canvas)
@@ -795,9 +817,9 @@
     (doto canvas
       (.setFocusTraversable true)
       (.addEventFilter KeyEvent/KEY_PRESSED (ui/event-handler event (view/handle-key-pressed! view-node prefs event false)))
-      (.addEventHandler MouseEvent/MOUSE_MOVED (ui/event-handler event (view/handle-mouse-moved! view-node prefs event)))
+      (.addEventHandler MouseEvent/MOUSE_MOVED (ui/event-handler event (handle-mouse-moved! view-node event)))
       (.addEventHandler MouseEvent/MOUSE_PRESSED (ui/event-handler event (view/handle-mouse-pressed! view-node event)))
-      (.addEventHandler MouseEvent/MOUSE_DRAGGED (ui/event-handler event (view/handle-mouse-moved! view-node prefs event)))
+      (.addEventHandler MouseEvent/MOUSE_DRAGGED (ui/event-handler event (handle-mouse-moved! view-node event)))
       (.addEventHandler MouseEvent/MOUSE_RELEASED (ui/event-handler event (view/handle-mouse-released! view-node event)))
       (.addEventHandler MouseEvent/MOUSE_EXITED (ui/event-handler event (view/handle-mouse-exited! view-node event)))
       (.addEventHandler ScrollEvent/SCROLL (ui/event-handler event (view/handle-scroll! view-node false event))))

--- a/editor/src/clj/editor/curve_view.clj
+++ b/editor/src/clj/editor/curve_view.clj
@@ -535,6 +535,9 @@
   (input camera-id g/NodeID :cascade-delete)
   (input grid-id g/NodeID :cascade-delete)
   (input background-id g/NodeID :cascade-delete)
+  (input controller-id g/NodeID :cascade-delete)
+  (input selection-id g/NodeID :cascade-delete)
+  (input rulers-id g/NodeID :cascade-delete)
   (input input-handlers Runnable :array)
   ;; NOTE: Part of an interface SceneView calls during update-image-view!
   (input update-tick-handlers Runnable :array)
@@ -685,6 +688,9 @@
 
                                    (g/connect camera :_node-id view-id :camera-id)
                                    (g/connect grid :_node-id view-id :grid-id)
+                                   (g/connect controller :_node-id view-id :controller-id)
+                                   (g/connect selection :_node-id view-id :selection-id)
+                                   (g/connect rulers :_node-id view-id :rulers-id)
                                    (g/connect camera :local-camera view-id :local-camera)
                                    (g/connect camera :camera view-id :camera)
                                    (g/connect camera :camera grid :camera)

--- a/editor/src/clj/editor/debug_view.clj
+++ b/editor/src/clj/editor/debug_view.clj
@@ -462,7 +462,7 @@
   debug-view)
 
 (defn make-view!
-  [app-view view-graph project ^Parent root open-resource-fn state-changed-fn localization]
+  [app-view graph project ^Parent root open-resource-fn state-changed-fn localization]
   (let [console-grid-pane (.lookup root "#console-grid-pane")
         call-stack-view (doto (ListView.)
                           (.setId "debugger-call-stack"))
@@ -474,7 +474,7 @@
                   (g/tx-nodes-added
                     (g/transact
                       {:undoable false}
-                      (g/make-node view-graph DebugView
+                      (g/make-node graph DebugView
                                    :localization localization
                                    :open-resource-fn (make-open-resource-fn project open-resource-fn)
                                    :state-changed-fn state-changed-fn))))

--- a/editor/src/clj/editor/outline_view.clj
+++ b/editor/src/clj/editor/outline_view.clj
@@ -792,7 +792,7 @@
       (ui/context! :outline {:outline-view outline-view} (->SelectionProvider tree-view) {} {Long :node-id
                                                                                              resource/Resource :link}))))
 
-(defn make-outline-view [view-graph project app-view localization]
+(defn make-outline-view [graph project app-view localization]
   (let [tree-view (doto (ExtendedTreeView.)
                     (.setId "outline")
                     (.setPrefWidth 269.0)
@@ -801,7 +801,7 @@
                        (g/tx-nodes-added
                          (g/transact
                            {:undoable false}
-                           (g/make-nodes view-graph [outline-view [OutlineView
+                           (g/make-nodes graph [outline-view [OutlineView
                                                                    :tree-view tree-view
                                                                    :localization localization]]
                              (g/connect app-view :_node-id outline-view :app-view)))))]

--- a/editor/src/clj/editor/outline_view.clj
+++ b/editor/src/clj/editor/outline_view.clj
@@ -802,8 +802,8 @@
                          (g/transact
                            {:undoable false}
                            (g/make-nodes graph [outline-view [OutlineView
-                                                                   :tree-view tree-view
-                                                                   :localization localization]]
+                                                              :tree-view tree-view
+                                                              :localization localization]]
                              (g/connect app-view :_node-id outline-view :app-view)))))]
     (setup-tree-view project tree-view outline-view app-view localization)
     outline-view))

--- a/editor/src/clj/editor/properties_view.clj
+++ b/editor/src/clj/editor/properties_view.clj
@@ -824,12 +824,12 @@
 
   (output pane-desc g/Any :cached produce-pane-desc))
 
-(defn make-properties-view [workspace project app-view search-results-view view-graph prefs]
+(defn make-properties-view [workspace project app-view search-results-view graph prefs]
   (first
     (g/tx-nodes-added
       (g/transact
         {:undoable false}
-        (g/make-nodes view-graph [view [PropertiesView :prefs prefs]]
+        (g/make-nodes graph [view [PropertiesView :prefs prefs]]
           (g/connect workspace :_node-id view :workspace)
           (g/connect workspace :localization view :localization)
           (g/connect project :_node-id view :project)

--- a/editor/src/clj/editor/scene_visibility.clj
+++ b/editor/src/clj/editor/scene_visibility.clj
@@ -99,7 +99,7 @@
   (input active-resource-node+type g/Any)
   (input active-scene g/Any :substitute nil)
   (input outline-selection g/Any :substitute nil)
-  (input scene-hide-history-datas SceneHideHistoryData :array)
+  (input scene-hide-history-datas SceneHideHistoryData :array :cascade-delete)
 
   (output active-scene-resource-node g/NodeID (g/fnk [active-resource-node+type]
                                                 (when (some? active-resource-node+type)
@@ -152,12 +152,12 @@
                                                                                     hide-history))
                                                                                 scene-hide-history-datas)))))
 
-(defn make-scene-visibility-node! [view-graph prefs app-view]
+(defn make-scene-visibility-node! [graph prefs app-view]
   (first
     (g/tx-nodes-added
       (g/transact
         {:undoable false}
-        (g/make-node view-graph SceneVisibilityNode :prefs prefs :app-view app-view)))))
+        (g/make-node graph SceneVisibilityNode :prefs prefs :app-view app-view)))))
 
 ;; -----------------------------------------------------------------------------
 ;; Per-Object Visibility

--- a/editor/src/clj/editor/search_results_view.clj
+++ b/editor/src/clj/editor/search_results_view.clj
@@ -382,12 +382,12 @@
                                (open-selected!)))))
       (.add progress-indicator))))
 
-(defn make-search-results-view! [view-graph ^AnchorPane search-results-container open-resource-fn]
+(defn make-search-results-view! [graph ^AnchorPane search-results-container open-resource-fn]
   (first
     (g/tx-nodes-added
       (g/transact
         {:undoable false}
-        (g/make-node view-graph SearchResultsView
+        (g/make-node graph SearchResultsView
                      :open-resource-fn open-resource-fn
                      :search-results-container search-results-container)))))
 

--- a/editor/test/integration/test_util.clj
+++ b/editor/test/integration/test_util.clj
@@ -537,18 +537,18 @@
   (output active-view g/NodeID (gu/passthrough active-view)))
 
 (defn make-view-graph! []
-  (g/make-graph! :volatility 2))
+  (g/make-graph!))
 
 (defn setup-app-view! [project]
-  (let [view-graph (make-view-graph!)]
+  (let [project-graph (g/node-id->graph-id project)]
     (first
       (g/tx-nodes-added
         (g/transact
           {:undoable false}
-          (g/make-nodes view-graph [app-view [MockAppView
-                                              :active-tool :move
-                                              :manip-space :world
-                                              :scene (Scene. (VBox.))]]
+          (g/make-nodes project-graph [app-view [MockAppView
+                                                 :active-tool :move
+                                                 :manip-space :world
+                                                 :scene (Scene. (VBox.))]]
             (g/connect project :_node-id app-view :project-id)
             (for [label [:selected-node-ids-by-resource-node :selected-node-properties-by-resource-node :sub-selections-by-resource-node]]
               (g/connect project label app-view label))))))))
@@ -564,7 +564,7 @@
           {:undoable false}
           (g/set-property app-view :active-view view))
         [node-id view])
-      (let [view-graph (g/make-graph! :volatility 2)
+      (let [view-graph (g/make-graph!)
             view (make-view-fn! view-graph node-id)]
         (g/transact
           {:undoable false}


### PR DESCRIPTION
Note: We previously gated hover on mouse move by `lsp` graph value availability (the Console Node was in the view graph -> no LSP node). Now that we moved to a single graph, that gate no longer works, so I added a custom mouse move handler in the console.

Related to #13093