### PR TITLE
Preserve Lua error messages and tracebacks

### DIFF
--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -766,32 +766,6 @@ namespace dmEngine
         engine->m_UpdateFrequency = frequency;
     }
 
-    struct LuaCallstackCtx
-    {
-        bool     m_First;
-        char*    m_Buffer;
-        uint32_t m_BufferSize;
-    };
-
-    static void GetLuaStackTraceCbk(lua_State* L, lua_Debug* entry, void* _ctx)
-    {
-        LuaCallstackCtx* ctx = (LuaCallstackCtx*)_ctx;
-
-        if (ctx->m_First)
-        {
-            int32_t nwritten = dmSnPrintf(ctx->m_Buffer, ctx->m_BufferSize, "Lua Callstack:\n");
-            if (nwritten < 0)
-                nwritten = 0;
-            ctx->m_Buffer += nwritten;
-            ctx->m_BufferSize -= nwritten;
-            ctx->m_First = false;
-        }
-
-        uint32_t nwritten = dmScript::WriteLuaTracebackEntry(entry, ctx->m_Buffer, ctx->m_BufferSize);
-        ctx->m_Buffer += nwritten;
-        ctx->m_BufferSize -= nwritten;
-    }
-
     static void LoadDependencyJson(HEngine engine)
     {
         void* resource = 0;
@@ -826,11 +800,7 @@ namespace dmEngine
 
         if (engine->m_SharedScriptContext)
         {
-            LuaCallstackCtx ctx;
-            ctx.m_First = true;
-            ctx.m_Buffer = buffer;
-            ctx.m_BufferSize = buffersize;
-            dmScript::GetLuaTraceback(dmScript::GetLuaState(engine->m_SharedScriptContext), "Sln", GetLuaStackTraceCbk, &ctx);
+            dmScript::WriteLuaTraceback(dmScript::GetLuaState(engine->m_SharedScriptContext), "Lua Callstack:\n", buffer, buffersize);
         }
     }
 

--- a/engine/script/src/script.cpp
+++ b/engine/script/src/script.cpp
@@ -377,7 +377,7 @@ namespace dmScript
     // From https://zeux.io/2010/11/07/lua-callstack-with-c-debugger/
     // and also
     // https://github.com/defold/defold/blob/dev/engine/lua/src/lua/ldblib.c#L321
-    void GetLuaTraceback(lua_State* L, const char* infostring, void (*cbk)(lua_State* L, lua_Debug* entry, void* ctx), void* ctx)
+    static void GetLuaTraceback(lua_State* L, const char* infostring, void (*cbk)(lua_State* L, lua_Debug* entry, void* ctx), void* ctx)
     {
         const int LEVELS1 = 12;  // size of the first part of the stack
         const int LEVELS2 = 10;  // size of the second part of the stack
@@ -406,7 +406,7 @@ namespace dmScript
                 if (!lua_getstack(L1, level+LEVELS2, &entry)) {
                     level--;  // keep going
                 } else {
-                    lua_pushliteral(L, "\n\t...");  // too many levels
+                    cbk(L1, 0, ctx);  // too many levels
                     while (lua_getstack(L1, level+LEVELS2, &entry))  // find last levels
                         level++;
                 }
@@ -422,7 +422,7 @@ namespace dmScript
     }
 
     // From ldblib.c function db_errorfb()
-    uint32_t WriteLuaTracebackEntry(lua_Debug* entry, char* buffer, uint32_t buffer_size)
+    static int32_t WriteLuaTracebackEntry(lua_Debug* entry, char* buffer, uint32_t buffer_size)
     {
         int32_t nwritten = 0;
         if (*entry->namewhat != '\0')
@@ -442,11 +442,7 @@ namespace dmScript
             nwritten = dmSnPrintf(buffer, buffer_size, "  %s:%d: in function <%s:%d>\n", entry->short_src, entry->currentline, entry->short_src, entry->linedefined);
         }
 
