### PR TITLE
Fix custom vertex attribute animation type errors

### DIFF
--- a/engine/gamesys/src/gamesys/test/material/attributes_uninitialized_element_ids.go
+++ b/engine/gamesys/src/gamesys/test/material/attributes_uninitialized_element_ids.go
@@ -1,0 +1,13 @@
+components {
+  id: "script"
+  component: "/material/attributes_uninitialized_element_ids.script"
+}
+
+embedded_components {
+  id: "sprite"
+  type: "sprite"
+  data: "tile_set: \"/material/flipbook.tilesource\"\n"
+  "default_animation: \"anim\"\n"
+  "material: \"/material/attributes_uninitialized_element_ids.material\"\n"
+  "blend_mode: BLEND_MODE_ALPHA\n"
+}

--- a/engine/gamesys/src/gamesys/test/material/attributes_uninitialized_element_ids.material
+++ b/engine/gamesys/src/gamesys/test/material/attributes_uninitialized_element_ids.material
@@ -1,0 +1,24 @@
+name: "attributes_uninitialized_element_ids"
+vertex_program: "/material/attributes_uninitialized_element_ids.vp"
+fragment_program: "/material/fragment_program_valid.fp"
+
+attributes {
+  name: "saturation"
+  double_values { v: 1 v: 0 v: 0 v: 0 }
+}
+attributes {
+  name: "tint"
+  double_values { v: 1 v: 1 v: 1 v: 1 }
+}
+attributes {
+  name: "transparency"
+  double_values { v: 1 v: 0 v: 0 v: 0 }
+}
+attributes {
+  name: "highlight"
+  double_values { v: 1 v: 1 v: 1 v: 1 }
+}
+attributes {
+  name: "dissolve"
+  double_values { v: 0 v: 0 v: 0 v: 0 }
+}

--- a/engine/gamesys/src/gamesys/test/material/attributes_uninitialized_element_ids.script
+++ b/engine/gamesys/src/gamesys/test/material/attributes_uninitialized_element_ids.script
@@ -1,0 +1,19 @@
+-- Copyright 2020-2026 The Defold Foundation
+-- Copyright 2014-2020 King
+-- Copyright 2009-2014 Ragnar Svensson, Christian Murray
+-- Licensed under the Defold License version 1.0 (the "License"); you may not use
+-- this file except in compliance with the License.
+--
+-- You may obtain a copy of the License, together with FAQs at
+-- https://www.defold.com/license
+--
+-- Unless required by applicable law or agreed to in writing, software distributed
+-- under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+-- CONDITIONS OF ANY KIND, either express or implied. See the License for the
+-- specific language governing permissions and limitations under the License.
+
+function init(self)
+    local pipe_url = msg.url("#sprite")
+    go.set(pipe_url, "tint", vmath.vector4(1, 1, 1, 0))
+    go.animate(pipe_url, "tint", go.PLAYBACK_LOOP_PINGPONG, vmath.vector4(1), go.EASING_LINEAR, 2)
+end

--- a/engine/gamesys/src/gamesys/test/material/attributes_uninitialized_element_ids.vp
+++ b/engine/gamesys/src/gamesys/test/material/attributes_uninitialized_element_ids.vp
@@ -1,0 +1,17 @@
+attribute vec4 position;
+attribute vec2 texcoord0;
+attribute vec4 saturation;
+attribute vec4 tint;
+attribute vec4 transparency;
+attribute vec4 highlight;
+attribute vec4 dissolve;
+
+varying vec2 var_uv;
+varying vec3 var_normal;
+
+void main()
+{
+    gl_Position = position + saturation + tint + transparency + highlight + dissolve;
+    var_uv = texcoord0;
+    var_normal = saturation.xyz + tint.xyz + transparency.xyz + highlight.xyz + dissolve.xyz;
+}

--- a/engine/gamesys/src/gamesys/test/material/build.inputs
+++ b/engine/gamesys/src/gamesys/test/material/build.inputs
@@ -5,6 +5,8 @@
 /material/attributes_dynamic_go_animate.material
 /material/attributes_dynamic_go_set_get_sparse.go
 /material/attributes_dynamic_go_set_get_sparse.material
+/material/attributes_uninitialized_element_ids.go
+/material/attributes_uninitialized_element_ids.material
 /material/attributes_instancing_valid.material
 /material/attributes_many_streams_valid.material
 /material/attributes_texture_transform_multi.material

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -78,6 +78,10 @@
 
 #include <sound/sound.h>
 
+#if defined(DM_SANITIZE_ADDRESS) && !defined(_MSC_VER)
+#include <sanitizer/allocator_interface.h>
+#endif
+
 #define JC_TEST_IMPLEMENTATION
 #include <jc_test/jc_test.h>
 
@@ -96,6 +100,63 @@ static int16_t ReadUnalignedInt16(const void* ptr)
     memcpy(&value, ptr, sizeof(value));
     return value;
 }