-        // Truncated, so we'll just make sure we've not written anything
-        if (nwritten < 0)
-            nwritten = 0;
-
-        return (uint32_t)nwritten;
+        return nwritten;
     }
 
 
@@ -1468,45 +1464,100 @@ namespace dmScript
     }
 
 
-    struct LuaCallstackCtx
+    static const uint32_t LUA_TRACEBACK_BUFFER_SIZE = 8 * 1024;
+    static const char LUA_TRACEBACK_ELIDED[] = "  ...\n";
+    static const char LUA_TRACEBACK_TRUNCATED[] = "  ... (traceback truncated)\n";
+
+    struct LuaTracebackCtx
     {
-        bool     m_First;
-        char*    m_Buffer;
-        uint32_t m_BufferSize;
+        bool        m_First;
+        bool        m_Truncated;
+        const char* m_Header;
+        char*       m_Buffer;
+        uint32_t    m_BufferSize;
     };
 
-    static void GetLuaStackTraceCbk(lua_State* L, lua_Debug* entry, void* _ctx)
+    static void MarkLuaTracebackTruncated(LuaTracebackCtx* ctx)
     {
-        LuaCallstackCtx* ctx = (LuaCallstackCtx*)_ctx;
+        if (ctx->m_BufferSize > 0)
+            dmSnPrintf(ctx->m_Buffer, ctx->m_BufferSize, "%s", LUA_TRACEBACK_TRUNCATED);
+        ctx->m_Truncated = true;
+    }
+
+    static uint32_t GetLuaTracebackWriteSize(const LuaTracebackCtx* ctx)
+    {
+        const uint32_t marker_length = sizeof(LUA_TRACEBACK_TRUNCATED) - 1;
+        return ctx->m_BufferSize > marker_length ? ctx->m_BufferSize - marker_length : 0;
+    }
+
+    static bool AppendLuaTracebackString(LuaTracebackCtx* ctx, const char* string)
+    {
+        uint32_t write_size = GetLuaTracebackWriteSize(ctx);
+        int32_t nwritten = write_size > 0 ? dmSnPrintf(ctx->m_Buffer, write_size, "%s", string) : -1;
+        if (nwritten < 0)
+        {
+            MarkLuaTracebackTruncated(ctx);
+            return false;
+        }
+        ctx->m_Buffer += nwritten;
+        ctx->m_BufferSize -= nwritten;
+        return true;
+    }
+
+    static void WriteLuaTracebackCallback(lua_State* L, lua_Debug* entry, void* _ctx)
+    {
+        LuaTracebackCtx* ctx = (LuaTracebackCtx*)_ctx;
+
+        if (ctx->m_Truncated)
+            return;
 
         if (ctx->m_First)
         {
-            int32_t nwritten = dmSnPrintf(ctx->m_Buffer, ctx->m_BufferSize, "stack traceback:\n");
-            if (nwritten < 0)
-                nwritten = 0;
-            ctx->m_Buffer += nwritten;
-            ctx->m_BufferSize -= nwritten;
             ctx->m_First = false;
+            if (!AppendLuaTracebackString(ctx, ctx->m_Header))
+                return;
         }
 
-        uint32_t nwritten = dmScript::WriteLuaTracebackEntry(entry, ctx->m_Buffer, ctx->m_BufferSize);
+        if (entry == 0)
+        {
+            AppendLuaTracebackString(ctx, LUA_TRACEBACK_ELIDED);
+            return;
+        }
+
+        uint32_t write_size = GetLuaTracebackWriteSize(ctx);
+        int32_t nwritten = write_size > 0 ? WriteLuaTracebackEntry(entry, ctx->m_Buffer, write_size) : -1;
+        if (nwritten < 0)
+        {
+            MarkLuaTracebackTruncated(ctx);
+            return;
+        }
         ctx->m_Buffer += nwritten;
         ctx->m_BufferSize -= nwritten;
     }
 