+
+#if defined(DM_SANITIZE_ADDRESS) && !defined(_MSC_VER)
+struct MaterialAttributeAllocationPoison
+{
+    dmhash_t m_ElementId;
+    uint32_t m_AttributeCount;
+    bool     m_Armed;
+    bool     m_MaterialAllocated;
+    bool     m_Poisoned;
+};
+
+static MaterialAttributeAllocationPoison g_MaterialAttributeAllocationPoison;
+
+static void MaterialAttributeMallocHook(const volatile void* ptr, size_t size)
+{
+    MaterialAttributeAllocationPoison& poison = g_MaterialAttributeAllocationPoison;
+    if (!poison.m_Armed)
+        return;
+
+    if (!poison.m_MaterialAllocated)
+    {
+        poison.m_MaterialAllocated = size == sizeof(dmRender::Material);
+        return;
+    }
+
+    if (size == sizeof(dmRender::MaterialAttribute) * poison.m_AttributeCount)
+    {
+        dmRender::MaterialAttribute* attributes = (dmRender::MaterialAttribute*) const_cast<void*>(ptr);
+        attributes[0].m_ElementIds[0] = poison.m_ElementId;
+        poison.m_Poisoned = true;
+        poison.m_Armed = false;
+    }
+    else
+    {
+        poison.m_MaterialAllocated = size == sizeof(dmRender::Material);
+    }
+}
+
+static void MaterialAttributeFreeHook(const volatile void*)
+{
+}
+
+static bool PoisonNextMaterialAttributeAllocation(dmhash_t element_id, uint32_t attribute_count)
+{
+    static bool hook_installed = false;
+    if (!hook_installed)
+    {
+        hook_installed = __sanitizer_install_malloc_and_free_hooks(MaterialAttributeMallocHook, MaterialAttributeFreeHook) != 0;
+    }
+
+    memset(&g_MaterialAttributeAllocationPoison, 0, sizeof(g_MaterialAttributeAllocationPoison));
+    g_MaterialAttributeAllocationPoison.m_ElementId = element_id;
+    g_MaterialAttributeAllocationPoison.m_AttributeCount = attribute_count;
+    g_MaterialAttributeAllocationPoison.m_Armed = hook_installed;
+    return hook_installed;
+}
+#endif
 
 namespace dmGameObject
 {
@@ -9782,6 +9843,30 @@ TEST_F(MaterialTest, DynamicVertexAttributesWithGoAnimate)
 
     ASSERT_TRUE(dmGameObject::Final(m_Collection));
 }
+
+#if defined(DM_SANITIZE_ADDRESS) && !defined(_MSC_VER)
+// Tests #13108 through the complete script-to-sprite property path: an omitted
+// shader attribute must not use a stale element id to shadow a declared vector4.
+// Poisoning the fresh MaterialAttribute allocation with the "tint" hash makes the
+// go.set() followed by go.animate() failure deterministic under ASan.
+TEST_F(MaterialTest, DynamicVertexAttributesWithUninitializedElementIds)
+{
+    ASSERT_TRUE(dmGameObject::Init(m_Collection));
+    ASSERT_TRUE(PoisonNextMaterialAttributeAllocation(dmHashString64("tint"), 7));
+
+    dmGameSystem::MaterialResource* material_res = 0;
+    ASSERT_EQ(dmResource::RESULT_OK, dmResource::Get(m_Factory, "/material/attributes_uninitialized_element_ids.materialc", (void**) &material_res));
+    ASSERT_TRUE(g_MaterialAttributeAllocationPoison.m_Poisoned);
+
+    dmGameObject::HInstance go = Spawn(m_Factory, m_Collection, "/material/attributes_uninitialized_element_ids.goc", dmHashString64("/attributes_uninitialized_element_ids"), 0, Point3(0, 0, 0), Quat(0, 0, 0, 1), Vector3(1, 1, 1));
+
+    bool finalized = dmGameObject::Final(m_Collection);
+    dmResource::Release(m_Factory, material_res);
+
+    ASSERT_NE((void*) 0, go);
+    ASSERT_TRUE(finalized);
+}
+#endif
 
 TEST_F(MaterialTest, DynamicVertexAttributesGoSetGetSparse)
 {

--- a/engine/render/src/render/material.cpp
+++ b/engine/render/src/render/material.cpp
@@ -255,6 +255,7 @@ namespace dmRender
 
         m->m_MaterialAttributes.SetCapacity(num_program_attributes);
         m->m_MaterialAttributes.SetSize(num_program_attributes);
+        memset(m->m_MaterialAttributes.Begin(), 0, sizeof(MaterialAttribute) * num_program_attributes);
         m->m_VertexAttributeInfos.SetCapacity(num_program_attributes);
         m->m_VertexAttributeInfos.SetSize(num_program_attributes);
 


### PR DESCRIPTION
Custom vector attributes on sprites now retain the correct property type when their shader contains attributes omitted from the material. This prevents `go.animate()` from reporting an incorrect-type Lua error after setting attributes such as `tint`:
>The property 'tint' of '[collection:/attributes_uninitialized_element_ids#sprite]'
has incorrect type 4 (errcode: -4)

Fix https://github.com/defold/defold/issues/13108

### Technical changes

- Zero-initialize material attribute metadata to prevent stale element hashes from shadowing valid attributes.
- Add an ASan regression test covering the complete material, shader, sprite, and Lua property path.
- Reproduce the original `go.set()` followed by `go.animate()` sequence with a deterministic stale `tint` hash.
- Verify the new regression test and existing dynamic-attribute animation test pass under ASan.
- Verify all eight `test_render_programs` tests pass.