+    void WriteLuaTraceback(lua_State* L, const char* header, char* buffer, uint32_t buffer_size)
+    {
+        if (buffer_size == 0)
+            return;
+
+        buffer[0] = '\0';
+
+        LuaTracebackCtx ctx;
+        ctx.m_First = true;
+        ctx.m_Truncated = false;
+        ctx.m_Header = header;
+        ctx.m_Buffer = buffer;
+        ctx.m_BufferSize = buffer_size;
+        GetLuaTraceback(L, "Sln", WriteLuaTracebackCallback, &ctx);
+    }
+
     static int BacktraceErrorHandler(lua_State *m_state) {
         lua_createtable(m_state, 0, 2);
-        
-        // First, generate traceback BEFORE we modify the stack
-        // We need to do this first because GetLuaTraceback expects string errors
-        char traceback[1024];
-        traceback[0] = '\0'; // Initialize the buffer
-        LuaCallstackCtx ctx;
-        ctx.m_First = true;
-        ctx.m_Buffer = traceback;
-        ctx.m_BufferSize = sizeof(traceback);
-        
-        // If error is not a string, temporarily convert it for traceback generation
+        int result_table = lua_gettop(m_state);
+
+        char traceback[LUA_TRACEBACK_BUFFER_SIZE];
+
+        // GetLuaTraceback only generates output for string errors.
         if (!lua_isstring(m_state, 1))
         {
             // Replace stack position 1 with string version for GetLuaTraceback
@@ -1535,18 +1586,19 @@ namespace dmScript
                 lua_replace(m_state, 1); // Replace with type name
             }
         }
-        
+
         // Now generate traceback with string error message
-        dmScript::GetLuaTraceback(m_state, "Sln", GetLuaStackTraceCbk, &ctx);
-        
+        WriteLuaTraceback(m_state, "stack traceback:\n", traceback, sizeof(traceback));
+
         // Store the converted error message
         lua_pushvalue(m_state, 1);
-        lua_setfield(m_state, -2, "error");
+        lua_setfield(m_state, result_table, "error");
 
         // Store the traceback
         lua_pushstring(m_state, traceback);
-        lua_setfield(m_state, -2, "traceback");
+        lua_setfield(m_state, result_table, "traceback");
 
+        lua_settop(m_state, result_table);
         return 1;
     }
 

--- a/engine/script/src/script.h
+++ b/engine/script/src/script.h
@@ -518,22 +518,15 @@ namespace dmScript
     uint32_t GenerateUniqueScriptId();
 
     /**
-     * Retrieve the Lua traceback from the current context
+     * Write the current Lua traceback to a bounded character buffer. Elided and
+     * truncated frames are identified explicitly in the resulting string.
      * @param lua context
-     * @param infostring determines what fields are valid in the entry (passed to lua_getinfo())
-     * @param cbk the callback which receives calls for each debug entry in the callstack
-     * @param ctx the user data to be passed to the callback
+     * @param header the text written before the traceback entries
+     * @param buffer the buffer to write the traceback to
+     * @param buffer_size the size of the buffer. A non-empty buffer is always
+     *                    null-terminated.
      */
-    void GetLuaTraceback(lua_State* L, const char* infostring, void (*cbk)(lua_State* L, lua_Debug* entry, void* ctx), void* ctx);
-
-    /**
-     * Write a Lua traceback entry to a character buffer
-     * @param entry the Lua traceback entry to write
-     * @param buffer the buffer to write entry to
-     * @param buffer_size the size of the buffer
-     * @return number of bytes written
-     */
-    uint32_t WriteLuaTracebackEntry(lua_Debug* entry, char* buffer, uint32_t buffer_size);
+    void WriteLuaTraceback(lua_State* L, const char* header, char* buffer, uint32_t buffer_size);
 
     /**
      * Retrieve config file handle from the context

--- a/engine/script/src/test/test_script_lua.cpp
+++ b/engine/script/src/test/test_script_lua.cpp
@@ -134,11 +134,17 @@ TEST_F(ScriptTestLua, TestLuaCallstack)
     luaL_checktype(L, -1, LUA_TFUNCTION);
     int ret = dmScript::PCall(L, 0, LUA_MULTRET);
 
-    ASSERT_EQ(5, ret);
+    // A deep call stack must preserve the original runtime-error result instead
+    // of turning it into an error raised by the native traceback handler.
+    ASSERT_EQ(LUA_ERRRUN, ret);
     ASSERT_EQ(top, lua_gettop(L));
 
+    // Verify that the existing call-stack fixture still logs the original error,
+    // a traceback, and the marker that replaces its elided middle frames.
     const char* log = GetLog();
-    printf("LOG: %s\n", log ? log : "");
+    ASSERT_NE((const char*)0, strstr(log, "attempt to index global 'testmodule'"));
+    ASSERT_NE((const char*)0, strstr(log, "stack traceback:"));
+    ASSERT_NE((const char*)0, strstr(log, "  ...\n"));
 }
 
 TEST_F(ScriptTestLua, TestPPrintTruncate)
@@ -496,6 +502,195 @@ TEST_F(ScriptTestLua, TestErrorHandlerFunction)
     lua_pushcfunction(L, FailingFunc);
     result = dmScript::PCall(L, 0, LUA_MULTRET);
     ASSERT_EQ(LUA_ERRRUN, result);
+    ASSERT_EQ(top, lua_gettop(L));
+}
+
+// Verifies that an error raised from a deep Lua call stack reaches the registered
+// error handler with both its original message and a usable traceback.
+TEST_F(ScriptTestLua, TestErrorHandlerWithDeepCallstack)
+{
+    int top = lua_gettop(L);
+
+    // Capture the values forwarded by PCallInternal after its native traceback
+    // handler has processed the error.
+    const char* install_error_handler =
+        "sys.set_error_handler(function(type, error, traceback)\n"
+        "    _type = type\n"
+        "    _error = error\n"
+        "    _traceback = traceback\n"
+        "end)\n";
+
+    ASSERT_TRUE(RunString(L, install_error_handler));
+
+    // Prevent tail-call elimination so all 30 recursive Lua frames remain on
+    // the stack when the error is raised. This takes GetLuaTraceback through
+    // its middle-frame elision path (LEVELS1 + LEVELS2).
+    const char* deep_error =
+        "local function f(depth)\n"
+        "    if depth == 0 then error('deep error', 0) end\n"
+        "    local result = f(depth - 1)\n"
+        "    return result\n"
+        "end\n"
+        "return function() return f(30) end\n";
+
+    // Keep the source name short so this test only exercises deep-stack handling,
+    // independently of the traceback buffer size.
+    ASSERT_EQ(0, luaL_loadbuffer(L, deep_error, strlen(deep_error), "@x.lua"));
+    ASSERT_EQ(0, lua_pcall(L, 0, 1, 0));
+    ASSERT_TRUE(lua_isfunction(L, -1));
+
+    // LUA_ERRRUN means the original runtime error survived. LUA_ERRERR here
+    // means that BacktraceErrorHandler itself failed while handling the error.
+    int result = dmScript::PCall(L, 0, LUA_MULTRET);
+    EXPECT_EQ(LUA_ERRRUN, result);
+    ASSERT_EQ(top, lua_gettop(L));
+
+    // Use non-fatal checks so one run reports whether either callback argument
+    // was lost even when the native error handler returned LUA_ERRERR.
+    lua_getglobal(L, "_error");
+    int error_type = lua_type(L, -1);
+    EXPECT_EQ(LUA_TSTRING, error_type);
+    if (error_type == LUA_TSTRING)
+        EXPECT_STREQ("deep error", lua_tostring(L, -1));
+    lua_pop(L, 1);
+
+    lua_getglobal(L, "_traceback");
+    int traceback_type = lua_type(L, -1);
+    EXPECT_EQ(LUA_TSTRING, traceback_type);
+    if (traceback_type == LUA_TSTRING)
+        EXPECT_NE((const char*)0, strstr(lua_tostring(L, -1), "x.lua"));
+    lua_pop(L, 1);
+
+    ASSERT_EQ(top, lua_gettop(L));
+}
+
+static uint32_t CountCharacter(const char* string, char character)
+{
+    uint32_t count = 0;
+    while (*string != '\0')
+    {
+        if (*string == character)
+            ++count;
+        ++string;
+    }
+    return count;
+}
+
+// Verifies that long source paths do not silently remove traceback frames by
+// comparing them with an otherwise identical call chain using short paths.
+TEST_F(ScriptTestLua, TestErrorHandlerTracebackWithLongPaths)
+{
+    int top = lua_gettop(L);
+
+    // Build two identical chains from separately named chunks. Only their
+    // source-path lengths differ, so both tracebacks must contain the same
+    // number of complete frames.
+    const char* setup =
+        "sys.set_error_handler(function(type, error, traceback)\n"
+        "    _error = error\n"
+        "    _traceback = traceback\n"
+        "end)\n"
+        "local function make_chain(path, depth)\n"
+        "    local source = [[\n"
+        "local next = ...\n"
+        "return function()\n"
+        "    local result = next()\n"
+        "    return result\n"
+        "end]]\n"
+        "    local result = assert(loadstring([[return function() error('traceback error', 0) end]], '@' .. path .. 'base.lua'))()\n"
+        "    for i = 1, depth do\n"
+        "        local factory = assert(loadstring(source, ('@%sframe_%02d.lua'):format(path, i)))\n"
+        "        result = factory(result)\n"
+        "    end\n"
+        "    return result\n"
+        "end\n"
+        "_short_path_error = make_chain('s/', 16)\n"
+        "_long_path_error = make_chain('main/deeply/nested/module/path/realistic_xxxxxxxxxxxxxxxxxxxxxxxxx/', 16)\n";
+
+    // Sixteen frames exceeded the legacy 1024-byte traceback buffer only when
+    // the paths were long, and remain below the deep-stack elision threshold.
+    ASSERT_TRUE(RunString(L, setup));
+
+    // Establish the complete-frame baseline using names that fit comfortably
+    // inside the traceback buffer.
+    lua_getglobal(L, "_short_path_error");
+    ASSERT_TRUE(lua_isfunction(L, -1));
+    ASSERT_EQ(LUA_ERRRUN, dmScript::PCall(L, 0, LUA_MULTRET));
+    ASSERT_EQ(top, lua_gettop(L));
+
+    lua_getglobal(L, "_traceback");
+    ASSERT_EQ(LUA_TSTRING, lua_type(L, -1));
+    uint32_t short_path_line_count = CountCharacter(lua_tostring(L, -1), '\n');
+    lua_pop(L, 1);
+
+    // Repeat with long names whose formatted entries exceeded the legacy buffer
+    // in aggregate without increasing the call-stack depth.
+    lua_getglobal(L, "_long_path_error");
+    ASSERT_TRUE(lua_isfunction(L, -1));
+    ASSERT_EQ(LUA_ERRRUN, dmScript::PCall(L, 0, LUA_MULTRET));
+    ASSERT_EQ(top, lua_gettop(L));
+
+    lua_getglobal(L, "_traceback");
+    ASSERT_EQ(LUA_TSTRING, lua_type(L, -1));
+    uint32_t long_path_line_count = CountCharacter(lua_tostring(L, -1), '\n');
+    lua_pop(L, 1);
+
+    // Path length may change the byte length of a traceback, but it must not
+    // silently remove frames from an otherwise identical call chain.
+    EXPECT_EQ(short_path_line_count, long_path_line_count);
+    ASSERT_EQ(top, lua_gettop(L));
+}
+
+// Verifies that a traceback too large for the bounded native buffer ends with an
+// explicit truncation marker instead of a silently shortened or partial frame.
+TEST_F(ScriptTestLua, TestErrorHandlerMarksTruncatedTraceback)
+{
+    int top = lua_gettop(L);
+
+    // Capture the error information passed through the native error handler so
+    // the test can inspect the final traceback string directly.
+    const char* install_error_handler =
+        "sys.set_error_handler(function(type, error, traceback)\n"
+        "    _error = error\n"
+        "    _traceback = traceback\n"
+        "end)\n";
+
+    ASSERT_TRUE(RunString(L, install_error_handler));
+
+    // Lua does not limit debug-entry function names to LUA_IDSIZE. Calling a
+    // function with an unusually long identifier forces one formatted frame to
+    // exceed the complete traceback buffer without requiring a huge call stack.
+    const char* oversized_error =
+        "return function()\n"
+        "    local name = string.rep('a', 9000)\n"
+        "    local source = \"function \" .. name .. \"() error('oversized error', 0) end\\n\" .. name .. \"()\"\n"
+        "    assert(loadstring(source, '@oversized.lua'))()\n"
+        "end\n";
+
+    ASSERT_EQ(0, luaL_loadbuffer(L, oversized_error, strlen(oversized_error), "@truncation_test.lua"));
+    ASSERT_EQ(0, lua_pcall(L, 0, 1, 0));
+    ASSERT_TRUE(lua_isfunction(L, -1));
+    ASSERT_EQ(LUA_ERRRUN, dmScript::PCall(L, 0, LUA_MULTRET));
+    ASSERT_EQ(top, lua_gettop(L));
+
+    // The original error remains usable even though its traceback could not be
+    // represented in full.
+    lua_getglobal(L, "_error");
+    ASSERT_EQ(LUA_TSTRING, lua_type(L, -1));
+    EXPECT_STREQ("oversized error", lua_tostring(L, -1));
+    lua_pop(L, 1);
+
+    // The marker must be the complete suffix, proving no later frame overwrote
+    // it and no partial line was presented as a complete traceback.
+    lua_getglobal(L, "_traceback");
+    ASSERT_EQ(LUA_TSTRING, lua_type(L, -1));
+    const char* marker = "  ... (traceback truncated)\n";
+    const char* traceback = lua_tostring(L, -1);
+    const char* marker_position = strstr(traceback, marker);
+    ASSERT_NE((const char*)0, marker_position);
+    EXPECT_STREQ(marker, marker_position);
+    lua_pop(L, 1);
+
     ASSERT_EQ(top, lua_gettop(L));
 }
 


### PR DESCRIPTION
Lua errors raised from deep call stacks now reach `sys.set_error_handler` with their original message and a usable traceback instead of `nil` values. Tracebacks accommodate realistic long source paths and clearly indicate when bounded output must be truncated.

Fix https://github.com/defold/defold/issues/13112

### Technical changes

- Report elided Lua frames through the traceback formatter instead of leaking a value onto the Lua stack.
- Address the error-result table by absolute stack index and restore the expected stack before returning.
- Centralize traceback walking, formatting, elision, and truncation handling in `dmScript::WriteLuaTraceback`.
- Use the shared traceback writer for both regular Lua errors and engine crash reports.
- Increase the regular error traceback buffer from 1 KiB to 8 KiB.
- Reserve space for an explicit `... (traceback truncated)` suffix and stop writing after truncation.
- Keep low-level traceback walking and entry formatting private to `script.cpp`.
- Add regression coverage for deep non-tail call stacks, realistic long source paths, and oversized traceback entries.
- Update the existing deep-callstack test to expect the original `LUA_ERRRUN` result and preserved error details.
- Validated on arm64 macOS: all 26 `test_script_lua` tests pass with 285 assertions.